### PR TITLE
Simplify settings handling

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="styles/main.css">
   </head>
 
-  <body ng-app="dimApp" ng-strict-di ng-controller="dimAppCtrl as app" ng-class="{ 'show-elements': app.showElements }">
+  <body ng-app="dimApp" ng-strict-di ng-controller="dimAppCtrl as app" ng-class="{ 'show-elements': app.settings.showElements }">
     <div class="ng-cloak" ng-click="trackActivity()">
       <div id="header">
         <div class="content">

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -33,7 +33,7 @@
         '    </div>',
         '    <div id="loadout-contents">',
         '      <div ng-repeat="value in vm.types track by value" class="loadout-{{ value }} loadout-bucket" ng-if="vm.loadout.items[value].length">',
-        '        <div ng-repeat="item in vm.loadout.items[value] | sortItems:vm.itemSort track by item.index" ng-click="vm.equip(item)" id="loadout-item-{{:: $id }}" class="loadout-item">',
+        '        <div ng-repeat="item in vm.loadout.items[value] | sortItems:vm.settings.itemSort track by item.index" ng-click="vm.equip(item)" id="loadout-item-{{:: $id }}" class="loadout-item">',
         '          <dim-simple-item item-data="item"></dim-simple-item>',
         '          <div class="close" ng-click="vm.remove(item, $event); vm.form.name.$rollbackViewValue(); $event.stopPropagation();"></div>',
         '          <div class="equipped" ng-show="item.equipped"></div>',
@@ -94,10 +94,12 @@
     }
   }
 
-  LoadoutCtrl.$inject = ['dimLoadoutService', 'dimCategory', 'dimItemTier', 'toaster', 'dimPlatformService', 'dimSettingsService', '$scope'];
+  LoadoutCtrl.$inject = ['dimLoadoutService', 'dimCategory', 'dimItemTier', 'toaster', 'dimPlatformService', 'dimSettingsService'];
 
-  function LoadoutCtrl(dimLoadoutService, dimCategory, dimItemTier, toaster, dimPlatformService, dimSettingsService, $scope) {
+  function LoadoutCtrl(dimLoadoutService, dimCategory, dimItemTier, toaster, dimPlatformService, dimSettingsService) {
     var vm = this;
+
+    vm.settings = dimSettingsService;
 
     vm.types = _.chain(dimCategory)
       .values()
@@ -236,15 +238,5 @@
         }
       }
     };
-
-    dimSettingsService.getSetting('itemSort').then(function(sort) {
-      vm.itemSort = sort;
-    });
-
-    $scope.$on('dim-settings-updated', function(event, settings) {
-      if (_.has(settings, 'itemSort')) {
-        vm.itemSort = settings.itemSort;
-      }
-    });
   }
 })();

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -50,7 +50,7 @@
         '       <span ng-if="!stat.bar && (!stat.equippedStatsName || stat.comparable)" ng-class="{ \'higher-stats\': (stat.value > stat.equippedStatsValue), \'lower-stats\': (stat.value < stat.equippedStatsValue)}">{{ stat.value }}</span>',
         '     </span>',
         '     <span class="stat-box-val stat-box-cell" ng-class="{ \'higher-stats\': (stat.value > stat.equippedStatsValue && stat.comparable), \'lower-stats\': (stat.value < stat.equippedStatsValue && stat.comparable)}" ng-show="{{ stat.bar }}">{{ stat.value }}',
-        '       <span ng-if="stat.bar && vm.itemQuality && stat.qualityPercentage.min" ng-style="stat.qualityPercentage.min | qualityColor:\'color\'">({{ stat.qualityPercentage.range }})</span>',
+        '       <span ng-if="stat.bar && vm.settings.itemQuality && stat.qualityPercentage.min" ng-style="stat.qualityPercentage.min | qualityColor:\'color\'">({{ stat.qualityPercentage.range }})</span>',
         '     </span>',
         '  </div>',
         '  <div class="stat-box-row" ng-if="vm.item.quality && vm.item.quality.min">',
@@ -87,6 +87,7 @@
     //    (!vm.item.equipment || (vm.item.objectives && vm.item.objectives.length)));
     vm.locking = false;
 
+    // The 'i' keyboard shortcut toggles full details
     $scope.$on('dim-toggle-item-details', function() {
       vm.itemDetails = !vm.itemDetails;
     });
