### PR TITLE
Update to scrollbar styles

### DIFF
--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -408,7 +408,7 @@ body {
 
 ::-webkit-scrollbar-thumb {
   background: #E4E4E4;
-  border-radius: 2px;
+  border-radius: 3px;
 }
 
 #system {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -397,6 +397,20 @@ body {
   }
 }
 
+::-webkit-scrollbar {
+  width: 3px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(228, 228, 228, 0.2);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #E4E4E4;
+  border-radius: 2px;
+}
+
 #system {
   outline: none;
   margin-top: 1px;
@@ -1015,7 +1029,7 @@ img {
   display: block;
   width: 100%;
   max-height: 465px;
-  overflow: scroll;
+  overflow: auto;
   z-index: 2;
   top: 0;
   bottom: initial;


### PR DESCRIPTION
With one of the recent updates to DIM, the scrollbar began interfering with long loadout names, including the "Create Loadout" button.

On OS X:

![screen shot 2016-06-20 at 2 28 10 pm](https://cloud.githubusercontent.com/assets/471333/16205757/46f45800-36f3-11e6-9a3a-a300338bf155.png)

On Windows:

![screen shot 2016-06-20 at 2 21 28 pm](https://cloud.githubusercontent.com/assets/471333/16205767/59f38cf0-36f3-11e6-90e1-341b101113c3.png)

This PR updates the scrollbars universally across DIM, making them not interfere with loadout names and the "Clear Loadout" text does not have an ellipsis anymore either.

On OS X:

![screen shot 2016-06-20 at 2 21 17 pm](https://cloud.githubusercontent.com/assets/471333/16205833/af70781e-36f3-11e6-8aba-0223c9123939.png)

On Windows (with a long loadout name for testing):

![screen shot 2016-06-20 at 2 23 23 pm](https://cloud.githubusercontent.com/assets/471333/16205849/be84f2a8-36f3-11e6-804d-526302b24242.png)

On OS X again, this time with the main scrollbar visible:

![screen shot 2016-06-20 at 2 23 48 pm](https://cloud.githubusercontent.com/assets/471333/16205864/d5b9f5ae-36f3-11e6-9a39-6d81f3dc25c4.png)

Let me know if there is any feedback or suggestions.