### PR TITLE
Add npm scripts to run all required installation commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: "4"
 before_install: npm install -g grunt-cli && npm install -g bower
-install: npm install && bower install
+install: npm install
 before_script: grunt publish_chrome_beta
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@ Clone the repo:
 Install dependencies:
 
 * `npm install`
-* `bower install` (if you don't already have bower installed, install it with `npm install -g bower`)
 
 Generate CSS
-* `grunt css`
-* `grunt dev-chrome` or `grunt dev-firefox` (This will watch the scss files for any changes and generate a new style.css)
+* `npm run generate-css`
+* `npm run dev-chrome` or `npm run dev-firefox` (This will watch the scss files for any changes and generate a new style.css)
 
 Check code Style
-* `grunt eslint` will tell you if you're following the DIM code style (and automatically fix what it can).
+* `npm run lint` will tell you if you're following the DIM code style (and automatically fix what it can).
 
 You can run now run DIM locally by enabling [Chrome Extensions Developer Mode](https://developer.chrome.com/extensions/faq#faq-dev-01) and point to the `app/` folder, or by installing [Firefox Developer Edition](https://www.mozilla.org/en-US/firefox/developer/) and [loading the extension from disk](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Packaging_and_Installation#Loading_from_disk).
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "An item manager for Destiny.",
   "main": "app/index.html",
   "scripts": {
+    "dev-chrome": "./node_modules/.bin/grunt dev-chrome",
+    "dev-firefox": "./node_modules/.bin/grunt dev-firefox",
+    "generate-css": "./node_modules/.bin/grunt css",
+    "lint": "./node_modules/.bin/grunt eslint",
+    "postinstall": "./node_modules/.bin/bower install",
     "test": "echo \"No tests\""
   },
   "repository": {
@@ -20,6 +25,7 @@
     "adm-zip": "^0.4.7",
     "async": "^2.0.0",
     "autoprefixer": "^6.3.7",
+    "bower": "^1.7.9",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-compress": "^1.3.0",


### PR DESCRIPTION
Previously developers needed to have `bower` and `grunt` globally installed
and the scripts weren't using the locally installed binaries of either.
This commit updates it so that all necessary commands can be run with
`npm run COMMAND` and no longer requires developers to install `grunt`
or `bower` globally.

Also worth noting, `bower install` now happens in the `postinstall` step
of `npm install`.  No need to run separately.