### PR TITLE
Styling updates

### DIFF
--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -57,10 +57,11 @@
 }
 
 .sub-bucket {
-  min-height: calc(var(--item-size) + ((var(--item-size) + 2px) / 5) + 5px);
+  min-height: calc(var(--item-size) + ((var(--item-size) + 2px) / 5) + 9px);
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
+  padding: 4px 0;
 
   &.on-drag-hover {
     box-shadow: inset 0 0 6px 0 rgba(200, 200, 200, 0.7);
@@ -76,12 +77,7 @@
 
   &.unequipped {
     flex: 1;
-    margin-right: 20px;
     width: 100%;
-
-    @include phone-portrait {
-      margin-right: 0px;
-    }
 
     .vault & {
       margin-left: 0;

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -1,17 +1,4 @@
-.equipped {
-  width: calc(var(--item-size) + 8px);
-  margin-right: 12px;
-}
-
-.unequipped {
-  flex: 1;
-  margin-right: 20px;
-
-  .vault & {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
+@import '../../scss/variables.scss';
 
 .on-drag-enter,
 .on-drag-hover {
@@ -20,32 +7,85 @@
 
 .sub-section {
   width: 100%;
-  margin-top: 6px;
-  margin-bottom: 6px;
   position: relative;
   display: flex;
   flex-direction: row;
-  height: calc(100% - 12px);
+  // TODO: what was this for?
+  // height: calc(100% - 12px);
   flex: 1;
 
   > div {
     white-space: normal;
   }
+
+  .equipped-item {
+    border: 2px solid #ddd;
+    height: fit-content;
+    padding: 2px;
+    //transform: translate(-4px, -4px);
+
+    .item-drag-container {
+      margin: 0;
+    }
+  }
+
+  &.not-equippable {
+    padding-left: 5px;
+  }
+
+  // Subclasses
+  &.bucket-3284755031 {
+    .sub-bucket {
+      min-height: 0;
+      &.equipped {
+        justify-content: center;
+      }
+    }
+
+    .item-drag-container {
+      --item-size: 32px;
+      @include phone-portrait {
+        --item-size: calc(
+          ((100vw - 40px - 5px * var(--character-columns)) / (var(--character-columns) + 1)) * 0.6
+        );
+      }
+    }
+    .equipped-item {
+      border: none;
+    }
+  }
 }
 
 .sub-bucket {
-  min-height: calc(var(--item-size) + 4px);
-  background-size: var(--item-size);
-  background-position: 1px 1px;
-  background-image: url('../../images/bg_inventory_bucket_single_crop.png');
-  background-repeat: no-repeat;
+  min-height: calc(var(--item-size) + ((var(--item-size) + 2px) / 5) + 5px);
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
+
   &.on-drag-hover {
     box-shadow: inset 0 0 6px 0 rgba(200, 200, 200, 0.7);
   }
+  .no-badge & {
+    min-height: calc(var(--item-size) + 5px);
+  }
+
+  &.equipped {
+    width: calc(var(--item-size) + 10px);
+    margin-right: 4px;
+  }
+
   &.unequipped {
+    flex: 1;
+    margin-right: 20px;
     width: 100%;
+
+    @include phone-portrait {
+      margin-right: 0px;
+    }
+
+    .vault & {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }
 }

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -63,15 +63,18 @@ class StoreBucket extends React.Component<Props> {
   render() {
     const { items, itemSortOrder, bucket, store } = this.props;
 
-    const empty = !items.length;
     const equippedItem = items.find((i) => i.equipped);
     const unequippedItems = sortItems(items.filter((i) => !i.equipped), itemSortOrder);
 
     return (
-      <div className={classNames('sub-section', { empty })}>
+      <div
+        className={classNames('sub-section', `bucket-${bucket.hash}`, {
+          'not-equippable': !equippedItem
+        })}
+      >
         {equippedItem && (
           <StoreBucketDropTarget equip={true} bucket={bucket} store={store}>
-            {this.renderItem(equippedItem)}
+            <div className="equipped-item">{this.renderItem(equippedItem)}</div>
           </StoreBucketDropTarget>
         )}
         <StoreBucketDropTarget equip={false} bucket={bucket} store={store}>

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -69,7 +69,7 @@ class StoreBucket extends React.Component<Props> {
     return (
       <div
         className={classNames('sub-section', `bucket-${bucket.hash}`, {
-          'not-equippable': !equippedItem
+          'not-equippable': !store.isVault && !equippedItem
         })}
       >
         {equippedItem && (

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -67,5 +67,5 @@ export function StoreBuckets({
 }
 
 function bgColor(color: DestinyColor) {
-  return { backgroundColor: `rgba(${color.red}, ${color.green}, ${color.blue}, 0.2)` };
+  return { backgroundColor: `rgba(${color.red}, ${color.green}, ${color.blue}, 0.15)` };
 }

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -4,6 +4,7 @@ import StoreBucket from './StoreBucket';
 import { InventoryBucket } from './inventory-buckets';
 import classNames from 'classnames';
 import { PullFromPostmaster } from './PullFromPostmaster';
+import { DestinyColor } from 'bungie-api-ts/destiny2';
 
 /** One row of store buckets, one for each character and vault. */
 export function StoreBuckets({
@@ -50,6 +51,7 @@ export function StoreBuckets({
           vault: store.isVault,
           'no-badge': noBadges
         })}
+        style={store.isDestiny2() && store.color ? bgColor(store.color) : undefined}
       >
         {(!store.isVault || bucket.vaultBucket) && (
           <StoreBucket bucketId={bucket.id} storeId={store.id} />
@@ -62,4 +64,8 @@ export function StoreBuckets({
   }
 
   return <div className="store-row items">{content}</div>;
+}
+
+function bgColor(color: DestinyColor) {
+  return { backgroundColor: `rgba(${color.red}, ${color.green}, ${color.blue}, 0.2)` };
 }

--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -7,7 +7,7 @@
 
 .powerLevel,
 .light {
-  color: $gold;
+  color: $power;
 
   .app-icon {
     vertical-align: 25%;

--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -230,17 +230,3 @@
     font-size: 16px;
   }
 }
-
-.sticky-header-background {
-  left: 0;
-  right: 0;
-  background-color: #434444;
-  height: 82px;
-  position: fixed;
-  backface-visibility: hidden;
-  z-index: 4;
-
-  &.something-is-sticky {
-    box-shadow: 0 1px 6px 0px #222;
-  }
-}

--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -72,11 +72,16 @@
     }
   }
 
-  .character-text {
-    font-family: Roboto, 'Open Sans', sans-serif;
+  .character-text,
+  .currencies {
     flex: 1;
     text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5), 0px 0px 10px rgba(0, 0, 0, 0.5);
     min-width: 0;
+
+    .app-icon {
+      filter: drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.5))
+        drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.5));
+    }
   }
 
   .top,

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -34,12 +34,19 @@
   width: 100%;
   display: flex;
   flex-direction: row;
-  padding-left: 24px;
   box-sizing: border-box;
+  padding-left: 24px;
+
+  &.items {
+    margin: 8px 0;
+  }
 
   // Bit of a hack to make things line up
   &.items:last-child .store-cell {
     padding-bottom: 14px;
+  }
+  @include phone-portrait {
+    padding-left: 8px;
   }
 }
 
@@ -58,6 +65,11 @@
     margin-right: 0;
     width: auto;
     flex: 1;
+  }
+
+  @include phone-portrait {
+    width: 100%;
+    margin-right: 0;
   }
 
   &.account-wide {

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -35,41 +35,28 @@
   display: flex;
   flex-direction: row;
   box-sizing: border-box;
-  padding-left: 24px;
-
-  &.items {
-    margin: 8px 0;
-  }
-
-  // Bit of a hack to make things line up
-  &.items:last-child .store-cell {
-    padding-bottom: 14px;
-  }
-  @include phone-portrait {
-    padding-left: 8px;
-  }
 }
 
 .store-cell {
   flex-shrink: 0;
   display: flex;
-  margin-right: 12px;
-  width: calc(40px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 8px)));
+  width: calc(18px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 5px)));
   flex-direction: column;
+  padding: 0 8px 0 12px;
 
   &.vault {
     max-width: calc(8px + (var(--vault-max-columns) * (var(--item-size) + 8px)));
     background-color: rgba(245, 245, 245, 0.25);
-    padding: 0 12px 1px;
-    margin-left: -12px;
-    margin-right: 0;
     width: auto;
     flex: 1;
   }
 
+  &:nth-child(2) {
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+
   @include phone-portrait {
     width: 100%;
-    margin-right: 0;
   }
 
   &.account-wide {
@@ -95,9 +82,13 @@
   left: 0;
   width: auto;
   z-index: 10;
-  padding: 8px 0 4px 24px;
   background-color: #434444;
   filter: var(--color-filter);
+
+  .store-cell {
+    width: calc(14px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 5px)));
+    padding: 8px 12px 4px 12px;
+  }
 
   @supports (position: sticky) {
     position: sticky;

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -40,19 +40,16 @@
 .store-cell {
   flex-shrink: 0;
   display: flex;
-  width: calc(18px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 5px)));
+  width: calc(38px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 5px)));
   flex-direction: column;
   padding: 0 8px 0 12px;
+  box-sizing: border-box;
 
   &.vault {
     max-width: calc(8px + (var(--vault-max-columns) * (var(--item-size) + 8px)));
     background-color: rgba(245, 245, 245, 0.25);
     width: auto;
     flex: 1;
-  }
-
-  &:nth-child(2) {
-    background-color: rgba(0, 0, 0, 0.1);
   }
 
   @include phone-portrait {
@@ -86,7 +83,6 @@
   filter: var(--color-filter);
 
   .store-cell {
-    width: calc(14px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 5px)));
     padding: 8px 12px 4px 12px;
   }
 
@@ -105,6 +101,7 @@
     .store-cell {
       margin: 0;
       width: 100%;
+      padding: 8px 0 4px 0;
     }
 
     > div {

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -107,15 +107,6 @@
     box-shadow: 0 1px 6px 0px #222;
   }
 
-  .react.phone-portrait & > div {
-    max-width: 250px;
-    margin: 0 auto;
-    overflow: visible !important;
-    .frame {
-      overflow: visible !important;
-    }
-  }
-
   .phone-portrait & {
     padding-left: 0;
     overflow: hidden;
@@ -123,6 +114,15 @@
     .store-cell {
       margin: 0;
       width: 100%;
+    }
+
+    > div {
+      max-width: 250px;
+      margin: 0 auto;
+      overflow: visible !important;
+      .frame {
+        overflow: visible !important;
+      }
     }
   }
 }

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -62,7 +62,7 @@ class Stores extends React.Component<Props, State> {
 
     if (isPhonePortrait) {
       return (
-        <div className="inventory-content phone-portrait react">
+        <div className="inventory-content phone-portrait">
           <ScrollClassDiv className="store-row store-header" scrollClass="sticky">
             <ViewPager>
               <Frame className="frame" autoSize={false}>

--- a/src/app/inventory/TallTile.scss
+++ b/src/app/inventory/TallTile.scss
@@ -84,7 +84,6 @@
     color: black;
     height: calc(((var(--item-size) + 2px) / 5) + 4px);
     font-size: calc((var(--item-size) + 2px) / 5);
-    -webkit-font-smoothing: antialiased;
     width: 100%;
     display: flex;
     text-align: right;
@@ -101,19 +100,21 @@
   }
 
   .item-review {
-    font-size: calc((var(--item-size) + 2px) / 6.25);
-    color: #333;
+    font-size: calc((var(--item-size) + 2px) / 5.5);
     text-align: left;
     display: flex;
     align-items: center;
     line-height: 1em;
+    transform: translateY(-0.5px);
     .godroll {
       color: #ff7722;
     }
     .app-icon {
+      font-size: 0.7em;
       padding-right: 1px;
       padding-left: 0;
       position: static;
+      transform: translateY(0.5px);
     }
   }
 

--- a/src/app/inventory/TallTile.tsx
+++ b/src/app/inventory/TallTile.tsx
@@ -40,15 +40,8 @@ export default function DarkTile({
   tag?: TagValue;
   isNew: boolean;
 }) {
-  const borderless =
-    (item.isDestiny2 &&
-      item.isDestiny2() &&
-      (item.bucket.hash === 3284755031 ||
-        (item.itemCategoryHashes && item.itemCategoryHashes.includes(268598612)))) ||
-    item.isEngram;
-
   const itemImageStyles = {
-    diamond: borderless,
+    diamond: borderless(item),
     masterwork: item.masterwork,
     capped: badgeInfo.isCapped,
     exotic: item.isExotic,
@@ -113,4 +106,14 @@ function ElementIcon({ element }: { element: DimItem['dmg'] }) {
     );
   }
   return null;
+}
+
+export function borderless(item: DimItem) {
+  return (
+    (item.isDestiny2 &&
+      item.isDestiny2() &&
+      (item.bucket.hash === 3284755031 ||
+        (item.itemCategoryHashes && item.itemCategoryHashes.includes(268598612)))) ||
+    item.isEngram
+  );
 }

--- a/src/app/inventory/get-badge-info.ts
+++ b/src/app/inventory/get-badge-info.ts
@@ -54,7 +54,7 @@ function processStackable(item: DimItem) {
 
 function processItem(item: DimItem) {
   const result = {
-    showBadge: Boolean(item.primStat && item.primStat.value),
+    showBadge: Boolean(item.primStat && item.primStat.value) || item.classified,
     badgeClassNames: {
       'item-equipment': true
     },
@@ -64,6 +64,10 @@ function processItem(item: DimItem) {
   if (item.primStat && result.showBadge) {
     result.badgeClassNames['item-stat'] = true;
     result.badgeCount = item.primStat.value.toString();
+  }
+  if (item.classified) {
+    result.badgeClassNames['item-stat'] = true;
+    result.badgeCount = '???';
   }
   return result;
 }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -2,7 +2,8 @@ import {
   DestinyClass,
   DestinyProgression,
   DestinyCharacterComponent,
-  DestinyFactionDefinition
+  DestinyFactionDefinition,
+  DestinyColor
 } from 'bungie-api-ts/destiny2';
 import { Loadout } from '../loadout/loadout.service';
 import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
@@ -262,6 +263,7 @@ export interface D2Store extends DimStore {
   buckets: { [bucketId: string]: D2Item[] };
   /** The vault associated with this store. */
   vault?: D2Vault;
+  color: DestinyColor;
   stats: {
     maxBasePower?: D2CharacterStat;
     [statHash: number]: D2CharacterStat;

--- a/src/app/inventory/store/d2-store-factory.service.ts
+++ b/src/app/inventory/store/d2-store-factory.service.ts
@@ -87,6 +87,7 @@ const StoreProto = {
     this.background = bungieNetPath(character.emblemBackgroundPath);
     this.icon = bungieNetPath(character.emblemPath);
     this.stats = { ...this.stats, ...getCharacterStatsData(defs.Stat, character.stats) };
+    this.color = character.emblemColor;
   },
 
   // Remove an item from this store. Returns whether it actually removed anything.
@@ -173,7 +174,8 @@ export function makeCharacter(
     className,
     gender: genderName,
     genderRace,
-    isVault: false
+    isVault: false,
+    color: character.emblemColor
   });
 
   store.name = `${store.genderRace} ${store.className}`;

--- a/src/app/login/login.scss
+++ b/src/app/login/login.scss
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: Roboto, 'Open Sans', sans-serif;
   font-size: 16px;
 
   .content {

--- a/src/index.html
+++ b/src/index.html
@@ -22,11 +22,6 @@
       rel="stylesheet"
       type="text/css"
     />
-    <link
-      href="https://fonts.googleapis.com/css?family=Roboto:300"
-      rel="stylesheet"
-      type="text/css"
-    />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-6-2018.png" />
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -22,7 +22,7 @@
 @include phone-portrait {
   :root {
     --item-size: calc(
-      (100vw - 80px - 8px * var(--character-columns)) / (var(--character-columns) + 1)
+      (100vw - 40px - 5px * var(--character-columns)) / (var(--character-columns) + 1)
     ) !important;
     --vault-max-columns: 999 !important;
   }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -254,21 +254,6 @@ h4 {
   }
 }
 
-.sticky-header-background {
-  left: 0;
-  right: 0;
-  top: $header-height;
-  background-color: #434444;
-  height: 82px;
-  position: fixed;
-  backface-visibility: hidden;
-  z-index: 4;
-
-  &.sticky {
-    box-shadow: 0 1px 6px 0px #222;
-  }
-}
-
 .fa.fa-circle.trials {
   font-size: 18px;
   margin-right: 3px;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -17,6 +17,7 @@ $exotic: #ceaf32;
 $xp: #5ea16a;
 // Border for completed items/quests/bounties
 $gold: #f5dc56;
+$power: #09d7d0;
 
 $character-box-height: 46px;
 


### PR DESCRIPTION
<img width="1430" alt="screen shot 2018-11-21 at 4 18 58 pm" src="https://user-images.githubusercontent.com/313208/48868885-2c1aa600-eda9-11e8-88ba-5065c0397819.png">
<img width="232" alt="screen shot 2018-11-21 at 4 19 43 pm" src="https://user-images.githubusercontent.com/313208/48868914-49e80b00-eda9-11e8-888e-d0af6a766b3f.png">

![localhost_8080_ iphone 6_7_8 2](https://user-images.githubusercontent.com/313208/48868944-67b57000-eda9-11e8-9a29-aaa831cf3a7b.png)

1. Remove some dead CSS
2. Add a "???" badge for classified items.
3. Size tiles to fill the full width on mobile.
4. Add a border around equipped items and no longer space them out.
5. Generally trim margins in order to pack items together more regularly.
6. Remove Roboto usage (replaced with Open Sans).
7. Switch power to be blue instead of yellow.
8. Tint columns by the color of the equipped emblem.
9. Make ratings a bit larger and bolder.

