### PR TITLE
Remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "jquery": "^3.1.1",
     "jquery-textcomplete": "^1.8.0",
     "jquery-ui": "^1.12.1",
-    "lodash": "^4.17.3",
     "messageformat": "^1.0.2",
     "ng-dialog": "^0.6.4",
     "ng-http-rate-limiter": "^1.0.1",

--- a/src/scripts/shell/platform-choice/platform-choice.component.js
+++ b/src/scripts/shell/platform-choice/platform-choice.component.js
@@ -1,4 +1,3 @@
-import isFunction from 'lodash/isFunction';
 import template from './platform-choice.html';
 import './platform-choice.scss';
 
@@ -20,7 +19,7 @@ class PlatformChoiceController {
   }
 
   change(platform) {
-    if (platform && isFunction(this.onPlatformChange)) {
+    if (platform && this.onPlatformChange) {
       this.onPlatformChange({
         platform: platform
       });


### PR DESCRIPTION
This PR started out as "replace underscore with lodash" but a simple search/replace of the imports adds 56KB to the final bundle, thanks to Webpack's anemic tree-shaking support. So instead, I removed our only use of lodash, which ends up shaving off 1.2K from our bundle.

In the future we could theoretically make some gains in bundle size by importing only the specific functions we want out of lodash, but only if we did that everywhere. That sounds like a huge pain in the ass.