### PR TITLE
Optimize Redux update for loading stores

### DIFF
--- a/src/app/accounts/platform.service.ts
+++ b/src/app/accounts/platform.service.ts
@@ -121,7 +121,7 @@ function saveActivePlatform(account: DestinyAccount | null): Promise<void> {
     // TODO: Starting to look like a saga
     store.dispatch(actions.setCurrentAccount(account));
     // Also clear inventory
-    store.dispatch(update([]));
+    store.dispatch(update({ stores: [] }));
 
     return SyncService.set({
       platformType: account.platformType,

--- a/src/app/destiny1/d1-buckets.service.ts
+++ b/src/app/destiny1/d1-buckets.service.ts
@@ -75,7 +75,7 @@ _.each(D1Categories, (types, category) => {
   });
 });
 
-export const getBuckets: () => IPromise<any> = _.once(() => {
+export const getBuckets = _.once(() => {
   return getDefinitions().then((defs) => {
     const buckets: InventoryBuckets = {
       byHash: {}, // numeric hash -> bucket

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -7,7 +7,11 @@ import { DimItemInfo } from './dim-item-info';
 /**
  * Reflect the old stores service data into the Redux store as a migration aid.
  */
-export const update = createStandardAction('inventory/UPDATE')<DimStore[]>();
+export const update = createStandardAction('inventory/UPDATE')<{
+  stores: DimStore[];
+  buckets?: InventoryBuckets;
+  newItems?: Set<string>;
+}>();
 
 /**
  * Set the bucket info.

--- a/src/app/inventory/d1-stores.service.ts
+++ b/src/app/inventory/d1-stores.service.ts
@@ -22,7 +22,7 @@ import { InventoryBuckets } from './inventory-buckets';
 import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { router } from '../../router';
 import store from '../store/store';
-import { update, setBuckets } from './actions';
+import { update } from './actions';
 
 export const D1StoresService = StoreService();
 
@@ -70,7 +70,7 @@ function StoreService(): D1StoreServiceType {
     updateCharacters,
     reloadStores,
     touch() {
-      store.dispatch(update(_stores));
+      store.dispatch(update({ stores: _stores }));
     }
   };
 
@@ -206,10 +206,9 @@ function StoreService(): D1StoreServiceType {
           )
         );
 
-        store.dispatch(setBuckets(buckets));
-        return $q.all([newItems, itemInfoService, processStorePromises]);
+        return $q.all([buckets, newItems, itemInfoService, processStorePromises]);
       })
-      .then(([newItems, itemInfoService, stores]) => {
+      .then(([buckets, newItems, itemInfoService, stores]) => {
         // Save and notify about new items
         NewItemsService.applyRemovedNewItems(newItems);
         NewItemsService.saveNewItems(newItems, account);
@@ -227,7 +226,7 @@ function StoreService(): D1StoreServiceType {
 
         dimDestinyTrackerService.reattachScoresFromCache(stores);
 
-        store.dispatch(update(stores));
+        store.dispatch(update({ stores, buckets, newItems }));
 
         return stores;
       })

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -35,7 +35,7 @@ import { DimError } from '../bungie-api/bungie-service-helper';
 import { dimDestinyTrackerService } from '../item-review/destiny-tracker.service';
 import { router } from '../../router';
 import store from '../store/store';
-import { update, setBuckets } from './actions';
+import { update } from './actions';
 
 export const D2StoresService = makeD2StoresService();
 
@@ -85,7 +85,7 @@ function makeD2StoresService(): D2StoreServiceType {
     reloadStores,
     refreshRatingsData,
     touch() {
-      store.dispatch(update(_stores));
+      store.dispatch(update({ stores: _stores }));
     }
   };
 
@@ -259,8 +259,6 @@ function makeD2StoresService(): D2StoreServiceType {
           )
         );
 
-        store.dispatch(setBuckets(buckets));
-
         return $q.all([
           defs,
           buckets,
@@ -294,7 +292,7 @@ function makeD2StoresService(): D2StoreServiceType {
 
         dimDestinyTrackerService.reattachScoresFromCache(stores);
 
-        store.dispatch(update(stores));
+        store.dispatch(update({ stores, buckets, newItems }));
 
         return stores;
       })

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -61,10 +61,17 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.update):
       // TODO: we really want to decompose these, drive out all deep mutation
       // TODO: mark DimItem, DimStore properties as Readonly
-      return {
+      const newState = {
         ...state,
-        stores: [...action.payload]
+        stores: [...action.payload.stores]
       };
+      if (action.payload.buckets) {
+        newState.buckets = action.payload.buckets;
+      }
+      if (action.payload.newItems) {
+        newState.newItems = action.payload.newItems;
+      }
+      return newState;
 
     // Buckets
     // TODO: only need to do this once, on loading a new platform.

--- a/src/app/inventory/store/new-items.service.ts
+++ b/src/app/inventory/store/new-items.service.ts
@@ -44,6 +44,7 @@ export const NewItemsService = {
     const account = getActivePlatform();
     return this.loadNewItems(account).then((newItems) => {
       newItems.delete(item.id);
+      store.dispatch(setNewItems(newItems));
       this.saveNewItems(newItems, account, item.destinyVersion);
     });
   },
@@ -52,6 +53,7 @@ export const NewItemsService = {
     if (!stores || !account) {
       return;
     }
+    store.dispatch(setNewItems(new Set()));
     this.saveNewItems(new Set(), account);
   },
 
@@ -64,7 +66,6 @@ export const NewItemsService = {
   },
 
   saveNewItems(newItems: Set<string>, account: DestinyAccount) {
-    store.dispatch(setNewItems(newItems));
     return Promise.resolve(set(newItemsKey(account), newItems)).catch(handleLocalStorageFullError);
   },
 


### PR DESCRIPTION
This is a minor update, but it prevents several unnecessary re-renders while we're loading stores. Instead of separately setting buckets, stores, and newItems in separate Redux actions, I simply coalesce them into one.