### PR TITLE
Filter weapons by stats

### DIFF
--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -671,15 +671,15 @@
       },
       hasLight: function(predicate, item) {
         const lightBuckets = ["BUCKET_CHEST",
-                                 "BUCKET_LEGS",
-                                 "BUCKET_ARTIFACT",
-                                 "BUCKET_HEAVY_WEAPON",
-                                 "BUCKET_PRIMARY_WEAPON",
-                                 "BUCKET_CLASS_ITEMS",
-                                 "BUCKET_SPECIAL_WEAPON",
-                                 "BUCKET_HEAD",
-                                 "BUCKET_ARMS",
-                                 "BUCKET_GHOST"];
+          "BUCKET_LEGS",
+          "BUCKET_ARTIFACT",
+          "BUCKET_HEAVY_WEAPON",
+          "BUCKET_PRIMARY_WEAPON",
+          "BUCKET_CLASS_ITEMS",
+          "BUCKET_SPECIAL_WEAPON",
+          "BUCKET_HEAD",
+          "BUCKET_ARMS",
+          "BUCKET_GHOST"];
         return item.bucket && _.contains(lightBuckets, item.bucket.id);
       },
       weapon: function(predicate, item) {
@@ -690,12 +690,12 @@
       },
       cosmetic: function(predicate, item) {
         const cosmeticBuckets = ["BUCKET_SHADER",
-                                 "BUCKET_MODS",
-                                 "BUCKET_EMOTES",
-                                 "BUCKET_EMBLEM",
-                                 "BUCKET_VEHICLE",
-                                 "BUCKET_SHIP",
-                                 "BUCKET_HORN"];
+          "BUCKET_MODS",
+          "BUCKET_EMOTES",
+          "BUCKET_EMBLEM",
+          "BUCKET_VEHICLE",
+          "BUCKET_SHIP",
+          "BUCKET_HORN"];
         return item.bucket && _.contains(cosmeticBuckets, item.bucket.id);
       },
       equipment: function(predicate, item) {
@@ -760,35 +760,36 @@
         }, this);
 
         switch (statType) {
-          case 'impact': // Impact
-            statHash = 4043523819;
-            break;
-          case 'range': // Range
-            statHash = 1240592695;
-            break;
-          case 'stability': // Stability
-            statHash = 155624089;
-            break;
-          case 'rof': // Rate of fire
-            statHash = 4284893193;
-            break;
-          case 'reload': // Reload
-            statHash = 4188031367;
-            break;
-          case 'magazine': // Magazine
-            statHash = 387123106;
-            break;
-          case 'aa': // Aim Assist
-            statHash = 1345609583;
-            break;
-          case 'equipspeed': // Equip Speed
-            statHash = 943549884
-            break;
+        case 'impact': // Impact
+          statHash = 4043523819;
+          break;
+        case 'range': // Range
+          statHash = 1240592695;
+          break;
+        case 'stability': // Stability
+          statHash = 155624089;
+          break;
+        case 'rof': // Rate of fire
+          statHash = 4284893193;
+          break;
+        case 'reload': // Reload
+          statHash = 4188031367;
+          break;
+        case 'magazine': // Magazine
+          statHash = 387123106;
+          break;
+        case 'aa': // Aim Assist
+          statHash = 1345609583;
+          break;
+        case 'equipspeed': // Equip Speed
+          statHash = 943549884;
+          break;
         }
 
         item.stats.forEach(function(stat) {
           if (stat.statHash === statHash) {
             item.stats.value = stat.value;
+            return true;
           }
           else {
             return false;

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -260,8 +260,11 @@
           filter = term.replace('quality:', '').replace('percentage:', '');
           addPredicate("quality", filter);
         } else if (term.indexOf('stat:') >= 0) {
-          filter = term.split(':')[1];
-          addPredicate(filter, term.split(':')[2]);
+          // Avoid console.error by checking if all parameters are typed
+          if (term.split(':').length === 3) {
+            filter = term.split(':')[1];
+            addPredicate(filter, term.split(':')[2]);
+          }
         } else if (!/^\s*$/.test(term)) {
           addPredicate("keyword", term);
         }

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -693,96 +693,94 @@
         return !item.notransfer;
       },
       rof: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'rof');
+        return filterByStats(predicate, item, 'rof');
       },
       impact: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'impact');
