### PR TITLE
Fix the logic for deciding when an item can be tagged.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+* Fixed the logic for deciding which items can be tagged.
+
 # v3.17.1
 
 * Fixed a bug with the display of the amount selection controls in the move popup for stackable items.

--- a/src/scripts/services/dimStoreService.factory.js
+++ b/src/scripts/services/dimStoreService.factory.js
@@ -789,7 +789,6 @@ function StoreService(
       visible: true,
       sourceHashes: itemDef.sourceHashes,
       lockable: normalBucket.type !== 'Class' && ((currentBucket.inPostmaster && item.isEquipment) || currentBucket.inWeapons || item.lockable),
-      taggable: item.lockable && !_.contains(categories, 'CATEGORY_ENGRAM'),
       trackable: currentBucket.inProgress && (currentBucket.hash === 2197472680 || currentBucket.hash === 1801258597),
       tracked: item.state === 2,
       locked: item.locked,
@@ -797,6 +796,8 @@ function StoreService(
       classified: itemDef.classified,
       isInLoadout: false
     });
+
+    createdItem.taggable = createdItem.lockable && !_.contains(categories, 'CATEGORY_ENGRAM');
 
     createdItem.index = createItemIndex(createdItem);
 


### PR DESCRIPTION
https://github.com/DestinyItemManager/DIM/pull/1478 introduced the `taggable` property on items, but used a `lockable` property that doesn't exist on `item` - it exists on `createdItem` which is still being constructed at this point. Moving the definition out of the object literal allows it to reference the correct `lockable`. This fixes #1556.