### PR TITLE
Switch to 1px borders, 6px padding

### DIFF
--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -57,7 +57,7 @@ export interface Settings {
 }
 
 export function defaultItemSize() {
-  return 48;
+  return 50;
 }
 
 export const initialState: Settings = {

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -5,11 +5,17 @@
 @import 'variables.scss';
 
 :root {
-  --item-size: 48px;
-  --item-margin: 8px;
+  --item-size: 50px;
+  --item-margin: 6px;
   --num-characters: 3;
   --character-columns: 3;
   --color-filter: '';
+}
+
+@media (max-width: 1025px) {
+  :root {
+    --item-size: 48px !important;
+  }
 }
 
 @include phone-portrait {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -22,8 +22,7 @@ $power: #09d7d0;
 $character-box-height: 46px;
 
 // Item tiles
-$item-border-width: 2px;
-$item-margin: 8px;
+$item-border-width: 1px;
 
 // Border around equipped items
 $equipped-item-border: 1px;


### PR DESCRIPTION
I think this is actually the sweet spot in terms of getting enough items on screen while making things clean and visible. I'm also setting a 50px default item size which makes the icons perfectly half-size, which looks very sharp (no blurring from minor scaling).

<img width="1394" alt="screen shot 2018-11-25 at 12 45 11 pm" src="https://user-images.githubusercontent.com/313208/48982414-13afd180-f0b0-11e8-8985-a45ab6ce0ca8.png">

On iPad sized screens I'm scaling things down a bit so we still fit 5 columns of items in the vault.
![localhost_8080_ ipad](https://user-images.githubusercontent.com/313208/48984094-4f08cb00-f0c5-11e8-96f4-bb1936084e8c.png)
