### PR TITLE
Use applyAsync to attempt to reduce digest cycles

### DIFF
--- a/src/scripts/dimApp.config.js
+++ b/src/scripts/dimApp.config.js
@@ -19,6 +19,7 @@ function config($compileProvider, $httpProvider, $translateProvider, $translateM
   if (!window.chrome || !window.chrome.extension) {
     $httpProvider.interceptors.push('http-refresh-token');
   }
+  $httpProvider.useApplyAsync(true);
 
   // See https://angular-translate.github.io/docs/#/guide
   $translateProvider.useSanitizeValueStrategy('escape');


### PR DESCRIPTION
This sets a property on `$httpProvider` that will use `$applyAsync` in $http handlers. See https://docs.angularjs.org/api/ng/provider/$httpProvider. This should allow us to reduce some spurious digest cycles as we join multiple HTTP requests. In practice it doesn't do a lot since it only coalesces between frames (~10ms) - we have to do more to really reduce digests. But it doesn't hurt.