### PR TITLE
Item leveling loadout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Bring back the infusion dialog as an Infusion Fuel Finder. It doesn't do as much as it used to, but now it's optimized for quickly finding eligable infusion items.
 * Fix a bug where hovering over a drop zone with a consumable/material stack and waiting for the message to turn green still wouldn't trigger the partial move dialog.
+* Added a new "Item Leveling" auto-loadout. This loadout finds items for you to dump XP into. It strongly favors locked items, and won't replace an incomplete item that you have equipped. Otherwise, it goes after items that already have the most XP (closest to completion), preferring exotics and legendaries if they are locked, and rares and legendaries if they're not locked (because you get more materials out of disassembling them that way).
 
 # 3.5.4
 

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -33,7 +33,7 @@
         '      <span class="button-name button-full" ng-click="vm.maxLightLoadout($event)"><i class="fa fa-star"></i> Maximize Light</span>',
         '    </div>',
         '    <div class="loadout-set">',
-        '      <span class="button-name button-full" ng-click="vm.minBlueLoadout($event)"><i class="fa fa-star"></i> Min Blue Light</span>',
+        '      <span class="button-name button-full" ng-click="vm.itemLevelingLoadout($event)"><i class="fa fa-level-up"></i> Item Leveling</span>',
         '    </div>',
         '    <div class="loadout-set" ng-if="vm.previousLoadout">',
         '      <span class="button-name button-full" ng-click="vm.applyLoadout(vm.previousLoadout, $event)"><i class="fa fa-undo"></i> {{vm.previousLoadout.name}}</span>',
@@ -137,83 +137,60 @@
       dimLoadoutService.applyLoadout(vm.store, loadout);
     };
 
-    // Apply a loadout that's dynamically calculated to maximize Light level (preferring not to change currently-equipped items)
-    vm.minBlueLoadout = function minBlueLoadout($event) {
-      // These types contribute to light level
-      var lightTypes = ['Primary',
-                        'Special',
-                        'Heavy',
-                        'Helmet',
-                        'Gauntlets',
-                        'Chest',
-                        'Leg',
-                        'ClassItem',
-                        'Artifact',
-                        'Ghost'];
-
+    // A dynamic loadout set up to level weapons and armor
+    vm.itemLevelingLoadout = function minBlueLoadout($event) {
       // TODO: this should be a method somewhere that gets all items equippable by a character
       var applicableItems = _.select(dimItemService.getItems(), function(i) {
         return i.equipment &&
-          i.primStat !== undefined && // has a primary stat (sanity check)
           (i.classTypeName === 'unknown' || i.classTypeName === vm.store.class) && // for our class
           i.equipRequiredLevel <= vm.store.level && // nothing we are too low-level to equip
-          _.contains(lightTypes, i.type) && // one of our selected types
-          !i.notransfer // can be moved
-
+          !i.notransfer && // can be moved
+          i.talentGrid && !i.talentGrid.xpComplete; // Still need XP
       });
       var itemsByType = _.groupBy(applicableItems, 'type');
 
       var bestItemFn = function(item) {
-        var value = 0; //item.primStat.value;
-        var is_equiped = false;
-        // Break ties when items have the same stats. Note that this should only
-        // add less than 0.25 total, since in the exotics special case there can be
-        // three items in consideration and you don't want to go over 1 total.
+        // Leave equipped items alone if they need XP
+        if (item.equipped) {
+          return 1000;
+        }
+
+        var value = 0;
+        // Prefer locked items (they're stuff you want to use/keep)
+        // and apply different rules to them.
+        if (item.locked) {
+          value += 500;
+          value += [
+            'Common',
+            'Uncommon',
+            'Rare',
+            'Legendary',
+            'Exotic'
+          ].indexOf(item.tier) * 10;
+        } else {
+          // For unlocked, prefer blue items so when you destroy them you get more mats.
+          value += [
+            'Common',
+            'Uncommon',
+            'Exotic',
+            'Legendary',
+            'Rare'
+          ].indexOf(item.tier) * 10;
+        }
+
+        // Choose the item w/ the highest XP
+        value += 10 * (1 - (item.talentGrid.totalXP / item.talentGrid.totalXPRequired));
+
         if (item.owner == vm.store.id) {
           // Prefer items owned by this character
-          value -= 0.1;
-          if (item.equipped) {
-            // Prefer them even more if they're already equipped
-            value -= 0.1;
-            is_equiped = true;
-          }
+          value += 0.5;
         } else if (item.owner == 'vault') {
           // Prefer items in the vault over items owned by a different character
           // (but not as much as items owned by this character)
-          value -= 0.05;
-        }
-        // Prefer blue things, when you destruct a completed blue you get 2 motes.
-        if(item.tier == 'Rare')
-        {
-            value += 1000;
-        }
-        // Prefer unlvled locked items.
-        if(item.locked)
-        {
-            value += 1500;
+          value += 0.05;
         }
 
-        // Prefer items based on exp left
-        if(item.talentGrid)
-        {
-            // Avoid things that have their exp completed.
-            if(item.talentGrid.xpComplete == true)
-            {
-                value -= 1000000;
-            }
-            else{
-                // Give preference to items that are mostly lvled
-                value += 1000.0*item.talentGrid.totalXP/item.talentGrid.totalXPRequired;
-                // If it is already equiped, and has exp left then leave it equiped.
-                if(is_equiped)
-                {
-                    value += 100000000.0;
-                }
-            }
-        }
-        else{ //There is no exp on this item to lvl, common/year 1 cloaks?
-            value -= 100000;
-        }
+        value += item.primStat ? item.primStat.value / 1000 : 0;
 
         return value;
       };
@@ -222,12 +199,9 @@
         return item.tier === dimItemTier.exotic;
       };
 
-      // Pick the best item by primary stat
-      var items = {};
-      _.each(lightTypes, function(type) {
-        if (itemsByType.hasOwnProperty(type)) {
-          items[type] = _.max(itemsByType[type], bestItemFn);
-        }
+      // Pick the best item
+      var items = _.mapObject(itemsByType, function(items, type) {
+        return _.max(items, bestItemFn);
       });
 
       // Solve for the case where our optimizer decided to equip two exotics
@@ -262,13 +236,13 @@
             }
           });
 
