### PR TITLE
Change core-js polyfills so preset-env works

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -1,4 +1,4 @@
-import 'core-js/stable';
+import 'core-js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/src/authReturn.ts
+++ b/src/authReturn.ts
@@ -1,4 +1,4 @@
-import 'core-js/stable';
+import 'core-js';
 
 import { parse } from 'simple-query-string';
 import { getAccessTokenFromCode } from './app/oauth/oauth.service';


### PR DESCRIPTION
We had lost our polyfills so less-cutting-edge browsers like Edge were left out.