### PR TITLE
Check for damage type perks

### DIFF
--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -39,7 +39,7 @@
         '            <div class="counter" ng-if="item.amount > 1">{{ item.amount }}</div>',
         '            <div class="close" ng-click="vm.remove(item); vm.form.name.$rollbackViewValue(); $event.stopPropagation();"></div>',
         '            <div class="equipped" ng-show="item.equipped"></div>',
-        '            <div class="damage-type" ng-if="item.sort === \'Weapons\'" ng-class="\'damage-\' + item.dmg"></div>',
+        '            <div class="damage-type" ng-if="item.sort === \'Weapons\'" ng-class="\'damage-\' + item.dmg[0]"></div>',
         '          </div>',
         '        </span>',
         '      </span>',

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -68,23 +68,9 @@
         // 	case 'void': vm.color = '#b184c5'; break;
         // }
 
-        switch (vm.item.dmg) {
-        case 'arc':
-          {
-            vm.classes['is-arc'] = true;
-            break;
-          }
-        case 'solar':
-          {
-            vm.classes['is-solar'] = true;
-            break;
-          }
-        case 'void':
-          {
-            vm.classes['is-void'] = true;
-            break;
-          }
-        }
+        vm.classes['is-arc'] = _.contains(vm.item.dmg, 'arc');
+        vm.classes['is-solar'] = _.contains(vm.item.dmg, 'solar');
+        vm.classes['is-void'] = _.contains(vm.item.dmg, 'void');
 
         vm.stats.push({
           'label': 'Atk:',

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -380,7 +380,17 @@
           4248486431
         ];
 
-        var dmgName = [null, 'kinetic', 'arc', 'solar', 'void'][item.damageType];
+        var dmgTypes = [ [null, 'kinetic', 'arc', 'solar', 'void'][item.damageType] ];
+
+        var dmgTypePerks = {
+          3787917923: [ 'arc', 'solar' ]
+        };
+
+        _.forEach(dmgTypePerks, function(perkDmgTypes, perkHash) {
+          if (_.any(item.perks, function(perk) { return perk.perkHash == perkHash; })) {
+            [].push.apply(dmgTypes, perkDmgTypes);
+          }
+        });
 
         var createdItem = {
           index: getNextIndex(),
@@ -405,7 +415,7 @@
           maxStackSize: definitions[item.itemHash].maxStackSize,
           classType: itemDef.classType,
           /* 0: titan, 1: hunter, 2: warlock, 3: any */
-          dmg: dmgName,
+          dmg: dmgTypes,
           visible: true
         };
 

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -103,7 +103,7 @@
         case 'elemental':
           {
             result = function(p, item) {
-              return (item.dmg !== p);
+              return !_.contains(item.dmg, p);
             };
             break;
           }

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -23,7 +23,7 @@
         '<div ui-draggable="{{ (vm.item.type !== \'Lost Items\') && (vm.item.type !== \'Messages\')  }}" id="item-{{:: $id }}" drag-channel="{{ vm.item.type }}" title="{{ vm.item.primStat.value }} {{ vm.item.name }}" alt="{{ vm.item.primStat.value }} {{ vm.item.name }}" drag="\'item-\' + $id" class="item" ng-class="{ \'search-hidden\': !vm.item.visible, \'complete\': vm.item.complete}">',
         '  <div ui-draggable="false" class="img" ng-class="{ \'how\': vm.item.inHoW }" style="background-size: 44px 44px; background-image: url({{ vm.item.icon.slice(1) }})" ng-click="vm.clicked(vm.item, $event)"></div>',
         '  <div ui-draggable="false" class="counter" ng-if="vm.item.amount > 1">{{ vm.item.amount }}</div>',
-        '  <div ui-draggable="false" class="damage-type" ng-if="vm.item.sort === \'Weapons\'" ng-class="\'damage-\' + vm.item.dmg"></div>',
+        '  <div ui-draggable="false" class="damage-type" ng-if="vm.item.sort === \'Weapons\'" ng-class="\'damage-\' + vm.item.dmg[0]"></div>',
         '</div>'
       ].join('')
     };


### PR DESCRIPTION
This closes #10 

For early discussion of approach.  I was also considering adding a new property to the item object, so we end up with the original `dmg` property which contains the primary damage type, and then an additional property (`perkDmg`?) which contains any additional damage types provided by perks.

This has the advantage of reducing the scope of the change required to implement this feature.  Interested to hear people's thoughts.  Cheers!