### PR TITLE
Include mods/perks in D2 compare tool

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fix the display of crucible rank points.
 * Fix faction rank progress bars on D1.
-
+* Compare view includes perks and mods for D2 items.
 
 # 4.53.0 (2018-05-20)
 

--- a/src/app/compare/compare.component.ts
+++ b/src/app/compare/compare.component.ts
@@ -6,6 +6,7 @@ import { sum } from '../util';
 import { DimItem } from '../inventory/item-types';
 import { StoreServiceType } from '../inventory/store-types';
 import { CompareService } from './compare.service';
+import { TransitionService } from '@uirouter/angularjs';
 
 export function StatRangeFilter() {
   // Turns a stat and a list of ranges into a 0-100 scale
@@ -41,11 +42,23 @@ function CompareCtrl(
   toaster,
   dimStoreService: StoreServiceType,
   D2StoresService: StoreServiceType,
-  $i18next
+  $i18next,
+  $transitions: TransitionService
 ) {
   'ngInject';
 
   const vm = this;
+
+  vm.$onInit = () => {
+    this.listener = $transitions.onExit({}, () => {
+      CompareService.dialogOpen = false;
+      vm.show = false;
+    });
+  };
+
+  vm.$onDestroy = () => {
+    this.listener();
+  };
 
   function getStoreService(item: DimItem) {
     return item.destinyVersion === 2 ? D2StoresService : dimStoreService;

--- a/src/app/compare/compare.html
+++ b/src/app/compare/compare.html
@@ -30,6 +30,7 @@
         <span ng-if="stat.value && stat.qualityPercentage.range" class="range">({{::stat.qualityPercentage.range}})</span>
       </div>
       <dim-talent-grid ng-if="item.talentGrid" talent-grid="item.talentGrid"></dim-talent-grid>
+      <sockets ng-if="item.sockets" item="item"></sockets>
     </div>
   </div>
 </div>

--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -92,6 +92,30 @@ dim-compare {
   .spacer {
     height: 40px;
   }
+
+  .tip-text {
+    display: none;
+  }
+
+  .socket-container {
+    img {
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  .item-socket {
+    margin-right: 2px;
+
+  }
+  .item-socket-category-Reusable .item-socket {
+    border: none;
+    padding: 0;
+  }
+
+  .item-details {
+    clear: both;
+  }
 }
 
 @keyframes pop {

--- a/src/app/loadout/loadout-drawer.component.ts
+++ b/src/app/loadout/loadout-drawer.component.ts
@@ -10,9 +10,10 @@ import { settings } from '../settings/settings';
 import { getDefinitions as getD1Definitions } from '../destiny1/d1-definitions.service';
 import { getDefinitions as getD2Definitions } from '../destiny2/d2-definitions.service';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { Loadout } from './loadout.service';
+import { Loadout, LoadoutServiceType } from './loadout.service';
 import { DimStore } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
+import { TransitionService } from '@uirouter/angularjs';
 
 export const LoadoutDrawerComponent: IComponentOptions = {
   controller: LoadoutDrawerCtrl,
@@ -31,12 +32,24 @@ function LoadoutDrawerCtrl(
     loadout?: Loadout & { warnitems?: DimItem[] };
   },
   $scope: IScope,
-  dimLoadoutService,
+  dimLoadoutService: LoadoutServiceType,
   toaster,
-  $i18next
+  $i18next,
+  $transitions: TransitionService
 ) {
   'ngInject';
   const vm = this;
+
+  vm.$onInit = () => {
+    this.listener = $transitions.onExit({}, () => {
+      dimLoadoutService.dialogOpen = false;
+      vm.show = false;
+    });
+  };
+
+  vm.$onDestroy = () => {
+    this.listener();
+  };
 
   this.$onChanges = (changes) => {
     if (changes.stores) {

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -1,3 +1,5 @@
+@import '../../scss/variables.scss';
+
 #loadout-drawer {
   left: 0;
   right: 0;
@@ -10,6 +12,8 @@
   box-shadow: 0 -1px 6px 0px #222;
   padding-bottom: constant(safe-area-inset-bottom);
   padding-bottom: env(safe-area-inset-bottom);
+  // 10px below the character header
+  max-height: calc(100% - #{$header-height} - 82px - 10px);
 
   dim-stats {
     display: block;


### PR DESCRIPTION
This brings back the perk/mod display from D1:

<img width="903" alt="screen shot 2018-05-22 at 11 32 48 pm" src="https://user-images.githubusercontent.com/313208/40407288-c8a278fc-5e18-11e8-9f50-80e60436c20c.png">
<img width="1050" alt="screen shot 2018-05-22 at 11 33 01 pm" src="https://user-images.githubusercontent.com/313208/40407289-c8b757c2-5e18-11e8-9064-7d3d1db6df70.png">

I also made the loadout and compare drawers auto-close when we navigate to another page (they were broken otherwise).