### PR TITLE
Ratings/tags in Loadout Builder, plus visual tweaks

### DIFF
--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -42,7 +42,7 @@ export default function GeneratedSetButtons({
       <button className="dim-button equip-button" onClick={equipItems}>
         {t('LoadoutBuilder.EquipItems', { name: store.name })}
       </button>
-      {t('LoadoutBuilder.ArmorPower', { power: set.power / 5 })}
+      <span className="light">{set.power / set.armor.length}</span>
     </div>
   );
 }

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -2,7 +2,7 @@ import { t } from 'i18next';
 import * as React from 'react';
 import * as _ from 'underscore';
 import { DimStore } from '../../inventory/store-types';
-import { dimLoadoutService, Loadout } from '../../loadout/loadout.service';
+import { dimLoadoutService, Loadout, LoadoutClass } from '../../loadout/loadout.service';
 import { ArmorSet } from '../types';
 import { newLoadout } from '../../loadout/loadout-utils';
 
@@ -50,7 +50,7 @@ export default function GeneratedSetButtons({
 /**
  * Create a Loadout object, used for equipping or creating a new saved loadout
  */
-function createLoadout(classType: string, set: ArmorSet): Loadout {
+function createLoadout(classType: DimStore['class'], set: ArmorSet): Loadout {
   const loadout = newLoadout(t('Loadouts.AppliedAuto'), {
     helmet: [set.armor[0]],
     gauntlets: [set.armor[1]],
@@ -58,6 +58,6 @@ function createLoadout(classType: string, set: ArmorSet): Loadout {
     leg: [set.armor[3]],
     classitem: [set.armor[4]]
   });
-  loadout.classType = { warlock: 0, titan: 1, hunter: 2 }[classType];
+  loadout.classType = LoadoutClass[classType];
   return loadout;
 }

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { D2Item } from '../../inventory/item-types';
+import { filterPlugs } from './utils';
+import PressTip from '../../dim-ui/PressTip';
+import PlugTooltip from './PlugTooltip';
+import BungieImage from '../../dim-ui/BungieImage';
+import ConnectedInventoryItem from '../../inventory/ConnectedInventoryItem';
+
+export default function GeneratedSetItem({ item }: { item: D2Item }) {
+  return (
+    <div className="generated-build-items">
+      <ConnectedInventoryItem item={item} />
+      {item!.sockets &&
+        item!.sockets!.categories.length === 2 &&
+        // TODO: look at plugs that we filtered on to see if they match selected perk or not.
+        item!.sockets!.categories[0].sockets.filter(filterPlugs).map((socket) => (
+          <PressTip
+            key={socket!.plug!.plugItem.hash}
+            tooltip={<PlugTooltip item={item} socket={socket} />}
+          >
+            <div>
+              <BungieImage
+                className="item-mod"
+                src={socket!.plug!.plugItem.displayProperties.icon}
+              />
+            </div>
+          </PressTip>
+        ))}
+    </div>
+  );
+}

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -5,11 +5,17 @@ import PressTip from '../../dim-ui/PressTip';
 import PlugTooltip from './PlugTooltip';
 import BungieImage from '../../dim-ui/BungieImage';
 import ConnectedInventoryItem from '../../inventory/ConnectedInventoryItem';
+import DraggableInventoryItem from '../../inventory/DraggableInventoryItem';
+import ItemPopupTrigger from '../../inventory/ItemPopupTrigger';
 
 export default function GeneratedSetItem({ item }: { item: D2Item }) {
   return (
     <div className="generated-build-items">
-      <ConnectedInventoryItem item={item} />
+      <DraggableInventoryItem item={item}>
+        <ItemPopupTrigger item={item}>
+          <ConnectedInventoryItem item={item} />
+        </ItemPopupTrigger>
+      </DraggableInventoryItem>
       {item!.sockets &&
         item!.sockets!.categories.length === 2 &&
         // TODO: look at plugs that we filtered on to see if they match selected perk or not.

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -8,7 +8,7 @@ import GeneratedSetButtons from './GeneratedSetButtons';
 import { DimStore } from '../../inventory/store-types';
 import LoadoutDrawer from '../../loadout/LoadoutDrawer';
 import { $rootScope } from 'ngimport';
-import GeneratedSet from './GeneratedSet';
+import GeneratedSetItem from './GeneratedSetItem';
 
 interface Props {
   processRunning: number;
@@ -123,7 +123,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
             />
             <div className="sub-bucket">
               {Object.values(set.armor).map((item) => (
-                <GeneratedSet key={item.index} item={item} />
+                <GeneratedSetItem key={item.index} item={item} />
               ))}
             </div>
           </div>

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,17 +1,14 @@
 import { t } from 'i18next';
 import * as React from 'react';
 import * as _ from 'underscore';
-import BungieImage from '../../dim-ui/BungieImage';
-import PressTip from '../../dim-ui/PressTip';
-import StoreInventoryItem from '../../inventory/StoreInventoryItem';
 import { Loadout } from '../../loadout/loadout.service';
 import { ArmorSet, LockType } from '../types';
-import { filterPlugs, getSetsForTier, getSetTiers } from './utils';
+import { getSetsForTier, getSetTiers } from './utils';
 import GeneratedSetButtons from './GeneratedSetButtons';
-import PlugTooltip from './PlugTooltip';
 import { DimStore } from '../../inventory/store-types';
 import LoadoutDrawer from '../../loadout/LoadoutDrawer';
 import { $rootScope } from 'ngimport';
+import GeneratedSet from './GeneratedSet';
 
 interface Props {
   processRunning: number;
@@ -126,25 +123,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
             />
             <div className="sub-bucket">
               {Object.values(set.armor).map((item) => (
-                <div className="generated-build-items" key={item.index}>
-                  <StoreInventoryItem item={item} isNew={false} searchHidden={false} />
-                  {item!.sockets &&
-                    item!.sockets!.categories.length === 2 &&
-                    // TODO: look at plugs that we filtered on to see if they match selected perk or not.
-                    item!.sockets!.categories[0].sockets.filter(filterPlugs).map((socket) => (
-                      <PressTip
-                        key={socket!.plug!.plugItem.hash}
-                        tooltip={<PlugTooltip item={item} socket={socket} />}
-                      >
-                        <div>
-                          <BungieImage
-                            className="item-mod"
-                            src={socket!.plug!.plugItem.displayProperties.icon}
-                          />
-                        </div>
-                      </PressTip>
-                    ))}
-                </div>
+                <GeneratedSet key={item.index} item={item} />
               ))}
             </div>
           </div>

--- a/src/app/d2-loadout-builder/loadoutbuilder.scss
+++ b/src/app/d2-loadout-builder/loadoutbuilder.scss
@@ -12,6 +12,9 @@
 
   .generated-build-buttons {
     padding-bottom: 5px;
+    > * {
+      margin-right: 4px;
+    }
   }
   .generated-build-items {
     display: flex;

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { DimItem } from './item-types';
 import './dimStoreBucket.scss';
-import StoreInventoryItem from './StoreInventoryItem';
 import { InventoryState } from './reducer';
 import { ReviewsState } from '../item-review/reducer';
 import { TagValue } from './dim-item-info';
@@ -9,6 +8,7 @@ import { RootState } from '../store/reducers';
 import { connect } from 'react-redux';
 import { D1RatingData } from '../item-review/d1-dtr-api-types';
 import { D2RatingData } from '../item-review/d2-dtr-api-types';
+import InventoryItem from './InventoryItem';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -54,14 +54,7 @@ class ConnectedInventoryItem extends React.Component<Props> {
     const { item, isNew, tag, rating, hideRating } = this.props;
 
     return (
-      <StoreInventoryItem
-        key={item.index}
-        item={item}
-        isNew={isNew}
-        tag={tag}
-        rating={rating}
-        hideRating={hideRating}
-      />
+      <InventoryItem item={item} isNew={isNew} tag={tag} rating={rating} hideRating={hideRating} />
     );
   }
 }

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { DimItem } from './item-types';
+import './dimStoreBucket.scss';
+import StoreInventoryItem from './StoreInventoryItem';
+import { InventoryState } from './reducer';
+import { ReviewsState } from '../item-review/reducer';
+import { TagValue } from './dim-item-info';
+import { RootState } from '../store/reducers';
+import { connect } from 'react-redux';
+import { D1RatingData } from '../item-review/d1-dtr-api-types';
+import { D2RatingData } from '../item-review/d2-dtr-api-types';
+
+// Props provided from parents
+interface ProvidedProps {
+  item: DimItem;
+}
+
+// Props from Redux via mapStateToProps
+interface StoreProps {
+  isNew: boolean;
+  tag?: TagValue;
+  rating?: number;
+  hideRating?: boolean;
+}
+
+function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
+  const { item } = props;
+
+  const settings = state.settings;
+
+  const dtrRating = getRating(item, state.reviews.ratings);
+  const showRating =
+    dtrRating &&
+    dtrRating.overallScore &&
+    (dtrRating.ratingCount > (item.destinyVersion === 2 ? 0 : 1) ||
+      dtrRating.highlightedRatingCount > 0);
+
+  return {
+    isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,
+    tag: getTag(item, state.inventory.itemInfos),
+    rating: dtrRating ? dtrRating.overallScore : undefined,
+    hideRating: !showRating
+  };
+}
+
+type Props = ProvidedProps & StoreProps;
+
+/**
+ * An item that can load its auxiliary state directly from Redux. Not suitable
+ * for showing a ton of items, but useful!
+ */
+class ConnectedInventoryItem extends React.Component<Props> {
+  render() {
+    const { item, isNew, tag, rating, hideRating } = this.props;
+
+    return (
+      <StoreInventoryItem
+        key={item.index}
+        item={item}
+        isNew={isNew}
+        tag={tag}
+        rating={rating}
+        hideRating={hideRating}
+      />
+    );
+  }
+}
+
+function getTag(item: DimItem, itemInfos: InventoryState['itemInfos']): TagValue | undefined {
+  const itemKey = `${item.hash}-${item.id}`;
+  return itemInfos[itemKey] && itemInfos[itemKey].tag;
+}
+
+function getRating(
+  item: DimItem,
+  ratings: ReviewsState['ratings']
+): D2RatingData | D1RatingData | undefined {
+  const roll = item.isDestiny1() ? (item.talentGrid ? item.talentGrid.dtrRoll : null) : 'fixed'; // TODO: implement random rolls
+  const itemKey = `${item.hash}-${roll}`;
+  return ratings[itemKey] && ratings[itemKey];
+}
+
+export default connect<StoreProps>(mapStateToProps)(ConnectedInventoryItem);

--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -5,6 +5,18 @@
   width: 100%;
 }
 
+.powerLevel,
+.light {
+  color: $gold;
+  &:before {
+    content: '\2726';
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 2px;
+    font-size: 50%;
+  }
+}
+
 .character-box {
   position: relative;
   border-bottom: 2px solid #888;
@@ -98,15 +110,6 @@
   }
   .level {
     margin-right: 1px;
-  }
-  .powerLevel {
-    color: $gold;
-    &:before {
-      content: '\2726';
-      display: inline-block;
-      vertical-align: 25%;
-      font-size: 50%;
-    }
   }
   .currencies {
     text-align: right;

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -15,7 +15,7 @@ interface Props {
   tag?: TagValue;
   rating?: number;
   hideRating?: boolean;
-  searchHidden: boolean;
+  searchHidden?: boolean;
 }
 
 /**

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -88,7 +88,7 @@ export interface DimStore {
   /** Power/light level. */
   powerLevel: number;
   /** String class name. */
-  class: 'titan' | 'warlock' | 'hunter';
+  class: 'titan' | 'warlock' | 'hunter' | 'vault';
   /** Integer class type. */
   classType: DestinyClass;
   /** Localized class name. */

--- a/src/app/loadout-builder/loadout-builder.component.ts
+++ b/src/app/loadout-builder/loadout-builder.component.ts
@@ -10,7 +10,7 @@ import { getBonus } from '../inventory/store/character-utils';
 import { getDefinitions } from '../destiny1/d1-definitions.service';
 import { IComponentOptions, IController, IScope, ITimeoutService, extend, copy } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
-import { Loadout, dimLoadoutService } from '../loadout/loadout.service';
+import { Loadout, dimLoadoutService, LoadoutClass } from '../loadout/loadout.service';
 import { sum } from '../util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { D1Item, D1GridNode } from '../inventory/item-types';
@@ -598,7 +598,10 @@ function LoadoutBuilderController(
       },
       onSelectedChange(prevIdx, selectedIdx) {
         if (vm.activeCharacters[prevIdx].class !== vm.activeCharacters[selectedIdx].class) {
-          vm.active = vm.activeCharacters[selectedIdx].class;
+          const classType = vm.activeCharacters[selectedIdx].class;
+          if (classType !== 'vault') {
+            vm.active = classType;
+          }
           vm.onCharacterChange();
           vm.selectedCharacter = selectedIdx;
         }
@@ -795,7 +798,7 @@ function LoadoutBuilderController(
       newLoadout(set) {
         ngDialog.closeAll();
         const loadout = newLoadout('', {});
-        loadout.classType = { warlock: 0, titan: 1, hunter: 2 }[vm.active];
+        loadout.classType = LoadoutClass[vm.active];
         const items = _.pick(
           set.armor,
           'Helmet',
@@ -819,7 +822,7 @@ function LoadoutBuilderController(
       equipItems(set) {
         ngDialog.closeAll();
         let loadout: Loadout = newLoadout($i18next.t('Loadouts.AppliedAuto'), {});
-        loadout.classType = { warlock: 0, titan: 1, hunter: 2 }[vm.active];
+        loadout.classType = LoadoutClass[vm.active];
         const items = _.pick(
           set.armor,
           'Helmet',

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -3,7 +3,7 @@ import { copy as angularCopy } from 'angular';
 import { t } from 'i18next';
 import './loadout-popup.scss';
 import { DimStore } from '../inventory/store-types';
-import { Loadout, getLight, dimLoadoutService } from './loadout.service';
+import { Loadout, getLight, dimLoadoutService, LoadoutClass } from './loadout.service';
 import { RootState } from '../store/reducers';
 import { previousLoadoutSelector, loadoutsSelector } from './reducer';
 import { currentAccountSelector } from '../accounts/reducer';
@@ -51,14 +51,7 @@ function mapStateToProps(state: RootState, ownProps: ProvidedProps): StoreProps 
   const currentAccount = currentAccountSelector(state)!;
   const { dimStore } = ownProps;
 
-  let classTypeId = {
-    warlock: 0,
-    titan: 1,
-    hunter: 2
-  }[dimStore.class];
-  if (classTypeId === undefined) {
-    classTypeId = -1;
-  }
+  const classTypeId = LoadoutClass[dimStore.class === 'vault' ? 'any' : dimStore.class];
 
   const loadoutsForPlatform = _.sortBy(loadouts, 'name').filter((loadout: Loadout) => {
     return (
@@ -66,7 +59,9 @@ function mapStateToProps(state: RootState, ownProps: ProvidedProps): StoreProps 
         ? loadout.destinyVersion === 2
         : loadout.destinyVersion !== 2) &&
       (loadout.platform === undefined || loadout.platform === currentAccount.platformLabel) &&
-      (classTypeId === -1 || loadout.classType === -1 || loadout.classType === classTypeId)
+      (classTypeId === LoadoutClass.any ||
+        loadout.classType === LoadoutClass.any ||
+        loadout.classType === classTypeId)
     );
   });
 

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -56,14 +56,7 @@
 
   .light {
     font-weight: 200;
-    color: $gold;
     float: right;
-    &:before {
-      content: '\2726';
-      display: inline-block;
-      vertical-align: 7%;
-      font-size: 50%;
-    }
   }
 }
 

--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -14,7 +14,7 @@ import { default as reduxStore } from '../store/store';
 import * as actions from './actions';
 import { loadoutsSelector } from './reducer';
 
-export const enum LoadoutClass {
+export enum LoadoutClass {
   any = -1,
   warlock = 0,
   titan = 1,


### PR DESCRIPTION
1. Add a new `ConnectedInventoryItem` component that pulls a bunch of info automatically from the Redux store. Use it whenever you want to display an item that has tags and ratings and all the other bells and whistles. This is (probably) too expensive for when you're showing a ton of items though.
2. Use that on the loadout builder.
3. Tweak the styles a bit to separate out buttons and also to show the "armor light" as a power level.
4. Use the LoadoutClass enum everywhere instead of copying around that same hash.

<img width="677" alt="screen shot 2018-10-07 at 5 17 31 pm" src="https://user-images.githubusercontent.com/313208/46588668-f61d9e80-ca54-11e8-8664-ce5016f40db8.png">
