### PR TITLE
Restrict cookie domain to www.bungie.net

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -16,7 +16,7 @@
   },
   "permissions": [
     "storage",
-    "*://*.bungie.net/*",
+    "*://www.bungie.net/*",
     "cookies",
     "identity"
   ],

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -113,7 +113,7 @@
     function getBnetCookies() {
       return $q(function(resolve, reject) {
         chrome.cookies.getAll({
-          domain: '.bungie.net'
+          domain: 'www.bungie.net'
         }, getAllCallback);
 
         function getAllCallback(cookies) {


### PR DESCRIPTION
We're currently wildcarding the bungie domain when picking up cookies, *.bungie.net.  This is causing issues for Bungie employees using DIM to verify their authentication work doesn't disrupt our operation.  

Lets test with the beta client to see if making the domain more restrictive prompts a user for a permission change.

If Chrome does prompt for a permission change, then we need to **_only_** update the beta client with the more restrictive domain, and leave production as is.  This will be a grunt task to manage this config for beta/production.

If it does not prompt, then make the change and release.