### PR TITLE
Set Double Click Action in settings

### DIFF
--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -49,6 +49,8 @@
       charCol: 3,
       // How many columns to display vault buckets
       vaultMaxCol: 999,
+      // Which action to take when double clicking
+      dblClickAction: 1,
       // How big in pixels to draw items
       itemSize: 44,
       // Which categories or buckets should be collapsed?

--- a/app/scripts/shell/dimSettingsCtrl.controller.js
+++ b/app/scripts/shell/dimSettingsCtrl.controller.js
@@ -17,6 +17,7 @@
     vm.charColOptions = _.range(3, 6).map((num) => ({ id: num, name: num }));
     vm.vaultColOptions = _.range(5, 21).map((num) => ({ id: num, name: num }));
     vm.vaultColOptions.unshift({ id: 999, name: 'Auto' });
+    vm.dblClickActions = [{ id: 1, name: 'Equip' }, { id: 2, name: 'Move' }];
 
     vm.languageOptions = {
       en: 'English',

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -23,9 +23,9 @@
     }]);
 
 
-  StoreItem.$inject = ['dimItemService', 'dimStoreService', 'ngDialog', 'dimLoadoutService', '$rootScope', 'dimActionQueue'];
+  StoreItem.$inject = ['dimItemService', 'dimStoreService', 'ngDialog', 'dimLoadoutService', '$rootScope', 'dimActionQueue', 'dimSettingsService'];
 
-  function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService, $rootScope, dimActionQueue) {
+  function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService, $rootScope, dimActionQueue, settings) {
     var otherDialog = null;
     let firstItemTimed = false;
 
@@ -104,8 +104,8 @@
           e.stopPropagation();
           const active = dimStoreService.getActiveStore();
 
-          // Equip if it's not equipped or it's on another character
-          const equip = !item.equipped || item.owner !== active.id;
+          // Check setting for dblClickAction, Equip if it's not equipped or it's on another character
+          const equip = (settings.dblClickAction == 1) && (!item.equipped || item.owner !== active.id);
 
           dimItemService.moveTo(item, active, item.canBeEquippedBy(active) ? equip : false, item.amount);
         }

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -105,7 +105,7 @@
           const active = dimStoreService.getActiveStore();
 
           // Check setting for dblClickAction, Equip if it's not equipped or it's on another character
-          const equip = (settings.dblClickAction == 1) && (!item.equipped || item.owner !== active.id);
+          const equip = (settings.dblClickAction === 1) && (!item.equipped || item.owner !== active.id);
 
           dimItemService.moveTo(item, active, item.canBeEquippedBy(active) ? equip : false, item.amount);
         }

--- a/app/views/setting.html
+++ b/app/views/setting.html
@@ -116,6 +116,14 @@
       </tr>
       <tr>
         <td>
+          <label for="dblClickAction" title="Select the action for double clicking an item">Double Click Action</label>
+        </td>
+        <td>
+          <select id="dblClickAction" ng-model="vm.settings.dblClickAction" ng-options="option.id as option.name for option in vm.dblClickActions" required></select>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label for="spreadsheetLinks" title="Download a CSV list of your items that can be easily viewed in the spreadsheet app of your choice.">Download Spreadsheets</label>
         </td>
         <td>


### PR DESCRIPTION
The "double click to equip" feature is nice, but often times I wish I could simply move the item to my character (if I plan to dismantle it for example).

This introduces a new field in settings `dblClickAction` which has two selectable options: "Equip" and "Move", and does what you'd expect.

I don't have a ton of Angular experience, so any feedback is welcome.