### PR TITLE
Don't always delete the manifest for tranient or Bungie errors.

### DIFF
--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -252,7 +252,6 @@
       "Error": "Error loading Destiny info:\n{error}\nReload to retry.",
       "Outdated": "Outdated Destiny Info",
       "OutdatedExplanation": "Bungie has updated their Destiny info database. Reload DIM to pick up the new info. Note that some things in DIM may not work for a few hours after Bungie updates Destiny, as the new data propagates through their systems.",
-      "BungieDown": "Bungie.net may be having trouble.",
       "Load": "Loading saved Destiny info",
       "LoadCharInv": "Loading Destiny characters and inventory",
       "Save": "Saving latest Destiny info",


### PR DESCRIPTION
I noticed that I was re-downloading the manifest more often than I would expect. Turns out it was roughly the same problem as what was causing re-auths (see #https://github.com/DestinyItemManager/DIM/pull/1592) - transient network errors or Bungie.net outages caused us to delete the manifest and redownload.

This PR just handles some of those errors so we keep our file around more often.