### PR TITLE
Sorting(rarity, prim stat) not working for general items

### DIFF
--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -43,7 +43,7 @@
       showElements: false,
       // Sort characters (mostRecent, mostRecentReverse, fixed)
       characterOrder: 'mostRecent',
-      // Sort items in buckets (primaryStat, rarity, quality)
+      // Sort items in buckets (primaryStat, rarityThenPrimary, quality)
       itemSort: 'primaryStat',
       // How many columns to display character buckets
       charCol: 3,

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -43,8 +43,7 @@
       showElements: false,
       // Sort characters (mostRecent, mostRecentReverse, fixed)
       characterOrder: 'mostRecent',
-      // Sort items in buckets (primaryStat, rarityThenPrimary,
-      // rarity, quality)
+      // Sort items in buckets (primaryStat, rarity, quality)
       itemSort: 'primaryStat',
       // How many columns to display character buckets
       charCol: 3,

--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -143,7 +143,7 @@
         ];
       }
 
-      if (specificSortOrder.length > 0 && sort !== 'rarity') {
+      if (specificSortOrder.length > 0 && sort !== 'rarityThenPrimary') {
         items = _.sortBy(items, function(item) {
           var ix = specificSortOrder.indexOf(item.hash);
           return (ix === -1) ? 999 : ix;
@@ -152,7 +152,7 @@
       }
 
       items = _.sortBy(items || [], 'name');
-      if (sort === 'primaryStat' || sort === 'rarity' || sort === 'quality') {
+      if (sort === 'primaryStat' || sort === 'rarityThenPrimary' || sort === 'quality') {
         items = _.sortBy(items, function(item) {
           return (item.primStat) ? (-1 * item.primStat.value) : 1000;
         });
@@ -162,7 +162,7 @@
           return item.quality && item.quality.min ? -item.quality.min : 1000;
         });
       }
-      if (sort === 'rarity' || (items.length && items[0].location.inGeneral)) {
+      if (sort === 'rarityThenPrimary' || (items.length && items[0].location.inGeneral)) {
         items = _.sortBy(items, function(item) {
           switch (item.tier) {
           case 'Exotic':

--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -143,7 +143,7 @@
         ];
       }
 
-      if (specificSortOrder.length > 0) {
+      if (specificSortOrder.length > 0 && sort !== 'rarity') {
         items = _.sortBy(items, function(item) {
           var ix = specificSortOrder.indexOf(item.hash);
           return (ix === -1) ? 999 : ix;
@@ -152,7 +152,7 @@
       }
 
       items = _.sortBy(items || [], 'name');
-      if (sort === 'primaryStat' || sort === 'rarityThenPrimary' || sort === 'quality') {
+      if (sort === 'primaryStat' || sort === 'rarity' || sort === 'quality') {
         items = _.sortBy(items, function(item) {
           return (item.primStat) ? (-1 * item.primStat.value) : 1000;
         });
@@ -162,7 +162,7 @@
           return item.quality && item.quality.min ? -item.quality.min : 1000;
         });
       }
-      if (sort === 'rarity' || sort === 'rarityThenPrimary' || (items.length && items[0].location.inGeneral)) {
+      if (sort === 'rarity' || (items.length && items[0].location.inGeneral)) {
         items = _.sortBy(items, function(item) {
           switch (item.tier) {
           case 'Exotic':

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -69,13 +69,10 @@
             <input type="radio" ng-model="vm.settings.itemSort" value="primaryStat">Primary stat</label>
           <br>
           <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="rarityThenPrimary">Rarity, then primary stat</label>
-          <br>
-          <label>
-            <input type="radio" ng-model="vm.settings.itemSort" value="rarity">Rarity, then name</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="rarity">Rarity</label>
           <br>
           <label ng-show="vm.settings.itemQuality">
-            <input type="radio" ng-model="vm.settings.itemSort" value="quality">Stat roll percent, then Prim Stat</label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="quality">Stat roll percent</label>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
*not working for inventory items

It used to. Not sure if intentional or not. It'd be nice if you could sort them by "actual" and have 5 columns like there is in game too.