### PR TITLE
Move materials-exchange into its own module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,10 +74,6 @@ require('./scripts/debug/dimDebugItem.controller');
 if ($DIM_FLAVOR === 'dev') {
   require('./scripts/developer/dimDeveloper.controller');
 }
-if ($featureFlags.materialsExchangeEnabled) {
-  require('./scripts/shell/dimMaterialsExchangeCtrl.controller');
-  require('./scripts/materials-exchange/dimCollapsible.directive');
-}
 require('./scripts/login/dimLogin.controller');
 
 require('./scss/main.scss');

--- a/src/scripts/dimApp.module.js
+++ b/src/scripts/dimApp.module.js
@@ -29,30 +29,37 @@ import run from './dimApp.run';
 import state from './state';
 import loadingTracker from './services/dimLoadingTracker.factory';
 
+const dependencies = [
+  AriaModule,
+  DialogModule,
+  DragAndDropModule,
+  MessagesModule,
+  RateLimiterModule,
+  ShellModule,
+  SliderModule,
+  ToasterModule,
+  TranslateModule,
+  TranslateMessageFormatModule,
+  UIRouterModule,
+  bungieApiModule,
+  inventoryModule,
+  recordBooksModule,
+  vendorsModule,
+  itemReviewModule,
+  loadoutBuilderModule,
+  oauthModule,
+  storageModule,
+  'ajoslin.promise-tracker',
+  'cfp.hotkeys'
+];
+
+if ($featureFlags.materialsExchangeEnabled) {
+  const materialsExchangeModule = require('./materials-exchange/materials-exchange.module').default;
+  dependencies.push(materialsExchangeModule);
+}
+
 export const DimAppModule = angular
-  .module('dimApp', [
-    AriaModule,
-    DialogModule,
-    DragAndDropModule,
-    MessagesModule,
-    RateLimiterModule,
-    ShellModule,
-    SliderModule,
-    ToasterModule,
-    TranslateModule,
-    TranslateMessageFormatModule,
-    UIRouterModule,
-    bungieApiModule,
-    inventoryModule,
-    recordBooksModule,
-    vendorsModule,
-    itemReviewModule,
-    loadoutBuilderModule,
-    oauthModule,
-    storageModule,
-    'ajoslin.promise-tracker',
-    'cfp.hotkeys'
-  ])
+  .module('dimApp', dependencies)
   .config(config)
   .config(routes)
   .run(run)

--- a/src/scripts/dimApp.routes.js
+++ b/src/scripts/dimApp.routes.js
@@ -22,15 +22,6 @@ function routes($stateProvider, $urlRouterProvider) {
     }
   }];
 
-  if ($featureFlags.materialsExchangeEnabled) {
-    states.push({
-      name: 'materials-exchange',
-      parent: 'content',
-      url: '/materials-exchange',
-      template: require('app/views/mats-exchange.html')
-    });
-  }
-
   if ($DIM_FLAVOR === 'dev') {
     states.push({
       name: 'developer',

--- a/src/scripts/materials-exchange/dimCollapsible.directive.js
+++ b/src/scripts/materials-exchange/dimCollapsible.directive.js
@@ -1,9 +1,6 @@
-import angular from 'angular';
 import template from './dimCollapsible.directive.html';
 
-angular.module('dimApp').directive('dimCollapsibleSection', Section);
-
-function Section() {
+export function Section() {
   return {
     transclude: true,
     scope: {

--- a/src/scripts/materials-exchange/materials-exchange.component.js
+++ b/src/scripts/materials-exchange/materials-exchange.component.js
@@ -1,11 +1,17 @@
 import angular from 'angular';
 import _ from 'underscore';
-import '../materials-exchange/materials-exchange.scss';
+import template from './materials-exchange.html';
+import './materials-exchange.scss';
 
-angular.module('dimApp').controller('dimMaterialsExchangeCtrl', MaterialsController);
-
+export const MaterialsExchangeComponent = {
+  template: template,
+  controller: MaterialsController,
+  controllerAs: 'vm'
+};
 
 function MaterialsController(dimDefinitions, dimStoreService, $state) {
+  'ngInject';
+
   if (!$featureFlags.materialsExchangeEnabled) {
     $state.go('inventory');
     return;

--- a/src/scripts/materials-exchange/materials-exchange.html
+++ b/src/scripts/materials-exchange/materials-exchange.html
@@ -1,4 +1,4 @@
-<div ng-controller="dimMaterialsExchangeCtrl as vm" class="materials-exchange">
+<div class="materials-exchange">
    <back-link></back-link>
    <div class="stats-panel">
       <div class="section">

--- a/src/scripts/materials-exchange/materials-exchange.module.js
+++ b/src/scripts/materials-exchange/materials-exchange.module.js
@@ -1,0 +1,20 @@
+import angular from 'angular';
+
+import { Section } from './dimCollapsible.directive';
+import { MaterialsExchangeComponent } from './materials-exchange.component';
+
+export default angular
+  .module('MaterialsExchangeModule', [])
+  .component('materialsExchange', MaterialsExchangeComponent)
+  .directive('dimCollapsibleSection', Section)
+  .config(($stateProvider) => {
+    'ngInject';
+
+    $stateProvider.state({
+      name: 'materials-exchange',
+      parent: 'content',
+      url: '/materials-exchange',
+      component: 'materialsExchange'
+    });
+  })
+  .name;


### PR DESCRIPTION
I'd still vote to just delete all this code, but this at least moves it into a module that'll continue to compile out entirely when the feature flag is off.