### PR TITLE
Vendor engram previews

### DIFF
--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -58,7 +58,7 @@ export default class VendorItemComponent extends React.Component<Props> {
         {(!item.canPurchase || !item.canBeSold) &&
           <div className="locked-overlay"/>
         }
-        <div className="item" ref={this.captureElementRef} onClick={this.openDetailsPopup}>
+        <div className="item" title={item.displayProperties.name} ref={this.captureElementRef} onClick={this.openDetailsPopup}>
           <div
             className={classNames("item-img", { transparent: item.borderless })}
             style={bungieBackgroundStyle(item.displayProperties.icon)}

--- a/src/app/d2-vendors/vendor-items.tsx
+++ b/src/app/d2-vendors/vendor-items.tsx
@@ -11,6 +11,9 @@ import { VendorItem } from './vendor-item';
 import VendorItemComponent from './VendorItemComponent';
 import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
 import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { bungieBackgroundStyle } from '../dim-ui/bungie-image';
+import { $state } from '../ngimport-more';
+import { t } from 'i18next';
 
 export default function VendorItems({
   vendorDef,
@@ -37,8 +40,23 @@ export default function VendorItems({
   // TODO: sort items, maybe subgroup them
   const itemsByCategory = _.groupBy(items, (item: VendorItem) => item.displayCategoryIndex);
 
+  const faction = vendorDef.factionHash ? defs.Faction[vendorDef.factionHash] : undefined;
+  const rewardVendorHash = faction && faction.rewardVendorHash || undefined;
+  const rewardItem = rewardVendorHash && defs.InventoryItem.get(faction!.rewardItemHash);
+  const goToRewardVendor = rewardVendorHash && (() => $state.go('destiny2.vendor', { id: rewardVendorHash }));
+
   return (
     <div className="vendor-char-items">
+      {rewardVendorHash && rewardItem && goToRewardVendor &&
+        <div className="vendor-row">
+          <h3 className="category-title">{t('Vendors.Engram')}</h3>
+          <div className="item" title={rewardItem.displayProperties.name} onClick={goToRewardVendor}>
+            <div
+              className="item-img transparent"
+              style={bungieBackgroundStyle(rewardItem.displayProperties.icon)}
+            />
+          </div>
+        </div>}
       {_.map(itemsByCategory, (items, categoryIndex) =>
         <div className="vendor-row" key={categoryIndex}>
           <h3 className="category-title">{vendorDef.displayCategories[categoryIndex] && vendorDef.displayCategories[categoryIndex].displayProperties.name || 'Unknown'}</h3>

--- a/src/app/progress/faction.tsx
+++ b/src/app/progress/faction.tsx
@@ -47,14 +47,12 @@ export function Faction(props: FactionProps) {
       <div className="faction-info">
         <div className="faction-name" title={vendorDef.displayProperties.description}>{vendorDef.displayProperties.name}</div>
         <div className="faction-level" title={factionDef.displayProperties.description}>{factionDef.displayProperties.name}</div>
-        {engramsAvailable > 0 &&
-          <div className="faction-rewards">
-            {factionDef.rewardVendorHash && $featureFlags.vendors
-              ? <a onClick={rewardClick}>{t('Faction.EngramsAvailable', { count: engramsAvailable })}</a>
-              : <>{t('Faction.EngramsAvailable', { count: engramsAvailable })}</>
-            }
-          </div>
-        }
+        <div className="faction-rewards">
+          {factionDef.rewardVendorHash && $featureFlags.vendors
+            ? <a onClick={rewardClick}>{t('Faction.EngramsAvailable', { count: engramsAvailable })}</a>
+            : <>{t('Faction.EngramsAvailable', { count: engramsAvailable })}</>
+          }
+        </div>
       </div>
     </div>
   );

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -652,7 +652,8 @@
     "Load": "Loading Vendors",
     "ShadersAndEmblems": "Shaders & Emblems",
     "ShipsAndVehicles": "Ships & Vehicles",
-    "Vendors": "Vendors"
+    "Vendors": "Vendors",
+    "Engram": "Reward Engram"
   },
   "Views": {
     "About": {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -97,6 +97,7 @@ dd {
 a {
   color: $blue;
   font-size: 13px;
+  cursor: pointer;
 }
 
 h2, h3 {


### PR DESCRIPTION
<img width="301" alt="screen shot 2018-03-25 at 11 07 30 pm" src="https://user-images.githubusercontent.com/313208/37889465-53adb210-3081-11e8-9573-6793a89eff14.png">

This adds engrams to vendors that are associated with a faction that rewards engrams. This is a bit of a cheat since the vendors don't technically sell these items - again, the faction they are associated with rewards them for reputation. But the game UI shows them so by gosh so will we.

Instead of showing an item popup when you click these, we go to the full engram preview page, showing all possible contents of the engram.