### PR TITLE
Deangularize dimDestinyTrackerService

### DIFF
--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -10,7 +10,6 @@ import { getKiosks } from '../bungie-api/destiny2-api';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
 import { D2ManifestService } from '../manifest/manifest-service';
 import './collections.scss';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
 import { fetchRatingsForKiosks } from '../d2-vendors/vendor-ratings';
 import { Subscription } from 'rxjs/Subscription';
 import { DimStore, StoreServiceType } from '../inventory/store-types';
@@ -18,19 +17,19 @@ import Kiosk from './Kiosk';
 import { t } from 'i18next';
 import PlugSet from './PlugSet';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
+import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 
 interface Props {
   $scope: IScope;
   $stateParams: StateParams;
   account: DestinyAccount;
   D2StoresService: StoreServiceType;
-  dimDestinyTrackerService: DestinyTrackerServiceType;
 }
 
 interface State {
   defs?: D2ManifestDefinitions;
   profileResponse?: DestinyProfileResponse;
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   stores?: DimStore[];
   ownedItemHashes?: Set<number>;
 }
@@ -58,7 +57,7 @@ export default class Collections extends React.Component<Props, State> {
     const profileResponse = await getKiosks(this.props.account);
     this.setState({ profileResponse, defs });
 
-    const trackerService = await fetchRatingsForKiosks(defs, this.props.dimDestinyTrackerService, profileResponse);
+    const trackerService = await fetchRatingsForKiosks(defs, profileResponse);
     this.setState({ trackerService });
   }
 

--- a/src/app/collections/Kiosk.tsx
+++ b/src/app/collections/Kiosk.tsx
@@ -8,7 +8,7 @@ import { DestinyAccount } from '../accounts/destiny-account.service';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import './collections.scss';
 import VendorItems from '../d2-vendors/VendorItems';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { VendorItem } from '../d2-vendors/vendor-item';
 import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
 
