### PR TITLE
Support custom notes on items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
-* You can now mark items as "favorite", "keep" or "delete". There are corresponding search filters. There are also keyboard shortcuts - press "?" to see them.
+* You can now mark items as "favorite", "keep", "delete" or "infuse". There are corresponding search filters (tag:keep, tag:favorite, etc.) There are also keyboard shortcuts - press "?" to see them.
+* You can now add custom notes to items. Just type them in the box and it automatically saves the text. You can also search for notes -> notes:"god roll"
 * Fixed a "move-canceled" message showing up sometimes when applying loadouts.
 * Bugged items like Iron Shell no longer attempt to compute quality. They'll fix themselves when Bungie fixes them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next
 
-* You can now mark items as "favorite", "keep", "delete" or "infuse". There are corresponding search filters (tag:keep, tag:favorite, etc.) There are also keyboard shortcuts - press "?" to see them.
+* You can now mark items as "favorite", "keep", "dismantle" or "infuse". There are corresponding search filters (tag:keep, tag:favorite, etc.) There are also keyboard shortcuts - press "?" to see them.
 * You can now add custom notes to items. Just type them in the box and it automatically saves the text. You can also search for notes -> notes:"god roll"
 * Fixed a "move-canceled" message showing up sometimes when applying loadouts.
 * Bugged items like Iron Shell no longer attempt to compute quality. They'll fix themselves when Bungie fixes them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next
 
-* You can now mark items as "favorite", "keep", "dismantle" or "infuse". There are corresponding search filters (tag:keep, tag:favorite, etc.) There are also keyboard shortcuts - press "?" to see them.
+* You can now mark items as "favorite", "keep", "junk" or "infuse". There are corresponding search filters (tag:keep, tag:favorite, etc.) There are also keyboard shortcuts - press "?" to see them.
 * You can now add custom notes to items. Just type them in the box and it automatically saves the text. You can also search for notes -> notes:"god roll"
 * Fixed a "move-canceled" message showing up sometimes when applying loadouts.
 * Bugged items like Iron Shell no longer attempt to compute quality. They'll fix themselves when Bungie fixes them.

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -34,7 +34,7 @@
           'Tag Item': "Tag Item",
           Favorite: "Favorite",
           Keep: "Keep",
-          Dismantle: "Dismantle",
+          Junk: "Junk",
           Infuse: "Infuse",
           notes_placeholder: "Add notes to this item"
         })
@@ -64,7 +64,7 @@
           'Tag Item': "Elemento Tag",
           Favorite: "Preferito",
           Keep: "Tenere",
-          Dismantle: "",
+          Junk: "",
           Infuse: "Infondi",
           notes_placeholder: "Aggiungere note a questa voce"
         })
@@ -93,7 +93,7 @@
           'Tag Item': "Tag Artikel",
           Favorite: "Favorit",
           Keep: "Behalten",
-          Dismantle: "",
+          Junk: "",
           Infuse: "Infundieren",
           notes_placeholder: "Hinzufügen von Anmerkungen zu diesem Artikel"
         })
@@ -123,7 +123,7 @@
           'Tag Item': "Tag Article",
           Favorite: "Préféré",
           Keep: "Garder",
-          Dismantle: "",
+          Junk: "",
           Infuse: "Infuser",
           notes_placeholder: "Ajouter des notes à cet article"
         })
@@ -152,7 +152,7 @@
           'Tag Item': "Elemento de Etiqueta",
           Favorite: "Favorito",
           Keep: "Guardar",
-          Dismantle: "",
+          Junk: "",
           Infuse: "Infundir",
           notes_placeholder: "Agregar notas a este artículo"
         })
@@ -177,7 +177,7 @@
           'Tag Item': "タグアイテム",
           Favorite: "本命",
           Keep: "保つ",
-          Dismantle: "",
+          Junk: "",
           Infuse: "煎じる",
           notes_placeholder: "このアイテムにメモを追加"
         })
@@ -207,7 +207,7 @@
           'Tag Item': "Item de Tag",
           Favorite: "Favorito",
           Keep: "Guarda",
-          Dismantle: "",
+          Junk: "",
           Infuse: "Infundir",
           notes_placeholder: "Adicionar observações a este item"
         })

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -34,7 +34,7 @@
           'Tag Item': "Tag Item",
           Favorite: "Favorite",
           Keep: "Keep",
