### PR TITLE
Added net neutrality popup.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Added Net Neutrality popup.
+
 # 4.25.0
 
 # 4.24.1

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -476,7 +476,7 @@ AddDefaultCharset utf-8
 
 <IfModule mod_headers.c>
 
-    Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' https://apis.google.com https://www.google-analytics.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css; connect-src 'self' https://beta.destinyitemmanager.com https://www.bungie.net https://reviews-api.destinytracker.net https://db-api.destinytracker.com; img-src 'self' https://www.bungie.net https://ssl.google-analytics.com https://www.google-analytics.com https://csi.gstatic.com https://opencollective.com data:; font-src 'self' https://fonts.gstatic.com; child-src 'self' https://accounts.google.com https://content.googleapis.com; object-src 'self'; manifest-src 'self'"
+    Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' https://apis.google.com https://www.google-analytics.com https://widget.battleforthenet.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css; connect-src 'self' https://beta.destinyitemmanager.com https://www.bungie.net https://reviews-api.destinytracker.net https://db-api.destinytracker.com; img-src 'self' https://www.bungie.net https://ssl.google-analytics.com https://www.google-analytics.com https://csi.gstatic.com https://opencollective.com data:; font-src 'self' https://fonts.gstatic.com; child-src 'self' https://accounts.google.com https://content.googleapis.com; object-src 'self'; manifest-src 'self'"
 
     # `mod_headers` cannot match based on the content-type, however,
     # the `Content-Security-Policy` response header should be send

--- a/src/index.html
+++ b/src/index.html
@@ -50,4 +50,28 @@
     <script type="text/javascript" src="{{ webpackConfig.output.publicPath }}{{ this }}"></script>
     {{/each}}
   </body>
+  <script type="text/javascript">
+    var _bftn_options = {
+
+      /*
+       * Specify view cookie expiration. After initial view, modal will not be
+       * displayed to a user again until after this cookie expires. Defaults to one
+       * day.
+       */
+      viewCookieExpires: 1000, // @type {number}
+
+      /*
+       * Specify action cookie expiration. After initiating a call or clicking a
+       * donate link, modal will not be displayed to a user again until after this
+       * cookie expires. Defaults to one week.
+       */
+      actionCookieExpires: 1000, // @type {number}
+
+      /*
+       * Always show the widget. Useful for testing.
+       */
+      always_show_widget: false // @type {boolean}
+    };
+  </script>
+  <script src="https://widget.battleforthenet.com/widget.js" async></script>
 </html>


### PR DESCRIPTION
Creates an effectively one time popup for the net neutrality push going on atm.  Dismissing the popup will set a cookie that prevents it from showing for 1000 days. Here's a preview for mobile and desktop.

![2017-11-21_210118](https://user-images.githubusercontent.com/984608/33108405-9331c778-cf01-11e7-9b53-556c011f251e.png)
![2017-11-21_205820](https://user-images.githubusercontent.com/984608/33108406-93461d68-cf01-11e7-919e-0df3b946d482.png)
