### PR TITLE
Fix platform switching

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,8 @@
     "chrome": true,
     "sum": true,
     "count": true,
-    "gapi": true
+    "gapi": true,
+    "Set": true
   },
   "rules": {
     "array-callback-return": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * If you have an open loadout, and you click "Create loadout", it switches to the new loadout now instead of leaving the previous loadout open.
 * DIM is once again faster.
 * The loadout editor won't stay visible when you change platforms.
+* Fixed a lot of bugs that would show all your items as new.
+* New-ness of items persists across reloads and syncs across your Chrome profile.
+* New button to clear all new items. Keyboard shortcut is "x".
+* Help dialog for keyboard shortcuts. Triggered with "?".
 
 # 3.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Show current vendor items being sold
 * Move popup won't pop up under the header anymore.
 * If you have an open loadout, and you click "Create loadout", it switches to the new loadout now instead of leaving the previous loadout open.
+* DIM is once again faster.
+* The loadout editor won't stay visible when you change platforms.
 
 # 3.8.3
 

--- a/app/index.html
+++ b/app/index.html
@@ -113,6 +113,7 @@
     <script src="scripts/store/dimSimpleItem.directive.js?v=$DIM_VERSION"></script>
     <script src="scripts/store/dimStats.directive.js?v=$DIM_VERSION"></script>
     <script src="scripts/store/dimEngramFarming.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/store/dimClearNewItems.directive.js?v=$DIM_VERSION"></script>
     <script src="scripts/move-popup/dimMoveAmount.directive.js?v=$DIM_VERSION"></script>
     <script src="scripts/move-popup/dimMovePopup.directive.js?v=$DIM_VERSION"></script>
     <script src="scripts/move-popup/dimTalentGrid.directive.js?v=$DIM_VERSION"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -32,7 +32,7 @@
             <div dim-platform-choice class="header-right"></div>
             <div class="header-right" id="actions">
               <span class="link" ng-click="app.refresh($event)" title="Refresh Destiny Data"><i ng-class="{'fa-spin': loadingTracker.active()}" class="fa fa-refresh"></i></span>
-              <span class="link" ng-disabled="loadingTracker.active()" ng-click="app.toggleMinMax($event)" title="Loadout Builder"><i class="fa fa-bar-chart"></i></span>
+              <span class="link" ng-click="app.toggleMinMax($event)" title="Loadout Builder"><i class="fa fa-bar-chart"></i></span>
               <span class="link" ng-click="app.showSetting($event)" title="Settings"><i class="fa fa-cog"></i></span>
               <span class="link" ng-click="app.showFilters($event)" title="Filters"><i class="fa fa-filter"></i></span>
               <span class="link" title="Search"><span focus-on="clicked" dim-search-filter=""></span></span>
@@ -41,7 +41,7 @@
           <span class="logo link" ui-sref="inventory" title="v$DIM_VERSION">DIM</span>
           <span class="link" ng-click="app.showAbout($event)">About</span>
           <span class="link" ng-click="app.showSupport($event)">Support DIM</span>
-          <span class="link" ng-disabled="loadingTracker.active()" ui-sref="vendors">Vendors</span>
+          <span class="link" ng-click="app.toggleVendors($event)">Vendors</span>
           <span class="link" ng-if="app.xur.available" ng-click="app.showXur($event)">Xûr</span>
         </div>
       </div>

--- a/app/index.html
+++ b/app/index.html
@@ -21,6 +21,7 @@
     <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="stylesheet" href="vendor/components-font-awesome/css/font-awesome.min.css">
+    <link rel="stylesheet" href="vendor/angular-hotkeys/build/hotkeys.css">
     <link rel="stylesheet" href="styles/main.css?v=$DIM_VERSION">
   </head>
 

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -92,7 +92,7 @@
     .config([
       'hotkeysProvider',
       function(hotkeysProvider) {
-        hotkeysProvider.includeCheatSheet = false;
+        hotkeysProvider.includeCheatSheet = true;
       }
     ])
     .config([

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -97,6 +97,10 @@
       scope.$on('dim-store-item-clicked', function(event, args) {
         vm.add(args.item, args.clickEvent);
       });
+
+      scope.$on('dim-active-platform-updated', function() {
+        vm.show = false;
+      });
     }
   }
 

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -181,123 +181,120 @@
 
     function applyLoadout(store, loadout) {
       return dimActionQueue.queueAction(function() {
-        return dimStoreService.afterStoreSync()
+        var items = angular.copy(_.flatten(_.values(loadout.items)));
+        var totalItems = items.length;
+
+        var loadoutItemIds = items.map(function(i) {
+          return {
+            id: i.id,
+            hash: i.hash
+          };
+        });
+
+        // Only select stuff that needs to change state
+        items = _.filter(items, function(pseudoItem) {
+          var item = dimItemService.getItem(pseudoItem);
+          return !item ||
+            !item.equipment ||
+            item.owner !== store.id ||
+            item.equipped !== pseudoItem.equipped;
+        });
+
+        // vault can't equip
+        if (store.isVault) {
+          items.forEach(function(i) { i.equipped = false; });
+        }
+
+        // We'll equip these all in one go!
+        var itemsToEquip = _.filter(items, 'equipped');
+        if (itemsToEquip.length > 1) {
+          // we'll use the equipItems function
+          itemsToEquip.forEach(function(i) { i.equipped = false; });
+        }
+
+        // Stuff that's equipped on another character. We can bulk-dequip these
+        var itemsToDequip = _.filter(items, function(pseudoItem) {
+          var item = dimItemService.getItem(pseudoItem);
+          return item.owner !== store.id && item.equipped;
+        });
+
+        var scope = {
+          failed: 0,
+          total: totalItems,
+          successfulItems: []
+        };
+
+        var promise = $q.when();
+
+        if (itemsToDequip.length > 1) {
+          var realItemsToDequip = itemsToDequip.map(function(i) {
+            return dimItemService.getItem(i);
+          });
+          var dequips = _.map(_.groupBy(realItemsToDequip, 'owner'), function(dequipItems, owner) {
+            var equipItems = realItemsToDequip.map(function(i) {
+              return dimItemService.getSimilarItem(i, loadoutItemIds);
+            });
+            return dimItemService.equipItems(dimStoreService.getStore(owner), equipItems);
+          });
+          promise = $q.all(dequips);
+        }
+
+        promise = promise
           .then(function() {
-            var items = angular.copy(_.flatten(_.values(loadout.items)));
-            var totalItems = items.length;
-
-            var loadoutItemIds = items.map(function(i) {
-              return {
-                id: i.id,
-                hash: i.hash
-              };
-            });
-
-            // Only select stuff that needs to change state
-            items = _.filter(items, function(pseudoItem) {
-              var item = dimItemService.getItem(pseudoItem);
-              return !item ||
-                !item.equipment ||
-                item.owner !== store.id ||
-                item.equipped !== pseudoItem.equipped;
-            });
-
-            // vault can't equip
-            if (store.isVault) {
-              items.forEach(function(i) { i.equipped = false; });
-            }
-
-            // We'll equip these all in one go!
-            var itemsToEquip = _.filter(items, 'equipped');
+            return applyLoadoutItems(store, items, loadout, loadoutItemIds, scope);
+          })
+          .then(function() {
             if (itemsToEquip.length > 1) {
-              // we'll use the equipItems function
-              itemsToEquip.forEach(function(i) { i.equipped = false; });
-            }
-
-            // Stuff that's equipped on another character. We can bulk-dequip these
-            var itemsToDequip = _.filter(items, function(pseudoItem) {
-              var item = dimItemService.getItem(pseudoItem);
-              return item.owner !== store.id && item.equipped;
-            });
-
-            var scope = {
-              failed: 0,
-              total: totalItems,
-              successfulItems: []
-            };
-
-            var promise = $q.when();
-
-            if (itemsToDequip.length > 1) {
-              var realItemsToDequip = itemsToDequip.map(function(i) {
+              // Use the bulk equipAll API to equip all at once.
+              itemsToEquip = _.filter(itemsToEquip, function(i) {
+                return _.find(scope.successfulItems, { id: i.id });
+              });
+              var realItemsToEquip = itemsToEquip.map(function(i) {
                 return dimItemService.getItem(i);
               });
-              var dequips = _.map(_.groupBy(realItemsToDequip, 'owner'), function(dequipItems, owner) {
-                var equipItems = realItemsToDequip.map(function(i) {
-                  return dimItemService.getSimilarItem(i, loadoutItemIds);
-                });
-                return dimItemService.equipItems(dimStoreService.getStore(owner), equipItems);
+              return dimItemService.equipItems(store, realItemsToEquip);
+            } else {
+              return itemsToEquip;
+            }
+          })
+          .then(function(equippedItems) {
+            if (equippedItems.length < itemsToEquip.length) {
+              var failedItems = _.filter(itemsToEquip, function(i) {
+                return !_.find(equippedItems, { id: i.id });
               });
-              promise = $q.all(dequips);
+              failedItems.forEach(function(item) {
+                scope.failed++;
+                toaster.pop('error', loadout.name, 'Could not equip ' + item.name);
+              });
+            }
+          })
+          .then(function() {
+            // We need to do this until https://github.com/DestinyItemManager/DIM/issues/323
+            // is fixed on Bungie's end. When that happens, just remove this call.
+            if (scope.successfulItems.length > 0) {
+              return dimStoreService.updateCharacters();
+            }
+            return undefined;
+          })
+          .then(function() {
+            var value = 'success';
+            var message = 'Your loadout of ' + scope.total + ' items has been transferred to your ' + store.name + '.';
+
+            if (scope.failed > 0) {
+              if (scope.failed === scope.total) {
+                value = 'error';
+                message = 'None of the items in your loadout could be transferred.';
+              } else {
+                value = 'warning';
+                message = 'Your loadout has been partially transferred, but ' + scope.failed + ' of ' + scope.total + ' items had errors.';
+              }
             }
 
-            promise = promise
-              .then(function() {
-                return applyLoadoutItems(store, items, loadout, loadoutItemIds, scope);
-              })
-              .then(function() {
-                if (itemsToEquip.length > 1) {
-                  // Use the bulk equipAll API to equip all at once.
-                  itemsToEquip = _.filter(itemsToEquip, function(i) {
-                    return _.find(scope.successfulItems, { id: i.id });
-                  });
-                  var realItemsToEquip = itemsToEquip.map(function(i) {
-                    return dimItemService.getItem(i);
-                  });
-                  return dimItemService.equipItems(store, realItemsToEquip);
-                } else {
-                  return itemsToEquip;
-                }
-              })
-              .then(function(equippedItems) {
-                if (equippedItems.length < itemsToEquip.length) {
-                  var failedItems = _.filter(itemsToEquip, function(i) {
-                    return !_.find(equippedItems, { id: i.id });
-                  });
-                  failedItems.forEach(function(item) {
-                    scope.failed++;
-                    toaster.pop('error', loadout.name, 'Could not equip ' + item.name);
-                  });
-                }
-              })
-              .then(function() {
-                // We need to do this until https://github.com/DestinyItemManager/DIM/issues/323
-                // is fixed on Bungie's end. When that happens, just remove this call.
-                if (scope.successfulItems.length > 0) {
-                  return dimStoreService.updateCharacters();
-                }
-                return undefined;
-              })
-              .then(function() {
-                var value = 'success';
-                var message = 'Your loadout of ' + scope.total + ' items has been transferred to your ' + store.name + '.';
-
-                if (scope.failed > 0) {
-                  if (scope.failed === scope.total) {
-                    value = 'error';
-                    message = 'None of the items in your loadout could be transferred.';
-                  } else {
-                    value = 'warning';
-                    message = 'Your loadout has been partially transferred, but ' + scope.failed + ' of ' + scope.total + ' items had errors.';
-                  }
-                }
-
-                toaster.pop(value, loadout.name, message);
-              });
-
-            loadingTracker.addPromise(promise);
-            return promise;
+            toaster.pop(value, loadout.name, message);
           });
+
+        loadingTracker.addPromise(promise);
+        return promise;
       });
     }
 

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -384,26 +384,23 @@
         items: {}
       };
 
-      dimStoreService.afterStoreSync()
-        .then(function() {
-          _.each(loadoutPrimitive.items, function(itemPrimitive) {
-            var item = angular.copy(dimItemService.getItem({
-              id: itemPrimitive.id,
-              hash: itemPrimitive.hash
-            }));
+      _.each(loadoutPrimitive.items, function(itemPrimitive) {
+        var item = angular.copy(dimItemService.getItem({
+          id: itemPrimitive.id,
+          hash: itemPrimitive.hash
+        }));
 
-            if (item) {
-              var discriminator = item.type.toLowerCase();
+        if (item) {
+          var discriminator = item.type.toLowerCase();
 
-              item.equipped = itemPrimitive.equipped;
+          item.equipped = itemPrimitive.equipped;
 
-              item.amount = itemPrimitive.amount;
+          item.amount = itemPrimitive.amount;
 
-              result.items[discriminator] = (result.items[discriminator] || []);
-              result.items[discriminator].push(item);
-            }
-          });
-        });
+          result.items[discriminator] = (result.items[discriminator] || []);
+          result.items[discriminator].push(item);
+        }
+      });
 
       return result;
     }

--- a/app/scripts/services/dimPlatformService.factory.js
+++ b/app/scripts/services/dimPlatformService.factory.js
@@ -90,7 +90,7 @@
     }
 
     function getActive() {
-      return (_active);
+      return _active;
     }
 
     function setActive(platform) {
@@ -102,8 +102,6 @@
       } else {
         promise = SyncService.set({ platformType: platform.type });
       }
-
-      $rootScope.activePlatformUpdated = true;
 
       $rootScope.$broadcast('dim-active-platform-updated', { platform: _active });
       return promise;

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -8,13 +8,14 @@
 
   function StoreService($rootScope, $q, dimBungieService, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions, dimRecordsDefinitions, dimInfoService, SyncService, loadingTracker) {
     var _stores = [];
-    var _oldItems = {};
-    var _currItems = {};
-    var _newItems = {};
     var progressionDefs = {};
     let recordsDefs = {};
     var buckets = {};
     var idTracker = {};
+
+    // A set of items IDs that are new - this is cleared out by the user
+    var _newItems = new Set();
+
     dimBucketService.then(function(defs) {
       buckets = defs;
     });
@@ -130,6 +131,7 @@
       getBonus: getBonus,
       getVault: getStore.bind(null, 'vault'),
       updateCharacters: updateCharacters,
+      clearNewItems: clearNewItems,
       dropNewItem: dropNewItem,
       createItemIndex: createItemIndex,
       processItems: processItems
@@ -137,14 +139,10 @@
 
     $rootScope.$on('dim-active-platform-updated', function() {
       _stores = [];
-      _oldItems = {};
-      _currItems = {};
-      _newItems = {};
-
       $rootScope.$broadcast('dim-stores-updated', {
         stores: _stores
       });
-      loadingTracker.addPromise(service.reloadStores());
+      loadingTracker.addPromise(loadNewItems().then(() => service.reloadStores()));
     });
 
     return service;
@@ -175,16 +173,17 @@
       if (reloadPromise) {
         return reloadPromise;
       }
-      _oldItems = buildItemMap(_stores);
-      if (_.isEmpty(_stores)) {
-        clearNewItems();
-      }
+
+      // Save a snapshot of all the items before we update
+      const previousItemsMap = buildItemMap(_stores);
+      const previousItems = new Set(_.keys(previousItemsMap));
+
       reloadPromise = dimBungieService.getStores(dimPlatformService.getActive())
         .then(function(rawStores) {
           var glimmer;
           var marks;
 
-          return $q.all(rawStores.map(function(raw) {
+          return $q.all([previousItemsMap, ...rawStores.map(function(raw) {
             var store;
             var items = [];
             if (!raw) {
@@ -298,7 +297,7 @@
               }
             }
 
-            return processItems(store, items).then(function(items) {
+            return processItems(store, items, previousItems).then(function(items) {
               store.items = items;
 
               // by type-bucket
@@ -327,33 +326,37 @@
 
               return store;
             });
-          }));
+          })]);
         })
-        .then(function(stores) {
+        .then(function([previousItemsMap, ...stores]) {
+          // Save and notify about new items (but only if this wasn't the first load)
+          if (previousItems.size) {
+            // Save the list of new item IDs
+            saveNewItems();
+
+            // Only notify new items from this refresh
+            const notifyNewItems = _.omit(buildItemMap(stores), _.keys(previousItemsMap));
+
+            // Show a toaster about the new items
+            var listStr = '';
+            _.each(notifyNewItems, function(val) {
+              listStr += '<li>[' + val.type + ']' + ' ' + val.name + '</li>';
+            });
+            if (listStr) {
+              dimInfoService.show('newitemsbox', {
+                title: 'New items found',
+                body: '<p>The following items are new:</p><ul>' + listStr + '</ul>',
+                hide: 'Don\'t show me new item notifications'
+              }, 10000);
+            }
+          }
+
           _stores = stores;
 
           $rootScope.$broadcast('dim-stores-updated', {
             stores: stores
           });
 
-          return stores;
-        })
-        .then(function(stores) {
-          _currItems = buildItemMap(stores);
-          _newItems = clearStaleNewItems(_currItems, _newItems);
-          SyncService.set({ newItems: _.keys(_newItems) });
-
-          var listStr = '';
-          _.each(_newItems, function(val) {
-            listStr += '<li>[' + val.type + ']' + ' ' + val.name + '</li>';
-          });
-          if (listStr) {
-            dimInfoService.show('newitemsbox', {
-              title: 'New items found',
-              body: '<p>The following items are new:</p><ul>' + listStr + '</ul>',
-              hide: 'Don\'t show me new item notifications'
-            }, 10000);
-          }
           return stores;
         })
         .finally(function() {
@@ -382,7 +385,7 @@
       return index;
     }
 
-    function processSingleItem(definitions, buckets, statDef, objectiveDef, perkDefs, talentDefs, yearsDefs, progressDefs, cachedNewItems, item, owner) {
+    function processSingleItem(definitions, buckets, statDef, objectiveDef, perkDefs, talentDefs, yearsDefs, progressDefs, previousItems, item, owner) {
       var itemDef = definitions[item.itemHash];
       // Missing definition?
       if (!itemDef || itemDef.itemName === 'Classified') {
@@ -520,38 +523,34 @@
 
       createdItem.index = createItemIndex(createdItem);
 
-      if (_.isEmpty(_stores)) {
-        createdItem.isNew = false;
-      } else {
-        createdItem.isNew = _.contains(cachedNewItems, createdItem.id);
-        if (createdItem.isNew === false) {
-          createdItem.isNew = isItemNew(createdItem.id);
-          if (createdItem.isNew) {
-            _newItems[createdItem.id] = { name: createdItem.name, type: createdItem.type };
-          }
-        }
+      // An item is new if it was previously known to be new, or if it's new since the last load (previousItems);
+      createdItem.isNew = false;
+      try {
+        createdItem.isNew = isItemNew(createdItem.id, previousItems);
+      } catch (e) {
+        console.error("Error determining new-ness of " + createdItem.name, item, itemDef, e);
       }
 
       try {
         createdItem.talentGrid = buildTalentGrid(item, talentDefs, progressDefs);
       } catch (e) {
-        console.error("Error building talent grid for " + createdItem.name, item, itemDef);
+        console.error("Error building talent grid for " + createdItem.name, item, itemDef, e);
       }
       try {
         createdItem.stats = buildStats(item, itemDef, statDef, createdItem.talentGrid, itemType);
       } catch (e) {
-        console.error("Error building stats for " + createdItem.name, item, itemDef);
+        console.error("Error building stats for " + createdItem.name, item, itemDef, e);
       }
       try {
         createdItem.objectives = buildObjectives(item.objectives, objectiveDef);
       } catch (e) {
-        console.error("Error building objectives for " + createdItem.name, item, itemDef);
+        console.error("Error building objectives for " + createdItem.name, item, itemDef, e);
       }
       if (createdItem.talentGrid && createdItem.talentGrid.infusable) {
         try {
           createdItem.quality = getQualityRating(createdItem.stats, item.primaryStat, itemType);
         } catch (e) {
-          console.error("Error building quality rating for " + createdItem.name, item, itemDef);
+          console.error("Error building quality rating for " + createdItem.name, item, itemDef, e);
         }
       }
 
@@ -904,47 +903,6 @@
       return quality;
     }
 
-    function buildItemMap(stores) {
-      var itemMap = {};
-      _.each(stores, function(store) {
-        _.each(store.items, function(item) {
-          itemMap[item.id] = { name: item.name, type: item.type };
-        });
-      });
-      return itemMap;
-    }
-
-    function clearStaleNewItems(currItems, newItems) {
-      var newItemsClean = {};
-      _.each(newItems, function(val, id) {
-        if (currItems[id]) {
-          newItemsClean[id] = val;
-        }
-      });
-      return newItemsClean;
-    }
-
-    function isItemNew(newId) {
-      // Don't worry about general items and consumables
-      return newId !== '0' && !_oldItems[newId];
-    }
-
-    function dropNewItem(item) {
-      delete _newItems[item.id];
-      SyncService.set({ newItems: _.keys(_newItems) });
-      item.isNew = false;
-    }
-
-    function getCachedNewItems() {
-      return SyncService.get().then(function processCachedNewItems(data) {
-        return data.newItems || [];
-      });
-    }
-
-    function clearNewItems() {
-      SyncService.set({ newItems: [] });
-    }
-
     // thanks to /u/iihavetoes for the bonuses at each level
     // thanks to /u/tehdaw for the spreadsheet with bonuses
     // https://docs.google.com/spreadsheets/d/1YyFDoHtaiOOeFoqc5Wc_WC2_qyQhBlZckQx5Jd4bJXI/edit?pref=2&pli=1#gid=0
@@ -1087,7 +1045,65 @@
       })), 'sort');
     }
 
-    function processItems(owner, items) {
+    /** New Item Tracking **/
+
+    function buildItemMap(stores) {
+      var itemMap = {};
+      stores.forEach((store) => {
+        store.items.forEach((item) => {
+          itemMap[item.id] = { name: item.name, type: item.type };
+        });
+      });
+      return itemMap;
+    }
+
+    // Should this item display as new? Note the check for previousItems size, so that
+    // we don't mark everything as new on the first load.
+    function isItemNew(id, previousItems) {
+      let isNew = false;
+      if (_newItems.has(id)) {
+        isNew = true;
+      } else if (previousItems.size) {
+        // Zero id check is to ignore general items and consumables
+        isNew = (id !== '0' && !previousItems.has(id));
+        if (isNew) {
+          _newItems.add(id);
+        }
+      }
+      return isNew;
+    }
+
+    function dropNewItem(item) {
+      _newItems.delete(item.id);
+      saveNewItems();
+      item.isNew = false;
+    }
+
+    function clearNewItems() {
+      _newItems = new Set();
+      saveNewItems();
+    }
+
+    function loadNewItems() {
+      if (dimPlatformService.getActive()) {
+        _newItems = new Set();
+        return SyncService.get().then(function processCachedNewItems(data) {
+          _newItems = new Set(data[newItemsKey()]);
+        });
+      }
+      return $q.when();
+    }
+
+    function saveNewItems() {
+      SyncService.set({ [newItemsKey()]: [..._newItems] });
+    }
+
+    function newItemsKey() {
+      const platform = dimPlatformService.getActive();
+      return 'newItems-' + (platform ? platform.type : '');
+    }
+
+    function processItems(owner, items, previousItems = new Set()) {
       idTracker = {};
       return $q.all([
         dimItemDefinitions,
@@ -1098,7 +1114,7 @@
         dimTalentDefinitions,
         dimYearsDefinitions,
         dimProgressionDefinitions,
-        getCachedNewItems()])
+        previousItems])
         .then(function(args) {
           var result = [];
           _.each(items, function(item) {

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -129,8 +129,7 @@
       updateCharacters: updateCharacters,
       dropNewItem: dropNewItem,
       createItemIndex: createItemIndex,
-      processItems: processItems,
-      afterStoreSync: getIsStoreSyncingPromise
+      processItems: processItems
     };
 
     $rootScope.$on('dim-active-platform-updated', function() {
@@ -139,23 +138,6 @@
         $rootScope.activePlatformUpdated = false;
       }
     });
-
-    function getIsStoreSyncingPromise() {
-      var self = service;
-
-      return $q(function(resolve) {
-        if (self.IsStoreSyncing) {
-          var intervalId = window.setInterval(function() {
-            if (!self.IsStoreSyncing) {
-              clearInterval(intervalId);
-              resolve();
-            }
-          }, 250);
-        } else {
-          resolve();
-        }
-      });
-    }
 
     return service;
 
@@ -184,10 +166,6 @@
       if (_.isEmpty(_stores)) {
         clearNewItems();
       }
-
-      var self = service;
-      self.IsStoreSyncing = true;
-
       return dimBungieService.getStores(dimPlatformService.getActive())
         .then(function(rawStores) {
           var glimmer;
@@ -363,13 +341,7 @@
               hide: 'Don\'t show me new item notifications'
             }, 10000);
           }
-
-          self.IsStoreSyncing = false;
-
           return stores;
-        })
-        .catch(function() {
-          self.IsStoreSyncing = false;
         });
     }
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -134,6 +134,10 @@
 
     $rootScope.$on('dim-active-platform-updated', function() {
       _stores = [];
+      _oldItems = {};
+      _currItems = {};
+      _newItems = {};
+
       $rootScope.$broadcast('dim-stores-updated', {
         stores: _stores
       });

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -134,7 +134,8 @@
       clearNewItems: clearNewItems,
       dropNewItem: dropNewItem,
       createItemIndex: createItemIndex,
-      processItems: processItems
+      processItems: processItems,
+      hasNewItems: Boolean(_newItems.size)
     };
 
     $rootScope.$on('dim-active-platform-updated', function() {
@@ -1081,20 +1082,29 @@
 
     function clearNewItems() {
       _newItems = new Set();
+      _stores.forEach((store) => {
+        store.items.forEach((item) => {
+          item.isNew = false;
+        });
+      });
+      service.hasNewItems = false;
       saveNewItems();
     }
 
     function loadNewItems() {
       if (dimPlatformService.getActive()) {
         _newItems = new Set();
+        service.hasNewItems = false;
         return SyncService.get().then(function processCachedNewItems(data) {
           _newItems = new Set(data[newItemsKey()]);
+          service.hasNewItems = Boolean(_newItems.size);
         });
       }
       return $q.when();
     }
 
     function saveNewItems() {
+      service.hasNewItems = Boolean(_newItems.size);
       SyncService.set({ [newItemsKey()]: [..._newItems] });
     }
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .factory('dimStoreService', StoreService);
 
-  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimPlatformService', 'dimItemTier', 'dimCategory', 'dimItemDefinitions', 'dimBucketService', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions', 'dimRecordsDefinitions', 'dimInfoService', 'SyncService'];
+  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimPlatformService', 'dimItemTier', 'dimCategory', 'dimItemDefinitions', 'dimBucketService', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions', 'dimRecordsDefinitions', 'dimInfoService', 'SyncService', 'loadingTracker'];
 
-  function StoreService($rootScope, $q, dimBungieService, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions, dimRecordsDefinitions, dimInfoService, SyncService) {
+  function StoreService($rootScope, $q, dimBungieService, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions, dimRecordsDefinitions, dimInfoService, SyncService, loadingTracker) {
     var _stores = [];
     var _oldItems = {};
     var _currItems = {};
@@ -134,6 +134,10 @@
 
     $rootScope.$on('dim-active-platform-updated', function() {
       _stores = [];
+      $rootScope.$broadcast('dim-stores-updated', {
+        stores: _stores
+      });
+      loadingTracker.addPromise(service.reloadStores());
     });
 
     return service;

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -133,10 +133,7 @@
     };
 
     $rootScope.$on('dim-active-platform-updated', function() {
-      if ($rootScope.activePlatformUpdated === true) {
-        _stores = [];
-        $rootScope.activePlatformUpdated = false;
-      }
+      _stores = [];
     });
 
     return service;

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -24,7 +24,7 @@
 
     hotkeys.add({
       combo: ['f'],
-      description: "Start a search.",
+      description: "Start a search",
       callback: function(event) {
         $rootScope.$broadcast('dim-focus-filter-input');
 
@@ -43,7 +43,7 @@
 
     hotkeys.add({
       combo: ['r'],
-      description: "Refresh inventory.",
+      description: "Refresh inventory",
       callback: function() {
         vm.refresh();
       }
@@ -51,7 +51,7 @@
 
     hotkeys.add({
       combo: ['i'],
-      description: "Toggle showing full item details.",
+      description: "Toggle showing full item details",
       callback: function() {
         $rootScope.$broadcast('dim-toggle-item-details');
       }
@@ -59,7 +59,7 @@
 
     hotkeys.add({
       combo: ['x'],
-      description: "Clear new items.",
+      description: "Clear new items",
       callback: function() {
         storeService.clearNewItems();
       }

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -61,7 +61,7 @@
       combo: ['x'],
       description: "Clear new items",
       callback: function() {
-        storeService.clearNewItems();
+        dimStoreService.clearNewItems();
       }
     });
 

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -24,6 +24,7 @@
 
     hotkeys.add({
       combo: ['f'],
+      description: "Start a search.",
       callback: function(event) {
         $rootScope.$broadcast('dim-focus-filter-input');
 
@@ -42,6 +43,7 @@
 
     hotkeys.add({
       combo: ['r'],
+      description: "Refresh inventory.",
       callback: function() {
         vm.refresh();
       }
@@ -49,8 +51,17 @@
 
     hotkeys.add({
       combo: ['i'],
+      description: "Toggle showing full item details.",
       callback: function() {
         $rootScope.$broadcast('dim-toggle-item-details');
+      }
+    });
+
+    hotkeys.add({
+      combo: ['x'],
+      description: "Clear new items.",
+      callback: function() {
+        storeService.clearNewItems();
       }
     });
 

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -98,13 +98,8 @@
     vm.xur = dimXurService;
 
     vm.refresh = function refresh() {
-      var activePlatform = dimPlatformService.getActive();
-      if (activePlatform !== null) {
-        $rootScope.$broadcast('dim-active-platform-updated', {
-          platform: activePlatform
-        });
-        dimXurService.updateXur();
-      }
+      loadingTracker.addPromise(dimStoreService.reloadStores());
+      dimXurService.updateXur();
     };
 
     // Don't refresh more than once a minute

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -94,6 +94,10 @@
       $state.go($state.is('best') ? 'inventory' : 'best');
     };
 
+    vm.toggleVendors = function(e) {
+      $state.go($state.is('vendors') ? 'inventory' : 'vendors');
+    };
+
     dimXurService.updateXur();
     vm.xur = dimXurService;
 

--- a/app/scripts/shell/dimPlatformChoice.directive.js
+++ b/app/scripts/shell/dimPlatformChoice.directive.js
@@ -20,9 +20,9 @@
     };
   }
 
-  PlatformChoiceCtrl.$inject = ['$scope', 'dimPlatformService', 'dimState', 'loadingTracker', '$http'];
+  PlatformChoiceCtrl.$inject = ['$scope', 'dimPlatformService', 'dimState', 'loadingTracker'];
 
-  function PlatformChoiceCtrl($scope, dimPlatformService, dimState, loadingTracker, $http) {
+  function PlatformChoiceCtrl($scope, dimPlatformService, dimState, loadingTracker) {
     var vm = this;
 
     vm.active = null;
@@ -31,33 +31,14 @@
       dimPlatformService.setActive(vm.active);
     };
 
-    activate();
-
-    function activate() {
-      var promise = $http.get('https://www.bungie.net', {
-        timeout: 5000
-      })
-        .then(function() {
-          return dimPlatformService.getPlatforms();
-        }, function() {
-          return dimPlatformService.getPlatforms();
-        });
-
-      loadingTracker.addPromise(promise);
-    }
+    loadingTracker.addPromise(dimPlatformService.getPlatforms());
 
     $scope.$on('dim-platforms-updated', function(e, args) {
       vm.platforms = args.platforms;
     });
 
     $scope.$on('dim-active-platform-updated', function(e, args) {
-      if (_.isNull(args.platform)) {
-        dimState.active = vm.active = null;
-      } else {
-        // if (_.isNull(vm.active) || (vm.active.type !== args.platform.type)) {
-        dimState.active = vm.active = args.platform;
-        // }
-      }
+      dimState.active = vm.active = args.platform;
     });
   }
 })();

--- a/app/scripts/store/dimClearNewItems.directive.js
+++ b/app/scripts/store/dimClearNewItems.directive.js
@@ -8,7 +8,7 @@
     .component('dimClearNewItems', {
       template: [
         '<div class="clear-new-items" ng-if="$ctrl.storeService.hasNewItems">',
-        '  <button ng-click="$ctrl.storeService.clearNewItems()"><i class="fa fa-thumbs-up"></i> Clear new items</button>',
+        '  <button ng-click="$ctrl.storeService.clearNewItems()" title="Keyboard shortcut: X"><i class="fa fa-thumbs-up"></i> Clear new items</button>',
         '</div>'
       ].join(''),
       controller: ClearNewItemsCtrl

--- a/app/scripts/store/dimClearNewItems.directive.js
+++ b/app/scripts/store/dimClearNewItems.directive.js
@@ -1,0 +1,21 @@
+(function() {
+  'use strict';
+
+  /**
+   * A button that marks all new items as "seen".
+   */
+  angular.module('dimApp')
+    .component('dimClearNewItems', {
+      template: [
+        '<div class="clear-new-items" ng-if="$ctrl.storeService.hasNewItems">',
+        '  <button ng-click="$ctrl.storeService.clearNewItems()"><i class="fa fa-thumbs-up"></i> Clear new items</button>',
+        '</div>'
+      ].join(''),
+      controller: ClearNewItemsCtrl
+    });
+
+  ClearNewItemsCtrl.$inject = ['dimStoreService'];
+  function ClearNewItemsCtrl(dimStoreService) {
+    this.storeService = dimStoreService;
+  }
+})();

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -89,10 +89,7 @@
       vm.vault = dimStoreService.getVault();
     });
 
-    if ($scope.$root.activePlatformUpdated) {
-      loadingTracker.addPromise(dimStoreService.reloadStores());
-      $scope.$root.activePlatformUpdated = false;
-    } else if (!_.isNull(dimPlatformService.getActive())) {
+    if (!vm.stores.length && dimPlatformService.getActive()) {
       loadingTracker.addPromise(dimStoreService.reloadStores());
     }
 

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -92,9 +92,5 @@
     if (!vm.stores.length && dimPlatformService.getActive()) {
       loadingTracker.addPromise(dimStoreService.reloadStores());
     }
-
-    $scope.$on('dim-active-platform-updated', function(e) {
-      loadingTracker.addPromise(dimStoreService.reloadStores());
-    });
   }
 })();

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1928,7 +1928,6 @@ button.toast-close-button {
   width: 40rem;
   right: 0;
   border-radius: .5rem;
-  text-align: center;
   padding: .5rem 1rem;
   color: #e0e0e0;
   display: flex;
@@ -1980,6 +1979,43 @@ button.toast-close-button {
 
   p {
     margin: .25em 0;
+  }
+
+  &.ng-animate {
+    transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+  }
+
+  &.ng-enter, &.ng-leave.ng-leave-active {
+    opacity: 0;
+    transform: translateY(5rem);
+  }
+
+  &.ng-leave, &.ng-enter.ng-enter-active {
+    opacity: 1;
+    transform: translateY(0rem);
+  }
+}
+
+/* Clear new items */
+
+.clear-new-items {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+
+  button {
+    color: white;
+    padding: 1rem 1.5rem;
+    background-color: rgba(128, 128, 128, 1.0);
+    border-radius: 4px;
+    border: none;
+    text-align: center;
+    font-size: 1.5em;
+    transition: .3s background-color;
+    box-shadow: 1px 1px 10px rgba(0, 0, 0, .5);
+    &:hover, &:active {
+      background-color: rgba(232, 165, 52, 1.0);
+    }
   }
 
   &.ng-animate {

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -47,6 +47,10 @@
             <dd>Your session is tied to Bungie.net. If you logout on Bungie.net, you're effectively logged out of DIM.</dd>
         </dl>
         <dl>
+          <dt>Does DIM support keyboard shortcuts?</dt>
+          <dd>Yes! Press "?" to see a list of available shortcuts.</dd>
+        </dl>
+        <dl>
             <dt>I lost my item using your tool!</dt>
             <dd>More than likely a transfer failed, leaving your item in the vault or on another character. You could search for the item. If that doesn't turn it up, refresh the app by pressing F5. Check <a href="http://bungie.net" target="_blank">Bungie.net</a> or in game to see if your item still exists. We're sure it's still there.</dd>
         </dl>

--- a/app/views/inventory.html
+++ b/app/views/inventory.html
@@ -3,3 +3,4 @@
 <dim-loadout></dim-loadout>
 <div id="drag-help" class="drag-help-hidden">Hold shift or pause over drop zone to transfer a partial stack</div>
 <dim-engram-farming></dim-engram-farming>
+<dim-clear-new-items></dim-clear-new-items>


### PR DESCRIPTION
Things had gotten a bit byzantine around platform switching and updating stores. This attempts to fix it. In the process I reverted some of the fixes we've applied recently. Long story short, 2253c8c added a bug that unassigned `_stores` while stores were updating, and then 1135831511936ddcd182f8342d313d67e8e57fbe and d71b308161954364fe682d8ab6d7d867169639b8 were added in order to work around that bug - but what was actually needed was to simplify things and stop using "platform updated" to trigger refreshes. This PR untangles all that stuff. It also gets rid of hacks like `$rootScope.activePlatformUpdated` which are no longer necessary, and properly fires events so that all items disappear right when you change platform, etc.

As a consequence of the untangling we end up avoiding several service calls that we were doing on every refresh (and a handful elsewhere) which improves DIM performance.

@SunburnedGoose, I'd appreciate if you could test this out - it works for everything I can test, but I don't have an Xbox so I can't test all the double platform stuff. 

/cc @ericnelson0