### PR TITLE
Applying downward pressure on ratings.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * NEW - Move items from the postmaster in DIM!
+* Revamped rating algorithm for D2 items.
 
 # 4.27.1
 

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.js
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.js
@@ -81,11 +81,7 @@ class D2BulkFetcher {
 
     const self = this;
 
-    if (bulkRankings) {
-      bulkRankings.forEach((bulkRanking) => {
-        self._reviewDataCache.addScore(bulkRanking);
-      });
-    }
+    this._reviewDataCache.addScores(bulkRankings);
 
     stores.forEach((store) => {
       store.items.forEach((storeItem) => {

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.js
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.js
@@ -12,6 +12,7 @@ class D2ReviewDataCache {
   constructor() {
     this._itemTransformer = new D2ItemTransformer();
     this._itemStores = [];
+    this._maxTotalVotes = 0;
   }
 
   _getMatchingItem(item) {
@@ -45,15 +46,15 @@ class D2ReviewDataCache {
   }
 
   _getDownvoteMultiplier(dtrRating) {
-    if (dtrRating.votes.total > 300) {
+    if (dtrRating.votes.total > (this._maxTotalVotes * .75)) {
       return 1.0;
     }
 
-    if (dtrRating.votes.total > 200) {
+    if (dtrRating.votes.total > (this._maxTotalVotes * .50)) {
       return 1.5;
     }
 
-    if (dtrRating.votes.total > 100) {
+    if (dtrRating.votes.total > (this._maxTotalVotes * .25)) {
       return 2.0;
     }
 
@@ -73,6 +74,27 @@ class D2ReviewDataCache {
     return rating;
   }
 
+  _setMaximumTotalVotes(bulkRankings) {
+    this._maxTotalVotes = _.max(_.pluck(_.pluck(bulkRankings, 'votes'), 'total'));
+  }
+
+  /**
+   * Add (and track) the community scores.
+   *
+   * @param {List<DtrRating>} dtrRating
+   *
+   * @memberof ReviewDataCache
+   */
+  addScores(bulkRankings) {
+    if (bulkRankings) {
+      this._setMaximumTotalVotes(bulkRankings);
+
+      bulkRankings.forEach((bulkRanking) => {
+        this._addScore(bulkRanking);
+      });
+    }
+  }
+
   /**
    * Add (and track) the community score.
    *
@@ -80,7 +102,7 @@ class D2ReviewDataCache {
    *
    * @memberof ReviewDataCache
    */
-  addScore(dtrRating) {
+  _addScore(dtrRating) {
     const score = this._getScore(dtrRating);
     dtrRating.rating = this._toAtMostOneDecimal(score);
 

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.js
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.js
@@ -44,11 +44,29 @@ class D2ReviewDataCache {
     return rating.toFixed(1);
   }
 
+  _getDownvoteMultiplier(dtrRating) {
+    if (dtrRating.votes.total > 300) {
+      return 1.0;
+    }
+
+    if (dtrRating.votes.total > 200) {
+      return 1.5;
+    }
+
+    if (dtrRating.votes.total > 100) {
+      return 2.0;
+    }
+
+    return 2.5;
+  }
+
   _getScore(dtrRating) {
-    const rating = (dtrRating.votes.upvotes / dtrRating.votes.total) * 5;
+    const downvoteMultipler = this._getDownvoteMultiplier(dtrRating);
+
+    const rating = ((dtrRating.votes.total - (dtrRating.votes.downvotes * downvoteMultipler)) / dtrRating.votes.total) * 5;
 
     if ((rating < 1) &&
-            (dtrRating.votes.total > 0)) {
+        (dtrRating.votes.total > 0)) {
       return 1;
     }
 


### PR DESCRIPTION
tl;dr - a repeated complaint is that everything is rated too highly, so I'm trying to achieve some separation in ratings.

We generally don't get a lot of downvotes on items, but we (ironically?) do get more of those on items popular in the meta.

I made the algo a little more sensitive to downvotes - we weight them more heavily, but the weighting we applies disappates as the number of total votes grows. Items people don't care much about that have a smattering of downvotes will look worse, items with oodles of reviews (good and bad) we'll report what the numbers give us.

A few before/after numbers (for PC platform ratings):

- Nameless Midnight
  - 4.9 / 4.9
- Better Devils
  - 4.9 / 4.9
- Hard Light
  - 4.7 / 4.5
- Uriel's Gift
  - 4.9 / 4.8
- Scathelocke
  - 4.9 / 4.9
- Lincoln Green
  - 4.6 / 4.1
- Skyburner's Oath
  - 3.7 / 1.8
- Sunshot
  - 5.0 / 5.0
- MIDA Multi-Tool
  - 4.2 / 4.2
- MIDA Mini-Tool
  - 4.6 / 3.9
- Inaugural Address
  - 4.3 / 3.3
- Tractor Cannon
  - 3.6 / 1.6