### PR TITLE
More vendors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2130,9 +2130,9 @@
       "dev": true
     },
     "bungie-api-ts": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bungie-api-ts/-/bungie-api-ts-1.4.0.tgz",
-      "integrity": "sha512-nN6oVooYotE+cMGK6CGQDMm8Rh8SYXA+C3zn/z+Lkte5bAA/H3aG8DbE5tGJ/RIkeWGZu0Z55682ZvvVQPNf9w=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bungie-api-ts/-/bungie-api-ts-1.5.0.tgz",
+      "integrity": "sha512-YbWge18ZLzN4A8qfZ3RPwqVWtG23hl1ywWbuAahaTkjnOy+/xsguPIuhkOt3bYzkQWLGycNRPAgD2nG9/Apyng=="
     },
     "bytes": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "angularjs-toaster": "github:DestinyItemManager/AngularJS-Toaster",
     "babel-polyfill": "^6.26.0",
     "browserslist": "^3.1.1",
-    "bungie-api-ts": "^1.4.0",
+    "bungie-api-ts": "^1.5.0",
     "classnames": "^2.2.5",
     "components-font-awesome": "^4.7.0",
     "core-js": "^2.5.3",

--- a/src/app/d2-vendors/vendor-item-component.tsx
+++ b/src/app/d2-vendors/vendor-item-component.tsx
@@ -44,6 +44,8 @@ export class VendorItemComponent extends React.Component<Props, {}> {
               className={classNames("item-img", { transparent: item.borderless })}
               style={bungieBackgroundStyle(item.displayProperties.icon)}
             />
+            {item.primaryStat &&
+              <div className="item-stat item-equipment">{item.primaryStat}</div>}
           </div>
         </a>
         <div className="vendor-costs">

--- a/src/app/d2-vendors/vendor-item-component.tsx
+++ b/src/app/d2-vendors/vendor-item-component.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { D2ManifestDefinitions } from "../destiny2/d2-definitions.service";
 import { settings } from '../settings/settings';
 import { DestinyItemQuantity } from "bungie-api-ts/destiny2";
+import { PressTip } from "../dim-ui/press-tip";
 
 interface Props {
   defs: D2ManifestDefinitions;
@@ -33,20 +34,27 @@ export class VendorItemComponent extends React.Component<Props, {}> {
       );
     }
 
+    let title = item.displayProperties.name;
+    if (!item.canBeSold) {
+      title = `${title}\n${item.failureStrings.join("\n")}`;
+    }
+
     return (
-      <div className="vendor-item">
+      <div className={classNames("vendor-item", { 'search-hidden': !item.canBeSold })}>
         {!item.canPurchase &&
           <div className="locked-overlay"/>
         }
         <a href={`http://db.destinytracker.com/d2/${settings.language}/items/${item.itemHash}`} target="_blank" rel="noopener">
-          <div title={item.displayProperties.name} className="item">
-            <div
-              className={classNames("item-img", { transparent: item.borderless })}
-              style={bungieBackgroundStyle(item.displayProperties.icon)}
-            />
-            {item.primaryStat &&
-              <div className="item-stat item-equipment">{item.primaryStat}</div>}
-          </div>
+          <PressTip tooltip={title}>
+            <div className="item">
+                <div
+                  className={classNames("item-img", { transparent: item.borderless })}
+                  style={bungieBackgroundStyle(item.displayProperties.icon)}
+                />
+                {item.primaryStat &&
+                  <div className="item-stat item-equipment">{item.primaryStat}</div>}
+              </div>
+          </PressTip>
         </a>
         <div className="vendor-costs">
           {item.costs.map((cost) =>

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -1,4 +1,4 @@
-import { DestinyVendorItemDefinition, DestinyVendorSaleItemComponent, DestinyItemComponentSetOfint32, DestinyInventoryItemDefinition } from "bungie-api-ts/destiny2";
+import { DestinyVendorItemDefinition, DestinyVendorSaleItemComponent, DestinyItemComponentSetOfint32, DestinyInventoryItemDefinition, DestinyItemInstanceComponent } from "bungie-api-ts/destiny2";
 import { D2ManifestDefinitions } from "../destiny2/d2-definitions.service";
 import { equals } from 'angular';
 
@@ -15,6 +15,7 @@ export class VendorItem {
   private saleItem?: DestinyVendorSaleItemComponent;
   private inventoryItem: DestinyInventoryItemDefinition;
   // TODO: each useful component
+  private instance: DestinyItemInstanceComponent;
 
   private defs: D2ManifestDefinitions;
 
@@ -23,7 +24,7 @@ export class VendorItem {
     vendorItemDef: DestinyVendorItemDefinition,
     saleItem?: DestinyVendorSaleItemComponent,
     // TODO: this'll be useful for showing the move-popup details
-    _itemComponents?: DestinyItemComponentSetOfint32,
+    itemComponents?: DestinyItemComponentSetOfint32,
     canPurchase = true
   ) {
     this.defs = defs;
@@ -31,6 +32,10 @@ export class VendorItem {
     this.saleItem = saleItem;
     this.inventoryItem = this.defs.InventoryItem.get(this.vendorItemDef.itemHash);
     this.canPurchase = canPurchase;
+    if (saleItem && itemComponents && itemComponents.instances && itemComponents.instances.data) {
+      this.instance = itemComponents.instances.data[saleItem!.vendorItemIndex];
+      // TODO: more here, like perks and such
+    }
   }
 
   get key() {
@@ -77,6 +82,10 @@ export class VendorItem {
 
   get costs() {
     return (this.saleItem && this.saleItem.costs) || [];
+  }
+
+  get primaryStat() {
+    return (this.instance && this.instance.primaryStat && this.instance.primaryStat.value);
   }
 
   equals(other: VendorItem) {

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -1,4 +1,4 @@
-import { DestinyVendorItemDefinition, DestinyVendorSaleItemComponent, DestinyItemComponentSetOfint32, DestinyInventoryItemDefinition, DestinyItemInstanceComponent } from "bungie-api-ts/destiny2";
+import { DestinyVendorItemDefinition, DestinyVendorSaleItemComponent, DestinyItemComponentSetOfint32, DestinyInventoryItemDefinition, DestinyItemInstanceComponent, DestinyVendorDefinition } from "bungie-api-ts/destiny2";
 import { D2ManifestDefinitions } from "../destiny2/d2-definitions.service";
 import { equals } from 'angular';
 
@@ -11,6 +11,7 @@ import { equals } from 'angular';
  */
 export class VendorItem {
   canPurchase: boolean;
+  private vendorDef: DestinyVendorDefinition;
   private vendorItemDef: DestinyVendorItemDefinition;
   private saleItem?: DestinyVendorSaleItemComponent;
   private inventoryItem: DestinyInventoryItemDefinition;
@@ -21,6 +22,7 @@ export class VendorItem {
 
   constructor(
     defs: D2ManifestDefinitions,
+    vendorDef: DestinyVendorDefinition,
     vendorItemDef: DestinyVendorItemDefinition,
     saleItem?: DestinyVendorSaleItemComponent,
     // TODO: this'll be useful for showing the move-popup details
@@ -28,6 +30,7 @@ export class VendorItem {
     canPurchase = true
   ) {
     this.defs = defs;
+    this.vendorDef = vendorDef;
     this.vendorItemDef = vendorItemDef;
     this.saleItem = saleItem;
     this.inventoryItem = this.defs.InventoryItem.get(this.vendorItemDef.itemHash);
@@ -71,6 +74,12 @@ export class VendorItem {
    */
   get canBeSold() {
     return (!this.saleItem || this.saleItem.failureIndexes.length === 0);
+  }
+
+  get failureStrings(): string[] {
+    return this.saleItem
+      ? (this.saleItem.failureIndexes || []).map((i) => this.vendorDef.failureStrings[i])
+      : [];
   }
 
   /**

--- a/src/app/d2-vendors/vendor-items.tsx
+++ b/src/app/d2-vendors/vendor-items.tsx
@@ -29,7 +29,7 @@ export default function VendorItems({
   const items = getItems(defs, vendorDef, itemComponents, sales, kioskItems);
 
   // TODO: sort items, maybe subgroup them
-  const itemsByCategory = _.groupBy(items.filter((i) => i.canBeSold), (item: VendorItem) => item.displayCategoryIndex);
+  const itemsByCategory = _.groupBy(items, (item: VendorItem) => item.displayCategoryIndex);
 
   return (
     <div className="vendor-char-items">
@@ -57,11 +57,12 @@ function getItems(
   kioskItems?: DestinyKioskItem[]
 ) {
   if (kioskItems) {
-    return vendorDef.itemList.map((i, index) => new VendorItem(defs, i, undefined, undefined, kioskItems.some((k) => k.index === index)));
+    return vendorDef.itemList.map((i, index) => new VendorItem(defs, vendorDef, i, undefined, undefined, kioskItems.some((k) => k.index === index)));
   } else if (sales && itemComponents) {
     const components = Object.values(sales);
     return components.map((component) => new VendorItem(
       defs,
+      vendorDef,
       vendorDef.itemList[component.vendorItemIndex],
       component,
       itemComponents
@@ -70,6 +71,6 @@ function getItems(
     // If the sales should come from the server, don't show anything until we have them
     return [];
   } else {
-    return vendorDef.itemList.map((i) => new VendorItem(defs, i));
+    return vendorDef.itemList.map((i) => new VendorItem(defs, vendorDef, i));
   }
 }

--- a/src/app/d2-vendors/vendors.tsx
+++ b/src/app/d2-vendors/vendors.tsx
@@ -4,7 +4,8 @@ import {
   DestinyItemComponentSetOfint32,
   DestinyVendorComponent,
   DestinyVendorSaleItemComponent,
-  DestinyVendorsResponse
+  DestinyVendorsResponse,
+  DestinyVendorGroup
   } from 'bungie-api-ts/destiny2';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -16,7 +17,7 @@ import Countdown from '../dim-ui/countdown';
 import { StoreServiceType } from '../inventory/d2-stores.service';
 import { D2ManifestService } from '../manifest/manifest-service';
 import VendorItems from './vendor-items';
-import { $state } from '../ngimport-more';
+import { $state, loadingTracker } from '../ngimport-more';
 import './vendor.scss';
 
 interface Props {
@@ -61,7 +62,13 @@ export default class Vendors extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    this.loadVendors();
+    const promise = this.loadVendors();
+    loadingTracker.addPromise(promise);
+
+    this.props.$scope.$on('dim-refresh', () => {
+      const promise = this.loadVendors();
+      loadingTracker.addPromise(promise);
+    });
   }
 
   render() {
@@ -72,27 +79,42 @@ export default class Vendors extends React.Component<Props, State> {
       return <div className="vendor dim-page">Loading...</div>;
     }
 
-    const vendors = _.sortBy(Object.values(vendorsResponse.vendors.data), (vendor) => {
-      const def = defs.Vendor.get(vendor.vendorHash);
-      // TODO: maybe group by location?
-      return def ? def.displayProperties.name : 999;
-    });
-
     return (
       <div className="vendor d2-vendors dim-page">
         <div className="under-construction">This feature is a preview - we're still working on it!</div>
-        {vendors.map((vendor) =>
-          <Vendor
-            key={vendor.vendorHash}
-            defs={defs}
-            vendor={vendor}
-            itemComponents={vendorsResponse.itemComponents[vendor.vendorHash]}
-            sales={vendorsResponse.sales.data[vendor.vendorHash] && vendorsResponse.sales.data[vendor.vendorHash].saleItems}
-          />
+        {Object.values(vendorsResponse.vendorGroups.data.groups).map((group) =>
+          <VendorGroup key={group.vendorGroupHash} defs={defs} group={group} vendorsResponse={vendorsResponse}/>
         )}
+
       </div>
     );
   }
+}
+
+function VendorGroup({
+  defs,
+  group,
+  vendorsResponse
+}: {
+  defs: D2ManifestDefinitions;
+  group: DestinyVendorGroup;
+  vendorsResponse: DestinyVendorsResponse;
+}) {
+  const groupDef = defs.VendorGroup.get(group.vendorGroupHash);
+  return (
+    <>
+      <h2>{groupDef.categoryName}</h2>
+      {group.vendorHashes.map((h) => vendorsResponse.vendors.data[h]).map((vendor) =>
+        <Vendor
+          key={vendor.vendorHash}
+          defs={defs}
+          vendor={vendor}
+          itemComponents={vendorsResponse.itemComponents[vendor.vendorHash]}
+          sales={vendorsResponse.sales.data[vendor.vendorHash] && vendorsResponse.sales.data[vendor.vendorHash].saleItems}
+        />
+      )}
+    </>
+  );
 }
 
 function Vendor({

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -21,7 +21,8 @@ import {
   DestinyTalentGridDefinition,
   DestinyVendorDefinition,
   DestinyDestinationDefinition,
-  DestinyPlaceDefinition
+  DestinyPlaceDefinition,
+  DestinyVendorGroupDefinition
   } from 'bungie-api-ts/destiny2';
 import { $q } from 'ngimport';
 import * as _ from 'underscore';
@@ -43,7 +44,8 @@ const lazyTables = [
   'SocketType',
   'Milestone',
   'Destination',
-  'Place'
+  'Place',
+  'VendorGroup'
 ];
 
 const eagerTables = [
@@ -76,6 +78,7 @@ export interface D2ManifestDefinitions {
   Milestone: LazyDefinition<DestinyMilestoneDefinition>;
   Destination: LazyDefinition<DestinyDestinationDefinition>;
   Place: LazyDefinition<DestinyPlaceDefinition>;
+  VendorGroup: LazyDefinition<DestinyVendorGroupDefinition>;
 
   InventoryBucket: { [hash: number]: DestinyInventoryBucketDefinition };
   Class: { [hash: number]: DestinyClassDefinition };


### PR DESCRIPTION
1. Add primary stat to vendor items, where available.
2. Show all vendor items, even the ones you can't buy.
3. Add a press-tip so we can show why you can't buy them.
4. Group vendors in the same way as the companion app.