### PR TITLE
Wait for settings to be ready before loading manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Fixed a bug where item data would stay in English despite your language settings.
+
 # 4.3.0
 
 * DIM is now just a website - the extension now just sends you to our website. This gives us one, more cross-platform, place to focus on and enables features we couldn't do with just an extension. Don't forget to import your data from the storage page!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next
 
-* Fixed a bug where item data would stay in English despite your language settings.
+* Fixed a bug where item data would not respect your language settings.
 
 # 4.3.0
 

--- a/src/scripts/settings/dimSettingsService.factory.js
+++ b/src/scripts/settings/dimSettingsService.factory.js
@@ -12,10 +12,11 @@ import _ from 'underscore';
  * load in the user's actual settings, so it is a good sidea to
  * always watch the settings you are using.
  */
-export function SettingsService($rootScope, SyncService, $window, $translate) {
+export function SettingsService($rootScope, SyncService, $window, $translate, $q) {
   'ngInject';
 
   let _loaded = false;
+  const _ready = $q.defer();
 
   const destinyLanguages = ['de', 'en', 'fr', 'es', 'it', 'ja', 'pt-br'];
 
@@ -82,7 +83,9 @@ export function SettingsService($rootScope, SyncService, $window, $translate) {
           'settings-v1.0': _.omit(settings, 'save', 'itemTags')
         });
       });
-    }
+    },
+
+    ready: _ready.promise
   };
 
   // Load settings async
@@ -101,6 +104,7 @@ export function SettingsService($rootScope, SyncService, $window, $translate) {
     ];
 
     _loaded = true;
+    _ready.resolve();
 
     $rootScope.$evalAsync(() => {
       angular.merge(settings, savedSettings);


### PR DESCRIPTION
This fixes #1900 which was broken when sync service got more async (and was possibly triggered by optimizations that caused things to load in a different order).