### PR TITLE
implicit-dependencies whitelist

### DIFF
--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -1,4 +1,3 @@
-// tslint:disable:no-implicit-dependencies
 import en from '../locale/dim.json';
 import ko from '../locale/ko/dim.json';
 import it from '../locale/it/dim.json';

--- a/src/app/inventory/StoreHeading.tsx
+++ b/src/app/inventory/StoreHeading.tsx
@@ -4,11 +4,8 @@ import { DimStore, DimVault } from './store-types';
 import PressTip from '../dim-ui/PressTip';
 import { percent } from './dimPercentWidth.directive';
 import { t } from 'i18next';
-// tslint:disable-next-line:no-implicit-dependencies
 import glimmer from 'app/images/glimmer.png';
-// tslint:disable-next-line:no-implicit-dependencies
 import legendaryMarks from 'app/images/legendaryMarks.png';
-// tslint:disable-next-line:no-implicit-dependencies
 import legendaryShards from 'app/images/legendaryShards.png';
 import { InventoryBucket } from './inventory-buckets';
 import './StoreHeading.scss';

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -1,8 +1,5 @@
-// tslint:disable-next-line:no-implicit-dependencies
 import intellectIcon from 'app/images/intellect.png';
-// tslint:disable-next-line:no-implicit-dependencies
 import disciplineIcon from 'app/images/discipline.png';
-// tslint:disable-next-line:no-implicit-dependencies
 import strengthIcon from 'app/images/strength.png';
 import { D1CharacterStat } from '../store-types';
 

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-// tslint:disable-next-line:no-implicit-dependencies
 import missingSources from 'app/data/missing_sources.json';
 import { getClass, getBonus } from './character-utils';
 import { getQualityRating } from './armor-quality';

--- a/src/app/inventory/store/d1-store-factory.service.ts
+++ b/src/app/inventory/store/d1-store-factory.service.ts
@@ -4,9 +4,7 @@ import { getCharacterStatsData, getClass } from './character-utils';
 import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions.service';
 import copy from 'fast-copy';
 import { t } from 'i18next';
-// tslint:disable-next-line:no-implicit-dependencies
 import vaultBackground from 'app/images/vault-background.svg';
-// tslint:disable-next-line:no-implicit-dependencies
 import vaultIcon from 'app/images/vault.svg';
 import { D1Store, D1Vault } from '../store-types';
 import { D1Item } from '../item-types';

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -58,9 +58,7 @@ import { InventoryBuckets } from '../inventory-buckets';
 import { D2RatingData } from '../../item-review/d2-dtr-api-types';
 import { D2StoresService } from '../d2-stores.service';
 import { filterPlugs } from '../../d2-loadout-builder/generated-sets/utils';
-// tslint:disable-next-line:no-implicit-dependencies
 import D2Seasons from 'app/data/d2-seasons.json';
-// tslint:disable-next-line:no-implicit-dependencies
 import D2Events from 'app/data/d2-events.json';
 
 // Maps tierType to tierTypeName in English

--- a/src/app/inventory/store/d2-store-factory.service.ts
+++ b/src/app/inventory/store/d2-store-factory.service.ts
@@ -10,9 +10,7 @@ import { count } from '../../util';
 import { D2ManifestDefinitions, LazyDefinition } from '../../destiny2/d2-definitions.service';
 import { Loadout } from '../../loadout/loadout.service';
 import { getClass } from './character-utils';
-// tslint:disable-next-line:no-implicit-dependencies
 import vaultBackground from 'app/images/vault-background.svg';
-// tslint:disable-next-line:no-implicit-dependencies
 import vaultIcon from 'app/images/vault.svg';
 import { t } from 'i18next';
 import { D2Store, D2Vault, D2CharacterStat } from '../store-types';

--- a/src/app/loadout-builder/loadout-builder.component.ts
+++ b/src/app/loadout-builder/loadout-builder.component.ts
@@ -265,9 +265,7 @@ function LoadoutBuilderController(
         }
         let bonus = 0;
         let total = 0;
