### PR TITLE
Fix felwinters exclusion and too-small perk lockdown dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * When dequipping an item, we try harder to find a good item to equip in its place. We also prefer replacing exotics with other exotics, and correctly handle The Life Exotic perk.
 * Lots of new translations and localized strings.
 * Vendors update when you reach a new level in their associated faction, or when you change faction alignment.
+* Fixed a too-small perk selection box in the loadout builder, and properly handle when vendors are selling Memory of Felwinter.
 
 # 3.14.1
 

--- a/src/scripts/minmax/dimMinMax.controller.js
+++ b/src/scripts/minmax/dimMinMax.controller.js
@@ -637,6 +637,7 @@ function dimMinMaxCtrl($scope, $rootScope, $state, $q, $timeout, $location, $tra
           var felwinters = _.filter(items, { hash: 2672107540 });
           if (felwinters.length) {
             vm.excludeditems.push(...felwinters);
+            vm.excludeditems = _.uniq(vm.excludeditems, 'id');
           }
 
           allItems = allItems.concat(items);
@@ -662,6 +663,7 @@ function dimMinMaxCtrl($scope, $rootScope, $state, $q, $timeout, $location, $tra
           var felwinters = _.filter(vendorItems, { hash: 2672107540 });
           if (felwinters.length) {
             vm.excludeditems.push(...felwinters);
+            vm.excludeditems = _.uniq(vm.excludeditems, 'id');
           }
 
           // Build a map of perks

--- a/src/scripts/minmax/dimMinMaxLocks.directive.js
+++ b/src/scripts/minmax/dimMinMaxLocks.directive.js
@@ -56,7 +56,8 @@ function MinMaxLocksCtrl($scope, hotkeys, ngDialog) {
         my: 'left-2 top-2',
         at: 'left top',
         of: detailItemElement,
-        collision: 'flip flip'
+        collision: 'flip flip',
+        within: '.store-bounds'
       });
     }
   });

--- a/src/scss/_loadout-builder.scss
+++ b/src/scss/_loadout-builder.scss
@@ -335,8 +335,7 @@
   left: 0;
   top: 0;
   width: calc(((var(--item-size) + 20px) * 5) + 14px);
-  min-height: var(--item-size);
-  max-height: calc((var(--item-size) * 5) + 10px);
+  min-height: calc((var(--item-size) * 5) + 10px);
   overflow-y: auto;
   background-color: #656565;
   border: 2px solid #DDD;

--- a/src/views/best.template.html
+++ b/src/views/best.template.html
@@ -52,7 +52,7 @@
       <div class="excluded-container">
         <div drag-channel="Helmet, Gauntlets, Chest, Leg, ClassItem, Ghost, Artifact" drop-channel="Helmet, Gauntlets, Chest, Leg, ClassItem, Ghost, Artifact" ui-on-drop="vm.onExcludedDrop($data, $channel)" drop-validate="vm.excludedItemsValid($data, $channel)">
           <div class="excluded-items">
-            <div class="excluded-item" ng-repeat="excludeditem in vm.excludeditems">
+            <div class="excluded-item" ng-repeat="excludeditem in vm.excludeditems track by excludeditem.index">
               <dim-min-max-item item-data="excludeditem" store-data="vm.getStore(excludeditem.owner)"></dim-min-max-item>
               <div class="close" ng-click="vm.onExcludedRemove(excludeditem.index)" role="button" tabindex="0"></div>
             </div>


### PR DESCRIPTION
We were getting a repeater error on felwinters being added to the exclusion list - there's something deeper wrong with the code, but I don't have time to dig into it. Also fixes #1542.