### PR TITLE
organize the rest of the items in the general bucket.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,30 @@
 # Next
 
+##### New
 * Added `is:inloadout` filter
+* New filters: is:light, is:hasLight, is:weapon, is:armor, is:cosmetic, is:equipment, is:equippable, is:postmaster, is:inpostmaster, is:equipped, is:transferable, is:movable.
+* New filters for items based on where they come from: is:year3, is:fwc, is:do, is:nm, is:speaker, is:variks, is:shipwright, is:vanguard, is:osiris, is:xur, is:shaxx, is:cq, is:eris, is:vanilla, is:trials, is:ib, is:qw, is:cd, is:srl, is:vog, is:ce, is:ttk, is:kf, is:roi, is:wotm, is:poe, is:coe, is:af.
+* Added debug mode (ctrl+alt+shift+d) to view an item in the move-popup dialog.
+
+##### Tweaks
+* Consumables and materials are now sorted by category.
+* All other items in the General Bucket are sorted by Rarity.
+* Move ornaments inbetween materials and emblems.
 * Link to wiki for stat quality in the move-popup box.
+* Full item details are shown in the move popup by default (they can still be turned off in settings).
+
+##### Bugfixes
 * Prevent double click to move item if loadout dialog is open.
 * [#889](https://github.com/DestinyItemManager/DIM/issues/889) Fixed stats for Iron Banner and Trials of Osiris items.
 * Fix infusion finder preview item not changing as you choose different fuel items. Also filter out year 1 items.
 * Fix some green boots that would show up with a gold border.
-* Move ornaments inbetween materials and emblems.
-* Full item details are shown in the move popup by default (they can still be turned off in settings).
-* Consumables and materials are now sorted by category.
-* A bunch of consumables that can't be moved by the API (Treasure Keys, Splicer Keys, Wormsinger Runes, etc) no show up as non-transferable in DIM.
+* A bunch of consumables that can't be moved by the API (Treasure Keys, Splicer Keys, Wormsinger Runes, etc) now show up as non-transferable in DIM.
 * Husk of the Pit will no longer be equipped by the Item Leveling loadout.
 * Fixed equipping loadouts onto the current character from Loadout Builder.
 * The default shader no longer counts as a duplicate item.
 * DIM no longer tries to equip exotic faction class items where your character isn't aligned with the right faction.
 * Fixed more cases where your loadouts wouldn't be applied because you already had an exotic equipped.
-* New filters: is:light, is:hasLight, is:weapon, is:armor, is:cosmetic, is:equipment, is:equippable, is:postmaster, is:inpostmaster, is:equipped, is:transferable, is:movable.
-* Ornaments are now sorted by rarity.
-* New filters for items based on where they come from: is:year3, is:fwc, is:do, is:nm, is:speaker, is:variks, is:shipwright, is:vanguard, is:osiris, is:xur, is:shaxx, is:cq, is:eris, is:vanilla, is:trials, is:ib, is:qw, is:cd, is:srl, is:vog, is:ce, is:ttk, is:kf, is:roi, is:wotm, is:poe, is:coe, is:af.
+* Elemental Icons moved to bottom left to not cover the expansion symbol.
 
 # 3.10.6
 

--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -162,7 +162,7 @@
           return item.quality && item.quality.min ? -item.quality.min : 1000;
         });
       }
-      if (sort === 'rarity' || sort === 'rarityThenPrimary' || items[0].location.id === "BUCKET_MODS") {
+      if (sort === 'rarity' || sort === 'rarityThenPrimary' || items[0].location.inGeneral) {
         items = _.sortBy(items, function(item) {
           switch (item.tier) {
           case 'Exotic':


### PR DESCRIPTION
this relates to #1005

basically, always sort all general items by their rarity (unless it hits a different sort first)

so basically: mods, emblems, shaders, emotes, ships, etc.
![screen shot 2016-10-03 at 12 39 44 pm](https://cloud.githubusercontent.com/assets/424158/19045377/7faeffcc-8966-11e6-9487-b10f64581ee7.png)
