### PR TITLE
Get more info from DIM Beta

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -246,7 +246,9 @@ module.exports = (env) => {
         // Debug ui-router
         '$featureFlags.debugRouter': JSON.stringify(false),
         // Show drag and drop on dev only
-        '$featureFlags.dnd': JSON.stringify(isDev)
+        '$featureFlags.dnd': JSON.stringify(isDev),
+        // Send exception reports to Google Analytics on beta only
+        '$featureFlags.googleExceptionReports': JSON.stringify(env === 'beta')
       }),
 
       new webpack.SourceMapDevToolPlugin({

--- a/src/app/accounts/destiny-account.service.ts
+++ b/src/app/accounts/destiny-account.service.ts
@@ -4,6 +4,7 @@ import { UserMembershipData } from 'bungie-api-ts/user';
 import { BungieUserApiService } from '../bungie-api/bungie-user-api.service';
 import { PLATFORMS } from '../bungie-api/platforms';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
+import { reportExceptionToGoogleAnalytics } from '../google';
 
 /** A specific Destiny account (one per platform and Destiny version) */
 export interface DestinyAccount {
@@ -42,6 +43,7 @@ export function DestinyAccountService(BungieUserApi: BungieUserApiService, toast
       .catch((e) => {
         // TODO: show a full-page error, or show a diagnostics page, rather than a popup
         toaster.pop(bungieErrorToaster(e));
+        reportExceptionToGoogleAnalytics('getDestinyAccountsForBungieAccount', e);
         throw e;
       });
   }

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -118,10 +118,6 @@ export function D2Definitions($q, D2ManifestService): D2DefinitionsService {
         });
 
         return defs;
-      })
-      .catch((e) => {
-        console.error(e);
-        return $q.reject(e);
       }));
   };
 

--- a/src/app/dimApp.module.js
+++ b/src/app/dimApp.module.js
@@ -44,6 +44,7 @@ import routes from './dimApp.routes';
 import run from './dimApp.run';
 import state from './state';
 import loadingTracker from './services/dimLoadingTracker.factory';
