### PR TITLE
Switch to ES6 dynamic import from require.ensure

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015"
+    ["es2015", { modules: false }]
   ],
-  "plugins": ["angularjs-annotate"]
+  "plugins": ["angularjs-annotate", "syntax-dynamic-import"]
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-core": "^6.21.0",
     "babel-loader": "^7.0.0",
     "babel-plugin-angularjs-annotate": "^0.7.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "bower": "^1.7.9",
     "chalk": "^1.1.3",

--- a/src/scripts/services/dimManifestService.factory.js
+++ b/src/scripts/services/dimManifestService.factory.js
@@ -5,18 +5,14 @@ import _ from 'underscore';
 import idbKeyval from 'idb-keyval';
 
 // For zip
-require('imports-loader?this=>window!zip-js/WebContent/zip.js');
+import 'imports-loader?this=>window!zip-js/WebContent/zip.js';
 
-// require.ensure splits up the sql library so the user only loads it
+// Dynamic import splits up the sql library so the user only loads it
 // if they need it. So we can minify sql.js specifically (as explained
 // in the Webpack config, we need to explicitly name this chunk, which
-// can only be done using the require.ensure method
+// can only be done using the dynamic import method.
 function requireSqlLib() {
-  return new Promise((resolve) => {
-    require.ensure('sql.js', (require) => {
-      resolve(require('sql.js'));
-    }, 'sqlLib');
-  });
+  return import(/* webpackChunkName: "sqlLib" */ 'sql.js');
 }
 
 angular.module('dimApp')


### PR DESCRIPTION
Not a biggie, but `require.ensure` is webpack-specific while dynamic import is at least on standards track, and it has a native promise interface to boot.