### PR TITLE
Loadout Builder: Use $state instead of $location

### DIFF
--- a/src/scripts/loadout-builder/loadout-builder.component.js
+++ b/src/scripts/loadout-builder/loadout-builder.component.js
@@ -12,7 +12,7 @@ export const LoadoutBuilderComponent = {
   controllerAs: 'vm'
 };
 
-function LoadoutBuilderController($scope, $state, $q, $timeout, $location, $i18next, dimSettingsService, dimStoreService, ngDialog, dimLoadoutService, dimDefinitions, dimVendorService) {
+function LoadoutBuilderController($scope, $state, $q, $timeout, $i18next, dimSettingsService, dimStoreService, ngDialog, dimLoadoutService, dimDefinitions, dimVendorService) {
   'ngInject';
 
   const vm = this;
@@ -580,7 +580,11 @@ function LoadoutBuilderController($scope, $state, $q, $timeout, $location, $i18n
 
                         processedCount++;
                         if (processedCount % 50000 === 0) { // do this so the page doesn't lock up
-                          if (vm.active !== activeGuardian || vm.lockedchanged || vm.excludedchanged || vm.perkschanged || !$location.path().endsWith('/loadout-builder')) {
+                          if (vm.active !== activeGuardian ||
+                              vm.lockedchanged ||
+                              vm.excludedchanged ||
+                              vm.perkschanged ||
+                              !$state.is('loadout-builder')) {
                             // If active guardian or page is changed then stop processing combinations
                             vm.lockedchanged = false;
                             vm.excludedchanged = false;


### PR DESCRIPTION
#1947 fixed loadout builder, but the strategy of checking the path isn't very robust. This switches to asking about the actual state, which should be stable despite changes to paths (assuming we don't rename the state...)