### PR TITLE
Ratings with random rolls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * New is:primary, is:special, and is:heavy search terms for ammo types.
 * Add is:tracerifle and is:linearfusionrifle searches.
 * Added Korean as a language option.
+* Ratings system understands random rolls in D2.
 
 # 4.67.0 (2018-08-26)
 

--- a/src/app/destinyTrackerApi/d2-itemTransformer.ts
+++ b/src/app/destinyTrackerApi/d2-itemTransformer.ts
@@ -23,6 +23,7 @@ export function translateToDtrItem(item: D2Item | DestinyVendorSaleItemComponent
  */
 export function getRollAndPerks(item: D2Item): DtrD2BasicItem {
   const powerModHashes = getPowerMods(item).map((m) => m.hash);
+
   return {
     selectedPerks: getSelectedPlugs(item, powerModHashes),
     attachedMods: powerModHashes,
@@ -50,19 +51,17 @@ function isD2Item(item: D2Item | DestinyVendorSaleItemComponent): item is D2Item
  * If the item has a random roll, we supply the random plug hashes it has in
  * a value named `availablePerks` to the DTR API.
  */
-function getAvailablePerks(item: D2Item | DestinyVendorSaleItemComponent): number[] {
+function getAvailablePerks(item: D2Item | DestinyVendorSaleItemComponent): number[] | undefined {
   if (isD2Item(item)) {
     if (!item.sockets) {
-      return [];
+      return undefined;
     }
 
-    if (item.hash === 2681395357) {
-      console.log('Trackless Waste');
-    }
-
-    return flatMap(item
+    const randomPlugOptions = flatMap(item
       .sockets
       .sockets, (s) => s.hasRandomizedPlugItems ? s.plugOptions.map((po) => po.plugItem.hash) : []);
+
+    return (randomPlugOptions && randomPlugOptions.length > 0) ? randomPlugOptions : undefined;
   }
 
   // TODO: look up vendor rolls

--- a/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/d2-reviewSubmitter.ts
@@ -18,6 +18,8 @@ interface D2ReviewSubmitRequest {
   attachedMods?: number[];
   /** What perks does the user have selected? */
   selectedPerks?: number[];
+  /** If it's a random roll, what's the complete list of (random) perks on it? */
+  availablePerks?: number[];
 
   reviewer: DtrReviewer;
   voted: number;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -397,6 +397,8 @@ export interface DimSocket {
   plug: DimPlug | null;
   /** Potential plugs for this socket. */
   plugOptions: DimPlug[];
+  /** Does the socket contain randomized plug items? */
+  hasRandomizedPlugItems: boolean;
 }
 
 export interface DimSocketCategory {

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -834,11 +834,7 @@ function buildSockets(
     return null;
   }
 
-  if (item.itemHash === 2681395357) {
-    console.log('building - Trackless Waste');
-  }
-
-  const realSockets = sockets.map((socket, i) => buildSocket(defs, socket, i));
+  const realSockets = sockets.map((socket, i) => buildSocket(defs, socket, itemDef.sockets.socketEntries[i], i));
 
   const categories = itemDef.sockets.socketCategories.map((category): DimSocketCategory => {
     return {
@@ -929,20 +925,6 @@ function isDestinyItemPlug(plug: DestinyItemPlug | DestinyItemSocketState): plug
   return Boolean((plug as DestinyItemPlug).plugItemHash);
 }
 
-function getHasRandomizedPlugItems(
-  defs: D2ManifestDefinitions,
-  plug: DestinyItemPlug | DestinyItemSocketState
-): boolean {
-  const plugHash = isDestinyItemPlug(plug) ? plug.plugItemHash : plug.plugHash;
-
-  const plugItem = plugHash && defs.InventoryItem.get(plugHash);
-  if (!plugItem || !plugItem.sockets) {
-    return false;
-  }
-
-  return plugItem.sockets.socketEntries.some((se) => se.randomizedPlugItems && se.randomizedPlugItems.length > 0);
-}
-
 function buildPlug(
   defs: D2ManifestDefinitions,
   plug: DestinyItemPlug | DestinyItemSocketState
@@ -992,13 +974,14 @@ function buildDefinedPlug(
 function buildSocket(
   defs: D2ManifestDefinitions,
   socket: DestinyItemSocketState,
+  socketEntry: DestinyItemSocketEntryDefinition,
   index: number
 ): DimSocket {
   // The currently equipped plug, if any
   const plug = buildPlug(defs, socket);
   const reusablePlugs = compact((socket.reusablePlugs || []).map((reusablePlug) => buildPlug(defs, reusablePlug)));
   const plugOptions = plug ? [plug] : [];
-  const hasRandomizedPlugItems = getHasRandomizedPlugItems(defs, socket);
+  const hasRandomizedPlugItems = socketEntry.randomizedPlugItems && socketEntry.randomizedPlugItems.length > 0;
 
   if (reusablePlugs.length) {
     reusablePlugs.forEach((reusablePlug) => {

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -834,6 +834,10 @@ function buildSockets(
     return null;
   }
 
+  if (item.itemHash === 2681395357) {
+    console.log('building - Trackless Waste');
+  }
+
   const realSockets = sockets.map((socket, i) => buildSocket(defs, socket, i));
 
   const categories = itemDef.sockets.socketCategories.map((category): DimSocketCategory => {
@@ -916,12 +920,27 @@ function buildDefinedSocket(
   return {
     socketIndex: index,
     plug: null,
-    plugOptions
+    plugOptions,
+    hasRandomizedPlugItems: socket.randomizedPlugItems && socket.randomizedPlugItems.length > 0
   };
 }
 
 function isDestinyItemPlug(plug: DestinyItemPlug | DestinyItemSocketState): plug is DestinyItemPlug {
   return Boolean((plug as DestinyItemPlug).plugItemHash);
+}
+
+function getHasRandomizedPlugItems(
+  defs: D2ManifestDefinitions,
+  plug: DestinyItemPlug | DestinyItemSocketState
+): boolean {
+  const plugHash = isDestinyItemPlug(plug) ? plug.plugItemHash : plug.plugHash;
+
+  const plugItem = plugHash && defs.InventoryItem.get(plugHash);
+  if (!plugItem || !plugItem.sockets) {
+    return false;
+  }
+
+  return plugItem.sockets.socketEntries.some((se) => se.randomizedPlugItems && se.randomizedPlugItems.length > 0);
 }
 
 function buildPlug(
@@ -979,6 +998,7 @@ function buildSocket(
   const plug = buildPlug(defs, socket);
   const reusablePlugs = compact((socket.reusablePlugs || []).map((reusablePlug) => buildPlug(defs, reusablePlug)));
   const plugOptions = plug ? [plug] : [];
+  const hasRandomizedPlugItems = getHasRandomizedPlugItems(defs, socket);
 
   if (reusablePlugs.length) {
     reusablePlugs.forEach((reusablePlug) => {
@@ -996,7 +1016,8 @@ function buildSocket(
   return {
     socketIndex: index,
     plug,
-    plugOptions
+    plugOptions,
+    hasRandomizedPlugItems
   };
 }
 

--- a/src/app/item-review/d2-dtr-api-types.ts
+++ b/src/app/item-review/d2-dtr-api-types.ts
@@ -15,6 +15,8 @@ export interface DtrD2BasicItem {
   attachedMods?: number[];
   /** What perks does the user have selected? */
   selectedPerks?: number[];
+  /** If it's a random roll, what's the complete list of (random) perks on it? */
+  availablePerks?: number[];
 }
 
 /** The form that votes come back to us in for items in D2. */
@@ -38,6 +40,8 @@ export interface DtrD2Vote {
 export interface D2ItemFetchRequest {
   /** Reference ID (hash ID). */
   referenceId: number;
+  /** If it's a random roll, what's the complete list of (random) perks on it? */
+  availablePerks?: number[];
 }
 
 /** The fetch response for a single item. */
@@ -83,6 +87,8 @@ export interface D2ItemUserReview extends DimUserReview {
   text: string;
   /** What perks did the user have selected on this item? */
   selectedPerks: number[];
+  /** If it's a random roll, what's the complete list of (random) perks on it? */
+  availablePerks?: number[];
   /** What power mods did the user have attached to this item? */
   attachedMods: number[];
   /** What play mode is this for? */


### PR DESCRIPTION
The DTR API accepts a property, `availablePerks`, that's expected to be an array of all of the random plug hashes that an instanced item has.

This updates DIM to send them for bulk fetches, review requests and review submissions.