### PR TITLE
Reduce global state updates while dragging and pause auto refresh while dragging

### DIFF
--- a/src/app/dim-ui/ActivityTracker.tsx
+++ b/src/app/dim-ui/ActivityTracker.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { loadingTracker } from '../ngimport-more';
 import { refresh as triggerRefresh, refresh$ } from '../shell/refresh';
 import { Subscription } from 'rxjs/Subscription';
+import { isDragging } from '../inventory/DraggableInventoryItem';
 
 const MIN_REFRESH_INTERVAL = 10 * 1000;
 const AUTO_REFRESH_INTERVAL = 30 * 1000;
@@ -93,8 +94,15 @@ export class ActivityTracker extends React.Component {
     const userWasActiveInTheLastHour = this.activeWithinTimespan(ONE_HOUR);
     const isDimVisible = !document.hidden;
     const isOnline = navigator.onLine;
+    const notDragging = !isDragging;
 
-    if (dimHasNoActivePromises && userWasActiveInTheLastHour && isDimVisible && isOnline) {
+    if (
+      dimHasNoActivePromises &&
+      userWasActiveInTheLastHour &&
+      isDimVisible &&
+      isOnline &&
+      notDragging
+    ) {
       this.refresh();
     }
   };

--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -27,11 +27,14 @@ export interface DragObject {
   item: DimItem;
 }
 
+export let isDragging = false;
+
 const dragSpec: DragSourceSpec<Props, DragObject> = {
   beginDrag(props) {
     if (props.item.maxStackSize > 1 && props.item.amount > 1) {
       store.dispatch(stackableDrag(true));
     }
+    isDragging = true;
     return { item: props.item };
   },
 
@@ -39,6 +42,7 @@ const dragSpec: DragSourceSpec<Props, DragObject> = {
     if (props.item.maxStackSize > 1 && props.item.amount > 1) {
       store.dispatch(stackableDrag(false));
     }
+    isDragging = false;
   },
 
   canDrag(props): boolean {


### PR DESCRIPTION
This should reduce "jank" in dragging because we won't do expensive updates while you're dragging. Loading item reviews can still jank it up though....