### PR TITLE
Add a logout button

### DIFF
--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -318,6 +318,8 @@
    },
    "Settings": {
       "Settings": "Settings",
+      "LogOutDesc": "Log out of DIM, or switch Bungie.net accounts",
+      "LogOut": "Log out",
       "Language": "Language (reload DIM to take effect)",
       "HideUnfiltered": "Hide Unfiltered Items while Filtering",
       "HideUnfilteredHelp": "Items that do not match filter criteria will be hidden.",

--- a/src/scripts/dimApp.routes.js
+++ b/src/scripts/dimApp.routes.js
@@ -16,7 +16,10 @@ function routes($stateProvider, $urlRouterProvider) {
     name: 'login',
     parent: 'shell',
     url: '/login',
-    template: login
+    template: login,
+    params: {
+      reauth: false
+    }
   }];
 
   if ($featureFlags.materialsExchangeEnabled) {

--- a/src/scripts/login/dimLogin.controller.js
+++ b/src/scripts/login/dimLogin.controller.js
@@ -5,12 +5,22 @@ import { oauthClientId } from '../services/bungie-api-utils';
 angular.module('dimApp')
   .controller('dimLoginCtrl', dimLoginCtrl);
 
-function dimLoginCtrl(uuid2) {
+function dimLoginCtrl(uuid2, $stateParams) {
   const vm = this;
 
   localStorage.authorizationState = uuid2.newguid();
   const clientId = oauthClientId();
 
-  vm.authorizationURL = `https://www.bungie.net/en/OAuth/Authorize?client_id=${clientId}&response_type=code&state=${localStorage.authorizationState}`;
+  const reauth = $stateParams.reauth;
+  const loginUrl = `/en/OAuth/Authorize?client_id=${clientId}&response_type=code&state=${localStorage.authorizationState}`;
+
+  if (reauth) {
+    // TEMPORARY: fully log out from Bungie.net by redirecting to a special logout/relogin page
+    // Soon, Bungie.net will respect the reauth parameter and we won't have to do this
+    const logoutUrl = `https://www.bungie.net/en/User/SignOut?bru=${encodeURIComponent(loginUrl)}`;
+    vm.authorizationURL = logoutUrl;
+  } else {
+    vm.authorizationURL = `https://www.bungie.net${loginUrl}${reauth ? '&reauth=true' : ''}`;
+  }
 }
 

--- a/src/scripts/shell/dimSettingsCtrl.controller.js
+++ b/src/scripts/shell/dimSettingsCtrl.controller.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 
 angular.module('dimApp').controller('dimSettingsCtrl', SettingsController);
 
-function SettingsController(loadingTracker, dimSettingsService, $scope, SyncService, dimCsvService, dimStoreService, dimInfoService, $window, $timeout) {
+function SettingsController(loadingTracker, dimSettingsService, $scope, SyncService, dimCsvService, dimStoreService, dimInfoService, $window, $timeout, OAuthTokenService, $state) {
   var vm = this;
 
   vm.featureFlags = {
@@ -36,6 +36,12 @@ function SettingsController(loadingTracker, dimSettingsService, $scope, SyncServ
 
   // Edge doesn't support these
   vm.supportsCssVar = window.CSS && window.CSS.supports && window.CSS.supports('width', 'var(--fake-var)', 0);
+
+  vm.logout = function() {
+    OAuthTokenService.removeToken();
+    $scope.closeThisDialog();
+    $state.go('login', { reauth: true });
+  };
 
   vm.showSync = function() {
     return SyncService.drive();

--- a/src/views/settings.html
+++ b/src/views/settings.html
@@ -1,9 +1,16 @@
 <div ng-controller="dimSettingsCtrl as vm">
   <h1 translate="Settings"></h1>
   <div class="ngdialog-inner-content">
-<!--  <input ng-if='vm.showSync()' type='button' class='btn' ng-click='vm.driveSync()' value='Sync with Drive' />-->
   <form class="settings">
     <table>
+      <tr>
+        <td>
+          <label for="logout" translate="Settings.LogOutDesc"></label>
+        </td>
+        <td>
+          <button id="logout" ng-click="vm.logout()" translate="Settings.LogOut"></select>
+        </td>
+      </tr>
       <tr>
         <td>
           <label for="language" translate="Settings.Language"></label>


### PR DESCRIPTION
This adds a "Log out" button to the settings page, which will both kill our cached auth tokens, and present a login page that will force a re-auth with Bungie.net so you can switch accounts.

![screen shot 2017-06-25 at 3 20 40 pm](https://user-images.githubusercontent.com/313208/27520188-19413eec-59ba-11e7-81b7-8b9eabdde8a5.png)

I cut this off the v4.1.1 tag, and will release a v4.1.2 that includes this feature directly from this branch.

@delphiactual any chance we can get some quick translations?
