### PR TITLE
Consolidate definitions into a single object

### DIFF
--- a/app/scripts/services/dimBucketService.factory.js
+++ b/app/scripts/services/dimBucketService.factory.js
@@ -43,9 +43,9 @@
       ]
     });
 
-  BucketService.$inject = ['dimItemBucketDefinitions', 'dimCategory'];
+  BucketService.$inject = ['dimDefinitions', 'dimCategory'];
 
-  function BucketService(dimItemBucketDefinitions, dimCategory) {
+  function BucketService(dimDefinitions, dimCategory) {
     // A mapping from the bucket names to DIM item types
     // Some buckets like vault and currencies have been ommitted
     var bucketToType = {
@@ -90,7 +90,7 @@
       });
     });
 
-    return dimItemBucketDefinitions.then(function(bucketDefs) {
+    return dimDefinitions.then(function(defs) {
       var buckets = {
         byHash: {}, // numeric hash -> bucket
         byId: {}, // BUCKET_LEGS -> bucket
@@ -112,7 +112,7 @@
           this.byType[this.unknown.type] = this.unknown;
         }
       };
-      _.each(bucketDefs, function(def) {
+      _.each(defs.InventoryBucket, function(def) {
         if (def.enabled) {
           var bucket = {
             id: def.bucketIdentifier,

--- a/app/scripts/services/dimXurService.factory.js
+++ b/app/scripts/services/dimXurService.factory.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .factory('dimXurService', XurService);
 
-  XurService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimItemDefinitions', 'dimStoreService', '$http'];
+  XurService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimDefinitions', 'dimStoreService', '$http'];
 
-  function XurService($rootScope, $q, dimBungieService, dimItemDefinitions, dimStoreService, $http) {
+  function XurService($rootScope, $q, dimBungieService, dimDefinitions, dimStoreService, $http) {
     var xurTest = false; // set this to true when you want to test but Xur's not around
     function xurTestData() {
       return $http.get('scripts/xur/xur.json')
@@ -26,7 +26,7 @@
           self.available = xurData && xurData.enabled && xurData.saleItemCategories;
 
           if (self.available) {
-            dimItemDefinitions.then(function(itemDefs) {
+            dimDefinitions.then(function(defs) {
               self.itemCategories = {};
               var rawItems = [];
               xurData.saleItemCategories.forEach(function(categoryData) {
@@ -34,7 +34,7 @@
                   rawItems.push(saleItem.item);
                   return {
                     cost: saleItem.costs[0].value,
-                    currency: _.pick(itemDefs[saleItem.costs[0].itemHash], 'itemName', 'icon', 'itemHash'),
+                    currency: _.pick(defs.InventoryItem[saleItem.costs[0].itemHash], 'itemName', 'icon', 'itemHash'),
                     itemHash: saleItem.item.itemHash
                   };
                 });


### PR DESCRIPTION
This is a refactoring I've wanted to do for a while. Since most of our definitions come out of the single SQLite database, this consolidates them all into a single object, from a single promise. That cuts down on the lists of injections, promises, etc. I took the opportunity to align the names with the actual table names to make things easier to trace back, too. The only definition that's still on its own is `dimYearsDefinition` because it doesn't come from the manifest.