### PR TITLE
Scroll to top when changing pages

### DIFF
--- a/src/router.config.ts
+++ b/src/router.config.ts
@@ -27,6 +27,11 @@ export default function makeRouter() {
   router.urlService.rules.initial({ state: 'default-account' });
   router.urlService.rules.otherwise({ state: 'default-account' });
 
+  // Scroll to the top of the page when we switch pages
+  router.transitionService.onSuccess({}, () => {
+    document.body.scrollTop = document.documentElement.scrollTop = 0;
+  });
+
   if ($featureFlags.googleAnalyticsForRouter) {
     router.transitionService.onSuccess({ }, (transition) => {
       ga('send', 'pageview', transition.$to().name);


### PR DESCRIPTION
When we switch between pages, we should make sure to scroll to the top. Usually this doesn't matter since we're switching to a blank unrendered page at first, but it will matter as we get more efficient.