### PR TITLE
Update Rank display

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Updated Crucible and Gambit ranks to reflect new multi-stage ranks.
+
 # 5.5.2 (2018-12-10)
 
 * Changed search behavior of perk:. It now tries to match the start of all words.

--- a/src/app/progress/CrucibleRank.scss
+++ b/src/app/progress/CrucibleRank.scss
@@ -1,5 +1,9 @@
 @import '../../scss/variables.scss';
 
+.activity-rank .faction-name {
+  text-transform: uppercase;
+}
+
 .crucible-rank-icon {
   margin: 2px 10px -2px 2px;
   position: relative;
@@ -9,13 +13,17 @@
 }
 
 .crucible-rank-progress {
-  stroke: $orange;
   fill: none;
 }
 
 .crucible-rank-total-progress {
   stroke: $blue;
   fill: none;
+}
+
+.faction-level .rank-icon {
+  height: 10px;
+  margin-right: 4px;
 }
 
 @include phone-portrait {

--- a/src/app/progress/CrucibleRank.tsx
+++ b/src/app/progress/CrucibleRank.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { t } from 'i18next';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import './faction.scss';
-import { bungieNetPath } from '../dim-ui/BungieImage';
+import BungieImage, { bungieNetPath } from '../dim-ui/BungieImage';
 import './CrucibleRank.scss';
 import * as _ from 'lodash';
 
@@ -19,12 +19,10 @@ export function CrucibleRank(props: CrucibleRankProps) {
 
   const step = progressionDef.steps[Math.min(progress.level, progressionDef.steps.length - 1)];
 
-  const rankTotal = progressionDef.steps.reduce((prev, cur) => {
-    return prev + cur.progressTotal;
-  }, 0);
+  const rankTotal = _.sumBy(progressionDef.steps, (cur) => cur.progressTotal);
 
   return (
-    <div className="faction" title={progressionDef.displayProperties.description}>
+    <div className="faction activity-rank" title={progressionDef.displayProperties.description}>
       <div>
         <CrucibleRankIcon progress={progress} defs={defs} />
       </div>
@@ -32,7 +30,8 @@ export function CrucibleRank(props: CrucibleRankProps) {
         <div className="faction-level">{progressionDef.displayProperties.name}</div>
         <div className="faction-name">{step.stepName}</div>
         <div className="faction-level">
-          {progress.progressToNextLevel} / {progress.nextLevelAt}
+          <BungieImage className="rank-icon" src={progressionDef.rankIcon} />
+          {progress.currentProgress} ({progress.progressToNextLevel} / {progress.nextLevelAt})
         </div>
         <div className="faction-level">
           {t('Progress.PercentPrestige', {
@@ -71,6 +70,9 @@ function CrucibleRankIcon(props: { progress: DestinyProgression; defs: D2Manifes
             strokeWidth="3"
             strokeDasharray={`${(circumference * progress.progressToNextLevel) /
               progress.nextLevelAt} ${circumference}`}
+            stroke={`rgb(${progressionDef.color.red}, ${progressionDef.color.green},${
+              progressionDef.color.blue
+            })`}
           />
         )}
         {progress.currentProgress > 0 && (
@@ -85,7 +87,7 @@ function CrucibleRankIcon(props: { progress: DestinyProgression; defs: D2Manifes
               rankTotal} ${circumference2}`}
           />
         )}
-        <image xlinkHref={bungieNetPath(step.icon)} width="44" height="44" x="5" y="5" />
+        <image xlinkHref={bungieNetPath(step.icon)} width="40" height="40" x="7" y="7" />
       </svg>
     </div>
   );

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -137,9 +137,9 @@ class Progress extends React.Component<Props, State> {
       .progressions;
     const crucibleRanks = [
       // Valor
-      firstCharacterProgression[3882308435],
+      firstCharacterProgression[2626549951],
       // Glory
-      firstCharacterProgression[2679551909],
+      firstCharacterProgression[2000925172],
       // Infamy
       firstCharacterProgression[2772425241]
     ];


### PR DESCRIPTION
<img width="204" alt="screen shot 2018-12-13 at 11 25 56 pm" src="https://user-images.githubusercontent.com/313208/49989322-b41a4880-ff2e-11e8-8c0c-730188b7a165.png">

This uses some new manifest data to display the progress bar for ranks in the ranks' preferred color, adds a rank value icon, shows the total rank points, and adjusts the image sizing a bit. I'm also using the new progression definitions that have the I, II, III divisions in them.