### PR TITLE
Fix showing elements, new-item shine, quality when prefs are changed

### DIFF
--- a/src/scripts/shell/shell/shell.controller.js
+++ b/src/scripts/shell/shell/shell.controller.js
@@ -4,11 +4,5 @@ export default class ShellController {
 
     this.featureFlags = dimFeatureFlags;
     this.settings = dimSettingsService;
-    this.classes = {
-      'show-elements': this.settings.showElements,
-      itemQuality: this.featureFlags.qualityEnabled && this.settings.itemQuality,
-      'show-new-items': this.settings.showNewItems,
-      'new-item-animated': this.settings.showNewAnimation
-    };
   }
 }

--- a/src/scripts/shell/shell/shell.html
+++ b/src/scripts/shell/shell/shell.html
@@ -1,3 +1,8 @@
-<div class="app" ng-class="$ctrl.classes">
+<div class="app" ng-class="{
+  'show-elements': $ctrl.settings.showElements,
+  itemQuality: $ctrl.featureFlags.qualityEnabled && $ctrl.settings.itemQuality,
+  'show-new-items': $ctrl.settings.showNewItems,
+  'new-item-animated': $ctrl.settings.showNewAnimation
+}">
   <ui-view></ui-view>
 </div>


### PR DESCRIPTION
Fix a regression from when we added the `shell` component where quality, new-item shine, and elements on items won't change when you change settings. The code had been changed to statically compute a class map when the controller started, but wouldn't watch for subsequent updates.