### PR TITLE
Responsive improvements

### DIFF
--- a/src/scripts/activities/activities.scss
+++ b/src/scripts/activities/activities.scss
@@ -1,5 +1,4 @@
 back-link {
-  width: 1160px;
   margin: 0 auto;
   display: block;
 }

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -29,9 +29,9 @@
   <span class="link second-to-go" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>
 
   <span class="header-right">
-    <refresh-stores class="link"></refresh-stores>
-    <span class="link" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
-    <span class="link" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
+    <refresh-stores ng-if="@$ctrl.showSearch" class="link"></refresh-stores>
+    <span class="link" ng-if="@$ctrl.showSearch" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
+    <span class="link" ng-if="@$ctrl.showSearch" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
     <span class="link search-link" ng-class="{ show: $ctrl.showSearch }">
       <span class="filter-help" ng-click="$ctrl.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-question-circle-o"></i></span>
       <dim-search-filter></dim-search-filter>

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -30,8 +30,8 @@
 
   <span class="header-right">
     <refresh-stores class="link"></refresh-stores>
-    <span class="link third-to-go" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
-    <span class="link third-to-go" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
+    <span class="link" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
+    <span class="link" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
     <span class="link search-link" ng-class="{ show: $ctrl.showSearch }">
       <span class="filter-help" ng-click="$ctrl.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-question-circle-o"></i></span>
       <dim-search-filter></dim-search-filter>

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -30,12 +30,13 @@
 
   <span class="header-right">
     <refresh-stores class="link"></refresh-stores>
-    <span class="link" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
-    <span class="link" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
-    <span class="link search-link">
+    <span class="link third-to-go" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage'}"><i class="fa fa-save"></i></span>
+    <span class="link third-to-go" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
+    <span class="link search-link" ng-class="{ show: $ctrl.showSearch }">
       <span class="filter-help" ng-click="$ctrl.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-question-circle-o"></i></span>
       <dim-search-filter></dim-search-filter>
     </span>
+    <span class="link search-button" ng-click="$ctrl.showSearch = !$ctrl.showSearch"><i class="fa fa-search"></i></span>
     <dim-platform-choice platforms="$ctrl.platforms" current="$ctrl.currentPlatform" on-platform-change="$ctrl.platformChange(platform)" class="header-right"></dim-platform-choice>
   </span>
 </div>
@@ -43,7 +44,4 @@
 <div id="content" ui-view></div>
 <div class="store-bounds"></div>
 <dim-manifest-progress></dim-manifest-progress>
-<div class="random-loadout" ng-controller="dimRandomCtrl as random">
-  <a class="loadout random" href="#" ng-disabled="random.disableRandomLoadout" ng-if="::random.showRandomLoadout" ng-click="random.applyRandomLoadout($event)">&Pi;</a>
-</div>
 <ng-include ng-if="::$ctrl.featureFlags.colorA11y" src="'data/color-a11y.svg'"></ng-include>

--- a/src/scripts/shell/dimManifestProgress.scss
+++ b/src/scripts/shell/dimManifestProgress.scss
@@ -13,21 +13,21 @@ dim-manifest-progress {
   justify-content: center;
 
   .manifest-progress {
-    width: 24rem;
+    width: 327px;
     display: flex;
     align-items: center;
     flex-direction: column;
     justify-content: center;
     text-align: center;
     font-size: 1rem;
-    padding: 1.5rem 1.5rem;
+    padding: 24px;
     background-color: #222;
     box-shadow: 1px 1px 10px rgba(0, 0, 0, .5);
     white-space: pre-wrap;
 
     i {
-      font-size: 2rem;
-      margin-bottom: .5rem;
+      font-size: 32px;
+      margin-bottom: 8px;
     }
 
     &.ng-animate {

--- a/src/scripts/storage/storage.scss
+++ b/src/scripts/storage/storage.scss
@@ -2,7 +2,6 @@
 
 .storage {
   max-width: 900px;
-  min-width: 450px;
   margin: 0 auto;
 
   h2 {

--- a/src/scripts/store/inventory.html
+++ b/src/scripts/store/inventory.html
@@ -5,4 +5,7 @@
 <dim-item-discuss></dim-item-discuss>
 <div id="drag-help" class="drag-help-hidden" translate="Help.Drag"></div>
 <dim-farming></dim-farming>
-<dim-clear-new-items></dim-clear-new-items>
+<dim-clear-new-items></dim-clear-new-items
+<div class="random-loadout" ng-controller="dimRandomCtrl as random">
+  <a class="loadout random" href="#" ng-disabled="random.disableRandomLoadout" ng-if="::random.showRandomLoadout" ng-click="random.applyRandomLoadout($event)">&Pi;</a>
+</div>>

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -190,6 +190,13 @@ div:focus, span:focus {
     }
   }
 
+  /* OK this is getting silly. Time for some real breakpoints! */
+  .third-to-go {
+    @media (max-width: 375px) {
+      display: none;
+    }
+  }
+
   .menu {
     display: none;
     margin-right: none;
@@ -235,6 +242,43 @@ dd {
 .search-link {
   position: relative;
   top: -2px;
+
+  // Yikes this is a hack
+  @media (max-width: 375px) {
+    display: none;
+
+    &.show {
+      position: absolute;
+      left: 40px;
+      top: 4px;
+      display: block;
+
+      #filter-input {
+        width: 185px;
+        height: 28px;
+      }
+
+      .filter-help {
+        top: 8px;
+      }
+
+      .dim-input {
+        &:hover, &:focus {
+          background-color: #222;
+        }
+      }
+
+      input, select:focus {
+        font-size: 16px; // so iOS doesn't zoom
+      }
+    }
+  }
+}
+.search-button {
+  display: none;
+  @media (max-width: 375px) {
+    display: inline-block;
+  }
 }
 
 .filter-help {
@@ -273,7 +317,6 @@ h2, h3 {
 
 body {
   overflow-y: auto;
-  min-width: 410px;
   margin: 0 auto;
   padding-top: 40px;
   background-color: #434444;

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -190,13 +190,6 @@ div:focus, span:focus {
     }
   }
 
-  /* OK this is getting silly. Time for some real breakpoints! */
-  .third-to-go {
-    @media (max-width: 375px) {
-      display: none;
-    }
-  }
-
   .menu {
     display: none;
     margin-right: none;


### PR DESCRIPTION
This implements a version of the "search button" Kyle's old branch had:

![small-search](https://user-images.githubusercontent.com/313208/27992304-16958fe0-6446-11e7-81f7-1ddd101ead2e.gif)

It'd kind of hardcoded for iPhone 6 sizes, but it's better. I applied some special styles that prevent focusing on the text field from zooming the screen, too. This search field is begging to be broken into its own component.

Other fixes:
1. The manifest loading dialog is no longer larger than the screen on mobile.
2. Storage page no longer defines a too-large min-width.
3. "Random Loadout" has been moved to only appear on the inventory page.