-          // Pick the option where the primary stats add up to the biggest number, again favoring equipped stuff
+          // Pick the option where the optimizer function adds up to the biggest number, again favoring equipped stuff
           var bestOption = _.max(options, function(opt) { return sum(_.values(opt), bestItemFn); });
           _.assign(items, bestOption);
         }
       });
 
-      // Copy the items and mark them "equipped" and put them in arrays, so they look like a loadout
+      // Copy the items and mark them equipped and put them in arrays, so they look like a loadout
       var finalItems = {};
       _.each(items, function(item, type) {
         var itemCopy = angular.copy(item);
@@ -278,7 +252,7 @@
 
       var loadout = {
         classType: -1,
-        name: 'Min Blue Light',
+        name: 'Item Leveling',
         items: finalItems
       };
 

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -139,12 +139,8 @@
 
     // A dynamic loadout set up to level weapons and armor
     vm.itemLevelingLoadout = function minBlueLoadout($event) {
-      // TODO: this should be a method somewhere that gets all items equippable by a character
       var applicableItems = _.select(dimItemService.getItems(), function(i) {
-        return i.equipment &&
-          (i.classTypeName === 'unknown' || i.classTypeName === vm.store.class) && // for our class
-          i.equipRequiredLevel <= vm.store.level && // nothing we are too low-level to equip
-          !i.notransfer && // can be moved
+        return i.canBeEquippedBy(vm.store) &&
           i.talentGrid && !i.talentGrid.xpComplete; // Still need XP
       });
       var itemsByType = _.groupBy(applicableItems, 'type');
@@ -275,12 +271,9 @@
 
       // TODO: this should be a method somewhere that gets all items equippable by a character
       var applicableItems = _.select(dimItemService.getItems(), function(i) {
-        return i.equipment &&
+        return i.canBeEquippedBy(vm.store) &&
           i.primStat !== undefined && // has a primary stat (sanity check)
-          (i.classTypeName === 'unknown' || i.classTypeName === vm.store.class) && // for our class
-          i.equipRequiredLevel <= vm.store.level && // nothing we are too low-level to equip
-          _.contains(lightTypes, i.type) && // one of our selected types
-          !i.notransfer; // can be moved
+          _.contains(lightTypes, i.type); // one of our selected types
       });
       var itemsByType = _.groupBy(applicableItems, 'type');
 

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -143,7 +143,6 @@
         return i.canBeEquippedBy(vm.store) &&
           i.talentGrid && !i.talentGrid.xpComplete; // Still need XP
       });
-      var itemsByType = _.groupBy(applicableItems, 'type');
 
       var bestItemFn = function(item) {
         // Leave equipped items alone if they need XP
@@ -190,6 +189,59 @@
 
         return value;
       };
+
+      var loadout = optimalLoadout(applicableItems, bestItemFn, 'Item Leveling');
+      vm.applyLoadout(loadout, $event);
+    };
+
+    // Apply a loadout that's dynamically calculated to maximize Light level (preferring not to change currently-equipped items)
+    vm.maxLightLoadout = function maxLightLoadout($event) {
+      // These types contribute to light level
+      var lightTypes = ['Primary',
+                        'Special',
+                        'Heavy',
+                        'Helmet',
+                        'Gauntlets',
+                        'Chest',
+                        'Leg',
+                        'ClassItem',
+                        'Artifact',
+                        'Ghost'];
+
+      var applicableItems = _.select(dimItemService.getItems(), function(i) {
+        return i.canBeEquippedBy(vm.store) &&
+          i.primStat !== undefined && // has a primary stat (sanity check)
+          _.contains(lightTypes, i.type); // one of our selected types
+      });
+
+      var bestItemFn = function(item) {
+        var value = item.primStat.value;
+
+        // Break ties when items have the same stats. Note that this should only
+        // add less than 0.25 total, since in the exotics special case there can be
+        // three items in consideration and you don't want to go over 1 total.
+        if (item.owner == vm.store.id) {
+          // Prefer items owned by this character
+          value += 0.1;
+          if (item.equipped) {
+            // Prefer them even more if they're already equipped
+            value += 0.1;
+          }
+        } else if (item.owner == 'vault') {
+          // Prefer items in the vault over items owned by a different character
+          // (but not as much as items owned by this character)
+          value += 0.05;
+        }
+        return value;
+      };
+
+      var loadout = optimalLoadout(applicableItems, bestItemFn, 'Maximize Light');
+      vm.applyLoadout(loadout, $event);
+    };
+
+    // Generate an optimized loadout based on a filtered set of items and a value function
+    function optimalLoadout(applicableItems, bestItemFn, name) {
+      var itemsByType = _.groupBy(applicableItems, 'type');
 
       var isExotic = function(item) {
         return item.tier === dimItemTier.exotic;
@@ -246,123 +298,11 @@
         finalItems[type.toLowerCase()] = [ itemCopy ];
       });
 
