### PR TITLE
Add border radius to backer images

### DIFF
--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -2145,6 +2145,11 @@ dim-manifest-progress {
   margin-bottom: .25em;
 }
 
-.backers a {
-  margin-right: 1em;
+.backers {
+  a {
+    margin-right: 1em;
+  }
+  img {
+    border-radius: 50%;
+  }
 }


### PR DESCRIPTION
Fixes #1628

<img width="635" alt="screen shot 2017-05-07 at 5 43 20 pm" src="https://cloud.githubusercontent.com/assets/313208/25786142/ef756b8a-334c-11e7-903c-311fe98c4875.png">
