### PR TITLE
Hide 'Split' button in D2

### DIFF
--- a/src/app/move-popup/dimMovePopup.directive.html
+++ b/src/app/move-popup/dimMovePopup.directive.html
@@ -24,7 +24,7 @@
       <span ng-i18next="MovePopup.Take"></span>
     </div>
     <div class="move-button move-distribute" ng-i18next="[title]MovePopup.DistributeEvenly;[alt]MovePopup.DistributeEvenly"
-      ng-if="!vm.item.notransfer && vm.item.maxStackSize > 1" ng-click="vm.distribute()">
+      ng-if="vm.item.destinyVersion === 1 && !vm.item.notransfer && vm.item.maxStackSize > 1" ng-click="vm.distribute()">
       <span ng-i18next="MovePopup.Split"></span>
     </div>
   <div class="locations" ng-if="vm.item.infusable">


### PR DESCRIPTION
Account wide items are either in the vault or out. There is no dividing between characters.
Fixes part of #2312 and part of #2310 .
The take button could still make sense if you could have items in the vault you want to consolidate.