### PR TITLE
Add "gather reputation items" and rep token farming

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Link to DestinyDB in your language instead of always English.
 * Updated documentation for search filters.
 * Fixed logic that makes room for items when your vault is full for D2.
+* Add an option to farming mode that stashes reputation items in the vault.
+* Add a new smart loadout to gather reputation items for redemption.
 
 # 4.19.2
 

--- a/src/app/farming/d2farming.component.js
+++ b/src/app/farming/d2farming.component.js
@@ -8,13 +8,14 @@ export const D2FarmingComponent = {
   template
 };
 
-function FarmingCtrl(D2FarmingService) {
+function FarmingCtrl(D2FarmingService, dimSettingsService) {
   'ngInject';
 
   const vm = this;
 
   angular.extend(vm, {
     service: D2FarmingService,
+    settings: dimSettingsService,
     stop: function($event) {
       $event.preventDefault();
       D2FarmingService.stop();

--- a/src/app/farming/d2farming.html
+++ b/src/app/farming/d2farming.html
@@ -1,6 +1,8 @@
 <div ng-if="vm.service.active" id="item-farming" class="d2-farming">
   <span>
     <p ng-i18next="[i18next]({ store: vm.service.store.name, context: vm.service.store.gender })FarmingMode.D2Desc"></p>
+    <p><input id="move-tokens" type="checkbox" ng-change="vm.settings.save()" ng-model="vm.settings.farming.moveTokens" /><label for="move-tokens" ng-i18next="FarmingMode.MoveTokens"></label></p>
   </span>
+
   <span><button ng-click="vm.stop($event)" ng-i18next="FarmingMode.Stop"></button></span>
 </div>

--- a/src/app/farming/rep-tokens.js
+++ b/src/app/farming/rep-tokens.js
@@ -1,0 +1,26 @@
+export const REP_TOKENS = new Set([
+  2959556799, // Dead Orbit Token
+  183980811, // Crucible Token
+  461171930, // Alkane Spores,
+  478751073, // Dusklight Crystal
+  494493680, // Arcology Token
+  685157381, // Weapon Telemetry
+  685157383, // Gunsmith Materials
+  885593286, // Trials of the Nine Token
+  950899352, // Dusklight Shard
+  1270564331, // FWC Token
+  1305274547, // Phaseglass Needle
+  1505278293, // Emperor Calus Token
+  1873857625, // Iron Banner Token
+  2014411539, // Alkane Dust
+  2270228604, // New Monarchy Token
+  2640973641, // EDZ Token
+  2949414982, // Quantized Datalattice
+  2959556799, // Dead Orbit Token
+  3201839676, // Nessus Token
+  3487922223, // Microphasic Datalattice
+  3756389242, // Phaseglass Spire
+  3825769808, // Io Token
+  3899548068, // Vanguard Tactician Token
+  3957264072, // Vanguard Research Token
+]);

--- a/src/app/loadout/loadout-popup.component.js
+++ b/src/app/loadout/loadout-popup.component.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import _ from 'underscore';
 import { flatMap } from '../util';
 import { optimalLoadout } from './loadout-utils';
+import { REP_TOKENS } from '../farming/rep-tokens';
 import template from './loadout-popup.html';
 import './loadout-popup.scss';
 
@@ -277,6 +278,36 @@ function LoadoutPopupCtrl($rootScope, $scope, ngDialog, dimLoadoutService, dimIt
     const loadout = {
       classType: -1,
       name: $i18next.t('Loadouts.GatherEngrams'),
+      items: finalItems
+    };
+    vm.applyLoadout(loadout, $event);
+  };
+
+  vm.gatherTokensLoadout = function gatherTokensLoadout($event) {
+    const tokens = _.filter(storeService.getAllItems(), (i) => {
+      return REP_TOKENS.has(i.hash) && !i.notransfer;
+    });
+
+    if (tokens.length === 0) {
+      toaster.pop('warning', $i18next.t('Loadouts.GatherTokens'), $i18next.t('Loadouts.NoTokens'));
+      return;
+    }
+
+    const itemsByType = _.groupBy(tokens, 'type');
+
+    // Copy the items and mark them equipped and put them in arrays, so they look like a loadout
+    const finalItems = {};
+    _.each(itemsByType, (items, type) => {
+      if (items) {
+        finalItems[type.toLowerCase()] = items.map((i) => {
+          return angular.copy(i);
+        });
+      }
+    });
+
+    const loadout = {
+      classType: -1,
+      name: $i18next.t('Loadouts.GatherTokens'),
       items: finalItems
     };
     vm.applyLoadout(loadout, $event);

--- a/src/app/loadout/loadout-popup.html
+++ b/src/app/loadout/loadout-popup.html
@@ -61,6 +61,13 @@
       </span>
     </li>
 
+    <li ng-if="vm.store.destinyVersion === 2" class="loadout-set">
+      <span ng-click="vm.gatherTokensLoadout($event)">
+        <i class="fa fa-arrow-circle-o-up"></i>
+        <span ng-i18next="Loadouts.GatherTokens"></span>
+      </span>
+    </li>
+
     <li class="loadout-set" ng-if="!vm.store.isVault">
       <span ng-click="vm.startFarming($event)">
         <img class="fa" src="~app/images/engram.svg" height="12" width="12"/>

--- a/src/app/settings/dimSettingsService.factory.js
+++ b/src/app/settings/dimSettingsService.factory.js
@@ -59,7 +59,8 @@ export function SettingsService($rootScope, SyncService, $window, $i18next, $q) 
     // What settings for farming mode
     farming: {
       // Whether to keep one slot per item type open
-      makeRoomForItems: true
+      makeRoomForItems: true,
+      moveTokens: false
     },
     // Active destiny version
     destinyVersion: 2,

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -114,6 +114,7 @@
       "MakeRoom": "Make room to pick up items by moving equipment",
       "Tooltip": "If checked, DIM will move weapons and armor around to make space in the vault for engrams."
     },
+    "MoveTokens": "Send reputation items to the vault",
     "OutOfRoom": "You're out of space to move items off of {{character}}. Time to decrypt some engrams and clear out the trash!",
     "OutOfRoomTitle": "Out of Room",
     "Quickmove": "Quick Move",
@@ -378,6 +379,7 @@
     "FromEquipped": "Equipped",
     "GatherEngrams": "Gather Engrams",
     "GatherEngramsExceptExotics": "Exotics",
+    "GatherTokens": "Gather Reputation Items",
     "ItemLeveling": "Item Leveling",
     "ItemsWithIcon": "Items with this icon will be equipped. Click on an item to toggle equip.",
     "LoadoutName": "Loadout Name...",
@@ -396,6 +398,7 @@
     "NameRequired": "A name is required.",
     "NoEngrams": "No non-exotic engrams are available to transfer.",
     "NoExotics": "No engrams are available to transfer.",
+    "NoTokens": "No reputation items are available to transfer.",
     "OnlyItems": "Only equippable items, materials, and consumables can be added to a loadout.",
     "Random": "Random",
     "Randomize": "Randomize your equipped weapons, armor, ghost, and artifact?",


### PR DESCRIPTION
This is like our old farming mode and "gather engrams" but for reputation items. Sadly there's nothing in the manifest that can identify rep items, so I've had to enumerate all the hashes.

Closes #2323.