### PR TITLE
Rework engram display

### DIFF
--- a/src/app/destiny2/d2-buckets.service.ts
+++ b/src/app/destiny2/d2-buckets.service.ts
@@ -6,7 +6,7 @@ import { InventoryBuckets, InventoryBucket } from '../inventory/inventory-bucket
 // TODO: These have to change
 // TODO: We can generate this based on making a tree from DestinyItemCategoryDefinitions
 export const D2Categories = {
-  Postmaster: ['LostItems', 'Messages', 'SpecialOrders', 'Engrams'],
+  Postmaster: ['Engrams', 'LostItems', 'Messages', 'SpecialOrders'],
   Weapons: ['Class', 'Kinetic', 'Energy', 'Power'],
   Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
   General: ['Ghost', 'ClanBanners', 'Vehicle', 'Ships', 'Emblems'],

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -47,10 +47,10 @@
 
     .item-drag-container,
     .empty-engram {
-      --item-size: 40px;
-      --item-margin: 2px;
+      --item-size: 22px;
+      --item-margin: 0px;
       @include phone-portrait {
-        --item-size: calc(((100vw - 32px) / 5) - 2px);
+        --item-size: calc(((100vw - 32px) / 10));
       }
     }
   }

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -31,6 +31,30 @@
     padding-left: 4px;
   }
 
+  // Engrams
+  &.bucket-375726501 {
+    .empty-engram {
+      border: $item-border-width solid transparent;
+      box-sizing: border-box;
+      height: var(--item-size);
+      width: var(--item-size);
+      margin-right: var(--item-margin);
+    }
+
+    .sub-bucket {
+      min-height: 0;
+    }
+
+    .item-drag-container,
+    .empty-engram {
+      --item-size: 40px;
+      --item-margin: 2px;
+      @include phone-portrait {
+        --item-size: calc(((100vw - 32px) / 5) - 2px);
+      }
+    }
+  }
+
   // Subclasses
   &.bucket-3284755031 {
     /*

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -14,6 +14,8 @@ import { RootState } from '../store/reducers';
 import { searchFilterSelector } from '../search/search-filters';
 import { connect } from 'react-redux';
 import { itemSortOrderSelector } from '../settings/item-sort';
+import emptyEngram from '../../../destiny-icons/general/empty-engram.svg';
+import * as _ from 'lodash';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -79,6 +81,10 @@ class StoreBucket extends React.Component<Props> {
         )}
         <StoreBucketDropTarget equip={false} bucket={bucket} store={store}>
           {unequippedItems.map((item) => this.renderItem(item))}
+          {bucket.id === '375726501' &&
+            _.times(bucket.capacity - unequippedItems.length, (index) => (
+              <img src={emptyEngram} className="empty-engram" key={index} />
+            ))}
         </StoreBucketDropTarget>
       </div>
     );

--- a/src/app/move-popup/move-locations.component.ts
+++ b/src/app/move-popup/move-locations.component.ts
@@ -73,7 +73,7 @@ function controller(
     }
 
     // Can pull items from the postmaster to the same character
-    if (vm.item.location.inPostmaster) {
+    if (vm.item.location.inPostmaster && vm.item.location.type !== 'Engrams') {
       return (
         vm.store.id === buttonStore.id &&
         vm.item.destinyVersion === 2 &&


### PR DESCRIPTION
<img width="778" alt="screen shot 2018-12-01 at 11 23 38 am" src="https://user-images.githubusercontent.com/313208/49332102-d3db6500-f55b-11e8-8c80-da015d4ce463.png">
<img width="276" alt="screen shot 2018-12-01 at 11 24 57 am" src="https://user-images.githubusercontent.com/313208/49332103-d3db6500-f55b-11e8-948f-48c4ea4c5d58.png">

This moves engrams to a small single row, with empty slots for other in-game engrams. This minimizes their impact on screen space while also visually distinguishing them from a regular bucket. I also fixed a bug where we offered to allow them to be transferred from DIM.