### PR TITLE
Don't dequip equipped items just because they're not marked as equip in a loadout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Fixed objective text in the record book floating above stuff.
 * Fixed displaying record objectives that are time-based as time instead of just a number of seconds.
 * When pinned to the iOS home screen, DIM now looks more like a regular browser than an app. The upside is you can now actually authorize it when it's pinned!
+* Loadouts with non-equipping items now won't *de-equip* those items if they're already equipped. #1567
+* The count of items in your loadout is now more accurate.
 
 # v3.17.1
 


### PR DESCRIPTION
Also fix loadout item counts (so we don't say "applied your loadout of 0 items" just because we didn't need to move anything).

Fixes #1567.