### PR TITLE
Show accounts even if they return an error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Handle the Warmind API bug better, and provide helpful info on how to fix it.
+
 # 4.51.1 (2018-05-08)
 
 * Fix progress page not displaying after the Warmind update.

--- a/src/app/bungie-api/error-toaster.ts
+++ b/src/app/bungie-api/error-toaster.ts
@@ -12,7 +12,7 @@ export function bungieErrorToaster(e: Error) {
   return {
     type: 'error',
     bodyOutputType: 'trustedHtml',
-    title: 'Bungie.net Error',
+    title: t('BungieService.ErrorTitle'),
     body: e.message + twitter,
     showCloseButton: false
   };

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -4,7 +4,8 @@ import {
   DestinyItemComponent,
   DestinyItemComponentSetOfint64,
   DestinyProfileResponse,
-  DestinyProgression
+  DestinyProgression,
+  PlatformErrorCodes
   } from 'bungie-api-ts/destiny2';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Subject } from 'rxjs/Subject';
@@ -32,6 +33,7 @@ import { t } from 'i18next';
 import { D2Vault, D2Store, D2StoreServiceType } from './store-types';
 import { DimItem } from './item-types';
 import { InventoryBuckets } from './inventory-buckets';
+import { DimError } from '../bungie-api/bungie-service-helper';
 
 /**
  * TODO: For now this is a copy of StoreService customized for D2. Over time we should either
@@ -245,8 +247,18 @@ export function D2StoresService(
 
         return stores;
       })
-      .catch((e) => {
-        toaster.pop(bungieErrorToaster(e));
+      .catch((e: DimError) => {
+        // Special messaging for the Warmind error
+        if (e.code && e.code === PlatformErrorCodes.DestinyUnexpectedError) {
+          toaster.pop({
+            type: 'error',
+            title: t('BungieService.ErrorTitle'),
+            body: t('BungieService.WarmindLoginNeeded'),
+            showCloseButton: false
+          });
+        } else {
+          toaster.pop(bungieErrorToaster(e));
+        }
         console.error('Error loading stores', e);
         reportException('d2stores', e);
         // It's important that we swallow all errors here - otherwise

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -50,7 +50,9 @@
     "Throttled": "Bungie API throttling limit exceeded. Please wait a bit and then retry.",
     "Twitter": "Get status updates on:",
     "UnknownError": "Bungie.net message: {{message}}",
-    "VendorNotFound": "Vendor data is unavailable."
+    "VendorNotFound": "Vendor data is unavailable.",
+    "ErrorTitle": "Bungie.net Error",
+    "WarmindLoginNeeded": "We can't load your inventory due to a bug in the Destiny API. To fix it, load each of your characters and set up the emote wheel."
   },
   "Compare": {
     "All": "{{type}} comparisons ({{quantity}})",


### PR DESCRIPTION
And provide a helpful message for the Warmind issue. This should mean you don't have to log into all characters on ALL platforms, and it's more effective than Twitter at telling people how to fix it.