### PR TITLE
Use collectibles for displayProperties on redacted items

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Some redacted items now have a picture and some description, pulled from their collection record.
+
 # 5.4.0 (2018-12-02)
 
 * Moved is:yearX and is:seasonX searches to year:# and season:#.

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -67,6 +67,7 @@ const eagerTables = [
 
 export interface LazyDefinition<T> {
   get(hash: number): T;
+  getAll(): { [hash: number]: T };
 }
 
 export interface D2ManifestDefinitions {
@@ -128,6 +129,10 @@ async function getDefinitionsUncached() {
         const val = D2ManifestService.getRecord(db, table, name);
         this[name] = val;
         return val;
+      },
+
+      getAll() {
+        return D2ManifestService.getAllRecords(db, table);
       }
     };
   });

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -131,7 +131,7 @@ async function getDefinitionsUncached() {
         return val;
       },
 
-      getAll: _.once(() => {
+      getAll: _.once(function() {
         const allRecords = D2ManifestService.getAllRecords(db, table);
         // Cache all the results individually
         Object.assign(this, allRecords);

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -131,9 +131,12 @@ async function getDefinitionsUncached() {
         return val;
       },
 
-      getAll() {
-        return D2ManifestService.getAllRecords(db, table);
-      }
+      getAll: _.once(() => {
+        const allRecords = D2ManifestService.getAllRecords(db, table);
+        // Cache all the results individually
+        Object.assign(this, allRecords);
+        return allRecords;
+      })
     };
   });
   // Resources that need to be fully loaded (because they're iterated over)

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -225,6 +225,10 @@ export function createItemIndex(item: D2Item): string {
   return index;
 }
 
+const collectiblesByItemHash = _.memoize((Collectible) => {
+  return _.keyBy(Collectible.getAll(), 'itemHash');
+});
+
 /**
  * Process a single raw item into a DIM item.
  * @param defs the manifest definitions
@@ -267,6 +271,13 @@ export function makeItem(
   if (!itemDef || !itemDef.displayProperties.name) {
     return null;
   }
+
+  const collectibleDef = collectiblesByItemHash(defs.Collectible)[item.itemHash];
+
+  const displayProperties =
+    itemDef.redacted && collectibleDef
+      ? collectibleDef.displayProperties
+      : itemDef.displayProperties;
 
   // def.bucketTypeHash is where it goes normally
   let normalBucket = buckets.byHash[itemDef.inventory.bucketTypeHash];
@@ -316,9 +327,9 @@ export function makeItem(
     tier: tiers[itemDef.inventory.tierType] || 'Common',
     isExotic: tiers[itemDef.inventory.tierType] === 'Exotic',
     isVendorItem: !owner || owner.id === null,
-    name: itemDef.displayProperties.name,
-    description: itemDef.displayProperties.description,
-    icon: itemDef.displayProperties.icon || '/img/misc/missing_icon_d2.png',
+    name: displayProperties.name,
+    description: displayProperties.description,
+    icon: displayProperties.icon || '/img/misc/missing_icon_d2.png',
     secondaryIcon: itemDef.secondaryIcon || '/img/misc/missing_icon_d2.png',
     notransfer: Boolean(
       itemDef.nonTransferrable || item.transferStatus === TransferStatuses.NotTransferrable

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -225,10 +225,6 @@ export function createItemIndex(item: D2Item): string {
   return index;
 }
 
-const collectiblesByItemHash = _.memoize((Collectible) => {
-  return _.keyBy(Collectible.getAll(), 'itemHash');
-});
-
 /**
  * Process a single raw item into a DIM item.
  * @param defs the manifest definitions
@@ -272,12 +268,14 @@ export function makeItem(
     return null;
   }
 
-  const collectibleDef = collectiblesByItemHash(defs.Collectible)[item.itemHash];
-
-  const displayProperties =
-    itemDef.redacted && collectibleDef
-      ? collectibleDef.displayProperties
-      : itemDef.displayProperties;
+  let displayProperties = itemDef.displayProperties;
+  if (itemDef.redacted) {
+    // Fill in display info from the collectible, sometimes it's not redacted there!
+    const collectibleDef = defs.Collectible.getAll()[item.itemHash];
+    if (collectibleDef) {
+      displayProperties = collectibleDef.displayProperties;
+    }
+  }
 
   // def.bucketTypeHash is where it goes normally
   let normalBucket = buckets.byHash[itemDef.inventory.bucketTypeHash];

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -106,6 +106,10 @@ const resistanceMods = {
   1546607979: DamageType.Thermal
 };
 
+const collectiblesByItemHash = _.once((Collectible) => {
+  return _.keyBy(Collectible.getAll(), 'itemHash');
+});
+
 // Prototype for Item objects - add methods to this to add them to all
 // items.
 const ItemProto = {
@@ -271,7 +275,7 @@ export function makeItem(
   let displayProperties = itemDef.displayProperties;
   if (itemDef.redacted) {
     // Fill in display info from the collectible, sometimes it's not redacted there!
-    const collectibleDef = defs.Collectible.getAll()[item.itemHash];
+    const collectibleDef = collectiblesByItemHash(defs.Collectible)[item.itemHash];
     if (collectibleDef) {
       displayProperties = collectibleDef.displayProperties;
     }

--- a/src/app/progress/D2SupplementalManifestDefinitions.ts
+++ b/src/app/progress/D2SupplementalManifestDefinitions.ts
@@ -7,10 +7,15 @@ const get = function(identifier: number) {
   return this[0];
 };
 
+const getAll = function() {
+  return this;
+};
+
 export const D2SupplementalManifestDefinitions = {
-  InventoryItem: { get },
+  InventoryItem: { get, getAll },
   Objective: {
     get,
+    getAll,
     // dummy objective
     0: {
       minimumVisibilityThreshold: Number.MAX_VALUE,
@@ -34,25 +39,25 @@ export const D2SupplementalManifestDefinitions = {
       completionValue: 7
     }
   },
-  SandboxPerk: { get },
-  Stat: { get },
-  TalentGrid: { get },
-  Progression: { get },
-  ItemCategory: { get },
-  Activity: { get },
-  ActivityType: { get },
-  ActivityModifier: { get },
-  Vendor: { get },
-  SocketCategory: { get },
-  SocketType: { get },
-  Milestone: { get },
-  Destination: { get },
-  Place: { get },
-  VendorGroup: { get },
-  PlugSet: { get },
-  Collectible: { get },
-  PresentationNode: { get },
-  Record: { get },
+  SandboxPerk: { get, getAll },
+  Stat: { get, getAll },
+  TalentGrid: { get, getAll },
+  Progression: { get, getAll },
+  ItemCategory: { get, getAll },
+  Activity: { get, getAll },
+  ActivityType: { get, getAll },
+  ActivityModifier: { get, getAll },
+  Vendor: { get, getAll },
+  SocketCategory: { get, getAll },
+  SocketType: { get, getAll },
+  Milestone: { get, getAll },
+  Destination: { get, getAll },
+  Place: { get, getAll },
+  VendorGroup: { get, getAll },
+  PlugSet: { get, getAll },
+  Collectible: { get, getAll },
+  PresentationNode: { get, getAll },
+  Record: { get, getAll },
 
   InventoryBucket: {},
   Class: {},


### PR DESCRIPTION
_Most_ redacted items have Collectibles that are not redacted. This PR uses them for displayProperties of name, icon and description where they can be used. It still doesn't let us equip the item or determine its power, but at least the item is now searchable and provides a bit more context.

I also had to make a change to LazyDefinition to support getting all definitions of a type (because I need to key Collectibles by itemHash). I hope this is okay and I've done it correctly 😇 

<img width="695" alt="screenshot 2018-12-09 at 13 34 15" src="https://user-images.githubusercontent.com/46142/49698435-a3c73e00-fbbb-11e8-96ba-762aa3a51e6e.png">
