### PR TITLE
Fix move popup to use jquery.position, fix page jumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Items in the Postmaster are sorted by the order you got them, so you know what'll get bumped when your postmaster is full.
 * Clicking the loadout builder button again, or the DIM logo, will take you back to the main screen.
 * You may now order your characters by the reverse of the most recent, so the most recent character is next to the vault.
+* The screen no longer jumps around when clicking on items, and the item details popup should always be visible.
 
 # 3.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * Fixed wobbly refresh icon.
+* The screen no longer jumps around when clicking on items, and the item details popup should always be visible.
 
 # 3.8.0
 
@@ -28,7 +29,6 @@
 * Items in the Postmaster are sorted by the order you got them, so you know what'll get bumped when your postmaster is full.
 * Clicking the loadout builder button again, or the DIM logo, will take you back to the main screen.
 * You may now order your characters by the reverse of the most recent, so the most recent character is next to the vault.
-* The screen no longer jumps around when clicking on items, and the item details popup should always be visible.
 
 # 3.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Next
 * Update filter list to include quality/percentage filters
 * Add year column to CSV export scripts
+* The screen no longer jumps around when clicking on items, and the item details popup should always be visible.
 
 # 3.8.1
 
 * Added steps to Moments of Triumph popup (and other record books.)
 * Fixed wobbly refresh icon.
-* The screen no longer jumps around when clicking on items, and the item details popup should always be visible.
 * Fixed single item stat percentages.
 * Fixed armor export script.
 * Possible fix for loadout builder.

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -12,7 +12,8 @@
       scope: {
         item: '=dimMoveItemProperties',
         compareItem: '=dimCompareItem',
-        infuse: '=dimInfuse'
+        infuse: '=dimInfuse',
+        changeDetails: '&'
       },
       restrict: 'A',
       replace: true,
@@ -35,7 +36,7 @@
         '      </span>',
         '      {{ vm.light }} {{ vm.item.typeName }}',
         '      <span ng-if="vm.item.objectives">({{ vm.item.percentComplete | percent }} Complete)</span>',
-        '      <a ng-if="!vm.showDetailsByDefault && (vm.showDescription || vm.hasDetails) && !vm.item.classified;" href ng-click="vm.itemDetails = !vm.itemDetails">',
+        '      <a ng-if="!vm.showDetailsByDefault && (vm.showDescription || vm.hasDetails) && !vm.item.classified;" href ng-click="vm.changeDetails(); vm.itemDetails = !vm.itemDetails">',
         '        <i class="info fa" ng-class="{ \'fa-chevron-circle-up\': vm.itemDetails, \'fa-chevron-circle-down\': !vm.itemDetails }">',
         '        </i>',
         '      </a>',
@@ -102,6 +103,7 @@
     // The 'i' keyboard shortcut toggles full details
     $scope.$on('dim-toggle-item-details', function() {
       vm.itemDetails = !vm.itemDetails;
+      vm.changeDetails();
     });
 
     vm.setLockState = function setLockState(item) {

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -17,7 +17,7 @@
       replace: true,
       template: [
         '<div class="move-popup" alt="" title="">',
-        '  <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse"></div>',
+        '  <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse" change-details="vm.reposition()"></div>',
         '  <dim-move-amount ng-if="vm.item.amount > 1 && !vm.item.notransfer" amount="vm.moveAmount" maximum="vm.maximum"></dim-move-amount>',
         '  <div class="interaction">',
         '    <div class="locations" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
@@ -54,10 +54,41 @@
     };
   }
 
-  MovePopupController.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster', 'dimActionQueue', 'dimInfoService'];
+  MovePopupController.$inject = ['$scope', 'loadingTracker', 'dimStoreService', 'dimItemService', 'ngDialog', '$q', 'toaster', 'dimActionQueue', 'dimInfoService', '$timeout'];
 
