### PR TITLE
Shim drag and drop for iOS / Chrome-touch

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -60,7 +60,10 @@
     <script src="scripts/google.js?v=$DIM_VERSION"></script>
 
     <!-- begin vendor scripts -->
-    <script src="vendor/jquery/dist/jquery.min.js?v=$DIM_VERSION"></script>
+    <script>
+     var iosDragDropShim = { enableEnterLeave: true }
+    </script>
+    <script src="vendor/drag-drop-webkit-mobile/ios-drag-drop.js?v=$DIM_VERSION"></script    <script src="vendor/jquery/dist/jquery.min.js?v=$DIM_VERSION"></script>
     <script src="scripts/jquery-ui.position.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular/angular.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-ui-router/release/angular-ui-router.min.js?v=$DIM_VERSION"></script>
@@ -83,10 +86,7 @@
     <script src="vendor/ng-http-rate-limiter/dist/ng-http-rate-limiter.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-translate/angular-translate.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/idb-keyval/dist/idb-keyval-min.js?v=$DIM_VERSION"></script>
-    <script>
-     var iosDragDropShim = { enableEnterLeave: true }
-    </script>
-    <script src="vendor/drag-drop-webkit-mobile/ios-drag-drop.js?v=$DIM_VERSION"></script>
+>
     <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-hotkeys/build/hotkeys.js?v=$DIM_VERSION"></script>
     <script src="vendor/zip.js/WebContent/zip.js?v=$DIM_VERSION"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -60,10 +60,8 @@
     <script src="scripts/google.js?v=$DIM_VERSION"></script>
 
     <!-- begin vendor scripts -->
-    <script>
-     var iosDragDropShim = { enableEnterLeave: true }
-    </script>
-    <script src="vendor/drag-drop-webkit-mobile/ios-drag-drop.js?v=$DIM_VERSION"></script    <script src="vendor/jquery/dist/jquery.min.js?v=$DIM_VERSION"></script>
+    <script src="vendor/drag-drop-webkit-mobile/ios-drag-drop.js?v=$DIM_VERSION"></script>
+    <script src="vendor/jquery/dist/jquery.min.js?v=$DIM_VERSION"></script>
     <script src="scripts/jquery-ui.position.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular/angular.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-ui-router/release/angular-ui-router.min.js?v=$DIM_VERSION"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -84,7 +84,6 @@
     <script src="vendor/ng-http-rate-limiter/dist/ng-http-rate-limiter.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-translate/angular-translate.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/idb-keyval/dist/idb-keyval-min.js?v=$DIM_VERSION"></script>
->
     <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-hotkeys/build/hotkeys.js?v=$DIM_VERSION"></script>
     <script src="vendor/zip.js/WebContent/zip.js?v=$DIM_VERSION"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -83,12 +83,12 @@
     <script src="vendor/ng-http-rate-limiter/dist/ng-http-rate-limiter.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-translate/angular-translate.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/idb-keyval/dist/idb-keyval-min.js?v=$DIM_VERSION"></script>
-    <!-- end vendor scripts -->
-
+    <script src="vendor/drag-drop-webkit-mobile/ios-drag-drop.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-hotkeys/build/hotkeys.js?v=$DIM_VERSION"></script>
     <script src="vendor/zip.js/WebContent/zip.js?v=$DIM_VERSION"></script>
     <script src="vendor/sql.js/js/sql.js?v=$DIM_VERSION"></script>
+    <!-- end vendor scripts -->
 
     <!-- begin app scripts -->
     <script src="scripts/util.js?v=$DIM_VERSION"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -83,6 +83,9 @@
     <script src="vendor/ng-http-rate-limiter/dist/ng-http-rate-limiter.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-translate/angular-translate.min.js?v=$DIM_VERSION"></script>
     <script src="vendor/idb-keyval/dist/idb-keyval-min.js?v=$DIM_VERSION"></script>
+    <script>
+     var iosDragDropShim = { enableEnterLeave: true }
+    </script>
     <script src="vendor/drag-drop-webkit-mobile/ios-drag-drop.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-chrome-storage/angular-chrome-storage.js?v=$DIM_VERSION"></script>
     <script src="vendor/angular-hotkeys/build/hotkeys.js?v=$DIM_VERSION"></script>

--- a/app/scripts/google.js
+++ b/app/scripts/google.js
@@ -17,3 +17,6 @@ _gaq.push(['_trackPageview']);
   ga.src = 'https://www.google-analytics.com/ga.js';
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
+
+/* eslint no-unused-vars:0 no-implicit-globals:0 */
+var iosDragDropShim = { enableEnterLeave: true };

--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,8 @@
     "zip.js": "*",
     "sql.js": "*",
     "angular-translate": "^2.11.1",
-    "idb-keyval": "*"
+    "idb-keyval": "*",
+    "drag-drop-webkit-mobile": "ios-html5-drag-drop-shim#^1.2.0"
   },
   "resolutions": {
     "angular": "~1.5.8",


### PR DESCRIPTION
This adds a polyfill for HTML5 drag and drop that should work in iOS Safari and Chrome on touch devices (Windows/Android). I haven't tested it but we can try it in the website branch and on Surface.