### PR TITLE
Move elemental icons to the bottom left

### DIFF
--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -658,10 +658,11 @@ img {
     .show-elements & {
       display: block;
       position: absolute;
-      top: 2px;
-      right: 2px;
-      height: 14px;
-      width: 14px;
+      bottom: 2px;
+      left: 2px;
+      height: 16px;
+      width: 16px;
+      filter: drop-shadow(0px 0px 3px rgba(0,0,0,0.7));
     }
   }
 }
@@ -672,10 +673,7 @@ img {
   top: 4px;
   left: 4px;
   color: gold;
-//  &.fa-ban {
-//    -webkit-text-stroke: 0px;
-//    color: red;
-  //  }
+  pointer-events: none;
   &.no-tag {
     display: none;
   }


### PR DESCRIPTION
And add a shadow to them. This makes things pop better. This should address #987.

Original:
![screen shot 2016-10-01 at 12 21 19 pm](https://cloud.githubusercontent.com/assets/313208/19016539/d4a8bc70-87d1-11e6-83ac-12e47d9eb4aa.png)

New:
![screen shot 2016-10-01 at 12 21 40 pm](https://cloud.githubusercontent.com/assets/313208/19016540/d4aab6d8-87d1-11e6-843a-bb52f0f84cee.png)

Same location but with a stronger shadow. It helps, but not enough IMO:
![screen shot 2016-10-01 at 12 22 09 pm](https://cloud.githubusercontent.com/assets/313208/19016538/d4a83480-87d1-11e6-94e6-a747ebb39b8f.png)
