### PR TITLE
Add a DestinySets.com link to the bottom of the collections page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Next
 
 * The DIM changelog popup has moved to a "What's New" page along with Bungie.net alerts and our Twitter feed. We also moved the "Update DIM" popup to the "What's New" link.
+* The Collections page now has a link to DestinySets.com.
+
 
 # 4.48.0 (2018-04-15)
 

--- a/src/app/collections/collections.scss
+++ b/src/app/collections/collections.scss
@@ -1,0 +1,8 @@
+.collections-partner.dim-button {
+  text-decoration: none;
+  padding: 1em 2em;
+  font-size: 12px;
+  margin: 0 auto;
+  display: block;
+  width: fit-content;
+}

--- a/src/app/collections/collections.tsx
+++ b/src/app/collections/collections.tsx
@@ -16,6 +16,7 @@ import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.servic
 import { fetchRatingsForKiosks } from '../d2-vendors/vendor-ratings';
 import { Subscription } from 'rxjs/Subscription';
 import { DimStore } from '../inventory/store/d2-store-factory.service';
+import { t } from 'i18next';
 
 interface Props {
   $scope: IScope;
@@ -104,6 +105,9 @@ export default class Collections extends React.Component<Props, State> {
             ownedItemHashes={ownedItemHashes}
           />
         )}
+        <a className="collections-partner dim-button" target="_blank" rel="noopener" href="https://destinysets.com">
+          {t('Vendors.DestinySets')}
+        </a>
       </div>
     );
   }

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -671,7 +671,8 @@
     "Load": "Loading Vendors",
     "ShadersAndEmblems": "Shaders & Emblems",
     "ShipsAndVehicles": "Ships & Vehicles",
-    "Vendors": "Vendors"
+    "Vendors": "Vendors",
+    "DestinySets": "Browse more item sets at Destiny Sets"
   },
   "Views": {
     "About": {


### PR DESCRIPTION
<img width="871" alt="screen shot 2018-04-20 at 11 31 17 pm" src="https://user-images.githubusercontent.com/313208/39081282-4d2aeb0c-44f3-11e8-9c3a-a78b9bc39f6a.png">

Folks often ask us to support other collections, and we always point them to DestinySets.com. This puts the link right there where they'd be looking for more.