### PR TITLE
Add stat:handling as a synonym for stat:equipspeed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Add stat:handling as a synonym for stat:equipspeed, to match the name shown in displays.
+
 # 5.15.0 (2019-02-17)
 
 * Remember the last direction the infusion fuel finder was left in.

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -109,7 +109,7 @@ function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
                   <li>stat:reload:</li>
                   <li>stat:magazine:</li>
                   <li>stat:aimassist: or stat:aa:</li>
-                  <li>stat:equipspeed:</li>
+                  <li>stat:equipspeed: or stat:handling:</li>
                   {destinyVersion === 2 && <li>stat:mobility:</li>}
                   {destinyVersion === 2 && <li>stat:resilience:</li>}
                   {destinyVersion === 2 && <li>stat:recovery:</li>}

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -107,7 +107,8 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     'reload',
     'magazine',
     'aimassist',
-    'equipspeed'
+    'equipspeed',
+    'handling',
   ];
 
   const source = [
@@ -1488,6 +1489,7 @@ function searchFilters(
       magazine: filterByStats('magazine'),
       aimassist: filterByStats('aimassist'),
       equipspeed: filterByStats('equipspeed'),
+      handling: filterByStats('equipspeed'), // Synonym
       mobility: filterByStats('mobility'),
       recovery: filterByStats('recovery'),
       resilience: filterByStats('resilience'),


### PR DESCRIPTION
A simple PR for the first time: I kept seeing "Handling" in the item statistics pages, but there was no obvious filter for it. Turns out it exists as `stat:equipspeed`, but I probably won't be the first person a little confused.

This change just adds `stat:handling` as an alternate way to invoke the same behavior.

