### PR TITLE
Link to destinytracker for weapons/armor to include perks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+* You can now mark items as "favorite", "keep", "junk" or "infuse". There are corresponding search filters (tag:keep, tag:favorite, etc.) There are also keyboard shortcuts - press "?" to see them.
+* You can now add custom notes to items. Just type them in the box and it automatically saves the text. You can also search for notes -> notes:"god roll"
+* The DestinyTracker link in the item popup header now includes your perk rolls and selected perk. Share your roll easily!
+
 # 3.10.5
 
 * Added Ornaments.

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -29,7 +29,7 @@
         '          <i class="lock fa" ng-class="{\'fa-star\': vm.item.tracked, \'fa-star-o\': !vm.item.tracked, \'is-locking\': vm.locking }"></i>',
         '        </a>',
         '      </span>',
-        '      <a target="_new" href="http://db.destinytracker.com/inventory/item/{{ vm.item.hash }}" class="item-title">',
+        '      <a target="_blank" rel="noopener noreferrer" href="http://db.destinytracker.com/inventory/item/{{ vm.item.hash }}#{{ vm.item.talentGrid.dtrPerks }}" class="item-title">',
         '        {{vm.title}}',
         '      </a>',
         '    </div>',

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -841,6 +841,22 @@
         var xpRequired = xpToReachLevel(activatedAtGridLevel) - startProgressionBarAtProgress;
         var xp = Math.max(0, Math.min(totalXP - startProgressionBarAtProgress, xpRequired));
 
+        // Build a perk string for the DTR link. See https://github.com/DestinyItemManager/DIM/issues/934
+        var dtrHash = null;
+        if (node.isActivated || talentNodeGroup.isRandom) {
+          dtrHash = node.nodeHash.toString(16);
+          if (dtrHash.length > 1) {
+            dtrHash += ".";
+          }
+
+          if (talentNodeGroup.isRandom) {
+            dtrHash += node.stepIndex.toString(16);
+            if (node.isActivated) {
+              dtrHash += "o";
+            }
+          }
+        }
+
         // There's a lot more here, but we're taking just what we need
         return {
           name: nodeName,
@@ -865,7 +881,9 @@
           // Whether or not the material cost has been paid for the node
           unlocked: unlocked,
           // Some nodes don't show up in the grid, like purchased ascend nodes
-          hidden: node.hidden
+          hidden: node.hidden,
+
+          dtrHash: dtrHash
 
           // Whether (and in which order) this perk should be
           // "featured" on an abbreviated info panel, as in the
@@ -915,6 +933,7 @@
         hasAscendNode: Boolean(ascendNode),
         ascended: Boolean(ascendNode && ascendNode.activated),
         infusable: _.any(gridNodes, { hash: 1270552711 }),
+        dtrPerks: _.compact(_.pluck(gridNodes, 'dtrHash')).join(';'),
         complete: totalXPRequired <= totalXP && _.all(gridNodes, (n) => n.unlocked || (n.xpRequired === 0 && n.column === maxColumn))
       };
     }


### PR DESCRIPTION
For example, we could include some translation that (at least attempts) to convert the perks to the destinytracker url.

`#01;30;42o;22;72o;10;52;62o`
http://db.destinytracker.com/items/1201310194-hawksaw#01;30;42o;22;72o;10;52;62o

Something minor, but could be an easy way to share your roll.

Idea from:
https://www.reddit.com/r/DestinyItemManager/comments/533y7b/weapon_roll_permalinks/