### PR TITLE
Helvetica again

### DIFF
--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -233,6 +233,8 @@ $item-header-spacing: 5px;
     font-weight: 600;
     letter-spacing: 0;
     font-family: 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .icon {
     display: inline-block;

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -230,8 +230,9 @@ $item-header-spacing: 5px;
     font-size: 1rem;
     text-decoration: none;
     text-transform: uppercase;
-    font-weight: 700;
+    font-weight: 600;
     letter-spacing: 0;
+    font-family: 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
   }
   .icon {
     display: inline-block;

--- a/src/app/move-popup/press-tip.scss
+++ b/src/app/move-popup/press-tip.scss
@@ -14,8 +14,9 @@
   h2 {
     margin: 0 0 4px 0;
     font-size: 14px;
-    letter-spacing: 1px;
-    font-weight: normal;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-family: 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
   }
 }
 


### PR DESCRIPTION
I think Helvetica still looks better for the item popup titles:
<img width="384" alt="screen shot 2018-11-17 at 9 38 08 pm" src="https://user-images.githubusercontent.com/313208/48669100-8bc73780-eab1-11e8-82b8-c9e949de2d18.png">

And I decided that the press-tips could be bolder too:
<img width="341" alt="screen shot 2018-11-17 at 9 38 05 pm" src="https://user-images.githubusercontent.com/313208/48669099-8b2ea100-eab1-11e8-94ac-048fdb7591b1.png">
