### PR TITLE
More robust error handling

### DIFF
--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -132,17 +132,14 @@ export function handleErrors<T>(response: IHttpResponse<ServerResponse<T>>): IHt
   }
 
   // Any other error
-  if (errorCode > 1) {
-    if (response.data.Message) {
-      const e = error(t('BungieService.UnknownError', { message: response.data.Message }), errorCode);
-      e.status = response.data.ErrorStatus;
-      throw e;
-    } else {
-      throw new Error(t('BungieService.Difficulties'));
-    }
+  if (response.data && response.data.Message) {
+    const e = error(t('BungieService.UnknownError', { message: response.data.Message }), errorCode);
+    e.status = response.data.ErrorStatus;
+    throw e;
+  } else {
+    console.error('No response data:', response.status, response.statusText);
+    throw new Error(t('BungieService.Difficulties'));
   }
-
-  return response;
 }
 
 /**


### PR DESCRIPTION
I'm attempting to figure out the `undefined is not an object evaluating t.Response` errors we keep seeing. It's a problem with Bungie.net but I'm not exactly sure how and why. This catches the error higher up, and logs some info. See https://sentry.io/destiny-item-manager/dim/issues/466162671/