### PR TITLE
Fixing local caching in the updated review UI.

### DIFF
--- a/src/scripts/destinyTrackerApi/reviewsFetcher.js
+++ b/src/scripts/destinyTrackerApi/reviewsFetcher.js
@@ -70,7 +70,7 @@ class ReviewsFetcher {
       item.userRating = cachedItem.userRating;
     }
 
-    if (cachedItem.review) {
+    if (cachedItem.userReview) {
       item.userReview = cachedItem.userReview;
     }
 

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -6,9 +6,9 @@ function ItemReviewController($rootScope, dimSettingsService) {
 
   const vm = this;
   vm.canReview = dimSettingsService.allowIdPostToDtr;
-  vm.expandReview = false;
   vm.submitted = false;
   vm.hasUserReview = vm.item.userRating;
+  vm.expandReview = vm.hasUserReview;
 
   vm.procon = false; // TODO: turn this back on..
   vm.aggregate = {

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -1,7 +1,7 @@
 import template from './item-review.html';
 import './item-review.scss';
 
-function ItemReviewController($rootScope, dimSettingsService) {
+function ItemReviewController($rootScope, dimSettingsService, dimDestinyTrackerService) {
   'ngInject';
 
   const vm = this;
@@ -35,6 +35,30 @@ function ItemReviewController($rootScope, dimSettingsService) {
       vm.item.userRating = rating;
     }
     vm.expandReview = true;
+  };
+
+  vm.reviewBlur = function() {
+    var item = vm.item;
+    var userReview = vm.toUserReview(item);
+
+    dimDestinyTrackerService.updateCachedUserRankings(item,
+                                                      userReview);
+  };
+
+  vm.toUserReview = function(item) {
+    var newRating = item.userRating;
+    var review = item.userReview;
+    var pros = item.userReviewPros;
+    var cons = item.userReviewCons;
+
+    var userReview = {
+      rating: newRating,
+      review: review,
+      pros: pros,
+      cons: cons
+    };
+
+    return userReview;
   };
 }
 

--- a/src/scripts/item-review/item-review.html
+++ b/src/scripts/item-review/item-review.html
@@ -1,6 +1,6 @@
 <div ng-if="$ctrl.canReview" class="user-review--header">
   <span translate="DtrReview.YourReview"></span>
-  <star-rating rating="$ctrl.item.userRating" on-rating-change="$ctrl.setRating(rating)"></star-rating>
+  <star-rating rating="$ctrl.item.userRating" on-rating-change="$ctrl.setRating(rating)" ng-blur="vm.reviewBlur()"></star-rating>
 
   <span ng-show="$ctrl.expandReview">
     <span class="dim-button" ng-click="$ctrl.submitReview()" translate="DtrReview.Submit"></span>
@@ -10,12 +10,15 @@
 
 <div class="community-review--details" ng-show="$ctrl.expandReview">
   <textarea translate-attr="{ placeholder: 'DtrReview.Help' }"
-            ng-model="$ctrl.item.userReview"></textarea>
+            ng-model="$ctrl.item.userReview"
+            ng-blur="vm.reviewBlur()"></textarea>
   <div ng-if="$ctrl.procon" class="community-review--procon">
     <textarea translate-attr="{ placeholder: 'DtrReview.HelpPros' }"
-              ng-model="$ctrl.item.userReviewPros"></textarea>
+              ng-model="$ctrl.item.userReviewPros"
+              ng-blur="vm.reviewBlur()"></textarea>
     <textarea translate-attr="{ placeholder: 'DtrReview.HelpCons' }"
-              ng-model="$ctrl.item.userReviewCons"></textarea>
+              ng-model="$ctrl.item.userReviewCons"
+              ng-blur="vm.reviewBlur()"></textarea>
   </div>
 </div>
 

--- a/src/scripts/item-review/item-review.html
+++ b/src/scripts/item-review/item-review.html
@@ -1,6 +1,6 @@
 <div ng-if="$ctrl.canReview" class="user-review--header">
   <span translate="DtrReview.YourReview"></span>
-  <star-rating rating="$ctrl.item.userRating" on-rating-change="$ctrl.setRating(rating)" ng-blur="vm.reviewBlur()"></star-rating>
+  <star-rating rating="$ctrl.item.userRating" on-rating-change="$ctrl.setRating(rating)" ng-blur="$ctrl.reviewBlur()"></star-rating>
 
   <span ng-show="$ctrl.expandReview">
     <span class="dim-button" ng-click="$ctrl.submitReview()" translate="DtrReview.Submit"></span>
@@ -11,14 +11,14 @@
 <div class="community-review--details" ng-show="$ctrl.expandReview">
   <textarea translate-attr="{ placeholder: 'DtrReview.Help' }"
             ng-model="$ctrl.item.userReview"
-            ng-blur="vm.reviewBlur()"></textarea>
+            ng-blur="$ctrl.reviewBlur()"></textarea>
   <div ng-if="$ctrl.procon" class="community-review--procon">
     <textarea translate-attr="{ placeholder: 'DtrReview.HelpPros' }"
               ng-model="$ctrl.item.userReviewPros"
-              ng-blur="vm.reviewBlur()"></textarea>
+              ng-blur="$ctrl.reviewBlur()"></textarea>
     <textarea translate-attr="{ placeholder: 'DtrReview.HelpCons' }"
               ng-model="$ctrl.item.userReviewCons"
-              ng-blur="vm.reviewBlur()"></textarea>
+              ng-blur="$ctrl.reviewBlur()"></textarea>
   </div>
 </div>
 


### PR DESCRIPTION
This was one of the not-obvious things that the review bits did - cache reviews in-memory locally (so that we don't lose data across refresh cycles or if the person doesn't post right away).