### PR TITLE
Add an option to restore all items (not just equipped) when restoring to before loadout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Stat bars are more accurately sized.
 * It is no longer possible to choose column sizes that cause the vault to disappear.
 * The Vault now has a character-style header, and can have loadouts applied to it. Full-ness of each vault is displayed below the vault header.
+* New option to restore all the items that were in your inventory before applying a loadout, rather than just the equipped ones.
+* You can now undo multiple loadouts, going backwards in time.
+
 
 # 3.6.1
 

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -131,7 +131,7 @@
     };
 
     vm.add = function add(item, $event) {
-      if (item.equipment || item.type === 'Material' || item.type === 'Consumable') {
+      if (item.canBeInLoadout()) {
         var clone = angular.copy(item);
 
         var discriminator = clone.type.toLowerCase();

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -17,34 +17,33 @@
       replace: true,
       template: [
         '<div class="loadout-popup-content">',
-        '  <div class="loadout-list"><div class="loadout-set">',
-        '    <span class="button-create" ng-click="vm.newLoadout($event)">+ Create Loadout</span>',
-        '    <span class="button-create-equipped" ng-click="vm.newLoadoutFromEquipped($event)">From Equipped</span>',
-        '  </div></div>',
-        '  <div class="loadout-list">',
-        '    <div ng-repeat="loadout in vm.loadouts track by loadout.id" class="loadout-set">',
-        '      <span class="button-name" title="{{ loadout.name }}" ng-click="vm.applyLoadout(loadout, $event)">{{ loadout.name }}</span>',
-        '      <span class="button-delete" ng-click="vm.deleteLoadout(loadout, $event)"><i class="fa fa-trash-o"></i></span>',
-        '      <span class="button-edit" ng-click="vm.editLoadout(loadout, $event)"><i class="fa fa-pencil"></i></span>',
-        '    </div>',
-        '  </div>',
-        '  <div class="loadout-list">',
-        '    <div class="loadout-set" ng-if="!vm.store.isVault">',
-        '      <span class="button-name button-full" ng-click="vm.maxLightLoadout($event)"><i class="fa fa-star"></i> Maximize Light</span>',
-        '    </div>',
-        '    <div class="loadout-set" ng-if="!vm.store.isVault">',
-        '      <span class="button-name button-full" ng-click="vm.itemLevelingLoadout($event)"><i class="fa fa-level-up"></i> Item Leveling</span>',
-        '    </div>',
-        '    <div class="loadout-set">',
-        '      <span class="button-name button-full" ng-click="vm.gatherEngramsLoadout($event)"><img class="fa" src="/images/engram.svg" height="12" width="12"/> Gather Engrams</span>',
-        '    </div>',
-        '    <div class="loadout-set" ng-if="!vm.store.isVault">',
-        '      <span class="button-name button-full" ng-click="vm.startFarmingEngrams($event)"><img class="fa" src="/images/engram.svg" height="12" width="12"/> Engrams to Vault</span>',
-        '    </div>',
-        '    <div class="loadout-set" ng-if="vm.previousLoadout">',
-        '      <span class="button-name button-full" ng-click="vm.applyLoadout(vm.previousLoadout, $event)"><i class="fa fa-undo"></i> {{vm.previousLoadout.name}}</span>',
-        '    </div>',
-        '  </div>',
+        '  <ul class="loadout-list">',
+        '    <li class="loadout-set">',
+        '      <span ng-click="vm.newLoadout($event)">+ Create Loadout</span>',
+        '      <span ng-click="vm.newLoadoutFromEquipped($event)">From Equipped</span>',
+        '    </li>',
+        '    <li ng-repeat="loadout in vm.loadouts track by loadout.id" class="loadout-set">',
+        '      <span title="{{ loadout.name }}" ng-click="vm.applyLoadout(loadout, $event)">{{ loadout.name }}</span>',
+        '      <span ng-click="vm.deleteLoadout(loadout, $event)"><i class="fa fa-trash-o"></i></span>',
+        '      <span ng-click="vm.editLoadout(loadout, $event)"><i class="fa fa-pencil"></i></span>',
+        '    </li>',
+        '    <li class="loadout-set" ng-if="!vm.store.isVault">',
+        '      <span ng-click="vm.maxLightLoadout($event)"><i class="fa fa-star"></i> Maximize Light</span>',
+        '    </li>',
+        '    <li class="loadout-set" ng-if="!vm.store.isVault">',
+        '      <span ng-click="vm.itemLevelingLoadout($event)"><i class="fa fa-level-up"></i> Item Leveling</span>',
+        '    </li>',
+        '    <li class="loadout-set">',
+        '      <span ng-click="vm.gatherEngramsLoadout($event)"><img class="fa" src="/images/engram.svg" height="12" width="12"/> Gather Engrams</span>',
+        '    </li>',
+        '    <li class="loadout-set" ng-if="!vm.store.isVault">',
+        '      <span ng-click="vm.startFarmingEngrams($event)"><img class="fa" src="/images/engram.svg" height="12" width="12"/> Engrams to Vault</span>',
+        '    </li>',
+        '    <li class="loadout-set" ng-if="vm.previousLoadout">',
+        '      <span title="{{ vm.previousLoadout.name }}" ng-click="vm.applyLoadout(vm.previousLoadout, $event, true)"><i class="fa fa-undo"></i> {{vm.previousLoadout.name}}</span>',
+        '      <span ng-click="vm.applyLoadout(vm.previousLoadout, $event)">All items</span>',
+        '    </li>',
+        '  </ul>',
         '</div>'
       ].join('')
     };
@@ -122,7 +121,9 @@
         name: name,
         items: _(items)
           .chain()
-          .select('equipped')
+          .select(function(item) {
+            return item.canBeInLoadout();
+          })
           .map(function (i) {
             return angular.copy(i);
           })
@@ -132,7 +133,7 @@
       };
     }
 
