### PR TITLE
Make stores services and item service into normal modules

### DIFF
--- a/docs/TRANSLATIONS.md
+++ b/docs/TRANSLATIONS.md
@@ -14,7 +14,7 @@ Due to what information is provided by Bungie about item names and descriptions 
 
 # Translating DIM
 
-We use [i18next](https://github.com/i18next/ng-i18next) for all our translated strings, so if you want to translate something that's currently English-only, take a look at that. Usually it's as simple as replacing some text with `<span ng-i18next="KEY"></span>` and then defining KEY in the i18n file. Within code, you need to use the `$i18next.t` service - see `dimStoreService` for an example.
+We use [i18next](https://github.com/i18next/ng-i18next) for all our translated strings, so if you want to translate something that's currently English-only, take a look at that. Usually it's as simple as replacing some text with `<span ng-i18next="KEY"></span>` and then defining KEY in the i18n file. Within code, you need to use the `$i18next.t` service - see `D1StoresService` for an example.
 
 # Join the translation team @ Crowdin
  [Crowdin](https://crowdin.com/project/destiny-item-manager/invite?d=6565n46535j5l4135333g443q4e4n4r413f3a323o4k5o4u4b343n4k4)

--- a/src/app/activities/activities.component.ts
+++ b/src/app/activities/activities.component.ts
@@ -7,7 +7,8 @@ import template from './activities.html';
 import './activities.scss';
 import { IComponentOptions, IController, IScope } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { D1StoreServiceType, D1Store } from '../inventory/store-types';
+import { D1Store } from '../inventory/store-types';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 export const ActivitiesComponent: IComponentOptions = {
   controller: ActivitiesController,
@@ -23,7 +24,6 @@ function ActivitiesController(
     settings: typeof settings;
   },
   $scope: IScope,
-  dimStoreService: D1StoreServiceType,
   $i18next
 ) {
   'ngInject';
@@ -43,12 +43,12 @@ function ActivitiesController(
   };
 
   this.$onInit = () => {
-    subscribeOnScope($scope, dimStoreService.getStoresStream(vm.account), init);
+    subscribeOnScope($scope, D1StoresService.getStoresStream(vm.account), init);
   };
 
   $scope.$on('dim-refresh', () => {
     // TODO: refresh just advisors
-    dimStoreService.reloadStores();
+    D1StoresService.reloadStores();
   });
 
   // TODO: Ideally there would be an Advisors service that would

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -12,19 +12,19 @@ import { D2ManifestService } from '../manifest/manifest-service';
 import './collections.scss';
 import { fetchRatingsForKiosks } from '../d2-vendors/vendor-ratings';
 import { Subscription } from 'rxjs/Subscription';
-import { DimStore, StoreServiceType } from '../inventory/store-types';
+import { DimStore } from '../inventory/store-types';
 import Kiosk from './Kiosk';
 import { t } from 'i18next';
 import PlugSet from './PlugSet';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import Ornaments from './Ornaments';
+import { D2StoresService } from '../inventory/d2-stores.service';
 
 interface Props {
   $scope: IScope;
   $stateParams: StateParams;
   account: DestinyAccount;
-  D2StoresService: StoreServiceType;
 }
 
 interface State {
@@ -64,7 +64,7 @@ export default class Collections extends React.Component<Props, State> {
 
   componentDidMount() {
     this.loadCollections();
-    this.storesSubscription = this.props.D2StoresService.getStoresStream(this.props.account).subscribe((stores) => {
+    this.storesSubscription = D2StoresService.getStoresStream(this.props.account).subscribe((stores) => {
       if (stores) {
         const ownedItemHashes = new Set<number>();
         for (const store of stores) {

--- a/src/app/collections/collections.module.ts
+++ b/src/app/collections/collections.module.ts
@@ -5,7 +5,7 @@ import Collections from './Collections';
 
 // This is the Destiny 2 "collections" pages
 export const collectionsModule = module('d2collectionsModule', [])
-  .component('collections', react2angular(Collections, ['account'], ['$scope', '$stateParams', 'D2StoresService']))
+  .component('collections', react2angular(Collections, ['account'], ['$scope', '$stateParams']))
   .config(($stateProvider: StateProvider) => {
     'ngInject';
 

--- a/src/app/compare/compare.component.ts
+++ b/src/app/compare/compare.component.ts
@@ -4,7 +4,6 @@ import './compare.scss';
 import { element as angularElement, IController, IComponentOptions, IScope } from 'angular';
 import { sum } from '../util';
 import { DimItem } from '../inventory/item-types';
-import { StoreServiceType } from '../inventory/store-types';
 import { CompareService } from './compare.service';
 import { TransitionService } from '@uirouter/angularjs';
 
@@ -40,8 +39,6 @@ function CompareCtrl(
   },
   $scope: IScope,
   toaster,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   $i18next,
   $transitions: TransitionService
 ) {
@@ -59,10 +56,6 @@ function CompareCtrl(
   vm.$onDestroy = () => {
     this.listener();
   };
-
-  function getStoreService(item: DimItem) {
-    return item.destinyVersion === 2 ? D2StoresService : dimStoreService;
-  }
 
   function addMissingStats(item: DimItem): DimItem {
     if (!item.stats) {
@@ -196,7 +189,7 @@ function CompareCtrl(
 
     if (args.dupes) {
       vm.compare = args.item;
-      const allItems = getStoreService(args.item).getAllItems();
+      const allItems = args.item.getStoresService().getAllItems();
       vm.similarTypes = allItems.filter((i) => i.typeName === vm.compare.typeName);
       let armorSplit;
       if (!vm.compare.location.inWeapons) {

--- a/src/app/d2-vendors/SingleVendor.tsx
+++ b/src/app/d2-vendors/SingleVendor.tsx
@@ -14,15 +14,15 @@ import './vendor.scss';
 import { fetchRatingsForVendor, fetchRatingsForVendorDef } from './vendor-ratings';
 import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { Subscription } from 'rxjs/Subscription';
-import { D2StoreServiceType, D2Store } from '../inventory/store-types';
+import { D2Store } from '../inventory/store-types';
 import { getVendorItems } from './Vendor';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
+import { D2StoresService } from '../inventory/d2-stores.service';
 
 interface Props {
   $scope: IScope;
   $stateParams: StateParams;
   account: DestinyAccount;
-  D2StoresService: D2StoreServiceType;
 }
 
 interface State {
@@ -68,7 +68,7 @@ export default class SingleVendor extends React.Component<Props, State> {
       // we at least need to display that character!
       let characterId: string = this.props.$stateParams.characterId;
       if (!characterId) {
-        const stores = this.state.stores || await this.props.D2StoresService.getStoresStream(this.props.account).take(1).toPromise();
+        const stores = this.state.stores || await D2StoresService.getStoresStream(this.props.account).take(1).toPromise();
         if (stores) {
           characterId = stores.find((s) => s.current)!.id;
         }
@@ -86,7 +86,7 @@ export default class SingleVendor extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    this.storesSubscription = this.props.D2StoresService.getStoresStream(this.props.account).subscribe((stores) => {
+    this.storesSubscription = D2StoresService.getStoresStream(this.props.account).subscribe((stores) => {
       if (stores) {
         const ownedItemHashes = new Set<number>();
         for (const store of stores) {

--- a/src/app/d2-vendors/Vendors.tsx
+++ b/src/app/d2-vendors/Vendors.tsx
@@ -14,15 +14,15 @@ import './vendor.scss';
 import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { fetchRatingsForVendors } from './vendor-ratings';
 import { Subscription } from 'rxjs/Subscription';
-import { D2StoreServiceType, D2Store } from '../inventory/store-types';
+import { D2Store } from '../inventory/store-types';
 import Vendor from './Vendor';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
+import { D2StoresService } from '../inventory/d2-stores.service';
 
 interface Props {
   $scope: IScope;
   $stateParams: StateParams;
   account: DestinyAccount;
-  D2StoresService: D2StoreServiceType;
 }
 
 interface State {
@@ -56,7 +56,7 @@ export default class Vendors extends React.Component<Props, State> {
     // we at least need to display that character!
     let characterId: string = this.props.$stateParams.characterId;
     if (!characterId) {
-      const stores = this.state.stores || await this.props.D2StoresService.getStoresStream(this.props.account).take(1).toPromise();
+      const stores = this.state.stores || await D2StoresService.getStoresStream(this.props.account).take(1).toPromise();
       if (stores) {
         characterId = stores.find((s) => s.current)!.id;
       }
@@ -78,7 +78,7 @@ export default class Vendors extends React.Component<Props, State> {
       loadingTracker.addPromise(promise);
     });
 
-    this.storesSubscription = this.props.D2StoresService.getStoresStream(this.props.account).subscribe((stores) => {
+    this.storesSubscription = D2StoresService.getStoresStream(this.props.account).subscribe((stores) => {
       if (stores) {
         const ownedItemHashes = new Set<number>();
         for (const store of stores) {

--- a/src/app/d2-vendors/vendors.module.ts
+++ b/src/app/d2-vendors/vendors.module.ts
@@ -6,8 +6,8 @@ import Vendors from './Vendors';
 
 // This is the Destiny 2 "Vendors" pages
 export const d2VendorsModule = module('d2VendorsModule', [])
-  .component('d2Vendors', react2angular(Vendors, ['account'], ['$scope', '$stateParams', 'D2StoresService']))
-  .component('d2SingleVendor', react2angular(SingleVendor, ['account'], ['$scope', '$stateParams', 'D2StoresService']))
+  .component('d2Vendors', react2angular(Vendors, ['account'], ['$scope', '$stateParams']))
+  .component('d2SingleVendor', react2angular(SingleVendor, ['account'], ['$scope', '$stateParams']))
   .config(($stateProvider: StateProvider) => {
     'ngInject';
 

--- a/src/app/destiny2/d2-inventory.component.ts
+++ b/src/app/destiny2/d2-inventory.component.ts
@@ -3,7 +3,7 @@ import { subscribeOnScope } from '../rx-utils';
 import { getBuckets } from './d2-buckets.service';
 import { IComponentOptions, IScope, IController } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { StoreServiceType } from '../inventory/store-types';
+import { D2StoresService } from '../inventory/d2-stores.service';
 
 export const D2InventoryComponent: IComponentOptions = {
   template,
@@ -17,8 +17,7 @@ function D2InventoryController(
   this: IController & {
     account: DestinyAccount;
   },
-  $scope: IScope,
-  D2StoresService: StoreServiceType
+  $scope: IScope
 ) {
   'ngInject';
 

--- a/src/app/farming/d2farming.service.ts
+++ b/src/app/farming/d2farming.service.ts
@@ -4,7 +4,7 @@ import { getBuckets } from '../destiny2/d2-buckets.service';
 import { IIntervalService, IQService, IRootScopeService } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { settings } from '../settings/settings';
-import { ItemServiceType, MoveReservations } from '../inventory/dimItemService.factory';
+import { MoveReservations, dimItemService } from '../inventory/dimItemService.factory';
 import { D2Store } from '../inventory/store-types';
 import { D2Item } from '../inventory/item-types';
 import { InventoryBucket } from '../inventory/inventory-buckets';
@@ -18,7 +18,6 @@ import { D2StoresService } from '../inventory/d2-stores.service';
 export function D2FarmingService(
   $rootScope: IRootScopeService,
   $q: IQService,
-  dimItemService: ItemServiceType,
   $interval: IIntervalService,
   toaster,
   $i18next

--- a/src/app/farming/d2farming.service.ts
+++ b/src/app/farming/d2farming.service.ts
@@ -5,10 +5,11 @@ import { IIntervalService, IQService, IRootScopeService } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { settings } from '../settings/settings';
 import { ItemServiceType, MoveReservations } from '../inventory/dimItemService.factory';
-import { D2StoreServiceType, D2Store } from '../inventory/store-types';
+import { D2Store } from '../inventory/store-types';
 import { D2Item } from '../inventory/item-types';
 import { InventoryBucket } from '../inventory/inventory-buckets';
 import { BucketCategory } from 'bungie-api-ts/destiny2';
+import { D2StoresService } from '../inventory/d2-stores.service';
 
 /**
  * A service for "farming" items by moving them continuously off a character,
@@ -18,7 +19,6 @@ export function D2FarmingService(
   $rootScope: IRootScopeService,
   $q: IQService,
   dimItemService: ItemServiceType,
-  D2StoresService: D2StoreServiceType,
   $interval: IIntervalService,
   toaster,
   $i18next

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -3,9 +3,9 @@ import { settings as dimSettings } from '../settings/settings';
 import * as _ from 'underscore';
 import { sum } from '../util';
 import { getBuckets } from '../destiny1/d1-buckets.service';
-import { StoreServiceType } from '../inventory/store-types';
 import { ItemServiceType, MoveReservations } from '../inventory/dimItemService.factory';
 import { D1Item, DimItem } from '../inventory/item-types';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 /**
  * A service for "farming" items by moving them continuously off a character,
@@ -15,7 +15,6 @@ export function FarmingService(
   $rootScope: IRootScopeService,
   $q: IQService,
   dimItemService: ItemServiceType,
-  dimStoreService: StoreServiceType,
   $interval: IIntervalService,
   toaster,
   $i18next
@@ -77,22 +76,22 @@ export function FarmingService(
           // Move a single item. We do this as a chain of promises so we can reevaluate the situation after each move.
           return promise
             .then(() => {
-              const vault = dimStoreService.getVault()!;
+              const vault = D1StoresService.getVault()!;
               const vaultSpaceLeft = vault.spaceLeftForItem(item);
               if (vaultSpaceLeft <= 1) {
                 // If we're down to one space, try putting it on other characters
-                const otherStores = dimStoreService.getStores().filter((store) => !store.isVault && store.id !== this.store.id);
+                const otherStores = D1StoresService.getStores().filter((store) => !store.isVault && store.id !== this.store.id);
                 const otherStoresWithSpace = otherStores.filter((store) => store.spaceLeftForItem(item));
 
                 if (otherStoresWithSpace.length) {
                   if ($featureFlags.debugMoves) {
-                    console.log("Farming initiated move:", item.amount, item.name, item.type, 'to', otherStoresWithSpace[0].name, 'from', dimStoreService.getStore(item.owner)!.name);
+                    console.log("Farming initiated move:", item.amount, item.name, item.type, 'to', otherStoresWithSpace[0].name, 'from', D1StoresService.getStore(item.owner)!.name);
                   }
                   return dimItemService.moveTo(item, otherStoresWithSpace[0], false, item.amount, items, reservations);
                 }
               }
               if ($featureFlags.debugMoves) {
-                console.log("Farming initiated move:", item.amount, item.name, item.type, 'to', vault.name, 'from', dimStoreService.getStore(item.owner)!.name);
+                console.log("Farming initiated move:", item.amount, item.name, item.type, 'to', vault.name, 'from', D1StoresService.getStore(item.owner)!.name);
               }
               return dimItemService.moveTo(item, vault, false, item.amount, items, reservations);
             })
@@ -113,7 +112,7 @@ export function FarmingService(
       });
     },
     farmItems() {
-      const store = dimStoreService.getStore(this.store.id)!;
+      const store = D1StoresService.getStore(this.store.id)!;
       const toMove = _.select(store.items, (i) => {
         return !i.notransfer && (
           i.isEngram ||
@@ -134,7 +133,7 @@ export function FarmingService(
     // Ensure that there's one open space in each category that could
     // hold an item, so they don't go to the postmaster.
     makeRoomForItems() {
-      const store = dimStoreService.getStore(this.store.id)!;
+      const store = D1StoresService.getStore(this.store.id)!;
 
       // If any category is full, we'll move one aside
       const itemsToMove: DimItem[] = [];
@@ -182,11 +181,11 @@ export function FarmingService(
         ];
 
         this.consolidate = _.compact(consolidateHashes.map((hash) => {
-          const ret = copy(dimStoreService.getItemAcrossStores({
+          const ret = copy(D1StoresService.getItemAcrossStores({
             hash
           }));
           if (ret) {
-            ret.amount = sum(dimStoreService.getStores(), (s) => s.amountOfItem(ret));
+            ret.amount = sum(D1StoresService.getStores(), (s) => s.amountOfItem(ret));
           }
           return ret;
         }));
@@ -206,7 +205,7 @@ export function FarmingService(
 
         // Whenever the store is reloaded, run the farming algo
         // That way folks can reload manually too
-        subscription = dimStoreService.getStoresStream(account).subscribe((stores) => {
+        subscription = D1StoresService.getStoresStream(account).subscribe((stores) => {
           // prevent some recursion...
           if (this.active && !this.movingItems && !this.makingRoom && stores) {
             const store = stores.find((s) => s.id === storeId);

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -3,7 +3,7 @@ import { settings as dimSettings } from '../settings/settings';
 import * as _ from 'underscore';
 import { sum } from '../util';
 import { getBuckets } from '../destiny1/d1-buckets.service';
-import { ItemServiceType, MoveReservations } from '../inventory/dimItemService.factory';
+import { MoveReservations, dimItemService } from '../inventory/dimItemService.factory';
 import { D1Item, DimItem } from '../inventory/item-types';
 import { D1StoresService } from '../inventory/d1-stores.service';
 
@@ -14,7 +14,6 @@ import { D1StoresService } from '../inventory/d1-stores.service';
 export function FarmingService(
   $rootScope: IRootScopeService,
   $q: IQService,
-  dimItemService: ItemServiceType,
   $interval: IIntervalService,
   toaster,
   $i18next

--- a/src/app/infuse/infuse.component.ts
+++ b/src/app/infuse/infuse.component.ts
@@ -5,7 +5,7 @@ import { getDefinitions } from '../destiny1/d1-definitions.service';
 import template from './infuse.html';
 import './infuse.scss';
 import { LoadoutServiceType, Loadout } from '../loadout/loadout.service';
-import { StoreServiceType } from '../inventory/store-types';
+import { DimItem } from '../inventory/item-types';
 
 export const InfuseComponent: IComponentOptions = {
   template,
@@ -17,10 +17,10 @@ export const InfuseComponent: IComponentOptions = {
 };
 
 function InfuseCtrl(
-  this: IController,
+  this: IController & {
+    query: DimItem;
+  },
   $scope,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   dimLoadoutService: LoadoutServiceType,
   toaster,
   $q: IQService,
@@ -68,12 +68,15 @@ function InfuseCtrl(
       if (e) {
         e.stopPropagation();
       }
+      if (!source || !target) {
+        return;
+      }
       vm.source = source;
       vm.target = target;
 
       vm.infused = vm.target.primStat.value;
 
-      if (vm.source.destinyVersion === 2) {
+      if (vm.source!.destinyVersion === 2) {
         /*
         // Rules taken from https://bungie-net.github.io/multi/schema_Destiny-Definitions-Items-DestinyItemTierTypeInfusionBlock.html#schema_Destiny-Definitions-Items-DestinyItemTierTypeInfusionBlock
         const sourceBasePower = vm.source.basePower;
@@ -106,7 +109,7 @@ function InfuseCtrl(
 
     // get Items for infusion
     getItems() {
-      let stores = vm.query.destinyVersion === 1 ? dimStoreService.getStores() : D2StoresService.getStores();
+      let stores = vm.query.getStoresService().getStores();
 
       // If we want ALL our weapons, including vault's one
       if (!vm.getAllItems) {
@@ -181,7 +184,7 @@ function InfuseCtrl(
         return $q.resolve();
       }
 
-      const store = (vm.source.destinyVersion === 1 ? dimStoreService : D2StoresService).getStore(vm.query.owner)!;
+      const store = vm.source.getStoresService().getStore(vm.query.owner)!;
       const items: { [key: string]: any[] } = {};
       const targetKey = vm.target.type.toLowerCase();
       items[targetKey] = items[targetKey] || [];

--- a/src/app/inventory/d1-stores.service.ts
+++ b/src/app/inventory/d1-stores.service.ts
@@ -23,7 +23,9 @@ import { D1Item } from './item-types';
 import { InventoryBuckets } from './inventory-buckets';
 import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 
-export function StoreService(): D1StoreServiceType {
+export const D1StoresService = StoreService();
+
+function StoreService(): D1StoreServiceType {
   'ngInject';
 
   let _stores: D1Store[] = [];
@@ -210,7 +212,7 @@ export function StoreService(): D1StoreServiceType {
       .catch((e) => {
         toaster.pop(bungieErrorToaster(e));
         console.error('Error loading stores', e);
-        reportException('dimStoreService', e);
+        reportException('D1StoresService', e);
         // It's important that we swallow all errors here - otherwise
         // our observable will fail on the first error. We could work
         // around that with some rxjs operators, but it's easier to

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -36,11 +36,13 @@ import { InventoryBuckets } from './inventory-buckets';
 import { DimError } from '../bungie-api/bungie-service-helper';
 import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 
+export const D2StoresService = makeD2StoresService();
+
 /**
  * TODO: For now this is a copy of StoreService customized for D2. Over time we should either
  * consolidate them, or at least organize them better.
  */
-export function D2StoresService(): D2StoreServiceType {
+function makeD2StoresService(): D2StoreServiceType {
   'ngInject';
 
   let _stores: D2Store[] = [];

--- a/src/app/inventory/dimClearNewItems.directive.ts
+++ b/src/app/inventory/dimClearNewItems.directive.ts
@@ -4,7 +4,8 @@ import template from './dimClearNewItems.directive.html';
 import './dimClearNewItems.scss';
 import { IComponentOptions, IController, IScope } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { StoreServiceType } from './store-types';
+import { D2StoresService } from './d2-stores.service';
+import { D1StoresService } from './d1-stores.service';
 
 /**
  * A button that marks all new items as "seen".
@@ -20,10 +21,8 @@ export const ClearNewItemsComponent: IComponentOptions = {
 function ClearNewItemsCtrl(
   this: IController & { account: DestinyAccount },
   $scope: IScope,
-  D2StoresService: StoreServiceType,
   hotkeys,
-  $i18next,
-  dimStoreService: StoreServiceType
+  $i18next
 ) {
   "ngInject";
 
@@ -45,7 +44,7 @@ function ClearNewItemsCtrl(
   this.clearNewItems = () => {
     const stores = (this.account.destinyVersion === 2
       ? D2StoresService
-      : dimStoreService
+      : D1StoresService
     ).getStores();
     NewItemsService.clearNewItems(stores, this.account);
   };

--- a/src/app/inventory/dimItemMoveService.factory.ts
+++ b/src/app/inventory/dimItemMoveService.factory.ts
@@ -3,15 +3,14 @@ import { reportException } from '../exceptions';
 import { queuedAction } from '../inventory/action-queue';
 import { showInfoPopup } from '../shell/info-popup';
 import { IQService, IPromise } from 'angular';
-import { ItemServiceType } from './dimItemService.factory';
 import { DimStore } from './store-types';
 import { DimItem } from './item-types';
+import { dimItemService } from './dimItemService.factory';
 
 export function ItemMoveService(
   $q: IQService,
   loadingTracker,
   toaster,
-  dimItemService: ItemServiceType,
   $i18next
 ) {
   "ngInject";

--- a/src/app/inventory/dimStoreBucket.directive.ts
+++ b/src/app/inventory/dimStoreBucket.directive.ts
@@ -8,7 +8,7 @@ import { showInfoPopup } from '../shell/info-popup';
 import dialogTemplate from './dimStoreBucket.directive.dialog.html';
 import template from './dimStoreBucket.directive.html';
 import './dimStoreBucket.scss';
-import { ItemServiceType } from './dimItemService.factory';
+import { dimItemService } from './dimItemService.factory';
 import { DimError } from '../bungie-api/bungie-service-helper';
 import { DimStore } from './store-types';
 import { DimItem } from './item-types';
@@ -33,7 +33,6 @@ function StoreBucketCtrl(
   },
   $scope: IScope,
   loadingTracker,
-  dimItemService: ItemServiceType,
   $q: IQService,
   $timeout: ITimeoutService,
   toaster,

--- a/src/app/inventory/dimStoreBucket.directive.ts
+++ b/src/app/inventory/dimStoreBucket.directive.ts
@@ -10,7 +10,7 @@ import template from './dimStoreBucket.directive.html';
 import './dimStoreBucket.scss';
 import { ItemServiceType } from './dimItemService.factory';
 import { DimError } from '../bungie-api/bungie-service-helper';
-import { DimStore, StoreServiceType } from './store-types';
+import { DimStore } from './store-types';
 import { DimItem } from './item-types';
 import { InventoryBucket } from './inventory-buckets';
 
@@ -33,8 +33,6 @@ function StoreBucketCtrl(
   },
   $scope: IScope,
   loadingTracker,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   dimItemService: ItemServiceType,
   $q: IQService,
   $timeout: ITimeoutService,
@@ -45,10 +43,6 @@ function StoreBucketCtrl(
 ) {
   "ngInject";
   const vm = this;
-
-  function getStoreService(item: DimItem) {
-    return item.destinyVersion === 2 ? D2StoresService : dimStoreService;
-  }
 
   vm.settings = settings;
 
@@ -142,7 +136,7 @@ function StoreBucketCtrl(
           const vm = this;
           vm.item = $scope.ngDialogData;
           vm.moveAmount = vm.item.amount;
-          vm.maximum = getStoreService(vm.item)
+          vm.maximum = vm.item.getStoresService()
             .getStore(vm.item.owner)!
             .amountOfItem(item);
           vm.stacksWorth = Math.min(
@@ -187,7 +181,7 @@ function StoreBucketCtrl(
             "to",
             target.name,
             "from",
-            getStoreService(item).getStore(item.owner)!.name
+            item.getStoresService().getStore(item.owner)!.name
           );
         }
         let movePromise = dimItemService.moveTo(
@@ -200,7 +194,7 @@ function StoreBucketCtrl(
         const reload = item.equipped || equip;
         if (reload) {
           movePromise = movePromise.then((item) => {
-            return getStoreService(item)
+            return item.getStoresService()
               .updateCharacters()
               .then(() => item);
           });

--- a/src/app/inventory/dimStoreItem.directive.ts
+++ b/src/app/inventory/dimStoreItem.directive.ts
@@ -7,7 +7,6 @@ import './dimStoreItem.scss';
 import { IComponentOptions, IController, IScope, IRootElementService, IRootScopeService } from 'angular';
 import { LoadoutServiceType } from '../loadout/loadout.service';
 import { DimItem } from './item-types';
-import { StoreServiceType } from './store-types';
 import { CompareService } from '../compare/compare.service';
 
 export function tagIconFilter() {
@@ -51,17 +50,11 @@ export function StoreItemCtrl(
   $scope: IScope,
   $element: IRootElementService,
   dimItemMoveService,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   ngDialog,
   dimLoadoutService: LoadoutServiceType,
   $rootScope: IRootScopeService & { dragItem: DimItem }
 ) {
   "ngInject";
-
-  function getStoreService(item: DimItem) {
-    return item.destinyVersion === 2 ? D2StoresService : dimStoreService;
-  }
 
   if (!firstItemTimed) {
     firstItemTimed = true;
@@ -140,7 +133,7 @@ export function StoreItemCtrl(
   vm.doubleClicked = queuedAction((item, e) => {
     if (!dimLoadoutService.dialogOpen && !CompareService.dialogOpen) {
       e.stopPropagation();
-      const active = getStoreService(item).getActiveStore()!;
+      const active = item.getStoresService().getActiveStore()!;
 
       // Equip if it's not equipped or it's on another character
       const equip = !item.equipped || item.owner !== active.id;
@@ -185,7 +178,7 @@ export function StoreItemCtrl(
       function dialogController() {
         "ngInject";
         this.item = vm.item;
-        this.store = getStoreService(item).getStore(this.item.owner);
+        this.store = item.getStoresService().getStore(this.item.owner);
       }
 
       dialogResult = ngDialog.open({

--- a/src/app/inventory/inventory.component.ts
+++ b/src/app/inventory/inventory.component.ts
@@ -3,7 +3,7 @@ import { subscribeOnScope } from "../rx-utils";
 import { getBuckets } from "../destiny1/d1-buckets.service";
 import { IComponentOptions, IController, IScope } from "angular";
 import { DestinyAccount } from "../accounts/destiny-account.service";
-import { StoreServiceType } from "./store-types";
+import { D1StoresService } from "./d1-stores.service";
 
 export const InventoryComponent: IComponentOptions = {
   template,
@@ -15,8 +15,7 @@ export const InventoryComponent: IComponentOptions = {
 
 function InventoryController(
   this: IController & { account: DestinyAccount },
-  $scope: IScope,
-  dimStoreService: StoreServiceType
+  $scope: IScope
 ) {
   "ngInject";
 
@@ -25,7 +24,7 @@ function InventoryController(
   this.$onInit = () => {
     getBuckets().then((buckets) => {
       vm.buckets = buckets;
-      subscribeOnScope($scope, dimStoreService.getStoresStream(vm.account), (stores) => {
+      subscribeOnScope($scope, D1StoresService.getStoresStream(vm.account), (stores) => {
         if (stores) {
           vm.stores = stores;
         }
@@ -34,6 +33,6 @@ function InventoryController(
   };
 
   $scope.$on("dim-refresh", () => {
-    dimStoreService.reloadStores();
+    D1StoresService.reloadStores();
   });
 }

--- a/src/app/inventory/inventory.module.ts
+++ b/src/app/inventory/inventory.module.ts
@@ -9,14 +9,12 @@ import { StoreBucketComponent } from './dimStoreBucket.directive';
 import { StatsComponent } from './dimStats.directive';
 import { SimpleItemComponent } from './dimSimpleItem.directive';
 import { PercentWidth, percent } from './dimPercentWidth.directive';
-import { ItemService } from './dimItemService.factory';
 import { ItemMoveService } from './dimItemMoveService.factory';
 import { ClearNewItemsComponent } from './dimClearNewItems.directive';
 import { StorePagerComponent } from './store-pager.component';
 import { StateProvider } from '@uirouter/angularjs';
 
 export default module('inventoryModule', [])
-  .factory('dimItemService', ItemService)
   .factory('dimItemMoveService', ItemMoveService)
   .component('inventory', InventoryComponent)
   .component('dimStores', StoresComponent)

--- a/src/app/inventory/inventory.module.ts
+++ b/src/app/inventory/inventory.module.ts
@@ -1,8 +1,6 @@
 import { module } from 'angular';
 
 import { InventoryComponent } from './inventory.component';
-import { StoreService } from './d1-stores.service';
-import { D2StoresService } from './d2-stores.service';
 import { StoresComponent } from './dimStores.directive';
 import { StoreReputation } from './dimStoreReputation.directive';
 import { tagIconFilter, StoreItemComponent } from './dimStoreItem.directive';
@@ -18,8 +16,6 @@ import { StorePagerComponent } from './store-pager.component';
 import { StateProvider } from '@uirouter/angularjs';
 
 export default module('inventoryModule', [])
-  .factory('dimStoreService', StoreService)
-  .factory('D2StoresService', D2StoresService)
   .factory('dimItemService', ItemService)
   .factory('dimItemMoveService', ItemMoveService)
   .component('inventory', InventoryComponent)

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -10,7 +10,7 @@ import {
   DestinyItemQualityBlockDefinition
 } from 'bungie-api-ts/destiny2';
 import { DimItemInfo } from './dim-item-info';
-import { DimStore } from './store-types';
+import { DimStore, StoreServiceType, D1StoreServiceType, D2StoreServiceType } from './store-types';
 import { InventoryBucket } from './inventory-buckets';
 import { D2RatingData } from '../item-review/d2-dtr-api-types';
 import { D1RatingData } from '../item-review/d1-dtr-api-types';
@@ -102,6 +102,7 @@ export interface DimItem {
   inCategory(categoryName: string): boolean;
   canBeInLoadout(): boolean;
   updateManualMoveTimestamp(): void;
+  getStoresService(): StoreServiceType;
 
   /**
    * Check if this item is from D1. Inside an if statement, this item will be narrowed to type D1Item.
@@ -130,6 +131,7 @@ export interface D1Item extends DimItem {
   trackable: boolean;
 
   dtrRating: D1RatingData | null;
+  getStoresService(): D1StoreServiceType;
 }
 
 /**
@@ -145,6 +147,7 @@ export interface D2Item extends DimItem {
   infusionQuality: DestinyItemQualityBlockDefinition | null;
   infusionProcess: DestinyItemTierTypeInfusionBlock | null;
   dtrRating: D2RatingData | null;
+  getStoresService(): D2StoreServiceType;
 }
 
 export interface D2PrimStat extends DestinyStat {

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -110,6 +110,8 @@ export interface DimStore {
    * Check if this store is from D2. Inside an if statement, this item will be narrowed to type D2Store.
    */
   isDestiny2(): this is D2Store;
+
+  getStoresService(): StoreServiceType;
 }
 
 interface VaultCounts {
@@ -190,6 +192,7 @@ export interface D1Store extends DimStore {
   ): IPromise<D1Store[]>;
   updateCharacterInfoFromEquip(characterInfo);
   factionAlignment();
+  getStoresService(): D1StoreServiceType;
 }
 
 /**
@@ -207,4 +210,5 @@ export interface D2Store extends DimStore {
     defs: D2ManifestDefinitions,
     bStore: DestinyCharacterComponent
   ): IPromise<D2Store[]>;
+  getStoresService(): D1StoreServiceType;
 }

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -17,6 +17,7 @@ import { t } from 'i18next';
 import { D1Store } from '../store-types';
 import { D1Item, D1TalentGrid, D1GridNode, DimObjective, D1Stat } from '../item-types';
 import { InventoryBuckets } from '../inventory-buckets';
+import { D1StoresService } from '../d1-stores.service';
 
 const yearHashes = {
   //         tTK       Variks        CoE         FoTL    Kings Fall
@@ -102,6 +103,9 @@ const ItemProto = {
   },
   isDestiny2(this: D1Item) {
     return false;
+  },
+  getStoresService() {
+    return D1StoresService;
   }
 };
 

--- a/src/app/inventory/store/d1-store-factory.service.ts
+++ b/src/app/inventory/store/d1-store-factory.service.ts
@@ -12,6 +12,7 @@ import vaultIcon from 'app/images/vault.png';
 import vaultBackground from 'app/images/vault-background.png';
 import { D1Store, D1Vault } from '../store-types';
 import { D1Item } from '../item-types';
+import { D1StoresService } from '../d1-stores.service';
 
 // Label isn't used, but it helps us understand what each one is
 const progressionMeta = {
@@ -160,6 +161,10 @@ const StoreProto = {
 
   isDestiny2(this: D1Store) {
     return false;
+  },
+
+  getStoresService() {
+    return D1StoresService;
   }
 };
 

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -38,6 +38,7 @@ import { D2Item, DimPerk, DimStat, DimObjective, DimFlavorObjective, DimTalentGr
 import { D2Store } from '../store-types';
 import { InventoryBuckets } from '../inventory-buckets';
 import { D2RatingData } from '../../item-review/d2-dtr-api-types';
+import { D2StoresService } from '../d2-stores.service';
 
 // Maps tierType to tierTypeName in English
 const tiers = [
@@ -143,6 +144,9 @@ const ItemProto = {
   },
   isDestiny2(this: D2Item) {
     return true;
+  },
+  getStoresService() {
+    return D2StoresService;
   }
 };
 

--- a/src/app/inventory/store/d2-store-factory.service.ts
+++ b/src/app/inventory/store/d2-store-factory.service.ts
@@ -19,6 +19,7 @@ import { showInfoPopup } from '../../shell/info-popup';
 import { t } from 'i18next';
 import { D2Store, D2Vault, D2CharacterStat } from '../store-types';
 import { D2Item } from '../item-types';
+import { D2StoresService } from '../d2-stores.service';
 
 /**
  * A factory service for producing "stores" (characters or the vault).
@@ -142,6 +143,10 @@ const StoreProto = {
 
   isDestiny2(this: D2Store) {
     return true;
+  },
+
+  getStoresService() {
+    return D2StoresService;
   }
 };
 

--- a/src/app/loadout-builder/loadout-builder-item.component.ts
+++ b/src/app/loadout-builder/loadout-builder-item.component.ts
@@ -4,7 +4,7 @@ import template from './loadout-builder-item.html';
 import dialogTemplate from './loadout-builder-item-dialog.html';
 import { extend, IController } from 'angular';
 import { DimItem } from '../inventory/item-types';
-import { StoreServiceType } from '../inventory/store-types';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 export const LoadoutBuilderItem = {
   controller: LoadoutBuilderItemCtrl,
@@ -22,8 +22,7 @@ function LoadoutBuilderItemCtrl(
   },
   $scope,
   $element,
-  ngDialog,
-  dimStoreService: StoreServiceType
+  ngDialog
 ) {
   'ngInject';
 
@@ -42,7 +41,7 @@ function LoadoutBuilderItemCtrl(
       } else if (vm.shiftClickCallback && e.shiftKey) {
         vm.shiftClickCallback(vm.itemData);
       } else {
-        const compareItems = flatMap(dimStoreService.getStores(), (store) => {
+        const compareItems = flatMap(D1StoresService.getStores(), (store) => {
           return store.items.filter((i) => i.hash === item.hash);
         });
 

--- a/src/app/loadout-builder/loadout-builder.component.ts
+++ b/src/app/loadout-builder/loadout-builder.component.ts
@@ -124,7 +124,7 @@ function LoadoutBuilderController(
   $state: StateService,
   $timeout: ITimeoutService,
   $i18next,
-  dimStoreService: D1StoreServiceType,
+  D1StoresService: D1StoreServiceType,
   ngDialog,
   dimLoadoutService: LoadoutServiceType,
   dimVendorService
@@ -134,7 +134,7 @@ function LoadoutBuilderController(
   const vm = this;
   vm.reviewsEnabled = $featureFlags.reviewsEnabled;
 
-  if (dimStoreService.getStores().length === 0) {
+  if (D1StoresService.getStores().length === 0) {
     $state.go('destiny1.inventory');
     return;
   }
@@ -452,8 +452,8 @@ function LoadoutBuilderController(
       },
       onCharacterChange() {
         vm.ranked = getActiveBuckets(buckets[vm.active], vendorBuckets[vm.active], vm.includeVendors);
-        vm.activeCharacters = dimStoreService.getStores().filter((s) => !s.isVault);
-        const activeStore = dimStoreService.getActiveStore()!;
+        vm.activeCharacters = D1StoresService.getStores().filter((s) => !s.isVault);
+        const activeStore = D1StoresService.getActiveStore()!;
         vm.selectedCharacter = _.findIndex(vm.activeCharacters, (char) => char.id === activeStore.id);
         vm.activePerks = getActiveBuckets(perks[vm.active], vendorPerks[vm.active], vm.includeVendors);
         vm.lockeditems = { Helmet: null, Gauntlets: null, Chest: null, Leg: null, ClassItem: null, Artifact: null, Ghost: null };
@@ -786,9 +786,9 @@ function LoadoutBuilderController(
         return setMap;
       },
       getBonus,
-      getStore: dimStoreService.getStore,
+      getStore: D1StoresService.getStore,
       getItems() {
-        const stores = dimStoreService.getStores();
+        const stores = D1StoresService.getStores();
         vm.stores = stores;
 
         if (stores.length === 0) {
@@ -815,9 +815,9 @@ function LoadoutBuilderController(
           });
         }
 
-        vm.selectedCharacter = dimStoreService.getActiveStore();
+        vm.selectedCharacter = D1StoresService.getActiveStore();
         vm.active = vm.selectedCharacter.class.toLowerCase() || 'warlock';
-        vm.activeCharacters = _.reject(dimStoreService.getStores(), (s) => s.isVault);
+        vm.activeCharacters = _.reject(D1StoresService.getStores(), (s) => s.isVault);
         vm.selectedCharacter = _.findIndex(vm.activeCharacters, (char) => char.id === vm.selectedCharacter.id);
 
         let allItems: D1Item[] = [];

--- a/src/app/loadout/loadout-popup.component.ts
+++ b/src/app/loadout/loadout-popup.component.ts
@@ -17,7 +17,7 @@ import { IDialogService } from 'ng-dialog';
 import { getBuckets as d2GetBuckets } from '../destiny2/d2-buckets.service';
 import { getBuckets as d1GetBuckets } from '../destiny1/d1-buckets.service';
 import { ItemServiceType } from '../inventory/dimItemService.factory';
-import { DimStore, StoreServiceType } from '../inventory/store-types';
+import { DimStore } from '../inventory/store-types';
 import { SearchService } from '../search/search-filter.component';
 
 export const LoadoutPopupComponent: IComponentOptions = {
@@ -67,16 +67,10 @@ function LoadoutPopupCtrl(
   D2FarmingService,
   $window,
   $i18next,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   $stateParams
 ) {
   'ngInject';
   const vm = this;
-
-  function getStoreService() {
-    return vm.store.destinyVersion === 1 ? dimStoreService : D2StoresService;
-  }
 
   vm.$onInit = () => {
     vm.previousLoadout = _.last(dimLoadoutService.previousLoadouts[vm.store.id]);
@@ -94,13 +88,13 @@ function LoadoutPopupCtrl(
 
     initLoadouts();
 
-    vm.hasClassified = getStoreService().getAllItems().some((i) => {
+    vm.hasClassified = vm.store.getStoresService().getAllItems().some((i) => {
       return i.classified &&
         (i.location.sort === 'Weapons' ||
         i.location.sort === 'Armor' ||
         i.type === 'Ghost');
     });
-    vm.maxLightValue = dimLoadoutService.getLight(vm.store, maxLightLoadout(getStoreService(), vm.store)) + (vm.hasClassified ? '*' : '');
+    vm.maxLightValue = dimLoadoutService.getLight(vm.store, maxLightLoadout(vm.store.getStoresService(), vm.store)) + (vm.hasClassified ? '*' : '');
   };
 
   vm.search = SearchService;
@@ -204,13 +198,13 @@ function LoadoutPopupCtrl(
 
   // A dynamic loadout set up to level weapons and armor
   vm.itemLevelingLoadout = ($event: IAngularEvent) => {
-    const loadout = itemLevelingLoadout(getStoreService(), vm.store);
+    const loadout = itemLevelingLoadout(vm.store.getStoresService(), vm.store);
     vm.applyLoadout(loadout, $event);
   };
 
   // Apply a loadout that's dynamically calculated to maximize Light level (preferring not to change currently-equipped items)
   vm.maxLightLoadout = ($event: IAngularEvent) => {
-    const loadout = maxLightLoadout(getStoreService(), vm.store);
+    const loadout = maxLightLoadout(vm.store.getStoresService(), vm.store);
     vm.applyLoadout(loadout, $event);
   };
 
@@ -218,7 +212,7 @@ function LoadoutPopupCtrl(
   vm.gatherEngramsLoadout = ($event: IAngularEvent, options: { exotics: boolean } = { exotics: false }) => {
     let loadout;
     try {
-      loadout = gatherEngramsLoadout(getStoreService(), options);
+      loadout = gatherEngramsLoadout(vm.store.getStoresService(), options);
     } catch (e) {
       toaster.pop('warning', $i18next.t('Loadouts.GatherEngrams'), e.message);
       return;
@@ -229,7 +223,7 @@ function LoadoutPopupCtrl(
   vm.gatherTokensLoadout = ($event: IAngularEvent) => {
     let loadout;
     try {
-      loadout = gatherTokensLoadout(getStoreService());
+      loadout = gatherTokensLoadout(vm.store.getStoresService());
     } catch (e) {
       toaster.pop('warning', $i18next.t('Loadouts.GatherTokens'), e.message);
       return;
@@ -239,14 +233,14 @@ function LoadoutPopupCtrl(
 
   // Move items matching the current search. Max 9 per type.
   vm.searchLoadout = ($event: IAngularEvent) => {
-    const loadout = searchLoadout(getStoreService(), vm.store);
+    const loadout = searchLoadout(vm.store.getStoresService(), vm.store);
     vm.applyLoadout(loadout, $event);
   };
 
   vm.makeRoomForPostmaster = () => {
     ngDialog.closeAll();
     const bucketsService = vm.store.destinyVersion === 1 ? d1GetBuckets : d2GetBuckets;
-    return queueAction(() => makeRoomForPostmaster(getStoreService(), vm.store, dimItemService, toaster, bucketsService));
+    return queueAction(() => makeRoomForPostmaster(vm.store.getStoresService(), vm.store, dimItemService, toaster, bucketsService));
   };
 
   vm.pullFromPostmaster = () => {

--- a/src/app/loadout/loadout-popup.component.ts
+++ b/src/app/loadout/loadout-popup.component.ts
@@ -16,7 +16,7 @@ import { getActivePlatform } from '../accounts/platform.service';
 import { IDialogService } from 'ng-dialog';
 import { getBuckets as d2GetBuckets } from '../destiny2/d2-buckets.service';
 import { getBuckets as d1GetBuckets } from '../destiny1/d1-buckets.service';
-import { ItemServiceType } from '../inventory/dimItemService.factory';
+import { dimItemService } from '../inventory/dimItemService.factory';
 import { DimStore } from '../inventory/store-types';
 import { SearchService } from '../search/search-filter.component';
 
@@ -61,7 +61,6 @@ function LoadoutPopupCtrl(
   $scope,
   ngDialog: IDialogService,
   dimLoadoutService: LoadoutServiceType,
-  dimItemService: ItemServiceType,
   toaster,
   dimFarmingService,
   D2FarmingService,
@@ -240,7 +239,7 @@ function LoadoutPopupCtrl(
   vm.makeRoomForPostmaster = () => {
     ngDialog.closeAll();
     const bucketsService = vm.store.destinyVersion === 1 ? d1GetBuckets : d2GetBuckets;
-    return queueAction(() => makeRoomForPostmaster(vm.store.getStoresService(), vm.store, dimItemService, toaster, bucketsService));
+    return queueAction(() => makeRoomForPostmaster(vm.store, toaster, bucketsService));
   };
 
   vm.pullFromPostmaster = () => {

--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -2,12 +2,12 @@ import { copy, IPromise, IQService } from 'angular';
 import * as _ from 'underscore';
 import uuidv4 from 'uuid/v4';
 import { queueAction } from '../inventory/action-queue';
-import { ItemServiceType } from '../inventory/dimItemService.factory';
 import { SyncService } from '../storage/sync.service';
 import { DimItem } from '../inventory/item-types';
 import { DimStore } from '../inventory/store-types';
 import { D2StoresService } from '../inventory/d2-stores.service';
 import { D1StoresService } from '../inventory/d1-stores.service';
+import { dimItemService } from '../inventory/dimItemService.factory';
 
 export const enum LoadoutClass {
   any = -1,
@@ -55,7 +55,6 @@ export function LoadoutService(
   $q: IQService,
   $rootScope: angular.IRootScopeService,
   $i18next,
-  dimItemService: ItemServiceType,
   toaster,
   loadingTracker
 ): LoadoutServiceType {

--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -3,10 +3,11 @@ import * as _ from 'underscore';
 import uuidv4 from 'uuid/v4';
 import { queueAction } from '../inventory/action-queue';
 import { ItemServiceType } from '../inventory/dimItemService.factory';
-import { settings } from '../settings/settings';
 import { SyncService } from '../storage/sync.service';
 import { DimItem } from '../inventory/item-types';
-import { DimStore, StoreServiceType } from '../inventory/store-types';
+import { DimStore } from '../inventory/store-types';
+import { D2StoresService } from '../inventory/d2-stores.service';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 export const enum LoadoutClass {
   any = -1,
@@ -55,16 +56,14 @@ export function LoadoutService(
   $rootScope: angular.IRootScopeService,
   $i18next,
   dimItemService: ItemServiceType,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   toaster,
   loadingTracker
 ): LoadoutServiceType {
   'ngInject';
 
-  function getStoreService(destinyVersion = settings.destinyVersion) {
+  function getStoresService(destinyVersion) {
     // TODO: this needs to use account, store, or item version
-    return destinyVersion === 2 ? D2StoresService : dimStoreService;
+    return destinyVersion === 2 ? D2StoresService : D1StoresService;
   }
 
   let _loadouts: Loadout[] = [];
@@ -108,8 +107,8 @@ export function LoadoutService(
       const ids = data['loadouts-v3.0'];
       loadouts = ids.map((id) => {
         // Mark all the items as being in loadouts
-        data[id].items.forEach((item) => {
-          const itemFromStore = getStoreService().getItemAcrossStores({
+        data[id].items.forEach((item: LoadoutItem) => {
+          const itemFromStore = getStoresService(item.destinyVersion).getItemAcrossStores({
             id: item.id,
             hash: item.hash
           });
@@ -237,7 +236,7 @@ export function LoadoutService(
   // A special getItem that takes into account the fact that
   // subclasses have unique IDs, and emblems/shaders/etc are interchangeable.
   function getLoadoutItem(pseudoItem: DimItem, store: DimStore): DimItem | null {
-    let item = getStoreService(store.destinyVersion).getItemAcrossStores(pseudoItem);
+    let item = store.getStoresService().getItemAcrossStores(pseudoItem);
     if (!item) {
       return null;
     }
@@ -288,7 +287,7 @@ export function LoadoutService(
     if (!store) {
       throw new Error("You need a store!");
     }
-    const storeService = getStoreService(store.destinyVersion);
+    const storeService = store.getStoresService();
 
     if ($featureFlags.debugMoves) {
       console.log("LoadoutService: Apply loadout", loadout.name, "to", store.name);
@@ -463,7 +462,7 @@ export function LoadoutService(
         const amountAlreadyHave = store.amountOfItem(pseudoItem);
         let amountNeeded = pseudoItem.amount - amountAlreadyHave;
         if (amountNeeded > 0) {
-          const otherStores = getStoreService(store.destinyVersion).getStores()
+          const otherStores = store.getStoresService().getStores()
             .filter((otherStore) => store.id !== otherStore.id);
           const storesByAmount = _.sortBy(otherStores.map((store) => {
             return {
@@ -532,7 +531,7 @@ export function LoadoutService(
     };
 
     for (const itemPrimitive of loadoutPrimitive.items) {
-      const item = copy(getStoreService().getItemAcrossStores({
+      const item = copy(getStoresService(result.destinyVersion).getItemAcrossStores({
         id: itemPrimitive.id,
         hash: itemPrimitive.hash
       }));

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -2,15 +2,13 @@ import { t } from 'i18next';
 import * as _ from 'underscore';
 import { flatMap } from '../util';
 import { IPromise } from 'angular';
-import { ItemServiceType } from '../inventory/dimItemService.factory';
+import { ItemServiceType, dimItemService } from '../inventory/dimItemService.factory';
 import { StoreServiceType, DimStore } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
 import { InventoryBucket, InventoryBuckets } from '../inventory/inventory-buckets';
 
 export function makeRoomForPostmaster(
-  storeService: StoreServiceType,
   store: DimStore,
-  dimItemService: ItemServiceType,
   toaster,
   bucketsService: () => IPromise<InventoryBuckets>
 ): IPromise<void> {
@@ -49,7 +47,7 @@ export function makeRoomForPostmaster(
     });
 
     // TODO: it'd be nice if this were a loadout option
-    return moveItemsToVault(storeService, store, itemsToMove, dimItemService)
+    return moveItemsToVault(store.getStoresService(), store, itemsToMove, dimItemService)
       .then(() => {
         toaster.pop('success',
                     t('Loadouts.MakeRoom'),

--- a/src/app/loadout/random/random-loadout.component.ts
+++ b/src/app/loadout/random/random-loadout.component.ts
@@ -2,7 +2,7 @@ import { optimalLoadout } from '../loadout-utils';
 import template from './random-loadout.html';
 import './random-loadout.scss';
 import { IComponentOptions, IController, IWindowService } from 'angular';
-import { DimStore, StoreServiceType } from '../../inventory/store-types';
+import { DimStore } from '../../inventory/store-types';
 
 export const RandomLoadoutComponent: IComponentOptions = {
   template,
@@ -17,8 +17,6 @@ function RandomLoadoutCtrl(
     stores: DimStore[];
   },
   $window: IWindowService,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   dimLoadoutService,
   $i18next
 ) {
@@ -61,7 +59,7 @@ function RandomLoadoutCtrl(
       'Artifact',
       'Ghost'
     ]);
-    const storeService = (store.destinyVersion === 2 ? D2StoresService : dimStoreService);
+    const storeService = store.getStoresService();
 
     // Any item equippable by this character in the given types
     const applicableItems = storeService.getAllItems().filter((i) => types.has(i.type) && i.canBeEquippedBy(store));

--- a/src/app/move-popup/dimMoveItemProperties.directive.ts
+++ b/src/app/move-popup/dimMoveItemProperties.directive.ts
@@ -4,7 +4,6 @@ import { settings } from '../settings/settings';
 import { IController, IRootScopeService, IScope, IComponentOptions, IAngularEvent } from 'angular';
 import template from './dimMoveItemProperties.html';
 import { DimItem } from '../inventory/item-types';
-import { StoreServiceType } from '../inventory/store-types';
 import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { $q } from 'ngimport';
 
@@ -25,18 +24,12 @@ function MoveItemPropertiesCtrl(
     compareItem?: DimItem;
     infuse(item: DimItem, $event: IAngularEvent): void;
   },
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   ngDialog,
   $scope: IScope,
   $rootScope: IRootScopeService
 ) {
   'ngInject';
   const vm = this;
-
-  function getStoreService(item: DimItem) {
-    return item.destinyVersion === 2 ? D2StoresService : dimStoreService;
-  }
 
   vm.tab = 'default';
   vm.locking = false;
@@ -152,8 +145,8 @@ function MoveItemPropertiesCtrl(
     }
 
     const store = item.owner === 'vault'
-      ? getStoreService(item).getActiveStore()!
-      : getStoreService(item).getStore(item.owner)!;
+      ? item.getStoresService().getActiveStore()!
+      : item.getStoresService().getStore(item.owner)!;
 
     vm.locking = true;
 

--- a/src/app/move-popup/dimMovePopup.directive.ts
+++ b/src/app/move-popup/dimMovePopup.directive.ts
@@ -2,7 +2,7 @@ import { settings } from '../settings/settings';
 import template from './dimMovePopup.directive.html';
 import './move-popup.scss';
 import { IController } from 'angular';
-import { DimStore, StoreServiceType } from '../inventory/store-types';
+import { DimStore } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
 
 export const MovePopupComponent = {
@@ -29,8 +29,6 @@ interface MovePopupControllerType {
 function MovePopupController(
   this: IController & MovePopupControllerType,
   $scope,
-  D2StoresService: StoreServiceType,
-  dimStoreService: StoreServiceType,
   ngDialog,
   dimItemMoveService
 ) {
@@ -38,14 +36,10 @@ function MovePopupController(
   const vm = this;
   vm.settings = settings;
 
-  function getStoreService() {
-    return vm.item.destinyVersion === 2 ? D2StoresService : dimStoreService;
-  }
-
   vm.$onInit = () => {
     vm.moveAmount = vm.item.amount;
     if (vm.item.maxStackSize > 1) {
-      const store = getStoreService().getStore(vm.item.owner)!;
+      const store = vm.item.getStoresService().getStore(vm.item.owner)!;
       vm.maximum = store.amountOfItem(vm.item);
     }
   };

--- a/src/app/move-popup/move-locations.component.ts
+++ b/src/app/move-popup/move-locations.component.ts
@@ -3,7 +3,7 @@ import template from './move-locations.html';
 import './move-locations.scss';
 import { IComponentOptions, IController } from 'angular';
 import { DimItem } from '../inventory/item-types';
-import { DimStore, StoreServiceType } from '../inventory/store-types';
+import { DimStore } from '../inventory/store-types';
 
 export const MoveLocationsComponent: IComponentOptions = {
   template,
@@ -21,9 +21,7 @@ function controller(
     store: DimStore;
     stores: DimStore[];
   },
-  dimItemMoveService,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType
+  dimItemMoveService
 ) {
   'ngInject';
   const vm = this;
@@ -31,7 +29,7 @@ function controller(
   vm.settings = settings;
 
   vm.$onInit = () => {
-    const storeService = vm.item.destinyVersion === 2 ? D2StoresService : dimStoreService;
+    const storeService = vm.item.getStoresService();
 
     vm.store = storeService.getStore(vm.item.owner)!;
     vm.stores = storeService.getStores();

--- a/src/app/record-books/record-books.component.ts
+++ b/src/app/record-books/record-books.component.ts
@@ -8,7 +8,7 @@ import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definition
 import template from './record-books.html';
 import './record-books.scss';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { StoreServiceType } from '../inventory/store-types';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 export const RecordBooksComponent: IComponentOptions = {
   controller: RecordBooksController,
@@ -23,7 +23,6 @@ function RecordBooksController(
     account: DestinyAccount;
   },
   $scope: IScope,
-  dimStoreService: StoreServiceType,
   $filter
 ) {
   'ngInject';
@@ -43,12 +42,12 @@ function RecordBooksController(
   };
 
   this.$onInit = () => {
-    subscribeOnScope($scope, dimStoreService.getStoresStream(vm.account), init);
+    subscribeOnScope($scope, D1StoresService.getStoresStream(vm.account), init);
   };
 
   $scope.$on('dim-refresh', () => {
     // TODO: refresh just advisors
-    dimStoreService.reloadStores();
+    D1StoresService.reloadStores();
   });
 
   // TODO: Ideally there would be an Advisors service that would

--- a/src/app/search/search-filter.component.ts
+++ b/src/app/search/search-filter.component.ts
@@ -11,8 +11,9 @@ import { getItemInfoSource } from '../inventory/dim-item-info';
 import './search-filter.scss';
 import { IComponentOptions, IController, IScope, IRootElementService } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { StoreServiceType } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
+import { D2StoresService } from '../inventory/d2-stores.service';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 /**
  * A simple holder to share the search query among components
@@ -34,8 +35,6 @@ function SearchFilterCtrl(
     account: DestinyAccount;
   },
   $scope: IScope,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   hotkeys,
   $i18next,
   $element: IRootElementService,
@@ -50,8 +49,8 @@ function SearchFilterCtrl(
   vm.bulkItemTags = _.clone(itemTags);
   vm.bulkItemTags.push({ type: 'clear', label: 'Tags.ClearTag' });
 
-  function getStoreService() {
-    return vm.account.destinyVersion === 2 ? D2StoresService : dimStoreService;
+  function getStoresService() {
+    return vm.account.destinyVersion === 2 ? D2StoresService : D1StoresService;
   }
 
   // This hacks around the fact that dimVendorService isn't defined until the destiny1 modules are lazy-loaded
@@ -76,7 +75,7 @@ function SearchFilterCtrl(
         vm.account.destinyVersion,
         itemTags,
         vm.account.destinyVersion === 1 ? D1Categories : D2Categories);
-      filters = searchFilters(searchConfig, getStoreService(), toaster, $i18next);
+      filters = searchFilters(searchConfig, getStoresService(), toaster, $i18next);
       setupTextcomplete();
     }
   };
@@ -244,7 +243,7 @@ function SearchFilterCtrl(
 
     const filterFn = filters.filterFunction(filterValue);
 
-    for (const item of getStoreService().getAllItems()) {
+    for (const item of getStoresService().getAllItems()) {
       item.visible = filterFn(item);
       if (item.visible) {
         filteredItems.push(item);

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -14,7 +14,8 @@ import { IComponentOptions, IController, IScope, IRootScopeService } from 'angul
 import { getDefinitions } from '../destiny2/d2-definitions.service';
 import { getReviewModes } from '../destinyTrackerApi/reviewModesFetcher';
 import { downloadCsvFiles } from '../inventory/dimCsvService.factory';
-import { StoreServiceType } from '../inventory/store-types';
+import { D2StoresService } from '../inventory/d2-stores.service';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 export const SettingsComponent: IComponentOptions = {
   template,
@@ -26,8 +27,6 @@ export function SettingsController(
   this: IController,
   loadingTracker,
   $scope: IScope,
-  dimStoreService: StoreServiceType,
-  D2StoresService: StoreServiceType,
   $i18next,
   $rootScope: IRootScopeService
 ) {
@@ -126,12 +125,12 @@ export function SettingsController(
   vm.supportsCssVar = window.CSS && window.CSS.supports && window.CSS.supports('(--foo: red)');
 
   vm.downloadWeaponCsv = () => {
-    downloadCsvFiles(vm.settings.destinyVersion === 2 ? D2StoresService.getStores() : dimStoreService.getStores(), "Weapons");
+    downloadCsvFiles(vm.settings.destinyVersion === 2 ? D2StoresService.getStores() : D1StoresService.getStores(), "Weapons");
     ga('send', 'event', 'Download CSV', 'Weapons');
   };
 
   vm.downloadArmorCsv = () => {
-    downloadCsvFiles(vm.settings.destinyVersion === 2 ? D2StoresService.getStores() : dimStoreService.getStores(), "Armor");
+    downloadCsvFiles(vm.settings.destinyVersion === 2 ? D2StoresService.getStores() : D1StoresService.getStores(), "Armor");
     ga('send', 'event', 'Download CSV', 'Armor');
   };
 

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -22,7 +22,6 @@ import RatingMode from './rating-mode/RatingMode';
 import { settings } from '../settings/settings';
 import WhatsNewLink from '../whats-new/WhatsNewLink';
 import MenuBadge from './MenuBadge';
-import { StoreServiceType } from '../inventory/store-types';
 
 const destiny1Links = [
   {
@@ -77,7 +76,6 @@ interface State {
 
 interface Props {
   $scope: IScope;
-  D2StoresService: StoreServiceType;
 }
 
 export default class Header extends React.PureComponent<Props, State> {
@@ -240,7 +238,7 @@ export default class Header extends React.PureComponent<Props, State> {
         <span className="header-right">
           {!showSearch && <Refresh/>}
           {(!showSearch && account && account.destinyVersion === 2 && settings.showReviews) &&
-            <RatingMode D2StoresService={this.props.D2StoresService} />}
+            <RatingMode />}
           {!showSearch &&
             <a
               className="link fa fa-cog"

--- a/src/app/shell/rating-mode/RatingMode.tsx
+++ b/src/app/shell/rating-mode/RatingMode.tsx
@@ -6,11 +6,7 @@ import { settings } from '../../settings/settings';
 import { $rootScope } from 'ngimport';
 import { D2ManifestDefinitions, getDefinitions } from '../../destiny2/d2-definitions.service';
 import { getReviewModes, D2ReviewMode } from '../../destinyTrackerApi/reviewModesFetcher';
-import { StoreServiceType } from '../../inventory/store-types';
-
-interface Props {
-  D2StoresService: StoreServiceType;
-}
+import { D2StoresService } from '../../inventory/d2-stores.service';
 
 interface State {
   open: boolean;
@@ -19,11 +15,11 @@ interface State {
 }
 
 // TODO: observe Settings changes - changes in the reviews pane aren't reflected here without an app refresh.
-export default class RatingMode extends React.Component<Props, State> {
+export default class RatingMode extends React.Component<{}, State> {
   private dropdownToggler = React.createRef<HTMLElement>();
   private _reviewModeOptions?: D2ReviewMode[];
 
-  constructor(props: Props) {
+  constructor(props) {
     super(props);
     this.state = { open: false, reviewsModeSelection: settings.reviewsModeSelection };
   }
@@ -81,7 +77,7 @@ export default class RatingMode extends React.Component<Props, State> {
 
     const newModeSelection = e.target.value;
     settings.reviewsModeSelection = newModeSelection;
-    this.props.D2StoresService.refreshRatingsData();
+    D2StoresService.refreshRatingsData();
     this.setState({ reviewsModeSelection: newModeSelection });
     $rootScope.$broadcast('dim-refresh');
   }

--- a/src/app/shell/shell.module.ts
+++ b/src/app/shell/shell.module.ts
@@ -28,7 +28,7 @@ export const ShellModule = module('dimShell', [
   .factory('loadingTracker', loadingTracker)
   .component('countdown', CountdownComponent)
   .component('starRating', StarRatingComponent)
-  .component('header', react2angular(Header, [], ['$scope', 'D2StoresService']))
+  .component('header', react2angular(Header, [], ['$scope']))
   .component('dimManifestProgress', ManifestProgressComponent)
   .directive('scrollClass', ScrollClass)
   .directive('dimClickAnywhereButHere', ClickAnywhereButHere)

--- a/src/app/vendors/vendor-item.component.ts
+++ b/src/app/vendors/vendor-item.component.ts
@@ -3,7 +3,7 @@ import * as _ from 'underscore';
 import { sum, flatMap } from '../util';
 import template from './vendor-item.html';
 import dialogTemplate from './vendor-item-dialog.html';
-import { StoreServiceType } from '../inventory/store-types';
+import { D1StoresService } from '../inventory/d1-stores.service';
 
 export const VendorItem: IComponentOptions = {
   bindings: {
@@ -20,8 +20,7 @@ function VendorItemCtrl(
   this: IController,
   $scope,
   $element,
-  ngDialog,
-  dimStoreService: StoreServiceType
+  ngDialog
 ) {
   'ngInject';
 
@@ -47,7 +46,7 @@ function VendorItemCtrl(
     } else {
       const item = vm.saleItem.item;
 
-      const compareItems = flatMap(dimStoreService.getStores(), (store) => {
+      const compareItems = flatMap(D1StoresService.getStores(), (store) => {
         return store.items.filter((i) => i.hash === item.hash);
       });
 
@@ -69,7 +68,7 @@ function VendorItemCtrl(
             settings: this.settings,
             item,
             saleItem: vm.saleItem,
-            unlockStores: vm.saleItem.unlockedByCharacter.map((id) => _.find(dimStoreService.getStores(), { id })),
+            unlockStores: vm.saleItem.unlockedByCharacter.map((id) => _.find(D1StoresService.getStores(), { id })),
             compareItems,
             compareItem: _.first(compareItems),
             compareItemCount,

--- a/src/app/vendors/vendor.service.ts
+++ b/src/app/vendors/vendor.service.ts
@@ -149,7 +149,7 @@ export interface VendorServiceType {
 
 export function VendorService(
   $rootScope: IRootScopeService,
-  dimStoreService: D1StoreServiceType,
+  D1StoresService: D1StoreServiceType,
   loadingTracker,
   $q: IQService
 ): VendorServiceType {
@@ -187,7 +187,7 @@ export function VendorService(
       service.vendors = {};
       service.vendorsLoaded = false;
     })
-    .switchMap((account) => dimStoreService.getStoresStream(account!), (account, stores) => [account!, stores!])
+    .switchMap((account) => D1StoresService.getStoresStream(account!), (account, stores) => [account!, stores!])
     .switchMap(([account, stores]: [DestinyAccount, D1Store[]]) => loadVendors(account, stores))
     // Keep track of the last value for new subscribers
     .publishReplay(1);
@@ -228,7 +228,7 @@ export function VendorService(
   }
 
   function reloadVendors() {
-    dimStoreService.reloadStores();
+    D1StoresService.reloadStores();
   }
 
   /**
@@ -632,13 +632,13 @@ export function VendorService(
       // Legendary marks and glimmer are special cases
       switch (currencyHash) {
       case 2534352370:
-        totalCoins[currencyHash] = dimStoreService.getVault()!.legendaryMarks;
+        totalCoins[currencyHash] = D1StoresService.getVault()!.legendaryMarks;
         break;
       case 3159615086:
-        totalCoins[currencyHash] = dimStoreService.getVault()!.glimmer;
+        totalCoins[currencyHash] = D1StoresService.getVault()!.glimmer;
         break;
       case 2749350776:
-        totalCoins[currencyHash] = dimStoreService.getVault()!.silver;
+        totalCoins[currencyHash] = D1StoresService.getVault()!.silver;
         break;
       default:
         totalCoins[currencyHash] = sum(stores, (store) => {


### PR DESCRIPTION
We're nearing the end of the Angular services - only a few more after this to turn into normal JS modules.

This moves our super important Stores services, and renames `dimStoreService` to `D1StoresService` to match `D2StoresService`. I also added `getStoresService()` helpers to both items and stores, so we can easily get the appropriate service for them without copy/pasting helpers everywhere.