### PR TITLE
Adds a reverse lookup to Infusion Fuel Finder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config/dim_travis.rsa
 .brackets.json
 .npmrc
 npm-debug.log
+.nvmrc

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Rotating to and from landscape and portrait should be faster.
 * Fix quest steps showing up in the "haspower" search.
 * Do a better job of figuring out what's infusable.
+* Added a reverse lookup to Infusion Fuel Finder.
 
 # 4.31.0
 

--- a/docs/TRANSLATIONS.md
+++ b/docs/TRANSLATIONS.md
@@ -28,7 +28,7 @@ There are two different roles available per language
 
 # Translators
 Using the 'Show' dropdown menu, select 'Untranslated'.
-Translate these to you language.
+Translate these to your language.
 
 As translations are changed they will automatically be marked as 'Fuzzy'.
 Using the 'Show' dropdown menu, select 'Fuzzy'.

--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -81,17 +81,15 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
         // and that you just always get the full value.
         // https://github.com/DestinyItemManager/DIM/issues/2215
         vm.infused = vm.target.basePower + (vm.source.primStat.value - vm.source.basePower);
+      } else if (vm.source.bucket.sort === 'General') {
+        vm.wildcardMaterialCost = 2;
+        vm.wildcardMaterialHash = 937555249;
+      } else if (vm.source.primStat.stat.statIdentifier === 'STAT_DAMAGE') {
+        vm.wildcardMaterialCost = 10;
+        vm.wildcardMaterialHash = 1898539128;
       } else {
-        if (vm.source.bucket.sort === 'General') {
-          vm.wildcardMaterialCost = 2;
-          vm.wildcardMaterialHash = 937555249;
-        } else if (vm.source.primStat.stat.statIdentifier === 'STAT_DAMAGE') {
-          vm.wildcardMaterialCost = 10;
-          vm.wildcardMaterialHash = 1898539128;
-        } else {
-          vm.wildcardMaterialCost = 10;
-          vm.wildcardMaterialHash = 1542293174;
-        }
+        vm.wildcardMaterialCost = 10;
+        vm.wildcardMaterialHash = 1542293174;
       }
 
       vm.result = angular.copy(vm.source);
