### PR TITLE
Ignore browserlist regions

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -109,6 +109,8 @@ module.exports = (env) => {
     },
 
     plugins: [
+      new webpack.IgnorePlugin(/caniuse-lite\/data\/regions/),
+
       new webpack.ProvidePlugin({
         i18next: 'i18next',
         'window.i18next': 'i18next'


### PR DESCRIPTION
This drops vendor.js from 1.4mb -> 838kb

More information: https://github.com/ai/browserslist#webpack

> This plugin will reduce Browserslist size from 150 KB to 6 KB. But you loose "> 1% in US" queries support.