+        return filterByStats(predicate, item, 'impact');
       },
       range: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'range');
+        return filterByStats(predicate, item, 'range');
       },
       stability: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'stability');
+        return filterByStats(predicate, item, 'stability');
       },
       reload: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'reload');
+        return filterByStats(predicate, item, 'reload');
       },
       magazine: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'magazine');
+        return filterByStats(predicate, item, 'magazine');
       },
       aimassist: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'aa');
+        return filterByStats(predicate, item, 'aa');
       },
       equipspeed: function(predicate, item) {
-        return filterByStats.do(predicate, item, 'equipspeed');
+        return filterByStats(predicate, item, 'equipspeed');
       }
     };
 
     // This refactored method filters items by stats
     //   * statType = [aa|impact|range|stability|rof|reload|magazine|equipspeed]
-    var filterByStats = {
-      do: function(predicate, item, statType) {
-        if (predicate.length === 0 || item.stats === undefined) {
-          return false;
-        }
-
-        var foundStatHash;
-        var operands = ['<=', '>=', '=', '>', '<'];
-        var operand = 'none';
-        var result = false;
-        var statHash = {};
-
-        operands.forEach(function(element) {
-          if (predicate.substring(0, element.length) === element) {
-            operand = element;
-            predicate = predicate.substring(element.length);
-            return false;
-          } else {
-            return true;
-          }
-        }, this);
-
-        statHash = {
-          impact: 4043523819,
-          range: 1240592695,
-          stability: 155624089,
-          rof: 4284893193,
-          reload: 4188031367,
-          magazine: 387123106,
-          aa: 1345609583,
-          equipspeed: 943549884
-        }[statType];
-
-        foundStatHash = _.find(item.stats, { statHash });
-
-        if (typeof foundStatHash === 'undefined') {
-          return false;
-        }
-
-        predicate = parseInt(predicate, 10);
-
-        switch (operand) {
-        case 'none':
-          result = (foundStatHash.value === predicate);
-          break;
-        case '=':
-          result = (foundStatHash.value === predicate);
-          break;
-        case '<':
-          result = (foundStatHash.value < predicate);
-          break;
-        case '<=':
-          result = (foundStatHash.value <= predicate);
-          break;
-        case '>':
-          result = (foundStatHash.value > predicate);
-          break;
-        case '>=':
-          result = (foundStatHash.value >= predicate);
-          break;
-        }
-        return result;
+    var filterByStats = function(predicate, item, statType) {
+      if (predicate.length === 0 || item.stats === undefined) {
+        return false;
       }
+
+      var foundStatHash;
+      var operands = ['<=', '>=', '=', '>', '<'];
+      var operand = 'none';
+      var result = false;
+      var statHash = {};
+
+      operands.forEach(function(element) {
+        if (predicate.substring(0, element.length) === element) {
+          operand = element;
+          predicate = predicate.substring(element.length);
+          return false;
+        } else {
+          return true;
+        }
+      }, this);
+
+      statHash = {
+        impact: 4043523819,
+        range: 1240592695,
+        stability: 155624089,
+        rof: 4284893193,
+        reload: 4188031367,
+        magazine: 387123106,
+        aa: 1345609583,
+        equipspeed: 943549884
+      }[statType];
+
+      foundStatHash = _.find(item.stats, { statHash });
+
+      if (typeof foundStatHash === 'undefined') {
+        return false;
+      }
+
+      predicate = parseInt(predicate, 10);
+
+      switch (operand) {
+      case 'none':
+        result = (foundStatHash.value === predicate);
+        break;
+      case '=':
+        result = (foundStatHash.value === predicate);
+        break;
+      case '<':
+        result = (foundStatHash.value < predicate);
+        break;
+      case '<=':
+        result = (foundStatHash.value <= predicate);
+        break;
+      case '>':
+        result = (foundStatHash.value > predicate);
+        break;
+      case '>=':
+        result = (foundStatHash.value >= predicate);
+        break;
+      }
+      return result;
     };
   }
 })();

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -798,27 +798,27 @@
         predicate = parseInt(predicate, 10);
 
         switch (operand) {
-          case 'none':
-            result = (item.stats.value === predicate);
-            break;
-          case '=':
-            result = (item.stats.value === predicate);
-            break;
-          case '<':
-            result = (item.stats.value < predicate);
-            break;
-          case '<=':
-            result = (item.stats.value <= predicate);
-            break;
-          case '>':
-            result = (item.stats.value > predicate);
-            break;
-          case '>=':
-            result = (item.stats.value >= predicate);
-            break;
+        case 'none':
+          result = (item.stats.value === predicate);
+          break;
+        case '=':
+          result = (item.stats.value === predicate);
+          break;
+        case '<':
+          result = (item.stats.value < predicate);
+          break;
+        case '<=':
+          result = (item.stats.value <= predicate);
+          break;
+        case '>':
+          result = (item.stats.value > predicate);
+          break;
+        case '>=':
+          result = (item.stats.value >= predicate);
+          break;
         }
         return result;
       }
