### PR TITLE
Remove angular-animate

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -62,7 +62,6 @@
     <script src="scripts/jquery-ui.position.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular/angular.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-ui-router/release/angular-ui-router.min.js?v=$DIM_VERSION"></script>
-    <script src="vendor/angular-animate/angular-animate.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-aria/angular-aria.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/moment/moment.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-moment/angular-moment.min.js?v=$DIM_VERSION"></script>

--- a/app/scripts/dimApp.module.js
+++ b/app/scripts/dimApp.module.js
@@ -3,7 +3,6 @@
 
   angular.module('dimApp', [
     'ui.router',
-    'ngAnimate',
     'timer',
     'ngAria',
     'ngDialog',

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "Angular.uuid2": "https://github.com/MBehtemam/angular-uuid.git",
     "AngularJS-Toaster": "https://github.com/DestinyItemManager/AngularJS-Toaster.git#master",
     "angular": "~1.5.8",
-    "angular-animate": "1.5.x",
     "angular-moment": "~0.10.3",
     "angular-timer": "~1.3.4",
     "angular-chrome-storage": "infomofo/angular-chrome-storage",


### PR DESCRIPTION
I was doing some profiling, and I realized that `angular-animate` was doing a ton of heavy DOM work and forcing reflows. Removing it saves hundreds of milliseconds while displaying our item grids - it's a noticeable difference.

We only used animate in three places - to show and hide the farming dialog, the "clear new items" button, and the manifest loading box. I'm happy to just not have transitions on those for now, and to add them back in using less heavy methods later.