### PR TITLE
support jqLite selector

### DIFF
--- a/src/scripts/compare/compare.component.js
+++ b/src/scripts/compare/compare.component.js
@@ -120,7 +120,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, $i18ne
   };
 
   vm.itemClick = function itemClick(item) {
-    const element = angular.element(`#${item.index}`);
+    const element = angular.element(document.getElementById(item.index));
     const elementRect = element[0].getBoundingClientRect();
     const absoluteElementTop = elementRect.top + window.pageYOffset;
     window.scrollTo(0, absoluteElementTop - 150);

--- a/src/scripts/storage/storage.component.js
+++ b/src/scripts/storage/storage.component.js
@@ -104,7 +104,7 @@ function StorageController($scope, dimSettingsService, SyncService, GoogleDriveS
       });
       $window.alert($i18next.t('Storage.ImportSuccess'));
     };
-    const file = angular.element('#importFile')[0].files[0];
+    const file = angular.element(document.getElementById('importFile'))[0].files[0];
     if (file) {
       reader.readAsText(file);
     } else {

--- a/src/scripts/store/dimStoreBucket.directive.js
+++ b/src/scripts/store/dimStoreBucket.directive.js
@@ -70,7 +70,7 @@ function StoreBucketCtrl($scope,
     }
   };
   vm.onDrop = function(id, $event, equip) {
-    vm.moveDroppedItem(angular.element(`#${id}`).scope().item, equip, $event, hovering);
+    vm.moveDroppedItem(angular.element(document.getElementById(id)).scope().item, equip, $event, hovering);
     hovering = false;
     dragHelp.classList.remove('drag-dwell-activated');
     $timeout.cancel(dragTimer);


### PR DESCRIPTION
Drag/Drop item, Scroll to item in the compare view, and importing file isn't working w/o jQuery -

> Error: [jqLite:nosel] Looking up elements via selectors is not supported by jqLite! See: http://docs.angularjs.org/api/angular.element