### PR TITLE
Add option to include armor bonuses from mods in loadout builder. 

### DIFF
--- a/src/app/d2-loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/d2-loadout-builder/LoadoutBuilder.tsx
@@ -368,14 +368,21 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
    * Handle then the use base stats checkbox is toggled
    * Recomputes matched sets
    */
-  setUseBaseStats = (element) => {
-    this.setState({ useBaseStats: element.target.checked });
-    this.computeSets({ useBaseStats: element.target.checked });
+  setUseBaseStats = (event: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ useBaseStats: event.target.checked });
+    this.computeSets({ useBaseStats: event.target.checked });
   };
 
   render() {
     const { storesLoaded, stores, buckets } = this.props;
-    const { processedSets, processRunning, lockedMap, selectedPerks, selectedStore } = this.state;
+    const {
+      processedSets,
+      processRunning,
+      lockedMap,
+      selectedPerks,
+      selectedStore,
+      useBaseStats
+    } = this.state;
 
     if (!storesLoaded) {
       return <Loading />;
@@ -465,7 +472,9 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
               processRunning={processRunning}
               processedSets={processedSets}
               lockedMap={lockedMap}
+              useBaseStats={useBaseStats}
               selectedStore={selectedStore}
+              setUseBaseStats={this.setUseBaseStats}
               onLockChanged={this.updateLockedArmor}
             />
           )

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -17,7 +17,9 @@ interface Props {
   processRunning: number;
   selectedStore?: DimStore;
   processedSets: ArmorSet[];
+  useBaseStats: boolean;
   lockedMap: { [bucketHash: number]: LockedItemType[] };
+  setUseBaseStats(event: React.ChangeEvent): void;
   onLockChanged(bucket: InventoryBucket, locked?: LockedItemType[]): void;
 }
 
@@ -76,7 +78,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
   };
 
   render() {
-    const { processRunning, lockedMap, selectedStore } = this.props;
+    const { processRunning, lockedMap, selectedStore, setUseBaseStats, useBaseStats } = this.props;
     const { minimumPower, shownSets, stats } = this.state;
 
     if (processRunning > 0) {
@@ -101,6 +103,15 @@ export default class GeneratedSets extends React.Component<Props, State> {
           sectionId="loadoutbuilder-options"
         >
           <div className="flex loadout-builder-row space-between">
+            <div className="mr4">
+              <input
+                id="useBaseStats"
+                type="checkbox"
+                onChange={setUseBaseStats}
+                checked={useBaseStats}
+              />
+              <label htmlFor="useBaseStats">{t('LoadoutBuilder.UseBaseStats')}</label>
+            </div>
             <TierSelect stats={stats} onTierChange={(stats) => this.setState({ stats })} />
             <div className="mr4">
               <span>{t('LoadoutBuilder.SelectPower')}</span>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -467,7 +467,8 @@
     "SelectPowerMinimum": "- None -",
     "ShowMore": "Show More",
     "Title": "Loadout Builder (Beta)",
-    "Traction": "\nThe Traction perk provides +1 Mobility."
+    "Traction": "\nThe Traction perk provides +1 Mobility.",
+    "UseBaseStats": "Exclude Mod Bonus"
   },
   "Loadouts": {
     "AlreadyExistsClass": "A loadout with this name already exists for your {{className}}.",


### PR DESCRIPTION

With exclude mods (Default)
<img width="923" alt="screen shot 2019-02-04 at 8 20 33 pm" src="https://user-images.githubusercontent.com/424158/52253064-8ad8c180-28ba-11e9-92c4-c3cd0ab075ef.png">

Without exclude mods
<img width="909" alt="screen shot 2019-02-04 at 8 20 40 pm" src="https://user-images.githubusercontent.com/424158/52253074-988e4700-28ba-11e9-809b-69d36a3499ea.png">

Resolves #3508
