### PR TITLE
Compare: trimmed talent grid

### DIFF
--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -31,7 +31,9 @@
                 <span ng-bind="::stat.value"></span>
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
               </div>
-              <dim-talent-grid ng-if="item.talentGrid" talent-grid="item.talentGrid"></dim-talent-grid>
+              <div ng-repeat="node in vm.talentGrids[item.id].nodes" title="{{node.description}}">
+               {{node.name}}
+              </div>
               <div class="close" ng-click="vm.remove(item);"></div>
             </span>
           </div>
@@ -151,6 +153,40 @@
           max: Math.max(...bucket)
         };
       });
+
+
+      const nodeCounts = {};
+      vm.talentGrids = {};
+      _.each(vm.comparisons, (item) => {
+        _.each(item.talentGrid.nodes, (node) => {
+          if (!nodeCounts[node.hash]) {
+            nodeCounts[node.hash] = 0;
+          }
+          nodeCounts[node.hash]++;
+        });
+      });
+
+      const commonNodes = new Set();
+      _.each(nodeCounts, (count, hash) => {
+        if (count === vm.comparisons.length) {
+          commonNodes.add(hash);
+        }
+      });
+
+      vm.talentGrids = {};
+      _.each(vm.comparisons, (item) => {
+        vm.talentGrids[item.id] = trimTalentGrid(item.talentGrid, commonNodes);
+      });
     }, true);
+
+    function trimTalentGrid(talentGrid, commonNodes) {
+      const trimmedGrid = angular.copy(talentGrid);
+      trimmedGrid.nodes = _.reject(trimmedGrid.nodes, (n) => commonNodes.has(n.hash.toString()));
+      if (trimmedGrid.nodes.length) {
+        return trimmedGrid;
+      } else {
+        return null;
+      }
+    }
   }
 })();


### PR DESCRIPTION
@kyleshay, this is a rough implementation of an idea I had for the compare feature. Rather than showing the full talent grid, this figures out which nodes are actually different across the compared set, and lists them out. So if all your weapons are the same except for one or two nodes, you see that difference. Spelling them out as text also seems easier to read than the icons.

<img width="877" alt="screen shot 2016-10-18 at 11 25 49 pm" src="https://cloud.githubusercontent.com/assets/313208/19507843/3e5ac580-958a-11e6-9ecd-18552f1007c4.png">

We can do more stuff along this line (like hiding stats that are all the same, for example).
