### PR TITLE
Put the manifest definitions in Redux

### DIFF
--- a/src/app/activities/Activities.tsx
+++ b/src/app/activities/Activities.tsx
@@ -9,7 +9,7 @@ import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
 import { AppIcon, starIcon } from '../shell/icons';
 import { t } from 'i18next';
 import _ from 'lodash';
-import { D1ManifestDefinitions, getDefinitions } from '../destiny1/d1-definitions.service';
+import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 import { D1StoresService } from '../inventory/d1-stores.service';
 import { DestinyAccount } from '../accounts/destiny-account.service';
 import { Loading } from '../dim-ui/Loading';
@@ -53,31 +53,25 @@ interface ProvidedProps {
 
 interface StoreProps {
   stores: DimStore[];
+  defs?: D1ManifestDefinitions;
 }
 
 type Props = ProvidedProps & StoreProps;
 
-interface State {
-  defs?: D1ManifestDefinitions;
-}
-
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    stores: sortedStoresSelector(state)
+    stores: sortedStoresSelector(state),
+    defs: state.manifest.d1Manifest
   };
 }
 
-class Activities extends React.Component<Props, State> {
-  state: State = {};
-
+class Activities extends React.Component<Props> {
   componentDidMount() {
-    getDefinitions().then((defs) => this.setState({ defs }));
     D1StoresService.getStoresStream(this.props.account);
   }
 
   render() {
-    const { stores } = this.props;
-    const { defs } = this.state;
+    const { stores, defs } = this.props;
 
     if (!defs || !stores.length) {
       return (

--- a/src/app/destiny1/d1-definitions.service.ts
+++ b/src/app/destiny1/d1-definitions.service.ts
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 import { D1ManifestService } from '../manifest/manifest-service';
+import store from '../store/store';
+import { setD1Manifest } from '../manifest/actions';
 
 const lazyTables = [
   'InventoryItem',
@@ -78,6 +80,7 @@ async function getUncachedDefinitions() {
       const table = `Destiny${tableShort}Definition`;
       defs[tableShort] = D1ManifestService.getAllRecords(db, table);
     });
+    store.dispatch(setD1Manifest(defs as D1ManifestDefinitions));
     return defs as D1ManifestDefinitions;
   } catch (e) {
     console.error(e);

--- a/src/app/destiny1/d1-definitions.service.ts
+++ b/src/app/destiny1/d1-definitions.service.ts
@@ -81,6 +81,7 @@ async function getUncachedDefinitions() {
       defs[tableShort] = D1ManifestService.getAllRecords(db, table);
     });
     store.dispatch(setD1Manifest(defs as D1ManifestDefinitions));
+    D1ManifestService.loaded = true;
     return defs as D1ManifestDefinitions;
   } catch (e) {
     console.error(e);

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -31,8 +31,7 @@ import {
 import _ from 'lodash';
 import { D2ManifestService } from '../manifest/manifest-service-json';
 import store from '../store/store';
-import { setD1Manifest } from '../manifest/actions';
-import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
+import { setD2Manifest } from '../manifest/actions';
 
 const lazyTables = [
   'InventoryItem', // DestinyInventoryItemDefinition
@@ -146,6 +145,7 @@ async function getDefinitionsUncached() {
     const table = `Destiny${tableShort}Definition`;
     defs[tableShort] = D2ManifestService.getAllRecords(db, table);
   });
-  store.dispatch(setD1Manifest(defs as D1ManifestDefinitions));
+  store.dispatch(setD2Manifest(defs as D2ManifestDefinitions));
+  D2ManifestService.loaded = true;
   return defs as D2ManifestDefinitions;
 }

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -30,6 +30,9 @@ import {
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { D2ManifestService } from '../manifest/manifest-service-json';
+import store from '../store/store';
+import { setD1Manifest } from '../manifest/actions';
+import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 
 const lazyTables = [
   'InventoryItem', // DestinyInventoryItemDefinition
@@ -143,5 +146,6 @@ async function getDefinitionsUncached() {
     const table = `Destiny${tableShort}Definition`;
     defs[tableShort] = D2ManifestService.getAllRecords(db, table);
   });
+  store.dispatch(setD1Manifest(defs as D1ManifestDefinitions));
   return defs as D2ManifestDefinitions;
 }

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -7,7 +7,6 @@ import { router } from '../../router';
 import Sheet from '../dim-ui/Sheet';
 import { AppIcon, plusIcon, helpIcon } from '../shell/icons';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
-import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 import copy from 'fast-copy';
 import { storesSelector } from '../inventory/reducer';
 import { DimStore } from '../inventory/store-types';
@@ -71,7 +70,6 @@ interface State {
   query?: DimItem;
   source?: DimItem;
   target?: DimItem;
-  defs?: D1ManifestDefinitions;
   direction: InfuseDirection;
   filter: string;
   height?: number;
@@ -129,11 +127,7 @@ class InfusionFinder extends React.Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.destinyVersion !== 1 && this.props.destinyVersion === 1 && !this.state.defs) {
-      getDefinitions().then((defs) => this.setState({ defs }));
-    }
-
+  componentDidUpdate() {
     if (this.itemContainer.current && !this.state.height) {
       this.setState({ height: this.itemContainer.current.clientHeight });
     }

--- a/src/app/inventory/d1-stores.service.ts
+++ b/src/app/inventory/d1-stores.service.ts
@@ -6,7 +6,6 @@ import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.ser
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { reportException } from '../exceptions';
 import { getCharacters, getStores } from '../bungie-api/destiny1-api';
-import { D1ManifestService } from '../manifest/manifest-service';
 import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 import { getBuckets } from '../destiny1/d1-buckets.service';
 import { NewItemsService } from './store/new-items.service';
@@ -234,9 +233,6 @@ function StoreService(): D1StoreServiceType {
         // around that with some rxjs operators, but it's easier to
         // just make this never fail.
         return undefined;
-      })
-      .finally(() => {
-        D1ManifestService.loaded = true;
       });
 
     loadingTracker.addPromise(reloadPromise);

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -24,7 +24,6 @@ import { reportException } from '../exceptions';
 import { optimalLoadout } from '../loadout/loadout-utils';
 import { getLight } from '../loadout/loadout.service';
 import '../rx-operators';
-import { D2ManifestService } from '../manifest/manifest-service-json';
 import { resetIdTracker, processItems } from './store/d2-item-factory.service';
 import { makeVault, makeCharacter } from './store/d2-store-factory.service';
 import { NewItemsService } from './store/new-items.service';
@@ -318,7 +317,6 @@ function makeD2StoresService(): D2StoreServiceType {
       return undefined;
     } finally {
       console.timeEnd('Load stores');
-      D2ManifestService.loaded = true;
     }
   }
 

--- a/src/app/item-popup/BestRatedIcon.tsx
+++ b/src/app/item-popup/BestRatedIcon.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { AppIcon, thumbsUpIcon } from '../shell/icons';
+import { t } from 'i18next';
+
+export default function BestRatedIcon({ curationEnabled }: { curationEnabled?: boolean }) {
+  const tipText = curationEnabled ? t('CuratedRoll.BestRatedTip') : t('DtrReview.BestRatedTip');
+
+  return <AppIcon className="thumbs-up" icon={thumbsUpIcon} title={tipText} />;
+}

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -1,0 +1,65 @@
+import classNames from 'classnames';
+import React from 'react';
+import PressTip from '../dim-ui/PressTip';
+import './ItemSockets.scss';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import { D2Item, DimSocket, DimPlug } from '../inventory/item-types';
+import { InventoryCuratedRoll } from '../curated-rolls/curatedRollService';
+import BungieImageAndAmmo from '../dim-ui/BungieImageAndAmmo';
+import BestRatedIcon from './BestRatedIcon';
+import PlugTooltip from './PlugTooltip';
+
+export default function Plug({
+  defs,
+  plug,
+  item,
+  socketInfo,
+  curationEnabled,
+  inventoryCuratedRoll,
+  bestPerks
+}: {
+  defs: D2ManifestDefinitions;
+  plug: DimPlug;
+  item: D2Item;
+  socketInfo: DimSocket;
+  curationEnabled?: boolean;
+  inventoryCuratedRoll?: InventoryCuratedRoll;
+  bestPerks: Set<number>;
+}) {
+  return (
+    <div
+      key={plug.plugItem.hash}
+      className={classNames('socket-container', {
+        disabled: !plug.enabled,
+        notChosen: plug !== socketInfo.plug
+      })}
+    >
+      {(!curationEnabled || !inventoryCuratedRoll || !inventoryCuratedRoll.isCuratedRoll) &&
+        bestPerks.has(plug.plugItem.hash) && <BestRatedIcon curationEnabled={curationEnabled} />}
+      {curationEnabled &&
+        inventoryCuratedRoll &&
+        inventoryCuratedRoll.curatedPerks.find((ph) => ph === plug.plugItem.hash) && (
+          <BestRatedIcon curationEnabled={curationEnabled} />
+        )}
+      <PressTip
+        tooltip={
+          <PlugTooltip
+            item={item}
+            plug={plug}
+            defs={defs}
+            curationEnabled={curationEnabled}
+            bestPerks={bestPerks}
+          />
+        }
+      >
+        <div>
+          <BungieImageAndAmmo
+            hash={plug.plugItem.hash}
+            className="item-mod"
+            src={plug.plugItem.displayProperties.icon}
+          />
+        </div>
+      </PressTip>
+    </div>
+  );
+}

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -1,0 +1,63 @@
+import { t } from 'i18next';
+import React from 'react';
+import './ItemSockets.scss';
+import Objective from '../progress/Objective';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import { D2Item, DimPlug } from '../inventory/item-types';
+import BestRatedIcon from './BestRatedIcon';
+
+// TODO: Connect this to redux
+export default function PlugTooltip({
+  item,
+  plug,
+  defs,
+  curationEnabled,
+  bestPerks
+}: {
+  item: D2Item;
+  plug: DimPlug;
+  defs?: D2ManifestDefinitions;
+  curationEnabled?: boolean;
+  bestPerks: Set<number>;
+}) {
+  // TODO: show insertion costs
+
+  return (
+    <>
+      <h2>
+        {plug.plugItem.displayProperties.name}
+        {item.masterworkInfo &&
+          plug.plugItem.investmentStats &&
+          plug.plugItem.investmentStats[0] &&
+          item.masterworkInfo.statHash === plug.plugItem.investmentStats[0].statTypeHash &&
+          ` (${item.masterworkInfo.statName})`}
+      </h2>
+
+      {plug.plugItem.displayProperties.description ? (
+        <div>{plug.plugItem.displayProperties.description}</div>
+      ) : (
+        plug.perks.map((perk) => (
+          <div key={perk.hash}>
+            {plug.plugItem.displayProperties.name !== perk.displayProperties.name && (
+              <div>{perk.displayProperties.name}</div>
+            )}
+            <div>{perk.displayProperties.description}</div>
+          </div>
+        ))
+      )}
+      {defs && plug.plugObjectives.length > 0 && (
+        <div className="plug-objectives">
+          {plug.plugObjectives.map((objective) => (
+            <Objective key={objective.objectiveHash} objective={objective} defs={defs} />
+          ))}
+        </div>
+      )}
+      {plug.enableFailReasons && <div>{plug.enableFailReasons}</div>}
+      {bestPerks.has(plug.plugItem.hash) && (
+        <div className="best-rated-tip">
+          <BestRatedIcon curationEnabled={curationEnabled} /> = {t('DtrReview.BestRatedTip')}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -8,6 +8,8 @@ import { getReviewKey, getD2Roll } from '../destinyTrackerApi/d2-itemTransformer
 import { RootState } from '../store/reducers';
 import produce from 'immer';
 import { DtrRating } from './dtr-api-types';
+import { createSelector } from 'reselect';
+import { getReviewModes } from '../destinyTrackerApi/reviewModesFetcher';
 
 /** Each of the states here is keyed by an "item store key" - see getItemStoreKey */
 export interface ReviewsState {
@@ -28,6 +30,11 @@ const initialState: ReviewsState = {
 };
 
 export const ratingsSelector = (state: RootState) => state.reviews.ratings;
+
+export const reviewModesSelector = createSelector(
+  (state: RootState) => state.manifest.d2Manifest,
+  (defs) => (defs ? getReviewModes(defs) : [])
+);
 
 export const reviews: Reducer<ReviewsState, ReviewsAction> = (
   state: ReviewsState = initialState,

--- a/src/app/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/D1LoadoutBuilder.tsx
@@ -22,7 +22,7 @@ import { Loading } from '../dim-ui/Loading';
 import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
 import { t } from 'i18next';
 import LoadoutDrawer from '../loadout/LoadoutDrawer';
-import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
+import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { getColor } from '../shell/filters';
 import {
@@ -47,6 +47,7 @@ interface StoreProps {
   account: DestinyAccount;
   stores: D1Store[];
   buckets?: InventoryBuckets;
+  defs?: D1ManifestDefinitions;
 }
 
 type Props = StoreProps;
@@ -55,12 +56,12 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     account: currentAccountSelector(state)!,
     buckets: state.inventory.buckets,
-    stores: storesSelector(state) as D1Store[]
+    stores: storesSelector(state) as D1Store[],
+    defs: state.manifest.d1Manifest
   };
 }
 
 interface State {
-  defs?: D1ManifestDefinitions;
   selectedCharacter?: D1Store;
   excludeditems: D1Item[];
   lockedperks: { [armorType in ArmorTypes]: LockedPerkHash };
@@ -134,8 +135,6 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       D1StoresService.getStoresStream(this.props.account);
     }
 
-    getDefinitions().then((defs) => this.setState({ defs }));
-
     if (this.props.stores.length > 0) {
       // Exclude felwinters if we have them, but only the first time stores load
       const felwinters = _.flatMap(this.props.stores, (store) =>
@@ -163,7 +162,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
     }
 
     // TODO: replace progress with state field (calculating/done)
-    if (this.state.defs && this.props.stores.length && !this.state.progress) {
+    if (this.props.defs && this.props.stores.length && !this.state.progress) {
       this.calculateSets();
     }
 
@@ -191,11 +190,10 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
   }
 
   render() {
-    const { stores, buckets } = this.props;
+    const { stores, buckets, defs } = this.props;
     const {
       includeVendors,
       loadingVendors,
-      defs,
       type,
       excludeditems,
       progress,

--- a/src/app/manifest/actions.ts
+++ b/src/app/manifest/actions.ts
@@ -1,0 +1,6 @@
+import { createStandardAction } from 'typesafe-actions';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
+
+export const setD2Manifest = createStandardAction('manifest/D2')<D2ManifestDefinitions>();
+export const setD1Manifest = createStandardAction('manifest/D1')<D1ManifestDefinitions>();

--- a/src/app/manifest/reducer.ts
+++ b/src/app/manifest/reducer.ts
@@ -1,0 +1,39 @@
+import { Reducer } from 'redux';
+import * as actions from './actions';
+import { ActionType, getType } from 'typesafe-actions';
+import { AccountsAction } from '../accounts/reducer';
+import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+
+export interface ManifestState {
+  d1Manifest?: D1ManifestDefinitions;
+  d2Manifest?: D2ManifestDefinitions;
+}
+
+export type ManifestAction = ActionType<typeof actions>;
+
+const initialState: ManifestState = {};
+
+export const manifest: Reducer<ManifestState, ManifestAction | AccountsAction> = (
+  state: ManifestState = initialState,
+  action: ManifestAction
+) => {
+  switch (action.type) {
+    case getType(actions.setD1Manifest): {
+      return {
+        ...state,
+        d1Manifest: action.payload
+      };
+    }
+
+    case getType(actions.setD2Manifest): {
+      return {
+        ...state,
+        d2Manifest: action.payload
+      };
+    }
+
+    default:
+      return state;
+  }
+};

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -10,11 +10,8 @@ import { Subject } from 'rxjs/Subject';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account.service';
 import { getProgression, getVendors } from '../bungie-api/destiny2-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
-import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
 import { reportException } from '../exceptions';
 import '../rx-operators';
-import { getBuckets } from '../destiny2/d2-buckets.service';
-import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { loadingTracker } from '../shell/loading-tracker';
 import { showNotification } from '../notifications/notifications';
 
@@ -28,14 +25,12 @@ export interface ProgressService {
 // Should allow for better understanding of updates, but prevents us from "correcting" and interpreting the data,
 // and means we may have to block on defs lookup in the UI rendering :-/
 export interface ProgressProfile {
-  readonly defs: D2ManifestDefinitions;
   readonly profileInfo: DestinyProfileResponse;
   readonly vendors: { [characterId: string]: DestinyVendorsResponse };
   /**
    * The date the most recently played character was last played.
    */
   readonly lastPlayedDate: Date;
-  readonly buckets: InventoryBuckets;
 }
 // A subject that keeps track of the current account. Because it's a
 // behavior subject, any new subscriber will always see its last
@@ -84,7 +79,6 @@ export function reloadProgress() {
 
 async function loadProgress(account: DestinyAccount): Promise<ProgressProfile | undefined> {
   try {
-    const defsPromise = getDefinitions();
     const profileInfo = await getProgression(account);
     const characterIds = Object.keys(profileInfo.characters.data);
     let vendors: DestinyVendorsResponse[] = [];
@@ -96,10 +90,7 @@ async function loadProgress(account: DestinyAccount): Promise<ProgressProfile | 
       console.error('Failed to load vendors', e);
     }
 
-    const defs = await defsPromise;
-    const buckets = await getBuckets();
     return {
-      defs,
       profileInfo,
       vendors: _.zipObject(characterIds, vendors) as ProgressProfile['vendors'],
       get lastPlayedDate() {
@@ -110,8 +101,7 @@ async function loadProgress(account: DestinyAccount): Promise<ProgressProfile | 
           },
           new Date(0)
         );
-      },
-      buckets
+      }
     };
   } catch (e) {
     showNotification(bungieErrorToaster(e));

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -12,7 +12,6 @@ import { getProgression, getVendors } from '../bungie-api/destiny2-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions.service';
 import { reportException } from '../exceptions';
-import { D2ManifestService } from '../manifest/manifest-service-json';
 import '../rx-operators';
 import { getBuckets } from '../destiny2/d2-buckets.service';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
@@ -123,7 +122,5 @@ async function loadProgress(account: DestinyAccount): Promise<ProgressProfile | 
     // around that with some rxjs operators, but it's easier to
     // just make this never fail.
     return undefined;
-  } finally {
-    D2ManifestService.loaded = true;
   }
 }

--- a/src/app/record-books/RecordBooks.tsx
+++ b/src/app/record-books/RecordBooks.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { t } from 'i18next';
 import classNames from 'classnames';
 import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
-import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
+import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
 import _ from 'lodash';
 import { count } from '../util';
 import { setSetting } from '../settings/actions';
@@ -26,6 +26,7 @@ interface ProvidedProps {
 interface StoreProps {
   hideCompletedRecords: boolean;
   stores: D1Store[];
+  defs?: D1ManifestDefinitions;
 }
 
 const mapDispatchToProps = {
@@ -36,7 +37,8 @@ type DispatchProps = typeof mapDispatchToProps;
 function mapStateToProps(state: RootState): StoreProps {
   return {
     hideCompletedRecords: state.settings.hideCompletedRecords,
-    stores: storesSelector(state) as D1Store[]
+    stores: storesSelector(state) as D1Store[],
+    defs: state.manifest.d1Manifest
   };
 }
 
@@ -66,16 +68,10 @@ interface RecordBookPage {
   completedCount: number;
 }
 
-interface State {
-  defs?: D1ManifestDefinitions;
-}
-
-class RecordBooks extends React.Component<Props, State> {
-  state: State = {};
+class RecordBooks extends React.Component<Props> {
   private subscriptions = new Subscriptions();
 
   componentDidMount() {
-    getDefinitions().then((defs) => this.setState({ defs }));
     D1StoresService.getStoresStream(this.props.account);
     this.subscriptions.add(
       refresh$.subscribe(() => {
@@ -89,8 +85,7 @@ class RecordBooks extends React.Component<Props, State> {
   }
 
   render() {
-    const { stores, hideCompletedRecords } = this.props;
-    const { defs } = this.state;
+    const { defs, stores, hideCompletedRecords } = this.props;
 
     if (!defs || !stores.length) {
       return (

--- a/src/app/shell/rating-mode/RatingMode.tsx
+++ b/src/app/shell/rating-mode/RatingMode.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { t } from 'i18next';
 import './RatingMode.scss';
 import ClickOutside from '../../dim-ui/ClickOutside';
-import { D2ManifestDefinitions, getDefinitions } from '../../destiny2/d2-definitions.service';
-import { getReviewModes, D2ReviewMode } from '../../destinyTrackerApi/reviewModesFetcher';
+import { D2ReviewMode } from '../../destinyTrackerApi/reviewModesFetcher';
 import { D2StoresService } from '../../inventory/d2-stores.service';
 import { reviewPlatformOptions } from '../../destinyTrackerApi/platformOptionsFetcher';
 import { setSetting } from '../../settings/actions';
@@ -18,32 +17,33 @@ import HelpLink from '../../dim-ui/HelpLink';
 import RatingsKey from '../../item-review/RatingsKey';
 import { DropzoneOptions } from 'react-dropzone';
 import FileUpload from '../../dim-ui/FileUpload';
+import { reviewModesSelector } from '../../item-review/reducer';
 
 interface StoreProps {
   reviewsModeSelection: number;
   platformSelection: number;
   showReviews: boolean;
+  reviewModeOptions: D2ReviewMode[];
 }
 
 type Props = StoreProps;
 
 interface State {
   open: boolean;
-  defs?: D2ManifestDefinitions;
 }
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
     reviewsModeSelection: state.settings.reviewsModeSelection,
     platformSelection: state.settings.reviewsPlatformSelection,
-    showReviews: state.settings.showReviews
+    showReviews: state.settings.showReviews,
+    reviewModeOptions: reviewModesSelector(state)
   };
 }
 
 // TODO: observe Settings changes - changes in the reviews pane aren't reflected here without an app refresh.
 class RatingMode extends React.Component<Props, State> {
   private dropdownToggler = React.createRef<HTMLElement>();
-  private _reviewModeOptions?: D2ReviewMode[];
 
   constructor(props) {
     super(props);
@@ -52,17 +52,9 @@ class RatingMode extends React.Component<Props, State> {
     };
   }
 
-  componentDidMount() {
-    getDefinitions().then((defs) => this.setState({ defs }));
-  }
-
   render() {
-    const { open, defs } = this.state;
-    const { reviewsModeSelection, platformSelection, showReviews } = this.props;
-
-    if (!defs) {
-      return null;
-    }
+    const { open } = this.state;
+    const { reviewsModeSelection, platformSelection, showReviews, reviewModeOptions } = this.props;
 
     return (
       <div>
@@ -91,7 +83,7 @@ class RatingMode extends React.Component<Props, State> {
                       value={reviewsModeSelection}
                       onChange={this.modeChange}
                     >
-                      {this.reviewModeOptions.map((r) => (
+                      {reviewModeOptions.map((r) => (
                         <option key={r.mode} value={r.mode}>
                           {r.description}
                         </option>
@@ -138,13 +130,6 @@ class RatingMode extends React.Component<Props, State> {
         )}
       </div>
     );
-  }
-
-  private get reviewModeOptions() {
-    if (!this._reviewModeOptions) {
-      this._reviewModeOptions = getReviewModes(this.state.defs);
-    }
-    return this._reviewModeOptions;
   }
 
   private toggleDropdown = () => {

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -7,6 +7,7 @@ import { ReviewsState, reviews } from '../item-review/reducer';
 import { LoadoutsState, loadouts } from '../loadout/reducer';
 import { CurationsState, curations } from '../curated-rolls/reducer';
 import { FarmingState, farming } from '../farming/reducer';
+import { ManifestState, manifest } from '../manifest/reducer';
 import { ThunkAction } from 'redux-thunk';
 
 // See https://github.com/piotrwitek/react-redux-typescript-guide#redux
@@ -20,6 +21,7 @@ export interface RootState {
   readonly loadouts: LoadoutsState;
   readonly curations: CurationsState;
   readonly farming: FarmingState;
+  readonly manifest: ManifestState;
 }
 
 export type ThunkResult<R> = ThunkAction<R, RootState, {}, AnyAction>;
@@ -32,5 +34,6 @@ export default combineReducers({
   shell,
   loadouts,
   curations,
-  farming
+  farming,
+  manifest
 });

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -3,6 +3,7 @@ import allReducers, { RootState } from './reducers';
 import thunk from 'redux-thunk';
 import { getType } from 'typesafe-actions';
 import { update } from '../inventory/actions';
+import { setD1Manifest, setD2Manifest } from '../manifest/actions';
 
 declare global {
   interface Window {
@@ -13,9 +14,9 @@ declare global {
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
   ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
       serialize: false,
-      actionsBlacklist: [getType(update)],
+      actionsBlacklist: [getType(update), getType(setD1Manifest), getType(setD2Manifest)],
       stateSanitizer: (state: RootState) =>
-        state.inventory ? { ...state, inventory: '<<EXCLUDED>>' } : state
+        state.inventory ? { ...state, inventory: '<<EXCLUDED>>', manifest: '<<EXCLUDED>>' } : state
     })
   : compose;
 


### PR DESCRIPTION
This makes it easier (and in many cases, faster) to get ahold of the manifest in components. Notably it removes a double-render from Sockets that caused the new view-pager based item popup to animate when shown.