### PR TITLE
Show inventory on all characters in phone mode

### DIFF
--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -9,16 +9,21 @@ import { PullFromPostmaster } from './PullFromPostmaster';
 export function StoreBuckets({
   bucket,
   stores,
-  vault
+  vault,
+  currentStore
 }: {
   bucket: InventoryBucket;
   stores: DimStore[];
   vault: DimVault;
+  currentStore: DimStore;
 }) {
   let content: React.ReactNode;
 
   // Don't show buckets with no items
-  if (!stores.some((s) => s.buckets[bucket.id].length > 0)) {
+  if (
+    (!bucket.accountWide || bucket.type === 'SpecialOrders') &&
+    !stores.some((s) => s.buckets[bucket.id].length > 0)
+  ) {
     return null;
   }
 
@@ -27,7 +32,6 @@ export function StoreBuckets({
   if (bucket.accountWide) {
     // If we're in mobile view, we only render one store
     const allStoresView = stores.length > 1;
-    const currentStore = stores.find((s) => s.current)!;
     content = (
       <>
         {(allStoresView || stores[0] !== vault) && (

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -90,7 +90,7 @@ class Stores extends React.Component<Props, State> {
           <div className="detached" ref={this.detachedLoadoutMenu} />
 
           <Hammer direction="DIRECTION_HORIZONTAL" onSwipe={this.handleSwipe}>
-            {this.renderStores([selectedStore], vault)}
+            {this.renderStores([selectedStore], vault, currentStore)}
           </Hammer>
         </div>
       );
@@ -105,7 +105,7 @@ class Stores extends React.Component<Props, State> {
             </div>
           ))}
         </ScrollClassDiv>
-        {this.renderStores(stores, vault)}
+        {this.renderStores(stores, vault, currentStore)}
       </div>
     );
   }
@@ -135,7 +135,7 @@ class Stores extends React.Component<Props, State> {
   };
 
   // TODO: move RenderStores to a component
-  private renderStores(stores: DimStore[], vault: DimVault) {
+  private renderStores(stores: DimStore[], vault: DimVault, currentStore: DimStore) {
     const { buckets } = this.props;
 
     return (
@@ -146,7 +146,13 @@ class Stores extends React.Component<Props, State> {
               <div key={category} className="section">
                 <CollapsibleTitle title={t(`Bucket.${category}`)} sectionId={category}>
                   {buckets.byCategory[category].map((bucket) => (
-                    <StoreBuckets key={bucket.id} bucket={bucket} stores={stores} vault={vault} />
+                    <StoreBuckets
+                      key={bucket.id}
+                      bucket={bucket}
+                      stores={stores}
+                      vault={vault}
+                      currentStore={currentStore}
+                    />
                   ))}
                 </CollapsibleTitle>
               </div>


### PR DESCRIPTION
This was a bug that was introduced when I tried to hide empty buckets. Now in mobile, Inventory will show for all characters.