-      var loadout = {
+      return {
         classType: -1,
-        name: 'Item Leveling',
+        name: name,
         items: finalItems
       };
-
-      vm.applyLoadout(loadout, $event);
-    };
-
-    // Apply a loadout that's dynamically calculated to maximize Light level (preferring not to change currently-equipped items)
-    vm.maxLightLoadout = function maxLightLoadout($event) {
-      // These types contribute to light level
-      var lightTypes = ['Primary',
-                        'Special',
-                        'Heavy',
-                        'Helmet',
-                        'Gauntlets',
-                        'Chest',
-                        'Leg',
-                        'ClassItem',
-                        'Artifact',
-                        'Ghost'];
-
-      // TODO: this should be a method somewhere that gets all items equippable by a character
-      var applicableItems = _.select(dimItemService.getItems(), function(i) {
-        return i.canBeEquippedBy(vm.store) &&
-          i.primStat !== undefined && // has a primary stat (sanity check)
-          _.contains(lightTypes, i.type); // one of our selected types
-      });
-      var itemsByType = _.groupBy(applicableItems, 'type');
-
-      var bestItemFn = function(item) {
-        var value = item.primStat.value;
-
-        // Break ties when items have the same stats. Note that this should only
-        // add less than 0.25 total, since in the exotics special case there can be
-        // three items in consideration and you don't want to go over 1 total.
-        if (item.owner == vm.store.id) {
-          // Prefer items owned by this character
-          value += 0.1;
-          if (item.equipped) {
-            // Prefer them even more if they're already equipped
-            value += 0.1;
-          }
-        } else if (item.owner == 'vault') {
-          // Prefer items in the vault over items owned by a different character
-          // (but not as much as items owned by this character)
-          value += 0.05;
-        }
-        return value;
-      };
-
-      var isExotic = function(item) {
-        return item.tier === dimItemTier.exotic;
-      };
-
-      // Pick the best item by primary stat
-      var items = {};
-      _.each(lightTypes, function(type) {
-        if (itemsByType.hasOwnProperty(type)) {
-          items[type] = _.max(itemsByType[type], bestItemFn);
-        }
-      });
-
-      // Solve for the case where our optimizer decided to equip two exotics
-      var exoticGroups = [ ['Primary', 'Special', 'Heavy'], ['Helmet', 'Gauntlets', 'Chest', 'Leg'] ];
-      _.each(exoticGroups, function(group) {
-        var itemsInGroup = _.pick(items, group);
-        var numExotics = _.select(_.values(itemsInGroup), isExotic).length;
-        if (numExotics > 1) {
-          var options = [];
-
-          // Generate an option where we use each exotic
-          _.each(itemsInGroup, function(item, type) {
-            if (isExotic(item)) {
-              var option = angular.copy(itemsInGroup);
-              var optionValid = true;
-              // Switch the other exotic items to the next best non-exotic
-              _.each(_.omit(itemsInGroup, type), function(otherItem, otherType) {
-                if (isExotic(otherItem)) {
-                  var nonExotics = _.reject(itemsByType[otherType], isExotic);
-                  if (_.isEmpty(nonExotics)) {
-                    // this option isn't usable because we couldn't swap this exotic for any non-exotic
-                    optionValid = false;
-                  } else {
-                    option[otherType] = _.max(nonExotics, bestItemFn);
-                  }
-                }
-              });
-
-              if (optionValid) {
-                options.push(option);
-              }
-            }
-          });
-
-          // Pick the option where the primary stats add up to the biggest number, again favoring equipped stuff
-          var bestOption = _.max(options, function(opt) { return sum(_.values(opt), bestItemFn); });
-          _.assign(items, bestOption);
-        }
-      });
-
-      // Copy the items and mark them "equipped" and put them in arrays, so they look like a loadout
-      var finalItems = {};
-      _.each(items, function(item, type) {
-        var itemCopy = angular.copy(item);
-        itemCopy.equipped = true;
-        finalItems[type.toLowerCase()] = [ itemCopy ];
-      });
-
-      var loadout = {
-        classType: -1,
-        name: 'Maximize Light',
-        items: finalItems
-      };
-
-      vm.applyLoadout(loadout, $event);
-    };
+    }
   }
 })();

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -182,23 +182,27 @@
           // (but not as much as items owned by this character)
           value -= 0.05;
         }
