### PR TITLE
Storage fixes

### DIFF
--- a/src/app/destiny2/d2-inventory.html
+++ b/src/app/destiny2/d2-inventory.html
@@ -5,5 +5,5 @@
 <dim-item-discuss></dim-item-discuss>
 <div id="drag-help" class="drag-help-hidden" ng-i18next="Help.Drag"></div>
 <d2-farming></d2-farming>
-<dim-clear-new-items destiny-version="2"></dim-clear-new-items>
+<dim-clear-new-items destiny-version="2" account="$ctrl.account"></dim-clear-new-items>
 <random-loadout></random-loadout>

--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -155,7 +155,7 @@ export function D2StoresService(
       D2Definitions.getDefinitions(),
       D2BucketsService.getBuckets(),
       NewItemsService.loadNewItems(account),
-      dimItemInfoService(account),
+      dimItemInfoService(account, 2),
       Destiny2Api.getStores(account)
     ];
 

--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -154,7 +154,7 @@ export function D2StoresService(
     const dataDependencies = [
       D2Definitions.getDefinitions(),
       D2BucketsService.getBuckets(),
-      NewItemsService.loadNewItems(account),
+      NewItemsService.loadNewItems(account, 2),
       dimItemInfoService(account, 2),
       Destiny2Api.getStores(account)
     ];
@@ -197,7 +197,7 @@ export function D2StoresService(
         if (!firstLoad) {
           // Save the list of new item IDs
           NewItemsService.applyRemovedNewItems(newItems);
-          NewItemsService.saveNewItems(newItems);
+          NewItemsService.saveNewItems(newItems, account, 2);
         }
 
         _stores = stores;

--- a/src/app/inventory/dimClearNewItems.directive.js
+++ b/src/app/inventory/dimClearNewItems.directive.js
@@ -8,7 +8,8 @@ export const ClearNewItemsComponent = {
   template,
   controller: ClearNewItemsCtrl,
   bindings: {
-    destinyVersion: '<'
+    destinyVersion: '<',
+    account: '<'
   }
 };
 
@@ -29,6 +30,7 @@ function ClearNewItemsCtrl($scope, NewItemsService, dimSettingsService, D2Stores
   });
 
   this.clearNewItems = function() {
-    NewItemsService.clearNewItems((this.destinyVersion === 2 ? D2StoresService : dimStoreService).getStores());
+    const stores = (this.destinyVersion === 2 ? D2StoresService : dimStoreService).getStores();
+    NewItemsService.clearNewItems(stores, this.account, this.destinyVersion);
   };
 }

