### PR TITLE
Clean up infusion tool styling for mobile

### DIFF
--- a/src/app/infuse/infuse.html
+++ b/src/app/infuse/infuse.html
@@ -31,19 +31,18 @@
         <span ng-if="vm.targetItems.length" ng-i18next="[i18next]({name: vm.query.name})Infusion.InfuseTarget"></span>
         <div class="itemGrid">
           <div ng-repeat="value in vm.targetItems track by value.index">
-            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.target }" item-data="value" ng-click="vm.setSourceAndTarget(vm.query, value, $event)"></dim-simple-item>
+            <dim-simple-item ng-class="{ 'infuse-selected': (value.id == vm.target.id) }" item-data="value" ng-click="vm.setSourceAndTarget(vm.query, value, $event)"></dim-simple-item>
           </div>
         </div>
       </div>
       <div class="infuseSeparator">
-        <span></span>
       </div>
       <div class="infuseSources">
         <span ng-if="!vm.sourceItems.length"><strong ng-i18next="Infusion.NoItems"></strong></span>
         <span ng-if="vm.sourceItems.length" ng-i18next="[i18next]({name: vm.query.name})Infusion.InfuseSource"></span>
         <div class="itemGrid">
           <div ng-repeat="value in vm.sourceItems track by value.index">
-            <dim-simple-item ng-class="{ 'infuse-selected': value == vm.source }" item-data="value" ng-click="vm.setSourceAndTarget(value, vm.query, $event)"></dim-simple-item>
+            <dim-simple-item ng-class="{ 'infuse-selected': (value.id == vm.source.id) }" item-data="value" ng-click="vm.setSourceAndTarget(value, vm.query, $event)"></dim-simple-item>
           </div>
         </div>
       </div>
@@ -73,7 +72,7 @@
             </div>
           </div>
         </div>
-        <button ng-if="vm.getAllItems" ng-disabled="vm.transferInProgress" ng-click="vm.transferItems()" ng-i18next="Infusion.TransferItems" class="infuse-btn"></button>
+        <button class="dim-button" ng-if="vm.getAllItems" ng-disabled="vm.transferInProgress" ng-click="vm.transferItems()" ng-i18next="Infusion.TransferItems" class="infuse-btn"></button>
       </div>
     </div>
 

--- a/src/app/infuse/infuse.scss
+++ b/src/app/infuse/infuse.scss
@@ -1,17 +1,28 @@
+@import '../../scss/variables.scss';
+
 .infuseDialog {
   width: 100%;
   display: flex;
   flex-direction: column;
   overflow: auto;
+  @include phone-portrait {
+    --item-size: 44px;
+  }
 
   .ngdialog-inner-content {
     padding-left: 0;
     padding-right: 0;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 57px);
   }
 
   .bigValue {
     font-size: 32px;
     line-height: 1em;
+    @include phone-portrait {
+      font-size: 22px;
+    }
   }
 
   .infuseSourceDetailsRow {
@@ -28,14 +39,23 @@
 
   .green {
     color: green;
+    font-weight: bold;
   }
 
   .infuseHeader {
     display: flex;
     flex-direction: row;
+
+    @include phone-portrait {
+      flex-direction: column;
+
+      .infuseControls {
+        font-size: 11px;
+      }
+    }
   }
 
-  .infuse-selected {
+  .infuse-selected .item {
     outline: 2px solid black !important;
   }
 
@@ -44,13 +64,13 @@
   }
 
   .infuseSourceItemInfo {
-    padding: 0px 0px 10px 25px;
+    padding: 0px 0px 8px 8px;
     display: flex;
     flex-direction: row;
   }
 
   .infuseControls {
-    padding: 0px 25px 10px 25px;
+    padding: 0px 8px 8px 8px;
     label {
       display: block;
     }
@@ -58,7 +78,7 @@
 
   .gearsContainer {
     width: auto;
-    padding: 10px 25px;
+    padding: 8px;
     overflow: hidden;
 
     .resultContainer {
@@ -67,6 +87,9 @@
 
     .infusedItem {
       margin: 3px 3px 3px 3px;
+      &:first-child {
+        margin-left: 0;
+      }
     }
 
     .plusSeparator {
@@ -77,7 +100,6 @@
 
     .itemGrid {
       display: flex;
-      max-width: calc((var(--item-size) + 8px) * 5);
       flex-wrap: wrap;
     }
 
@@ -86,7 +108,6 @@
 
       .infusionEquation {
         display: flex;
-        height: calc(var(--item-size) + 8px + 6px);
 
         .icon {
           align-self: center;
@@ -96,15 +117,21 @@
   }
 
   .infuseSelector {
+    flex: 1;
+    overflow: auto;
     justify-content: space-around;
     display: flex;
 
     .infuseSeparator {
       width: 1px;
-      margin: 15px 15px 0px 15px;
+      margin: 15px 8px 0px 8px;
       flex: none;
       background: white;
     }
+  }
+
+  .infuseSources, .infuseTargets {
+    flex: 1;
   }
 }
 

--- a/src/app/infuse/infuse.scss
+++ b/src/app/infuse/infuse.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   overflow: auto;
   @include phone-portrait {
-    --item-size: 44px;
+    --item-size: 48px;
   }
 
   .ngdialog-inner-content {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -273,8 +273,8 @@
   "Infusion": {
     "BringGear": "Will bring {{name}} to:",
     "Calc": "Infusion calculator",
-    "InfuseSource": "Select item to infuse into; consumes {{name}}:",
-    "InfuseTarget": "Select item to infuse {{name}}:",
+    "InfuseSource": "Select item to infuse {{name}} into:",
+    "InfuseTarget": "Select item to infuse into {{name}}:",
     "Infusion": "Infusion Fuel Finder",
     "InfusionMaterials": "Infusion Materials",
     "LockedItems": "Include 'locked' items",


### PR DESCRIPTION
Clean up the styling for the infusion tool to work better on mobile:

1. Smaller items so we can fit more in.
2. Fix selected item highlighting.
3. Moved stuff around on mobile so it doesn't squish.
4. Flexbox optimizations to pack more in.
5. Thinner margins/padding.
6. The inner list of items will scroll if it has to, leaving the header and footer put.

The item tap targets are pretty small now, but I think it's best to show a bunch of options.

![image](https://user-images.githubusercontent.com/313208/34925494-8526d5d8-f95e-11e7-9ff2-aa8ea3ecec21.png)
