### PR TITLE
Bungie Alerts component + toaster cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Add a new storage page (under the floppy disk icon) for managing your DIM data. Import and export to a file, and set up Google Drive storage to sync across machines (website only). You can import your data from the Chrome extension into the website from this page as well.
 * The settings page has been cleaned up and reworded.
 * Added missing Trials emblems and shaders to the is:trials search.
+* DIM should look more like an app if you add it to your home screen on Android.
+* DIM will show service alerts from Bungie.
 
 # 4.1.2
 

--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -10,6 +10,9 @@
       "Vault": "Vault",
       "Weapons": "Weapons"
    },
+   "BungieAlert": {
+     "Title": "A message from Bungie:"
+   },
    "BungieService": {
       "DevVersion": "Are you running a development version of DIM? You must register your chrome extension with bungie.net.",
       "Down": "Bungie.net is down.",

--- a/src/scripts/app.component.js
+++ b/src/scripts/app.component.js
@@ -1,6 +1,37 @@
 import template from './app.html';
 import './app.scss';
+import changelog from '../views/changelog-toaster-release.html';
 
 export const AppComponent = {
-  template: template
+  template: template,
+  controller: AppComponentCtrl
 };
+
+function AppComponentCtrl($window, $rootScope, dimInfoService, $translate) {
+  'ngInject';
+
+  this.$onInit = function() {
+    // Check for old Chrome versions
+    // TODO: do feature checks instead? Use Modernizr?
+    const chromeVersion = /Chrome\/(\d+)/.exec($window.navigator.userAgent);
+    if (chromeVersion && chromeVersion.length === 2 && parseInt(chromeVersion[1], 10) < 51) {
+      dimInfoService.show('old-chrome', {
+        title: $translate.instant('Help.UpgradeChrome'),
+        body: $translate.instant('Views.UpgradeChrome'),
+        type: 'error',
+        hideable: false
+      }, 0);
+    }
+
+    // Show the changelog
+    if ($featureFlags.changelogToaster) {
+      dimInfoService.show(`changelogv${$DIM_VERSION.replace(/\./gi, '')}`, {
+        title: $translate.instant('Help.Version', {
+          version: $DIM_VERSION,
+          beta: $DIM_FLAVOR === 'beta'
+        }),
+        body: changelog
+      });
+    }
+  };
+}

--- a/src/scripts/app.html
+++ b/src/scripts/app.html
@@ -1,3 +1,4 @@
 <div dim-activity-tracker>
   <ui-view></ui-view>
+  <toaster-container toaster-options="{ 'time-out': 10000, limit: 6 }"></toaster-container>
 </div>

--- a/src/scripts/bungie-api/bungie-api.module.js
+++ b/src/scripts/bungie-api/bungie-api.module.js
@@ -2,11 +2,13 @@ import angular from 'angular';
 
 import { BungieServiceHelper } from './bungie-service-helper.service';
 import { BungieUserApi } from './bungie-user-api.service';
+import { BungieCoreApi } from './bungie-core-api.service';
 import { Destiny1Api } from './destiny1-api.service';
 
 export default angular
   .module('BungieApi', [])
   .factory('BungieServiceHelper', BungieServiceHelper)
   .factory('BungieUserApi', BungieUserApi)
+  .factory('BungieCoreApi', BungieCoreApi)
   .factory('Destiny1Api', Destiny1Api)
   .name;

--- a/src/scripts/bungie-api/bungie-core-api.service.js
+++ b/src/scripts/bungie-api/bungie-core-api.service.js
@@ -1,0 +1,41 @@
+import { bungieApiQuery } from './bungie-api-utils';
+
+// http://destinydevs.github.io/BungieNetPlatform/docs/Enums
+const GlobalAlertLevelsToToastLevels = [
+  'info', // Unknown
+  'info', // Blue
+  'warn', // Yellow
+  'error' // Red
+];
+
+/**
+ * CoreService at https://destinydevs.github.io/BungieNetPlatform/docs/Endpoints
+ */
+export function BungieCoreApi($http) {
+  'ngInject';
+
+  return {
+    getGlobalAlerts
+  };
+
+  /**
+   * Global notifications about Bungie.net and Destiny status.
+   * @return {Array<{key, type, body, timestamp}>}
+   */
+  function getGlobalAlerts() {
+    return $http(bungieApiQuery(`/Platform/GlobalAlerts/`))
+      .then((response) => {
+        if (response && response.data && response.data.Response) {
+          return response.data.Response.map((alert) => {
+            return {
+              key: alert.AlertKey,
+              type: GlobalAlertLevelsToToastLevels[alert.AlertLevel],
+              body: alert.AlertHtml,
+              timestamp: alert.AlertTimestamp
+            };
+          });
+        }
+        return [];
+      });
+  }
+}

--- a/src/scripts/bungie-api/bungie-user-api.service.js
+++ b/src/scripts/bungie-api/bungie-user-api.service.js
@@ -1,5 +1,8 @@
 import { bungieApiQuery } from './bungie-api-utils';
 
+/**
+ * UserService at https://destinydevs.github.io/BungieNetPlatform/docs/Endpoints
+ */
 export function BungieUserApi(
   BungieServiceHelper,
   $http) {

--- a/src/scripts/bungie-api/destiny1-api.service.js
+++ b/src/scripts/bungie-api/destiny1-api.service.js
@@ -3,6 +3,8 @@ import { bungieApiQuery, bungieApiUpdate } from './bungie-api-utils';
 
 /**
  * APIs for interacting with Destiny 1 game data.
+ *
+ * DestinyService at https://destinydevs.github.io/BungieNetPlatform/docs/Endpoints
  */
 export function Destiny1Api(
   BungieServiceHelper,

--- a/src/scripts/dimApp.run.js
+++ b/src/scripts/dimApp.run.js
@@ -1,11 +1,8 @@
-import changelog from '../views/changelog-toaster-release.html';
 
-function run($window, $rootScope, $translate, SyncService, dimInfoService, $timeout) {
+function run($rootScope, SyncService) {
   'ngInject';
 
   SyncService.init();
-
-  const chromeVersion = /Chrome\/(\d+)/.exec($window.navigator.userAgent);
 
   // Variables for templates that webpack does not automatically correct.
   $rootScope.$DIM_VERSION = $DIM_VERSION;
@@ -13,32 +10,7 @@ function run($window, $rootScope, $translate, SyncService, dimInfoService, $time
   $rootScope.$DIM_CHANGELOG = $DIM_CHANGELOG;
   $rootScope.$DIM_BUILD_DATE = new Date($DIM_BUILD_DATE).toLocaleString();
 
-  const unregister = $rootScope.$on('dim-settings-loaded', () => {
-    if (chromeVersion && chromeVersion.length === 2 && parseInt(chromeVersion[1], 10) < 51) {
-      $timeout(() => {
-        dimInfoService.show('old-chrome', {
-          title: $translate.instant('Help.UpgradeChrome'),
-          body: $translate.instant('Views.UpgradeChrome'),
-          type: 'error',
-          hideable: false
-        }, 0);
-      }, 1000);
-    }
-
-    console.log(`DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.reddit.com/r/destinyitemmanager`);
-
-    if ($featureFlags.changelogToaster) {
-      dimInfoService.show(`changelogv${$DIM_VERSION.replace(/\./gi, '')}`, {
-        title: $translate.instant('Help.Version', {
-          version: $DIM_VERSION,
-          beta: $DIM_FLAVOR === 'beta'
-        }),
-        body: changelog
-      });
-    }
-
-    unregister();
-  });
+  console.log(`DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.reddit.com/r/destinyitemmanager`);
 }
 
 export default run;

--- a/src/scripts/shell/bungie-alerts.component.js
+++ b/src/scripts/shell/bungie-alerts.component.js
@@ -1,0 +1,40 @@
+import _ from 'underscore';
+
+export const BungieAlertsComponent = {
+  controller: BungieAlertsCtrl
+};
+
+/**
+ * A component that will check for Bungie alerts every 5 minutes and publish them as toasts.
+ * Each alert will only be shown once per session.
+ */
+function BungieAlertsCtrl(BungieCoreApi, $interval, toaster, $translate) {
+  'ngInject';
+
+  this.$onInit = function() {
+    // Poll every 5 minutes for new alerts
+    this.interval = $interval(pollBungieAlerts, 5 * 1000);
+    pollBungieAlerts();
+  };
+
+  this.$onDestroy = function() {
+    $interval.cancel(this.interval);
+  };
+
+  // Memoize so we only show each alert once per session
+  const showAlertToaster = _.memoize((alert) => {
+    toaster.pop({
+      type: alert.type,
+      title: $translate.instant('BungieAlert.Title'),
+      body: alert.body
+    });
+  }, (alert) => `${alert.key}-${alert.timestamp}`);
+
+  function pollBungieAlerts() {
+    BungieCoreApi.getGlobalAlerts()
+      .then((alerts) => {
+        alerts.forEach(showAlertToaster);
+      })
+      .catch((e) => { console.log(e) });
+  }
+}

--- a/src/scripts/shell/bungie-alerts.component.js
+++ b/src/scripts/shell/bungie-alerts.component.js
@@ -35,6 +35,6 @@ function BungieAlertsCtrl(BungieCoreApi, $interval, toaster, $translate) {
       .then((alerts) => {
         alerts.forEach(showAlertToaster);
       })
-      .catch((e) => { console.log(e) });
+      .catch((e) => { });
   }
 }

--- a/src/scripts/shell/bungie-alerts.component.js
+++ b/src/scripts/shell/bungie-alerts.component.js
@@ -23,10 +23,15 @@ function BungieAlertsCtrl(BungieCoreApi, $interval, toaster, $translate) {
 
   // Memoize so we only show each alert once per session
   const showAlertToaster = _.memoize((alert) => {
+    const bungieTwitterLink = '<a target="_blank" rel="noopener noreferrer" href="http://twitter.com/BungieHelp">@BungieHelp Twitter</a> <a target="_blank" rel="noopener noreferrer" href="http://twitter.com/BungieHelp"></a>';
+    const dimTwitterLink = '<a target="_blank" rel="noopener noreferrer" href="http://twitter.com/ThisIsDIM">@ThisIsDIM Twitter</a> <a target="_blank" rel="noopener noreferrer" href="http://twitter.com/ThisIsDIM"></a>';
+    const twitter = `<div>${$translate.instant('BungieService.Twitter')} ${bungieTwitterLink} | ${dimTwitterLink}</div>`;
+
     toaster.pop({
       type: alert.type,
       title: $translate.instant('BungieAlert.Title'),
-      body: alert.body
+      bodyOutputType: 'trustedHtml',
+      body: `<p>${alert.body}</p>${twitter}`
     });
   }, (alert) => `${alert.key}-${alert.timestamp}`);
 

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -24,7 +24,6 @@
     <span class="link" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>
   </div>
 </div>
-<toaster-container toaster-options="{ 'time-out': 10000, limit: 6 }"></toaster-container>
 <div id="content" class="content" ui-view></div>
 <div class="store-bounds"></div>
 <dim-manifest-progress></dim-manifest-progress>

--- a/src/scripts/shell/dimMaterialsExchangeCtrl.controller.js
+++ b/src/scripts/shell/dimMaterialsExchangeCtrl.controller.js
@@ -5,7 +5,7 @@ import '../materials-exchange/materials-exchange.scss';
 angular.module('dimApp').controller('dimMaterialsExchangeCtrl', MaterialsController);
 
 
-function MaterialsController(dimDefinitions, dimItemService, dimStoreService, $state) {
+function MaterialsController(dimDefinitions, dimStoreService, $state) {
   if (!$featureFlags.materialsExchangeEnabled) {
     $state.go('inventory');
     return;

--- a/src/scripts/shell/shell.module.js
+++ b/src/scripts/shell/shell.module.js
@@ -8,6 +8,7 @@ import shellComponent from './shell/shell.component';
 import contentComponent from './content/content.component';
 import backLinkComponent from './shell/backLink.component';
 import { CountdownComponent } from './countdown.component';
+import { BungieAlertsComponent } from './bungie-alerts.component';
 import { StarRatingComponent } from './star-rating/star-rating.component';
 
 export const ShellModule = angular
@@ -16,6 +17,7 @@ export const ShellModule = angular
   ])
   .directive('dimActivityTracker', ActivityTrackerDirective)
   .service('dimActivityTrackerService', ActivityTrackerService)
+  .component('bungieAlerts', BungieAlertsComponent)
   .component('dimPlatformChoice', PlatformChoiceComponent)
   .component('dimShell', shellComponent)
   .component('content', contentComponent)

--- a/src/scripts/shell/shell/shell.html
+++ b/src/scripts/shell/shell/shell.html
@@ -6,4 +6,5 @@
   'new-item-animated': $ctrl.settings.showNewAnimation
 }">
   <ui-view></ui-view>
+  <bungie-alerts></bungie-alerts>
 </div>


### PR DESCRIPTION
This uses the Bungie GetGlobalAlerts API to pull global Bungie.net messages and surface them through our toaster. This should let folks know about maintenance like we had recently (if Bungie publishes an alert). Alerts are only shown once per session, and are polled every 5 minutes. Note that the example suggests this will include notifications like "There will be maintenance tomorrow" - I'm not sure if we want to show that, or filter out the "info" level alerts. I tested with the example data as there are currently no alerts going.

![screen shot 2017-06-27 at 9 22 39 pm](https://user-images.githubusercontent.com/313208/27620822-2a89c570-5b81-11e7-8ac7-8b908e034c7f.png)

As part of this work I fixed how we do toasters, moving the toaster-container up into the app component and putting our chrome-version and changelog toasters into the app component instead of the app module run function. This solves #1800.