### PR TITLE
Remove rating star

### DIFF
--- a/src/app/inventory/InventoryItem.scss
+++ b/src/app/inventory/InventoryItem.scss
@@ -168,14 +168,10 @@
     .show-reviews & {
       display: flex;
     }
-
-    font-size: calc(var(--item-size) / 5.5);
     text-align: left;
     align-items: center;
-    line-height: 1em;
-    transform: translateY(-0.5px);
-    .godroll {
-      color: #ff7722;
+    &.godroll {
+      font-weight: bold;
     }
     .app-icon {
       font-size: 0.7em;
@@ -216,6 +212,7 @@
     width: calc(var(--item-size) / 6);
     height: calc(var(--item-size) / 6);
     transform: translateY(0.5px);
+    margin-right: 1px;
     &.void {
       filter: brightness(200%);
       background-color: transparent !important;

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -7,7 +7,7 @@ import getBadgeInfo from './get-badge-info';
 import BungieImage, { bungieBackgroundStyle } from '../dim-ui/BungieImage';
 import { percent } from './dimPercentWidth.directive';
 import { getColor } from '../shell/dimAngularFilters.filter';
-import { AppIcon, starIcon, halfStarIcon, starOutlineIcon, lockIcon } from '../shell/icons';
+import { AppIcon, lockIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 // tslint:disable-next-line:no-implicit-dependencies
 import newOverlay from 'app/images/overlay.svg';
@@ -89,12 +89,8 @@ export default class InventoryItem extends React.Component<Props> {
               </div>
             )}
             {rating !== undefined && !hideRating && (
-              <div className="item-review">
-                <AppIcon
-                  className={rating === 5 ? 'godroll' : ''}
-                  icon={rating > 4 ? starIcon : rating > 2 ? halfStarIcon : starOutlineIcon}
-                />
-                {rating}
+              <div className={classNames('item-review', { godroll: rating === 5 })}>
+                {rating.toFixed(1)}
               </div>
             )}
             <div className="primary-stat">


### PR DESCRIPTION
<img width="868" alt="screen shot 2018-11-28 at 12 04 09 am" src="https://user-images.githubusercontent.com/313208/49137454-51c01780-f2a1-11e8-909f-86fddbd58000.png">

This removes the rating star in favor of:

1. Full numbers even for whole-number ratings (i.e., 5.0 instead of 5).
2. Bold perfect 5.0 ratings.

I also added some padding to the element icon and made the rating font the exact same size as the power.