### PR TITLE
Fix auto loadouts for D2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
+
 * Added back in Repuation for D2.
+* Max Light Loadout, Make Room for Postmaster, Farming Mode, and Search Loadout are all reenabled for D2.
 
 # 4.13.0
 

--- a/src/app/destiny2/d2-buckets.service.js
+++ b/src/app/destiny2/d2-buckets.service.js
@@ -120,7 +120,8 @@ export function D2BucketsService(D2Definitions, D2Categories) {
             hash: def.hash,
             hasTransferDestination: def.hasTransferDestination,
             capacity: def.itemCount,
-            accountWide: def.scope === 1
+            accountWide: def.scope === 1,
+            category: def.category
           };
 
           bucket.type = bucketToType[bucket.hash];
@@ -130,7 +131,9 @@ export function D2BucketsService(D2Definitions, D2Categories) {
           }
 
           // Add an easy helper property like "inPostmaster"
-          bucket[`in${bucket.sort}`] = true;
+          if (bucket.sort) {
+            bucket[`in${bucket.sort}`] = true;
+          }
 
           buckets.byHash[bucket.hash] = bucket;
           buckets.byId[bucket.id] = bucket;

--- a/src/app/destiny2/d2-inventory.html
+++ b/src/app/destiny2/d2-inventory.html
@@ -4,6 +4,6 @@
 <dim-compare></dim-compare>
 <dim-item-discuss></dim-item-discuss>
 <div id="drag-help" class="drag-help-hidden" ng-i18next="Help.Drag"></div>
-<dim-farming></dim-farming>
+<d2-farming></d2-farming>
 <dim-clear-new-items destiny-version="2"></dim-clear-new-items>
 <random-loadout></random-loadout>

--- a/src/app/farming/d2farming.component.js
+++ b/src/app/farming/d2farming.component.js
@@ -1,0 +1,23 @@
+import angular from 'angular';
+import template from './d2farming.html';
+import './farming.scss';
+
+export const D2FarmingComponent = {
+  controller: FarmingCtrl,
+  controllerAs: 'vm',
+  template
+};
+
+function FarmingCtrl(D2FarmingService) {
+  'ngInject';
+
+  const vm = this;
+
+  angular.extend(vm, {
+    service: D2FarmingService,
+    stop: function($event) {
+      $event.preventDefault();
+      D2FarmingService.stop();
+    }
+  });
+}

--- a/src/app/farming/d2farming.html
+++ b/src/app/farming/d2farming.html
@@ -1,0 +1,6 @@
+<div ng-if="vm.service.active" id="item-farming" class="d2-farming">
+  <span>
+    <p ng-i18next="[i18next]({ store: vm.service.store.name, context: vm.service.store.gender })FarmingMode.D2Desc"></p>
+  </span>
+  <span><button ng-click="vm.stop($event)" ng-i18next="FarmingMode.Stop"></button></span>
+</div>

