### PR TITLE
Remove hover to split stack

### DIFF
--- a/src/app/inventory/StackableDragHelp.tsx
+++ b/src/app/inventory/StackableDragHelp.tsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 
 interface Props {
   isDraggingStack: boolean;
-  isHoveringStack: boolean;
 }
 
 interface State {
@@ -15,8 +14,7 @@ interface State {
 
 function mapStateToProps(state: RootState) {
   return {
-    isDraggingStack: state.inventory.isDraggingStack,
-    isHoveringStack: state.inventory.isHoveringStack
+    isDraggingStack: state.inventory.isDraggingStack
   };
 }
 
@@ -32,13 +30,12 @@ class StackableDragHelp extends React.Component<Props, State> {
   }
 
   render() {
-    const { isDraggingStack, isHoveringStack } = this.props;
+    const { isDraggingStack } = this.props;
     const { shiftKeyDown } = this.state;
 
     const classes = {
       'drag-help-hidden': !isDraggingStack,
-      'drag-shift-activated': shiftKeyDown,
-      'drag-dwell-activated': isHoveringStack
+      'drag-shift-activated': shiftKeyDown
     };
 
     // TODO: CSS Transition group? would have to handle attach/detach

--- a/src/app/inventory/StoreBucketDropTarget.tsx
+++ b/src/app/inventory/StoreBucketDropTarget.tsx
@@ -11,8 +11,6 @@ import { InventoryBucket } from './inventory-buckets';
 import { DimStore } from './store-types';
 import { DimItem } from './item-types';
 import moveDroppedItem from './move-dropped-item';
-import { stackableHover } from './actions';
-import store from '../store/store';
 
 interface ExternalProps {
   bucket: InventoryBucket;
@@ -39,12 +37,10 @@ function dragType(props: ExternalProps) {
 // This determines the behavior of dropping on this target
 const dropSpec: DropTargetSpec<Props> = {
   drop(props, monitor, component) {
-    // TODO: ooh, monitor has interesting offset info
-    const hovering = (component as StoreBucketDropTarget).hovering;
     // https://github.com/react-dnd/react-dnd-html5-backend/issues/23
     const shiftPressed = (component as StoreBucketDropTarget).shiftKeyDown;
     const item = monitor.getItem().item as DimItem;
-    moveDroppedItem(props.store, item, Boolean(props.equip), shiftPressed, hovering);
+    moveDroppedItem(props.store, item, Boolean(props.equip), shiftPressed);
   },
   canDrop(props, monitor) {
     // You can drop anything that can be transferred into a non-equipped bucket
@@ -74,42 +70,7 @@ function collect(connect: DropTargetConnector, monitor: DropTargetMonitor): Inte
 class StoreBucketDropTarget extends React.Component<Props> {
   dragTimer?: number;
   shiftKeyDown = false;
-  hovering = false;
   private element?: HTMLDivElement;
-
-  componentWillReceiveProps(nextProps) {
-    if (
-      !this.props.isOver &&
-      nextProps.isOver &&
-      nextProps.item &&
-      nextProps.item.maxStackSize > 1 &&
-      nextProps.item.amount > 1
-    ) {
-      // You can use this as enter handler
-      this.dragTimer = window.setTimeout(() => {
-        // TODO: publish this up to the parent and then consume it via props??
-        // TODO: only do this if the store isn't the origin store
-        this.hovering = true;
-        store.dispatch(stackableHover(true));
-      }, 1000);
-    }
-
-    if (
-      this.props.isOver &&
-      !nextProps.isOver &&
-      this.props.item &&
-      this.props.item.maxStackSize > 1 &&
-      this.props.item.amount > 1
-    ) {
-      // You can use this as leave handler
-      this.hovering = false;
-      store.dispatch(stackableHover(false));
-      if (this.dragTimer) {
-        window.clearTimeout(this.dragTimer);
-        this.dragTimer = undefined;
-      }
-    }
-  }
 
   render() {
     const { connectDropTarget, children, isOver, canDrop, equip } = this.props;

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -51,5 +51,3 @@ export const setTagsAndNotesForItem = createStandardAction('tag_notes/UPDATE_ITE
 
 /** Notify that a stackable stack has begun or ended dragging. A bit overkill to put this in redux but eh. */
 export const stackableDrag = createStandardAction('stackable_drag/DRAG')<boolean>();
-/** Notify that a stackable stack has started or stopped hovering. */
-export const stackableHover = createStandardAction('stackable_drag/HOVER')<boolean>();

--- a/src/app/inventory/move-dropped-item.ts
+++ b/src/app/inventory/move-dropped-item.ts
@@ -40,13 +40,7 @@ export function showMoveAmountPopup(
 
 export default queuedAction(
   loadingTracker.trackPromise(
-    async (
-      target: DimStore,
-      item: DimItem,
-      equip: boolean,
-      shiftPressed: boolean,
-      hovering: boolean
-    ) => {
+    async (target: DimStore, item: DimItem, equip: boolean, forceChooseAmount: boolean) => {
       if (item.notransfer && item.owner !== target.id) {
         throw new Error(t('Help.CannotMove'));
       }
@@ -66,7 +60,7 @@ export default queuedAction(
           item.amount > 1 &&
           // https://github.com/DestinyItemManager/DIM/issues/3373
           !item.uniqueStack &&
-          (shiftPressed || hovering)
+          forceChooseAmount
         ) {
           const maximum = item
             .getStoresService()

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -52,8 +52,6 @@ export interface InventoryState {
 
   /** Are we currently dragging a stack? */
   readonly isDraggingStack;
-  /** Are we hovering a stack over a drop target, with some dwell time? */
-  readonly isHoveringStack;
 }
 
 export type InventoryAction = ActionType<typeof actions>;
@@ -62,8 +60,7 @@ const initialState: InventoryState = {
   stores: [],
   newItems: new Set(),
   itemInfos: {},
-  isDraggingStack: false,
-  isHoveringStack: false
+  isDraggingStack: false
 };
 
 export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction> = (
@@ -133,11 +130,6 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
       return {
         ...state,
         isDraggingStack: action.payload
-      };
-    case getType(actions.stackableHover):
-      return {
-        ...state,
-        isHoveringStack: action.payload
       };
 
     default:

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -317,7 +317,7 @@
   },
   "Help": {
     "CannotMove": "Cannot move that item off this character.",
-    "Drag": "Hold shift or pause over drop zone to transfer a partial stack.",
+    "Drag": "Hold shift to transfer a partial stack",
     "NoStorage": "DIM can't store data",
     "NoStorageMessage": "DIM can't store data in your browser. This can be caused by browsing in private or incognito mode, or when you have low disk space."
   },

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -221,8 +221,7 @@ input[type='search'] {
 }
 
 .drag-help {
-  &.drag-shift-activated,
-  &.drag-dwell-activated {
+  &.drag-shift-activated {
     background-color: rgba(0, 60, 0, 0.8);
   }
 }


### PR DESCRIPTION
Fixes #3512. A React DnD bug has broken this for a long time, and nobody has complained, which makes me think it wasn't a very valuable feature.