### PR TITLE
Reintroduce objectives and quests-as-inventory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* D2 items with objectives now show them, and quests + milestones are displayed for your characters.
+
 # 4.14.0
 
 * Added back in Repuation for D2.

--- a/src/app/destiny2/d2-buckets.service.js
+++ b/src/app/destiny2/d2-buckets.service.js
@@ -31,6 +31,9 @@ export const D2Categories = {
     'Modifications',
     'Shaders'
   ],
+  Progress: [
+    'Quests',
+  ],
   Postmaster: [
     'Lost Items',
     'Messages',
@@ -76,7 +79,8 @@ const bucketToType = {
   1585787867: "ClassItem",
   2025709351: "Vehicle",
   1469714392: "Consumables",
-  138197802: "General"
+  138197802: "General",
+  1801258597: "Quests"
 };
 
 export function D2BucketsService(D2Definitions, D2Categories) {

--- a/src/app/move-popup/objectives.html
+++ b/src/app/move-popup/objectives.html
@@ -1,5 +1,5 @@
 <div class="item-objectives" ng-if="$ctrl.objectives.length">
-  <div class="objective-row" ng-switch="objective.displayStyle" ng-repeat="objective in $ctrl.objectives track by $index" ng-class="{ 'objective-complete': objective.complete, 'objective-boolean': objective.boolean }">
+  <div class="objective-row" title="{{objective.description}}" ng-switch="objective.displayStyle" ng-repeat="objective in $ctrl.objectives track by $index" ng-class="{ 'objective-complete': objective.complete, 'objective-boolean': objective.boolean }">
     <div ng-switch-when="trials">
       <i class="fa fa-circle trials" ng-repeat="i in objective.completionValue | range track by $index" ng-class="{ 'incomplete': $index >= objective.progress, 'wins': objective.completionValue === 9 }"></i>
       <span ng-if="objective.completionValue === 9 && objective.progress > 9"> + {{ objective.progress - 9 }}</span>


### PR DESCRIPTION
This brings back objectives on items, and rediscovers that quests (milestones and quests together) are actually available as inventory! We can use them until we have a proper milestone page I guess.

![screen shot 2017-09-14 at 8 30 37 pm](https://user-images.githubusercontent.com/313208/30465393-c40bf09a-998b-11e7-94b7-e56abc08b3d8.png)

