### PR TITLE
Forsaken cleanup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Bugfixes post-Forsaken launch.
 * Add Infamy rank to progress page.
 * Remove "is:powermod" search.
+* Remove "basepower:" search.
 * Masterworks now have a gold border. Previously items with a power mod had a gold border, but there are no more power mods.
 
 # 4.68.3 (2018-09-03)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Max power updated to 600 for Forsaken owners.
 * Bugfixes post-Forsaken launch.
 * Add Infamy rank to progress page.
+* Remove "is:powermod" search.
+* Masterworks now have a gold border. Previously items with a power mod had a gold border, but there are no more power mods.
 
 # 4.68.3 (2018-09-03)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+* Max power updated to 600 for Forsaken owners.
+* Bugfixes post-Forsaken launch.
+* Add Infamy rank to progress page.
+
 # 4.68.3 (2018-09-03)
 
 # 4.68.2 (2018-09-03)

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -12,7 +12,6 @@ import { DestinyTrackerService } from "../item-review/destiny-tracker.service";
 import { dtrRatingColor } from "../shell/dimAngularFilters.filter";
 import { ratePerks } from "../destinyTrackerApi/d2-perkRater";
 import checkMark from '../../images/check.svg';
-import { D2Item } from "../inventory/item-types";
 import { D2RatingData } from "../item-review/d2-dtr-api-types";
 import { percent } from "../inventory/dimPercentWidth.directive";
 import { UISref } from "@uirouter/react";
@@ -127,21 +126,25 @@ export default class VendorItemComponent extends React.Component<Props> {
         this.dialogResult = null;
       }
     } else {
-      const dimItem = item.toDimItem(buckets, cachedItem);
-      let cachedItem: D2RatingData | null = null;
       const buckets = await getBuckets();
 
+      let cachedItem: D2RatingData | null = null;
       if (trackerService) {
         cachedItem = trackerService.getD2ReviewDataCache().getRatingData(undefined, item.itemHash);
+      }
+      const dimItem = item.toDimItem(buckets, cachedItem);
 
-        if (cachedItem && (!cachedItem.reviewsResponse || !cachedItem.reviewsResponse.reviews)) {
-          trackerService.getItemReviewAsync(item.itemHash).then(() => {
-            cachedItem = trackerService.getD2ReviewDataCache().getRatingData(undefined, item.itemHash);
-            // TODO: it'd be nice to push this into tracker service
+      if (cachedItem && (!cachedItem.reviewsResponse || !cachedItem.reviewsResponse.reviews) && trackerService) {
+        trackerService.getItemReviewAsync(item.itemHash).then(() => {
+          cachedItem = trackerService.getD2ReviewDataCache().getRatingData(undefined, item.itemHash);
+          // TODO: it'd be nice to push this into tracker service
+          if (dimItem) {
             Object.assign(dimItem, item.toDimItem(buckets, cachedItem));
             ratePerks(dimItem!);
-          });
-        }
+          } else {
+            console.error(item);
+          }
+        });
       }
 
       this.dialogResult = ngDialog.open({

--- a/src/app/d2-vendors/VendorItemComponent.tsx
+++ b/src/app/d2-vendors/VendorItemComponent.tsx
@@ -127,7 +127,7 @@ export default class VendorItemComponent extends React.Component<Props> {
         this.dialogResult = null;
       }
     } else {
-      let dimItem: D2Item | null = null;
+      const dimItem = item.toDimItem(buckets, cachedItem);
       let cachedItem: D2RatingData | null = null;
       const buckets = await getBuckets();
 
@@ -143,7 +143,6 @@ export default class VendorItemComponent extends React.Component<Props> {
           });
         }
       }
