### PR TITLE
Lazy load D1 routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9765,6 +9765,11 @@
         "isobject": "3.0.1"
       }
     },
+    "oclazyload": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/oclazyload/-/oclazyload-1.1.0.tgz",
+      "integrity": "sha1-qYBzIvGQggqBwCLy7xcB0DbYPoc="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "ng-http-rate-limiter": "^1.0.1",
     "ng-i18next": "^1.0.5",
     "ngimport": "^0.8.0",
+    "oclazyload": "^1.1.0",
     "popper.js": "^1.13.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/src/app/destiny1/destiny1.module.js
+++ b/src/app/destiny1/destiny1.module.js
@@ -2,8 +2,16 @@ import angular from 'angular';
 
 import { Destiny1Component } from './destiny1.component';
 
+import recordBooksModule from '../record-books/record-books.module';
+import activitiesModule from '../activities/activities.module';
+import loadoutBuilderModule from '../loadout-builder/loadout-builder.module';
+
 export default angular
-  .module('destiny1Module', [])
+  .module('destiny1Module', [
+    recordBooksModule,
+    activitiesModule,
+    loadoutBuilderModule
+  ])
   .component('destiny1', Destiny1Component)
   .config(($stateProvider) => {
     'ngInject';
@@ -16,5 +24,4 @@ export default angular
       url: '/d1',
       component: 'destiny1'
     });
-  })
-  .name;
+  });

--- a/src/app/destiny1/destiny1.module.js
+++ b/src/app/destiny1/destiny1.module.js
@@ -5,12 +5,14 @@ import { Destiny1Component } from './destiny1.component';
 import recordBooksModule from '../record-books/record-books.module';
 import activitiesModule from '../activities/activities.module';
 import loadoutBuilderModule from '../loadout-builder/loadout-builder.module';
