### PR TITLE
Improve scroll performance by applying backface-visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Scrolling should be smoother overall.
+
 # 4.2.2
 
 * Fix DIM being invisible on Firefox

--- a/src/scripts/farming/farming.scss
+++ b/src/scripts/farming/farming.scss
@@ -2,6 +2,7 @@
 
 #item-farming {
   position: fixed;
+  backface-visibility: hidden;
   bottom: 6rem;
   background-color: rgba(0, 0, 0, 0.9);
   left: calc(50% - 21.5rem);

--- a/src/scripts/shell/dimManifestProgress.directive.js
+++ b/src/scripts/shell/dimManifestProgress.directive.js
@@ -1,5 +1,7 @@
 import angular from 'angular';
 import template from './dimManifestProgress.directive.html';
+import './dimManifestProgress.scss';
+
 /**
  * A dialog that shows the progress of loading the manifest.
  */

--- a/src/scripts/shell/dimManifestProgress.scss
+++ b/src/scripts/shell/dimManifestProgress.scss
@@ -1,0 +1,45 @@
+dim-manifest-progress {
+  position: fixed;
+  backface-visibility: hidden;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  pointer-events: none;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .manifest-progress {
+    width: 24rem;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    font-size: 1rem;
+    padding: 1.5rem 1.5rem;
+    background-color: #222;
+    box-shadow: 1px 1px 10px rgba(0, 0, 0, .5);
+    white-space: pre-wrap;
+
+    i {
+      font-size: 2rem;
+      margin-bottom: .5rem;
+    }
+
+    &.ng-animate {
+      transition: opacity 0.3s ease-out;
+    }
+
+    &.ng-enter, &.ng-leave.ng-leave-active {
+      opacity: 0;
+    }
+
+    &.ng-leave, &.ng-enter.ng-enter-active {
+      opacity: 1;
+    }
+  }
+}

--- a/src/scripts/vendors/vendors.scss
+++ b/src/scripts/vendors/vendors.scss
@@ -165,6 +165,7 @@
   z-index: 1;
   background-color: rgba(40,40,40,0.5);
   margin-top: 2px;
+  backface-visibility: hidden;
 }
 
 .ngdialog.vendor-move-popup {

--- a/src/scss/_ngdialog.scss
+++ b/src/scss/_ngdialog.scss
@@ -73,6 +73,7 @@
   right: 0;
   bottom: 0;
   left: 0;
+  backface-visibility: hidden;
 }
 
 .ngdialog-content {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -406,6 +406,7 @@ img {
 #drag-help {
   font-size: 1.5em;
   position: fixed;
+  backface-visibility: hidden;
   bottom: 2em;
   transition: transform .5s, opacity .5s, background-color .1s;
   background-color: rgba(0, 0, 0, 0.8);
@@ -1111,6 +1112,7 @@ rzslider, .rzslider {
 .objective-text {
   z-index: 2;
   margin-right: 4px;
+  backface-visibility: hidden;
 }
 
 .objective-boolean {
@@ -1177,6 +1179,7 @@ g {
 
 .store-bounds {
   position: fixed;
+  backface-visibility: hidden;
   pointer-events: none;
   bottom: -800px;
   left: 0;
@@ -1238,6 +1241,7 @@ g {
 
 .store-header {
   position: fixed;
+  backface-visibility: hidden;
   top: 53px;
   z-index: 10;
 }
@@ -1258,6 +1262,7 @@ g {
   left: 0;
   right: 0;
   position: fixed;
+  backface-visibility: hidden;
   z-index: 3;
   bottom: 0;
   background: #434444;
@@ -1458,6 +1463,7 @@ h2, h3, h4 {
   background-color: #434444;
   height: 82px;
   position: fixed;
+  backface-visibility: hidden;
   z-index: 4;
 
   .something-is-sticky & {
@@ -1518,6 +1524,7 @@ h2, h3, h4 {
   .show-new-items & {
     display: block;
     position: fixed;
+    backface-visibility: hidden;
     bottom: 2rem;
     right: 2rem;
 
@@ -1540,54 +1547,10 @@ h2, h3, h4 {
   }
 }
 
-dim-manifest-progress {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-
-  pointer-events: none;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  .manifest-progress {
-    width: 24rem;
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    justify-content: center;
-    text-align: center;
-    font-size: 1rem;
-    padding: 1.5rem 1.5rem;
-    background-color: #222;
-    box-shadow: 1px 1px 10px rgba(0, 0, 0, .5);
-    white-space: pre-wrap;
-
-    i {
-      font-size: 2rem;
-      margin-bottom: .5rem;
-    }
-
-    &.ng-animate {
-      transition: opacity 0.3s ease-out;
-    }
-
-    &.ng-enter, &.ng-leave.ng-leave-active {
-      opacity: 0;
-    }
-
-    &.ng-leave, &.ng-enter.ng-enter-active {
-      opacity: 1;
-    }
-  }
-}
-
 .loadout {
   &.random {
     position: fixed;
+    backface-visibility: hidden;
     bottom: 0;
     right: 0;
     padding: .5rem;

--- a/src/scss/_toast.scss
+++ b/src/scss/_toast.scss
@@ -97,6 +97,7 @@ button.toast-close-button {
 
 #toast-container {
   position: fixed;
+  backface-visibility: hidden;
   z-index: 999999;
   top: 60px;
 


### PR DESCRIPTION
I used the paint debugger in Chrome to find that we were repainting everything all the time. By applying `backface-visibility: hidden` liberally, I'm able to avoid most paints. Scrolling is noticeably smoother.