### PR TITLE
Don't allow developer page on non-dev builds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,9 @@ require('./scripts/minmax/dimMinMaxItem.directive');
 require('./scripts/minmax/dimMinMaxLocks.directive');
 require('./scripts/minmax/dimMinMaxCharSelect.directive');
 require('./scripts/debug/dimDebugItem.controller');
-require('./scripts/developer/dimDeveloper.controller');
+if ($DIM_FLAVOR === 'dev') {
+  require('./scripts/developer/dimDeveloper.controller');
+}
 require('./scripts/materials-exchange/dimCollapsible.directive');
 require('./scripts/login/dimLogin.controller');
 

--- a/src/scripts/dimApp.routes.js
+++ b/src/scripts/dimApp.routes.js
@@ -1,7 +1,6 @@
 import best from 'app/views/best.template.html';
 import materialExchange from 'app/views/mats-exchange.template.html';
 import debugItem from 'app/views/debugItem.template.html';
-import developer from 'app/scripts/developer/developer.template.html';
 import login from 'app/scripts/login/login.template.html';
 
 function routes($stateProvider, $urlRouterProvider) {
@@ -26,16 +25,20 @@ function routes($stateProvider, $urlRouterProvider) {
     url: '/debugItem/:itemId',
     templateUrl: debugItem
   }, {
-    name: 'developer',
-    parent: 'content',
-    url: '/developer',
-    templateUrl: developer
-  }, {
     name: 'login',
     parent: 'shell',
     url: '/login',
     templateUrl: login
   }];
+
+  if ($DIM_FLAVOR === 'dev') {
+    states.push({
+      name: 'developer',
+      parent: 'content',
+      url: '/developer',
+      templateUrl: require('app/scripts/developer/developer.template.html')
+    });
+  }
 
   states.forEach((state) => {
     $stateProvider.state(state);

--- a/src/scripts/oauth/oauth.module.js
+++ b/src/scripts/oauth/oauth.module.js
@@ -5,11 +5,9 @@ require('angular-local-storage');
 angular.module('dim-oauth', ['LocalStorageModule'])
   .run(function($rootScope, $state) {
     $rootScope.$on('dim-no-token-found', function() {
-      if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {
+      if ($DIM_FLAVOR !== 'dev') {
         $state.go('login');
-        return;
-      }
-      if (!localStorage.apiKey || !localStorage.authorizationURL) {
+      } else if (!localStorage.apiKey || !localStorage.authorizationURL) {
         $state.go('developer');
       } else {
         $state.go('login');

--- a/src/scripts/oauth/oauth.service.js
+++ b/src/scripts/oauth/oauth.service.js
@@ -15,11 +15,22 @@ function OAuthService($q, $injector, localStorageService, OAuthTokenService) {
   function refreshToken() {
     const $http = $injector.get('$http');
 
+    var apiKey;
+    if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {
+      if (window.chrome && window.chrome.extension) {
+        apiKey = $DIM_API_KEY;
+      } else {
+        apiKey = $DIM_WEB_API_KEY;
+      }
+    } else {
+      apiKey = localStorageService.get('apiKey');
+    }
+
     return $http({
       method: 'POST',
       url: 'https://www.bungie.net/Platform/App/GetAccessTokensFromRefreshToken/',
       headers: {
-        'X-API-Key': localStorageService.get('apiKey')
+        'X-API-Key': apiKey
       },
       data: {
         refreshToken: OAuthTokenService.getRefreshToken().value

--- a/src/scripts/services/dimBungieService.factory.js
+++ b/src/scripts/services/dimBungieService.factory.js
@@ -103,8 +103,12 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
     case 2101: // ApiInvalidOrExpiredKey
     case 2102: // ApiKeyMissingFromRequest
     case 2107: // OriginHeaderDoesNotMatchKey
-      $state.go('developer');
-      return $q.reject(new Error($translate.instant('BungieService.DevVersion')));
+      if ($DIM_FLAVOR === 'dev') {
+        $state.go('developer');
+        return $q.reject(new Error($translate.instant('BungieService.DevVersion')));
+      } else {
+        return $q.reject(new Error($translate.instant('BungieService.Difficulties')));
+      }
     }
 
     // Any other error


### PR DESCRIPTION
This completely removes the developer route and template from non-dev builds. It also prevents the local storage API key from being used in non-dev. This should fix #1604.