### PR TITLE
Adds apple-mobile-web-app-capable meta tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,7 @@
     <link rel="manifest" href="/manifest-webapp.json">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444">
     <meta name="theme-color" content="#404141">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
     {{#each htmlWebpackPlugin.files.css}}


### PR DESCRIPTION
Hi DIM! Long-time user and love the app! I recently added DIM as a shortcut on my Home screen, but noticed that it wasn't launching in standalone mode like I thought it would. I did a little reading of documentation, and I think I found out why.

This adds the apple-mobile-web-app-capable meta tag to index.html so that DIM can show up in standalone mode on iOS devices when it is launched from the Home screen.

index.html already had apple-mobile-web-app-status-bar-style, but according to [Apple's documentation][1] this tag has no effect unless you also activate standalone mode using apple-mobile-web-app-capable.

[1]:
https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW2