### PR TITLE
Make the promise tracker a service

### DIFF
--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -45,11 +45,16 @@
         'Consumable',
         'Material'
       ]
-    });
+    })
+    .factory('loadingTracker', ['promiseTracker', function(promiseTracker) {
+      return promiseTracker();
+    }]);
+
 
   angular.module('dimApp')
-    .run(function($rootScope, promiseTracker, $cookies, $timeout, toaster) {
-      $rootScope.loadingTracker = promiseTracker();
+    .run(['$rootScope', 'loadingTracker', '$cookies', '$timeout', 'toaster',
+          function($rootScope, loadingTracker, $cookies, $timeout, toaster) {
+      $rootScope.loadingTracker = loadingTracker;
 
       //1 Hour
       $rootScope.inactivityLength = 60 * 60 * 1000;
@@ -125,7 +130,7 @@
           }, 3000);
         }
       });
-    });
+    }]);
 
   angular.module('dimApp')
     .config([

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -33,9 +33,9 @@
     };
   }
 
-  LoadoutPopupCtrl.$inject = ['$rootScope', 'ngDialog', 'dimLoadoutService', 'dimItemService', 'toaster', '$q', 'dimStoreService', 'dimItemTier'];
+  LoadoutPopupCtrl.$inject = ['$rootScope', 'loadingTracker', 'ngDialog', 'dimLoadoutService', 'dimItemService', 'toaster', '$q', 'dimStoreService', 'dimItemTier'];
 
-  function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemService, toaster, $q, dimStoreService, dimItemTier) {
+  function LoadoutPopupCtrl($rootScope, loadingTracker, ngDialog, dimLoadoutService, dimItemService, toaster, $q, dimStoreService, dimItemTier) {
     var vm = this;
 
     vm.classTypeId = {
@@ -302,7 +302,7 @@
               applyLoadoutItems(items, loadout, _items, scope);
             });
 
-          $rootScope.loadingTracker.addPromise(promise);
+          loadingTracker.addPromise(promise);
         }
       } else {
         var dimStores;

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -45,9 +45,9 @@
     };
   }
 
-  MovePopupController.$inject = ['$scope', '$rootScope', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster'];
+  MovePopupController.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster'];
 
-  function MovePopupController($scope, $rootScope, dimStoreService, dimItemService, ngDialog, $q, toaster) {
+  function MovePopupController($scope, loadingTracker, dimStoreService, dimItemService, ngDialog, $q, toaster) {
     var vm = this;
 
     function capitalizeFirstLetter(string) {
@@ -116,7 +116,7 @@
           toaster.pop('error', vm.item.name, a.message);
         });
 
-      $rootScope.loadingTracker.addPromise(promise);
+      loadingTracker.addPromise(promise);
       $scope.$parent.closeThisDialog();
       return promise;
     };

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -3,9 +3,9 @@
 
   angular.module('dimApp').controller('dimAppCtrl', DimApp);
 
-  DimApp.$inject = ['ngDialog', '$rootScope', 'dimPlatformService', 'dimStoreService', '$interval', 'hotkeys', '$timeout', 'dimStoreService'];
+  DimApp.$inject = ['ngDialog', '$rootScope', 'loadingTracker', 'dimPlatformService', 'dimStoreService', '$interval', 'hotkeys', '$timeout', 'dimStoreService'];
 
-  function DimApp(ngDialog, $rootScope, dimPlatformService, storeService, $interval, hotkeys, $timeout, dimStoreService) {
+  function DimApp(ngDialog, $rootScope, loadingTracker, dimPlatformService, storeService, $interval, hotkeys, $timeout, dimStoreService) {
     var vm = this;
     var aboutResult = null;
     var settingResult = null;
@@ -171,7 +171,7 @@
       $rootScope.autoRefreshTimer = $interval(function () {
        //Only Refresh If We're Not Already Doing Something
        //And We're Not Inactive
-       if (!$rootScope.loadingTracker.active() && !$rootScope.isUserInactive() && document.visibilityState == 'visible') {
+       if (!loadingTracker.active() && !$rootScope.isUserInactive() && document.visibilityState == 'visible') {
          refresh();
        }
       }, secondsToWait * 1000);
@@ -187,7 +187,7 @@
 
     // Refresh when the user comes back to the page
     document.addEventListener("visibilitychange", function() {
-      if (!$rootScope.loadingTracker.active() && !$rootScope.isUserInactive() && document.visibilityState == 'visible') {
+      if (!loadingTracker.active() && !$rootScope.isUserInactive() && document.visibilityState == 'visible') {
         refresh();
       }
     }, false);

--- a/app/scripts/shell/dimPlatformChoice.directive.js
+++ b/app/scripts/shell/dimPlatformChoice.directive.js
@@ -22,9 +22,9 @@
     };
   }
 
-  PlatformChoiceCtrl.$inject = ['$scope', 'dimPlatformService', 'dimState', '$rootScope'];
+  PlatformChoiceCtrl.$inject = ['$scope', 'dimPlatformService', 'dimState', 'loadingTracker'];
 
-  function PlatformChoiceCtrl($scope, dimPlatformService, dimState, $rootScope) {
+  function PlatformChoiceCtrl($scope, dimPlatformService, dimState, loadingTracker) {
     var vm = this;
 
     vm.active = null;
@@ -40,13 +40,9 @@
         setTimeout(function() {
           var promise = dimPlatformService.getPlatforms();
 
-          $rootScope.loadingTracker.addPromise(promise);
+          loadingTracker.addPromise(promise);
         }, 250);
       });
-
-      // var promise = dimPlatformService.getPlatforms();
-      //
-      // $rootScope.loadingTracker.addPromise(promise);
     }
 
     $scope.$on('dim-platforms-updated', function(e, args) {

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -94,9 +94,9 @@
     }
   }
 
-  StoreItemsCtrl.$inject = ['$scope', '$rootScope', 'dimStoreService', 'dimItemService', '$q', '$timeout', 'toaster', 'dimSettingsService'];
+  StoreItemsCtrl.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', '$q', '$timeout', 'toaster', 'dimSettingsService'];
 
-  function StoreItemsCtrl($scope, $rootScope, dimStoreService, dimItemService, $q, $timeout, toaster, dimSettingsService) {
+  function StoreItemsCtrl($scope, loadingTracker, dimStoreService, dimItemService, $q, $timeout, toaster, dimSettingsService) {
     var vm = this;
 
     var types = [ // Order of types in the rows.
@@ -317,7 +317,7 @@
           toaster.pop('error', item.name, a.message);
         });
 
-      $rootScope.loadingTracker.addPromise(promise);
+      loadingTracker.addPromise(promise);
       return promise;
     };
 

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -27,9 +27,9 @@
     };
   }
 
-  StoresCtrl.$inject = ['dimSettingsService', '$scope', 'dimStoreService', '$rootScope', '$q'];
+  StoresCtrl.$inject = ['dimSettingsService', '$scope', 'dimStoreService', 'loadingTracker', '$q'];
 
-  function StoresCtrl(settings, $scope, dimStoreService, $rootScope, $q) {
+  function StoresCtrl(settings, $scope, dimStoreService, loadingTracker, $q) {
     var vm = this;
 
     vm.stores = null;
@@ -63,7 +63,7 @@
           vm.stores = stores;
         });
 
-      $rootScope.loadingTracker.addPromise(promise);
+      loadingTracker.addPromise(promise);
     });
   }
 })();


### PR DESCRIPTION
This way, it doesn't need to be referred to via `$rootScope`, so we don't end up depending on `$rootScope` all over.