@@ -127,15 +128,10 @@
     vm.classType = '';
     vm.showDetailsByDefault = (!vm.item.equipment && vm.item.notransfer);
     vm.itemDetails = vm.showDetailsByDefault;
-    settings.getSetting('itemDetails')
-      .then(function(show) {
-        vm.itemDetails = vm.itemDetails || show;
-      });
-    vm.itemQuality = false;
-    settings.getSetting('itemQuality')
-      .then(function(show) {
-        vm.itemQuality = vm.itemQuality || show;
-      });
+    vm.settings = settings;
+    $scope.$watch('vm.settings.itemDetails', function(show) {
+      vm.itemDetails = vm.itemDetails || show;
+    });
 
     if (vm.item.primStat) {
       vm.light = vm.item.primStat.value.toString();

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -20,7 +20,7 @@
         '  <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse"></div>',
         '  <dim-move-amount ng-if="vm.item.amount > 1 && !vm.item.notransfer" amount="vm.moveAmount" maximum="vm.maximum"></dim-move-amount>',
         '  <div class="interaction">',
-        '    <div class="locations" ng-repeat="store in vm.stores track by store.id">',
+        '    <div class="locations" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '      <div class="move-button move-vault" alt="{{::vm.characterInfo(store) }}" title="{{::vm.characterInfo(store) }}" ',
         '        ng-if="vm.canShowVault(vm.item, vm.store, store)" ng-click="vm.moveItemTo(store)" ',
         '        data-type="item" data-character="{{::store.id}}">',

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .factory('dimStoreService', StoreService);
 
-  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimSettingsService', 'dimPlatformService', 'dimItemTier', 'dimCategory', 'dimItemDefinitions', 'dimBucketService', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions', 'dimInfoService', 'SyncService'];
+  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimPlatformService', 'dimItemTier', 'dimCategory', 'dimItemDefinitions', 'dimBucketService', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions', 'dimInfoService', 'SyncService'];
 
-  function StoreService($rootScope, $q, dimBungieService, settings, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions, dimInfoService, SyncService) {
+  function StoreService($rootScope, $q, dimBungieService, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions, dimInfoService, SyncService) {
     var _stores = [];
     var _oldItems = {};
     var _currItems = {};
@@ -130,17 +130,6 @@
       processItems: getItems
     };
 
-    $rootScope.$on('dim-settings-updated', function(event, setting) {
-      if (_.has(setting, 'characterOrder')) {
-        sortStores(_stores).then(function(stores) {
-          _stores = stores;
-          $rootScope.$broadcast('dim-stores-updated', {
-            stores: stores
-          });
-        });
-      }
-    });
-
     return service;
 
     // Update the high level character information for all the stores
@@ -156,17 +145,6 @@
         });
         return _stores;
       });
-    }
-
-    function sortStores(stores) {
-      return settings.getSetting('characterOrder')
-        .then(function(characterOrder) {
-          if (characterOrder === 'mostRecent') {
-            return _.sortBy(stores, 'lastPlayed').reverse();
-          } else {
-            return _.sortBy(stores, 'id');
-          }
-        });
     }
 
     function getStores() {
@@ -323,9 +301,6 @@
               return store;
             });
           }));
