### PR TITLE
Hint that items can be drag/dropped versus move dialog

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -75,6 +75,7 @@
     <script src="scripts/services/dimActionQueue.factory.js?v=3.5.4"></script>
     <script src="scripts/services/dimBungieService.factory.js?v=3.5.4"></script>
     <script src="scripts/services/dimDefinitions.factory.js?v=3.5.4"></script>
+    <script src="scripts/services/dimInfoService.factory.js?v=3.5.4"></script>
     <script src="scripts/services/dimPlatformService.factory.js?v=3.5.4"></script>
     <script src="scripts/services/dimLoadoutService.factory.js?v=3.5.4"></script>
     <script src="scripts/services/dimSettingsService.factory.js?v=3.5.4"></script>

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -52,8 +52,8 @@
 
 
   angular.module('dimApp')
-    .run(['$rootScope', 'loadingTracker', '$timeout', 'toaster', '$http',
-      function($rootScope, loadingTracker, $timeout, toaster, $http) {
+    .run(['$rootScope', 'loadingTracker', '$timeout', 'toaster', '$http', 'dimInfoService',
+      function($rootScope, loadingTracker, $timeout, toaster, $http, dimInfoService) {
         $rootScope.loadingTracker = loadingTracker;
 
         //1 Hour
@@ -73,41 +73,10 @@
         //Track Our Initial Activity of Starting the App
         $rootScope.trackActivity();
 
-        chrome.storage.sync.get('20160411v35', function(data) {
-          if(_.isNull(data) || _.isEmpty(data)) {
-
-            $timeout(function() {
-              $http.get('views/changelog-toaster.html?v=v3.5.4')
-              .then(function(changelog) {
-                toaster.pop({
-                  type: 'info',
-                  title: 'DIM v3.5.4 Released',
-                  body: changelog.data,
-                  timeout: 0,
-                  bodyOutputType: 'trustedHtml',
-                  showCloseButton: true,
-                  clickHandler: function(a, b, c, d, e, f, g) {
-                    if(b) {
-                      return true;
-                    }
-
-                    return false;
-                  },
-                  onHideCallback: function() {
-                    if($('#20160411v35')
-                      .is(':checked')) {
-                      chrome.storage.sync.set({
-                        "20160411v35": 1
-                      }, function(e) {});
-                    }
-                  }
-                });
-
-              });
-            }, 3000);
-          }
+        dimInfoService.show('20160411v35', {
+          title: 'DIM v3.5.4 Released',
+          view: 'views/changelog-toaster.html?v=v3.5.4',
         });
-
       }
     ]);
 

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -102,10 +102,46 @@
       }
     };
 
+    function showTip() {
+      chrome.storage.sync.get('help.movebox', function(data) {
+        if(_.isNull(data) || _.isEmpty(data)) {
+          toaster.pop({
+            type: 'info',
+            title: 'Did you know?',
+            body: [
+              '<p>Items can be dragged and dropped between different characters/vault columns.</p>',
+              '<p>Try it out next time!<p>',
+              '<input style="margin-top: 1px; vertical-align: middle;" id="help-movebox" type="checkbox">',
+              '<label for="help-movebox">Don\'t show this tip again</label></p>'
+            ].join(''),
+            timeout: 0,
+            bodyOutputType: 'trustedHtml',
+            showCloseButton: true,
+            clickHandler: function(a, b, c, d, e, f, g) {
+              if(b) {
+                return true;
+              }
+              return false;
+            },
+            onHideCallback: function() {
+              if($('#help-movebox')
+                .is(':checked')) {
+                chrome.storage.sync.set({
+                  "help.movebox": 1
+                }, function(e) {});
+              }
+            }
+          });
+        }
+      });
+    }
+
     /**
      * Move the item to the specified store. Equip it if equip is true.
      */
     vm.moveItemTo = dimActionQueue.wrap(function moveItemTo(store, equip) {
+      showTip();
+
       var reload = vm.item.equipped || equip;
       var promise = dimItemService.moveTo(vm.item, store, equip, vm.moveAmount);
 

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -106,10 +106,12 @@
      * Move the item to the specified store. Equip it if equip is true.
      */
     vm.moveItemTo = dimActionQueue.wrap(function moveItemTo(store, equip) {
-      dimInfoService.show('movebox', [
-              '<p>Items can be dragged and dropped between different characters/vault columns.</p>',
-              '<p>Try it out next time!<p>'].join(''),
-              'Don\'t show this tip again');
+      dimInfoService.show('movebox', {
+        title: 'Did you know?',
+        body: ['<p>Items can be dragged and dropped between different characters/vault columns.</p>',
+               '<p>Try it out next time!<p>'].join(''),
+        hide: 'Don\'t show this tip again'
+      });
 
       var reload = vm.item.equipped || equip;
       var promise = dimItemService.moveTo(vm.item, store, equip, vm.moveAmount);

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -54,9 +54,9 @@
     };
   }
 
-  MovePopupController.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster', 'dimActionQueue'];
+  MovePopupController.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster', 'dimActionQueue', 'dimInfoService'];
 
-  function MovePopupController($scope, loadingTracker, dimStoreService, dimItemService, ngDialog, $q, toaster, dimActionQueue) {
+  function MovePopupController($scope, loadingTracker, dimStoreService, dimItemService, ngDialog, $q, toaster, dimActionQueue, dimInfoService) {
     var vm = this;
 
     // TODO: cache this, instead?
@@ -102,45 +102,14 @@
       }
     };
 
-    function showTip() {
-      chrome.storage.sync.get('help.movebox', function(data) {
-        if(_.isNull(data) || _.isEmpty(data)) {
-          toaster.pop({
-            type: 'info',
-            title: 'Did you know?',
-            body: [
-              '<p>Items can be dragged and dropped between different characters/vault columns.</p>',
-              '<p>Try it out next time!<p>',
-              '<input style="margin-top: 1px; vertical-align: middle;" id="help-movebox" type="checkbox">',
-              '<label for="help-movebox">Don\'t show this tip again</label></p>'
-            ].join(''),
-            timeout: 0,
-            bodyOutputType: 'trustedHtml',
-            showCloseButton: true,
-            clickHandler: function(a, b, c, d, e, f, g) {
-              if(b) {
-                return true;
-              }
-              return false;
-            },
-            onHideCallback: function() {
-              if($('#help-movebox')
-                .is(':checked')) {
-                chrome.storage.sync.set({
-                  "help.movebox": 1
-                }, function(e) {});
-              }
-            }
-          });
-        }
-      });
-    }
-
     /**
      * Move the item to the specified store. Equip it if equip is true.
      */
     vm.moveItemTo = dimActionQueue.wrap(function moveItemTo(store, equip) {
-      showTip();
+      dimInfoService.show('movebox', [
+              '<p>Items can be dragged and dropped between different characters/vault columns.</p>',
+              '<p>Try it out next time!<p>'].join(''),
+              'Don\'t show this tip again');
 
       var reload = vm.item.equipped || equip;
       var promise = dimItemService.moveTo(vm.item, store, equip, vm.moveAmount);

--- a/app/scripts/services/dimHelpService.factory.js
+++ b/app/scripts/services/dimHelpService.factory.js
@@ -1,0 +1,46 @@
+(function() {
+  'use strict';
+
+  angular.module('dimApp')
+    .factory('dimInfoService', InfoService);
+
+  InfoService.$inject = ['toaster'];
+
+  function InfoService(toaster) {
+    return {
+      show: function(id, body, hide) {
+        hide = hide || '';
+        chrome.storage.sync.get('info.' + id, function(data) {
+          if(_.isNull(data) || _.isEmpty(data)) {
+            toaster.pop({
+              type: 'info',
+              title: 'Did you know?',
+              body: [
+                body,
+                '<input style="margin-top: 1px; vertical-align: middle;" id="info-' + id + '" type="checkbox">',
+                '<label for="info-' + id + '">' + hide + '</label></p>'
+              ].join(''),
+              timeout: 0,
+              bodyOutputType: 'trustedHtml',
+              showCloseButton: true,
+              clickHandler: function(a, b, c, d, e, f, g) {
+                if(b) {
+                  return true;
+                }
+                return false;
+              },
+              onHideCallback: function() {
+                if($('#help-' + id)
+                  .is(':checked')) {
+                  var save = {};
+                  save['info.' + id] = 1;
+                  chrome.storage.sync.set(save, function(e) {});
+                }
+              }
+            });
+          }
+        });
+      }
+    };
+  }
+})();

--- a/app/scripts/services/dimInfoService.factory.js
+++ b/app/scripts/services/dimInfoService.factory.js
@@ -8,17 +8,21 @@
 
   function InfoService(toaster) {
     return {
-      show: function(id, body, hide) {
-        hide = hide || '';
+      show: function(id, content) {
+        content = content || {};
+        content.title = content.title || '';
+        content.body = content.body || '';
+        content.hide = content.hide || '';
+
         chrome.storage.sync.get('info.' + id, function(data) {
           if(_.isNull(data) || _.isEmpty(data)) {
             toaster.pop({
               type: 'info',
-              title: 'Did you know?',
+              title: content.title,
               body: [
-                body,
+                content.body,
                 '<input style="margin-top: 1px; vertical-align: middle;" id="info-' + id + '" type="checkbox">',
-                '<label for="info-' + id + '">' + hide + '</label></p>'
+                '<label for="info-' + id + '">' + content.hide + '</label></p>'
               ].join(''),
               timeout: 0,
               bodyOutputType: 'trustedHtml',

--- a/app/scripts/services/dimInfoService.factory.js
+++ b/app/scripts/services/dimInfoService.factory.js
@@ -30,7 +30,7 @@
                 return false;
               },
               onHideCallback: function() {
-                if($('#help-' + id)
+                if($('#info-' + id)
                   .is(':checked')) {
                   var save = {};
                   save['info.' + id] = 1;

--- a/app/scripts/services/dimInfoService.factory.js
+++ b/app/scripts/services/dimInfoService.factory.js
@@ -4,44 +4,54 @@
   angular.module('dimApp')
     .factory('dimInfoService', InfoService);
 
-  InfoService.$inject = ['toaster'];
+  InfoService.$inject = ['toaster', '$http'];
 
-  function InfoService(toaster) {
+  function InfoService(toaster, $http) {
     return {
       show: function(id, content) {
         content = content || {};
         content.title = content.title || '';
         content.body = content.body || '';
-        content.hide = content.hide || '';
+        content.hide = content.hide || 'Hide This Popup';
+
+        function showToaster(body) {
+          toaster.pop({
+            type: 'info',
+            title: content.title,
+            body: [
+              body,
+              '<input style="margin-top: 1px; vertical-align: middle;" id="info-' + id + '" type="checkbox">',
+              '<label for="info-' + id + '">' + content.hide + '</label></p>'
+            ].join(''),
+            timeout: 0,
+            bodyOutputType: 'trustedHtml',
+            showCloseButton: true,
+            clickHandler: function(a, b, c, d, e, f, g) {
+              if(b) {
+                return true;
+              }
+              return false;
+            },
+            onHideCallback: function() {
+              if($('#info-' + id)
+                .is(':checked')) {
+                var save = {};
+                save['info.' + id] = 1;
+                chrome.storage.sync.set(save, function(e) {});
+              }
+            }
+          });
+        }
 
         chrome.storage.sync.get('info.' + id, function(data) {
           if(_.isNull(data) || _.isEmpty(data)) {
-            toaster.pop({
-              type: 'info',
-              title: content.title,
-              body: [
-                content.body,
-                '<input style="margin-top: 1px; vertical-align: middle;" id="info-' + id + '" type="checkbox">',
-                '<label for="info-' + id + '">' + content.hide + '</label></p>'
-              ].join(''),
-              timeout: 0,
-              bodyOutputType: 'trustedHtml',
-              showCloseButton: true,
-              clickHandler: function(a, b, c, d, e, f, g) {
-                if(b) {
-                  return true;
-                }
-                return false;
-              },
-              onHideCallback: function() {
-                if($('#info-' + id)
-                  .is(':checked')) {
-                  var save = {};
-                  save['info.' + id] = 1;
-                  chrome.storage.sync.set(save, function(e) {});
-                }
-              }
-            });
+            if(content.view) {
+              $http.get(content.view).then(function(changelog) {
+                showToaster(changelog.data);
+              });
+            } else {
+              showToaster(content.body);
+            }
           }
         });
       }

--- a/app/views/changelog-toaster.html
+++ b/app/views/changelog-toaster.html
@@ -13,8 +13,6 @@
   Visit us on Twitter and Reddit to learn more about these and other updates in v3.5.4
 <p>
   Follow us on: <a style="margin: 0 5px;" href="http://destinyitemmanager.reddit.com"
-  target="_blank"><i<i class="fa fa-reddit fa-2x"></i></a> <a style="margin: 0 5px;"
+  target="_blank"><i class="fa fa-reddit fa-2x"></i></a> <a style="margin: 0 5px;"
   href="http://twitter.com/ThisIsDIM" target="_blank"><i class="fa fa-twitter fa-2x"></i></a>
 <p>
-  <input style="margin-top: 1px; vertical-align: middle;" id="20160411v35" type="checkbox">
-  <label for="20160411v35">Hide This Popup</label></p>


### PR DESCRIPTION
It seems some users are still unaware that items can be moved via drag and drop versus the move dialog. This PR adds a simple toaster that hints the other functionality. There is a function to 'not show the tip again'.

Functions just as the version bump toaster does.

![demo2](https://cloud.githubusercontent.com/assets/424158/14956834/c52260de-104f-11e6-8ef9-297e7d90c3c2.gif)



If we don't think this is necessary we can kill this PR.