-          Delete: "Delete",
+          Dismantle: "Dismantle",
           Infuse: "Infuse",
           notes_placeholder: "Add notes to this item"
         })
@@ -64,7 +64,7 @@
           'Tag Item': "Elemento Tag",
           Favorite: "Preferito",
           Keep: "Tenere",
-          Delete: "Cancellare",
+          Dismantle: "",
           Infuse: "Infondi",
           notes_placeholder: "Aggiungere note a questa voce"
         })
@@ -93,7 +93,7 @@
           'Tag Item': "Tag Artikel",
           Favorite: "Favorit",
           Keep: "Behalten",
-          Delete: "Löschen",
+          Dismantle: "",
           Infuse: "Infundieren",
           notes_placeholder: "Hinzufügen von Anmerkungen zu diesem Artikel"
         })
@@ -123,7 +123,7 @@
           'Tag Item': "Tag Article",
           Favorite: "Préféré",
           Keep: "Garder",
-          Delete: "Effacer",
+          Dismantle: "",
           Infuse: "Infuser",
           notes_placeholder: "Ajouter des notes à cet article"
         })
@@ -152,7 +152,7 @@
           'Tag Item': "Elemento de Etiqueta",
           Favorite: "Favorito",
           Keep: "Guardar",
-          Delete: "Borrar",
+          Dismantle: "",
           Infuse: "Infundir",
           notes_placeholder: "Agregar notas a este artículo"
         })
@@ -177,7 +177,7 @@
           'Tag Item': "タグアイテム",
           Favorite: "本命",
           Keep: "保つ",
-          Delete: "消す",
+          Dismantle: "",
           Infuse: "煎じる",
           notes_placeholder: "このアイテムにメモを追加"
         })
@@ -207,7 +207,7 @@
           'Tag Item': "Item de Tag",
           Favorite: "Favorito",
           Keep: "Guarda",
-          Delete: "Excluir",
+          Dismantle: "",
           Infuse: "Infundir",
           notes_placeholder: "Adicionar observações a este item"
         })

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -34,7 +34,8 @@
           'Tag Item': "Tag Item",
           Favorite: "Favorite",
           Keep: "Keep",
-          Delete: "Delete"
+          Delete: "Delete",
+          Infuse: "Infuse"
         })
         .translations('it', {
           Level: "Livello",

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -35,7 +35,8 @@
           Favorite: "Favorite",
           Keep: "Keep",
           Delete: "Delete",
-          Infuse: "Infuse"
+          Infuse: "Infuse",
+          notes_placeholder: "Add notes to this item"
         })
         .translations('it', {
           Level: "Livello",

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -49,6 +49,7 @@
         '  <div class="item-xp-bar" ng-if="vm.item.percentComplete != null && !vm.item.complete">',
         '    <div dim-percent-width="vm.item.percentComplete"></div>',
         '  </div>',
+        '  <textarea placeholder="Add notes to this item" class="item-notes" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.item.dimInfo.save()"></textarea>',
         '  <div class="item-description" ng-if="vm.itemDetails && vm.showDescription" ng-bind="::vm.item.description"></div>',
         '  <div class="item-details" ng-if="vm.item.classified">Classified item. Bungie does not yet provide information about this item. Item is not yet transferable.</div>',
         '  <div class="stats" ng-if="vm.itemDetails && vm.hasDetails">',

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -49,7 +49,7 @@
         '  <div class="item-xp-bar" ng-if="vm.item.percentComplete != null && !vm.item.complete">',
         '    <div dim-percent-width="vm.item.percentComplete"></div>',
         '  </div>',
-        '  <form name="notes"><textarea name="data" placeholder="{{ \'notes_placeholder\' | translate }}" class="item-notes" ng-maxlength="120" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.updateNote()"></textarea></form>',
+        '  <form ng-if="vm.item.lockable" name="notes"><textarea name="data" placeholder="{{ \'notes_placeholder\' | translate }}" class="item-notes" ng-maxlength="120" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.updateNote()"></textarea></form>',
         '  <span class="item-notes-error" ng-show="notes.data.$error.maxlength">Error! Max 120 characters for notes.</span>',
         '  <div class="item-description" ng-if="vm.itemDetails && vm.showDescription" ng-bind="::vm.item.description"></div>',
         '  <div class="item-details" ng-if="vm.item.classified">Classified item. Bungie does not yet provide information about this item. Item is not yet transferable.</div>',

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -49,7 +49,8 @@
         '  <div class="item-xp-bar" ng-if="vm.item.percentComplete != null && !vm.item.complete">',
         '    <div dim-percent-width="vm.item.percentComplete"></div>',
         '  </div>',
-        '  <textarea placeholder="{{ \'notes_placeholder\' | translate }}" class="item-notes" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.item.dimInfo.save()"></textarea>',
+        '  <form name="notes"><textarea name="data" placeholder="{{ \'notes_placeholder\' | translate }}" class="item-notes" ng-maxlength="120" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.updateNote()"></textarea></form>',
+        '  <span class="item-notes-error" ng-show="notes.data.$error.maxlength">Error! Max 120 characters for notes.</span>',
         '  <div class="item-description" ng-if="vm.itemDetails && vm.showDescription" ng-bind="::vm.item.description"></div>',
         '  <div class="item-details" ng-if="vm.item.classified">Classified item. Bungie does not yet provide information about this item. Item is not yet transferable.</div>',
         '  <div class="stats" ng-if="vm.itemDetails && vm.hasDetails">',
@@ -107,6 +108,12 @@
       vm.itemDetails = !vm.itemDetails;
       vm.changeDetails();
     });
