### PR TITLE
bump angular to 1.6

### DIFF
--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -120,9 +120,8 @@
     ])
     .config([
       '$compileProvider',
-      '$qProvider',
       function($compileProvider) {
-        // TODO: remove https://github.com/angular/angular.js/blob/master/CHANGELOG.md#breaking-changes-1
+        // TODO: remove this depenency by fixing component bindings https://github.com/angular/angular.js/blob/master/CHANGELOG.md#breaking-changes-1
         $compileProvider.preAssignBindingsEnabled(true);
         // Allow chrome-extension: URLs in ng-src
         $compileProvider.imgSrcSanitizationWhitelist(/^\s*((https?|chrome-extension):|data:image\/)/);

--- a/app/scripts/dimApp.config.js
+++ b/app/scripts/dimApp.config.js
@@ -120,7 +120,10 @@
     ])
     .config([
       '$compileProvider',
+      '$qProvider',
       function($compileProvider) {
+        // TODO: remove https://github.com/angular/angular.js/blob/master/CHANGELOG.md#breaking-changes-1
+        $compileProvider.preAssignBindingsEnabled(true);
         // Allow chrome-extension: URLs in ng-src
         $compileProvider.imgSrcSanitizationWhitelist(/^\s*((https?|chrome-extension):|data:image\/)/);
       }

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "Angular.uuid2": "https://github.com/MBehtemam/angular-uuid.git",
     "AngularJS-Toaster": "https://github.com/DestinyItemManager/AngularJS-Toaster.git#master",
-    "angular": "~1.5.8",
+    "angular": "~1.6.0",
     "angular-moment": "~0.10.3",
     "angular-timer": "~1.3.4",
     "angular-chrome-storage": "infomofo/angular-chrome-storage",
@@ -18,7 +18,7 @@
     "angular-messages": "~1.3.x",
     "angular-native-dragdrop": "https://github.com/angular-dragdrop/angular-dragdrop.git",
     "angular-promise-tracker": "~2.1.0",
-    "angular-ui-router": "~0.2.x",
+    "angular-ui-router": "~0.3.2",
     "components-font-awesome": "~4.4.0",
     "humanize-duration": "~3.9.1",
     "jquery": "~2",
@@ -35,7 +35,7 @@
     "idb-keyval": "*"
   },
   "resolutions": {
-    "angular": "~1.5.8",
-    "humanize-duration": "~3.9.1"
+    "humanize-duration": "~3.9.1",
+    "angular": "1.6.0"
   }
 }


### PR DESCRIPTION
There are some breaking changes from 1.5 to 1.6

One was resolved by also upgrading the angular-ui-router. Routes seem fine still. 

Other was resolved by setting this flag to true: `$compileProvider.preAssignBindingsEnabled(true);` (defaulted to true in 1.5, now defaults to false in 1.6)

Might require some more smoke testing.

https://github.com/angular/angular.js/blob/master/CHANGELOG.md

https://docs.angularjs.org/guide/migration#migrating-from-1-5-to-1-6