### PR TITLE
Move vendor templates to external files, replace Xur with component

### DIFF
--- a/src/scripts/shell/content/content.controller.js
+++ b/src/scripts/shell/content/content.controller.js
@@ -2,7 +2,6 @@ import settingsTemplate from 'app/views/settings.template.html';
 import aboutTemplate from 'app/views/about.template.html';
 import supportTemplate from 'app/views/support.template.html';
 import filtersTemplate from 'app/views/filters.template.html';
-import xurTemplate from 'app/scripts/vendors/xur.html';
 import matsExchangeTemplate from 'app/views/mats-exchange.template.html';
 
 export default class ContentController {
@@ -169,7 +168,6 @@ export default class ContentController {
           ngDialog.closeAll();
           result = ngDialog.open({
             template: template,
-            plain: true,
             className: name,
             appendClassName: 'modal-dialog'
           });
@@ -185,7 +183,7 @@ export default class ContentController {
     vm.showAbout = showPopupFunction('about', aboutTemplate);
     vm.showSupport = showPopupFunction('support', supportTemplate);
     vm.showFilters = showPopupFunction('filters', filtersTemplate);
-    vm.showXur = showPopupFunction('xur', xurTemplate);
+    vm.showXur = showPopupFunction('xur', '<xur></xur>');
     vm.showMatsExchange = showPopupFunction('mats-exchange', matsExchangeTemplate);
 
     function toggleState(name) {

--- a/src/scripts/vendors/vendor-item-dialog.html
+++ b/src/scripts/vendors/vendor-item-dialog.html
@@ -1,0 +1,29 @@
+<div class="move-popup"
+     dim-click-anywhere-but-here="closeThisDialog()">
+  <div dim-move-item-properties="vm.item"
+       dim-compare-item="vm.compareItem"></div>
+  <div class="item-details more-item-details"
+       ng-if="vm.item.equipment && vm.compareItems.length">
+    <div translate="Vendors.Compare"></div>
+    <div class="compare-items">
+      <dim-simple-item ng-repeat="ownedItem in vm.compareItems track by ownedItem.index"
+                       item-data="ownedItem"
+                       ng-click="vm.setCompareItem(ownedItem)"
+                       ng-class="{ selected: (ownedItem.index === vm.compareItem.index) }"></dim-simple-item>
+    </div>
+  </div>
+  <div class="item-description"
+       ng-if="!vm.item.equipment && vm.compareItemCount">You have {{vm.compareItemCount}} of these.</div>
+  <div class="item-details"
+       ng-if="vm.saleItem.failureStrings">{{vm.saleItem.failureStrings}}</div>
+  <div class="item-details"
+       ng-if="vm.unlockStores.length">
+    <div translate="Vendors.Available"></div>
+    <div class="unlocked-character"
+         ng-repeat="store in vm.unlockStores | sortStores:vm.settings.characterOrder track by store.id">
+      <div class="emblem"
+           ng-style="{ 'background-image': 'url(' + store.icon + ')' }"></div>
+      {{store.name}}
+    </div>
+  </div>
+</div>

--- a/src/scripts/vendors/vendor-item.html
+++ b/src/scripts/vendors/vendor-item.html
@@ -1,0 +1,17 @@
+<div class="vendor-item"
+     ng-class="{ 'search-hidden': !$ctrl.saleItem.item.visible }">
+  <div ng-if="!$ctrl.saleItem.unlocked"
+       class="locked-overlay"></div>
+  <dim-simple-item item-data="$ctrl.saleItem.item"
+                   ng-click="$ctrl.clicked($event)"></dim-simple-item>
+  <div class="vendor-costs">
+    <div ng-repeat="cost in ::$ctrl.saleItem.costs track by cost.currency.itemHash"
+         class="cost"
+         ng-class="{notenough: ($ctrl.totalCoins[saleItem.cost.currency.itemHash] < saleItem.cost.value)}">
+      {{::cost.value}}
+      <span class="currency"><img
+                               ng-src="{{::cost.currency.icon | bungieIcon}}"
+                               title="{{::cost.currency.itemName}}"></span>
+    </div>
+  </div>
+</div>

--- a/src/scripts/vendors/vendor-items.component.js
+++ b/src/scripts/vendors/vendor-items.component.js
@@ -1,10 +1,7 @@
-import angular from 'angular';
-import _ from 'underscore';
-import { sum } from '../util';
+import template from './vendor-items.html';
 
 export const VendorItems = {
   controller: VendorItemsCtrl,
-  controllerAs: 'vm',
   bindings: {
     vendors: '=vendorsData',
     types: '<displayTypes',
@@ -12,130 +9,18 @@ export const VendorItems = {
     activeTab: '<',
     extraMovePopupClass: '<'
   },
-  template: [
-    '<div class="vendor-char-items" ng-repeat="(vendorHash, vendor) in vm.vendors | values | vendorTab:vm.activeTab | orderBy:[\'vendorOrder\'] track by vendor.hash">',
-    '  <div class="title">',
-    '    <div class="collapse-handle" ng-click="vm.toggleSection(vendorHash)">',
-    '      <i class="fa collapse" ng-class="vm.settings.collapsedSections[vendorHash] ? \'fa-plus-square-o\': \'fa-minus-square-o\'"></i>',
-    '      <img class="vendor-icon" ng-src="{{::vendor.icon | bungieIcon}}" />',
-    '      {{::vendor.name}}',
-    '      <span class="vendor-location">{{::vendor.location}}</span>',
-    '    </div>',
-    '    <countdown class="vendor-timer" ng-if="vendor.nextRefreshDate[0] !== \'9\'" end-time="vendor.nextRefreshDate"></countdown>',
-    '  </div>',
-    '  <div class="vendor-row" ng-if="!vm.settings.collapsedSections[vendorHash]">',
-    '    <vendor-currencies vendor-categories="vendor.categories" total-coins="vm.totalCoins" property-filter="vm.activeTab"></vendor-currencies>',
-    '    <div class="vendor-category" ng-repeat="category in vendor.categories | vendorTab:vm.activeTab track by category.index">',
-    '      <h3 class="category-title">{{::category.title}}</h3>',
-    '      <div class="vendor-items">',
-    '        <vendor-item ng-repeat="saleItem in category.saleItems | vendorTabItems:vm.activeTab track by saleItem.index" sale-item="saleItem" total-coins="vm.totalCoins" item-clicked="vm.itemClicked(saleItem, $event)"></vendor-item>',
-    '      </div>',
-    '    </div>',
-    '  </div>',
-    '</div>'
-  ].join('')
+  template: template
 };
 
-function VendorItemsCtrl($scope, ngDialog, dimStoreService, dimSettingsService) {
+function VendorItemsCtrl(dimSettingsService) {
   'ngInject';
 
   var vm = this;
-  var dialogResult = null;
-  var detailItem = null;
-  var detailItemElement = null;
 
   vm.settings = dimSettingsService;
 
-  $scope.$on('ngDialog.opened', function(event, $dialog) {
-    if (dialogResult && $dialog[0].id === dialogResult.id) {
-      $dialog.position({
-        my: 'left top',
-        at: 'left bottom+2',
-        of: detailItemElement,
-        collision: 'flip flip'
-      });
-    }
-  });
-
-  angular.extend(vm, {
-    itemClicked: function(saleItem, e) {
-      e.stopPropagation();
-      if (dialogResult) {
-        dialogResult.close();
-      }
-
-      const item = saleItem.item;
-      if (detailItem === item) {
-        detailItem = null;
-        dialogResult = null;
-        detailItemElement = null;
-      } else {
-        detailItem = item;
-        detailItemElement = angular.element(e.currentTarget);
-
-        var compareItems = _.flatten(dimStoreService.getStores().map(function(store) {
-          return _.filter(store.items, { hash: item.hash });
-        }));
-
-        var compareItemCount = sum(compareItems, 'amount');
-
-        dialogResult = ngDialog.open({
-          template: [
-            '<div class="move-popup" dim-click-anywhere-but-here="closeThisDialog()">',
-            '  <div dim-move-item-properties="vm.item" dim-compare-item="vm.compareItem"></div>',
-            '  <div class="item-details more-item-details" ng-if="vm.item.equipment && vm.compareItems.length">',
-            '    <div translate="Vendors.Compare"></div>',
-            '    <div class="compare-items">',
-            '      <dim-simple-item ng-repeat="ownedItem in vm.compareItems track by ownedItem.index" item-data="ownedItem" ng-click="vm.setCompareItem(ownedItem)" ng-class="{ selected: (ownedItem.index === vm.compareItem.index) }"></dim-simple-item>',
-            '    </div>',
-            '  </div>',
-            '  <div class="item-description" ng-if="!vm.item.equipment && vm.compareItemCount">You have {{vm.compareItemCount}} of these.</div>',
-            '  <div class="item-details" ng-if="vm.saleItem.failureStrings">{{vm.saleItem.failureStrings}}</div>',
-            '  <div class="item-details" ng-if="vm.unlockStores.length">',
-            '    <div translate="Vendors.Available"></div>',
-            '    <div class="unlocked-character" ng-repeat="store in vm.unlockStores | sortStores:vm.settings.characterOrder track by store.id">',
-            '      <div class="emblem" ng-style="{ \'background-image\': \'url(\' + store.icon + \')\' }"></div>',
-            '      {{store.name}}',
-            '    </div>',
-            '  </div>',
-            '</div>'].join(''),
-          plain: true,
-          overlay: false,
-          className: 'move-popup vendor-move-popup ' + (vm.extraMovePopupClass || ''),
-          showClose: false,
-          scope: angular.extend($scope.$new(true), {
-          }),
-          controllerAs: 'vm',
-          controller: [function() {
-            var innerVm = this;
-            angular.extend(innerVm, {
-              settings: innerVm.settings,
-              item: item,
-              saleItem: saleItem,
-              unlockStores: saleItem.unlockedByCharacter.map((id) => _.find(dimStoreService.getStores(), { id })),
-              compareItems: compareItems,
-              compareItem: _.first(compareItems),
-              compareItemCount: compareItemCount,
-              setCompareItem: function(item) {
-                this.compareItem = item;
-              }
-            });
-          }],
-          // Setting these focus options prevents the page from
-          // jumping as dialogs are shown/hidden
-          trapFocus: false,
-          preserveFocus: false
-        });
-      }
-    },
-    $onDestroy: function() {
-      if (dialogResult) {
-        dialogResult.close();
-      }
-    },
-    toggleSection: function(id) {
-      vm.settings.collapsedSections[id] = !vm.settings.collapsedSections[id];
-      vm.settings.save();
-    }
-  });
+  vm.toggleSection = function(id) {
+    vm.settings.collapsedSections[id] = !vm.settings.collapsedSections[id];
+    vm.settings.save();
+  };
 }

--- a/src/scripts/vendors/vendor-items.html
+++ b/src/scripts/vendors/vendor-items.html
@@ -1,0 +1,32 @@
+<div class="vendor-char-items"
+     ng-repeat="(vendorHash, vendor) in $ctrl.vendors | values | vendorTab:$ctrl.activeTab | orderBy:['vendorOrder'] track by vendor.hash">
+  <div class="title">
+    <div class="collapse-handle"
+         ng-click="$ctrl.toggleSection(vendorHash)">
+      <i class="fa collapse"
+         ng-class="$ctrl.settings.collapsedSections[vendorHash] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
+      <img class="vendor-icon"
+           ng-src="{{::vendor.icon | bungieIcon}}" />
+      {{::vendor.name}}
+      <span class="vendor-location">{{::vendor.location}}</span>
+    </div>
+    <countdown class="vendor-timer"
+               ng-if="vendor.nextRefreshDate[0] !== '9'"
+               end-time="vendor.nextRefreshDate"></countdown>
+  </div>
+  <div class="vendor-row"
+       ng-if="!$ctrl.settings.collapsedSections[vendorHash]">
+    <vendor-currencies vendor-categories="vendor.categories"
+                       total-coins="$ctrl.totalCoins"
+                       property-filter="$ctrl.activeTab"></vendor-currencies>
+    <div class="vendor-category"
+         ng-repeat="category in vendor.categories | vendorTab:$ctrl.activeTab track by category.index">
+      <h3 class="category-title">{{::category.title}}</h3>
+      <div class="vendor-items">
+        <vendor-item ng-repeat="saleItem in category.saleItems | vendorTabItems:$ctrl.activeTab track by saleItem.index"
+                     sale-item="saleItem"
+                     total-coins="$ctrl.totalCoins"></vendor-item>
+      </div>
+    </div>
+  </div>
+</div>'

--- a/src/scripts/vendors/vendors.module.js
+++ b/src/scripts/vendors/vendors.module.js
@@ -8,7 +8,7 @@ import { VendorItems } from './vendor-items.component';
 import { VendorItem } from './vendor-item.component';
 import { VendorCurrencies } from './vendor-currencies.component';
 import { vendorTab, vendorTabItems } from './vendors.filters';
-import { XurController } from './xur.controller';
+import { Xur } from './xur.component';
 
 export default angular
   // TODO: once bungie service is its own module, add a dependency here
@@ -19,7 +19,7 @@ export default angular
   .component('vendorItems', VendorItems)
   .component('vendorItem', VendorItem)
   .component('vendorCurrencies', VendorCurrencies)
-  .controller('dimXurCtrl', XurController)
+  .component('xur', Xur)
   .filter('vendorTab', () => vendorTab)
   .filter('vendorTabItems', () => vendorTabItems)
   .filter('values', () => _.values)

--- a/src/scripts/vendors/xur.component.js
+++ b/src/scripts/vendors/xur.component.js
@@ -1,0 +1,11 @@
+import template from './xur.html';
+
+export const Xur = {
+  template: template,
+  controller: XurController
+};
+
+function XurController(dimXurService) {
+  'ngInject';
+  this.xurService = dimXurService;
+}

--- a/src/scripts/vendors/xur.controller.js
+++ b/src/scripts/vendors/xur.controller.js
@@ -1,4 +1,0 @@
-export function XurController(dimXurService) {
-  'ngInject';
-  this.xurService = dimXurService;
-}

--- a/src/scripts/vendors/xur.html
+++ b/src/scripts/vendors/xur.html
@@ -1,8 +1,8 @@
-<div class="xurDialog" ng-controller="dimXurCtrl as vm">
+<div class="xurDialog">
   <h1 translate="Help.Xur"></h1>
   <div class="ngdialog-inner-content vendor">
     <div class="vendors">
-      <vendor-items vendors-data="vm.xurService.vendors" total-coins="vm.xurService.totalCoins" extra-move-popup-class="'xur-move-popup'"></vendor-items>
+      <vendor-items vendors-data="$ctrl.xurService.vendors" total-coins="$ctrl.xurService.totalCoins" extra-move-popup-class="'xur-move-popup'"></vendor-items>
     </div>
   </div>
 </div>

--- a/src/scripts/vendors/xur.service.js
+++ b/src/scripts/vendors/xur.service.js
@@ -1,4 +1,3 @@
-import angular from 'angular';
 import _ from 'underscore';
 
 function XurService($rootScope, dimVendorService, dimStoreService) {


### PR DESCRIPTION
A touch of cleanup to the vendors and Xur - instead of Xur being an old-school template with controller, there's now just a `<xur>` component. Plus, moved templates out to external files and moved the vendor item popup into the item instead of the item collection.