### PR TITLE
Break out image fallback into a directive

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -92,6 +92,7 @@
     <script src="scripts/shell/dimPlatformChoice.directive.js?v=3.4.1"></script>
     <script src="scripts/shell/dimSearchFilter.directive.js?v=3.4.1"></script>
     <script src="scripts/shell/dimClickAnywhereButHere.directive.js?v=3.4.1"></script>
+    <script src="scripts/store/dimBungieImageFallback.directive.js?v=3.4.1"></script>
     <script src="scripts/store/dimStores.directive.js?v=3.4.1"></script>
     <script src="scripts/store/dimStoreItems.directive.js?v=3.4.1"></script>
     <script src="scripts/store/dimStoreItem.directive.js?v=3.4.1"></script>

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -49,6 +49,7 @@
                                                        'Unknown'; // new item?
         vm.wildcardMaterialIcon = item.sort === 'General' ? '2e026fc67d445e5b2630277aa794b4b1' :
           vm.statType === 'Attack' ? 'f2572a4949fb16df87ba9760f713dac3' : '972ae2c6ccbf59cde293a2ed50a57a93';
+        vm.wildcardMaterialIcon = '/common/destiny_content/icons/' + vm.wildcardMaterialIcon + '.jpg';
         // 2 motes, or 10 armor/weapon materials
         vm.wildcardMaterialCost = item.sort === 'General' ? 2 : 10;
       },

--- a/app/scripts/infuse/dimInfuseItem.directive.js
+++ b/app/scripts/infuse/dimInfuseItem.directive.js
@@ -15,7 +15,7 @@
       template: [
         '<div title="{{ vm.item.primStat.value }} {{ vm.item.name }}" alt="{{ vm.item.primStat.value }} {{ vm.item.name }}" class="item">',
         '  <div class="item-elem" ng-class="{ \'complete\': vm.item.complete }">',
-        '    <div class="img"></div>',
+        '    <div class="img" dim-bungie-image-fallback="::vm.item.icon"></div>',
         '    <div class="damage-type" ng-if="!vm.item.itemStat && vm.item.sort === \'Weapons\'" ng-class="\'damage-\' + vm.item.dmg"></div>',
         '    <div class="item-stat" ng-if="vm.item.primStat.value" ng-class="\'stat-damage-\' + vm.item.dmg">{{ vm.item.primStat.value }}</div>',
         '  </div>',
@@ -23,24 +23,9 @@
       ].join(''),
       bindToController: true,
       controllerAs: 'vm',
-      controller: dimItemInfuseCtrl,
-      link: function (scope, element, attrs) {
-        var vm = scope.vm;
-        $('<img/>').attr('src', 'http://www.bungie.net' + vm.item.icon).load(function() {
-           $(this).remove();
-          element[0].querySelector('.img')
-            .style.backgroundImage = 'url(' + 'http://www.bungie.net' + vm.item.icon + ')';
-        }).error(function() {
-           $(this).remove();
-          element[0].querySelector('.img')
-            .style.backgroundImage = 'url(' + chrome.extension.getURL(vm.item.icon) + ')';
-        });
-      }
+      controller: dimItemInfuseCtrl
     };
   }
-
-  angular.module('dimApp')
-    .controller('dimItemInfuseCtrl', dimItemInfuseCtrl);
 
   dimItemInfuseCtrl.$inject = [];
 

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -36,7 +36,7 @@
         '      <div ng-repeat="value in vm.types track by value" class="loadout-{{ value }} loadout-bucket" ng-if="vm.loadout.items[value].length">',
         '        <div ng-repeat="item in vm.loadout.items[value] | sortItems:vm.itemSort track by item.index" ng-click="vm.equip(item)" id="loadout-item-{{:: $id }}" class="item" ng-class="{ \'complete\': item.complete}">',
         '          <div class="item-elem">',
-        '            <img ng-src="{{ item.icon }}" title="{{ item.primStat.value }} {{ item.name }}">',
+        '            <img dim-bungie-image-fallback="::item.icon" title="{{ item.primStat.value }} {{ item.name }}">',
         '            <div class="item-stat" ng-if="item.amount > 1">{{ item.amount }}</div>',
         '            <div class="close" ng-click="vm.remove(item, $event); vm.form.name.$rollbackViewValue(); $event.stopPropagation();"></div>',
         '            <div class="equipped" ng-show="item.equipped"></div>',

