### PR TITLE
Remove unnecessary settings save every time we show the item popup

### DIFF
--- a/src/app/item-review/item-review.component.ts
+++ b/src/app/item-review/item-review.component.ts
@@ -226,10 +226,6 @@ function ItemReviewController(
 
   vm.settings = settings;
 
-  $scope.$watchCollection('vm.settings', () => {
-    settings.save();
-  });
-
   $rootScope.$on('dim-item-reviews-fetched', () => {
     vm.reviewData = vm.getReviewData();
   });
@@ -240,6 +236,8 @@ function ItemReviewController(
     if (vm.canReview) {
       dimDestinyTrackerService.getItemReviews(vm.item);
     }
+
+    settings.save();
   };
 
   vm.translateReviewMode = (review: D2ItemUserReview) => {


### PR DESCRIPTION
A `$watch` in AngularJS will always fire once, to initialize its value. This watch was causing us to save settings every time an item popup was shown. I suspect this actually has something to do with all the "over rate limit" GDrive errors we see in Sentry.