### PR TITLE
remove the underline (from links) on the filter autocomplete popup

### DIFF
--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -134,6 +134,7 @@
     &:hover {
       cursor: pointer;
     }
+    text-decoration-line: none;
   }
   list-style: none;
   padding: 0;


### PR DESCRIPTION
because I do believe this was a mistake/undesired result of some rss change.

![image](https://user-images.githubusercontent.com/32077894/40889870-2691891a-6744-11e8-8982-7dc8183d9b1e.png)
