### PR TITLE
Selector can return a null set of accounts.

### DIFF
--- a/src/app/accounts/platform.service.ts
+++ b/src/app/accounts/platform.service.ts
@@ -21,7 +21,7 @@ export async function getPlatforms(): Promise<readonly DestinyAccount[]> {
 
   const state = store.getState();
   let accounts = accountsSelector(state);
-  if (accounts.length && state.accounts.loaded) {
+  if (accounts && accounts.length && state.accounts.loaded) {
     return accounts;
   }
 


### PR DESCRIPTION
This addresses issue #3758 