### PR TITLE
Make account-wide buckets full width

### DIFF
--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -52,7 +52,7 @@
         <span ng-if="::vm.stores[0].destinyVersion != 2 && vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{ ::vm.vault.capacityForItem({sort: category}) }}</span>
       </div>
       <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
-        <div ng-if="bucket.accountWide && !vm.settings.collapsedSections[bucket.id]" class="store-cell">
+        <div ng-if="bucket.accountWide && !vm.settings.collapsedSections[bucket.id]" class="store-cell account-wide">
           <dim-store-bucket
             store-data="vm.vault"
             bucket-items="vm.vault.buckets[bucket.id]"

--- a/src/app/inventory/dimStores.scss
+++ b/src/app/inventory/dimStores.scss
@@ -48,6 +48,10 @@
     width: auto;
     flex: 1;
   }
+
+  &.account-wide {
+    width: auto;
+  }
 }
 .store-text {
   padding-top: 5px;


### PR DESCRIPTION
The inventory buckets (mods, consumables, and shaders) were a bit cramped. This just makes them take the full width of the screen which tends to spread them out in a single row:

<img width="1258" alt="screen shot 2017-09-14 at 12 43 01 am" src="https://user-images.githubusercontent.com/313208/30417771-b1c9d1c8-98e5-11e7-8329-dea97223376d.png">
