### PR TITLE
Fix centering inventory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix a bug where the popup for Xur items was below Xur's own popup.
 * The first item in the search autocompleter is once again selected automatically.
+* If you don't have the vault width set to "auto", the inventory is once again centered.
 
 # 4.5.0
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -801,6 +801,7 @@ dim-store-heading {
   max-width: calc((52px + 44px + (3 * (44px + 8px))) * 3 + 20px + (999 * (44px + 8px)));
   min-width: calc((52px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px))) * var(--num-characters) + 39px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px)));
   max-width: calc((52px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px))) * var(--num-characters) + 20px + (var(--vault-max-columns) * (var(--item-size) + 8px)));
+  margin: 0 auto;
 }
 
 .stores {


### PR DESCRIPTION
Somebody on Reddit noticed that if you don't have the vault width set to "auto", the inventory was left-aligned instead of centered. This puts it back.

Longer-term, do we want to remove these settings (character and vault width)? I'm not sure what the value is, and they do complicate things.