### PR TITLE
Find wish list items and dupes of them.

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -282,6 +282,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
       hasLight: ['light', 'haslight', 'haspower'],
       complete: ['goldborder', 'yellowborder', 'complete'],
       curated: ['curated', 'wishlist'],
+      wishlistdupe: ['wishlistdupe'],
       masterwork: ['masterwork', 'masterworks'],
       hasShader: ['shaded', 'hasshader'],
       hasMod: ['modded', 'hasmod'],
@@ -1471,6 +1472,15 @@ function searchFilters(
       },
       curated(item: D2Item) {
         return Boolean(inventoryCuratedRolls[item.id]);
+      },
+      wishlistdupe(item: D2Item) {
+        if (!this.dupe(item) || !_duplicates) {
+          return false;
+        }
+
+        const itemDupes = _duplicates[item.hash];
+
+        return itemDupes.some(this.curated);
       },
       ammoType(item: D2Item, predicate: string) {
         return (


### PR DESCRIPTION
This adds another search filter, `is:wishlistdupe`. It adds another piece of functionality that's a mouthful, but hopefully makes sense when you see what it does. It's like `is:dupe`, except we restrict the set of results a bit - we only show items where you've got duplicates if some of those duplicates are also in your wish list.

This fulfills an itch I've had - I know I've got wish list gear and forgettable dupes, but how can I easily find infusion fodder/dupes to scrap?

![Screenshot_2019-04-19 DIM](https://user-images.githubusercontent.com/606888/56433661-a5a6b980-629f-11e9-8eb6-dc8dbf40a158.png)
