### PR TITLE
Turn off materials exchange

### DIFF
--- a/src/scripts/feature-flags.js
+++ b/src/scripts/feature-flags.js
@@ -12,7 +12,7 @@ const featureFlag = {
   // show changelog toaster
   changelogToaster: $DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta',
 
-  materialsExchangeEnabled: $DIM_FLAVOR !== 'release',
+  materialsExchangeEnabled: false,
   // allow importing and exporting your DIM data to JSON
   importExport: $DIM_FLAVOR !== 'release'
 };


### PR DESCRIPTION
This feature is a cool idea, but it hasn't gotten any love since the initial merge, and IMO it's very far from being in the state where it could be released. I personally can't understand what information it's presenting to me, or how it works.

This PR suggests turning it off completely (without deleting it) since the beta website and extension are being used by more people and we don't have a current plan to get this to a releasable state. If somebody wants to work on it, we can reenable it - otherwise after a while the code can be removed.