### PR TITLE
Updated URL's to MDN and underscorejs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 * DIM is now better at figuring out which platforms you have Destiny accounts on.
 * DIM is faster!
 * Added Age of Triumph filters is:aot and is:triumph
-* Fixed documentation links pointing to legacy locations
 
 # v3.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * DIM is now better at figuring out which platforms you have Destiny accounts on.
 * DIM is faster!
 * Added Age of Triumph filters is:aot and is:triumph
+* Fixed documentation links pointing to legacy locations
 
 # v3.17.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Here are some tips to make sure your pull request can be merged smoothly:
 2. Resist the temptation to change more than one thing in your PR. Keeping PRs focused on a single change makes them much easier to review and accept. If you want to change multiple things, or clean up/refactor the code, make a new branch and submit those changes as a separate PR.
 3. Please follow the existing style of DIM code when making your changes. While there's certainly room for improvement in the DIM codebase, if everybody used their favorite code style nothing would match up.
 4. You can use any ES6/ES2015 features [supported by a reasonably modern Chrome version](https://kangax.github.io/compat-table/es6).
-5. Take advantage of the [native JavaScript Array methods](http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array.html) and the [Underscore](http://underscorejs.com) library to write compact, easy-to-understand code.
+5. Take advantage of the [native JavaScript Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) and the [Underscore](http://underscorejs.org) library to write compact, easy-to-understand code.
 6. Be sure to run `grunt eslint` before submitting your PR - it'll catch most style problems and make things much easier to merge.
 7. Don't forget to add a description of your change to `CHANGELOG.md` so it'll be included in the release notes!
 


### PR DESCRIPTION
I noticed that the links used in the contributing documentation were actually legacy, so updating them