### PR TITLE
Platform selection for D2 ratings.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Added setting to pick relevant platforms for reviews.
 
 # 4.23.0
 

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.js
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.js
@@ -11,16 +11,16 @@ class D2BulkFetcher {
     this._reviewDataCache = reviewDataCache;
   }
 
-  _getBulkWeaponDataEndpointPost(gunList) {
+  _getBulkWeaponDataEndpointPost(gunList, platformSelection) {
     return {
       method: 'POST',
-      url: 'https://db-api.destinytracker.com/api/external/reviews/fetch',
+      url: `https://db-api.destinytracker.com/api/external/reviews/fetch?platform=${platformSelection}`,
       data: gunList,
       dataType: 'json'
     };
   }
 
-  _getBulkFetchPromise(stores) {
+  _getBulkFetchPromise(stores, platformSelection) {
     if (!stores.length) {
       return this.$q.resolve();
     }
@@ -32,7 +32,7 @@ class D2BulkFetcher {
     }
 
     const promise = this.$q
-              .when(this._getBulkWeaponDataEndpointPost(weaponList))
+              .when(this._getBulkWeaponDataEndpointPost(weaponList, platformSelection))
               .then(this.$http)
               .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
               .then((response) => response.data);
@@ -46,13 +46,14 @@ class D2BulkFetcher {
    * Fetch the DTR community scores for all weapon items found in the supplied stores.
    *
    * @param {any} storesContainer
+   * @param {number} platformSelection
    *
    * @memberof D2BulkFetcher
    */
-  bulkFetch(storesContainer) {
+  bulkFetch(storesContainer, platformSelection) {
     const stores = _.values(storesContainer);
 
-    this._getBulkFetchPromise(stores)
+    this._getBulkFetchPromise(stores, platformSelection)
       .then((bulkRankings) => this.attachRankings(bulkRankings,
                                                   stores));
   }

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.js
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.js
@@ -32,10 +32,10 @@ class D2BulkFetcher {
     }
 
     const promise = this.$q
-              .when(this._getBulkWeaponDataEndpointPost(weaponList, platformSelection))
-              .then(this.$http)
-              .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
-              .then((response) => response.data);
+      .when(this._getBulkWeaponDataEndpointPost(weaponList, platformSelection))
+      .then(this.$http)
+      .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
+      .then((response) => response.data);
 
     this._loadingTracker.addPromise(promise);
 
@@ -55,7 +55,7 @@ class D2BulkFetcher {
 
     this._getBulkFetchPromise(stores, platformSelection)
       .then((bulkRankings) => this.attachRankings(bulkRankings,
-                                                  stores));
+        stores));
   }
 
   /**
@@ -70,11 +70,11 @@ class D2BulkFetcher {
 
     this._getBulkFetchPromise(vendors)
       .then((bulkRankings) => this.attachVendorRankings(bulkRankings,
-                                                        vendors));
+        vendors));
   }
 
   attachRankings(bulkRankings,
-                 stores) {
+    stores) {
     if (!bulkRankings && !stores) {
       return;
     }
@@ -107,7 +107,7 @@ class D2BulkFetcher {
   }
 
   attachVendorRankings(bulkRankings,
-                       vendors) {
+    vendors) {
     if (!bulkRankings && !vendors) {
       return;
     }

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.js
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.js
@@ -157,6 +157,15 @@ class D2ReviewDataCache {
   }
 
   /**
+   * Clears all items (in case of, say, platform re-selection).
+   *
+   * @memberof D2ReviewDataCache
+   */
+  clearAllItems() {
+    this._itemStores = [];
+  }
+
+  /**
    * There's a 10 minute delay between posting an item review to the DTR API
    * and being able to fetch that review from it.
    * To prevent angry bug reports, we'll continue to hang on to local user review data for

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.js
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.js
@@ -21,7 +21,7 @@ class D2ReviewsFetcher {
   }
 
   _getItemReviewsCall(item, platformSelection) {
-    const queryString = `reviews?page=1&platform=${platformSelection}`;
+    const queryString = `page=1&platform=${platformSelection}`;
 
     return {
       method: 'POST',

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.js
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.js
@@ -35,10 +35,10 @@ class D2ReviewsFetcher {
     const postWeapon = this._itemTransformer.getRollAndPerks(item);
 
     const promise = this.$q
-              .when(this._getItemReviewsCall(postWeapon, platformSelection))
-              .then(this.$http)
-              .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
-              .then((response) => { return response.data; });
+      .when(this._getItemReviewsCall(postWeapon, platformSelection))
+      .then(this.$http)
+      .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
+      .then((response) => { return response.data; });
 
     this._loadingTracker.addPromise(promise);
 
@@ -124,7 +124,7 @@ class D2ReviewsFetcher {
   }
 
   _attachCachedReviews(item,
-                       cachedItem) {
+    cachedItem) {
     item.communityReviews = cachedItem.reviews;
 
     this._attachReviews(item, cachedItem);
@@ -165,7 +165,7 @@ class D2ReviewsFetcher {
 
     if (ratingData && ratingData.reviewsDataFetched) {
       this._attachCachedReviews(item,
-                                ratingData);
+        ratingData);
 
       return;
     }
@@ -173,7 +173,7 @@ class D2ReviewsFetcher {
     this._getItemReviewsPromise(item, platformSelection)
       .then((reviewData) => this._markUserReview(reviewData))
       .then((reviewData) => this._attachReviews(item,
-                                                reviewData));
+        reviewData));
   }
 }
 

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.js
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.js
@@ -20,20 +20,22 @@ class D2ReviewsFetcher {
     this._perkRater = new D2PerkRater();
   }
 
-  _getItemReviewsCall(item) {
+  _getItemReviewsCall(item, platformSelection) {
+    const queryString = `reviews?page=1&platform=${platformSelection}`;
+
     return {
       method: 'POST',
-      url: 'https://db-api.destinytracker.com/api/external/reviews?page=1', // TODO: pagination
+      url: `https://db-api.destinytracker.com/api/external/reviews?${queryString}`, // TODO: pagination
       data: item,
       dataType: 'json'
     };
   }
 
-  _getItemReviewsPromise(item) {
+  _getItemReviewsPromise(item, platformSelection) {
     const postWeapon = this._itemTransformer.getRollAndPerks(item);
 
     const promise = this.$q
-              .when(this._getItemReviewsCall(postWeapon))
+              .when(this._getItemReviewsCall(postWeapon, platformSelection))
               .then(this.$http)
               .then(this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler), this._trackerErrorHandler.handleErrors.bind(this._trackerErrorHandler))
               .then((response) => { return response.data; });
@@ -150,11 +152,12 @@ class D2ReviewsFetcher {
    * Attempts to fetch data from the cache first.
    *
    * @param {any} item
+   * @param {number} platformSelection
    * @returns {void}
    *
-   * @memberof ReviewsFetcher
+   * @memberof D2ReviewsFetcher
    */
-  getItemReviews(item) {
+  getItemReviews(item, platformSelection) {
     if (!item.reviewable) {
       return;
     }
@@ -167,7 +170,7 @@ class D2ReviewsFetcher {
       return;
     }
 
-    this._getItemReviewsPromise(item)
+    this._getItemReviewsPromise(item, platformSelection)
       .then((reviewData) => this._markUserReview(reviewData))
       .then((reviewData) => this._attachReviews(item,
                                                 reviewData));

--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -65,7 +65,8 @@ export function D2StoresService(
     getStoresStream,
     getItemAcrossStores,
     updateCharacters,
-    reloadStores
+    reloadStores,
+    refreshRatingsData
   };
 
   return service;
@@ -506,5 +507,10 @@ export function D2StoresService(
       }
     });
     activeStore.vault = vault; // god help me
+  }
+
+  function refreshRatingsData() {
+    dimDestinyTrackerService.clearCache();
+    dimDestinyTrackerService.fetchReviews(_stores);
   }
 }

--- a/src/app/services/dimDestinyTrackerService.factory.js
+++ b/src/app/services/dimDestinyTrackerService.factory.js
@@ -88,7 +88,8 @@ function DestinyTrackerService($q,
         if (_isDestinyOne()) {
           _reviewsFetcher.getItemReviews(item);
         } else if (_isDestinyTwo()) {
-          _d2reviewsFetcher.getItemReviews(item);
+          const platformSelection = dimSettingsService.platformSelection;
+          _d2reviewsFetcher.getItemReviews(item, platformSelection);
         }
       }
     },
