### PR TITLE
[DIM 976] Farming Mode: Allow option to never rearrange non-engram-items in inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed marking which characters had access to vendor items.
 * Fix duplicate ghosts in Vangaurd vendors.
 * Fix tracking new items when the new-item shine is disabled.
+* Added option to Farming Mode to not move weapons and armor to make space for engrams. 
 
 # 3.13.0
 

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -29,12 +29,12 @@
           FarmingMode: {
             FarmingMode: "Farming Mode (move items)",
             Desc: "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
-            DescMakeRoom: "DIM is moving only Engram and Glimmer items from {{store}} to the vault or other characters to prevent anything from going to the Postmaster.",
             Configuration: "Configuration",
             Greens: {
               Greens: "Move Uncommon/Green Items to Vault",
               Tooltip: "If checked, DIM will also transfer all uncommon (green) items to the vault. If it's not checked, then green items will stay on your active character." },
             MakeRoom: {
+              Desc: "DIM is moving only Engram and Glimmer items from {{store}} to the vault or other characters to prevent anything from going to the Postmaster.",
               MakeRoom: "Make room to pick up items by moving equipment",
               Tooltip: "If checked, DIM will move weapons and armor around to make space in the vault for engrams." },
             Quickmove: "Quick Move",

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -35,7 +35,7 @@
               Greens: "Move Uncommon/Green Items to Vault",
               Tooltip: "If checked, DIM will also transfer all uncommon (green) items to the vault. If it's not checked, then green items will stay on your active character." },
             MakeRoom: {
-              MakeRoom: "Allow weapons/armor rearranging",
+              MakeRoom: "Make room to pick up items by moving equipment",
               Tooltip: "If checked, DIM will move weapons and armor around to make space in the vault for engrams." },
             Quickmove: "Quick Move",
             Stop: "Stop" },

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -29,10 +29,14 @@
           FarmingMode: {
             FarmingMode: "Farming Mode (move items)",
             Desc: "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
+            DescMakeRoom: "DIM is moving only Engram and Glimmer items from {{store}} to the vault or other characters to prevent anything from going to the Postmaster.",
             Configuration: "Configuration",
             Greens: {
               Greens: "Move Uncommon/Green Items to Vault",
               Tooltip: "If checked, DIM will also transfer all uncommon (green) items to the vault. If it's not checked, then green items will stay on your active character." },
+            MakeRoom: {
+              MakeRoom: "Allow weapons/armor rearranging",
+              Tooltip: "If checked, DIM will move weapons and armor around to make space in the vault for engrams." },
             Quickmove: "Quick Move",
             Stop: "Stop" },
           Header: {

--- a/app/scripts/services/dimFarmingService.factory.js
+++ b/app/scripts/services/dimFarmingService.factory.js
@@ -57,7 +57,7 @@
                         return _.any(dimCategory[item.bucket.sort], function(category) {
                           return store.spaceLeftForItem({ type: category, location: buckets.byType[category], bucket: buckets.byType[category] }) > 0;
                         });
-                      })) {
+                      }) || (!settings.makeRoomForItems)) {
                         return $q.reject(new Error(nospace));
                       }
                     }
