### PR TITLE
Add a debug mode that allows you to easily see raw item info

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -142,6 +142,7 @@
     <script src="scripts/minmax/dimMinMax.controller.js?v=$DIM_VERSION"></script>
     <script src="scripts/minmax/dimMinMaxItem.directive.js?v=$DIM_VERSION"></script>
     <script src="scripts/minmax/dimMinMaxLocks.directive.js?v=$DIM_VERSION"></script>
+    <script src="scripts/debug/dimDebugItem.controller.js?v=$DIM_VERSION"></script>
     <!-- end app scripts -->
 
     <!-- <script src="scripts/scripts.min.js?v=$DIM_VERSION"></script> -->

--- a/app/scripts/debug/dimDebugItem.controller.js
+++ b/app/scripts/debug/dimDebugItem.controller.js
@@ -1,0 +1,30 @@
+(function() {
+  'use strict';
+
+  angular.module('dimApp')
+    .controller('dimDebugItemCtrl', dimDebugItemCtrl);
+
+  function dimDebugItemCtrl($scope, $state, dimStoreService, dimItemService, dimDefinitions, $stateParams, dimFeatureFlags) {
+    const vm = this;
+    dimFeatureFlags.debugMode = true; // if you got here, turn on debug mode
+
+    function init() {
+      dimDefinitions.then((defs) => {
+        vm.fullItem = dimItemService.getItem({ id: $stateParams.itemId });
+        if (!vm.fullItem) {
+          return;
+        }
+        vm.item = angular.copy(vm.fullItem);
+        vm.originalItem = vm.item.originalItem;
+        vm.definition = defs.InventoryItem[vm.item.hash];
+        delete vm.item.originalItem;
+
+        vm.store = dimStoreService.getStore(vm.item.owner);
+      });
+    }
+
+    $scope.$on('dim-stores-updated', function(e) {
+      init();
+    });
+  }
+})();

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -19,7 +19,9 @@
       // vendors are off until we can make them lighter on the API
       vendorsEnabled: false,
       // Stats are off in release until we get better formulas
-      qualityEnabled: true
+      qualityEnabled: true,
+      // Additional debugging / item info tools
+      debugMode: false
     })
     .factory('loadingTracker', ['promiseTracker', function(promiseTracker) {
       return promiseTracker();
@@ -144,6 +146,10 @@
         .state('vendors', {
           url: "/vendors",
           templateUrl: "views/vendors.html"
+        })
+        .state('debugItem', {
+          url: "/debugItem/:itemId",
+          templateUrl: "views/debugItem.html"
         });
     });
 })();

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -86,14 +86,18 @@
         '      </div>',
         '    </div>',
         '  </div>',
+        '  <div ng-if="vm.featureFlags.debugMode" class="item-details">',
+        '    <a ui-sref="debugItem({itemId: vm.item.id})">View Item Debug Info</a>',
+        '    <button ng-click="vm.dumpDebugInfo()">Dump info to console</a>',
+        '  </div>',
         '</div>'
       ].join('')
     };
   }
 
-  MoveItemPropertiesCtrl.$inject = ['$sce', '$q', 'dimStoreService', 'dimItemService', 'dimSettingsService', 'ngDialog', '$scope', '$rootScope', 'dimFeatureFlags'];
+  MoveItemPropertiesCtrl.$inject = ['$sce', '$q', 'dimStoreService', 'dimItemService', 'dimSettingsService', 'ngDialog', '$scope', '$rootScope', 'dimFeatureFlags', 'dimDefinitions'];
 
-  function MoveItemPropertiesCtrl($sce, $q, storeService, itemService, settings, ngDialog, $scope, $rootScope, dimFeatureFlags) {
+  function MoveItemPropertiesCtrl($sce, $q, storeService, itemService, settings, ngDialog, $scope, $rootScope, dimFeatureFlags, dimDefinitions) {
     var vm = this;
 
     vm.featureFlags = dimFeatureFlags;
@@ -216,5 +220,14 @@
         });
       }
     }
