### PR TITLE
RFC: Try highlighting items w/ power mods

### DIFF
--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -34,20 +34,6 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
     });
   }
 
-  function getBasePowerLevel(item) {
-    const MOD_CATEGORY = 59;
-    const POWER_STAT_HASH = 1935470627;
-    const powerMods = item.sockets ? _.pluck(item.sockets.sockets, 'plug').filter((plug) => {
-      return plug &&
-        plug.itemCategoryHashes.includes(MOD_CATEGORY) &&
-        plug.investmentStats.some((s) => s.statTypeHash === POWER_STAT_HASH);
-    }) : [];
-
-    const modPower = sum(powerMods, (mod) => mod.investmentStats.find((s) => s.statTypeHash === POWER_STAT_HASH).value);
-
-    return item.primStat.value - modPower;
-  }
-
   angular.extend(vm, {
     getAllItems: true,
     showLockedItems: false,
@@ -86,8 +72,8 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
 
       if (vm.source.destinyVersion === 2) {
         // Rules taken from  https://bungie-net.github.io/multi/schema_Destiny-Definitions-Items-DestinyItemTierTypeInfusionBlock.html#schema_Destiny-Definitions-Items-DestinyItemTierTypeInfusionBlock
-        const sourceBasePower = getBasePowerLevel(vm.source);
-        const targetBasePower = getBasePowerLevel(vm.target);
+        const sourceBasePower = vm.source.basePower;
+        const targetBasePower = vm.target.basePower;
         const powerDiff = Math.max(0, targetBasePower - sourceBasePower);
         const quality = vm.target.infusionProcess;
         const transferAmount = powerDiff * quality.baseQualityTransferRatio;

--- a/src/app/inventory/store/d2-item-factory.service.js
+++ b/src/app/inventory/store/d2-item-factory.service.js
@@ -327,6 +327,13 @@ export function D2ItemFactory(
     createdItem.infusable = Boolean(createdItem.infusionProcess && itemDef.quality && itemDef.quality.infusionCategoryName.length);
     createdItem.infusionQuality = itemDef.quality || null;
 
+    if (createdItem.primStat) {
+      createdItem.basePower = getBasePowerLevel(createdItem);
+      if (createdItem.basePower !== createdItem.primStat.value) {
+        createdItem.complete = true;
+      }
+    }
+
     return createdItem;
   }
 
@@ -521,5 +528,19 @@ export function D2ItemFactory(
     };
 
     return dimSockets;
+  }
+
+  function getBasePowerLevel(item) {
+    const MOD_CATEGORY = 59;
+    const POWER_STAT_HASH = 1935470627;
+    const powerMods = item.sockets ? _.pluck(item.sockets.sockets, 'plug').filter((plug) => {
+      return plug &&
+        plug.itemCategoryHashes.includes(MOD_CATEGORY) &&
+        plug.investmentStats.some((s) => s.statTypeHash === POWER_STAT_HASH);
+    }) : [];
+
+    const modPower = sum(powerMods, (mod) => mod.investmentStats.find((s) => s.statTypeHash === POWER_STAT_HASH).value);
+
+    return item.primStat.value - modPower;
   }
 }

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -93,7 +93,11 @@ function SearchService(dimSettingsService) {
       year: ['year1', 'year2', 'year3'],
       vendor: ['fwc', 'do', 'nm', 'speaker', 'variks', 'shipwright', 'vanguard', 'osiris', 'xur', 'shaxx', 'cq', 'eris', 'ev', 'gunsmith'],
       activity: ['vanilla', 'trials', 'ib', 'qw', 'cd', 'srl', 'vog', 'ce', 'ttk', 'kf', 'roi', 'wotm', 'poe', 'coe', 'af', 'dawning', 'aot'],
-      cosmetic: ['cosmetic'],
+      cosmetic: ['cosmetic']
+    });
+  } else {
+    Object.assign(filterTrans, {
+      powermod: ['powermod', 'haspowermod']
     });
   }
 
