### PR TITLE
Fix hang on phone when showing move amount input

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * New iOS app icons when you add to home screen.
+* Fix a bug where the item popup could hang iOS Safari in landscape view.
 
 # 4.58.0 (2018-06-24)
 

--- a/src/app/move-popup/move-amount.directive.ts
+++ b/src/app/move-popup/move-amount.directive.ts
@@ -2,7 +2,7 @@ import template from './move-amount.html';
 import './move-amount.scss';
 import { IDirective, IController } from 'angular';
 
-export function MoveAmount($timeout): IDirective {
+export function MoveAmount(): IDirective {
   'ngInject';
   return {
     controller: MoveAmountController,
@@ -15,15 +15,7 @@ export function MoveAmount($timeout): IDirective {
       maxStackSize: '=maxStackSize'
     },
     replace: true,
-    template,
-    link(scope, element) {
-      $timeout(() => {
-        scope.$broadcast('rzSliderForceRender');
-        const input = element[0].getElementsByTagName('input')[0];
-        input.focus();
-        input.setSelectionRange(0, input.value.length);
-      });
-    }
+    template
   };
 }
 

--- a/src/app/move-popup/move-locations.component.ts
+++ b/src/app/move-popup/move-locations.component.ts
@@ -21,7 +21,8 @@ function controller(
     amount: number;
     store: DimStore;
     stores: DimStore[];
-  }
+  },
+  $scope
 ) {
   'ngInject';
   const vm = this;
@@ -92,5 +93,6 @@ function controller(
 
   vm.moveItemTo = (store: DimStore, equip: boolean) => {
     moveItemTo(vm.item, store, equip, vm.amount);
+    $scope.$parent.$parent.closeThisDialog();
   };
 }


### PR DESCRIPTION
For some reason, auto-focusing the textbox was hanging iOS (and only in landscape mode, too!). Auto-focusing probably isn't right for mobile anyway, so I just removed it.