### PR TITLE
Compare Tool Improvements

### DIFF
--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -60,9 +60,16 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
         }
       });
       vm.statsMap[statId] = itemStatsMap[statId].index;
-      vm.comparisons[0].stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId), name: itemStatsMap[statId].name });
+
+      const missingStatItemIdx = vm.comparisons.findIndex((compItem) => !compItem.stats.some((stat) => stat.id === Number(statId)));
+      if (item.hash === 2208405142) { debugger; }
+      if (missingStatItemIdx > 0) {
+        if (item.hash === 2208405142) { debugger; }
+        vm.comparisons[missingStatItemIdx].stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId), name: itemStatsMap[statId].name });
+      }
     });
 
+    if (item.hash === 2208405142) { debugger; }
     return item;
   }
 
@@ -191,6 +198,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     }
 
     vm.comparisons.forEach((item) => {
+      addMissingStats(item);
       if (item.stats) {
         item.stats.forEach(bucketStat);
         bucketStat(item.primStat);

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -62,14 +62,10 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
       vm.statsMap[statId] = itemStatsMap[statId].index;
 
       const missingStatItemIdx = vm.comparisons.findIndex((compItem) => !compItem.stats.some((stat) => stat.id === Number(statId)));
-      if (item.hash === 2208405142) { debugger; }
       if (missingStatItemIdx > 0) {
-        if (item.hash === 2208405142) { debugger; }
         vm.comparisons[missingStatItemIdx].stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId), name: itemStatsMap[statId].name });
       }
     });
-
-    if (item.hash === 2208405142) { debugger; }
     return item;
   }
 

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -101,7 +101,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
   vm.sort = function(statHash) {
     vm.sortedHash = statHash;
     vm.comparisons = _.sortBy(_.sortBy(_.sortBy(vm.comparisons, 'index'), 'name').reverse(), (item) => {
-      const stat = _.find(item.stats, { statHash: statHash }) || item.primStat;
+      const stat = statHash === item.primStat.statHash ? item.primStat : (vm.sortedHash === 'Rating' ? {value:item.dtrRating} : _.find(item.stats, { statHash: statHash }));
       return stat.value || -1;
     }).reverse();
   };
@@ -131,7 +131,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
           return memo + (stat.base === 0 ? 0 : stat.statHash);
         }, 0);
       }
-
+debugger;
       // 4284893193 is RPM in D2
       const archetypeStat = _.find(vm.compare.stats, {
         statHash: (vm.compare.destinyVersion === 1

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -131,7 +131,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
           return memo + (stat.base === 0 ? 0 : stat.statHash);
         }, 0);
       }
