### PR TITLE
Make stat filters able to match zero values

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * Farming mode won't try to move unmoveable reputation tokens.
+* Filters like stat:recovery:=0 now work (they couldn't match stat values of zero before).
 
 # 4.59.0 (2018-07-01)
 

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -249,7 +249,7 @@ export function searchFilters(
 
     return (item: DimItem, predicate: string) => {
       const foundStatHash = item.stats && item.stats.find((s) => s.statHash === statHash);
-      return foundStatHash && foundStatHash.value && compareByOperand(foundStatHash.value, predicate);
+      return foundStatHash && compareByOperand(foundStatHash.value, predicate);
     };
   };
 
@@ -275,7 +275,6 @@ export function searchFilters(
 
     switch (operand) {
     case 'none':
-      return compare === predicate;
     case '=':
       return compare === predicate;
     case '<':


### PR DESCRIPTION
Reported on Reddit: https://www.reddit.com/r/DestinyItemManager/comments/8oir9i/statn0_filter_doesnt_work/

We were filtering out zero value stats before comparing against the operand.