### PR TITLE
Fix exotics in loadouts, plus The Life Exotic handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Item class requirements are part of the header ("Hunter Helmet") instead of in the stats area.
 * You can search for the opposite of "is:" filters with "not:" filters. For example, "is:helmet not:hunter quality:>90".
 * Clicking away from the Xur dialog will close any open item popups.
+* Fixed an issue where you could not equip a loadout that included an exotic item when you already had an exotic equipped that was not going to be replaced by the loadout.
+* Better handling of items with "The Life Exotic" perk.
 
 # 3.8.3
 

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -11,13 +11,6 @@
       active: null,
       debug: true
     })
-    .value('dimItemTier', {
-      exotic: 'Exotic',
-      legendary: 'Legendary',
-      rare: 'Rare',
-      uncommon: 'Uncommon',
-      basic: 'Basic'
-    })
     .factory('loadingTracker', ['promiseTracker', function(promiseTracker) {
       return promiseTracker();
     }]);

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -104,9 +104,9 @@
     }
   }
 
-  LoadoutCtrl.$inject = ['dimLoadoutService', 'dimCategory', 'dimItemTier', 'toaster', 'dimPlatformService', 'dimSettingsService'];
+  LoadoutCtrl.$inject = ['dimLoadoutService', 'dimCategory', 'toaster', 'dimPlatformService', 'dimSettingsService'];
 
