### PR TITLE
Offer a WASM version of the SQLite library

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,7 +99,7 @@ module.exports = function(grunt) {
 
     precompress: {
       web: {
-        src: "dist/**/*.{js,html,css,json,map,ttf,eot,svg}"
+        src: "dist/**/*.{js,html,css,json,map,ttf,eot,svg,wasm}"
       }
     }
   });

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -61,7 +61,7 @@ module.exports = (env) => {
       rules: [
         {
           test: /\.js$/,
-          exclude: /node_modules/,
+          exclude: [/node_modules/, /sql\.js/],
           use: [
             'babel-loader'
           ]
@@ -96,7 +96,6 @@ module.exports = (env) => {
       ],
 
       noParse: [
-        /\/jquery\.slim\.min\.js$/,
         /\/sql\.js$/
       ]
     },
@@ -228,7 +227,7 @@ module.exports = (env) => {
     // so we exclude it from the regular minification
     // FYI, uglification runs on final chunks rather than individual modules
     config.plugins.push(new webpack.optimize.UglifyJsPlugin({
-      exclude: /-sqlLib-/, // ensure the sqlLib chunk doesnt get minifed
+      exclude: [/-sqlLib-/, /sql-wasm/], // ensure the sqlLib chunk doesnt get minifed
       compress: { warnings: false },
       output: { comments: false },
       sourceMap: true

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -769,6 +769,11 @@ AddEncoding br .br
     Header set Content-Encoding gzip
 </FilesMatch>
 
+<FilesMatch \.wasm\.gz$>
+    ForceType application/wasm
+    Header set Content-Encoding gzip
+</FilesMatch>
+
 # ----------------------------------------------------------------------
 # | Content transformation                                             |
 # ----------------------------------------------------------------------

--- a/src/scripts/services/dimDefinitions.factory.js
+++ b/src/scripts/services/dimDefinitions.factory.js
@@ -34,7 +34,7 @@ mod.factory('dimDefinitions', Definitions);
 function Definitions($q, dimManifestService) {
   return {
     getDefinitions: _.memoize(function getDefinitions() {
-      return dimManifestService.getManifest()
+      return $q.when(dimManifestService.getManifest()
         .then(function(db) {
           const defs = {};
 
@@ -64,7 +64,7 @@ function Definitions($q, dimManifestService) {
         .catch(function(e) {
           console.error(e);
           return $q.reject(e);
-        });
+        }));
     })
   };
 }

--- a/src/scripts/services/dimStoreService.factory.js
+++ b/src/scripts/services/dimStoreService.factory.js
@@ -643,7 +643,6 @@ function StoreService(
           _reloadPromise = null;
         }
         dimManifestService.isLoaded = true;
-        console.timeEnd('manifest');
       });
 
     _reloadPromise.activePlatform = activePlatform;

--- a/src/scripts/services/dimStoreService.factory.js
+++ b/src/scripts/services/dimStoreService.factory.js
@@ -643,6 +643,7 @@ function StoreService(
           _reloadPromise = null;
         }
         dimManifestService.isLoaded = true;
+        console.timeEnd('manifest');
       });
 
     _reloadPromise.activePlatform = activePlatform;


### PR DESCRIPTION
Most of the work here has been in our fork of sql.js - basically, I'm now generating a parallel wasm version of SQLite and attempting to load it instead. It's not easy to load right now, but it's not *too* bad - the only weird bit is you have to load a JS file that *then* loads the wasm, and it interacts with Webpack badly so I had to work around that. I haven't pushed the updated sql.js yet.

On my machine this isn't much faster to load, and it's not too much smaller in aggregate (about 30K after gzip). It should be easier for more constrained devices to parse, though, and should execute faster everywhere. There's decent WASM coverage already, and Safari gets it soon: http://caniuse.com/#feat=wasm

If the library takes too long to load, or fails for whatever reason, after 10 seconds we'll fall back to the old asm.js version. We'll also still use that whenever WebAssembly isn't available.