### PR TITLE
Update service worker to inline dependencies, cache fonts, and notify updates

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -19,8 +19,7 @@ const nodeModulesDir = path.join(__dirname, '../node_modules');
 
 // https://github.com/dmachat/angular-webpack-cookbook/wiki/Optimizing-Development
 const preMinifiedDeps = [
-  'underscore/underscore-min.js',
-  'indexeddbshim/dist/indexeddbshim.min.js'
+  'underscore/underscore-min.js'
 ];
 
 module.exports = (env) => {
@@ -256,7 +255,7 @@ module.exports = (env) => {
       output: { comments: false },
       sourceMap: true
     }));
-
+  }
     // Generate a service worker
     config.plugins.push(new WorkboxPlugin({
       maximumFileSizeToCacheInBytes: 5000000,
@@ -265,11 +264,28 @@ module.exports = (env) => {
         'authReturn*',
         'extension-scripts/*',
         'return.html',
+        'service-worker\.js'
       ],
-      // swSrc: './src/sw.js',
+      swSrc: './dist/service-worker.js',
       swDest: './dist/service-worker.js'
     }));
-  }
+  //}
 
-  return config;
+  // Build the service worker in an entirely separate configuration so
+  // it doesn't get name-mangled. It'll be used by the
+  // WorkboxPlugin. This lets us inline the dependencies.
+  const serviceWorker = {
+    entry: {
+      'service-worker': './src/service-worker.js'
+    },
+
+    output: {
+      path: path.resolve('./dist'),
+      filename: '[name].js'
+    },
+
+    stats: 'errors-only'
+  };
+
+  return [serviceWorker, config];
 };

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -255,7 +255,7 @@ module.exports = (env) => {
       output: { comments: false },
       sourceMap: true
     }));
-  }
+
     // Generate a service worker
     config.plugins.push(new WorkboxPlugin({
       maximumFileSizeToCacheInBytes: 5000000,
@@ -264,12 +264,12 @@ module.exports = (env) => {
         'authReturn*',
         'extension-scripts/*',
         'return.html',
-        'service-worker\.js'
+        'service-worker.js'
       ],
       swSrc: './dist/service-worker.js',
       swDest: './dist/service-worker.js'
     }));
-  //}
+  }
 
   // Build the service worker in an entirely separate configuration so
   // it doesn't get name-mangled. It'll be used by the

--- a/src/app/app.component.js
+++ b/src/app/app.component.js
@@ -1,6 +1,7 @@
 import template from './app.html';
 import './app.scss';
 import changelog from '../views/changelog-toaster-release.html';
+import _ from 'underscore';
 
 export const AppComponent = {
   template: template,
@@ -99,6 +100,28 @@ function AppComponentCtrl(
           type: 'error',
           hideable: false
         }, 0);
+      });
+    }
+
+    if (window.BroadcastChannel) {
+      const updateChannel = new window.BroadcastChannel('precache-updates');
+
+      const updateMessage = _.once(() => {
+        $timeout(() => {
+          dimInfoService.show('update-available', {
+            title: $i18next.t('Help.UpdateAvailable'),
+            body: $i18next.t('Help.UpdateAvailableMessage'),
+            type: 'warn',
+            hideable: false
+          }, 0);
+        });
+      });
+
+      const messageHandler = () => updateMessage();
+
+      updateChannel.addEventListener('message', messageHandler);
+      $scope.$on('$destroy', () => {
+        updateChannel.removeEventListener('message', messageHandler);
       });
     }
   };

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -239,7 +239,9 @@
     "UpgradeChrome": "Please Upgrade Chrome",
     "Version_beta": "Beta has been updated to v{{version}}",
     "Version_release": "DIM v{{version}} Released",
-    "Xur": "Xûr is Here"
+    "Xur": "Xûr is Here",
+    "UpdateAvailable": "DIM Updated",
+    "UpdateAvailableMessage": "An update is available for DIM. Reload the page to update."
   },
   "Hotkey": {
     "ClearNewItems": "Clear new items",

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,17 @@
+import WorkboxSW from 'workbox-sw';
+
+const workboxSW = new WorkboxSW();
+
+// This array will be filled in with our files by the Workbox plugin
+workboxSW.precache([]);
+
+// Cache our fonts!
+workboxSW.router.registerRoute('https://fonts.googleapis.com/(.*)',
+  workboxSW.strategies.cacheFirst({
+    cacheName: 'googleapis',
+    cacheExpiration: {
+      maxEntries: 20
+    },
+    cacheableResponse: { statuses: [0, 200] }
+  })
+);


### PR DESCRIPTION
Some upgrades to service worker:

1. Inline the import of the service worker code. This reduces cacheability and makes the service worker bigger, but it *may* fix #2183, though I can't reproduce that.
2. Cache Google Fonts.
3. Listen for a message when the service worker updates, that tells people to reload to get a new version of DIM. This helps because the service worker will always serve the old version on the first visit.