### PR TITLE
now support min-max ranges for qualities

### DIFF
--- a/app/scripts/minmax/dimMinMax.controller.js
+++ b/app/scripts/minmax/dimMinMax.controller.js
@@ -30,9 +30,21 @@
             //{item: _.max(bucket[armortype], function(o){var stats = (_.findWhere(o.normalStats, {statHash: 144602215}) || {scaled: 0, bonus: 0}); return  stats.scaled + stats.bonus;}), bonus_type: 'int'}, // best int_w_bonus
             //{item: _.max(bucket[armortype], function(o){var stats = (_.findWhere(o.normalStats, {statHash: 1735777505}) || {scaled: 0, bonus: 0}); return stats.scaled + stats.bonus;}), bonus_type: 'disc'}, // best dis_w_bonus
             //{item: _.max(bucket[armortype], function(o){var stats = (_.findWhere(o.normalStats, {statHash: 4244567218}) || {scaled: 0, bonus: 0}); return stats.scaled + stats.bonus;}), bonus_type: 'str'}, // best str_w_bonus
-            {item: _.max(bucket[armortype], function(o){var int_stats = (_.findWhere(o.normalStats, {statHash: 144602215}) || {scaled: 0, bonus: 0}); var disc_stats = (_.findWhere(o.normalStats, {statHash: 1735777505}) || {scaled: 0, bonus: 0}); return int_stats.scaled + int_stats.bonus + disc_stats.scaled; }), bonus_type: 'intdisc'}, // best int + bonus + dis
-            {item: _.max(bucket[armortype], function(o){var int_stats = (_.findWhere(o.normalStats, {statHash: 144602215}) || {scaled: 0, bonus: 0}); var str_stats = (_.findWhere(o.normalStats, {statHash: 4244567218}) || {scaled: 0, bonus: 0}); return int_stats.scaled + int_stats.bonus + str_stats.scaled; }), bonus_type: 'intstr'}, // best int + bonus + str
-            {item: _.max(bucket[armortype], function(o){var disc_stats = (_.findWhere(o.normalStats, {statHash: 1735777505}) || {scaled: 0, bonus: 0}); var str_stats = (_.findWhere(o.normalStats, {statHash: 4244567218}) || {scaled: 0, bonus: 0}); return disc_stats.scaled + str_stats.scaled + str_stats.bonus; }), bonus_type: 'discstr'}, // best dis + bonus + str            
+              {item: _.max(bucket[armortype], function(o){
+                var int_stats = (_.findWhere(o.normalStats, {statHash: 144602215}) || {scaled: 0, bonus: 0});
+                var disc_stats = (_.findWhere(o.normalStats, {statHash: 1735777505}) || {scaled: 0, bonus: 0});
+                return int_stats.scaled + int_stats.bonus + disc_stats.scaled; }), bonus_type: 'intdisc'
+              }, // best int + bonus + dis
+              {item: _.max(bucket[armortype], function(o){
+                var int_stats = (_.findWhere(o.normalStats, {statHash: 144602215}) || {scaled: 0, bonus: 0});
+                var str_stats = (_.findWhere(o.normalStats, {statHash: 4244567218}) || {scaled: 0, bonus: 0});
+                return int_stats.scaled + int_stats.bonus + str_stats.scaled; }), bonus_type: 'intstr'
+              }, // best int + bonus + str
+              {item: _.max(bucket[armortype], function(o){
+                var disc_stats = (_.findWhere(o.normalStats, {statHash: 1735777505}) || {scaled: 0, bonus: 0});
+                var str_stats = (_.findWhere(o.normalStats, {statHash: 4244567218}) || {scaled: 0, bonus: 0});
+                return disc_stats.scaled + str_stats.scaled + str_stats.bonus; }), bonus_type: 'discstr'
+              }, // best dis + bonus + str
             ];
             if(armortype.toLowerCase() !== 'classitem') {
                 // Best needs to include a non-exotic if the max is an exotic item
@@ -44,13 +56,13 @@
                 //        best_non_exotic.push({item: _.max(bucket[armortype], function(o){if (o.tier === 'Exotic') { return 0; } var stats = (_.findWhere(o.normalStats, {statHash: hash}) || {scaled: 0, bonus: 0}); return  stats.scaled + stats.bonus;}), bonus_type: ''});
                 //    }
                 //}
-                if(best[0].item.tier === 'Exotic') { 
+                if(best[0].item.tier === 'Exotic') {
                     best_non_exotic.push({item: _.max(bucket[armortype], function(o){ if (o.tier === 'Exotic') { return 0; } var int_stats = (_.findWhere(o.normalStats, {statHash: 144602215}) || {scaled: 0, bonus: 0}); var disc_stats = (_.findWhere(o.normalStats, {statHash: 1735777505}) || {scaled: 0, bonus: 0}); return int_stats.scaled + int_stats.bonus + disc_stats.scaled; }), bonus_type: ''});
                 }
-                if(best[1].item.tier === 'Exotic') { 
+                if(best[1].item.tier === 'Exotic') {
                     best_non_exotic.push({item: _.max(bucket[armortype], function(o){ if (o.tier === 'Exotic') { return 0; } var int_stats = (_.findWhere(o.normalStats, {statHash: 144602215}) || {scaled: 0, bonus: 0}); var str_stats = (_.findWhere(o.normalStats, {statHash: 4244567218}) || {scaled: 0, bonus: 0}); return int_stats.scaled + int_stats.bonus + str_stats.scaled; }), bonus_type: ''});
                 }
-                if(best[2].item.tier === 'Exotic') { 
+                if(best[2].item.tier === 'Exotic') {
                     best_non_exotic.push({item: _.max(bucket[armortype], function(o){ if (o.tier === 'Exotic') { return 0; } var disc_stats = (_.findWhere(o.normalStats, {statHash: 1735777505}) || {scaled: 0, bonus: 0}); var str_stats = (_.findWhere(o.normalStats, {statHash: 4244567218}) || {scaled: 0, bonus: 0}); return disc_stats.scaled + disc_stats.bonus + str_stats.scaled; }), bonus_type: ''});
                 }
                 best = best.concat(best_non_exotic);
@@ -217,7 +229,7 @@
             var classItems = bestArmor['classItem'] || [];
             var ghosts = bestArmor['ghost'] || [];
             var artifacts = bestArmor['artifact'] || [];
-            
+
             if(helms.length == 0 || gaunts.length == 0 || chests.length == 0 ||
                 legs.length == 0 || classItems.length == 0 || ghosts.length == 0 || artifacts.length == 0) {
                 return null;
@@ -228,7 +240,7 @@
                 var total = 0;
                 _.each(set.armor, function(armor) {
                     var stat = _.findWhere(armor.item.normalStats, {statHash: hash}) || {scaled: 0, bonus: 0};
-                    total += stat.scaled.min + (armor.bonus_type == target_type ? stat.bonus : 0);
+                    total += stat.scaled + (armor.bonus_type == target_type ? stat.bonus : 0);
                 });
                 return total;
             };
@@ -271,9 +283,9 @@
                         return;
                     }
                 } ar = 0; } gh = 0; } ci = 0; } l = 0; } c = 0; } g = 0; }
