### PR TITLE
Force item amounts to update in the UI when modified

### DIFF
--- a/src/scripts/services/dimItemService.factory.js
+++ b/src/scripts/services/dimItemService.factory.js
@@ -47,7 +47,7 @@ function ItemService(dimStoreService,
       var stackable = item.maxStackSize > 1;
       // Items to be decremented
       var sourceItems = stackable
-            ? _.sortBy(_.select(source.items, function(i) {
+            ? _.sortBy(_.select(source.buckets[item.location.id], function(i) {
               return i.hash === item.hash &&
                 i.id === item.id &&
                 !i.notransfer;
@@ -55,7 +55,7 @@ function ItemService(dimStoreService,
       // Items to be incremented. There's really only ever at most one of these, but
       // it's easier to deal with as a list.
       var targetItems = stackable
-            ? _.sortBy(_.select(target.items, function(i) {
+            ? _.sortBy(_.select(target.buckets[item.location.id], function(i) {
               return i.hash === item.hash &&
                 i.id === item.id &&
                 // Don't consider full stacks as targets
@@ -82,7 +82,17 @@ function ItemService(dimStoreService,
             removedSourceItem = sourceItem.index === item.index;
           }
         } else {
+          // Perf hack: by replacing the item entirely with a cloned
+          // item that has an adjusted index, we force the ng-repeat
+          // to refresh its view of the item, updating the
+          // amount. This is because we've switched to bind-once for
+          // the amount since it rarely changes.
+          source.removeItem(sourceItem);
+          sourceItem = angular.copy(sourceItem);
           sourceItem.amount -= amountToRemove;
+          sourceItem.index = dimStoreService.createItemIndex(sourceItem);
+          source.addItem(sourceItem);
+          console.log(source.buckets[item.location.id]);
         }
 
         removeAmount -= amountToRemove;
@@ -105,7 +115,16 @@ function ItemService(dimStoreService,
         }
 
         var amountToAdd = Math.min(addAmount, targetItem.maxStackSize - targetItem.amount);
+        // Perf hack: by replacing the item entirely with a cloned
+        // item that has an adjusted index, we force the ng-repeat to
+        // refresh its view of the item, updating the amount. This is
+        // because we've switched to bind-once for the amount since it
+        // rarely changes.
+        target.removeItem(targetItem);
+        targetItem = angular.copy(targetItem);
         targetItem.amount += amountToAdd;
+        targetItem.index = dimStoreService.createItemIndex(targetItem);
+        target.addItem(targetItem);
         addAmount -= amountToAdd;
       }
       item = targetItem; // The item we're operating on switches to the last target


### PR DESCRIPTION
As a consequence of my recent bind-once efficiency hacks, updating the amount of stackables as they were moved around broke (#1676). The fix is awkward, but involves making Angular see a completely new object (by cloning and replacing the item) with a new index (by regenerating the index, since amount is part of the index) which will cause it to completely replace the directive.

While I was there I also restricted the source/target items to only be in the same bucket as the item you're moving. Won't change anything, but it'll inspect fewer items.