### PR TITLE
option to farm greens or not

### DIFF
--- a/app/scripts/services/dimFarmingService.factory.js
+++ b/app/scripts/services/dimFarmingService.factory.js
@@ -19,8 +19,10 @@
       2904517731, // -axiomatic-beads
       1932910919 // -network-keys
     ];
+
+    var settings = dimSettingsService.farming;
+
     return {
-      settings: dimSettingsService.farming,
       active: false,
       store: null,
       itemsMoved: 0,
@@ -82,7 +84,7 @@
         var toMove = _.select(store.items, function(i) {
           return !i.location.inPostmaster && (
             i.isEngram() ||
-            (self.settings.farmGreens && i.type === 'Uncommon') ||
+            (settings.farmGreens && i.type === 'Uncommon') ||
             glimmerHashes.includes(i.hash));
         });
 
@@ -133,7 +135,7 @@
               var value = {
                 // we can assume if someone isn't farming greens they want to keep them on their character to dismantle
                 Common: 0,
-                Uncommon: self.settings.farmGreens ? 1 : 9,
+                Uncommon: settings.farmGreens ? 1 : 9,
                 Rare: 2,
                 Legendary: 3,
                 Exotic: 4

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -55,6 +55,7 @@
       collapsedSections: {},
       // What settings for farming mode
       farming: {
+        farmGreens: true
       },
       // Predefined item tags. Maybe eventually allow to add more (also i18n?)
       itemTags: [

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -18,6 +18,9 @@
           <span>
             <p>DIM is moving Engram and Glimmer items from {{vm.service.store.name}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.</p>
             <div class="item-details"><span>
+              <p>Configuration</p>
+              <p><input id="farm-greens" type='checkbox' ng-model='vm.service.settings.farmGreens' /><label for="farm-greens">Farm Uncommon/Green Items</label></p>
+            </span><span>
               <p>Quick Move</p>
               <p><dim-simple-item ng-repeat="item in vm.service.consolidate track by $index" item-data="item" ng-click="vm.consolidate(item, vm.service.store)"></dim-simple-item></p>
             </span></div>
@@ -27,14 +30,13 @@
     };
   }
 
-  FarmingCtrl.$inject = ['dimFarmingService', 'dimSettingsService', 'dimItemMoveService'];
+  FarmingCtrl.$inject = ['dimFarmingService', 'dimItemMoveService'];
 
-  function FarmingCtrl(dimFarmingService, dimSettingsService, dimItemMoveService) {
+  function FarmingCtrl(dimFarmingService, dimItemMoveService) {
     var vm = this;
 
     angular.extend(vm, {
       service: dimFarmingService,
-      settings: dimSettingsService.farming,
       consolidate: dimItemMoveService.consolidate,
       stop: function($event) {
         $event.preventDefault();

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -19,7 +19,7 @@
             <p>DIM is moving Engram and Glimmer items from {{vm.service.store.name}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.</p>
             <div class="item-details"><span>
               <p>Configuration</p>
-              <p><input id="farm-greens" type='checkbox' ng-model='vm.service.settings.farmGreens' /><label for="farm-greens">Farm Uncommon/Green Items</label></p>
+              <p><input id="farm-greens" type='checkbox' ng-model='vm.service.settings.farmGreens' /><label for="farm-greens" title="If checked, DIM will also transfer all uncommon (green) items to the vault. If it's not checked, then green items will stay on your active character.">Move Uncommon/Green Items to Vault</label></p>
             </span><span>
               <p>Quick Move</p>
               <p><dim-simple-item ng-repeat="item in vm.service.consolidate track by $index" item-data="item" ng-click="vm.consolidate(item, vm.service.store)"></dim-simple-item></p>
@@ -30,13 +30,14 @@
     };
   }
 
-  FarmingCtrl.$inject = ['dimFarmingService', 'dimItemMoveService'];
+  FarmingCtrl.$inject = ['dimFarmingService', 'dimItemMoveService', 'dimSettingsService'];
 
-  function FarmingCtrl(dimFarmingService, dimItemMoveService) {
+  function FarmingCtrl(dimFarmingService, dimItemMoveService, dimSettingsService) {
     var vm = this;
 
     angular.extend(vm, {
       service: dimFarmingService,
+      settings: dimSettingsService.farming,
       consolidate: dimItemMoveService.consolidate,
       stop: function($event) {
         $event.preventDefault();

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -19,7 +19,7 @@
             <p>DIM is moving Engram and Glimmer items from {{vm.service.store.name}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.</p>
             <div class="item-details"><span>
               <p>Configuration</p>
-              <p><input id="farm-greens" type='checkbox' ng-model='vm.service.settings.farmGreens' /><label for="farm-greens" title="If checked, DIM will also transfer all uncommon (green) items to the vault. If it's not checked, then green items will stay on your active character.">Move Uncommon/Green Items to Vault</label></p>
+              <p><input id="farm-greens" type='checkbox' ng-model='vm.settings.farmGreens' /><label for="farm-greens" title="If checked, DIM will also transfer all uncommon (green) items to the vault. If it's not checked, then green items will stay on your active character.">Move Uncommon/Green Items to Vault</label></p>
             </span><span>
               <p>Quick Move</p>
               <p><dim-simple-item ng-repeat="item in vm.service.consolidate track by $index" item-data="item" ng-click="vm.consolidate(item, vm.service.store)"></dim-simple-item></p>


### PR DESCRIPTION
People play differently. 

This adds the option to choose to send greens to the vault or not. 

On by default, but the setting persists between sessions.

[This PR also fixes a couple of issues.](https://www.reddit.com/r/DestinyItemManager/comments/58gphx/dim_farming_mode_glitches/)

![screen shot 2016-10-20 at 2 23 32 pm](https://cloud.githubusercontent.com/assets/424158/19572607/f6dd0f7c-96d0-11e6-9496-5bac3aab1b75.png)


