### PR TITLE
Add id to exported csv for armor and weapons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Remove the ability to set a specific vault width. Vault always takes all remaining space.
 * Inventory columns are shaded to match the equipped emblem.
 * Fit and finish changes to the new tiles and inventory display.
-* Add id column to exported csv for armor and weapons
+* Add id column to exported csv for ghosts, armor, and weapons
 
 # 5.2.1 (2018-11-20)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove the ability to set a specific vault width. Vault always takes all remaining space.
 * Inventory columns are shaded to match the equipped emblem.
 * Fit and finish changes to the new tiles and inventory display.
+* Add id column to exported csv for armor and weapons
 
 # 5.2.1 (2018-11-20)
 

--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -98,10 +98,11 @@ function downloadGhost(items, nameMap) {
 
 function downloadArmor(items, nameMap) {
   const header =
-    'Name,Tag,Tier,Type,Equippable,Light,Owner,% Leveled,Locked,Equipped,Year,DTR Rating,# of Reviews,% Quality,% IntQ,% DiscQ,% StrQ,Int,Disc,Str,Notes,Perks\n';
+    'Name,Id,Tag,Tier,Type,Equippable,Light,Owner,% Leveled,Locked,Equipped,Year,DTR Rating,# of Reviews,% Quality,% IntQ,% DiscQ,% StrQ,Int,Disc,Str,Notes,Perks\n';
   let data = '';
   items.forEach((item) => {
     data += `"${item.name}",`;
+    data += `${item.id},`;
     data += `${item.dimInfo.tag || ''},`;
     data += `${item.tier},`;
     data += `${item.typeName},`;
@@ -158,12 +159,13 @@ function downloadArmor(items, nameMap) {
 
 function downloadWeapons(guns, nameMap) {
   const header =
-    'Name,Tag,Tier,Type,Light,Dmg,Owner,% Leveled,Locked,Equipped,Year,DTR Rating,# of Reviews,' +
+    'Name,Id,Tag,Tier,Type,Light,Dmg,Owner,% Leveled,Locked,Equipped,Year,DTR Rating,# of Reviews,' +
     'AA,Impact,Range,Stability,ROF,Reload,Mag,Equip,' +
     'Notes,Nodes\n';
   let data = '';
   guns.forEach((gun) => {
     data += `"${gun.name}",`;
+    data += `${gun.id},`;
     data += `${gun.dimInfo.tag || ''},`;
     data += `${gun.tier},`;
     data += `${gun.typeName},`;

--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -73,11 +73,12 @@ function buildNodeString(nodes) {
 }
 
 function downloadGhost(items, nameMap) {
-  const header = 'Name,Tag,Tier,Owner,Locked,Equipped,Perks\n';
+  const header = 'Name,Id,Tag,Tier,Owner,Locked,Equipped,Perks\n';
 
   let data = '';
   items.forEach((item) => {
     data += `"${item.name}",`;
+    data += `${item.id},`;
     data += `${item.dimInfo.tag || ''},`;
     data += `${item.tier},`;
     data += `${nameMap[item.owner]},`;


### PR DESCRIPTION
I was looking to use some scripts to auto-tag items in DIM using the exported csvs. However, it's currently not possible to link the items in the CSV with their instances. This adds the id field to the csv to fix this. 