### PR TITLE
Replace stars with new rating icons, and properly suppress ratings

### DIFF
--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -36,7 +36,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   const dtrRating = getRating(item, state.reviews.ratings);
   const showRating =
     dtrRating &&
-    dtrRating.overallScore &&
+    dtrRating.overallScore !== undefined &&
     (dtrRating.ratingCount > (item.destinyVersion === 2 ? 0 : 1) ||
       dtrRating.highlightedRatingCount > 0);
 
@@ -64,6 +64,7 @@ class ConnectedInventoryItem extends React.Component<Props> {
       isNew,
       tag,
       rating,
+      hideRating,
       onClick,
       onDoubleClick,
       searchHidden,
@@ -77,6 +78,7 @@ class ConnectedInventoryItem extends React.Component<Props> {
         isNew={isNew}
         tag={tag}
         rating={rating}
+        hideRating={hideRating}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
         searchHidden={searchHidden}

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -7,10 +7,10 @@ import getBadgeInfo from './get-badge-info';
 import BungieImage, { bungieBackgroundStyle } from '../dim-ui/BungieImage';
 import { percent } from './dimPercentWidth.directive';
 import { getColor } from '../shell/dimAngularFilters.filter';
-import { AppIcon, starIcon, lockIcon, thumbsUpIcon } from '../shell/icons';
+import { AppIcon, lockIcon, thumbsUpIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { InventoryCuratedRoll } from '../curated-rolls/curatedRollService';
-import { faCaretUp, faCaretDown, faMinus } from '@fortawesome/free-solid-svg-icons';
+import RatingIcon from './RatingIcon';
 
 const tagIcons: { [tag: string]: IconDefinition | undefined } = {};
 itemTags.forEach((tag) => {
@@ -131,22 +131,6 @@ function ElementIcon({ element }: { element: DimItem['dmg'] }) {
     );
   }
   return null;
-}
-
-function RatingIcon({ rating }: { rating: number }) {
-  if (rating === 5) {
-    return <AppIcon className="godroll" icon={starIcon} />;
-  }
-
-  if (rating < 4) {
-    return <AppIcon className="dogroll" icon={faCaretDown} />;
-  }
-
-  if (rating >= 4.7) {
-    return <AppIcon className="goodroll" icon={faCaretUp} />;
-  }
-
-  return <AppIcon className="mehroll" icon={faMinus} />;
 }
 
 export function borderless(item: DimItem) {

--- a/src/app/move-popup/dimMoveItemProperties.html
+++ b/src/app/move-popup/dimMoveItemProperties.html
@@ -83,10 +83,12 @@
       ></div>
       <dim-item-tag ng-if="vm.item.taggable" item="vm.item"></dim-item-tag>
     </div>
-    <div ng-if="vm.item.reviewable && vm.item.dtrRating.overallScore" class="item-review-average">
-      <star-rating rating="vm.item.dtrRating.overallScore" read-only></star-rating>
+    <div
+      ng-if="vm.item.reviewable && vm.item.dtrRating.overallScore !== undefined && vm.item.dtrRating.ratingCount > 0"
+      class="item-review-average"
+    >
+      <rating-icon rating="vm.item.dtrRating.overallScore"></rating-icon>
       <span
-        ng-if="vm.item.reviewable"
         ng-i18next="[i18next]({ itemRating: vm.item.dtrRating.overallScore, numRatings: vm.item.dtrRating.ratingCount || 0 })DtrReview.AverageRating"
       ></span>
     </div>

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -173,6 +173,9 @@ $item-header-spacing: 5px;
 
   .item-review-average {
     margin-left: 1rem;
+    .rating-icon {
+      filter: drop-shadow(0 0 4px white);
+    }
   }
 
   .item-subtitle,

--- a/src/app/shell/shell.module.ts
+++ b/src/app/shell/shell.module.ts
@@ -4,8 +4,11 @@ import { ClickAnywhereButHere } from './click-anywhere-but-here.directive';
 import { FontAwesomeIcon } from './font-awesome-icon.directive';
 import dimAngularFiltersModule from './dimAngularFilters.filter';
 import { ToasterContainerComponent } from './toaster-container.component';
+import { react2angular } from 'react2angular';
+import RatingIcon from '../inventory/RatingIcon';
 
 export const ShellModule = module('dimShell', [dimAngularFiltersModule])
   .component('dimToasterContainer', ToasterContainerComponent)
   .directive('fontAwesomeIcon', FontAwesomeIcon)
+  .component('ratingIcon', react2angular(RatingIcon, ['rating']))
   .directive('dimClickAnywhereButHere', ClickAnywhereButHere).name;


### PR DESCRIPTION
1. Replace the stars with the new rating symbols in the item popup. The stars were confusing since they didn't line up with the new icons, and they also rounded up (so 4.5 === "5 stars").
2. Properly hide the icon on items when there are no reviews - I think this got missed when I switched to using ConnectedInventoryItem.

<img width="337" alt="screen shot 2018-12-15 at 12 01 35 pm" src="https://user-images.githubusercontent.com/313208/50046946-330f9e00-0061-11e9-819f-b3e9deb486d9.png">
