### PR TITLE
Wider media query for phone mode

### DIFF
--- a/src/app/inventory/dimStores.directive.js
+++ b/src/app/inventory/dimStores.directive.js
@@ -56,7 +56,7 @@ function StoresCtrl(dimSettingsService, $scope, dimPlatformService, loadingTrack
   };
 
   // TODO: angular media-query-switch directive
-  const phoneWidthQuery = window.matchMedia('(max-width: 414px)');
+  const phoneWidthQuery = window.matchMedia('(orientation: portrait) and (max-device-width: 750px)');
   function phoneWidthHandler(e) {
     $scope.$apply(() => {
       vm.isPhonePortrait = e.matches;

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -30,7 +30,7 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
   vm.vaultColOptions.unshift({ id: 999, name: $i18next.t('Settings.ColumnSizeAuto') });
 
   // TODO: angular media-query-switch directive
-  const phoneWidthQuery = window.matchMedia('(max-width: 414px)');
+  const phoneWidthQuery = window.matchMedia('(orientation: portrait) and (max-device-width: 750px)');
   function phoneWidthHandler(e) {
     $scope.$apply(() => {
       vm.isPhonePortrait = e.matches;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -14,9 +14,8 @@ $gold: #f5dc56;
 
 $character-box-height: 46px;
 
-// Based on the CSS width of an iPhone 6 Plus
 @mixin phone-portrait {
-  @media (max-width: 414px) {
+  @media (orientation: portrait) and (max-device-width: 750px) {
     @content;
   }
 }


### PR DESCRIPTION
This should catch devices in portrait that are smaller in width than an iPad Air.

@kyleshay can you try this out on your Pixel?