### PR TITLE
Make room for Postmaster auto loadout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Removed farming option to keep greens since they're disassembled by default now.
 * Added stat search, for example: "stat:rof:>= 22"
 * Fixed formatting for search loadouts when the search terms contain angle brackets.
+* A new "Make room for Postmaster items" auto layout will clear out enough space on your character to pick up all the stuff you've accumulated at the Postmaster.
 
 # 3.15.0
 

--- a/app/scripts/dimApp.i18n.js
+++ b/app/scripts/dimApp.i18n.js
@@ -214,7 +214,10 @@
             Applied: "Your {amount, plural, =1{single item loadout has} other{loadout of # items have}} been transferred to your {store}.",
             AppliedError: "None of the items in your loadout could be transferred.",
             AppliedWarn: "Your loadout has been partially transferred, but {failed} of {total} items had errors.",
-            NameRequired: "A name is required."
+            NameRequired: "A name is required.",
+            MakeRoom: "Make Room for Postmaster",
+            MakeRoomDone: "Finished making room for {postmasterNum, plural, =1{1 Postmaster item} other{# Postmaster items}} by moving {movedNum, plural, =1{1 item} other{# items}} off of {store}.",
+            MakeRoomError: "Unable to make room for all Postmaster items: {error}."
           },
           Manifest: {
             Build: "Building Destiny info database",

--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -82,7 +82,7 @@
         while (removeAmount > 0) {
           var sourceItem = sourceItems.shift();
           if (!sourceItem) {
-            throw new Error($translate.instant('ItemService.TooMany'));
+            throw new Error($translate.instant('ItemService.TooMuch'));
           }
 
           var amountToRemove = Math.min(removeAmount, sourceItem.amount);
@@ -625,7 +625,7 @@
         // Refresh the stores to see if anything has changed
         var reloadPromise = throttledReloadStores() || $q.when(dimStoreService.getStores());
         return reloadPromise.then(function(stores) {
-          store = _.find(stores, { id: store.id });
+          var store = _.find(stores, { id: store.id });
           options.triedFallback = true;
           return canMoveToStore(item, store, options);
         });


### PR DESCRIPTION
<img width="264" alt="screen shot 2017-01-03 at 12 13 20 am" src="https://cloud.githubusercontent.com/assets/313208/21602554/ecaab5d2-d149-11e6-8230-d1b151dcd2b0.png">

This new auto loadout will move aside enough stuff from your character so that you can pick up everything in the Postmaster. It's super convenient! It follows the same rules for picking items to move as Farming Mode does.

This fixes #502. It's basically the same code as the "make room" code from Farming Mode, but with some customizations. I have longer-term plans to consolidate all of it, but for now they each have their own special copy.