### PR TITLE
Store/load ratings and reviews to IndexedDB

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * You can now swipe between pages on the item popup.
 * Fixed a bug where reviews failing to load would result in an infinite refresh spinner.
+* Ratings and reviews are now cached on your device for 24 hours, so they should load much faster after the first time.
+* The ratings tab has a cleaned up design.
 * All of the stat filters now show up in search autocomplete and the search help page.
 * You can now move items from the postmaster directly to the vault or other characters.
 * When adding all equipped items to a loadout, the class type for the loadout will be set to the class that can use the armor that's equipped.

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -20,6 +20,7 @@ import updateCSSVariables from './app/css-variables';
 import setupRateLimiter from './app/bungie-api/rate-limit-config';
 import { SyncService } from './app/storage/sync.service';
 import { initSettings } from './app/settings/settings';
+import { saveReviewsToIndexedDB } from './app/item-review/reducer';
 
 polyfill({
   holdToDrag: 300,
@@ -38,6 +39,7 @@ initi18n().then(() => {
 
   SyncService.init();
   initSettings();
+  saveReviewsToIndexedDB();
 
   console.log(
     `DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.github.com/DestinyItemManager/DIM/issues`

--- a/src/app/destinyTrackerApi/bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/bulkFetcher.ts
@@ -11,7 +11,7 @@ import { roundToAtMostOneDecimal } from './d2-bulkFetcher';
 import { ThunkResult, RootState } from '../store/reducers';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
-import { ratingsSelector } from '../item-review/reducer';
+import { ratingsSelector, loadReviewsFromIndexedDB } from '../item-review/reducer';
 
 function getBulkFetchPromise(
   stores: (D1Store | Vendor)[],
@@ -44,6 +44,9 @@ function getBulkFetchPromise(
  */
 export function bulkFetch(stores: D1Store[]): ThunkResult<Promise<DtrRating[]>> {
   return async (dispatch, getState) => {
+    if (!getState().reviews.loadedFromIDB) {
+      await loadReviewsFromIndexedDB()(dispatch, getState, {});
+    }
     const bulkRankings = await getBulkFetchPromise(stores, ratingsSelector(getState()));
     return attachRankings(bulkRankings, dispatch);
   };

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -75,31 +75,35 @@ export async function getBulkItems(
       arraySlice
     ).then(handleD2Errors, handleD2Errors);
 
-    loadingTracker.addPromise(promiseSlice);
+    try {
+      loadingTracker.addPromise(promiseSlice);
 
-    const result = (await promiseSlice) as D2ItemFetchResponse[];
-    // DTR returns nothing for items with no ratings - fill in empties
-    for (const item of arraySlice) {
-      if (
-        !result.some(
-          (r) => r.referenceId === item.referenceId && r.availablePerks === item.availablePerks
-        )
-      ) {
-        result.push({
-          referenceId: item.referenceId,
-          availablePerks: item.availablePerks,
-          votes: { referenceId: item.referenceId, upvotes: 0, downvotes: 0, total: 0, score: 0 },
-          reviewVotes: {
+      const result = (await promiseSlice) as D2ItemFetchResponse[];
+      // DTR returns nothing for items with no ratings - fill in empties
+      for (const item of arraySlice) {
+        if (
+          !result.some(
+            (r) => r.referenceId === item.referenceId && r.availablePerks === item.availablePerks
+          )
+        ) {
+          result.push({
             referenceId: item.referenceId,
-            upvotes: 0,
-            downvotes: 0,
-            total: 0,
-            score: 0
-          }
-        });
+            availablePerks: item.availablePerks,
+            votes: { referenceId: item.referenceId, upvotes: 0, downvotes: 0, total: 0, score: 0 },
+            reviewVotes: {
+              referenceId: item.referenceId,
+              upvotes: 0,
+              downvotes: 0,
+              total: 0,
+              score: 0
+            }
+          });
+        }
       }
+      results.push(...result);
+    } catch (e) {
+      console.error(e);
     }
-    results.push(...result);
   }
 
   return results;

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -18,7 +18,7 @@ import { updateRatings } from '../item-review/actions';
 import { DtrRating } from '../item-review/dtr-api-types';
 import { getD2Roll } from './d2-itemTransformer';
 import { ThunkResult, RootState } from '../store/reducers';
-import { ratingsSelector } from '../item-review/reducer';
+import { ratingsSelector, loadReviewsFromIndexedDB } from '../item-review/reducer';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
 
@@ -75,14 +75,31 @@ export async function getBulkItems(
       arraySlice
     ).then(handleD2Errors, handleD2Errors);
 
-    try {
-      loadingTracker.addPromise(promiseSlice);
+    loadingTracker.addPromise(promiseSlice);
 
-      const result = await promiseSlice;
-      results.push(...result);
-    } catch (error) {
-      console.error(error);
+    const result = (await promiseSlice) as D2ItemFetchResponse[];
+    // DTR returns nothing for items with no ratings - fill in empties
+    for (const item of arraySlice) {
+      if (
+        !result.some(
+          (r) => r.referenceId === item.referenceId && r.availablePerks === item.availablePerks
+        )
+      ) {
+        result.push({
+          referenceId: item.referenceId,
+          availablePerks: item.availablePerks,
+          votes: { referenceId: item.referenceId, upvotes: 0, downvotes: 0, total: 0, score: 0 },
+          reviewVotes: {
+            referenceId: item.referenceId,
+            upvotes: 0,
+            downvotes: 0,
+            total: 0,
+            score: 0
+          }
+        });
+      }
     }
+    results.push(...result);
   }
 
   return results;
@@ -97,6 +114,10 @@ export function bulkFetch(
   mode: DtrD2ActivityModes
 ): ThunkResult<Promise<DtrRating[]>> {
   return async (dispatch, getState) => {
+    if (!getState().reviews.loadedFromIDB) {
+      await loadReviewsFromIndexedDB()(dispatch, getState, {});
+    }
+
     const existingRatings = ratingsSelector(getState());
     const bulkRankings = await getBulkFetchPromise(
       existingRatings,

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -42,6 +42,7 @@ export function getItemReviewsD2(
     const reviewData = returnedReviewData;
     markUserReview(reviewData);
     sortAndIgnoreReviews(reviewData);
+    reviewData.lastUpdated = new Date();
 
     dispatch(
       reviewsLoaded({

--- a/src/app/destinyTrackerApi/dtr-service-helper.ts
+++ b/src/app/destinyTrackerApi/dtr-service-helper.ts
@@ -2,6 +2,9 @@
 export const dtrTextReviewMultiplier = 10;
 
 export function dtrFetch(url: string, body: object) {
+  const controller = typeof AbortController === 'function' ? new AbortController() : null;
+  const signal = controller && controller.signal;
+
   const request = new Request(url, {
     method: 'POST',
     body: JSON.stringify(body),
@@ -10,5 +13,15 @@ export function dtrFetch(url: string, body: object) {
     }
   });
 
-  return Promise.resolve(fetch(request));
+  let timer;
+  if (controller) {
+    timer = setTimeout(() => controller.abort(), 5000);
+  }
+
+  return Promise.resolve(fetch(request, { signal })).then((r) => {
+    if (controller) {
+      clearTimeout(timer);
+    }
+    return r;
+  });
 }

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -115,5 +115,5 @@ function translateReview(actualReview: ActualD1ItemUserReview): D1ItemUserReview
 function translateReviewResponse(actualResponse: ActualD1ItemReviewResponse): D1ItemReviewResponse {
   const reviews = actualResponse.reviews.map(translateReview);
 
-  return { ...actualResponse, reviews };
+  return { ...actualResponse, reviews, lastUpdated: new Date() };
 }

--- a/src/app/item-review/actions.ts
+++ b/src/app/item-review/actions.ts
@@ -37,3 +37,10 @@ export const markReviewSubmitted = createStandardAction('ratings/REVIEW_SUBMITTE
 export const purgeCachedReview = createStandardAction('ratings/PURGE_REVIEW')<{
   key: string;
 }>();
+
+export const loadFromIDB = createStandardAction('ratings/LOAD_FROM_IDB')<{
+  /** Summary rating data for items (votes/values) */
+  ratings: { [key: string]: DtrRating };
+  /** Detailed reviews for items. */
+  reviews: { [key: string]: D2ItemReviewResponse | D1ItemReviewResponse };
+}>();

--- a/src/app/item-review/d1-dtr-api-types.ts
+++ b/src/app/item-review/d1-dtr-api-types.ts
@@ -91,6 +91,8 @@ export interface D1ItemReviewResponse {
   /** The number of highlighted ratings that DTR has for the weapon (roll). */
   highlightedRatingCount: number;
   reviews: D1ItemUserReview[];
+
+  lastUpdated: Date;
 }
 
 /** A single user's review for a D1 weapon. */

--- a/src/app/item-review/d2-dtr-api-types.ts
+++ b/src/app/item-review/d2-dtr-api-types.ts
@@ -116,6 +116,8 @@ export interface D2ItemReviewResponse {
    * Don't tell anyone I haven't bothered building pagination out yet.
    */
   reviews: D2ItemUserReview[];
+
+  lastUpdated: Date;
 }
 
 /** The subset of DestinyActivityModeType that we use for game modes. */

--- a/src/app/item-review/dtr-api-types.ts
+++ b/src/app/item-review/dtr-api-types.ts
@@ -65,10 +65,7 @@ export interface DtrRating {
   readonly highlightedRatingCount: number;
   /**
    * When was the rating data last updated?
-   * This is touched when we recieve new data (bulk rating/reviews response).
-   * We don't currently touch it when the user makes changes to their working review.
    */
-  // TODO: Remove!
   readonly lastUpdated: Date;
   /** The roll (perk hashes in the form that DTR expects). */
   readonly roll: string | null;

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -5,9 +5,13 @@ import { WorkingD2Rating, D2ItemReviewResponse, D2ItemUserReview } from './d2-dt
 import { WorkingD1Rating, D1ItemReviewResponse, D1ItemUserReview } from './d1-dtr-api-types';
 import { DimItem } from '../inventory/item-types';
 import { getReviewKey, getD2Roll } from '../destinyTrackerApi/d2-itemTransformer';
-import { RootState } from '../store/reducers';
+import { RootState, ThunkResult } from '../store/reducers';
 import produce from 'immer';
 import { DtrRating } from './dtr-api-types';
+import { set, get } from 'idb-keyval';
+import { observeStore } from '../redux-utils';
+import _ from 'lodash';
+import { ITEM_RATING_EXPIRATION } from '../destinyTrackerApi/d2-itemListBuilder';
 
 /** Each of the states here is keyed by an "item store key" - see getItemStoreKey */
 export interface ReviewsState {
@@ -17,6 +21,7 @@ export interface ReviewsState {
   userReviews: { [key: string]: WorkingD2Rating | WorkingD1Rating };
   /** Detailed reviews for items. */
   reviews: { [key: string]: D2ItemReviewResponse | D1ItemReviewResponse };
+  loadedFromIDB: boolean;
 }
 
 export type ReviewsAction = ActionType<typeof actions>;
@@ -24,7 +29,8 @@ export type ReviewsAction = ActionType<typeof actions>;
 const initialState: ReviewsState = {
   ratings: {},
   userReviews: {},
-  reviews: {}
+  reviews: {},
+  loadedFromIDB: false
 };
 
 export const ratingsSelector = (state: RootState) => state.reviews.ratings;
@@ -101,6 +107,21 @@ export const reviews: Reducer<ReviewsState, ReviewsAction> = (
       });
     }
 
+    case getType(actions.loadFromIDB): {
+      return {
+        ...state,
+        reviews: {
+          ...state.reviews,
+          ...action.payload.reviews
+        },
+        ratings: {
+          ...state.ratings,
+          ...action.payload.ratings
+        },
+        loadedFromIDB: true
+      };
+    }
+
     default:
       return state;
   }
@@ -172,4 +193,33 @@ function convertToRatingMap(ratings: DtrRating[]) {
     result[getItemStoreKey(rating.referenceId, rating.roll)] = rating;
   }
   return result;
+}
+
+export function saveReviewsToIndexedDB() {
+  return observeStore(
+    (state) => state.reviews,
+    (currentState, nextState) => {
+      if (nextState.loadedFromIDB) {
+        const cutoff = new Date(Date.now() - ITEM_RATING_EXPIRATION);
+
+        if (!_.isEmpty(nextState.reviews) && nextState.reviews !== currentState.reviews) {
+          set('reviews', _.pickBy(nextState.reviews, (r) => r.lastUpdated > cutoff));
+        }
+        if (!_.isEmpty(nextState.ratings) && nextState.ratings !== currentState.ratings) {
+          set('ratings', _.pickBy(nextState.ratings, (r) => r.lastUpdated > cutoff));
+        }
+      }
+    }
+  );
+}
+
+export function loadReviewsFromIndexedDB(): ThunkResult<Promise<void>> {
+  return async (dispatch) => {
+    const ratingsP = get<{ [key: string]: DtrRating }>('ratings');
+    const reviewsP = get<{ [key: string]: D2ItemReviewResponse | D1ItemReviewResponse }>('reviews');
+
+    const [ratings, reviews] = await Promise.all([ratingsP, reviewsP]);
+
+    dispatch(actions.loadFromIDB({ ratings, reviews }));
+  };
 }


### PR DESCRIPTION
This caches ratings info for 24 hours in IndexedDB, and only fetches for new items or items that were fetched >24 hours ago. This not only improves load performance, but fixes a bit of a bug where ratings would never update once loaded.