### PR TITLE
Including option text (to go along with the label) for the loadout builder.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * We no longer support searching D1 vendor items.
 * Added support for showing ratings and reviews based on the item roll in Destiny 2.
+* Fix for missing class names in the loadout builder in Firefox.
 
 # 4.74.0 (2018-10-14)
 

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -195,7 +195,9 @@ class LoadoutDrawer extends React.Component<Props, State> {
               {showClass && (
                 <select name="classType" onChange={this.setClassType} value={loadout.classType}>
                   {classTypeOptions.map((option) => (
-                    <option key={option.value} label={option.label} value={option.value} />
+                    <option key={option.value} label={option.label} value={option.value}>
+                      {option.label}
+                    </option>
                   ))}
                 </select>
               )}{' '}


### PR DESCRIPTION
Firefox wasn't rendering text without.

This address issue #3228 

I audited the other options we build and this looks like the only one that was missing a node value.