### PR TITLE
Vendors tweaks (order, location)

### DIFF
--- a/src/scripts/services/dimDefinitions.factory.js
+++ b/src/scripts/services/dimDefinitions.factory.js
@@ -8,7 +8,8 @@ const lazyTables = [
   'TalentGrid',
   'Progression',
   'Record',
-  'ItemCategory'
+  'ItemCategory',
+  'VendorCategory'
 ];
 
 const eagerTables = [

--- a/src/scripts/services/dimVendorService.factory.js
+++ b/src/scripts/services/dimVendorService.factory.js
@@ -59,8 +59,7 @@ function VendorService(
   // Vendors we don't want to load by default
   const vendorBlackList = [
     2021251983, // Postmaster,
-    4269570979, // Cryptarch (Tower)
-    1303406887 // Cryptarch (Reef)
+  ];
 
   // Hashes for 'Decode Engram'
   const categoryBlacklist = [
@@ -347,7 +346,7 @@ function VendorService(
   }
 
   function processVendor(vendor, vendorDef, defs, store) {
-    var def = vendorDef.summary;
+    const def = vendorDef.summary;
     const createdVendor = {
       def: vendorDef,
       hash: vendorDef.hash,
@@ -361,9 +360,9 @@ function VendorService(
           factionAligned: vendor.factionAligned
         }
       },
-      eventVendor: def.mapSectionIdentifier === 'EVENT',
-      vendorOrder: (def.mapSectionOrder * 1000) + def.vendorOrder,
-      faction: def.factionHash // TODO: show rep!
+      vendorOrder: def.vendorSubcategoryHash + def.vendorOrder,
+      faction: def.factionHash, // TODO: show rep!
+      location: defs.VendorCategory[def.vendorCategoryHash].categoryName
     };
 
     const saleItems = flatMap(vendor.saleItemCategories, (categoryData) => {

--- a/src/scripts/services/dimVendorService.factory.js
+++ b/src/scripts/services/dimVendorService.factory.js
@@ -61,6 +61,13 @@ function VendorService(
     2021251983, // Postmaster,
     4269570979, // Cryptarch (Tower)
     1303406887 // Cryptarch (Reef)
+
+  // Hashes for 'Decode Engram'
+  const categoryBlacklist = [
+    3574600435,
+    3612261728,
+    1333567905,
+    2634310414
   ];
 
   let _reloadPromise = null;
@@ -370,7 +377,12 @@ function VendorService(
     return dimStoreService.processItems({ id: null }, _.pluck(saleItems, 'item'))
       .then(function(items) {
         const itemsById = _.indexBy(items, 'id');
-        const categories = _.map(vendor.saleItemCategories, (category) => {
+        const categories = _.compact(_.map(vendor.saleItemCategories, (category) => {
+          const categoryInfo = vendorDef.categories[category.categoryIndex];
+          if (_.contains(categoryBlacklist, categoryInfo.categoryHash)) {
+            return null;
+          }
+
           const categoryItems = category.saleItems.map((saleItem) => {
             const unlocked = isSaleItemUnlocked(saleItem);
             return {
@@ -419,7 +431,7 @@ function VendorService(
 
           return {
             index: category.categoryIndex,
-            title: vendorDef.categories[category.categoryIndex].displayTitle,
+            title: categoryInfo.displayTitle,
             saleItems: categoryItems,
             hasArmorWeaps: hasArmorWeaps,
             hasVehicles: hasVehicles,
@@ -428,7 +440,7 @@ function VendorService(
             hasConsumables: hasConsumables,
             hasBounties: hasBounties
           };
-        });
+        }));
 
         items.forEach((item) => {
           item.vendorIcon = createdVendor.icon;

--- a/src/scripts/vendors/dimVendorItems.directive.js
+++ b/src/scripts/vendors/dimVendorItems.directive.js
@@ -33,12 +33,13 @@ var VendorItems = {
     extraMovePopupClass: '<'
   },
   template: [
-    '<div class="vendor-char-items" ng-repeat="(vendorHash, vendor) in vm.vendors | values | vendorTab:vm.activeTab | orderBy:[\'-eventVendor\',\'vendorOrder\'] track by vendor.hash">',
+    '<div class="vendor-char-items" ng-repeat="(vendorHash, vendor) in vm.vendors | values | vendorTab:vm.activeTab | orderBy:[\'vendorOrder\'] track by vendor.hash">',
     '  <div class="title">',
     '    <div class="collapse-handle" ng-click="vm.toggleSection(vendorHash)">',
     '      <i class="fa collapse" ng-class="vm.settings.collapsedSections[vendorHash] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i>',
     '      <img class="vendor-icon" ng-src="{{::vendor.icon | bungieIcon}}" />',
     '      {{::vendor.name}}',
+    '      <span class="vendor-location">{{::vendor.location}}</span>',
     '    </div>',
     '    <timer class="vendor-timer" ng-if="vendor.nextRefreshDate[0] !== \'9\'" end-time="vendor.nextRefreshDate" max-time-unit="\'day\'" interval="1000">{{days}} <span translate="Vendors.Day" translate-values="{ numDays: days }"></span> {{hhours}}:{{mminutes}}:{{sseconds}}</timer>',
     '  </div>',

--- a/src/scss/_vendors.scss
+++ b/src/scss/_vendors.scss
@@ -95,6 +95,13 @@
     flex-direction: row;
     justify-content: space-between;
   }
+  .vendor-location {
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: 12px;
+    color: #999;
+    margin-left: 6px;
+  }
   .vendor-row {
     margin-bottom: 10px;
     margin-top: 10px;


### PR DESCRIPTION
A few Vendors tweaks:

* Remove engrams in your inventory from the Cryptarchs. Nobody wants to see that they're "selling" the ability to decrypt your stuff.
* Reorder vendors using the same categories and order as Bungie.net (except we put all the locations together instead of separating them by location).
* Show vendor locations next to their name.
* Un-blacklist the Tower and Reef Cryptarchs.

![screen shot 2017-02-25 at 5 35 08 pm](https://cloud.githubusercontent.com/assets/313208/23336315/015dd796-fb81-11e6-8a87-bd8aa3f408be.png)
