### PR TITLE
change docker network_mode to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,12 @@ services:
   webpack:
     container_name: dim-webpack
     image: node:10.9.0
-    ports:
-      - '8080:8080'
+    expose:
+      - '8080'
     command: bash -c 'yarn install && yarn start'
     environment:
       - NODE_ENV=dev
-    restart: always
+    restart: 'no'
+    network_mode: host
     volumes:
       - .:/usr/src/app


### PR DESCRIPTION
Corrects the traffic directed to the dockerized dim app. When using
`ports` to map host to container, the traffic is sent to the containers
overlay network interface instead of the container's loopback interface.

Webpack-dev-server listens to localhost, which is bound to the
the loopback interface of the container.

By changing the network_mode to host, we bind the container's network
interfaces to the hosts interfaces, making ports exposed by the container
accessible accodig to the hosts network without needing to map ports.

This bug was introduced in the revert request #3155