### PR TITLE
Remove messageformat and window.i18next

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -20,7 +20,6 @@ const nodeModulesDir = path.join(__dirname, '../node_modules');
 const preMinifiedDeps = [
   'underscore/underscore-min.js',
   'indexeddbshim/dist/indexeddbshim.min.js',
-  'messageformat/messageformat.min.js',
   'jquery/dist/jquery.min.js'
 ];
 
@@ -113,7 +112,8 @@ module.exports = (env) => {
         $: 'jquery',
         jQuery: 'jquery',
         'window.jQuery': 'jquery',
-        MessageFormat: 'messageformat'
+        i18next: 'i18next',
+        'window.i18next': 'i18next'
       }),
 
       new CleanWebpackPlugin(['dist'], {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dim",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4813,6 +4813,10 @@
         "rsyncwrapper": "https://registry.npmjs.org/rsyncwrapper/-/rsyncwrapper-2.0.1.tgz"
       }
     },
+    "grunt-sort-json": {
+      "version": "github:delphiactual/grunt-sort-json#ba37194070f9391b875ffe43bd73df7283cd6d92",
+      "dev": true
+    },
     "grunt-upload-file": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/grunt-upload-file/-/grunt-upload-file-0.0.2.tgz",
@@ -6783,7 +6787,8 @@
       "dev": true
     },
     "jquery": {
-      "version": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
       "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
     },
     "jquery-textcomplete": {
@@ -6792,7 +6797,8 @@
       "integrity": "sha512-eFIaZZAWksIFtyULLlrlVO8MGeaHoCtPdyLqR3MZUp1BlUD7uIi3jO4soRHKlR1+lNcspS8bLnLYpqn12Hlzlw=="
     },
     "jquery-ui": {
-      "version": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
       "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
     "js-base64": {

--- a/src/scripts/dimApp.config.js
+++ b/src/scripts/dimApp.config.js
@@ -6,6 +6,8 @@ import es from '../i18n/dim_es.json';
 import ja from '../i18n/dim_ja.json';
 import ptBR from '../i18n/dim_pt_BR.json';
 
+import i18next from 'i18next';
+
 function config($compileProvider, $httpProvider, hotkeysProvider,
                 ngHttpRateLimiterConfigProvider, ngDialogProvider) {
   'ngInject';
@@ -21,7 +23,7 @@ function config($compileProvider, $httpProvider, hotkeysProvider,
   hotkeysProvider.includeCheatSheet = true;
 
   // See https://github.com/i18next/ng-i18next
-  window.i18next.init({
+  i18next.init({
     debug: $DIM_FLAVOR === 'dev',
     fallbackLng: 'en',
     lowerCaseLng: true,

--- a/src/scripts/dimApp.config.js
+++ b/src/scripts/dimApp.config.js
@@ -6,7 +6,7 @@ import es from '../i18n/dim_es.json';
 import ja from '../i18n/dim_ja.json';
 import ptBR from '../i18n/dim_pt_BR.json';
 
-import i18next from 'i18next';
+import { init as i18init } from 'i18next';
 
 function config($compileProvider, $httpProvider, hotkeysProvider,
                 ngHttpRateLimiterConfigProvider, ngDialogProvider) {
@@ -23,7 +23,7 @@ function config($compileProvider, $httpProvider, hotkeysProvider,
   hotkeysProvider.includeCheatSheet = true;
 
   // See https://github.com/i18next/ng-i18next
-  i18next.init({
+  i18init({
     debug: $DIM_FLAVOR === 'dev',
     fallbackLng: 'en',
     lowerCaseLng: true,

--- a/src/scripts/dimApp.module.js
+++ b/src/scripts/dimApp.module.js
@@ -40,9 +40,6 @@ import run from './dimApp.run';
 import state from './state';
 import loadingTracker from './services/dimLoadingTracker.factory';
 
-// required to make ng-i18next work
-window.i18next = i18next;
-
 const dependencies = [
   AriaModule,
   DialogModule,

--- a/src/scripts/settings/dimSettingsService.factory.js
+++ b/src/scripts/settings/dimSettingsService.factory.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import _ from 'underscore';
-import i18next from 'i18next';
+import { changeLanguage } from 'i18next';
 
 /**
  * The settings service provides a settings object which contains
@@ -109,9 +109,7 @@ export function SettingsService($rootScope, SyncService, $window, $i18next, $q) 
 
     $rootScope.$evalAsync(() => {
       angular.merge(settings, savedSettings);
-      i18next.init({
-        lng: settings.language
-      });
+      changeLanguage(settings.language);
       $rootScope.$emit('dim-settings-loaded', {});
     });
   });

--- a/src/scripts/settings/dimSettingsService.factory.js
+++ b/src/scripts/settings/dimSettingsService.factory.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import _ from 'underscore';
+import i18next from 'i18next';
 
 /**
  * The settings service provides a settings object which contains
@@ -108,8 +109,8 @@ export function SettingsService($rootScope, SyncService, $window, $i18next, $q) 
 
     $rootScope.$evalAsync(() => {
       angular.merge(settings, savedSettings);
-      window.i18next.init({
-        lng: settings.language,
+      i18next.init({
+        lng: settings.language
       });
       $rootScope.$emit('dim-settings-loaded', {});
     });


### PR DESCRIPTION
This removes messageformat handling from webpack.js, and uses the provide plugin to make i18next work (instead of assigning to a window global).