### PR TITLE
Surface errors while running loadout builder

### DIFF
--- a/src/app/d2-loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/d2-loadout-builder/LoadoutBuilder.tsx
@@ -37,6 +37,7 @@ type Props = ProvidedProps & StoreProps;
 
 interface State {
   processRunning: number;
+  processError?: Error;
   showingOptions: boolean;
   requirePerks: boolean;
   useBaseStats: boolean;
@@ -260,7 +261,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     });
 
     // re-process all sets
-    this.setState({ lockedMap, processRunning: 0, processedSets: [] });
+    this.setState({ lockedMap, processRunning: 0, processedSets: [], processError: undefined });
     startNewProcess.call(this, filteredItems, useBaseStats, this.cancelToken);
   };
 
@@ -382,6 +383,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     const {
       processedSets,
       processRunning,
+      processError,
       lockedMap,
       selectedPerks,
       selectedStore,
@@ -458,7 +460,10 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
           </div>
         </CollapsibleTitle>
 
-        {processedSets.length === 0 && !processRunning && this.state.requirePerks ? (
+        {processedSets.length === 0 &&
+        !processRunning &&
+        !processError &&
+        this.state.requirePerks ? (
           <>
             <h3>{t('LoadoutBuilder.NoBuildsFound')}</h3>
             <input
@@ -471,6 +476,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
         ) : (
           <GeneratedSets
             processRunning={processRunning}
+            processError={processError}
             processedSets={processedSets}
             lockedMap={lockedMap}
             useBaseStats={useBaseStats}

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -16,6 +16,7 @@ import memoizeOne from 'memoize-one';
 
 interface Props {
   processRunning: number;
+  processError?: Error;
   selectedStore?: DimStore;
   processedSets: ArmorSet[];
   useBaseStats: boolean;
@@ -89,8 +90,24 @@ export default class GeneratedSets extends React.Component<Props, State> {
   };
 
   render() {
-    const { processRunning, lockedMap, selectedStore, setUseBaseStats, useBaseStats } = this.props;
+    const {
+      processRunning,
+      processError,
+      lockedMap,
+      selectedStore,
+      setUseBaseStats,
+      useBaseStats
+    } = this.props;
     const { minimumPower, shownSets, stats } = this.state;
+
+    if (processError) {
+      return (
+        <div className="dim-error">
+          <h2>{t('ErrorBoundary.Title')}</h2>
+          <div>{processError.message}</div>
+        </div>
+      );
+    }
 
     if (processRunning > 0) {
       return (

--- a/src/app/d2-loadout-builder/process.ts
+++ b/src/app/d2-loadout-builder/process.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { D2Item } from '../inventory/item-types';
 import { LoadoutBuilder } from './LoadoutBuilder';
 import { LockableBuckets, ArmorSet, StatTypes } from './types';
+import { reportException } from '../exceptions';
 
 /**
  * This safely waits for an existing process to be killed, then begins another.
@@ -149,5 +150,13 @@ function process(
     });
   }
 
-  step.call(this);
+  try {
+    step.call(this);
+  } catch (e) {
+    this.setState({
+      processRunning: 0,
+      processError: e
+    });
+    reportException('d2-loadout-builder', e, { combos });
+  }
 }


### PR DESCRIPTION
If the loadout builder has a problem, we just stick. This'll print out an error.