### PR TITLE
Use Grunt to replace $DIM_VERSION with the right version number.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,15 +37,27 @@ module.exports = function(grunt) {
     clean: ["build/extension", "build/dim-extension.zip"],
 
     replace: {
-      // Replace all instances of the current version number (from package.json)
+      // Replace all instances of $DIM_VERSION with the version number from package.json
+      main_version: {
+        src: ['build/extension/**/*.{json,html,js}'],
+        overwrite: true,
+        replacements: [{
+          from: '$DIM_VERSION',
+          to: pkg.version.toString()
+        }]
+      },
+      // Replace all instances of $DIM_VERSION or the current version number (from package.json)
       // with a beta version based on the current time.
       beta_version: {
         src: ['build/extension/*.{json,html,js}'],
         overwrite: true,
         replacements: [{
+          from: '$DIM_VERSION',
+          to: betaVersion
+        },{
           from: pkg.version.toString(),
           to: betaVersion
-        }]
+        },]
       }
     },
 
@@ -154,6 +166,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build_extension', ['clean',
                                       'css',
                                       'copy:main',
+                                      'replace:main_version',
                                       'compress']);
 
 };

--- a/app/index.html
+++ b/app/index.html
@@ -29,7 +29,7 @@
               <span class="link" title="Search"><span focus-on="clicked" dim-search-filter=""></span></span>
             </div>
           </span>
-          <span class="logo" title="v3.7.3">DIM</span>
+          <span class="logo" title="v$DIM_VERSION">DIM</span>
           <span class="link" ng-click="app.showAbout($event)">About</span>
           <span class="link" ng-click="app.showSupport($event)">Support DIM</span>
           <span class="link" ng-if="app.xur.available" ng-click="app.showXur($event)">Xûr</span>
@@ -42,71 +42,71 @@
       <div id="content" ui-view></div>
     </div>
 
-    <script src="scripts/google.js?v=3.7.3"></script>
+    <script src="scripts/google.js?v=$DIM_VERSION"></script>
 
     <!-- begin vendor scripts -->
-    <script src="vendor/jquery/dist/jquery.min.js?v=3.7.3"></script>
-    <script src="scripts/jquery-ui.position.js?v=3.7.3"></script>
-    <script src="vendor/angular/angular.min.js?v=3.7.3"></script>
-    <script src="vendor/angular-ui-router/release/angular-ui-router.min.js?v=3.7.3"></script>
-    <script src="vendor/angular-animate/angular-animate.min.js?v=3.7.3"></script>
-    <script src="vendor/angular-aria/angular-aria.min.js?v=3.7.3"></script>
-    <script src="scripts/toaster.js?v=3.7.3"></script>
-    <script src="vendor/angular-native-dragdrop/draganddrop.js?v=3.7.3"></script>
-    <script src="vendor/ngDialog/js/ngDialog.min.js?v=3.7.3"></script>
-    <script src="vendor/Angular.uuid2/dist/angular-uuid2.min.js?v=3.7.3"></script>
-    <script src="vendor/underscore/underscore-min.js?v=3.7.3"></script>
-    <script src="vendor/lz-string/libs/lz-string.min.js?v=3.7.3"></script>
-    <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=3.7.3"></script>
-    <script src="vendor/angular-messages/angular-messages.min.js?v=3.7.3"></script>
-    <script src="vendor/angular-promise-tracker/promise-tracker.js?v=3.7.3"></script>
-    <script src="vendor/jquery-textcomplete/dist/jquery.textcomplete.js?v=3.7.3"></script>
+    <script src="vendor/jquery/dist/jquery.min.js?v=$DIM_VERSION"></script>
+    <script src="scripts/jquery-ui.position.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular/angular.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-ui-router/release/angular-ui-router.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-animate/angular-animate.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-aria/angular-aria.min.js?v=$DIM_VERSION"></script>
+    <script src="scripts/toaster.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-native-dragdrop/draganddrop.js?v=$DIM_VERSION"></script>
+    <script src="vendor/ngDialog/js/ngDialog.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/Angular.uuid2/dist/angular-uuid2.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/underscore/underscore-min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/lz-string/libs/lz-string.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-messages/angular-messages.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-promise-tracker/promise-tracker.js?v=$DIM_VERSION"></script>
+    <script src="vendor/jquery-textcomplete/dist/jquery.textcomplete.js?v=$DIM_VERSION"></script>
     <script src="vendor/angularjs-slider/dist/rzslider.js"></script>
     <script src="vendor/ng-http-rate-limiter/dist/ng-http-rate-limiter.js"></script>
     <!-- end vendor scripts -->
 
