### PR TITLE
Fix moving items with uniqueStack

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * You can now swipe between pages on the item popup.
 * Fixed a bug where reviews failing to load would result in an infinite refresh spinner.
+* Actually fixed the bug where Pull from Postmaster with full modulus reports would move all your other consumables to the vault.
 * Ratings and reviews are now cached on your device for 24 hours, so they should load much faster after the first time.
 * The ratings tab has a cleaned up design.
 * All of the stat filters now show up in search autocomplete and the search help page.

--- a/src/app/inventory/dimItemService.factory.ts
+++ b/src/app/inventory/dimItemService.factory.ts
@@ -776,6 +776,13 @@ function ItemService(): ItemServiceType {
       return true;
     }
 
+    // You can't move more than the max stack of a unique stack item.
+    if (item.uniqueStack && store.amountOfItem(item) + item.amount > item.maxStackSize) {
+      const error: DimError = new Error(t('ItemService.StackFull', { name: item.name }));
+      error.code = 'no-space';
+      throw error;
+    }
+
     const stores = storeService.getStores();
 
     // How much space will be needed (in amount, not stacks) in the target store in order to make the transfer?

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -119,17 +119,16 @@ export async function pullFromPostmaster(store: DimStore): Promise<void> {
     if (item.uniqueStack) {
       const spaceLeft = store.spaceLeftForItem(item);
       if (spaceLeft > 0) {
-        amount = Math.min(item.amount || 1, spaceLeft)
+        // Only transfer enough to top off the stack
+        amount = Math.min(item.amount || 1, spaceLeft);
       }
+      // otherwise try the move anyway - it may be that you don't have any but your bucket
+      // is full, so it'll move aside something else (or the stack itself can be moved into
+      // the vault). Otherwise it'll fail in moveTo.
     }
-    
+
     try {
-      await dimItemService.moveTo(
-        item,
-        store,
-        false,
-        amount
-      );
+      await dimItemService.moveTo(item, store, false, amount);
       succeeded++;
     } catch (e) {
       console.error(`Error pulling ${item.name} from postmaster`, e);

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -381,6 +381,7 @@
     "OnlyEquippedLevel": "This can only be equipped on characters at or above level {{level}}.",
     "PercentComplete": "({{percent, pct}} Complete)",
     "PreviewVendor": "Preview {{type}} contents",
+    "StackFull": "You already have a full stack of {{name}}",
     "TooMuch": "Looks like you requested to move more of this item than exists in the source!"
   },
   "LB": {


### PR DESCRIPTION
Fixes #3694. It turns out that item movement hadn't really been updated to handle uniqueStack items. A previous change fixed `spaceLeftForItem` to correctly return 0 when there was a full stack. When we tried to move something and there was already a full stack, it'd choose another item to move to try and make room for "another stack". But then there still wasn't room so it'd move another, and another...

This adds the logic directly in to say "No, if there's already a full stack you can't move anything aside to make it have room."