### PR TITLE
New filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The default shader no longer counts as a duplicate item.
 * DIM no longer tries to equip exotic faction class items where your character isn't aligned with the right faction.
 * Fixed more cases where your loadouts wouldn't be applied because you already had an exotic equipped.
+* New filters: is:light, is:hasLight, is:weapon, is:armor, is:cosmetic, is:equipment, is:equippable, is:postmaster, is:inpostmaster, is:equipped, is:transferable, is:movable.
 
 # 3.10.6
 

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -53,7 +53,15 @@
       stattype: ['intellect', 'discipline', 'strength'],
       inloadout: ['inloadout'],
       new: ['new'],
-      glimmer: ['glimmeritem', 'glimmerboost', 'glimmersupply']
+      glimmer: ['glimmeritem', 'glimmerboost', 'glimmersupply'],
+      hasLight: ['light', 'haslight'],
+      weapon: ['weapon'],
+      armor: ['armor'],
+      cosmetic: ['cosmetic'],
+      equipment: ['equipment', 'equippable'],
+      postmaster: ['postmaster', 'inpostmaster'],
+      equipped: ['equipped'],
+      transferable: ['transferable', 'movable']
     };
 
     var keywords = _.flatten(_.flatten(_.values(filterTrans)).map(function(word) {
@@ -537,6 +545,47 @@
       },
       new: function(predicate, item) {
         return item.isNew;
+      },
+      hasLight: function(predicate, item) {
+        const lightBuckets = ["BUCKET_CHEST",
+                                 "BUCKET_LEGS",
+                                 "BUCKET_ARTIFACT",
+                                 "BUCKET_HEAVY_WEAPON",
+                                 "BUCKET_PRIMARY_WEAPON",
+                                 "BUCKET_CLASS_ITEMS",
+                                 "BUCKET_SPECIAL_WEAPON",
+                                 "BUCKET_HEAD",
+                                 "BUCKET_ARMS",
+                                 "BUCKET_GHOST"];
+        return item.bucket && _.contains(lightBuckets, item.bucket.id);
+      },
+      weapon: function(predicate, item) {
+        return item.bucket && item.bucket.sort === 'Weapons';
+      },
+      armor: function(predicate, item) {
+        return item.bucket && item.bucket.sort === 'Armor';
+      },
+      cosmetic: function(predicate, item) {
+        const cosmeticBuckets = ["BUCKET_SHADER",
+                                 "BUCKET_MODS",
+                                 "BUCKET_EMOTES",
+                                 "BUCKET_EMBLEM",
+                                 "BUCKET_VEHICLE",
+                                 "BUCKET_SHIP",
+                                 "BUCKET_HORN"];
+        return item.bucket && _.contains(cosmeticBuckets, item.bucket.id);
+      },
+      equipment: function(predicate, item) {
+        return item.equipment;
+      },
+      postmaster: function(predicate, item) {
+        return item.location && item.location.inPostmaster;
+      },
+      equipped: function(predicate, item) {
+        return item.equipped;
+      },
+      transferable: function(predicate, item) {
+        return !item.notransfer;
       }
     };
   }

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -5,7 +5,7 @@
     Click filters below to apply, or by typing in the search box.
   </p>
   <p>
-    Filters are combined using 'and' logic, for example "is:arc light:>300" will return all arc items with over 300 light.
+    Filters are combined using 'and' logic, for example "is:arc light:>300" will return all arc items with over 300 light. Filters can be negated using "not:", for example "not:engram" will find all non-engram items.
   </p>
   <table>
     <tr>
@@ -49,6 +49,42 @@
     </tr>
     <tr>
       <td>
+        <dim-filter-link filter="is:light"></dim-filter-link>
+        <dim-filter-link filter="has:light"></dim-filter-link>
+      </td>
+      <td>Items that contribute to your light level.</td>
+    </tr>
+    <tr>
+      <td>
+        <dim-filter-link filter="is:weapon"></dim-filter-link>
+        <dim-filter-link filter="is:armor"></dim-filter-link>
+        <dim-filter-link filter="is:cosmetic"></dim-filter-link>
+      </td>
+      <td>High level item categories.</td>
+    </tr>
+    <tr>
+      <td>
+        <dim-filter-link filter="is:equipment"></dim-filter-link>
+        <dim-filter-link filter="is:equippable"></dim-filter-link>
+      </td>
+      <td>Items that can be equipped.</td>
+    </tr>
+    <tr>
+      <td>
+        <dim-filter-link filter="is:transferable"></dim-filter-link>
+        <dim-filter-link filter="is:movable"></dim-filter-link>
+      </td>
+      <td>Items that can be moved between characters.</td>
+    </tr>
+    <tr>
+      <td>
+        <dim-filter-link filter="is:equipped"></dim-filter-link>
+      </td>
+      <td>Items that are currently equipped on a character.</td>
+    </tr>
+    <tr>
+      <td>
+        <dim-filter-link filter="is:weapon"></dim-filter-link>
         <dim-filter-link filter="is:class"></dim-filter-link>
         <dim-filter-link filter="is:primary"></dim-filter-link>
         <dim-filter-link filter="is:special"></dim-filter-link>
@@ -58,6 +94,7 @@
     </tr>
     <tr>
       <td>
+        <dim-filter-link filter="is:armor"></dim-filter-link>
         <dim-filter-link filter="is:helmet"></dim-filter-link>
         <dim-filter-link filter="is:gauntlets"></dim-filter-link>
         <dim-filter-link filter="is:chest"></dim-filter-link>
@@ -245,6 +282,12 @@
       </td>
       <td>Shows items that are included in any loadout.</td>
     </tr>
-    
+    <tr>
+      <td>
+        <dim-filter-link filter="is:postmaster"></dim-filter-link>
+        <dim-filter-link filter="is:inpostmaster"></dim-filter-link>
+      </td>
+      <td>Items that are currently in the Postmaster.</td>
+    </tr>
   </table>
   </div>


### PR DESCRIPTION
is:light, is:hasLight, is:weapon, is:armor, is:cosmetic, is:equipment, is:equippable, is:postmaster, is:inpostmaster, is:equipped, is:transferable, and is:movable

Some of these seem a bit silly but I think they'll be useful when I start working on the saved search and search-loadout stuff more.

This addresses #989.