### PR TITLE
add preferredLanguage

### DIFF
--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -6,6 +6,7 @@
     .config(['$translateProvider', function($translateProvider) {
       $translateProvider.useSanitizeValueStrategy('escape');
       $translateProvider.useMessageFormatInterpolation();
+      $translateProvider.preferredLanguage('en');
 
       $translateProvider
         .translations('en', {


### PR DESCRIPTION
This stops the flashing of `Header.About` etc and will just provide the English equivalent until translations are ready.