### PR TITLE
Repeatedly Moving Stacks of Planetary Materials Leads to Odd Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * You can now add custom notes to items. Just type them in the box and it automatically saves the text. You can also search for notes -> notes:"god roll"
 * The DestinyTracker link in the item popup header now includes your perk rolls and selected perk. Share your roll easily!
 * Fixed moving consumables in loadouts. Before, you would frequently get errors applying a loadout that included consumables. We also have a friendlier, more informative error message when you don't have enough of a consumable to fulfill your loadout.
+* Fixed a bug where when moving stacks of items, the stack would disappear.
 
 # 3.10.5
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -1328,7 +1328,6 @@
     }
 
     function processItems(owner, items, previousItems = new Set(), newItems = new Set(), itemInfoService) {
-      _idTracker = {};
       return $q.all([
         dimDefinitions,
         dimBucketService,


### PR DESCRIPTION
Hard to exactly reproduce, but I have multiple stacks of Planetary Materials.  I like to keep exactly 200 on each character and put the rest in the vault.  When I go to shuffle the materials around to create full stacks of 200, DIM sometimes gets confused and moves the wrong stack or fails to update the UI properly.

Here's an example:
[DIM Multiple Planetary Materials Bug.mov.zip](https://github.com/DestinyItemManager/DIM/files/478162/DIM.Multiple.Planetary.Materials.Bug.mov.zip)

The first part with trying to move the Relic Iron may be because I wasn't over the empty space, but the part at the end with trying to move Spinmetal showed the 165 Stack outright disappearing.
