### PR TITLE
Separate concepts of "type" and "location" and use buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * Removed the option to hide or show the primary stat of items - it's always shown now.
+* Items in the postmaster now have quality ratings, can use the infusion fuel finder, show up in the infusion fuel finder, compare against currently equipped items, etc. They behave just like a normal item except you can't move them and they're in a different spot.
 
 # 3.7.3
 
@@ -40,7 +41,6 @@
 * The Vault now has a character-style header, and can have loadouts applied to it. Full-ness of each vault is displayed below the vault header.
 * New option to restore all the items that were in your inventory before applying a loadout, rather than just the equipped ones.
 * You can now undo multiple loadouts, going backwards in time.
-* Items in the postmaster now have quality ratings, can use the infusion fuel finder, show up in the infusion fuel finder, compare against currently equipped items, etc. They behave just like a normal item except you can't move them and they're in a different spot.
 
 # 3.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * The Vault now has a character-style header, and can have loadouts applied to it. Full-ness of each vault is displayed below the vault header.
 * New option to restore all the items that were in your inventory before applying a loadout, rather than just the equipped ones.
 * You can now undo multiple loadouts, going backwards in time.
+* Items in the postmaster now have quality ratings, can use the infusion fuel finder, show up in the infusion fuel finder, compare against currently equipped items, etc. They behave just like a normal item except you can't move them and they're in a different spot.
 
 # 3.6.1
 

--- a/app/index.html
+++ b/app/index.html
@@ -76,6 +76,7 @@
     <script src="scripts/services/dimActionQueue.factory.js?v=3.7.3"></script>
     <script src="scripts/services/dimBungieService.factory.js?v=3.7.3"></script>
     <script src="scripts/services/dimDefinitions.factory.js?v=3.7.3"></script>
+    <script src="scripts/services/dimBucketService.factory.js?v=3.7.3"></script>
     <script src="scripts/services/dimInfoService.factory.js?v=3.7.3"></script>
     <script src="scripts/services/dimPlatformService.factory.js?v=3.7.3"></script>
     <script src="scripts/services/dimLoadoutService.factory.js?v=3.7.3"></script>

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -18,43 +18,6 @@
       uncommon: 'Uncommon',
       basic: 'Basic'
     })
