### PR TITLE
Switch to redirects for GDrive login

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -35,7 +35,8 @@ module.exports = (env) => {
     entry: {
       main: './src/index.js',
       browsercheck: './src/browsercheck.js',
-      authReturn: './src/authReturn.js'
+      authReturn: './src/authReturn.js',
+      gdriveReturn: './src/gdriveReturn.js'
     },
 
     output: {
@@ -137,6 +138,13 @@ module.exports = (env) => {
         filename: 'return.html',
         template: '!handlebars-loader!src/return.html',
         chunks: ['manifest', 'vendor', 'authReturn']
+      }),
+
+      new HtmlWebpackPlugin({
+        inject: false,
+        filename: 'gdrive-return.html',
+        template: '!handlebars-loader!src/gdrive-return.html',
+        chunks: ['manifest', 'vendor', 'gdriveReturn']
       }),
 
       new CopyWebpackPlugin([

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Hide "split" and "take" button for D2 consumables.
 * OK really really fix the vault count.
 * Fix showing item popup for some D1 items.
+* Changed how we do Google Drive log-in - it should be smoother on mobile.
 
 
 # 4.18.0

--- a/src/app/storage/google-drive-storage.js
+++ b/src/app/storage/google-drive-storage.js
@@ -8,7 +8,10 @@ export function GoogleDriveStorage($q, $i18next, OAuthTokenService) {
     drive: {
       client_id: $GOOGLE_DRIVE_CLIENT_ID,
       scope: 'https://www.googleapis.com/auth/drive.appdata',
-      discoveryDocs: ["https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"]
+      discoveryDocs: ["https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"],
+      fetch_basic_profile: false,
+      ux_mode: 'redirect',
+      redirect_uri: window.location.origin
     },
 
     // The Google Drive ID of the file we use to save data.
@@ -140,9 +143,12 @@ export function GoogleDriveStorage($q, $i18next, OAuthTokenService) {
           if ($featureFlags.debugSync) {
             console.log('authorizing Google Drive');
           }
-          return auth.signIn().then(() => {
-            return this.updateSigninStatus(true);
-          });
+          return auth
+            .signIn()
+            .then(() => this.updateSigninStatus(true))
+            .catch((e) => {
+              throw new Error(`Failed to sign in to Google Drive: ${e.error}`);
+            });
         }
       });
     },

--- a/src/app/storage/google-drive-storage.js
+++ b/src/app/storage/google-drive-storage.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-export function GoogleDriveStorage($q, $i18next, OAuthTokenService) {
+export function GoogleDriveStorage($q, $i18next, OAuthTokenService, $rootScope) {
   'ngInject';
 
   return {
@@ -11,7 +11,7 @@ export function GoogleDriveStorage($q, $i18next, OAuthTokenService) {
       discoveryDocs: ["https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"],
       fetch_basic_profile: false,
       ux_mode: 'redirect',
-      redirect_uri: window.location.origin
+      redirect_uri: `${window.location.origin}/gdrive-return.html`
     },
 
     // The Google Drive ID of the file we use to save data.
@@ -115,7 +115,13 @@ export function GoogleDriveStorage($q, $i18next, OAuthTokenService) {
             auth.isSignedIn.listen(this.updateSigninStatus.bind(this));
 
             // Handle the initial sign-in state.
-            return this.updateSigninStatus(auth.isSignedIn.get()).then(() => this.ready.resolve());
+            return this.updateSigninStatus(auth.isSignedIn.get())
+              .then(() => {
+                if (auth.isSignedIn.get()) {
+                  $rootScope.$broadcast('gdrive-sign-in');
+                }
+                this.ready.resolve();
+              });
           });
         });
       } else {
@@ -145,6 +151,7 @@ export function GoogleDriveStorage($q, $i18next, OAuthTokenService) {
           }
           return auth
             .signIn()
+            // This won't happen since we'll redirect
             .then(() => this.updateSigninStatus(true))
             .catch((e) => {
               throw new Error(`Failed to sign in to Google Drive: ${e.error}`);

--- a/src/app/storage/storage.component.js
+++ b/src/app/storage/storage.component.js
@@ -5,7 +5,7 @@ import { sum } from '../util';
 import template from './storage.html';
 import './storage.scss';
 
-function StorageController($scope, dimSettingsService, SyncService, GoogleDriveStorage, dimDestinyTrackerService, $timeout, $window, $q, $i18next) {
+function StorageController($scope, dimSettingsService, SyncService, GoogleDriveStorage, dimDestinyTrackerService, $timeout, $window, $q, $i18next, $stateParams, $state) {
   'ngInject';
 
   const vm = this;
@@ -150,6 +150,12 @@ function StorageController($scope, dimSettingsService, SyncService, GoogleDriveS
 
   $scope.$on('$destroy', () => {
     window.removeEventListener('message', messageHandler);
+  });
+
+  $scope.$on('gdrive-sign-in', () => {
+    if ($stateParams.gdrive === 'true') {
+      vm.forceSync().then(() => $state.go('storage', { gdrive: undefined }, 'replace'));
+    }
   });
 
   vm.browserMayClearData = true;

--- a/src/app/storage/storage.module.js
+++ b/src/app/storage/storage.module.js
@@ -20,7 +20,7 @@ export default angular
     $stateProvider.state({
       name: 'storage',
       component: 'storage',
-      url: '/storage'
+      url: '/storage?gdrive'
     });
   })
   .name;

--- a/src/gdrive-return.html
+++ b/src/gdrive-return.html
@@ -1,0 +1,25 @@
+<html !doctype>
+  <head>
+    <title>Authorizing Google Drive</title>
+
+    {{#each htmlWebpackPlugin.files.css}}
+    <link href="{{ webpackConfig.output.publicPath }}{{ this }}" rel="stylesheet">
+    {{/each}}
+  </head>
+
+  <body>
+    <div id="return">
+      Authorizing Google Drive...
+    </div>
+
+    <div id="return-error" style="display: none">
+      <p>We were unable to set up Google Drive.</p>
+      <a href="/index.html">Go back to DIM</a>
+    </div>
+
+    <script src="https://apis.google.com/js/api.js"></script>
+    {{#each htmlWebpackPlugin.files.js}}
+    <script type="text/javascript" src="{{ webpackConfig.output.publicPath }}{{ this }}"></script>
+    {{/each}}
+  </body>
+</html>

--- a/src/gdriveReturn.js
+++ b/src/gdriveReturn.js
@@ -1,0 +1,25 @@
+const drive = {
+  client_id: $GOOGLE_DRIVE_CLIENT_ID,
+  scope: 'https://www.googleapis.com/auth/drive.appdata',
+  discoveryDocs: ["https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"],
+  fetch_basic_profile: false
+};
+
+if (window.gapi) {
+  gapi.load('client:auth2', () => {
+    gapi.client.init(drive).then(() => {
+      if ($featureFlags.debugSync) {
+        console.log("gdrive init complete");
+      }
+      const auth = gapi.auth2.getAuthInstance();
+      if (auth && auth.isSignedIn.get()) {
+        window.location = '/index.html#!/storage?gdrive=true';
+      } else {
+        document.getElementById('return-error').style.display = 'block';
+      }
+    });
+  });
+} else {
+  document.getElementById('return-error').style.display = 'block';
+  console.warn("Google Drive API blocked");
+}


### PR DESCRIPTION
This switches to a different GDrive login process that should be more stable for mobile and iOS 11. It uses a redirect instead of an iframe + popup. This should be a lot more reliable. I did have to do quite a bit to create a new redirect landing page, check that we're really able to log in, then redirect back to our storage page with a special parameter that forces a sync. But I think it'll all go smoother.

This should help with #2313 and #2187. I'll be honest, the Google Drive web API is really hard to use and has a lot of problems. None of this has been easy.