-debugger;
+
       // 4284893193 is RPM in D2
       const archetypeStat = _.find(vm.compare.stats, {
         statHash: (vm.compare.destinyVersion === 1

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -107,6 +107,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
 
   vm.compareSimilar = function(type) {
     vm.comparisons = type === 'archetype' ? vm.archeTypes : vm.similarTypes;
+    vm.comparisons.forEach((item) => addMissingStats(item));
   };
 
   vm.sort = function(statHash) {
@@ -205,7 +206,6 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     }
 
     vm.comparisons.forEach((item) => {
-      addMissingStats(item);
       if (item.stats) {
         item.stats.forEach(bucketStat);
         bucketStat(item.primStat);

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -51,7 +51,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
 
     _.difference(_.keys(vm.statsMap), _.keys(itemStatsMap)).forEach((statId) => {
       item.stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId) });
-      vm.statRanges[statId] = { min:0, max:0, enabled:false};
+      vm.statRanges[statId] = { min: 0, max: 0, enabled: false };
     });
 
     _.difference(_.keys(itemStatsMap), _.keys(vm.statsMap)).forEach((statId) => {
@@ -71,8 +71,8 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
   }
 
   function removeMissingStats() {
-    vm.comparisons.map((compItem) => {
-      const statIndex = compItem.stats.findIndex((stat) => (stat.bar && stat.base && stat.sort) == undefined);
+    _.map(vm.comparisons, (compItem) => {
+      const statIndex = compItem.stats.findIndex((stat) => (stat.bar && stat.base && stat.sort) === undefined);
       if (statIndex > 0) {
         compItem.stats.splice(statIndex, 1);
       }
@@ -113,7 +113,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
   vm.sort = function(statHash) {
     vm.sortedHash = statHash;
     vm.comparisons = _.sortBy(_.sortBy(_.sortBy(vm.comparisons, 'index'), 'name').reverse(), (item) => {
-      const stat = statHash === item.primStat.statHash ? item.primStat : (vm.sortedHash === 'Rating' ? {value:item.dtrRating} : _.find(item.stats, { statHash: statHash }));
+      const stat = statHash === item.primStat.statHash ? item.primStat : (vm.sortedHash === 'Rating' ? { value: item.dtrRating } : _.find(item.stats, { statHash: statHash }));
       return stat.value || -1;
     }).reverse();
   };
@@ -209,7 +209,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
       if (item.stats) {
         item.stats.forEach(bucketStat);
         bucketStat(item.primStat);
-        bucketStat({statHash:0, value:Number(item.dtrRating)});
+        bucketStat({ statHash: 0, value: Number(item.dtrRating) });
       }
     });
 

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -50,7 +50,11 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     });
 
     _.difference(_.keys(vm.statsMap), _.keys(itemStatsMap)).forEach((statId) => {
-      item.stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId) });
+      item.stats.splice(vm.statsMap[statId], 0, { value: undefined,
+                                                  id: Number(statId),
+                                                  statHash: Number(statId),
+                                                  name: itemStatsMap[statId].name,
+                                                  missingStat: true });
       vm.statRanges[statId] = { min: 0, max: 0, enabled: false };
     });
 
@@ -64,15 +68,19 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
 
       const missingStatItemIdx = vm.comparisons.findIndex((compItem) => !compItem.stats.some((stat) => stat.id === Number(statId)));
       if (missingStatItemIdx > 0) {
-        vm.comparisons[missingStatItemIdx].stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId), name: itemStatsMap[statId].name });
+        vm.comparisons[missingStatItemIdx].stats.splice(vm.statsMap[statId], 0, { value: undefined,
+                                                                                  id: Number(statId),
+                                                                                  statHash: Number(statId),
+                                                                                  name: itemStatsMap[statId].name,
+                                                                                  missingStat: true });
       }
     });
     return item;
   }
 
   function removeMissingStats() {
-    _.map(vm.comparisons, (compItem) => {
-      const statIndex = compItem.stats.findIndex((stat) => (stat.bar && stat.base && stat.sort) === undefined);
+    _.each(vm.comparisons, (compItem) => {
+      const statIndex = compItem.stats.findIndex((stat) => stat.missingStat);
       if (statIndex > 0) {
         compItem.stats.splice(statIndex, 1);
       }
@@ -107,13 +115,17 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
 
   vm.compareSimilar = function(type) {
     vm.comparisons = type === 'archetype' ? vm.archeTypes : vm.similarTypes;
-    vm.comparisons.forEach((item) => addMissingStats(item));
+    vm.comparisons.forEach(addMissingStats);
   };
 
   vm.sort = function(statHash) {
     vm.sortedHash = statHash;
     vm.comparisons = _.sortBy(_.sortBy(_.sortBy(vm.comparisons, 'index'), 'name').reverse(), (item) => {
-      const stat = statHash === item.primStat.statHash ? item.primStat : (vm.sortedHash === 'Rating' ? { value: item.dtrRating } : _.find(item.stats, { statHash: statHash }));
+      const stat = statHash === item.primStat.statHash
+        ? item.primStat
+        : (vm.sortedHash === 'Rating'
+          ? { value: item.dtrRating }
+          : _.find(item.stats, { statHash: statHash }));
       return stat.value || -1;
     }).reverse();
   };
@@ -209,7 +221,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
       if (item.stats) {
         item.stats.forEach(bucketStat);
         bucketStat(item.primStat);
-        bucketStat({ statHash: 0, value: Number(item.dtrRating) });
+        bucketStat({ statHash: 0, value: item.dtrRating });
       }
     });
 

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -40,7 +40,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
   function addMissingStats(item) {
     if (!vm.comparisons[0]) {
       item.stats.forEach((stat, idx) => {
-        vm.statsMap[stat.id] = idx;
+        vm.statsMap[stat.id] = { index: idx, name: stat.name };
       });
       return item;
     }
@@ -50,29 +50,33 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     });
 
     _.difference(_.keys(vm.statsMap), _.keys(itemStatsMap)).forEach((statId) => {
-      item.stats.splice(vm.statsMap[statId], 0, { value: undefined,
-                                                  id: Number(statId),
-                                                  statHash: Number(statId),
-                                                  name: itemStatsMap[statId].name,
-                                                  missingStat: true });
+      item.stats.splice(vm.statsMap[statId].index, 0, {
+        value: undefined,
+        id: Number(statId),
+        statHash: Number(statId),
+        name: vm.statsMap[statId].name,
+        missingStat: true
+      });
       vm.statRanges[statId] = { min: 0, max: 0, enabled: false };
     });
 
     _.difference(_.keys(itemStatsMap), _.keys(vm.statsMap)).forEach((statId) => {
       _.keys(vm.statsMap).forEach((statMapId) => {
-        if (vm.statsMap[statMapId] >= itemStatsMap[statId].index) {
-          vm.statsMap[statMapId]++;
+        if (vm.statsMap[statMapId].index >= itemStatsMap[statId].index) {
+          vm.statsMap[statMapId].index++;
         }
       });
-      vm.statsMap[statId] = itemStatsMap[statId].index;
+      vm.statsMap[statId] = itemStatsMap[statId];
 
       const missingStatItemIdx = vm.comparisons.findIndex((compItem) => !compItem.stats.some((stat) => stat.id === Number(statId)));
-      if (missingStatItemIdx > 0) {
-        vm.comparisons[missingStatItemIdx].stats.splice(vm.statsMap[statId], 0, { value: undefined,
-                                                                                  id: Number(statId),
-                                                                                  statHash: Number(statId),
-                                                                                  name: itemStatsMap[statId].name,
-                                                                                  missingStat: true });
+      if (missingStatItemIdx >= 0) {
+        vm.comparisons[missingStatItemIdx].stats.splice(vm.statsMap[statId].index, 0, {
+          value: undefined,
+          id: Number(statId),
+          statHash: Number(statId),
+          name: itemStatsMap[statId].name,
+          missingStat: true
+        });
       }
     });
     return item;
@@ -81,7 +85,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
   function removeMissingStats() {
     _.each(vm.comparisons, (compItem) => {
       const statIndex = compItem.stats.findIndex((stat) => stat.missingStat);
-      if (statIndex > 0) {
+      if (statIndex >= 0) {
         compItem.stats.splice(statIndex, 1);
       }
     });
@@ -180,7 +184,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
           }, 0) === armorSplit;
         });
       }
-      vm.comparisons = _.map(_.filter(allItems, { hash: vm.compare.hash }), (item) => addMissingStats(item));
+      vm.comparisons = _.map(_.filter(allItems, { hash: vm.compare.hash }), addMissingStats);
     } else if (!_.findWhere(vm.comparisons, { hash: args.item.hash, id: args.item.id })) {
       addMissingStats(args.item);
       vm.comparisons.push(args.item);

--- a/src/app/compare/compare.component.js
+++ b/src/app/compare/compare.component.js
@@ -51,6 +51,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
 
     _.difference(_.keys(vm.statsMap), _.keys(itemStatsMap)).forEach((statId) => {
       item.stats.splice(vm.statsMap[statId], 0, { value: undefined, id: Number(statId), statHash: Number(statId) });
+      vm.statRanges[statId] = { min:0, max:0, enabled:false};
     });
 
     _.difference(_.keys(itemStatsMap), _.keys(vm.statsMap)).forEach((statId) => {
@@ -69,6 +70,15 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
     return item;
   }
 
+  function removeMissingStats() {
+    vm.comparisons.map((compItem) => {
+      const statIndex = compItem.stats.findIndex((stat) => (stat.bar && stat.base && stat.sort) == undefined);
+      if (statIndex > 0) {
+        compItem.stats.splice(statIndex, 1);
+      }
+    });
+  }
+
   vm.show = dimCompareService.dialogOpen;
 
   vm.comparisons = [];
@@ -83,6 +93,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
   });
 
   vm.cancel = function cancel() {
+    removeMissingStats();
     vm.comparisons = [];
     vm.statRanges = {};
     vm.statsMap = {};
@@ -198,6 +209,7 @@ function CompareCtrl($scope, toaster, dimCompareService, dimStoreService, D2Stor
       if (item.stats) {
         item.stats.forEach(bucketStat);
         bucketStat(item.primStat);
+        bucketStat({statHash:0, value:Number(item.dtrRating)});
       }
     });
 

