### PR TITLE
Add back emotes (via PlugSets) to collections page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Next
 
 * Add previews for engrams and other preview-able items.
+* Add emotes back to the collections page.
+* Remove masterwork objectives that never complete.
+* Fix loading loadouts the first time you open a character menu.
+* Fix exporting CSV inventories in Firefox.
 
 # 4.52.0 (2018-05-13)
 

--- a/src/app/collections/Kiosk.tsx
+++ b/src/app/collections/Kiosk.tsx
@@ -48,7 +48,7 @@ export default function Kiosk({
     i.exclusivity === account.platformType
   );
 
-  const vendorItems = itemList.map((i) => new VendorItem(defs, vendorDef, i, reviewCache, undefined, undefined, items.some((k) => k.index === i.vendorItemIndex && k.canAcquire)));
+  const vendorItems = itemList.map((i) => VendorItem.forKioskItem(defs, vendorDef, i, items.some((k) => k.index === i.vendorItemIndex && k.canAcquire), reviewCache));
 
   return (
     <div className="vendor-char-items">

--- a/src/app/collections/PlugSet.tsx
+++ b/src/app/collections/PlugSet.tsx
@@ -1,0 +1,52 @@
+import {
+  DestinyItemPlug
+} from 'bungie-api-ts/destiny2';
+import * as React from 'react';
+import * as _ from 'underscore';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import './collections.scss';
+import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { VendorItem } from '../d2-vendors/vendor-item';
+import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
+import VendorItemComponent from '../d2-vendors/VendorItemComponent';
+
+/**
+ * A single plug set.
+ */
+export default function PlugSet({
+  defs,
+  plugSetHash,
+  items,
+  trackerService
+}: {
+  defs: D2ManifestDefinitions;
+  plugSetHash: number;
+  items: DestinyItemPlug[];
+  trackerService?: DestinyTrackerServiceType;
+  ownedItemHashes?: Set<number>;
+}) {
+  const plugSetDef = defs.PlugSet.get(plugSetHash);
+
+  const reviewCache: D2ReviewDataCache | undefined = trackerService ? trackerService.getD2ReviewDataCache() : undefined;
+
+  const vendorItems = plugSetDef.reusablePlugItems.map((i) => VendorItem.forPlugSetItem(defs, i, reviewCache, items.some((k) => k.plugItemHash === i.plugItemHash && k.enabled)));
+
+  return (
+    <div className="vendor-char-items">
+      <div className="vendor-row">
+        <h3 className="category-title">{defs.InventoryItem.get(plugSetDef.reusablePlugItems[0].plugItemHash).itemTypeDisplayName}</h3>
+        <div className="vendor-items">
+        {_.sortBy(vendorItems, (i) => i.displayProperties.name).map((item) =>
+          <VendorItemComponent
+            key={item.key}
+            defs={defs}
+            item={item}
+            trackerService={trackerService}
+            owned={false}
+          />
+        )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/d2-vendors/Vendor.tsx
+++ b/src/app/d2-vendors/Vendor.tsx
@@ -91,13 +91,12 @@ export function getVendorItems(
 
   if (sales && itemComponents) {
     const components = Object.values(sales);
-    return components.map((component) => new VendorItem(
+    return components.map((component) => VendorItem.forVendorSaleItem(
       defs,
       vendorDef,
-      vendorDef.itemList[component.vendorItemIndex],
-      reviewCache,
       component,
-      itemComponents
+      reviewCache,
+      itemComponents,
     ));
   } else if (vendorDef.returnWithVendorRequest) {
     // If the sales should come from the server, don't show anything until we have them
@@ -107,6 +106,6 @@ export function getVendorItems(
       !i.exclusivity ||
       i.exclusivity === BungieMembershipType.All ||
       i.exclusivity === account.platformType
-    ).map((i) => new VendorItem(defs, vendorDef, i, reviewCache));
+    ).map((i) => VendorItem.forVendorDefinitionItem(defs, vendorDef, i, reviewCache));
   }
 }

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -23,7 +23,8 @@ import {
   DestinyDestinationDefinition,
   DestinyPlaceDefinition,
   DestinyVendorGroupDefinition,
-  DestinyActivityModeDefinition
+  DestinyActivityModeDefinition,
+  DestinyPlugSetDefinition
   } from 'bungie-api-ts/destiny2';
 import { $q } from 'ngimport';
 import * as _ from 'underscore';
@@ -46,7 +47,8 @@ const lazyTables = [
   'Milestone',
   'Destination',
   'Place',
-  'VendorGroup'
+  'VendorGroup',
+  'PlugSet'
 ];
 
 const eagerTables = [
@@ -81,6 +83,7 @@ export interface D2ManifestDefinitions {
   Destination: LazyDefinition<DestinyDestinationDefinition>;
   Place: LazyDefinition<DestinyPlaceDefinition>;
   VendorGroup: LazyDefinition<DestinyVendorGroupDefinition>;
+  PlugSet: LazyDefinition<DestinyPlugSetDefinition>;
 
   InventoryBucket: { [hash: number]: DestinyInventoryBucketDefinition };
   Class: { [hash: number]: DestinyClassDefinition };

--- a/src/app/dim-ui/ErrorBoundary.scss
+++ b/src/app/dim-ui/ErrorBoundary.scss
@@ -1,0 +1,13 @@
+.dim-error {
+  margin: 1em 0;
+  padding: 1em;
+  border: 2px solid rgba(255, 255, 255, .5);
+  h2 {
+    margin: 0 0 1em 0;
+  }
+  a {
+    color: white;
+    font-size: 12px;
+  }
+  background-color: #bd362f !important;
+}

--- a/src/app/dim-ui/ErrorBoundary.tsx
+++ b/src/app/dim-ui/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { reportException } from '../exceptions';
+import { t } from 'i18next';
+import './ErrorBoundary.scss';
+
+interface Props {
+  name: string;
+}
+
+interface State {
+  error?: Error;
+}
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = { };
+  }
+
+  componentDidCatch(error: Error) {
+    this.setState({ error });
+    reportException(this.props.name, error);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="dim-error">
+          <h2>{t('ErrorBoundary.Title')}</h2>
+          <div>{this.state.error.message}</div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/app/exceptions.ts
+++ b/src/app/exceptions.ts
@@ -1,5 +1,5 @@
 /** Sentry.io exception reporting */
-export let reportException: (name, e) => void = () => { return; };
+export let reportException: (name: string, e: Error) => void = () => { return; };
 
 if ($featureFlags.sentry) {
   // The require instead of import helps us trim this from the production bundle
@@ -25,7 +25,7 @@ if ($featureFlags.sentry) {
     .addPlugin(require('raven-js/plugins/angular'), require('angular'))
     .install();
 
-  reportException = (name, e) => {
+  reportException = (name: string, e: Error) => {
     // TODO: we can also do this in some situations to gather more feedback from users
     // Raven.showReportDialog();
     Raven.captureException(e, { extra: { context: name } });

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -124,6 +124,9 @@
     "VerifyReport": "Are you sure you want to flag this review?",
     "YourReview": "Your Review"
   },
+  "ErrorBoundary": {
+    "Title": "Something went wrong"
+  },
   "Faction": {
     "EngramsAvailable": "1 engram available",
     "EngramsAvailable_plural": "{{count}} engrams available"


### PR DESCRIPTION
This restores emotes to the collections page - they moved to a new concept called PlugSets which took some new code to fix.

I also finally introduced an `ErrorBoundary` component that can limit the blast radius of errors while rendering component trees. Used correctly this should let us limit errors to only a small part of the UI.