### PR TITLE
Handle vendors API being unavailable

### DIFF
--- a/src/app/d2-vendors/Vendors.tsx
+++ b/src/app/d2-vendors/Vendors.tsx
@@ -21,6 +21,7 @@ import { $rootScope } from 'ngimport';
 import { Loading } from '../dim-ui/Loading';
 import { dimVendorEngramsService } from '../vendorEngramsXyzApi/vendorEngramsXyzService';
 import { VendorDrop } from '../vendorEngramsXyzApi/vendorDrops';
+import { t } from 'i18next';
 
 interface Props {
   account: DestinyAccount;
@@ -34,6 +35,7 @@ interface State {
   ownedItemHashes?: Set<number>;
   vendorEngramDrops?: VendorDrop[];
   basePowerLevel?: number;
+  error?: Error;
 }
 
 /**
@@ -73,12 +75,19 @@ export default class Vendors extends React.Component<Props & UIViewInjectedProps
         }
       }
     }
-    const vendorsResponse = await getVendorsApi(this.props.account, characterId);
 
-    this.setState({ defs, vendorsResponse });
+    let vendorsResponse;
+    try {
+      vendorsResponse = await getVendorsApi(this.props.account, characterId);
+      this.setState({ defs, vendorsResponse });
+    } catch (error) {
+      this.setState({ error });
+    }
 
-    const trackerService = await fetchRatingsForVendors(defs, vendorsResponse);
-    this.setState({ trackerService });
+    if (vendorsResponse) {
+      const trackerService = await fetchRatingsForVendors(defs, vendorsResponse);
+      this.setState({ trackerService });
+    }
   }
 
   componentDidMount() {
@@ -109,8 +118,16 @@ export default class Vendors extends React.Component<Props & UIViewInjectedProps
   }
 
   render() {
-    const { defs, vendorsResponse, trackerService, ownedItemHashes, vendorEngramDrops, basePowerLevel } = this.state;
+    const { defs, vendorsResponse, trackerService, ownedItemHashes, vendorEngramDrops, basePowerLevel, error } = this.state;
     const { account } = this.props;
+
+    if (error) {
+      return (
+        <div className="vendor dim-page">
+          <h2>{t('Forsaken.Vendors')}</h2>
+        </div>
+      );
+    }
 
     if (!vendorsResponse || !defs) {
       return <div className="vendor dim-page"><Loading/></div>;

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -193,9 +193,14 @@ export default class Progress extends React.Component<Props, State> {
       </>
     );
 
+    const forsaken = (
+      <p>{t('Forsaken.Progress')}</p>
+    );
+
     if (this.state.isPhonePortrait) {
       return (
         <div className="progress-page dim-page">
+         {forsaken}
           {profileMilestonesContent}
           <ViewPager>
             <Frame className="frame" autoSize={true}>
@@ -217,6 +222,7 @@ export default class Progress extends React.Component<Props, State> {
     } else {
       return (
         <div className="progress-page dim-page">
+          {forsaken}
           {profileMilestonesContent}
           {this.renderCharacters(characters)}
         </div>
@@ -314,7 +320,7 @@ export default class Progress extends React.Component<Props, State> {
     const { vendors, defs } = this.state.progress!;
     const factionDef = defs.Faction[faction.factionHash];
     const vendorHash = factionDef.vendors[faction.factionVendorIndex].vendorHash;
-    return vendors[character.characterId].vendors.data[vendorHash];
+    return vendors[character.characterId] ? vendors[character.characterId].vendors.data[vendorHash] : undefined;
   }
 
   /**

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -88,7 +88,12 @@ async function loadProgress(account: DestinyAccount): Promise<ProgressProfile | 
     const defsPromise = getDefinitions();
     const profileInfo = await getProgression(account);
     const characterIds = Object.keys(profileInfo.characters.data);
-    const vendors = await Promise.all(characterIds.map((characterId) => getVendors(account, characterId)));
+    let vendors: DestinyVendorsResponse[] = [];
+    try {
+      vendors = await Promise.all(characterIds.map((characterId) => getVendors(account, characterId)));
+    } catch (e) {
+      console.error('Failed to load vendors', e);
+    }
     const defs = await defsPromise;
     return {
       defs,

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -259,6 +259,10 @@
     "WeaponType": "Shows weapons based on their weapon type.",
     "Year": "Shows items from which year of Destiny they appeared in."
   },
+  "Forsaken": {
+    "Progress": "Note: Progress data can be incomplete or incorrect until some time after Forsaken launches.",
+    "Vendors": "Vendors will be unavailable until some time after Forsaken launches."
+  },
   "Header": {
     "About": "About",
     "Back": "Go Back",


### PR DESCRIPTION
The vendors API is down until after Forsaken, but we didn't handle that. So I'm working around it with some quick notes.

This fixes #2982.