--- a/src/app/farming/d2farming.service.js
+++ b/src/app/farming/d2farming.service.js
@@ -1,0 +1,165 @@
+import _ from 'underscore';
+
+/**
+ * A service for "farming" items by moving them continuously off a character,
+ * so that they don't go to the Postmaster.
+ */
+export function D2FarmingService($rootScope,
+                        $q,
+                        dimItemService,
+                        D2StoresService,
+                        $interval,
+                        toaster,
+                        $i18next,
+                        D2BucketsService) {
+  'ngInject';
+
+  let intervalId;
+  let cancelReloadListener;
+  let subscription;
+
+  const outOfSpaceWarning = _.throttle((store) => {
+    toaster.pop('info',
+                $i18next.t('FarmingMode.OutOfRoomTitle'),
+                $i18next.t('FarmingMode.OutOfRoom', { character: store.name }));
+  }, 60000);
+
+  function getMakeRoomBuckets() {
+    return D2BucketsService.getBuckets().then((buckets) => {
+      const makeRoomBuckets = Object.values(buckets.byHash).filter((b) => b.category === 3 && b.type);
+      console.log({ makeRoomBuckets });
+      return makeRoomBuckets;
+    });
+  }
+
+  return {
+    active: false,
+    store: null,
+    itemsMoved: 0,
+    movingItems: false,
+    makingRoom: false,
+    // Move all items on the selected character to the vault.
+    moveItemsToVault: function(store, items, makeRoomBuckets) {
+      const reservations = {};
+      // reserve one space in the active character
+      reservations[store.id] = {};
+      makeRoomBuckets.forEach((bucket) => {
+        reservations[store.id][bucket.type] = 1;
+      });
+
+      return _.reduce(items, (promise, item) => {
+        // Move a single item. We do this as a chain of promises so we can reevaluate the situation after each move.
+        return promise
+          .then(() => {
+            const vault = D2StoresService.getVault();
+            const vaultSpaceLeft = vault.spaceLeftForItem(item);
+            if (vaultSpaceLeft <= 1) {
+              // If we're down to one space, try putting it on other characters
+              const otherStores = _.select(D2StoresService.getStores(),
+                                            (store) => !store.isVault && store.id !== store.id);
+              const otherStoresWithSpace = _.select(otherStores, (store) => store.spaceLeftForItem(item));
+
+              if (otherStoresWithSpace.length) {
+                if ($featureFlags.debugMoves) {
+                  console.log("Farming initiated move:", item.amount, item.name, item.type, 'to', otherStoresWithSpace[0].name, 'from', D2StoresService.getStore(item.owner).name);
+                }
+                return dimItemService.moveTo(item, otherStoresWithSpace[0], false, item.amount, items, reservations);
+              }
+            }
+            if ($featureFlags.debugMoves) {
+              console.log("Farming initiated move:", item.amount, item.name, item.type, 'to', vault.name, 'from', D2StoresService.getStore(item.owner).name);
+            }
+            return dimItemService.moveTo(item, vault, false, item.amount, items, reservations);
+          })
+          .catch((e) => {
+            if (e.code === 'no-space') {
+              outOfSpaceWarning(store);
+            } else {
+              toaster.pop('error', item.name, e.message);
+            }
+            throw e;
+          });
+      }, $q.resolve());
+    },
+    // Ensure that there's one open space in each category that could
+    // hold an item, so they don't go to the postmaster.
+    makeRoomForItems: function(store) {
+      return getMakeRoomBuckets().then((makeRoomBuckets) => {
+        // If any category is full, we'll move one aside
+        const itemsToMove = [];
+        makeRoomBuckets.forEach((makeRoomBucket) => {
+          const items = store.buckets[makeRoomBucket.id];
+          if (items.length > 0 && items.length >= makeRoomBucket.capacity) {
+            // We'll move the lowest-value item to the vault.
+            const itemToMove = _.min(_.select(items, { equipped: false, notransfer: false }), (i) => {
+              let value = {
+                Common: 0,
+                Uncommon: 1,
+                Rare: 2,
+                Legendary: 3,
+                Exotic: 4
+              }[i.tier];
+              // And low-stat
+              if (i.primStat) {
+                value += i.primStat.value / 1000.0;
+              }
+              return value;
+            });
+            if (itemToMove !== Infinity) {
+              itemsToMove.push(itemToMove);
+            }
+          }
+        });
+
+        if (itemsToMove.length === 0) {
+          return $q.resolve();
+        }
+
+        this.makingRoom = true;
+        return this.moveItemsToVault(store, itemsToMove, makeRoomBuckets)
+          .finally(() => {
+            this.makingRoom = false;
+          });
+      });
+    },
+    start: function(account, storeId) {
+      if (!this.active) {
+        this.active = true;
+        this.itemsMoved = 0;
+        this.movingItems = false;
+        this.makingRoom = false;
+
+        // Whenever the store is reloaded, run the farming algo
+        // That way folks can reload manually too
+        subscription = D2StoresService.getStoresStream(account).subscribe((stores) => {
+          // prevent some recursion...
+          if (this.active && !this.movingItems && !this.makingRoom) {
+            const store = stores.find((s) => s.id === storeId);
+            this.store = store;
+            this.makeRoomForItems(store);
+          }
+        });
+
+        intervalId = $interval(() => {
+          // just start reloading stores more often
+          $rootScope.$broadcast('dim-refresh');
+        }, 60000);
+      }
+    },
+    stop: function() {
+      if (intervalId) {
+        $interval.cancel(intervalId);
+      }
+      if (cancelReloadListener) {
+        cancelReloadListener();
+      }
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = null;
+      }
+      this.active = false;
+      this.store = null;
+    }
+  };
+}
+

--- a/src/app/farming/farming.module.js
+++ b/src/app/farming/farming.module.js
@@ -2,9 +2,13 @@ import angular from 'angular';
 
 import { FarmingComponent } from './farming.component';
 import { FarmingService } from './farming.service';
