### PR TITLE
Replace bungie.net with www.bungie.net in a few places

### DIFF
--- a/app/scripts/services/dimBungieService.factory.js
+++ b/app/scripts/services/dimBungieService.factory.js
@@ -26,7 +26,7 @@
     // Don't open bungie tab more than once a minute
     const openBungieNetTab = _.debounce(() => {
       chrome.tabs.create({
-        url: 'https://bungie.net',
+        url: 'https://www.bungie.net',
         active: true
       });
     }, 60 * 1000, true);

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -477,7 +477,7 @@
                 icon: 'https://www.bungie.net/' + character.emblemPath,
                 current: lastPlayedDate.getTime() === (new Date(character.characterBase.dateLastPlayed)).getTime(),
                 lastPlayed: character.characterBase.dateLastPlayed,
-                background: 'https://bungie.net/' + character.backgroundPath,
+                background: 'https://www.bungie.net/' + character.backgroundPath,
                 level: character.characterLevel,
                 powerLevel: character.characterBase.powerLevel,
                 stats: getCharacterStatsData(defs.Stat, character.characterBase),

--- a/app/views/de/about.html
+++ b/app/views/de/about.html
@@ -38,7 +38,7 @@
             </dl>
 <dl>
 <dt>Ich habe einen Gegenstand verloren durch eure Erweiterung verloren!</dt>
-                <dd>Sehr wahrscheinlich ist eine Übertragung fehlgeschlagen, so dass der Gegenstand im Tresor oder auf einem anderen Charakter gelandet ist. Du kannst nach dem Gegenstand suchen. Wenn du ihn trotzdem nicht findest, aktualisiere die App, indem du F5 drückst. Schau auf <a href="http://bungie.net" target="_blank">Bungie.net</a> oder im Spiel nach, um zu sehen wo sich der Gegenstand befindet. Wir sind sicher, er ist da.</dd>
+                <dd>Sehr wahrscheinlich ist eine Übertragung fehlgeschlagen, so dass der Gegenstand im Tresor oder auf einem anderen Charakter gelandet ist. Du kannst nach dem Gegenstand suchen. Wenn du ihn trotzdem nicht findest, aktualisiere die App, indem du F5 drückst. Schau auf <a href="https://www.bungie.net" target="_blank">Bungie.net</a> oder im Spiel nach, um zu sehen wo sich der Gegenstand befindet. Wir sind sicher, er ist da.</dd>
             </dl>
 <dl>
 <dt>Hey, DIM hat mein Gjallarhorn dupliziert!</dt>

--- a/app/views/en/about.html
+++ b/app/views/en/about.html
@@ -38,7 +38,7 @@
             </dl>
 <dl>
 <dt>I lost my item using your tool!</dt>
-                <dd>More than likely a transfer failed, leaving your item in the vault or on another character. You could search for the item. If that doesn't turn it up, refresh the app by pressing F5. Check <a href="http://bungie.net" target="_blank">Bungie.net</a> or in game to see if your item still exists. We're sure it's still there.</dd>
+                <dd>More than likely a transfer failed, leaving your item in the vault or on another character. You could search for the item. If that doesn't turn it up, refresh the app by pressing F5. Check <a href="https://www.bungie.net" target="_blank">Bungie.net</a> or in game to see if your item still exists. We're sure it's still there.</dd>
             </dl>
 <dl>
 <dt>Hey, DIM duplicated my Gjallarhorn!</dt>

--- a/app/views/es/about.html
+++ b/app/views/es/about.html
@@ -37,7 +37,7 @@
             </dl>
 <dl>
 <dt>¡Perdí mi artículo usando tu herramienta!</dt>
-                <dd>Es muy probable que la transferencia falló, lo cual deja tu artículo en el Depósito o en otro personaje. Puedes buscar ese objeto. Si incluso así no aparece, actualiza la aplicación presionando F5. Asegúrate de revisar <a href="http://bungie.net" target="_blank">Bungie.net</a> o en el juego para verificar que tu objeto todavía existe. Estamos seguros de que todavía esta ahí.</dd>
+                <dd>Es muy probable que la transferencia falló, lo cual deja tu artículo en el Depósito o en otro personaje. Puedes buscar ese objeto. Si incluso así no aparece, actualiza la aplicación presionando F5. Asegúrate de revisar <a href="https://www.bungie.net" target="_blank">Bungie.net</a> o en el juego para verificar que tu objeto todavía existe. Estamos seguros de que todavía esta ahí.</dd>
             </dl>
 <dl>
 <dt>Hey, DIM duplicó mi Gjallarhorn!</dt>

--- a/app/views/fr/about.html
+++ b/app/views/fr/about.html
@@ -38,7 +38,7 @@
             </dl>
 <dl>
 <dt>J'ai perdu mes objets en utilisant votre outil!</dt>
