### PR TITLE
Remove usage of Angular helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "components-font-awesome": "^4.7.0",
     "core-js": "^2.5.5",
     "fast-copy": "^1.2.2",
+    "fast-equals": "^1.6.1",
     "i18next": "^11.2.3",
     "i18next-xhr-backend": "^1.5.1",
     "idb-keyval": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "classnames": "^2.2.5",
     "components-font-awesome": "^4.7.0",
     "core-js": "^2.5.5",
+    "fast-copy": "^1.2.2",
     "i18next": "^11.2.3",
     "i18next-xhr-backend": "^1.5.1",
     "idb-keyval": "^2.3.0",

--- a/src/app/d2-vendors/vendor-item.ts
+++ b/src/app/d2-vendors/vendor-item.ts
@@ -13,7 +13,6 @@ import {
   DestinyObjectiveProgress
 } from 'bungie-api-ts/destiny2';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
-import { equals } from 'angular';
 import { makeItem } from '../inventory/store/d2-item-factory.service';
 import { D2ReviewDataCache } from '../destinyTrackerApi/d2-reviewDataCache';
 import { D2Item } from '../inventory/item-types';
@@ -345,8 +344,7 @@ export class VendorItem {
       this.vendorItemDef === other.vendorItemDef &&
       this.canPurchase === other.canPurchase &&
       this.rating === other.rating &&
-      // Deep equals
-      equals(this.saleItem, other.saleItem)
+      this.saleItem === other.saleItem
     );
   }
 

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -1,4 +1,4 @@
-import { copy } from 'angular';
+import copy from 'fast-copy';
 import { settings } from '../settings/settings';
 import * as _ from 'underscore';
 import { sum } from '../util';

--- a/src/app/infuse/infuse.component.ts
+++ b/src/app/infuse/infuse.component.ts
@@ -1,4 +1,4 @@
-import { extend, IComponentOptions, IController, IQService } from 'angular';
+import { IComponentOptions, IController, IQService } from 'angular';
 import copy from 'fast-copy';
 import * as _ from 'underscore';
 import { flatMap } from '../util';