+
+    vm.dumpDebugInfo = function() {
+      console.log("DEBUG INFO for '" + vm.item.name + "'");
+      console.log("DIM Item", vm.item);
+      console.log("Bungie API Item", vm.item.originalItem || "Enable debug mode (ctrl+shift+r) and refresh items to see this.");
+      dimDefinitions.then((defs) => {
+        console.log("Manifest Item Definition", defs.InventoryItem[vm.item.hash]);
+      });
+    };
   }
 })();

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -829,6 +829,11 @@
         createdItem.complete = createdItem.talentGrid.complete;
       }
 
+      // In debug mode, keep the original JSON around
+      if (dimFeatureFlags.debugMode) {
+        createdItem.originalItem = item;
+      }
+
       return createdItem;
     }
 

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -78,6 +78,14 @@
       }
     });
 
+    hotkeys.add({
+      combo: ['ctrl+shift+d'],
+      callback: function() {
+        dimFeatureFlags.debugMode = true;
+        console.log("***** DIM DEBUG MODE ENABLED *****");
+      }
+    });
+
     /**
      * Show a popup dialog containing the given template. Its class
      * will be based on the name.

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -79,7 +79,7 @@
     });
 
     hotkeys.add({
-      combo: ['ctrl+shift+d'],
+      combo: ['ctrl+alt+shift+d'],
       callback: function() {
         dimFeatureFlags.debugMode = true;
         console.log("***** DIM DEBUG MODE ENABLED *****");

--- a/app/scss/_debug.scss
+++ b/app/scss/_debug.scss
@@ -1,0 +1,11 @@
+.debugItem {
+  max-width: 80em;
+
+  .section {
+    margin: 2em 0;
+  }
+
+  pre {
+    font-size: 120%;
+  }
+}

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -11,3 +11,4 @@
 @import 'item-header';
 @import 'loadout-builder';
 @import 'vendors';
+@import 'debug';

--- a/app/views/debugItem.html
+++ b/app/views/debugItem.html
@@ -1,0 +1,16 @@
+<div class="debugItem" ng-controller="dimDebugItemCtrl as vm">
+  <a ui-sref='inventory' class="link"><i class='fa fa-arrow-circle-left'></i>Back to DIM</a>
+
+  <div class="section" ng-if="vm.item">
+    <div dim-move-item-properties="vm.fullItem"></div>
+
+    <p>Hash: <a href="http://db.destinytracker.com/inventory/item/{{ vm.item.hash }}#{{ vm.item.talentGrid.dtrPerks }}">{{vm.item.hash}}</a></p>
+    <h2>Item JSON (as it appears from Bungie's API):</h2>
+    <p ng-if="!vm.originalItem">Enable debug mode (ctrl+shift+r) and refresh items to see this.</p>
+    <pre>{{vm.originalItem | json}}</pre>
+    <h2>Item Definition JSON (from Manifest):</h2>
+    <pre>{{vm.definition | json}}</pre>
+    <h2>DIM Item JSON (after processing):</h2>
+    <pre>{{vm.item | json}}</pre>
+  </div>
+</div>


### PR DESCRIPTION
Inspired by @delphiactual in #1006, I've added a quick-and-dirty debug info capability to DIM. Press Ctrl+Shift+R to turn on debug mode (it resets if you reload the page) and you'll see new links in the move popup - one to go to a whole page with JSON printed out for the original item info, the definition, and our processed item, and a button to dump that info to the console.

It's not pretty, but it's not meant for users (though we can more easily have them provide us info with this).

![screen shot 2016-10-01 at 8 17 45 pm](https://cloud.githubusercontent.com/assets/313208/19018407/44a5e6fa-8814-11e6-820f-bb801c50da59.png)
![screen shot 2016-10-01 at 8 17 56 pm](https://cloud.githubusercontent.com/assets/313208/19018408/44a82a00-8814-11e6-9201-3a370c20363c.png)
