### PR TITLE
Tweaks to character headers

### DIFF
--- a/src/app/inventory/dimStoreHeading.directive.js
+++ b/src/app/inventory/dimStoreHeading.directive.js
@@ -8,7 +8,9 @@ export const StoreHeadingComponent = {
   controllerAs: 'vm',
   bindings: {
     store: '<storeData',
-    internalLoadoutMenu: '<internalLoadoutMenu'
+    internalLoadoutMenu: '<internalLoadoutMenu',
+    currentStore: '<',
+    onTapped: '&'
   },
   template
 };
@@ -45,6 +47,11 @@ function StoreHeadingCtrl($scope, ngDialog, $i18next) {
 
   vm.openLoadoutPopup = function openLoadoutPopup(e) {
     e.stopPropagation();
+
+    if (vm.store !== vm.currentStore) {
+      vm.onTapped();
+      return;
+    }
 
     if (dialogResult === null) {
       ngDialog.closeAll();

--- a/src/app/inventory/dimStoreHeading.scss
+++ b/src/app/inventory/dimStoreHeading.scss
@@ -18,6 +18,10 @@ dim-store-heading {
   max-width: 230px;
   cursor: pointer;
 
+  store-pager & {
+    margin: 0 auto;
+  }
+
   .details {
     display: flex;
     flex-direction: row;

--- a/src/app/inventory/dimStoreHeading.scss
+++ b/src/app/inventory/dimStoreHeading.scss
@@ -15,6 +15,7 @@ dim-store-heading {
   position: relative;
   border-bottom: 2px solid #888;
   height: 46px;
+  max-width: 230px;
   cursor: pointer;
 
   .details {

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -8,7 +8,7 @@
           ng-class="{ current: vm.currentStore.current }"
           store-data="store"
           internal-loadout-menu="false"
-          ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id"></dim-store-heading>></dim-store-heading>
+          ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id"></dim-store-heading>
       </store-pager>
       <div class="detached" loadout-id="{{vm.currentStore.id}}"></div>
     </div>

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -5,10 +5,12 @@
       <store-pager on-store-change="vm.currentStore = store" initial-index="vm.currentStoreIndex" stores="vm.stores" current-store="vm.currentStore">
         <dim-store-heading
           class="character-swipe"
+          current-store="vm.currentStore"
           ng-class="{ current: vm.currentStore.current }"
           store-data="store"
           internal-loadout-menu="false"
-          ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id"></dim-store-heading>
+          ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id"
+          on-tapped="vm.currentStore = store"></dim-store-heading>
       </store-pager>
       <div class="detached" loadout-id="{{vm.currentStore.id}}"></div>
     </div>

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -12,8 +12,8 @@
           ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id"
           on-tapped="vm.currentStore = store"></dim-store-heading>
       </store-pager>
-      <div class="detached" loadout-id="{{vm.currentStore.id}}"></div>
     </div>
+    <div class="detached" loadout-id="{{vm.currentStore.id}}"></div>
     <div ng-swipe-right="vm.swipeRight($event)" ng-swipe-left="vm.swipeLeft($event)">
       <div ng-repeat="(category, buckets) in ::vm.buckets.byCategory track by category" class="section" ng-class="::category | lowercase">
         <div class="title">

--- a/src/app/inventory/store-pager.scss
+++ b/src/app/inventory/store-pager.scss
@@ -1,14 +1,25 @@
 store-pager {
   display: block;
   height: 72px;
+  max-width: 250px;
+  overflow: visible !important;
+  margin: 0 auto;
+
+  > div {
+    overflow: visible !important;
+  }
+}
+
+.store-header {
 }
 
 .character-swipe {
-
 }
 
 .phone-portrait {
   .store-header {
-    margin-left: 0;
+    max-width: calc(100% + 16px);
+    overflow: hidden;
+    margin: 0 -8px;
   }
 }

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -29,6 +29,16 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
   vm.vaultColOptions = _.range(5, 21).map((num) => ({ id: num, name: $i18next.t('Settings.ColumnSize', { num }) }));
   vm.vaultColOptions.unshift({ id: 999, name: $i18next.t('Settings.ColumnSizeAuto') });
 
+  // TODO: angular media-query-switch directive
+  const phoneWidthQuery = window.matchMedia('(max-width: 414px)');
+  function phoneWidthHandler(e) {
+    $scope.$apply(() => {
+      vm.isPhonePortrait = e.matches;
+    });
+  }
+  phoneWidthQuery.addListener(phoneWidthHandler);
+  vm.isPhonePortrait = phoneWidthQuery.matches;
+
   vm.filters = {
     vendors: {
       FWC: $i18next.t('Filter.Vendors.FWC'),

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -117,7 +117,7 @@
             <input type="radio" ng-model="vm.settings.characterOrder" value="fixed" ng-model-options="{ updateOn: 'default blur' }"><span ng-i18next="Settings.CharacterOrderFixed"></span></label>
         </td>
       </tr>
-      <tr ng-if="vm.supportsCssVar">
+      <tr ng-if="vm.supportsCssVar && !vm.isPhonePortrait">
         <td>
           <label for="charCol" ng-i18next="Settings.InventoryColumns"></label>
         </td>
@@ -125,7 +125,7 @@
           <select id="charCol" ng-model="vm.settings.charCol" ng-options="option.id as option.name for option in vm.charColOptions" required></select>
         </td>
       </tr>
-      <tr ng-if="vm.supportsCssVar">
+      <tr ng-if="vm.supportsCssVar && !vm.isPhonePortrait">
         <td>
           <label for="vaultCol" ng-i18next="Settings.VaultColumns"></label>
         </td>
@@ -133,7 +133,7 @@
           <select id="vaultCol" ng-model="vm.settings.vaultMaxCol" ng-options="option.id as option.name for option in vm.vaultColOptions" required></select>
         </td>
       </tr>
-      <tr ng-if="vm.supportsCssVar">
+      <tr ng-if="vm.supportsCssVar && !vm.isPhonePortrait">
         <td>
           <label for="itemSize" ng-i18next="Settings.SizeItem"></label>
         </td>

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -357,8 +357,11 @@ img {
   cursor: pointer;
 
   .detached & {
-    top: 48px;
+    top: 103px;
+    z-index: 1000;
     max-height: calc(100vh - 221px);
+    max-width: 230px;
+    left: calc((100% - 230px) / 2);
   }
 }
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -22,6 +22,8 @@
 @include phone-portrait {
   :root {
     --item-size: 64px !important;
+    --character-columns: 3 !important;
+    --vault-max-columns: 999 !important;
   }
 }
 


### PR DESCRIPTION
A few tweaks to the character headers in mobile.

Don't let character headers get too wide. This prevents the emblem from scaling vertically and getting misaligned:

Before:
<img width="384" alt="screen shot 2017-09-16 at 5 41 33 pm" src="https://user-images.githubusercontent.com/313208/30517090-660a1d2c-9b08-11e7-8f26-8cb7d5362186.png">

After:
<img width="383" alt="screen shot 2017-09-16 at 5 40 54 pm" src="https://user-images.githubusercontent.com/313208/30517089-6608961e-9b08-11e7-89b4-f6147fbc3a82.png">

Note how before, the background was really stretched out vertically, so things got misaligned or cut off.

In desktop mode this only affects users who have their character columns set to 4 or 5 - in those cases, the titles are left-aligned and still proportional. Given how bad these look stretched out, I think it's a win:

<img width="1266" alt="screen shot 2017-09-16 at 5 57 33 pm" src="https://user-images.githubusercontent.com/313208/30517094-9f25f766-9b08-11e7-976c-78a96c3c3e2a.png">

After that, I also reworked the swiper styling so you can see the headers to the left and right:

![swiper2](https://user-images.githubusercontent.com/313208/30517097-ccf5d986-9b08-11e7-94ff-81a68d176cac.gif)

This should make it much more obvious that you can swipe. However, for folks that don't figure it out, they can also tap on the bits of header showing on the side to instantly switch to them.

The loadout menu ends up skinnier too, which makes it easier to dismiss:

<img width="376" alt="screen shot 2017-09-16 at 6 21 04 pm" src="https://user-images.githubusercontent.com/313208/30517175-eaa16a4c-9b0b-11e7-990b-2adf712d49bd.png">
