### PR TITLE
Make sure that missing stats also display in the comparison window.

### DIFF
--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -80,6 +80,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
   vm.cancel = function cancel() {
     vm.comparisons = [];
     vm.statRanges = {};
+    vm.statsMap = {};
     vm.similarTypes = [];
     vm.archeTypes = [];
     vm.highlight = null;

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -34,11 +34,41 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     return item.destinyVersion === 2 ? D2StoresService : dimStoreService;
   }
 
+  function addMissingStats(item) {
+    if (!vm.comparisons[0]) {
+      item.stats.forEach((stat, idx) => {
+        vm.statsMap[stat.id] = idx;
+      });
+      return item;
+    }
+    const itemStatsMap = {};
+    item.stats.forEach((stat, idx) => {
+      itemStatsMap[stat.id] = { index: idx, name: stat.name };
+    });
+
+    _.difference(_.keys(vm.statsMap), _.keys(itemStatsMap)).forEach((statId) => {
+      item.stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId) });
+    });
+
+    _.difference(_.keys(itemStatsMap), _.keys(vm.statsMap)).forEach((statId) => {
+      _.keys(vm.statsMap).forEach((statMapId) => {
+        if (vm.statsMap[statMapId] >= itemStatsMap[statId].index) {
+          vm.statsMap[statMapId]++;
+        }
+      });
+      vm.statsMap[statId] = itemStatsMap[statId].index;
+      vm.comparisons[0].stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId), name: itemStatsMap[statId].name });
+    });
+
+    return item;
+  }
+
   vm.tagsEnabled = $featureFlags.tagsEnabled;
   vm.show = dimCompareService.dialogOpen;
 
   vm.comparisons = [];
   vm.statRanges = {};
+  vm.statsMap = {};
 
   $scope.$on('dim-store-item-compare', (event, args) => {
     vm.show = true;
@@ -66,7 +96,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     vm.sortedHash = statHash;
     vm.comparisons = _.sortBy(_.sortBy(_.sortBy(vm.comparisons, 'index'), 'name').reverse(), (item) => {
       const stat = _.find(item.stats, { statHash: statHash }) || item.primStat;
-      return stat.value;
+      return stat.value || -1;
     }).reverse();
   };
 
@@ -120,9 +150,9 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
           }, 0) === armorSplit;
         });
       }
-
-      vm.comparisons = _.filter(allItems, { hash: vm.compare.hash });
+      vm.comparisons = _.map(_.filter(allItems, { hash: vm.compare.hash }), (item) => addMissingStats(item));
     } else if (!_.findWhere(vm.comparisons, { hash: args.item.hash, id: args.item.id })) {
+      addMissingStats(args.item);
       vm.comparisons.push(args.item);
     }
   };
@@ -152,7 +182,9 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     const statBuckets = {};
 
     function bucketStat(stat) {
-      (statBuckets[stat.statHash] = statBuckets[stat.statHash] || []).push(stat.value);
+      if (stat.value) {
+        (statBuckets[stat.statHash] = statBuckets[stat.statHash] || []).push(stat.value);
+      }
     }
 
     vm.comparisons.forEach((item) => {

--- a/src/app/compare/compare.html
+++ b/src/app/compare/compare.html
@@ -19,7 +19,7 @@
         <span ng-bind="item.primStat.value"></span>
       </div>
       <div ng-class="{ highlight: vm.highlight === stat.statHash }" ng-mouseover="vm.highlight = stat.statHash" ng-repeat="stat in item.stats track by $index" ng-style="stat | statRange:vm.statRanges | qualityColor:'color'">
-        <span ng-bind="stat.value || 'N/A'"></span>
+        <span ng-bind="stat.value || ('Stats.NotApplicable' | i18next)"></span>
         <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
       </div>
       <dim-talent-grid ng-if="item.talentGrid" talent-grid="item.talentGrid"></dim-talent-grid>

--- a/src/app/compare/compare.html
+++ b/src/app/compare/compare.html
@@ -8,7 +8,7 @@
     <div class="compare-item fixed-left">
       <div class="spacer" ng-class="::{withTags: vm.tagsEnabled}"></div>
       <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === vm.comparisons[0].primStat.statHash, sorted: vm.sortedHash === vm.comparisons[0].primStat.statHash }" ng-mouseover="vm.highlight = vm.comparisons[0].primStat.statHash" ng-click="vm.sort(vm.comparisons[0].primStat.statHash)" ng-bind="vm.comparisons[0].primStat.stat.statName || vm.comparisons[0].primStat.stat.displayProperties.name"></div>
-      <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash }" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by stat.statHash" ng-bind="::stat.name"></div>
+      <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash }" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by stat.statHash" ng-bind="stat.name"></div>
     </div>
     <div ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
       <div class="close" ng-click="vm.remove(item);"></div>
@@ -19,7 +19,7 @@
         <span ng-bind="item.primStat.value"></span>
       </div>
       <div ng-class="{ highlight: vm.highlight === stat.statHash }" ng-mouseover="vm.highlight = stat.statHash" ng-repeat="stat in item.stats track by $index" ng-style="stat | statRange:vm.statRanges | qualityColor:'color'">
-        <span ng-bind="::stat.value"></span>
+        <span ng-bind="stat.value || 'N/A'"></span>
         <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
       </div>
       <dim-talent-grid ng-if="item.talentGrid" talent-grid="item.talentGrid"></dim-talent-grid>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -509,6 +509,7 @@
     "Level": "Level",
     "MaxBasePower": "Max Base Power (w/o mods)",
     "NoBonus": "No Bonus",
+    "NotApplicable": "N/A",
     "OfMaxRoll": "{{range}} of max roll",
     "PercentHelp": "Click for more information about what Stats Quality is.",
     "Prestige": "Prestige Level: {{level}}\n{{exp}}xp until 5 motes of light.",


### PR DESCRIPTION
This should resolve https://github.com/DestinyItemManager/DIM/issues/2391. In order to support the case where the item initially select for comparison is the item with missing properties I had to remove the one time binding on the stat names and values. If there is some existing service that can be used to grab the list of "default" stats for each item type I could probably rework things to use that and then I could add back in the one time binding but I didn't see one.