### PR TITLE
Explain missing socket info during B.net update

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -145,6 +145,8 @@ export interface DimItem {
   loreHash: number;
   /** A timestamp of when, in this session, the item was last manually moved */
   lastManuallyMoved: number;
+  /** Sometimes the API doesn't return socket info. This tells whether the item *should* have socket info but doesn't. */
+  missingSockets: boolean;
 
   /**
    * Information about community ratings.

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -375,7 +375,8 @@ export function makeItem(
     event: D2Events[item.itemHash],
     source: itemDef.collectibleHash
       ? defs.Collectible.get(itemDef.collectibleHash).sourceHash
-      : null
+      : null,
+    missingSockets: false
   });
 
   // *able
@@ -414,7 +415,17 @@ export function makeItem(
     // TODO: move socket handling and stuff into a different file
     if (itemComponents && itemComponents.sockets && itemComponents.sockets.data) {
       createdItem.sockets = buildSockets(item, itemComponents.sockets.data, defs, itemDef);
-    } else if (itemDef.sockets) {
+    }
+    if (!createdItem.sockets && itemDef.sockets) {
+      if (
+        itemComponents &&
+        itemComponents.sockets &&
+        itemComponents.sockets.data &&
+        item.itemInstanceId &&
+        !itemComponents.sockets.data[item.itemInstanceId]
+      ) {
+        createdItem.missingSockets = true;
+      }
       createdItem.sockets = buildDefinedSockets(defs, itemDef);
     }
   } catch (e) {

--- a/src/app/move-popup/dimMoveItemProperties.html
+++ b/src/app/move-popup/dimMoveItemProperties.html
@@ -208,6 +208,11 @@
           dim-infuse="vm.infuse(vm.item, $event)"
         ></dim-talent-grid>
       </div>
+      <div
+        ng-if="vm.item.missingSockets"
+        class="item-details warning"
+        ng-i18next="MovePopup.MissingSockets"
+      ></div>
       <sockets
         ng-if="vm.item.sockets"
         item="vm.item"

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -288,6 +288,17 @@ $item-header-spacing: 5px;
 
 .item-details {
   margin: 10px;
+  box-sizing: border-box;
+
+  &.warning {
+    background-color: #bd362f !important;
+    padding: 8px;
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    a {
+      color: white;
+      font-size: 12px;
+    }
+  }
 }
 
 .item-description {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -582,6 +582,7 @@
     "Infuse": "Infuse",
     "LockUnlock_Lock": "Lock {{itemType}}",
     "LockUnlock_Unlock": "Unlock {{itemType}}",
+    "MissingSockets": "Perk and mod details are unavailable while Bungie is updating their services. It will return when they are done, usually in a few hours.",
     "OverviewTab": "Overview",
     "ReadLore": "Read lore on Ishtar Collective",
     "ReviewsTab": "Reviews",


### PR DESCRIPTION
This implements half of https://github.com/DestinyItemManager/DIM/issues/3238.

When Bungie.net updates, they return an empty map of socket info. We can detect whether they *should have* had that info, and set a property that lets us show a warning. This should hopefully decrease all the questions we get every time there's a deployment.

I was also able to rearrange the conditions a bit so we are still showing some default info about the perks, just not what's actually selected/rolled.

<img width="328" alt="screen shot 2018-12-16 at 9 41 13 am" src="https://user-images.githubusercontent.com/313208/50056825-12a21b00-0117-11e9-969c-47f83635abf0.png">
