### PR TITLE
Adding instruction detailing issues around npm install using Git Bash on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Install dependencies:
 * Install [NodeJS](https://nodejs.org/).
 * Windows-based developers will need to install `windows-build-tools` (`npm install --global windows-build-tools`) globally prior to running `npm install`. Refer to issue #1439 for [details](https://github.com/DestinyItemManager/DIM/issues/1439).
 * Run `npm install`.
+  * Note that on Windows, the Git Bash shell may fail to fetch all necessary packages even when run as Admin ([details](https://github.com/DestinyItemManager/DIM/issues/2487)). If that's the case, simply use cmd as Admin instead.
 
 Check code Style
 * `npm run lint` will tell you if you're following the DIM code style (and automatically fix what it can).

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "clean-webpack-plugin": "^0.1.17",
     "copy-webpack-plugin": "^4.2.0",
     "css-loader": "^0.28.7",
+    "es-to-primitive": "^1.1.1",
     "eslint": "^4.9.0",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-angular": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "clean-webpack-plugin": "^0.1.17",
     "copy-webpack-plugin": "^4.2.0",
     "css-loader": "^0.28.7",
-    "es-to-primitive": "^1.1.1",
     "eslint": "^4.9.0",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-angular": "^3.1.1",


### PR DESCRIPTION
`npm install` can fail to fetch all necessary dependencies when run from Git Bash on Windows even if the shell is ran as Admin.

This currently leads to issues getting es-to-primitive and is-regex which leads failures like the following when finally trying to `npm run server`. Any other shell seems to behave correctly (cmd is fine for example).

Adding info to help in the README.