### PR TITLE
listen on localhost instead of 0.0.0.0

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -47,7 +47,7 @@ module.exports = (env) => {
       contentBase: path.resolve(__dirname, './src'),
       publicPath: '/',
       https: true,
-      host: '0.0.0.0',
+      host: 'localhost',
       hot: false
     },
 


### PR DESCRIPTION
windows 10 does not have access to 0.0.0.0, but does localhost.

0.0.0.0 does allow for using localhost, but to output from `npm run server` is misleading