### PR TITLE
Clarify contribution docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Here are some tips to make sure your pull request can be merged smoothly:
 * Linux-based developers will need to install `build-essential` (`sudo apt-get install -y build-essential`) prior to runninng `yarn install`.
 
 **Docker Supported Development**
-* As an alternative to installing the above, we support a docker-based development environment. See: [Docker Development Guide](DOCKER.md) 
+* As an alternative to installing the above, we support a docker-based development environment. See: [Docker Development Guide](Docker.md) 
 
 
 ### Clone the repo

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,18 +55,18 @@ Here are some tips to make sure your pull request can be merged smoothly:
 This step will need to be done each time you clear your browser cache. You will be automatically redirected to a screen to enter these credentials
 if the app can't load them from local storage when it starts.
 
-1. Open your browser and navigate to [https://localhost:8080][]
+1. Open your browser and navigate to [https://localhost:8080]()
 1. Copy your API-key, Oauth Client_id, and OAuth client_secret from bungie.net into DIM developer settings panel when it is loaded.
 
 ### Development
 
 **Overview**
 
-The `yarn start` step will create a hot-loading webserver, and a TLS cert/key pair. You will access your local development site by visiting [https://localhost:8080][].
+The `yarn start` step will create a hot-loading webserver, and a TLS cert/key pair. You will access your local development site by visiting [https://localhost:8080]().
 You will likely get a security warning about the certificate not being trusted. This is because it's a self-signed cert generated dynamically for your environment,
 and is not signed by a recognized autority. Dismass/advance past these warning to view your local DIM application.
 
 **Check code Style**
 
 * `yarn lint` will tell you if you're following the DIM code style (and automatically fix what it can).
-Check out the [docs](https://github.com/DestinyItemManager/DIM/blob/master/docs) folder for more tips.
+Check out the [docs]() folder for more tips.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,35 +10,30 @@ Here are some tips to make sure your pull request can be merged smoothly:
 1. Don't forget to add a description of your change to `CHANGELOG.md` so it'll be included in the release notes!
 
 ## Developer Quick start
-Clone the repo:
 
-* `git clone https://github.com/DestinyItemManager/DIM.git`
+1. [Install Pre-requisites](#pre-requisites)
+1. [Clone](#clone-the-repo)
+1. [Get your own API key](#get-your-own-api-key)
+1. [Start Dev Server](#start-dev-server)
+1. [Enter API credentials](#enter-api-credentials)
 
-Install dependencies:
+### Pre-requisites
 
 * Install [NodeJS](https://nodejs.org/).
 * Install [Yarn](https://yarnpkg.com/en/docs/install). If you're used to NPM, see "[Migrating from NPM](https://yarnpkg.com/lang/en/docs/migrating-from-npm/)". If you were already using NPM with DIM, run `yarn` to convert to Yarn. 
 * Windows-based developers will need to install `windows-build-tools` (`yarn global add windows-build-tools`) globally prior to running `yarn install`. Refer to issue #1439 for [details](https://github.com/DestinyItemManager/DIM/issues/1439).
-* Linux-based developers will need to install `build-essential` (`sudo apt-get install -y build-essential`) prior to runninng `yarn install`.
-* Run `yarn install`.
-  * Note that on Windows, the Git Bash shell may fail to fetch all necessary packages even when run as Admin ([details](https://github.com/DestinyItemManager/DIM/issues/2487)). If that's the case, simply use cmd as Admin instead.
 * It is highly recommended to use [VSCode](https://code.visualstudio.com/) to work on DIM. When you open DIM in VSCode, accept the recommended plugins it suggests.
+* Linux-based developers will need to install `build-essential` (`sudo apt-get install -y build-essential`) prior to runninng `yarn install`.
 
-Check code Style
-* `yarn lint` will tell you if you're following the DIM code style (and automatically fix what it can).
+**Docker Supported Development**
+* As an alternative to installing the above, we support a docker-based development environment. See: [Docker Development Guide](DOCKER.md) 
 
-## Docker Compose Setup
-Install Dependencies, and start webpack, with Docker
-* Install Docker https://www.docker.com/get-started
-* Open terminal/cmd/powershell window and change to the cloned folder
-* `docker-compose up` to build the dist and start yarn watcher
-* It will take a while for the dist files to build on the first startup while yarn installs dependencies
-* `ctrl+c` to stop
-* `docker-compose up -d` to start in detached mode
-* `docker-compose stop` to stop detached mode
-* `docker-compose build` to re-build if the compose files change
 
-Get your own API key:
+### Clone the repo
+
+    git clone https://github.com/DestinyItemManager/DIM.git
+
+### Get your own API key:
 
 1. Goto [Bungie](https://www.bungie.net/en/Application)
 1. Click `Create New App`
@@ -47,7 +42,31 @@ Get your own API key:
 1. Set your redirect url to `https://127.0.0.1:8080/return.html` (or whatever the IP or hostname is of your dev server)
 1. Select all scopes _except_ the Administrate Groups/Clans
 1. Enter `https://127.0.0.1:8080` as the `Origin Header`
-1. Run `yarn install && yarn start`
+
+### Start Dev Server
+
+* Run `yarn install`
+* Run `yarn start`
+
+*Note:* on Windows, when running `yarn install` the Git Bash shell may fail to fetch all necessary packages even when run as Admin ([details](https://github.com/DestinyItemManager/DIM/issues/2487)). If that's the case, simply use cmd as Admin instead.
+
+### Enter API Credentials
+
+This step will need to be done each time you clear your browser cache. You will be automatically redirected to a screen to enter these credentials
+if the app can't load them from local storage when it starts.
+
+1. Open your browser and navigate to [https://localhost:8080][]
 1. Copy your API-key, Oauth Client_id, and OAuth client_secret from bungie.net into DIM developer settings panel when it is loaded.
 
+### Development
+
+**Overview**
+
+The `yarn start` step will create a hot-loading webserver, and a TLS cert/key pair. You will access your local development site by visiting [https://localhost:8080][].
+You will likely get a security warning about the certificate not being trusted. This is because it's a self-signed cert generated dynamically for your environment,
+and is not signed by a recognized autority. Dismass/advance past these warning to view your local DIM application.
+
+**Check code Style**
+
+* `yarn lint` will tell you if you're following the DIM code style (and automatically fix what it can).
 Check out the [docs](https://github.com/DestinyItemManager/DIM/blob/master/docs) folder for more tips.

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,0 +1,29 @@
+# Docker Compose Quick Start
+
+Install Dependencies, and start webpack, with Docker
+
+1. [Pre-requisites](#pre-requisites)
+1. [Docker-compose up](#docker-compose-up)
+1. Refer to [Entering your API credentials in CONTRIBUTING.md](CONTRIBUTING.md#enter-api-credentials)
+
+### Pre-Requisites
+
+* Install Docker https://www.docker.com/get-started
+* Install docker-compose https://docs.docker.com/compose/install/
+* Follow the steps for getting an API key in [CONTIRBUTING.md](CONTRIBUTING.md#get-your-own-api-key)
+
+### Docker Compose Up
+
+Run the following commands from the DIM cloned directory on your machine:
+
+* `docker-compose up` to build the dist and start yarn watcher
+* It will take a while for the dist files to build on the first startup while yarn installs dependencies
+* `ctrl+c` to stop
+* `docker-compose up -d` to start in detached mode
+* `docker-compose stop` to stop detached mode
+* `docker-compose build` to re-build if the compose files change
+
+### Tips and How-To's
+
+- when using docker for your development platform, you will need to install new node dependencies from within a running container. This can be done by
+running `docker-compose exec yarn install nameofdependency webpack`


### PR DESCRIPTION
Doing some further cleanup and formatting of the contribution docs. With the latest updates, new contributors were going through the docker steps as if they were required. The docker setup steps also split the `yarn install` commands and the `yarn start` commands, which was causing some confusion as well.

I moved the Docker instructions into their own doc, giving those docs room to grow, and I added a bit more formatting with some ToC's for both docs.