### PR TITLE
Make WebKit scrollbar definitions global

### DIFF
--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -407,20 +407,22 @@ body {
   }
 }
 
-.ngdialog {
-  ::-webkit-scrollbar {
-    width: 3px;
-  }
+::-webkit-scrollbar {
+  width: 3px;
 
-  ::-webkit-scrollbar-track {
-    background: rgba(228, 228, 228, 0.2);
-    border-radius: 3px;
+  &:horizontal {
+    height: 3px;
   }
+}
 
-  ::-webkit-scrollbar-thumb {
-    background: #E4E4E4;
-    border-radius: 3px;
-  }
+::-webkit-scrollbar-track {
+  background: rgba(228, 228, 228, 0.2);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #E4E4E4;
+  border-radius: 3px;
 }
 
 #system {


### PR DESCRIPTION
As described in #694, the scrollbar styles were scoped to `.ngdialog`, which prevents their application throughout the web app.

This PR makes the scrollbar styles global.

Closes #694.