### PR TITLE
make it more obvious that character cards can be clicked

### DIFF
--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -23,6 +23,12 @@
   max-width: 230px;
   cursor: pointer;
 
+  &:hover {
+    .loadout-button {
+      color: $orange;
+    }
+  }
+
   .phone-portrait & {
     margin: 0 auto;
   }


### PR DESCRIPTION
some people still don't realize that the character cards are clickable, this makes the chevron color orange on hover. 
<img width="647" alt="screen shot 2018-11-13 at 9 47 29 pm" src="https://user-images.githubusercontent.com/424158/48462679-f6b0ff80-e78d-11e8-81e5-758a79ae2fd3.png">
