### PR TITLE
Treat TypeError as a network failure

### DIFF
--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -47,6 +47,12 @@ export function error(message: string, errorCode: PlatformErrorCodes): DimError 
 }
 
 export async function handleErrors<T>(response: Response): Promise<ServerResponse<T>> {
+  if (response instanceof TypeError) {
+    throw new Error(navigator.onLine
+      ? t('BungieService.NotConnectedOrBlocked')
+      : t('BungieService.NotConnected'));
+  }
+
   if (response instanceof Error) {
     throw response;
   }

--- a/src/app/manifest/manifest-service.ts
+++ b/src/app/manifest/manifest-service.ts
@@ -93,7 +93,7 @@ class ManifestService {
         let message = e.message || e;
         this.statusText = t('Manifest.Error', { error: message });
 
-        if (e.status === -1) {
+        if (e instanceof TypeError || e.status === -1) {
           message = navigator.onLine
             ? t('BungieService.NotConnectedOrBlocked')
             : t('BungieService.NotConnected');

--- a/src/authReturn.ts
+++ b/src/authReturn.ts
@@ -35,7 +35,7 @@ function handleAuthReturn() {
       window.location.href = "/index.html";
     })
     .catch((error) => {
-      if (error.status === -1) {
+      if (error instanceof TypeError || error.status === -1) {
         setError('A content blocker is interfering with either DIM or Bungie.net, or you are not connected to the internet.');
         return;
       }


### PR DESCRIPTION
For Fetch, when there's a network error, it'll throw a TypeError instead of returning a response with status code -1. This is unfortunate as TypeErrors can also be thrown from other bugs, but it's the best we've got.