### PR TITLE
Stop supporting iOS 9

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,7 @@
           "last 2 ChromeAndroid versions",
           "last 2 Firefox versions",
           "last 1 Safari versions",
-          "iOS >= 9",
+          "last 1 iOS versions",
           "last 2 Edge versions"
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6349,10 +6349,6 @@
         "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
       }
     },
-    "indexeddbshim": {
-      "version": "https://registry.npmjs.org/indexeddbshim/-/indexeddbshim-2.2.1.tgz",
-      "integrity": "sha1-yxFwknMpnyKt8vHOy3Q+whNKY1Y="
-    },
     "indexes-of": {
       "version": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "last 2 ChromeAndroid versions",
     "last 2 Firefox versions",
     "last 1 Safari versions",
-    "iOS >= 9",
+    "last 1 iOS versions",
     "last 2 Edge versions"
   ],
   "devDependencies": {
@@ -107,7 +107,6 @@
     "file-loader": "^0.11.1",
     "i18next": "^8.4.3",
     "idb-keyval": "^2.3.0",
-    "indexeddbshim": "^2.2.1",
     "ng-dialog": "^1.3.0",
     "ng-http-rate-limiter": "^1.0.1",
     "rxjs": "^5.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-require('babel-polyfill');
+import 'babel-polyfill';
 
 require('./app/google');
 
@@ -11,9 +11,6 @@ iosDragDropShim({
 });
 // https://github.com/timruffles/ios-html5-drag-drop-shim/issues/77
 window.addEventListener('touchmove', () => {});
-
-// Shim IndexedDB using WebSQL for iOS 9
-require('indexeddbshim');
 
 // Initialize the main DIM app
 require('./app/app.module');


### PR DESCRIPTION
I've done a new round of testing, and DIM no longer loads on iOS 9. I think it was right on the edge before, and despite our performance improvements, the new manifest file and the new stuff we're doing kills it. This formally removes support for iOS 9, which kills support for iPad 2 and 3, and iPad Mini 1. To be honest, this wasn't something I was going to be able to keep testing anyway. By removing this support, we also get the opportunity to optimize more against newer browsers (and we save 50KB of JS right off the top).

This requires https://github.com/DestinyItemManager/DIM/pull/2043 so that users know why things aren't working.