### PR TITLE
Fix up OAuth - no more spurious login screens

### DIFF
--- a/src/scripts/login/return.component.js
+++ b/src/scripts/login/return.component.js
@@ -44,7 +44,7 @@ function ReturnController($http) {
     })
     .then((response) => {
       if (response.data.ErrorCode === 1) {
-        const inception = new Date().toISOString();
+        const inception = Date.now();
         const authorization = {
           accessToken: angular.merge({}, response.data.Response.accessToken, { name: 'access', inception: inception }),
           refreshToken: angular.merge({}, response.data.Response.refreshToken, { name: 'refresh', inception: inception }),

--- a/src/scripts/oauth/http-refresh-token.service.js
+++ b/src/scripts/oauth/http-refresh-token.service.js
@@ -35,15 +35,19 @@ function HttpRefreshTokenService($rootScope, $q, $injector, OAuthService, OAuthT
                 cache = OAuthService.refreshToken();
               }
 
-              return cache.then(function() {
-                config.headers.Authorization = OAuthTokenService.getAuthorizationHeader();
-
-                return config;
-              })
-              .catch(() => {
-                OAuthTokenService.removeToken();
-                $rootScope.$broadcast('dim-no-token-found');
-              });
+              return cache
+                .then(function() {
+                  config.headers.Authorization = OAuthTokenService.getAuthorizationHeader();
+                  return config;
+                })
+                .catch((e) => {
+                  OAuthTokenService.removeToken();
+                  $rootScope.$broadcast('dim-no-token-found');
+                  throw e;
+                })
+                .finally(() => {
+                  cache = null;
+                });
             } else {
               OAuthTokenService.removeToken();
               $rootScope.$broadcast('dim-no-token-found');

--- a/src/scripts/oauth/http-refresh-token.service.js
+++ b/src/scripts/oauth/http-refresh-token.service.js
@@ -3,6 +3,10 @@ import angular from 'angular';
 angular.module('dim-oauth')
   .service('http-refresh-token', HttpRefreshTokenService);
 
+/**
+ * This is an interceptor for the $http service that watches for missing or expired
+ * OAuth tokens and attempts to acquire them.
+ */
 function HttpRefreshTokenService($rootScope, $q, $injector, OAuthService, OAuthTokenService) {
   'ngInject';
 

--- a/src/scripts/oauth/http-refresh-token.service.js
+++ b/src/scripts/oauth/http-refresh-token.service.js
@@ -65,7 +65,8 @@ function HttpRefreshTokenService($rootScope, $q, $injector, OAuthService, OAuthT
       console.warn("Error getting auth token from refresh token because there's no internet connection. Not clearing token.", response);
     } else if (response.data && response.data.ErrorCode) {
       if (response.data.ErrorCode === 2110 /* RefreshTokenNotYetValid */ ||
-          response.data.ErrorCode === 2111 /* AccessTokenHasExpired */) {
+          response.data.ErrorCode === 2111 /* AccessTokenHasExpired */ ||
+          response.data.ErrorCode === 2106 /* AuthorizationCodeInvalid */) {
         console.warn("Refresh token expired or not valid, clearing auth tokens & going to login", response);
         OAuthTokenService.removeToken();
         $rootScope.$broadcast('dim-no-token-found');

--- a/src/scripts/oauth/oauth-token.service.js
+++ b/src/scripts/oauth/oauth-token.service.js
@@ -3,62 +3,117 @@ import angular from 'angular';
 angular.module('dim-oauth')
   .service('OAuthTokenService', OAuthTokenService);
 
+/**
+ * This service manages storage and management of saved OAuth
+ * authorization and refresh tokens.
+ *
+ * See https://www.bungie.net/en/Help/Article/45481 for details about
+ * Bungie.net OAuth.
+ */
 function OAuthTokenService(localStorageService) {
+  /**
+   * An OAuth token, either authorization or refresh.
+   * @typedef {Object} Token
+   * @property {string} value - The oauth token key
+   * @property {number} readyin - The token is not valid until this many seconds after it is acquired.
+   * @property {number} expires - The token expires this many seconds after it is acquired.
+   * @property {string} name - Either 'access' or 'refresh'.
+   * @property {number} inception - A UTC epoch milliseconds timestamp representing when the token was acquired.
+   */
+  /**
+   * Get all token information from saved storage.
+   * @return {{accessToken, refreshToken, scope}}
+   */
   function getToken() {
     return localStorageService.get('authorization');
   }
 
+  /**
+   * Save all the information about access/refresh tokens.
+   * @param {Token} token.accessToken
+   * @param {Token} token.refreshToken
+   * @param {string} scope the scope bitfield describing allowed actions
+   */
   function setToken(token) {
     localStorageService.set('authorization', token);
   }
 
+  /**
+   * Get just the access token from saved storage.
+   * @return {Token}
+   */
   function getAccessToken() {
-    return (getToken()) ? getToken().accessToken : undefined;
+    const token = getToken();
+    return token ? token.accessToken : undefined;
   }
 
+  /**
+   * Get just the refresh token from saved storage.
+   * @return {Token}
+   */
   function getRefreshToken() {
-    return (getToken()) ? getToken().refreshToken : undefined;
+    const token = getToken();
+    return token ? token.refreshToken : undefined;
   }
 
+  /**
+   * Generate a bearer authorization header from our saved access token.
+   * @return {string}
+   */
   function getAuthorizationHeader() {
-    if (!getAccessToken()) {
+    const accessToken = getAccessToken();
+    if (!accessToken) {
       return undefined;
     }
 
-    return 'Bearer ' + getAccessToken().value;
+    return 'Bearer ' + accessToken.value;
   }
 
+  /**
+   * Clear any saved token information.
+   */
   function removeToken() {
     localStorageService.remove('authorization');
   }
 
-  function getTokenDate(token, property, offset = 0) {
+  /**
+   * Get an absolute UTC epoch milliseconds timestamp for either the 'expires' or 'readyin' property.
+   * @param {Token} token
+   * @param {string} property - 'expires' or 'readyin'
+   */
+  function getTokenDate(token, property) {
     if (token && token.hasOwnProperty('inception') && token.hasOwnProperty(property)) {
-      const inception = new Date(token.inception);
-      return new Date(inception.valueOf() + (token[property] * 1000) + offset);
+      const inception = token.inception;
+      return new Date(inception.valueOf() + (token[property] * 1000));
     }
 
-    return (new Date(0));
+    return 0;
   }
 
+  /**
+   * Has the token expired, based on its 'expires' property?
+   */
   function hasTokenExpired(token) {
-    const expires = getTokenDate(token, 'expires', -1800000).valueOf();
-    const now = (new Date()).valueOf();
+    const expires = getTokenDate(token, 'expires');
+    const now = Date.now();
 
     // if (token)
     //   { console.log("Expires: " + token.name + " " + ((expires <= now)) + " " + ((expires - now) / 1000 / 60)); }
 
-    return (expires <= now);
+    return now > expires;
   }
 
+  /**
+   * Is the token ready to use, based on its 'readyin' property?
+   */
   function isTokenReady(token) {
-    const readyIn = getTokenDate(token, 'readyin').valueOf();
-    const now = (new Date()).valueOf();
+    const readyIn = getTokenDate(token, 'readyin');
+    const now = Date.now();
 
     // if (token)
     //   { console.log("ReadyIn: " + token.name + " " + (readyIn <= now) + " " + ((readyIn - now) / 1000 / 60)); }
 
-    return (readyIn <= now);
+    return now > readyIn;
   }
 
   return {

--- a/src/scripts/oauth/oauth-token.service.js
+++ b/src/scripts/oauth/oauth-token.service.js
@@ -32,7 +32,7 @@ function OAuthTokenService(localStorageService) {
    * Save all the information about access/refresh tokens.
    * @param {Token} token.accessToken
    * @param {Token} token.refreshToken
-   * @param {string} scope the scope bitfield describing allowed actions
+   * @param {string} token.scope the scope bitfield describing allowed actions
    */
   function setToken(token) {
     localStorageService.set('authorization', token);
@@ -80,11 +80,12 @@ function OAuthTokenService(localStorageService) {
    * Get an absolute UTC epoch milliseconds timestamp for either the 'expires' or 'readyin' property.
    * @param {Token} token
    * @param {string} property - 'expires' or 'readyin'
+   * @return {number} UTC epoch milliseconds timestamp
    */
   function getTokenDate(token, property) {
     if (token && token.hasOwnProperty('inception') && token.hasOwnProperty(property)) {
       const inception = token.inception;
-      return new Date(inception.valueOf() + (token[property] * 1000));
+      return inception + (token[property] * 1000);
     }
 
     return 0;

--- a/src/scripts/oauth/oauth.service.js
+++ b/src/scripts/oauth/oauth.service.js
@@ -27,8 +27,9 @@ function OAuthService($q, $injector, localStorageService, OAuthTokenService) {
     })
     .then((response) => {
       if (response && response.data && (response.data.ErrorCode === 1) && response.data.Response && response.data.Response.accessToken) {
-        const accessToken = angular.merge({}, response.data.Response.accessToken, { name: 'access', inception: (new Date()).toISOString() });
-        const refreshToken = angular.merge({}, response.data.Response.refreshToken, { name: 'refresh', inception: (new Date()).toISOString() });
+        const inception = Date.now();
+        const accessToken = angular.merge({}, response.data.Response.accessToken, { name: 'access', inception: inception });
+        const refreshToken = angular.merge({}, response.data.Response.refreshToken, { name: 'refresh', inception: inception });
 
         OAuthTokenService.setToken({
           accessToken,


### PR DESCRIPTION
I've been tinkering with the OAuth stuff for a while, trying to nail down the problem where, after a while away from DIM, I go back to the tab or open my laptop and immediately get redirected to a login screen. After a bunch of iteration, this appears to fix it. I have more improvements on the way, but this change is already too big.

Major changes:

1. Handle errors better when failing to refresh the auth token. This is the real meat of the fix - before, any error (including spurious errors like "you're not connected to the internet" which happens when I first open my laptop and it hasn't acquired WiFi), would cause us to dump auth tokens and require re-authing. Now, we only do so if Bungie responds with a specific set of errors that indicate a bad auth token. This allows our normal retry logic to work around connectivity issues (or Bungie.net being down, as it was last night) and remain authed.
1. Dates are handled as numbers (UTC epoch timestamps) instead of `Date` objects. In general this avoids a lot of conversions, makes the code easier to understand, and avoids some possible time zone issues.
2. Added a bunch of documentation to make things easier to follow.
3. Removed the response filter from the HTTP interceptor - we weren't doing anything useful in it.
4. Clear the cached refresh promise once it resolves. Fixes #1253.
5. Added logging around auth. We can tone this down.