### PR TITLE
Infuse Fuel Finder - Math was still off (part 3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Fix in infusion calculator to correctly consider +5 mod
 
 # 4.16.1
 

--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -39,7 +39,7 @@
           <div>
             <div ng-i18next="Infusion.BringGear"></div>
             <span class="bigValue">{{ vm.infused }}</span>
-            <span class="green">(+ {{ vm.infused - (vm.source.basePower || vm.source.primStat.value) }})</span>
+            <span class="green">(+ {{ vm.infused - vm.source.primStat.value }})</span>
           </div>
           <div ng-if="vm.source.destinyVersion === 1">
             <span> 3 <span class="currency"><img alt="{{ ::vm.items[2534352370].itemName }}" title="{{ ::vm.items[2534352370].itemName }}" ng-src="{{ vm.items[2534352370].icon | bungieIcon }}"></span></span>


### PR DESCRIPTION
Changing on infuse.component.js made the green value wrong (when item have a powermod). This should fix it for good.