### PR TITLE
Only show "did you know?" popups once per session.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Better handle errors when record book info isn't available.
 * Show an error message if the manifest doesn't load.
 * Fix an error when equipping loadouts.
+* DIM usage tips will only show up once per session now. You can bring back previously hidden tips with a button in the settings page.
 
 # 3.10.0
 

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -120,16 +120,21 @@
       });
     };
 
-    /**
-     * Move the item to the specified store. Equip it if equip is true.
-     */
-    vm.moveItemTo = dimActionQueue.wrap(function moveItemTo(store, equip) {
+    // Only show this once per session
+    const didYouKnow = _.once(() => {
       dimInfoService.show('movebox', {
         title: 'Did you know?',
         body: ['<p>Items can be dragged and dropped between different characters/vault columns.</p>',
                '<p>Try it out next time!<p>'].join(''),
         hide: 'Don\'t show this tip again'
       });
+    });
+
+    /**
+     * Move the item to the specified store. Equip it if equip is true.
+     */
+    vm.moveItemTo = dimActionQueue.wrap(function moveItemTo(store, equip) {
+      didYouKnow();
 
       var reload = vm.item.equipped || equip;
       var promise = dimItemService.moveTo(vm.item, store, equip, vm.moveAmount);

--- a/app/scripts/services/dimInfoService.factory.js
+++ b/app/scripts/services/dimInfoService.factory.js
@@ -53,6 +53,12 @@
           }
           content.func();
         });
+      },
+      // Remove prefs for "don't show this again"
+      resetHiddenInfos: function() {
+        SyncService.get().then(function(data) {
+          SyncService.set(_.omit(data, (v, k) => k.startsWith('info.')), true);
+        });
       }
     };
   }

--- a/app/scripts/shell/dimSettingsCtrl.controller.js
+++ b/app/scripts/shell/dimSettingsCtrl.controller.js
@@ -3,9 +3,9 @@
 
   angular.module('dimApp').controller('dimSettingsCtrl', SettingsController);
 
-  SettingsController.$inject = ['dimSettingsService', '$scope', 'SyncService', 'dimCsvService', 'dimStoreService'];
+  SettingsController.$inject = ['dimSettingsService', '$scope', 'SyncService', 'dimCsvService', 'dimStoreService', 'dimInfoService'];
 
-  function SettingsController(settings, $scope, SyncService, dimCsvService, dimStoreService) {
+  function SettingsController(settings, $scope, SyncService, dimCsvService, dimStoreService, dimInfoService) {
     var vm = this;
 
     $scope.$watchCollection('vm.settings', function() {
@@ -36,14 +36,18 @@
       SyncService.authorize();
     };
 
-    vm.downloadWeaponCsv = function(){
+    vm.downloadWeaponCsv = function() {
       dimCsvService.downloadCsvFiles(dimStoreService.getStores(), "Weapons");
       _gaq.push(['_trackEvent', 'Download CSV', 'Weapons']);
     };
 
-    vm.downloadArmorCsv = function(){
+    vm.downloadArmorCsv = function() {
       dimCsvService.downloadCsvFiles(dimStoreService.getStores(), "Armor");
       _gaq.push(['_trackEvent', 'Download CSV', 'Armor']);
+    };
+
+    vm.resetHiddenInfos = function() {
+      dimInfoService.resetHiddenInfos();
     };
   }
 })();

--- a/app/scripts/store/dimStoreBucket.directive.js
+++ b/app/scripts/store/dimStoreBucket.directive.js
@@ -127,16 +127,21 @@
       $timeout.cancel(dragTimer);
     };
 
+    // Only show this once per session
+    const didYouKnow = _.once(() => {
+      dimInfoService.show('doubleclick', {
+        title: 'Did you know?',
+        body: ['<p>If you\'re moving an item to your currently active (last logged in) character, you can instead double click that item to instantly equip it.</p>',
+               '<p>Try it out next time!<p>'].join(''),
+        hide: 'Don\'t show this tip again'
+      });
+    });
+
     vm.moveDroppedItem = dimActionQueue.wrap(function(item, equip, $event, hovering) {
       var target = vm.store;
 
       if (target.current && equip) {
-        dimInfoService.show('doubleclick', {
-          title: 'Did you know?',
-          body: ['<p>If you\'re moving an item to your currently active (last logged in) character, you can instead double click that item to instantly equip it.</p>',
-                 '<p>Try it out next time!<p>'].join(''),
-          hide: 'Don\'t show this tip again'
-        });
+        didYouKnow();
       }
 
       if (item.notransfer && item.owner !== target.id) {

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -6,17 +6,6 @@
     <table>
       <tr>
         <td>
-          <label for="spreadsheetLinks" title="Download a CSV list of your items that can be easily viewed in the spreadsheet app of your choice.">Download Spreadsheets</label>
-        </td>
-        <td>
-          <div id="spreadsheetLinks">
-            <button ng-click="vm.downloadWeaponCsv()" ng-disabled="loadingTracker.active()" title="Download Csv"> <i class="fa fa-table"></i> Weapons</button>
-            <button ng-click="vm.downloadArmorCsv()" ng-disabled="loadingTracker.active()" title="Download Csv"> <i class="fa fa-table"></i> Armor</button>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
           <label for="language">Language (reload DIM to take effect)</label>
         </td>
         <td>
@@ -126,6 +115,25 @@
             <br>
           <label>
             <input type="radio" ng-model="vm.settings.characterOrder" value="fixed" ng-model-options="{ updateOn: 'default blur' }">Fixed (By Character Age)</label>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label for="spreadsheetLinks" title="Download a CSV list of your items that can be easily viewed in the spreadsheet app of your choice.">Download Spreadsheets</label>
+        </td>
+        <td>
+          <div id="spreadsheetLinks">
+            <button ng-click="vm.downloadWeaponCsv()" ng-disabled="loadingTracker.active()" title="Download Csv"> <i class="fa fa-table"></i> Weapons</button>
+            <button ng-click="vm.downloadArmorCsv()" ng-disabled="loadingTracker.active()" title="Download Csv"> <i class="fa fa-table"></i> Armor</button>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label for="resetHiddenInfos">DIM Info Popups</label>
+        </td>
+        <td>
+          <button ng-click="vm.resetHiddenInfos()">Reset previously hidden info tips</button>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
Plus, offer a settings button to bring back all previously hidden tips. I also moved the CSV export buttons down to the bottom of the settings page while I was at it.