### PR TITLE
Improve sync by waiting for full google login before syncing.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * Updated `is:dupelower` search filter for items with the same/no power level.
+* Fix some issues with Google Drive that might lead to lost data.
 
 # 4.17.0
 

--- a/src/app/storage/google-drive-storage.js
+++ b/src/app/storage/google-drive-storage.js
@@ -140,7 +140,9 @@ export function GoogleDriveStorage($q, $i18next, OAuthTokenService) {
           if ($featureFlags.debugSync) {
             console.log('authorizing Google Drive');
           }
-          return auth.signIn();
+          return auth.signIn().then(() => {
+            return this.updateSigninStatus(true);
+          });
         }
       });
     },

--- a/src/app/storage/storage.component.js
+++ b/src/app/storage/storage.component.js
@@ -65,7 +65,11 @@ function StorageController($scope, dimSettingsService, SyncService, GoogleDriveS
 
   vm.driveSync = function() {
     if ($window.confirm($i18next.t('Storage.GDriveSignInWarning'))) {
-      return GoogleDriveStorage.authorize().then(vm.forceSync);
+      return GoogleDriveStorage.authorize()
+        .then(vm.forceSync)
+        .catch((e) => {
+          $window.alert($i18next.t('Storage.GDriveSignInError') + e.message);
+        });
     }
     return null;
   };

--- a/src/app/storage/sync.service.js
+++ b/src/app/storage/sync.service.js
@@ -118,6 +118,8 @@ export function SyncService(
               console.error('Sync: Error loading from', adapter.name, e);
               return null;
             });
+        } else if ($featureFlags.debugSync) {
+          console.log(adapter.name, 'is disabled');
         }
         return promise;
       }, $q.when())

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -529,6 +529,7 @@
     "ForceSync": "Force sync data",
     "GDriveLogout": "Your data is still in Google Drive - if you log in again, DIM will go back to using it.",
     "GDriveSignInWarning": "If you already have saved DIM data in Google Drive, it will overwrite anything you have saved locally. You may want to back up your data before signing in.\n\nContinue to sign in to Google Drive?",
+    "GDriveSignInError": "Error signing in to Google Drive:",
     "GoogleApiBlocked": "Google Drive is not available because a content blocker has blocked the Google Drive JavaScript. Please exclude DIM from content blockers and try again.",
     "GoogleDriveStorage": "Google Drive",
     "IgnoredUsers": "{{value}} ignored users",


### PR DESCRIPTION
This may help with https://github.com/DestinyItemManager/DIM/issues/2223. Basically I wasn't waiting until GDrive was fully initialized before syncing, which might possibly get things into a bad state. I'm also showing an error when GDrive fails to log in, instead of just nothing - that may help with some mobile users who are having trouble (#2187). 