### PR TITLE
Fix a bug in sync service where we wouldn't save

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Fix a case where changes to preferences may not be saved.
+
 # 4.11.0
 
 * Fix a case where DIM wouldn't work because auth tokens had expired.

--- a/src/app/inventory/dimStores.directive.js
+++ b/src/app/inventory/dimStores.directive.js
@@ -29,7 +29,10 @@ function StoresCtrl(dimSettingsService, $scope, dimStoreService, dimPlatformServ
   vm.buckets = null;
   vm.settings = dimSettingsService;
   vm.toggleSection = function(id) {
-    didYouKnow();
+    // Only tip when collapsing
+    if (!vm.settings.collapsedSections[id]) {
+      didYouKnow();
+    }
     vm.settings.collapsedSections[id] = !vm.settings.collapsedSections[id];
     vm.settings.save();
   };

--- a/src/app/settings/dimSettingsService.factory.js
+++ b/src/app/settings/dimSettingsService.factory.js
@@ -79,10 +79,8 @@ export function SettingsService($rootScope, SyncService, $window, $i18next, $q) 
       if (!_loaded) {
         throw new Error("Settings haven't loaded - they can't be saved.");
       }
-      $rootScope.$evalAsync(() => {
-        SyncService.set({
-          'settings-v1.0': _.omit(settings, 'save', 'itemTags')
-        });
+      SyncService.set({
+        'settings-v1.0': _.omit(settings, 'save', 'itemTags')
       });
     },
 

--- a/src/app/storage/sync.service.js
+++ b/src/app/storage/sync.service.js
@@ -53,9 +53,9 @@ export function SyncService(
 
     // use replace to override the data. normally we're doing a PATCH
     if (PUT) { // update our data
-      cached = value;
+      cached = angular.copy(value);
     } else {
-      angular.extend(cached, value);
+      angular.extend(cached, angular.copy(value));
     }
 
     return adapters.reduce((promise, adapter) => {
@@ -122,7 +122,7 @@ export function SyncService(
       }, $q.when())
       .then((value) => {
         cached = value || {};
-        return value;
+        return angular.copy(cached);
       })
       .finally(() => {
         _getPromise = null;


### PR DESCRIPTION
This fixes a rather serious bug in the sync service. We were giving out the internal cache object to clients, and as a result, they were able to modify it directly. When they did that, it triggered our "this has already been saved" check and skipped saving the info.

Now, I return (and accept) copies so this won't happen.