### PR TITLE
Revert "Adds apple-mobile-web-app-capable meta tag"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,6 @@
     <link rel="manifest" href="/manifest-webapp.json">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444">
     <meta name="theme-color" content="#404141">
-    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
     {{#each htmlWebpackPlugin.files.css}}


### PR DESCRIPTION
Reverts DestinyItemManager/DIM#2275

This prevents login and we can't do it with iOS.  