### PR TITLE
Added inverse keyword (item/perk) search option

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -483,8 +483,7 @@ export function searchFilters(
             addPredicate(filter, pieces[2]);
           }
         } else if (!/^\s*$/.test(term)) {
-          // TODO: not
-          addPredicate('keyword', term);
+          addPredicate('keyword', term.replace(/^-/, ''), term.startsWith('-'));
         }
       }
 
@@ -756,11 +755,7 @@ export function searchFilters(
         return categories.every((c) => item.inCategory(c));
       },
       keyword(item: DimItem, predicate: string) {
-        const inverse = predicate.startsWith('-');
-        if (inverse) {
-          predicate = predicate.substring(1);
-        }
-        const found =
+        return (
           item.name.toLowerCase().includes(predicate) ||
           item.description.toLowerCase().includes(predicate) ||
           // Search for typeName (itemTypeDisplayName of modifications)
@@ -790,8 +785,8 @@ export function searchFilters(
                     )
                   )
               )
-            ));
-        return inverse ? !found : found;
+            ))
+        );
       },
       light(item: DimItem, predicate: string) {
         if (!item.primStat) {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -756,11 +756,11 @@ export function searchFilters(
         return categories.every((c) => item.inCategory(c));
       },
       keyword(item: DimItem, predicate: string) {
-        let inverse = predicate.startsWith('-');
+        const inverse = predicate.startsWith('-');
         if (inverse) {
           predicate = predicate.substring(1);
         }
-        let found =
+        const found =
           item.name.toLowerCase().includes(predicate) ||
           item.description.toLowerCase().includes(predicate) ||
           // Search for typeName (itemTypeDisplayName of modifications)

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -756,7 +756,11 @@ export function searchFilters(
         return categories.every((c) => item.inCategory(c));
       },
       keyword(item: DimItem, predicate: string) {
-        return (
+        let inverse = predicate.startsWith('-');
+        if (inverse) {
+          predicate = predicate.substring(1);
+        }
+        let found =
           item.name.toLowerCase().includes(predicate) ||
           item.description.toLowerCase().includes(predicate) ||
           // Search for typeName (itemTypeDisplayName of modifications)
@@ -786,8 +790,8 @@ export function searchFilters(
                     )
                   )
               )
-            ))
-        );
+            ));
+        return inverse ? !found : found;
       },
       light(item: DimItem, predicate: string) {
         if (!item.primStat) {


### PR DESCRIPTION
It seems natural to add a minus sign before a term to match the
opposite of a string search.

<img width="1225" alt="screen shot 2018-09-12 at 10 37 17 am" src="https://user-images.githubusercontent.com/424158/45442847-0326b800-b678-11e8-9ff4-2d6e6ed69edf.png">

This resolves #2287