### PR TITLE
Add a tooltip and asterix when light calculations may be wrong because of classified items

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Equipping an exotic emote won't unequip your exotic sparrow and vice versa.
 * Item popups aren't weirdly tall on Firefox anymore.
 * Armor stats now match the order in the game.
+* Show a warning that your max light may be wrong if you have classified items.
 
 # 4.15.0
 

--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -399,11 +399,20 @@ export function D2StoresService(
     if (!store.isVault) {
       const def = defs.Stat.get(1935470627);
       const maxBasePower = getBasePower(store, maxBasePowerLoadout(stores, store));
+
+      const hasClassified = flatMap(_stores, 'items').some((i) => {
+        return i.classified &&
+          (i.location.sort === 'Weapons' ||
+           i.location.sort === 'Armor' ||
+           i.type === 'Ghost');
+      });
+
       store.stats.maxBasePower = {
         id: 'maxBasePower',
         name: $i18next.t('Stats.MaxBasePower'),
+        hasClassified,
         description: def.displayProperties.description,
-        value: maxBasePower,
+        value: hasClassified ? `${maxBasePower}*` : maxBasePower,
         icon: `https://www.bungie.net${def.displayProperties.icon}`,
         tiers: [maxBasePower],
         tierMax: 300,

--- a/src/app/inventory/dimStats.directive.js
+++ b/src/app/inventory/dimStats.directive.js
@@ -47,6 +47,10 @@ function StatsCtrl($scope, $i18next) {
         } else {
           stat.tooltip = `${stat.name}: ${stat.value} / ${stat.tierMax}`;
         }
+
+        if (stat.hasClassified) {
+          stat.tooltip += `\n\n${$i18next.t('Loadouts.Classified')}`;
+        }
       }
     });
   });

--- a/src/app/loadout/loadout-popup.component.js
+++ b/src/app/loadout/loadout-popup.component.js
@@ -231,7 +231,14 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
     }
     return loadout;
   };
-  vm.maxLightValue = dimLoadoutService.getLight(vm.store, vm.maxLightLoadout());
+
+  vm.hasClassified = storeService.getAllItems().some((i) => {
+    return i.classified &&
+      (i.location.sort === 'Weapons' ||
+       i.location.sort === 'Armor' ||
+       i.type === 'Ghost');
+  });
+  vm.maxLightValue = dimLoadoutService.getLight(vm.store, vm.maxLightLoadout()) + (vm.hasClassified ? '*' : '');
 
   // A dynamic loadout set up to level weapons and armor
   vm.gatherEngramsLoadout = function gatherEngramsLoadout($event, options = {}) {

--- a/src/app/loadout/loadout-popup.html
+++ b/src/app/loadout/loadout-popup.html
@@ -30,7 +30,7 @@
 
     <li class="loadout-set" ng-if="!vm.store.isVault">
       <span ng-click="vm.maxLightLoadout($event)">
-        <span class="light" ng-bind="::vm.maxLightValue"></span>
+        <span class="light" ng-bind="::vm.maxLightValue" press-tip="{{ vm.hasClassified ? 'Loadouts.Classified' : '' | i18next }}"></span>
         <i class="fa">✦</i>
         <span ng-i18next="{{ vm.store.destinyVersion == 2 ? 'Loadouts.MaximizePower' : 'Loadouts.MaximizeLight' }}"></span>
       </span>

--- a/src/app/move-popup/press-tip.directive.js
+++ b/src/app/move-popup/press-tip.directive.js
@@ -11,18 +11,20 @@ export function PressTip() {
       let timer = null;
 
       function showTip() {
-        let title = $attrs.pressTip;
-        if ($attrs.pressTipTitle) {
-          title = `<h2>${$attrs.pressTipTitle}</h2>${title}`;
+        if (!tooltip) {
+          let title = $attrs.pressTip;
+          if ($attrs.pressTipTitle) {
+            title = `<h2>${$attrs.pressTipTitle}</h2>${title}`;
+          }
+          tooltip = new Tooltip($element[0], {
+            placement: 'top', // or bottom, left, right, and variations
+            title,
+            html: true,
+            trigger: 'manual',
+            container: 'body'
+          });
+          tooltip.show();
         }
-        tooltip = new Tooltip($element[0], {
-          placement: 'top', // or bottom, left, right, and variations
-          title,
-          html: true,
-          trigger: 'manual',
-          container: 'body'
-        });
-        tooltip.show();
       }
 
       $element.on('mouseenter', (e) => {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -361,6 +361,7 @@
     "ApplySearch": "Items = \"{{query}}\"",
     "Before": "Before '{{name}}'",
     "Cancel": "Cancel",
+    "Classified": "Some of your items are classified, and cannot be included in the max power calculation.",
     "ConfirmDelete": "Are you sure you want to delete '{{name}}'?",
     "CouldNotEquip": "Could not equip {{itemname}}",
     "Create": "Create Loadout",


### PR DESCRIPTION
It's kind of ugly, but might avoid confusion. Mobile users probably don't know to press...

<img width="381" alt="screen shot 2017-09-23 at 5 36 18 pm" src="https://user-images.githubusercontent.com/313208/30778304-23d5f4ce-a087-11e7-863b-7d04a267797b.png">
<img width="276" alt="screen shot 2017-09-23 at 5 43 35 pm" src="https://user-images.githubusercontent.com/313208/30778303-23d5781e-a087-11e7-8295-6d967fcbf3a3.png">