@@ -34,7 +34,7 @@ function InfuseCtrl(
 
   const vm = this;
 
-  extend(vm, {
+  Object.assign(vm, {
     items: {},
     getAllItems: true,
     showLockedItems: false,

--- a/src/app/infuse/infuse.component.ts
+++ b/src/app/infuse/infuse.component.ts
@@ -1,4 +1,5 @@
-import { extend, copy, IComponentOptions, IController, IQService } from 'angular';
+import { extend, IComponentOptions, IController, IQService } from 'angular';
+import copy from 'fast-copy';
 import * as _ from 'underscore';
 import { flatMap } from '../util';
 import { getDefinitions } from '../destiny1/d1-definitions.service';

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -1,4 +1,3 @@
-import { extend } from 'angular';
 import * as _ from 'underscore';
 import { reportException } from '../exceptions';
 import { SyncService } from '../storage/sync.service';
@@ -47,29 +46,27 @@ export class ItemInfoSource {
     const itemKey = `${hash}-${id}`;
     const info = this.infos[itemKey];
     const accountKey = this.key;
-    return extend(
-      {
-        save() {
-          return getInfos(accountKey).then((infos) => {
-            infos[itemKey] = _.omit(this, 'save');
-            if (_.isEmpty(infos[itemKey])) {
-              delete infos[itemKey];
-            }
-            store.dispatch(setTagsAndNotesForItem({ key: itemKey, info: infos[itemKey] }));
-            setInfos(accountKey, infos).catch((e) => {
-              toaster.pop(
-                'error',
-                t('ItemInfoService.SaveInfoErrorTitle'),
-                t('ItemInfoService.SaveInfoErrorDescription', { error: e.message })
-              );
-              console.error('Error saving item info (tags, notes):', e);
-              reportException('itemInfo', e);
-            });
+    return {
+      ...info,
+      save() {
+        return getInfos(accountKey).then((infos) => {
+          infos[itemKey] = _.omit(this, 'save');
+          if (_.isEmpty(infos[itemKey])) {
+            delete infos[itemKey];
+          }
+          store.dispatch(setTagsAndNotesForItem({ key: itemKey, info: infos[itemKey] }));
+          setInfos(accountKey, infos).catch((e) => {
+            toaster.pop(
+              'error',
+              t('ItemInfoService.SaveInfoErrorTitle'),
+              t('ItemInfoService.SaveInfoErrorDescription', { error: e.message })
+            );
+            console.error('Error saving item info (tags, notes):', e);
+            reportException('itemInfo', e);
           });
-        }
-      },
-      info
-    );
+        });
+      }
+    };
   }
 
   // Remove all item info that isn't in stores' items

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -1,4 +1,5 @@
-import { copy as angularCopy, IPromise } from 'angular';
+import { IPromise } from 'angular';
+import copy from 'fast-copy';
 import * as _ from 'underscore';
 import { DimError } from '../bungie-api/bungie-service-helper';
 import {
@@ -20,6 +21,7 @@ import { D1StoresService } from './d1-stores.service';
 import { D2StoresService } from './d2-stores.service';
 import { t } from 'i18next';
 import { $q } from 'ngimport';
+import { shallowCopy } from '../util';
 
 /**
  * You can reserve a number of each type of item in each store.
@@ -191,7 +193,7 @@ function ItemService(): ItemServiceType {
           // amount. This is because we've switched to bind-once for
           // the amount since it rarely changes.
           source.removeItem(sourceItem);
-          sourceItem = angularCopy(sourceItem);
+          sourceItem = copy(sourceItem);
           sourceItem.amount -= amountToRemove;
           sourceItem.index = createItemIndex(sourceItem);
           source.addItem(sourceItem);
@@ -208,7 +210,7 @@ function ItemService(): ItemServiceType {
         if (!targetItem) {
           targetItem = item;
           if (!removedSourceItem) {
-            targetItem = angularCopy(item);
+            targetItem = copy(item);
             targetItem.index = createItemIndex(targetItem);
           }
           removedSourceItem = false; // only move without cloning once
@@ -226,7 +228,7 @@ function ItemService(): ItemServiceType {
         // because we've switched to bind-once for the amount since it
         // rarely changes.
         target.removeItem(targetItem);
-        targetItem = angularCopy(targetItem);
+        targetItem = shallowCopy(targetItem);
         targetItem.amount += amountToAdd;
         targetItem.index = createItemIndex(targetItem);
         target.addItem(targetItem);

--- a/src/app/inventory/store/d1-store-factory.service.ts
+++ b/src/app/inventory/store/d1-store-factory.service.ts
@@ -2,7 +2,7 @@ import * as _ from 'underscore';
 import { sum, count } from '../../util';
 import { getCharacterStatsData, getClass } from './character-utils';
 import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions.service';
-import { copy as angularCopy } from 'angular';
+import copy from 'fast-copy';
 import { t } from 'i18next';
 // tslint:disable-next-line:no-implicit-dependencies
 import vaultIcon from 'app/images/vault.png';
@@ -130,10 +130,7 @@ const StoreProto = {
 
   // Create a loadout from this store's equipped items
   loadoutFromCurrentlyEquipped(this: D1Store, name: string) {
-    const allItems = this.items
-      .filter((item) => item.canBeInLoadout())
-      // tslint:disable-next-line:no-unnecessary-callback-wrapper
-      .map((item) => angularCopy(item));
+    const allItems = this.items.filter((item) => item.canBeInLoadout()).map(copy);
     return newLoadout(name, _.groupBy(allItems, (i) => i.type.toLowerCase()));
   },
 

--- a/src/app/inventory/store/d1-store-factory.service.ts
+++ b/src/app/inventory/store/d1-store-factory.service.ts
@@ -130,7 +130,8 @@ const StoreProto = {
 
   // Create a loadout from this store's equipped items
   loadoutFromCurrentlyEquipped(this: D1Store, name: string) {
-    const allItems = this.items.filter((item) => item.canBeInLoadout()).map(copy);
+    // tslint:disable-next-line:no-unnecessary-callback-wrapper
+    const allItems = this.items.filter((item) => item.canBeInLoadout()).map((item) => copy(item));
     return newLoadout(name, _.groupBy(allItems, (i) => i.type.toLowerCase()));
   },
 

--- a/src/app/inventory/store/d2-store-factory.service.ts
+++ b/src/app/inventory/store/d2-store-factory.service.ts
@@ -123,7 +123,10 @@ const StoreProto = {
 
   // Create a loadout from this store's equipped items
   loadoutFromCurrentlyEquipped(this: D2Store, name: string): Loadout {
-    const allItems = (this.items as D2Item[]).filter((item) => item.canBeInLoadout()).map(copy);
+    const allItems = (this.items as D2Item[])
+      .filter((item) => item.canBeInLoadout())
+      // tslint:disable-next-line:no-unnecessary-callback-wrapper
+      .map((item) => copy(item));
     return newLoadout(name, _.groupBy(allItems, (i) => i.type.toLowerCase()));
   },
 

--- a/src/app/inventory/store/d2-store-factory.service.ts
+++ b/src/app/inventory/store/d2-store-factory.service.ts
@@ -1,4 +1,4 @@
-import { copy as angularCopy } from 'angular';
+import copy from 'fast-copy';
 import {
   DestinyCharacterComponent,
   DestinyItemComponent,
@@ -123,10 +123,7 @@ const StoreProto = {
 
   // Create a loadout from this store's equipped items
   loadoutFromCurrentlyEquipped(this: D2Store, name: string): Loadout {
-    const allItems = (this.items as D2Item[])
-      .filter((item) => item.canBeInLoadout())
-      // tslint:disable-next-line:no-unnecessary-callback-wrapper
-      .map((item) => angularCopy(item));
+    const allItems = (this.items as D2Item[]).filter((item) => item.canBeInLoadout()).map(copy);
     return newLoadout(name, _.groupBy(allItems, (i) => i.type.toLowerCase()));
   },
 

--- a/src/app/loadout-builder/loadout-builder-item.component.ts
+++ b/src/app/loadout-builder/loadout-builder-item.component.ts
@@ -2,7 +2,7 @@ import * as _ from 'underscore';
 import { sum, flatMap } from '../util';
 import template from './loadout-builder-item.html';
 import dialogTemplate from './loadout-builder-item-dialog.html';
-import { extend, IController } from 'angular';
+import { IController } from 'angular';
 import { DimItem } from '../inventory/item-types';
 import { D1StoresService } from '../inventory/d1-stores.service';
 
@@ -29,7 +29,7 @@ function LoadoutBuilderItemCtrl(
   const vm = this;
   let dialogResult: any = null;
 
-  extend(vm, {
+  Object.assign(vm, {
     itemClicked(item: DimItem, e) {
       e.stopPropagation();
 
@@ -53,12 +53,12 @@ function LoadoutBuilderItemCtrl(
           overlay: false,
           className: 'move-popup-dialog vendor-move-popup',
           showClose: false,
-          scope: extend($scope.$new(true), {}),
+          scope: $scope.$new(true),
           data: itemElement,
           controllerAs: 'vm',
           controller() {
             const vm = this;
-            extend(vm, {
+            Object.assign(vm, {
               item,
               compareItems,
               compareItem: _.first(compareItems),

--- a/src/app/loadout-builder/loadout-builder-locks.component.ts
+++ b/src/app/loadout-builder/loadout-builder-locks.component.ts
@@ -1,4 +1,4 @@
-import { IComponentOptions, extend } from 'angular';
+import { IComponentOptions } from 'angular';
 import * as _ from 'underscore';
 import template from './loadout-builder-locks.html';
 import dialogTemplate from './loadout-builder-locks-dialog.html';
@@ -26,7 +26,7 @@ function LoadoutBuilderLocksCtrl($scope, ngDialog) {
   const vm = this;
   let dialogResult: any = null;
 
-  extend(vm, {
+  Object.assign(vm, {
     getFirstPerk(lockedPerks, type) {
       return lockedPerks[type][_.keys(lockedPerks[type])[0]];
     },
@@ -45,7 +45,7 @@ function LoadoutBuilderLocksCtrl($scope, ngDialog) {
         className: 'perk-select-popup',
         showClose: false,
         appendTo: `#locked-perks-${type}`,
-        scope: extend($scope.$new(true), {}),
+        scope: $scope.$new(true),
         controllerAs: 'vmd',
         controller($document, $scope) {
           'ngInject';
@@ -75,7 +75,7 @@ function LoadoutBuilderLocksCtrl($scope, ngDialog) {
             $document.off('keyup', keydown);
           });
 
-          extend(vmd, {
+          Object.assign(vmd, {
             perks,
             lockedPerks,
             shiftHeld: false,

--- a/src/app/loadout-builder/loadout-builder.component.ts
+++ b/src/app/loadout-builder/loadout-builder.component.ts
@@ -9,7 +9,7 @@ import disciplineIcon from 'app/images/discipline.png';
 import strengthIcon from 'app/images/strength.png';
 import { getBonus } from '../inventory/store/character-utils';
 import { getDefinitions } from '../destiny1/d1-definitions.service';
-import { IComponentOptions, IController, IScope, ITimeoutService, extend } from 'angular';
+import { IComponentOptions, IController, IScope, ITimeoutService } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { Loadout, dimLoadoutService } from '../loadout/loadout.service';
 import { sum } from '../util';
@@ -520,7 +520,7 @@ function LoadoutBuilderController(
   }
 
   getDefinitions().then((defs) => {
-    extend(vm, {
+    Object.assign(vm, {
       active: 'titan',
       i18nClassNames: _.object(
         ['titan', 'hunter', 'warlock'],

--- a/src/app/loadout-builder/loadout-builder.component.ts
+++ b/src/app/loadout-builder/loadout-builder.component.ts
@@ -1,4 +1,5 @@
 import * as _ from 'underscore';
+import copy from 'fast-copy';
 import template from './loadout-builder.html';
 // tslint:disable-next-line:no-implicit-dependencies
 import intellectIcon from 'app/images/intellect.png';
@@ -8,7 +9,7 @@ import disciplineIcon from 'app/images/discipline.png';
 import strengthIcon from 'app/images/strength.png';
 import { getBonus } from '../inventory/store/character-utils';
 import { getDefinitions } from '../destiny1/d1-definitions.service';
-import { IComponentOptions, IController, IScope, ITimeoutService, extend, copy } from 'angular';
+import { IComponentOptions, IController, IScope, ITimeoutService, extend } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { Loadout, dimLoadoutService } from '../loadout/loadout.service';
 import { sum } from '../util';

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -6,7 +6,7 @@ import { dimLoadoutService, Loadout } from './loadout.service';
 import * as _ from 'underscore';
 import { $rootScope } from 'ngimport';
 import { sortItems } from '../shell/dimAngularFilters.filter';
-import { copy } from 'angular';
+import copy from 'fast-copy';
 import { flatMap } from '../util';
 import { getDefinitions as getD1Definitions } from '../destiny1/d1-definitions.service';
 import { getDefinitions as getD2Definitions } from '../destiny2/d2-definitions.service';

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { copy as angularCopy } from 'angular';
 import { t } from 'i18next';
 import './loadout-popup.scss';
 import { DimStore } from '../inventory/store-types';
@@ -31,6 +30,7 @@ import { getPlatformMatching } from '../accounts/platform.service';
 import { router } from '../../router';
 // tslint:disable-next-line:no-implicit-dependencies
 import engramSvg from '../../images/engram.svg';
+import copy from 'fast-copy';
 
 interface ProvidedProps {
   dimStore: DimStore;
@@ -385,7 +385,7 @@ class LoadoutPopup extends React.Component<Props> {
 export default connect<StoreProps>(mapStateToProps)(LoadoutPopup);
 
 function filterLoadoutToEquipped(loadout: Loadout) {
-  const filteredLoadout = angularCopy(loadout);
+  const filteredLoadout = copy(loadout);
   filteredLoadout.items = _.mapObject(filteredLoadout.items, (items) =>
     items.filter((i) => i.equipped)
   );

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -1,4 +1,4 @@
-import { copy } from 'angular';
+import copy from 'fast-copy';
 import { t } from 'i18next';
 import * as _ from 'underscore';
 import { optimalLoadout, newLoadout } from './loadout-utils';

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -1,4 +1,4 @@
-import { copy } from 'angular';
+import copy from 'fast-copy';
 import * as _ from 'underscore';
 import { sum } from '../util';
 import { Loadout } from './loadout.service';

--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -1,4 +1,4 @@
-import { copy } from 'angular';
+import copy from 'fast-copy';
 import * as _ from 'underscore';
 import { queueAction } from '../inventory/action-queue';
 import { SyncService } from '../storage/sync.service';

--- a/src/app/record-books/record-books.component.ts
+++ b/src/app/record-books/record-books.component.ts
@@ -1,5 +1,5 @@
 import * as _ from 'underscore';
-import { extend, IComponentOptions, IController, IScope } from 'angular';
+import { IComponentOptions, IController, IScope } from 'angular';
 import { sum, count } from '../util';
 import { subscribeOnScope } from '../rx-utils';
 import { settings } from '../settings/settings';
@@ -123,10 +123,10 @@ function RecordBooksController(
     // TODO: show rewards
 
     if (rawRecordBook.progression) {
-      rawRecordBook.progression = extend(
-        rawRecordBook.progression,
-        defs.Progression.get(rawRecordBook.progression.progressionHash)
-      );
+      rawRecordBook.progression = {
+        ...rawRecordBook.progression,
+        ...defs.Progression.get(rawRecordBook.progression.progressionHash)
+      };
       rawRecordBook.progress = rawRecordBook.progression;
       rawRecordBook.percentComplete =
         rawRecordBook.progress.currentProgress /

--- a/src/app/storage/sync.service.ts
+++ b/src/app/storage/sync.service.ts
@@ -1,5 +1,6 @@
-import { equals, extend } from 'angular';
+import { extend } from 'angular';
 import copy from 'fast-copy';
+import { deepEqual } from 'fast-equals';
 import * as _ from 'underscore';
 import { reportException } from '../exceptions';
 import { IndexedDBStorage } from './indexed-db-storage';
@@ -95,7 +96,7 @@ export const SyncService = {
       throw new Error('Must call get at least once before setting');
     }
 
-    if (!PUT && equals(_.pick(cached, Object.keys(value)), value)) {
+    if (!PUT && deepEqual(_.pick(cached, Object.keys(value)), value)) {
       if ($featureFlags.debugSync) {
         console.log(_.pick(cached, Object.keys(value)), value);
         console.log('Skip save, already got it');

--- a/src/app/storage/sync.service.ts
+++ b/src/app/storage/sync.service.ts
@@ -1,4 +1,3 @@
-import { extend } from 'angular';
 import copy from 'fast-copy';
 import { deepEqual } from 'fast-equals';
 import * as _ from 'underscore';
@@ -109,7 +108,7 @@ export const SyncService = {
       // update our data
       cached = copy(value) as DimData;
     } else {
-      extend(cached, copy(value));
+      Object.assign(cached, copy(value));
     }
 
     for (const adapter of adapters) {

--- a/src/app/storage/sync.service.ts
+++ b/src/app/storage/sync.service.ts
@@ -1,4 +1,5 @@
-import { equals, copy, extend } from 'angular';
+import { equals, extend } from 'angular';
+import copy from 'fast-copy';
 import * as _ from 'underscore';
 import { reportException } from '../exceptions';
 import { IndexedDBStorage } from './indexed-db-storage';

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -49,3 +49,8 @@ export function flatMap<T, TResult>(list: T[], fx: _.ListIterator<T, TResult[]>)
 export function compact<T>(arr: (T | false | undefined | 0 | '' | null)[]): T[] {
   return arr.filter(Boolean) as T[];
 }
+
+/** A shallow copy (just top level properties) of an object, preserving its prototype. */
+export function shallowCopy<T>(o: T): T {
+  return Object.assign(Object.create(Object.getPrototypeOf(o)), o);
+}

--- a/src/app/vendors/vendor-item.component.ts
+++ b/src/app/vendors/vendor-item.component.ts
@@ -1,4 +1,4 @@
-import { IComponentOptions, IController, extend } from 'angular';
+import { IComponentOptions, IController } from 'angular';
 import * as _ from 'underscore';
 import { sum, flatMap } from '../util';
 import template from './vendor-item.html';
@@ -54,11 +54,11 @@ function VendorItemCtrl(this: IController, $scope, $element, ngDialog) {
         overlay: false,
         className: `move-popup-dialog vendor-move-popup ${vm.extraMovePopupClass || ''}`,
         showClose: false,
-        scope: extend($scope.$new(true), {}),
+        scope: $scope.$new(true),
         data: itemElement, // Dialog anchor
         controllerAs: 'vm',
         controller() {
-          extend(this, {
+          Object.assign(this, {
             settings: this.settings,
             item,
             saleItem: vm.saleItem,

--- a/src/app/vendors/vendor.service.ts
+++ b/src/app/vendors/vendor.service.ts
@@ -7,7 +7,8 @@ import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.ser
 import { getVendorForCharacter } from '../bungie-api/destiny1-api';
 import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 import { processItems } from '../inventory/store/d1-item-factory.service';
-import { IPromise, copy } from 'angular';
+import { IPromise } from 'angular';
+import copy from 'fast-copy';
 import { D1Store } from '../inventory/store-types';
 import { Observable } from 'rxjs/Observable';
 import { D1Item } from '../inventory/item-types';

--- a/src/app/whats-new/BungieAlerts.tsx
+++ b/src/app/whats-new/BungieAlerts.tsx
@@ -1,4 +1,3 @@
-import { equals } from 'angular';
 import { t } from 'i18next';
 import * as React from 'react';
 import { Observable } from 'rxjs/Observable';
@@ -6,6 +5,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { getGlobalAlerts, GlobalAlert } from '../bungie-api/bungie-core-api';
 import '../rx-operators';
 import './BungieAlerts.scss';
+import { deepEqual } from 'fast-equals';
 
 export const alerts$ = Observable.timer(0, 10 * 60 * 1000)
   // Fetch global alerts, but swallow errors
@@ -14,7 +14,7 @@ export const alerts$ = Observable.timer(0, 10 * 60 * 1000)
   )
   .startWith([] as GlobalAlert[])
   // Deep equals
-  .distinctUntilChanged<GlobalAlert[]>(equals)
+  .distinctUntilChanged<GlobalAlert[]>(deepEqual)
   .shareReplay();
 
 interface State {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2704,6 +2704,10 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
+fast-equals@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-1.6.1.tgz#66cc5a0922ea747599f41aedf44a76ec2908adc0"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,10 +387,6 @@ angular-hotkeys@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/angular-hotkeys/-/angular-hotkeys-1.7.0.tgz#052e6b6f44dfcd824427798b7f10e1917e8700a1"
 
-angular-messages@^1.6.9:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/angular-messages/-/angular-messages-1.7.4.tgz#845c3e3dce80ca698ba62bcf70105ab76cfdbb50"
-
 "angular-native-dragdrop@github:DestinyItemManager/angular-dragdrop":
   version "1.2.2"
   resolved "https://codeload.github.com/DestinyItemManager/angular-dragdrop/tar.gz/0a8770f97abf290617fac366db63c85d081e2cbf"
@@ -2695,6 +2691,10 @@ extsprintf@1.3.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
+fast-copy@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-1.2.2.tgz#b15cf14d767f07c22cd5ffbd6cc615c12d206b7e"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This removes all usage of the AngularJS `equals`, `copy`, and `extend` helpers. I'm using some nice optimized libraries for deep equals and copy, and in one case started using my own new `shallowCopy` helper.