@@ -111,7 +109,7 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
 
       // all stores
       let targetItems = flatMap(stores, (store) => {
-        let source = vm.query;
+        const source = vm.query;
 
         // all items in store
         return _.filter(store.items, (item) => {
@@ -135,7 +133,7 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
       });
 
       let sourceItems = flatMap(stores, (store) => {
-        let target = vm.query;
+        const target = vm.query;
 
         return _.filter(store.items, (item) => {
           return item.primStat &&

--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -130,7 +130,9 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
           return -((item.basePower || item.primStat.value) +
                   (item.talentGrid ? ((item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5) : 0));
         });
-      };
+
+        vm.targetItems = targetItems;
+      }
 
       let sourceItems = flatMap(stores, (store) => {
         const target = vm.query;
@@ -154,7 +156,6 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
       });
 
       vm.sourceItems = sourceItems;
-      vm.targetItems = targetItems;
 
       vm.target = null;
       vm.infused = 0;

--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -140,6 +140,7 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
         return _.filter(store.items, (item) => {
           return item.primStat &&
             item.year !== 1 &&
+            item.infusable &&
             (!item.locked || vm.showLockedItems) &&
             (target.destinyVersion === 1
               ? (item.type === target.type)

--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -7,7 +7,7 @@ import './infuse.scss';
 export const InfuseComponent = {
   template,
   bindings: {
-    source: '<'
+    query: '<'
   },
   controller: InfuseCtrl,
   controllerAs: 'vm'
@@ -19,7 +19,7 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
   const vm = this;
 
   vm.items = {};
-  if (vm.source.destinyVersion === 1) {
+  if (vm.query.destinyVersion === 1) {
     dimDefinitions.getDefinitions().then((defs) => {
       [
         452597397,
@@ -40,16 +40,17 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
     target: null,
     exotic: false,
     infused: 0,
-    infusable: [],
+    sourceItems: [],
+    targetItems: [],
     transferInProgress: false,
 
     $onInit: function() {
       // Set the source and reset the targets
       vm.infused = 0;
       vm.target = null;
-      vm.exotic = vm.source.tier === 'Exotic';
-      vm.stat = vm.source.primStat.stat;
-      if (vm.source.bucket.sort === 'General') {
+      vm.exotic = vm.query.tier === 'Exotic';
+      vm.stat = vm.query.primStat.stat;
+      if (vm.query.bucket.sort === 'General') {
         vm.wildcardMaterialCost = 2;
         vm.wildcardMaterialHash = 937555249;
       } else if (vm.stat.statIdentifier === 'STAT_DAMAGE') {
@@ -63,11 +64,17 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
       vm.getItems();
     },
 
-    selectItem: function(item, e) {
+    selectItem: function(item, isTarget, e) {
       if (e) {
         e.stopPropagation();
       }
-      vm.target = item;
+      if (isTarget) {
+        vm.target = item;
+        vm.source = vm.query;
+      } else {
+        vm.target = vm.query;
+        vm.source = item;
+      }
       vm.infused = vm.target.primStat.value;
 
       if (vm.source.destinyVersion === 2) {
@@ -87,21 +94,26 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
         // https://github.com/DestinyItemManager/DIM/issues/2215
         vm.infused = vm.target.basePower + (vm.source.primStat.value - vm.source.basePower);
       }
+
+      vm.result = angular.copy(vm.source);
+      vm.result.primStat.value = vm.infused;
     },
 
     // get Items for infusion
     getItems: function() {
-      let stores = vm.source.destinyVersion === 1 ? dimStoreService.getStores() : D2StoresService.getStores();
+      let stores = vm.query.destinyVersion === 1 ? dimStoreService.getStores() : D2StoresService.getStores();
 
       // If we want ALL our weapons, including vault's one
       if (!vm.getAllItems) {
         stores = _.filter(stores, (store) => {
-          return store.id === vm.source.owner;
+          return store.id === vm.query.owner;
         });
       }
 
       // all stores
-      let allItems = flatMap(stores, (store) => {
+      let targetItems = flatMap(stores, (store) => {
+        let source = vm.query;
+
         // all items in store
         return _.filter(store.items, (item) => {
           if (item.name === 'Rat King') {
@@ -110,26 +122,44 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
           return item.primStat &&
             item.year !== 1 &&
             (!item.locked || vm.showLockedItems) &&
-            (vm.source.destinyVersion === 1
-              ? (item.type === vm.source.type)
-              : (item.infusionQuality && (item.infusionQuality.infusionCategoryHashes.some((h) => vm.source.infusionQuality.infusionCategoryHashes.includes(h))))) &&
-            ((item.destinyVersion === 1 && item.primStat.value > vm.source.primStat.value) ||
-             (item.destinyVersion === 2 && item.basePower > vm.source.basePower));
+            (source.destinyVersion === 1
+              ? (item.type === source.type)
+              : (item.infusionQuality && (item.infusionQuality.infusionCategoryHashes.some((h) => source.infusionQuality.infusionCategoryHashes.includes(h))))) &&
+            ((item.destinyVersion === 1 && item.primStat.value > source.primStat.value) ||
+             (item.destinyVersion === 2 && item.basePower > source.basePower));
         });
       });
 
-      allItems = _.sortBy(allItems, (item) => {
+      targetItems = _.sortBy(targetItems, (item) => {
         return -((item.basePower || item.primStat.value) +
                  (item.talentGrid ? ((item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5) : 0));
       });
 
-      vm.infusable = allItems;
-      if (allItems.length) {
-        vm.selectItem(allItems[allItems.length - 1]);
-      } else {
-        vm.target = null;
-        vm.infused = 0;
-      }
+      let sourceItems = flatMap(stores, (store) => {
+        let target = vm.query;
+
+        return _.filter(store.items, (item) => {
+          return item.primStat &&
+            item.year !== 1 &&
+            (!item.locked || vm.showLockedItems) &&
+            (target.destinyVersion === 1
+              ? (item.type === target.type)
+              : (item.infusionQuality && (item.infusionQuality.infusionCategoryHashes.some((h) => target.infusionQuality.infusionCategoryHashes.includes(h))))) &&
+              ((item.destinyVersion === 1 && item.primStat.value < target.primStat.value) ||
+               (item.destinyVersion === 2 && item.basePower < target.basePower));
+        });
+      });
+
+      sourceItems = _.sortBy(sourceItems, (item) => {
+        return -((item.basePower || item.primStat.value) +
+                 (item.talentGrid ? ((item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5) : 0));
+      });
+
+      vm.sourceItems = sourceItems;
+      vm.targetItems = targetItems;
+
+      vm.target = null;
+      vm.infused = 0;
     },
 
     closeDialog: function() {
@@ -137,11 +167,14 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
     },
 
     transferItems: function() {
-      if (vm.target.notransfer) {
-        toaster.pop('error', $i18next.t('Infusion.NoTransfer', { target: vm.target.name }));
+      if (vm.target.notransfer || vm.source.notransfer) {
+        const name = vm.source.notransfer ? vm.source.name : vm.target.name;
+
+        toaster.pop('error', $i18next.t('Infusion.NoTransfer', { target: name }));
         return $q.resolve();
       }
-      const store = (vm.source.destinyVersion === 1 ? dimStoreService : D2StoresService).getStore(vm.source.owner);
+
+      const store = (vm.source.destinyVersion === 1 ? dimStoreService : D2StoresService).getStore(vm.query.owner);
       const items = {};
       const targetKey = vm.target.type.toLowerCase();
       items[targetKey] = items[targetKey] || [];

--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -107,30 +107,30 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
         });
       }
 
-      // all stores
-      let targetItems = flatMap(stores, (store) => {
-        const source = vm.query;
+      if (vm.query.infusable) {
+        let targetItems = flatMap(stores, (store) => {
+          const source = vm.query;
 
-        // all items in store
-        return _.filter(store.items, (item) => {
-          if (item.name === 'Rat King') {
-            console.log(item.name, item.infusionQuality);
-          }
-          return item.primStat &&
-            item.year !== 1 &&
-            (!item.locked || vm.showLockedItems) &&
-            (source.destinyVersion === 1
-              ? (item.type === source.type)
-              : (item.infusionQuality && (item.infusionQuality.infusionCategoryHashes.some((h) => source.infusionQuality.infusionCategoryHashes.includes(h))))) &&
-            ((item.destinyVersion === 1 && item.primStat.value > source.primStat.value) ||
-             (item.destinyVersion === 2 && item.basePower > source.basePower));
+          return _.filter(store.items, (item) => {
+            if (item.name === 'Rat King') {
+              console.log(item.name, item.infusionQuality);
+            }
+            return item.primStat &&
+              item.year !== 1 &&
+              (!item.locked || vm.showLockedItems) &&
+              (source.destinyVersion === 1
+                ? (item.type === source.type)
+                : (item.infusionQuality && (item.infusionQuality.infusionCategoryHashes.some((h) => source.infusionQuality.infusionCategoryHashes.includes(h))))) &&
+              ((item.destinyVersion === 1 && item.primStat.value > source.primStat.value) ||
+              (item.destinyVersion === 2 && item.basePower > source.basePower));
+          });
         });
-      });
 
-      targetItems = _.sortBy(targetItems, (item) => {
-        return -((item.basePower || item.primStat.value) +
-                 (item.talentGrid ? ((item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5) : 0));
-      });
+        targetItems = _.sortBy(targetItems, (item) => {
+          return -((item.basePower || item.primStat.value) +
+                  (item.talentGrid ? ((item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5) : 0));
+        });
+      };
 
       let sourceItems = flatMap(stores, (store) => {
         const target = vm.query;

--- a/src/app/infuse/infuse.component.js
+++ b/src/app/infuse/infuse.component.js
@@ -37,8 +37,8 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
   angular.extend(vm, {
     getAllItems: true,
     showLockedItems: false,
+    source: null,
     target: null,
-    exotic: false,
     infused: 0,
     sourceItems: [],
     targetItems: [],
@@ -48,18 +48,6 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
       // Set the source and reset the targets
       vm.infused = 0;
       vm.target = null;
-      vm.exotic = vm.query.tier === 'Exotic';
-      vm.stat = vm.query.primStat.stat;
-      if (vm.query.bucket.sort === 'General') {
-        vm.wildcardMaterialCost = 2;
-        vm.wildcardMaterialHash = 937555249;
-      } else if (vm.stat.statIdentifier === 'STAT_DAMAGE') {
-        vm.wildcardMaterialCost = 10;
-        vm.wildcardMaterialHash = 1898539128;
-      } else {
-        vm.wildcardMaterialCost = 10;
-        vm.wildcardMaterialHash = 1542293174;
-      }
 
       vm.getItems();
     },
@@ -93,6 +81,17 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
         // and that you just always get the full value.
         // https://github.com/DestinyItemManager/DIM/issues/2215
         vm.infused = vm.target.basePower + (vm.source.primStat.value - vm.source.basePower);
+      } else {
+        if (vm.source.bucket.sort === 'General') {
+          vm.wildcardMaterialCost = 2;
+          vm.wildcardMaterialHash = 937555249;
+        } else if (vm.source.primStat.stat.statIdentifier === 'STAT_DAMAGE') {
+          vm.wildcardMaterialCost = 10;
+          vm.wildcardMaterialHash = 1898539128;
+        } else {
+          vm.wildcardMaterialCost = 10;
+          vm.wildcardMaterialHash = 1542293174;
+        }
       }
 
       vm.result = angular.copy(vm.source);
@@ -195,7 +194,7 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
           amount: 2,
           equipped: false
         });
-      } else if (vm.stat.statIdentifier === 'STAT_DAMAGE') {
+      } else if (vm.source.primStat.stat.statIdentifier === 'STAT_DAMAGE') {
         // Weapon Parts
         items.material.push({
           id: '0',
@@ -212,7 +211,7 @@ function InfuseCtrl($scope, dimStoreService, D2StoresService, dimDefinitions, D2
           equipped: false
         });
       }
-      if (vm.exotic) {
+      if (vm.source.isExotic) {
         // Exotic shard
         items.material.push({
           id: '0',

--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -4,16 +4,16 @@
     <div class="infuseHeader">
 
       <div class="infuseSourceItemInfo">
-        <dim-simple-item item-data="vm.source"></dim-simple-item>
+        <dim-simple-item item-data="vm.query"></dim-simple-item>
 
         <div class="infuseSourceDetailsRow">
-          <div><strong>{{ vm.source.name }}</strong></div>
-          <div>{{ vm.source.destinyVersion === 1 ? vm.source.type : vm.source.typeName }}</div>
+          <div><strong>{{ vm.query.name }}</strong></div>
+          <div>{{ vm.query.destinyVersion === 1 ? vm.query.type : vm.query.typeName }}</div>
         </div>
 
         <div class="infuseSourceDetailsRow">
           <div>{{ vm.stat.statName }}</div>
-          <div class="bigValue">{{ vm.source.primStat.value }}</div>
+          <div class="bigValue">{{ vm.query.primStat.value }}</div>
         </div>
       </div>
 
@@ -24,31 +24,54 @@
 
     </div>
 
-    <div class="gearsContainer grey infuseTargets">
-      <span ng-if="!vm.infusable.length"><strong ng-i18next="Infusion.NoItems"></strong></span>
-      <span ng-if="vm.infusable.length" ng-i18next="Infusion.InfuseItems"></span>
-      <div ng-repeat="value in vm.infusable track by value.index">
-        <dim-simple-item ng-class="{ 'infuse-selected': value == vm.target }" item-data="value" ng-click="vm.selectItem(value, $event)"></dim-simple-item>
+    <div class="gearsContainer grey infuseSelector">
+      <div class="infuseTargets">
+        <span ng-if="!vm.targetItems.length"><strong ng-i18next="Infusion.NoItems"></strong></span>
+        <span ng-if="vm.targetItems.length" ng-i18next="[i18next]({name: vm.query.name})Infusion.InfuseTarget"></span>
+        <div class="itemGrid">
+          <div ng-repeat="value in vm.targetItems track by value.index">
+            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.target }" item-data="value" ng-click="vm.selectItem(value, true, $event)"></dim-simple-item>
+          </div>
+        </div>
+      </div>
+      <div class="infuseSeparator">
+        <span></span>
+      </div>
+      <div class="infuseSources">
+        <span ng-if="!vm.sourceItems.length"><strong ng-i18next="Infusion.NoItems"></strong></span>
+        <span ng-if="vm.sourceItems.length" ng-i18next="[i18next]({name: vm.query.name})Infusion.InfuseSource"></span>
+        <div class="itemGrid">
+          <div ng-repeat="value in vm.sourceItems track by value.index">
+            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.source }" item-data="value" ng-click="vm.selectItem(value, false, $event)"></dim-simple-item>
+          </div>
+        </div>
+      </div>
       </div>
     </div>
 
     <div class="gearsContainer black">
       <div ng-show="vm.infused != 0">
-        <dim-simple-item class="infusedItem" item-data="vm.target"></dim-simple-item>
-        <div class="result">
-          <div>
-            <div ng-i18next="Infusion.BringGear"></div>
-            <span class="bigValue">{{ vm.infused }}</span>
-            <span class="green">(+ {{ vm.infused - vm.source.primStat.value }})</span>
+        <div class="infusionPlan">
+          <dim-simple-item class="infusedItem" item-data="vm.source"></dim-simple-item>
+          <div class="icon"><i class="fa fa-plus" aria-hidden="true"></i></div>
+          <dim-simple-item class="infusedItem" item-data="vm.target"></dim-simple-item>
+          <div class="icon"><i class="fa fa-arrow-right" aria-hidden="true"></i></div>
+          <dim-simple-item class="infusedItem" item-data="vm.result"></dim-simple-item>
+          <div class="result">
+            <div>
+              <div ng-i18next="[i18next]({name: vm.source.name})Infusion.BringGear"></div>
+              <span class="bigValue">{{ vm.infused }}</span>
+              <span class="green">(+ {{ vm.infused - vm.source.primStat.value }})</span>
+            </div>
+            <div ng-if="vm.query.destinyVersion === 1">
+              <span> 3 <span class="currency"><img alt="{{ ::vm.items[2534352370].itemName }}" title="{{ ::vm.items[2534352370].itemName }}" ng-src="{{ vm.items[2534352370].icon | bungieIcon }}"></span></span>
+              <span ng-if="vm.exotic"> + 1 <span class="currency"><img alt="{{ ::vm.items[452597397].itemName }}" title="{{ ::vm.items[452597397].itemName }}" ng-src="{{ vm.items[452597397].icon | bungieIcon }}"></span></span>
+              <span> + 250 <span class="currency"><img alt="{{ ::vm.items[3159615086].itemName }}" title="{{ ::vm.items[3159615086].itemName }}" ng-src="{{ vm.items[3159615086].icon | bungieIcon }}"></span></span>
+              <span> + {{ vm.wildcardMaterialCost | number }} <span class="currency"><img alt="{{ ::vm.items[vm.wildcardMaterialHash].itemName }}" title="{{::vm.items[vm.wildcardMaterialHash].itemName }}" ng-src="{{ vm.items[vm.wildcardMaterialHash].icon | bungieIcon }}"></span></span>
+            </div>
           </div>
-          <div ng-if="vm.source.destinyVersion === 1">
-            <span> 3 <span class="currency"><img alt="{{ ::vm.items[2534352370].itemName }}" title="{{ ::vm.items[2534352370].itemName }}" ng-src="{{ vm.items[2534352370].icon | bungieIcon }}"></span></span>
-            <span ng-if="vm.exotic"> + 1 <span class="currency"><img alt="{{ ::vm.items[452597397].itemName }}" title="{{ ::vm.items[452597397].itemName }}" ng-src="{{ vm.items[452597397].icon | bungieIcon }}"></span></span>
-            <span> + 250 <span class="currency"><img alt="{{ ::vm.items[3159615086].itemName }}" title="{{ ::vm.items[3159615086].itemName }}" ng-src="{{ vm.items[3159615086].icon | bungieIcon }}"></span></span>
-            <span> + {{ vm.wildcardMaterialCost | number }} <span class="currency"><img alt="{{ ::vm.items[vm.wildcardMaterialHash].itemName }}" title="{{::vm.items[vm.wildcardMaterialHash].itemName }}" ng-src="{{ vm.items[vm.wildcardMaterialHash].icon | bungieIcon }}"></span></span>
-          </div>
-          <button ng-if="vm.getAllItems" ng-disabled="vm.transferInProgress" ng-click="vm.transferItems()" ng-i18next="Infusion.TransferItems" class="infuse-btn"></button>
         </div>
+        <button ng-if="vm.getAllItems" ng-disabled="vm.transferInProgress" ng-click="vm.transferItems()" ng-i18next="Infusion.TransferItems" class="infuse-btn"></button>
       </div>
     </div>
 

--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -31,7 +31,7 @@
         <span ng-if="vm.targetItems.length" ng-i18next="[i18next]({name: vm.query.name})Infusion.InfuseTarget"></span>
         <div class="itemGrid">
           <div ng-repeat="value in vm.targetItems track by value.index">
-            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.target }" item-data="value" ng-click="vm.selectItem(value, true, $event)"></dim-simple-item>
+            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.target }" item-data="value" ng-click="vm.setSourceAndTarget(vm.query, value, $event)"></dim-simple-item>
           </div>
         </div>
       </div>
@@ -43,7 +43,7 @@
         <span ng-if="vm.sourceItems.length" ng-i18next="[i18next]({name: vm.query.name})Infusion.InfuseSource"></span>
         <div class="itemGrid">
           <div ng-repeat="value in vm.sourceItems track by value.index">
-            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.source }" item-data="value" ng-click="vm.selectItem(value, false, $event)"></dim-simple-item>
+            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.source }" item-data="value" ng-click="vm.setSourceAndTarget(value, vm.query, $event)"></dim-simple-item>
           </div>
         </div>
       </div>

--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -52,11 +52,13 @@
     <div class="gearsContainer black">
       <div ng-show="vm.infused != 0">
         <div class="infusionPlan">
-          <dim-simple-item class="infusedItem" item-data="vm.source"></dim-simple-item>
-          <div class="icon"><i class="fa fa-plus" aria-hidden="true"></i></div>
-          <dim-simple-item class="infusedItem" item-data="vm.target"></dim-simple-item>
-          <div class="icon"><i class="fa fa-arrow-right" aria-hidden="true"></i></div>
-          <dim-simple-item class="infusedItem" item-data="vm.result"></dim-simple-item>
+          <div class="infusionEquation">
+            <dim-simple-item class="infusedItem" item-data="vm.source"></dim-simple-item>
+            <div class="icon"><i class="fa fa-plus" aria-hidden="true"></i></div>
+            <dim-simple-item class="infusedItem" item-data="vm.target"></dim-simple-item>
+            <div class="icon"><i class="fa fa-arrow-right" aria-hidden="true"></i></div>
+            <dim-simple-item class="infusedItem" item-data="vm.result"></dim-simple-item>
+          </div>
           <div class="result">
             <div>
               <div ng-i18next="[i18next]({name: vm.source.name})Infusion.BringGear"></div>

--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -65,7 +65,7 @@
             </div>
             <div ng-if="vm.query.destinyVersion === 1">
               <span> 3 <span class="currency"><img alt="{{ ::vm.items[2534352370].itemName }}" title="{{ ::vm.items[2534352370].itemName }}" ng-src="{{ vm.items[2534352370].icon | bungieIcon }}"></span></span>
-              <span ng-if="vm.exotic"> + 1 <span class="currency"><img alt="{{ ::vm.items[452597397].itemName }}" title="{{ ::vm.items[452597397].itemName }}" ng-src="{{ vm.items[452597397].icon | bungieIcon }}"></span></span>
+              <span ng-if="vm.source.isExotic"> + 1 <span class="currency"><img alt="{{ ::vm.items[452597397].itemName }}" title="{{ ::vm.items[452597397].itemName }}" ng-src="{{ vm.items[452597397].icon | bungieIcon }}"></span></span>
               <span> + 250 <span class="currency"><img alt="{{ ::vm.items[3159615086].itemName }}" title="{{ ::vm.items[3159615086].itemName }}" ng-src="{{ vm.items[3159615086].icon | bungieIcon }}"></span></span>
               <span> + {{ vm.wildcardMaterialCost | number }} <span class="currency"><img alt="{{ ::vm.items[vm.wildcardMaterialHash].itemName }}" title="{{::vm.items[vm.wildcardMaterialHash].itemName }}" ng-src="{{ vm.items[vm.wildcardMaterialHash].icon | bungieIcon }}"></span></span>
             </div>

--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -46,7 +46,6 @@
           </div>
         </div>
       </div>
-      </div>
     </div>
 
     <div class="gearsContainer black">

--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -26,7 +26,8 @@
 
     <div class="gearsContainer grey infuseSelector">
       <div class="infuseTargets">
-        <span ng-if="!vm.targetItems.length"><strong ng-i18next="Infusion.NoItems"></strong></span>
+        <span ng-if="!vm.query.infusable"><strong ng-i18next="Infusion.Uninfusable"></strong></span>
+        <span ng-if="vm.query.infusable && !vm.targetItems.length"><strong ng-i18next="Infusion.NoItems"></strong></span>
         <span ng-if="vm.targetItems.length" ng-i18next="[i18next]({name: vm.query.name})Infusion.InfuseTarget"></span>
         <div class="itemGrid">
           <div ng-repeat="value in vm.targetItems track by value.index">

--- a/src/app/infuse/infuse.scss
+++ b/src/app/infuse/infuse.scss
@@ -107,13 +107,20 @@
 
     .itemGrid {
       display: flex;
+      max-width: calc((var(--item-size) + 8px) * 5);
+      flex-wrap: wrap;
     }
 
     .infusionPlan {
       display: flex;
 
-      .icon {
-        align-self: center;
+      .infusionEquation {
+        display: flex;
+        height: calc(var(--item-size) + 8px + 6px);
+
+        .icon {
+          align-self: center;
+        }
       }
     }
   }
@@ -124,14 +131,10 @@
 
     .infuseSeparator {
       width: 1px;
-      margin: 15px 0;
+      margin: 15px 15px 0px 15px;
+      flex: none;
       background: white;
-      display: flex;
-      justify-content: center;
-      flex-direction: column;
-      text-align: center;
     }
   }
-
 }
 

--- a/src/app/infuse/infuse.scss
+++ b/src/app/infuse/infuse.scss
@@ -91,18 +91,47 @@
     padding: 10px 25px;
     overflow: hidden;
 
-    .item {
-      float: left;
-      margin: 3px 3px;
+    .resultContainer {
+      display: flex;
     }
+
     .infusedItem {
-      float: left;
-      margin: 3px 10px 3px 3px;
+      margin: 3px 3px 3px 3px;
     }
+
     .plusSeparator {
       float: left;
       margin-top: 5px;
       font-size: 32px;
     }
+
+    .itemGrid {
+      display: flex;
+    }
+
+    .infusionPlan {
+      display: flex;
+
+      .icon {
+        align-self: center;
+      }
+    }
   }
+
+  .infuseSelector {
+    justify-content: space-around;
+    display: flex;
+
+    .infuseSeparator {
+      width: 1px;
+      margin: 15px 0;
+      background: white;
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+      text-align: center;
+    }
+  }
+
 }
+

--- a/src/app/infuse/infuse.scss
+++ b/src/app/infuse/infuse.scss
@@ -4,17 +4,9 @@
   flex-direction: column;
   overflow: auto;
 
-  small {
-    font-size: 10px;
-  }
-
   .ngdialog-inner-content {
     padding-left: 0;
     padding-right: 0;
-  }
-
-  .locked {
-    position: absolute;
   }
 
   .bigValue {
@@ -24,10 +16,6 @@
 
   .infuseSourceDetailsRow {
     margin-left: 1rem;
-  }
-
-  .results {
-    margin-bottom: 2px;
   }
 
   .black {
@@ -47,26 +35,8 @@
     flex-direction: row;
   }
 
-  .infuseResults {
-    flex: 1;
-  }
-
   .infuse-selected {
     outline: 2px solid black !important;
-  }
-
-  .bestInfusion label {
-    display: inline;
-    margin-right: 22px;
-  }
-
-  .infuse-hidden {
-    opacity: 0.35;
-  }
-
-  .infuse-excluded {
-    filter: greyscale();
-    opacity: 0.15;
   }
 
   .infuse-btn {

--- a/src/app/inventory/store/d2-item-factory.service.js
+++ b/src/app/inventory/store/d2-item-factory.service.js
@@ -380,7 +380,7 @@ export function D2ItemFactory(
     const tier = itemDef.inventory ? defs.ItemTierType[itemDef.inventory.tierTypeHash] : null;
     createdItem.infusionProcess = tier && tier.infusionProcess;
     createdItem.infusionFuel = Boolean(createdItem.infusionProcess && itemDef.quality && itemDef.quality.infusionCategoryHashes && itemDef.quality.infusionCategoryHashes.length);
-    createdItem.infusable = createdItem.infusionFuel && isLegendaryOrBetter(createdItem)
+    createdItem.infusable = createdItem.infusionFuel && isLegendaryOrBetter(createdItem);
     createdItem.infusionQuality = itemDef.quality || null;
 
     // Mark items with power mods

--- a/src/app/inventory/store/d2-item-factory.service.js
+++ b/src/app/inventory/store/d2-item-factory.service.js
@@ -379,7 +379,8 @@ export function D2ItemFactory(
     // Infusion
     const tier = itemDef.inventory ? defs.ItemTierType[itemDef.inventory.tierTypeHash] : null;
     createdItem.infusionProcess = tier && tier.infusionProcess;
-    createdItem.infusable = Boolean(createdItem.infusionProcess && itemDef.quality && itemDef.quality.infusionCategoryHashes && itemDef.quality.infusionCategoryHashes.length);
+    createdItem.infusionFuel = Boolean(createdItem.infusionProcess && itemDef.quality && itemDef.quality.infusionCategoryHashes && itemDef.quality.infusionCategoryHashes.length);
+    createdItem.infusable = createdItem.infusionFuel && isLegendaryOrBetter(createdItem)
     createdItem.infusionQuality = itemDef.quality || null;
 
     // Mark items with power mods
@@ -406,6 +407,10 @@ export function D2ItemFactory(
   function isWeaponOrArmor(item) {
     return ((item.primStat.statHash === 1480404414) || // weapon
             (item.primStat.statHash === 3897883278)); // armor
+  }
+
+  function isLegendaryOrBetter(item) {
+    return (item.tier === 'Legendary' || item.tier === 'Exotic');
   }
 
   // Set an ID for the item that should be unique across all items

--- a/src/app/inventory/store/item-factory.service.js
+++ b/src/app/inventory/store/item-factory.service.js
@@ -354,6 +354,9 @@ export function ItemFactory(
 
     createdItem.infusable = createdItem.talentGrid && createdItem.talentGrid.infusable;
 
+    // An item can be used as infusion fuel if it is equipment, and has a primary stat that isn't Speed
+    createdItem.infusionFuel = Boolean(createdItem.equipment && createdItem.primStat && createdItem.primStat.statHash !== 1501155019);
+
     try {
       createdItem.stats = buildStats(item, itemDef, defs.Stat, createdItem.talentGrid, itemType);
 

--- a/src/app/move-popup/dimMovePopup.directive.html
+++ b/src/app/move-popup/dimMovePopup.directive.html
@@ -11,7 +11,7 @@
       ng-if="vm.item.destinyVersion === 1 && !vm.item.notransfer && vm.item.maxStackSize > 1" ng-click="vm.distribute()">
       <span ng-i18next="MovePopup.Split"></span>
     </div>
-    <div class="locations" ng-if="vm.item.infusable">
+    <div class="locations" ng-if="vm.item.infusionFuel">
       <div class="move-button infuse-perk" ng-class="[{ destiny2: vm.item.destinyVersion === 2}, vm.item.bucket.sort]" ng-click="vm.infuse(vm.item, $event)" ng-i18next="[title]Infusion.Infusion;[alt]Infusion.Calc"></div>
     </div>
   </div>

--- a/src/app/move-popup/dimMovePopup.directive.js
+++ b/src/app/move-popup/dimMovePopup.directive.js
@@ -39,7 +39,7 @@ function MovePopupController($scope, D2StoresService, dimStoreService, ngDialog,
 
     // Open the infuse window
     ngDialog.open({
-      template: '<infuse source="item"></infuse>',
+      template: '<infuse query="item"></infuse>',
       className: 'app-settings',
       appendClassName: 'modal-dialog',
       controller: function($scope) {

--- a/src/locale/de/dim.json
+++ b/src/locale/de/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Bringt die Ausrüstung auf:",
     "Calc": "Infusionsrechner",
-    "InfuseItems": "Item zum Infundieren auswählen:",
     "Infusion": "Finde Infusions-Material",
     "InfusionMaterials": "Infusions-Material",
     "LockedItems": "'Gesperrte' Items einbeziehen",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -267,9 +267,10 @@
     "ToggleDetails": "Toggle showing full item details"
   },
   "Infusion": {
-    "BringGear": "Will bring the gear to:",
+    "BringGear": "Will bring {{name}} to:",
     "Calc": "Infusion calculator",
-    "InfuseItems": "Select item to infuse with:",
+    "InfuseTarget": "Select item to infuse {{name}}:",
+    "InfuseSource": "Select item to infuse into; consumes {{name}}:",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "Infusion Materials",
     "LockedItems": "Include 'locked' items",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -277,7 +277,8 @@
     "NoItems": "No infusable items available.",
     "NoTransfer": "Transfer infusion material\n {{target}} cannot be moved.",
     "ShowItems": "Show infusable items across all characters and vault",
-    "TransferItems": "Transfer items"
+    "TransferItems": "Transfer items",
+    "Uninfusable": "This item cannot be infused."
   },
   "ItemInfoService": {
     "SaveInfoErrorDescription": "There's been a problem saving DIM-specific info for an item. One problem is that there is a limit on how much data can be stored - this is why tags and notes have not yet been allowed out of the Beta version. The error was: {{error}}.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -269,8 +269,8 @@
   "Infusion": {
     "BringGear": "Will bring {{name}} to:",
     "Calc": "Infusion calculator",
-    "InfuseTarget": "Select item to infuse {{name}}:",
     "InfuseSource": "Select item to infuse into; consumes {{name}}:",
+    "InfuseTarget": "Select item to infuse {{name}}:",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "Infusion Materials",
     "LockedItems": "Include 'locked' items",

--- a/src/locale/es-ES/dim.json
+++ b/src/locale/es-ES/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Traerá el equipo a:",
     "Calc": "Calculador de Infusión",
-    "InfuseItems": "Selecciona un objeto para infusionar:",
     "Infusion": "Buscador de Combustible de Infusión",
     "InfusionMaterials": "Materiales para Infusionar",
     "LockedItems": "Incluir objetos 'bloqueados'",

--- a/src/locale/es-MX/dim.json
+++ b/src/locale/es-MX/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Traerá el equipo a:",
     "Calc": "Calculador de Infusión",
-    "InfuseItems": "Selecciona un objeto para infusionar:",
     "Infusion": "Buscador de Combustible de Infusión",
     "InfusionMaterials": "Materiales para Infusionar",
     "LockedItems": "Incluir objetos 'bloqueados'",

--- a/src/locale/fr/dim.json
+++ b/src/locale/fr/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Cela amènera l'équipement à:",
     "Calc": "Calculateur d'infusion",
-    "InfuseItems": "Sélectionner un objet avec lequel infuser:",
     "Infusion": "Chercheur de Fuel à Infusion",
     "InfusionMaterials": "Matériels d'Infusion",
     "LockedItems": "Inclure les objets \"verrouillés\"",

--- a/src/locale/it/dim.json
+++ b/src/locale/it/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Porterà l'oggetto a:",
     "Calc": "Calcolatrice per Infusione",
-    "InfuseItems": "Seleziona oggetto da infondere con:",
     "Infusion": "Trova oggetti per infusione",
     "InfusionMaterials": "Materiali da Infusione",
     "LockedItems": "Include oggetti 'bloccati'",

--- a/src/locale/ja/dim.json
+++ b/src/locale/ja/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "装備を転送する:",
     "Calc": "融合計算機能",
-    "InfuseItems": "融合するアイテムを選択",
     "Infusion": "融合対象物発掘機能",
     "InfusionMaterials": "融合材料",
     "LockedItems": "ロックされているアイテムも含む",

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -269,7 +269,8 @@
   "Infusion": {
     "BringGear": "Will bring the gear to:",
     "Calc": "Infusion calculator",
-    "InfuseItems": "Select item to infuse with:",
+    "InfuseTarget": "Select item to infuse {{name}}:",
+    "InfuseSource": "Select item to infuse into; consumes {{name}}:",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "Infusion Materials",
     "LockedItems": "Include 'locked' items",

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -277,7 +277,8 @@
     "NoItems": "No infusable items available.",
     "NoTransfer": "Transfer infusion material\n {{target}} cannot be moved.",
     "ShowItems": "Show infusable items across all characters and vault",
-    "TransferItems": "Transfer items"
+    "TransferItems": "Transfer items",
+    "Uninfusable": "This item cannot be infused."
   },
   "ItemInfoService": {
     "SaveInfoErrorDescription": "There's been a problem saving DIM-specific info for an item. One problem is that there is a limit on how much data can be stored - this is why tags and notes have not yet been allowed out of the Beta version. The error was: {{error}}.",

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -269,8 +269,8 @@
   "Infusion": {
     "BringGear": "Will bring the gear to:",
     "Calc": "Infusion calculator",
-    "InfuseTarget": "Select item to infuse {{name}}:",
     "InfuseSource": "Select item to infuse into; consumes {{name}}:",
+    "InfuseTarget": "Select item to infuse {{name}}:",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "Infusion Materials",
     "LockedItems": "Include 'locked' items",

--- a/src/locale/pt-BR/dim.json
+++ b/src/locale/pt-BR/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Elevará o item para:",
     "Calc": "Calculadora de infusões",
-    "InfuseItems": "Selecione um item para infundir:",
     "Infusion": "Buscador de Item para Infusão",
     "InfusionMaterials": "Materiais de infusão",
     "LockedItems": "Incluir itens travados",

--- a/src/locale/ru/dim.json
+++ b/src/locale/ru/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Will bring the gear to:",
     "Calc": "Калькулятор синтеза",
-    "InfuseItems": "Выбрать предмет для Синтеза:",
     "Infusion": "Предметы доступные для Синтеза",
     "InfusionMaterials": "Материалы для Синтеза",
     "LockedItems": "Включая 'заблокированные' предметы",

--- a/src/locale/zh-CN/dim.json
+++ b/src/locale/zh-CN/dim.json
@@ -269,7 +269,6 @@
   "Infusion": {
     "BringGear": "Will bring the gear to:",
     "Calc": "灌注计算器",
-    "InfuseItems": "选择灌注材料：",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "灌注材料",
     "LockedItems": "包括 \"锁定\" 项目",

--- a/src/locale/zh-TW/dim.json
+++ b/src/locale/zh-TW/dim.json
@@ -269,7 +269,8 @@
   "Infusion": {
     "BringGear": "Will bring the gear to:",
     "Calc": "Infusion calculator",
-    "InfuseItems": "Select item to infuse with:",
+    "InfuseTarget": "Select item to infuse {{name}}:",
+    "InfuseSource": "Select item to infuse into; consumes {{name}}:",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "Infusion Materials",
     "LockedItems": "Include 'locked' items",

--- a/src/locale/zh-TW/dim.json
+++ b/src/locale/zh-TW/dim.json
@@ -277,7 +277,8 @@
     "NoItems": "No infusable items available.",
     "NoTransfer": "Transfer infusion material\n {{target}} cannot be moved.",
     "ShowItems": "Show infusable items across all characters and vault",
-    "TransferItems": "Transfer items"
+    "TransferItems": "Transfer items",
+    "Uninfusable": "This item cannot be infused."
   },
   "ItemInfoService": {
     "SaveInfoErrorDescription": "There's been a problem saving DIM-specific info for an item. One problem is that there is a limit on how much data can be stored - this is why tags and notes have not yet been allowed out of the Beta version. The error was: {{error}}.",

--- a/src/locale/zh-TW/dim.json
+++ b/src/locale/zh-TW/dim.json
@@ -269,8 +269,8 @@
   "Infusion": {
     "BringGear": "Will bring the gear to:",
     "Calc": "Infusion calculator",
-    "InfuseTarget": "Select item to infuse {{name}}:",
     "InfuseSource": "Select item to infuse into; consumes {{name}}:",
+    "InfuseTarget": "Select item to infuse {{name}}:",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "Infusion Materials",
     "LockedItems": "Include 'locked' items",


### PR DESCRIPTION
Fixes #2507 

This PR adds a reverse infusion lookup to the Infusion Fuel Finder. It adds a second item grid to the Infusion modal which contains equipment that the selected item can be infused into.

To clarify the outcome of the infusion, this PR also improves the infusion plan and result displays by including the source, target, and result items.  

Additional Notes:
* Adds the fuel finder to all items that can be used as infusion fuel
* Changes some UI messaging; will need localization
* Implicitly fixes a D2 issue where the `.infusable` property on non-infusable items was set to `true`
* Removed some dead CSS

Testing:
* Hand tested all item types I could find for D1 and D2

### Screenshots 
Destiny 2 - Using selected item as fuel
<img width="658" src="https://user-images.githubusercontent.com/6517289/34474210-e6350436-ef30-11e7-8d48-443011420d93.png">

Destiny 2 - Infusing selected item
<img width="669" src="https://user-images.githubusercontent.com/6517289/34474169-1ba7e396-ef30-11e7-9a94-17e415af6760.png">

Destiny 2 - View of a selected item that can't be infused
<img width="667" src="https://user-images.githubusercontent.com/6517289/34474177-5119f596-ef30-11e7-93d6-b9e0f816cbb8.png">

Destiny 1 Example
<img width="657" src="https://user-images.githubusercontent.com/6517289/34474127-adb46eb8-ef2f-11e7-8aa2-e202c57bdc69.png">