### PR TITLE
RFC: Support sorting by base power

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Support sorting by base power
+
 # 4.18.0
 
 * Updated `is:dupelower` search filter for items with the same/no power level.

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -93,6 +93,9 @@
             <input type="radio" ng-model="vm.settings.itemSort" value="primaryStat"><span ng-i18next="Settings.SortPrimary"></span></label>
           <br>
           <label>
+            <input type="radio" ng-model="vm.settings.itemSort" value="basePowerThenPrimary"><span ng-i18next="Settings.SortBasePower"></span></label>
+          <br>
+          <label>
             <input type="radio" ng-model="vm.settings.itemSort" value="rarityThenPrimary"><span ng-i18next="Settings.SortRarity"></span></label>
           <br>
           <label ng-show="vm.settings.itemQuality">

--- a/src/app/shell/dimAngularFilters.filter.js
+++ b/src/app/shell/dimAngularFilters.filter.js
@@ -166,9 +166,14 @@ mod.filter('sortItems', (dimSettingsService) => {
     }
 
     items = _.sortBy(items || [], 'name');
-    if (sort === 'primaryStat' || sort === 'rarityThenPrimary' || sort === 'quality' || sort === 'typeThenPrimary') {
+    if (sort === 'primaryStat' || sort === 'rarityThenPrimary' || sort === 'quality' || sort === 'typeThenPrimary' || sort === 'basePowerThenPrimary') {
       items = _.sortBy(items, (item) => {
         return (item.primStat) ? (-1 * item.primStat.value) : 1000;
+      });
+    }
+    if (sort === 'basePowerThenPrimary') {
+      items = _.sortBy(items, (item) => {
+        return (item.basePower) ? (-1 * item.basePower) : 1000;
       });
     }
     if (sort === 'quality') {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -491,6 +491,7 @@
     "SizeItem": "Item size",
     "SortName": "name",
     "SortPrimary": "primary stat",
+    "SortBasePower": "base power (destiny 2 only)",
     "SortRarity": "rarity",
     "SortRoll": "rating",
     "SortTypeThenName": "item type then name",


### PR DESCRIPTION
I've been missing the feature to sort by base power in DIM (as that's often what's most important in Destiny 2, especially before you arrive at power 305). I've spoken to a few friends who also felt this would be useful, so I decided to give it a go and add the feature myself,

This PR is sort of a basic implementation - just adding the setting and getting the sorting done, but I realize there is is a major issue with the fact that base power vs primary stat is really only a thing in Destiny 2 - yet settings is shared between the games. I couldn't find any existing cases where the actual settings where specific to one of the games, so I was kinda of looking for your opinion if there is a certain way you think this should be handled.

Obviously I'm also interested in if you actually think this is a worthwhile feature to add, or if it maybe should be part of a bigger change - like the one discussed in #647