### PR TITLE
SRL Reputation Fix

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -57,7 +57,7 @@
       807090922: { label: "Queen's Wrath", order: 8 },
       3641985238: { label: "House of Judgment", order: 9 },
       2335631936: { label: "Gunsmith", order: 10 },
-      2763619072: { label: "SRL", order: 11 }
+      2576753410: { label: "SRL", order: 11 }
     };
 
     // Maps tierType to tierTypeName in English


### PR DESCRIPTION
In response to issue #1275.  Looks like Bungie updated the hash when SRL came back around this year.