### PR TITLE
Vehicle, Ships and Emotes have exotic variations as well.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * NEW - Revamped rating algorithm for D2 items.
 * Fixed a bug trying to maximize power level (and sometimes transfer items) in Destiny 2.
 * When hovering over an icon, the name and type will be displayed
+* Allowing more exotic item types to be simultaneously equipped in Destiny 2
 
 # 4.29.0
 

--- a/src/app/inventory/store/d2-item-factory.service.js
+++ b/src/app/inventory/store/d2-item-factory.service.js
@@ -80,7 +80,7 @@ export function D2ItemFactory(
       return this.equipment || this.type === 'Material' || this.type === 'Consumable';
     },
     hasLifeExotic() {
-      return this.type === 'Ghost' && this.isExotic;
+      return (this.type === 'Ghost' || this.type === 'Vehicle' || this.type === 'Ships' || this.type === 'Emotes') && this.isExotic;
     }
   };
 


### PR DESCRIPTION
I've seen an error log from someone with an exotic ghost, emote and vehicle equipped that led to an ItemService.Deequip error being thrown when trying to process a loadout.

I don't have the inventory on hand to verify, but this should fix it. Hopefully.