### PR TITLE
Remove "Show full item details" setting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Move Random Loadout into the Loadout menu and add a "Random Weapons Only" option.
 * Restyle the alternate options in the loadout menu.
 * Removed the quick consolidate buttons and engram counter from D1 farming mode.
+* Remove the setting to "Show full item details in the item popup". DIM now just remembers the last state of the popup, and you can expand/collapse with the arrow in the top right corner of the popup.
 * Fix showing which perks are highly rated by the community.
 * Fix for getting stuck on the reviews tab when clicking on items that can't be reviewed.
 * Fix highlighting of subclass perks.

--- a/src/app/inventory/InventoryItem.scss
+++ b/src/app/inventory/InventoryItem.scss
@@ -175,6 +175,8 @@
     display: none;
     .itemQuality & {
       display: block;
+      padding: 0 2px;
+      margin-left: -2px;
     }
     .app-icon {
       filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.8));

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -287,13 +287,6 @@ class SettingsPage extends React.Component<Props, State> {
             )}
 
             <Checkbox
-              label="Settings.AlwaysShowDetails"
-              name="itemDetails"
-              value={settings.itemDetails}
-              onChange={this.onChange}
-            />
-
-            <Checkbox
               label="Settings.ShowNewItems"
               name="showNewItems"
               value={settings.showNewItems}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -650,7 +650,6 @@
   "Settings": {
     "AllowIdPostToDtr": "Show detailed weapon reviews and allow rating weapons",
     "AllowIdPostToDtrLine2": "This will share your account name and reviewed items with Destiny Tracker.",
-    "AlwaysShowDetails": "Show full item details in item popup",
     "CharacterOrder": "Sort characters by",
     "CharacterOrderFixed": "Character age (buggy on PC)",
     "CharacterOrderRecent": "Most recent character",


### PR DESCRIPTION
People were getting upset that this wasn't staying checked now that it just remembers whatever you last had it set to. This just removes the setting - it still works in the background.