### PR TITLE
Turn off filters on Edge

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -53,7 +53,8 @@ class App extends React.Component<Props> {
           itemQuality: this.props.itemQuality,
           'show-new-items': this.props.showNewItems,
           'new-item-animated': this.props.showNewAnimation,
-          'tall-tiles': $featureFlags.tallTiles
+          'tall-tiles': $featureFlags.tallTiles,
+          'ms-edge': /Edge/.test(navigator.userAgent)
         })}
       >
         <Header />

--- a/src/app/inventory/TallTile.scss
+++ b/src/app/inventory/TallTile.scss
@@ -132,6 +132,10 @@
     margin-right: 2px;
     color: #29f36a; // #5eff92;
     filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.8));
+    .ms-edge & {
+      // https://github.com/DestinyItemManager/DIM/issues/3291
+      filter: none;
+    }
   }
 
   .element {


### PR DESCRIPTION
This kills tag drop shadows for Edge, in hopes of fixing https://github.com/DestinyItemManager/DIM/issues/3291.