--- a/src/app/compare/compare.html
+++ b/src/app/compare/compare.html
@@ -19,7 +19,7 @@
       <dim-item-tag item="item"></dim-item-tag>
       <div class="item-name" ng-click="vm.itemClick(item)" ng-bind="::item.name"></div>
       <dim-simple-item item-data="item"></dim-simple-item>
-      <div ng-class="{ highlight: vm.highlight === 'Rating' }" ng-mouseover="vm.highlight = 'Rating'" ng-style="item.dtrRating | statRange:vm.statRanges | qualityColor:'color'" ng-if="item.dtrRatingCount && item.dtrRating">
+      <div ng-class="{ highlight: vm.highlight === 'Rating' }" ng-mouseover="vm.highlight = 'Rating'" ng-style="{value:item.dtrRating, statHash:0} | statRange:vm.statRanges | qualityColor:'color'" ng-if="item.dtrRatingCount && item.dtrRating">
         <span ng-bind="item.dtrRating"></span>
       </div>
       <div ng-class="{ highlight: vm.highlight === item.primStat.statHash }" ng-mouseover="vm.highlight = item.primStat.statHash" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">

--- a/src/app/compare/compare.html
+++ b/src/app/compare/compare.html
@@ -7,15 +7,22 @@
   <div class="compare-bucket" ng-mouseleave="vm.highlight = null">
     <div class="compare-item fixed-left">
       <div class="spacer"></div>
