### PR TITLE
Adding `is:modded` filter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Removed a bunch of help popups.
 * Added `is:maxpower` search to return highest light items.
+* Added `is:modded` search to return items that have a mod applied.
 * Bounties with expiration times are now shown, and are sorted in front in order of expiration time.
 * Added masterwork tier range filter.
 * Highlight the stat that is boosted by masterwork in item details.

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1106,9 +1106,11 @@ export function searchFilters(
           item.sockets &&
           item.sockets.sockets.some((socket) => {
             return !!(
-              (socket.plug || false) &&
-              ![2323986101, 2600899007].includes(socket.plug.plugItem.hash) &&
-              socket.plug.plugItem.itemTypeDisplayName.includes(' Mod')
+              socket.plug &&
+              ![2323986101, 2600899007, 1835369552].includes(socket.plug.plugItem.hash) &&
+              socket.plug.plugItem.plug.plugCategoryIdentifier.match(
+                /(v400.weapon.mod_guns|enhancements.)/
+              )
             );
           })
         );

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -231,6 +231,7 @@ export function buildSearchConfig(
       complete: ['goldborder', 'yellowborder', 'complete'],
       masterwork: ['masterwork', 'masterworks'],
       hasShader: ['shaded', 'hasshader'],
+      hasMod: ['modded', 'hasmod'],
       prophecy: ['prophecy'],
       ikelos: ['ikelos'],
       randomroll: ['randomroll'],
@@ -1096,6 +1097,18 @@ export function searchFilters(
               (socket.plug || false) &&
               socket.plug.plugItem.plug.plugCategoryHash === 2973005342 &&
               socket.plug.plugItem.hash !== 4248210736
+            );
+          })
+        );
+      },
+      hasMod(item: D2Item) {
+        return (
+          item.sockets &&
+          item.sockets.sockets.some((socket) => {
+            return !!(
+              (socket.plug || false) &&
+              ![2323986101, 2600899007].includes(socket.plug.plugItem.hash) &&
+              socket.plug.plugItem.itemTypeDisplayName.includes(' Mod')
             );
           })
         );


### PR DESCRIPTION
Looks for the mod slot and filters out ones that are empty

This resolves #3117