### PR TITLE
Split vendor JS into a separate chunk

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,7 @@
     <meta name="theme-color" content="#434444">
     <meta name='apple-mobile-web-app-status-bar-style' content='black'>
 
-    {{#each htmlWebpackPlugin.files.chunks.main.css}}
+    {{#each htmlWebpackPlugin.files.css}}
       <link href="{{webpackConfig.output.publicPath}}{{this}}" rel="stylesheet">
     {{/each}}
 
@@ -35,7 +35,10 @@
 
   <body ng-strict-di>
     <app></app>
-    <script type="text/javascript" src="{{webpackConfig.output.publicPath}}{{htmlWebpackPlugin.files.chunks.main.entry}}"></script>
+
+    {{#each htmlWebpackPlugin.files.js}}
+    <script type="text/javascript" src="{{webpackConfig.output.publicPath}}{{this}}"></script>
+    {{/each}}
   </body>
 
 </html>


### PR DESCRIPTION
This chunk should stay stable unless our dependencies change, improving cacheability.

This fixes #1315. It follows roughly the same guide as when we tried it before (https://webpack.js.org/guides/code-splitting-libraries/) but the documentation has improved and I believe some Webpack bugs have been fixed. I verified that changing application code won't change the vendor chunk hash.