@@ -115,7 +116,8 @@ function DestinyTrackerService($q,
       if (stores[0].destinyVersion === 1) {
         _bulkFetcher.bulkFetch(stores);
       } else if (stores[0].destinyVersion === 2) {
-        _d2bulkFetcher.bulkFetch(stores);
+        const platformSelection = dimSettingsService.platformSelection;
+        _d2bulkFetcher.bulkFetch(stores, platformSelection);
       }
     },
 

--- a/src/app/services/dimDestinyTrackerService.factory.js
+++ b/src/app/services/dimDestinyTrackerService.factory.js
@@ -88,7 +88,7 @@ function DestinyTrackerService($q,
         if (_isDestinyOne()) {
           _reviewsFetcher.getItemReviews(item);
         } else if (_isDestinyTwo()) {
-          const platformSelection = dimSettingsService.platformSelection;
+          const platformSelection = dimSettingsService.reviewsPlatformSelection;
           _d2reviewsFetcher.getItemReviews(item, platformSelection);
         }
       }
@@ -116,7 +116,7 @@ function DestinyTrackerService($q,
       if (stores[0].destinyVersion === 1) {
         _bulkFetcher.bulkFetch(stores);
       } else if (stores[0].destinyVersion === 2) {
-        const platformSelection = dimSettingsService.platformSelection;
+        const platformSelection = dimSettingsService.reviewsPlatformSelection;
         _d2bulkFetcher.bulkFetch(stores, platformSelection);
       }
     },

