### PR TITLE
Add support for not: searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Help dialog for keyboard shortcuts. Triggered with "?".
 * When you have two characters of the same class, applying a loadout with a subclass will work all the time now.
 * Item class requirements are part of the header ("Hunter Helmet") instead of in the stats area.
+* You can search for the opposite of "is:" filters with "not:" filters. For example, "is:helmet not:hunter quality:>90".
 
 # 3.8.3
 

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -55,9 +55,9 @@
     new: ['new']
   };
 
-  var keywords = _.flatten(_.values(filterTrans)).map(function(word) {
-    return "is:" + word;
-  });
+  var keywords = _.flatten(_.flatten(_.values(filterTrans)).map(function(word) {
+    return ["is:" + word, "not:" + word];
+  }));
 
   // Filters that operate on ranges (>, <, >=, <=)
   var ranges = ['light', 'level', 'quality', 'percentage'];
@@ -69,7 +69,7 @@
     element.find('input').textcomplete([
       {
         words: keywords,
-        match: /\b((li|le|qu|pe|is:)\w*)$/,
+        match: /\b((li|le|qu|pe|is:|not:)\w*)$/,
         search: function(term, callback) {
           callback($.map(this.words, function(word) {
             return word.indexOf(term) === 0 ? word : null;
@@ -77,7 +77,8 @@
         },
         index: 1,
         replace: function(word) {
-          return word.indexOf('is:') === 0 ? (word + ' ') : word;
+          return (word.indexOf('is:') === 0 && word.indexOf('not:') === 0)
+            ? (word + ' ') : word;
         }
       }
     ], {
@@ -150,8 +151,8 @@
       var filterFn;
       var filters = [];
 
-      function addPredicate(predicate, filter) {
-        filters.push({ predicate: predicate, value: filter });
+      function addPredicate(predicate, filter, invert = false) {
+        filters.push({ predicate: predicate, value: filter, invert: invert });
       }
 
       _.each(searchTerms, function(term) {
@@ -161,11 +162,26 @@
             predicate = _cachedFilters[filter];
             addPredicate(predicate, filter);
           } else {
-            for (var key in filterTrans) {
+            for (const key in filterTrans) {
               if (filterTrans.hasOwnProperty(key) && filterTrans[key].indexOf(filter) > -1) {
                 predicate = key;
                 _cachedFilters[filter] = key;
                 addPredicate(predicate, filter);
+                break;
+              }
+            }
+          }
+        } else if (term.indexOf('not:') >= 0) {
+          filter = term.replace('not:', '');
+          if (_cachedFilters[filter]) {
+            predicate = _cachedFilters[filter];
+            addPredicate(predicate, filter, true);
+          } else {
+            for (const key in filterTrans) {
+              if (filterTrans.hasOwnProperty(key) && filterTrans[key].indexOf(filter) > -1) {
+                predicate = key;
+                _cachedFilters[filter] = key;
+                addPredicate(predicate, filter, true);
                 break;
               }
             }
@@ -183,7 +199,8 @@
 
       filterFn = function(item) {
         return _.all(filters, function(filter) {
-          return filterFns[filter.predicate](filter.value, item);
+          var result = filterFns[filter.predicate](filter.value, item);
+          return filter.invert ? !result : result;
         });
       };
 


### PR DESCRIPTION
This is an old change that'd been hanging out on a branch. Turns out it works pretty well!

Basically, everything that's an "is:" search now has a corresponding "not:" search, which allows for some interesting stuff (like "is:engram not:exotic").