### PR TITLE
Improvements to Loadout Optimizer / Loadout Editor

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -339,7 +339,7 @@ module.exports = (env) => {
         // Forsaken Item Tiles
         '$featureFlags.forsakenTiles': JSON.stringify(env !== 'release'),
         // D2 Loadout Builder
-        '$featureFlags.d2LoadoutBuilder': JSON.stringify(env !== 'release'),
+        '$featureFlags.d2LoadoutBuilder': JSON.stringify(true),
         // Community-curated rolls (wish lists)
         '$featureFlags.curatedRolls': JSON.stringify(true)
       }),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The loadout creator/editor has been redesigned to be easier to use. Select items directly from inside the loadout editor, with search. You can still click items in the inventory to add them as well.
 * Loadouts can now use an option to move all the items that are not in the loadout to the vault when applying the loadout.
 * Made it clearer when inventory and item popups are collapsed.
+* The Loadout Optimizer is out of beta! Use it to automatically calculate loadouts that include certain perks or hit your targets for specific stats.
 
 # 5.19.0 (2019-03-17)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Items in the postmaster now count towards your max possible light.
 * DIM now correctly calculates how much space you have free for items that can't have multiple stacks (like Modulus Reports). This makes pulling from postmaster more reliable.
+* The loadout creator/editor has been redesigned to be easier to use. Select items directly from inside the loadout editor, with search. You can still click items in the inventory to add them as well.
+* Loadouts can now use an option to move all the items that are not in the loadout to the vault when applying the loadout.
+* Made it clearer when inventory and item popups are collapsed.
 
 # 5.19.0 (2019-03-17)
 

--- a/src/app/d2-loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/d2-loadout-builder/LoadoutBuilder.tsx
@@ -21,7 +21,6 @@ import LockedArmor from './locked-armor/LockedArmor';
 import startNewProcess from './process';
 import { ArmorSet, LockableBuckets, LockedItemType } from './types';
 import PerkAutoComplete from './PerkAutoComplete';
