### PR TITLE
Tile tweaks - sizing and only for socketable items

### DIFF
--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -52,6 +52,9 @@ export default class InventoryItem extends React.Component<Props> {
 
     const badgeInfo = getBadgeInfo(item);
 
+    const elaborateTile =
+      $featureFlags.forsakenTiles && item.isDestiny2() && (item.primStat || item.sockets);
+
     return (
       <div
         id={item.index}
@@ -60,10 +63,10 @@ export default class InventoryItem extends React.Component<Props> {
         title={`${item.name}\n${item.typeName}`}
         className={classNames('item', {
           'search-hidden': searchHidden,
-          'd2-item': $featureFlags.forsakenTiles && item.isDestiny2()
+          'd2-item': elaborateTile
         })}
       >
-        {$featureFlags.forsakenTiles && item.isDestiny2() ? (
+        {elaborateTile && item.isDestiny2() ? (
           <ItemRender item={item} badge={badgeInfo} rating={rating} hideRating={hideRating} />
         ) : (
           <div>

--- a/src/app/inventory/ItemMod.tsx
+++ b/src/app/inventory/ItemMod.tsx
@@ -15,6 +15,7 @@ export default class ItemRender extends React.Component<Props> {
     return (
       <div
         className={classNames(`item-mod`)}
+        title={mod.displayProperties.name}
         style={bungieBackgroundStyle(mod.displayProperties.icon)}
       />
     );

--- a/src/app/inventory/ItemRating.tsx
+++ b/src/app/inventory/ItemRating.tsx
@@ -13,7 +13,7 @@ export default class ItemRender extends React.Component<Props> {
 
     if (rating !== undefined && !hideRating) {
       return (
-        <div className="review-score">
+        <div className="review-score" title={rating.toLocaleString()}>
           <i className={classNames('fa', rating >= 4 ? 'fa-thumbs-up' : '')} />
         </div>
       );

--- a/src/app/inventory/ItemRender.scss
+++ b/src/app/inventory/ItemRender.scss
@@ -21,7 +21,7 @@
       right: 2px;
       bottom: 2px;
       position: absolute;
-      width: calc(v(var(--item-size) + 4px) / 4);
+      width: calc((var(--item-size) + 4px) / 4);
       height: calc((var(--item-size) + 4px) / 6);
       content: '';
       background-size: contain;

--- a/src/app/inventory/ItemRender.scss
+++ b/src/app/inventory/ItemRender.scss
@@ -21,8 +21,8 @@
       right: 2px;
       bottom: 2px;
       position: absolute;
-      width: calc(var(--item-size) / 4);
-      height: calc(var(--item-size) / 6);
+      width: calc(v(var(--item-size) + 4px) / 4);
+      height: calc((var(--item-size) + 4px) / 6);
       content: '';
       background-size: contain;
       background-repeat: no-repeat;
@@ -79,7 +79,7 @@
       grid-template-rows: 1fr;
       grid-gap: 0;
       grid-template-areas: '1a 2a';
-      font-size: calc(var(--item-size) / 5.8);
+      font-size: calc((var(--item-size) + 4px) / 5.8);
       line-height: 100%;
     }
 
@@ -112,7 +112,7 @@
     }
 
     .power {
-      margin-right: calc(var(--item-size) / 4);
+      margin-right: calc((var(--item-size) + 4px) / 4);
       text-align: right;
     }
 
@@ -122,7 +122,7 @@
     }
 
     .power::before {
-      right: calc(var(--item-size) / -4.5);
+      right: calc((var(--item-size) + 4px) / -4.5);
       position: absolute;
       width: 1em;
       height: 1em;

--- a/src/app/inventory/ItemRender.scss
+++ b/src/app/inventory/ItemRender.scss
@@ -1,12 +1,12 @@
 .d2-item {
-  width: var(--item-size);
-  height: var(--item-size);
+  width: calc(var(--item-size) + 4px);
+  height: calc(var(--item-size) + 4px);
 
   .item-render {
     background-color: #262626;
     display: grid;
-    width: var(--item-size);
-    height: var(--item-size);
+    width: calc(var(--item-size) + 4px);
+    height: calc(var(--item-size) + 4px);
     grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-template-rows: 1fr 1fr 1fr 1fr;
     grid-gap: 1px;

--- a/src/app/inventory/ItemRender.tsx
+++ b/src/app/inventory/ItemRender.tsx
@@ -7,6 +7,7 @@ import { bungieBackgroundStyle } from '../dim-ui/BungieImage';
 import { D2Item } from './item-types';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import './ItemRender.scss';
+import * as _ from 'underscore';
 
 interface Props {
   item: D2Item;
@@ -23,6 +24,13 @@ export default class ItemRender extends React.Component<Props> {
       item.sockets.categories.find(
         (category) => category.category.categoryStyle === DestinySocketCategoryStyle.Consumable
       );
+
+    const sockets = category
+      ? _.take(
+          category.sockets.filter((socketInfo) => socketInfo.plug && socketInfo.plug.enabled),
+          3
+        )
+      : [];
 
     return (
       <div
@@ -42,20 +50,14 @@ export default class ItemRender extends React.Component<Props> {
         </div>
         <div className="plugs">
           {category &&
-            category.sockets.map((socketInfo, index) => {
-              if (index > 2) {
-                return null;
-              }
-
-              return (
-                <div key={socketInfo.socketIndex} className={`plug-${index + 1}`}>
-                  {socketInfo.plug &&
-                    category.category.categoryStyle !== DestinySocketCategoryStyle.Reusable && (
-                      <ItemMod mod={socketInfo.plug.plugItem} />
-                    )}
-                </div>
-              );
-            })}
+            sockets.map((socketInfo, index) => (
+              <div key={socketInfo.socketIndex} className={`plug-${index + 1}`}>
+                {socketInfo.plug &&
+                  category.category.categoryStyle !== DestinySocketCategoryStyle.Reusable && (
+                    <ItemMod mod={socketInfo.plug.plugItem} />
+                  )}
+              </div>
+            ))}
         </div>
         <div className="attributes">
           <div className="area-overlap attribute-1">

--- a/src/app/inventory/ItemRender.tsx
+++ b/src/app/inventory/ItemRender.tsx
@@ -26,10 +26,7 @@ export default class ItemRender extends React.Component<Props> {
       );
 
     const sockets = category
-      ? _.take(
-          category.sockets.filter((socketInfo) => socketInfo.plug && socketInfo.plug.enabled),
-          3
-        )
+      ? _.take(category.sockets.filter((socketInfo) => socketInfo.plug), 3)
       : [];
 
     return (

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -1058,9 +1058,21 @@ const EXCLUDED_PLUGS = new Set([
 function filterReusablePlug(reusablePlug: DimPlug) {
   return (
     !EXCLUDED_PLUGS.has(reusablePlug.plugItem.hash) &&
-    !reusablePlug.plugItem.itemCategoryHashes.includes(141186804)
+    !(reusablePlug.plugItem.itemCategoryHashes || []).includes(141186804)
   );
 }
+
+// Deprecated Damage Mods
+const DEPRECATED_MODS = new Set([
+  4160547565,
+  344032858,
+  1837294881,
+  2273483223,
+  3728733956,
+  3994397859,
+  4126105782,
+  4207478320
+]);
 
 function buildDefinedSocket(
   defs: D2ManifestDefinitions,
@@ -1183,7 +1195,7 @@ function buildSocket(
 
   return {
     socketIndex: index,
-    plug,
+    plug: plug && plug.plugItem && !DEPRECATED_MODS.has(plug.plugItem.hash) ? plug : null,
     plugOptions,
     hasRandomizedPlugItems
   };

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -1058,7 +1058,8 @@ const EXCLUDED_PLUGS = new Set([
 function filterReusablePlug(reusablePlug: DimPlug) {
   return (
     !EXCLUDED_PLUGS.has(reusablePlug.plugItem.hash) &&
-    !(reusablePlug.plugItem.itemCategoryHashes || []).includes(141186804)
+    !(reusablePlug.plugItem.itemCategoryHashes || []).includes(141186804) &&
+    !reusablePlug.plugItem.plug.plugCategoryIdentifier.includes('masterworks.stat')
   );
 }
 
@@ -1195,7 +1196,14 @@ function buildSocket(
 
   return {
     socketIndex: index,
-    plug: plug && plug.plugItem && !DEPRECATED_MODS.has(plug.plugItem.hash) ? plug : null,
+    plug:
+      plug &&
+      plug.plugItem &&
+      !DEPRECATED_MODS.has(plug.plugItem.hash) &&
+      (plug.plugItem.plug.plugCategoryIdentifier === 'enhancements.universal' ||
+        !plug.plugItem.plug.plugCategoryIdentifier.startsWith('enhancements.'))
+        ? plug
+        : null,
     plugOptions,
     hasRandomizedPlugItems
   };


### PR DESCRIPTION
<img width="253" alt="screen shot 2018-09-17 at 8 48 35 pm" src="https://user-images.githubusercontent.com/313208/45663405-17751580-babb-11e8-9ee1-2a5cc7cfba85.png">
<img width="235" alt="screen shot 2018-09-17 at 8 48 40 pm" src="https://user-images.githubusercontent.com/313208/45663406-17751580-babb-11e8-8134-42d0ddd30552.png">

A couple tweaks - due to an accident of history, the real item size should actually be 4px larger than `--item-size`. Plus, this switches off the new tiles for things that can't or don't have sockets.