### PR TITLE
Switch to Bungie's new reauth parameter for logout

### DIFF
--- a/src/scripts/login/login.component.js
+++ b/src/scripts/login/login.component.js
@@ -18,15 +18,7 @@ function LoginCtrl($stateParams) {
   const clientId = oauthClientId();
 
   const reauth = $stateParams.reauth;
-  const loginUrl = `/en/OAuth/Authorize?client_id=${clientId}&response_type=code&state=${localStorage.authorizationState}`;
 
-  if (reauth) {
-    // TEMPORARY: fully log out from Bungie.net by redirecting to a special logout/relogin page
-    // Soon, Bungie.net will respect the reauth parameter and we won't have to do this
-    const logoutUrl = `https://www.bungie.net/en/User/SignOut?bru=${encodeURIComponent(loginUrl)}`;
-    vm.authorizationURL = logoutUrl;
-  } else {
-    vm.authorizationURL = `https://www.bungie.net${loginUrl}${reauth ? '&reauth=true' : ''}`;
-  }
+  vm.authorizationURL = `https://www.bungie.net/en/OAuth/Authorize?client_id=${clientId}&response_type=code&state=${localStorage.authorizationState}${reauth ? '&reauth=true' : ''}`;
 }
 


### PR DESCRIPTION
Today, when you log out and then click the authorize button, we use a special URL to log you out of Bungie.net, and you get this screen immediately:

![screen shot 2017-07-05 at 10 07 23 pm](https://user-images.githubusercontent.com/313208/27896359-617b7a8a-61ce-11e7-9b64-1cadb138a922.png)

After this change, you'll go to the normal auth page, which has a logout link on it:

![screen shot 2017-07-05 at 10 15 00 pm](https://user-images.githubusercontent.com/313208/27896512-72d6089e-61cf-11e7-9b8d-61518d6de266.png)

@SunburnedGoose not sure which one we like better.