### PR TITLE
Styling touchups to compare tool

### DIFF
--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -18,10 +18,8 @@
             <label ng-if="vm.similarTypes.length > 1" class="dim-button" ng-click="vm.compareSimilar()" translate="Compare.All" translate-values="{ type: vm.compare.typeName, quantity: vm.similarTypes.length}"></label>
             <label class="dim-button" ng-click="vm.cancel()" translate>Compare.Close</label>
           </p>
-          <!-- TODO: css hover -->
           <div class="compare-bucket" ng-mouseleave="vm.highlight = null">
             <span class="compare-item fixed-left">
-              <!-- TODO: get rid of this, use a table! -->
               <div>&nbsp;</div>
               <div>&nbsp;</div>
               <div ng-class="{highlight: vm.highlight === vm.comparisons[0].primStat.statHash, sorted: vm.sortedHash === vm.comparisons[0].primStat.statHash}" ng-mouseover="vm.highlight = vm.comparisons[0].primStat.statHash" ng-click="vm.sort(vm.comparisons[0].primStat.statHash)" ng-bind="vm.comparisons[0].primStat.stat.statName"></div>

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -42,7 +42,7 @@
             </span>
             <span ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
               <dim-item-tag ng-if="vm.featureFlags.tagsEnabled" item="item"></dim-item-tag>
-              <div ng-bind="::item.name" class="item-name"></div>
+              <div ng-bind="::item.name" class="item-name" ng-click="vm.itemClick(item)"></div>
               <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-click="vm.sort(item.primStat.statHash)" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">
                 <span ng-bind="item.primStat.value"></span>
               </div>
@@ -151,6 +151,18 @@
         vm.cancel();
         return;
       }
