### PR TITLE
Reviews fixes

### DIFF
--- a/src/scripts/destinyTrackerApi/bulkFetcher.js
+++ b/src/scripts/destinyTrackerApi/bulkFetcher.js
@@ -72,14 +72,16 @@ class BulkFetcher {
 
     stores.forEach(function(store) {
       store.items.forEach(function(storeItem) {
-        const matchingItem = self._reviewDataCache.getRatingData(storeItem);
+        if (storeItem.reviewable) {
+          const matchingItem = self._reviewDataCache.getRatingData(storeItem);
 
-        if (matchingItem) {
-          storeItem.dtrRating = matchingItem.rating;
-          storeItem.userRating = matchingItem.userRating;
-          storeItem.userReview = matchingItem.review;
-          storeItem.pros = matchingItem.pros;
-          storeItem.cons = matchingItem.cons;
+          if (matchingItem) {
+            storeItem.dtrRating = matchingItem.rating;
+            storeItem.userRating = matchingItem.userRating;
+            storeItem.userReview = matchingItem.review;
+            storeItem.pros = matchingItem.pros;
+            storeItem.cons = matchingItem.cons;
+          }
         }
       });
     });

--- a/src/scripts/destinyTrackerApi/bulkFetcher.js
+++ b/src/scripts/destinyTrackerApi/bulkFetcher.js
@@ -58,8 +58,7 @@ class BulkFetcher {
 
   attachRankings(bulkRankings,
                  stores) {
-    if ((!bulkRankings) &&
-        (!stores)) {
+    if (!bulkRankings && !stores) {
       return;
     }
 

--- a/src/scripts/destinyTrackerApi/reviewDataCache.js
+++ b/src/scripts/destinyTrackerApi/reviewDataCache.js
@@ -98,9 +98,10 @@ class ReviewDataCache {
   addReviewsData(item,
                  reviewsData) {
     var matchingItem = this._getMatchingItem(item);
-
-    matchingItem.reviews = reviewsData.reviews;
-    matchingItem.reviewsDataFetched = true;
+    if (matchingItem) {
+      matchingItem.reviews = reviewsData.reviews;
+      matchingItem.reviewsDataFetched = true;
+    }
   }
 
   /**

--- a/src/scripts/destinyTrackerApi/reviewDataCache.js
+++ b/src/scripts/destinyTrackerApi/reviewDataCache.js
@@ -20,7 +20,7 @@ class ReviewDataCache {
     // and findWhere considers 123 !== "123".
     dtrItem.referenceId = String(dtrItem.referenceId);
 
-    return _.findWhere(this._itemStores, { referenceId: dtrItem.referenceId, roll: dtrItem.roll });
+    return _.find(this._itemStores, { referenceId: dtrItem.referenceId, roll: dtrItem.roll });
   }
 
   /**

--- a/src/scripts/destinyTrackerApi/reviewsFetcher.js
+++ b/src/scripts/destinyTrackerApi/reviewsFetcher.js
@@ -99,7 +99,7 @@ class ReviewsFetcher {
     }
     const ratingData = this._reviewDataCache.getRatingData(item);
 
-    if (ratingData.reviewsDataFetched) {
+    if (ratingData && ratingData.reviewsDataFetched) {
       this._attachCachedReviews(item,
                                ratingData);
 

--- a/src/scripts/destinyTrackerApi/reviewsFetcher.js
+++ b/src/scripts/destinyTrackerApi/reviewsFetcher.js
@@ -41,7 +41,7 @@ class ReviewsFetcher {
   }
 
   _getUserReview(reviewData) {
-    return _.findWhere(reviewData.reviews, { isReviewer: true });
+    return _.find(reviewData.reviews, { isReviewer: true });
   }
 
   _attachReviews(item, reviewData) {

--- a/src/scripts/store/dimSimpleItem.directive.html
+++ b/src/scripts/store/dimSimpleItem.directive.html
@@ -1,10 +1,10 @@
 <div title="{{ vm.item.name }}" class="item">
   <div class="item-img"
        ng-class="{ complete: vm.item.complete }"
-       ng-style="vm.item.icon | bungieBackground">
-  <div ng-class="vm.item.dimInfo.tag | tagIcon"></div>
+       ng-style="vm.item.icon | bungieBackground"></div>
   <div class="item-element"
        ng-class="::vm.item.dmg"></div>
+  <div ng-class="vm.item.dimInfo.tag | tagIcon"></div>
   <div ng-if="vm.item.quality"
        class="item-stat item-quality"
        ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>

--- a/src/scripts/store/dimSimpleItem.directive.html
+++ b/src/scripts/store/dimSimpleItem.directive.html
@@ -1,7 +1,16 @@
 <div title="{{ vm.item.name }}" class="item">
-  <div class="item-img" ng-class="{ complete: vm.item.complete }" ng-style="vm.item.icon | bungieBackground">
+  <div class="item-img"
+       ng-class="{ complete: vm.item.complete }"
+       ng-style="vm.item.icon | bungieBackground">
   <div ng-class="vm.item.dimInfo.tag | tagIcon"></div>
-  <div class="item-element" ng-class="::vm.item.dmg"></div>
-  <div ng-if="vm.item.quality" class="item-stat item-quality" ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>
-  <div class="item-stat item-equipment" ng-if="vm.item.primStat.value || vm.item.maxStackSize > 1">{{ vm.item.primStat.value || vm.item.amount }}</div>
+  <div class="item-element"
+       ng-class="::vm.item.dmg"></div>
+  <div ng-if="vm.item.quality"
+       class="item-stat item-quality"
+       ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>
+  <div ng-if="vm.item.dtrRating"
+       class="item-stat item-review"
+       ng-style="vm.item.dtrRating | dtrRatingColor">{{ vm.item.dtrRating }}<i class='fa fa-star'></i></div>
+  <div class="item-stat item-equipment"
+       ng-if="vm.item.primStat.value || vm.item.maxStackSize > 1">{{ vm.item.primStat.value || vm.item.amount }}</div>
 </div>

--- a/src/scripts/store/dimStoreItem.directive.html
+++ b/src/scripts/store/dimStoreItem.directive.html
@@ -18,7 +18,7 @@
        ng-style="::vm.item.quality.min | qualityColor">{{ ::vm.item.quality.min }}%</div>
   <div ng-if="vm.item.dtrRating"
        class="item-stat item-review"
-       ng-style="vm.item.dtrRating | dtrRatingColor">{{ ::vm.item.dtrRating }}<i class='fa fa-star'></i></div>
+       ng-style="vm.item.dtrRating | dtrRatingColor">{{ vm.item.dtrRating }}<i class='fa fa-star'></i></div>
   <div class="item-element"
        ng-class="::vm.item.dmg"></div>
   <div ng-class="vm.item.dimInfo.tag | tagIcon"></div>
@@ -29,7 +29,7 @@
          height="44"
          width="44" />
   </div>
-  <div ng-class="vm.badgeClassNames"
+  <div ng-class="::vm.badgeClassNames"
        ng-if="::vm.showBadge"
        ng-bind="::vm.badgeCount"></div>
 </div>

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -653,6 +653,7 @@ img {
   position: relative;
   contain: strict;
   cursor: pointer;
+  box-sizing: border-box;
 }
 
 .search-hidden {
@@ -1512,10 +1513,8 @@ dim-compare {
   .item {
     float: right;
     padding: 0 4px 0 0;
+    margin-right: 4px;
     z-index: -10;
-    .item-stat {
-      display: none;
-    }
   }
   > div {
     padding-left: 4px;


### PR DESCRIPTION
1. Remove an extra watcher that slipped out.
2. Fix some stuff in the DTR service code - undefined objects, remove some extra work, etc.
3. Add ratings to the simple item so they show up in the comparison tool, infuse tool, etc. This fixes #1734.

@48klocs note that with this change, it's possible to show ratings for vendor items. We need to plumb through the code to call DTR with those items, but it'd be a cool feature to add on later.

<img width="749" alt="screen shot 2017-06-18 at 6 21 30 pm" src="https://user-images.githubusercontent.com/313208/27266125-fdd16b76-5452-11e7-90de-b7aa444926f7.png">
