### PR TITLE
Warmind fixes (collections, emotes)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Collection exotics are no longer duplicated. They are also sorted by name.
 * Updated max power to 380.
 * Vendors and collections will no longer show items exclusive to platforms other than the current account's platform.
+* Fix masterworks not showing as masterworks.
 
 # 4.51.2 (2018-05-09)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Collection exotics are no longer duplicated. They are also sorted by name.
 * Updated max power to 380.
+* Vendors and collections will no longer show items exclusive to platforms other than the current account's platform.
 
 # 4.51.2 (2018-05-09)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next
 
+* Collection exotics are no longer duplicated. They are also sorted by name.
+* Updated max power to 380.
+
 # 4.51.2 (2018-05-09)
 
 * Handle the Warmind API bug better, and provide helpful info on how to fix it.

--- a/src/app/collections/collections.tsx
+++ b/src/app/collections/collections.tsx
@@ -135,7 +135,17 @@ function Kiosk({
 
   // TODO: Some items have flavor (emblems)
   const reviewCache: D2ReviewDataCache | undefined = trackerService ? trackerService.getD2ReviewDataCache() : undefined;
-  const vendorItems = vendorDef.itemList.map((i, index) => new VendorItem(defs, vendorDef, i, reviewCache, undefined, undefined, items.some((k) => k.index === index && k.canAcquire)));
+
+  // Work around https://github.com/Bungie-net/api/issues/480
+  const itemList = _.map(_.groupBy(vendorDef.itemList, (i) => i.itemHash), (l) => {
+    if (l.length === 0) {
+      return l[0];
+    } else {
+      return l.find((i) => items.some((k) => k.index === i.vendorItemIndex)) || l[0];
+    }
+  });
+
+  const vendorItems = itemList.map((i) => new VendorItem(defs, vendorDef, i, reviewCache, undefined, undefined, items.some((k) => k.index === i.vendorItemIndex && k.canAcquire)));
 
   return (
     <div className="vendor-char-items">

--- a/src/app/collections/collections.tsx
+++ b/src/app/collections/collections.tsx
@@ -16,6 +16,8 @@ import { fetchRatingsForKiosks } from '../d2-vendors/vendor-ratings';
 import { Subscription } from 'rxjs/Subscription';
 import { DimStore, StoreServiceType } from '../inventory/store-types';
 import { t } from 'i18next';
+import { VendorItem } from '../d2-vendors/vendor-item';
+import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
 
 interface Props {
   $scope: IScope;
@@ -132,16 +134,17 @@ function Kiosk({
   const vendorDef = defs.Vendor.get(vendorHash);
 
   // TODO: Some items have flavor (emblems)
+  const reviewCache: D2ReviewDataCache | undefined = trackerService ? trackerService.getD2ReviewDataCache() : undefined;
+  const vendorItems = vendorDef.itemList.map((i, index) => new VendorItem(defs, vendorDef, i, reviewCache, undefined, undefined, items.some((k) => k.index === index && k.canAcquire)));
 
   return (
     <div className="vendor-char-items">
       <VendorItems
         defs={defs}
         vendorDef={vendorDef}
-        kioskItems={items.filter((i) => i.canAcquire)}
+        vendorItems={vendorItems}
         trackerService={trackerService}
         ownedItemHashes={ownedItemHashes}
-        currencyLookups={{}}
       />
     </div>
   );

--- a/src/app/collections/collections.tsx
+++ b/src/app/collections/collections.tsx
@@ -1,7 +1,7 @@
 import { StateParams } from '@uirouter/angularjs';
 import { IScope } from 'angular';
 import {
-  DestinyProfileResponse, DestinyKioskItem
+  DestinyProfileResponse, DestinyKioskItem, BungieMembershipType
 } from 'bungie-api-ts/destiny2';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -81,6 +81,7 @@ export default class Collections extends React.Component<Props, State> {
 
   render() {
     const { defs, profileResponse, trackerService, ownedItemHashes } = this.state;
+    const { account } = this.props;
 
     if (!profileResponse || !defs) {
       // TODO: loading component!
@@ -104,6 +105,7 @@ export default class Collections extends React.Component<Props, State> {
             items={itemsForKiosk(profileResponse, Number(vendorHash))}
             trackerService={trackerService}
             ownedItemHashes={ownedItemHashes}
+            account={account}
           />
         )}
         <a className="collections-partner dim-button" target="_blank" rel="noopener" href="https://destinysets.com">
@@ -123,13 +125,15 @@ function Kiosk({
   vendorHash,
   items,
   trackerService,
-  ownedItemHashes
+  ownedItemHashes,
+  account
 }: {
   defs: D2ManifestDefinitions;
   vendorHash: number;
   items: DestinyKioskItem[];
   trackerService?: DestinyTrackerServiceType;
   ownedItemHashes?: Set<number>;
+  account: DestinyAccount;
 }) {
   const vendorDef = defs.Vendor.get(vendorHash);
 
@@ -143,7 +147,11 @@ function Kiosk({
     } else {
       return l.find((i) => items.some((k) => k.index === i.vendorItemIndex)) || l[0];
     }
-  });
+  }).filter((i) =>
+    !i.exclusivity ||
+    i.exclusivity === BungieMembershipType.All ||
+    i.exclusivity === account.platformType
+  );
 
   const vendorItems = itemList.map((i) => new VendorItem(defs, vendorDef, i, reviewCache, undefined, undefined, items.some((k) => k.index === i.vendorItemIndex && k.canAcquire)));
 

--- a/src/app/d2-vendors/single-vendor.tsx
+++ b/src/app/d2-vendors/single-vendor.tsx
@@ -103,6 +103,7 @@ export default class SingleVendor extends React.Component<Props, State> {
 
   render() {
     const { defs, vendorDef, vendorResponse, trackerService, ownedItemHashes } = this.state;
+    const { account } = this.props;
 
     if (!vendorDef || !defs) {
       // TODO: loading component!
@@ -127,7 +128,7 @@ export default class SingleVendor extends React.Component<Props, State> {
     const placeString = [(destinationDef && destinationDef.displayProperties.name), (placeDef && placeDef.displayProperties.name)].filter((n) => n && n.length).join(', ');
     // TODO: there's a cool background image but I'm not sure how to use it
 
-    const vendorItems = getVendorItems(defs, vendorDef, trackerService, vendorResponse && vendorResponse.itemComponents, vendorResponse && vendorResponse.sales.data);
+    const vendorItems = getVendorItems(account, defs, vendorDef, trackerService, vendorResponse && vendorResponse.itemComponents, vendorResponse && vendorResponse.sales.data);
 
     // TODO: localize
     return (

--- a/src/app/d2-vendors/single-vendor.tsx
+++ b/src/app/d2-vendors/single-vendor.tsx
@@ -15,6 +15,7 @@ import { fetchRatingsForVendor, fetchRatingsForVendorDef } from './vendor-rating
 import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
 import { Subscription } from 'rxjs/Subscription';
 import { D2StoreServiceType, D2Store } from '../inventory/store-types';
+import { getVendorItems } from './vendors';
 
 interface Props {
   $scope: IScope;
@@ -126,6 +127,8 @@ export default class SingleVendor extends React.Component<Props, State> {
     const placeString = [(destinationDef && destinationDef.displayProperties.name), (placeDef && placeDef.displayProperties.name)].filter((n) => n && n.length).join(', ');
     // TODO: there's a cool background image but I'm not sure how to use it
 
+    const vendorItems = getVendorItems(defs, vendorDef, trackerService, vendorResponse && vendorResponse.itemComponents, vendorResponse && vendorResponse.sales.data);
+
     // TODO: localize
     return (
       <div className="vendor dim-page">
@@ -147,8 +150,7 @@ export default class SingleVendor extends React.Component<Props, State> {
         <VendorItems
           defs={defs}
           vendorDef={vendorDef}
-          sales={vendorResponse && vendorResponse.sales.data}
-          itemComponents={vendorResponse && vendorResponse.itemComponents}
+          vendorItems={vendorItems}
           trackerService={trackerService}
           ownedItemHashes={ownedItemHashes}
           currencyLookups={vendorResponse ? vendorResponse.currencyLookups.data.itemQuantities : {}}

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -14,6 +14,7 @@ import { InventoryBuckets } from "../inventory/inventory-buckets";
  *
  * This is the pattern I want to follow for our main items!
  */
+// TODO: Replace with DimItem
 export class VendorItem {
   canPurchase: boolean;
   private itemComponents?: DestinyItemComponentSetOfint32;

--- a/src/app/d2-vendors/vendor-items.tsx
+++ b/src/app/d2-vendors/vendor-items.tsx
@@ -1,53 +1,34 @@
-import {
-  DestinyItemComponentSetOfint32,
-  DestinyVendorDefinition,
-  DestinyVendorSaleItemComponent,
-  DestinyKioskItem
-} from 'bungie-api-ts/destiny2';
+import { DestinyVendorDefinition } from 'bungie-api-ts/destiny2';
+import { t } from 'i18next';
 import * as React from 'react';
 import * as _ from 'underscore';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
-import { VendorItem } from './vendor-item';
-import VendorItemComponent from './VendorItemComponent';
-import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
+import { BungieImage, bungieBackgroundStyle } from '../dim-ui/bungie-image';
 import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
-import { bungieBackgroundStyle, BungieImage } from '../dim-ui/bungie-image';
 import { $state } from '../ngimport-more';
-import { t } from 'i18next';
 import { compact } from '../util';
-import { D2Store } from '../inventory/store-types';
+import VendorItemComponent from './VendorItemComponent';
+import { VendorItem } from './vendor-item';
 
 export default function VendorItems({
   vendorDef,
   defs,
-  itemComponents,
-  sales,
-  kioskItems,
+  vendorItems,
   trackerService,
   ownedItemHashes,
   currencyLookups
 }: {
-  defs: D2ManifestDefinitions;
   vendorDef: DestinyVendorDefinition;
-  itemComponents?: DestinyItemComponentSetOfint32;
-  sales?: {
-    [key: string]: DestinyVendorSaleItemComponent;
-  };
-  kioskItems?: DestinyKioskItem[];
+  defs: D2ManifestDefinitions;
+  vendorItems: VendorItem[];
   trackerService?: DestinyTrackerServiceType;
-  stores?: D2Store[];
   ownedItemHashes?: Set<number>;
-  currencyLookups: {
+  currencyLookups?: {
     [itemHash: number]: number;
   };
 }) {
-  const reviewCache: D2ReviewDataCache | undefined = (trackerService) ? trackerService.getD2ReviewDataCache() : undefined;
-
-  // TODO: do this stuff in setState handlers
-  const items = getItems(defs, vendorDef, reviewCache, itemComponents, sales, kioskItems);
-
   // TODO: sort items, maybe subgroup them
-  const itemsByCategory = _.groupBy(items, (item: VendorItem) => item.displayCategoryIndex);
+  const itemsByCategory = _.groupBy(vendorItems, (item: VendorItem) => item.displayCategoryIndex);
 
   const faction = vendorDef.factionHash ? defs.Faction[vendorDef.factionHash] : undefined;
   const rewardVendorHash = faction && faction.rewardVendorHash || undefined;
@@ -55,7 +36,7 @@ export default function VendorItems({
   const goToRewardVendor = rewardVendorHash && (() => $state.go('destiny2.vendor', { id: rewardVendorHash }));
 
   const vendorCurrencyHashes = new Set<number>();
-  for (const item of items) {
+  for (const item of vendorItems) {
     for (const cost of item.costs) {
       vendorCurrencyHashes.add(cost.itemHash);
     }
@@ -67,7 +48,7 @@ export default function VendorItems({
       {vendorCurrencies.length > 0 && <div className="vendor-currencies">
         {vendorCurrencies.map((currency) =>
           <div className="vendor-currency" key={currency.hash}>
-            {currencyLookups[currency.hash] || 0}{' '}
+            {(currencyLookups && currencyLookups[currency.hash]) || 0}{' '}
             <BungieImage src={currency.displayProperties.icon} title={currency.displayProperties.name}/>
           </div>
         )}
@@ -100,35 +81,4 @@ export default function VendorItems({
       )}
     </div>
   );
-}
-
-// TODO: do this in parent components, pass in the right thing
-function getItems(
-  defs: D2ManifestDefinitions,
-  vendorDef: DestinyVendorDefinition,
-  reviewCache?: D2ReviewDataCache,
-  itemComponents?: DestinyItemComponentSetOfint32,
-  sales?: {
-    [key: string]: DestinyVendorSaleItemComponent;
-  },
-  kioskItems?: DestinyKioskItem[]
-) {
-  if (kioskItems) {
-    return vendorDef.itemList.map((i, index) => new VendorItem(defs, vendorDef, i, reviewCache, undefined, undefined, kioskItems.some((k) => k.index === index)));
-  } else if (sales && itemComponents) {
-    const components = Object.values(sales);
-    return components.map((component) => new VendorItem(
-      defs,
-      vendorDef,
-      vendorDef.itemList[component.vendorItemIndex],
-      reviewCache,
-      component,
-      itemComponents
-    ));
-  } else if (vendorDef.returnWithVendorRequest) {
-    // If the sales should come from the server, don't show anything until we have them
-    return [];
-  } else {
-    return vendorDef.itemList.map((i) => new VendorItem(defs, vendorDef, i, reviewCache));
-  }
 }

--- a/src/app/d2-vendors/vendor-items.tsx
+++ b/src/app/d2-vendors/vendor-items.tsx
@@ -67,7 +67,7 @@ export default function VendorItems({
         <div className="vendor-row" key={categoryIndex}>
           <h3 className="category-title">{vendorDef.displayCategories[categoryIndex] && vendorDef.displayCategories[categoryIndex].displayProperties.name || 'Unknown'}</h3>
           <div className="vendor-items">
-          {items.map((item) =>
+          {_.sortBy(items, (i) => i.displayProperties.name).map((item) =>
             <VendorItemComponent
               key={item.key}
               defs={defs}

--- a/src/app/destiny2/d2-buckets.service.ts
+++ b/src/app/destiny2/d2-buckets.service.ts
@@ -26,7 +26,6 @@ export const D2Categories = {
     'Vehicle',
     'Ships',
     'Emblems',
-    'Emotes',
     'Engrams'
   ],
   Inventory: [
@@ -56,7 +55,6 @@ const bucketToType: { [hash: number]: string | undefined } = {
   2689798310: "Silver",
   2689798311: "Bright Dust",
   2973005342: "Shaders",
-  3054419239: "Emotes",
   3161908920: "Messages",
   3284755031: "Class",
   3313201758: "Modifications",
@@ -78,7 +76,9 @@ const bucketToType: { [hash: number]: string | undefined } = {
   1585787867: "ClassItem",
   2025709351: "Vehicle",
   1469714392: "Consumables",
-  138197802: "General"
+  138197802: "General",
+  1107761855: "Emotes",
+  1345459588: "Pursuits"
 };
 
 const typeToSort: { [type: string]: string } = {};

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -488,9 +488,13 @@ export function makeItem(
   createdItem.infusionQuality = itemDef.quality || null;
 
   // Masterwork
-  if (createdItem.masterwork && createdItem.sockets) {
+  if (createdItem.sockets) {
     try {
       createdItem.masterworkInfo = buildMasterworkInfo(createdItem.sockets, defs);
+      // TODO: this is a temporary fix for https://github.com/Bungie-net/api/issues/469
+      if (createdItem.masterworkInfo) {
+        createdItem.masterwork = true;
+      }
     } catch (e) {
       console.error(`Error building masterwork info for ${createdItem.name}`, item, itemDef, e);
     }

--- a/src/app/progress/progress.tsx
+++ b/src/app/progress/progress.tsx
@@ -330,6 +330,11 @@ export class Progress extends React.Component<Props, State> {
     const filteredItems = allItems.filter((item) => {
       const itemDef = defs.InventoryItem.get(item.itemHash);
 
+      // Pursuits
+      if (itemDef.inventory && itemDef.inventory.bucketTypeHash === 1345459588) {
+        return true;
+      }
+
       // This required a lot of trial and error.
       return (itemDef.itemCategoryHashes &&
           (


### PR DESCRIPTION
1. Remove the emotes bucket. I can show the emote wheel, but it doesn't look good yet and you can't do anything with it.
2. Leverage the pursuits bucket to accurately fill out quests in the Progress page.
3. Fix duplicate collections bug (from https://github.com/Bungie-net/api/issues/480)