### PR TITLE
More responsive fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Logging out now brings you to Bungie's auth page, where you can choose to change account or not.
 * Fixed "Clear New Items" not working.
 * Adjusted the UI a bunch to make it work better on mobile. Just a start - there's still a long way to go.
+* On Firefox, the new-item shines don't extend past the item anymore.
 
 # 4.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12025,8 +12025,8 @@
       "requires": {
         "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
+        "ajv": "5.2.2",
+        "ajv-keywords": "2.1.0",
         "async": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
         "enhanced-resolve": "3.3.0",
         "escope": "3.6.0",
@@ -12039,12 +12039,100 @@
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "node-libs-browser": "2.0.0",
         "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-        "supports-color": "4.0.0",
+        "supports-color": "3.2.3",
         "tapable": "0.2.6",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.3.1",
         "webpack-sources": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+          "dev": true,
+          "requires": {
+            "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+          "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "4.2.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
       }
     },
     "webpack-bundle-analyzer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3216,8 +3216,9 @@
       }
     },
     "extract-text-webpack-plugin": {
-      "version": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
-      "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha1-kMqnkHvESfM1AF46x1MrQbAN5hI=",
       "dev": true,
       "requires": {
         "async": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-import": "^2.7.0",
     "exports-loader": "^0.6.3",
     "extract-loader": "^0.1.0",
-    "extract-text-webpack-plugin": "^2.0.0",
+    "extract-text-webpack-plugin": "^3.0.0",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-compress": "^1.3.0",

--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -87,7 +87,8 @@
       "FilterHelp": "Search item/perk or is:arc",
       "Refresh": "Refresh Destiny Data",
       "SupportDIM": "Backers",
-      "Shop": "Shop"
+      "Shop": "Shop",
+      "Inventory": "Inventory"
    },
    "Help": {
       "BackToDIM": "Back to DIM",

--- a/src/scripts/record-books/record-books.scss
+++ b/src/scripts/record-books/record-books.scss
@@ -25,7 +25,7 @@
 
   .record-book-page {
     background: #555;
-    margin: 10px 10px 0 10px;
+    margin: 8px 0 0 0;
     padding: 8px;
 
     .record-book-page-title {
@@ -68,6 +68,10 @@
     display: flex;
     flex-direction: row;
 
+    @media(max-width: 375px) {
+      width: 100%;
+    }
+
     h3 {
       margin: 0;
       font-size: 16px;
@@ -103,6 +107,7 @@
     background-size: 75%;
     width: 60px;
     height: 60px;
+    flex-shrink: 0;
     border: 2px solid #fff;
   }
 

--- a/src/scripts/record-books/record-books.scss
+++ b/src/scripts/record-books/record-books.scss
@@ -1,3 +1,5 @@
+@import '../../scss/variables.scss';
+
 .record-books {
   max-width: 900px;
   margin: 0 auto;
@@ -68,7 +70,7 @@
     display: flex;
     flex-direction: row;
 
-    @media (max-width: 375px) {
+    @include phone-portrait {
       width: 100%;
     }
 

--- a/src/scripts/record-books/record-books.scss
+++ b/src/scripts/record-books/record-books.scss
@@ -68,7 +68,7 @@
     display: flex;
     flex-direction: row;
 
-    @media(max-width: 375px) {
+    @media (max-width: 375px) {
       width: 100%;
     }
 

--- a/src/scripts/shell/content/content.html
+++ b/src/scripts/shell/content/content.html
@@ -2,14 +2,15 @@
   <span class="menu link" ng-click="$ctrl.dropdown = !$ctrl.dropdown" dim-click-anywhere-but-here="$ctrl.dropdown = false">
     <i class="fa fa-bars"></i>
     <div class="dropdown" ng-if="$ctrl.dropdown">
+      <span class="link" ui-sref="inventory" translate="Header.Inventory"></span>
       <span class="link" ng-click="$ctrl.toggleState('loadout-builder')" translate="LB.LB"></span>
       <span class="link" ng-if="::$ctrl.featureFlags.vendorsEnabled" ng-class="{disabled: !$ctrl.vendorService.vendorsLoaded}" ng-click="$ctrl.toggleState('vendors')" translate="Vendors"></span>
       <span class="link" ng-click="$ctrl.toggleState('record-books')" translate="RecordBooks"></span>
       <span class="link" ng-if="::$ctrl.featureFlags.activities" ng-click="$ctrl.toggleState('activities')" translate="Activities"></span>
       <span class="link" ng-if="$ctrl.xur.available" ng-click="$ctrl.showXur($event)">Xûr</span>
       <hr>
-      <span class="link" ng-click="$ctrl.toggleState('storage')" translate="Storage"></span>
-      <span class="link" ng-click="$ctrl.showSetting($event)" translate="Settings"></span>
+      <span class="link" ng-click="$ctrl.toggleState('storage')" translate="Storage.Title"></span>
+      <span class="link" ng-click="$ctrl.showSetting($event)" translate="Settings.Settings"></span>
       <hr>
       <span class="link" ng-click="$ctrl.showAbout($event)" translate="Header.About"></span>
       <span class="link" ng-click="$ctrl.showSupport($event)" translate="Header.SupportDIM"></span>
@@ -31,7 +32,7 @@
   <span class="header-right">
     <refresh-stores ng-if="!$ctrl.showSearch" class="link"></refresh-stores>
     <span class="link" ng-if="!$ctrl.showSearch" ng-click="$ctrl.toggleState('storage')" translate-attr="{ title: 'Storage.Title'}"><i class="fa fa-save"></i></span>
-    <span class="link" ng-if="!$ctrl.showSearch" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings'}"><i class="fa fa-cog"></i></span>
+    <span class="link" ng-if="!$ctrl.showSearch" ng-click="$ctrl.showSetting($event)" translate-attr="{ title: 'Settings.Settings'}"><i class="fa fa-cog"></i></span>
     <span class="link search-link" ng-class="{ show: $ctrl.showSearch }">
       <span class="filter-help" ng-click="$ctrl.showFilters($event)" translate-attr="{ title: 'Header.Filters'}"><i class="fa fa-question-circle-o"></i></span>
       <dim-search-filter></dim-search-filter>

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -102,7 +102,7 @@ div:focus, span:focus {
 }
 
 #header {
-  padding: 0 1em;
+  padding: 0 8px;
   position: fixed;
   z-index: 15;
   top: 0;
@@ -1233,7 +1233,7 @@ g {
 
 #content {
   margin: 15px auto;
-  padding: 0 1em;
+  padding: 0 8px;
   margin-top: 15px;
   user-select: none;
 }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -56,10 +56,10 @@ div:focus, span:focus {
 }
 
 .new_overlay {
-  @include item-size;
+  @include item-size-padded;
   position: absolute;
-  top: 2px;
-  left: 2px;
+  top: 0;
+  left: 0;
   pointer-events: none;
   .new-item-animated & {
     will-change: transform;
@@ -71,7 +71,10 @@ div:focus, span:focus {
   display: none;
   .show-new-items & {
     display: block;
-    @include item-size;
+    position: absolute;
+    top: 0;
+    left: 0;
+    @include item-size-padded;
     overflow: hidden;
   }
 }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -174,7 +174,7 @@ div:focus, span:focus {
       display: block;
       padding: 4px 2em;
       font-size: 12px;
-      @media (max-width: 375px) {
+      @include phone-portrait {
         font-size: 14px;
         padding: 6px 2em;
       }
@@ -245,7 +245,7 @@ dd {
   top: -2px;
 
   // Yikes this is a hack
-  @media (max-width: 375px) {
+  @include phone-portrait {
     display: none;
 
     &.show {
@@ -277,7 +277,7 @@ dd {
 }
 .search-button {
   display: none;
-  @media (max-width: 375px) {
+  @include phone-portrait {
     display: inline-block;
   }
 }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -102,7 +102,7 @@ div:focus, span:focus {
 }
 
 #header {
-  padding: 0 8px;
+  padding: 0 2px;
   position: fixed;
   z-index: 15;
   top: 0;
@@ -169,7 +169,12 @@ div:focus, span:focus {
 
     .link {
       display: block;
-      padding: 4px 1em;
+      padding: 4px 2em;
+      font-size: 12px;
+      @media (max-width: 375px) {
+        font-size: 14px;
+        padding: 6px 2em;
+      }
       margin: 0;
 
       &:hover, &:focus {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -13,3 +13,10 @@ $xp: #5EA16A;
 $gold: #f5dc56;
 
 $character-box-height: 46px;
+
+// Based on the CSS width of an iPhone 6+
+@mixin phone-portrait {
+  @media (max-width: 375px) {
+    @content;
+  }
+}


### PR DESCRIPTION
1. Fix up record books on mobile - no more distorted icons, and no side-by-side in portrait.
2. Trim and adjust some paddings/margins to be more mobile-friendly.
3. Upgrade extract-text (not relevant, just slipped in there).
4. Fix the new-item shine on Firefox (not mobile, but it was broken).
5. Introduce some reusable scss functions for media queries.

![screen shot 2017-07-10 at 6 00 20 pm](https://user-images.githubusercontent.com/313208/28047482-2bf7770e-659f-11e7-80a1-5b60c25318a9.png)
