### PR TITLE
Allow pulling directly from the postmaster to anywhere

### DIFF
--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -17,10 +17,7 @@ type Props = InternalProps & ExternalProps;
 
 function dragType(props: ExternalProps): string {
   const item = props.item;
-  // TODO: let postmaster stuff be dragged anywhere?
-  return item.notransfer || (item.location.inPostmaster && item.destinyVersion === 2)
-    ? `${item.owner}-${item.bucket.type}`
-    : item.bucket.type!;
+  return item.notransfer ? `${item.owner}-${item.bucket.type}` : item.bucket.type!;
 }
 
 export interface DragObject {

--- a/src/app/item-popup/ItemMoveLocation.tsx
+++ b/src/app/item-popup/ItemMoveLocation.tsx
@@ -71,10 +71,6 @@ export default class ItemMoveLocation extends React.PureComponent<Props> {
       return false;
     }
 
-    if (item.location.inPostmaster) {
-      return false;
-    }
-
     return true;
   };
 
@@ -86,9 +82,9 @@ export default class ItemMoveLocation extends React.PureComponent<Props> {
       return false;
     }
 
-    // Can pull items from the postmaster to the same character
+    // Can pull items from the postmaster.
     if (item.location.inPostmaster && item.location.type !== 'Engrams') {
-      return store.id === buttonStore.id && item.isDestiny2() && item.canPullFromPostmaster;
+      return item.isDestiny2() && item.canPullFromPostmaster;
     } else if (item.notransfer) {
       // Can store an equiped item in same itemStore
       if (item.equipped && store.id === buttonStore.id) {


### PR DESCRIPTION
This fixes our move logic to allow for moving (dragging, etc) items from the postmaster to any other character or the vault, and it'll do the right thing.