### PR TITLE
Update position of item tag

### DIFF
--- a/src/app/inventory/dimStoreItem.scss
+++ b/src/app/inventory/dimStoreItem.scss
@@ -179,7 +179,7 @@ dim-store-item {
   text-shadow: 0px 0px 2px rgba(0, 0, 0, 0.7);
   position: absolute;
   top: 4px;
-  left: 4px;
+  right: 4px;
   color: gold;
   pointer-events: none;
   &.no-tag {


### PR DESCRIPTION
Move tag icon to top-right corner of each item so that it does not overlap expansion icon.