### PR TITLE
Add vault counts under vault tile

### DIFF
--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -334,10 +334,19 @@ export function D2StoresService(
         return i.location.id;
       });
 
+      store.d2VaultCounts = {};
+
       // Fill in any missing buckets
       _.values(buckets.byType).forEach((bucket) => {
         if (!store.buckets[bucket.id]) {
           store.buckets[bucket.id] = [];
+        } else {
+          const vaultBucketId = bucket.accountWide ? bucket.id : bucket.vaultBucket.id;
+          store.d2VaultCounts[vaultBucketId] = store.d2VaultCounts[vaultBucketId] || {
+            count: 0,
+            bucket: bucket.accountWide ? bucket : bucket.vaultBucket
+          };
+          store.d2VaultCounts[vaultBucketId].count += store.buckets[bucket.id].length;
         }
       });
 

--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -330,23 +330,21 @@ export function D2StoresService(
       store.items = items;
 
       // by type-bucket
-      store.buckets = _.groupBy(items, (i) => {
-        return i.location.id;
-      });
+      store.buckets = _.groupBy(items, (i) => i.location.id);
 
       store.d2VaultCounts = {};
 
       // Fill in any missing buckets
       _.values(buckets.byType).forEach((bucket) => {
-        if (!store.buckets[bucket.id]) {
-          store.buckets[bucket.id] = [];
-        } else {
+        if (store.buckets[bucket.id]) {
           const vaultBucketId = bucket.accountWide ? bucket.id : bucket.vaultBucket.id;
           store.d2VaultCounts[vaultBucketId] = store.d2VaultCounts[vaultBucketId] || {
             count: 0,
             bucket: bucket.accountWide ? bucket : bucket.vaultBucket
           };
           store.d2VaultCounts[vaultBucketId].count += store.buckets[bucket.id].length;
+        } else {
+          store.buckets[bucket.id] = [];
         }
       });
 

--- a/src/app/inventory/dimStoreHeading.directive.html
+++ b/src/app/inventory/dimStoreHeading.directive.html
@@ -42,8 +42,6 @@
        press-tip="{{ vaultCount.count }}/{{ ::capacity }}"
        press-tip-title="{{ ::vaultCount.bucket.name }}">
     <div class="vault-bucket-tag">{{ ::vaultCount.bucket.name | firstLetter }}</div>
-    <div class="vault-fill-bar">
-      <div class="fill-bar" ng-class="{ 'vault-full': vaultCount.count == capacity }" dim-percent-width="vaultCount.count / capacity"></div>
-    </div>
+    {{ vaultCount.count }}/{{ ::capacity }}
   </div>
 </div>

--- a/src/app/inventory/dimStoreHeading.directive.html
+++ b/src/app/inventory/dimStoreHeading.directive.html
@@ -22,11 +22,28 @@
 </div>
 <div ng-if="::vm.internalLoadoutMenu" class="loadout-menu" loadout-id="{{ ::vm.store.id }}"></div>
 <dim-stats destiny-version="vm.store.destinyVersion" stats="vm.store.stats" ng-if="::!vm.store.isVault"></dim-stats>
-<div ng-if="::vm.store.isVault && vm.store.destinyVersion === 1" class="vault-capacity">
-  <div class="vault-bucket" title="{{ ::bucket | i18next }}: {{ size }}/{{ ::capacity }}" ng-repeat="(sort, size) in vm.store.vaultCounts" ng-init="capacity = vm.store.capacityForItem({ sort: sort }); bucket = 'Bucket.' + sort">
-    <div class="vault-bucket-tag">{{ ::bucket | i18next | firstLetter }}</div>
+    <div ng-if="::vm.store.isVault" class="vault-capacity">
+      <div class="vault-bucket"
+           ng-if="::vm.store.destinyVersion === 1"
+           press-tip="{{ size }}/{{ ::capacity }}"
+           press-tip-title="{{ ::bucket | i18next }}"
+           ng-repeat="(sort, size) in vm.store.vaultCounts"
+           ng-init="capacity = vm.store.capacityForItem({ sort: sort }); bucket = 'Bucket.' + sort">
+        <div class="vault-bucket-tag">{{ ::bucket | i18next | firstLetter }}</div>
     <div class="vault-fill-bar">
       <div class="fill-bar" ng-class="{ 'vault-full': size == capacity }" dim-percent-width="size / capacity"></div>
+    </div>
+  </div>
+
+  <div class="vault-bucket"
+       ng-repeat="(bucketId, vaultCount) in vm.store.d2VaultCounts"
+       ng-if="::vm.store.destinyVersion === 2"
+       ng-init="capacity = vaultCount.bucket.capacity"
+       press-tip="{{ vaultCount.count }}/{{ ::capacity }}"
+       press-tip-title="{{ ::vaultCount.bucket.name }}">
+    <div class="vault-bucket-tag">{{ ::vaultCount.bucket.name | firstLetter }}</div>
+    <div class="vault-fill-bar">
+      <div class="fill-bar" ng-class="{ 'vault-full': vaultCount.count == capacity }" dim-percent-width="vaultCount.count / capacity"></div>
     </div>
   </div>
 </div>

--- a/src/app/inventory/dimStoreHeading.scss
+++ b/src/app/inventory/dimStoreHeading.scss
@@ -145,6 +145,12 @@ dim-store-heading {
   align-items: center;
   justify-content: space-between;
   opacity: 0.8;
+  max-width: 230px;
+
+  store-pager & {
+    margin-left: auto;
+    margin-right: auto;
+  }
 
   height: 16px;
   margin-top: 3px;

--- a/src/app/inventory/dimStoreHeading.scss
+++ b/src/app/inventory/dimStoreHeading.scss
@@ -165,11 +165,13 @@ dim-store-heading {
     &:last-child {
       margin-right: 0;
     }
+    color: #AAA;
   }
 
   .vault-bucket-tag {
     height: 16px;
     width: 16px;
+    font-weight: bold;
     text-align: center;
   }
 

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -71,7 +71,7 @@
              ng-class="{ vault: store.isVault }"
              ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id">
           <dim-store-bucket
-            ng-if="::!store.isVault || (vm.vault.vaultCounts[category] !== undefined && (store.destinyVersion ==1 || bucket.vaultBucket))"
+            ng-if="::!store.isVault || (vm.vault.vaultCounts[category] !== undefined && (store.destinyVersion == 1 || bucket.vaultBucket))"
             store-data="store"
             bucket-items="store.buckets[bucket.id]"
             bucket="bucket"></dim-store-bucket>

--- a/src/app/inventory/store/d2-store-factory.service.js
+++ b/src/app/inventory/store/d2-store-factory.service.js
@@ -200,12 +200,12 @@ export function D2StoreFactory($i18next, dimInfoService) {
         },
         removeItem: function(item) {
           const result = StoreProto.removeItem.call(this, item);
-          this.vaultCounts[item.location.sort]--;
+          this.vaultCounts[item.location.vaultBucket.id].count--;
           return result;
         },
         addItem: function(item) {
           StoreProto.addItem.call(this, item);
-          this.vaultCounts[item.location.sort]++;
+          this.vaultCounts[item.location.vaultBucket.id].count++;
         }
       });
     }

