### PR TITLE
Lodash compatibility

### DIFF
--- a/src/scripts/compare/compare.component.js
+++ b/src/scripts/compare/compare.component.js
@@ -81,10 +81,11 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, $trans
 
     if (args.dupes) {
       vm.compare = args.item;
-      vm.similarTypes = _.where(dimStoreService.getAllItems(), { typeName: vm.compare.typeName });
+      const allItems = dimStoreService.getAllItems();
+      vm.similarTypes = _.filter(allItems, { typeName: vm.compare.typeName });
       let armorSplit;
       if (!vm.compare.location.inWeapons) {
-        vm.similarTypes = _.where(vm.similarTypes, { classType: vm.compare.classType });
+        vm.similarTypes = _.filter(vm.similarTypes, { classType: vm.compare.classType });
         armorSplit = _.reduce(vm.compare.stats, (memo, stat) => {
           return memo + (stat.base === 0 ? 0 : stat.statHash);
         }, 0);
@@ -102,7 +103,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, $trans
           return memo + (stat.base === 0 ? 0 : stat.statHash);
         }, 0) === armorSplit;
       });
-      vm.comparisons = _.where(dimStoreService.getAllItems(), { hash: vm.compare.hash });
+      vm.comparisons = _.filter(allItems, { hash: vm.compare.hash });
     } else if (!_.findWhere(vm.comparisons, { hash: args.item.hash, id: args.item.id })) {
       vm.comparisons.push(args.item);
     }

--- a/src/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/src/scripts/loadout/dimLoadoutPopup.directive.js
@@ -42,12 +42,13 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
 
         vm.loadouts = _.sortBy(loadouts, 'name') || [];
 
-        vm.loadouts = _.chain(vm.loadouts)
-          .filter((item) => _.isUndefined(item.platform) || item.platform === platform.label)
-          .filter((item) => {
-            return vm.classTypeId === -1 || ((item.classType === -1) || (item.classType === vm.classTypeId));
-          })
-          .value();
+        vm.loadouts = vm.loadouts.filter((item) => {
+          return (_.isUndefined(item.platform) ||
+                  item.platform === platform.label) &&
+            (vm.classTypeId === -1 ||
+             item.classType === -1 ||
+             item.classType === vm.classTypeId);
+        });
       });
   }
   $scope.$on('dim-save-loadout', initLoadouts);

