### PR TITLE
i18n'd item tagging

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fixed display of Clan XP milestone.
 * DIM's logic to automatically move aside items to make room for what you're moving is smarter - it'll leave put things you just moved, and it'll prefer items you've tagged as favorites.
 * Accounts with no characters will no longer show up in the account dropdown.
-* Item tagging via keyboard should be a little more international-friendly.
+* Item tagging via keyboard should be a little more international-friendly. Calling the help menu (via shift+/) is too.
 
 # 4.37.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed display of Clan XP milestone.
 * DIM's logic to automatically move aside items to make room for what you're moving is smarter - it'll leave put things you just moved, and it'll prefer items you've tagged as favorites.
 * Accounts with no characters will no longer show up in the account dropdown.
+* Item tagging via keyboard should be a little more international-friendly.
 
 # 4.37.0
 

--- a/src/app/dimApp.config.js
+++ b/src/app/dimApp.config.js
@@ -11,6 +11,7 @@ function config($compileProvider, $httpProvider, hotkeysProvider,
   $httpProvider.useApplyAsync(true);
 
   hotkeysProvider.includeCheatSheet = true;
+  hotkeysProvider.cheatSheetHotkey = 'shift+/';
 
   // Bungie's API will start throttling an API if it's called more than once per second. It does this
   // by making responses take 2s to return, not by sending an error code or throttling response. Choosing

--- a/src/app/settings/dimSettingsService.factory.js
+++ b/src/app/settings/dimSettingsService.factory.js
@@ -110,10 +110,10 @@ export function SettingsService($rootScope, SyncService, $window, $i18next, $q) 
     // for now just override itemTags. eventually let users create own?
     savedSettings.itemTags = [
       { type: undefined, label: 'Tags.TagItem' },
-      { type: 'favorite', label: 'Tags.Favorite', hotkey: '!', icon: 'star' },
-      { type: 'keep', label: 'Tags.Keep', hotkey: '@', icon: 'tag' },
-      { type: 'junk', label: 'Tags.Junk', hotkey: '#', icon: 'ban' },
-      { type: 'infuse', label: 'Tags.Infuse', hotkey: '$', icon: 'bolt' }
+      { type: 'favorite', label: 'Tags.Favorite', hotkey: 'shift+1', icon: 'star' },
+      { type: 'keep', label: 'Tags.Keep', hotkey: 'shift+2', icon: 'tag' },
+      { type: 'junk', label: 'Tags.Junk', hotkey: 'shift+3', icon: 'ban' },
+      { type: 'infuse', label: 'Tags.Infuse', hotkey: 'shift+4', icon: 'bolt' }
     ];
 
     _loaded = true;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -654,7 +654,7 @@
       "FAQDupeGally": "Hey, DIM duplicated my Gjallarhorn!",
       "FAQDupeGallyAnswer": "No, we didn't. Promise.",
       "FAQKeyboard": "Does DIM support keyboard shortcuts?",
-      "FAQKeyboardAnswer": "Yes! Press \"?\" to see a list of available shortcuts.",
+      "FAQKeyboardAnswer": "Yes! Press \"shift+/\" to see a list of available shortcuts.",
       "FAQLogout": "How can I log out of DIM?",
       "FAQLogoutAnswer": "Click on your account in the top right of the screen and choose \"Log out\".",
       "FAQLostItem": "I lost my item using your tool!",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -654,7 +654,7 @@
       "FAQDupeGally": "Hey, DIM duplicated my Gjallarhorn!",
       "FAQDupeGallyAnswer": "No, we didn't. Promise.",
       "FAQKeyboard": "Does DIM support keyboard shortcuts?",
-      "FAQKeyboardAnswer": "Yes! Press \"shift+/\" to see a list of available shortcuts.",
+      "FAQKeyboardAnswer": "Yes! Press \"shift+/ or ?\" to see a list of available shortcuts.",
       "FAQLogout": "How can I log out of DIM?",
       "FAQLogoutAnswer": "Click on your account in the top right of the screen and choose \"Log out\".",
       "FAQLostItem": "I lost my item using your tool!",


### PR DESCRIPTION
From issue #2589, made item tagging via keyboard a little more i18n-friendly.

The shortcuts are the same on en-US, they should just work in other places now without excess contortion.

![i18n-keyboard-shortcuts](https://user-images.githubusercontent.com/606888/35526102-694e8148-04f4-11e8-9df8-97c9d6d26384.png)
