### PR TITLE
Switch to a DIM-specific fork of sql.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "ng-dialog": "^0.6.4",
     "ng-http-rate-limiter": "^1.0.1",
     "simple-query-string": "^1.3.0",
-    "sql.js": "^0.4.0",
+    "sql.js": "github:DestinyItemManager/sql.js",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
`sql.js` is the secret sauce that lets us directly use Bungie's SQLite-format manifest database, but it comes at a cost - it's a huge library generated by Emscripten from the original SQLite C source. Today it accounts for 2.1MB of code before gzip.

However, we don't use most of SQLite's fancy features, so there's an opportunity to make a smaller library. This switches us to a [DIM fork of sql.js](https://github.com/DestinyItemManager/sql.js) with the following changes:

1. Upgrade to the latest SQLite
2. Build with the latest Emscripten available in Homebrew (size and performance updates)
3. Fix a deprecated method in favor of a safer and faster one: https://github.com/kripken/sql.js/pull/192
4. Turn off as many SQLite features as we can, guided by [the SQLite footprint reduction guide](https://www.sqlite.org/footprint.html). We don't use much!

This reduces the library to 1.2MB uncompressed and anecdotally it feels faster.

Note that there's more that could be done here - for example building a separate memory image file, or adding WebAssembly support. I worked on those a bit, but the memory file requires more invasive changes to sql.js, and WebAssembly seems to be slightly off in both Emscripten and Chrome right now.