+import vendorsrModule from '../vendors/vendors.module';
 
 export default angular
   .module('destiny1Module', [
     recordBooksModule,
     activitiesModule,
-    loadoutBuilderModule
+    loadoutBuilderModule,
+    vendorsrModule
   ])
   .component('destiny1', Destiny1Component)
   .config(($stateProvider) => {

--- a/src/app/dimApp.module.js
+++ b/src/app/dimApp.module.js
@@ -21,7 +21,6 @@ import bungieApiModule from './bungie-api/bungie-api.module';
 import accountsModule from './accounts/accounts.module';
 import { ShellModule } from './shell/shell.module';
 import inventoryModule from './inventory/inventory.module';
-import vendorsModule from './vendors/vendors.module';
 import itemReviewModule from './item-review/item-review.module';
 import loginModule from './login/login.module';
 import compareModule from './compare/compare.module';
@@ -60,7 +59,6 @@ const dependencies = [
   bungieApiModule,
   accountsModule,
   inventoryModule,
-  vendorsModule,
   itemReviewModule,
   loginModule,
   compareModule,

--- a/src/app/dimApp.module.js
+++ b/src/app/dimApp.module.js
@@ -15,16 +15,14 @@ import UIRouterModule from '@uirouter/angularjs';
 import ngI18Next from 'ng-i18next';
 import 'angular-hotkeys';
 import 'angular-promise-tracker';
+import ocLazyLoadModule from 'oclazyload';
 
 import bungieApiModule from './bungie-api/bungie-api.module';
 import accountsModule from './accounts/accounts.module';
 import { ShellModule } from './shell/shell.module';
 import inventoryModule from './inventory/inventory.module';
-import recordBooksModule from './record-books/record-books.module';
-import activitiesModule from './activities/activities.module';
 import vendorsModule from './vendors/vendors.module';
 import itemReviewModule from './item-review/item-review.module';
-import loadoutBuilderModule from './loadout-builder/loadout-builder.module';
 import loginModule from './login/login.module';
 import compareModule from './compare/compare.module';
 import infuseModule from './infuse/infuse.module';
@@ -35,7 +33,6 @@ import storageModule from './storage/storage.module';
 import loadoutModule from './loadout/loadout.module';
 import movePopupModule from './move-popup/move-popup.module';
 import searchModule from './search/search.module';
-import destiny1Module from './destiny1/destiny1.module';
 import destiny2Module from './destiny2/destiny2.module';
 import { progressModule } from './progress/progress.module';
 
@@ -53,6 +50,7 @@ const dependencies = [
   MessagesModule,
   TouchModule,
   ngI18Next,
+  ocLazyLoadModule,
   ngSanitize,
   RateLimiterModule,
   ShellModule,
@@ -62,11 +60,8 @@ const dependencies = [
   bungieApiModule,
   accountsModule,
   inventoryModule,
-  recordBooksModule,
-  activitiesModule,
   vendorsModule,
   itemReviewModule,
-  loadoutBuilderModule,
   loginModule,
   compareModule,
   infuseModule,
@@ -77,7 +72,6 @@ const dependencies = [
   loadoutModule,
   movePopupModule,
   searchModule,
-  destiny1Module,
   destiny2Module,
   progressModule,
   'ajoslin.promise-tracker',

--- a/src/app/search/search-filter.component.js
+++ b/src/app/search/search-filter.component.js
@@ -16,7 +16,7 @@ export const SearchFilterComponent = {
 };
 
 function SearchFilterCtrl(
-  $scope, dimStoreService, D2StoresService, dimVendorService, dimSearchService, dimItemInfoService, hotkeys, $i18next, $element, dimCategory, dimSettingsService, toaster, ngDialog, $stateParams) {
+  $scope, dimStoreService, D2StoresService, dimSearchService, dimItemInfoService, hotkeys, $i18next, $element, dimCategory, dimSettingsService, toaster, ngDialog, $stateParams, $injector) {
   'ngInject';
   const vm = this;
   vm.search = dimSearchService;
@@ -216,6 +216,8 @@ function SearchFilterCtrl(
     }
 
     if (vm.destinyVersion === 1) {
+      // This hacks around the fact that dimVendorService isn't defined until the destiny1 modules are lazy-loaded
+      const dimVendorService = $injector.get('dimVendorService');
       // Filter vendor items
       _.each(dimVendorService.vendors, (vendor) => {
         for (const saleItem of vendor.allItems) {

--- a/src/app/shell/destiny-account.route.js
+++ b/src/app/shell/destiny-account.route.js
@@ -36,4 +36,15 @@ export function destinyAccountRoute($stateProvider) {
       }
     }
   });
+
+  // Register a lazy future state for all Destiny 1 pages, so they are not in the main chunk.
+  $stateProvider.state({
+    name: 'destiny1.**',
+    parent: 'destiny-account',
+    lazyLoad($transition$) {
+      const $ocLazyLoad = $transition$.injector().get('$ocLazyLoad');
+      return import(/* webpackChunkName: "destiny1" */ '../destiny1/destiny1.module.js')
+        .then((mod) => $ocLazyLoad.load(mod.default));
+    }
+  });
 }

--- a/src/app/shell/header.component.js
+++ b/src/app/shell/header.component.js
@@ -13,10 +13,10 @@ function HeaderController(
   ngDialog,
   $rootScope,
   hotkeys,
-  dimXurService,
   dimSettingsService,
   $transitions,
-  $state
+  $state,
+  $injector
 ) {
   'ngInject';
 
@@ -35,7 +35,16 @@ function HeaderController(
     bugReportLink: $DIM_FLAVOR !== 'release'
   };
 
-  vm.destinyVersion = getCurrentDestinyVersion($state);
+  vm.$onInit = function() {
+    vm.destinyVersion = getCurrentDestinyVersion();
+
+    // This hacks around the fact that dimXurService isn't defined until the destiny1 modules are lazy-loaded
+    if (vm.destinyVersion === 1) {
+      const dimXurService = $injector.get('dimXurService');
+      vm.showXur = showPopupFunction('xur', '<xur></xur>');
+      vm.xur = dimXurService;
+    }
+  };
 
   function getCurrentDestinyVersion() {
     // TODO there must be a better way of doing this?
@@ -47,9 +56,7 @@ function HeaderController(
     return null;
   }
 
-  $transitions.onSuccess({ }, () => {
-    vm.destinyVersion = getCurrentDestinyVersion();
-  });
+  $transitions.onSuccess({ }, () => vm.$onInit());
 
   /**
    * Show a popup dialog containing the given template. Its class
@@ -76,8 +83,4 @@ function HeaderController(
       }
     };
   }
-
-  vm.showXur = showPopupFunction('xur', '<xur></xur>');
-
-  vm.xur = dimXurService;
 }


### PR DESCRIPTION
This starts playing with code splitting and lazy-loading functionality when it's needed. I'm starting out very coarse-grained, by lazy-loading all the modules that are only used in D1.

```
Before:
841K vendor-7d7bb7.js
161K styles-a37919.css
433K main-b42033.js

After:
854K vendor-8e38a7.js
144K styles-72d7bb.css
371K main-95638a.js
83K chunk-0-destiny1-7e1f47.js
```

I'm not super sure why vendor got bigger, but you can see that a fair bit of styles and code have moved to the destiny1 chunk. We still share the majority of stuff between D1 and D2 so it's not larger, but this is still pretty interesting. Another thing to note is that the CSS unique to D1 is now inside the destiny1 JS chunk - I haven't figured out how to (or if I should) split it out into a separate CSS file that's required in parallel.