+import { D2FarmingComponent } from './d2farming.component';
+import { D2FarmingService } from './d2farming.service';
 
 export default angular
   .module('farmingModule', [])
   .component('dimFarming', FarmingComponent)
   .factory('dimFarmingService', FarmingService)
+  .component('d2Farming', D2FarmingComponent)
+  .factory('D2FarmingService', D2FarmingService)
   .name;

--- a/src/app/farming/farming.scss
+++ b/src/app/farming/farming.scss
@@ -16,6 +16,10 @@
   display: flex;
   flex-direction: row;
 
+  &.d2-farming {
+    bottom: 1rem;
+  }
+
   button {
     color: white;
     background-color: rgba(128, 128, 128, .8);
@@ -25,6 +29,7 @@
     height: 3rem;
     text-align: center;
     font-size: 1.5em;
+    margin-left: 1rem;
     transition: .3s background-color;
     &:hover, &:active {
       background-color: rgba(232, 165, 52, .8);

--- a/src/app/inventory/dimItemService.factory.js
+++ b/src/app/inventory/dimItemService.factory.js
@@ -24,6 +24,10 @@ export function ItemService(
     return dimStoreService.reloadStores();
   }, 10000, { trailing: false });
 
+  const throttledD2ReloadStores = _.throttle(() => {
+    return D2StoresService.reloadStores();
+  }, 10000, { trailing: false });
+
   return {
     getSimilarItem,
     moveTo,
@@ -649,7 +653,8 @@ export function ItemService(
       }
     } else {
       // Refresh the stores to see if anything has changed
-      const reloadPromise = throttledReloadStores() || $q.when(storeService.getStores());
+      const reloadPromise = (item.destinyVersion === 2 ? throttledD2ReloadStores() : throttledReloadStores()) ||
+            $q.when(storeService.getStores());
       const storeId = store.id;
       return reloadPromise.then((stores) => {
         const store = _.find(stores, { id: storeId });

--- a/src/app/loadout/loadout-popup.component.js
+++ b/src/app/loadout/loadout-popup.component.js
@@ -13,7 +13,7 @@ export const LoadoutPopupComponent = {
   template
 };
 
-function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimItemService, toaster, dimFarmingService, D2FarmingService, $window, dimSearchService, dimPlatformService, $i18next, dimBucketService, $q, dimStoreService, D2StoresService, $stateParams) {
+function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimItemService, toaster, dimFarmingService, D2FarmingService, $window, dimSearchService, dimPlatformService, $i18next, dimBucketService, D2BucketsService, $q, dimStoreService, D2StoresService, $stateParams) {
   'ngInject';
   const vm = this;
   vm.previousLoadout = _.last(dimLoadoutService.previousLoadouts[vm.store.id]);
@@ -302,7 +302,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
   vm.makeRoomForPostmaster = function makeRoomForPostmaster() {
     ngDialog.closeAll();
 
-    dimBucketService.getBuckets().then((buckets) => {
+    (vm.store.destinyVersion === 1 ? dimBucketService : D2BucketsService).getBuckets().then((buckets) => {
       const postmasterItems = flatMap(buckets.byCategory.Postmaster,
                                       (bucket) => vm.store.buckets[bucket.id]);
       const postmasterItemCountsByType = _.countBy(postmasterItems,

--- a/src/app/loadout/loadout-popup.component.js
+++ b/src/app/loadout/loadout-popup.component.js
@@ -13,7 +13,7 @@ export const LoadoutPopupComponent = {
   template
 };
 
-function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimItemService, toaster, dimFarmingService, $window, dimSearchService, dimPlatformService, $i18next, dimBucketService, $q, dimStoreService) {
+function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimItemService, toaster, dimFarmingService, D2FarmingService, $window, dimSearchService, dimPlatformService, $i18next, dimBucketService, $q, dimStoreService, $stateParams) {
   'ngInject';
   const vm = this;
   vm.previousLoadout = _.last(dimLoadoutService.previousLoadouts[vm.store.id]);
@@ -109,6 +109,7 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
   vm.applyLoadout = function applyLoadout(loadout, $event, filterToEquipped) {
     ngDialog.closeAll();
     dimFarmingService.stop();
+    D2FarmingService.stop();
 
     if (filterToEquipped) {
       loadout = filterLoadoutToEquipped(loadout);
@@ -385,6 +386,18 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
   vm.startFarming = function startFarming() {
     ngDialog.closeAll();
     dimFarmingService.start(vm.store);
+  };
+
+  vm.startFarming = function startFarming() {
+    ngDialog.closeAll();
+    if (vm.store.destinyVersion === 2) {
+      D2FarmingService.start({
+        membershipId: $stateParams.membershipId,
+        platformType: $stateParams.platformType
+      }, vm.store.id);
+    } else {
+      dimFarmingService.start(vm.store);
+    }
   };
 
   // Generate an optimized loadout based on a filtered set of items and a value function

--- a/src/app/loadout/loadout-popup.html
+++ b/src/app/loadout/loadout-popup.html
@@ -21,7 +21,7 @@
       </span>
     </li>
 
-    <li class="loadout-set" ng-if="vm.store.destinyVersion === 1 && vm.search.query">
+    <li class="loadout-set" ng-if="vm.search.query">
       <span ng-click="vm.searchLoadout($event)">
         <i class="fa fa-search"></i>
         <span ng-i18next="[i18next]({ query: vm.search.query })Loadouts.ApplySearch"></span>
@@ -43,7 +43,7 @@
       </span>
     </li>
 
-    <li class="loadout-set" ng-if="vm.store.destinyVersion === 1 && !vm.store.isVault">
+    <li class="loadout-set" ng-if="!vm.store.isVault">
       <span ng-click="vm.makeRoomForPostmaster($event)">
         <i class="fa fa-envelope"></i>
         <span ng-i18next="Loadouts.MakeRoom"></span>

--- a/src/app/loadout/loadout-popup.html
+++ b/src/app/loadout/loadout-popup.html
@@ -28,7 +28,7 @@
       </span>
     </li>
 
-    <li class="loadout-set" ng-if="vm.store.destinyVersion === 1 && !vm.store.isVault">
+    <li class="loadout-set" ng-if="!vm.store.isVault">
       <span ng-click="vm.maxLightLoadout($event)">
         <span class="light" ng-bind="::vm.maxLightValue"></span>
         <i class="fa fa-star"></i>

--- a/src/app/loadout/loadout.service.js
+++ b/src/app/loadout/loadout.service.js
@@ -209,11 +209,18 @@ export function LoadoutService($q, $rootScope, $i18next, dimItemService, dimStor
       Armor: store.level === 40 ? .10 : .1087,
       General: store.level === 40 ? .08 : .087
     };
-    return (Math.floor(10 * _.reduce(loadout.items, (memo, items) => {
-      const item = _.find(items, { equipped: true });
 
-      return memo + (item.primStat.value * itemWeight[item.location.id === 'BUCKET_CLASS_ITEMS' ? 'General' : item.location.sort]);
-    }, 0)) / 10).toFixed(1);
+    const items = _.filter(_.flatten(_.values(loadout.items)), 'equipped');
+
+    if (store.destinyVersion === 1) {
+      return (Math.floor(items.length * _.reduce(items, (memo, item) => {
+        return memo + (item.primStat.value * itemWeight[item.location.id === 'BUCKET_CLASS_ITEMS' ? 'General' : item.location.sort]);
+      }, 0)) / items.length).toFixed(1);
+    } else {
+      return (_.reduce(items, (memo, item) => {
+        return memo + item.primStat.value;
+      }, 0) / items.length).toFixed(1);
+    }
   }
 
   /**

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -113,7 +113,10 @@
     "OutOfRoom": "You're out of space to move items off of {{character}}. Time to decrypt some engrams and clear out the trash!",
     "OutOfRoomTitle": "Out of Room",
     "Quickmove": "Quick Move",
-    "Stop": "Stop"
+    "Stop": "Stop",
+    "D2Desc": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
+    "D2Desc_female": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
+    "D2Desc_male": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room."
   },
   "Filter": {
     "Activities": {


### PR DESCRIPTION
This reenables the following loadouts:

* Search loadout.
* Max light loadout, including the max light calculation.
* Make room for Postmaster (thought it's a bit weird that you can't move emblems and stuff to the vault).
* Farming mode. I split farming mode into its own thing since so much of what the old farming mode did is irrelevant (moving engrams, glimmer items, grabbing consumables, etc.) Now the only thing it does is move items off your characters to avoid stuff going to the postmaster. It's much simpler as a result.

These weren't enabled:

* Saved loadouts. I know @kyleshay is working on these so I left them out.
* Item Leveling. AFAIK we don't level items in D2.
* Gather Engrams. Engrams aren't really the same thing now.