### PR TITLE
Search improvements and fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Searching mods and perks in D2 now searches non-selected perks as well.
 * Perks are in the correct order again (instead of the selected one being first always).
 * Unpurchaseable vendor items are displayed better.
+* Fix "is:dupelower" to only affect Weapons/Armor
+* Add armor stats to the "stat:" filter (in D2 only)
+* Add ":=" comparison to the text complete tooltip
 
 # 4.44.0
 

--- a/src/app/search/filters.html
+++ b/src/app/search/filters.html
@@ -89,6 +89,9 @@
             <li>stat:magazine:</li>
             <li>stat:aimassist: or stat:aa:</li>
             <li>stat:equipspeed:</li>
+            <li ng-if="vm.settings.destinyVersion === 2">stat:mobility:</li>
+            <li ng-if="vm.settings.destinyVersion === 2">stat:resilience:</li>
+            <li ng-if="vm.settings.destinyVersion === 2">stat:recovery:</li>
           </ul>
         </td>
       </tr>

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -484,7 +484,6 @@ export function searchFilters(
               dupes.sort(dupeComparator);
               const bestDupe = dupes[0];
               for (const dupe of dupes) {
-                // uses the same logic of isWeaponOrArmor from d2-item-factory
                 if (dupe.bucket && (dupe.bucket.sort === 'Weapons' || dupe.bucket.sort === 'Armor') && !dupe.notransfer) {
                   _lowerDupes[dupe.id] = dupe !== bestDupe;
                 }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -54,6 +54,9 @@ export function buildSearchConfig(
     });
     itemTypes.push(...flatMap(Object.values(categories), (l: string[]) => l.map((v) => v.toLowerCase())));
     stats.push('rpm');
+    stats.push('mobility');
+    stats.push('recovery');
+    stats.push('resilience');
   }
 
   /**
@@ -134,7 +137,7 @@ export function buildSearchConfig(
   });
 
   // Filters that operate on ranges (>, <, >=, <=)
-  const comparisons = [":<", ":>", ":<=", ":>=", ":"];
+  const comparisons = [":<", ":>", ":<=", ":>=", ":", ":="];
 
   stats.forEach((word) => {
     const filter = `stat:${word}`;
@@ -212,7 +215,7 @@ export function searchFilters(
   let _dupeInPost = false;
 
   // This refactored method filters items by stats
-  //   * statType = [aa|impact|range|stability|rof|reload|magazine|equipspeed]
+  //   * statType = [aa|impact|range|stability|rof|reload|magazine|equipspeed|mobility|resilience|recovery]
   const filterByStats = (statType) => {
     const statHash = {
       rpm: 4284893193,
@@ -224,7 +227,10 @@ export function searchFilters(
       reload: 4188031367,
       magazine: 387123106,
       aimassist: 1345609583,
-      equipspeed: 943549884
+      equipspeed: 943549884,
+      mobility: 2996146975,
+      resilience: 392767087,
+      recovery: 1943323491
     }[statType];
 
     return (item: DimItem, predicate: string) => {
@@ -478,7 +484,10 @@ export function searchFilters(
               dupes.sort(dupeComparator);
               const bestDupe = dupes[0];
               for (const dupe of dupes) {
-                _lowerDupes[dupe.id] = dupe !== bestDupe;
+                // uses the same logic of isWeaponOrArmor from d2-item-factory
+                if (dupe.bucket && (dupe.bucket.sort === 'Weapons' || dupe.bucket.sort === 'Armor') && !dupe.notransfer) {
+                  _lowerDupes[dupe.id] = dupe !== bestDupe;
+                }
               }
 
               if (!_dupeInPost) {
@@ -811,7 +820,10 @@ export function searchFilters(
       reload: filterByStats('reload'),
       magazine: filterByStats('magazine'),
       aimassist: filterByStats('aimassist'),
-      equipspeed: filterByStats('equipspeed')
+      equipspeed: filterByStats('equipspeed'),
+      mobility: filterByStats('mobility'),
+      recovery: filterByStats('recovery'),
+      resilience: filterByStats('resilience')
     }
   };
 }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -137,7 +137,7 @@ export function buildSearchConfig(
   });
 
   // Filters that operate on ranges (>, <, >=, <=)
-  const comparisons = [":<", ":>", ":<=", ":>=", ":", ":="];
+  const comparisons = [":<", ":>", ":<=", ":>=", ":="];
 
   stats.forEach((word) => {
     const filter = `stat:${word}`;


### PR DESCRIPTION
Improvement - Includes armor stats on the `stat:` filter for D2
Fixes #2684 - used @delphiactual code suggestion because mine would make dupelower only work on D2
Fixes #2692 - although I'm still not sure we should suggest two ways to achieve the same thing.