### PR TITLE
ManifestDig tools

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,8 @@ app/scripts/toaster.js
 app/vendor/
 build/
 build/processBungieManifest.js
+build/getBungieManifest.js
+build/manifestDig.js
 dist/
 Gruntfile.js
 karma.conf.js

--- a/build/getBungieManifest.js
+++ b/build/getBungieManifest.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+var http = require('http');
+var fs = require('fs');
+var request = require('request');
+var sqlite3 = require('sqlite3').verbose();
+var _ = require("underscore");
+var unzip = require('unzip');
+var mkdirp = require('mkdirp');
+var async = require("async");
+var ProgressBar = require('progress');
+
+var progressionMeta = require('./progressionMeta.json');
+
+var version;
+
+function onManifestRequest(error, response, body) {
+  var parsedResponse = JSON.parse(body);
+  var manifestFile = fs.createWriteStream("manifest.zip");
+  version = parsedResponse.Response.version;
+
+  request
+    .get('https://www.bungie.net' + parsedResponse.Response.mobileWorldContentPaths.en)
+    .pipe(manifestFile)
+    .on('close', onManifestDownloaded);
+}
+
+function onManifestDownloaded() {
+  fs.createReadStream('manifest.zip')
+    .pipe(unzip.Parse())
+    .on('entry', function(entry) {
+      var ws = fs.createWriteStream('manifest/' + entry.path);
+      entry.pipe(ws);
+    });
+}
+
+request({
+  headers: {
+    'X-API-Key': '57c5ff5864634503a0340ffdfbeb20c0'
+  },
+  uri: 'http://www.bungie.net/platform/Destiny/Manifest/',
+  method: 'GET'
+}, onManifestRequest);

--- a/build/manifestDig.js
+++ b/build/manifestDig.js
@@ -12,6 +12,9 @@ var sqlite3 = require('sqlite3').verbose();
 var target = process.argv[3];
 
 var tables = (process.argv[4] || '').split(',');
+if (tables.length == 1 && !tables[0].length) {
+  tables = [];
+}
 
 var db = new sqlite3.Database(process.argv[2], sqlite3.OPEN_READONLY);
 
@@ -36,7 +39,7 @@ function dig(object, target, table, result) {
 
 db.serialize(function () {
   db.each("select name from sqlite_master where type='table'", function (err, table) {
-    if (tables.indexOf(table.name) >= 0) {
+    if (!tables.length || tables.indexOf(table.name) >= 0) {
       db.all("select * from " + table.name, function (err, result) {
         (result || []).forEach(function(entry) {
           if (entry.id === target) {

--- a/build/manifestDig.js
+++ b/build/manifestDig.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+// For example, to find the nodeStepHash of "The Life Exotic" nodes:
+
+// brew install jq
+// ./getBungieManifest.js
+// ./manifestDig.js manifest/world_sql_content_c7ea5036ed3278fe06a7a8feae87bf94.content 'The Life Exotic' DestinyTalentGridDefinition | jq '.nodes[].steps[] | select(.nodeStepName == "The Life Exotic") | .["nodeStepHash"]' | sort | uniq
+
+var fs = require('fs');
+var sqlite3 = require('sqlite3').verbose();
+
+var target = process.argv[3];
+
+var tables = (process.argv[4] || '').split(',');
+
+var db = new sqlite3.Database(process.argv[2], sqlite3.OPEN_READONLY);
+
+function dig(object, target, table, result) {
+  if (typeof object === 'object') {
+    for (var key in object) {
+      if (key === target) {
+        console.log(result);
+      } else {
+        dig(object[key], target, table, result);
+      }
+    }
+  } else if (Array.isArray(object)) {
+    object.forEach(function(val) {
+      dig(val, target, table, result);
+    });
+  } else if (object == target) {
+    console.log(result);
+  }
+}
+
+
+db.serialize(function () {
+  db.each("select name from sqlite_master where type='table'", function (err, table) {
+    if (tables.indexOf(table.name) >= 0) {
+      db.all("select * from " + table.name, function (err, result) {
+        (result || []).forEach(function(entry) {
+          if (entry.id === target) {
+            console.log(entry.json);
+          } else {
+            try {
+              var doc = JSON.parse(entry.json);
+              dig(doc, target, table.name, entry.json);
+            } catch(e) {
+              console.error(e, entry.json);
+            }
+          }
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
These are some tools I've had around to help find info from the manifest database. I combine this with just exploring around in `sqlite3` to find stuff.

The idea of manifestDig is that it'll recursively search the manifest for a value, like a string or ID. Here's a usage example I recently did to find out what the nodeStepHash of "The Life Exotic" perk was:

```
./manifestDig.js manifest/world_sql_content_c7ea5036ed3278fe06a7a8feae87bf94.content 'The Life Exotic' DestinyTalentGridDefinition | jq '.nodes[].steps[] | select(.nodeStepName == "The Life Exotic") | .["nodeStepHash"]' | sort | uniq
```

manifestDig produces the JSON document for all matching entries, and then I'm able to use `jq` to rip it apart.