### PR TITLE
Fixed text when consolidating items into the Vault.

### DIFF
--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -136,7 +136,13 @@
 
       promise = promise.then(function() {
         dimStoreService.setHeights();
-        toaster.pop('success', 'Consolidated ' + vm.item.name, 'All ' + vm.item.name + ' is now on your ' + vm.store.race + " " + vm.store.class + ".");
+        var message;
+        if (vm.store.isVault) {
+          message = 'All ' + vm.item.name + ' is now in your Vault.';
+        } else {
+          message = 'All ' + vm.item.name + ' is now on your ' + vm.store.race + " " + vm.store.class + ".";
+        }
+        toaster.pop('success', 'Consolidated ' + vm.item.name, message);
       })
       .catch(function(a) {
         toaster.pop('error', vm.item.name, a.message);


### PR DESCRIPTION
When consolidating items into the player vault, vm.store.race and vm.store.class are both null.
Check if the target store is the vault and then adjust the displayed message accordingly.