### PR TITLE
set color of item tag text

### DIFF
--- a/src/app/move-popup/item-tag.scss
+++ b/src/app/move-popup/item-tag.scss
@@ -1,5 +1,6 @@
 dim-item-tag {
   select {
+    color: black;
     background: transparent;
     border: none;
     outline: none;


### PR DESCRIPTION
After #2791 the tagging dropdown was white-on-white.