### PR TITLE
Try to detect content blockers in return component

### DIFF
--- a/src/scripts/auth-return/return.component.js
+++ b/src/scripts/auth-return/return.component.js
@@ -33,8 +33,12 @@ function ReturnController($http, OAuthService, OAuthTokenService) {
         window.location = "/index.html";
       })
       .catch((error) => {
+        if (error.status === -1) {
+          ctrl.error = 'A content blocker is interfering with either DIM or Bungie.net, or you are not connected to the internet.';
+          return;
+        }
         console.error(error);
-        ctrl.error = error.message || error.data.error_description;
+        ctrl.error = error.message || (error.data && error.data.error_description) || "Unknown";
       });
   };
 }


### PR DESCRIPTION
This tries to fix #1982 a bit by detecting when the auth request completely fails, which either indicates that the user is content-blocking the request or is not connected to the internet. Given that they were just sent from the OAuth page, it's probably the former.