### PR TITLE
Add DestinySets and VendorEngrams.xyz to header

### DIFF
--- a/src/app/shell/header.html
+++ b/src/app/shell/header.html
@@ -54,6 +54,19 @@
          rel="noopener noreferrer"
          href="https://teespring.com/stores/dim"
          ng-i18next="Header.Shop"></a>
+
+      <hr>
+
+      <a class="link"
+         href="http://destinysets.com"
+         target="_blank"
+         rel="noopener noreferrer"
+         ng-if="$ctrl.destinyVersion == 2">DestinySets.com</a>
+      <a class="link"
+         target="_blank"
+         rel="noopener noreferrer"
+         href="http://vendorengrams.xyz"
+         ng-if="$ctrl.destinyVersion == 2">VendorEngrams.xyz</a>
     </div>
   </span>
 
@@ -106,6 +119,16 @@
   <span class="link second-to-go"
         ng-if="$ctrl.destinyVersion == 1 && $ctrl.xur.available"
         ng-click="$ctrl.showXur($event)">Xûr</span>
+  <a class="link first-to-go"
+     href="http://destinysets.com"
+     target="_blank"
+     rel="noopener noreferrer"
+     ng-if="$ctrl.destinyVersion == 2">DestinySets.com</a>
+  <a class="link first-to-go"
+     target="_blank"
+     rel="noopener noreferrer"
+     href="http://vendorengrams.xyz"
+     ng-if="$ctrl.destinyVersion == 2">VendorEngrams.xyz</a>
 
   <span class="header-right">
     <refresh


### PR DESCRIPTION
There are two other tools besides DIM that I use when playing D2 - DestinySets.com and VendorEngrams.xyz. Since I don't really want to duplicate them both inside DIM right now, I figure we should link out to them so DIM users know these tools exist.

/cc @joshhunt