### PR TITLE
Updated is:dupelower

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Updated `is:dupelower` search filter for items with the same/no power level.
+
 # 4.17.0
 
 * Fix bug that prevented pinned apps in iOS from authenticating with Bungie.net.

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -545,11 +545,12 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
         _duplicates = _.groupBy(getStoreService().getAllItems(), 'hash');
         _.each(_duplicates, (dupes) => {
           if (dupes.length > 1) {
-            const bestBasePower = _.max(_.pluck(dupes, 'basePower'));
+            let bestBasePower = _.max(dupes, 'basePower');
+            if (bestBasePower === -Infinity) {
+              bestBasePower = dupes[0];
+            }
 
-            _.filter(dupes, (dupe) => {
-              return dupe.basePower < bestBasePower;
-            }).forEach((dupe) => {
+            _.reject(dupes, (dupe) => dupe.id === bestBasePower.id).forEach((dupe) => {
               _lowerDupes[dupe.id] = 1;
             });
 


### PR DESCRIPTION
The way it works now is that it picks the highest level item for
duplicate items. If the items are the same level or don’t have a level
(emblems, etc.) then it picks a random one.