### PR TITLE
Fetching D2 ratings + reviews based on random rolls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added negative search. Prefix any search term with `-` and it will match the opposite.
 * Added `perk:"* **"` seach filter to match any keywords against perks on an item
 * Lock and unlock items matching your current search from the same menu you use for tagging them.
+* Added support for showing ratings and reviews based on the item roll in Destiny 2.
 
 # 4.73.0 (2018-10-07)
 

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -59,22 +59,17 @@ class D2BulkFetcher {
       arrayOfArrays.push(itemList.slice(i, i + size));
     }
 
-    const arrayOfPromises: Promise<D2ItemFetchResponse[]>[] = [];
-
-    for (const arraySlice of arrayOfArrays) {
-      arrayOfPromises.push(
-        dtrFetch(
-          `https://db-api.destinytracker.com/api/external/reviews/fetch?platform=${platformSelection}&mode=${mode}`,
-          arraySlice
-        ).then(handleD2Errors, handleD2Errors)
-      );
-    }
-
     const results: D2ItemFetchResponse[] = [];
 
-    for (const promiseStep of arrayOfPromises) {
-      loadingTracker.addPromise(promiseStep);
-      const result = await promiseStep;
+    for (const arraySlice of arrayOfArrays) {
+      const promiseSlice = dtrFetch(
+        `https://db-api.destinytracker.com/api/external/reviews/fetch?platform=${platformSelection}&mode=${mode}`,
+        arraySlice
+      ).then(handleD2Errors, handleD2Errors);
+
+      loadingTracker.addPromise(promiseSlice);
+
+      const result = await promiseSlice;
       results.push(...result);
     }
 

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -21,9 +21,9 @@ class D2BulkFetcher {
     stores: D2Store[],
     platformSelection: number,
     mode: number
-  ): Promise<D2ItemFetchResponse[]> {
+  ): Promise<D2ItemFetchResponse[][]> {
     if (!stores.length) {
-      return Promise.resolve<D2ItemFetchResponse[]>([]);
+      return Promise.resolve<D2ItemFetchResponse[][]>([]);
     }
 
     const itemList = getItemList(stores, this._reviewDataCache);
@@ -35,9 +35,9 @@ class D2BulkFetcher {
     mode: number,
     vendorSaleItems?: DestinyVendorSaleItemComponent[],
     vendorItems?: DestinyVendorItemDefinition[]
-  ): Promise<D2ItemFetchResponse[]> {
+  ): Promise<D2ItemFetchResponse[][]> {
     if ((vendorSaleItems && !vendorSaleItems.length) || (vendorItems && !vendorItems.length)) {
-      return Promise.resolve<D2ItemFetchResponse[]>([]);
+      return Promise.resolve<D2ItemFetchResponse[][]>([]);
     }
 
     const vendorDtrItems = getVendorItemList(this._reviewDataCache, vendorSaleItems, vendorItems);
@@ -48,19 +48,33 @@ class D2BulkFetcher {
     itemList: D2ItemFetchRequest[],
     platformSelection: number,
     mode: number
-  ): Promise<D2ItemFetchResponse[]> {
+  ): Promise<D2ItemFetchResponse[][]> {
     if (!itemList.length) {
-      return Promise.resolve<D2ItemFetchResponse[]>([]);
+      return Promise.resolve<D2ItemFetchResponse[][]>([]);
     }
 
-    const promise = dtrFetch(
-      `https://db-api.destinytracker.com/api/external/reviews/fetch?platform=${platformSelection}&mode=${mode}`,
-      itemList
-    ).then(handleD2Errors, handleD2Errors);
+    const size = 10;
+    const arrayOfArrays: D2ItemFetchRequest[][] = [];
+    for (let i = 0; i < itemList.length; i += size) {
+      arrayOfArrays.push(itemList.slice(i, i + size));
+    }
 
-    loadingTracker.addPromise(promise);
+    const arrayOfPromises: Promise<D2ItemFetchResponse[]>[] = [];
 
-    return promise;
+    for (const arraySlice of arrayOfArrays) {
+      arrayOfPromises.push(
+        dtrFetch(
+          `https://db-api.destinytracker.com/api/external/reviews/fetch?platform=${platformSelection}&mode=${mode}`,
+          arraySlice
+        ).then(handleD2Errors, handleD2Errors)
+      );
+    }
+
+    const promise4All = Promise.all<D2ItemFetchResponse[]>(arrayOfPromises);
+
+    loadingTracker.addPromise(promise4All);
+
+    return promise4All;
   }
 
   /**
@@ -68,7 +82,7 @@ class D2BulkFetcher {
    */
   bulkFetch(stores: D2Store[], platformSelection: number, mode: number) {
     this._getBulkFetchPromise(stores, platformSelection, mode).then((bulkRankings) =>
-      this.attachRankings(bulkRankings, stores)
+      bulkRankings.forEach((br) => this.attachRankings(br, stores))
     );
   }
 
@@ -94,7 +108,7 @@ class D2BulkFetcher {
       mode,
       vendorSaleItems,
       vendorItems
-    ).then((bulkRankings) => this._addScores(bulkRankings));
+    ).then((bulkRankings) => bulkRankings.forEach((br) => this._addScores(br)));
   }
 
   attachRankings(bulkRankings: D2ItemFetchResponse[] | null, stores: D2Store[]): void {

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.ts
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.ts
@@ -202,8 +202,6 @@ class D2ReviewDataCache {
       highlightedRatingCount: 0 // bugbug: D2 API doesn't seem to be returning highlighted ratings in fetch
     };
 
-    console.log(cachedItem);
-
     this._itemStores.push(cachedItem);
   }
 

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.ts
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.ts
@@ -230,11 +230,13 @@ class D2ReviewDataCache {
    * Keep track of expanded item review data from the DTR API for this DIM store item.
    * The expectation is that this will be building on top of community score data that's already been supplied.
    */
-  addReviewsData(reviewsData: D2ItemReviewResponse) {
+  addReviewsData(item: D2Item, reviewsData: D2ItemReviewResponse) {
+    const referenceKey = getReferenceKey(item);
+
     const cachedItem = this._itemStores.find(
       (s) =>
         s.referenceId === reviewsData.referenceId &&
-        (!reviewsData.availablePerks || s.roll === reviewsData.availablePerks.join(','))
+        (!referenceKey.availablePerks || s.roll === referenceKey.availablePerks.join(','))
     );
 
     if (!cachedItem) {

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.ts
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.ts
@@ -37,6 +37,10 @@ export function getReferenceKey(
   }
 }
 
+export function getD2Roll(availablePerks?: number[]): string {
+  return availablePerks && availablePerks.length > 0 ? availablePerks.join(',') : 'fixed';
+}
+
 /**
  * Cache of review data.
  * Mixes and matches remote as well as local data to cut down on chatter and prevent data loss on store refreshes.
@@ -54,7 +58,7 @@ class D2ReviewDataCache {
     return this._itemStores.find(
       (s) =>
         s.referenceId === referenceKey.referenceId &&
-        (!referenceKey.availablePerks || s.roll === referenceKey.availablePerks.join(','))
+        (!referenceKey.availablePerks || s.roll === getD2Roll(referenceKey.availablePerks))
     );
   }
 
@@ -76,10 +80,7 @@ class D2ReviewDataCache {
     const referenceKey = getReferenceKey(item, itemHash);
     const blankItem: D2RatingData = {
       referenceId: referenceKey.referenceId,
-      roll:
-        referenceKey.availablePerks && referenceKey.availablePerks.length > 0
-          ? referenceKey.availablePerks.join(',')
-          : 'fixed',
+      roll: getD2Roll(referenceKey.availablePerks),
       lastUpdated: new Date(),
       userReview: this._getBlankWorkingD2Rating(),
       overallScore: 0,
@@ -165,7 +166,7 @@ class D2ReviewDataCache {
         const matchingStore = this._itemStores.find(
           (ci) =>
             ci.referenceId === bulkRanking.referenceId &&
-            (!bulkRanking.availablePerks || bulkRanking.availablePerks.join(',') === ci.roll)
+            (!bulkRanking.availablePerks || getD2Roll(bulkRanking.availablePerks) === ci.roll)
         );
 
         if (matchingStore) {
@@ -192,10 +193,7 @@ class D2ReviewDataCache {
 
     const cachedItem: D2RatingData = {
       referenceId: dtrRating.referenceId,
-      roll:
-        dtrRating.availablePerks && dtrRating.availablePerks.length > 0
-          ? dtrRating.availablePerks.join(',')
-          : 'fixed',
+      roll: getD2Roll(dtrRating.availablePerks),
       overallScore: dimScore,
       fetchResponse: dtrRating,
       lastUpdated: new Date(),
@@ -236,7 +234,7 @@ class D2ReviewDataCache {
     const cachedItem = this._itemStores.find(
       (s) =>
         s.referenceId === reviewsData.referenceId &&
-        (!referenceKey.availablePerks || s.roll === referenceKey.availablePerks.join(','))
+        (!referenceKey.availablePerks || s.roll === getD2Roll(referenceKey.availablePerks))
     );
 
     if (!cachedItem) {

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -72,7 +72,7 @@ class D2ReviewsFetcher {
   _attachReviews(item: D2Item, reviewData: D2ItemReviewResponse) {
     this._sortAndIgnoreReviews(reviewData);
 
-    this._reviewDataCache.addReviewsData(reviewData);
+    this._reviewDataCache.addReviewsData(item, reviewData);
     item.dtrRating = this._reviewDataCache.getRatingData(item);
 
     ratePerks(item);

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { D1RatingData } from '../item-review/d1-dtr-api-types';
 import { D2RatingData } from '../item-review/d2-dtr-api-types';
 import InventoryItem from './InventoryItem';
-import { getReferenceKey } from '../destinyTrackerApi/d2-reviewDataCache';
+import { getReferenceKey, getD2Roll } from '../destinyTrackerApi/d2-reviewDataCache';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -76,10 +76,7 @@ function getRating(
   } else if (item.isDestiny2()) {
     const referenceKey = getReferenceKey(item);
 
-    roll =
-      referenceKey.availablePerks && referenceKey.availablePerks.length > 0
-        ? referenceKey.availablePerks.join(',')
-        : 'fixed';
+    roll = getD2Roll(referenceKey.availablePerks);
   }
 
   const itemKey = `${item.hash}-${roll}`;

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { D1RatingData } from '../item-review/d1-dtr-api-types';
 import { D2RatingData } from '../item-review/d2-dtr-api-types';
 import InventoryItem from './InventoryItem';
+import { getReferenceKey } from '../destinyTrackerApi/d2-reviewDataCache';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -68,7 +69,19 @@ function getRating(
   item: DimItem,
   ratings: ReviewsState['ratings']
 ): D2RatingData | D1RatingData | undefined {
-  const roll = item.isDestiny1() ? (item.talentGrid ? item.talentGrid.dtrRoll : null) : 'fixed'; // TODO: implement random rolls
+  let roll: string | null = null;
+
+  if (item.isDestiny1() && item.talentGrid) {
+    roll = item.talentGrid.dtrRoll;
+  } else if (item.isDestiny2()) {
+    const referenceKey = getReferenceKey(item);
+
+    roll =
+      referenceKey.availablePerks && referenceKey.availablePerks.length > 0
+        ? referenceKey.availablePerks.join(',')
+        : 'fixed';
+  }
+
   const itemKey = `${item.hash}-${roll}`;
   return ratings[itemKey] && ratings[itemKey];
 }

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import { D1RatingData } from '../item-review/d1-dtr-api-types';
 import { D2RatingData } from '../item-review/d2-dtr-api-types';
 import { itemSortOrderSelector } from '../settings/item-sort';
+import { getReferenceKey } from '../destinyTrackerApi/d2-reviewDataCache';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -118,7 +119,19 @@ function getRating(
   item: DimItem,
   ratings: ReviewsState['ratings']
 ): D2RatingData | D1RatingData | undefined {
-  const roll = item.isDestiny1() ? (item.talentGrid ? item.talentGrid.dtrRoll : null) : 'fixed'; // TODO: implement random rolls
+  let roll: string | null = null;
+
+  if (item.isDestiny1() && item.talentGrid) {
+    roll = item.talentGrid.dtrRoll;
+  } else if (item.isDestiny2()) {
+    const referenceKey = getReferenceKey(item);
+
+    roll =
+      referenceKey.availablePerks && referenceKey.availablePerks.length > 0
+        ? referenceKey.availablePerks.join(',')
+        : 'fixed';
+  }
+
   const itemKey = `${item.hash}-${roll}`;
   return ratings[itemKey] && ratings[itemKey];
 }

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 import { D1RatingData } from '../item-review/d1-dtr-api-types';
 import { D2RatingData } from '../item-review/d2-dtr-api-types';
 import { itemSortOrderSelector } from '../settings/item-sort';
-import { getReferenceKey } from '../destinyTrackerApi/d2-reviewDataCache';
+import { getReferenceKey, getD2Roll } from '../destinyTrackerApi/d2-reviewDataCache';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -126,10 +126,7 @@ function getRating(
   } else if (item.isDestiny2()) {
     const referenceKey = getReferenceKey(item);
 
-    roll =
-      referenceKey.availablePerks && referenceKey.availablePerks.length > 0
-        ? referenceKey.availablePerks.join(',')
-        : 'fixed';
+    roll = getD2Roll(referenceKey.availablePerks);
   }
 
   const itemKey = `${item.hash}-${roll}`;

--- a/src/app/item-review/d2-dtr-api-types.ts
+++ b/src/app/item-review/d2-dtr-api-types.ts
@@ -108,6 +108,8 @@ export interface D2ItemUserReview extends DimUserReview {
 export interface D2ItemReviewResponse {
   /** Reference ID (hash ID). */
   referenceId: number;
+  /** If it's a random roll, what's the complete list of (random) perks on it? */
+  availablePerks?: number[];
   /** The votes for a single item. */
   votes: DtrD2Vote;
   /** The total number of reviews. */

--- a/src/app/item-review/d2-dtr-api-types.ts
+++ b/src/app/item-review/d2-dtr-api-types.ts
@@ -52,6 +52,8 @@ export interface D2ItemFetchResponse {
   votes: DtrD2Vote;
   /** The votes that have review text along with them. */
   reviewVotes: DtrD2Vote;
+  /** If it's a random roll, what's the complete list of (random) perks on it (that we sent)? */
+  availablePerks?: number[];
 }
 
 /** If the user chooses to make any review moves on an item, they're stored here. */

--- a/src/app/item-review/d2-dtr-api-types.ts
+++ b/src/app/item-review/d2-dtr-api-types.ts
@@ -108,8 +108,6 @@ export interface D2ItemUserReview extends DimUserReview {
 export interface D2ItemReviewResponse {
   /** Reference ID (hash ID). */
   referenceId: number;
-  /** If it's a random roll, what's the complete list of (random) perks on it? */
-  availablePerks?: number[];
   /** The votes for a single item. */
   votes: DtrD2Vote;
   /** The total number of reviews. */


### PR DESCRIPTION
A while ago, I baked in support for sending the perks available on an item when a user made an item rating/review, but we still didn't have any way to fetch ratings (or retrieve reviews) based off of the rolls.

The API got support for fetching ratings and reviews based off of available perks the other day, so I touched up DIM to work with that.

![rating random rolls with highlighting](https://user-images.githubusercontent.com/606888/46767893-6f66fc80-ccb4-11e8-96ea-b7ef1ebd13c4.png)

The change to how we fetch is by design - there was concern that the request/response for fetches was getting computationally heavy, so we split what was one big request up in to a bunch of smaller fetches and run them serially (the official guesstimate is 2 at a time per user max, but I didn't see a whole lot of value in writing more code to tempt fate with a bit more load).