### PR TITLE
"or" filters in search

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix mods/perks on items - there was a bug that affected both display and searches.
 * Fix is:hasmod search to include some more mods.
 * You can now drag items into the loadout drawer.
+* Filters can now be combined with "or" to match either filter. For example: "is:shotgun or is:handcannon".
 
 # 4.72.0 (2018-09-30)
 

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -465,21 +465,42 @@ export function searchFilters(
       // [^\s]*?'[^']+?' -> match is:'stuff here'
       // [^\s"']+' -> match is:stuff
       const searchTerms = query.match(/[^\s]*?"[^"]+?"|[^\s]*?'[^']+?'|[^\s"']+/g) || [];
-      const filters: {
+      interface Filter {
         invert: boolean;
         value: string;
         predicate: string;
-      }[] = [];
+        orFilters?: Filter[];
+      }
+      const filters: Filter[] = [];
+
+      // The entire implementation of "or" is a dirty hack - we should really
+      // build an expression tree instead. But here, we flip a flag when we see
+      // an "or" token, and then on the next filter we instead combine the filter
+      // with the previous one in a hacked-up "or" node that we'll handle specially.
+      let or = false;
 
       function addPredicate(predicate: string, filter: string, invert = false) {
-        filters.push({ predicate, value: filter, invert });
+        const filterDef: Filter = { predicate, value: filter, invert };
+        if (or && filters.length) {
+          const lastFilter = filters.pop();
+          filters.push({
+            predicate: 'or',
+            invert: false,
+            value: '',
+            orFilters: [...(lastFilter!.orFilters! || [lastFilter])!, filterDef]
+          });
+        } else {
+          filters.push(filterDef);
+        }
+        or = false;
       }
 
-      // TODO: replace this if-ladder with a split and check
       for (let term of searchTerms) {
         term = term.replace(/['"]/g, '');
 
-        if (term.startsWith('is:')) {
+        if (term === 'or') {
+          or = true;
+        } else if (term.startsWith('is:')) {
           const filter = term.replace('is:', '');
           const predicate = searchConfig.keywordToFilter[filter];
           if (predicate) {
@@ -532,10 +553,21 @@ export function searchFilters(
 
       _sortedStores = null;
 
-      return (item) => {
+      return (item: DimItem) => {
         return filters.every((filter) => {
-          const result =
-            this.filters[filter.predicate] && this.filters[filter.predicate](item, filter.value);
+          let result;
+          if (filter.orFilters) {
+            result = filter.orFilters.some((filter) => {
+              const result =
+                this.filters[filter.predicate] &&
+                this.filters[filter.predicate](item, filter.value);
+
+              return filter.invert ? !result : result;
+            });
+          } else {
+            result =
+              this.filters[filter.predicate] && this.filters[filter.predicate](item, filter.value);
+          }
           return filter.invert ? !result : result;
         });
       };

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -461,10 +461,10 @@ export function searchFilters(
       }
 
       // could probably tidy this regex, just a quick hack to support multi term:
-      // [^\s]*"[^"]*" -> match is:"stuff here"
-      // [^\s]*'[^']*' -> match is:'stuff here'
+      // [^\s]*?"[^"]+?" -> match is:"stuff here"
+      // [^\s]*?'[^']+?' -> match is:'stuff here'
       // [^\s"']+' -> match is:stuff
-      const searchTerms = query.match(/[^\s]*"[^"]*"|[^\s]*'[^']*'|[^\s"']+/g) || [];
+      const searchTerms = query.match(/[^\s]*?"[^"]+?"|[^\s]*?'[^']+?'|[^\s"']+/g) || [];
       const filters: {
         invert: boolean;
         value: string;


### PR DESCRIPTION
I was fixing #3177, when I suddenly realized there was an easy way to do "or" filters. So here they are!

This video shows me searching for all my handcannons, shotguns, and autorifles, and then filtering them all by rating. @philkernick is gonna love this I'm sure.

![orsearch](https://user-images.githubusercontent.com/313208/46576963-9b6d3f80-c98d-11e8-92c6-c60639992968.gif)
