### PR TITLE
Use equippingBlock's uniqueLabel to improve exotic equipping logic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Next
 
-* Mobile on portrait mode will be able to set the number of inventory columns (the icon size will be resized to accomodate)
-* You can now check your emblem objectives
-* Armor mods show more info
+* Mobile on portrait mode will be able to set the number of inventory columns (the icon size will be resized to accomodate).
+* You can now check your emblem objectives.
+* Armor mods show more info.
+* Destiny 1 transfers are faster.
+* DIM is better at equipping exotics when you already have exotic ghosts, sparrows, and ships equipped.
 
 # 4.40.0
 

--- a/src/app/dimApp.config.js
+++ b/src/app/dimApp.config.js
@@ -20,8 +20,8 @@ function config($compileProvider, $httpProvider, hotkeysProvider,
   // by making responses take 2s to return, not by sending an error code or throttling response. Choosing
   // our throttling limit to be 1 request every 1100ms lets us achieve best throughput while accounting for
   // what I assume is clock skew between Bungie's hosts when they calculate a global rate limit.
-  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 110);
-  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 110);
+  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 1100);
+  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100);
   ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 1, 100);
   ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100);
 

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -461,7 +461,7 @@ export function D2StoresService(
       return value;
     };
 
-    return optimalLoadout(store, applicableItems, bestItemFn, '');
+    return optimalLoadout(applicableItems, bestItemFn, '');
   }
 
   function getBasePower(loadout: Loadout) {

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -147,6 +147,7 @@ export interface DimItem {
   id: string; // zero for non-instanced is legacy hack
   equipped: boolean;
   equipment: boolean;
+  equippingLabel?: string;
   complete: boolean;
   amount: number;
   primStat: EnhancedStat | null;
@@ -199,7 +200,6 @@ export interface DimItem {
   inCategory(categoryName: string): boolean;
   isEngram(): boolean;
   canBeInLoadout(): boolean;
-  hasLifeExotic(): boolean;
 }
 
 export interface D2ItemFactoryType {
@@ -327,9 +327,6 @@ export function D2ItemFactory(
     },
     canBeInLoadout() {
       return this.equipment || this.type === 'Material' || this.type === 'Consumable';
-    },
-    hasLifeExotic() {
-      return (this.type === 'Ghost' || this.type === 'Vehicle' || this.type === 'Ships' || this.type === 'Emotes') && this.isExotic;
     },
     // Mark that this item has been moved manually
     updateManualMoveTimestamp() {
@@ -496,6 +493,7 @@ export function D2ItemFactory(
       id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
       equipped: Boolean(instanceDef.isEquipped),
       equipment: Boolean(itemDef.equippingBlock), // TODO: this has a ton of good info for the item move logic
+      equippingLabel: itemDef.equippingBlock && itemDef.equippingBlock.uniqueLabel,
       complete: false, // TODO: what's the deal w/ item progression?
       amount: item.quantity,
       primStat: primaryStat,

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -128,12 +128,12 @@ export interface DimItem {
   owner: string;
   /** The version of Destiny this comes from */
   destinyVersion: 1 | 2;
-  // The bucket the item is currently in
+  /** The bucket the item is currently in */
   location: DimInventoryBucket;
-  // The bucket the item normally resides in (even though it may be in the vault/postmaster)
+  /** The bucket the item normally resides in (even though it may be in the vault/postmaster) */
   bucket: DimInventoryBucket;
   hash: number;
-  // This is the type of the item (see D2Category/D2Buckets) regardless of location
+  /** This is the type of the item (see D2Category/D2Buckets) regardless of location */
   type: string;
   categories: string[];
   tier: string;
@@ -147,6 +147,15 @@ export interface DimItem {
   id: string; // zero for non-instanced is legacy hack
   equipped: boolean;
   equipment: boolean;
+  /**
+   * If defined, this is the label used to check if the character has other items of
+   * matching types already equipped.
+   *
+   * For instance, when you aren't allowed to equip more than one Exotic Weapon, that's
+   * because all exotic weapons have identical labels and the game checks the
+   * to-be-equipped item's label vs. all other already equipped items (other
+   * than the item in the slot that's about to be occupied).
+   */
   equippingLabel?: string;
   complete: boolean;
   amount: number;
@@ -184,7 +193,7 @@ export interface DimItem {
   infusionFuel: boolean;
   masterworkInfo: DimMasterwork | null;
   _isEngram: boolean;
-  // A timestamp of when, in this session, the item was last manually moved
+  /** A timestamp of when, in this session, the item was last manually moved */
   lastManuallyMoved: number;
   flavorObjective: DimFlavorObjective | null;
 
@@ -195,7 +204,7 @@ export interface DimItem {
   userVote: number;
   dtrRating: number;
 
-  // Can this item be equipped by the given store?
+  /** Can this item be equipped by the given store? */
   canBeEquippedBy(store: DimStore): boolean;
   inCategory(categoryName: string): boolean;
   isEngram(): boolean;

--- a/src/app/inventory/store/item-factory.service.js
+++ b/src/app/inventory/store/item-factory.service.js
@@ -97,10 +97,6 @@ export function ItemFactory(
     canBeInLoadout: function() {
       return this.equipment || this.type === 'Material' || this.type === 'Consumable';
     },
-    // "The Life Exotic" Perk on Exotic Items means you can equip another exotic
-    hasLifeExotic: function() {
-      return this.isExotic && this.talentGrid && (_.find(this.talentGrid.nodes, { hash: 4044819214 }) !== undefined);
-    },
     // Mark that this item has been moved manually
     updateManualMoveTimestamp() {
       this.lastManuallyMoved = Date.now();
@@ -296,6 +292,7 @@ export function ItemFactory(
       id: item.itemInstanceId,
       equipped: item.isEquipped,
       equipment: item.isEquipment,
+      equippingLabel: item.isEquipment && tiers[itemDef.tierType] === 'Exotic' ? normalBucket.sort : undefined,
       complete: item.isGridComplete,
       amount: item.stackSize,
       primStat: item.primaryStat || null,
@@ -406,6 +403,11 @@ export function ItemFactory(
     } else if (createdItem.talentGrid) {
       createdItem.percentComplete = Math.min(1.0, createdItem.talentGrid.totalXP / createdItem.talentGrid.totalXPRequired);
       createdItem.complete = createdItem.year === 1 ? createdItem.talentGrid.totalXP === createdItem.talentGrid.totalXPRequired : createdItem.talentGrid.complete;
+    }
+
+    // "The Life Exotic" perk means you can equip other exotics, so clear out the equipping label
+    if (createdItem.isExotic && createdItem.talentGrid && createdItem.talentGrid.nodes.some((n) => n.hash === 4044819214)) {
+      createdItem.equippingLabel = undefined;
     }
 
     // In debug mode, keep the original JSON around

--- a/src/app/loadout-builder/loadout-builder.component.js
+++ b/src/app/loadout-builder/loadout-builder.component.js
@@ -49,7 +49,7 @@ function LoadoutBuilderController($scope, $state, $q, $timeout, $i18next, dimSet
   }
 
   function getBestItem(armor, stats, type, nonExotic) {
-    // for specifc armor (Helmet), look at stats (int/dis), return best one.
+    // for specific armor (Helmet), look at stats (int/dis), return best one.
     return {
       item: _.max(armor, (o) => {
         if (nonExotic && o.isExotic) {

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -67,7 +67,7 @@ export function itemLevelingLoadout(storeService: StoreServiceType, store: DimSt
     return value;
   };
 
-  return optimalLoadout(store, applicableItems, bestItemFn, t('Loadouts.ItemLeveling'));
+  return optimalLoadout(applicableItems, bestItemFn, t('Loadouts.ItemLeveling'));
 }
 
 /**
@@ -107,7 +107,7 @@ export function maxLightLoadout(storeService: StoreServiceType, store: DimStore)
     return value;
   };
 
-  return optimalLoadout(store, applicableItems, bestItemFn, t('Loadouts.MaximizeLight'));
+  return optimalLoadout(applicableItems, bestItemFn, t('Loadouts.MaximizeLight'));
 }
 
 /**

--- a/src/app/loadout/loadout-drawer.component.js
+++ b/src/app/loadout/loadout-drawer.component.js
@@ -214,14 +214,9 @@ function LoadoutDrawerCtrl($scope, dimLoadoutService, dimCategory, toaster, dimS
         item.equipped = false;
       } else {
         const allItems = _.flatten(Object.values(vm.loadout.items));
-        if (item.isExotic) {
-          const exotic = _.find(allItems, {
-            sort: item.bucket.sort,
-            isExotic: true,
-            equipped: true
-          });
-
-          if (!_.isUndefined(exotic)) {
+        if (item.equippingLabel) {
+          const exotics = allItems.filter((i) => i.equippingLabel === item.equippingLabel && i.equipped);
+          for (const exotic of exotics) {
             exotic.equipped = false;
           }
         }


### PR DESCRIPTION
This backports D2's unique equipping label to D1, and then replaces all exotic-handling logic with checks for equippingLabel collisions. This makes the code more future-proof and correct, even as wacky new things with similar rules to exotics show up (and more exotic things that can be equipped concurrently show up). In the process I found a few other things around this logic that could be improved.

I also snuck in a change to the rate limiter for D1 endpoints since in testing I noticed that they are still being throttled at 1s, and using the faster value resulted in much slower transfers.