### PR TITLE
Dedupe wish list items

### DIFF
--- a/src/app/curated-rolls/curated-roll-reader.ts
+++ b/src/app/curated-rolls/curated-roll-reader.ts
@@ -57,11 +57,30 @@ function toDimWishListCuratedRoll(textLine: string): CuratedRoll | null {
   };
 }
 
+function alreadyExists(currentRoll: CuratedRoll, rolls: CuratedRoll[]): boolean {
+  return rolls.some(
+    (cr) =>
+      cr.itemHash === currentRoll.itemHash &&
+      cr.isExpertMode === currentRoll.isExpertMode &&
+      cr.recommendedPerks.every((rp) => currentRoll.recommendedPerks.includes(rp))
+  );
+}
+
 /** Newline-separated banshee-44.com text -> CuratedRolls. */
 export function toCuratedRolls(bansheeText: string): CuratedRoll[] {
   const textArray = bansheeText.split('\n');
 
-  return _.uniq(
-    _.compact(textArray.map(toCuratedRoll).concat(textArray.map(toDimWishListCuratedRoll)))
+  const compactedRolls = _.compact(
+    textArray.map(toCuratedRoll).concat(textArray.map(toDimWishListCuratedRoll))
   );
+
+  const uniqueRolls: CuratedRoll[] = [];
+
+  compactedRolls.forEach((cr) => {
+    if (!alreadyExists(cr, uniqueRolls)) {
+      uniqueRolls.push(cr);
+    }
+  });
+
+  return uniqueRolls;
 }

--- a/src/app/curated-rolls/curated-roll-reader.ts
+++ b/src/app/curated-rolls/curated-roll-reader.ts
@@ -61,5 +61,7 @@ function toDimWishListCuratedRoll(textLine: string): CuratedRoll | null {
 export function toCuratedRolls(bansheeText: string): CuratedRoll[] {
   const textArray = bansheeText.split('\n');
 
-  return _.compact(textArray.map(toCuratedRoll).concat(textArray.map(toDimWishListCuratedRoll)));
+  return _.uniq(
+    _.compact(textArray.map(toCuratedRoll).concat(textArray.map(toDimWishListCuratedRoll)))
+  );
 }

--- a/src/app/curated-rolls/curated-roll-reader.ts
+++ b/src/app/curated-rolls/curated-roll-reader.ts
@@ -57,12 +57,12 @@ function toDimWishListCuratedRoll(textLine: string): CuratedRoll | null {
   };
 }
 
-function alreadyExists(currentRoll: CuratedRoll, rolls: CuratedRoll[]): boolean {
-  return rolls.some(
-    (cr) =>
-      cr.itemHash === currentRoll.itemHash &&
-      cr.isExpertMode === currentRoll.isExpertMode &&
-      cr.recommendedPerks.every((rp) => currentRoll.recommendedPerks.includes(rp))
+function alreadyExists(currentRoll: CuratedRoll, otherRoll: CuratedRoll): boolean {
+  return (
+    currentRoll.itemHash === otherRoll.itemHash &&
+    currentRoll.isExpertMode === otherRoll.isExpertMode &&
+    currentRoll.recommendedPerks.length === otherRoll.recommendedPerks.length &&
+    currentRoll.recommendedPerks.every((rp) => otherRoll.recommendedPerks.includes(rp))
   );
 }
 
@@ -70,17 +70,8 @@ function alreadyExists(currentRoll: CuratedRoll, rolls: CuratedRoll[]): boolean 
 export function toCuratedRolls(bansheeText: string): CuratedRoll[] {
   const textArray = bansheeText.split('\n');
 
-  const compactedRolls = _.compact(
-    textArray.map(toCuratedRoll).concat(textArray.map(toDimWishListCuratedRoll))
+  return _.uniqWith(
+    _.compact(textArray.map(toCuratedRoll).concat(textArray.map(toDimWishListCuratedRoll))),
+    alreadyExists
   );
-
-  const uniqueRolls: CuratedRoll[] = [];
-
-  compactedRolls.forEach((cr) => {
-    if (!alreadyExists(cr, uniqueRolls)) {
-      uniqueRolls.push(cr);
-    }
-  });
-
-  return uniqueRolls;
 }


### PR DESCRIPTION
Because...

a) it's pretty easy to have a concat'd wish list that contains dupes
b) as we move towards persisting the `CuratedRoll`s that people ask for across refreshes, it'd be good  to not have a mountain of dupes hogging up space/memory

I initially tried `_.uniq` but that I guess works on values and not objects, hence the O(n^2)-ish implementation.