-      <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === vm.comparisons[0].primStat.statHash, sorted: vm.sortedHash === vm.comparisons[0].primStat.statHash }" ng-mouseover="vm.highlight = vm.comparisons[0].primStat.statHash" ng-click="vm.sort(vm.comparisons[0].primStat.statHash)" ng-bind="vm.comparisons[0].primStat.stat.statName || vm.comparisons[0].primStat.stat.displayProperties.name"></div>
-      <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash }" ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by stat.statHash" ng-bind="stat.name"></div>
+      <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === 'Rating', sorted: vm.sortedHash === 'Rating' }"
+           ng-mouseover="vm.highlight = 'Rating'" ng-click="vm.sort('Rating')" ng-i18next="[i18next]Compare.Rating" ng-if="vm.comparisons[0].dtrRatingCount && vm.comparisons[0].dtrRating"></div>
+      <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === vm.comparisons[0].primStat.statHash, sorted: vm.sortedHash === vm.comparisons[0].primStat.statHash }"
+           ng-mouseover="vm.highlight = vm.comparisons[0].primStat.statHash" ng-click="vm.sort(vm.comparisons[0].primStat.statHash)" ng-bind="vm.comparisons[0].primStat.stat.statName || vm.comparisons[0].primStat.stat.displayProperties.name"></div>
+      <div class="compare-stat-label" ng-class="{ highlight: vm.highlight === stat.statHash, sorted: vm.sortedHash === stat.statHash }"
+           ng-mouseover="vm.highlight = stat.statHash" ng-click="vm.sort(stat.statHash)" ng-repeat="stat in vm.comparisons[0].stats track by stat.statHash" ng-bind="stat.name"></div>
     </div>
     <div ng-repeat="item in vm.comparisons track by item.id" class="compare-item">
       <div class="close" ng-click="vm.remove(item);"></div>
       <dim-item-tag item="item"></dim-item-tag>
       <div class="item-name" ng-click="vm.itemClick(item)" ng-bind="::item.name"></div>
       <dim-simple-item item-data="item"></dim-simple-item>
-      <div ng-class="{ highlight: vm.highlight === item.primStat.stat.statHash }" ng-mouseover="vm.highlight = item.primStat.statHash" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">
+      <div ng-class="{ highlight: vm.highlight === 'Rating' }" ng-mouseover="vm.highlight = 'Rating'" ng-style="item.dtrRating | statRange:vm.statRanges | qualityColor:'color'" ng-if="item.dtrRatingCount && item.dtrRating">
+        <span ng-bind="item.dtrRating"></span>
+      </div>
+      <div ng-class="{ highlight: vm.highlight === item.primStat.statHash }" ng-mouseover="vm.highlight = item.primStat.statHash" ng-style="item.primStat | statRange:vm.statRanges | qualityColor:'color'">
         <span ng-bind="item.primStat.value"></span>
       </div>
       <div ng-class="{ highlight: vm.highlight === stat.statHash }" ng-mouseover="vm.highlight = stat.statHash" ng-repeat="stat in item.stats track by $index" ng-style="stat | statRange:vm.statRanges | qualityColor:'color'">

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -59,6 +59,7 @@
       "Class": "Cannot compare this item as it is not for a {{class}}."
     },
     "ItemCount": "You have {{num}} of these.",
+    "Rating": "Rating",
     "Splits": "Compare similar splits ({{quantity}})"
   },
   "Cooldown": {


### PR DESCRIPTION
The problem on the missing (#2476) stat was that when you press the comparison buttons (archetype/similar), the addMissingStats is never run because there's no add in this case.

While debugging I discovered 2 other bugs, one that after we do a compare on merciless, the missing stat is added on the item itself.  So we end with this:
![image](https://user-images.githubusercontent.com/32077894/36233714-6f71785a-11ce-11e8-9a04-0333dec08399.png)

The other one was that sometimes we would add stats in the leftmost item when we shouldn't. (For some reason I can't reproduce it right know so can't get a picture of the bug.)

I fixed those above and since I was messing with this code, I decided to add the Rating to the list.
I know the way I did it it's not the most orthodox way, but I believe that it's better than adding some if's around the code.
![image](https://user-images.githubusercontent.com/32077894/36234296-5ab50c94-11d1-11e8-9ba2-ad2a262a8bfa.png)

As I'm writing this I realized that another way would be to add the rating as a stat, but then we would mess with all the items instead of just some, also I would need to also add primStat as stat so Rating stays on first.

This PR should fix #2476