### PR TITLE
Vendor ratings cleanup

### DIFF
--- a/src/app/collections/collections.tsx
+++ b/src/app/collections/collections.tsx
@@ -13,7 +13,7 @@ import { D2ManifestService } from '../manifest/manifest-service';
 import './collections.scss';
 import VendorItems from '../d2-vendors/vendor-items';
 import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
-import { fetchRatings } from '../d2-vendors/vendor-ratings';
+import { fetchRatingsForKiosks } from '../d2-vendors/vendor-ratings';
 
 interface Props {
   $scope: IScope;
@@ -48,7 +48,7 @@ export default class Collections extends React.Component<Props, State> {
     const profileResponse = await getKiosks(this.props.account);
     this.setState({ profileResponse, defs });
 
-    const trackerService = await fetchRatings(defs, this.props.dimDestinyTrackerService, undefined, undefined, profileResponse);
+    const trackerService = await fetchRatingsForKiosks(defs, this.props.dimDestinyTrackerService, profileResponse);
     this.setState({ trackerService });
   }
 

--- a/src/app/collections/collections.tsx
+++ b/src/app/collections/collections.tsx
@@ -83,7 +83,7 @@ export default class Collections extends React.Component<Props, State> {
 }
 
 function itemsForKiosk(profileResponse: DestinyProfileResponse, vendorHash: number) {
-  return profileResponse.profileKiosks.data.kioskItems[vendorHash].concat(_.flatten(Object.values(profileResponse.characterKiosks.data).map((d) => Object.values(d.kioskItems))));
+  return profileResponse.profileKiosks.data.kioskItems[vendorHash].concat(_.flatten(Object.values(profileResponse.characterKiosks.data).map((d) => d.kioskItems[vendorHash])));
 }
 
 function Kiosk({

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -9,6 +9,7 @@ import { IDialogOpenResult } from "ng-dialog";
 import dialogTemplate from './vendor-item-dialog.html';
 import { getBuckets } from "../destiny2/d2-buckets.service";
 import { DestinyTrackerServiceType, DimWorkingUserReview } from "../item-review/destiny-tracker.service";
+import { dtrRatingColor } from "../shell/dimAngularFilters.filter";
 
 interface Props {
   defs: D2ManifestDefinitions;
@@ -63,14 +64,13 @@ export default class VendorItemComponent extends React.Component<Props, {}> {
             className={classNames("item-img", { transparent: item.borderless })}
             style={bungieBackgroundStyle(item.displayProperties.icon)}
           />
-          {(item.primaryStat) &&
+          {(item.primaryStat || item.rating) &&
             <div>
-              {item.rating && <div className="item-stat item-review">{item.rating}</div>}
-              <div className="item-stat item-equipment">{item.primaryStat}</div>
-            </div>}
-          {(item.rating && !item.primaryStat) &&
-            <div>
-              <div className="item-stat item-review">{item.rating}</div>
+              {item.rating && <div className="item-stat item-review">
+                <i className="fa fa-star" style={dtrRatingColor(item.rating)}/>
+                {item.rating}
+              </div>}
+              {item.primaryStat && <div className="item-stat item-equipment">{item.primaryStat}</div>}
             </div>}
         </div>
         <div className="vendor-costs">

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -10,6 +10,8 @@ import dialogTemplate from './vendor-item-dialog.html';
 import { getBuckets } from "../destiny2/d2-buckets.service";
 import { DestinyTrackerServiceType, DimWorkingUserReview } from "../item-review/destiny-tracker.service";
 import { dtrRatingColor } from "../shell/dimAngularFilters.filter";
+import { DimItem } from "../inventory/store/d2-item-factory.service";
+import { D2PerkRater } from "../destinyTrackerApi/d2-perkRater";
 
 interface Props {
   defs: D2ManifestDefinitions;
@@ -106,19 +108,24 @@ export default class VendorItemComponent extends React.Component<Props, {}> {
     } else {
 
       let reviewData: DimWorkingUserReview | null = null;
+      let dimItem: DimItem | null = null;
 
       if (trackerService) {
         reviewData = trackerService.getD2ReviewDataCache().getRatingData(undefined, item.itemHash);
 
         if (reviewData && !reviewData.reviews) {
-          const reviewsData = await trackerService.getItemReviewAsync(item.itemHash);
-
-          Object.assign(reviewData, reviewsData);
+          trackerService.getItemReviewAsync(item.itemHash).then((reviewsData) => {
+            Object.assign(reviewData, reviewsData);
+            // TODO: it'd be nice to push this into tracker service
+            Object.assign(dimItem, item.toDimItem(buckets, reviewData));
+            new D2PerkRater().ratePerks(dimItem!);
+            dimItem!.reviewsUpdated = Date.now();
+          });
         }
       }
 
       const buckets = await getBuckets();
-      const dimItem = item.toDimItem(buckets, reviewData);
+      dimItem = item.toDimItem(buckets, reviewData);
 
       this.dialogResult = ngDialog.open({
         template: dialogTemplate,

--- a/src/app/d2-vendors/single-vendor.tsx
+++ b/src/app/d2-vendors/single-vendor.tsx
@@ -12,7 +12,7 @@ import { D2ManifestService } from '../manifest/manifest-service';
 import { FactionIcon } from '../progress/faction';
 import VendorItems from './vendor-items';
 import './vendor.scss';
-import { fetchRatings } from './vendor-ratings';
+import { fetchRatingsForVendor } from './vendor-ratings';
 import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
 
 interface Props {
@@ -70,7 +70,7 @@ export default class SingleVendor extends React.Component<Props, State> {
 
       this.setState({ defs, vendorResponse });
 
-      const trackerService = await fetchRatings(defs, this.props.dimDestinyTrackerService, undefined, vendorResponse);
+      const trackerService = await fetchRatingsForVendor(defs, this.props.dimDestinyTrackerService, vendorResponse);
       this.setState({ trackerService });
     }
   }

--- a/src/app/d2-vendors/single-vendor.tsx
+++ b/src/app/d2-vendors/single-vendor.tsx
@@ -12,7 +12,7 @@ import { D2ManifestService } from '../manifest/manifest-service';
 import { FactionIcon } from '../progress/faction';
 import VendorItems from './vendor-items';
 import './vendor.scss';
-import { fetchRatingsForVendor } from './vendor-ratings';
+import { fetchRatingsForVendor, fetchRatingsForVendorDef } from './vendor-ratings';
 import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
 
 interface Props {
@@ -71,6 +71,9 @@ export default class SingleVendor extends React.Component<Props, State> {
       this.setState({ defs, vendorResponse });
 
       const trackerService = await fetchRatingsForVendor(defs, this.props.dimDestinyTrackerService, vendorResponse);
+      this.setState({ trackerService });
+    } else {
+      const trackerService = await fetchRatingsForVendorDef(defs, this.props.dimDestinyTrackerService, vendorDef);
       this.setState({ trackerService });
     }
   }

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -51,7 +51,7 @@ export class VendorItem {
         this.reviewData = reviewCache.getRatingData(saleItem);
       }
       // TODO: more here, like perks and such
-    } else if (vendorItemDef && reviewCache) {
+    } else if (reviewCache) {
       this.reviewData = reviewCache.getRatingData(undefined, vendorItemDef.itemHash);
     }
   }

--- a/src/app/d2-vendors/vendor-items.tsx
+++ b/src/app/d2-vendors/vendor-items.tsx
@@ -53,6 +53,7 @@ export default function VendorItems({
   );
 }
 
+// TODO: do this in parent components, pass in the right thing
 function getItems(
   defs: D2ManifestDefinitions,
   vendorDef: DestinyVendorDefinition,

--- a/src/app/d2-vendors/vendor-ratings.ts
+++ b/src/app/d2-vendors/vendor-ratings.ts
@@ -53,9 +53,8 @@ export async function fetchRatingsForKiosks(
 
   const vendorItems = flatMap(Array.from(kioskVendorHashes), (kvh) => {
     const vendorHash = Number(kvh);
-    const kioskItems = profileResponse.profileKiosks.data.kioskItems[vendorHash].concat(_.flatten(Object.values(profileResponse.characterKiosks.data).map((d) => Object.values(d.kioskItems))));
     const vendorDef = defs.Vendor.get(vendorHash);
-    return kioskItems.map((ki) => vendorDef.itemList[ki.index]).filter((vid) => isWeaponOrArmor(defs, vid));
+    return vendorDef.itemList.filter((vid) => isWeaponOrArmor(defs, vid));
   });
 
   return destinyTrackerService.bulkFetchKioskItems(vendorItems);

--- a/src/app/d2-vendors/vendor-ratings.ts
+++ b/src/app/d2-vendors/vendor-ratings.ts
@@ -2,52 +2,61 @@ import { DestinyTrackerServiceType } from "../item-review/destiny-tracker.servic
 import { DestinyVendorsResponse, DestinyVendorSaleItemComponent, DestinyVendorResponse, DestinyProfileResponse, DestinyVendorItemDefinition } from "bungie-api-ts/destiny2";
 import * as _ from "underscore";
 import { D2ManifestDefinitions } from "../destiny2/d2-definitions.service";
+import { flatMap } from "../util";
 
-function isWeaponOrArmor(defs: D2ManifestDefinitions,
-                         saleItemComponent: DestinyVendorSaleItemComponent | DestinyVendorItemDefinition): boolean {
+function isWeaponOrArmor(
+  defs: D2ManifestDefinitions,
+  saleItemComponent: DestinyVendorSaleItemComponent | DestinyVendorItemDefinition
+): boolean {
   const inventoryItemStats = defs.InventoryItem.get(saleItemComponent.itemHash).stats;
-  return (inventoryItemStats &&
-          ((inventoryItemStats.primaryBaseStatHash === 1480404414) || // weapon
-          (inventoryItemStats.primaryBaseStatHash === 3897883278))); // armor
+  return inventoryItemStats &&
+          (inventoryItemStats.primaryBaseStatHash === 1480404414 || // weapon
+           inventoryItemStats.primaryBaseStatHash === 3897883278); // armor
 }
 
-export async function fetchRatings(defs: D2ManifestDefinitions,
-                                   destinyTrackerService: DestinyTrackerServiceType,
-                                   vendorsResponse?: DestinyVendorsResponse,
-                                   vendorResponse?: DestinyVendorResponse,
-                                   profileResponse?: DestinyProfileResponse): Promise<DestinyTrackerServiceType> {
-  if (vendorsResponse) {
-    const saleComponentArray = Object.values(vendorsResponse.sales.data)
-      .map((saleItemComponent) => saleItemComponent.saleItems);
+export async function fetchRatingsForVendors(
+  defs: D2ManifestDefinitions,
+  destinyTrackerService: DestinyTrackerServiceType,
+  vendorsResponse: DestinyVendorsResponse
+): Promise<DestinyTrackerServiceType> {
+  const saleComponentArray = Object.values(vendorsResponse.sales.data)
+    .map((saleItemComponent) => saleItemComponent.saleItems);
 
-    const saleComponents = ([] as DestinyVendorSaleItemComponent[]).concat(...saleComponentArray.map((v) => Object.values(v)))
-      .filter((sc) => isWeaponOrArmor(defs, sc));
+  const saleComponents = flatMap(saleComponentArray, (v) => Object.values(v))
+    .filter((sc) => isWeaponOrArmor(defs, sc));
 
-    return destinyTrackerService.bulkFetchVendorItems(saleComponents);
-  } else if (vendorResponse) {
-    const saleComponents = Object.values(vendorResponse.sales.data)
-      .filter((sc) => isWeaponOrArmor(defs, sc));
+  return destinyTrackerService.bulkFetchVendorItems(saleComponents);
+}
 
-    return destinyTrackerService.bulkFetchVendorItems(saleComponents);
-  } else if (profileResponse && defs) {
-    const vendorItems: DestinyVendorItemDefinition[] = [];
+export async function fetchRatingsForVendor(
+  defs: D2ManifestDefinitions,
+  destinyTrackerService: DestinyTrackerServiceType,
+  vendorResponse: DestinyVendorResponse
+): Promise<DestinyTrackerServiceType> {
+  const saleComponents = Object.values(vendorResponse.sales.data)
+    .filter((sc) => isWeaponOrArmor(defs, sc));
 
-    const kioskVendorHashes = new Set(Object.keys(profileResponse.profileKiosks.data.kioskItems));
-    _.each(profileResponse.characterKiosks.data, (kiosk) => {
-      _.each(kiosk.kioskItems, (_, kioskHash) => {
-        kioskVendorHashes.add(kioskHash);
-      });
+  return destinyTrackerService.bulkFetchVendorItems(saleComponents);
+}
+
+export async function fetchRatingsForKiosks(
+  defs: D2ManifestDefinitions,
+  destinyTrackerService: DestinyTrackerServiceType,
+  profileResponse: DestinyProfileResponse
+): Promise<DestinyTrackerServiceType> {
+  const kioskVendorHashes = new Set(Object.keys(profileResponse.profileKiosks.data.kioskItems));
+  _.each(profileResponse.characterKiosks.data, (kiosk) => {
+    _.each(kiosk.kioskItems, (_, kioskHash) => {
+      kioskVendorHashes.add(kioskHash);
     });
+  });
 
-    Array.from(kioskVendorHashes).map((kvh) => {
-      const vendorHash = Number(kvh);
-      const kioskItems = profileResponse.profileKiosks.data.kioskItems[vendorHash].concat(_.flatten(Object.values(profileResponse.characterKiosks.data).map((d) => Object.values(d.kioskItems))));
-      const vendorDef = defs.Vendor.get(vendorHash);
-      vendorItems.push(...kioskItems.map((ki) => vendorDef.itemList[ki.index]).filter((vid) => isWeaponOrArmor(defs, vid)));
-    });
+  const vendorItems = flatMap(Array.from(kioskVendorHashes), (kvh) => {
+    const vendorHash = Number(kvh);
+    const kioskItems = profileResponse.profileKiosks.data.kioskItems[vendorHash].concat(_.flatten(Object.values(profileResponse.characterKiosks.data).map((d) => Object.values(d.kioskItems))));
+    const vendorDef = defs.Vendor.get(vendorHash);
+    return kioskItems.map((ki) => vendorDef.itemList[ki.index]).filter((vid) => isWeaponOrArmor(defs, vid));
+  });
 
-    return destinyTrackerService.bulkFetchVendorItems(undefined, vendorItems);
-  } else {
-    throw new Error("No response was supplied.");
-  }
+  return destinyTrackerService.bulkFetchKioskItems(vendorItems);
 }

--- a/src/app/d2-vendors/vendor-ratings.ts
+++ b/src/app/d2-vendors/vendor-ratings.ts
@@ -1,5 +1,5 @@
 import { DestinyTrackerServiceType } from "../item-review/destiny-tracker.service";
-import { DestinyVendorsResponse, DestinyVendorSaleItemComponent, DestinyVendorResponse, DestinyProfileResponse, DestinyVendorItemDefinition } from "bungie-api-ts/destiny2";
+import { DestinyVendorsResponse, DestinyVendorSaleItemComponent, DestinyVendorResponse, DestinyProfileResponse, DestinyVendorItemDefinition, DestinyVendorDefinition } from "bungie-api-ts/destiny2";
 import * as _ from "underscore";
 import { D2ManifestDefinitions } from "../destiny2/d2-definitions.service";
 import { flatMap } from "../util";
@@ -56,6 +56,16 @@ export async function fetchRatingsForKiosks(
     const vendorDef = defs.Vendor.get(vendorHash);
     return vendorDef.itemList.filter((vid) => isWeaponOrArmor(defs, vid));
   });
+
+  return destinyTrackerService.bulkFetchKioskItems(vendorItems);
+}
+
+export async function fetchRatingsForVendorDef(
+  defs: D2ManifestDefinitions,
+  destinyTrackerService: DestinyTrackerServiceType,
+  vendorDef: DestinyVendorDefinition
+): Promise<DestinyTrackerServiceType> {
+  const vendorItems = vendorDef.itemList.filter((vid) => isWeaponOrArmor(defs, vid));
 
   return destinyTrackerService.bulkFetchKioskItems(vendorItems);
 }

--- a/src/app/d2-vendors/vendors.tsx
+++ b/src/app/d2-vendors/vendors.tsx
@@ -19,7 +19,7 @@ import VendorItems from './vendor-items';
 import { $state, loadingTracker } from '../ngimport-more';
 import './vendor.scss';
 import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
-import { fetchRatings } from './vendor-ratings';
+import { fetchRatingsForVendors } from './vendor-ratings';
 
 interface Props {
   $scope: IScope;
@@ -64,7 +64,7 @@ export default class Vendors extends React.Component<Props, State> {
 
     this.setState({ defs, vendorsResponse });
 
-    const trackerService = await fetchRatings(defs, this.props.dimDestinyTrackerService, vendorsResponse);
+    const trackerService = await fetchRatingsForVendors(defs, this.props.dimDestinyTrackerService, vendorsResponse);
     this.setState({ trackerService });
   }
 

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -93,8 +93,8 @@ import { DimItem } from '../inventory/store/d2-item-factory.service';
 import { IPromise } from 'angular';
 
 export interface DestinyTrackerServiceType {
-  bulkFetchVendorItems(vendorSaleItems?: DestinyVendorSaleItemComponent[],
-                       vendorItems?: DestinyVendorItemDefinition[]): Promise<DestinyTrackerServiceType>;
+  bulkFetchVendorItems(vendorSaleItems: DestinyVendorSaleItemComponent[]): Promise<DestinyTrackerServiceType>;
+  bulkFetchKioskItems(vendorItems: DestinyVendorItemDefinition[]): Promise<DestinyTrackerServiceType>;
   reattachScoresFromCache(stores: any | DimStore[]): void;
   updateCachedUserRankings(item: any | DimItem, userReview: any);
   updateVendorRankings(vendors: any);
@@ -163,14 +163,31 @@ export function DestinyTrackerService(
       }
     },
 
-    async bulkFetchVendorItems(vendorSaleItems?: DestinyVendorSaleItemComponent[],
-                               vendorItems?: DestinyVendorItemDefinition[]): Promise<DestinyTrackerServiceType> {
+    async bulkFetchVendorItems(
+      vendorSaleItems: DestinyVendorSaleItemComponent[]
+    ): Promise<DestinyTrackerServiceType> {
       if (settings.showReviews) {
         if (_isDestinyOne()) {
           throw new Error(("This is a D2-only call."));
         } else if (_isDestinyTwo()) {
           const platformSelection = settings.reviewsPlatformSelection;
-          await _d2bulkFetcher.bulkFetchVendorItems(platformSelection, vendorSaleItems, vendorItems);
+          await _d2bulkFetcher.bulkFetchVendorItems(platformSelection, vendorSaleItems, undefined);
+          return this;
+        }
+      }
+
+      return $q.when();
+    },
+
+    async bulkFetchKioskItems(
+      vendorItems: DestinyVendorItemDefinition[]
+    ): Promise<DestinyTrackerServiceType> {
+      if (settings.showReviews) {
+        if (_isDestinyOne()) {
+          throw new Error(("This is a D2-only call."));
+        } else if (_isDestinyTwo()) {
+          const platformSelection = settings.reviewsPlatformSelection;
+          await _d2bulkFetcher.bulkFetchVendorItems(platformSelection, undefined, vendorItems);
           return this;
         }
       }

--- a/src/app/move-popup/dimMoveItemProperties.directive.ts
+++ b/src/app/move-popup/dimMoveItemProperties.directive.ts
@@ -233,7 +233,7 @@ function MoveItemPropertiesCtrl(
       $scope.$watch('vm.compareItem', compareItems);
     } else {
       $scope.$watch('$parent.$parent.vm.store.items', (items: DimItem[]) => {
-        const item = items.find((item) => item.equipped && item.type === vm.item.type);
+        const item = (items || []).find((item) => item.equipped && item.type === vm.item.type);
         compareItems(item);
       });
     }

--- a/src/app/shell/dimAngularFilters.filter.ts
+++ b/src/app/shell/dimAngularFilters.filter.ts
@@ -276,32 +276,32 @@ mod.filter('qualityColor', () => {
   };
 });
 
-mod.filter('dtrRatingColor', () => {
-  return function getColor(value, property) {
-    if (!value) {
-      return null;
-    }
+export function dtrRatingColor(value: number, property?: string) {
+  if (!value) {
+    return {};
+  }
 
-    property = property || 'color';
-    let color;
-    if (value < 2) {
-      color = 'hsl(0,45%,45%)';
-    } else if (value <= 3) {
-      color = 'hsl(15,65%,40%)';
-    } else if (value <= 4) {
-      color = 'hsl(30,75%,45%)';
-    } else if (value <= 4.4) {
-      color = 'hsl(60,100%,30%)';
-    } else if (value <= 4.8) {
-      color = 'hsl(120,65%,40%)';
-    } else if (value >= 4.9) {
-      color = 'hsl(190,90%,45%)';
-    }
-    const result = {};
-    result[property] = color;
-    return result;
-  };
-});
+  property = property || 'color';
+  let color;
+  if (value < 2) {
+    color = 'hsl(0,45%,45%)';
+  } else if (value <= 3) {
+    color = 'hsl(15,65%,40%)';
+  } else if (value <= 4) {
+    color = 'hsl(30,75%,45%)';
+  } else if (value <= 4.4) {
+    color = 'hsl(60,100%,30%)';
+  } else if (value <= 4.8) {
+    color = 'hsl(120,65%,40%)';
+  } else if (value >= 4.9) {
+    color = 'hsl(190,90%,45%)';
+  }
+  const result = {};
+  result[property] = color;
+  return result;
+}
+
+mod.filter('dtrRatingColor', () => dtrRatingColor);
 
 /**
  * Reduce a string to its first letter.


### PR DESCRIPTION
1. Fix ratings on non-unlocked collection items.
2. Add the colored star to ratings.
3. Fix ratings on definition-only vendors, like engram previews.
4. Some general code cleanup.