### PR TITLE
Bind loadouts to a single platform.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Infusion calculator performance enhancements
 * Larger lock icon
 * Completed segments of Intelligence, Discipline, and Strength are now colored orange.
-* New loadouts are now scoped to the platform they're created on, rather than applying across accounts.
+* When you save a loadout, it is now scoped to the platform it's created on, rather than applying across accounts. Loadouts created on one account used to show on both accounts, but wouldn't work on the wrong account.
 
 # 3.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Infusion calculator performance enhancements
 * Larger lock icon
 * Completed segments of Intelligence, Discipline, and Strength are now colored orange.
+* New loadouts are now scoped to the platform they're created on, rather than applying across accounts.
 
 # 3.3.2
 

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -3,9 +3,9 @@
 
   angular.module('dimApp').directive('dimLoadout', Loadout);
 
-  Loadout.$inject = ['dimLoadoutService'];
+  Loadout.$inject = ['dimLoadoutService', 'dimPlatformService'];
 
-  function Loadout(dimLoadoutService) {
+  function Loadout(dimLoadoutService, dimPlatformService) {
     return {
       controller: LoadoutCtrl,
       controllerAs: 'vm',
@@ -27,7 +27,7 @@
         '          <input name="name" ng-model="vm.loadout.name" minlength="1" maxlength="50" required type="search" placeholder="Loadout Name..." />',
         '          <select name="classType" ng-model="vm.loadout.classType" ng-options="item.value as item.label for item in vm.classTypeValues"></select>',
         '          <input type="button" ng-disabled="vm.form.$invalid" value="Save" ng-click="vm.save()"></input>',
-        '          <input type="button" ng-disabled="vm.form.$invalid" value="Save as New" ng-click="vm.saveAsNew()"></input>',
+        '          <input type="button" ng-disabled="vm.form.$invalid || !vm.loadout.id" value="Save as New" ng-click="vm.saveAsNew()"></input>',
         '          <input type="button" ng-click="vm.cancel()" value="Cancel"></input>',
         '          <span>Items with the <img src="images/spartan.png" style="border: 1px solid #333; background-color: #f00; margin: 0 2px; width: 16px; height: 16px;  vertical-align: text-bottom;"> icon will be equipped.  Click on an item toggle equip.</span>',
         '          <p id="loadout-error"></p>',
@@ -79,6 +79,8 @@
         dimLoadoutService.dialogOpen = true;
 
         vm.loadout = angular.copy(vm.defaults);
+        var platform = dimPlatformService.getActive();
+        vm.loadout.platform = platform.label; // Playstation or Xbox
       });
 
       scope.$on('dim-delete-loadout', function(event, args) {

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -78,8 +78,6 @@
         vm.show = true;
         dimLoadoutService.dialogOpen = true;
 
-        vm.loadout = angular.copy(vm.defaults);
-        var platform = dimPlatformService.getActive();
         vm.loadout.platform = platform.label; // Playstation or Xbox
       });
 
@@ -125,6 +123,8 @@
     vm.loadout = angular.copy(vm.defaults);
 
     vm.save = function save() {
+      var platform = dimPlatformService.getActive();
+      vm.loadout.platform = platform.label; // Playstation or Xbox
       dimLoadoutService.saveLoadout(vm.loadout);
       vm.cancel();
     };

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -4,16 +4,15 @@
   angular.module('dimApp')
     .factory('dimLoadoutService', LoadoutService);
 
-  LoadoutService.$inject = ['$q', '$rootScope', 'uuid2', 'dimItemService', 'dimStoreService', 'toaster', 'loadingTracker'];
+  LoadoutService.$inject = ['$q', '$rootScope', 'uuid2', 'dimItemService', 'dimStoreService', 'toaster', 'loadingTracker', 'dimPlatformService'];
 
-  function LoadoutService($q, $rootScope, uuid2, dimItemService, dimStoreService, toaster, loadingTracker) {
+  function LoadoutService($q, $rootScope, uuid2, dimItemService, dimStoreService, toaster, loadingTracker, dimPlatformService) {
     var _loadouts = [];
 
     return {
       dialogOpen: false,
       getLoadouts: getLoadouts,
       deleteLoadout: deleteLoadout,
-      saveLoadouts: saveLoadouts,
       saveLoadout: saveLoadout,
       addItemToLoadout: addItemToLoadout,
       applyLoadout: applyLoadout,
@@ -85,7 +84,13 @@
         result = $q.when(_loadouts);
       }
 
-      return result;
+      return result.then(function(loadouts) {
+        // Filter to current platform
+        var platform = dimPlatformService.getActive();
+        return _.filter(loadouts, function(loadout) {
+          return loadout.platform === undefined || loadout.platform === platform.label; // Playstation or Xbox
+        });
+      });
     }
 
     function saveLoadouts(loadouts) {
@@ -407,6 +412,7 @@
         name: loadout.name,
         classType: loadout.classType,
         version: 'v3.0',
+        platform: loadout.platform,
         items: []
       };
 


### PR DESCRIPTION
I don't actually have two accounts, so it's hard for me to test this, but it's pretty straightforward. This doesn't affect existing loadouts in order to reduce surprise, but it will apply the correct metadata for any new loadouts.

Fixes #435 and #413.