### PR TITLE
Switch to GetCurrentBungieAccount for platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Loadouts with a complete set of equipped armor now include a stat bar that will tell you the stat tiers of the equipped loadout pieces.
 * Loadouts with non-equipping items now won't *de-equip* those items if they're already equipped. #1567
 * The count of items in your loadout is now more accurate.
+* DIM is now better at figuring out which platforms you have Destiny accounts on.
+* DIM is faster!
 
 # v3.17.1
 

--- a/src/scripts/login/return.component.js
+++ b/src/scripts/login/return.component.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import simpleQueryString from 'simple-query-string';
 import template from './return.component.template.html';
+import { bungieApiUpdate } from '../services/bungie-api-utils';
 
 angular.module('dimLogin').component('dimReturn', {
   controller: ReturnController,
@@ -26,28 +27,12 @@ function ReturnController($http) {
       return;
     }
 
-    var apiKey;
-
-    if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {
-      if (window.chrome && window.chrome.extension) {
-        apiKey = $DIM_API_KEY;
-      } else {
-        apiKey = $DIM_WEB_API_KEY;
-      }
-    } else {
-      apiKey = localStorage.apiKey;
-    }
-
-    $http({
-      method: 'POST',
-      url: 'https://www.bungie.net/Platform/App/GetAccessTokensFromCode/',
-      headers: {
-        'X-API-Key': apiKey
-      },
-      data: {
+    $http(bungieApiUpdate(
+      '/Platform/App/GetAccessTokensFromCode/',
+      {
         code: ctrl.code
       }
-    })
+    ))
     .then((response) => {
       if (response.data.ErrorCode === 1) {
         const inception = Date.now();

--- a/src/scripts/oauth/oauth.module.js
+++ b/src/scripts/oauth/oauth.module.js
@@ -10,9 +10,8 @@ export default angular.module('dim-oauth', [LocalStorageModule])
   .service('http-refresh-token', HttpRefreshTokenService)
   .run(function($rootScope, $state) {
     $rootScope.$on('dim-no-token-found', function() {
-      if ($DIM_FLAVOR !== 'dev') {
-        $state.go('login');
-      } else if (!localStorage.apiKey || !localStorage.authorizationURL) {
+      if ($DIM_FLAVOR !== 'dev' &&
+          (!localStorage.apiKey || !localStorage.authorizationURL)) {
         $state.go('developer');
       } else {
         $state.go('login');

--- a/src/scripts/oauth/oauth.module.js
+++ b/src/scripts/oauth/oauth.module.js
@@ -10,7 +10,7 @@ export default angular.module('dim-oauth', [LocalStorageModule])
   .service('http-refresh-token', HttpRefreshTokenService)
   .run(function($rootScope, $state) {
     $rootScope.$on('dim-no-token-found', function() {
-      if ($DIM_FLAVOR !== 'dev' &&
+      if ($DIM_FLAVOR === 'dev' &&
           (!localStorage.apiKey || !localStorage.authorizationURL)) {
         $state.go('developer');
       } else {

--- a/src/scripts/oauth/oauth.service.js
+++ b/src/scripts/oauth/oauth.service.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import { bungieApiUpdate } from '../services/bungie-api-utils';
 
 export function OAuthService($q, $injector, localStorageService, OAuthTokenService) {
   'ngInject';
@@ -14,27 +15,12 @@ export function OAuthService($q, $injector, localStorageService, OAuthTokenServi
   function refreshToken() {
     const $http = $injector.get('$http');
 
-    var apiKey;
-    if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {
-      if (window.chrome && window.chrome.extension) {
-        apiKey = $DIM_API_KEY;
-      } else {
-        apiKey = $DIM_WEB_API_KEY;
-      }
-    } else {
-      apiKey = localStorageService.get('apiKey');
-    }
-
-    return $http({
-      method: 'POST',
-      url: 'https://www.bungie.net/Platform/App/GetAccessTokensFromRefreshToken/',
-      headers: {
-        'X-API-Key': apiKey
-      },
-      data: {
+    return $http(bungieApiUpdate(
+      '/Platform/App/GetAccessTokensFromRefreshToken/',
+      {
         refreshToken: OAuthTokenService.getRefreshToken().value
       }
-    })
+    ))
     .then((response) => {
       if (response && response.data && (response.data.ErrorCode === 1) && response.data.Response && response.data.Response.accessToken) {
         const inception = Date.now();
@@ -54,15 +40,10 @@ export function OAuthService($q, $injector, localStorageService, OAuthTokenServi
     });
   }
 
-  function revokeToken() {
-    // Revokes token via api
-  }
-
   return {
     isAuthenticated,
     getToken,
-    refreshToken,
-    revokeToken
+    refreshToken
   };
 }
 

--- a/src/scripts/services/bungie-api-utils.js
+++ b/src/scripts/services/bungie-api-utils.js
@@ -1,0 +1,40 @@
+let apiKey;
+
+if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {
+  if (window.chrome && window.chrome.extension) {
+    apiKey = $DIM_API_KEY;
+  } else {
+    apiKey = $DIM_WEB_API_KEY;
+  }
+} else {
+  apiKey = localStorage.apiKey;
+}
+
+function bungieApiUpdate(path, data) {
+  return {
+    method: 'POST',
+    url: 'https://www.bungie.net' + path,
+    headers: {
+      'X-API-Key': apiKey
+    },
+    withCredentials: true,
+    dataType: 'json',
+    data: data
+  };
+}
+
+function bungieApiQuery(path) {
+  return {
+    method: 'GET',
+    url: 'https://www.bungie.net' + path,
+    headers: {
+      'X-API-Key': apiKey
+    },
+    withCredentials: true
+  };
+}
+
+export {
+  bungieApiQuery,
+  bungieApiUpdate
+};

--- a/src/scripts/services/dimBungieService.factory.js
+++ b/src/scripts/services/dimBungieService.factory.js
@@ -1,21 +1,11 @@
 import angular from 'angular';
 import _ from 'underscore';
+import { bungieApiQuery, bungieApiUpdate } from './bungie-api-utils';
 
 angular.module('dimApp')
   .factory('dimBungieService', BungieService);
 
 function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaster, $translate) {
-  var apiKey;
-  if ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') {
-    if (window.chrome && window.chrome.extension) {
-      apiKey = $DIM_API_KEY;
-    } else {
-      apiKey = $DIM_WEB_API_KEY;
-    }
-  } else {
-    apiKey = localStorage.apiKey;
-  }
-
   var service = {
     getAccounts: getAccounts,
     getCharacters: getCharacters,
@@ -29,31 +19,6 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
   };
 
   return service;
-
-  function bungieApiUpdate(path, data) {
-    return {
-      method: 'POST',
-      url: 'https://www.bungie.net' + path,
-      headers: {
-        'X-API-Key': apiKey
-      },
-      withCredentials: true,
-      dataType: 'json',
-      data: data
-    };
-  }
-
-  function bungieApiQuery(path) {
-    return {
-      method: 'GET',
-      url: 'https://www.bungie.net' + path,
-      headers: {
-        'X-API-Key': apiKey
-      },
-      withCredentials: true
-    };
-  }
-
   function handleErrors(response) {
     if (response.status === -1) {
       return $q.reject(new Error($translate.instant('BungieService.NotConnected')));

--- a/src/scripts/services/dimBungieService.factory.js
+++ b/src/scripts/services/dimBungieService.factory.js
@@ -16,16 +16,8 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
     apiKey = localStorage.apiKey;
   }
 
-  var platformPromise = null;
-  var membershipPromise = null;
-
-  $rootScope.$on('dim-active-platform-updated', function() {
-    platformPromise = null;
-    membershipPromise = null;
-  });
-
   var service = {
-    getPlatforms: getPlatforms,
+    getAccounts: getAccounts,
     getCharacters: getCharacters,
     getStores: getStores,
     transfer: transfer,
@@ -169,56 +161,16 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
       .then((response) => response.data.Response);
   }
 
-  function getPlatforms() {
-    platformPromise = platformPromise ||
-      $http(bungieApiQuery('/Platform/User/GetBungieNetUser/'))
+  function getAccounts() {
+    return $http(bungieApiQuery('/Platform/User/GetCurrentBungieAccount/'))
       .then(handleErrors, handleErrors)
-      .catch(function(e) {
-        showErrorToaster(e);
-        return $q.reject(e);
-      });
-
-    return platformPromise;
-  }
-
-  function getMembership(platform) {
-    membershipPromise = membershipPromise ||
-      $http(bungieApiQuery(
-        `/Platform/Destiny/${platform.type}/Stats/GetMembershipIdByDisplayName/${platform.id}/`
-      ))
-      .then(handleErrors, handleErrors)
-      .then(processBnetMembershipRequest, rejectBnetMembershipRequest)
-      .catch(function(error) {
-        membershipPromise = null;
-        return $q.reject(error);
-      });
-
-    return membershipPromise;
-
-    function processBnetMembershipRequest(response) {
-      if (_.size(response.data.Response) === 0) {
-        return $q.reject(new Error($translate.instant('BungieService.NoAccountForPlatform', {
-          platform: platform.label
-        })));
-      }
-
-      return $q.when(response.data.Response);
-    }
-
-    function rejectBnetMembershipRequest() {
-      return $q.reject(new Error($translate.instant('BungieService.NoAccountForPlatform', {
-        platform: platform.label
-      })));
-    }
+      .then((response) => response.data.Response);
   }
 
   function getCharacters(platform) {
-    const platformName = platform.type === 1 ? 'Xbox' : 'PSN';
-
-    var charactersPromise = getMembership(platform)
-        .then((membershipId) => $http(bungieApiQuery(
-          `/Platform/Destiny/Tiger${platformName}/Account/${membershipId}/`
-        )))
+    var charactersPromise = $http(bungieApiQuery(
+      `/Platform/Destiny/${platform.type}/Account/${platform.membershipId}/`
+    ))
         .then(handleErrors, handleErrors)
         .then(processBnetCharactersRequest);
 
@@ -243,17 +195,14 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
   }
 
   function getStores(platform) {
-    return $q.all([
-      getMembership(platform),
-      getCharacters(platform)
-    ])
-      .then(function([membershipId, characters]) {
+    return getCharacters(platform)
+      .then((characters) => {
         return $q.all([
-          getDestinyInventories(platform, membershipId, characters),
-          getDestinyProgression(platform, membershipId, characters)
+          getDestinyInventories(platform, characters),
+          getDestinyProgression(platform, characters)
           // Don't let failure of progression fail other requests.
             .catch((e) => console.error("Failed to load character progression", e)),
-          getDestinyAdvisors(platform, membershipId, characters)
+          getDestinyAdvisors(platform, characters)
           // Don't let failure of advisors fail other requests.
             .catch((e) => console.error("Failed to load advisors", e))
         ]).then(function(data) {
@@ -274,11 +223,11 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
       return payload;
     }
 
-    function getDestinyInventories(platform, membershipId, characters) {
+    function getDestinyInventories(platform, characters) {
       // Guardians
       const promises = characters.map(function(character) {
         return $http(bungieApiQuery(
-          `/Platform/Destiny/${platform.type}/Account/${membershipId}/Character/${character.id}/Inventory/?definitions=false`
+          `/Platform/Destiny/${platform.type}/Account/${platform.membershipId}/Character/${character.id}/Inventory/`
         ))
           .then(handleErrors, handleErrors)
           .then((response) => processInventoryResponse(character, response));
@@ -290,7 +239,7 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
         base: null
       };
 
-      const vaultPromise = $http(bungieApiQuery(`/Platform/Destiny/${platform.type}/MyAccount/Vault/?definitions=false`))
+      const vaultPromise = $http(bungieApiQuery(`/Platform/Destiny/${platform.type}/MyAccount/Vault/`))
         .then(handleErrors, handleErrors)
           .then((response) => processInventoryResponse(vault, response));
 
@@ -300,10 +249,10 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
     }
   }
 
-  function getDestinyProgression(platform, membershipId, characters) {
+  function getDestinyProgression(platform, characters) {
     const promises = characters.map(function(character) {
       return $http(bungieApiQuery(
-        `/Platform/Destiny/${platform.type}/Account/${membershipId}/Character/${character.id}/Progression/?definitions=false`
+        `/Platform/Destiny/${platform.type}/Account/${platform.membershipId}/Character/${character.id}/Progression/`
       ))
         .then(handleErrors, handleErrors)
         .then((response) => processProgressionResponse(character, response));
@@ -317,10 +266,10 @@ function BungieService($rootScope, $q, $timeout, $http, $state, dimState, toaste
     return $q.all(promises);
   }
 
-  function getDestinyAdvisors(platform, membershipId, characters) {
+  function getDestinyAdvisors(platform, characters) {
     var promises = characters.map(function(character) {
       return $http(bungieApiQuery(
-        `/Platform/Destiny/${platform.type}/Account/${membershipId}/Character/${character.id}/Advisors/V2/?definitions=false`
+        `/Platform/Destiny/${platform.type}/Account/${platform.membershipId}/Character/${character.id}/Advisors/V2/`
       ))
         .then(handleErrors, handleErrors)
         .then((response) => processAdvisorsResponse(character, response));


### PR DESCRIPTION
This resolves #1631 by switching to `GetCurrentBungieAccount` for getting platforms. It appears to be faster, and has better quality data (for example, it doesn't show my unused Xbox account). There's a bunch of other nice info in there we can use later. Sadly, while it has all characters for all accounts, it doesn't have their stats so we can't entirely skip the `GetAccount` calls we do today.

While I was in there I also deduplicated the request builders and API key logic into a plain JS module so we could share it with the special OAuth handling code.