### PR TITLE
Reenable wasm for beta, but not android.

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -194,8 +194,8 @@ module.exports = (env) => {
         // Sync data over gdrive
         '$featureFlags.gdrive': JSON.stringify(true),
         '$featureFlags.debugSync': JSON.stringify(false),
-        // Use a WebAssembly version of SQLite, if possible
-        '$featureFlags.wasm': JSON.stringify(false),
+        // Use a WebAssembly version of SQLite, if possible (this crashes on Android Chrome right now)
+        '$featureFlags.wasm': `${JSON.stringify(env !== 'release')} && !window.navigator.userAgent.includes("Android")`,
         // Enable color-blind a11y
         '$featureFlags.colorA11y': JSON.stringify(env !== 'release'),
         // Whether to log page views for router events


### PR DESCRIPTION
Using the WebAssembly version of SQLite is a lot faster on Chrome and Firefox, and soon in iOS 11 Safari too. I had turned this off because it appears to crash Chrome on Android sometimes, so this disables wasm for Android but leaves it on for everybody else. Still beta-only for now.