### PR TITLE
Fix color styling for mass tag dropdown

### DIFF
--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -122,9 +122,12 @@
     }
   }
   .bulk-tag-select {
-    background-color: #444;
+    background-color: transparent;
     position: relative;
-    color: white;
+    option {
+      color: white;
+      background: #444;
+    }
   }
 
   span,

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -122,7 +122,7 @@
     }
   }
   .bulk-tag-select {
-    background-color: transparent;
+    background-color: #444;
     position: relative;
     option {
       color: white;


### PR DESCRIPTION
After:
![screenshot from 2018-12-02 16-09-59](https://user-images.githubusercontent.com/4798491/49346423-922be680-f64f-11e8-8ffe-1028a6455214.png)
![screenshot from 2018-12-02 16-10-06](https://user-images.githubusercontent.com/4798491/49346424-922be680-f64f-11e8-9132-3e18c35bd778.png)
![screenshot from 2018-12-02 16-10-09](https://user-images.githubusercontent.com/4798491/49346425-92c47d00-f64f-11e8-81ac-7f9fd88e1ceb.png)


Before:
![screenshot from 2018-12-02 16-10-21](https://user-images.githubusercontent.com/4798491/49346426-9952f480-f64f-11e8-8177-858ea1b0a865.png)
![screenshot from 2018-12-02 16-27-32](https://user-images.githubusercontent.com/4798491/49346427-9952f480-f64f-11e8-845e-832527643e9b.png)
