### PR TITLE
different way to diff emblem color columns

### DIFF
--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -68,12 +68,12 @@ export function StoreBuckets({
 function bgColor(store: D2Store, index: number) {
   if (index % 2 === 1 && !store.isVault) {
     return {
-      backgroundColor: `rgba(${store.color.red}, ${store.color.green}, ${store.color.blue}, 0.25)`
+      backgroundColor: `rgba(${store.color.red * 0.75}, ${store.color.green * 0.75}, ${store.color
+        .blue * 0.75}, 0.25)`
     };
   } else {
     return {
-      backgroundColor: `rgba(${store.color.red * 0.95}, ${store.color.green * 0.95}, ${store.color
-        .blue * 0.95}, 0.25)`
+      backgroundColor: `rgba(${store.color.red}, ${store.color.green}, ${store.color.blue}, 0.25)`
     };
   }
 }

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -45,6 +45,7 @@
   &.vault {
     width: auto;
     flex: 1;
+    background: rgba(0, 0, 0, 0.12);
   }
 
   @include phone-portrait {
@@ -73,7 +74,6 @@
 .store-text {
   padding-top: 5px;
 }
-
 .store-header {
   position: fixed;
   backface-visibility: hidden;
@@ -83,30 +83,24 @@
   z-index: 10;
   background-color: #313233;
   filter: var(--color-filter);
-
   .store-cell {
     padding: 8px calc(#{$inventory-column-padding} - var(--item-margin)) 4px
       $inventory-column-padding;
   }
-
   @supports (position: sticky) {
     position: sticky;
   }
-
   &.sticky {
     box-shadow: 0 1px 6px 0px #222;
   }
-
   .phone-portrait & {
     padding-left: 0;
     overflow: hidden;
-
     .store-cell {
       margin: 0;
       width: 100%;
       padding: 8px 0 4px 0;
     }
-
     > div {
       max-width: 250px;
       margin: 0 auto;
@@ -117,21 +111,17 @@
     }
   }
 }
-
 .stores {
-  display: block;
-  // 77px margin to make room for the fixed header
+  display: block; // 77px margin to make room for the fixed header
   margin-top: 77px;
   @supports (position: sticky) {
     margin-top: 0;
   }
 }
-
 .dim-button.bucket-button {
   align-self: center;
   margin-top: 8px;
   background-color: #222;
-
   &:hover {
     background-color: #666;
   }


### PR DESCRIPTION
darkened the middle column for emblems to `* .75` to get same emblems to look different. darkened vault column by 12% to make it standout from inventory column.
![image](https://user-images.githubusercontent.com/29002828/48975262-c04f6c00-f03a-11e8-85dd-2c88a4d0f94c.png)
