### PR TITLE
Letting refresh be leftmost in the (right part of the) header again.

### DIFF
--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -233,8 +233,8 @@ export default class Header extends React.Component<Props, State> {
         </div>
 
         <span className="header-right">
-          {(!showSearch && account && account.destinyVersion === 2 && settings.showReviews && defs) && <RatingMode defs={defs} D2StoresService={this.props.D2StoresService} />}
           {!showSearch && <Refresh/>}
+          {(!showSearch && account && account.destinyVersion === 2 && settings.showReviews && defs) && <RatingMode defs={defs} D2StoresService={this.props.D2StoresService} />}
           {!showSearch &&
             <a
               className="link fa fa-cog"


### PR DESCRIPTION
Someone on the twitters mentioned that they were used to refresh being leftmost in the rightmost section. I'm not looking to jam anyone up, so I shuffled the new rating mode toggle button slightly.

![changing the header game](https://user-images.githubusercontent.com/606888/38629656-a58b2398-3d82-11e8-8279-195faaacc391.png)
