### PR TITLE
travis xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js: 10
-install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
-  - export PATH="$HOME/.yarn/bin:$PATH"
-  - yarn install
+dist: xenial
 script: build/travis_build.sh
 sudo: false
 cache:


### PR DESCRIPTION
includes yarn 1.13 by default

https://travis-ci.community/t/upgrade-yarn-to-a-newer-version/2135/2