### PR TITLE
Queue loadouts and item moves so they don't interfere.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed a bug where DIM would refuse to equip an exotic when dequipping something else, even if the exotic was OK to equip.
 * When applying a loadout, DIM will now equip and dequip loadout items all at once, in order to speed up applying the loadout.
 * The search box has a new style.
+* Item moves and loadouts will now wait for each other, to prevent errors when they would collide. This means if you apply two loadouts, the second will wait for the first to complete before starting.
 
 # 3.4.1
 

--- a/app/index.html
+++ b/app/index.html
@@ -71,6 +71,7 @@
     <script src="scripts/dimApp.config.js?v=3.4.1"></script>
     <script src="scripts/dimWebWorker.factory.js?v=3.4.1"></script>
     <script src="scripts/services/dimRateLimit.factory.js?v=3.4.1"></script>
+    <script src="scripts/services/dimActionQueue.factory.js?v=3.4.1"></script>
     <script src="scripts/services/dimBungieService.factory.js?v=3.4.1"></script>
     <script src="scripts/services/dimDefinitions.factory.js?v=3.4.1"></script>
     <script src="scripts/services/dimPlatformService.factory.js?v=3.4.1"></script>

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -54,9 +54,9 @@
     };
   }
 
-  MovePopupController.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster'];
+  MovePopupController.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster', 'dimActionQueue'];
 
