### PR TITLE
Switch to JSON manifest for D2

### DIFF
--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { getCollections } from '../bungie-api/destiny2-api';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
-import { D2ManifestService } from '../manifest/manifest-service';
+import { D2ManifestService } from '../manifest/manifest-service-json';
 import './collections.scss';
 import { DimStore } from '../inventory/store-types';
 import { t } from 'i18next';

--- a/src/app/d2-vendors/SingleVendor.tsx
+++ b/src/app/d2-vendors/SingleVendor.tsx
@@ -4,7 +4,7 @@ import { DestinyAccount } from '../accounts/destiny-account.service';
 import { getVendor as getVendorApi } from '../bungie-api/destiny2-api';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
 import Countdown from '../dim-ui/Countdown';
-import { D2ManifestService } from '../manifest/manifest-service';
+import { D2ManifestService } from '../manifest/manifest-service-json';
 import VendorItems from './VendorItems';
 import './vendor.scss';
 import { fetchRatingsForVendor, fetchRatingsForVendorDef } from './vendor-ratings';

--- a/src/app/d2-vendors/Vendors.tsx
+++ b/src/app/d2-vendors/Vendors.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { getVendors as getVendorsApi } from '../bungie-api/destiny2-api';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
-import { D2ManifestService } from '../manifest/manifest-service';
+import { D2ManifestService } from '../manifest/manifest-service-json';
 import { loadingTracker } from '../shell/loading-tracker';
 import './vendor.scss';
 import { DestinyTrackerService } from '../item-review/destiny-tracker.service';

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -115,7 +115,7 @@ export const getDefinitions = _.once(getDefinitionsUncached);
  * above (defs.TalentGrid, etc.).
  */
 async function getDefinitionsUncached() {
-  const db = await D2ManifestService.getManifest();
+  const db = await D2ManifestService.getManifest([...eagerTables, ...lazyTables]);
   const defs = {};
   // Load objects that lazily load their properties from the sqlite DB.
   lazyTables.forEach((tableShort) => {

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -29,7 +29,7 @@ import {
   DestinyRecordDefinition
 } from 'bungie-api-ts/destiny2';
 import * as _ from 'lodash';
-import { D2ManifestService } from '../manifest/manifest-service';
+import { D2ManifestService } from '../manifest/manifest-service-json';
 
 const lazyTables = [
   'InventoryItem', // DestinyInventoryItemDefinition

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -19,7 +19,7 @@ import { reportException } from '../exceptions';
 import { optimalLoadout } from '../loadout/loadout-utils';
 import { getLight } from '../loadout/loadout.service';
 import '../rx-operators';
-import { D2ManifestService } from '../manifest/manifest-service';
+import { D2ManifestService } from '../manifest/manifest-service-json';
 import { resetIdTracker, processItems } from './store/d2-item-factory.service';
 import { makeVault, makeCharacter } from './store/d2-store-factory.service';
 import { NewItemsService } from './store/new-items.service';

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -34,7 +34,7 @@ import {
 } from '../../destiny2/d2-definitions.service';
 import { reportException } from '../../exceptions';
 
-import { D2ManifestService } from '../../manifest/manifest-service';
+import { D2ManifestService } from '../../manifest/manifest-service-json';
 import { getClass } from './character-utils';
 import { NewItemsService } from './new-items.service';
 import { ItemInfoSource } from '../dim-item-info';

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -12,7 +12,7 @@ import { getProgression, getVendors } from '../bungie-api/destiny2-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
 import { reportException } from '../exceptions';
-import { D2ManifestService } from '../manifest/manifest-service';
+import { D2ManifestService } from '../manifest/manifest-service-json';
 import { toaster } from '../ngimport-more';
 import '../rx-operators';
 import { getBuckets } from '../destiny2/d2-buckets.service';

--- a/src/app/shell/ManifestProgress.tsx
+++ b/src/app/shell/ManifestProgress.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
-import {
-  D1ManifestService,
-  D2ManifestService,
-  ManifestServiceState
-} from '../manifest/manifest-service';
+import { D1ManifestService, ManifestServiceState } from '../manifest/manifest-service';
 import './ManifestProgress.scss';
 import { Subscription } from 'rxjs/Subscription';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { AppIcon, refreshIcon } from './icons';
+import { D2ManifestService } from '../manifest/manifest-service-json';
 
 interface Props {
   destinyVersion: number;


### PR DESCRIPTION
This switches to the new JSON manifest, direct from Bungie.net, instead of using the SQLite stuff we were using. Note that we can't ditch that code because D1 doesn't have JSON manifests, so this is a fork of the manifest service.

The JSON definitions take about the same space on disk/indexedDB, seem to load about 40% faster than the SQLite version (once cached), and don't require as much code to be loaded (zip.js, SQLite) to handle. That's a win all around. This seems be a win on memory too, as we won't be keeping around the whole SQLite DB plus any deserialized objects (we just have ALL deserialized objects in memory instead). I measured around 430MB startup & 280MB after GC/background instead of 470MB/315MB for the SQLite version.

In the second commit I implemented a table whitelist driven from the definitions loader which trims out unused tables from the response - this further cuts down on disk and memory usage and makes loading even faster. The whitelist is kept in sync with a localStorage key, so if we deploy a change that requires a new table we will reload the manifest from the server to get it.

