### PR TITLE
Clean up Support link

### DIFF
--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -393,7 +393,11 @@
      "Support": {
        "Support": "Supporting DIM",
        "FreeToDownload": "DIM is a product that is free to download and use. The source code for DIM is open sourced, and free to anyone to enhance. You will never see an ad in DIM. That is our commitment.",
-       "OpenCollective": "We are using OpenCollective as a service to provide compensation to our developers for their dedication and time spent on this project."
+       "OpenCollective": "We are using OpenCollective as a service to provide compensation to our developers for their dedication and time spent on this project.",
+       "Backers": "Backers",
+       "BackersDetail": "Support us with a one-time or monthly donation and help us continue our active development.",
+       "Sponsors": "Sponsors",
+       "SponsorsDetail": "Become a sponsor and get your logo here with a link to your site."
      },
      "UpgradeChrome": "Your version of Chrome is too old to run DIM. Please update Chrome in order to use DIM."
    },

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -2113,3 +2113,12 @@ dim-manifest-progress {
 .disabled {
   opacity: 0.5;
 }
+
+.support h2 {
+  margin-top: 1em;
+  margin-bottom: .25em;
+}
+
+.backers a {
+  margin-right: 1em;
+}

--- a/src/views/content.html
+++ b/src/views/content.html
@@ -13,7 +13,7 @@
     </span>
     <span class="logo link" ng-class="app.$DIM_FLAVOR" ui-sref="inventory" title="v{{app.$DIM_VERSION}} ({{app.$DIM_FLAVOR}})">DIM</span>
     <span class="link" ng-click="app.showAbout($event)" translate="Header.About"></span>
-    <a class="oc link" ng-click="app.showSupport($event)" target='_blank' href='https://opencollective.com/dim' translate="Header.SupportDIM"></a>
+    <a class="oc link" ng-click="app.showSupport($event)" translate="Header.SupportDIM"></a>
     <span class="link" ng-if="app.featureFlags.vendorsEnabled" ng-class="{disabled: !app.vendorService.vendorsLoaded}" ng-click="app.toggleVendors($event)" translate="Vendors"></span>
     <span class="link" ng-if="app.xur.available" ng-click="app.showXur($event)">Xûr</span>
   </div>

--- a/src/views/support.template.html
+++ b/src/views/support.template.html
@@ -3,5 +3,15 @@
     <div class="ngdialog-inner-content">
         <p translate="Views.Support.FreeToDownload"></p>
         <p translate="Views.Support.OpenCollective"></p>
+        <h2 translate="Views.Support.Backers"></h2>
+        <p translate="Views.Support.BackersDetail"></p>
+        <div class="backers">
+          <a ng-repeat="i in 29 | range track by $index" ng-href="https://opencollective.com/dim/backer/{{$index}}/website" target="_blank"><img ng-src="https://opencollective.com/dim/backer/{{$index}}/avatar.svg"></a>
+        </div>
+        <h2 translate="Views.Support.Sponsors"></h2>
+        <p translate="Views.Support.SponsorsDetail"></p>
+        <div class="backers">
+          <a ng-repeat="i in 29 | range track by $index" ng-href="https://opencollective.com/dim/sponsor/{{$index}}/website" target="_blank"><img ng-src="https://opencollective.com/dim/sponsor/{{$index}}/avatar.svg"></a>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
With the OpenCollective changes, the "Support" link would open both the dialog and a new tab to OpenCollective. I've switched it to only open the dialog. I've also added in the list of supporters/backers and call to action buttons like we have on the README.

<img width="704" alt="screen shot 2017-03-07 at 10 57 24 pm" src="https://cloud.githubusercontent.com/assets/313208/23693461/786cbda6-0389-11e7-8bf9-7beeef0214aa.png">
