### PR TITLE
Fix reporting reviews in Destiny 2.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * NEW - Revamped rating algorithm for D2 items.
 * Fixed a bug trying to maximize power level (and sometimes transfer items) in Destiny 2.
 * When hovering over an icon, the name and type will be displayed
+* Fixed reporting reviews in Destiny 2.
 
 # 4.29.0
 

--- a/src/app/destinyTrackerApi/d2-reviewReporter.js
+++ b/src/app/destinyTrackerApi/d2-reviewReporter.js
@@ -35,7 +35,7 @@ class D2ReviewReporter {
 
     return {
       reviewId: reviewId,
-      report: "",
+      text: "",
       reporter: reporter
     };
   }
@@ -71,7 +71,7 @@ class D2ReviewReporter {
       return;
     }
 
-    this._submitReportReviewPromise(review.reviewId, membershipInfo)
+    this._submitReportReviewPromise(review.id, membershipInfo)
         .then(this._reviewDataCache.markReviewAsIgnored(review))
         .then(this._ignoreReportedUser(review));
   }


### PR DESCRIPTION
I was pulling from the wrong value for review IDs in D2, so reports were failing.

Also, a vestigial informational field had the wrong name, so I touched that up too.