### PR TITLE
Guessing at a bandaid for #2195

### DIFF
--- a/src/app/inventory/d2-stores.service.js
+++ b/src/app/inventory/d2-stores.service.js
@@ -175,6 +175,11 @@ export function D2StoresService(
 
         // TODO: components may be hidden (privacy)
 
+        if (!profileInfo.profileInventory.data || !profileInfo.characterInventories.data) {
+          console.error("Vault or character inventory was missing - bailing in order to avoid corruption");
+          throw new Error($i18next.t('BungieService.Difficulties'));
+        }
+
         const processVaultPromise = processVault(defs,
           profileInfo.profileInventory.data ? profileInfo.profileInventory.data.items : [],
           profileInfo.profileCurrencies.data ? profileInfo.profileCurrencies.data.items : [],


### PR DESCRIPTION
I still haven't seen the "empty vault" thing happen to me, but here's a bandaid that might fix it - if the `data` attribute is missing for either vault or profile inventories, bail early rather than accidentally wipe things out. We'll say "Bungie.net is having difficulties" since it seems to happen during maintenance. I'm slightly worried this might affect people with a completely empty profile inventory (no vault, no shaders, no mods, no consumables, no nothing) but that should be pretty rare except maybe when they just start?