### PR TITLE
Add "dupelower"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Added `is:dupelower` to search filters for easier trashing.
 * Added missing factions to the reputation section.
 * Fix in infusion calculator to correctly consider +5 mod
 * Fix for CSV export (e.g.: First In, Last Out in 2 columns)

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -554,8 +554,8 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
             });
 
             if (!_dupeInPost) {
-              if(_.any(dupes, (dupe) => dupe.location.inPostmaster)) {
-                toaster.pop('warn', $i18next.t('Filter.DupeInPostmaster'),);
+              if (_.any(dupes, (dupe) => dupe.location.inPostmaster)) {
+                toaster.pop('warn', $i18next.t('Filter.DupeInPostmaster'));
                 _dupeInPost = true;
               }
             }

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -146,6 +146,7 @@
     "DamageType": "Shows items based on their damage type.",
     "Description": "Description",
     "Dupe": "Shows duplicate items",
+    "DupeInPostmaster": "Some item duplicates are at the postmaster.",
     "Engrams": "Shows engrams.",
     "EnterName": "Enter an item name:",
     "EnterNote": "Enter notes text:",

--- a/src/views/filters.html
+++ b/src/views/filters.html
@@ -219,6 +219,7 @@
         <td>
           <dim-filter-link filter="is:dupe"></dim-filter-link>
           <dim-filter-link filter="is:duplicate"></dim-filter-link>
+          <dim-filter-link filter="is:dupelower"></dim-filter-link>
         </td>
         <td ng-i18next="Filter.Dupe"></td>
       </tr>


### PR DESCRIPTION
Maybe we could find a better name for it, but basically it looks for all the duplicates that are a lower light level than the highest dupe. Combined with the search load out, it could make for quick cleanup of your extra stuff.

wanted to use the same prefix of `is:dupe` so that when people use the auto complete they see the new feature.

![rec](https://user-images.githubusercontent.com/424158/31009601-e527a63e-a4bc-11e7-9bc1-e5497495b980.gif)
