### PR TITLE
Path already has a leading slash

### DIFF
--- a/app/scripts/services/dimManifestService.factory.js
+++ b/app/scripts/services/dimManifestService.factory.js
@@ -55,7 +55,7 @@
             const version = path;
             service.version = version;
 
-            return loadManifestFromCache(version)
+            return loadManifestFromCache(version + 1)
               .catch(function(e) {
                 return loadManifestRemote(version, language, path);
               })
@@ -108,7 +108,7 @@
      */
     function loadManifestRemote(version, language, path) {
       service.statusText = 'Downloading latest Destiny info from Bungie...';
-      return $http.get("https://www.bungie.net/" + path, { responseType: "blob" })
+      return $http.get("https://www.bungie.net" + path, { responseType: "blob" })
         .then(function(response) {
           service.statusText = 'Unzipping latest Destiny info...';
           return unzipManifest(response.data);

--- a/app/scripts/services/dimManifestService.factory.js
+++ b/app/scripts/services/dimManifestService.factory.js
@@ -55,7 +55,7 @@
             const version = path;
             service.version = version;
 
-            return loadManifestFromCache(version + 1)
+            return loadManifestFromCache(version)
               .catch(function(e) {
                 return loadManifestRemote(version, language, path);
               })


### PR DESCRIPTION
This is related to #979. I noticed that the request contained a double slash, this cleans that up.