### PR TITLE
darkened loadout drawer background, made getColor return opaque colors

### DIFF
--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -7,7 +7,7 @@
   backface-visibility: hidden;
   z-index: 3;
   bottom: 0;
-  background: #434444;
+  background: #222222;
   color: #e0e0e0;
   box-shadow: 0 -1px 6px 0px #222;
   padding-bottom: constant(safe-area-inset-bottom);

--- a/src/app/shell/dimAngularFilters.filter.ts
+++ b/src/app/shell/dimAngularFilters.filter.ts
@@ -272,7 +272,7 @@ export function getColor(value: number, property = 'background-color') {
     color = 190;
   }
   const result = {};
-  result[property] = `hsla(${color},65%,50%, .85)`;
+  result[property] = `hsla(${color},65%,50%, 1)`;
   return result;
 }
 


### PR DESCRIPTION
This adds more contrast to the comparisons panel by darkening it and removing opacity from the text coloring. It addresses #3167