### PR TITLE
Deprecate >1yo browsers and enable ES6 uglify

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,13 +4,12 @@
       "modules": false,
       "useBuiltIns": true,
       "targets": {
-        "uglify": true,
         "browsers": [
-          "Chrome >= 51",
+          "last 2 Chrome versions",
           "last 2 ChromeAndroid versions",
           "last 2 Firefox versions",
           "last 2 Safari versions",
-          "iOS >= 10",
+          "iOS >= 10.3",
           "last 2 Edge versions",
           "last 2 Opera versions"
         ]

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -68,6 +68,7 @@ module.exports = (env) => {
           parallel: true,
           exclude: [/sqlLib/, /sql-wasm/], // ensure the sqlLib chunk doesnt get minifed
           uglifyOptions: {
+            ecma: 8,
             compress: { warnings: false },
             output: { comments: false }
           },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "last 2 ChromeAndroid versions",
     "last 2 Firefox versions",
     "last 2 Safari versions",
-    "iOS >= 10",
+    "iOS >= 10.3",
     "last 2 Edge versions",
     "last 2 Opera versions",
     "unreleased versions"


### PR DESCRIPTION
This change deprecates some holdout browsers we had hardcoded support for. They are now more than a year old. Chrome 51 was there because somebody didn't like the way fonts rendered after that (which is understandable, but that ship has sailed), and iOS 10.0-10.2 was there because it was still kinda popular (it now represents ~0.39% of global usage).

Doing this gets us:

1. async functions natively
2. generators natively
3. CSS grid
4. A reduction of about 90K in our bundle size (before compression)

This also turns on new-syntax support through Uglify. The last several times I tried this it resulted in the site not loading and had to be rolled back, but this is a different attempt. Weirdly I've never been able to repro the problem locally so I'll just have to try it.