### PR TITLE
Restore character order by age for D2 characters

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -1203,6 +1203,7 @@ function buildMasterworkInfo(
   if (
     !socket ||
     !socket.plug ||
+    !socket.plug.plugObjectives ||
     !socket.plug.plugObjectives.length ||
     !socket.plugOptions ||
     !socket.plugOptions.length

--- a/src/app/shell/dimAngularFilters.filter.ts
+++ b/src/app/shell/dimAngularFilters.filter.ts
@@ -78,7 +78,7 @@ mod.filter('sortStores', () => sortStores);
 
 export function sortStores(stores: DimStore[], order: string) {
   if (order === 'mostRecent') {
-    return _.sortBy(stores, 'lastPlayed').reverse();
+    return _.sortBy(stores, (store) => store.lastPlayed).reverse();
   } else if (order === 'mostRecentReverse') {
     return _.sortBy(stores, (store) => {
       if (store.isVault) {
@@ -87,9 +87,11 @@ export function sortStores(stores: DimStore[], order: string) {
         return store.lastPlayed;
       }
     });
-  } else if (stores.length) {
-    return _.sortBy(stores, 'id');
+  } else if (stores.length && stores[0].destinyVersion === 1) {
+    return _.sortBy(stores, (s) => s.id);
   } else {
+    // The response is in character creation order by default, at least in D2
+    // https://github.com/Bungie-net/api/issues/614
     return stores;
   }
 }


### PR DESCRIPTION
Bungie fixed the API to always return (at least D2) characters in creation order: https://github.com/Bungie-net/api/issues/614

Fixes #3103, which was caused by folks not realizing that the Progress page had its own function for sorting characters. Fixes #3007 as well.