### PR TITLE
Protect against empty data attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@uirouter/visualizer": "^7.0.0",
     "body-scroll-lock": "^2.6.1",
     "browserslist": "^4.0.0",
-    "bungie-api-ts": "^1.6.0",
+    "bungie-api-ts": "^2.0.0",
     "caniuse-lite": ">=1.0.30000843",
     "ceaser-easing": "^1.0.1",
     "classnames": "^2.2.5",

--- a/src/app/collections/Catalysts.tsx
+++ b/src/app/collections/Catalysts.tsx
@@ -102,17 +102,24 @@ function getCatalysts(
 }
 
 function* allItemInstances(profileResponse: DestinyProfileResponse) {
-  for (const item of profileResponse.profileInventory.data.items) {
-    yield item;
-  }
-  for (const character of Object.values(profileResponse.characterInventories.data)) {
-    for (const item of character.items) {
+  if (profileResponse.profileInventory.data) {
+    for (const item of profileResponse.profileInventory.data.items) {
       yield item;
     }
   }
-  for (const character of Object.values(profileResponse.characterEquipment.data)) {
-    for (const item of character.items) {
-      yield item;
+  if (profileResponse.characterInventories.data) {
+    for (const character of Object.values(profileResponse.characterInventories.data)) {
+      for (const item of character.items) {
+        yield item;
+      }
+    }
+  }
+
+  if (profileResponse.characterEquipment.data) {
+    for (const character of Object.values(profileResponse.characterEquipment.data)) {
+      for (const item of character.items) {
+        yield item;
+      }
     }
   }
 }

--- a/src/app/collections/Collectible.tsx
+++ b/src/app/collections/Collectible.tsx
@@ -35,7 +35,7 @@ export default class Collectible extends React.Component<Props> {
       return null;
     }
     const state = getCollectibleState(collectibleDef, profileResponse);
-    if (state & DestinyCollectibleState.Invisible || collectibleDef.redacted) {
+    if (!state || state & DestinyCollectibleState.Invisible || collectibleDef.redacted) {
       return null;
     }
 
@@ -91,7 +91,12 @@ export function getCollectibleState(
   profileResponse: DestinyProfileResponse
 ) {
   return collectibleDef.scope === DestinyScope.Character
-    ? Object.values(profileResponse.characterCollectibles.data)[0].collectibles[collectibleDef.hash]
-        .state
-    : profileResponse.profileCollectibles.data.collectibles[collectibleDef.hash].state;
+    ? profileResponse.characterCollectibles.data
+      ? Object.values(profileResponse.characterCollectibles.data)[0].collectibles[
+          collectibleDef.hash
+        ].state
+      : undefined
+    : profileResponse.profileCollectibles.data
+    ? profileResponse.profileCollectibles.data.collectibles[collectibleDef.hash].state
+    : undefined;
 }

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -121,7 +121,11 @@ class Collections extends React.Component<Props, State> {
 
     // TODO: a lot of this processing should happen at setState, not render?
 
-    const plugSetHashes = new Set(Object.keys(profileResponse.profilePlugSets.data.plugs));
+    const plugSetHashes = new Set(
+      profileResponse.profilePlugSets.data
+        ? Object.keys(profileResponse.profilePlugSets.data.plugs)
+        : []
+    );
     _.each(profileResponse.characterPlugSets.data, (plugSet) => {
       _.each(plugSet.plugs, (_, plugSetHash) => {
         plugSetHashes.add(plugSetHash);

--- a/src/app/collections/PresentationNodeRoot.tsx
+++ b/src/app/collections/PresentationNodeRoot.tsx
@@ -123,20 +123,18 @@ export function countCollectibles(
     );
 
     // TODO: class based on displayStyle
-    const visibleCollectibles = count(
-      collectibleDefs,
-      (c) =>
-        c &&
-        !(getCollectibleState(c, profileResponse) & DestinyCollectibleState.Invisible) &&
-        !c.redacted
-    );
-    const acquiredCollectibles = count(
-      collectibleDefs,
-      (c) =>
-        c &&
-        !(getCollectibleState(c, profileResponse) & DestinyCollectibleState.NotAcquired) &&
-        !c.redacted
-    );
+    const visibleCollectibles = count(collectibleDefs, (c) => {
+      const collectibleState = c && getCollectibleState(c, profileResponse);
+      return Boolean(
+        collectibleState && !(collectibleState & DestinyCollectibleState.Invisible) && !c.redacted
+      );
+    });
+    const acquiredCollectibles = count(collectibleDefs, (c) => {
+      const collectibleState = c && getCollectibleState(c, profileResponse);
+      return Boolean(
+        collectibleState && !(collectibleState & DestinyCollectibleState.NotAcquired) && !c.redacted
+      );
+    });
 
     // add an entry for self and return
     return {
@@ -151,20 +149,14 @@ export function countCollectibles(
     );
 
     // TODO: class based on displayStyle
-    const visibleCollectibles = count(
-      recordDefs,
-      (c) =>
-        c &&
-        !(getRecordComponent(c, profileResponse).state & DestinyRecordState.Invisible) &&
-        !c.redacted
-    );
-    const acquiredCollectibles = count(
-      recordDefs,
-      (c) =>
-        c &&
-        Boolean(getRecordComponent(c, profileResponse).state & DestinyRecordState.RecordRedeemed) &&
-        !c.redacted
-    );
+    const visibleCollectibles = count(recordDefs, (c) => {
+      const record = c && getRecordComponent(c, profileResponse);
+      return Boolean(record && !(record.state & DestinyRecordState.Invisible) && !c.redacted);
+    });
+    const acquiredCollectibles = count(recordDefs, (c) => {
+      const record = c && getRecordComponent(c, profileResponse);
+      return Boolean(record && record.state & DestinyRecordState.RecordRedeemed && !c.redacted);
+    });
 
     // add an entry for self and return
     return {
@@ -200,7 +192,10 @@ export function countCollectibles(
 }
 
 function itemsForPlugSet(profileResponse: DestinyProfileResponse, plugSetHash: number) {
-  return profileResponse.profilePlugSets.data.plugs[plugSetHash].concat(
-    Object.values(profileResponse.characterPlugSets.data).flatMap((d) => d.plugs[plugSetHash])
+  return (profileResponse.profilePlugSets.data
+    ? profileResponse.profilePlugSets.data.plugs[plugSetHash]
+    : []
+  ).concat(
+    Object.values(profileResponse.characterPlugSets.data || {}).flatMap((d) => d.plugs[plugSetHash])
   );
 }

--- a/src/app/collections/Record.tsx
+++ b/src/app/collections/Record.tsx
@@ -31,7 +31,7 @@ export default class Record extends React.Component<Props> {
     }
     const record = getRecordComponent(recordDef, profileResponse);
 
-    if (record.state & DestinyRecordState.Invisible || recordDef.redacted) {
+    if (!record || record.state & DestinyRecordState.Invisible || recordDef.redacted) {
       return null;
     }
 
@@ -100,8 +100,12 @@ export default class Record extends React.Component<Props> {
 export function getRecordComponent(
   recordDef: DestinyRecordDefinition,
   profileResponse: DestinyProfileResponse
-): DestinyRecordComponent {
+): DestinyRecordComponent | undefined {
   return recordDef.scope === DestinyScope.Character
-    ? Object.values(profileResponse.characterRecords.data)[0].records[recordDef.hash]
-    : profileResponse.profileRecords.data.records[recordDef.hash];
+    ? profileResponse.characterRecords.data
+      ? Object.values(profileResponse.characterRecords.data)[0].records[recordDef.hash]
+      : undefined
+    : profileResponse.profileRecords.data
+    ? profileResponse.profileRecords.data.records[recordDef.hash]
+    : undefined;
 }

--- a/src/app/d2-vendors/SingleVendor.tsx
+++ b/src/app/d2-vendors/SingleVendor.tsx
@@ -146,7 +146,7 @@ class SingleVendor extends React.Component<Props, State> {
                   <span className="vendor-location">{placeString}</span>
                 </h1>
                 <div>{vendorDef.displayProperties.description}</div>
-                {vendorResponse && (
+                {vendorResponse && vendorResponse.vendor.data && (
                   <div>
                     Inventory updates in{' '}
                     <Countdown endTime={new Date(vendorResponse.vendor.data.nextRefreshDate)} />
@@ -162,7 +162,9 @@ class SingleVendor extends React.Component<Props, State> {
             vendorItems={vendorItems}
             ownedItemHashes={ownedItemHashes}
             currencyLookups={
-              vendorResponse ? vendorResponse.currencyLookups.data.itemQuantities : {}
+              vendorResponse && vendorResponse.currencyLookups.data
+                ? vendorResponse.currencyLookups.data.itemQuantities
+                : {}
             }
           />
         </ErrorBoundary>

--- a/src/app/d2-vendors/Vendors.tsx
+++ b/src/app/d2-vendors/Vendors.tsx
@@ -175,18 +175,19 @@ class Vendors extends React.Component<Props, State> {
             onCharacterChanged={this.onCharacterChanged}
           />
         )}
-        {Object.values(vendorsResponse.vendorGroups.data.groups).map((group) => (
-          <VendorGroup
-            key={group.vendorGroupHash}
-            defs={defs}
-            buckets={buckets}
-            group={group}
-            vendorsResponse={vendorsResponse}
-            ownedItemHashes={ownedItemHashes}
-            account={account}
-            mergedCollectibles={mergedCollectibles}
-          />
-        ))}
+        {vendorsResponse.vendorGroups.data &&
+          Object.values(vendorsResponse.vendorGroups.data.groups).map((group) => (
+            <VendorGroup
+              key={group.vendorGroupHash}
+              defs={defs}
+              buckets={buckets}
+              group={group}
+              vendorsResponse={vendorsResponse}
+              ownedItemHashes={ownedItemHashes}
+              account={account}
+              mergedCollectibles={mergedCollectibles}
+            />
+          ))}
       </div>
     );
   }
@@ -222,26 +223,32 @@ function VendorGroup({
   return (
     <>
       <h2>{groupDef.categoryName}</h2>
-      {group.vendorHashes
-        .map((h) => vendorsResponse.vendors.data[h])
-        .map((vendor) => (
-          <ErrorBoundary key={vendor.vendorHash} name="Vendor">
-            <Vendor
-              account={account}
-              defs={defs}
-              buckets={buckets}
-              vendor={vendor}
-              itemComponents={vendorsResponse.itemComponents[vendor.vendorHash]}
-              sales={
-                vendorsResponse.sales.data[vendor.vendorHash] &&
-                vendorsResponse.sales.data[vendor.vendorHash].saleItems
-              }
-              ownedItemHashes={ownedItemHashes}
-              currencyLookups={vendorsResponse.currencyLookups.data.itemQuantities}
-              mergedCollectibles={mergedCollectibles}
-            />
-          </ErrorBoundary>
-        ))}
+      {vendorsResponse.vendors.data &&
+        group.vendorHashes
+          .map((h) => vendorsResponse.vendors.data![h])
+          .map((vendor) => (
+            <ErrorBoundary key={vendor.vendorHash} name="Vendor">
+              <Vendor
+                account={account}
+                defs={defs}
+                buckets={buckets}
+                vendor={vendor}
+                itemComponents={vendorsResponse.itemComponents[vendor.vendorHash]}
+                sales={
+                  vendorsResponse.sales.data &&
+                  vendorsResponse.sales.data[vendor.vendorHash] &&
+                  vendorsResponse.sales.data[vendor.vendorHash].saleItems
+                }
+                ownedItemHashes={ownedItemHashes}
+                currencyLookups={
+                  vendorsResponse.currencyLookups.data
+                    ? vendorsResponse.currencyLookups.data.itemQuantities
+                    : {}
+                }
+                mergedCollectibles={mergedCollectibles}
+              />
+            </ErrorBoundary>
+          ))}
     </>
   );
 }

--- a/src/app/d2-vendors/vendor-ratings.ts
+++ b/src/app/d2-vendors/vendor-ratings.ts
@@ -28,7 +28,7 @@ export function fetchRatingsForVendors(
   defs: D2ManifestDefinitions,
   vendorsResponse: DestinyVendorsResponse
 ): ThunkResult<Promise<DtrRating[]>> {
-  const saleComponentArray = Object.values(vendorsResponse.sales.data).map(
+  const saleComponentArray = Object.values(vendorsResponse.sales.data || {}).map(
     (saleItemComponent) => saleItemComponent.saleItems
   );
 
@@ -43,7 +43,7 @@ export function fetchRatingsForVendor(
   defs: D2ManifestDefinitions,
   vendorResponse: DestinyVendorResponse
 ): ThunkResult<Promise<DtrRating[]>> {
-  const saleComponents = Object.values(vendorResponse.sales.data).filter((sc) =>
+  const saleComponents = Object.values(vendorResponse.sales.data || {}).filter((sc) =>
     isWeaponOrArmor(defs, sc)
   );
 

--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -155,7 +155,7 @@ function makeD2StoresService(): D2StoreServiceType {
     // TODO: create a new store
     _stores.forEach((dStore) => {
       if (!dStore.isVault) {
-        const bStore = profileInfo.characters.data[dStore.id];
+        const bStore = profileInfo.characters.data && profileInfo.characters.data[dStore.id];
         if (bStore) {
           dStore.updateCharacterInfo(defs, bStore);
         }
@@ -250,7 +250,7 @@ function makeD2StoresService(): D2StoreServiceType {
       const processStorePromises = Object.keys(profileInfo.characters.data).map((characterId) =>
         processCharacter(
           defs,
-          profileInfo.characters.data[characterId],
+          profileInfo.characters.data![characterId],
 
           profileInfo.characterInventories.data &&
             profileInfo.characterInventories.data[characterId]
@@ -430,7 +430,7 @@ function makeD2StoresService(): D2StoreServiceType {
    * Find the date of the most recently played character.
    */
   function findLastPlayedDate(profileInfo: DestinyProfileResponse) {
-    return Object.values(profileInfo.characters.data).reduce(
+    return Object.values(profileInfo.characters.data!).reduce(
       (memo: Date, character: DestinyCharacterComponent) => {
         const d1 = new Date(character.dateLastPlayed);
         return memo ? (d1 >= memo ? d1 : memo) : d1;

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -258,7 +258,9 @@ export function makeItem(
 ): D2Item | null {
   const itemDef = defs.InventoryItem.get(item.itemHash);
   const instanceDef: Partial<DestinyItemInstanceComponent> =
-    item.itemInstanceId && itemComponents ? itemComponents.instances.data[item.itemInstanceId] : {};
+    item.itemInstanceId && itemComponents && itemComponents.instances.data
+      ? itemComponents.instances.data[item.itemInstanceId]
+      : {};
   // Missing definition?
   if (!itemDef) {
     D2ManifestService.warnMissingDefinition();

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -105,7 +105,7 @@ class Progress extends React.Component<Props, State> {
             currentCharacterId: prevState.currentCharacterId
           };
           if (prevState.currentCharacterId === '') {
-            const characters = Object.values(progress.profileInfo.characters.data);
+            const characters = Object.values(progress.profileInfo.characters.data || {});
             if (characters.length) {
               const lastPlayedDate = progress.lastPlayedDate;
               updatedState.currentCharacterId = characters.find((c) =>
@@ -136,16 +136,17 @@ class Progress extends React.Component<Props, State> {
 
     const { profileInfo } = this.state.progress;
 
-    const characters = this.props.characterOrder(Object.values(profileInfo.characters.data));
+    const characters = this.props.characterOrder(Object.values(profileInfo.characters.data || {}));
 
     const profileMilestones = this.milestonesForProfile(characters[0]);
     const profileQuests = this.questItems(
       characters[0].characterId,
-      profileInfo.profileInventory.data.items
+      profileInfo.profileInventory.data ? profileInfo.profileInventory.data.items : []
     );
 
-    const firstCharacterProgression = Object.values(profileInfo.characterProgressions.data)[0]
-      .progressions;
+    const firstCharacterProgression = profileInfo.characterProgressions.data
+      ? Object.values(profileInfo.characterProgressions.data)[0].progressions
+      : {};
     const crucibleRanks = [
       // Valor
       firstCharacterProgression[2626549951],
@@ -281,6 +282,8 @@ class Progress extends React.Component<Props, State> {
     }
 
     const pursuitsLabel = defs.InventoryBucket[1345459588].displayProperties.name;
+    const characterProgressions = profileInfo.characterProgressions.data || {};
+    const characterInventories = profileInfo.characterInventories.data || {};
 
     return (
       <>
@@ -303,7 +306,7 @@ class Progress extends React.Component<Props, State> {
                   <div className="progress-for-character" key={character.characterId}>
                     <WellRestedPerkIcon
                       defs={defs}
-                      progressions={profileInfo.characterProgressions.data[character.characterId]}
+                      progressions={characterProgressions[character.characterId]}
                     />
                     {this.milestonesForCharacter(character).map((milestone) => (
                       <Milestone
@@ -328,7 +331,7 @@ class Progress extends React.Component<Props, State> {
                   <div className="progress-for-character" key={character.characterId}>
                     {this.questItems(
                       character.characterId,
-                      profileInfo.characterInventories.data[character.characterId].items
+                      characterInventories[character.characterId].items
                     ).map((item) => (
                       <Quest
                         defs={defs}
@@ -350,16 +353,19 @@ class Progress extends React.Component<Props, State> {
               <ErrorBoundary name="Factions">
                 {characters.map((character) => (
                   <div className="progress-for-character" key={character.characterId}>
-                    {this.factionsForCharacter(character).map((faction) => (
-                      <Faction
-                        factionProgress={faction}
-                        defs={defs}
-                        character={character}
-                        profileInventory={profileInfo.profileInventory.data}
-                        key={faction.factionHash}
-                        vendor={this.vendorForFaction(character, faction)}
-                      />
-                    ))}
+                    {this.factionsForCharacter(character).map(
+                      (faction) =>
+                        profileInfo.profileInventory.data && (
+                          <Faction
+                            factionProgress={faction}
+                            defs={defs}
+                            character={character}
+                            profileInventory={profileInfo.profileInventory.data}
+                            key={faction.factionHash}
+                            vendor={this.vendorForFaction(character, faction)}
+                          />
+                        )
+                    )}
                   </div>
                 ))}
               </ErrorBoundary>
@@ -385,8 +391,8 @@ class Progress extends React.Component<Props, State> {
     const { vendors } = this.state.progress!;
     const factionDef = defs.Faction[faction.factionHash];
     const vendorHash = factionDef.vendors[faction.factionVendorIndex].vendorHash;
-    return vendors[character.characterId]
-      ? vendors[character.characterId].vendors.data[vendorHash]
+    return vendors[character.characterId] && vendors[character.characterId].vendors.data
+      ? vendors[character.characterId].vendors.data![vendorHash]
       : undefined;
   }
 
@@ -398,9 +404,9 @@ class Progress extends React.Component<Props, State> {
     const { defs } = this.props;
     const { profileInfo } = this.state.progress!;
 
-    const allMilestones: DestinyMilestone[] = Object.values(
-      profileInfo.characterProgressions.data[character.characterId].milestones
-    );
+    const allMilestones: DestinyMilestone[] = profileInfo.characterProgressions.data
+      ? Object.values(profileInfo.characterProgressions.data[character.characterId].milestones)
+      : [];
 
     const filteredMilestones = allMilestones.filter((milestone) => {
       return (
@@ -454,9 +460,9 @@ class Progress extends React.Component<Props, State> {
   private factionsForCharacter(character: DestinyCharacterComponent): DestinyFactionProgression[] {
     const { profileInfo } = this.state.progress!;
 
-    const allFactions: DestinyFactionProgression[] = Object.values(
-      profileInfo.characterProgressions.data[character.characterId].factions
-    );
+    const allFactions: DestinyFactionProgression[] = profileInfo.characterProgressions.data
+      ? Object.values(profileInfo.characterProgressions.data[character.characterId].factions)
+      : [];
     return _.sortBy(allFactions, (f) => {
       const order = factionOrder.indexOf(f.factionHash);
       return (order >= 0 ? order : 999) + (f.factionVendorIndex === -1 ? 1000 : 0);
@@ -544,16 +550,19 @@ class Progress extends React.Component<Props, State> {
   ): DestinyObjectiveProgress[] {
     const { profileInfo } = this.state.progress!;
 
-    const objectives = item.itemInstanceId
-      ? profileInfo.itemComponents.objectives.data[item.itemInstanceId]
-      : undefined;
+    const objectives =
+      item.itemInstanceId && profileInfo.itemComponents.objectives.data
+        ? profileInfo.itemComponents.objectives.data[item.itemInstanceId]
+        : undefined;
     if (objectives) {
       return objectives.objectives;
     }
     return (
-      profileInfo.characterProgressions.data[characterId].uninstancedItemObjectives[
-        item.itemHash
-      ] || []
+      (profileInfo.characterProgressions.data &&
+        profileInfo.characterProgressions.data[characterId].uninstancedItemObjectives[
+          item.itemHash
+        ]) ||
+      []
     );
   }
 }

--- a/src/app/progress/progress.service.ts
+++ b/src/app/progress/progress.service.ts
@@ -86,7 +86,9 @@ export function reloadProgress() {
 async function loadProgress(account: DestinyAccount): Promise<ProgressProfile | undefined> {
   try {
     const profileInfo = await getProgression(account);
-    const characterIds = Object.keys(profileInfo.characters.data);
+    const characterIds = profileInfo.characters.data
+      ? Object.keys(profileInfo.characters.data)
+      : [];
     let vendors: DestinyVendorsResponse[] = [];
     try {
       vendors = await Promise.all(
@@ -100,13 +102,12 @@ async function loadProgress(account: DestinyAccount): Promise<ProgressProfile | 
       profileInfo,
       vendors: _.zipObject(characterIds, vendors) as ProgressProfile['vendors'],
       get lastPlayedDate() {
-        return Object.values((this.profileInfo as DestinyProfileResponse).characters.data).reduce(
-          (memo, character: DestinyCharacterComponent) => {
-            const d1 = new Date(character.dateLastPlayed);
-            return memo ? (d1 >= memo ? d1 : memo) : d1;
-          },
-          new Date(0)
-        );
+        return Object.values(
+          (this.profileInfo as DestinyProfileResponse).characters.data || {}
+        ).reduce((memo, character: DestinyCharacterComponent) => {
+          const d1 = new Date(character.dateLastPlayed);
+          return memo ? (d1 >= memo ? d1 : memo) : d1;
+        }, new Date(0));
       }
     };
   } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,10 +2030,10 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bungie-api-ts@^1.6.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-1.16.0.tgz#db17660064fa48b40f46155174cc47feb34794f2"
-  integrity sha512-Ob078kVrTqGRaokaS0CPZyuYZDdEN/ffL/8E7yxZ/rrc4qmAIPTZz+zkJEMbvdBeEM5+KgS4Ao0ZVeIBjDprug==
+bungie-api-ts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-2.0.0.tgz#3c34a5d1438ac2ffee63a3cb62542ed093015977"
+  integrity sha512-vGXVmIwbNYHIRkz1MYcZWlV4dORg/W3/oGoEi35fqvxfCRKpxUAFvdPK38wkLxcLP+Mug4tAV+SK3QfGKP28Qw==
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
I plan on releasing a version of `bungie-api-ts` that redefines these `data` fields to be nullable since the API behaves that way. This fixes all the stuff that would be broken by that.