### PR TITLE
Fix Safari styling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-src/scripts/jquery-ui.position.js
+src/scripts/ios-drag-drop.js
 build/
 dist/
 Gruntfile.js

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -80,8 +80,12 @@ module.exports = (env) => {
         }, {
           test: /\.scss$/,
           loader: ExtractTextPlugin.extract({
-            fallbackLoader: 'style-loader',
-            loader: 'css-loader!sass-loader',
+            use: [
+              'css-loader',
+              'postcss-loader',
+              'sass-loader'
+            ],
+            fallback: 'style-loader'
           }),
         }
       ],

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "angularjs-toaster": "github:DestinyItemManager/AngularJS-Toaster",
     "babel-polyfill": "^6.20.0",
     "components-font-awesome": "^4.7.0",
+    "drag-drop-webkit-mobile": "^1.2.0",
     "file-loader": "^0.9.0",
     "humanize-duration": "^3.10.0",
     "idb-keyval": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
     "url": "https://github.com/DestinyItemManager/DIM/issues"
   },
   "homepage": "https://github.com/DestinyItemManager/DIM",
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 ChromeAndroid versions",
+    "last 2 Firefox versions",
+    "last 1 Safari versions",
+    "last 1 iOS versions",
+    "last 2 Edge versions"
+  ],
   "devDependencies": {
     "autoprefixer": "^6.3.7",
     "babel-core": "^6.21.0",
@@ -66,6 +74,7 @@
     "node-sass": "^3.13.1",
     "notify-webpack-plugin": "^1.0.0",
     "npm-run-all": "^3.1.2",
+    "postcss-loader": "^1.3.1",
     "request": "^2.73.0",
     "sass-loader": "^4.1.1",
     "sqlite3": "^3.1.4",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,16 @@ require('babel-polyfill');
 
 require('./scripts/google');
 
+// Drag and drop
+window.iosDragDropShim = {
+  enableEnterLeave: true,
+  holdToDrag: 300
+};
+// Use our forked version until https://github.com/timruffles/ios-html5-drag-drop-shim/pull/85 is merged
+// require('drag-drop-webkit-mobile');
+require('./scripts/ios-drag-drop.js');
+window.addEventListener('touchmove', function() {});
+
 // TODO: remove this globals and instead require where needed
 window.$ = window.jQuery = require('jquery');
 require('jquery-textcomplete');
@@ -14,7 +24,6 @@ require('./scripts/oauth/oauth.module');
 require('./scripts/oauth/http-refresh-token.service');
 require('./scripts/oauth/oauth.service');
 require('./scripts/oauth/oauth-token.service');
-
 
 // Initialize the main DIM app
 require('./scripts/dimApp.module');

--- a/src/manifest-webapp.json
+++ b/src/manifest-webapp.json
@@ -15,5 +15,6 @@
   ],
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
-  "display": "standalone"
+  "display": "standalone",
+  "start_url": "index.html?utm_source=homescreen"
 }

--- a/src/postcss.config.js
+++ b/src/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    require('autoprefixer')
+  ]
+};

--- a/src/scripts/dimApp.config.js
+++ b/src/scripts/dimApp.config.js
@@ -7,7 +7,7 @@ import ja from '../i18n/dim_ja.json';
 import ptBr from '../i18n/dim_pt_BR.json';
 
 function config($compileProvider, $httpProvider, $translateProvider, $translateMessageFormatInterpolationProvider,
-  hotkeysProvider, localStorageServiceProvider, ngHttpRateLimiterConfigProvider) {
+                hotkeysProvider, localStorageServiceProvider, ngHttpRateLimiterConfigProvider, ngDialogProvider) {
   'ngInject';
 
   // TODO: remove this depenency by fixing component bindings https://github.com/angular/angular.js/blob/master/CHANGELOG.md#breaking-changes-1
@@ -49,6 +49,11 @@ function config($compileProvider, $httpProvider, $translateProvider, $translateM
   // what I assume is clock skew between Bungie's hosts when they calculate a global rate limit.
   ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny\/TransferItem/, 1, 1100);
   ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny\/EquipItem/, 1, 1100);
