### PR TITLE
Progress tweaks

### DIFF
--- a/src/app/progress/character-tile.tsx
+++ b/src/app/progress/character-tile.tsx
@@ -9,6 +9,11 @@ interface CharacterTileProps {
   lastPlayedDate: Date;
 }
 
+// TODO: this should probably move to a library of character functions
+export function characterIsCurrent(character: IDestinyCharacterComponent, lastPlayedDate: Date): boolean {
+  return lastPlayedDate.getTime() === new Date(character.dateLastPlayed).getTime();
+}
+
 export function CharacterTile(props: CharacterTileProps) {
   const { defs, character, lastPlayedDate } = props;
 
@@ -17,7 +22,7 @@ export function CharacterTile(props: CharacterTileProps) {
   const classy = defs.Class[character.classHash];
   const genderRace = race.genderedRaceNames[gender.genderType === 1 ? 'Female' : 'Male'];
   const className = classy.genderedClassNames[gender.genderType === 1 ? 'Female' : 'Male'];
-  const current = lastPlayedDate.getTime() === new Date(character.dateLastPlayed).getTime() ? 'current' : '';
+  const current = characterIsCurrent(character, lastPlayedDate) ? 'current' : '';
 
   // TODO: update this to be a D2-specific, simplified tile
   return (

--- a/src/app/progress/progress.tsx
+++ b/src/app/progress/progress.tsx
@@ -121,12 +121,12 @@ export class Progress extends React.Component<Props, State> {
         <div className="progress dim-page">
           {profileMilestonesContent}
           <ViewPager>
-            <Frame className="frame">
+            <Frame className="frame" autoSize={true}>
               <Track
                 viewsToShow={1}
                 contain={true}
                 className="track"
-                autoSize={true}
+                flickTimeout={100}
               >
                 {characters.map((character) =>
                   <View className="view" key={character.characterId}>{this.renderCharacters([character])}</View>


### PR DESCRIPTION
* Tweak the pager settings to reduce the time a swipe is considered a "flick" (so you have to "flick" faster to make it go, which should reduce "twitchiness". @duckmanBR 
* Use the right config to autosize frames when paging so people don't page into a big empty space at the bottom.
* Set the initial character to the current character on mobile, for folks with different character sorts.