### PR TITLE
Use allChunks option for ExtractTextPlugin

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -139,7 +139,10 @@ module.exports = (env) => {
 
       new NotifyPlugin('DIM', !isDev),
 
-      new ExtractTextPlugin('styles-[contenthash:6].css'),
+      new ExtractTextPlugin({
+        filename: 'styles-[contenthash:6].css',
+        allChunks: true
+      }),
 
       new InlineManifestWebpackPlugin({
         name: 'webpackManifest'


### PR DESCRIPTION
Turns out we were supposed to be setting `allChunks: true` on `ExtractTextPlugin` when using `CommonsChunkPlugin`. Enabling this saves us 70K across our JS files, and only adds 17K to our CSS.