-  function MovePopupController($scope, loadingTracker, dimStoreService, dimItemService, ngDialog, $q, toaster, dimActionQueue, dimInfoService) {
+  function MovePopupController($scope, loadingTracker, dimStoreService, dimItemService, ngDialog, $q, toaster, dimActionQueue, dimInfoService, $timeout) {
     var vm = this;
+
+    var shown = false;
+
+    // Capture the dialog element
+    var dialog = null;
+    $scope.$on('ngDialog.opened', function(event, $dialog) {
+      dialog = $dialog;
+      vm.reposition();
+    });
+
+    // Reposition the popup as it is shown or if its size changes
+    vm.reposition = function() {
+      var element = $scope.$parent.ngDialogData;
+      if (element) {
+        if (!shown) {
+          dialog.hide();
+        }
+        shown = true;
+        $timeout(function() {
+          dialog
+            .position({
+              my: 'left bottom',
+              at: 'left top-2',
+              of: element,
+              collision: 'flip flip',
+              within: '.stores'
+            })
+            .show();
+        });
+      }
+    };
 
     // TODO: cache this, instead?
     $scope.$watch('vm.item', function() {

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -46,7 +46,7 @@
         item: '=itemData'
       },
       template: [
-        '<div ui-draggable="{{ ::vm.draggable }}" drag-channel="{{ ::vm.dragChannel }}" ',
+        '<div ui-draggable="{{ ::vm.draggable }}" id="{{ ::vm.item.index }}" drag-channel="{{ ::vm.dragChannel }}" ',
         '  title="{{vm.item.primStat.value}} {{::vm.item.name}}" ',
         '  drag="::vm.item.index"',
         '  class="item"',

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -46,7 +46,7 @@
         item: '=itemData'
       },
       template: [
-        '<div ui-draggable="{{ ::vm.draggable }}" id="{{ ::vm.item.index }}" drag-channel="{{ ::vm.dragChannel }}" ',
+        '<div ui-draggable="{{ ::vm.draggable }}" drag-channel="{{ ::vm.dragChannel }}" ',
         '  title="{{vm.item.primStat.value}} {{::vm.item.name}}" ',
         '  drag="::vm.item.index"',
         '  class="item"',
@@ -97,6 +97,17 @@
         });
       }
 
+      scope.$on('ngDialog.opened', function(event, $dialog) {
+        if (dialogResult && $dialog[0].id === dialogResult.id) {
+          $dialog.position({
+            my: 'left top',
+            at: 'left bottom+2',
+            of: element,
+            collision: 'flip'
+          });
+        }
+      });
+
       vm.clicked = function openPopup(item, e) {
         e.stopPropagation();
 
@@ -117,17 +128,17 @@
         } else if (dimLoadoutService.dialogOpen) {
           dimLoadoutService.addItemToLoadout(item, e);
         } else {
-          var bottom = ($(element).offset().top < 400) ? ' move-popup-bottom' : '';
-          var right = ((($('body').width() - $(element).offset().left - 320) < 0) ? ' move-popup-right' : '');
-
           dialogResult = ngDialog.open({
             template: '<div ng-click="$event.stopPropagation();" dim-click-anywhere-but-here="vm.closePopup()" dim-move-popup dim-store="vm.store" dim-item="vm.item"></div>',
             plain: true,
-            appendTo: 'div[id="' + item.index + '"]',
             overlay: false,
-            className: 'move-popup' + right + bottom,
+            className: 'move-popup-dialog',
             showClose: false,
-            scope: scope
+            scope: scope,
+            // Setting these focus options prevents the page from
+            // jumping as dialogs are shown/hidden
+            trapFocus: false,
+            preserveFocus: false
           });
           otherDialog = dialogResult;
 

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -97,23 +97,6 @@
         });
       }
 
