### PR TITLE
Remove popup notification for new items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Better handling of items with "The Life Exotic" perk.
 * New aliases for rarity filters (is:white, is:green, is:blue, is:purple, is:yellow).
 * An alternate option for the "Gather Engrams" loadout can exclude gathering exotic engrams.
+* Removed popup notification for new items.
 
 # 3.8.3
 


### PR DESCRIPTION
I think there's still a discussion to be had about whether indicating new items is a feature we want to have. But I think we can streamline the feature by removing this popup - it doesn't look good, and doesn't really offer any value (it's not clickable to focus the new items, etc.) I think we'd be better off without it.

/cc @ericnelson0