### PR TITLE
Add sticky headers to vendors page

### DIFF
--- a/app/scripts/vendors/dimVendor.controller.js
+++ b/app/scripts/vendors/dimVendor.controller.js
@@ -9,6 +9,22 @@
   function dimVendorCtrl($scope, $state, $q, dimStoreService, dimSettingsService) {
     var vm = this;
 
+    var $window = $(window);
+    var $vendorHeaders = $('#vendorHeaders');
+    var $vendorHeadersBackground = $('#vendorHeadersBackground');
+    var vendorsTop = $vendorHeaders.offset().top - 66; // Subtract height of title and back link
+
+    function stickyHeader(e) {
+      $vendorHeaders.toggleClass('sticky', $window.scrollTop() > vendorsTop);
+      $vendorHeadersBackground.toggleClass('sticky', $window.scrollTop() > vendorsTop);
+    }
+
+    $window.on('scroll', stickyHeader);
+
+    $scope.$on('$destroy', function() {
+      $window.off('scroll', stickyHeader);
+    });
+
     vm.settings = dimSettingsService;
     function init(stores) {
       vm.stores = _.reject(stores, (s) => s.isVault);

--- a/app/scss/_vendors.scss
+++ b/app/scss/_vendors.scss
@@ -2,6 +2,9 @@
   width: calc(((40px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px)) + 12px) * 3) - 12px);
   margin: 0 auto;
 
+  .vendors {
+    margin-top: 90px;
+  }
   .vendor-col {
     margin-right: 20px;
   }
@@ -34,9 +37,28 @@
   .fa-arrow-circle-left {
     padding-right: 5px;
   }
+  .vendor-headers-background {
+    display: none;
+    position: fixed;
+    height: 90px;
+    left: 0;
+    width: 100%;
+    top: 50px;
+    background-color: #434444;
+    z-index: 4;
+  }
+  .vendor-headers-background.sticky {
+    display: block;
+  }
+  .vendor-headers.sticky {
+    position:fixed;
+    top: 64px;
+  }
   .vendor-headers {
+    position: absolute;
+    top: 142px;
+    z-index: 4;
     display: flex;
-    padding-bottom: 10px;
   }
   .vendor-header {
     .title {

--- a/app/views/vendors.html
+++ b/app/views/vendors.html
@@ -1,7 +1,8 @@
 <div class="vendor" ng-controller="dimVendorCtrl as vm">
   <a ui-sref='inventory' class="link"><i class='fa fa-arrow-circle-left'></i>Back to DIM</a>
   <h1>Vendors</h1>
-  <div class="vendor-headers">
+  <div id="vendorHeadersBackground" class="vendor-headers-background"></div>
+  <div id="vendorHeaders" class="vendor-headers">
     <div class="store-cell" ng-if="!store.isVault" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">
       <dim-store-heading class="character" store-data="store"></dim-store-heading>
     </div>


### PR DESCRIPTION
Issue #808 

![example-vendor-sticky](https://cloud.githubusercontent.com/assets/4594931/18152710/920f80aa-6fbd-11e6-81d1-78ade18753fe.gif)

I decided against adding in the box-shadow, but if you guys want it in it should be simple.