### PR TITLE
Filter out vendor items when the checkbox is unchecked

### DIFF
--- a/app/scripts/minmax/dimMinMax.controller.js
+++ b/app/scripts/minmax/dimMinMax.controller.js
@@ -180,7 +180,9 @@
         vm.highestsets = vm.getSetBucketsStep(vm.active);
       },
       onIncludeVendorsChange: function() {
-        if (!vm.includeVendors) {
+        if (vm.includeVendors) {
+          vm.ranked = mergeBuckets(buckets[vm.active], vendorBuckets[vm.active]);
+        } else {
           vm.ranked = buckets[vm.active];
 
           // Filter any vendor items from locked or excluded items
@@ -193,8 +195,6 @@
           vm.excludeditems = _.filter(vm.excludeditems, function(item) {
             return !item.isVendorItem;
           });
-        } else {
-          vm.ranked = mergeBuckets(buckets[vm.active], vendorBuckets[vm.active]);
         }
         vm.highestsets = vm.getSetBucketsStep(vm.active);
       },

--- a/app/scripts/minmax/dimMinMax.controller.js
+++ b/app/scripts/minmax/dimMinMax.controller.js
@@ -180,7 +180,22 @@
         vm.highestsets = vm.getSetBucketsStep(vm.active);
       },
       onIncludeVendorsChange: function() {
-        vm.ranked = (vm.includeVendors) ? mergeBuckets(buckets[vm.active], vendorBuckets[vm.active]) : buckets[vm.active];
+        if (!vm.includeVendors) {
+          vm.ranked = buckets[vm.active];
+
+          // Filter any vendor items from locked or excluded items
+          _.each(vm.lockeditems, function(item, type) {
+            if (item && item.isVendorItem) {
+              vm.lockeditems[type] = null;
+            }
+          });
+
+          vm.excludeditems = _.filter(vm.excludeditems, function(item) {
+            return !item.isVendorItem;
+          });
+        } else {
+          vm.ranked = mergeBuckets(buckets[vm.active], vendorBuckets[vm.active]);
+        }
         vm.highestsets = vm.getSetBucketsStep(vm.active);
       },
       onOrderChange: function() {


### PR DESCRIPTION
If the vendor items checkbox is checked and vendor items are locked/excluded then they currently still appear after the include vendor items checkbox is unchecked. This PR will filter out vendor items when the checkbox is unchecked.