### PR TITLE
Turn on tags/notes in release

### DIFF
--- a/src/scripts/feature-flags.js
+++ b/src/scripts/feature-flags.js
@@ -1,7 +1,7 @@
 const featureFlag = {
   isExtension: window.chrome && window.chrome.extension,
   // Tags are off in release right now
-  tagsEnabled: $DIM_FLAVOR !== 'release',
+  tagsEnabled: true,
   compareEnabled: true,
   vendorsEnabled: true,
   qualityEnabled: true,


### PR DESCRIPTION
RFC, but I think it's time to turn tagging/notes on in the release extension, now that we've successfully worked around the storage limitations.