### PR TITLE
Switch to HTTPS for all Bungie URLs

### DIFF
--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -103,7 +103,7 @@
 
     function openBungieNetTab() {
       chrome.tabs.create({
-        url: 'http://bungie.net',
+        url: 'https://bungie.net',
         active: true
       });
     }

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -61,8 +61,8 @@
         this.level = characterInfo.characterLevel;
         this.percentToNextLevel = characterInfo.percentToNextLevel / 100.0;
         this.powerLevel = characterInfo.characterBase.powerLevel;
-        this.background = 'http://bungie.net/' + characterInfo.backgroundPath;
-        this.icon = 'http://bungie.net/' + characterInfo.emblemPath;
+        this.background = 'https://bungie.net/' + characterInfo.backgroundPath;
+        this.icon = 'https://bungie.net/' + characterInfo.emblemPath;
         this.stats = getStatsData(characterInfo.characterBase);
       },
       // Remove an item from this store. Returns whether it actually removed anything.
@@ -286,9 +286,9 @@
 
               store = angular.extend(Object.create(StoreProto), {
                 id: raw.id,
-                icon: 'http://bungie.net/' + raw.character.base.emblemPath,
+                icon: 'https://bungie.net/' + raw.character.base.emblemPath,
                 lastPlayed: raw.character.base.characterBase.dateLastPlayed,
-                background: 'http://bungie.net/' + raw.character.base.backgroundPath,
+                background: 'https://bungie.net/' + raw.character.base.backgroundPath,
                 level: raw.character.base.characterLevel,
                 powerLevel: raw.character.base.characterBase.powerLevel,
                 stats: getStatsData(raw.character.base.characterBase),

--- a/app/scripts/store/dimBungieImageFallback.directive.js
+++ b/app/scripts/store/dimBungieImageFallback.directive.js
@@ -14,10 +14,10 @@
     // we don't try again.
     var loadImage = _.memoize(function(path) {
       return $q(function(resolve) {
-        $('<img/>').attr('src', 'http://www.bungie.net' + path)
+        $('<img/>').attr('src', 'https://www.bungie.net' + path)
           .load(function() {
             $(this).remove();
-            resolve('http://www.bungie.net' + path);
+            resolve('https://www.bungie.net' + path);
           })
           .error(function() {
             $(this).remove();


### PR DESCRIPTION
I'm convinced that @kyleshay is right - the folks who can't load images but can use the API are in that situation because we load our images over HTTP but the API via HTTPS. Firewalls can't see the URL or content type for HTTPS connections, so if we get images over HTTPS, they can't be selectively blocked (unless the person's IT department has also spoofed a root cert and is intercepting all HTTPS traffic, in which case they shouldn't use the internet at work at all!)

There's no performance difference here (we actually get to reuse SSL connections we make for the API) and this should help out with ISP firewalls and antivirus messing with the images as well. I recently read that YouTube switching to HTTPS really improved video delivery reliability, though I can't find the post.