### PR TITLE
RFC: Rating display tweaks

### DIFF
--- a/src/app/inventory/dimSimpleItem.directive.html
+++ b/src/app/inventory/dimSimpleItem.directive.html
@@ -9,8 +9,8 @@
        class="item-stat item-quality"
        ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>
   <div ng-if="vm.item.dtrRating && (vm.item.dtrRatingCount > (vm.item.destinyVersion == 2 ? 0 : 1) || vm.item.dtrHighlightedRatingCount > 0)"
-       class="item-stat item-review"
-       ng-style="vm.item.dtrRating | dtrRatingColor">{{ vm.item.dtrRating }}<i class="fa fa-star"></i></div>
+       class="item-stat item-review">{{ vm.item.dtrRating }}<i class="fa fa-star"
+                                                               ng-style="vm.item.dtrRating | dtrRatingColor"></i></div>
   <div class="item-stat item-equipment"
        ng-if="vm.item.primStat.value || vm.item.maxStackSize > 1">{{ vm.item.primStat.value || vm.item.amount }}</div>
 </div>

--- a/src/app/inventory/dimStoreItem.directive.html
+++ b/src/app/inventory/dimStoreItem.directive.html
@@ -17,8 +17,8 @@
        class="item-stat item-quality"
        ng-style="::vm.item.quality.min | qualityColor">{{ ::vm.item.quality.min }}%</div>
   <div ng-if="vm.item.dtrRating && (vm.item.dtrRatingCount > (vm.item.destinyVersion == 2 ? 0 : 1) || vm.item.dtrHighlightedRatingCount > 0)"
-       class="item-stat item-review"
-       ng-style="vm.item.dtrRating | dtrRatingColor">{{ vm.item.dtrRating }}<i class="fa fa-star"></i></div>
+       class="item-stat item-review">{{ vm.item.dtrRating }}<i class="fa fa-star"
+                                                               ng-style="vm.item.dtrRating | dtrRatingColor"></i></div>
   <div class="item-element"
        ng-class="::vm.item.dmg"></div>
   <div ng-class="vm.item.dimInfo.tag | tagIcon"></div>

--- a/src/app/inventory/dimStoreItem.scss
+++ b/src/app/inventory/dimStoreItem.scss
@@ -15,13 +15,12 @@
 }
 
 .item-stat {
-  opacity: .85;
   position: absolute;
   bottom: 0;
   right: 0;
   font-size: 9.5px;
   padding: 0 2px;
-  background: #ddd;
+  background: rgba(221, 221, 221, .85);
   color: #000;
   min-width: 10px;
   text-align: center;

--- a/src/app/shell/dimAngularFilters.filter.js
+++ b/src/app/shell/dimAngularFilters.filter.js
@@ -269,22 +269,22 @@ mod.filter('dtrRatingColor', () => {
     }
 
     property = property || 'color';
-    let color = 0;
+    let color;
     if (value < 2) {
-      color = 0;
+      color = 'hsl(0,45%,45%)';
     } else if (value <= 3) {
-      color = 15;
+      color = 'hsl(15,65%,40%)';
     } else if (value <= 4) {
-      color = 30;
+      color = 'hsl(30,75%,45%)';
     } else if (value <= 4.4) {
-      color = 60;
+      color = 'hsl(60,100%,30%)';
     } else if (value <= 4.8) {
-      color = 120;
+      color = 'hsl(120,65%,40%)';
     } else if (value >= 4.9) {
-      color = 190;
+      color = 'hsl(190,90%,45%)';
     }
     const result = {};
-    result[property] = `hsl(${color},65%,35%)`;
+    result[property] = color;
     return result;
   };
 });

--- a/src/app/shell/dimAngularFilters.filter.js
+++ b/src/app/shell/dimAngularFilters.filter.js
@@ -257,7 +257,7 @@ mod.filter('qualityColor', () => {
       color = 190;
     }
     const result = {};
-    result[property] = `hsl(${color},85%,60%)`;
+    result[property] = `hsla(${color},65%,50%, .85)`;
     return result;
   };
 });
@@ -268,7 +268,7 @@ mod.filter('dtrRatingColor', () => {
       return null;
     }
 
-    property = property || 'background-color';
+    property = property || 'color';
     let color = 0;
     if (value < 2) {
       color = 0;
@@ -284,7 +284,7 @@ mod.filter('dtrRatingColor', () => {
       color = 190;
     }
     const result = {};
-    result[property] = `hsl(${color},85%,60%)`;
+    result[property] = `hsl(${color},65%,35%)`;
     return result;
   };
 });

--- a/src/scss/_item-discussion.scss
+++ b/src/scss/_item-discussion.scss
@@ -10,6 +10,5 @@
     bottom: 1px;
     padding-left: 1px;
     position: relative;
-    opacity: .4;
   }
 }


### PR DESCRIPTION
I'm finding it hard to go back to the Christmas-tree-lights world of item ratings after the first few weeks of clean items. I took a stab at turning things down a bit. Changes:

1. Switched the stat element to have a transparent background, rather than the whole element being transparent. This makes the text easier to read.
2. Muted the rating/quality colors a bit.
3. For ratings, only color the star. I tried coloring the text too, but it got really hard to read. This plus the darkened colors required to make things contrast make it harder to see the color differences, but it's still pretty easy to pick out good from bad.

Old:
<img width="664" alt="screen shot 2017-10-19 at 11 58 02 pm" src="https://user-images.githubusercontent.com/313208/31808755-62342838-b529-11e7-95cc-ab195330046d.png">

New:
<img width="662" alt="screen shot 2017-10-20 at 12 16 49 am" src="https://user-images.githubusercontent.com/313208/31809321-08bd43f4-b52c-11e7-8c2f-000ad30663e8.png">

And in D2:
<img width="423" alt="screen shot 2017-10-20 at 12 17 03 am" src="https://user-images.githubusercontent.com/313208/31809330-172fd5b4-b52c-11e7-802e-7c47ed1aefc4.png">

I also tried out this variation, which rounds the rating to the nearest integer (is a 4.9 really that much worse than a 5.0?) but keeps the coloration the same, and makes the star larger since we have space for it. I also tried rounding before coloring, but that erases the coloration differences we have between 4.0 and 5.0.

<img width="373" alt="screen shot 2017-10-19 at 11 46 56 pm" src="https://user-images.githubusercontent.com/313208/31808460-14d6c9fc-b528-11e7-9efa-5d00cac2d74d.png">

/cc @SunburnedGoose @kyleshay @48klocs 