### PR TITLE
Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-eslint": "^19.0.0",
     "grunt-postcss": "^0.8.0",
     "grunt-sass": "^1.2.0",
-    "grunt-sync": "^0.5.2",
+    "grunt-sync": "^0.6.2",
     "grunt-text-replace": "^0.4.0",
     "grunt-webstore-upload": "^0.9.3",
     "jpm": "^1.1.1",


### PR DESCRIPTION
update grunt-sync to 0.6.2.
This update to grunt-sync is all dependency related. It includes an update which removes a `npm warning` from `npm install` regarding `minimatch`