### PR TITLE
Rearrange code in PerkAutoComplete so it'll react to prop changes

### DIFF
--- a/src/app/d2-loadout-builder/PerkAutoComplete.tsx
+++ b/src/app/d2-loadout-builder/PerkAutoComplete.tsx
@@ -14,28 +14,12 @@ interface Props {
 
 interface State {
   value: string;
-  suggestions: any[];
+  suggestions: {
+    bucket: InventoryBucket;
+    perks: DestinyInventoryItemDefinition[];
+  }[];
 }
 
-const perkOptions: {
-  bucket: InventoryBucket;
-  perks: DestinyInventoryItemDefinition[];
-}[] = [];
-
-function getSuggestions(value) {
-  const inputValue = value.trim().toLowerCase();
-
-  return perkOptions
-    .map((section) => {
-      return {
-        bucket: section.bucket,
-        perks: section.perks.filter((perk) =>
-          perk.displayProperties.name.toLowerCase().includes(inputValue)
-        )
-      };
-    })
-    .filter((section) => section.perks.length > 0);
-}
 const getSuggestionValue = () => 'noop';
 const getSectionSuggestions = (section) => section.perks;
 const renderSectionTitle = (section) => section.bucket.name;
@@ -45,16 +29,6 @@ export default class PerkAutoComplete extends React.Component<Props, State> {
     value: '',
     suggestions: []
   };
-
-  componentDidMount() {
-    const { perks, bucketsById } = this.props;
-    Object.keys(perks).forEach((bucketType) => {
-      perkOptions.push({
-        bucket: bucketsById[bucketType],
-        perks: perks[bucketType]
-      });
-    });
-  }
 
   onChange = (_, { newValue }) => {
     if (newValue !== 'noop') {
@@ -66,6 +40,34 @@ export default class PerkAutoComplete extends React.Component<Props, State> {
 
   // Autosuggest will call this function every time you need to update suggestions.
   onSuggestionsFetchRequested = ({ value }) => {
+    const { perks, bucketsById } = this.props;
+    const perkOptions: {
+      bucket: InventoryBucket;
+      perks: DestinyInventoryItemDefinition[];
+    }[] = [];
+
+    Object.keys(perks).forEach((bucketType) => {
+      perkOptions.push({
+        bucket: bucketsById[bucketType],
+        perks: perks[bucketType]
+      });
+    });
+
+    function getSuggestions(value) {
+      const inputValue = value.trim().toLowerCase();
+
+      return perkOptions
+        .map((section) => {
+          return {
+            bucket: section.bucket,
+            perks: section.perks.filter((perk) =>
+              perk.displayProperties.name.toLowerCase().includes(inputValue)
+            )
+          };
+        })
+        .filter((section) => section.perks.length > 0);
+    }
+
     this.setState({
       suggestions: getSuggestions(value)
     });

--- a/src/app/d2-loadout-builder/process.ts
+++ b/src/app/d2-loadout-builder/process.ts
@@ -13,9 +13,7 @@ export default function startNewProcess(
   useBaseStats: boolean,
   cancelToken: { cancelled: boolean }
 ) {
-  return window.requestAnimationFrame(() =>
-    process.call(this, filteredItems, useBaseStats, cancelToken)
-  );
+  return setTimeout(() => process.call(this, filteredItems, useBaseStats, cancelToken));
 }
 
 /**
@@ -104,7 +102,7 @@ function process(
               }
               if (processedCount % 10000 === 0) {
                 this.setState({ processRunning: Math.floor((processedCount / combos) * 100) });
-                return window.requestAnimationFrame(() => {
+                return setTimeout(() => {
                   step.call(this, h, g, c, l, ci, processedCount);
                 });
               }


### PR DESCRIPTION
The auto completer wasn't particularly reactive - it computed its set of suggestions once, based on the first props it got, and then never again.

Fixes #3710.