### PR TITLE
More specific wildcard wishlists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* You can specify item categories to be specific about your expert wish list items.
 
 # 5.6.0 (2018-12-17)
 

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -41,4 +41,8 @@ This lets you express things like "if you see a Bygones with outlaw and kill cli
 
 Additionally, I've added a wildcard item ID - `-69420` **(nice)**. If you give your `item` that value, we'll look for the perks you specify in that line on every item in your inventory. If all of the specified perks match, it's wish listed.
 
+If a wildcard is too broad and an item is too specific, you can supply the `ItemCategoryHash` that you want to look up the perk/perk combo on in the item ID. If you know, for example, that you're looking for perks X and Y on a class item, you can specify `item=49&perks=X,Y` and we'll only look for those perks on class items.
+
 This lets you do things like, for example, wish list all armor pieces that have the "enhanced heavy lifting" perk on them, or all ghosts that have "improved Dreaming City cache detector", or all armor pieces with both "rocket launcher dexterity" and "rocket launcher scavenger" on them.
+
+For wishlist line items, we'll ignore comments at the end of the line. Banshee-44 URLs are expected to be copy/paste friendly, so comments on those lines will break them.

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -45,4 +45,6 @@ If a wildcard is too broad and an item is too specific, you can supply the `Item
 
 This lets you do things like, for example, wish list all armor pieces that have the "enhanced heavy lifting" perk on them, or all ghosts that have "improved Dreaming City cache detector", or all armor pieces with both "rocket launcher dexterity" and "rocket launcher scavenger" on them.
 
+If there are multiple perks for a given slot that you'd be happy to get, and further there are multiple slots where multiple perks would be nice, then [48klocs built a little tool that will help you build out all of those permutations](https://48klocs.github.io/wish-list-magic-wand/fingerwave.html).
+
 For wishlist line items, we'll ignore comments at the end of the line. Banshee-44 URLs are expected to be copy/paste friendly, so comments on those lines will break them.

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -41,7 +41,7 @@ This lets you express things like "if you see a Bygones with outlaw and kill cli
 
 Additionally, I've added a wildcard item ID - `-69420` **(nice)**. If you give your `item` that value, we'll look for the perks you specify in that line on every item in your inventory. If all of the specified perks match, it's wish listed.
 
-If a wildcard is too broad and an item is too specific, you can supply the `ItemCategoryHash` that you want to look up the perk/perk combo on in the item ID. If you know, for example, that you're looking for perks X and Y on a class item, you can specify `item=49&perks=X,Y` and we'll only look for those perks on class items.
+If a wildcard is too broad and an item is too specific, you can supply the `ItemCategoryHash` that you want to look up the perk/perk combo on in the item ID. If you know, for example, that you're looking for perks X and Y on a class item, you can specify `item=49&perks=X,Y` and we'll only look for those perks on class items. You can currently only specify one `ItemCategoryHash`, so be as general or as specific as you need with it.
 
 This lets you do things like, for example, wish list all armor pieces that have the "enhanced heavy lifting" perk on them, or all ghosts that have "improved Dreaming City cache detector", or all armor pieces with both "rocket launcher dexterity" and "rocket launcher scavenger" on them.
 

--- a/src/app/curated-rolls/curated-roll-reader.ts
+++ b/src/app/curated-rolls/curated-roll-reader.ts
@@ -32,7 +32,7 @@ function toDimWishListCuratedRoll(textLine: string): CuratedRoll | null {
     return null;
   }
 
-  const matchResults = textLine.match(/dimwishlist:item=(-?\d.+)&perks=(.*)/);
+  const matchResults = textLine.match(/dimwishlist:item=(-?\d.+)&perks=([\d|,]*).*/);
 
   if (!matchResults || matchResults.length !== 3) {
     return null;

--- a/src/app/curated-rolls/curatedRollService.ts
+++ b/src/app/curated-rolls/curatedRollService.ts
@@ -115,6 +115,14 @@ export class CuratedRollService {
   curationEnabled: boolean;
   private _curatedRolls: CuratedRoll[];
 
+  curatedRollAppliesToItem(curatedRoll: CuratedRoll, item: DimItem): boolean {
+    return (
+      curatedRoll.itemHash === item.hash ||
+      curatedRoll.itemHash === DimWishList.WildcardItemId ||
+      item.itemCategoryHashes.some((ich) => curatedRoll.itemHash === ich)
+    );
+  }
+
   /** Get the InventoryCuratedRoll for this item. */
   getInventoryCuratedRoll(item: DimItem): InventoryCuratedRoll {
     if (
@@ -127,21 +135,18 @@ export class CuratedRollService {
       return getNonCuratedRollIndicator(item);
     }
 
-    if (
-      this._curatedRolls.some(
-        (cr) => cr.itemHash === item.hash || cr.itemHash === DimWishList.WildcardItemId
-      )
-    ) {
-      const associatedRolls = this._curatedRolls.filter(
-        (cr) => cr.itemHash === item.hash || cr.itemHash === DimWishList.WildcardItemId
-      );
+    const associatedRolls = this._curatedRolls.filter((cr) =>
+      this.curatedRollAppliesToItem(cr, item)
+    );
 
+    if (associatedRolls.length > 0) {
       const matchingCuratedRoll = associatedRolls.find((ar) => allDesiredPerksExist(item, ar));
 
       if (matchingCuratedRoll) {
         return getInventoryCuratedRoll(item, matchingCuratedRoll);
       }
     }
+
     return getNonCuratedRollIndicator(item);
   }
 


### PR DESCRIPTION
An early wish list I saw from a user made a couple of things obvious.

One, in-line comments can be useful when defining wish list items.

Two, every-single-item wildcards can be too vague. I've updated it so that a user can call out an `ItemCategoryHash` (or still a wildcard) in case they want to be specific and express that "these are perks to look for on class armor" or "this is the perk I want on a ghost" or "give me this good stuff on an auto rifle" or whatever.

This doesn't cover weapon/armor archetypes (think: adaptive pulse rifles, mobility gloves, etc.), but I'm still trying to figure out if that's valuable to people.