### PR TITLE
Fix a bug with checking isAuthenticated

### DIFF
--- a/src/scripts/oauth/http-refresh-token.service.js
+++ b/src/scripts/oauth/http-refresh-token.service.js
@@ -25,7 +25,7 @@ function HttpRefreshTokenService($rootScope, $q, $injector, OAuthService, OAuthT
 
     if (matched >= 0) {
       if (!config.headers.hasOwnProperty('Authorization')) {
-        if (OAuthService.isAuthenticated) {
+        if (OAuthService.isAuthenticated()) {
           let isValid = isTokenValid(OAuthTokenService.getAccessToken());
 
           if (isValid) {


### PR DESCRIPTION
We forgot the parentheses, so we were checking the presence of the `isAuthenticated` function, not its result. This may help with the refresh token problems folks have been seeing.