### PR TITLE
Replace tagging hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix DIM being invisible on Firefox
 * Fix a case where DIM would never finish loading.
+* Put back the accidentally removed hotkeys for setting tags on items.
 
 # 4.2.1
 

--- a/src/scripts/shell/content/content.controller.js
+++ b/src/scripts/shell/content/content.controller.js
@@ -66,7 +66,7 @@ export default class ContentController {
       }
     });
 
-    if (vm.featureFlags.tagsEnabled) {
+    if ($featureFlags.tagsEnabled) {
       dimSettingsService.itemTags.forEach((tag) => {
         if (tag.hotkey) {
           hotkeys.add({


### PR DESCRIPTION
These got messed up when we moved to static feature flags.