### PR TITLE
Adding omitted dependency which causes initial npm run server to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "clean-webpack-plugin": "^0.1.17",
     "copy-webpack-plugin": "^4.2.0",
     "css-loader": "^0.28.7",
+    "es-to-primitive": "^1.1.1",
     "eslint": "^4.9.0",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-angular": "^3.1.1",


### PR DESCRIPTION
Issue:
Following the steps at https://github.com/DestinyItemManager/DIM/blob/master/README.md, the initial npm run server will fail due to missing packages:

$ npm run server

dim@4.29.0 server xxxxxxx\repos\dim
webpack-dev-server --config ./config/webpack.js --env=dev

module.js:538
throw err;
^

Error: Cannot find module 'es-to-primitive/es6'
