### PR TITLE
Add a simple service worker using workbox

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const WorkboxPlugin = require('workbox-webpack-plugin');
 // const Visualizer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const NotifyPlugin = require('notify-webpack-plugin');
@@ -202,6 +203,19 @@ module.exports = (env) => {
         '$featureFlags.debugSync': JSON.stringify(false),
         // Use a WebAssembly version of SQLite, if possible
         '$featureFlags.wasm': JSON.stringify(false)
+      }),
+
+      // Generate a service worker
+      new WorkboxPlugin({
+        maximumFileSizeToCacheInBytes: 5000000,
+        globPatterns: ['**/*.{html,js,css,woff2}', 'static/*.png'],
+        globIgnores: [
+          'authReturn*',
+          'extension-scripts/*',
+          'return.html',
+        ],
+        // swSrc: './src/sw.js',
+        swDest: './dist/sw.js'
       }),
 
       // Enable if you want to debug the size of the chunks

--- a/package-lock.json
+++ b/package-lock.json
@@ -8748,6 +8748,12 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true
     },
+    "universalify": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
+      "integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g=",
+      "dev": true
+    },
     "unpipe": {
       "version": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
@@ -9145,6 +9151,50 @@
     "wordwrap": {
       "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "workbox-build": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-1.0.1.tgz",
+      "integrity": "sha1-uv2rNTvdXEysQ2HGBd/EaKL0bv4=",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
+          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "dev": true
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true
+        }
+      }
+    },
+    "workbox-sw": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-1.0.1.tgz",
+      "integrity": "sha1-spFpix1Y8Fq+zGy5GflFyamvDx8=",
+      "dev": true
+    },
+    "workbox-webpack-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-1.0.1.tgz",
+      "integrity": "sha1-CKirumG9dZQ/qUx3IcX5UHttKVc=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "url-loader": "^0.5.7",
     "webpack": "^2.2.0-rc.0",
     "webpack-bundle-analyzer": "^2.8.2",
-    "webpack-dev-server": "^2.2.0-rc.0"
+    "webpack-dev-server": "^2.2.0-rc.0",
+    "workbox-webpack-plugin": "^1.0.1"
   },
   "dependencies": {
     "@uirouter/angularjs": "^1.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -81,3 +81,10 @@ if ($featureFlags.materialsExchangeEnabled) {
 require('./scripts/login/dimLogin.controller');
 
 require('./scss/main.scss');
+
+if (navigator.serviceWorker) {
+  navigator.serviceWorker.register('/sw.js')
+    .catch((err) => {
+      console.error('Unable to register service worker.', err);
+    });
+}


### PR DESCRIPTION
This adds a service worker using Google Chrome's Workbox library (previously sw-precache) and its webpack plugin. This will precache our assets such that subsequent visits to the page are snappy.

Note that, when running from localhost, the service worker will not install, unless you jump through some hoops and launch Chrome with some special flags. However, for most development, aside from seeing some errors in the logs not having a service worker won't affect anything.

I spent a ton of time trying to augment this into a full offline mode (view your inventory when not connected) but I hit some walls where not all the Destiny API responses were being cached, and at any rate, it required a ton of cache storage to store all the item images. I also would have to do a lot of work to make the auth refresh not explode when offline. I've decided it's probably best to ship this (which will among other things cause Chrome on Android to start advertising an install button) and try for an opt-in offline mode later.