@@ -806,6 +810,9 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
     },
     transferable: function(predicate, item) {
       return !item.notransfer;
+    },
+    powermod: function(predicate, item) {
+      return item.primStat && (item.primStat.value !== item.basePower);
     },
     rpm: function(predicate, item) {
       return filterByStats(predicate, item, 'rpm');

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -71,7 +71,8 @@ function SearchService(dimSettingsService) {
     equipment: ['equipment', 'equippable'],
     postmaster: ['postmaster', 'inpostmaster'],
     equipped: ['equipped'],
-    transferable: ['transferable', 'movable']
+    transferable: ['transferable', 'movable'],
+    infusable: ['infusable', 'infuse']
   };
 
   if (dimSettingsService.destinyVersion === 1) {
@@ -87,7 +88,6 @@ function SearchService(dimSettingsService) {
       reforgeable: ['reforgeable', 'reforge', 'rerollable', 'reroll'],
       ornament: ['ornament', 'ornamentmissing', 'ornamentunlocked'],
       engram: ['engram'],
-      infusable: ['infusable', 'infuse'],
       stattype: ['intellect', 'discipline', 'strength'],
       glimmer: ['glimmeritem', 'glimmerboost', 'glimmersupply'],
       year: ['year1', 'year2', 'year3'],

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -99,9 +99,6 @@
   },
   "FarmingMode": {
     "Configuration": "Configuration",
-    "D2Desc": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
-    "D2Desc_female": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
-    "D2Desc_male": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
     "Desc": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "Desc_female": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "Desc_male": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
@@ -116,7 +113,10 @@
     "OutOfRoom": "You're out of space to move items off of {{character}}. Time to decrypt some engrams and clear out the trash!",
     "OutOfRoomTitle": "Out of Room",
     "Quickmove": "Quick Move",
-    "Stop": "Stop"
+    "Stop": "Stop",
+    "D2Desc": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
+    "D2Desc_female": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
+    "D2Desc_male": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room."
   },
   "Filter": {
     "Activities": {
@@ -176,6 +176,7 @@
     "Ornament": "Shows items with ornaments and filters for their status.",
     "PartialMatch": "Shows items where their name has a partial match to the filter text.",
     "Postmaster": "Items that are currently in the Postmaster.",
+    "PowerMod": "Items that have a mod to increase their Power.",
     "Quality": "Shows items based on their total stat quality percentage. '{{percentage}}' is an alias for '{{quality}}'.",
     "RarityTier": "Shows items based on their rarity tier.",
     "Rated": "Shows all weapons that have a rating from Destiny Tracker.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -99,6 +99,9 @@
   },
   "FarmingMode": {
     "Configuration": "Configuration",
+    "D2Desc": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
+    "D2Desc_female": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
+    "D2Desc_male": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
     "Desc": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "Desc_female": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "Desc_male": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
@@ -113,10 +116,7 @@
     "OutOfRoom": "You're out of space to move items off of {{character}}. Time to decrypt some engrams and clear out the trash!",
     "OutOfRoomTitle": "Out of Room",
     "Quickmove": "Quick Move",
-    "Stop": "Stop",
-    "D2Desc": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
-    "D2Desc_female": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",
-    "D2Desc_male": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room."
+    "Stop": "Stop"
   },
   "Filter": {
     "Activities": {

--- a/src/views/filters.html
+++ b/src/views/filters.html
@@ -66,7 +66,7 @@
           </ul>
         </td>
       </tr>
-      <tr>
+      <tr ng-if="vm.settings.destinyVersion === 1">
         <td>
           <dim-filter-link filter="quality:value"></dim-filter-link>
           <dim-filter-link filter="quality:&gt;=value"></dim-filter-link>
@@ -151,6 +151,13 @@
         </td>
         <td ng-i18next="Filter.RarityTier"></td>
       </tr>
+
+      <tr ng-if="vm.settings.destinyVersion === 2">
+        <td>
+          <dim-filter-link filter="is:powermod"></dim-filter-link>
+        </td>
+        <td ng-i18next="Filter.PowerMod"></td>
+      </tr>
       <tr ng-if="vm.settings.destinyVersion === 1">
         <td>
           <dim-filter-link filter="is:intellect"></dim-filter-link>
@@ -159,7 +166,7 @@
         </td>
         <td ng-i18next="Filter.NamedStat"></td>
       </tr>
-      <tr ng-if="vm.settings.destinyVersion === 1">
+      <tr>
         <td>
           <dim-filter-link filter="is:infusable"></dim-filter-link>
           <dim-filter-link filter="is:infuse"></dim-filter-link>
@@ -222,7 +229,7 @@
         </td>
         <td ng-i18next="Filter.Locked"></td>
       </tr>
-      <tr>
+      <tr ng-if="vm.settings.destinyVersion === 1">
         <td>
           <dim-filter-link filter="is:tracked"></dim-filter-link>
           <dim-filter-link filter="is:untracked"></dim-filter-link>


### PR DESCRIPTION
This is half-baked, but the idea is to add a border to items that have a mod that affects their power. We could follow up by also explaining this in the move popup. I also added a search for these.

Calculating base power isn't super cheap, but it isn't bad.

<img width="235" alt="screen shot 2017-09-17 at 4 18 03 pm" src="https://user-images.githubusercontent.com/313208/30525845-ed10687e-9bc3-11e7-8b5d-66e214ef5854.png">