-  function MovePopupController($scope, loadingTracker, dimStoreService, dimItemService, ngDialog, $q, toaster) {
+  function MovePopupController($scope, loadingTracker, dimStoreService, dimItemService, ngDialog, $q, toaster, dimActionQueue) {
     var vm = this;
 
     // TODO: cache this, instead?
@@ -106,7 +106,7 @@
     /**
      * Move the item to the specified store. Equip it if equip is true.
      */
-    vm.moveItemTo = function moveItemTo(store, equip) {
+    vm.moveItemTo = dimActionQueue.wrap(function moveItemTo(store, equip) {
       var reload = vm.item.equipped || equip;
       var promise = dimItemService.moveTo(vm.item, store, equip, vm.moveAmount);
 
@@ -128,9 +128,9 @@
       loadingTracker.addPromise(promise);
       $scope.$parent.closeThisDialog();
       return promise;
-    };
+    });
 
-    vm.consolidate = function() {
+    vm.consolidate = dimActionQueue.wrap(function() {
       var stores = _.filter(dimStoreService.getStores(), function(s) { return s.id !== vm.item.owner && !s.isVault; });
       var vault = dimStoreService.getVault();
 
@@ -165,9 +165,9 @@
       loadingTracker.addPromise(promise);
       $scope.$parent.closeThisDialog();
       return promise;
-    };
+    });
 
-    vm.distribute = function() {
+    vm.distribute = dimActionQueue.wrap(function() {
       // Sort vault to the end
       var stores = _.sortBy(dimStoreService.getStores(), function(s) { return s.id == 'vault' ? 2 : 1; });
 
@@ -242,7 +242,7 @@
       loadingTracker.addPromise(promise);
       $scope.$parent.closeThisDialog();
       return promise;
-    };
+    });
 
     vm.stores = dimStoreService.getStores();
 

--- a/app/scripts/services/dimActionQueue.factory.js
+++ b/app/scripts/services/dimActionQueue.factory.js
@@ -1,0 +1,41 @@
+(function() {
+  'use strict';
+
+  angular.module('dimApp')
+    .factory('dimActionQueue', ActionQueue);
+
+  ActionQueue.$inject = ['$q'];
+
+  // A queue of actions that will execute one after the other
+  function ActionQueue($q) {
+    var _queue = [];
+    return {
+      // fn is either a blocking function or a function that returns a promise
+      queueAction: function(fn) {
+        var promise = (_queue.length) ? _queue[_queue.length-1] : $q.when();
+        // Execute fn regardless of the result of the existing promise. We
+        // don't use finally here because finally can't modify the return value.
+        promise = promise.then(function() {
+          return fn();
+        }, function() {
+          return fn();
+        }).finally(function() {
+          _queue.shift();
+        });
+        _queue.push(promise);
+      },
+
+      // Wrap a function to produce a function that will be queued
+      wrap: function(fn, context) {
+        var self = this;
+        return function() {
+          var args = arguments;
+          return self.queueAction(function() {
+            var res = fn.apply(context, args);
+            return res;
+          });
+        };
+      }
+    };
+  }
+})();

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .factory('dimLoadoutService', LoadoutService);
 
-  LoadoutService.$inject = ['$q', '$rootScope', 'uuid2', 'dimItemService', 'dimStoreService', 'toaster', 'loadingTracker', 'dimPlatformService'];
+  LoadoutService.$inject = ['$q', '$rootScope', 'uuid2', 'dimItemService', 'dimStoreService', 'toaster', 'loadingTracker', 'dimPlatformService', 'dimActionQueue'];
 
-  function LoadoutService($q, $rootScope, uuid2, dimItemService, dimStoreService, toaster, loadingTracker, dimPlatformService) {
+  function LoadoutService($q, $rootScope, uuid2, dimItemService, dimStoreService, toaster, loadingTracker, dimPlatformService, dimActionQueue) {
     var _loadouts = [];
 
     return {
@@ -187,116 +187,118 @@
     }
 
     function applyLoadout(store, loadout) {
-      var items = angular.copy(_.flatten(_.values(loadout.items)));
-      var totalItems = items.length;
+      dimActionQueue.queueAction(function() {
+        var items = angular.copy(_.flatten(_.values(loadout.items)));
+        var totalItems = items.length;
 
-      // Only select stuff that needs to change state
-      items = _.filter(items, function(pseudoItem) {
-        var item = dimItemService.getItem(pseudoItem);
-        return !item ||
-          !item.equipment ||
-          item.owner !== store.id ||
-          item.equipped !== pseudoItem.equipped;
-      });
+        // Only select stuff that needs to change state
+        items = _.filter(items, function(pseudoItem) {
+          var item = dimItemService.getItem(pseudoItem);
+          return !item ||
+            !item.equipment ||
+            item.owner !== store.id ||
+            item.equipped !== pseudoItem.equipped;
+        });
 
-      var _types = _.uniq(_.pluck(items, 'type'));
+        var _types = _.uniq(_.pluck(items, 'type'));
 
-      var loadoutItemIds = items.map(function(i) {
-        return {
-          id: i.id,
-          hash: i.hash
+        var loadoutItemIds = items.map(function(i) {
+          return {
+            id: i.id,
+            hash: i.hash
+          };
+        });
+
+        // We'll equip these all in one go!
+        var itemsToEquip = _.filter(items, 'equipped');
+        if (itemsToEquip.length > 1) {
+          // we'll use the equipItems function
+          itemsToEquip.forEach(function(i) { i.equipped = false; });
+        }
+
+        // Stuff that's equipped on another character. We can bulk-dequip these
+        var itemsToDequip = _.filter(items, function(pseudoItem) {
+          var item = dimItemService.getItem(pseudoItem);
+          return item.owner !== store.id && item.equipped;
+        });
+
+        var scope = {
+          failed: 0,
+          total: totalItems,
+          successfulItems: []
         };
-      });
 
-      // We'll equip these all in one go!
-      var itemsToEquip = _.filter(items, 'equipped');
-      if (itemsToEquip.length > 1) {
-        // we'll use the equipItems function
-        itemsToEquip.forEach(function(i) { i.equipped = false; });
-      }
+        var promise = $q.when();
 
-      // Stuff that's equipped on another character. We can bulk-dequip these
-      var itemsToDequip = _.filter(items, function(pseudoItem) {
-        var item = dimItemService.getItem(pseudoItem);
-        return item.owner !== store.id && item.equipped;
-      });
-
-      var scope = {
-        failed: 0,
-        total: totalItems,
-        successfulItems: []
-      };
-
-      var promise = $q.when();
-
-      if (itemsToDequip.length > 1) {
-        var realItemsToDequip = itemsToDequip.map(function(i) {
-          return dimItemService.getItem(i);
-        });
-        var dequips = _.map(_.groupBy(realItemsToDequip, 'owner'), function(dequipItems, owner) {
-          var equipItems = realItemsToDequip.map(function(i) {
-            return dimItemService.getSimilarItem(i, loadoutItemIds);
+        if (itemsToDequip.length > 1) {
+          var realItemsToDequip = itemsToDequip.map(function(i) {
+            return dimItemService.getItem(i);
           });
-          return dimItemService.equipItems(dimStoreService.getStore(owner), equipItems);
-        });
-        promise = $q.all(dequips);
-      }
+          var dequips = _.map(_.groupBy(realItemsToDequip, 'owner'), function(dequipItems, owner) {
+            var equipItems = realItemsToDequip.map(function(i) {
+              return dimItemService.getSimilarItem(i, loadoutItemIds);
+            });
+            return dimItemService.equipItems(dimStoreService.getStore(owner), equipItems);
+          });
+          promise = $q.all(dequips);
+        }
 
-      promise = promise
-        .then(function() {
-          return applyLoadoutItems(store, items, loadout, loadoutItemIds, scope);
-        })
-        .then(function() {
-          if (itemsToEquip.length > 1) {
-            // Use the bulk equipAll API to equip all at once.
-            itemsToEquip = _.filter(itemsToEquip, function(i) {
-              return _.find(scope.successfulItems, { id: i.id });
-            });
-            var realItemsToEquip = itemsToEquip.map(function(i) {
-              return dimItemService.getItem(i);
-            });
-            return dimItemService.equipItems(store, realItemsToEquip);
-          } else {
-            return itemsToEquip;
-          }
-        })
-        .then(function(equippedItems) {
-          if (equippedItems.length < itemsToEquip.length) {
-            var failedItems = _.filter(itemsToEquip, function(i) {
-              return !_.find(equippedItems, { id: i.id });
-            });
-            _.difference(itemsToEquip, equippedItems).forEach(function(item) {
-              scope.failed++;
-              toaster.pop('error', 'Could not equip ' + item.name);
-            });
-          }
-        })
-        .then(function() {
-          // We need to do this until https://github.com/DestinyItemManager/DIM/issues/323
-          // is fixed on Bungie's end. When that happens, just remove this call.
-          if (scope.successfulItems.length > 0) {
-            return dimStoreService.updateCharacters();
-          }
-        })
-        .then(function() {
-          var value = 'success';
-          var message = 'Your loadout of ' + scope.total + ' items has been transfered.';
-
-          if (scope.failed > 0) {
-            if (scope.failed === scope.total) {
-              value = 'error';
-              message = 'None of the items in your loadout could be transferred.';
+        promise = promise
+          .then(function() {
+            return applyLoadoutItems(store, items, loadout, loadoutItemIds, scope);
+          })
+          .then(function() {
+            if (itemsToEquip.length > 1) {
+              // Use the bulk equipAll API to equip all at once.
+              itemsToEquip = _.filter(itemsToEquip, function(i) {
+                return _.find(scope.successfulItems, { id: i.id });
+              });
+              var realItemsToEquip = itemsToEquip.map(function(i) {
+                return dimItemService.getItem(i);
+              });
+              return dimItemService.equipItems(store, realItemsToEquip);
             } else {
-              value = 'warning';
-              message = 'Your loadout has been partially transferred, but ' + scope.failed + ' of ' + scope.total + ' items had errors.';
+              return itemsToEquip;
             }
-          }
+          })
+          .then(function(equippedItems) {
+            if (equippedItems.length < itemsToEquip.length) {
+              var failedItems = _.filter(itemsToEquip, function(i) {
+                return !_.find(equippedItems, { id: i.id });
+              });
+              _.difference(itemsToEquip, equippedItems).forEach(function(item) {
+                scope.failed++;
+                toaster.pop('error', 'Could not equip ' + item.name);
+              });
+            }
+          })
+          .then(function() {
+            // We need to do this until https://github.com/DestinyItemManager/DIM/issues/323
+            // is fixed on Bungie's end. When that happens, just remove this call.
+            if (scope.successfulItems.length > 0) {
+              return dimStoreService.updateCharacters();
+            }
+          })
+          .then(function() {
+            var value = 'success';
+            var message = 'Your loadout of ' + scope.total + ' items has been transferred to your ' + [store.race, store.gender, store.class].join(' ') + '.';
 
-          toaster.pop(value, loadout.name, message);
-        });
+            if (scope.failed > 0) {
+              if (scope.failed === scope.total) {
+                value = 'error';
+                message = 'None of the items in your loadout could be transferred.';
+              } else {
+                value = 'warning';
+                message = 'Your loadout has been partially transferred, but ' + scope.failed + ' of ' + scope.total + ' items had errors.';
+              }
+            }
 
-      loadingTracker.addPromise(promise);
-      return promise;
+            toaster.pop(value, loadout.name, message);
+          });
+
+        loadingTracker.addPromise(promise);
+        return promise;
+      });
     }
 
     // Move one loadout item at a time. Called recursively to move items!

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -82,9 +82,9 @@
   }
 
 
-  StoreItemsCtrl.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', '$q', '$timeout', 'toaster', 'dimSettingsService', 'ngDialog', '$rootScope'];
+  StoreItemsCtrl.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', '$q', '$timeout', 'toaster', 'dimSettingsService', 'ngDialog', '$rootScope', 'dimActionQueue'];
 
-  function StoreItemsCtrl($scope, loadingTracker, dimStoreService, dimItemService, $q, $timeout, toaster, dimSettingsService, ngDialog, $rootScope) {
+  function StoreItemsCtrl($scope, loadingTracker, dimStoreService, dimItemService, $q, $timeout, toaster, dimSettingsService, ngDialog, $rootScope, dimActionQueue) {
     var vm = this;
 
     // Detect when we're hovering a dragged item over a target
@@ -299,7 +299,7 @@
       }
     };
 
-    vm.moveDroppedItem = function(item, equip, $event) {
+    vm.moveDroppedItem = dimActionQueue.wrap(function(item, equip, $event) {
       var target = vm.store;
 
       if (item.notransfer && item.owner !== target.id) {
@@ -357,7 +357,7 @@
         });
       }
 
-      promise.then(function(moveAmount) {
+      promise = promise.then(function(moveAmount) {
         var movePromise = dimItemService.moveTo(item, target, equip, moveAmount);
 
         var reload = item.equipped || equip;


### PR DESCRIPTION
This prevents us from having errors caused by stuff moving while a loadout is applying or an item transfer is making space. It's now possible to issue commands to apply multiple loadouts at once, and they'll all succeed since they won't compete with each other.

This fixes #455.