### PR TITLE
browserslist target specific versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "homepage": "https://destinyitemmanager.com",
   "browserslist": [
-    "last 2 Chrome versions",
-    "last 2 ChromeAndroid versions",
-    "last 2 Firefox versions",
-    "last 1 Safari versions",
-    "last 1 iOS versions",
-    "last 2 Edge versions"
+    "Chrome >= 58",
+    "ChromeAndroid >= 59",
+    "Firefox >= 53",
+    "Safari >= 10",
+    "iOS >= 10",
+    "Edge >= 14"
   ],
   "devDependencies": {
     "autoprefixer": "^7.1.2",


### PR DESCRIPTION
Using the previous targets, this now targets those versions specifically instead of forcing people to upgrade to newer versions unless they are required (i.e Chrome_Android 59 because 58 crashes with wasm).
This has been tested on Chrome, Firefox, and the popup does not appear unless falling outside of the requirements. I do not have access to macOS or an iOS device to test for them, we may have to specify major.minor on macOS/iOS versions.