### PR TITLE
Masterworks display visual improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Slightly tweaked visuals of displaying masterworks weapons and stats
 
 # 4.31.0
 * "is:complete" will find completed rare mod stacks in Destiny 2.

--- a/src/app/inventory/dimStoreItem.scss
+++ b/src/app/inventory/dimStoreItem.scss
@@ -99,6 +99,15 @@ dim-store-item {
   }
   &.masterwork {
     border-color: $gold;
+
+    &::after {
+      content: '';
+      display: block;
+      width: 0;
+      height: 0;
+      margin: calc(100% + 6px) auto;
+      box-shadow: 0 0 25px 18px $orange;
+    }
   }
 }
 

--- a/src/app/move-popup/dimMoveItemProperties.html
+++ b/src/app/move-popup/dimMoveItemProperties.html
@@ -49,7 +49,7 @@
       <form ng-if="vm.item.taggable" name="notes"><textarea name="data" ng-i18next="[placeholder]Notes.Help" ng-maxlength="120" ng-model="vm.item.dimInfo.notes" ng-model-options="{ debounce: 250 }" ng-change="vm.updateNote()"></textarea></form>
       <span class="textarea-error" ng-show="notes.data.$error.maxlength" ng-i18next="Notes.Error"></span>
       <div class="item-description" ng-if="vm.showDescription" ng-bind="::vm.item.description"></div>
-      <div class="masterwork-progress" ng-if="vm.item.masterwork" ng-i18next="[i18next]({ progress: vm.masterworkProgress() })ItemService.MasterworkProgress"></div>
+      <div class="masterwork-progress" ng-if="vm.item.masterwork" ng-i18next="[html:i18next]({ progress: '<strong>' + vm.masterworkProgress() + '</strong>' })ItemService.MasterworkProgress"></div>
       <div class="item-details" ng-if="vm.item.classified" ng-i18next="ItemService.Classified2"></div>
       <dim-item-stats item="vm.item" class="stats" ng-if="vm.hasDetails"></dim-item-stats>
       <div class="item-details item-perks" ng-if="vm.item.talentGrid">

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -255,7 +255,13 @@ $item-header-spacing: 5px;
 }
 
 .masterwork-progress {
-  margin: 5px 10px;
+  margin: 4px 0px;
+  padding: 3px 10px;
+  background: #333;
+
+  strong {
+    color: orange;
+  }
 }
 
 .item-perks {


### PR DESCRIPTION
Slightly changed the visuals of the displayed masterworks weapons and their stats based on the destiny 2 visuals to make them slightly more visually separable from the rest of weapons and to make the stats more readable:

<img width="327" alt="masterworks" src="https://user-images.githubusercontent.com/1033103/34341851-883ebcfe-e9a0-11e7-8528-b05808c70748.png">