-    vm.applyLoadout = function applyLoadout(loadout, $event) {
+    vm.applyLoadout = function applyLoadout(loadout, $event, filterToEquipped) {
       ngDialog.closeAll();
       dimEngramFarmingService.stop();
 
@@ -143,6 +144,12 @@
           vm.previousLoadout = loadoutFromCurrentlyEquipped(vm.store.items, 'Before "' + loadout.name + '"');
         }
         dimLoadoutService.previousLoadouts[vm.store.id] = vm.previousLoadout; // ugly hack
+      }
+
+      if (filterToEquipped) {
+        loadout = _.mapObject(loadout, function(items) {
+          return _.select(items, 'equipped');
+        });
       }
 
       dimLoadoutService.applyLoadout(vm.store, loadout);

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -83,7 +83,7 @@
     vm.newLoadoutFromEquipped = function newLoadout($event) {
       ngDialog.closeAll();
 
-      var loadout = loadoutFromCurrentlyEquipped(vm.store.items, "");
+      var loadout = filterLoadoutToEquipped(loadoutFromCurrentlyEquipped(vm.store.items, ""));
       // We don't want to prepopulate the loadout with a bunch of cosmetic junk
       // like emblems and ships and horns.
       loadout.items = _.pick(loadout.items,
@@ -133,6 +133,14 @@
       };
     }
 
+    function filterLoadoutToEquipped(loadout) {
+      var filteredLoadout = angular.copy(loadout);
+      filteredLoadout.items = _.mapObject(filteredLoadout.items, function(items) {
+        return _.select(items, 'equipped');
+      });
+      return filteredLoadout;
+    }
+
     vm.applyLoadout = function applyLoadout(loadout, $event, filterToEquipped) {
       ngDialog.closeAll();
       dimEngramFarmingService.stop();
@@ -147,9 +155,7 @@
       }
 
       if (filterToEquipped) {
-        loadout = _.mapObject(loadout, function(items) {
-          return _.select(items, 'equipped');
-        });
+        loadout = filterLoadoutToEquipped(loadout);
       }
 
       dimLoadoutService.applyLoadout(vm.store, loadout);

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -53,7 +53,7 @@
 
   function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemService, dimItemTier, toaster, dimEngramFarmingService) {
     var vm = this;
-    vm.previousLoadout = dimLoadoutService.previousLoadouts[vm.store.id];
+    vm.previousLoadout = _.last(dimLoadoutService.previousLoadouts[vm.store.id]);
 
     vm.classTypeId = {
       'warlock': 0,
@@ -145,13 +145,17 @@
       ngDialog.closeAll();
       dimEngramFarmingService.stop();
 
+      if (!dimLoadoutService.previousLoadouts[vm.store.id]) {
+        dimLoadoutService.previousLoadouts[vm.store.id] = [];
+      }
+
       if (!vm.store.isVault) {
         if (loadout === vm.previousLoadout) {
-          vm.previousLoadout = undefined;
+          vm.previousLoadout = dimLoadoutService.previousLoadouts[vm.store.id].pop();
         } else {
           vm.previousLoadout = loadoutFromCurrentlyEquipped(vm.store.items, 'Before "' + loadout.name + '"');
+          dimLoadoutService.previousLoadouts[vm.store.id].push(vm.previousLoadout); // ugly hack
         }
-        dimLoadoutService.previousLoadouts[vm.store.id] = vm.previousLoadout; // ugly hack
       }
 
       if (filterToEquipped) {

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -117,6 +117,9 @@
       },
       isEngram: function() {
         return !this.equipment && this.typeName.toLowerCase().indexOf('engram') >= 0;
+      },
+      canBeInLoadout: function() {
+        return this.equipment || this.type === 'Material' || this.type === 'Consumable';
       }
     };
 

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -120,51 +120,6 @@ body > div, #header {
   /*min-width: 1000px;*/
 }
 
