### PR TITLE
Remove buttons from loadout suggestions that contain vendor items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add gunsmith filter is:gunsmith
 * Updated filters to remove common items for specific filters (e.g. is:wotm no longer shows exotic items from xur, engrams, and planetary materials)
 * Loadout Builder's equip button now operates on the selected character, not your last-played character.
+* Loadout Builder no longer has equip and create loadout buttons for loadouts that include vendor items.
 
 # v3.17.1
 

--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -151,7 +151,7 @@
       "LockedHelp": "Drag and drop any item into its bucket to build set with that specific gear. Shift + click to exclude items.",
       "FilterSets": "Filter sets",
       "AdvancedOptions": "Advanced Options",
-     "ContainsVendorItems": "This loadout contains vendor items",
+      "ContainsVendorItems": "This loadout contains vendor items",
       "ProcessingMode": {
          "Fast": "Fast",
          "Full": "Full",

--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -151,6 +151,7 @@
       "LockedHelp": "Drag and drop any item into its bucket to build set with that specific gear. Shift + click to exclude items.",
       "FilterSets": "Filter sets",
       "AdvancedOptions": "Advanced Options",
+     "ContainsVendorItems": "This loadout contains vendor items",
       "ProcessingMode": {
          "Fast": "Fast",
          "Full": "Full",

--- a/src/scripts/loadout-builder/loadout-builder-locks.html
+++ b/src/scripts/loadout-builder/loadout-builder-locks.html
@@ -1,37 +1,34 @@
-<div ng-repeat="(type, lockeditem) in vm.lockedItems">
-  <div class="locked-item"
-       ng-switch="lockeditem"
-       ui-on-drop="vm.onDrop({$data: $data, type: type})"
-       drag-channel="{{type}}"
-       drop-channel="{{type}}"
-       drop-validate="vm.lockedItemsValid({$data: $data, type: type})">
-    <div ng-switch-when="null"
-         class="empty-item">
-      <div ng-switch="vm.hasLockedPerks(vm.lockedPerks, type)"
-           class="perk-addition"
-           ng-click="vm.addPerkClicked(vm.activePerks, vm.lockedPerks, type, $event)">
-        <div ng-switch-when="false"
-             class="perk-addition-text-container">
-          <i class="fa fa-plus"></i>
-          <small class="perk-addition-text"
-                 translate="LB.LockPerk"></small>
-        </div>
-        <div ng-switch-when="true"
-             class="locked-perk-notification">
-          <img ng-src="{{vm.getFirstPerk(vm.lockedPerks, type).icon | bungieIcon}}"
-               ng-attr-title="{{vm.getFirstPerk(vm.lockedPerks, type).description}}" />
-        </div>
+<div class="locked-item"
+     ng-repeat="(type, lockeditem) in vm.lockedItems"
+     ng-switch="lockeditem"
+     ui-on-drop="vm.onDrop({$data: $data, type: type})"
+     drag-channel="{{type}}"
+     drop-channel="{{type}}"
+     drop-validate="vm.lockedItemsValid({$data: $data, type: type})">
+  <div ng-switch-when="null"
+       class="empty-item">
+    <div ng-switch="vm.hasLockedPerks(vm.lockedPerks, type)"
+         class="perk-addition"
+         ng-click="vm.addPerkClicked(vm.activePerks, vm.lockedPerks, type, $event)">
+      <div ng-switch-when="false"
+           class="perk-addition-text-container">
+        <i class="fa fa-plus"></i>
+        <small class="perk-addition-text"
+               translate="LB.LockPerk"></small>
+      </div>
+      <div ng-switch-when="true"
+           class="locked-perk-notification">
+        <img ng-src="{{vm.getFirstPerk(vm.lockedPerks, type).icon | bungieIcon}}"
+             ng-attr-title="{{vm.getFirstPerk(vm.lockedPerks, type).description}}" />
       </div>
     </div>
-    <div ng-switch-default>
-      <div class="lock-container">
-        <loadout-builder-item item-data="lockeditem"></loadout-builder-item>
-        <div class="close"
-             ng-click="vm.onRemove({type: type})"
-             role="button"
-             tabindex="0"></div>
-      </div>
-    </div>
-    <div class="label">{{vm.i18nItemNames[type]}}</div>
   </div>
+  <div class="lock-container" ng-switch-default>
+    <loadout-builder-item item-data="lockeditem"></loadout-builder-item>
+    <div class="close"
+         ng-click="vm.onRemove({type: type})"
+         role="button"
+         tabindex="0"></div>
+  </div>
+  <div class="label">{{vm.i18nItemNames[type]}}</div>
 </div>

--- a/src/scripts/loadout-builder/loadout-builder.component.js
+++ b/src/scripts/loadout-builder/loadout-builder.component.js
@@ -549,6 +549,8 @@ function LoadoutBuilderController($scope, $state, $q, $timeout, $location, $tran
                             setMap[set.setHash] = { set: set, tiers: {} };
                             setMap[set.setHash].tiers[tiersString] = { stats: set.stats, configs: [getBonusConfig(set.armor)] };
                           }
+
+                          set.includesVendorItems = _.any(_.values(set.armor), (armor) => armor.item.isVendorItem);
                         }
 
                         processedCount++;

--- a/src/scripts/loadout-builder/loadout-builder.html
+++ b/src/scripts/loadout-builder/loadout-builder.html
@@ -141,8 +141,13 @@
     <p><span translate="LB.Loading"></span> <span>({{vm.progress*100 | number:2}}%)</span></p>
   </div>
   <div ng-show="vm.progress >= 1">
-    <div class="section loadout" ng-repeat="setType in vm.activeHighestSets">
-      <div><dim-stats stats="setType.tiers[vm.activesets].stats"></dim-stats><span class='dim-button' ng-click="vm.newLoadout(setType.set)" translate="Loadouts.Create"></span><span class='dim-button equip-button' ng-click="vm.equipItems(setType.set)" translate="LB.Equip" translate-values="{ character: vm.activeCharacters[vm.selectedCharacter].name }"></span></div>
+    <div class="section loadout" ng-repeat="setType in vm.activeHighestSets track by setType.set.setHash">
+      <div class="loadout-builder-controls">
+        <span ng-if="setType.set.includesVendorItems" translate="LB.ContainsVendorItems"></span>
+        <span ng-if="!setType.set.includesVendorItems" class='dim-button' ng-click="vm.newLoadout(setType.set)" translate="Loadouts.Create"></span>
+        <span ng-if="!setType.set.includesVendorItems" class='dim-button equip-button' ng-click="vm.equipItems(setType.set)" translate="LB.Equip" translate-values="{ character: vm.activeCharacters[vm.selectedCharacter].name }"></span>
+        <dim-stats stats="setType.tiers[vm.activesets].stats"></dim-stats>
+      </div>
       <div class="loadout-builder-section">
         <div class="set-item" ng-repeat="armorpiece in setType.set.armor">
           <loadout-builder-item shift-click-callback="vm.excludeItem" item-data="armorpiece.item"></loadout-builder-item>

--- a/src/scripts/loadout-builder/loadout-builder.scss
+++ b/src/scripts/loadout-builder/loadout-builder.scss
@@ -114,6 +114,13 @@
     cursor: pointer;
   }
 
