### PR TITLE
Loadouts should be restricted by platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * The vault width preference has been removed - the vault now always takes up all the remaining space on the screen.
 * Section headers don't repeat themselves anymore.
 * Returning from the min-max tool no longer greets you with a blank, item-less screen.
+* Fixed a bug where loadouts were not properly restricted to the platform they were created for.
 
 # 3.7.4
 

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -385,6 +385,7 @@
       var result = {
         id: loadoutPrimitive.id,
         name: loadoutPrimitive.name,
+        platform: loadoutPrimitive.platform,
         classType: (_.isUndefined(loadoutPrimitive.classType) ? -1 : loadoutPrimitive.classType),
         version: 'v3.0',
         items: {}


### PR DESCRIPTION
As a crossplatform player, it makes little sense to list the loadouts I created for my PS4 account when I'm viewing my Xbox inventory.