### PR TITLE
Responsive elements

### DIFF
--- a/src/scripts/loadout-builder/loadout-builder.scss
+++ b/src/scripts/loadout-builder/loadout-builder.scss
@@ -1,7 +1,7 @@
 @import '../../scss/variables';
 
 .loadout-builder {
-  width: 900px;
+  max-width: 900px;
   margin: 0 auto;
 
   #includeVendors {

--- a/src/scripts/login/login.scss
+++ b/src/scripts/login/login.scss
@@ -11,8 +11,8 @@
     padding: 1rem 3rem;
     background-color: #506d86;
     color: white;
-    margin-top: 1rem;
     box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.2);
+    margin: 1rem;
   }
 
   h1 {

--- a/src/scripts/record-books/record-books.scss
+++ b/src/scripts/record-books/record-books.scss
@@ -1,6 +1,5 @@
 .record-books {
   max-width: 900px;
-  min-width: 450px;
   margin: 0 auto;
 
   h1 {

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -1,29 +1,44 @@
 <div id="header">
-  <div class="content">
-    <span class="header-right">
-      <dim-platform-choice platforms="$ctrl.platforms" current="$ctrl.currentPlatform" on-platform-change="$ctrl.platformChange(platform)" class="header-right"></dim-platform-choice>
-      <div class="header-right" id="actions">
-        <refresh-stores class="link"></refresh-stores>
-        <span class="link" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
-        <span class="link" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
-        <span class="link search-link">
-          <span class="filter-help" ng-click="$ctrl.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-question-circle-o"></i></span>
-          <dim-search-filter></dim-search-filter>
-        </span>
-      </div>
+  <span class="menu link" ng-click="$ctrl.dropdown = !$ctrl.dropdown" dim-click-anywhere-but-here="$ctrl.dropdown = false">
+    <i class="fa fa-bars"></i>
+    <div class="dropdown" ng-if="$ctrl.dropdown">
+      <span class="link" ng-click="$ctrl.toggleState('loadout-builder')" translate="LB.LB"></span>
+      <span class="link" ng-click="$ctrl.toggleState('record-books')" translate="RecordBooks"></span>
+      <span class="link" ng-if="::$ctrl.featureFlags.vendorsEnabled" ng-class="{disabled: !$ctrl.vendorService.vendorsLoaded}" ng-click="$ctrl.toggleState('vendors')" translate="Vendors"></span>
+      <span class="link" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>
+      <hr>
+      <span class="link" ng-click="$ctrl.toggleState('storage')" translate="Storage"></span>
+      <span class="link" ng-click="$ctrl.showSetting($event)" translate="Settings"></span>
+      <hr>
+      <span class="link" ng-click="$ctrl.showAbout($event)" translate="Header.About"></span>
+      <span class="link" ng-click="$ctrl.showSupport($event)" translate="Header.SupportDIM"></span>
+      <a class="link" target="_blank" rel="noopener noreferrer" href="https://teespring.com/stores/dim" translate="Header.Shop"></a>
+    </div>
+  </span>
+
+  <img class="logo link" ng-class="::$ctrl.$DIM_FLAVOR" ui-sref="inventory" title="v{{::$ctrl.$DIM_VERSION}} ({{::$ctrl.$DIM_FLAVOR}})" src="~app/images/logo-type-right-light.svg" alt="DIM"/>
+  <span class="link first-to-go" ng-click="$ctrl.showAbout($event)" translate="Header.About"></span>
+  <span class="link first-to-go" ng-click="$ctrl.showSupport($event)" translate="Header.SupportDIM"></span>
+  <a class="link first-to-go" target="_blank" rel="noopener noreferrer" href="https://teespring.com/stores/dim" translate="Header.Shop"></a>
+  <span class="link first-to-go header-separator"></span>
+  <span class="link second-to-go" ng-click="$ctrl.toggleState('loadout-builder')" translate="LB.LB"></span>
+  <span class="link second-to-go" ng-click="$ctrl.toggleState('record-books')" translate="RecordBooks"></span>
+  <span class="link second-to-go" ng-if="::$ctrl.featureFlags.vendorsEnabled" ng-class="{disabled: !$ctrl.vendorService.vendorsLoaded}" ng-click="$ctrl.toggleState('vendors')" translate="Vendors"></span>
+  <span class="link second-to-go" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>
+
+  <span class="header-right">
+    <refresh-stores class="link"></refresh-stores>
+    <span class="link" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
+    <span class="link" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
+    <span class="link search-link">
+      <span class="filter-help" ng-click="$ctrl.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-question-circle-o"></i></span>
+      <dim-search-filter></dim-search-filter>
     </span>
-    <img class="logo link" ng-class="::$ctrl.$DIM_FLAVOR" ui-sref="inventory" title="v{{::$ctrl.$DIM_VERSION}} ({{::$ctrl.$DIM_FLAVOR}})" src="~app/images/logo-type-right-light.svg" alt="DIM"/>
-    <span class="link" ng-click="$ctrl.showAbout($event)" translate="Header.About"></span>
-    <span class="link" ng-click="$ctrl.showSupport($event)" translate="Header.SupportDIM"></span>
-    <a class="link" target="_blank" rel="noopener noreferrer" href="https://teespring.com/stores/dim" translate="Header.Shop"></a>
-    <span class="link header-separator"></span>
-    <span class="link" ng-click="$ctrl.toggleState('loadout-builder')" translate="LB.LB"></span>
-    <span class="link" ng-click="$ctrl.toggleState('record-books')" translate="RecordBooks"></span>
-    <span class="link" ng-if="::$ctrl.featureFlags.vendorsEnabled" ng-class="{disabled: !$ctrl.vendorService.vendorsLoaded}" ng-click="$ctrl.toggleState('vendors')" translate="Vendors"></span>
-    <span class="link" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>
-  </div>
+    <dim-platform-choice platforms="$ctrl.platforms" current="$ctrl.currentPlatform" on-platform-change="$ctrl.platformChange(platform)" class="header-right"></dim-platform-choice>
+  </span>
 </div>
-<div id="content" class="content" ui-view></div>
+
+<div id="content" ui-view></div>
 <div class="store-bounds"></div>
 <dim-manifest-progress></dim-manifest-progress>
 <div class="random-loadout" ng-controller="dimRandomCtrl as random">

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -4,7 +4,6 @@
       <dim-platform-choice platforms="$ctrl.platforms" current="$ctrl.currentPlatform" on-platform-change="$ctrl.platformChange(platform)" class="header-right"></dim-platform-choice>
       <div class="header-right" id="actions">
         <refresh-stores class="link"></refresh-stores>
-        <span class="link" ng-click="$ctrl.toggleState('loadout-builder')" translate-attr="{ title: 'LB'}"><i class="fa fa-bar-chart"></i></span>
         <span class="link" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
         <span class="link" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
         <span class="link search-link">
@@ -18,6 +17,7 @@
     <span class="link" ng-click="$ctrl.showSupport($event)" translate="Header.SupportDIM"></span>
     <a class="link" target="_blank" rel="noopener noreferrer" href="https://teespring.com/stores/dim" translate="Header.Shop"></a>
     <span class="link header-separator"></span>
+    <span class="link" ng-click="$ctrl.toggleState('loadout-builder')" translate="LB.LB"></span>
     <span class="link" ng-click="$ctrl.toggleState('record-books')" translate="RecordBooks"></span>
     <span class="link" ng-if="::$ctrl.featureFlags.vendorsEnabled" ng-class="{disabled: !$ctrl.vendorService.vendorsLoaded}" ng-click="$ctrl.toggleState('vendors')" translate="Vendors"></span>
     <span class="link" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>

--- a/src/scripts/shell/platform-choice/platform-choice.html
+++ b/src/scripts/shell/platform-choice/platform-choice.html
@@ -1,5 +1,5 @@
 <div class="platform-choice">
-  <span ng-if="$ctrl.current" id="user">{{ $ctrl.current.id }}</span>
+  <span ng-if="$ctrl.current" class="first-to-go" id="user">{{ $ctrl.current.id }}</span>
   <select id="system" ng-if="$ctrl.platforms.length > 1" ng-model="$ctrl.current"
     ng-options="platform.label for platform in $ctrl.platforms track by platform.type"
     ng-change="$ctrl.change($ctrl.current)"></select>

--- a/src/scripts/store/dimStores.directive.html
+++ b/src/scripts/store/dimStores.directive.html
@@ -1,4 +1,4 @@
-<div ng-if="vm.stores.length" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems }">
+<div ng-if="vm.stores.length" class="inventory-content" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems }">
   <div class="store-row store-header">
     <div class="store-cell" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">
       <dim-store-heading class="character" ng-class="{ current: store.current }" store-data="store"></dim-store-heading>

--- a/src/scripts/vendors/vendors.html
+++ b/src/scripts/vendors/vendors.html
@@ -4,31 +4,29 @@
 
   <div id="vendorHeadersBackground" class="vendor-headers-background"></div>
   <div id="vendorHeaderWrapper" class="vendorHeaderWrapper">
-    <div class="vendorLabels">
+    <div class="vendorTabs">
       <h1 translate="Vendors"></h1>
-      <div class="vendorTabs">
-        <label ng-class="{ active: vm.activeTab === '' }">
-          <input type="radio" ng-model="vm.activeTab" value=""><span translate="Vendors.All"></span>
-        </label>
-        <label ng-class="{ active: vm.activeTab === 'hasArmorWeaps' }">
-          <input type="radio" ng-model="vm.activeTab" value="hasArmorWeaps"><span translate="Vendors.ArmorAndWeapons"></span>
-        </label>
-        <label ng-class="{ active: vm.activeTab === 'hasConsumables' }">
-          <input type="radio" ng-model="vm.activeTab" value="hasConsumables"><span translate="Vendors.Consumables"></span>
-        </label>
-        <label ng-class="{ active: vm.activeTab === 'hasBounties' }">
-          <input type="radio" ng-model="vm.activeTab" value="hasBounties"><span translate="Vendors.Bounties"></span>
-        </label>
-        <label ng-class="{ active: vm.activeTab === 'hasVehicles' }">
-          <input type="radio" ng-model="vm.activeTab" value="hasVehicles"><span translate="Vendors.ShipsAndVehicles"></span>
-        </label>
-        <label ng-class="{ active: vm.activeTab === 'hasShadersEmbs' }">
-          <input type="radio" ng-model="vm.activeTab" value="hasShadersEmbs"><span translate="Vendors.ShadersAndEmblems"></span>
-        </label>
-        <label ng-class="{ active: vm.activeTab === 'hasEmotes' }">
-          <input type="radio" ng-model="vm.activeTab" value="hasEmotes"><span translate="Vendors.Emotes"></span>
-        </label>
-      </div>
+      <label ng-class="{ active: vm.activeTab === '' }">
+        <input type="radio" ng-model="vm.activeTab" value=""><span translate="Vendors.All"></span>
+      </label>
+      <label ng-class="{ active: vm.activeTab === 'hasArmorWeaps' }">
+        <input type="radio" ng-model="vm.activeTab" value="hasArmorWeaps"><span translate="Vendors.ArmorAndWeapons"></span>
+      </label>
+      <label ng-class="{ active: vm.activeTab === 'hasConsumables' }">
+        <input type="radio" ng-model="vm.activeTab" value="hasConsumables"><span translate="Vendors.Consumables"></span>
+      </label>
+      <label ng-class="{ active: vm.activeTab === 'hasBounties' }">
+        <input type="radio" ng-model="vm.activeTab" value="hasBounties"><span translate="Vendors.Bounties"></span>
+      </label>
+      <label ng-class="{ active: vm.activeTab === 'hasVehicles' }">
+        <input type="radio" ng-model="vm.activeTab" value="hasVehicles"><span translate="Vendors.ShipsAndVehicles"></span>
+      </label>
+      <label ng-class="{ active: vm.activeTab === 'hasShadersEmbs' }">
+        <input type="radio" ng-model="vm.activeTab" value="hasShadersEmbs"><span translate="Vendors.ShadersAndEmblems"></span>
+      </label>
+      <label ng-class="{ active: vm.activeTab === 'hasEmotes' }">
+        <input type="radio" ng-model="vm.activeTab" value="hasEmotes"><span translate="Vendors.Emotes"></span>
+      </label>
     </div>
   </div>
   <div class="vendors" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems }">

