### PR TITLE
Switch to explicit Angular bootstrap and remove ng-csp

### DIFF
--- a/src/authReturn.js
+++ b/src/authReturn.js
@@ -1,1 +1,4 @@
+import angular from 'angular';
 import './app/auth-return/auth-return.module';
+
+angular.bootstrap(document.body, ['authReturnModule'], { strictDi: true });

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="" ng-app="app" ng-csp ng-strict-di>
+<html lang="">
 
   <head>
     <meta charset="utf-8">
@@ -33,7 +33,7 @@
 
   </head>
 
-  <body ng-strict-di>
+  <body>
     <app></app>
 
     <script async src="https://www.google-analytics.com/analytics.js"></script>

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import angular from 'angular';
+
 require('babel-polyfill');
 
 require('./app/google');
@@ -58,3 +60,5 @@ if ($DIM_FLAVOR !== 'dev' && navigator.serviceWorker) {
       console.error('Unable to register service worker.', err);
     });
 }
+
+angular.bootstrap(document.body, ['app'], { strictDi: true });

--- a/src/return.html
+++ b/src/return.html
@@ -8,7 +8,7 @@
   </head>
 
   <body>
-    <div ng-app="authReturnModule" ng-strict-di ng-csp>
+    <div>
       <dim-return></dim-return>
     </div>
 


### PR DESCRIPTION
Switching to explicit bootstrap (instead of `ng-app`) is one of the steps along the road to Angular 2+. Removing `ng-csp` (after making sure our CSP rules were OK) allows AngularJS to make some optimizations that they claim could improve performance of some operations by up to 30%.