### PR TITLE
Replace unzip with unzipper

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "sqlite3": "^3.1.4",
     "uglify-js": "^2.7.0",
     "underscore": "^1.8.3",
-    "unzip": "^0.1.11"
+    "unzipper": "^0.3.1"
   }
 }


### PR DESCRIPTION
Unzipper is a drop in replacement for unzip which is actively being maintained... https://github.com/EvanOxfeld/node-unzip/pull/100

May also want to look at replacing jpm with web-ext as per: https://github.com/mozilla-jetpack/jpm/issues/538