### PR TITLE
Perk rating D2 gear

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Or run your own local web server
 * `npm install http-server -g` will install http-server
 * `npm start` will start webpack building (and rebuilding as file changes are detected)
 * then go in to the `dist` subdirectory and run `http-server -S` to run http-server over SSL. It'll run on port 8080.
-* If it complains about missing certificates, run `openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem -subj '/CN=www.mydom.com/O=My Company Name LTD./C=US'` in the dist directory (thanks to [Stack Overflow](https://stackoverflow.com/questions/12871565/how-to-create-pem-files-for-https-web-server)) and generate your own local certs
+* If it complains about missing certificates, run `openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem -subj '/CN=www.mydom.com/O=My Company Name LTD./C=US'` in the dist directory (thanks to [Stack Overflow](https://stackoverflow.com/questions/12871565/how-to-create-pem-files-for-https-web-server) and again to [Stack Overflow](https://stackoverflow.com/questions/8075274/is-it-possible-making-openssl-skipping-the-country-common-name-prompts) for the quiet recipe) and generate your own local certs
 * After the one-time setup, `npm start` and `http-server -S` and you're off to the races.
 
 Get your own API key:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Or run your own local web server
 * `npm install http-server -g` will install http-server
 * `npm start` will start webpack building (and rebuilding as file changes are detected)
 * then go in to the `dist` subdirectory and run `http-server -S` to run http-server over SSL. It'll run on port 8080.
-* If it complains about missing certificates, run `openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem` in the dist directory (thanks to [Stack Overflow](https://stackoverflow.com/questions/12871565/how-to-create-pem-files-for-https-web-server)) and generate your own local certs
+* If it complains about missing certificates, run `openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem -subj '/CN=www.mydom.com/O=My Company Name LTD./C=US'` in the dist directory (thanks to [Stack Overflow](https://stackoverflow.com/questions/12871565/how-to-create-pem-files-for-https-web-server)) and generate your own local certs
 * After the one-time setup, `npm start` and `http-server -S` and you're off to the races.
 
 Get your own API key:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add a button to clear the current search.
 * Fix moving partial stacks of items.
 * Fixed "transfer items" in the Infusion Fuel Finder.
+* Giving hints about the community's favorite plugs on D2 items.
 
 # 4.21.0
 

--- a/src/app/destinyTrackerApi/d2-perkRater.js
+++ b/src/app/destinyTrackerApi/d2-perkRater.js
@@ -25,7 +25,8 @@ class D2PerkRater {
           (socket.plugOptions.length > 1)) {
         const plugOptionHashes = _.pluck(socket.plugOptions, 'hash');
 
-        const ratingsAndReviews = _.map(plugOptionHashes, (plugOptionHash) => this._getPlugRatingsAndReviewCount(plugOptionHash, item.writtenReviews));
+        const ratingsAndReviews = _.map(plugOptionHashes,
+          (plugOptionHash) => this._getPlugRatingsAndReviewCount(plugOptionHash, item.writtenReviews));
 
         const maxReview = this._getMaxReview(ratingsAndReviews);
 

--- a/src/app/destinyTrackerApi/d2-perkRater.js
+++ b/src/app/destinyTrackerApi/d2-perkRater.js
@@ -36,7 +36,7 @@ class D2PerkRater {
   }
 
   _markPlugAsBest(maxReview,
-                  socket) {
+    socket) {
     if (!maxReview) {
       return;
     }
@@ -61,9 +61,9 @@ class D2PerkRater {
   }
 
   _getPlugRatingsAndReviewCount(plugOptionHash,
-                                reviews) {
+    reviews) {
     const matchingReviews = this._getMatchingReviews(plugOptionHash,
-                                                     reviews);
+      reviews);
 
     const ratingCount = matchingReviews.length;
     const averageReview = _.pluck(matchingReviews, 'rating').reduce((memo, num) => memo + num, 0) / matchingReviews.length || 1;
@@ -78,7 +78,7 @@ class D2PerkRater {
   }
 
   _getMatchingReviews(plugOptionHash,
-                      reviews) {
+    reviews) {
     return _.filter(reviews, (review) => { return review.selectedPerks.includes(plugOptionHash) ||
                                                   (review.attachedMods &&
                                                    review.attachedMods.includes(plugOptionHash)); });

--- a/src/app/destinyTrackerApi/d2-perkRater.js
+++ b/src/app/destinyTrackerApi/d2-perkRater.js
@@ -30,8 +30,7 @@ class D2PerkRater {
 
         const maxReview = this._getMaxReview(ratingsAndReviews);
 
-        this._markPlugAsBest(maxReview,
-                             socket);
+        this._markPlugAsBest(maxReview, socket);
       }
     });
   }
@@ -80,8 +79,8 @@ class D2PerkRater {
   _getMatchingReviews(plugOptionHash,
                       reviews) {
     return _.filter(reviews, (review) => { return review.selectedPerks.includes(plugOptionHash) ||
-                                                  ((review.attachedMods) &&
-                                                   (review.attachedMods.includes(plugOptionHash))); });
+                                                  (review.attachedMods &&
+                                                   review.attachedMods.includes(plugOptionHash)); });
   }
 }
 

--- a/src/app/destinyTrackerApi/d2-perkRater.js
+++ b/src/app/destinyTrackerApi/d2-perkRater.js
@@ -1,0 +1,111 @@
+import _ from 'underscore';
+
+/**
+ * Rate perks on a Destiny 2 item (based off of its attached user reviews).
+ *
+ * @class D2PerkRater
+ */
+class D2PerkRater {
+  /**
+   * Rate the perks on a Destiny 2 item based off of its attached user reviews.
+   *
+   * @param {any} item
+   * @memberof D2PerkRater
+   */
+  ratePerks(item) {
+    if ((!item.writtenReviews) ||
+        (!item.writtenReviews.length)) {
+      return;
+    }
+
+    console.log(item);
+
+    // const maxColumn = this._getMaxColumn(item);
+
+    // for (let i = 1; i < maxColumn; i++) {
+    //   const perkNodesInColumn = this._getPerkNodesInColumn(item, i);
+
+    //   const ratingsAndReviews = _.map(perkNodesInColumn, (perkNode) => this._getPerkRatingsAndReviewCount(perkNode, item.writtenReviews));
+
+    //   const maxReview = this._getMaxReview(ratingsAndReviews);
+
+    //   this._markNodeAsBest(maxReview);
+    // }
+  }
+
+  _markNodeAsBest(maxReview) {
+    if (!maxReview) {
+      return;
+    }
+
+    maxReview.perkNode.bestRated = true;
+  }
+
+  _getMaxReview(ratingsAndReviews) {
+    const orderedRatingsAndReviews = _.sortBy(ratingsAndReviews, (ratingAndReview) => { return ratingAndReview.ratingCount < 2 ? 0 : ratingAndReview.averageReview; }).reverse();
+
+    if ((orderedRatingsAndReviews.length > 0) &&
+        (orderedRatingsAndReviews[0].ratingCount > 1)) {
+      return orderedRatingsAndReviews[0];
+    }
+
+    return null;
+  }
+
+  _getMaxColumn(item) {
+    return _.max(item.talentGrid.nodes, (node) => { return node.column; }).column;
+  }
+
+  _getPerkNodesInColumn(item,
+                        column) {
+    return _.where(item.talentGrid.nodes, { column: column });
+  }
+
+  _getPerkRatingsAndReviewCount(perkNode,
+                                reviews) {
+    const matchingReviews = this._getMatchingReviews(perkNode,
+                                                     reviews);
+
+    const ratingCount = matchingReviews.length;
+    const averageReview = _.pluck(matchingReviews, 'rating').reduce((memo, num) => memo + num, 0) / matchingReviews.length || 1;
+
+    const ratingAndReview = {
+      ratingCount: ratingCount,
+      averageReview: averageReview,
+      perkNode: perkNode
+    };
+
+    return ratingAndReview;
+  }
+
+  _getSelectedPerksAndRating(review) {
+    const selectedPerks = this._getSelectedPerks(review);
+
+    return {
+      selectedPerks: selectedPerks,
+      rating: review.rating,
+      isHighlighted: review.isHighlighted
+    };
+  }
+
+  _getMatchingReviews(perkNode,
+                      reviews) {
+    const perkRoll = perkNode.dtrRoll.replace('o', '');
+    return _.filter(reviews, (review) => { return this._selectedPerkNodeApplies(perkRoll, review); });
+  }
+
+  _selectedPerkNodeApplies(perkRoll,
+                           review) {
+    const reviewSelectedPerks = this._getSelectedPerks(review);
+
+    return _.some(reviewSelectedPerks, (reviewSelectedPerk) => { return perkRoll === reviewSelectedPerk; });
+  }
+
+  _getSelectedPerks(review) {
+    const allSelectedPerks = _.filter(review.roll.split(';'), ((str) => { return str.indexOf('o') > -1; }));
+
+    return _.map(allSelectedPerks, (selectedPerk) => { return selectedPerk.replace('o', ''); });
+  }
+}
+
+export { D2PerkRater };

--- a/src/app/destinyTrackerApi/d2-perkRater.js
+++ b/src/app/destinyTrackerApi/d2-perkRater.js
@@ -13,10 +13,10 @@ class D2PerkRater {
    * @memberof D2PerkRater
    */
   ratePerks(item) {
-    if ((!item.writtenReviews) ||
-        (!item.writtenReviews.length) ||
-        (!item.sockets) ||
-        (!item.sockets.sockets)) {
+    if (!item.writtenReviews ||
+        !item.writtenReviews.length ||
+        !item.sockets ||
+        !item.sockets.sockets) {
       return;
     }
 

--- a/src/app/destinyTrackerApi/d2-perkRater.js
+++ b/src/app/destinyTrackerApi/d2-perkRater.js
@@ -49,7 +49,8 @@ class D2PerkRater {
   }
 
   _getMaxReview(ratingsAndReviews) {
-    const orderedRatingsAndReviews = _.sortBy(ratingsAndReviews, (ratingAndReview) => { return ratingAndReview.ratingCount < 2 ? 0 : ratingAndReview.averageReview; }).reverse();
+    const orderedRatingsAndReviews = _.sortBy(ratingsAndReviews, (ratingAndReview) => (ratingAndReview.ratingCount < 2 ? 0
+      : ratingAndReview.averageReview)).reverse();
 
     if ((orderedRatingsAndReviews.length > 0) &&
         (orderedRatingsAndReviews[0].ratingCount > 1)) {

--- a/src/app/move-popup/sockets.component.js
+++ b/src/app/move-popup/sockets.component.js
@@ -10,6 +10,10 @@ export const SocketsComponent = {
   template
 };
 
-function SocketsCtrl() {
+function SocketsCtrl($i18next) {
   'ngInject';
+
+  const vm = this;
+
+  vm.bestRatedText = `\n${$i18next.t('DtrReview.BestRatedTip')}`;
 }

--- a/src/app/move-popup/sockets.html
+++ b/src/app/move-popup/sockets.html
@@ -6,7 +6,7 @@
       ng-repeat="socketInfo in category.sockets track by $index">
       <img class="item-mod"
         ng-src="{{ socket.displayProperties.icon | bungieIcon }}"
-        ng-class="{ notChosen: socket != socketInfo.plug }"
+        ng-class="{ notChosen: socket != socketInfo.plug && !socket.bestRated, bestRated: socket != socketInfo.plug && socket.bestRated }"
         ng-repeat="socket in socketInfo.plugOptions track by $index"
         press-tip="{{ socket.displayProperties.description }}{{ socketInfo.enableFailReasons }}"
         press-tip-title="{{ socket.displayProperties.name }}">

--- a/src/app/move-popup/sockets.html
+++ b/src/app/move-popup/sockets.html
@@ -4,12 +4,22 @@
     <div class="item-socket"
       ng-class="{ disabled: !socketInfo.enabled }"
       ng-repeat="socketInfo in category.sockets track by $index">
-      <img class="item-mod"
-        ng-src="{{ socket.displayProperties.icon | bungieIcon }}"
-        ng-class="{ notChosen: socket != socketInfo.plug && !socket.bestRated, bestRated: socket != socketInfo.plug && socket.bestRated }"
-        ng-repeat="socket in socketInfo.plugOptions track by $index"
-        press-tip="{{ socket.displayProperties.description }}{{ socketInfo.enableFailReasons }}"
-        press-tip-title="{{ socket.displayProperties.name }}">
+      <div class="socket-container"
+           ng-repeat="socket in socketInfo.plugOptions track by $index">
+        <svg ng-if="socket != socketInfo.plug && socket.bestRated" width="34" height="34">
+          <circle
+            class="talent-node-best-rated-circle"
+            r="5"
+            cx="25"
+            cy="6"
+          />
+        </svg>
+        <img class="item-mod"
+          ng-src="{{ socket.displayProperties.icon | bungieIcon }}"
+          ng-class="{ notChosen: socket != socketInfo.plug }"
+          press-tip="{{ socket.displayProperties.description }}{{ socketInfo.enableFailReasons }}"
+          press-tip-title="{{ socket.displayProperties.name }}">
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/move-popup/sockets.html
+++ b/src/app/move-popup/sockets.html
@@ -6,18 +6,15 @@
       ng-repeat="socketInfo in category.sockets track by $index">
       <div class="socket-container"
            ng-repeat="socket in socketInfo.plugOptions track by $index">
-        <svg ng-if="socket != socketInfo.plug && socket.bestRated" width="34" height="34">
-          <circle
-            class="talent-node-best-rated-circle"
-            r="5"
-            cx="25"
-            cy="6"
-          />
-        </svg>
+        <div ng-if="socket != socketInfo.plug && socket.bestRated" class="circle-container">
+          <div class="blue-circle">
+            <i class="fa fa-circle" aria-hidden="true"></i>
+          </div>
+        </div>
         <img class="item-mod"
           ng-src="{{ socket.displayProperties.icon | bungieIcon }}"
           ng-class="{ notChosen: socket != socketInfo.plug }"
-          press-tip="{{ socket.displayProperties.description }}{{ socketInfo.enableFailReasons }}"
+          press-tip="{{ socket.displayProperties.description }}{{ socketInfo.enableFailReasons }}{{socket.bestRated ? $ctrl.bestRatedText : ''}}"
           press-tip-title="{{ socket.displayProperties.name }}">
       </div>
     </div>

--- a/src/app/move-popup/sockets.html
+++ b/src/app/move-popup/sockets.html
@@ -7,9 +7,7 @@
       <div class="socket-container"
            ng-repeat="socket in socketInfo.plugOptions track by $index">
         <div ng-if="socket != socketInfo.plug && socket.bestRated" class="circle-container">
-          <div class="blue-circle">
-            <i class="fa fa-circle" aria-hidden="true"></i>
-          </div>
+          <div class="blue-circle"></div>
         </div>
         <img class="item-mod"
           ng-src="{{ socket.displayProperties.icon | bungieIcon }}"

--- a/src/app/move-popup/sockets.scss
+++ b/src/app/move-popup/sockets.scss
@@ -47,6 +47,9 @@
   }
 
   .blue-circle {
-    color: #0099ff;
+    background-color: #0099ff;
+    border-radius: 50%;
+    width: 10px;
+    height: 10px;
   }
 }

--- a/src/app/move-popup/sockets.scss
+++ b/src/app/move-popup/sockets.scss
@@ -40,9 +40,13 @@
     }
   }
 
-  svg {
+  .circle-container {
     position: absolute;
     top: 0;
-    left: 0;
+    right: 0;
+  }
+
+  .blue-circle {
+    color: #0099ff;
   }
 }

--- a/src/app/move-popup/sockets.scss
+++ b/src/app/move-popup/sockets.scss
@@ -28,6 +28,10 @@
     &.notChosen {
       opacity: .4;
     }
+    &.bestRated {
+      -webkit-filter: opacity(50%) sepia() saturate(10000%) hue-rotate(30deg);
+      filter: opacity(50%) sepia() saturate(10000%) hue-rotate(30deg);
+    }
   }
   &.disabled {
     opacity: .4;

--- a/src/app/move-popup/sockets.scss
+++ b/src/app/move-popup/sockets.scss
@@ -21,19 +21,28 @@
   display: flex;
   flex-direction: column;
 
+  &.disabled {
+    opacity: .4;
+  }
+}
+
+.socket-container {
+  position: relative;
+  display: inline-block;
+
   img {
     -webkit-touch-callout: none;
     width: 34px;
     height: 34px;
+    display: block;
     &.notChosen {
       opacity: .4;
     }
-    &.bestRated {
-      -webkit-filter: opacity(50%) sepia() saturate(10000%) hue-rotate(30deg);
-      filter: opacity(50%) sepia() saturate(10000%) hue-rotate(30deg);
-    }
   }
-  &.disabled {
-    opacity: .4;
+
+  svg {
+    position: absolute;
+    top: 0;
+    left: 0;
   }
 }

--- a/src/app/services/dimDestinyTrackerService.factory.js
+++ b/src/app/services/dimDestinyTrackerService.factory.js
@@ -35,7 +35,7 @@ function DestinyTrackerService($q,
   const _d2reviewDataCache = new D2ReviewDataCache();
   const _d2trackerErrorHandler = new D2TrackerErrorHandler($q, $i18next);
   const _d2bulkFetcher = new D2BulkFetcher($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache);
-  const _d2reviewsFetcher = new D2ReviewsFetcher($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache, _userFilter);
+  const _d2reviewsFetcher = new D2ReviewsFetcher($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache, _userFilter, dimPlatformService);
   const _d2reviewSubmitter = new D2ReviewSubmitter($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache);
   const _d2reviewReporter = new D2ReviewReporter($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache, _userFilter);
 

--- a/src/app/services/dimDestinyTrackerService.factory.js
+++ b/src/app/services/dimDestinyTrackerService.factory.js
@@ -35,7 +35,7 @@ function DestinyTrackerService($q,
   const _d2reviewDataCache = new D2ReviewDataCache();
   const _d2trackerErrorHandler = new D2TrackerErrorHandler($q, $i18next);
   const _d2bulkFetcher = new D2BulkFetcher($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache);
-  const _d2reviewsFetcher = new D2ReviewsFetcher($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache, _userFilter, dimPlatformService);
+  const _d2reviewsFetcher = new D2ReviewsFetcher($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache, _userFilter);
   const _d2reviewSubmitter = new D2ReviewSubmitter($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache);
   const _d2reviewReporter = new D2ReviewReporter($q, $http, _d2trackerErrorHandler, loadingTracker, _d2reviewDataCache, _userFilter);
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -96,7 +96,8 @@
     "Submit": "Submit",
     "ThankYou": "Thank you for submitting a review! It will go live shortly.",
     "VerifyReport": "Are you sure you want to flag this review?",
-    "YourReview": "Your Review"
+    "YourReview": "Your Review",
+    "BestRatedTip": "This perk is associated with high community ratings."
   },
   "FarmingMode": {
     "Configuration": "Configuration",


### PR DESCRIPTION
The initial drop of D2 item ratings left out perk hinting (the blue dots on gear letting you know that high community ratings were associated with a perk you didn't have selected).

I've changed that up, so in places where we have multiple plug options, we display the best-rated ones by coloring them green, but hopefully not too horrifying a green? I didn't carry forward the blue circle from D1 because there was a bunch of SVG to display nodes, where this is just NG foreach'ing up a bunch of images.

![d2-perk-ratings-are-go-maybe](https://user-images.githubusercontent.com/606888/32137044-bd22f42c-bbe6-11e7-9f98-ed9354aeb32e.png)
