### PR TITLE
Fix moving partial stacks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add basepower: filter and is:goldborder filter.
 * Fix filtering in D1.
 * Add a button to clear the current search.
+* Fix moving partial stacks of items.
 
 # 4.21.0
 

--- a/src/app/move-popup/dimMovePopup.directive.html
+++ b/src/app/move-popup/dimMovePopup.directive.html
@@ -2,7 +2,7 @@
   <div dim-move-item-properties="vm.item" dim-infuse="vm.infuse"></div>
   <dim-move-amount ng-if="vm.maximum > 1 && !vm.item.notransfer" amount="vm.moveAmount" maximum="vm.maximum" max-stack-size="vm.item.maxStackSize"></dim-move-amount>
   <div class="interaction">
-    <dim-move-locations item="vm.item"></dim-move-locations>
+    <dim-move-locations item="vm.item" amount="vm.moveAmount"></dim-move-locations>
     <div class="move-button move-consolidate" ng-i18next="[title]MovePopup.Consolidate;[alt]MovePopup.Consolidate"
       ng-if="!vm.item.notransfer && vm.item.maxStackSize > 1" ng-click="vm.consolidate()">
       <span ng-i18next="MovePopup.Take"></span>

--- a/src/app/move-popup/move-locations.component.js
+++ b/src/app/move-popup/move-locations.component.js
@@ -5,7 +5,8 @@ export const MoveLocationsComponent = {
   template,
   controller,
   bindings: {
-    item: '<'
+    item: '<',
+    amount: '<'
   }
 };
 
@@ -66,7 +67,7 @@ function controller(dimSettingsService, dimItemMoveService, dimStoreService, D2S
   };
 
   vm.moveItemTo = function(store, equip) {
-    dimItemMoveService.moveItemTo(vm.item, store, equip, vm.moveAmount);
+    dimItemMoveService.moveItemTo(vm.item, store, equip, vm.amount);
   };
 
   // drag stuff


### PR DESCRIPTION
The refactor of `dim-move-locations` missed passing in an amount, so the amount selected in the move popup was always being ignored.