### PR TITLE
Rearrange item stats

### DIFF
--- a/src/app/inventory/dimStats.scss
+++ b/src/app/inventory/dimStats.scss
@@ -50,8 +50,12 @@
       color: #aaa;
       flex: 0;
 
-      &:first-child img {
-        opacity: 0.6;
+      &:first-child {
+        margin-right: auto;
+
+        img {
+          opacity: 0.6;
+        }
       }
     }
   }


### PR DESCRIPTION
<img width="972" alt="screen shot 2018-11-25 at 3 22 38 pm" src="https://user-images.githubusercontent.com/313208/48984334-61383880-f0c8-11e8-8d71-aeb76f7e5553.png">

This just rearranges the item stats a bit to group the three character stats together and separate out the max light.