+
+  // https://github.com/likeastore/ngDialog/issues/327
+  ngDialogProvider.setDefaults({
+    disableAnimation: true
+  });
 }
 
 export default config;

--- a/src/scripts/google.js
+++ b/src/scripts/google.js
@@ -18,6 +18,3 @@ _gaq.push(['_trackPageview']);
   ga.src = 'https://www.google-analytics.com/ga.js';
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
-
-/* eslint no-unused-vars:0 no-implicit-globals:0 */
-var iosDragDropShim = { enableEnterLeave: true };

--- a/src/scripts/ios-drag-drop.js
+++ b/src/scripts/ios-drag-drop.js
@@ -1,0 +1,436 @@
+(function(doc) {
+
+  log = noop; // noOp, remove this line to enable debugging
+
+  var coordinateSystemForElementFromPoint;
+
+  function main(config) {
+    config = config || {};
+
+    coordinateSystemForElementFromPoint = navigator.userAgent.match(/OS [1-4](?:_\d+)+ like Mac/) ? "page" : "client";
+
+    var div = doc.createElement('div');
+    var dragDiv = 'draggable' in div;
+    var evts = 'ondragstart' in div && 'ondrop' in div;
+
+    var needsPatch = !(dragDiv || evts) || /iPad|iPhone|iPod|Android/.test(navigator.userAgent);
+    log((needsPatch ? "" : "not ") + "patching html5 drag drop");
+
+    if(!needsPatch) {
+        return;
+    }
+
+    if(!config.enableEnterLeave) {
+      DragDrop.prototype.synthesizeEnterLeave = noop;
+    }
+
+    if(config.holdToDrag){
+      doc.addEventListener("touchstart", touchstartDelay(config.holdToDrag));
+    }
+    else {
+      doc.addEventListener("touchstart", touchstart);
+    }
+  }
+
+  function DragDrop(event, el) {
+
+    this.dragData = {};
+    this.dragDataTypes = [];
+    this.dragImage = null;
+    this.dragImageTransform = null;
+    this.dragImageWebKitTransform = null;
+    this.customDragImage = null;
+    this.customDragImageX = null;
+    this.customDragImageY = null;
+    this.el = el || event.target;
+
+    log("dragstart");
+
+    if (this.dispatchDragStart()) {
+      this.createDragImage();
+      this.listen();
+    }
+  }
+
+  DragDrop.prototype = {
+    listen: function() {
+      var move = onEvt(doc, "touchmove", this.move, this);
+      var end = onEvt(doc, "touchend", ontouchend, this);
+      var cancel = onEvt(doc, "touchcancel", cleanup, this);
+
+      function ontouchend(event) {
+        this.dragend(event, event.target);
+        cleanup.call(this);
+      }
+      function cleanup() {
+        log("cleanup");
+        this.dragDataTypes = [];
+        if (this.dragImage !== null) {
+          this.dragImage.parentNode.removeChild(this.dragImage);
+          this.dragImage = null;
+          this.dragImageTransform = null;
+          this.dragImageWebKitTransform = null;
+        }
+        this.customDragImage = null;
+        this.customDragImageX = null;
+        this.customDragImageY = null;
+        this.el = this.dragData = null;
+        return [move, end, cancel].forEach(function(handler) {
+          return handler.off();
+        });
+      }
+    },
+    move: function(event) {
+      event.preventDefault();
+      var pageXs = [], pageYs = [];
+      [].forEach.call(event.changedTouches, function(touch) {
+        pageXs.push(touch.pageX);
+        pageYs.push(touch.pageY);
+      });
+
+      var x = average(pageXs) - (this.customDragImageX || parseInt(this.dragImage.offsetWidth, 10) / 2);
+      var y = average(pageYs) - (this.customDragImageY || parseInt(this.dragImage.offsetHeight, 10) / 2);
+      this.translateDragImage(x, y);
+
+      this.synthesizeEnterLeave(event);
+    },
+    // We use translate instead of top/left because of sub-pixel rendering and for the hope of better performance
+    // http://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/
+    translateDragImage: function(x, y) {
+      var translate = "translate(" + x + "px," + y + "px) ";
+
+      if (this.dragImageWebKitTransform !== null) {
+        this.dragImage.style["-webkit-transform"] = translate + this.dragImageWebKitTransform;
+      }
+      if (this.dragImageTransform !== null) {
+        this.dragImage.style.transform = translate + this.dragImageTransform;
+      }
+    },
+    synthesizeEnterLeave: function(event) {
+      var target = elementFromTouchEvent(this.el,event)
+      if (target != this.lastEnter) {
+        if (this.lastEnter) {
+          this.dispatchLeave(event);
+        }
+        this.lastEnter = target;
+        if (this.lastEnter) {
+          this.dispatchEnter(event);
+        }
+      }
+      if (this.lastEnter) {
+        this.dispatchOver(event);
+      }
+    },
+    dragend: function(event) {
+
+      // we'll dispatch drop if there's a target, then dragEnd.
+      // drop comes first http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#drag-and-drop-processing-model
+      log("dragend");
+
+      if (this.lastEnter) {
+        this.dispatchLeave(event);
+      }
+
+      var target = elementFromTouchEvent(this.el,event)
+      if (target) {
+        log("found drop target " + target.tagName);
+        this.dispatchDrop(target, event);
+      } else {
+        log("no drop target");
+      }
+
+      var dragendEvt = doc.createEvent("Event");
+      dragendEvt.initEvent("dragend", true, true);
+      this.el.dispatchEvent(dragendEvt);
+    },
+    dispatchDrop: function(target, event) {
+      var dropEvt = doc.createEvent("Event");
+      dropEvt.initEvent("drop", true, true);
+
+      var touch = event.changedTouches[0];
+      var x = touch[coordinateSystemForElementFromPoint + 'X'];
+      var y = touch[coordinateSystemForElementFromPoint + 'Y'];
+
+      var targetOffset = getOffset(target);
+
+      dropEvt.offsetX = x - targetOffset.x;
+      dropEvt.offsetY = y - targetOffset.y;
+
+      dropEvt.dataTransfer = {
+        types: this.dragDataTypes,
+        getData: function(type) {
+          return this.dragData[type];
+        }.bind(this),
+        dropEffect: "move"
+      };
+      dropEvt.preventDefault = function() {
+         // https://www.w3.org/Bugs/Public/show_bug.cgi?id=14638 - if we don't cancel it, we'll snap back
+      }.bind(this);
+
+      once(doc, "drop", function() {
+        log("drop event not canceled");
+      },this);
+
+      target.dispatchEvent(dropEvt);
+    },
+    dispatchEnter: function(event) {
+
+      var enterEvt = doc.createEvent("Event");
+      enterEvt.initEvent("dragenter", true, true);
+      enterEvt.dataTransfer = {
+        types: this.dragDataTypes,
+        getData: function(type) {
+          return this.dragData[type];
+        }.bind(this)
+      };
+
+      var touch = event.changedTouches[0];
+      enterEvt.pageX = touch.pageX;
+      enterEvt.pageY = touch.pageY;
+      enterEvt.clientX = touch.clientX;
+      enterEvt.clientY = touch.clientY;
+
+      this.lastEnter.dispatchEvent(enterEvt);
+    },
+    dispatchOver: function(event) {
+
+      var overEvt = doc.createEvent("Event");
+      overEvt.initEvent("dragover", true, true);
+      overEvt.dataTransfer = {
+        types: this.dragDataTypes,
+        getData: function(type) {
+          return this.dragData[type];
+        }.bind(this)
+      };
+
+      var touch = event.changedTouches[0];
+      overEvt.pageX = touch.pageX;
+      overEvt.pageY = touch.pageY;
+      overEvt.clientX = touch.clientX;
+      overEvt.clientY = touch.clientY;
+
+      this.lastEnter.dispatchEvent(overEvt);
+    },
+    dispatchLeave: function(event) {
+
+      var leaveEvt = doc.createEvent("Event");
+      leaveEvt.initEvent("dragleave", true, true);
+      leaveEvt.dataTransfer = {
+        types: this.dragDataTypes,
+        getData: function(type) {
+          return this.dragData[type];
+        }.bind(this)
+      };
+
+      var touch = event.changedTouches[0];
+      leaveEvt.pageX = touch.pageX;
+      leaveEvt.pageY = touch.pageY;
+      leaveEvt.clientX = touch.clientX;
+      leaveEvt.clientY = touch.clientY;
+
+      this.lastEnter.dispatchEvent(leaveEvt);
+      this.lastEnter = null;
+    },
+    dispatchDragStart: function() {
+      var evt = doc.createEvent("Event");
+      evt.initEvent("dragstart", true, true);
+      evt.dataTransfer = {
+        setData: function(type, val) {
+          this.dragData[type] = val;
+          if (this.dragDataTypes.indexOf(type) == -1) {
+            this.dragDataTypes[this.dragDataTypes.length] = type;
+          }
+          return val;
+        }.bind(this),
+        setDragImage: function(el, x, y){
+          this.customDragImage = el;
+          this.customDragImageX = x
+          this.customDragImageY = y
+        }.bind(this),
+        dropEffect: "move"
+      };
+      return this.el.dispatchEvent(evt);
+    },
+    createDragImage: function() {
+      if (this.customDragImage) {
+        this.dragImage = this.customDragImage.cloneNode(true);
+        duplicateStyle(this.customDragImage, this.dragImage);
+      } else {
+        this.dragImage = this.el.cloneNode(true);
+        duplicateStyle(this.el, this.dragImage);
+      }
+      this.dragImage.style.opacity = "0.5";
+      this.dragImage.style.position = "absolute";
+      this.dragImage.style.left = "0px";
+      this.dragImage.style.top = "0px";
+      this.dragImage.style.zIndex = "999999";
+
+      var transform = this.dragImage.style.transform;
+      if (typeof transform !== "undefined") {
+        this.dragImageTransform = "";
+        if (transform != "none") {
+          this.dragImageTransform = transform.replace(/translate\(\D*\d+[^,]*,\D*\d+[^,]*\)\s*/g, '');
+        }
+      }
+
+      var webkitTransform = this.dragImage.style["-webkit-transform"];
+      if (typeof webkitTransform !== "undefined") {
+        this.dragImageWebKitTransform = "";
+        if (webkitTransform != "none") {
+          this.dragImageWebKitTransform = webkitTransform.replace(/translate\(\D*\d+[^,]*,\D*\d+[^,]*\)\s*/g, '');
+        }
+      }
+
+      this.translateDragImage(-9999, -9999);
+
+      doc.body.appendChild(this.dragImage);
+    }
+  };
+
+  // delayed touch start event
+  function touchstartDelay(delay) {
+    return function(evt){
+      var el = evt.target;
+
+      console.log('touchstartDelay', delay, el.draggable, evt);
+      do {
+        if (el.draggable === true) {
+          var heldItem = function(e) {
+            console.log('touchstart', e);
+            end.off();
+            cancel.off();
+            scroll.off();
+            touchstart(evt);
+          };
+
+          var onReleasedItem = function(e) {
+            console.log('released', e);
+            end.off();
+            cancel.off();
+            scroll.off();
+            clearTimeout(timer);
+          };
+
+          var timer = setTimeout(heldItem, delay);
+
+          var end = onEvt(el, 'touchend', onReleasedItem, this);
+          var cancel = onEvt(el, 'touchcancel', onReleasedItem, this);
+          var scroll = onEvt(window, 'scroll', onReleasedItem, this);
+          break;
+        }
+      } while ((el = el.parentNode) && el !== doc.body);
+    };
+  };
+
+  // event listeners
+  function touchstart(evt) {
+    var el = evt.target;
+    do {
+      if (el.draggable === true) {
+        // If draggable isn't explicitly set for anchors, then simulate a click event.
+        // Otherwise plain old vanilla links will stop working.
+        // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Touch_events#Handling_clicks
+        if (!el.hasAttribute("draggable") && el.tagName.toLowerCase() == "a") {
+          var clickEvt = document.createEvent("MouseEvents");
+          clickEvt.initMouseEvent("click", true, true, el.ownerDocument.defaultView, 1,
+            evt.screenX, evt.screenY, evt.clientX, evt.clientY,
+            evt.ctrlKey, evt.altKey, evt.shiftKey, evt.metaKey, 0, null);
+          el.dispatchEvent(clickEvt);
+          log("Simulating click to anchor");
+        }
+        evt.preventDefault();
+        new DragDrop(evt,el);
+        break;
+      }
+    } while((el = el.parentNode) && el !== doc.body);
+  }
+
+  // DOM helpers
+  function elementFromTouchEvent(el,event) {
+    var touch = event.changedTouches[0];
+    var target = doc.elementFromPoint(
+      touch[coordinateSystemForElementFromPoint + "X"],
+      touch[coordinateSystemForElementFromPoint + "Y"]
+    );
+    return target;
+  }
+
+  //calculate the offset position of an element (relative to the window, not the document)
+  function getOffset(el) {
+    var rect = el.getBoundingClientRect();
+    return {
+      "x": rect.left,
+      "y": rect.top
+    };
+  }
+
+  function onEvt(el, event, handler, context) {
+    if(context) {
+      handler = handler.bind(context);
+    }
+    el.addEventListener(event, handler);
+    return {
+      off: function() {
+        return el.removeEventListener(event, handler);
+      }
+    };
+  }
+
+  function once(el, event, handler, context) {
+    if(context) {
+      handler = handler.bind(context);
+    }
+    function listener(evt) {
+      handler(evt);
+      return el.removeEventListener(event,listener);
+    }
+    return el.addEventListener(event,listener);
+  }
+
+  // duplicateStyle expects dstNode to be a clone of srcNode
+  function duplicateStyle(srcNode, dstNode) {
+    // Is this node an element?
+    if (srcNode.nodeType == 1) {
+      // Remove any potential conflict attributes
+      dstNode.removeAttribute("id");
+      dstNode.removeAttribute("class");
+      dstNode.removeAttribute("style");
+      dstNode.removeAttribute("draggable");
+
+      // Clone the style
+      var cs = window.getComputedStyle(srcNode);
+      for (var i = 0; i < cs.length; i++) {
+        var csName = cs[i];
+        dstNode.style.setProperty(csName, cs.getPropertyValue(csName), cs.getPropertyPriority(csName));
+      }
+
+      // Pointer events as none makes the drag image transparent to document.elementFromPoint()
+      dstNode.style.pointerEvents = "none";
+    }
+
+    // Do the same for the children
+    if (srcNode.hasChildNodes()) {
+      for (var j = 0; j < srcNode.childNodes.length; j++) {
+        duplicateStyle(srcNode.childNodes[j], dstNode.childNodes[j]);
+      }
+    }
+  }
+
+  // general helpers
+  function log(msg) {
+    console.log(msg);
+  }
+
+  function average(arr) {
+    if (arr.length === 0) return 0;
+    return arr.reduce((function(s, v) {
+      return v + s;
+    }), 0) / arr.length;
+  }
+
+  function noop() {}
+
+  main(window.iosDragDropShim);
+
+
+})(document);

