### PR TITLE
Collapsible sections

### DIFF
--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -41,6 +41,8 @@
       vaultMaxCol: 999,
       // How big in pixels to draw items
       itemSize: 44,
+      // Which categories should be collapsed?
+      collapsedCategories: {},
 
       save: function() {
         if (!_loaded) {

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -41,8 +41,8 @@
       vaultMaxCol: 999,
       // How big in pixels to draw items
       itemSize: 44,
-      // Which categories should be collapsed?
-      collapsedCategories: {},
+      // Which categories or buckets should be collapsed?
+      collapsedSections: {},
 
       save: function() {
         if (!_loaded) {

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -36,20 +36,21 @@
         '    </div>',
         '  </div>',
         '  <div ng-repeat="(category, buckets) in ::vm.buckets.byCategory track by category" class="section" ng-class="::category | lowercase">',
-        '    <div class="title" ng-click="vm.toggleCategory(category)">',
-        '      <span><i class="fa" ng-class="vm.settings.collapsedCategories[category] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> {{::category}}</span>',
+        '    <div class="title" ng-click="vm.toggleSection(category)">',
+        '      <span><i class="fa collapse" ng-class="vm.settings.collapsedSections[category] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> {{::category}}</span>',
         '      <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{::vm.vault.capacityForItem({sort: category})}}</span>',
         '    </div>',
-        '    <div class="store-row items" ng-if="!vm.settings.collapsedCategories[category]" ng-repeat="bucket in ::buckets track by bucket.id">',
-        '      <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
+        '    <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i>',
+        '      <div ng-if="!vm.settings.collapsedSections[bucket.id]" class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '        <dim-store-bucket ng-if="::!store.isVault || vm.vault.vaultCounts[category] !== undefined" store-data="store" bucket-items="store.buckets[bucket.id]" bucket="bucket"></dim-store-bucket>',
         '      </div>',
+        '      <div ng-if="vm.settings.collapsedSections[bucket.id]" ng-click="vm.toggleSection(bucket.id)" class="store-text collapse">Show {{bucket.name}}</div>',
         '    </div>',
         '  </div>',
-        '  <div class="title" ng-click="vm.toggleCategory(\'Reputation\')">',
-        '    <span><i class="fa" ng-class="vm.settings.collapsedCategories[\'Reputation\'] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> Reputation</span>',
+        '  <div class="title" ng-click="vm.toggleSection(\'Reputation\')">',
+        '    <span><i class="fa collapse" ng-class="vm.settings.collapsedSections[\'Reputation\'] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> Reputation</span>',
         '  </div>',
-        '  <div class="store-row items" ng-if="!vm.settings.collapsedCategories[\'Reputation\']">',
+        '  <div class="store-row items" ng-if="!vm.settings.collapsedSections[\'Reputation\']">',
         '    <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '      <dim-store-reputation store-data="store"></dim-store-reputation>',
         '    </div>',
@@ -83,8 +84,8 @@
     dimBucketService.then(function(buckets) {
       vm.buckets = angular.copy(buckets);
     });
-    vm.toggleCategory = function(category) {
-      vm.settings.collapsedCategories[category] = !vm.settings.collapsedCategories[category];
+    vm.toggleSection = function(id) {
+      vm.settings.collapsedSections[id] = !vm.settings.collapsedSections[id];
       vm.settings.save();
     };
 

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -87,7 +87,7 @@
       vm.settings.collapsedCategories[category] = !vm.settings.collapsedCategories[category];
       vm.settings.save();
     };
-console.log(vm.settings.collapsedCategories);
+
     $scope.$on('dim-stores-updated', function(e, stores) {
       vm.stores = stores.stores;
       vm.vault = dimStoreService.getVault();

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -36,20 +36,20 @@
         '    </div>',
         '  </div>',
         '  <div ng-repeat="(category, buckets) in ::vm.buckets.byCategory track by category" class="section" ng-class="::category | lowercase">',
-        '    <div class="title">',
-        '      <span>{{::category}}</span>',
+        '    <div class="title" ng-click="vm.toggleCategory(category)">',
+        '      <span><i class="fa" ng-class="vm.settings.collapsedCategories[category] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> {{::category}}</span>',
         '      <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{::vm.vault.capacityForItem({sort: category})}}</span>',
         '    </div>',
-        '    <div class="store-row items" ng-repeat="bucket in ::buckets track by bucket.id">',
+        '    <div class="store-row items" ng-if="!vm.settings.collapsedCategories[category]" ng-repeat="bucket in ::buckets track by bucket.id">',
         '      <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '        <dim-store-bucket ng-if="::!store.isVault || vm.vault.vaultCounts[category] !== undefined" store-data="store" bucket-items="store.buckets[bucket.id]" bucket="bucket"></dim-store-bucket>',
         '      </div>',
         '    </div>',
         '  </div>',
-        '  <div class="title">',
-        '    <span>Reputation</span>',
+        '  <div class="title" ng-click="vm.toggleCategory(\'Reputation\')">',
+        '    <span><i class="fa" ng-class="vm.settings.collapsedCategories[\'Reputation\'] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> Reputation</span>',
         '  </div>',
-        '  <div class="store-row items">',
+        '  <div class="store-row items" ng-if="!vm.settings.collapsedCategories[\'Reputation\']">',
         '    <div class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">',
         '      <dim-store-reputation store-data="store"></dim-store-reputation>',
         '    </div>',
@@ -83,7 +83,11 @@
     dimBucketService.then(function(buckets) {
       vm.buckets = angular.copy(buckets);
     });
-
+    vm.toggleCategory = function(category) {
+      vm.settings.collapsedCategories[category] = !vm.settings.collapsedCategories[category];
+      vm.settings.save();
+    };
+console.log(vm.settings.collapsedCategories);
     $scope.$on('dim-stores-updated', function(e, stores) {
       vm.stores = stores.stores;
       vm.vault = dimStoreService.getVault();

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -484,6 +484,9 @@ img {
   .icon {
     width: 30px;
   }
+  .collapse {
+    margin-left: -6px;
+  }
 }
 
 .equipped {
@@ -1296,6 +1299,15 @@ g {
   top: 141px;
 }
 
+.collapse {
+  cursor: pointer;
+  font-size: 14px;
+  color: $lightgray;
+  &:hover {
+    color: $orange;
+  }
+}
+
 .store-row {
   width: 100%;
   display: flex;
@@ -1304,6 +1316,10 @@ g {
   // Bit of a hack to make things line up
   &.items:last-child .store-cell {
     padding-bottom: 14px;
+  }
+
+  i.collapse {
+    margin: 16px 7px 8px 10px;
   }
 }
 
@@ -1322,6 +1338,10 @@ g {
     width: auto;
     flex: 1;
   }
+}
+.store-text {
+  align-self: center;
+  margin-top: 5px;
 }
 
 .store-header {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1319,6 +1319,7 @@ g {
   }
 
   i.collapse {
+    outline: none;
     margin: 16px 7px 8px 10px;
   }
 }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -510,7 +510,7 @@ img {
 
 .sub-section {
   flex: 1;
-  margin-top: 14px;
+  margin-top: 6px;
   margin-bottom: 6px;
   position: relative;
   display: flex;
@@ -1320,7 +1320,7 @@ g {
 
   i.collapse {
     outline: none;
-    padding: 16px 7px 8px 10px;
+    padding: 8px 7px 8px 10px;
   }
 }
 
@@ -1341,7 +1341,6 @@ g {
   }
 }
 .store-text {
-  align-self: center;
   padding-top: 5px;
 }
 

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1320,7 +1320,7 @@ g {
 
   i.collapse {
     outline: none;
-    margin: 16px 7px 8px 10px;
+    padding: 16px 7px 8px 10px;
   }
 }
 
@@ -1342,7 +1342,7 @@ g {
 }
 .store-text {
   align-self: center;
-  margin-top: 5px;
+  padding-top: 5px;
 }
 
 .store-header {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -465,6 +465,7 @@ img {
 }
 
 .title {
+  cursor: pointer;
   flex: 1;
   padding: 0 16px;
   background-color: #353535;

--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -1,3 +1,4 @@
+$lightgray: rgba(245, 245, 245, 0.25);
 $orange: #E8A534;
 
 $arc: #85c5ec;


### PR DESCRIPTION
It would be nice if I could collapse certain sections (such as Horns and Emotes), and have that preference remembered between sessions. I'd prefer for this to be something in the main UI (for example, I'd still see a Horns row, but no content until I expand it) rather than something configured in settings.

It might be nice to even allow me to use drag-n-drop to reorder the sections as well.