### PR TITLE
Added a new type of sort to group items by type.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 
+* Added item type sort to settings group items by type (e.g. all Sniper Rifles together).
 * Reputation emblems are the same size as items now, however you have item size set.
 * Shaders show up in an item's mods now.
 * Transfering search loadouts is more reliable.

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -100,6 +100,9 @@
           <br>
           <label>
             <input type="radio" ng-model="vm.settings.itemSort" value="name"><span ng-i18next="Settings.SortName"></span></label>
+          <br>
+          <label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="type"><span ng-i18next="Settings.SortType"></span></label>
         </td>
       </tr>
       <tr>

--- a/src/app/shell/dimAngularFilters.filter.js
+++ b/src/app/shell/dimAngularFilters.filter.js
@@ -194,6 +194,14 @@ mod.filter('sortItems', (dimSettingsService) => {
         }
       });
     }
+    if (sort === 'type') {
+      items = _.sortBy(items, (item) => {
+        return item.classType;
+      });
+      items = _.sortBy(items, (item) => {
+        return item.typeName;
+      });
+    }
     return items;
   };
 });

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -489,6 +489,7 @@
     "SortPrimary": "primary stat",
     "SortRarity": "rarity",
     "SortRoll": "rating",
+    "SortType": "item type",
     "VaultColumns": "Vault maximum inventory width"
   },
   "Stats": {


### PR DESCRIPTION
Something I've been wanting (both from the in-game vault and DIM) is the ability to sort things by item type (i.e. all Scout Rifles together). It seemed like a simple enough thing to implement myself, so I did.