-      scope.$on('ngDialog.opened', function(event, $dialog) {
-        if (dialogResult && $dialog[0].id === dialogResult.id) {
-          $dialog.hide();
-          setTimeout(function() {
-            $dialog
-              .position({
-                my: 'left bottom',
-                at: 'left top-2',
-                of: element,
-                collision: 'flip flip',
-                within: '.stores'
-              })
-              .show();
-          }, 0);
-        }
-      });
-
       vm.clicked = function openPopup(item, e) {
         e.stopPropagation();
 
@@ -135,11 +118,12 @@
           dimLoadoutService.addItemToLoadout(item, e);
         } else {
           dialogResult = ngDialog.open({
-            template: '<div ng-click="$event.stopPropagation();" dim-click-anywhere-but-here="vm.closePopup()" dim-move-popup dim-store="vm.store" dim-item="vm.item"></div>',
+            template: '<div ng-click="$event.stopPropagation();" dim-click-anywhere-but-here="closeThisDialog()" dim-move-popup dim-store="vm.store" dim-item="vm.item"></div>',
             plain: true,
             overlay: false,
             className: 'move-popup-dialog',
             showClose: false,
+            data: element,
             scope: scope,
             // Setting these focus options prevents the page from
             // jumping as dialogs are shown/hidden
@@ -151,12 +135,6 @@
           dialogResult.closePromise.then(function() {
             dialogResult = null;
           });
-        }
-      };
-
-      vm.closePopup = function closePopup() {
-        if (!_.isNull(dialogResult)) {
-          dialogResult.close();
         }
       };
 

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -99,12 +99,18 @@
 
       scope.$on('ngDialog.opened', function(event, $dialog) {
         if (dialogResult && $dialog[0].id === dialogResult.id) {
-          $dialog.position({
-            my: 'left top',
-            at: 'left bottom+2',
-            of: element,
-            collision: 'flip'
-          });
+          $dialog.hide();
+          setTimeout(function() {
+            $dialog
+              .position({
+                my: 'left bottom',
+                at: 'left top-2',
+                of: element,
+                collision: 'flip flip',
+                within: '.stores'
+              })
+              .show();
+          }, 0);
         }
       });
 

--- a/app/scripts/store/dimStoreReputation.directive.js
+++ b/app/scripts/store/dimStoreReputation.directive.js
@@ -9,15 +9,15 @@
     template: [
       '<div class="sub-section sort-progression">',
       '  <div class="unequipped">',
-      '    <span class="item" ng-if="faction.color" ng-repeat="faction in vm.store.progression.progressions | orderBy:\'order\' track by $index" title="{{faction.label}}\n{{faction.progressToNextLevel}}/{{faction.nextLevelAt}}\nLevel: {{faction.level}}">',
+      '    <div class="item" ng-if="faction.color" ng-repeat="faction in vm.store.progression.progressions | orderBy:\'order\' track by $index" title="{{faction.label}}\n{{faction.progressToNextLevel}}/{{faction.nextLevelAt}}\nLevel: {{faction.level}}">',
       '      <svg width="48" height="48">',
       '        <polygon stroke-dasharray="130" fill="{{faction.color}}" points="24,1 47,24 24,47 1,24"/>',
       '        <image xlink:href="" ng-attr-xlink:href="{{faction.icon | bungieIcon}}" ng-attr-x="{{faction.scale === \'.8\' ? 6 : 48-(faction.scale*48)}}" ng-attr-y="{{faction.scale === \'.8\' ? 6 : 48-(faction.scale*48)}}" width="48" height="48" ng-attr-transform="scale({{faction.scale}})" />',
       '        <polygon fill-opacity="0" stroke="#666" stroke-width="2" points="24,1 47,24 24,47 1,24" stroke-linecap="square"/>',
       '        <polygon stroke-dasharray="130" ng-if="faction.progressToNextLevel > 0" style="stroke-dashoffset:{{130-(130*faction.progressToNextLevel/faction.nextLevelAt)}}" fill-opacity="0" stroke="#FFF" stroke-width="2" points="24,1 47,24 24,47 1,24" stroke-linecap="square"/>',
       '      </svg>',
-      '      <span class="item-stat item-faction" ng-bind="faction.level"></span>',
-      '    </span>',
+      '      <div class="item-stat item-faction" ng-bind="faction.level"></div>',
+      '    </div>',
       '  </div>',
       '</div>'
     ].join('')

--- a/app/scripts/xur/dimXur.controller.js
+++ b/app/scripts/xur/dimXur.controller.js
@@ -33,17 +33,6 @@
       countCurrencies();
     });
 
