### PR TITLE
Disable vendors temporarily

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -273,7 +273,7 @@
 
       // Include vendors on the first load and if they're expired
       const currDate = new Date().toISOString();
-      const includeVendors = !_stores.length || _.any(_stores, (store) => store.minRefreshDate < currDate);
+      const includeVendors = false && (!_stores.length || _.any(_stores, (store) => store.minRefreshDate < currDate));
 
       // Save a snapshot of all the items before we update
       const previousItems = buildItemSet(_stores);
@@ -420,8 +420,10 @@
 
               if (!includeVendors) {
                 var prevStore = _.findWhere(_stores, { id: raw.id });
-                store.vendors = prevStore.vendors;
-                store.minRefreshDate = prevStore.minRefreshDate;
+                if (prevStore) {
+                  store.vendors = prevStore.vendors;
+                  store.minRefreshDate = prevStore.minRefreshDate;
+                }
               }
 
               store.name = store.genderRace + ' ' + store.className;


### PR DESCRIPTION
Putting this PR out here in case we want to turn off vendors for a while. We'll have a lot of users for the RoI launch and we are making too many requests to the API.