### PR TITLE
Fix accidentally losing loadouts

### DIFF
--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -173,12 +173,14 @@ function LoadoutService(): LoadoutServiceType {
   }
 
   async function deleteLoadout(loadout: Loadout): Promise<void> {
+    await getLoadouts(); // make sure we have loaded all loadouts first!
     reduxStore.dispatch(actions.deleteLoadout(loadout.id));
     await SyncService.remove(loadout.id);
     await saveLoadouts(reduxStore.getState().loadouts.loadouts);
   }
 
   async function saveLoadout(loadout: Loadout): Promise<void> {
+    await getLoadouts(); // make sure we have loaded all loadouts first!
     reduxStore.dispatch(actions.updateLoadout(loadout));
     await saveLoadouts(reduxStore.getState().loadouts.loadouts);
   }


### PR DESCRIPTION
https://twitter.com/twrenner/status/1053472049992228864?s=21

The issue is, if you hadn't opened the loadouts popup, we hadn't actually loaded any loadouts yet. So when we went to add a new loadout, it overwrote all of the other loadouts.

Easy fix is just to make sure loadouts have been loaded before saving or deleting any.