### PR TITLE
Make ratings service use methods instead of events

### DIFF
--- a/src/scripts/destinyTrackerApi/bulkFetcher.js
+++ b/src/scripts/destinyTrackerApi/bulkFetcher.js
@@ -32,10 +32,10 @@ class BulkFetcher {
     }
 
     const promise = this.$q
-              .when(this._getBulkWeaponDataEndpointPost(weaponList))
-              .then(this.$http)
-              .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
-              .then((response) => response.data);
+      .when(this._getBulkWeaponDataEndpointPost(weaponList))
+      .then(this.$http)
+      .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
+      .then((response) => response.data);
 
     this._loadingTracker.addPromise(promise);
 
@@ -50,24 +50,23 @@ class BulkFetcher {
    * @memberof BulkFetcher
    */
   bulkFetch(storesContainer) {
-    if (storesContainer.stores) {
-      const stores = storesContainer.stores;
+    const stores = _.values(storesContainer);
 
-      this._getBulkFetchPromise(stores)
-        .then((bulkRankings) => this.attachRankings(bulkRankings,
-                                                    stores));
-    }
-    else if (storesContainer) {
-      const vendors = _.values(storesContainer);
+    this._getBulkFetchPromise(stores)
+      .then((bulkRankings) => this.attachRankings(bulkRankings,
+        stores));
+  }
 
-      this._getBulkFetchPromise(vendors)
-        .then((bulkRankings) => this.attachVendorRankings(bulkRankings,
-                                                          vendors));
-    }
+  bulkFetchVendorItems(vendorContainer) {
+    const vendors = _.values(vendorContainer);
+
+    this._getBulkFetchPromise(vendors)
+      .then((bulkRankings) => this.attachVendorRankings(bulkRankings,
+        vendors));
   }
 
   attachRankings(bulkRankings,
-                 stores) {
+    stores) {
     if (!bulkRankings && !stores) {
       return;
     }
@@ -98,7 +97,7 @@ class BulkFetcher {
   }
 
   attachVendorRankings(bulkRankings,
-                       vendors) {
+    vendors) {
     if (!bulkRankings && !vendors) {
       return;
     }

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -26,7 +26,7 @@ function ItemReviewController($rootScope, dimSettingsService, dimDestinyTrackerS
   };
 
   vm.submitReview = function() {
-    $rootScope.$broadcast('review-submitted', vm.item);
+    dimDestinyTrackerService.submitReview(vm.item);
     vm.expandReview = false;
     vm.submitted = true;
   };

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -1,7 +1,7 @@
 import template from './item-review.html';
 import './item-review.scss';
 
-function ItemReviewController($rootScope, dimSettingsService, dimDestinyTrackerService, $scope) {
+function ItemReviewController(dimSettingsService, dimDestinyTrackerService, $scope) {
   'ngInject';
 
   const vm = this;

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -16,10 +16,10 @@ function ItemReviewController($rootScope, dimSettingsService, dimDestinyTrackerS
     pros: ['fast', 'lol'],
     cons: ['ok']
   };
-//  vm.item.writtenReviews.forEach((review) => {
-//    aggregate.pros.push(review.pros);
-//    aggregate.cons.push(review.cons);
-//  });
+  //  vm.item.writtenReviews.forEach((review) => {
+  //    aggregate.pros.push(review.pros);
+  //    aggregate.cons.push(review.cons);
+  //  });
 
   vm.toggleEdit = function() {
     vm.expandReview = !vm.expandReview;
@@ -43,7 +43,7 @@ function ItemReviewController($rootScope, dimSettingsService, dimDestinyTrackerS
     const userReview = vm.toUserReview(item);
 
     dimDestinyTrackerService.updateCachedUserRankings(item,
-                                                      userReview);
+      userReview);
   };
 
   vm.toUserReview = function(item) {
@@ -77,7 +77,7 @@ function ItemReviewController($rootScope, dimSettingsService, dimDestinyTrackerS
     vm.canReview = dimSettingsService.allowIdPostToDtr;
 
     if (vm.canReview) {
-      $rootScope.$broadcast('item-clicked', vm.item);
+      dimDestinyTrackerService.getItemReviews(vm.item);
     }
   };
 }

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -6,7 +6,8 @@ function ItemReviewController(dimSettingsService, dimDestinyTrackerService, $sco
 
   const vm = this;
   vm.canReview = dimSettingsService.allowIdPostToDtr;
-  vm.canCreateReview = (vm.canReview && vm.item.instanceId);
+
+  vm.canCreateReview = (vm.canReview && vm.item.owner);
   vm.submitted = false;
   vm.hasUserReview = vm.item.userRating;
   vm.expandReview = vm.hasUserReview;

--- a/src/scripts/itemDiscuss/dimItemDiscuss.directive.js
+++ b/src/scripts/itemDiscuss/dimItemDiscuss.directive.js
@@ -32,9 +32,8 @@ function ItemDiscussCtrl($scope, $rootScope, toaster, dimItemDiscussService, dim
 
   vm.submitReview = function submitReview() {
     const item = vm.item;
-    const userReview = vm.toUserReview(item);
 
-    $rootScope.$broadcast('review-submitted', item, userReview);
+    dimDestinyTrackerService.submitReview(item);
 
     return false;
   };

--- a/src/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/src/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -85,7 +85,7 @@ function MoveItemPropertiesCtrl($sce, $q, dimStoreService, dimItemService, dimSe
     const userReview = vm.toUserReview(item);
 
     dimDestinyTrackerService.updateCachedUserRankings(item,
-                                                      userReview);
+      userReview);
   };
 
   vm.toUserReview = function(item) {
@@ -107,9 +107,7 @@ function MoveItemPropertiesCtrl($sce, $q, dimStoreService, dimItemService, dimSe
   vm.submitReview = function() {
     const item = vm.item;
 
-    const userReview = vm.toUserReview(item);
-
-    $rootScope.$broadcast('review-submitted', item, userReview);
+    dimDestinyTrackerService.submitReview(item);
 
     return false;
   };

--- a/src/scripts/services/dimDestinyTrackerService.factory.js
+++ b/src/scripts/services/dimDestinyTrackerService.factory.js
@@ -9,23 +9,17 @@ angular.module('dimApp')
   .factory('dimDestinyTrackerService', DestinyTrackerService);
 
 function DestinyTrackerService($q,
-                               $http,
-                               $rootScope,
-                               dimPlatformService,
-                               dimSettingsService,
-                               $translate,
-                               loadingTracker) {
+  $http,
+  $rootScope,
+  dimPlatformService,
+  dimSettingsService,
+  $translate,
+  loadingTracker) {
   const _reviewDataCache = new ReviewDataCache();
   const _trackerErrorHandler = new TrackerErrorHandler($q, $translate);
   const _bulkFetcher = new BulkFetcher($q, $http, _trackerErrorHandler, loadingTracker, _reviewDataCache);
   const _reviewsFetcher = new ReviewsFetcher($q, $http, _trackerErrorHandler, loadingTracker, _reviewDataCache);
   const _reviewSubmitter = new ReviewSubmitter($q, $http, dimPlatformService, _trackerErrorHandler, loadingTracker, _reviewDataCache);
-
-  $rootScope.$on('item-clicked', (event, item) => {
-    if (dimSettingsService.allowIdPostToDtr) {
-      _reviewsFetcher.getItemReviews(item);
-    }
-  });
 
   $rootScope.$on('dim-stores-updated', (event, stores) => {
     if (dimSettingsService.showReviews) {
@@ -42,16 +36,21 @@ function DestinyTrackerService($q,
   return {
     reattachScoresFromCache: function(stores) {
       _bulkFetcher.attachRankings(null,
-                                  stores);
+        stores);
     },
     updateCachedUserRankings: function(item,
-                                       userReview) {
+      userReview) {
       _reviewDataCache.addUserReviewData(item,
-                                         userReview);
+        userReview);
     },
     updateVendorRankings: function(vendors) {
       if (dimSettingsService.showReviews) {
         _bulkFetcher.bulkFetch(vendors);
+      }
+    },
+    getItemReviews(item) {
+      if (dimSettingsService.allowIdPostToDtr) {
+        _reviewsFetcher.getItemReviews(item);
       }
     }
   };

--- a/src/scripts/services/dimDestinyTrackerService.factory.js
+++ b/src/scripts/services/dimDestinyTrackerService.factory.js
@@ -10,7 +10,6 @@ angular.module('dimApp')
 
 function DestinyTrackerService($q,
   $http,
-  $rootScope,
   dimPlatformService,
   dimSettingsService,
   $translate,
@@ -20,12 +19,6 @@ function DestinyTrackerService($q,
   const _bulkFetcher = new BulkFetcher($q, $http, _trackerErrorHandler, loadingTracker, _reviewDataCache);
   const _reviewsFetcher = new ReviewsFetcher($q, $http, _trackerErrorHandler, loadingTracker, _reviewDataCache);
   const _reviewSubmitter = new ReviewSubmitter($q, $http, dimPlatformService, _trackerErrorHandler, loadingTracker, _reviewDataCache);
-
-  $rootScope.$on('dim-stores-updated', (event, stores) => {
-    if (dimSettingsService.showReviews) {
-      _bulkFetcher.bulkFetch(stores);
-    }
-  });
 
   return {
     reattachScoresFromCache: function(stores) {
@@ -39,7 +32,7 @@ function DestinyTrackerService($q,
     },
     updateVendorRankings: function(vendors) {
       if (dimSettingsService.showReviews) {
-        _bulkFetcher.bulkFetch(vendors);
+        _bulkFetcher.bulkFetchVendorItems(vendors);
       }
     },
     getItemReviews: function(item) {
@@ -50,6 +43,11 @@ function DestinyTrackerService($q,
     submitReview: function(item) {
       if (dimSettingsService.allowIdPostToDtr) {
         _reviewSubmitter.submitReview(item);
+      }
+    },
+    fetchReviews: function(stores) {
+      if (dimSettingsService.showReviews) {
+        _bulkFetcher.bulkFetch(stores);
       }
     }
   };

--- a/src/scripts/services/dimDestinyTrackerService.factory.js
+++ b/src/scripts/services/dimDestinyTrackerService.factory.js
@@ -27,12 +27,6 @@ function DestinyTrackerService($q,
     }
   });
 
-  $rootScope.$on('review-submitted', (event, item) => {
-    if (dimSettingsService.allowIdPostToDtr) {
-      _reviewSubmitter.submitReview(item);
-    }
-  });
-
   return {
     reattachScoresFromCache: function(stores) {
       _bulkFetcher.attachRankings(null,
@@ -48,9 +42,14 @@ function DestinyTrackerService($q,
         _bulkFetcher.bulkFetch(vendors);
       }
     },
-    getItemReviews(item) {
+    getItemReviews: function(item) {
       if (dimSettingsService.allowIdPostToDtr) {
         _reviewsFetcher.getItemReviews(item);
+      }
+    },
+    submitReview: function(item) {
+      if (dimSettingsService.allowIdPostToDtr) {
+        _reviewSubmitter.submitReview(item);
       }
     }
   };

--- a/src/scripts/services/dimStoreService.factory.js
+++ b/src/scripts/services/dimStoreService.factory.js
@@ -53,6 +53,8 @@ function StoreService(
       stores: _stores
     });
     loadingTracker.addPromise(service.reloadStores(true));
+
+    dimDestinyTrackerService.fetchReviews(_stores);
   });
 
   return service;
@@ -160,6 +162,8 @@ function StoreService(
         $rootScope.$broadcast('dim-stores-updated', {
           stores: stores
         });
+
+        dimDestinyTrackerService.fetchReviews(stores);
 
         itemInfoService.cleanInfos(stores);
 

--- a/src/scripts/store/dimStoreItem.directive.js
+++ b/src/scripts/store/dimStoreItem.directive.js
@@ -89,7 +89,6 @@ function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService,
     vm.clicked = function clicked(item, e) {
       e.stopPropagation();
 
-      $rootScope.$broadcast('item-clicked', item);
       dimDestinyTrackerService.getItemReviews(item);
 
       if (vm.shiftClickCallback && e.shiftKey) {

--- a/src/scripts/store/dimStoreItem.directive.js
+++ b/src/scripts/store/dimStoreItem.directive.js
@@ -23,7 +23,7 @@ angular.module('dimApp')
     };
   });
 
-function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService, dimCompareService, $rootScope, dimActionQueue, NewItemsService) {
+function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService, dimCompareService, $rootScope, dimActionQueue, NewItemsService, dimDestinyTrackerService) {
   let otherDialog = null;
   let firstItemTimed = false;
 
@@ -90,6 +90,7 @@ function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService,
       e.stopPropagation();
 
       $rootScope.$broadcast('item-clicked', item);
+      dimDestinyTrackerService.getItemReviews(item);
 
       if (vm.shiftClickCallback && e.shiftKey) {
         vm.shiftClickCallback(item);

--- a/src/scripts/vendors/vendor-item.component.js
+++ b/src/scripts/vendors/vendor-item.component.js
@@ -16,7 +16,7 @@ export const VendorItem = {
 
 let otherDialog = null;
 
-function VendorItemCtrl($rootScope, $scope, ngDialog, dimStoreService) {
+function VendorItemCtrl($rootScope, $scope, ngDialog, dimStoreService, dimDestinyTrackerService) {
   'ngInject';
 
   const vm = this;
@@ -99,7 +99,7 @@ function VendorItemCtrl($rootScope, $scope, ngDialog, dimStoreService) {
         dialogResult = null;
       });
 
-      $rootScope.$broadcast('item-clicked', item);
+      dimDestinyTrackerService.getItemReviews(item);
     }
   };
 


### PR DESCRIPTION
Addressing issue #1857 I moved from broadcasting events to making function calls.

Removed $rootScope injection in a few classes where it was no longer needed and got rid of an event that no one was listening to.