--- a/src/app/inventory/dimItemInfoService.factory.js
+++ b/src/app/inventory/dimItemInfoService.factory.js
@@ -8,104 +8,109 @@ import _ from 'underscore';
 export function ItemInfoService(SyncService, $i18next, toaster, $q) {
   'ngInject';
 
-  /**
-   * Rebuild infos from partitioned info keys.
-   */
   function getInfos(key) {
     return SyncService.get().then((data) => {
-      const infos = {};
-      _.each(data, (v, k) => {
-        if (k.startsWith(key)) {
-          angular.extend(infos, v);
-        }
-      });
-      return infos;
+      return data[key] || {};
     });
   }
 
   /**
-   * Save infos to the sync service as a partitioned set, with no more than
-   * 50 items in a set. This help avoid bumping up against the 8k/key chrome sync
-   * limit.
+   * Save infos to the sync service.
    */
   function setInfos(key, infos) {
-    const partitions = {};
-    let partition = {};
-    let partitionCount = 0;
-    let partitionSize = 0;
-    _.each(infos, (v, k) => {
-      partition[k] = v;
-      partitionSize++;
-      if (partitionSize >= 50) {
-        partitions[`${key}-p${partitionCount}`] = partition;
-        partition = {};
-        partitionSize = 0;
-        partitionCount++;
-      }
-    });
-    partitions[`${key}-p${partitionCount}`] = partition;
-
-    return SyncService.get().then((data) => {
-      const emptyPartitions = _.filter(
-        _.keys(data), (k) => k.startsWith(key) && !partitions[k]);
-
-      return SyncService
-        .set(partitions)
-        .then(() => {
-          return SyncService.remove(emptyPartitions);
-        });
-    });
+    return SyncService.set({ [key]: infos });
   }
 
-  // Returns a function that, when given a platform, returns the item info source for that platform
-  return function(platform) {
-    const key = `dimItemInfo-${platform.platformType}`;
-    return getInfos(key).then((infos) => {
-      return {
-        infoForItem: function(hash, id) {
-          const itemKey = `${hash}-${id}`;
-          const info = infos[itemKey];
-          return angular.extend({
-            save: function() {
-              return getInfos(key).then((infos) => {
-                infos[itemKey] = _.omit(this, 'save');
-                setInfos(key, infos)
-                  .catch((e) => {
-                    toaster.pop('error',
-                                $i18next.t('ItemInfoService.SaveInfoErrorTitle'),
-                                $i18next.t('ItemInfoService.SaveInfoErrorDescription', { error: e.message }));
-                    console.error("Error saving item info (tags, notes):", e);
-                  });
-              });
-            }
-          }, info);
-        },
+  /**
+   * Migrate old data, which was under a different key and stored
+   * info in partitioned pieces to avoid an old Chrome sync limit.
+   */
+  function migrateOldData(account, key) {
+    // Before we stored things just by platform type
+    const oldKey = `dimItemInfo-${account.platformType}`;
 
-        // Remove all item info that isn't in stores' items
-        cleanInfos: function(stores) {
-          if (!stores.length) {
-            // don't accidentally wipe out notes
-            return $q.when();
+    // Load the old partitioned data
+    return SyncService.get()
+      .then((data) => {
+        const infos = {};
+        _.each(data, (v, k) => {
+          if (k.startsWith(oldKey)) {
+            angular.extend(infos, v);
           }
+        });
+        return infos;
+      })
+      .then((oldInfos) => {
+        if (!_.isEmpty(oldInfos)) {
+          // Store the data under the new key
+          return setInfos(key, oldInfos)
+            .then(() => {
+              // Delete all the old partitions
+              SyncService.get().then((data) => {
+                const oldPartitions = _.filter(
+                  _.keys(data), (k) => k !== oldKey && k.startsWith(oldKey));
 
-          return getInfos(key).then((infos) => {
-            const remain = {};
-
-            stores.forEach((store) => {
-              store.items.forEach((item) => {
-                const itemKey = `${item.hash}-${item.id}`;
-                const info = infos[itemKey];
-                if (info && (info.tag !== undefined || (info.notes && info.notes.length))) {
-                  remain[itemKey] = info;
-                }
+                return SyncService.remove(oldPartitions);
               });
             });
-
-            return setInfos(key, remain);
-          });
         }
-      };
-    });
+        return null;
+      });
+  }
+
+  // Returns a function that, when given an account, returns the item info source for that platform
+  return function(account, destinyVersion = 1) {
+    const key = `dimItemInfo-m${account.membershipId}-p${account.platformType}-d${destinyVersion}`;
+
+    // Load and clean out old infos
+    return migrateOldData(account, key)
+      .then(() => getInfos(key))
+      .then((infos) => {
+        return {
+          infoForItem: function(hash, id) {
+            const itemKey = `${hash}-${id}`;
+            const info = infos[itemKey];
+            return angular.extend({
+              save: function() {
+                return getInfos(key).then((infos) => {
+                  infos[itemKey] = _.omit(this, 'save');
+                  setInfos(key, infos)
+                    .catch((e) => {
+                      toaster.pop('error',
+                                  $i18next.t('ItemInfoService.SaveInfoErrorTitle'),
+                                  $i18next.t('ItemInfoService.SaveInfoErrorDescription', { error: e.message }));
+                      console.error("Error saving item info (tags, notes):", e);
+                    });
+                });
+              }
+            }, info);
+          },
+
+          // Remove all item info that isn't in stores' items
+          cleanInfos: function(stores) {
+            if (!stores.length) {
+              // don't accidentally wipe out notes
+              return $q.when();
+            }
+
+            return getInfos(key).then((infos) => {
+              const remain = {};
+
+              stores.forEach((store) => {
+                store.items.forEach((item) => {
+                  const itemKey = `${item.hash}-${item.id}`;
+                  const info = infos[itemKey];
+                  if (info && (info.tag !== undefined || (info.notes && info.notes.length))) {
+                    remain[itemKey] = info;
+                  }
+                });
+              });
+
+              return setInfos(key, remain);
+            });
+          }
+        };
+      });
   };
 }
 

--- a/src/app/inventory/dimStoreService.factory.js
+++ b/src/app/inventory/dimStoreService.factory.js
@@ -151,8 +151,8 @@ export function StoreService(
     const dataDependencies = [
       dimDefinitions.getDefinitions(),
       dimBucketService.getBuckets(),
-      NewItemsService.loadNewItems(account),
-      dimItemInfoService(account),
+      NewItemsService.loadNewItems(account, 1),
+      dimItemInfoService(account, 1),
       Destiny1Api.getStores(account)
     ];
 
@@ -178,7 +178,7 @@ export function StoreService(
         if (!firstLoad) {
           // Save the list of new item IDs
           NewItemsService.applyRemovedNewItems(newItems);
-          NewItemsService.saveNewItems(newItems);
+          NewItemsService.saveNewItems(newItems, account, 1);
         }
 
         _stores = stores;

--- a/src/app/inventory/inventory.html
+++ b/src/app/inventory/inventory.html
@@ -5,5 +5,5 @@
 <dim-item-discuss></dim-item-discuss>
 <div id="drag-help" class="drag-help-hidden" ng-i18next="Help.Drag"></div>
 <dim-farming></dim-farming>
-<dim-clear-new-items></dim-clear-new-items>
+<dim-clear-new-items destiny-version="1" account="$ctrl.account"></dim-clear-new-items>
 <random-loadout></random-loadout>

--- a/src/app/inventory/store/new-items.service.js
+++ b/src/app/inventory/store/new-items.service.js
@@ -52,14 +52,15 @@ export function NewItemsService(dimPlatformService, $q) {
     }
     _removedNewItems.add(item.id);
     item.isNew = false;
-    loadNewItems(dimPlatformService.getActive()).then((newItems) => {
+    const account = dimPlatformService.getActive();
+    loadNewItems(account).then((newItems) => {
       newItems.delete(item.id);
       service.hasNewItems = (newItems.size !== 0);
-      saveNewItems(newItems);
+      saveNewItems(newItems, account, item.destinyVersion);
     });
   }
 
-  function clearNewItems(stores) {
+  function clearNewItems(stores, account, destinyVersion) {
     stores.forEach((store) => {
       store.items.forEach((item) => {
         if (item.isNew) {
@@ -69,24 +70,23 @@ export function NewItemsService(dimPlatformService, $q) {
       });
     });
     service.hasNewItems = false;
-    saveNewItems(new Set());
+    saveNewItems(new Set(), account, destinyVersion);
   }
 
-  function loadNewItems(activePlatform) {
-    if (activePlatform) {
-      const key = newItemsKey();
+  function loadNewItems(account, destinyVersion) {
+    if (account) {
+      const key = newItemsKey(account, destinyVersion);
       return idbKeyval.get(key).then((v) => v || new Set());
     }
     return $q.resolve(new Set());
   }
 
-  function saveNewItems(newItems) {
-    return idbKeyval.set(newItemsKey(), newItems);
+  function saveNewItems(newItems, account, destinyVersion) {
+    return idbKeyval.set(newItemsKey(account, destinyVersion), newItems);
   }
 
-  function newItemsKey() {
-    const platform = dimPlatformService.getActive();
-    return `newItems-${platform ? platform.platformType : ''}`;
+  function newItemsKey(account, destinyVersion) {
+    return `newItems-m${account.membershipId}-p${account.platformType}-d${destinyVersion}`;
   }
 
   function buildItemSet(stores) {

--- a/src/app/storage/sync.service.js
+++ b/src/app/storage/sync.service.js
@@ -46,6 +46,7 @@ export function SyncService(
 
     if (!PUT && angular.equals(_.pick(cached, _.keys(value)), value)) {
       if ($featureFlags.debugSync) {
+        console.log(_.pick(cached, _.keys(value)), value);
         console.log("Skip save, already got it");
       }
       return $q.when();
@@ -88,7 +89,7 @@ export function SyncService(
   function get(force) {
     // if we already have it and we're not forcing a sync
     if (cached && !force) {
-      return $q.resolve(cached);
+      return $q.resolve(angular.copy(cached));
     }
 
     if (_getPromise) {


### PR DESCRIPTION
Because we were storing info about item tags & notes, and new items, under keys that only took into account platform, we were accidentally overwriting D1 info with D2 and vice versa.

This change makes the keys include membership ID, platform, and destiny version. This should uniquely identify an account and preserve data even if somebody logs into multiple Bungie.net accounts on the same platform.

While I was in there I also un-partitioned the item info stuff, since that was a workaround for a Chrome sync limitation we no longer have.

I'm really excited to rework all the storage and sync stuff for the rewrite 😫