### PR TITLE
Error handling

### DIFF
--- a/src/i18n/dim_en.json
+++ b/src/i18n/dim_en.json
@@ -15,7 +15,6 @@
    },
    "BungieService": {
       "DevVersion": "Are you running a development version of DIM? You must register your chrome extension with bungie.net.",
-      "Down": "Bungie.net is down.",
       "Difficulties": "The Bungie API is currently experiencing difficulties.",
       "NetworkError": "Network error - {status} {statusText}",
       "Throttled": "Bungie API throttling limit exceeded. Please wait a bit and then retry.",
@@ -28,7 +27,8 @@
       "Twitter": "Get status updates on:",
       "ItemUniqueness": "Item Uniqueness",
       "ItemUniquenessExplanation": "You tried to move the '{name}' {type} to your {character} but that destination already has that item and is only allowed one.",
-      "VendorNotFound": "Vendor data is unavailable."
+      "VendorNotFound": "Vendor data is unavailable.",
+      "UnknownError": "Bungie.net message: {message}"
    },
    "Compare": {
       "ButtonHelp": "Compare Items",

--- a/src/scripts/auth-return/return.component.html
+++ b/src/scripts/auth-return/return.component.html
@@ -1,1 +1,7 @@
-<div>Authorizing...</div>
+<div ng-if="!$ctrl.error">Authorizing...</div>
+<div ng-if="$ctrl.error">
+  <p>Error authorizing DIM: {{ $ctrl.error }}. This might be a problem with DIM, or it might be an issue with Bungie.net or your browser.</p>
+  <p>Check DIM status on <a target="_blank" rel="noopener noreferrer" href="http://twitter.com/ThisIsDIM">Twitter</a> <a target="_blank" rel="noopener noreferrer" href="http://twitter.com/ThisIsDIM"><i class="fa fa-twitter fa-2x" style="vertical-align: middle;"></i></a> or let us know what error you're seeing.</p>
+
+  <a href="/index.html">Go back to DIM and try again</a>
+</div>

--- a/src/scripts/auth-return/return.component.js
+++ b/src/scripts/auth-return/return.component.js
@@ -20,9 +20,9 @@ function ReturnController($http, OAuthService, OAuthTokenService) {
 
     ctrl.code = queryString.code;
     ctrl.state = queryString.state;
-    ctrl.authorized = (ctrl.code.length > 0);
+    ctrl.authorized = (ctrl.code && ctrl.code.length > 0);
 
-    if (ctrl.state !== localStorage.authorizationState) {
+    if (!ctrl.authorized || ctrl.state !== localStorage.authorizationState) {
       window.location = "/index.html#!/login";
       return;
     }
@@ -34,6 +34,7 @@ function ReturnController($http, OAuthService, OAuthTokenService) {
       })
       .catch((error) => {
         console.error(error);
+        ctrl.error = error.message || error.data.error_description;
       });
   };
 }

--- a/src/scripts/bungie-api/bungie-service-helper.service.js
+++ b/src/scripts/bungie-api/bungie-service-helper.service.js
@@ -23,7 +23,7 @@ export function BungieServiceHelper($rootScope, $q, $timeout, $http, $state, dim
       return $q.reject(new Error($translate.instant('BungieService.NotLoggedIn')));
     }
     if (response.status >= 503 && response.status <= 526 /* cloudflare */) {
-      return $q.reject(new Error($translate.instant('BungieService.Down')));
+      return $q.reject(new Error($translate.instant('BungieService.Difficulties')));
     }
     if (response.status < 200 || response.status >= 400) {
       return $q.reject(new Error($translate.instant('BungieService.NetworkError', {
@@ -38,6 +38,9 @@ export function BungieServiceHelper($rootScope, $q, $timeout, $http, $state, dim
     switch (errorCode) {
     case 1: // Success
       return response;
+    case 22: // WebAuthModuleAsyncFailed
+      // We've only seen this when B.net is down
+      return $q.reject(new Error($translate.instant('BungieService.Difficulties')));
     case 1627: // DestinyVendorNotFound
       return $q.reject(new Error($translate.instant('BungieService.VendorNotFound')));
     case 2106: // AuthorizationCodeInvalid
@@ -76,7 +79,7 @@ export function BungieServiceHelper($rootScope, $q, $timeout, $http, $state, dim
     // Any other error
     if (errorCode > 1) {
       if (response.data.Message) {
-        const error = new Error(response.data.Message);
+        const error = new Error($translate.instant('BungieService.UnknownError', { message: response.data.Message }));
         error.code = response.data.ErrorCode;
         error.status = response.data.ErrorStatus;
         return $q.reject(error);

--- a/src/scripts/services/dimManifestService.factory.js
+++ b/src/scripts/services/dimManifestService.factory.js
@@ -138,6 +138,7 @@ function ManifestService($q, Destiny1Api, $http, toaster, dimSettingsService, $t
 
           manifestPromise = null;
           service.isError = true;
+          console.error("Manifest loading error", { error: e }, e);
           throw new Error(message);
         });
 


### PR DESCRIPTION
Added error handling for code 22 (web auth broken), consolidated our "Bungie.net is down" messaging, and added a "this error is from bungie.net" bit to our general error catcher. Added some extra manifest debugging info.

Also, added some error display to the auth return page. Won't necessarily fix #1927 but will help us understand it.