### PR TITLE
Mobile Safari updates

### DIFF
--- a/src/scripts/services/dimSettingsService.factory.js
+++ b/src/scripts/services/dimSettingsService.factory.js
@@ -48,8 +48,8 @@ function SettingsService($rootScope, SyncService, $window, $translate) {
     charCol: 3,
     // How many columns to display vault buckets
     vaultMaxCol: 999,
-    // How big in pixels to draw items
-    itemSize: 44,
+    // How big in pixels to draw items - start smaller for iPad
+    itemSize: window.matchMedia('(max-width: 1025px)').matches ? 38 : 44,
     // Which categories or buckets should be collapsed?
     collapsedSections: {},
     // What settings for farming mode

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -140,7 +140,7 @@ function SearchFilter(dimSearchService) {
     bindToController: true,
     restrict: 'E',
     template: [
-      '<input id="filter-input" class="dim-input" translate-attr="{ placeholder: \'Header.FilterHelp\' }" type="search" name="filter" ng-model="vm.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">'
+      '<input id="filter-input" class="dim-input" autocomplete="off" autocorrect="off" autocapitalize="off" translate-attr="{ placeholder: \'Header.FilterHelp\' }" type="search" name="filter" ng-model="vm.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">'
     ].join('')
   };
 }

--- a/src/scripts/shell/dimSettingsCtrl.controller.js
+++ b/src/scripts/shell/dimSettingsCtrl.controller.js
@@ -30,7 +30,7 @@ function SettingsController(loadingTracker, dimSettingsService, $scope, SyncServ
   vm.settings = dimSettingsService;
 
   // Edge doesn't support these
-  vm.supportsCssVar = window.CSS && window.CSS.supports && window.CSS.supports('--fake-var', 0);
+  vm.supportsCssVar = window.CSS && window.CSS.supports && window.CSS.supports('width', 'var(--fake-var)', 0);
 
   vm.showSync = function() {
     return SyncService.drive();

--- a/src/scripts/shell/dimSettingsCtrl.controller.js
+++ b/src/scripts/shell/dimSettingsCtrl.controller.js
@@ -54,6 +54,11 @@ function SettingsController(loadingTracker, dimSettingsService, $scope, SyncServ
     dimInfoService.resetHiddenInfos();
   };
 
+  vm.resetItemSize = function() {
+    vm.settings.itemSize = window.matchMedia('(max-width: 1025px)').matches ? 38 : 44;
+    vm.save();
+  };
+
   vm.exportData = function() {
     // Function to download data to a file
     function download(data, filename, type) {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -11,6 +11,13 @@
   --vault-max-columns: 999;
 }
 
+// iPad - use smaller items to fit them on screen.
+@media (max-width: 1025px) {
+  :root {
+    --item-size: 38px;
+  }
+}
+
 @mixin item-size {
   width: 44px;
   height: 44px;

--- a/src/views/settings.template.html
+++ b/src/views/settings.template.html
@@ -96,7 +96,7 @@
           <label for="itemSize" translate-attr="{ title: 'Settings.SizeItemHelp'}" translate="Settings.SizeItem"></label>
         </td>
         <td>
-          <input ng-model="vm.settings.itemSize" type="range" min="38" max="66" ng-change="vm.save()" /> <button ng-click="vm.settings.itemSize = 44" translate>Settings.ResetToDefault</button>
+          <input ng-model="vm.settings.itemSize" type="range" min="38" max="66" ng-change="vm.save()" /> <button ng-click="vm.resetItemSize()" translate>Settings.ResetToDefault</button>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
* Turn off autocomplete for search. Fixes #1601.
* Start out with smaller icons for iPad (or any screen iPad sized or below), so things better fit on one screen.
* Fix CSS variable support detection, so users can choose item size.

![screen shot 2017-04-11 at 10 14 36 pm](https://cloud.githubusercontent.com/assets/313208/24942190/420c0a1e-1f04-11e7-98a8-bef5152a359f.png)