### PR TITLE
Add VSCode workspace settings and recommended plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ dist/
 extension-dist/
 .settings/
 .idea/
-.vscode/
 node_modules/
 build/common
 build/img

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+		"eg2.tslint",
+		"dbaeumer.vscode-eslint",
+		"Angular.ng-template",
+		"miclo.sort-typescript-imports"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "editor.tabSize": 2,
+  "editor.trimAutoWhitespace": true,
+  "files.trimTrailingWhitespace": true,"typescript.extension.sortImports.sortMethod": "path",
+  "typescript.extension.sortImports.pathSortOrder": [
+      "package",
+      "relativeUpLevel",
+      "relativeDownLevel"
+  ],
+  "typescript.extension.sortImports.enableJavascript": true
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,10 +2,10 @@ First, thank you for contributing to DIM! We're a community-driven project and w
 
 Here are some tips to make sure your pull request can be merged smoothly:
 
-1. If you want to add a feature or make some change to DIM, consider [filing an issue](https://github.com/DestinyItemManager/DIM/issues/new) describing your idea first. This will give the DIM community a chance to discuss the idea, offer suggestions and pointers, and make sure what you're thinking of fits with the style and direction of DIM.
+1. If you want to add a feature or make some change to DIM, consider [filing an issue](https://github.com/DestinyItemManager/DIM/issues/new) describing your idea first. This will give the DIM community a chance to discuss the idea, offer suggestions and pointers, and make sure what you're thinking of fits with the style and direction of DIM. If you want a more free-form chat, [join our Discord](https://discordapp.com/invite/UK2GWC7).
 2. Resist the temptation to change more than one thing in your PR. Keeping PRs focused on a single change makes them much easier to review and accept. If you want to change multiple things, or clean up/refactor the code, make a new branch and submit those changes as a separate PR.
 3. Please follow the existing style of DIM code when making your changes. While there's certainly room for improvement in the DIM codebase, if everybody used their favorite code style nothing would match up.
-4. You can use any ES6/ES2015 features - we use Babel to compile out any features too new for browsers.
+4. You can use any ES6/ES2015 features - we use Babel to compile out any features too new for browsers. We are also encouraging developers to write new code in [TypeScript](https://typescriptlang.org) and to use React instead of AngularJS where possible.
 5. Take advantage of the [native JavaScript Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) and the [Underscore](http://underscorejs.org) library to write compact, easy-to-understand code.
 6. Be sure to run `npm run lint` before submitting your PR - it'll catch most style problems and make things much easier to merge.
 7. Don't forget to add a description of your change to `CHANGELOG.md` so it'll be included in the release notes!


### PR DESCRIPTION
I've really been enjoying VSCode as an editor for DIM, especially with TypeScript. These changes add project-specific settings and a recommended plugins list to the DIM project - when it is opened, it'll prompt to install the recommended plugins and configure them to match our style.