### PR TITLE
update htaccess for ga

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -476,7 +476,7 @@ AddDefaultCharset utf-8
 
 <IfModule mod_headers.c>
 
-    Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' https://apis.google.com https://www.google-analytics.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css; connect-src 'self' https://beta.destinyitemmanager.com https://www.bungie.net https://reviews-api.destinytracker.net; img-src 'self' https://www.bungie.net https://ssl.google-analytics.com https://csi.gstatic.com https://opencollective.com data:; font-src 'self' https://fonts.gstatic.com; child-src 'self' https://accounts.google.com https://content.googleapis.com; object-src 'self'; manifest-src 'self'"
+    Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' https://apis.google.com https://www.google-analytics.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css; connect-src 'self' https://beta.destinyitemmanager.com https://www.bungie.net https://reviews-api.destinytracker.net; img-src 'self' https://www.bungie.net https://ssl.google-analytics.com https://www.google-analytics.com https://csi.gstatic.com https://opencollective.com data:; font-src 'self' https://fonts.gstatic.com; child-src 'self' https://accounts.google.com https://content.googleapis.com; object-src 'self'; manifest-src 'self'"
 
     # `mod_headers` cannot match based on the content-type, however,
     # the `Content-Security-Policy` response header should be send


### PR DESCRIPTION
Fix for 

Refused to load the image 'https://www.google-analytics.com/r/collect?v=1&_v=j56&a=533351986&t=pagevie…38.1492939228&tid=UA-60316581-1&_gid=658226596.1499572245&_r=1&z=814361045' because it violates the following Content Security Policy directive: "img-src 'self' https://www.bungie.net https://ssl.google-analytics.com https://csi.gstatic.com https://opencollective.com data:".

in beta .1107 due to recent change for google-analytics...