### PR TITLE
Fix errors because we weren't returning stores anymore from reloadStores

### DIFF
--- a/src/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/src/scripts/loadout/dimLoadoutPopup.directive.js
@@ -346,12 +346,12 @@ function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemServic
           toaster.pop('success',
                       $translate.instant('Loadouts.MakeRoom'),
                       $translate.instant('Loadouts.MakeRoomDone', { postmasterNum: postmasterItems.length, movedNum: itemsToMove.length, store: vm.store.name, gender: vm.store.gender }));
-          return $q.resolve();
         })
         .catch((e) => {
           toaster.pop('error',
                       $translate.instant('Loadouts.MakeRoom'),
                       $translate.instant('Loadouts.MakeRoomError', { error: e.message }));
+          throw e;
         });
     });
   };

--- a/src/scripts/services/dimStoreService.factory.js
+++ b/src/scripts/services/dimStoreService.factory.js
@@ -620,6 +620,7 @@ function StoreService(
       })
       .then(function(stores) {
         dimDestinyTrackerService.reattachScoresFromCache(stores);
+        return stores;
       })
       .catch(function(e) {
         if (e.message === 'Active platform mismatch') {


### PR DESCRIPTION
PR #1620 changed the `reloadStores` method to no longer return the stores at the end of the promise. This breaks a bunch of stuff, but specifically the "reload stores when buckets are full" move logic.