-                
+
                 var tiers = _.each(_.groupBy(Object.keys(set_map), function(set) {
-                    return _.reduce(set.split('/'), function(memo, num){ 
+                    return _.reduce(set.split('/'), function(memo, num){
                         return memo + parseInt(num); }, 0);;
                 }), function(tier) {
                     tier.sort().reverse();
@@ -294,6 +306,7 @@
                 vm.progress = processed_count/combos;
                 console.timeEnd('elapsed');
                 vm.topsets = vm.getTopSets(vm.highestsets[vm.activesets]);
+              console.log('done')
             }
             console.time('elapsed');
             $timeout(step, 0, true, activeGaurdian, 0,0,0,0,0,0,0,0);
@@ -305,10 +318,10 @@
             return {
               statHash: stat.statHash,
               base: (stat.base*(vm.doNormalize ? vm.normalize : item.primStat.value)/item.primStat.value).toFixed(0),
-              scaled: stat.scaled.min,
+              scaled: stat.scaled ? stat.scaled.min : 0,
               bonus: stat.bonus,
               split: stat.split,
-              qualityPercentage: stat.qualityPercentage.min
+              qualityPercentage: stat.qualityPercentage ? stat.qualityPercentage.min : 0
             };
           });
           return item;

--- a/app/scripts/minmax/dimMinMax.controller.js
+++ b/app/scripts/minmax/dimMinMax.controller.js
@@ -244,7 +244,7 @@
                 var total = 0;
                 _.each(set.armor, function(armor) {
                     var stat = _.findWhere(armor.item.normalStats, {statHash: hash}) || {scaled: 0, bonus: 0};
-                    total += stat.scaled + (armor.bonus_type == target_type ? stat.bonus : 0);
+                    total += stat.scaled.min + (armor.bonus_type == target_type ? stat.bonus : 0);
                 });
                 return total;
             };
