### PR TITLE
Fix moving mods/shaders from the Postmaster.

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -225,7 +225,7 @@ module.exports = (env) => {
         // Feature flags!
 
         // Print debug info to console about item moves
-        '$featureFlags.debugMoves': JSON.stringify(false),
+        '$featureFlags.debugMoves': JSON.stringify(env !== 'release'),
         '$featureFlags.reviewsEnabled': JSON.stringify(true),
         // Sync data over gdrive
         '$featureFlags.gdrive': JSON.stringify(true),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Next
 
 * The DIM changelog popup has moved to a "What's New" page along with Bungie.net alerts and our Twitter feed. We also moved the "Update DIM" popup to the "What's New" link.
+* Fix moving mods and shaders from the postmaster.
+* Remove "Take" button from stackables in the postmaster.
 
 # 4.48.0 (2018-04-15)
 

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -187,7 +187,7 @@ export function getVendors(account: DestinyAccount, characterId: string): IPromi
 export function transfer(item: DimItem, store: DimStore, amount: number): IPromise<ServerResponse<number>> {
   const platform = getActivePlatform();
   const request = {
-    characterId: store.isVault ? item.owner : store.id,
+    characterId: (store.isVault || item.location.inPostmaster) ? item.owner : store.id,
     membershipType: platform!.platformType,
     itemId: item.id,
     itemReferenceHash: item.hash,

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -14,7 +14,7 @@ import * as _ from 'underscore';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.service';
 import { getCharacters, getStores } from '../bungie-api/destiny2-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
-import { getBuckets, DimInventoryBuckets } from '../destiny2/d2-buckets.service';
+import { getBuckets, DimInventoryBuckets, DimInventoryBucket } from '../destiny2/d2-buckets.service';
 import { getDefinitions, D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { bungieNetPath } from '../dim-ui/bungie-image';
 import { reportException } from '../exceptions';
@@ -38,7 +38,8 @@ export interface StoreServiceType {
   getItemAcrossStores(params: {
     id?: string;
     hash?: number;
-    notransfer?: boolean;
+    location?: DimInventoryBucket;
+    owner?: string;
   }): DimItem | undefined;
   updateCharacters(account?: DestinyAccount): IPromise<DimStore[]>;
   reloadStores(): Promise<DimStore[]>;
@@ -105,8 +106,13 @@ export function D2StoresService(
   /**
    * Find an item among all stores that matches the params provided.
    */
-  function getItemAcrossStores(params: { id?: string; hash?: number; notransfer?: boolean }) {
-    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'notransfer')) as (DimItem) => boolean;
+  function getItemAcrossStores(params: {
+    id?: string;
+    hash?: number;
+    location?: DimInventoryBucket;
+    owner?: string;
+  }) {
+    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'location', 'owner')) as (DimItem) => boolean;
     for (const store of _stores) {
       const result = store.items.find(predicate);
       if (result) {

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -346,7 +346,7 @@ export function ItemService(
     return moveToStore(item, getStoreService(item).getVault()!, false, amount);
   }
 
-  function moveToStore(item: DimItem, store: DimStore, equip: boolean = false, amount: number = 0) {
+  function moveToStore(item: DimItem, store: DimStore, equip: boolean = false, amount: number = item.amount) {
     if ($featureFlags.debugMoves) {
       console.log('Move', amount, item.name, item.type, 'to', store.name, 'from', getStoreService(item).getStore(item.owner)!.name);
     }
@@ -773,7 +773,7 @@ export function ItemService(
         let promise: IPromise<DimItem> = $q.when(item);
 
         if (!source.isVault && !target.isVault) { // Guardian to Guardian
-          if (source.id !== target.id) { // Different Guardian
+          if (source.id !== target.id && !item.bucket.accountWide) { // Different Guardian
             if (item.equipped) {
               promise = promise.then(dequipItem);
             }

--- a/src/app/inventory/dimStoreService.factory.js
+++ b/src/app/inventory/dimStoreService.factory.js
@@ -69,10 +69,10 @@ export function StoreService(
 
   /**
    * Find an item among all stores that matches the params provided.
-   * @param {{ id, hash, notransfer }} params
+   * @param {{ id, hash, location, owner }} params
    */
   function getItemAcrossStores(params) {
-    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'notransfer'));
+    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'location', 'owner'));
     for (let i = 0; i < _stores.length; i++) {
       const result = _stores[i].items.find(predicate);
       if (result) {

--- a/src/app/move-popup/dimMovePopup.directive.html
+++ b/src/app/move-popup/dimMovePopup.directive.html
@@ -4,7 +4,7 @@
   <div class="interaction">
     <dim-move-locations item="vm.item" amount="vm.moveAmount"></dim-move-locations>
     <div class="move-button move-consolidate" ng-i18next="[title]MovePopup.Consolidate;[alt]MovePopup.Consolidate"
-      ng-if="!vm.item.notransfer && vm.item.maxStackSize > 1" ng-click="vm.consolidate()">
+      ng-if="!vm.item.notransfer && vm.item.location.hasTransferDestination && vm.item.maxStackSize > 1" ng-click="vm.consolidate()">
       <span ng-i18next="MovePopup.Take"></span>
     </div>
     <div class="move-button move-distribute" ng-i18next="[title]MovePopup.DistributeEvenly;[alt]MovePopup.DistributeEvenly"


### PR DESCRIPTION
This should fix #2744. They were working OK, but throwing errors in our own logic because we got confused. This fixes us trying to move them through the vault too, and removes the "Take" button from stackables in the postmaster.