### PR TITLE
Second attempt at move-aside functionality.

### DIFF
--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -21,7 +21,6 @@
         getItems: getItems,
         moveTo: moveTo,
         equipItems: equipItems,
-        makeRoomForItem: makeRoomForItem,
         setLockState: setLockState
       };
 
@@ -336,57 +335,31 @@
         return promise;
       }
 
-      // Make room to move this item into a full store. This assumes you've already
-      // checked to see that the store is full. excludes are an optional list
-      // of which items we are not allowed to move. storeReservations is for recursion.
-      function makeRoomForItem(item, store, excludes, storeReservations) {
-        var stores = dimStoreService.getStores();
-
-        if (!excludes) {
-          excludes = [];
-        }
-
-        // Reserve enough space for the transfer to succeed, even if we recurse
-        if (!storeReservations) {
-          storeReservations = {};
-          stores.forEach(function(s) {
-            storeReservations[s.id] = (s.id === store.id ? 1 : 0);
-          });
-          // guardian-to-guardian transfer will need space in the vault
-          if (item.owner !== 'vault' && !store.isVault) {
-            storeReservations['vault'] = 1;
-          }
-        }
-
-        function spaceLeft(s, i) {
-          return Math.max(s.spaceLeftForItem(i) - storeReservations[s.id], 0);
-        }
-
+      function chooseMoveAsideItem(store, item, moveContext) {
         var moveAsideCandidates;
-        if (!moveAsideCandidates) {
-          if (store.isVault && !_.any(stores, function(s) { return spaceLeft(s, item); })) {
-            // If it's the vault, we can get rid of anything in the same sort category.
-            // Pick whatever we have the most space for on some guardian.
-            var bestType = _.max(dimCategory[item.sort], function(type) {
-              var res = _.max(stores.map(function(s) {
-                if (s.id == store.id || !_.any(store.items, { type: type })) {
-                  return 0;
-                } else {
-                  return spaceLeft(s, { type: type });
-                }
-              }));
-              return res;
-            });
+        var stores = dimStoreService.getStores();
+        if (store.isVault && !_.any(stores, function(s) { return moveContext.spaceLeft(s, item); })) {
+          // If it's the vault, we can get rid of anything in the same sort category.
+          // Pick whatever we have the most space for on some guardian.
+          var bestType = _.max(dimCategory[item.sort], function(type) {
+            var res = _.max(stores.map(function(s) {
+              if (s.id == store.id || !_.any(store.items, { type: type })) {
+                return 0;
+              } else {
+                return moveContext.spaceLeft(s, { type: type });
+              }
+            }));
+            return res;
+          });
 
-            moveAsideCandidates = _.filter(store.items, { type: bestType });
-          } else {
-            moveAsideCandidates = _.filter(store.items, { type: item.type });
-          }
+          moveAsideCandidates = _.filter(store.items, { type: bestType });
+        } else {
+          moveAsideCandidates = _.filter(store.items, { type: item.type });
         }
 
         // Don't move that which cannot be moved
         moveAsideCandidates = _.reject(moveAsideCandidates, function(i) {
-          return i.notransfer || _.any(excludes, { id: i.id, hash: i.hash });
+          return i.notransfer || _.any(moveContext.excludes, { id: i.id, hash: i.hash });
         });
 
         if (moveAsideCandidates.length === 0) {
@@ -416,80 +389,105 @@
           return value;
         });
 
+        return moveAsideItem;
+      }
+
+      function chooseMoveAsideTarget(store, moveAsideItem, moveContext) {
         var target;
+        var stores = dimStoreService.getStores();
         if (store.isVault) {
           // Find the character with the most space
-          target = _.max(stores, function(s) { return spaceLeft(s, moveAsideItem); });
+          target = _.max(_.reject(stores, 'isVault'), function(s) { return moveContext.spaceLeft(s, moveAsideItem); });
         } else {
           var vault = dimStoreService.getVault();
           // Prefer moving to the vault
-          if (spaceLeft(vault, moveAsideItem) > 0) {
+          if (moveContext.spaceLeft(vault, moveAsideItem) > 0) {
             target = vault;
           } else {
-            target = _.max(stores, function(s) { return spaceLeft(s, moveAsideItem); });
+            target = _.max(stores, function(s) { return moveContext.spaceLeft(s, moveAsideItem); });
+          }
+          if (moveContext.spaceLeft(target, moveAsideItem) <= 0) {
+            target = vault;
           }
         }
-
-        if (spaceLeft(target, moveAsideItem) <= 0) {
-          var failure = $q.reject(new Error('There are too many \'' + (store.isVault ? item.sort : item.type) + '\' items in the ' + (store.isVault ? 'vault' : 'guardian') + '.'));
-          if (!store.isVault) {
-            return makeRoomForItem(moveAsideItem, dimStoreService.getVault(), excludes, storeReservations)
-              .then(function() {
-                return makeRoomForItem(item, store, excludes, storeReservations);
-              })
-              .catch(function() { return failure; });
-          } else {
-            return failure;
-          }
-        } else {
-          return moveTo(moveAsideItem, target);
-        }
+        return target === -Infinity ? undefined : target;
       }
 
-      // Is there anough space to move the given item into store? This will refresh
-      // data and/or move items aside in an attempt to make a move possible.
-      function canMoveToStore(item, store, triedFallback) {
-        if (item.owner === store.id) {
-          return $q.resolve(true);
-        }
-
+      function slotsNeededForTransferTo(store, item) {
         var slotsNeededForTransfer = 0;
 
         if (item.maxStackSize > 1) {
           var stackAmount = store.amountOfItem(item);
           slotsNeededForTransfer = Math.ceil((stackAmount + item.amount) / item.maxStackSize) - Math.ceil((stackAmount) / item.maxStackSize);
         } else {
-          if (item.owner === store.id) {
-            slotsNeededForTransfer = 0;
-          } else {
-            slotsNeededForTransfer = 1;
-          }
+          slotsNeededForTransfer = 1;
         }
 
-        if (store.spaceLeftForItem(item) >= slotsNeededForTransfer) {
-          if ((item.owner !== store.id) && !store.isVault && (item.owner !== 'vault')) {
-            // It's a guardian-to-guardian move, so we need to check
-            // if there's space in the vault since the item has to go
-            // through there.
-            return canMoveToStore(item, dimStoreService.getVault());
-          } else {
-            return $q.resolve(true);
-          }
+        return slotsNeededForTransfer;
+      }
+
+      // Is there anough space to move the given item into store? This will refresh
+      // data and/or move items aside in an attempt to make a move possible.
+      function canMoveToStore(item, store, triedFallback, excludes) {
+        if (item.owner === store.id) {
+          return $q.resolve(true);
+        }
+
+        var stores = dimStoreService.getStores();
+        // How much space will be needed in the various stores in order to make the transfer?
+        var storeReservations = {};
+        stores.forEach(function(s) {
+          storeReservations[s.id] = (s.id === store.id ? slotsNeededForTransferTo(s, item) : 0);
+        });
+        // guardian-to-guardian transfer will also need space in the vault
+        if (item.owner !== 'vault' && !store.isVault) {
+          storeReservations['vault'] = slotsNeededForTransferTo(dimStoreService.getVault(), item);
+        }
+
+        // How many moves are needed from each
+        var movesNeeded = {};
+        dimStoreService.getStores().forEach(function(s) {
+          movesNeeded[s.id] = Math.max(0, storeReservations[s.id] - s.spaceLeftForItem(item));
+        });
+
+        if (!_.any(movesNeeded)) {
+          return $q.resolve(true);
         } else {
-          // Not enough space!
           if (store.isVault || triedFallback) {
-            return makeRoomForItem(item, store).then(function() {
-              return canMoveToStore(item, store);
-            });
-          } else {
-            // Refresh the store
-            var reloadPromise = throttledReloadStores();
-            if (!reloadPromise) {
-              reloadPromise = $q.when(dimStoreService.getStores());
+            // Move aside one of the items that's in the way
+            var moveContext = {
+              reservations: storeReservations,
+              originalItemType: item.type,
+              excludes: excludes || [],
+              spaceLeft: function(s, i) {
+                var left = s.spaceLeftForItem(i);
+                if (i.type === this.originalItemType) {
+                  left = left - this.reservations[s.id];
+                }
+                return Math.max(0, left);
+              }
+            };
+
+            // Move starting from the vault (which is always last)
+            var move = _.pairs(movesNeeded).reverse().find(function(p) { return p[1] > 0; });
+            var source = dimStoreService.getStore(move[0]);
+            var moveAsideItem = chooseMoveAsideItem(source, item, moveContext);
+            var target = chooseMoveAsideTarget(source, moveAsideItem, moveContext);
+
+            if (!target || (!target.isVault && target.spaceLeftForItem(moveAsideItem) <= 0)) {
+              return $q.reject(new Error('There are too many \'' + (target.isVault ? moveAsideItem.sort : moveAsideItem.type) + '\' items in the ' + target.name + '.'));
+            } else {
+              // Make one move and start over!
+              return moveTo(moveAsideItem, target, false, moveAsideItem.amount, excludes).then(function() {
+                return canMoveToStore(item, store, triedFallback, excludes);
+              });
             }
+          } else {
+            // Refresh the stores to see if anything has changed
+            var reloadPromise = throttledReloadStores() || $q.when(dimStoreService.getStores());
             return reloadPromise.then(function(stores) {
               store = _.find(stores, { id: store.id });
-              return canMoveToStore(item, store, true);
+              return canMoveToStore(item, store, true, excludes);
             });
           }
         }
@@ -505,10 +503,10 @@
         });
       }
 
-      function isValidTransfer(equip, store, item) {
+      function isValidTransfer(equip, store, item, excludes) {
         var promises = [];
 
-        promises.push(canMoveToStore(item, store));
+        promises.push(canMoveToStore(item, store, false, excludes));
 
         if (equip) {
           promises.push(canEquip(item, store));
@@ -521,7 +519,7 @@
         return $q.all(promises);
       }
 
-      function moveTo(item, target, equip, amount) {
+      function moveTo(item, target, equip, amount, excludes) {
         var data = {
           item: item,
           source: dimStoreService.getStore(item.owner),
@@ -532,7 +530,7 @@
           }
         };
 
-        var movePlan = isValidTransfer(equip, target, item)
+        var movePlan = isValidTransfer(equip, target, item, excludes)
           .then(function(targetStore) {
             // Replace the target store - isValidTransfer may have replaced it
             data.target = dimStoreService.getStore(target.id);

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -191,6 +191,13 @@
         var items = angular.copy(_.flatten(_.values(loadout.items)));
         var totalItems = items.length;
 
+        var loadoutItemIds = items.map(function(i) {
+          return {
+            id: i.id,
+            hash: i.hash
+          };
+        });
+
         // Only select stuff that needs to change state
         items = _.filter(items, function(pseudoItem) {
           var item = dimItemService.getItem(pseudoItem);
@@ -198,15 +205,6 @@
             !item.equipment ||
             item.owner !== store.id ||
             item.equipped !== pseudoItem.equipped;
-        });
-
-        var _types = _.uniq(_.pluck(items, 'type'));
-
-        var loadoutItemIds = items.map(function(i) {
-          return {
-            id: i.id,
-            hash: i.hash
-          };
         });
 
         // We'll equip these all in one go!
@@ -354,19 +352,8 @@
         }
 
         if (item) {
-          var size = _.where(store.items, { type: item.type }).length;
-
-          // If full, make room.
-          if (size >= store.capacityForItem(item)) {
-            if (item.owner !== store.id) {
-              // Pass in the list of items that shouldn't be moved away
-              promise = dimItemService.makeRoomForItem(item, store, loadoutItemIds);
-            }
-          }
-
-          promise = promise.then(function() {
-            return dimItemService.moveTo(item, store, pseudoItem.equipped);
-          });
+          // Pass in the list of items that shouldn't be moved away
+          promise = dimItemService.moveTo(item, store, pseudoItem.equipped, item.amount, loadoutItemIds);
         } else {
           promise = $.reject(new Error(item.name + " doesn't exist in your account."));
         }

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -196,6 +196,7 @@
             if (raw.id === 'vault') {
               store = angular.extend(Object.create(StoreProto), {
                 id: 'vault',
+                name: 'vault',
                 lastPlayed: '2005-01-01T12:00:01Z',
                 icon: '',
                 items: [],
@@ -251,6 +252,7 @@
                 percentToNextLevel: raw.character.base.percentToNextLevel,
                 isVault: false
               });
+              store.name = store.class;
 
               _.each(raw.data.buckets, function(bucket) {
                 _.each(bucket, function(pail) {


### PR DESCRIPTION
This version is less complicated, and handles several edge cases the other version didn't.

Specifically, I hit a case where I had a full vault, and full primary weapons on all but one character. Trying to move the best exotic in my vault into one of the full characters led to it moving items around, then moving them *back* and blocking my original move. This is largely because the moves/move-asides for character-to-vault and then vault-to-character were being handled separately, rather than together. This version does more work but has better results. There were a handful of other cases that also failed that don't now.

I'm pretty tired - this really needs to get hammered on by the community.