### PR TITLE
Use equipItems to apply loadouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * DIM will now go to great lengths to make sure your transfer will succeed, even if your target's inventory is full, or the vault is full. It does this by moving stuff aside to make space, automatically.
 * Fixed a bug that would cause applying loadouts to fill up the vault and then fail.
 * Fixed a bug where DIM would refuse to equip an exotic when dequipping something else, even if the exotic was OK to equip.
+* When applying a loadout, DIM will now equip and dequip loadout items all at once, in order to speed up applying the loadout.
 
 # 3.4.1
 

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -544,8 +544,10 @@
         .then(networkError)
         .then(throttleCheck)
         .then(function(response) {
+          var data = response.data.Response;
+          store.updateCharacterInfo(data.summary);
           return _.select(items, function(i) {
-            var item = _.find(response.data.Response.equipResults, {itemInstanceId: i.id});
+            var item = _.find(data.equipResults, {itemInstanceId: i.id});
             return item && item.equipStatus === 1;
           });
         });

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -190,10 +190,13 @@
       var items = angular.copy(_.flatten(_.values(loadout.items)));
       var totalItems = items.length;
 
-      // Remove stuff from the list that's already in the right state
+      // Only select stuff that needs to change state
       items = _.filter(items, function(pseudoItem) {
         var item = dimItemService.getItem(pseudoItem);
-        return !item || item.owner !== store.id || item.equipped !== pseudoItem.equipped;
+        return !item ||
+          !item.equipment ||
+          item.owner !== store.id ||
+          item.equipped !== pseudoItem.equipped;
       });
 
       var _types = _.uniq(_.pluck(items, 'type'));

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -30,6 +30,14 @@
       // How many *more* items like this item can fit in this store?
       spaceLeftForItem: function(item) {
         return this.capacityForItem(item) - count(this.items, { type: item.type });
+      },
+      updateCharacterInfo: function(characterInfo) {
+        this.level = characterInfo.characterLevel;
+        this.percentToNextLevel = characterInfo.percentToNextLevel;
+        this.powerLevel = characterInfo.characterBase.powerLevel;
+        this.background = characterInfo.backgroundPath;
+        this.icon = characterInfo.emblemPath;
+        this.stats = getStatsData(characterInfo.characterBase);
       }
     };
 
@@ -61,13 +69,7 @@
         _.each(_stores, function(dStore) {
           if (!dStore.isVault) {
             var bStore = _.findWhere(bungieStores, { id: dStore.id });
-
-            dStore.level = bStore.base.characterLevel;
-            dStore.percentToNextLevel = bStore.base.percentToNextLevel;
-            dStore.powerLevel = bStore.base.characterBase.powerLevel;
-            dStore.background = bStore.base.backgroundPath;
-            dStore.icon = bStore.base.emblemPath;
-            dStore.stats = getStatsData(bStore.base.characterBase);
+            dStore.updateCharacterInfo(bStore.base);
           }
         });
         return _stores;


### PR DESCRIPTION
This implements the stuff we were discussing in #323. Unfortunately, as mentioned there, we cannot yet get rid of the call to refresh character info, but this PR has wired things up such that when the `EquipItems` API is fixed, we just need to stop calling the character refresh in a couple places and that's it.

With this change, we use `EquipItems` to dequip loadout items from other characters all at once, then move all the items to the target character (without equipping them), then use `EquipItems` again to equip them all at once when they arrive on our target character. This can speed up loadouts quite a bit in some situations, though in others it has no benefit or even a slight slowdown. It turns out that in loadouts that move from one character to another, the `EquipItem` overhead wasn't big at all, and because it alternated with transfer requests, it rarely had to wait for the request limiter. `EquipItems` is much slower, and all the transfers still have to be throttled, so moving between characters is a wash, or slightly slower. But if you have a bunch of items already on a character that you want to equip, it's much faster. I suppose we could do some fancy calculations to figure out when the ratio of items to move vs. items to equip is right. As it is, I just have the rule that if you're going to have to do more than one equip/dequip on the same character, use the bulk operation.

While I was in here I did one other thing to speed up loadouts a touch, which is to filter out anything that's already in the right place from the move plan. I also did a little refactoring in the `dimBungieService` module. Plus, apparently, I removed some code that tried to query open tabs, since Chrome doesn't allow us to do that anymore.