### PR TITLE
setting to hide "< year X" items

### DIFF
--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -19,6 +19,7 @@
     function loadSettings() {
       settingState = {
         hideFilteredItems: false,
+        showMinYear: 0,
         itemDetails: false,
         itemStat: false,
         condensed: false,

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -17,10 +17,11 @@
       replace: true,
       scope: {
         'store': '=storeData',
-        'item': '=itemData'
+        'item': '=itemData',
+        'minYear': '='
       },
       template: [
-        '<div ui-draggable="{{ ::vm.draggable }}" id="{{ ::vm.item.index }}" drag-channel="{{ ::vm.dragChannel }}" ',
+        '<div ng-hide="vm.hideItem()" ui-draggable="{{ ::vm.draggable }}" id="{{ ::vm.item.index }}" drag-channel="{{ ::vm.dragChannel }}" ',
         '  title="{{vm.item.primStat.value}} {{::vm.item.name}}" ',
         '  drag="::vm.item.index"',
         '  class="item">',
@@ -48,6 +49,11 @@
         element[0].querySelector('.img')
           .style.backgroundImage = 'url(' + chrome.extension.getURL(vm.item.icon) + ')';
       });
+
+      vm.hideItem = function() {
+        return (vm.item.primStat.statHash === 3897883278 ||
+                vm.item.primStat.statHash === 368428387) && vm.item.year <= vm.minYear
+      }
 
       vm.clicked = function openPopup(item, e) {
         e.stopPropagation();

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -71,7 +71,7 @@
         '          <div ng-repeat="item in vm.data[vm.orderedTypes[type]] | equipped:true track by item.index" dim-store-item store-data="vm.store" item-data="item"></div>',
         '        </div>',
         '        <div ng-class="vm.styles[type.replace(\' \', \'-\')].unequipped" ui-on-drop="vm.onDrop($data, $event, false)" drop-channel="{{ type + \',\' + vm.store.id + type }}">',
-        '          <div ng-repeat="item in vm.data[vm.orderedTypes[type]] | equipped:false | sortItems:vm.itemSort track by item.index" dim-store-item store-data="vm.store" item-data="item"></div>',
+        '          <div ng-repeat="item in vm.data[vm.orderedTypes[type]] | equipped:false | sortItems:vm.itemSort track by item.index" dim-store-item min-year="vm.minYear" store-data="vm.store" item-data="item"></div>',
         '          <div class="item-target"></div>',
         '        </div>',
         '      </div>',
@@ -321,6 +321,10 @@
 
     dimSettingsService.getSetting('itemSort').then(function(sort) {
       vm.itemSort = sort;
+    });
+
+    dimSettingsService.getSetting('showMinYear').then(function(min) {
+      vm.minYear = min;
     });
 
     $scope.$on('dim-settings-updated', function(event, settings) {

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -13,7 +13,15 @@
           <label for="condensedItems" title="Items that do not match filter criteria will be hidden.">Hide Unfiltered Items while Filtering</label>
         </td>
         <td>
-          <input type="checkbox" ng-model="vm.settings.hideFilteredItems" ng-change="vm.save('hideFilteredItems')"></input>
+          <input type="checkbox" id="condensedItems" ng-model="vm.settings.hideFilteredItems" ng-change="vm.save('hideFilteredItems')" />
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label for="showMinYear" title="Weapons and armor to show from which year">Minimum year of armor and weapons to show</label>
+        </td>
+        <td>
+          <input type="text" id="showMinYear" ng-model="vm.settings.showMinYear" ng-change="vm.save('showMinYear')" />
         </td>
       </tr>
       <tr>
@@ -21,7 +29,7 @@
           <label for="details" title="Clicking on an item will show a popup that can be expanded to show perk and stat details.  This option will always show that detail when you click on an item.">Always Show Item Details</label>
         </td>
         <td>
-          <input type="checkbox" id="details" ng-model="vm.settings.itemDetails" ng-change="vm.save('itemDetails')"></input>
+          <input type="checkbox" id="details" ng-model="vm.settings.itemDetails" ng-change="vm.save('itemDetails')" />
         </td>
       </tr>
       <tr>
@@ -29,7 +37,7 @@
           <label for="itemStat" title="Will display information in the lower-right of the item that is appropriate to the item such as attack, defense, and bounty status.">Display Primary Stat Values on Items</label>
         </td>
         <td>
-          <input type="checkbox" id="itemStat" ng-model="vm.settings.itemStat" ng-change="vm.save('itemStat')"></input>
+          <input type="checkbox" id="itemStat" ng-model="vm.settings.itemStat" ng-change="vm.save('itemStat')" />
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
* only filters amor and weapons (we always want to see y1 consumables, etc)
*  if an item is equipped it will always show

TODO:
- [ ] still needs to refresh the UI when the value changes
- [ ] we should use a range slider here
- [ ] any item should appear in search mode, regardless of this setting

# setting
<img width="589" alt="screen shot 2016-03-04 at 10 35 08 am" src="https://cloud.githubusercontent.com/assets/424158/13531499/d45aafd6-e1f4-11e5-9e3d-b9c035d0ea54.png">

# > year 0
<img width="1558" alt="screen shot 2016-03-04 at 10 33 12 am" src="https://cloud.githubusercontent.com/assets/424158/13531443/9ab280a6-e1f4-11e5-8c49-c13138d8dd4c.png">

# > year 1
<img width="1558" alt="screen shot 2016-03-04 at 10 33 34 am" src="https://cloud.githubusercontent.com/assets/424158/13531444/9ab39220-e1f4-11e5-9f95-b99ef99dc911.png">
