### PR TITLE
fixes to mobile, general spacing, and ranks wrapping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Next
 
-# 5.23.3 (2019-04-10)
-
 * Progress page changes to utilize more screen real-estate.
 
 # 5.23.2 (2019-04-09)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 5.23.3 (2019-04-10)
+
+* Progress page changes to utilize more screen real-estate.
+
 # 5.23.2 (2019-04-09)
 
 * Fix Edge issues.

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -206,7 +206,7 @@ class Progress extends React.Component<Props, State> {
           <div className="section crucible-ranks">
             <CollapsibleTitle title={t('Progress.CrucibleRank')} sectionId="profile-ranks">
               <div className="progress-row">
-                <div className="progress-for-character">
+                <div className="progress-for-character ranks-for-character">
                   <ErrorBoundary name="CrucibleRanks">
                     {crucibleRanks.map(
                       (progression) =>

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -1,9 +1,14 @@
+@import '../../scss/variables.scss';
+
 .milestone-quest {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   padding: 10px 10px 20px 10px;
   align-self: start;
+  @include phone-portrait {
+    padding: 2px 2px 2px 5px;
+  }
 
   .complete {
     color: #a1a2a2;
@@ -26,7 +31,7 @@
   }
 
   .milestone-name {
-    font-size: 16px;
+    font-size: 14px;
   }
 
   .milestone-location {

--- a/src/app/progress/progress.scss
+++ b/src/app/progress/progress.scss
@@ -42,15 +42,22 @@
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     grid-auto-rows: min-content;
     grid-gap: 15px;
-    padding: 15px;
+    padding: 5px;
     margin: 15px 0;
     width: 100%;
     border-right: 1px solid rgba(255, 255, 255, 0.5);
     &:last-child {
       border-right: none;
     }
+    &.ranks-for-character {
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
     @include phone-portrait {
       max-width: none;
+      margin: 0;
+      &.ranks-for-character {
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+      }
     }
   }
 


### PR DESCRIPTION
fixed up the mobile view to have less padding and be more inline with the current mobile view. Fixed the wrapping of ranks to not be one column on mobile. better alignment and smaller headers on milestone items.

DESKTOP
![image](https://user-images.githubusercontent.com/29002828/55924577-64941280-5bd8-11e9-8c36-258f720ee0af.png)

MOBILE
![image](https://user-images.githubusercontent.com/29002828/55924614-7ecdf080-5bd8-11e9-9ad4-c7ce533de254.png)
