### PR TITLE
Sort pursuits a bit better

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove "is:powermod" search.
 * Remove "basepower:" search.
 * Masterworks now have a gold border. Previously items with a power mod had a gold border, but there are no more power mods.
+* Pursuits are sorted such that bounties are displayed together.
 
 # 4.68.3 (2018-09-03)
 

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -31,6 +31,7 @@ import { CrucibleRank } from './CrucibleRank';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import { $rootScope } from 'ngimport';
 import { Loading } from '../dim-ui/Loading';
+import { chainComparator, compareBy } from '../comparators';
 
 const factionOrder = [
   611314723, // Vanguard,
@@ -414,10 +415,27 @@ export default class Progress extends React.Component<Props, State> {
         (itemDef.inventory && itemDef.inventory.tierTypeHash === 0 &&
           itemDef.backgroundColor && itemDef.backgroundColor.alpha > 0);
     });
-    return _.sortBy(filteredItems, (item) => {
-      const itemDef = defs.InventoryItem.get(item.itemHash);
-      return itemDef.displayProperties.name;
-    });
+
+    filteredItems.sort(chainComparator(
+      compareBy((item) => {
+        const itemDef = defs.InventoryItem.get(item.itemHash);
+        return itemDef.itemType;
+      }),
+      compareBy((item) => {
+        // Sort by icon image, but only for bounties...
+        const itemDef = defs.InventoryItem.get(item.itemHash);
+        if (itemDef.itemCategoryHashes.includes(1784235469)) {
+          return itemDef.displayProperties.icon;
+        } else {
+          return undefined;
+        }
+      }),
+      compareBy((item) => {
+        const itemDef = defs.InventoryItem.get(item.itemHash);
+        return itemDef.displayProperties.name;
+      })
+    ));
+    return filteredItems;
   }
 
   /**


### PR DESCRIPTION
Still a lot that needs to be done for the Progress page in Forsaken, but this addresses a little annoyance. Now bounties are grouped together, and bounties of the same source are next to each other:

<img width="298" alt="screen shot 2018-09-07 at 12 07 57 am" src="https://user-images.githubusercontent.com/313208/45203838-45906500-b232-11e8-9c69-4b449aabce0a.png">
