### PR TITLE
Fix bad reference in D2ReviewDataCache

### DIFF
--- a/src/app/destinyTrackerApi/d2-reviewDataCache.js
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.js
@@ -151,7 +151,7 @@ class D2ReviewDataCache {
     let matchingItem = this._getMatchingItem(item);
 
     if (!matchingItem) {
-      this.addScore(reviewsData);
+      this._addScore(reviewsData);
     }
 
     matchingItem = this._getMatchingItem(item);


### PR DESCRIPTION
I see that we're getting this error: `Possibly unhandled rejection: {}: this.addScore is not a function`. I think this is the fix, but there's another method called `addScores` that could be the right one as well, and I can't really tell the difference between the two. @48klocs, can you confirm?