### PR TITLE
Fix move-aside logic for D2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * Sort consumables, mods, and shaders in a more useful way (generally grouping same type together, alphabetical for shaders).
+* Updated documentation for search filters.
 
 # 4.19.2
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Sort consumables, mods, and shaders in a more useful way (generally grouping same type together, alphabetical for shaders).
 * Updated documentation for search filters.
+* Fixed logic that makes room for items when your vault is full for D2.
 
 # 4.19.2
 

--- a/src/app/inventory/dimItemService.factory.js
+++ b/src/app/inventory/dimItemService.factory.js
@@ -443,7 +443,10 @@ export function ItemService(
 
     // Start with candidates of the same type (or sort if it's vault)
     const allItems = store.isVault
-      ? _.filter(store.items, (i) => i.bucket.sort === item.bucket.sort)
+      ? _.filter(store.items,
+             store.destinyVersion === 2
+               ? (i) => i.bucket.vaultBucket.id === item.bucket.vaultBucket.id
+               : (i) => i.bucket.sort === item.bucket.sort)
       : store.buckets[item.location.id];
     let moveAsideCandidates = _.filter(allItems, movable);
 

--- a/src/app/inventory/store/d2-store-factory.service.js
+++ b/src/app/inventory/store/d2-store-factory.service.js
@@ -45,6 +45,10 @@ export function D2StoreFactory($i18next, dimInfoService) {
       if (!item.type) {
         throw new Error("item needs a 'type' field");
       }
+      // Account-wide buckets (mods, etc) are only on the first character
+      if (item.location.accountWide && !this.current) {
+        return 0;
+      }
       const openStacks = Math.max(0, this.capacityForItem(item) -
                                   this.buckets[item.location.id].length);
       const maxStackSize = item.maxStackSize || 1;
@@ -188,15 +192,8 @@ export function D2StoreFactory($i18next, dimInfoService) {
           return buckets.byHash[item.bucket.hash].vaultBucket.capacity;
         },
         spaceLeftForItem: function(item) {
-          let sort = item.sort;
-          if (item.bucket) {
-            sort = item.bucket.sort;
-          }
-          if (!sort) {
-            throw new Error("item needs a 'sort' field");
-          }
           const openStacks = Math.max(0, this.capacityForItem(item) -
-                                      count(this.items, (i) => i.bucket.sort === sort));
+                                      count(this.items, (i) => i.bucket.vaultBucket.id === item.bucket.vaultBucket.id));
           const maxStackSize = item.maxStackSize || 1;
           if (maxStackSize === 1) {
             return openStacks;


### PR DESCRIPTION
I hadn't correctly updated the vault "space left" algorithm or the item service's "move aside" logic for D2. With these corrections, we will correctly move things aside and not miscalculate the space left (which was resulting in B.net errors). This means that if your characters are all full on weapons and you try to move something to a full vault, it may now move armor to the other characters. I tested things out by moving a bunch of my mods to a full vault - armor and weapons got moved to my alts to make room!