### PR TITLE
Try out wasm on Android again

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -200,8 +200,8 @@ module.exports = (env) => {
         // Sync data over gdrive
         '$featureFlags.gdrive': JSON.stringify(true),
         '$featureFlags.debugSync': JSON.stringify(false),
-        // Use a WebAssembly version of SQLite, if possible (this crashes on Android Chrome right now)
-        '$featureFlags.wasm': '!window.navigator.userAgent.includes("Android")',
+        // Use a WebAssembly version of SQLite, if possible (this crashes on Chrome 58 on Android though)
+        '$featureFlags.wasm': JSON.stringify(true),
         // Enable color-blind a11y
         '$featureFlags.colorA11y': JSON.stringify(env !== 'release'),
         // Whether to log page views for router events


### PR DESCRIPTION
WASM was causing crashes on Android Chrome 58 (or was it 57?), but current Chrome on Android is 60. What do you say we try again, and if people have crashes we just tell them to upgrade?