### PR TITLE
DOCKER - Performance Improvements and Fixes for running in Docker

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -60,6 +60,7 @@ module.exports = (env) => {
     // Dev server
     serve: process.env.WEBPACK_SERVE
       ? {
+          host: process.env.DOCKER ? '0.0.0.0' : 'localhost',
           devMiddleware: {
             stats: 'errors-only'
           },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,18 @@ services:
   webpack:
     container_name: dim-webpack
     image: node:10.9.0
-    expose:
-      - '8080'
-    command: bash -c 'yarn install && yarn start'
+    ports:
+      - '8080:8080'
+    working_dir: /usr/src/app
+    command: >
+      bash -c "yarn install &&
+               yarn start"
     environment:
       - NODE_ENV=dev
+      - DOCKER=true
     restart: 'no'
-    network_mode: host
     volumes:
       - .:/usr/src/app
+      - node_modules:/usr/src/app/node_modules
+volumes:
+  node_modules:


### PR DESCRIPTION
- Added env flag for docker to correctly bind webpack-serve to 0.0.0.0 to allow for host based port mapping
- Changed expose to ports to make it easier for user to modify mapped port if they desire
- Added working_dir so yarn command starts in proper folder
- Changed command for easier readability and to make it easier to see changes in a git log
- Removed network_mode: host to keep network inside container
- made node_modules a docker volume instead of host mapped folder to improve performance and compatibility with node modules