### PR TITLE
Loadout Delete Confirmation

### DIFF
--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -104,7 +104,9 @@
     };
 
     vm.deleteLoadout = function deleteLoadout(loadout, $event) {
-      dimLoadoutService.deleteLoadout(loadout);
+      if (confirm("Are you sure you want to delete '" + loadout.name + "'?")) {
+        dimLoadoutService.deleteLoadout(loadout);
+      }
     };
 
     vm.editLoadout = function editLoadout(loadout, $event) {


### PR DESCRIPTION
Accidentally fat-fingered the delete button a few times.  It burns.  Can we confirm that the user wants to delete their loadout?