-        // tslint:disable-next-line:prefer-for-of
-        for (let i = 0; i < stats.length; i++) {
-          const stat = stats[i];
+        for (const stat of stats) {
           const scaleType = o.tier === 'Rare' ? 'base' : vm.scaleType;
           const normalStats = o.normalStats![stat];
           total += normalStats[scaleType];
@@ -296,9 +294,7 @@ function LoadoutBuilderController(
   }
 
   function calcArmorStats(pieces, stats) {
-    // tslint:disable-next-line:prefer-for-of
-    for (let i = 0; i < pieces.length; i++) {
-      const armor = pieces[i];
+    for (const armor of pieces) {
       const int = armor.item.normalStats[144602215];
       const dis = armor.item.normalStats[1735777505];
       const str = armor.item.normalStats[4244567218];
@@ -341,9 +337,8 @@ function LoadoutBuilderController(
 
   function genSetHash(armorPieces) {
     let hash = '';
-    // tslint:disable-next-line:prefer-for-of
-    for (let i = 0; i < armorPieces.length; i++) {
-      hash += armorPieces[i].item.id;
+    for (const armorPiece of armorPieces) {
+      hash += armorPiece.item.id;
     }
     return hash;
   }

--- a/src/app/loadout-builder/loadout-builder.component.ts
+++ b/src/app/loadout-builder/loadout-builder.component.ts
@@ -1,11 +1,8 @@
 import * as _ from 'lodash';
 import copy from 'fast-copy';
 import template from './loadout-builder.html';
-// tslint:disable-next-line:no-implicit-dependencies
 import intellectIcon from 'app/images/intellect.png';
-// tslint:disable-next-line:no-implicit-dependencies
 import disciplineIcon from 'app/images/discipline.png';
-// tslint:disable-next-line:no-implicit-dependencies
 import strengthIcon from 'app/images/strength.png';
 import { getBonus } from '../inventory/store/character-utils';
 import { getDefinitions } from '../destiny1/d1-definitions.service';

--- a/src/app/manifest/database.ts
+++ b/src/app/manifest/database.ts
@@ -1,8 +1,6 @@
 import * as _ from 'lodash';
 
-// tslint:disable-next-line:no-implicit-dependencies
 import sqlWasmPath from 'file-loader?name=[name]-[hash:6].[ext]!sql.js/js/sql-wasm.js';
-// tslint:disable-next-line:no-implicit-dependencies
 import sqlWasmBinaryPath from 'file-loader?name=[name]-[hash:6].[ext]!sql.js/js/sql-optimized-wasm-raw.wasm';
 
 declare global {

--- a/src/app/manifest/manifest-service.ts
+++ b/src/app/manifest/manifest-service.ts
@@ -2,11 +2,9 @@ import * as _ from 'lodash';
 import { get, set, del } from 'idb-keyval';
 
 // For zip
-// tslint:disable-next-line:no-implicit-dependencies
+
 import 'imports-loader?this=>window!@destiny-item-manager/zip.js';
-// tslint:disable-next-line:no-implicit-dependencies
 import inflate from 'file-loader?name=[name]-[hash:6].[ext]!@destiny-item-manager/zip.js/WebContent/inflate.js';
-// tslint:disable-next-line:no-implicit-dependencies
 import zipWorker from 'file-loader?name=[name]-[hash:6].[ext]!@destiny-item-manager/zip.js/WebContent/z-worker.js';
 
 import { requireSqlLib } from './database';

--- a/src/app/settings/DiagnosticsPage.tsx
+++ b/src/app/settings/DiagnosticsPage.tsx
@@ -45,8 +45,8 @@ interface Props {
   };
 }
 
-// tslint:disable-next-line:prefer-template
-const stringToCodeBlock = (str: string) => '```\n' + str + '\n```';
+const backticks = '```';
+const stringToCodeBlock = (str: string) => `${backticks}\n${str}\n${backticks}`;
 
 const copyStringOnClick = (content: string) => () => {
   copyString(content);

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -6,9 +6,7 @@ import InventoryItem from '../inventory/InventoryItem';
 import SortOrderEditor, { SortProperty } from './SortOrderEditor';
 import CharacterOrderEditor from './CharacterOrderEditor';
 import { connect } from 'react-redux';
-// tslint:disable-next-line:no-implicit-dependencies
 import exampleWeaponImage from 'app/images/example-weapon.jpg';
-// tslint:disable-next-line:no-implicit-dependencies
 import exampleArmorImage from 'app/images/example-armor.jpg';
 import './settings.scss';
 import { DimItem } from '../inventory/item-types';

--- a/src/app/shell/About.tsx
+++ b/src/app/shell/About.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { t } from 'i18next';
 import ExternalLink from '../dim-ui/ExternalLink';
 import { Transition } from '@uirouter/react';
-// tslint:disable-next-line:no-implicit-dependencies
 import logo from '../../images/logo-light.svg';
 import './page.scss';
 import * as _ from 'lodash';

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -9,7 +9,6 @@ import Link from './Link';
 import { router } from '../../router';
 import './header.scss';
 
-// tslint:disable-next-line:no-implicit-dependencies
 import logo from 'app/images/logo-type-right-light.svg';
 import ClickOutside from '../dim-ui/ClickOutside';
 import Refresh from './refresh';

--- a/tslint.json
+++ b/tslint.json
@@ -71,7 +71,16 @@
     "no-duplicate-switch-case": true,
     "no-floating-promises": [false, "Thenable", "IPromise"],
     "no-for-in-array": true,
-    "no-implicit-dependencies": true,
+    "no-implicit-dependencies": [
+      true,
+      [
+        "locale",
+        "app",
+        "file-loader?name=[name]-[hash:6].[ext]!@destiny-item-manager",
+        "imports-loader?this=>window!@destiny-item-manager",
+        "file-loader?name=[name]-[hash:6].[ext]!sql.js"
+      ]
+    ],
     "no-invalid-template-strings": true,
     "no-misused-new": true,
     "no-object-literal-type-assertion": true,


### PR DESCRIPTION
adds a whitelist to the rule allowing us to remove `// tslint:disable:no-implicit-dependencies` and `// tslint:disable-next-line:no-implicit-dependencies` from multiple files.