+  .loadout-builder-controls {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 7px;
+  }
+
   .loadout-builder-section {
     width: 100%;
     display: flex;
@@ -226,7 +233,6 @@
 
   .lock-container {
     position: relative;
-    width: calc(var(--item-size) + 4px);
   }
 
   .item-container {
@@ -242,19 +248,20 @@
   }
 
   .locked-item {
-    display:inline-block;
     margin-right:20px;
     position:relative;
-    float: left;
     text-align: center;
     width: calc(var(--item-size) + 15px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     .empty-item {
-      display: inline-block;
       background-color:#656565;
       width: var(--item-size);
       height: var(--item-size);
       border:2px solid #DDD;
+      margin-bottom: 4px;
     }
   }
 
@@ -289,14 +296,11 @@
 
   dim-stats {
     display: inline-block;
-    margin-bottom: 7px;
     margin-left: 22px;
     .stat-bars {
       width: 375px;
+      margin-top: 0;
     }
-  }
-  .loadout .dim-button {
-    float: left;
   }
   .set-item {
     position: relative;


### PR DESCRIPTION
![screen shot 2017-06-13 at 11 36 13 pm](https://user-images.githubusercontent.com/313208/27118686-49086fce-5091-11e7-82a8-d59c5495fb69.png)

This fixes #1686 by removing the buttons from loadouts that contain vendor items, since you can neither equip them or create a valid loadout from them.