+        // Prefer blue things, when you destruct a completed blue you get 2 motes.
         if(item.tier == 'Rare')
         {
             value += 1000;
         }
-        if(item.tier == 'Common')
+        // Prefer unlvled locked items.
+        if(item.locked)
         {
-            value -= 10000;
+            value += 1500;
         }
+
         // Prefer items based on exp left
         if(item.talentGrid)
         {
             // Avoid things that have their exp completed.
             if(item.talentGrid.xpComplete == true)
             {
-                value -= 10000;
+                value -= 1000000;
             }
             else{
+                // Give preference to items that are mostly lvled
                 value += 1000.0*item.talentGrid.totalXP/item.talentGrid.totalXPRequired;
                 // If it is already equiped, and has exp left then leave it equiped.
                 if(is_equiped)
@@ -207,7 +211,9 @@
                 }
             }
         }
-
+        else{ //There is no exp on this item to lvl, common/year 1 cloaks?
+            value -= 100000;
+        }
 
         return value;
       };

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -158,8 +158,8 @@
           (i.classTypeName === 'unknown' || i.classTypeName === vm.store.class) && // for our class
           i.equipRequiredLevel <= vm.store.level && // nothing we are too low-level to equip
           _.contains(lightTypes, i.type) && // one of our selected types
-          !i.notransfer && // can be moved
-          i.tier === "Rare"; // Is it blue?
+          !i.notransfer // can be moved
+
       });
       var itemsByType = _.groupBy(applicableItems, 'type');
 
@@ -181,6 +181,27 @@
           // (but not as much as items owned by this character)
           value -= 0.05;
         }
