### PR TITLE
Remove preAssignBindingsEnabled (deprecated Angular behavior)

### DIFF
--- a/src/app/dimApp.config.ts
+++ b/src/app/dimApp.config.ts
@@ -6,8 +6,6 @@ export default function config(
   ngDialogProvider) {
   'ngInject';
 
-  // TODO: remove this dependency by fixing component bindings https://github.com/angular/angular.js/blob/master/docs/CHANGELOG.md#breaking-changes-1
-  $compileProvider.preAssignBindingsEnabled(true);
   $compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?:|data:image\/)/);
 
   $httpProvider.interceptors.push('ngHttpRateLimiterInterceptor');

--- a/src/app/infuse/infuse.component.ts
+++ b/src/app/infuse/infuse.component.ts
@@ -30,23 +30,8 @@ function InfuseCtrl(
 
   const vm = this;
 
-  vm.items = {};
-  if (vm.query.destinyVersion === 1) {
-    getDefinitions().then((defs) => {
-      [
-        452597397,
-        2534352370,
-        3159615086,
-        937555249,
-        1898539128,
-        1542293174
-      ].forEach((hash) => {
-        vm.items[hash] = defs.InventoryItem.get(hash);
-      });
-    });
-  }
-
   extend(vm, {
+    items: {},
     getAllItems: true,
     showLockedItems: false,
     source: null,
@@ -60,6 +45,21 @@ function InfuseCtrl(
       // Set the source and reset the targets
       vm.infused = 0;
       vm.target = null;
+
+      if (vm.query.destinyVersion === 1) {
+        getDefinitions().then((defs) => {
+          [
+            452597397,
+            2534352370,
+            3159615086,
+            937555249,
+            1898539128,
+            1542293174
+          ].forEach((hash) => {
+            vm.items[hash] = defs.InventoryItem.get(hash);
+          });
+        });
+      }
 
       vm.getItems();
     },

--- a/src/app/inventory/dimStoreBucket.directive.ts
+++ b/src/app/inventory/dimStoreBucket.directive.ts
@@ -53,7 +53,9 @@ function StoreBucketCtrl(
 
   vm.settings = settings;
 
-  vm.dropChannel = `${vm.bucket.type},${vm.store.id}${vm.bucket.type}`;
+  vm.$onInit = () => {
+    vm.dropChannel = `${vm.bucket.type},${vm.store.id}${vm.bucket.type}`;
+  };
 
   // Detect when we're hovering a dragged item over a target
   let dragTimer: IPromise<void> | undefined;

--- a/src/app/item-review/item-review.component.ts
+++ b/src/app/item-review/item-review.component.ts
@@ -29,17 +29,27 @@ function ItemReviewController(
 
   const vm = this;
   vm.canReview = settings.allowIdPostToDtr;
-  vm.canCreateReview = (vm.canReview && vm.item.owner);
-  vm.submitted = false;
-  vm.hasUserReview = ((vm.item.userRating) || (vm.item.userVote));
-  vm.expandReview = ((vm.item.isLocallyCached) && (vm.item.userVote !== 0));
   vm.toggledFlags = [];
-
-  if (!vm.item.mode) {
-    vm.item.mode = settings.reviewsModeSelection;
-  }
-
+  vm.submitted = false;
   vm.isCollapsed = false;
+
+  vm.$onInit = () => {
+    vm.canCreateReview = (vm.canReview && vm.item.owner);
+    vm.hasUserReview = ((vm.item.userRating) || (vm.item.userVote));
+    vm.expandReview = ((vm.item.isLocallyCached) && (vm.item.userVote !== 0));
+    if (!vm.item.mode) {
+      vm.item.mode = settings.reviewsModeSelection;
+    }
+
+    vm.reviewData = vm.getReviewData();
+
+    if (vm.item.destinyVersion === 2) {
+      getDefinitions().then((defs) => {
+        vm.reviewModeOptions = getReviewModes(defs);
+      });
+    }
+  };
+
 
   vm.toggleChart = () => {
     vm.isCollapsed = !vm.isCollapsed;
@@ -121,12 +131,6 @@ function ItemReviewController(
 
   vm.reviewLabels = [5, 4, 3, 2, 1];
 
-  if (vm.item.destinyVersion === 2) {
-    getDefinitions().then((defs) => {
-      vm.reviewModeOptions = getReviewModes(defs);
-    });
-  }
-
   vm.getReviewData = () => {
     if (!vm.item.reviews) {
       return [];
@@ -145,8 +149,6 @@ function ItemReviewController(
 
     return mapData;
   };
-
-  vm.reviewData = vm.getReviewData();
 
   vm.shouldDrawChart = () => {
     vm.reviewData = vm.getReviewData();

--- a/src/app/loadout/loadout-drawer.component.ts
+++ b/src/app/loadout/loadout-drawer.component.ts
@@ -38,8 +38,6 @@ function LoadoutDrawerCtrl(
   'ngInject';
   const vm = this;
 
-  const dimItemCategories = vm.account.destinyVersion === 2 ? D2Categories : D1Categories;
-
   this.$onChanges = (changes) => {
     if (changes.stores) {
       const stores = vm.stores || [];
@@ -74,6 +72,8 @@ function LoadoutDrawerCtrl(
 
     if (changes.account) {
       vm.show = false;
+      const dimItemCategories = vm.account.destinyVersion === 2 ? D2Categories : D1Categories;
+      vm.types = _.flatten(Object.values(dimItemCategories)).map((t) => t.toLowerCase());
     }
   };
 
@@ -116,8 +116,6 @@ function LoadoutDrawerCtrl(
   });
 
   vm.settings = settings;
-
-  vm.types = _.flatten(Object.values(dimItemCategories)).map((t) => t.toLowerCase());
 
   vm.show = false;
   dimLoadoutService.dialogOpen = false;

--- a/src/app/move-popup/dimMovePopup.directive.ts
+++ b/src/app/move-popup/dimMovePopup.directive.ts
@@ -4,6 +4,7 @@ import './move-popup.scss';
 import { DimItem } from '../inventory/store/d2-item-factory.service';
 import { DimStore } from '../inventory/store/d2-store-factory.service';
 import { StoreServiceType } from '../inventory/d2-stores.service';
+import { IController } from 'angular';
 
 export const MovePopupComponent = {
   controller: MovePopupController,
@@ -27,7 +28,7 @@ interface MovePopupControllerType {
 }
 
 function MovePopupController(
-  this: MovePopupControllerType,
+  this: IController & MovePopupControllerType,
   $scope,
   D2StoresService: StoreServiceType,
   dimStoreService: StoreServiceType,
@@ -36,18 +37,19 @@ function MovePopupController(
 ) {
   'ngInject';
   const vm = this;
+  vm.settings = settings;
 
   function getStoreService() {
     return vm.item.destinyVersion === 2 ? D2StoresService : dimStoreService;
   }
 
-  vm.moveAmount = vm.item.amount;
-  vm.settings = settings;
-
-  if (vm.item.maxStackSize > 1) {
-    const store = getStoreService().getStore(vm.item.owner)!;
-    vm.maximum = store.amountOfItem(vm.item);
-  }
+  vm.$onInit = () => {
+    vm.moveAmount = vm.item.amount;
+    if (vm.item.maxStackSize > 1) {
+      const store = getStoreService().getStore(vm.item.owner)!;
+      vm.maximum = store.amountOfItem(vm.item);
+    }
+  };
 
   /*
   * Open up the dialog for infusion by passing

--- a/src/app/move-popup/move-locations.component.ts
+++ b/src/app/move-popup/move-locations.component.ts
@@ -29,12 +29,14 @@ function controller(
   'ngInject';
   const vm = this;
 
-  const storeService = vm.item.destinyVersion === 2 ? D2StoresService : dimStoreService;
-
   vm.settings = settings;
 
-  vm.store = storeService.getStore(vm.item.owner)!;
-  vm.stores = storeService.getStores();
+  vm.$onInit = () => {
+    const storeService = vm.item.destinyVersion === 2 ? D2StoresService : dimStoreService;
+
+    vm.store = storeService.getStore(vm.item.owner)!;
+    vm.stores = storeService.getStores();
+  };
 
   vm.canShowVault = function canShowVault(buttonStore: DimStore) {
     // If my itemStore is the vault, don't show a vault button.

--- a/src/app/move-popup/talent-grid.component.ts
+++ b/src/app/move-popup/talent-grid.component.ts
@@ -51,19 +51,21 @@ function TalentGridCtrl(
     }
   };
 
-  vm.hiddenColumns = 0;
-  if (vm.perksOnly) {
-    if (_.find(vm.talentGrid.nodes, { hash: infuseHash })) {
-      vm.hiddenColumns += 1;
+  vm.$onInit = () => {
+    vm.hiddenColumns = 0;
+    if (vm.perksOnly) {
+      if (_.find(vm.talentGrid.nodes, { hash: infuseHash })) {
+        vm.hiddenColumns += 1;
+      }
+      if (_.find(vm.talentGrid.nodes, { hash: 2133116599 })) {
+        vm.hiddenColumns += 1;
+      }
     }
-    if (_.find(vm.talentGrid.nodes, { hash: 2133116599 })) {
-      vm.hiddenColumns += 1;
-    }
-  }
 
-  if (vm.talentGrid) {
-    const visibleNodes = vm.talentGrid.nodes.filter((n) => !n.hidden);
-    vm.numColumns = _.max(visibleNodes, (n) => n.column).column + 1 - vm.hiddenColumns;
-    vm.numRows = vm.perksOnly ? 2 : (_.max(visibleNodes, (n) => n.row).row + 1);
-  }
+    if (vm.talentGrid) {
+      const visibleNodes = vm.talentGrid.nodes.filter((n) => !n.hidden);
+      vm.numColumns = _.max(visibleNodes, (n) => n.column).column + 1 - vm.hiddenColumns;
+      vm.numRows = vm.perksOnly ? 2 : (_.max(visibleNodes, (n) => n.row).row + 1);
+    }
+  };
 }

--- a/src/app/shell/countdown.component.ts
+++ b/src/app/shell/countdown.component.ts
@@ -16,7 +16,17 @@ function CountdownController(this: IController, $interval: IIntervalService, $i1
 
   const vm = this;
 
-  vm.endTime = new Date(vm.endTime);
+  vm.$onInit = () => {
+    vm.endTime = new Date(vm.endTime);
+
+    // Update once a minute
+    vm.timer = $interval(update, 60000);
+    update();
+  };
+
+  vm.$onDestroy = () => {
+    $interval.cancel(vm.timer);
+  };
 
   function update() {
     const diff = vm.endTime.getTime() - Date.now();
@@ -46,12 +56,4 @@ function CountdownController(this: IController, $interval: IIntervalService, $i1
     }
     return text;
   }
-
-  // Update once a minute
-  vm.timer = $interval(update, 60000);
-  update();
-
-  vm.$onDestroy = () => {
-    $interval.cancel(vm.timer);
-  };
 }

--- a/src/app/shell/manifest-progress.component.ts
+++ b/src/app/shell/manifest-progress.component.ts
@@ -1,7 +1,7 @@
 import { D1ManifestService, D2ManifestService } from '../manifest/manifest-service';
 import template from './dimManifestProgress.directive.html';
 import './dimManifestProgress.scss';
-import { IComponentOptions } from 'angular';
+import { IComponentOptions, IController } from 'angular';
 
 /**
  * A dialog that shows the progress of loading the manifest.
@@ -14,6 +14,8 @@ export const ManifestProgressComponent: IComponentOptions = {
   }
 };
 
-function ManifestProgressCtrl() {
-  this.manifest = this.destinyVersion === 2 ? D2ManifestService : D1ManifestService;
+function ManifestProgressCtrl(this: IController) {
+  this.$onInit = () => {
+    this.manifest = this.destinyVersion === 2 ? D2ManifestService : D1ManifestService;
+  };
 }

--- a/src/app/shell/star-rating/star-rating.component.ts
+++ b/src/app/shell/star-rating/star-rating.component.ts
@@ -23,7 +23,10 @@ function StarRatingController(
 
   const vm = this;
 
-  vm.isReadOnly = $element[0].hasAttribute('read-only');
+  vm.$postLink = () => {
+    vm.isReadOnly = $element[0].hasAttribute('read-only');
+  };
+
   function updateStars() {
     vm.stars = [];
     for (let id = 0; id < 5; id++) {


### PR DESCRIPTION
AngularJS 1.5 deprecated the ability to reference bindings before `$onInit`, but let us opt in to the old behavior. 1.7 will remove this fallback. It's better for perf to do it the new way anyway. This finally does the job of moving over all references to bindings before init.