### PR TITLE
Editing user reviews

### DIFF
--- a/src/scripts/destinyTrackerApi/reviewDataCache.js
+++ b/src/scripts/destinyTrackerApi/reviewDataCache.js
@@ -115,6 +115,21 @@ class ReviewDataCache {
     return this._itemStores;
   }
 
+  markItemAsReviewedAndSubmitted(item,
+                                 userReview) {
+    const matchingItem = this._getMatchingItem(item);
+
+    if (matchingItem.reviews) {
+      matchingItem.reviews = _.find(matchingItem.reviews, { isReviewer: false });
+    }
+
+    if (!matchingItem.reviews) {
+      matchingItem.reviews = [];
+    }
+
+    matchingItem.reviews.unshift(userReview);
+  }
+
   /**
    * There's a 10 minute delay between posting an item review to the DTR API
    * and being able to fetch that review from it.

--- a/src/scripts/destinyTrackerApi/reviewDataCache.js
+++ b/src/scripts/destinyTrackerApi/reviewDataCache.js
@@ -76,6 +76,8 @@ class ReviewDataCache {
                     userReview) {
     const matchingItem = this._getMatchingItem(item);
 
+    this._markItemAsLocallyCached(item, true);
+
     const rating = matchingItem.rating;
 
     Object.assign(matchingItem,
@@ -115,8 +117,21 @@ class ReviewDataCache {
     return this._itemStores;
   }
 
+  /**
+   * Should we consider this item locally cached with changes?
+   * 
+   * @param {any} item 
+   * @param {bool} isCached 
+   * @memberof ReviewDataCache
+   */
+  _markItemAsLocallyCached(item,
+                           isCached) {
+    item.isLocallyCached = isCached;
+  }
+
   markItemAsReviewedAndSubmitted(item,
                                  userReview) {
+    this._markItemAsLocallyCached(item, false);
     const matchingItem = this._getMatchingItem(item);
 
     if (matchingItem.reviews) {

--- a/src/scripts/destinyTrackerApi/reviewDataCache.js
+++ b/src/scripts/destinyTrackerApi/reviewDataCache.js
@@ -135,7 +135,7 @@ class ReviewDataCache {
     const matchingItem = this._getMatchingItem(item);
 
     if (matchingItem.reviews) {
-      matchingItem.reviews = _.find(matchingItem.reviews, { isReviewer: false });
+      matchingItem.reviews = _.reject(matchingItem.reviews, { isReviewer: true });
     }
 
     if (!matchingItem.reviews) {

--- a/src/scripts/destinyTrackerApi/reviewDataCache.js
+++ b/src/scripts/destinyTrackerApi/reviewDataCache.js
@@ -117,13 +117,6 @@ class ReviewDataCache {
     return this._itemStores;
   }
 
-  /**
-   * Should we consider this item locally cached with changes?
-   *
-   * @param {any} item
-   * @param {bool} isCached
-   * @memberof ReviewDataCache
-   */
   _markItemAsLocallyCached(item,
                            isCached) {
     item.isLocallyCached = isCached;
@@ -137,8 +130,7 @@ class ReviewDataCache {
     if (matchingItem.reviews) {
       matchingItem.reviews = _.reject(matchingItem.reviews, { isReviewer: true });
     }
-
-    if (!matchingItem.reviews) {
+    else {
       matchingItem.reviews = [];
     }
 

--- a/src/scripts/destinyTrackerApi/reviewDataCache.js
+++ b/src/scripts/destinyTrackerApi/reviewDataCache.js
@@ -119,9 +119,9 @@ class ReviewDataCache {
 
   /**
    * Should we consider this item locally cached with changes?
-   * 
-   * @param {any} item 
-   * @param {bool} isCached 
+   *
+   * @param {any} item
+   * @param {bool} isCached
    * @memberof ReviewDataCache
    */
   _markItemAsLocallyCached(item,

--- a/src/scripts/destinyTrackerApi/reviewSubmitter.js
+++ b/src/scripts/destinyTrackerApi/reviewSubmitter.js
@@ -69,13 +69,17 @@ class ReviewSubmitter {
 
   _markItemAsReviewedAndSubmitted(item) {
     const review = this.toRatingAndReview(item);
+    review.isReviewer = true;
+    review.reviewer = this._getReviewer();
+    review.timestamp = new Date().toISOString();
 
     this._reviewDataCache.markItemAsReviewedAndSubmitted(item,
-                                                         userReview);
+                                                         review);
   }
 
   submitReview(item) {
     this._submitReviewPromise(item)
+      .then(this._markItemAsReviewedAndSubmitted(item))
       .then(this._eventuallyPurgeCachedData(item));
   }
 }

--- a/src/scripts/destinyTrackerApi/reviewSubmitter.js
+++ b/src/scripts/destinyTrackerApi/reviewSubmitter.js
@@ -67,6 +67,13 @@ class ReviewSubmitter {
     this._reviewDataCache.eventuallyPurgeCachedData(item);
   }
 
+  _markItemAsReviewedAndSubmitted(item) {
+    const review = this.toRatingAndReview(item);
+
+    this._reviewDataCache.markItemAsReviewedAndSubmitted(item,
+                                                         userReview);
+  }
+
   submitReview(item) {
     this._submitReviewPromise(item)
       .then(this._eventuallyPurgeCachedData(item));

--- a/src/scripts/destinyTrackerApi/reviewsFetcher.js
+++ b/src/scripts/destinyTrackerApi/reviewsFetcher.js
@@ -71,8 +71,8 @@ class ReviewsFetcher {
       item.userRating = cachedItem.userRating;
     }
 
-    if (cachedItem.userReview) {
-      item.userReview = cachedItem.userReview;
+    if (cachedItem.review) {
+      item.userReview = cachedItem.review;
     }
 
     if (cachedItem.pros) {

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -9,7 +9,7 @@ function ItemReviewController(dimSettingsService, dimDestinyTrackerService, $sco
   vm.canCreateReview = (vm.canReview && vm.item.owner);
   vm.submitted = false;
   vm.hasUserReview = vm.item.userRating;
-  vm.expandReview = false;
+  vm.expandReview = vm.item.isLocallyCached;
 
   vm.procon = false; // TODO: turn this back on..
   vm.aggregate = {

--- a/src/scripts/item-review/item-review.component.js
+++ b/src/scripts/item-review/item-review.component.js
@@ -9,7 +9,7 @@ function ItemReviewController(dimSettingsService, dimDestinyTrackerService, $sco
   vm.canCreateReview = (vm.canReview && vm.item.owner);
   vm.submitted = false;
   vm.hasUserReview = vm.item.userRating;
-  vm.expandReview = vm.hasUserReview;
+  vm.expandReview = false;
 
   vm.procon = false; // TODO: turn this back on..
   vm.aggregate = {
@@ -23,6 +23,10 @@ function ItemReviewController(dimSettingsService, dimDestinyTrackerService, $sco
 
   vm.toggleEdit = function() {
     vm.expandReview = !vm.expandReview;
+  };
+
+  vm.editReview = function() {
+    vm.expandReview = true;
   };
 
   vm.submitReview = function() {

--- a/src/scripts/item-review/item-review.html
+++ b/src/scripts/item-review/item-review.html
@@ -72,6 +72,7 @@
       <star-rating rating="review.rating" read-only></star-rating>
       <div ng-bind="review.reviewer.displayName" ng-class="{ 'community-review--who__special': review.isHighlighted }"></div>
       <div ng-bind="review.timestamp | utcToLocal:'mediumDate'"></div>
+      <div ng-if="review.isReviewer"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></div>
     </div>
     <div ng-bind="review.review"></div>
   </div>

--- a/src/scripts/item-review/item-review.html
+++ b/src/scripts/item-review/item-review.html
@@ -72,7 +72,7 @@
       <star-rating rating="review.rating" read-only></star-rating>
       <div ng-bind="review.reviewer.displayName" ng-class="{ 'community-review--who__special': review.isHighlighted }"></div>
       <div ng-bind="review.timestamp | utcToLocal:'mediumDate'"></div>
-      <div ng-if="review.isReviewer"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></div>
+      <div ng-if="review.isReviewer" class="fa fa-pencil-square-o" aria-hidden="true" ng-click="$ctrl.editReview()"></div>
     </div>
     <div ng-bind="review.review"></div>
   </div>

--- a/src/scripts/item-review/item-review.html
+++ b/src/scripts/item-review/item-review.html
@@ -68,12 +68,14 @@
     </div>
   </div>
   <div class="community-review" ng-repeat="review in $ctrl.item.writtenReviews">
-    <div class="community-review--who">
-      <star-rating rating="review.rating" read-only></star-rating>
-      <div ng-bind="review.reviewer.displayName" ng-class="{ 'community-review--who__special': review.isHighlighted }"></div>
-      <div ng-bind="review.timestamp | utcToLocal:'mediumDate'"></div>
-      <div ng-if="review.isReviewer" class="fa fa-pencil-square-o" aria-hidden="true" ng-click="$ctrl.editReview()"></div>
+    <div ng-click="!review.isReviewer || $ctrl.editReview()">
+      <div class="community-review--who">
+        <star-rating rating="review.rating" read-only></star-rating>
+        <div ng-bind="review.reviewer.displayName" ng-class="{ 'community-review--who__special': review.isHighlighted }"></div>
+        <div ng-bind="review.timestamp | utcToLocal:'mediumDate'"></div>
+        <div ng-if="review.isReviewer" class="fa fa-pencil-square-o" aria-hidden="true"></div>
+      </div>
+      <div ng-bind="review.review"></div>
     </div>
-    <div ng-bind="review.review"></div>
   </div>
 </div>


### PR DESCRIPTION
#1829 pointed out that our workflow around editing user reviews was kind of... lacking.

I added a little edit icon to a review that the user submitted and made the whole review element clickable (because leaving the edit icon the sole clickable element would have been hateful UI).

Also there was an outstanding problem of the "grace period" between when we post reviews to the API and when it would reflect those changes.  When you submit, it flushes the user's old review and attaches the new one so that the UI makes it look like it's already there, and you can use the edit UI.

![editing-user-reviews-with-changes](https://user-images.githubusercontent.com/606888/27988662-31209950-63f5-11e7-8535-8977550d5596.gif)

User reviews will be conditionally expanded (if we think there's a locally-changed review).

![editing-user-reviews-with-changes-and-conditional-expansion](https://user-images.githubusercontent.com/606888/27988712-eeaba130-63f6-11e7-8da9-88913ded72f8.gif)

Oh and here's what the edit icon looks along with other reviews.

![reviews-with-edit-icon](https://user-images.githubusercontent.com/606888/27989135-f5583828-63ff-11e7-9130-71ee995134f7.png)
