### PR TITLE
Style updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Remove Materials Exchange from the beta.
 * Vendors now show where they are, and are sorted better. All the cryptarchs now appear. Engrams waiting to be decrypted aren't shown in the vendor screen.
 * Experimental iOS 9 Mobile Safari compatibility. May be removed in the future.
+* Style updates to clean up DIM's look and make sure more screen space is being used for items.
 
 # 3.16.1
 

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,7 @@
     <link href='https://ssl.gstatic.com' rel='preconnect'>
 
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:200,400,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:300' rel='stylesheet' type='text/css'>
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -138,7 +138,7 @@ function SearchFilter(dimSearchService) {
       });
     },
     bindToController: true,
-    restrict: 'A',
+    restrict: 'E',
     template: [
       '<input id="filter-input" class="dim-input" translate-attr="{ placeholder: \'Header.FilterHelp\' }" type="search" name="filter" ng-model="vm.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">'
     ].join('')

--- a/src/scripts/shell/platform-choice/platform-choice.html
+++ b/src/scripts/shell/platform-choice/platform-choice.html
@@ -1,7 +1,5 @@
 <div class="platform-choice">
-  <span ng-if="$ctrl.current" id="user">
-    <i class="fa fa-user"></i> {{ $ctrl.current.id }}
-  </span>
+  <span ng-if="$ctrl.current" id="user">{{ $ctrl.current.id }}</span>
   <select id="system" ng-if="$ctrl.platforms.length > 1" ng-model="$ctrl.current"
     ng-options="platform.label for platform in $ctrl.platforms track by platform.type"
     ng-change="$ctrl.change($ctrl.current)"></select>

--- a/src/scripts/store/dimStoreHeading.directive.template.html
+++ b/src/scripts/store/dimStoreHeading.directive.template.html
@@ -1,15 +1,29 @@
-<div class="character-box" ng-style="{ 'background-image': 'url(' + vm.store.background + ')' }">
-  <div class="emblem" ng-style="{ 'background-image': 'url(' + vm.store.icon + ')' }"></div>
-  <div class="class">{{:: vm.store.className }}</div>
-  <div class="race-gender" ng-if="::!vm.store.isVault">{{:: vm.store.genderRace }}</div>
-  <div class="level" ng-if="::!vm.store.isVault"><span translate="Stats.Level"></span> {{ vm.store.level }}</div>
-  <div class="level powerLevel" ng-if="!vm.store.isVault">{{ vm.store.powerLevel }}</div>
-  <div class="currency" ng-if="::!!vm.store.isVault"> {{ vm.store.glimmer }} <img src="~app/images/glimmer.png"></div>
-  <div class="currency legendaryMarks" ng-if="::!!vm.store.isVault"> {{ vm.store.legendaryMarks }} <img src="~app/images/legendaryMarks.png"></div>
-  <div class="levelBar" ng-class="{ moteProgress: !vm.store.percentToNextLevel }" ng-if="::!vm.store.isVault" title="{{vm.xpTillMote}}">
-    <div class="barFill" dim-percent-width="vm.levelBar"></div>
+<div class="character-box">
+  <div class="background" ng-style="{ 'background-image': 'url(' + vm.store.background + ')' }"></div>
+  <div class="details">
+    <div class="emblem" ng-style="{ 'background-image': 'url(' + vm.store.icon + ')' }"></div>
+    <div class="character-text">
+      <div class="top">
+        <div class="class">{{:: vm.store.className }}</div>
+        <div class="powerLevel" ng-if="!vm.store.isVault">{{ vm.store.powerLevel }}</div>
+      </div>
+      <div class="bottom">
+        <div class="race-gender" ng-if="::!vm.store.isVault">{{:: vm.store.genderRace }}</div>
+        <div class="level" ng-if="::!vm.store.isVault">{{ vm.store.level }}</div>
+      </div>
+      <div class="levelBar" ng-class="{ moteProgress: !vm.store.percentToNextLevel }" ng-if="::!vm.store.isVault" title="{{vm.xpTillMote}}" dim-percent-width="vm.levelBar"></div>
+    </div>
+    <div class="currencies">
+      <div class="currency" ng-if="::!!vm.store.isVault"> {{ vm.store.glimmer }} <img src="~app/images/glimmer.png"></div>
+      <div class="currency legendaryMarks" ng-if="::!!vm.store.isVault"> {{ vm.store.legendaryMarks }} <img src="~app/images/legendaryMarks.png"></div>
+    </div>
+    <i class="loadout-button fa fa-chevron-circle-down" translate-attr="{ title: 'Loadouts' }" ng-click="vm.openLoadoutPopup($event)"></i>
+    <!--
+         <div class="loadout-button" translate-attr="{ title: 'Loadouts' }" ng-click="vm.openLoadoutPopup($event)"><i class="fa fa-chevron-down"></i></div>
+       -->
   </div>
