### PR TITLE
Activities tab

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -207,7 +207,9 @@ module.exports = (env) => {
         // Use a WebAssembly version of SQLite, if possible
         '$featureFlags.wasm': JSON.stringify(false),
         // Enable color-blind a11y
-        '$featureFlags.colorA11y': JSON.stringify(env !== 'release')
+        '$featureFlags.colorA11y': JSON.stringify(env !== 'release'),
+        // Enable activities tab
+        '$featureFlags.activities': JSON.stringify(env !== 'release')
       }),
 
       new webpack.optimize.ModuleConcatenationPlugin(),

--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -423,6 +423,11 @@
       "ShadersAndEmblems": "Shaders & Emblems",
       "Emotes": "Emotes"
    },
+   "Activities": {
+      "Activities": "Activities",
+      "Normal": "Normal",
+      "Hard": "Hard"
+   },
    "RecordBooks": {
       "RecordBooks": "Record Books",
       "HideCompleted": "Hide completed records"

--- a/src/scripts/activities/activities.component.js
+++ b/src/scripts/activities/activities.component.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 import template from './activities.html';
 import './activities.scss';
 
-function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettingsService) {
+function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettingsService, $translate) {
   'ngInject';
 
   const vm = this;
@@ -76,14 +76,14 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
   });
 
   function processActivities(defs, stores, rawActivity) {
-    const activityDef = defs.Activity[rawActivity.display.activityHash];
+    const categoryDef = defs.ActivityCategory.get(rawActivity.display.categoryHash);
+    //    const skullDef = defs.ScriptedSkull;
 
     const activity = {
       hash: rawActivity.display.activityHash,
-      name: rawActivity.display.advisorTypeCategory,
+      name: categoryDef.title,
       icon: rawActivity.display.icon,
       image: rawActivity.display.image,
-      description: activityDef.activityDescription,
     };
 
     if (rawActivity.extended) {
@@ -92,10 +92,16 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
       }).reduce((a, b) => {
         return a.concat(b);
       });
+      //      .map((s) => {
+      //        return skullDef.get(s.hash);
+      //      });
     }
 
     if (rawActivity.activityTiers[0].skullCategories && rawActivity.activityTiers[0].skullCategories.length) {
       activity.skulls = rawActivity.activityTiers[0].skullCategories[0].skulls;
+      //      .map((s) => {
+      //        return skullDef.get(s.hash);
+      //      });
     }
 
     activity.tiers = rawActivity.activityTiers.map((r, i) => processActivity(defs, rawActivity.identifier, stores, r, i));
@@ -107,7 +113,7 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
     const tierDef = defs.Activity[tier.activityHash];
 
     const name = tier.activityData.recommendedLight === 390 ? 390
