### PR TITLE
Add Crucible ranks to Progress page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * Add previews for engrams and other preview-able items.
+* Display Crucible ranks on the progress page.
 
 # 4.52.0 (2018-05-13)
 

--- a/src/app/progress/CrucibleRank.scss
+++ b/src/app/progress/CrucibleRank.scss
@@ -1,0 +1,27 @@
+@import '../../scss/variables.scss';
+
+.crucible-rank-icon {
+  margin: 2px 10px -2px 2px;
+  position: relative;
+  display: inline-block;
+  width: 64px;
+  height: 64px;
+}
+
+.crucible-rank-progress {
+  stroke: $orange;
+  fill: none;
+}
+
+@include phone-portrait {
+  .crucible-ranks {
+    .progress-for-character {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+
+    .faction {
+      flex: 1;
+    }
+  }
+}

--- a/src/app/progress/CrucibleRank.tsx
+++ b/src/app/progress/CrucibleRank.tsx
@@ -1,0 +1,79 @@
+import {
+  DestinyProgression
+} from 'bungie-api-ts/destiny2';
+import * as React from 'react';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import './faction.scss';
+import { bungieNetPath } from '../dim-ui/BungieImage';
+import './CrucibleRank.scss';
+
+interface CrucibleRankProps {
+  progress: DestinyProgression;
+  defs: D2ManifestDefinitions;
+}
+
+export function CrucibleRank(props: CrucibleRankProps) {
+  const { defs, progress } = props;
+
+  const progressionDef = defs.Progression.get(progress.progressionHash);
+
+  const step = progressionDef.steps[progress.level];
+
+  console.log(progress);
+
+  return (
+    <div className="faction" title={progressionDef.displayProperties.description}>
+      <div><CrucibleRankIcon progress={progress} defs={defs}/></div>
+      <div className="faction-info">
+        <div className="faction-level">{progressionDef.displayProperties.name}</div>
+        <div className="faction-name">{step.stepName}</div>
+        <div className="faction-level">
+          {progress.currentProgress} / {progress.nextLevelAt}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CrucibleRankIcon(props: {
+  progress: DestinyProgression;
+  defs: D2ManifestDefinitions;
+}) {
+  const { progress, defs } = props;
+
+  const progessionDef = defs.Progression.get(progress.progressionHash);
+
+  const step = progessionDef.steps[progress.level];
+
+  const circumference = 2 * 22 * Math.PI;
+
+  return (
+    <div className="crucible-rank-icon">
+      <svg viewBox="0 0 48 48">
+        <circle
+          r="24"
+          cx="24"
+          cy="24"
+          fill="#555"
+        />
+        <circle
+          r="21"
+          cx="24"
+          cy="24"
+          fill="#353535"
+        />
+        {progress.progressToNextLevel > 0 &&
+          <circle
+            r="22"
+            cx="-24"
+            cy="24"
+            transform="rotate(-90)"
+            className="crucible-rank-progress"
+            strokeWidth="3"
+            strokeDasharray={`${circumference * progress.progressToNextLevel / progress.nextLevelAt} ${circumference}`}
+          />}
+        <image xlinkHref={bungieNetPath(step.icon)} width="44" height="44" x="2" y="2" />
+      </svg>
+    </div>
+  );
+}

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -5,7 +5,10 @@ import {
   DestinyFactionProgression,
   DestinyItemComponent,
   DestinyMilestone,
-  DestinyObjectiveProgress
+  DestinyObjectiveProgress,
+  DestinyProgression,
+  DestinyFactionVendorDefinition,
+  DestinyFactionDefinition
 } from 'bungie-api-ts/destiny2';
 import { t } from 'i18next';
 import * as React from 'react';
@@ -26,6 +29,8 @@ import { ProgressProfile, reloadProgress, getProgressStream } from './progress.s
 import Quest from './Quest';
 import { settings, CharacterOrder } from '../settings/settings';
 import WellRestedPerkIcon from './WellRestedPerkIcon';
+import FactionIcon from './FactionIcon';
+import { CrucibleRank } from './CrucibleRank';
 
 /* Label isn't used, but it helps us understand what each one is */
 const progressionMeta = {
@@ -127,6 +132,15 @@ export class Progress extends React.Component<Props, State> {
 
     const profileMilestones = this.milestonesForProfile(characters[0]);
     const profileQuests = this.questItems(profileInfo.profileInventory.data.items);
+
+    const firstCharacterProgression = Object.values(profileInfo.characterProgressions.data)[0].progressions;
+    const crucibleRanks = [
+      // Valor
+      firstCharacterProgression[3882308435],
+      // Glory
+      firstCharacterProgression[2679551909]
+    ];
+
     const profileMilestonesContent = (profileMilestones.length > 0 || profileQuests.length > 0) && (
       <>
         <div className="profile-content">
@@ -151,6 +165,21 @@ export class Progress extends React.Component<Props, State> {
                 </div>
             </div>
           </div>}
+
+          <div className="section crucible-ranks">
+            <div className="title">{t('Progress.CrucibleRank')}</div>
+            <div className="progress-row">
+              <div className="progress-for-character">
+                {crucibleRanks.map((progression) =>
+                  <CrucibleRank
+                    key={progression.progressionHash}
+                    defs={defs}
+                    progress={progression}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
         </div>
         <hr/>
       </>

--- a/src/app/progress/faction.scss
+++ b/src/app/progress/faction.scss
@@ -10,17 +10,6 @@
     opacity: .4;
   }
 
-  .faction-icon {
-    margin: 2px 10px -2px 2px;
-    position: relative;
-    display: inline-block;
-
-    svg {
-      width: calc(var(--item-size) + 4px);
-      height: calc(var(--item-size) + 4px);
-    }
-  }
-
   .faction-info {
     display: flex;
     flex-direction: column;
@@ -34,10 +23,15 @@
     color: #A1A2A2;
   }
 
-  .faction-rewards {
-  }
-
   .purchase-unlocked {
     background-color: $gold;
   }
+}
+
+.faction-icon {
+  margin: 2px 10px -2px 2px;
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 48px;
 }

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -38,6 +38,10 @@
     flex: 1;
     margin: 12px;
     max-width: 276px;
+
+    @include phone-portrait {
+      max-width: none;
+    }
   }
 
   .profile-content {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -513,6 +513,7 @@
     "Limit": "Postmaster Limit"
   },
   "Progress": {
+    "CrucibleRank": "Crucible Ranks",
     "Daily": "Daily",
     "ExpiresIn": "expires at {{endTime}}",
     "Factions": "Factions",


### PR DESCRIPTION
This adds the new Crucible ranks to the Progress page as a third account-wide column (with different display for mobile).

Desktop:
<img width="924" alt="screen shot 2018-05-20 at 12 36 36 am" src="https://user-images.githubusercontent.com/313208/40276718-37515d90-5bc6-11e8-80cc-8725245c92d8.png">

Mobile:
<img width="211" alt="screen shot 2018-05-20 at 12 36 22 am" src="https://user-images.githubusercontent.com/313208/40276717-373ccd26-5bc6-11e8-91a1-cc04253c4677.png">

This fixes #2809.