### PR TITLE
Fix #1335, which as far as I can tell is a Chrome bug?

### DIFF
--- a/app/scripts/services/dimItemService.factory.js
+++ b/app/scripts/services/dimItemService.factory.js
@@ -624,8 +624,9 @@
       } else {
         // Refresh the stores to see if anything has changed
         var reloadPromise = throttledReloadStores() || $q.when(dimStoreService.getStores());
-        return reloadPromise.then(function(stores) {
-          var store = _.find(stores, { id: store.id });
+        const storeId = store.id;
+        return reloadPromise.then((stores) => {
+          var store = _.find(stores, { id: storeId });
           options.triedFallback = true;
           return canMoveToStore(item, store, options);
         });


### PR DESCRIPTION
The code in question, which reloads stores and retries if you don't have space do do a move, hasn't changed since July or so, and it's been working fine. Now, all of a sudden, it's failing to capture `store` in the `then` handler. Pausing at the debugger or using `console.log` confirms that `store` is present outside the closure, and `undefined` within. Capturing just the ID appears to fix it. While I'm generally hesitant to blame browser bugs, this sounds like a bad optimization in a recent V8, or maybe store is getting (improperly) garbage collected before the closure is run. I haven't found the right search terms to find any existing bug report.