### PR TITLE
Add missing Search bucket filters

### DIFF
--- a/src/app/destiny2/d2-buckets.service.js
+++ b/src/app/destiny2/d2-buckets.service.js
@@ -18,7 +18,7 @@ export const D2Categories = {
   ],
   General: [
     'Ghost',
-    'Clan Banners',
+    'ClanBanners',
     'Vehicle',
     'Ships',
     'Emblems',
@@ -35,9 +35,9 @@ export const D2Categories = {
     'Quests',
   ],
   Postmaster: [
-    'Lost Items',
+    'LostItems',
     'Messages',
-    'Special Orders'
+    'SpecialOrders'
   ]
 };
 
@@ -65,16 +65,16 @@ const bucketToType = {
   3865314626: "Materials",
   4023194814: "Ghost",
   4274335291: "Emblems",
-  4292445962: "Clan Banners",
+  4292445962: "ClanBanners",
   14239492: "Chest",
   18606351: "Shaders",
   20886954: "Leg",
-  215593132: "Lost Items",
+  215593132: "LostItems",
   284967655: "Ships",
   375726501: "Engrams",
   953998645: "Power",
   1269569095: "Auras",
-  1367666825: "Special Orders",
+  1367666825: "SpecialOrders",
   1498876634: "Kinetic",
   1585787867: "ClassItem",
   2025709351: "Vehicle",

--- a/src/app/services/dimBucketService.factory.js
+++ b/src/app/services/dimBucketService.factory.js
@@ -37,8 +37,8 @@ angular.module('dimApp')
       'Missions'
     ],
     Postmaster: [
-      'Lost Items',
-      'Special Orders',
+      'LostItems',
+      'SpecialOrders',
       'Messages'
     ]
   });
@@ -50,12 +50,12 @@ function BucketService(dimDefinitions, dimCategory) {
   const bucketToType = {
     BUCKET_CHEST: "Chest",
     BUCKET_LEGS: "Leg",
-    BUCKET_RECOVERY: "Lost Items",
+    BUCKET_RECOVERY: "LostItems",
     BUCKET_SHIP: "Ship",
     BUCKET_MISSION: "Missions",
     BUCKET_ARTIFACT: "Artifact",
     BUCKET_HEAVY_WEAPON: "Heavy",
-    BUCKET_COMMERCIALIZATION: "Special Orders",
+    BUCKET_COMMERCIALIZATION: "SpecialOrders",
     BUCKET_CONSUMABLES: "Consumable",
     BUCKET_PRIMARY_WEAPON: "Primary",
     BUCKET_CLASS_ITEMS: "ClassItem",

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -899,10 +899,6 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
 
     const foundStatHash = _.find(item.stats, { statHash });
 
-    if (typeof foundStatHash === 'undefined') {
-      return false;
-    }
-
-    return compareByOperand(foundStatHash, predicate);
+    return foundStatHash && foundStatHash.value && compareByOperand(foundStatHash.value, predicate);
   };
 }

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -3,12 +3,13 @@ import _ from 'underscore';
 import template from './dimSearchFilter.directive.html';
 import Textcomplete from 'textcomplete/lib/textcomplete';
 import Textarea from 'textcomplete/lib/textarea';
+import { flatMap } from '../util';
 
 angular.module('dimApp')
   .factory('dimSearchService', SearchService)
   .directive('dimSearchFilter', SearchFilter);
 
