### PR TITLE
Specific sorts for shaders, mods, and consumables

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Sort consumables, mods, and shaders in a more useful way (generally grouping same type together, alphabetical for shaders).
+
 # 4.19.2
 
 * Keyword searchs now also search on mod subtitles, so `is:modifications helmet void` will bring only Helmet Mods for Void subclass.

--- a/src/app/destiny2/d2-buckets.service.js
+++ b/src/app/destiny2/d2-buckets.service.js
@@ -67,7 +67,6 @@ const bucketToType = {
   4274335291: "Emblems",
   4292445962: "ClanBanners",
   14239492: "Chest",
-  18606351: "Shaders",
   20886954: "Leg",
   215593132: "LostItems",
   284967655: "Ships",

--- a/src/app/shell/dimAngularFilters.filter.js
+++ b/src/app/shell/dimAngularFilters.filter.js
@@ -221,7 +221,7 @@ mod.filter('sortItems', (dimSettingsService) => {
         return item.quality && item.quality.min ? -item.quality.min : (dimSettingsService.showReviews && item.dtrRating ? -item.dtrRating : 1000);
       });
     }
-    if (sort === 'rarityThenPrimary' || (items.length &&  items[0].location.inGeneral)) {
+    if (sort === 'rarityThenPrimary' || (items.length && items[0].location.inGeneral)) {
       items = _.sortBy(items, rarity);
     }
     if (sort === 'typeThenPrimary' || sort === 'typeThenName') {

--- a/src/app/shell/dimAngularFilters.filter.js
+++ b/src/app/shell/dimAngularFilters.filter.js
@@ -51,6 +51,23 @@ mod.filter('equipped', () => {
   };
 });
 
+function rarity(item) {
+  switch (item.tier) {
+  case 'Exotic':
+    return 0;
+  case 'Legendary':
+    return 1;
+  case 'Rare':
+    return 2;
+  case 'Uncommon':
+    return 3;
+  case 'Common':
+    return 4;
+  default:
+    return 5;
+  }
+}
+
 /**
  * Sort the stores according to the user's preferences (via the order parameter).
  */
@@ -79,7 +96,7 @@ mod.filter('sortItems', (dimSettingsService) => {
   return function(items, sort) {
     // Don't resort postmaster items - that way people can see
     // what'll get bumped when it's full.
-    const dontsort = ["BUCKET_BOUNTIES", "BUCKET_MISSION", "BUCKET_QUESTS", "BUCKET_POSTMASTER"];
+    const dontsort = ["BUCKET_BOUNTIES", "BUCKET_MISSION", "BUCKET_QUESTS", "BUCKET_POSTMASTER", 215593132, 1801258597];
     if (items.length && dontsort.includes(items[0].location.id)) {
       return items;
     }
@@ -166,6 +183,29 @@ mod.filter('sortItems', (dimSettingsService) => {
     }
 
     items = _.sortBy(items || [], 'name');
+
+    // Re-sort mods
+    if (items.length && items[0].location.id === 3313201758) {
+      items = _.sortBy(items, 'typeName');
+      if (sort === 'rarityThenPrimary') {
+        items = _.sortBy(items, rarity);
+      }
+      return items;
+    }
+
+    // Re-sort consumables
+    if (items.length && items[0].location.id === 1469714392) {
+      items = _.sortBy(items, rarity);
+      items = _.sortBy(items, 'typeName');
+      return items;
+    }
+
+    // Re-sort shaders
+    if (items.length && items[0].location.id === 2973005342) {
+      // Just sort by name
+      return items;
+    }
+
     if (sort === 'primaryStat' || sort === 'rarityThenPrimary' || sort === 'quality' || sort === 'typeThenPrimary' || sort === 'basePowerThenPrimary') {
       items = _.sortBy(items, (item) => {
         return (item.primStat) ? (-1 * item.primStat.value) : 1000;
@@ -181,23 +221,8 @@ mod.filter('sortItems', (dimSettingsService) => {
         return item.quality && item.quality.min ? -item.quality.min : (dimSettingsService.showReviews && item.dtrRating ? -item.dtrRating : 1000);
       });
     }
-    if (sort === 'rarityThenPrimary' || (items.length && items[0].location.inGeneral)) {
-      items = _.sortBy(items, (item) => {
-        switch (item.tier) {
-        case 'Exotic':
-          return 0;
-        case 'Legendary':
-          return 1;
-        case 'Rare':
-          return 2;
-        case 'Uncommon':
-          return 3;
-        case 'Common':
-          return 4;
-        default:
-          return 5;
-        }
-      });
+    if (sort === 'rarityThenPrimary' || (items.length &&  items[0].location.inGeneral)) {
+      items = _.sortBy(items, rarity);
     }
     if (sort === 'typeThenPrimary' || sort === 'typeThenName') {
       items = _.sortBy(items, (item) => {


### PR DESCRIPTION
This brings back some of the logic we used to have for consumables and such:

1. Postmaster and quests are no longer sorted at all.
2. Consumables are sorted by type (consumable or redeemable) and then by rarity, then name.
3. Mods are sorted by rarity if everything is set to sort by rarity, otherwise by type then name (so all leg mods are together, etc).
4. Shaders are sorted by name.