### PR TITLE
Add Ornaments to Collections

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Next
-* Displaying available rating data in spreadsheet export.
 
+* Displaying available rating data in spreadsheet export.
 * Correctly display masterwork plug objectives - check the "Upgrade Masterwork" plug for catalyst updates.
+* The Collections page now shows progress towards unlocking ornaments. Due to restrictions in the API, it can only show ornaments that go with items you already have.
 
 # 4.54.0 (2018-05-27)
 

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -85,8 +85,10 @@ export function getProgression(platform: DestinyAccount): Promise<DestinyProfile
  */
 export function getKiosks(platform: DestinyAccount): Promise<DestinyProfileResponse> {
   return getProfile(platform,
+    DestinyComponentType.ProfileInventories,
+    DestinyComponentType.CharacterInventories,
+    DestinyComponentType.CharacterEquipment,
     DestinyComponentType.Characters,
-    DestinyComponentType.ItemObjectives,
     DestinyComponentType.Kiosks,
     DestinyComponentType.ItemInstances,
     DestinyComponentType.ItemObjectives,

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -18,6 +18,7 @@ import { t } from 'i18next';
 import PlugSet from './PlugSet';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
+import Ornaments from './Ornaments';
 
 interface Props {
   $scope: IScope;
@@ -89,6 +90,8 @@ export default class Collections extends React.Component<Props, State> {
       return <div className="vendor d2-vendors dim-page"><i className="fa fa-spinner fa-spin"/></div>;
     }
 
+    // TODO: a lot of this processing should happen at setState, not render?
+
     // Note that today, there is only one kiosk vendor
     const kioskVendors = new Set(Object.keys(profileResponse.profileKiosks.data.kioskItems));
     _.each(profileResponse.characterKiosks.data, (kiosk) => {
@@ -129,6 +132,12 @@ export default class Collections extends React.Component<Props, State> {
               trackerService={trackerService}
             />
           )}
+        </ErrorBoundary>
+        <ErrorBoundary name="Ornaments">
+          <Ornaments
+            defs={defs}
+            profileResponse={profileResponse}
+          />
         </ErrorBoundary>
         <a className="collections-partner dim-button" target="_blank" rel="noopener" href="https://destinysets.com">
           {t('Vendors.DestinySets')}

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -109,6 +109,12 @@ export default class Collections extends React.Component<Props, State> {
 
     return (
       <div className="vendor d2-vendors dim-page">
+        <ErrorBoundary name="Ornaments">
+          <Ornaments
+            defs={defs}
+            profileResponse={profileResponse}
+          />
+        </ErrorBoundary>
         <ErrorBoundary name="Kiosks">
           {Array.from(kioskVendors).map((vendorHash) =>
             <Kiosk
@@ -132,12 +138,6 @@ export default class Collections extends React.Component<Props, State> {
               trackerService={trackerService}
             />
           )}
-        </ErrorBoundary>
-        <ErrorBoundary name="Ornaments">
-          <Ornaments
-            defs={defs}
-            profileResponse={profileResponse}
-          />
         </ErrorBoundary>
         <a className="collections-partner dim-button" target="_blank" rel="noopener" href="https://destinysets.com">
           {t('Vendors.DestinySets')}

--- a/src/app/collections/Ornaments.tsx
+++ b/src/app/collections/Ornaments.tsx
@@ -1,0 +1,80 @@
+import {
+  DestinyProfileResponse,
+  DestinyObjectiveProgress
+} from 'bungie-api-ts/destiny2';
+import * as React from 'react';
+import * as _ from 'underscore';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import './collections.scss';
+import VendorItemComponent from '../d2-vendors/VendorItemComponent';
+import { VendorItem } from '../d2-vendors/vendor-item';
+
+/**
+ * A single plug set.
+ */
+export default function Ornaments({
+  defs,
+  profileResponse
+}: {
+  defs: D2ManifestDefinitions;
+  profileResponse: DestinyProfileResponse;
+}) {
+  const ornaments = getOrnaments(defs, profileResponse);
+
+  return (
+    <div className="vendor-char-items">
+      <div className="vendor-row">
+        <h3 className="category-title">
+          {defs.Vendor.get(2107783226).displayProperties.name}
+          <div className="ornaments-disclaimer">DIM can only show ornaments that could be unlocked on items you have in your inventory.</div>
+        </h3>
+        <div className="vendor-items">
+        {ornaments.map((ornament) =>
+          <VendorItemComponent
+            key={ornament.itemHash}
+            defs={defs}
+            item={VendorItem.forOrnament(defs, ornament.itemHash, ornament.objectives, ornament.canInsert)}
+            owned={false}
+          />
+        )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface OrnamentInfo {
+  itemHash: number;
+  objectives: DestinyObjectiveProgress[];
+  canInsert: boolean;
+}
+
+function getOrnaments(
+  defs: D2ManifestDefinitions,
+  profileResponse: DestinyProfileResponse
+): OrnamentInfo[] {
+  const plugsWithObjectives = {};
+  _.each(profileResponse.itemComponents.sockets.data, (sockets) => {
+    for (const socket of sockets.sockets) {
+      if (socket.reusablePlugs) {
+        for (const reusablePlug of socket.reusablePlugs) {
+          if (reusablePlug.plugObjectives && reusablePlug.plugObjectives.length) {
+            const item = defs.InventoryItem.get(reusablePlug.plugItemHash);
+            if (item.itemCategoryHashes.includes(1742617626)) {
+              plugsWithObjectives[reusablePlug.plugItemHash] = {
+                itemHash: reusablePlug.plugItemHash,
+                objectives: reusablePlug.plugObjectives,
+                canInsert: reusablePlug.canInsert
+              };
+            }
+          }
+        }
+      }
+    }
+  });
+
+  return _.sortBy(Object.values(plugsWithObjectives), (ornament) => {
+    const item = defs.InventoryItem.get(ornament.itemHash);
+    return item.displayProperties.name;
+  });
+}

--- a/src/app/collections/Ornaments.tsx
+++ b/src/app/collections/Ornaments.tsx
@@ -8,6 +8,7 @@ import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import './collections.scss';
 import VendorItemComponent from '../d2-vendors/VendorItemComponent';
 import { VendorItem } from '../d2-vendors/vendor-item';
+import { t } from 'i18next';
 
 /**
  * A single plug set.
@@ -26,7 +27,7 @@ export default function Ornaments({
       <div className="vendor-row">
         <h3 className="category-title">
           {defs.Vendor.get(2107783226).displayProperties.name}
-          <div className="ornaments-disclaimer">DIM can only show ornaments that could be unlocked on items you have in your inventory.</div>
+          <div className="ornaments-disclaimer">{t("Vendors.OrnamentsDisclaimer")}</div>
         </h3>
         <div className="vendor-items">
         {ornaments.map((ornament) =>

--- a/src/app/collections/collections.scss
+++ b/src/app/collections/collections.scss
@@ -6,3 +6,8 @@
   display: block;
   width: fit-content;
 }
+
+.ornaments-disclaimer {
+  text-transform: none;
+  color: #999;
+}

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -14,6 +14,7 @@ import { ratePerks } from "../destinyTrackerApi/d2-perkRater";
 import checkMark from '../../images/check.svg';
 import { D2Item } from "../inventory/item-types";
 import { D2RatingData } from "../item-review/d2-dtr-api-types";
+import { percent } from "../inventory/dimPercentWidth.directive";
 
 interface Props {
   defs: D2ManifestDefinitions;
@@ -68,12 +69,20 @@ export default class VendorItemComponent extends React.Component<Props> {
       title = `${title}\n${item.failureStrings.join("\n")}`;
     }
 
+    const progress = item.objectiveProgress;
+
     return (
       <div className={classNames("vendor-item", { owned })}>
         {(!item.canPurchase || !item.canBeSold) &&
           <div className="locked-overlay"/>
         }
         <div className="item" title={item.displayProperties.name} ref={this.itemElement} onClick={this.openDetailsPopup}>
+          {progress !== null && !item.canPurchase &&
+            <div
+              className="item-xp-bar-small"
+              style={{ width: percent(progress) }}
+            />
+          }
           <div
             className={classNames("item-img", { transparent: item.borderless })}
             style={bungieBackgroundStyle(item.displayProperties.icon)}

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -77,7 +77,7 @@ export default class VendorItemComponent extends React.Component<Props> {
           <div className="locked-overlay"/>
         }
         <div className="item" title={item.displayProperties.name} ref={this.itemElement} onClick={this.openDetailsPopup}>
-          {progress !== null && !item.canPurchase &&
+          {progress > 0 && !item.canPurchase &&
             <div
               className="item-xp-bar-small"
               style={{ width: percent(progress) }}
@@ -88,15 +88,15 @@ export default class VendorItemComponent extends React.Component<Props> {
             style={bungieBackgroundStyle(item.displayProperties.icon)}
           />
           {owned && <img className="owned-icon" src={checkMark}/>}
-          {(item.primaryStat || item.rating) &&
+          {Boolean(item.primaryStat || item.rating) &&
             <div>
-              {item.rating && <div className="item-stat item-review">
+              {item.rating && item.rating > 0 && <div className="item-stat item-review">
                 {item.rating}
                 <i className="fa fa-star" style={dtrRatingColor(item.rating)}/>
               </div>}
-              {item.primaryStat && <div className="item-stat item-equipment">{item.primaryStat}</div>}
+              {Boolean(item.primaryStat) && <div className="item-stat item-equipment">{item.primaryStat}</div>}
             </div>}
-          {progress !== null && !item.canPurchase &&
+          {progress > 0 && !item.canPurchase &&
             <div className="item-stat item-equipment">{percent(progress)}</div>
           }
         </div>

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -96,6 +96,9 @@ export default class VendorItemComponent extends React.Component<Props> {
               </div>}
               {item.primaryStat && <div className="item-stat item-equipment">{item.primaryStat}</div>}
             </div>}
+          {progress !== null && !item.canPurchase &&
+            <div className="item-stat item-equipment">{percent(progress)}</div>
+          }
         </div>
         <div className="vendor-costs">
           {item.costs.map((cost) =>

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -244,7 +244,7 @@ export class VendorItem {
     return null;
   }
 
-  get objectiveProgress(): number | null {
+  get objectiveProgress(): number {
     if (this.itemComponents && this.itemComponents.objectives && this.itemComponents.objectives.data[this.inventoryItem.hash]) {
       const objectives = this.itemComponents.objectives.data[this.inventoryItem.hash].objectives;
       return sum(objectives, (objective) => {
@@ -256,7 +256,7 @@ export class VendorItem {
         }
       });
     }
-    return null;
+    return 0;
   }
 
   equals(other: VendorItem) {

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -42,7 +42,7 @@ export function initi18n(): Promise<never> {
         escapeValue: false,
         format(val, format) {
           if (format === 'pct') {
-            return percent(parseInt(val, 10));
+            return percent(parseFloat(val));
           } else if (format === 'humanBytes') {
             return humanBytes(parseInt(val, 10));
           }

--- a/src/app/move-popup/Sockets.tsx
+++ b/src/app/move-popup/Sockets.tsx
@@ -158,7 +158,6 @@ function PlugTooltip({
   defs?: D2ManifestDefinitions;
 }) {
 
-  // TODO: Show objectives too, by processing plugObjectives like any other objectives
   // TODO: show insertion costs
 
   return (

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -683,7 +683,8 @@
     "Load": "Loading Vendors",
     "ShadersAndEmblems": "Shaders & Emblems",
     "ShipsAndVehicles": "Ships & Vehicles",
-    "Vendors": "Vendors"
+    "Vendors": "Vendors",
+    "OrnamentsDisclaimer": "DIM can only show ornaments that could be unlocked on items you have in your inventory."
   },
   "Views": {
     "About": {


### PR DESCRIPTION
This adds an "Ornaments" section to the bottom of the "Collections" page. Unfortunately I can't find the status of every ornament, only the ones that could be slotted into items you happen to own. Vendors don't even return sockets on armor, and while I could enumerate all the ornaments, I couldn't tell you what your progress was on them. So this is limited to only stuff you could actually equip if you unlocked it.

<img width="946" alt="screen shot 2018-05-28 at 11 03 37 pm" src="https://user-images.githubusercontent.com/313208/40640557-60c673c0-62cb-11e8-98be-e583282fecb5.png">

Note: The Vendors/Collections React stuff is getting really messy. I'll fix it all when I join it back to the Inventory screen code.