### PR TITLE
Split bundle to vendor and 1st-party

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -104,6 +104,13 @@ module.exports = (env) => {
         root: path.resolve('./'),
       }),
 
+      new webpack.optimize.CommonsChunkPlugin({
+        name: 'vendor',
+        minChunks: function(module) {
+          return module.context && module.context.indexOf('node_modules') !== -1;
+        },
+      }),
+
       new NotifyPlugin('DIM', !isDev),
 
       new ExtractTextPlugin('styles-[hash:6].css'),

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
     <title>DIM</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -39,7 +40,7 @@
         <div ui-view></div>
       </div>
     </div>
-
+    <script type="text/javascript" src="{{webpackConfig.output.publicPath}}{{htmlWebpackPlugin.files.chunks.vendor.entry}}"></script>
     <script type="text/javascript" src="{{webpackConfig.output.publicPath}}{{htmlWebpackPlugin.files.chunks.main.entry}}"></script>
   </body>
 


### PR DESCRIPTION
#1315 

//cc @bhollis 

ref: https://webpack.js.org/guides/code-splitting-libraries/#implicit-common-vendor-chunk