### PR TITLE
For this season, Trials is out. Gambit is in.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Remove "basepower:" search.
 * Masterworks now have a gold border. Previously items with a power mod had a gold border, but there are no more power mods.
 * Disabled vendorengrams.xyz integration until they are back online.
+* Review modes - say hello to Gambit (and goodbye to Trials, at least for a little while).
 
 # 4.68.3 (2018-09-03)
 

--- a/src/app/destinyTrackerApi/reviewModesFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewModesFetcher.ts
@@ -11,7 +11,8 @@ enum ActivityModeHashes {
   playerVersusEnemy = 1164760493,
   playerVersusPlayer = 1164760504,
   raid = 2043403989,
-  trials = 1370326378
+  trials = 1370326378,
+  gambit = 1848252830
 }
 
 export function getReviewModes(defs?: D2ManifestDefinitions): D2ReviewMode[] {
@@ -24,6 +25,7 @@ export function getReviewModes(defs?: D2ManifestDefinitions): D2ReviewMode[] {
     { mode: DtrD2ActivityModes.playerVersusEnemy, description: defs.ActivityMode[ActivityModeHashes.playerVersusEnemy].displayProperties.name },
     { mode: DtrD2ActivityModes.playerVersusPlayer, description: defs.ActivityMode[ActivityModeHashes.playerVersusPlayer].displayProperties.name },
     { mode: DtrD2ActivityModes.raid, description: defs.ActivityMode[ActivityModeHashes.raid].displayProperties.name },
-    { mode: DtrD2ActivityModes.trials, description: defs.ActivityMode[ActivityModeHashes.trials].displayProperties.name }
+    // { mode: DtrD2ActivityModes.trials, description: defs.ActivityMode[ActivityModeHashes.trials].displayProperties.name }
+    { mode: DtrD2ActivityModes.gambit, description: defs.ActivityMode[ActivityModeHashes.gambit].displayProperties.name }
   ];
 }

--- a/src/app/item-review/d2-dtr-api-types.ts
+++ b/src/app/item-review/d2-dtr-api-types.ts
@@ -122,7 +122,8 @@ export enum DtrD2ActivityModes {
   playerVersusEnemy = DestinyActivityModeType.AllPvE,
   playerVersusPlayer = DestinyActivityModeType.AllPvP,
   raid = DestinyActivityModeType.Raid,
-  trials = DestinyActivityModeType.TrialsOfTheNine
+  // trials = DestinyActivityModeType.TrialsOfTheNine
+  gambit = DestinyActivityModeType.Gambit
 }
 
 /**


### PR DESCRIPTION
Commented code intentionally left in so that bringing To9 back will be easy (since it's due to make a comeback next sandbox season).

![trials out gambit in](https://user-images.githubusercontent.com/606888/45195511-f04e5680-b225-11e8-8106-bb0341bc1fdb.png)