@@ -185,7 +185,7 @@
           }).filter((item) => !_.isUndefined(item));
 
           self.farmItems().then(function() {
-            if (settings.makeRoomForItems !== false) {
+            if (settings.makeRoomForItems) {
               self.makeRoomForItems();
             }
           });

--- a/app/scripts/services/dimFarmingService.factory.js
+++ b/app/scripts/services/dimFarmingService.factory.js
@@ -103,6 +103,11 @@
       makeRoomForItems: function() {
         var self = this;
 
+        // early out if users don't want farming mode rearranging non-engram-items in their inventory
+        if (dimSettingsService.farming.makeRoomForItems === false) {
+            return $q.resolve();
+        }
+
         var store = dimStoreService.getStore(self.store.id);
         // TODO: this'll be easier with buckets
         // These types can have engrams

--- a/app/scripts/services/dimFarmingService.factory.js
+++ b/app/scripts/services/dimFarmingService.factory.js
@@ -50,6 +50,9 @@
                     });
                     if (otherStoresWithSpace.length) {
                       return dimItemService.moveTo(item, otherStoresWithSpace[0], false, item.amount, items);
+                    } else if ((vaultSpaceLeft === 1) && !settings.makeRoomForItems) {
+                      // Still allow transfers through the Vault to other characters.
+                      return $q.reject(new Error(nospace));
                     } else if (vaultSpaceLeft === 0) {
                       // If there's no room on other characters to move out of the vault,
                       // give up entirely.

--- a/app/scripts/services/dimFarmingService.factory.js
+++ b/app/scripts/services/dimFarmingService.factory.js
@@ -105,7 +105,7 @@
 
         // early out if users don't want farming mode rearranging non-engram-items in their inventory
         if (dimSettingsService.farming.makeRoomForItems === false) {
-            return $q.resolve();
+          return $q.resolve();
         }
 
         var store = dimStoreService.getStore(self.store.id);

--- a/app/scripts/services/dimFarmingService.factory.js
+++ b/app/scripts/services/dimFarmingService.factory.js
@@ -103,11 +103,6 @@
       makeRoomForItems: function() {
         var self = this;
 
-        // early out if users don't want farming mode rearranging non-engram-items in their inventory
-        if (dimSettingsService.farming.makeRoomForItems === false) {
-          return $q.resolve();
-        }
-
         var store = dimStoreService.getStore(self.store.id);
         // TODO: this'll be easier with buckets
         // These types can have engrams
@@ -190,7 +185,9 @@
           }).filter((item) => !_.isUndefined(item));
 
           self.farmItems().then(function() {
-            self.makeRoomForItems();
+            if (settings.makeRoomForItems !== false) {
+              self.makeRoomForItems();
+            }
           });
         }
 

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -55,7 +55,9 @@
       collapsedSections: {},
       // What settings for farming mode
       farming: {
-        farmGreens: true
+        farmGreens: true,
+        // Whether to keep one slot per item type open
+        makeRoomForItems: true
       },
       // Predefined item tags. Maybe eventually allow to add more (also i18n?)
       itemTags: [

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -20,6 +20,7 @@
             <div class="item-details"><span>
               <p translate="FarmingMode.Configuration"></p>
               <p><input id="farm-greens" type='checkbox' ng-change="vm.settings.save()" ng-model='vm.settings.farming.farmGreens' /><label for="farm-greens" translate-attr="{ title: 'FarmingMode.Greens.Tooltip'}" translate="FarmingMode.Greens"></p>
+              <p><input id="make-room-for-items" type='checkbox' ng-change="vm.settings.save()" ng-model='vm.settings.farming.makeRoomForItems' /><label for="make-room-for-items" title="If checked, DIM will move weapons and armor around to make space in the vault for engrams.">Allow weapons/armor rearranging</label></p>
             </span><span>
               <p translate="FarmingMode.Quickmove"></p>
               <p><dim-simple-item ng-repeat="item in vm.service.consolidate track by $index" item-data="item" ng-click="vm.consolidate(item, vm.service.store)"></dim-simple-item></p>

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -16,7 +16,7 @@
             <img class="engram" ng-class="{ active: (vm.service.movingItems || vm.service.makingRoom) }" src="/images/engram.svg" height="60" width="60"/>
           </span>
           <span>
-            <p translate="{{vm.settings.farming.makeRoomForItems ? 'FarmingMode.DescMakeRoom' : 'FarmingMode.Desc'}}" translate-values="{ store: vm.service.store.name }"></p>
+            <p translate="{{vm.settings.farming.makeRoomForItems ? 'FarmingMode.Desc' : 'FarmingMode.DescMakeRoom'}}" translate-values="{ store: vm.service.store.name }"></p>
             <div class="item-details"><span>
               <p translate="FarmingMode.Configuration"></p>
               <p><input id="farm-greens" type='checkbox' ng-change="vm.settings.save()" ng-model='vm.settings.farming.farmGreens' /><label for="farm-greens" translate-attr="{ title: 'FarmingMode.Greens.Tooltip'}" translate="FarmingMode.Greens"></p>

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -16,11 +16,11 @@
             <img class="engram" ng-class="{ active: (vm.service.movingItems || vm.service.makingRoom) }" src="/images/engram.svg" height="60" width="60"/>
           </span>
           <span>
-            <p translate="FarmingMode.Desc" translate-values="{ store: vm.service.store.name }"></p>
+            <p translate="{{vm.settings.farming.makeRoomForItems ? 'FarmingMode.DescMakeRoom' : 'FarmingMode.Desc'}}" translate-values="{ store: vm.service.store.name }"></p>
             <div class="item-details"><span>
               <p translate="FarmingMode.Configuration"></p>
               <p><input id="farm-greens" type='checkbox' ng-change="vm.settings.save()" ng-model='vm.settings.farming.farmGreens' /><label for="farm-greens" translate-attr="{ title: 'FarmingMode.Greens.Tooltip'}" translate="FarmingMode.Greens"></p>
-              <p><input id="make-room-for-items" type='checkbox' ng-change="vm.settings.save()" ng-model='vm.settings.farming.makeRoomForItems' /><label for="make-room-for-items" title="If checked, DIM will move weapons and armor around to make space in the vault for engrams.">Allow weapons/armor rearranging</label></p>
+              <p><input id="make-room-for-items" type='checkbox' ng-change="vm.settings.save()" ng-model='vm.settings.farming.makeRoomForItems' /><label for="make-room-for-items" translate-attr="{title: 'FarmingMode.MakeRoom.Tooltip'}" translate="FarmingMode.MakeRoom"></label></p>
             </span><span>
               <p translate="FarmingMode.Quickmove"></p>
               <p><dim-simple-item ng-repeat="item in vm.service.consolidate track by $index" item-data="item" ng-click="vm.consolidate(item, vm.service.store)"></dim-simple-item></p>

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -16,7 +16,7 @@
             <img class="engram" ng-class="{ active: (vm.service.movingItems || vm.service.makingRoom) }" src="/images/engram.svg" height="60" width="60"/>
           </span>
           <span>
-            <p translate="{{vm.settings.farming.makeRoomForItems ? 'FarmingMode.Desc' : 'FarmingMode.DescMakeRoom'}}" translate-values="{ store: vm.service.store.name }"></p>
+            <p translate="{{vm.settings.farming.makeRoomForItems ? 'FarmingMode.Desc' : 'FarmingMode.MakeRoom.Desc'}}" translate-values="{ store: vm.service.store.name }"></p>
             <div class="item-details"><span>
               <p translate="FarmingMode.Configuration"></p>
               <p><input id="farm-greens" type='checkbox' ng-change="vm.settings.save()" ng-model='vm.settings.farming.farmGreens' /><label for="farm-greens" translate-attr="{ title: 'FarmingMode.Greens.Tooltip'}" translate="FarmingMode.Greens"></p>

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -133,6 +133,14 @@
           <button ng-click="vm.resetHiddenInfos()" translate="Settings.DIMPopupsReset"></button>
         </td>
       </tr>
+      <tr>
+        <td>
+          <label for="makeRoomForItems" title="Farming Mode: Keep one slot per item type open.">Farming Mode: Keep one slot per item type open</label>
+        </td>
+        <td>
+          <input type="checkbox" id="" ng-model="vm.settings.farming.makeRoomForItems"/>
+        </td>
+      </tr>
     </table>
   </form>
   </div>

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -133,14 +133,6 @@
           <button ng-click="vm.resetHiddenInfos()" translate="Settings.DIMPopupsReset"></button>
         </td>
       </tr>
-      <tr>
-        <td>
-          <label for="makeRoomForItems" title="Farming Mode: Keep one slot per item type open.">Farming Mode: Keep one slot per item type open</label>
-        </td>
-        <td>
-          <input type="checkbox" id="" ng-model="vm.settings.farming.makeRoomForItems"/>
-        </td>
-      </tr>
     </table>
   </form>
   </div>


### PR DESCRIPTION
This pull request adds a setting to Farming Mode so that it won't move non-engrams around.  https://github.com/DestinyItemManager/DIM/issues/976

Settings page-
![image](https://cloud.githubusercontent.com/assets/11757993/19448811/2eb69182-9458-11e6-938f-0a851cda86a5.png)

The default value is true to enable the current behavior of making room so users wouldn't see a change unless they toggled the option off.
