### PR TITLE
Separate Quests from Bounties, and show objectives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * The talent grid for an item are now shown in the item details, just like in the game, including XP per node.
 * Subclasses show a talent grid as well!
 * The item stats comparison will no longer be cleared if DIM reloads items while an item popup is open.
+* Bounties and quests are now separated, and under their own "Progress" heading.
+* Bounties, quests, and anything else that can have objectives (like test weapons and runes) now show their objectives and the progress towards them. As a result, completion percentages are also now accurate for those items.
+* Descriptions are now available as details for non-equipment items.
 
 # 3.2.3
 

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -20,7 +20,6 @@
       template: [
         '<div class="move-popup" alt="" title="">',
         '  <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse"></div>',
-        '  <span ng-if="::vm.item.type === \'Bounties\'" class="bounty-description" ng-bind="::vm.item.description"></span>',
         '  <div class="interaction">',
         '    <div class="locations" ng-repeat="store in vm.stores track by store.id">',
         '      <div class="move-button move-vault" ng-class="{ \'little\': item.notransfer }" alt="{{::vm.characterInfo(store) }}" title="{{::vm.characterInfo(store) }}" ',
@@ -39,7 +38,7 @@
         '        <span>Equip</span>',
         '      </div>',
         '    </div>',
-        '  <div class="infuse-perk" ng-if="vm.item.talentGrid.infusable" ng-click="vm.infuse(vm.item, $event)" title="Infusion calculator" alt="Infusion calculator" style="background-image: url(\'/images/{{vm.item.sort}}.png\');"></div>',
+        '  <div class="infuse-perk" ng-if="vm.item.talentGrid.infusable && vm.item.sort !== \'Postmaster\'" ng-click="vm.infuse(vm.item, $event)" title="Infusion calculator" alt="Infusion calculator" style="background-image: url(\'/images/{{vm.item.sort}}.png\');"></div>',
         '  </div>',
         '</div>'
       ].join('')
@@ -61,6 +60,9 @@
     * the selected item
     */
     vm.infuse = function infuse(item, e) {
+      if (item.sort === 'Postmaster') {
+        return;
+      }
       e.stopPropagation();
 
       // Close the move-popup

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -85,7 +85,7 @@
         }
       };
 
-      if (vm.item.type === 'Bounties') {
+      if (!vm.item.primStat && vm.item.objectives) {
         scope.$watchGroup([
           'vm.item.xpComplete',
           'vm.itemStat',
@@ -171,6 +171,7 @@
     case 'Lost Items':
     case 'Missions':
     case 'Bounties':
+    case 'Quests':
     case 'Special Orders':
     case 'Messages':
       {

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -121,6 +121,7 @@
       'Material',
       'Missions',
       'Bounties',
+      'Quests',
       'Messages',
       'Special Orders',
       'Lost Items'
@@ -157,9 +158,11 @@
         'Emote',
         'Ship',
         'Vehicle',
-        'Horn',
+        'Horn'],
+      Progress: [
+        'Bounties',
+        'Quests',
         'Missions',
-        'Bounties'
       ],
       Postmaster: [
         'Messages',

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -145,7 +145,7 @@ body.about .about, body.app-settings .app-settings, body.support .support, body.
   border-bottom: solid 1px #111;
   background-color: #222;
 }
-.vault .sort-class, .vault .section.postmaster {
+.vault .sort-class, .vault .section.postmaster, .vault .sort-class, .vault .section.progress {
   /*display: none;*/
   visibility: hidden;
 }
@@ -923,19 +923,23 @@ img.void {
  */
 
 .item-details {
-  padding: 10px;
+  margin: 10px;
+}
+.item-description {
+  margin: 10px;
+  white-space: pre-wrap;
 }
 .item-stats {
   width: 100%;
 }
 .stat-box-row {
   overflow: hidden;
-  margin-bottom: 5px;
+  margin-bottom: 4px;
 }
 .item-details .stat-box-text {
   display: block;
   float: left;
-  line-height: 20px;
+  line-height: 14px;
   padding-right: 10px;
   width: 30%;
   text-align: right;
@@ -943,7 +947,7 @@ img.void {
 .item-details .stat-box-val{
   display: block;
   float: left;
-  line-height: 20px;
+  line-height: 14px;
   width: 10%;
   text-align: left;
   padding-left: 5px;
@@ -962,7 +966,8 @@ img.void {
 }
 .item-details .stat-box-outer, .item-details .stat-box-inner {
   display: block;
-  height: 20px;
+  height: 14px;
+  line-height: 14px;
   width: 60%;
   float: left;
   background-color: #333;
@@ -982,6 +987,68 @@ img.void {
 }
 .item-details.stat-box-row {
   padding-bottom: 3px;
+}
+
+.objective-row {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 4px;
+}
+.objective-checkbox {
+  width: 17px;
+  height: 17px;
+  border: 1px solid #999;
+  margin-right: 4px;
+}
+.objective-complete {
+  opacity: 0.5;
+}
+.objective-complete .objective-progress {
+  background-color: #111;
+}
+.objective-complete .objective-progress-bar {
+  display: none;
+}
+.objective-complete .objective-checkbox div {
+  margin: 2px;
+  height: 11px;
+  width: 11px;
+  background-color: #7DC878;
+}
+.objective-progress {
+  flex: 1;
+  background-color: black;
+  position: relative;
+  min-height: 17px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  color: white;
+}
+.objective-progress-bar {
+  background-color: #7DC878;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+}
+.objective-description {
+  position: relative;
+  padding: 0 4px;
+  flex: 1;
+}
+.objective-text {
+  margin-right: 4px;
+  z-index: 100;
+}
+.objective-boolean .objective-progress-bar, .objective-boolean .objective-text {
+  display: none;
+}
+.objective-boolean .objective-progress {
+  background-color: transparent;
+}
+.objective-boolean .objective-description {
+  padding: 0;
 }
 
 .infuse-perk {
@@ -1004,7 +1071,6 @@ img.void {
   max-width: 100%;
   height: auto;
   width: auto;
-  margin-top: .5rem;
 }
 .talent-node-xp {
   fill: rgba(255,255,255,0.1);


### PR DESCRIPTION
Quests being mixed with bounties never felt quite right to me - this sorts them out, and then I completely integrated the information we have about the various objectives and their completion. This was implemented in a generic enough way that it also shows objectives for things like test weapons and runes.

![image](https://cloud.githubusercontent.com/assets/313208/13042987/ebb89cee-d379-11e5-8386-449603630cc3.png)
![image](https://cloud.githubusercontent.com/assets/313208/13043004/1a898092-d37a-11e5-86cb-63d2883132bf.png)
![image](https://cloud.githubusercontent.com/assets/313208/13043013/2bb91922-d37a-11e5-9b1b-38f5fd99debd.png)

