### PR TITLE
Set plain:true for dialogs

### DIFF
--- a/src/scripts/dimApp.config.js
+++ b/src/scripts/dimApp.config.js
@@ -53,7 +53,8 @@ function config($compileProvider, $httpProvider, $translateProvider, $translateM
   // https://github.com/likeastore/ngDialog/issues/327
   ngDialogProvider.setDefaults({
     appendTo: '.app',
-    disableAnimation: true
+    disableAnimation: true,
+    plain: true
   });
 }
 


### PR DESCRIPTION
Now that we inline all our templates, we should always use `plain: true` in `ngDialog` calls. This sets that as the default.