### PR TITLE
Put a yellow border on stacks of three or more rare mods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add a new smart loadout to gather reputation items for redemption.
 * Scroll the loadout drawer on mobile.
 * Show character level progression under level 20 for D2.
+* Stacks of three or more rare mods now have a yellow border
 
 # 4.20.1
 

--- a/src/app/inventory/store/d2-item-factory.service.js
+++ b/src/app/inventory/store/d2-item-factory.service.js
@@ -331,11 +331,20 @@ export function D2ItemFactory(
     createdItem.infusable = Boolean(createdItem.infusionProcess && itemDef.quality && itemDef.quality.infusionCategoryName.length);
     createdItem.infusionQuality = itemDef.quality || null;
 
+    // Mark items with power mods
     if (createdItem.primStat) {
       createdItem.basePower = getBasePowerLevel(createdItem);
       if (createdItem.basePower !== createdItem.primStat.value) {
         createdItem.complete = true;
       }
+    }
+
+    // Mark upgradeable stacks of rare modifications
+    if (createdItem.maxStackSize > 1 &&
+        createdItem.amount >= 3 &&
+        createdItem.tier === 'Rare' &&
+        createdItem.bucket.id === 3313201758) {
+      createdItem.complete = true;
     }
 
     return createdItem;


### PR DESCRIPTION
Somebody on Twitter suggested this, and it seemed like an easy QoL improvement.

<img width="280" alt="screen shot 2017-10-20 at 10 45 41 pm" src="https://user-images.githubusercontent.com/313208/31848461-7c13b952-b5e8-11e7-9a70-3c9129956694.png">
