### PR TITLE
Add "max power minus mods" to characters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Farming mode looks better on mobile.
 * If you're viewing a non-current character in mobile, it won't mess up on reload anymore.
 * You can tag and write notes on classified items to help remember which they are.
+* Add "max power without mods" stat to character headers.
 
 # 4.14.0
 

--- a/src/app/inventory/dimStoreHeading.directive.html
+++ b/src/app/inventory/dimStoreHeading.directive.html
@@ -22,7 +22,7 @@
 </div>
 <div ng-if="::vm.internalLoadoutMenu" class="loadout-menu" loadout-id="{{ ::vm.store.id }}"></div>
 <dim-stats stats="vm.store.stats" ng-if="::!vm.store.isVault"></dim-stats>
-<div class="powerMinusMods" ng-if="vm.store.maxPowerMinusMods">&#10022;{{vm.store.maxPowerMinusMods}} max power w/o mods</div>
+<div class="powerMinusMods" ng-if="vm.store.maxPowerMinusMods" ng-i18next="[i18next]({ power: vm.store.maxPowerMinusMods })Stats.PowerMinusMods"></div>
 <div ng-if="::vm.store.isVault && vm.store.destinyVersion === 1" class="vault-capacity">
   <div class="vault-bucket" title="{{ ::bucket | i18next }}: {{ size }}/{{ ::capacity }}" ng-repeat="(sort, size) in vm.store.vaultCounts" ng-init="capacity = 999; bucket = 'Bucket.' + sort">
     <div class="vault-bucket-tag">{{ ::bucket | i18next | firstLetter }}</div>

--- a/src/app/inventory/dimStoreHeading.directive.html
+++ b/src/app/inventory/dimStoreHeading.directive.html
@@ -22,6 +22,7 @@
 </div>
 <div ng-if="::vm.internalLoadoutMenu" class="loadout-menu" loadout-id="{{ ::vm.store.id }}"></div>
 <dim-stats stats="vm.store.stats" ng-if="::!vm.store.isVault"></dim-stats>
+<div class="powerMinusMods" ng-if="vm.store.maxPowerMinusMods">&#10022;{{vm.store.maxPowerMinusMods}} max power w/o mods</div>
 <div ng-if="::vm.store.isVault && vm.store.destinyVersion === 1" class="vault-capacity">
   <div class="vault-bucket" title="{{ ::bucket | i18next }}: {{ size }}/{{ ::capacity }}" ng-repeat="(sort, size) in vm.store.vaultCounts" ng-init="capacity = 999; bucket = 'Bucket.' + sort">
     <div class="vault-bucket-tag">{{ ::bucket | i18next | firstLetter }}</div>

--- a/src/app/inventory/dimStoreHeading.scss
+++ b/src/app/inventory/dimStoreHeading.scss
@@ -204,3 +204,8 @@ dim-store-heading {
   border-top: 13px solid gold;
   border-right: 13px solid transparent;
 }
+
+.powerMinusMods {
+    font-size: 10px;
+    color: #aaa;
+}

--- a/src/app/inventory/store/d2-store-factory.service.js
+++ b/src/app/inventory/store/d2-store-factory.service.js
@@ -134,6 +134,7 @@ export function D2StoreFactory($i18next, dimInfoService) {
         background: `https://www.bungie.net/${character.emblemBackgroundPath}`,
         level: character.levelProgression.level, // Maybe?
         powerLevel: character.light,
+        maxPowerMinusMods: character.stats[1885944937],
         // stats: getCharacterStatsData(defs.Stat, character.characterBase),
         class: getClass(classy.classType),
         classType: classy.classType,

--- a/src/app/inventory/store/d2-store-factory.service.js
+++ b/src/app/inventory/store/d2-store-factory.service.js
@@ -60,6 +60,7 @@ export function D2StoreFactory($i18next, dimInfoService) {
     updateCharacterInfo: function(defs, character) {
       this.level = character.levelProgression.level; // Maybe?
       this.powerLevel = character.light;
+      this.maxPowerMinusMods = character.stats[1885944937];
       this.background = `https://www.bungie.net/${character.emblemBackgroundPath}`;
       this.icon = `https://www.bungie.net/${character.emblemPath}`;
       // this.stats = getCharacterStatsData(defs.Stat, characterInfo.characterBase);

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -499,7 +499,8 @@
     "Quality": "Stats quality",
     "Strength": "Strength",
     "TierProgress": "T{{tier}} {{statName}} ({{progress}}/60 for T{{nextTier}})\n",
-    "TierProgress_Max": "T{{tier}} {{statName}} ({{progress}}/300)\n"
+    "TierProgress_Max": "T{{tier}} {{statName}} ({{progress}}/300)\n",
+    "PowerMinusMods": "✦{{power}} max power w/o mods"
   },
   "Storage": {
     "BrowserMayClearData": "The browser may delete this information if you run out of space or don't visit DIM frequently.",


### PR DESCRIPTION
<img width="686" alt="screen shot 2017-09-16 at 6 35 01 pm" src="https://user-images.githubusercontent.com/313208/30517252-f94cdd9a-9b0d-11e7-9b67-4a0acc6cfbae.png">

Open to suggestions on how to display or word this - just seemed like something useful to put in that space.

Caveat - I don't know if this stat actually represents your "drop power". It's unnamed, but it seems right (except for on uninitialized characters).