### PR TITLE
Stat Bars in Move Popup are not accurate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Next
 
+* Add warning if the lost items section of the postmaster has 20 items.
+* Stat bars are more accurately sized.
+
+# 3.6.1
+
 * Removed the "Only blues" option in the infusion fuel finder, because it wasn't necessary.
 * Engram searches and the engram loadout features won't mistake Candy Engrams for real engrams.
 * Items in the Postmaster include their type in the move popup, so they're easier to distinguish.
 * Sometimes equipping loadouts would fail to equip one of your exotics. No more!
 * Add an 'is:infusable' search filter.
 * Add 'is:intellect', 'is:discipline', 'is:strength' search filters for armor.
-* Add warning if the lost items section of the postmaster has 20 items.
 * XP Progress on bar items
 
 # 3.6.0

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1388,14 +1388,6 @@ rzslider {
   .lower-stats {
     color: #985C58;
   }
-  .stat-box-inner {
-    &.higher-stats {
-      background-color: #7DC878;
-    }
-    &.lower-stats {
-      background-color: #985C58;
-    }
-  }
   .stat-box-outer {
     display: block;
     height: 14px;
@@ -1413,11 +1405,12 @@ rzslider {
     background-color: #333;
     background-color: white;
     color: black;
-    padding-left: 5px;
     line-height: 20px;
-    border-right: solid 1px #000;
-    &:last-child {
-      border-right: none;
+    &.higher-stats {
+      background-color: #7DC878;
+    }
+    &.lower-stats {
+      background-color: #985C58;
     }
   }
   .stat-box-outer span:last-child {


### PR DESCRIPTION
Looking at this image, both items are at 43, but the stat bars are not equal.  What's up here?

![image](https://cloud.githubusercontent.com/assets/984608/15219756/8dbfceaa-182a-11e6-8ac8-8a79c97655e5.png)
