### PR TITLE
Use angular.merge to properly default settings

### DIFF
--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -59,14 +59,6 @@
         // Whether to keep one slot per item type open
         makeRoomForItems: true
       },
-      // Predefined item tags. Maybe eventually allow to add more (also i18n?)
-      itemTags: [
-        { type: undefined, label: 'Tags.TagItem' },
-        { type: 'favorite', label: 'Tags.Favorite', hotkey: '!', icon: 'star' },
-        { type: 'keep', label: 'Tags.Keep', hotkey: '@', icon: 'tag' },
-        { type: 'junk', label: 'Tags.Junk', hotkey: '#', icon: 'ban' },
-        { type: 'infuse', label: 'Tags.Infuse', hotkey: '$', icon: 'bolt' }
-      ],
 
       language: defaultLanguage(),
 
@@ -97,7 +89,7 @@
 
       _loaded = true;
       $rootScope.$evalAsync(function() {
-        angular.extend(settings, savedSettings);
+        angular.merge(settings, savedSettings);
         $translate.use(settings.language);
         $translate.fallbackLanguage('en');
       });


### PR DESCRIPTION
This fixes the problem Kyle noticed in https://github.com/DestinyItemManager/DIM/issues/1141#issuecomment-258644680 where the farming modes aren't correctly enabled by default. Our move to hierarchical settings ran afoul of `angular.extend`, which does not recursively extend. Switching to `angular.merge` will properly set the defaults. 