### PR TITLE
Restyle reviews tab

### DIFF
--- a/src/app/accounts/destiny-account.service.ts
+++ b/src/app/accounts/destiny-account.service.ts
@@ -18,7 +18,7 @@ import { showNotification } from '../notifications/notifications';
 export const PLATFORM_LABELS = {
   [BungieMembershipType.TigerXbox]: 'Xbox',
   [BungieMembershipType.TigerPsn]: 'PlayStation',
-  [BungieMembershipType.TigerBlizzard]: 'Blizzard',
+  [BungieMembershipType.TigerBlizzard]: 'PC',
   [BungieMembershipType.TigerDemon]: 'Demon',
   [BungieMembershipType.BungieNext]: 'Bungie.net'
 };

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -203,6 +203,8 @@ function makeRating(dtrRating: D2ItemFetchResponse, maxTotalVotes: number): DtrR
     overallScore: getScore(dtrRating, maxTotalVotes),
     lastUpdated: new Date(),
     ratingCount: dtrRating.votes.total,
+    votes: dtrRating.votes,
+    reviewVotes: dtrRating.reviewVotes,
     highlightedRatingCount: 0 // bugbug: D2 API doesn't seem to be returning highlighted ratings in fetch
   };
 }

--- a/src/app/item-review/ItemReview.tsx
+++ b/src/app/item-review/ItemReview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DimItem } from '../inventory/item-types';
-import { D2ItemUserReview } from './d2-dtr-api-types';
+import { D2ItemUserReview, DtrD2ActivityModes } from './d2-dtr-api-types';
 import { D1ItemUserReview } from './d1-dtr-api-types';
 import { AppIcon, thumbsUpIcon, thumbsDownIcon } from '../shell/icons';
 import { faPenSquare, faExclamationTriangle, faBan } from '@fortawesome/free-solid-svg-icons';
