### PR TITLE
Fix for "new" objective styles

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -885,6 +885,36 @@ function buildObjectives(
   return objectives.map((objective) => {
     const def = objectiveDefs.get(objective.objectiveHash);
 
+    let complete = false;
+    let booleanValue = false;
+    let display = `${objective.progress || 0}/${def.completionValue}`;
+    let displayStyle: string | null;
+    switch (def.valueStyle) {
+      case DestinyUnlockValueUIStyle.Integer:
+        display = `${objective.progress || 0}`;
+        displayStyle = 'integer';
+        break;
+      case DestinyUnlockValueUIStyle.Multiplier:
+        display = `${(objective.progress || 0) / def.completionValue}x`;
+        displayStyle = 'integer';
+        break;
+      case DestinyUnlockValueUIStyle.DateTime:
+        const date = new Date(0);
+        date.setUTCSeconds(objective.progress || 0);
+        display = `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+        displayStyle = 'integer';
+        break;
+      case DestinyUnlockValueUIStyle.Checkbox:
+      case DestinyUnlockValueUIStyle.Automatic:
+        displayStyle = null;
+        booleanValue = def.completionValue === 1;
+        complete = objective.complete;
+        break;
+      default:
+        displayStyle = null;
+        complete = objective.complete;
+    }
+
     return {
       displayName: def.displayProperties.name || def.progressDescription ||
         (objective.complete
@@ -893,10 +923,10 @@ function buildObjectives(
       description: def.displayProperties.description,
       progress: objective.progress || 0,
       completionValue: def.completionValue,
-      complete: def.valueStyle === DestinyUnlockValueUIStyle.Integer ? false : objective.complete,
-      boolean: def.completionValue === 1 && (def.valueStyle === DestinyUnlockValueUIStyle.Checkbox || def.valueStyle === DestinyUnlockValueUIStyle.Automatic),
-      displayStyle: def.valueStyle === DestinyUnlockValueUIStyle.Integer ? 'integer' : null,
-      display: `${objective.progress || 0}/${def.completionValue}`
+      complete,
+      boolean: booleanValue,
+      displayStyle,
+      display
     };
   });
 }

--- a/src/app/move-popup/objectives.html
+++ b/src/app/move-popup/objectives.html
@@ -6,7 +6,7 @@
     </div>
     <div ng-switch-when="integer" class="objective-integer">
       <div class="objective-description">{{ objective.displayName }}</div>
-      <div class="objective-text">{{ objective.progress }}</div>
+      <div class="objective-text">{{ objective.display }}</div>
     </div>
     <div ng-switch-default class="objective-checkbox"><div></div></div>
     <div ng-switch-default class="objective-progress">


### PR DESCRIPTION
Completes #2675 fix (no completeness state + proper multiplier objective format)
![image](https://user-images.githubusercontent.com/32077894/37872130-a0817810-2fd7-11e8-83e2-ade3dd473830.png)

Also, should fix the completeness state on #2678 (don't have the emblem to be sure) and datetime objective (that I could test) format (using locale from browser)

![image](https://user-images.githubusercontent.com/32077894/37872103-7d75d5ec-2fd6-11e8-990c-1b6fbcf904e1.png) ![image](https://user-images.githubusercontent.com/32077894/37872108-ad5a5d00-2fd6-11e8-96c1-3ea5be6cd316.png)
Chrome in English x Portuguese (Brazil)

What I didn't fix was those formatings on the tooltip
![image](https://user-images.githubusercontent.com/32077894/37872238-b87fad04-2fd9-11e8-9eb8-b0d768135971.png)
Still trying to understand how TS works but since this would be a different problem (and different files), I'll create a new issue for this and take care of it later.

Closes #2675 
Closes #2678 