### PR TITLE
Set max base power based on owned Destiny version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Set the max base power depending on which DLC you own.
+
 # 4.51.2 (2018-05-09)
 
 * Handle the Warmind API bug better, and provide helpful info on how to fix it.

--- a/src/app/accounts/destiny-account.service.ts
+++ b/src/app/accounts/destiny-account.service.ts
@@ -1,6 +1,6 @@
 import { IPromise } from 'angular';
 import { BungieMembershipType } from 'bungie-api-ts/common';
-import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
+import { PlatformErrorCodes, DestinyGameVersions } from 'bungie-api-ts/destiny2';
 import { UserMembershipData } from 'bungie-api-ts/user';
 import { t } from 'i18next';
 import { $q } from 'ngimport';
@@ -38,6 +38,8 @@ export interface DestinyAccount {
   membershipId: string;
   /** Which version of Destiny is this account for? */
   destinyVersion: 1 | 2;
+  /** Which version of Destiny 2 / DLC do they own? */
+  versionsOwned?: DestinyGameVersions;
 }
 
 /**
@@ -102,7 +104,8 @@ function findD2Characters(account: DestinyAccount): IPromise<DestinyAccount | nu
         response.profile.data.characterIds.length) {
         const result: DestinyAccount = {
           ...account,
-          destinyVersion: 2
+          destinyVersion: 2,
+          versionsOwned: response.profile.data.versionsOwned
         };
         return result;
       }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -141,10 +141,10 @@ export interface D2CharacterStat {
   id: number;
   name: string;
   description: string;
-  value: number;
+  value: number | string;
   icon: string;
   tierMax?: number;
-  tiers?: number[];
+  tiers?: number[] | string[];
   hasClassified?: boolean;
 }
 
@@ -200,7 +200,7 @@ export interface D2Store extends DimStore {
   buckets: { [bucketId: string]: D2Item[] };
   vault?: D2Vault;
   stats: {
-    basePower?: D2CharacterStat;
+    maxBasePower?: D2CharacterStat;
     [statHash: number]: D2CharacterStat;
   };
   updateCharacterInfo(


### PR DESCRIPTION
This uses the version of Destiny you own (Base, DLC1, etc) to set max base power. We can use this to set up base power for upcoming DLC as well.