### PR TITLE
Better Nav on non-account specific pages

### DIFF
--- a/src/app/shell/header.html
+++ b/src/app/shell/header.html
@@ -3,6 +3,10 @@
     <i class="fa fa-bars"></i>
     <div class="dropdown" ng-if="$ctrl.dropdown">
       <a class="link"
+         ng-if="!$ctrl.destinyVersion"
+         ui-sref-active="active"
+         ui-sref="default-account">DIM</a>
+      <a class="link"
          ng-if="$ctrl.destinyVersion == 1"
          ui-sref-active="active"
          ui-sref="destiny1.inventory"
@@ -75,6 +79,13 @@
      rel="noopener noreferrer"
      href="https://teespring.com/stores/dim"
      ng-i18next="Header.Shop"></a>
+
+  <span ng-if="!$ctrl.destinyVersion" class="link first-to-go header-separator"></span>
+
+  <a class="link second-to-go"
+     ui-sref-active="active"
+     ui-sref="default-account"
+     ng-if="!$ctrl.destinyVersion">DIM</a>
 
   <span ng-if="$ctrl.destinyVersion == 1" class="link first-to-go header-separator"></span>
 


### PR DESCRIPTION
Added `DIM` to Header and dropdown when no account is set. Makes for a more cohesive navigation experience for the end user. We can of course change the name from DIM, to something else. #2032 

![screenshot 2017-07-23 08 45 38](https://user-images.githubusercontent.com/4798491/28500317-6ae61158-6f83-11e7-9efa-dce5ec0293ce.png)


//cc @bhollis 