### PR TITLE
Vendor service cleanup

### DIFF
--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -318,23 +318,21 @@
         .then(addCharactersToData)
         .then(function() {
           // Titan van, Hunter van, Warlock van, Dead orb, Future war, New mon, Eris Morn, Cruc hand, Speaker, Variks, Exotic Blue
-          var vendorHashes = ['1990950', '3003633346', '1575820975', '3611686524', '1821699360', '1808244981', '174528503', '3746647075', '2680694281', '1998812735', '3902439767'];
+          var vendorHashes = ['1990950', '3003633346', '1575820975', '3611686524', '1821699360', '1808244981', '174528503', '3746647075', '2680694281', '1998812735', '3902439767', '242140165'];
           var promises = [];
           _.each(vendorHashes, function(vendorHash) {
             _.each(data.characters, function(character) {
-              promises.push(getVendor(data.token, platform, data.membershipId, character, vendorHash));
+              var vendorPromise = getVendor(data.token, platform, data.membershipId, character, vendorHash)
+                    .catch(function(e) {
+                      if (e.message !== 'The Vendor you requested was not found.') {
+                        throw e;
+                      }
+                    });
+
+              promises.push(vendorPromise);
             });
           });
-          return $q.all(promises).then(function(vendorData) {
-            // Get banner if it's up
-            var bannerPromises = [];
-            _.each(data.characters, function(character) {
-              bannerPromises.push(getVendor(data.token, platform, data.membershipId, character, '242140165'));
-            });
-            return $q.all(bannerPromises).then(function(bannerData) {
-              return $q.resolve(vendorData.concat(bannerData));
-            });
-          });
+          return $q.all(promises);
         })
         .catch(function(e) {
           toaster.pop('error', 'Bungie.net Error', e.message);
@@ -348,7 +346,7 @@
     function getVendor(token, platform, membershipId, character, vendorId) {
       return $q.when({
         method: 'GET',
-        url: 'https://www.bungie.net/platform/Destiny/' + platform.type + '/MyAccount/Character/' + character.id + '/Vendor/' + vendorId + '/?lc=en&fmt=true&lcin=true&definitions=true',
+        url: 'https://www.bungie.net/platform/Destiny/' + platform.type + '/MyAccount/Character/' + character.id + '/Vendor/' + vendorId + '/?definitions=false',
         headers: {
           'X-API-Key': apiKey,
           'x-csrf': token

--- a/app/scripts/services/dimVendorService.factory.js
+++ b/app/scripts/services/dimVendorService.factory.js
@@ -133,8 +133,10 @@
             // Get vendor metadata
             return dimVendorDefinitions.then(function(vendorDefs) {
               _.each(vendors, function(vendor) {
-                vendor.vendorName = vendorDefs[vendor.vendorHash].vendorName;
-                vendor.vendorIcon = vendorDefs[vendor.vendorHash].factionIcon || vendorDefs[vendor.vendorHash].vendorIcon;
+                if (vendor) {
+                  vendor.vendorName = vendorDefs[vendor.vendorHash].vendorName;
+                  vendor.vendorIcon = vendorDefs[vendor.vendorHash].factionIcon || vendorDefs[vendor.vendorHash].vendorIcon;
+                }
               });
               return vendors;
             });
@@ -143,7 +145,7 @@
             // Add items that are buyable to vendors
             var vendorsWithItems = [];
             _.each(vendors, function(vendor) {
-              if (vendor.enabled) {
+              if (vendor && vendor.enabled) {
                 var items = [];
                 _.each(vendor.saleItemCategories, function(categoryData) {
                   var filteredSaleItems = _.filter(categoryData.saleItems, function(saleItem) { return saleItem.item.isEquipment && saleItem.costs.length; });


### PR DESCRIPTION
Some minor cleanup of the vendors stuff:

1. No longer load full definitions and pretty-printed JSON.
2. No longer wait for all vendors, then wait again for Saladin (he's in the normal list now).
3. Handle missing vendors (like Saladin) without knocking out the whole vendor service.

/cc @ericnelson0