### PR TITLE
Fix for #989 which clears loadouts when platform updates.

### DIFF
--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -10,8 +10,8 @@
     var _loadouts = [];
     var _previousLoadouts = {}; // by character ID
 
-    $rootScope.$on('dim-active-platform-updated', function() {
-      _loadouts.splice(0);
+    $rootScope.$on('dim-stores-updated', function() {
+      getLoadouts(true);
     });
 
     return {
@@ -441,7 +441,9 @@
         platform: loadoutPrimitive.platform,
         classType: (_.isUndefined(loadoutPrimitive.classType) ? -1 : loadoutPrimitive.classType),
         version: 'v3.0',
-        items: {}
+        items: {
+          'unknown': []
+        }
       };
 
       _.each(loadoutPrimitive.items, function(itemPrimitive) {
@@ -459,6 +461,15 @@
 
           result.items[discriminator] = (result.items[discriminator] || []);
           result.items[discriminator].push(item);
+        } else {
+          item = {
+            id: itemPrimitive.id,
+            hash: itemPrimitive.hash,
+            amount: itemPrimitive.amount,
+            equipped: itemPrimitive.equipped
+          };
+
+          result.items.unknown.push(item);
         }
       });
 
@@ -471,7 +482,9 @@
         name: loadoutPrimitive.name,
         classType: (_.isUndefined(loadoutPrimitive.classType) ? -1 : loadoutPrimitive.classType),
         version: 'v3.0',
-        items: {}
+        items: {
+          'unknown': []
+        }
       };
 
       _.each(loadoutPrimitive.items, function(itemPrimitive) {
@@ -487,6 +500,15 @@
 
           result.items[discriminator] = (result.items[discriminator] || []);
           result.items[discriminator].push(item);
+        } else {
+          item = {
+            id: itemPrimitive.id,
+            hash: itemPrimitive.hash,
+            amount: itemPrimitive.amount,
+            equipped: itemPrimitive.equipped
+          };
+
+          result.items['unknown'].push(item);
         }
       });
 
@@ -499,7 +521,9 @@
         name: loadoutPrimitive.name,
         classType: -1,
         version: 'v3.0',
-        items: {}
+        items: {
+          'unknown': []
+        }
       };
 
       _.each(loadoutPrimitive.items, function(itemPrimitive) {
@@ -512,6 +536,15 @@
           result.items[discriminator].push(item);
 
           item.equipped = true;
+        } else {
+          item = {
+            id: itemPrimitive.id,
+            hash: itemPrimitive.hash,
+            amount: itemPrimitive.amount,
+            equipped: itemPrimitive.equipped
+          };
+
+          result.items['unknown'].push(item);
         }
       });
 

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -442,7 +442,7 @@
         classType: (_.isUndefined(loadoutPrimitive.classType) ? -1 : loadoutPrimitive.classType),
         version: 'v3.0',
         items: {
-          'unknown': []
+          unknown: []
         }
       };
 
@@ -483,7 +483,7 @@
         classType: (_.isUndefined(loadoutPrimitive.classType) ? -1 : loadoutPrimitive.classType),
         version: 'v3.0',
         items: {
-          'unknown': []
+          unknown: []
         }
       };
 
@@ -508,7 +508,7 @@
             equipped: itemPrimitive.equipped
           };
 
-          result.items['unknown'].push(item);
+          result.items.unknown.push(item);
         }
       });
 
@@ -522,7 +522,7 @@
         classType: -1,
         version: 'v3.0',
         items: {
-          'unknown': []
+          unknown: []
         }
       };
 
@@ -544,7 +544,7 @@
             equipped: itemPrimitive.equipped
           };
 
-          result.items['unknown'].push(item);
+          result.items.unknown.push(item);
         }
       });
 

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -10,6 +10,10 @@
     var _loadouts = [];
     var _previousLoadouts = {}; // by character ID
 
+    $rootScope.$on('dim-active-platform-updated', function() {
+      _loadouts.splice(0);
+    });
+
     return {
       dialogOpen: false,
       getLoadouts: getLoadouts,
@@ -53,6 +57,8 @@
         _loadouts = _loadouts.splice(0);
       }
     }
+
+
 
     function getLoadouts(getLatest) {
       var deferred = $q.defer();


### PR DESCRIPTION
Listens to an event called 'dim-active-platform-updated' and will clear the loadout cache.  This will force the loadouts to rehydrate with the platform appropriate items.