### PR TITLE
Fix CSS variable detection for Edge

### DIFF
--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -123,7 +123,7 @@ export function SettingsController(
   vm.initialLanguage = vm.settings.language;
 
   // Edge doesn't support these
-  vm.supportsCssVar = window.CSS && window.CSS.supports && window.CSS.supports('width', 'var(--fake-var)', 0);
+  vm.supportsCssVar = window.CSS && window.CSS.supports && window.CSS.supports('(--foo: red)');
 
   vm.downloadWeaponCsv = () => {
     downloadCsvFiles(vm.settings.destinyVersion === 2 ? D2StoresService.getStores() : dimStoreService.getStores(), "Weapons");

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,7 +35,7 @@ declare function ga(...params: string[]);
 
 interface Window {
   CSS: {
-    supports(propertyName: string, value: string, something: number);
+    supports(propertyName: string);
   }
   BroadcastChannel?: BroadcastChannel;
 }


### PR DESCRIPTION
Use a different expression. This is tested in Edge via BrowserScope.