-import { AppIcon, refreshIcon } from '../shell/icons';
 import { sortedStoresSelector, storesLoadedSelector } from '../inventory/reducer';
 
 interface ProvidedProps {
@@ -48,11 +47,6 @@ interface State {
   selectedStore?: DimStore;
 }
 
-const perks: { [classType: number]: { [bucketHash: number]: any } } = {};
-const items: {
-  [classType: number]: { [bucketHash: number]: { [itemHash: number]: D2Item[] } };
-} = {};
-
 function mapStateToProps(state: RootState): StoreProps {
   return {
     buckets: state.inventory.buckets!,
@@ -66,10 +60,13 @@ function mapStateToProps(state: RootState): StoreProps {
  */
 export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps, State> {
   private storesSubscription: Subscription;
-  private foundSets: boolean;
   private cancelToken: { cancelled: boolean } = {
     cancelled: false
   };
+  private perks: { [classType: number]: { [bucketHash: number]: any } } = {};
+  private items: {
+    [classType: number]: { [bucketHash: number]: { [itemHash: number]: D2Item[] } };
+  } = {};
 
   constructor(props: Props) {
     super(props);
@@ -98,32 +95,34 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
             if (!item || !item.sockets || !item.bucket.inArmor) {
               continue;
             }
-            if (!perks[item.classType]) {
-              perks[item.classType] = {};
-              items[item.classType] = {};
+            if (!this.perks[item.classType]) {
+              this.perks[item.classType] = {};
+              this.items[item.classType] = {};
             }
-            if (!perks[item.classType][item.bucket.hash]) {
-              perks[item.classType][item.bucket.hash] = new Set<DestinyInventoryItemDefinition>();
-              items[item.classType][item.bucket.hash] = [];
+            if (!this.perks[item.classType][item.bucket.hash]) {
+              this.perks[item.classType][item.bucket.hash] = new Set<
+                DestinyInventoryItemDefinition
+              >();
+              this.items[item.classType][item.bucket.hash] = [];
             }
-            if (!items[item.classType][item.bucket.hash][item.hash]) {
-              items[item.classType][item.bucket.hash][item.hash] = [];
+            if (!this.items[item.classType][item.bucket.hash][item.hash]) {
+              this.items[item.classType][item.bucket.hash][item.hash] = [];
             }
-            items[item.classType][item.bucket.hash][item.hash].push(item);
+            this.items[item.classType][item.bucket.hash][item.hash].push(item);
 
             // build the filtered unique perks item picker
             item.sockets.sockets.filter(filterPlugs).forEach((socket) => {
               socket.plugOptions.forEach((option) => {
-                perks[item.classType][item.bucket.hash].add(option.plugItem);
+                this.perks[item.classType][item.bucket.hash].add(option.plugItem);
               });
             });
           }
         }
 
         // sort exotic perks first, then by index
-        Object.keys(perks).forEach((classType) =>
-          Object.keys(perks[classType]).forEach((bucket) =>
-            (perks[classType][bucket] = [...perks[classType][bucket]].sort(
+        Object.keys(this.perks).forEach((classType) =>
+          Object.keys(this.perks[classType]).forEach((bucket) =>
+            (this.perks[classType][bucket] = [...this.perks[classType][bucket]].sort(
               (a, b) => b.index - a.index
             )).sort((a, b) => b.inventory.tierType - a.inventory.tierType)
           )
@@ -141,9 +140,9 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
   }
 
   componentWillUnmount() {
-    Object.keys(perks).forEach((classType) => {
-      perks[classType] = {};
-      items[classType] = {};
+    Object.keys(this.perks).forEach((classType) => {
+      this.perks[classType] = {};
+      this.items[classType] = {};
     });
     this.storesSubscription.unsubscribe();
   }
@@ -164,7 +163,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     useBaseStats?: boolean;
     requirePerks?: boolean;
   }) => {
-    const allItems = { ...items[classType] };
+    const allItems = { ...this.items[classType] };
     const filteredItems: { [bucket: number]: D2Item[] } = {};
     this.cancelToken.cancelled = true;
     this.cancelToken = {
@@ -261,8 +260,8 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     });
 
     // re-process all sets
+    this.setState({ lockedMap, processRunning: 0, processedSets: [] });
     startNewProcess.call(this, filteredItems, useBaseStats, this.cancelToken);
-    this.setState({ lockedMap });
   };
 
   /**
@@ -299,7 +298,6 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
    * Recomputes matched sets
    */
   onCharacterChanged = (storeId: string) => {
-    this.foundSets = false;
     const selectedStore = this.props.stores.find((s) => s.id === storeId)!;
     this.setState({ selectedStore, lockedMap: {}, requirePerks: true });
     this.computeSets({ classType: selectedStore.classType, lockedMap: {}, requirePerks: true });
@@ -318,7 +316,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     const filteredPerks: { [bucketHash: number]: Set<DestinyInventoryItemDefinition> } = {};
 
     // loop all buckets
-    Object.keys(items[storeClass]).forEach((bucket) => {
+    Object.keys(this.items[storeClass]).forEach((bucket) => {
       if (!lockedMap[bucket]) {
         return;
       }
@@ -332,8 +330,8 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
         this.state.selectedPerks.add((lockedItem.item as DestinyInventoryItemDefinition).index);
       });
       // loop all items by hash
-      Object.keys(items[storeClass][bucket]).forEach((itemHash) => {
-        const itemInstances = items[storeClass][bucket][itemHash];
+      Object.keys(this.items[storeClass][bucket]).forEach((itemHash) => {
+        const itemInstances = this.items[storeClass][bucket][itemHash];
 
         // loop all items by instance
         itemInstances.forEach((item) => {
@@ -399,7 +397,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       store = stores.find((s) => s.current)!;
     }
 
-    if (!perks[store.classType]) {
+    if (!this.perks[store.classType]) {
       return <Loading />;
     }
 
@@ -429,8 +427,8 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
                   key={armor}
                   locked={lockedMap[armor]}
                   bucket={buckets.byId[armor]}
-                  items={items[store!.classType][armor]}
-                  perks={perks[store!.classType][armor]}
+                  items={this.items[store!.classType][armor]}
+                  perks={this.perks[store!.classType][armor]}
                   filteredPerks={this.state.filteredPerks}
                   onLockChanged={this.updateLockedArmor}
                 />
@@ -444,7 +442,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
                 {t('LoadoutBuilder.ResetLocked')}
               </button>
               <PerkAutoComplete
-                perks={perks[store.classType]}
+                perks={this.perks[store.classType]}
                 selectedPerks={selectedPerks}
                 bucketsById={buckets.byId}
                 onSelect={(bucket, item) =>
@@ -460,11 +458,9 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
           </div>
         </CollapsibleTitle>
 
-        {processedSets.length === 0 && this.state.requirePerks && !this.foundSets ? (
+        {processedSets.length === 0 && !processRunning && this.state.requirePerks ? (
           <>
-            <h3>
-              {t('LoadoutBuilder.NoBuildsFound')} <AppIcon spinning={true} icon={refreshIcon} />
-            </h3>
+            <h3>{t('LoadoutBuilder.NoBuildsFound')}</h3>
             <input
               type="button"
               className="dim-button"
@@ -473,17 +469,15 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
             />
           </>
         ) : (
-          (this.foundSets = true) && (
-            <GeneratedSets
-              processRunning={processRunning}
-              processedSets={processedSets}
-              lockedMap={lockedMap}
-              useBaseStats={useBaseStats}
-              selectedStore={selectedStore}
-              setUseBaseStats={this.setUseBaseStats}
-              onLockChanged={this.updateLockedArmor}
-            />
-          )
+          <GeneratedSets
+            processRunning={processRunning}
+            processedSets={processedSets}
+            lockedMap={lockedMap}
+            useBaseStats={useBaseStats}
+            selectedStore={selectedStore}
+            setUseBaseStats={this.setUseBaseStats}
+            onLockChanged={this.updateLockedArmor}
+          />
         )}
       </div>
     );

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -47,7 +47,7 @@ export default function GeneratedSetButtons({
  */
 function createLoadout(classType: DimStore['class'], set: ArmorSet): Loadout {
   const loadout = newLoadout(
-    t('Loadouts.Generated', set.tiers[0]),
+    t('Loadouts.Generated', { ...set.tiers[0], tier: _.sum(Object.values(set.tiers[0])) }),
     copy({
       helmet: [set.armor[0]],
       gauntlets: [set.armor[1]],

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -47,7 +47,7 @@ export default function GeneratedSetButtons({
  */
 function createLoadout(classType: DimStore['class'], set: ArmorSet): Loadout {
   const loadout = newLoadout(
-    t('Loadouts.AppliedAuto'),
+    t('Loadouts.Generated', set.tiers[0]),
     copy({
       helmet: [set.armor[0]],
       gauntlets: [set.armor[1]],

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -6,7 +6,7 @@ import { D2Item } from '../../inventory/item-types';
 import { DimStore } from '../../inventory/store-types';
 import { dimLoadoutService, Loadout } from '../../loadout/loadout.service';
 import LoadoutDrawer from '../../loadout/LoadoutDrawer';
-import { AppIcon, powerIndicatorIcon } from '../../shell/icons';
+import { AppIcon, powerIndicatorIcon, refreshIcon } from '../../shell/icons';
 import { ArmorSet, LockedItemType, MinMax, StatTypes } from '../types';
 import GeneratedSetButtons from './GeneratedSetButtons';
 import GeneratedSetItem from './GeneratedSetItem';
@@ -82,14 +82,20 @@ export default class GeneratedSets extends React.Component<Props, State> {
     const { minimumPower, shownSets, stats } = this.state;
 
     if (processRunning > 0) {
-      return <h3>{t('LoadoutBuilder.Loading', { loading: processRunning })}</h3>;
+      return (
+        <h3>
+          {t('LoadoutBuilder.Loading', { loading: processRunning })}{' '}
+          <AppIcon spinning={true} icon={refreshIcon} />
+        </h3>
+      );
     }
 
     // Filter before set tiers are generated
     const uniquePowerLevels = new Set<number>();
     matchedSets = this.props.processedSets.filter((set) => {
-      uniquePowerLevels.add(Math.floor(set.power / 5));
-      return set.power / 5 >= minimumPower;
+      const power = set.power / 5;
+      uniquePowerLevels.add(Math.floor(power));
+      return power >= minimumPower;
     });
     const powerLevelOptions = Array.from(uniquePowerLevels).sort((a, b) => b - a);
     powerLevelOptions.splice(0, 0, 0);

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -140,9 +140,6 @@ export default class GeneratedSets extends React.Component<Props, State> {
             <div className="generated-build" key={set.id}>
               <div className="generated-build-header">
                 <div>
-                  <span className="light">
-                    <AppIcon icon={powerIndicatorIcon} /> {set.power / set.armor.length}
-                  </span>
                   <span>
                     {`T${set.tiers[0].Mobility +
                       set.tiers[0].Resilience +
@@ -151,6 +148,9 @@ export default class GeneratedSets extends React.Component<Props, State> {
                     } | ${t('LoadoutBuilder.Resilience')} ${set.tiers[0].Resilience} | ${t(
                       'LoadoutBuilder.Recovery'
                     )} ${set.tiers[0].Recovery}`}
+                  </span>
+                  <span className="light">
+                    <AppIcon icon={powerIndicatorIcon} /> {set.power / set.armor.length}
                   </span>
                 </div>
 

--- a/src/app/d2-loadout-builder/generated-sets/TierSelect.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/TierSelect.tsx
@@ -11,18 +11,19 @@ export default function TierSelect({
 }) {
   const handleTierChange = (which: string, changed) => {
     const newTiers = stats;
-    if (changed.min) {
+    if (changed.min !== undefined) {
       if (changed.min >= newTiers[which].max) {
         newTiers[which].max = changed.min;
       }
       newTiers[which].min = changed.min;
     }
-    if (changed.max) {
+    if (changed.max !== undefined) {
       if (changed.max <= newTiers[which].min) {
         newTiers[which].min = changed.max;
       }
       newTiers[which].max = changed.max;
     }
+
     onTierChange(newTiers);
   };
 

--- a/src/app/d2-loadout-builder/generated-sets/utils.ts
+++ b/src/app/d2-loadout-builder/generated-sets/utils.ts
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { InventoryBucket } from '../../inventory/inventory-buckets';
 import { DimSocket } from '../../inventory/item-types';
 import { ArmorSet, LockedItemType, MinMax, StatTypes } from '../types';
-import { compareBy } from '../../comparators';
 import { count } from '../../util';
 
 /**
@@ -56,24 +55,31 @@ export function getBestSets(
   stats: { [statType in StatTypes]: MinMax }
 ): ArmorSet[] {
   // Remove sets that do not match tier filters
-  let sortedSets = setMap.filter((set) => {
-    return set.tiers.some((tier) => {
-      return (
-        stats.Mobility.min <= tier.Mobility &&
-        stats.Mobility.max >= tier.Mobility &&
-        stats.Resilience.min <= tier.Resilience &&
-        stats.Resilience.max >= tier.Resilience &&
-        stats.Recovery.min <= tier.Recovery &&
-        stats.Recovery.max >= tier.Recovery
-      );
+  let sortedSets: ArmorSet[];
+  if (
+    stats.Mobility.min === 0 &&
+    stats.Resilience.min === 0 &&
+    stats.Recovery.min === 0 &&
+    stats.Mobility.max === 10 &&
+    stats.Resilience.max === 10 &&
+    stats.Recovery.max === 10
+  ) {
+    sortedSets = Array.from(setMap);
+  } else {
+    sortedSets = setMap.filter((set) => {
+      return set.tiers.some((tier) => {
+        return (
+          stats.Mobility.min <= tier.Mobility &&
+          stats.Mobility.max >= tier.Mobility &&
+          stats.Resilience.min <= tier.Resilience &&
+          stats.Resilience.max >= tier.Resilience &&
+          stats.Recovery.min <= tier.Recovery &&
+          stats.Recovery.max >= tier.Recovery
+        );
+      });
     });
-  });
+  }
 
-  // Sort based highest combined tier, then on power level
-  sortedSets.sort(compareBy((set) => -set.power));
-  sortedSets.sort(
-    compareBy((set) => -(set.tiers[0].Mobility + set.tiers[0].Resilience + set.tiers[0].Recovery))
-  );
   // Prioritize list based on number of matched perks
   Object.keys(lockedMap).forEach((bucket) => {
     // if there are locked perks for this bucket

--- a/src/app/d2-loadout-builder/generated-sets/utils.ts
+++ b/src/app/d2-loadout-builder/generated-sets/utils.ts
@@ -53,17 +53,8 @@ export function getBestSets(
   lockedMap: { [bucketHash: number]: LockedItemType[] },
   stats: { [statType in StatTypes]: MinMax }
 ): ArmorSet[] {
-  // Sort based on power level
-  let sortedSets = _.sortBy(setMap, (set) => -set.power);
-
-  // Sort by highest combined tier
-  sortedSets = _.sortBy(
-    sortedSets,
-    (set) => -(set.tiers[0].Mobility + set.tiers[0].Resilience + set.tiers[0].Recovery)
-  );
-
   // Remove sets that do not match tier filters
-  sortedSets = sortedSets.filter((set) => {
+  const sets = setMap.filter((set) => {
     return set.tiers.some((tier) => {
       return (
         stats.Mobility.min <= tier.Mobility &&
@@ -75,6 +66,12 @@ export function getBestSets(
       );
     });
   });
+
+  // Sort based highest combined tier, then on power level
+  let sortedSets = _.sortBy(sets, (set) => [
+    -(set.tiers[0].Mobility + set.tiers[0].Resilience + set.tiers[0].Recovery),
+    -set.power
+  ]);
 
   // Prioritize list based on number of matched perks
   Object.keys(lockedMap).forEach((bucket) => {

--- a/src/app/d2-loadout-builder/loadoutbuilder.scss
+++ b/src/app/d2-loadout-builder/loadoutbuilder.scss
@@ -136,7 +136,7 @@
   }
 
   .light {
-    margin-right: 6px;
+    margin-left: 8px;
 
     .app-icon {
       font-size: 10px;

--- a/src/app/d2-loadout-builder/process.ts
+++ b/src/app/d2-loadout-builder/process.ts
@@ -3,8 +3,6 @@ import { D2Item } from '../inventory/item-types';
 import { LoadoutBuilder } from './LoadoutBuilder';
 import { LockableBuckets, ArmorSet, StatTypes } from './types';
 
-let killProcess = false;
-
 /**
  * This safely waits for an existing process to be killed, then begins another.
  */
@@ -14,14 +12,9 @@ export default function startNewProcess(
   useBaseStats: boolean,
   cancelToken: { cancelled: boolean }
 ) {
-  if (this.state.processRunning !== 0) {
-    killProcess = true;
-    return window.requestAnimationFrame(() =>
-      startNewProcess.call(this, filteredItems, useBaseStats, cancelToken)
-    );
-  }
-
-  process.call(this, filteredItems, useBaseStats, cancelToken);
+  return window.requestAnimationFrame(() =>
+    process.call(this, filteredItems, useBaseStats, cancelToken)
+  );
 }
 
 /**
@@ -108,12 +101,7 @@ function process(
                 console.log('cancelled processing');
                 return;
               }
-              if (processedCount % 50000 === 0) {
-                if (killProcess) {
-                  this.setState({ processRunning: 0 });
-                  killProcess = false;
-                  return;
-                }
+              if (processedCount % 10000 === 0) {
                 this.setState({ processRunning: Math.floor((processedCount / combos) * 100) });
                 return window.requestAnimationFrame(() => {
                   step.call(this, h, g, c, l, ci, processedCount);

--- a/src/app/d2-loadout-builder/process.ts
+++ b/src/app/d2-loadout-builder/process.ts
@@ -122,11 +122,6 @@ function process(
       return;
     }
 
-    this.setState({
-      processedSets: setMap,
-      processRunning: 0
-    });
-
     console.log(
       'found',
       Object.keys(setMap).length,
@@ -135,6 +130,23 @@ function process(
       'combinations in',
       performance.now() - pstart
     );
+
+    // Pre-sort by tier, then power
+    console.time('sorting sets');
+    setMap.sort((a, b) => b.power - a.power);
+    setMap.sort(
+      (a, b) =>
+        b.tiers[0].Mobility +
+        b.tiers[0].Resilience +
+        b.tiers[0].Recovery -
+        (a.tiers[0].Mobility + a.tiers[0].Resilience + a.tiers[0].Recovery)
+    );
+    console.timeEnd('sorting sets');
+
+    this.setState({
+      processedSets: setMap,
+      processRunning: 0
+    });
   }
 
   step.call(this);

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -262,7 +262,6 @@ class LoadoutDrawer extends React.Component<Props, State> {
     };
 
     const loadoutClassType = loadout && loadoutClassToClassType[loadout.classType];
-    console.log(loadout, loadoutClassType);
 
     try {
       const { item, equip } = await showItemPicker({

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -104,9 +104,9 @@ export default function LoadoutDrawerContents(
       {typesWithoutItems.length > 0 && (
         <div className="loadout-add-types">
           {showFillFromEquipped && (
-            <button className="dim-button loadout-add" onClick={doFillLoadoutFromEquipped}>
+            <a className="dim-button loadout-add" onClick={doFillLoadoutFromEquipped}>
               <AppIcon icon={faPlusCircle} /> {t('Loadouts.AddEquippedItems')}
-            </button>
+            </a>
           )}
           {typesWithoutItems.map((bucket) => (
             <a
@@ -174,7 +174,7 @@ async function pickLoadoutItem(
 function fillLoadoutFromEquipped(
   loadout: Loadout,
   stores: DimStore[],
-  add: (item: DimItem) => void
+  add: (item: DimItem, e?: MouseEvent, equip?: boolean) => void
 ) {
   if (!loadout) {
     return;
@@ -192,7 +192,7 @@ function fillLoadoutFromEquipped(
 
   _.each(equippedLoadout.items, (items, type) => {
     if (items.length && (!loadout.items[type] || !loadout.items[type].some((i) => i.equipped))) {
-      add(items[0]);
+      add(items[0], undefined, true);
     }
   });
 }

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -96,12 +96,13 @@ export default function LoadoutDrawerOptions(
             </button>
           )}
         </div>
-        <div className="input-group">
-          <button className="dim-button" onClick={(e) => goToLoadoutBuilder(e, loadout)}>
-            {t('LB.LB')}
-          </button>
-        </div>
-
+        {$featureFlags.d2LoadoutBuilder && (
+          <div className="input-group">
+            <button className="dim-button" onClick={(e) => goToLoadoutBuilder(e, loadout)}>
+              {t('LB.LB')}
+            </button>
+          </div>
+        )}
         <div className="input-group">
           <label>
             <input type="checkbox" checked={Boolean(loadout.clearSpace)} onChange={setClearSpace} />{' '}

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -56,7 +56,7 @@ export default function LoadoutDrawerOptions(
   return (
     <div className="loadout-options">
       <form onSubmit={saveLoadout}>
-        <div className="input-group">
+        <div className="input-group loadout-name">
           <input
             className="dim-input"
             name="name"

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -160,6 +160,10 @@
     &.bucket-Class {
       min-width: 0;
     }
+
+    .equipped {
+      padding-bottom: 8px;
+    }
   }
 
   .pull-item-button {

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -46,6 +46,11 @@
     flex-wrap: wrap;
   }
 
+  .loadout-name {
+    flex: 1;
+    max-width: 20em;
+  }
+
   .dim-input {
     padding-left: 5px;
     height: 23px;
@@ -53,6 +58,7 @@
     border: none;
     border-bottom: 1px solid #555;
     color: white;
+    width: 100%;
 
     &:hover,
     &:focus {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -475,6 +475,7 @@
     "Any": "Any class",
     "Applied": "Your single item loadout has been transferred to your {{store}}.",
     "AppliedAuto": "Automatic Loadout Builder",
+    "Generated": "Mob{{Mobility}}/Res{{Resilience}}/Rec{{Recovery}}",
     "AppliedError": "None of the items in your loadout could be transferred.",
     "AppliedWarn": "Your loadout has been partially transferred, but {{failed}} of {{total}} items had errors.",
     "Applied_female": "Your single item loadout has been transferred to your {{store}}.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -475,7 +475,7 @@
     "Any": "Any class",
     "Applied": "Your single item loadout has been transferred to your {{store}}.",
     "AppliedAuto": "Automatic Loadout Builder",
-    "Generated": "Mob{{Mobility}}/Res{{Resilience}}/Rec{{Recovery}}",
+    "Generated": "T{{tier}} {{Mobility}}/{{Resilience}}/{{Recovery}}",
     "AppliedError": "None of the items in your loadout could be transferred.",
     "AppliedWarn": "Your loadout has been partially transferred, but {{failed}} of {{total}} items had errors.",
     "Applied_female": "Your single item loadout has been transferred to your {{store}}.",


### PR DESCRIPTION
These improvements should make it so we can take Loadout Optimizer out of beta:

1. Lots of performance improvements. Less "hanging" and better responsiveness when editing filters. Fixes #3601.
2. Add the ability to cancel an in-progress loadout optimizer calculation (for example, when switching characters).
3. Generated loadouts are now named like "T14 7/6/1" instead of "Automatic Loadout Builder".
4. Characters in the loadout optimizer are now properly sorted.
5. Fixed a bug noticed by @duckmanBR where the loadout editor's "Add Equipped" button wouldn't add an item if there was another (nonequipped) item in that slot.
