### PR TITLE
increased line height for char cards, moved currencies down

### DIFF
--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -117,7 +117,7 @@
     flex: 1;
     text-overflow: ellipsis;
     overflow: hidden;
-    line-height: 1em;
+    line-height: 1.4em;
   }
   .level {
     margin-right: 1px;
@@ -128,7 +128,12 @@
   }
   .currency {
     font-weight: 400;
-    font-size: 14px;
+    font-size: 12px;
+    margin-right: 10px;
+
+    & img {
+      margin-right: 2px;
+    }
   }
 
   &.destiny2 {

--- a/src/app/inventory/StoreHeading.tsx
+++ b/src/app/inventory/StoreHeading.tsx
@@ -82,15 +82,15 @@ export default class StoreHeading extends React.Component<Props, State> {
                 <div className="top">
                   <div className="class">{store.className}</div>
                 </div>
-                <div className="bottom" />
-              </div>
-              <div className="currencies">
-                <div className="currency">
-                  {store.glimmer} <img src={glimmer} />
-                </div>
-                <div className="currency legendaryMarks">
-                  {store.legendaryMarks}{' '}
-                  <img src={store.isDestiny1() ? legendaryMarks : legendaryShards} />
+                <div className="bottom">
+                  <div className="currency">
+                    <img src={glimmer} />
+                    {store.glimmer}
+                  </div>
+                  <div className="currency legendaryMarks">
+                    <img src={store.isDestiny1() ? legendaryMarks : legendaryShards} />
+                    {store.legendaryMarks}{' '}
+                  </div>
                 </div>
               </div>
               {loadoutButton}


### PR DESCRIPTION
Increased line-height for class names from 1em to 1.4em, this allows low hanging characters to not get cut off. Also moved the currencies from the right hand side of the vault card to the bottom (where the race resides on characters), this allows the vault name to not go into ellipsis so soon so other languages can see the full name of the vault. 

Example images are for Italian.
before:
![image](https://user-images.githubusercontent.com/29002828/49320988-d645ac80-f4d2-11e8-92d2-8292a6a2f3be.png)

after:
![image](https://user-images.githubusercontent.com/29002828/49321022-00976a00-f4d3-11e8-88c7-e2d322f979b1.png)
 