--- a/src/app/inventory/store/d2-store-factory.service.js
+++ b/src/app/inventory/store/d2-store-factory.service.js
@@ -200,12 +200,14 @@ export function D2StoreFactory($i18next, dimInfoService) {
         },
         removeItem: function(item) {
           const result = StoreProto.removeItem.call(this, item);
-          this.vaultCounts[item.location.vaultBucket.id].count--;
+          const bucket = item.location.accountWide ? item.location : item.location.vaultBucket;
+          this.d2VaultCounts[bucket.id].count--;
           return result;
         },
         addItem: function(item) {
           StoreProto.addItem.call(this, item);
-          this.vaultCounts[item.location.vaultBucket.id].count++;
+          const bucket = item.location.accountWide ? item.location : item.location.vaultBucket;
+          this.d2VaultCounts[bucket.id].count++;
         }
       });
     }

--- a/src/app/move-popup/press-tip.directive.js
+++ b/src/app/move-popup/press-tip.directive.js
@@ -11,19 +11,18 @@ export function PressTip() {
       let timer = null;
 
       function showTip() {
-        if (!tooltip) {
-          let title = $attrs.pressTip;
-          if ($attrs.pressTipTitle) {
-            title = `<h2>${$attrs.pressTipTitle}</h2>${title}`;
-          }
-          tooltip = new Tooltip($element[0], {
-            placement: 'top', // or bottom, left, right, and variations
-            title,
-            html: true,
-            trigger: 'manual',
-            container: 'body'
-          });
+        let title = $attrs.pressTip;
+        console.log($attrs, title);
+        if ($attrs.pressTipTitle) {
+          title = `<h2>${$attrs.pressTipTitle}</h2>${title}`;
         }
+        tooltip = new Tooltip($element[0], {
+          placement: 'top', // or bottom, left, right, and variations
+          title,
+          html: true,
+          trigger: 'manual',
+          container: 'body'
+        });
         tooltip.show();
       }
 
@@ -41,7 +40,8 @@ export function PressTip() {
       $element.on('mouseup mouseleave touchend', (e) => {
         e.preventDefault();
         if (tooltip) {
-          tooltip.hide();
+          tooltip.dispose();
+          tooltip = null;
         }
         clearTimeout(timer);
       });

--- a/src/app/move-popup/press-tip.scss
+++ b/src/app/move-popup/press-tip.scss
@@ -2,7 +2,8 @@
     position: absolute;
     background: #FB9F28;
     color: black;
-    width: 250px;
+    width: fit-content;
+    max-width: 250px;
     border-radius: 3px;
     box-shadow: 0 0 2px rgba(0,0,0,0.5);
     padding: 8px;


### PR DESCRIPTION

<img width="314" alt="screen shot 2017-09-19 at 1 04 27 am" src="https://user-images.githubusercontent.com/313208/30581901-a189c544-9cd6-11e7-86ee-41de13e1c42d.png">

Still haven't figured out a good way to put counts back in the category titles since categories don't map to vaults anymore, but this at least lists the four vaults under the tile.