-  function LoadoutCtrl(dimLoadoutService, dimCategory, dimItemTier, toaster, dimPlatformService, dimSettingsService) {
+  function LoadoutCtrl(dimLoadoutService, dimCategory, toaster, dimPlatformService, dimSettingsService) {
     var vm = this;
 
     vm.settings = dimSettingsService;
@@ -217,13 +217,13 @@
         } else if (item.equipped) {
           item.equipped = false;
         } else {
-          if (item.tier === dimItemTier.exotic) {
+          if (item.isExotic) {
             var exotic = _.chain(vm.loadout.items)
               .values()
               .flatten()
               .findWhere({
                 sort: item.bucket.sort,
-                tier: dimItemTier.exotic,
+                isExotic: true,
                 equipped: true
               })
               .value();

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -52,9 +52,9 @@
     };
   }
 
-  LoadoutPopupCtrl.$inject = ['$rootScope', 'ngDialog', 'dimLoadoutService', 'dimItemService', 'dimItemTier', 'toaster', 'dimEngramFarmingService', '$window', 'dimSearchService', 'dimPlatformService'];
+  LoadoutPopupCtrl.$inject = ['$rootScope', 'ngDialog', 'dimLoadoutService', 'dimItemService', 'toaster', 'dimEngramFarmingService', '$window', 'dimSearchService', 'dimPlatformService'];
 
-  function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemService, dimItemTier, toaster, dimEngramFarmingService, $window, dimSearchService, dimPlatformService) {
+  function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemService, toaster, dimEngramFarmingService, $window, dimSearchService, dimPlatformService) {
     var vm = this;
     vm.previousLoadout = _.last(dimLoadoutService.previousLoadouts[vm.store.id]);
 
@@ -359,7 +359,7 @@
       var itemsByType = _.groupBy(applicableItems, 'type');
 
       var isExotic = function(item) {
-        return item.tier === dimItemTier.exotic;
+        return item.isExotic && !item.hasLifeExotic();
       };
 
       // Pick the best item

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .factory('dimItemService', ItemService);
 
-  ItemService.$inject = ['dimStoreService', 'dimBungieService', 'dimItemTier', 'dimCategory', '$q'];
+  ItemService.$inject = ['dimStoreService', 'dimBungieService', 'dimCategory', '$q'];
 
-  function ItemService(dimStoreService, dimBungieService, dimItemTier, dimCategory, $q) {
+  function ItemService(dimStoreService, dimBungieService, dimCategory, $q) {
     // We'll reload the stores to check if things have been
     // thrown away or moved and we just don't have up to date info. But let's
     // throttle these calls so we don't just keep refreshing over and over.
@@ -173,11 +173,11 @@
         return value;
       });
 
-      if (result && result.tier === dimItemTier.exotic) {
+      if (result && result.isExotic) {
         var prefix = _.filter(store.items, function(i) {
           return i.equipped &&
             i.bucket.sort === item.bucket.sort &&
-            i.tier === dimItemTier.exotic;
+            i.isExotic;
         });
 
         if (prefix.length === 0) {
@@ -192,6 +192,9 @@
 
     // Bulk equip items. Only use for multiple equips at once.
     function equipItems(store, items) {
+      if (items.length === 1) {
+        return equipItem(items[0]);
+      }
       return dimBungieService.equipItems(store, items)
         .then(function(equippedItems) {
           return equippedItems.map(function(i) {
@@ -251,18 +254,12 @@
                 i.isExotic);
       });
 
-      // Fix for "The Life Exotic" Perk on Exotic Items
-      // Can equip multiples
-      function hasLifeExotic(item) {
-        return _.find(item.talentGrid.nodes, { name: 'The Life Exotic' }) !== undefined;
-      }
-
       if (equippedExotics.length === 0) {
         deferred.resolve(true);
       } else if (equippedExotics.length === 1) {
         var equippedExotic = equippedExotics[0];
 
-        if (hasLifeExotic(item) || hasLifeExotic(equippedExotic)) {
+        if (item.hasLifeExotic() || item.hasLifeExotic()) {
           deferred.resolve(true);
         } else {
           dequipItem(equippedExotic)
@@ -275,8 +272,8 @@
         }
       } else if (equippedExotics.length === 2) {
         // Assume that only one of the equipped items has 'The Life Exotic' perk
-        if (hasLifeExotic(item)) {
-          var exoticItemWithPerk = _.find(equippedExotics, hasLifeExotic(item));
+        if (item.hasLifeExotic()) {
+          var exoticItemWithPerk = _.find(equippedExotics, item.hasLifeExotic());
           dequipItem(exoticItemWithPerk)
             .then(function() {
               deferred.resolve(true);
@@ -286,7 +283,7 @@
             });
         } else {
           var equippedExoticWithoutPerk = _.find(equippedExotics, function(item) {
-            return !hasLifeExotic(item);
+            return !item.hasLifeExotic();
           });
 
           dequipItem(equippedExoticWithoutPerk)

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -259,7 +259,7 @@
       } else if (equippedExotics.length === 1) {
         var equippedExotic = equippedExotics[0];
 
-        if (item.hasLifeExotic() || item.hasLifeExotic()) {
+        if (item.hasLifeExotic() || equippedExotic.hasLifeExotic()) {
           deferred.resolve(true);
         } else {
           dequipItem(equippedExotic)

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .factory('dimStoreService', StoreService);
 
-  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimPlatformService', 'dimItemTier', 'dimCategory', 'dimItemDefinitions', 'dimBucketService', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions', 'dimRecordsDefinitions', 'dimInfoService', 'SyncService', 'loadingTracker'];
+  StoreService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimPlatformService', 'dimCategory', 'dimItemDefinitions', 'dimBucketService', 'dimStatDefinitions', 'dimObjectiveDefinitions', 'dimTalentDefinitions', 'dimSandboxPerkDefinitions', 'dimYearsDefinitions', 'dimProgressionDefinitions', 'dimRecordsDefinitions', 'dimInfoService', 'SyncService', 'loadingTracker'];
 
-  function StoreService($rootScope, $q, dimBungieService, dimPlatformService, dimItemTier, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions, dimRecordsDefinitions, dimInfoService, SyncService, loadingTracker) {
+  function StoreService($rootScope, $q, dimBungieService, dimPlatformService, dimCategory, dimItemDefinitions, dimBucketService, dimStatDefinitions, dimObjectiveDefinitions, dimTalentDefinitions, dimSandboxPerkDefinitions, dimYearsDefinitions, dimProgressionDefinitions, dimRecordsDefinitions, dimInfoService, SyncService, loadingTracker) {
     var _stores = [];
     var progressionDefs = {};
     let recordsDefs = {};
@@ -120,6 +120,10 @@
       },
       canBeInLoadout: function() {
         return this.equipment || this.type === 'Material' || this.type === 'Consumable';
+      },
+      // "The Life Exotic" Perk on Exotic Items means you can equip another exotic
+      hasLifeExotic: function() {
+        return this.isExotic && this.talentGrid && (_.find(this.talentGrid.nodes, { name: 'The Life Exotic' }) !== undefined);
       }
     };
 


### PR DESCRIPTION
Fixed an issue where you could not equip a loadout that included an exotic item when you already had an exotic equipped that was not going to be replaced by the loadout. Also, in general better handling of items with "The Life Exotic" perk.

Fixes #749.