### PR TITLE
Make popup arrows match the new header colors

### DIFF
--- a/src/app/collections/collectible-popup.html
+++ b/src/app/collections/collectible-popup.html
@@ -14,5 +14,5 @@
       <img class="owned-icon" ng-src="{{vm.checkMark}}" /> This item is unlocked in collections.
     </div>
   </div>
-  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
+  <div class="arrow" ng-class="'is-{{vm.item.tier}}'"></div>
 </div>

--- a/src/app/d2-vendors/vendor-item-dialog.html
+++ b/src/app/d2-vendors/vendor-item-dialog.html
@@ -9,5 +9,5 @@
     failure-strings="vm.vendorItem.failureStrings"
     rewards="vm.rewards"
   ></dim-move-item-properties>
-  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
+  <div class="arrow" ng-class="'is-{{vm.item.tier}}'"></div>
 </div>

--- a/src/app/loadout-builder/loadout-builder-item-dialog.html
+++ b/src/app/loadout-builder/loadout-builder-item-dialog.html
@@ -21,5 +21,5 @@
     ng-if="!vm.item.equipment"
     ng-i18next="[i18next]({ num: vm.compareItemCount })Compare.ItemCount"
   ></div>
-  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
+  <div class="arrow" ng-class="'is-{{vm.item.tier}}'"></div>
 </div>

--- a/src/app/move-popup/dimMovePopup.directive.html
+++ b/src/app/move-popup/dimMovePopup.directive.html
@@ -35,5 +35,5 @@
       </div>
     </div>
   </div>
-  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
+  <div class="arrow" ng-class="'is-{{vm.item.tier}}'"></div>
 </div>

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -41,14 +41,20 @@
 
     border-bottom-color: white;
 
-    &.is-arc {
-      border-bottom-color: $arc;
+    &.is-Exotic {
+      border-bottom-color: $exotic;
     }
-    &.is-solar {
-      border-bottom-color: $solar;
+    &.is-Legendary {
+      border-bottom-color: $legendary;
     }
-    &.is-void {
-      border-bottom-color: $void;
+    &.is-Rare {
+      border-bottom-color: $rare;
+    }
+    &.is-Uncommon {
+      border-bottom-color: $uncommon;
+    }
+    &.is-Common {
+      border-bottom-color: $common;
     }
   }
   &[x-placement^='right'] .arrow {

--- a/src/app/vendors/vendor-item-dialog.html
+++ b/src/app/vendors/vendor-item-dialog.html
@@ -34,5 +34,5 @@
       {{ store.name }}
     </div>
   </div>
-  <div class="arrow" ng-class="'is-{{vm.item.dmg}}'"></div>
+  <div class="arrow" ng-class="'is-{{vm.item.tier}}'"></div>
 </div>


### PR DESCRIPTION
They hadn't been updated when we switched from damage to tier.