### PR TITLE
Fix bucket inconsistency

### DIFF
--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -137,9 +137,14 @@ export function D2StoresService(
    * @return {Promise} the new stores
    */
   function reloadStores() {
+    // adhere to the old contract by returning the next value as a
+    // promise We take 2 from the stream because the publishReplay
+    // will always return the latest value instantly, and we want the
+    // next value (the refreshed value). toPromise returns the last
+    // value in the sequence.
+    const promise = storesStream.take(2).toPromise();
     forceReloadTrigger.next(); // signal the force reload
-    // adhere to the old contract by returning the next value as a promise
-    return storesStream.take(1).toPromise();
+    return promise;
   }
 
   /**

--- a/src/app/inventory/dimItemService.factory.js
+++ b/src/app/inventory/dimItemService.factory.js
@@ -146,11 +146,9 @@ export function ItemService(
     }
 
     if (equip) {
-      const equipped = _.find(target.buckets[item.location.id], { equipped: true });
-      if (equipped) {
-        equipped.equipped = false;
-      }
-      item.equipped = true;
+      target.buckets[item.location.id].forEach((i) => {
+        i.equipped = (i.index === item.index);
+      });
     }
 
     return item;

--- a/src/app/inventory/dimStoreService.factory.js
+++ b/src/app/inventory/dimStoreService.factory.js
@@ -133,9 +133,14 @@ export function StoreService(
    * @return {Promise} the new stores
    */
   function reloadStores() {
+    // adhere to the old contract by returning the next value as a
+    // promise We take 2 from the stream because the publishReplay
+    // will always return the latest value instantly, and we want the
+    // next value (the refreshed value). toPromise returns the last
+    // value in the sequence.
+    const promise = storesStream.take(2).toPromise();
     forceReloadTrigger.next(); // signal the force reload
-    // adhere to the old contract by returning the next value as a promise
-    return storesStream.take(1).toPromise();
+    return promise;
   }
 
   /**


### PR DESCRIPTION
There was a subtle problem with how I'd defined `reloadStores` after moving to observables, that commonly exposed us to a race condition that was always there (moving and equipping items while the stores are being updated). This should avoid it in most cases by properly waiting for the store refresh that gets triggered when the bucket is full.

This fixes #2239.