### PR TITLE
Correctly bind trackerErrorHandler methods in promise handlers

### DIFF
--- a/src/scripts/destinyTrackerApi/bulkFetcher.js
+++ b/src/scripts/destinyTrackerApi/bulkFetcher.js
@@ -33,7 +33,7 @@ class BulkFetcher {
     const promise = this.$q
               .when(this._getBulkWeaponDataEndpointPost(weaponList))
               .then(this.$http)
-              .then(this._trackerErrorHandler.handleErrors, this._trackerErrorHandler.handleErrors)
+              .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
               .then((response) => response.data);
 
     this._loadingTracker.addPromise(promise);

--- a/src/scripts/destinyTrackerApi/reviewSubmitter.js
+++ b/src/scripts/destinyTrackerApi/reviewSubmitter.js
@@ -55,7 +55,7 @@ class ReviewSubmitter {
     const promise = this.$q
               .when(this._submitItemReviewCall(rating))
               .then(this.$http)
-              .then(this._trackerErrorHandler.handleSubmitErrors, this._trackerErrorHandler.handleSubmitErrors);
+              .then(this._trackerErrorHandler.handleSubmitErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleSubmitErrors.bind(this._trackerErrorHandler));
 
     this._loadingTracker.addPromise(promise);
 

--- a/src/scripts/destinyTrackerApi/reviewsFetcher.js
+++ b/src/scripts/destinyTrackerApi/reviewsFetcher.js
@@ -32,7 +32,7 @@ class ReviewsFetcher {
     const promise = this.$q
               .when(this._getItemReviewsCall(postWeapon))
               .then(this.$http)
-              .then(this._trackerErrorHandler.handleErrors, this._trackerErrorHandler.handleErrors)
+              .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
               .then((response) => { return response.data; });
 
     this._loadingTracker.addPromise(promise);


### PR DESCRIPTION
This binds the `TrackerErrorHandler` methods to their object so they can be passed into promise handlers. It should fix #1798.

/cc @48klocs 