### PR TITLE
Reduce potential memory use of loadout builder

### DIFF
--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -47,7 +47,7 @@ export default function GeneratedSetButtons({
  */
 function createLoadout(classType: DimStore['class'], set: ArmorSet): Loadout {
   const loadout = newLoadout(
-    t('Loadouts.Generated', { ...set.tiers[0], tier: _.sum(Object.values(set.tiers[0])) }),
+    t('Loadouts.Generated', { ...set.stats, tier: _.sum(Object.values(set.stats)) }),
     copy({
       helmet: [set.armor[0]],
       gauntlets: [set.armor[1]],

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -173,13 +173,11 @@ export default class GeneratedSets extends React.Component<Props, State> {
               <div className="generated-build-header">
                 <div>
                   <span>
-                    {`T${set.tiers[0].Mobility +
-                      set.tiers[0].Resilience +
-                      set.tiers[0].Recovery} | ${t('LoadoutBuilder.Mobility')} ${
-                      set.tiers[0].Mobility
-                    } | ${t('LoadoutBuilder.Resilience')} ${set.tiers[0].Resilience} | ${t(
-                      'LoadoutBuilder.Recovery'
-                    )} ${set.tiers[0].Recovery}`}
+                    {`T${set.stats.Mobility + set.stats.Resilience + set.stats.Recovery} | ${t(
+                      'LoadoutBuilder.Mobility'
+                    )} ${set.stats.Mobility} | ${t('LoadoutBuilder.Resilience')} ${
+                      set.stats.Resilience
+                    } | ${t('LoadoutBuilder.Recovery')} ${set.stats.Recovery}`}
                   </span>
                   <span className="light">
                     <AppIcon icon={powerIndicatorIcon} /> {set.power / set.armor.length}

--- a/src/app/d2-loadout-builder/generated-sets/utils.ts
+++ b/src/app/d2-loadout-builder/generated-sets/utils.ts
@@ -67,16 +67,14 @@ export function getBestSets(
     sortedSets = Array.from(setMap);
   } else {
     sortedSets = setMap.filter((set) => {
-      return set.tiers.some((tier) => {
-        return (
-          stats.Mobility.min <= tier.Mobility &&
-          stats.Mobility.max >= tier.Mobility &&
-          stats.Resilience.min <= tier.Resilience &&
-          stats.Resilience.max >= tier.Resilience &&
-          stats.Recovery.min <= tier.Recovery &&
-          stats.Recovery.max >= tier.Recovery
-        );
-      });
+      return (
+        stats.Mobility.min <= set.stats.Mobility &&
+        stats.Mobility.max >= set.stats.Mobility &&
+        stats.Resilience.min <= set.stats.Resilience &&
+        stats.Resilience.max >= set.stats.Resilience &&
+        stats.Recovery.min <= set.stats.Recovery &&
+        stats.Recovery.max >= set.stats.Recovery
+      );
     });
   }
 

--- a/src/app/d2-loadout-builder/process.ts
+++ b/src/app/d2-loadout-builder/process.ts
@@ -56,6 +56,12 @@ function process(
                 2;
 
               if (validSet) {
+                const stats: { [statType in StatTypes]: number } = {
+                  Mobility: 0,
+                  Resilience: 0,
+                  Recovery: 0
+                };
+
                 const set: ArmorSet = {
                   id: processedCount,
                   armor: [helms[h], gaunts[g], chests[c], legs[l], classitems[ci]],
@@ -65,19 +71,12 @@ function process(
                     chests[c].basePower +
                     legs[l].basePower +
                     classitems[ci].basePower,
-                  tiers: [],
-                  includesVendorItems: false
+                  // TODO: iterate over perk bonus options and add all tier options
+                  stats
                 };
 
-                const stats: { [statType in StatTypes]: number } = {
-                  Mobility: 0,
-                  Resilience: 0,
-                  Recovery: 0
-                };
-
-                let i = set.armor.length;
-                while (i--) {
-                  const stat = set.armor[i].stats;
+                for (const armor of set.armor) {
+                  const stat = armor.stats;
                   if (stat && stat.length) {
                     stats.Mobility +=
                       (stat[0].value || 0) - ((useBaseStats && stat[0].modsBonus) || 0);
@@ -88,10 +87,6 @@ function process(
                   }
                 }
 
-                // TODO: iterate over perk bonus options and add all tier options
-                set.tiers.push(stats);
-
-                // set.includesVendorItems = pieces.some((armor: any) => armor.isVendorItem);
                 setMap.push(set);
               }
 
@@ -127,7 +122,8 @@ function process(
       'sets after processing',
       combos,
       'combinations in',
-      performance.now() - pstart
+      performance.now() - pstart,
+      processedCount
     );
 
     // Pre-sort by tier, then power
@@ -135,10 +131,10 @@ function process(
     setMap.sort((a, b) => b.power - a.power);
     setMap.sort(
       (a, b) =>
-        b.tiers[0].Mobility +
-        b.tiers[0].Resilience +
-        b.tiers[0].Recovery -
-        (a.tiers[0].Mobility + a.tiers[0].Resilience + a.tiers[0].Recovery)
+        b.stats.Mobility +
+        b.stats.Resilience +
+        b.stats.Recovery -
+        (a.stats.Mobility + a.stats.Resilience + a.stats.Recovery)
     );
     console.timeEnd('sorting sets');
 

--- a/src/app/d2-loadout-builder/types.ts
+++ b/src/app/d2-loadout-builder/types.ts
@@ -26,8 +26,7 @@ export interface ArmorSet {
   id: number;
   armor: D2Item[];
   power: number;
-  tiers: { [statType in StatTypes]: number }[];
-  includesVendorItems: boolean;
+  stats: { [statType in StatTypes]: number };
 }
 
 // bucket lookup, also used for ordering of the buckets.

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -178,7 +178,7 @@ function anyCuratedRolls(category: DimSocketCategory, inventoryCuratedRoll: Inve
     socket.plugOptions.some(
       (plugOption) =>
         plugOption !== socket.plug &&
-        socket.plugOptions.some((dp) => inventoryCuratedRoll.curatedPerks.has(dp.plugItem.hash))
+        inventoryCuratedRoll.curatedPerks.has(plugOption.plugItem.hash)
     )
   );
 }


### PR DESCRIPTION
Just a couple minor things that should reduce the memory footprint a tiny bit.