### PR TITLE
Upgrade error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix tracking new items when the new-item shine is disabled.
 * Added option to Farming Mode to not move weapons and armor to make space for engrams.
 * About and Support pages are now translatable.
+* Improved error handling and error messages.
 
 # 3.13.0
 

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -19,6 +19,20 @@
             Unknown: "Unknown",
             Vault: "Vault",
             Weapons: "Weapons" },
+          BungieService: {
+            Down: "Bungie.net is down.",
+            Difficulties: "The Bungie API is currently experiencing difficulties.",
+            NetworkError: "Network error - {{status}} {{statusText}}",
+            Throttled: 'Bungie API throttling limit exceeded. Please wait a bit and then retry.',
+            NotLoggedIn: 'Please log into Bungie.net in order to use this extension.',
+            Maintenance: "Bungie.net servers are down for maintenance.",
+            NoAccount: "No Destiny account was found for this platform. Do you have the right platform selected?",
+            NoAccountForPlatform: "Failed to find a Destiny account for you on {{platform}}.",
+            NotConnected: "You may not be connected to the internet.",
+            Twitter: "Get status updates on",
+            ItemUniqueness: "Item Uniqueness",
+            ItemUniquenessExplanation: "You tried to move the '{{name}}' {{type}} to your {{character}} but that destination already has that item and is only allowed one."
+          },
           Cooldown: {
             Grenade: "Grenade cooldown",
             Melee: "Melee cooldown",
@@ -117,7 +131,7 @@
           Manifest: {
             Build: "Building Destiny info database",
             Download: "Downloading latest Destiny info from Bungie",
-            Error: "Error loading Destiny info: {{error}}. Reload to retry.",
+            Error: "Error loading Destiny info:\n{{error}}\nReload to retry.",
             BungieDown: "Bungie.net may be having trouble.",
             Load: "Loading saved Destiny info",
             Save: "Saving latest Destiny info",
@@ -347,7 +361,7 @@
             AppliedWarn: "Dein Loadout wurde teilweise angewendet, aber {{failed}} von {{total}} Gegenständen waren fehlerhaft." },
           Manifest: {
             Build: "Lege Destiny Datenbank an",
-            Error: "Fehler beim Laden von Informationen: {{error}}. App neu laden, um es nochmals zu versuchen.",
+            Error: "Fehler beim Laden von Informationen:\n{{error}}\nApp neu laden, um es nochmals zu versuchen.",
             Download: "Lade neueste Daten von Bungie herunter",
             Load: "Lade gespeicherte Daten",
             Unzip: "Entpacke neueste Daten",

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -132,6 +132,8 @@
             Build: "Building Destiny info database",
             Download: "Downloading latest Destiny info from Bungie",
             Error: "Error loading Destiny info:\n{{error}}\nReload to retry.",
+            Outdated: "Outdated Destiny Info",
+            OutdatedExplanation: "Bungie has updated their Destiny info database. Reload DIM to pick up the new info. Note that some things in DIM may not work for a few hours after Bungie updates Destiny, as the new data propagates through their systems.",
             BungieDown: "Bungie.net may be having trouble.",
             Load: "Loading saved Destiny info",
             Save: "Saving latest Destiny info",

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -117,8 +117,8 @@
           Manifest: {
             Build: "Building Destiny info database",
             Download: "Downloading latest Destiny info from Bungie",
-            Error1: "Error loading Destiny info: ",
-            Error2: "Reload to retry.",
+            Error: "Error loading Destiny info: {{error}}. Reload to retry.",
+            BungieDown: "Bungie.net may be having trouble.",
             Load: "Loading saved Destiny info",
             Save: "Saving latest Destiny info",
             Unzip: "Unzipping latest Destiny info" },
@@ -347,8 +347,7 @@
             AppliedWarn: "Dein Loadout wurde teilweise angewendet, aber {{failed}} von {{total}} Gegenständen waren fehlerhaft." },
           Manifest: {
             Build: "Lege Destiny Datenbank an",
-            Error1: "Fehler beim Laden von Informationen: ",
-            Error2: "App neu laden, um es nochmals zu versuchen.",
+            Error: "Fehler beim Laden von Informationen: {{error}}. App neu laden, um es nochmals zu versuchen.",
             Download: "Lade neueste Daten von Bungie herunter",
             Load: "Lade gespeicherte Daten",
             Unzip: "Entpacke neueste Daten",

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -56,7 +56,7 @@
       if (response.status === -1) {
         return $q.reject($translate.instant('BungieService.NotConnected'));
       }
-      if (response.status >= 500) {
+      if (response.status === 503 || response.status === 522 /* cloudflare */) {
         return $q.reject(new Error($translate.instant('BungieService.Down')));
       }
       if (response.status < 200 || response.status >= 400) {
@@ -74,14 +74,10 @@
       } else if (errorCode === 1618 &&
                  response.config.url.indexOf('/Account/') >= 0 &&
                  response.config.url.indexOf('/Character/') < 0) {
-<<<<<<< HEAD
-        return $q.reject(new Error('No Destiny account was found for this platform.'));
+        return $q.reject(new Error($translate.instant('BungieService.NoAccount')));
       } else if (errorCode === 2107 || errorCode === 2101 || errorCode === 2102) {
         $state.go('developer');
         $q.reject(new Error('Are you running a development version of DIM? You must register your chrome extension with bungie.net.'));
-=======
-        return $q.reject(new Error($translate.instant('BungieService.NoAccount')));
->>>>>>> Upgrade error handling, add i18n to error messages
       } else if (errorCode > 1) {
         if (response.data.Message) {
           const error = new Error(response.data.Message);

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -4,9 +4,9 @@
   angular.module('dimApp')
     .factory('dimBungieService', BungieService);
 
-  BungieService.$inject = ['$rootScope', '$q', '$timeout', '$http', '$state', 'dimState', 'toaster'];
+  BungieService.$inject = ['$rootScope', '$q', '$timeout', '$http', '$state', 'dimState', 'toaster', '$translate'];
 
-  function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaster) {
+  function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaster, $translate) {
     var apiKey = localStorage.apiKey;
     /* eslint no-constant-condition: 0*/
     if ('$DIM_FLAVOR' === 'release' || '$DIM_FLAVOR' === 'beta') {
@@ -53,28 +53,35 @@
     }
 
     function handleErrors(response) {
-      if (response.status === 503) {
-        return $q.reject(new Error("Bungie.net is down."));
+      if (response.status === -1) {
+        return $q.reject($translate.instant('BungieService.NotConnected'));
+      }
+      if (response.status === 503 || response.status === 522 /* cloudflare */) {
+        return $q.reject(new Error($translate.instant('BungieService.Down')));
       }
       if (response.status < 200 || response.status >= 400) {
-        return $q.reject(new Error('Network error: ' + response.status));
+        return $q.reject(new Error($translate.instant('BungieService.NetworkError', { status: response.status, statusText: response.statusText })));
       }
 
       var errorCode = response.data.ErrorCode;
       if (errorCode === 36) {
-        return $q.reject(new Error('Bungie API throttling limit exceeded. Please wait a bit and then retry.'));
+        return $q.reject(new Error($translate.instant('BungieService.Throttled')));
       } else if (errorCode === 99) {
         openBungieNetTab();
-        return $q.reject(new Error('Please log into Bungie.net in order to use this extension.'));
+        return $q.reject(new Error($translate.instant('BungieService.NotLoggedIn')));
       } else if (errorCode === 5) {
-        return $q.reject(new Error('Bungie.net servers are down for maintenance.'));
+        return $q.reject(new Error($translate.instant('BungieService.Maintenance')));
       } else if (errorCode === 1618 &&
                  response.config.url.indexOf('/Account/') >= 0 &&
                  response.config.url.indexOf('/Character/') < 0) {
+<<<<<<< HEAD
         return $q.reject(new Error('No Destiny account was found for this platform.'));
       } else if (errorCode === 2107 || errorCode === 2101 || errorCode === 2102) {
         $state.go('developer');
         $q.reject(new Error('Are you running a development version of DIM? You must register your chrome extension with bungie.net.'));
+=======
+        return $q.reject(new Error($translate.instant('BungieService.NoAccount')));
+>>>>>>> Upgrade error handling, add i18n to error messages
       } else if (errorCode > 1) {
         if (response.data.Message) {
           const error = new Error(response.data.Message);
@@ -82,7 +89,7 @@
           error.status = response.data.ErrorStatus;
           return $q.reject(error);
         } else {
-          return $q.reject(new Error('The Bungie API is currently experiencing difficulties.'));
+          return $q.reject(new Error($translate.instant('BungieService.Difficulties')));
         }
       }
 
@@ -90,40 +97,36 @@
     }
 
     function retryOnThrottled(request) {
-      var a = $q(function(resolve, reject) {
-        var retries = 4;
-
-        function run() {
-          $http(request).then(function success(response) {
+      function run(retries) {
+        return $http(request)
+          .then(function success(response) {
             if (response.data.ErrorCode === 36) {
-              retries = retries - 1;
-
               if (retries <= 0) {
-                // debugger;
-                resolve(response);
+                return response;
               } else {
-                $timeout(run, Math.pow(2, 4 - retries) * 1000);
+                return $timeout(Math.pow(2, 4 - retries) * 1000).then(() => run(retries - 1));
               }
             } else {
-              resolve(response);
+              return response;
             }
-          }, function failure(response) {
-            // debugger;
-            if (response.data) {
-              reject(new Error(response.data.Message));
-            } else if (response.status === -1) {
-              reject(new Error("You may not be connected to the internet."));
-            } else {
-              console.error("Failed to make service call", response);
-              reject(new Error("Failed to make service call."));
-            }
-          });
-        }
+          })
+          .catch(handleErrors);
+      }
 
-        run();
+      return run(3);
+    }
+
+    function showErrorToaster(e) {
+      const twitterLink = '<a target="_blank" href="http://twitter.com/ThisIsDIM">Twitter</a> <a target="_blank" href="http://twitter.com/ThisIsDIM"><i class="fa fa-twitter fa-2x" style="vertical-align: middle;"></i></a>';
+      const twitter = `<div> ${$translate.instant('BungieService.Twitter')} ${twitterLink}</div>`;
+
+      toaster.pop({
+        type: 'error',
+        bodyOutputType: 'trustedHtml',
+        title: 'Bungie.net Error',
+        body: e.message + twitter,
+        showCloseButton: false
       });
-
-      return a;
     }
 
     /************************************************************************************************************************************/
@@ -139,7 +142,7 @@
       .then(function(request) {
         return $http(request);
       })
-      .then(handleErrors)
+      .then(handleErrors, handleErrors)
       .then(function(response) {
         return response.data.Response;
       });
@@ -169,18 +172,16 @@
     function getBungleToken() {
       tokenPromise = tokenPromise || getBnetCookies()
         .then(function(cookies) {
-          return $q(function(resolve, reject) {
-            var cookie = _.find(cookies, function(cookie) {
-              return cookie.name === 'bungled';
-            });
-
-            if (cookie) {
-              resolve(cookie.value);
-            } else {
-              openBungieNetTab();
-              reject(new Error('Please log into Bungie.net in order to use this extension.'));
-            }
+          const cookie = _.find(cookies, function(cookie) {
+            return cookie.name === 'bungled';
           });
+
+          if (cookie) {
+            return cookie.value;
+          } else {
+            openBungieNetTab();
+            throw new Error($translate.instant('BungieService.NotLoggedIn'));
+          }
         })
         .catch(function() {
           tokenPromise = null;
@@ -195,39 +196,25 @@
       platformPromise = platformPromise || getBungleToken()
         .then(getBnetPlatformsRequest)
         .then($http)
-        .then(handleErrors)
+        .then(handleErrors, handleErrors)
         .catch(function(e) {
-          var message = e.message;
-          if (e.status === -1) {
-            message = 'You may not be connected to the internet.';
-          }
-
-          var twitter = '<div>Get status updates on <a target="_blank" href="http://twitter.com/ThisIsDIM">Twitter</a> <a target="_blank" href="http://twitter.com/ThisIsDIM"><i class="fa fa-twitter fa-2x" style="vertical-align: middle;"></i></a></div>';
-
-          toaster.pop({
-            type: 'error',
-            bodyOutputType: 'trustedHtml',
-            title: 'Bungie.net Error',
-            body: message + twitter,
-            showCloseButton: false
-          });
-
+          showErrorToaster(e);
           return $q.reject(e);
         });
 
       return platformPromise;
-    }
 
-    function getBnetPlatformsRequest(token) {
-      return {
-        method: 'GET',
-        url: 'https://www.bungie.net/Platform/User/GetBungieNetUser/',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token
-        },
-        withCredentials: true
-      };
+      function getBnetPlatformsRequest(token) {
+        return {
+          method: 'GET',
+          url: 'https://www.bungie.net/Platform/User/GetBungieNetUser/',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token
+          },
+          withCredentials: true
+        };
+      }
     }
 
     /************************************************************************************************************************************/
@@ -236,7 +223,7 @@
       membershipPromise = membershipPromise || getBungleToken()
         .then(getBnetMembershipReqest)
         .then($http)
-        .then(handleErrors)
+        .then(handleErrors, handleErrors)
         .then(processBnetMembershipRequest, rejectBnetMembershipRequest)
         .catch(function(error) {
           membershipPromise = null;
@@ -259,17 +246,14 @@
 
       function processBnetMembershipRequest(response) {
         if (_.size(response.data.Response) === 0) {
-          return $q.reject(new Error('Failed to find a Destiny account for you on ' + platform.label + '.'));
+          return $q.reject(new Error($translate.instant('BungieService.NoAccountForPlatform', { platform: platform.label })));
         }
 
         return $q.when(response.data.Response);
       }
 
-      function rejectBnetMembershipRequest(response) {
-        if (response.status === -1) {
-          return $q.reject(new Error('You may not be connected to the internet.'));
-        }
-        return $q.reject(new Error('Failed to find a Destiny account for you on ' + platform.label + '.'));
+      function rejectBnetMembershipRequest() {
+        return $q.reject(new Error($translate.instant('BungieService.NoAccountForPlatform', { platform: platform.label })));
       }
     }
 
@@ -292,37 +276,37 @@
           return getBnetCharactersRequest(data.token, platform, membershipId);
         })
         .then($http)
-        .then(handleErrors)
+        .then(handleErrors, handleErrors)
         .then(processBnetCharactersRequest);
 
       return charactersPromise;
-    }
 
-    function getBnetCharactersRequest(token, platform, membershipId) {
-      return {
-        method: 'GET',
-        url: 'https://www.bungie.net/Platform/Destiny/Tiger' + (platform.type === 1 ? 'Xbox' : 'PSN') + '/Account/' + membershipId + '/',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token
-        },
-        withCredentials: true
-      };
-    }
-
-    function processBnetCharactersRequest(response) {
-      if (_.size(response.data.Response) === 0) {
-        return $q.reject(new Error('The membership id was not available.'));
+      function getBnetCharactersRequest(token, platform, membershipId) {
+        return {
+          method: 'GET',
+          url: 'https://www.bungie.net/Platform/Destiny/Tiger' + (platform.type === 1 ? 'Xbox' : 'PSN') + '/Account/' + membershipId + '/',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token
+          },
+          withCredentials: true
+        };
       }
 
-      return _.map(response.data.Response.data.characters, function(c) {
-        c.inventory = response.data.Response.data.inventory;
+      function processBnetCharactersRequest(response) {
+        if (_.size(response.data.Response) === 0) {
+          return $q.reject(new Error($translate.instant('BungieService.NoAccountForPlatform', { platform: platform.label })));
+        }
 
-        return {
-          id: c.characterBase.characterId,
-          base: c
-        };
-      });
+        return _.map(response.data.Response.data.characters, function(c) {
+          c.inventory = response.data.Response.data.inventory;
+
+          return {
+            id: c.characterBase.characterId,
+            base: c
+          };
+        });
+      }
     }
 
 
@@ -339,7 +323,7 @@
       .then(function(request) {
         return $http(request);
       })
-      .then(handleErrors)
+      .then(handleErrors, handleErrors)
       .then(function(response) {
         return response.data.Response.data;
       });
@@ -380,103 +364,76 @@
           });
         })
         .catch(function(e) {
-          var twitter = '<div>Get status updates on <a target="_blank" href="http://twitter.com/ThisIsDIM">Twitter</a> <a target="_blank" href="http://twitter.com/ThisIsDIM"><i class="fa fa-twitter fa-2x" style="vertical-align: middle;"></i></a></div>';
-
-          toaster.pop({
-            type: 'error',
-            bodyOutputType: 'trustedHtml',
-            title: 'Bungie.net Error',
-            body: e.message + twitter,
-            showCloseButton: false
-          });
-
-          // toaster.pop('error', 'Bungie.net Error', e.message);
-
+          showErrorToaster(e);
           return $q.reject(e);
         });
 
       return promise;
+
+      function getGuardianInventoryRequest(token, platform, membershipId, character) {
+        return {
+          method: 'GET',
+          url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/Account/' + membershipId + '/Character/' + character.id + '/Inventory/?definitions=false',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token
+          },
+          withCredentials: true
+        };
+      }
+
+      function getDestinyVaultRequest(token, platform) {
+        return {
+          method: 'GET',
+          url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/MyAccount/Vault/?definitions=false',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token
+          },
+          withCredentials: true
+        };
+      }
+
+      function processInventoryResponse(character, response) {
+        var payload = response.data.Response;
+
+        payload.id = character.id;
+        payload.character = character;
+
+        return payload;
+      }
+
+      function getDestinyInventories(token, platform, membershipId, characters) {
+        // Guardians
+        var promises = characters.map(function(character) {
+          var processPB = processInventoryResponse.bind(null, character);
+
+          return $q.when(getGuardianInventoryRequest(token, platform, membershipId, character))
+            .then($http)
+            .then(handleErrors, handleErrors)
+            .then(processPB);
+        });
+
+        // Vault
+
+        var processPB = processInventoryResponse.bind(null, {
+          id: 'vault',
+          base: null
+        });
+
+        var promise = $q.when(getDestinyVaultRequest(token, platform))
+              .then($http)
+              .then(handleErrors, handleErrors)
+              .then(processPB);
+
+        promises.push(promise);
+
+        return $q.all(promises);
+      }
     }
 
-    function getGuardianInventoryRequest(token, platform, membershipId, character) {
-      return {
-        method: 'GET',
-        url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/Account/' + membershipId + '/Character/' + character.id + '/Inventory/?definitions=false',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token
-        },
-        withCredentials: true
-      };
-    }
-
-    function getDestinyVaultRequest(token, platform) {
-      return {
-        method: 'GET',
-        url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/MyAccount/Vault/?definitions=false',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token
-        },
-        withCredentials: true
-      };
-    }
-
-    function processInventoryResponse(character, response) {
-      var payload = response.data.Response;
-
-      payload.id = character.id;
-      payload.character = character;
-
-      return payload;
-    }
-
-    function getDestinyInventories(token, platform, membershipId, characters) {
-      // Guardians
-      var promises = characters.map(function(character) {
-        var processPB = processInventoryResponse.bind(null, character);
-
-        return $q.when(getGuardianInventoryRequest(token, platform, membershipId, character))
-          .then($http)
-          .then(handleErrors)
-          .then(processPB);
-      });
-
-      // Vault
-
-      var processPB = processInventoryResponse.bind(null, {
-        id: 'vault',
-        base: null
-      });
-
-      var promise = $q.when(getDestinyVaultRequest(token, platform))
-        .then($http)
-        .then(handleErrors)
-        .then(processPB);
-
-      promises.push(promise);
-
-      return $q.all(promises);
-    }
 
     /************************************************************************************************************************************/
