### PR TITLE
Remove web-app-compatible flag since it doesn't play with OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Localization updates.
 * Fixed objective text in the record book floating above stuff.
 * Fixed displaying record objectives that are time-based as time instead of just a number of seconds.
+* When pinned to the iOS home screen, DIM now looks more like a regular browser than an app. The upside is you can now actually authorize it when it's pinned!
 
 # v3.17.1
 

--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,6 @@
     <link rel="manifest" href="/manifest-webapp.json">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444">
     <meta name="theme-color" content="#434444">
-    <meta name='apple-mobile-web-app-capable' content='yes'>
     <meta name='apple-mobile-web-app-status-bar-style' content='black'>
 
     {{#each htmlWebpackPlugin.files.chunks.main.css}}


### PR DESCRIPTION
This fixes #1571. Sadly Apple hasn't got a solution for app-style pinned apps that also need to redirect to another site for an OAuth authorization flow. After this change DIM should actually work when pinned to the home screen.