### PR TITLE
Added a hash list to manually sort consumables and materials 

### DIFF
--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -69,6 +69,88 @@
       if (items.length && items[0].location.inPostmaster) {
         return items;
       }
+
+      var specific_sort_order = []
+      // Group like items in the General Section
+      if (items.length && items[0].location.id == "BUCKET_CONSUMABLES") {
+        specific_sort_order = [
+          1043138475, // black-wax-idol
+          1772853454, // blue-polyphage
+          3783295803, // ether-seeds
+          3446457162, // resupply-codes
+          269776572,  // house-banners
+          3632619276, // silken-codex
+          2904517731, // axiomatic-beads
+          1932910919, // network-keys
+
+          417308266,  // three of coins
+          
+          2180254632, // ammo-synth
+          928169143,  // special-ammo-synth
+          211861343,  // heavy-ammo-synth
+
+          705234570,  // primary telemetry
+          3371478409, // special telemetry
+          2929837733, // heavy telemetry
+          4159731660, // auto rifle telemetry
+          846470091,  // hand cannon telemetry
+          2610276738, // pulse telemetry
+          323927027,  // scout telemetry
+          729893597,  // fusion rifle telemetry
+          4141501356, // shotgun telemetry
+          927802664,  // sniper rifle telemetry
+          1485751393, // machine gun telemetry
+          3036931873, // rocket launcher telemetry
+
+          2220921114, // vanguard rep boost
+          1500229041, // crucible rep boost
+          1603376703, // HoJ rep boost
+
+          2575095887, // Splicer Intel Relay
+          3815757277, // Splicer Cache Key
+          4244618453, // Splicer Key
+        ]
+      }
+
+      // Group like items in the General Section
+      if (items.length && items[0].location.id == "BUCKET_MATERIALS") {
+        specific_sort_order = [
+          1797491610, // Helium
+          3242866270, // Relic Iron
+          2882093969, // Spin Metal
+          2254123540, // Spirit Bloom
+          3164836592, // Wormspore
+          3164836593, // Hadium Flakes
+
+          452597397,  // Exotic Shard
+          1542293174, // Armor Materials
+          1898539128, // Weapon Materials
+
+          937555249, // Motes of Light
+
+          1738186005, // Strange Coins
+
+          258181985,  // Ascendant Shards
+          1893498008, // Ascendant Energy
+          769865458,  // Radiant Shards
+          616706469,  // Radiant Energy
+
+          342707701,  // Reciprocal Rune
+          342707700,  // Stolen Rune
+          2906158273, // Antiquated Rune
+          2620224196, // Stolen Rune (Charging)
+          2906158273, // Antiquated Rune (Charging)
+        ]
+      }
+
+      if (specific_sort_order.length > 0) {
+        items = _.sortBy(items, function(item) {
+          var ix = specific_sort_order.indexOf(item.hash);
+          return (ix == -1) ? 999 : ix; 
+        })
+        return items;
+      }
+
       items = _.sortBy(items || [], 'name');
       if (sort === 'primaryStat' || sort === 'rarityThenPrimary' || sort === 'quality') {
         items = _.sortBy(items, function(item) {

--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -70,10 +70,10 @@
         return items;
       }
 
-      var specific_sort_order = []
+      var specificSortOrder = [];
       // Group like items in the General Section
       if (items.length && items[0].location.id == "BUCKET_CONSUMABLES") {
-        specific_sort_order = [
+        specificSortOrder = [
           1043138475, // black-wax-idol
           1772853454, // blue-polyphage
           3783295803, // ether-seeds
@@ -108,13 +108,13 @@
 
           2575095887, // Splicer Intel Relay
           3815757277, // Splicer Cache Key
-          4244618453, // Splicer Key
-        ]
+          4244618453  // Splicer Key
+        ];
       }
 
       // Group like items in the General Section
       if (items.length && items[0].location.id == "BUCKET_MATERIALS") {
-        specific_sort_order = [
+        specificSortOrder = [
           1797491610, // Helium
           3242866270, // Relic Iron
           2882093969, // Spin Metal
@@ -139,15 +139,15 @@
           342707700,  // Stolen Rune
           2906158273, // Antiquated Rune
           2620224196, // Stolen Rune (Charging)
-          2906158273, // Antiquated Rune (Charging)
-        ]
+          2906158273  // Antiquated Rune (Charging)
+        ];
       }
 
-      if (specific_sort_order.length > 0) {
+      if (specificSortOrder.length > 0) {
         items = _.sortBy(items, function(item) {
-          var ix = specific_sort_order.indexOf(item.hash);
-          return (ix == -1) ? 999 : ix; 
-        })
+          var ix = specificSortOrder.indexOf(item.hash);
+          return (ix === -1) ? 999 : ix; 
+        });
         return items;
       }
 

--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -72,7 +72,7 @@
 
       var specificSortOrder = [];
       // Group like items in the General Section
-      if (items.length && items[0].location.id == "BUCKET_CONSUMABLES") {
+      if (items.length && items[0].location.id === "BUCKET_CONSUMABLES") {
         specificSortOrder = [
           1043138475, // black-wax-idol
           1772853454, // blue-polyphage
@@ -82,13 +82,13 @@
           3632619276, // silken-codex
           2904517731, // axiomatic-beads
           1932910919, // network-keys
-
+          //
           417308266,  // three of coins
-          
+          //
           2180254632, // ammo-synth
           928169143,  // special-ammo-synth
           211861343,  // heavy-ammo-synth
-
+          //
           705234570,  // primary telemetry
           3371478409, // special telemetry
           2929837733, // heavy telemetry
@@ -101,11 +101,11 @@
           927802664,  // sniper rifle telemetry
           1485751393, // machine gun telemetry
           3036931873, // rocket launcher telemetry
-
+          //
           2220921114, // vanguard rep boost
           1500229041, // crucible rep boost
           1603376703, // HoJ rep boost
-
+          //
           2575095887, // Splicer Intel Relay
           3815757277, // Splicer Cache Key
           4244618453  // Splicer Key
@@ -113,7 +113,7 @@
       }
 
       // Group like items in the General Section
-      if (items.length && items[0].location.id == "BUCKET_MATERIALS") {
+      if (items.length && items[0].location.id === "BUCKET_MATERIALS") {
         specificSortOrder = [
           1797491610, // Helium
           3242866270, // Relic Iron
@@ -121,20 +121,20 @@
           2254123540, // Spirit Bloom
           3164836592, // Wormspore
           3164836593, // Hadium Flakes
-
+          //
           452597397,  // Exotic Shard
           1542293174, // Armor Materials
           1898539128, // Weapon Materials
-
+          //
           937555249, // Motes of Light
-
+          //
           1738186005, // Strange Coins
-
+          //
           258181985,  // Ascendant Shards
           1893498008, // Ascendant Energy
           769865458,  // Radiant Shards
           616706469,  // Radiant Energy
-
+          //
           342707701,  // Reciprocal Rune
           342707700,  // Stolen Rune
           2906158273, // Antiquated Rune
@@ -146,7 +146,7 @@
       if (specificSortOrder.length > 0) {
         items = _.sortBy(items, function(item) {
           var ix = specificSortOrder.indexOf(item.hash);
-          return (ix === -1) ? 999 : ix; 
+          return (ix === -1) ? 999 : ix;
         });
         return items;
       }


### PR DESCRIPTION
In addition to grouping things nicely it provides consistency across your toons and in the vault.

If this particular order doesn't make sense, they are easy to move around.  Everything that is not explicitly list in consumables or materials is placed at the end of the sorted list.

This address issue #84 as well.