### PR TITLE
Revamp item popup positioning, and add press-tips

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -20,8 +20,7 @@ const nodeModulesDir = path.join(__dirname, '../node_modules');
 const preMinifiedDeps = [
   'underscore/underscore-min.js',
   'indexeddbshim/dist/indexeddbshim.min.js',
-  'messageformat/messageformat.min.js',
-  'jquery/dist/jquery.min.js'
+  'messageformat/messageformat.min.js'
 ];
 
 module.exports = (env) => {
@@ -110,9 +109,6 @@ module.exports = (env) => {
 
     plugins: [
       new webpack.ProvidePlugin({
-        $: 'jquery',
-        jQuery: 'jquery',
-        'window.jQuery': 'jquery',
         MessageFormat: 'messageformat'
       }),
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * The item detail popup now does a better job of fitting itself onto the screen - it may appear to the left or right of an item now!
 * Press on a talent grid node to read its description. The same goes for the stats under your character.
+* Subclasses now have the correct elemental type in their header color.
 
 # 4.4.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next
 
+* The item detail popup now does a better job of fitting itself onto the screen - it may appear to the left or right of an item now!
+* Press on a talent grid node to read its description. The same goes for the stats under your character.
+
 # 4.4.0
 
 * New filters for ornaments - is:ornament, is:ornamentmissing, is:ornamentunlocked

--- a/package-lock.json
+++ b/package-lock.json
@@ -12077,6 +12077,14 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "tooltip.js": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.1.4.tgz",
+      "integrity": "sha1-FzN/IgZfwE1KRWQpzhItvxhL2GE=",
+      "requires": {
+        "popper.js": "1.10.8"
+      }
+    },
     "toposort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4813,6 +4813,10 @@
         "rsyncwrapper": "https://registry.npmjs.org/rsyncwrapper/-/rsyncwrapper-2.0.1.tgz"
       }
     },
+    "grunt-sort-json": {
+      "version": "github:delphiactual/grunt-sort-json#ba37194070f9391b875ffe43bd73df7283cd6d92",
+      "dev": true
+    },
     "grunt-upload-file": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/grunt-upload-file/-/grunt-upload-file-0.0.2.tgz",
@@ -6790,10 +6794,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/jquery-textcomplete/-/jquery-textcomplete-1.8.2.tgz",
       "integrity": "sha512-eFIaZZAWksIFtyULLlrlVO8MGeaHoCtPdyLqR3MZUp1BlUD7uIi3jO4soRHKlR1+lNcspS8bLnLYpqn12Hlzlw=="
