### PR TITLE
Group buttons on move popup

### DIFF
--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1416,7 +1416,7 @@ g {
     height: 37px;
     text-align: center;
     line-height: 10px;
-    margin: 6px;
+    margin: 6px 2px;
     cursor: pointer;
     &:focus {
       outline-width: 5px;
@@ -1628,7 +1628,7 @@ g {
   top: 0;
   -webkit-overflow-scrolling: touch;
   z-index: 3;
-  width: 343px;
+  width: 327px;
   top: initial;
   left: initial;
   right: initial;
@@ -1665,6 +1665,7 @@ h2, h3, h4 {
 .locations {
   display: flex;
   flex-direction: row;
+  margin: 0 4px;
 }
 
 .ng-hide {


### PR DESCRIPTION
This is something somebody suggested a long time ago, but it never happened. I think it's a nice subtle improvement - see how buttons for a single character are closer together:

<img width="429" alt="screen shot 2016-06-25 at 11 31 35 pm" src="https://cloud.githubusercontent.com/assets/313208/16360862/3bf30670-3b2d-11e6-894a-57dc0a4b0014.png">