-
-    function getGuardianProgressionRequest(token, platform, membershipId, character) {
-      return {
-        method: 'GET',
-        url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/Account/' + membershipId + '/Character/' + character.id + '/Progression/?definitions=false',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token
-        },
-        withCredentials: true
-      };
-    }
-
-    function processProgressionResponse(character, response) {
-      character.progression = response.data.Response.data;
-      return character;
-    }
 
     function getDestinyProgression(token, platform, membershipId, characters) {
       var promises = characters.map(function(character) {
@@ -484,31 +441,31 @@
 
         return $q.when(getGuardianProgressionRequest(token, platform, membershipId, character))
           .then($http)
-          .then(handleErrors)
+          .then(handleErrors, handleErrors)
           .then(processPB);
       });
+
+      function getGuardianProgressionRequest(token, platform, membershipId, character) {
+        return {
+          method: 'GET',
+          url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/Account/' + membershipId + '/Character/' + character.id + '/Progression/?definitions=false',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token
+          },
+          withCredentials: true
+        };
+      }
+
+      function processProgressionResponse(character, response) {
+        character.progression = response.data.Response.data;
+        return character;
+      }
 
       return $q.all(promises);
     }
 
     /************************************************************************************************************************************/
-
-    function getCharacterAdvisorsRequest(token, platform, membershipId, character) {
-      return {
-        method: 'GET',
-        url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/Account/' + membershipId + '/Character/' + character.id + '/Advisors/V2/?definitions=false',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token
-        },
-        withCredentials: true
-      };
-    }
-
-    function processAdvisorsResponse(character, response) {
-      character.advisors = response.data.Response.data;
-      return character;
-    }
 
     function getDestinyAdvisors(token, platform, membershipId, characters) {
       var promises = characters.map(function(character) {
@@ -516,11 +473,28 @@
 
         return $q.when(getCharacterAdvisorsRequest(token, platform, membershipId, character))
           .then($http)
-          .then(handleErrors)
+          .then(handleErrors, handleErrors)
           .then(processPB);
       });
 
       return $q.all(promises);
+
+      function getCharacterAdvisorsRequest(token, platform, membershipId, character) {
+        return {
+          method: 'GET',
+          url: 'https://www.bungie.net/Platform/Destiny/' + platform.type + '/Account/' + membershipId + '/Character/' + character.id + '/Advisors/V2/?definitions=false',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token
+          },
+          withCredentials: true
+        };
+      }
+
+      function processAdvisorsResponse(character, response) {
+        character.advisors = response.data.Response.data;
+        return character;
+      }
     }
 
     /************************************************************************************************************************************/
