### PR TITLE
Restore quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Fixed moving consumables in loadouts. Before, you would frequently get errors applying a loadout that included consumables. We also have a friendlier, more informative error message when you don't have enough of a consumable to fulfill your loadout.
 * Fixed a bug where when moving stacks of items, the stack would disappear.
 * The progress bar around the reputation diamonds is now more accurate.
+* Enabled item quality. 
+* Item Quality is enabled by default for new installs.
 
 # 3.10.5
 

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -34,7 +34,7 @@
       // Show full details in item popup
       itemDetails: false,
       // Show item quality percentages
-      itemQuality: false,
+      itemQuality: true,
       // Show new items with an overlay
       showNewItems: false,
       // Show animation of new item overlay on new items

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -993,6 +993,10 @@
     function getScaledStat(base, light) {
       var max = 335;
 
+      if (light > 335) {
+        light = 335;
+      }
+
       return {
         min: Math.floor((base) * (fitValue(max) / fitValue(light))),
         max: Math.floor((base + 1) * (fitValue(max) / fitValue(light)))
@@ -1009,6 +1013,11 @@
         if (!quality) {
           return '';
         }
+
+        if (light > 335) {
+          light = 335;
+        }
+
         return ((quality.min === quality.max || light === 335)
                 ? quality.min
                 : (quality.min + "%-" + quality.max)) + '%';


### PR DESCRIPTION
Set the maximum light for statistics at 335.  Anything over 335 is measured as if it was 335. 