### PR TITLE
Log state names instead of paths to google analytics

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -202,7 +202,7 @@ module.exports = (env) => {
         // Enable color-blind a11y
         '$featureFlags.colorA11y': JSON.stringify(env !== 'release'),
         // Whether to log page views for router events
-        '$featureFlags.googleAnalyticsForRouter': JSON.stringify(env !== 'release'),
+        '$featureFlags.googleAnalyticsForRouter': JSON.stringify(true),
         // Enable activities tab
         '$featureFlags.activities': JSON.stringify(true),
         // Debug ui-router

--- a/src/app/dimApp.routes.js
+++ b/src/app/dimApp.routes.js
@@ -1,8 +1,14 @@
-function routes($stateProvider, $urlServiceProvider) {
+function routes($stateProvider, $urlServiceProvider, $transitionsProvider) {
   'ngInject';
 
   $urlServiceProvider.rules.initial({ state: 'default-account' });
   $urlServiceProvider.rules.otherwise({ state: 'default-account' });
+
+  if ($featureFlags.googleAnalyticsForRouter) {
+    $transitionsProvider.onSuccess({ }, (transition) => {
+      ga('send', 'pageview', transition.$to().name);
+    });
+  }
 }
 
 export default routes;

--- a/src/app/dimApp.run.js
+++ b/src/app/dimApp.run.js
@@ -15,12 +15,6 @@ function run($rootScope, SyncService, $transitions, $location, $trace, $uiRouter
   $rootScope.$DIM_BUILD_DATE = new Date($DIM_BUILD_DATE).toLocaleString();
 
   console.log(`DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.reddit.com/r/destinyitemmanager`);
-
-  if ($featureFlags.googleAnalyticsForRouter) {
-    $transitions.onSuccess({ }, () => {
-      ga('send', 'pageview', $location.path());
-    });
-  }
 }
 
 export default run;


### PR DESCRIPTION
This does two things:

1. Switches from logging the router paths to GA, to logging state names. So instead of logging `/4611686018433092312-2/d1/inventory`, it'll log `destiny1.inventory` which is the name of the state.
2. Turns on per-state pageviews for the production app. Before, we were only logging the initial pageload (so either `/` or `/index.html` for app.destinyitemmanager.com) and logging full router paths in Beta.