### PR TITLE
Restyle farming mode dialog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * DIM won't log you out if you've been idle too long.
 * Swipe left or right anywhere on the page in mobile mode to switch characters.
 * If you have lots of inventory, it won't make the page scroll anymore.
+* Farming mode looks better on mobile.
 
 # 4.14.0
 

--- a/src/app/farming/farming.scss
+++ b/src/app/farming/farming.scss
@@ -3,30 +3,29 @@
 #item-farming {
   position: fixed;
   backface-visibility: hidden;
-  bottom: 6rem;
-  background-color: rgba(0, 0, 0, 0.9);
-  left: calc(50% - 21.5rem);
+  bottom: 0;
+  background-color: rgba(34, 34, 34, 0.9);
+  @supports(backdrop-filter: blur(10px)) {
+    background-color: rgba(34, 34, 34, 0.6);
+    backdrop-filter: blur(10px);
+  }
   width: 43rem;
-  right: 0;
-  border-radius: .5rem;
   padding: .5rem 1rem;
   color: #e0e0e0;
   align-items: center;
   text-align: left;
   display: flex;
   flex-direction: row;
-
-  &.d2-farming {
-    bottom: 1rem;
-  }
+  max-width: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  box-sizing: border-box;
 
   button {
     color: white;
-    background-color: rgba(128, 128, 128, .8);
-    border-radius: 4px;
+    background-color: rgba(128, 128, 128, .4);
     border: none;
-    width: 6rem;
-    height: 3rem;
+    padding: .5rem 1rem;
     text-align: center;
     font-size: 1.5em;
     margin-left: 1rem;


### PR DESCRIPTION
The farming mode dialog was unusable on mobile. Now it looks pretty nice! I dropped all the rounded corners since everything we do is sharp-edged, and anchored the dialog to the bottom of the screen.

<img width="377" alt="screen shot 2017-09-16 at 6 59 13 pm" src="https://user-images.githubusercontent.com/313208/30517358-3e85b35c-9b11-11e7-8694-c0e0db9c9ae6.png">

<img width="845" alt="screen shot 2017-09-16 at 6 59 22 pm" src="https://user-images.githubusercontent.com/313208/30517359-3e987a32-9b11-11e7-8952-163517531e92.png">
