### PR TITLE
Enable strict dependency injection

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="" ng-app="app" ng-csp>
+<html lang="" ng-app="app" ng-csp ng-strict-di>
 
   <head>
     <meta charset="utf-8">

--- a/src/return.html
+++ b/src/return.html
@@ -8,7 +8,7 @@
   </head>
 
   <body>
-    <div ng-app="dimLogin">
+    <div ng-app="dimLogin" ng-strict-di ng-csp>
       <dim-return></dim-return>
     </div>
 


### PR DESCRIPTION
A few times now we've hit a situation where `ng-annotate` hasn't done its job and the app has stopped working after minification. This inspired #1473 but minifying all the time is super slow. Instead, we can turn on `ng-strict-di` mode, which turns off Angular's auto-injection machinery (which we don't want to use anyway). This means you are required to either state `'ngInject';` explicitly, or write your code in such a way that `ng-annotate` can automatically annotate it (this is most of our existing code, but the new patterns don't lend themselves to this). If it works in `dev`, it'll be guaranteed to also work that way when minified.