@@ -548,7 +522,7 @@
           };
         })
         .then($http)
-        .then(handleErrors)
+        .then(handleErrors, handleErrors)
         .then((response) => response.data.Response.data);
     }
 
@@ -573,49 +547,49 @@
           return getTransferRequest(data.token, platform.type, item, store, amount);
         })
         .then(retryOnThrottled)
-        .then(function(response) {
-          return handleUniquenessViolation(response, item, store);
-        })
-        .then(handleErrors);
+        .then(handleErrors, handleErrors)
+        .catch(function(e) {
+          return handleUniquenessViolation(e, item, store);
+        });
 
       return promise;
-    }
 
-    // Handle "DestinyUniquenessViolation" (1648)
-    function handleUniquenessViolation(response, item, store) {
-      if (response && response.data && response.data.ErrorCode === 1648) {
-        toaster.pop('warning', 'Item Uniqueness', [
-          "You tried to move the '" + item.name + "'",
-          item.type.toLowerCase(),
-          "to your",
-          store.name,
-          "but that destination already has that item and is only allowed one."
-        ].join(' '));
-        return $q.reject(new Error('move-canceled'));
+      // Handle "DestinyUniquenessViolation" (1648)
+      function handleUniquenessViolation(e, item, store) {
+        if (e && e.code === 1648) {
+          toaster.pop('warning',
+                      $translate.instant('BungieService.ItemUniqueness'),
+                      $translate.instant('BungieService.ItemUniquenessExplanation', {
+                        name: item.name,
+                        type: item.type.toLowerCase(),
+                        character: store.name
+                      }));
+          return $q.reject(new Error('move-canceled'));
+        }
+        return $q.reject(e);
       }
-      return response;
-    }
 
-    function getTransferRequest(token, membershipType, item, store, amount) {
-      return {
-        method: 'POST',
-        url: 'https://www.bungie.net/Platform/Destiny/TransferItem/',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token,
-          'content-type': 'application/json; charset=UTF-8;'
-        },
-        data: {
-          characterId: store.isVault ? item.owner : store.id,
-          membershipType: membershipType,
-          itemId: item.id,
-          itemReferenceHash: item.hash,
-          stackSize: amount || item.amount,
-          transferToVault: store.isVault
-        },
-        dataType: 'json',
-        withCredentials: true
-      };
+      function getTransferRequest(token, membershipType, item, store, amount) {
+        return {
+          method: 'POST',
+          url: 'https://www.bungie.net/Platform/Destiny/TransferItem/',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token,
+            'content-type': 'application/json; charset=UTF-8;'
+          },
+          data: {
+            characterId: store.isVault ? item.owner : store.id,
+            membershipType: membershipType,
+            itemId: item.id,
+            itemReferenceHash: item.hash,
+            stackSize: amount || item.amount,
+            transferToVault: store.isVault
+          },
+          dataType: 'json',
+          withCredentials: true
+        };
+      }
     }
 
     /************************************************************************************************************************************/
