### PR TITLE
Seasonal Rank

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+* Factions now show seasonal rank instead of lifetime rank.
+* Vendors show their faction rank next to their reward engrams.
+* Factions in the progress page also link to their vendor.
+
 # 4.57.0 (2018-06-17)
 
 * Item sizing setting works in Edge.
@@ -28,7 +32,6 @@
 * Fix the display of crucible rank points.
 * Fix faction rank progress bars on D1.
 * Compare view includes perks and mods for D2 items.
-* Factions now show seasonal rank instead of lifetime rank.
 
 # 4.53.0 (2018-05-20)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix the display of crucible rank points.
 * Fix faction rank progress bars on D1.
 * Compare view includes perks and mods for D2 items.
+* Factions now show seasonal rank instead of lifetime rank.
 
 # 4.53.0 (2018-05-20)
 

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -183,6 +183,19 @@ export function getVendors(account: DestinyAccount, characterId: string): Promis
   .then((response) => response.Response);
 }
 
+/** Just get the vendors, for seasonal rank */
+export function getVendorsMinimal(account: DestinyAccount, characterId: string): Promise<DestinyVendorsResponse> {
+  return getVendorsApi(httpAdapter, {
+    characterId,
+    destinyMembershipId: account.membershipId,
+    membershipType: account.platformType,
+    components: [
+      DestinyComponentType.Vendors
+    ]
+  })
+  .then((response) => response.Response);
+}
+
 /**
  * Transfer an item to another store.
  */

