### PR TITLE
Move to individual Rxjs imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,14 +116,6 @@
     "@destiny-item-manager/zip.js": {
       "version": "github:DestinyItemManager/zip.js#6931dae24f729399100ee7a6fe5dce43007581f0"
     },
-    "@reactivex/rxjs": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-5.5.6.tgz",
-      "integrity": "sha512-lIc+Yc18M8MG6oJ6OlPIPZ6jJ2QtOEKaGFefnl/41QlZymjuLiYa+gu/56V/0oTj6FNuE+4qiGjRE5OnlIDiOg==",
-      "requires": {
-        "symbol-observable": "1.0.1"
-      }
-    },
     "@types/angular": {
       "version": "1.6.40",
       "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.40.tgz",
@@ -13289,6 +13281,14 @@
       "dev": true,
       "requires": {
         "rx-lite": "4.0.8"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "requires": {
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
   },
   "dependencies": {
     "@destiny-item-manager/zip.js": "github:DestinyItemManager/zip.js",
-    "@reactivex/rxjs": "^5.5.6",
     "@types/angular": "^1.6.40",
     "@types/i18next": "^8.4.2",
     "@types/react": "^16.0.34",
@@ -137,6 +136,7 @@
     "react-dom": "^16.2.0",
     "react-view-pager": "^0.5.1",
     "react2angular": "^3.1.0",
+    "rxjs": "^5.5.6",
     "simple-query-string": "^1.3.0",
     "sql.js": "github:DestinyItemManager/sql.js",
     "textcomplete": "^0.16.0",

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -1,4 +1,3 @@
-import { BehaviorSubject, Subject } from '@reactivex/rxjs';
 import { StateParams } from '@uirouter/angularjs';
 import { IPromise, IRootScopeService } from 'angular';
 import {
@@ -8,19 +7,22 @@ import {
   DestinyProfileResponse,
   DestinyProgression
   } from 'bungie-api-ts/destiny2';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Subject } from 'rxjs/Subject';
 import * as _ from 'underscore';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.service';
 import { Destiny2ApiService } from '../bungie-api/destiny2-api.service';
+import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { PLATFORMS } from '../bungie-api/platforms';
 import { BucketsService, DimInventoryBuckets } from '../destiny2/d2-buckets.service';
 import { D2DefinitionsService, D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { bungieNetPath } from '../dim-ui/bungie-image';
 import { optimalLoadout } from '../loadout/loadout-utils';
 import { Loadout } from '../loadout/loadout.service';
+import '../rx-operators';
 import { flatMap } from '../util';
 import { D2ItemFactoryType } from './store/d2-item-factory.service';
 import { D2StoreFactoryType, DimStore, DimVault } from './store/d2-store-factory.service';
-import { bungieErrorToaster } from '../bungie-api/error-toaster';
 
 /**
  * TODO: For now this is a copy of StoreService customized for D2. Over time we should either

--- a/src/app/inventory/dimStoreService.factory.js
+++ b/src/app/inventory/dimStoreService.factory.js
@@ -1,5 +1,7 @@
 import _ from 'underscore';
-import { Subject, BehaviorSubject } from '@reactivex/rxjs';
+import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import '../rx-operators';
 
 import { flatMap } from '../util';
 import { compareAccounts } from '../accounts/destiny-account.service';

--- a/src/app/mediaQueries.js
+++ b/src/app/mediaQueries.js
@@ -1,4 +1,6 @@
-import { Observable, Scheduler } from '@reactivex/rxjs';
+import { Observable } from 'rxjs/Observable';
+import { Scheduler } from 'rxjs/Scheduler';
+import './rx-operators';
 
 // This seems like a good breakpoint for portrait based on https://material.io/devices/
 // We can't use orientation:portrait because Android Chrome messes up when the keyboard is shown: https://www.chromestatus.com/feature/5656077370654720

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -1,4 +1,3 @@
-import { ConnectableObservable, ReplaySubject, Subject } from '@reactivex/rxjs';
 import {
   DestinyCharacterComponent,
   DestinyCharacterProgressionComponent,
@@ -8,11 +7,15 @@ import {
   DictionaryComponentResponse,
   SingleComponentResponse
   } from 'bungie-api-ts/destiny2';
+import { ConnectableObservable } from 'rxjs/observable/ConnectableObservable';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { Subject } from 'rxjs/Subject';
 import * as _ from 'underscore';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.service';
 import { Destiny2ApiService } from '../bungie-api/destiny2-api.service';
-import { D2DefinitionsService, D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
+import { D2DefinitionsService, D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import '../rx-operators';
 
 export interface ProgressService {
   getProgressStream(account: DestinyAccount): ConnectableObservable<ProgressProfile>;

--- a/src/app/progress/progress.tsx
+++ b/src/app/progress/progress.tsx
@@ -1,4 +1,4 @@
-import { Subscription } from '@reactivex/rxjs';
+import { Subscription } from 'rxjs/Subscription';
 import { IScope } from 'angular';
 import {
   DestinyCharacterComponent,


### PR DESCRIPTION
This moves back to the normal 'rxjs' package (I'd only switched to `@reactivex/rxjs` because it seemed to have better TS support, but the normal package started working again). I also switched to individual imports instead of importing all of 'rxjs'. It's a bit of a pain (especially having to import every operator) but it saves ~150K in our bundle! I made a `rx-operators` file you can import that'll just take care of the dirty work, anyway.