### PR TITLE
Improve move-aside logic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Storage (Google Drive) settings have moved to the Settings page.
 * You can configure a custom item sorting method from the Settings page.
 * Improved display of the account selection dropdown.
+* DIM's logic to automatically move aside items to make room for what you're moving is smarter - it'll leave put things you just moved, and it'll prefer items you've tagged as favorites.
 
 # 4.36.1
 

--- a/src/app/inventory/dimItemMoveService.factory.js
+++ b/src/app/inventory/dimItemMoveService.factory.js
@@ -1,4 +1,3 @@
-import angular from 'angular';
 import _ from 'underscore';
 
 export function ItemMoveService($q, loadingTracker, toaster, D2StoresService, dimStoreService, dimActionQueue, dimItemService, dimInfoService, $i18next) {
@@ -18,36 +17,36 @@ export function ItemMoveService($q, loadingTracker, toaster, D2StoresService, di
       hide: $i18next.t('DidYouKnow.DontShowAgain')
     });
   });
-
   /**
    * Move the item to the specified store. Equip it if equip is true.
    */
-  const moveItemTo = dimActionQueue.wrap((item, store, equip, amount, callback) => {
+  const moveItemTo = dimActionQueue.wrap((item, store, equip, amount) => {
     didYouKnow();
-
     const reload = item.equipped || equip;
     let promise = dimItemService.moveTo(item, store, equip, amount);
 
     if (reload) {
       // Refresh light levels and such
-      promise = promise.then(() => {
-        return getStoreService(item).updateCharacters();
+      promise = promise.then((item) => {
+        return getStoreService(item)
+          .updateCharacters()
+          .then(() => item);
       });
     }
 
     promise = promise
+      .then((item) => item.updateManualMoveTimestamp())
       .catch((a) => {
         toaster.pop('error', item.name, a.message);
         console.error('error moving item', item, 'to', store, a);
       });
 
     loadingTracker.addPromise(promise);
-    (callback || angular.noop)();
 
     return promise;
   });
 
-  const consolidate = dimActionQueue.wrap((actionableItem, store, callback) => {
+  const consolidate = dimActionQueue.wrap((actionableItem, store) => {
     const stores = _.filter(getStoreService(actionableItem).getStores(), (s) => { return !s.isVault; });
     const vault = getStoreService(actionableItem).getVault();
 
@@ -92,12 +91,11 @@ export function ItemMoveService($q, loadingTracker, toaster, D2StoresService, di
     });
 
     loadingTracker.addPromise(promise);
-    (callback || angular.noop)();
 
     return promise;
   });
 
-  const distribute = dimActionQueue.wrap((actionableItem, store, callback) => {
+  const distribute = dimActionQueue.wrap((actionableItem) => {
     // Sort vault to the end
     const stores = _.sortBy(getStoreService(actionableItem).getStores(), (s) => { return s.id === 'vault' ? 2 : 1; });
 
@@ -171,7 +169,6 @@ export function ItemMoveService($q, loadingTracker, toaster, D2StoresService, di
     });
 
     loadingTracker.addPromise(promise);
-    (callback || angular.noop)();
 
     return promise;
   });

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -5,6 +5,7 @@ import { Destiny2ApiService } from '../bungie-api/destiny2-api.service';
 import { DimStore } from './store/d2-store-factory.service';
 import { StoreServiceType } from './d2-stores.service';
 import { DimError } from '../bungie-api/bungie-service-helper.service';
+import { chainComparator, compareBy, reverseComparator } from '../comparators';
 
 /**
  * A service for moving/equipping items. dimItemMoveService should be preferred for most usages.
@@ -72,7 +73,7 @@ export function ItemService(
       const stackable = item.maxStackSize > 1;
       // Items to be decremented
       const sourceItems = stackable
-        ? _.sortBy(_.filter(source.buckets[item.bucket.id], (i) => {
+        ? _.sortBy(source.buckets[item.bucket.id].filter((i) => {
           return i.hash === item.hash &&
                 i.id === item.id &&
                 !i.notransfer;
@@ -80,7 +81,7 @@ export function ItemService(
       // Items to be incremented. There's really only ever at most one of these, but
       // it's easier to deal with as a list.
       const targetItems = stackable
-        ? _.sortBy(_.filter(target.buckets[item.bucket.id], (i) => {
+        ? _.sortBy(target.buckets[item.bucket.id].filter((i) => {
           return i.hash === item.hash &&
                 i.id === item.id &&
                 // Don't consider full stacks as targets
@@ -193,7 +194,7 @@ export function ItemService(
   function searchForSimilarItem(item: DimItem, store: DimStore, exclusions: DimItem[] | undefined, target: DimStore, excludeExotic: boolean) {
     const exclusionsList = exclusions || [];
 
-    let candidates = _.filter(store.items, (i) => {
+    let candidates = store.items.filter((i) => {
       return i.canBeEquippedBy(target) &&
         i.location.id === item.location.id &&
         !i.equipped &&
@@ -253,7 +254,7 @@ export function ItemService(
       if (i.isExotic) {
         const otherExotic = getOtherExoticThatNeedsDequipping(i, store);
         // If we aren't already equipping into that slot...
-        if (otherExotic && !_.find(items, { type: otherExotic.type })) {
+        if (otherExotic && !items.find((i) => i.type === otherExotic.type)) {
           const similarItem = getSimilarItem(otherExotic);
           if (!similarItem) {
             return $q.reject(new Error($i18next.t('ItemService.Deequip', { itemname: otherExotic.name })));
@@ -364,7 +365,7 @@ export function ItemService(
    * aside. This is not a promise, it returns immediately.
    */
   function getOtherExoticThatNeedsDequipping(item: DimItem, store: DimStore) {
-    const equippedExotics = _.filter(store.items, (i) => {
+    const equippedExotics = store.items.filter((i) => {
       return (i.equipped &&
               i.location.id !== item.location.id &&
               i.location.sort === item.location.sort &&
@@ -384,9 +385,7 @@ export function ItemService(
       case 2:
         // Assume that only one of the equipped items has 'The Life Exotic' perk
         const hasLifeExotic = item.hasLifeExotic();
-        return _.find(equippedExotics, (i) => {
-          return hasLifeExotic ? i.hasLifeExotic() : !i.hasLifeExotic();
-        });
+        return equippedExotics.find((i) => hasLifeExotic ? i.hasLifeExotic() : !i.hasLifeExotic());
       default:
         throw new Error($i18next.t('ItemService.TwoExotics'));
     }
@@ -413,44 +412,7 @@ export function ItemService(
     // Check whether an item cannot or should not be moved
     function movable(otherItem) {
       return !otherItem.notransfer &&
-        !_.any(moveContext.excludes, { id: otherItem.id, hash: otherItem.hash });
-    }
-
-    // The value of an item to use for ranking which item to move
-    // aside. When moving from the vault we'll choose the
-    // highest-value item, while moving from a character to the
-    // vault (or another character) we'll use the lower value.
-    function itemValue(i) {
-      // Lower means more likely to get moved away
-      // Prefer not moving the equipped item
-      let value = i.equipped ? 10 : 0;
-      // Prefer moving lower-tier
-      value += {
-        Common: 0,
-        Uncommon: 1,
-        Rare: 2,
-        Legendary: 3,
-        Exotic: 4
-      }[i.tier];
-      // Prefer things this character can use
-      if (!store.isVault && i.canBeEquippedBy(store)) {
-        value += 5;
-      }
-      // And low-stat
-      if (i.primStat) {
-        value += i.primStat.value / 1000;
-      }
-      // Engrams prefer to be in the vault
-      if (!i.isEngram()) {
-        value += 20;
-      }
-
-      // prefer same type over everything
-      if (i.type === item.type) {
-        value += 50;
-      }
-
-      return value;
+        !moveContext.excludes.some((i) => i.id == otherItem.id && i.hash === otherItem.hash);
     }
 
     const stores = getStoreService(item).getStores();
@@ -458,9 +420,9 @@ export function ItemService(
 
     // Start with candidates of the same type (or vault bucket if it's vault)
     const allItems = store.isVault
-      ? _.filter(store.items!, (i) => i.bucket.vaultBucket!.id === item.bucket.vaultBucket!.id)
+      ? store.items!.filter((i) => i.bucket.vaultBucket!.id === item.bucket.vaultBucket!.id)
       : store.buckets[item.bucket.id];
-    let moveAsideCandidates = _.filter(allItems, movable);
+    let moveAsideCandidates = allItems.filter(movable);
 
     // if there are no candidates at all, fail
     if (moveAsideCandidates.length === 0) {
@@ -477,7 +439,7 @@ export function ItemService(
         if (i.maxStackSize > 1) {
           // Find another store that has an appropriate stackable
           otherStore = otherStores.find(
-            (otherStore) => _.any(otherStore.items, (otherItem) =>
+            (otherStore) => otherStore.items.some((otherItem) =>
               // Same basic item
               otherItem.hash === i.hash &&
                                   // Enough space to absorb this stack
@@ -493,11 +455,49 @@ export function ItemService(
       }
     }
 
+
+    const tierValue = {
+      Common: 0,
+      Uncommon: 1,
+      Rare: 2,
+      Legendary: 3,
+      Exotic: 4
+    };
+
+    const tagValue = {
+      // Infusion fuel belongs in the vault
+      infuse: -1,
+      // These are still good
+      keep: 1,
+      // Junk should probably bubble towards the character so you remember to delete them!
+      junk: 2,
+      // Favorites you want on your character
+      favorite: 3
+    };
+
+    // A sort for items to use for ranking which item to move
+    // aside. When moving from the vault we'll choose the
+    // "largest" item, while moving from a character to the
+    // vault (or another character) we'll use the "smallest".
+    // Note, in JS "true" is greater than "false".
+    const itemValueComparator: (a: DimItem, b: DimItem) => number = chainComparator(
+      // prefer same type over everything
+      compareBy((i) => i.type === item.typeName),
+      // Engrams prefer to be in the vault, so not-engram is larger than engram
+      compareBy((i) => !i.isEngram()),
+      compareBy((i) => i.equipped),
+      // Prefer things this character can use
+      compareBy((i) => !store.isVault && i.canBeEquippedBy(store)),
+      // Tagged items sort by the value of their tags
+      compareBy((i) => (i.dimInfo && i.dimInfo.tag) ? tagValue[i.dimInfo.tag] : 0),
+      // Prefer moving lower-tier
+      compareBy((i) => tierValue[i.tier]),
+      // Prefer keeping higher-stat items
+      compareBy((i) => i.primStat && i.primStat.value)
+    );
+
     // Sort all candidates
-    moveAsideCandidates = _.sortBy(moveAsideCandidates, itemValue);
-    if (store.isVault) {
-      moveAsideCandidates = moveAsideCandidates.reverse();
-    }
+    moveAsideCandidates.sort(store.isVault ? reverseComparator(itemValueComparator) : itemValueComparator);
 
     // A cached version of the space-left function
     const cachedSpaceLeft = _.memoize((store, item) => {
@@ -520,11 +520,10 @@ export function ItemService(
       // owner ranked last, but otherwise sorted by the
       // available space for the candidate item.
       const otherNonVaultStores = _.sortBy(
-        _.filter(otherStores, (s) => !s.isVault && s.id !== item.owner),
+        otherStores.filter((s) => !s.isVault && s.id !== item.owner),
         (s) => cachedSpaceLeft(s, candidate)).reverse();
       otherNonVaultStores.push(storeService.getStore(item.owner)!);
-      const otherCharacterWithSpace = _.find(otherNonVaultStores,
-                                             (s) => cachedSpaceLeft(s, candidate));
+      const otherCharacterWithSpace = otherNonVaultStores.find((s) => cachedSpaceLeft(s, candidate));
 
       if (store.isVault) { // If we're moving from the vault
         // If there's somewhere with space, put it there

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -493,7 +493,7 @@ export function ItemService(
       compareBy((i) => !i.isEngram()),
       // Never unequip something
       compareBy((i) => i.equipped),
-      // Always prefer keeping something that was manually moved over something that wasn't
+      // Always prefer keeping something that was manually moved where it is
       compareBy((i) => store.isVault ? (-1 * i.lastManuallyMoved) : (i.lastManuallyMoved)),
       // Prefer things this character can use
       compareBy((i) => !store.isVault && i.canBeEquippedBy(store)),

--- a/src/app/inventory/dimStoreBucket.directive.js
+++ b/src/app/inventory/dimStoreBucket.directive.js
@@ -156,11 +156,16 @@ function StoreBucketCtrl($scope,
 
       const reload = item.equipped || equip;
       if (reload) {
-        movePromise = movePromise.then(() => {
-          return getStoreService(item).updateCharacters();
+        movePromise = movePromise.then((item) => {
+          return getStoreService(item)
+            .updateCharacters()
+            .then(() => item);
         });
       }
-      return movePromise;
+      return movePromise
+        .then((item) => {
+          item.updateManualMoveTimestamp();
+        });
     }).catch((e) => {
       if (e.message !== 'move-canceled') {
         toaster.pop('error', item.name, e.message);

--- a/src/app/inventory/dimStoreItem.directive.js
+++ b/src/app/inventory/dimStoreItem.directive.js
@@ -36,7 +36,7 @@ export const StoreItemComponent = {
 let otherDialog = null;
 let firstItemTimed = false;
 
-export function StoreItemCtrl($scope, $element, dimItemService, dimStoreService, D2StoresService, ngDialog, dimLoadoutService, dimCompareService, $rootScope, dimActionQueue, dimDestinyTrackerService, NewItemsService) {
+export function StoreItemCtrl($scope, $element, dimItemMoveService, dimStoreService, D2StoresService, ngDialog, dimLoadoutService, dimCompareService, $rootScope, dimActionQueue, dimDestinyTrackerService, NewItemsService) {
   'ngInject';
 
   function getStoreService(item) {
@@ -91,10 +91,7 @@ export function StoreItemCtrl($scope, $element, dimItemService, dimStoreService,
       // Equip if it's not equipped or it's on another character
       const equip = !item.equipped || item.owner !== active.id;
 
-      dimItemService.moveTo(item, active, item.canBeEquippedBy(active) ? equip : false, item.amount)
-        .then(() => {
-          return getStoreService(item).updateCharacters();
-        });
+      dimItemMoveService.moveItemTo(item, active, item.canBeEquippedBy(active) ? equip : false, item.amount);
     }
   });
 

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -178,6 +178,7 @@ export interface DimItem {
   infusionQuality: DestinyItemQualityBlockDefinition | null;
   infusionFuel: boolean;
   masterworkInfo: DimMasterwork | null;
+  _isEngram: boolean;
 
   // TODO: this should be on a separate object, with the other DTR stuff
   pros: string;
@@ -313,7 +314,7 @@ export function D2ItemFactory(
       return _.contains(this.categories, categoryName);
     },
     isEngram() {
-      return false;
+      return this._isEngram;
     },
     canBeInLoadout() {
       return this.equipment || this.type === 'Material' || this.type === 'Consumable';
@@ -495,6 +496,7 @@ export function D2ItemFactory(
       locked: item.state & 1,
       masterwork: item.state & 4,
       classified: Boolean(itemDef.redacted),
+      _isEngram: itemDef.itemCategoryHashes.includes(34), // category hash for engrams
       isInLoadout: false,
       percentComplete: null, // filled in later
       talentGrid: null, // filled in later

--- a/src/app/inventory/store/item-factory.service.js
+++ b/src/app/inventory/store/item-factory.service.js
@@ -40,6 +40,8 @@ export function ItemFactory(
   'ngInject';
 
   let _idTracker = {};
+  // A map from instance id to the last time it was manually moved this session
+  const _moveTouchTimestamps = new Map();
 
   /**
    * Check to see if this item has a node that restricts it to a
@@ -97,6 +99,13 @@ export function ItemFactory(
     // "The Life Exotic" Perk on Exotic Items means you can equip another exotic
     hasLifeExotic: function() {
       return this.isExotic && this.talentGrid && (_.find(this.talentGrid.nodes, { hash: 4044819214 }) !== undefined);
+    },
+    // Mark that this item has been moved manually
+    updateManualMoveTimestamp() {
+      this.lastManuallyMoved = Date.now();
+      if (this.id !== '0') {
+        _moveTouchTimestamps.set(this.id, this.lastManuallyMoved);
+      }
     }
   };
 
@@ -307,6 +316,7 @@ export function ItemFactory(
       locked: item.locked,
       redacted: Boolean(itemDef.redacted),
       classified: Boolean(itemDef.classified),
+      lastManuallyMoved: item.itemInstanceId === '0' ? 0 : _moveTouchTimestamps.get(item.itemInstanceId) || 0,
       isInLoadout: false,
       dtrRating: item.dtrRating,
       percentComplete: null, // filled in later

--- a/src/app/move-popup/dimMovePopup.directive.js
+++ b/src/app/move-popup/dimMovePopup.directive.js
@@ -54,10 +54,12 @@ function MovePopupController($scope, D2StoresService, dimStoreService, ngDialog,
   }
 
   vm.consolidate = function() {
-    dimItemMoveService.consolidate(vm.item, vm.store, closeThisDialog);
+    closeThisDialog();
+    dimItemMoveService.consolidate(vm.item, vm.store);
   };
 
   vm.distribute = function() {
-    dimItemMoveService.distribute(vm.item, vm.store, closeThisDialog);
+    closeThisDialog();
+    dimItemMoveService.distribute(vm.item);
   };
 }

--- a/src/app/services/dimBucketService.factory.js
+++ b/src/app/services/dimBucketService.factory.js
@@ -150,7 +150,7 @@ function BucketService(dimDefinitions, dimCategory) {
 
         _.each(buckets.byHash, (bucket) => {
           if (sortToVault[bucket.sort]) {
-            bucket.vaultBucket = buckets.byId[bucket.sort];
+            bucket.vaultBucket = buckets.byId[sortToVault[bucket.sort]];
           }
         });
 


### PR DESCRIPTION
This finally fixes #739 - we no longer will move aside something you just moved there manually to make room for another item!

This change has a few things:
1. Fixes some bugs that prevented moving items from character to character through a full vault.
2. Fixes a bug in D1 that I introduced in [this change](169011cd689d3feb44c156589c613928f4fbe4dd) (`vaultBucket` isn't defined).
3. Switches the move-aside value comparator to use my new comparator builders. No more weird adding and removing numbers to try and make a hierarchical sort.
4. Add tagging to the move-aside logic. It'll prefer to keep favorites, keeps, and junk (so you can delete it), and prefer to move away infusion material.
5. Add a session-scoped tracker of when you last *manually* moved an item, and incorporate that into the move-aside logic. This means you can drag multiple items onto a full character and we won't start moving them back to make room for each new item. This was #739 and it's been a long-standing annoyance.