### PR TITLE
Slightly more generic way to find replacement weapons

### DIFF
--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -128,7 +128,6 @@
       }
 
       function searchForSimilarItem(item, store) {
-        var result = null;
         var sortType = {
           Legendary: 0,
           Rare: 1,
@@ -137,41 +136,32 @@
           Exotic: 5
         };
 
-        var results = _.chain(store.items)
-          .where({
-            classType: item.sort === 'Weapons' ? 3 : item.classType
+        var result = _.chain(store.items)
+          .filter(function(i) {
+            return i.equipment &&
+              i.type === item.type &&
+              !i.equipped &&
+              // Compatible with this class
+              (i.classTypeName === 'unknown' || i.classTypeName === vm.store.class) &&
+              // Not the same item
+              i.id !== item.id &&
+              i.hash !== item.hash;
           })
           .sortBy(function(i) {
             return sortType[i.tier];
           })
-          .where({
-            type: item.type,
-            equipped: false,
-            equipment: true
-          })
+          .first()
           .value();
 
-        if (_.size(results) > 0) {
-          result = results[0];
+        if (result && result.tier === dimItemTier.exotic) {
+          var prefix = _.filter(store.items, function(i) {
+            return i.equipped &&
+              i.type !== item.type &&
+              i.sort === item.sort &&
+              i.tier === dimItemTier.exotic;
+          });
 
-          if ((result.id === item.id) && (result.hash === item.hash)) {
-            if (_.size(results) > 1) {
-              result = results[1];
-            } else {
-              result = null;
-            }
-          }
-        }
-
-        if (result !== null && result.tier === dimItemTier.exotic) {
-          var prefix = _(store.items)
-            .chain()
-            .filter(function(i) {
-              return (i.equipped && i.type !== item.type && i.sort === item.sort && i.tier === dimItemTier.exotic);
-            });
-
-          if (prefix.size()
-            .value() === 0) {
+          if (prefix.length === 0) {
             return result;
           } else {
             return null;


### PR DESCRIPTION
This is a slight tweak to @kyleshay's fix for class-specific weapons. This uses the same check I used to filter for appropriate items in the maximize light auto-loadout - the rule is to only pick items that can be equipped, as opposed to picking items that are similar in class-requirement to the item being dequipped.

While I was in there I cleaned up a bit of the underscore stuff too :-)