### PR TITLE
Move aside, coming through!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Next
+
+* DIM will now go to great lengths to make sure your transfer will succeed, even if your target's inventory is full, or the vault is full. It does this by moving stuff aside to make space, automatically.
+* Fixed a bug that would cause applying loadouts to fill up the vault and then fail.
+
 # 3.4.1
 
 * Bugfix to address an infinite loop while moving emotes.

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -187,61 +187,41 @@
     }
 
     function applyLoadout(store, loadout) {
-      var scope = {
-        failed: false
-      };
-
       var items = _.flatten(_.values(loadout.items));
 
       var _types = _.uniq(_.pluck(items, 'type'));
 
-      // Existing items on the character, minus ones that we want as part of the loadout
-      var existingItems = _.chain(store.items)
-        .filter(function(item) {
-          return !item.notransfer && _.contains(_types, item.type) &&
-            (!_.any(items, function(i) {
-              return i.id === item.id && i.hash === item.hash;
-            }));
-        })
-        .groupBy('type')
-        .mapObject(function(items) {
-          // The order of items determines which ones get moved away to make space
-          // TODO: move all this into a "moveAsideItem" function in itemService
-          return _.sortBy(items, function(item) {
-            // Lower means more likely to get moved away
-            // Prefer not moving the equipped item
-            var value = item.equipped ? 10 : 0;
-            // Prefer moving lower-tier
-            value += {
-              Common: 0,
-              Uncommon: 1,
-              Rare: 2,
-              Legendary: 3,
-              Exotic: 4
-            }[item.tier];
-            if (item.primStat) {
-              value += item.primStat.value / 1000.0;
-            }
-            return value;
-          });
-        })
-        .value();
+      var loadoutItemIds = items.map(function(i) {
+        return {
+          id: i.id,
+          hash: i.hash
+        };
+      });
 
-      return applyLoadoutItems(store, items, loadout, existingItems, scope);
+      var scope = {
+        failed: 0,
+        total: items.length
+      };
+      return applyLoadoutItems(store, items, loadout, loadoutItemIds, scope);
     }
 
     // Move one loadout item at a time. Called recursively to move items!
-    function applyLoadoutItems(store, items, loadout, existingItems, scope) {
+    function applyLoadoutItems(store, items, loadout, loadoutItemIds, scope) {
       if (items.length == 0) {
         // We're done!
         return dimStoreService.updateCharacters()
           .then(function() {
             var value = 'success';
-            var message = 'Your loadout has been transfered.';
+            var message = 'Your loadout of ' + scope.total + ' items has been transfered.';
 
-            if (scope.failed) {
-              value = 'warning';
-              message = 'Your loadout has been transfered, with errors.';
+            if (scope.failed > 0) {
+              if (scope.failed === scope.total) {
+                value = 'error';
+                message = 'None of the items in your loadout could be transferred.';
+              } else {
+                value = 'warning';
+                message = 'Your loadout has been partially transferred, but ' + scope.failed + ' of ' + scope.total + ' items had errors.';
+              }
             }
 
             toaster.pop(value, loadout.name, message);
@@ -296,35 +276,11 @@
         if (item) {
           var size = _.where(store.items, { type: item.type }).length;
 
-          // If full, make room. TODO: put this in the move service!
+          // If full, make room.
           if (size >= store.capacityForItem(item)) {
             if (item.owner !== store.id) {
-              var moveAwayItem = existingItems[item.type].shift();
-              var sortedStores = _.sortBy(dimStoreService.getStores(), function(s) {
-                if (s.isVault) {
-                  return 0;
-                } else if (s.id !== store.id) {
-                  return 1;
-                } else {
-                  // Same store... shouldn't ever work
-                  return 2;
-                }
-              });
-              // Get the first store with space
-              // TODO: handle consumable capacity
-              var target = _.find(sortedStores, function(s) {
-                if (s.isVault) {
-                  // leave space for one item so we can still do guardian-guardian transfers
-                  return s.spaceLeftForItem(moveAwayItem) > 1;
-                } else {
-                  return s.spaceLeftForItem(moveAwayItem) > 0;
-                }
-              });
-              if (!target) {
-                promise = $q.reject(new Error("Collector, eh?  All your characters' " + moveAwayItem.type.toLowerCase() + ' slots are full and I can\'t move items off characters, yet... Clear a slot on a character and I can complete the loadout.'));
-              } else {
-                promise = dimItemService.moveTo(moveAwayItem, target);
-              }
+              // Pass in the list of items that shouldn't be moved away
+              promise = dimItemService.makeRoomForItem(item, store, loadoutItemIds);
             }
           }
 
@@ -338,12 +294,12 @@
 
       promise = promise
         .catch(function(e) {
-          scope.failed = true;
+          scope.failed++;
           toaster.pop('error', item.name, e.message);
         })
         .finally(function() {
           // Keep going
-          return applyLoadoutItems(store, items, loadout, existingItems, scope);
+          return applyLoadoutItems(store, items, loadout, loadoutItemIds, scope);
         });
 
       loadingTracker.addPromise(promise);


### PR DESCRIPTION
![full-transfers](https://cloud.githubusercontent.com/assets/313208/13727260/a97401b6-e8a0-11e5-8013-621470befacf.gif)

We've always had some functionality in the loadouts code to move stuff out of the way so a loadout could succeed. This PR generalizes that, and applies it to all moves - so it'll really try its hardest to make a move happen, it just may need to move some other stuff around to do it.

In the GIF above, you can see that all my characters have full primary inventory, and my weapons vault is also full. Yet I'm still able to drag one primary weapon to another character, and have it transfer correctly. See how it moves secondary weapons onto other characters in order to make space in the vault for the transfer, as well as moving an item away from the target character. This works in concert with my earlier change to refresh the stores to see if I've already trashed some weapons - it tries that before moving items aside, but limits how often it'll try to refresh.

I've also stress-tested this by making a loadout with 10 primaries in it, then filling up all the primary inventory and the vault, then applying the loadout. It worked!

One point that I'm not as sure about is the value function I'm using to choose items to move aside. The code prefers to move low-value stuff into the vault, and high-value stuff out of the vault. Value is defined as rarity, then primary stat, with a strong emphasis placed on not moving the currently-equipped item. However, you can see that in the GIF, this ends up moving some Year 1 exotics onto characters because they're the best. Maybe I should specifically boost year 2 stuff's value over year 1?
