### PR TITLE
Fix chevron and correct emblem display

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -695,6 +695,16 @@ export function makeItem(
     }
   }
 
+  // Secondary Icon
+  if (createdItem.sockets) {
+    const multiEmblem = createdItem.sockets.sockets.filter((plug) => plug.plug && plug.plug.plugItem.itemType === 14);
+    const selectedEmblem = multiEmblem[0] && multiEmblem[0].plug;
+
+    if (selectedEmblem) {
+      createdItem.secondaryIcon = selectedEmblem.plugItem.secondaryIcon;
+    }
+  }
+
   // Infusion
   const tier = itemDef.inventory ? defs.ItemTierType[itemDef.inventory.tierTypeHash] : null;
   createdItem.infusionProcess = tier && tier.infusionProcess;

--- a/src/app/move-popup/dimMoveItemProperties.directive.ts
+++ b/src/app/move-popup/dimMoveItemProperties.directive.ts
@@ -40,7 +40,8 @@ function MoveItemPropertiesCtrl(
   vm.tab = 'default';
 
   vm.hasDetails = Boolean((vm.item.stats && vm.item.stats.length) ||
-                          vm.item.talentGrid || vm.item.objectives);
+                          vm.item.talentGrid || vm.item.objectives ||
+                          vm.item.flavorObjective || vm.item.secondaryIcon);
   vm.showDescription = Boolean(vm.item.description && vm.item.description.length);
   vm.locking = false;
 


### PR DESCRIPTION
With #2716 two bugs were "implemented"

- Some emblems lost the chevron to see it's contents
![image](https://user-images.githubusercontent.com/32077894/38124981-4ca53720-33bc-11e8-9691-9effb049f6ef.png)

Altough it was "looking fine" if you had the "always show expanded popup" selected
![image](https://user-images.githubusercontent.com/32077894/38125018-ab0adbbc-33bc-11e8-9786-9b447a364ea1.png)

- The emblem preview was always showing the default emblem and not the selected one:
![image](https://user-images.githubusercontent.com/32077894/38125041-da43e27a-33bc-11e8-9513-49925757e9cc.png)


This PR should fix both:
![image](https://user-images.githubusercontent.com/32077894/38125054-04f72db0-33bd-11e8-8267-5425b4ba32b2.png)
![image](https://user-images.githubusercontent.com/32077894/38125058-1095e882-33bd-11e8-9c7d-5b279709e37e.png)

