### PR TITLE
Fresh masterworks gear has no kills tracked on it.

### DIFF
--- a/src/app/move-popup/dimMoveItemProperties.directive.js
+++ b/src/app/move-popup/dimMoveItemProperties.directive.js
@@ -103,7 +103,7 @@ function MoveItemPropertiesCtrl($sce, $q, dimStoreService, D2StoresService, dimI
     const item = vm.item;
 
     if (item.sockets) {
-      return _.find(_.pluck(item.sockets.sockets, 'masterworkProgress'), (mp) => mp > 0);
+      return _.find(_.pluck(item.sockets.sockets, 'masterworkProgress'), (mp) => mp >= 0);
     }
 
     return null;


### PR DESCRIPTION
I went to peek at a fresh masterworks weapon and the display was busted ("Masterworks - enemies defeated.")

![put-that-masterworks-to-use](https://user-images.githubusercontent.com/606888/34185757-33ed4698-e4f5-11e7-93ea-6dbbc1565b42.png)
