### PR TITLE
Handle Google Analytics code initializing in a module

### DIFF
--- a/src/scripts/google.js
+++ b/src/scripts/google.js
@@ -7,7 +7,8 @@
   head.appendChild(script);
 })();
 
-var _gaq = _gaq || [];
+window._gaq = window._gaq || [];
+var _gaq = window._gaq;
 _gaq.push(['_setAccount', 'UA-60316581-1']);
 _gaq.push(['_setCustomVar', 1, 'DIMVersion', '$DIM_VERSION', 3]);
 _gaq.push(['_trackPageview']);


### PR DESCRIPTION
This should fix #1407 by making sure `_gaq` gets defined on `window`. I tested with the script loading code commented out to simulate an adblocker.