### PR TITLE
Improve error for no-account-on-platform

### DIFF
--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -18,7 +18,7 @@
       "Throttled": "Bungie API throttling limit exceeded. Please wait a bit and then retry.",
       "NotLoggedIn": "Please log into Bungie.net in order to use this extension.",
       "Maintenance": "Bungie.net servers are down for maintenance.",
-      "NoAccount": "No Destiny account was found for this platform. Do you have the right platform selected?",
+      "NoAccount": "No Destiny account was found on {platform}. Do you have the right platform selected?",
       "NoAccountForPlatform": "Failed to find a Destiny account for you on {platform}.",
       "NoCookies": "No cookies found.",
       "NotConnected": "You may not be connected to the internet.",

--- a/src/scripts/services/dimBungieService.factory.js
+++ b/src/scripts/services/dimBungieService.factory.js
@@ -104,10 +104,10 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
       return $q.reject(new Error($translate.instant('BungieService.NotLoggedIn')));
     } else if (errorCode === 5) {
       return $q.reject(new Error($translate.instant('BungieService.Maintenance')));
-    } else if (errorCode === 1618 &&
+    } else if ((errorCode === 1618 || errorCode === 1601) &&
       response.config.url.indexOf('/Account/') >= 0 &&
       response.config.url.indexOf('/Character/') < 0) {
-      return $q.reject(new Error($translate.instant('BungieService.NoAccount')));
+      return $q.reject(new Error($translate.instant('BungieService.NoAccount', { platform: dimState.active.label })));
     } else if (errorCode === 2107 || errorCode === 2101 || errorCode === 2102) {
       $state.go('developer');
       return $q.reject(new Error($translate.instant('BungieService.DevVersion')));


### PR DESCRIPTION
Instead of just passing the Bungie error along, call out the selected platform name and use our better error text.

/cc @delphiactual for updated translations