### PR TITLE
Drop support for iOS 10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "last 2 ChromeAndroid versions",
     "last 2 Firefox versions",
     "last 2 Safari versions",
-    "iOS >= 10.3",
+    "iOS >= 11",
     "last 2 Edge versions",
     "last 2 Opera versions",
     "unreleased versions"


### PR DESCRIPTION
iOS 10.3 is pretty old and we don't have a ton of users on it. This drops the iPad 4th gen and iPhone 5.