### PR TITLE
Use the page visibility API to control refresh

### DIFF
--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -162,27 +162,35 @@
       }
     };
 
+    // Don't refresh more than once a minute
+    var refresh = _.throttle(vm.refresh, 60 * 1000);
+
     vm.startAutoRefreshTimer = function () {
       var secondsToWait = 360;
 
       $rootScope.autoRefreshTimer = $interval(function () {
        //Only Refresh If We're Not Already Doing Something
        //And We're Not Inactive
-       if (!$rootScope.loadingTracker.active() && !$rootScope.isUserInactive()) {
-         vm.refresh();
+       if (!$rootScope.loadingTracker.active() && !$rootScope.isUserInactive() && document.visibilityState == 'visible') {
+         refresh();
        }
       }, secondsToWait * 1000);
     };
 
     vm.startAutoRefreshTimer();
 
-    var refresh = _.debounce(vm.refresh, 300);
-
     $rootScope.$on('dim-settings-updated', function(event, arg) {
       // if ((!_.has(arg, 'charCol')) && (!_.has(arg, 'vaultCol'))) {
         refresh();
       // }
     });
+
+    // Refresh when the user comes back to the page
+    document.addEventListener("visibilitychange", function() {
+      if (!$rootScope.loadingTracker.active() && !$rootScope.isUserInactive() && document.visibilityState == 'visible') {
+        refresh();
+      }
+    }, false);
   }
 })();
 
@@ -196,7 +204,7 @@ function addFilter(filter) {
     filter = prompt("Enter an item name:");
     filter = filter.trim();
   }
-  
+
   if (filter.indexOf('light:') == 0) {
     var lightFilterType = filter.substring(6);
     var light = prompt("Enter a light value:");


### PR DESCRIPTION
Use the page visibility API to avoid refreshing when the page is not visible, and to trigger a refresh when it becomes visible. There's still a maximum of one auto-refresh per minute, even caused by tab switching.