### PR TITLE
Some CSS changes from the redux branch

### DIFF
--- a/src/app/activities/activities.scss
+++ b/src/app/activities/activities.scss
@@ -6,6 +6,7 @@
   .activities-characters {
     display: flex;
     margin-top: 12px;
+    margin-bottom: 12px;
   }
 
   .activities-character {

--- a/src/app/destiny1/d1-inventory.html
+++ b/src/app/destiny1/d1-inventory.html
@@ -1,4 +1,4 @@
-<div class="sticky-header-background" scroll-class="something-is-sticky"></div>
+<div class="sticky-header-background" scroll-class="sticky"></div>
 <loading ng-if="!$ctrl.stores"></loading>
 <dim-stores class="stores" stores="$ctrl.stores" buckets="$ctrl.buckets"></dim-stores>
 <loadout-drawer stores="$ctrl.stores" account="$ctrl.account"></loadout-drawer>

--- a/src/app/destiny2/d2-inventory.html
+++ b/src/app/destiny2/d2-inventory.html
@@ -1,4 +1,4 @@
-<div class="sticky-header-background" scroll-class="something-is-sticky"></div>
+<div class="sticky-header-background" scroll-class="sticky"></div>
 <loading ng-if="!$ctrl.stores"></loading>
 <dim-stores class="stores" stores="$ctrl.stores" buckets="$ctrl.buckets"></dim-stores>
 <loadout-drawer stores="$ctrl.stores" account="$ctrl.account"></loadout-drawer>

--- a/src/app/inventory/dimStoreHeading.scss
+++ b/src/app/inventory/dimStoreHeading.scss
@@ -6,8 +6,6 @@ dim-store-heading {
 
 .character {
   flex: 1;
-  margin-bottom: 10px;
-  height: 58px;
   width: 100%;
 }
 

--- a/src/app/inventory/dimStores.scss
+++ b/src/app/inventory/dimStores.scss
@@ -61,12 +61,12 @@
 .store-header {
   position: fixed;
   backface-visibility: hidden;
-  top: 55px;
+  top: 44px;
   left: 0;
   width: auto;
   z-index: 10;
-  margin-left: 28px;
-  height: 82px;
+  padding: 8px 0 4px 8px;
+  background-color: #434444;
 
   @supports (position: sticky) {
     position: sticky;

--- a/src/app/inventory/store-pager.scss
+++ b/src/app/inventory/store-pager.scss
@@ -10,16 +10,9 @@ store-pager {
   }
 }
 
-.store-header {
-}
-
-.character-swipe {
-}
-
 .phone-portrait {
   .store-header {
     max-width: 100%;
     overflow: hidden;
-    margin: 0 -8px;
   }
 }

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -1,11 +1,12 @@
 @import '../../scss/variables.scss';
 
 .progress-page {
-  margin: 0 auto;
+  margin: 16px auto !important;
 
   .progress-characters {
     display: flex;
     margin-top: 12px;
+    margin-bottom: 12px;
 
     .character {
       height: auto;
@@ -67,6 +68,6 @@
   hr {
     border: none;
     border-bottom: 1px solid #666;
-    margin: 0 0 24px 0;
+    margin: 0 0 16px 0;
   }
 }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -107,7 +107,6 @@ h2, h3 {
 
 
 body {
-  overflow-y: auto;
   margin: 0 auto;
   padding-top: 44px;
   padding-top: calc(44px + constant(safe-area-inset-top));
@@ -117,9 +116,6 @@ body {
   font-family: 'Open Sans', sans-serif;
   font-size:12px;
   filter: var(--color-filter);
-  > div:first-child {
-    padding-top: 10px;
-  }
 }
 
 ::-webkit-scrollbar {
@@ -250,10 +246,6 @@ img {
   padding-right: env(safe-area-inset-right);
 }
 
-.bucket-padding {
-  padding: 0 8px;
-}
-
 .store-bounds {
   position: fixed;
   backface-visibility: hidden;
@@ -326,7 +318,7 @@ h2, h3, h4 {
   backface-visibility: hidden;
   z-index: 4;
 
-  &.something-is-sticky {
+  &.sticky {
     box-shadow: 0 1px 6px 0px #222;
   }
 }


### PR DESCRIPTION
Some CSS updates extracted from the `redux-redux` branch. The main thing changed is that I removed the padding around the outside of the app, which makes it "wall to wall" which I think looks nicer, especially on mobile. I also trimmed down the space under and around the character headers and fixed the offset at which the sticky header displays.

Old:
<img width="1347" alt="screen shot 2018-08-18 at 10 53 17 am" src="https://user-images.githubusercontent.com/313208/44305555-30a96b80-a32f-11e8-8bc7-d186c21fd15b.png">

New:
<img width="1347" alt="screen shot 2018-08-18 at 10 53 04 am" src="https://user-images.githubusercontent.com/313208/44305554-30a96b80-a32f-11e8-883f-cbc71fe3deaf.png">