--- a/src/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/src/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -42,7 +42,7 @@ function MoveItemProperties() {
       '    </div>',
       '    <div class="item-subtitle">',
       '      <div ng-if="vm.item.trackable || vm.item.lockable || vm.item.dmg" class="icon">',
-      '        <img ng-if="vm.item.dmg && vm.item.dmg !== \'kinetic\'" class="element" ng-src="/images/{{ ::vm.item.dmg }}.png"/>',
+      '        <div ng-if="vm.item.dmg && vm.item.dmg !== \'kinetic\'" class="element" ng-class="::vm.item.dmg"></div>',
       '      </div>',
       '      <div class="item-type-info">{{vm.light}} {{::vm.classType}} {{::vm.item.typeName}}</div>',
       '      <div ng-if="vm.item.objectives" translate-values="{ percent: vm.item.percentComplete }" translate="ItemService.PercentComplete"></div>',

--- a/src/scripts/move-popup/dimTalentGrid.directive.js
+++ b/src/scripts/move-popup/dimTalentGrid.directive.js
@@ -28,7 +28,7 @@ function TalentGrid() {
       '<svg preserveAspectRatio="xMaxYMin meet" svg-bind-viewbox="0 0 {{(vm.numColumns * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor}} {{(vm.numRows * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor + 1}}" class="talent-grid" ng-attr-height="{{(vm.numRows * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor}}" ng-attr-width="{{(vm.numColumns * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor}}">',
       ' <g ng-attr-transform="scale({{vm.scaleFactor}})">',
       '  <g class="talent-node" ng-attr-transform="translate({{(node.column - vm.hiddenColumns) * (vm.totalNodeSize)}},{{node.row * (vm.totalNodeSize)}})" ng-repeat="node in vm.talentGrid.nodes | talentGridNodes:vm.hiddenColumns track by $index" ng-class="{ \'talent-node-activated\': node.activated, \'talent-node-showxp\': (!node.activated && node.xpRequired), \'talent-node-default\': (node.activated && !node.xpRequired && !node.exclusiveInColumn) }" ng-click="node.hash == 1270552711 ? vm.infuse({\'$event\': $event}) : true">',
-      '    <circle r="16" cx="-17" cy="17" transform="rotate(-90)" class="talent-node-xp" stroke-width="2" ng-attr-stroke-dasharray="{{100.0 * node.xp / node.xpRequired}} 100" />',
+      '    <circle r="16" cx="-17" cy="17" transform="rotate(-90)" class="talent-node-xp" ng-attr-stroke-width="{{node.xp ? 2 : 0}}" ng-attr-stroke-dasharray="{{100.0 * node.xp / node.xpRequired}} 100" />',
       '    <image class="talent-node-img" xlink:href="" ng-attr-xlink:href="{{ node.icon | bungieIcon }}" x="20" y="20" height="96" width="96" transform="scale(0.25)"/>',
       '    <title>{{node.name}}\n{{node.description}}</title>',
       '  </g>',

--- a/src/scss/_move-popup.scss
+++ b/src/scss/_move-popup.scss
@@ -5,7 +5,6 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 .move-popup-dialog {
-  height: -webkit-fit-content;
   height: fit-content;
 }
 

--- a/src/scss/_move-popup.scss
+++ b/src/scss/_move-popup.scss
@@ -5,6 +5,7 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 .move-popup-dialog {
+  height: -webkit-fit-content;
   height: fit-content;
 }
 

--- a/src/scss/_move-popup.scss
+++ b/src/scss/_move-popup.scss
@@ -160,6 +160,16 @@ $item-header-spacing: 5px;
     height: 1rem;
     vertical-align: top;
     width: 1rem;
+    background-size: contain;
+    &.void {
+      background-image: url('../images/void.png');
+    }
+    &.arc {
+      background-image: url('../images/arc.png');
+    }
+    &.solar {
+      background-image: url('../images/solar.png');
+    }
   }
   .info {
     font-size: 1.5em;

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -135,6 +135,8 @@ div:focus, span:focus {
   width: 250px;
   margin-left: -10px;
   margin-bottom: 4px;
+  border-radius: 0;
+  -webkit-appearance: none;
 }
 
 dt {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -191,7 +191,7 @@ a {
 .ngdialog-content > div {
   display: flex;
   flex-direction: column;
-  height: fit-content;
+  height: 90%;
   max-height: 100%;
 }
 
@@ -436,6 +436,10 @@ input, select, option {
   option {
     cursor: pointer;
   }
+}
+
+input[type="search"] {
+  -webkit-appearance: textfield;
 }
 
 #filter-view ul {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -95,6 +95,7 @@ div:focus, span:focus {
     text-align: center;
     -webkit-touch-callout: none;
     user-select: none;
+    outline: none;
   }
 }
 
@@ -493,6 +494,7 @@ img {
   border-left: solid 1px #2b2b2b;
   span[role="button"] {
     cursor: pointer;
+    outline: none;
   }
   .bucket-count {
     float: right;
@@ -917,6 +919,7 @@ dim-store-heading {
   border: 1px solid rgba(0, 0, 0, 0.1);
   box-sizing: border-box;
   cursor: pointer;
+  outline: none;
   &:hover {
     background-color: rgba(160, 160, 160, 0.8);
     border: 1px solid rgba(32, 32, 32, 0);
@@ -936,6 +939,9 @@ dim-store-heading {
 
 .loadout-menu {
   position: relative;
+  [role="button"] {
+    outline: none;
+  }
 }
 
 .ngdialog.loadout-popup {

--- a/src/views/infuse.template.html
+++ b/src/views/infuse.template.html
@@ -38,9 +38,9 @@
         <span translate="Infusion.BringGear"></span>
         <span class="bigValue">{{vm.infused}}</span>
         <span class="green">(+ {{vm.infused - vm.source.primStat.value}})</span>
-        <span translate="Infusion.Using3"> </span><span class="currency"><img alt="Legendary Marks" title="Legendary Marks" src="/images/legendaryMarks.png"></span>
+        <span translate="Infusion.Using3"> </span><span class="currency"><img alt="Legendary Marks" title="Legendary Marks" src="~app/images/legendaryMarks.png"></span>
         <span ng-if="vm.exotic">+ 1 <span class="currency"><img alt="Exotic Shards" title="Exotic Shards" src="https://www.bungie.net/common/destiny_content/icons/e6d2a0561e784ae224e2aa53aa66e8a7.jpg"></span></span>
-        <span>+ 250 <span class="currency"><img alt="Glimmer" title="Glimmer" src="/images/glimmer.png"></span></span>
+        <span>+ 250 <span class="currency"><img alt="Glimmer" title="Glimmer" src="~app/images/glimmer.png"></span></span>
         <span>+ {{vm.wildcardMaterialCost | number}} <span class="currency"><img alt="Materials" title="Materials" ng-src="{{vm.wildcardMaterialIcon | bungieIcon}}"></span></span>
       </div>
       <button ng-if="vm.getAllItems" ng-disabled="vm.transferInProgress" ng-click="vm.transferItems()" translate="Infusion.TransferItems"></button>


### PR DESCRIPTION
This probably also helps out a bunch of other browsers, but I'm mostly testing in Safari.

1. Re-enable autoprefixer to get the CSS that wasn't working on non-Chrome browser because of prefixes.
2. Fix dialogs getting squished (#1260)
3. Fix search bar styling (#1260)
4. Fix sliver of XP when XP in talent grid is 0 (#1374)
5. Fix elemental icons in move popup.
6. Fix infusion cost icons in infusion calculator.
7. Fix move popups being too big and not dismissing.
8. Suppress unwanted focus outlines. (#1260)