### PR TITLE
Upgrade to Angular 1.5

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -69,7 +69,6 @@
 
     <script src="scripts/ScrollToFixed.js?v=3.4.1"></script>
     <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=3.4.1"></script>
-    <script src="vendor/angular-cookies/angular-cookies.js?v=3.4.1"></script>
     <script src="vendor/angular-hotkeys/build/hotkeys.js?v=3.4.1"></script>
 
     <!-- begin app scripts -->

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -52,8 +52,8 @@
 
 
   angular.module('dimApp')
-    .run(['$rootScope', 'loadingTracker', '$cookies', '$timeout', 'toaster',
-      function($rootScope, loadingTracker, $cookies, $timeout, toaster) {
+    .run(['$rootScope', 'loadingTracker', '$timeout', 'toaster',
+      function($rootScope, loadingTracker, $timeout, toaster) {
         $rootScope.loadingTracker = loadingTracker;
 
         //1 Hour

--- a/app/scripts/dimApp.module.js
+++ b/app/scripts/dimApp.module.js
@@ -5,7 +5,6 @@
     'ui.router',
     'ngAnimate',
     'ngAria',
-    'ngCookies',
     'ngDialog',
     'ngMessages',
     'ang-drag-drop',

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "angular": "~1.5.3",
     "angular-animate": "1.5.x",
     "angular-chrome-storage": "infomofo/angular-chrome-storage",
-    "angular-cookies": "~1.4.5",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#~1.4.5",
     "angular-messages": "~1.3.x",
     "angular-native-dragdrop": "https://github.com/angular-dragdrop/angular-dragdrop.git",

--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,8 @@
     "Angular.uuid2": "https://github.com/MBehtemam/angular-uuid.git",
     "AngularJS-Toaster": "https://github.com/DestinyItemManager/AngularJS-Toaster.git#master",
     "ScrollToFixed": "https://github.com/bigspotteddog/ScrollToFixed.git#~1.0.6",
-    "angular": "1.4.x",
-    "angular-animate": "1.4.x",
+    "angular": "~1.5.3",
+    "angular-animate": "1.5.x",
     "angular-chrome-storage": "infomofo/angular-chrome-storage",
     "angular-cookies": "~1.4.5",
     "angular-hotkeys": "chieffancypants/angular-hotkeys#~1.4.5",
@@ -30,6 +30,6 @@
     "jquery-textcomplete": "~1.3.2"
   },
   "resolutions": {
-    "angular": "1.4.x"
+    "angular": "~1.5.3"
   }
 }


### PR DESCRIPTION
Nothing much new - we get some perf improvements, `component` style directives, and the ability to declare one-direction bindings in directive scopes. I also dropped our dependency on `$cookie` that we weren't using.

Note that you'll have to run `bower install` after pulling this change.