### PR TITLE
Precalculate stat-range and fix width.

### DIFF
--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -43,7 +43,7 @@
         '  </div>',
         '  <div class="stat-box-row" ng-repeat="stat in vm.item.stats track by $index">',
         '     <span class="stat-box-text stat-box-cell"> {{ stat.name }} </span>',
-        '     <span class="stat-box-outer" ng-class="{ \'show-quality\': vm.itemQuality }">',
+        '     <span class="stat-box-outer">',
         '       <span ng-if="stat.bar && stat.value && (stat.value === stat.equippedStatsValue || !stat.comparable)" class="stat-box-inner" dim-percent-width="stat.value / stat.maximumValue"></span>',
         '       <span ng-if="stat.bar && stat.value && stat.value < stat.equippedStatsValue && stat.comparable" class="stat-box-inner" dim-percent-width="stat.value / stat.maximumValue"></span>',
         '       <span ng-if="stat.bar && stat.value < stat.equippedStatsValue && stat.comparable" class="stat-box-inner lower-stats" dim-percent-width="(stat.equippedStatsValue - stat.value) / stat.maximumValue"></span>',
@@ -52,12 +52,12 @@
         '       <span ng-if="!stat.bar && (!stat.equippedStatsName || stat.comparable)" ng-class="{ \'higher-stats\': (stat.value > stat.equippedStatsValue), \'lower-stats\': (stat.value < stat.equippedStatsValue)}">{{ stat.value }}</span>',
         '     </span>',
         '     <span class="stat-box-val stat-box-cell" ng-class="{ \'higher-stats\': (stat.value > stat.equippedStatsValue && stat.comparable), \'lower-stats\': (stat.value < stat.equippedStatsValue && stat.comparable)}" ng-show="{{ stat.bar }}">{{ stat.value }}',
-        '       <span ng-show="vm.itemQuality && stat.qualityPercentage.min" ng-class="{ \'show-quality\': vm.itemQuality && stat.qualityPercentage.min }" ng-show="{{ stat.bar }}" ng-style="stat.qualityPercentage.min | qualityColor:\'color\'">({{ vm.getStatRange(stat) }})</span>',
+        '       <span ng-if="stat.bar && vm.itemQuality && stat.qualityPercentage.min" ng-style="stat.qualityPercentage.min | qualityColor:\'color\'">({{ stat.qualityPercentage.range }})</span>',
         '     </span>',
         '  </div>',
         '  <div class="stat-box-row" ng-if="vm.item.quality && vm.item.quality.min">',
         '    <span class="stat-box-text stat-box-cell">Stats quality</span>',
-        '    <span class="stat-box-cell" ng-style="vm.item.quality.min | qualityColor:\'color\'">{{ vm.getItemQualityRange() }} of max possible roll</span>',
+        '    <span class="stat-box-cell" ng-style="vm.item.quality.min | qualityColor:\'color\'">{{ vm.item.quality.range }} of max roll</span>',
         '  </div>',
         '</div>',
         '<div class="item-details item-perks" ng-if="vm.item.talentGrid && vm.itemDetails">',
@@ -150,21 +150,6 @@
         vm.light += ' Attack';
         vm.classes['is-' + vm.item.dmg] = true;
       }
-    }
-
-    vm.getStatRange = function(stat) {
-      if(!stat.qualityPercentage) {
-        return '';
-      }
-      return ((stat.qualityPercentage.min === stat.qualityPercentage.max || vm.item.primStat.value === 335) ?
-        stat.qualityPercentage.min :
-        (stat.qualityPercentage.min + "%-" +  stat.qualityPercentage.max)) + '%';
-    }
-
-    vm.getItemQualityRange = function() {
-      return ((vm.item.quality.min === vm.item.quality.max || vm.item.primStat.value === 335) ?
-        vm.item.quality.min :
-        (vm.item.quality.min + "%-" +  vm.item.quality.max)) + '%';
     }
 
     function compareItems(item) {

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -773,7 +773,7 @@
       return {
         min: Math.floor((base)*(fitValue(max)/fitValue(light))),
         max: Math.floor((base+1)*(fitValue(max)/fitValue(light)))
-      }
+      };
     }
 
     // thanks to bungie armory for the max-base stats
@@ -781,6 +781,16 @@
     // https://www.reddit.com/r/DestinyTheGame/comments/4geixn/a_shift_in_how_we_view_stat_infusion_12tier/
     // TODO set a property on a bucket saying whether it can have quality rating, etc
     function getQualityRating(stats, light, type) {
+      // For a quality property, return a range string (min-max percentage)
+      function getQualityRange(light, quality) {
+        if (!quality) {
+          return '';
+        }
+        return ((quality.min === quality.max || light === 335) ?
+                quality.min :
+                (quality.min + "%-" +  quality.max)) + '%';
+      }
+
       var maxLight = 335;
 
       if (!stats || light.value < 280) {
@@ -835,7 +845,7 @@
         stat.qualityPercentage = {
           min: Math.round(100 * stat.scaled.min / stat.split),
           max: Math.round(100 * stat.scaled.max / stat.split)
-        }
+        };
         ret.total.min += scaled.min || 0;
         ret.total.max += scaled.max || 0;
       });
@@ -849,10 +859,9 @@
           stat.qualityPercentage = {
             min: Math.round(100 * stat.scaled.min / stat.split),
             max: Math.round(100 * stat.scaled.max / stat.split)
-          }
+          };
         });
       }
-
 
       var quality = {
         min: Math.round(ret.total.min / ret.max * 100),
@@ -871,6 +880,11 @@
           max: Math.min(100, quality.max)
         };
       }
+
+      stats.forEach(function(stat) {
+        stat.qualityPercentage.range = getQualityRange(light, stat.qualityPercentage);
+      });
+      quality.range = getQualityRange(light, quality);
 
       return quality;
     }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1316,7 +1316,6 @@ rzslider {
   .stat-box-row {
     overflow: hidden;
     margin-bottom: 4px;
-    width: 100%;
     display: table-row;
   }
   .stat-box-cell {
@@ -1363,9 +1362,6 @@ rzslider {
     &.lower-stats {
       background-color: #985C58;
     }
-  }
-  .stat-box-outer span:last-child {
-    padding-left: 5px;
   }
 }
 


### PR DESCRIPTION
Fixes #603. Remember that using a function in a bound expression is very bad for performance, as the function will be evaluated on every single digest pass, because Angular can't tell whether the underlying properties have changed. (I could have done this as a somewhat fancy filter, but precomputing was easier.)