### PR TITLE
Filter by Light/Level of Armor and Weapons

### DIFF
--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -196,6 +196,32 @@ function addFilter(filter) {
     filter = prompt("Enter an item name:");
     filter = filter.trim();
   }
+  
+  if (filter.indexOf('light:') == 0) {
+    var lightFilterType = filter.substring(6);
+    var light = prompt("Enter a light value:").trim();
+    filter = 'light:';
+    switch (lightFilterType) {
+      case 'value':
+        filter += light;
+        break;
+      case '>value':
+        filter += '>' + light;
+        break;
+      case '>=value':
+        filter += '>=' + light;
+        break;
+      case '<value':
+        filter += '<' + light;
+        break;
+      case '<=value':
+        filter += '<=' + light;
+        break;
+      default:
+        filter = '';
+        break;
+    }
+  }
 
   var text = input.val();
 

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -246,13 +246,15 @@
         if (predicate.length === 0 || item.primStat == undefined) return false;
         if (item.primStat.statHash != '3897883278' && item.primStat.statHash != '368428387') return false;
         
-        var operands = ['=','>','<'];
-        var result = false;
+        var operands = ['<=','>=','=','>','<'];
         var operand = 'none';
+        var result = false;
+        
         operands.forEach(function(element) {
           if (predicate.substring(0,element.length) === element) {
             operand = element;
             predicate = predicate.substring(element.length);
+            return false;
           }
         }, this);
         
@@ -264,9 +266,15 @@
             result = (item.primStat.value == predicate)
             break;
           case '<':
+            result = (item.primStat.value < predicate)
+            break;
+          case '<=':
             result = (item.primStat.value <= predicate)
             break;
           case '>':
+            result = (item.primStat.value > predicate)
+            break;
+          case '>=':
             result = (item.primStat.value >= predicate)
             break;
         }

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -103,8 +103,8 @@
               }
             }
           }
-        } else if(term.indexOf('light:') >=0) {
-          filter = term.replace('light:', '');
+        } else if(term.indexOf('light:') >= 0 || term.indexOf('level:') >= 0) {
+          filter = term.replace('light:', '').replace('level:', '');
           addPredicate("light", filter);
         } else {
           addPredicate("keyword", term);
@@ -149,8 +149,7 @@
       'locked':       ['locked'],
       'unlocked':     ['unlocked'],
       'stackable':    ['stackable'],
-      'weaponClass':  ["pulserifle", "scoutrifle", "handcannon", "autorifle", "primaryweaponengram", "sniperrifle", "shotgun", "fusionrifle", "specialweaponengram", "rocketlauncher", "machinegun", "heavyweaponengram", "sidearm"],
-      'light':        ['light', 'level']
+      'weaponClass':  ["pulserifle", "scoutrifle", "handcannon", "autorifle", "primaryweaponengram", "sniperrifle", "shotgun", "fusionrifle", "specialweaponengram", "rocketlauncher", "machinegun", "heavyweaponengram", "sidearm"]
     };
 
     // Cache for searches against filterTrans. Somewhat noticebly speeds up the lookup on my older Mac, YMMV. Helps

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -242,8 +242,7 @@
         return !!~item.name.toLowerCase().indexOf(predicate);
       },
       'light': function(predicate, item){
-        if (predicate.length === 0 || item.primStat == undefined) return false;
-        if (item.primStat.statHash != '3897883278' && item.primStat.statHash != '368428387') return false;
+        if (predicate.length === 0 || item.primStat == undefined || !item.equipment) return false;
         
         var operands = ['<=','>=','=','>','<'];
         var operand = 'none';

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -242,7 +242,7 @@
         return !!~item.name.toLowerCase().indexOf(predicate);
       },
       'light': function(predicate, item){
-        if (predicate.length === 0 || item.primStat == undefined || !item.equipment) return false;
+        if (predicate.length === 0 || item.primStat == undefined) return false;
         
         var operands = ['<=','>=','=','>','<'];
         var operand = 'none';

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -103,6 +103,9 @@
               }
             }
           }
+        } else if(term.indexOf('light:') >=0) {
+          filter = term.replace('light:', '');
+          addPredicate("light", filter);
         } else {
           addPredicate("keyword", term);
         }
@@ -146,7 +149,8 @@
       'locked':       ['locked'],
       'unlocked':     ['unlocked'],
       'stackable':    ['stackable'],
-      'weaponClass':  ["pulserifle", "scoutrifle", "handcannon", "autorifle", "primaryweaponengram", "sniperrifle", "shotgun", "fusionrifle", "specialweaponengram", "rocketlauncher", "machinegun", "heavyweaponengram", "sidearm"]
+      'weaponClass':  ["pulserifle", "scoutrifle", "handcannon", "autorifle", "primaryweaponengram", "sniperrifle", "shotgun", "fusionrifle", "specialweaponengram", "rocketlauncher", "machinegun", "heavyweaponengram", "sidearm"],
+      'light':        ['light', 'level']
     };
 
     // Cache for searches against filterTrans. Somewhat noticebly speeds up the lookup on my older Mac, YMMV. Helps
@@ -237,6 +241,36 @@
       },
       'keyword': function(predicate, item){
         return !!~item.name.toLowerCase().indexOf(predicate);
+      },
+      'light': function(predicate, item){
+        if (predicate.length === 0 || item.primStat == undefined) return false;
+        if (item.primStat.statHash != '3897883278' && item.primStat.statHash != '368428387') return false;
+        
+        var operands = ['=','>','<'];
+        var result = false;
+        var operand = 'none';
+        operands.forEach(function(element) {
+          if (predicate.substring(0,element.length) === element) {
+            operand = element;
+            predicate = predicate.substring(element.length);
+          }
+        }, this);
+        
+        switch (operand) {
+          case 'none':
+            result = (item.primStat.value == predicate)
+            break;
+          case '=':
+            result = (item.primStat.value == predicate)
+            break;
+          case '<':
+            result = (item.primStat.value <= predicate)
+            break;
+          case '>':
+            result = (item.primStat.value >= predicate)
+            break;
+        }
+        return result;
       }
     };
   }

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -28,6 +28,16 @@
     </tr>
     <tr>
       <td>
+        <span>light:value</span>
+        <span>light:&gt;=value</span>
+        <span>light:&gt;value</span>
+        <span>light:&lt;value</span>
+        <span>light:&lt;=value</span>
+      </td>
+      <td>Shows items based on their light level (Damage for Weapons; Defense for Armor).</td>
+    </tr>
+    <tr>
+      <td>
         <span>is:class</span>
         <span>is:primary</span>
         <span>is:special</span>


### PR DESCRIPTION
Implemented feature as described in #279 

* Search using 'light' or 'level' keywords
* Operands available are =, >=, >, <, <=
* Filter is explained in the filter popup (including interaction with prompt for light value)
* Compatible in combination with itself or other filters