### PR TITLE
Fix infinite-spinner bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Fixed a bug where reviews failing to load would result in an infinite refresh spinner.
+
 # 5.20.2 (2019-03-27)
 
 * Fixed Pull from Postmaster.

--- a/src/app/shell/loading-tracker.ts
+++ b/src/app/shell/loading-tracker.ts
@@ -12,7 +12,7 @@ class PromiseTracker {
   addPromise<T>(promise: Promise<T>): Promise<T> {
     this.numTracked++;
     this.subject.next(true);
-    promise.then(this.countDown);
+    promise.finally(this.countDown);
     return promise;
   }
 


### PR DESCRIPTION
The problem was that our promise tracker wasn't counting down on failure, so when DTR went down it looked like there was always still work to do.