+    };
+
+    vm.itemClick = function itemClick(item) {
+      const element = angular.element('#' + item.hash + '-' + item.id);
+      const elementRect = element[0].getBoundingClientRect();
+      const absoluteElementTop = elementRect.top + window.pageYOffset;
+      const middle = absoluteElementTop - (window.innerHeight / 2);
+      window.scrollTo(0, middle);
+      element.addClass('item-pop');
+      element.on('webkitAnimationEnd oanimationend msAnimationEnd animationend', () => {
+        element.removeClass('item-pop');
+      });
     };
 
     $scope.$watch('vm.comparisons', function() {

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -46,10 +46,11 @@
                 <img ng-if="item.dmg && item.dmg !== \'kinetic\'" class="elemental" ng-src="/images/{{::item.dmg}}.png"/>
                 {{::item.name}}
               </div>
-              <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-click="vm.sort(item.primStat.statHash)" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">
+              <dim-simple-item item-data="item"></dim-simple-item>
+              <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">
                 <span ng-bind="item.primStat.value"></span>
               </div>
-              <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="stat | statRange:vm.statRanges | qualityColor:'color'">
+              <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-repeat="stat in item.stats track by $index" ng-style="stat | statRange:vm.statRanges | qualityColor:'color'">
                 <span ng-bind="::stat.value"></span>
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
               </div>
@@ -159,8 +160,7 @@
       const element = angular.element('#' + item.hash + '-' + item.id);
       const elementRect = element[0].getBoundingClientRect();
       const absoluteElementTop = elementRect.top + window.pageYOffset;
-      const middle = absoluteElementTop - (window.innerHeight / 2);
-      window.scrollTo(0, middle);
+      window.scrollTo(0, absoluteElementTop - 150);
       element.addClass('item-pop');
       element.on('webkitAnimationEnd oanimationend msAnimationEnd animationend', () => {
         element.removeClass('item-pop');

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -42,10 +42,7 @@
             <div ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
               <div class="close" ng-click="vm.remove(item);"></div>
               <dim-item-tag ng-if="vm.featureFlags.tagsEnabled" item="item"></dim-item-tag>
-              <div class="item-name" ng-click="vm.itemClick(item)">
-                <img ng-if="item.dmg && item.dmg !== \'kinetic\'" class="elemental" ng-src="/images/{{::item.dmg}}.png"/>
-                {{::item.name}}
-              </div>
+              <div class="item-name" ng-click="vm.itemClick(item)" ng-bind="::item.name"></div>
               <dim-simple-item item-data="item"></dim-simple-item>
               <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">
                 <span ng-bind="item.primStat.value"></span>

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -24,11 +24,15 @@
               <!-- TODO: get rid of this, use a table! -->
               <div>&nbsp;</div>
               <div>&nbsp;</div>
+              <div ng-class="{highlight: vm.highlight === vm.comparisons[0].primStat.statHash, sorted: vm.sortedHash === vm.comparisons[0].primStat.statHash}" ng-mouseover="vm.highlight = vm.comparisons[0].primStat.statHash" ng-click="vm.sort(vm.comparisons[0].primStat.statHash)" ng-bind="vm.comparisons[0].primStat.stat.statName"></div>
               <div ng-class="{highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by stat.statHash" ng-bind="::stat.name"></div>
             </span>
             <span ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
               <dim-item-tag ng-if="vm.featureFlags.tagsEnabled" item="item"></dim-item-tag>
               <div ng-bind="::item.name" class="item-name"></div>
+              <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-click="vm.sort(item.primStat.statHash)">
+                <span ng-bind="item.primStat.value"></span>
+              </div>
               <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="vm.compare.location.inWeapons ? (stat.value === vm.statRanges[stat.statHash].max ? 100 : (100 * stat.value - vm.statRanges[stat.statHash].min) / vm.statRanges[stat.statHash].max) : (stat.qualityPercentage.min) | qualityColor:'color'">
                 <span ng-bind="::stat.value"></span>
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -31,13 +31,11 @@
               <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-click="vm.sort(item.primStat.statHash)">
                 <span ng-bind="item.primStat.value"></span>
               </div>
-              <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="vm.statRanges[stat.statHash].max == vm.statRanges[stat.statHash].min ? -1 : vm.compare.location.inWeapons ? (stat.value === vm.statRanges[stat.statHash].max ? 100 : (100 * stat.value - vm.statRanges[stat.statHash].min) / vm.statRanges[stat.statHash].max) : (stat.qualityPercentage.min) | qualityColor:'color'">
+              <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="vm.statRanges[stat.statHash].enabled ? vm.compare.location.inWeapons ? (stat.value === vm.statRanges[stat.statHash].max ? 100 : (100 * stat.value - vm.statRanges[stat.statHash].min) / vm.statRanges[stat.statHash].max) : (stat.qualityPercentage.min) : -1 | qualityColor:'color'">
                 <span ng-bind="::stat.value"></span>
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
               </div>
-              <div ng-repeat="node in vm.talentGrids[item.id].nodes" title="{{node.description}}">
-               {{node.name}}
-              </div>
+              <dim-talent-grid ng-if="item.talentGrid" talent-grid="item.talentGrid"></dim-talent-grid>
               <div class="close" ng-click="vm.remove(item);"></div>
             </span>
           </div>
@@ -157,39 +155,6 @@
         statRange.enabled = statRange.min !== statRange.max;
         vm.statRanges[hash] = statRange;
       });
-
-      const nodeCounts = {};
-      vm.talentGrids = {};
-      _.each(vm.comparisons, (item) => {
-        _.each(item.talentGrid.nodes, (node) => {
-          if (!nodeCounts[node.hash]) {
-            nodeCounts[node.hash] = 0;
-          }
-          nodeCounts[node.hash]++;
-        });
-      });
-
-      const commonNodes = new Set();
-      _.each(nodeCounts, (count, hash) => {
-        if (count === vm.comparisons.length) {
-          commonNodes.add(hash);
-        }
-      });
-
-      vm.talentGrids = {};
-      _.each(vm.comparisons, (item) => {
-        vm.talentGrids[item.id] = trimTalentGrid(item.talentGrid, commonNodes, nodeCounts);
-      });
-    }, true);
-
-    function trimTalentGrid(talentGrid, commonNodes, nodeCounts) {
-      const trimmedGrid = angular.copy(talentGrid);
-      trimmedGrid.nodes = _.reject(trimmedGrid.nodes, (n) => commonNodes.has(n.hash.toString()));
-      if (trimmedGrid.nodes.length) {
-        return trimmedGrid;
-      } else {
-        return null;
-      }
     }
   }
 })();

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -6,12 +6,12 @@
     .filter('statRange', function() {
       return function(stat, statRanges) {
         const statRange = statRanges[stat.statHash];
-        if (!statRange.enabled) {
-          return -1;
-        }
-
         if (stat.qualityPercentage) {
           return stat.qualityPercentage.min;
+        }
+
+        if (!statRange.enabled) {
+          return -1;
         }
 
         return 100 * (stat.value - statRange.min) / (statRange.max - statRange.min);
@@ -28,21 +28,24 @@
       scope: {},
       template: `
         <div id="loadout-drawer" ng-if="vm.show">
-          <p>
+          <div class="compare-options">
             <label ng-if="vm.archeTypes.length > 1" class="dim-button" ng-click="vm.compareSimilar('archetype')" translate="{{ vm.compare.location.inWeapons ? 'Compare.Archetype' : 'Compare.Splits'}}" translate-values="{ quantity:  vm.archeTypes.length }"></label>
             <label ng-if="vm.similarTypes.length > 1" class="dim-button" ng-click="vm.compareSimilar()" translate="Compare.All" translate-values="{ type: vm.compare.typeName, quantity: vm.similarTypes.length}"></label>
             <label class="dim-button" ng-click="vm.cancel()" translate>Compare.Close</label>
-          </p>
+          </div>
           <div class="compare-bucket" ng-mouseleave="vm.highlight = null">
-            <span class="compare-item fixed-left">
-              <div>&nbsp;</div>
-              <div>&nbsp;</div>
+            <div class="compare-item fixed-left">
+              <div class="spacer" ng-class="{withTags: vm.featureFlags.tagsEnabled}"></div>
               <div ng-class="{highlight: vm.highlight === vm.comparisons[0].primStat.statHash, sorted: vm.sortedHash === vm.comparisons[0].primStat.statHash}" ng-mouseover="vm.highlight = vm.comparisons[0].primStat.statHash" ng-click="vm.sort(vm.comparisons[0].primStat.statHash)" ng-bind="vm.comparisons[0].primStat.stat.statName"></div>
               <div ng-class="{highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by stat.statHash" ng-bind="::stat.name"></div>
-            </span>
-            <span ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
+            </div>
+            <div ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
+              <div class="close" ng-click="vm.remove(item);"></div>
               <dim-item-tag ng-if="vm.featureFlags.tagsEnabled" item="item"></dim-item-tag>
-              <div ng-bind="::item.name" class="item-name" ng-click="vm.itemClick(item)"></div>
+              <div class="item-name" ng-click="vm.itemClick(item)">
+                <img ng-if="item.dmg && item.dmg !== \'kinetic\'" class="elemental" ng-src="/images/{{::item.dmg}}.png"/>
+                {{::item.name}}
+              </div>
               <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-click="vm.sort(item.primStat.statHash)" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">
                 <span ng-bind="item.primStat.value"></span>
               </div>
@@ -51,8 +54,7 @@
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
               </div>
               <dim-talent-grid ng-if="item.talentGrid" talent-grid="item.talentGrid"></dim-talent-grid>
-              <div class="close" ng-click="vm.remove(item);"></div>
-            </span>
+            </div>
           </div>
         </div>
       `

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -31,7 +31,9 @@
                 <span ng-bind="::stat.value"></span>
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
               </div>
-              <dim-talent-grid ng-if="item.talentGrid" talent-grid="item.talentGrid"></dim-talent-grid>
+              <div ng-repeat="node in vm.talentGrids[item.id].nodes" title="{{node.description}}">
+               {{node.name}}
+              </div>
               <div class="close" ng-click="vm.remove(item);"></div>
             </span>
           </div>
@@ -149,6 +151,40 @@
           max: Math.max(...bucket)
         };
       });
