### PR TITLE
Update invite URL

### DIFF
--- a/src/views/about.html
+++ b/src/views/about.html
@@ -25,7 +25,7 @@
         </td>
         <td ng-i18next="[html:i18next]({ link: '<a href=\'https://github.com/DestinyItemManager/DIM/\' target=\'_blank\' rel=\'noopener noreferrer\'>GitHub</a>' })Views.About.GitHubHelp"></td>
         <td ng-i18next="[html:i18next]({
-                        link: '<a href=\'https://crowdin.com/project/destiny-item-manager/invite?d=6565n46535j5l4135333g443q4e4n4r413f3a323o4k5o4u4b343n4k4\' target=\'_blank\' rel=\'noopener noreferrer\'>Crowdin</a>'
+                        link: '<a href=\'https://crowdin.com/project/destiny-item-manager/invite?d=6565n46535j5o4a30373q4u2o4e4m4n413b3b323n4d3i4p4e3t2s4l4v24333436323t4k4c583b3c3535383' target=\'_blank\' rel=\'noopener noreferrer\'>Crowdin</a>'
                         })Views.About.TranslationText"></td>
       </tr>
     </table>


### PR DESCRIPTION
The old link does not give permissions to Chinese (Simplified & Traditional), Russian, Polish, or Spanish (Mexico). This link ensures all languages are available for translators automatically.