+        if(item.tier == 'Rare')
+        {
+            value -= 1000;
+        }
+        if(item.tier == 'Common')
+        {
+            value += 10000;
+        }
+
+        if( item.talentGrid)
+        {
+            if(item.talentGrid.xpComplete == true)
+            {
+                value += 1000;
+            }
+            else{
+                value -= 1000.0 * item.talentGrid.totalXP/item.talentGrid.totalXPRequired;
+            }
+        }
+
+
         return value;
       };
 

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -32,6 +32,9 @@
         '    <div class="loadout-set">',
         '      <span class="button-name button-full" ng-click="vm.maxLightLoadout($event)"><i class="fa fa-star"></i> Maximize Light</span>',
         '    </div>',
+        '    <div class="loadout-set">',
+        '      <span class="button-name button-full" ng-click="vm.minBlueLoadout($event)"><i class="fa fa-star"></i> Min Blue Light</span>',
+        '    </div>',
         '    <div class="loadout-set" ng-if="vm.previousLoadout">',
         '      <span class="button-name button-full" ng-click="vm.applyLoadout(vm.previousLoadout, $event)"><i class="fa fa-undo"></i> {{vm.previousLoadout.name}}</span>',
         '    </div>',
@@ -132,6 +135,120 @@
       dimLoadoutService.previousLoadouts[vm.store.id] = vm.previousLoadout; // ugly hack
 
       dimLoadoutService.applyLoadout(vm.store, loadout);
+    };
+
+    // Apply a loadout that's dynamically calculated to maximize Light level (preferring not to change currently-equipped items)
+    vm.minBlueLoadout = function minBlueLoadout($event) {
+      // These types contribute to light level
+      var lightTypes = ['Primary',
+                        'Special',
+                        'Heavy',
+                        'Helmet',
+                        'Gauntlets',
+                        'Chest',
+                        'Leg',
+                        'ClassItem',
+                        'Artifact',
+                        'Ghost'];
+
+      // TODO: this should be a method somewhere that gets all items equippable by a character
+      var applicableItems = _.select(dimItemService.getItems(), function(i) {
+        return i.equipment &&
+          i.primStat !== undefined && // has a primary stat (sanity check)
+          (i.classTypeName === 'unknown' || i.classTypeName === vm.store.class) && // for our class
+          i.equipRequiredLevel <= vm.store.level && // nothing we are too low-level to equip
+          _.contains(lightTypes, i.type) && // one of our selected types
+          !i.notransfer && // can be moved
+          i.tier === "Rare"; // Is it blue?
+      });
+      var itemsByType = _.groupBy(applicableItems, 'type');
+
+      var bestItemFn = function(item) {
+        var value = item.primStat.value;
+
+        // Break ties when items have the same stats. Note that this should only
+        // add less than 0.25 total, since in the exotics special case there can be
+        // three items in consideration and you don't want to go over 1 total.
+        if (item.owner == vm.store.id) {
+          // Prefer items owned by this character
+          value -= 0.1;
+          if (item.equipped) {
+            // Prefer them even more if they're already equipped
+            value -= 0.1;
+          }
+        } else if (item.owner == 'vault') {
+          // Prefer items in the vault over items owned by a different character
+          // (but not as much as items owned by this character)
+          value -= 0.05;
+        }
+        return value;
+      };
+
+      var isExotic = function(item) {
+        return item.tier === dimItemTier.exotic;
+      };
+
+      // Pick the best item by primary stat
+      var items = {};
+      _.each(lightTypes, function(type) {
+        if (itemsByType.hasOwnProperty(type)) {
+          items[type] = _.min(itemsByType[type], bestItemFn);
+        }
+      });
+
+      // Solve for the case where our optimizer decided to equip two exotics
+      var exoticGroups = [ ['Primary', 'Special', 'Heavy'], ['Helmet', 'Gauntlets', 'Chest', 'Leg'] ];
+      _.each(exoticGroups, function(group) {
+        var itemsInGroup = _.pick(items, group);
+        var numExotics = _.select(_.values(itemsInGroup), isExotic).length;
+        if (numExotics > 1) {
+          var options = [];
+
+          // Generate an option where we use each exotic
+          _.each(itemsInGroup, function(item, type) {
+            if (isExotic(item)) {
+              var option = angular.copy(itemsInGroup);
+              var optionValid = true;
+              // Switch the other exotic items to the next best non-exotic
+              _.each(_.omit(itemsInGroup, type), function(otherItem, otherType) {
+                if (isExotic(otherItem)) {
+                  var nonExotics = _.reject(itemsByType[otherType], isExotic);
+                  if (_.isEmpty(nonExotics)) {
+                    // this option isn't usable because we couldn't swap this exotic for any non-exotic
+                    optionValid = false;
+                  } else {
+                    option[otherType] = _.min(nonExotics, bestItemFn);
+                  }
+                }
+              });
+
+              if (optionValid) {
+                options.push(option);
+              }
+            }
+          });
+
+          // Pick the option where the primary stats add up to the biggest number, again favoring equipped stuff
+          var bestOption = _.min(options, function(opt) { return sum(_.values(opt), bestItemFn); });
+          _.assign(items, bestOption);
+        }
+      });
+
+      // Copy the items and mark them "equipped" and put them in arrays, so they look like a loadout
+      var finalItems = {};
+      _.each(items, function(item, type) {
+        var itemCopy = angular.copy(item);
+        itemCopy.equipped = true;
+        finalItems[type.toLowerCase()] = [ itemCopy ];
+      });
+
+      var loadout = {
+        classType: -1,
+        name: 'Min Blue Light',
+        items: finalItems
+      };
+
+      vm.applyLoadout(loadout, $event);
     };
 
     // Apply a loadout that's dynamically calculated to maximize Light level (preferring not to change currently-equipped items)

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -174,7 +174,7 @@
         }
 
         // Choose the item w/ the highest XP
