### PR TITLE
Press-tip port to React

### DIFF
--- a/src/app/dim-ui/press-tip.tsx
+++ b/src/app/dim-ui/press-tip.tsx
@@ -48,7 +48,6 @@ export class PressTip extends React.Component<Props, State> {
     if (this.tooltip) {
       this.tooltip.show();
     } else {
-      console.log(this.tooltipContent);
       this.tooltip = new Tooltip(this.ref, {
         placement: 'top', // or bottom, left, right, and variations
         title: '...',
@@ -57,7 +56,6 @@ export class PressTip extends React.Component<Props, State> {
         container: 'body'
       });
       this.tooltip.show();
-      console.log(this.tooltip);
 
       // Ugh this is a real hack
       this.tooltipContent = this.tooltip._tooltipNode.querySelector(this.tooltip.innerSelector);

--- a/src/app/dim-ui/press-tip.tsx
+++ b/src/app/dim-ui/press-tip.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import Tooltip from 'tooltip.js';
+import '../move-popup/press-tip.scss';
+
+interface Props {
+  tooltip: React.ReactNode;
+}
+
+interface State {
+  isOpen: boolean;
+}
+
+/**
+ * A "press tip" is a tooltip that can be shown by pressing on an element, or via hover.
+ *
+ * Tooltop content can be any React element, and can be updated through React.
+ *
+ * Example:
+ *
+ * <PressTip
+ *   tooltip={
+ *     <span>
+ *       PressTip Content
+ *     </span>
+ *   }>
+ *   <div>PressTip context element</div>
+ * </PressTip>
+ */
+export class PressTip extends React.Component<Props, State> {
+  private tooltip?: Tooltip;
+  private timer: number;
+  private tooltipContent: Element;
+  private ref;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+  }
+
+  componentWillUnmount() {
+    this.destroy();
+  }
+
+  showTip = () => {
+    if (this.tooltip) {
+      this.tooltip.show();
+    } else {
+      console.log(this.tooltipContent);
+      this.tooltip = new Tooltip(this.ref, {
+        placement: 'top', // or bottom, left, right, and variations
+        title: '...',
+        html: true,
+        trigger: 'manual',
+        container: 'body'
+      });
+      this.tooltip.show();
+      console.log(this.tooltip);
+
+      // Ugh this is a real hack
+      this.tooltipContent = this.tooltip._tooltipNode.querySelector(this.tooltip.innerSelector);
+      this.tooltipContent.innerHTML = '';
+    }
+    this.setState({ isOpen: true });
+  }
+
+  closeToolTip = (e) => {
+    e.preventDefault();
+    if (this.tooltip) {
+      this.tooltip.hide();
+    }
+    this.setState({ isOpen: false });
+    clearTimeout(this.timer);
+  }
+
+  hover = () => {
+    this.timer = window.setTimeout(() => {
+      this.showTip();
+    }, 100);
+  }
+
+  press = (e) => {
+    e.preventDefault();
+    this.showTip();
+  }
+
+  captureReference = (ref: HTMLElement) => {
+    if (ref === this.ref) {
+      return;
+    }
+
+    this.destroy();
+
+    this.ref = ref;
+
+    if (ref) {
+      ref.addEventListener('mouseenter', this.hover);
+      ref.addEventListener('mousedown', this.press);
+      ref.addEventListener('touchstart', this.press);
+      ref.addEventListener('mouseup', this.closeToolTip);
+      ref.addEventListener('mouseleave', this.closeToolTip);
+      ref.addEventListener('touchend', this.closeToolTip);
+    }
+  }
+
+  render() {
+    const { tooltip, children } = this.props;
+    const { isOpen } = this.state;
+
+    const element = React.Children.only(children);
+    if (element.props.ref) {
+      throw new Error("You can't use the ref option with PressTip contents, because we steal it for ergonomics' sake");
+    }
+
+    const otherProps = {
+      ref: this.captureReference
+    };
+
+    return (
+      <>
+        <element.type {...element.props} {...otherProps}/>
+        {isOpen && ReactDOM.createPortal(tooltip, this.tooltipContent)}
+      </>
+    );
+  }
+
+  private destroy() {
+    if (this.tooltip) {
+      this.tooltip.dispose();
+      this.tooltip = null;
+    }
+    if (this.ref) {
+      this.ref.removeEventListener('mouseenter', this.hover);
+      this.ref.removeEventListener('mousedown', this.press);
+      this.ref.removeEventListener('touchstart', this.press);
+      this.ref.removeEventListener('mouseup', this.closeToolTip);
+      this.ref.removeEventListener('mouseleave', this.closeToolTip);
+      this.ref.removeEventListener('touchend', this.closeToolTip);
+      this.ref = null;
+    }
+  }
+}

--- a/src/app/progress/faction.tsx
+++ b/src/app/progress/faction.tsx
@@ -11,6 +11,7 @@ import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { bungieNetPath } from '../dim-ui/bungie-image';
 import { sum } from '../util';
 import './faction.scss';
+import { PressTip } from '../dim-ui/press-tip';
 
 interface FactionProps {
   factionProgress: DestinyFactionProgression;
@@ -37,17 +38,20 @@ export function Faction(props: FactionProps) {
   return (
     <div
       className={classNames("faction", { 'faction-unavailable': factionProgress.factionVendorIndex === -1 })}
-      title={`${factionProgress.progressToNextLevel}/${factionProgress.nextLevelAt}`}
     >
-      <div className="faction-icon">
-        <svg viewBox="0 0 48 48">
-          <image xlinkHref={bungieNetPath(factionDef.displayProperties.icon)} width="48" height="48" />
-          {factionProgress.progressToNextLevel > 0 &&
-            <polygon strokeDasharray="121.622368" style={style} fillOpacity="0" stroke="#FFF" strokeWidth="3" points="24,2.5 45.5,24 24,45.5 2.5,24" strokeLinecap="butt"/>
-          }
-        </svg>
-        <div className={classNames('item-stat', 'item-faction', { 'purchase-unlocked': factionProgress.level >= 10 })}>{factionProgress.level}</div>
-      </div>
+      <PressTip
+        tooltip={`${factionProgress.progressToNextLevel}/${factionProgress.nextLevelAt}`}
+      >
+        <div className="faction-icon">
+          <svg viewBox="0 0 48 48">
+            <image xlinkHref={bungieNetPath(factionDef.displayProperties.icon)} width="48" height="48" />
+            {factionProgress.progressToNextLevel > 0 &&
+              <polygon strokeDasharray="121.622368" style={style} fillOpacity="0" stroke="#FFF" strokeWidth="3" points="24,2.5 45.5,24 24,45.5 2.5,24" strokeLinecap="butt"/>
+            }
+          </svg>
+          <div className={classNames('item-stat', 'item-faction', { 'purchase-unlocked': factionProgress.level >= 10 })}>{factionProgress.level}</div>
+        </div>
+      </PressTip>
       <div className="faction-info">
         <div className="faction-name" title={vendorDef.displayProperties.description}>{vendorDef.displayProperties.name}</div>
         <div className="faction-level" title={factionDef.displayProperties.description}>{factionDef.displayProperties.name}</div>


### PR DESCRIPTION
This ports the "press tip" functionality to React. I used React 16's Portal feature to allow users to drive the contents of the tip from React components, so no more limitation to just strings - we can now have any arbitrary (live updating) HTML content we want inside the tip.

As sort of a demo I added it to the faction icons - we don't need to actually do that, but it's the first React area I'd consider adding it.

<img width="144" alt="screen shot 2018-03-03 at 3 23 52 pm" src="https://user-images.githubusercontent.com/313208/36940406-003b515a-1ef7-11e8-8304-7e87eb048fa2.png">
