### PR TITLE
Sort items when adding them to the infusion calculator

### DIFF
--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -22,7 +22,7 @@
     vm.toggleItem = function(e, item) {
       e.stopPropagation();
       infuseService.toggleItem(item);
-    }
+    };
 
     // get Items for infusion
     vm.getItems = function() {
@@ -57,11 +57,11 @@
 
       });
 
-    }
+    };
 
     vm.closeDialog = function() {
         ngDialog.closeAll();
-    }
+    };
 
     vm.getItems();
 

--- a/app/scripts/infuse/dimInfuse.factory.js
+++ b/app/scripts/infuse/dimInfuse.factory.js
@@ -61,7 +61,9 @@
           _data.targets.splice(index, 1);
         }
         else {
-          _data.targets.push(item);
+          var sortedIndex = _.sortedIndex(_data.targets, item,
+                                          function(i) { return i.primStat.value; });
+          _data.targets.splice(sortedIndex, 0, item);
         }
 
         // Value of infused result
@@ -78,8 +80,8 @@
           .value();
 
       },
-      data: _data,
-    }
+      data: _data
+    };
 
   }
 


### PR DESCRIPTION
Previously, if you didn't select items in the proper order, you'd get a result that actually went down in light. This inserts the items in order, because you'd always infuse from lowest to highest light.

For example, before:

Starting with a 280 legendary, adding a 300 and a 298 results in: 298

After:

Starting with a 280 legendary, adding a 300 and a 298 results in: 300
