### PR TITLE
[DIM-990] Add option to move item dialog to easily do the math of fil…

### DIFF
--- a/app/scripts/store/dimStoreBucket.directive.js
+++ b/app/scripts/store/dimStoreBucket.directive.js
@@ -126,7 +126,7 @@
             '    </form>',
             '    <div class="buttons">' +
             '      <button ng-click="vm.finish()">Move</button>',
-            '      <span ng-show="vm.stacksWorth > 0"><input type="checkbox" ng-click="vm.stacksWorthClick()">Enough to fill a stack</span>',
+            '      <button ng-click="vm.stacksWorthClick()" ng-show="vm.stacksWorth > 0">Fill Stack ({{vm.stacksWorth}})</button>',
             '    </div>',
             '  </div>',
             '</div>'].join(''),
@@ -137,9 +137,10 @@
             vm.item = $scope.ngDialogData;
             vm.moveAmount = vm.item.amount;
             vm.maximum = dimStoreService.getStore(vm.item.owner).amountOfItem(item);
-            vm.stacksWorth = Math.max(item.maxStackSize - target.amountOfItem(item), 0);
+            vm.stacksWorth = Math.min(Math.max(item.maxStackSize - target.amountOfItem(item), 0), vm.maximum);
             vm.stacksWorthClick = function() {
               vm.moveAmount = vm.stacksWorth;
+              vm.finish();
             };
             vm.finish = function() {
               $scope.closeThisDialog(vm.moveAmount);

--- a/app/scripts/store/dimStoreBucket.directive.js
+++ b/app/scripts/store/dimStoreBucket.directive.js
@@ -124,7 +124,10 @@
             '    <form ng-submit="vm.finish()">',
             '      <dim-move-amount amount="vm.moveAmount" maximum="vm.maximum"></dim-move-amount>',
             '    </form>',
-            '    <div class="buttons"><button ng-click="vm.finish()">Move</button></buttons>',
+            '    <div class="buttons">' +
+            '      <button ng-click="vm.finish()">Move</button>',
+            '      <span ng-show="vm.stacksWorth > 0"><input type="checkbox" ng-click="vm.stacksWorthClick()">Enough to fill a stack</span>',
+            '    </div>',
             '  </div>',
             '</div>'].join(''),
           scope: $scope,
@@ -134,6 +137,10 @@
             vm.item = $scope.ngDialogData;
             vm.moveAmount = vm.item.amount;
             vm.maximum = dimStoreService.getStore(vm.item.owner).amountOfItem(item);
+            vm.stacksWorth = Math.max(item.maxStackSize - target.amountOfItem(item), 0);
+            vm.stacksWorthClick = function() {
+              vm.moveAmount = vm.stacksWorth;
+            };
             vm.finish = function() {
               $scope.closeThisDialog(vm.moveAmount);
             };


### PR DESCRIPTION
…ling up to a stack

From https://github.com/DestinyItemManager/DIM/issues/990

![stacksworth](https://cloud.githubusercontent.com/assets/11757993/19325668/0583f316-907c-11e6-8b8a-ec0b87255453.gif)

First attempt at adding an option to the move item dialog that lets us OCD users easily keep a full stack of a particular item on our character without having to do math or multiple-transfer-workarounds.