-    <script src="scripts/ScrollToFixed.js?v=3.7.3"></script>
-    <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=3.7.3"></script>
-    <script src="vendor/angular-hotkeys/build/hotkeys.js?v=3.7.3"></script>
+    <script src="scripts/ScrollToFixed.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=$DIM_VERSION"></script>
+    <script src="vendor/angular-hotkeys/build/hotkeys.js?v=$DIM_VERSION"></script>
 
     <!-- begin app scripts -->
-    <script src="scripts/util.js?v=3.7.3"></script>
-    <script src="scripts/dimApp.module.js?v=3.7.3"></script>
-    <script src="scripts/dimApp.config.js?v=3.7.3"></script>
-    <script src="scripts/services/dimActionQueue.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimBungieService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimDefinitions.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimInfoService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimPlatformService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimLoadoutService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimSettingsService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimStoreService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimXurService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimItemService.factory.js?v=3.7.3"></script>
-    <script src="scripts/services/dimEngramFarmingService.factory.js?v=3.7.3"></script>
-    <script src="scripts/loadout/dimLoadout.directive.js?v=3.7.3"></script>
-    <script src="scripts/loadout/dimLoadoutPopup.directive.js?v=3.7.3"></script>
-    <script src="scripts/shell/dimAppCtrl.controller.js?v=3.7.3"></script>
-    <script src="scripts/shell/dimSettingsCtrl.controller.js?v=3.7.3"></script>
-    <script src="scripts/shell/dimPlatformChoice.directive.js?v=3.7.3"></script>
-    <script src="scripts/shell/dimSearchFilter.directive.js?v=3.7.3"></script>
-    <script src="scripts/shell/dimClickAnywhereButHere.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimBungieImageFallback.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimPercentWidth.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimStores.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimStoreItems.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimStoreItem.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimStoreHeading.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimSimpleItem.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimStats.directive.js?v=3.7.3"></script>
-    <script src="scripts/store/dimEngramFarming.directive.js?v=3.7.3"></script>
-    <script src="scripts/move-popup/dimMoveAmount.directive.js?v=3.7.3"></script>
-    <script src="scripts/move-popup/dimMovePopup.directive.js?v=3.7.3"></script>
-    <script src="scripts/move-popup/dimTalentGrid.directive.js?v=3.7.3"></script>
-    <script src="scripts/move-popup/dimMoveItemProperties.directive.js?v=3.7.3"></script>
-    <script src="scripts/infuse/dimInfuse.controller.js?v=3.7.3"></script>
-    <script src="scripts/xur/dimXur.controller.js?v=3.7.3"></script>
-    <script src="scripts/minmax/dimMinMax.controller.js?v=3.7.3"></script>
+    <script src="scripts/util.js?v=$DIM_VERSION"></script>
+    <script src="scripts/dimApp.module.js?v=$DIM_VERSION"></script>
+    <script src="scripts/dimApp.config.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimActionQueue.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimBungieService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimDefinitions.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimInfoService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimPlatformService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimLoadoutService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimSettingsService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimStoreService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimXurService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimItemService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/services/dimEngramFarmingService.factory.js?v=$DIM_VERSION"></script>
+    <script src="scripts/loadout/dimLoadout.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/loadout/dimLoadoutPopup.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/shell/dimAppCtrl.controller.js?v=$DIM_VERSION"></script>
+    <script src="scripts/shell/dimSettingsCtrl.controller.js?v=$DIM_VERSION"></script>
+    <script src="scripts/shell/dimPlatformChoice.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/shell/dimSearchFilter.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/shell/dimClickAnywhereButHere.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimBungieImageFallback.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimPercentWidth.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimStores.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimStoreItems.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimStoreItem.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimStoreHeading.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimSimpleItem.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimStats.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimEngramFarming.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/move-popup/dimMoveAmount.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/move-popup/dimMovePopup.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/move-popup/dimTalentGrid.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/move-popup/dimMoveItemProperties.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/infuse/dimInfuse.controller.js?v=$DIM_VERSION"></script>
+    <script src="scripts/xur/dimXur.controller.js?v=$DIM_VERSION"></script>
+    <script src="scripts/minmax/dimMinMax.controller.js?v=$DIM_VERSION"></script>
     <!-- end app scripts -->
 
     <!--
