### PR TITLE
Handle a bug in the manifest data where Ornament nodes appear twice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed a "move-canceled" message showing up sometimes when applying loadouts.
 * Bugged items like Iron Shell no longer attempt to compute quality. They'll fix themselves when Bungie fixes them.
 * Fixed "Aim assist" stat not showing up in CSV (and no stats showing up if your language wasn't English).
+* Worked around a bug in the manifest data where Ornamenent nodes show up twice.
 
 # 3.10.2
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -834,7 +834,9 @@
           // itemNode: node
         };
       });
-      gridNodes = _.compact(gridNodes);
+
+      // We need to unique-ify because Ornament nodes show up twice!
+      gridNodes = _.uniq(_.compact(gridNodes), false, 'hash');
 
       // This can be handy for visualization/debugging
       // var columns = _.groupBy(gridNodes, 'column');


### PR DESCRIPTION
This is the other half of #906. Bizarrely, the Destiny manifest data has each Ornament node duplicated.