### PR TITLE
Hiding solo ratings in D2

### DIFF
--- a/src/app/inventory/dimSimpleItem.directive.html
+++ b/src/app/inventory/dimSimpleItem.directive.html
@@ -8,7 +8,7 @@
   <div ng-if="vm.item.quality"
        class="item-stat item-quality"
        ng-style="vm.item.quality.min | qualityColor">{{ vm.item.quality.min }}%</div>
-  <div ng-if="vm.item.dtrRating && (vm.item.dtrRatingCount > (vm.item.destinyVersion == 2 ? 0 : 1) || vm.item.dtrHighlightedRatingCount > 0)"
+  <div ng-if="vm.item.dtrRating && (vm.item.dtrRatingCount > 1 || vm.item.dtrHighlightedRatingCount > 0)"
        class="item-stat item-review">{{ vm.item.dtrRating }}<i class="fa fa-star"
                                                                ng-style="vm.item.dtrRating | dtrRatingColor"></i></div>
   <div class="item-stat item-equipment"


### PR DESCRIPTION
After we got a decent body of ratings in D1, I added this to filter away ratings where only one (non-highlighted) rating existed on an item from the view, so that the weapon that only one person thought was amazing (something I was guilty of!) didn't grab your attention.

I initially allowed any rating to show, but we've gotten enough that it's time to ask for a little consensus before showing again.