### PR TITLE
Remove D1 vault counts

### DIFF
--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -232,15 +232,7 @@ class Stores extends React.Component<Props, State> {
                   title={t(`Bucket.${category}`)}
                   sectionId={category}
                   collapsedSections={collapsedSections}
-                >
-                  {stores[0].isDestiny1() &&
-                    buckets.byCategory[category][0].vaultBucket && (
-                      <span className="bucket-count">
-                        {vault.vaultCounts[buckets.byCategory[category][0].vaultBucket!.id].count}/
-                        {buckets.byCategory[category][0].vaultBucket!.capacity}
-                      </span>
-                    )}
-                </CollapsibleTitle>
+                />
                 {!collapsedSections[category] &&
                   buckets.byCategory[category].map((bucket) => (
                     <StoreBuckets


### PR DESCRIPTION
For consistency, I'd like to remove the vault counts in section headers from D1 inventory. This leaves the vault counts under the vault tile for both D1 and D2.