### PR TITLE
Added filter capability for new ratings system

### DIFF
--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -92,7 +92,7 @@ function SearchService(dimSettingsService) {
     });
   });
 
-  var ranges = ['light', 'level', 'quality', 'percentage'];
+  var ranges = ['light', 'level', 'quality', 'percentage', 'rating'];
   ranges.forEach(function(range) {
     comparisons.forEach((comparison) => {
       keywords.push(range + comparison);
@@ -121,7 +121,7 @@ function SearchFilter(dimSearchService) {
       element.find('input').textcomplete([
         {
           words: dimSearchService.keywords,
-          match: /\b((li|le|qu|pe|is:|not:|tag:|notes:|stat:)\w*)$/,
+          match: /\b((li|le|qu|pe|ra|is:|not:|tag:|notes:|stat:)\w*)$/,
           search: function(term, callback) {
             callback($.map(this.words, function(word) {
               return word.indexOf(term) === 0 ? word : null;
@@ -279,6 +279,9 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
       } else if (term.startsWith('quality:') || term.startsWith('percentage:')) {
         filter = term.replace('quality:', '').replace('percentage:', '');
         addPredicate("quality", filter);
+      } else if (term.startsWith('rating:')) {
+        filter = term.replace('rating:', '');
+        addPredicate("rating", filter);
       } else if (term.startsWith('stat:')) {
         // Avoid console.error by checking if all parameters are typed
         var pieces = term.split(':');
@@ -577,6 +580,50 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
         break;
       case '>=':
         result = (item.quality.min >= predicate);
+        break;
+      }
+      return result;
+    },
+    rating: function(predicate, item) {
+      if (predicate.length === 0 || !item.dtrRating) {
+        return false;
+      }
+
+      var operands = ['<=', '>=', '=', '>', '<'];
+      var operand = 'none';
+      var result = false;
+
+      operands.forEach(function(element) {
+        if (predicate.substring(0, element.length) === element) {
+          operand = element;
+          predicate = predicate.substring(element.length);
+          return false;
+        } else {
+          return true;
+        }
+      }, this);
+
+      predicate = parseFloat(predicate);
+      var itemRating = parseFloat(item.dtrRating);
+
+      switch (operand) {
+      case 'none':
+        result = (itemRating === predicate);
+        break;
+      case '=':
+        result = (itemRating === predicate);
+        break;
+      case '<':
+        result = (itemRating < predicate);
+        break;
+      case '<=':
+        result = (itemRating <= predicate);
+        break;
+      case '>':
+        result = (itemRating > predicate);
+        break;
+      case '>=':
+        result = (itemRating >= predicate);
         break;
       }
       return result;

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -92,6 +92,12 @@ function SearchService(dimSettingsService) {
     });
   });
 
+  const states = ['rating'];
+  states.forEach(function(word) {
+    const filter = 'has:' + word;
+    keywords.push(filter);
+  });
+
   var ranges = ['light', 'level', 'quality', 'percentage', 'rating'];
   ranges.forEach(function(range) {
     comparisons.forEach((comparison) => {
@@ -121,7 +127,7 @@ function SearchFilter(dimSearchService) {
       element.find('input').textcomplete([
         {
           words: dimSearchService.keywords,
-          match: /\b((li|le|qu|pe|ra|is:|not:|tag:|notes:|stat:)\w*)$/,
+          match: /\b((li|le|qu|pe|ra|is:|not:|tag:|notes:|stat:|has:)\w*)$/,
           search: function(term, callback) {
             callback($.map(this.words, function(word) {
               return word.indexOf(term) === 0 ? word : null;
@@ -284,10 +290,16 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
         addPredicate("rating", filter);
       } else if (term.startsWith('stat:')) {
         // Avoid console.error by checking if all parameters are typed
-        var pieces = term.split(':');
-        if (pieces.length === 3) {
-          filter = pieces[1];
-          addPredicate(filter, pieces[2]);
+        var statPieces = term.split(':');
+        if (statPieces.length === 3) {
+          filter = statPieces[1];
+          addPredicate(filter, statPieces[2]);
+        }
+      } else if (term.startsWith('has:')) {
+        var hasPieces = term.split(':');
+        if (hasPieces.length === 2) {
+          filter = hasPieces[0];
+          addPredicate(filter, hasPieces[1]);
         }
       } else if (!/^\s*$/.test(term)) {
         addPredicate("keyword", term);
@@ -497,6 +509,14 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
           // Fixed #798 by searching on the description too.
           return (node.name + ' ' + node.description).toLowerCase().indexOf(predicate) >= 0;
         }));
+    },
+    has: function(predicate, item) {
+      switch (predicate) {
+      case "rating":
+        return item.dtrRating;
+      default:
+        return false;
+      }
     },
     light: function(predicate, item) {
       if (predicate.length === 0 || !item.primStat) {

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -130,7 +130,7 @@ function SearchFilter(dimSearchService) {
       element.find('input').textcomplete([
         {
           words: dimSearchService.keywords,
-          match: /\b((li|le|qu|pe|ra|is:|not:|tag:|notes:|stat:|has:)\w*)$/,
+          match: /\b((li|le|qu|pe|ra|is:|not:|tag:|notes:|stat:)\w*)$/,
           search: function(term, callback) {
             callback($.map(this.words, function(word) {
               return word.indexOf(term) === 0 ? word : null;
@@ -297,12 +297,6 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
         if (statPieces.length === 3) {
           filter = statPieces[1];
           addPredicate(filter, statPieces[2]);
-        }
-      } else if (term.startsWith('has:')) {
-        var hasPieces = term.split(':');
-        if (hasPieces.length === 2) {
-          filter = hasPieces[0];
-          addPredicate(filter, hasPieces[1]);
         }
       } else if (!/^\s*$/.test(term)) {
         addPredicate("keyword", term);

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -293,10 +293,10 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
         addPredicate("rating", filter);
       } else if (term.startsWith('stat:')) {
         // Avoid console.error by checking if all parameters are typed
-        var statPieces = term.split(':');
-        if (statPieces.length === 3) {
-          filter = statPieces[1];
-          addPredicate(filter, statPieces[2]);
+        var pieces = term.split(':');
+        if (pieces.length === 3) {
+          filter = pieces[1];
+          addPredicate(filter, pieces[2]);
         }
       } else if (!/^\s*$/.test(term)) {
         addPredicate("keyword", term);

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -67,6 +67,10 @@ function SearchService(dimSettingsService) {
     transferable: ['transferable', 'movable']
   };
 
+  if ($featureFlags.reviewsEnabled) {
+    filterTrans.hasRating = ['rated', 'hasrating'];
+  }
+
   var keywords = _.flatten(_.flatten(_.values(filterTrans)).map(function(word) {
     return ["is:" + word, "not:" + word];
   }));
@@ -92,13 +96,12 @@ function SearchService(dimSettingsService) {
     });
   });
 
-  const states = ['rating'];
-  states.forEach(function(word) {
-    const filter = 'has:' + word;
-    keywords.push(filter);
-  });
+  var ranges = ['light', 'level', 'quality', 'percentage'];
 
-  var ranges = ['light', 'level', 'quality', 'percentage', 'rating'];
+  if ($featureFlags.reviewsEnabled) {
+    ranges.push('rating');
+  }
+
   ranges.forEach(function(range) {
     comparisons.forEach((comparison) => {
       keywords.push(range + comparison);
@@ -510,14 +513,6 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
           return (node.name + ' ' + node.description).toLowerCase().indexOf(predicate) >= 0;
         }));
     },
-    has: function(predicate, item) {
-      switch (predicate) {
-      case "rating":
-        return item.dtrRating;
-      default:
-        return false;
-      }
-    },
     light: function(predicate, item) {
       if (predicate.length === 0 || !item.primStat) {
         return false;
@@ -603,6 +598,9 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
         break;
       }
       return result;
+    },
+    hasRating: function(predicate, item) {
+      return predicate.length !== 0 && item.dtrRating;
     },
     rating: function(predicate, item) {
       if (predicate.length === 0 || !item.dtrRating) {


### PR DESCRIPTION
This adds the ability to filter gear by it's current rating.

You can use "rating:" with the different comparison operators, or "is/not:rated" or "is/not:hasrating" to filter to all gear that currently has/does not have a rating of any kind. Use "rating" for comparison/range queries.