### PR TITLE
Disable vendor engrams until they are back

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -281,7 +281,7 @@ module.exports = (env) => {
         // D2 Vendors
         '$featureFlags.vendors': JSON.stringify(true),
         // Enable vendorengrams.xyz integration
-        '$featureFlags.vendorEngrams': JSON.stringify(true)
+        '$featureFlags.vendorEngrams': JSON.stringify(false)
       }),
 
       // Enable if you want to debug the size of the chunks

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove "is:powermod" search.
 * Remove "basepower:" search.
 * Masterworks now have a gold border. Previously items with a power mod had a gold border, but there are no more power mods.
+* Disabled vendorengrams.xyz integration until they are back online.
 
 # 4.68.3 (2018-09-03)
 


### PR DESCRIPTION
I don't think we're getting useful data from them right now?