### PR TITLE
Improvement of modification sockets

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -99,6 +99,7 @@ export interface DimSocket {
   enabled: boolean;
   enableFailReasons: string;
   plugOptions: DestinyInventoryItemDefinition[];
+  plugOptionsPerks: DestinySandboxPerkDefinition[];
   plugObjectives: DestinyObjectiveProgress[];
 }
 
@@ -903,6 +904,13 @@ export function D2ItemFactory(
       }
       const reusablePlugs = (socket.reusablePlugHashes || []).map((hash) => defs.InventoryItem.get(hash));
       const plugOptions = reusablePlugs.length > 0 && (!plug || !socket.plugHash || (socket.reusablePlugHashes || []).includes(socket.plugHash)) ? reusablePlugs : (plug ? [plug] : []);
+      // the merge is to enable the intrinsic mods to show up even if the user choosed another
+      // plug.itemTyper - removes the reusablePlugs from masterwork
+      // plug.action - removes the "Remove Shader" plug
+      if (reusablePlugs.length > 0 && plugOptions.length > 0) {
+        reusablePlugs.forEach((plug) => { if (!plugOptions.includes(plug) && plug.itemType && plug.action) { plugOptions.push(plug); } });
+      }
+      const plugOptionsPerks = plugOptions.length > 0 ? (plugOptions.filter((plug) => plug.perks.length > 0) || []).map((plug) => defs.SandboxPerk.get(plug.perks[0].perkHash)) : [];
       const plugObjectives = (socket.plugObjectives && socket.plugObjectives.length) ? socket.plugObjectives : [];
 
       return {
@@ -911,6 +919,7 @@ export function D2ItemFactory(
         enabled: socket.isEnabled,
         enableFailReasons: failReasons,
         plugOptions,
+        plugOptionsPerks,
         plugObjectives
       };
     });

--- a/src/app/move-popup/sockets.html
+++ b/src/app/move-popup/sockets.html
@@ -23,7 +23,7 @@
         <img class="item-mod"
           ng-src="{{ socket.displayProperties.icon | bungieIcon }}"
           ng-class="{ notChosen: socket != socketInfo.plug }"
-          press-tip="{{ socket.plug.plugCategoryHash == '2109207426' || socket.plug.plugCategoryHash == '2989652629' ? '<strong>' + $ctrl.item.masterworkInfo.statName + ' ' + $ctrl.item.masterworkInfo.statValue + '</strong>\n' : ''}}{{ socket.displayProperties.description }}{{ socketInfo.enableFailReasons }}{{socket != socketInfo.plug && socket.bestRated ? $ctrl.bestRatedText : ''}}"
+          press-tip="{{ socket.plug.plugCategoryHash == '2109207426' || socket.plug.plugCategoryHash == '2989652629' ? '<strong>' + $ctrl.item.masterworkInfo.statName + ' ' + $ctrl.item.masterworkInfo.statValue + '</strong>\n' : ''}}{{ socket.displayProperties.description ? socket.displayProperties.description : ((socket.displayProperties.name !== socketInfo.plugOptionsPerks[$index].displayProperties.name) ? socketInfo.plugOptionsPerks[$index].displayProperties.name +'\n' : '')+ socketInfo.plugOptionsPerks[$index].displayProperties.description }}{{ socketInfo.enableFailReasons }}{{socket != socketInfo.plug && socket.bestRated ? $ctrl.bestRatedText : ''}}"
           press-tip-title="{{ socket.displayProperties.name }}">
       </div>
     </div>


### PR DESCRIPTION
Something that always bothered me was the fact that since the mod real description is in its perk, on the armor popup this wasn't available:
![image](https://user-images.githubusercontent.com/32077894/36069812-4629f1e2-0ed7-11e8-8447-cbfc7468a507.png)

But wasn't a priority because we could read it's description on the mod itself.  But now we have armor with intrinsic mods, and since they don't exist by themselves, there's no place to check their description:
![image](https://user-images.githubusercontent.com/32077894/36069826-91c0858a-0ed7-11e8-8953-9b8c6e56b18e.png)

Here comes this PR to save the day:
![image](https://user-images.githubusercontent.com/32077894/36069841-bc54c734-0ed7-11e8-9df1-948597f4bcbf.png)

Then, while debugging, I realized that right now, if the user didn't select a mod for those armors, or if the user used an "old" mod in the place of the intrinsic one, then the user wouldn't know that this armor had an intrinsic one (both below are raid armor):
![image](https://user-images.githubusercontent.com/32077894/36069873-fddbd2d8-0ed7-11e8-811c-b5d2dcbb0391.png) ![image](https://user-images.githubusercontent.com/32077894/36069930-a42f3a44-0ed8-11e8-94cd-7d961977a2cb.png)

So then I merged plugOptions with reusablePlugs (with some restrictions) and it did the trick (same armors from above):
![image](https://user-images.githubusercontent.com/32077894/36069915-4f5826e8-0ed8-11e8-9ab4-41ddff90508a.png) ![image](https://user-images.githubusercontent.com/32077894/36069924-7ff11b84-0ed8-11e8-822b-52069df1a2cf.png)


