### PR TITLE
Avoid reloading stores unless changing equipped item

### DIFF
--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -82,34 +82,39 @@
      */
     vm.moveItemTo = function moveItemTo(store, equip) {
       var dimStores;
+      var reload = vm.item.equipped || equip;
+      var promise = dimItemService.moveTo(vm.item, store, equip);
 
-      var promise = dimItemService.moveTo(vm.item, store, equip)
-        .then(dimStoreService.getStores)
-        .then(function(stores) {
-          dimStores = stores;
-          return dimStoreService.updateStores();
-        })
-        .then(function(bungieStores) {
-          _.each(dimStores, function(dStore) {
-            if (dStore.id !== 'vault') {
-              var bStore = _.find(bungieStores, function(bStore) {
-                return dStore.id === bStore.id;
-              });
+      if (reload) {
+        promise = promise.then(dimStoreService.getStores)
+          .then(function(stores) {
+            dimStores = stores;
+            return dimStoreService.updateStores();
+          })
+          .then(function(bungieStores) {
+            _.each(dimStores, function(dStore) {
+              if (dStore.id !== 'vault') {
+                var bStore = _.find(bungieStores, function(bStore) {
+                  return dStore.id === bStore.id;
+                });
 
-              dStore.level = bStore.base.characterLevel;
-              dStore.percentToNextLevel = bStore.base.percentToNextLevel;
-              dStore.powerLevel = bStore.base.characterBase.powerLevel;
-              dStore.background = bStore.base.backgroundPath;
-              dStore.icon = bStore.base.emblemPath;
-            }
+                dStore.level = bStore.base.characterLevel;
+                dStore.percentToNextLevel = bStore.base.percentToNextLevel;
+                dStore.powerLevel = bStore.base.characterBase.powerLevel;
+                dStore.background = bStore.base.backgroundPath;
+                dStore.icon = bStore.base.emblemPath;
+              }
+            });
           });
-        })
-        .catch(function(a) {
-          toaster.pop('error', vm.item.name, a.message);
-        });
+      }
+
+      promise = promise.catch(function(a) {
+        toaster.pop('error', vm.item.name, a.message);
+      });
 
       $rootScope.loadingTracker.addPromise(promise);
       $scope.$parent.closeThisDialog();
+      return promise;
     };
 
     dimStoreService.getStores(false, true)

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -108,9 +108,13 @@
           });
       }
 
-      promise = promise.catch(function(a) {
-        toaster.pop('error', vm.item.name, a.message);
-      });
+      promise = promise
+        .then(function() {
+          setTimeout(function() { dimStoreService.setHeights(); }, 0);
+        })
+        .catch(function(a) {
+          toaster.pop('error', vm.item.name, a.message);
+        });
 
       $rootScope.loadingTracker.addPromise(promise);
       $scope.$parent.closeThisDialog();

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -262,13 +262,14 @@
       }
     };
 
+    // TODO: Consolidate this with the same code in dimMovePopup.directive.js
     vm.moveDroppedItem = function(item, equip) {
       var promise = null;
       var target = vm.store;
 
       if (item.owner === vm.store.id) {
         if ((item.equipped && equip) || (!item.equipped) && (!equip)) {
-          return;
+          return $q.resolve();
         }
 
         promise = $q.when(vm.store);
@@ -277,44 +278,44 @@
         promise = dimStoreService.getStore(item.owner);
       }
 
-      var source;
-
       if (item.notransfer && item.owner !== target.id) {
-        return $q.reject(new Error('Cannot move class to different store.'));
+        promise = $q.reject(new Error('Cannot move that item off this character.'));
       }
 
       var dimStores = null;
 
-      promise = promise
-        .then(function(s) {
-          source = s;
-        })
-        .then(dimItemService.moveTo.bind(null, item, target, equip))
-        .then(dimStoreService.getStores)
-        .then(function(stores) {
-          dimStores = stores;
-          return dimStoreService.updateStores();
-        })
-        .then(function(bungieStores) {
-          _.each(dimStores, function(dStore) {
-            if (dStore.id !== 'vault') {
-              var bStore = _.find(bungieStores, function(bStore) {
-                return dStore.id === bStore.id;
-              });
+      var reload = item.equipped || equip;
 
-              dStore.level = bStore.base.characterLevel;
-              dStore.percentToNextLevel = bStore.base.percentToNextLevel;
-              dStore.powerLevel = bStore.base.characterBase.powerLevel;
-              dStore.background = bStore.base.backgroundPath;
-              dStore.icon = bStore.base.emblemPath;
-            }
+      promise = promise.then(dimItemService.moveTo.bind(null, item, target, equip));
+
+      if (reload) {
+        promise = promise.then(dimStoreService.getStores)
+          .then(function(stores) {
+            dimStores = stores;
+            return dimStoreService.updateStores();
+          })
+          .then(function(bungieStores) {
+            _.each(dimStores, function(dStore) {
+              if (dStore.id !== 'vault') {
+                var bStore = _.find(bungieStores, function(bStore) {
+                  return dStore.id === bStore.id;
+                });
+
+                dStore.level = bStore.base.characterLevel;
+                dStore.percentToNextLevel = bStore.base.percentToNextLevel;
+                dStore.powerLevel = bStore.base.characterBase.powerLevel;
+                dStore.background = bStore.base.backgroundPath;
+                dStore.icon = bStore.base.emblemPath;
+              }
+            });
           });
-        })
-        .catch(function(a) {
-          toaster.pop('error', item.name, a.message);
-        });
+      }
+      promise = promise.catch(function(a) {
+        toaster.pop('error', item.name, a.message);
+      });
 
       $rootScope.loadingTracker.addPromise(promise);
+      return promise;
     };
 
     function resetData() {

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -310,9 +310,13 @@
             });
           });
       }
-      promise = promise.catch(function(a) {
-        toaster.pop('error', item.name, a.message);
-      });
+      promise = promise
+        .then(function() {
+          setTimeout(function() { dimStoreService.setHeights(); }, 0);
+        })
+        .catch(function(a) {
+          toaster.pop('error', item.name, a.message);
+        });
 
       $rootScope.loadingTracker.addPromise(promise);
       return promise;
@@ -336,6 +340,9 @@
     $scope.$on('dim-settings-updated', function(event, settings) {
       if (_.has(settings, 'itemSort')) {
         vm.itemSort = settings.itemSort;
+      }
+      if (_.has(settings, 'charCol') || _.has(settings, 'vaultCol')) {
+        setTimeout(function() { dimStoreService.setHeights(); }, 0);
       }
     });
 


### PR DESCRIPTION
This is a second try at 8f3d113463c3d8f79af702080ff9556530c7da6c that avoids the problems in #353 (by correctly wiring a `catch` handler). Now, we will only make the call to reload info if the active equipment is being changed (equipped or dequipped), so we can see the new light level. Otherwise, we can simply trust that the move worked as we intended. This should speed up moves a bit.

These changes were originally made by @SunburnedGoose on the `perf` branch.