-    .value('dimCategory', {
-      Weapons: [
-        'Class',
-        'Primary',
-        'Special',
-        'Heavy',
-      ],
-      Armor: [
-        'Helmet',
-        'Gauntlets',
-        'Chest',
-        'Leg',
-        'ClassItem'
-      ],
-      General: [
-        'Artifact',
-        'Ghost',
-        'Consumable',
-        'Material',
-        'Emblem',
-        'Shader',
-        'Emote',
-        'Ship',
-        'Vehicle',
-        'Horn',
-      ],
-      Progress: [
-        'Bounties',
-        'Quests',
-        'Missions',
-      ],
-      Postmaster: [
-        'Lost Items',
-        'Special Orders',
-        'Messages'
-      ]
-    })
     .factory('loadingTracker', ['promiseTracker', function(promiseTracker) {
       return promiseTracker();
     }]);

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -86,8 +86,8 @@
       },
 
       transferItems: function() {
-        if (vm.source.notransfer) {
-          toaster.pop('error', 'Transfer infusion material', vm.source.name + " can't be moved.");
+        if (vm.target.notransfer) {
+          toaster.pop('error', 'Transfer infusion material', vm.target.name + " can't be moved.");
           return $q.resolve();
         }
         var store = dimStoreService.getStore(vm.source.owner);

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .controller('dimInfuseCtrl', dimInfuseCtrl);
 
-  dimInfuseCtrl.$inject = ['$scope', 'dimStoreService', 'dimItemService', 'ngDialog', 'dimLoadoutService'];
+  dimInfuseCtrl.$inject = ['$scope', 'dimStoreService', 'dimItemService', 'ngDialog', 'dimLoadoutService', 'toaster'];
 
-  function dimInfuseCtrl($scope, dimStoreService, dimItemService, ngDialog, dimLoadoutService) {
+  function dimInfuseCtrl($scope, dimStoreService, dimItemService, ngDialog, dimLoadoutService, toaster) {
     var vm = this;
 
     angular.extend(vm, {
@@ -27,11 +27,11 @@
           vm.source.primStat.statHash === 3897883278 ? 'Defense' : // armor item
           vm.source.primStat.statHash === 368428387 ?  'Attack' :  // weapon item
                                                        'Unknown'; // new item?
-        vm.wildcardMaterialIcon = item.sort === 'General' ? '2e026fc67d445e5b2630277aa794b4b1' :
+        vm.wildcardMaterialIcon = item.bucket.sort === 'General' ? '2e026fc67d445e5b2630277aa794b4b1' :
           vm.statType === 'Attack' ? 'f2572a4949fb16df87ba9760f713dac3' : '972ae2c6ccbf59cde293a2ed50a57a93';
         vm.wildcardMaterialIcon = '/common/destiny_content/icons/' + vm.wildcardMaterialIcon + '.jpg';
         // 2 motes, or 10 armor/weapon materials
-        vm.wildcardMaterialCost = item.sort === 'General' ? 2 : 10;
+        vm.wildcardMaterialCost = item.bucket.sort === 'General' ? 2 : 10;
       },
 
       selectItem: function(item, e) {
@@ -86,6 +86,10 @@
       },
 
       transferItems: function() {
+        if (vm.source.notransfer) {
+          toaster.pop('error', 'Transfer infusion material', vm.source.name + " can't be moved.");
+          return $q.resolve();
+        }
         var store = dimStoreService.getStore(vm.source.owner);
         var items = {};
         var key = vm.target.type.toLowerCase();
@@ -97,7 +101,7 @@
         items[vm.source.type.toLowerCase()].push(vm.source);
 
         items['material'] = [];
-        if (vm.sort === 'General') {
+        if (vm.bucket.sort === 'General') {
           // Mote of Light
           items['material'].push({
             id: '0',

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -212,7 +212,7 @@
               .values()
               .flatten()
               .findWhere({
-                sort: item.sort,
+                sort: item.bucket.sort,
                 tier: dimItemTier.exotic,
                 equipped: true
               })

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -273,7 +273,7 @@
     // A dynamic loadout set up to level weapons and armor
     vm.gatherEngramsLoadout = function gatherEngramsLoadout($event) {
       var engrams = _.select(dimItemService.getItems(), function(i) {
-        return i.isEngram() && i.sort !== 'Postmaster';
+        return i.isEngram() && i.location.isPostmaster;
       });
 
       if (engrams.length === 0) {

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -28,7 +28,7 @@
         '  <span><img class="title-element" ng-if=":: vm.item.dmg && vm.item.dmg !== \'kinetic\'" ng-src="/images/{{::vm.item.dmg}}.png"/>',
         '    <a target="_new" href="http://db.destinytracker.com/inventory/item/{{vm.item.hash}}">{{vm.title}}</a></span>',
         '  <span ng-if="vm.light" ng-bind="vm.light"></span>',
-        '  <span ng-if="::vm.item.sort == \'Weapons\' || vm.item.sort ==\'Postmaster\'" ng-bind="::vm.item.typeName"></span>',
+        '  <span ng-if="::vm.item.bucket.inWeapons || vm.item.location.inPostmaster" ng-bind="::vm.item.typeName"></span>',
         '  <span ng-if="(vm.item.type === \'Bounties\' || vm.item.type ===\'Quests\') && !vm.item.complete" class="bounty-progress"> | {{vm.item.percentComplete | percent}}</span>',
         '  <span class="pull-right move-popup-info-detail" ng-click="vm.itemDetails = !vm.itemDetails;" ng-if="!vm.showDetailsByDefault && (vm.showDescription || vm.hasDetails) && !vm.item.classified"><span class="fa fa-info-circle"></span></span>',
         '</div>',

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -29,7 +29,7 @@
         '    <a target="_new" href="http://db.destinytracker.com/inventory/item/{{vm.item.hash}}">{{vm.title}}</a></span>',
         '  <span ng-if="vm.light" ng-bind="vm.light"></span>',
         '  <span ng-if="::vm.item.sort == \'Weapons\' || vm.item.sort ==\'Postmaster\'" ng-bind="::vm.item.typeName"></span>',
-        '  <span ng-if="vm.item.type === \'Bounties\' && !vm.item.complete" class="bounty-progress"> | {{vm.item.percentComplete | percent}}</span>',
+        '  <span ng-if="(vm.item.type === \'Bounties\' || vm.item.type ===\'Quests\') && !vm.item.complete" class="bounty-progress"> | {{vm.item.percentComplete | percent}}</span>',
         '  <span class="pull-right move-popup-info-detail" ng-click="vm.itemDetails = !vm.itemDetails;" ng-if="!vm.showDetailsByDefault && (vm.showDescription || vm.hasDetails) && !vm.item.classified"><span class="fa fa-info-circle"></span></span>',
         '</div>',
         '<div class="item-xp-bar" ng-if="vm.item.percentComplete != null && !vm.item.complete">',

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -47,7 +47,7 @@
         '      ng-if="!vm.item.notransfer && vm.item.maxStackSize > 1" ng-click="vm.distribute()">',
         '      <span>Split</span>',
         '    </div>',
-        '  <div class="infuse-perk" ng-if="vm.item.talentGrid.infusable && vm.item.location.inPostmaster" ng-click="vm.infuse(vm.item, $event)" title="Infusion fuel finder" alt="Infusion calculator" ng-style="{ \'background-image\': \'url(/images/\' + vm.item.sort + \'.png)\' }"></div>',
+        '  <div class="infuse-perk" ng-if="vm.item.talentGrid.infusable" ng-click="vm.infuse(vm.item, $event)" title="Infusion fuel finder" alt="Infusion calculator" ng-style="{ \'background-image\': \'url(/images/\' + vm.item.bucket.sort + \'.png)\' }"></div>',
         '  </div>',
         '</div>'
       ].join('')

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -34,7 +34,7 @@
         '        <span>Store</span>',
         '      </div>',
         '      <div class="move-button move-equip" alt="{{::vm.characterInfo(store) }}" title="{{::vm.characterInfo(store) }}" ',
-        '        ng-if="vm.canShowEquip(vm.item, vm.store, store)" ng-click="vm.moveItemTo(store, true)" ',
+        '        ng-if="vm.item.canBeEquippedBy(store)" ng-click="vm.moveItemTo(store, true)" ',
         '        data-type="equip" data-character="{{::store.id}}" style="background-image: url({{::store.icon}})">',
         '        <span>Equip</span>',
         '      </div>',
@@ -47,7 +47,7 @@
         '      ng-if="!vm.item.notransfer && vm.item.maxStackSize > 1" ng-click="vm.distribute()">',
         '      <span>Split</span>',
         '    </div>',
-        '  <div class="infuse-perk" ng-if="vm.item.talentGrid.infusable && vm.item.sort !== \'Postmaster\'" ng-click="vm.infuse(vm.item, $event)" title="Infusion fuel finder" alt="Infusion calculator" ng-style="{ \'background-image\': \'url(/images/\' + vm.item.sort + \'.png)\' }"></div>',
+        '  <div class="infuse-perk" ng-if="vm.item.talentGrid.infusable && vm.item.location.inPostmaster" ng-click="vm.infuse(vm.item, $event)" title="Infusion fuel finder" alt="Infusion calculator" ng-style="{ \'background-image\': \'url(/images/\' + vm.item.sort + \'.png)\' }"></div>',
         '  </div>',
         '</div>'
       ].join('')
@@ -77,9 +77,6 @@
     * the selected item
     */
     vm.infuse = function infuse(item, e) {
-      if (item.sort === 'Postmaster') {
-        return;
-      }
       e.stopPropagation();
 
       // Close the move-popup
@@ -143,7 +140,7 @@
       var promise = $q.all(stores.map(function(store) {
         // First move everything into the vault
         var item = _.find(store.items, function(i) {
-          return i.hash === vm.item.hash && i.sort !== 'Postmaster';
+          return i.hash === vm.item.hash && !i.location.inPostmaster;
         });
         if (item) {
           var amount = store.amountOfItem(vm.item);
@@ -155,7 +152,7 @@
       if (!vm.store.isVault) {
         promise = promise.then(function() {
           var item = _.find(vault.items, function(i) {
-            return i.hash === vm.item.hash && i.sort !== 'Postmaster';
+            return i.hash === vm.item.hash && i.location.inPostmaster;
           });
           if (item) {
             var amount = vault.amountOfItem(vm.item);
@@ -238,7 +235,7 @@
       function applyMoves(moves) {
         return $q.all(moves.map(function(move) {
           var item = _.find(move.source.items, function(i) {
-            return i.hash === vm.item.hash;// && i.sort !== 'Postmaster';
+            return i.hash === vm.item.hash;
           });
           return dimItemService.moveTo(item, move.target, false, move.amount);
         }));
@@ -297,26 +294,6 @@
         }
       } else {
         if (item.equipped && itemStore.id === buttonStore.id) {
-          return true;
-        }
-      }
-
-      return false;
-    };
-
-    vm.canShowEquip = function canShowButton(item, itemStore, buttonStore) {
-      if (buttonStore.isVault || !item.equipment) {
-        return false;
-      }
-
-      if (!item.notransfer) {
-        if ((itemStore.id !== buttonStore.id) && (item.sort !== 'Postmaster')) {
-          return true;
-        } else if ((!item.equipped) && (item.sort !== 'Postmaster')) {
-          return true;
-        }
-      } else {
-        if ((!item.equipped) && (itemStore.id === buttonStore.id) && (item.sort !== 'Postmaster')) {
           return true;
         }
       }

--- a/app/scripts/services/dimBucketService.factory.js
+++ b/app/scripts/services/dimBucketService.factory.js
@@ -1,0 +1,77 @@
+(function() {
+  'use strict';
+
+  angular.module('dimApp')
+    .factory('dimBucketService', BucketService);
+
+  BucketService.$inject = ['dimItemBucketDefinitions', 'dimCategory'];
+
+  function BucketService(dimItemBucketDefinitions, dimCategory) {
+    // A mapping from the bucket names to DIM categories
+    // Some buckets like vault and currencies have been ommitted
+    var bucketToType = {
+      "BUCKET_CHEST": "Chest",
+      "BUCKET_LEGS": "Leg",
+      "BUCKET_RECOVERY": "Lost Items",
+      "BUCKET_SHIP": "Ship",
+      "BUCKET_MISSION": "Missions",
+      "BUCKET_ARTIFACT": "Artifact",
+      "BUCKET_HEAVY_WEAPON": "Heavy",
+      "BUCKET_COMMERCIALIZATION": "Special Orders",
+      "BUCKET_CONSUMABLES": "Consumable",
+      "BUCKET_PRIMARY_WEAPON": "Primary",
+      "BUCKET_CLASS_ITEMS": "ClassItem",
+      "BUCKET_QUESTS": "Quests",
+      "BUCKET_VEHICLE": "Vehicle",
+      "BUCKET_BOUNTIES": "Bounties",
+      "BUCKET_SPECIAL_WEAPON": "Special",
+      "BUCKET_SHADER": "Shader",
+      "BUCKET_EMOTES": "Emote",
+      "BUCKET_MAIL": "Messages",
+      "BUCKET_BUILD": "Class",
+      "BUCKET_HEAD": "Helmet",
+      "BUCKET_ARMS": "Gauntlets",
+      "BUCKET_HORN": "Horn",
+      "BUCKET_MATERIALS": "Material",
+      "BUCKET_GHOST": "Ghost",
+      "BUCKET_EMBLEM": "Emblem"
+    };
+
+    var vaultTypes = {
+      "BUCKET_VAULT_ARMOR": 'Armor',
+      "BUCKET_VAULT_WEAPONS": 'Weapons',
+      "BUCKET_VAULT_ITEMS": 'General'
+    };
+
+    var typeToSort = {};
+    _.each(dimCategory, function(types, category) {
+      types.forEach(function(type) {
+        typeToSort[type] = category;
+      });
+    });
+
+    return dimItemBucketDefinitions.then(function(bucketDefs) {
+      var buckets = {
+        byHash: {},
+        byName: {}
+        // TODO: category heirarchy
+      };
+      _.each(bucketDefs, function(def, hash) {
+        var bucket = def;
+        if (bucket.enabled) {
+          bucket.type = bucketToType[bucket.bucketIdentifier];
+          if (bucket.type) {
+            bucket.sort = typeToSort[bucket.type];
+          } else if (vaultTypes[bucket.bucketIdentifier]) {
+            bucket.sort = vaultTypes[bucket.bucketIdentifier];
+            buckets[bucket.sort] = bucket;
+          }
+
+          buckets.byHash[hash] = bucket;
+          buckets.byName[bucket.bucketIdentifier] = bucket;
+        }
+      });
+      return buckets;
+    });
+  }
+})();

--- a/app/scripts/services/dimBucketService.factory.js
+++ b/app/scripts/services/dimBucketService.factory.js
@@ -2,12 +2,50 @@
   'use strict';
 
   angular.module('dimApp')
-    .factory('dimBucketService', BucketService);
+    .factory('dimBucketService', BucketService)
+    // Categories (sorts) and the types within them
+    .value('dimCategory', {
+      Weapons: [
+        'Class',
+        'Primary',
+        'Special',
+        'Heavy',
+      ],
+      Armor: [
+        'Helmet',
+        'Gauntlets',
+        'Chest',
+        'Leg',
+        'ClassItem'
+      ],
+      General: [
+        'Artifact',
+        'Ghost',
+        'Consumable',
+        'Material',
+        'Emblem',
+        'Shader',
+        'Emote',
+        'Ship',
+        'Vehicle',
+        'Horn',
+      ],
+      Progress: [
+        'Bounties',
+        'Quests',
+        'Missions',
+      ],
+      Postmaster: [
+        'Lost Items',
+        'Special Orders',
+        'Messages'
+      ]
+    });
 
   BucketService.$inject = ['dimItemBucketDefinitions', 'dimCategory'];
 
   function BucketService(dimItemBucketDefinitions, dimCategory) {
-    // A mapping from the bucket names to DIM categories
+    // A mapping from the bucket names to DIM item types
     // Some buckets like vault and currencies have been ommitted
     var bucketToType = {
       "BUCKET_CHEST": "Chest",
@@ -53,22 +91,23 @@
     return dimItemBucketDefinitions.then(function(bucketDefs) {
       var buckets = {
         byHash: {},
-        byName: {}
+        byId: {}
         // TODO: category heirarchy
       };
       _.each(bucketDefs, function(def, hash) {
         var bucket = def;
         if (bucket.enabled) {
-          bucket.type = bucketToType[bucket.bucketIdentifier];
+          bucket.id = bucket.bucketIdentifier;
+          bucket.type = bucketToType[bucket.id];
           if (bucket.type) {
             bucket.sort = typeToSort[bucket.type];
-          } else if (vaultTypes[bucket.bucketIdentifier]) {
-            bucket.sort = vaultTypes[bucket.bucketIdentifier];
+          } else if (vaultTypes[bucket.id]) {
+            bucket.sort = vaultTypes[bucket.id];
             buckets[bucket.sort] = bucket;
           }
 
           buckets.byHash[hash] = bucket;
-          buckets.byName[bucket.bucketIdentifier] = bucket;
+          buckets.byId[bucket.id] = bucket;
         }
       });
       return buckets;

--- a/app/scripts/services/dimBucketService.factory.js
+++ b/app/scripts/services/dimBucketService.factory.js
@@ -95,9 +95,16 @@
         // TODO: category heirarchy
       };
       _.each(bucketDefs, function(def, hash) {
-        var bucket = def;
-        if (bucket.enabled) {
-          bucket.id = bucket.bucketIdentifier;
+        if (def.enabled) {
+          var bucket = {
+            id: def.bucketIdentifier,
+            description: def.bucketDescription,
+            name: def.bucketName,
+            hash: def.hash,
+            hasTransferDestination: def.hasTransferDestination,
+            capacity: def.itemCount
+          };
+
           bucket.type = bucketToType[bucket.id];
           if (bucket.type) {
             bucket.sort = typeToSort[bucket.type];
@@ -106,7 +113,10 @@
             buckets[bucket.sort] = bucket;
           }
 
-          buckets.byHash[hash] = bucket;
+          // Add an easy helper property like "inPostmaster"
+          bucket['in' + bucket.sort] = true;
+
+          buckets.byHash[bucket.hash] = bucket;
           buckets.byId[bucket.id] = bucket;
         }
       });

--- a/app/scripts/services/dimEngramFarmingService.factory.js
+++ b/app/scripts/services/dimEngramFarmingService.factory.js
@@ -70,7 +70,7 @@
         var self = this;
         var store = dimStoreService.getStore(self.store.id);
         var engrams = _.select(store.items, function(i) {
-          return i.isEngram() && i.sort !== 'Postmaster';
+          return i.isEngram() && !i.location.inPostmaster;
         });
 
         if (engrams.length === 0) {
@@ -102,7 +102,7 @@
 
         var applicableItems = _.select(store.items, function(i) {
           return !i.equipped &&
-            i.sort !== 'Postmaster' &&
+            !i.location.inPostmaster &&
             _.contains(engramTypes, i.type);
         });
         var itemsByType = _.groupBy(applicableItems, 'type');

--- a/app/scripts/services/dimEngramFarmingService.factory.js
+++ b/app/scripts/services/dimEngramFarmingService.factory.js
@@ -43,7 +43,7 @@
                   // If there's no room on other characters to move out of the vault,
                   // give up entirely.
                   if (!_.any(otherStores, function(store) {
-                    return _.any(dimCategory[item.sort], function(category) {
+                    return _.any(dimCategory[item.bucket.sort], function(category) {
                       return store.spaceLeftForItem({ type: category }) > 0;
                     });
                   })) {

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -182,7 +182,7 @@
         if (result && result.tier === dimItemTier.exotic) {
           var prefix = _.filter(store.items, function(i) {
             return i.equipped &&
-              i.sort === item.sort &&
+              i.bucket.sort === item.bucket.sort &&
               i.tier === dimItemTier.exotic;
           });
 
@@ -253,7 +253,7 @@
         var equippedExotics = _.filter(store.items, function(i) {
             return (i.equipped &&
                     i.type !== item.type &&
-                    i.sort === item.sort &&
+                    i.bucket.sort === item.bucket.sort &&
                     i.tier === 'Exotic');
           });
 
@@ -314,7 +314,7 @@
         if (store.isVault && !_.any(stores, function(s) { return moveContext.spaceLeft(s, item); })) {
           // If it's the vault, we can get rid of anything in the same sort category.
           // Pick whatever we have the most space for on some guardian.
-          var bestType = _.max(dimCategory[item.sort], function(type) {
+          var bestType = _.max(dimCategory[item.bucket.sort], function(type) {
             return _.max(stores.map(function(s) {
               if (s.id === store.id) {
                 return 0;
@@ -451,7 +451,7 @@
             var target = chooseMoveAsideTarget(source, moveAsideItem, moveContext);
 
             if (!target || (!target.isVault && target.spaceLeftForItem(moveAsideItem) <= 0)) {
-              return $q.reject(new Error('There are too many \'' + (target.isVault ? moveAsideItem.sort : moveAsideItem.type) + '\' items in the ' + target.name + '.'));
+              return $q.reject(new Error('There are too many \'' + (target.isVault ? moveAsideItem.bucket.sort : moveAsideItem.type) + '\' items in the ' + target.name + '.'));
             } else {
               // Make one move and start over!
               return moveTo(moveAsideItem, target, false, moveAsideItem.amount, excludes).then(function() {

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -495,8 +495,6 @@
         hash: item.itemHash,
         // This is the type of the item (see dimCategory/dimBucketService) regardless of location
         type: itemType,
-        // Equivalent to location.sort, the general section of the item's current location
-        sort: itemSort,
         tier: itemDef.tierTypeName || 'Common',
         name: itemDef.itemName,
         description: itemDef.itemDescription || '', // Added description for Bounties for now JFLAY2015

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -292,7 +292,9 @@
                   if (!sort) {
                     throw new Error("item needs a 'sort' field");
                   }
-                  return Math.max(0, this.capacityForItem(item) - count(this.items, { sort: sort }));
+                  return Math.max(0, this.capacityForItem(item) - count(this.items, function(i) {
+                    return i.bucket.sort == sort;
+                  }));
                 }
               });
 
@@ -463,26 +465,21 @@
       // item.bucket is where it IS right now
       var currentBucket = buckets.byHash[item.bucket] || normalBucket;
 
-      var location;
-      var itemSort;
-      var itemType = 'Unknown';
-      if (currentBucket) {
-        location = currentBucket.type;
-        itemSort = currentBucket.sort;
+      // We cheat a bit for items in the vault, since we treat the
+      // vault as a character. So put them in the bucket they would
+      // have been in if they'd been on a character.
+      if (currentBucket && currentBucket.id.startsWith('BUCKET_VAULT')) {
+        currentBucket = normalBucket;
       }
+
+      var itemType = 'Unknown';
       if (normalBucket) {
-        location = location || normalBucket.type;
-        itemSort = itemSort || normalBucket.sort;
         itemType = normalBucket.type;
       }
 
       var weaponClass = null;
       if (normalBucket.inWeapons) {
         weaponClass = itemDef.itemTypeName.toLowerCase().replace(/\s/g, '');
-      }
-
-      if (!itemSort) {
-        console.log(itemDef.itemTypeName + " does not have a sort property.");
       }
 
       var dmgName = [null, 'kinetic', 'arc', 'solar', 'void'][item.damageType];
@@ -502,7 +499,6 @@
         notransfer: (currentBucket.inPostmaster || itemDef.nonTransferrable),
         id: item.itemInstanceId,
         equipped: item.isEquipped,
-        //bucket: itemDef.bucketTypeHash,
         equipment: item.isEquipment,
         complete: item.isGridComplete,
         percentComplete: null,

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -45,8 +45,9 @@
       capacityForItem: function(item) {
         if (!item.bucket) {
           console.error("item needs a 'bucket' field", item);
+          return 10;
         }
-        return bucketSizes[item.bucket] || 10;
+        return item.bucket.itemCount;
       },
       // How many *more* items like this item can fit in this store?
       spaceLeftForItem: function(item) {
@@ -273,16 +274,24 @@
                 isVault: true,
                 // Vault has different capacity rules
                 capacityForItem: function(item) {
-                  if (!item.sort) {
+                  var sort = item.sort;
+                  if (item.bucket) {
+                    sort = item.bucket.sort;
+                  }
+                  if (!sort) {
                     throw new Error("item needs a 'sort' field");
                   }
-                  return vaultSizes[item.sort];
+                  return vaultSizes[sort];
                 },
                 spaceLeftForItem: function(item) {
-                  if (!item.sort) {
+                  var sort = item.sort;
+                  if (item.bucket) {
+                    sort = item.bucket.sort;
+                  }
+                  if (!sort) {
                     throw new Error("item needs a 'sort' field");
                   }
-                  return Math.max(0, this.capacityForItem(item) - count(this.items, { sort: item.sort }));
+                  return Math.max(0, this.capacityForItem(item) - count(this.items, { sort: sort }));
                 }
               });
 
@@ -455,6 +464,7 @@
 
       var location;
       var itemSort;
+      var itemType = 'Unknown';
       if (currentBucket) {
         location = currentBucket.type;
         itemSort = currentBucket.sort;
@@ -462,6 +472,7 @@
       if (normalBucket) {
         location = location || normalBucket.type;
         itemSort = itemSort || normalBucket.sort;
+        itemType = normalBucket.type;
       }
 
       var weaponClass = null;
@@ -469,12 +480,12 @@
         weaponClass = itemDef.itemTypeName.toLowerCase().replace(/\s/g, '');
       }
 
-      var itemType = location || 'Unknown';
       if (!itemSort) {
         console.log(itemDef.itemTypeName + " does not have a sort property.");
         console.log(normalBucket, currentBucket);
       }
 
+      /*
       if (itemSort !== 'Postmaster' && item.location === 4) {
         itemSort = 'Postmaster';
         if (itemType === 'Consumable') {
@@ -483,10 +494,13 @@
           itemType = 'Lost Items';
         }
       }
+       */
 
       var dmgName = [null, 'kinetic', 'arc', 'solar', 'void'][item.damageType];
 
       var createdItem = angular.extend(Object.create(ItemProto), {
+        location: currentBucket,
+        bucket: normalBucket,
         hash: item.itemHash,
         type: itemType,
         sort: itemSort,
@@ -497,7 +511,7 @@
         notransfer: (itemSort === 'Postmaster' || itemDef.nonTransferrable),
         id: item.itemInstanceId,
         equipped: item.isEquipped,
-        bucket: itemDef.bucketTypeHash,
+        //bucket: itemDef.bucketTypeHash,
         equipment: item.isEquipment,
         complete: item.isGridComplete,
         percentComplete: null,
@@ -878,9 +892,6 @@
                  light < 319 ? 39 :
                  light < 325 ? 40 :
                  light < 330 ? 41 : 42;
-        case 'lost items':
-          // TODO: this can be improved when we separate an item's type from its location, but for now we don't know
-          return 0;
       }
       console.warn('item bonus not found', type);
       return 0;

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -4,23 +4,23 @@
   angular.module('dimApp')
     .factory('dimStoreService', StoreService);
 
-  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimSettingsService', 'dimPlatformService', 'dimItemTier', 'dimCategory', 'dimItemDefinitions', 'dimItemBucketDefinitions', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions'];
+  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimSettingsService', 'dimPlatformService', 'dimItemTier', 'dimCategory', 'dimItemDefinitions', 'dimBucketService', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions'];
 
-  function StoreService($rootScope, $q, dimBungieService, settings, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimItemBucketDefinitions, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions) {
+  function StoreService($rootScope, $q, dimBungieService, settings, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions) {
     var _stores = [];
     var _index = 0;
     var vaultSizes = {};
     var bucketSizes = {};
     var progressionDefs = {};
-    dimItemBucketDefinitions.then(function(defs) {
-      _.each(defs, function(def, hash) {
+    dimBucketService.then(function(defs) {
+      _.each(defs.byHash, function(def, hash) {
         if (def.enabled) {
           bucketSizes[hash] = def.itemCount;
         }
       });
-      vaultSizes['Weapons'] = bucketSizes[4046403665];
-      vaultSizes['Armor'] = bucketSizes[3003523923];
-      vaultSizes['General'] = bucketSizes[138197802];
+      vaultSizes['Weapons'] = defs.Weapons.itemCount;
+      vaultSizes['Armor'] = defs.Armor.itemCount;
+      vaultSizes['General'] = defs.General.itemCount;
     });
     dimProgressionDefinitions.then(function(defs) {
       progressionDefs = defs;
@@ -31,43 +31,6 @@
     var cooldownsSuperB  = ['5:30', '5:14', '4:57', '4:39', '4:20', '4:00'];
     var cooldownsGrenade = ['1:00', '0:55', '0:49', '0:42', '0:34', '0:25'];
     var cooldownsMelee   = ['1:10', '1:04', '0:57', '0:49', '0:40', '0:29'];
-
-    // A mapping from the bucket names to DIM categories
-    // Some buckets like vault and currencies have been ommitted
-    var bucketToType = {
-      "BUCKET_CHEST": "Chest",
-      "BUCKET_LEGS": "Leg",
-      "BUCKET_RECOVERY": "Lost Items",
-      "BUCKET_SHIP": "Ship",
-      "BUCKET_MISSION": "Missions",
-      "BUCKET_ARTIFACT": "Artifact",
-      "BUCKET_HEAVY_WEAPON": "Heavy",
-      "BUCKET_COMMERCIALIZATION": "Special Orders",
-      "BUCKET_CONSUMABLES": "Consumable",
-      "BUCKET_PRIMARY_WEAPON": "Primary",
-      "BUCKET_CLASS_ITEMS": "ClassItem",
-      "BUCKET_QUESTS": "Quests",
-      "BUCKET_VEHICLE": "Vehicle",
-      "BUCKET_BOUNTIES": "Bounties",
-      "BUCKET_SPECIAL_WEAPON": "Special",
-      "BUCKET_SHADER": "Shader",
-      "BUCKET_EMOTES": "Emote",
-      "BUCKET_MAIL": "Messages",
-      "BUCKET_BUILD": "Class",
-      "BUCKET_HEAD": "Helmet",
-      "BUCKET_ARMS": "Gauntlets",
-      "BUCKET_HORN": "Horn",
-      "BUCKET_MATERIALS": "Material",
-      "BUCKET_GHOST": "Ghost",
-      "BUCKET_EMBLEM": "Emblem"
-    };
-
-    var typeToSort = {};
-    _.each(dimCategory, function(types, category) {
-      types.forEach(function(type) {
-        typeToSort[type] = category;
-      });
-    });
 
     // Prototype for Store objects - add methods to this to add them to all
     // stores.
@@ -324,13 +287,6 @@
               });
 
               _.each(raw.data.buckets, function(bucket) {
-                if (bucket.bucketHash === 3003523923)
-                  store.bucketCounts.Armor = _.size(bucket.items);
-                if (bucket.bucketHash === 138197802)
-                  store.bucketCounts.General = _.size(bucket.items);
-                if (bucket.bucketHash === 4046403665)
-                  store.bucketCounts.Weapons = _.size(bucket.items);
-
                 _.each(bucket.items, function(item) {
                   item.bucket = bucket.bucketHash;
                 });
@@ -423,7 +379,7 @@
       return index;
     }
 
-    function processSingleItem(definitions, itemBucketDef, statDef, objectiveDef, perkDefs, talentDefs, yearsDefs, progressDefs, item) {
+    function processSingleItem(definitions, buckets, statDef, objectiveDef, perkDefs, talentDefs, yearsDefs, progressDefs, item) {
       var itemDef = definitions[item.itemHash];
       // Missing definition?
       if (!itemDef || itemDef.itemName === 'Classified') {
@@ -486,36 +442,37 @@
                 minimum: defaultMinMax.minimum,
                 statHash: val,
                 value: 0
-              }
+              };
             }
           });
         }
       }
 
       // def.bucketTypeHash is where it goes normally
-      var normalBucket = itemBucketDef[itemDef.bucketTypeHash];
+      var normalBucket = buckets.byHash[itemDef.bucketTypeHash];
       // item.bucket is where it IS right now
-      var currentBucket = itemBucketDef[item.bucket];
+      var currentBucket = buckets.byHash[item.bucket] || normalBucket;
 
       var location;
-      if (currentBucket && bucketToType[currentBucket.bucketIdentifier]) {
-        location = bucketToType[currentBucket.bucketIdentifier];
+      var itemSort;
+      if (currentBucket) {
+        location = currentBucket.type;
+        itemSort = currentBucket.sort;
       }
-      var normalLocation;
-      if (normalBucket && bucketToType[normalBucket.bucketIdentifier]) {
-        normalLocation = bucketToType[normalBucket.bucketIdentifier];
+      if (normalBucket) {
+        location = location || normalBucket.type;
+        itemSort = itemSort || normalBucket.sort;
       }
 
       var weaponClass = null;
-      if (dimCategory['Weapons'].indexOf(normalLocation) >= 0) {
+      if (dimCategory['Weapons'].indexOf(location) >= 0) {
         weaponClass = itemDef.itemTypeName.toLowerCase().replace(/\s/g, '');
       }
 
-      var itemType = location || normalLocation || 'Unknown';
-
-      var itemSort = typeToSort[itemType];
+      var itemType = location || 'Unknown';
       if (!itemSort) {
         console.log(itemDef.itemTypeName + " does not have a sort property.");
+        console.log(normalBucket, currentBucket);
       }
 
       if (itemSort !== 'Postmaster' && item.location === 4) {
@@ -1019,7 +976,7 @@
       idTracker = {};
       return $q.all([
         dimItemDefinitions,
-        dimItemBucketDefinitions,
+        dimBucketService,
         dimStatDefinitions,
         dimObjectiveDefinitions,
         dimSandboxPerkDefinitions,

--- a/app/scripts/store/dimStoreHeading.directive.js
+++ b/app/scripts/store/dimStoreHeading.directive.js
@@ -73,7 +73,9 @@
       // TODO: do this by buckets
       $scope.$watchCollection('vm.store.items', function() {
         ['Weapons', 'Armor', 'General'].forEach(function(sort) {
-          vm.sortSize[sort] = count(vm.store.items, {sort: sort});
+          vm.sortSize[sort] = count(vm.store.items, function(i) {
+            return i.bucket.sort == sort;
+          });
         });
       });
     }

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -240,8 +240,7 @@
       }
 
       vm.data = _.groupBy(vm.store.items, function(item) {
-        // TODO: where's the vault??
-        return vm.store.isVault ? item.type : item.location.type;
+        return item.location.type;
       });
 
       if (count(vm.store.items, {type: 'Lost Items'}) >= 20) {

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -143,8 +143,6 @@
       $timeout.cancel(dragTimer);
     };
 
-    vm.sortSize = _.countBy(vm.store.items, 'sort');
-
     vm.categories = angular.copy(dimCategory); // Grouping of the types in the rows.
 
     vm.moveDroppedItem = dimActionQueue.wrap(function(item, equip, $event, hovering) {
@@ -236,7 +234,9 @@
       }
 
       if (vm.store.isVault) {
-        vm.sortSize = _.countBy(vm.store.items, 'sort');
+        vm.sortSize = _.countBy(vm.store.items, function(i) {
+          return i.location.sort;
+        });
       }
 
       vm.data = _.groupBy(vm.store.items, function(item) {

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -240,7 +240,7 @@
       }
 
       vm.data = _.groupBy(vm.store.items, function(item) {
-        return item.type;
+        return item.location.type;
       });
 
       if (count(vm.store.items, {type: 'Lost Items'}) >= 20) {

--- a/app/scripts/store/dimStoreItems.directive.js
+++ b/app/scripts/store/dimStoreItems.directive.js
@@ -240,7 +240,8 @@
       }
 
       vm.data = _.groupBy(vm.store.items, function(item) {
-        return item.location.type;
+        // TODO: where's the vault??
+        return vm.store.isVault ? item.type : item.location.type;
       });
 
       if (count(vm.store.items, {type: 'Lost Items'}) >= 20) {


### PR DESCRIPTION
This PR switches us to using the bucket definitions more directly, and separates our concept of the "type" of an item from its "location". Aside from making the internal model more consistent, the most notable user-facing benefit is that items in the postmaster are now recognized as what they actually are, and they participate in all our features (stat comparisons, stat quality, infusion fuel finder, loadout builder, etc). This is also a building block for a lot of other stuff I'm working on, but this should be shippable as-is.

That said, this touches a lot, so I'd appreciate some heavy-duty testing.

This should fix #531.