### PR TITLE
Ensure tag drop-down is always black on white

### DIFF
--- a/src/app/move-popup/item-tag.scss
+++ b/src/app/move-popup/item-tag.scss
@@ -6,4 +6,8 @@ dim-item-tag,
     border: none;
     outline: none;
   }
+  option {
+    color: black;
+    background: white;
+  }
 }


### PR DESCRIPTION
Could possibly use variables so it matches item rarity, but this is MVP.