### PR TITLE
Fixes overlaid text for filter search box

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -17,6 +17,9 @@
 
 div[dim-search-filter] input {
   width: 300px;
+  -webkit-appearance: none;
+  border: 1px solid #999;
+  padding: 3px 2px;
 }
 
 dt {


### PR DESCRIPTION
At least in Chrome on a Mac, the filter search box has had a the placeholder text obstructed by a second placeholder text, 'Search'.

<img width="1041" alt="screen shot 2015-07-18 at 10 41 58 am" src="https://cloud.githubusercontent.com/assets/46142/8759578/5162eed2-2d3a-11e5-8e34-332820ed7e0b.png">

This is due to the use of `type="search"` for that filter, and OS X applying some native styling to it.

The PR removes that styling with using the CSS `-webkit-appearance: none`, and then sets some basic default styling back on it.

Here's the end result:

<img width="1041" alt="screen shot 2015-07-18 at 10 41 42 am" src="https://cloud.githubusercontent.com/assets/46142/8759587/8628517a-2d3a-11e5-916a-3da46a83d949.png">
