### PR TITLE
Best infusion first pass

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -68,6 +68,7 @@
   <!-- begin app scripts -->
   <script src="scripts/dimApp.module.js?v=3.2.0"></script>
   <script src="scripts/dimApp.config.js?v=3.2.0"></script>
+  <script src="scripts/dimWebWorker.factory.js?v=3.2.0"></script>
   <script src="scripts/services/dimRateLimit.factory.js?v=3.2.0"></script>
   <script src="scripts/services/dimBungieService.factory.js?v=3.2.0"></script>
   <script src="scripts/services/dimItemDefinitions.factory.js?v=3.2.0"></script>
@@ -95,6 +96,7 @@
   <script src="scripts/store/dimStoreHeading.directive.js?v=3.2.0"></script>
   <script src="scripts/move-popup/dimMovePopup.directive.js?v=3.2.0"></script>
   <script src="scripts/move-popup/dimMoveItemProperties.directive.js?v=3.2.0"></script>
+  <script src="scripts/infuse/dimInfuse.util.js?v=3.2.0"></script>
   <script src="scripts/infuse/dimInfuse.factory.js?v=3.2.0"></script>
   <script src="scripts/infuse/dimInfuseItem.directive.js?v=3.2.0"></script>
   <script src="scripts/infuse/dimShareData.factory.js?v=3.2.0"></script>

--- a/app/scripts/dimWebWorker.factory.js
+++ b/app/scripts/dimWebWorker.factory.js
@@ -1,0 +1,69 @@
+(function() {
+'use strict';
+
+angular.module('dimApp')
+    .factory('dimWebWorker', dimWebWorker);
+
+  dimWebWorker.$inject = ['$q', '$location'];
+
+  // heavily based on http://stackoverflow.com/questions/29282817/running-a-background-task-in-javascript/29283013#29283013
+  function dimWebWorker($q, $location) {
+      var _worker;
+      var _blobURL;
+
+      var DIMWorker = function(settings) {
+        _init(settings);
+      };
+
+      DIMWorker.prototype.do = function(args) {
+        var deferred = $q.defer();
+
+        _worker.onmessage = function(message) {
+          deferred.resolve(message.data);
+        };
+
+        //Fire up the blades.
+        if (args) {
+          _worker.postMessage(args);
+        }
+        else {
+          _worker.postMessage();
+        }
+
+        return deferred.promise;
+      };
+
+      DIMWorker.prototype.destroy = function() {
+        _worker.terminate();
+        window.URL.revokeObjectURL(_blobURL);
+      };
+
+      function _init(settings) {
+        if (settings.script) {
+          _worker = new Worker(settings.script);
+        }
+        else if (settings.fn) {
+          var includeScripts = '';
+          if (settings.include && settings.include.constructor === Array) {
+            var basePath = $location.protocol() + '://' + $location.host() + '/';
+            _.each(settings.include, function(script, index) { // quote wrap
+              settings.include[index] = '\'' + basePath + script + '\'';
+            });
+            var list = settings.include.join(',');
+            includeScripts = 'self.importScripts(' + list + ');\n';
+          }
+
+          var onmsg = 'this.onmessage = ' + settings.fn.toString();
+          var fn = 'function() {\n' + includeScripts + onmsg + '\n}';
+          _blobURL = window.URL.createObjectURL(new Blob(
+              ['(', fn, ')()'],
+              { type: 'application/javascript' }
+          ));
+
+          _worker = new Worker(_blobURL);
+        }
+      };
+
+      return DIMWorker;
+  }
+})();

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -19,6 +19,10 @@
     // Expose the service to view
     vm.infuseService = infuseService;
 
+    vm.isCalculating = function() {
+      return infuseService.isCalculating();
+    }
+
     vm.toggleItem = function(e, item) {
       e.stopPropagation();
       infuseService.toggleItem(item);

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -24,6 +24,16 @@
       infuseService.toggleItem(item);
     };
 
