### PR TITLE
FIX:Search - Adjust rating search based off of #3447

### DIFF
--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -152,13 +152,14 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }) {
       Equippable: equippable(item),
       [item.isDestiny1() ? 'Light' : 'Power']: item.primStat && item.primStat.value
     };
-    if (item.isDestiny2() && item.masterworkInfo) {
-      row['Masterwork Type'] = item.masterworkInfo.statName;
-      row['Masterwork Tier'] = item.masterworkInfo.statValue
-        ? item.masterworkInfo.statValue <= 10
-          ? item.masterworkInfo.statValue
-          : 10
-        : undefined;
+    if (item.isDestiny2()) {
+      row['Masterwork Type'] = item.masterworkInfo && item.masterworkInfo.statName;
+      row['Masterwork Tier'] =
+        item.masterworkInfo && item.masterworkInfo.statValue
+          ? item.masterworkInfo.statValue <= 5
+            ? item.masterworkInfo.statValue
+            : 5
+          : undefined;
     }
     row.Owner = nameMap[item.owner];
     if (item.isDestiny1()) {
@@ -242,13 +243,14 @@ function downloadWeapons(items: DimItem[], nameMap: { [key: string]: string }) {
       [item.isDestiny1() ? 'Light' : 'Power']: item.primStat && item.primStat.value,
       Dmg: item.dmg ? `${capitalizeFirstLetter(item.dmg)}` : 'Kinetic'
     };
-    if (item.isDestiny2() && item.masterworkInfo) {
-      row['Masterwork Type'] = item.masterworkInfo.statName;
-      row['Masterwork Tier'] = item.masterworkInfo.statValue
-        ? item.masterworkInfo.statValue <= 10
-          ? item.masterworkInfo.statValue
-          : 10
-        : undefined;
+    if (item.isDestiny2()) {
+      row['Masterwork Type'] = item.masterworkInfo && item.masterworkInfo.statName;
+      row['Masterwork Tier'] =
+        item.masterworkInfo && item.masterworkInfo.statValue
+          ? item.masterworkInfo.statValue <= 10
+            ? item.masterworkInfo.statValue
+            : 10
+          : undefined;
     }
     row.Owner = nameMap[item.owner];
     if (item.isDestiny1()) {
@@ -338,9 +340,11 @@ function downloadWeapons(items: DimItem[], nameMap: { [key: string]: string }) {
     row.Reload = stats.reload;
     row.Mag = stats.magazine;
     row.Equip = stats.equipSpeed;
-    row.DrawTime = stats.drawtime;
-    row.ChargeTime = stats.chargetime;
-    row.Accuracy = stats.accuracy;
+    row['Charge Time'] = stats.chargetime;
+    if (item.isDestiny2()) {
+      row['Draw Time'] = stats.drawtime;
+      row.Accuracy = stats.accuracy;
+    }
 
     row.Notes = item.dimInfo.notes;
 

--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -152,14 +152,13 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }) {
       Equippable: equippable(item),
       [item.isDestiny1() ? 'Light' : 'Power']: item.primStat && item.primStat.value
     };
-    if (item.isDestiny2()) {
-      row['Masterwork Type'] = item.masterworkInfo && item.masterworkInfo.statName;
-      row['Masterwork Tier'] =
-        item.masterworkInfo && item.masterworkInfo.statValue
-          ? item.masterworkInfo.statValue <= 5
-            ? item.masterworkInfo.statValue
-            : 5
-          : undefined;
+    if (item.isDestiny2() && item.masterworkInfo) {
+      row['Masterwork Type'] = item.masterworkInfo.statName;
+      row['Masterwork Tier'] = item.masterworkInfo.statValue
+        ? item.masterworkInfo.statValue <= 10
+          ? item.masterworkInfo.statValue
+          : 10
+        : undefined;
     }
     row.Owner = nameMap[item.owner];
     if (item.isDestiny1()) {
@@ -243,14 +242,13 @@ function downloadWeapons(items: DimItem[], nameMap: { [key: string]: string }) {
       [item.isDestiny1() ? 'Light' : 'Power']: item.primStat && item.primStat.value,
       Dmg: item.dmg ? `${capitalizeFirstLetter(item.dmg)}` : 'Kinetic'
     };
-    if (item.isDestiny2()) {
-      row['Masterwork Type'] = item.masterworkInfo && item.masterworkInfo.statName;
-      row['Masterwork Tier'] =
-        item.masterworkInfo && item.masterworkInfo.statValue
-          ? item.masterworkInfo.statValue <= 10
-            ? item.masterworkInfo.statValue
-            : 10
-          : undefined;
+    if (item.isDestiny2() && item.masterworkInfo) {
+      row['Masterwork Type'] = item.masterworkInfo.statName;
+      row['Masterwork Tier'] = item.masterworkInfo.statValue
+        ? item.masterworkInfo.statValue <= 10
+          ? item.masterworkInfo.statValue
+          : 10
+        : undefined;
     }
     row.Owner = nameMap[item.owner];
     if (item.isDestiny1()) {
@@ -340,11 +338,9 @@ function downloadWeapons(items: DimItem[], nameMap: { [key: string]: string }) {
     row.Reload = stats.reload;
     row.Mag = stats.magazine;
     row.Equip = stats.equipSpeed;
-    row['Charge Time'] = stats.chargetime;
-    if (item.isDestiny2()) {
-      row['Draw Time'] = stats.drawtime;
-      row.Accuracy = stats.accuracy;
-    }
+    row.DrawTime = stats.drawtime;
+    row.ChargeTime = stats.chargetime;
+    row.Accuracy = stats.accuracy;
 
     row.Notes = item.dimInfo.notes;
 

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1141,6 +1141,7 @@ function searchFilters(
       rating(item: DimItem, predicate: string) {
         return (
           item.dtrRating &&
+          item.dtrRating.ratingCount > 3 &&
           item.dtrRating.overallScore &&
           compareByOperand(item.dtrRating.overallScore, predicate)
         );

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1141,7 +1141,7 @@ function searchFilters(
       rating(item: DimItem, predicate: string) {
         return (
           item.dtrRating &&
-          item.dtrRating.ratingCount > 3 &&
+          item.dtrRating.ratingCount > 2 &&
           item.dtrRating.overallScore &&
           compareByOperand(item.dtrRating.overallScore, predicate)
         );


### PR DESCRIPTION
https://www.reddit.com/r/DestinyItemManager/comments/ae0euo/bug_filtering_rating5_will_include_items_with_no/

In #3447 we adjusted the rating count to only deem items worthy if the had at least 3 reviews, this adjusts the search on ratings accordingly as well.