### PR TITLE
Tie break `is:dupelower` by primary stat

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Changed how we do Google Drive log-in - it should be smoother on mobile.
 * Completed objectives will now show as "complete".
 * Bring back the yellow triangle for current character on mobile.
+* Updated `is:dupelower` search filter for items to tie break by primary stat.
 
 # 4.18.0
 

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -551,9 +551,9 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
           if (dupes.length > 1) {
             let bestDupe = _.max(dupes, 'basePower');
             if (bestDupe !== -Infinity) {
-              const dupesWithMaxBasePower = _.select(dupes, (dupe) => dupe.basePower == bestDupe.basePower);
+              const dupesWithMaxBasePower = _.select(dupes, (dupe) => dupe.basePower === bestDupe.basePower);
               if (dupesWithMaxBasePower.length > 1) {
-                bestDupe = _.max(dupesWithMaxBasePower, (item) => item.primStat ? item.primStat.value : 0);
+                bestDupe = _.max(dupesWithMaxBasePower, (item) => (item.primStat ? item.primStat.value : 0));
               }
             }
 

--- a/src/app/shell/dimSearchFilter.directive.js
+++ b/src/app/shell/dimSearchFilter.directive.js
@@ -549,12 +549,19 @@ function SearchFilterCtrl($scope, dimSettingsService, dimStoreService, D2StoresS
         _duplicates = _.groupBy(getStoreService().getAllItems(), 'hash');
         _.each(_duplicates, (dupes) => {
           if (dupes.length > 1) {
-            let bestBasePower = _.max(dupes, 'basePower');
-            if (bestBasePower === -Infinity) {
-              bestBasePower = dupes[0];
+            let bestDupe = _.max(dupes, 'basePower');
+            if (bestDupe !== -Infinity) {
+              const dupesWithMaxBasePower = _.select(dupes, (dupe) => dupe.basePower == bestDupe.basePower);
+              if (dupesWithMaxBasePower.length > 1) {
+                bestDupe = _.max(dupesWithMaxBasePower, (item) => item.primStat ? item.primStat.value : 0);
+              }
             }
 
-            _.reject(dupes, (dupe) => dupe.id === bestBasePower.id).forEach((dupe) => {
+            if (bestDupe === -Infinity) {
+              bestDupe = dupes[0];
+            }
+
+            _.reject(dupes, (dupe) => dupe.id === bestDupe.id).forEach((dupe) => {
               _lowerDupes[dupe.id] = 1;
             });
 


### PR DESCRIPTION
For cases when basePower is the same, pick the item with highest primary stat. Helps to avoid accidentally removing them valuable kinetic weapon mods.