### PR TITLE
Implement pull-to-refresh for mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "react-dom": "^16.3.1",
     "react-hammerjs": "^1.0.1",
     "react-hot-loader": "^4.3.3",
+    "react-pull-to-refresh": "^1.1.2",
     "react-redux": "^5.0.7",
     "react-transition-group": "^2.3.1",
     "react-twitter-widgets": "^1.7.1",

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -3,6 +3,7 @@ import { DimStore, DimVault } from './store-types';
 import { InventoryBuckets } from './inventory-buckets';
 import { t } from 'i18next';
 import './Stores.scss';
+import './pull-to-refresh.scss';
 import StoreHeading from './StoreHeading';
 import { RootState } from '../store/reducers';
 import { connect } from 'react-redux';
@@ -14,6 +15,8 @@ import D1ReputationSection from './D1ReputationSection';
 import Hammer from 'react-hammerjs';
 import { sortedStoresSelector } from './reducer';
 import { Settings } from '../settings/reducer';
+import ReactPullToRefresh from 'react-pull-to-refresh';
+import { AppIcon, refreshIcon } from '../shell/icons';
 
 interface Props {
   stores: DimStore[];
@@ -70,37 +73,39 @@ class Stores extends React.Component<Props, State> {
 
     if (isPhonePortrait) {
       return (
-        <div className="inventory-content phone-portrait react">
-          <ScrollClassDiv className="store-row store-header" scrollClass="sticky">
-            <ViewPager>
-              <Frame className="frame" autoSize={false}>
-                <Track
-                  currentView={selectedStoreId === undefined ? currentStore.id : selectedStoreId}
-                  contain={false}
-                  onViewChange={this.onViewChange}
-                  className="track"
-                >
-                  {stores.map((store) => (
-                    <View className="store-cell" key={store.id}>
-                      <StoreHeading
-                        store={store}
-                        selectedStore={selectedStore}
-                        onTapped={this.selectStore}
-                        loadoutMenuRef={this.detachedLoadoutMenu}
-                      />
-                    </View>
-                  ))}
-                </Track>
-              </Frame>
-            </ViewPager>
-          </ScrollClassDiv>
+        <ReactPullToRefresh onRefresh={this.handleRefresh} icon={<AppIcon icon={refreshIcon} />}>
+          <div className="inventory-content phone-portrait react">
+            <ScrollClassDiv className="store-row store-header" scrollClass="sticky">
+              <ViewPager>
+                <Frame className="frame" autoSize={false}>
+                  <Track
+                    currentView={selectedStoreId === undefined ? currentStore.id : selectedStoreId}
+                    contain={false}
+                    onViewChange={this.onViewChange}
+                    className="track"
+                  >
+                    {stores.map((store) => (
+                      <View className="store-cell" key={store.id}>
+                        <StoreHeading
+                          store={store}
+                          selectedStore={selectedStore}
+                          onTapped={this.selectStore}
+                          loadoutMenuRef={this.detachedLoadoutMenu}
+                        />
+                      </View>
+                    ))}
+                  </Track>
+                </Frame>
+              </ViewPager>
+            </ScrollClassDiv>
 
-          <div className="detached" ref={this.detachedLoadoutMenu} />
+            <div className="detached" ref={this.detachedLoadoutMenu} />
 
-          <Hammer direction="DIRECTION_HORIZONTAL" onSwipe={this.handleSwipe}>
-            {this.renderStores([selectedStore], vault)}
-          </Hammer>
-        </div>
+            <Hammer direction="DIRECTION_HORIZONTAL" onSwipe={this.handleSwipe}>
+              {this.renderStores([selectedStore], vault)}
+            </Hammer>
+          </div>
+        </ReactPullToRefresh>
       );
     }
 
@@ -117,6 +122,13 @@ class Stores extends React.Component<Props, State> {
       </div>
     );
   }
+
+  private handleRefresh = (resolve, reject) => {
+    this.props.stores[0]
+      .getStoresService()
+      .reloadStores()
+      .then(resolve, reject);
+  };
 
   private onViewChange = (indices) => {
     const { stores } = this.props;

--- a/src/app/inventory/pull-to-refresh.scss
+++ b/src/app/inventory/pull-to-refresh.scss
@@ -1,0 +1,62 @@
+@import '../../scss/variables.scss';
+
+$ptrHeight: 50px;
+$iconSize: 30px;
+
+.ptr-element {
+  position: absolute;
+  top: $header-height;
+  left: 0;
+  width: 100%;
+  color: white;
+  z-index: 10;
+  text-align: center;
+  height: $ptrHeight;
+}
+
+.ptr-element .app-icon {
+  opacity: 0.6;
+  width: $iconSize;
+  height: $iconSize;
+  transition: all 0.25s ease;
+  transform: rotate(90deg);
+  margin-top: ($ptrHeight - $iconSize) / 2;
+}
+.ptr-refresh .ptr-element .app-icon {
+  transform: rotate(270deg);
+}
+.ptr-reset .ptr-element {
+  transform: translate3d(0, -$ptrHeight, 0);
+}
+
+.ptr-loading,
+.ptr-reset {
+  .ptr-element .app-icon {
+    animation: spin 2s infinite linear;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+.ptr-loading .refresh-view,
+.ptr-reset .refresh-view,
+.ptr-loading .ptr-element,
+.ptr-reset .ptr-element {
+  transition: all 0.25s ease;
+}
+
+.ptr-reset .refresh-view {
+  transform: translate3d(0, 0, 0);
+}
+
+.ptr-loading .refresh-view {
+  transform: translate3d(0, $ptrHeight, 0);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,7 +3533,7 @@ gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
-hammerjs@^2.0.8:
+hammerjs@^2.0.4, hammerjs@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
 
@@ -6270,6 +6270,13 @@ react-motion@^0.5.0, react-motion@^0.5.2:
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"
+
+react-pull-to-refresh@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-pull-to-refresh/-/react-pull-to-refresh-1.1.2.tgz#cf488ed3ac5b941d44c31fcb55b2b3a0f7669544"
+  dependencies:
+    hammerjs "^2.0.4"
+    prop-types "^15.5.10"
 
 react-redux@^5.0.7:
   version "5.0.7"


### PR DESCRIPTION
This is a stab at a native-like "pull to refresh" behavior for mobile.

Note that it's kind of weird to have refresh both in the header and in pull-to-refresh. Personally I'd be OK with removing it from the header if we had some other way of indicating "DIM is doing something". @inexorableAce got any good ideas?

![ptr](https://user-images.githubusercontent.com/313208/46930625-98142c80-cffb-11e8-9a39-5ccfd0569f6f.gif)