-    }
+    };
   }
 })();

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -259,30 +259,9 @@
         } else if (term.indexOf('quality:') >= 0 || term.indexOf('percentage:') >= 0) {
           filter = term.replace('quality:', '').replace('percentage:', '');
           addPredicate("quality", filter);
-        } else if (term.indexOf('rof:') >= 0) {
-          filter = term.replace('rof:', '');
-          addPredicate("rof", filter);
-        } else if (term.indexOf('impact:') >= 0) {
-          filter = term.replace('impact:', '');
-          addPredicate("impact", filter);
-        } else if (term.indexOf('range:') >= 0) {
-          filter = term.replace('range:', '');
-          addPredicate("range", filter);
-        } else if (term.indexOf('stability:') >= 0) {
-          filter = term.replace('stability:', '');
-          addPredicate("stability", filter);
-        } else if (term.indexOf('reload:') >= 0) {
-          filter = term.replace('reload:', '');
-          addPredicate("reload", filter);
-        } else if (term.indexOf('magazine:') >= 0) {
-          filter = term.replace('magazine:', '');
-          addPredicate("magazine", filter);
-        } else if (term.indexOf('aimassist:') >= 0 || term.indexOf('aa:') >= 0) {
-          filter = term.replace('aimassist:', '').replace('aa:', '');
-          addPredicate("aimassist", filter);
-        } else if (term.indexOf('equipspeed:') >= 0) {
-          filter = term.replace('equipspeed:', '');
-          addPredicate("equipspeed", filter);
+        } else if (term.indexOf('stat:') >= 0) {
+          filter = term.split(':')[1];
+          addPredicate(filter, term.split(':')[2]);
         } else if (!/^\s*$/.test(term)) {
           addPredicate("keyword", term);
         }
@@ -744,10 +723,11 @@
           return false;
         }
 
+        var foundStatHash;
         var operands = ['<=', '>=', '=', '>', '<'];
         var operand = 'none';
         var result = false;
-        var statHash = 0;
+        var statHash = {};
 
         operands.forEach(function(element) {
           if (predicate.substring(0, element.length) === element) {
@@ -759,63 +739,43 @@
           }
         }, this);
 
-        switch (statType) {
-        case 'impact': // Impact
-          statHash = 4043523819;
-          break;
-        case 'range': // Range
-          statHash = 1240592695;
-          break;
-        case 'stability': // Stability
-          statHash = 155624089;
-          break;
-        case 'rof': // Rate of fire
-          statHash = 4284893193;
-          break;
-        case 'reload': // Reload
-          statHash = 4188031367;
-          break;
-        case 'magazine': // Magazine
-          statHash = 387123106;
-          break;
-        case 'aa': // Aim Assist
-          statHash = 1345609583;
-          break;
-        case 'equipspeed': // Equip Speed
-          statHash = 943549884;
-          break;
-        }
+        statHash = {
+          impact: 4043523819,
+          range: 1240592695,
+          stability: 155624089,
+          rof: 4284893193,
+          reload: 4188031367,
+          magazine: 387123106,
+          aa: 1345609583,
+          equipspeed: 943549884
+        }[statType];
 
