### PR TITLE
Better error handling for API requests

### DIFF
--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -92,12 +92,10 @@
     }
 
     function openBungieNetTab() {
-      if (_.size(tabs) === 0) {
-        chrome.tabs.create({
-          url: 'http://bungie.net',
-          active: false
-        });
-      }
+      chrome.tabs.create({
+        url: 'http://bungie.net',
+        active: false
+      });
     }
 
     /************************************************************************************************************************************/


### PR DESCRIPTION
On the theme of "fewer errors shown to users", this PR makes it so we never show confusing error messages like "no property 'id' for undefined" or "The store inventory is not available." or "Please sign in to continue" when folks get signed out while using DIM. While I was at it, I simplified the error handling code and made it generally more robust.