### PR TITLE
Re-attempt moving from UglifyJS to UglifyES

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,6 @@
       "modules": false,
       "useBuiltIns": true,
       "targets": {
-        "uglify": true,
         "browsers": [
           "last 2 Chrome versions",
           "last 2 ChromeAndroid versions",

--- a/.babelrc
+++ b/.babelrc
@@ -5,12 +5,12 @@
       "useBuiltIns": true,
       "targets": {
         "browsers": [
-          "last 2 Chrome versions",
+          "Chrome >= 51",
           "last 2 ChromeAndroid versions",
           "last 2 Firefox versions",
           "last 2 Safari versions",
           "iOS >= 10",
-          "last 2 Edge versions",
+          "last 3 Edge versions",
           "last 2 Opera versions"
         ]
       }

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -7,6 +7,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const WebpackNotifierPlugin = require('webpack-notifier');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 // const Visualizer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const NotifyPlugin = require('notify-webpack-plugin');
@@ -65,9 +66,10 @@ module.exports = (env) => {
         {
           test: /\.js$/,
           exclude: [/node_modules/, /sql\.js/],
-          use: [
-            'babel-loader'
-          ]
+          loader: 'babel-loader',
+          options: {
+            cacheDirectory: true
+          }
         }, {
           test: /\.json$/,
           loader: 'json-loader'
@@ -292,11 +294,20 @@ module.exports = (env) => {
     // The sql.js library doesnt work at all (reports no tables) when minified,
     // so we exclude it from the regular minification
     // FYI, uglification runs on final chunks rather than individual modules
-    config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+    config.plugins.push(new UglifyJsPlugin({
       exclude: [/-sqlLib-/, /sql-wasm/], // ensure the sqlLib chunk doesnt get minifed
-      compress: { warnings: false },
-      output: { comments: false },
-      sourceMap: true
+      uglifyOptions: {
+        compress: {
+          ecma: 6,
+          passes: 2
+        },
+        output: {
+          ecma: 6
+        }
+      },
+      sourceMap: true,
+      cache: true,
+      parallel: true
     }));
 
     // Generate a service worker

--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,6 +2518,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "center-align": "0.1.3",
         "right-align": "0.1.3",
@@ -2528,7 +2529,8 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15765,25 +15767,51 @@
       "optional": true
     },
     "uglifyjs-webpack-plugin": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz",
+      "integrity": "sha512-VUja+7rYbznEvUaeb8IxOCTUrq4BCb1ml0vffa+mfwKtrAwlqnU0ENF14DtYltV1cxd/HSuK51CCA/D/8kMQVw==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.1.0"
+        "cacache": "10.0.1",
+        "find-cache-dir": "1.0.0",
+        "schema-utils": "0.4.3",
+        "serialize-javascript": "1.4.0",
+        "source-map": "0.6.1",
+        "uglify-es": "3.3.7",
+        "webpack-sources": "1.1.0",
+        "worker-farm": "1.5.2"
       },
       "dependencies": {
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.3.tgz",
+          "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "ajv": "5.2.2",
+            "ajv-keywords": "2.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "uglify-es": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.7.tgz",
+          "integrity": "sha512-fGMnE6SsDRsCjxm78C+lv7MuXsse/dtF7QuTUT43BYf4jlxPjd+XTnGB8YjaCQJ3sv2LT4zk0mwpp9+QJocU6g==",
+          "dev": true,
+          "requires": {
+            "commander": "2.13.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -16368,10 +16396,69 @@
             "setimmediate": "1.0.5"
           }
         },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+              "dev": true
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+              "dev": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              }
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+          "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-js": "2.8.29",
+            "webpack-sources": "1.1.0"
+          }
+        },
         "which-module": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true
         },
         "yargs": {
@@ -17188,6 +17275,16 @@
         "workbox-build": "2.1.2"
       }
     },
+    "worker-farm": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.6",
+        "xtend": "4.0.1"
+      }
+    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -17281,6 +17378,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
+      "optional": true,
       "requires": {
         "camelcase": "1.2.1",
         "cliui": "2.1.0",
@@ -17292,7 +17390,8 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "homepage": "https://destinyitemmanager.com",
   "browserslist": [
-    "Chrome >= 51",
+    "last 2 Chrome versions",
     "last 2 ChromeAndroid versions",
     "last 2 Firefox versions",
     "last 2 Safari versions",
     "iOS >= 10",
-    "last 3 Edge versions",
+    "last 2 Edge versions",
     "last 2 Opera versions",
     "unreleased versions"
   ],

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "tslint-eslint-rules": "^4.1.1",
     "tslint-react": "^3.4.0",
     "typescript": "^2.6.2",
-    "uglify-js": "^3.3.7",
+    "uglifyjs-webpack-plugin": "^1.0.1",
     "unzip": "^0.1.11",
     "url-loader": "^0.6.2",
     "webpack": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "homepage": "https://destinyitemmanager.com",
   "browserslist": [
-    "last 2 Chrome versions",
+    "Chrome >= 51",
     "last 2 ChromeAndroid versions",
     "last 2 Firefox versions",
     "last 2 Safari versions",
     "iOS >= 10",
-    "last 2 Edge versions",
+    "last 3 Edge versions",
     "last 2 Opera versions",
     "unreleased versions"
   ],

--- a/src/app/search/search.module.js
+++ b/src/app/search/search.module.js
@@ -3,12 +3,14 @@ import angular from 'angular';
 import { SearchFilterComponent } from './search-filter.component';
 import { FilterLinkComponent } from './filter-link.component';
 
+// a simple service to share the search query among components
+function SearchService() {
+  return { query: '' };
+}
+
 export default angular
   .module('searchModule', [])
   .component('dimSearchFilter', SearchFilterComponent)
   .component('dimFilterLink', FilterLinkComponent)
-  // a simple service to share the search query among components
-  .service('dimSearchService', () => {
-    return { query: '' };
-  })
+  .service('dimSearchService', SearchService)
   .name;


### PR DESCRIPTION
#2389 moved us to the newer, ES2015+ compatible UglifyES, gaining both file size advantages and the ability to send newer JS constructs directly to the browser where they can be better optimized. However, issues with AngularJS (it can't handle an arrow function being used to define a service) caused errors that led to a swift revert. This brings it back, with a hopefully longer bake in beta to shake out any remaining issues.

I also pinned the JS transpiler's supported Chrome version back to 51 because somebody complained last time. This should not be construed as support for that version (and they'll still get the warning). Chrome 51 shares most of the same deficiencies with iOS 10, and when we decide to stop supporting iOS 10 (in favor of iOS 10.3, so we can use native async/await instead of ugly generator stuff) we'll also stop supporting Chrome 51.