### PR TITLE
Glue mode popup to the right on mobile

### DIFF
--- a/src/app/rating-mode/rating-mode.scss
+++ b/src/app/rating-mode/rating-mode.scss
@@ -1,3 +1,5 @@
+@import '../../scss/variables.scss';
+
 .mode-popup {
   position: absolute;
   display: block;
@@ -9,6 +11,9 @@
   height: fit-content;
   background-color: #222;
   float: left;
+  @include phone-portrait {
+    right: 0px;
+  }
 }
 
 .mode-label {


### PR DESCRIPTION
Just a tweak on the css because on mobile the popup would be cut
![image](https://user-images.githubusercontent.com/32077894/38765032-715343de-3f90-11e8-983a-5f9cfe8f7665.png)

With the tweak
![image](https://user-images.githubusercontent.com/32077894/38765035-81f3998c-3f90-11e8-941b-e0e0dfde421a.png)
