### PR TITLE
Fix for issue in relation to #557 rounding error in calculation of scaled stat 

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -771,8 +771,8 @@
       var max = 335;
 
       return {
-        min: Math.floor((base)*fitValue(max)/fitValue(light)),
-        max: Math.floor((base+1)*fitValue(max)/fitValue(light))
+        min: Math.floor((base)*(fitValue(max)/fitValue(light))),
+        max: Math.floor((base+1)*(fitValue(max)/fitValue(light)))
       }
     }
 


### PR DESCRIPTION
Related to issue #557 

This is kind of tricky but the parentheses prevent the possibility of being off by one on the scaled stat due to floating point error and use of the floor operator.

For example, I had a 335 class item with 25 int and 24 dis and the scaled stat was showing as 23 for dis. This is because <code>(24*fitValue(335)/fitValue(335) == 23.9999...</code> which becomes 23 when floored. 

Using <code>24*(fitValue(335)/fitValue(335))</code> gives the correct results.

![image](https://cloud.githubusercontent.com/assets/4594931/15846024/b3563492-2c3e-11e6-95f9-57e35c8cd7ea.png)


