### PR TITLE
Ace-styled inventory headers

### DIFF
--- a/src/app/inventory/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory/InventoryCollapsibleTitle.scss
@@ -1,0 +1,24 @@
+.inventory-title {
+  .title {
+    flex: none;
+    cursor: default;
+    padding-top: 4px;
+    min-height: 28px;
+
+    &.vault {
+      flex: 1;
+    }
+    &.collapsed {
+      color: #aaa;
+      &:nth-child(even) {
+        background-color: rgba(0, 0, 0, 0.2);
+      }
+    }
+  }
+
+  .collapse-handle {
+    cursor: pointer;
+    height: 100%;
+    padding-right: 8px;
+  }
+}

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { RootState } from '../store/reducers';
+import { connect } from 'react-redux';
+import { toggleCollapsedSection } from '../settings/actions';
+import { Dispatch } from 'redux';
+import { AppIcon, expandIcon, collapseIcon } from '../shell/icons';
+import classNames from 'classnames';
+import '../dim-ui/CollapsibleTitle.scss';
+import './InventoryCollapsibleTitle.scss';
+import { DimStore } from './store-types';
+import { storeBackgroundColor } from '../shell/dimAngularFilters.filter';
+
+interface ProvidedProps {
+  sectionId: string;
+  title: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+  stores: DimStore[];
+}
+
+interface StoreProps {
+  collapsed: boolean;
+}
+
+interface DispatchProps {
+  toggle(): void;
+}
+
+function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
+  return {
+    collapsed: state.settings.collapsedSections[props.sectionId]
+  };
+}
+
+function mapDispatchToProps(dispatch: Dispatch, ownProps: ProvidedProps): DispatchProps {
+  return {
+    toggle: () => {
+      dispatch(toggleCollapsedSection(ownProps.sectionId));
+    }
+  };
+}
+
+type Props = StoreProps & ProvidedProps & DispatchProps;
+
+class InventoryCollapsibleTitle extends React.Component<Props> {
+  render() {
+    const { title, collapsed, children, toggle, className, stores } = this.props;
+    return (
+      <>
+        <div className="store-row inventory-title">
+          {stores.map((store, index) => (
+            <div
+              className={classNames('title', 'store-cell', className, {
+                collapsed,
+                vault: store.isVault
+              })}
+              style={
+                store.isDestiny2() && store.color ? storeBackgroundColor(store, index) : undefined
+              }
+            >
+              {index === 0 && (
+                <span className="collapse-handle" onClick={toggle}>
+                  <AppIcon className="collapse" icon={collapsed ? expandIcon : collapseIcon} />{' '}
+                  <span>{title}</span>
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+        {!collapsed && children}
+      </>
+    );
+  }
+}
+
+export default connect<StoreProps, DispatchProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(InventoryCollapsibleTitle);

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { DimStore, DimVault, D2Store } from './store-types';
+import { DimStore, DimVault } from './store-types';
 import StoreBucket from './StoreBucket';
 import { InventoryBucket } from './inventory-buckets';
 import classNames from 'classnames';
 import { PullFromPostmaster } from './PullFromPostmaster';
 import { hasBadge } from './get-badge-info';
+import { storeBackgroundColor } from '../shell/dimAngularFilters.filter';
 
 /** One row of store buckets, one for each character and vault. */
 export function StoreBuckets({
@@ -55,7 +56,7 @@ export function StoreBuckets({
           vault: store.isVault,
           'no-badge': noBadges
         })}
-        style={store.isDestiny2() && store.color ? bgColor(store, index) : undefined}
+        style={store.isDestiny2() && store.color ? storeBackgroundColor(store, index) : undefined}
       >
         {(!store.isVault || bucket.vaultBucket) && (
           <StoreBucket bucketId={bucket.id} storeId={store.id} />
@@ -68,18 +69,4 @@ export function StoreBuckets({
   }
 
   return <div className="store-row items">{content}</div>;
-}
-
-function bgColor(store: D2Store, index: number) {
-  if (index % 2 === 1 && !store.isVault) {
-    return {
-      backgroundColor: `rgba(${Math.round(store.color.red * 0.75)}, ${Math.round(
-        store.color.green * 0.75
-      )}, ${Math.round(store.color.blue * 0.75)}, 0.25)`
-    };
-  } else {
-    return {
-      backgroundColor: `rgba(${store.color.red}, ${store.color.green}, ${store.color.blue}, 0.25)`
-    };
-  }
 }

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -59,6 +59,9 @@
     );
     flex: 1;
     background: rgba(0, 0, 0, 0.12);
+    .phone-portrait & {
+      background: transparent;
+    }
   }
 
   @include phone-portrait {
@@ -83,10 +86,13 @@
         )
     );
   }
-}
 
-.items .store-cell:nth-child(even) {
-  background-color: rgba(0, 0, 0, 0.2);
+  &:nth-child(even) {
+    background-color: rgba(0, 0, 0, 0.2);
+    .phone-portrait & {
+      background-color: transparent;
+    }
+  }
 }
 
 .store-text {
@@ -109,7 +115,7 @@
     position: sticky;
   }
   &.sticky {
-    box-shadow: 0 1px 6px 0px #222;
+    box-shadow: 0 1px 4px 0px black;
   }
   .phone-portrait & {
     padding-left: 0;

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -8,12 +8,14 @@ import { RootState } from '../store/reducers';
 import { connect } from 'react-redux';
 import { Frame, Track, View, ViewPager } from 'react-view-pager';
 import ScrollClassDiv from '../dim-ui/ScrollClassDiv';
-import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
 import { StoreBuckets } from './StoreBuckets';
 import D1ReputationSection from './D1ReputationSection';
 import Hammer from 'react-hammerjs';
 import { sortedStoresSelector } from './reducer';
 import { hideItemPopup } from '../item-popup/item-popup';
+import { storeBackgroundColor } from '../shell/dimAngularFilters.filter';
+import InventoryCollapsibleTitle from './InventoryCollapsibleTitle';
+import classNames from 'classnames';
 
 interface Props {
   stores: DimStore[];
@@ -64,7 +66,15 @@ class Stores extends React.Component<Props, State> {
     if (isPhonePortrait) {
       return (
         <div className="inventory-content phone-portrait">
-          <ScrollClassDiv className="store-row store-header" scrollClass="sticky">
+          <ScrollClassDiv
+            className="store-row store-header"
+            scrollClass="sticky"
+            style={
+              selectedStore.isDestiny2() && selectedStore.color
+                ? storeBackgroundColor(selectedStore, 0)
+                : undefined
+            }
+          >
             <ViewPager>
               <Frame className="frame" autoSize={false}>
                 <Track
@@ -100,8 +110,14 @@ class Stores extends React.Component<Props, State> {
     return (
       <div className="inventory-content">
         <ScrollClassDiv className="store-row store-header" scrollClass="sticky">
-          {stores.map((store) => (
-            <div className="store-cell" key={store.id}>
+          {stores.map((store, index) => (
+            <div
+              className={classNames('store-cell', { vault: store.isVault })}
+              key={store.id}
+              style={
+                store.isDestiny2() && store.color ? storeBackgroundColor(store, index) : undefined
+              }
+            >
               <StoreHeading store={store} />
             </div>
           ))}
@@ -141,12 +157,16 @@ class Stores extends React.Component<Props, State> {
     const { buckets } = this.props;
 
     return (
-      <div>
+      <div className="store-buckets">
         {Object.keys(buckets.byCategory).map(
           (category) =>
             categoryHasItems(buckets, category, stores, currentStore) && (
               <div key={category} className="section">
-                <CollapsibleTitle title={t(`Bucket.${category}`)} sectionId={category}>
+                <InventoryCollapsibleTitle
+                  title={t(`Bucket.${category}`)}
+                  sectionId={category}
+                  stores={stores}
+                >
                   {buckets.byCategory[category].map((bucket) => (
                     <StoreBuckets
                       key={bucket.id}
@@ -156,7 +176,7 @@ class Stores extends React.Component<Props, State> {
                       currentStore={currentStore}
                     />
                   ))}
-                </CollapsibleTitle>
+                </InventoryCollapsibleTitle>
               </div>
             )
         )}

--- a/src/app/shell/dimAngularFilters.filter.ts
+++ b/src/app/shell/dimAngularFilters.filter.ts
@@ -4,7 +4,7 @@ import { bungieNetPath } from '../dim-ui/BungieImage';
 import { compareBy, reverseComparator, chainComparator, Comparator } from '../comparators';
 import { settings } from '../settings/settings';
 import { DimItem } from '../inventory/item-types';
-import { DimStore } from '../inventory/store-types';
+import { DimStore, D2Store } from '../inventory/store-types';
 import { itemSortOrder as itemSortOrderFn } from '../settings/item-sort';
 import { characterSortSelector } from '../settings/character-sort';
 import store from '../store/store';
@@ -298,6 +298,20 @@ export function dtrRatingColor(value: number, property: string = 'color') {
   const result = {};
   result[property] = color;
   return result;
+}
+
+export function storeBackgroundColor(store: D2Store, index: number) {
+  if (index % 2 === 1 && !store.isVault) {
+    return {
+      backgroundColor: `rgba(${Math.round(store.color.red * 0.75)}, ${Math.round(
+        store.color.green * 0.75
+      )}, ${Math.round(store.color.blue * 0.75)}, 0.25)`
+    };
+  } else {
+    return {
+      backgroundColor: `rgba(${store.color.red}, ${store.color.green}, ${store.color.blue}, 0.25)`
+    };
+  }
 }
 
 mod.filter('dtrRatingColor', () => dtrRatingColor);

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -81,6 +81,9 @@
     &.active {
       color: $orange;
       transition: color 0.2s linear;
+      border-bottom: 2px solid #e8a534;
+      border-top: 2px solid black;
+      box-sizing: border-box;
     }
   }
 


### PR DESCRIPTION
Getting closer to @inexorableAce's mockups. Besides the inventory, I also added an underline to the current tab to help it stand out. I also reduced the click target for collapsing headers to just the text, which should help with mis-clicks.

I am a bit concerned that the header doesn't have enough separation when you're scrolled all the way to the top.

<img width="274" alt="screen shot 2019-01-11 at 6 51 08 pm" src="https://user-images.githubusercontent.com/313208/51068404-5da63580-15d2-11e9-8495-e9fa214ca00a.png">
<img width="1057" alt="screen shot 2019-01-11 at 6 51 18 pm" src="https://user-images.githubusercontent.com/313208/51068394-259ef280-15d2-11e9-86bd-5f6a9772742c.png">
<img width="1051" alt="screen shot 2019-01-11 at 6 51 24 pm" src="https://user-images.githubusercontent.com/313208/51068395-259ef280-15d2-11e9-8dbc-59df7da1c1ee.png">
