### PR TITLE
Show activity modifiers for nightfall

### DIFF
--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -18,7 +18,8 @@ import {
   DestinySocketTypeDefinition,
   DestinyStatDefinition,
   DestinyTalentGridDefinition,
-  DestinyVendorDefinition
+  DestinyVendorDefinition,
+  DestinyActivityModifierDefinition
   } from 'bungie-api-ts/destiny2';
 import * as _ from 'underscore';
 
@@ -32,6 +33,7 @@ const lazyTables = [
   'ItemCategory', // DestinyItemCategoryDefinition
   'Activity', // DestinyActivityDefinition
   'ActivityType', // DestinyActivityTypeDefinition
+  'ActivityModifier',
   'Vendor',
   'SocketCategory',
   'SocketType',
@@ -61,6 +63,7 @@ export interface D2ManifestDefinitions {
   ItemCategory: LazyDefinition<DestinyItemCategoryDefinition>;
   Activity: LazyDefinition<DestinyActivityDefinition>;
   ActivityType: LazyDefinition<DestinyActivityTypeDefinition>;
+  ActivityModifier: LazyDefinition<DestinyActivityModifierDefinition>;
   Vendor: LazyDefinition<DestinyVendorDefinition>;
   SocketCategory: LazyDefinition<DestinySocketCategoryDefinition>;
   SocketType: LazyDefinition<DestinySocketTypeDefinition>;

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -117,4 +117,27 @@
       font-size: 10px;
     }
   }
+
+
+  .milestone-modifier {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    margin-top: 4px;
+
+    img {
+      width: 16px;
+      height: 16px;
+      margin: 1px 6px 0 2px;
+    }
+
+    .milestone-modifier-info {
+      flex: 1;
+    }
+
+    .milestone-modifier-description {
+      font-size: 10px;
+      color: #A1A2A2;
+    }
+  }
 }

--- a/src/app/progress/milestone.tsx
+++ b/src/app/progress/milestone.tsx
@@ -8,7 +8,8 @@ import {
   DestinyMilestoneRewardCategoryDefinition,
   DestinyMilestoneRewardEntry,
   DestinyObjectiveProgress,
-  DestinyQuestStatus
+  DestinyQuestStatus,
+  DestinyActivityModifierDefinition
   } from 'bungie-api-ts/destiny2';
 import classNames from 'classnames';
 import { t } from 'i18next';
@@ -122,8 +123,12 @@ function AvailableQuest(props: AvailableQuestProps) {
   const displayProperties: DestinyDisplayPropertiesDefinition = questDef.displayProperties || milestoneDef.displayProperties;
 
   let activityDef: DestinyActivityDefinition | null = null;
+  let modifiers: DestinyActivityModifierDefinition[] = [];
   if (availableQuest.activity) {
     activityDef = defs.Activity.get(availableQuest.activity.activityHash);
+    if (availableQuest.activity.modifierHashes) {
+      modifiers = availableQuest.activity.modifierHashes.map((h) => defs.ActivityModifier.get(h));
+    }
   }
 
   // Only look at the first reward, the rest are screwy (old engram versions, etc)
@@ -146,6 +151,9 @@ function AvailableQuest(props: AvailableQuestProps) {
         {activityDef && activityDef.displayProperties.name !== displayProperties.name &&
           <div className="milestone-location">{activityDef.displayProperties.name}</div>}
         <div className="milestone-description">{objectiveDef ? objectiveDef.progressDescription : displayProperties.description}</div>
+        {modifiers.map((modifier) =>
+          <ActivityModifier key={modifier.hash} modifier={modifier}/>
+        )}
         {questRewards.map((questReward) =>
           <div className="milestone-reward" key={questReward.hash}>
             <BungieImage src={questReward.displayProperties.icon} />
@@ -273,4 +281,20 @@ function MilestoneObjectiveStatus(props: MilestoneObjectiveStatusProps) {
   }
 
   return null;
+}
+
+function ActivityModifier(props: {
+  modifier: DestinyActivityModifierDefinition;
+}) {
+  const { modifier } = props;
+
+  return (
+    <div className="milestone-modifier">
+      <BungieImage src={modifier.displayProperties.icon}/>
+      <div className="milestone-modifier-info">
+        <div className="milestone-modifier-name">{modifier.displayProperties.name}</div>
+        <div className="milestone-modifier-description">{modifier.displayProperties.description}</div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
<img width="298" alt="screen shot 2018-01-19 at 10 10 43 pm" src="https://user-images.githubusercontent.com/313208/35180463-a725f104-fd65-11e7-932a-3678bb5ffbca.png">

This shows the modifiers for activities (right now it's only nightfall).