### PR TITLE
Support loadouts in D2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * D2 items with objectives now show them, and quests + milestones are displayed for your characters.
+* Custom loadouts return for D2.
 
 # 4.14.0
 

--- a/src/app/loadout/loadout-drawer.component.js
+++ b/src/app/loadout/loadout-drawer.component.js
@@ -14,9 +14,11 @@ export const LoadoutDrawerComponent = {
   template
 };
 
-function LoadoutDrawerCtrl($scope, dimLoadoutService, dimCategory, toaster, dimSettingsService, $i18next, dimDefinitions) {
+function LoadoutDrawerCtrl($scope, dimLoadoutService, dimCategory, D2Categories, toaster, dimSettingsService, $i18next, dimDefinitions) {
   'ngInject';
   const vm = this;
+
+  const dimItemCategories = dimSettingsService.destinyVersion === 2 ? D2Categories : dimCategory;
 
   this.$onChanges = function(changes) {
     if (changes.stores) {
@@ -103,7 +105,7 @@ function LoadoutDrawerCtrl($scope, dimLoadoutService, dimCategory, toaster, dimS
 
   vm.settings = dimSettingsService;
 
-  vm.types = _.flatten(Object.values(dimCategory)).map((t) => t.toLowerCase());
+  vm.types = _.flatten(Object.values(dimItemCategories)).map((t) => t.toLowerCase());
 
   vm.show = false;
   dimLoadoutService.dialogOpen = false;
@@ -115,6 +117,7 @@ function LoadoutDrawerCtrl($scope, dimLoadoutService, dimCategory, toaster, dimS
 
   vm.save = function save() {
     vm.loadout.platform = vm.account.platformLabel; // Playstation or Xbox
+    vm.loadout.destinyVersion = dimSettingsService.destinyVersion; // D1 or D2
     dimLoadoutService
       .saveLoadout(vm.loadout)
       .catch((e) => {

--- a/src/app/loadout/loadout-popup.component.js
+++ b/src/app/loadout/loadout-popup.component.js
@@ -39,7 +39,9 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
         vm.loadouts = _.sortBy(loadouts, 'name') || [];
 
         vm.loadouts = vm.loadouts.filter((loadout) => {
-          return (_.isUndefined(loadout.platform) ||
+          return (vm.store.destinyVersion === 2
+            ? loadout.destinyVersion === 2 : loadout.destinyVersion !== 2) &&
+            (_.isUndefined(loadout.platform) ||
                   loadout.platform === platform.platformLabel) &&
             (vm.classTypeId === -1 ||
              loadout.classType === -1 ||
@@ -64,6 +66,9 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
     // like emblems and ships and horns.
     loadout.items = _.pick(loadout.items,
                            'class',
+                           'kinetic',
+                           'energy',
+                           'power',
                            'primary',
                            'special',
                            'heavy',
@@ -378,11 +383,6 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
         });
     }, $q.resolve());
   }
-
-  vm.startFarming = function startFarming() {
-    ngDialog.closeAll();
-    dimFarmingService.start(vm.store);
-  };
 
   vm.startFarming = function startFarming() {
     ngDialog.closeAll();

--- a/src/app/loadout/loadout-popup.html
+++ b/src/app/loadout/loadout-popup.html
@@ -1,7 +1,7 @@
 <div class="loadout-popup-content">
   <ul class="loadout-list">
 
-    <li ng-if="vm.store.destinyVersion === 1" class="loadout-set">
+    <li class="loadout-set">
       <span ng-click="vm.newLoadout($event)">
         <i class="fa fa-plus-circle"></i>
         <span ng-i18next="Loadouts.Create"></span>
@@ -9,7 +9,7 @@
       <span ng-click="vm.newLoadoutFromEquipped($event)" ng-i18next="Loadouts.FromEquipped"></span>
     </li>
 
-    <li ng-if="vm.store.destinyVersion === 1" ng-repeat="loadout in vm.loadouts track by loadout.id" class="loadout-set">
+    <li ng-repeat="loadout in vm.loadouts track by loadout.id" class="loadout-set">
       <span title="{{ loadout.name }}" ng-click="vm.applyLoadout(loadout, $event)">
         {{ loadout.name }}
       </span>
@@ -68,7 +68,7 @@
       </span>
     </li>
 
-    <li class="loadout-set" ng-if="vm.store.destinyVersion === 1 && vm.previousLoadout">
+    <li class="loadout-set" ng-if="vm.previousLoadout">
       <span title="{{ vm.previousLoadout.name }}" ng-click="vm.applyLoadout(vm.previousLoadout, $event, true)">
         <i class="fa fa-undo"></i>
         {{ vm.previousLoadout.name }}

--- a/src/app/loadout/loadout.service.js
+++ b/src/app/loadout/loadout.service.js
@@ -470,6 +470,7 @@ export function LoadoutService($q, $rootScope, $i18next, dimItemService, dimStor
       id: loadoutPrimitive.id,
       name: loadoutPrimitive.name,
       platform: loadoutPrimitive.platform,
+      destinyVersion: loadoutPrimitive.destinyVersion,
       classType: (_.isUndefined(loadoutPrimitive.classType) ? -1 : loadoutPrimitive.classType),
       version: 'v3.0',
       items: {
@@ -514,6 +515,7 @@ export function LoadoutService($q, $rootScope, $i18next, dimItemService, dimStor
       classType: loadout.classType,
       version: 'v3.0',
       platform: loadout.platform,
+      destinyVersion: loadout.destinyVersion,
       items: []
     };
 


### PR DESCRIPTION
Turning on loadouts in D2, added destinyVersion to loadouts. If that flag is D2 it will show in D2, if it doesn’t exist (legacy D1 loadouts) then it will only show in D1

“Apply Previous loadout” also returns!

![rec](https://user-images.githubusercontent.com/424158/30503398-e1522b7c-9a1e-11e7-847f-1536347803e9.gif)