+
+
+      const nodeCounts = {};
+      vm.talentGrids = {};
+      _.each(vm.comparisons, (item) => {
+        _.each(item.talentGrid.nodes, (node) => {
+          if (!nodeCounts[node.hash]) {
+            nodeCounts[node.hash] = 0;
+          }
+          nodeCounts[node.hash]++;
+        });
+      });
+
+      const commonNodes = new Set();
+      _.each(nodeCounts, (count, hash) => {
+        if (count === vm.comparisons.length) {
+          commonNodes.add(hash);
+        }
+      });
+
+      vm.talentGrids = {};
+      _.each(vm.comparisons, (item) => {
+        vm.talentGrids[item.id] = trimTalentGrid(item.talentGrid, commonNodes);
+      });
     }, true);
+
+    function trimTalentGrid(talentGrid, commonNodes) {
+      const trimmedGrid = angular.copy(talentGrid);
+      trimmedGrid.nodes = _.reject(trimmedGrid.nodes, (n) => commonNodes.has(n.hash.toString()));
+      if (trimmedGrid.nodes.length) {
+        return trimmedGrid;
+      } else {
+        return null;
+      }
+    }
   }
 })();

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -18,13 +18,15 @@
             <label ng-if="vm.similarTypes.length > 1" class="dim-button" ng-click="vm.compareSimilar()" translate="Compare.All" translate-values="{ type: vm.compare.typeName, quantity: vm.similarTypes.length}"></label>
             <label class="dim-button" ng-click="vm.cancel()" translate>Compare.Close</label>
           </p>