--- a/src/app/services/dimDestinyTrackerService.factory.js
+++ b/src/app/services/dimDestinyTrackerService.factory.js
@@ -134,6 +134,11 @@ function DestinyTrackerService($q,
     },
     clearIgnoredUsers: function() {
       _userFilter.clearIgnoredUsers();
+    },
+    clearCache: function() {
+      if (_isDestinyTwo()) {
+        _d2reviewDataCache.clearAllItems();
+      }
     }
   };
 }

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -10,7 +10,7 @@ export const SettingsComponent = {
   controllerAs: 'vm'
 };
 
-export function SettingsController(loadingTracker, dimSettingsService, $scope, dimCsvService, dimStoreService, D2StoresService, dimInfoService, OAuthTokenService, $state, $i18next, dimDestinyTrackerService) {
+export function SettingsController(loadingTracker, dimSettingsService, $scope, dimCsvService, dimStoreService, D2StoresService, dimInfoService, OAuthTokenService, $state, $i18next) {
   'ngInject';
 
   const vm = this;
@@ -121,7 +121,7 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
   };
 
   vm.platformChanged = function() {
-    // bugbug: need to get stores for fetch after this
-    dimDestinyTrackerService.clearCache();
+    dimSettingsService.save();
+    D2StoresService.refreshRatingsData();
   };
 }

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -86,11 +86,11 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
   };
 
   vm.platformOptions = {
-    0: $i18next.t('Filter.Platforms.All'),
-    1: $i18next.t('Filter.Platforms.Xbox'),
-    2: $i18next.t('Filter.Platforms.Playstation'),
-    3: $i18next.t('Filter.Platforms.AllConsoles'),
-    4: $i18next.t('Filter.Platforms.Pc')
+    0: $i18next.t('DtrReview.Platforms.All'),
+    1: $i18next.t('DtrReview.Platforms.Xbox'),
+    2: $i18next.t('DtrReview.Platforms.Playstation'),
+    3: $i18next.t('DtrReview.Platforms.AllConsoles'),
+    4: $i18next.t('DtrReview.Platforms.Pc')
   };
 
   if ($featureFlags.colorA11y) {

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -85,7 +85,7 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
     'zh-cht': '繁體中文' // Chinese (Traditional)
   };
 
