### PR TITLE
Make the move popup wider and the buttons bigger

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Add the option to sort inventory by tag in custom sort options.
 * Fixed a long-standing bug where you couldn't transfer some stacks to a full inventory.
 * Item popup is nicer on mobile.
+* Wider item popups on desktop.
+* Larger buttons for transfers.
 * Wish lists allow you to create and import lists of items or perks that will be highlighted in your inventory.
 * Dropped support for iOS 10.
 * Prevent the vault from getting really narrow, at the expense of some scrolling.

--- a/src/app/move-popup/move-locations.scss
+++ b/src/app/move-popup/move-locations.scss
@@ -1,27 +1,3 @@
-.drag-locations {
-  position: fixed;
-  backface-visibility: hidden;
-  transition: transform 0.2s, opacity 0.2s;
-  background-color: black;
-  text-align: center;
-  padding: 0.5em 0.5em;
-  color: #e0e0e0;
-  z-index: 10;
-
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  left: 0;
-  width: 100%;
-
-  .move-button {
-    width: 57px;
-    height: 57px;
-    border-radius: 50%;
-    border: 1px solid transparent;
-  }
-}
-
 dim-move-locations {
   display: flex;
 
@@ -33,8 +9,8 @@ dim-move-locations {
 
 .move-button {
   background-size: cover;
-  width: 37px;
-  height: 37px;
+  width: 48px;
+  height: 48px;
   text-align: center;
   line-height: 10px;
   margin: 6px 4px 6px 0;
@@ -51,7 +27,8 @@ dim-move-locations {
   }
   span {
     text-transform: uppercase;
-    background: rgba(0, 0, 0, 0.4);
+    text-shadow: 1px 1px 3px rgba(0, 0, 0, 1);
+    background: rgba(0, 0, 0, 0.5);
     width: 100%;
     height: 100%;
     display: flex;

--- a/src/app/move-popup/move-popup.scss
+++ b/src/app/move-popup/move-popup.scss
@@ -8,7 +8,7 @@
 
 .move-popup-dialog {
   min-height: 77px;
-  width: 320px;
+  width: 375px;
   z-index: 10;
 
   background-color: black;


### PR DESCRIPTION
This change makes the popup the same width as the iPhone 7 screen (375 up from 320) in order to make them more consistent as we redesign. I also use this extra space to bring the action buttons (which will be replaced soon) up to 50px and I gave them a bit of shadow so they're readable.

<img width="429" alt="screen shot 2018-12-28 at 6 35 38 pm" src="https://user-images.githubusercontent.com/313208/50532571-00898a80-0ad0-11e9-817b-862e45d910a7.png">
<img width="261" alt="screen shot 2018-12-28 at 6 38 04 pm" src="https://user-images.githubusercontent.com/313208/50532559-cc15ce80-0acf-11e9-9997-89bbea34f3a8.png">
