### PR TITLE
Add pursuits bucket to inventory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Add Pursuits to the main inventory screen. Quest items are still shown on the Progress screen as well.
+
 # 4.57.0 (2018-06-17)
 
 * Item sizing setting works in Edge.

--- a/src/app/destiny2/d2-buckets.service.ts
+++ b/src/app/destiny2/d2-buckets.service.ts
@@ -31,7 +31,8 @@ export const D2Categories = {
   Inventory: [
     'Consumables',
     'Modifications',
-    'Shaders'
+    'Shaders',
+    'Pursuits'
   ],
   Postmaster: [
     'LostItems',


### PR DESCRIPTION
Originally I thought it was OK to just show pursuits on progress, but for some reason Bungie decided to also put some things I'd consider consumables into the pursuits bucket as well. This change adds pursuits to the main inventory screen as well so you know how many keys you have:

![screen shot 2018-06-23 at 4 28 18 pm](https://user-images.githubusercontent.com/313208/41814488-965376dc-7702-11e8-83a8-3b1cad41e705.png)
