### PR TITLE
Avoid caching the service worker

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -264,7 +264,7 @@ module.exports = (env) => {
         'return.html',
       ],
       // swSrc: './src/sw.js',
-      swDest: './dist/sw.js'
+      swDest: './dist/service-worker.js'
     }));
   }
 

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -958,3 +958,15 @@ FileETag None
     </FilesMatch>
 
 </IfModule>
+
+# Do not cache the service worker!
+
+<Files "service-worker.js">
+    FileETag None
+    <IfModule mod_headers.c>
+        Header unset ETag
+        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+        Header set Pragma "no-cache"
+        Header unset Expires
+    </IfModule>
+</Files>

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,9 @@
   </head>
 
   <body>
-    <app></app>
+    <app>
+      DIM hasn't loaded. Something may be wrong with it, or with your browser (maybe you have a content blocker, or have disabled JavaScript). Try force reloading to make sure (Ctrl-F5 or Cmd-R).
+    </app>
     <div id="browser-warning" class="hidden">Your browser is not supported by DIM. Some or all DIM functionality may not work. Please upgrade to a supported browser.</div>
 
     <script async src="https://www.google-analytics.com/analytics.js"></script>

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ require('./app/shell/dimManifestProgress.directive');
 require('./scss/main.scss');
 
 if ($DIM_FLAVOR !== 'dev' && navigator.serviceWorker) {
-  navigator.serviceWorker.register('/sw.js')
+  navigator.serviceWorker.register('/service-worker.js')
     .catch((err) => {
       console.error('Unable to register service worker.', err);
     });


### PR DESCRIPTION
Our service worker doesn't work very well, because it's served with the same expiration rules as all the other JS - one year expiration. This changes it to never be cached, so new pageloads will always check for a new service worker (this is recommended: https://github.com/w3c/ServiceWorker/issues/893). Unfortunately, to break the CloudFlare cache without waiting a year, I also needed to rename the file.

This should fix some cases where DIM loads as a blank white screen and requires a force-refresh to actually work.

I also added some text that gets blown away on app load, but will try to help a bit in cases where JavaScript is disabled or the scripts completely fail to load.