-        value += 10 * (1 - (item.talentGrid.totalXP / item.talentGrid.totalXPRequired));
+        value += 10 * (item.talentGrid.totalXP / item.talentGrid.totalXPRequired);
 
         if (item.owner == vm.store.id) {
           // Prefer items owned by this character

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -264,7 +264,7 @@
               var failedItems = _.filter(itemsToEquip, function(i) {
                 return !_.find(equippedItems, { id: i.id });
               });
-              _.difference(itemsToEquip, equippedItems).forEach(function(item) {
+              failedItems.forEach(function(item) {
                 scope.failed++;
                 toaster.pop('error', 'Could not equip ' + item.name);
               });
@@ -276,6 +276,7 @@
             if (scope.successfulItems.length > 0) {
               return dimStoreService.updateCharacters();
             }
+            return undefined;
           })
           .then(function() {
             var value = 'success';

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -61,6 +61,24 @@
       }
     };
 
+    // Prototype for Item objects - add methods to this to add them to all
+    // items.
+    var ItemProto = {
+      // Can this item be equipped by the current store?
+      canBeEquippedBy: function(store) {
+        if (store.isVault) {
+          return false;
+        }
+        return this.equipment &&
+          // For the right class
+          (this.classTypeName === 'unknown' || this.classTypeName === store.class) &&
+          // nothing we are too low-level to equip
+          this.equipRequiredLevel <= store.level &&
+          // can be moved or is already here
+          (!this.notransfer || this.owner === store.id);
+      }
+    };
+
     var service = {
       getStores: getStores,
       reloadStores: reloadStores,
@@ -421,7 +439,7 @@
 
       var dmgName = [null, 'kinetic', 'arc', 'solar', 'void'][item.damageType];
 
-      var createdItem = {
+      var createdItem = angular.extend(Object.create(ItemProto), {
         hash: item.itemHash,
         type: itemType,
         sort: itemSort,
@@ -453,7 +471,7 @@
         weaponClass: weaponClass || '',
         weaponClassName: weaponClassName,
         classified: itemDef.classified
-      };
+      });
       createdItem.index = createItemIndex(createdItem);
 
       try {

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -75,7 +75,8 @@
           // nothing we are too low-level to equip
           this.equipRequiredLevel <= store.level &&
           // can be moved or is already here
-          (!this.notransfer || this.owner === store.id);
+          (!this.notransfer || this.owner === store.id) &&
+          this.sort !== 'Postmaster';
       }
     };
 


### PR DESCRIPTION
Building on @thesamprice's great contribution in #486 (because I can't push to his branch), and our discussion in #391. This adds an "Item Leveling" loadout, plus does some refactoring to make auto-loadouts like this easier in the future.

The rules are somewhat complex, but basically boil down to:

* If an item that needs XP is equipped, leave it be.
* Otherwise, find an item that needs XP. Prefer locked items to unlocked items.
* Of locked items, prefer exotics and legendaries, because you want to use them. Of unlocked items, prefer rares, then legendaries, because you can get more materials out of destroying leveled versions.

The idea here is that this will help you complete all your locked items (so you can use them), then once you run out of locked items, it'll help you farm stuff by churning through blues.