### PR TITLE
Set item completion in an Ornament-aware way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * DIM won't allow you to move rare Masks, because that'll destroy them.
 * The "Random" auto loadout can now be un-done from the loadout menu.
 * For non-variable items (emblems, shaders, ships, etc) in a loadout, DIM will use whichever copy is already on a character if it can, rather than moving a specific instance from another character.
+* Items that are complete but do not have an ornament get a gold border just like in the game.
 
 # 3.10.2
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -767,6 +767,7 @@
         });
       } else if (createdItem.talentGrid) {
         createdItem.percentComplete = Math.min(1.0, createdItem.talentGrid.totalXP / createdItem.talentGrid.totalXPRequired);
+        createdItem.complete = createdItem.talentGrid.complete;
       }
 
       return createdItem;
@@ -904,6 +905,7 @@
       if (minColumn > 0) {
         gridNodes.forEach(function(node) { node.column -= minColumn; });
       }
+      var maxColumn = _.max(gridNodes, 'column').column;
 
       return {
         nodes: _.sortBy(gridNodes, function(node) { return node.column + (0.1 * node.row); }),
@@ -912,7 +914,8 @@
         totalXP: Math.min(totalXPRequired, totalXP),
         hasAscendNode: Boolean(ascendNode),
         ascended: Boolean(ascendNode && ascendNode.activated),
-        infusable: _.any(gridNodes, { hash: 1270552711 })
+        infusable: _.any(gridNodes, { hash: 1270552711 }),
+        complete: totalXPRequired <= totalXP && _.all(gridNodes, (n) => n.unlocked || (n.xpRequired === 0 && n.column === maxColumn))
       };
     }
 


### PR DESCRIPTION
This fixes #931 by overriding the `isGridComplete` property with a check of talent grid completion. It's a bit fragile, but not as bad as it could be - basically it makes sure you've unlocked everything except for nodes in the last row that don't require XP. Hopefully in some manifest update soon the `isGridComplete` property will be accurate again and we won't need this.