### PR TITLE
Change the merge strategy for CHANGELOG.md to avoid conflicts.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
This instructs Git to always take both changes when there are conflicts in CHANGELOG.md. This should prevent merge conflicts from two PRs both adding to the CHANGELOG, which is 99% of conflicts.