### PR TITLE
[Filters] Add dawning filter

### DIFF
--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -57,7 +57,7 @@
       glimmer: ['glimmeritem', 'glimmerboost', 'glimmersupply'],
       year: ['year1', 'year2', 'year3'],
       vendor: ['fwc', 'do', 'nm', 'speaker', 'variks', 'shipwright', 'vanguard', 'osiris', 'xur', 'shaxx', 'cq', 'eris'],
-      activity: ['vanilla', 'trials', 'ib', 'qw', 'cd', 'srl', 'vog', 'ce', 'ttk', 'kf', 'roi', 'wotm', 'poe', 'coe', 'af'],
+      activity: ['vanilla', 'trials', 'ib', 'qw', 'cd', 'srl', 'vog', 'ce', 'ttk', 'kf', 'roi', 'wotm', 'poe', 'coe', 'af', 'dawning'],
       hasLight: ['light', 'haslight'],
       weapon: ['weapon'],
       armor: ['armor'],
@@ -630,7 +630,8 @@
           wotm: 3147905712,
           poe: 36493462,
           coe: 3739898362,
-          af: 1389125983
+          af: 1389125983,
+          dawning: 4153390200
         };
         if (!item) {
           return false;

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -56,7 +56,7 @@
       new: ['new'],
       glimmer: ['glimmeritem', 'glimmerboost', 'glimmersupply'],
       year: ['year1', 'year2', 'year3'],
-      vendor: ['fwc', 'do', 'nm', 'speaker', 'variks', 'shipwright', 'vanguard', 'osiris', 'xur', 'shaxx', 'cq', 'eris'],
+      vendor: ['fwc', 'do', 'nm', 'speaker', 'variks', 'shipwright', 'vanguard', 'osiris', 'xur', 'shaxx', 'cq', 'eris', 'ev'],
       activity: ['vanilla', 'trials', 'ib', 'qw', 'cd', 'srl', 'vog', 'ce', 'ttk', 'kf', 'roi', 'wotm', 'poe', 'coe', 'af', 'dawning'],
       hasLight: ['light', 'haslight'],
       weapon: ['weapon'],
@@ -579,6 +579,7 @@
       //   * Shaxx: (shaxx)
       //   * Crucible Quartermaster (cq)
       //   * Eris Morn (eris)
+      //   * Eververse (ev)
       vendor: function(predicate, item) {
         var vendorHashes = {
           fwc: 2859308742,
@@ -592,7 +593,8 @@
           xur: 941581325,
           shaxx: 1257353826,
           cq: 1587918730,
-          eris: 1662396737
+          eris: 1662396737,
+          ev: 2155337848
         };
         if (!item) {
           return false;

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -305,6 +305,7 @@
         <dim-filter-link filter="is:shaxx"></dim-filter-link>
         <dim-filter-link filter="is:cq"></dim-filter-link>
         <dim-filter-link filter="is:eris"></dim-filter-link>
+        <dim-filter-link filter="is:ev"></dim-filter-link>
       </td>
       <td>
         <span>Item is available from vendor <i>Future War Cult</i></span>
@@ -318,6 +319,7 @@
         <span>Item is available from vendor <i>Shaxx</i></span>
         <span>Item is available from vendor <i>Crucible Quartermaster</i></span>
         <span>Item is available from vendor <i>Eris Morn</i></span>
+        <span>Item is available from vendor <i>Eververse</i></span>
       </td>
     </tr>
     <tr>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -337,6 +337,7 @@
         <dim-filter-link filter="is:roi"></dim-filter-link>
         <dim-filter-link filter="is:af"></dim-filter-link>
         <dim-filter-link filter="is:wotm"></dim-filter-link>
+        <dim-filter-link filter="is:dawning"></dim-filter-link>
       </td>
       <td>
         <span>Available from release <i>Vanilla</i></span>
@@ -354,6 +355,7 @@
         <span>Available from release <i>Rise of Iron</i></span>
         <span>Available from activity <i>Archon Forge</i></span>
         <span>Available from activity <i>Wrath of the Machine</i></span>
+        <span>Available from activity <i>The Dawning</i></span>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
In response to [Reddit](https://www.reddit.com/r/DestinyItemManager/comments/5kyl7s/hood_of_the_spawn/?utm_content=title&utm_medium=hot&utm_source=reddit&utm_name=DestinyItemManager)

I found the following items do not have sourceHashes:
 - Y3 Trials Gear
 - Hood of the Spawn
 - Y3 SRL Gear
The following do not have specific enough sourceHashes:
 - Queen's Guard (sourceHashes: Quest, RoI)

Maybe we have to provide a json for items that are not sourceHashed properly, same idea as #1262.