### PR TITLE
D2 Account wide items don't need to be transferred between characters

### DIFF
--- a/src/app/move-popup/dimMovePopup.directive.js
+++ b/src/app/move-popup/dimMovePopup.directive.js
@@ -88,16 +88,23 @@ function MovePopupController($scope, D2StoresService, dimStoreService, ngDialog,
   };
 
   vm.canShowStore = function canShowStore(item, itemStore, buttonStore) {
+    // Can't store into a vault
     if (buttonStore.isVault) {
       return false;
     }
 
     if (item.notransfer) {
+      // Can store an equiped item in same itemStore
       if (item.equipped && itemStore.id === buttonStore.id) {
         return true;
       }
     } else if (itemStore.id !== buttonStore.id || item.equipped) {
-      return true;
+      // In Destiny2, only show one store for account wide items
+      if (item.destinyVersion === 2 && item.bucket && item.bucket.accountWide && !buttonStore.current) {
+        return false;
+      } else {
+        return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
Hide the Store buttons for account wide items out of the Vault. In the Vault, only show one Store button. I use the current character as the one Store.
This solves the issue with #2310 and the same issue would occur with mods and consumables.

I added a D2 check, because I don't know if this is an issue with D1 items.