### PR TITLE
Use connected item in store item

### DIFF
--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -14,6 +14,7 @@ interface ProvidedProps {
   item: DimItem;
   allowFilter?: boolean;
   onClick?(e): void;
+  onDoubleClick?(e): void;
 }
 
 // Props from Redux via mapStateToProps
@@ -64,6 +65,7 @@ class ConnectedInventoryItem extends React.Component<Props> {
       tag,
       rating,
       onClick,
+      onDoubleClick,
       searchHidden,
       inventoryCuratedRoll,
       curationEnabled
@@ -76,6 +78,7 @@ class ConnectedInventoryItem extends React.Component<Props> {
         tag={tag}
         rating={rating}
         onClick={onClick}
+        onDoubleClick={onDoubleClick}
         searchHidden={searchHidden}
         curationEnabled={curationEnabled}
         inventoryCuratedRoll={inventoryCuratedRoll}

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -2,22 +2,13 @@ import * as React from 'react';
 import { DimItem } from './item-types';
 import DraggableInventoryItem from './DraggableInventoryItem';
 import ItemPopupTrigger from './ItemPopupTrigger';
-import InventoryItem from './InventoryItem';
 import { CompareService } from '../compare/compare.service';
 import { dimLoadoutService } from '../loadout/loadout.service';
 import { moveItemTo } from './dimItemMoveService.factory';
-import { TagValue } from './dim-item-info';
-import { InventoryCuratedRoll } from '../curated-rolls/curatedRollService';
+import ConnectedInventoryItem from './ConnectedInventoryItem';
 
 interface Props {
   item: DimItem;
-  isNew: boolean;
-  tag?: TagValue;
-  rating?: number;
-  hideRating?: boolean;
-  searchHidden?: boolean;
-  curationEnabled?: boolean;
-  inventoryCuratedRoll?: InventoryCuratedRoll;
 }
 
 /**
@@ -25,30 +16,15 @@ interface Props {
  */
 export default class StoreInventoryItem extends React.PureComponent<Props> {
   render() {
-    const {
-      item,
-      isNew,
-      tag,
-      rating,
-      searchHidden,
-      hideRating,
-      curationEnabled,
-      inventoryCuratedRoll
-    } = this.props;
+    const { item } = this.props;
 
     return (
       <DraggableInventoryItem item={item}>
         <ItemPopupTrigger item={item}>
-          <InventoryItem
+          <ConnectedInventoryItem
             item={item}
+            allowFilter={true}
             onDoubleClick={this.doubleClicked}
-            isNew={isNew}
-            tag={tag}
-            rating={rating}
-            hideRating={hideRating}
-            searchHidden={searchHidden}
-            curationEnabled={curationEnabled}
-            inventoryCuratedRoll={inventoryCuratedRoll}
           />
         </ItemPopupTrigger>
       </DraggableInventoryItem>


### PR DESCRIPTION
This switches to directly using the `ConnectedInventoryItem` instead of trying to "optimize" react-redux by connecting higher up the tree. After reading [this blog post](https://blog.isquaredsoftware.com/2018/11/react-redux-history-implementation/) I realized that it would probably be more responsive to just use the connected component directly, and my testing shows that this does in fact result in faster renders (and subsequently quicker interactions when updating stores and moving items).

Note that react-redux v6 may regress this improvement - I haven't upgraded yet.