-        item.stats.forEach(function(stat) {
-          if (stat.statHash === statHash) {
-            item.stats.value = stat.value;
-            return true;
-          }
-          else {
-            return false;
-          }
-        });
+        foundStatHash = _.find(item.stats, { statHash });
+
+        if(typeof foundStatHash === 'undefined') {
+          return false;
+        }
 
         predicate = parseInt(predicate, 10);
 
         switch (operand) {
         case 'none':
-          result = (item.stats.value === predicate);
+          result = (foundStatHash.value === predicate);
           break;
         case '=':
-          result = (item.stats.value === predicate);
+          result = (foundStatHash.value === predicate);
           break;
         case '<':
-          result = (item.stats.value < predicate);
+          result = (foundStatHash.value < predicate);
           break;
         case '<=':
-          result = (item.stats.value <= predicate);
+          result = (foundStatHash.value <= predicate);
           break;
         case '>':
-          result = (item.stats.value > predicate);
+          result = (foundStatHash.value > predicate);
           break;
         case '>=':
-          result = (item.stats.value >= predicate);
+          result = (foundStatHash.value >= predicate);
           break;
         }
         return result;

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -259,6 +259,30 @@
         } else if (term.indexOf('quality:') >= 0 || term.indexOf('percentage:') >= 0) {
           filter = term.replace('quality:', '').replace('percentage:', '');
           addPredicate("quality", filter);
+        } else if (term.indexOf('rof:') >= 0) {
+          filter = term.replace('rof:', '');
+          addPredicate("rof", filter);
+        } else if (term.indexOf('impact:') >= 0) {
+          filter = term.replace('impact:', '');
+          addPredicate("impact", filter);
+        } else if (term.indexOf('range:') >= 0) {
+          filter = term.replace('range:', '');
+          addPredicate("range", filter);
+        } else if (term.indexOf('stability:') >= 0) {
+          filter = term.replace('stability:', '');
+          addPredicate("stability", filter);
+        } else if (term.indexOf('reload:') >= 0) {
+          filter = term.replace('reload:', '');
+          addPredicate("reload", filter);
+        } else if (term.indexOf('magazine:') >= 0) {
+          filter = term.replace('magazine:', '');
+          addPredicate("magazine", filter);
+        } else if (term.indexOf('aimassist:') >= 0 || term.indexOf('aa:') >= 0) {
+          filter = term.replace('aimassist:', '').replace('aa:', '');
+          addPredicate("aimassist", filter);
+        } else if (term.indexOf('equipspeed:') >= 0) {
+          filter = term.replace('equipspeed:', '');
+          addPredicate("equipspeed", filter);
         } else if (!/^\s*$/.test(term)) {
           addPredicate("keyword", term);
         }
@@ -685,7 +709,116 @@
       },
       transferable: function(predicate, item) {
         return !item.notransfer;
+      },
+      rof: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'rof');
+      },
+      impact: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'impact');
+      },
+      range: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'range');
+      },
+      stability: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'stability');
+      },
+      reload: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'reload');
+      },
+      magazine: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'magazine');
+      },
+      aimassist: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'aa');
+      },
+      equipspeed: function(predicate, item) {
+        return filterByStats.do(predicate, item, 'equipspeed');
       }
     };
+
+    // This refactored method filters items by stats
+    //   * statType = [aa|impact|range|stability|rof|reload|magazine|equipspeed]
+    var filterByStats = {
+      do: function(predicate, item, statType) {
+        if (predicate.length === 0 || item.stats === undefined) {
+          return false;
+        }
+
+        var operands = ['<=', '>=', '=', '>', '<'];
+        var operand = 'none';
+        var result = false;
+        var statHash = 0;
+
+        operands.forEach(function(element) {
+          if (predicate.substring(0, element.length) === element) {
+            operand = element;
+            predicate = predicate.substring(element.length);
+            return false;
+          } else {
+            return true;
+          }
+        }, this);
+
+        switch (statType) {
+          case 'impact': // Impact
+            statHash = 4043523819;
+            break;
+          case 'range': // Range
+            statHash = 1240592695;
+            break;
+          case 'stability': // Stability
+            statHash = 155624089;
+            break;
+          case 'rof': // Rate of fire
+            statHash = 4284893193;
+            break;
+          case 'reload': // Reload
+            statHash = 4188031367;
+            break;
+          case 'magazine': // Magazine
+            statHash = 387123106;
+            break;
+          case 'aa': // Aim Assist
+            statHash = 1345609583;
+            break;
+          case 'equipspeed': // Equip Speed
+            statHash = 943549884
+            break;
+        }
+
+        item.stats.forEach(function(stat) {
+          if (stat.statHash === statHash) {
+            item.stats.value = stat.value;
+          }
+          else {
+            return false;
+          }
+        });
+
+        predicate = parseInt(predicate, 10);
+
+        switch (operand) {
+          case 'none':
+            result = (item.stats.value === predicate);
+            break;
+          case '=':
+            result = (item.stats.value === predicate);
+            break;
+          case '<':
+            result = (item.stats.value < predicate);
+            break;
+          case '<=':
+            result = (item.stats.value <= predicate);
+            break;
+          case '>':
+            result = (item.stats.value > predicate);
+            break;
+          case '>=':
+            result = (item.stats.value >= predicate);
+            break;
+        }
+        return result;
+      }
+    }
   }
 })();

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -752,7 +752,7 @@
 
         foundStatHash = _.find(item.stats, { statHash });
 
