### PR TITLE
layout tweaks or better layout when someone has fewer than 3 characters

### DIFF
--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  padding: 20px 10px;
+  padding: 10px 10px 20px 10px;
+  align-self: start;
 
   .complete {
     color: #a1a2a2;

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -3,7 +3,6 @@
   flex-direction: row;
   align-items: flex-start;
   padding: 20px 10px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
 
   .complete {
     color: #a1a2a2;
@@ -26,7 +25,7 @@
   }
 
   .milestone-name {
-    font-size: 14px;
+    font-size: 16px;
   }
 
   .milestone-location {

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -2,7 +2,8 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  margin-bottom: 20px;
+  padding: 20px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
 
   .complete {
     color: #a1a2a2;

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -3,6 +3,7 @@
 .progress-page {
   margin: 16px auto !important;
   user-select: text;
+  max-width: 90%;
 
   .progress-characters {
     display: flex;
@@ -35,11 +36,11 @@
   }
 
   .progress-for-character {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    margin: 12px;
-    max-width: 276px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-gap: 15px;
+    margin: 15px;
+    width: 100%;
 
     @include phone-portrait {
       max-width: none;

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -4,7 +4,9 @@
   margin: 16px auto !important;
   user-select: text;
   max-width: 90%;
-
+  @media (max-width: 540px) {
+    max-width: 100%;
+  }
   .progress-characters {
     display: flex;
     margin-top: 12px;

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -39,9 +39,13 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     grid-gap: 15px;
-    margin: 15px;
+    padding: 15px;
+    margin: 15px 0;
     width: 100%;
-
+    border-right: 1px solid rgba(255, 255, 255, 0.5);
+    &:last-child {
+      border-right: none;
+    }
     @include phone-portrait {
       max-width: none;
     }

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -4,7 +4,7 @@
   margin: 16px auto !important;
   user-select: text;
   max-width: 90%;
-  @media (max-width: 540px) {
+  @include phone-portrait {
     max-width: 100%;
   }
   .progress-characters {

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -38,6 +38,7 @@
   .progress-for-character {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-auto-rows: min-content;
     grid-gap: 15px;
     padding: 15px;
     margin: 15px 0;


### PR DESCRIPTION
There was a question in discord today about utilizing the space on the progress page better. Essentially this user only had one character so the progress page was a single thin column for them. Even with 3 characters we can likely utilize the space better. This swaps some of the current flexbox in that layout to CSS grid and removes the max-width on the progress page allowing those with more screen real estate to use it.

parts of the API are currently down so you can ignore the red "something went wrong" box. 

BEFORE (1 character)
![image](https://user-images.githubusercontent.com/29002828/55818297-4e952d80-5ac4-11e9-9c09-61afe36a4a7e.png)

BEFORE (3 characters)
![image](https://user-images.githubusercontent.com/29002828/55818354-6967a200-5ac4-11e9-90f6-fbaa65ae69c2.png)

AFTER (1 character)
![image](https://user-images.githubusercontent.com/29002828/55818407-8bf9bb00-5ac4-11e9-87bb-2c207868824d.png)

AFTER (3 characters)
![image](https://user-images.githubusercontent.com/29002828/55818438-a2a01200-5ac4-11e9-98e6-0b1fba7ba60e.png)

AFTER (smaller window)
![image](https://user-images.githubusercontent.com/29002828/55818486-b9deff80-5ac4-11e9-9f16-393001738317.png)

Not a real sweeping change just utilizing the space better and having grid do the lifting on scalability. 


