### PR TITLE
If an item's not equipped, don't try to unequip it again.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Fixed a bug trying to maximize power level (and sometimes transfer items) in Destiny 2.
 
 # 4.28.0
 

--- a/src/app/inventory/dimItemService.factory.js
+++ b/src/app/inventory/dimItemService.factory.js
@@ -738,7 +738,7 @@ export function ItemService(
           if (equip) {
             promise = promise.then((item) => (item.equipped ? item : equipItem(item)));
           } else if (!equip) {
-            promise = promise.then((item) => (item.equipped ? dequipItem(item) : moveToStore(item, target)));
+            promise = promise.then((item) => (item.equipped ? dequipItem(item) : item));
           }
         } else if (source.isVault && target.isVault) { // Vault to Vault
           // Do Nothing.


### PR DESCRIPTION
We were generating redundant TransferItem requests and getting DestinyItemNotFound errors in some cases (like maxing power level).