### PR TITLE
Fix being unable to move stackables when the postmaster contains a stackable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Fix a bug where having mods, shaders, or materials in the postmaster might make it impossible to move any mod/shader/material into or out of the vault.
+
 # 4.50.0 (2018-04-30)
 
 * The settings page now shows how much of your local storage quota is being used by DIM (if your browser supports it).

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -459,20 +459,21 @@ export function ItemService(
     // Find any stackable that could be combined with another stack
     // on a different store to form a single stack
     if (item.maxStackSize > 1) {
-      let otherStore;
+      let otherStore: DimStore | undefined;
       const stackable = moveAsideCandidates.find((i) => {
         if (i.maxStackSize > 1) {
           // Find another store that has an appropriate stackable
-          otherStore = otherStores.find(
-            (otherStore) => otherStore.items.some((otherItem) =>
+          otherStore = otherStores.find((s) =>
+            s.items.some((otherItem) =>
               // Same basic item
               otherItem.hash === i.hash &&
-                                  // Enough space to absorb this stack
-                                  (i.maxStackSize - otherItem.amount) >= i.amount));
+              !otherItem.location.inPostmaster &&
+              // Enough space to absorb this stack
+              (i.maxStackSize - otherItem.amount) >= i.amount));
         }
-        return otherStore;
+        return Boolean(otherStore);
       });
-      if (stackable) {
+      if (stackable && otherStore) {
         return {
           item: stackable,
           target: otherStore


### PR DESCRIPTION
This fixes an annoying bug where you can no longer move a stackable item (mods, shaders, etc) if any stackable item of that category exists in the postmaster.