-.button-name {
-  float: left;
-  width: 60%;
-  padding-left: 10px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap !important;
-}
-
-.button-full {
-  width: 100%;
-}
-
-.button-create {
-  float: left;
-  width: 60%;
-  padding-left: 10px;
-  height: 35px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap !important;
-}
-
-.button-create-equipped {
-  text-align: center;
-  float: right;
-  width: 40%;
-}
-
-.button-delete, .button-edit {
-  text-align: center;
-}
-
-.loadout-set {
-  padding-left: 10px;
-}
-
-.loadout-list > .loadout-set {
-  padding-left: 0px;
-  overflow: hidden;
-  border-top: solid 1px #383838;
-  border-bottom: solid 1px #111;
-  background-color: #222;
-}
-
 .vault {
   flex: 1;
   .sort-class, .section.postmaster, .sort-class, .section.progress, .section.unknown .bucket-count {
@@ -1653,6 +1608,8 @@ g {
   margin: 0 2em;
 }
 
+/* Loadout editor */
+
 #loadout-drawer {
   left: 0;
   right: 0;
@@ -1699,44 +1656,59 @@ g {
   align-items: flex-start;
 }
 
-.loadout-list .loadout-set:hover, .loadout-new:hover, .loadout-options span:hover {
-  background-color: #151515;
-  border-top: solid 1px #151515;
-}
+/* Loadouts Dropdown */
 
 .loadout-list {
-  .button-name .fa {
-    width: 12px;
-    margin-right: 2px;
-    text-align: center;
-  }
-  img.fa {
-    transform: translateY(1px);
-  }
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .loadout-set {
-  .button-edit {
-    float: right;
-    width: 20%;
-    font-size: 1.2em;
+  display: flex;
+  flex-direction: row;
+  padding-left: 0px;
+  overflow: hidden;
+  border-top: solid 1px #383838;
+  border-bottom: solid 1px #111;
+  background-color: #222;
+
+  &:hover {
+    background-color: #151515;
+    border-top: solid 1px #151515;
   }
-  .button-delete {
-    float: right;
-    width: 20%;
-    font-size: 1.2em;
+
+  span:first-child {
+    flex: 1;
+    padding: 0 10px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap !important;
+    .fa {
+      width: 12px;
+      margin-right: 2px;
+      text-align: center;
+    }
+    img.fa {
+      transform: translateY(1px);
+    }
+  }
+
+  span:not(:first-child) {
+    padding: 0 12px;
+    text-align: center;
+    color: #888;
+    .fa {
+      font-size: 1.2em;
+    }
     &:hover {
       background-color: #68a0b7;
       color: #222;
     }
   }
-  .button-edit:hover, .button-create-equipped:hover {
-    background-color: #68a0b7;
-    color: #222;
-  }
 }
 
-.loadout-new {
+.button-extra {
   text-align: center;
 }
 


### PR DESCRIPTION
Video: http://screencast.com/t/zMx9dp5FvW

* In the attached video I start up engram farming mode via "Engrams to Vault"
* I then turn it off to simulate that I'm done farming
* I then click "Gather Engrams" which moves some engrams stored in the Vault to my Hunter
 * It's in this process that it has to make space in the Chest bucket to bring engrams over
* I simulate decrypting the engrams by manually moving them back to my Vault and off of my Hunter
* I then click "Before 'Gather Engrams'" hoping that my pre-'Gather Engrams' gear will be preserved and put back on my character but it is not

I mentioned in https://github.com/DestinyItemManager/DIM/pull/496 that I thought there might be a bug with the "Engrams to Vault" functionality, but I believe it's the "Before 'Gather Engrams'" part that's causing the 'gear moving around randomly' comments I made.