+
+    vm.updateNote = function() {
+      if(angular.isDefined(vm.item.dimInfo.notes)) {
+        vm.item.dimInfo.save();
+      }
+    }
 
     vm.setItemState = function setItemState(item, type) {
       if (vm.locking) {

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -110,10 +110,10 @@
     });
 
     vm.updateNote = function() {
-      if(angular.isDefined(vm.item.dimInfo.notes)) {
+      if (angular.isDefined(vm.item.dimInfo.notes)) {
         vm.item.dimInfo.save();
       }
-    }
+    };
 
     vm.setItemState = function setItemState(item, type) {
       if (vm.locking) {

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -49,7 +49,7 @@
         '  <div class="item-xp-bar" ng-if="vm.item.percentComplete != null && !vm.item.complete">',
         '    <div dim-percent-width="vm.item.percentComplete"></div>',
         '  </div>',
-        '  <textarea placeholder="Add notes to this item" class="item-notes" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.item.dimInfo.save()"></textarea>',
+        '  <textarea placeholder="{{ \'notes_placeholder\' | translate }}" class="item-notes" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.item.dimInfo.save()"></textarea>',
         '  <div class="item-description" ng-if="vm.itemDetails && vm.showDescription" ng-bind="::vm.item.description"></div>',
         '  <div class="item-details" ng-if="vm.item.classified">Classified item. Bungie does not yet provide information about this item. Item is not yet transferable.</div>',
         '  <div class="stats" ng-if="vm.itemDetails && vm.hasDetails">',

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -367,7 +367,6 @@
           });
         })
         .catch(function(e) {
-
           var twitter = '<div>Get status updates on <a target="_blank" href="http://twitter.com/ThisIsDIM">Twitter</a> <a target="_blank" href="http://twitter.com/ThisIsDIM"><i class="fa fa-twitter fa-2x" style="vertical-align: middle;"></i></a></div>';
 
           toaster.pop({

--- a/app/scripts/services/dimItemInfoService.factory.js
+++ b/app/scripts/services/dimItemInfoService.factory.js
@@ -47,7 +47,7 @@
                 store.items.forEach((item) => {
                   const itemKey = item.hash + '-' + item.id;
                   const info = infos[itemKey];
-                  if (info) {
+                  if (info && (info.tag !== undefined || (info.notes && info.notes.length))) {
                     remain[itemKey] = info;
                   }
                 });

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -60,7 +60,7 @@
         { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
         { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
         { type: 'delete', label: 'Delete', hotkey: '#', icon: 'ban' },
-        { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' },
+        { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' }
       ],
 
       language: defaultLanguage(),
@@ -90,7 +90,7 @@
         { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
         { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
         { type: 'delete', label: 'Delete', hotkey: '#', icon: 'ban' },
-        { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' },
+        { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' }
       ];
 
       _loaded = true;

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -59,7 +59,7 @@
         { type: undefined, label: 'Tag Item' },
         { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
         { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
-        { type: 'dismantle', label: 'Dismantle', hotkey: '#', icon: 'ban' },
+        { type: 'junk', label: 'Junk', hotkey: '#', icon: 'ban' },
         { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' }
       ],
 
@@ -89,7 +89,7 @@
         { type: undefined, label: 'Tag Item' },
         { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
         { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
-        { type: 'dismantle', label: 'Dismantle', hotkey: '#', icon: 'ban' },
+        { type: 'junk', label: 'Junk', hotkey: '#', icon: 'ban' },
         { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' }
       ];
 

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -59,7 +59,7 @@
         { type: undefined, label: 'Tag Item' },
         { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
         { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
-        { type: 'delete', label: 'Delete', hotkey: '#', icon: 'ban' },
+        { type: 'dismantle', label: 'Dismantle', hotkey: '#', icon: 'ban' },
         { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' }
       ],
 
@@ -89,7 +89,7 @@
         { type: undefined, label: 'Tag Item' },
         { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
         { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
-        { type: 'delete', label: 'Delete', hotkey: '#', icon: 'ban' },
+        { type: 'dismantle', label: 'Dismantle', hotkey: '#', icon: 'ban' },
         { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' }
       ];
 

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -57,9 +57,10 @@
       // Predefined item tags. Maybe eventually allow to add more (also i18n?)
       itemTags: [
         { type: undefined, label: 'Tag Item' },
-        { type: 'favorite', label: 'Favorite', hotkey: '!' },
-        { type: 'keep', label: 'Keep', hotkey: '@' },
-        { type: 'delete', label: 'Delete', hotkey: '#' }
+        { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
+        { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
+        { type: 'delete', label: 'Delete', hotkey: '#', icon: 'ban' },
+        { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' },
       ],
 
       language: defaultLanguage(),
@@ -82,6 +83,15 @@
 
       // self destruct timer for quality, hope we can remove this some day...
       savedSettings.disableQuality = new Date('9/19/2016') <= new Date();
+
+      // for now just override itemTags. eventually let users create own?
+      savedSettings.itemTags = [
+        { type: undefined, label: 'Tag Item' },
+        { type: 'favorite', label: 'Favorite', hotkey: '!', icon: 'star' },
+        { type: 'keep', label: 'Keep', hotkey: '@', icon: 'tag' },
+        { type: 'delete', label: 'Delete', hotkey: '#', icon: 'ban' },
+        { type: 'infuse', label: 'Infuse', hotkey: '$', icon: 'bolt' },
+      ];
 
       _loaded = true;
       $rootScope.$evalAsync(function() {

--- a/app/scripts/shell/dimFilterLink.directive.js
+++ b/app/scripts/shell/dimFilterLink.directive.js
@@ -25,6 +25,12 @@
         filter = filter.trim();
       }
 
+      if (filter === 'notes:value') {
+        itemNameFilter = true;
+        filter = $window.prompt("Enter notes text:");
+        filter = 'notes:"' + filter.trim() + '"';
+      }
+
       if (filter.indexOf('light:') === 0 || filter.indexOf('quality:') === 0) {
         var type = filter.split(':');
         var lightFilterType = type[1];

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -56,7 +56,7 @@
       }));
 
       dimSettingsService.itemTags.forEach(function(tag) {
-        if(tag.type) {
+        if (tag.type) {
           keywords.push("tag:" + tag.type);
         }
       });
@@ -400,7 +400,7 @@
         return item.dimInfo && item.dimInfo.tag === predicate;
       },
       notes: function(predicate, item) {
-        return item.dimInfo && item.dimInfo.notes &&  item.dimInfo.notes.toLocaleLowerCase().includes(predicate.toLocaleLowerCase());
+        return item.dimInfo && item.dimInfo.notes && item.dimInfo.notes.toLocaleLowerCase().includes(predicate.toLocaleLowerCase());
       },
       stattype: function(predicate, item) {
         return item.stats && _.any(item.stats, function(s) { return s.name.toLowerCase() === predicate && s.value > 0; });

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -33,20 +33,24 @@
         };
       };
     })
-    .filter('tagIcon', function() {
+    .filter('tagIcon', ['dimSettingsService', function(dimSettingsService) {
+      var iconType = {};
+
+      dimSettingsService.itemTags.forEach((tag) => {
+        if (tag.type) {
+          iconType[tag.type] = tag.icon;
+        }
+      });
+
       return function tagIcon(value) {
-        const iconType = {
-          favorite: 'star',
-          keep: 'tag',
-          delete: 'ban'
-        }[value];
-        if (iconType) {
-          return "item-tag fa fa-" + iconType;
+        var icon = iconType[value];
+        if (icon) {
+          return "item-tag fa fa-" + icon;
         } else {
           return "item-tag no-tag";
         }
       };
-    });
+    }]);
 
 
   StoreItem.$inject = ['dimItemService', 'dimStoreService', 'ngDialog', 'dimLoadoutService', '$rootScope', 'dimActionQueue'];

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1128,6 +1128,13 @@ rzslider {
   margin: 5px 10px;
   white-space: pre-wrap;
 }
+.item-notes-error {
+  margin: 5px 10px;
+  white-space: pre-wrap;
+  color: #985C58;
+  width: 100%;
+  text-align: right;
+}
 
 .item-perks {
   margin: 5px 10px;

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1115,6 +1115,15 @@ rzslider {
   margin: 10px;
 }
 
+.item-notes {
+  width: 100%;
+  height: 30px;
+  background-color: #333;
+  padding: 4px 8px;
+  border: none;
+  outline: none;
+  color: white;
+}
 .item-description {
   margin: 5px 10px;
   white-space: pre-wrap;

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -211,9 +211,10 @@
       <td>Shows new items.</td>
     </tr><tr>
       <td>
-        <dim-filter-link filter="is:favorite"></dim-filter-link>
-        <dim-filter-link filter="is:keep"></dim-filter-link>
-        <dim-filter-link filter="is:delete"></dim-filter-link>
+        <dim-filter-link filter="tag:favorite"></dim-filter-link>
+        <dim-filter-link filter="tag:keep"></dim-filter-link>
+        <dim-filter-link filter="tag:delete"></dim-filter-link>
+        <dim-filter-link filter="tag:infuse"></dim-filter-link>
       </td>
       <td><ul>
         <li>Shows favorite items.</li>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -220,7 +220,14 @@
         <li>Shows favorite items.</li>
         <li>Shows keep items.</li>
         <li>Shows items you wish to eventually delete.</li>
+        <li>Shows items you wish to eventually infuse.</li>
       </ul></td>
+    </tr>
+    <tr>
+      <td>
+        <dim-filter-link filter="notes:value"></dim-filter-link>
+      </td>
+      <td>Search for items that you have tagged with custom notes</td>
     </tr>
     <tr>
       <td>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -213,13 +213,13 @@
       <td>
         <dim-filter-link filter="tag:favorite"></dim-filter-link>
         <dim-filter-link filter="tag:keep"></dim-filter-link>
-        <dim-filter-link filter="tag:delete"></dim-filter-link>
+        <dim-filter-link filter="tag:dismantle"></dim-filter-link>
         <dim-filter-link filter="tag:infuse"></dim-filter-link>
       </td>
       <td><ul>
         <li>Shows favorite items.</li>
         <li>Shows keep items.</li>
-        <li>Shows items you wish to eventually delete.</li>
+        <li>Shows items you wish to eventually dismantle.</li>
         <li>Shows items you wish to eventually infuse.</li>
       </ul></td>
     </tr>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -213,7 +213,7 @@
       <td>
         <dim-filter-link filter="tag:favorite"></dim-filter-link>
         <dim-filter-link filter="tag:keep"></dim-filter-link>
-        <dim-filter-link filter="tag:dismantle"></dim-filter-link>
+        <dim-filter-link filter="tag:junk"></dim-filter-link>
         <dim-filter-link filter="tag:infuse"></dim-filter-link>
       </td>
       <td><ul>


### PR DESCRIPTION

![color](https://cloud.githubusercontent.com/assets/424158/18447384/6aa168ea-78f4-11e6-988a-a45b9eb62354.gif)


Added custom notes:
* Added a box to allow users to input custom notes.
* Notes may be search by doing `notes:<term>` or if you want to support
more data as part of the note query, wrap your query in single or
double quotes: `notes:”<term1> <term2> …”`

Also tweaked tags a little bit:

* Added infuse to the tag list
* Moved icons for tags to the itemTags object
* Searching for tags now requires to you to search for `tag:<tag name>`
instead of `is:<tag name>`