### PR TITLE
Include postmaster items in max light loadouts / calculation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Items in the postmaster now count towards your max possible light.
+
 # 5.19.0 (2019-03-17)
 
 * Fixed: Export mobility value correctly in CSV export.

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -68,7 +68,11 @@ export function maxLightLoadout(storeService: StoreServiceType, store: DimStore)
 
   const applicableItems = storeService.getAllItems().filter((i) => {
     return (
-      i.canBeEquippedBy(store) &&
+      (i.canBeEquippedBy(store) ||
+        (this.location.inPostmaster &&
+          (this.classTypeName === 'unknown' || this.classTypeName === store.class) &&
+          // nothing we are too low-level to equip
+          this.equipRequiredLevel <= store.level)) &&
       i.primStat && // has a primary stat (sanity check)
       statHashes.has(i.primStat.statHash)
     ); // one of our selected stats


### PR DESCRIPTION
Fixes #3633. I'm not sure though, since we don't really handle transfers out of Postmaster super well - this could get in a situation where it's trying to pull something off the Postmaster on another character and has trouble.