### PR TITLE
remove redundant `ng-i18next keys`

### DIFF
--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -248,7 +248,7 @@ class SettingsPage extends React.Component<Props, State> {
             />
           </section>
 
-          <h2 ng-i18next="Settings.Items">{t('Settings.Items')}</h2>
+          <h2>{t('Settings.Items')}</h2>
 
           <section>
             <div className="examples">
@@ -267,11 +267,7 @@ class SettingsPage extends React.Component<Props, State> {
                     name="itemSize"
                     onChange={this.onChange}
                   />
-                  <button
-                    className="dim-button"
-                    onClick={this.resetItemSize}
-                    ng-i18next="Settings.ResetToDefault"
-                  >
+                  <button className="dim-button" onClick={this.resetItemSize}>
                     {t('Settings.ResetToDefault')}
                   </button>
                 </div>
@@ -309,9 +305,7 @@ class SettingsPage extends React.Component<Props, State> {
             />
 
             <div className="setting">
-              <label htmlFor="itemSort" ng-i18next="Settings.SetSort">
-                {t('Settings.SetSort')}
-              </label>
+              <label htmlFor="itemSort">{t('Settings.SetSort')}</label>
 
               <div className="radioOptions">
                 {_.map(itemSortPresets, (i18nkey, value) => (
@@ -369,9 +363,7 @@ class SettingsPage extends React.Component<Props, State> {
                     value={settings.allowIdPostToDtr}
                     onChange={this.onChange}
                   />
-                  <div className="fineprint" ng-i18next="Settings.AllowIdPostToDtrLine2">
-                    {t('Settings.AllowIdPostToDtrLine2')}
-                  </div>
+                  <div className="fineprint">{t('Settings.AllowIdPostToDtrLine2')}</div>
                 </div>
 
                 {settings.allowIdPostToDtr && (


### PR DESCRIPTION
If we can move all or most of  the ng-i18next directives to the `t` function then `react-i18next` becomes basically a drop-in replacement for `ng-i18next`