### PR TITLE
Remove Backup/Export on iOS

### DIFF
--- a/src/scripts/storage/storage.component.js
+++ b/src/scripts/storage/storage.component.js
@@ -15,6 +15,9 @@ function StorageController($scope, dimSettingsService, SyncService, GoogleDriveS
   vm.adapterStats = {};
   vm.googleApiBlocked = !window.gapi;
 
+  const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+  vm.supportsExport = !iOS;
+
   function dataStats(data) {
     const taggedItems = sum(Object.keys(data)
                             .filter((k) => k.startsWith('dimItemInfo'))

--- a/src/scripts/storage/storage.html
+++ b/src/scripts/storage/storage.html
@@ -62,7 +62,7 @@
     </button>
   </div>
 
-  <div class="storage-adapter">
+  <div class="storage-adapter" ng-if="$ctrl.supportsExport">
     <h2 translate="Storage.ImportExport"></h2>
     <p>
       <button class="dim-button" ng-click="$ctrl.exportData()">


### PR DESCRIPTION
Not supported (until iOS 11?).

Fixes #1905.