@@ -639,28 +613,28 @@
           return getEquipRequest(data.token, platform.type, item);
         })
         .then(retryOnThrottled)
-        .then(handleErrors);
+        .then(handleErrors, handleErrors);
 
       return promise;
-    }
 
-    function getEquipRequest(token, membershipType, item) {
-      return {
-        method: 'POST',
-        url: 'https://www.bungie.net/Platform/Destiny/EquipItem/',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token,
-          'content-type': 'application/json; charset=UTF-8;'
-        },
-        data: {
-          characterId: item.owner,
-          membershipType: membershipType,
-          itemId: item.id
-        },
-        dataType: 'json',
-        withCredentials: true
-      };
+      function getEquipRequest(token, membershipType, item) {
+        return {
+          method: 'POST',
+          url: 'https://www.bungie.net/Platform/Destiny/EquipItem/',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token,
+            'content-type': 'application/json; charset=UTF-8;'
+          },
+          data: {
+            characterId: item.owner,
+            membershipType: membershipType,
+            itemId: item.id
+          },
+          dataType: 'json',
+          withCredentials: true
+        };
+      }
     }
 
     /************************************************************************************************************************************/
@@ -705,7 +679,7 @@
           };
         })
         .then(retryOnThrottled)
-        .then(handleErrors)
+        .then(handleErrors, handleErrors)
         .then(function(response) {
           var data = response.data.Response;
           store.updateCharacterInfoFromEquip(data.summary);
@@ -747,29 +721,29 @@
           return getSetItemStateRequest(data.token, platform.type, item, store, lockState, type);
         })
         .then(retryOnThrottled)
