### PR TITLE
Add new categories for trace rifle and linear fusion rifle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -198,6 +198,7 @@
 * Pulling an item from the postmaster updates the list of items quickly now.
 * Navigation from "About" or "Backers" back to your inventory works.
 * is:dupelower breaks ties more intelligently.
+* Add is:tracerifle and is:linearfusionrifle searches.
 
 # 4.40.0 (2018-02-12)
 

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -84,10 +84,10 @@ const statWhiteList = [
 
 // Mapping from itemCategoryHash to our category strings for filtering.
 const categoryFromHash = {
-  // These three types are missing.
-  // ???: 'CATEGORY_GRENADE_LAUNCHER',
-  // ???: 'CATEGORY_SUBMACHINEGUN',
-  // ???: 'CATEGORY_TRACE_RIFLE',
+  153950757: 'CATEGORY_GRENADE_LAUNCHER',
+  3954685534: 'CATEGORY_SUBMACHINEGUN',
+  2489664120: 'CATEGORY_TRACE_RIFLE',
+  1504945536: 'CATEGORY_LINEAR_FUSION_RIFLE',
   5: 'CATEGORY_AUTO_RIFLE',
   6: 'CATEGORY_HAND_CANNON',
   7: 'CATEGORY_PULSE_RIFLE',
@@ -98,15 +98,6 @@ const categoryFromHash = {
   13: 'CATEGORY_ROCKET_LAUNCHER',
   14: 'CATEGORY_SIDEARM',
   54: 'CATEGORY_SWORD',
-};
-
-// Mapping from infusionCategoryHash to our category strings for
-// cases where the itemCategory is missing.
-// TODO: Remove this once the bug in the API is fixed.
-const categoryFromInfusionHash = {
-  3879234379: 'CATEGORY_GRENADE_LAUNCHER',
-  3499784695: 'CATEGORY_SUBMACHINEGUN',
-  522776512: 'CATEGORY_AUTO_RIFLE', // Trace Rifle
 };
 
 // Prototype for Item objects - add methods to this to add them to all
@@ -233,12 +224,6 @@ function findCategories(itemDef): string[] {
       const c = categoryFromHash[hash];
       if (c) { categories.push(c); }
     }
-  }
-  // TODO: Some of our categories are not yet available as
-  // ItemCategories. This is a hack.
-  if (categories.length === 0 && itemDef.quality) {
-    const c = categoryFromInfusionHash[itemDef.quality.infusionCategoryHash];
-    if (c) { categories.push(c); }
   }
   return categories;
 }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -56,6 +56,8 @@ export function buildSearchConfig(
     Object.assign(categoryFilters, {
       grenadelauncher: ['CATEGORY_GRENADE_LAUNCHER'],
       submachine: ['CATEGORY_SUBMACHINEGUN'],
+      tracerifle: ['CATEGORY_TRACE_RIFLE'],
+      linearfusionrifle: ['CATEGORY_LINEAR_FUSION_RIFLE']
     });
     itemTypes.push(...flatMap(Object.values(categories), (l: string[]) => l.map((v) => v.toLowerCase())));
     stats.push('rpm');


### PR DESCRIPTION
Now that the categories are fixed we can get rid of our workaround and support some more searches.