### PR TITLE
Fix info popup hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add a "sort by name" option for item sorting.
 * In Google Chrome (and the next version of Firefox), your local DIM data won't be deleted by the browser in low storage situations if you visit DIM frequently.
 * Ratings will no longer disappear from the item details popup the second time it is shown.
+* Info popups should do a better job of hiding when you ask them to hide.
 
 # 4.2.4
 

--- a/src/scripts/services/dimInfoService.factory.js
+++ b/src/scripts/services/dimInfoService.factory.js
@@ -16,7 +16,7 @@ function InfoService(toaster, $translate, SyncService) {
       content.func = content.func || function() {};
       content.hideable = content.hideable === undefined ? true : content.hideable;
 
-      function showToaster(body, save, timeout) {
+      function showToaster(body, timeout) {
         timeout = timeout || 0;
 
         body = `<p>${body}</p>`;
@@ -39,8 +39,9 @@ function InfoService(toaster, $translate, SyncService) {
           },
           onHideCallback: function() {
             if ($(`#info-${id}`).is(':checked')) {
-              save[`info.${id}`] = 1;
-              SyncService.set(save);
+              SyncService.set({
+                [`info.${id}`]: 1
+              });
             }
           }
         });
@@ -51,11 +52,11 @@ function InfoService(toaster, $translate, SyncService) {
           if (!data || data[`info.${id}`]) {
             return;
           }
-          showToaster(content.body, data, timeout);
+          showToaster(content.body, timeout);
           content.func();
         });
       } else {
-        showToaster(content.body, {}, timeout);
+        showToaster(content.body, timeout);
         content.func();
       }
     },


### PR DESCRIPTION
Looks like we could get into situations where the info popup would never hide (like the new "we're a website now" popup). Simplifying the info service fixes this.