### PR TITLE
Clean up activities

### DIFF
--- a/src/scripts/activities/activities.component.js
+++ b/src/scripts/activities/activities.component.js
@@ -10,12 +10,6 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
 
   vm.settings = dimSettingsService;
 
-  // TODO: it's time for a directive
-  vm.toggleSection = function(id) {
-    vm.settings.collapsedSections[id] = !vm.settings.collapsedSections[id];
-    vm.settings.save();
-  };
-
   vm.settingsChanged = function() {
     vm.settings.save();
   };
@@ -71,11 +65,13 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
   });
 
   function processActivities(defs, stores, rawActivity) {
+    const def = defs.Activity.get(rawActivity.display.activityHash);
     const activity = {
       hash: rawActivity.display.activityHash,
-      name: defs.Activity[rawActivity.display.activityHash].activityName,
+      name: def.activityName,
       icon: rawActivity.display.icon,
       image: rawActivity.display.image,
+      type: defs.ActivityType.get(def.activityTypeHash).activityTypeName
     };
 
     if (rawActivity.extended) {
@@ -104,7 +100,7 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
   }
 
   function processActivity(defs, activityId, stores, tier, index) {
-    const tierDef = defs.Activity[tier.activityHash];
+    const tierDef = defs.Activity.get(tier.activityHash);
 
     const name = tier.activityData.recommendedLight === 390 ? 390
       : (tier.tierDisplayName ? $translate.instant(`Activities.${tier.tierDisplayName}`) : tierDef.activityName);
@@ -160,11 +156,11 @@ function ActivitiesController($scope, dimStoreService, dimDefinitions, dimSettin
       hash = hash.length ? hash[0].hash : -1;
       if (hash >= 0) {
         if (hash < 20) { // set all skulls except for epic from heroic playlist...
-          skulls[0][i].displayName = defs.Activity[870614351].skulls[hash].displayName;
-          skulls[0][i].description = defs.Activity[870614351].skulls[hash].description;
+          skulls[0][i].displayName = defs.Activity.get(870614351).skulls[hash].displayName;
+          skulls[0][i].description = defs.Activity.get(870614351).skulls[hash].description;
         } else { // set Epic skull based off of a nightfall
-          skulls[0][i].displayName = defs.Activity[2234107290].skulls[0].displayName;
-          skulls[0][i].description = defs.Activity[2234107290].skulls[0].description;
+          skulls[0][i].displayName = defs.Activity.get(2234107290).skulls[0].displayName;
+          skulls[0][i].description = defs.Activity.get(2234107290).skulls[0].description;
         }
       }
     }

--- a/src/scripts/activities/activities.html
+++ b/src/scripts/activities/activities.html
@@ -1,11 +1,12 @@
-<back-link></back-link>
-
 <div class="activities">
+  <back-link></back-link>
   <div class="activity" ng-repeat="activity in $ctrl.activities track by $index">
 
     <div class="activity-header">
       <div class="activity-title" ng-style="::activity.image | bungieBackground" ng-class="{ 'activity-featured': activity.featured }">
-        <img class="small-icon" ng-src="{{ ::activity.icon | bungieIcon }}" /> {{ ::activity.name }} <i ng-if="::activity.featured"  class="fa fa-star"></i>
+        <img class="small-icon" ng-src="{{ ::activity.icon | bungieIcon }}" />
+        <span class="activity-name">{{ ::activity.name }}</span>
+        <i ng-if="::activity.featured"  class="fa fa-star"></i>
       </div>
     </div>
 

--- a/src/scripts/activities/activities.scss
+++ b/src/scripts/activities/activities.scss
@@ -1,26 +1,26 @@
-back-link {
-  width: 1160px;
-  margin: 0 auto;
-  display: block;
-}
 
 .activities {
-  max-width: 1200px;
+  back-link {
+    width: 100%;
+    margin-left: 20px;
+    display: block;
+  }
+
+  max-width: 1053px;
   margin: 0 auto;
   display: flex;
   flex-wrap: wrap;
 
   .activity {
     margin: 20px;
-    width: 350px;
+    width: 311px;
   }
 
   .activity-header {
     position: relative;
   }
-  .activity-image {
-    position: absolute;
-    width: 100%;
+  .activity-name {
+    text-shadow: 2px 2px 5px black;
   }
   .activity-featured {
     color: gold;

--- a/src/scripts/services/dimDefinitions.factory.js
+++ b/src/scripts/services/dimDefinitions.factory.js
@@ -13,7 +13,9 @@ const lazyTables = [
   'VendorCategory',
   'RecordBook',
   'ActivityCategory',
-  'ScriptedSkull'
+  'ScriptedSkull',
+  'Activity',
+  'ActivityType'
 ];
 
 const eagerTables = [
@@ -21,8 +23,7 @@ const eagerTables = [
   'Class',
   'Race',
   'Faction',
-  'Vendor',
-  'Activity'
+  'Vendor'
 ];
 
 const mod = angular.module('dimApp');

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -273,7 +273,6 @@ h2, h3 {
 
 body {
   overflow-y: auto;
-  min-width: 410px;
   margin: 0 auto;
   padding-top: 40px;
   background-color: #434444;


### PR DESCRIPTION
This PR contains backport cleanups from my other Activities PR (stuff we should do regardless) as well as making the current Activities page work perfectly on mobile (no side to side scrolling!). Note that I didn't do any breakpoints, so as a result the "panels" are always narrower now - we could introduce breakpoints that reduced padding and such if we wanted. This also likely won't work for screens smaller than iPhone 6.

![screen shot 2017-07-09 at 12 46 04 am](https://user-images.githubusercontent.com/313208/27992086-0fc95a9e-6440-11e7-8215-e2a5d3e7d36a.png)
