### PR TITLE
Fix loadout menu max-height based on window height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed a bug where loadouts were not properly restricted to the platform they were created for.
 * Xur's menu item will properly disappear when he leaves for the week.
 * New items are marked with a "shiny" animation, and there are notifications when new items appear.
+* The loadout menu may expand to fill the height of the window, but no more.
 
 # 3.7.4
 

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -934,7 +934,7 @@ dim-store-heading {
   position: absolute;
   display: block;
   width: 100%;
-  max-height: 465px;
+  max-height: calc(100vh - 121px);
   overflow: auto;
   z-index: 2;
   top: 0;


### PR DESCRIPTION
The change to limit the height of the loadout menu and let it scroll was good, but it can force the menu to scroll even when there's plenty of space on large screens. This change simply sets the max height based on the window height.