### PR TITLE
Vendor engrams cleanup

### DIFF
--- a/src/app/d2-vendors/Vendors.tsx
+++ b/src/app/d2-vendors/Vendors.tsx
@@ -19,7 +19,8 @@ import { D2StoresService } from '../inventory/d2-stores.service';
 import { UIViewInjectedProps } from '@uirouter/react';
 import { $rootScope } from 'ngimport';
 import { Loading } from '../dim-ui/Loading';
-import { VendorEngramsXyzService, dimVendorEngramsService } from '../vendorEngramsXyzApi/vendorEngramsXyzService';
+import { dimVendorEngramsService } from '../vendorEngramsXyzApi/vendorEngramsXyzService';
+import { VendorDrop } from '../vendorEngramsXyzApi/vendorDrops';
 
 interface Props {
   account: DestinyAccount;
@@ -31,7 +32,7 @@ interface State {
   trackerService?: DestinyTrackerService;
   stores?: D2Store[];
   ownedItemHashes?: Set<number>;
-  vendorEngramsService?: VendorEngramsXyzService;
+  vendorEngramDrops?: VendorDrop[];
   basePowerLevel?: number;
 }
 
@@ -49,6 +50,8 @@ export default class Vendors extends React.Component<Props & UIViewInjectedProps
 
   // TODO: pull this into a service?
   async loadVendors() {
+    dimVendorEngramsService.getAllVendorDrops().then((vendorEngramDrops) => this.setState({ vendorEngramDrops }));
+
     // TODO: defs as a property, not state
     const defs = await getDefinitions();
     D2ManifestService.loaded = true;
@@ -76,9 +79,6 @@ export default class Vendors extends React.Component<Props & UIViewInjectedProps
 
     const trackerService = await fetchRatingsForVendors(defs, vendorsResponse);
     this.setState({ trackerService });
-
-    const vendorEngramsService = await dimVendorEngramsService.fetchVendorDrops();
-    this.setState({ vendorEngramsService });
   }
 
   componentDidMount() {
@@ -109,7 +109,7 @@ export default class Vendors extends React.Component<Props & UIViewInjectedProps
   }
 
   render() {
-    const { defs, vendorsResponse, trackerService, ownedItemHashes, vendorEngramsService, basePowerLevel } = this.state;
+    const { defs, vendorsResponse, trackerService, ownedItemHashes, vendorEngramDrops, basePowerLevel } = this.state;
     const { account } = this.props;
 
     if (!vendorsResponse || !defs) {
@@ -127,7 +127,7 @@ export default class Vendors extends React.Component<Props & UIViewInjectedProps
             trackerService={trackerService}
             ownedItemHashes={ownedItemHashes}
             account={account}
-            vendorEngramsService={vendorEngramsService}
+            vendorEngramDrops={vendorEngramDrops}
             basePowerLevel={basePowerLevel}
           />
         )}
@@ -144,7 +144,7 @@ function VendorGroup({
   trackerService,
   ownedItemHashes,
   account,
-  vendorEngramsService,
+  vendorEngramDrops,
   basePowerLevel
 }: {
   defs: D2ManifestDefinitions;
@@ -153,7 +153,7 @@ function VendorGroup({
   trackerService?: DestinyTrackerService;
   ownedItemHashes?: Set<number>;
   account: DestinyAccount;
-  vendorEngramsService?: VendorEngramsXyzService;
+  vendorEngramDrops?: VendorDrop[];
   basePowerLevel?: number;
 }) {
   const groupDef = defs.VendorGroup.get(group.vendorGroupHash);
@@ -172,7 +172,7 @@ function VendorGroup({
             trackerService={trackerService}
             ownedItemHashes={ownedItemHashes}
             currencyLookups={vendorsResponse.currencyLookups.data.itemQuantities}
-            vendorEngramsService={vendorEngramsService}
+            allVendorEngramDrops={vendorEngramDrops}
             basePowerLevel={basePowerLevel}
           />
         </ErrorBoundary>

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -261,12 +261,7 @@ export default class Header extends React.PureComponent<Props, State> {
 
     dimVendorEngramsService.getAllVendorDrops()
       .then((vds) => {
-        if (!vds) {
-          return;
-        }
-
         const anyActive = vds.some(isVerified380);
-
         this.setState({ vendorEngramDropActive: anyActive });
       });
 

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -73,7 +73,6 @@ interface State {
   dropdownOpen: boolean;
   showSearch: boolean;
   vendorEngramDropActive: boolean;
-  engramRefreshTimeout: number;
 }
 
 interface Props {
@@ -85,6 +84,7 @@ export default class Header extends React.PureComponent<Props, State> {
   // tslint:disable-next-line:ban-types
   private unregisterTransitionHooks: Function[] = [];
   private dropdownToggler = React.createRef<HTMLElement>();
+  private engramRefreshTimer: number;
 
   private SearchFilter: React.ComponentClass<{ account: DestinyAccount }>;
 
@@ -96,15 +96,14 @@ export default class Header extends React.PureComponent<Props, State> {
     this.state = {
       dropdownOpen: false,
       showSearch: false,
-      vendorEngramDropActive: false,
-      engramRefreshTimeout: 0
+      vendorEngramDropActive: false
     };
   }
 
   componentDidMount() {
     this.accountSubscription = getActiveAccountStream().subscribe((account) => {
       this.setState({ account: account || undefined });
-      this.updateVendorEngrams();
+      this.updateVendorEngrams(account || undefined);
     });
 
     this.unregisterTransitionHooks = [
@@ -122,9 +121,7 @@ export default class Header extends React.PureComponent<Props, State> {
   componentWillUnmount() {
     this.unregisterTransitionHooks.forEach((f) => f());
     this.accountSubscription.unsubscribe();
-    if (this.state.engramRefreshTimeout) {
-      clearTimeout(this.state.engramRefreshTimeout);
-    }
+    this.stopPollingVendorEngrams();
   }
 
   render() {
@@ -256,8 +253,9 @@ export default class Header extends React.PureComponent<Props, State> {
     );
   }
 
-  private updateVendorEngrams = () => {
-    if (!$featureFlags.vendorEngrams || !this.state.account || this.state.account.destinyVersion !== 2) {
+  private updateVendorEngrams = (account = this.state.account) => {
+    if (!$featureFlags.vendorEngrams || !account || account.destinyVersion !== 2) {
+      this.stopPollingVendorEngrams();
       return;
     }
 
@@ -272,11 +270,16 @@ export default class Header extends React.PureComponent<Props, State> {
         this.setState({ vendorEngramDropActive: anyActive });
       });
 
-    if (!this.state.engramRefreshTimeout) {
-      const engramRefreshTimeout = window.setInterval(this.updateVendorEngrams,
+    if (!this.engramRefreshTimer) {
+      this.engramRefreshTimer = window.setInterval(this.updateVendorEngrams,
         dimVendorEngramsService.refreshInterval);
+    }
+  }
 
-      this.setState({ engramRefreshTimeout });
+  private stopPollingVendorEngrams = () => {
+    if (this.engramRefreshTimer) {
+      clearInterval(this.engramRefreshTimer);
+      this.engramRefreshTimer = 0;
     }
   }
 

--- a/src/app/shell/Link.tsx
+++ b/src/app/shell/Link.tsx
@@ -50,7 +50,7 @@ export default class Link extends React.Component<Props, State> {
     return (
       <UISrefActive key={this.state.generation} class='active'>
         <UISref to={state} params={account}>
-          <a className='link'>{showWhatsNew && <span className='badge-new'></span>}{children}{text && t(text)}</a>
+          <a className='link'>{showWhatsNew && <span className='badge-new'/>}{children}{text && t(text)}</a>
         </UISref>
       </UISrefActive>
     );

--- a/src/app/vendorEngramsXyzApi/vendorDrops.ts
+++ b/src/app/vendorEngramsXyzApi/vendorDrops.ts
@@ -2,8 +2,8 @@ export interface VendorDrop {
   id: number;
   vendor: VendorEngramVendor;
   type: VendorDropType;
-  verified: boolean;
-  enabled: boolean;
+  verified: number;
+  enabled: number;
 }
 
 export enum VendorDropType {
@@ -32,6 +32,7 @@ export enum VendorEngramVendor {
   ArachJalaal =	15,
   TheEmissary =	16,
   LordSaladin =	17,
+  BrotherVance = 18,
   AnaBray =	19,
   IKELOS_HC_V1_0_1 = 20,
   BraytechRWPMk_II = 21
@@ -43,6 +44,7 @@ export enum ManifestVendor {
   AsherMir = 3982706173,
   Banshee44 = 672118013,
   Benedict9940 = 1265988377,
+  BrotherVance = 2398407866,
   CommanderZavala = 69482069,
   DevrimKay = 396892126,
   ExecutorHideo = 3819664660,
@@ -59,3 +61,28 @@ export enum ManifestVendor {
   TheEmissary_TRIALS4 = 3190557734,
   TyraKarn = 1748437699
 }
+
+export const vendorHashToVendorEngramVendor: { [k: number]: VendorEngramVendor[] | undefined } = {
+  [ManifestVendor.AsherMir]: [VendorEngramVendor.AsherMir,
+    VendorEngramVendor.ManOWar],
+  [ManifestVendor.AnaBray]: [VendorEngramVendor.AnaBray, VendorEngramVendor.BraytechRWPMk_II, VendorEngramVendor.IKELOS_HC_V1_0_1],
+  [ManifestVendor.Banshee44]: [VendorEngramVendor.Banshee44],
+  [ManifestVendor.Benedict9940]: [VendorEngramVendor.Benedict9940],
+  [ManifestVendor.BrotherVance]: [VendorEngramVendor.BrotherVance],
+  [ManifestVendor.CommanderZavala]: [VendorEngramVendor.CommanderZavala],
+  [ManifestVendor.DevrimKay]: [VendorEngramVendor.DevrimKay,
+    VendorEngramVendor.MidaMiniTool],
+  [ManifestVendor.TyraKarn]: [VendorEngramVendor.Drang],
+  [ManifestVendor.ExecutorHideo]: [VendorEngramVendor.ExecutorHideo],
+  [ManifestVendor.Failsafe]: [VendorEngramVendor.Failsafe],
+  [ManifestVendor.IkoraRey]: [VendorEngramVendor.IkoraRey],
+  [ManifestVendor.Lakshmi2]: [VendorEngramVendor.Lakshmi2],
+  [ManifestVendor.LordSaladin]: [VendorEngramVendor.LordSaladin],
+  [ManifestVendor.LordShaxx]: [VendorEngramVendor.LordShaxx],
+  [ManifestVendor.Sloane]: [VendorEngramVendor.Sloane],
+  [ManifestVendor.TheEmissary_TRIALS0]: [VendorEngramVendor.TheEmissary],
+  [ManifestVendor.TheEmissary_TRIALS1]: [VendorEngramVendor.TheEmissary],
+  [ManifestVendor.TheEmissary_TRIALS2]: [VendorEngramVendor.TheEmissary],
+  [ManifestVendor.TheEmissary_TRIALS3]: [VendorEngramVendor.TheEmissary],
+  [ManifestVendor.TheEmissary_TRIALS4]: [VendorEngramVendor.TheEmissary]
+};

--- a/src/app/vendorEngramsXyzApi/vendorEngramsXyzService.ts
+++ b/src/app/vendorEngramsXyzApi/vendorEngramsXyzService.ts
@@ -1,58 +1,27 @@
-import { VendorDrop, VendorEngramVendor, VendorDropType, ManifestVendor } from "./vendorDrops";
+import { VendorDrop, VendorDropType, vendorHashToVendorEngramVendor } from "./vendorDrops";
 import { loadingTracker } from "../ngimport-more";
 import { t } from 'i18next';
 
 export class VendorEngramsXyzService {
-  readonly vendorMap: { [k: number]: VendorEngramVendor[] } = {
-    [ManifestVendor.AsherMir]: [VendorEngramVendor.AsherMir,
-      VendorEngramVendor.ManOWar],
-    [ManifestVendor.Banshee44]: [VendorEngramVendor.Banshee44],
-    [ManifestVendor.Benedict9940]: [VendorEngramVendor.Benedict9940],
-    [ManifestVendor.CommanderZavala]: [VendorEngramVendor.CommanderZavala],
-    [ManifestVendor.DevrimKay]: [VendorEngramVendor.DevrimKay,
-      VendorEngramVendor.MidaMiniTool],
-    [ManifestVendor.TyraKarn]: [VendorEngramVendor.Drang],
-    [ManifestVendor.ExecutorHideo]: [VendorEngramVendor.ExecutorHideo],
-    [ManifestVendor.Failsafe]: [VendorEngramVendor.Failsafe],
-    [ManifestVendor.IkoraRey]: [VendorEngramVendor.IkoraRey],
-    [ManifestVendor.Lakshmi2]: [VendorEngramVendor.Lakshmi2],
-    [ManifestVendor.LordSaladin]: [VendorEngramVendor.LordSaladin],
-    [ManifestVendor.LordShaxx]: [VendorEngramVendor.LordShaxx],
-    [ManifestVendor.Sloane]: [VendorEngramVendor.Sloane],
-    [ManifestVendor.TheEmissary_TRIALS0]: [VendorEngramVendor.TheEmissary],
-    [ManifestVendor.TheEmissary_TRIALS1]: [VendorEngramVendor.TheEmissary],
-    [ManifestVendor.TheEmissary_TRIALS2]: [VendorEngramVendor.TheEmissary],
-    [ManifestVendor.TheEmissary_TRIALS3]: [VendorEngramVendor.TheEmissary],
-    [ManifestVendor.TheEmissary_TRIALS4]: [VendorEngramVendor.TheEmissary]
-  };
+  refreshInterval: number = 1000 * 60 * 15;
+  cachedResponse: VendorDrop[];
+  lastUpdated: number = 0;
+  refreshPromise?: Promise<VendorDrop[]>;
 
-  refreshInterval: number;
-  cachedResponse: VendorDrop[] | null;
-  lastUpdated: Date | null;
-
-  constructor() {
-    this.refreshInterval = 1000 * 60 * 15;
-  }
-
-  handleVendorEngramsErrors(response: Response) {
+  handleVendorEngramsErrors(response: Response): Promise<VendorDrop[]> {
     if (response.status !== 200) {
       throw new Error(t('VendorEngramsXyz.ServiceCallError'));
     }
 
-    return response.json();
+    return response.json() || [];
   }
 
-  lastUpdatedInPastFifteenMinutes(): boolean {
+  cacheExpired(): boolean {
     if (!this.lastUpdated) {
-      return false;
+      return true;
     }
 
-    const now = new Date();
-    const lastToNow = Math.abs(now.getTime() - this.lastUpdated.getTime());
-
-    const difference = Math.floor((lastToNow / 1000) / 60);
-
-    return (difference <= 15);
+    return Date.now() - this.lastUpdated >= this.refreshInterval;
   }
 
   vendorEngramsFetch(url: string) {
@@ -66,47 +35,32 @@ export class VendorEngramsXyzService {
     return Promise.resolve(fetch(request));
   }
 
-  async fetchVendorDrops(): Promise<this> {
-    if (this.cachedResponse && this.lastUpdatedInPastFifteenMinutes()) {
-      return this;
+  async getAllVendorDrops(): Promise<VendorDrop[]> {
+    if (this.cachedResponse && !this.cacheExpired()) {
+      return this.cachedResponse;
     }
 
-    const promise = this.vendorEngramsFetch('https://api.vendorengrams.xyz/getVendorDrops?source=DIM')
+    this.refreshPromise = this.refreshPromise || this.vendorEngramsFetch('https://api.vendorengrams.xyz/getVendorDrops?source=DIM')
       .then(this.handleVendorEngramsErrors, this.handleVendorEngramsErrors);
 
-    loadingTracker.addPromise(promise);
+    loadingTracker.addPromise(this.refreshPromise);
 
-    this.cachedResponse = await promise;
-    this.lastUpdated = new Date();
-
-    return this;
-  }
-
-  async getAllVendorDrops(): Promise<VendorDrop[] | null> {
-    await this.fetchVendorDrops();
+    this.cachedResponse = await this.refreshPromise;
+    this.lastUpdated = Date.now();
+    this.refreshPromise = undefined;
 
     return this.cachedResponse;
   }
+}
 
-  async getVendorDrops(vendorHash: number): Promise<VendorDrop[] | undefined> {
-    if (!this.cachedResponse) {
-      await this.fetchVendorDrops();
-    }
+export function getVendorDropsForVendor(vendorHash: number, vendorDrops?: VendorDrop[]): VendorDrop[] {
+  const matchedValues = vendorHashToVendorEngramVendor[vendorHash];
 
-    if (!this.cachedResponse) {
-      return undefined;
-    }
-
-    const matchedValues = this.vendorMap[vendorHash];
-
-    if (!matchedValues) {
-      return undefined;
-    }
-
-    return this
-      .cachedResponse
-      .filter((vd) => matchedValues.some((vev) => vev === vd.vendor));
+  if (!matchedValues) {
+    return [];
   }
+
+  return (vendorDrops && vendorDrops.filter((vd) => vd.enabled === 1 && matchedValues.includes(vd.vendor))) || [];
 }
 
 export function powerLevelMatters(powerLevel?: number): boolean {
@@ -115,7 +69,7 @@ export function powerLevelMatters(powerLevel?: number): boolean {
 
 export function isVerified380(vendorDrop: VendorDrop): boolean {
   return vendorDrop.type === VendorDropType.Likely380 &&
-    vendorDrop.verified;
+    vendorDrop.verified === 1;
 }
 
 export const dimVendorEngramsService = new VendorEngramsXyzService();

--- a/src/app/vendors/vendors.scss
+++ b/src/app/vendors/vendors.scss
@@ -39,14 +39,11 @@
   }
 
   .xyz-active-throb {
-    width: 30px;
-    height: 30px;
     border-radius: 100px;
-    margin-right: 20px;
     animation: glow 1s infinite alternate;
   }
 
-  .xyz-inactive {
+  .xyz-engram {
     width: 30px;
     height: 30px;
     margin-right: 20px;


### PR DESCRIPTION
A cleanup/efficiency pass on the vendor engrams stuff:

1. Add Ana Bray and Brother Vance as vendors.
2. Only show engram marker for enabled vendors that are mapped to VendorEngrams vendors.
3. Don't read state right after `setState`, because `setState` is async.
4. Don't block waiting for other stuff to happen before loading vendors.
5. Only allow one outstanding request for vendor engrams at once.
6. Stop polling when the account is no longer D2.
7. Move a bunch of state into props.
8. Pass values rather than the vendor drops service.

And a bunch of other minor cleanups. I also understood that the fix in #2961 didn't have anything to do with moving the timer into state - the fix was avoiding registering a new interval every time the interval fired.