### PR TITLE
update extract-text to fix npm error

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint": "^3.12.2",
     "exports-loader": "^0.6.3",
     "extract-loader": "^0.1.0",
-    "extract-text-webpack-plugin": "github:webpack/extract-text-webpack-plugin",
+    "extract-text-webpack-plugin": "^2.0.0",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-compress": "^1.3.0",


### PR DESCRIPTION
Without update was getting the following error, 2.0.0 was released yesterday
```
D:\Documents\GitHub\DIM\node_modules\extract-text-webpack-plugin\index.js:134
        if(!loader.query) return loader.loader;
                  ^

TypeError: Cannot read property 'query' of undefined
    at getLoaderWithQuery (D:\Documents\GitHub\DIM\node_modules\extract-text-webpack-plugin\index.js:134:12)
    at Array.map (native)
    at Function.ExtractTextPlugin.extract (D:\Documents\GitHub\DIM\node_modules\extract-text-webpack-plugin\index.js:201:4)
    at module.exports (D:\Documents\GitHub\DIM\config\webpack.js:82:37)
    at requireConfig (D:\Documents\GitHub\DIM\node_modules\webpack\bin\convert-argv.js:102:15)
    at D:\Documents\GitHub\DIM\node_modules\webpack\bin\convert-argv.js:109:17
    at Array.forEach (native)
    at module.exports (D:\Documents\GitHub\DIM\node_modules\webpack\bin\convert-argv.js:107:15)
    at Object.<anonymous> (D:\Documents\GitHub\DIM\node_modules\webpack\bin\webpack.js:153:40)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```