### PR TITLE
Disabled the changelog toaster for DIM.

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -219,7 +219,7 @@ module.exports = (env) => {
         // Print debug info to console about item moves
         '$featureFlags.debugMoves': JSON.stringify(false),
         // show changelog toaster
-        '$featureFlags.changelogToaster': JSON.stringify(env === 'release'),
+        '$featureFlags.changelogToaster': JSON.stringify(false),
         '$featureFlags.reviewsEnabled': JSON.stringify(true),
         // Sync data over gdrive
         '$featureFlags.gdrive': JSON.stringify(true),


### PR DESCRIPTION
There isn't enough content for it with our automated weekly updates.  Let's ease this user pain.