### PR TITLE
Masterwork fix + slight improve of Ornaments

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -910,14 +910,24 @@ function buildSockets(
       failReasons = `\n\n${failReasons}`;
     }
     const reusablePlugs = (socket.reusablePlugHashes || []).map((hash) => defs.InventoryItem.get(hash));
-    const plugOptions = reusablePlugs.length > 0 && (!plug || !socket.plugHash || (socket.reusablePlugHashes || []).includes(socket.plugHash)) ? reusablePlugs : (plug ? [plug] : []);
+    // 1742617626 - armor ornaments
+    // 3124752623 - weapon ornaments
+    const isOrnamentPlug = plug && (plug.itemCategoryHashes.some((hash) => [1742617626, 3124752623].includes(hash)));
+    const plugOptions = reusablePlugs.length > 0 && (!plug || !socket.plugHash || ((socket.reusablePlugHashes || []).includes(socket.plugHash) && !isOrnamentPlug)) ?
+      reusablePlugs :
+      (plug ? [plug] : []);
     // the merge is to enable the intrinsic mods to show up even if the user choosed another
-    // plug.itemTyper - removes the reusablePlugs from masterwork
+    // plug.itemCategoryHashes.includes(141186804) - removes the reusablePlugs from masterwork
     // plug.action - removes the "Remove Shader" plug
     if (reusablePlugs.length > 0 && plugOptions.length > 0) {
-      reusablePlugs.forEach((plug) => { if (!plugOptions.includes(plug) && plug.itemType && plug.action) { plugOptions.push(plug); } });
+      reusablePlugs.forEach((plug) => {
+        if (!plugOptions.includes(plug) && !plug.itemCategoryHashes.includes(141186804) && !isOrnamentPlug && plug.action) {
+            plugOptions.push(plug);
+          }});
     }
-    const plugOptionsPerks = plugOptions.length > 0 ? (plugOptions.filter((plug) => plug.perks.length > 0) || []).map((plug) => defs.SandboxPerk.get(plug.perks[0].perkHash)) : [];
+    const plugOptionsPerks = plugOptions.length > 0 ?
+      (plugOptions.filter((plug) => plug.perks.length > 0) || []).map((plug) => defs.SandboxPerk.get(plug.perks[0].perkHash)) :
+      [];
     const plugObjectives = (socket.plugObjectives && socket.plugObjectives.length) ? socket.plugObjectives : [];
 
     return {


### PR DESCRIPTION
As stated on #2656, in the API release from yesterday, masterwork sockets changed and now all plugs have an itemType, so the filter now is by the itemCategoryHash.
![image](https://user-images.githubusercontent.com/32077894/36575995-b2e1165e-182c-11e8-8e1e-35481349c9eb.png)

and since I was messing with filtering the plugOptions with itemCategoryHash, I also changed it so when you equip an ornament we don't show the "default ornament" plug (same behavior as shaders) anymore.

now:
![image](https://user-images.githubusercontent.com/32077894/36576096-47cc2cb8-182d-11e8-9704-dfb60a431721.png) ![image](https://user-images.githubusercontent.com/32077894/36576107-52e04198-182d-11e8-9864-179473e19833.png)

with this PR:
![image](https://user-images.githubusercontent.com/32077894/36576115-60118070-182d-11e8-92fc-f3bd4d9055e3.png) ![image](https://user-images.githubusercontent.com/32077894/36576121-6c588c2a-182d-11e8-9de9-94a6b410a915.png)

this doesn't affect armor ornaments that aren't equipped (even if you unlocked it)
locked/incomplete objectives
![image](https://user-images.githubusercontent.com/32077894/36576173-c1f24ca2-182d-11e8-8c70-e4bef7df0e41.png)

unlocked/complete objectives
![image](https://user-images.githubusercontent.com/32077894/36576187-e6fce318-182d-11e8-80d5-48cacbfe892f.png)

fix #2656


