### PR TITLE
Find more nontransferable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Move ornaments inbetween materials and emblems.
 * Full item details are shown in the move popup by default (they can still be turned off in settings).
 * Consumables and materials are now sorted by category.
+* A bunch of consumables that can't be moved by the API (Treasure Keys, Splicer Keys, Wormsinger Runes, etc) no show up as non-transferable in DIM.
 
 # 3.10.6
 

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -665,7 +665,7 @@
         name: itemDef.itemName,
         description: itemDef.itemDescription || '', // Added description for Bounties for now JFLAY2015
         icon: itemDef.icon,
-        notransfer: (currentBucket.inPostmaster || itemDef.nonTransferrable),
+        notransfer: (currentBucket.inPostmaster || itemDef.nonTransferrable || !itemDef.allowActions),
         id: item.itemInstanceId,
         equipped: item.isEquipped,
         equipment: item.isEquipment,


### PR DESCRIPTION
The `allowActions` flag appears to be for items that can't be moved to another character. This makes things like Splicer Keys, Treasure Keys, Charged Agonarch Runes, Wormsinger Runes, etc non-transferable.

This should fix #867 and #810.