### PR TITLE
Make vendors collapsible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added option to Farming Mode to not move weapons and armor to make space for engrams.
 * About and Support pages are now translatable.
 * Improved error handling and error messages.
+* Vendors are collapsible.
 
 # 3.13.0
 

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -20,7 +20,7 @@
         '  </div>',
         '  <div ng-repeat="(category, buckets) in ::vm.buckets.byCategory track by category" class="section" ng-class="::category | lowercase">',
         '    <div class="title">',
-        '      <span ng-click="vm.toggleSection(category)"><i class="fa collapse" ng-class="vm.settings.collapsedSections[category] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> <span translate="Bucket.{{::category}}"></span></span>',
+        '      <span class="collapse-handle" ng-click="vm.toggleSection(category)"><i class="fa collapse" ng-class="vm.settings.collapsedSections[category] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> <span translate="Bucket.{{::category}}"></span></span>',
         '      <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{::vm.vault.capacityForItem({sort: category})}}</span>',
         '    </div>',
         '    <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i>',

--- a/app/scripts/vendors/dimVendorItems.directive.js
+++ b/app/scripts/vendors/dimVendorItems.directive.js
@@ -32,22 +32,23 @@
     },
     template: [
       '<div class="vendor-char-items" ng-repeat="(vendorHash, vendor) in vm.vendors | values | vendorTab:vm.activeTab | orderBy:[\'-eventVendor\',\'vendorOrder\'] track by vendor.hash">',
-      '   <div class="vendor-header">',
-      '     <div class="title">',
-      '     {{::vendor.name}}',
-      '     <img class="vendor-icon" ng-src="{{::vendor.icon | bungieIcon}}" />',
-      '     <timer class="vendor-timer" ng-if="vendor.nextRefreshDate[0] !== \'9\'" end-time="vendor.nextRefreshDate" max-time-unit="\'day\'" interval="1000">{{days}} day{{daysS}} {{hhours}}:{{mminutes}}:{{sseconds}}</timer>',
-      '     </div>',
-      '   </div>',
-      '   <dim-vendor-currencies vendor-categories="vendor.categories" total-coins="vm.totalCoins" property-filter="vm.activeTab"></dim-vendor-currencies>',
-      '   <div class="vendor-row">',
-      '     <div class="vendor-category" ng-repeat="category in vendor.categories | vendorTab:vm.activeTab track by category.index">',
-      '        <h3 class="category-title">{{::category.title}}</h3>',
-      '        <div class="vendor-items">',
-      '          <dim-vendor-item ng-repeat="saleItem in category.saleItems | vendorTabItems:vm.activeTab track by saleItem.index" sale-item="saleItem" total-coins="vm.totalCoins" item-clicked="vm.itemClicked(saleItem, $event)"></dim-vendor-item>',
-      '        </div>',
+      '  <div class="title">',
+      '    <div class="collapse-handle" ng-click="vm.toggleSection(vendorHash)">',
+      '      <i class="fa collapse" ng-class="vm.settings.collapsedSections[vendorHash] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i>',
+      '      <img class="vendor-icon" ng-src="{{::vendor.icon | bungieIcon}}" />',
+      '      {{::vendor.name}}',
+      '    </div>',
+      '    <timer class="vendor-timer" ng-if="vendor.nextRefreshDate[0] !== \'9\'" end-time="vendor.nextRefreshDate" max-time-unit="\'day\'" interval="1000">{{days}} day{{daysS}} {{hhours}}:{{mminutes}}:{{sseconds}}</timer>',
+      '  </div>',
+      '  <div class="vendor-row" ng-if="!vm.settings.collapsedSections[vendorHash]">',
+      '    <dim-vendor-currencies vendor-categories="vendor.categories" total-coins="vm.totalCoins" property-filter="vm.activeTab"></dim-vendor-currencies>',
+      '    <div class="vendor-category" ng-repeat="category in vendor.categories | vendorTab:vm.activeTab track by category.index">',
+      '      <h3 class="category-title">{{::category.title}}</h3>',
+      '      <div class="vendor-items">',
+      '        <dim-vendor-item ng-repeat="saleItem in category.saleItems | vendorTabItems:vm.activeTab track by saleItem.index" sale-item="saleItem" total-coins="vm.totalCoins" item-clicked="vm.itemClicked(saleItem, $event)"></dim-vendor-item>',
       '      </div>',
       '    </div>',
+      '  </div>',
       '</div>'
     ].join('')
   };
@@ -181,6 +182,10 @@
           dialogResult.close();
         }
         $scope.closeThisDialog();
+      },
+      toggleSection: function(id) {
+        vm.settings.collapsedSections[id] = !vm.settings.collapsedSections[id];
+        vm.settings.save();
       }
     });
   }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1339,9 +1339,13 @@ g {
   cursor: pointer;
   font-size: 14px;
   color: $lightgray;
-  &:hover {
+  &:hover, .collapse-handle:hover & {
     color: $orange;
   }
+}
+
+.collapse-handle {
+  cursor: pointer;
 }
 
 .store-row {

--- a/app/scss/_vendors.scss
+++ b/app/scss/_vendors.scss
@@ -32,9 +32,6 @@
   .vendor-col {
     margin-right: 20px;
   }
-  .vendor-timer {
-    float: right;
-  }
   .vendor-items {
     display: flex;
     flex-wrap: wrap;
@@ -86,10 +83,14 @@
   .vendor-headers {
     display: flex;
   }
-  .vendor-header {
-    .title {
-      padding: 0 8px;
-    }
+  .collapse-handle {
+    display: flex;
+    align-items: center;
+  }
+  .title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
   }
   .vendor-row {
     margin-bottom: 10px;
@@ -106,9 +107,7 @@
   .vendor-icon {
     width: 30px;
     height: 30px;
-    margin-top: 5px;
-    margin-right: 10px;
-    float:left;
+    margin: 5px 10px 5px 5px;
   }
   .currency img {
     height: 12px;


### PR DESCRIPTION
This makes individual vendors collapsible (with memory, just like main buckets). I also tweaked the styling for collapsible areas such that when you hover over text that's clickable to collapse it lights up the collapse handle. Hopefully that helps people understand better what's happening.

<img width="289" alt="screen shot 2016-11-01 at 9 10 54 pm" src="https://cloud.githubusercontent.com/assets/313208/19916504/b5b545c2-a077-11e6-9ad5-4be396a0a9a3.png">
