### PR TITLE
CSV-escape the notes field if necessary

### DIFF
--- a/app/scripts/services/dimCsvService.factory.js
+++ b/app/scripts/services/dimCsvService.factory.js
@@ -84,7 +84,25 @@
         data += stats.Intellect ? stats.Intellect.value + "," : "0,";
         data += stats.Discipline ? stats.Discipline.value + "," : "0,";
         data += stats.Strength ? stats.Strength.value + "," : "0,";
-        data += ((item.dimInfo && item.dimInfo.notes) || '') + ",";
+
+        // the Notes column may need CSV escaping, as it's user-supplied input.
+        if (item.dimInfo && item.dimInfo.notes) {
+          // if any of these four characters are present, we have to escape it.
+          if (/[",\r\n]/.test(item.dimInfo.notes)) {
+            var notes = item.dimInfo.notes;
+            // emit the escaped data, wrapped in double quotes.
+            // any instances of " need to be changed to "" per RFC 4180.
+            // everything else is fine, as long as it's in double quotes.
+            data += '"' + notes.replace(/"/g, '""') + '",';
+          } else {
+            // no escaping required, append it as-is.
+            data += item.dimInfo.notes + ",";
+          }
+        } else {
+          // terminate the empty Notes column with a comma and continue.
+          data += ",";
+        }
+
         // if DB is out of date this can be null, can't hurt to be careful
         if (item.talentGrid) {
           data += buildNodeString(item.talentGrid.nodes);


### PR DESCRIPTION
CSV escaping is sort of a nightmare. Escaping is easy:

IF it contains ```,``` ```"``` ```\r``` ```\n```
THEN replace ```"``` with ```""``` and emit ```"```...```"``` surrounding the fie;d

Parsing is less easy. Some parsers will handle this correctly. Others
won't.

This patch takes a "can't be worse than before" approach to the problem:
rather than just blindly emitting the note ```"AAA,BBB"``` without even
*trying* to escape, which of course breaks the entire CSV, at least
escape it properly so that there's *some* hope of the parsing tools
being able to interpret the CSV correctly (and, specifically, the Perks
column which follows the Notes column).

After this patch, adding a Note to an item with the characters ```AAA",BBB```
should result in the CSV Notes field containing the chars ```"AAA"",BBB"```

Fixes #1370, if it passes testing.