-    },
-    "jquery-ui": {
-      "version": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
-      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
     "js-base64": {
       "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,13 +177,11 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
       "version": "1.3.0",
@@ -267,6 +265,11 @@
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+    },
     "array-find": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
@@ -283,6 +286,16 @@
       "version": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-union": {
       "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -1095,8 +1108,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
@@ -1202,7 +1214,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1330,8 +1341,7 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "builtin-status-codes": {
       "version": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -1441,7 +1451,6 @@
     "chalk": {
       "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
         "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1452,8 +1461,7 @@
       "dependencies": {
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -1765,8 +1773,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -2289,6 +2296,15 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "defined": {
       "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
@@ -2472,8 +2488,7 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2564,9 +2579,29 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -2655,8 +2690,7 @@
     },
     "escape-string-regexp": {
       "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escope": {
       "version": "3.6.0",
@@ -3055,6 +3089,20 @@
         "es5-ext": "0.10.24"
       }
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
     "eventemitter2": {
       "version": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
@@ -3411,6 +3459,11 @@
         "for-in": "1.0.2"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
@@ -3435,6 +3488,11 @@
       "version": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs-extra": {
       "version": "0.26.7",
@@ -4481,8 +4539,7 @@
     },
     "function-bind": {
       "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
-      "dev": true
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
     },
     "gauge": {
       "version": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
@@ -4635,8 +4692,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
@@ -5116,7 +5172,6 @@
     "has": {
       "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
       "requires": {
         "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
       }
@@ -5124,7 +5179,6 @@
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -5206,8 +5260,7 @@
     "hosted-git-info": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
-      "dev": true
+      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
     },
     "hpack.js": {
       "version": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -6570,8 +6623,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -6592,10 +6644,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-directory": {
       "version": "0.3.1",
@@ -6719,6 +6780,14 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+      }
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -6735,6 +6804,11 @@
       "requires": {
         "html-comment-regex": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
       }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -6770,8 +6844,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -6925,8 +6998,7 @@
     },
     "jsonify": {
       "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -7226,6 +7298,11 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
     "match-stream": {
       "version": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
       "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
@@ -7397,7 +7474,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -7662,7 +7738,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.4.2",
         "is-builtin-module": "1.0.0",
@@ -7701,6 +7776,70 @@
       "dev": true,
       "requires": {
         "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      }
+    },
+    "npm-run-all": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.0.2.tgz",
+      "integrity": "sha1-qEZpNI5ttsy+BSIAtM22v+A0pP4=",
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cross-spawn": "5.1.0",
+        "minimatch": "3.0.4",
+        "ps-tree": "1.1.0",
+        "read-pkg": "2.0.0",
+        "shell-quote": "1.6.1",
+        "string.prototype.padend": "3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.2.14"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "requires": {
+            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.3.8",
+            "path-type": "2.0.0"
+          }
+        }
       }
     },
     "npmlog": {
@@ -7743,6 +7882,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object.omit": {
       "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -7973,7 +8117,6 @@
     "parse-json": {
       "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -8031,6 +8174,14 @@
         "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
     "pbkdf2": {
       "version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
@@ -8050,8 +8201,7 @@
     },
     "pify": {
       "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -9280,11 +9430,18 @@
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
       "dev": true
     },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "requires": {
+        "event-stream": "3.3.4"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "public-encrypt": {
       "version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
@@ -10044,8 +10201,7 @@
     },
     "semver": {
       "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "send": {
       "version": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
@@ -10160,6 +10316,30 @@
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
           "dev": true
         }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
       }
     },
     "sigmund": {
@@ -10304,7 +10484,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -10312,14 +10491,12 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "spdy": {
       "version": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
@@ -10346,6 +10523,14 @@
         "readable-stream": "2.3.2",
         "safe-buffer": "5.1.1",
         "wbuf": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz"
+      }
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
     "sprintf-js": {
@@ -11642,6 +11827,14 @@
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
       "dev": true
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
     "stream-http": {
       "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
@@ -11678,6 +11871,16 @@
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
       }
     },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.7.0",
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+      }
+    },
     "stringstream": {
       "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
@@ -11686,7 +11889,6 @@
     "strip-ansi": {
       "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -11694,8 +11896,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-indent": {
       "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -11825,10 +12026,31 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "textarea-caret": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textarea-caret/-/textarea-caret-3.0.2.tgz",
+      "integrity": "sha1-82DEhpmqGr9xhoCkOjGoUGZcLK8="
+    },
+    "textcomplete": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/textcomplete/-/textcomplete-0.13.1.tgz",
+      "integrity": "sha512-cY79gz5YGWhS0mCTn6pmun00mM8XKx4JDbwS+HJnxPdnZxIYfumvV0YOgkOBgmWQ2YZGVso5CIBK/OmMmhlPaA==",
+      "requires": {
+        "eventemitter3": "2.0.3",
+        "textarea-caret": "3.0.2",
+        "undate": "0.2.1"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+        }
+      }
+    },
     "through": {
       "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "thunky": {
       "version": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
@@ -11986,6 +12208,14 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
+    },
+    "undate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/undate/-/undate-0.2.1.tgz",
+      "integrity": "sha512-HVtm/Ed/kiqD3Gbo0SMksLRzBOJl2rf5BBRd6+JCFj4vDCB4k4V4qUEP1dMjQdfii8x/XQ4ISSZm7jVCeuCASQ==",
+      "requires": {
+        "npm-run-all": "4.0.2"
+      }
     },
     "underscore": {
       "version": "1.8.3",
@@ -12171,7 +12401,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -12579,7 +12808,6 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -12725,8 +12953,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8110,6 +8110,11 @@
       "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
       "dev": true
     },
+    "popper.js": {
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.10.8.tgz",
+      "integrity": "sha512-2LbS9yubeRwcRhThjGGcuKUHS5oGDxDRdYa+tBVjvwKBh7BBaNyALysYIJogCqTfQzOVtng8Z2TvaaSuYZtW8w=="
+    },
     "portfinder": {
       "version": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dim",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6863,11 +6863,6 @@
       "version": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
       "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
     },
-    "jquery-textcomplete": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/jquery-textcomplete/-/jquery-textcomplete-1.8.2.tgz",
-      "integrity": "sha512-eFIaZZAWksIFtyULLlrlVO8MGeaHoCtPdyLqR3MZUp1BlUD7uIi3jO4soRHKlR1+lNcspS8bLnLYpqn12Hlzlw=="
-    },
     "js-base64": {
       "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6859,10 +6859,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "jquery": {
-      "version": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
-      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
-    },
     "js-base64": {
       "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "indexeddbshim": "^2.2.1",
     "jquery": "^3.1.1",
     "jquery-textcomplete": "^1.8.2",
-    "jquery-ui": "^1.12.1",
     "ng-dialog": "^1.3.0",
     "ng-http-rate-limiter": "^1.0.1",
     "ng-i18next": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "i18next": "^8.4.3",
     "idb-keyval": "^2.3.0",
     "indexeddbshim": "^2.2.1",
-    "jquery": "^3.1.1",
     "ng-dialog": "^1.3.0",
     "ng-http-rate-limiter": "^1.0.1",
     "ng-i18next": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "simple-query-string": "^1.3.0",
     "sql.js": "github:DestinyItemManager/sql.js",
     "textcomplete": "^0.13.1",
+    "tooltip.js": "^1.1.4",
     "underscore": "^1.8.3",
     "uuid": "^3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "idb-keyval": "^2.3.0",
     "indexeddbshim": "^2.2.1",
     "jquery": "^3.1.1",
-    "jquery-textcomplete": "^1.8.2",
     "ng-dialog": "^1.3.0",
     "ng-http-rate-limiter": "^1.0.1",
     "ng-i18next": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "ng-dialog": "^1.3.0",
     "ng-http-rate-limiter": "^1.0.1",
     "ng-i18next": "^1.0.5",
+    "popper.js": "^1.10.8",
     "simple-query-string": "^1.3.0",
     "sql.js": "github:DestinyItemManager/sql.js",
     "underscore": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "popper.js": "^1.10.8",
     "simple-query-string": "^1.3.0",
     "sql.js": "github:DestinyItemManager/sql.js",
+    "textcomplete": "^0.13.1",
     "underscore": "^1.8.3",
     "uuid": "^3.1.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ require('./scripts/move-popup/dimTalentGrid.directive');
 require('./scripts/move-popup/dimMoveItemProperties.directive');
 require('./scripts/move-popup/dimItemTag.directive');
 require('./scripts/move-popup/item-popup.directive');
+require('./scripts/move-popup/press-tip.directive');
 
 require('./scss/main.scss');
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ require('./scripts/move-popup/dimMovePopup.directive');
 require('./scripts/move-popup/dimTalentGrid.directive');
 require('./scripts/move-popup/dimMoveItemProperties.directive');
 require('./scripts/move-popup/dimItemTag.directive');
+require('./scripts/move-popup/item-popup.directive');
 
 require('./scss/main.scss');
 

--- a/src/scripts/loadout-builder/loadout-builder-item-dialog.html
+++ b/src/scripts/loadout-builder/loadout-builder-item-dialog.html
@@ -1,5 +1,6 @@
 <div class="move-popup"
      item-popup
+     item-popup-boundary-class="store-bounds"
      dim-click-anywhere-but-here="closeThisDialog()">
   <div dim-move-item-properties="vm.item"
        dim-compare-item="vm.compareItem"></div>

--- a/src/scripts/loadout-builder/loadout-builder-item-dialog.html
+++ b/src/scripts/loadout-builder/loadout-builder-item-dialog.html
@@ -1,4 +1,5 @@
 <div class="move-popup"
+     item-popup
      dim-click-anywhere-but-here="closeThisDialog()">
   <div dim-move-item-properties="vm.item"
        dim-compare-item="vm.compareItem"></div>

--- a/src/scripts/loadout-builder/loadout-builder-item-dialog.html
+++ b/src/scripts/loadout-builder/loadout-builder-item-dialog.html
@@ -14,4 +14,5 @@
   </div>
   <div class="item-description"
        ng-if="!vm.item.equipment" ng-i18next="[i18next]({ num: vm.compareItemCount })Compare.ItemCount"></div>
+  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
 </div>

--- a/src/scripts/loadout-builder/loadout-builder-item.component.js
+++ b/src/scripts/loadout-builder/loadout-builder-item.component.js
@@ -3,7 +3,6 @@ import _ from 'underscore';
 import { sum, flatMap } from '../util';
 import template from './loadout-builder-item.html';
 import dialogTemplate from './loadout-builder-item-dialog.html';
-import Popper from 'popper.js';
 
 export const LoadoutBuilderItem = {
   controller: LoadoutBuilderItemCtrl,

--- a/src/scripts/loadout-builder/loadout-builder-item.component.js
+++ b/src/scripts/loadout-builder/loadout-builder-item.component.js
@@ -37,7 +37,7 @@ function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
       if (popper) {
         popper.scheduleUpdate();
       } else {
-        popper = new Popper($element[0].getElementsByClassName('item')[0], dialog, {
+        popper = new Popper($element[0].getElementsByClassName('item')[0], dialog[0], {
           placement: 'top-start',
           eventsEnabled: false,
           modifiers: {

--- a/src/scripts/loadout-builder/loadout-builder-item.component.js
+++ b/src/scripts/loadout-builder/loadout-builder-item.component.js
@@ -21,45 +21,6 @@ function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
   const vm = this;
   let dialogResult = null;
 
-  let dialog = null;
-  $scope.$on('ngDialog.opened', (event, $dialog) => {
-    dialog = $dialog;
-    vm.reposition();
-  });
-
-  let popper;
-
-  // TODO: gotta make a popup directive
-
-  // Reposition the popup as it is shown or if its size changes
-  vm.reposition = function() {
-    if (dialogResult && dialog[0].id === dialogResult.id) {
-      if (popper) {
-        popper.scheduleUpdate();
-      } else {
-        popper = new Popper($element[0].getElementsByClassName('item')[0], dialog[0], {
-          placement: 'top-start',
-          eventsEnabled: false,
-          modifiers: {
-            preventOverflow: {
-              priority: ['bottom', 'top', 'right', 'left']
-            },
-            flip: {
-              behavior: ['top', 'bottom', 'right', 'left']
-            },
-            offset: {
-              offset: '0,7px'
-            },
-            arrow: {
-              element: '.arrow'
-            }
-          }
-        });
-        popper.scheduleUpdate(); // helps fix arrow position
-      }
-    }
-  };
-
   angular.extend(vm, {
     itemClicked: function(item, e) {
       e.stopPropagation();
@@ -68,8 +29,6 @@ function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
         if (ngDialog.isOpen(dialogResult.id)) {
           dialogResult.close();
           dialogResult = null;
-          popper.destroy();
-          popper = null;
         }
       } else if (vm.shiftClickCallback && e.shiftKey) {
         vm.shiftClickCallback(vm.itemData);
@@ -79,6 +38,7 @@ function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
         });
 
         const compareItemCount = sum(compareItems, 'amount');
+        const itemElement = $element[0].getElementsByClassName('item')[0];
 
         dialogResult = ngDialog.open({
           template: dialogTemplate,
@@ -87,6 +47,7 @@ function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
           showClose: false,
           scope: angular.extend($scope.$new(true), {
           }),
+          data: itemElement,
           controllerAs: 'vm',
           controller: [function() {
             const vm = this;
@@ -108,8 +69,6 @@ function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
 
         dialogResult.closePromise.then(() => {
           dialogResult = null;
-          popper.destroy();
-          popper = null;
         });
       }
     },
@@ -123,9 +82,6 @@ function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
     $onDestroy() {
       if (dialogResult) {
         dialogResult.close();
-      }
-      if (popper) {
-        popper.destroy();
       }
     }
   });

--- a/src/scripts/loadout-builder/loadout-builder-item.component.js
+++ b/src/scripts/loadout-builder/loadout-builder-item.component.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 import { sum, flatMap } from '../util';
 import template from './loadout-builder-item.html';
 import dialogTemplate from './loadout-builder-item-dialog.html';
-import 'jquery-ui/ui/position';
+import Popper from 'popper.js';
 
 export const LoadoutBuilderItem = {
   controller: LoadoutBuilderItemCtrl,
@@ -15,45 +15,65 @@ export const LoadoutBuilderItem = {
   template: template
 };
 
-function LoadoutBuilderItemCtrl($scope, ngDialog, dimStoreService) {
+function LoadoutBuilderItemCtrl($scope, $element, ngDialog, dimStoreService) {
   'ngInject';
 
   const vm = this;
   let dialogResult = null;
-  let detailItem = null;
-  let detailItemElement = null;
 
+  let dialog = null;
   $scope.$on('ngDialog.opened', (event, $dialog) => {
-    if (dialogResult && $dialog[0].id === dialogResult.id) {
-      $dialog.position({
-        my: 'left top',
-        at: 'left bottom+2',
-        of: detailItemElement,
-        collision: 'flip flip'
-      });
-    }
+    dialog = $dialog;
+    vm.reposition();
   });
+
+  let popper;
+
+  // TODO: gotta make a popup directive
+
+  // Reposition the popup as it is shown or if its size changes
+  vm.reposition = function() {
+    if (dialogResult && dialog[0].id === dialogResult.id) {
+      if (popper) {
+        popper.scheduleUpdate();
+      } else {
+        popper = new Popper($element[0].getElementsByClassName('item')[0], dialog, {
+          placement: 'top-start',
+          eventsEnabled: false,
+          modifiers: {
+            preventOverflow: {
+              priority: ['bottom', 'top', 'right', 'left']
+            },
+            flip: {
+              behavior: ['top', 'bottom', 'right', 'left']
+            },
+            offset: {
+              offset: '0,7px'
+            },
+            arrow: {
+              element: '.arrow'
+            }
+          }
+        });
+        popper.scheduleUpdate(); // helps fix arrow position
+      }
+    }
+  };
 
   angular.extend(vm, {
     itemClicked: function(item, e) {
       e.stopPropagation();
+
       if (dialogResult) {
-        dialogResult.close();
-      }
-
-      if (vm.shiftClickCallback && e.shiftKey) {
+        if (ngDialog.isOpen(dialogResult.id)) {
+          dialogResult.close();
+          dialogResult = null;
+          popper.destroy();
+          popper = null;
+        }
+      } else if (vm.shiftClickCallback && e.shiftKey) {
         vm.shiftClickCallback(vm.itemData);
-        return;
-      }
-
-      if (detailItem === item) {
-        detailItem = null;
-        dialogResult = null;
-        detailItemElement = null;
       } else {
-        detailItem = item;
-        detailItemElement = angular.element(e.currentTarget);
-
         const compareItems = flatMap(dimStoreService.getStores(), (store) => {
           return _.filter(store.items, { hash: item.hash });
         });
@@ -63,7 +83,7 @@ function LoadoutBuilderItemCtrl($scope, ngDialog, dimStoreService) {
         dialogResult = ngDialog.open({
           template: dialogTemplate,
           overlay: false,
-          className: 'move-popup vendor-move-popup',
+          className: 'move-popup-dialog vendor-move-popup',
           showClose: false,
           scope: angular.extend($scope.$new(true), {
           }),
@@ -85,6 +105,12 @@ function LoadoutBuilderItemCtrl($scope, ngDialog, dimStoreService) {
           trapFocus: false,
           preserveFocus: false
         });
+
+        dialogResult.closePromise.then(() => {
+          dialogResult = null;
+          popper.destroy();
+          popper = null;
+        });
       }
     },
     close: function() {
@@ -92,7 +118,17 @@ function LoadoutBuilderItemCtrl($scope, ngDialog, dimStoreService) {
         dialogResult.close();
       }
       $scope.closeThisDialog();
+    },
+
+    $onDestroy() {
+      if (dialogResult) {
+        dialogResult.close();
+      }
+      if (popper) {
+        popper.destroy();
+      }
     }
   });
+
 }
 

--- a/src/scripts/loadout-builder/loadout-builder-locks.component.js
+++ b/src/scripts/loadout-builder/loadout-builder-locks.component.js
@@ -62,7 +62,7 @@ function LoadoutBuilderLocksCtrl($scope, ngDialog) {
               });
             }
           }
-          $document.keyup(keyup);
+          $document.on('keyup', keyup);
 
           function keydown(e) {
             if (vmd.shiftHeld === false && e.shiftKey) {
@@ -71,7 +71,7 @@ function LoadoutBuilderLocksCtrl($scope, ngDialog) {
               });
             }
           }
-          $document.keydown(keydown);
+          $document.on('keydown', keydown);
 
           $scope.$on('$destroy', () => {
             $document.off('keyup', keyup);

--- a/src/scripts/loadout-builder/loadout-builder-locks.component.js
+++ b/src/scripts/loadout-builder/loadout-builder-locks.component.js
@@ -2,7 +2,6 @@ import angular from 'angular';
 import _ from 'underscore';
 import template from './loadout-builder-locks.html';
 import dialogTemplate from './loadout-builder-locks-dialog.html';
-import 'jquery-ui/ui/position';
 
 export const LoadoutBuilderLocks = {
   controller: LoadoutBuilderLocksCtrl,
@@ -28,18 +27,6 @@ function LoadoutBuilderLocksCtrl($scope, ngDialog) {
   let dialogResult = null;
   let detailItemElement = null;
 
-  $scope.$on('ngDialog.opened', (event, $dialog) => {
-    if (dialogResult && $dialog[0].id === dialogResult.id) {
-      $dialog.position({
-        my: 'left-2 top-2',
-        at: 'left top',
-        of: detailItemElement,
-        collision: 'flip flip',
-        within: '.store-bounds'
-      });
-    }
-  });
-
   angular.extend(vm, {
     getFirstPerk: function(lockedPerks, type) {
       return vm.lockedPerks[type][_.keys(vm.lockedPerks[type])[0]];
@@ -60,26 +47,35 @@ function LoadoutBuilderLocksCtrl($scope, ngDialog) {
         overlay: false,
         className: 'perk-select-popup',
         showClose: false,
+        appendTo: `#locked-perks-${type}`,
         scope: angular.extend($scope.$new(true), {}),
         controllerAs: 'vmd',
-        controller: function($document) {
+        controller: function($document, $scope) {
           'ngInject';
           const vmd = this;
 
-          $document.keyup((e) => {
+          function keyup(e) {
+            console.log('keyup');
             if (vmd.shiftHeld) {
               $scope.$apply(() => {
                 vmd.shiftHeld = e.shiftKey;
               });
             }
-          });
+          }
+          $document.keyup(keyup);
 
-          $document.keydown((e) => {
+          function keydown(e) {
             if (vmd.shiftHeld === false && e.shiftKey) {
               $scope.$apply(() => {
                 vmd.shiftHeld = e.shiftKey;
               });
             }
+          }
+          $document.keydown(keydown);
+
+          $scope.$on('$destroy', () => {
+            $document.off('keyup', keyup);
+            $document.off('keyup', keydown);
           });
 
           angular.extend(vmd, {

--- a/src/scripts/loadout-builder/loadout-builder-locks.html
+++ b/src/scripts/loadout-builder/loadout-builder-locks.html
@@ -1,6 +1,7 @@
 <div class="locked-item"
      ng-repeat="(type, lockeditem) in vm.lockedItems"
      ng-switch="lockeditem"
+     id="locked-perks-{{type}}"
      ui-on-drop="vm.onDrop({ $data: $data, type: type })"
      drag-channel="{{ type }}"
      drop-channel="{{ type }}"

--- a/src/scripts/loadout-builder/loadout-builder.scss
+++ b/src/scripts/loadout-builder/loadout-builder.scss
@@ -341,44 +341,49 @@
   }
 }
 
-.ngdialog.perk-select-popup .perk-select-box {
-  user-select: none;
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  position: absolute;
-  left: 0;
+.ngdialog.perk-select-popup {
+  left: 6px;
   top: 0;
-  width: calc(((var(--item-size) + 20px) * 5) + 14px);
-  min-height: calc((var(--item-size) * 5) + 10px);
-  overflow-y: auto;
-  background-color: #656565;
-  border: 2px solid #DDD;
-  z-index: 3;
-  & .perk {
-    width: calc(var(--item-size) + 20px);
-    padding-left: 3px;
-    padding-right: 3px;
-    cursor: pointer;
-  }
 
-  & .perk:hover, & .active-perk-or {
-    background-color: $orange;
-  }
+  .perk-select-box {
+    user-select: none;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: calc(((var(--item-size) + 20px) * 5) + 14px);
+    min-height: calc((var(--item-size) * 5) + 10px);
+    overflow-y: auto;
+    background-color: #656565;
+    border: 2px solid #DDD;
+    z-index: 3;
+    & .perk {
+      width: calc(var(--item-size) + 20px);
+      padding-left: 3px;
+      padding-right: 3px;
+      cursor: pointer;
+    }
 
-  &.shift-held .perk:hover, & .active-perk-and {
-    background-color: $void;
-  }
+    & .perk:hover, & .active-perk-or {
+      background-color: $orange;
+    }
 
-  & .perk img {
-    width: var(--item-size);
-    height: var(--item-size);
-    display: block;
-    margin: auto;
-  }
+    &.shift-held .perk:hover, & .active-perk-and {
+      background-color: $void;
+    }
 
-  & .perk small {
-    text-align: center;
-    display: block;
+    & .perk img {
+      width: var(--item-size);
+      height: var(--item-size);
+      display: block;
+      margin: auto;
+    }
+
+    & .perk small {
+      text-align: center;
+      display: block;
+    }
   }
 }

--- a/src/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/src/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -168,9 +168,9 @@ function MoveItemPropertiesCtrl($sce, $q, dimStoreService, dimItemService, dimSe
 
   if (vm.item.primStat) {
     vm.light = vm.item.primStat.value.toString();
-    if (vm.item.dmg) {
-      vm.classes[`is-${vm.item.dmg}`] = true;
-    }
+  }
+  if (vm.item.dmg) {
+    vm.classes[`is-${vm.item.dmg}`] = true;
   }
 
   if (vm.item.classTypeName !== 'unknown' &&

--- a/src/scripts/move-popup/dimMoveItemProperties.directive.js
+++ b/src/scripts/move-popup/dimMoveItemProperties.directive.js
@@ -24,8 +24,7 @@ function MoveItemProperties() {
     scope: {
       item: '=dimMoveItemProperties',
       compareItem: '=dimCompareItem',
-      infuse: '=dimInfuse',
-      changeDetails: '&'
+      infuse: '=dimInfuse'
     },
     restrict: 'A',
     replace: true,
@@ -56,7 +55,12 @@ function MoveItemPropertiesCtrl($sce, $q, dimStoreService, dimItemService, dimSe
   // The 'i' keyboard shortcut toggles full details
   $scope.$on('dim-toggle-item-details', () => {
     vm.itemDetails = !vm.itemDetails;
-    vm.changeDetails();
+  });
+
+  $scope.$watch('vm.itemDetails', (newValue, oldValue) => {
+    if (newValue !== oldValue) {
+      $scope.$emit('popup-size-changed');
+    }
   });
 
   vm.openCompare = function() {

--- a/src/scripts/move-popup/dimMovePopup.directive.html
+++ b/src/scripts/move-popup/dimMovePopup.directive.html
@@ -31,4 +31,5 @@
     <div class="move-button infuse-perk" ng-if="vm.item.talentGrid.infusable" ng-click="vm.infuse(vm.item, $event)" ng-i18next="[title]Infusion.Infusion;[alt]Infusion.Calc" ng-class="vm.item.bucket.sort"></div>
   </div>
   </div>
+  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
 </div>

--- a/src/scripts/move-popup/dimMovePopup.directive.html
+++ b/src/scripts/move-popup/dimMovePopup.directive.html
@@ -1,4 +1,4 @@
-<div class="move-popup" alt="" title="">
+<div class="move-popup" item-popup item-popup-boundary-class="store-bounds">
   <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse" change-details="vm.reposition()"></div>
   <dim-move-amount ng-if="vm.maximum > 1 && !vm.item.notransfer" amount="vm.moveAmount" maximum="vm.maximum" max-stack-size="vm.item.maxStackSize"></dim-move-amount>
   <div class="interaction">

--- a/src/scripts/move-popup/dimMovePopup.directive.html
+++ b/src/scripts/move-popup/dimMovePopup.directive.html
@@ -1,5 +1,5 @@
 <div class="move-popup" item-popup item-popup-boundary-class="store-bounds">
-  <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse" change-details="vm.reposition()"></div>
+  <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse"></div>
   <dim-move-amount ng-if="vm.maximum > 1 && !vm.item.notransfer" amount="vm.moveAmount" maximum="vm.maximum" max-stack-size="vm.item.maxStackSize"></dim-move-amount>
   <div class="interaction">
     <div class="locations" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">

--- a/src/scripts/move-popup/dimMovePopup.directive.js
+++ b/src/scripts/move-popup/dimMovePopup.directive.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import template from './dimMovePopup.directive.html';
-import Popper from 'popper.js';
 
 angular.module('dimApp')
   .component('dimMovePopup', movePopup());
@@ -27,53 +26,6 @@ function MovePopupController($scope, dimStoreService, ngDialog, $timeout, dimSet
     const store = dimStoreService.getStore(vm.item.owner);
     vm.maximum = store.amountOfItem(vm.item);
   }
-
-  // Capture the dialog element
-  let dialog = null;
-  $scope.$on('ngDialog.opened', (event, $dialog) => {
-    dialog = $dialog;
-    vm.reposition();
-  });
-
-  let popper;
-  $scope.$on('$destroy', () => {
-    if (popper) {
-      popper.destroy();
-    }
-  });
-
-  // Reposition the popup as it is shown or if its size changes
-  vm.reposition = function() {
-    const element = $scope.$parent.ngDialogData;
-    if (element) {
-      if (popper) {
-        popper.scheduleUpdate();
-      } else {
-        const boundariesElement = document.getElementsByClassName('store-bounds')[0];
-        popper = new Popper(element[0], dialog[0], {
-          placement: 'top-start',
-          eventsEnabled: false,
-          modifiers: {
-            preventOverflow: {
-              priority: ['bottom', 'top', 'right', 'left'],
-              boundariesElement
-            },
-            flip: {
-              behavior: ['top', 'bottom', 'right', 'left'],
-              boundariesElement
-            },
-            offset: {
-              offset: '0,5px'
-            },
-            arrow: {
-              element: '.arrow'
-            }
-          }
-        });
-        popper.scheduleUpdate(); // helps fix arrow position
-      }
-    }
-  };
 
   /*
   * Open up the dialog for infusion by passing

--- a/src/scripts/move-popup/dimMovePopup.directive.js
+++ b/src/scripts/move-popup/dimMovePopup.directive.js
@@ -50,30 +50,30 @@ function MovePopupController($scope, dimStoreService, ngDialog, $timeout, dimSet
     const element = $scope.$parent.ngDialogData;
     if (element) {
       if (popper) {
-        popper.update();
+        popper.scheduleUpdate();
       } else {
+        const boundariesElement = document.getElementsByClassName('store-bounds')[0];
         popper = new Popper(element, dialog, {
-          placement: 'bottom-start',
+          placement: 'top-start',
           eventsEnabled: false,
           modifiers: {
             preventOverflow: {
-              boundariesElement: document.getElementsByClassName('store-bounds')[0],
-              escapeWithReference: true
+              priority: ['bottom', 'top', 'right', 'left'],
+              boundariesElement
             },
             flip: {
-              behavior: ['left', 'right', 'top']
+              behavior: ['top', 'bottom', 'right', 'left'],
+              boundariesElement
             },
             offset: {
               offset: '0,5px'
             },
             arrow: {
               element: '.arrow'
-            },
-            keepTogether: {
-              enabled: true
             }
           }
         });
+        popper.scheduleUpdate(); // helps fix arrow position
       }
     }
   };

--- a/src/scripts/move-popup/dimMovePopup.directive.js
+++ b/src/scripts/move-popup/dimMovePopup.directive.js
@@ -3,25 +3,22 @@ import template from './dimMovePopup.directive.html';
 import Popper from 'popper.js';
 
 angular.module('dimApp')
-  .directive('dimMovePopup', MovePopup);
+  .component('dimMovePopup', movePopup());
 
-function MovePopup() {
+function movePopup() {
   return {
     controller: MovePopupController,
     controllerAs: 'vm',
-    bindToController: true,
-    restrict: 'E',
-    scope: {
-      store: '=',
-      item: '='
+    bindings: {
+      store: '<',
+      item: '<'
     },
-    replace: true,
-    template: template
+    template
   };
 }
 
-
 function MovePopupController($scope, dimStoreService, ngDialog, $timeout, dimSettingsService, dimItemMoveService) {
+  'ngInject';
   const vm = this;
   vm.moveAmount = vm.item.amount;
   vm.settings = dimSettingsService;

--- a/src/scripts/move-popup/dimMovePopup.directive.js
+++ b/src/scripts/move-popup/dimMovePopup.directive.js
@@ -50,7 +50,7 @@ function MovePopupController($scope, dimStoreService, ngDialog, $timeout, dimSet
         popper.scheduleUpdate();
       } else {
         const boundariesElement = document.getElementsByClassName('store-bounds')[0];
-        popper = new Popper(element, dialog, {
+        popper = new Popper(element[0], dialog[0], {
           placement: 'top-start',
           eventsEnabled: false,
           modifiers: {

--- a/src/scripts/move-popup/dimTalentGrid.directive.html
+++ b/src/scripts/move-popup/dimTalentGrid.directive.html
@@ -9,7 +9,8 @@
        ng-repeat="node in vm.talentGrid.nodes | talentGridNodes:vm.hiddenColumns track by $index"
        ng-class="{ 'talent-node-activated': node.activated, 'talent-node-showxp': (!node.activated && node.xpRequired), 'talent-node-default': (node.activated && !node.xpRequired && !node.exclusiveInColumn && node.column < 1) }"
        ng-click="node.hash == 1270552711 ? vm.infuse({ '$event': $event }) : true"
-       press-tip="{{ node.name }}&#10;{{ node.description }}">
+       press-tip="{{ node.description }}"
+       press-tip-title="{{ node.name }}">
       <circle r="16"
               cx="-17"
               cy="17"

--- a/src/scripts/move-popup/dimTalentGrid.directive.html
+++ b/src/scripts/move-popup/dimTalentGrid.directive.html
@@ -1,9 +1,31 @@
-<svg preserveAspectRatio="xMaxYMin meet" svg-bind-viewbox="0 0 {{ (vm.numColumns * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor }} {{ (vm.numRows * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor + 1 }}" class="talent-grid" ng-attr-height="{{ (vm.numRows * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor }}" ng-attr-width="{{ (vm.numColumns * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor }}">
- <g ng-attr-transform="scale({{ vm.scaleFactor }})">
-  <g class="talent-node" ng-attr-transform="translate({{ (node.column - vm.hiddenColumns) * (vm.totalNodeSize) }},{{ node.row * (vm.totalNodeSize) }})" ng-repeat="node in vm.talentGrid.nodes | talentGridNodes:vm.hiddenColumns track by $index" ng-class="{ 'talent-node-activated': node.activated, 'talent-node-showxp': (!node.activated && node.xpRequired), 'talent-node-default': (node.activated && !node.xpRequired && !node.exclusiveInColumn && node.column < 1) }" ng-click="node.hash == 1270552711 ? vm.infuse({ '$event': $event }) : true">
-    <circle r="16" cx="-17" cy="17" transform="rotate(-90)" class="talent-node-xp" ng-attr-stroke-width="{{ node.xp ? 2 : 0 }}" ng-attr-stroke-dasharray="{{ 100.0 * node.xp / node.xpRequired }} 100" />
-    <image class="talent-node-img" xlink:href="" ng-attr-xlink:href="{{ node.icon | bungieIcon }}" x="20" y="20" height="96" width="96" transform="scale(0.25)"/>
-    <title>{{ node.name }}&#10;{{ node.description }}</title>
+<svg preserveAspectRatio="xMaxYMin meet"
+     svg-bind-viewbox="0 0 {{ (vm.numColumns * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor }} {{ (vm.numRows * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor + 1 }}"
+     class="talent-grid"
+     ng-attr-height="{{ (vm.numRows * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor }}"
+     ng-attr-width="{{ (vm.numColumns * vm.totalNodeSize - vm.nodePadding) * vm.scaleFactor }}">
+  <g ng-attr-transform="scale({{ vm.scaleFactor }})">
+    <g class="talent-node"
+       ng-attr-transform="translate({{ (node.column - vm.hiddenColumns) * (vm.totalNodeSize) }},{{ node.row * (vm.totalNodeSize) }})"
+       ng-repeat="node in vm.talentGrid.nodes | talentGridNodes:vm.hiddenColumns track by $index"
+       ng-class="{ 'talent-node-activated': node.activated, 'talent-node-showxp': (!node.activated && node.xpRequired), 'talent-node-default': (node.activated && !node.xpRequired && !node.exclusiveInColumn && node.column < 1) }"
+       ng-click="node.hash == 1270552711 ? vm.infuse({ '$event': $event }) : true"
+       press-tip="{{ node.name }}&#10;{{ node.description }}">
+      <circle r="16"
+              cx="-17"
+              cy="17"
+              transform="rotate(-90)"
+              class="talent-node-xp"
+              ng-attr-stroke-width="{{ node.xp ? 2 : 0 }}"
+              ng-attr-stroke-dasharray="{{ 100.0 * node.xp / node.xpRequired }} 100" />
+      <image class="talent-node-img"
+             xlink:href=""
+             ng-attr-xlink:href="{{ node.icon | bungieIcon }}"
+             x="20"
+             y="20"
+             height="96"
+             width="96"
+             transform="scale(0.25)"/>
+      <title>{{ node.name }}&#10;{{ node.description }}</title>
+    </g>
   </g>
- </g>
 </svg>

--- a/src/scripts/move-popup/item-popup.directive.js
+++ b/src/scripts/move-popup/item-popup.directive.js
@@ -1,0 +1,87 @@
+import angular from 'angular';
+import Popper from 'popper.js';
+
+angular.module('dimApp')
+  .directive('itemPopup', ItemPopup);
+
+/**
+ * Common functionality for positioning a popup next to an item (or
+ * item-like thing).  To use, add the "item-popup" attribute to the
+ * root of your ngDialog template, and pass the element you want to
+ * pop next to in the "data" option of the ngDialog call.  If you want
+ * an arrow to show, also include a (properly styled) element with the
+ * class "arrow" somewhere in your popup template.
+ */
+function ItemPopup() {
+  return {
+    restrict: 'A',
+    link: ItemPopupLink
+  };
+}
+
+function ItemPopupLink($scope, $element, $attrs) {
+  'ngInject';
+  const vm = this;
+
+  // Capture the dialog element
+  let dialog = null;
+  $scope.$on('ngDialog.opened', (event, $dialog) => {
+    dialog = $dialog;
+    vm.reposition();
+  });
+
+  let popper;
+  $scope.$on('$destroy', () => {
+    if (popper) {
+      popper.destroy();
+    }
+  });
+
+  function findDialogData() {
+    let scope = $scope;
+    let element = scope.ngDialogData;
+    while (!element && scope.$parent) {
+      scope = scope.$parent;
+      element = scope.ngDialogData;
+    }
+    return element;
+  }
+
+  // Reposition the popup as it is shown or if its size changes
+  vm.reposition = function() {
+    const element = findDialogData();
+    if (element) {
+      if (popper) {
+        popper.scheduleUpdate();
+      } else {
+        const popperOptions = {
+          placement: 'top-start',
+          eventsEnabled: false,
+          modifiers: {
+            preventOverflow: {
+              priority: ['bottom', 'top', 'right', 'left']
+            },
+            flip: {
+              behavior: ['top', 'bottom', 'right', 'left']
+            },
+            offset: {
+              offset: '0,5px'
+            },
+            arrow: {
+              element: '.arrow'
+            }
+          }
+        };
+
+        const boundariesElement = $attrs.itemPopupBoundaryClass ? document.getElementsByClassName($attrs.itemPopupBoundaryClass)[0] : undefined;
+        if (boundariesElement) {
+          popperOptions.modifiers.preventOverflow.boundariesElement = boundariesElement;
+          popperOptions.modifiers.flip.boundariesElement = boundariesElement;
+        }
+
+        popper = new Popper(element, dialog[0], popperOptions);
+        popper.scheduleUpdate(); // helps fix arrow position
+      }
+    }
+  };
+}

--- a/src/scripts/move-popup/item-popup.directive.js
+++ b/src/scripts/move-popup/item-popup.directive.js
@@ -21,13 +21,12 @@ function ItemPopup() {
 
 function ItemPopupLink($scope, $element, $attrs) {
   'ngInject';
-  const vm = this;
 
   // Capture the dialog element
   let dialog = null;
   $scope.$on('ngDialog.opened', (event, $dialog) => {
     dialog = $dialog;
-    vm.reposition();
+    reposition();
   });
 
   let popper;
@@ -36,6 +35,8 @@ function ItemPopupLink($scope, $element, $attrs) {
       popper.destroy();
     }
   });
+
+  $scope.$on('popup-size-changed', reposition);
 
   function findDialogData() {
     let scope = $scope;
@@ -48,7 +49,7 @@ function ItemPopupLink($scope, $element, $attrs) {
   }
 
   // Reposition the popup as it is shown or if its size changes
-  vm.reposition = function() {
+  function reposition() {
     const element = findDialogData();
     if (element) {
       if (popper) {
@@ -83,5 +84,5 @@ function ItemPopupLink($scope, $element, $attrs) {
         popper.scheduleUpdate(); // helps fix arrow position
       }
     }
-  };
+  }
 }

--- a/src/scripts/move-popup/press-tip.directive.js
+++ b/src/scripts/move-popup/press-tip.directive.js
@@ -5,27 +5,24 @@ import './press-tip.scss';
 angular.module('dimApp')
   .directive('pressTip', PressTip);
 
-function PressTip($timeout) {
+function PressTip() {
   'ngInject';
 
   return {
     restrict: 'A',
     link($scope, $element, $attrs) {
-      'ngInject';
-      console.log('link');
-
       let tooltip = null;
-      let timer = null;
 
       function showTip() {
-        console.log('show');
-        if (timer) {
-          timer.cancel();
-        }
         if (!tooltip) {
+          let title = $attrs.pressTip;
+          if ($attrs.pressTipTitle) {
+            title = `<h2>${$attrs.pressTipTitle}</h2>${title}`;
+          }
           tooltip = new Tooltip($element[0], {
             placement: 'top', // or bottom, left, right, and variations
-            title: $attrs.pressTip,
+            title,
+            html: true,
             trigger: 'manual',
             container: 'body'
           });
@@ -37,23 +34,13 @@ function PressTip($timeout) {
         showTip();
       });
 
-      $element.on('mouseenter', () => {
-        timer = $timeout(showTip, 2000);
-      });
-
       $element.on('mouseup mouseleave', () => {
-        if (timer) {
-          timer.cancel();
-        }
         if (tooltip) {
           tooltip.hide();
         }
       });
 
       $scope.$on('$destroy', () => {
-        if (timer) {
-          timer.cancel();
-        }
         if (tooltip) {
           tooltip.dispose();
           tooltip = null;

--- a/src/scripts/move-popup/press-tip.directive.js
+++ b/src/scripts/move-popup/press-tip.directive.js
@@ -30,11 +30,13 @@ function PressTip() {
         tooltip.show();
       }
 
-      $element.on('mousedown', () => {
+      $element.on('mousedown touchstart', (e) => {
+        e.preventDefault();
         showTip();
       });
 
-      $element.on('mouseup mouseleave', () => {
+      $element.on('mouseup mouseleave touchend', (e) => {
+        e.preventDefault();
         if (tooltip) {
           tooltip.hide();
         }

--- a/src/scripts/move-popup/press-tip.directive.js
+++ b/src/scripts/move-popup/press-tip.directive.js
@@ -1,0 +1,64 @@
+import angular from 'angular';
+import Tooltip from 'tooltip.js';
+import './press-tip.scss';
+
+angular.module('dimApp')
+  .directive('pressTip', PressTip);
+
+function PressTip($timeout) {
+  'ngInject';
+
+  return {
+    restrict: 'A',
+    link($scope, $element, $attrs) {
+      'ngInject';
+      console.log('link');
+
+      let tooltip = null;
+      let timer = null;
+
+      function showTip() {
+        console.log('show');
+        if (timer) {
+          timer.cancel();
+        }
+        if (!tooltip) {
+          tooltip = new Tooltip($element[0], {
+            placement: 'top', // or bottom, left, right, and variations
+            title: $attrs.pressTip,
+            trigger: 'manual',
+            container: 'body'
+          });
+        }
+        tooltip.show();
+      }
+
+      $element.on('mousedown', () => {
+        showTip();
+      });
+
+      $element.on('mouseenter', () => {
+        timer = $timeout(showTip, 2000);
+      });
+
+      $element.on('mouseup mouseleave', () => {
+        if (timer) {
+          timer.cancel();
+        }
+        if (tooltip) {
+          tooltip.hide();
+        }
+      });
+
+      $scope.$on('$destroy', () => {
+        if (timer) {
+          timer.cancel();
+        }
+        if (tooltip) {
+          tooltip.dispose();
+          tooltip = null;
+        }
+      });
+    }
+  };
+}

--- a/src/scripts/move-popup/press-tip.scss
+++ b/src/scripts/move-popup/press-tip.scss
@@ -6,8 +6,15 @@
     border-radius: 3px;
     box-shadow: 0 0 2px rgba(0,0,0,0.5);
     padding: 8px;
-    text-align: center;
+    text-align: left;
     z-index: 99999;
+
+    h2 {
+      margin: 0 0 4px 0;
+      font-size: 14px;
+      letter-spacing: 1px;
+      font-weight: normal;
+    }
 }
 
 .tooltip .tooltip-arrow {

--- a/src/scripts/move-popup/press-tip.scss
+++ b/src/scripts/move-popup/press-tip.scss
@@ -1,0 +1,75 @@
+.tooltip {
+    position: absolute;
+    background: #FB9F28;
+    color: black;
+    width: 150px;
+    border-radius: 3px;
+    box-shadow: 0 0 2px rgba(0,0,0,0.5);
+    padding: 8px;
+    text-align: center;
+    z-index: 99999;
+}
+
+.tooltip .tooltip-arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
+}
+
+.tooltip .tooltip-arrow {
+    border-color: #FB9F28;
+}
+.tooltip[x-placement^="top"] {
+    margin-bottom: 5px;
+}
+.tooltip[x-placement^="top"] .tooltip-arrow {
+    border-width: 5px 5px 0 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    bottom: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+.tooltip[x-placement^="bottom"] {
+    margin-top: 5px;
+}
+.tooltip[x-placement^="bottom"] .tooltip-arrow {
+    border-width: 0 5px 5px 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    top: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+.tooltip[x-placement^="right"] {
+    margin-left: 5px;
+}
+.tooltip[x-placement^="right"] .tooltip-arrow {
+    border-width: 5px 5px 5px 0;
+    border-left-color: transparent;
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    left: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+}
+.tooltip[x-placement^="left"] {
+    margin-right: 5px;
+}
+.tooltip[x-placement^="left"] .tooltip-arrow {
+    border-width: 5px 0 5px 5px;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    right: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+}

--- a/src/scripts/shell/dimAngularFilters.filter.js
+++ b/src/scripts/shell/dimAngularFilters.filter.js
@@ -279,7 +279,7 @@ mod.directive('svgBindViewbox', () => {
   return {
     link: function(scope, element, attrs) {
       attrs.$observe('svgBindViewbox', (value) => {
-        element.get(0).setAttribute('viewBox', value);
+        element[0].setAttribute('viewBox', value);
       });
     }
   };

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -1,8 +1,9 @@
 import angular from 'angular';
 import _ from 'underscore';
 import template from './dimSearchFilter.directive.html';
-import 'jquery-textcomplete';
 import { flatMap } from '../util';
+import Textcomplete from 'textcomplete/lib/textcomplete';
+import Textarea from 'textcomplete/lib/textarea';
 
 angular.module('dimApp')
   .factory('dimSearchService', SearchService)
@@ -132,7 +133,9 @@ function SearchFilter(dimSearchService) {
     controller: SearchFilterCtrl,
     controllerAs: 'vm',
     link: function link(scope, element) {
-      element.find('input').textcomplete([
+      const editor = new Textarea(element[0].getElementsByTagName('input')[0]);
+      const textcomplete = new Textcomplete(editor);
+      textcomplete.register([
         {
           words: dimSearchService.keywords,
           match: /\b((li|le|qu|pe|ra|is:|not:|tag:|notes:|stat:)\w*)$/,
@@ -149,6 +152,10 @@ function SearchFilter(dimSearchService) {
         }
       ], {
         zIndex: 1000
+      });
+
+      scope.$on('$destroy', () => {
+        textcomplete.destroy();
       });
     },
     bindToController: true,

--- a/src/scripts/shell/dimSearchFilter.directive.js
+++ b/src/scripts/shell/dimSearchFilter.directive.js
@@ -140,7 +140,7 @@ function SearchFilter(dimSearchService) {
           words: dimSearchService.keywords,
           match: /\b((li|le|qu|pe|ra|is:|not:|tag:|notes:|stat:)\w*)$/,
           search: function(term, callback) {
-            callback($.map(this.words, (word) => {
+            callback(this.words.map((word) => {
               return word.indexOf(term) === 0 ? word : null;
             }));
           },

--- a/src/scripts/store/dimStats.directive.html
+++ b/src/scripts/store/dimStats.directive.html
@@ -1,5 +1,5 @@
 <div class="stat-bars">
-  <div class="stat" title="{{ stat.tooltip }}" ng-repeat="stat in vm.statList track by stat.name">
+  <div class="stat" title="{{ stat.tooltip }}" press-tip="{{ stat.tooltip }}" ng-repeat="stat in vm.statList track by stat.name">
     <img ng-src="{{ ::stat.icon }}">
     <div class="bar" ng-repeat="n in stat.tiers track by $index">
       <div class="progress" ng-class="{ complete: (n / 60) === 1 }" dim-percent-width="n / 60"></div>

--- a/src/scripts/store/dimStoreItem.directive.dialog.html
+++ b/src/scripts/store/dimStoreItem.directive.dialog.html
@@ -1,1 +1,1 @@
-<dim-move-popup store="vm.store" item="vm.item" ng-click="$event.stopPropagation();" dim-click-anywhere-but-here="closeThisDialog()"></dim-move-popup>
+<dim-move-popup store="vm.store" item="vm.item" dim-click-anywhere-but-here="closeThisDialog()"></dim-move-popup>

--- a/src/scripts/store/dimStoreItem.directive.js
+++ b/src/scripts/store/dimStoreItem.directive.js
@@ -122,7 +122,7 @@ function StoreItem(dimItemService, dimStoreService, ngDialog, dimLoadoutService,
           overlay: false,
           className: 'move-popup-dialog',
           showClose: false,
-          data: element,
+          data: element[0],
           controllerAs: 'vm',
           controller: function() {
             'ngInject';

--- a/src/scripts/vendors/vendor-item-dialog.html
+++ b/src/scripts/vendors/vendor-item-dialog.html
@@ -1,4 +1,5 @@
 <div class="move-popup"
+     item-popup
      dim-click-anywhere-but-here="closeThisDialog()">
   <div dim-move-item-properties="vm.item"
        dim-compare-item="vm.compareItem"

--- a/src/scripts/vendors/vendor-item-dialog.html
+++ b/src/scripts/vendors/vendor-item-dialog.html
@@ -1,5 +1,6 @@
 <div class="move-popup"
      item-popup
+     item-popup-boundary-class="store-bounds"
      dim-click-anywhere-but-here="closeThisDialog()">
   <div dim-move-item-properties="vm.item"
        dim-compare-item="vm.compareItem"></div>

--- a/src/scripts/vendors/vendor-item-dialog.html
+++ b/src/scripts/vendors/vendor-item-dialog.html
@@ -1,7 +1,8 @@
 <div class="move-popup"
      dim-click-anywhere-but-here="closeThisDialog()">
   <div dim-move-item-properties="vm.item"
-       dim-compare-item="vm.compareItem"></div>
+       dim-compare-item="vm.compareItem"
+       change-details="vm.reposition()"></div>
   <div class="item-details more-item-details"
        ng-if="vm.item.equipment && vm.compareItems.length">
     <div ng-i18next="Vendors.Compare"></div>
@@ -27,4 +28,5 @@
       {{ store.name }}
     </div>
   </div>
+  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
 </div>

--- a/src/scripts/vendors/vendor-item-dialog.html
+++ b/src/scripts/vendors/vendor-item-dialog.html
@@ -2,8 +2,7 @@
      item-popup
      dim-click-anywhere-but-here="closeThisDialog()">
   <div dim-move-item-properties="vm.item"
-       dim-compare-item="vm.compareItem"
-       change-details="vm.reposition()"></div>
+       dim-compare-item="vm.compareItem"></div>
   <div class="item-details more-item-details"
        ng-if="vm.item.equipment && vm.compareItems.length">
     <div ng-i18next="Vendors.Compare"></div>

--- a/src/scripts/vendors/vendor-item.component.js
+++ b/src/scripts/vendors/vendor-item.component.js
@@ -91,7 +91,7 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
       dialogResult = ngDialog.open({
         template: dialogTemplate,
         overlay: false,
-        className: `move-popup vendor-move-popup ${vm.extraMovePopupClass || ''}`,
+        className: `move-popup-dialog vendor-move-popup ${vm.extraMovePopupClass || ''}`,
         showClose: false,
         scope: angular.extend($scope.$new(true), {
         }),

--- a/src/scripts/vendors/vendor-item.component.js
+++ b/src/scripts/vendors/vendor-item.component.js
@@ -23,45 +23,6 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
 
   let dialogResult = null;
 
-  let dialog = null;
-  $scope.$on('ngDialog.opened', (event, $dialog) => {
-    dialog = $dialog;
-    vm.reposition();
-  });
-
-  let popper;
-
-  // TODO: gotta make a vendor item popup directive
-
-  // Reposition the popup as it is shown or if its size changes
-  vm.reposition = function() {
-    if (dialogResult && dialog[0].id === dialogResult.id) {
-      if (popper) {
-        popper.scheduleUpdate();
-      } else {
-        popper = new Popper($element[0].getElementsByClassName('item')[0], dialog[0], {
-          placement: 'top-start',
-          eventsEnabled: false,
-          modifiers: {
-            preventOverflow: {
-              priority: ['bottom', 'top', 'right', 'left']
-            },
-            flip: {
-              behavior: ['top', 'bottom', 'right', 'left']
-            },
-            offset: {
-              offset: '0,7px'
-            },
-            arrow: {
-              element: '.arrow'
-            }
-          }
-        });
-        popper.scheduleUpdate(); // helps fix arrow position
-      }
-    }
-  };
-
   vm.clicked = function(e) {
     e.stopPropagation();
 
@@ -76,8 +37,6 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
       if (ngDialog.isOpen(dialogResult.id)) {
         dialogResult.close();
         dialogResult = null;
-        popper.destroy();
-        popper = null;
       }
     } else {
       const item = vm.saleItem.item;
@@ -88,6 +47,8 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
 
       const compareItemCount = sum(compareItems, 'amount');
 
+      const itemElement = $element[0].getElementsByClassName('item')[0];
+
       dialogResult = ngDialog.open({
         template: dialogTemplate,
         overlay: false,
@@ -95,6 +56,7 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
         showClose: false,
         scope: angular.extend($scope.$new(true), {
         }),
+        data: itemElement, // Dialog anchor
         controllerAs: 'vm',
         controller: function() {
           const innerVm = this;
@@ -122,8 +84,6 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
 
       dialogResult.closePromise.then(() => {
         dialogResult = null;
-        popper.destroy();
-        popper = null;
       });
 
       dimDestinyTrackerService.getItemReviews(item);
@@ -133,9 +93,6 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
   vm.$onDestroy = function() {
     if (dialogResult) {
       dialogResult.close();
-    }
-    if (popper) {
-      popper.destroy();
     }
   };
 }

--- a/src/scripts/vendors/vendor-item.component.js
+++ b/src/scripts/vendors/vendor-item.component.js
@@ -3,7 +3,6 @@ import _ from 'underscore';
 import { sum } from '../util';
 import template from './vendor-item.html';
 import dialogTemplate from './vendor-item-dialog.html';
-import Popper from 'popper.js';
 
 export const VendorItem = {
   bindings: {

--- a/src/scripts/vendors/vendor-item.component.js
+++ b/src/scripts/vendors/vendor-item.component.js
@@ -70,8 +70,7 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
             compareItemCount: compareItemCount,
             setCompareItem: function(item) {
               this.compareItem = item;
-            },
-            reposition: vm.reposition
+            }
           });
         },
         // Setting these focus options prevents the page from

--- a/src/scripts/vendors/vendor-item.component.js
+++ b/src/scripts/vendors/vendor-item.component.js
@@ -39,7 +39,7 @@ function VendorItemCtrl($scope, $element, ngDialog, dimStoreService, dimDestinyT
       if (popper) {
         popper.scheduleUpdate();
       } else {
-        popper = new Popper($element[0].getElementsByClassName('item')[0], dialog, {
+        popper = new Popper($element[0].getElementsByClassName('item')[0], dialog[0], {
           placement: 'top-start',
           eventsEnabled: false,
           modifiers: {

--- a/src/scripts/vendors/vendors.scss
+++ b/src/scripts/vendors/vendors.scss
@@ -177,9 +177,7 @@
 
 .ngdialog.vendor-move-popup {
   position: absolute;
-  z-index: 10000;
   height: fit-content;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, .8);
   .compare-items {
     margin-top: 0;
     display: flex;

--- a/src/scss/_move-popup.scss
+++ b/src/scss/_move-popup.scss
@@ -4,8 +4,68 @@
 // The popup displaying info and actions for an single item.
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+@import 'variables.scss';
+
 .move-popup-dialog {
   height: fit-content;
+
+  .arrow {
+    border-color: #222;
+  }
+
+  &[x-placement^="top"] .arrow {
+    border-width: 5px 5px 0 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    bottom: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  &[x-placement^="bottom"] .arrow {
+    border-width: 0 5px 5px 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    top: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+
+    border-bottom-color: white;
+
+    &.is-arc {
+      border-bottom-color: $arc;
+    }
+    &.is-solar {
+      border-bottom-color: $solar;
+    }
+    &.is-void {
+      border-bottom-color: $void;
+    }
+  }
+  &[x-placement^="right"] .arrow {
+    border-width: 5px 5px 5px 0;
+    border-left-color: transparent;
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    left: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+  }
+  &[x-placement^="left"] .arrow {
+    border-width: 5px 0 5px 5px;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    right: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 .move-popup-tabs {
@@ -213,4 +273,12 @@ $item-header-spacing: 5px;
 
 dim-objectives {
   display: block;
+}
+
+.arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
 }

--- a/src/scss/_move-popup.scss
+++ b/src/scss/_move-popup.scss
@@ -8,6 +8,69 @@
 
 .move-popup-dialog {
   height: fit-content;
+
+  .arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
+    border-color: #222;
+  }
+
+  &[x-placement^="top"] .arrow {
+    border-width: 5px 5px 0 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    bottom: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  &[x-placement^="bottom"] .arrow {
+    border-width: 0 5px 5px 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    top: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+
+    border-bottom-color: white;
+
+    &.is-arc {
+      border-bottom-color: $arc;
+    }
+    &.is-solar {
+      border-bottom-color: $solar;
+    }
+    &.is-void {
+      border-bottom-color: $void;
+    }
+  }
+  &[x-placement^="right"] .arrow {
+    border-width: 5px 5px 5px 0;
+    border-left-color: transparent;
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    left: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+  }
+  &[x-placement^="left"] .arrow {
+    border-width: 5px 0 5px 5px;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    right: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 .move-popup-tabs {
@@ -102,64 +165,6 @@
       border: none;
       outline: none;
     }
-  }
-
-  .arrow {
-    border-color: #222;
-  }
-
-  &[x-placement^="top"] .arrow {
-    border-width: 5px 5px 0 5px;
-    border-left-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    bottom: -5px;
-    left: calc(50% - 5px);
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-
-  &[x-placement^="bottom"] .arrow {
-    border-width: 0 5px 5px 5px;
-    border-left-color: transparent;
-    border-right-color: transparent;
-    border-top-color: transparent;
-    top: -5px;
-    left: calc(50% - 5px);
-    margin-top: 0;
-    margin-bottom: 0;
-
-    border-bottom-color: white;
-
-    &.is-arc {
-      border-bottom-color: $arc;
-    }
-    &.is-solar {
-      border-bottom-color: $solar;
-    }
-    &.is-void {
-      border-bottom-color: $void;
-    }
-  }
-  &[x-placement^="right"] .arrow {
-    border-width: 5px 5px 5px 0;
-    border-left-color: transparent;
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    left: -5px;
-    top: calc(50% - 5px);
-    margin-left: 0;
-    margin-right: 0;
-  }
-  &[x-placement^="left"] .arrow {
-    border-width: 5px 0 5px 5px;
-    border-top-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    right: -5px;
-    top: calc(50% - 5px);
-    margin-left: 0;
-    margin-right: 0;
   }
 }
 
@@ -273,12 +278,4 @@ $item-header-spacing: 5px;
 
 dim-objectives {
   display: block;
-}
-
-.arrow {
-    width: 0;
-    height: 0;
-    border-style: solid;
-    position: absolute;
-    margin: 5px;
 }

--- a/src/scss/_move-popup.scss
+++ b/src/scss/_move-popup.scss
@@ -8,64 +8,6 @@
 
 .move-popup-dialog {
   height: fit-content;
-
-  .arrow {
-    border-color: #222;
-  }
-
-  &[x-placement^="top"] .arrow {
-    border-width: 5px 5px 0 5px;
-    border-left-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    bottom: -5px;
-    left: calc(50% - 5px);
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-
-  &[x-placement^="bottom"] .arrow {
-    border-width: 0 5px 5px 5px;
-    border-left-color: transparent;
-    border-right-color: transparent;
-    border-top-color: transparent;
-    top: -5px;
-    left: calc(50% - 5px);
-    margin-top: 0;
-    margin-bottom: 0;
-
-    border-bottom-color: white;
-
-    &.is-arc {
-      border-bottom-color: $arc;
-    }
-    &.is-solar {
-      border-bottom-color: $solar;
-    }
-    &.is-void {
-      border-bottom-color: $void;
-    }
-  }
-  &[x-placement^="right"] .arrow {
-    border-width: 5px 5px 5px 0;
-    border-left-color: transparent;
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    left: -5px;
-    top: calc(50% - 5px);
-    margin-left: 0;
-    margin-right: 0;
-  }
-  &[x-placement^="left"] .arrow {
-    border-width: 5px 0 5px 5px;
-    border-top-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    right: -5px;
-    top: calc(50% - 5px);
-    margin-left: 0;
-    margin-right: 0;
-  }
 }
 
 .move-popup-tabs {
@@ -160,6 +102,64 @@
       border: none;
       outline: none;
     }
+  }
+
+  .arrow {
+    border-color: #222;
+  }
+
+  &[x-placement^="top"] .arrow {
+    border-width: 5px 5px 0 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    bottom: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  &[x-placement^="bottom"] .arrow {
+    border-width: 0 5px 5px 5px;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    top: -5px;
+    left: calc(50% - 5px);
+    margin-top: 0;
+    margin-bottom: 0;
+
+    border-bottom-color: white;
+
+    &.is-arc {
+      border-bottom-color: $arc;
+    }
+    &.is-solar {
+      border-bottom-color: $solar;
+    }
+    &.is-void {
+      border-bottom-color: $void;
+    }
+  }
+  &[x-placement^="right"] .arrow {
+    border-width: 5px 5px 5px 0;
+    border-left-color: transparent;
+    border-top-color: transparent;
+    border-bottom-color: transparent;
+    left: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
+  }
+  &[x-placement^="left"] .arrow {
+    border-width: 5px 0 5px 5px;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+    right: -5px;
+    top: calc(50% - 5px);
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -1590,11 +1590,14 @@ h2, h3, h4 {
 .dropdown-menu {
   border: 1px solid #ddd;
   background-color: white;
-  transform: translate(-11px, 5px);
+  transform: translate(0, -1px);
+  .textcomplete-header, .textcomplete-footer {
+    display: none;
+  }
   li {
     border-top: 1px solid #ddd;
     padding: 2px 5px;
-    &:first-child {
+    &:nth-child(2) {
       border-top: none;
     }
     &:hover {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -1282,7 +1282,7 @@ g {
   bottom: -800px;
   left: 0;
   right: 0;
-  top: 141px;
+  top: 124px;
 }
 
 .collapse {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -1279,7 +1279,7 @@ g {
   position: fixed;
   backface-visibility: hidden;
   pointer-events: none;
-  bottom: -800px;
+  bottom: 0px;
   left: 0;
   right: 0;
   top: 124px;


### PR DESCRIPTION
1. Ditched `jquery-ui.position` in favor of [`popper.js`](https://popper.js.org/), which has more capabilities (better positioning, etc) and no jQuery dependency. It also works on SVG elements, which the previous library didn't. New popups are positioned to make use of screen space much better, meaning they may appear on the left or right of the item as well as above or below it, and they may slide back and forth next to the arrow to make space. To help this make sense, the popup has a little arrow on it pointing to the item. Note: The arrow is a bit hard to see because of the color of the move popup - we should change that!
2. Move popup positioning logic is now extracted into a common directive that's shared between regular items, vendor items, and loadout builder items.
3. I've added a "press-tip" library that uses tooltip.js (also from the popper.js framework), and applied it to the talent grid nodes and the status under your character. Now you can see that tooltip text by pressing on them, even on mobile!
4. I've completely removed our dependency on jQuery. This involved also swapping out `jquery.textcomplete` for `textcomplete`, a newer version of the same library that doesn't depend on jQuery. I expect I've missed a few conversions here and there due to AngularJS' bad API decisions.
5. I've fixed several global event leaks.

This doesn't yet fix the move popup for mobile - that'll be a bit more work.

![popper](https://user-images.githubusercontent.com/313208/28243400-b2d66376-697c-11e7-988d-db095751fc00.gif)

![presstip](https://user-images.githubusercontent.com/313208/28243381-1530a12c-697c-11e7-8c91-5b115e196131.gif)

This fixes #575 and #1129.