### PR TITLE
Exclude Husk of the Pit from leveling loadout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Full item details are shown in the move popup by default (they can still be turned off in settings).
 * Consumables and materials are now sorted by category.
 * A bunch of consumables that can't be moved by the API (Treasure Keys, Splicer Keys, Wormsinger Runes, etc) no show up as non-transferable in DIM.
+* Husk of the Pit will no longer be equipped by the Item Leveling loadout.
 
 # 3.10.6
 

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -154,7 +154,9 @@
     vm.itemLevelingLoadout = function itemLevelingLoadout($event) {
       var applicableItems = _.select(dimItemService.getItems(), function(i) {
         return i.canBeEquippedBy(vm.store) &&
-          i.talentGrid && !i.talentGrid.xpComplete; // Still need XP
+          i.talentGrid &&
+          !i.talentGrid.xpComplete && // Still need XP
+          i.hash !== 2168530918; // Husk of the pit has a weirdo one-off xp mechanic
       });
 
       var bestItemFn = function(item) {


### PR DESCRIPTION
Fixes #591. I tried to generalize some rule, but I finally determined that Husk's XP mechanic is a weird one-off.

I'm only excluding it from the XP loadout - other things like the "needsxp" search still show it if you haven't gotten the Hive kills, because it really does gain XP, it just has a weird way of doing it.