### PR TITLE
Do a better job of handling expired auth tokens

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Google Drive syncing is a bit smoother.
 * Fixed a case where you couldn't create a new class-specific loadout.
 * On Firefox, the new-item shines don't extend past the item anymore.
+* Do a better job of refreshing your authentication credentials - before, we'd sometimes show errors for a few minutes after you'd used DIM for a while.
 
 # 4.3.0
 

--- a/src/scripts/bungie-api/bungie-service-helper.service.js
+++ b/src/scripts/bungie-api/bungie-service-helper.service.js
@@ -38,9 +38,6 @@ export function BungieServiceHelper($rootScope, $q, $timeout, $http, $state, dim
     switch (errorCode) {
     case 1: // Success
       return response;
-    case 22: // WebAuthModuleAsyncFailed
-      // We've only seen this when B.net is down
-      return $q.reject(new Error($i18next.t('BungieService.Difficulties')));
     case 1627: // DestinyVendorNotFound
       return $q.reject(new Error($i18next.t('BungieService.VendorNotFound')));
     case 2106: // AuthorizationCodeInvalid
@@ -55,6 +52,7 @@ export function BungieServiceHelper($rootScope, $q, $timeout, $http, $state, dim
       return $q.reject(new Error($i18next.t('BungieService.Throttled')));
     case 2111: // token expired
     case 99: // WebAuthRequired
+    case 22: // WebAuthModuleAsyncFailed (means the access token has expired)
       $rootScope.$broadcast('dim-no-token-found');
       return $q.reject(new Error($i18next.t('BungieService.NotLoggedIn')));
     case 1601: // DestinyAccountNotFound


### PR DESCRIPTION
This addresses #1955. `WebAuthModuleAsyncFailed` means the access token has expired, which can happen for all kinds of reasons (like clock drift). This code adds a response handler to our OAuth HTTP interceptor which knows about some of Bungie's errors related to expired auth token, and will refresh the token and retry the request (only once, to avoid an infinite loop). This is a tricky one to test, but I was able to simulate this failure and verify that we reload.