### PR TITLE
Fix "make room for postmaster"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+* Fix "Make room for postmaster".
+
 # v3.17.1
 
 * Fixed a bug with the display of the amount selection controls in the move popup for stackable items.

--- a/src/scripts/services/dimStoreService.factory.js
+++ b/src/scripts/services/dimStoreService.factory.js
@@ -767,7 +767,7 @@ function StoreService(
       name: itemDef.itemName,
       description: itemDef.itemDescription || '', // Added description for Bounties for now JFLAY2015
       icon: itemDef.icon,
-      notransfer: (currentBucket.inPostmaster || itemDef.nonTransferrable || !itemDef.allowActions || itemDef.classified),
+      notransfer: Boolean(currentBucket.inPostmaster || itemDef.nonTransferrable || !itemDef.allowActions || itemDef.classified),
       id: item.itemInstanceId,
       equipped: item.isEquipped,
       equipment: item.isEquipment,


### PR DESCRIPTION
The classified item changes ended up setting the value of `notransfer` to `undefined`, which is falsy but not `false`. This broke the `_.select` filter in the "make room for Postmaster" function, which was specifically looking for `false`, not just falsy.

This fixes #1559.