-      : (tier.tierDisplayName ? tier.tierDisplayName : tierDef.activityName);
+      : (tier.tierDisplayName ? $translate.instant(`Activities.${tier.tierDisplayName}`) : tierDef.activityName);
 
     const characters = activityId === 'heroicstrike' ? [] : stores.map((store) => {
       let steps = store.advisors.activities[activityId].activityTiers[index].steps;

--- a/src/scripts/activities/activities.component.js
+++ b/src/scripts/activities/activities.component.js
@@ -1,0 +1,135 @@
+import _ from 'underscore';
+import angular from 'angular';
+import { sum, count } from '../util';
+
+import template from './activities.html';
+import './activities.scss';
+
+function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettingsService, $filter) {
+  'ngInject';
+
+  const vm = this;
+
+  vm.settings = dimSettingsService;
+
+  // TODO: it's time for a directive
+  vm.toggleSection = function(id) {
+    vm.settings.collapsedSections[id] = !vm.settings.collapsedSections[id];
+    vm.settings.save();
+  };
+
+  vm.settingsChanged = function() {
+    vm.settings.save();
+  };
+
+  // TODO: Ideally there would be an Advisors service that would
+  // lazily load advisor info, and we'd get that info
+  // here. Unfortunately we're also using advisor info to populate
+  // extra info in Trials cards in Store service, and it's more
+  // efficient to just fish the info out of there.
+
+  // TODO: it'll be nice to replace this pattern with RxJS observables
+  function init(stores = dimStoreService.getStores()) {
+    if (_.isEmpty(stores)) {
+      return;
+    }
+
+    stores = stores.filter((s) => s.id !== 'vault');
+
+    var whitelist = [
+      'vaultofglass',
+      'crota',
+      'kingsfall',
+      'wrathofthemachine',
+//      'elderchallenge',
+      'nightfall',
+      'heroicstrike',
+    ];
+
+    dimDefinitions.getDefinitions().then((defs) => {
+      const rawActivities = stores[0].advisors.activities;
+      vm.activities = _.chain(rawActivities)
+        .filter('activityTiers') // exclude trials, iron banner, armsday, xur
+        .filter((a) => {
+          return whitelist.includes(a.identifier);
+        })
+        .sortBy((a) => {
+          const ix = whitelist.indexOf(a.identifier);
+          return (ix === -1) ? 999 : ix;
+//          return -a.display.categoryHash;
+        })
+        .map((a) => processActivities(defs, stores, a))
+        .value();
+
+      vm.activities.forEach((a) => {
+        a.tiers.forEach((t) => {
+          if (t.hash === stores[0].advisors.activities.weeklyfeaturedraid.display.activityHash) {
+            a.featured = true;
+          }
+        });
+      })
+    });
+  }
+
+  init();
+
+  $scope.$on('dim-stores-updated', (e, args) => {
+    init(args.stores);
+  });
+
+  function processActivities(defs, stores, rawActivity) {
+    const activityDef = defs.Activity[rawActivity.display.activityHash];
+
+    const activity = {
+      hash: rawActivity.display.activityHash,
+      name: rawActivity.display.advisorTypeCategory,
+      icon: rawActivity.display.icon,
+      image: rawActivity.display.image,
+      description: activityDef.activityDescription,
+    };
+
+    if (rawActivity.extended) {
+      activity.skulls = rawActivity.extended.skullCategories.map((s) => {
+        return s.skulls;
+      }).reduce((a, b) => {
+        return a.concat(b)
+      });
+    }
+
+    if (rawActivity.activityTiers[0].skullCategories && rawActivity.activityTiers[0].skullCategories.length) {
+      activity.skulls = rawActivity.activityTiers[0].skullCategories[0].skulls;
+    }
+
+    activity.tiers = rawActivity.activityTiers.map((r, i) => processActivity(defs, rawActivity.identifier, stores, r, i));
+
+    return activity;
+  }
+
+  function processActivity(defs, activityId, stores, tier, index) {
+    const tierDef = defs.Activity[tier.activityHash];
+
+    const name = tier.activityData.recommendedLight === 390 ? 390 :
+      (tier.tierDisplayName ? tier.tierDisplayName : tierDef.activityName);
+
+    const characters = stores.map((store) => {
+      return {
+        name: store.name,
+        icon: store.icon,
+        steps: store.advisors.activities[activityId].activityTiers[index].steps
+      };
+    });
+
+    return {
+      hash: tierDef.activityHash,
+      icon: tierDef.icon,
+      name: name,
+      complete: tier.activityData.isCompleted,
+      characters: characters
+    };
+  }
+}
+
+export const ActivitiesComponent = {
+  controller: ActivitiesController,
+  template: template
+};

--- a/src/scripts/activities/activities.component.js
+++ b/src/scripts/activities/activities.component.js
@@ -109,13 +109,19 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
     const name = tier.activityData.recommendedLight === 390 ? 390
       : (tier.tierDisplayName ? tier.tierDisplayName : tierDef.activityName);
 
-    const characters = stores.map((store) => {
+    const characters = activityId !== 'heroicstrike' ? stores.map((store) => {
+      let steps = store.advisors.activities[activityId].activityTiers[index].steps;
+
+      if (!steps) {
+        steps = [store.advisors.activities[activityId].activityTiers[index].completion]
+      }
+
       return {
         name: store.name,
         icon: store.icon,
-        steps: store.advisors.activities[activityId].activityTiers[index].steps
+        steps: steps
       };
-    });
+    }) : [];
 
     return {
       hash: tierDef.activityHash,

--- a/src/scripts/activities/activities.component.js
+++ b/src/scripts/activities/activities.component.js
@@ -48,7 +48,7 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
       const rawActivities = stores[0].advisors.activities;
       vm.activities = _.filter(rawActivities, (a) => {
         return a.activityTiers && whitelist.includes(a.identifier);
-      })
+      });
       vm.activities = _.sortBy(vm.activities, (a) => {
         const ix = whitelist.indexOf(a.identifier);
         return (ix === -1) ? 999 : ix;

--- a/src/scripts/activities/activities.component.js
+++ b/src/scripts/activities/activities.component.js
@@ -1,11 +1,9 @@
 import _ from 'underscore';
-import angular from 'angular';
-import { sum, count } from '../util';
 
 import template from './activities.html';
 import './activities.scss';
 
-function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettingsService, $filter) {
+function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettingsService) {
   'ngInject';
 
   const vm = this;
@@ -36,12 +34,12 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
 
     stores = stores.filter((s) => s.id !== 'vault');
 
-    var whitelist = [
+    const whitelist = [
       'vaultofglass',
       'crota',
       'kingsfall',
       'wrathofthemachine',
-//      'elderchallenge',
+      //      'elderchallenge',
       'nightfall',
       'heroicstrike',
     ];
@@ -56,7 +54,7 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
         .sortBy((a) => {
           const ix = whitelist.indexOf(a.identifier);
           return (ix === -1) ? 999 : ix;
-//          return -a.display.categoryHash;
+          //          return -a.display.categoryHash;
         })
         .map((a) => processActivities(defs, stores, a))
         .value();
@@ -67,7 +65,7 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
             a.featured = true;
           }
         });