-  vm.platformOptions = {
+  vm.reviewsPlatformOptions = {
     0: $i18next.t('DtrReview.Platforms.All'),
     1: $i18next.t('DtrReview.Platforms.Xbox'),
     2: $i18next.t('DtrReview.Platforms.Playstation'),
@@ -120,7 +120,7 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
     vm.settings.itemSize = window.matchMedia('(max-width: 1025px)').matches ? 38 : 44;
   };
 
-  vm.platformChanged = function() {
+  vm.reviewsPlatformChanged = function() {
     dimSettingsService.save();
     D2StoresService.refreshRatingsData();
   };

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -10,7 +10,7 @@ export const SettingsComponent = {
   controllerAs: 'vm'
 };
 
-export function SettingsController(loadingTracker, dimSettingsService, $scope, dimCsvService, dimStoreService, D2StoresService, dimInfoService, OAuthTokenService, $state, $i18next) {
+export function SettingsController(loadingTracker, dimSettingsService, $scope, dimCsvService, dimStoreService, D2StoresService, dimInfoService, OAuthTokenService, $state, $i18next, dimDestinyTrackerService) {
   'ngInject';
 
   const vm = this;
@@ -118,5 +118,10 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
 
   vm.resetItemSize = function() {
     vm.settings.itemSize = window.matchMedia('(max-width: 1025px)').matches ? 38 : 44;
+  };
+
+  vm.platformChanged = function() {
+    // bugbug: need to get stores for fetch after this
+    dimDestinyTrackerService.clearCache();
   };
 }

--- a/src/app/settings/settings.component.js
+++ b/src/app/settings/settings.component.js
@@ -85,6 +85,14 @@ export function SettingsController(loadingTracker, dimSettingsService, $scope, d
     'zh-cht': '繁體中文' // Chinese (Traditional)
   };
 
+  vm.platformOptions = {
+    0: $i18next.t('Filter.Platforms.All'),
+    1: $i18next.t('Filter.Platforms.Xbox'),
+    2: $i18next.t('Filter.Platforms.Playstation'),
+    3: $i18next.t('Filter.Platforms.AllConsoles'),
+    4: $i18next.t('Filter.Platforms.Pc')
+  };
+
   if ($featureFlags.colorA11y) {
     vm.colorA11yOptions = ['-', 'Protanopia', 'Protanomaly', 'Deuteranopia', 'Deuteranomaly', 'Tritanopia', 'Tritanomaly', 'Achromatopsia', 'Achromatomaly'];
   }

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -84,7 +84,7 @@
           <input type="checkbox" id="allowIdPostToDtr" ng-model="vm.settings.allowIdPostToDtr"/>
         </td>
       </tr>
-      <tr ng-if="vm.settings.showReviews || vm.settings.allowIdPostToDtr">
+      <tr ng-if="vm.settings.destinyVersion === 2 && (vm.settings.showReviews || vm.settings.allowIdPostToDtr)">
         <td>
           <label for="reviewPlatformSelection" ng-i18next="Settings.PlatformSelection"></label>
         </td>

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -89,7 +89,10 @@
           <label for="reviewPlatformSelection" ng-i18next="Settings.PlatformSelection"></label>
         </td>
         <td>
-          <select id="reviewPlatformSelection" ng-model="vm.settings.platformSelection" ng-options="code as name for (code, name) in vm.platformOptions"></select>
+          <select id="reviewPlatformSelection"
+            ng-model="vm.settings.platformSelection"
+            ng-options="code as name for (code, name) in vm.platformOptions"
+            ng-change="vm.platformChanged()"></select>
         </td>
       </tr>
       <tr>

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -84,6 +84,14 @@
           <input type="checkbox" id="allowIdPostToDtr" ng-model="vm.settings.allowIdPostToDtr"/>
         </td>
       </tr>
+      <tr ng-if="vm.settings.showReviews || vm.settings.allowIdPostToDtr">
+        <td>
+          <label for="reviewPlatformSelection" ng-i18next="Settings.PlatformSelection"></label>
+        </td>
+        <td>
+          <select id="reviewPlatformSelection" ng-model="vm.settings.platformSelection" ng-options="code as name for (code, name) in vm.platformOptions"></select>
+        </td>
+      </tr>
       <tr>
         <td>
           <label for="itemSort" ng-i18next="Settings.SetSort"></label>

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -86,13 +86,14 @@
       </tr>
       <tr ng-if="vm.settings.destinyVersion === 2 && (vm.settings.showReviews || vm.settings.allowIdPostToDtr)">
         <td>
-          <label for="reviewPlatformSelection" ng-i18next="Settings.PlatformSelection"></label>
+          <label for="reviewsPlatformSelection" ng-i18next="Settings.ReviewsPlatformSelection"></label>
         </td>
         <td>
-          <select id="reviewPlatformSelection"
-            ng-model="vm.settings.platformSelection"
-            ng-options="code as name for (code, name) in vm.platformOptions"
-            ng-change="vm.platformChanged()"></select>
+          <select id="reviewsPlatformSelection"
+            ng-model="vm.settings.reviewsPlatformSelection"
+            ng-options="code as name for (code, name) in vm.reviewsPlatformOptions"
+            ng-change="vm.reviewsPlatformChanged()">
+          </select>
         </td>
       </tr>
       <tr>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -97,7 +97,15 @@
     "Submit": "Submit",
     "ThankYou": "Thank you for submitting a review! It will go live shortly.",
     "VerifyReport": "Are you sure you want to flag this review?",
-    "YourReview": "Your Review"
+    "YourReview": "Your Review",
+    "BestRatedTip": "This perk is associated with high community ratings.",
+    "Platforms" : {
+      "All": "Show All",
+      "Xbox": "XBox Only",
+      "Playstation": "Playstation Only",
+      "AllConsoles": "All Consoles",
+      "Pc": "PC Only"
+    }
   },
   "FarmingMode": {
     "Configuration": "Configuration",
@@ -222,14 +230,7 @@
     "VideoExample": "For an even better example of how to use filters, watch this video on {{link}}",
     "WeaponClass": "Shows items based on their weapon classes.",
     "WeaponType": "Shows weapons based on their weapon type.",
-    "Year": "Shows items from which year of Destiny they appeared in.",
-    "Platforms" : {
-      "All": "Show All",
-      "Xbox": "XBox Only",
-      "Playstation": "Playstation Only",
-      "AllConsoles": "All Consoles",
-      "Pc": "PC Only"
-    }
+    "Year": "Shows items from which year of Destiny they appeared in."
   },
   "Header": {
     "About": "About",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -222,7 +222,14 @@
     "VideoExample": "For an even better example of how to use filters, watch this video on {{link}}",
     "WeaponClass": "Shows items based on their weapon classes.",
     "WeaponType": "Shows weapons based on their weapon type.",
-    "Year": "Shows items from which year of Destiny they appeared in."
+    "Year": "Shows items from which year of Destiny they appeared in.",
+    "Platforms" : {
+      "All": "Show All",
+      "Xbox": "XBox Only",
+      "Playstation": "Playstation Only",
+      "AllConsoles": "All Consoles",
+      "Pc": "PC Only"
+    }
   },
   "Header": {
     "About": "About",
@@ -486,6 +493,7 @@
     "InventoryColumns": "Character inventory width",
     "Language": "Language (reload DIM to take effect)",
     "LogOut": "Log out",
+    "PlatformSelection": "Only show ratings from the following platforms",
     "ResetToDefault": "Reset",
     "SetSort": "Sort items by",
     "Settings": "Settings",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -493,7 +493,7 @@
     "InventoryColumns": "Character inventory width",
     "Language": "Language (reload DIM to take effect)",
     "LogOut": "Log out",
-    "PlatformSelection": "Only show ratings from the following platforms",
+    "PlatformSelection": "Only show ratings from the following platform",
     "ResetToDefault": "Reset",
     "SetSort": "Sort items by",
     "Settings": "Settings",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -90,6 +90,13 @@
     "HelpCons": "Describe the negatives of this weapon (optional)",
     "HelpPros": "Describe the positives of this weapon (optional)",
     "NoReviews": "There are no reviews for this item, be the first!",
+    "Platforms" : {
+      "All": "Show All",
+      "Xbox": "XBox Only",
+      "Playstation": "Playstation Only",
+      "AllConsoles": "All Consoles",
+      "Pc": "PC Only"
+    },
     "Pros": "Pros",
     "ReallyReport": "Report",
     "ServiceCallError": "Destiny tracker service call failed.",
@@ -97,15 +104,7 @@
     "Submit": "Submit",
     "ThankYou": "Thank you for submitting a review! It will go live shortly.",
     "VerifyReport": "Are you sure you want to flag this review?",
-    "YourReview": "Your Review",
-    "BestRatedTip": "This perk is associated with high community ratings.",
-    "Platforms" : {
-      "All": "Show All",
-      "Xbox": "XBox Only",
-      "Playstation": "Playstation Only",
-      "AllConsoles": "All Consoles",
-      "Pc": "PC Only"
-    }
+    "YourReview": "Your Review"
   },
   "FarmingMode": {
     "Configuration": "Configuration",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -493,7 +493,7 @@
     "InventoryColumns": "Character inventory width",
     "Language": "Language (reload DIM to take effect)",
     "LogOut": "Log out",
-    "PlatformSelection": "Only show ratings from the following platform",
+    "ReviewsPlatformSelection": "Only show ratings from the following platform",
     "ResetToDefault": "Reset",
     "SetSort": "Sort items by",
     "Settings": "Settings",


### PR DESCRIPTION
In the settings menu, if you're working with a Destiny 2 character and either ratings or reviews are turned on, we also present you the option of filtering down what platform(s) you want to get reviews from. The API was modified to support the options you see.

If no platform is selected (which is the default), it returns reviews from people on all platforms, same as it does now.

![shouts-to-my-mouse-heads](https://user-images.githubusercontent.com/606888/32587418-43d63130-c4d6-11e7-85df-6f42cff8f2a7.png)