-function SearchService(dimSettingsService) {
+function SearchService(dimSettingsService, dimCategory, D2Categories) {
   const categoryFilters = {
     pulserifle: ['CATEGORY_PULSE_RIFLE'],
     scoutrifle: ['CATEGORY_SCOUT_RIFLE'],
@@ -22,7 +23,7 @@ function SearchService(dimSettingsService) {
     sword: ['CATEGORY_SWORD'],
   };
 
-  const itemTypes = ['helmet', 'leg', 'gauntlets', 'chest', 'class', 'classitem', 'artifact', 'ghost', 'consumable', 'ship', 'material', 'vehicle', 'emblem', 'emote'];
+  const itemTypes = [];
 
   const stats = ['charge', 'impact', 'range', 'stability', 'reload', 'magazine', 'aimassist', 'equipspeed'];
 
@@ -34,14 +35,14 @@ function SearchService(dimSettingsService) {
       heavyweaponengram: ['CATEGORY_HEAVY_WEAPON', 'CATEGORY_ENGRAM'],
       machinegun: ['CATEGORY_MACHINE_GUN'],
     });
-    itemTypes.push(...['primary', 'special', 'heavy', 'horn', 'bounties', 'quests', 'messages', 'missions']);
+    itemTypes.push(...flatMap(dimCategory, (l) => _.map(l, (v) => v.toLowerCase())));
     stats.push(...['rof']);
   } else {
     Object.assign(categoryFilters, {
       grenadelauncher: ['CATEGORY_GRENADE_LAUNCHER'],
       submachine: ['CATEGORY_SUBMACHINEGUN'],
     });
-    itemTypes.push(...['energy', 'power']);
+    itemTypes.push(...flatMap(D2Categories, (l) => _.map(l, (v) => v.toLowerCase())));
     stats.push(...['rpm']);
   }
 
@@ -883,26 +884,7 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
   // This refactored method filters items by stats
   //   * statType = [aa|impact|range|stability|rof|reload|magazine|equipspeed]
   const filterByStats = function(predicate, item, statType) {
-    if (predicate.length === 0 || !item.stats) {
-      return false;
-    }
-
-    const operands = ['<=', '>=', '=', '>', '<'];
-    let operand = 'none';
-    let result = false;
-    let statHash = {};
-
-    operands.forEach((element) => {
-      if (predicate.substring(0, element.length) === element) {
-        operand = element;
-        predicate = predicate.substring(element.length);
-        return false;
-      } else {
-        return true;
-      }
-    }, this);
-
-    statHash = {
+    const statHash = {
       rpm: 4284893193,
       charge: 2961396640,
       impact: 4043523819,
@@ -921,28 +903,6 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
       return false;
     }
 
-    predicate = parseInt(predicate, 10);
-
-    switch (operand) {
-    case 'none':
-      result = (foundStatHash.value === predicate);
-      break;
-    case '=':
-      result = (foundStatHash.value === predicate);
-      break;
-    case '<':
-      result = (foundStatHash.value < predicate);
-      break;
-    case '<=':
-      result = (foundStatHash.value <= predicate);
-      break;
-    case '>':
-      result = (foundStatHash.value > predicate);
-      break;
-    case '>=':
-      result = (foundStatHash.value >= predicate);
-      break;
-    }
-    return result;
+    return compareByOperand(foundStatHash, predicate);
   };
 }

--- a/src/app/util.js
+++ b/src/app/util.js
@@ -16,12 +16,12 @@ function count(list, predicate) {
   });
 }
 
-// A replacement for _.compact(_.flatten(_.map(l, fn))) that is more efficient.
+// A replacement for _.compact(_.flatten(_.map(c, fn))) that is more efficient.
 function flatMap(list, fx) {
   const fn = _.iteratee(fx);
   const res = [];
-  list.forEach((item) => {
-    const resList = fn(item);
+  Object.keys(list).forEach((item) => {
+    const resList = fn(list[item]);
     if (resList) {
       resList.forEach((resItem) => {
         if (resItem !== undefined && resItem !== null) {


### PR DESCRIPTION
We were maintaining a separate list in the search filters, when we have
the bucket information in dimCategory and D2Categories

Now the search filters are built based off of whatever the contents of
the buckets are.

This mostly adds support for missing D2 “Inventory” filters, such as
Consumables, Modifications, and Shaders.

Also, removed some dupe code from the compare w/ stats section.