-  <div class="loadout-button" translate-attr="{ title: 'Loadouts' }" ng-click="vm.openLoadoutPopup($event)"><i class="fa fa-chevron-down"></i></div>
+  <div class="overlay" ng-click="vm.openLoadoutPopup($event)"></div>
+</div>
 </div>
 <div class="loadout-menu" loadout-id="{{:: vm.store.id }}"></div>
 <dim-stats stats="vm.store.stats" ng-if="!vm.store.isVault"></dim-stats>

--- a/src/scripts/store/dimStoreHeading.directive.template.html
+++ b/src/scripts/store/dimStoreHeading.directive.template.html
@@ -1,4 +1,4 @@
-<div class="character-box">
+<div class="character-box" ng-click="vm.openLoadoutPopup($event)">
   <div class="background" ng-style="{ 'background-image': 'url(' + vm.store.background + ')' }"></div>
   <div class="details">
     <div class="emblem" ng-style="{ 'background-image': 'url(' + vm.store.icon + ')' }"></div>
@@ -17,12 +17,8 @@
       <div class="currency" ng-if="::!!vm.store.isVault"> {{ vm.store.glimmer }} <img src="~app/images/glimmer.png"></div>
       <div class="currency legendaryMarks" ng-if="::!!vm.store.isVault"> {{ vm.store.legendaryMarks }} <img src="~app/images/legendaryMarks.png"></div>
     </div>
-    <i class="loadout-button fa fa-chevron-circle-down" translate-attr="{ title: 'Loadouts' }" ng-click="vm.openLoadoutPopup($event)"></i>
-    <!--
-         <div class="loadout-button" translate-attr="{ title: 'Loadouts' }" ng-click="vm.openLoadoutPopup($event)"><i class="fa fa-chevron-down"></i></div>
-       -->
+    <i class="loadout-button fa fa-chevron-circle-down" translate-attr="{ title: 'Loadouts' }"></i>
   </div>
