### PR TITLE
Fix error equipping exotic items

### DIFF
--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -156,7 +156,6 @@
         if (result && result.tier === dimItemTier.exotic) {
           var prefix = _.filter(store.items, function(i) {
             return i.equipped &&
-              i.type !== item.type &&
               i.sort === item.sort &&
               i.tier === dimItemTier.exotic;
           });
@@ -197,6 +196,7 @@
           .then(function(similarItem) {
             scope.similarItem = similarItem;
 
+            // could this be removed now, along with all refrences to `equipExotic` that are passed in?
             if (!equipExotic && (similarItem) && (similarItem.tier === 'Exotic')) {
               return $q.reject('There are no items to equip in the \'' + item.type + '\' slot.');
             } else if (!similarItem) {


### PR DESCRIPTION
If there is an exotic item equipped (`The Last Word`) and the only other item in the primary slot inventory on that character is another exotic item (`Red Death`), an error will be thrown if the user tries to move the equipped exotic primary. The most user friendly solution here would be to then instead equip the inventory item, the (`Red Death`)

Another interesting case is if an exotic item is equipped (`The Last Word`) and the only other item in the inventory is the `Red Death`, and a user wants to equip their `Black Spindle`, DIM will currently just error (due to some of this logic: https://github.com/DestinyItemManager/DIM/blob/dev/app/scripts/services/dimItemService.factory.js#L200). A more user friendly solution may be to equip the `Black Spindle`, but only after pulling a legendary from the vault and equipping that in the primary slot.

This fix satisfies the second scenario (equipping the Spindle), and in turn also solves the first, but maybe not in the most ideal of ways. Instead if an exotic is dequipped, instead of equipping the only other item in the inventory (another exotic) it will instead pull a legendary from the vault. I'm not thrilled with that solution, but it is better than just throwing an error, as it does now. Especially so since that second scenario is now resolved.

The main benefit of this PR is there are now a lot less scenarios that will present an error (in the form of a toaster) if a user was trying to do something.

I also wonder with this fix if all references in `dimItemService.factory.js` to `equipExotic` and passing in that flag to `dequipItem(item, equipExotic)` can now be removed since those cases won't be hit anymore. Might need a bit more digging. 