### PR TITLE
If they've loaded the vendors, don't drop visible ratings.

### DIFF
--- a/src/scripts/vendors/vendor.service.js
+++ b/src/scripts/vendors/vendor.service.js
@@ -481,8 +481,6 @@ function VendorService(
 
   function _fulfillRatingsRequest() {
     if ((service.vendorsLoaded) && (_ratingsRequested)) {
-      _ratingsRequested = false;
-
       dimDestinyTrackerService.updateVendorRankings(service.vendors);
     }
   }


### PR DESCRIPTION
Foreground or background refreshes (without leaving the vendors tab) don't re-mark the user as being on it, so just assume that they've stayed on the tab when a refresh happens.

The logic was just in there to prevent hammering the API if the user didn't look at vendors.