-        })
-        .then(function(stores) {
-          return sortStores(stores);
         })
         .then(function(stores) {
           _stores = stores;

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -13,6 +13,8 @@
     var supportResult = null;
     var filterResult = null;
 
+    vm.settings = dimSettingsService;
+
     hotkeys.add({
       combo: ['f'],
       callback: function(event) {
@@ -42,17 +44,6 @@
       combo: ['i'],
       callback: function() {
         $rootScope.$broadcast('dim-toggle-item-details');
-      }
-    });
-
-    dimSettingsService.getSettings()
-      .then(function(settings) {
-        vm.showElements = settings.showElements;
-      });
-
-    $rootScope.$on('dim-settings-updated', function(event, arg) {
-      if (_.has(arg, 'showElements')) {
-        vm.showElements = arg.showElements;
       }
     });
 
@@ -209,12 +200,6 @@
     };
 
     vm.startAutoRefreshTimer();
-
-    $rootScope.$on('dim-settings-updated', function(event, arg) {
-      if (_.has(arg, 'characterOrder')) {
-        refresh();
-      }
-    });
 
     // Refresh when the user comes back to the page
     document.addEventListener("visibilitychange", function() {

--- a/app/scripts/shell/dimSettingsCtrl.controller.js
+++ b/app/scripts/shell/dimSettingsCtrl.controller.js
@@ -8,6 +8,10 @@
   function SettingsController(settings, $scope, SyncService) {
     var vm = this;
 
+    $scope.$watchCollection('vm.settings', function() {
+      settings.save();
+    });
+
     vm.charColOptions = [
       { id: 3, name: '3' },
       { id: 4, name: '4' },
@@ -15,10 +19,6 @@
     ];
 
     vm.settings = settings;
-
-    vm.save = function() {
-      settings.save();
-    };
 
     vm.showSync = function() {
       return SyncService.drive();

--- a/app/scripts/shell/dimSettingsCtrl.controller.js
+++ b/app/scripts/shell/dimSettingsCtrl.controller.js
@@ -3,10 +3,10 @@
 
   angular.module('dimApp').controller('dimSettingsCtrl', SettingsController);
 
-  SettingsController.$inject = ['dimSettingsService', '$scope', '$rootScope', 'SyncService'];
+  SettingsController.$inject = ['dimSettingsService', '$scope', 'SyncService'];
 
-  function SettingsController(settings, $scope, $rootScope, SyncService) {
-    var vm = $scope.vm = {};
+  function SettingsController(settings, $scope, SyncService) {
+    var vm = this;
 
     vm.charColOptions = [
       { id: 3, name: '3' },
@@ -14,13 +14,10 @@
       { id: 5, name: '5' }
     ];
 
-    settings.getSetting()
-      .then(function(s) {
-        vm.settings = s;
-      });
+    vm.settings = settings;
 
-    vm.save = function(key) {
-      settings.saveSetting(key, vm.settings[key]);
+    vm.save = function() {
+      settings.save();
     };
 
     vm.showSync = function() {
@@ -28,10 +25,7 @@
     };
 
     vm.driveSync = function() {
-      SyncService.authorize().then(function() {
-        // TODO: still requires a hard refresh... why does this not work?
-        $rootScope.$broadcast('dim-settings-updated');
-      });
+      SyncService.authorize();
     };
   }
 })();

--- a/app/scripts/store/dimStoreBucket.directive.js
+++ b/app/scripts/store/dimStoreBucket.directive.js
@@ -71,7 +71,7 @@
         '  <div class="unequipped sub-bucket" ui-on-drop="vm.onDrop($data, $event, false)" ',
         '      ui-on-drag-enter="vm.onDragEnter($event)" ui-on-drag-leave="vm.onDragLeave($event)" ',
         '      drop-channel="{{::vm.dropChannel}}">',
-        '    <dim-store-item ng-repeat="item in vm.items | equipped:false | sortItems:vm.itemSort track by item.index" store-data="vm.store" item-data="item"></dim-store-item>',
+        '    <dim-store-item ng-repeat="item in vm.items | equipped:false | sortItems:vm.settings.itemSort track by item.index" store-data="vm.store" item-data="item"></dim-store-item>',
         '  </div>',
         '</div>'
       ].join('')
@@ -82,6 +82,8 @@
 
   function StoreBucketCtrl($scope, loadingTracker, dimStoreService, dimItemService, $q, $timeout, toaster, dimSettingsService, ngDialog, $rootScope, dimActionQueue) {
     var vm = this;
+
+    vm.settings = dimSettingsService;
 
     vm.dropChannel = vm.bucket.type + ',' + vm.store.id + vm.bucket.type;
 
@@ -197,16 +199,6 @@
       loadingTracker.addPromise(promise);
 
       return promise;
-    });
-
-    dimSettingsService.getSetting('itemSort').then(function(sort) {
-      vm.itemSort = sort;
-    });
-
-    $scope.$on('dim-settings-updated', function(event, settings) {
-      if (_.has(settings, 'itemSort')) {
-        vm.itemSort = settings.itemSort;
-      }
     });
   }
 })();

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -2,7 +2,16 @@
   'use strict';
 
   angular.module('dimApp')
-    .directive('dimStores', Stores);
+    .directive('dimStores', Stores)
+    .filter('sortStores', function() {
+      return function sortStores(stores, order) {
+        if (order === 'mostRecent') {
+          return _.sortBy(stores, 'lastPlayed').reverse();
+        } else {
+          return _.sortBy(stores, 'id');
+        }
+      };
+    });
 
   function Stores() {
     return {
@@ -12,9 +21,9 @@
       scope: {},
       link: Link,
       template: [
-        '<div ng-if="vm.stores.length" ng-class="[\'dim-col-\' + vm.charCol, { \'hide-filtered\': vm.hideFilteredItems, itemQuality: vm.itemQuality }]">',
+        '<div ng-if="vm.stores.length" ng-class="[\'dim-col-\' + vm.settings.charCol, { \'hide-filtered\': vm.settings.hideFilteredItems, itemQuality: vm.settings.itemQuality }]">',
         '  <div class="store-row store-header">',
-        '    <div class="store-cell" ng-repeat="store in vm.stores track by store.id">',
+        '    <div class="store-cell" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '      <dim-store-heading class="character" store-data="store"></dim-store-heading>',
         '    </div>',
         '  </div>',
@@ -24,7 +33,7 @@
         '      <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{::vm.vault.capacityForItem({sort: category})}}</span>',
         '    </div>',
         '    <div class="store-row items" ng-repeat="bucket in ::buckets track by bucket.id">',
-        '      <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores track by store.id">',
+        '      <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '        <dim-store-bucket ng-if="::!store.isVault || vm.vault.vaultCounts[category] !== undefined" store-data="store" bucket-items="store.buckets[bucket.id]" bucket="bucket"></dim-store-bucket>',
         '      </div>',
         '    </div>',
@@ -33,7 +42,7 @@
         '    <span>Reputation</span>',
         '  </div>',
         '  <div class="store-row items">',
-        '    <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores track by store.id">',
+        '    <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '      <dim-store-reputation store-data="store"></dim-store-reputation>',
         '    </div>',
         '  </div>',
@@ -54,29 +63,12 @@
   function StoresCtrl(settings, $scope, dimStoreService, dimPlatformService, loadingTracker, dimBucketService) {
     var vm = this;
 
+    vm.settings = settings;
     vm.stores = dimStoreService.getStores();
     vm.vault = dimStoreService.getVault();
     vm.buckets = null;
     dimBucketService.then(function(buckets) {
       vm.buckets = angular.copy(buckets);
-    });
-
-    vm.charCol = 3;
-    settings.getSettings()
-      .then(function(settings) {
-        vm.hideFilteredItems = settings.hideFilteredItems;
-        vm.charCol = Math.max(3, Math.min(settings.charCol, 5));
-        vm.itemQuality = settings.itemQuality;
-      });
-
-    $scope.$on('dim-settings-updated', function(event, arg) {
-      if (_.has(arg, 'charCol')) {
-        vm.charCol = arg.charCol;
-      } else if (_.has(arg, 'hideFilteredItems')) {
-        vm.hideFilteredItems = arg.hideFilteredItems;
-      } else if (_.has(arg, 'itemQuality')) {
-        vm.itemQuality = arg.itemQuality;
-      }
     });
 
     $scope.$on('dim-stores-updated', function(e, stores) {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -213,6 +213,7 @@ a {
 
 .settings td:nth-child(2) {
   white-space: nowrap;
+  min-width: 20em;
 }
 
 @keyframes ngdialog-fadeout {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -211,6 +211,10 @@ a {
 
 /* settings dialog */
 
+.settings td:nth-child(2) {
+  white-space: nowrap;
+}
+
 @keyframes ngdialog-fadeout {
   0% {
     opacity: 1;

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -1,11 +1,6 @@
-<div ng-controller="dimSettingsCtrl">
+<div ng-controller="dimSettingsCtrl as vm">
   <h1>Settings</h1>
   <div class="ngdialog-inner-content">
-  <style>
-    .settings td:nth-child(2) {
-      white-space: nowrap;
-    }
-  </style>
 <!--  <input ng-if='vm.showSync()' type='button' class='btn' ng-click='vm.driveSync()' value='Sync with Drive' />-->
   <form class="settings">
     <table>
@@ -14,7 +9,7 @@
           <label for="condensedItems" title="Items that do not match filter criteria will be hidden.">Hide Unfiltered Items while Filtering</label>
         </td>
         <td>
-          <input type="checkbox" ng-model="vm.settings.hideFilteredItems" ng-change="vm.save('hideFilteredItems')" />
+          <input type="checkbox" ng-model="vm.settings.hideFilteredItems" ng-change="vm.save()" />
         </td>
       </tr>
       <tr>
@@ -22,7 +17,7 @@
           <label for="details" title="Clicking on an item will show a popup that can be expanded to show perk and stat details.  This option will always show that detail when you click on an item.">Always Show Item Details</label>
         </td>
         <td>
-          <input type="checkbox" id="details" ng-model="vm.settings.itemDetails" ng-change="vm.save('itemDetails')" />
+          <input type="checkbox" id="details" ng-model="vm.settings.itemDetails" ng-change="vm.save()" />
         </td>
       </tr>
       <tr>
@@ -30,7 +25,7 @@
           <label for="itemQuality" title="Will enable advanced min/max features on the move dialog and enable the armor comparison view.">Enable advanced stat quality comparison features</label>
         </td>
         <td>
-          <input type="checkbox" id="itemQuality" ng-model="vm.settings.itemQuality" ng-change="vm.save('itemQuality')" />
+          <input type="checkbox" id="itemQuality" ng-model="vm.settings.itemQuality" ng-change="vm.save()" />
         </td>
       </tr>
       <tr>
@@ -38,7 +33,7 @@
           <label for="showElements" title="Show elemental damage icons on weapons.">Show elemental damage icons on weapons</label>
         </td>
         <td>
-          <input type="checkbox" id="showElements" ng-model="vm.settings.showElements" ng-change="vm.save('showElements')" />
+          <input type="checkbox" id="showElements" ng-model="vm.settings.showElements" ng-change="vm.save()" />
         </td>
       </tr>
       <tr>
@@ -47,16 +42,16 @@
         </td>
         <td>
           <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="primaryStat" ng-change="vm.save('itemSort')">Primary stat</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="primaryStat" ng-change="vm.save()">Primary stat</label>
           <br>
           <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="rarityThenPrimary" ng-change="vm.save('itemSort')">Rarity, then primary stat</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="rarityThenPrimary" ng-change="vm.save()">Rarity, then primary stat</label>
           <br>
           <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="rarity" ng-change="vm.save('itemSort')">Rarity, then name</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="rarity" ng-change="vm.save()">Rarity, then name</label>
           <br>
           <label ng-show="vm.settings.itemQuality">
-            <input type="radio" ng-model="vm.settings.itemSort" value="quality" ng-change="vm.save('itemSort')">Stat roll percent, then Prim Stat</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="quality" ng-change="vm.save()">Stat roll percent, then Prim Stat</label>
         </td>
       </tr>
       <tr>
@@ -64,7 +59,7 @@
           <label for="charCol" title="Select the number of columns for character inventory.">Character Inventory Columns</label>
         </td>
         <td>
-          <select id="charCol" ng-model="vm.settings.charCol" ng-options="option.id as option.name for option in vm.charColOptions" required ng-change="vm.save('charCol')"></select>
+          <select id="charCol" ng-model="vm.settings.charCol" ng-options="option.id as option.name for option in vm.charColOptions" required ng-change="vm.save()"></select>
         </td>
       </tr>
       <tr>
@@ -73,10 +68,10 @@
         </td>
         <td>
           <label>
-            <input type="radio" ng-model="vm.settings.characterOrder" value="mostRecent" ng-model-options="{ updateOn: 'default blur', debounce: { default: 500, blur: 0 } }" ng-change="vm.save('characterOrder')">By Most Recent Character</label>
+            <input type="radio" ng-model="vm.settings.characterOrder" value="mostRecent" ng-model-options="{ updateOn: 'default blur' }" ng-change="vm.save()">By Most Recent Character</label>
           <br>
           <label>
-            <input type="radio" ng-model="vm.settings.characterOrder" value="fixed" ng-model-options="{ updateOn: 'default blur', debounce: { default: 500, blur: 0 } }" ng-change="vm.save('characterOrder')">Fixed</label>
+            <input type="radio" ng-model="vm.settings.characterOrder" value="fixed" ng-model-options="{ updateOn: 'default blur' }" ng-change="vm.save()">Fixed</label>
         </td>
       </tr>
     </table>

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -9,7 +9,7 @@
           <label for="condensedItems" title="Items that do not match filter criteria will be hidden.">Hide Unfiltered Items while Filtering</label>
         </td>
         <td>
-          <input type="checkbox" ng-model="vm.settings.hideFilteredItems" ng-change="vm.save()" />
+          <input type="checkbox" ng-model="vm.settings.hideFilteredItems"/>
         </td>
       </tr>
       <tr>
@@ -17,7 +17,7 @@
           <label for="details" title="Clicking on an item will show a popup that can be expanded to show perk and stat details.  This option will always show that detail when you click on an item.">Always Show Item Details</label>
         </td>
         <td>
-          <input type="checkbox" id="details" ng-model="vm.settings.itemDetails" ng-change="vm.save()" />
+          <input type="checkbox" id="details" ng-model="vm.settings.itemDetails"/>
         </td>
       </tr>
       <tr>
@@ -25,7 +25,7 @@
           <label for="itemQuality" title="Will enable advanced min/max features on the move dialog and enable the armor comparison view.">Enable advanced stat quality comparison features</label>
         </td>
         <td>
-          <input type="checkbox" id="itemQuality" ng-model="vm.settings.itemQuality" ng-change="vm.save()" />
+          <input type="checkbox" id="itemQuality" ng-model="vm.settings.itemQuality"/>
         </td>
       </tr>
       <tr>
@@ -33,7 +33,7 @@
           <label for="showElements" title="Show elemental damage icons on weapons.">Show elemental damage icons on weapons</label>
         </td>
         <td>
-          <input type="checkbox" id="showElements" ng-model="vm.settings.showElements" ng-change="vm.save()" />
+          <input type="checkbox" id="showElements" ng-model="vm.settings.showElements"/>
         </td>
       </tr>
       <tr>
@@ -42,16 +42,16 @@
         </td>
         <td>
           <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="primaryStat" ng-change="vm.save()">Primary stat</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="primaryStat">Primary stat</label>
           <br>
           <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="rarityThenPrimary" ng-change="vm.save()">Rarity, then primary stat</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="rarityThenPrimary">Rarity, then primary stat</label>
           <br>
           <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="rarity" ng-change="vm.save()">Rarity, then name</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="rarity">Rarity, then name</label>
           <br>
           <label ng-show="vm.settings.itemQuality">
-            <input type="radio" ng-model="vm.settings.itemSort" value="quality" ng-change="vm.save()">Stat roll percent, then Prim Stat</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="quality">Stat roll percent, then Prim Stat</label>
         </td>
       </tr>
       <tr>
@@ -59,7 +59,7 @@
           <label for="charCol" title="Select the number of columns for character inventory.">Character Inventory Columns</label>
         </td>
         <td>
-          <select id="charCol" ng-model="vm.settings.charCol" ng-options="option.id as option.name for option in vm.charColOptions" required ng-change="vm.save()"></select>
+          <select id="charCol" ng-model="vm.settings.charCol" ng-options="option.id as option.name for option in vm.charColOptions" required></select>
         </td>
       </tr>
       <tr>
@@ -68,10 +68,10 @@
         </td>
         <td>
           <label>
-            <input type="radio" ng-model="vm.settings.characterOrder" value="mostRecent" ng-model-options="{ updateOn: 'default blur' }" ng-change="vm.save()">By Most Recent Character</label>
+            <input type="radio" ng-model="vm.settings.characterOrder" value="mostRecent" ng-model-options="{ updateOn: 'default blur' }">By Most Recent Character</label>
           <br>
           <label>
-            <input type="radio" ng-model="vm.settings.characterOrder" value="fixed" ng-model-options="{ updateOn: 'default blur' }" ng-change="vm.save()">Fixed</label>
+            <input type="radio" ng-model="vm.settings.characterOrder" value="fixed" ng-model-options="{ updateOn: 'default blur' }">Fixed</label>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
This PR changes how we handle settings, by getting rid of the get/set settings methods and just providing a normal JavaScript object. All settings observation can then be achieved via Angular's standard watcher capabilities. This makes settings handling much easier.

As a bonus, I've removed the delay on applying settings, which fixes #615.