### PR TITLE
Add inventory currencies to vendor items

### DIFF
--- a/src/app/activities/activities.html
+++ b/src/app/activities/activities.html
@@ -33,8 +33,8 @@
         <img class="small-icon" ng-src="{{ ::activity.icon | bungieIcon }}" />
         <span class="activity-name">{{ ::activity.name }}</span>
         <i ng-if="::activity.featured"  class="fa fa-star"></i>
-        <span class="activity-type" ng-bind="::activity.type"></span>
       </span>
+      <span class="activity-type" ng-bind="::activity.type"></span>
     </div>
 
     <div class="activity-info" ng-if="!$ctrl.settings.collapsedSections['activities-' + activity.hash]">

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -152,7 +152,8 @@ export function getVendor(account: DestinyAccount, characterId: string, vendorHa
       DestinyComponentType.ItemSockets,
       DestinyComponentType.ItemTalentGrids,
       DestinyComponentType.ItemCommonData,
-      DestinyComponentType.ItemPlugStates
+      DestinyComponentType.ItemPlugStates,
+      DestinyComponentType.CurrencyLookups
     ],
     vendorHash
   })
@@ -173,7 +174,8 @@ export function getVendors(account: DestinyAccount, characterId: string): IPromi
       DestinyComponentType.ItemSockets,
       DestinyComponentType.ItemTalentGrids,
       DestinyComponentType.ItemCommonData,
-      DestinyComponentType.ItemPlugStates
+      DestinyComponentType.ItemPlugStates,
+      DestinyComponentType.CurrencyLookups
     ]
   })
   .then((response) => response.Response) as IPromise<DestinyVendorsResponse>;

--- a/src/app/collections/collections.tsx
+++ b/src/app/collections/collections.tsx
@@ -139,6 +139,7 @@ function Kiosk({
         kioskItems={items.filter((i) => i.canAcquire)}
         trackerService={trackerService}
         ownedItemHashes={ownedItemHashes}
+        currencyLookups={{}}
       />
     </div>
   );

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -166,7 +166,7 @@ function VendorItemCost({
   const currencyItem = defs.InventoryItem.get(cost.itemHash);
   return (
     <div key={cost.itemHash} className="cost">
-      {cost.quantity}
+      {cost.quantity}{' '}
       <span className="currency">
         <BungieImage
           src={currencyItem.displayProperties.icon}

--- a/src/app/d2-vendors/single-vendor.tsx
+++ b/src/app/d2-vendors/single-vendor.tsx
@@ -151,6 +151,7 @@ export default class SingleVendor extends React.Component<Props, State> {
           itemComponents={vendorResponse && vendorResponse.itemComponents}
           trackerService={trackerService}
           ownedItemHashes={ownedItemHashes}
+          currencyLookups={vendorResponse ? vendorResponse.currencyLookups.data.itemQuantities : {}}
         />
       </div>
     );

--- a/src/app/d2-vendors/vendor.scss
+++ b/src/app/d2-vendors/vendor.scss
@@ -11,6 +11,7 @@
 }
 
 .d2-vendors {
+  padding: 0 1em;
   .vendor-icon {
     margin: 5px 5px 5px 0;
   }

--- a/src/app/d2-vendors/vendors.tsx
+++ b/src/app/d2-vendors/vendors.tsx
@@ -149,6 +149,7 @@ function VendorGroup({
           sales={vendorsResponse.sales.data[vendor.vendorHash] && vendorsResponse.sales.data[vendor.vendorHash].saleItems}
           trackerService={trackerService}
           ownedItemHashes={ownedItemHashes}
+          currencyLookups={vendorsResponse.currencyLookups.data.itemQuantities}
         />
       )}
     </>
@@ -161,7 +162,8 @@ function Vendor({
   itemComponents,
   sales,
   trackerService,
-  ownedItemHashes
+  ownedItemHashes,
+  currencyLookups
 }: {
   defs: D2ManifestDefinitions;
   vendor: DestinyVendorComponent;
@@ -171,6 +173,9 @@ function Vendor({
   };
   trackerService?: DestinyTrackerServiceType;
   ownedItemHashes?: Set<number>;
+  currencyLookups: {
+    [itemHash: number]: number;
+  };
 }) {
   const vendorDef = defs.Vendor.get(vendor.vendorHash);
   if (!vendorDef) {
@@ -201,6 +206,7 @@ function Vendor({
         itemComponents={itemComponents}
         trackerService={trackerService}
         ownedItemHashes={ownedItemHashes}
+        currencyLookups={currencyLookups}
       />
     </div>
   );

--- a/src/app/record-books/record-books.html
+++ b/src/app/record-books/record-books.html
@@ -14,8 +14,8 @@
         <i class="fa collapse" ng-class="$ctrl.settings.collapsedSections[book.hash] ? 'fa-plus-square-o': 'fa-minus-square-o'"></i>
         <img class="book-icon" ng-src="{{ ::book.icon | bungieIcon }}" />
         {{ ::book.name }}
-        <span class="record-book-completion">{{ book.completedCount }} / {{ ::book.recordCount }}</span>
       </div>
+      <span class="record-book-completion">{{ book.completedCount }} / {{ ::book.recordCount }}</span>
     </div>
 
     <div ng-if="!$ctrl.settings.collapsedSections[book.hash]">

--- a/src/app/vendors/vendors.scss
+++ b/src/app/vendors/vendors.scss
@@ -1,4 +1,6 @@
 .vendor {
+  padding: 0 1em;
+
   .vendorTabs {
     display: flex;
     flex-direction: row;
@@ -96,11 +98,10 @@
     align-items: center;
   }
   .title {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
     .countdown {
       font-size: 11px;
+      text-align: right;
+      flex: 1;
     }
   }
   .vendor-location {
@@ -109,6 +110,7 @@
     font-size: 12px;
     color: #999;
     margin-left: 6px;
+    flex: 1;
   }
   .vendor-row {
     margin-bottom: 10px;

--- a/src/app/vendors/vendors.scss
+++ b/src/app/vendors/vendors.scss
@@ -138,7 +138,6 @@
   .cost {
     font-size: 10px;
     margin-top: 1px;
-    margin-left: 2px;
     text-align: center;
   }
   .empty-cost {
@@ -209,10 +208,9 @@
   float: right;
 }
 
-vendor-currencies {
+vendor-currencies, .vendor-currencies {
   font-size: 12px;
   float: right;
-  margin-top: 10px;
   display: flex;
   flex-direction: row;
   .vendor-currency {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -183,11 +183,14 @@ img {
   padding: 0 16px;
   background-color: #353535;
   color: white;
-  line-height: 34px;
-  height: 34px;
+  min-height: 34px;
   text-transform: uppercase;
   letter-spacing: 2px;
   font-size: 14px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
   &:hover {
     background-color: #2f2f2f;


### PR DESCRIPTION
Like with our old vendors page, this shows you how much of the necessary currencies you have, for each vendor. This helps make it clear what you can afford without putting the total next to every item.

<img width="252" alt="screen shot 2018-03-31 at 11 07 08 pm" src="https://user-images.githubusercontent.com/313208/38170345-45ec13e0-3538-11e8-84e6-1cc2c8bf7bb8.png">
