### PR TITLE
Fix mobile issue with infusion UI

### DIFF
--- a/src/app/infuse/infuse.scss
+++ b/src/app/infuse/infuse.scss
@@ -122,6 +122,11 @@
     justify-content: space-around;
     display: flex;
 
+    @media (max-width: 768px) {
+      display: block;
+      max-height: 50vh;
+    }
+
     .infuseSeparator {
       width: 1px;
       margin: 15px 8px 0px 8px;


### PR DESCRIPTION
Desktop stays the same, but on <768 viewports, we stack the columns and limit the max-height

< 768:
<img width="377" alt="screen shot 2018-09-18 at 2 11 23 am" src="https://user-images.githubusercontent.com/424158/45677210-7d2bc680-bae8-11e8-9c46-5fc426faaf0b.png">

otherwise:
<img width="854" alt="screen shot 2018-09-18 at 2 14 14 am" src="https://user-images.githubusercontent.com/424158/45677249-95034a80-bae8-11e8-9ae7-194c4dd9c6fb.png">


This resolves #2895
