### PR TITLE
Fix: Recoil stat being shown in AA column on weapon CSV export

### DIFF
--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -295,6 +295,7 @@ function downloadWeapons(items: DimItem[], nameMap: { [key: string]: string }) {
           switch (stat.statHash) {
             case 2715839340: // Recoil direction
               stats.recoil = stat.value;
+              break;
             case 1345609583: // Aim Assist
               stats.aa = stat.value;
               break;


### PR DESCRIPTION
Fixed bug where recoil stat was being shown in aim assist column on weapon export to csv.