@@ -26,7 +26,7 @@ export default function Kiosk({
   defs: D2ManifestDefinitions;
   vendorHash: number;
   items: DestinyKioskItem[];
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   ownedItemHashes?: Set<number>;
   account: DestinyAccount;
 }) {

--- a/src/app/collections/PlugSet.tsx
+++ b/src/app/collections/PlugSet.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import * as _ from 'underscore';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import './collections.scss';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { VendorItem } from '../d2-vendors/vendor-item';
 import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
 import VendorItemComponent from '../d2-vendors/VendorItemComponent';
@@ -22,7 +22,7 @@ export default function PlugSet({
   defs: D2ManifestDefinitions;
   plugSetHash: number;
   items: DestinyItemPlug[];
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   ownedItemHashes?: Set<number>;
 }) {
   const plugSetDef = defs.PlugSet.get(plugSetHash);

--- a/src/app/collections/collections.module.ts
+++ b/src/app/collections/collections.module.ts
@@ -5,7 +5,7 @@ import Collections from './Collections';
 
 // This is the Destiny 2 "collections" pages
 export const collectionsModule = module('d2collectionsModule', [])
-  .component('collections', react2angular(Collections, ['account'], ['$scope', '$stateParams', 'D2StoresService', 'dimDestinyTrackerService']))
+  .component('collections', react2angular(Collections, ['account'], ['$scope', '$stateParams', 'D2StoresService']))
   .config(($stateProvider: StateProvider) => {
     'ngInject';
 

--- a/src/app/d2-vendors/SingleVendor.tsx
+++ b/src/app/d2-vendors/SingleVendor.tsx
@@ -12,7 +12,7 @@ import FactionIcon from '../progress/FactionIcon';
 import VendorItems from './VendorItems';
 import './vendor.scss';
 import { fetchRatingsForVendor, fetchRatingsForVendorDef } from './vendor-ratings';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { Subscription } from 'rxjs/Subscription';
 import { D2StoreServiceType, D2Store } from '../inventory/store-types';
 import { getVendorItems } from './Vendor';
@@ -22,7 +22,6 @@ interface Props {
   $stateParams: StateParams;
   account: DestinyAccount;
   D2StoresService: D2StoreServiceType;
-  dimDestinyTrackerService: DestinyTrackerServiceType;
 }
 
 interface State {
@@ -32,7 +31,7 @@ interface State {
   defs?: D2ManifestDefinitions;
   vendorDef?: DestinyVendorDefinition;
   vendorResponse?: DestinyVendorResponse;
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
 }
 
 /**
@@ -77,10 +76,10 @@ export default class SingleVendor extends React.Component<Props, State> {
 
       this.setState({ defs, vendorResponse });
 
-      const trackerService = await fetchRatingsForVendor(defs, this.props.dimDestinyTrackerService, vendorResponse);
+      const trackerService = await fetchRatingsForVendor(defs, vendorResponse);
       this.setState({ trackerService });
     } else {
-      const trackerService = await fetchRatingsForVendorDef(defs, this.props.dimDestinyTrackerService, vendorDef);
+      const trackerService = await fetchRatingsForVendorDef(defs, vendorDef);
       this.setState({ trackerService });
     }
   }

--- a/src/app/d2-vendors/Vendor.tsx
+++ b/src/app/d2-vendors/Vendor.tsx
@@ -13,7 +13,7 @@ import Countdown from '../dim-ui/Countdown';
 import VendorItems from './VendorItems';
 import { $state } from '../ngimport-more';
 import './vendor.scss';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { VendorItem } from './vendor-item';
 import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
 
@@ -36,7 +36,7 @@ export default function Vendor({
   sales?: {
     [key: string]: DestinyVendorSaleItemComponent;
   };
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   ownedItemHashes?: Set<number>;
   currencyLookups: {
     [itemHash: number]: number;
@@ -81,7 +81,7 @@ export function getVendorItems(
   account: DestinyAccount,
   defs: D2ManifestDefinitions,
   vendorDef: DestinyVendorDefinition,
-  trackerService?: DestinyTrackerServiceType,
+  trackerService?: DestinyTrackerService,
   itemComponents?: DestinyItemComponentSetOfint32,
   sales?: {
     [key: string]: DestinyVendorSaleItemComponent;

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -8,7 +8,7 @@ import { ngDialog, $state } from "../ngimport-more";
 import { IDialogOpenResult } from "ng-dialog";
 import dialogTemplate from './vendor-item-dialog.html';
 import { getBuckets } from "../destiny2/d2-buckets.service";
-import { DestinyTrackerServiceType } from "../item-review/destiny-tracker.service";
+import { DestinyTrackerService } from "../item-review/destiny-tracker.service";
 import { dtrRatingColor } from "../shell/dimAngularFilters.filter";
 import { ratePerks } from "../destinyTrackerApi/d2-perkRater";
 import checkMark from '../../images/check.svg';
@@ -18,7 +18,7 @@ import { D2RatingData } from "../item-review/d2-dtr-api-types";
 interface Props {
   defs: D2ManifestDefinitions;
   item: VendorItem;
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   owned: boolean;
 }
 

--- a/src/app/d2-vendors/VendorItems.tsx
+++ b/src/app/d2-vendors/VendorItems.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import * as _ from 'underscore';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import BungieImage, { bungieBackgroundStyle } from '../dim-ui/BungieImage';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { $state } from '../ngimport-more';
 import { compact } from '../util';
 import VendorItemComponent from './VendorItemComponent';
@@ -24,7 +24,7 @@ export default function VendorItems({
   vendorDef: DestinyVendorDefinition;
   defs: D2ManifestDefinitions;
   vendorItems: VendorItem[];
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   ownedItemHashes?: Set<number>;
   currencyLookups?: {
     [itemHash: number]: number;

--- a/src/app/d2-vendors/Vendors.tsx
+++ b/src/app/d2-vendors/Vendors.tsx
@@ -11,7 +11,7 @@ import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definition
 import { D2ManifestService } from '../manifest/manifest-service';
 import { loadingTracker } from '../ngimport-more';
 import './vendor.scss';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
+import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { fetchRatingsForVendors } from './vendor-ratings';
 import { Subscription } from 'rxjs/Subscription';
 import { D2StoreServiceType, D2Store } from '../inventory/store-types';
@@ -22,13 +22,12 @@ interface Props {
   $stateParams: StateParams;
   account: DestinyAccount;
   D2StoresService: D2StoreServiceType;
-  dimDestinyTrackerService: DestinyTrackerServiceType;
 }
 
 interface State {
   defs?: D2ManifestDefinitions;
   vendorsResponse?: DestinyVendorsResponse;
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   stores?: D2Store[];
   ownedItemHashes?: Set<number>;
 }
@@ -65,7 +64,7 @@ export default class Vendors extends React.Component<Props, State> {
 
     this.setState({ defs, vendorsResponse });
 
-    const trackerService = await fetchRatingsForVendors(defs, this.props.dimDestinyTrackerService, vendorsResponse);
+    const trackerService = await fetchRatingsForVendors(defs, vendorsResponse);
     this.setState({ trackerService });
   }
 
@@ -134,7 +133,7 @@ function VendorGroup({
   defs: D2ManifestDefinitions;
   group: DestinyVendorGroup;
   vendorsResponse: DestinyVendorsResponse;
-  trackerService?: DestinyTrackerServiceType;
+  trackerService?: DestinyTrackerService;
   ownedItemHashes?: Set<number>;
   account: DestinyAccount;
 }) {

--- a/src/app/d2-vendors/vendor-ratings.ts
+++ b/src/app/d2-vendors/vendor-ratings.ts
@@ -1,4 +1,4 @@
-import { DestinyTrackerServiceType } from "../item-review/destiny-tracker.service";
+import { DestinyTrackerService, dimDestinyTrackerService } from "../item-review/destiny-tracker.service";
 import { DestinyVendorsResponse, DestinyVendorSaleItemComponent, DestinyVendorResponse, DestinyProfileResponse, DestinyVendorItemDefinition, DestinyVendorDefinition } from "bungie-api-ts/destiny2";
 import * as _ from "underscore";
 import { D2ManifestDefinitions } from "../destiny2/d2-definitions.service";
@@ -16,34 +16,31 @@ function isWeaponOrArmor(
 
 export async function fetchRatingsForVendors(
   defs: D2ManifestDefinitions,
-  destinyTrackerService: DestinyTrackerServiceType,
   vendorsResponse: DestinyVendorsResponse
-): Promise<DestinyTrackerServiceType> {
+): Promise<DestinyTrackerService> {
   const saleComponentArray = Object.values(vendorsResponse.sales.data)
     .map((saleItemComponent) => saleItemComponent.saleItems);
 
   const saleComponents = flatMap(saleComponentArray, (v) => Object.values(v))
     .filter((sc) => isWeaponOrArmor(defs, sc));
 
-  return destinyTrackerService.bulkFetchVendorItems(saleComponents);
+  return dimDestinyTrackerService.bulkFetchVendorItems(saleComponents);
 }
 
 export async function fetchRatingsForVendor(
   defs: D2ManifestDefinitions,
-  destinyTrackerService: DestinyTrackerServiceType,
   vendorResponse: DestinyVendorResponse
-): Promise<DestinyTrackerServiceType> {
+): Promise<DestinyTrackerService> {
   const saleComponents = Object.values(vendorResponse.sales.data)
     .filter((sc) => isWeaponOrArmor(defs, sc));
 
-  return destinyTrackerService.bulkFetchVendorItems(saleComponents);
+  return dimDestinyTrackerService.bulkFetchVendorItems(saleComponents);
 }
 
 export async function fetchRatingsForKiosks(
   defs: D2ManifestDefinitions,
-  destinyTrackerService: DestinyTrackerServiceType,
   profileResponse: DestinyProfileResponse
-): Promise<DestinyTrackerServiceType> {
+): Promise<DestinyTrackerService> {
   const kioskVendorHashes = new Set(Object.keys(profileResponse.profileKiosks.data.kioskItems));
   _.each(profileResponse.characterKiosks.data, (kiosk) => {
     _.each(kiosk.kioskItems, (_, kioskHash) => {
@@ -57,15 +54,14 @@ export async function fetchRatingsForKiosks(
     return vendorDef.itemList.filter((vid) => isWeaponOrArmor(defs, vid));
   });
 
-  return destinyTrackerService.bulkFetchKioskItems(vendorItems);
+  return dimDestinyTrackerService.bulkFetchKioskItems(vendorItems);
 }
 
 export async function fetchRatingsForVendorDef(
   defs: D2ManifestDefinitions,
-  destinyTrackerService: DestinyTrackerServiceType,
   vendorDef: DestinyVendorDefinition
-): Promise<DestinyTrackerServiceType> {
+): Promise<DestinyTrackerService> {
   const vendorItems = vendorDef.itemList.filter((vid) => isWeaponOrArmor(defs, vid));
 
-  return destinyTrackerService.bulkFetchKioskItems(vendorItems);
+  return dimDestinyTrackerService.bulkFetchKioskItems(vendorItems);
 }

--- a/src/app/d2-vendors/vendors.module.ts
+++ b/src/app/d2-vendors/vendors.module.ts
@@ -6,8 +6,8 @@ import Vendors from './Vendors';
 
 // This is the Destiny 2 "Vendors" pages
 export const d2VendorsModule = module('d2VendorsModule', [])
-  .component('d2Vendors', react2angular(Vendors, ['account'], ['$scope', '$stateParams', 'D2StoresService', 'dimDestinyTrackerService']))
-  .component('d2SingleVendor', react2angular(SingleVendor, ['account'], ['$scope', '$stateParams', 'D2StoresService', 'dimDestinyTrackerService']))
+  .component('d2Vendors', react2angular(Vendors, ['account'], ['$scope', '$stateParams', 'D2StoresService']))
+  .component('d2SingleVendor', react2angular(SingleVendor, ['account'], ['$scope', '$stateParams', 'D2StoresService']))
   .config(($stateProvider: StateProvider) => {
     'ngInject';
 

--- a/src/app/destinyTrackerApi/bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/bulkFetcher.ts
@@ -95,10 +95,10 @@ class BulkFetcher {
 
     vendors.forEach((vendor) => {
       vendor.allItems.forEach((vendorItem) => {
-        const matchingItem = this._reviewDataCache.getRatingData(vendorItem);
+        const matchingItem = this._reviewDataCache.getRatingData(vendorItem.item);
 
         if (matchingItem) {
-          vendorItem.dtrRating = matchingItem;
+          vendorItem.item.dtrRating = matchingItem;
         }
       });
     });

--- a/src/app/destinyTrackerApi/bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/bulkFetcher.ts
@@ -49,7 +49,7 @@ class BulkFetcher {
   bulkFetchVendorItems(vendorContainer: { [key: number]: Vendor }) {
     const vendors = Object.values(vendorContainer);
 
-    this._getBulkFetchPromise(vendors)
+    return this._getBulkFetchPromise(vendors)
       .then((bulkRankings) => this.attachVendorRankings(bulkRankings,
                                                         vendors));
   }

--- a/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
@@ -6,7 +6,6 @@ import { D2Item } from '../inventory/item-types';
 import { dtrFetch } from './dtr-service-helper';
 import { WorkingD2Rating } from '../item-review/d2-dtr-api-types';
 import { DtrReviewer } from '../item-review/dtr-api-types';
-import { $q } from 'ngimport';
 import { getRollAndPerks } from './d2-itemTransformer';
 
 /** Request to add a new rating (and optional review) for an item. */
@@ -92,13 +91,13 @@ class D2ReviewSubmitter {
     this._reviewDataCache.markItemAsReviewedAndSubmitted(item);
   }
 
-  submitReview(item: D2Item, membershipInfo: DestinyAccount | null) {
+  async submitReview(item: D2Item, membershipInfo: DestinyAccount | null) {
     if (!item.dtrRating ||
         !item.dtrRating.userReview) {
-      return $q.resolve();
+      return Promise.resolve();
     }
 
-    this._submitReviewPromise(item, membershipInfo)
+    return this._submitReviewPromise(item, membershipInfo)
       .then(() => {
         this._markItemAsReviewedAndSubmitted(item);
         this._eventuallyPurgeCachedData(item);

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -108,24 +108,24 @@ class D2ReviewsFetcher {
    * them to the item.
    * Attempts to fetch data from the cache first.
    */
-  getItemReviews(item: D2Item, platformSelection: number, mode: number) {
+  async getItemReviews(item: D2Item, platformSelection: number, mode: number) {
     if (!item.reviewable) {
-      return Promise.resolve();
+      return;
     }
 
     const cachedData = this._reviewDataCache.getRatingData(item);
 
-    if (cachedData && cachedData.reviewsResponse) {
+    if (cachedData) {
       item.dtrRating = cachedData;
-
-      return Promise.resolve();
+    }
+    if (cachedData && cachedData.reviewsResponse) {
+      return;
     }
 
     return this._getItemReviewsPromise(item, platformSelection, mode)
       .then((reviewData) => {
         this._markUserReview(reviewData);
-        this._attachReviews(item,
-                            reviewData);
+        this._attachReviews(item, reviewData);
       });
   }
 

--- a/src/app/destinyTrackerApi/itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/itemListBuilder.ts
@@ -29,7 +29,7 @@ function getNewItems(allItems: D1Item[], reviewDataCache: ReviewDataCache): D1It
 }
 
 function getAllItems(stores: (D1Store | Vendor)[]): D1Item[] {
-  return flatMap(stores, (store) => isVendor(store) ? store.allItems : store.items);
+  return flatMap(stores, (store) => isVendor(store) ? store.allItems.map((i) => i.item) : store.items);
 }
 
 function isVendor(store: D1Store | Vendor): store is Vendor {

--- a/src/app/destinyTrackerApi/reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/reviewSubmitter.ts
@@ -81,8 +81,8 @@ export class ReviewSubmitter {
     this._reviewDataCache.markItemAsReviewedAndSubmitted(item);
   }
 
-  submitReview(item, membershipInfo) {
-    this._submitReviewPromise(item, membershipInfo)
+  async submitReview(item, membershipInfo) {
+    return this._submitReviewPromise(item, membershipInfo)
       .then(() => {
         this._markItemAsReviewedAndSubmitted(item);
         this._eventuallyPurgeCachedData(item);

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -187,7 +187,7 @@ export class ReviewsFetcher {
    * them to the item.
    * Attempts to fetch data from the cache first.
    */
-  getItemReviews(item: D1Item) {
+  async getItemReviews(item: D1Item) {
     if (!item.reviewable) {
       return;
     }
@@ -197,9 +197,8 @@ export class ReviewsFetcher {
       return;
     }
 
-    this._getItemReviewsPromise(item)
+    return this._getItemReviewsPromise(item)
       .then((data) => this._translateReviewResponse(data))
-      .then((translatedData) => this._attachReviews(item,
-                                                    translatedData));
+      .then((translatedData) => this._attachReviews(item, translatedData));
   }
 }

--- a/src/app/inventory/d1-stores.service.ts
+++ b/src/app/inventory/d1-stores.service.ts
@@ -13,7 +13,6 @@ import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definition
 import { getBuckets } from '../destiny1/d1-buckets.service';
 import { NewItemsService } from './store/new-items.service';
 import { getItemInfoSource, ItemInfoSource } from './dim-item-info';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
 import { D1Currencies, makeCharacter, makeVault } from './store/d1-store-factory.service';
 import { $rootScope, $q } from 'ngimport';
 import { $stateParams, loadingTracker, toaster } from '../ngimport-more';
@@ -22,10 +21,9 @@ import { resetIdTracker, processItems } from './store/d1-item-factory.service';
 import { D1Store, D1Vault, D1StoreServiceType } from './store-types';
 import { D1Item } from './item-types';
 import { InventoryBuckets } from './inventory-buckets';
+import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 
-export function StoreService(
-  dimDestinyTrackerService: DestinyTrackerServiceType
-): D1StoreServiceType {
+export function StoreService(): D1StoreServiceType {
   'ngInject';
 
   let _stores: D1Store[] = [];

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -27,7 +27,6 @@ import { resetIdTracker, processItems } from './store/d2-item-factory.service';
 import { makeVault, makeCharacter } from './store/d2-store-factory.service';
 import { NewItemsService } from './store/new-items.service';
 import { getItemInfoSource, ItemInfoSource } from './dim-item-info';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
 import { $rootScope, $q } from 'ngimport';
 import { $stateParams, loadingTracker, toaster } from '../ngimport-more';
 import { t } from 'i18next';
@@ -35,14 +34,13 @@ import { D2Vault, D2Store, D2StoreServiceType } from './store-types';
 import { DimItem, D2Item } from './item-types';
 import { InventoryBuckets } from './inventory-buckets';
 import { DimError } from '../bungie-api/bungie-service-helper';
+import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 
 /**
  * TODO: For now this is a copy of StoreService customized for D2. Over time we should either
  * consolidate them, or at least organize them better.
  */
-export function D2StoresService(
-  dimDestinyTrackerService: DestinyTrackerServiceType
-): D2StoreServiceType {
+export function D2StoresService(): D2StoreServiceType {
   'ngInject';
 
   let _stores: D2Store[] = [];

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -18,186 +18,152 @@ import { DimItem } from '../inventory/item-types';
 import { D2ItemReviewResponse, WorkingD2Rating, D2ItemUserReview } from './d2-dtr-api-types';
 import { WorkingD1Rating, D1ItemUserReview } from './d1-dtr-api-types';
 import { DimUserReview } from './dtr-api-types';
+import { Vendor } from '../vendors/vendor.service';
 
-export interface DestinyTrackerServiceType {
-  bulkFetchVendorItems(vendorSaleItems: DestinyVendorSaleItemComponent[]): Promise<DestinyTrackerServiceType>;
-  bulkFetchKioskItems(vendorItems: DestinyVendorItemDefinition[]): Promise<DestinyTrackerServiceType>;
-  reattachScoresFromCache(stores: DimStore[]): void;
-  updateCachedUserRankings(item: DimItem, userReview: WorkingD1Rating | WorkingD2Rating);
-  updateVendorRankings(vendors: any);
-  getItemReviews(item: DimItem);
-  getItemReviewAsync(itemHash: number): IPromise<D2ItemReviewResponse>;
-  submitReview(item: DimItem);
-  fetchReviews(stores: DimStore[]);
-  reportReview(review: DimUserReview);
-  clearCache();
-  getD2ReviewDataCache(): D2ReviewDataCache;
-}
+/**
+ * Tools for interacting with the DTR-provided item ratings.
+ *
+ * The global instance of this can be imported as dimDestinyTrackerService
+ */
+export class DestinyTrackerService {
+  private _reviewDataCache = new ReviewDataCache();
+  private _bulkFetcher = new BulkFetcher(this._reviewDataCache);
+  private _reviewsFetcher = new ReviewsFetcher(this._reviewDataCache);
+  private _reviewSubmitter = new ReviewSubmitter(this._reviewDataCache);
+  private _reviewReporter = new ReviewReporter(this._reviewDataCache);
 
-export function DestinyTrackerService(): DestinyTrackerServiceType {
-  'ngInject';
+  private _d2reviewDataCache = new D2ReviewDataCache();
+  private _d2bulkFetcher = new D2BulkFetcher(this._d2reviewDataCache);
+  private _d2reviewsFetcher = new D2ReviewsFetcher(this._d2reviewDataCache);
+  private _d2reviewSubmitter = new D2ReviewSubmitter(this._d2reviewDataCache);
+  private _d2reviewReporter = new D2ReviewReporter(this._d2reviewDataCache);
 
-  const _reviewDataCache = new ReviewDataCache();
-  const _bulkFetcher = new BulkFetcher(_reviewDataCache);
-  const _reviewsFetcher = new ReviewsFetcher(_reviewDataCache);
-  const _reviewSubmitter = new ReviewSubmitter(_reviewDataCache);
-  const _reviewReporter = new ReviewReporter(_reviewDataCache);
+  reattachScoresFromCache(stores: DimStore[]): void {
+    if (!stores || !stores[0]) {
+      return;
+    }
 
-  const _d2reviewDataCache = new D2ReviewDataCache();
-  const _d2bulkFetcher = new D2BulkFetcher(_d2reviewDataCache);
-  const _d2reviewsFetcher = new D2ReviewsFetcher(_d2reviewDataCache);
-  const _d2reviewSubmitter = new D2ReviewSubmitter(_d2reviewDataCache);
-  const _d2reviewReporter = new D2ReviewReporter(_d2reviewDataCache);
-
-  function _isDestinyOne() {
-    return (settings.destinyVersion === 1);
+    if (stores[0].isDestiny1()) {
+      this._bulkFetcher.attachRankings(null,
+                                  stores as D1Store[]);
+    } else if (stores[0].isDestiny2()) {
+      this._d2bulkFetcher.attachRankings(null,
+                                    stores as D2Store[]);
+    }
   }
 
-  function _isDestinyTwo() {
-    return (settings.destinyVersion === 2);
+  updateCachedUserRankings(item: DimItem, userReview: WorkingD1Rating | WorkingD2Rating) {
+    if (item.isDestiny1()) {
+      this._reviewDataCache.addUserReviewData(item,
+                                          userReview as WorkingD1Rating);
+    } else if (item.isDestiny2()) {
+      this._d2reviewDataCache.addUserReviewData(item,
+                                            userReview as WorkingD2Rating);
+    }
   }
 
-  return {
-    reattachScoresFromCache(stores: DimStore[]): void {
-      if (!stores || !stores[0]) {
-        return;
-      }
+  async bulkFetchVendorItems(
+    vendorSaleItems: DestinyVendorSaleItemComponent[]
+  ): Promise<this> {
+    if (settings.showReviews) {
+      const platformSelection = settings.reviewsPlatformSelection;
+      const mode = settings.reviewsModeSelection;
+      await this._d2bulkFetcher.bulkFetchVendorItems(platformSelection, mode, vendorSaleItems);
+      return this;
+    }
 
-      if (stores[0].isDestiny1()) {
-        _bulkFetcher.attachRankings(null,
-                                    stores as D1Store[]);
-      } else if (stores[0].isDestiny2()) {
-        _d2bulkFetcher.attachRankings(null,
-                                      stores as D2Store[]);
-      }
-    },
+    return $q.when(this);
+  }
 
-    updateCachedUserRankings(item: DimItem, userReview: WorkingD1Rating | WorkingD2Rating) {
+  async bulkFetchKioskItems(
+    vendorItems: DestinyVendorItemDefinition[]
+  ): Promise<this> {
+    if (settings.showReviews) {
+      const platformSelection = settings.reviewsPlatformSelection;
+      const mode = settings.reviewsModeSelection;
+      await this._d2bulkFetcher.bulkFetchVendorItems(platformSelection, mode, undefined, vendorItems);
+      return this;
+    }
+
+    return $q.when(this);
+  }
+
+  getD2ReviewDataCache(): D2ReviewDataCache {
+    return this._d2bulkFetcher.getCache();
+  }
+
+  updateVendorRankings(vendors: { [key: number]: Vendor }) {
+    if (settings.showReviews) {
+      this._bulkFetcher.bulkFetchVendorItems(vendors);
+    }
+  }
+
+  getItemReviews(item: DimItem) {
+    if (settings.allowIdPostToDtr) {
       if (item.isDestiny1()) {
-        _reviewDataCache.addUserReviewData(item,
-                                           userReview as WorkingD1Rating);
+        this._reviewsFetcher.getItemReviews(item);
       } else if (item.isDestiny2()) {
-        _d2reviewDataCache.addUserReviewData(item,
-                                             userReview as WorkingD2Rating);
-      }
-    },
-
-    async bulkFetchVendorItems(
-      vendorSaleItems: DestinyVendorSaleItemComponent[]
-    ): Promise<DestinyTrackerServiceType> {
-      if (settings.showReviews) {
-        if (_isDestinyOne()) {
-          throw new Error(("This is a D2-only call."));
-        } else if (_isDestinyTwo()) {
-          const platformSelection = settings.reviewsPlatformSelection;
-          const mode = settings.reviewsModeSelection;
-          await _d2bulkFetcher.bulkFetchVendorItems(platformSelection, mode, vendorSaleItems);
-          return this;
-        }
-      }
-
-      return $q.when(this);
-    },
-
-    async bulkFetchKioskItems(
-      vendorItems: DestinyVendorItemDefinition[]
-    ): Promise<DestinyTrackerServiceType> {
-      if (settings.showReviews) {
-        if (_isDestinyOne()) {
-          throw new Error(("This is a D2-only call."));
-        } else if (_isDestinyTwo()) {
-          const platformSelection = settings.reviewsPlatformSelection;
-          const mode = settings.reviewsModeSelection;
-          await _d2bulkFetcher.bulkFetchVendorItems(platformSelection, mode, undefined, vendorItems);
-          return this;
-        }
-      }
-
-      return $q.when(this);
-    },
-
-    getD2ReviewDataCache(): D2ReviewDataCache {
-      return _d2bulkFetcher.getCache();
-    },
-
-    updateVendorRankings(vendors) {
-      if (settings.showReviews) {
-        if (_isDestinyOne()) {
-          _bulkFetcher.bulkFetchVendorItems(vendors);
-        } else if (_isDestinyTwo()) {
-          console.log("update vendor for D2 called");
-        }
-      }
-    },
-
-    getItemReviews(item: DimItem) {
-      if (settings.allowIdPostToDtr) {
-        if (item.isDestiny1()) {
-          _reviewsFetcher.getItemReviews(item);
-        } else if (item.isDestiny2()) {
-          const platformSelection = settings.reviewsPlatformSelection;
-          const mode = settings.reviewsModeSelection;
-          _d2reviewsFetcher.getItemReviews(item, platformSelection, mode);
-        }
-      }
-    },
-
-    submitReview(item: DimItem) {
-      if (settings.allowIdPostToDtr) {
-        const membershipInfo = getActivePlatform();
-
-        if (item.isDestiny1()) {
-          _reviewSubmitter.submitReview(item, membershipInfo);
-        } else if (item.isDestiny2()) {
-          _d2reviewSubmitter.submitReview(item, membershipInfo);
-        }
-      }
-    },
-
-    fetchReviews(stores: DimStore[]) {
-      if (!settings.showReviews ||
-          !stores ||
-          !stores[0]) {
-        return;
-      }
-
-      if (stores[0].isDestiny1()) {
-        _bulkFetcher.bulkFetch(stores as D1Store[]);
-      } else if (stores[0].isDestiny2()) {
         const platformSelection = settings.reviewsPlatformSelection;
         const mode = settings.reviewsModeSelection;
-        _d2bulkFetcher.bulkFetch(stores as D2Store[], platformSelection, mode);
-      }
-    },
-
-    getItemReviewAsync(itemHash: number): IPromise<D2ItemReviewResponse> {
-      if (settings.allowIdPostToDtr) {
-        if (_isDestinyOne()) {
-          console.error("This is a D2-only call.");
-        } else if (_isDestinyTwo()) {
-          const platformSelection = settings.reviewsPlatformSelection;
-          const mode = settings.reviewsModeSelection;
-          return _d2reviewsFetcher.fetchItemReviews(itemHash, platformSelection, mode);
-        }
-      }
-      return $q.when(this);
-    },
-
-    reportReview(review: DimUserReview) {
-      if (settings.allowIdPostToDtr) {
-        const membershipInfo = getActivePlatform();
-
-        if (_isDestinyOne()) {
-          _reviewReporter.reportReview(review as D1ItemUserReview, membershipInfo);
-        } else if (_isDestinyTwo()) {
-          _d2reviewReporter.reportReview(review as D2ItemUserReview, membershipInfo);
-        }
-      }
-    },
-    clearCache() {
-      if (_isDestinyTwo()) {
-        _d2reviewDataCache.clearAllItems();
+        this._d2reviewsFetcher.getItemReviews(item, platformSelection, mode);
       }
     }
-  };
+  }
+
+  submitReview(item: DimItem) {
+    if (settings.allowIdPostToDtr) {
+      const membershipInfo = getActivePlatform();
+
+      if (item.isDestiny1()) {
+        this._reviewSubmitter.submitReview(item, membershipInfo);
+      } else if (item.isDestiny2()) {
+        this._d2reviewSubmitter.submitReview(item, membershipInfo);
+      }
+    }
+  }
+
+  fetchReviews(stores: DimStore[]) {
+    if (!settings.showReviews ||
+        !stores ||
+        !stores[0]) {
+      return;
+    }
+
+    if (stores[0].isDestiny1()) {
+      this._bulkFetcher.bulkFetch(stores as D1Store[]);
+    } else if (stores[0].isDestiny2()) {
+      const platformSelection = settings.reviewsPlatformSelection;
+      const mode = settings.reviewsModeSelection;
+      this._d2bulkFetcher.bulkFetch(stores as D2Store[], platformSelection, mode);
+    }
+  }
+
+  getItemReviewAsync(itemHash: number): IPromise<D2ItemReviewResponse | undefined> {
+    if (settings.allowIdPostToDtr) {
+      const platformSelection = settings.reviewsPlatformSelection;
+      const mode = settings.reviewsModeSelection;
+      return this._d2reviewsFetcher.fetchItemReviews(itemHash, platformSelection, mode);
+    }
+    return $q.when(undefined);
+  }
+
+  reportReview(review: DimUserReview) {
+    if (settings.allowIdPostToDtr) {
+      const membershipInfo = getActivePlatform();
+
+      if (membershipInfo) {
+        if (membershipInfo.destinyVersion === 1) {
+          this._reviewReporter.reportReview(review as D1ItemUserReview, membershipInfo);
+        } else if (membershipInfo.destinyVersion === 2) {
+          this._d2reviewReporter.reportReview(review as D2ItemUserReview, membershipInfo);
+        }
+      }
+    }
+  }
+
+  clearCache() {
+    this._d2reviewDataCache.clearAllItems();
+  }
 }
+
+export const dimDestinyTrackerService = new DestinyTrackerService();

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -11,8 +11,6 @@ import { settings } from '../settings/settings';
 import { getActivePlatform } from '../accounts/platform.service';
 import { D2BulkFetcher } from '../destinyTrackerApi/d2-bulkFetcher';
 import { DestinyVendorSaleItemComponent, DestinyVendorItemDefinition } from 'bungie-api-ts/destiny2';
-import { IPromise } from 'angular';
-import { $q } from 'ngimport';
 import { DimStore, D2Store, D1Store } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
 import { D2ItemReviewResponse, WorkingD2Rating, D2ItemUserReview } from './d2-dtr-api-types';
@@ -72,7 +70,7 @@ export class DestinyTrackerService {
       return this;
     }
 
-    return $q.when(this);
+    return this;
   }
 
   async bulkFetchKioskItems(
@@ -85,44 +83,44 @@ export class DestinyTrackerService {
       return this;
     }
 
-    return $q.when(this);
+    return this;
   }
 
   getD2ReviewDataCache(): D2ReviewDataCache {
     return this._d2bulkFetcher.getCache();
   }
 
-  updateVendorRankings(vendors: { [key: number]: Vendor }) {
+  async updateVendorRankings(vendors: { [key: number]: Vendor }) {
     if (settings.showReviews) {
       this._bulkFetcher.bulkFetchVendorItems(vendors);
     }
   }
 
-  getItemReviews(item: DimItem) {
+  async getItemReviews(item: DimItem) {
     if (settings.allowIdPostToDtr) {
       if (item.isDestiny1()) {
-        this._reviewsFetcher.getItemReviews(item);
+        return this._reviewsFetcher.getItemReviews(item);
       } else if (item.isDestiny2()) {
         const platformSelection = settings.reviewsPlatformSelection;
         const mode = settings.reviewsModeSelection;
-        this._d2reviewsFetcher.getItemReviews(item, platformSelection, mode);
+        return this._d2reviewsFetcher.getItemReviews(item, platformSelection, mode);
       }
     }
   }
 
-  submitReview(item: DimItem) {
+  async submitReview(item: DimItem) {
     if (settings.allowIdPostToDtr) {
       const membershipInfo = getActivePlatform();
 
       if (item.isDestiny1()) {
-        this._reviewSubmitter.submitReview(item, membershipInfo);
+        return this._reviewSubmitter.submitReview(item, membershipInfo);
       } else if (item.isDestiny2()) {
-        this._d2reviewSubmitter.submitReview(item, membershipInfo);
+        return this._d2reviewSubmitter.submitReview(item, membershipInfo);
       }
     }
   }
 
-  fetchReviews(stores: DimStore[]) {
+  async fetchReviews(stores: DimStore[]) {
     if (!settings.showReviews ||
         !stores ||
         !stores[0]) {
@@ -130,32 +128,32 @@ export class DestinyTrackerService {
     }
 
     if (stores[0].isDestiny1()) {
-      this._bulkFetcher.bulkFetch(stores as D1Store[]);
+      return this._bulkFetcher.bulkFetch(stores as D1Store[]);
     } else if (stores[0].isDestiny2()) {
       const platformSelection = settings.reviewsPlatformSelection;
       const mode = settings.reviewsModeSelection;
-      this._d2bulkFetcher.bulkFetch(stores as D2Store[], platformSelection, mode);
+      return this._d2bulkFetcher.bulkFetch(stores as D2Store[], platformSelection, mode);
     }
   }
 
-  getItemReviewAsync(itemHash: number): IPromise<D2ItemReviewResponse | undefined> {
+  async getItemReviewAsync(itemHash: number): Promise<D2ItemReviewResponse | undefined> {
     if (settings.allowIdPostToDtr) {
       const platformSelection = settings.reviewsPlatformSelection;
       const mode = settings.reviewsModeSelection;
       return this._d2reviewsFetcher.fetchItemReviews(itemHash, platformSelection, mode);
     }
-    return $q.when(undefined);
+    return undefined;
   }
 
-  reportReview(review: DimUserReview) {
+  async reportReview(review: DimUserReview) {
     if (settings.allowIdPostToDtr) {
       const membershipInfo = getActivePlatform();
 
       if (membershipInfo) {
         if (membershipInfo.destinyVersion === 1) {
-          this._reviewReporter.reportReview(review as D1ItemUserReview, membershipInfo);
+          return this._reviewReporter.reportReview(review as D1ItemUserReview, membershipInfo);
         } else if (membershipInfo.destinyVersion === 2) {
-          this._d2reviewReporter.reportReview(review as D2ItemUserReview, membershipInfo);
+          return this._d2reviewReporter.reportReview(review as D2ItemUserReview, membershipInfo);
         }
       }
     }

--- a/src/app/item-review/item-review.component.ts
+++ b/src/app/item-review/item-review.component.ts
@@ -6,10 +6,10 @@ import { getReviewModes } from '../destinyTrackerApi/reviewModesFetcher';
 import { getDefinitions } from '../destiny2/d2-definitions.service';
 import { translateReviewMode } from './reviewModeTranslator';
 import { IComponentOptions, IController, IScope, IRootScopeService } from 'angular';
-import { DestinyTrackerServiceType } from './destiny-tracker.service';
 import { DimItem } from '../inventory/item-types';
 import { D1ItemUserReview, WorkingD1Rating } from './d1-dtr-api-types';
 import { D2ItemUserReview, WorkingD2Rating } from './d2-dtr-api-types';
+import { dimDestinyTrackerService } from './destiny-tracker.service';
 
 export const ItemReviewComponent: IComponentOptions = {
   bindings: {
@@ -26,7 +26,6 @@ function ItemReviewController(
     findReview(reviewId: string): D1ItemUserReview | D2ItemUserReview | null;
     getReviewData(): number[];
   },
-  dimDestinyTrackerService: DestinyTrackerServiceType,
   $scope: IScope,
   $rootScope: IRootScopeService
 ) {

--- a/src/app/item-review/item-review.module.ts
+++ b/src/app/item-review/item-review.module.ts
@@ -1,9 +1,7 @@
 import { module } from 'angular';
 
 import { ItemReviewComponent } from './item-review.component';
-import { DestinyTrackerService } from './destiny-tracker.service';
 
 export default module('ReviewModule', [])
-  .factory('dimDestinyTrackerService', DestinyTrackerService)
   .component('dimItemReview', ItemReviewComponent)
   .name;

--- a/src/app/move-popup/dimMoveItemProperties.directive.ts
+++ b/src/app/move-popup/dimMoveItemProperties.directive.ts
@@ -5,6 +5,7 @@ import { IController, IRootScopeService, IScope, IComponentOptions, IAngularEven
 import template from './dimMoveItemProperties.html';
 import { DimItem } from '../inventory/item-types';
 import { StoreServiceType } from '../inventory/store-types';
+import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 
 export const MoveItemPropertiesComponent: IComponentOptions = {
   controller: MoveItemPropertiesCtrl,
@@ -27,8 +28,7 @@ function MoveItemPropertiesCtrl(
   D2StoresService: StoreServiceType,
   ngDialog,
   $scope: IScope,
-  $rootScope: IRootScopeService,
-  dimDestinyTrackerService
+  $rootScope: IRootScopeService
 ) {
   'ngInject';
   const vm = this;

--- a/src/app/move-popup/dimMoveItemProperties.directive.ts
+++ b/src/app/move-popup/dimMoveItemProperties.directive.ts
@@ -56,7 +56,7 @@ function MoveItemPropertiesCtrl(
     vm.showDetailsByDefault = (!item.equipment && item.notransfer);
     vm.itemDetails = vm.showDetailsByDefault;
 
-    dimDestinyTrackerService.getItemReviews(vm.item);
+    dimDestinyTrackerService.getItemReviews(vm.item).then(() => $scope.$apply());
 
     // DTR 404s on the new D2 languages for D1 items
     let language = vm.settings.language;

--- a/src/app/move-popup/dimMoveItemProperties.html
+++ b/src/app/move-popup/dimMoveItemProperties.html
@@ -28,12 +28,7 @@
       <div ng-if="vm.item.objectives && !vm.item.hidePercentage" ng-i18next="[i18next]({ percent: vm.item.percentComplete })ItemService.PercentComplete"></div>
       <dim-item-tag ng-if="vm.item.taggable" item="vm.item"></dim-item-tag>
     </div>
-    <div ng-if="vm.item.destinyVersion === 1 && vm.item.reviewable && vm.item.dtrRating.overallScore" class="item-review-average">
-      <star-rating rating="vm.item.dtrRating.overallScore" read-only></star-rating>
-      <span ng-if="vm.item.reviewable" ng-i18next="[i18next]({ itemRating: vm.item.dtrRating.overallScore, numRatings: vm.item.dtrRating.ratingCount || 0 })DtrReview.AverageRating"></span>
-    </div>
-    <!-- we were displaying the number of reviews rather than the total # of ratings before, which seems... wrong? -->
-    <div ng-if="vm.item.destinyVersion === 2 && vm.item.reviewable && vm.item.dtrRating.overallScore" class="item-review-average">
+    <div ng-if="vm.item.reviewable && vm.item.dtrRating.overallScore" class="item-review-average">
       <star-rating rating="vm.item.dtrRating.overallScore" read-only></star-rating>
       <span ng-if="vm.item.reviewable" ng-i18next="[i18next]({ itemRating: vm.item.dtrRating.overallScore, numRatings: vm.item.dtrRating.ratingCount || 0 })DtrReview.AverageRating"></span>
     </div>
@@ -44,7 +39,7 @@
       <span class="move-popup-tab" ng-class="{ selected: vm.tab==='default' }" ng-click="vm.tab='default'" ng-i18next="MovePopup.OverviewTab"></span>
       <span class="move-popup-tab" ng-class="{ selected: vm.tab==='reviews' }" ng-click="vm.tab='reviews'" ng-i18next="MovePopup.ReviewsTab"></span>
     </div>
-    <dim-item-review item="vm.item" ng-if="vm.item.lockable || vm.item.reviews" ng-show="vm.tab === 'reviews'"></dim-item-review>
+    <dim-item-review item="vm.item" ng-if="vm.item.reviewable" ng-show="vm.tab === 'reviews'"></dim-item-review>
     <div ng-show="vm.tab === 'default'">
       <form ng-if="vm.item.taggable" name="notes"><textarea name="data" ng-i18next="[placeholder]Notes.Help" ng-maxlength="120" ng-model="vm.item.dimInfo.notes" ng-model-options="{ updateOn: 'blur' }" ng-change="vm.updateNote()"></textarea></form>
       <span class="textarea-error" ng-show="notes.data.$error.maxlength" ng-i18next="Notes.Error"></span>

--- a/src/app/vendors/vendor.service.ts
+++ b/src/app/vendors/vendor.service.ts
@@ -9,9 +9,9 @@ import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definition
 import { processItems } from '../inventory/store/d1-item-factory.service';
 import { IRootScopeService, IPromise, copy, IQService } from 'angular';
 import { D1StoreServiceType, D1Store } from '../inventory/store-types';
-import { DestinyTrackerServiceType } from '../item-review/destiny-tracker.service';
 import { Observable } from 'rxjs/Observable';
 import { D1Item } from '../inventory/item-types';
+import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 
 /*
 const allVendors = [
@@ -132,7 +132,6 @@ export interface VendorServiceType {
 export function VendorService(
   $rootScope: IRootScopeService,
   dimStoreService: D1StoreServiceType,
-  dimDestinyTrackerService: DestinyTrackerServiceType,
   loadingTracker,
   $q: IQService
 ): VendorServiceType {

--- a/src/app/vendors/vendor.service.ts
+++ b/src/app/vendors/vendor.service.ts
@@ -69,6 +69,24 @@ const categoryBlacklist = [
 
 const xur = 2796397637;
 
+export interface VendorCost {
+  currency: {
+    icon: string;
+    itemHash: number;
+    itemName: string;
+  };
+  value: number;
+}
+
+export interface VendorSaleItem {
+  costs: VendorCost[];
+  failureStrings: string;
+  index: number;
+  item: D1Item;
+  unlocked: boolean;
+  unlockedByCharacter: string[];
+}
+
 export interface Vendor {
   failed: boolean;
   nextRefreshDate: string;
@@ -84,11 +102,11 @@ export interface Vendor {
   factionLevel: number;
   factionAligned: boolean;
 
-  allItems: D1Item[];
+  allItems: VendorSaleItem[];
   categories: {
     index: number;
     title: string;
-    saleItems: D1Item[];
+    saleItems: VendorSaleItem[];
     hasArmorWeaps: boolean;
     hasVehicles: boolean;
     hasShadersEmbs: boolean;
@@ -265,7 +283,7 @@ export function VendorService(
     return reloadPromise;
   }
 
-  function mergeVendors([firstVendor, ...otherVendors]) {
+  function mergeVendors([firstVendor, ...otherVendors]: Vendor[]) {
     const mergedVendor = copy(firstVendor);
 
     otherVendors.forEach((vendor) => {
@@ -563,7 +581,6 @@ export function VendorService(
           item.vendorIcon = createdVendor.icon;
         });
 
-        createdVendor.allItems = items;
         createdVendor.categories = categories;
 
         createdVendor.hasArmorWeaps = _.any(categories, (c) => c.hasArmorWeaps);

--- a/src/app/vendors/vendor.service.ts
+++ b/src/app/vendors/vendor.service.ts
@@ -601,14 +601,14 @@ export function VendorService(
   // TODO: do this with another observable!
   function requestRatings() {
     _ratingsRequested = true;
-    fulfillRatingsRequest();
+    return fulfillRatingsRequest();
   }
 
-  function fulfillRatingsRequest() {
+  async function fulfillRatingsRequest(): Promise<void> {
     if (service.vendorsLoaded && _ratingsRequested) {
       // TODO: Throttle this. Right now we reload this on every page
       // view and refresh of the vendors page.
-      dimDestinyTrackerService.updateVendorRankings(service.vendors);
+      return dimDestinyTrackerService.updateVendorRankings(service.vendors);
     }
   }
 

--- a/src/app/vendors/vendors.component.ts
+++ b/src/app/vendors/vendors.component.ts
@@ -39,7 +39,7 @@ function VendorsController(
       vm.stores = stores;
       vm.vendors = vendors;
       vm.totalCoins = dimVendorService.countCurrencies(stores, vendors);
-      dimVendorService.requestRatings();
+      dimVendorService.requestRatings().then(() => $scope.$apply());
     });
   };
 

--- a/src/app/vendors/vendors.module.ts
+++ b/src/app/vendors/vendors.module.ts
@@ -18,7 +18,11 @@ export default module('VendorsModule', [])
   .component('xur', Xur)
   .filter('vendorTab', () => vendorTab)
   .filter('vendorTabItems', () => vendorTabItems)
-  .filter('values', () => Object.values)
+  .filter('values', () => {
+    return (i) => {
+      return i ? Object.values(i) : i;
+    };
+  })
   .config(($stateProvider: StateProvider) => {
     'ngInject';
 


### PR DESCRIPTION
This makes `dimDestinyTrackerService` a normal object instead of an Angular service, freeing up StoresService to finally get extracted from Angular. I also made more stuff async/promise-y so we can wait for stuff if we want.

Plus, fix D1 Vendor reviews (due to my incorrect Vendors types) and sorta fix D2 vendor reviews (#2849) in the move popup (though sometimes the reviews will load and then disappear again, haven't managed to track that down yet).