+          <!-- TODO: css hover -->
           <div class="compare-bucket" ng-mouseleave="vm.highlight = null">
             <span class="compare-item fixed-left">
+              <!-- TODO: get rid of this, use a table! -->
               <div>&nbsp;</div>
               <div>&nbsp;</div>
-              <div ng-class="{highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by $index" ng-bind="::stat.name"></div>
+              <div ng-class="{highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by stat.statHash" ng-bind="::stat.name"></div>
             </span>
-            <span ng-repeat="item in vm.comparisons track by item.index" class="compare-item">
+            <span ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
               <dim-item-tag ng-if="vm.featureFlags.tagsEnabled" item="item"></dim-item-tag>
               <div ng-bind="::item.name" class="item-name"></div>
               <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="vm.compare.location.inWeapons ? (stat.value === vm.statRanges[stat.statHash].max ? 100 : (100 * stat.value - vm.statRanges[stat.statHash].min) / vm.statRanges[stat.statHash].max) : (stat.qualityPercentage.min) | qualityColor:'color'">
@@ -146,12 +148,13 @@
 
       vm.statRanges = {};
       _.each(statBuckets, function(bucket, hash) {
-        vm.statRanges[hash] = {
+        const statRange = {
           min: Math.min(...bucket),
           max: Math.max(...bucket)
         };
+        statRange.enabled = statRange.min !== statRange.max;
+        vm.statRanges[hash] = statRange;
       });
-
 
       const nodeCounts = {};
       vm.talentGrids = {};
@@ -173,11 +176,11 @@
 
       vm.talentGrids = {};
       _.each(vm.comparisons, (item) => {
-        vm.talentGrids[item.id] = trimTalentGrid(item.talentGrid, commonNodes);
+        vm.talentGrids[item.id] = trimTalentGrid(item.talentGrid, commonNodes, nodeCounts);
       });
     }, true);
 
