### PR TITLE
Add some missing search filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Next
 
-* If multiple items in the infusion calculator have the same light, but different XP completion percentage, favor suggesting the item with the least XP for infusion.
+* If multiple items in the infusion calculator have the same light, but different XP completion percentage, favor suggesting the item with the least XP for in
+* Keyword search also searches perks on items.
+* New search terms for is:engram, is:sword, is:artifact, is:ghost, is:consumable, is:material, etc.
 
 # 3.3
 

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -122,12 +122,12 @@
      */
     var filterTrans = {
       'dmg':          ['arc', 'solar', 'void', 'kinetic'],
-      'type':         ['primary', 'special', 'heavy', 'helmet', 'leg', 'gauntlets', 'chest', 'class', 'classitem'],
+      'type':         ['primary', 'special', 'heavy', 'helmet', 'leg', 'gauntlets', 'chest', 'class', 'classitem', 'artifact', 'ghost', 'horn', 'consumable', 'ship', 'material', 'vehicle', 'emblem', 'bounties', 'quests', 'messages', 'missions', 'emote'],
       'tier':         ['common', 'uncommon', 'rare', 'legendary', 'exotic'],
       'incomplete':   ['incomplete'],
       'complete':     ['complete'],
       'xpcomplete':   ['xpcomplete'],
-      'xpincomplete': ['xpincomplete'],
+      'xpincomplete': ['xpincomplete', 'needsxp'],
       'upgraded':     ['upgraded'],
       'classType':    ['titan', 'hunter', 'warlock'],
       'dupe':         ['dupe', 'duplicate'],
@@ -137,7 +137,8 @@
       'locked':       ['locked'],
       'unlocked':     ['unlocked'],
       'stackable':    ['stackable'],
-      'weaponClass':  ["pulserifle", "scoutrifle", "handcannon", "autorifle", "primaryweaponengram", "sniperrifle", "shotgun", "fusionrifle", "specialweaponengram", "rocketlauncher", "machinegun", "heavyweaponengram", "sidearm"],
+      'engram':       ['engram'],
+      'weaponClass':  ['pulserifle', 'scoutrifle', 'handcannon', 'autorifle', 'primaryweaponengram', 'sniperrifle', 'shotgun', 'fusionrifle', 'specialweaponengram', 'rocketlauncher', 'machinegun', 'heavyweaponengram', 'sidearm', 'sword'],
       'year':         ['year1', 'year2']
     };
 
@@ -240,6 +241,9 @@
       },
       'stackable': function(predicate, item) {
         return item.maxStackSize > 1;
+      },
+      'engram': function(predicate, item) {
+        return item.type.toLowerCase().indexOf('Engram') >= 0;
       },
       'weaponClass': function(predicate, item) {
         return predicate.toLowerCase().replace(/\s/g, '') == item.weaponClass;

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -249,7 +249,11 @@
         return predicate.toLowerCase().replace(/\s/g, '') == item.weaponClass;
       },
       'keyword': function(predicate, item) {
-        return item.name.toLowerCase().indexOf(predicate) >= 0;
+        return item.name.toLowerCase().indexOf(predicate) >= 0 ||
+          // Search perks as well
+          (item.talentGrid && _.any(item.talentGrid.nodes, function(node) {
+            return node.name.toLowerCase().indexOf(predicate) >= 0;
+          }));
       },
       'light': function(predicate, item) {
         if (predicate.length === 0 || item.primStat === undefined) {

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -85,7 +85,7 @@
       <td>
         <span>is:complete</span>
         <span>is:incomplete</span>
-        <span>is:xpincomplete</span>
+        <span>is:xpincomplete, is:needsxp</span>
         <span>is:xpcomplete</span>
         <span>is:upgraded</span>
       </td>
@@ -93,7 +93,7 @@
         <ul>
           <li>Complete shows items that are totally complete - every upgrade unlocked.</li>
           <li>Incomplete shows items that are not complete - there's still at least one upgrade to unlock.</li>
-          <li>xpincomplete shows items that can still have XP put into them.</li>
+          <li>xpincomplete/needsxp shows items that can still have XP put into them.</li>
           <li>xpcomplete shows items that cannot have XP put into them (whether or not their upgrades have been unlocked).</li>
           <li>Upgraded shows items that have enough XP to unlock all their nodes, but not all the nodes have been unlocked.</li>
         </ul>
@@ -133,17 +133,24 @@
         <span>is:scoutrifle</span>
         <span>is:handcannon</span>
         <span>is:autorifle</span>
-        <span>is:primaryweaponengram</span>
         <span>is:sniperrifle</span>
         <span>is:shotgun</span>
         <span>is:fusionrifle</span>
         <span>is:sidearm</span>
-        <span>is:specialweaponengram</span>
         <span>is:rocketlauncher</span>
         <span>is:machinegun</span>
+        <span>is:sword</span>
+        <span>is:primaryweaponengram</span>
+        <span>is:specialweaponengram</span>
         <span>is:heavyweaponengram</span>
       </td>
       <td>Shows weapons based on their weapon type.</td>
+    </tr>
+    <tr>
+      <td>
+        <span>is:engram</span>
+      </td>
+      <td>Shows engrams.</td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
For the next version, I want to do some more with search. To start off, I added support for searching perks with the freeform text search, and added some missing keywords like is:engram, is:sword, is:artifact, is:ghost, is:consumable, is:material, etc.