### PR TITLE
compare button now resets the comparisons array

### DIFF
--- a/src/scripts/compare/compare.component.js
+++ b/src/scripts/compare/compare.component.js
@@ -54,7 +54,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, $trans
   };
 
   vm.compareSimilar = function(type) {
-    vm.comparisons = _.union(vm.comparisons, type === 'archetype' ? vm.archeTypes : vm.similarTypes);
+    vm.comparisons = type === 'archetype' ? vm.archeTypes : vm.similarTypes;
   };
 
   vm.sort = function(statHash) {


### PR DESCRIPTION
Previously we would union all of the items in the compare view when you pressed compared within weapon or archetype. Now, when you press compare archetype after comparing all within weapon type it will effectively reset the array to just show the archetype comparison, instead of everything.