### PR TITLE
Fix for large overlay on new items on drag

### DIFF
--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -24,6 +24,7 @@ div:focus, span:focus {
   animation: new_overlay 5s infinite;
   width: var(--item-size);
   height: var(--item-size);
+  pointer-events: none;
 }
 
 .new_overlay_overflow {


### PR DESCRIPTION
Dragging new items while the overlay is showing results in a large overlay being dragged around instead of the item.

This fixes that issue.