### PR TITLE
RFC: Prototype of showing items that could help fill out your collection

### DIFF
--- a/src/scripts/vendors/vendor.service.js
+++ b/src/scripts/vendors/vendor.service.js
@@ -54,7 +54,7 @@ function VendorService(
     3917130357, // Eververse
     4269570979 // Cryptarch (Tower)
   ];
-   */
+  */
 
   // Vendors we don't want to load by default
   const vendorBlackList = [
@@ -161,6 +161,8 @@ function VendorService(
         })));
       })
       .then(() => {
+        // Look at a list of kiosks, figure out which you don't have that are being sold
+        calculateCollectibles();
         $rootScope.$broadcast('dim-vendors-updated');
         service.vendorsLoaded = true;
         fulfillRatingsRequest();
@@ -174,6 +176,33 @@ function VendorService(
 
     _reloadPromise.activePlatform = activePlatform;
     return _reloadPromise;
+  }
+
+  function calculateCollectibles() {
+    // TODO: do this while building
+    const lockedItems = new Set();
+    // Calculate set of hashes of things you can't buy
+    Object.values(service.vendors).forEach((vendor) => {
+      vendor.categories.forEach((category) => {
+        category.saleItems.forEach((saleItem) => {
+          if (!saleItem.unlocked && !saleItem.item.isEngram()) {
+            lockedItems.add(saleItem.item.hash);
+          }
+        });
+      });
+    });
+
+    Object.values(service.vendors).forEach((vendor) => {
+      vendor.categories.forEach((category) => {
+        category.saleItems.forEach((saleItem) => {
+          if (saleItem.unlocked && lockedItems.has(saleItem.item.hash)) {
+            // TODO: new property, on the saleItem?
+            saleItem.item.complete = true;
+          }
+        });
+      });
+    });
+
   }
 
   function mergeVendors([firstVendor, ...otherVendors]) {


### PR DESCRIPTION
This is a quick prototype of a solution to #1094. It highlights items you could buy from vendors that you don't have in your collection kiosks. Right now it highlights them by marking them complete, which isn't what we'd want.

Questions I need answers to before merging something like this:
1. How should we highlight these items? An icon? A special border?
2. What should the search keyword be? `is:neededforcollection`?
3. This won't update when you actually buy those items, because we cache the kiosks the same way we do all vendors (actually, kiosks have no refresh time, so we choose 8 hours now). How do we want to handle that? Just deal with it and things will update at the reset? Make a hand-maintained list of kiosks that refresh quicker? Add manual "force refresh" buttons to every vendor?

<img width="329" alt="screen shot 2017-07-16 at 12 59 02 pm" src="https://user-images.githubusercontent.com/313208/28250812-9223ae18-6a26-11e7-8d2b-5282adccc2d1.png">
