### PR TITLE
Another attempt at clearing up collapsing

### DIFF
--- a/src/app/dim-ui/CollapsibleTitle.scss
+++ b/src/app/dim-ui/CollapsibleTitle.scss
@@ -31,7 +31,7 @@
   }
   .collapse {
     margin-left: -4px;
-    width: 8px;
+    width: 10px;
     margin-right: 8px;
   }
 
@@ -43,8 +43,8 @@
 
 .collapse {
   cursor: pointer;
-  font-size: 14px;
-  color: $lightgray;
+  font-size: 16px;
+  color: white;
   &:hover,
   .title:hover & {
     color: $orange;

--- a/src/app/inventory/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory/InventoryCollapsibleTitle.scss
@@ -26,10 +26,16 @@
     &.collapsed {
       color: white;
       filter: brightness(0.5);
+      min-height: 32px;
+      padding-bottom: 4px;
       &:nth-child(even) {
         background-color: rgba(0, 0, 0, 0.2);
       }
     }
+  }
+
+  &.collapsed {
+    background-color: black;
   }
 
   .collapse-handle {

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -47,7 +47,11 @@ class InventoryCollapsibleTitle extends React.Component<Props> {
     const { title, collapsed, children, toggle, className, stores } = this.props;
     return (
       <>
-        <div className="store-row inventory-title">
+        <div
+          className={classNames('store-row', 'inventory-title', {
+            collapsed
+          })}
+        >
           {stores.map((store, index) => (
             <div
               key={store.id}

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -7,6 +7,8 @@ import ItemActions from './ItemActions';
 import classNames from 'classnames';
 import ItemReviews from '../item-review/ItemReviews';
 import { percent } from '../shell/filters';
+import { AppIcon } from '../shell/icons';
+import { faChevronCircleDown } from '@fortawesome/free-solid-svg-icons';
 
 export enum ItemPopupTab {
   Overview,
@@ -20,7 +22,8 @@ export default function ItemPopupBody({
   extraInfo,
   tab,
   expanded,
-  onTabChanged
+  onTabChanged,
+  onToggleExpanded
 }: {
   item: DimItem;
   failureStrings?: string[];
@@ -28,6 +31,7 @@ export default function ItemPopupBody({
   tab: ItemPopupTab;
   expanded: boolean;
   onTabChanged(tab: ItemPopupTab): void;
+  onToggleExpanded(): void;
 }) {
   failureStrings = Array.from(failureStrings || []);
   if (!item.canPullFromPostmaster && item.location.inPostmaster) {
@@ -52,7 +56,7 @@ export default function ItemPopupBody({
           )
       )}
       <div className="move-popup-details">
-        {itemDetails && (
+        {itemDetails ? (
           <>
             {/* TODO: Should tabs be in the header? */}
             {item.reviewable && (
@@ -78,6 +82,12 @@ export default function ItemPopupBody({
             {tab === ItemPopupTab.Overview && <ItemOverview item={item} extraInfo={extraInfo} />}
             {tab === ItemPopupTab.Reviews && <ItemReviews item={item} />}
           </>
+        ) : (
+          <div className="item-popup-collapsed item-details">
+            <button className="dim-button" onClick={onToggleExpanded}>
+              <AppIcon icon={faChevronCircleDown} /> {t('MovePopup.Expand')}
+            </button>
+          </div>
         )}
         <ItemActions item={item} />
       </div>

--- a/src/app/item-popup/ItemPopupContainer.scss
+++ b/src/app/item-popup/ItemPopupContainer.scss
@@ -117,6 +117,12 @@
  * Move Popup - Details
  */
 
+.item-popup-collapsed {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
 .item-details {
   margin: 10px;
   box-sizing: border-box;

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -134,6 +134,7 @@ class ItemPopupContainer extends React.Component<Props, State> {
         tab={tab}
         expanded={itemDetails}
         onTabChanged={this.onTabChanged}
+        onToggleExpanded={this.toggleItemDetails}
       />
     );
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -566,6 +566,7 @@
     "Consolidate": "Consolidate",
     "DistributeEvenly": "Distribute Evenly",
     "Equip": "Equip",
+    "Expand": "Expand item details",
     "Infuse": "Infuse",
     "LockUnlock": "",
     "LockUnlock_Lock": "Lock {{itemType}}",


### PR DESCRIPTION
Make collapsed sections hella dark:
<img width="1122" alt="Screen Shot 2019-03-23 at 11 07 21 PM" src="https://user-images.githubusercontent.com/313208/54875668-709e6880-4dc0-11e9-9dce-ce0933443ec8.png">

For item popups, just make a button to open them again (this is getting redesigned soon, I promise):
<img width="392" alt="Screen Shot 2019-03-23 at 7 11 25 PM" src="https://user-images.githubusercontent.com/313208/54875669-7300c280-4dc0-11e9-8c09-d3148dca815b.png">