--- a/src/scripts/loadout/dimLoadoutPopup.directive.js
+++ b/src/scripts/loadout/dimLoadoutPopup.directive.js
@@ -126,7 +126,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
 
   // A dynamic loadout set up to level weapons and armor
   vm.itemLevelingLoadout = function itemLevelingLoadout($event) {
-    const applicableItems = _.select(dimStoreService.getAllItems(), (i) => {
+    const applicableItems = _.filter(dimStoreService.getAllItems(), (i) => {
       return i.canBeEquippedBy(vm.store) &&
         i.talentGrid &&
         !i.talentGrid.xpComplete && // Still need XP
@@ -200,7 +200,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
       'Artifact',
       'Ghost'];
 
-    const applicableItems = _.select(dimStoreService.getAllItems(), (i) => {
+    const applicableItems = _.filter(dimStoreService.getAllItems(), (i) => {
       return i.canBeEquippedBy(vm.store) &&
         i.primStat && // has a primary stat (sanity check)
         _.contains(lightTypes, i.type); // one of our selected types
@@ -237,7 +237,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
 
   // A dynamic loadout set up to level weapons and armor
   vm.gatherEngramsLoadout = function gatherEngramsLoadout($event, options = {}) {
-    const engrams = _.select(dimStoreService.getAllItems(), (i) => {
+    const engrams = _.filter(dimStoreService.getAllItems(), (i) => {
       return i.isEngram() && !i.location.inPostmaster && (options.exotics ? true : !i.isExotic);
     });
 
@@ -279,7 +279,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
 
   // Move items matching the current search. Max 9 per type.
   vm.searchLoadout = function searchLoadout($event) {
-    const items = _.select(dimStoreService.getAllItems(), (i) => {
+    const items = _.filter(dimStoreService.getAllItems(), (i) => {
       return i.visible && !i.location.inPostmaster;
     });
 
@@ -325,7 +325,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
           const numNeededToMove = Math.max(0, count + items.length - capacity);
           if (numNeededToMove > 0) {
             // We'll move the lowest-value item to the vault.
-            const candidates = _.sortBy(_.select(items, { equipped: false, notransfer: false }), (i) => {
+            const candidates = _.sortBy(_.filter(items, { equipped: false, notransfer: false }), (i) => {
               let value = {
                 Common: 0,
                 Uncommon: 1,
@@ -374,9 +374,9 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
           const vaultSpaceLeft = vault.spaceLeftForItem(item);
           if (vaultSpaceLeft <= 1) {
             // If we're down to one space, try putting it on other characters
-            const otherStores = _.select(dimStoreService.getStores(),
+            const otherStores = _.filter(dimStoreService.getStores(),
                                          (store) => !store.isVault && store.id !== vm.store.id);
-            const otherStoresWithSpace = _.select(otherStores, (store) => store.spaceLeftForItem(item));
+            const otherStoresWithSpace = _.filter(otherStores, (store) => store.spaceLeftForItem(item));
 
             if (otherStoresWithSpace.length) {
               return dimItemService.moveTo(item, otherStoresWithSpace[0], false, item.amount, items, reservations);
@@ -409,7 +409,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
     const exoticGroups = [['Primary', 'Special', 'Heavy'], ['Helmet', 'Gauntlets', 'Chest', 'Leg']];
     _.each(exoticGroups, (group) => {
       const itemsInGroup = _.pick(items, group);
-      const numExotics = _.select(_.values(itemsInGroup), isExotic).length;
+      const numExotics = _.filter(_.values(itemsInGroup), isExotic).length;
       if (numExotics > 1) {
         const options = [];
 

--- a/src/scripts/services/dimItemService.factory.js
+++ b/src/scripts/services/dimItemService.factory.js
@@ -44,7 +44,7 @@ function ItemService(
       const stackable = item.maxStackSize > 1;
       // Items to be decremented
       const sourceItems = stackable
-            ? _.sortBy(_.select(source.buckets[item.location.id], (i) => {
+            ? _.sortBy(_.filter(source.buckets[item.location.id], (i) => {
               return i.hash === item.hash &&
                 i.id === item.id &&
                 !i.notransfer;
@@ -52,7 +52,7 @@ function ItemService(
       // Items to be incremented. There's really only ever at most one of these, but
       // it's easier to deal with as a list.
       const targetItems = stackable
-            ? _.sortBy(_.select(target.buckets[item.location.id], (i) => {
+            ? _.sortBy(_.filter(target.buckets[item.location.id], (i) => {
               return i.hash === item.hash &&
                 i.id === item.id &&
                 // Don't consider full stacks as targets

--- a/src/scripts/services/dimLoadoutService.factory.js
+++ b/src/scripts/services/dimLoadoutService.factory.js
@@ -70,12 +70,11 @@ function LoadoutService($q, $rootScope, $translate, dimItemService, dimStoreServ
     const loadoutGuids = new Set(_.pluck(loadouts, 'id'));
     const containsLoadoutGuids = (item) => loadoutGuids.has(item.id);
 
-    const orphanIds = _.chain(data)
-      .filter(objectTest)
-      .filter(hasGuid)
-      .reject(containsLoadoutGuids)
-      .pluck('id')
-      .value();
+    const orphanIds = _.pluck(Object.values(data).filter((item) => {
+      return objectTest(item) &&
+        hasGuid(item) &&
+        !containsLoadoutGuids(item);
+    }), 'id');
 
     if (orphanIds.length > 0) {
       return SyncService.remove(orphanIds).then(() => loadouts);
@@ -508,18 +507,15 @@ function LoadoutService($q, $rootScope, $translate, dimItemService, dimStoreServ
       items: []
     };
 
-    result.items = _.chain(loadout.items)
-      .values()
-      .flatten()
-      .map((item) => {
-        return {
-          id: item.id,
-          hash: item.hash,
-          amount: item.amount,
-          equipped: item.equipped
-        };
-      })
-      .value();
+    const allItems = _.flatten(Object.values(loadout.items));
+    result.items = allItems.map((item) => {
+      return {
+        id: item.id,
+        hash: item.hash,
+        amount: item.amount,
+        equipped: item.equipped
+      };
+    });
 
     return result;
   }

--- a/src/scripts/services/dimLoadoutService.factory.js
+++ b/src/scripts/services/dimLoadoutService.factory.js
@@ -208,7 +208,7 @@ function LoadoutService($q, $rootScope, $translate, dimItemService, dimStoreServ
       General: store.level === 40 ? .08 : .087
     };
     return (Math.floor(10 * _.reduce(loadout.items, (memo, items) => {
-      const item = _.findWhere(items, { equipped: true });
+      const item = _.find(items, { equipped: true });
 
       return memo + (item.primStat.value * itemWeight[item.location.id === 'BUCKET_CLASS_ITEMS' ? 'General' : item.location.sort]);
     }, 0)) / 10).toFixed(1);
@@ -404,7 +404,7 @@ function LoadoutService($q, $rootScope, $translate, dimItemService, dimStoreServ
         while (amountNeeded > 0) {
           const source = _.max(storesByAmount, 'amount');
           const amountToMove = Math.min(source.amount, amountNeeded);
-          const sourceItem = _.findWhere(source.store.items, { hash: pseudoItem.hash });
+          const sourceItem = _.find(source.store.items, { hash: pseudoItem.hash });
 
           if (amountToMove === 0 || !sourceItem) {
             promise = promise.then(() => {
@@ -424,7 +424,7 @@ function LoadoutService($q, $rootScope, $translate, dimItemService, dimStoreServ
       }
     } else {
       if (item.type === 'Class') {
-        item = _.findWhere(store.items, {
+        item = _.find(store.items, {
           hash: pseudoItem.hash
         });
       }

--- a/src/scripts/services/store/item-factory.service.js
+++ b/src/scripts/services/store/item-factory.service.js
@@ -726,7 +726,7 @@ export function ItemFactory(
         return _.contains([1034209669, 1263323987, 193091484], node.hash); // ['Increase Intellect', 'Increase Discipline', 'Increase Strength']
       });
       if (armorNodes) {
-        activeArmorNode = _.findWhere(armorNodes, { activated: true }) || { hash: 0 };
+        activeArmorNode = _.find(armorNodes, { activated: true }) || { hash: 0 };
       }
     }
 

--- a/src/scripts/services/store/store-factory.service.js
+++ b/src/scripts/services/store/store-factory.service.js
@@ -126,16 +126,14 @@ export function StoreFactory($translate, dimInfoService, dimDefinitions) {
 
     // Create a loadout from this store's equipped items
     loadoutFromCurrentlyEquipped: function(name) {
+      const allItems = this.items
+        .filter((item) => item.canBeInLoadout())
+        .map((i) => angular.copy(i));
       return {
         id: uuidv4(),
         classType: -1,
         name: name,
-        items: _(this.items)
-          .chain()
-          .select((item) => item.canBeInLoadout())
-          .map((i) => angular.copy(i))
-          .groupBy((i) => i.type.toLowerCase())
-          .value()
+        items: _.groupBy(allItems, (i) => i.type.toLowerCase())
       };
     },
 

--- a/src/scripts/shell/dimAngularFilters.filter.js
+++ b/src/scripts/shell/dimAngularFilters.filter.js
@@ -45,7 +45,7 @@ mod.filter('bungieBackground', () => {
  */
 mod.filter('equipped', () => {
   return function(items, isEquipped) {
-    return _.select(items || [], (item) => {
+    return _.filter(items || [], (item) => {
       return item.equipped === isEquipped;
     });
   };

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import _ from 'underscore';
 import template from './dimSearchFilter.directive.html';
 import 'jquery-textcomplete';
+import { flatMap } from '../util';
 
 angular.module('dimApp')
   .factory('dimSearchService', SearchService)
@@ -426,11 +427,7 @@ function SearchFilterCtrl($scope, dimStoreService, dimVendorService, dimSearchSe
     },
     dupe: function(predicate, item) {
       if (_duplicates === null) {
-        _duplicates = _.chain(dimStoreService.getStores())
-          .pluck('items')
-          .flatten()
-          .countBy('hash')
-          .value();
+        _duplicates = _.countBy(flatMap(dimStoreService.getStores(), 'items'), 'hash');
       }
 
       // We filter out the "Default Shader" because everybody has one per character

--- a/src/scripts/store/dimStoreHeading.directive.js
+++ b/src/scripts/store/dimStoreHeading.directive.js
@@ -28,7 +28,7 @@ function StoreHeadingCtrl($scope, ngDialog, $translate) {
       return vm.store.percentToNextLevel;
     }
     if (vm.store.progression && vm.store.progression.progressions) {
-      const prestige = _.findWhere(vm.store.progression.progressions, {
+      const prestige = _.find(vm.store.progression.progressions, {
         progressionHash: 2030054750
       });
       vm.xpTillMote = $translate.instant('Stats.Prestige', {

--- a/src/scripts/vendors/vendor.service.js
+++ b/src/scripts/vendors/vendor.service.js
@@ -494,18 +494,12 @@ function VendorService(
     if (!stores || !vendors || !stores.length || _.isEmpty(vendors)) {
       return {};
     }
-    const currencies = _.chain(vendors)
-          .values()
-          .pluck('categories')
-          .flatten()
-          .pluck('saleItems')
-          .flatten()
-          .pluck('costs')
-          .flatten()
-          .pluck('currency')
-          .pluck('itemHash')
-          .unique()
-          .value();
+
+    const categories = flatMap(Object.values(vendors), 'categories');
+    const saleItems = flatMap(categories, 'saleItems');
+    const costs = flatMap(saleItems, 'costs');
+    const currencies = costs.map((c) => c.currency.itemHash);
+
     const totalCoins = {};
     currencies.forEach((currencyHash) => {
       // Legendary marks and glimmer are special cases


### PR DESCRIPTION
I've been maintaining a branch of DIM that uses lodash instead of underscore. So far, even with a lot of webpack and babel magic, using lodash is significantly more code in the bundle than just importing all of underscore. But I keep it around in hopes that over time webpack will improve.

This PR just applies a few changes that help maintain that branch by improving compatibility with lodash:

1. Use `filter` instead of `select` or `where`.
2. Use `find` instead of `findWhere`.
3. Avoid `chain`, since in the lodash branch this will cause all of lodash to get imported, which defeats the purpose of having fine-grained modules.