### PR TITLE
Change the example search to be 'is:dupe'

### DIFF
--- a/src/app/shell/dimSearchFilter.directive.html
+++ b/src/app/shell/dimSearchFilter.directive.html
@@ -1,1 +1,1 @@
-<input id="filter-input" class="dim-input" autocomplete="off" autocorrect="off" autocapitalize="off" ng-i18next="[i18next:placeholder]({ example: 'is:arc' })Header.FilterHelp" type="search" name="filter" ng-model="vm.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">
+<input id="filter-input" class="dim-input" autocomplete="off" autocorrect="off" autocapitalize="off" ng-i18next="[i18next:placeholder]({ example: 'is:dupe' })Header.FilterHelp" type="search" name="filter" ng-model="vm.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">


### PR DESCRIPTION
`is:dupe` is cooler than `is:arc`. Maybe putting it in the example will help people learn about it.