### PR TITLE
New loadout features

### DIFF
--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -126,9 +126,7 @@
         dimLoadoutService.saveLoadout(vm.loadout);
       }
 
-      vm.loadout = angular.copy(vm.defaults);
-      vm.show = false;
-      dimLoadoutService.dialogOpen = false;
+      vm.cancel();
     };
 
     vm.cancel = function cancel() {

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -144,12 +144,10 @@
         var discriminator = clone.type.toLowerCase();
         var typeInventory = vm.loadout.items[discriminator] = (vm.loadout.items[discriminator] || []);
 
-        var dupe = _.find(typeInventory, function(i) {
-          return (i.id === clone.id);
-        });
+        var dupe = _.findWhere(typeInventory, {id: clone.id});
 
-        if (_.isUndefined(dupe) && (_.size(typeInventory) < 9)) {
-          clone.equipped = false;
+        if (!dupe && typeInventory.length < 9) {
+          clone.equipped = (typeInventory.length === 0);
 
           if (clone.type === 'Class') {
             if (_.has(vm.loadout.items, 'class')) {
@@ -175,6 +173,10 @@
 
       if (index >= 0) {
         typeInventory.splice(index, 1);
+      }
+
+      if (item.equipped && typeInventory.length > 0) {
+        typeInventory[0].equipped = true;
       }
     };
 

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -17,7 +17,10 @@
       replace: true,
       template: [
         '<div class="loadout-popup-content">',
-        '  <div class="loadout-list"><div class="loadout-set"><span class="button-create" ng-click="vm.newLoadout($event)">+ Create Loadout</span></div></div>',
+        '  <div class="loadout-list"><div class="loadout-set">',
+        '    <span class="button-create" ng-click="vm.newLoadout($event)">+ Create Loadout</span>',
+        '    <span class="button-create-equipped" ng-click="vm.newLoadoutFromEquipped($event)">From Equipped</span>',
+        '  </div></div>',
         '  <div class="loadout-list">',
         '    <div ng-repeat="loadout in vm.loadouts track by loadout.id" class="loadout-set">',
         '      <span class="button-name" title="{{ loadout.name }}" ng-click="vm.applyLoadout(loadout, $event)">{{ loadout.name }}</span>',
@@ -61,7 +64,29 @@
 
     vm.newLoadout = function newLoadout($event) {
       ngDialog.closeAll();
-      $rootScope.$broadcast('dim-create-new-loadout', {});
+      $rootScope.$broadcast('dim-create-new-loadout', { });
+    };
+
+    vm.newLoadoutFromEquipped = function newLoadout($event) {
+      ngDialog.closeAll();
+
+      var loadout = loadoutFromCurrentlyEquipped(vm.store.items, "");
+      // We don't want to prepopulate the loadout with a bunch of cosmetic junk
+      // like emblems and ships and horns.
+      loadout.items = _.pick(loadout.items,
+                             'class',
+                             'primary',
+                             'special',
+                             'heavy',
+                             'helmet',
+                             'gauntlets',
+                             'chest',
+                             'leg',
+                             'classitem',
+                             'artifact',
+                             'ghost');
+      loadout.classType = vm.classTypeId;
+      vm.editLoadout(loadout, $event);
     };
 
     vm.deleteLoadout = function deleteLoadout(loadout, $event) {

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -114,12 +114,17 @@ body.about .about, body.app-settings .app-settings, body.support .support, body.
 }
 .button-create {
   float: left;
-  width: 100%;
+  width: 60%;
   padding-left: 10px;
   height: 35px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap !important;
+}
+.button-create-equipped {
+  text-align: center;
+  float: right;
+  width: 40%;
 }
 /*.condensed .character .ngdialog {
   width: 289px;
@@ -1106,7 +1111,7 @@ div[dim-loadout] {
   width: 20%;
   font-size: 1.2em
 }
-.loadout-set .button-delete:hover, .loadout-set .button-edit:hover {
+.loadout-set .button-delete:hover, .loadout-set .button-edit:hover, .loadout-set .button-create-equipped:hover {
   background-color: #68a0b7;
   color: #222;
 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -109,6 +109,9 @@ body.about .about, body.app-settings .app-settings, body.support .support, body.
   text-overflow: ellipsis;
   white-space: nowrap !important;
 }
+.button-full {
+  width: 100%;
+}
 .button-create {
   float: left;
   width: 100%;


### PR DESCRIPTION
Now, whenever you apply a layout, a new menu item appears that says 'Before "&laquo;layout name&raquo;"' that'll put back all the equipped items from before you used the layout. Then the menu item disappears. Note, this only applies to equipped items, not everything your character was holding.

[![selfie-1](http://i.imgur.com/khTlCVK.gif)](https://github.com/thieman/github-selfies/)
