### PR TITLE
Fix search loadouts to use the filter function directly

### DIFF
--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -43,6 +43,8 @@ import {
   powerActionIcon,
   powerIndicatorIcon
 } from '../shell/icons';
+import { DimItem } from '../inventory/item-types';
+import { searchFilterSelector } from '../search/search-filters';
 
 interface ProvidedProps {
   dimStore: DimStore;
@@ -54,6 +56,7 @@ interface StoreProps {
   loadouts: Loadout[];
   query: string;
   classTypeId: number;
+  searchFilter(item: DimItem): boolean;
 }
 
 type Props = ProvidedProps & StoreProps;
@@ -81,6 +84,7 @@ function mapStateToProps(state: RootState, ownProps: ProvidedProps): StoreProps 
     previousLoadout: previousLoadoutSelector(state, ownProps.dimStore.id),
     loadouts: loadoutsForPlatform,
     query: querySelector(state),
+    searchFilter: searchFilterSelector(state),
     classTypeId
   };
 }
@@ -359,8 +363,8 @@ class LoadoutPopup extends React.Component<Props> {
 
   // Move items matching the current search. Max 9 per type.
   private searchLoadout = (e) => {
-    const { dimStore } = this.props;
-    const loadout = searchLoadout(dimStore.getStoresService(), dimStore);
+    const { dimStore, searchFilter } = this.props;
+    const loadout = searchLoadout(dimStore.getStoresService(), dimStore, searchFilter);
     this.applyLoadout(loadout, e);
   };
 

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -166,9 +166,13 @@ export function gatherTokensLoadout(storeService: StoreServiceType): Loadout {
 /**
  * Move items matching the current search.
  */
-export function searchLoadout(storeService: StoreServiceType, store: DimStore): Loadout {
+export function searchLoadout(
+  storeService: StoreServiceType,
+  store: DimStore,
+  searchFilter: (item: DimItem) => boolean
+): Loadout {
   let items = storeService.getAllItems().filter((i) => {
-    return i.visible && !i.location.inPostmaster && !i.notransfer;
+    return !i.location.inPostmaster && !i.notransfer && searchFilter(i);
   });
 
   items = addUpStackables(items);

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -51,7 +51,7 @@ export const searchFilterSelector = createSelector(
   (query, filters) => filters.filterFunction(query)
 );
 
-interface SearchConfig {
+export interface SearchConfig {
   destinyVersion: 1 | 2;
   keywords: string[];
   categoryHashFilters: { [key: string]: number };


### PR DESCRIPTION
Fixes #3212. With the new event stuff we weren't refreshing filters on store refresh, but we don't need to do that anymore - we can just apply the filters directly.