### PR TITLE
Make search bar a bit more clickable

### DIFF
--- a/src/app/search/search-filter.component.ts
+++ b/src/app/search/search-filter.component.ts
@@ -15,6 +15,9 @@ import { DimItem } from '../inventory/item-types';
 import { D2StoresService } from '../inventory/d2-stores.service';
 import { D1StoresService } from '../inventory/d1-stores.service';
 import { dimVendorService } from '../vendors/vendor.service';
+import { subscribeOnScope } from '../rx-utils';
+import { isPhonePortraitStream } from '../mediaQueries';
+import { t } from 'i18next';
 
 /**
  * A simple holder to share the search query among components
@@ -55,6 +58,15 @@ function SearchFilterCtrl(
   let filters: SearchFilters;
   let searchConfig;
   let filteredItems: DimItem[] = [];
+
+  //vm.placeholder = t("Header.FilterHelp", { example: 'is:dupe' });
+
+  subscribeOnScope($scope, isPhonePortraitStream(), (isPhonePortrait) => {
+    $scope.$apply(() => {
+      console.log('isPhonePortrait', isPhonePortrait);
+      vm.placeholder = isPhonePortrait ? t("Header.FilterHelpBrief") : t("Header.FilterHelp", { example: 'is:dupe' });
+    });
+  });
 
   vm.$onChanges = (changes) => {
     if (changes.account && changes.account) {

--- a/src/app/search/search-filter.html
+++ b/src/app/search/search-filter.html
@@ -1,9 +1,12 @@
+<input id="filter-input" autocomplete="off" autocorrect="off" autocapitalize="off" ng-i18next="[i18next:placeholder]({ example: 'is:dupe' })Header.FilterHelp" type="text" name="filter" ng-model="$ctrl.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">
+
 <span class="filter-help"
     ng-if="!$ctrl.search.query"
     ng-click="$ctrl.showFilters($event)"
     ng-i18next="[title]Header.Filters">
   <i class="fa fa-question-circle-o"></i>
 </span>
+
 <span class="filter-help"
   ng-if="$ctrl.search.query">
   <i class="fa fa-tag"
@@ -19,4 +22,3 @@
     ng-click="$ctrl.clearFilter($event)"
     ng-i18next="[title]Header.Filters"></i>
 </span>
-<input id="filter-input" class="dim-input" autocomplete="off" autocorrect="off" autocapitalize="off" ng-i18next="[i18next:placeholder]({ example: 'is:dupe' })Header.FilterHelp" type="text" name="filter" ng-model="$ctrl.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">

--- a/src/app/search/search-filter.html
+++ b/src/app/search/search-filter.html
@@ -1,4 +1,4 @@
-<input id="filter-input" autocomplete="off" autocorrect="off" autocapitalize="off" ng-i18next="[i18next:placeholder]({ example: 'is:dupe' })Header.FilterHelp" type="text" name="filter" ng-model="$ctrl.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">
+<input id="filter-input" autocomplete="off" autocorrect="off" autocapitalize="off" ng-attr-placeholder="{{$ctrl.placeholder}}" type="text" name="filter" ng-model="$ctrl.search.query" ng-model-options="{ debounce: 500 }" ng-trim="true">
 
 <span class="filter-help"
     ng-if="!$ctrl.search.query"

--- a/src/app/search/search-filter.html
+++ b/src/app/search/search-filter.html
@@ -11,7 +11,7 @@
     ng-click="$ctrl.showSelect = true"
     ng-i18next="[title]Header.BulkTag"></i>
   <select class="bulk-tag-select"
-    ng-show="$ctrl.showSelect"
+    ng-if="$ctrl.showSelect"
     ng-options="tag as tag.label | i18next for tag in $ctrl.bulkItemTags track by tag.type"
     ng-model="$ctrl.selectedTag"
     ng-change="$ctrl.bulkTag()"></select>

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -52,6 +52,7 @@ dim-search-filter {
 
     &.show {
       display: block;
+      flex: 1;
 
       #filter-input {
         height: 34px;

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -27,14 +27,16 @@
 
     &.show {
       position: absolute;
-      left: 29px;
+      left: 32px;
       top: 4px;
+      right: 170px;
       display: block;
 
       #filter-input {
-        height: 28px;
+        height: 34px;
         margin-top: 0;
-        width: 150px;
+        width: 100%;
+        box-sizing: border-box;
       }
 
       .filter-help {
@@ -68,6 +70,13 @@
   .fa {
     font-size: 16px !important;
     color: #999 !important;
+    // Increase touch target size
+    padding: 4px;
+    margin: -4px;
+    margin-left: 4px;
+    &:first-child {
+      margin-left: -4px;
+    }
     &:hover {
       color: #E8A534 !important;
     }

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -5,31 +5,52 @@
 }
 
 #filter-input {
-  width: 250px;
-  margin-left: -3px;
-  margin-top: 4px;
-  padding-right: 20px;
   border-radius: 0;
   -webkit-appearance: none;
+  height: 25px;
+
+}
+
+dim-search-filter {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  background: rgb(46, 46, 46);
+  border-bottom: 1px solid gray;
+  padding-left: 5px;
+  margin-left: -3px;
+  height: 25px;
+  width: 275px;
 
   @media (max-width: 1100px) {
-    width: 175px;
+    width: 200px;
+  }
+  @include phone-portrait {
+    width: auto;
+    height: 34px;
+  }
+
+  &:hover, &:focus {
+    background: transparent;
+    outline: none;
+    border-bottom: 1px solid $orange;
+  }
+
+  input[type="text"] {
+    border: none;
+    color: white;
+    background: transparent;
+    outline: none;
+    flex: 1;
   }
 }
 
 .search-link {
-  position: relative;
-  top: -2px;
-
   // Yikes this is a hack
   @include phone-portrait {
     display: none;
 
     &.show {
-      position: absolute;
-      left: 32px;
-      top: 4px;
-      right: 170px;
       display: block;
 
       #filter-input {
@@ -40,7 +61,7 @@
       }
 
       .filter-help {
-        top: 8px;
+        top: 0;
       }
 
       .dim-input {
@@ -63,10 +84,11 @@
 }
 
 .filter-help {
-  position: absolute;
-  right: -2px;
-  top: 8px;
   cursor: pointer;
+  @include phone-portrait {
+    margin-right: 8px !important;
+  }
+
   .fa {
     font-size: 16px !important;
     color: #999 !important;

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -196,7 +196,7 @@ export default class Header extends React.PureComponent<Props, State> {
     );
 
     return (
-      <div id="header">
+      <div id="header" className={showSearch ? 'search-expanded' : ''}>
         <span className="menu link" ref={this.dropdownToggler} onClick={this.toggleDropdown}>
           <i className="fa fa-bars" />
           <MenuBadge />
@@ -218,19 +218,19 @@ export default class Header extends React.PureComponent<Props, State> {
             </CSSTransition>}
         </TransitionGroup>
 
-        <UISref to='default-account'>
+        {!showSearch && <UISref to='default-account'>
           <img
             className={classNames('logo', 'link', $DIM_FLAVOR)}
             title={`v${$DIM_VERSION} (${$DIM_FLAVOR})`}
             src={logo}
             alt="DIM"
           />
-        </UISref>
+        </UISref>}
 
-        <div className="header-links">
+        {!showSearch && <div className="header-links">
           {reverseDestinyLinks}
           {reverseDimLinks}
-        </div>
+        </div>}
 
         <span className="header-right">
           {!showSearch && <Refresh/>}

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -76,6 +76,13 @@
     flex-direction: row;
     height: 100%;
   }
+
+  &.search-expanded .header-right {
+    @include phone-portrait {
+      flex: 1;
+    }
+  }
+
   .header-separator {
       display: block !important;
       width: 0;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -265,6 +265,7 @@
     "BulkTag": "Bulk tag items",
     "BungieNetAlert": "Bungie Alert",
     "FilterHelp": "Search item/perk or {{example}}",
+    "FilterHelpBrief": "Search items",
     "Filters": "Filters",
     "Inventory": "Inventory",
     "Refresh": "Refresh Destiny Data",


### PR DESCRIPTION
This addresses #2965 by making the search filter buttons have a larger tap target and more separation. I also re-worked the layout so that on mobile it always fills the header correctly. We should still revisit the overall design of the header, but this should help for now.

Before:
<img width="273" alt="screen shot 2018-09-09 at 9 56 04 am" src="https://user-images.githubusercontent.com/313208/45266855-c7d97e80-b416-11e8-9486-1f5778ab9762.png">

After:
<img width="263" alt="screen shot 2018-09-09 at 9 55 58 am" src="https://user-images.githubusercontent.com/313208/45266854-c7d97e80-b416-11e8-9eaa-362d3aa4e4e9.png">
