### PR TITLE
Put back throttling

### DIFF
--- a/src/app/dimApp.config.js
+++ b/src/app/dimApp.config.js
@@ -60,10 +60,10 @@ function config($compileProvider, $httpProvider, hotkeysProvider,
   // by making responses take 2s to return, not by sending an error code or throttling response. Choosing
   // our throttling limit to be 1 request every 1100ms lets us achieve best throughput while accounting for
   // what I assume is clock skew between Bungie's hosts when they calculate a global rate limit.
-  // ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 1100);
-  // ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100);
-  // ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 1, 1100);
-  // ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 1100);
+  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 1100);
+  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100);
+  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 1, 1100);
+  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 1100);
 
   // https://github.com/likeastore/ngDialog/issues/327
   ngDialogProvider.setDefaults({


### PR DESCRIPTION
Sadly, Bungie has fixed their beautiful, beautiful oversight that removed throttling from the API. Thus, we're back to issuing a max of 1 move request per second lest we be throttled to an even slower rate.

😭 😭 😭 