### PR TITLE
Bug missing grunt cmds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,8 +227,6 @@ module.exports = function(grunt) {
 
   grunt.registerTask('build', ['clean','css', 'sync', 'update_firefox_manifest']);
 
-
-
   grunt.registerTask('update_firefox_manifest', function() {
     var manifest = grunt.file.readJSON('dist/firefox/manifest.json');
     manifest.applications = firefoxBrowserSupport;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,6 +227,8 @@ module.exports = function(grunt) {
 
   grunt.registerTask('build', ['clean','css', 'sync', 'update_firefox_manifest']);
 
+
+
   grunt.registerTask('update_firefox_manifest', function() {
     var manifest = grunt.file.readJSON('dist/firefox/manifest.json');
     manifest.applications = firefoxBrowserSupport;
@@ -262,6 +264,12 @@ module.exports = function(grunt) {
     'replace:beta_version',
     'compress:firefox'
   ]);
+
+
+  // Aliases for local dev to mirror README examples
+  grunt.registerTask('dev-firefox', ['default']);
+  grunt.registerTask('dev-chrome', ['default']);
+
 
   // Builds release-able extensions in dist/
   grunt.registerTask('build_extension', [


### PR DESCRIPTION
Was looking to help out with your backlog and noticed that the Quick Start README was pointing to Grunt commands that didn't exist.  Here's a quick patch to suppress the error.  If there are more verbose items that each browser command should be explicitly doing let me know and I'll add them to the PR.  