### PR TITLE
Parameterize item layout

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -317,9 +317,7 @@ module.exports = (env) => {
         // Forsaken Item Tiles
         '$featureFlags.forsakenTiles': JSON.stringify(env !== 'release'),
         // D2 Loadout Builder
-        '$featureFlags.d2LoadoutBuilder': JSON.stringify(env !== 'release'),
-        // New Tile Style
-        '$featureFlags.tallTiles': JSON.stringify(true)
+        '$featureFlags.d2LoadoutBuilder': JSON.stringify(env !== 'release')
       }),
 
       new LodashModuleReplacementPlugin({

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -53,7 +53,6 @@ class App extends React.Component<Props> {
           itemQuality: this.props.itemQuality,
           'show-new-items': this.props.showNewItems,
           'new-item-animated': this.props.showNewAnimation,
-          'tall-tiles': $featureFlags.tallTiles,
           'ms-edge': /Edge/.test(navigator.userAgent)
         })}
       >

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -5,7 +5,6 @@ import './InventoryItem.scss';
 import { TagValue } from './dim-item-info';
 import getBadgeInfo from './get-badge-info';
 import TallTile from './TallTile';
-import ClassicTile from './ClassicTile';
 
 interface Props {
   item: DimItem;
@@ -49,25 +48,14 @@ export default class InventoryItem extends React.Component<Props> {
           'search-hidden': searchHidden
         })}
       >
