### PR TITLE
Handle manifest download errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * DIM won't allow you to move rare Masks, because that'll destroy them.
 * The "Random" auto loadout can now be un-done from the loadout menu.
 * For non-variable items (emblems, shaders, ships, etc) in a loadout, DIM will use whichever copy is already on a character if it can, rather than moving a specific instance from another character.
+* We handle manifest download/cache errors better, by deleting the cached file and letting you retry.
 
 # 3.10.2
 


### PR DESCRIPTION
Kind of a combo here that should help for folks who have corrupted databases. It won't help if the problem is persistent, but it'll let you retry.

1. Fix to listen to "load" (success only) instead of "loadend" (which fires on success and error, apparently). We were accidentally resolving when we shouldn't.
2. Test the DB before returning it.
3. If there's any problem, nuke the saved version and manifest file.