### PR TITLE
Fix for issue in loadout builder where all items aren't marked as equ…

### DIFF
--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -82,8 +82,8 @@
         if (args.loadout) {
           vm.show = true;
           dimLoadoutService.dialogOpen = true;
-          vm.originalLoadout = args.loadout;
           vm.loadout = angular.copy(args.loadout);
+          vm.originalLoadout = vm.loadout;
           if (args.equipAll) {
             _.each(vm.loadout.items, function(item) {
               if (item[0]) {


### PR DESCRIPTION
…ipped

Issue #750.

@SunburnedGoose, would you mind verifying this fix as it looks like it was your commit [here](https://github.com/DestinyItemManager/DIM/commit/af9721c936e696028a6deb2235df6c569c1f90a0#diff-0f295dd92414a2201fc02e2c3a08a604) that I'm modifying.

EDIT:

Just to explain a bit. It looks like the copying here was resetting the equipped property on the objects.