### PR TITLE
Hide DTRTooltip

### DIFF
--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -16,6 +16,10 @@ div:focus, span:focus {
   outline-width: 0;
 }
 
+#DTRTooltip {
+  display: none;
+}
+
 /**
   New Item overlay area
 **/


### PR DESCRIPTION
Simple fix to hide DTR tooltip by just setting display to none. The
events are still firing, but I’m not sure if there is an easy way to
disable it…