### PR TITLE
Avoid moving non-legendary masks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed "Aim assist" stat not showing up in CSV (and no stats showing up if your language wasn't English).
 * We now catch manifest updates that don't update the manifest version - if you see broken images, try reloading DIM and it should pick up new info.
 * Worked around a bug in the manifest data where Ornamenent nodes show up twice.
+* DIM won't allow you to move rare Masks, because that'll destroy them.
 
 # 3.10.2
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -638,7 +638,7 @@
       createdItem.index = createItemIndex(createdItem);
 
       // Moving rare masks destroys them
-      if (createdItem.isInCategory('CATEGORY_MASK') && createdItem.tier !== 'Legendary') {
+      if (createdItem.inCategory('CATEGORY_MASK') && createdItem.tier !== 'Legendary') {
         createdItem.notransfer = true;
       }
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -637,6 +637,11 @@
 
       createdItem.index = createItemIndex(createdItem);
 
+      // Moving rare masks destroys them
+      if (createdItem.isInCategory('CATEGORY_MASK') && createdItem.tier !== 'Legendary') {
+        createdItem.notransfer = true;
+      }
+
       if (createdItem.primStat) {
         createdItem.primStat.stat = statDef[createdItem.primStat.statHash];
       }


### PR DESCRIPTION
Fixes #813, unless those other items also get destroyed. I wouldn't know - I didn't keep them (or any rare masks, for that matter). I'm not sure how to identify those items (masks were easier).