### PR TITLE
Fix masterwork CSS and remove border

### DIFF
--- a/src/app/inventory/dimStoreItem.scss
+++ b/src/app/inventory/dimStoreItem.scss
@@ -98,15 +98,19 @@ dim-store-item {
     padding: 2px;
   }
   &.masterwork {
-    border-color: $gold;
+    overflow: hidden;
 
     &::after {
+      $size: 28px;
       content: '';
       display: block;
-      width: 0;
-      height: 0;
-      margin: calc(100% + 6px) auto;
-      box-shadow: 0 0 25px 18px $orange;
+      width: $size;
+      height: $size;
+      position: relative;
+      left: calc(50% - #{$size / 2});
+      top: calc(100% - #{$size / 2});
+      background-color: $orange;
+      filter: blur(8px);
     }
   }
 }

--- a/src/app/inventory/dimStoreItem.scss
+++ b/src/app/inventory/dimStoreItem.scss
@@ -105,10 +105,10 @@ dim-store-item {
       content: '';
       display: block;
       width: $size;
-      height: $size;
+      height: $size + 14px;
       position: relative;
       left: calc(50% - #{$size / 2});
-      top: calc(100% - #{$size / 2});
+      bottom: -1 * $size + 4px;
       background-color: $orange;
       filter: blur(8px);
     }


### PR DESCRIPTION
This fixes #2515 and makes the glow look the same on Safari and Chrome (it didn't before). I also removed the border as in @duckmanBR's PR #2516 since the glow is now obvious enough on its own (which makes it easier to see modded masterworks).