### PR TITLE
Add Record Books to Progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Fixed moving consumables in loadouts. Before, you would frequently get errors applying a loadout that included consumables. We also have a friendlier, more informative error message when you don't have enough of a consumable to fulfill your loadout.
 * Fixed a bug where when moving stacks of items, the stack would disappear.
 * The progress bar around the reputation diamonds is now more accurate.
+* A new Record Books row in Progress has your Rise of Iron record book.
+* Searches now work for all characters and the vault again.
 
 # 3.10.5
 

--- a/app/scripts/services/dimBucketService.factory.js
+++ b/app/scripts/services/dimBucketService.factory.js
@@ -34,6 +34,7 @@
       Progress: [
         'Bounties',
         'Quests',
+        'RecordBook',
         'Missions'
       ],
       Postmaster: [
@@ -60,6 +61,7 @@
       BUCKET_CONSUMABLES: "Consumable",
       BUCKET_PRIMARY_WEAPON: "Primary",
       BUCKET_CLASS_ITEMS: "ClassItem",
+      BUCKET_BOOK_LARGE: "RecordBook",
       BUCKET_QUESTS: "Quests",
       BUCKET_VEHICLE: "Vehicle",
       BUCKET_BOUNTIES: "Bounties",

--- a/app/scripts/services/dimBucketService.factory.js
+++ b/app/scripts/services/dimBucketService.factory.js
@@ -35,6 +35,7 @@
         'Bounties',
         'Quests',
         'RecordBook',
+        'RecordBookLegacy',
         'Missions'
       ],
       Postmaster: [
@@ -62,6 +63,7 @@
       BUCKET_PRIMARY_WEAPON: "Primary",
       BUCKET_CLASS_ITEMS: "ClassItem",
       BUCKET_BOOK_LARGE: "RecordBook",
+      BUCKET_BOOK_SMALL: "RecordBookLegacy",
       BUCKET_QUESTS: "Quests",
       BUCKET_VEHICLE: "Vehicle",
       BUCKET_BOUNTIES: "Bounties",

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -631,7 +631,7 @@
         currentBucket = normalBucket;
       }
 
-      var itemType = normalBucket.type;
+      var itemType = normalBucket.type || 'Unknown';
 
       const categories = itemDef.itemCategoryHashes ? _.compact(itemDef.itemCategoryHashes.map((c) => {
         const category = defs.ItemCategory[c];

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -287,7 +287,7 @@
         return item.dmg === predicate;
       },
       type: function(predicate, item) {
-        return item.type.toLowerCase() === predicate;
+        return item.type && item.type.toLowerCase() === predicate;
       },
       tier: function(predicate, item) {
         const tierMap = {


### PR DESCRIPTION
Rise of Iron record book gets its own category in Progress (#940). This also fixes searches (#950) because we were erroring out on the record book (its bucket doesn't have a "type").

One weird thing is that there's a RECORD_BOOK_SMALL bucket for legacy record books, but it doesn't appear to be used for the old record books...

I agree with @kyleshay's comment in #940 that we may want a better way of displaying this, though - right now with the data we have each character gets their own identical copy of the same record book.