### PR TITLE
Infuse Fuel Finder - Math was still off (part 2)

### DIFF
--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -85,7 +85,7 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
         // Folks report that that formula isn't really what's used,
         // and that you just always get the full value.
         // https://github.com/DestinyItemManager/DIM/issues/2215
-        vm.infused = vm.target.basePower;
+        vm.infused = vm.target.basePower + (vm.source.primStat.value - vm.source.basePower);
       }
     },
 


### PR DESCRIPTION
In #2232 there was 2 problems, only one of them was solved.  If what I done is right, it should be the last bug... The mod value of the source item wasn't being considered in the final value.