### PR TITLE
Try to handle stacked items better

### DIFF
--- a/src/app/inventory/d1-stores.service.ts
+++ b/src/app/inventory/d1-stores.service.ts
@@ -78,8 +78,9 @@ function StoreService(): D1StoreServiceType {
     id?: string;
     hash?: number;
     notransfer?: boolean;
+    amount?: number;
   }) {
-    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'notransfer')) as (DimItem) => boolean;
+    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'notransfer', 'amount')) as (DimItem) => boolean;
     for (const store of _stores) {
       const result = store.items.find(predicate);
       if (result) {

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -91,8 +91,8 @@ function makeD2StoresService(): D2StoreServiceType {
   /**
    * Find an item among all stores that matches the params provided.
    */
-  function getItemAcrossStores(params: { id?: string; hash?: number; notransfer?: boolean }) {
-    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'notransfer')) as (i: DimItem) => boolean;
+  function getItemAcrossStores(params: { id?: string; hash?: number; notransfer?: boolean; amount?: number }) {
+    const predicate = _.iteratee(_.pick(params, 'id', 'hash', 'notransfer', 'amount')) as (i: DimItem) => boolean;
     for (const store of _stores) {
       const result = store.items.find(predicate);
       if (result) {

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -96,7 +96,8 @@ function ItemService(): ItemServiceType {
     const storeService = item.getStoresService();
     source = storeService.getStore(source.id)!;
     target = storeService.getStore(target.id)!;
-    item = storeService.getItemAcrossStores(item)!;
+    // We really shouldn't do this!
+    item = storeService.getItemAcrossStores(item) || item;
 
     // If we've moved to a new place
     if (source.id !== target.id || item.location.inPostmaster) {

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -35,6 +35,7 @@ export interface StoreServiceType<StoreType = DimStore, VaultType = DimVault, It
     id?: string;
     hash?: number;
     notransfer?: boolean;
+    account?: number;
   }): ItemType | undefined;
   /** Refresh just character info (current light/stats, etc.) */
   updateCharacters(account?: DestinyAccount): IPromise<StoreType[]>;


### PR DESCRIPTION
This fixes a relatively obscure bug moving items. When you have full Shaders (or consumables, etc) and a shader in your Postmaster, and you move that same type of shader from Vault to Shaders, the item will move but you'll get an error from DIM. This is because we lose track of which item we were talking about - some code we added to the updateItemModel code to handle when the stores have refreshed between moving causes us to select the wrong item to apply the update to. This'll be fixed better long term, but for now, I changed things to search for a matching item including the same stack size, which makes things work.