### PR TITLE
changelog on beta branch

### DIFF
--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -69,8 +69,8 @@
         console.log('DIM v$DIM_VERSION - Please report any errors to https://www.reddit.com/r/destinyitemmanager');
         if (dimFeatureFlags.changelogToaster) {
           dimInfoService.show('changelogv$DIM_VERSION'.replace(/\./gi, ''), {
-            title: 'DIM v$DIM_VERSION Released',
-            view: 'views/changelog-toaster.html?v=v$DIM_VERSION'
+            title: '$DIM_FLAVOR' === 'release' ? 'DIM v$DIM_VERSION Released' : 'Beta has been updated!',
+            view: 'views/changelog-toaster' + ('$DIM_FLAVOR' === 'release' ? '' : '-beta') + '.html?v=v$DIM_VERSION'
           });
         }
 

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -70,7 +70,7 @@
         if (dimFeatureFlags.changelogToaster) {
           /* eslint no-constant-condition: 0*/
           dimInfoService.show('changelogv$DIM_VERSION'.replace(/\./gi, ''), {
-            title: '$DIM_FLAVOR' === 'release' ? 'DIM v$DIM_VERSION Released' : 'Beta has been updated!',
+            title: '$DIM_FLAVOR' === 'release' ? 'DIM v$DIM_VERSION Released' : 'Beta has been updated to v$DIM_VERSION!',
             view: 'views/changelog-toaster' + ('$DIM_FLAVOR' === 'release' ? '' : '-beta') + '.html?v=v$DIM_VERSION'
           });
         }

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -68,6 +68,7 @@
 
         console.log('DIM v$DIM_VERSION - Please report any errors to https://www.reddit.com/r/destinyitemmanager');
         if (dimFeatureFlags.changelogToaster) {
+          /* eslint no-constant-condition: 0*/
           dimInfoService.show('changelogv$DIM_VERSION'.replace(/\./gi, ''), {
             title: '$DIM_FLAVOR' === 'release' ? 'DIM v$DIM_VERSION Released' : 'Beta has been updated!',
             view: 'views/changelog-toaster' + ('$DIM_FLAVOR' === 'release' ? '' : '-beta') + '.html?v=v$DIM_VERSION'

--- a/app/views/changelog-toaster-beta.html
+++ b/app/views/changelog-toaster-beta.html
@@ -1,0 +1,6 @@
+<p><a target="_blank" href="https://github.com/DestinyItemManager/DIM/blob/dev/CHANGELOG.md#next">Click to view changes</a></p>
+<p>
+  Please report any issues: <br/><a style="margin: 0 5px;" href="http://destinyitemmanager.reddit.com"
+  target="_blank"><i class="fa fa-reddit fa-2x"></i></a> <a style="margin: 0 5px;"
+  href="http://twitter.com/ThisIsDIM" target="_blank"><i class="fa fa-twitter fa-2x"></i></a>
+</p>


### PR DESCRIPTION
instead of showing the last releases changelog in the beta build, just
link to the changelog#next on the dev branch.

<img width="307" alt="screen shot 2016-11-07 at 4 21 44 pm" src="https://cloud.githubusercontent.com/assets/424158/20076625/2c7f6910-a507-11e6-9df2-4ee6d3f9ca4f.png">