-        .then(handleErrors);
+        .then(handleErrors, handleErrors);
 
       return promise;
-    }
 
-    function getSetItemStateRequest(token, membershipType, item, store, lockState, type) {
-      return {
-        method: 'POST',
-        url: 'https://www.bungie.net/Platform/Destiny/' + type + '/',
-        headers: {
-          'X-API-Key': apiKey,
-          'x-csrf': token,
-          'content-type': 'application/json; charset=UTF-8;'
-        },
-        data: {
-          characterId: store.isVault ? item.owner : store.id,
-          membershipType: membershipType,
-          itemId: item.id,
-          state: lockState
-        },
-        dataType: 'json',
-        withCredentials: true
-      };
+      function getSetItemStateRequest(token, membershipType, item, store, lockState, type) {
+        return {
+          method: 'POST',
+          url: 'https://www.bungie.net/Platform/Destiny/' + type + '/',
+          headers: {
+            'X-API-Key': apiKey,
+            'x-csrf': token,
+            'content-type': 'application/json; charset=UTF-8;'
+          },
+          data: {
+            characterId: store.isVault ? item.owner : store.id,
+            membershipType: membershipType,
+            itemId: item.id,
+            state: lockState
+          },
+          dataType: 'json',
+          withCredentials: true
+        };
+      }
     }
   }
 })();

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -56,7 +56,7 @@
       if (response.status === -1) {
         return $q.reject($translate.instant('BungieService.NotConnected'));
       }
