### PR TITLE
For each category, display a count of items matching the active search query or filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * When dequipping an item, we try harder to find a good item to equip in its place. We also prefer replacing exotics with other exotics, and correctly handle The Life Exotic perk.
 * Lots of new translations and localized strings.
 * Vendors update when you reach a new level in their associated faction, or when you change faction alignment.
+* Display a count of items matching the active filter next to the bucket category name (weapons, armor, etc.).
 
 # 3.14.1
 

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -11,7 +11,6 @@
           Level: "Level",
           Bucket: {
             Armor: "Armor",
-            FilterCount: "matching current filter",
             General: "General",
             Postmaster: "Postmaster",
             Progress: "Progress",
@@ -98,6 +97,7 @@
             BackToDIM: "Back to DIM",
             CannotMove: "Cannot move that item off this character.",
             Drag: "Hold shift or pause over drop zone to transfer a partial stack.",
+            FilterCount: "{{amount}} matching current filter",
             ChangingPerks: "Changing Perks Not Supported",
             ChangingPerksInfo: "Sorry, there's no way to change perks outside the game. We wish we could!",
             NeverShow: "Never show me this again.",

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -11,6 +11,7 @@
           Level: "Level",
           Bucket: {
             Armor: "Armor",
+            FilterCount: "matching current filter",
             General: "General",
             Postmaster: "Postmaster",
             Progress: "Progress",

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -213,15 +213,15 @@
     vm.maxLightLoadout = function maxLightLoadout($event) {
       // These types contribute to light level
       var lightTypes = ['Primary',
-                        'Special',
-                        'Heavy',
-                        'Helmet',
-                        'Gauntlets',
-                        'Chest',
-                        'Leg',
-                        'ClassItem',
-                        'Artifact',
-                        'Ghost'];
+        'Special',
+        'Heavy',
+        'Helmet',
+        'Gauntlets',
+        'Chest',
+        'Leg',
+        'ClassItem',
+        'Artifact',
+        'Ghost'];
 
       var applicableItems = _.select(dimItemService.getItems(), function(i) {
         return i.canBeEquippedBy(vm.store) &&

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -331,10 +331,10 @@
 
       console.time('Load stores (Bungie API)');
       _reloadPromise = $q.all([dimDefinitions,
-                              dimBucketService,
-                              loadNewItems(activePlatform),
-                              dimItemInfoService(activePlatform),
-                              dimBungieService.getStores(activePlatform)])
+        dimBucketService,
+        loadNewItems(activePlatform),
+        dimItemInfoService(activePlatform),
+        dimBungieService.getStores(activePlatform)])
         .then(function([defs, buckets, newItems, itemInfoService, rawStores]) {
           console.timeEnd('Load stores (Bungie API)');
           if (activePlatform !== dimPlatformService.getActive()) {

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -95,10 +95,10 @@
 
     // a dictionary to track the amount of "visible" items per item category (weapons, armor, etc) when there is an active filter
     // initialized by making use of the categories in the bucket service
-    // counts are reset, recounted, and sent to the dimStores directive via event broadcast each time a filter is applied
+    // counts are reset and recounted each time a filter is applied
     var filterCounts = {};
     dimBucketService.then(function(buckets) {
-      _.each(_.keys(buckets.byCategory), function(category) {
+      _.each(buckets.byCategory, (_, category) => {
         filterCounts[category] = 0;
       });
     });
@@ -146,9 +146,9 @@
     };
   }
 
-  SearchFilterCtrl.$inject = ['$rootScope', '$scope', 'dimStoreService', 'dimVendorService', 'dimSearchService'];
+  SearchFilterCtrl.$inject = ['$scope', 'dimStoreService', 'dimVendorService', 'dimSearchService'];
 
-  function SearchFilterCtrl($rootScope, $scope, dimStoreService, dimVendorService, dimSearchService) {
+  function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchService) {
     var vm = this;
     var filterInputSelector = '#filter-input';
     var _duplicates = null; // Holds a map from item hash to count of occurrances of that hash
@@ -283,15 +283,17 @@
       };
 
       // reset the visible item counts
-      _.each(_.keys(vm.search.filterCounts), function(category) {
+      _.each(vm.search.filterCounts, (_, category) => {
         vm.search.filterCounts[category] = 0;
       });
 
       // mark items as visible based on filter and increment the counts in the dictionary as needed
-      _.each(dimStoreService.getStores(), function(store) {
-        _.each(store.items, function(item) {
+      _.each(dimStoreService.getStores(), (store) => {
+        _.each(store.items, (item) => {
           item.visible = (filters.length > 0) ? filterFn(item) : true;
-          if (item.visible) { vm.search.filterCounts[item.location.sort] ++; }
+          if (item.visible) {
+            vm.search.filterCounts[item.location.sort]++;
+          }
         });
       });
 
@@ -301,9 +303,6 @@
           saleItem.item.visible = (filters.length > 0) ? filterFn(saleItem.item) : true;
         });
       });
-
-      // broadcast an event for any controllers that need to know that a filter has been applied
-      $rootScope.$broadcast("dim-filtered");
     };
 
     // Cache for searches against filterTrans. Somewhat noticebly speeds up the lookup on my older Mac, YMMV. Helps

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -666,15 +666,15 @@
       },
       hasLight: function(predicate, item) {
         const lightBuckets = ["BUCKET_CHEST",
-                              "BUCKET_LEGS",
-                              "BUCKET_ARTIFACT",
-                              "BUCKET_HEAVY_WEAPON",
-                              "BUCKET_PRIMARY_WEAPON",
-                              "BUCKET_CLASS_ITEMS",
-                              "BUCKET_SPECIAL_WEAPON",
-                              "BUCKET_HEAD",
-                              "BUCKET_ARMS",
-                              "BUCKET_GHOST"];
+          "BUCKET_LEGS",
+          "BUCKET_ARTIFACT",
+          "BUCKET_HEAVY_WEAPON",
+          "BUCKET_PRIMARY_WEAPON",
+          "BUCKET_CLASS_ITEMS",
+          "BUCKET_SPECIAL_WEAPON",
+          "BUCKET_HEAD",
+          "BUCKET_ARMS",
+          "BUCKET_GHOST"];
         return item.bucket && _.contains(lightBuckets, item.bucket.id);
       },
       weapon: function(predicate, item) {
@@ -685,12 +685,12 @@
       },
       cosmetic: function(predicate, item) {
         const cosmeticBuckets = ["BUCKET_SHADER",
-                                 "BUCKET_MODS",
-                                 "BUCKET_EMOTES",
-                                 "BUCKET_EMBLEM",
-                                 "BUCKET_VEHICLE",
-                                 "BUCKET_SHIP",
-                                 "BUCKET_HORN"];
+          "BUCKET_MODS",
+          "BUCKET_EMOTES",
+          "BUCKET_EMBLEM",
+          "BUCKET_VEHICLE",
+          "BUCKET_SHIP",
+          "BUCKET_HORN"];
         return item.bucket && _.contains(cosmeticBuckets, item.bucket.id);
       },
       equipment: function(predicate, item) {

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -22,7 +22,7 @@
         '    <div class="title">',
         '      <span class="collapse-handle" ng-click="vm.toggleSection(category)"><i class="fa collapse" ng-class="vm.settings.collapsedSections[category] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> <span translate="Bucket.{{::category}}"></span></span>',
         //     if the user has input a search query, display the amount of items that match the query
-        '      <span ng-hide="vm.search.query === \'\'" class="filter-count">({{ vm.search.filterCounts[category] }} matching current filter)</span>',
+        '      <span ng-hide="vm.search.query === \'\'" class="filter-count">({{ vm.search.filterCounts[category] }} <span translate="Bucket.FilterCount"></span>)</span>',
         '      <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{::vm.vault.capacityForItem({sort: category})}}</span>',
         '    </div>',
         '    <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i>',
@@ -89,13 +89,6 @@
     $scope.$on('dim-stores-updated', function(e, stores) {
       vm.stores = stores.stores;
       vm.vault = dimStoreService.getVault();
-    });
-
-    // Update the search service when a filter has been applied. We will need this to:
-    //   A) see if there is an active filter (non-empty query string)
-    //   B) populate the item count for each category
-    $scope.$on('dim-filtered', function(e) {
-      vm.search = dimSearchService;
     });
 
     if (!vm.stores.length && dimPlatformService.getActive()) {

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -22,7 +22,7 @@
         '    <div class="title">',
         '      <span class="collapse-handle" ng-click="vm.toggleSection(category)"><i class="fa collapse" ng-class="vm.settings.collapsedSections[category] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i> <span translate="Bucket.{{::category}}"></span></span>',
         //     if the user has input a search query, display the amount of items that match the query
-        '      <span ng-hide="vm.search.query === \'\'" class="filter-count">({{ vm.search.filterCounts[category] }} <span translate="Bucket.FilterCount"></span>)</span>',
+        '      <span ng-hide="vm.search.query === \'\'" class="filter-count">(<span translate="Help.FilterCount" translate-values="{ amount: vm.search.filterCounts[category] }"></span>)</span>',
         '      <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{::vm.vault.capacityForItem({sort: category})}}</span>',
         '    </div>',
         '    <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i>',

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -484,6 +484,10 @@ img {
   span[role="button"] {
     cursor: pointer;
   }
+  .filter-count {
+    letter-spacing: 1px;
+    font-size: 12px;
+  }
   .bucket-count {
     float: right;
   }


### PR DESCRIPTION
Hi!  I decided to take a swing at implementing the feature requested in issue #1219.  This was my first time using Angular, so I'm looking forward to seeing what y'all think of it.

I figured the best place to display the count would be right next to the item category.  Since the user is able to filter further within these buckets, e.g. filter by primary weapons within the weapons bucket, I only implemented the counter display for the main categories (weapons, armor, etc.).

Here's a screenshot of what the count looks like when there is an active filter or search query.
![selection_071](https://cloud.githubusercontent.com/assets/3094090/21070507/5ae8d87a-be54-11e6-82bd-4c0c5ca2e32b.png)

A summary of the changes:
* `app/scripts/shell/dimSearchFilter.directive.js`
  * Use the `dimBucketService`'s categories to create a dictionary (`filterCounts`) that will store the item counts.
  * Whenever the filter function is called:
    * Reset the counts within the dictionary.
    * If it's determined that an item should be visible, increment that item's category within the dictionary.
    * Broadcast an event from the `$rootScope` denoting that the filter function has run.
* `app/scripts/store/dimStores.directive.js`
  * Require `dimSearchService` so that we can check the query string and read the dictionary.
  * Listen for the filter event so that we know to update the view.
