### PR TITLE
DOC: Update translation links and translation team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Become a sponsor and get your logo here with a link to your site.
 <a href="https://opencollective.com/dim/sponsor/3/website" target="_blank"><img src="https://opencollective.com/dim/sponsor/3/avatar.svg"></a>
 
 ## Translation
-If you speak a language other than English that Destiny supports (Italian, German, French, Spanish, Japanese, Korean, or Portuguese), a great way to help with DIM development is to provide translations. See [translation guide](https://github.com/DestinyItemManager/DIM/blob/master/docs/TRANSLATIONS.md) for more info on how to help.
+If you speak a language other than English that Destiny supports (Italian, German, French, Spanish, Spanish (Latin America), Polish, Japanese, Korean, Portuguese, Chinese (Simplified), or Chinese(Traditional)), a great way to help with DIM development is to provide translations. See [translation guide](https://github.com/DestinyItemManager/DIM/blob/master/docs/TRANSLATIONS.md) for more info on how to help.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Become a sponsor and get your logo here with a link to your site.
 <a href="https://opencollective.com/dim/sponsor/3/website" target="_blank"><img src="https://opencollective.com/dim/sponsor/3/avatar.svg"></a>
 
 ## Translation
-If you speak a language other than English that Destiny supports (Italian, German, French, Spanish, Spanish (Latin America), Polish, Japanese, Korean, Portuguese, Chinese (Simplified), or Chinese(Traditional)), a great way to help with DIM development is to provide translations. See [translation guide](https://github.com/DestinyItemManager/DIM/blob/master/docs/TRANSLATIONS.md) for more info on how to help.
+If you speak a language other than English that Destiny supports, a great way to help with DIM development is to provide translations. See [translation guide](https://github.com/DestinyItemManager/DIM/blob/master/docs/TRANSLATIONS.md) for more info on how to help.
 
 ## Contributing
 

--- a/docs/TRANSLATIONS.md
+++ b/docs/TRANSLATIONS.md
@@ -12,10 +12,11 @@ Due to what information is provided by Bungie about item names and descriptions 
   - Polish
   - Russian
   - Chinese (Traditional)
+  - Chinese (Simplified)
 
 # Translating DIM
 
-We use [i18next](https://github.com/i18next/ng-i18next) for all our translated strings, so if you want to translate something that's currently English-only, take a look at that. Usually it's as simple as replacing some text with `<span ng-i18next="KEY"></span>` and then defining KEY in the i18n file. Within code, you need to use the `$i18next.t` service - see `D1StoresService` for an example.
+We use [i18next](https://github.com/i18next/i18next) for all our translated strings, so if you want to translate something that's currently English-only, take a look at that. Usually it's as simple as replacing some text with `<span>{t('KEY')}</span>` and then defining KEY in the i18n file.
 
 # Join the translation team @ Crowdin
  [Crowdin](https://crowdin.com/project/destiny-item-manager/invite?d=65a5l46565176393s2a3p403a3u22323e46383232393h4k4r443o4h3d4c333t2a3j4f453f4f3o4u643g393b343n4)
@@ -30,10 +31,6 @@ There are two different roles available per language
 # Translators
 Using the 'Show' dropdown menu, select 'Untranslated'.
 Translate these to your language.
-
-As translations are changed they will automatically be marked as 'Fuzzy'.
-Using the 'Show' dropdown menu, select 'Fuzzy'.
-Verify these translations as the wording in English has been changed.
 
 *Translations are not considered complete, until they have been proofread.*
 
@@ -61,19 +58,25 @@ If your language requires plural or gender support for a translation do not hesi
  - Loadouts.MakeRoomDone
 
 # Variables
-| Variable | Resolves to |
-|----------|-------------|
+| Variable  | Resolves to |
+|-----------|-------------|
 | {{store}} | Exo Male Warlock, etc |
 
 ## Translation Team
-| Language           | Reviewers        | Translators |
-|--------------------|------------------|-------------|
-| German (de)        | Korben85, StefanGose | dleising, itspick |
-| French (fr)        | Julian, yannickguillemot, qcmethical |  ScaRdrow  |
-| Italian (it)       | simonefranza, Theovorn | |
-| Japanese (ja)      | omar_senpai, thatjapanesedude, winy0808 | chickenmer |
-| Portuguese (pt-br) | SiLeNtWaLkEr, brunnopleffken |  |
-| Spanish (es)       | JaviG1105 | Bec04015, Jakio, Pochev, tsps_03 |
+| Language | Code | Proofreaders | Translators |
+|----------|------|--------------|-------------|
+| Chinese Simplified | zh-chs | coralfox, Meisy | digmouse, Lance ACE, Min Chen, Obzer, Remedy-, yuebing233 |
+| Chinese Traditional | zh-cht | coralfox, Meisy | NerdBunny,  kourge |
+| German | de | Korben-85, StefanGose, itspick | dleising, Stereoide, Heslant, patriksuter |
+| French | fr | Julian, yannickguillemot, qcmethical |  ScaRdrow, cbperez90, Sospuff |
+| Italian | it | simonefranza, Theovorn | Apokalipsys-ZR7, MuurStardust |
+| Japanese | ja | omar_senpai, thatjapanesedude, winy0808 | chickenmer, Meisy, LKSFerreira, Nicacio, rsb007, ricdonabre, HowlinVixen, WagnerFCruz |
+| Korean | ko | lion0738, Mental01 | juniac, lavenza, Luthervan, tinkrain, seed1482 |
+| Polish | pl |  | |
+| Portuguese | pt-br | duckmanBR, SiLeNtWaLkEr, brunnopleffken, edson.igd | Medeiros97, LKSFerreira |
+| Russian | ru | Aibot, monechka | Anakros, safrashenkov, tatarinovm.s, bogshev |
+| Spanish | es | JaviG1105, Apokalipsys-ZR7, tsps_03 | Bec04015, Jakio, Pochev, tsps_03, Hekutoru, JIM_SLIDER, cbperez90, NeedlessCred |
+| Spanish (Latin America) | es-mx | jairjrr | random.zits, TimeBokan84 |
 
 # Translation Coordinator
 

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -45,7 +45,7 @@ export function defaultLanguage(): string {
 
 export function initi18n(): Promise<never> {
   return new Promise((resolve, reject) => {
-    // See https://github.com/i18next/ng-i18next
+    // See https://github.com/i18next/i18next
     i18use(XHR);
     i18init(
       {


### PR DESCRIPTION
Have links resolve to i18next instead of ng-i18next.
Update language list as well as translation team.