-      if (response.status === 503 || response.status === 522 /* cloudflare */) {
+      if (response.status >= 500) {
         return $q.reject(new Error($translate.instant('BungieService.Down')));
       }
       if (response.status < 200 || response.status >= 400) {

--- a/app/scripts/services/dimManifestService.factory.js
+++ b/app/scripts/services/dimManifestService.factory.js
@@ -68,7 +68,11 @@
               });
           })
           .catch((e) => {
-            service.statusText = $translate.instant('Manifest.Error1') + (e.message || e) + ". " + $translate.instant('Manifest.Error2');
+            let message = e.message || e;
+            if (e.status && e.status !== 200) {
+              message = $translate.instant('Manifest.BungieDown', { error: e.statusText });
+            }
+            service.statusText = $translate.instant('Manifest.Error', { error: message });
             manifestPromise = null;
             service.isError = true;
             return deleteManifestFile().finally(() => $q.reject(e));

--- a/app/scripts/services/dimManifestService.factory.js
+++ b/app/scripts/services/dimManifestService.factory.js
@@ -33,7 +33,9 @@
 
             // The manifest has updated!
             if (path !== service.version) {
-              toaster.pop('error', 'Outdated Destiny Info', "Bungie has updated their Destiny info database. Reload DIM to pick up the new info. Note that some things in DIM may not work for a few hours after Bungie updates Destiny, as the new data propagates through their systems.");
+              toaster.pop('error',
+                          $translate.instant('Manfiest.Outdated'),
+                          $translate.instant('Manfiest.OutdatedExplanation'));
             }
           });
       }, 10000, true),

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -287,10 +287,6 @@
       return _stores;
     }
 
