### PR TITLE
Replace all Angular $http service usage with fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "idb-keyval": "^2.3.0",
     "mobile-drag-drop": "^2.3.0-rc.1",
     "ng-dialog": "^1.4.0",
-    "ng-http-rate-limiter": "^1.0.1",
     "ng-i18next": "^1.0.5",
     "ngimport": "^1.0.0",
     "oclazyload": "^1.1.0",

--- a/src/app/bungie-api/bungie-api-utils.ts
+++ b/src/app/bungie-api/bungie-api-utils.ts
@@ -1,28 +1,20 @@
-import { IRequestConfig } from "angular";
+import { HttpClientConfig } from "bungie-api-ts/http";
 
 export const API_KEY = ($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta') ? $DIM_WEB_API_KEY : localStorage.apiKey;
 
-export function bungieApiUpdate(path: string, data?: object): IRequestConfig {
+export function bungieApiUpdate(path: string, data?: object): HttpClientConfig {
   return {
     method: 'POST',
     url: `https://www.bungie.net${path}`,
-    headers: {
-      'X-API-Key': API_KEY
-    },
-    withCredentials: true,
-    data
+    body: data
   };
 }
 
-export function bungieApiQuery(path: string, params?: object): IRequestConfig {
+export function bungieApiQuery(path: string, params?: object): HttpClientConfig {
   return {
     method: 'GET',
     url: `https://www.bungie.net${path}`,
-    params,
-    headers: {
-      'X-API-Key': API_KEY
-    },
-    withCredentials: true
+    params
   };
 }
 

--- a/src/app/bungie-api/bungie-core-api.ts
+++ b/src/app/bungie-api/bungie-core-api.ts
@@ -1,7 +1,6 @@
-import { IPromise, IHttpResponse } from 'angular';
-import { $http } from 'ngimport';
 import { bungieApiQuery } from './bungie-api-utils';
 import { ServerResponse } from 'bungie-api-ts/common';
+import { httpAdapter } from './bungie-service-helper';
 
 export interface GlobalAlert {
   key: string;
@@ -21,11 +20,11 @@ const GlobalAlertLevelsToToastLevels = [
 /**
  * Get global alerts (like maintenance warnings) from Bungie.
  */
-export function getGlobalAlerts(): IPromise<GlobalAlert[]> {
-  return $http(bungieApiQuery(`/Platform/GlobalAlerts/`))
-    .then((response: IHttpResponse<ServerResponse<any>>) => {
-      if (response && response.data && response.data.Response) {
-        return response.data.Response.map((alert) => {
+export function getGlobalAlerts(): Promise<GlobalAlert[]> {
+  return httpAdapter(bungieApiQuery(`/Platform/GlobalAlerts/`))
+    .then((response: ServerResponse<any>) => {
+      if (response && response.Response) {
+        return response.Response.map((alert) => {
           return {
             key: alert.AlertKey,
             type: GlobalAlertLevelsToToastLevels[alert.AlertLevel],

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -1,51 +1,48 @@
 import { PlatformErrorCodes, ServerResponse } from 'bungie-api-ts/common';
 import { HttpClientConfig } from 'bungie-api-ts/http';
 import { t } from 'i18next';
-import { $http, $rootScope, $timeout } from 'ngimport';
+import { $rootScope } from 'ngimport';
 import { API_KEY } from './bungie-api-utils';
-import {
-  IHttpResponse,
-  IPromise,
-  IRequestConfig,
-} from 'angular';
 import { getActivePlatform } from '../accounts/platform.service';
+import { fetchWithBungieOAuth } from '../oauth/http-refresh-token.service';
+import { rateLimitedFetch } from './rate-limiter';
+import { stringify } from 'simple-query-string';
 
 export interface DimError extends Error {
   code?: PlatformErrorCodes | string;
   status?: string;
 }
 
-export function httpAdapter(config: HttpClientConfig): Promise<any> {
-  return $http(buildOptions(config))
-      .then(handleErrors, handleErrors)
-      .then((response) => response.data) as Promise<any>;
+const ourFetch = rateLimitedFetch(fetchWithBungieOAuth);
+
+export function httpAdapter(config: HttpClientConfig): Promise<ServerResponse<any>> {
+  return Promise.resolve(ourFetch(buildOptions(config)))
+      .then(handleErrors, handleErrors);
 }
 
-export function httpAdapterWithRetry(config: HttpClientConfig): Promise<any> {
-  return $http(buildOptions(config))
-      .then(handleErrors, handleErrors)
-      .then(retryOnThrottled)
-      .then((response) => response.data) as Promise<any>;
+export function httpAdapterWithRetry(config: HttpClientConfig): Promise<ServerResponse<any>> {
+  return Promise.resolve(ourFetch(buildOptions(config)))
+      .then(handleErrors, handleErrors);
 }
 
-function buildOptions(config: HttpClientConfig): IRequestConfig {
-  const options: IRequestConfig = {
-    method: config.method,
-    url: config.url,
-    headers: {
-      'X-API-Key': API_KEY
-    },
-    withCredentials: true
-  };
-
+function buildOptions(config: HttpClientConfig): Request {
+  let url = config.url;
   if (config.params) {
-    options.params = config.params;
-  }
-  if (config.body) {
-    options.data = config.body;
+    url = `${url}?${stringify(config.params)}`;
   }
 
-  return options;
+  console.log(config);
+  return new Request(
+    url,
+    {
+      method: config.method,
+      body: JSON.stringify(config.body),
+      headers: {
+        'X-API-Key': API_KEY,
+        'Content-Type': 'application/json'
+      },
+      credentials: 'include'
+    });
 }
 
 /** Generate an error with a bit more info */
@@ -55,7 +52,7 @@ export function error(message: string, errorCode: PlatformErrorCodes): DimError 
   return error;
 }
 
-export function handleErrors<T>(response: IHttpResponse<ServerResponse<T>>): IHttpResponse<ServerResponse<T>> {
+export async function handleErrors<T>(response: Response): Promise<ServerResponse<T>> {
   if (response instanceof Error) {
     throw response;
   }
@@ -81,12 +78,15 @@ export function handleErrors<T>(response: IHttpResponse<ServerResponse<T>>): IHt
     }));
   }
 
-  const errorCode = response.data ? response.data.ErrorCode : -1;
+  console.log(response);
+  const data: ServerResponse<any> = await response.json();
+
+  const errorCode = data ? data.ErrorCode : -1;
 
   // See https://github.com/DestinyDevs/BungieNetPlatform/wiki/Enums#platformerrorcodes
   switch (errorCode) {
   case PlatformErrorCodes.Success:
-    return response;
+    return data;
 
   case PlatformErrorCodes.DestinyVendorNotFound:
     throw error(t('BungieService.VendorNotFound'), errorCode);
@@ -112,8 +112,8 @@ export function handleErrors<T>(response: IHttpResponse<ServerResponse<T>>): IHt
 
   case PlatformErrorCodes.DestinyAccountNotFound:
   case PlatformErrorCodes.DestinyUnexpectedError:
-    if (response.config.url.indexOf('/Account/') >= 0 &&
-        response.config.url.indexOf('/Character/') < 0) {
+    if (response.url.indexOf('/Account/') >= 0 &&
+        response.url.indexOf('/Character/') < 0) {
       const account = getActivePlatform();
       throw error(t('BungieService.NoAccount', {
         platform: account ? account.platformLabel : 'Unknown'
@@ -136,12 +136,12 @@ export function handleErrors<T>(response: IHttpResponse<ServerResponse<T>>): IHt
   }
 
   // Any other error
-  if (response.data && response.data.Message) {
-    const e = error(t('BungieService.UnknownError', { message: response.data.Message }), errorCode);
-    e.status = response.data.ErrorStatus;
+  if (data && data.Message) {
+    const e = error(t('BungieService.UnknownError', { message: data.Message }), errorCode);
+    e.status = data.ErrorStatus;
     throw e;
   } else {
-    console.error('No response data:', response.status, response.statusText, response.xhrStatus);
+    console.error('No response data:', response.status, response.statusText);
     throw new Error(t('BungieService.Difficulties'));
   }
 }
@@ -150,15 +150,21 @@ export function handleErrors<T>(response: IHttpResponse<ServerResponse<T>>): IHt
  * A response handler that can be used to retry the response if it
  * receives the specific Bungie throttling error codes.
  */
-export function retryOnThrottled<T>(response: IHttpResponse<ServerResponse<T>>, retries: number = 3): IPromise<IHttpResponse<ServerResponse<T>>> | IHttpResponse<ServerResponse<T>> {
+/*
+export function retryOnThrottled<T>(response: ServerResponse<T>, retries: number = 3): Promise<ServerResponse<T>> | ServerResponse<T> {
   // TODO: these different statuses suggest different backoffs
-  if (response.data &&
-      (response.data.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededMinutes ||
-        response.data.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededMomentarily ||
-        response.data.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededSeconds)) {
+  if (response &&
+      (response.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededMinutes ||
+        response.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededMomentarily ||
+        response.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededSeconds)) {
     if (retries <= 0) {
       return response;
     } else {
+      return Promise.new((resolve, reject) => {
+        setTimeout(() => {
+          ourFetch()
+        }, Math.pow(2, 4 - retries) * 1000);
+      });
       return $timeout(Math.pow(2, 4 - retries) * 1000)
         .then(() => $http(response.config))
         .then((response: IHttpResponse<ServerResponse<T>>) => retryOnThrottled(response, retries - 1));
@@ -167,3 +173,4 @@ export function retryOnThrottled<T>(response: IHttpResponse<ServerResponse<T>>, 
     return response;
   }
 }
+*/

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -20,18 +20,12 @@ export function httpAdapter(config: HttpClientConfig): Promise<ServerResponse<an
       .then(handleErrors, handleErrors);
 }
 
-export function httpAdapterWithRetry(config: HttpClientConfig): Promise<ServerResponse<any>> {
-  return Promise.resolve(ourFetch(buildOptions(config)))
-      .then(handleErrors, handleErrors);
-}
-
 function buildOptions(config: HttpClientConfig): Request {
   let url = config.url;
   if (config.params) {
     url = `${url}?${stringify(config.params)}`;
   }
 
-  console.log(config);
   return new Request(
     url,
     {
@@ -78,7 +72,6 @@ export async function handleErrors<T>(response: Response): Promise<ServerRespons
     }));
   }
 
-  console.log(response);
   const data: ServerResponse<any> = await response.json();
 
   const errorCode = data ? data.ErrorCode : -1;
@@ -145,32 +138,3 @@ export async function handleErrors<T>(response: Response): Promise<ServerRespons
     throw new Error(t('BungieService.Difficulties'));
   }
 }
-
-/**
- * A response handler that can be used to retry the response if it
- * receives the specific Bungie throttling error codes.
- */
-/*
-export function retryOnThrottled<T>(response: ServerResponse<T>, retries: number = 3): Promise<ServerResponse<T>> | ServerResponse<T> {
-  // TODO: these different statuses suggest different backoffs
-  if (response &&
-      (response.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededMinutes ||
-        response.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededMomentarily ||
-        response.ErrorCode === PlatformErrorCodes.ThrottleLimitExceededSeconds)) {
-    if (retries <= 0) {
-      return response;
-    } else {
-      return Promise.new((resolve, reject) => {
-        setTimeout(() => {
-          ourFetch()
-        }, Math.pow(2, 4 - retries) * 1000);
-      });
-      return $timeout(Math.pow(2, 4 - retries) * 1000)
-        .then(() => $http(response.config))
-        .then((response: IHttpResponse<ServerResponse<T>>) => retryOnThrottled(response, retries - 1));
-    }
-  } else {
-    return response;
-  }
-}
-*/

--- a/src/app/bungie-api/rate-limiter.ts
+++ b/src/app/bungie-api/rate-limiter.ts
@@ -1,0 +1,119 @@
+
+export class RateLimiterQueue {
+  pattern: RegExp;
+  requestLimit: number;
+  timeLimit: number;
+  queue: {
+    fetcher: typeof fetch;
+    request: Request | string;
+    options?: RequestInit;
+    resolver();
+    rejecter();
+  }[] = [];
+  /** number of requests in the current period */
+  count = 0;
+  lastRequestTime = window.performance.now();
+  timer?: number;
+
+  constructor(pattern: RegExp, requestLimit: number, timeLimit: number) {
+    this.pattern = pattern;
+    this.requestLimit = requestLimit;
+    this.timeLimit = timeLimit || 1000;
+  }
+
+  matches(url: string) {
+    return url.match(this.pattern);
+  }
+
+  // Add a request to the queue, acting on it immediately if possible
+  add<T>(fetcher: typeof fetch, request: Request | string, options?: RequestInit): Promise<T> {
+    let resolver;
+    let rejecter;
+    const promise = new Promise<T>((resolve, reject) => {
+      resolver = resolve;
+      rejecter = reject;
+    });
+
+    this.queue.push({
+      fetcher,
+      request,
+      options,
+      resolver,
+      rejecter
+    });
+    this.processQueue();
+
+    return promise;
+  }
+
+  // Schedule processing the queue at the next soonest time.
+  scheduleProcessing() {
+    if (!this.timer) {
+      const nextTryIn = Math.max(0, this.timeLimit - (window.performance.now() - this.lastRequestTime));
+      this.timer = window.setTimeout(() => {
+        this.timer = undefined;
+        this.processQueue();
+      }, nextTryIn);
+    }
+  }
+
+  processQueue() {
+    while (this.queue.length) {
+      if (this.canProcess()) {
+        const config = this.queue.shift()!;
+        config.fetcher(config.request, config.options).then(config.resolver, config.rejecter);
+      } else {
+        this.scheduleProcessing();
+        return;
+      }
+    }
+  }
+
+  // Returns whether or not we can process a request right now. Mutates state.
+  canProcess() {
+    const currentRequestTime = window.performance.now();
+
+    const timeSinceLastRequest = currentRequestTime - this.lastRequestTime;
+    if (timeSinceLastRequest >= this.timeLimit) {
+      this.lastRequestTime = currentRequestTime;
+      this.count = 0;
+    }
+
+    if (this.count < this.requestLimit) {
+      this.count++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+export const RateLimiterConfig = {
+  limiters: [] as RateLimiterQueue[],
+
+  addLimiter(queue: RateLimiterQueue) {
+    this.limiters.push(queue);
+  }
+};
+
+/**
+ * Produce a version of "fetch" that respects global rate limiting rules.
+ */
+export function rateLimitedFetch(fetcher: typeof fetch): typeof fetch {
+  return (request: Request | string, options?: RequestInit) => {
+    const url = typeof request === "string" ? request : request.url;
+    let limiter;
+    for (const possibleLimiter of RateLimiterConfig.limiters) {
+      if (possibleLimiter.matches(url)) {
+        limiter = possibleLimiter;
+        break;
+      }
+    }
+
+    if (limiter) {
+      return limiter.add(fetcher, request, options);
+    } else {
+      return fetcher(request, options);
+    }
+  };
+}

--- a/src/app/compare/compare.component.ts
+++ b/src/app/compare/compare.component.ts
@@ -5,6 +5,7 @@ import { element as angularElement, IController, IComponentOptions, IScope } fro
 import { sum } from '../util';
 import { DimItem } from '../inventory/item-types';
 import { StoreServiceType } from '../inventory/store-types';
+import { CompareService } from './compare.service';
 
 export function StatRangeFilter() {
   // Turns a stat and a list of ranges into a 0-100 scale
@@ -38,7 +39,6 @@ function CompareCtrl(
   },
   $scope: IScope,
   toaster,
-  dimCompareService,
   dimStoreService: StoreServiceType,
   D2StoresService: StoreServiceType,
   $i18next
@@ -124,7 +124,7 @@ function CompareCtrl(
     });
   }
 
-  vm.show = dimCompareService.dialogOpen;
+  vm.show = CompareService.dialogOpen;
 
   vm.comparisons = [];
   vm.statRanges = {};
@@ -132,7 +132,7 @@ function CompareCtrl(
 
   $scope.$on('dim-store-item-compare', (_event, args) => {
     vm.show = true;
-    dimCompareService.dialogOpen = true;
+    CompareService.dialogOpen = true;
 
     vm.add(args);
   });
@@ -147,7 +147,7 @@ function CompareCtrl(
     vm.highlight = null;
     vm.sortedHash = null;
     vm.show = false;
-    dimCompareService.dialogOpen = false;
+    CompareService.dialogOpen = false;
   };
 
   vm.compareSimilar = (type) => {

--- a/src/app/compare/compare.module.ts
+++ b/src/app/compare/compare.module.ts
@@ -1,10 +1,8 @@
 import { module } from 'angular';
 
 import { CompareComponent, StatRangeFilter } from './compare.component';
-import { CompareService } from './compare.service';
 
 export default module('compareModule', [])
   .component('dimCompare', CompareComponent)
   .filter('statRange', StatRangeFilter)
-  .factory('dimCompareService', CompareService)
   .name;

--- a/src/app/compare/compare.service.ts
+++ b/src/app/compare/compare.service.ts
@@ -1,16 +1,12 @@
-import { IRootScopeService } from "angular";
 import { DimItem } from "../inventory/item-types";
+import { $rootScope } from 'ngimport';
 
-export function CompareService($rootScope: IRootScopeService) {
-  'ngInject';
-
-  return {
-    dialogOpen: false,
-    addItemToCompare(item: DimItem, $event) {
-      $rootScope.$broadcast('dim-store-item-compare', {
-        item,
-        clickEvent: $event
-      });
-    }
-  };
-}
+export const CompareService = {
+  dialogOpen: false,
+  addItemToCompare(item: DimItem, $event) {
+    $rootScope.$broadcast('dim-store-item-compare', {
+      item,
+      clickEvent: $event
+    });
+  }
+};

--- a/src/app/destinyTrackerApi/d2-reviewReporter.ts
+++ b/src/app/destinyTrackerApi/d2-reviewReporter.ts
@@ -1,10 +1,10 @@
 import { D2ReviewDataCache } from "./d2-reviewDataCache";
 import { DestinyAccount } from "../accounts/destiny-account.service";
 import { DtrUserReview, Reviewer, DimReviewReport } from '../item-review/destiny-tracker.service';
-import { $q, $http } from 'ngimport';
 import { UserFilter } from "./userFilter";
 import { loadingTracker } from "../ngimport-more";
 import { handleD2SubmitErrors } from "./d2-trackerErrorHandler";
+import { dtrFetch } from "./dtr-service-helper";
 
 /**
  * Class to support reporting bad takes.
@@ -24,15 +24,6 @@ class D2ReviewReporter {
     };
   }
 
-  _submitReviewReportCall(reviewReport: DimReviewReport) {
-    return {
-      method: 'POST',
-      url: 'https://db-api.destinytracker.com/api/external/reviews/report',
-      data: reviewReport,
-      dataType: 'json'
-    };
-  }
-
   _generateReviewReport(reviewId: string, membershipInfo: DestinyAccount): DimReviewReport {
     const reporter = this._getReporter(membershipInfo);
 
@@ -45,11 +36,10 @@ class D2ReviewReporter {
 
   _submitReportReviewPromise(reviewId: string, membershipInfo: DestinyAccount) {
     const reviewReport = this._generateReviewReport(reviewId, membershipInfo);
-
-    const promise = $q
-                .when(this._submitReviewReportCall(reviewReport))
-                .then($http)
-                .then(handleD2SubmitErrors, handleD2SubmitErrors);
+    const promise = dtrFetch(
+      'https://db-api.destinytracker.com/api/external/reviews/report',
+      reviewReport
+    ).then(handleD2SubmitErrors, handleD2SubmitErrors);
 
     loadingTracker.addPromise(promise);
 

--- a/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
@@ -2,10 +2,10 @@ import { D2ItemTransformer } from './d2-itemTransformer';
 import { D2ReviewDataCache } from './d2-reviewDataCache';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { Reviewer } from '../item-review/destiny-tracker.service';
-import { $q, $http } from 'ngimport';
 import { loadingTracker } from '../ngimport-more';
 import { handleD2SubmitErrors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
+import { dtrFetch } from './dtr-service-helper';
 
 export interface RatingAndReviewRequest {
   reviewer?: Reviewer;
@@ -46,15 +46,6 @@ class D2ReviewSubmitter {
     };
   }
 
-  _submitItemReviewCall(itemReview: RatingAndReviewRequest) {
-    return {
-      method: 'POST',
-      url: `https://db-api.destinytracker.com/api/external/reviews/submit`,
-      data: itemReview,
-      dataType: 'json'
-    };
-  }
-
   _submitReviewPromise(item: D2Item, membershipInfo: DestinyAccount | null) {
     const rollAndPerks = this._itemTransformer.getRollAndPerks(item);
     const reviewer = this._getReviewer(membershipInfo);
@@ -62,10 +53,10 @@ class D2ReviewSubmitter {
 
     const rating = { ...rollAndPerks, ...review, reviewer };
 
-    const promise = $q
-              .when(this._submitItemReviewCall(rating))
-              .then($http)
-              .then(handleD2SubmitErrors, handleD2SubmitErrors);
+    const promise = dtrFetch(
+      `https://db-api.destinytracker.com/api/external/reviews/submit`,
+      rating
+    ).then(handleD2SubmitErrors, handleD2SubmitErrors);
 
     loadingTracker.addPromise(promise);
 

--- a/src/app/destinyTrackerApi/d2-trackerErrorHandler.ts
+++ b/src/app/destinyTrackerApi/d2-trackerErrorHandler.ts
@@ -1,22 +1,23 @@
-import { $q } from 'ngimport';
 import { t } from 'i18next';
-import { IHttpResponse } from 'angular';
-import { DtrSubmitResponse } from '../item-review/destiny-tracker.service';
 
-export function handleD2Errors<T>(response: IHttpResponse<T>) {
+export function handleD2Errors(response: Response) {
     if (response.status !== 200) {
-      return $q.reject(new Error(t('DtrReview.ServiceCallError')));
+      throw new Error(t('DtrReview.ServiceCallError'));
     }
 
-    return response;
+    return response.json();
   }
 
-export function handleD2SubmitErrors(response: IHttpResponse<DtrSubmitResponse>) {
-  if ((response.status !== 200) ||
-      (!response.data) ||
-      (!response.data.success)) {
-    return $q.reject(new Error(t('DtrReview.ServiceSubmitError')));
+export async function handleD2SubmitErrors(response: Response) {
+  if (response.status !== 200) {
+    throw new Error(t('DtrReview.ServiceSubmitError'));
   }
 
-  return response;
+  const data = await response.json();
+
+  if (!data || !data.success) {
+    throw new Error(t('DtrReview.ServiceSubmitError'));
+  }
+
+  return data;
 }

--- a/src/app/destinyTrackerApi/dtr-service-helper.ts
+++ b/src/app/destinyTrackerApi/dtr-service-helper.ts
@@ -1,0 +1,11 @@
+export function dtrFetch(url: string, body: object) {
+  const request = new Request(url, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json'
+      },
+    });
+
+  return Promise.resolve(fetch(request));
+}

--- a/src/app/destinyTrackerApi/reviewReporter.ts
+++ b/src/app/destinyTrackerApi/reviewReporter.ts
@@ -1,10 +1,10 @@
-import { $q, $http } from 'ngimport';
 import { ReviewDataCache } from './reviewDataCache';
 import { D1ItemUserReview, D1MembershipInfo } from '../item-review/destiny-tracker.service';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { UserFilter } from './userFilter';
 import { handleSubmitErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../ngimport-more';
+import { dtrFetch } from './dtr-service-helper';
 
 /**
  * Class to support reporting bad takes.
@@ -24,15 +24,6 @@ export class ReviewReporter {
     };
   }
 
-  _submitReviewReportCall(reviewReport) {
-    return {
-      method: 'POST',
-      url: 'https://reviews-api.destinytracker.net/api/weaponChecker/reviews/report',
-      data: reviewReport,
-      dataType: 'json'
-    };
-  }
-
   _generateReviewReport(reviewId, membershipInfo: DestinyAccount) {
     const reporter = this._getReporter(membershipInfo);
 
@@ -46,10 +37,10 @@ export class ReviewReporter {
   _submitReportReviewPromise(reviewId, membershipInfo) {
     const reviewReport = this._generateReviewReport(reviewId, membershipInfo);
 
-    const promise = $q
-              .when(this._submitReviewReportCall(reviewReport))
-              .then($http)
-              .then(handleSubmitErrors, handleSubmitErrors);
+    const promise = dtrFetch(
+      'https://reviews-api.destinytracker.net/api/weaponChecker/reviews/report',
+      reviewReport
+    ).then(handleSubmitErrors, handleSubmitErrors);
 
     loadingTracker.addPromise(promise);
 

--- a/src/app/destinyTrackerApi/reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/reviewSubmitter.ts
@@ -1,10 +1,10 @@
 import { ItemTransformer } from './itemTransformer';
 import { ReviewDataCache } from './reviewDataCache';
 import { D1MembershipInfo, D1ItemUserReview } from '../item-review/destiny-tracker.service';
-import { $q, $http } from 'ngimport';
 import { handleSubmitErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../ngimport-more';
 import { D1Item } from '../inventory/item-types';
+import { dtrFetch } from './dtr-service-helper';
 
 /**
  * Supports submitting review data to the DTR API.
@@ -49,10 +49,10 @@ export class ReviewSubmitter {
 
     const rating = { ...rollAndPerks, ...review, reviewer };
 
-    const promise = $q
-              .when(this._submitItemReviewCall(rating))
-              .then($http)
-              .then(handleSubmitErrors, handleSubmitErrors);
+    const promise = dtrFetch(
+      'https://reviews-api.destinytracker.net/api/weaponChecker/reviews/submit',
+      rating
+    ).then(handleSubmitErrors, handleSubmitErrors);
 
     loadingTracker.addPromise(promise);
 

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -1,13 +1,12 @@
-import { $q, $http } from 'ngimport';
 import { ItemTransformer } from './itemTransformer';
 import { PerkRater } from './perkRater';
 import { UserFilter } from './userFilter';
 import { D1ItemReviewResponse, D1CachedItem } from '../item-review/destiny-tracker.service';
 import { ReviewDataCache } from './reviewDataCache';
-import { IPromise } from 'angular';
 import { handleErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../ngimport-more';
 import { D1Item } from '../inventory/item-types';
+import { dtrFetch } from './dtr-service-helper';
 
 /**
  * Get the community reviews from the DTR API for a specific item.
@@ -31,18 +30,17 @@ export class ReviewsFetcher {
     };
   }
 
-  _getItemReviewsPromise(item: D1Item): IPromise<D1ItemReviewResponse[]> {
+  _getItemReviewsPromise(item: D1Item): Promise<D1ItemReviewResponse[]> {
     const postWeapon = this._itemTransformer.getRollAndPerks(item);
 
-    const promise = $q
-              .when(this._getItemReviewsCall(postWeapon))
-              .then($http)
-              .then(handleErrors, handleErrors)
-              .then((response) => response.data);
+    const promise = dtrFetch(
+      'https://reviews-api.destinytracker.net/api/weaponChecker/reviews',
+      postWeapon
+    ).then(handleErrors, handleErrors);
 
     loadingTracker.addPromise(promise);
 
-    return promise as IPromise<D1ItemReviewResponse[]>;
+    return promise;
   }
 
   _getUserReview(reviewData: D1ItemReviewResponse | D1CachedItem) {

--- a/src/app/destinyTrackerApi/trackerErrorHandler.ts
+++ b/src/app/destinyTrackerApi/trackerErrorHandler.ts
@@ -1,19 +1,17 @@
-import { $q } from 'ngimport';
 import { t } from 'i18next';
-import { IHttpResponse } from 'angular';
 
-export function handleErrors<T>(response: IHttpResponse<T>) {
+export function handleErrors(response: Response) {
   if (response.status !== 200) {
-    return $q.reject(new Error(t('DtrReview.ServiceCallError')));
+    throw new Error(t('DtrReview.ServiceCallError'));
   }
 
-  return response;
+  return response.json();
 }
 
-export function handleSubmitErrors<T>(response: IHttpResponse<T>) {
+export function handleSubmitErrors(response: Response) {
   if (response.status !== 204) {
-    return $q.reject(new Error(t('DtrReview.ServiceSubmitError')));
+    throw new Error(t('DtrReview.ServiceSubmitError'));
   }
 
-  return response;
+  return response.json();
 }

--- a/src/app/dimApp.config.ts
+++ b/src/app/dimApp.config.ts
@@ -2,17 +2,11 @@ import { RateLimiterConfig, RateLimiterQueue } from "./bungie-api/rate-limiter";
 
 export default function config(
   $compileProvider,
-  $httpProvider,
   hotkeysProvider,
-  ngHttpRateLimiterConfigProvider,
   ngDialogProvider) {
   'ngInject';
 
   $compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?:|data:image\/)/);
-
-  $httpProvider.interceptors.push('ngHttpRateLimiterInterceptor');
-  $httpProvider.interceptors.push('http-refresh-token');
-  $httpProvider.useApplyAsync(true);
 
   hotkeysProvider.includeCheatSheet = true;
 
@@ -24,11 +18,6 @@ export default function config(
   // by making responses take 2s to return, not by sending an error code or throttling response. Choosing
   // our throttling limit to be 1 request every 1100ms lets us achieve best throughput while accounting for
   // what I assume is clock skew between Bungie's hosts when they calculate a global rate limit.
-  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 1100);
-  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100);
-  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 1, 100);
-  ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100);
-
   RateLimiterConfig.addLimiter(new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 1100));
   RateLimiterConfig.addLimiter(new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100));
   RateLimiterConfig.addLimiter(new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 1, 100));

--- a/src/app/dimApp.config.ts
+++ b/src/app/dimApp.config.ts
@@ -1,3 +1,5 @@
+import { RateLimiterConfig, RateLimiterQueue } from "./bungie-api/rate-limiter";
+
 export default function config(
   $compileProvider,
   $httpProvider,
@@ -26,6 +28,11 @@ export default function config(
   ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100);
   ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 1, 100);
   ngHttpRateLimiterConfigProvider.addLimiter(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100);
+
+  RateLimiterConfig.addLimiter(new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 1100));
+  RateLimiterConfig.addLimiter(new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100));
+  RateLimiterConfig.addLimiter(new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 1, 100));
+  RateLimiterConfig.addLimiter(new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100));
 
   // https://github.com/likeastore/ngDialog/issues/327
   ngDialogProvider.setDefaults({

--- a/src/app/dimApp.module.ts
+++ b/src/app/dimApp.module.ts
@@ -8,7 +8,6 @@ import ngSanitize from 'angular-sanitize';
 import MessagesModule from 'angular-messages';
 import TouchModule from 'angular-touch';
 
-import RateLimiterModule from 'ng-http-rate-limiter';
 import 'angularjs-slider';
 import ToasterModule from 'angularjs-toaster';
 import UIRouterModule from '@uirouter/angularjs';
@@ -47,7 +46,6 @@ const dependencies = [
   ngI18Next,
   ocLazyLoadModule,
   ngSanitize,
-  RateLimiterModule,
   ShellModule,
   'rzModule',
   ToasterModule,

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -2,10 +2,10 @@ import { DestinyAccount } from "../accounts/destiny-account.service";
 import { AwaType, AwaAuthorizationResult, AwaUserSelection, insertSocketPlug, DestinySocketArrayType } from "bungie-api-ts/destiny2";
 import { requestAdvancedWriteActionToken } from "../bungie-api/destiny2-api";
 import * as idbKeyval from 'idb-keyval';
-import { httpAdapterWithRetry } from "../bungie-api/bungie-service-helper";
 import { toaster } from '../ngimport-more';
 import { t } from 'i18next';
 import { DimSocket, D2Item } from "./item-types";
+import { httpAdapter } from "../bungie-api/bungie-service-helper";
 
 let awaCache: {
   [key: number]: AwaAuthorizationResult & { used: number };
@@ -18,7 +18,7 @@ export async function insertPlug(account: DestinyAccount, item: D2Item, socket: 
 
   // TODO: if the plug costs resources to insert, add a confirmation
 
-  return insertSocketPlug(httpAdapterWithRetry, {
+  return insertSocketPlug(httpAdapter, {
     actionToken,
     itemInstanceId: item.id,
     plug: {

--- a/src/app/inventory/dimStoreItem.directive.ts
+++ b/src/app/inventory/dimStoreItem.directive.ts
@@ -8,6 +8,7 @@ import { IComponentOptions, IController, IScope, IRootElementService, IRootScope
 import { LoadoutServiceType } from '../loadout/loadout.service';
 import { DimItem } from './item-types';
 import { StoreServiceType } from './store-types';
+import { CompareService } from '../compare/compare.service';
 
 export function tagIconFilter() {
   'ngInject';
@@ -54,7 +55,6 @@ export function StoreItemCtrl(
   D2StoresService: StoreServiceType,
   ngDialog,
   dimLoadoutService: LoadoutServiceType,
-  dimCompareService,
   $rootScope: IRootScopeService & { dragItem: DimItem }
 ) {
   "ngInject";
@@ -138,7 +138,7 @@ export function StoreItemCtrl(
   };
 
   vm.doubleClicked = queuedAction((item, e) => {
-    if (!dimLoadoutService.dialogOpen && !dimCompareService.dialogOpen) {
+    if (!dimLoadoutService.dialogOpen && !CompareService.dialogOpen) {
       e.stopPropagation();
       const active = getStoreService(item).getActiveStore()!;
 
@@ -178,8 +178,8 @@ export function StoreItemCtrl(
       }
     } else if (dimLoadoutService.dialogOpen) {
       dimLoadoutService.addItemToLoadout(item, e);
-    } else if (dimCompareService.dialogOpen) {
-      dimCompareService.addItemToCompare(item, e);
+    } else if (CompareService.dialogOpen) {
+      CompareService.addItemToCompare(item, e);
     } else {
       dialogResult = ngDialog.open({
         template: dialogTemplate,

--- a/src/app/loadout/loadout-popup.component.ts
+++ b/src/app/loadout/loadout-popup.component.ts
@@ -18,6 +18,7 @@ import { getBuckets as d2GetBuckets } from '../destiny2/d2-buckets.service';
 import { getBuckets as d1GetBuckets } from '../destiny1/d1-buckets.service';
 import { ItemServiceType } from '../inventory/dimItemService.factory';
 import { DimStore, StoreServiceType } from '../inventory/store-types';
+import { SearchService } from '../search/search-filter.component';
 
 export const LoadoutPopupComponent: IComponentOptions = {
   controller: LoadoutPopupCtrl,
@@ -65,7 +66,6 @@ function LoadoutPopupCtrl(
   dimFarmingService,
   D2FarmingService,
   $window,
-  dimSearchService,
   $i18next,
   dimStoreService: StoreServiceType,
   D2StoresService: StoreServiceType,
@@ -103,7 +103,7 @@ function LoadoutPopupCtrl(
     vm.maxLightValue = dimLoadoutService.getLight(vm.store, maxLightLoadout(getStoreService(), vm.store)) + (vm.hasClassified ? '*' : '');
   };
 
-  vm.search = dimSearchService;
+  vm.search = SearchService;
 
   function initLoadouts() {
     dimLoadoutService.getLoadouts()

--- a/src/app/move-popup/dimMoveItemProperties.directive.ts
+++ b/src/app/move-popup/dimMoveItemProperties.directive.ts
@@ -197,7 +197,7 @@ function MoveItemPropertiesCtrl(
       state = !item.tracked;
     }
 
-    if (item.destinyVersion === 2) {
+    if (item.isDestiny2()) {
       d2SetLockState(store, item, state)
         .then(() => {
           item.locked = state;
@@ -206,7 +206,7 @@ function MoveItemPropertiesCtrl(
         .finally(() => {
           vm.locking = false;
         });
-    } else {
+    } else if (item.isDestiny1()) {
       d1SetItemState(item, store, state, type)
         .then(() => {
           if (type === 'lock') {

--- a/src/app/oauth/http-refresh-token.service.ts
+++ b/src/app/oauth/http-refresh-token.service.ts
@@ -1,13 +1,64 @@
 import { getAccessTokenFromRefreshToken } from './oauth.service';
 import { Tokens, removeToken, setToken, getToken, hasTokenExpired } from './oauth-token.service';
-import { PlatformErrorCodes } from 'bungie-api-ts/user';
+import { PlatformErrorCodes, ServerResponse } from 'bungie-api-ts/user';
 import { IRequestConfig, IHttpResponse } from 'angular';
+import { $rootScope } from 'ngimport';
 
 declare module 'angular' {
   interface IRequestConfig {
     /** Track whether we've tried refreshing access tokens */
     triedRefresh?: boolean;
   }
+}
+
+let cache: Promise<Tokens> | null = null;
+const matcher = /www\.bungie\.net\/(D1\/)?Platform\/(User|Destiny|Destiny2)\//;
+
+export async function fetchWithBungieOAuth(request: Request | string, options?: RequestInit, triedRefresh = false): Promise<Response> {
+  if (typeof request === "string") {
+    request = new Request(request);
+  }
+
+  if (request.url.match(matcher) && !request.headers.has('Authorization')) {
+    try {
+      const token = await getActiveToken();
+      request.headers.set('Authorization', `Bearer ${token.accessToken.value}`);
+    } catch (e) {
+      if (e instanceof FatalTokenError) {
+        console.warn("Unable to get auth token, clearing auth tokens & going to login: ", e);
+        removeToken();
+        $rootScope.$broadcast('dim-no-token-found');
+      }
+      throw e;
+    }
+
+    return fetch(request, options).then(async(response) => {
+      const data = await response.json();
+      if (responseIndicatesBadToken(response, data)) {
+        if (triedRefresh) {
+          throw new Error("Access token expired, and we've already tried to refresh. Failing.");
+        }
+        // OK, Bungie has told us our access token is expired or
+        // invalid. Refresh it and try again.
+        console.log(`Access token expired (code ${data.ErrorCode}), removing tokens and trying again`);
+        removeToken();
+        return fetchWithBungieOAuth(request, options, true);
+      }
+
+      return response;
+    });
+  }
+
+  return fetch(request, options);
+}
+
+function responseIndicatesBadToken(response: Response | IHttpResponse<any>, data: ServerResponse<any>) {
+  return response.status === 401 ||
+    (data &&
+      (data.ErrorCode === PlatformErrorCodes.AccessTokenHasExpired ||
+      data.ErrorCode === PlatformErrorCodes.WebAuthRequired ||
+      // (also means the access token has expired)
+      data.ErrorCode === PlatformErrorCodes.WebAuthModuleAsyncFailed));
 }
 
 /**
@@ -17,91 +68,29 @@ declare module 'angular' {
 export function HttpRefreshTokenService($rootScope, $injector) {
   'ngInject';
 
-  let cache: Promise<Tokens> | null = null;
-  const matcher = /www\.bungie\.net\/(D1\/)?Platform\/(User|Destiny|Destiny2)\//;
-
   return {
     request: requestHandler,
     response: responseHandler
   };
 
-  function requestHandler(config: IRequestConfig) {
-    config.headers = config.headers || {};
+  async function requestHandler(request: IRequestConfig) {
+    request.headers = request.headers || {};
 
-    if (config.url.match(matcher) &&
-        !config.headers.hasOwnProperty('Authorization')) {
-      const token = getToken();
-      if (token) {
-        const accessTokenIsValid = token && isTokenValid(token.accessToken);
-
-        if (accessTokenIsValid) {
-          config.headers.Authorization = `Bearer ${token.accessToken.value}`;
-        } else {
-          const refreshTokenIsValid = token && isTokenValid(token.refreshToken);
-
-          if (refreshTokenIsValid) {
-            cache = cache || getAccessTokenFromRefreshToken(token.refreshToken);
-
-            return cache
-              .then((token) => {
-                setToken(token);
-
-                console.log("Successfully updated auth token from refresh token.");
-                config.headers!.Authorization = `Bearer ${token.accessToken.value}`;
-                return config;
-              })
-              .catch(handleRefreshTokenError)
-              .finally(() => {
-                cache = null;
-              });
-          } else {
-            console.warn("Refresh token invalid, clearing auth tokens & going to login");
-            removeToken();
-            $rootScope.$broadcast('dim-no-token-found');
-            // TODO: throw error?
-          }
-        }
-      } else {
-        console.warn("No auth token exists, redirect to login");
-        removeToken();
-        $rootScope.$broadcast('dim-no-token-found');
-        // TODO: throw error?
-      }
-    }
-
-    return config;
-  }
-
-  function handleRefreshTokenError(response: IHttpResponse<any>) {
-    if (response.status === -1) {
-      console.warn("Error getting auth token from refresh token because there's no internet connection. Not clearing token.", response);
-    } else if (response.status === 400 || response.status === 401 || response.status === 403) {
-      console.warn("Refresh token expired or not valid, clearing auth tokens & going to login", response);
-      removeToken();
-      $rootScope.$broadcast('dim-no-token-found');
-    } else if (response.data && response.data.ErrorCode) {
-      switch (response.data.ErrorCode) {
-        case PlatformErrorCodes.RefreshTokenNotYetValid:
-        case PlatformErrorCodes.AccessTokenHasExpired:
-        case PlatformErrorCodes.AuthorizationCodeInvalid:
-          console.warn("Refresh token expired or not valid, clearing auth tokens & going to login", response);
+    if (request.url.match(matcher) && !request.headers.hasOwnPropetry('Authorization')) {
+      try {
+        const token = await getActiveToken();
+        request.headers!.Authorization = `Bearer ${token.accessToken.value}`;
+      } catch (e) {
+        if (e instanceof FatalTokenError) {
+          console.warn("Unable to get auth token, clearing auth tokens & going to login: ", e);
           removeToken();
           $rootScope.$broadcast('dim-no-token-found');
-          break;
+        }
+        throw e;
       }
-    } else {
-      console.warn("Other error getting auth token from refresh token. Not clearing auth tokens", response);
     }
-    throw response;
-  }
 
-  function isTokenValid(token) {
-    // reject refresh tokens from the old auth process
-    if (token && token.name === 'refresh' && token.readyin) {
-      return false;
-    }
-    const expired = hasTokenExpired(token);
-    return !expired;
+    return request;
   }
 
   /**
@@ -110,40 +99,102 @@ export function HttpRefreshTokenService($rootScope, $injector) {
    */
   function responseHandler(response: IHttpResponse<any>) {
     if (response.config.url.match(matcher) &&
-        !response.config.triedRefresh && // Only try once, to avoid infinite loop
-        (response.status === 401 ||
-         (response.data &&
-          (response.data.ErrorCode === PlatformErrorCodes.AccessTokenHasExpired ||
-           response.data.ErrorCode === PlatformErrorCodes.WebAuthRequired ||
-           response.data.ErrorCode === PlatformErrorCodes.WebAuthModuleAsyncFailed)))) { // (also means the access token has expired)
+        responseIndicatesBadToken(response, response.data)) {
+      // Only try once, to avoid infinite loop
+      if (response.config.triedRefresh) {
+        throw new Error("Access token expired, and we've already tried to refresh. Failing.");
+      }
       // OK, Bungie has told us our access token is expired or
       // invalid. Refresh it and try again.
-      console.log(`Access token expired (code ${response.data.ErrorCode}), refreshing`);
-      const token = getToken();
-      const refreshTokenIsValid = token && isTokenValid(token.refreshToken);
-
-      if (token && refreshTokenIsValid) {
-        response.config.triedRefresh = true;
-        cache = cache || getAccessTokenFromRefreshToken(token.refreshToken);
-        return cache
-          .then((token) => {
-            setToken(token);
-
-            console.log("Successfully updated auth token from refresh token after failed request.");
-            response.config.headers!.Authorization = `Bearer ${token.accessToken.value}`;
-            return $injector.get('$http')(response.config);
-          })
-          .catch(handleRefreshTokenError)
-          .finally(() => {
-            cache = null;
-          });
-      } else {
-        console.warn("Refresh token invalid, clearing auth tokens & going to login");
-        removeToken();
-        $rootScope.$broadcast('dim-no-token-found');
-      }
+      console.log(`Access token expired (code ${response.data.ErrorCode}), removing tokens and trying again`);
+      removeToken();
+      response.config.triedRefresh = true;
+      return $injector.get('$http')(response.config);
     }
 
     return response;
   }
+}
+
+function isTokenValid(token) {
+  // reject refresh tokens from the old auth process
+  if (token && token.name === 'refresh' && token.readyin) {
+    return false;
+  }
+  const expired = hasTokenExpired(token);
+  return !expired;
+}
+
+/**
+ * A fatal token error means we have to log in again.
+ */
+class FatalTokenError extends Error {}
+
+async function getActiveToken(): Promise<Tokens> {
+  let token = getToken();
+  if (!token) {
+    removeToken();
+    $rootScope.$broadcast('dim-no-token-found');
+    throw new FatalTokenError("No auth token exists, redirect to login");
+  }
+
+  const accessTokenIsValid = token && isTokenValid(token.accessToken);
+  if (accessTokenIsValid) {
+    return token;
+  }
+
+  // Get a new token from refresh token
+  const refreshTokenIsValid = token && isTokenValid(token.refreshToken);
+  if (!refreshTokenIsValid) {
+    removeToken();
+    $rootScope.$broadcast('dim-no-token-found');
+    throw new FatalTokenError("Refresh token invalid, clearing auth tokens & going to login");
+  }
+
+  try {
+    token = await (cache || getAccessTokenFromRefreshToken(token.refreshToken!));
+    setToken(token);
+    console.log("Successfully updated auth token from refresh token.");
+    return token;
+  } catch (e) {
+    return handleRefreshTokenError(e);
+  } finally {
+    cache = null;
+  }
+}
+
+async function handleRefreshTokenError(response: Error | Response): Promise<Tokens> {
+  if (response instanceof TypeError) {
+    console.warn("Error getting auth token from refresh token because there's no internet connection (or a permissions issue). Not clearing token.", response);
+    throw response;
+  }
+  if (response instanceof Error) {
+    console.warn("Other error getting auth token from refresh token. Not clearing auth tokens", response);
+    throw response;
+  }
+  switch (response.status) {
+    case -1:
+      throw new Error("Error getting auth token from refresh token because there's no internet connection. Not clearing token.");
+    case 400:
+    case 401:
+    case 403: {
+      throw new FatalTokenError("Refresh token expired or not valid");
+    }
+    default: {
+      try {
+        const data = await response.json();
+        if (data && data.ErrorCode) {
+          switch (data.ErrorCode) {
+            case PlatformErrorCodes.RefreshTokenNotYetValid:
+            case PlatformErrorCodes.AccessTokenHasExpired:
+            case PlatformErrorCodes.AuthorizationCodeInvalid:
+              throw new FatalTokenError("Refresh token expired or not valid");
+          }
+        }
+      } catch (e) {
+        throw new Error("Error response wasn't json: " + response);
+      }
+    }
+  }
+  throw new Error("Unknown error getting response token: " + response);
 }

--- a/src/app/oauth/oauth.module.ts
+++ b/src/app/oauth/oauth.module.ts
@@ -1,8 +1,6 @@
 import { module } from 'angular';
-import { HttpRefreshTokenService } from './http-refresh-token.service';
 
 export default module('dim-oauth', [])
-  .service('http-refresh-token', HttpRefreshTokenService)
   .run(($rootScope, $state) => {
     'ngInject';
     $rootScope.$on('dim-no-token-found', () => {

--- a/src/app/oauth/oauth.service.ts
+++ b/src/app/oauth/oauth.service.ts
@@ -6,7 +6,7 @@ const TOKEN_URL = 'https://www.bungie.net/platform/app/oauth/token/';
 
 // https://www.bungie.net/en/Clan/Post/1777779/227330965/0/0
 
-export function getAccessTokenFromRefreshToken(refreshToken) {
+export function getAccessTokenFromRefreshToken(refreshToken: Token): Promise<Tokens> {
   // https://github.com/zloirock/core-js/issues/178#issuecomment-192081350
   return Promise.resolve(fetch(TOKEN_URL, {
     method: 'POST',
@@ -24,7 +24,7 @@ export function getAccessTokenFromRefreshToken(refreshToken) {
     .then(handleAccessToken));
 }
 
-export function getAccessTokenFromCode(code) {
+export function getAccessTokenFromCode(code: number): Promise<Tokens> {
   return Promise.resolve(fetch(TOKEN_URL, {
     method: 'POST',
     body: stringify({
@@ -68,6 +68,6 @@ function handleAccessToken(response): Tokens {
 
     return tokens;
   } else {
-    throw response;
+    throw new Error("No data or access token in response: " + JSON.stringify(response));
   }
 }

--- a/src/app/search/filter-link.component.ts
+++ b/src/app/search/filter-link.component.ts
@@ -1,5 +1,6 @@
 import template from './filter-link.html';
 import { IController, IWindowService, IComponentOptions } from 'angular';
+import { SearchService } from './search-filter.component';
 
 /**
  * Link to a specific filter in search. Clicking adds this term to the search.
@@ -13,7 +14,7 @@ export const FilterLinkComponent: IComponentOptions = {
   }
 };
 
-function FilterLinkCtrl(this: IController, dimSearchService, $window: IWindowService, $i18next) {
+function FilterLinkCtrl(this: IController, $window: IWindowService, $i18next) {
   'ngInject';
 
   this.addFilter = (filter: string) => {
@@ -63,12 +64,12 @@ function FilterLinkCtrl(this: IController, dimSearchService, $window: IWindowSer
       }
     }
 
-    const text = dimSearchService.query;
+    const text = SearchService.query;
 
     if (itemNameFilter) {
-      dimSearchService.query = filter + (text.length ? ` ${text}` : '');
+      SearchService.query = filter + (text.length ? ` ${text}` : '');
     } else if ((`${text} `).indexOf(`${filter} `) < 0) {
-      dimSearchService.query = (text.length > 0) ? `${text} ${filter}` : filter;
+      SearchService.query = (text.length > 0) ? `${text} ${filter}` : filter;
     }
   };
 }

--- a/src/app/search/search-filter.component.ts
+++ b/src/app/search/search-filter.component.ts
@@ -14,6 +14,13 @@ import { DestinyAccount } from '../accounts/destiny-account.service';
 import { StoreServiceType } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
 
+/**
+ * A simple holder to share the search query among components
+ */
+export const SearchService = {
+  query: ''
+};
+
 export const SearchFilterComponent: IComponentOptions = {
   controller: SearchFilterCtrl,
   bindings: {
@@ -29,7 +36,6 @@ function SearchFilterCtrl(
   $scope: IScope,
   dimStoreService: StoreServiceType,
   D2StoresService: StoreServiceType,
-  dimSearchService,
   hotkeys,
   $i18next,
   $element: IRootElementService,
@@ -40,7 +46,7 @@ function SearchFilterCtrl(
 ) {
   'ngInject';
   const vm = this;
-  vm.search = dimSearchService;
+  vm.search = SearchService;
   vm.bulkItemTags = _.clone(itemTags);
   vm.bulkItemTags.push({ type: 'clear', label: 'Tags.ClearTag' });
 

--- a/src/app/search/search.module.ts
+++ b/src/app/search/search.module.ts
@@ -3,13 +3,7 @@ import { module } from 'angular';
 import { SearchFilterComponent } from './search-filter.component';
 import { FilterLinkComponent } from './filter-link.component';
 
-// a simple service to share the search query among components
-function SearchService() {
-  return { query: '' };
-}
-
 export default module('searchModule', [])
   .component('dimSearchFilter', SearchFilterComponent)
   .component('dimFilterLink', FilterLinkComponent)
-  .service('dimSearchService', SearchService)
   .name;

--- a/src/app/shell/activity-tracker/activity-tracker.directive.ts
+++ b/src/app/shell/activity-tracker/activity-tracker.directive.ts
@@ -2,10 +2,11 @@ import * as _ from 'underscore';
 import { IRootScopeService, ITimeoutService, IDirective } from 'angular';
 import { ActivityTrackerService } from './activity-tracker.service';
 
+const dimActivityTrackerService = new ActivityTrackerService();
+
 export function ActivityTrackerDirective(
   $document,
   $timeout: ITimeoutService,
-  dimActivityTrackerService: ActivityTrackerService,
   loadingTracker,
   $rootScope: IRootScopeService
 ): IDirective {

--- a/src/app/shell/shell.module.ts
+++ b/src/app/shell/shell.module.ts
@@ -2,7 +2,7 @@ import { module } from 'angular';
 
 import UIRouterModule from '@uirouter/angularjs';
 
-import { ActivityTrackerDirective, ActivityTrackerService } from './activity-tracker';
+import { ActivityTrackerDirective } from './activity-tracker';
 import { CountdownComponent } from './countdown.component';
 import { StarRatingComponent } from './star-rating/star-rating.component';
 import { ScrollClass } from './scroll-class.directive';
@@ -25,7 +25,6 @@ export const ShellModule = module('dimShell', [
     dimAngularFiltersModule
   ])
   .directive('dimActivityTracker', ActivityTrackerDirective)
-  .service('dimActivityTrackerService', ActivityTrackerService)
   .factory('loadingTracker', loadingTracker)
   .component('countdown', CountdownComponent)
   .component('starRating', StarRatingComponent)

--- a/src/app/vendors/vendor.service.ts
+++ b/src/app/vendors/vendor.service.ts
@@ -378,7 +378,7 @@ export function VendorService(
     const vendorHash = vendorDef.hash;
 
     const key = vendorKey(store, vendorHash);
-    return $q.when(idbKeyval.get<Vendor>(key))
+    return idbKeyval.get<Vendor>(key)
       .then((vendor) => {
         if (cachedVendorUpToDate(vendor, store, vendorDef)) {
           // console.log("loaded local", vendorDef.summary.vendorName, key, vendor);
@@ -393,7 +393,7 @@ export function VendorService(
               vendor.expires = calculateExpiration(vendor.nextRefreshDate, vendorHash);
               vendor.factionLevel = factionLevel(store, vendorDef.summary.factionHash);
               vendor.factionAligned = factionAligned(store, vendorDef.summary.factionHash);
-              return $q.when(idbKeyval.set(key, vendor))
+              return idbKeyval.set(key, vendor)
                 .then(() => vendor);
             })
             .catch((e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4937,10 +4937,6 @@ ng-dialog@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ng-dialog/-/ng-dialog-1.4.0.tgz#3f81330e7caac614e99fbceb76f304bf820c413e"
 
-ng-http-rate-limiter@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ng-http-rate-limiter/-/ng-http-rate-limiter-1.0.4.tgz#1b698dbc9f98715bc84e5d20e433370df2584dcd"
-
 ng-i18next@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/ng-i18next/-/ng-i18next-1.0.5.tgz#fa3e924bb50f81e51c71ec3cd5bd84c0e7a9b013"


### PR DESCRIPTION
This is a major step in disentangling from AngularJS. After this change, we no longer use their HTTP service - all HTTP calls are made through the fetch API.

This has a number of benefits:

1. Removes a major point of coupling between us and AngularJS.
2. AngularJS' $http service integrated with its $q promise service. As a result, there were some perf issues:
  a. Digest was fired for each response, whether we had new data or not.
  b. Digest was fired for many Promise handlers, whether we had new data or not.
3. By getting away from `$q` promises towards native promises, we can use `async`/`await` correctly in more places.
1. It has the potential to be faster for some types of responses, and it appears to actually be faster in downloading the manifest.

To do this, I had to:

1. Reimplement our rate limiter in terms of a composable `fetch` method.
2. Reimplement our Bungie OAuth handling in terms of promises and `fetch`.

The main type of bug I can imagine happening after this will be that things don't update correctly in the Angular world due to missing digests. We can patch those up closer to where the data is used.