### PR TITLE
Rework curated rolls to persist in IndexedDB and handle new items

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -21,6 +21,7 @@ import setupRateLimiter from './app/bungie-api/rate-limit-config';
 import { SyncService } from './app/storage/sync.service';
 import { initSettings } from './app/settings/settings';
 import { saveReviewsToIndexedDB } from './app/item-review/reducer';
+import { saveCurationsToIndexedDB } from './app/curated-rolls/reducer';
 
 polyfill({
   holdToDrag: 300,
@@ -40,6 +41,7 @@ initi18n().then(() => {
   SyncService.init();
   initSettings();
   saveReviewsToIndexedDB();
+  saveCurationsToIndexedDB();
 
   console.log(
     `DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.github.com/DestinyItemManager/DIM/issues`

--- a/src/app/curated-rolls/actions.ts
+++ b/src/app/curated-rolls/actions.ts
@@ -1,7 +1,6 @@
 import { createStandardAction } from 'typesafe-actions';
-import { InventoryCuratedRoll } from './curatedRollService';
+import { CuratedRoll } from './curatedRoll';
 
-export const updateCurations = createStandardAction('curations/UPDATE')<{
-  curationEnabled: boolean;
-  inventoryCuratedRolls: InventoryCuratedRoll[];
-}>();
+export const loadCurations = createStandardAction('curations/LOAD')<CuratedRoll[]>();
+
+export const clearCurations = createStandardAction('curations/CLEAR')();

--- a/src/app/curated-rolls/curatedRoll.ts
+++ b/src/app/curated-rolls/curatedRoll.ts
@@ -9,7 +9,7 @@ export const enum DimWishList {
  * get us this information.
  */
 export interface CuratedRoll {
-  /** Item hash for the recommended item. */
+  /** Item hash for the recommended item, OR an item category hash, OR the special WildcardItemId. */
   itemHash: number;
   /**
    * All of the perks (perk hashes) that need to be present for an item roll to
@@ -18,7 +18,7 @@ export interface CuratedRoll {
    * Also note that fuzzy matching isn't present, but can be faked by removing
    * perks that are thought to have marginal bearing on an item.
    */
-  recommendedPerks: number[];
+  recommendedPerks: Set<number>;
   /**
    * Is this an expert mode recommendation?
    * With B-44 rolls, we make sure that most every perk asked for exists

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -7,6 +7,7 @@ import InventoryItem from './InventoryItem';
 import { getRating, shouldShowRating, ratingsSelector } from '../item-review/reducer';
 import { searchFilterSelector } from '../search/search-filters';
 import { InventoryCuratedRoll } from '../curated-rolls/curatedRollService';
+import { curationsEnabledSelector, inventoryCuratedRollsSelector } from '../curated-rolls/reducer';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -41,8 +42,8 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
     rating: dtrRating ? dtrRating.overallScore : undefined,
     hideRating: !showRating,
     searchHidden: props.allowFilter && !searchFilterSelector(state)(item),
-    curationEnabled: state.curations.curationEnabled,
-    inventoryCuratedRoll: state.curations.curations[item.id]
+    curationEnabled: curationsEnabledSelector(state),
+    inventoryCuratedRoll: inventoryCuratedRollsSelector(state)[item.id]
   };
 }
 

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -64,8 +64,7 @@ export default class InventoryItem extends React.Component<Props> {
       'search-hidden': searchHidden
     };
 
-    const treatAsCurated =
-      curationEnabled && inventoryCuratedRoll && inventoryCuratedRoll.isCuratedRoll;
+    const treatAsCurated = Boolean(curationEnabled && inventoryCuratedRoll);
 
     return (
       <div

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -34,11 +34,12 @@ export default function Plug({
         notChosen: plug !== socketInfo.plug
       })}
     >
-      {(!curationEnabled || !inventoryCuratedRoll || !inventoryCuratedRoll.isCuratedRoll) &&
-        bestPerks.has(plug.plugItem.hash) && <BestRatedIcon curationEnabled={curationEnabled} />}
+      {(!curationEnabled || !inventoryCuratedRoll) && bestPerks.has(plug.plugItem.hash) && (
+        <BestRatedIcon curationEnabled={curationEnabled} />
+      )}
       {curationEnabled &&
         inventoryCuratedRoll &&
-        inventoryCuratedRoll.curatedPerks.find((ph) => ph === plug.plugItem.hash) && (
+        inventoryCuratedRoll.curatedPerks.has(plug.plugItem.hash) && (
           <BestRatedIcon curationEnabled={curationEnabled} />
         )}
       <PressTip

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -17,7 +17,7 @@ import { characterSortSelector } from '../settings/character-sort';
 import store from '../store/store';
 import { loadoutsSelector } from '../loadout/reducer';
 import { InventoryCuratedRoll } from '../curated-rolls/curatedRollService';
-import { curationsSelector } from '../curated-rolls/reducer';
+import { inventoryCuratedRollsSelector } from '../curated-rolls/reducer';
 import { D2SeasonInfo } from '../inventory/d2-season-info';
 import { D2EventPredicateLookup } from '../inventory/d2-event-info';
 import memoizeOne from 'memoize-one';
@@ -46,19 +46,12 @@ export const searchFiltersConfigSelector = createSelector(
   searchConfigSelector,
   sortedStoresSelector,
   loadoutsSelector,
-  curationsSelector,
+  inventoryCuratedRollsSelector,
   ratingsSelector,
   (state: RootState) => state.inventory.newItems,
   characterSortSelector,
-  (searchConfig, stores, loadouts, curationsSelector, ratings, newItems) => {
-    return searchFilters(
-      searchConfig,
-      stores,
-      loadouts,
-      curationsSelector.curations,
-      ratings,
-      newItems
-    );
+  (searchConfig, stores, loadouts, curations, ratings, newItems) => {
+    return searchFilters(searchConfig, stores, loadouts, curations, ratings, newItems);
   }
 );
 
@@ -1479,9 +1472,7 @@ function searchFilters(
         );
       },
       curated(item: D2Item) {
-        const inventoryCuratedRoll = inventoryCuratedRolls[item.id];
-
-        return inventoryCuratedRoll && inventoryCuratedRoll.isCuratedRoll;
+        return Boolean(inventoryCuratedRolls[item.id]);
       },
       ammoType(item: D2Item, predicate: string) {
         return (

--- a/src/app/shell/rating-mode/RatingMode.tsx
+++ b/src/app/shell/rating-mode/RatingMode.tsx
@@ -6,27 +6,36 @@ import { D2ReviewMode } from '../../destinyTrackerApi/reviewModesFetcher';
 import { D2StoresService } from '../../inventory/d2-stores.service';
 import { reviewPlatformOptions } from '../../destinyTrackerApi/platformOptionsFetcher';
 import { setSetting } from '../../settings/actions';
-import store from '../../store/store';
 import { connect } from 'react-redux';
 import { RootState } from '../../store/reducers';
 import { refresh } from '../refresh';
 import { AppIcon, thumbsUpIcon } from '../icons';
-import { dimCuratedRollService } from '../../curated-rolls/curatedRollService';
-import { updateCurations } from '../../curated-rolls/actions';
+import { clearCurations, loadCurations } from '../../curated-rolls/actions';
 import HelpLink from '../../dim-ui/HelpLink';
 import RatingsKey from '../../item-review/RatingsKey';
 import { DropzoneOptions } from 'react-dropzone';
 import FileUpload from '../../dim-ui/FileUpload';
 import { reviewModesSelector } from '../../item-review/reducer';
+import { curationsEnabledSelector, loadCurationsFromIndexedDB } from '../../curated-rolls/reducer';
+import { loadCuratedRolls } from '../../curated-rolls/curatedRollService';
 
 interface StoreProps {
   reviewsModeSelection: number;
   platformSelection: number;
   showReviews: boolean;
   reviewModeOptions: D2ReviewMode[];
+  curationsEnabled: boolean;
 }
 
-type Props = StoreProps;
+const mapDispatchToProps = {
+  clearCurations,
+  loadCurations,
+  setSetting,
+  loadCurationsFromIndexedDB: loadCurationsFromIndexedDB as any
+};
+type DispatchProps = typeof mapDispatchToProps;
+
+type Props = StoreProps & DispatchProps;
 
 interface State {
   open: boolean;
@@ -37,7 +46,8 @@ function mapStateToProps(state: RootState): StoreProps {
     reviewsModeSelection: state.settings.reviewsModeSelection,
     platformSelection: state.settings.reviewsPlatformSelection,
     showReviews: state.settings.showReviews,
-    reviewModeOptions: reviewModesSelector(state)
+    reviewModeOptions: reviewModesSelector(state),
+    curationsEnabled: curationsEnabledSelector(state)
   };
 }
 
@@ -52,9 +62,20 @@ class RatingMode extends React.Component<Props, State> {
     };
   }
 
+  componentDidMount() {
+    this.props.loadCurationsFromIndexedDB();
+  }
+
   render() {
     const { open } = this.state;
-    const { reviewsModeSelection, platformSelection, showReviews, reviewModeOptions } = this.props;
+    const {
+      reviewsModeSelection,
+      platformSelection,
+      showReviews,
+      reviewModeOptions,
+      curationsEnabled,
+      clearCurations
+    } = this.props;
 
     return (
       <div>
@@ -74,7 +95,7 @@ class RatingMode extends React.Component<Props, State> {
                   <RatingsKey />
                   <div className="mode-row">
                     <label className="mode-label" htmlFor="reviewMode">
-                      {t('DtrReview.ForGameMode')}
+                      {t('DtrReview.ForGameMode', { mode: '' })}
                     </label>
                   </div>
                   <div className="mode-row">
@@ -123,6 +144,11 @@ class RatingMode extends React.Component<Props, State> {
                   <div className="mode-row">
                     <FileUpload onDrop={this.loadCurations} title={t('CuratedRoll.Import')} />
                   </div>
+                  {curationsEnabled && (
+                    <button className="dim-button" onClick={clearCurations}>
+                      {t('CuratedRoll.Clear')}
+                    </button>
+                  )}
                 </>
               )}
             </div>
@@ -151,7 +177,7 @@ class RatingMode extends React.Component<Props, State> {
     }
 
     const newModeSelection = e.target.value;
-    store.dispatch(setSetting('reviewsModeSelection', newModeSelection));
+    this.props.setSetting('reviewsModeSelection', newModeSelection);
     D2StoresService.refreshRatingsData();
     refresh();
     ga('send', 'event', 'Rating Options', 'Change Mode');
@@ -163,7 +189,7 @@ class RatingMode extends React.Component<Props, State> {
     }
 
     const newPlatformSelection = e.target.value;
-    store.dispatch(setSetting('reviewsPlatformSelection', newPlatformSelection));
+    this.props.setSetting('reviewsPlatformSelection', newPlatformSelection);
     D2StoresService.refreshRatingsData();
     refresh();
     ga('send', 'event', 'Rating Options', 'Change Platform');
@@ -172,25 +198,16 @@ class RatingMode extends React.Component<Props, State> {
   private loadCurations: DropzoneOptions['onDrop'] = (acceptedFiles) => {
     const reader = new FileReader();
     reader.onload = () => {
-      // TODO: we're kinda trusting that this is the right data here, no validation!
       if (reader.result && typeof reader.result === 'string') {
-        dimCuratedRollService.loadCuratedRolls(reader.result);
+        const curatedRolls = loadCuratedRolls(reader.result);
         ga('send', 'event', 'Rating Options', 'Load Ratings');
 
-        if (dimCuratedRollService.getCuratedRolls()) {
-          const storeRolls = D2StoresService.getStores();
-          const inventoryCuratedRolls = dimCuratedRollService.getInventoryCuratedRolls(storeRolls);
-
-          const curationActionData = {
-            curationEnabled: dimCuratedRollService.curationEnabled,
-            inventoryCuratedRolls
-          };
-
-          store.dispatch(updateCurations(curationActionData));
+        if (curatedRolls.length > 0) {
+          this.props.loadCurations(curatedRolls);
           refresh();
           alert(
             t('CuratedRoll.ImportSuccess', {
-              count: dimCuratedRollService.getCuratedRolls().length
+              count: curatedRolls.length
             })
           );
         } else {
@@ -209,4 +226,7 @@ class RatingMode extends React.Component<Props, State> {
   };
 }
 
-export default connect<StoreProps>(mapStateToProps)(RatingMode);
+export default connect<StoreProps, DispatchProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(RatingMode);

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -86,6 +86,7 @@
   "CuratedRoll": {
     "BestRatedKey": " = curator-suggested perk",
     "BestRatedTip": "This perk was selected by the curator.",
+    "Clear": "Clear Wish List",
     "Header": "Wish List",
     "Import": "Load Wish List Rolls",
     "ImportFailed": "No wish list information found.",


### PR DESCRIPTION
This reworks the wishlist feature, to solve a couple issues:

1. We weren't persisting your wish list between refresh.
2. As a consequence, you also had to reload to clear your wishlist.
3. The wishlist wouldn't get applied to new items - only the items you had when it loaded.

By persisting the wishlist to IndexedDB and reworking things with a Redux-centric workflow, all of these now work as expected.