-  <div class="overlay" ng-click="vm.openLoadoutPopup($event)"></div>
 </div>
 </div>
 <div class="loadout-menu" loadout-id="{{:: vm.store.id }}"></div>

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -754,96 +754,123 @@ dim-store-heading {
   flex: 1;
   margin-bottom: 10px;
   height: 70px;
+  width: 100%;
 }
 
 .character-box {
   position: relative;
-  height: 50px;
-  padding: 0 30px 0 44px;
-  /* background: rgba(30, 36, 43, .5); */
-  text-shadow: 1px 1px 1px #000000;
-  color: #f5f5f5;
-  text-decoration: none;
-  background-size: cover;
-  .emblem {
+  border-bottom: 2px solid #888;
+  height: 46px;
+  cursor: pointer;
+
+  * {
+    //box-sizing: border-box;
+  }
+
+  .details {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 4px 6px 4px 8px;
+  }
+
+  .background {
     position: absolute;
-    top: 3px;
-    left: 1px;
-    width: 38px;
-    height: 38px;
+    width: 100%;
+    height: 100%;
+    filter: brightness(60%);
+    background-size: cover;
+    background-position: right center;
+    background-repeat: no-repeat;
+    z-index: -1;
+  }
+
+  .overlay {
+    display: none;
+    z-index: 1;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: .1;
+    background-color: white;
+  }
+
+  &:hover, &:active {
+    .overlay {
+      display: block;
+    }
+  }
+
+  .character-text {
+    font-family: Roboto, 'Open Sans', sans-serif;
+    flex: 1;
+    text-shadow: 1px 1px 1px rgba(0,0,0,.5), 0px 0px 10px rgba(0,0,0,.5);
+  }
+
+  .top, .bottom {
+    width: 100%;
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: row;
+    align-items: center;
+    font-weight: 300;
+  }
+  .top {
+    font-size: 20px;
+    font-weight: 300;
+    height: 24px;
+  }
+  .bottom {
+    font-size: 12px;
+    color: #bbb;
+    letter-spacing: .125px;
+    height: 14px;
+  }
+  .emblem {
+    width: 32px;
+    height: 32px;
+    margin-right: 8px;
     background-color: rgba(0, 0, 0, 0.2);
     background-size: cover;
   }
-  .class {
+  .class, .race-gender {
     text-transform: capitalize;
-    position: relative;
-    display: block;
-    top: 5px;
-    font-size: 16px;
-    font-weight: 400;
-  }
-}
-
-.character-box {
-  .race-gender {
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    font-size: 0.9em;
-    top: 1px;
-    position: relative;
+    flex: 1;
+    text-overflow: ellipsis;
   }
   .level {
-    position: absolute;
-    top: 5px;
-    right: 35px;
-    font-weight: 200;
-    font-size: 14px;
+    margin-right: 1px;
+  }
+  .powerLevel {
+    color: #f5dc56;
+    &:before {
+      content: "\2726";
+      display: inline-block;
+      vertical-align: 25%;
+      font-size: 50%;
+    }
+  }
+  .currencies {
+    text-align: right;
   }
   .currency {
-    position: absolute;
-    top: 4px;
-    right: 40px;
     font-weight: 200;
     font-size: 14px;
-  }
-  .legendaryMarks {
-    position: absolute;
-    top: 23px;
-    right: 40px;
-  }
-  .level.powerLevel {
-    position: absolute;
-    top: 20px;
-    right: 35px;
-    font-weight: 200;
-    font-size: 14px;
-    color: #f5dc56;
-  }
-  .powerLevel:before {
-    content: "\2726";
-    display: inline-block;
-    vertical-align: 25%;
-    font-size: 50%;
   }
 }
 
 .levelBar {
-  height: 4px;
-  background-color: rgba(245, 245, 245, 0.1);
+  height: 2px;
   width: 100%;
   position: absolute;
-  bottom: 0;
+  bottom: -2px;
   left: 0;
-
-}
-
-.barFill {
   background-color: #5da469;
-  width: 0%;
-  height: 100%;
 
-  .moteProgress & {
-    background-color: #00aae1;
+  &.moteProgress {
+    background-color: #069;
     opacity: .6;
   }
 }
@@ -932,28 +959,14 @@ dim-store-heading {
 }
 
 .loadout-button {
-  position: absolute;
-  top: 0;
-  right: 0;
-  background-color: rgba(120, 120, 120, 0.7);
-  width: 30px;
-  height: 46px;
-  color: rgba(200, 200, 200, 1);
+  color: white;
   text-align: center;
-  font-size: 15px;
-  line-height: 41px;
-  padding: 0;
-  box-sizing: border-box;
+  font-size: 18px;
   cursor: pointer;
   outline: none;
-  &:hover {
-    background-color: rgba(160, 160, 160, 0.8);
-    color: rgba(245, 245, 245, 1);
-  }
-  .active {
-    background-color: rgba(10, 10, 10, 0.25);
-    color: rgba(245, 245, 245, 0.75);
-  }
+  margin-left: 6px;
+  margin-top: 1px;
+  opacity: 0.8;
 }
 
 .loadout-popup-content {
@@ -1346,8 +1359,8 @@ g {
 
 .stores {
   display: block;
-  // 100px margin to make room for the fixed header
-  margin-top: 100px;
+  // 97px margin to make room for the fixed header
+  margin-top: 97px;
 }
 
 .store-bounds {
@@ -1743,7 +1756,7 @@ h2, h3, h4 {
   right: 0;
   top: 50px;
   background-color: #434444;
-  height: 90px;
+  height: 87px;
   position: fixed;
   z-index: 4;
 
@@ -2093,8 +2106,8 @@ dim-manifest-progress {
   top: 0;
   left: 0;
   z-index: 1000;
-  border-top: 15px solid gold;
-  border-right: 15px solid transparent;
+  border-top: 13px solid gold;
+  border-right: 13px solid transparent;
 }
 
 .fa.fa-circle.trials {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -25,6 +25,10 @@
   height: var(--item-size + 4px);
 }
 
+h1, h2, h3, h4, h5 {
+  font-weight: normal;
+}
+
 div:focus, span:focus {
   outline-width: 0;
 }
@@ -193,6 +197,21 @@ dd {
   opacity: .20;
 }
 
+.search-link {
+  position: relative;
+  top: -2px;
+}
+
+.filter-help {
+  position: absolute;
+  right: -4px;
+  top: 1px;
+  .fa {
+    font-size: 16px !important;
+    color: #999 !important;
+  }
+}
+
 .ngdialog.modal-dialog {
   position: fixed;
   width: 100%;
@@ -325,6 +344,7 @@ a {
     margin-bottom: 0;
     padding: 15px;
     font-weight: 200;
+    background-color: #101010;
   }
   h2 {
     margin-top: 0;
@@ -804,8 +824,8 @@ dim-store-heading {
   }
 
   &:hover, &:active {
-    .overlay {
-      display: block;
+    .background {
+      filter: none;
     }
   }
 
@@ -887,7 +907,7 @@ dim-store-heading {
   opacity: .8;
   display: flex;
   flex-direction: row;
-  margin-top: 2px;
+  margin-top: 3px;
   .stat {
     flex: 1;
     display: flex;
@@ -928,7 +948,7 @@ dim-store-heading {
   opacity: 0.8;
 
   height: 16px;
-  margin-top: 2px;
+  margin-top: 3px;
   .vault-bucket {
     flex: 1;
     margin-right: 8px;
@@ -1421,7 +1441,7 @@ g {
 
 .store-header {
   position: fixed;
-  top: 54px;
+  top: 53px;
   z-index: 10;
 }
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -179,6 +179,7 @@ div:focus, span:focus {
   width: 250px;
   margin-left: -3gpx;
   margin-bottom: 4px;
+  padding-right: 20px;
   border-radius: 0;
   -webkit-appearance: none;
 }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -105,6 +105,15 @@ div:focus, span:focus {
     font-size: 15px;
     color: #fafafa;
   }
+  .content {
+    margin: 0 auto;
+    padding: 8px 1em;
+    > {
+      .link, .header-right {
+        margin-top: 1px;
+      }
+    }
+  }
   .content span, .content a {
     vertical-align: middle;
     margin: 0 8px;
@@ -116,6 +125,17 @@ div:focus, span:focus {
     -webkit-touch-callout: none;
     user-select: none;
     outline: none;
+  }
+  position: fixed;
+  z-index: 5;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 42px;
+  background-color: #222;
+  .header-right {
+    cursor: default;
+    float: right;
   }
 }
 
@@ -434,20 +454,6 @@ input, select, option {
   font-family: 'Open Sans', sans-serif;
 }
 
-#header {
-  position: fixed;
-  z-index: 5;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 50px;
-  background-color: #222;
-  .header-right {
-    cursor: default;
-    float: right;
-  }
-}
-
 #system {
   float: right;
   margin-right: 5px;
@@ -506,8 +512,8 @@ img {
   padding: 0 16px;
   background-color: #353535;
   color: white;
-  line-height: 40px;
-  height: 40px;
+  line-height: 34px;
+  height: 34px;
   text-transform: uppercase;
   letter-spacing: 2px;
   font-size: 14px;
@@ -753,7 +759,7 @@ dim-store-heading {
 .character {
   flex: 1;
   margin-bottom: 10px;
-  height: 70px;
+  height: 58px;
   width: 100%;
 }
 
@@ -778,7 +784,7 @@ dim-store-heading {
     position: absolute;
     width: 100%;
     height: 100%;
-    filter: brightness(60%);
+    filter: brightness(70%);
     background-size: cover;
     background-position: right center;
     background-repeat: no-repeat;
@@ -881,7 +887,7 @@ dim-store-heading {
   opacity: .8;
   display: flex;
   flex-direction: row;
-  margin-top: 4px;
+  margin-top: 2px;
   .stat {
     flex: 1;
     display: flex;
@@ -919,9 +925,10 @@ dim-store-heading {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  opacity: 0.8;
 
   height: 16px;
-  margin-top: 4px;
+  margin-top: 2px;
   .vault-bucket {
     flex: 1;
     margin-right: 8px;
@@ -1332,7 +1339,7 @@ g {
 
 #content {
   margin: 15px auto;
-  padding: 0 2em;
+  padding: 0 1em;
   margin-top: 15px;
   user-select: none;
 }
@@ -1345,22 +1352,10 @@ g {
   max-width: calc((52px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px))) * var(--num-characters) + 20px + (var(--vault-max-columns) * (var(--item-size) + 8px)));
 }
 
-#header {
-  .content {
-    margin: 0 auto;
-    padding: 12px 2em;
-    > {
-      .link, .header-right {
-        margin-top: 1px;
-      }
-    }
-  }
-}
-
 .stores {
   display: block;
-  // 97px margin to make room for the fixed header
-  margin-top: 97px;
+  // 84px margin to make room for the fixed header
+  margin-top: 84px;
 }
 
 .store-bounds {
@@ -1426,7 +1421,7 @@ g {
 
 .store-header {
   position: fixed;
-  top: 64px;
+  top: 54px;
   z-index: 10;
 }
 
@@ -1754,9 +1749,9 @@ h2, h3, h4 {
 .sticky-header-background {
   left: 0;
   right: 0;
-  top: 50px;
+  top: 42px;
   background-color: #434444;
-  height: 87px;
+  height: 82px;
   position: fixed;
   z-index: 4;
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -117,18 +117,18 @@ div:focus, span:focus {
         margin-top: 1px;
       }
     }
-  }
-  .content span, .content a {
-    vertical-align: middle;
-    margin: 0 8px;
-    text-decoration: none;
-    display: inline-block;
-    font-size: 13px;
-    line-height: 25px;
-    text-align: center;
-    -webkit-touch-callout: none;
-    user-select: none;
-    outline: none;
+    span, a {
+      vertical-align: middle;
+      margin: 0 6px;
+      text-decoration: none;
+      display: inline-block;
+      font-size: 13px;
+      line-height: 25px;
+      text-align: center;
+      -webkit-touch-callout: none;
+      user-select: none;
+      outline: none;
+    }
   }
   position: fixed;
   z-index: 5;

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -177,7 +177,7 @@ div:focus, span:focus {
 
 #filter-input {
   width: 250px;
-  margin-left: -10px;
+  margin-left: -3gpx;
   margin-bottom: 4px;
   border-radius: 0;
   -webkit-appearance: none;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -5,3 +5,5 @@ $blue: #68a0b7;
 $arc: #85c5ec;
 $solar: #f2721b;
 $void: #b184c5;
+
+$character-box-height: 46px;

--- a/src/scss/_vendors.scss
+++ b/src/scss/_vendors.scss
@@ -4,7 +4,7 @@
   margin: 0 auto;
 
   .vendors {
-    margin-top: 55px;
+    margin-top: 44px;
   }
   .vendorLabels h1 {
     display: inline-block;
@@ -66,18 +66,18 @@
     height: 51px;
     left: 0;
     width: 100%;
-    top: 50px;
+    top: 42px;
     background-color: #434444;
     z-index: 4;
   }
   .vendorHeaderWrapper {
     position: absolute;
-    top: 85px;
+    top: 72px;
     z-index: 4;
   }
   .vendorHeaderWrapper.sticky {
     position:fixed;
-    top: 50px;
+    top: 42px;
   }
   .vendor-headers-background.sticky {
     display: block;

--- a/src/views/content.html
+++ b/src/views/content.html
@@ -7,8 +7,10 @@
         <span class="link" ng-click="app.toggleMinMax($event)" translate-attr="{ title: 'LB'}"><i class="fa fa-bar-chart"></i></span>
         <span class="link" ng-if="app.featureFlags.materialsExchangeEnabled" ui-sref="materials-exchange" translate-attr="{ title: 'Header.MaterialsExchange' }"><i class="fa fa-list-alt"></i></span>
         <span class="link" ng-click="app.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
-        <span class="link" ng-click="app.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-filter"></i></span>
-        <span class="link" title="Search"><span focus-on="clicked" dim-search-filter=""></span></span>
+        <span class="link search-link">
+          <span class="filter-help" ng-click="app.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-question-circle-o"></i></span>
+          <dim-search-filter></dim-search-filter>
+        </span>
       </div>
     </span>
     <span class="logo link" ng-class="app.$DIM_FLAVOR" ui-sref="inventory" title="v{{app.$DIM_VERSION}} ({{app.$DIM_FLAVOR}})">DIM</span>


### PR DESCRIPTION
Inspired by the flat styling and a handful of prototypes we'd passed around a few months ago, here are some general styling updates to DIM.

Before:
<img width="508" alt="screen shot 2017-03-07 at 10 06 12 pm" src="https://cloud.githubusercontent.com/assets/313208/23692260/5e8c9836-0382-11e7-8fd5-8ddae1ece0bd.png">
After:
<img width="490" alt="screen shot 2017-03-07 at 10 05 18 pm" src="https://cloud.githubusercontent.com/assets/313208/23692262/5e8e1a26-0382-11e7-8990-7ff53f81f7a1.png">

* New design (based on @SunburnedGoose's work) for character headers. These are a bit shorter, have a dimmed background, more separated emblem, and generally better typography and visual hierarchy. Less overlapping stuff, all-caps, and fewer extra words. Level is less prominent while light and class is more. I've replaced the loadouts button with a smaller icon and now the entire character header is tappable to open loadouts (with a hover effect) so it should be a bit more touch-friendly.
* Reduced the height of the header, the height of section titles, and padding values around the edge of the screen and around the header. This gets us back some wasted space that's precious on smaller screens.

Before:
<img width="278" alt="screen shot 2017-03-07 at 10 06 32 pm" src="https://cloud.githubusercontent.com/assets/313208/23692261/5e8d3520-0382-11e7-8b13-5fd7b097b182.png">
After:
<img width="306" alt="screen shot 2017-03-07 at 10 05 35 pm" src="https://cloud.githubusercontent.com/assets/313208/23692259/5e8be47c-0382-11e7-8074-11fad0892803.png">

* The vault gets the same character styling, plus I fixed a bug that'd bothered me for a long time - the vault fullness meters were slightly too bright, since I hadn't seen that the other stat meters had a slight transparency effect applied to them.

Before:
<img width="629" alt="screen shot 2017-03-07 at 10 06 37 pm" src="https://cloud.githubusercontent.com/assets/313208/23692263/5e8e392a-0382-11e7-96a6-ce04cb0ff7c2.png">
After:
<img width="559" alt="screen shot 2017-03-07 at 10 23 53 pm" src="https://cloud.githubusercontent.com/assets/313208/23692643/ca3a7bf0-0384-11e7-8ced-520d944469d9.png">

* Removed the "person" icon from next to your username, since it doesn't really add much and takes up space.
* Move the "funnel" filter-help icon into the filter textbox itself, with a more standard "help" icon.
* Move the links/icons a bit closer together so they don't look too spread out with the new shorter header.

Plus a few small fixes to headers (not so bold) and popup titles (they lost their background in the flat styling PR).