### PR TITLE
Handle 400 response codes from token refresh

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Fix a case where DIM wouldn't work because auth tokens had expired.
+
 # 4.10.0
 
 * You can flag reviews for being offensive or arguing or whatever. Be helpful but also be nice.

--- a/src/app/oauth/http-refresh-token.service.js
+++ b/src/app/oauth/http-refresh-token.service.js
@@ -63,7 +63,7 @@ export function HttpRefreshTokenService($rootScope, $q, $injector, OAuthService,
   function handleRefreshTokenError(response) {
     if (response.status === -1) {
       console.warn("Error getting auth token from refresh token because there's no internet connection. Not clearing token.", response);
-    } else if (response.status === 401 || response.status === 403) {
+    } else if (response.status === 400 || response.status === 401 || response.status === 403) {
       console.warn("Refresh token expired or not valid, clearing auth tokens & going to login", response);
       OAuthTokenService.removeToken();
       $rootScope.$broadcast('dim-no-token-found');


### PR DESCRIPTION
This should handle cases where we have "invalid_grant" errors, or where the token has gotten mangled.