### PR TITLE
Handle storage errors better and don't hang on classified data.

### DIFF
--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -99,7 +99,9 @@
       "NeverShow": "Never show me this again.",
       "UpgradeChrome": "Please Upgrade Chrome",
       "Version": "{beta, select, true{Beta has been updated to v{version}} other{DIM v{version} Released}}",
-      "Xur": "Xûr is Here"
+      "Xur": "Xûr is Here",
+      "NoStorage": "DIM can't store data",
+      "NoStorageMessage": "DIM can't store data in your browser. This can be caused by browsing in private or incognito mode, or when you have low disk space. DIM cannot continue."
    },
    "Hotkey": {
       "StartSearch": "Start a search",

--- a/src/scripts/app.component.js
+++ b/src/scripts/app.component.js
@@ -7,7 +7,7 @@ export const AppComponent = {
   controller: AppComponentCtrl
 };
 
-function AppComponentCtrl($window, $rootScope, dimInfoService, dimSettingsService, $translate) {
+function AppComponentCtrl($window, $rootScope, dimInfoService, dimSettingsService, $translate, toaster, $timeout) {
   'ngInject';
 
   this.$onInit = function() {
@@ -19,22 +19,40 @@ function AppComponentCtrl($window, $rootScope, dimInfoService, dimSettingsServic
     // TODO: do feature checks instead? Use Modernizr?
     const chromeVersion = /Chrome\/(\d+)/.exec($window.navigator.userAgent);
     if (chromeVersion && chromeVersion.length === 2 && parseInt(chromeVersion[1], 10) < 51) {
-      dimInfoService.show('old-chrome', {
-        title: $translate.instant('Help.UpgradeChrome'),
-        body: $translate.instant('Views.UpgradeChrome'),
-        type: 'error',
-        hideable: false
-      }, 0);
+      $timeout(() => {
+        dimInfoService.show('old-chrome', {
+          title: $translate.instant('Help.UpgradeChrome'),
+          body: $translate.instant('Views.UpgradeChrome'),
+          type: 'error',
+          hideable: false
+        }, 0);
+      });
     }
 
     // Show the changelog
     if ($featureFlags.changelogToaster) {
-      dimInfoService.show(`changelogv${$DIM_VERSION.replace(/\./gi, '')}`, {
-        title: $translate.instant('Help.Version', {
-          version: $DIM_VERSION,
-          beta: $DIM_FLAVOR === 'beta'
-        }),
-        body: changelog
+      $timeout(() => {
+        dimInfoService.show(`changelogv${$DIM_VERSION.replace(/\./gi, '')}`, {
+          title: $translate.instant('Help.Version', {
+            version: $DIM_VERSION,
+            beta: $DIM_FLAVOR === 'beta'
+          }),
+          body: changelog
+        });
+      });
+    }
+
+    try {
+      localStorage.setItem('test', 'true');
+    } catch (e) {
+      console.log('storage test', e);
+      $timeout(() => {
+        dimInfoService.show('no-storage', {
+          title: $translate.instant('Help.NoStorage'),
+          body: $translate.instant('Help.NoStorageMessage'),
+          type: 'error',
+          hideable: false
+        }, 0);
       });
     }
   };

--- a/src/scripts/services/dimManifestService.factory.js
+++ b/src/scripts/services/dimManifestService.factory.js
@@ -202,7 +202,14 @@ function ManifestService($q, Destiny1Api, $http, toaster, dimSettingsService, $t
             console.log(`Sucessfully stored ${typedArray.length} byte manifest file.`);
             localStorage.setItem('manifest-version', version);
           })
-          .catch((e) => console.error('Error saving manifest file', e));
+          .catch((e) => {
+            console.error('Error saving manifest file', e);
+            toaster.pop({
+              title: $translate.instant('Help.NoStorage'),
+              body: $translate.instant('Help.NoStorageMessage'),
+              type: 'error'
+            }, 0);
+          });
 
         $rootScope.$broadcast('dim-new-manifest');
         return typedArray;

--- a/src/scripts/services/store/classified-data.service.js
+++ b/src/scripts/services/store/classified-data.service.js
@@ -39,7 +39,9 @@ export function ClassifiedDataService($http, dimSettingsService) {
             if (response && response.status === 200) {
               const remoteData = response.data;
               remoteData.time = Date.now();
-              return idbKeyval.set('classified-data', remoteData).then(() => remoteData);
+              // Don't wait for the set - for some reason this was hanging
+              idbKeyval.set('classified-data', remoteData);
+              return remoteData;
             }
 
             console.error(`Couldn't load classified info from ${url}`);


### PR DESCRIPTION
I tortured my system until it had almost no storage left, and found that IndexedDB hangs on one and only one point - when trying to store the classified data. If I return without waiting for this, we still store classified data, but we don't hang.

I also added some tests and alerts that should notify when users are out of quota or in Safari's bugged incognito mode. Note that even when my system was basically nonfunctional (<100MB left) I couldn't get Chrome to throw a quota exception and it happily continued to store the manifest and other items.