### PR TITLE
Full-width focused mobile search

### DIFF
--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -30,6 +30,11 @@ bulkItemTags.push({ type: 'clear', label: 'Tags.ClearTag' });
 bulkItemTags.push({ type: 'lock', label: 'Tags.LockAll' });
 bulkItemTags.push({ type: 'unlock', label: 'Tags.UnlockAll' });
 
+interface ProvidedProps {
+  mobile?: boolean;
+  onClear?(): void;
+}
+
 interface StoreProps {
   isPhonePortrait: boolean;
   destinyVersion: 1 | 2;
@@ -44,7 +49,7 @@ const mapDispatchToProps = {
 
 type DispatchProps = typeof mapDispatchToProps;
 
-type Props = StoreProps & DispatchProps;
+type Props = ProvidedProps & StoreProps & DispatchProps;
 
 interface State {
   showSelect: boolean;
@@ -178,7 +183,7 @@ class SearchFilter extends React.Component<Props, State> {
   }
 
   render() {
-    const { isPhonePortrait } = this.props;
+    const { isPhonePortrait, mobile } = this.props;
     const { showSelect, liveQuery } = this.state;
 
     // TODO: since we no longer take in the query as a prop, we can't set it from outside (filterhelp, etc)
@@ -224,6 +229,10 @@ class SearchFilter extends React.Component<Props, State> {
                 <AppIcon icon={tagIcon} title={t('Header.BulkTag')} />
               </a>
             )}
+          </span>
+        )}
+        {(liveQuery.length > 0 || mobile) && (
+          <span className="filter-help">
             <a onClick={this.clearFilter}>
               <AppIcon icon={disabledIcon} title={t('Header.Filters')} />
             </a>
@@ -232,6 +241,10 @@ class SearchFilter extends React.Component<Props, State> {
       </div>
     );
   }
+
+  focusFilterInput = () => {
+    this.inputElement.current && this.inputElement.current.focus();
+  };
 
   private showFilters = (e) => {
     e.stopPropagation();
@@ -266,10 +279,6 @@ class SearchFilter extends React.Component<Props, State> {
     }
   };
 
-  private focusFilterInput = () => {
-    this.inputElement.current && this.inputElement.current.focus();
-  };
-
   private blurFilterInput = () => {
     this.inputElement.current && this.inputElement.current.blur();
   };
@@ -291,6 +300,7 @@ class SearchFilter extends React.Component<Props, State> {
     this.props.setSearchQuery('');
     this.setState({ showSelect: false, liveQuery: '' });
     this.textcomplete && this.textcomplete.trigger('');
+    this.props.onClear && this.props.onClear();
   };
 
   private getStoresService = (): StoreServiceType => {
@@ -350,5 +360,7 @@ class SearchFilter extends React.Component<Props, State> {
 
 export default connect<StoreProps, DispatchProps>(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
+  null,
+  { withRef: true }
 )(SearchFilter);

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -32,7 +32,7 @@
 
   &:hover,
   &:focus {
-    background: transparent;
+    background: black;
     outline: none;
     border-bottom: 1px solid $orange;
   }
@@ -53,7 +53,19 @@
 
     &.show {
       display: block;
-      flex: 1;
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      height: $header-height;
+      z-index: 1;
+      margin: 0 !important;
+
+      .search-filter {
+        height: 100%;
+        padding: 0 0 0 8px;
+        margin: 0;
+      }
 
       .filter-input {
         height: 34px;
@@ -71,6 +83,10 @@
         &:focus {
           background-color: #222;
         }
+      }
+
+      .app-icon {
+        font-size: 18px !important;
       }
 
       input,
@@ -112,6 +128,11 @@
     background-color: #2e2e2e;
     position: relative;
     color: white;
+  }
+
+  span,
+  a {
+    margin: 0 !important;
   }
 }
 
@@ -172,6 +193,15 @@
       cursor: pointer;
     }
     text-decoration-line: none;
+  }
+
+  @include phone-portrait {
+    a {
+      font-size: 16px;
+    }
+    li {
+      padding: 8px 10px;
+    }
   }
   list-style: none;
   padding: 0;

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -88,6 +88,7 @@ export default class Header extends React.PureComponent<{}, State> {
   // tslint:disable-next-line:ban-types
   private unregisterTransitionHooks: Function[] = [];
   private dropdownToggler = React.createRef<HTMLElement>();
+  private searchFilter = React.createRef<any>();
 
   constructor(props) {
     super(props);
@@ -193,39 +194,31 @@ export default class Header extends React.PureComponent<{}, State> {
           )}
         </TransitionGroup>
 
-        {!showSearch && (
-          <UISref to="default-account">
-            <img
-              className={classNames('logo', 'link', $DIM_FLAVOR)}
-              title={`v${$DIM_VERSION} (${$DIM_FLAVOR})`}
-              src={logo}
-              alt="DIM"
-            />
-          </UISref>
-        )}
+        <UISref to="default-account">
+          <img
+            className={classNames('logo', 'link', $DIM_FLAVOR)}
+            title={`v${$DIM_VERSION} (${$DIM_FLAVOR})`}
+            src={logo}
+            alt="DIM"
+          />
+        </UISref>
 
-        {!showSearch && (
-          <div className="header-links">
-            {reverseDestinyLinks}
-            {reverseDimLinks}
-          </div>
-        )}
+        <div className="header-links">
+          {reverseDestinyLinks}
+          {reverseDimLinks}
+        </div>
 
         <span className="header-right">
-          {!showSearch && <Refresh />}
-          {!showSearch && account && account.destinyVersion === 2 && settings.showReviews && (
-            <RatingMode />
-          )}
-          {!showSearch && (
-            <UISref to="settings">
-              <a className="link" title={t('Settings.Settings')}>
-                <AppIcon icon={settingsIcon} />
-              </a>
-            </UISref>
-          )}
+          <Refresh />
+          {account && account.destinyVersion === 2 && settings.showReviews && <RatingMode />}
+          <UISref to="settings">
+            <a className="link" title={t('Settings.Settings')}>
+              <AppIcon icon={settingsIcon} />
+            </a>
+          </UISref>
           {account && (
             <span className={classNames('link', 'search-link', { show: showSearch })}>
-              <SearchFilter />
+              <SearchFilter onClear={this.hideSearch} ref={this.searchFilter} mobile={showSearch} />
             </span>
           )}
           <span className="link search-button" onClick={this.toggleSearch}>
@@ -235,6 +228,12 @@ export default class Header extends React.PureComponent<{}, State> {
         </span>
       </div>
     );
+  }
+
+  componentDidUpdate(_prevProps, prevState: State) {
+    if (!prevState.showSearch && this.state.showSearch && this.searchFilter.current) {
+      this.searchFilter.current.getWrappedInstance().focusFilterInput();
+    }
   }
 
   private toggleDropdown = () => {
@@ -249,6 +248,12 @@ export default class Header extends React.PureComponent<{}, State> {
 
   private toggleSearch = () => {
     this.setState({ showSearch: !this.state.showSearch });
+  };
+
+  private hideSearch = () => {
+    if (this.state.showSearch) {
+      this.setState({ showSearch: false });
+    }
   };
 
   private installDim = () => {


### PR DESCRIPTION
This is the first of a long series of changes to improve search, but it's valuable on its own. Now when you tap the search icon in mobile, search takes over the entire header and is immediately focused.

<img width="322" alt="screen shot 2018-12-01 at 11 30 37 am" src="https://user-images.githubusercontent.com/313208/49332147-8ca1a400-f55c-11e8-812f-e28082a883c9.png">
