### PR TITLE
Handle moving to full inventory better

### DIFF
--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -57,12 +57,12 @@
       }
     });
 
-    $scope.$on('dim-active-platform-updated', function(e, args) {
-      var promise = $q.when(dimStoreService.getStores(true))
-        .then(function(stores) {
-          vm.stores = stores;
-        });
+    $scope.$on('dim-stores-updated', function (e, stores) {
+      vm.stores = stores.stores;
+    });
 
+    $scope.$on('dim-active-platform-updated', function(e, args) {
+      var promise = $q.when(dimStoreService.getStores(true));
       loadingTracker.addPromise(promise);
     });
   }


### PR DESCRIPTION
A situation I find myself often in, is when DIM says my character's inventory is full, but it's not because I've trashed some items or something. DIM will then fail moves into my inventory, and I have to refresh to make it work. I've trained myself to do that, but this patch makes it so that moving an item into a full inventory will cause a refresh automatically, which will then give the move a chance to succeed. This works well in my testing (though less well when the Bungie service is out of sync with game state as well). While I was in there I took the opportunity to clean up some promise code in `canMoveToStore`.