### PR TITLE
Suppress bounty expiration when we should suppress expiration

### DIFF
--- a/src/app/progress/Quest.tsx
+++ b/src/app/progress/Quest.tsx
@@ -40,8 +40,7 @@ export default function Quest(props: QuestProps) {
     ? new Date(item.expirationDate).getTime() < Date.now()
     : false;
   const complete = percentComplete >= 1;
-  const suppressExpiration =
-    itemDef.inventory.suppressExpirationWhenObjectivesComplete && expired && complete;
+  const suppressExpiration = itemDef.inventory.suppressExpirationWhenObjectivesComplete && complete;
 
   return (
     <MilestoneDisplay displayProperties={itemDef.displayProperties} progress={progress}>


### PR DESCRIPTION
I think I had misunderstood this property before - it tells when we should suppress expiration on completion, regardless of whether it's expired.

Fixes #3123.