### PR TITLE
Exotic catalysts in Collections

### DIFF
--- a/src/app/collections/Catalysts.tsx
+++ b/src/app/collections/Catalysts.tsx
@@ -1,0 +1,107 @@
+import {
+  DestinyProfileResponse,
+  DestinyObjectiveProgress
+} from 'bungie-api-ts/destiny2';
+import * as React from 'react';
+import * as _ from 'underscore';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import './collections.scss';
+import VendorItemComponent from '../d2-vendors/VendorItemComponent';
+import { VendorItem } from '../d2-vendors/vendor-item';
+import { t } from 'i18next';
+
+/**
+ * A single plug set.
+ */
+export default function Catalysts({
+  defs,
+  profileResponse
+}: {
+  defs: D2ManifestDefinitions;
+  profileResponse: DestinyProfileResponse;
+}) {
+  const catalysts = getCatalysts(defs, profileResponse);
+
+  return (
+    <div className="vendor-char-items">
+      <div className="vendor-row">
+        <h3 className="category-title">
+          Catalysts
+          <div className="ornaments-disclaimer">{t("Vendors.CatalystsDisclaimer")}</div>
+        </h3>
+        <div className="vendor-items">
+        {catalysts.map((catalyst) =>
+          <VendorItemComponent
+            key={catalyst.itemHash}
+            defs={defs}
+            item={VendorItem.forCatalyst(defs, catalyst.attachedItemHash, catalyst.itemHash, catalyst.objectives, catalyst.canInsert)}
+            owned={false}
+          />
+        )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CatalystInfo {
+  attachedItemHash: number;
+  itemHash: number;
+  objectives: DestinyObjectiveProgress[];
+  canInsert: boolean;
+}
+
+function getCatalysts(
+  defs: D2ManifestDefinitions,
+  profileResponse: DestinyProfileResponse
+): CatalystInfo[] {
+  const plugsWithObjectives = {};
+  _.each(profileResponse.itemComponents.sockets.data, (sockets, instanceHash) => {
+    for (const socket of sockets.sockets) {
+      if (socket.reusablePlugs) {
+        for (const reusablePlug of socket.reusablePlugs) {
+          if (reusablePlug.plugObjectives && reusablePlug.plugObjectives.length) {
+            const item = defs.InventoryItem.get(reusablePlug.plugItemHash);
+            // TODO: show the item, not the masterwork mod! But somehow patch in the mod as well...
+            let itemHash;
+            for (const item of allItemInstances(profileResponse)) {
+              if (item.itemInstanceId === instanceHash) {
+                itemHash = item.itemHash;
+                break;
+              }
+            }
+            if (item.plug && item.plug.uiPlugLabel === 'masterwork_interactable') {
+              plugsWithObjectives[reusablePlug.plugItemHash] = {
+                attachedItemHash: itemHash,
+                itemHash: reusablePlug.plugItemHash,
+                objectives: reusablePlug.plugObjectives,
+                canInsert: reusablePlug.canInsert
+              };
+            }
+          }
+        }
+      }
+    }
+  });
+
+  return _.sortBy(Object.values(plugsWithObjectives), (catalyst) => {
+    const item = defs.InventoryItem.get(catalyst.itemHash);
+    return item.displayProperties.name;
+  });
+}
+
+function *allItemInstances(profileResponse: DestinyProfileResponse) {
+  for (const item of profileResponse.profileInventory.data.items) {
+    yield item;
+  }
+  for (const character of Object.values(profileResponse.characterInventories.data)) {
+    for (const item of character.items) {
+      yield item;
+    }
+  }
+  for (const character of Object.values(profileResponse.characterEquipment.data)) {
+    for (const item of character.items) {
+      yield item;
+    }
+  }
+}

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -20,6 +20,7 @@ import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import { DestinyTrackerService } from '../item-review/destiny-tracker.service';
 import Ornaments from './Ornaments';
 import { D2StoresService } from '../inventory/d2-stores.service';
+import Catalysts from './Catalysts';
 
 interface Props {
   $scope: IScope;
@@ -109,6 +110,12 @@ export default class Collections extends React.Component<Props, State> {
       <div className="vendor d2-vendors dim-page">
         <ErrorBoundary name="Ornaments">
           <Ornaments
+            defs={defs}
+            profileResponse={profileResponse}
+          />
+        </ErrorBoundary>
+        <ErrorBoundary name="Catalysts">
+          <Catalysts
             defs={defs}
             profileResponse={profileResponse}
           />

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -15,7 +15,7 @@ import { sum } from "../util";
  *
  * This is the pattern I want to follow for our main items!
  */
-// TODO: Replace with DimItem
+// TODO: Replace with DimItem + vendory stuff
 export class VendorItem {
   static forPlugSetItem(
     defs: D2ManifestDefinitions,
@@ -111,6 +111,62 @@ export class VendorItem {
     return new VendorItem(
       defs,
       defs.InventoryItem.get(itemHash),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        objectives: {
+          data: {
+            [itemHash]: {
+              objectives,
+              flavorObjective: undefined as any as DestinyObjectiveProgress,
+            }
+          },
+          privacy: 2
+        },
+        perks: { data: {}, privacy: 2 },
+        renderData: { data: {}, privacy: 2 },
+        stats: { data: {}, privacy: 2 },
+        sockets: { data: {}, privacy: 2 },
+        talentGrids: { data: {}, privacy: 2 },
+        plugStates: { data: {}, privacy: 2 },
+        instances: { data: {
+          [itemHash]: fakeInstance
+        }, privacy: 2 }
+      },
+      undefined,
+      canInsert
+    );
+  }
+
+  // TODO: This is getting silly. Rethink this whole thing.
+  static forCatalyst(
+    defs: D2ManifestDefinitions,
+    attachedItemHash: number,
+    itemHash: number,
+    objectives: DestinyObjectiveProgress[],
+    canInsert: boolean
+  ): VendorItem {
+    const fakeInstance = {
+
+    } as any as DestinyItemInstanceComponent;
+
+    const modDef = defs.InventoryItem.get(itemHash);
+    const itemDef = defs.InventoryItem.get(attachedItemHash);
+
+    const fakedDef = {
+      ...modDef,
+      displayProperties: {
+        ...modDef.displayProperties,
+        name: itemDef.displayProperties.name,
+        icon: itemDef.displayProperties.icon
+      }
+    };
+
+    return new VendorItem(
+      defs,
+      fakedDef,
       undefined,
       undefined,
       undefined,

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -683,6 +683,7 @@
     "Engram": "Reward Engram",
     "Load": "Loading Vendors",
     "OrnamentsDisclaimer": "DIM can only show ornaments that could be unlocked on items you have in your inventory.",
+    "CatalystsDisclaimer": "DIM can only show exotic masterwork catalysts that you have earned for items in your inventory.",
     "ShadersAndEmblems": "Shaders & Emblems",
     "ShipsAndVehicles": "Ships & Vehicles",
     "Vendors": "Vendors"


### PR DESCRIPTION
This isn't perfect, but it might be good enough. This displays exotic catalyst progress for catalysts you have. The main thing still bugging me is that the tooltip is for the mod, not the weapon, which is nice except the titles aren't super helpful. But I think it's better than showing the weapon and making people dig for the catalyst progress.

![screen shot 2018-06-23 at 7 02 19 pm](https://user-images.githubusercontent.com/313208/41815187-04f32dc0-7718-11e8-8ec2-fedbc65d9ebc.png)
![screen shot 2018-06-23 at 7 02 22 pm](https://user-images.githubusercontent.com/313208/41815188-0506c3f8-7718-11e8-8c8d-8b773c80be83.png)
