### PR TITLE
Update translations

### DIFF
--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -20,37 +20,47 @@
           Weapons: "Armi",
           Armor: "Armatura",
           Equip: "Equipaggia",
-          Vault: "Deposito"
+          Vault: "Depositi",
+          Vanguard: "Avanguardia"
         })
         .translations('de', {
           Weapons: "Waffen",
-          Armor: "Schutz",
-          Equip: "Ausstatten",
-          Vault: "Ausrüstungstresor"
+          Armor: "Rüstung",
+          Equip: "Ausrüsten",
+          Vault: "Tresor",
+          Vanguard: "Vorhut"
         })
         .translations('fr', {
           Level: "Niveau",
           Weapons: "Armes",
           Armor: "Armure",
           Equip: "Équiper",
-          Vault: "Coffres"
+          Vault: "Coffres",
+          Vanguard: "Avant-garde"
         })
         .translations('es', {
           Level: "Nivel",
           Weapons: "Armas",
           Armor: "Armadura",
           Equip: "Equipar",
-          Vault: "Bóveda",
+          Vault: "Depósito",
           Vanguard: "Vanguardia"
         })
         .translations('ja', {
+          Level: "レベル",
+          Weapons: "武器",
+          Armor: "装甲",
+          Equip: "装備し",
+          Vault: "保管",
+          Vanguard: "前衛"
         })
         .translations('pt-br', {
-          Level: "Nivel",
+          Level: "Nível",
           Weapons: "Armas",
           Armor: "Armadura",
           Equip: "Equipar",
-          Vault: "Cofres"
+          Vault: "Cofres",
+          Vanguard: "Vanguarda"
         })
         .fallbackLanguage('en');
     }]);

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -41,7 +41,7 @@
           Weapons: "Armes",
           Armor: "Armure",
           General: "Général",
-          Postmaster: "Commis des postes",          
+          Postmaster: "Commis des postes",
           Equip: "Équiper",
           Vault: "Coffres",
           Vanguard: "Avant-garde"
@@ -50,7 +50,7 @@
           Level: "Nivel",
           Weapons: "Armas",
           Armor: "Armadura",
-          Postmaster: "Administración",          
+          Postmaster: "Administración",
           Equip: "Equipar",
           Vault: "Depósito",
           Vanguard: "Vanguardia"
@@ -60,7 +60,7 @@
           Weapons: "武器",
           Armor: "装甲",
           General: "一般的な",
-          Postmaster: "郵便局",          
+          Postmaster: "郵便局",
           Equip: "装備し",
           Vault: "保管",
           Vanguard: "前衛"
@@ -71,7 +71,7 @@
           Armor: "Armadura",
           Equip: "Equipar",
           General: "Geral",
-          Postmaster: "Chefe do Correio",          
+          Postmaster: "Chefe do Correio",
           Vault: "Cofres",
           Vanguard: "Vanguarda"
         })

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -11,6 +11,8 @@
           Level: "Level",
           Weapons: "Weapons",
           Armor: "Armor",
+          General: "General",
+          Postmaster: "Postmaster",
           Equip: "Equip",
           Vault: "Vault",
           Vanguard: "Vanguard"
@@ -19,6 +21,8 @@
           Level: "Livello",
           Weapons: "Armi",
           Armor: "Armatura",
+          General: "Generale",
+          Postmaster: "Amministratrice",
           Equip: "Equipaggia",
           Vault: "Depositi",
           Vanguard: "Avanguardia"
@@ -26,6 +30,8 @@
         .translations('de', {
           Weapons: "Waffen",
           Armor: "Rüstung",
+          General: "Allgemein",
+          Postmaster: "Poststelle",
           Equip: "Ausrüsten",
           Vault: "Tresor",
           Vanguard: "Vorhut"
@@ -34,6 +40,8 @@
           Level: "Niveau",
           Weapons: "Armes",
           Armor: "Armure",
+          General: "Général",
+          Postmaster: "Commis des postes",          
           Equip: "Équiper",
           Vault: "Coffres",
           Vanguard: "Avant-garde"
@@ -42,6 +50,7 @@
           Level: "Nivel",
           Weapons: "Armas",
           Armor: "Armadura",
+          Postmaster: "Administración",          
           Equip: "Equipar",
           Vault: "Depósito",
           Vanguard: "Vanguardia"
@@ -50,6 +59,8 @@
           Level: "レベル",
           Weapons: "武器",
           Armor: "装甲",
+          General: "一般的な",
+          Postmaster: "郵便局",          
           Equip: "装備し",
           Vault: "保管",
           Vanguard: "前衛"
@@ -59,6 +70,8 @@
           Weapons: "Armas",
           Armor: "Armadura",
           Equip: "Equipar",
+          General: "Geral",
+          Postmaster: "Chefe do Correio",          
           Vault: "Cofres",
           Vanguard: "Vanguarda"
         })


### PR DESCRIPTION
All translations are sourced directly from Destiny, with the exception of Japanese (it shows English text, when system language is set to JP)
Japanese is sourced from google translate using different languages as sources to find the most common occurrence.
Spanish translation is based off of Spanish (Spain)

Locations used: (In case anyone wants to double check)
Level, Equip: Equip Screen (Highlight your level), Choose an equip-able item (X equip)
Weapons, Armor, General, Vault: From an open Vault, All caps word is Vault, top row lowercase (weapons, armor, general)
Vanguard: Vanguard Faction name from Quest Page
Postmaster: From postmaster screen, All caps word(s), Capitalization from paragraph text...