### PR TITLE
Stop updating chrome extension - pin it to version 10.0.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,6 @@ module.exports = function(grunt) {
     if (dist === 'beta') {
       manifest.name = 'Destiny Item Manager Beta Shortcut';
     }
-    manifest.version = dist === 'beta' ? betaVersion : pkg.version;
 
     grunt.file.write('extension-dist/manifest.json', JSON.stringify(manifest));
     var mainjs = grunt.file.read('extension-dist/main.js');
@@ -228,24 +227,32 @@ module.exports = function(grunt) {
     'sortJSON:i18n'
   ]);
 
-  grunt.registerTask('publish_beta', [
-    'crowdin-request:upload',
+  grunt.registerTask('publish_beta_extension', [
     'update_chrome_beta_manifest',
     'compress:chrome',
     'log_beta_version',
-    'webstore_upload:beta',
-    'precompress',
-    'rsync:beta',
-    'rsync:website',
+    'webstore_upload:beta'
   ]);
 
-  grunt.registerTask('publish_release', [
+  grunt.registerTask('publish_release_extension', [
     'update_chrome_release_manifest',
     'compress:chrome',
     'log_release_version',
-    'precompress',
-    'rsync:prod',
     'webstore_upload:release'
+  ]);
+
+  grunt.registerTask('publish_beta', [
+    'crowdin-request:upload',
+    'log_beta_version',
+    'precompress',
+    'rsync:beta',
+    'rsync:website'
+  ]);
+
+  grunt.registerTask('publish_release', [
+    'log_release_version',
+    'precompress',
+    'rsync:prod'
   ]);
 
   grunt.registerTask('log_beta_version', function() {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Destiny Item Manager Shortcut",
-  "version": "4.0.0",
+  "version": "10.0.0",
   "description": "A link to the DIM website which provides a robust interface to manage items in Destiny.",
   "icons": {
     "16": "icon16.png",
@@ -19,6 +19,5 @@
       "19": "icon19.png",
       "38": "icon38.png"
     }
-  },
-  "offline_enabled": false
+  }
 }


### PR DESCRIPTION
This proposes to stop automatically updating the Chrome extension, since it's just a shortcut now. I'll pin the version to 10.0.0 as the last update, and manually upload those versions, then we won't include them in our Travis CI jobs anymore.

I'll also upload a version of the prod extension for Firefox, since it works without modifications. I'm not sure if I should add a beta version too?