### PR TITLE
Reverse priority of account selector info

### DIFF
--- a/src/app/accounts/account-select.scss
+++ b/src/app/accounts/account-select.scss
@@ -8,17 +8,21 @@ account-select {
 account {
   display: block;
   cursor: pointer;
-  line-height: 13px;
+  line-height: 15px;
   text-align: left;
   padding-left: 8px;
   padding-right: 8px;
   position: relative;
-  padding-top: 8px;
-  padding-bottom: 6px;
+  padding-top: 6px;
+  padding-bottom: 4px;
 
   .account-details {
     font-size: 10px !important;
     color: #AAA;
+  }
+
+  .account-name span {
+    margin: 0 !important;
   }
 
   &:focus, &:active {
@@ -27,7 +31,7 @@ account {
 
   &.selected-account {
     margin: 0 0 0 2px;
-    padding-right: 19px;
+    padding-right: 22px;
     border-bottom: 2px solid $orange;
 
     &::after {

--- a/src/app/accounts/account.html
+++ b/src/app/accounts/account.html
@@ -1,2 +1,2 @@
-<div class="account-name">{{ $ctrl.account.displayName }}</div>
-<div class="account-details">Destiny{{ $ctrl.account.destinyVersion == 1 ? '' : ' 2' }} • {{ $ctrl.account.platformLabel }}</div>
+<div class="account-name">Destiny {{ $ctrl.account.destinyVersion == 1 ? '1' : '2' }} • <span ng-i18next="{{ 'Accounts.' + $ctrl.account.platformLabel }}"></span></div>
+<div class="account-details">{{ $ctrl.account.displayName }}</div>

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -16,7 +16,7 @@
 }
 
 #header {
-  padding: 0 2px;
+  padding: 0 0 0 2px;
   position: fixed;
   z-index: 15;
   top: 0;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -1,4 +1,9 @@
 {
+  "Accounts": {
+    "PlayStation": "PS4",
+    "Xbox": "XB1",
+    "Blizzard": "PC"
+  },
   "Activities": {
     "Activities": "Activities",
     "Hard": "Hard",


### PR DESCRIPTION
<img width="208" alt="screen shot 2018-01-20 at 10 03 05 pm" src="https://user-images.githubusercontent.com/313208/35191347-d0e311a2-fe2d-11e7-9f76-6c9c4dcf6028.png">
<img width="183" alt="screen shot 2018-01-20 at 10 03 10 pm" src="https://user-images.githubusercontent.com/313208/35191348-d0fb1c66-fe2d-11e7-96fc-eb2ba953dff6.png">

This is a little thing that'd been bugging me for a while - I think it's more important to show the version and platform than the username (especially since some people have the same name across platforms). I also think people can handle us not spelling out "PlayStation" and "Blizzard", so I abbreviated them to PS4, XB1, and PC. I also considered icons, though there's no good icon/color for "PC" and making colored icons stand out would be tough.

As a result, the menu seems to take a bit less space, too.