### PR TITLE
Fix some Firefox rendering bugs

### DIFF
--- a/src/scripts/loadout/dimLoadoutPopup.directive.html
+++ b/src/scripts/loadout/dimLoadoutPopup.directive.html
@@ -30,9 +30,9 @@
 
     <li class="loadout-set" ng-if="!vm.store.isVault">
       <span ng-click="vm.maxLightLoadout($event)">
+        <span class="light" ng-bind="::vm.maxLightValue"></span>
         <i class="fa fa-star"></i>
         <span translate="Loadouts.MaximizeLight"></span>
-        <span class="light" ng-bind="::vm.maxLightValue"></span>
       </span>
     </li>
 

--- a/src/scss/_move-popup.scss
+++ b/src/scss/_move-popup.scss
@@ -5,7 +5,7 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 .move-popup-dialog {
-  height: fit-content;
+  height: 0;
 }
 
 .move-popup-tabs {


### PR DESCRIPTION
The move popup and "maximize light" button both looked weird on Firefox. This appears to fix them.