### PR TITLE
Update caching rules in .htaccess

### DIFF
--- a/src/htaccess
+++ b/src/htaccess
@@ -846,7 +846,7 @@ FileETag None
     ExpiresByType application/rdf+xml                   "access plus 1 hour"
     ExpiresByType application/rss+xml                   "access plus 1 hour"
 
-    ExpiresByType application/json                      "access plus 0 seconds"
+    ExpiresByType application/json                      "access plus 1 year"
     ExpiresByType application/ld+json                   "access plus 0 seconds"
     ExpiresByType application/schema+json               "access plus 0 seconds"
     ExpiresByType application/vnd.geo+json              "access plus 0 seconds"
@@ -869,6 +869,7 @@ FileETag None
     ExpiresByType application/javascript                "access plus 1 year"
     ExpiresByType application/x-javascript              "access plus 1 year"
     ExpiresByType text/javascript                       "access plus 1 year"
+    ExpiresByType application/wasm                      "access plus 1 year"
 
 
   # Manifest files
@@ -880,37 +881,37 @@ FileETag None
 
   # Media files
 
-    ExpiresByType audio/ogg                             "access plus 1 month"
-    ExpiresByType image/bmp                             "access plus 1 month"
-    ExpiresByType image/gif                             "access plus 1 month"
-    ExpiresByType image/jpeg                            "access plus 1 month"
-    ExpiresByType image/png                             "access plus 1 month"
-    ExpiresByType image/svg+xml                         "access plus 1 month"
-    ExpiresByType image/webp                            "access plus 1 month"
-    ExpiresByType video/mp4                             "access plus 1 month"
-    ExpiresByType video/ogg                             "access plus 1 month"
-    ExpiresByType video/webm                            "access plus 1 month"
+    ExpiresByType audio/ogg                             "access plus 1 year"
+    ExpiresByType image/bmp                             "access plus 1 year"
+    ExpiresByType image/gif                             "access plus 1 year"
+    ExpiresByType image/jpeg                            "access plus 1 year"
+    ExpiresByType image/png                             "access plus 1 year"
+    ExpiresByType image/svg+xml                         "access plus 1 year"
+    ExpiresByType image/webp                            "access plus 1 year"
+    ExpiresByType video/mp4                             "access plus 1 year"
+    ExpiresByType video/ogg                             "access plus 1 year"
+    ExpiresByType video/webm                            "access plus 1 year"
 
 
   # Web fonts
 
     # Embedded OpenType (EOT)
-    ExpiresByType application/vnd.ms-fontobject         "access plus 1 month"
-    ExpiresByType font/eot                              "access plus 1 month"
+    ExpiresByType application/vnd.ms-fontobject         "access plus 1 year"
+    ExpiresByType font/eot                              "access plus 1 year"
 
     # OpenType
-    ExpiresByType font/opentype                         "access plus 1 month"
+    ExpiresByType font/opentype                         "access plus 1 year"
 
     # TrueType
-    ExpiresByType application/x-font-ttf                "access plus 1 month"
+    ExpiresByType application/x-font-ttf                "access plus 1 year"
 
     # Web Open Font Format (WOFF) 1.0
-    ExpiresByType application/font-woff                 "access plus 1 month"
-    ExpiresByType application/x-font-woff               "access plus 1 month"
-    ExpiresByType font/woff                             "access plus 1 month"
+    ExpiresByType application/font-woff                 "access plus 1 year"
+    ExpiresByType application/x-font-woff               "access plus 1 year"
+    ExpiresByType font/woff                             "access plus 1 year"
 
     # Web Open Font Format (WOFF) 2.0
-    ExpiresByType application/font-woff2                "access plus 1 month"
+    ExpiresByType application/font-woff2                "access plus 1 year"
 
 
   # Other
@@ -977,14 +978,13 @@ FileETag None
     </IfModule>
 </FilesMatch>
 
-# Do not cache version.json either
+# Cache version.json for only 15 minutes
 
 <FilesMatch "version\.json(\.(gz|br))?">
     FileETag None
     <IfModule mod_headers.c>
         Header unset ETag
-        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
-        Header set Pragma "no-cache"
+        Header set Cache-Control "max-age=900"
         Header unset Expires
     </IfModule>
 </FilesMatch>


### PR DESCRIPTION
This updates our `.htaccess` file to cache JSON, WASM, and some other files. `version.json` is set to be cached for 15 minutes.

https://github.com/DestinyItemManager/DIM/pull/3230 only changed which files got the [`Cache-Control: immutable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Revalidation_and_reloading) header, which can help prevent reloads when a user manually reloads the page (read [the blog post](http://bitsup.blogspot.com/2016/05/cache-control-immutable.html) attached to the MDN article).

Our general expiration for assets is determined by the block that maps file types to expirations via [`ExpiresByType`](https://httpd.apache.org/docs/current/mod/mod_expires.html) directives. In turn, CloudFlare will honor these expirations when caching content from our server. We can set most of these to "access plus 1 year" because our Webpack build generates content-hashed filenames, so a new asset will always show up as a new file.

Note that we do *not* want to do this for HTML, specifically `index.html`, `return.html`, and `authReturn.html`, since they do not have content-hashed filenames. I'm slightly wary of caching them at all, because they get pre-cached by our Service Worker. If they were to be cached, a new service worker could cache the old HTML, and all kinds of bad stuff would happen.

To further customize our caching for certain files, we set explicit [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) options for our Service Worker and the `version.json` file we use to indicate to open clients that there is a new version. The Service Worker should never be cached (see [this Stackoverflow answer](https://stackoverflow.com/questions/38843970/service-worker-javascript-update-frequency-every-24-hours/38854905#38854905)), and `version.json` gets cached for up to 15 minutes (so that new deployments get noticed quickly). These rules are important because we ever so occasionally roll out a broken release, and it's nice to be able to fix it and have people pick up the fix quickly. If we wanted to specifically protect our origin server against these requests, the best way to do it would be to override our cache headers on Cloudflare using a page rule (this tells Cloudflare to ignore our headers and cache longer, even though it will still serve our "don't cache" headers to browsers) and [purge it programmatically](https://api.cloudflare.com/#zone-purge-files-by-url) on deployment. This requires some extra setup in our deployment script, however.