### PR TITLE
Loadout builder stat bars

### DIFF
--- a/src/scripts/loadout-builder/loadout-builder.scss
+++ b/src/scripts/loadout-builder/loadout-builder.scss
@@ -297,9 +297,20 @@
   dim-stats {
     display: inline-block;
     margin-left: 22px;
+    @media (max-width: 680px) {
+      margin-left: 4px;
+    }
+
     .stat-bars {
       width: 375px;
       margin-top: 0;
+      @media (max-width: 680px) {
+        width: 150px;
+        display: inline-block;
+        .stat {
+          margin-right: 0;
+        }
+      }
     }
   }
   .set-item {


### PR DESCRIPTION

making them more responsive

400 width
<img width="364" alt="screen shot 2017-07-13 at 7 08 57 pm" src="https://user-images.githubusercontent.com/424158/28195440-12354b36-67ff-11e7-9139-caa8f30114ab.png">
bigger
<img width="429" alt="screen shot 2017-07-13 at 7 09 42 pm" src="https://user-images.githubusercontent.com/424158/28195442-14e421f4-67ff-11e7-8a82-c0818dc98baf.png">
desktop
<img width="1162" alt="screen shot 2017-07-13 at 7 10 51 pm" src="https://user-images.githubusercontent.com/424158/28195444-174a8d52-67ff-11e7-964e-a4ff01278fe1.png">

