### PR TITLE
Search Bar - Tweak on hover/focus

### DIFF
--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -29,7 +29,6 @@
 
   &:hover,
   &:focus {
-    background: black;
     outline: none;
     border-bottom: 1px solid $orange;
   }

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -29,8 +29,7 @@
 
   &:hover,
   &:focus {
-    outline: none;
-    border-bottom: 1px solid $orange;
+    outline: 1px solid $orange;
   }
 
   input[type='text'] {


### PR DESCRIPTION
![screenshot from 2018-12-02 20-40-35](https://user-images.githubusercontent.com/4798491/49351954-e72d2400-f672-11e8-9c49-e7ef4155d6cd.png)

Applies orange border on hover/focus 