### PR TITLE
Add class to list of items including class name

### DIFF
--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -194,7 +194,8 @@
     if (vm.item.classTypeName !== 'unknown' &&
         // These already include the class name
         vm.item.type !== 'ClassItem' &&
-        vm.item.type !== 'Artifact') {
+        vm.item.type !== 'Artifact' &&
+        vm.item.type !== 'Class') {
       vm.classType = vm.item.classTypeName[0].toUpperCase() + vm.item.classTypeName.slice(1);
     }
 


### PR DESCRIPTION
Subclasses no longer showing as: `Warlock Warlock Subclass`

![screenshot 2016-12-11 15 54 19](https://cloud.githubusercontent.com/assets/4798491/21084311/cb906424-bfbe-11e6-93ed-db068e241789.png)

vm.classType still needs to be localized...