@@ -324,10 +324,10 @@
             return {
               statHash: stat.statHash,
               base: (stat.base*(vm.doNormalize ? vm.normalize : item.primStat.value)/item.primStat.value).toFixed(0),
-              scaled: stat.scaled,
+              scaled: stat.scaled.min,
               bonus: stat.bonus,
               split: stat.split,
-              qualityPercentage: stat.qualityPercentage
+              qualityPercentage: stat.qualityPercentage.min
             };
           });
           return item;

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -52,12 +52,12 @@
         '       <span ng-if="!stat.bar && (!stat.equippedStatsName || stat.comparable)" ng-class="{ \'higher-stats\': (stat.value > stat.equippedStatsValue), \'lower-stats\': (stat.value < stat.equippedStatsValue)}">{{ stat.value }}</span>',
         '     </span>',
         '     <span class="stat-box-val stat-box-cell" ng-class="{ \'higher-stats\': (stat.value > stat.equippedStatsValue && stat.comparable), \'lower-stats\': (stat.value < stat.equippedStatsValue && stat.comparable)}" ng-show="{{ stat.bar }}">{{ stat.value }}',
-        '       <span ng-show="vm.itemQuality && stat.qualityPercentage" ng-class="{ \'show-quality\': vm.itemQuality && stat.qualityPercentage }" ng-show="{{ stat.bar }}" ng-style="stat.qualityPercentage | qualityColor:\'color\'">({{ stat.qualityPercentage }}%)</span>',
+        '       <span ng-show="vm.itemQuality && stat.qualityPercentage.min" ng-class="{ \'show-quality\': vm.itemQuality && stat.qualityPercentage.min }" ng-show="{{ stat.bar }}" ng-style="stat.qualityPercentage.min | qualityColor:\'color\'">({{ vm.getStatRange(stat) }})</span>',
         '     </span>',
         '  </div>',
-        '  <div class="stat-box-row" ng-if="vm.item.quality">',
+        '  <div class="stat-box-row" ng-if="vm.item.quality && vm.item.quality.min">',
         '    <span class="stat-box-text stat-box-cell">Stats quality</span>',
-        '    <span class="stat-box-cell" ng-style="vm.item.quality | qualityColor:\'color\'">{{ vm.item.quality }}% of max possible roll</span>',
+        '    <span class="stat-box-cell" ng-style="vm.item.quality.min | qualityColor:\'color\'">{{ vm.getItemQualityRange() }} of max possible roll</span>',
         '  </div>',
         '</div>',
         '<div class="item-details item-perks" ng-if="vm.item.talentGrid && vm.itemDetails">',
@@ -150,6 +150,21 @@
         vm.light += ' Attack';
         vm.classes['is-' + vm.item.dmg] = true;
       }
