### PR TITLE
lightened up base bg a bit for pop-up contrast

### DIFF
--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -35,7 +35,7 @@
     display: block;
     width: calc(100% + 20px);
     height: 100%;
-    background: rgba(0, 0, 0, 0.25);
+    background: rgba(0, 0, 0, 0.15);
     margin-left: -12px;
   }
 }
@@ -80,7 +80,7 @@
   left: 0;
   width: auto;
   z-index: 10;
-  background-color: #262626;
+  background-color: #313233;
   filter: var(--color-filter);
 
   .store-cell {

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -9,7 +9,7 @@
   bottom: 0;
   background: #222222;
   color: #e0e0e0;
-  box-shadow: 0 -1px 6px 0px #222;
+  box-shadow: 0 -1px 20px 8px rgba(0, 0, 0, 0.8);
   padding-bottom: constant(safe-area-inset-bottom);
   padding-bottom: env(safe-area-inset-bottom);
   // 10px below the character header

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -108,7 +108,7 @@
   min-height: 77px;
   width: 320px;
   height: fit-content;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.8);
+  box-shadow: 0px 0px 20px 8px rgba(0, 0, 0, 0.8);
 
   .interaction {
     display: flex;

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -111,7 +111,7 @@ body {
   padding-top: 44px;
   padding-top: calc(44px + constant(safe-area-inset-top));
   padding-top: calc(44px + env(safe-area-inset-top));
-  background-color: #262626;
+  background-color: #313233;
   color: white;
   font-family: 'Open Sans', sans-serif;
   font-size: 12px;


### PR DESCRIPTION
last pass made the item pop-ups lack contrast, lightened up the base BG a bit and added a slightly larger drop shadow to the pop-up and loadout drawer
![image](https://user-images.githubusercontent.com/29002828/48974267-a5bcc900-f021-11e8-9f5d-b4f5a12ab6f1.png)