+    vm.maximizeAttack = function(e) {
+      e.stopPropagation();
+      infuseService.maximizeAttack();
+    }
+
+    vm.statType =
+      vm.item.primStat.statHash === 3897883278? 'Defense': // armor item
+      vm.item.primStat.statHash === 368428387?  'Attack':  // weapon item
+                                                'Unknown'; // new item?
+
     // get Items for infusion
     vm.getItems = function() {
 

--- a/app/scripts/infuse/dimInfuse.factory.js
+++ b/app/scripts/infuse/dimInfuse.factory.js
@@ -4,123 +4,33 @@
   angular.module('dimApp')
     .factory('infuseService', infuseService);
 
-  infuseService.$inject = [];
+  infuseService.$inject = ['dimWebWorker'];
 
-  function infuseService() {
-
-    function halfToEven(n) {
-        var i = Math.floor(n),
-            f = (n - i).toFixed(8),
-            e = 1e-8; // Allow for rounding errors in f
-        return (f > 0.5 - e && f < 0.5 + e) ?
-            ((i % 2 == 0) ? i : i + 1) : Math.round(n);
-    }
+  function infuseService(dimWebWorker) {
 
     var _data = {
       source: null,
       targets: [],
       infused: 0,
+      exotic: false,
       view: [],
       infusable: [],
-      // huge props to /u/Apswny https://github.com/Apsu
-      infuse: function(source, target) {
-        var diff = target - source;
-
-        if (diff <= (_data.exotic ? 4 : 6)) {
-            return target;
-        }
-        return source + halfToEven(diff * (_data.exotic ? 0.7 : 0.8));
-      },
-      getInfusionResult: function(target, sourceItem, sourceStat) {
-        var targetStat = target.primStat.value;
-
-        // see if we can absorb the entire stat value
-        if (targetStat - sourceStat <= _data.getThreshold(target, sourceItem)) {
-          return targetStat;
-        }
-
-        // otherwise we take a % value
-        var multiplier = (sourceItem.tier === 'Exotic')? 0.7: 0.8;
-        return Math.round((targetStat - sourceStat) * multiplier + sourceStat);
-      },
-      getInfusionResult: function(target, sourceItem, sourceStat) {
-        var targetStat = target.primStat.value;
-
-        // see if we can absorb the entire stat value
-        if (targetStat - sourceStat <= _data.getThreshold(target, sourceItem)) {
-          return targetStat;
-        }
-
-        // otherwise we take a % value
-        var multiplier = (sourceItem.tier === 'Exotic')? 0.7: 0.8;
-        return Math.round((targetStat - sourceStat) * multiplier + sourceStat);
-      },
+      calculating: false,
       calculate: function() {
         var result = _data.source.primStat.value;
 
         _data.targets.forEach(function(target) {
-          result = _data.infuse(result, target.primStat.value);
+          result = InfuseUtil.infuse(result, target.primStat.value, _data.exotic);
         });
+
         return result;
-      },
-      walkPaths: function(list, cameFrom, paths, currentStat) {
-        var start = -1;
-
-        // find the first viable item
-        var start = _.findIndex(list, function(item) {
-          return item.primStat.value > currentStat;
-        });
-        // base case, we've exhausted the list of viable targets
-        if (start === -1) return;
-
-        for (;start != list.length;++start) {
-          var currentNodes = cameFrom.slice(0); // clone
-          currentNodes.push(list[start]);
-
-          var result = _data.getInfusionResult(list[start], _data.source, currentStat);
-
-          // see if a current path exists
-          var existingPath = _.find(paths, function(p) {
-            return p.light === result;
-          });
-          if (existingPath) {
-              // let's see if this one beats it
-            if (currentNodes.length < existingPath.path.length) {
-              existingPath.path = currentNodes; // better path
-            }
-          }
-          else {
-            paths.push({light:result, path:currentNodes}); // add the current path
-          }
-
-          // move to next node (depth first)
-          var next = list.slice(0); // clone
-          next.splice(start, 1); // remove current node
-          _data.walkPaths(next, currentNodes, paths, result);
-        }
-      },
-      maximizeAttack: function() {
-        // we want to use the entire list of infusable items but only use the ones that are possible infusion targets
-        var possibleTargets = _data.infusable.slice(0); // clone
-        var paths = [];
-        _data.walkPaths(possibleTargets, [], paths, _data.source.primStat.value);
-
-        if (_.isEmpty(paths)) return; // no suitable path found
-
-        // find the max light stat
-        var max = _.max(paths, function(path) {
-          return path.light;
-        });
-
-        // apply to view
-        _data.view       = []; // there are no other options
-        _data.targets    = max.path;
-        _data.infused    = max.light;
-        _data.difference = _data.infused - _data.source.primStat.value;
       }
     };
 
     return {
+      isCalculating: function() {
+        return _data.calculating;
+      },
       setSourceItem: function(item) {
         // Set the source and reset the targets
         _data.source = item;
@@ -133,7 +43,6 @@
         _data.view = items;
       },
       toggleItem: function(item) {
-
         // Add or remove the item from the infusion chain
         var index = _.indexOf(_data.targets, item);
         if (index > -1) {
@@ -160,7 +69,41 @@
 
       },
       maximizeAttack: function() {
-        _data.maximizeAttack();
+        if (_data.calculating) return; // no work to do
+
+        var worker = new dimWebWorker({
+          fn:function(args) {
+            var data = JSON.parse(args.data);
+            var max = InfuseUtil.maximizeAttack(data.infusable, data.source, data.exotic);
+
+            if (!max) {
+              this.postMessage('undefined');
+            }
+            else {
+              this.postMessage(JSON.stringify(max));
+            }
+          },
+          include:['vendor/underscore/underscore-min.js', 'scripts/infuse/dimInfuse.util.js']
+        });
+
+        _data.calculating = true;
+        worker.do(JSON.stringify(_data))
+        .then(function(message) {
+          _data.calculating = false;
+
+          if (message === 'undefined') return; // no suitable path found
+
+          var max = JSON.parse(message);
+
+          _data.view       = []; // there are no other options
+          _data.targets    = max.path;
+          _data.infused    = max.light;
+          _data.difference = _data.infused - _data.source.primStat.value;
+        })
+        .then(function() {
+          // cleanup worker
+          worker.destroy();
+        });
       },
       data: _data
     };

--- a/app/scripts/infuse/dimInfuse.util.js
+++ b/app/scripts/infuse/dimInfuse.util.js
@@ -1,0 +1,70 @@
+var InfuseUtil = {
+
+  halfToEven: function(n) {
+      var i = Math.floor(n),
+          f = (n - i).toFixed(8),
+          e = 1e-8; // Allow for rounding errors in f
+      return (f > 0.5 - e && f < 0.5 + e) ?
+          ((i % 2 == 0) ? i : i + 1) : Math.round(n);
+  },
+  // huge props to /u/Apswny https://github.com/Apsu
+  infuse: function(source, target, exotic) {
+    var diff = target - source;
+
+    if (diff <= (exotic ? 4 : 6)) {
+        return target;
+    }
+    return source + InfuseUtil.halfToEven(diff * (exotic ? 0.7 : 0.8));
+  },
+  walkPaths: function(list, cameFrom, paths, currentStat, source, sourceIsExotic) {
+    var start = -1;
+
+    // find the first viable item
+    start = _.findIndex(list, function(item) {
+      return item.primStat.value > currentStat;
+    });
+    // base case, we've exhausted the list of viable targets
+    if (start === -1) return;
+
+    for (;start != list.length;++start) {
+      var currentNodes = cameFrom.slice(0); // clone
+      currentNodes.push(list[start]);
+
+      var result = InfuseUtil.infuse(currentStat, list[start].primStat.value, sourceIsExotic);
+
+      // see if a current path exists
+      var existingPath = _.find(paths, function(p) {
+        return p.light === result;
+      });
+      if (existingPath) {
+          // let's see if this one beats it
+        if (currentNodes.length < existingPath.path.length) {
+          existingPath.path = currentNodes; // better path
+        }
+      }
+      else {
+        paths.push({light:result, path:currentNodes}); // add the current path
+      }
+
+      // move to next node (depth first)
+      var next = list.slice(0); // clone
+      next.splice(start, 1); // remove current node
+      InfuseUtil.walkPaths(next, currentNodes, paths, result, source, sourceIsExotic);
+    }
+  },
+  maximizeAttack: function(possibleTargets, source, sourceIsExotic) {
+    // we want to use the entire list of infusable items but only use the ones that are possible infusion targets
+    var paths = [];
+    InfuseUtil.walkPaths(possibleTargets, [], paths, source.primStat.value, source, sourceIsExotic);
+
+    if (_.isEmpty(paths)) return undefined; // no suitable path found
+
+    // find the max light stat
+    var max = _.max(paths, function(path) {
+      return path.light;
+    });
+
+    return max;
+  }
+
+};

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1590,6 +1590,12 @@ button.toast-close-button {
   margin-left: 30px;
 }
 
+.infuseCalculating {
+  background-size: 22px;
+  height: 22px;
+  display: inline-block;
+}
+
 .black {
   background-color: #222222;
 }

--- a/app/views/infuse.html
+++ b/app/views/infuse.html
@@ -7,6 +7,7 @@
     <br class="clear" />
     <br class="clear" />
     <input type="button" ng-click="infuse.maximizeAttack($event)" value="Maximize {{infuse.statType}}" />
+    <img ng-if="infuse.isCalculating()" class="infuseCalculating" src="../images/712.GIF"></img>
   </p>
 
   <p>

--- a/app/views/infuse.html
+++ b/app/views/infuse.html
@@ -4,6 +4,9 @@
     <input class="controls" type="checkbox" id="infuse-all" ng-model="infuse.getAllItems" ng-change="infuse.getItems()"><label for="infuse-all">Show infusable items across all characters and vault</label>
     <br class="clear" />
     <input class="controls" type="checkbox" id="infuse-locked" ng-model="infuse.showLockedItems" ng-change="infuse.getItems()"><label for="infuse-locked">Include 'locked' items</label>
+    <br class="clear" />
+    <br class="clear" />
+    <input type="button" ng-click="infuse.maximizeAttack($event)" value="Maximize {{infuse.statType}}" />
   </p>
 
   <p>
@@ -15,7 +18,7 @@
     </span>
 
     <span class="infuseSourceDetailsRow">
-      <span>Attack</span><br />
+      <span>{{infuse.statType}}</span><br />
       <span class="bigValue">{{infuse.item.primStat.value}}</span>
     </span>
   </p>


### PR DESCRIPTION
Addressing the second part of issue #289 

> Calculate "best upgrade path"

![demo](https://cloud.githubusercontent.com/assets/4330297/10567400/3e567bb0-75c9-11e5-8c38-7e297819804f.gif)


A couple of other things this addresses:
* The dialog will now display "Defense" rather than "Attack" when viewing a defensive item
* Cleaned up a little bit of the infusion logic (divorced the actual infusion algorithm independent from the list we feed it)

I know this is a fairly significant change and may take some iteration but this is a good first pass.

Things to address in the future:
* Performance when processing large lists of items (beyond 10+ items it starts to get sluggish)
* Add additional filters to the infusion list
    * Filter exotics?
    * Select light range of items?