### PR TITLE
Fix consumables in loadouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * You can now mark items as "favorite", "keep", "junk" or "infuse". There are corresponding search filters (tag:keep, tag:favorite, etc.) There are also keyboard shortcuts - press "?" to see them.
 * You can now add custom notes to items. Just type them in the box and it automatically saves the text. You can also search for notes -> notes:"god roll"
 * The DestinyTracker link in the item popup header now includes your perk rolls and selected perk. Share your roll easily!
+* Fixed moving consumables in loadouts. Before, you would frequently get errors applying a loadout that included consumables. We also have a friendlier, more informative error message when you don't have enough of a consumable to fulfill your loadout.
 
 # 3.10.5
 

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -233,9 +233,9 @@
     }
 
     function moveToStore(item, store, equip, amount) {
-      var source = dimStoreService.getStore(item.owner);
       return dimBungieService.transfer(item, store, amount)
         .then(function() {
+          var source = dimStoreService.getStore(item.owner);
           var newItem = updateItemModel(item, source, store, false, amount);
           if ((newItem.owner !== 'vault') && equip) {
             return equipItem(newItem);

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -233,9 +233,9 @@
     }
 
     function moveToStore(item, store, equip, amount) {
+      var source = dimStoreService.getStore(item.owner);
       return dimBungieService.transfer(item, store, amount)
         .then(function() {
-          var source = dimStoreService.getStore(item.owner);
           var newItem = updateItemModel(item, source, store, false, amount);
           if ((newItem.owner !== 'vault') && equip) {
             return equipItem(newItem);

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -372,10 +372,10 @@
         var amountAlreadyHave = store.amountOfItem(pseudoItem);
         var amountNeeded = pseudoItem.amount - amountAlreadyHave;
         if (amountNeeded > 0) {
-          var otherStores = _.reject(dimStoreService.getStores(), function(otherStore) {
+          const otherStores = _.reject(dimStoreService.getStores(), function(otherStore) {
             return store.id === otherStore.id;
           });
-          var storesByAmount = _.sortBy(otherStores.map(function(store) {
+          const storesByAmount = _.sortBy(otherStores.map(function(store) {
             return {
               store: store,
               amount: store.amountOfItem(pseudoItem)
@@ -384,9 +384,9 @@
 
           let totalAmount = amountAlreadyHave;
           while (amountNeeded > 0) {
-            var source = _.max(storesByAmount, 'amount');
-            var amountToMove = Math.min(source.amount, amountNeeded);
-            var sourceItem = _.findWhere(source.store.items, { hash: pseudoItem.hash });
+            const source = _.max(storesByAmount, 'amount');
+            const amountToMove = Math.min(source.amount, amountNeeded);
+            const sourceItem = _.findWhere(source.store.items, { hash: pseudoItem.hash });
 
             if (amountToMove === 0 || !sourceItem) {
               promise = promise.then(function() {
@@ -401,9 +401,7 @@
             amountNeeded -= amountToMove;
             totalAmount += amountToMove;
 
-            promise = promise.then(function() {
-              return dimItemService.moveTo(sourceItem, store, false, amountToMove);
-            });
+            promise = promise.then(() => dimItemService.moveTo(sourceItem, store, false, amountToMove));
           }
         }
       } else {


### PR DESCRIPTION
Issue #936 led me down a road where I found some real, actual problems with how we were moving consumables in loadouts. It all came down to my old nemesis, closure-in-a-loop with var scoping (the captured value of `amountToMove` was getting set to the last value in the loop rather than the value when the closure was created). Switching things to ES6 `const` fixed the scope and and made things work.

I also softened the error message when you don't have enough of a material, which should address the UX problem that prompted #936. Now it's no longer messaged as a failed transfer when you don't have enough of a material, and you get a nice blue info message telling you what happened in detail:

<img width="312" alt="screen shot 2016-09-19 at 11 06 18 pm" src="https://cloud.githubusercontent.com/assets/313208/18660409/1a96fdca-7ec5-11e6-9b74-150fbfafa838.png">
