### PR TITLE
Listen on the local, not global, scope for broadcast events

### DIFF
--- a/src/scripts/itemDiscuss/dimItemDiscuss.directive.js
+++ b/src/scripts/itemDiscuss/dimItemDiscuss.directive.js
@@ -20,7 +20,7 @@ function ItemDiscussCtrl($scope, $rootScope, toaster, dimItemDiscussService, dim
   vm.show = dimItemDiscussService.dialogOpen;
   vm.dtrRatingOptions = [1, 2, 3, 4, 5];
 
-  $rootScope.$on('dim-store-item-discuss', function(event, item) {
+  $scope.$on('dim-store-item-discuss', function(event, item) {
     vm.show = true;
 
     vm.item = item.item;

--- a/src/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/src/scripts/loadout/dimLoadoutPopup.directive.js
@@ -20,7 +20,7 @@ function LoadoutPopup() {
   };
 }
 
-function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemService, toaster, dimFarmingService, $window, dimSearchService, dimPlatformService, $translate, dimBucketService, $q, dimStoreService) {
+function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimItemService, toaster, dimFarmingService, $window, dimSearchService, dimPlatformService, $translate, dimBucketService, $q, dimStoreService) {
   var vm = this;
   vm.previousLoadout = _.last(dimLoadoutService.previousLoadouts[vm.store.id]);
 
@@ -50,8 +50,8 @@ function LoadoutPopupCtrl($rootScope, ngDialog, dimLoadoutService, dimItemServic
           .value();
       });
   }
-  $rootScope.$on('dim-save-loadout', initLoadouts);
-  $rootScope.$on('dim-delete-loadout', initLoadouts);
+  $scope.$on('dim-save-loadout', initLoadouts);
+  $scope.$on('dim-delete-loadout', initLoadouts);
   initLoadouts();
 
   vm.newLoadout = function newLoadout() {


### PR DESCRIPTION
Since these events are broadcast from the root scope, they will reach all scopes, and thus should be listened to on the local scope, so they unregister properly. Otherwise we have a memory leak!