### PR TITLE
Improved Storage settings page

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -58,7 +58,9 @@ module.exports = function csp(env) {
       // Twitter Widget
       'https://syndication.twitter.com',
       'https://platform.twitter.com',
-      'https://*.twimg.com/'
+      'https://*.twimg.com/',
+      // User profile info in storage settings
+      'https://*.googleusercontent.com/'
     ],
     fontSrc: [
       SELF,

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -252,7 +252,12 @@ class SettingsPage extends React.Component<Props, State> {
 
           <section>
             <div className="examples">
-              <InventoryItem item={(fakeWeapon as any) as DimItem} isNew={true} rating={4.6} />
+              <InventoryItem
+                item={(fakeWeapon as any) as DimItem}
+                isNew={true}
+                rating={4.6}
+                tag="favorite"
+              />
             </div>
 
             {supportsCssVar && !isPhonePortrait && (

--- a/src/app/storage/GoogleDriveInfo.tsx
+++ b/src/app/storage/GoogleDriveInfo.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { DriveAboutResource } from './google-drive-storage';
+import { percent } from '../inventory/dimPercentWidth.directive';
+import { t } from 'i18next';
+import classNames from 'classnames';
+
+export function GoogleDriveInfo({ driveInfo }: { driveInfo: DriveAboutResource }) {
+  return (
+    <div>
+      <p className="google-user">
+        {driveInfo.user.photoLink && <img src={driveInfo.user.photoLink} />}
+        {driveInfo.user.displayName && <div>{driveInfo.user.displayName}</div>}
+        {driveInfo.user.emailAddress && <div>{driveInfo.user.emailAddress}</div>}
+      </p>
+      <div className="storage-guage">
+        <div
+          className={classNames({
+            full:
+              driveInfo.storageQuota.usage /
+                (driveInfo.storageQuota.limit || Number.MAX_SAFE_INTEGER) >
+              0.9
+          })}
+          style={{
+            width: percent(
+              driveInfo.storageQuota.usage /
+                (driveInfo.storageQuota.limit || Number.MAX_SAFE_INTEGER)
+            )
+          }}
+        />
+        {driveInfo.storageQuota.dimQuotaUsed && (
+          <div
+            className="dim-usage"
+            style={{
+              width: percent(
+                driveInfo.storageQuota.dimQuotaUsed /
+                  (driveInfo.storageQuota.limit || Number.MAX_SAFE_INTEGER)
+              )
+            }}
+          />
+        )}
+      </div>
+      <p>
+        {t(
+          driveInfo.storageQuota.limit
+            ? driveInfo.storageQuota.dimQuotaUsed
+              ? 'Storage.GoogleDriveUsage'
+              : 'Storage.GoogleDriveUsageNoFile'
+            : 'Storage.GoogleDriveUsageUnlimited',
+          driveInfo.storageQuota
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/app/storage/human-bytes.ts
+++ b/src/app/storage/human-bytes.ts
@@ -6,5 +6,5 @@ export function humanBytes(size: number) {
     return '0B';
   }
   const i = Math.floor(Math.log(size) / Math.log(1024));
-  return `${(size / Math.pow(1024, i)).toFixed(2)} ${['B', 'kB', 'MB', 'GB', 'TB'][i]}`;
+  return `${(size / Math.pow(1024, i)).toFixed(2)} ${['B', 'KB', 'MB', 'GB', 'TB'][i]}`;
 }

--- a/src/app/storage/storage.scss
+++ b/src/app/storage/storage.scss
@@ -8,6 +8,7 @@
   .storage-status {
     font-size: 12px;
     color: #ddd;
+    float: right;
 
     &.enabled {
       color: #20ea42;
@@ -24,13 +25,25 @@
     padding: 8px;
   }
 
-  .dim-button {
-    //font-size: 14px;
-  }
-
   ul {
     margin: 8px 0;
     padding-left: 2em;
+  }
+
+  .google-user {
+    overflow: hidden;
+    img {
+      border-radius: 50%;
+      float: left;
+      margin-right: 8px;
+      height: 32px;
+      width: 32px;
+    }
+    div {
+      &:nth-child(2) {
+        font-weight: bold;
+      }
+    }
   }
 
   .storage-guage {
@@ -48,6 +61,12 @@
       top: 0;
       left: 0;
       bottom: 0;
+      &.dim-usage {
+        background-color: $orange;
+      }
+      &.full {
+        background-color: red;
+      }
     }
   }
 }

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -696,7 +696,7 @@
     "Details": {
       "ChromeSyncStorage": "If you are logged in to Chrome, this will sync your data to other Chrome instances. It does not work on the DIM website.",
       "GoogleDriveStorage": "DIM can save data to Google Drive's app storage. If you sign in to Google Drive on multiple browsers, your data will be shared everywhere. This data is stored per Bungie account.",
-      "IndexedDBStorage": "Local storage will save your information only on this browser."
+      "IndexedDBStorage": "Local storage will save your information only on this browser. Clearing your browsing data will delete this information."
     },
     "Disabled": "Disabled",
     "DriveLogout": "Log out of Google Drive",
@@ -729,8 +729,11 @@
     "StatLabel": "This currently contains:",
     "TagNotesD1": "{{value}} Destiny 1 items with tags or notes",
     "TagNotesD2": "{{value}} Destiny 2 items with tags or notes",
-    "Title": "DIM Storage",
-    "Usage": "DIM is using {{usage, humanBytes}} out of {{quota, humanBytes}} available to it on this device."
+    "Title": "Data Storage",
+    "Usage": "DIM is using {{usage, humanBytes}} out of {{quota, humanBytes}} available to it on this device. This includes the downloaded Destiny item databases from Bungie.net.",
+    "GoogleDriveUsage": "Your Google Drive has {{usage, humanBytes}} total used out of {{limit, humanBytes}}. DIM is using {{dimQuotaUsed, humanBytes}} of that. If Google Drive fills up DIM will not be able to save data.",
+    "GoogleDriveUsageNoFile": "Your Google Drive has {{usage, humanBytes}} out of {{limit, humanBytes}} free. We couldn't find info about the DIM file, which may indicate a problem. If Google Drive fills up DIM will not be able to save data.",
+    "GoogleDriveUsageUnlimited": "Your Google Drive storage is unlimited."
   },
   "StoreBucket": {
     "FillStack": "Fill Stack ({{amount}})",


### PR DESCRIPTION
<img width="420" alt="screen shot 2018-11-18 at 3 08 30 pm" src="https://user-images.githubusercontent.com/313208/48679380-69cac500-eb44-11e8-81ae-bfb236d38c3b.png">

This adds more info to the Storage settings page:

1. Currently logged in Google identity.
2. Google Drive quota usage, and how much of that is used by DIM (it'll always be a really small amount).
3. Improved wording on some of the messages.
4. Move local storage quota info into the local storage box.