### PR TITLE
Fix infusion finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Added `is:inloadout` filter
 * Link to wiki for stat quality in the move-popup box.
 * Prevent double click to move item if loadout dialog is open.
-* [#889](https://github.com/DestinyItemManager/DIM/issues/889) Fixed stats for Iron Banner and Trials of Osiris items. 
+* [#889](https://github.com/DestinyItemManager/DIM/issues/889) Fixed stats for Iron Banner and Trials of Osiris items.
+* Fix infusion finder preview item not changing as you choose different fuel items. Also filter out year 1 items.
 
 # 3.10.6
 

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -64,6 +64,7 @@
           // all items in store
           var items = _.filter(store.items, function(item) {
             return item.primStat &&
+              item.year !== 1 &&
               (!item.locked || vm.showLockedItems) &&
               item.type === vm.source.type &&
               item.primStat.value > vm.source.primStat.value;

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -115,8 +115,7 @@
         template: 'views/infuse.html',
         className: 'app-settings',
         appendClassName: 'modal-dialog',
-        data: item,
-        scope: $('#infuseDialog').scope()
+        data: item
       });
     };
 

--- a/app/scripts/store/dimSimpleItem.directive.js
+++ b/app/scripts/store/dimSimpleItem.directive.js
@@ -12,10 +12,10 @@
       },
       restrict: 'E',
       template: [
-        '<div title="{{ vm.item.primStat.value }} {{:: vm.item.name }}" alt="{{ vm.item.primStat.value }} {{:: vm.item.name }}" class="item">',
+        '<div title="{{ vm.item.primStat.value }} {{ vm.item.name }}" alt="{{ vm.item.primStat.value }} {{ vm.item.name }}" class="item">',
         '  <div ng-if="!vm.item.isUnlocked" class="locked-overlay"></div>',
         '  <div class="item-elem" ng-class="{ complete: vm.item.complete }">',
-        '    <div class="img" ng-style="::vm.item.icon | bungieBackground">',
+        '    <div class="img" ng-style="vm.item.icon | bungieBackground">',
         '    <span ng-class="vm.item.dimInfo.tag | tagIcon"></span>',
         '    <div ng-if="vm.item.quality" class="item-stat item-quality" ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>',
         '    <div class="item-stat item-equipment stat-damage-{{::vm.item.dmg}}" ng-class="{\'item-stat-no-bg\': (vm.item.quality && vm.item.quality.min > 0) }" ng-if="vm.item.primStat.value || vm.item.maxStackSize > 1">{{ vm.item.primStat.value || vm.item.amount }}</div>',


### PR DESCRIPTION
Fixes #970 by filtering out year1 items and removing the bind-once on simple-item, which was preventing name/icon from updating when we changed the target item