### PR TITLE
'Fake' Objectives: Objective Tracking for Cache Keys

### DIFF
--- a/src/app/progress/D2SupplementalManifestDefinitions.ts
+++ b/src/app/progress/D2SupplementalManifestDefinitions.ts
@@ -1,0 +1,64 @@
+import { DestinyUnlockValueUIStyle } from 'bungie-api-ts/destiny2';
+
+const get = function(identifier: number) {
+  if (this.hasOwnProperty(identifier)) {
+    return this[identifier];
+  }
+  return this[0];
+};
+
+export const D2SupplementalManifestDefinitions = {
+  InventoryItem: { get },
+  Objective: {
+    get,
+    // dummy objective
+    0: {
+      minimumVisibilityThreshold: Number.MAX_VALUE,
+      progressDescription: '',
+      valueStyle: DestinyUnlockValueUIStyle.Automatic,
+      displayProperties: {
+        hasIcon: false,
+        icon: ''
+      },
+      completionValue: 0
+    },
+    // Encrypted Cache Key
+    1: {
+      minimumVisibilityThreshold: 0,
+      progressDescription: '',
+      valueStyle: DestinyUnlockValueUIStyle.Automatic,
+      displayProperties: {
+        hasIcon: false,
+        icon: ''
+      },
+      completionValue: 7
+    }
+  },
+  SandboxPerk: { get },
+  Stat: { get },
+  TalentGrid: { get },
+  Progression: { get },
+  ItemCategory: { get },
+  Activity: { get },
+  ActivityType: { get },
+  ActivityModifier: { get },
+  Vendor: { get },
+  SocketCategory: { get },
+  SocketType: { get },
+  Milestone: { get },
+  Destination: { get },
+  Place: { get },
+  VendorGroup: { get },
+  PlugSet: { get },
+  Collectible: { get },
+  PresentationNode: { get },
+  Record: { get },
+
+  InventoryBucket: {},
+  Class: {},
+  Gender: {},
+  Race: {},
+  Faction: {},
+  ItemTierType: {},
+  ActivityMode: {}
+};

--- a/src/app/progress/Quest.tsx
+++ b/src/app/progress/Quest.tsx
@@ -7,6 +7,8 @@ import { t } from 'i18next';
 import MilestoneDisplay from './MilestoneDisplay';
 import Countdown from '../dim-ui/Countdown';
 import * as _ from 'lodash';
+import { D2SupplementalManifestDefinitions } from './D2SupplementalManifestDefinitions';
+import { SupplementalObjectives } from './SupplementalObjectives';
 
 interface QuestProps {
   defs: D2ManifestDefinitions;
@@ -58,6 +60,9 @@ export default function Quest(props: QuestProps) {
       <div className="quest-objectives">
         {objectives.map((objective) => (
           <Objective defs={defs} objective={objective} key={objective.objectiveHash} />
+        ))}
+        {SupplementalObjectives.get(item.itemHash).map((objective) => (
+            <Objective defs={D2SupplementalManifestDefinitions} objective={objective} key={objective.objectiveHash}/>
         ))}
       </div>
       {rewards.map((reward) => (

--- a/src/app/progress/SupplementalObjectives.ts
+++ b/src/app/progress/SupplementalObjectives.ts
@@ -1,0 +1,51 @@
+
+export const SupplementalObjectives = {
+    get(hash: number) {
+      if (this.hasOwnProperty(hash)) {
+        return this[hash];
+      }
+      return [];
+    },
+    // Encrypted Cache Key - 0 / 7
+    1008524376: [{
+      progress: 0,
+      complete: false,
+      objectiveHash: 1
+    }],
+    // Encrypted Cache Key - 1 / 7
+    1008524377: [{
+      progress: 1,
+      complete: false,
+      objectiveHash: 1
+    }],
+    // Encrypted Cache Key - 2 / 7
+    1008524378: [{
+      progress: 2,
+      complete: false,
+      objectiveHash: 1
+    }],
+    // Encrypted Cache Key - 3 / 7
+    1008524379: [{
+      progress: 3,
+      complete: false,
+      objectiveHash: 1
+    }],
+    // Encrypted Cache Key - 4 / 7
+    1008524381: [{
+      progress: 4,
+      complete: false,
+      objectiveHash: 1
+    }],
+    // Encrypted Cache Key - 5 / 7
+    1008524382: [{
+      progress: 5,
+      complete: false,
+      objectiveHash: 1
+    }],
+    // Encrypted Cache Key - 6 / 7
+    1008524383: [{
+      progress: 6,
+      complete: false,
+      objectiveHash: 1
+    }]
+};


### PR DESCRIPTION
This addresses issue #2934 .

Added Supplemental Objectives and a Supplemental Manifest which can be used to manually add objective tracking to items when needed.

Encrypted Cache Keys are the notable use for this system.