### PR TITLE
Comparison panel layout fixes

### DIFF
--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -26,7 +26,7 @@
             </span>
             <span ng-repeat="item in vm.comparisons track by item.index" class="compare-item">
               <dim-item-tag ng-if="vm.featureFlags.tagsEnabled" item="item"></dim-item-tag>
-              <div ng-bind="::item.name"></div>
+              <div ng-bind="::item.name" class="item-name"></div>
               <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="vm.compare.location.inWeapons ? (stat.value === vm.statRanges[stat.statHash].max ? 100 : (100 * stat.value - vm.statRanges[stat.statHash].min) / vm.statRanges[stat.statHash].max) : (stat.qualityPercentage.min) | qualityColor:'color'">
                 <span ng-bind="::stat.value"></span>
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1434,6 +1434,7 @@ dim-compare {
     border-left: none;
     position: fixed;
     left: 1em;
+    margin-top: 1px;
     min-width: 100px;
   }
 }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1454,6 +1454,10 @@ dim-compare {
     background-color: gray;
     cursor: pointer;
   }
+  .item-name {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
   .sorted {
     color: $orange;
   }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1407,7 +1407,6 @@ g {
   left: 0;
   right: 0;
   position: fixed;
-  width: 100%;
   z-index: 3;
   bottom: 0;
   background: #434444;
@@ -1418,6 +1417,7 @@ g {
 dim-compare {
   #loadout-drawer {
     padding-left: 1em;
+    padding-right: 1em;
   }
 }
 
@@ -1428,7 +1428,6 @@ dim-compare {
 .compare-bucket {
   white-space: nowrap;
   overflow-x: scroll;
-  width: 100%;
   display: flex;
   margin-left: 100px;
   .fixed-left {


### PR DESCRIPTION
Fixed the following issues related to the comparison panel:

- Horizontal scroll now behaves as expected (#1174);
- If the item name is too long (like "Harrowed Defiance of Yasmin") it is ellipsed (mentioned in #1176);
- There were a small vertical misalignment in the left panel.