-                <dd>Il est plus que probable que votre transfer a échoué, laissant votre objet dans les coffres ou sur un autre perso. Vous pouvez rechercher votre objet. Si vous ne le trouvez pas, relancer l'app en appuyant sur F5. Verifiez <a href="http://bungie.net" target="_blank">Bungie.net</a> ou le jeu pour voir si votre objet existe toujours. Nous sommes sûres qu'il y est toujours.</dd>
+                <dd>Il est plus que probable que votre transfer a échoué, laissant votre objet dans les coffres ou sur un autre perso. Vous pouvez rechercher votre objet. Si vous ne le trouvez pas, relancer l'app en appuyant sur F5. Verifiez <a href="https://www.bungie.net" target="_blank">Bungie.net</a> ou le jeu pour voir si votre objet existe toujours. Nous sommes sûres qu'il y est toujours.</dd>
             </dl>
 <dl>
 <dt>Hey, DIM a dupliqué mon Gjallahorn!</dt>

--- a/app/views/it/about.html
+++ b/app/views/it/about.html
@@ -38,7 +38,7 @@
             </dl>
 <dl>
 <dt>Ho perso un mio oggetto utilizzando DIM!</dt>
-                <dd>Molto probabilmente un trasferimento fallito, che ha lasciato il tuo oggetto nel deposito o a un altro personaggio. Puoi cercare quell'oggetto. Se ciò non dovesse funzionare, aggiorna l'applicazione premendo F5. Controlla su <a href="http://bungie.net" target="_blank">Bungie.net</a> oppure nel gioco per vedere se il tuo oggetto esiste ancora. Siamo sicuri che è ancora lì.</dd>
+                <dd>Molto probabilmente un trasferimento fallito, che ha lasciato il tuo oggetto nel deposito o a un altro personaggio. Puoi cercare quell'oggetto. Se ciò non dovesse funzionare, aggiorna l'applicazione premendo F5. Controlla su <a href="https://www.bungie.net" target="_blank">Bungie.net</a> oppure nel gioco per vedere se il tuo oggetto esiste ancora. Siamo sicuri che è ancora lì.</dd>
             </dl>
 <dl>
 <dt>Hey, DIM ha duplicato il mio Gjallarhorn!</dt>

--- a/app/views/ja/about.html
+++ b/app/views/ja/about.html
@@ -38,7 +38,7 @@
             </dl>
 <dl>
 <dt>私はあなたのツールを使用して、私のアイテムを失いました！</dt>
-                <dd>More than likely a transfer failed, leaving your item in the vault or on another character. You could search for the item. If that doesn't turn it up, refresh the app by pressing F5. Check <a href="http://bungie.net" target="_blank">Bungie.net</a> or in game to see if your item still exists. We're sure it's still there.</dd>
+                <dd>More than likely a transfer failed, leaving your item in the vault or on another character. You could search for the item. If that doesn't turn it up, refresh the app by pressing F5. Check <a href="https://www.bungie.net" target="_blank">Bungie.net</a> or in game to see if your item still exists. We're sure it's still there.</dd>
             </dl>
 <dl>
 <dt>ちょっと、DIMは私のギャラルホルンを複製しました！</dt>

--- a/app/views/pt-br/about.html
+++ b/app/views/pt-br/about.html
@@ -38,7 +38,7 @@
             </dl>
 <dl>
 <dt>Eu perdi um item usando a ferramenta de vocês!</dt>
-                <dd>Muito provavelmente sua transferência falhou e seu item está no Cofre ou em outro personagem. Você pode usar o campo de busca para encontrá-lo. Caso não encontre, pressione F5 para atualizar a página. Verifique no <a href="http://bungie.net" target="_blank">Bungie.net</a> ou no próprio jogo se o item realmente existe. Temos plena certeza que ele está em algum lugar.</dd>
+                <dd>Muito provavelmente sua transferência falhou e seu item está no Cofre ou em outro personagem. Você pode usar o campo de busca para encontrá-lo. Caso não encontre, pressione F5 para atualizar a página. Verifique no <a href="https://www.bungie.net" target="_blank">Bungie.net</a> ou no próprio jogo se o item realmente existe. Temos plena certeza que ele está em algum lugar.</dd>
             </dl>
 <dl>
 <dt>Ei, o DIM duplicou minha Gjallarhorn!</dt>


### PR DESCRIPTION
I went through the code base and found the few remaining instances of 'bungie.net' in a live URL and replaced it with 'www.bungie.net'. A few get upgraded from http://bungie to https://www.bungie along the way. This pull request derived from #1359 where I discovered three images on the website being loaded from an unexpected origin.