### PR TITLE
Generate content security policy config

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -1,0 +1,98 @@
+const csp = require('content-security-policy-builder');
+
+const SELF = "'self'";
+
+/**
+ * Generate a Content Security Policy directive for a particular DIM environment (beta, release)
+ */
+module.exports = function csp(env) {
+  const baseCSP = {
+    defaultSrc: ['none'],
+    scriptSrc: [
+      SELF,
+      // For Webpack?
+      "'unsafe-eval'",
+      "'unsafe-inline'",
+      'data:',
+      // Include a snippet of inline scripts
+      "'report-sample'",
+      // Google API (Drive)
+      'https://apis.google.com',
+      'https://www.google-analytics.com',
+      // Twitter Widget
+      'https://platform.twitter.com',
+      'https://cdn.syndication.twimg.com',
+    ],
+    styleSrc: [
+      SELF,
+      // For Webpack's inserted styles
+      "'unsafe-inline'",
+      // Google Fonts
+      "https://fonts.googleapis.com/css",
+      // Twitter Widget
+      "https://platform.twitter.com/css/",
+      "https://*.twimg.com/"
+    ],
+    connectSrc: [
+      SELF,
+      // Google Analytics
+      "https://www.google-analytics.com",
+      // Bungie.net API
+      "https://www.bungie.net",
+      // DTR Reviews API
+      "https://reviews-api.destinytracker.net",
+      "https://db-api.destinytracker.com"
+    ],
+    imgSrc: [
+      SELF,
+      // Webpack inlines some images
+      "data:",
+      // Bungie.net images
+      "https://www.bungie.net",
+      // Google analytics tracking
+      "https://ssl.google-analytics.com",
+      "https://www.google-analytics.com",
+      "https://csi.gstatic.com",
+      // OpenCollective backers
+      "https://opencollective.com",
+      // Twitter Widget
+      "https://syndication.twitter.com",
+      "https://platform.twitter.com",
+      "https://*.twimg.com/"
+    ],
+    fontSrc: [
+      SELF,
+      // Google Fonts
+      "https://fonts.gstatic.com"
+    ],
+    childSrc: [
+      SELF,
+      // Google Login
+      "https://accounts.google.com",
+      "https://content.googleapis.com"
+    ],
+    frameSrc: [
+      // Google Login
+      "https://accounts.google.com",
+      "https://content.googleapis.com",
+      // Twitter Widget
+      "https://syndication.twitter.com/",
+      "https://platform.twitter.com/"
+    ],
+    objectSrc: SELF,
+    // Web app manifest
+    manifestSrc: SELF
+  }
+
+  // Turn on reporting to sentry.io on beta only
+  if (env === 'beta') {
+    baseCSP.reportUri = "https://sentry.io/api/279673/csp-report/?sentry_key=1367619d45da481b8148dd345c1a1330"
+    baseCSP.connectSrc.push("https://sentry.io/api/279673/store/")
+  } else if (env === 'release') {
+    // Allow release to load updated classified item definitions and images from beta
+    baseCSP.connectSrc.push("https://beta.destinyitemmanager.com");
+    baseCSP.imgSrc.push("https://beta.destinyitemmanager.com");
+  }
+
+  return builder(baseCSP);
+}

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -11,6 +11,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackIncludeSiblingChunksPlugin = require('html-webpack-include-sibling-chunks-plugin');
 const GenerateJsonPlugin = require('generate-json-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
+const csp = require('./content-security-policy');
 
 // const Visualizer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
@@ -206,13 +207,23 @@ module.exports = (env) => {
         chunks: ['gdriveReturn']
       }),
 
+      // Generate the .htaccess file (kind of an abuse of HtmlWebpack plugin just for templating)
+      new HtmlWebpackPlugin({
+        filename: '.htaccess',
+        template: 'src/htaccess',
+        inject: false,
+        templateParameters: {
+          csp: csp(env)
+        }
+      }),
+
+
       // Generate a version info JSON file we can poll. We could theoretically add more info here too.
       new GenerateJsonPlugin('./version.json', {
         version
       }),
 
       new CopyWebpackPlugin([
-        { from: './src/.htaccess' },
         { from: './extension', to: '../extension-dist' },
         { from: `./icons/${env}-extension/`, to: '../extension-dist' },
         { from: './src/manifest-webapp.json' },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-preset-env": "^1.6.1",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "clean-webpack-plugin": "^0.1.19",
+    "content-security-policy-builder": "^2.0.0",
     "copy-webpack-plugin": "^4.5.1",
     "css-loader": "^0.28.11",
     "exports-loader": "^0.7.0",

--- a/src/htaccess
+++ b/src/htaccess
@@ -476,7 +476,7 @@ AddDefaultCharset utf-8
 
 <IfModule mod_headers.c>
 
-    Header set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' 'report-sample' https://apis.google.com https://www.google-analytics.com https://platform.twitter.com https://cdn.syndication.twimg.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css https://platform.twitter.com/css/ https://*.twimg.com/; connect-src 'self' https://*.destinyitemmanager.com https://www.google-analytics.com https://www.bungie.net https://reviews-api.destinytracker.net https://db-api.destinytracker.com https://sentry.io/api/279673/store/; img-src 'self' https://*.destinyitemmanager.com https://www.bungie.net https://ssl.google-analytics.com https://www.google-analytics.com https://csi.gstatic.com https://opencollective.com https://syndication.twitter.com https://platform.twitter.com https://*.twimg.com/ data:; font-src 'self' https://fonts.gstatic.com; child-src 'self' https://accounts.google.com https://content.googleapis.com; frame-src  https://accounts.google.com https://content.googleapis.com https://syndication.twitter.com/ https://platform.twitter.com/; object-src 'self'; manifest-src 'self'; report-uri https://sentry.io/api/279673/csp-report/?sentry_key=1367619d45da481b8148dd345c1a1330"
+    Header set Content-Security-Policy "<%= csp %>"
 
     # `mod_headers` cannot match based on the content-type, however,
     # the `Content-Security-Policy` response header should be send

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,6 +1967,10 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
+content-security-policy-builder@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/content-security-policy-builder/-/content-security-policy-builder-2.0.0.tgz#8749a1d542fcbe82237281ea9f716ce68b394dd2"
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"


### PR DESCRIPTION
This switches to generating the CSP header config in our .htaccess file from JavaScript, instead of hardcoding it. This gets us two things:

1. We can now generate different things for beta and release - for example, not including Sentry on release.
2. It's way easier to read and can have comments!