--- a/app/scripts/store/dimBungieImageFallback.directive.js
+++ b/app/scripts/store/dimBungieImageFallback.directive.js
@@ -1,0 +1,46 @@
+(function() {
+  'use strict';
+
+  // A directive to either set src (for images) or background-image (everything else)
+  // to a path on bungie.net, or if unavailable, to a path in our extension.
+  angular.module('dimApp')
+    .directive('dimBungieImageFallback', ImageFallback);
+
+  ImageFallback.$inject = ['$q'];
+
+  function ImageFallback($q) {
+    // Return an always-successful promise to either the bungie-hosted image
+    // or the local (slower) extension hosted image. Memoized so once we know
+    // we don't try again.
+    var loadImage = _.memoize(function(path) {
+      return $q(function(resolve, reject) {
+        $('<img/>').attr('src', 'http://www.bungie.net' + path).load(function() {
+          $(this).remove();
+          resolve('http://www.bungie.net' + path);
+        }).error(function() {
+          $(this).remove();
+          resolve(chrome.extension.getURL(path));
+        });
+      });
+    });
+
+    return {
+      bind: 'A',
+      link: function (scope, element, attrs) {
+        var elem = element[0];
+
+        scope.$watch(attrs.dimBungieImageFallback, function(path) {
+          if (path && path.length) {
+            loadImage(path).then(function(url) {
+              if (elem.nodeName === 'IMG') {
+                elem.src = url;
+              } else {
+                elem.style.backgroundImage = 'url(' + url + ')';
+              }
+            });
+          }
+        });
+      }
+    };
+  }
+})();

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -28,7 +28,7 @@
         "    'search-hidden': !vm.item.visible,",
         "    'complete': vm.item.complete",
         '  }">',
-        '    <div class="img" ng-click="vm.clicked(vm.item, $event)">',
+        '    <div class="img" dim-bungie-image-fallback="::vm.item.icon" ng-click="vm.clicked(vm.item, $event)">',
         '    <div ng-class="vm.badgeClassNames" ng-if="vm.showBadge">{{ vm.badgeCount }}</div>',
         '  </div>',
         '</div>'
@@ -38,16 +38,6 @@
     function Link(scope, element, attrs) {
       var vm = scope.vm;
       var dialogResult = null;
-
-      $('<img/>').attr('src', 'http://www.bungie.net' + vm.item.icon).load(function() {
-        $(this).remove();
-        element[0].querySelector('.img')
-          .style.backgroundImage = 'url(' + 'http://www.bungie.net' + vm.item.icon + ')';
-      }).error(function() {
-        $(this).remove();
-        element[0].querySelector('.img')
-          .style.backgroundImage = 'url(' + chrome.extension.getURL(vm.item.icon) + ')';
-      });
 
       var dragHelp = document.getElementById('drag-help');
 

--- a/app/views/infuse.html
+++ b/app/views/infuse.html
@@ -54,7 +54,7 @@
         <span>using {{infuse.targets.length*3}} <span class="legendaryMarks"><img alt="Legendary Marks" title="Legendary Marks" src="/images/legendaryMarks.png"></span></span>
         <span ng-if="infuse.exotic">+ {{infuse.targets.length}} <span class="legendaryMarks"><img alt="Exotic Shards" title="Exotic Shards" src="http://www.bungie.net/common/destiny_content/icons/e6d2a0561e784ae224e2aa53aa66e8a7.jpg"></span></span>
         <span>+ {{infuse.targets.length*250 | number}} <span class="glimmer"><img alt="Glimmer" title="Glimmer" src="/images/glimmer.png"></span></span>
-        <span>+ {{infuse.targets.length*infuse.wildcardMaterialCost | number}} <span class="glimmer"><img alt="Materials" title="Materials" ng-src="http://www.bungie.net/common/destiny_content/icons/{{infuse.wildcardMaterialIcon}}.jpg"></span></span>
+        <span>+ {{infuse.targets.length*infuse.wildcardMaterialCost | number}} <span class="glimmer"><img alt="Materials" title="Materials"  dim-bungie-image-fallback="infuse.wildcardMaterialIcon"></span></span>
 
       </div>
       <button ng-if="infuse.getAllItems" ng-disabled="infuse.transferInProgress" ng-click="infuse.transferItems()">Transfer items</button>


### PR DESCRIPTION
This is the copy/pasted code to try to load an image from bungie.net, and fall back to the local copy (which is inexplicably slower). While I was at it, I memoized the result to make it more efficient (we'll only ever do the dance once per image), and I applied it to more areas (loadout editor and infusion materials).