### PR TITLE
Fix iOS layout thrashing bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Fixed a bug that could cause iOS Safari to hang.
+
 # 4.62.0 (2018-07-22)
 
 * Xur has been removed from the header in D1. Find him in the Vendors page.

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -49,10 +49,10 @@ export default class Destiny extends React.Component<Props> {
   render() {
     return (
       <>
+        <div className="store-bounds"/>
         <div id="content">
           <UIView/>
         </div>
-        <div className="store-bounds"/>
         <ManifestProgress destinyVersion={this.props.account.destinyVersion} />
       </>
     );


### PR DESCRIPTION
This fixes #2930 and #2905. Something about the order of DOM elements was causing Safari on iOS to really thrash layout (for up to 20 seconds!) when it didn't need to. Simply rearranging it solves the issue.