--- a/src/scripts/vendors/vendors.scss
+++ b/src/scripts/vendors/vendors.scss
@@ -1,32 +1,36 @@
 .vendor {
   max-width: 900px;
-  min-width: 450px;
   margin: 0 auto;
 
-  .vendors {
-    margin-top: 44px;
-  }
-  .vendorLabels h1 {
-    display: inline-block;
-    margin-bottom: 5px;
-    margin-top: 5px;
-  }
   .vendorTabs {
-    float:right;
-    display:inline-block;
-  }
-  .vendorTabs label {
-    display: inline-block;
-    margin-left: 20px;
-    margin-top: 15px;
-    font-weight:400;
-    font-size:1.3em;
-    cursor: pointer;
-    &.active {
-      color: #FB9F28
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin: 10px 0;
+
+    h1 {
+      display: inline-block;
+      margin: 0;
+      line-height: 1em;
     }
-    & input {
-      display: none;
+
+    label {
+      display: inline-block;
+      font-weight: 400;
+      font-size: 15px;
+      cursor: pointer;
+      text-align: center;
+      &.active {
+        color: #FB9F28
+      }
+      & input {
+        display: none;
+      }
+      @media (max-width: 680px) {
+        font-size: 12px;
+        margin-left: 8px;
+      }
     }
   }
   .vendor-char-items {
@@ -45,6 +49,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    position: relative;
   }
   .category-title {
     margin-top: 10px;
@@ -71,13 +76,18 @@
     z-index: 4;
   }
   .vendorHeaderWrapper {
-    position: absolute;
-    top: 72px;
     z-index: 4;
   }
   .vendorHeaderWrapper.sticky {
     position:fixed;
     top: 42px;
+    max-width: 900px;
+    width: 100%;
+
+    @supports (position: sticky) {
+      position: sticky;
+      top: 50px;
+    }
   }
   .vendor-headers-background.sticky {
     display: block;
@@ -161,6 +171,8 @@
   width: calc(var(--item-size) + 4px);
   height: calc(var(--item-size) + 4px);
   position: absolute;
+  top: 0;
+  left: 2px;
   pointer-events: none;
   z-index: 1;
   background-color: rgba(40,40,40,0.5);

--- a/src/scss/_ngdialog.scss
+++ b/src/scss/_ngdialog.scss
@@ -31,6 +31,11 @@
       background-color: #222;
       border: solid 1px #3e3e3e;
       height: 70%;
+
+      @media (max-width: 800px) {
+        max-width: 100%;
+        height: 100%;
+      }
     }
   }
 }
@@ -54,6 +59,11 @@
   background: transparent;
   color: #e0e0e0;
   border: 0;
+
+
+  @media (max-width: 800px) {
+    top: 7px;
+  }
 
   &:hover {
     color: $orange;
@@ -113,6 +123,12 @@
     padding: 15px;
     font-weight: 200;
     background-color: #101010;
+
+    @media (max-width: 800px) {
+      font-size: 20px;
+      padding: 8px 15px;
+
+    }
   }
   h2 {
     margin-top: 0;

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -102,44 +102,46 @@ div:focus, span:focus {
 }
 
 #header {
-  #user {
-    color: white;
-  }
-  .fa {
-    font-size: 15px;
-    color: #fafafa;
-  }
-  .content {
-    margin: 0 auto;
-    padding: 8px 1em;
-    > {
-      .link, .header-right {
-        margin-top: 1px;
-      }
-    }
-    span, a, img {
-      vertical-align: middle;
-      margin: 0 6px;
-      text-decoration: none;
-      display: inline-block;
-      font-size: 13px;
-      line-height: 25px;
-      text-align: center;
-      -webkit-touch-callout: none;
-      user-select: none;
-      outline: none;
-    }
-  }
+  padding: 0 1em;
   position: fixed;
-  z-index: 5;
+  z-index: 15;
   top: 0;
   left: 0;
   right: 0;
   height: 42px;
   background-color: #222;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  #user {
+    color: white;
+  }
+  .fa {
+    font-size: 20px;
+    color: #fafafa;
+    &:hover {
+      color: $orange;
+      cursor: pointer;
+    }
+  }
+
+  span, a, img {
+    margin: 0 6px;
+    text-decoration: none;
+    font-size: 13px;
+    -webkit-touch-callout: none;
+    user-select: none;
+    outline: none;
+    white-space: nowrap;
+  }
+
   .header-right {
     cursor: default;
-    float: right;
+    display: flex;
+    margin-left: auto;
+    align-items: center;
+    flex-direction: row;
   }
   .header-separator {
       display: inline;
@@ -147,15 +149,53 @@ div:focus, span:focus {
       height: 16px;
       border-right: 1px solid #6f7070;
   }
-}
+  .dropdown {
+    position: absolute;
+    display: block;
+    overflow: auto;
+    top: 42px;
+    left: 0;
+    margin: 0;
+    padding: 0;
+    min-width: 150px;
+    background-color: #222;
+    padding-bottom: 4px;
 
-#actions {
-  margin-top: 1px;
-  .fa {
-    font-size: 20px;
-    &:hover {
-      color: $orange;
-      cursor: pointer;
+    hr {
+      margin: 2px 0;
+      border: none;
+      border-top: 1px solid #333;
+    }
+
+    .link {
+      display: block;
+      padding: 4px 1em;
+      margin: 0;
+
+      &:hover, &:focus {
+        background-color: #151515;
+      }
+    }
+  }
+
+  .first-to-go {
+    @media (max-width: 1100px) {
+      display: none;
+    }
+  }
+
+  .second-to-go {
+    @media (max-width: 800px) {
+      display: none;
+    }
+  }
+
+  .menu {
+    display: none;
+    margin-right: none;
+
+    @media (max-width: 1100px) {
+      display: block;
     }
   }
 }
@@ -171,11 +211,15 @@ div:focus, span:focus {
 
 #filter-input {
   width: 250px;
-  margin-left: -3gpx;
-  margin-bottom: 4px;
+  margin-left: -3px;
+  margin-top: 4px;
   padding-right: 20px;
   border-radius: 0;
   -webkit-appearance: none;
+
+  @media (max-width: 1100px) {
+    width: 175px;
+  }
 }
 
 dt {
@@ -196,7 +240,7 @@ dd {
 .filter-help {
   position: absolute;
   right: -4px;
-  top: 1px;
+  top: 6px;
   .fa {
     font-size: 16px !important;
     color: #999 !important;
@@ -262,21 +306,16 @@ body {
 
 #system {
   outline: none;
-  margin-top: 1px;
   background-color: #fafafa;
-}
-
-input, select, option {
-  font-family: 'Open Sans', sans-serif;
-}
-
-#system {
   float: right;
-  margin-right: 5px;
   cursor: pointer;
   option {
     cursor: pointer;
   }
+}
+
+input, select, option {
+  font-family: 'Open Sans', sans-serif;
 }
 
 input[type="search"] {
@@ -1163,7 +1202,7 @@ g {
   user-select: none;
 }
 
-.content {
+.inventory-content {
   // This assumes 3 characters
   min-width: calc((52px + 44px + (3 * (44px + 8px))) * 3 + 39px + 44px + (3 * (44px + 8px)));
   max-width: calc((52px + 44px + (3 * (44px + 8px))) * 3 + 20px + (999 * (44px + 8px)));
@@ -1175,6 +1214,9 @@ g {
   display: block;
   // 84px margin to make room for the fixed header
   margin-top: 84px;
+  @supports (position: sticky) {
+    margin-top: 0;
+  }
 }
 
 .store-bounds {
@@ -1242,8 +1284,12 @@ g {
 .store-header {
   position: fixed;
   backface-visibility: hidden;
-  top: 53px;
+  top: 55px;
+  left: 0;
   z-index: 10;
+  @supports (position: sticky) {
+    position: sticky;
+  }
 }
 
 .store-header {


### PR DESCRIPTION
This is a handful of experiments in making things more responsive and ergonomic on phone sized devices. Still requires zooming to be totally effective, but it takes off some sharp edges:

1. The loadout builder has been moved to a text link in the header.
3. The header has been redone with a bit of flexbox.
2. When the screen gets smaller, links get moved into a hamburger menu, in two stages. Your username also disappears and the search box gets skinnier.
3. Scrolling right and left in the inventory screen now brings your characters with you as you scroll, instead of having them be mismatched (except maybe on Edge).
4. Many pages no longer require zooming and will try to crunch themselves instead (vendors, record books, loadout builder).
5. Dialogs like settings now stretch to fill the screen, so you can actually use them.

This is still pretty ad-hoc - I'd want to formalize some mixins we could use and actually try to get a design together that works (probably with different approaches to portrait and landscape) but this seems better than before?

![dialog-size](https://user-images.githubusercontent.com/313208/27946693-bd270d98-62a7-11e7-9109-b55647f5dcbf.gif)
![dropdown](https://user-images.githubusercontent.com/313208/27946694-bd29a4a4-62a7-11e7-8200-d5146587a06d.gif)
![ios-horizscroll](https://user-images.githubusercontent.com/313208/27946692-bd2545ee-62a7-11e7-9f7c-08efd6429de3.gif)

<img width="680" alt="screen shot 2017-07-06 at 11 56 35 pm" src="https://user-images.githubusercontent.com/313208/27946525-15760b1c-62a7-11e7-91f4-c265223d6bb4.png">
<img width="680" alt="screen shot 2017-07-06 at 11 56 43 pm" src="https://user-images.githubusercontent.com/313208/27946527-15795bc8-62a7-11e7-8538-37c6063acfd4.png">
<img width="680" alt="screen shot 2017-07-06 at 11 56 49 pm" src="https://user-images.githubusercontent.com/313208/27946529-158a27dc-62a7-11e7-90ed-63e82cf6ecf3.png">
<img width="680" alt="screen shot 2017-07-06 at 11 57 06 pm" src="https://user-images.githubusercontent.com/313208/27946526-157941d8-62a7-11e7-867f-c98c3f78d7e2.png">
<img width="562" alt="screen shot 2017-07-06 at 11 58 34 pm" src="https://user-images.githubusercontent.com/313208/27946530-158be69e-62a7-11e7-99a7-d27b86da49b8.png">





