### PR TITLE
Fix return JavaScript + implement state parameter

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -129,7 +129,8 @@ module.exports = (env) => {
       new HtmlWebpackPlugin({
         inject: false,
         filename: 'return.html',
-        template: '!handlebars-loader!src/return.html'
+        template: '!handlebars-loader!src/return.html',
+        chunks: ['manifest', 'vendor', 'authReturn']
       }),
 
       new CopyWebpackPlugin([

--- a/src/return.html
+++ b/src/return.html
@@ -2,8 +2,8 @@
   <head>
     <title>Validating Authorization</title>
 
-    {{#each htmlWebpackPlugin.files.chunks.authReturn.css}}
-      <link href="{{webpackConfig.output.publicPath}}{{this}}" rel="stylesheet">
+    {{#each htmlWebpackPlugin.files.css}}
+    <link href="{{webpackConfig.output.publicPath}}{{this}}" rel="stylesheet">
     {{/each}}
   </head>
 
@@ -12,6 +12,8 @@
       <dim-return></dim-return>
     </div>
 
-    <script type="text/javascript" src="{{webpackConfig.output.publicPath}}{{htmlWebpackPlugin.files.chunks.authReturn.entry}}"></script>
+    {{#each htmlWebpackPlugin.files.js}}
+    <script type="text/javascript" src="{{webpackConfig.output.publicPath}}{{this}}"></script>
+    {{/each}}
   </body>
 </html>

--- a/src/scripts/dimLogin.module.js
+++ b/src/scripts/dimLogin.module.js
@@ -1,2 +1,4 @@
 import angular from 'angular';
-angular.module('dimLogin', []);
+import 'angular-uuid2/dist/angular-uuid2.js';
+
+angular.module('dimLogin', ['angularUUID2']);

--- a/src/scripts/login/dimLogin.controller.js
+++ b/src/scripts/login/dimLogin.controller.js
@@ -4,8 +4,10 @@ import './login.scss';
 angular.module('dimApp')
   .controller('dimLoginCtrl', dimLoginCtrl);
 
-function dimLoginCtrl() {
+function dimLoginCtrl(uuid2) {
   const vm = this;
+
+  localStorage.authorizationState = uuid2.newguid();
 
   if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {
     if (window.chrome && window.chrome.extension) {
@@ -16,5 +18,7 @@ function dimLoginCtrl() {
   } else {
     vm.authorizationURL = localStorage.authorizationURL;
   }
+
+  vm.authorizationURL = vm.authorizationURL + '?state=' + localStorage.authorizationState;
 }
 

--- a/src/scripts/login/return.component.js
+++ b/src/scripts/login/return.component.js
@@ -21,6 +21,11 @@ function ReturnController($http) {
     ctrl.state = queryString.state;
     ctrl.authorized = (ctrl.code.length > 0);
 
+    if (ctrl.state !== localStorage.authorizationState) {
+      window.location = "/#!/login";
+      return;
+    }
+
     var apiKey;
 
     if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {


### PR DESCRIPTION
The vendor-chunk PR accidentally broke the oauth return page, since it wasn't loading all the right chunks. This fixes that, while also implementing the "state" parameter verification (issue #1249).