-    function trimTalentGrid(talentGrid, commonNodes) {
+    function trimTalentGrid(talentGrid, commonNodes, nodeCounts) {
       const trimmedGrid = angular.copy(talentGrid);
       trimmedGrid.nodes = _.reject(trimmedGrid.nodes, (n) => commonNodes.has(n.hash.toString()));
       if (trimmedGrid.nodes.length) {

--- a/app/scripts/compare/dimCompare.directive.js
+++ b/app/scripts/compare/dimCompare.directive.js
@@ -33,7 +33,7 @@
               <div ng-class="{highlight: vm.highlight === item.primStat.stat.statHash}" ng-mouseover="vm.highlight = item.primStat.statHash" ng-click="vm.sort(item.primStat.statHash)">
                 <span ng-bind="item.primStat.value"></span>
               </div>
-              <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="vm.compare.location.inWeapons ? (stat.value === vm.statRanges[stat.statHash].max ? 100 : (100 * stat.value - vm.statRanges[stat.statHash].min) / vm.statRanges[stat.statHash].max) : (stat.qualityPercentage.min) | qualityColor:'color'">
+              <div ng-class="{highlight: vm.highlight === stat.statHash}" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in item.stats track by $index" ng-style="vm.statRanges[stat.statHash].max == vm.statRanges[stat.statHash].min ? -1 : vm.compare.location.inWeapons ? (stat.value === vm.statRanges[stat.statHash].max ? 100 : (100 * stat.value - vm.statRanges[stat.statHash].min) / vm.statRanges[stat.statHash].max) : (stat.qualityPercentage.min) | qualityColor:'color'">
                 <span ng-bind="::stat.value"></span>
                 <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
               </div>

--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -193,7 +193,7 @@
       property = property || 'background-color';
       var color = 0;
       if (value < 0) {
-        return 'white';
+        return { [property]: 'white' };
       } else if (value <= 85) {
         color = 0;
       } else if (value <= 90) {

--- a/app/scripts/shell/dimAngularFilters.filter.js
+++ b/app/scripts/shell/dimAngularFilters.filter.js
@@ -192,7 +192,9 @@
     return function getColor(value, property) {
       property = property || 'background-color';
       var color = 0;
-      if (value <= 85) {
+      if (value < 0) {
+        return 'white';
+      } else if (value <= 85) {
         color = 0;
       } else if (value <= 90) {
         color = 20;
@@ -202,8 +204,6 @@
         color = 120;
       } else if (value >= 100) {
         color = 190;
-      } else {
-        return 'white';
       }
       var result = {};
       result[property] = 'hsl(' + color + ',85%,60%)';

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1454,20 +1454,28 @@ dim-compare {
   min-width: 150px;
   max-width: 150px;
   border-left: 1px solid $lightgray;
+
+  .item {
+    float: right;
+    margin: 0 4px 0 0;
+    z-index: -10;
+    .item-stat {
+      display: none;
+    }
+  }
   > div {
     padding-left: 4px;
     height: 16px;
   }
   .highlight {
-    color: white !important;
-    background-color: gray;
+    background-color: rgba(128, 128, 128, .25);
     cursor: pointer;
   }
   .item-name {
     text-overflow: ellipsis;
     overflow: hidden;
     cursor: pointer;
-    margin-bottom: 2px;
+    margin-bottom: 4px;
 
     .elemental {
       vertical-align: bottom;
@@ -1498,9 +1506,9 @@ dim-compare {
     }
   }
   .spacer {
-    height: 18px;
+    height: 20px;
     &.withTags {
-      height: 38px;
+      height: 40px;
     }
   }
 }

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1265,7 +1265,7 @@ rzslider {
 }
 
 .compare-bucket .talent-grid {
-  padding: 5px;
+  padding: 4px 2px 0 2px;
   box-sizing: border-box;
   width: 150px;
   height: auto;
@@ -1475,7 +1475,8 @@ dim-compare {
     text-overflow: ellipsis;
     overflow: hidden;
     cursor: pointer;
-    margin-bottom: 4px;
+    margin-top: 2px;
+    margin-bottom: 2px;
 
     .elemental {
       vertical-align: bottom;
@@ -1488,7 +1489,7 @@ dim-compare {
   .close {
     position: static;
     float: right;
-    margin: 0 4px;
+    margin: 1px 4px;
     padding-left: 0px;
   }
   .range {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1268,6 +1268,7 @@ rzslider {
   padding: 5px;
   box-sizing: border-box;
   width: 150px;
+  height: auto;
 }
 
 .talent-node-xp {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1462,6 +1462,7 @@ dim-compare {
   .item-name {
     text-overflow: ellipsis;
     overflow: hidden;
+    cursor: pointer;
   }
   .sorted {
     color: $orange;
@@ -1483,6 +1484,14 @@ dim-compare {
       width: 125px;
     }
   }
+}
+
+@keyframes pop {
+  to { transform: scale(1.5) }
+}
+.item-pop {
+  animation: .25s linear 2 alternate pop;
+  z-index: 1;
 }
 
 .loadout-content {

--- a/app/scss/_style.scss
+++ b/app/scss/_style.scss
@@ -1439,9 +1439,12 @@ dim-compare {
     border-left: none;
     position: fixed;
     left: 1em;
-    margin-top: 1px;
     min-width: 100px;
   }
+}
+
+.compare-options {
+  margin: 1em 0;
 }
 
 .compare-item {
@@ -1451,8 +1454,9 @@ dim-compare {
   min-width: 150px;
   max-width: 150px;
   border-left: 1px solid $lightgray;
-  div {
-    padding-left: 5px;
+  > div {
+    padding-left: 4px;
+    height: 16px;
   }
   .highlight {
     color: white !important;
@@ -1463,25 +1467,40 @@ dim-compare {
     text-overflow: ellipsis;
     overflow: hidden;
     cursor: pointer;
+    margin-bottom: 2px;
+
+    .elemental {
+      vertical-align: bottom;
+      margin: 0;
+    }
   }
   .sorted {
     color: $orange;
   }
   .close {
-    top: 0px;
-    right: 6px;
+    position: static;
+    float: right;
+    margin: 0 4px;
     padding-left: 0px;
   }
   .range {
     font-size: .9em;
   }
   dim-item-tag {
+    height: 20px;
+    margin-left: 5px;
     display: block;
     select {
       background: gray;
       border: none;
       color: white;
-      width: 125px;
+      width: 120px;
+    }
+  }
+  .spacer {
+    height: 18px;
+    &.withTags {
+      height: 38px;
     }
   }
 }


### PR DESCRIPTION
This is a handful of style tweaks to the compare tool. The changes are:

1. Add attack/defense stat.
3. If all the stats of a type are the same, show them in white rather than blue (there's nothing different, so it's not worth focusing on).
4. Show a picture of the item (with its completion border and tag icon).
5. When you click on the title of an item (but sadly not the picture - the click-to-sort-stat interfered) the item will be scrolled into view and a little "pop" animation will play. This really helps find the one item among many you're looking for.
6. Rows are always aligned, no matter if tags are enabled or not.
7. Overall things have been tweaked (a pixel here, a pixel there).
8. Fixed excessive space on the bottom of the talent grid.
1. Replace complicated style expressions with a filter.

<img width="419" alt="screen shot 2017-01-08 at 10 42 46 pm" src="https://cloud.githubusercontent.com/assets/313208/21758793/d2f674b0-d5f3-11e6-82a5-fa30ca742f0d.png">

These items' stats are all the same, so they're white:
<img width="405" alt="screen shot 2017-01-08 at 10 52 34 pm" src="https://cloud.githubusercontent.com/assets/313208/21758950/338bae70-d5f5-11e6-8a20-8ffbdbe4489b.png">

Pop when clicking the title:
<img width="1200" alt="screen shot 2017-01-08 at 10 36 27 pm" src="https://cloud.githubusercontent.com/assets/313208/21758777/9566cbd6-d5f3-11e6-8ce1-c47b520fa46e.gif">

Fixes #1284 by adding atk/defense - burn is unnecessary since it's in the talent grid (I added it but then removed it again once I realized that).
Fixes #1247 and #1213.