-    $scope.$on('ngDialog.opened', function(event, $dialog) {
-      if (dialogResult) {
-        $dialog.position({
-          my: 'left top',
-          at: 'left bottom+2',
-          of: detailItemElement,
-          collision: 'flip'
-        });
-      }
-    });
-
     angular.extend(vm, {
       itemCategories: dimXurService.itemCategories,
       categoryOrder: [
@@ -89,6 +78,7 @@
             showClose: false,
             scope: angular.extend($scope.$new(true), {
             }),
+            data: detailItemElement,
             controllerAs: 'vm',
             controller: [function() {
               var vm = this;

--- a/app/scripts/xur/dimXur.controller.js
+++ b/app/scripts/xur/dimXur.controller.js
@@ -37,7 +37,7 @@
       if (dialogResult) {
         $dialog.position({
           my: 'left top',
-          at: 'left bottom+4',
+          at: 'left bottom+2',
           of: detailItemElement,
           collision: 'flip'
         });

--- a/app/scss/_move-popup.scss
+++ b/app/scss/_move-popup.scss
@@ -4,12 +4,17 @@
 // The popup displaying info and actions for an single item.
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+.move-popup-dialog {
+  height: fit-content;
+}
+
 .move-popup {
   background-color: #222;
   cursor: default;
-  bottom: 50px;
   min-height: 77px;
   width: 320px;
+  height: fit-content;
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, .8);
 
   .interaction {
     display: flex;
@@ -79,7 +84,7 @@
     background-image: url(/images/arrows-in.png);
   }
 }
-
+/*
 .move-popup-right {
   right: 0;
 }
@@ -87,13 +92,12 @@
 .move-popup-bottom {
   top: 50px;
 }
+*/
 
 .ngdialog.xur-move-popup {
   position: fixed;
-  height: 0;
   z-index: 10000;
-  height: fit-content;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, .8);
+
   .compare-items {
     margin-top: 0;
     display: flex;

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -208,7 +208,8 @@ a {
 .ngdialog-content > div {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: fit-content;
+  max-height: 100%;
 }
 
 .ngdialog-inner-content {
@@ -297,6 +298,7 @@ a {
     padding: 0;
   }
   h1 {
+    flex-shrink: 0;
     margin-top: 0;
     margin-bottom: 0;
     padding: 15px 25px;
@@ -388,10 +390,7 @@ h2, h3 {
 }
 
 body {
-  &.ngdialog-open {
-    overflow: auto;
-  }
-  overflow-y: scroll;
+  overflow-y: auto;
   min-width: 410px;
   margin: 0 auto;
   padding-top: 40px;


### PR DESCRIPTION
This fixes the "jumping" that happened when clicking items (it was caused by moving the input focus around), and positions the dialog such that it won't ever be offscreen. The major differences now:

1. No more page jumping.
2. There's a drop shadow.
3. The dialog is slightly closer to the item.
4. The dialog prefers showing up below the item, rather than above it (which was the preference before). It's easier to scroll down to see more info.
5. The dialog will never be offscreen or hidden.
6. In the minmax tool, the dialog will always show up next to the thing you clicked, rather than the first instance of it in the page. This is because we no longer use the element ID to position the dialog.

On the dev side, we've got some nice properties such as the popup being attached to `body` instead of the item (which means it won't accidentally inherit styles, etc).

I'll add on a change to this that moves the move popup into its own service (like ngDialog) so it can be safely used from all kinds of places.

This fixes #621, #539, and #508.