### PR TITLE
Fix transferring mods via search loadout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed display of masterwork mod and ornaments.
 * Remove Auras from inventory since they're part of Emblems now.
 * Fancy new emblems show all their counters correctly.
+* Improved moving mods, shaders, and consumables via search loadouts. They can now go to any character (not just the active one) and aren't limited to 9 items.
 
 # 4.41.1
 

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -743,6 +743,11 @@ export function ItemService(
    * @return A promise for the completion of the whole sequence of moves, or a rejection if the move cannot complete.
    */
   function moveTo(item: DimItem, target: DimStore, equip: boolean = false, amount: number = item.amount, excludes?: DimItem[], reservations?: { [storeId: number]: number }): IPromise<DimItem> {
+    // Reassign the target store to the active store if we're moving the item to an account-wide bucket
+    if (!target.isVault && item.bucket.accountWide) {
+      target = getStoreService(item).getActiveStore()!;
+    }
+
     return isValidTransfer(equip, target, item, excludes, reservations)
       .then(() => {
         const storeService = getStoreService(item);

--- a/src/app/loadout/loadout.service.js
+++ b/src/app/loadout/loadout.service.js
@@ -268,7 +268,7 @@ export function LoadoutService($q, $rootScope, $i18next, dimItemService, dimStor
       let totalItems = items.length;
       items = _.filter(items, (pseudoItem) => {
         const item = getLoadoutItem(pseudoItem, store);
-        const invalid = !item || !item.equipment;
+        const invalid = !item;
         // provide a more accurate count of total items
         if (invalid) {
           totalItems--;

--- a/src/app/loadout/loadout.service.js
+++ b/src/app/loadout/loadout.service.js
@@ -425,7 +425,7 @@ export function LoadoutService($q, $rootScope, $i18next, dimItemService, dimStor
             amountNeeded -= amountToMove;
             totalAmount += amountToMove;
 
-            promise = promise.then(() => dimItemService.moveTo(sourceItem, store, false, amountToMove));
+            promise = promise.then(() => dimItemService.moveTo(sourceItem, store, false, amountToMove, loadoutItemIds));
           }
         }
       } else {


### PR DESCRIPTION
Fixes #2663 and some issues identified by @duckmanBR:

1. We use bucket sizes to limit search loadouts now, so the mods/consumables/shaders can transfer more than 9 to a character.
2. Pass in the right exclusion list when applying loadouts containing stackables, which prevents them from getting moved back out as they're being moved in.
3. Swap in the active character for the target store when moving accountwide items so you can move them to any character, not just the active one.