### PR TITLE
Fix chrome version warning

### DIFF
--- a/src/scripts/dimApp.run.js
+++ b/src/scripts/dimApp.run.js
@@ -1,8 +1,6 @@
 import changelog from '../views/changelog-toaster-release.html';
 
-import upgradeChrome from '../views/upgrade-chrome.html';
-
-function run($window, $rootScope, $translate, SyncService, dimInfoService) {
+function run($window, $rootScope, $translate, SyncService, dimInfoService, $timeout) {
   'ngInject';
 
   $window.initgapi = () => {
@@ -16,13 +14,16 @@ function run($window, $rootScope, $translate, SyncService, dimInfoService) {
   $rootScope.$DIM_FLAVOR = $DIM_FLAVOR;
   $rootScope.$DIM_CHANGELOG = $DIM_CHANGELOG;
 
-  $rootScope.$on('dim-settings-loaded', () => {
+  const unregister = $rootScope.$on('dim-settings-loaded', () => {
     if (chromeVersion && chromeVersion.length === 2 && parseInt(chromeVersion[1], 10) < 51) {
-      dimInfoService.show('old-chrome', {
-        title: $translate.instant('Help.UpgradeChrome'),
-        view: upgradeChrome,
-        type: 'error'
-      }, 0);
+      $timeout(function() {
+        dimInfoService.show('old-chrome', {
+          title: $translate.instant('Help.UpgradeChrome'),
+          body: $translate.instant('Views.UpgradeChrome'),
+          type: 'error',
+          hideable: false
+        }, 0);
+      }, 1000);
     }
 
     console.log('DIM v' + $DIM_VERSION + ' (' + $DIM_FLAVOR + ') - Please report any errors to https://www.reddit.com/r/destinyitemmanager');
@@ -33,9 +34,11 @@ function run($window, $rootScope, $translate, SyncService, dimInfoService) {
           version: $DIM_VERSION,
           beta: $DIM_FLAVOR === 'beta'
         }),
-        view: changelog
+        body: changelog
       });
     }
+
+    unregister();
   });
 }
 

--- a/src/scripts/services/dimInfoService.factory.js
+++ b/src/scripts/services/dimInfoService.factory.js
@@ -14,30 +14,31 @@ function InfoService(toaster, $http, $translate, SyncService) {
       content.body = content.body || '';
       content.hide = content.hide || $translate.instant('Help.HidePopup');
       content.func = content.func || function() {};
+      content.hideable = content.hideable === undefined ? true : content.hideable;
 
       function showToaster(body, save, timeout) {
         timeout = timeout || 0;
+
+        body = `<p>${body}</p>`;
+
+        if (content.hideable) {
+          body += `<input id="info-${id}" type="checkbox">
+            <label for="info-${id}">${content.hide}</label></p>`;
+        }
+
         toaster.pop({
           type: content.type,
           title: content.title,
-          body: [
-            '<p>' + body + '</p>',
-            '<input id="info-' + id + '" type="checkbox">',
-            '<label for="info-' + id + '">' + content.hide + '</label></p>'
-          ].join(''),
+          body: body,
           timeout: timeout,
           bodyOutputType: 'trustedHtml',
           showCloseButton: true,
-          clickHandler: function(a, b) {
-            if (b) {
-              return true;
-            }
-
-            return false;
+          clickHandler: function(_, closeButton) {
+            // Only close when the close button is clicked
+            return Boolean(closeButton);
           },
           onHideCallback: function() {
-            if ($('#info-' + id)
-              .is(':checked')) {
+            if ($('#info-' + id).is(':checked')) {
               save['info.' + id] = 1;
               SyncService.set(save);
             }
@@ -45,19 +46,18 @@ function InfoService(toaster, $http, $translate, SyncService) {
         });
       }
 
-      SyncService.get().then(function(data) {
-        if (!data || data['info.' + id]) {
-          return;
-        }
-        if (content.view) {
-          $http.get(content.view).then(function(changelog) {
-            showToaster(changelog.data, data, timeout);
-          });
-        } else {
+      if (content.hideable) {
+        SyncService.get().then(function(data) {
+          if (!data || data['info.' + id]) {
+            return;
+          }
           showToaster(content.body, data, timeout);
-        }
+          content.func();
+        });
+      } else {
+        showToaster(content.body, {}, timeout);
         content.func();
-      });
+      }
     },
     // Remove prefs for "don't show this again"
     resetHiddenInfos: function() {

--- a/src/views/upgrade-chrome.html
+++ b/src/views/upgrade-chrome.html
@@ -1,1 +1,0 @@
-<p translate="Views.UpgradeChrome"></p>


### PR DESCRIPTION
The move to loading templates as strings broke the version warning, but so did a lot of our routing changes and such. I took the opportunity to make this warning definitely show up, and then to not allow people to hide it.