@@ -44,34 +44,31 @@ export default class ItemReview extends React.Component<Props, State> {
             onClick={this.editReview}
           >
             <div className="community-review--who">
-              {isD1Review(item, review) ? (
-                <StarRatingDisplay rating={review.rating} />
-              ) : (
-                <>
-                  {review.voted === 1 && (
-                    <div>
-                      <span className="community-review--thumbs-up">
-                        <AppIcon icon={thumbsUpIcon} />
-                      </span>
-                    </div>
-                  )}
-                  {review.voted === -1 && (
-                    <div>
-                      <span className="community-review--thumbs-down">
-                        <AppIcon icon={thumbsDownIcon} />
-                      </span>
-                    </div>
-                  )}
-                </>
-              )}
-              <div
-                className={classNames({
-                  'community-review--who__special': review.isHighlighted
-                })}
-              >
-                {review.reviewer.displayName} ({PLATFORM_LABELS[review.reviewer.membershipType]})
+              <div>
+                {isD1Review(item, review) ? (
+                  <StarRatingDisplay rating={review.rating} />
+                ) : review.voted === 1 ? (
+                  <span className="community-review--thumbs-up">
+                    <AppIcon icon={thumbsUpIcon} />
+                  </span>
+                ) : (
+                  review.voted === -1 && (
+                    <span className="community-review--thumbs-down">
+                      <AppIcon icon={thumbsDownIcon} />
+                    </span>
+                  )
+                )}{' '}
+                <span
+                  className={classNames('community-review--review-author', {
+                    'community-review--who__special': review.isHighlighted
+                  })}
+                >
+                  {review.reviewer.displayName}
+                </span>{' '}
+                <span className="community-review--days-ago">
+                  {daysAgo(review.timestamp, PLATFORM_LABELS[review.reviewer.membershipType])}
+                </span>
               </div>
-              <div>{review.timestamp.toLocaleDateString()}</div>
               {!item.isVendorItem && (
                 <a
                   className="community-review--clickable"
@@ -81,11 +78,15 @@ export default class ItemReview extends React.Component<Props, State> {
                 </a>
               )}
             </div>
-            {isD2Review(item, review) && reviewModeOptions && (
-              <div className="community-review--game-mode">
-                {t('DtrReview.ForGameMode')} {translateReviewMode(reviewModeOptions, review)}
-              </div>
-            )}
+            {isD2Review(item, review) &&
+              reviewModeOptions &&
+              review.mode !== DtrD2ActivityModes.notSpecified && (
+                <div className="community-review--game-mode">
+                  {t('DtrReview.ForGameMode', {
+                    mode: translateReviewMode(reviewModeOptions, review)
+                  })}
+                </div>
+              )}
             <div className="community-review--review">
               {isD2Review(item, review) ? review.text : review.review}
             </div>
@@ -159,4 +160,13 @@ export function isD2Review(
   _review: D2ItemUserReview | D1ItemUserReview
 ): _review is D2ItemUserReview {
   return item.isDestiny2();
+}
+
+function daysAgo(timestamp: Date, platform: string) {
+  const days = Math.floor((Date.now() - timestamp.getTime()) / (24 * 60 * 60 * 1000));
+  return (
+    <span title={timestamp.toLocaleDateString()}>
+      {t('DtrReview.DaysAgo', { count: days, platform })}
+    </span>
+  );
 }

--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -17,6 +17,7 @@ import { getItemReviews, submitReview } from './destiny-tracker.service';
 import { DtrRating } from './dtr-api-types';
 import { saveUserReview } from './actions';
 import { isD1UserReview, isD2UserReview } from '../destinyTrackerApi/reviewSubmitter';
+import RatingIcon from '../inventory/RatingIcon';
 
 interface ProvidedProps {
   item: DimItem;
@@ -108,48 +109,67 @@ class ItemReviews extends React.Component<Props, State> {
 
     return (
       <div>
-        {canCreateReview && (
-          <div className="user-review--header">
-            <span>{t('DtrReview.YourReview')}</span>
-
-            {isD2UserReview(item, userReview) ? (
-              <div className="user-review--thumbs">
-                <div className="user-review--thumbs-up link" onClick={this.thumbsUp}>
-                  <span className="user-review--thumbs-up-button">
-                    <AppIcon
-                      className="fa-2x"
-                      icon={dtrRating && userReview.voted === 1 ? thumbsUpIcon : faThumbsUp}
-                    />
-                  </span>
-                </div>
-
-                <div className="user-review--thumbs-down">
-                  <span className="user-review--thumbs-down-button" onClick={this.thumbsDown}>
-                    <AppIcon
-                      className="fa-2x"
-                      icon={dtrRating && userReview.voted === -1 ? thumbsDownIcon : faThumbsDown}
-                    />
-                  </span>
-                </div>
-              </div>
-            ) : (
-              <div>
-                <StarRatingEditor rating={userReview.rating} onRatingChange={this.setRating} />
-              </div>
-            )}
-
-            {expandReview && (
-              <span ng-show="expandReview">
-                <button className="dim-button" onClick={this.submitReview}>
-                  {t('DtrReview.Submit')}
-                </button>{' '}
-                <button className="dim-button" onClick={this.cancelEdit}>
-                  {t('DtrReview.Cancel')}
-                </button>
+        <div className="user-review--header">
+          {dtrRating && dtrRating.votes && (
+            <div className="user-review--vote-summary">
+              <span>
+                <AppIcon icon={thumbsUpIcon} className="community-review--thumbs-up" />{' '}
+                {dtrRating.votes.upvotes}
               </span>
-            )}
-          </div>
-        )}
+              <span>+</span>
+              <span>
+                <AppIcon icon={thumbsDownIcon} className="community-review--thumbs-down" />{' '}
+                {dtrRating.votes.downvotes}
+              </span>
+              <span>=</span>
+              <span>
+                <RatingIcon rating={dtrRating.overallScore} /> ({dtrRating.overallScore.toFixed(1)})
+              </span>
+            </div>
+          )}
+          {canCreateReview && (
+            <>
+              <span>{t('DtrReview.YourReview')}</span>
+
+              {isD2UserReview(item, userReview) ? (
+                <div className="user-review--thumbs">
+                  <div className="user-review--thumbs-up link" onClick={this.thumbsUp}>
+                    <span className="user-review--thumbs-up-button">
+                      <AppIcon
+                        className="fa-2x"
+                        icon={dtrRating && userReview.voted === 1 ? thumbsUpIcon : faThumbsUp}
+                      />
+                    </span>
+                  </div>
+
+                  <div className="user-review--thumbs-down">
+                    <span className="user-review--thumbs-down-button" onClick={this.thumbsDown}>
+                      <AppIcon
+                        className="fa-2x"
+                        icon={dtrRating && userReview.voted === -1 ? thumbsDownIcon : faThumbsDown}
+                      />
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <StarRatingEditor rating={userReview.rating} onRatingChange={this.setRating} />
+                </div>
+              )}
+
+              {expandReview && (
+                <span ng-show="expandReview">
+                  <button className="dim-button" onClick={this.submitReview}>
+                    {t('DtrReview.Submit')}
+                  </button>{' '}
+                  <button className="dim-button" onClick={this.cancelEdit}>
+                    {t('DtrReview.Cancel')}
+                  </button>
+                </span>
+              )}
+            </>
+          )}
+        </div>
 
         {expandReview ? (
           <div className="community-review--details">

--- a/src/app/item-review/dtr-api-types.ts
+++ b/src/app/item-review/dtr-api-types.ts
@@ -1,3 +1,5 @@
+import { DtrD2Vote } from './d2-dtr-api-types';
+
 /** Information about the reviewer. Consistent between D1 and D2. */
 export interface DtrReviewer {
   membershipType: number;
@@ -72,4 +74,9 @@ export interface DtrRating {
   readonly lastUpdated: Date;
   /** The roll (perk hashes in the form that DTR expects). */
   readonly roll: string | null;
+
+  /** The votes for a single item. Includes ratings with and without review text. */
+  votes?: DtrD2Vote;
+  /** The votes that have review text along with them. */
+  reviewVotes?: DtrD2Vote;
 }

--- a/src/app/item-review/item-review.scss
+++ b/src/app/item-review/item-review.scss
@@ -5,8 +5,9 @@
 .user-review {
   &--header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     margin: 10px;
+    align-items: center;
 
     star-rating {
       font-size: 1.2em;
@@ -15,6 +16,7 @@
 
   &--thumbs {
     display: flex;
+    margin-left: 16px;
   }
 
   &--thumbs-up {
@@ -27,6 +29,19 @@
 
   &--thumbs-down-button {
     color: #cc6666;
+  }
+
+  &--vote-summary {
+    flex: 1;
+    > span {
+      margin-right: 4px;
+    }
+    .mehroll {
+      color: #ccc;
+    }
+    .rating-icon {
+      font-size: 16px;
+    }
   }
 }
 
@@ -48,8 +63,12 @@
 }
 
 .community-review {
-  border-top: 1px dashed #444;
+  border-top: 1px solid #444;
   margin: 10px;
+
+  &:first-child {
+    margin-top: 0;
+  }
 
   &--reviews {
     max-height: 350px;
@@ -69,8 +88,10 @@
 
   &--who {
     display: flex;
-    justify-content: space-between;
     padding-top: 5px;
+    > *:first-child {
+      flex: 1;
+    }
   }
 
   &--who__special {
@@ -83,6 +104,7 @@
 
   &--review {
     word-wrap: break-word;
+    margin-top: 2px;
   }
 
   &--report-container {
@@ -109,9 +131,18 @@
 
   &--thumbs-down {
     color: #cc6666 !important;
+    font-size: 14px;
   }
 
   &--thumbs-up {
     color: #6dcc66 !important;
+    font-size: 14px;
+  }
+
+  &--days-ago,
+  &--game-mode {
+    color: hsla(0, 0%, 100%, 0.7);
+    font-size: 11px;
+    font-style: italic;
   }
 }

--- a/src/app/shell/star-rating/StarRatingDisplay.tsx
+++ b/src/app/shell/star-rating/StarRatingDisplay.tsx
@@ -11,8 +11,8 @@ export function StarRatingDisplay({ rating }: { rating: number }) {
       {_.times(5, (index) => (
         <AppIcon
           key={index}
-          icon={index + 1 >= rating ? starIcon : starOutlineIcon}
-          className={classNames({ filled: index + 1 >= rating })}
+          icon={index < rating ? starIcon : starOutlineIcon}
+          className={classNames({ filled: index < rating })}
         />
       ))}
     </span>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -104,11 +104,13 @@
     "View": "View Developer Diagnostics"
   },
   "DtrReview": {
+    "DaysAgo": "{{count}} day ago on {{platform}}",
+    "DaysAgo_plural": "{{count}} days ago on {{platform}}",
     "AverageRating": "({{itemRating}}) based on {{numRatings}} ratings.",
     "BestRatedKey": " = suggested perk",
     "BestRatedTip": "This perk is associated with high community ratings.",
     "Cancel": "Cancel",
-    "ForGameMode": "For game mode",
+    "ForGameMode": "For game mode {{mode}}",
     "ForPlatform": "For platform(s)",
     "Help": "Write a review (optional)",
     "ModeNotSpecified": "Not Specified",
@@ -128,7 +130,7 @@
     "ThankYou": "Thank you for submitting a review! It will go live shortly.",
     "UnknownGameMode": "Unknown",
     "VerifyReport": "Are you sure you want to flag this review?",
-    "YourReview": "Your Review"
+    "YourReview": "Your Review:"
   },
   "ErrorBoundary": {
     "Title": "Something went wrong"


### PR DESCRIPTION
<img width="380" alt="Screen Shot 2019-03-30 at 5 50 16 PM" src="https://user-images.githubusercontent.com/313208/55283282-84902000-5314-11e9-93ce-c85b7531ca98.png">

Just some visual cleanup to the reviews tab, plus showing the total up and down votes.