### PR TITLE
Allow and encourage ES6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,12 @@
   },
   "extends": "eslint:recommended",
   "root": true,
-  "ecmaVersion": 5,
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
+  },
   "globals": {
     "angular": true,
     "$": true,
@@ -82,6 +87,24 @@
     "space-in-parens": "error",
     "space-infix-ops": "error",
     "space-unary-ops": "error",
-    "spaced-comment": ["error", "always", { "exceptions": ["-", "*"] }]
+    "spaced-comment": ["error", "always", { "exceptions": ["-", "*"] }],
+    "arrow-parens": "error",
+    "arrow-spacing": "error",
+    "constructor-super": "error",
+    "generator-star-spacing": "error",
+    "no-class-assign": "error",
+    "no-confusing-arrow": "error",
+    "no-const-assign": "error",
+    "no-dupe-class-members": "error",
+    "no-new-symbol": "error",
+    "no-useless-computed-key": "error",
+    "no-useless-constructor": "error",
+    "prefer-const": "error",
+    "prefer-rest-params": "error",
+    "prefer-spread": "error",
+    "require-yield": "error",
+    "rest-spread-spacing": "error",
+    "template-curly-spacing": "error",
+    "yield-star-spacing": "error"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Here are some tips to make sure your pull request can be merged smoothly:
 1. If you want to add a feature or make some change to DIM, consider [filing an issue](https://github.com/DestinyItemManager/DIM/issues/new) describing your idea first. This will give the DIM community a chance to discuss the idea, offer suggestions and pointers, and make sure what you're thinking of fits with the style and direction of DIM.
 2. Resist the temptation to change more than one thing in your PR. Keeping PRs focused on a single change makes them much easier to review and accept. If you want to change multiple things, or clean up/refactor the code, make a new branch and submit those changes as a separate PR.
 3. Please follow the existing style of DIM code when making your changes. While there's certainly room for improvement in the DIM codebase, if everybody used their favorite code style nothing would match up.
-4. DIM is not using ES6 yet, so please avoid ES6-specific language features.
+4. You can use any ES6/ES2015 features [supported by a reasonably modern Chrome version](https://kangax.github.io/compat-table/es6).
 5. Take advantage of the [native JavaScript Array mathods](http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array.html) and the [Underscore](http://underscorejs.com) library to write compact, easy-to-understand code.
 6. Be sure to run `grunt eslint` before submitting your PR - it'll catch most style problems and make things much easier to merge.
 7. Don't forget to add a description of your change to `CHANGELOG.md` so it'll be included in the release notes!

--- a/app/scripts/services/dimActionQueue.factory.js
+++ b/app/scripts/services/dimActionQueue.factory.js
@@ -29,11 +29,9 @@
       // Wrap a function to produce a function that will be queued
       wrap: function(fn, context) {
         var self = this;
-        return function() {
-          var args = arguments;
+        return function(...args) {
           return self.queueAction(function() {
-            var res = fn.apply(context, args);
-            return res;
+            return fn.apply(context, args);
           });
         };
       }

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -1018,7 +1018,7 @@
           _.each(items, function(item) {
             var createdItem = null;
             try {
-              createdItem = processSingleItem.apply(undefined, args.concat(item));
+              createdItem = processSingleItem(...args, item);
             } catch (e) {
               console.error("Error processing item", item, e);
             }


### PR DESCRIPTION
I was about to set up Babel for DIM so we could use ES6 features, when I realized that [Chrome and Firefox both support ES6 natively](https://kangax.github.io/compat-table/es6/). So there's no reason to mangle our code into unreadable, questionably performant, bloated Babel output - we can just write ES6 directly! Chrome support is pretty much complete as of recent versions, and Firefox only has a few gotchas.

This change mainly sets up eslint to understand and have rules for ES6, and changes the Contributor Guide to encourage ES6.