### PR TITLE
fixes SyntaxError for people running Chrome lower than ver. 38

### DIFF
--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -152,7 +152,8 @@
     */
     var items = $scope.$parent.$parent.vm.store.items;
 
-    for (var item of items) {
+    for (var item in items) {
+      item = items[item]; 
       if (item.equipped && item.type === vm.item.type) {
         for (var key in vm.item.stats) {
           if(item.stats.length) {


### PR DESCRIPTION
This should theoretically fix this issue people are having when they are using an older version of Chrome 
https://www.reddit.com/r/DestinyItemManager/comments/3ody1s/possible_bug_with_v31132/

Browser compatibility for this syntax is set for 38 and newer.
```javascript
for (variable of object) {
  statement
}
```
See https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Statements/for...of#Browser_compatibility