### PR TITLE
Remove angular-moment

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -16,7 +16,6 @@ const nodeModulesDir = path.join(__dirname, '../node_modules');
 
 // https://github.com/dmachat/angular-webpack-cookbook/wiki/Optimizing-Development
 var preMinifiedDeps = [
-  'moment/min/moment.min.js',
   'underscore/underscore-min.js',
   'indexeddbshim/dist/indexeddbshim.min.js',
   'messageformat/messageformat.min.js',

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "angular-hotkeys": "^1.7.0",
     "angular-local-storage": "^0.5.0",
     "angular-messages": "^1.6.1",
-    "angular-moment": "^1.0.1",
     "angular-native-dragdrop": "^1.2.2",
     "angular-promise-tracker": "^2.2.2",
     "angular-translate": "^2.13.1",

--- a/src/scripts/dimApp.module.js
+++ b/src/scripts/dimApp.module.js
@@ -5,7 +5,6 @@ import DialogModule from 'ng-dialog';
 import DragAndDropModule from 'angular-native-dragdrop';
 import LocalStorageModule from 'angular-local-storage';
 import MessagesModule from 'angular-messages';
-import MomentModule from 'angular-moment';
 import RateLimiterModule from 'ng-http-rate-limiter';
 import SliderModule from 'angularjs-slider';
 import ToasterModule from 'angularjs-toaster';
@@ -37,7 +36,6 @@ export const DimAppModule = angular
     DragAndDropModule,
     LocalStorageModule,
     MessagesModule,
-    MomentModule,
     RateLimiterModule,
     ShellModule,
     SliderModule,


### PR DESCRIPTION
Looks like I missed this when removing the direct reference to moment.js. Thought I'd verified that it was gone completely, guess I hadn't. We don't use this, and it'll save a lot in the bundle.