### PR TITLE
Make the size of items configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Xur's menu item will properly disappear when he leaves for the week.
 * New items are marked with a "shiny" animation, and there are notifications when new items appear.
 * The loadout menu may expand to fill the height of the window, but no more.
+* Items can now be made larger (or smaller) in settings. Pick the perfect size for your screen!
 
 # 3.7.4
 

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -35,6 +35,8 @@
       itemSort: 'primaryStat',
       // How many columns to display character buckets
       charCol: 3,
+      // How big in pixels to draw items
+      itemSize: 44,
 
       save: function() {
         if (!_loaded) {

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .controller('dimAppCtrl', DimApp);
 
-  DimApp.$inject = ['ngDialog', '$rootScope', 'loadingTracker', 'dimPlatformService', 'dimStoreService', '$interval', 'hotkeys', '$timeout', 'dimStoreService', 'dimXurService', 'dimCsvService', 'dimSettingsService', '$window'];
+  DimApp.$inject = ['ngDialog', '$rootScope', 'loadingTracker', 'dimPlatformService', 'dimStoreService', '$interval', 'hotkeys', '$timeout', 'dimStoreService', 'dimXurService', 'dimCsvService', 'dimSettingsService', '$window', '$scope'];
 
-  function DimApp(ngDialog, $rootScope, loadingTracker, dimPlatformService, storeService, $interval, hotkeys, $timeout, dimStoreService, dimXurService, dimCsvService, dimSettingsService, $window) {
+  function DimApp(ngDialog, $rootScope, loadingTracker, dimPlatformService, storeService, $interval, hotkeys, $timeout, dimStoreService, dimXurService, dimCsvService, dimSettingsService, $window, $scope) {
     var vm = this;
     var aboutResult = null;
     var settingResult = null;
@@ -14,6 +14,9 @@
     var filterResult = null;
 
     vm.settings = dimSettingsService;
+    $scope.$watch('app.settings.itemSize', function(size) {
+      document.querySelector('html').style.setProperty("--item-size", size + 'px');
+    });
 
     hotkeys.add({
       combo: ['f'],

--- a/app/scss/_minmax.scss
+++ b/app/scss/_minmax.scss
@@ -51,8 +51,8 @@
 
     .empty-item {
       background-color:#656565;
-      width:48px;
-      height:48px;
+      width: calc(var(--item-size) + 4px);
+      height: calc(var(--item-size) + 4px);
       border:2px solid #DDD;
     }
   }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -2,6 +2,11 @@
 /* css-indent-offset: 2 */
 /* End:                 */
 
+:root {
+  --item-size: 44px;
+}
+
+
 div:focus, span:focus {
   outline-width: 0;
 }
@@ -581,7 +586,7 @@ img {
 }
 
 .sub-bucket {
-  background-size: 44px;
+  background-size: var(--item-size);
   background-position: 4px 4px;
   background-image: url('../images/bg_inventory_bucket_single_crop.png');
   background-repeat: no-repeat;
@@ -707,8 +712,8 @@ img {
   border: 2px solid #DDD;
   > {
     .img, img {
-      width: 44px;
-      height: 44px;
+      width: var(--item-size);
+      height: var(--item-size);
       background-size: cover;
       display: block;
     }
@@ -747,7 +752,7 @@ dim-store-heading {
 .character-box {
   position: relative;
   height: 50px;
-  padding: 0 30px 0 44px;
+  padding: 0 30px 0 var(--item-size);
   /* background: rgba(30, 36, 43, .5); */
   text-shadow: 1px 1px 1px #000000;
   color: #f5f5f5;
@@ -1383,8 +1388,8 @@ rzslider {
   display: inline-block;
   border-radius: 50%;
   margin: 4px;
-  width: 44px;
-  height: 44px;
+  width: var(--item-size);
+  height: var(--item-size);
   background-color: rgba(255, 255, 255, 0.1);
   position: relative;
   height: 100%;
@@ -2012,9 +2017,9 @@ button.toast-close-button {
 @for $i from 3 through 5 {
   .dim-col-#{$i} {
     .store-cell {
-      width: 84px + ($i * 52px);
+      width: calc(84px + (#{$i} * (var(--item-size) + 8px)));
       &.vault {
-        min-width: 70px + ($i * 52px);
+        min-width: calc(70px + (#{$i} * (var(--item-size) + 8px)));
       }
     }
   }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -352,15 +352,6 @@ a {
     font-size: 13px;
     padding: 6px 9px;
     vertical-align: top;
-    span {
-      margin: 2px 4px;
-      color: #eee;
-      display: block;
-      &:hover {
-        color: #68a0b7;
-        cursor: pointer;
-      }
-    }
   }
   input {
     &[type="checkbox"], &[type="radio"] {
@@ -368,6 +359,16 @@ a {
       width: 15px;
       height: 15px;
     }
+  }
+}
+
+.filter-view td span {
+  margin: 2px 4px;
+  color: #eee;
+  display: block;
+  &:hover {
+    color: #68a0b7;
+    cursor: pointer;
   }
 }
 
@@ -523,7 +524,7 @@ img {
 }
 
 .equipped {
-  width: 52px;
+  width: calc(var(--item-size) + 8px);
 }
 
 .unequipped {
@@ -2017,9 +2018,9 @@ button.toast-close-button {
 @for $i from 3 through 5 {
   .dim-col-#{$i} {
     .store-cell {
-      width: calc(84px + (#{$i} * (var(--item-size) + 8px)));
+      width: calc(40px + var(--item-size) + (#{$i} * (var(--item-size) + 8px)));
       &.vault {
-        min-width: calc(70px + (#{$i} * (var(--item-size) + 8px)));
+        min-width: calc(26px + var(--item-size) + (#{$i} * (var(--item-size) + 8px)));
       }
     }
   }

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -79,7 +79,7 @@
           <label for="itemSize" title="How big should items be?">Item Size</label>
         </td>
         <td>
-          <input ng-model="vm.settings.itemSize" type="range" min="44" max="66" ng-change="vm.save()" />
+          <input ng-model="vm.settings.itemSize" type="range" min="38" max="66" ng-change="vm.save()" /> <button ng-click="vm.settings.itemSize = 44">Reset to Default</button>
         </td>
       </tr>
       <tr>

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -76,6 +76,14 @@
       </tr>
       <tr>
         <td>
+          <label for="itemSize" title="How big should items be?">Item Size</label>
+        </td>
+        <td>
+          <input ng-model="vm.settings.itemSize" type="range" min="44" max="66" ng-change="vm.save()" />
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label title="Characters can be ordered by last login or based on their creation date.">Character Order</label>
         </td>
         <td>


### PR DESCRIPTION
This uses a true CSS variable (not a SASS variable) to modify the size of items based on a preference. Items can be made up to 50% larger than they are today. This, combined with the fluid vault sizes, should give folks a lot of nice customizability. Everything smoothly adjusts based on this one variable.

Small:
![screen shot 2016-06-27 at 9 24 13 pm](https://cloud.githubusercontent.com/assets/313208/16403792/a87cbe86-3cad-11e6-89b4-69ff871505a1.png)

Big:
![screen shot 2016-06-27 at 9 24 23 pm](https://cloud.githubusercontent.com/assets/313208/16403793/a9a26054-3cad-11e6-882a-0e85e5857968.png)

Settings:
![screen shot 2016-06-27 at 9 25 07 pm](https://cloud.githubusercontent.com/assets/313208/16403794/aadd7292-3cad-11e6-9c8c-0f44b65b38ed.png)
