### PR TITLE
Fix deleting items you don't have from loadouts.

### DIFF
--- a/src/app/loadout/loadout-drawer.component.ts
+++ b/src/app/loadout/loadout-drawer.component.ts
@@ -7,7 +7,8 @@ import { D2Categories } from '../destiny2/d2-buckets.service';
 import { D1Categories } from '../destiny1/d1-buckets.service';
 import { flatMap } from '../util';
 import { settings } from '../settings/settings';
-import { getDefinitions } from '../destiny1/d1-definitions.service';
+import { getDefinitions as getD1Definitions } from '../destiny1/d1-definitions.service';
+import { getDefinitions as getD2Definitions } from '../destiny2/d2-definitions.service';
 import { DimStore } from '../inventory/store/d2-store-factory.service';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { Loadout } from './loadout.service';
@@ -95,6 +96,7 @@ function LoadoutDrawerCtrl(
 
       // Filter out any vendor items and equip all if requested
       vm.loadout.warnitems = flatMap(Object.values(vm.loadout.items), (items) => items.filter((item) => !item.owner));
+      fillInDefinitionsForWarnItems(vm.loadout);
 
       _.each(vm.loadout.items, (items, type) => {
         vm.loadout!.items[type] = items.filter((item) => item.owner);
@@ -214,12 +216,11 @@ function LoadoutDrawerCtrl(
     if (!vm.loadout) {
       return;
     }
+    console.log(item);
     const discriminator = item.type.toLowerCase();
     const typeInventory = vm.loadout.items[discriminator] = (vm.loadout.items[discriminator] || []);
 
-    const index = _.findIndex(typeInventory, (i) => {
-      return i.hash === item.hash && i.id === item.id;
-    });
+    const index = typeInventory.findIndex((i) => i.hash === item.hash && i.id === item.id);
 
     if (index >= 0) {
       const decrement = $event.shiftKey ? 5 : 1;
@@ -234,6 +235,18 @@ function LoadoutDrawerCtrl(
     }
 
     vm.recalculateStats();
+  };
+
+  // TODO: In D2 we should probably just sub in another item w/ the same hash
+  vm.removeWarnItem = (item) => {
+    if (!vm.loadout) {
+      return;
+    }
+
+    const index = (vm.loadout.warnitems || []).findIndex((i) => i.hash === item.hash && i.id === item.id);
+    if (index >= 0) {
+      vm.warnItems.splice(index, 1);
+    }
   };
 
   vm.equip = function equip(item) {
@@ -305,8 +318,36 @@ function LoadoutDrawerCtrl(
       return;
     }
 
-    getDefinitions().then((defs) => {
+    getD1Definitions().then((defs) => {
       vm.stats = getCharacterStatsData(defs.Stat, { stats: combinedStats });
     });
   };
+}
+
+function fillInDefinitionsForWarnItems(loadout: Loadout & { warnitems?: DimItem[] }) {
+  if (!loadout.warnitems || !loadout.warnitems.length) {
+    return;
+  }
+
+  if (loadout.destinyVersion === 2) {
+    getD2Definitions().then((defs) => {
+      for (const warnItem of loadout.warnitems!) {
+        const itemDef = defs.InventoryItem.get(warnItem.hash);
+        if (itemDef) {
+          warnItem.icon = itemDef.displayProperties.icon;
+          warnItem.name = itemDef.displayProperties.name;
+        }
+      }
+    });
+  } else {
+    getD1Definitions().then((defs) => {
+      for (const warnItem of loadout.warnitems!) {
+        const itemDef = defs.InventoryItem.get(warnItem.hash);
+        if (itemDef) {
+          warnItem.icon = itemDef.icon;
+          warnItem.name = itemDef.itemName;
+        }
+      }
+    });
+  }
 }

--- a/src/app/loadout/loadout-drawer.html
+++ b/src/app/loadout/loadout-drawer.html
@@ -20,7 +20,7 @@
     <div ng-if="vm.loadout.warnitems.length" class="loadout-contents">
       <div ng-repeat="item in vm.loadout.warnitems" id="loadout-warn-item-{{:: $index }}" class="loadout-item">
         <dim-simple-item item-data="item"></dim-simple-item>
-        <div class="close" ng-click="vm.remove(item, $event); vm.form.name.$rollbackViewValue(); $event.stopPropagation();"></div>
+        <div class="close" ng-click="vm.removeWarnItem(item, $event)"></div>
         <div class="fa warn"></div>
       </div>
     </div>
@@ -29,7 +29,7 @@
       <div ng-repeat="value in vm.types track by value" class="loadout-{{ value }} loadout-bucket" ng-if="vm.loadout.items[value].length">
         <div ng-repeat="item in vm.loadout.items[value] | sortItems:vm.settings.itemSort track by item.index" ng-click="vm.equip(item)" id="loadout-item-{{:: $id }}" class="loadout-item">
           <dim-simple-item item-data="item"></dim-simple-item>
-          <div class="close" ng-click="vm.remove(item, $event); vm.form.name.$rollbackViewValue(); $event.stopPropagation();"></div>
+          <div class="close" ng-click="vm.remove(item, $event)"></div>
           <div class="equipped" ng-show="item.equipped"></div>
         </div>
       </div>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -447,7 +447,7 @@
     "SaveErrorTitle": "Error saving loadout",
     "TooManyRequested": "You have {{total}} {{itemname}} but your loadout asks for {{requested}}. We transfered all you had.",
     "VendorsCanEquip": "These items can be equipped:",
-    "VendorsCannotEquip": "These items cannot be equipped:"
+    "VendorsCannotEquip": "These items cannot be equipped because you don't have them:"
   },
   "Manifest": {
     "Build": "Building Destiny info database",


### PR DESCRIPTION
We were throwing an error when you tried to remove missing items from loadouts. You could always clear them by resaving the loadout, but the Xs wouldn't work. Also, they were always shown as empty boxes, which is not super helpful - now they include their icon and name, so you know what to go replace them with.

https://sentry.io/destiny-item-manager/dim/issues/444928529/

Fixes DIM-2Q

<img width="432" alt="screen shot 2018-03-31 at 11 56 20 pm" src="https://user-images.githubusercontent.com/313208/38170627-32f31098-353f-11e8-8be0-2c920bc64292.png">
