### PR TITLE
Fix record books to show time formatting

### DIFF
--- a/src/scripts/record-books/record-books.component.js
+++ b/src/scripts/record-books/record-books.component.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import angular from 'angular';
+import moment from 'moment';
 import { sum, count } from '../util';
 
 import templateUrl from './record-books.html';
@@ -107,8 +108,10 @@ function RecordBooksController($scope, dimStoreService, dimDefinitions, dimSetti
       const objectiveDef = defs.Objective.get(objective.objectiveHash);
 
       let display = undefined;
-      if (record.recordValueUIStyle === '_investment_record_value_ui_style_time_in_milliseconds') {
-        display = objective.displayValue;
+      if (recordDef.recordValueUIStyle === '_investment_record_value_ui_style_time_in_milliseconds') {
+        display = objective.isComplete
+          ? objective.displayValue
+          : moment(moment.duration(objectiveDef.completionValue)._data).format("m:ss.SSS");
       }
 
       return {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -1327,7 +1327,6 @@ rzslider, .rzslider {
 
 .objective-text {
   margin-right: 4px;
-  z-index: 100;
 }
 
 .objective-boolean {


### PR DESCRIPTION
(Also snuck in a resolution for #1570) 

Some objectives are a time to beat, it looks like there may have been a
typo copying things over. I also went and added the formatted
completion value if the objective is not complete, so the user knows
the time to beat instead of come in at “under the time limit”

### Before
<img width="437" alt="screen shot 2017-03-29 at 12 05 30 pm" src="https://cloud.githubusercontent.com/assets/424158/24472448/8f046e36-147a-11e7-938c-254f3661b7a7.png">

### After (uncompleted example)
<img width="435" alt="screen shot 2017-03-29 at 12 20 37 pm" src="https://cloud.githubusercontent.com/assets/424158/24472416/79660d00-147a-11e7-88bc-513c22e689a7.png">

### After (completed example)
<img width="434" alt="screen shot 2017-03-29 at 12 20 17 pm" src="https://cloud.githubusercontent.com/assets/424158/24472442/8b419292-147a-11e7-853a-aa359c65ccdb.png">
