### PR TITLE
sort before upload to crowdin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -242,6 +242,7 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('publish_beta', [
+    'sortJSON:i18n',
     'crowdin-request:upload',
     'log_beta_version',
     'precompress',


### PR DESCRIPTION
This will ensure a sort happened on the i18n files before upload to stop from a sort that causes a '0 diff' on crowdin.