### PR TITLE
Use translated category titles for vendors

### DIFF
--- a/app/scripts/services/dimVendorService.factory.js
+++ b/app/scripts/services/dimVendorService.factory.js
@@ -422,7 +422,7 @@
 
             return {
               index: category.categoryIndex,
-              title: category.categoryTitle,
+              title: vendorDef.categories[category.categoryIndex].displayTitle,
               saleItems: categoryItems,
               hasArmorWeaps: hasArmorWeaps,
               hasVehicles: hasVehicles,


### PR DESCRIPTION
Fixes #1236.

<img width="536" alt="screen shot 2016-12-13 at 11 54 36 pm" src="https://cloud.githubusercontent.com/assets/313208/21174029/acf38ee2-c18f-11e6-8419-431b7714791e.png">
