### PR TITLE
Ability to search by item type name

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -410,7 +410,8 @@
           hasAscendNode: false,
           ascended: false,
           lockable: item.lockable,
-          locked: item.locked
+          locked: item.locked,
+          itemTypeName: itemDef.itemTypeName
         };
 
         if (item.itemHash === 2809229973) { // Necrochasm

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -71,6 +71,8 @@
               special = 'locked';
             } else if (['unlocked'].indexOf(filterResult) >= 0) {
               special = 'unlocked';
+            } else if (['rifle', 'scout rifle', 'scout', 'pulse rifle', 'pulse', 'auto rifle', 'auto', 'hand cannon', 'hand', 'cannon', 'shotgun', 'shot', 'sidearm', 'sniper rifle', 'sniper', 'fusion rifle', 'fusion', 'machine gun', 'machine', 'rocket launcher', 'rocket', 'launcher']) {
+              special = 'itemtype';
             }
 
             tempFns.push(filterGenerator(filterResult, special));
@@ -235,6 +237,13 @@
               }
 
               return (item.classType !== value);
+            };
+            break;
+          }
+        case 'itemtype':
+          {
+            result = function(p, item) {
+              return (item.itemTypeName.toLowerCase().indexOf(p) === -1);
             };
             break;
           }


### PR DESCRIPTION
This small change enables the searching by item type name, e.g., is:sniper rifle or is:launcher.