### PR TITLE
Display weapon history

### DIFF
--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -36,6 +36,7 @@
         '  <div ng-style="{ width: vm.item.percentComplete + \'%\' }"></div>',
         '</div>',
         '<div class="item-description" ng-if="vm.itemDetails && vm.showDescription" ng-bind="::vm.item.description"></div>',
+        '<div class="item-description" ng-if="vm.item.kills">{{vm.item.kills}} kills ({{vm.item.precisionKills}} precision) with this character.</div>',
         '<div class="item-details" ng-if="vm.item.classified">Classified item. Bungie does not yet provide information about this item. Item is not yet transferable.</div>',
         '<div class="item-details" ng-if="vm.itemDetails && vm.hasDetails">',
         '  <div ng-if="vm.classType && vm.classType !==\'Unknown\'" class="stat-box-row">',
@@ -79,9 +80,9 @@
     };
   }
 
-  MoveItemPropertiesCtrl.$inject = ['$sce', '$q', 'dimStoreService', 'dimItemService', 'dimSettingsService', 'ngDialog', '$scope', '$rootScope'];
+  MoveItemPropertiesCtrl.$inject = ['$sce', '$q', 'dimStoreService', 'dimItemService', 'dimSettingsService', 'ngDialog', '$scope', '$rootScope', 'dimBungieService', 'dimPlatformService'];
 
-  function MoveItemPropertiesCtrl($sce, $q, storeService, itemService, settings, ngDialog, $scope, $rootScope) {
+  function MoveItemPropertiesCtrl($sce, $q, storeService, itemService, settings, ngDialog, $scope, $rootScope, dimBungieService, dimPlatformService) {
     var vm = this;
 
     vm.hasDetails = (vm.item.stats && vm.item.stats.length) ||
@@ -164,6 +165,14 @@
       .then(function(show) {
         vm.itemQuality = vm.itemQuality || show;
       });
+
+    dimBungieService.getWeaponHistory(dimPlatformService.getActive(), vm.item.owner).then(function (history) {
+      var weaponHistory = history[vm.item.hash];
+      if (weaponHistory) {
+        vm.item.kills = weaponHistory.uniqueWeaponKills.basic.value;
+        vm.item.precisionKills = weaponHistory.uniqueWeaponPrecisionKills.basic.value;
+      }
+    });
 
     if (vm.item.primStat) {
       vm.light = vm.item.primStat.value.toString();


### PR DESCRIPTION
Opening a PR for comment - I'm not sure if this is a real thing we want, but I had it lying around in a branch.

<img width="421" alt="screen shot 2016-05-08 at 9 56 39 am" src="https://cloud.githubusercontent.com/assets/313208/15099171/3e68ce44-1503-11e6-910c-6d87c082cee6.png">

This adds kill stats for certain weapons. It only shows kills from the character the weapon's currently equipped on. It doesn't show anything from the vault. I guess I could call this three times to get a sum across all characters. I also don't really know what the stats mean - I assume they're both PvP and PvE kills.