### PR TITLE
fix for class specific weapons

### DIFF
--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -139,7 +139,7 @@
 
         var results = _.chain(store.items)
           .where({
-            classType: item.classType
+            classType: item.sort === 'Weapons' ? 3 : item.classType
           })
           .sortBy(function(i) {
             return sortType[i.tier];


### PR DESCRIPTION
issue found in #414

when we're dequiping an item, we search for a 'similar item'

the issue is in `dimItemService.factory.js#141`

          .where({
            classType: item.classType
          })

for example. if we try to dequip the stillpiercer (a weapon just for hunters) DIM looks for another item that is just for hunters. Since there isn't one (unless they have another stillpeircer), an error is thrown.

`classType` for any given equipment is 3. Unless it's a class specific, then it's 0 for titan, 1 for hunter, 2 for warlock. A stillpeircer has a `classType` of 1.

so a viable fix may be something like (and still preserve the `classType` filter for armor):

          .where({
            classType: item.sort === 'Weapons' ? 3 : item.classType
          })

another thing to keep in mind (which this does not break since for weapons we ONLY look for classType of 3 to equip) is if the stillpeircer is sitting on a titan and a user dequips an item on that titan, we don't want them to equip the hunter class weapon. 

however, if a user has only a stillpeircer on their hunter and tries to dequip their current item it won't fallback and find the stillpeircer. a very rare usecase, but it does exist (and technically already does exist) so instead DIM will automatically pull something from the vault. not ideal, but nothing breaks.