### PR TITLE
Adds is:sublime filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Added `is:sublime` filter
 
 # 3.13.0
 

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -32,6 +32,7 @@
       dmg: ['arc', 'solar', 'void', 'kinetic'],
       type: ['primary', 'special', 'heavy', 'helmet', 'leg', 'gauntlets', 'chest', 'class', 'classitem', 'artifact', 'ghost', 'horn', 'consumable', 'ship', 'material', 'vehicle', 'emblem', 'bounties', 'quests', 'messages', 'missions', 'emote'],
       tier: ['common', 'uncommon', 'rare', 'legendary', 'exotic', 'white', 'green', 'blue', 'purple', 'yellow'],
+      sublime: ['sublime'],
       incomplete: ['incomplete'],
       complete: ['complete'],
       xpcomplete: ['xpcomplete'],
@@ -314,6 +315,21 @@
           yellow: 'exotic'
         };
         return item.tier.toLowerCase() === (tierMap[predicate] || predicate);
+      },
+      sublime: function(predicate, item) {
+        var sublimeEngrams = [
+          1986458096, // -gauntlet
+          2218811091,
+          2672986950, // -body-armor
+          779347563,
+          3497374572, // -class-item
+          808079385,
+          3592189221, // -leg-armor
+          738642122,
+          3797169075, // -helmet
+          838904328
+        ];
+        return sublimeEngrams.includes(item.hash);
       },
       // Incomplete will show items that are not fully leveled.
       incomplete: function(predicate, item) {

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -109,6 +109,7 @@
         <dim-filter-link filter="is:uncommon"></dim-filter-link>
         <dim-filter-link filter="is:rare"></dim-filter-link>
         <dim-filter-link filter="is:legendary"></dim-filter-link>
+        <dim-filter-link filter="is:sublime"></dim-filter-link>
         <dim-filter-link filter="is:exotic"></dim-filter-link>
         <dim-filter-link filter="is:white"></dim-filter-link>
         <dim-filter-link filter="is:green"></dim-filter-link>


### PR DESCRIPTION
When decrypting "sublime" engrams a user may need to be mindful of the character being used to efficiently complete the PS exclusive armor sets.  I found myself often wanting a way to exclude these engrams from a search filter when bulk decrypting engrams after a farming session so I could handle their decryption with more attention at a later time.

With this change, this is now possible using a filter like: "is:legendary is:engram not:sublime".