-        if(typeof foundStatHash === 'undefined') {
+        if (typeof foundStatHash === 'undefined') {
           return false;
         }
 

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -39,6 +39,27 @@
     </tr>
     <tr>
       <td>
+        <dim-filter-link filter="impact:value"></dim-filter-link>
+        <dim-filter-link filter="impact:&gt;=value"></dim-filter-link>
+        <dim-filter-link filter="impact:&gt;value"></dim-filter-link>
+        <dim-filter-link filter="impact:&lt;value"></dim-filter-link>
+        <dim-filter-link filter="impact:&lt;=value"></dim-filter-link>
+      </td>
+      <td>Shows items based on their stat value. The available filters are:
+        <ul>
+          <li>rof:</li>
+          <li>impact:</li>
+          <li>range:</li>
+          <li>stability:</li>
+          <li>reload:</li>
+          <li>magazine:</li>
+          <li>aimassist:</li>
+          <li>equipspeed:</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <dim-filter-link filter="quality:value"></dim-filter-link>
         <dim-filter-link filter="quality:&gt;=value"></dim-filter-link>
         <dim-filter-link filter="quality:&gt;value"></dim-filter-link>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -39,22 +39,22 @@
     </tr>
     <tr>
       <td>
-        <dim-filter-link filter="impact:value"></dim-filter-link>
-        <dim-filter-link filter="impact:&gt;=value"></dim-filter-link>
-        <dim-filter-link filter="impact:&gt;value"></dim-filter-link>
-        <dim-filter-link filter="impact:&lt;value"></dim-filter-link>
-        <dim-filter-link filter="impact:&lt;=value"></dim-filter-link>
+        <dim-filter-link filter="stat:impact:value"></dim-filter-link>
+        <dim-filter-link filter="stat:impact:&gt;=value"></dim-filter-link>
+        <dim-filter-link filter="stat:impact:&gt;value"></dim-filter-link>
+        <dim-filter-link filter="stat:impact:&lt;value"></dim-filter-link>
+        <dim-filter-link filter="stat:impact:&lt;=value"></dim-filter-link>
       </td>
       <td>Shows items based on their stat value. The available filters are:
         <ul>
-          <li>rof:</li>
-          <li>impact:</li>
-          <li>range:</li>
-          <li>stability:</li>
-          <li>reload:</li>
-          <li>magazine:</li>
-          <li>aimassist: or aa:</li>
-          <li>equipspeed:</li>
+          <li>stat:rof:</li>
+          <li>stat:impact:</li>
+          <li>stat:range:</li>
+          <li>stat:stability:</li>
+          <li>stat:reload:</li>
+          <li>stat:magazine:</li>
+          <li>stat:aimassist: or stat:aa:</li>
+          <li>stat:equipspeed:</li>
         </ul>
       </td>
     </tr>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -53,7 +53,7 @@
           <li>stability:</li>
           <li>reload:</li>
           <li>magazine:</li>
-          <li>aimassist:</li>
+          <li>aimassist: or aa:</li>
           <li>equipspeed:</li>
         </ul>
       </td>


### PR DESCRIPTION
Added new filters for weapons' stats (as proposed in #1173). They work the same way as `light:`, but it iterates in `item.stats` to get the values. Well... the new filters are:

- rof:value
- impact:value
- range:value
- stability:value
- reload:value
- magazine:value
- aimassist:value _or_ aa:value
- equipspeed:value

And I think the help page is clear enough.