@@ -114,7 +114,7 @@
     <script src="scripts/rotate3Di.js" type="text/javascript"></script>
     -->
 
-    <!-- <script src="scripts/scripts.min.js?v=3.7.3"></script> -->
+    <!-- <script src="scripts/scripts.min.js?v=$DIM_VERSION"></script> -->
 
   </body>
 

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -82,7 +82,7 @@
         //Track Our Initial Activity of Starting the App
         $rootScope.trackActivity();
 
-        console.log('DIM v3.7.3 - Please report any errors to https://www.reddit.com/r/destinyitemmanager');
+        console.log('DIM v$DIM_VERSION - Please report any errors to https://www.reddit.com/r/destinyitemmanager');
         dimInfoService.show('20160603v370', {
           title: 'DIM v3.7.3 Released',
           view: 'views/changelog-toaster.html?v=v3.7.3',

--- a/app/scripts/services/dimDefinitions.factory.js
+++ b/app/scripts/services/dimDefinitions.factory.js
@@ -20,7 +20,7 @@
   _.each(definitions, function(file, name) {
     var factory = function($http) {
       //console.time("loading " + name);
-      return $http.get('scripts/api-manifest/' + file + '.json?v=3.7.3')
+      return $http.get('scripts/api-manifest/' + file + '.json?v=$DIM_VERSION')
         .then(function(json) {
           //console.timeEnd("loading " + name);
           return json.data;

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -1,12 +1,10 @@
 <div>
   <h1 class="orange">About Destiny Item Manager (DIM)</h1>
   <div class="ngdialog-inner-content">
-    <h3>Version 3.7.3</h3>
+    <h3>Version $DIM_VERSION</h3>
     <p>
       DIM is built upon the same services used by Bungie.net and the Destiny Companion App. DIM can access the items within your Guardians inventory and the Vault for both PlayStation and Xbox. You then can drag and drop items anywhere you wish to move them.
     </p>
-    <!-- <h1>Blacksmith Shader Giveaway</h1>
-  <p>The DIM team is giving away six Blacksmith shaders on Twitter to celebrate your #YearOneGear.</p><p>Visit us at <a href="https://twitter.com/ThisIsDIM/status/639237265944899584" target="_blank">@ThisIsDIM</a> on twitter or the <a href="https://www.reddit.com/r/DestinyItemManager/comments/3jfl0f/blacksmith_shader_giveaway/" target="_blank">/r/destinyitemmanager</a> subreddit to learn how to enter.</p><p>See you starside Guardians.</p> -->
     <h2>Contact Us</h2>
     <table>
         <tr>


### PR DESCRIPTION
I've gotten sick of resolving `index.html` conflicts every time the version changes. This change just adds a Grunt task to the `build_extension` task that'll replace any instance of the string `$DIM_VERSION` with the current version out of `package.json`. Now we only need to update `package.json` and `manifest.json` before building and it'll all work out, no need to ever change the actual extension files again.

This also fixes #577.