### PR TITLE
Don't sort postmaster items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * DIM is generally just a little bit snappier, especially when scrolling.
 * Clicking the icon to open DIM will now switch to an active DIM tab if it's already running.
 * Bungie.net will open in a new tab as a convenience for expired cookies.
+* Items in the Postmaster are sorted by the order you got them, so you know what'll get bumped when your postmaster is full.
 
 # 3.7.4
 

--- a/app/scripts/store/dimStoreBucket.directive.js
+++ b/app/scripts/store/dimStoreBucket.directive.js
@@ -12,6 +12,11 @@
     })
     .filter('sortItems', function() {
       return function(items, sort) {
+        // Don't resort postmaster items - that way people can see
+        // what'll get bumped when it's full.
+        if (items.length && items[0].location.inPostmaster) {
+          return items;
+        }
         items = _.sortBy(items || [], 'name');
         if (sort === 'primaryStat' || sort === 'rarityThenPrimary' || sort === 'quality') {
           items = _.sortBy(items, function(item) {


### PR DESCRIPTION
From Nigel:

> DIM is sorting the postmaster by light I think. It probably should leave the array unsorted as the oldest items in the postmaster are pushed out by the newest ones when you have more than 20 items. The sorting might make people think an item is safe, when it isn’t.