-      })
+      });
     });
   }
 
@@ -92,7 +90,7 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
       activity.skulls = rawActivity.extended.skullCategories.map((s) => {
         return s.skulls;
       }).reduce((a, b) => {
-        return a.concat(b)
+        return a.concat(b);
       });
     }
 
@@ -108,8 +106,8 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
   function processActivity(defs, activityId, stores, tier, index) {
     const tierDef = defs.Activity[tier.activityHash];
 
-    const name = tier.activityData.recommendedLight === 390 ? 390 :
-      (tier.tierDisplayName ? tier.tierDisplayName : tierDef.activityName);
+    const name = tier.activityData.recommendedLight === 390 ? 390
+      : (tier.tierDisplayName ? tier.tierDisplayName : tierDef.activityName);
 
     const characters = stores.map((store) => {
       return {

--- a/src/scripts/activities/activities.component.js
+++ b/src/scripts/activities/activities.component.js
@@ -109,11 +109,11 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
     const name = tier.activityData.recommendedLight === 390 ? 390
       : (tier.tierDisplayName ? tier.tierDisplayName : tierDef.activityName);
 
-    const characters = activityId !== 'heroicstrike' ? stores.map((store) => {
+    const characters = activityId === 'heroicstrike' ? [] : stores.map((store) => {
       let steps = store.advisors.activities[activityId].activityTiers[index].steps;
 
       if (!steps) {
-        steps = [store.advisors.activities[activityId].activityTiers[index].completion]
+        steps = [store.advisors.activities[activityId].activityTiers[index].completion];
       }
 
       return {
@@ -121,7 +121,7 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
         icon: store.icon,
         steps: steps
       };
-    }) : [];
+    });
 
     return {
       hash: tierDef.activityHash,

--- a/src/scripts/activities/activities.html
+++ b/src/scripts/activities/activities.html
@@ -5,15 +5,15 @@
 
     <div class="activity-header">
       <div class="activity-title" style="background-image: url({{ ::activity.image | bungieIcon }})" ng-class="{ 'activity-featured': activity.featured }">
-        <img class="step-icon" ng-src="{{ ::activity.icon | bungieIcon }}" /> {{ ::activity.name }} <i ng-if="::activity.featured"  class="fa fa-star"></i>
+        <img class="small-icon" ng-src="{{ ::activity.icon | bungieIcon }}" /> {{ ::activity.name }} <i ng-if="::activity.featured"  class="fa fa-star"></i>
       </div>
     </div>
 
-    <div class="activity-progress" ng-class="{ complete: tier.complete }" ng-repeat="tier in activity.tiers track by $index">
+    <div class="activity-progress" ng-repeat="tier in activity.tiers track by $index">
       <div class="tier-title">{{ ::tier.name }}</div>
       <div class="tier-row" ng-if="tier.characters.length" ng-repeat="character in tier.characters track by $index">
         <span>
-          <img class="step-icon" ng-src="{{ ::character.icon }}" /> {{ ::character.name }}
+          <img class="small-icon" ng-src="{{ ::character.icon }}" /> {{ ::character.name }}
         </span>
         <span>
           <span class="step-icon" ng-class="{ complete: step.complete }" ng-repeat="step in character.steps track by $index"></span>
@@ -22,7 +22,7 @@
     </div>
 
     <div class="activity-skulls" ng-if="::activity.skulls" ng-repeat="skull in activity.skulls">
-      <img class="step-icon" ng-src="{{ ::skull.icon | bungieIcon }}" />
+      <img class="small-icon" ng-src="{{ ::skull.icon | bungieIcon }}" />
       {{ ::skull.displayName }} - {{ ::skull.description }}
     </div>
   </div>

--- a/src/scripts/activities/activities.html
+++ b/src/scripts/activities/activities.html
@@ -5,7 +5,7 @@
 
     <div class="activity-header">
       <div class="activity-title" style="background-image: url({{ ::activity.image | bungieIcon }})" ng-class="{ 'activity-featured': activity.featured }">
-        <img class="book-icon" ng-src="{{ ::activity.icon | bungieIcon }}" /> {{ ::activity.name }} <i ng-if="::activity.featured"  class="fa fa-star"></i>
+        <img class="step-icon" ng-src="{{ ::activity.icon | bungieIcon }}" /> {{ ::activity.name }} <i ng-if="::activity.featured"  class="fa fa-star"></i>
       </div>
     </div>
 
@@ -13,7 +13,7 @@
       <div class="tier-title">{{ ::tier.name }}</div>
       <div class="tier-row" ng-if="tier.characters.length" ng-repeat="character in tier.characters track by $index">
         <span>
-          <img class="book-icon" ng-src="{{ ::character.icon }}" /> {{ ::character.name }}
+          <img class="step-icon" ng-src="{{ ::character.icon }}" /> {{ ::character.name }}
         </span>
         <span>
           <span class="step-icon" ng-class="{ complete: step.complete }" ng-repeat="step in character.steps track by $index"></span>
@@ -22,7 +22,7 @@
     </div>
 
     <div class="activity-skulls" ng-if="::activity.skulls" ng-repeat="skull in activity.skulls">
-      <img class="book-icon" ng-src="{{ ::skull.icon | bungieIcon }}" />
+      <img class="step-icon" ng-src="{{ ::skull.icon | bungieIcon }}" />
       {{ ::skull.displayName }} - {{ ::skull.description }}
     </div>
   </div>

--- a/src/scripts/activities/activities.html
+++ b/src/scripts/activities/activities.html
@@ -1,0 +1,29 @@
+<back-link></back-link>
+
+<div class="activities">
+  <div class="activity" ng-repeat="activity in $ctrl.activities track by $index">
+
+    <div class="activity-header">
+      <div class="activity-title" style="background-image: url({{ ::activity.image | bungieIcon }})" ng-class="{ 'activity-featured': activity.featured }">
+        <img class="book-icon" ng-src="{{ ::activity.icon | bungieIcon }}" /> {{ ::activity.name }} <i ng-if="::activity.featured"  class="fa fa-star"></i>
+      </div>
+    </div>
+
+    <div class="activity-progress" ng-class="{ complete: tier.complete }" ng-repeat="tier in activity.tiers track by $index">
+      <div class="tier-title">{{ ::tier.name }}</div>
+      <div class="tier-row" ng-if="tier.characters.length" ng-repeat="character in tier.characters track by $index">
+        <span>
+          <img class="book-icon" ng-src="{{ ::character.icon }}" /> {{ ::character.name }}
+        </span>
+        <span>
+          <span class="step-icon" ng-class="{ complete: step.complete }" ng-repeat="step in character.steps track by $index"></span>
+        </span>
+      </div>
+    </div>
+
+    <div class="activity-skulls" ng-if="::activity.skulls" ng-repeat="skull in activity.skulls">
+      <img class="book-icon" ng-src="{{ ::skull.icon | bungieIcon }}" />
+      {{ ::skull.displayName }} - {{ ::skull.description }}
+    </div>
+  </div>
+</div>

--- a/src/scripts/activities/activities.html
+++ b/src/scripts/activities/activities.html
@@ -4,7 +4,7 @@
   <div class="activity" ng-repeat="activity in $ctrl.activities track by $index">
 
     <div class="activity-header">
-      <div class="activity-title" style="background-image: url({{ ::activity.image | bungieIcon }})" ng-class="{ 'activity-featured': activity.featured }">
+      <div class="activity-title" ng-style="::activity.image | bungieBackground" ng-class="{ 'activity-featured': activity.featured }">
         <img class="small-icon" ng-src="{{ ::activity.icon | bungieIcon }}" /> {{ ::activity.name }} <i ng-if="::activity.featured"  class="fa fa-star"></i>
       </div>
     </div>

--- a/src/scripts/activities/activities.module.js
+++ b/src/scripts/activities/activities.module.js
@@ -1,0 +1,20 @@
+import angular from 'angular';
+import 'angular-duration-format';
+
+import bungieApiModule from '../bungie-api/bungie-api.module';
+import { ActivitiesComponent } from './activities.component';
+
+export default angular
+  .module('activitiesModule', ['angular-duration-format', bungieApiModule])
+  .component('activities', ActivitiesComponent)
+  .config(($stateProvider) => {
+    'ngInject';
+
+    $stateProvider.state({
+      name: 'activities',
+      parent: 'content',
+      component: 'activities',
+      url: '/activities'
+    });
+  })
+  .name;

--- a/src/scripts/activities/activities.scss
+++ b/src/scripts/activities/activities.scss
@@ -1,3 +1,9 @@
+back-link {
+  width: 1160px;
+  margin: 0 auto;
+  display: block;
+}
+
 .activities {
   width: 1200px;
   margin: 0 auto;
@@ -29,10 +35,13 @@
 
   .activity-skulls {
     padding: 4px 0px;
+    font-size: .8em;
 
-    .step-icon {
-      height: 18px;
-      padding: 0 4px;
+    .small-icon {
+      height: 13px;
+      padding: 2px 7px;
+      margin-right: 6px;
+      float: left;
     }
   }
 
@@ -40,7 +49,7 @@
     position: relative;
   }
 
-  .step-icon {
+  .small-icon {
     height: 26px;
     vertical-align: middle;
     position: relative;
@@ -48,8 +57,7 @@
   }
 
   .tier-title {
-
-    padding: 0 16px;
+    padding: 0 32px;
     background-color: #353535;
     line-height: 34px;
 
@@ -59,6 +67,10 @@
   .tier-row {
     display: flex;
     justify-content: space-between;
+
+    img {
+      padding-right: 4px;
+    }
   }
 
   .step-icon {
@@ -69,6 +81,7 @@
     display: inline-block;
     border: 2px solid #fff;
     margin: 2px;
+    margin-top: 6px;
   }
 
   .complete .step-icon {

--- a/src/scripts/activities/activities.scss
+++ b/src/scripts/activities/activities.scss
@@ -5,7 +5,7 @@ back-link {
 }
 
 .activities {
-  width: 1200px;
+  max-width: 1200px;
   margin: 0 auto;
   display: flex;
   flex-wrap: wrap;

--- a/src/scripts/activities/activities.scss
+++ b/src/scripts/activities/activities.scss
@@ -1,0 +1,78 @@
+.activities {
+  width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+
+  .activity {
+    margin: 20px;
+    width: 350px;
+  }
+
+  .activity-header {
+    position: relative;
+  }
+  .activity-image {
+    position: absolute;
+    width: 100%;
+  }
+  .activity-featured {
+    color: gold;
+  }
+  .activity-title {
+    padding: 0 16px;
+    line-height: 34px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-size: 14px;
+  }
+
+  .activity-skulls {
+    padding: 4px 0px;
+
+    .book-icon {
+      height: 18px;
+      padding: 0 4px;
+    }
+  }
+
+  .activity-progress {
+    position: relative;
+  }
+
+  .book-icon {
+    height: 26px;
+    vertical-align: middle;
+    position: relative;
+    top: -1px;
+  }
+
+  .tier-title {
+
+    padding: 0 16px;
+    background-color: #353535;
+    line-height: 34px;
+
+    text-transform: uppercase;
+  }
+
+  .tier-row {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .step-icon {
+    border-radius: 50%;
+    background-color: rgba(245, 245, 245, 0.1);
+    width: 8px;
+    height: 8px;
+    display: inline-block;
+    border: 2px solid #fff;
+    margin: 2px;
+  }
+
+  .complete .step-icon {
+    border-color: #ffce1f;
+    background-color: rgba(255,206,31,0.4);
+  }
+}

--- a/src/scripts/activities/activities.scss
+++ b/src/scripts/activities/activities.scss
@@ -84,7 +84,7 @@ back-link {
     margin-top: 6px;
   }
 
-  .complete .step-icon {
+  .step-icon.complete {
     border-color: #ffce1f;
     background-color: rgba(255,206,31,0.4);
   }

--- a/src/scripts/activities/activities.scss
+++ b/src/scripts/activities/activities.scss
@@ -30,7 +30,7 @@
   .activity-skulls {
     padding: 4px 0px;
 
-    .book-icon {
+    .step-icon {
       height: 18px;
       padding: 0 4px;
     }
@@ -40,7 +40,7 @@
     position: relative;
   }
 
-  .book-icon {
+  .step-icon {
     height: 26px;
     vertical-align: middle;
     position: relative;

--- a/src/scripts/dimApp.module.js
+++ b/src/scripts/dimApp.module.js
@@ -17,6 +17,7 @@ import bungieApiModule from './bungie-api/bungie-api.module';
 import { ShellModule } from './shell/shell.module';
 import inventoryModule from './store/inventory.module';
 import recordBooksModule from './record-books/record-books.module';
+import activitiesModule from './activities/activities.module';
 import vendorsModule from './vendors/vendors.module';
 import itemReviewModule from './item-review/item-review.module';
 import loadoutBuilderModule from './loadout-builder/loadout-builder.module';
@@ -48,6 +49,7 @@ const dependencies = [
   bungieApiModule,
   inventoryModule,
   recordBooksModule,
+  activitiesModule,
   vendorsModule,
   itemReviewModule,
   loadoutBuilderModule,

--- a/src/scripts/services/dimDefinitions.factory.js
+++ b/src/scripts/services/dimDefinitions.factory.js
@@ -11,7 +11,9 @@ const lazyTables = [
   'Record',
   'ItemCategory',
   'VendorCategory',
-  'RecordBook'
+  'RecordBook',
+  'ActivityCategory',
+  'ScriptedSkull'
 ];
 
 const eagerTables = [

--- a/src/scripts/services/dimDefinitions.factory.js
+++ b/src/scripts/services/dimDefinitions.factory.js
@@ -19,7 +19,8 @@ const eagerTables = [
   'Class',
   'Race',
   'Faction',
-  'Vendor'
+  'Vendor',
+  'Activity'
 ];
 
 const mod = angular.module('dimApp');

--- a/src/scripts/shell/content/content.controller.js
+++ b/src/scripts/shell/content/content.controller.js
@@ -52,6 +52,7 @@ export default class ContentController {
 
     vm.featureFlags = {
       vendorsEnabled: $featureFlags.vendorsEnabled,
+      activities: $featureFlags.activities,
       colorA11y: $featureFlags.colorA11y
     };
     vm.vendorService = dimVendorService;

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -19,6 +19,7 @@
     <a class="link" target="_blank" rel="noopener noreferrer" href="https://teespring.com/stores/dim" translate="Header.Shop"></a>
     <span class="link header-separator"></span>
     <span class="link" ng-click="$ctrl.toggleState('record-books')" translate="RecordBooks"></span>
+    <span class="link" ng-if="::$ctrl.featureFlags.activities" ng-click="$ctrl.toggleState('activities')" translate="Activities"></span>
     <span class="link" ng-if="::$ctrl.featureFlags.vendorsEnabled" ng-class="{disabled: !$ctrl.vendorService.vendorsLoaded}" ng-click="$ctrl.toggleState('vendors')" translate="Vendors"></span>
     <span class="link" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>
   </div>


### PR DESCRIPTION
Figured we should get this into DIM as seeing these things within the same app might be useful for D2.

I’m intentionally hiding some activities (by using a whitelist, because is it really that important to know what the weekly crucible type is? you can just see it in game. weekly strike/nightfall is nice because then you can setup your loadout based on the burn.) I can add more in, but for the first phase this is what is shown.

<img width="1444" alt="screen shot 2017-07-05 at 10 55 23 pm" src="https://user-images.githubusercontent.com/424158/27897665-698fd7ae-61d6-11e7-93e3-38d437901fdd.png">

todo: 

- [x] nightfall still needs a checkbox
- [x] weekly heroic doesn't need to show each of the characters, just the modifiers.
~~- [ ] weekly heroic should show number of weekly bonuses remaining~~
- [x] i18n

This fixes #145