### PR TITLE
Breaking up long strings in item reviews

### DIFF
--- a/src/scripts/item-review/item-review.html
+++ b/src/scripts/item-review/item-review.html
@@ -73,6 +73,6 @@
       <div ng-bind="review.reviewer.displayName" ng-class="{ 'community-review--who__special': review.isHighlighted }"></div>
       <div ng-bind="review.timestamp | utcToLocal:'mediumDate'"></div>
     </div>
-    <div ng-bind="review.review"></div>
+    <div class="community-review--review" ng-bind="review.review"></div>
   </div>
 </div>

--- a/src/scripts/item-review/item-review.scss
+++ b/src/scripts/item-review/item-review.scss
@@ -58,4 +58,8 @@
   &--who__special {
     color: gold;
   }
+
+  &--review {
+    word-wrap: break-word;
+  }
 }


### PR DESCRIPTION
This addresses long, unbroken strings that sometimes are found in reviews (mostly of Telesto (which you can't blame anyone for because it is the besto)).

This addresses issue #1901

![telesto-is-still-exciting-just-in-a-different-way](https://user-images.githubusercontent.com/606888/27990682-40537eb0-642c-11e7-80ce-26b0ab3bb92e.png)
