### PR TITLE
Inline the webpack manifest

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -8,6 +8,7 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const WebpackNotifierPlugin = require('webpack-notifier');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const InlineManifestWebpackPlugin = require('inline-manifest-webpack-plugin');
 // const Visualizer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const NotifyPlugin = require('notify-webpack-plugin');
@@ -152,25 +153,29 @@ module.exports = (env) => {
 
       new ExtractTextPlugin('styles-[contenthash:6].css'),
 
+      new InlineManifestWebpackPlugin({
+        name: 'webpackManifest'
+      }),
+
       new HtmlWebpackPlugin({
         inject: false,
         filename: 'index.html',
         template: '!handlebars-loader!src/index.html',
-        chunks: ['manifest', 'vendor', 'main', 'browsercheck']
+        chunks: ['vendor', 'main', 'browsercheck']
       }),
 
       new HtmlWebpackPlugin({
         inject: false,
         filename: 'return.html',
         template: '!handlebars-loader!src/return.html',
-        chunks: ['manifest', 'vendor', 'authReturn']
+        chunks: ['vendor', 'authReturn']
       }),
 
       new HtmlWebpackPlugin({
         inject: false,
         filename: 'gdrive-return.html',
         template: '!handlebars-loader!src/gdrive-return.html',
-        chunks: ['manifest', 'vendor', 'gdriveReturn']
+        chunks: ['vendor', 'gdriveReturn']
       }),
 
       new CopyWebpackPlugin([
@@ -317,9 +322,8 @@ module.exports = (env) => {
       maximumFileSizeToCacheInBytes: 5000000,
       globPatterns: ['**/*.{html,js,css,woff2}', 'static/*.png'],
       globIgnores: [
-        'authReturn*',
+        'manifest-*.js',
         'extension-scripts/*',
-        'return.html',
         'service-worker.js'
       ],
       swSrc: './dist/service-worker.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7951,6 +7951,15 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "inline-manifest-webpack-plugin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/inline-manifest-webpack-plugin/-/inline-manifest-webpack-plugin-3.0.1.tgz",
+      "integrity": "sha1-yiFRBjEVKY4v2UtmmrdsfdY+RK0=",
+      "dev": true,
+      "requires": {
+        "source-map-url": "0.4.0"
+      }
+    },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "html-webpack-plugin": "^2.30.1",
     "htmlhint": "^0.9.13",
     "imports-loader": "^0.7.0",
+    "inline-manifest-webpack-plugin": "^3.0.1",
     "load-grunt-tasks": "^3.5.0",
     "node-sass": "^4.7.2",
     "notify-webpack-plugin": "^1.0.0",

--- a/src/gdrive-return.html
+++ b/src/gdrive-return.html
@@ -18,6 +18,7 @@
     </div>
 
     <script src="https://apis.google.com/js/api.js"></script>
+    {{htmlWebpackPlugin.files.webpackManifest}}
     {{#each htmlWebpackPlugin.files.js}}
     <script type="text/javascript" src="{{ webpackConfig.output.publicPath }}{{ this }}"></script>
     {{/each}}

--- a/src/index.html
+++ b/src/index.html
@@ -46,6 +46,7 @@
     <script async src="https://www.google-analytics.com/analytics.js"></script>
     <script src="https://apis.google.com/js/api.js"></script>
 
+    {{{htmlWebpackPlugin.files.webpackManifest}}}
     {{#each htmlWebpackPlugin.files.js}}
     <script type="text/javascript" src="{{ webpackConfig.output.publicPath }}{{ this }}"></script>
     {{/each}}

--- a/src/return.html
+++ b/src/return.html
@@ -12,6 +12,7 @@
       <dim-return></dim-return>
     </div>
 
+    {{htmlWebpackPlugin.files.webpackManifest}}
     {{#each htmlWebpackPlugin.files.js}}
     <script type="text/javascript" src="{{ webpackConfig.output.publicPath }}{{ this }}"></script>
     {{/each}}


### PR DESCRIPTION
Another small optimization. We previously split out the webpack manifest code into a separate chunk to aid in caching (if you don't do this, your entry chunk will always change when any other chunk changes!). This is a piddly little blob of code, though, so it's easy enough to just inline it into the HTML to avoid an extra fetch.