### PR TITLE
Fix csp for google drive

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -476,7 +476,7 @@ AddDefaultCharset utf-8
 
 <IfModule mod_headers.c>
 
-    Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' https://apis.google.com https://www.google-analytics.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css; connect-src 'self' https://beta.destinyitemmanager.com https://www.bungie.net https://reviews-api.destinytracker.net; img-src 'self' https://www.bungie.net https://ssl.google-analytics.com https://csi.gstatic.com https://opencollective.com data:; font-src 'self' https://fonts.gstatic.com; child-src 'self' https://accounts.google.com; object-src 'self'"
+    Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' https://apis.google.com https://www.google-analytics.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css; connect-src 'self' https://beta.destinyitemmanager.com https://www.bungie.net https://reviews-api.destinytracker.net; img-src 'self' https://www.bungie.net https://ssl.google-analytics.com https://csi.gstatic.com https://opencollective.com data:; font-src 'self' https://fonts.gstatic.com; child-src 'self' https://accounts.google.com https://content.googleapis.com; object-src 'self'"
 
     # `mod_headers` cannot match based on the content-type, however,
     # the `Content-Security-Policy` response header should be send


### PR DESCRIPTION
Fix for

```
apis.google.com/_/scs/apps-static/_/js/k=oz.gapi.en.1V5wxOvLBv8.O/m=auth2,c…/d=1/ed=1/am=AQ/rs=AGLTcCMr7U2u-7yixNK9ADCsYrFnCGRJpQ/cb=gapi.loaded_0:290 

Refused to frame 
'https://content.googleapis.com/static/proxy.html?jsh=m%3B%2F_%2Fscs%2Fapps-…CGRJpQ#parent=https%3A%2F%2Fbeta.destinyitemmanager.com&rpctoken=952085088' 

because it violates the following Content Security Policy directive: "child-src 'self' https://accounts.google.com". 

Note that 'frame-src' was not explicitly set, so 'child-src' is used as a fallback.
```