### PR TITLE
Fix popup heading title overflow

### DIFF
--- a/app/scss/_item-header.scss
+++ b/app/scss/_item-header.scss
@@ -15,7 +15,6 @@ $item-header-spacing: 5px;
   padding: $item-header-spacing 28px $item-header-spacing $item-header-spacing;
   position: relative;
   text-overflow: ellipsis;
-  white-space: nowrap !important;
 
   &.is-arc {
     background-color: $arc;


### PR DESCRIPTION
Here we go again.

Fixes https://github.com/DestinyItemManager/DIM/issues/849

Remove the CSS attribute and the titles will break to a new line if it's too long.

![screen shot 2016-09-09 at 11 25 04 pm](https://cloud.githubusercontent.com/assets/2036594/18407949/b26ad718-76e4-11e6-8dd9-0a6d14355321.png)
