### PR TITLE
Another stab at pursuits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Vendors show their faction rank next to their reward engrams.
 * Factions in the progress page also link to their vendor.
 * Add Pursuits to the main inventory screen. Quest items are still shown on the Progress screen as well.
+* Quest keys in your Pursuits now show their quantity. They're still on the Progress page.
 
 # 4.57.0 (2018-06-17)
 

--- a/src/app/destiny2/d2-buckets.service.ts
+++ b/src/app/destiny2/d2-buckets.service.ts
@@ -31,8 +31,7 @@ export const D2Categories = {
   Inventory: [
     'Consumables',
     'Modifications',
-    'Shaders',
-    'Pursuits'
+    'Shaders'
   ],
   Postmaster: [
     'LostItems',

--- a/src/app/progress/Quest.tsx
+++ b/src/app/progress/Quest.tsx
@@ -32,6 +32,8 @@ export default function Quest(props: QuestProps) {
         <BungieImage src={itemDef.displayProperties.icon} />
         {percentComplete > 0 &&
           <span>{Math.floor(percentComplete * 100)}%</span>}
+        {itemDef.inventory.maxStackSize > 1 &&
+          <span>{item.quantity}</span>}
       </div>
       <div className="milestone-info">
         <span className="milestone-name">{itemDef.displayProperties.name}</span>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -526,7 +526,7 @@
     "ProfileMilestones": "Account Milestones",
     "ProfileQuests": "Account Quests",
     "Progress": "Progress",
-    "Quests": "Quests",
+    "Quests": "Pursuits & Quests",
     "RewardEarned": "Reward earned but not redeemed",
     "RewardNotEarned": "Reward not earned",
     "RewardRedeemed": "Reward redeemed",


### PR DESCRIPTION
I didn't like how the pursuits ended up displaying as items - they're really useless that way. I went back and updated the Progress page to have a better title and to show the amount of stackable items:

![screen shot 2018-06-24 at 6 49 40 pm](https://user-images.githubusercontent.com/313208/41826615-ba33b34a-77df-11e8-8999-b60a1247f42f.png)