-    function loadStores(activePlatform) {
-      return dimBungieService.getStores(activePlatform);
-    }
-
     // Returns a promise for a fresh view of the stores and their items.
     // If this is called while a reload is already happening, it'll return the promise
     // for the ongoing reload rather than kicking off a new reload.
@@ -321,7 +317,7 @@
                               loadNewItems(activePlatform),
                               dimItemInfoService(activePlatform),
                               $translate(['Vault']),
-                              loadStores(activePlatform)])
+                              dimBungieService.getStores(activePlatform)])
         .then(function([defs, buckets, newItems, itemInfoService, translations, rawStores]) {
           console.timeEnd('Load stores (Bungie API)');
           if (activePlatform !== dimPlatformService.getActive()) {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -2230,6 +2230,7 @@ dim-manifest-progress {
     padding: 1.5rem 1.5rem;
     background-color: #222;
     box-shadow: 1px 1px 10px rgba(0, 0, 0, .5);
+    white-space: pre-wrap;
 
     i {
       font-size: 2rem;


### PR DESCRIPTION
This is a pretty thorough upgrade to our error handling. Before we were actually missing a ton of errors with our `handleErrors` method since it only ran on promise success - I've made it handle failed requests as well. I've also fixed up manifest errors some more. The error messages should all be in the i18n file now, which will allow them to be translated. I also handle the new 522 errors since Bungie is behind Cloudflare now.