### PR TITLE
Postmaster on top

### DIFF
--- a/src/app/destiny1/d1-buckets.service.ts
+++ b/src/app/destiny1/d1-buckets.service.ts
@@ -5,6 +5,7 @@ import { InventoryBuckets, InventoryBucket } from '../inventory/inventory-bucket
 import { BucketCategory } from 'bungie-api-ts/destiny2';
 
 export const D1Categories = {
+  Postmaster: ['LostItems', 'SpecialOrders', 'Messages'],
   Weapons: ['Class', 'Primary', 'Special', 'Heavy'],
   Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
   General: [
@@ -20,8 +21,7 @@ export const D1Categories = {
     'Vehicle',
     'Horn'
   ],
-  Progress: ['Bounties', 'Quests', 'Missions'],
-  Postmaster: ['LostItems', 'SpecialOrders', 'Messages']
+  Progress: ['Bounties', 'Quests', 'Missions']
 };
 
 // A mapping from the bucket names to DIM item types

--- a/src/app/destiny2/d2-buckets.service.ts
+++ b/src/app/destiny2/d2-buckets.service.ts
@@ -7,11 +7,11 @@ import { InventoryBuckets, InventoryBucket } from '../inventory/inventory-bucket
 // TODO: These have to change
 // TODO: We can generate this based on making a tree from DestinyItemCategoryDefinitions
 export const D2Categories = {
+  Postmaster: ['LostItems', 'Messages', 'SpecialOrders'],
   Weapons: ['Class', 'Kinetic', 'Energy', 'Power'],
   Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
   General: ['Ghost', 'ClanBanners', 'Vehicle', 'Ships', 'Emblems', 'Engrams'],
-  Inventory: ['Consumables', 'Modifications', 'Shaders'],
-  Postmaster: ['LostItems', 'Messages', 'SpecialOrders']
+  Inventory: ['Consumables', 'Modifications', 'Shaders']
 };
 
 // A mapping from the bucket names to DIM item types

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -36,6 +36,12 @@ export function StoreBuckets({
   toggleSection(id: string): void;
 }) {
   let content: React.ReactNode;
+
+  // Don't show buckets with no items
+  if (!stores.some((s) => s.buckets[bucket.id].length > 0)) {
+    return null;
+  }
+
   if (collapsedSections[bucket.id]) {
     content = (
       <div onClick={() => toggleSection(bucket.id)} className="store-text collapse">

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -52,6 +52,7 @@
   margin-right: 12px;
   width: calc(40px + 44px + (3 * (44px + 8px)));
   width: calc(40px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px)));
+  flex-direction: column;
 
   &.vault {
     max-width: calc(8px + (999 * (44px + 8px)));
@@ -121,5 +122,15 @@
   margin-top: 77px;
   @supports (position: sticky) {
     margin-top: 0;
+  }
+}
+
+.dim-button.bucket-button {
+  align-self: center;
+  margin-top: 8px;
+  background-color: #222;
+
+  &:hover {
+    background-color: #666;
   }
 }

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -224,46 +224,59 @@ class Stores extends React.Component<Props, State> {
 
     return (
       <div>
-        {Object.keys(buckets.byCategory).map((category) => (
-          <div key={category} className="section">
-            <CollapsibleTitle
-              title={t(`Bucket.${category}`)}
-              sectionId={category}
-              collapsedSections={collapsedSections}
-            >
-              {stores[0].isDestiny1() &&
-                buckets.byCategory[category][0].vaultBucket && (
-                  <span className="bucket-count">
-                    {vault.vaultCounts[buckets.byCategory[category][0].vaultBucket!.id].count}/
-                    {buckets.byCategory[category][0].vaultBucket!.capacity}
-                  </span>
-                )}
-            </CollapsibleTitle>
-            {!collapsedSections[category] &&
-              buckets.byCategory[category].map((bucket) => (
-                <StoreBuckets
-                  key={bucket.id}
-                  bucket={bucket}
-                  stores={stores}
+        {Object.keys(buckets.byCategory).map(
+          (category) =>
+            categoryHasItems(buckets, category, stores) && (
+              <div key={category} className="section">
+                <CollapsibleTitle
+                  title={t(`Bucket.${category}`)}
+                  sectionId={category}
                   collapsedSections={collapsedSections}
-                  vault={vault}
-                  currentStore={currentStore}
-                  settings={settings}
-                  toggleSection={this.toggleSection}
-                  newItems={newItems}
-                  itemInfos={itemInfos}
-                  ratings={ratings}
-                  searchFilter={searchFilter}
-                />
-              ))}
-          </div>
-        ))}
+                >
+                  {stores[0].isDestiny1() &&
+                    buckets.byCategory[category][0].vaultBucket && (
+                      <span className="bucket-count">
+                        {vault.vaultCounts[buckets.byCategory[category][0].vaultBucket!.id].count}/
+                        {buckets.byCategory[category][0].vaultBucket!.capacity}
+                      </span>
+                    )}
+                </CollapsibleTitle>
+                {!collapsedSections[category] &&
+                  buckets.byCategory[category].map((bucket) => (
+                    <StoreBuckets
+                      key={bucket.id}
+                      bucket={bucket}
+                      stores={stores}
+                      collapsedSections={collapsedSections}
+                      vault={vault}
+                      currentStore={currentStore}
+                      settings={settings}
+                      toggleSection={this.toggleSection}
+                      newItems={newItems}
+                      itemInfos={itemInfos}
+                      ratings={ratings}
+                      searchFilter={searchFilter}
+                    />
+                  ))}
+              </div>
+            )
+        )}
         {stores[0].isDestiny1() && (
           <D1ReputationSection stores={stores} collapsedSections={collapsedSections} />
         )}
       </div>
     );
   }
+}
+
+/** Is there any store that has an item in any of the buckets in this category? */
+function categoryHasItems(
+  buckets: InventoryBuckets,
+  category: string,
+  stores: DimStore[]
+): boolean {
+  const bucketIds = buckets.byCategory[category].map((b) => b.id);
+  return stores.some((s) => bucketIds.some((bucketId) => s.buckets[bucketId].length > 0));
 }
 
 export default connect(mapStateToProps)(Stores);

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -65,15 +65,15 @@
       font-size: 50%;
     }
   }
+}
 
-  .badge {
-    border-radius: 50%;
-    border-radius: 10px;
-    background: $orange;
-    padding: 0 4px;
-    color: black;
-    font-size: 9px;
-  }
+.badge {
+  border-radius: 50%;
+  border-radius: 10px;
+  background: $orange;
+  padding: 0 4px;
+  color: black;
+  font-size: 9px;
 }
 
 .loadout-popup-content {


### PR DESCRIPTION
Now that Inventory is rendered in React, we can have much more complex logic for how to display (and what to display) without necessarily taking a performance hit for doing so. One of the ones I've been most excited about is moving the postmaster to the top of the screen, while being able to completely hide it (and any other inventory buckets) when empty. As a bonus, we can inline the "pull" button right there on the screen:

<img width="873" alt="screen shot 2018-09-13 at 11 44 08 pm" src="https://user-images.githubusercontent.com/313208/45534235-551e2980-b7af-11e8-8d10-6d913bbee1f6.png">

The "special orders" and "messages" buckets are automatically hidden because they don't have anything present on any character.

Note that just like in the loadout popup, the button only shows the number of items that we could successfully move, not the count of all items in the postmaster.