### PR TITLE
updates to docker-compose based dev env

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -65,7 +65,9 @@ module.exports = (env) => {
           https: {
             key: fs.readFileSync('key.pem'), // Private keys in PEM format.
             cert: fs.readFileSync('cert.pem') // Cert chains in PEM format.
-          }
+          },
+          host: '0.0.0.0',
+          port: '8080'
         }
       : {},
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
-version: "3.7"
+version: '3'
 services:
   webpack:
     container_name: dim-webpack
     image: node:10.9.0
-    build:
-      context: ./docker-compose/webpack
-    command: bash -c "yarn install && yarn start"
+    ports:
+      - '8080:8080'
+    command: bash -c 'yarn install && yarn start'
+    environment:
+      - NODE_ENV=dev
     restart: always
     volumes:
       - .:/usr/src/app

--- a/docker-compose/webpack/Dockerfile
+++ b/docker-compose/webpack/Dockerfile
@@ -1,3 +1,0 @@
-FROM node:10.9.0
-WORKDIR /usr/src/app
-CMD [ "yarn", "start" ]


### PR DESCRIPTION
fixes #3141 

- updated the `webpack/config.js` to bind to `0.0.0.0` instead of loopback
- changed `version` specification in `docker-compose.yml` to just `3` to prevent client api mismatch errors with newer versions of docker client
- removed the `build` command and the `docker-compose` directory, since these actually aren't needed at all, speeding up the process since no docker images need to be built
- specified host to container port mappings in `docker-compose.yml` for the devServer 