### PR TITLE
Searching for completed rare mod stacks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* "is:complete" will find completed rare mod stacks in Destiny 2.
 
 # 4.30.0
 

--- a/src/app/search/search-filters.js
+++ b/src/app/search/search-filters.js
@@ -94,7 +94,7 @@ export function buildSearchConfig(destinyVersion, itemTags, categories) {
     Object.assign(filterTrans, {
       hasLight: ['light', 'haslight', 'haspower'],
       powermod: ['powermod', 'haspowermod'],
-      complete: ['goldborder', 'yellowborder'],
+      complete: ['goldborder', 'yellowborder', 'complete'],
       masterwork: ['masterwork', 'masterworks']
     });
   }


### PR DESCRIPTION
A nice little QoL touch here - searching for is:complete now highlights completed rare mod stacks (as well as weapons with power mods attached).

The yellow border isn't super legible, but this is!

![render-unto-me-your-mod-stacks](https://user-images.githubusercontent.com/606888/34258197-e36a0e7c-e62a-11e7-9e63-9ecc9e5f4fed.PNG)
