### PR TITLE
remove host and port configs for devServer

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -65,9 +65,7 @@ module.exports = (env) => {
           https: {
             key: fs.readFileSync('key.pem'), // Private keys in PEM format.
             cert: fs.readFileSync('cert.pem') // Cert chains in PEM format.
-          },
-          host: '0.0.0.0',
-          port: '8080'
+          }
         }
       : {},
 


### PR DESCRIPTION
The new `0.0.0.0` bindings added in #3142 is breaking hot-reload server on some machines. Reverting this change.

This will cause the dockerized dev server to be unreachable until a reverse-proxy container can be placed in front of it to handle address translation.