### PR TITLE
Fix item count badge in loadout popup for postmaster

### DIFF
--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -167,7 +167,7 @@ class LoadoutPopup extends React.Component<Props> {
                   <li className="loadout-set">
                     <span onClick={this.pullFromPostmaster}>
                       <i className="fa fa-envelope" />
-                      <span className="badge" ng-bind="this.numPostmasterItems" />
+                      <span className="badge">{numPostmasterItems}</span>{' '}
                       <span>{t('Loadouts.PullFromPostmaster')}</span>
                     </span>
                     <span onClick={this.makeRoomForPostmaster}>{t('Loadouts.PullMakeSpace')}</span>


### PR DESCRIPTION
*Before:*
![image](https://user-images.githubusercontent.com/760143/46596899-aa88f480-cb29-11e8-871e-6e045f933e1d.png)

*After:*
![image](https://user-images.githubusercontent.com/760143/46596843-86c5ae80-cb29-11e8-83dd-6115f9b2b9bb.png)
