### PR TITLE
Support vault for "inventory" items

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * More places can be pressed to show a tooltip.
 * Fixed showing quality for D1 items.
 * D2 subclasses are diamonds instead of squares.
+* Inventory (mods, shaders, and consumables) in your vault now show up separated into the vault, and you can transfer them to and from the vault.
 
 # 4.15.0
 

--- a/src/app/inventory/dimStoreHeading.directive.js
+++ b/src/app/inventory/dimStoreHeading.directive.js
@@ -9,7 +9,7 @@ export const StoreHeadingComponent = {
   bindings: {
     store: '<storeData',
     internalLoadoutMenu: '<internalLoadoutMenu',
-    currentStore: '<',
+    selectedStore: '<',
     onTapped: '&'
   },
   template
@@ -48,7 +48,7 @@ function StoreHeadingCtrl($scope, ngDialog, $i18next) {
   vm.openLoadoutPopup = function openLoadoutPopup(e) {
     e.stopPropagation();
 
-    if (vm.store !== vm.currentStore && !vm.internalLoadoutMenu) {
+    if (vm.store !== vm.selectedStore && !vm.internalLoadoutMenu) {
       vm.onTapped();
       return;
     }

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -1,19 +1,19 @@
 <div ng-if="vm.stores.length && vm.vault" class="inventory-content" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems, 'phone-portrait': vm.isPhonePortrait }">
-  <div ng-if="vm.isPhonePortrait && vm.currentStore">
+  <div ng-if="vm.isPhonePortrait && vm.selectedStore">
     <!-- TODO: move most of these into their own components? -->
     <div class="store-header">
-      <store-pager on-store-change="vm.currentStore = store" initial-index="vm.currentStoreIndex" stores="vm.stores" current-store="vm.currentStore">
+      <store-pager on-store-change="vm.selectedStore = store" initial-index="vm.selectedStoreIndex" stores="vm.stores" selected-store="vm.selectedStore">
         <dim-store-heading
           class="character-swipe"
-          current-store="vm.currentStore"
-          ng-class="{ current: vm.currentStore.current }"
+          selected-store="vm.selectedStore"
+          ng-class="{ current: vm.selectedStore.current }"
           store-data="store"
           internal-loadout-menu="false"
           ng-repeat="store in vm.stores | sortStores:vm.settings.characterOrder track by store.id"
-          on-tapped="vm.currentStore = store"></dim-store-heading>
+          on-tapped="vm.selectedStore = store"></dim-store-heading>
       </store-pager>
     </div>
-    <div class="detached" loadout-id="{{vm.currentStore.id}}"></div>
+    <div class="detached" loadout-id="{{vm.selectedStore.id}}"></div>
     <div ng-swipe-right="vm.swipeRight($event)" ng-swipe-left="vm.swipeLeft($event)">
       <div ng-repeat="(category, buckets) in ::vm.buckets.byCategory track by category" class="section" ng-class="::category | lowercase">
         <div class="title">
@@ -21,11 +21,11 @@
           <span ng-if="::vm.stores[0].destinyVersion != 2 && vm.vault.vaultCounts[category] !== undefined" class="bucket-count">{{ vm.vault.vaultCounts[category] }}/{{ ::vm.vault.capacityForItem({sort: category}) }}</span>
         </div>
         <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
-          <div ng-if="!vm.settings.collapsedSections[bucket.id]" class="store-cell" ng-class="{ vault: vm.currentStore.isVault }">
+          <div ng-if="!vm.settings.collapsedSections[bucket.id]" class="store-cell" ng-class="{ vault: vm.selectedStore.isVault }">
             <dim-store-bucket
               ng-if="::!store.isVault || (vm.vault.vaultCounts[category] !== undefined && (store.destinyVersion ==1 || bucket.vaultBucket))"
-              store-data="bucket.accountWide ? vm.vault : vm.currentStore"
-              bucket-items="(bucket.accountWide ? vm.vault : vm.currentStore).buckets[bucket.id]"
+              store-data="bucket.accountWide ? vm.vault : vm.selectedStore"
+              bucket-items="(bucket.accountWide ? vm.vault : vm.selectedStore).buckets[bucket.id]"
               bucket="bucket"></dim-store-bucket>
           </div>
           <div ng-if="vm.settings.collapsedSections[bucket.id]" ng-click="vm.toggleSection(bucket.id)" class="store-text collapse"><span ng-i18next="[i18next]({ bucket: bucket.name })Bucket.Show"></span></div>
@@ -35,8 +35,8 @@
         <span><i class="fa collapse" ng-class="vm.settings.collapsedSections['Reputation'] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i> <span ng-i18next="Bucket.Reputation"></span></span>
       </div>
       <div class="store-row items reputation" ng-if="!vm.settings.collapsedSections['Reputation']">
-        <div class="store-cell" ng-class="::{ vault: vm.currentStore.isVault }">
-          <dim-store-reputation store-data="vm.currentStore"></dim-store-reputation>
+        <div class="store-cell" ng-class="::{ vault: vm.selectedStore.isVault }">
+          <dim-store-reputation store-data="vm.selectedStore"></dim-store-reputation>
         </div>
       </div>
     </div>

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -23,9 +23,9 @@
         <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
           <div ng-if="!vm.settings.collapsedSections[bucket.id]" class="store-cell" ng-class="{ vault: vm.selectedStore.isVault }">
             <dim-store-bucket
-              ng-if="::!store.isVault || (vm.vault.vaultCounts[category] !== undefined && (store.destinyVersion ==1 || bucket.vaultBucket))"
-              store-data="bucket.accountWide ? vm.vault : vm.selectedStore"
-              bucket-items="(bucket.accountWide ? vm.vault : vm.selectedStore).buckets[bucket.id]"
+              ng-if="::(vm.vault.vaultCounts[category] !== undefined && (store.destinyVersion == 1 || bucket.vaultBucket))"
+              store-data="bucket.accountWide && !vm.selectedStore.isVault ? vm.currentStore : vm.selectedStore"
+              bucket-items="(bucket.accountWide && !vm.selectedStore.isVault ? vm.currentStore : vm.selectedStore).buckets[bucket.id]"
               bucket="bucket"></dim-store-bucket>
           </div>
           <div ng-if="vm.settings.collapsedSections[bucket.id]" ng-click="vm.toggleSection(bucket.id)" class="store-text collapse"><span ng-i18next="[i18next]({ bucket: bucket.name })Bucket.Show"></span></div>
@@ -55,6 +55,12 @@
       </div>
       <div class="store-row items" ng-if="!vm.settings.collapsedSections[category]" ng-repeat="bucket in ::buckets track by bucket.id"><i ng-click="vm.toggleSection(bucket.id)" class="fa collapse" ng-class="vm.settings.collapsedSections[bucket.id] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
         <div ng-if="bucket.accountWide && !vm.settings.collapsedSections[bucket.id]" class="store-cell account-wide">
+          <dim-store-bucket
+            store-data="vm.currentStore"
+            bucket-items="vm.currentStore.buckets[bucket.id]"
+            bucket="bucket"></dim-store-bucket>
+        </div>
+        <div ng-if="bucket.accountWide && !vm.settings.collapsedSections[bucket.id]" class="store-cell vault">
           <dim-store-bucket
             store-data="vm.vault"
             bucket-items="vm.vault.buckets[bucket.id]"

--- a/src/app/inventory/dimStores.directive.js
+++ b/src/app/inventory/dimStores.directive.js
@@ -29,19 +29,19 @@ function StoresCtrl(dimSettingsService, $scope, dimPlatformService, loadingTrack
 
   vm.swipeLeft = () => {
     const sortedStores = $filter('sortStores')(vm.stores, dimSettingsService.characterOrder);
-    const currentIndex = sortedStores.indexOf(vm.currentStore);
+    const currentIndex = sortedStores.indexOf(vm.selectedStore);
 
     if (currentIndex < (sortedStores.length - 1)) {
-      vm.currentStore = sortedStores[currentIndex + 1];
+      vm.selectedStore = sortedStores[currentIndex + 1];
     }
   };
 
   vm.swipeRight = () => {
     const sortedStores = $filter('sortStores')(vm.stores, dimSettingsService.characterOrder);
-    const currentIndex = sortedStores.indexOf(vm.currentStore);
+    const currentIndex = sortedStores.indexOf(vm.selectedStore);
 
     if (currentIndex > 0) {
-      vm.currentStore = sortedStores[currentIndex - 1];
+      vm.selectedStore = sortedStores[currentIndex - 1];
     }
   };
   vm.buckets = null;
@@ -69,14 +69,18 @@ function StoresCtrl(dimSettingsService, $scope, dimPlatformService, loadingTrack
     vm.vault = _.find(vm.stores, 'isVault');
 
     if (vm.stores && vm.stores.length) {
-      if (!vm.currentStore || !_.find(vm.stores, { id: vm.currentStore.id })) {
-        vm.currentStore = _.find(vm.stores, 'current');
-        vm.currentStoreIndex = $filter('sortStores')(vm.stores, dimSettingsService.characterOrder).indexOf(vm.currentStore);
+      // This is the character that was last played
+      vm.currentStore = _.find(vm.stores, 'current');
+
+      // This is the character selected to display in mobile view
+      if (!vm.selectedStore || !_.find(vm.stores, { id: vm.selectedStore.id })) {
+        vm.selectedStore = vm.currentStore;
       } else {
-        vm.currentStore = _.find(vm.stores, { id: vm.currentStore.id });
-        vm.currentStoreIndex = $filter('sortStores')(vm.stores, dimSettingsService.characterOrder).indexOf(vm.currentStore);
+        vm.selectedStore = _.find(vm.stores, { id: vm.selectedStore.id });
       }
+      vm.selectedStoreIndex = $filter('sortStores')(vm.stores, dimSettingsService.characterOrder).indexOf(vm.selectedStore);
     } else {
+      vm.selectedStore = null;
       vm.currentStore = null;
     }
   };

--- a/src/app/inventory/dimStores.scss
+++ b/src/app/inventory/dimStores.scss
@@ -51,7 +51,7 @@
 
   &.account-wide {
     width: 100%;
-    max-width: calc((44px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px))) * var(--num-characters));
+    max-width: calc((40px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px))) * var(--num-characters) + ((var(--num-characters) - 1) * 12px));
   }
 }
 .store-text {

--- a/src/app/inventory/store-pager.component.js
+++ b/src/app/inventory/store-pager.component.js
@@ -9,7 +9,7 @@ export const StorePagerComponent = {
   bindings: {
     onStoreChange: '&',
     initialIndex: '<',
-    currentStore: '<',
+    selectedStore: '<',
     stores: '<'
   }
 };
@@ -30,8 +30,8 @@ function StorePagerCtrl($element, $scope, $filter, dimSettingsService) {
   };
 
   this.$onChanges = () => {
-    if (this.dragend && this.currentStore) {
-      const storeIndex = $filter('sortStores')(this.stores, dimSettingsService.characterOrder).indexOf(this.currentStore);
+    if (this.dragend && this.selectedStore) {
+      const storeIndex = $filter('sortStores')(this.stores, dimSettingsService.characterOrder).indexOf(this.selectedStore);
       this.dragend.jumpToPage(storeIndex + 1);
     }
   };

--- a/src/app/inventory/store/d2-item-factory.service.js
+++ b/src/app/inventory/store/d2-item-factory.service.js
@@ -218,7 +218,7 @@ export function D2ItemFactory(
       name: itemDef.displayProperties.name,
       description: itemDef.displayProperties.description,
       icon: itemDef.displayProperties.icon || '/img/misc/missing_icon_d2.png',
-      notransfer: Boolean(currentBucket.accountWide || currentBucket.inPostmaster || itemDef.nonTransferrable),
+      notransfer: Boolean(currentBucket.inPostmaster || itemDef.nonTransferrable),
       id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
       equipped: Boolean(instanceDef.isEquipped),
       equipment: Boolean(itemDef.equippingBlock), // TODO: this has a ton of good info for the item move logic


### PR DESCRIPTION
Inventory (mods, shaders, and consumables) in your vault now show up separated into the vault, and you can transfer them to and from the vault.

This was kind of tricky. It required me to split "profile-wide inventory" between the vault and whatever the active character was (I had to pick one), and then display the active character's inventory as all characters' inventory. This was all just something I missed in the initial implementation - it wasn't until somebody mentioned it on Twitter that I even realized that you could put Inventory items into the "General" bucket (which is the only true Vault - I thought there were four Vaults, one for General and then three globally accessible Vaults for Mods, Shaders, and Consumables, but I was wrong.

Fixes https://github.com/DestinyItemManager/DIM/issues/2193