### PR TITLE
Rearrange factions and grey out unavailable ones

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Next
 
 * Sorting characters by age should be correct for D2 on PC.
-* Factions that you can't turn in rewards to are now greyed out.
+* Factions that you can't turn in rewards to are now greyed out. We also show the vendor name, and the raw XP values have moved to a tooltip.
 
 # 4.33.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * Sorting characters by age should be correct for D2 on PC.
+* Factions that you can't turn in rewards to are now greyed out.
 
 # 4.33.1
 

--- a/src/app/bungie-api/interfaces.d.ts
+++ b/src/app/bungie-api/interfaces.d.ts
@@ -277,6 +277,7 @@ export interface IDestinyEquipItemResults {
 */
 export interface IDestinyFactionProgression extends IDestinyProgression {
   factionHash: number;
+  factionVendorIndex: number;
 }
 
 export interface IDestinyHistoricalStatsAccountResult {

--- a/src/app/progress/faction.scss
+++ b/src/app/progress/faction.scss
@@ -6,6 +6,10 @@
   align-items: center;
   margin-bottom: 16px;
 
+  &.faction-unavailable {
+    opacity: .4;
+  }
+
   .faction-icon {
     margin: 2px 10px -2px 2px;
     position: relative;

--- a/src/app/progress/faction.tsx
+++ b/src/app/progress/faction.tsx
@@ -16,6 +16,7 @@ interface FactionProps {
 
 export function Faction(props: FactionProps) {
   const { defs, factionProgress, profileInventory } = props;
+
   const factionDef = defs.Faction[factionProgress.factionHash];
 
   const style = {
@@ -24,8 +25,16 @@ export function Faction(props: FactionProps) {
 
   const engramsAvailable = calculateEngramsAvailable(profileInventory, factionDef, factionProgress);
 
+  const vendorIndex = factionProgress.factionVendorIndex === -1 ? 0 : factionProgress.factionVendorIndex;
+  const vendorHash = factionDef.vendors[vendorIndex].vendorHash;
+
+  const vendorDef = defs.Vendor.get(vendorHash);
+
   return (
-    <div className={classNames("faction", { 'faction-unavailable': factionProgress.factionVendorIndex === -1 })}>
+    <div
+      className={classNames("faction", { 'faction-unavailable': factionProgress.factionVendorIndex === -1 })}
+      title={`${factionProgress.progressToNextLevel}/${factionProgress.nextLevelAt}`}
+    >
       <div className="faction-icon">
         <svg viewBox="0 0 48 48">
           <image xlinkHref={bungieNetPath(factionDef.displayProperties.icon)} width="48" height="48" />
@@ -36,8 +45,8 @@ export function Faction(props: FactionProps) {
         <div className={classNames('item-stat', 'item-faction', { 'purchase-unlocked': factionProgress.level >= 10 })}>{factionProgress.level}</div>
       </div>
       <div className="faction-info">
-        <div className="faction-name" title={factionDef.displayProperties.description}>{factionDef.displayProperties.name}</div>
-        <div className="faction-level">{factionProgress.progressToNextLevel}/{factionProgress.nextLevelAt}</div>
+        <div className="faction-name" title={vendorDef.displayProperties.description}>{vendorDef.displayProperties.name}</div>
+        <div className="faction-level" title={factionDef.displayProperties.description}>{factionDef.displayProperties.name}</div>
         {engramsAvailable > 0 &&
           <div className="faction-rewards">{t('Faction.EngramsAvailable', { count: engramsAvailable })}</div>
         }

--- a/src/app/progress/faction.tsx
+++ b/src/app/progress/faction.tsx
@@ -25,7 +25,7 @@ export function Faction(props: FactionProps) {
   const engramsAvailable = calculateEngramsAvailable(profileInventory, factionDef, factionProgress);
 
   return (
-    <div className="faction">
+    <div className={classNames("faction", { 'faction-unavailable': factionProgress.factionVendorIndex === -1 })}>
       <div className="faction-icon">
         <svg viewBox="0 0 48 48">
           <image xlinkHref={bungieNetPath(factionDef.displayProperties.icon)} width="48" height="48" />

--- a/src/app/progress/progress.tsx
+++ b/src/app/progress/progress.tsx
@@ -302,7 +302,7 @@ export class Progress extends React.Component<Props, State> {
     const { defs, profileInfo } = this.state.progress!;
 
     const allFactions: IDestinyFactionProgression[] = Object.values(profileInfo.characterProgressions.data[character.characterId].factions);
-    return _.sortBy(allFactions, (f) => progressionMeta[f.factionHash] ? progressionMeta[f.factionHash].order : 999);
+    return _.sortBy(allFactions, (f) => (progressionMeta[f.factionHash] ? progressionMeta[f.factionHash].order : 999) + (f.factionVendorIndex === -1 ? 1000 : 0));
   }
 
   /**

--- a/src/app/progress/progress.tsx
+++ b/src/app/progress/progress.tsx
@@ -26,14 +26,14 @@ const progressionMeta = {
   1660497607: { label: "Nessus AI", order: 7 },
   828982195: { label: "Io Researcher", order: 8 },
   2677528157: { label: "Follower of Osiris", order: 9 },
+  24856709: { label: "Leviathan", order: 10 },
 
-  2105209711: { label: "New Monarchy", order: 10 },
-  1714509342: { label: "Future War Cult", order: 11 },
-  3398051042: { label: "Dead Orbit", order: 12 },
-  3468066401: { label: "The Nine", order: 13 },
-  1761642340: { label: "Iron Banner", order: 14 },
+  3468066401: { label: "The Nine", order: 11 },
+  1761642340: { label: "Iron Banner", order: 12 },
 
-  1482334108: { label: "Leviathan", order: 15 }
+  2105209711: { label: "New Monarchy", order: 13 },
+  1714509342: { label: "Future War Cult", order: 14 },
+  3398051042: { label: "Dead Orbit", order: 15 }
 };
 
 interface Props {


### PR DESCRIPTION
I found a property that tells us whether a given faction has a vendor available for a character. Using that, I greyed out unavailable factions (event vendors, etc). I also rearranged things a bit more to put event vendors on the bottom:

<img width="862" alt="screen shot 2018-01-09 at 11 18 32 pm" src="https://user-images.githubusercontent.com/313208/34760176-84e17188-f593-11e7-8df0-06a556e72f44.png">
