### PR TITLE
Remove individual-bucket collapsing

### DIFF
--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -4,7 +4,6 @@ import StoreBucket from './StoreBucket';
 import { Settings } from '../settings/settings';
 import { InventoryBucket } from './inventory-buckets';
 import classNames from 'classnames';
-import { t } from 'i18next';
 import { InventoryState } from './reducer';
 import { ReviewsState } from '../item-review/reducer';
 import { DimItem } from './item-types';
@@ -17,7 +16,6 @@ import { $rootScope } from 'ngimport';
 /** One row of store buckets, one for each character and vault. */
 export function StoreBuckets({
   bucket,
-  collapsedSections,
   stores,
   vault,
   currentStore,
@@ -25,12 +23,10 @@ export function StoreBuckets({
   newItems,
   itemInfos,
   ratings,
-  searchFilter,
-  toggleSection
+  searchFilter
 }: {
   bucket: InventoryBucket;
   stores: DimStore[];
-  collapsedSections: Settings['collapsedSections'];
   vault: DimVault;
   currentStore: DimStore;
   settings: Settings;
@@ -38,7 +34,6 @@ export function StoreBuckets({
   itemInfos: InventoryState['itemInfos'];
   ratings: ReviewsState['ratings'];
   searchFilter(item: DimItem): boolean;
-  toggleSection(id: string): void;
 }) {
   let content: React.ReactNode;
 
@@ -47,13 +42,7 @@ export function StoreBuckets({
     return null;
   }
 
-  if (collapsedSections[bucket.id]) {
-    content = (
-      <div onClick={() => toggleSection(bucket.id)} className="store-text collapse">
-        <span>{t('Bucket.Show', { bucket: bucket.name })}</span>
-      </div>
-    );
-  } else if (bucket.accountWide) {
+  if (bucket.accountWide) {
     // If we're in mobile view, we only render one store
     const allStoresView = stores.length > 1;
     content = (
@@ -115,18 +104,7 @@ export function StoreBuckets({
     ));
   }
 
-  return (
-    <div className="store-row items">
-      <i
-        onClick={() => toggleSection(bucket.id)}
-        className={classNames(
-          'fa collapse',
-          collapsedSections[bucket.id] ? 'fa-plus-square-o' : 'fa-minus-square-o'
-        )}
-      />
-      {content}
-    </div>
-  );
+  return <div className="store-row items">{content}</div>;
 }
 
 function PullFromPostmaster({ store }: { store: D2Store }) {

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -33,16 +33,11 @@
   width: 100%;
   display: flex;
   flex-direction: row;
+  padding-left: 28px;
 
   // Bit of a hack to make things line up
   &.items:last-child .store-cell {
     padding-bottom: 14px;
-  }
-
-  i.collapse {
-    outline: none;
-    padding: 8px 7px 8px 10px;
-    align-self: flex-start;
   }
 }
 
@@ -88,7 +83,7 @@
   left: 0;
   width: auto;
   z-index: 10;
-  padding: 8px 0 4px 8px;
+  padding: 8px 0 4px 24px;
   background-color: #434444;
 
   @supports (position: sticky) {
@@ -109,6 +104,8 @@
   }
 
   .phone-portrait & {
+    padding-left: 0;
+
     .store-cell {
       margin: 0;
       width: 100%;

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -201,16 +201,6 @@ class Stores extends React.Component<Props, State> {
     this.setState({ selectedStoreId: storeId });
   };
 
-  private toggleSection = (id: string) => {
-    const settings = this.props.settings;
-    // TODO: make an action!
-    settings.collapsedSections = {
-      ...settings.collapsedSections,
-      [id]: !settings.collapsedSections[id]
-    };
-    settings.save();
-  };
-
   private renderStores(stores: DimStore[], vault: DimVault, currentStore: DimStore) {
     const {
       settings,
@@ -247,11 +237,9 @@ class Stores extends React.Component<Props, State> {
                       key={bucket.id}
                       bucket={bucket}
                       stores={stores}
-                      collapsedSections={collapsedSections}
                       vault={vault}
                       currentStore={currentStore}
                       settings={settings}
-                      toggleSection={this.toggleSection}
                       newItems={newItems}
                       itemInfos={itemInfos}
                       ratings={ratings}


### PR DESCRIPTION
Now that we automatically hide empty buckets, and we show the postmaster at the top of the page, I don't think we need the ability to collapse individual buckets. You can still collapse sections.

<img width="478" alt="screen shot 2018-09-14 at 6 42 38 pm" src="https://user-images.githubusercontent.com/313208/45581160-39b62b80-b84e-11e8-89a7-21407f77a88f.png">
