### PR TITLE
Better error handling for weird Bungie.net auth responses (no auth loops)

### DIFF
--- a/src/app/auth-return/return.component.js
+++ b/src/app/auth-return/return.component.js
@@ -22,8 +22,16 @@ function ReturnController($http, OAuthService, OAuthTokenService) {
     ctrl.state = queryString.state;
     ctrl.authorized = (ctrl.code && ctrl.code.length > 0);
 
-    if (!ctrl.authorized || ctrl.state !== localStorage.authorizationState) {
-      window.location = "/index.html#!/login";
+    if (!ctrl.authorized) {
+      ctrl.error = "We expected an authorization code parameter from Bungie.net, but didn't get one.";
+      return;
+    }
+
+    if (ctrl.state !== localStorage.authorizationState) {
+      ctrl.error = "We expected the state parameter to match what we stored, but it didn't.";
+      if (!localStorage.authorizationState) {
+        ctrl.error += " There was no stored state at all - your browser may not support (or may be blocking) localStorage.";
+      }
       return;
     }
 


### PR DESCRIPTION
This should help us with "auth loops" when either Bungie.net or the user's browser is misbehaving. Instead of sending them directly back to the login page on missing code or state parameter, we'll display an error instead. It's not a very helpful error, but they'll at least have something to tell us.