### PR TITLE
Make it easy to add searches for item categories

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Add searches `is:transmat`, `is:armormod`, `is:weaponmod`, and `is:transmat`, and removed D1 `is:primaryweaponengram`, `is:specialweaponengram`, and `is:heavyweaponengram`.
+
 # 4.71.0 (2018-09-23)
 
 * Removed a bunch of help popups.

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -35,8 +35,8 @@ export interface DimItem {
   hash: number;
   /** This is the type of the item (see InventoryBuckets) regardless of location. This string is a DIM concept with no direct correlation to the API types. */
   type: string;
-  /** String names of "item categories" the item may be in. These are not the same as DestinyItemCategoryDefinitions. */
-  categories: string[];
+  /** Hashes of DestinyItemCategoryDefinitions this item belongs to */
+  itemCategoryHashes: number[];
   /** A readable English name for the rarity of the item (e.g. "Exotic", "Rare"). */
   tier: string;
   /** Is this an Exotic item? */
@@ -161,8 +161,6 @@ export interface DimItem {
 
   /** Can this item be equipped by the given store? */
   canBeEquippedBy(store: DimStore): boolean;
-  /** Is this item in the given category name? Only really useful in D1. */
-  inCategory(categoryName: string): boolean;
   /** Could this be added to a loadout? */
   canBeInLoadout(): boolean;
   /** "Touch" the item to mark it as having been manually moved. */
@@ -218,8 +216,6 @@ export interface D2Item extends DimItem {
   infusionQuality: DestinyItemQualityBlockDefinition | null;
   /** More infusion information about what can be infused with the item. */
   infusionProcess: DestinyItemTierTypeInfusionBlock | null;
-  /** Hashes of DestinyItemCategoryDefinitions this item belongs to */
-  itemCategoryHashes: number[];
   /** The DestinyVendorDefinition hash of the vendor that can preview the contents of this item, if there is one. */
   previewVendor?: number;
   dtrRating: D2RatingData | null;

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -307,7 +307,6 @@ export function makeItem(
     hash: item.itemHash,
     // This is the type of the item (see DimCategory/DimBuckets) regardless of location
     type: itemType,
-    categories: [],
     itemCategoryHashes: itemDef.itemCategoryHashes || [], // see defs.ItemCategory
     tier: tiers[itemDef.inventory.tierType] || 'Common',
     isExotic: tiers[itemDef.inventory.tierType] === 'Exotic',

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -95,26 +95,6 @@ const statWhiteList = [
 
 const statsNoBar = [4284893193, 3871231066, 2961396640, 447667954, 1931675084];
 
-// Mapping from itemCategoryHash to our category strings for filtering.
-const categoryFromHash = {
-  153950757: 'CATEGORY_GRENADE_LAUNCHER',
-  3954685534: 'CATEGORY_SUBMACHINEGUN',
-  2489664120: 'CATEGORY_TRACE_RIFLE',
-  1504945536: 'CATEGORY_LINEAR_FUSION_RIFLE',
-  3317538576: 'CATEGORY_BOW',
-  5: 'CATEGORY_AUTO_RIFLE',
-  6: 'CATEGORY_HAND_CANNON',
-  7: 'CATEGORY_PULSE_RIFLE',
-  8: 'CATEGORY_SCOUT_RIFLE',
-  9: 'CATEGORY_FUSION_RIFLE',
-  10: 'CATEGORY_SNIPER_RIFLE',
-  11: 'CATEGORY_SHOTGUN',
-  12: 'CATEGORY_MACHINE_GUN',
-  13: 'CATEGORY_ROCKET_LAUNCHER',
-  14: 'CATEGORY_SIDEARM',
-  54: 'CATEGORY_SWORD'
-};
-
 const resistanceMods = {
   1546607980: DamageType.Void,
   1546607978: DamageType.Arc,
@@ -140,9 +120,6 @@ const ItemProto = {
       (!this.notransfer || this.owner === store.id) &&
       !this.location.inPostmaster
     );
-  },
-  inCategory(this: D2Item, categoryName: string) {
-    return this.categories.includes(categoryName);
   },
   canBeInLoadout(this: D2Item) {
     return this.equipment || this.type === 'Material' || this.type === 'Consumable';
@@ -244,23 +221,6 @@ export function createItemIndex(item: D2Item): string {
 }
 
 /**
- * Construct the search category (CATEGORY_*) list from an item definition.
- * @param itemDef the item definition object
- */
-function findCategories(itemDef): string[] {
-  const categories: string[] = [];
-  if (itemDef.itemCategoryHashes) {
-    for (const hash of itemDef.itemCategoryHashes) {
-      const c = categoryFromHash[hash];
-      if (c) {
-        categories.push(c);
-      }
-    }
-  }
-  return categories;
-}
-
-/**
  * Process a single raw item into a DIM item.
  * @param defs the manifest definitions
  * @param buckets the bucket definitions
@@ -327,8 +287,6 @@ export function makeItem(
 
   const itemType = normalBucket.type || 'Unknown';
 
-  const categories = findCategories(itemDef);
-
   const dmgName = instanceDef
     ? [null, 'kinetic', 'arc', 'solar', 'void', 'raid'][instanceDef.damageType || 0]
     : null;
@@ -349,8 +307,8 @@ export function makeItem(
     hash: item.itemHash,
     // This is the type of the item (see DimCategory/DimBuckets) regardless of location
     type: itemType,
-    categories, // see defs.ItemCategories
-    itemCategoryHashes: itemDef.itemCategoryHashes || [],
+    categories: [],
+    itemCategoryHashes: itemDef.itemCategoryHashes || [], // see defs.ItemCategory
     tier: tiers[itemDef.inventory.tierType] || 'Common',
     isExotic: tiers[itemDef.inventory.tierType] === 'Exotic',
     isVendorItem: !owner || owner.id === null,

--- a/src/app/search/filters.html
+++ b/src/app/search/filters.html
@@ -304,18 +304,16 @@
           <dim-filter-link filter="is:fusionrifle"></dim-filter-link>
           <dim-filter-link ng-if="vm.settings.destinyVersion === 2" filter="is:grenadelauncher"></dim-filter-link>
           <dim-filter-link filter="is:handcannon"></dim-filter-link>
-          <dim-filter-link ng-if="vm.settings.destinyVersion === 1" filter="is:machinegun"></dim-filter-link>
+          <dim-filter-link filter="is:machinegun"></dim-filter-link>
           <dim-filter-link filter="is:pulserifle"></dim-filter-link>
           <dim-filter-link filter="is:scoutrifle"></dim-filter-link>
           <dim-filter-link filter="is:shotgun"></dim-filter-link>
           <dim-filter-link filter="is:sidearm"></dim-filter-link>
           <dim-filter-link filter="is:sniperrifle"></dim-filter-link>
           <dim-filter-link ng-if="vm.settings.destinyVersion === 2" filter="is:submachine"></dim-filter-link>
+          <dim-filter-link ng-if="vm.settings.destinyVersion === 2" filter="is:bow"></dim-filter-link>
           <dim-filter-link filter="is:rocketlauncher"></dim-filter-link>
           <dim-filter-link filter="is:sword"></dim-filter-link>
-          <dim-filter-link ng-if="vm.settings.destinyVersion === 1" filter="is:primaryweaponengram"></dim-filter-link>
-          <dim-filter-link ng-if="vm.settings.destinyVersion === 1" filter="is:specialweaponengram"></dim-filter-link>
-          <dim-filter-link ng-if="vm.settings.destinyVersion === 1" filter="is:heavyweaponengram"></dim-filter-link>
         </td>
         <td ng-i18next="Filter.WeaponType"></td>
       </tr>
@@ -354,13 +352,15 @@
             <dim-filter-link filter="tag:junk"></dim-filter-link>
             <dim-filter-link filter="tag:infuse"></dim-filter-link>
           </td>
-          <td><ul>
-            <li ng-i18next="Filter.Tags.NoTag"></li>
-            <li ng-i18next="Filter.Tags.Favorite"></li>
-            <li ng-i18next="Filter.Tags.Keep"></li>
-            <li ng-i18next="Filter.Tags.Dismantle"></li>
-            <li ng-i18next="Filter.Tags.Infuse"></li>
-          </ul></td>
+          <td>
+            <ul>
+              <li ng-i18next="Filter.Tags.NoTag"></li>
+              <li ng-i18next="Filter.Tags.Favorite"></li>
+              <li ng-i18next="Filter.Tags.Keep"></li>
+              <li ng-i18next="Filter.Tags.Dismantle"></li>
+              <li ng-i18next="Filter.Tags.Infuse"></li>
+            </ul>
+          </td>
         </tr>
         <tr>
           <td>
@@ -411,14 +411,14 @@
         </td>
         <td ng-i18next="Filter.InLoadout"></td>
       </tr>
-    <tr ng-if="vm.settings.destinyVersion === 1">
-      <td>
-        <dim-filter-link filter="is:ornamentable"></dim-filter-link>
-        <dim-filter-link filter="is:ornamentmissing"></dim-filter-link>
-        <dim-filter-link filter="is:ornamentunlocked"></dim-filter-link>
-      </td>
-      <td ng-i18next="Filter.Ornament"></td>
-    </tr>
+      <tr ng-if="vm.settings.destinyVersion === 1">
+        <td>
+          <dim-filter-link filter="is:ornamentable"></dim-filter-link>
+          <dim-filter-link filter="is:ornamentmissing"></dim-filter-link>
+          <dim-filter-link filter="is:ornamentunlocked"></dim-filter-link>
+        </td>
+        <td ng-i18next="Filter.Ornament"></td>
+      </tr>
       <tr>
         <td>
           <dim-filter-link filter="is:postmaster"></dim-filter-link>

--- a/src/app/search/search-filter.component.ts
+++ b/src/app/search/search-filter.component.ts
@@ -4,8 +4,6 @@ import Textcomplete from 'textcomplete/lib/textcomplete';
 import Textarea from 'textcomplete/lib/textarea';
 import { searchFilters, buildSearchConfig, SearchFilters } from './search-filters';
 import filtersTemplate from '../search/filters.html';
-import { D2Categories } from '../destiny2/d2-buckets.service';
-import { D1Categories } from '../destiny1/d1-buckets.service';
 import { itemTags } from '../settings/settings';
 import { getItemInfoSource } from '../inventory/dim-item-info';
 import './search-filter.scss';
@@ -71,10 +69,7 @@ function SearchFilterCtrl(
 
   vm.$onChanges = (changes) => {
     if (changes.account && changes.account) {
-      searchConfig = buildSearchConfig(
-        vm.account.destinyVersion,
-        vm.account.destinyVersion === 1 ? D1Categories : D2Categories
-      );
+      searchConfig = buildSearchConfig(vm.account.destinyVersion);
       filters = searchFilters(searchConfig, getStoresService());
       setupTextcomplete();
     }

--- a/src/app/search/search-filter.component.ts
+++ b/src/app/search/search-filter.component.ts
@@ -73,7 +73,6 @@ function SearchFilterCtrl(
     if (changes.account && changes.account) {
       searchConfig = buildSearchConfig(
         vm.account.destinyVersion,
-        itemTags,
         vm.account.destinyVersion === 1 ? D1Categories : D2Categories
       );
       filters = searchFilters(searchConfig, getStoresService());

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -29,7 +29,6 @@ const searchConfigSelector = createSelector(
     // From search filter component
     const searchConfig = buildSearchConfig(
       destinyVersion,
-      itemTags,
       destinyVersion === 1 ? D1Categories : D2Categories
     );
     return searchFilters(searchConfig, destinyVersion === 1 ? D1StoresService : D2StoresService);
@@ -66,7 +65,6 @@ interface SearchConfig {
  */
 export function buildSearchConfig(
   destinyVersion: 1 | 2,
-  itemTags: TagInfo[],
   categories: {
     [category: string]: string[];
   }
@@ -85,8 +83,11 @@ export function buildSearchConfig(
     bow: ['CATEGORY_BOW'],
     machinegun: ['CATEGORY_MACHINE_GUN']
   };
+  const itemCategoryHashFilters = {};
 
-  const itemTypes: string[] = [];
+  const itemTypes = flatMap(Object.values(categories), (l: string[]) =>
+    l.map((v) => v.toLowerCase())
+  );
 
   const stats = [
     'charge',
@@ -106,9 +107,6 @@ export function buildSearchConfig(
       heavyweaponengram: ['CATEGORY_HEAVY_WEAPON', 'CATEGORY_ENGRAM'],
       machinegun: ['CATEGORY_MACHINE_GUN']
     });
-    itemTypes.push(
-      ...flatMap(Object.values(categories), (l: string[]) => l.map((v) => v.toLowerCase()))
-    );
     stats.push('rof');
   } else {
     Object.assign(categoryFilters, {
@@ -117,9 +115,8 @@ export function buildSearchConfig(
       tracerifle: ['CATEGORY_TRACE_RIFLE'],
       linearfusionrifle: ['CATEGORY_LINEAR_FUSION_RIFLE']
     });
-    itemTypes.push(
-      ...flatMap(Object.values(categories), (l: string[]) => l.map((v) => v.toLowerCase()))
-    );
+    // TODO: map D1 categories into D2?
+    itemCategoryHashFilters = {};
     stats.push('rpm');
     stats.push('mobility');
     stats.push('recovery');

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1,7 +1,7 @@
 import * as _ from 'underscore';
 import { flatMap } from '../util';
 import { compareBy, chainComparator, reverseComparator } from '../comparators';
-import { TagInfo, settings, itemTags } from '../settings/settings';
+import { settings, itemTags } from '../settings/settings';
 import { DimItem, D1Item, D2Item } from '../inventory/item-types';
 import { StoreServiceType, DimStore } from '../inventory/store-types';
 import { sortStores } from '../shell/dimAngularFilters.filter';
@@ -27,10 +27,7 @@ const searchConfigSelector = createSelector(
   storesSelector,
   (destinyVersion, _stores) => {
     // From search filter component
-    const searchConfig = buildSearchConfig(
-      destinyVersion,
-      destinyVersion === 1 ? D1Categories : D2Categories
-    );
+    const searchConfig = buildSearchConfig(destinyVersion);
     return searchFilters(searchConfig, destinyVersion === 1 ? D1StoresService : D2StoresService);
   }
 );
@@ -56,38 +53,33 @@ export const searchFilterSelector = createSelector(
 interface SearchConfig {
   destinyVersion: 1 | 2;
   keywords: string[];
-  categoryFilters: { [key: string]: string[] };
+  categoryHashFilters: { [key: string]: number };
   keywordToFilter: { [key: string]: string };
 }
 
 /**
  * Builds an object that describes the available search keywords and category mappings.
  */
-export function buildSearchConfig(
-  destinyVersion: 1 | 2,
-  categories: {
-    [category: string]: string[];
-  }
-): SearchConfig {
-  const categoryFilters = {
-    pulserifle: ['CATEGORY_PULSE_RIFLE'],
-    scoutrifle: ['CATEGORY_SCOUT_RIFLE'],
-    handcannon: ['CATEGORY_HAND_CANNON'],
-    autorifle: ['CATEGORY_AUTO_RIFLE'],
-    sniperrifle: ['CATEGORY_SNIPER_RIFLE'],
-    shotgun: ['CATEGORY_SHOTGUN'],
-    sidearm: ['CATEGORY_SIDEARM'],
-    rocketlauncher: ['CATEGORY_ROCKET_LAUNCHER'],
-    fusionrifle: ['CATEGORY_FUSION_RIFLE'],
-    sword: ['CATEGORY_SWORD'],
-    bow: ['CATEGORY_BOW'],
-    machinegun: ['CATEGORY_MACHINE_GUN']
-  };
-  const itemCategoryHashFilters = {};
-
+export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
+  const categories = destinyVersion === 1 ? D1Categories : D2Categories;
   const itemTypes = flatMap(Object.values(categories), (l: string[]) =>
     l.map((v) => v.toLowerCase())
   );
+
+  // Add new ItemCategoryHash hashes to this (or down below in the D2 area) to add new category searches
+  let categoryHashFilters: { [key: string]: number } = {
+    autorifle: 5,
+    handcannon: 6,
+    pulserifle: 7,
+    scoutrifle: 8,
+    fusionrifle: 9,
+    sniperrifle: 10,
+    shotgun: 11,
+    machinegun: 12,
+    rocketlauncher: 13,
+    sidearm: 14,
+    sword: 54
+  };
 
   const stats = [
     'charge',
@@ -101,26 +93,21 @@ export function buildSearchConfig(
   ];
 
   if (destinyVersion === 1) {
-    Object.assign(categoryFilters, {
-      primaryweaponengram: ['CATEGORY_PRIMARY_WEAPON', 'CATEGORY_ENGRAM'],
-      specialweaponengram: ['CATEGORY_SPECIAL_WEAPON', 'CATEGORY_ENGRAM'],
-      heavyweaponengram: ['CATEGORY_HEAVY_WEAPON', 'CATEGORY_ENGRAM'],
-      machinegun: ['CATEGORY_MACHINE_GUN']
-    });
     stats.push('rof');
   } else {
-    Object.assign(categoryFilters, {
-      grenadelauncher: ['CATEGORY_GRENADE_LAUNCHER'],
-      submachine: ['CATEGORY_SUBMACHINEGUN'],
-      tracerifle: ['CATEGORY_TRACE_RIFLE'],
-      linearfusionrifle: ['CATEGORY_LINEAR_FUSION_RIFLE']
-    });
-    // TODO: map D1 categories into D2?
-    itemCategoryHashFilters = {};
-    stats.push('rpm');
-    stats.push('mobility');
-    stats.push('recovery');
-    stats.push('resilience');
+    categoryHashFilters = {
+      ...categoryHashFilters,
+      grenadelauncher: 153950757,
+      tracerifle: 2489664120,
+      linearfusionrifle: 1504945536,
+      submachine: 3954685534,
+      bow: 3317538576,
+      transmat: 208981632,
+      weaponmod: 610365472,
+      armormod: 4104513227,
+      reptoken: 2088636411
+    };
+    stats.push('rpm', 'mobility', 'recovery', 'resilience');
   }
 
   /**
@@ -149,7 +136,7 @@ export function buildSearchConfig(
     locked: ['locked'],
     unlocked: ['unlocked'],
     stackable: ['stackable'],
-    category: Object.keys(categoryFilters),
+    categoryHash: Object.keys(categoryHashFilters),
     inloadout: ['inloadout'],
     maxpower: ['maxpower'],
     new: ['new'],
@@ -298,8 +285,8 @@ export function buildSearchConfig(
   return {
     keywordToFilter,
     keywords,
-    categoryFilters,
-    destinyVersion
+    destinyVersion,
+    categoryHashFilters
   };
 }
 
@@ -808,13 +795,14 @@ export function searchFilters(
       infusable(item: DimItem) {
         return item.infusable;
       },
-      category(item: DimItem, predicate: string) {
-        const categories = searchConfig.categoryFilters[predicate.toLowerCase().replace(/\s/g, '')];
+      categoryHash(item: D2Item, predicate: string) {
+        const categoryHash =
+          searchConfig.categoryHashFilters[predicate.toLowerCase().replace(/\s/g, '')];
 
-        if (!categories || !categories.length) {
+        if (!categoryHash) {
           return false;
         }
-        return categories.every((c) => item.inCategory(c));
+        return item.itemCategoryHashes.includes(categoryHash);
       },
       keyword(item: DimItem, predicate: string) {
         return (


### PR DESCRIPTION
This completely removes the old `item.categories` property that only really worked for D1 items for `item.itemCategoryHashes` that works for both D1 and D2. It also makes a nice place for adding any new searches based on item category hash. I added `is:transmat`, `is:armormod`, `is:weaponmod`, and `is:transmat`, and removed D1 `is:primaryweaponengram`, `is:specialweaponengram`, and `is: heavyweaponengram`.

This supercedes #2881.