### PR TITLE
Show rarity on move popup

### DIFF
--- a/src/app/move-popup/dimMoveItemProperties.directive.ts
+++ b/src/app/move-popup/dimMoveItemProperties.directive.ts
@@ -46,9 +46,11 @@ function MoveItemPropertiesCtrl(
   vm.tab = 'default';
   vm.locking = false;
   vm.classes = {
-    'is-arc': false,
-    'is-solar': false,
-    'is-void': false
+    'is-Common': false,
+    'is-Uncommon': false,
+    'is-Rare': false,
+    'is-Legendary': false,
+    'is-Exotic': false
   };
   vm.light = null;
   $scope.$watch(
@@ -101,8 +103,8 @@ function MoveItemPropertiesCtrl(
     if (vm.item.primStat) {
       vm.light = vm.item.primStat.value.toString();
     }
-    if (vm.item.dmg) {
-      vm.classes[`is-${vm.item.dmg}`] = true;
+    if (vm.item.tier) {
+      vm.classes[`is-${vm.item.tier}`] = true;
     }
 
     if (

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -216,10 +216,6 @@ $item-header-spacing: 5px;
   }
   &.is-Legendary {
     background-color: $legendary;
-    color: #bbb;
-    select {
-      color: #bbb;
-    }
   }
   &.is-Exotic {
     background-color: $exotic;
@@ -227,6 +223,8 @@ $item-header-spacing: 5px;
   &.is-Uncommon,
   &.is-Rare,
   &.is-Legendary {
+    color: #bbb;
+    select,
     .item-title {
       color: #ddd;
     }

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -205,6 +205,33 @@ $item-header-spacing: 5px;
     background-color: $void;
   }
 
+  &.is-Common {
+    background-color: $common;
+  }
+  &.is-Uncommon {
+    background-color: $uncommon;
+  }
+  &.is-Rare {
+    background-color: $rare;
+  }
+  &.is-Legendary {
+    background-color: $legendary;
+    color: #bbb;
+    select {
+      color: #bbb;
+    }
+  }
+  &.is-Exotic {
+    background-color: $exotic;
+  }
+  &.is-Uncommon,
+  &.is-Rare,
+  &.is-Legendary {
+    .item-title {
+      color: #ddd;
+    }
+  }
+
   .item-title {
     color: #000;
     font-size: 1rem;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -7,6 +7,12 @@ $arc: #85c5ec;
 $solar: #f2721b;
 $void: #b184c5;
 
+$common: white;
+$uncommon: #366e42;
+$rare: #5076a3;
+$legendary: #513065;
+$exotic: #ceaf32;
+
 // The color of XP bars
 $xp: #5ea16a;
 // Border for completed items/quests/bounties


### PR DESCRIPTION
Removed the burn background color in favor of the rarity color.

We still show the burn icon on the move popup.

I know the move popup is good for a redesign, but figured this was a start.

![rec3](https://user-images.githubusercontent.com/424158/48251087-546fd100-e3b5-11e8-8100-5e859083b753.gif)


This resolves #2734