### PR TITLE
Use a (mostly) stable ID for items

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -542,9 +542,16 @@
 
         var dmgName = [null, 'kinetic', 'arc', 'solar', 'void'][item.damageType];
 
+        // Try to make a unique, but stable ID. This isn't always possible, such as in the case of consumables.
+        var index = item.itemHash + '-';
+        if (item.itemInstanceId === '0') {
+          index = index + getNextIndex();
+        } else {
+          index = index + item.itemInstanceId;
+        }
 
         var createdItem = {
-          index: getNextIndex(),
+          index: index,
           owner: owner,
           hash: item.itemHash,
           type: itemType,


### PR DESCRIPTION
Use a (mostly) stable ID for items to avoid recreating all the items, and flashing images whenever we reload. Before this patch, all items got a brand new index whenever they loaded, which meant each StoreItem got recreated, including the link code that fetches the image. This slows down DIM, and also causes a flash as the images are reloaded every time we reload inventory. After this patch, this only happens with consumables, and then only because I wasn't able to find a stable identifier for a particular stack of consumables like I could with everything else.