### PR TITLE
Add support for object rest/spread syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,5 +16,9 @@
       }
     }]
   ],
-  "plugins": ["angularjs-annotate", "syntax-dynamic-import"]
+  "plugins": [
+    "angularjs-annotate",
+    "syntax-dynamic-import",
+    ["transform-object-rest-spread", { "useBuiltIns": true }]
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -720,6 +720,12 @@
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -979,6 +985,16 @@
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.23.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
         "babel-runtime": "6.23.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-angularjs-annotate": "^0.7.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "clean-webpack-plugin": "^0.1.14",
     "copy-webpack-plugin": "^4.0.1",

--- a/src/app/accounts/account-select.component.js
+++ b/src/app/accounts/account-select.component.js
@@ -34,15 +34,15 @@ function AccountSelectController($scope, dimPlatformService, loadingTracker, ngD
       // Duplicate each Destiny account, since they may have played either D1 or D2.
       // TODO: Maybe push this into the account service, and allow people to "hide" accounts?
       return [
-        Object.assign({}, account, { destinyVersion: 1 }),
-        Object.assign({}, account, { destinyVersion: 2 })
+        { ...account, destinyVersion: 1 },
+        { ...account, destinyVersion: 2 }
       ];
     });
   }
 
-    // TODO: save this in the account service, or some other global state, so we don't flip flop
+  // TODO: save this in the account service, or some other global state, so we don't flip flop
   function setCurrentAccount(currentAccount) {
-    vm.currentAccount = Object.assign({}, currentAccount, { destinyVersion: vm.destinyVersion });
+    vm.currentAccount = { ...currentAccount, destinyVersion: vm.destinyVersion };
   }
 
   vm.accountChange = function accountChange(account) {


### PR DESCRIPTION
The (proposed) object rest/spread notation is quite nice, so this change adds the Babel transform for it.

It turns this:
```js
const bax = Object.assign({}, foo, { bar: baz });
```

Into:
```js
const bax = { ...foo, bar: baz };
```