### PR TITLE
Fix reset button in settings

### DIFF
--- a/src/scripts/shell/dimSettingsCtrl.controller.js
+++ b/src/scripts/shell/dimSettingsCtrl.controller.js
@@ -58,6 +58,5 @@ function SettingsController(loadingTracker, dimSettingsService, $scope, dimCsvSe
 
   vm.resetItemSize = function() {
     vm.settings.itemSize = window.matchMedia('(max-width: 1025px)').matches ? 38 : 44;
-    vm.save();
   };
 }

--- a/src/views/settings.html
+++ b/src/views/settings.html
@@ -131,7 +131,7 @@
           <label for="itemSize" translate="Settings.SizeItem"></label>
         </td>
         <td>
-          <input ng-model="vm.settings.itemSize" type="range" min="38" max="66" ng-change="vm.save()" /> <button ng-click="vm.resetItemSize()" translate>Settings.ResetToDefault</button>
+          <input ng-model="vm.settings.itemSize" type="range" min="38" max="66" /> <button ng-click="vm.resetItemSize()" translate>Settings.ResetToDefault</button>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
vm.save() was throwing an error each time the button was pressed. It looks like that function was removed awhile ago.