### PR TITLE
Load DIM version from the server

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -9,6 +9,7 @@ const WebpackNotifierPlugin = require('webpack-notifier');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackIncludeSiblingChunksPlugin = require('html-webpack-include-sibling-chunks-plugin');
+const GenerateJsonPlugin = require('generate-json-webpack-plugin');
 // const Visualizer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const NotifyPlugin = require('notify-webpack-plugin');
@@ -196,6 +197,11 @@ module.exports = (env) => {
         filename: 'gdrive-return.html',
         template: '!html-loader!src/gdrive-return.html',
         chunks: ['gdriveReturn']
+      }),
+
+      // Generate a version info JSON file we can poll. We could theoretically add more info here too.
+      new GenerateJsonPlugin('./version.json', {
+        version
       }),
 
       new CopyWebpackPlugin([

--- a/package-lock.json
+++ b/package-lock.json
@@ -6261,6 +6261,12 @@
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
+    "generate-json-webpack-plugin": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/generate-json-webpack-plugin/-/generate-json-webpack-plugin-0.3.1.tgz",
+      "integrity": "sha512-0gsqCyLf1OF+9tjN75QkPYV6UoyuPCfhgLXcX44/Ft9j82z9kBG/7yMS/ufN8yU2l4noSNEVNYQ9GdqenH/0cQ==",
+      "dev": true
+    },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "exports-loader": "^0.7.0",
     "extract-loader": "^2.0.1",
     "file-loader": "^1.1.11",
+    "generate-json-webpack-plugin": "^0.3.1",
     "grunt": "^1.0.2",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-compress": "^1.3.0",

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -976,3 +976,15 @@ FileETag None
         Header unset Expires
     </IfModule>
 </FilesMatch>
+
+# Do not cache version.json either
+
+<FilesMatch "version\.json(\.(gz|br))?">
+    FileETag None
+    <IfModule mod_headers.c>
+        Header unset ETag
+        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+        Header set Pragma "no-cache"
+        Header unset Expires
+    </IfModule>
+</FilesMatch>

--- a/src/app/rx-operators.ts
+++ b/src/app/rx-operators.ts
@@ -1,6 +1,8 @@
 // Spelling out each operator we need helps save on bundle size, but it's a pain
 // to type everywhere. So we keep them all here and you just have to import rx-operators.
 import 'rxjs/add/observable/defer';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/combineLatest';
 import 'rxjs/add/observable/timer';
 import 'rxjs/add/observable/fromEventPattern';
 import 'rxjs/add/observable/fromPromise';
@@ -16,4 +18,3 @@ import 'rxjs/add/operator/take';
 import 'rxjs/add/operator/subscribeOn';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/combineLatest';

--- a/src/app/whats-new/versions.ts
+++ b/src/app/whats-new/versions.ts
@@ -1,6 +1,5 @@
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import * as _ from 'underscore';
-import '../rx-operators';
 
 const localStorageKey = 'dim-changelog-viewed-version';
 

--- a/src/app/whats-new/versions.ts
+++ b/src/app/whats-new/versions.ts
@@ -1,6 +1,5 @@
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import * as _ from 'underscore';
-import { Observable } from 'rxjs/Observable';
 import '../rx-operators';
 
 const localStorageKey = 'dim-changelog-viewed-version';
@@ -12,15 +11,6 @@ class Versions {
 
   /** An observable for whether to show the changelog. */
   showChangelog$ = new BehaviorSubject(this.showChangelog);
-
-  /** An observable for whether the server thinks there's a new version. */
-  // TODO: does this belong here?
-  // TODO: if the versions are different (vs. currentVersion), force SW update and then go
-  serverVersion$ = Observable.timer(0, 10 * 60 * 1000)
-    // Fetch but swallow errors
-    .switchMap(() => Observable.fromPromise(getServerVersion()).catch(() => Observable.empty<string>()))
-    // Deep equals
-    .distinctUntilChanged();
 
   /**
    * Signify that the changelog page has been viewed.
@@ -79,19 +69,6 @@ export function compareVersions(version1: string, version2: string) {
   }
 
   return 0;
-}
-
-async function getServerVersion() {
-  const response = await fetch('/version.json');
-  if (response.ok) {
-    const data = await response.json();
-    if (!data.version) {
-      throw new Error("No version property");
-    }
-    return data.version as string;
-  } else {
-    throw response;
-  }
 }
 
 export const DimVersions = new Versions();

--- a/src/register-service-worker.ts
+++ b/src/register-service-worker.ts
@@ -109,6 +109,8 @@ export default function registerServiceWorker() {
           if ($featureFlags.debugSW) {
             console.error('SW: Unable to update service worker.', err);
           }
+        }).then(() => {
+          console.log('SW: New content is available; please refresh.');
         });
       };
     })

--- a/src/register-service-worker.ts
+++ b/src/register-service-worker.ts
@@ -1,6 +1,14 @@
 import { BehaviorSubject } from "rxjs/BehaviorSubject";
 import './app/rx-operators';
 import { reportException } from "./app/exceptions";
+import { Observable } from 'rxjs/Observable';
+
+/**
+ * A function that will attempt to update the service worker in place.
+ * It will return a promise for when the update is complete.
+ * If service workers are not enabled or installed, this is a no-op.
+ */
+let updateServiceWorker = () => Promise.resolve();
 
 /** Whether a new service worker has been installed */
 const serviceWorkerUpdated$ = new BehaviorSubject(false);
@@ -8,13 +16,31 @@ const serviceWorkerUpdated$ = new BehaviorSubject(false);
 const contentChanged$ = new BehaviorSubject(false);
 
 /**
+ * An observable for what version the server thinks is current.
+ * This is to handle cases where folks have DIM open for a long time.
+ * It will attempt to update the service worker before reporting true.
+ */
+const serverVersionChanged$ = Observable.timer(0, 15 * 60 * 1000)
+  // Fetch but swallow errors
+  .switchMap(() => Observable.fromPromise(getServerVersion()).catch(() => Observable.empty<string>()))
+  .map((version) => version !== $DIM_VERSION)
+  .distinctUntilChanged()
+  // At this point the value of the observable will flip to true once and only once
+  .switchMap((needsUpdate) => needsUpdate
+    ? Observable.fromPromise(updateServiceWorker().then(() => true))
+    : Observable.of(false));
+
+/**
  * Whether there is new content available if you reload DIM.
  *
- * We only need to update when there's new cached content and
+ * We only need to update when there's new content and we've already updated the service worker.
  */
-// TODO: mix in version updates from server-provided JSON as well, so we don't require service workers
-export const dimNeedsUpdate$ = serviceWorkerUpdated$
-  .combineLatest(contentChanged$, (updated, changed) => updated && changed)
+export const dimNeedsUpdate$ = Observable.combineLatest(
+  serverVersionChanged$,
+  serviceWorkerUpdated$,
+  contentChanged$,
+  (serverVersionChanged, updated, changed) => serverVersionChanged || (updated && changed)
+)
   .distinctUntilChanged();
 
 /**
@@ -77,9 +103,33 @@ export default function registerServiceWorker() {
           }
         };
       };
+
+      updateServiceWorker = () => {
+        return registration.update().catch((err) => {
+          if ($featureFlags.debugSW) {
+            console.error('SW: Unable to update service worker.', err);
+          }
+        });
+      };
     })
     .catch((err) => {
       console.error('SW: Unable to register service worker.', err);
       reportException('service-worker', err);
     });
+}
+
+/**
+ * Fetch a file on the server that contains the currently uploaded version number.
+ */
+async function getServerVersion() {
+  const response = await fetch('/version.json');
+  if (response.ok) {
+    const data = await response.json();
+    if (!data.version) {
+      throw new Error("No version property");
+    }
+    return data.version as string;
+  } else {
+    throw response;
+  }
 }


### PR DESCRIPTION
This is a backup to the service-worker based update detection mechanism we've been using so far. It writes a `version.json` file to the server containing the deployed version, and we poll it every 15 minutes, starting 15 minutes into your session. This way, even long-running DIM sessions get notified about updates - very useful if you keep DIM open without reloading it for a long time.