### PR TITLE
Convert stateless classes to modules in DTR code

### DIFF
--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -10,9 +10,9 @@ import dialogTemplate from './vendor-item-dialog.html';
 import { getBuckets } from "../destiny2/d2-buckets.service";
 import { DestinyTrackerServiceType, DimWorkingUserReview } from "../item-review/destiny-tracker.service";
 import { dtrRatingColor } from "../shell/dimAngularFilters.filter";
-import { D2PerkRater } from "../destinyTrackerApi/d2-perkRater";
 import checkMark from '../../images/check.svg';
 import { D2Item } from "../inventory/item-types";
+import { ratePerks } from "../destinyTrackerApi/d2-perkRater";
 
 interface Props {
   defs: D2ManifestDefinitions;
@@ -117,7 +117,7 @@ export default class VendorItemComponent extends React.Component<Props> {
             Object.assign(reviewData, reviewsData);
             // TODO: it'd be nice to push this into tracker service
             Object.assign(dimItem, item.toDimItem(buckets, reviewData));
-            new D2PerkRater().ratePerks(dimItem!);
+            ratePerks(dimItem!);
             dimItem!.reviewsUpdated = Date.now();
           });
         }

--- a/src/app/destinyTrackerApi/bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/bulkFetcher.ts
@@ -1,13 +1,12 @@
-import { ItemListBuilder } from './itemListBuilder';
 import { ReviewDataCache } from './reviewDataCache';
 import { D1ItemFetchResponse } from '../item-review/destiny-tracker.service';
 import { handleErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../ngimport-more';
 import { dtrFetch } from './dtr-service-helper';
+import { getWeaponList } from './itemListBuilder';
 
 class BulkFetcher {
   _reviewDataCache: ReviewDataCache;
-  _itemListBuilder = new ItemListBuilder();
   constructor(reviewDataCache) {
     this._reviewDataCache = reviewDataCache;
   }
@@ -17,7 +16,7 @@ class BulkFetcher {
       return Promise.resolve<D1ItemFetchResponse[]>([]);
     }
 
-    const weaponList = this._itemListBuilder.getWeaponList(stores, this._reviewDataCache);
+    const weaponList = getWeaponList(stores, this._reviewDataCache);
 
     if (!weaponList.length) {
       return Promise.resolve<D1ItemFetchResponse[]>([]);

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -1,4 +1,3 @@
-import { D2ItemListBuilder } from './d2-itemListBuilder';
 import { DtrBulkItem, DtrItem } from '../item-review/destiny-tracker.service';
 import { D2ReviewDataCache } from './d2-reviewDataCache';
 import { DestinyVendorSaleItemComponent, DestinyVendorItemDefinition } from 'bungie-api-ts/destiny2';
@@ -6,10 +5,10 @@ import { loadingTracker } from '../ngimport-more';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Store } from '../inventory/store-types';
 import { dtrFetch } from './dtr-service-helper';
+import { getItemList, getVendorItemList } from './d2-itemListBuilder';
 
 class D2BulkFetcher {
   _reviewDataCache: D2ReviewDataCache;
-  _itemListBuilder = new D2ItemListBuilder();
 
   constructor(reviewDataCache) {
     this._reviewDataCache = reviewDataCache;
@@ -20,7 +19,7 @@ class D2BulkFetcher {
       return Promise.resolve<DtrBulkItem[]>([]);
     }
 
-    const itemList = this._itemListBuilder.getItemList(stores, this._reviewDataCache);
+    const itemList = getItemList(stores, this._reviewDataCache);
     return this._getBulkItems(itemList, platformSelection, mode);
   }
 
@@ -32,7 +31,7 @@ class D2BulkFetcher {
       return Promise.resolve<DtrBulkItem[]>([]);
     }
 
-    const vendorDtrItems = this._itemListBuilder.getVendorItemList(this._reviewDataCache, vendorSaleItems, vendorItems);
+    const vendorDtrItems = getVendorItemList(this._reviewDataCache, vendorSaleItems, vendorItems);
     return this._getBulkItems(vendorDtrItems, platformSelection, mode);
   }
 

--- a/src/app/destinyTrackerApi/d2-itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/d2-itemListBuilder.ts
@@ -1,11 +1,11 @@
 import { flatMap } from '../util';
 import * as _ from 'underscore';
 import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
-import { D2ItemTransformer } from './d2-itemTransformer';
 import { DtrItem } from '../item-review/destiny-tracker.service';
 import { DestinyVendorSaleItemComponent, DestinyVendorItemDefinition } from 'bungie-api-ts/destiny2';
 import { D2Item } from '../inventory/item-types';
 import { D2Store } from '../inventory/store-types';
+import { translateToDtrItem } from './d2-itemTransformer';
 
 /**
  * Translates collections of DIM items into a collection of data almost ready to ship to the DTR API.
@@ -13,14 +13,8 @@ import { D2Store } from '../inventory/store-types';
  * Also tailored for the D2 version.
  */
 class D2ItemListBuilder {
-  _itemTransformer: D2ItemTransformer;
-
-  constructor() {
-    this._itemTransformer = new D2ItemTransformer();
-  }
-
   _getNewItems(allItems: D2Item[], reviewDataCache: D2ReviewDataCache) {
-    const allDtrItems = allItems.map((item) => this._itemTransformer.translateToDtrItem(item));
+    const allDtrItems = allItems.map(translateToDtrItem);
     const allKnownDtrItems = reviewDataCache.getItemStores();
 
     const unmatched = allDtrItems.filter((di) => allKnownDtrItems.every((kdi) => di.referenceId !== kdi.referenceId));
@@ -60,7 +54,7 @@ class D2ItemListBuilder {
       return newItems;
     }
 
-    return allReviewableItems.map((item) => this._itemTransformer.translateToDtrItem(item));
+    return allReviewableItems.map(translateToDtrItem);
   }
 
   /**

--- a/src/app/destinyTrackerApi/d2-itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/d2-itemListBuilder.ts
@@ -8,83 +8,76 @@ import { D2Store } from '../inventory/store-types';
 import { translateToDtrItem } from './d2-itemTransformer';
 
 /**
- * Translates collections of DIM items into a collection of data almost ready to ship to the DTR API.
- * Generally tailored to work with weapon data.
- * Also tailored for the D2 version.
+ * Translate the universe of items that the user has in their stores into a collection of data that we can send the DTR API.
+ * Tailored to work alongside the bulkFetcher.
+ * Non-obvious bit: it attempts to optimize away from sending items that already exist in the ReviewDataCache.
  */
-class D2ItemListBuilder {
-  _getNewItems(allItems: D2Item[], reviewDataCache: D2ReviewDataCache) {
-    const allDtrItems = allItems.map(translateToDtrItem);
-    const allKnownDtrItems = reviewDataCache.getItemStores();
+export function getItemList(stores: D2Store[], reviewDataCache: D2ReviewDataCache): DtrItem[] {
+  const dtrItems = getDtrItems(stores, reviewDataCache);
 
-    const unmatched = allDtrItems.filter((di) => allKnownDtrItems.every((kdi) => di.referenceId !== kdi.referenceId));
+  const list = new Set(dtrItems);
 
-    return unmatched;
-  }
+  return Array.from(list);
+}
 
-  _getNewVendorItems(vendorItems: DtrItem[], reviewDataCache: D2ReviewDataCache) {
-    const allKnownDtrItems = reviewDataCache.getItemStores();
+export function getVendorItemList(
+  reviewDataCache: D2ReviewDataCache,
+  vendorSaleItems?: DestinyVendorSaleItemComponent[],
+  vendorItems?: DestinyVendorItemDefinition[]
+): DtrItem[] {
+  if (vendorSaleItems) {
+    const allVendorItems = vendorSaleItems.map((vendorItem): DtrItem => ({ referenceId: vendorItem.itemHash }));
 
-    const unmatched = vendorItems.filter((vi) => allKnownDtrItems.every((di) => di.referenceId !== vi.referenceId));
+    return getNewVendorItems(allVendorItems, reviewDataCache);
+  } else if (vendorItems) {
+    const allVendorItems = vendorItems.map((vi) => ({ referenceId: vi.itemHash })) as DtrItem[];
 
-    return unmatched;
-  }
-
-  /**
-   * In D1, extracting all of the items from all of the stores was a little different from
-   * extracting all of the vendor items. If the interface is the same for both, this can go
-   * away.
-   */
-  _getAllItems(stores: D2Store[]): D2Item[] {
-    return flatMap(stores, (store) => store.items);
-  }
-
-  // Get all of the weapons from our stores in a DTR API-friendly format.
-  _getDtrItems(stores: D2Store[], reviewDataCache: D2ReviewDataCache): DtrItem[] {
-    const allItems = this._getAllItems(stores);
-
-    const allReviewableItems = _.filter(allItems,
-                        (item) => {
-                          return (item.reviewable);
-                        });
-
-    const newItems = this._getNewItems(allReviewableItems, reviewDataCache);
-
-    if (reviewDataCache.getItemStores().length > 0) {
-      return newItems;
-    }
-
-    return allReviewableItems.map(translateToDtrItem);
-  }
-
-  /**
-   * Translate the universe of items that the user has in their stores into a collection of data that we can send the DTR API.
-   * Tailored to work alongside the bulkFetcher.
-   * Non-obvious bit: it attempts to optimize away from sending items that already exist in the ReviewDataCache.
-   */
-  getItemList(stores: D2Store[], reviewDataCache: D2ReviewDataCache): DtrItem[] {
-    const dtrItems = this._getDtrItems(stores, reviewDataCache);
-
-    const list = new Set(dtrItems);
-
-    return Array.from(list);
-  }
-
-  getVendorItemList(reviewDataCache: D2ReviewDataCache,
-                    vendorSaleItems?: DestinyVendorSaleItemComponent[],
-                    vendorItems?: DestinyVendorItemDefinition[]): DtrItem[] {
-    if (vendorSaleItems) {
-      const allVendorItems = vendorSaleItems.map((vendorItem): DtrItem => ({ referenceId: vendorItem.itemHash }));
-
-      return this._getNewVendorItems(allVendorItems, reviewDataCache);
-    } else if (vendorItems) {
-      const allVendorItems = vendorItems.map((vi) => ({ referenceId: vi.itemHash })) as DtrItem[];
-
-      return this._getNewVendorItems(allVendorItems, reviewDataCache);
-    } else {
-      throw new Error("Neither sale items nor vendor items were supplied.");
-    }
+    return getNewVendorItems(allVendorItems, reviewDataCache);
+  } else {
+    throw new Error("Neither sale items nor vendor items were supplied.");
   }
 }
 
-export { D2ItemListBuilder };
+function getNewItems(allItems: D2Item[], reviewDataCache: D2ReviewDataCache) {
+  const allDtrItems = allItems.map(translateToDtrItem);
+  const allKnownDtrItems = reviewDataCache.getItemStores();
+
+  const unmatched = allDtrItems.filter((di) => allKnownDtrItems.every((kdi) => di.referenceId !== kdi.referenceId));
+
+  return unmatched;
+}
+
+function getNewVendorItems(vendorItems: DtrItem[], reviewDataCache: D2ReviewDataCache) {
+  const allKnownDtrItems = reviewDataCache.getItemStores();
+
+  const unmatched = vendorItems.filter((vi) => allKnownDtrItems.every((di) => di.referenceId !== vi.referenceId));
+
+  return unmatched;
+}
+
+/**
+ * In D1, extracting all of the items from all of the stores was a little different from
+ * extracting all of the vendor items. If the interface is the same for both, this can go
+ * away.
+ */
+function getAllItems(stores: D2Store[]): D2Item[] {
+  return flatMap(stores, (store) => store.items);
+}
+
+// Get all of the weapons from our stores in a DTR API-friendly format.
+function getDtrItems(stores: D2Store[], reviewDataCache: D2ReviewDataCache): DtrItem[] {
+  const allItems = getAllItems(stores);
+
+  const allReviewableItems = _.filter(allItems,
+                      (item) => {
+                        return (item.reviewable);
+                      });
+
+  const newItems = getNewItems(allReviewableItems, reviewDataCache);
+
+  if (reviewDataCache.getItemStores().length > 0) {
+    return newItems;
+  }
+
+  return allReviewableItems.map(translateToDtrItem);
+}

--- a/src/app/destinyTrackerApi/d2-itemTransformer.ts
+++ b/src/app/destinyTrackerApi/d2-itemTransformer.ts
@@ -6,45 +6,36 @@ import { D2Item } from '../inventory/item-types';
 import { getPowerMods } from '../inventory/store/d2-item-factory.service';
 
 /**
- * Translates items from the objects that DIM has to the form that the DTR API expects.
- * This is generally tailored towards working with weapons.
- * Also tailored for the Destiny 2 version.
+ * Translate a DIM item into the basic form that the DTR understands an item to contain.
+ * This does not contain personally-identifying information.
+ * Meant for fetch calls.
  */
-class D2ItemTransformer {
-  /**
-   * Translate a DIM item into the basic form that the DTR understands an item to contain.
-   * This does not contain personally-identifying information.
-   * Meant for fetch calls.
-   */
-  translateToDtrItem(item: D2Item | DestinyVendorSaleItemComponent): DtrItem {
-    return {
-      referenceId: ((item as DestinyVendorSaleItemComponent).itemHash !== undefined) ? (item as DestinyVendorSaleItemComponent).itemHash : (item as D2Item).hash
-    };
-  }
-
-  /**
-   * Get the roll and perks for the selected DIM item (to send to the DTR API).
-   * Will contain personally-identifying information.
-   */
-  getRollAndPerks(item: D2Item): DtrItem {
-    const powerModHashes = getPowerMods(item).map((m) => m.hash);
-    return {
-      selectedPerks: this._getSelectedPlugs(item, powerModHashes),
-      attachedMods: powerModHashes,
-      referenceId: item.hash,
-      instanceId: item.id,
-    };
-  }
-
-  _getSelectedPlugs(item: D2Item, powerModHashes: number[]) {
-    if (!item.sockets) {
-      return [];
-    }
-
-    const allPlugs = compact(item.sockets.sockets.map((i) => i.plug).map((i) => i && i.plugItem.hash));
-
-    return _.difference(allPlugs, powerModHashes);
-  }
+export function translateToDtrItem(item: D2Item | DestinyVendorSaleItemComponent): DtrItem {
+  return {
+    referenceId: ((item as DestinyVendorSaleItemComponent).itemHash !== undefined) ? (item as DestinyVendorSaleItemComponent).itemHash : (item as D2Item).hash
+  };
 }
 
-export { D2ItemTransformer };
+/**
+ * Get the roll and perks for the selected DIM item (to send to the DTR API).
+ * Will contain personally-identifying information.
+ */
+export function getRollAndPerks(item: D2Item): DtrItem {
+  const powerModHashes = getPowerMods(item).map((m) => m.hash);
+  return {
+    selectedPerks: getSelectedPlugs(item, powerModHashes),
+    attachedMods: powerModHashes,
+    referenceId: item.hash,
+    instanceId: item.id,
+  };
+}
+
+function getSelectedPlugs(item: D2Item, powerModHashes: number[]) {
+  if (!item.sockets) {
+    return [];
+  }
+
+  const allPlugs = compact(item.sockets.sockets.map((i) => i.plug).map((i) => i && i.plugItem.hash));
+
+  return _.difference(allPlugs, powerModHashes);
+}

--- a/src/app/destinyTrackerApi/d2-perkRater.ts
+++ b/src/app/destinyTrackerApi/d2-perkRater.ts
@@ -10,83 +10,82 @@ export interface RatingAndReview {
 }
 
 /**
- * Rate perks on a Destiny 2 item (based off of its attached user reviews).
+ * Rate the perks on a Destiny 2 item based off of its attached user reviews.
  */
-class D2PerkRater {
-  /**
-   * Rate the perks on a Destiny 2 item based off of its attached user reviews.
-   */
-  ratePerks(item: D2Item) {
-    if (!item.reviews ||
-        !item.reviews.length ||
-        !item.sockets ||
-        !item.sockets.sockets) {
-      return;
-    }
-
-    item.sockets.sockets.forEach((socket) => {
-      if ((socket.plugOptions.length) &&
-          (socket.plugOptions.length > 1)) {
-        const plugOptionHashes = socket.plugOptions.map((i) => i.plugItem.hash);
-
-        const ratingsAndReviews = plugOptionHashes.map((plugOptionHash) => this._getPlugRatingsAndReviewCount(plugOptionHash, item.reviews));
-
-        const maxReview = this._getMaxReview(ratingsAndReviews);
-
-        this._markPlugAsBest(maxReview, socket);
-      }
-    });
+export function ratePerks(item: D2Item) {
+  if (!item.reviews ||
+      !item.reviews.length ||
+      !item.sockets ||
+      !item.sockets.sockets) {
+    return;
   }
 
-  _markPlugAsBest(maxReview: RatingAndReview | null,
-                  socket: DimSocket) {
-    if (!maxReview) {
-      return;
-    }
+  item.sockets.sockets.forEach((socket) => {
+    if ((socket.plugOptions.length) &&
+        (socket.plugOptions.length > 1)) {
+      const plugOptionHashes = socket.plugOptions.map((i) => i.plugItem.hash);
 
-    const matchingPlugOption = socket.plugOptions.find((plugOption) => plugOption.plugItem.hash === maxReview.plugOptionHash);
+      const ratingsAndReviews = plugOptionHashes.map((plugOptionHash) => getPlugRatingsAndReviewCount(plugOptionHash, item.reviews));
 
-    if (matchingPlugOption) {
-      matchingPlugOption.bestRated = true;
+      const maxReview = getMaxReview(ratingsAndReviews);
+
+      markPlugAsBest(maxReview, socket);
     }
+  });
+}
+
+function markPlugAsBest(
+  maxReview: RatingAndReview | null,
+  socket: DimSocket
+) {
+  if (!maxReview) {
+    return;
   }
 
-  _getMaxReview(ratingsAndReviews: RatingAndReview[]) {
-    const orderedRatingsAndReviews = _.sortBy(ratingsAndReviews, (ratingAndReview) => (ratingAndReview.ratingCount < 2 ? 0
-      : ratingAndReview.averageReview)).reverse();
+  const matchingPlugOption = socket.plugOptions.find((plugOption) => plugOption.plugItem.hash === maxReview.plugOptionHash);
 
-    if ((orderedRatingsAndReviews.length > 0) &&
-        (orderedRatingsAndReviews[0].ratingCount > 1)) {
-      return orderedRatingsAndReviews[0];
-    }
-
-    return null;
-  }
-
-  _getPlugRatingsAndReviewCount(plugOptionHash,
-                                reviews): RatingAndReview {
-    const matchingReviews = this._getMatchingReviews(plugOptionHash,
-                                                     reviews);
-
-    const ratingCount = matchingReviews.length;
-    const averageReview = sum(matchingReviews, (r) => r.voted) / matchingReviews.length || 1;
-
-    const ratingAndReview = {
-      ratingCount,
-      averageReview,
-      plugOptionHash
-    };
-
-    return ratingAndReview;
-  }
-
-  _getMatchingReviews(plugOptionHash,
-                      reviews: DtrUserReview[]) {
-    return reviews.filter((review) => {
-      return (review.selectedPerks && review.selectedPerks.includes(plugOptionHash)) ||
-             (review.attachedMods && review.attachedMods.includes(plugOptionHash));
-    });
+  if (matchingPlugOption) {
+    matchingPlugOption.bestRated = true;
   }
 }
 
-export { D2PerkRater };
+function getMaxReview(ratingsAndReviews: RatingAndReview[]) {
+  const orderedRatingsAndReviews = _.sortBy(ratingsAndReviews, (ratingAndReview) => (ratingAndReview.ratingCount < 2 ? 0
+    : ratingAndReview.averageReview)).reverse();
+
+  if ((orderedRatingsAndReviews.length > 0) &&
+      (orderedRatingsAndReviews[0].ratingCount > 1)) {
+    return orderedRatingsAndReviews[0];
+  }
+
+  return null;
+}
+
+function getPlugRatingsAndReviewCount(
+  plugOptionHash,
+  reviews
+): RatingAndReview {
+  const matchingReviews = getMatchingReviews(plugOptionHash,
+                                                    reviews);
+
+  const ratingCount = matchingReviews.length;
+  const averageReview = sum(matchingReviews, (r) => r.voted) / matchingReviews.length || 1;
+
+  const ratingAndReview = {
+    ratingCount,
+    averageReview,
+    plugOptionHash
+  };
+
+  return ratingAndReview;
+}
+
+function getMatchingReviews(
+  plugOptionHash,
+  reviews: DtrUserReview[]
+) {
+  return reviews.filter((review) => {
+    return (review.selectedPerks && review.selectedPerks.includes(plugOptionHash)) ||
+            (review.attachedMods && review.attachedMods.includes(plugOptionHash));
+  });
+}

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.ts
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.ts
@@ -1,8 +1,8 @@
 import * as _ from 'underscore';
-import { D2ItemTransformer } from './d2-itemTransformer';
 import { DimWorkingUserReview, DtrUserReview, DtrBulkItem } from '../item-review/destiny-tracker.service';
 import { DestinyVendorSaleItemComponent } from 'bungie-api-ts/destiny2';
 import { D2Item } from '../inventory/item-types';
+import { translateToDtrItem } from './d2-itemTransformer';
 
 /**
  * Cache of review data.
@@ -12,9 +12,7 @@ import { D2Item } from '../inventory/item-types';
 class D2ReviewDataCache {
   _maxTotalVotes: number;
   _itemStores: DimWorkingUserReview[];
-  _itemTransformer: D2ItemTransformer;
   constructor() {
-    this._itemTransformer = new D2ItemTransformer();
     this._itemStores = [];
     this._maxTotalVotes = 0;
   }
@@ -22,7 +20,7 @@ class D2ReviewDataCache {
   _getMatchingItem(item?: D2Item | DestinyVendorSaleItemComponent,
                    itemHash?: number) {
     if (item) {
-      const dtrItem = this._itemTransformer.translateToDtrItem(item);
+      const dtrItem = translateToDtrItem(item);
 
       return this._itemStores.find((s) => s.referenceId === dtrItem.referenceId);
     } else if (itemHash) {

--- a/src/app/destinyTrackerApi/d2-reviewReporter.ts
+++ b/src/app/destinyTrackerApi/d2-reviewReporter.ts
@@ -1,10 +1,10 @@
 import { D2ReviewDataCache } from "./d2-reviewDataCache";
 import { DestinyAccount } from "../accounts/destiny-account.service";
 import { DtrUserReview, DtrReviewer } from '../item-review/destiny-tracker.service';
-import { UserFilter } from "./userFilter";
 import { loadingTracker } from "../ngimport-more";
 import { handleD2SubmitErrors } from "./d2-trackerErrorHandler";
 import { dtrFetch } from "./dtr-service-helper";
+import { ignoreUser } from "./userFilter";
 
 export interface DimReviewReport {
   reviewId: string;
@@ -16,7 +16,6 @@ export interface DimReviewReport {
  * Class to support reporting bad takes.
  */
 class D2ReviewReporter {
-  _userFilter = new UserFilter();
   _reviewDataCache: D2ReviewDataCache;
   constructor(reviewDataCache) {
     this._reviewDataCache = reviewDataCache;
@@ -54,7 +53,7 @@ class D2ReviewReporter {
 
   _ignoreReportedUser(review: DtrUserReview) {
     const reportedMembershipId = review.reviewer.membershipId;
-    this._userFilter.ignoreUser(reportedMembershipId);
+    ignoreUser(reportedMembershipId);
   }
 
   /**

--- a/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
@@ -1,4 +1,3 @@
-import { D2ItemTransformer } from './d2-itemTransformer';
 import { D2ReviewDataCache } from './d2-reviewDataCache';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { loadingTracker } from '../ngimport-more';
@@ -6,6 +5,7 @@ import { handleD2SubmitErrors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
 import { DtrReviewer } from '../item-review/destiny-tracker.service';
 import { dtrFetch } from './dtr-service-helper';
+import { getRollAndPerks } from './d2-itemTransformer';
 
 export interface RatingAndReviewRequest {
   reviewer?: DtrReviewer;
@@ -23,7 +23,6 @@ export interface RatingAndReviewRequest {
  */
 class D2ReviewSubmitter {
   _reviewDataCache: D2ReviewDataCache;
-  _itemTransformer = new D2ItemTransformer();
   constructor(reviewDataCache) {
     this._reviewDataCache = reviewDataCache;
   }
@@ -47,7 +46,7 @@ class D2ReviewSubmitter {
   }
 
   _submitReviewPromise(item: D2Item, membershipInfo: DestinyAccount | null) {
-    const rollAndPerks = this._itemTransformer.getRollAndPerks(item);
+    const rollAndPerks = getRollAndPerks(item);
     const reviewer = this._getReviewer(membershipInfo);
     const review = this.toRatingAndReview(item);
 

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -2,19 +2,18 @@ import * as _ from 'underscore';
 import { getActivePlatform } from '../accounts/platform.service';
 import { D2ReviewDataCache } from './d2-reviewDataCache';
 import { DtrReviewContainer, DimWorkingUserReview, DtrUserReview } from '../item-review/destiny-tracker.service';
-import { UserFilter } from './userFilter';
 import { loadingTracker } from '../ngimport-more';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
 import { getRollAndPerks } from './d2-itemTransformer';
 import { ratePerks } from './d2-perkRater';
+import { conditionallyIgnoreReview } from './userFilter';
 
 /**
  * Get the community reviews from the DTR API for a specific item.
  */
 class D2ReviewsFetcher {
-  _userFilter = new UserFilter();
   _reviewDataCache: D2ReviewDataCache;
   constructor(reviewDataCache) {
     this._reviewDataCache = reviewDataCache;
@@ -44,9 +43,7 @@ class D2ReviewsFetcher {
       item.reviews = item.reviews as DtrUserReview[]; // D1 and D2 reviews take different shapes
       item.reviews.sort(this._sortReviews);
 
-      item.reviews.forEach((writtenReview) => {
-        this._userFilter.conditionallyIgnoreReview(writtenReview);
-      });
+      item.reviews.forEach(conditionallyIgnoreReview);
     }
   }
 

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -1,5 +1,4 @@
 import * as _ from 'underscore';
-import { D2PerkRater } from './d2-perkRater';
 import { getActivePlatform } from '../accounts/platform.service';
 import { D2ReviewDataCache } from './d2-reviewDataCache';
 import { DtrReviewContainer, DimWorkingUserReview, DtrUserReview } from '../item-review/destiny-tracker.service';
@@ -9,12 +8,12 @@ import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
 import { getRollAndPerks } from './d2-itemTransformer';
+import { ratePerks } from './d2-perkRater';
 
 /**
  * Get the community reviews from the DTR API for a specific item.
  */
 class D2ReviewsFetcher {
-  _perkRater = new D2PerkRater();
   _userFilter = new UserFilter();
   _reviewDataCache: D2ReviewDataCache;
   constructor(reviewDataCache) {
@@ -88,7 +87,7 @@ class D2ReviewsFetcher {
 
     this._reviewDataCache.addReviewsData(item, reviewData);
 
-    this._perkRater.ratePerks(item);
+    ratePerks(item);
     item.reviewsUpdated = Date.now();
   }
 

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -1,5 +1,4 @@
 import * as _ from 'underscore';
-import { D2ItemTransformer } from './d2-itemTransformer';
 import { D2PerkRater } from './d2-perkRater';
 import { getActivePlatform } from '../accounts/platform.service';
 import { D2ReviewDataCache } from './d2-reviewDataCache';
@@ -9,6 +8,7 @@ import { loadingTracker } from '../ngimport-more';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
+import { getRollAndPerks } from './d2-itemTransformer';
 
 /**
  * Get the community reviews from the DTR API for a specific item.
@@ -17,13 +17,12 @@ class D2ReviewsFetcher {
   _perkRater = new D2PerkRater();
   _userFilter = new UserFilter();
   _reviewDataCache: D2ReviewDataCache;
-  _itemTransformer = new D2ItemTransformer();
   constructor(reviewDataCache) {
     this._reviewDataCache = reviewDataCache;
   }
 
   _getItemReviewsPromise(item, platformSelection: number, mode: number): Promise<DtrReviewContainer> {
-    const dtrItem = this._itemTransformer.getRollAndPerks(item);
+    const dtrItem = getRollAndPerks(item);
 
     const queryString = `page=1&platform=${platformSelection}&mode=${mode}`;
     const promise = dtrFetch(

--- a/src/app/destinyTrackerApi/itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/itemListBuilder.ts
@@ -6,54 +6,48 @@ import { D1Item } from '../inventory/item-types';
 import { translateToDtrWeapon } from './itemTransformer';
 
 /**
- * Translates collections of DIM items into a collection of data almost ready to ship to the DTR API.
- * Generally tailored to work with weapon data.
+ * Translate the universe of weapons that the user has in their stores into a collection of data that we can send the DTR API.
+ * Tailored to work alongside the bulkFetcher.
+ * Non-obvious bit: it attempts to optimize away from sending items that already exist in the ReviewDataCache.
  */
-export class ItemListBuilder {
-  _getNewItems(allItems: D1Item[], reviewDataCache: ReviewDataCache): D1ItemFetchRequest[] {
-    const allDtrItems = allItems.map(translateToDtrWeapon);
-    const allKnownDtrItems = reviewDataCache.getItemStores();
+export function getWeaponList(stores, reviewDataCache: ReviewDataCache): D1ItemFetchRequest[] {
+  const dtrWeapons = getDtrWeapons(stores, reviewDataCache);
 
-    const unmatched = _.reject(allDtrItems, (dtrItem) => _.any(allKnownDtrItems, { referenceId: dtrItem.referenceId.toString(), roll: dtrItem.roll }));
+  const list = new Set(dtrWeapons);
 
-    return unmatched;
+  return Array.from(list);
+}
+
+function getNewItems(allItems: D1Item[], reviewDataCache: ReviewDataCache): D1ItemFetchRequest[] {
+  const allDtrItems = allItems.map(translateToDtrWeapon);
+  const allKnownDtrItems = reviewDataCache.getItemStores();
+
+  const unmatched = _.reject(allDtrItems, (dtrItem) => _.any(allKnownDtrItems, { referenceId: dtrItem.referenceId.toString(), roll: dtrItem.roll }));
+
+  return unmatched;
+}
+
+function getAllItems(stores: any[]) {
+  const firstItem = stores[0];
+
+  if (firstItem.allItems !== undefined) {
+    return _.pluck(flatMap(stores, (vendor) => vendor.allItems), 'item');
   }
 
-  _getAllItems(stores: any[]) {
-    const firstItem = stores[0];
+  return flatMap(stores, (store) => store.items);
+}
 
-    if (firstItem.allItems !== undefined) {
-      return _.pluck(flatMap(stores, (vendor) => vendor.allItems), 'item');
-    }
+// Get all of the weapons from our stores in a DTR API-friendly format.
+function getDtrWeapons(stores, reviewDataCache: ReviewDataCache): D1ItemFetchRequest[] {
+  const allItems: D1Item[] = getAllItems(stores);
 
-    return flatMap(stores, (store) => store.items);
+  const allWeapons = allItems.filter((item) => item.reviewable);
+
+  const newGuns = getNewItems(allWeapons, reviewDataCache);
+
+  if (reviewDataCache.getItemStores().length > 0) {
+    return newGuns;
   }
 
-  // Get all of the weapons from our stores in a DTR API-friendly format.
-  _getDtrWeapons(stores, reviewDataCache: ReviewDataCache): D1ItemFetchRequest[] {
-    const allItems: D1Item[] = this._getAllItems(stores);
-
-    const allWeapons = allItems.filter((item) => item.reviewable);
-
-    const newGuns = this._getNewItems(allWeapons, reviewDataCache);
-
-    if (reviewDataCache.getItemStores().length > 0) {
-      return newGuns;
-    }
-
-    return allWeapons.map(translateToDtrWeapon);
-  }
-
-  /**
-   * Translate the universe of weapons that the user has in their stores into a collection of data that we can send the DTR API.
-   * Tailored to work alongside the bulkFetcher.
-   * Non-obvious bit: it attempts to optimize away from sending items that already exist in the ReviewDataCache.
-   */
-  getWeaponList(stores, reviewDataCache: ReviewDataCache): D1ItemFetchRequest[] {
-    const dtrWeapons = this._getDtrWeapons(stores, reviewDataCache);
-
-    const list = new Set(dtrWeapons);
-
-    return Array.from(list);
-  }
+  return allWeapons.map(translateToDtrWeapon);
 }

--- a/src/app/destinyTrackerApi/itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/itemListBuilder.ts
@@ -1,19 +1,17 @@
 import { flatMap } from '../util';
 import * as _ from 'underscore';
-import { ItemTransformer } from './itemTransformer';
 import { ReviewDataCache } from './reviewDataCache';
 import { D1ItemFetchRequest } from '../item-review/destiny-tracker.service';
 import { D1Item } from '../inventory/item-types';
+import { translateToDtrWeapon } from './itemTransformer';
 
 /**
  * Translates collections of DIM items into a collection of data almost ready to ship to the DTR API.
  * Generally tailored to work with weapon data.
  */
 export class ItemListBuilder {
-  _itemTransformer = new ItemTransformer();
-
   _getNewItems(allItems: D1Item[], reviewDataCache: ReviewDataCache): D1ItemFetchRequest[] {
-    const allDtrItems = allItems.map((item) => this._itemTransformer.translateToDtrWeapon(item));
+    const allDtrItems = allItems.map(translateToDtrWeapon);
     const allKnownDtrItems = reviewDataCache.getItemStores();
 
     const unmatched = _.reject(allDtrItems, (dtrItem) => _.any(allKnownDtrItems, { referenceId: dtrItem.referenceId.toString(), roll: dtrItem.roll }));
@@ -43,7 +41,7 @@ export class ItemListBuilder {
       return newGuns;
     }
 
-    return allWeapons.map((weapon) => this._itemTransformer.translateToDtrWeapon(weapon));
+    return allWeapons.map(translateToDtrWeapon);
   }
 
   /**

--- a/src/app/destinyTrackerApi/itemTransformer.ts
+++ b/src/app/destinyTrackerApi/itemTransformer.ts
@@ -2,47 +2,41 @@ import { D1ItemFetchRequest, D1ItemReviewRequest } from "../item-review/destiny-
 import { DimItem } from "../inventory/item-types";
 
 /**
- * Translates items from the objects that DIM has to the form that the DTR API expects.
- * This is generally tailored towards working with weapons.
+ * Translate a DIM weapon item into the basic form that the DTR understands a weapon to contain.
+ * This does not contain personally-identifying information.
  */
-export class ItemTransformer {
-  /**
-   * Translate a DIM weapon item into the basic form that the DTR understands a weapon to contain.
-   * This does not contain personally-identifying information.
-   */
-  translateToDtrWeapon(weapon: DimItem): D1ItemFetchRequest {
-    return {
-      referenceId: weapon.hash.toString(),
-      roll: this._getDtrRoll(weapon)
-    };
+export function translateToDtrWeapon(weapon: DimItem): D1ItemFetchRequest {
+  return {
+    referenceId: weapon.hash.toString(),
+    roll: getDtrRoll(weapon)
+  };
+}
+
+/**
+ * Get the roll and perks for the selected DIM item (to send to the DTR API).
+ * Will contain personally-identifying information.
+ */
+export function getRollAndPerks(weapon: DimItem): D1ItemReviewRequest {
+  return {
+    roll: getDtrRoll(weapon),
+    selectedPerks: getDtrPerks(weapon),
+    referenceId: weapon.hash.toString(),
+    instanceId: weapon.id,
+  };
+}
+
+function getDtrPerks(weapon) {
+  if (!weapon.talentGrid) {
+    return null;
   }
 
-  /**
-   * Get the roll and perks for the selected DIM item (to send to the DTR API).
-   * Will contain personally-identifying information.
-   */
-  getRollAndPerks(weapon: DimItem): D1ItemReviewRequest {
-    return {
-      roll: this._getDtrRoll(weapon),
-      selectedPerks: this._getDtrPerks(weapon),
-      referenceId: weapon.hash.toString(),
-      instanceId: weapon.id,
-    };
+  return weapon.talentGrid.dtrPerks;
+}
+
+function getDtrRoll(weapon) {
+  if (!weapon.talentGrid) {
+    return null;
   }
 
-  _getDtrPerks(weapon) {
-    if (!weapon.talentGrid) {
-      return null;
-    }
-
-    return weapon.talentGrid.dtrPerks;
-  }
-
-  _getDtrRoll(weapon) {
-    if (!weapon.talentGrid) {
-      return null;
-    }
-
-    return weapon.talentGrid.dtrRoll;
-  }
+  return weapon.talentGrid.dtrRoll;
 }

--- a/src/app/destinyTrackerApi/perkRater.ts
+++ b/src/app/destinyTrackerApi/perkRater.ts
@@ -9,103 +9,106 @@ interface RatingAndReview {
 }
 
 /**
- * Rate perks on an item (based off of its attached user reviews).
+ * Rate the perks on an item based off of its attached user reviews.
  */
-export class PerkRater {
-  /**
-   * Rate the perks on an item based off of its attached user reviews.
-   */
-  ratePerks(item: D1Item) {
-    if ((!item.talentGrid) ||
-        (!item.reviews) ||
-        (!item.reviews.length)) {
-      return;
-    }
-
-    const maxColumn = this._getMaxColumn(item);
-
-    if (!maxColumn) {
-      return;
-    }
-
-    for (let i = 1; i < maxColumn; i++) {
-      const perkNodesInColumn = this._getPerkNodesInColumn(item, i);
-
-      const ratingsAndReviews = perkNodesInColumn.map((perkNode) => this._getPerkRatingsAndReviewCount(perkNode, item.reviews as D1ItemUserReview[]));
-
-      const maxReview = this._getMaxReview(ratingsAndReviews);
-
-      this._markNodeAsBest(maxReview);
-    }
+export function ratePerks(item: D1Item) {
+  if ((!item.talentGrid) ||
+      (!item.reviews) ||
+      (!item.reviews.length)) {
+    return;
   }
 
-  _markNodeAsBest(maxReview: RatingAndReview | null) {
-    if (!maxReview) {
-      return;
-    }
+  const maxColumn = getMaxColumn(item);
 
-    maxReview.perkNode.bestRated = true;
+  if (!maxColumn) {
+    return;
   }
 
-  _getMaxReview(ratingsAndReviews: RatingAndReview[]) {
-    const orderedRatingsAndReviews = ratingsAndReviews.sort((ratingAndReview) => ratingAndReview.ratingCount < 2 ? 0 : ratingAndReview.averageReview).reverse();
+  for (let i = 1; i < maxColumn; i++) {
+    const perkNodesInColumn = getPerkNodesInColumn(item, i);
 
-    if ((orderedRatingsAndReviews.length > 0) &&
-        (orderedRatingsAndReviews[0].ratingCount > 1)) {
-      return orderedRatingsAndReviews[0];
-    }
+    const ratingsAndReviews = perkNodesInColumn.map((perkNode) => getPerkRatingsAndReviewCount(perkNode, item.reviews as D1ItemUserReview[]));
 
-    return null;
+    const maxReview = getMaxReview(ratingsAndReviews);
+
+    markNodeAsBest(maxReview);
+  }
+}
+
+function markNodeAsBest(maxReview: RatingAndReview | null) {
+  if (!maxReview) {
+    return;
   }
 
-  _getMaxColumn(item: D1Item): number | undefined {
-    if (!item.talentGrid) {
-      return undefined;
-    }
+  maxReview.perkNode.bestRated = true;
+}
 
-    return _.max(item.talentGrid.nodes, (node) => node.column).column;
+function getMaxReview(ratingsAndReviews: RatingAndReview[]) {
+  const orderedRatingsAndReviews = ratingsAndReviews.sort((ratingAndReview) => ratingAndReview.ratingCount < 2 ? 0 : ratingAndReview.averageReview).reverse();
+
+  if ((orderedRatingsAndReviews.length > 0) &&
+      (orderedRatingsAndReviews[0].ratingCount > 1)) {
+    return orderedRatingsAndReviews[0];
   }
 
-  _getPerkNodesInColumn(item: D1Item,
-                        column): D1GridNode[] {
-    if (!item.talentGrid) {
-      return [];
-    }
+  return null;
+}
 
-    return _.where(item.talentGrid.nodes, { column });
+function getMaxColumn(item: D1Item): number | undefined {
+  if (!item.talentGrid) {
+    return undefined;
   }
 
-  _getPerkRatingsAndReviewCount(perkNode: D1GridNode,
-                                reviews: D1ItemUserReview[]): RatingAndReview {
-    const matchingReviews = this._getMatchingReviews(perkNode,
-                                                     reviews);
+  return _.max(item.talentGrid.nodes, (node) => node.column).column;
+}
 
-    const ratingCount = matchingReviews.length;
-    const averageReview = _.pluck(matchingReviews, 'rating').reduce((memo, num) => memo + num, 0) / matchingReviews.length || 1;
-
-    const ratingAndReview = {
-      ratingCount,
-      averageReview,
-      perkNode
-    };
-
-    return ratingAndReview;
+function getPerkNodesInColumn(
+  item: D1Item,
+  column
+): D1GridNode[] {
+  if (!item.talentGrid) {
+    return [];
   }
 
-  _getMatchingReviews(perkNode,
-                      reviews: D1ItemUserReview[]) {
-    const perkRoll = perkNode.dtrRoll.replace('o', '');
-    return reviews.filter((review) => this._selectedPerkNodeApplies(perkRoll, review));
-  }
+  return _.where(item.talentGrid.nodes, { column });
+}
 
-  _selectedPerkNodeApplies(perkRoll,
-                           review) {
-    const reviewSelectedPerks = this._getSelectedPerks(review, perkRoll);
-    return reviewSelectedPerks.some((reviewSelectedPerk) => perkRoll === reviewSelectedPerk);
-  }
+function getPerkRatingsAndReviewCount(
+  perkNode: D1GridNode,
+  reviews: D1ItemUserReview[]
+): RatingAndReview {
+  const matchingReviews = getMatchingReviews(perkNode,
+                                                    reviews);
 
-  _getSelectedPerks(review, perkRoll) {
-    const allSelectedPerks = (review.roll) ? review.roll.split(';').filter((str) => str.indexOf('o') > -1) : perkRoll; // in narrow cases, we can be supplied a D1ItemWorkingUserReview
-    return allSelectedPerks.map((selectedPerk) => selectedPerk.replace('o', ''));
-  }
+  const ratingCount = matchingReviews.length;
+  const averageReview = _.pluck(matchingReviews, 'rating').reduce((memo, num) => memo + num, 0) / matchingReviews.length || 1;
+
+  const ratingAndReview = {
+    ratingCount,
+    averageReview,
+    perkNode
+  };
+
+  return ratingAndReview;
+}
+
+function getMatchingReviews(
+  perkNode: D1GridNode,
+  reviews: D1ItemUserReview[]
+) {
+  const perkRoll = perkNode.dtrRoll.replace('o', '');
+  return reviews.filter((review) => selectedPerkNodeApplies(perkRoll, review));
+}
+
+function selectedPerkNodeApplies(
+  perkRoll,
+  review
+) {
+  const reviewSelectedPerks = getSelectedPerks(review, perkRoll);
+  return reviewSelectedPerks.some((reviewSelectedPerk) => perkRoll === reviewSelectedPerk);
+}
+
+function getSelectedPerks(review, perkRoll) {
+  const allSelectedPerks = (review.roll) ? review.roll.split(';').filter((str) => str.indexOf('o') > -1) : perkRoll; // in narrow cases, we can be supplied a D1ItemWorkingUserReview
+  return allSelectedPerks.map((selectedPerk) => selectedPerk.replace('o', ''));
 }

--- a/src/app/destinyTrackerApi/reviewDataCache.ts
+++ b/src/app/destinyTrackerApi/reviewDataCache.ts
@@ -1,7 +1,7 @@
-import { ItemTransformer } from './itemTransformer';
 import * as _ from 'underscore';
 import { D1ItemFetchResponse, D1ItemWorkingUserReview, D1CachedItem, D1ItemUserReview, D1ItemReviewResponse } from '../item-review/destiny-tracker.service';
 import { D1Item } from '../inventory/item-types';
+import { translateToDtrWeapon } from './itemTransformer';
 
 /**
  * Cache of review data.
@@ -9,15 +9,13 @@ import { D1Item } from '../inventory/item-types';
  */
 export class ReviewDataCache {
   _itemStores: D1CachedItem[];
-  _itemTransformer: ItemTransformer;
 
   constructor() {
-    this._itemTransformer = new ItemTransformer();
     this._itemStores = [];
   }
 
   _getMatchingItem(item: D1Item): D1CachedItem | undefined {
-    const dtrItem = this._itemTransformer.translateToDtrWeapon(item);
+    const dtrItem = translateToDtrWeapon(item);
 
     // The DTR API isn't consistent about returning reference ID as an int in its responses
     // and findWhere considers 123 !== "123".

--- a/src/app/destinyTrackerApi/reviewReporter.ts
+++ b/src/app/destinyTrackerApi/reviewReporter.ts
@@ -1,16 +1,15 @@
 import { ReviewDataCache } from './reviewDataCache';
 import { D1ItemUserReview, DtrReviewer } from '../item-review/destiny-tracker.service';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { UserFilter } from './userFilter';
 import { handleSubmitErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../ngimport-more';
 import { dtrFetch } from './dtr-service-helper';
+import { ignoreUser } from './userFilter';
 
 /**
  * Class to support reporting bad takes.
  */
 export class ReviewReporter {
-  _userFilter = new UserFilter();
   _reviewDataCache: ReviewDataCache;
   constructor(reviewDataCache) {
     this._reviewDataCache = reviewDataCache;
@@ -49,7 +48,7 @@ export class ReviewReporter {
 
   _ignoreReportedUser(review) {
     const reportedMembershipId = review.reviewer.membershipId;
-    this._userFilter.ignoreUser(reportedMembershipId);
+    ignoreUser(reportedMembershipId);
   }
 
   /**

--- a/src/app/destinyTrackerApi/reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/reviewSubmitter.ts
@@ -1,17 +1,16 @@
-import { ItemTransformer } from './itemTransformer';
 import { ReviewDataCache } from './reviewDataCache';
 import { D1ItemUserReview, DtrReviewer } from '../item-review/destiny-tracker.service';
 import { handleSubmitErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../ngimport-more';
 import { D1Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
+import { getRollAndPerks } from './itemTransformer';
 
 /**
  * Supports submitting review data to the DTR API.
  */
 export class ReviewSubmitter {
   _reviewDataCache: ReviewDataCache;
-  _itemTransformer = new ItemTransformer();
   constructor(reviewDataCache: ReviewDataCache) {
     this._reviewDataCache = reviewDataCache;
   }
@@ -43,7 +42,7 @@ export class ReviewSubmitter {
   }
 
   _submitReviewPromise(item: D1Item, membershipInfo: DtrReviewer) {
-    const rollAndPerks = this._itemTransformer.getRollAndPerks(item);
+    const rollAndPerks = getRollAndPerks(item);
     const reviewer = this._getReviewer(membershipInfo);
     const review = this.toRatingAndReview(item);
 

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -1,4 +1,3 @@
-import { UserFilter } from './userFilter';
 import { D1ItemReviewResponse, D1CachedItem } from '../item-review/destiny-tracker.service';
 import { ReviewDataCache } from './reviewDataCache';
 import { handleErrors } from './trackerErrorHandler';
@@ -7,13 +6,13 @@ import { D1Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
 import { getRollAndPerks } from './itemTransformer';
 import { ratePerks } from './perkRater';
+import { conditionallyIgnoreReview } from './userFilter';
 
 /**
  * Get the community reviews from the DTR API for a specific item.
  * This was tailored to work for weapons.  Items (armor, etc.) may or may not work.
  */
 export class ReviewsFetcher {
-  _userFilter = new UserFilter();
   _reviewDataCache: ReviewDataCache;
   constructor(reviewDataCache: ReviewDataCache) {
     this._reviewDataCache = reviewDataCache;
@@ -50,7 +49,7 @@ export class ReviewsFetcher {
       item.reviews.sort(this._sortReviews);
 
       item.reviews.forEach((writtenReview) => {
-        writtenReview.isIgnored = this._userFilter.conditionallyIgnoreReview(writtenReview);
+        writtenReview.isIgnored = conditionallyIgnoreReview(writtenReview);
       });
     }
   }

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -1,4 +1,3 @@
-import { PerkRater } from './perkRater';
 import { UserFilter } from './userFilter';
 import { D1ItemReviewResponse, D1CachedItem } from '../item-review/destiny-tracker.service';
 import { ReviewDataCache } from './reviewDataCache';
@@ -7,13 +6,13 @@ import { loadingTracker } from '../ngimport-more';
 import { D1Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
 import { getRollAndPerks } from './itemTransformer';
+import { ratePerks } from './perkRater';
 
 /**
  * Get the community reviews from the DTR API for a specific item.
  * This was tailored to work for weapons.  Items (armor, etc.) may or may not work.
  */
 export class ReviewsFetcher {
-  _perkRater = new PerkRater();
   _userFilter = new UserFilter();
   _reviewDataCache: ReviewDataCache;
   constructor(reviewDataCache: ReviewDataCache) {
@@ -77,7 +76,7 @@ export class ReviewsFetcher {
 
     this._reviewDataCache.addReviewsData(item, reviewData);
 
-    this._perkRater.ratePerks(item);
+    ratePerks(item);
   }
 
   _sortReviews(a, b) {

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -1,4 +1,3 @@
-import { ItemTransformer } from './itemTransformer';
 import { PerkRater } from './perkRater';
 import { UserFilter } from './userFilter';
 import { D1ItemReviewResponse, D1CachedItem } from '../item-review/destiny-tracker.service';
@@ -7,6 +6,7 @@ import { handleErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../ngimport-more';
 import { D1Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
+import { getRollAndPerks } from './itemTransformer';
 
 /**
  * Get the community reviews from the DTR API for a specific item.
@@ -16,7 +16,6 @@ export class ReviewsFetcher {
   _perkRater = new PerkRater();
   _userFilter = new UserFilter();
   _reviewDataCache: ReviewDataCache;
-  _itemTransformer = new ItemTransformer();
   constructor(reviewDataCache: ReviewDataCache) {
     this._reviewDataCache = reviewDataCache;
   }
@@ -31,7 +30,7 @@ export class ReviewsFetcher {
   }
 
   _getItemReviewsPromise(item: D1Item): Promise<D1ItemReviewResponse[]> {
-    const postWeapon = this._itemTransformer.getRollAndPerks(item);
+    const postWeapon = getRollAndPerks(item);
 
     const promise = dtrFetch(
       'https://reviews-api.destinytracker.net/api/weaponChecker/reviews',

--- a/src/app/destinyTrackerApi/userFilter.ts
+++ b/src/app/destinyTrackerApi/userFilter.ts
@@ -1,48 +1,43 @@
 import { SyncService } from "../storage/sync.service";
 
 /**
- * Class to support registering (and remembering) displeasure with other reviewers.
+ * Note a problem user's membership ID so that we can ignore their reviews in the future.
+ * Persists the list of ignored users across sessions.
  */
-export class UserFilter {
-  _getIgnoredUsersPromise() {
-    const ignoredUsersKey = 'ignoredUsers';
-    return SyncService.get()
-      .then((data) => {
-        return data[ignoredUsersKey] || [];
-      });
-  }
+export function ignoreUser(reportedMembershipId) {
+  getIgnoredUsers()
+    .then((ignoredUsers) => {
+      ignoredUsers.push(reportedMembershipId);
 
-  /**
-   * Note a problem user's membership ID so that we can ignore their reviews in the future.
-   * Persists the list of ignored users across sessions.
-   */
-  ignoreUser(reportedMembershipId) {
-    this._getIgnoredUsersPromise()
-      .then((ignoredUsers) => {
-        ignoredUsers.push(reportedMembershipId);
+      SyncService.set({ ignoredUsers });
+    });
+}
 
-        SyncService.set({ ignoredUsers });
-      });
-  }
+/**
+ * Conditionally set the isIgnored flag on a review.
+ * Sets it if the review was written by someone that's already on the ignore list.
+ */
+export function conditionallyIgnoreReview(review) {
+  const membershipId = review.reviewer.membershipId;
 
-  /**
-   * Conditionally set the isIgnored flag on a review.
-   * Sets it if the review was written by someone that's already on the ignore list.
-   */
-  conditionallyIgnoreReview(review) {
-    const membershipId = review.reviewer.membershipId;
+  getIgnoredUsers()
+    .then((ignoredUsers) => {
+      review.isIgnored = (ignoredUsers.indexOf(membershipId) !== -1);
+    });
+}
 
-    this._getIgnoredUsersPromise()
-      .then((ignoredUsers) => {
-        review.isIgnored = (ignoredUsers.indexOf(membershipId) !== -1);
-      });
-  }
+/**
+ * Resets the list of ignored users.
+ * This is in for development, but maybe someone else will eventually want?
+ */
+export function clearIgnoredUsers() {
+  SyncService.set({ ignoredUsers: [] });
+}
 
-  /**
-   * Resets the list of ignored users.
-   * This is in for development, but maybe someone else will eventually want?
-   */
-  clearIgnoredUsers() {
-    SyncService.set({ ignoredUsers: [] });
-  }
+function getIgnoredUsers() {
+  const ignoredUsersKey = 'ignoredUsers';
+  return SyncService.get()
+    .then((data) => {
+      return data[ignoredUsersKey] || [];
+    });
 }

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -136,7 +136,6 @@ import { IPromise } from 'angular';
 import { $q } from 'ngimport';
 import { DimStore, D2Store } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
-import { clearIgnoredUsers } from '../destinyTrackerApi/userFilter';
 
 export interface DestinyTrackerServiceType {
   bulkFetchVendorItems(vendorSaleItems: DestinyVendorSaleItemComponent[]): Promise<DestinyTrackerServiceType>;
@@ -149,7 +148,6 @@ export interface DestinyTrackerServiceType {
   submitReview(item: any | DimItem);
   fetchReviews(stores: any | DimStore[]);
   reportReview(review: any);
-  clearIgnoredUsers();
   clearCache();
   getD2ReviewDataCache(): D2ReviewDataCache;
 }
@@ -314,7 +312,6 @@ export function DestinyTrackerService(): DestinyTrackerServiceType {
         }
       }
     },
-    clearIgnoredUsers,
     clearCache() {
       if (_isDestinyTwo()) {
         _d2reviewDataCache.clearAllItems();

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -134,9 +134,9 @@ import { D2BulkFetcher } from '../destinyTrackerApi/d2-bulkFetcher';
 import { DestinyVendorSaleItemComponent, DestinyVendorItemDefinition, DestinyActivityModeType } from 'bungie-api-ts/destiny2';
 import { IPromise } from 'angular';
 import { $q } from 'ngimport';
-import { UserFilter } from '../destinyTrackerApi/userFilter';
 import { DimStore, D2Store } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
+import { clearIgnoredUsers } from '../destinyTrackerApi/userFilter';
 
 export interface DestinyTrackerServiceType {
   bulkFetchVendorItems(vendorSaleItems: DestinyVendorSaleItemComponent[]): Promise<DestinyTrackerServiceType>;
@@ -314,10 +314,7 @@ export function DestinyTrackerService(): DestinyTrackerServiceType {
         }
       }
     },
-    clearIgnoredUsers() {
-      const userFilter = new UserFilter();
-      userFilter.clearIgnoredUsers();
-    },
+    clearIgnoredUsers,
     clearCache() {
       if (_isDestinyTwo()) {
         _d2reviewDataCache.clearAllItems();

--- a/src/app/storage/storage.component.ts
+++ b/src/app/storage/storage.component.ts
@@ -15,6 +15,7 @@ import { sum, count } from '../util';
 import template from './storage.html';
 import './storage.scss';
 import { StorageAdapter, SyncService } from './sync.service';
+import { clearIgnoredUsers } from '../destinyTrackerApi/userFilter';
 
 declare global {
   interface Window {
@@ -51,7 +52,6 @@ export const StorageComponent: IComponentOptions = {
 function StorageController(
   this: IController,
   $scope: IScope,
-  dimDestinyTrackerService,
   $timeout: ITimeoutService,
   $window: IWindowService,
   $q: IQService,
@@ -178,6 +178,6 @@ function StorageController(
       return;
     }
 
-    dimDestinyTrackerService.clearIgnoredUsers();
+    clearIgnoredUsers();
   };
 }


### PR DESCRIPTION
The DTR code had a bunch of classes in it - as we've extracted state out, they ended up just being collections of methods. This converts them to normal JS modules with exported functions, instead of classes.