### PR TITLE
Bring back the hotkeys cheat sheet

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -59,5 +59,5 @@ initi18n().then(() => {
       document.getElementById('app')
     );
   });
-  bootstrap(document.createElement('div'), ['Bootstrap'], { strictDi: true });
+  bootstrap(document.getElementById('angular')!, ['Bootstrap'], { strictDi: true });
 });

--- a/src/index.html
+++ b/src/index.html
@@ -1,45 +1,49 @@
 <!doctype html>
 <html lang="">
 
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>DIM</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
-    <meta name="twitter:widgets:csp" content="on">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>DIM</title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
+  <meta name="twitter:widgets:csp" content="on">
 
-    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
-    <link href="https://www.bungie.net" rel="preconnect">
-    <link href="https://apis.google.com" rel="preconnect">
-    <link href="https://ssl.google-analytics.com" rel="preconnect">
-    <link href="https://www.google-analytics.com" rel="preconnect">
-    <link href="https://accounts.google.com" rel="preconnect">
-    <link href="https://ssl.gstatic.com" rel="preconnect">
+  <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
+  <link href="https://www.bungie.net" rel="preconnect">
+  <link href="https://apis.google.com" rel="preconnect">
+  <link href="https://ssl.google-analytics.com" rel="preconnect">
+  <link href="https://www.google-analytics.com" rel="preconnect">
+  <link href="https://accounts.google.com" rel="preconnect">
+  <link href="https://ssl.gstatic.com" rel="preconnect">
 
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:200,400,700" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:200,400,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300" rel="stylesheet" type="text/css">
 
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-6-2018.png">
-    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="/manifest-webapp-6-2018.json">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444">
-    <meta name="theme-color" content="#404141">
-    <!-- We cannot use this, because our OAuth flow redirects to another site, and Safari cannot bring us back. Thus we'll never be able to log in. -->
-    <!--<meta name="apple-mobile-web-app-capable" content="yes">-->
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  </head>
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-6-2018.png">
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+  <link rel="manifest" href="/manifest-webapp-6-2018.json">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444">
+  <meta name="theme-color" content="#404141">
+  <!-- We cannot use this, because our OAuth flow redirects to another site, and Safari cannot bring us back. Thus we'll never be able to log in. -->
+  <!--<meta name="apple-mobile-web-app-capable" content="yes">-->
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+</head>
 
-  <body>
-    <div id="app">
-      <div class="notloaded">
-        DIM hasn't loaded. Something may be wrong with it, or with your browser (maybe you have a content blocker, or have disabled JavaScript, or your browser is too old). Try force reloading to make sure (Ctrl-F5 or Cmd-R).
-      </div>
+<body>
+  <div id="angular"></div>
+  <div id="app">
+    <div class="notloaded">
+      DIM hasn't loaded. Something may be wrong with it, or with your browser (maybe you have a content blocker, or
+      have disabled JavaScript, or your browser is too old). Try force reloading to make sure (Ctrl-F5 or Cmd-R).
     </div>
-    <div id="browser-warning" class="hidden">Your browser is not supported by DIM. Some or all DIM functionality may not work. Please switch to a supported browser.</div>
+  </div>
+  <div id="browser-warning" class="hidden">Your browser is not supported by DIM. Some or all DIM functionality may not
+    work. Please switch to a supported browser.</div>
 
-    <script async src="https://www.google-analytics.com/analytics.js"></script>
-    <script src="https://apis.google.com/js/api.js"></script>
-  </body>
+  <script async src="https://www.google-analytics.com/analytics.js"></script>
+  <script src="https://apis.google.com/js/api.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
We lost the keyboard shortcuts cheat sheet when we stopped bootstrapping AngularJS, since that module does some funky stuff to insert itself into the DOM. I added a separate root for Angular to put stuff into, and now it's back.

Fixes #2938.