### PR TITLE
Store service cleanup

### DIFF
--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -241,66 +241,65 @@
       },
 
       transferItems: function() {
-        dimStoreService.getStore(vm.source.owner).then(function(store) {
-          var items = {};
-          vm.targets.forEach(function(item) {
-            var key = item.type.toLowerCase();
-            items[key] = items[key] || [];
-            if (items[key].length < 8) {
-              var itemCopy = angular.copy(item);
-              itemCopy.equipped = false;
-              items[key].push(itemCopy);
-            }
-          });
-          // Include the source, since we wouldn't want it to get moved out of the way
-          items[vm.source.type.toLowerCase()].push(vm.source);
-
-          items['material'] = [];
-          if (vm.sort === 'General') {
-            // Mote of Light
-            items['material'].push({
-              id: '0',
-              hash: 937555249,
-              amount: 2 * vm.targets.length,
-              equipped: false
-            });
-          } else if (vm.statType === 'Attack') {
-            // Weapon Parts
-            items['material'].push({
-              id: '0',
-              hash: 1898539128,
-              amount: 10 * vm.targets.length,
-              equipped: false
-            });
-          } else {
-            // Armor Materials
-            items['material'].push({
-              id: '0',
-              hash: 1542293174,
-              amount: 10 * vm.targets.length,
-              equipped: false
-            });
+        var store = dimStoreService.getStore(vm.source.owner);
+        var items = {};
+        vm.targets.forEach(function(item) {
+          var key = item.type.toLowerCase();
+          items[key] = items[key] || [];
+          if (items[key].length < 8) {
+            var itemCopy = angular.copy(item);
+            itemCopy.equipped = false;
+            items[key].push(itemCopy);
           }
-          if (vm.exotic) {
-            // Exotic shard
-            items['material'].push({
-              id: '0',
-              hash: 452597397,
-              amount: vm.targets.length,
-              equipped: false
-            });
-          }
+        });
+        // Include the source, since we wouldn't want it to get moved out of the way
+        items[vm.source.type.toLowerCase()].push(vm.source);
 
-          var loadout = {
-            classType: -1,
-            name: 'Infusion Materials',
-            items: items
-          };
-
-          vm.transferInProgress = true;
-          dimLoadoutService.applyLoadout(store, loadout).then(function() {
-            vm.transferInProgress = false;
+        items['material'] = [];
+        if (vm.sort === 'General') {
+          // Mote of Light
+          items['material'].push({
+            id: '0',
+            hash: 937555249,
+            amount: 2 * vm.targets.length,
+            equipped: false
           });
+        } else if (vm.statType === 'Attack') {
+          // Weapon Parts
+          items['material'].push({
+            id: '0',
+            hash: 1898539128,
+            amount: 10 * vm.targets.length,
+            equipped: false
+          });
+        } else {
+          // Armor Materials
+          items['material'].push({
+            id: '0',
+            hash: 1542293174,
+            amount: 10 * vm.targets.length,
+            equipped: false
+          });
+        }
+        if (vm.exotic) {
+          // Exotic shard
+          items['material'].push({
+            id: '0',
+            hash: 452597397,
+            amount: vm.targets.length,
+            equipped: false
+          });
+        }
+
+        var loadout = {
+          classType: -1,
+          name: 'Infusion Materials',
+          items: items
+        };
+
+        vm.transferInProgress = true;
+        return dimLoadoutService.applyLoadout(store, loadout).then(function() {
+          vm.transferInProgress = false;
         });
       }
     });

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -203,39 +203,37 @@
 
       // get Items for infusion
       getItems: function() {
-        dimStoreService.getStores(false, true).then(function(stores) {
+        var stores = dimStoreService.getStores();
+        var allItems = [];
 
-          var allItems = [];
+        // If we want ALL our weapons, including vault's one
+        if (!vm.getAllItems) {
+          stores = _.filter(stores, function(store) {
+            return store.id === vm.source.owner;
+          });
+        }
 
-          // If we want ALL our weapons, including vault's one
-          if (!vm.getAllItems) {
-            stores = _.filter(stores, function(store) {
-              return store.id === vm.source.owner;
-            });
-          }
-
-          // all stores
-          _.each(stores, function(store, id, list) {
-            // all items in store
-            var items = _.filter(store.items, function(item) {
-              return item.primStat &&
-                (!item.locked || vm.showLockedItems) &&
-                item.type == vm.source.type &&
-                item.primStat.value > vm.source.primStat.value &&
-                (!vm.onlyBlues || item.tier === 'Rare');
-            });
-
-            allItems = allItems.concat(items);
-
+        // all stores
+        _.each(stores, function(store, id, list) {
+          // all items in store
+          var items = _.filter(store.items, function(item) {
+            return item.primStat &&
+              (!item.locked || vm.showLockedItems) &&
+              item.type == vm.source.type &&
+              item.primStat.value > vm.source.primStat.value &&
+              (!vm.onlyBlues || item.tier === 'Rare');
           });
 
-          allItems = _.sortBy(allItems, function(item) {
-            return item.primStat.value + ((item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5);
-          });
+          allItems = allItems.concat(items);
 
-          vm.setInfusibleItems(allItems);
-          vm.maximizeAttack();
         });
+
+        allItems = _.sortBy(allItems, function(item) {
+          return item.primStat.value + ((item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5);
+        });
+
+        vm.setInfusibleItems(allItems);
+        vm.maximizeAttack();
       },
 
       closeDialog: function() {

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -88,30 +88,23 @@
       if (vm.locking) {
         return;
       }
-      var storeId = item.owner;
-      var storePromise;
 
-      if (storeId === 'vault') {
-        storePromise = $q.when(storeService.getStores())
-          .then(function(stores) {
-            return stores[0];
-          });
+      var store;
+      if (item.owner === 'vault') {
+        store = storeService.getStores()[0];
       } else {
-        storePromise = storeService.getStore(item.owner);
+        store = storeService.getStore(item.owner);
       }
 
       vm.locking = true;
 
-      storePromise
-        .then(function(store) {
-          return itemService.setLockState(item, store, !item.locked)
-            .then(function(lockState) {
-              item.locked = lockState;
-              $rootScope.$broadcast('dim-filter-invalidate');
-            })
-            .finally(function() {
-              vm.locking = false;
-            });
+      itemService.setLockState(item, store, !item.locked)
+        .then(function(lockState) {
+          item.locked = lockState;
+          $rootScope.$broadcast('dim-filter-invalidate');
+        })
+        .finally(function() {
+          vm.locking = false;
         });
     };
 

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -247,10 +247,7 @@
       return promise;
     };
 
-    dimStoreService.getStores(false, true)
-      .then(function(stores) {
-        vm.stores = stores;
-      });
+    vm.stores = dimStoreService.getStores();
 
     vm.canShowItem = function canShowItem(item, itemStore, buttonStore) {
       var result = false;

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -119,7 +119,7 @@
 
       promise = promise
         .then(function() {
-          setTimeout(function() { dimStoreService.setHeights(); }, 0);
+          dimStoreService.setHeights();
         })
         .catch(function(a) {
           toaster.pop('error', vm.item.name, a.message);
@@ -155,7 +155,7 @@
       }
 
       promise = promise.then(function() {
-        setTimeout(function() { dimStoreService.setHeights(); }, 0);
+        dimStoreService.setHeights();
         toaster.pop('success', 'Consolidated ' + vm.item.name, 'All ' + vm.item.name + ' is now on your ' + vm.store.race + " " + vm.store.class + ".");
       })
       .catch(function(a) {
@@ -231,7 +231,7 @@
             });
 
       promise = promise.then(function() {
-        setTimeout(function() { dimStoreService.setHeights(); }, 0);
+        dimStoreService.setHeights();
         toaster.pop('success', 'Distributed ' + vm.item.name, vm.item.name + ' is now equally divided between characters.');
       })
       .catch(function(a) {

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -62,13 +62,9 @@
     // TODO: cache this, instead?
     $scope.$watch('vm.item', function() {
       if (vm.item.amount > 1) {
-        // TODO: sum up all the quantity of the item
-        vm.moveAmount = vm.item.amount;
-        dimStoreService.getStore(vm.item.owner)
-          .then(function(store) {
-            vm.maximum = store.amountOfItem(vm.item);
-            vm.moveAmount = vm.maximum;
-          });
+        var store = dimStoreService.getStore(vm.item.owner);
+        vm.maximum = store.amountOfItem(vm.item);
+        vm.moveAmount = vm.maximum;
       }
     });
 

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -111,15 +111,14 @@
      * Move the item to the specified store. Equip it if equip is true.
      */
     vm.moveItemTo = function moveItemTo(store, equip) {
-      var dimStores;
       var reload = vm.item.equipped || equip;
       var promise = dimItemService.moveTo(vm.item, store, equip, vm.moveAmount);
 
       if (reload) {
-        promise = promise.then(dimStoreService.getStores)
-          .then(function(stores) {
-            dimStores = dimStoreService.updateStores(stores);
-          });
+        // Refresh light levels and such
+        promise = promise.then(function() {
+          return dimStoreService.updateCharacters();
+        });
       }
 
       promise = promise

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -364,39 +364,7 @@
           }
         }
 
-        var typeQtyCap = 10;
-
-        //TODO Hardcoded Item Quantity
-        if (store.id === 'vault') {
-          switch (item.sort) {
-            case 'Weapons':
-            case 'Weapon':
-            case 'Armor':
-              {
-                typeQtyCap = 72;
-                break;
-              }
-            default:
-              {
-                typeQtyCap = 36;
-                break;
-              }
-          }
-        } else {
-          switch (item.type) {
-            case 'Material':
-            case 'Consumable':
-              {
-                typeQtyCap = 20;
-                break;
-              }
-            default:
-              {
-                typeQtyCap = 10;
-                break;
-              }
-          }
-        }
+        var typeQtyCap = store.capacityForItem(item);
 
         if ((itemsInStore + slotsNeededForTransfer) <= typeQtyCap) {
           if ((item.owner !== store.id) && (store.id !== 'vault') && (item.owner !== 'vault')) {

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -430,7 +430,7 @@
           // Not enough space!
           if (!triedFallback) {
             // Refresh the store
-            return $q.when(dimStoreService.getStores(true, false))
+            return dimStoreService.reloadStores()
               .then(function(stores) {
                 store = _.find(stores, { id: store.id });
                 return canMoveToStore(item, store, true);

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -243,7 +243,7 @@
     function applyLoadoutItems(store, items, loadout, existingItems, scope) {
       if (items.length == 0) {
         // We're done!
-        return dimStoreService.updateStores(dimStoreService.getStores())
+        return dimStoreService.updateCharacters()
           .then(function() {
             var value = 'success';
             var message = 'Your loadout has been transfered.';

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -306,7 +306,7 @@
           var size = _.where(store.items, { type: item.type }).length;
 
           // If full, make room. TODO: put this in the move service!
-          if (size === 10) {
+          if (size >= store.capacityForItem(item)) {
             if (item.owner !== store.id) {
               var moveAwayItem = existingItems[item.type].shift();
               var sortedStores = _.sortBy(dimStoreService.getStores(), function(s) {
@@ -322,7 +322,11 @@
               // Get the first store with space
               // TODO: handle consumable capacity
               var target = _.find(sortedStores, function(s) {
-                var capacity = (s.id === 'vault' ? 71 : 10);
+                var capacity = s.capacityForItem(item);
+                if (s.id === 'vault') {
+                  // leave space for one item so we can still do guardian-guardian transfers
+                  capacity -= 1;
+                }
                 return _.where(s.items, { type: item.type }).length < capacity;
               });
               if (!target) {

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -83,6 +83,7 @@
             // Found default
             settings[key] = settingState[key];
             saveSetting(key, settingState[key]);
+            return _.propertyOf(settings)(key);
           } else {
             return $q.reject("The key is not defined in the settings.");
           }

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -31,7 +31,7 @@
       getStore: getStore,
       getVault: getStore.bind(null, 'vault'),
       updateCharacters: updateCharacters,
-      setHeights: setHeights,
+      setHeights: setHeightsAsync,
       createItemIndex: createItemIndex
     };
 
@@ -68,6 +68,10 @@
 
     function getNextIndex() {
       return _index++;
+    }
+
+    function setHeightsAsync() {
+      setTimeout(setHeights, 0);
     }
 
     // Equalize the heights of the various rows of items.
@@ -260,6 +264,7 @@
           $rootScope.$broadcast('dim-stores-updated', {
             stores: stores
           });
+          setHeightsAsync();
 
           return stores;
         });

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -28,20 +28,21 @@
     var service = {
       getStores: getStores,
       getStore: getStore,
-      updateStores: updateStores,
+      updateCharacters: updateCharacters,
       setHeights: setHeights,
       createItemIndex: createItemIndex
     };
 
     return service;
 
-    function updateStores(dimStores) {
+    // Update the high level character information for all the stores
+    // (level, light, int/dis/str, etc.). This does not update the
+    // items in the stores - to do that, call getStores(true).
+    function updateCharacters() {
       return dimBungieService.getCharacters(dimPlatformService.getActive()).then(function(bungieStores) {
-        _.each(dimStores, function(dStore) {
+        _.each(_stores, function(dStore) {
           if (dStore.id !== 'vault') {
-            var bStore = _.find(bungieStores, function(bStore) {
-              return dStore.id === bStore.id;
-            });
+            var bStore = _.findWhere(bungieStores, { id: dStore.id });
 
             dStore.level = bStore.base.characterLevel;
             dStore.percentToNextLevel = bStore.base.percentToNextLevel;
@@ -51,7 +52,7 @@
             dStore.stats = getStatsData(bStore.base.characterBase);
           }
         });
-        return dimStores;
+        return _stores;
       });
     }
 
@@ -59,6 +60,8 @@
       return _index++;
     }
 
+    // Equalize the heights of the various rows of items.
+    // TODO: replace with flexbox
     function setHeights() {
       function outerHeight(el) {
         //var height = el.offsetHeight;
@@ -138,6 +141,10 @@
       setHeight('.general');
     }
 
+    // Without arguments, this returns the list of stores.  With
+    // arguments, it may refresh from Bungie (getFromBungie) and/or
+    // sort the stores based on the user's preference, but in both
+    // cases it will return a promise for the list of stores.
     function getStores(getFromBungie, withOrder) {
       if (!getFromBungie && !!withOrder) {
         return settings.getSetting('characterOrder')

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -22,6 +22,10 @@
       // Get the total amount of this item in the store, across all stacks.
       amountOfItem: function(item) {
         return sum(_.where(this.items, { hash: item.hash }), 'amount');
+      },
+      // How much of items like this item can fit in this store?
+      capacityForItem: function(item) {
+        return (item.type == 'Material' || item.type == 'Consumable') ? 20 : 10;
       }
     };
 
@@ -188,7 +192,11 @@
                 items: [],
                 legendaryMarks: marks,
                 glimmer: glimmer,
-                bucketCounts: {}
+                bucketCounts: {},
+                // Vault has different capacity rules
+                capacityForItem: function(item) {
+                  return (item.sort == 'Weapons' || item.sort == 'Armor') ? 72 : 36;
+                }
               });
 
               _.each(raw.data.buckets, function(bucket) {

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -29,6 +29,7 @@
       getStores: getStores,
       reloadStores: reloadStores,
       getStore: getStore,
+      getVault: getStore.bind(null, 'vault'),
       updateCharacters: updateCharacters,
       setHeights: setHeights,
       createItemIndex: createItemIndex
@@ -265,11 +266,7 @@
     }
 
     function getStore(id) {
-      var store = _.find(_stores, function(store) {
-        return store.id === id;
-      });
-
-      return $q.when(store);
+      return _.find(_stores, { id: id });
     }
 
     var idTracker = {};

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -71,9 +71,9 @@
     });
   }
 
-  SearchFilterCtrl.$inject = ['$scope', 'dimStoreService', '$timeout', '$interval'];
+  SearchFilterCtrl.$inject = ['$scope', 'dimStoreService', '$interval', 'dimSettingsService'];
 
-  function SearchFilterCtrl($scope, dimStoreService, $timeout, $interval) {
+  function SearchFilterCtrl($scope, dimStoreService, $interval, dimSettingsService) {
     var vm = this;
     var filterInputSelector = '#filter-input';
     var _duplicates = null; // Holds a map from item hash to count of occurrances of that hash
@@ -172,7 +172,11 @@
         });
       });
 
-      $timeout(dimStoreService.setHeights, 32);
+      dimSettingsService.getSetting('hideFilteredItems').then(function(hideFilteredItems) {
+        if (hideFilteredItems) {
+          dimStoreService.setHeights();
+        }
+      });
     };
 
     // Cache for searches against filterTrans. Somewhat noticebly speeds up the lookup on my older Mac, YMMV. Helps

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -367,7 +367,7 @@
           });
         }
         return movePromise.then(function() {
-          setTimeout(function() { dimStoreService.setHeights(); }, 0);
+          dimStoreService.setHeights();
         });
       }).catch(function(e) {
         if (e.message !== 'move-canceled') {
@@ -400,7 +400,7 @@
         vm.itemSort = settings.itemSort;
       }
       if (_.has(settings, 'charCol') || _.has(settings, 'vaultCol')) {
-        setTimeout(function() { dimStoreService.setHeights(); }, 0);
+        dimStoreService.setHeights();
       }
     });
 

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -372,7 +372,6 @@
         } else {
           getStore = dimStoreService.getStore(item.owner);
         }
-        var dimStores = null;
 
         var movePromise = getStore.then(function() {
           return dimItemService.moveTo(item, target, equip, moveAmount);
@@ -380,11 +379,9 @@
 
         var reload = item.equipped || equip;
         if (reload) {
-          movePromise = movePromise
-            .then(dimStoreService.getStores)
-            .then(function(stores) {
-              dimStores = dimStoreService.updateStores(stores);
-            });
+          movePromise = movePromise.then(function() {
+            return dimStoreService.updateCharacters();
+          });
         }
         return movePromise.then(function() {
           setTimeout(function() { dimStoreService.setHeights(); }, 0);
@@ -394,7 +391,6 @@
           toaster.pop('error', item.name, e.message);
         }
       });
-;
 
       loadingTracker.addPromise(promise);
 

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -331,20 +331,12 @@
             '  </div>',
             '</div>'].join(''),
           scope: $scope,
-          resolve: {
-            maximum: function() {
-              return dimStoreService.getStore(item.owner)
-                .then(function(store) {
-                  return store.amountOfItem(item);
-                });
-            }
-          },
           controllerAs: 'vm',
-          controller: ['$scope', 'maximum', function($scope, maximum) {
+          controller: ['$scope', function($scope) {
             var vm = this;
             vm.item = $scope.ngDialogData;
             vm.moveAmount = vm.item.amount;
-            vm.maximum = maximum;
+            vm.maximum = dimStoreService.getStore(vm.item.owner).amountOfItem(item);
             vm.finish = function() {
               $scope.closeThisDialog(vm.moveAmount);
             };
@@ -366,16 +358,7 @@
       }
 
       promise.then(function(moveAmount) {
-        var getStore;
-        if (item.owner === vm.store.id) {
-          getStore = $q.when(vm.store);
-        } else {
-          getStore = dimStoreService.getStore(item.owner);
-        }
-
-        var movePromise = getStore.then(function() {
-          return dimItemService.moveTo(item, target, equip, moveAmount);
-        });
+        var movePromise = dimItemService.moveTo(item, target, equip, moveAmount);
 
         var reload = item.equipped || equip;
         if (reload) {

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -57,7 +57,7 @@
         '    <div ng-repeat="key in ::vm.keys track by key" ng-init="value = vm.categories[key]" class="section" ng-class="::key.toLowerCase()">',
         '      <div class="title">',
         '        <span>{{ ::key }}</span>',
-        '        <span class="bucket-count" ng-if="::vm.store.id === \'vault\'">{{ vm.sortSize[key] ? vm.sortSize[key] : 0 }}/{{:: (key === \'Weapons\' || key === \'Armor\') ? 72 : 36 }}  </span>',
+        '        <span class="bucket-count" ng-if="::vm.store.id === \'vault\'">{{ vm.sortSize[key] ? vm.sortSize[key] : 0 }}/{{::vm.store.capacityForItem({sort:key})}}  </span>',
         '      </div>',
         '      <div ng-repeat="type in ::value track by type" class="sub-section"',
         '           ng-class="[\'sort-\' + type.replace(\' \', \'-\').toLowerCase(), { empty: !vm.data[vm.orderedTypes[type]] }]"',

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -62,13 +62,12 @@
     });
 
     if ($scope.$root.activePlatformUpdated) {
-      loadingTracker.addPromise($q.when(dimStoreService.getStores(true)));
+      loadingTracker.addPromise(dimStoreService.reloadStores());
       $scope.$root.activePlatformUpdated = false;
     }
 
     $scope.$on('dim-active-platform-updated', function(e, args) {
-      var promise = $q.when(dimStoreService.getStores(true));
-      loadingTracker.addPromise(promise);
+      loadingTracker.addPromise(dimStoreService.reloadStores());
     });
   }
 })();


### PR DESCRIPTION
This is a bunch of cleanup work I had noted down while working on the stack transfer stuff. None of it's a big deal, but the aim is to simplify the code and make it easier to develop new features. The major changes involve separating `getStores` into different methods, and making `getStore` not return a promise since it didn't need to.