### PR TITLE
No extra properties and filter for D2 reviews

### DIFF
--- a/src/app/inventory/dimSimpleItem.directive.html
+++ b/src/app/inventory/dimSimpleItem.directive.html
@@ -8,13 +8,9 @@
   <div ng-if="vm.item.quality"
        class="item-stat item-quality"
        ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>
-  <div ng-if="vm.item.destinyVersion === 1 && vm.item.dtrRating && (vm.item.dtrRatingCount > 1 || vm.item.dtrHighlightedRatingCount > 0)"
+  <div ng-if="vm.item.dtrRating && (vm.item.dtrRatingCount > (vm.item.destinyVersion == 2 ? 0 : 1) || vm.item.dtrHighlightedRatingCount > 0)"
        class="item-stat item-review"
        ng-style="vm.item.dtrRating | dtrRatingColor">{{ vm.item.dtrRating }}<i class="fa fa-star"></i></div>
-  <!-- we're allowing lonely one-review gear for now -->
-  <div ng-if="vm.item.destinyVersion === 2 && vm.item.dtrRating && (vm.item.dtrRatingCount > 0 || vm.item.dtrHighlightedRatingCount > 0)"
-    class="item-stat item-review"
-    ng-style="vm.item.dtrRating | dtr2RatingColor">{{ vm.item.dtrRating }}<i class="fa fa-star"></i></div>
   <div class="item-stat item-equipment"
        ng-if="vm.item.primStat.value || vm.item.maxStackSize > 1">{{ vm.item.primStat.value || vm.item.amount }}</div>
 </div>

--- a/src/app/inventory/dimStoreItem.directive.html
+++ b/src/app/inventory/dimStoreItem.directive.html
@@ -16,13 +16,9 @@
   <div ng-if="::vm.item.quality"
        class="item-stat item-quality"
        ng-style="::vm.item.quality.min | qualityColor">{{ ::vm.item.quality.min }}%</div>
-  <div ng-if="vm.item.destinyVersion === 1 && vm.item.dtrRating && (vm.item.dtrRatingCount > 1 || vm.item.dtrHighlightedRatingCount > 0)"
+  <div ng-if="vm.item.dtrRating && (vm.item.dtrRatingCount > (vm.item.destinyVersion == 2 ? 0 : 1) || vm.item.dtrHighlightedRatingCount > 0)"
        class="item-stat item-review"
        ng-style="vm.item.dtrRating | dtrRatingColor">{{ vm.item.dtrRating }}<i class="fa fa-star"></i></div>
-  <!-- we're allowing lonely one-review gear for now -->
-  <div ng-if="vm.item.destinyVersion === 2 && vm.item.dtrRating && (vm.item.dtrRatingCount > 0 || vm.item.dtrHighlightedRatingCount > 0)"
-        class="item-stat item-review"
-        ng-style="vm.item.dtrRating | dtr2RatingColor">{{ vm.item.dtrRating }}<i class="fa fa-star"></i></div>
   <div class="item-element"
        ng-class="::vm.item.dmg"></div>
   <div ng-class="vm.item.dimInfo.tag | tagIcon"></div>

--- a/src/app/shell/dimAngularFilters.filter.js
+++ b/src/app/shell/dimAngularFilters.filter.js
@@ -289,33 +289,6 @@ mod.filter('dtrRatingColor', () => {
   };
 });
 
-mod.filter('dtr2RatingColor', () => {
-  return function getColor(value, property) {
-    if (!value) {
-      return null;
-    }
-
-    property = property || 'background-color';
-    let color = 0;
-    if (value < 2) {
-      color = 0;
-    } else if (value <= 3) {
-      color = 15;
-    } else if (value <= 4) {
-      color = 30;
-    } else if (value <= 4.4) {
-      color = 60;
-    } else if (value <= 4.8) {
-      color = 120;
-    } else if (value >= 4.9) {
-      color = 190;
-    }
-    const result = {};
-    result[property] = `hsl(${color},85%,60%)`;
-    return result;
-  };
-});
-
 /**
  * Reduce a string to its first letter.
  */


### PR DESCRIPTION
It's super expensive to add new bindings to dimStoreItem, which can appear hundreds of times per page. There was not real reason to have a separate element and filter for D2 reviews vs D1 reviews.

/cc @48klocs 