### PR TITLE
Scroll the changelog

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -174,9 +174,9 @@ module.exports = function(grunt) {
     'update_chrome_release_manifest',
     'compress:chrome',
     'log_release_version',
-    'webstore_upload:release',
     'precompress',
-    'rsync:prod'
+    'rsync:prod',
+    'webstore_upload:release'
   ]);
 
   grunt.registerTask('log_beta_version', function() {

--- a/src/scss/_toast.scss
+++ b/src/scss/_toast.scss
@@ -210,7 +210,9 @@ button.toast-close-button {
 
 .changelog-toaster {
   margin: 0;
-  padding: 0 2rem;
+  padding: 0 2em;
+  max-height: 50vh;
+  overflow: auto;
   li {
     margin-bottom: 2px;
   }


### PR DESCRIPTION
This makes it so the changelog toaster is never too tall - it'll scroll internally if it needs to.