### PR TITLE
Revert replacing angular copy with fast-copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "classnames": "^2.2.5",
     "components-font-awesome": "^4.7.0",
     "core-js": "^2.5.5",
-    "fast-copy": "^1.2.2",
     "fast-equals": "^1.6.1",
     "i18next": "^11.2.3",
     "i18next-xhr-backend": "^1.5.1",

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -1,4 +1,4 @@
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import { settings } from '../settings/settings';
 import * as _ from 'lodash';
 import { MoveReservations, dimItemService } from '../inventory/dimItemService.factory';

--- a/src/app/infuse/infuse.component.ts
+++ b/src/app/infuse/infuse.component.ts
@@ -1,5 +1,4 @@
-import { IComponentOptions, IController, IQService } from 'angular';
-import copy from 'fast-copy';
+import { IComponentOptions, IController, IQService, copy } from 'angular';
 import * as _ from 'lodash';
 import { getDefinitions } from '../destiny1/d1-definitions.service';
 import template from './infuse.html';

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -1,5 +1,4 @@
-import { IPromise } from 'angular';
-import copy from 'fast-copy';
+import { IPromise, copy } from 'angular';
 import * as _ from 'lodash';
 import { DimError } from '../bungie-api/bungie-service-helper';
 import {

--- a/src/app/inventory/store/d1-store-factory.service.ts
+++ b/src/app/inventory/store/d1-store-factory.service.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { count } from '../../util';
 import { getCharacterStatsData, getClass } from './character-utils';
 import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions.service';
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import { t } from 'i18next';
 // tslint:disable-next-line:no-implicit-dependencies
 import vaultIcon from 'app/images/vault.png';

--- a/src/app/inventory/store/d2-store-factory.service.ts
+++ b/src/app/inventory/store/d2-store-factory.service.ts
@@ -1,4 +1,4 @@
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import {
   DestinyCharacterComponent,
   DestinyItemComponent,

--- a/src/app/loadout-builder/loadout-builder.component.ts
+++ b/src/app/loadout-builder/loadout-builder.component.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import copy from 'fast-copy';
 import template from './loadout-builder.html';
 // tslint:disable-next-line:no-implicit-dependencies
 import intellectIcon from 'app/images/intellect.png';
@@ -9,7 +8,7 @@ import disciplineIcon from 'app/images/discipline.png';
 import strengthIcon from 'app/images/strength.png';
 import { getBonus } from '../inventory/store/character-utils';
 import { getDefinitions } from '../destiny1/d1-definitions.service';
-import { IComponentOptions, IController, ITimeoutService } from 'angular';
+import { IComponentOptions, IController, ITimeoutService, copy } from 'angular';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { Loadout, dimLoadoutService, LoadoutClass } from '../loadout/loadout.service';
 import { DestinyClass } from 'bungie-api-ts/destiny2';

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -5,7 +5,7 @@ import { toaster } from '../ngimport-more';
 import { dimLoadoutService, Loadout } from './loadout.service';
 import * as _ from 'lodash';
 import { sortItems } from '../shell/dimAngularFilters.filter';
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import { getDefinitions as getD1Definitions } from '../destiny1/d1-definitions.service';
 import { getDefinitions as getD2Definitions } from '../destiny2/d2-definitions.service';
 import { DimItem } from '../inventory/item-types';

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { copy } from 'angular';
 import { t } from 'i18next';
 import './loadout-popup.scss';
 import { DimStore } from '../inventory/store-types';
@@ -42,7 +43,6 @@ import {
   powerActionIcon,
   powerIndicatorIcon
 } from '../shell/icons';
-import copy from 'fast-copy';
 
 interface ProvidedProps {
   dimStore: DimStore;

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -1,4 +1,4 @@
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import { t } from 'i18next';
 import * as _ from 'lodash';
 import { optimalLoadout, newLoadout } from './loadout-utils';

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -1,4 +1,4 @@
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import * as _ from 'lodash';
 import { Loadout } from './loadout.service';
 import { DimItem } from '../inventory/item-types';

--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -1,4 +1,4 @@
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import * as _ from 'lodash';
 import { queueAction } from '../inventory/action-queue';
 import { SyncService } from '../storage/sync.service';

--- a/src/app/storage/sync.service.ts
+++ b/src/app/storage/sync.service.ts
@@ -1,4 +1,4 @@
-import copy from 'fast-copy';
+import { copy } from 'angular';
 import { deepEqual } from 'fast-equals';
 import * as _ from 'lodash';
 import { reportException } from '../exceptions';

--- a/src/app/vendors/vendor.service.ts
+++ b/src/app/vendors/vendor.service.ts
@@ -6,8 +6,7 @@ import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.ser
 import { getVendorForCharacter } from '../bungie-api/destiny1-api';
 import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 import { processItems } from '../inventory/store/d1-item-factory.service';
-import { IPromise } from 'angular';
-import copy from 'fast-copy';
+import { IPromise, copy } from 'angular';
 import { D1Store } from '../inventory/store-types';
 import { Observable } from 'rxjs/Observable';
 import { D1Item } from '../inventory/item-types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,6 +460,10 @@ angular-hotkeys@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/angular-hotkeys/-/angular-hotkeys-1.7.0.tgz#052e6b6f44dfcd824427798b7f10e1917e8700a1"
 
+angular-messages@^1.6.9:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/angular-messages/-/angular-messages-1.7.4.tgz#845c3e3dce80ca698ba62bcf70105ab76cfdbb50"
+
 "angular-native-dragdrop@github:DestinyItemManager/angular-dragdrop":
   version "1.2.2"
   resolved "https://codeload.github.com/DestinyItemManager/angular-dragdrop/tar.gz/0a8770f97abf290617fac366db63c85d081e2cbf"
@@ -2797,10 +2801,6 @@ extsprintf@1.3.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-
-fast-copy@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-1.2.2.tgz#b15cf14d767f07c22cd5ffbd6cc615c12d206b7e"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
`fast-copy` doesn't support our weird way of making objects yet. Reverting until something like https://github.com/planttheidea/fast-copy/pull/12 gets merged.

This reverts commit be352cb705df0b045b34d977ffe5b08441d63053.