### PR TITLE
Tweaks and fixes to sync service, tags/notes, new-items, and loadouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+* Significantly increased the storage limit for tags and notes. It's still possible to go over (especially with long notes) but it should happen far less frequently - and it should notify you when it happens.
+
 # v3.16.0
 
 * Removed farming option to keep greens since they're disassembled by default now.

--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -117,6 +117,10 @@
       "TransferItems": "Transfer items",
       "Using3": "using 3"
    },
+   "ItemInfoService": {
+     "SaveInfoErrorTitle": "Error saving item info",
+     "SaveInfoErrorDescription": "There's been a problem saving DIM-specific info for an item. One problem is that there is a limit on how much data can be stored - this is why tags and notes have not yet been allowed out of the Beta version. The error was: {error}."
+   },
    "ItemMove": {
       "Consolidate": "Consolidated {name}",
       "Distributed": "Distributed {name}\n {name} is now equally divided between characters.",
@@ -215,7 +219,11 @@
       "NameRequired": "A name is required.",
       "MakeRoom": "Make Room for Postmaster",
       "MakeRoomDone": "Finished making room for {postmasterNum, plural, =1{1 Postmaster item} other{# Postmaster items}} by moving {movedNum, plural, =1{1 item} other{# items}} off of {store}.",
-      "MakeRoomError": "Unable to make room for all Postmaster items: {error}."
+      "MakeRoomError": "Unable to make room for all Postmaster items: {error}.",
+      "SaveErrorTitle": "Error saving loadout",
+      "SaveErrorDescription": "Unable to save loadout {loadoutName}: {error}.",
+      "DeleteErrorTitle": "Error deleting loadout",
+      "DeleteErrorDescription": "Unable to delete loadout {loadoutName}: {error}."
    },
    "Manifest": {
       "Build": "Building Destiny info database",

--- a/src/scripts/loadout/dimLoadout.directive.js
+++ b/src/scripts/loadout/dimLoadout.directive.js
@@ -121,7 +121,14 @@ function LoadoutCtrl(dimLoadoutService, dimCategory, toaster, dimPlatformService
   vm.save = function save() {
     var platform = dimPlatformService.getActive();
     vm.loadout.platform = platform.label; // Playstation or Xbox
-    dimLoadoutService.saveLoadout(vm.loadout);
+    dimLoadoutService
+      .saveLoadout(vm.loadout)
+      .catch((e) => {
+        toaster.pop('error',
+                    $translate.instant('Loadouts.SaveErrorTitle'),
+                    $translate.instant('Loadouts.SaveErrorDescription', { loadoutName: vm.loadout.name, error: e.message }));
+        console.error(e);
+      });
     vm.cancel();
   };
 

--- a/src/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/src/scripts/loadout/dimLoadoutPopup.directive.js
@@ -82,7 +82,13 @@ function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemServic
 
   vm.deleteLoadout = function deleteLoadout(loadout) {
     if ($window.confirm($translate.instant('Loadouts.ConfirmDelete', { name: loadout.name }))) {
-      dimLoadoutService.deleteLoadout(loadout);
+      dimLoadoutService.deleteLoadout(loadout)
+        .catch((e) => {
+          toaster.pop('error',
+                      $translate.instant('Loadouts.DeleteErrorTitle'),
+                      $translate.instant('Loadouts.DeleteErrorDescription', { loadoutName: vm.loadout.name, error: e.message }));
+          console.error(e);
+        });
     }
   };
 

--- a/src/scripts/services/dimInfoService.factory.js
+++ b/src/scripts/services/dimInfoService.factory.js
@@ -62,7 +62,7 @@ function InfoService(toaster, $http, $translate, SyncService) {
     // Remove prefs for "don't show this again"
     resetHiddenInfos: function() {
       SyncService.get().then(function(data) {
-        SyncService.set(_.omit(data, (v, k) => k.startsWith('info.')), true);
+        SyncService.remove(_.filter(_.keys(data), (k) => k.startsWith('info.')));
       });
     }
   };

--- a/src/scripts/services/dimItemInfoService.factory.js
+++ b/src/scripts/services/dimItemInfoService.factory.js
@@ -36,7 +36,6 @@ function ItemInfoService(dimPlatformService, SyncService, $translate, toaster, $
     let partitionCount = 0;
     let partitionSize = 0;
     _.each(infos, (v, k) => {
-      console.log(v, k);
       partition[k] = v;
       partitionSize++;
       if (partitionSize >= 50) {

--- a/src/scripts/services/dimItemInfoService.factory.js
+++ b/src/scripts/services/dimItemInfoService.factory.js
@@ -9,23 +9,76 @@ angular.module('dimApp')
  * The item info service maintains a map of extra, DIM-specific, synced data about items (per platform).
  * These info objects have a save method on them that can be used to persist any changes to their properties.
  */
-function ItemInfoService(dimPlatformService, SyncService) {
+function ItemInfoService(dimPlatformService, SyncService, $translate, toaster, $q) {
+  /**
+   * Rebuild infos from partitioned info keys.
+   */
+  function getInfos(key) {
+    return SyncService.get().then(function(data) {
+      const infos = {};
+      _.each(data, (v, k) => {
+        if (k.startsWith(key)) {
+          angular.extend(infos, v);
+        }
+      });
+      return infos;
+    });
+  }
+
+  /**
+   * Save infos to the sync service as a partitioned set, with no more than
+   * 50 items in a set. This help avoid bumping up against the 8k/key chrome sync
+   * limit.
+   */
+  function setInfos(key, infos) {
+    const partitions = {};
+    let partition = {};
+    let partitionCount = 0;
+    let partitionSize = 0;
+    _.each(infos, (v, k) => {
+      console.log(v, k);
+      partition[k] = v;
+      partitionSize++;
+      if (partitionSize >= 50) {
+        partitions[key + '-p' + partitionCount] = partition;
+        partition = {};
+        partitionSize = 0;
+        partitionCount++;
+      }
+    });
+    partitions[key + '-p' + partitionCount] = partition;
+
+    return SyncService.get().then(function(data) {
+      const emptyPartitions = _.filter(
+        _.keys(data), (k) => k.startsWith(key) && !partitions[k]);
+
+      return SyncService
+        .set(partitions)
+        .then(() => {
+          return SyncService.remove(emptyPartitions);
+        });
+    });
+  }
+
   // Returns a function that, when given a platform, returns the item info source for that platform
   return function(platform) {
-    return SyncService.get().then(function(data) {
-      const key = 'dimItemInfo-' + platform.type;
-      const infos = data[key] || {};
-
+    const key = 'dimItemInfo-' + platform.type;
+    return getInfos(key).then(function(infos) {
       return {
         infoForItem: function(hash, id) {
           const itemKey = hash + '-' + id;
           const info = infos[itemKey];
           return angular.extend({
             save: function() {
-              return SyncService.get().then((data) => {
-                const infos = data[key];
+              return getInfos(key).then((infos) => {
                 infos[itemKey] = _.omit(this, 'save');
-                SyncService.set({ [key]: infos });
+                setInfos(key, infos)
+                  .catch((e) => {
+                    toaster.pop('error',
+                                $translate.instant('ItemInfoService.SaveInfoErrorTitle'),
+                                $translate.instant('ItemInfoService.SaveInfoErrorDescription', { error: e.message }));
+                    console.error("Error saving item info (tags, notes):", e);
+                  });
               });
             }
           }, info);
@@ -35,12 +88,11 @@ function ItemInfoService(dimPlatformService, SyncService) {
         cleanInfos: function(stores) {
           if (!stores.length) {
             // don't accidentally wipe out notes
-            return;
+            return $q.when();
           }
 
-          SyncService.get().then(function(data) {
+          return getInfos(key).then(function(infos) {
             const remain = {};
-            const infos = data[key] || {};
 
             stores.forEach((store) => {
               store.items.forEach((item) => {
@@ -52,7 +104,7 @@ function ItemInfoService(dimPlatformService, SyncService) {
               });
             });
 
-            SyncService.set({ [key]: remain });
+            return setInfos(key, remain);
           });
         }
       };

--- a/src/scripts/services/dimLoadoutService.factory.js
+++ b/src/scripts/services/dimLoadoutService.factory.js
@@ -76,67 +76,54 @@ function LoadoutService($q, $rootScope, $translate, uuid2, dimItemService, dimSt
       var objectTest = (item) => _.isObject(item) && !(_.isArray(item) || _.isFunction(item));
       var hasGuid = (item) => _.has(item, 'id') && isGuid(item.id);
       var loadoutGuids = _.pluck(_loadouts, 'id');
-      var containsLoadoutGuids = (loadoutGuid, item) => !_.contains(loadoutGuid, item.id);
+      var containsLoadoutGuids = (item) => !_.contains(loadoutGuids, item.id);
 
       var orphanIds = _.chain(data)
         .filter(objectTest)
         .filter(hasGuid)
-        .filter(containsLoadoutGuids.bind(this, loadoutGuids))
+        .filter(containsLoadoutGuids)
         .pluck('id')
         .value();
 
       if (orphanIds.length > 0) {
-        SyncService.remove(orphanIds);
+        return SyncService.remove(orphanIds);
       }
     } else {
       _loadouts = _loadouts.splice(0);
     }
+    return $q.when();
   }
 
   function getLoadouts(getLatest) {
-    var deferred = $q.defer();
-    var result = deferred.promise;
-
     // Avoids the hit going to data store if we have data already.
     if (getLatest || _.size(_loadouts) === 0) {
-      SyncService.get()
+      return SyncService.get()
         .then((data) => {
           if (_.has(data, 'loadouts-v3.0')) {
-            processLoadout(data, 'v3.0');
+            return processLoadout(data, 'v3.0');
           } else if (_.has(data, 'loadouts-v2.0')) {
-            processLoadout(data['loadouts-v2.0'], 'v2.0');
-
-            saveLoadouts(_loadouts);
+            return processLoadout(data['loadouts-v2.0'], 'v2.0')
+              .then(() => {
+                saveLoadouts(_loadouts);
+              });
           } else {
-            processLoadout();
+            return processLoadout();
           }
-
-          deferred.resolve(_loadouts);
+        })
+        .then(() => {
+          return _loadouts;
         });
     } else {
-      result = $q.when(_loadouts);
+      return $q.when(_loadouts);
     }
-
-    return result;
   }
 
   function saveLoadouts(loadouts) {
-    var deferred = $q.defer();
-    var result;
-
-    if (loadouts) {
-      result = $q.when(loadouts);
-    } else {
-      result = getLoadouts();
-    }
-
-    return result
+    return $q.when(loadouts || getLoadouts())
       .then(function(loadouts) {
         _loadouts = loadouts;
 
-        var loadoutPrimitives = _.map(loadouts, function(loadout) {
-          return dehydrate(loadout);
-        });
+        var loadoutPrimitives = _.map(loadouts, dehydrate);
 
         var data = {
           'loadouts-v3.0': []
@@ -147,21 +134,14 @@ function LoadoutService($q, $rootScope, $translate, uuid2, dimItemService, dimSt
           data[l.id] = l;
         });
 
-        SyncService.set(data);
-
-        deferred.resolve(loadoutPrimitives);
-
-        return deferred.promise;
+        return SyncService.set(data).then(() => loadoutPrimitives);
       });
   }
 
   function deleteLoadout(loadout) {
     return getLoadouts()
       .then(function(loadouts) {
-        var index = _.findIndex(loadouts, function(l) {
-          return (l.id === loadout.id);
-        });
-
+        var index = _.findIndex(loadouts, { id: loadout.id });
         if (index >= 0) {
           loadouts.splice(index, 1);
         }
@@ -170,15 +150,15 @@ function LoadoutService($q, $rootScope, $translate, uuid2, dimItemService, dimSt
           return loadouts;
         });
       })
-      .then(function(_loadouts) {
-        return saveLoadouts(_loadouts);
+      .then(function(loadouts) {
+        return saveLoadouts(loadouts);
       })
       .then(function(loadouts) {
         $rootScope.$broadcast('dim-delete-loadout', {
           loadout: loadout
         });
 
-        return (loadouts);
+        return loadouts;
       });
   }
 
@@ -205,7 +185,7 @@ function LoadoutService($q, $rootScope, $translate, uuid2, dimItemService, dimSt
           loadout: loadout
         });
 
-        return (loadouts);
+        return loadouts;
       });
   }
 


### PR DESCRIPTION
Note: We often run into problems because chrome sync storage has a limit of 512 keys, 8k data per key, and 100k total data.

1. Clean up SyncService and dimLoadoutService to always use promises, and to correctly chain them so that operations happen in sequence.
2. Use `SyncService.remove` to clean up stuff in more places, so we can reclaim space.
3. New-item tracking now uses IndexedDB, so it doesn't contribute to our sync limit at all, though it of course no longer syncs. But that took up a lot of space!
4. The item info service (which stores tags and notes) gets rewritten to partition its data, rather than storing it all under one key (per platform). Instead, it spreads its data out among several keys, 50 items at a time, in order to avoid both the total-key limit and the 8k/entry limit. This should address #892 even though it doesn't totally fix it.
5. In several places I've added error feedback when saving data doesn't work, so you aren't *silently* losing your data.

Combined, these should at least help with #1400.