### PR TITLE
Fix drag and drop from postmaster

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* More items can be successfully dragged out of the postmaster.
+
 # 4.42.0
 
 * Compare tool shows ratings, and handles missing stats better.

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -75,7 +75,7 @@ export function ItemService(
       const stackable = item.maxStackSize > 1;
       // Items to be decremented
       const sourceItems = stackable
-        ? _.sortBy(source.buckets[item.bucket.id].filter((i) => {
+        ? _.sortBy(source.buckets[item.location.id].filter((i) => {
           return i.hash === item.hash &&
                 i.id === item.id &&
                 !i.notransfer;

--- a/src/app/inventory/dimStoreBucket.directive.js
+++ b/src/app/inventory/dimStoreBucket.directive.js
@@ -99,7 +99,7 @@ function StoreBucketCtrl($scope,
       return $q.reject(new Error($i18next.t('Help.CannotMove')));
     }
 
-    if (item.owner === vm.store.id) {
+    if (item.owner === vm.store.id && !item.location.inPostmaster) {
       if ((item.equipped && equip) || (!item.equipped && !equip)) {
         return $q.resolve(item);
       }

--- a/src/app/inventory/dimStoreItem.directive.js
+++ b/src/app/inventory/dimStoreItem.directive.js
@@ -181,11 +181,10 @@ export function StoreItemCtrl($scope, $element, dimItemMoveService, dimStoreServ
 
   // TODO: once we rewrite this in react and don't need the perf hack, we should show ghost affinity and flavor objective here
 
-  vm.dragChannel = (vm.item.notransfer) ? vm.item.owner + vm.item.location.type : vm.item.location.type;
-  vm.draggable = !vm.item.location.inPostmaster &&
-    (vm.item.notransfer)
+  vm.dragChannel = (vm.item.notransfer) ? vm.item.owner + vm.item.bucket.type : vm.item.bucket.type;
+  vm.draggable = (!vm.item.location.inPostmaster || vm.item.destinyVersion === 2) && vm.item.notransfer
     ? vm.item.equipment
-    : (vm.item.equipment || vm.item.location.hasTransferDestination);
+    : (vm.item.equipment || vm.item.bucket.hasTransferDestination);
 
   function processBounty(vm, item) {
     const showBountyPercentage = !item.complete && !item.hidePercentage;

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -504,8 +504,7 @@ function makeItem(
     name: itemDef.displayProperties.name,
     description: itemDef.displayProperties.description,
     icon: itemDef.displayProperties.icon || '/img/misc/missing_icon_d2.png',
-    notransfer: Boolean(currentBucket.inPostmaster ||
-      itemDef.nonTransferrable ||
+    notransfer: Boolean(itemDef.nonTransferrable ||
       item.transferStatus === TransferStatuses.NotTransferrable),
     canPullFromPostmaster: !itemDef.doesPostmasterPullHaveSideEffects,
     id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack

--- a/src/app/loadout/loadout.service.js
+++ b/src/app/loadout/loadout.service.js
@@ -275,12 +275,13 @@ export function LoadoutService($q, $rootScope, $i18next, dimItemService, dimStor
           return true;
         }
 
-        const alreadyThere = item.owner !== store.id ||
+        const notAlreadyThere = item.owner !== store.id ||
+              item.location.inPostmaster ||
               // Needs to be equipped. Stuff not marked "equip" doesn't
               // necessarily mean to de-equip it.
               (pseudoItem.equipped && !item.equipped);
 
-        return alreadyThere;
+        return notAlreadyThere;
       });
 
       // only try to equip subclasses that are equippable, since we allow multiple in a loadout


### PR DESCRIPTION
This allows us to drag and drop items from the Postmaster (not all of them worked before, like shaders and such. It should also fix [DIM-5R](https://sentry.io/destiny-item-manager/dim/issues/445886836/) which showed an unnecessary warning when pulling stacks.