-      dimItem = item.toDimItem(buckets, cachedItem);
 
       this.dialogResult = ngDialog.open({
         template: dialogTemplate,

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -306,9 +306,8 @@ export class VendorItem {
     if (this.itemComponents && this.itemComponents.objectives && this.itemComponents.objectives.data[this.inventoryItem.hash]) {
       const objectives = this.itemComponents.objectives.data[this.inventoryItem.hash].objectives;
       return sum(objectives, (objective) => {
-        const objectiveDef = this.defs.Objective.get(objective.objectiveHash);
-        if (objectiveDef.completionValue) {
-          return Math.min(1, (objective.progress || 0) / objectiveDef.completionValue) / objectives.length;
+        if (objective.completionValue) {
+          return Math.min(1, (objective.progress || 0) / objective.completionValue) / objectives.length;
         } else {
           return 0;
         }

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -413,15 +413,22 @@ function makeD2StoresService(): D2StoreServiceType {
   }
 
   function getCurrentMaxBasePower(account: DestinyAccount) {
-    switch (account.versionsOwned) {
-      case DestinyGameVersions.Destiny2:
-        return 300;
-      case DestinyGameVersions.DLC1:
-        return 330;
-      case 3: // DLC2 doesn't have an enum value yet
-      default: // If they don't own Destiny, or it's an unknown version
-        return 380;
+    if (!account.versionsOwned) {
+      return 600;
     }
+    if (8 & account.versionsOwned) {
+      return 600;
+    }
+    if (DestinyGameVersions.DLC2 & account.versionsOwned) {
+      return 380;
+    }
+    if (DestinyGameVersions.DLC1 & account.versionsOwned) {
+      return 330;
+    }
+    if (DestinyGameVersions.Destiny2 & account.versionsOwned) {
+      return 300;
+    }
+    return 600;
   }
 
   function maxBasePowerLoadout(stores: D2Store[], store: D2Store) {

--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -59,7 +59,7 @@ function buildNodeString(nodes) {
 
 function downloadArmor(items, nameMap) {
   const header =
-    "Name,Tag,Tier,Type,Equippable,Light,Owner,% Leveled,Locked,Equipped,PowerMod,Year,DTR Rating,# of Reviews,% Quality,% IntQ,% DiscQ,% StrQ,Int,Disc,Str,Notes,Perks\n";
+    "Name,Tag,Tier,Type,Equippable,Light,Owner,% Leveled,Locked,Equipped,Year,DTR Rating,# of Reviews,% Quality,% IntQ,% DiscQ,% StrQ,Int,Disc,Str,Notes,Perks\n";
   let data = "";
   items.forEach((item) => {
     data += `"${item.name}",`;
@@ -76,7 +76,6 @@ function downloadArmor(items, nameMap) {
     data += `${(item.percentComplete * 100).toFixed(0)},`;
     data += `${item.locked},`;
     data += `${item.equipped},`;
-    data += `${item.primStat && item.primStat.value !== item.basePower},`;
     data += `${item.year},`;
     if (item.dtrRating && item.dtrRating.overallScore) {
       data += `${item.dtrRating.overallScore},${item.dtrRating.ratingCount},`;
@@ -117,7 +116,7 @@ function downloadArmor(items, nameMap) {
 
 function downloadWeapons(guns, nameMap) {
   const header =
-    "Name,Tag,Tier,Type,Light,Dmg,Owner,% Leveled,Locked,Equipped,PowerMod,Year,DTR Rating,# of Reviews," +
+    "Name,Tag,Tier,Type,Light,Dmg,Owner,% Leveled,Locked,Equipped,Year,DTR Rating,# of Reviews," +
     "AA,Impact,Range,Stability,ROF,Reload,Mag,Equip," +
     "Notes,Nodes\n";
   let data = "";
@@ -136,7 +135,6 @@ function downloadWeapons(guns, nameMap) {
     data += `${(gun.percentComplete * 100).toFixed(0)},`;
     data += `${gun.locked},`;
     data += `${gun.equipped},`;
-    data += `${gun.primStat && gun.primStat.value !== gun.basePower},`;
     data += `${gun.year},`;
     if (gun.dtrRating && gun.dtrRating.overallScore) {
       data += `${gun.dtrRating.overallScore},${gun.dtrRating.ratingCount},`;

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -669,7 +669,7 @@ function buildObjectives(
 
     let complete = false;
     let booleanValue = false;
-    let display = `${objective.progress || 0}/${def.completionValue}`;
+    let display = `${objective.progress || 0}/${objective.completionValue}`;
     let displayStyle: string | null;
     switch (def.valueStyle) {
       case DestinyUnlockValueUIStyle.Integer:
@@ -677,7 +677,7 @@ function buildObjectives(
         displayStyle = 'integer';
         break;
       case DestinyUnlockValueUIStyle.Multiplier:
-        display = `${(objective.progress || 0) / def.completionValue}x`;
+        display = `${(objective.progress || 0) / objective.completionValue}x`;
         displayStyle = 'integer';
         break;
       case DestinyUnlockValueUIStyle.DateTime:
@@ -689,7 +689,7 @@ function buildObjectives(
       case DestinyUnlockValueUIStyle.Checkbox:
       case DestinyUnlockValueUIStyle.Automatic:
         displayStyle = null;
-        booleanValue = def.completionValue === 1;
+        booleanValue = objective.completionValue === 1;
         complete = objective.complete;
         break;
       default:
@@ -704,7 +704,7 @@ function buildObjectives(
           : t('Objectives.Incomplete')),
       description: def.displayProperties.description,
       progress: objective.progress || 0,
-      completionValue: def.completionValue,
+      completionValue: objective.completionValue,
       complete,
       boolean: booleanValue,
       displayStyle,
@@ -738,7 +738,7 @@ function buildFlavorObjective(
   return {
     description: def.progressDescription,
     icon: def.displayProperties.hasIcon ? def.displayProperties.icon : "",
-    progress: def.valueStyle === 5 ? (flavorObjective.progress || 0) / def.completionValue : (def.valueStyle === 6 ? flavorObjective.progress : 0) || 0
+    progress: def.valueStyle === 5 ? (flavorObjective.progress || 0) / flavorObjective.completionValue : (def.valueStyle === 6 ? flavorObjective.progress : 0) || 0
   };
 }
 

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -286,10 +286,10 @@ export function makeItem(
 
   const categories = findCategories(itemDef);
 
-  const dmgName = [null, 'kinetic', 'arc', 'solar', 'void', 'raid'][instanceDef.damageType || 0];
+  const dmgName = instanceDef ? [null, 'kinetic', 'arc', 'solar', 'void', 'raid'][instanceDef.damageType || 0] : null;
 
   // https://github.com/Bungie-net/api/issues/134, class items had a primary stat
-  const primaryStat = ((itemDef.stats && itemDef.stats.disablePrimaryStatDisplay) || itemType === 'Class') ? null : instanceDef.primaryStat || null;
+  const primaryStat = ((itemDef.stats && itemDef.stats.disablePrimaryStatDisplay) || itemType === 'Class') ? null : (instanceDef && instanceDef.primaryStat) || null;
 
   const createdItem: D2Item = Object.assign(Object.create(ItemProto), {
     // figure out what year this item is probably from
@@ -313,14 +313,14 @@ export function makeItem(
       item.transferStatus === TransferStatuses.NotTransferrable),
     canPullFromPostmaster: !itemDef.doesPostmasterPullHaveSideEffects,
     id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
-    equipped: Boolean(instanceDef.isEquipped),
+    equipped: Boolean(instanceDef && instanceDef.isEquipped),
     equipment: Boolean(itemDef.equippingBlock), // TODO: this has a ton of good info for the item move logic
     equippingLabel: itemDef.equippingBlock && itemDef.equippingBlock.uniqueLabel,
     complete: false,
     amount: item.quantity,
     primStat: primaryStat,
     typeName: itemDef.itemTypeDisplayName || 'Unknown',
-    equipRequiredLevel: instanceDef.equipRequiredLevel || 0,
+    equipRequiredLevel: (instanceDef && instanceDef.equipRequiredLevel) || 0,
     maxStackSize: Math.max(itemDef.inventory.maxStackSize, 1),
     // 0: titan, 1: hunter, 2: warlock, 3: any
     classType: itemDef.classType,

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -485,12 +485,14 @@ export function makeItem(
     }
   }
 
-  // Mark items with power mods
+  // TODO: Phase out "base power"
   if (createdItem.primStat) {
     createdItem.basePower = getBasePowerLevel(createdItem);
-    if (createdItem.basePower !== createdItem.primStat.value) {
-      createdItem.complete = true;
-    }
+  }
+
+  // Mark masterworks with a gold border
+  if (createdItem.masterwork) {
+    createdItem.complete = true;
   }
 
   // Mark upgradeable stacks of rare modifications

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -1043,10 +1043,7 @@ const MOD_CATEGORY = 59;
 const POWER_STAT_HASH = 1935470627;
 
 function getBasePowerLevel(item: D2Item): number {
-  const powerMods = getPowerMods(item);
-  const modPower = sum(powerMods, (mod) => mod.investmentStats.find((s) => s.statTypeHash === POWER_STAT_HASH)!.value);
-
-  return item.primStat ? (item.primStat.value - modPower) : 0;
+  return item.primStat ? (item.primStat.value) : 0;
 }
 
 export function getPowerMods(item: D2Item): DestinyInventoryItemDefinition[] {

--- a/src/app/progress/Challenge.tsx
+++ b/src/app/progress/Challenge.tsx
@@ -27,8 +27,8 @@ export default function Challenge({
       <div className="milestone-challenge-info">
         <div className="milestone-header">
           <span className="milestone-challenge-name">{objectiveDef.displayProperties.name}</span>
-          {objectiveDef.completionValue > 1 &&
-            <span className="milestone-challenge-progress">{challenge.objective.progress || 0}/{objectiveDef.completionValue}</span>
+          {challenge.objective.completionValue > 1 &&
+            <span className="milestone-challenge-progress">{challenge.objective.progress || 0}/{challenge.objective.completionValue}</span>
           }
         </div>
         <div className="milestone-challenge-description">{objectiveDef.displayProperties.description}</div>

--- a/src/app/progress/Milestone.tsx
+++ b/src/app/progress/Milestone.tsx
@@ -43,9 +43,10 @@ export function Milestone({
     // A vendor milestone (Xur)
     return (
       <div className="milestone-quest">
-        <div className="milestone-icon">
-          <BungieImage src={milestoneDef.displayProperties.icon} />
-        </div>
+        {milestoneDef.displayProperties.icon &&
+          <div className="milestone-icon">
+            <BungieImage src={milestoneDef.displayProperties.icon} />
+          </div>}
         <div className="milestone-info">
           <span className="milestone-name">{milestoneDef.displayProperties.name}</span>
           <div className="milestone-description">
@@ -66,9 +67,9 @@ export function Milestone({
 
     return (
       <div className="milestone-quest">
-        <div className="milestone-icon">
+        {milestoneDef.displayProperties.icon && <div className="milestone-icon">
           <BungieImage src={milestoneDef.displayProperties.icon} />
-        </div>
+        </div>}
         <div className="milestone-info">
           <span className="milestone-name">{milestoneDef.displayProperties.name}</span>
           <div className="milestone-description">{milestoneDef.displayProperties.description}</div>

--- a/src/app/progress/Objective.tsx
+++ b/src/app/progress/Objective.tsx
@@ -40,11 +40,11 @@ export default function Objective({
 
   const classes = classNames('objective-row', {
     'objective-complete': objective.complete,
-    'objective-boolean': objectiveDef.valueStyle === DestinyUnlockValueUIStyle.Checkbox || (objectiveDef.completionValue === 1 && !objectiveDef.allowOvercompletion)
+    'objective-boolean': objectiveDef.valueStyle === DestinyUnlockValueUIStyle.Checkbox || (objective.completionValue === 1 && !objectiveDef.allowOvercompletion)
   });
 
   const progressBarStyle = {
-    width: percent(progress / objectiveDef.completionValue)
+    width: percent(progress / objective.completionValue)
   };
 
   return (
@@ -53,9 +53,9 @@ export default function Objective({
       <div className="objective-progress">
         <div className="objective-progress-bar" style={progressBarStyle}/>
         <div className="objective-description">{displayName}</div>
-        {objectiveDef.allowOvercompletion && objectiveDef.completionValue === 1
+        {objectiveDef.allowOvercompletion && objective.completionValue === 1
           ? <div className="objective-text">{progress}</div>
-          : <div className="objective-text">{progress}/{objectiveDef.completionValue}</div>
+          : <div className="objective-text">{progress}/{objective.completionValue}</div>
         }
       </div>
     </div>

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -140,7 +140,9 @@ export default class Progress extends React.Component<Props, State> {
       // Valor
       firstCharacterProgression[3882308435],
       // Glory
-      firstCharacterProgression[2679551909]
+      firstCharacterProgression[2679551909],
+      // Infamy
+      firstCharacterProgression[2772425241]
     ];
 
     const profileMilestonesContent = (profileMilestones.length > 0 || profileQuests.length > 0) && (

--- a/src/app/progress/Quest.tsx
+++ b/src/app/progress/Quest.tsx
@@ -18,9 +18,8 @@ export default function Quest(props: QuestProps) {
   const itemDef = defs.InventoryItem.get(item.itemHash);
 
   const percentComplete = sum(objectives, (objective) => {
-    const objectiveDef = defs.Objective.get(objective.objectiveHash);
-    if (objectiveDef.completionValue) {
-      return Math.min(1, (objective.progress || 0) / objectiveDef.completionValue) / objectives.length;
+    if (objective.completionValue) {
+      return Math.min(1, (objective.progress || 0) / objective.completionValue) / objectives.length;
     } else {
       return 0;
     }

--- a/src/app/progress/RewardActivity.tsx
+++ b/src/app/progress/RewardActivity.tsx
@@ -26,7 +26,7 @@ export default function RewardActivity({
   return (
     <div className={classNames('milestone-reward-activity', { complete: rewardEntry.earned })} title={t(tooltip)}>
       <i className={classNames('fa', checkClass)}/>
-      <BungieImage src={rewardDef.displayProperties.icon} />
+      {rewardDef.displayProperties.icon && <BungieImage src={rewardDef.displayProperties.icon} />}
       <span>{rewardDef.displayProperties.name}</span>
     </div>
   );

--- a/src/app/search/filters.html
+++ b/src/app/search/filters.html
@@ -59,11 +59,6 @@
           <dim-filter-link filter="power:&gt;value"></dim-filter-link>
           <dim-filter-link filter="power:&lt;value"></dim-filter-link>
           <dim-filter-link filter="power:&lt;=value"></dim-filter-link>
-          <dim-filter-link filter="basepower:value"></dim-filter-link>
-          <dim-filter-link filter="basepower:&gt;=value"></dim-filter-link>
-          <dim-filter-link filter="basepower:&gt;value"></dim-filter-link>
-          <dim-filter-link filter="basepower:&lt;value"></dim-filter-link>
-          <dim-filter-link filter="basepower:&lt;=value"></dim-filter-link>
         </td>
         <td ng-i18next="Filter.PowerLevel"></td>
       </tr>

--- a/src/app/search/filters.html
+++ b/src/app/search/filters.html
@@ -212,12 +212,6 @@
         <td ng-i18next="Filter.RarityTier"></td>
       </tr>
 
-      <tr ng-if="vm.settings.destinyVersion === 2">
-        <td>
-          <dim-filter-link filter="is:powermod"></dim-filter-link>
-        </td>
-        <td ng-i18next="Filter.PowerMod"></td>
-      </tr>
       <tr ng-if="vm.settings.destinyVersion === 1">
         <td>
           <dim-filter-link filter="is:intellect"></dim-filter-link>

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -123,7 +123,6 @@ export function buildSearchConfig(
   } else {
     Object.assign(filterTrans, {
       hasLight: ['light', 'haslight', 'haspower'],
-      powermod: ['powermod', 'haspowermod'],
       complete: ['goldborder', 'yellowborder', 'complete'],
       masterwork: ['masterwork', 'masterworks'],
       hasShader: ['shaded', 'hasshader'],
@@ -916,9 +915,6 @@ export function searchFilters(
       },
       transferable(item: DimItem) {
         return !item.notransfer;
-      },
-      powermod(item: DimItem) {
-        return item.primStat && (item.primStat.value !== item.basePower);
       },
       hasShader(item: D2Item) {
         return item.sockets && _.any(item.sockets.sockets, (socket) => {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -161,8 +161,6 @@ export function buildSearchConfig(
   const ranges = ['light', 'power', 'level', 'stack'];
   if (destinyVersion === 1) {
     ranges.push('quality', 'percentage');
-  } else {
-    ranges.push('basepower');
   }
 
   if ($featureFlags.reviewsEnabled) {
@@ -197,13 +195,9 @@ export function buildSearchConfig(
 
 // The comparator for sorting dupes - the first item will be the "best" and all others are "dupelower".
 const dupeComparator = reverseComparator(chainComparator(
-  // basePower
-  compareBy((item: DimItem) => item.basePower || (item.primStat && item.primStat.value)),
   // primary stat
   compareBy((item: DimItem) => item.primStat && item.primStat.value),
   compareBy((item: DimItem) => item.masterwork),
-  // has a power mod
-  compareBy((item: DimItem) => item.primStat && item.basePower && (item.primStat.value !== item.basePower)),
   compareBy((item: DimItem) => item.locked),
   compareBy((item: DimItem) => item.dimInfo && item.dimInfo.tag && ['favorite', 'keep'].includes(item.dimInfo.tag)),
   compareBy((i: DimItem) => i.id) // tiebreak by ID

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -163,7 +163,6 @@ export function SettingsController(
     typeName: $i18next.t('Settings.SortByType'),
     rarity: $i18next.t('Settings.SortByRarity'),
     primStat: $i18next.t('Settings.SortByPrimary'),
-    basePower: $i18next.t('Settings.SortByBasePower'),
     rating: $i18next.t('Settings.SortByRating'),
     classType: $i18next.t('Settings.SortByClassType'),
     name: $i18next.t('Settings.SortName')

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -68,6 +68,9 @@ if ($featureFlags.vendors) {
   });
 }
 
+const shopLink = 'https://shop.destinyitemmanager.com/';
+const bugReport = 'https://github.com/DestinyItemManager/DIM/issues';
+
 interface State {
   account?: DestinyAccount;
   dropdownOpen: boolean;
@@ -136,11 +139,11 @@ export default class Header extends React.PureComponent<Props, State> {
       <>
         <Link state='about' text='Header.About'/>
         <Link state='support' text='Header.SupportDIM'/>
-        <ExternalLink href='https://shop.destinyitemmanager.com/' text='Header.Shop'/>
+        <ExternalLink href={shopLink} text='Header.Shop'/>
         <WhatsNewLink />
         {bugReportLink &&
           <ExternalLink
-            href="https://github.com/DestinyItemManager/DIM/issues"
+            href={bugReport}
             text="Header.ReportBug"
           />}
       </>
@@ -182,11 +185,11 @@ export default class Header extends React.PureComponent<Props, State> {
       {links.length > 0 && <span className="header-separator"/>}
       {bugReportLink &&
         <ExternalLink
-          href="https://github.com/DestinyItemManager/DIM/issues"
+          href={bugReport}
           text="Header.ReportBug"
         />}
         <WhatsNewLink />
-        <ExternalLink href='https://shop.destinyitemmanager.com/' text='Header.Shop'/>
+        <ExternalLink href={shopLink} text='Header.Shop'/>
         <Link state='support' text='Header.SupportDIM'/>
         <Link state='about' text='Header.About'/>
       </>

--- a/src/app/vendors/vendors.scss
+++ b/src/app/vendors/vendors.scss
@@ -234,10 +234,14 @@ vendor-currencies, .vendor-currencies {
   float: right;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
+  max-width: 50%;
+  justify-content: flex-end;
   .vendor-currency {
-    margin-right: 10px;
-    &:last-child {
-      margin-right: 0;
+    margin-left: 10px;
+    margin-bottom: 8px;
+    &:first-child {
+      margin-left: 0;
     }
     img {
       vertical-align: bottom;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -217,7 +217,6 @@
     "PartialMatch": "Shows items where their name/perk has a partial match to the filter text.",
     "Postmaster": "Items that are currently in the Postmaster.",
     "PowerLevel": "Shows items based on their power level (Attack for Weapons; Defense for Armor).",
-    "PowerMod": "Items that have a mod to increase their Power.",
     "Quality": "Shows items based on their total stat quality percentage. '{{percentage}}' is an alias for '{{quality}}'.",
     "RarityTier": "Shows items based on their rarity tier.",
     "Rated": "Shows all weapons that have a rating from Destiny Tracker.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -597,7 +597,7 @@
     "Discipline": "Discipline",
     "Intellect": "Intellect",
     "Level": "Level",
-    "MaxBasePower": "Max Base Power (w/o mods)",
+    "MaxBasePower": "Max Power",
     "NoBonus": "No Bonus",
     "NotApplicable": "N/A",
     "OfMaxRoll": "{{range}} of max roll",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@babel/runtime-corejs2@7.0.0-beta.56":
-  version "7.0.0-beta.56"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-beta.56.tgz#6df5fbaa78e4bfdc22dfc5b36493ef238d55a027"
+"@babel/runtime-corejs2@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0.tgz#786711ee099c2c2af7875638866c1259eff30a8c"
   dependencies:
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
@@ -14,8 +14,8 @@
   resolved "https://codeload.github.com/DestinyItemManager/zip.js/tar.gz/6931dae24f729399100ee7a6fe5dce43007581f0"
 
 "@sentry/cli@^1.30.4":
-  version "1.35.1"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.35.1.tgz#2eea225f0c3b8663930837ea0f0f2d07a0448cde"
+  version "1.35.4"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.35.4.tgz#d89bc26a62baa33a8bf4991af04247bfd5093849"
   dependencies:
     https-proxy-agent "^2.2.1"
     node-fetch "^2.1.2"
@@ -55,8 +55,8 @@
     "@types/angular" "*"
 
 "@types/node@*", "@types/node@^10.9.3":
-  version "10.9.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.3.tgz#85f288502503ade0b3bfc049fe1777b05d0327d5"
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
 
 "@types/prop-types@*", "@types/prop-types@^15.5.2":
   version "15.5.5"
@@ -65,8 +65,8 @@
     "@types/react" "*"
 
 "@types/react-beautiful-dnd@^7.1.0":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-7.1.1.tgz#f0e2360ca9ccfed94461d52cccb67f72675e4706"
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-7.1.2.tgz#98a5bc1dca5dadfe462ba73180e8c66b5a275dcf"
   dependencies:
     "@types/react" "*"
 
@@ -91,8 +91,8 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.3.10":
-  version "16.4.12"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.12.tgz#c554005770b06c7cbcd6b0b19721e180deab7a02"
+  version "16.4.13"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.13.tgz#1385f5dc3486aa493849a32ccce626a817543e28"
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -570,11 +570,11 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
 
 autoprefixer@^9.0.1:
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.1.3.tgz#bd5940ccb9d1bfa3508308659915f0a14394c8d5"
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.1.5.tgz#8675fd8d1c0d43069f3b19a2c316f3524e4f6671"
   dependencies:
-    browserslist "^4.0.2"
-    caniuse-lite "^1.0.30000878"
+    browserslist "^4.1.0"
+    caniuse-lite "^1.0.30000884"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^7.0.2"
@@ -777,19 +777,19 @@ babel-plugin-check-es2015-constants@^6.22.0:
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
@@ -1162,11 +1162,11 @@ block-stream@*:
 
 bluebird@^2.3.11:
   version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+  resolved "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
 bluebird@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -1277,7 +1277,7 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
-browserslist@^4.0.0, browserslist@^4.0.2:
+browserslist@^4.0.0, browserslist@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.1.0.tgz#81cbb8e52dfa09918f93c6e051d779cb7360785d"
   dependencies:
@@ -1314,15 +1314,15 @@ buffer-xor@^1.0.3:
 
 buffer@^4.3.0:
   version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  resolved "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
 buffer@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.0.tgz#53cf98241100099e9eeae20ee6d51d21b16e541e"
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -1340,8 +1340,8 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
 bungie-api-ts@^1.6.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-1.11.0.tgz#e97e8f361f1365c7a89324532649aa3238a83a6f"
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-1.12.0.tgz#e3ab5a725f4107e80227171d120b907acf5e076d"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1405,9 +1405,9 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-lite@>=1.0.30000843, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000878:
-  version "1.0.30000880"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000880.tgz#b7b6ceaf739e17d0dda0d89426cba4be16d07bb0"
+caniuse-lite@>=1.0.30000843, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000878, caniuse-lite@^1.0.30000884:
+  version "1.0.30000884"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000884.tgz#eb82a959698745033b26a4dcd34d89dba7cc6eb3"
 
 case-sensitive-paths-webpack-plugin@^2.1.2:
   version "2.1.2"
@@ -1445,9 +1445,9 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@~2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chardet@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.5.0.tgz#fe3ac73c00c3d865ffcc02a0682e2c20b6a06029"
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
 check-types@^7.3.0:
   version "7.4.0"
@@ -1672,8 +1672,10 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
 convert-source-map@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  dependencies:
+    safe-buffer "~5.1.1"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -2142,8 +2144,8 @@ ejs@^2.5.7:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
 electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.61:
-  version "1.3.61"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.61.tgz#a8ac295b28d0f03d85e37326fd16b6b6b17a1795"
+  version "1.3.62"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz#2e8e2dc070c800ec8ce23ff9dfcceb585d6f9ed8"
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -2314,7 +2316,7 @@ etag@~1.8.1:
 
 eventemitter2@~0.4.13:
   version "0.4.14"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
+  resolved "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
 
 eventemitter3@^2.0.3:
   version "2.0.3"
@@ -2433,11 +2435,11 @@ extend@^3.0.0, extend@~3.0.1, extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
 external-editor@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.1.tgz#fc9638c4d7cde4f0bb82b12307a1a23912c492e3"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
   dependencies:
-    chardet "^0.5.0"
-    iconv-lite "^0.4.22"
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
 extglob@^2.0.4:
@@ -2455,7 +2457,7 @@ extglob@^2.0.4:
 
 extract-loader@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extract-loader/-/extract-loader-2.0.1.tgz#3dfa57d5922c0edbb6248490183ff8602e7cc92b"
+  resolved "http://registry.npmjs.org/extract-loader/-/extract-loader-2.0.1.tgz#3dfa57d5922c0edbb6248490183ff8602e7cc92b"
   dependencies:
     loader-utils "^1.1.0"
 
@@ -2983,12 +2985,12 @@ grunt-rsync@^3.0.0:
   resolved "https://codeload.github.com/delphiactual/grunt-sort-json/tar.gz/87e92172920f0113ff15e71534bf938581432443"
 
 grunt-webstore-upload@^0.9.20:
-  version "0.9.20"
-  resolved "https://registry.yarnpkg.com/grunt-webstore-upload/-/grunt-webstore-upload-0.9.20.tgz#c9e4db596c5a403a3e99aea6731ce6f6db044a04"
+  version "0.9.21"
+  resolved "https://registry.yarnpkg.com/grunt-webstore-upload/-/grunt-webstore-upload-0.9.21.tgz#4e23277122ab669cdade3832d07c9e27ff6138c4"
   dependencies:
     lodash "^4.17.4"
     minimist "^1.2.0"
-    open "0.0.5"
+    opn "^5.3.0"
     q "^1.0.1"
 
 grunt@^1.0.2:
@@ -3172,7 +3174,7 @@ html-webpack-include-sibling-chunks-plugin@^0.1.4:
 
 html-webpack-plugin@^3.2.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
+  resolved "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
   dependencies:
     html-minifier "^3.2.3"
     loader-utils "^0.2.16"
@@ -3184,7 +3186,7 @@ html-webpack-plugin@^3.2.0:
 
 htmlhint@^0.9.13:
   version "0.9.13"
-  resolved "https://registry.yarnpkg.com/htmlhint/-/htmlhint-0.9.13.tgz#08163cb1e6aa505048ebb0b41063a7ca07dc6c88"
+  resolved "http://registry.npmjs.org/htmlhint/-/htmlhint-0.9.13.tgz#08163cb1e6aa505048ebb0b41063a7ca07dc6c88"
   dependencies:
     async "1.4.2"
     colors "1.0.3"
@@ -3264,7 +3266,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -3598,6 +3600,10 @@ is-utf8@^0.2.0:
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -3986,8 +3992,8 @@ mem@^1.1.0:
     mimic-fn "^1.0.0"
 
 memoize-one@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.0.tgz#fc5e2f1427a216676a62ec652cf7398cfad123db"
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -4113,11 +4119,11 @@ minimatch@2.0.x:
 
 minimist@0.0.8:
   version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 minipass@^2.2.1, minipass@^2.3.3:
   version "2.3.4"
@@ -4568,13 +4574,15 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-open@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
-
 opener@^1.4.3:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+
+opn@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"
+  dependencies:
+    is-wsl "^1.1.0"
 
 os-browserify@^0.3.0:
   version "0.3.0"
@@ -4586,7 +4594,7 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
 
 os-locale@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  resolved "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
 
@@ -5096,8 +5104,8 @@ range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
 raven-js@^3.24.1:
-  version "3.26.4"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.4.tgz#32aae3a63a9314467a453c94c89a364ea43707be"
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.0.tgz#9f47c03e17933ce756e189f3669d49c441c1ba6e"
 
 raw-body@2.3.2:
   version "2.3.2"
@@ -5118,10 +5126,10 @@ rc@^1.1.6, rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-beautiful-dnd@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-9.0.1.tgz#64fc29d40d0302379d1531c12974cc5a833588e4"
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-9.0.2.tgz#9785a96c1f1385620aed840f0bc774c7455b3fd4"
   dependencies:
-    "@babel/runtime-corejs2" "7.0.0-beta.56"
+    "@babel/runtime-corejs2" "^7.0.0"
     css-box-model "^1.0.0"
     memoize-one "^4.0.0"
     prop-types "^15.6.1"
@@ -5141,8 +5149,8 @@ react-dom@^16.3.1:
     prop-types "^15.6.0"
 
 react-hot-loader@^4.3.3:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.3.5.tgz#d8659839d8072d4b78938a776f29f5f1d2a40170"
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.3.6.tgz#26e1491f08daf2bad99d141b1927c9faadef2fb4"
   dependencies:
     fast-levenshtein "^2.0.6"
     global "^4.3.0"
@@ -5541,14 +5549,14 @@ run-queue@^1.0.0, run-queue@^1.0.3:
     aproba "^1.1.1"
 
 rxjs@^5.5.10:
-  version "5.5.11"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
   dependencies:
     symbol-observable "1.0.1"
 
 rxjs@^6.1.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.2.tgz#eb75fa3c186ff5289907d06483a77884586e1cf9"
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
   dependencies:
     tslib "^1.9.0"
 
@@ -6303,8 +6311,8 @@ typesafe-actions@^2.0.4:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-2.0.4.tgz#31c8f8df3566d549eb52edb64a75997e970c17d0"
 
 typescript@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 ua-parser-js@^0.7.17, ua-parser-js@^0.7.18:
   version "0.7.18"
@@ -6318,8 +6326,8 @@ uglify-es@^3.3.4:
     source-map "~0.6.1"
 
 uglify-js@3.4.x, uglify-js@^3.3.21:
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.8.tgz#d590777b208258b54131b1ae45bc9d3f68033a3e"
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
   dependencies:
     commander "~2.17.1"
     source-map "~0.6.1"
@@ -6576,16 +6584,16 @@ webpack-notifier@^1.6.0:
     object-assign "^4.1.0"
     strip-ansi "^3.0.1"
 
-webpack-sources@^1.0.1, webpack-sources@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
+webpack-sources@^1.1.0, webpack-sources@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.2.0.tgz#18181e0d013fce096faf6f8e6d41eeffffdceac2"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
 webpack@^4.5.0:
-  version "4.17.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.17.1.tgz#0f026e3d823f3fc604f811ed3ea8f0d9b267fb1e"
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.17.2.tgz#49feb20205bd15f0a5f1fe0a12097d5d9931878d"
   dependencies:
     "@webassemblyjs/ast" "1.5.13"
     "@webassemblyjs/helper-module-context" "1.5.13"
@@ -6611,7 +6619,7 @@ webpack@^4.5.0:
     tapable "^1.0.0"
     uglifyjs-webpack-plugin "^1.2.4"
     watchpack "^1.5.0"
-    webpack-sources "^1.0.1"
+    webpack-sources "^1.2.0"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.4"
@@ -6670,7 +6678,7 @@ worker-farm@^1.5.2:
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  resolved "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"


### PR DESCRIPTION
* Max power updated to 600 for Forsaken owners.
* Bugfixes to the progress and vendors page (JS errors, missing images).
* Add Infamy rank to progress page.
* Remove "is:powermod" search.
* Masterworks now have a gold border. Previously items with a power mod had a gold border, but there are no more power mods.
* Use the objective completion value instead of objective definition completion value.