### PR TITLE
Run dev server in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "npm run build-dev -s",
     "publish-beta": "npm run build-beta -s && grunt publish_beta",
     "publish-release": "npm run build-release -s && grunt publish_release",
-    "server": "webpack-dev-server --config ./config/webpack.js",
+    "server": "webpack-dev-server --config ./config/webpack.js --env=dev",
     "install": "napa"
   },
   "napa": {


### PR DESCRIPTION
The `npm run server` command wasn't passing an `env`, so it was breaking some stuff. This makes it work right.