### PR TITLE
Wish list: expert mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Added "expert mode" for more complex wish list expressions.
 
 # 5.4.0 (2018-12-02)
 

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -18,3 +18,17 @@ If you have a roll in your inventory that you'd like to add to your wish list to
 ## Comments
 
 If you want to add comments in your text file on separate lines, go ahead! We'll ignore any line that isn't a link to banshee-44, so you can put notes for which item+roll you're talking about.
+
+## "Expert Mode"
+
+**Please note: you're on your own with this option. It's called expert mode for a reason, people.**
+
+If you're feeling particularly saucy, I've added an "expert mode" line format (you can put it in a file with banshee-44 links and comments and it'll all be read together.) The format looks like...
+
+`dimwishlist:item=1234&perks=456,567`
+
+Item is expected to be the manifest hash, perks are one or more perk hashes. To find these, use the mighty [Destiny Sets Data Explorer](https://data.destinysets.com/). You can search for items, perks and other things by typing their name in the search bar. Focus on things named "Inventory Item" when picking them out (the sandbox perk and collectible versions won't be found in your inventory). If you find an item you want, copy its hash (the number to the right of the name). That becomes the value for `item`. Repeat the same for `perks`; again, you want the `InventoryItem` version of the perk. If you want to specify multiple perks, separate them with a comma.
+
+Additionally, I've added a wildcard item ID - `-69420` **(nice)**.
+
+This lets you do things like, for example, wish list all items that have the "enhanced heavy lifting" perk active on them, or all items that have "improved Dreaming City cache detector" or whatever.

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -21,14 +21,24 @@ If you want to add comments in your text file on separate lines, go ahead! We'll
 
 ## "Expert Mode"
 
-**Please note: you're on your own with this option. It's called expert mode for a reason, people.**
+**Please note: you're largely on your own with this option. It's called expert mode for a reason, people.**
 
-If you're feeling particularly saucy, I've added an "expert mode" line format (you can put it in a file with banshee-44 links and comments and it'll all be read together.) The format looks like...
+If you're feeling particularly saucy, I've added an "expert mode" line format. You can put add lines with this alternate format in file with banshee-44 links and comments and it'll all be read together. The format looks like...
 
 `dimwishlist:item=1234&perks=456,567`
 
-Item is expected to be the manifest hash, perks are one or more perk hashes. To find these, use the mighty [Destiny Sets Data Explorer](https://data.destinysets.com/). You can search for items, perks and other things by typing their name in the search bar. Focus on things named "Inventory Item" when picking them out (the sandbox perk and collectible versions won't be found in your inventory). If you find an item you want, copy its hash (the number to the right of the name). That becomes the value for `item`. Repeat the same for `perks`; again, you want the `InventoryItem` version of the perk. If you want to specify multiple perks, separate them with a comma.
+Do not expect it to be flexible with casing or naming (it's not).
 
-Additionally, I've added a wildcard item ID - `-69420` **(nice)**. If specified, we'll search for the perks you specify on every item in the inventory.If all of the specified perks match, it's wish listed.
+`item`'s value is expected to be the manifest hash for the item, `perks` are one or more perk hashes, separated by commas.
 
-This lets you do things like, for example, wish list all items that have the "enhanced heavy lifting" perk active on them, or all items that have "improved Dreaming City cache detector" or whatever.
+To find these hashes, use the mighty [Destiny Sets Data Explorer](https://data.destinysets.com/). You can search for items, perks and other things by typing their name in the search bar. Focus on things named "Inventory Item" when picking them out. The sandbox perk and collectible versions of perks won't be found in your inventory.
+
+Once you look up an item that you want to keep an eye out for, copy its hash (the number to the right of the name). That becomes the value for `item`.
+
+Repeat the same for each of the `perks` you're interested in. Again, you want the `InventoryItem` version of the perk. If you want to specify multiple perks, separate them with a comma.
+
+This lets you express things like "if you see a Bygones with outlaw and kill clip on it, that's a keeper, no matter what else it does or doesn't have."
+
+Additionally, I've added a wildcard item ID - `-69420` **(nice)**. If you give your `item` that value, we'll look for the perks you specify in that line on every item in your inventory. If all of the specified perks match, it's wish listed.
+
+This lets you do things like, for example, wish list all armor pieces that have the "enhanced heavy lifting" perk on them, or all ghosts that have "improved Dreaming City cache detector", or all armor pieces with both "rocket launcher dexterity" and "rocket launcher scavenger" on them.

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -29,6 +29,6 @@ If you're feeling particularly saucy, I've added an "expert mode" line format (y
 
 Item is expected to be the manifest hash, perks are one or more perk hashes. To find these, use the mighty [Destiny Sets Data Explorer](https://data.destinysets.com/). You can search for items, perks and other things by typing their name in the search bar. Focus on things named "Inventory Item" when picking them out (the sandbox perk and collectible versions won't be found in your inventory). If you find an item you want, copy its hash (the number to the right of the name). That becomes the value for `item`. Repeat the same for `perks`; again, you want the `InventoryItem` version of the perk. If you want to specify multiple perks, separate them with a comma.
 
-Additionally, I've added a wildcard item ID - `-69420` **(nice)**.
+Additionally, I've added a wildcard item ID - `-69420` **(nice)**. If specified, we'll search for the perks you specify on every item in the inventory.If all of the specified perks match, it's wish listed.
 
 This lets you do things like, for example, wish list all items that have the "enhanced heavy lifting" perk active on them, or all items that have "improved Dreaming City cache detector" or whatever.

--- a/src/app/curated-rolls/curated-roll-reader.ts
+++ b/src/app/curated-rolls/curated-roll-reader.ts
@@ -1,4 +1,4 @@
-import { CuratedRoll } from './curatedRoll';
+import { CuratedRoll, DimWishList } from './curatedRoll';
 import * as _ from 'lodash';
 
 /** Translate a single banshee-44.com URL -> CuratedRoll. */
@@ -15,7 +15,35 @@ function toCuratedRoll(bansheeTextLine: string): CuratedRoll | null {
     return null;
   }
 
-  const itemHash = +matchResults[1];
+  const itemHash = Number(matchResults[1]);
+  const recommendedPerks = matchResults[2]
+    .split(',')
+    .map(Number)
+    .filter((perkHash) => perkHash > 0);
+
+  return {
+    itemHash,
+    recommendedPerks
+  };
+}
+
+function toDimWishListCuratedRoll(textLine: string): CuratedRoll | null {
+  if (!textLine || textLine.length === 0) {
+    return null;
+  }
+
+  const matchResults = textLine.match(/dimwishlist:item=(-?\d.+)&perks=(.*)/);
+
+  if (!matchResults || matchResults.length !== 3) {
+    return null;
+  }
+
+  const itemHash = Number(matchResults[1]);
+
+  if (itemHash < 0 && itemHash !== DimWishList.WildcardItemId) {
+    return null;
+  }
+
   const recommendedPerks = matchResults[2]
     .split(',')
     .map(Number)
@@ -31,5 +59,5 @@ function toCuratedRoll(bansheeTextLine: string): CuratedRoll | null {
 export function toCuratedRolls(bansheeText: string): CuratedRoll[] {
   const textArray = bansheeText.split('\n');
 
-  return _.compact(textArray.map(toCuratedRoll));
+  return _.compact(textArray.map(toCuratedRoll).concat(textArray.map(toDimWishListCuratedRoll)));
 }

--- a/src/app/curated-rolls/curatedRoll.ts
+++ b/src/app/curated-rolls/curatedRoll.ts
@@ -1,3 +1,7 @@
+export const enum DimWishList {
+  WildcardItemId = -69420 // nice
+}
+
 /**
  * Interface for translating lists of curated rolls to a format we can use.
  * Initially, support for translating banshee-44.com -> this has been built,

--- a/src/app/curated-rolls/curatedRollService.ts
+++ b/src/app/curated-rolls/curatedRollService.ts
@@ -1,6 +1,6 @@
 import { DimStore } from '../inventory/store-types';
 import { toCuratedRolls } from './curated-roll-reader';
-import { CuratedRoll } from './curatedRoll';
+import { CuratedRoll, DimWishList } from './curatedRoll';
 import { D2Item, DimPlug, DimItem } from '../inventory/item-types';
 import * as _ from 'lodash';
 
@@ -72,6 +72,12 @@ function allDesiredPerksExist(item: D2Item, curatedRoll: CuratedRoll): boolean {
     return false;
   }
 
+  if (curatedRoll.itemHash === DimWishList.WildcardItemId) {
+    return curatedRoll.recommendedPerks.every((rp) =>
+      _.flatMap(item.sockets!.sockets, (s) => (!s.plug ? 0 : s.plug.plugItem.hash)).includes(rp)
+    );
+  }
+
   return item.sockets.sockets.every(
     (s) =>
       !s.plug ||
@@ -117,8 +123,14 @@ export class CuratedRollService {
       return getNonCuratedRollIndicator(item);
     }
 
-    if (this._curatedRolls.some((cr) => cr.itemHash === item.hash)) {
-      const associatedRolls = this._curatedRolls.filter((cr) => cr.itemHash === item.hash);
+    if (
+      this._curatedRolls.some(
+        (cr) => cr.itemHash === item.hash || cr.itemHash === DimWishList.WildcardItemId
+      )
+    ) {
+      const associatedRolls = this._curatedRolls.filter(
+        (cr) => cr.itemHash === item.hash || cr.itemHash === DimWishList.WildcardItemId
+      );
 
       const matchingCuratedRoll = associatedRolls.find((ar) => allDesiredPerksExist(item, ar));
 

--- a/src/app/curated-rolls/curatedRollService.ts
+++ b/src/app/curated-rolls/curatedRollService.ts
@@ -34,7 +34,9 @@ function isWeaponOrArmorMod(plug: DimPlug): boolean {
     return false;
   }
 
-  return plug.plugItem.itemCategoryHashes.some((ich) => ich === 610365472 || ich === 4104513227); // weapon or armor mod
+  return plug.plugItem.itemCategoryHashes.some(
+    (ich) => ich === 610365472 || ich === 4104513227 || ich === 303512563
+  ); // weapon or armor mod or bonus mod
 }
 
 /** Is the plug's hash included in the recommended perks from the curated roll? */

--- a/src/app/curated-rolls/curatedRollService.ts
+++ b/src/app/curated-rolls/curatedRollService.ts
@@ -22,7 +22,7 @@ export interface InventoryCuratedRoll {
  * This is in place so that we can disregard intrinsics, shaders/cosmetics
  * and other things (like masterworks) which add more variance than we need.
  */
-function isWeaponOrArmorMod(plug: DimPlug): boolean {
+function isWeaponOrArmorOrGhostMod(plug: DimPlug): boolean {
   if (
     plug.plugItem.itemCategoryHashes.find(
       (ich) =>
@@ -35,8 +35,8 @@ function isWeaponOrArmorMod(plug: DimPlug): boolean {
   }
 
   return plug.plugItem.itemCategoryHashes.some(
-    (ich) => ich === 610365472 || ich === 4104513227 || ich === 303512563
-  ); // weapon or armor mod or bonus mod
+    (ich) => ich === 610365472 || ich === 4104513227 || ich === 303512563 || ich === 4176831154
+  ); // weapon, then armor, then bonus (found on armor perks), then ghost mod
 }
 
 /** Is the plug's hash included in the recommended perks from the curated roll? */
@@ -52,10 +52,14 @@ function getCuratedPlugs(item: D2Item, curatedRoll: CuratedRoll): number[] {
 
   const curatedPlugs: number[] = [];
 
+  if (item.id === '6917529080517332138') {
+    console.log('yup');
+  }
+
   item.sockets.sockets.forEach((s) => {
     if (s.plug) {
       s.plugOptions.forEach((dp) => {
-        if (isWeaponOrArmorMod(dp) && isCuratedPlug(dp, curatedRoll)) {
+        if (isWeaponOrArmorOrGhostMod(dp) && isCuratedPlug(dp, curatedRoll)) {
           curatedPlugs.push(dp.plugItem.hash);
         }
       });
@@ -83,7 +87,7 @@ function allDesiredPerksExist(item: D2Item, curatedRoll: CuratedRoll): boolean {
   return item.sockets.sockets.every(
     (s) =>
       !s.plug ||
-      !isWeaponOrArmorMod(s.plug) ||
+      !isWeaponOrArmorOrGhostMod(s.plug) ||
       s.plugOptions.some((dp) => isCuratedPlug(dp, curatedRoll))
   );
 }


### PR DESCRIPTION
I think b-44 is a fine app to use and is probably the best bet for most folks to get in there and build out lists of those god rolls that they have in mind.

Early feedback asked about more expressive uses - what if you only care about a subset of perks? What if you don't care what item has perk X, Y and Z? What if you're looking for armor or ghosts with certain perks on it?

To answer that question, I've added (forgive the name) expert mode. If you load this example file up on a build with this in it, you'll see that you can do things like highlight ghosts with perks, find any piece of armor that has enhanced heavy lifting or a specific weapon with a couple specific perks on it.

Creating the entries is absolutely not user friendly (and I'm not planning to work on tooling to make it any easier in the near-term), but I think this does end up being pretty powerful, and could cut down on a lot of the things that people reach to the spreadsheets for.

[suggested_items-comments.txt](https://github.com/DestinyItemManager/DIM/files/2650997/suggested_items-comments.txt)