--- a/src/app/d2-vendors/SingleVendor.tsx
+++ b/src/app/d2-vendors/SingleVendor.tsx
@@ -131,14 +131,13 @@ export default class SingleVendor extends React.Component<Props, State> {
 
     const vendorItems = getVendorItems(account, defs, vendorDef, trackerService, vendorResponse && vendorResponse.itemComponents, vendorResponse && vendorResponse.sales.data);
 
-    // TODO: localize
     return (
       <div className="vendor dim-page">
         <ErrorBoundary name="SingleVendor">
           <div className="vendor-featured">
             <div className="vendor-featured-header">
               {factionProgress && faction
-                ? <FactionIcon factionProgress={factionProgress} factionDef={faction}/>
+                ? <FactionIcon factionProgress={factionProgress} factionDef={faction} vendor={vendor}/>
                 : <BungieImage src={vendorDef.displayProperties.icon}/>
               }
               <div className="vendor-header-info">

--- a/src/app/d2-vendors/SingleVendor.tsx
+++ b/src/app/d2-vendors/SingleVendor.tsx
@@ -5,10 +5,8 @@ import * as React from 'react';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { getVendor as getVendorApi } from '../bungie-api/destiny2-api';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
-import BungieImage from '../dim-ui/BungieImage';
 import Countdown from '../dim-ui/Countdown';
 import { D2ManifestService } from '../manifest/manifest-service';
-import FactionIcon from '../progress/FactionIcon';
 import VendorItems from './VendorItems';
 import './vendor.scss';
 import { fetchRatingsForVendor, fetchRatingsForVendorDef } from './vendor-ratings';
@@ -112,16 +110,10 @@ export default class SingleVendor extends React.Component<Props, State> {
     }
 
     // TODO:
-    // * countdown
     // * featured item
     // * enabled
-    // * ratings
-    // * show which items you have
     // * filter by character class
     const vendor = vendorResponse && vendorResponse.vendor.data;
-
-    const faction = vendorDef.factionHash ? defs.Faction[vendorDef.factionHash] : undefined;
-    const factionProgress = vendorResponse && vendorResponse.vendor.data.progression;
 
     const destinationDef = vendor && defs.Destination.get(vendorDef.locations[vendor.vendorLocationIndex].destinationHash);
     const placeDef = destinationDef && defs.Place.get(destinationDef.placeHash);
@@ -136,10 +128,6 @@ export default class SingleVendor extends React.Component<Props, State> {
         <ErrorBoundary name="SingleVendor">
           <div className="vendor-featured">
             <div className="vendor-featured-header">
-              {factionProgress && faction
-                ? <FactionIcon factionProgress={factionProgress} factionDef={faction} vendor={vendor}/>
-                : <BungieImage src={vendorDef.displayProperties.icon}/>
-              }
               <div className="vendor-header-info">
                 <h1>{vendorDef.displayProperties.name} <span className="vendor-location">{placeString}</span></h1>
                 <div>{vendorDef.displayProperties.description}</div>
@@ -151,6 +139,7 @@ export default class SingleVendor extends React.Component<Props, State> {
           </div>
           <VendorItems
             defs={defs}
+            vendor={vendor}
             vendorDef={vendorDef}
             vendorItems={vendorItems}
             trackerService={trackerService}

--- a/src/app/d2-vendors/Vendor.tsx
+++ b/src/app/d2-vendors/Vendor.tsx
@@ -67,6 +67,7 @@ export default function Vendor({
       </div>
       <VendorItems
         defs={defs}
+        vendor={vendor}
         vendorDef={vendorDef}
         vendorItems={getVendorItems(account, defs, vendorDef, trackerService, itemComponents, sales)}
         trackerService={trackerService}

--- a/src/app/d2-vendors/VendorItems.tsx
+++ b/src/app/d2-vendors/VendorItems.tsx
@@ -1,4 +1,4 @@
-import { DestinyVendorDefinition } from 'bungie-api-ts/destiny2';
+import { DestinyVendorDefinition, DestinyVendorComponent } from 'bungie-api-ts/destiny2';
 import { t } from 'i18next';
 import * as React from 'react';
 import * as _ from 'underscore';
@@ -9,6 +9,8 @@ import { $state } from '../ngimport-more';
 import { compact } from '../util';
 import VendorItemComponent from './VendorItemComponent';
 import { VendorItem } from './vendor-item';
+import FactionIcon from '../progress/FactionIcon';
+import PressTip from '../dim-ui/PressTip';
 
 /**
  * Display the items for a single vendor, organized by category.
@@ -17,6 +19,7 @@ export default function VendorItems({
   vendorDef,
   defs,
   vendorItems,
+  vendor,
   trackerService,
   ownedItemHashes,
   currencyLookups
@@ -24,6 +27,7 @@ export default function VendorItems({
   vendorDef: DestinyVendorDefinition;
   defs: D2ManifestDefinitions;
   vendorItems: VendorItem[];
+  vendor?: DestinyVendorComponent;
   trackerService?: DestinyTrackerService;
   ownedItemHashes?: Set<number>;
   currencyLookups?: {
@@ -37,6 +41,7 @@ export default function VendorItems({
   const rewardVendorHash = faction && faction.rewardVendorHash || undefined;
   const rewardItem = rewardVendorHash && defs.InventoryItem.get(faction!.rewardItemHash);
   const goToRewardVendor = rewardVendorHash && (() => $state.go('destiny2.vendor', { id: rewardVendorHash }));
+  const factionProgress = vendor && vendor.progression;
 
   const vendorCurrencyHashes = new Set<number>();
   for (const item of vendorItems) {
@@ -59,11 +64,18 @@ export default function VendorItems({
       {rewardVendorHash && rewardItem && goToRewardVendor &&
         <div className="vendor-row">
           <h3 className="category-title">{t('Vendors.Engram')}</h3>
-          <div className="item" title={rewardItem.displayProperties.name} onClick={goToRewardVendor}>
-            <div
-              className="item-img transparent"
-              style={bungieBackgroundStyle(rewardItem.displayProperties.icon)}
-            />
+          <div className="vendor-items">
+            {factionProgress && faction &&
+              <PressTip tooltip={`${factionProgress.progressToNextLevel}/${factionProgress.nextLevelAt}`}>
+                <div><FactionIcon factionProgress={factionProgress} factionDef={faction} vendor={vendor}/></div>
+              </PressTip>
+            }
+            <div className="item" title={rewardItem.displayProperties.name} onClick={goToRewardVendor}>
+              <div
+                className="item-img transparent"
+                style={bungieBackgroundStyle(rewardItem.displayProperties.icon)}
+              />
+            </div>
           </div>
         </div>}
       {_.map(itemsByCategory, (items, categoryIndex) =>

--- a/src/app/dim-ui/DiamondProgress.tsx
+++ b/src/app/dim-ui/DiamondProgress.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import './faction.scss';
+import '../progress/faction.scss';
 
 interface Props {
   /** 0-1 progress for the outer ring */

--- a/src/app/dim-ui/DiamondProgress.tsx
+++ b/src/app/dim-ui/DiamondProgress.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import './faction.scss';
+
+interface Props {
+  /** 0-1 progress for the outer ring */
+  progress: number;
+  /** Level to display */
+  level?: number;
+  /** The icon to use */
+  icon: string;
+  className: string;
+}
+
+/**
+ * A diamond-shaped progress bar (from faction icons).
+ */
+export default class DiamondProgress extends React.PureComponent<Props> {
+  render() {
+    const { progress, level, icon, className } = this.props;
+
+    const style = {
+      strokeDashoffset: 121.622368 - (121.622368 * progress)
+    };
+
+    // TODO: redo classes
+    return (
+      <div className={className}>
+        <svg viewBox="0 0 48 48">
+          <image xlinkHref={icon} width="48" height="48" />
+          {progress > 0 &&
+            <polygon strokeDasharray="121.622368" style={style} fillOpacity="0" stroke="#FFF" strokeWidth="3" points="24,2.5 45.5,24 24,45.5 2.5,24" strokeLinecap="butt"/>
+          }
+        </svg>
+        {level !== undefined && <div className="item-stat item-faction">{level}</div>}
+      </div>
+    );
+  }
+}

--- a/src/app/progress/Faction.tsx
+++ b/src/app/progress/Faction.tsx
@@ -3,7 +3,8 @@ import {
   DestinyFactionProgression,
   DestinyInventoryComponent,
   DestinyItemComponent,
-  DestinyCharacterComponent
+  DestinyCharacterComponent,
+  DestinyVendorComponent
 } from 'bungie-api-ts/destiny2';
 import classNames from 'classnames';
 import { t } from 'i18next';
@@ -17,13 +18,14 @@ import FactionIcon from './FactionIcon';
 
 interface FactionProps {
   factionProgress: DestinyFactionProgression;
+  vendor?: DestinyVendorComponent;
   profileInventory: DestinyInventoryComponent;
   defs: D2ManifestDefinitions;
   character: DestinyCharacterComponent;
 }
 
 export function Faction(props: FactionProps) {
-  const { defs, factionProgress, profileInventory, character } = props;
+  const { defs, factionProgress, profileInventory, character, vendor } = props;
 
   const factionDef = defs.Faction[factionProgress.factionHash];
 
@@ -35,18 +37,19 @@ export function Faction(props: FactionProps) {
   const vendorDef = defs.Vendor.get(vendorHash);
 
   const rewardClick = () => $state.go('destiny2.vendor', { id: factionDef.rewardVendorHash, characterId: character.characterId });
-
-  // TODO: load vendors to show their vendor rank
+  const vendorClick = () => $state.go('destiny2.vendor', { id: vendorHash, characterId: character.characterId });
 
   return (
     <div
       className={classNames("faction", { 'faction-unavailable': factionProgress.factionVendorIndex === -1 })}
     >
       <PressTip tooltip={`${factionProgress.progressToNextLevel}/${factionProgress.nextLevelAt}`}>
-        <div><FactionIcon factionDef={factionDef} factionProgress={factionProgress}/></div>
+        <div><FactionIcon factionDef={factionDef} factionProgress={factionProgress} vendor={vendor}/></div>
       </PressTip>
       <div className="faction-info">
-        <div className="faction-name" title={vendorDef.displayProperties.description}>{vendorDef.displayProperties.name}</div>
+        <div className="faction-name" title={vendorDef.displayProperties.description}>
+          <a onClick={vendorClick}>{vendorDef.displayProperties.name}</a>
+        </div>
         <div className="faction-level" title={factionDef.displayProperties.description}>{factionDef.displayProperties.name}</div>
         <div className="faction-rewards">
           {factionDef.rewardVendorHash && $featureFlags.vendors

--- a/src/app/progress/Faction.tsx
+++ b/src/app/progress/Faction.tsx
@@ -36,6 +36,8 @@ export function Faction(props: FactionProps) {
 
   const rewardClick = () => $state.go('destiny2.vendor', { id: factionDef.rewardVendorHash, characterId: character.characterId });
 
+  // TODO: load vendors to show their vendor rank
+
   return (
     <div
       className={classNames("faction", { 'faction-unavailable': factionProgress.factionVendorIndex === -1 })}

--- a/src/app/progress/FactionIcon.tsx
+++ b/src/app/progress/FactionIcon.tsx
@@ -1,31 +1,28 @@
 import {
   DestinyFactionDefinition,
-  DestinyProgression
+  DestinyProgression,
+  DestinyVendorComponent
 } from 'bungie-api-ts/destiny2';
-import classNames from 'classnames';
 import * as React from 'react';
 import { bungieNetPath } from '../dim-ui/BungieImage';
 import './faction.scss';
+import DiamondProgress from '../dim-ui/DiamondProgress';
 
 export default function FactionIcon(props: {
   factionProgress: DestinyProgression;
   factionDef: DestinyFactionDefinition;
+  vendor?: DestinyVendorComponent;
 }) {
-  const { factionProgress, factionDef } = props;
+  const { factionProgress, factionDef, vendor } = props;
 
-  const style = {
-    strokeDashoffset: 121.622368 - (121.622368 * factionProgress.progressToNextLevel) / factionProgress.nextLevelAt
-  };
+  const level = vendor && (vendor.seasonalRank !== undefined) ? vendor.seasonalRank : factionProgress.level;
 
   return (
-    <div className="faction-icon">
-      <svg viewBox="0 0 48 48">
-        <image xlinkHref={bungieNetPath(factionDef.displayProperties.icon)} width="48" height="48" />
-        {factionProgress.progressToNextLevel > 0 &&
-          <polygon strokeDasharray="121.622368" style={style} fillOpacity="0" stroke="#FFF" strokeWidth="3" points="24,2.5 45.5,24 24,45.5 2.5,24" strokeLinecap="butt"/>
-        }
-      </svg>
-      <div className={classNames('item-stat', 'item-faction', { 'purchase-unlocked': factionProgress.level >= 10 })}>{factionProgress.level}</div>
-    </div>
+    <DiamondProgress
+      icon={bungieNetPath(factionDef.displayProperties.icon)}
+      level={level}
+      className="faction-icon"
+      progress={factionProgress.progressToNextLevel / factionProgress.nextLevelAt}
+    />
   );
 }

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -6,6 +6,7 @@ import {
   DestinyItemComponent,
   DestinyMilestone,
   DestinyObjectiveProgress,
+  DestinyVendorComponent,
 } from 'bungie-api-ts/destiny2';
 import { t } from 'i18next';
 import * as React from 'react';
@@ -276,7 +277,14 @@ export class Progress extends React.Component<Props, State> {
               {characters.map((character) =>
                 <div className="progress-for-character" key={character.characterId}>
                   {this.factionsForCharacter(character).map((faction) =>
-                    <Faction factionProgress={faction} defs={defs} character={character} profileInventory={profileInfo.profileInventory.data} key={faction.factionHash} />
+                    <Faction
+                      factionProgress={faction}
+                      defs={defs}
+                      character={character}
+                      profileInventory={profileInfo.profileInventory.data}
+                      key={faction.factionHash}
+                      vendor={this.vendorForFaction(character, faction)}
+                    />
                   )}
                 </div>
               )}
@@ -292,6 +300,17 @@ export class Progress extends React.Component<Props, State> {
    */
   private sortedCharacters(progress: ProgressProfile = this.state.progress!, characterOrder: CharacterOrder = this.state.characterOrder): DestinyCharacterComponent[] {
     return sortCharacters(Object.values(progress.profileInfo.characters.data), characterOrder);
+  }
+
+  private vendorForFaction(character: DestinyCharacterComponent, faction: DestinyFactionProgression): DestinyVendorComponent | undefined {
+    if (faction.factionVendorIndex < 0) {
+      return undefined;
+    }
+
+    const { vendors, defs } = this.state.progress!;
+    const factionDef = defs.Faction[faction.factionHash];
+    const vendorHash = factionDef.vendors[faction.factionVendorIndex].vendorHash;
+    return vendors[character.characterId].vendors.data[vendorHash];
   }
 
   /**

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -1,13 +1,15 @@
 import {
   DestinyCharacterComponent,
-  DestinyProfileResponse
+  DestinyProfileResponse,
+  DestinyVendorsResponse
   } from 'bungie-api-ts/destiny2';
+import * as _ from 'underscore';
 import { $q } from 'ngimport';
 import { ConnectableObservable } from 'rxjs/observable/ConnectableObservable';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Subject } from 'rxjs/Subject';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.service';
-import { getProgression } from '../bungie-api/destiny2-api';
+import { getProgression, getVendors } from '../bungie-api/destiny2-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
 import { reportException } from '../exceptions';
@@ -28,6 +30,7 @@ export interface ProgressService {
 export interface ProgressProfile {
   readonly defs: D2ManifestDefinitions;
   readonly profileInfo: DestinyProfileResponse;
+  readonly vendors: { [characterId: string]: DestinyVendorsResponse };
   /**
    * The date the most recently played character was last played.
    */
@@ -81,17 +84,21 @@ export function reloadProgress() {
 function loadProgress(account: DestinyAccount): IPromise<ProgressProfile | undefined> {
   // TODO: this would be nicer as async/await, but we need the scope-awareness of the Angular promise for now
   const reloadPromise = $q.all([getProgression(account), getDefinitions()])
-    .then(([profileInfo, defs]): ProgressProfile => {
-      return {
-        defs,
-        profileInfo,
-        get lastPlayedDate() {
-          return Object.values((this.profileInfo as DestinyProfileResponse).characters.data).reduce((memo, character: DestinyCharacterComponent) => {
-            const d1 = new Date(character.dateLastPlayed);
-            return (memo) ? ((d1 >= memo) ? d1 : memo) : d1;
-          }, new Date(0));
-        }
-      };
+    .then(([profileInfo, defs]) => {
+      const characterIds = Object.keys(profileInfo.characters.data);
+      return $q.all(characterIds.map((characterId) => getVendors(account, characterId))).then((vendors) => {
+        return {
+          defs,
+          profileInfo,
+          vendors: _.object(_.zip(characterIds, vendors)) as ProgressProfile['vendors'],
+          get lastPlayedDate() {
+            return Object.values((this.profileInfo as DestinyProfileResponse).characters.data).reduce((memo, character: DestinyCharacterComponent) => {
+              const d1 = new Date(character.dateLastPlayed);
+              return (memo) ? ((d1 >= memo) ? d1 : memo) : d1;
+            }, new Date(0));
+          }
+        };
+      });
     })
     .catch((e) => {
       toaster.pop(bungieErrorToaster(e));

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -1,10 +1,5 @@
 import {
   DestinyCharacterComponent,
-  DestinyCharacterProgressionComponent,
-  DestinyInventoryComponent,
-  DestinyItemComponentSetOfint64,
-  DictionaryComponentResponse,
-  SingleComponentResponse,
   DestinyProfileResponse
   } from 'bungie-api-ts/destiny2';
 import { $q } from 'ngimport';
@@ -26,25 +21,13 @@ export interface ProgressService {
   reloadProgress(): void;
 }
 
-/**
- * A slimmed down version of IDestinyProfileResponse for just what we get
- * TODO: Move all this into bungie-api.
- */
-interface ProgressProfileResponse {
-  characters: DictionaryComponentResponse<DestinyCharacterComponent>;
-  characterProgressions: DictionaryComponentResponse<DestinyCharacterProgressionComponent>;
-  profileInventory: SingleComponentResponse<DestinyInventoryComponent>;
-  characterInventories: DictionaryComponentResponse<DestinyInventoryComponent>;
-  itemComponents: DestinyItemComponentSetOfint64;
-}
-
 // TODO: generate all the API structures from the Swagger docs
 // This is a kind of radical approach - the result is not modified or interpreted until we get to components!
 // Should allow for better understanding of updates, but prevents us from "correcting" and interpreting the data,
 // and means we may have to block on defs lookup in the UI rendering :-/
 export interface ProgressProfile {
   readonly defs: D2ManifestDefinitions;
-  readonly profileInfo: ProgressProfileResponse;
+  readonly profileInfo: DestinyProfileResponse;
   /**
    * The date the most recently played character was last played.
    */


### PR DESCRIPTION
This shows Seasonal rank on single vendor pages. Unfortunately, it doesn't show them on the Progress page, because we need to make another request (to the getVendors API) to get seasonal rank. I'm actually not sure how to display this - factions properly have a lifetime, per-character level, while *vendors* have seasonal rank. So they're actually different ideas. Thoughts?