### PR TITLE
Remove "hide unfiltered items" and animate items that don't match

### DIFF
--- a/src/app/inventory/dimStoreItem.scss
+++ b/src/app/inventory/dimStoreItem.scss
@@ -58,10 +58,12 @@ dim-store-item {
   contain: strict;
   cursor: pointer;
   box-sizing: border-box;
+  transition: opacity .2s, transform .2s;
 }
 
 .search-hidden {
   opacity: .2;
+  transform: scale(.85);
 }
 
 .item-xp-bar {

--- a/src/app/inventory/dimStores.directive.html
+++ b/src/app/inventory/dimStores.directive.html
@@ -1,4 +1,4 @@
-<div ng-if="vm.stores.length && vm.vault" class="inventory-content" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems, 'phone-portrait': vm.isPhonePortrait }">
+<div ng-if="vm.stores.length && vm.vault" class="inventory-content" ng-class="{ 'phone-portrait': vm.isPhonePortrait }">
   <div ng-if="vm.isPhonePortrait && vm.selectedStore">
     <!-- TODO: move most of these into their own components? -->
     <div class="store-header">

--- a/src/app/settings/settings.html
+++ b/src/app/settings/settings.html
@@ -39,11 +39,6 @@
       </div>
 
       <div class="setting horizontal">
-        <label for="condensedItems" ng-i18next="Settings.HideUnfiltered"></label>
-        <input id="condensedItems" type="checkbox" ng-model="vm.settings.hideFilteredItems"/>
-      </div>
-
-      <div class="setting horizontal">
         <label for="details" ng-i18next="Settings.AlwaysShowDetails"></label>
         <input type="checkbox" id="details" ng-model="vm.settings.itemDetails"/>
       </div>

--- a/src/app/settings/settings.ts
+++ b/src/app/settings/settings.ts
@@ -49,8 +49,6 @@ let readyResolve;
 export type CharacterOrder = 'mostRecent' | 'mostRecentReverse' | 'fixed';
 
 class Settings {
-  // Hide items that don't match the current search
-  hideFilteredItems = false;
   // Show full details in item popup
   itemDetails = true;
   // Show item quality percentages

--- a/src/app/vendors/vendors.html
+++ b/src/app/vendors/vendors.html
@@ -27,7 +27,7 @@
       </label>
     </div>
   </div>
-  <div class="vendors" ng-class="{ 'hide-filtered': vm.settings.hideFilteredItems }">
+  <div class="vendors">
     <vendor-items stores-data="vm.stores" vendors-data="vm.vendors" active-tab="vm.activeTab" total-coins="vm.totalCoins"></vendor-items>
   </div>
 </div>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -534,7 +534,6 @@
     "ExportSS": "Inventory spreadsheets",
     "ExportSSHelp": "Download a CSV list of your items that can be easily viewed in the spreadsheet app of your choice.",
     "General": "General",
-    "HideUnfiltered": "Hide items that don't match a search",
     "Inventory": "Inventory Display",
     "InventoryColumns": "Character inventory width",
     "InventoryColumnsMobile": "Character inventory width on mobile portrait",


### PR DESCRIPTION
I've been thinking it would be cool to add some subtle animations to DIM here and there - it makes it look "smarter". A good candidate is the search function, where we already need help making the matching items "pop" - a scale and opacity animation really helps that:

![hide-animated](https://user-images.githubusercontent.com/313208/37562478-6f7a7a5c-2a26-11e8-8225-c7eb52f1d09b.gif)

When I did this, I also removed the option to "hide unfiltered items" - this broke many months ago and nobody noticed (that's what happens when we add options...) - it was supposed to release the space used by filtered items, but now it just hides them but leaves the empty space. I think the scale and opacity changes do the same job of making it really clear where the item is, and that the old behavior was too fiddly.