### PR TITLE
Restore max vault size setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * The screen no longer jumps around when clicking on items, and the item details popup should always be visible.
 * Dialogs should be sized better now.
 * Fix character order in move popup buttons.
+* Restored the ability to set a maximum vault size. "Auto" (full width) is still an option, and is the default.
 
 # 3.8.1
 

--- a/app/index.html
+++ b/app/index.html
@@ -48,7 +48,7 @@
       <div class="about modal-dialog" ng-show="app.about"></div>
       <div class="donate modal-dialog" ng-show="app.donate"></div>
       <div class="filters modal-dialog" ng-show="app.filters"></div>
-      <div id="content" ui-view></div>
+      <div id="content" class="content" ui-view></div>
     </div>
 
     <script src="scripts/google.js?v=$DIM_VERSION"></script>

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -35,6 +35,8 @@
       itemSort: 'primaryStat',
       // How many columns to display character buckets
       charCol: 3,
+      // How many columns to display vault buckets
+      vaultMaxCol: 999,
       // How big in pixels to draw items
       itemSize: 44,
 

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -17,6 +17,14 @@
     $scope.$watch('app.settings.itemSize', function(size) {
       document.querySelector('html').style.setProperty("--item-size", size + 'px');
     });
+    $scope.$watch('app.settings.charCol', function(cols) {
+      document.querySelector('html').style.setProperty("--character-columns", cols);
+    });
+
+    $scope.$watch('app.settings.vaultMaxCol', function(cols) {
+      document.querySelector('html').style.setProperty("--vault-max-columns", cols);
+    });
+
 
     hotkeys.add({
       combo: ['f'],

--- a/app/scripts/shell/dimSettingsCtrl.controller.js
+++ b/app/scripts/shell/dimSettingsCtrl.controller.js
@@ -12,11 +12,9 @@
       settings.save();
     });
 
-    vm.charColOptions = [
-      { id: 3, name: '3' },
-      { id: 4, name: '4' },
-      { id: 5, name: '5' }
-    ];
+    vm.charColOptions = _.range(3, 6).map((num) => ({ id: num, name: num }));
+    vm.vaultColOptions = _.range(5, 21).map((num) => ({ id: num, name: num }));
+    vm.vaultColOptions.unshift({ id: 999, name: 'Auto' });
 
     vm.settings = settings;
 

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -29,7 +29,7 @@
       scope: {},
       link: Link,
       template: [
-        '<div ng-if="vm.stores.length" ng-class="[\'dim-col-\' + vm.settings.charCol, { \'hide-filtered\': vm.settings.hideFilteredItems, itemQuality: vm.settings.itemQuality }]">',
+        '<div ng-if="vm.stores.length" ng-class="{ \'hide-filtered\': vm.settings.hideFilteredItems, itemQuality: vm.settings.itemQuality }">',
         '  <div class="store-row store-header">',
         '    <div class="store-cell" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '      <dim-store-heading class="character" store-data="store"></dim-store-heading>',
@@ -61,10 +61,10 @@
     function Link($scope) {
       function stickyHeader(e) {
         $(document.body).toggleClass('something-is-sticky', document.body.scrollTop !== 0);
-        $('.store-header').css('left', 'calc(4em - ' + document.body.scrollLeft + 'px)');
       }
 
       $(document).on('scroll', stickyHeader);
+
       $scope.$on('$destroy', function() {
         $(document).off('scroll', stickyHeader);
       });

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -4,6 +4,8 @@
 
 :root {
   --item-size: 44px;
+  --character-columns: 3;
+  --vault-max-columns: 999;
 }
 
 
@@ -1283,16 +1285,22 @@ g {
 }
 
 #content {
-  margin: 0 4em;
+  margin: 15px auto;
+  padding: 0 2em;
   margin-top: 15px;
   user-select: none;
 }
 
+.content {
+  // This assumes 3 characters
+  min-width: calc((52px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px))) * 3 + 39px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px)));
+  max-width: calc((52px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px))) * 3 + 20px + (var(--vault-max-columns) * (var(--item-size) + 8px)));
+}
+
 #header {
-  min-width: 952px;
   .content {
-    margin: 0 4em;
-    padding: 12px 0;
+    margin: 0 auto;
+    padding: 12px 2em;
     > {
       .link, .header-right {
         margin-top: 1px;
@@ -1322,8 +1330,10 @@ g {
   flex-shrink: 0;
   display: flex;
   margin-right: 12px;
+  width: calc(40px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px)));
 
   &.vault {
+    max-width: calc(8px + (var(--vault-max-columns) * (var(--item-size) + 8px)));
     background-color: rgba(245, 245, 245, 0.25);
     padding: 0 12px 1px;
     margin-left: -12px;
@@ -1783,18 +1793,6 @@ button.toast-close-button {
     background-color: #5EA16A;
   }
 }
-
-@for $i from 3 through 5 {
-  .dim-col-#{$i} {
-    .store-cell {
-      width: calc(40px + var(--item-size) + (#{$i} * (var(--item-size) + 8px)));
-      &.vault {
-        min-width: calc(26px + var(--item-size) + (#{$i} * (var(--item-size) + 8px)));
-      }
-    }
-  }
-}
-
 
 /* Infuse */
 

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -76,6 +76,14 @@
       </tr>
       <tr>
         <td>
+          <label for="charCol" title="Select the maximum number of columns for vault.">Vault Maximum Inventory Columns</label>
+        </td>
+        <td>
+          <select id="charCol" ng-model="vm.settings.vaultMaxCol" ng-options="option.id as option.name for option in vm.vaultColOptions" required></select>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label for="itemSize" title="How big should items be?">Item Size</label>
         </td>
         <td>


### PR DESCRIPTION
I've used the magic of CSS variables to reimplement max-vault-size much more flexibly than before. The calculations are truly dynamic and responsive, and take into account your chosen item size, as well as responding well to having the window resized smaller than the number of columns you've chose. DIM will resize and center itself, including the header, as you choose different combinations. I also reduced padding on the full width view for folks who need more real estate.

Hopefully this should make everyone happy!

![screen shot 2016-07-08 at 10 12 11 pm](https://cloud.githubusercontent.com/assets/313208/16706229/0e6bda84-4559-11e6-83ac-fb9cc643f567.png)
