### PR TITLE
Mobile cleanup

### DIFF
--- a/src/app/destiny1/destiny1.component.js
+++ b/src/app/destiny1/destiny1.component.js
@@ -1,5 +1,3 @@
-import _ from 'underscore';
-
 import template from './destiny1.html';
 
 /**
@@ -10,24 +8,12 @@ export const Destiny1Component = {
   template
 };
 
-// This is outside the class in order to make it a truly global
-// fire-once function, so no matter how many times they visit this
-// page, they'll only see the popup once per session.
-const showExtensionDeprecation = _.once(($i18next, dimInfoService) => {
-  dimInfoService.show('extension-deprecated', {
-    title: $i18next.t('Help.ExtensionDeprecatedTitle'),
-    body: $i18next.t('Help.ExtensionDeprecatedMessage'),
-    type: 'info'
-  }, 0);
-});
-
 function Destiny1Controller(
   $rootScope,
   hotkeys,
   dimSettingsService,
   $scope,
-  $i18next,
-  dimInfoService
+  $i18next
 ) {
   'ngInject';
 
@@ -56,26 +42,4 @@ function Destiny1Controller(
       }
     });
   }
-
-  // An abbreviated version of the messager from storage.component.js,
-  // just so we can send an info popup.
-  function messageHandler(event) {
-    // We only accept messages from ourselves
-    if (event.source !== window) {
-      return;
-    }
-
-    switch (event.data.type) {
-    case 'DIM_EXT_PONG':
-      showExtensionDeprecation($i18next, dimInfoService);
-      break;
-    }
-  }
-
-  window.addEventListener('message', messageHandler, false);
-  window.postMessage({ type: 'DIM_EXT_PING' }, "*");
-
-  $scope.$on('$destroy', () => {
-    window.removeEventListener('message', messageHandler);
-  });
 }

--- a/src/app/inventory/dimStoreBucket.directive.js
+++ b/src/app/inventory/dimStoreBucket.directive.js
@@ -3,6 +3,7 @@ import _ from 'underscore';
 import template from './dimStoreBucket.directive.html';
 import dialogTemplate from './dimStoreBucket.directive.dialog.html';
 import './dimStoreBucket.scss';
+import { isPhonePortrait } from '../mediaQueries';
 
 export const StoreBucketComponent = {
   controller: StoreBucketCtrl,
@@ -88,7 +89,7 @@ function StoreBucketCtrl($scope,
   vm.moveDroppedItem = dimActionQueue.wrap((item, equip, $event, hovering) => {
     const target = vm.store;
 
-    if (target.current && equip) {
+    if (target.current && equip && !isPhonePortrait()) {
       didYouKnow();
     }
 

--- a/src/app/inventory/dimStores.directive.js
+++ b/src/app/inventory/dimStores.directive.js
@@ -1,6 +1,8 @@
 import _ from 'underscore';
 import template from './dimStores.directive.html';
 import './dimStores.scss';
+import { isPhonePortraitStream } from '../mediaQueries';
+import { subscribeOnScope } from '../rx-utils';
 
 export const StoresComponent = {
   controller: StoresCtrl,
@@ -55,17 +57,11 @@ function StoresCtrl(dimSettingsService, $scope, dimPlatformService, loadingTrack
     vm.settings.save();
   };
 
-  // TODO: angular media-query-switch directive
-  // This seems like a good breakpoint for portrait based on https://material.io/devices/
-  // We can't use orientation:portrait because Android Chrome messes up when the keyboard is shown: https://www.chromestatus.com/feature/5656077370654720
-  const phoneWidthQuery = window.matchMedia('(max-width: 540px)');
-  function phoneWidthHandler(e) {
+  subscribeOnScope($scope, isPhonePortraitStream(), (isPhonePortrait) => {
     $scope.$apply(() => {
-      vm.isPhonePortrait = e.matches;
+      vm.isPhonePortrait = isPhonePortrait;
     });
-  }
-  phoneWidthQuery.addListener(phoneWidthHandler);
-  vm.isPhonePortrait = phoneWidthQuery.matches;
+  });
 
   vm.$onChanges = function() {
     vm.vault = _.find(vm.stores, 'isVault');

--- a/src/app/mediaQueries.js
+++ b/src/app/mediaQueries.js
@@ -1,0 +1,27 @@
+import { Observable, Scheduler } from 'rxjs/';
+
+// This seems like a good breakpoint for portrait based on https://material.io/devices/
+// We can't use orientation:portrait because Android Chrome messes up when the keyboard is shown: https://www.chromestatus.com/feature/5656077370654720
+const phoneWidthQuery = window.matchMedia('(max-width: 540px)');
+
+/**
+ * Return whether we're in phone-portrait mode right now.
+ */
+export function isPhonePortrait() {
+  return phoneWidthQuery.matches;
+}
+
+/**
+ * Return an observable sequence of phone-portrait statuses.
+ */
+export function isPhonePortraitStream() {
+  return Observable.defer(() => {
+    return Observable.fromEventPattern(
+      (h) => phoneWidthQuery.addListener(h),
+      (h) => phoneWidthQuery.removeListener(h)
+    )
+    .map((e) => e.matches)
+    .startWith(phoneWidthQuery.matches)
+    .subscribeOn(Scheduler.asap);
+  });
+}

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -1,6 +1,8 @@
 import _ from 'underscore';
 import template from './settings.html';
 import './settings.scss';
+import { isPhonePortraitStream } from '../mediaQueries';
+import { subscribeOnScope } from '../rx-utils';
 
 export const SettingsComponent = {
   template,
@@ -29,17 +31,11 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
   vm.vaultColOptions = _.range(5, 21).map((num) => ({ id: num, name: $i18next.t('Settings.ColumnSize', { num }) }));
   vm.vaultColOptions.unshift({ id: 999, name: $i18next.t('Settings.ColumnSizeAuto') });
 
-  // TODO: angular media-query-switch directive
-  // This seems like a good breakpoint for portrait based on https://material.io/devices/
-  // We can't use orientation:portrait because Android Chrome messes up when the keyboard is shown: https://www.chromestatus.com/feature/5656077370654720
-  const phoneWidthQuery = window.matchMedia('(max-width: 540px)');
-  function phoneWidthHandler(e) {
+  subscribeOnScope($scope, isPhonePortraitStream(), (isPhonePortrait) => {
     $scope.$apply(() => {
-      vm.isPhonePortrait = e.matches;
+      vm.isPhonePortrait = isPhonePortrait;
     });
-  }
-  phoneWidthQuery.addListener(phoneWidthHandler);
-  vm.isPhonePortrait = phoneWidthQuery.matches;
+  });
 
   vm.filters = {
     vendors: {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -233,8 +233,6 @@
     "ChangingPerks": "Changing Perks Not Supported",
     "ChangingPerksInfo": "Sorry, there's no way to change perks outside the game. We wish we could!",
     "Drag": "Hold shift or pause over drop zone to transfer a partial stack.",
-    "ExtensionDeprecatedMessage": "The DIM Chrome extension now just opens our website - which works on every browser and on mobile devices! You can uninstall the extension, or leave it around as a convenient bookmark for the site. Your data (tags, notes, and settings) can be imported from the storage page (disk icon in the header).",
-    "ExtensionDeprecatedTitle": "DIM is just a website now!",
     "HidePopup": "Hide This Popup",
     "NeverShow": "Never show me this again.",
     "NoStorage": "DIM can't store data",


### PR DESCRIPTION
1. Don't show double-click tooltip on mobile. 
2. Don't show extension deprecation. 
3. Refactor mobile detection into a shared observable (that cleans up after itself to avoid leaks).