### PR TITLE
Upgrade Google Analytics and optionally track router pages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,8 @@
     "$DIM_CLIENT_SECRET": true,
     "$DIM_WEB_CLIENT_SECRET": true,
     "$GOOGLE_DRIVE_CLIENT_ID": true,
-    "$featureFlags": true
+    "$featureFlags": true,
+    "ga": true
   },
   "plugins": [
     "angular"

--- a/.eslintrc-hound
+++ b/.eslintrc-hound
@@ -32,7 +32,8 @@
     "$DIM_CLIENT_SECRET": true,
     "$DIM_WEB_CLIENT_SECRET": true,
     "$GOOGLE_DRIVE_CLIENT_ID": true,
-    "$featureFlags": true
+    "$featureFlags": true,
+    "ga"
   },
   "rules": {
     "array-callback-return": "error",

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -202,7 +202,9 @@ module.exports = (env) => {
         // Use a WebAssembly version of SQLite, if possible
         '$featureFlags.wasm': JSON.stringify(false),
         // Enable color-blind a11y
-        '$featureFlags.colorA11y': JSON.stringify(env !== 'release')
+        '$featureFlags.colorA11y': JSON.stringify(env !== 'release'),
+        // Whether to log page views for router events
+        '$featureFlags.googleAnalyticsForRouter': JSON.stringify(env !== 'release')
       }),
 
       new webpack.optimize.ModuleConcatenationPlugin(),

--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,8 @@
   <body ng-strict-di>
     <app></app>
 
-    <script src="https://apis.google.com/js/api.js"></script>
+    <script async src='https://www.google-analytics.com/analytics.js'></script>
+    <script async src="https://apis.google.com/js/api.js"></script>
 
     {{#each htmlWebpackPlugin.files.js}}
     <script type="text/javascript" src="{{ webpackConfig.output.publicPath }}{{ this }}"></script>

--- a/src/scripts/dimApp.run.js
+++ b/src/scripts/dimApp.run.js
@@ -1,5 +1,5 @@
 
-function run($rootScope, SyncService) {
+function run($rootScope, SyncService, $transitions, $location) {
   'ngInject';
 
   SyncService.init();
@@ -11,6 +11,12 @@ function run($rootScope, SyncService) {
   $rootScope.$DIM_BUILD_DATE = new Date($DIM_BUILD_DATE).toLocaleString();
 
   console.log(`DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.reddit.com/r/destinyitemmanager`);
+
+  if ($featureFlags.googleAnalyticsForRouter) {
+    $transitions.onSuccess({ }, () => {
+      ga('send', 'pageview', $location.path());
+    });
+  }
 }
 
 export default run;

--- a/src/scripts/google.js
+++ b/src/scripts/google.js
@@ -1,11 +1,10 @@
-window._gaq = window._gaq || [];
-const _gaq = window._gaq;
-_gaq.push(['_setAccount', 'UA-60316581-1']);
-_gaq.push(['_setCustomVar', 1, 'DIMVersion', $DIM_VERSION, 3]);
-_gaq.push(['_trackPageview']);
+window.ga = window.ga || function(...args) { (ga.q = ga.q || []).push(args); }; ga.l = Number(new Date());
 
-(function() {
-  const ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-  ga.src = 'https://www.google-analytics.com/ga.js';
-  const s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-})();
+ga('create', 'UA-60316581-1', document.location.hostname);
+ga('set', 'DIMVersion', $DIM_VERSION);
+ga('set', 'DIMFlavor', $DIM_FLAVOR);
+
+// If we're hooked into the router, let it send pageviews instead
+if (!$featureFlags.googleAnalyticsForRouter) {
+  ga('send', 'pageview');
+}

--- a/src/scripts/services/dimManifestService.factory.js
+++ b/src/scripts/services/dimManifestService.factory.js
@@ -242,7 +242,7 @@ function ManifestService($q, Destiny1Api, $http, toaster, dimSettingsService, $t
         return typedArray;
       });
     } else {
-      _gaq.push(['_trackEvent', 'Manifest', 'Need New Manifest']);
+      ga('send', 'event', 'Manifest', 'Need New Manifest');
       return $q.reject(new Error(`version mismatch: ${version} ${currentManifestVersion}`));
     }
   }

--- a/src/scripts/settings/settings.component.js
+++ b/src/scripts/settings/settings.component.js
@@ -56,12 +56,12 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
 
   vm.downloadWeaponCsv = function() {
     dimCsvService.downloadCsvFiles(dimStoreService.getStores(), "Weapons");
-    _gaq.push(['_trackEvent', 'Download CSV', 'Weapons']);
+    ga('send', 'event', 'Download CSV', 'Weapons');
   };
 
   vm.downloadArmorCsv = function() {
     dimCsvService.downloadCsvFiles(dimStoreService.getStores(), "Armor");
-    _gaq.push(['_trackEvent', 'Download CSV', 'Armor']);
+    ga('send', 'event', 'Download CSV', 'Armor');
   };
 
   vm.resetHiddenInfos = function() {


### PR DESCRIPTION
This upgrades our Google Analytics tracking code to the latest recommended library. It also gives us a feature flag to turn on per-route tracking in ui-router (off in release, on in beta). Something for us to try out.