### PR TITLE
Optimize DTR fetching

### DIFF
--- a/src/app/destinyTrackerApi/bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/bulkFetcher.ts
@@ -61,10 +61,14 @@ class BulkFetcher {
       return;
     }
 
-    if (bulkRankings) {
+    if (bulkRankings && bulkRankings.length > 0) {
       bulkRankings.forEach((bulkRanking) => {
         this._reviewDataCache.addScore(bulkRanking);
       });
+
+      store.dispatch(
+        updateRatings({ maxTotalVotes: 0, itemStores: this._reviewDataCache._itemStores })
+      );
     }
 
     stores.forEach((store) => {
@@ -76,10 +80,6 @@ class BulkFetcher {
         }
       });
     });
-
-    store.dispatch(
-      updateRatings({ maxTotalVotes: 0, itemStores: this._reviewDataCache._itemStores })
-    );
   }
 
   attachVendorRankings(bulkRankings: D1ItemFetchResponse[], vendors: Vendor[]) {

--- a/src/app/destinyTrackerApi/d2-itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/d2-itemListBuilder.ts
@@ -7,7 +7,8 @@ import {
 import { D2Item } from '../inventory/item-types';
 import { D2Store } from '../inventory/store-types';
 import { D2ItemFetchRequest } from '../item-review/d2-dtr-api-types';
-import { translateToDtrItem, getD2Roll } from './d2-itemTransformer';
+import { translateToDtrItem, getD2Roll, getD2Key } from './d2-itemTransformer';
+import { getItemStoreKey } from '../item-review/reducer';
 
 /**
  * Translate the universe of items that the user has in their stores into a collection of data that we can send the DTR API.
@@ -50,11 +51,11 @@ export function getVendorItemList(
 function getNewItems(allItems: D2Item[], reviewDataCache: D2ReviewDataCache) {
   const allDtrItems = allItems.map(translateToDtrItem);
   const allKnownDtrItems = new Set(
-    reviewDataCache.getItemStores().map((kdi) => `${kdi.referenceId}-${kdi.roll}`)
+    reviewDataCache.getItemStores().map((kdi) => getItemStoreKey(kdi.referenceId, kdi.roll))
   );
 
   const unmatched = allDtrItems.filter(
-    (di) => !allKnownDtrItems.has(`${di.referenceId}-${getD2Roll(di.availablePerks)}`)
+    (di) => !allKnownDtrItems.has(getItemStoreKey(di.referenceId, getD2Roll(di.availablePerks)))
   );
 
   return unmatched;
@@ -62,11 +63,11 @@ function getNewItems(allItems: D2Item[], reviewDataCache: D2ReviewDataCache) {
 
 function getNewVendorItems(vendorItems: D2ItemFetchRequest[], reviewDataCache: D2ReviewDataCache) {
   const allKnownDtrItems = new Set(
-    reviewDataCache.getItemStores().map((kdi) => `${kdi.referenceId}-${kdi.roll}`)
+    reviewDataCache.getItemStores().map((kdi) => getItemStoreKey(kdi.referenceId, kdi.roll))
   );
 
   const unmatched = vendorItems.filter(
-    (di) => !allKnownDtrItems.has(`${di.referenceId}-${getD2Roll(di.availablePerks)}`)
+    (di) => !allKnownDtrItems.has(getItemStoreKey(di.referenceId, getD2Roll(di.availablePerks)))
   );
 
   return unmatched;

--- a/src/app/destinyTrackerApi/d2-itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/d2-itemListBuilder.ts
@@ -7,7 +7,7 @@ import {
 import { D2Item } from '../inventory/item-types';
 import { D2Store } from '../inventory/store-types';
 import { D2ItemFetchRequest } from '../item-review/d2-dtr-api-types';
-import { translateToDtrItem } from './d2-itemTransformer';
+import { translateToDtrItem, getD2Roll } from './d2-itemTransformer';
 
 /**
  * Translate the universe of items that the user has in their stores into a collection of data that we can send the DTR API.
@@ -49,20 +49,24 @@ export function getVendorItemList(
 
 function getNewItems(allItems: D2Item[], reviewDataCache: D2ReviewDataCache) {
   const allDtrItems = allItems.map(translateToDtrItem);
-  const allKnownDtrItems = reviewDataCache.getItemStores();
+  const allKnownDtrItems = new Set(
+    reviewDataCache.getItemStores().map((kdi) => `${kdi.referenceId}-${kdi.roll}`)
+  );
 
-  const unmatched = allDtrItems.filter((di) =>
-    allKnownDtrItems.every((kdi) => di.referenceId !== kdi.referenceId)
+  const unmatched = allDtrItems.filter(
+    (di) => !allKnownDtrItems.has(`${di.referenceId}-${getD2Roll(di.availablePerks)}`)
   );
 
   return unmatched;
 }
 
 function getNewVendorItems(vendorItems: D2ItemFetchRequest[], reviewDataCache: D2ReviewDataCache) {
-  const allKnownDtrItems = reviewDataCache.getItemStores();
+  const allKnownDtrItems = new Set(
+    reviewDataCache.getItemStores().map((kdi) => `${kdi.referenceId}-${kdi.roll}`)
+  );
 
-  const unmatched = vendorItems.filter((vi) =>
-    allKnownDtrItems.every((di) => di.referenceId !== vi.referenceId)
+  const unmatched = vendorItems.filter(
+    (di) => !allKnownDtrItems.has(`${di.referenceId}-${getD2Roll(di.availablePerks)}`)
   );
 
   return unmatched;
@@ -73,21 +77,12 @@ function getNewVendorItems(vendorItems: D2ItemFetchRequest[], reviewDataCache: D
  * extracting all of the vendor items. If the interface is the same for both, this can go
  * away.
  */
-function getAllItems(stores: D2Store[]): D2Item[] {
-  return _.flatMap(stores, (store) => store.items);
+function getAllReviewableItems(stores: D2Store[]): D2Item[] {
+  return _.flatMap(stores, (store) => store.items.filter((item) => item.reviewable));
 }
 
 // Get all of the weapons from our stores in a DTR API-friendly format.
 function getDtrItems(stores: D2Store[], reviewDataCache: D2ReviewDataCache): D2ItemFetchRequest[] {
-  const allItems = getAllItems(stores);
-
-  const allReviewableItems = allItems.filter((item) => item.reviewable);
-
-  const newItems = getNewItems(allReviewableItems, reviewDataCache);
-
-  if (reviewDataCache.getItemStores().length > 0) {
-    return newItems;
-  }
-
-  return allReviewableItems.map(translateToDtrItem);
+  const allReviewableItems = getAllReviewableItems(stores);
+  return getNewItems(allReviewableItems, reviewDataCache);
 }

--- a/src/app/destinyTrackerApi/d2-reviewDataCache.ts
+++ b/src/app/destinyTrackerApi/d2-reviewDataCache.ts
@@ -135,7 +135,7 @@ class D2ReviewDataCache {
    * Add (and track) the community scores.
    */
   addScores(bulkRankings: D2ItemFetchResponse[]) {
-    if (bulkRankings) {
+    if (bulkRankings && bulkRankings.length > 0) {
       this._setMaximumTotalVotes(bulkRankings);
 
       bulkRankings.forEach((bulkRanking) => {

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -4,7 +4,7 @@ import { ActionType, getType } from 'typesafe-actions';
 import { D2RatingData } from './d2-dtr-api-types';
 import { D1RatingData } from './d1-dtr-api-types';
 import { DimItem } from '../inventory/item-types';
-import { getReviewKey, getD2Roll } from '../destinyTrackerApi/d2-itemTransformer';
+import { getReviewKey, getD2Roll, getD2Key } from '../destinyTrackerApi/d2-itemTransformer';
 
 // TODO: Should this be by account? Accounts need IDs
 export interface ReviewsState {
@@ -34,12 +34,16 @@ export const reviews: Reducer<ReviewsState, ReviewsAction> = (
   }
 };
 
+export function getItemStoreKey(referenceId: number | string, roll: string | null) {
+  return `${referenceId}-${roll || 'fixed'}`;
+}
+
 function ratingsFromItemStores(
   itemStores: (D2RatingData | D1RatingData)[]
 ): { [key: string]: D2RatingData | D1RatingData } {
   const ratings: { [key: string]: D2RatingData | D1RatingData } = {};
   for (const itemStore of itemStores) {
-    ratings[`${itemStore.referenceId}-${itemStore.roll}`] = itemStore;
+    ratings[getItemStoreKey(itemStore.referenceId, itemStore.roll)] = itemStore;
   }
   return ratings;
 }


### PR DESCRIPTION
With a batch size of 10, I was requiring 48 serial requests to DTR to load ratings, which took forever. This PR optimizes a few things:

1. Bump the batch size to 100.
2. Load all the batches in parallel, instead of serially.
3. Optimize the calculation of which items are new.
4. Include "roll" in whether an item is new, not just item hash.
5. Skip doing expensive work when the response is empty.