### PR TITLE
Add color aliases for rarity filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Clicking away from the Xur dialog will close any open item popups.
 * Fixed an issue where you could not equip a loadout that included an exotic item when you already had an exotic equipped that was not going to be replaced by the loadout.
 * Better handling of items with "The Life Exotic" perk.
+* New aliases for rarity filters (is:white, is:green, is:blue, is:purple, is:yellow).
 
 # 3.8.3
 

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -31,7 +31,7 @@
   var filterTrans = {
     dmg: ['arc', 'solar', 'void', 'kinetic'],
     type: ['primary', 'special', 'heavy', 'helmet', 'leg', 'gauntlets', 'chest', 'class', 'classitem', 'artifact', 'ghost', 'horn', 'consumable', 'ship', 'material', 'vehicle', 'emblem', 'bounties', 'quests', 'messages', 'missions', 'emote'],
-    tier: ['common', 'uncommon', 'rare', 'legendary', 'exotic'],
+    tier: ['common', 'uncommon', 'rare', 'legendary', 'exotic', 'white', 'green', 'blue', 'purple', 'yellow'],
     incomplete: ['incomplete'],
     complete: ['complete'],
     xpcomplete: ['xpcomplete'],
@@ -262,7 +262,14 @@
         return item.type.toLowerCase() === predicate;
       },
       tier: function(predicate, item) {
-        return item.tier.toLowerCase() === predicate;
+        const tierMap = {
+          white: 'common',
+          green: 'uncommon',
+          blue: 'rare',
+          purple: 'legendary',
+          yellow: 'exotic'
+        };
+        return item.tier.toLowerCase() === (tierMap[predicate] || predicate);
       },
       // Incomplete will show items that are not fully leveled.
       incomplete: function(predicate, item) {

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -73,6 +73,11 @@
         <dim-filter-link filter="is:rare"></dim-filter-link>
         <dim-filter-link filter="is:legendary"></dim-filter-link>
         <dim-filter-link filter="is:exotic"></dim-filter-link>
+        <dim-filter-link filter="is:white"></dim-filter-link>
+        <dim-filter-link filter="is:green"></dim-filter-link>
+        <dim-filter-link filter="is:blue"></dim-filter-link>
+        <dim-filter-link filter="is:purple"></dim-filter-link>
+        <dim-filter-link filter="is:yellow"></dim-filter-link>
       </td>
       <td>Shows items based on their rarity tier.</td>
     </tr>


### PR DESCRIPTION
This has gotten me enough times that I finally just added it. Now you can type "is:blue" to select your rare items, instead of "is:rare".

