### PR TITLE
Masterworks for real

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Correctly display masterwork plug objectives - check the "Upgrade Masterwork" plug for catalyst updates.
+
 # 4.54.0 (2018-05-27)
 
 * Fix the display of crucible rank points.

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -884,6 +884,28 @@ function buildDefinedSockets(
   };
 }
 
+/**
+ * Plugs to hide from plug options (if not socketed)
+ * removes the "Default Ornament" plug, "Default Shader" and "Rework Masterwork"
+ * TODO: with AWA we may want to put some of these back
+ */
+const EXCLUDED_PLUGS = new Set([
+  // Default ornament
+  2931483505,
+  1959648454,
+  702981643,
+  // Rework Masterwork
+  39869035,
+  1961001474,
+  3612467353,
+  // Default Shader
+  4248210736
+]);
+function filterReusablePlug(reusablePlug: DimPlug) {
+  return !EXCLUDED_PLUGS.has(reusablePlug.plugItem.hash) &&
+    !reusablePlug.plugItem.itemCategoryHashes.includes(141186804);
+}
+
 function buildDefinedSocket(
   defs: D2ManifestDefinitions,
   socket: DestinyItemSocketEntryDefinition,
@@ -895,16 +917,9 @@ function buildDefinedSocket(
 
   if (reusablePlugs.length) {
     reusablePlugs.forEach((reusablePlug) => {
-      if (// TODO: with AWA we may want to put some of these back
-          // removes the reusablePlugs from masterwork
-          !reusablePlug.plugItem.itemCategoryHashes.includes(141186804) &&
-          // removes the "Remove Shader" plug
-          reusablePlug.plugItem.action &&
-          // removes the "Default Ornament" plug
-          ![2931483505, 1959648454, 702981643].includes(reusablePlug.plugItem.hash)
-        ) {
-          plugOptions.push(reusablePlug);
-        }
+      if (filterReusablePlug(reusablePlug)) {
+        plugOptions.push(reusablePlug);
+      }
       });
   }
 
@@ -977,15 +992,7 @@ function buildSocket(
 
   if (reusablePlugs.length) {
     reusablePlugs.forEach((reusablePlug) => {
-      if (
-        // TODO: with AWA we may want to put some of these back
-        // removes the reusablePlugs from masterwork
-        !reusablePlug.plugItem.itemCategoryHashes.includes(141186804) &&
-        // removes the "Remove Shader" plug
-        reusablePlug.plugItem.action &&
-        // removes the "Default Ornament" plug
-        ![2931483505, 1959648454, 702981643].includes(reusablePlug.plugItem.hash)
-      ) {
+      if (filterReusablePlug(reusablePlug)) {
           if (plug && reusablePlug.plugItem.hash === plug.plugItem.hash) {
             plugOptions.push(plug);
             plugOptions.shift();

--- a/src/app/move-popup/objectives.scss
+++ b/src/app/move-popup/objectives.scss
@@ -77,12 +77,14 @@ dim-objectives {
   align-items: center;
   padding: 0 4px;
   flex: 1;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, .25);
 }
 
 .objective-text {
   z-index: 2;
   margin-right: 4px;
   backface-visibility: hidden;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, .25);
 }
 
 .objective-boolean {

--- a/src/app/move-popup/objectives.scss
+++ b/src/app/move-popup/objectives.scss
@@ -55,6 +55,11 @@ dim-objectives {
   flex-direction: row;
   align-items: center;
   color: white;
+  img {
+    width: 16px;
+    height: 16px;
+    margin-right: 8px;
+  }
 }
 
 .objective-progress-bar {
@@ -67,6 +72,9 @@ dim-objectives {
 
 .objective-description {
   position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   padding: 0 4px;
   flex: 1;
 }

--- a/src/app/progress/Objective.tsx
+++ b/src/app/progress/Objective.tsx
@@ -4,6 +4,7 @@ import { DestinyObjectiveProgress, DestinyUnlockValueUIStyle } from "bungie-api-
 import classNames from 'classnames';
 import { t } from 'i18next';
 import { percent } from '../inventory/dimPercentWidth.directive';
+import BungieImage from '../dim-ui/BungieImage';
 
 export default function Objective({
   defs,
@@ -14,8 +15,28 @@ export default function Objective({
 }) {
   const objectiveDef = defs.Objective.get(objective.objectiveHash);
 
+  const progress = objective.progress || 0;
+
+  if (objectiveDef.minimumVisibilityThreshold > 0 && progress < objectiveDef.minimumVisibilityThreshold) {
+    return null;
+  }
+
   const displayName = objectiveDef.progressDescription ||
       t(objective.complete ? 'Objectives.Complete' : 'Objectives.Incomplete');
+
+  if (objectiveDef.valueStyle === DestinyUnlockValueUIStyle.Integer) {
+    return (
+      <div className="objective-row">
+        <div className="objective-integer">
+          <div className="objective-description">
+            {objectiveDef.displayProperties.hasIcon && <BungieImage src={objectiveDef.displayProperties.icon}/>}
+            {displayName}
+          </div>
+          <div className="objective-text">{progress}</div>
+        </div>
+      </div>
+    );
+  }
 
   const classes = classNames('objective-row', {
     'objective-complete': objective.complete,
@@ -23,7 +44,7 @@ export default function Objective({
   });
 
   const progressBarStyle = {
-    width: percent((objective.progress || 0) / objectiveDef.completionValue)
+    width: percent(progress / objectiveDef.completionValue)
   };
 
   return (
@@ -33,8 +54,8 @@ export default function Objective({
         <div className="objective-progress-bar" style={progressBarStyle}/>
         <div className="objective-description">{displayName}</div>
         {objectiveDef.allowOvercompletion && objectiveDef.completionValue === 1
-          ? <div className="objective-text">{objective.progress || 0}</div>
-          : <div className="objective-text">{objective.progress || 0}/{objectiveDef.completionValue}</div>
+          ? <div className="objective-text">{progress}</div>
+          : <div className="objective-text">{progress}/{objectiveDef.completionValue}</div>
         }
       </div>
     </div>


### PR DESCRIPTION
With @designker's guidance I was able to correctly display Masterwork mods/objectives for weapons. Now:

1. The Masterwork mod itself just displays kill count, but formatted nicely.
2. The "Upgrade Masterwork" mod is no longer hidden, and contains the real objective for unlocking the masterwork.

<img width="403" alt="screen shot 2018-05-28 at 10 32 04 am" src="https://user-images.githubusercontent.com/313208/40624636-8260d9ee-6262-11e8-9fcb-a0a60fa2ecd5.png">
<img width="428" alt="screen shot 2018-05-28 at 10 31 58 am" src="https://user-images.githubusercontent.com/313208/40624635-8249fac6-6262-11e8-9ce5-9ceca4c01108.png">

