### PR TITLE
Take unique stacks into account in spaceLeftForItem.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* DIM now correctly calculates how much space you have free for items that can't have multiple stacks (like Modulus Reports). This makes pulling from postmaster more reliable.
+
 # 5.19.0 (2019-03-17)
 
 * Fixed: Export mobility value correctly in CSV export.

--- a/src/app/inventory/store/d2-store-factory.service.ts
+++ b/src/app/inventory/store/d2-store-factory.service.ts
@@ -63,6 +63,12 @@ const StoreProto = {
     if (!item.bucket) {
       return 0;
     }
+
+    // Some things can't have multiple stacks.
+    if (item.uniqueStack) {
+      return item.maxStackSize - this.amountOfItem(item);
+    }
+
     const occupiedStacks = this.buckets[item.bucket.id] ? this.buckets[item.bucket.id].length : 10;
     const openStacks = Math.max(0, this.capacityForItem(item) - occupiedStacks);
     const maxStackSize = item.maxStackSize || 1;


### PR DESCRIPTION
Plus, keep going even if one item can't be pulled from postmaster.

Fixes #3584.