### PR TITLE
[Webpack] Use babel-plugin-angularjs-annotate

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,5 +9,6 @@
       "modules": false,
       "loose": true
     }]
-  ]
+  ],
+  "plugins": ["angularjs-annotate"]
 }

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -6,7 +6,6 @@ const _ = require('underscore');
 
   angular.module('dimApp').directive('dimCompare', Compare);
 
-  Compare.$inject = [];
 
   function Compare() {
     return {
@@ -43,7 +42,6 @@ const _ = require('underscore');
     };
   }
 
-  CompareCtrl.$inject = ['$scope', 'toaster', 'dimCompareService', 'dimItemService', 'dimFeatureFlags', '$translate'];
 
   function CompareCtrl($scope, toaster, dimCompareService, dimItemService, dimFeatureFlags, $translate) {
     var vm = this;

--- a/app/scripts/compare/dimCompareService.factory.js
+++ b/app/scripts/compare/dimCompareService.factory.js
@@ -4,7 +4,6 @@
   angular.module('dimApp')
     .factory('dimCompareService', CompareService);
 
-  CompareService.$inject = ['$rootScope'];
   function CompareService($rootScope) {
     return {
       dialogOpen: false,

--- a/app/scripts/infuse/dimInfuse.controller.js
+++ b/app/scripts/infuse/dimInfuse.controller.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .controller('dimInfuseCtrl', dimInfuseCtrl);
 
-  dimInfuseCtrl.$inject = ['$scope', 'dimStoreService', 'dimItemService', 'ngDialog', 'dimLoadoutService', 'toaster', '$q', '$translate'];
 
   function dimInfuseCtrl($scope, dimStoreService, dimItemService, ngDialog, dimLoadoutService, toaster, $q, $translate) {
     var vm = this;

--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -6,7 +6,6 @@ const _ = require('underscore');
 
   angular.module('dimApp').directive('dimLoadout', Loadout);
 
-  Loadout.$inject = ['dimLoadoutService', '$translate'];
 
   function Loadout(dimLoadoutService, $translate) {
     return {
@@ -100,7 +99,6 @@ const _ = require('underscore');
     }
   }
 
-  LoadoutCtrl.$inject = ['dimLoadoutService', 'dimCategory', 'toaster', 'dimPlatformService', 'dimSettingsService', '$translate'];
 
   function LoadoutCtrl(dimLoadoutService, dimCategory, toaster, dimPlatformService, dimSettingsService, $translate) {
     var vm = this;

--- a/app/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/app/scripts/loadout/dimLoadoutPopup.directive.js
@@ -6,7 +6,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .directive('dimLoadoutPopup', LoadoutPopup);
 
-  LoadoutPopup.$inject = [];
 
   function LoadoutPopup() {
     return {
@@ -56,7 +55,6 @@ const _ = require('underscore');
     };
   }
 
-  LoadoutPopupCtrl.$inject = ['$rootScope', 'ngDialog', 'dimLoadoutService', 'dimItemService', 'toaster', 'dimFarmingService', '$window', 'dimSearchService', 'dimPlatformService', '$translate'];
 
   function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemService, toaster, dimFarmingService, $window, dimSearchService, dimPlatformService, $translate) {
     var vm = this;

--- a/app/scripts/loadout/random/dimRandom.controller.js
+++ b/app/scripts/loadout/random/dimRandom.controller.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .controller('dimRandomCtrl', dimRandomCtrl);
 
-  dimRandomCtrl.$inject = ['$window', '$scope', '$q', 'dimStoreService', 'dimLoadoutService', '$translate'];
 
   function dimRandomCtrl($window, $scope, $q, dimStoreService, dimLoadoutService, $translate) {
     var vm = this;

--- a/app/scripts/minmax/dimMinMax.controller.js
+++ b/app/scripts/minmax/dimMinMax.controller.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .controller('dimMinMaxCtrl', dimMinMaxCtrl);
 
-  dimMinMaxCtrl.$inject = ['$scope', '$rootScope', '$state', '$q', '$timeout', '$location', '$translate', 'dimSettingsService', 'dimStoreService', 'ngDialog', 'dimFeatureFlags', 'dimLoadoutService', 'dimDefinitions', 'dimVendorService'];
 
   function dimMinMaxCtrl($scope, $rootScope, $state, $q, $timeout, $location, $translate, dimSettingsService, dimStoreService, ngDialog, dimFeatureFlags, dimLoadoutService, dimDefinitions, dimVendorService) {
     var vm = this;

--- a/app/scripts/minmax/dimMinMaxCharSelect.directive.js
+++ b/app/scripts/minmax/dimMinMaxCharSelect.directive.js
@@ -44,7 +44,6 @@
     .component('dimMinMaxCharSelect', MinMaxCharSelect)
     .component('dimMinMaxCharPopup', MinMaxCharPopup);
 
-  MinMaxCharSelectCtrl.$inject = ['$scope', 'ngDialog'];
 
   function MinMaxCharSelectCtrl($scope, ngDialog) {
     var vm = this;

--- a/app/scripts/minmax/dimMinMaxItem.directive.js
+++ b/app/scripts/minmax/dimMinMaxItem.directive.js
@@ -26,7 +26,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .component('dimMinMaxItem', MinMaxItem);
 
-  MinMaxItemCtrl.$inject = ['$scope', 'ngDialog', 'dimStoreService'];
 
   function MinMaxItemCtrl($scope, ngDialog, dimStoreService) {
     var vm = this;

--- a/app/scripts/minmax/dimMinMaxLocks.directive.js
+++ b/app/scripts/minmax/dimMinMaxLocks.directive.js
@@ -47,7 +47,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .component('dimMinMaxLocks', MinMaxLocks);
 
-  MinMaxLocksCtrl.$inject = ['$scope', 'hotkeys', 'ngDialog'];
 
   function MinMaxLocksCtrl($scope, hotkeys, ngDialog) {
     var vm = this;

--- a/app/scripts/move-popup/dimItemTag.directive.js
+++ b/app/scripts/move-popup/dimItemTag.directive.js
@@ -14,7 +14,6 @@ const _ = require('underscore');
     `
   });
 
-  ItemTagController.$inject = ['$scope', '$rootScope', 'dimSettingsService'];
 
   function ItemTagController($scope, $rootScope, dimSettingsService) {
     var vm = this;

--- a/app/scripts/move-popup/dimMoveAmount.directive.js
+++ b/app/scripts/move-popup/dimMoveAmount.directive.js
@@ -4,7 +4,6 @@
   angular.module('dimApp')
     .directive('dimMoveAmount', MoveAmount);
 
-  MoveAmount.$inject = ['$timeout'];
 
   function MoveAmount($timeout) {
     return {
@@ -38,7 +37,6 @@
     };
   }
 
-  MoveAmountController.$inject = [];
 
   function MoveAmountController() {
     var vm = this;

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -102,7 +102,6 @@ const _ = require('underscore');
     };
   }
 
-  MoveItemPropertiesCtrl.$inject = ['$sce', '$q', 'dimStoreService', 'dimItemService', 'dimSettingsService', 'ngDialog', '$scope', '$rootScope', 'dimFeatureFlags', 'dimDefinitions'];
 
   function MoveItemPropertiesCtrl($sce, $q, storeService, itemService, settings, ngDialog, $scope, $rootScope, dimFeatureFlags, dimDefinitions) {
     var vm = this;

--- a/app/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/app/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -103,7 +103,7 @@ const _ = require('underscore');
   }
 
 
-  function MoveItemPropertiesCtrl($sce, $q, storeService, itemService, settings, ngDialog, $scope, $rootScope, dimFeatureFlags, dimDefinitions) {
+  function MoveItemPropertiesCtrl($sce, $q, dimStoreService, dimItemService, dimSettingsService, ngDialog, $scope, $rootScope, dimFeatureFlags, dimDefinitions) {
     var vm = this;
 
     vm.featureFlags = dimFeatureFlags;
@@ -142,9 +142,9 @@ const _ = require('underscore');
 
       var store;
       if (item.owner === 'vault') {
-        store = storeService.getStores()[0];
+        store = dimStoreService.getStores()[0];
       } else {
-        store = storeService.getStore(item.owner);
+        store = dimStoreService.getStore(item.owner);
       }
 
       vm.locking = true;
@@ -156,7 +156,7 @@ const _ = require('underscore');
         state = !item.tracked;
       }
 
-      itemService.setItemState(item, store, state, type)
+      dimItemService.setItemState(item, store, state, type)
         .then(function(lockState) {
           if (type === 'lock') {
             item.locked = lockState;
@@ -180,7 +180,7 @@ const _ = require('underscore');
     vm.classType = '';
     vm.showDetailsByDefault = (!vm.item.equipment && vm.item.notransfer);
     vm.itemDetails = vm.showDetailsByDefault;
-    vm.settings = settings;
+    vm.settings = dimSettingsService;
     $scope.$watch('vm.settings.itemDetails', function(show) {
       vm.itemDetails = vm.itemDetails || show;
     });

--- a/app/scripts/move-popup/dimMovePopup.directive.js
+++ b/app/scripts/move-popup/dimMovePopup.directive.js
@@ -54,7 +54,6 @@
     };
   }
 
-  MovePopupController.$inject = ['$scope', 'dimStoreService', 'ngDialog', '$timeout', 'dimSettingsService', 'dimItemMoveService'];
 
   function MovePopupController($scope, dimStoreService, ngDialog, $timeout, dimSettingsService, dimItemMoveService) {
     var vm = this;

--- a/app/scripts/move-popup/dimTalentGrid.directive.js
+++ b/app/scripts/move-popup/dimTalentGrid.directive.js
@@ -42,7 +42,6 @@ const _ = require('underscore');
     };
   }
 
-  TalentGridCtrl.$inject = ['dimInfoService', '$translate'];
 
   function TalentGridCtrl(dimInfoService, $translate) {
     const infuseHash = 1270552711;

--- a/app/scripts/services/dimActionQueue.factory.js
+++ b/app/scripts/services/dimActionQueue.factory.js
@@ -4,7 +4,6 @@
   angular.module('dimApp')
     .factory('dimActionQueue', ActionQueue);
 
-  ActionQueue.$inject = ['$q'];
 
   // A queue of actions that will execute one after the other
   function ActionQueue($q) {

--- a/app/scripts/services/dimBucketService.factory.js
+++ b/app/scripts/services/dimBucketService.factory.js
@@ -48,7 +48,6 @@ const _ = require('underscore');
       ]
     });
 
-  BucketService.$inject = ['dimDefinitions', 'dimCategory'];
 
   function BucketService(dimDefinitions, dimCategory) {
     // A mapping from the bucket names to DIM item types

--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimBungieService', BungieService);
 
-  BungieService.$inject = ['$rootScope', '$q', '$timeout', '$http', '$state', 'dimState', 'toaster', '$translate'];
 
   function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaster, $translate) {
     var apiKey = localStorage.apiKey;

--- a/app/scripts/services/dimFarmingService.factory.js
+++ b/app/scripts/services/dimFarmingService.factory.js
@@ -7,19 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimFarmingService', FarmingService);
 
-  FarmingService.$inject = [
-    '$rootScope',
-    '$q',
-    'dimItemService',
-    'dimStoreService',
-    '$interval',
-    'toaster',
-    'dimFeatureFlags',
-    'dimSettingsService',
-    '$translate',
-    'dimBucketService'
-  ];
-
   /**
    * A service for "farming" items by moving them continuously off a character,
    * so that they don't go to the Postmaster.

--- a/app/scripts/services/dimInfoService.factory.js
+++ b/app/scripts/services/dimInfoService.factory.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimInfoService', InfoService);
 
-  InfoService.$inject = ['toaster', '$http', 'SyncService'];
 
   function InfoService(toaster, $http, SyncService) {
     return {

--- a/app/scripts/services/dimItemInfoService.factory.js
+++ b/app/scripts/services/dimItemInfoService.factory.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimItemInfoService', ItemInfoService);
 
-  ItemInfoService.$inject = ['dimPlatformService', 'SyncService'];
 
   /**
    * The item info service maintains a map of extra, DIM-specific, synced data about items (per platform).

--- a/app/scripts/services/dimItemMoveService.factory.js
+++ b/app/scripts/services/dimItemMoveService.factory.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimItemMoveService', ItemMoveService);
 
-  ItemMoveService.$inject = ['$q', 'loadingTracker', 'toaster', 'dimStoreService', 'dimActionQueue', 'dimItemService', 'dimInfoService', '$translate'];
 
   function ItemMoveService($q, loadingTracker, toaster, dimStoreService, dimActionQueue, dimItemService, dimInfoService, $translate) {
 // `<div> ${$translate.instant('BungieService.Twitter')} ${twitterLink}</div>`

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -7,15 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimItemService', ItemService);
 
-  ItemService.$inject = [
-    'dimStoreService',
-    'dimBungieService',
-    'dimCategory',
-    'dimFeatureFlags',
-    '$q',
-    '$translate'
-  ];
-
   function ItemService(dimStoreService,
                        dimBungieService,
                        dimCategory,

--- a/app/scripts/services/dimLoadoutService.factory.js
+++ b/app/scripts/services/dimLoadoutService.factory.js
@@ -8,7 +8,6 @@ const _ = require('underscore');
     .factory('dimLoadoutService', LoadoutService);
 
 
-  LoadoutService.$inject = ['$q', '$rootScope', '$translate', 'uuid2', 'dimItemService', 'dimStoreService', 'toaster', 'loadingTracker', 'dimPlatformService', 'SyncService', 'dimActionQueue'];
   function LoadoutService($q, $rootScope, $translate, uuid2, dimItemService, dimStoreService, toaster, loadingTracker, dimPlatformService, SyncService, dimActionQueue) {
     var _loadouts = [];
     var _previousLoadouts = {}; // by character ID

--- a/app/scripts/services/dimManifestService.factory.js
+++ b/app/scripts/services/dimManifestService.factory.js
@@ -9,7 +9,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimManifestService', ManifestService);
 
-  ManifestService.$inject = ['$q', 'dimBungieService', '$http', 'toaster', 'dimSettingsService', '$translate', '$rootScope'];
 
   function ManifestService($q, dimBungieService, $http, toaster, dimSettingsService, $translate, $rootScope) {
     // Testing flags

--- a/app/scripts/services/dimPlatformService.factory.js
+++ b/app/scripts/services/dimPlatformService.factory.js
@@ -6,7 +6,6 @@ const _ = require('underscore');
 
   angular.module('dimApp').factory('dimPlatformService', PlatformService);
 
-  PlatformService.$inject = ['$rootScope', '$q', 'dimBungieService', 'SyncService'];
 
   function PlatformService($rootScope, $q, dimBungieService, SyncService) {
     var _platforms = [];

--- a/app/scripts/services/dimSettingsService.factory.js
+++ b/app/scripts/services/dimSettingsService.factory.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimSettingsService', SettingsService);
 
-  SettingsService.$inject = ['$rootScope', 'SyncService', '$window', '$translate'];
 
   /**
    * The settings service provides a settings object which contains

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -7,24 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimStoreService', StoreService);
 
-  StoreService.$inject = [
-    '$rootScope',
-    '$q',
-    'dimBungieService',
-    'dimPlatformService',
-    'dimCategory',
-    'dimDefinitions',
-    'dimBucketService',
-    'dimItemInfoService',
-    'dimInfoService',
-    'SyncService',
-    'loadingTracker',
-    'dimManifestService',
-    '$translate',
-    'uuid2',
-    'dimFeatureFlags'
-  ];
-
   function StoreService(
     $rootScope,
     $q,

--- a/app/scripts/services/dimSyncService.factory.js
+++ b/app/scripts/services/dimSyncService.factory.js
@@ -4,7 +4,6 @@
   angular.module('dimApp')
     .factory('SyncService', SyncService);
 
-  SyncService.$inject = ['$q', '$window'];
 
   function SyncService($q, $window) {
     var cached; // cached is the data in memory,

--- a/app/scripts/services/dimVendorService.factory.js
+++ b/app/scripts/services/dimVendorService.factory.js
@@ -7,16 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimVendorService', VendorService);
 
-  VendorService.$inject = [
-    '$rootScope',
-    'dimBungieService',
-    'dimStoreService',
-    'dimDefinitions',
-    'dimFeatureFlags',
-    'dimPlatformService',
-    '$q'
-  ];
-
   function VendorService(
     $rootScope,
     dimBungieService,

--- a/app/scripts/services/dimXurService.factory.js
+++ b/app/scripts/services/dimXurService.factory.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .factory('dimXurService', XurService);
 
-  XurService.$inject = ['$rootScope', '$q', 'dimBungieService', 'dimDefinitions', 'dimStoreService', '$http'];
 
   function XurService($rootScope, $q, dimBungieService, dimDefinitions, dimStoreService, $http) {
     var xurTest = false; // set this to true when you want to test but Xur's not around

--- a/app/scripts/shell/dimAppCtrl.controller.js
+++ b/app/scripts/shell/dimAppCtrl.controller.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .controller('dimAppCtrl', DimApp);
 
-  DimApp.$inject = ['ngDialog', '$rootScope', 'loadingTracker', 'dimPlatformService', '$interval', 'hotkeys', '$timeout', 'dimStoreService', 'dimXurService', 'dimSettingsService', '$window', '$scope', '$state', 'dimFeatureFlags', 'dimVendorService'];
 
   function DimApp(ngDialog, $rootScope, loadingTracker, dimPlatformService, $interval, hotkeys, $timeout, dimStoreService, dimXurService, dimSettingsService, $window, $scope, $state, dimFeatureFlags, dimVendorService) {
     var vm = this;

--- a/app/scripts/shell/dimClickAnywhereButHere.directive.js
+++ b/app/scripts/shell/dimClickAnywhereButHere.directive.js
@@ -2,7 +2,6 @@
   angular.module('dimApp')
     .directive('dimClickAnywhereButHere', ClickAnywhereButHere);
 
-  ClickAnywhereButHere.$inject = ['$document'];
 
   function ClickAnywhereButHere($document) {
     return {

--- a/app/scripts/shell/dimFilterLink.directive.js
+++ b/app/scripts/shell/dimFilterLink.directive.js
@@ -14,7 +14,6 @@
       }
     });
 
-  FilterLinkCtrl.$inject = ['dimSearchService', '$window', '$translate'];
   function FilterLinkCtrl(dimSearchService, $window, $translate) {
     this.addFilter = function(filter) {
       var itemNameFilter = false;

--- a/app/scripts/shell/dimManifestProgress.directive.js
+++ b/app/scripts/shell/dimManifestProgress.directive.js
@@ -15,7 +15,6 @@
       controller: ManifestProgressCtrl
     });
 
-  ManifestProgressCtrl.$inject = ['dimManifestService'];
   function ManifestProgressCtrl(dimManifestService) {
     this.manifest = dimManifestService;
   }

--- a/app/scripts/shell/dimMaterialsExchangeCtrl.controller.js
+++ b/app/scripts/shell/dimMaterialsExchangeCtrl.controller.js
@@ -6,7 +6,6 @@ const _ = require('underscore');
 
   angular.module('dimApp').controller('dimMaterialsExchangeCtrl', MaterialsController);
 
-  MaterialsController.$inject = ['$scope', 'dimItemService', 'dimStoreService', '$state', 'dimFeatureFlags'];
 
   function MaterialsController($scope, dimItemService, dimStoreService, $state, dimFeatureFlags) {
     if (!dimFeatureFlags.materialsExchangeEnabled) {

--- a/app/scripts/shell/dimPlatformChoice.directive.js
+++ b/app/scripts/shell/dimPlatformChoice.directive.js
@@ -4,7 +4,6 @@
   angular.module('dimApp')
     .directive('dimPlatformChoice', PlatformChoice);
 
-  PlatformChoice.$inject = [];
 
   function PlatformChoice() {
     return {
@@ -20,7 +19,6 @@
     };
   }
 
-  PlatformChoiceCtrl.$inject = ['$scope', 'dimPlatformService', 'dimState', 'loadingTracker'];
 
   function PlatformChoiceCtrl($scope, dimPlatformService, dimState, loadingTracker) {
     var vm = this;

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -8,7 +8,6 @@ const _ = require('underscore');
     .factory('dimSearchService', SearchService)
     .directive('dimSearchFilter', SearchFilter);
 
-  SearchService.$inject = ['dimSettingsService', 'dimFeatureFlags'];
   function SearchService(dimSettingsService, dimFeatureFlags) {
     const categoryFilters = {
       pulserifle: ['CATEGORY_PULSE_RIFLE'],
@@ -104,7 +103,6 @@ const _ = require('underscore');
     };
   }
 
-  SearchFilter.$inject = ['dimSearchService'];
 
   function SearchFilter(dimSearchService) {
     return {
@@ -138,7 +136,6 @@ const _ = require('underscore');
     };
   }
 
-  SearchFilterCtrl.$inject = ['$scope', 'dimStoreService', 'dimVendorService', 'dimSearchService'];
 
   function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchService) {
     var vm = this;

--- a/app/scripts/shell/dimSettingsCtrl.controller.js
+++ b/app/scripts/shell/dimSettingsCtrl.controller.js
@@ -6,7 +6,6 @@ const _ = require('underscore');
 
   angular.module('dimApp').controller('dimSettingsCtrl', SettingsController);
 
-  SettingsController.$inject = ['dimSettingsService', '$scope', 'SyncService', 'dimCsvService', 'dimStoreService', 'dimInfoService', 'dimFeatureFlags'];
 
   function SettingsController(settings, $scope, SyncService, dimCsvService, dimStoreService, dimInfoService, dimFeatureFlags) {
     var vm = this;

--- a/app/scripts/shell/dimSettingsCtrl.controller.js
+++ b/app/scripts/shell/dimSettingsCtrl.controller.js
@@ -7,13 +7,13 @@ const _ = require('underscore');
   angular.module('dimApp').controller('dimSettingsCtrl', SettingsController);
 
 
-  function SettingsController(settings, $scope, SyncService, dimCsvService, dimStoreService, dimInfoService, dimFeatureFlags) {
+  function SettingsController(dimSettingsService, $scope, SyncService, dimCsvService, dimStoreService, dimInfoService, dimFeatureFlags) {
     var vm = this;
 
     vm.featureFlags = dimFeatureFlags;
 
     $scope.$watchCollection('vm.settings', function() {
-      settings.save();
+      dimSettingsService.save();
     });
 
     vm.charColOptions = _.range(3, 6).map((num) => ({ id: num, name: num }));
@@ -30,7 +30,7 @@ const _ = require('underscore');
       ja: '日本語'
     };
 
-    vm.settings = settings;
+    vm.settings = dimSettingsService;
 
     vm.showSync = function() {
       return SyncService.drive();

--- a/app/scripts/store/dimClearNewItems.directive.js
+++ b/app/scripts/store/dimClearNewItems.directive.js
@@ -14,7 +14,6 @@
       controller: ClearNewItemsCtrl
     });
 
-  ClearNewItemsCtrl.$inject = ['dimStoreService', 'dimSettingsService'];
   function ClearNewItemsCtrl(dimStoreService, dimSettingsService) {
     this.storeService = dimStoreService;
     this.settings = dimSettingsService;

--- a/app/scripts/store/dimFarming.directive.js
+++ b/app/scripts/store/dimFarming.directive.js
@@ -30,7 +30,6 @@
     };
   }
 
-  FarmingCtrl.$inject = ['dimFarmingService', 'dimItemMoveService', 'dimSettingsService'];
 
   function FarmingCtrl(dimFarmingService, dimItemMoveService, dimSettingsService) {
     var vm = this;

--- a/app/scripts/store/dimSimpleItem.directive.js
+++ b/app/scripts/store/dimSimpleItem.directive.js
@@ -28,7 +28,6 @@
     };
   }
 
-  dimItemSimpleCtrl.$inject = [];
 
   function dimItemSimpleCtrl() {
     // nothing to do here...only needed for bindToController

--- a/app/scripts/store/dimStats.directive.js
+++ b/app/scripts/store/dimStats.directive.js
@@ -4,7 +4,6 @@
   angular.module('dimApp')
     .directive('dimStats', Stats);
 
-  Stats.$inject = [];
 
   function Stats() {
     return {
@@ -27,7 +26,6 @@
     };
   }
 
-  StatsCtrl.$inject = ['$scope', '$translate'];
 
   function StatsCtrl($scope, $translate) {
     var vm = this;

--- a/app/scripts/store/dimStoreBucket.directive.js
+++ b/app/scripts/store/dimStoreBucket.directive.js
@@ -40,22 +40,6 @@ const _ = require('underscore');
     };
   }
 
-  StoreBucketCtrl.$inject = [
-    '$scope',
-    'loadingTracker',
-    'dimStoreService',
-    'dimItemService',
-    '$q',
-    '$timeout',
-    'toaster',
-    'dimSettingsService',
-    'ngDialog',
-    '$rootScope',
-    'dimActionQueue',
-    'dimFeatureFlags',
-    'dimInfoService',
-    '$translate'];
-
   function StoreBucketCtrl($scope,
                            loadingTracker,
                            dimStoreService,

--- a/app/scripts/store/dimStoreHeading.directive.js
+++ b/app/scripts/store/dimStoreHeading.directive.js
@@ -44,7 +44,6 @@ const _ = require('underscore');
     };
   }
 
-  StoreHeadingCtrl.$inject = ['$scope', 'ngDialog'];
 
   function StoreHeadingCtrl($scope, ngDialog) {
     var vm = this;

--- a/app/scripts/store/dimStoreItem.directive.js
+++ b/app/scripts/store/dimStoreItem.directive.js
@@ -23,7 +23,6 @@
     }]);
 
 
-  StoreItem.$inject = ['dimItemService', 'dimStoreService', 'ngDialog', 'dimLoadoutService', 'dimCompareService', '$rootScope', 'dimActionQueue'];
 
   function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService, dimCompareService, $rootScope, dimActionQueue) {
     var otherDialog = null;
@@ -224,7 +223,6 @@
     }
   }
 
-  StoreItemCtrl.$inject = [];
 
   function StoreItemCtrl() {
     var vm = this;

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -58,7 +58,6 @@ const _ = require('underscore');
     }
   }
 
-  StoresCtrl.$inject = ['dimSettingsService', '$scope', 'dimStoreService', 'dimPlatformService', 'loadingTracker', 'dimBucketService', 'dimInfoService', '$translate'];
 
   function StoresCtrl(settings, $scope, dimStoreService, dimPlatformService, loadingTracker, dimBucketService, dimInfoService, $translate) {
     var vm = this;

--- a/app/scripts/store/dimStores.directive.js
+++ b/app/scripts/store/dimStores.directive.js
@@ -59,7 +59,7 @@ const _ = require('underscore');
   }
 
 
-  function StoresCtrl(settings, $scope, dimStoreService, dimPlatformService, loadingTracker, dimBucketService, dimInfoService, $translate) {
+  function StoresCtrl(dimSettingsService, $scope, dimStoreService, dimPlatformService, loadingTracker, dimBucketService, dimInfoService, $translate) {
     var vm = this;
     const didYouKnowTemplate = `<p>${$translate.instant('DidYouKnow.Collapse')}</p>` +
                                `<p>${$translate.instant('DidYouKnow.Expand')}</p>`;
@@ -72,7 +72,7 @@ const _ = require('underscore');
       });
     });
 
-    vm.settings = settings;
+    vm.settings = dimSettingsService;
     vm.stores = dimStoreService.getStores();
     vm.vault = dimStoreService.getVault();
     vm.buckets = null;

--- a/app/scripts/vendors/dimVendor.controller.js
+++ b/app/scripts/vendors/dimVendor.controller.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .controller('dimVendorCtrl', dimVendorCtrl);
 
-  dimVendorCtrl.$inject = ['$scope', '$state', '$q', 'dimStoreService', 'dimSettingsService', 'dimVendorService'];
 
   function dimVendorCtrl($scope, $state, $q, dimStoreService, dimSettingsService, dimVendorService) {
     var vm = this;

--- a/app/scripts/vendors/dimVendorCurrencies.directive.js
+++ b/app/scripts/vendors/dimVendorCurrencies.directive.js
@@ -20,7 +20,6 @@
   angular.module('dimApp')
     .component('dimVendorCurrencies', VendorCurrencies);
 
-  VendorCurrenciesCtrl.$inject = ['$scope', '$filter'];
 
   function VendorCurrenciesCtrl($scope, $filter) {
     const vm = this;

--- a/app/scripts/vendors/dimVendorItems.directive.js
+++ b/app/scripts/vendors/dimVendorItems.directive.js
@@ -90,7 +90,6 @@ const _ = require('underscore');
 
   // TODO: separate out class-specific stuff?
 
-  VendorItemsCtrl.$inject = ['$scope', 'ngDialog', 'dimStoreService', 'dimSettingsService'];
 
   function VendorItemsCtrl($scope, ngDialog, dimStoreService, dimSettingsService) {
     var vm = this;

--- a/app/scripts/xur/dimXur.controller.js
+++ b/app/scripts/xur/dimXur.controller.js
@@ -7,7 +7,6 @@ const _ = require('underscore');
   angular.module('dimApp')
     .controller('dimXurCtrl', dimXurCtrl);
 
-  dimXurCtrl.$inject = ['$scope', 'dimXurService', 'ngDialog', 'dimStoreService'];
 
   function dimXurCtrl($scope, dimXurService, ngDialog, dimStoreService) {
     var vm = this;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "autoprefixer": "^6.3.7",
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
+    "babel-plugin-angularjs-annotate": "^0.6.0",
     "babel-preset-env": "^1.1.4",
     "babel-preset-es2015": "^6.18.0",
     "bower": "^1.7.9",


### PR DESCRIPTION
One of the reasons I've been excited about babel was the opportunity to use [angularjs-annotate](https://www.npmjs.com/package/babel-plugin-angularjs-annotate) which will automatically generate all the `$inject` statements for making Angular components minify-safe. No more repetition (and bugs when you mess up).

/cc @joshhunt 