+import { reportExceptionToGoogleAnalytics } from './google';
 
 const dependencies = [
   AriaModule,
@@ -87,6 +88,14 @@ if ($DIM_FLAVOR === 'dev') {
   dependencies.push(require('./developer/developer.module').default);
 }
 
+function DimExceptionHandler($log) {
+  'ngInject';
+  return function myExceptionHandler(exception, cause) {
+    reportExceptionToGoogleAnalytics(cause, exception);
+    $log.warn(exception, cause);
+  };
+}
+
 export const DimAppModule = angular
   .module('dimApp', dependencies)
   .config(config)
@@ -94,4 +103,6 @@ export const DimAppModule = angular
   .run(run)
   .value('dimState', state)
   .factory('loadingTracker', loadingTracker)
+  // Overwrite exception handler to log
+  .factory('$exceptionHandler', DimExceptionHandler)
   .name;

--- a/src/app/google.js
+++ b/src/app/google.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 window.ga = window.ga || function(...args) { (ga.q = ga.q || []).push(args); }; ga.l = Number(new Date());
 
 ga('create', $DIM_FLAVOR === 'release' ? 'UA-60316581-1' : 'UA-60316581-5', 'auto');
@@ -8,3 +10,20 @@ ga('set', 'dimension2', $DIM_FLAVOR);
 if (!$featureFlags.googleAnalyticsForRouter) {
   ga('send', 'pageview');
 }
+
+let reportException = () => {};
+
+if ($featureFlags.googleExceptionReports) {
+  // Report no more than once every 5 minutes
+  reportException = _.throttle((name, e) => {
+    ga('send', 'exception', {
+      exDescription: `${name}: ${e.message}`,
+      exFatal: false
+    });
+  }, 5 * 60000, { trailing: false });
+
+  window.addEventListener('error', reportException.bind('Global Error'));
+  window.addEventListener('unhandledrejection', (event) => reportException('Unhandled Promise Rejection', event.reason));
+}
+
+export const reportExceptionToGoogleAnalytics = reportException;

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -11,16 +11,17 @@ import {
 import * as _ from 'underscore';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.service';
 import { Destiny2ApiService } from '../bungie-api/destiny2-api.service';
+import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { PLATFORMS } from '../bungie-api/platforms';
 import { BucketsService, DimInventoryBuckets } from '../destiny2/d2-buckets.service';
 import { D2DefinitionsService, D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { bungieNetPath } from '../dim-ui/bungie-image';
+import { reportExceptionToGoogleAnalytics } from '../google';
 import { optimalLoadout } from '../loadout/loadout-utils';
 import { Loadout } from '../loadout/loadout.service';
 import { flatMap } from '../util';
 import { D2ItemFactoryType } from './store/d2-item-factory.service';
 import { D2StoreFactoryType, DimStore, DimVault } from './store/d2-store-factory.service';
-import { bungieErrorToaster } from '../bungie-api/error-toaster';
 
 /**
  * TODO: For now this is a copy of StoreService customized for D2. Over time we should either
@@ -263,6 +264,7 @@ export function D2StoresService(
       .catch((e) => {
         toaster.pop(bungieErrorToaster(e));
         console.error('Error loading stores', e);
+        reportExceptionToGoogleAnalytics('d2stores', e);
         // It's important that we swallow all errors here - otherwise
         // our observable will fail on the first error. We could work
         // around that with some rxjs operators, but it's easier to

--- a/src/app/inventory/dimItemInfoService.factory.js
+++ b/src/app/inventory/dimItemInfoService.factory.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import _ from 'underscore';
+import { reportExceptionToGoogleAnalytics } from '../google';
 
 /**
  * The item info service maintains a map of extra, DIM-specific, synced data about items (per platform).
@@ -80,6 +81,7 @@ export function ItemInfoService(SyncService, $i18next, toaster, $q) {
                         $i18next.t('ItemInfoService.SaveInfoErrorTitle'),
                         $i18next.t('ItemInfoService.SaveInfoErrorDescription', { error: e.message }));
                       console.error("Error saving item info (tags, notes):", e);
+                      reportExceptionToGoogleAnalytics('itemInfo', e);
                     });
                 });
               }

--- a/src/app/inventory/dimStoreBucket.directive.js
+++ b/src/app/inventory/dimStoreBucket.directive.js
@@ -4,6 +4,7 @@ import template from './dimStoreBucket.directive.html';
 import dialogTemplate from './dimStoreBucket.directive.dialog.html';
 import './dimStoreBucket.scss';
 import { isPhonePortrait } from '../mediaQueries';
+import { reportExceptionToGoogleAnalytics } from '../google';
 
 export const StoreBucketComponent = {
   controller: StoreBucketCtrl,
@@ -164,6 +165,7 @@ function StoreBucketCtrl($scope,
       if (e.message !== 'move-canceled') {
         toaster.pop('error', item.name, e.message);
         console.error("error moving", e, item);
+        reportExceptionToGoogleAnalytics('moveItem', e);
       }
     });
 

--- a/src/app/inventory/dimStoreService.factory.js
+++ b/src/app/inventory/dimStoreService.factory.js
@@ -4,6 +4,7 @@ import { Subject, BehaviorSubject } from '@reactivex/rxjs';
 import { flatMap } from '../util';
 import { compareAccounts } from '../accounts/destiny-account.service';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
+import { reportExceptionToGoogleAnalytics } from '../google';
 
 export function StoreService(
   $rootScope,
@@ -213,6 +214,7 @@ export function StoreService(
       .catch((e) => {
         toaster.pop(bungieErrorToaster(e));
         console.error('Error loading stores', e);
+        reportExceptionToGoogleAnalytics('dimStoreService', e);
         // It's important that we swallow all errors here - otherwise
         // our observable will fail on the first error. We could work
         // around that with some rxjs operators, but it's easier to

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -11,8 +11,9 @@ import {
 import * as _ from 'underscore';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.service';
 import { Destiny2ApiService } from '../bungie-api/destiny2-api.service';
-import { D2DefinitionsService, D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
+import { D2DefinitionsService, D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import { reportExceptionToGoogleAnalytics } from '../google';
 
 export interface ProgressService {
   getProgressStream(account: DestinyAccount): ConnectableObservable<ProgressProfile>;
@@ -116,6 +117,7 @@ export function ProgressService(Destiny2Api: Destiny2ApiService, D2Definitions: 
     .catch((e) => {
       toaster.pop(bungieErrorToaster(e));
       console.error('Error loading progress', e);
+      reportExceptionToGoogleAnalytics('progressService', e);
       // It's important that we swallow all errors here - otherwise
       // our observable will fail on the first error. We could work
       // around that with some rxjs operators, but it's easier to

--- a/src/app/search/search-filters.js
+++ b/src/app/search/search-filters.js
@@ -452,7 +452,7 @@ export function searchFilters(searchConfig, storeService, toaster, $i18next) {
 
               if (!_dupeInPost) {
                 if (_.any(dupes, (dupe) => dupe.location.inPostmaster)) {
-                  toaster.pop('warn', $i18next.t('Filter.DupeInPostmaster'));
+                  toaster.pop('warning', $i18next.t('Filter.DupeInPostmaster'));
                   _dupeInPost = true;
                 }
               }

--- a/src/app/services/dimManifestService.factory.js
+++ b/src/app/services/dimManifestService.factory.js
@@ -56,7 +56,7 @@ function makeManifestService(localStorageKey, idbKey, $q, DestinyApi, $http, toa
 
           // The manifest has updated!
           if (path !== service.version) {
-            toaster.pop('error',
+            toaster.pop('warning',
                         $i18next.t('Manifest.Outdated'),
                         $i18next.t('Manifest.OutdatedExplanation'));
           }

--- a/src/app/shell/header.component.js
+++ b/src/app/shell/header.component.js
@@ -31,7 +31,8 @@ function HeaderController(
 
   vm.featureFlags = {
     vendorsEnabled: $featureFlags.vendorsEnabled,
-    activities: $featureFlags.activities
+    activities: $featureFlags.activities,
+    bugReportLink: $DIM_FLAVOR !== 'release'
   };
 
   vm.destinyVersion = getCurrentDestinyVersion($state);

--- a/src/app/shell/header.html
+++ b/src/app/shell/header.html
@@ -47,10 +47,15 @@
          ui-sref="storage"
          ng-i18next="Storage.Title"></a>
       <span class="link"
-            ui-sref-active="active"
-            ui-sref="storage"
-            ng-i18next="Settings.Settings"></span>
-
+         ui-sref-active="active"
+         ui-sref="storage"
+         ng-i18next="Settings.Settings"></span>
+      <a class="link"
+         ng-if="$ctrl.featureFlags.bugReportLink"
+         target="_blank"
+         rel="noopener noreferrer"
+         href="https://github.com/DestinyItemManager/DIM/issues"
+         ng-i18next="Header.ReportBug"></a>
       <hr>
 
       <span class="link"
@@ -89,6 +94,12 @@
      rel="noopener noreferrer"
      href="https://teespring.com/stores/dim"
      ng-i18next="Header.Shop"></a>
+  <a class="link"
+     ng-if="$ctrl.featureFlags.bugReportLink"
+     target="_blank"
+     rel="noopener noreferrer"
+     href="https://github.com/DestinyItemManager/DIM/issues"
+     ng-i18next="Header.ReportBug"></a>
 
   <span class="link first-to-go header-separator" ng-if="$ctrl.destinyVersion"></span>
 

--- a/src/app/storage/storage.component.js
+++ b/src/app/storage/storage.component.js
@@ -4,6 +4,7 @@ import { sum } from '../util';
 
 import template from './storage.html';
 import './storage.scss';
+import { reportExceptionToGoogleAnalytics } from '../google';
 
 function StorageController($scope, dimSettingsService, SyncService, GoogleDriveStorage, dimDestinyTrackerService, $timeout, $window, $q, $i18next, $stateParams, $state) {
   'ngInject';
@@ -69,6 +70,7 @@ function StorageController($scope, dimSettingsService, SyncService, GoogleDriveS
         .then(vm.forceSync)
         .catch((e) => {
           $window.alert($i18next.t('Storage.GDriveSignInError') + e.message);
+          reportExceptionToGoogleAnalytics('Google Drive Signin', e);
         });
     }
     return null;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,7 +35,9 @@ declare const $featureFlags: {
   /** Debug ui-router */
   debugRouter: boolean;
   /** Show drag and drop on dev only */
-  dnd: boolean
+  dnd: boolean,
+  /** Send exception reports to Google Analytics */
+  googleExceptionReports: boolean;
 }
 
 declare module "*.png" {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -245,7 +245,8 @@
     "Shop": "Shop",
     "SupportDIM": "Backers",
     "Back": "Go Back",
-    "BulkTag": "Bulk tag items"
+    "BulkTag": "Bulk tag items",
+    "ReportBug": "Report an Issue"
   },
   "Help": {
     "CannotMove": "Cannot move that item off this character.",


### PR DESCRIPTION
I've made two changes to DIM Beta in this PR in hopes of getting more info from beta users:

1. Added a "Report an Issue" link to the header and hamburger for Beta only, that links to the GitHub issues. This reinforces that Beta is for Beta testers, and gives them an easy reminder of how to report an issue.
2. Report errors and exceptions to Google Analytics in Beta only. We have a lot fewer users there, so we shouldn't bust any limits, and we can find common errors quickly. I am throttling this at one report per 5 minutes, too, in case there's a flood of errors.