### PR TITLE
Connect state closer to leaves (StoreBucket)

### DIFF
--- a/src/app/accounts/platform.service.ts
+++ b/src/app/accounts/platform.service.ts
@@ -14,6 +14,7 @@ import { SyncService } from '../storage/sync.service';
 import { getBungieAccounts } from './bungie-account.service';
 import * as actions from './actions';
 import store from '../store/store';
+import { loadingTracker } from '../ngimport-more';
 
 let _platforms: DestinyAccount[] = [];
 let _active: DestinyAccount | null = null;
@@ -37,7 +38,7 @@ export function getPlatforms(): IPromise<DestinyAccount[]> {
   }
 
   // TODO: wire this up with observables?
-  return getBungieAccounts()
+  const promise = getBungieAccounts()
     .then((bungieAccounts) => {
       if (!bungieAccounts.length) {
         // We're not logged in, don't bother
@@ -56,6 +57,9 @@ export function getPlatforms(): IPromise<DestinyAccount[]> {
     })
     .then(setActivePlatform)
     .then(() => _platforms);
+
+  loadingTracker.addPromise(promise);
+  return promise;
 }
 
 export function getActivePlatform(): DestinyAccount | null {

--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -2,6 +2,12 @@ import { Reducer } from 'redux';
 import { DestinyAccount } from './destiny-account.service';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
+import { RootState } from '../store/reducers';
+
+export const destinyVersionSelector = (state: RootState) =>
+  (state.accounts.currentAccount &&
+    state.accounts.accounts[state.accounts.currentAccount].destinyVersion) ||
+  2;
 
 export interface AccountsState {
   readonly accounts: ReadonlyArray<DestinyAccount>;

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -18,6 +18,7 @@ interface Props {
   tag?: TagValue;
   /** Rating value */
   rating?: number;
+  hideRating?: boolean;
   /** Has this been hidden by a search? */
   searchHidden?: boolean;
   onClick?(e);
@@ -29,19 +30,22 @@ const tagClasses = tagIconFilter();
 // TODO: Separate high and low levels (display vs display logic)
 export default class InventoryItem extends React.Component<Props> {
   render() {
-    const { item, isNew, tag, rating, searchHidden, onClick, onDoubleClick } = this.props;
+    const {
+      item,
+      isNew,
+      tag,
+      rating,
+      searchHidden,
+      hideRating,
+      onClick,
+      onDoubleClick
+    } = this.props;
 
     const itemImageStyles = {
       complete: item.complete,
       diamond: item.isDestiny2() && item.bucket.hash === 3284755031,
       masterwork: item.masterwork
     };
-
-    const showRating =
-      item.dtrRating &&
-      item.dtrRating.overallScore &&
-      (item.dtrRating.ratingCount > (item.destinyVersion === 2 ? 0 : 1) ||
-        item.dtrRating.highlightedRatingCount > 0);
 
     const badgeInfo = getBadgeInfo(item);
 
@@ -70,8 +74,8 @@ export default class InventoryItem extends React.Component<Props> {
               {item.quality.min}%
             </div>
           )}
-        {rating &&
-          showRating && (
+        {rating !== undefined &&
+          !hideRating && (
             <div className="item-stat item-review">
               {rating}
               <i className="fa fa-star" style={dtrRatingColor(rating)} />

--- a/src/app/inventory/ItemPopupTrigger.tsx
+++ b/src/app/inventory/ItemPopupTrigger.tsx
@@ -36,14 +36,6 @@ export default class ItemPopupTrigger extends React.Component<Props> {
 
     const item = this.props.item;
 
-    // TODO: This was used in the D1 loadout builder. It shouldn't be part of this.
-    /*
-    if (shiftClickCallback && e.shiftKey) {
-      shiftClickCallback(item);
-      return;
-    }
-    */
-
     NewItemsService.dropNewItem(item);
 
     if (otherDialog) {

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -9,7 +9,7 @@ import { pullablePostmasterItems, pullFromPostmaster } from '../loadout/postmast
 import { queueAction } from './action-queue';
 import { dimItemService } from './dimItemService.factory';
 import { toaster } from '../ngimport-more';
-import { $rootScope } from 'ngimport';
+import { $q } from 'ngimport';
 
 /** One row of store buckets, one for each character and vault. */
 export function StoreBuckets({
@@ -96,7 +96,7 @@ function PullFromPostmaster({ store }: { store: D2Store }) {
 
   // We need the Angular apply to drive the toaster, until Angular is gone
   function onClick() {
-    queueAction(() => $rootScope.$apply(() => pullFromPostmaster(store, dimItemService, toaster)));
+    queueAction(() => $q.when(pullFromPostmaster(store, dimItemService, toaster)));
   }
 
   return (

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -5,9 +5,6 @@ import { Settings } from '../settings/settings';
 import { InventoryBucket } from './inventory-buckets';
 import classNames from 'classnames';
 import { t } from 'i18next';
-import { InventoryState } from './reducer';
-import { ReviewsState } from '../item-review/reducer';
-import { DimItem } from './item-types';
 
 /** One row of store buckets, one for each character and vault. */
 export function StoreBuckets({
@@ -15,24 +12,12 @@ export function StoreBuckets({
   collapsedSections,
   stores,
   vault,
-  currentStore,
-  settings,
-  newItems,
-  itemInfos,
-  ratings,
-  searchFilter,
   toggleSection
 }: {
   bucket: InventoryBucket;
-  stores: DimStore[];
   collapsedSections: Settings['collapsedSections'];
+  stores: DimStore[];
   vault: DimVault;
-  currentStore: DimStore;
-  settings: Settings;
-  newItems: Set<string>;
-  itemInfos: InventoryState['itemInfos'];
-  ratings: ReviewsState['ratings'];
-  searchFilter(item: DimItem): boolean;
   toggleSection(id: string): void;
 }) {
   let content: React.ReactNode;
@@ -45,34 +30,17 @@ export function StoreBuckets({
   } else if (bucket.accountWide) {
     // If we're in mobile view, we only render one store
     const allStoresView = stores.length > 1;
+    const currentStore = stores.find((s) => s.current)!;
     content = (
       <>
         {(allStoresView || stores[0] !== vault) && (
           <div className="store-cell account-wide">
-            <StoreBucket
-              bucket={bucket}
-              store={stores[0]}
-              items={currentStore.buckets[bucket.id]}
-              settings={settings}
-              newItems={newItems}
-              itemInfos={itemInfos}
-              ratings={ratings}
-              searchFilter={searchFilter}
-            />
+            <StoreBucket bucketId={bucket.id} storeId={currentStore.id} />
           </div>
         )}
         {(allStoresView || stores[0] === vault) && (
           <div className="store-cell vault">
-            <StoreBucket
-              bucket={bucket}
-              store={vault}
-              items={vault.buckets[bucket.id]}
-              settings={settings}
-              newItems={newItems}
-              itemInfos={itemInfos}
-              ratings={ratings}
-              searchFilter={searchFilter}
-            />
+            <StoreBucket bucketId={bucket.id} storeId={vault.id} />
           </div>
         )}
       </>
@@ -86,16 +54,7 @@ export function StoreBuckets({
         })}
       >
         {(!store.isVault || bucket.vaultBucket) && (
-          <StoreBucket
-            bucket={bucket}
-            store={store}
-            items={store.buckets[bucket.id]}
-            settings={settings}
-            newItems={newItems}
-            itemInfos={itemInfos}
-            ratings={ratings}
-            searchFilter={searchFilter}
-          />
+          <StoreBucket bucketId={bucket.id} storeId={store.id} />
         )}
       </div>
     ));

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -14,6 +14,7 @@ interface Props {
   isNew: boolean;
   tag?: TagValue;
   rating?: number;
+  hideRating?: boolean;
   searchHidden: boolean;
 }
 
@@ -35,7 +36,7 @@ export default class StoreInventoryItem extends React.PureComponent<Props> {
   });
 
   render() {
-    const { item, isNew, tag, rating, searchHidden } = this.props;
+    const { item, isNew, tag, rating, searchHidden, hideRating } = this.props;
 
     return (
       <DraggableInventoryItem item={item}>
@@ -46,6 +47,7 @@ export default class StoreInventoryItem extends React.PureComponent<Props> {
             isNew={isNew}
             tag={tag}
             rating={rating}
+            hideRating={hideRating}
             searchHidden={searchHidden}
           />
         </ItemPopupTrigger>

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -20,7 +20,7 @@ interface Props {
 /**
  * The "full" inventory item, which can be dragged around and which pops up a move popup when clicked.
  */
-export default class StoreInventoryItem extends React.Component<Props> {
+export default class StoreInventoryItem extends React.PureComponent<Props> {
   private doubleClicked = queuedAction((e) => {
     const item = this.props.item;
     if (!dimLoadoutService.dialogOpen && !CompareService.dialogOpen) {

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { DimStore, DimVault } from './store-types';
-import { sortStores } from '../shell/dimAngularFilters.filter';
-import { Settings, itemTags } from '../settings/settings';
+import { Settings } from '../settings/settings';
 import { InventoryBuckets } from './inventory-buckets';
 import { t } from 'i18next';
 import './Stores.scss';
@@ -13,16 +12,8 @@ import ScrollClassDiv from '../dim-ui/ScrollClassDiv';
 import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
 import { StoreBuckets } from './StoreBuckets';
 import D1ReputationSection from './D1ReputationSection';
-import { InventoryState } from './reducer';
-import { ReviewsState } from '../item-review/reducer';
-import { DimItem } from './item-types';
-import { createSelector } from 'reselect';
-import { buildSearchConfig, searchFilters } from '../search/search-filters';
-import { D1Categories } from '../destiny1/d1-buckets.service';
-import { D2Categories } from '../destiny2/d2-buckets.service';
-import { D1StoresService } from './d1-stores.service';
-import { D2StoresService } from './d2-stores.service';
 import Hammer from 'react-hammerjs';
+import { sortedStoresSelector } from './reducer';
 
 interface Props {
   stores: DimStore[];
@@ -30,74 +21,22 @@ interface Props {
   // TODO: bind just the settings we care about
   settings: Settings;
   buckets: InventoryBuckets;
-  newItems: Set<string>;
-  itemInfos: InventoryState['itemInfos'];
-  ratings: ReviewsState['ratings'];
   collapsedSections: Settings['collapsedSections'];
-  searchFilter(item: DimItem): boolean;
 }
 
 interface State {
   selectedStoreId?: string;
 }
 
-const EMPTY_SET = new Set<string>();
-
-// TODO: move selectors elsewhere?
-const querySelector = (state: RootState) => state.shell.searchQuery;
-const destinyVersionSelector = (state: RootState) =>
-  (state.accounts.currentAccount &&
-    state.accounts.accounts[state.accounts.currentAccount].destinyVersion) ||
-  2;
-
-/**
- * A selector for the search config for a particular destiny version.
- */
-const searchConfigSelector = createSelector(destinyVersionSelector, (destinyVersion) => {
-  // From search filter component
-  const searchConfig = buildSearchConfig(
-    destinyVersion,
-    itemTags,
-    destinyVersion === 1 ? D1Categories : D2Categories
-  );
-  return searchFilters(searchConfig, destinyVersion === 1 ? D1StoresService : D2StoresService);
-});
-
-/**
- * A selector for a predicate function for searching items, given the current search query.
- */
-// TODO: this also needs to depend on:
-// * settings
-// * loadouts
-// * current character
-// * all items (for dupes)
-// * itemInfo
-// * ratings
-// * newItems
-// * and maybe some other stuff?
-const searchFilterSelector = createSelector(querySelector, searchConfigSelector, (query, filters) =>
-  filters.filterFunction(query)
-);
-
-const storesSelector = (state: RootState) => state.inventory.stores;
-const characterOrderSelector = (state: RootState) =>
-  (state.settings.settings as Settings).characterOrder;
-const sortedStoresSelector = createSelector(storesSelector, characterOrderSelector, sortStores);
-
-function mapStateToProps(state: RootState): Partial<Props> {
+function mapStateToProps(state: RootState): Props {
   const settings = state.settings.settings as Settings;
   return {
     stores: sortedStoresSelector(state),
-    buckets: state.inventory.buckets,
-    // If "show new items" is off, don't pay the cost of propagating new item updates
-    newItems: settings.showNewItems ? state.inventory.newItems : EMPTY_SET,
-    itemInfos: state.inventory.itemInfos,
-    ratings: state.reviews.ratings,
+    buckets: state.inventory.buckets!,
     isPhonePortrait: state.shell.isPhonePortrait,
     settings,
     // Pulling this out lets us do ref-equality
-    collapsedSections: settings.collapsedSections,
-    searchFilter: searchFilterSelector(state)
+    collapsedSections: settings.collapsedSections
   };
 }
 
@@ -157,7 +96,7 @@ class Stores extends React.Component<Props, State> {
           <div className="detached" loadout-id={selectedStore.id} />
 
           <Hammer direction="DIRECTION_HORIZONTAL" onSwipe={this.handleSwipe}>
-            {this.renderStores([selectedStore], vault, currentStore)}
+            {this.renderStores([selectedStore], vault)}
           </Hammer>
         </div>
       );
@@ -172,7 +111,7 @@ class Stores extends React.Component<Props, State> {
             </div>
           ))}
         </ScrollClassDiv>
-        {this.renderStores(stores, vault, currentStore)}
+        {this.renderStores(stores, vault)}
       </div>
     );
   }
@@ -211,16 +150,8 @@ class Stores extends React.Component<Props, State> {
     settings.save();
   };
 
-  private renderStores(stores: DimStore[], vault: DimVault, currentStore: DimStore) {
-    const {
-      settings,
-      buckets,
-      newItems,
-      itemInfos,
-      ratings,
-      searchFilter,
-      collapsedSections
-    } = this.props;
+  private renderStores(stores: DimStore[], vault: DimVault) {
+    const { buckets, collapsedSections } = this.props;
 
     return (
       <div>
@@ -247,13 +178,7 @@ class Stores extends React.Component<Props, State> {
                   stores={stores}
                   collapsedSections={collapsedSections}
                   vault={vault}
-                  currentStore={currentStore}
-                  settings={settings}
                   toggleSection={this.toggleSection}
-                  newItems={newItems}
-                  itemInfos={itemInfos}
-                  ratings={ratings}
-                  searchFilter={searchFilter}
                 />
               ))}
           </div>
@@ -266,4 +191,4 @@ class Stores extends React.Component<Props, State> {
   }
 }
 
-export default connect(mapStateToProps)(Stores);
+export default connect<Props>(mapStateToProps)(Stores);

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -137,6 +137,7 @@ function makeD2StoresService(): D2StoreServiceType {
     return $q
       .all([getDefinitions(), getCharacters(account)])
       .then(([defs, profileInfo]: [D2ManifestDefinitions, DestinyProfileResponse]) => {
+        // TODO: create a new store
         _stores.forEach((dStore) => {
           if (!dStore.isVault) {
             const bStore = profileInfo.characters.data[dStore.id];

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -236,8 +236,10 @@ function ItemService(): ItemServiceType {
     }
 
     if (equip) {
-      target.buckets[item.bucket.id].forEach((i) => {
+      target.buckets[item.bucket.id] = target.buckets[item.bucket.id].map((i) => {
+        // TODO: this state needs to be moved out
         i.equipped = i.index === item.index;
+        return i;
       });
     }
 

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -6,6 +6,17 @@ import { InventoryBuckets } from './inventory-buckets';
 import { DimItemInfo } from './dim-item-info';
 import { setCurrentAccount } from '../accounts/actions';
 import { AccountsAction } from '../accounts/reducer';
+import { RootState } from '../store/reducers';
+import { createSelector } from 'reselect';
+import { characterOrderSelector } from '../settings/reducer';
+import { sortStores } from '../shell/dimAngularFilters.filter';
+
+const storesSelector = (state: RootState) => state.inventory.stores;
+export const sortedStoresSelector = createSelector(
+  storesSelector,
+  characterOrderSelector,
+  sortStores
+);
 
 // TODO: Should this be by account? Accounts need IDs
 export interface InventoryState {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1,7 +1,7 @@
 import * as _ from 'underscore';
 import { flatMap } from '../util';
 import { compareBy, chainComparator, reverseComparator } from '../comparators';
-import { TagInfo, settings } from '../settings/settings';
+import { TagInfo, settings, itemTags } from '../settings/settings';
 import { DimItem, D1Item, D2Item } from '../inventory/item-types';
 import { StoreServiceType, DimStore } from '../inventory/store-types';
 import { sortStores } from '../shell/dimAngularFilters.filter';
@@ -10,6 +10,44 @@ import { $rootScope } from 'ngimport';
 import { DestinyAmmunitionType } from 'bungie-api-ts/destiny2';
 import { t } from 'i18next';
 import { toaster } from '../ngimport-more';
+import { createSelector } from 'reselect';
+import { destinyVersionSelector } from '../accounts/reducer';
+import { D1Categories } from '../destiny1/d1-buckets.service';
+import { D2Categories } from '../destiny2/d2-buckets.service';
+import { D1StoresService } from '../inventory/d1-stores.service';
+import { D2StoresService } from '../inventory/d2-stores.service';
+import { querySelector } from '../shell/reducer';
+
+/**
+ * A selector for the search config for a particular destiny version.
+ */
+const searchConfigSelector = createSelector(destinyVersionSelector, (destinyVersion) => {
+  // From search filter component
+  const searchConfig = buildSearchConfig(
+    destinyVersion,
+    itemTags,
+    destinyVersion === 1 ? D1Categories : D2Categories
+  );
+  return searchFilters(searchConfig, destinyVersion === 1 ? D1StoresService : D2StoresService);
+});
+
+/**
+ * A selector for a predicate function for searching items, given the current search query.
+ */
+// TODO: this also needs to depend on:
+// * settings
+// * loadouts
+// * current character
+// * all items (for dupes)
+// * itemInfo
+// * ratings
+// * newItems
+// * and maybe some other stuff?
+export const searchFilterSelector = createSelector(
+  querySelector,
+  searchConfigSelector,
+  (query, filters) => filters.filterFunction(query)
+);
 
 interface SearchConfig {
   destinyVersion: 1 | 2;

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -2,6 +2,10 @@ import { Reducer } from 'redux';
 import { Settings } from './settings';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
+import { RootState } from '../store/reducers';
+
+export const characterOrderSelector = (state: RootState) =>
+  (state.settings.settings as Settings).characterOrder;
 
 export interface SettingsState {
   readonly settings: Settings | {};

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -2,6 +2,9 @@ import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { isPhonePortrait } from '../mediaQueries';
+import { RootState } from '../store/reducers';
+
+export const querySelector = (state: RootState) => state.shell.searchQuery;
 
 export interface ShellState {
   readonly isPhonePortrait: boolean;


### PR DESCRIPTION
This moves the redux connection up to the individual store bucket - this allows us to skip re-rendering in many cases because only a single bucket has changed. There's still work to get some of the state (like reviews) to be granular immutable state so that still fewer things update.

Note that I'm avoiding connecting every single item, so far. I'm a bit worried that it'll be too much, though maybe that's unfounded.