### PR TITLE
Add gzip and brotli pre-compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
     packages:
     - gcc-4.8
     - g++-4.8
+    - brotli
 before_install:
 - openssl aes-256-cbc -K $encrypted_472c4900477c_key -iv $encrypted_472c4900477c_iv
   -in config/dim_travis.rsa.enc -out config/dim_travis.rsa -d && chmod 600 config/dim_travis.rsa

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
 
     precompress: {
       web: {
-        src: "dist/**/*.{js,html,css,json,map,ttf,eot,svg,woff,woff2}"
+        src: "dist/**/*.{js,html,css,json,map,ttf,eot,svg}"
       }
     }
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 const execFile = require("child_process").execFile;
+const fs = require("fs");
 
 module.exports = function(grunt) {
   var pkg = grunt.file.readJSON('package.json');
@@ -141,6 +142,10 @@ module.exports = function(grunt) {
             } else {
               resolve();
             }
+          });
+        }).then(function() {
+          return new Promise(function(resolve, reject) {
+            fs.chmod(file + ".br", 0644, resolve);
           });
         }));
       });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+const execFile = require("child_process").execFile;
+
 module.exports = function(grunt) {
   var pkg = grunt.file.readJSON('package.json');
 
@@ -93,6 +95,12 @@ module.exports = function(grunt) {
           dest: process.env.REMOTE_PATH + "prod"
         }
       }
+    },
+
+    precompress: {
+      web: {
+        src: "dist/**/*.{js,html,css,json,map,ttf,eot,svg,woff,woff2}"
+      }
     }
   });
 
@@ -106,6 +114,40 @@ module.exports = function(grunt) {
     manifest.version = betaVersion;
     grunt.file.write('dist/manifest.json', JSON.stringify(manifest));
   });
+
+  grunt.registerMultiTask(
+    'precompress',
+    'Create gzip and brotli versions of web assets',
+    function() {
+      const done = this.async();
+      const promises = [];
+      this.filesSrc.forEach(function(file) {
+        promises.push(new Promise(function(resolve, reject) {
+          execFile("gzip", ["--best", "--keep", "--no-name", file], function(error, stdout, stderr) {
+            grunt.log.writeln("gzip " + file + " => " + stdout + stderr);
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        }));
+
+        promises.push(new Promise(function(resolve, reject) {
+          execFile("bro", ["--quality", "9", "--input", file, "--output", file + ".br"], function(error, stdout, stderr) {
+            grunt.log.writeln("brotli " + file + " => " + stdout + stderr);
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        }));
+      });
+
+      Promise.all(promises).then(done);
+    }
+  );
 
   grunt.registerTask('publish_beta', [
     'update_chrome_beta_manifest',

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -710,88 +710,28 @@ ServerSignature Off
 # # WEB PERFORMANCE                                                    #
 # ######################################################################
 
-# ----------------------------------------------------------------------
-# | Compression                                                        |
-# ----------------------------------------------------------------------
 
-<IfModule mod_deflate.c>
+<IfModule mod_mime.c>
+    AddEncoding gzip .svgz
+    AddEncoding gzip .gz
+    AddEncoding br .br
+</IfModule>
 
-    # Force compression for mangled `Accept-Encoding` request headers
-    # https://developer.yahoo.com/blogs/ydn/pushing-beyond-gzipping-25601.html
+<IfModule mod_rewrite.c>
+    RewriteEngine On
 
-    <IfModule mod_setenvif.c>
-        <IfModule mod_headers.c>
-            SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding
-            RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
-        </IfModule>
-    </IfModule>
+    # for any request, search for pre-compressed versions (gzip or brotli) and serve that directly if it's supported
 
-    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Serve pre-brotli stuff if we got it
+    RewriteCond %{HTTP:Accept-encoding} br
+    RewriteCond %{REQUEST_FILENAME}.br -f
+    RewriteRule ^(.*)$ $1.br [QSA,L]
 
-    # Compress all output labeled with one of the following media types.
-    #
-    # (!) For Apache versions below version 2.3.7 you don't need to
-    # enable `mod_filter` and can remove the `<IfModule mod_filter.c>`
-    # and `</IfModule>` lines as `AddOutputFilterByType` is still in
-    # the core directives.
-    #
-    # https://httpd.apache.org/docs/current/mod/mod_filter.html#addoutputfilterbytype
-
-    <IfModule mod_filter.c>
-        AddOutputFilterByType DEFLATE "application/atom+xml" \
-                                      "application/javascript" \
-                                      "application/json" \
-                                      "application/ld+json" \
-                                      "application/manifest+json" \
-                                      "application/rdf+xml" \
-                                      "application/rss+xml" \
-                                      "application/schema+json" \
-                                      "application/vnd.geo+json" \
-                                      "application/vnd.ms-fontobject" \
-                                      "application/x-font-ttf" \
-                                      "application/x-javascript" \
-                                      "application/x-web-app-manifest+json" \
-                                      "application/xhtml+xml" \
-                                      "application/xml" \
-                                      "font/eot" \
-                                      "font/opentype" \
-                                      "image/bmp" \
-                                      "image/svg+xml" \
-                                      "image/vnd.microsoft.icon" \
-                                      "image/x-icon" \
-                                      "text/cache-manifest" \
-                                      "text/css" \
-                                      "text/html" \
-                                      "text/javascript" \
-                                      "text/plain" \
-                                      "text/vcard" \
-                                      "text/vnd.rim.location.xloc" \
-                                      "text/vtt" \
-                                      "text/x-component" \
-                                      "text/x-cross-domain-policy" \
-                                      "text/xml"
-
-    </IfModule>
-
-    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-    # Map the following filename extensions to the specified
-    # encoding type in order to make Apache serve the file types
-    # with the appropriate `Content-Encoding` response header
-    # (do note that this will NOT make Apache compress them!).
-    #
-    # If these files types would be served without an appropriate
-    # `Content-Enable` response header, client applications (e.g.:
-    # browsers) wouldn't know that they first need to uncompress
-    # the response, and thus, wouldn't be able to understand the
-    # content.
-    #
-    # https://httpd.apache.org/docs/current/mod/mod_mime.html#addencoding
-
-    <IfModule mod_mime.c>
-        AddEncoding gzip              svgz
-    </IfModule>
-
+    # Serve pre-gzipped stuff if we got it
+    RewriteCond %{HTTP:Accept-encoding} gzip
+    RewriteCond %{HTTP_USER_AGENT} !Konqueror
+    RewriteCond %{REQUEST_FILENAME}.gz -f
+    RewriteRule ^(.*)$ $1.gz [QSA,L]
 </IfModule>
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
[Brotli](https://github.com/google/brotli#introduction) is a new compression format supported in Chrome and Firefox that beats gzip for common web files (html, css, js, etc).

This change adds a step to our build that will pre-generate maximally compressed gzip and brotli versions of all our text files, and then configures Apache to serve those files directly to browsers that can handle them. This takes load off CloudFlare (which is gzipping for us now) and the Brotli versions tend to be smaller than the gzip versions by roughly 10%.

As an example, sqlite.js starts at 1.2MB uncompressed, goes to 282K gzipped, and 246K with brotli.