### PR TITLE
Don't update the loadout until saved

### DIFF
--- a/src/app/loadout/loadout-drawer.component.js
+++ b/src/app/loadout/loadout-drawer.component.js
@@ -62,7 +62,7 @@ function LoadoutDrawerCtrl($scope, dimLoadoutService, dimCategory, D2Categories,
   $scope.$on('dim-edit-loadout', (event, args) => {
     vm.showClass = args.showClass;
     if (args.loadout) {
-      vm.loadout = args.loadout;
+      vm.loadout = angular.copy(args.loadout);
       vm.show = true;
       dimLoadoutService.dialogOpen = true;
       if (vm.loadout.classType === undefined) {


### PR DESCRIPTION
This was modifying the loadout in-place, even when cancel was clicked.
By making a copy we can be sure the original won't be changed unless we ask for it.

Fixes #2297 