### PR TITLE
Clean up dimRateLimiter and tweak things so we can get maximum throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Moving and equipping items, especially many at a time (loadouts) is faster.
+
 # 3.3.3
 
 * Infusion calculator performance enhancements

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -128,8 +128,12 @@
       }
     ])
     .config(["rateLimiterConfigProvider", function(rateLimiterConfigProvider) {
-      rateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny\/TransferItem/, 1, 1250);
-      rateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny\/EquipItem/, 1, 1250);
+      // Bungie's API will start throttling an API if it's called more than once per second. It does this
+      // by making responses take 2s to return, not by sending an error code or throttling response. Choosing
+      // our throttling limit to be 1 request every 1100ms lets us achieve best throughput while accounting for
+      // what I assume is clock skew between Bungie's hosts when they calculate a global rate limit.
+      rateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny\/TransferItem/, 1, 1100);
+      rateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny\/EquipItem/, 1, 1100);
     }])
     .config(["$httpProvider", function($httpProvider) {
       $httpProvider.interceptors.push("rateLimiterInterceptor");

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -4,16 +4,14 @@
   angular.module('dimApp')
     .factory('dimBungieService', BungieService);
 
-  BungieService.$inject = ['$rootScope', '$q', '$timeout', '$http', 'dimState', 'rateLimiterQueue', 'toaster'];
+  BungieService.$inject = ['$rootScope', '$q', '$timeout', '$http', 'dimState', 'toaster'];
 
-  function BungieService($rootScope, $q, $timeout, $http, dimState, rateLimiterQueue, toaster) {
+  function BungieService($rootScope, $q, $timeout, $http, dimState, toaster) {
     var apiKey = '57c5ff5864634503a0340ffdfbeb20c0';
     var tokenPromise = null;
     var platformPromise = null;
     var membershipPromise = null;
     var charactersPromise = null;
-
-    //var transferRateLimit = dimRateLimit.rateLimit(transfer, 3000);
 
     $rootScope.$on('dim-active-platform-updated', function(event, args) {
       tokenPromise = null;

--- a/app/scripts/services/dimRateLimit.factory.js
+++ b/app/scripts/services/dimRateLimit.factory.js
@@ -2,104 +2,82 @@
   "use strict";
 
   angular.module("dimApp")
-    .factory("rateLimiterQueue", ["$interval", "$window", function rateLimiterQueue($interval, $window) {
+    .factory("rateLimiterQueue", ["$timeout", "$window", function rateLimiterQueue($timeout, $window) {
 
-    function RateLimiterQueue(pattern, requestLimit, timeLimit) {
-      this.pattern = pattern;
-      this.requestLimit = requestLimit;
-      this.timeLimit = timeLimit || 1000;
-      this.queue = [];
-      this.count = 0;
-      this.lastRequest = undefined;
-      this.currentRequest = undefined;
-      this.interval = undefined;
-    }
-
-    RateLimiterQueue.prototype.matches = function(url) {
-      return url.match(this.pattern);
-    };
-
-    RateLimiterQueue.prototype.add = function(config, deferred) {
-      this.queue.push({
-        config: config,
-        deferred: deferred
-      });
-    };
-
-    RateLimiterQueue.prototype.remove = function(index) {
-      this.queue.splice(index, 1);
-    };
-
-    RateLimiterQueue.prototype.startProcessing = function() {
-      if (!angular.isDefined(this.interval)) {
-        this.interval = $interval(this.processQueue.bind(this), this.timeLimit);
+      function RateLimiterQueue(pattern, requestLimit, timeLimit) {
+        this.pattern = pattern;
+        this.requestLimit = requestLimit;
+        this.timeLimit = timeLimit || 1000;
+        this.queue = [];
+        this.count = 0; // number of requests in the current period
+        this.lastRequestTime = $window.performance.now();
+        this.timer = undefined;
       }
-    };
 
-    RateLimiterQueue.prototype.stopProcessing = function() {
-      if (angular.isDefined(this.interval)) {
-        $interval.cancel(this.interval);
-        this.interval = undefined;
-      }
-    };
+      angular.extend(RateLimiterQueue.prototype, {
+        matches: function(url) {
+          return url.match(this.pattern);
+        },
 
-    RateLimiterQueue.prototype.processQueue = function() {
+        // Add a request to the queue, acting on it immediately if possible
+        add: function(config, deferred) {
+          this.queue.push({
+            config: config,
+            deferred: deferred
+          });
+          this.processQueue();
+        },
 
-      if (this.queue.length) {
+        // Schedule processing the queue at the next soonest time.
+        scheduleProcessing: function() {
+          if (!angular.isDefined(this.interval)) {
+            var nextTryIn = Math.max(0, this.timeLimit - ($window.performance.now() - this.lastRequestTime));
+            this.timer = $timeout(function() {
+              this.timer = undefined;
+              this.processQueue();
+            }.bind(this), nextTryIn);
+          }
+        },
 
-        for (var i = 0; i < this.requestLimit; i++) {
+        processQueue: function() {
+          do {
+            if (this.canProcess()) {
+              var request = this.queue.shift();
+              request.deferred.resolve(request.config);
+            } else {
+              this.scheduleProcessing();
+              return;
+            }
+          } while(this.queue.length);
+        },
 
-          var request = this.queue[i];
+        // Returns whether or not we can process a request right now. Mutates state.
+        canProcess: function() {
+          var currentRequestTime = $window.performance.now();
 
-          if (request) {
-            this.process(request, i);
+          var timeSinceLastRequest = currentRequestTime - this.lastRequestTime;
+          if (timeSinceLastRequest >= this.timeLimit) {
+            this.lastRequestTime = currentRequestTime;
+            this.count = 0;
           }
 
+          if (this.count < this.requestLimit) {
+            this.count++;
+            return true;
+          } else {
+            return false;
+          }
         }
+      });
 
-      } else {
-        this.stopProcessing();
+      function RateLimiterQueueFactory(pattern, requestLimit, timeLimit) {
+        return new RateLimiterQueue(pattern, requestLimit, timeLimit);
       }
 
-    };
-
-    RateLimiterQueue.prototype.process = function(request, index) {
-
-      var timeSinceLastRequest;
-
-      this.count++;
-      this.currentRequest = $window.performance.now();
-
-      if (!angular.isDefined(this.lastRequest)) {
-        this.lastRequest = this.currentRequest;
-      }
-
-      timeSinceLastRequest = this.currentRequest - this.lastRequest;
-
-      if (timeSinceLastRequest >= this.timeLimit) {
-        this.count = 0;
-      }
-
-      if (this.count < this.requestLimit) {
-        request.deferred.resolve(request.config);
-        this.lastRequest = this.currentRequest;
-        this.remove(index);
-      } else {
-        this.startProcessing();
-      }
-
-    };
-
-    function RateLimiterQueueFactory(pattern, requestLimit, timeLimit) {
-      return new RateLimiterQueue(pattern, requestLimit, timeLimit);
-    }
-
-    return RateLimiterQueueFactory;
-
+      return RateLimiterQueueFactory;
   }])
 
   .provider("rateLimiterConfig", function rateLimiterConfig() {
-
     var limiterConfig = [],
       limiters = [];
 
@@ -112,7 +90,6 @@
     };
 
     this.$get = ["rateLimiterQueue", function(rateLimiterQueue) {
-
       while (limiterConfig.length) {
         var config = limiterConfig.shift();
         limiters.push(rateLimiterQueue(config.pattern, config.requestLimit, config.timeLimit));
@@ -128,81 +105,22 @@
   })
 
   .factory("rateLimiterInterceptor", ["$q", "rateLimiterConfig", function rateLimiterInterceptor($q, rateLimiterConfig) {
-
     return {
-
       request: function(config) {
-
-        var deferred = $q.defer(),
-          queued = false;
-
-        angular.forEach(rateLimiterConfig.getLimiters(), function(limiter) {
-          if (limiter.matches(config.url)) {
-            limiter.add(config, deferred);
-            limiter.processQueue();
-            queued = true;
-          }
+        var limiter = _.find(rateLimiterConfig.getLimiters(), function(l) {
+          return l.matches(config.url);
         });
 
-        if (!queued) {
-          deferred.resolve(config);
+        if (limiter) {
+          var deferred = $q.defer();
+          limiter.add(config, deferred);
+          return deferred.promise;
+        } else {
+          return config;
         }
-
-        return deferred.promise;
-
       }
     };
 
   }]);
 
 })(angular);
-
-
-
-
-// (function(angular) {
-//   'use strict';
-//
-//   angular.module('dimApp').factory('dimRateLimit', RateLimit);
-//
-//   RateLimit.$inject = ['$q'];
-//
-//   function RateLimit($q) {
-//     var service = {
-//       'rateLimit': RateLimitFn
-//     };
-//
-//     return service;
-//
-//     function RateLimitFn(fn, delay, context) {
-//       var queue = [];
-//       var timer = null;
-//
-//       function processQueue() {
-//         var item = queue.shift();
-//
-//         if (item) {
-//           fn.apply(item.context, item.arguments);
-//         }
-//
-//         if (queue.length === 0) {
-//           clearInterval(timer);
-//           timer = null;
-//         }
-//       }
-//
-//       return function limited() {
-//         queue.push({
-//           context: context || this,
-//           arguments: [].slice.call(arguments)
-//         });
-//
-//         if (!timer) {
-//           processQueue(); // start immediately on the first invocation
-//           timer = setInterval(processQueue, delay);
-//         }
-//       };
-//     }
-//   }
-//
-// })(angular);


### PR DESCRIPTION
This fixes up the `dimRateLimiter` module so that we really achieve an API rate close to 1 request per second (which is the limit beyond which Bungie will start delaying our requests from their side). I've tested this by moving loadouts back and forth a bunch to arrive at the 1100ms limiting number, down from 1250 before. 

I also noticed that the rate limiter queue stuff had some bugs that forced it to wait too long before doing some requests - for example, the first request after DIM loads always waited 1250ms before running, and sometimes we waited twice the interval! I also fixed things up so if we ever wanted to use a different requestLimit (like 3 requests per second or something) that'll work correctly.

Fixing those speeds things up a bunch, and IMO makes the code easier to understand.