### PR TITLE
Stop deleting files on the server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,6 @@ module.exports = function(grunt) {
         host: process.env.REMOTE_HOST,
         port: 2222,
         recursive: true,
-        deleteAll: true,
         ssh: true,
         privateKey: 'config/dim_travis.rsa',
         sshCmdArgs: ["-o StrictHostKeyChecking=no"]


### PR DESCRIPTION
This will stop us from cleaning up old versions of files on the server - meaning that the service worker will still be able to cache those old versions if it wants to.