### PR TITLE
minor infusion calc performance buff

### DIFF
--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -157,7 +157,7 @@
 
         var worker = new dimWebWorker({
           fn:function(args) {
-            var data = JSON.parse(args.data);
+            var data = args.data;
             var max = InfuseUtil.maximizeAttack(
               _.reject(data.infusable, function(item) {
                 return _.any(data.excluded, function(otherItem) {
@@ -178,8 +178,12 @@
         });
 
         vm.calculating = true;
-        worker.do(JSON.stringify(vm))
-          .then(function(message) {
+        worker.do({
+          infusable: vm.infusable,
+          excluded: vm.excluded,
+          source: vm.source,
+          exotic: vm.exotic,
+        }).then(function(message) {
             vm.calculating = false;
 
             vm.paths = [manualPath];


### PR DESCRIPTION
eliminate the JSON.parse()

@bhollis I won't pull this in until you give the :+1:  since I know that you were working on some perf updates of your own. This isn't a huge priority since it functions fine as is, so we can hold off on it if it means less merge conflicts for you down the road.