+    }
+
+    vm.getStatRange = function(stat) {
+      if(!stat.qualityPercentage) {
+        return '';
+      }
+      return ((stat.qualityPercentage.min === stat.qualityPercentage.max || vm.item.primStat.value === 335) ?
+        stat.qualityPercentage.min :
+        (stat.qualityPercentage.min + "%-" +  stat.qualityPercentage.max)) + '%';
+    }
+
+    vm.getItemQualityRange = function() {
+      return ((vm.item.quality.min === vm.item.quality.max || vm.item.primStat.value === 335) ?
+        vm.item.quality.min :
+        (vm.item.quality.min + "%-" +  vm.item.quality.max)) + '%';
     }
 
     function compareItems(item) {

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -57,7 +57,7 @@
         '      <div dim-percent-width="vm.item.percentComplete"></div>',
         '    </div>',
         '    <div class="img" dim-bungie-image-fallback="::vm.item.icon" ng-click="vm.clicked(vm.item, $event)">',
-        '    <div ng-if="vm.item.quality" class="item-stat item-quality" ng-style="vm.item.quality | qualityColor">{{ vm.item.quality }}%</div>',
+        '    <div ng-if="vm.item.quality" class="item-stat item-quality" ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>',
         '    <img class="element" ng-if=":: vm.item.dmg && vm.item.dmg !== \'kinetic\'" ng-src="/images/{{::vm.item.dmg}}.png"/>',
         '    <div ng-class="vm.badgeClassNames" ng-if="vm.showBadge">{{ vm.badgeCount }}</div>',
         '    <div ng-if="::vm.item.dmg" class="damage-type damage-{{::vm.item.dmg}}"></div>',
@@ -160,7 +160,7 @@
       }
 
       scope.$watch('vm.item.quality', function() {
-        vm.badgeClassNames['item-stat-no-bg'] = (vm.item.quality > 0);
+        vm.badgeClassNames['item-stat-no-bg'] = (vm.item.quality && vm.item.quality.min > 0);
       });
     }
   }

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -20,7 +20,7 @@
         }
         if (sort === 'quality') {
           items = _.sortBy(items, function(item) {
-            return item.quality ? -item.quality : 1000;
+            return item.quality && item.quality.min ? -item.quality.min : 1000;
           });
         }
         if (sort === 'rarity' || sort === 'rarityThenPrimary') {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -2113,7 +2113,7 @@ button.toast-close-button {
 
 .sort-progression, .sort-lost-items, .sort-messages, .sort-special-orders,  .sort-consumable, .sort-material, .sort-bounties, .sort-quests, .sort-missions {
   .unequipped {
-    margin-left: 12px;
+    margin-left: 0px;
     margin-right: 20px;
   }
 }

--- a/app/views/best.html
+++ b/app/views/best.html
@@ -31,9 +31,9 @@
       <span ng-repeat="item in normal.ranked[normal.type] | orderBy:'-quality'">
         <div ng-if="item.primStat.value >= 280" style='display: inline-block; padding: 3px 0 0 3px'>
           <div style='display:inline-block;margin-bottom:20px;'>
-            <div ng-repeat="stat in item.stats track by $index" ng-init="normalStat = item.normalStats[$index]" ng-style="normalStat.qualityPercentage | qualityColor:'color'">
-              <small ng-if="normalStat.scaled === 0">-</small>
-              <span ng-if="normalStat.scaled > 0"><small ng-bind="normalStat.scaled"></small>/<small ng-bind="stat.split"></small></span>
+            <div ng-repeat="stat in item.stats track by $index" ng-init="normalStat = item.normalStats[$index]" ng-style="normalStat.qualityPercentage.min | qualityColor:'color'">
+              <small ng-if="normalStat.scaled.min === 0">-</small>
+              <span ng-if="normalStat.scaled.min > 0"><small ng-bind="normalStat.scaled.min"></small>/<small ng-bind="stat.split"></small></span>
             </div>
           </div>
           <div dim-store-item item-data="item" store-data="normal.getStore(item.owner)"></div>

--- a/app/views/best.html
+++ b/app/views/best.html
@@ -31,9 +31,9 @@
       <span ng-repeat="item in normal.ranked[normal.type] | orderBy:'-quality'">
         <div ng-if="item.primStat.value >= 280" style='display: inline-block; padding: 3px 0 0 3px'>
           <div style='display:inline-block;margin-bottom:20px;'>
-            <div ng-repeat="stat in item.stats track by $index" ng-init="normalStat = item.normalStats[$index]" ng-style="normalStat.qualityPercentage.min | qualityColor:'color'">
-              <small ng-if="normalStat.scaled.min === 0">-</small>
-              <span ng-if="normalStat.scaled.min > 0"><small ng-bind="normalStat.scaled.min"></small>/<small ng-bind="stat.split"></small></span>
+            <div ng-repeat="stat in item.stats track by $index" ng-init="normalStat = item.normalStats[$index]" ng-style="normalStat.qualityPercentage | qualityColor:'color'">
+              <small ng-if="normalStat.scaled === 0">-</small>
+              <span ng-if="normalStat.scaled > 0"><small ng-bind="normalStat.scaled"></small>/<small ng-bind="stat.split"></small></span>
             </div>
           </div>
           <div dim-store-item item-data="item" store-data="normal.getStore(item.owner)"></div>


### PR DESCRIPTION
Update the scaling formula....

Items < 335 it shows a range
<img width="350" alt="screen shot 2016-06-03 at 4 24 13 pm" src="https://cloud.githubusercontent.com/assets/424158/15791868/ccb25ea0-29a7-11e6-9e40-763919ad906b.png">

Items that are 335, or if the `quality.min === quality.max` then it just shows one number (`98%` instead of showing `98% - 98%`)
<img width="349" alt="screen shot 2016-06-03 at 4 24 20 pm" src="https://cloud.githubusercontent.com/assets/424158/15791871/ce28db4c-29a7-11e6-9fc1-6dc8e93b7e03.png">
<img width="349" alt="screen shot 2016-06-03 at 5 46 30 pm" src="https://cloud.githubusercontent.com/assets/424158/15793609/257f9218-29b3-11e6-9453-ed87a57fc7e7.png">


Everything (the badges/t12 armor builder/etc) looks at the `min` side, so that we err on the side of caution. The gap between min and max closes as the item approaches light level 335.