-        {$featureFlags.tallTiles ? (
-          <TallTile
-            item={item}
-            badgeInfo={badgeInfo}
-            rating={rating}
-            hideRating={hideRating}
-            tag={tag}
-            isNew={Boolean(isNew)}
-          />
-        ) : (
-          <ClassicTile
-            item={item}
-            badgeInfo={badgeInfo}
-            rating={rating}
-            hideRating={hideRating}
-            tag={tag}
-            isNew={Boolean(isNew)}
-          />
-        )}
+        <TallTile
+          item={item}
+          badgeInfo={badgeInfo}
+          rating={rating}
+          hideRating={hideRating}
+          tag={tag}
+          isNew={Boolean(isNew)}
+        />
       </div>
     );
   }

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -72,7 +72,7 @@
 
   &.equipped {
     width: calc(var(--item-size) + #{2 * ($equipped-item-border + $equipped-item-padding)});
-    margin-right: 8px;
+    margin-right: var(--item-margin);
   }
 
   &.unequipped {

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -17,9 +17,9 @@
   }
 
   .equipped-item {
-    border: 2px solid #ddd;
+    border: $equipped-item-border solid #ddd;
     height: fit-content;
-    padding: 2px;
+    padding: $equipped-item-padding;
 
     .item-drag-container {
       margin: 0;
@@ -71,7 +71,7 @@
   }
 
   &.equipped {
-    width: calc(var(--item-size) + 10px);
+    width: calc(var(--item-size) + #{2 * ($equipped-item-border + $equipped-item-padding)});
     margin-right: 8px;
   }
 

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -10,8 +10,6 @@
   position: relative;
   display: flex;
   flex-direction: row;
-  // TODO: what was this for?
-  // height: calc(100% - 12px);
   flex: 1;
 
   > div {
@@ -22,7 +20,6 @@
     border: 2px solid #ddd;
     height: fit-content;
     padding: 2px;
-    //transform: translate(-4px, -4px);
 
     .item-drag-container {
       margin: 0;
@@ -60,7 +57,7 @@
 }
 
 .sub-bucket {
-  min-height: calc(var(--item-size) + ((var(--item-size) + 2px) / 5) + 9px);
+  min-height: calc(#{$full-height-badge});
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
@@ -75,7 +72,7 @@
 
   &.equipped {
     width: calc(var(--item-size) + 10px);
-    margin-right: 4px;
+    margin-right: 8px;
   }
 
   &.unequipped {

--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -139,6 +139,14 @@
       filter: none;
     }
   }
+
+  &.vault {
+    background: black;
+    border-bottom-color: black;
+    .background {
+      display: none;
+    }
+  }
 }
 
 .levelBar {

--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -139,14 +139,6 @@
       filter: none;
     }
   }
-
-  &.vault {
-    background: black;
-    border-bottom-color: black;
-    .background {
-      display: none;
-    }
-  }
 }
 
 .levelBar {

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -27,7 +27,10 @@
 .store-cell {
   flex-shrink: 0;
   display: flex;
-  width: calc(38px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 5px)));
+  width: calc(
+    42px + var(--item-size) +
+      (var(--character-columns) * (var(--item-size) + (#{$item-border-width} + #{$item-margin})))
+  );
   flex-direction: column;
   padding: 0 8px 0 12px;
   box-sizing: border-box;

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -1,5 +1,8 @@
 @import '../../scss/variables.scss';
 
+$inventory-column-padding: 12px;
+$equipped-item-margin: 8px;
+
 .inventory-content {
   margin: 0 auto;
 
@@ -28,12 +31,12 @@
   flex-shrink: 0;
   display: flex;
   width: calc(
-    42px + var(--item-size) +
-      (var(--character-columns) * (var(--item-size) + (#{$item-border-width} + #{$item-margin})))
+    /* Equipped item */ var(--item-size) + #{2 * ($equipped-item-border + $equipped-item-padding)} +
+      /* Equipped item margin */ #{$equipped-item-margin} + /* Unequipped items */
+      (var(--character-columns) * (var(--item-size) + var(--item-margin)))
   );
   flex-direction: column;
-  padding: 0 8px 0 12px;
-  box-sizing: border-box;
+  padding: 0 calc(#{$inventory-column-padding} - var(--item-margin)) 0 $inventory-column-padding;
 
   &.vault {
     background-color: rgba(245, 245, 245, 0.25);
@@ -52,8 +55,12 @@
       flex: 1;
     }
     max-width: calc(
-      (38px + var(--item-size) + (var(--character-columns) * (var(--item-size) + 5px))) *
-        var(--num-characters)
+      var(--num-characters) *
+        (
+          /* The formula for a single cell above */ var(--item-size) + #{2 *
+            ($equipped-item-border + $equipped-item-padding)} + #{$equipped-item-margin} +
+            (var(--character-columns) * (var(--item-size) + var(--item-margin)))
+        ) + ((#{2 * $inventory-column-padding} - var(--item-margin)) * (var(--num-characters) - 1))
     );
   }
 }
@@ -72,7 +79,8 @@
   filter: var(--color-filter);
 
   .store-cell {
-    padding: 8px 12px 4px 12px;
+    padding: 8px calc(#{$inventory-column-padding} - var(--item-margin)) 4px
+      $inventory-column-padding;
   }
 
   @supports (position: sticky) {

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -1,7 +1,5 @@
 @import '../../scss/variables.scss';
 
-$inventory-column-padding: 12px;
-
 .inventory-content {
   margin: 0 auto;
 

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -1,7 +1,6 @@
 @import '../../scss/variables.scss';
 
 $inventory-column-padding: 12px;
-$equipped-item-margin: 8px;
 
 .inventory-content {
   margin: 0 auto;
@@ -31,12 +30,13 @@ $equipped-item-margin: 8px;
   flex-shrink: 0;
   display: flex;
   width: calc(
-    /* Equipped item */ var(--item-size) + #{2 * ($equipped-item-border + $equipped-item-padding)} +
-      /* Equipped item margin */ #{$equipped-item-margin} + /* Unequipped items */
-      (var(--character-columns) * (var(--item-size) + var(--item-margin)))
+    /* Equipped item border */ #{2 * ($equipped-item-border + $equipped-item-padding)} + /* Equipped + unequipped items */
+      ((var(--character-columns) + 1) * (var(--item-size) + var(--item-margin))) + (#{2 *
+          $inventory-column-padding} - var(--item-margin))
   );
   flex-direction: column;
   padding: 0 calc(#{$inventory-column-padding} - var(--item-margin)) 0 $inventory-column-padding;
+  box-sizing: border-box;
 
   &.vault {
     background-color: rgba(245, 245, 245, 0.25);
@@ -57,9 +57,12 @@ $equipped-item-margin: 8px;
     max-width: calc(
       var(--num-characters) *
         (
-          /* The formula for a single cell above */ var(--item-size) + #{2 *
-            ($equipped-item-border + $equipped-item-padding)} + #{$equipped-item-margin} +
-            (var(--character-columns) * (var(--item-size) + var(--item-margin)))
+          /* Equipped item */ var(--item-size) + #{2 *
+            ($equipped-item-border + $equipped-item-padding)} + /* Equipped item margin */ var(
+              --item-margin
+            ) + /* Unequipped items */ (
+              var(--character-columns) * (var(--item-size) + var(--item-margin))
+            ) + (#{2 * $inventory-column-padding} - var(--item-margin))
         ) + ((#{2 * $inventory-column-padding} - var(--item-margin)) * (var(--num-characters) - 1))
     );
   }

--- a/src/app/inventory/TallTile.scss
+++ b/src/app/inventory/TallTile.scss
@@ -1,11 +1,11 @@
 @import '../../scss/variables.scss';
 
-.tall-tiles .item-drag-container {
+.item-drag-container {
   width: calc(#{$full-width});
   height: calc(#{$full-height-badge});
   margin: 0 $item-margin $item-margin 0;
 }
-.tall-tiles .no-badge {
+.no-badge {
   .item-drag-container {
     height: calc(#{$full-width});
   }
@@ -14,11 +14,10 @@
   }
 }
 
-.tall-tiles .diamond .item-img {
+.diamond .item-img {
   border-color: transparent;
 }
-
-.tall-tiles .item {
+.item {
   width: calc(#{$full-width});
   height: calc(#{$full-height-badge});
   margin: 0 $item-margin $item-margin 0;
@@ -170,7 +169,7 @@
   }
 }
 
-.ms-edge.tall-tiles .item .item-tag {
+.ms-edge .item .item-tag {
   // https://github.com/DestinyItemManager/DIM/issues/3291
   filter: none !important;
 }

--- a/src/app/inventory/TallTile.scss
+++ b/src/app/inventory/TallTile.scss
@@ -1,16 +1,16 @@
 @import '../../scss/variables.scss';
 
 .tall-tiles .item-drag-container {
-  width: calc(var(--item-size) + 2px);
-  height: calc(var(--item-size) + ((var(--item-size) + 2px) / 5) + 5px);
-  margin: 0 4px 4px 0;
+  width: calc(#{$full-width});
+  height: calc(#{$full-height-badge});
+  margin: 0 $item-margin $item-margin 0;
 }
 .tall-tiles .no-badge {
   .item-drag-container {
-    height: calc(var(--item-size) + 2px);
+    height: calc(#{$full-width});
   }
   .item {
-    height: calc(var(--item-size) + 2px);
+    height: calc(#{$full-width});
   }
 }
 
@@ -19,18 +19,18 @@
 }
 
 .tall-tiles .item {
-  width: calc(var(--item-size) + 2px);
-  height: calc(var(--item-size) + ((var(--item-size) + 2px) / 5) + 5px);
-  margin: 0 4px 4px 0;
+  width: calc(#{$full-width});
+  height: calc(#{$full-height-badge});
+  margin: 0 $item-margin $item-margin 0;
 
   .item-img {
-    border-width: 1px;
+    border-width: $item-border-width;
   }
 
   .overlay {
     box-sizing: border-box;
-    top: 1px;
-    left: 1px;
+    top: $item-border-width;
+    left: $item-border-width;
     border-width: 0px;
     height: var(--item-size);
     width: var(--item-size);
@@ -78,12 +78,12 @@
   }
 
   .item-stat {
-    top: calc(var(--item-size) + 1px);
+    top: calc(var(--item-size) + #{$item-border-width});
     bottom: auto;
     background-color: #ddd;
     color: black;
-    height: calc(((var(--item-size) + 2px) / 5) + 4px);
-    font-size: calc((var(--item-size) + 2px) / 5);
+    height: calc(#{$badge-height});
+    font-size: calc(#{$badge-font-size});
     width: 100%;
     display: flex;
     text-align: right;
@@ -92,7 +92,7 @@
     white-space: pre;
     align-items: center;
     justify-content: flex-end;
-    line-height: calc(((var(--item-size) + 2px) / 5) + 4px);
+    line-height: calc(#{$badge-height});
   }
 
   .primary-stat {
@@ -100,7 +100,7 @@
   }
 
   .item-review {
-    font-size: calc((var(--item-size) + 2px) / 5.5);
+    font-size: calc(#{$full-width} / 5.5);
     text-align: left;
     display: flex;
     align-items: center;
@@ -121,7 +121,7 @@
   .icons {
     position: absolute;
     left: 3px;
-    top: calc((var(--item-size) + 2px) * (4 / 5) - 4px);
+    top: calc((var(--item-size) + #{$item-border-width}) - #{$badge-height});
     display: flex;
     flex-direction: row;
   }
@@ -130,16 +130,16 @@
     // TODO: proportional size
     display: block;
     position: static;
-    width: calc((var(--item-size) + 2px) / 5);
-    height: calc((var(--item-size) + 2px) / 5);
+    width: calc((var(--item-size) + #{$double-border}) / 5);
+    height: calc((var(--item-size) + #{$double-border}) / 5);
     margin-right: 2px;
     color: #29f36a; // #5eff92;
     filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.8));
   }
 
   .element {
-    width: calc((var(--item-size) + 2px) / 6);
-    height: calc((var(--item-size) + 2px) / 6);
+    width: calc((var(--item-size) + #{$double-border}) / 6);
+    height: calc((var(--item-size) + #{$double-border}) / 6);
     transform: translateY(0.5px);
     &.void {
       filter: brightness(200%);
@@ -162,7 +162,7 @@
     right: 3px;
     opacity: 0.9;
     top: 3px;
-    height: calc((var(--item-size) + 2px) / 9);
+    height: calc((var(--item-size) + #{$double-border}) / 9);
     .item-xp-bar-amount {
       height: 100%;
       background-color: $xp;

--- a/src/app/inventory/TallTile.scss
+++ b/src/app/inventory/TallTile.scss
@@ -123,8 +123,8 @@
 
   .icons {
     position: absolute;
-    left: 3px;
-    top: calc(var(--item-size) - #{$badge-height});
+    left: $item-border-width + 2px;
+    top: calc(var(--item-size) - #{$badge-height} - #{$item-border-width});
     display: flex;
     flex-direction: row;
   }

--- a/src/app/inventory/TallTile.scss
+++ b/src/app/inventory/TallTile.scss
@@ -1,16 +1,17 @@
 @import '../../scss/variables.scss';
 
 .item-drag-container {
-  width: calc(#{$full-width});
+  box-sizing: border-box;
+  width: var(--item-size);
   height: calc(#{$full-height-badge});
-  margin: 0 $item-margin $item-margin 0;
+  margin: 0 var(--item-margin) var(--item-margin) 0;
 }
 .no-badge {
   .item-drag-container {
-    height: calc(#{$full-width});
+    height: var(--item-size);
   }
   .item {
-    height: calc(#{$full-width});
+    height: var(--item-size);
   }
 }
 
@@ -18,11 +19,13 @@
   border-color: transparent;
 }
 .item {
-  width: calc(#{$full-width});
+  box-sizing: border-box;
+  width: var(--item-size);
   height: calc(#{$full-height-badge});
-  margin: 0 $item-margin $item-margin 0;
+  margin: 0 var(--item-margin) var(--item-margin) 0;
 
   .item-img {
+    box-sizing: border-box;
     border-width: $item-border-width;
   }
 
@@ -31,8 +34,8 @@
     top: $item-border-width;
     left: $item-border-width;
     border-width: 0px;
-    height: var(--item-size);
-    width: var(--item-size);
+    height: calc(var(--item-size) - #{2 * $item-border-width});
+    width: calc(var(--item-size) - #{2 * $item-border-width});
     position: absolute;
     background-repeat: no-repeat;
     background-position: center;
@@ -49,7 +52,8 @@
       display: none;
     }
     .overlay {
-      background-size: calc(var(--item-size) * (96 / 90)) calc(var(--item-size) * (96 / 90));
+      background-size: calc((var(--item-size) - #{2 * $item-border-width}) * (96 / 90))
+        calc((var(--item-size) - #{2 * $item-border-width}) * (96 / 90));
       background-image: url('../../images/masterwork.png');
     }
   }
@@ -77,7 +81,7 @@
   }
 
   .item-stat {
-    top: calc(var(--item-size) + #{$item-border-width});
+    top: calc(var(--item-size) - #{$item-border-width});
     bottom: auto;
     background-color: #ddd;
     color: black;
@@ -99,7 +103,7 @@
   }
 
   .item-review {
-    font-size: calc(#{$full-width} / 5.5);
+    font-size: calc(var(--item-size) / 5.5);
     text-align: left;
     display: flex;
     align-items: center;
@@ -120,7 +124,7 @@
   .icons {
     position: absolute;
     left: 3px;
-    top: calc((var(--item-size) + #{$item-border-width}) - #{$badge-height});
+    top: calc(var(--item-size) - #{$badge-height});
     display: flex;
     flex-direction: row;
   }
@@ -129,23 +133,23 @@
     // TODO: proportional size
     display: block;
     position: static;
-    width: calc((var(--item-size) + #{$double-border}) / 5);
-    height: calc((var(--item-size) + #{$double-border}) / 5);
+    width: calc(var(--item-size) / 5);
+    height: calc(var(--item-size) / 5);
     margin-right: 2px;
     color: #29f36a; // #5eff92;
     filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.8));
   }
 
   .element {
-    width: calc((var(--item-size) + #{$double-border}) / 6);
-    height: calc((var(--item-size) + #{$double-border}) / 6);
+    width: calc(var(--item-size) / 6);
+    height: calc(var(--item-size) / 6);
     transform: translateY(0.5px);
     &.void {
       filter: brightness(200%);
       background-color: transparent !important;
     }
     &.arc {
-      filter: brightness(85%);
+      filter: brightness(65%) saturate(200%);
     }
   }
 
@@ -161,7 +165,7 @@
     right: 3px;
     opacity: 0.9;
     top: 3px;
-    height: calc((var(--item-size) + #{$double-border}) / 9);
+    height: calc(var(--item-size) / 9);
     .item-xp-bar-amount {
       height: 100%;
       background-color: $xp;

--- a/src/app/inventory/TallTile.scss
+++ b/src/app/inventory/TallTile.scss
@@ -5,6 +5,9 @@
   width: var(--item-size);
   height: calc(#{$full-height-badge});
   margin: 0 var(--item-margin) var(--item-margin) 0;
+  &:hover {
+    outline: 1px solid #ddd;
+  }
 }
 .no-badge {
   .item-drag-container {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,8 +35,6 @@ declare const $featureFlags: {
   respectDNT: boolean;
   /** D2 Loadout Builder */
   d2LoadoutBuilder: boolean;
-  /** New Tile Style */
-  tallTiles: boolean;
 };
 
 declare function ga(...params: string[]);

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -21,9 +21,14 @@
 
 @include phone-portrait {
   :root {
+    --item-margin: 12px;
     --item-size: calc(
-      (100vw - 40px - var(--item-margin) * var(--character-columns)) /
-        (var(--character-columns) + 1)
+      (
+          100vw - /* Equipped item border */ #{2 * ($equipped-item-border + $equipped-item-padding)} -
+            /* End margins */ (#{2 * $inventory-column-padding} - var(--item-margin)) - (
+              var(--item-margin)
+            ) * (var(--character-columns) + 1)
+        ) / (var(--character-columns) + 1)
     ) !important;
   }
 }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -6,6 +6,7 @@
 
 :root {
   --item-size: 48px;
+  --item-margin: 6px;
   --num-characters: 3;
   --character-columns: 3;
   --color-filter: '';
@@ -21,7 +22,7 @@
 @include phone-portrait {
   :root {
     --item-size: calc(
-      (100vw - 40px - (#{$item-margin} + #{$item-border-width}) * var(--character-columns)) /
+      (100vw - 40px - var(--item-margin) * var(--character-columns)) /
         (var(--character-columns) + 1)
     ) !important;
   }

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -6,7 +6,7 @@
 
 :root {
   --item-size: 48px;
-  --item-margin: 6px;
+  --item-margin: 8px;
   --num-characters: 3;
   --character-columns: 3;
   --color-filter: '';

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -21,7 +21,8 @@
 @include phone-portrait {
   :root {
     --item-size: calc(
-      (100vw - 40px - 5px * var(--character-columns)) / (var(--character-columns) + 1)
+      (100vw - 40px - (#{$item-margin} + #{$item-border-width}) * var(--character-columns)) /
+        (var(--character-columns) + 1)
     ) !important;
   }
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -21,6 +21,17 @@ $power: #09d7d0;
 
 $character-box-height: 46px;
 
+// Item tiles
+$item-border-width: 1px;
+$item-margin: 6px;
+
+$double-border: $item-border-width * 2;
+// Full tile size including borders
+$full-width: '(var(--item-size) + #{$double-border})';
+$badge-font-size: '(#{$full-width} / 5)';
+$badge-height: '(#{$badge-font-size} + 4px)';
+$full-height-badge: '(var(--item-size) + #{$badge-height} + #{$item-border-width})';
+
 @mixin phone-portrait {
   // This seems like a good breakpoint for portrait based on https://material.io/devices/
   // We can't use orientation:portrait because Android Chrome messes up when the keyboard is shown: https://www.chromestatus.com/feature/5656077370654720

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -29,6 +29,9 @@ $item-margin: 8px;
 $equipped-item-border: 1px;
 $equipped-item-padding: 2px;
 
+// Padding at the ends of inventory column
+$inventory-column-padding: 12px;
+
 // Full tile size including borders
 $badge-font-size: '(var(--item-size) / 5)';
 $badge-height: '(#{$badge-font-size} + 4px)';

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -22,15 +22,17 @@ $power: #09d7d0;
 $character-box-height: 46px;
 
 // Item tiles
-$item-border-width: 1px;
-$item-margin: 6px;
+$item-border-width: 2px;
+$item-margin: 8px;
 
-$double-border: $item-border-width * 2;
+// Border around equipped items
+$equipped-item-border: 2px;
+$equipped-item-padding: 2px;
+
 // Full tile size including borders
-$full-width: '(var(--item-size) + #{$double-border})';
-$badge-font-size: '(#{$full-width} / 5)';
+$badge-font-size: '(var(--item-size) / 5)';
 $badge-height: '(#{$badge-font-size} + 4px)';
-$full-height-badge: '(var(--item-size) + #{$badge-height} + #{$item-border-width})';
+$full-height-badge: '(var(--item-size) + #{$badge-height} - #{$item-border-width})';
 
 @mixin phone-portrait {
   // This seems like a good breakpoint for portrait based on https://material.io/devices/

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -26,7 +26,7 @@ $item-border-width: 2px;
 $item-margin: 8px;
 
 // Border around equipped items
-$equipped-item-border: 2px;
+$equipped-item-border: 1px;
 $equipped-item-padding: 2px;
 
 // Full tile size including borders


### PR DESCRIPTION
This makes it possible to adjust the item border, margin, etc. and have the rest of the layout work correctly. I also removed the feature flag for non-tall item tiles.

This also makes some updates suggested by @inexorableAce:

1. 2px item borders
2. 8px spacing between items (12px on mobile).
3. Darken the arc icon.

The switch to `box-sizing: border-box` means that item size now refers to the full size of the tile, not just the image, so our 48px default is now the same as what would be 46px before.

The border size probably should be proportional rather than fixed, now that I think about it, but that starts to get weird.

<img width="252" alt="screen shot 2018-11-24 at 5 13 12 pm" src="https://user-images.githubusercontent.com/313208/48973393-4dc79780-f00c-11e8-832d-48007fb755c0.png">
<img width="1406" alt="screen shot 2018-11-24 at 5 13 29 pm" src="https://user-images.githubusercontent.com/313208/48973394-4dc79780-f00c-11e8-82f6-4ab2f465fb2e.png">

