### PR TITLE
Show a message when an item can't be pulled from postmaster

### DIFF
--- a/src/app/move-popup/dimMoveItemProperties.html
+++ b/src/app/move-popup/dimMoveItemProperties.html
@@ -42,6 +42,7 @@
   </div>
   <div class="item-details failure-reason" ng-if="failureString.length" ng-repeat="failureString in vm.failureStrings">{{
     failureString }}</div>
+  <div class="item-details failure-reason" ng-if="!vm.item.canPullFromPostmaster" ng-i18next="MovePopup.CantPullFromPostmaster"></div>
   <div class="item-xp-bar" ng-if="vm.item.percentComplete != null && !vm.item.complete" dim-percent-width="vm.item.percentComplete"></div>
   <div ng-if="vm.itemDetails" class="move-popup-details">
     <div ng-if="vm.item.reviewable" class="move-popup-tabs">

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -516,6 +516,7 @@
     "UpStack": "Increase up to the next full stack"
   },
   "MovePopup": {
+    "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "Consolidate": "Consolidate",
     "DistributeEvenly": "Distribute Evenly",
     "Equip": "Equip",


### PR DESCRIPTION
For #3199 this should show a red banner on the move popup when an item can't be pulled.

<img width="427" alt="screen shot 2018-10-12 at 7 13 24 pm" src="https://user-images.githubusercontent.com/313208/46900175-edf9a080-ce52-11e8-973e-27a04064f040.png">
