### PR TITLE
Ignore missing IB vendor

### DIFF
--- a/src/scripts/vendors/vendor.service.js
+++ b/src/scripts/vendors/vendor.service.js
@@ -233,7 +233,7 @@ function VendorService(
       })
       .catch((e) => {
         service.loadedVendors++;
-        if (vendorDef.hash !== 2796397637) { // Xur
+        if (vendorDef.hash !== 2796397637 && vendorDef.hash !== 2610555297) { // Xur, IB
           console.error(`Failed to load vendor ${vendorDef.summary.vendorName} for ${store.name}`, e);
         }
         return null;


### PR DESCRIPTION
Don't throw error message about IB vendor missing, since they come and go freely like Xur...

//cc @bhollis