### PR TITLE
[D2] Fix up buckets a lot

### DIFF
--- a/src/app/destiny2/d2-definitions.service.js
+++ b/src/app/destiny2/d2-definitions.service.js
@@ -9,7 +9,8 @@ const lazyTables = [
   'Progression', // DestinyProgressionDefinition
   'ItemCategory', // DestinyItemCategoryDefinition
   'Activity', // DestinyActivityDefinition
-  'ActivityType' // DestinyActivityTypeDefinition
+  'ActivityType', // DestinyActivityTypeDefinition
+  'Vendor'
 ];
 
 const eagerTables = [

--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -297,7 +297,7 @@ export function D2StoresService(
       });
 
       store.vaultCounts = {};
-      ['Weapons', 'Armor', 'General'].forEach((category) => {
+      ['Weapons', 'Armor', 'General', 'Inventory'].forEach((category) => {
         store.vaultCounts[category] = 0;
         buckets.byCategory[category].forEach((bucket) => {
           if (store.buckets[bucket.id]) {

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -21,7 +21,7 @@
       <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
         <div ng-if="!vm.settings.collapsedSections[bucket.id]" class="store-cell" ng-class="{ vault: vm.currentStore.isVault }">
           <dim-store-bucket
-            ng-if="::!vm.currentStore.isVault || vm.vault.vaultCounts[category] !== undefined"
+            ng-if="::!store.isVault || (vm.vault.vaultCounts[category] !== undefined && (store.destinyVersion ==1 || bucket.vaultBucket))"
             store-data="bucket.accountWide ? vm.vault : vm.currentStore"
             bucket-items="(bucket.accountWide ? vm.vault : vm.currentStore).buckets[bucket.id]"
             bucket="bucket"></dim-store-bucket>
@@ -63,7 +63,7 @@
              ng-class="{ vault: store.isVault }"
              ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">
           <dim-store-bucket
-            ng-if="::!store.isVault || vm.vault.vaultCounts[category] !== undefined"
+            ng-if="::!store.isVault || (vm.vault.vaultCounts[category] !== undefined && (store.destinyVersion ==1 || bucket.vaultBucket))"
             store-data="store"
             bucket-items="store.buckets[bucket.id]"
             bucket="bucket"></dim-store-bucket>

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -29,10 +29,10 @@
         <div ng-if="vm.settings.collapsedSections[bucket.id]" ng-click="vm.toggleSection(bucket.id)" class="store-text collapse"><span ng-i18next="[i18next]({ bucket: bucket.name })Bucket.Show"></span></div>
       </div>
     </div>
-    <div class="title" ng-click="vm.toggleSection('Reputation')">
+    <div ng-if="vm.stores[0].destinyVersion != 2" class="title" ng-click="vm.toggleSection('Reputation')">
       <span><i class="fa collapse" ng-class="vm.settings.collapsedSections['Reputation'] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i> <span ng-i18next="Bucket.Reputation"></span></span>
     </div>
-    <div class="store-row items reputation" ng-if="!vm.settings.collapsedSections['Reputation']">
+    <div ng-if="vm.stores[0].destinyVersion != 2" class="store-row items reputation" ng-if="!vm.settings.collapsedSections['Reputation']">
       <div class="store-cell" ng-class="::{ vault: vm.currentStore.isVault }">
         <dim-store-reputation store-data="vm.currentStore"></dim-store-reputation>
       </div>
@@ -71,10 +71,10 @@
         <div ng-if="vm.settings.collapsedSections[bucket.id]" ng-click="vm.toggleSection(bucket.id)" class="store-text collapse"><span ng-i18next="[i18next]({ bucket: bucket.name })Bucket.Show"></span></div>
       </div>
     </div>
-    <div class="title" ng-click="vm.toggleSection('Reputation')">
+    <div ng-if="vm.stores[0].destinyVersion != 2" class="title" ng-click="vm.toggleSection('Reputation')">
       <span><i class="fa collapse" ng-class="vm.settings.collapsedSections['Reputation'] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i> <span ng-i18next="Bucket.Reputation"></span></span>
     </div>
-    <div class="store-row items reputation" ng-if="!vm.settings.collapsedSections['Reputation']">
+    <div ng-if="vm.stores[0].destinyVersion != 2" class="store-row items reputation" ng-if="!vm.settings.collapsedSections['Reputation']">
       <div class="store-cell" ng-class="::{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">
         <dim-store-reputation store-data="store"></dim-store-reputation>
       </div>

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -1,4 +1,4 @@
-<div ng-if="vm.stores.length" class="inventory-content" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems, 'phone-portrait': vm.isPhonePortrait }">
+<div ng-if="vm.stores.length && vm.vault" class="inventory-content" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems, 'phone-portrait': vm.isPhonePortrait }">
   <div ng-if="vm.isPhonePortrait && vm.currentStore">
     <!-- TODO: move most of these into their own components? -->
     <div class="store-header">
@@ -16,11 +16,15 @@
     <div ng-repeat="(category, buckets) in ::vm.buckets.byCategory track by category" class="section" ng-class="::category | lowercase">
       <div class="title">
         <span class="collapse-handle" ng-click="vm.toggleSection(category)"><i class="fa collapse" ng-class="vm.settings.collapsedSections[category] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i> <span ng-i18next="Bucket.{{ ::category }}"></span></span>
-        <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{ ::vm.vault.capacityForItem({sort: category}) }}</span>
+        <span ng-if="::vm.stores[0].destinyVersion != 2 && vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{ ::vm.vault.capacityForItem({: category}) }}</span>
       </div>
       <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
         <div ng-if="!vm.settings.collapsedSections[bucket.id]" class="store-cell" ng-class="{ vault: vm.currentStore.isVault }">
-          <dim-store-bucket ng-if="::!vm.currentStore.isVault || vm.vault.vaultCounts[category] !== undefined" store-data="vm.currentStore" bucket-items="vm.currentStore.buckets[bucket.id]" bucket="bucket"></dim-store-bucket>
+          <dim-store-bucket
+            ng-if="::!vm.currentStore.isVault || vm.vault.vaultCounts[category] !== undefined"
+            store-data="bucket.accountWide ? vm.vault : vm.currentStore"
+            bucket-items="(bucket.accountWide ? vm.vault : vm.currentStore).buckets[bucket.id]"
+            bucket="bucket"></dim-store-bucket>
         </div>
         <div ng-if="vm.settings.collapsedSections[bucket.id]" ng-click="vm.toggleSection(bucket.id)" class="store-text collapse"><span ng-i18next="[i18next]({ bucket: bucket.name })Bucket.Show"></span></div>
       </div>
@@ -45,11 +49,24 @@
     <div ng-repeat="(category, buckets) in ::vm.buckets.byCategory track by category" class="section" ng-class="::category | lowercase">
       <div class="title">
         <span class="collapse-handle" ng-click="vm.toggleSection(category)"><i class="fa collapse" ng-class="vm.settings.collapsedSections[category] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i> <span ng-i18next="Bucket.{{ ::category }}"></span></span>
-        <span ng-if="::vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{ ::vm.vault.capacityForItem({sort: category}) }}</span>
+        <span ng-if="::vm.stores[0].destinyVersion != 2 && vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{ ::vm.vault.capacityForItem({sort: category}) }}</span>
       </div>
       <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
-        <div ng-if="!vm.settings.collapsedSections[bucket.id]" class="store-cell" ng-class="{ vault: store.isVault }" ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">
-          <dim-store-bucket ng-if="::!store.isVault || vm.vault.vaultCounts[category] !== undefined" store-data="store" bucket-items="store.buckets[bucket.id]" bucket="bucket"></dim-store-bucket>
+        <div ng-if="bucket.accountWide && !vm.settings.collapsedSections[bucket.id]" class="store-cell">
+          <dim-store-bucket
+            store-data="vm.vault"
+            bucket-items="vm.vault.buckets[bucket.id]"
+            bucket="bucket"></dim-store-bucket>
+        </div>
+        <div ng-if="!bucket.accountWide && !vm.settings.collapsedSections[bucket.id]"
+             class="store-cell"
+             ng-class="{ vault: store.isVault }"
+             ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">
+          <dim-store-bucket
+            ng-if="::!store.isVault || vm.vault.vaultCounts[category] !== undefined"
+            store-data="store"
+            bucket-items="store.buckets[bucket.id]"
+            bucket="bucket"></dim-store-bucket>
         </div>
         <div ng-if="vm.settings.collapsedSections[bucket.id]" ng-click="vm.toggleSection(bucket.id)" class="store-text collapse"><span ng-i18next="[i18next]({ bucket: bucket.name })Bucket.Show"></span></div>
       </div>

--- a/src/app/inventory/store/d2-item-factory.service.js
+++ b/src/app/inventory/store/d2-item-factory.service.js
@@ -162,14 +162,7 @@ export function D2ItemFactory(
     // We cheat a bit for items in the vault, since we treat the
     // vault as a character. So put them in the bucket they would
     // have been in if they'd been on a character.
-    if (currentBucket.id === 1469714392 || currentBucket.id === 138197802) {
-      currentBucket = normalBucket;
-    }
-
-    // We cheat a bit for items in the vault, since we treat the
-    // vault as a character. So put them in the bucket they would
-    // have been in if they'd been on a character.
-    if (instanceDef.location === 2 /* vault */) {
+    if (owner.isVault || instanceDef.location === 2 /* Vault */) {
       currentBucket = normalBucket;
     }
 
@@ -180,7 +173,7 @@ export function D2ItemFactory(
       return category ? category.hash : null; // Uh oh, no more readable IDs!
     })) : [];
 
-    const dmgName = [null, 'kinetic', 'arc', 'solar', 'void', 'raid'][instanceDef.damageType];
+    const dmgName = [null, 'kinetic', 'arc', 'solar', 'void', 'raid'][instanceDef.damageType || 0];
 
     const createdItem = angular.extend(Object.create(ItemProto), {
       // figure out what year this item is probably from
@@ -199,15 +192,15 @@ export function D2ItemFactory(
       name: itemDef.displayProperties.name,
       description: itemDef.displayProperties.description,
       icon: itemDef.displayProperties.icon,
-      notransfer: Boolean(currentBucket.inPostmaster || itemDef.nonTransferrable || !itemDef.allowActions || itemDef.classified),
-      id: item.itemInstanceId,
-      equipped: instanceDef.isEquipped,
+      notransfer: Boolean(currentBucket.accountWide || currentBucket.inPostmaster || itemDef.nonTransferrable || !itemDef.allowActions || itemDef.classified),
+      id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
+      equipped: Boolean(instanceDef.isEquipped),
       equipment: Boolean(itemDef.equippingBlock), // TODO: this has a ton of good info for the item move logic
       complete: false, // TODO: what's the deal w/ item progression?
       amount: item.quantity,
       primStat: instanceDef.primaryStat || null,
       typeName: itemDef.itemTypeDisplayName,
-      equipRequiredLevel: instanceDef.equipRequiredLevel,
+      equipRequiredLevel: instanceDef.equipRequiredLevel || 0,
       maxStackSize: Math.max(itemDef.inventory.maxStackSize, 1),
       // 0: titan, 1: hunter, 2: warlock, 3: any
       classType: itemDef.classType,

--- a/src/app/inventory/store/d2-store-factory.service.js
+++ b/src/app/inventory/store/d2-store-factory.service.js
@@ -175,14 +175,10 @@ export function D2StoreFactory($i18next, dimInfoService) {
         isVault: true,
         // Vault has different capacity rules
         capacityForItem: function(item) {
-          let sort = item.sort;
-          if (item.bucket) {
-            sort = item.bucket.sort;
+          if (!item.bucket) {
+            throw new Error("item needs a 'bucket' field");
           }
-          if (!sort) {
-            throw new Error("item needs a 'sort' field");
-          }
-          return buckets[sort].capacity;
+          return buckets.byHash[item.bucket.hash].vaultBucket.capacity;
         },
         spaceLeftForItem: function(item) {
           let sort = item.sort;

--- a/src/app/shell/header.html
+++ b/src/app/shell/header.html
@@ -129,7 +129,6 @@
       <dim-search-filter></dim-search-filter>
     </span>
     <span class="link search-button"
-          ng-if="$ctrl.destinyVersion == 1"
           ng-click="$ctrl.showSearch = !$ctrl.showSearch">
       <i class="fa fa-search"></i>
     </span>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -9,6 +9,7 @@
   "Bucket": {
     "Armor": "Armor",
     "General": "General",
+    "Inventory": "Inventory",
     "Postmaster": "Postmaster",
     "Progress": "Progress",
     "Reputation": "Reputation",


### PR DESCRIPTION
Now we show Inventory (mods, consumables, etc) as an account-independent row. Things are generally fixed up and reorganized. We shouldn't believe the vault is full when it isn't, though we also don't show vault capacity anymore since it's a bit different in D2 (weapons/armor are shared, etc).