### PR TITLE
Put item popup tabs into a view pager

### DIFF
--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -45,14 +45,14 @@ export default function ItemPopupBody({
   const tabs = [
     {
       tab: ItemPopupTab.Overview,
-      title: 'MovePopup.OverviewTab',
+      title: t('MovePopup.OverviewTab'),
       component: <ItemOverview item={item} extraInfo={extraInfo} />
     }
   ];
   if (item.reviewable) {
     tabs.push({
       tab: ItemPopupTab.Reviews,
-      title: 'MovePopup.ReviewsTab',
+      title: t('MovePopup.ReviewsTab'),
       component: <ItemReviews item={item} />
     });
   }
@@ -90,7 +90,7 @@ export default function ItemPopupBody({
                     })}
                     onClick={() => onTabChanged(ta.tab)}
                   >
-                    {t(ta.title)}
+                    {ta.title}
                   </span>
                 ))}
               </div>

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -9,6 +9,7 @@ import ItemReviews from '../item-review/ItemReviews';
 import { percent } from '../shell/filters';
 import { AppIcon } from '../shell/icons';
 import { faChevronCircleDown } from '@fortawesome/free-solid-svg-icons';
+import { Frame, Track, View, ViewPager } from 'react-view-pager';
 
 export const enum ItemPopupTab {
   Overview,
@@ -41,6 +42,27 @@ export default function ItemPopupBody({
   const showDetailsByDefault = !item.equipment && item.notransfer;
   const itemDetails = showDetailsByDefault || expanded;
 
+  const tabs = [
+    {
+      tab: ItemPopupTab.Overview,
+      title: 'MovePopup.OverviewTab',
+      component: <ItemOverview item={item} extraInfo={extraInfo} />
+    }
+  ];
+  if (item.reviewable) {
+    tabs.push({
+      tab: ItemPopupTab.Reviews,
+      title: 'MovePopup.ReviewsTab',
+      component: <ItemReviews item={item} />
+    });
+  }
+
+  const onViewChange = (indices) => {
+    onTabChanged(tabs[indices[0]].tab);
+  };
+
+  const onRest = () => onTabChanged(tab);
+
   return (
     <div>
       {/* TODO: Should these be in the details? Or in the header? */}
@@ -57,31 +79,40 @@ export default function ItemPopupBody({
       )}
       <div className="move-popup-details">
         {itemDetails ? (
-          <>
-            {/* TODO: Should tabs be in the header? */}
-            {item.reviewable && (
+          tabs.length > 1 ? (
+            <>
               <div className="move-popup-tabs">
-                <span
-                  className={classNames('move-popup-tab', {
-                    selected: tab === ItemPopupTab.Overview
-                  })}
-                  onClick={() => onTabChanged(ItemPopupTab.Overview)}
-                >
-                  {t('MovePopup.OverviewTab')}
-                </span>
-                <span
-                  className={classNames('move-popup-tab', {
-                    selected: tab === ItemPopupTab.Reviews
-                  })}
-                  onClick={() => onTabChanged(ItemPopupTab.Reviews)}
-                >
-                  {t('MovePopup.ReviewsTab')}
-                </span>
+                {tabs.map((ta) => (
+                  <span
+                    key={ta.tab}
+                    className={classNames('move-popup-tab', {
+                      selected: tab === ta.tab
+                    })}
+                    onClick={() => onTabChanged(ta.tab)}
+                  >
+                    {t(ta.title)}
+                  </span>
+                ))}
               </div>
-            )}
-            {tab === ItemPopupTab.Overview && <ItemOverview item={item} extraInfo={extraInfo} />}
-            {tab === ItemPopupTab.Reviews && <ItemReviews item={item} />}
-          </>
+              <ViewPager>
+                <Frame className="frame" autoSize="height">
+                  <Track
+                    currentView={tab}
+                    contain={false}
+                    className="track"
+                    onViewChange={onViewChange}
+                    onRest={onRest}
+                  >
+                    {tabs.map((ta) => (
+                      <View key={ta.tab}>{ta.component}</View>
+                    ))}
+                  </Track>
+                </Frame>
+              </ViewPager>
+            </>
+          ) : (
+            tabs[0].component
+          )
         ) : (
           <div className="item-popup-collapsed item-details">
             <button className="dim-button" onClick={onToggleExpanded}>

--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -94,7 +94,7 @@ class ItemReviews extends React.Component<Props, State> {
     const { canReview, item, dtrRating, reviews, userReview } = this.props;
     const { reviewModeOptions, submitted, expandReview } = this.state;
 
-    if (!$featureFlags.reviewsEnabled || !dtrRating) {
+    if (!$featureFlags.reviewsEnabled) {
       return null;
     }
 


### PR DESCRIPTION
![tab-pager](https://user-images.githubusercontent.com/313208/54876026-42bc2280-4dc6-11e9-9bc7-3f3752f5f263.gif)
![tab-pager2](https://user-images.githubusercontent.com/313208/54876027-42bc2280-4dc6-11e9-9cee-9841f2316b86.gif)

This makes the tabs of the item popup swipeable, which will help when we have more tabs. I'm not in love with this view pager, and there are some issues with how we display the popup that cause extra animations (we render certain things in multiple passes that we should do in one). I'm tempted to rewrite our own view pager with react-with-gesture and react-spring but that can come later.