### PR TITLE
Exclude D1 manifests from service worker precache

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -424,13 +424,13 @@ module.exports = (env) => {
       // Generate a service worker
       new InjectManifest({
         maximumFileSizeToCacheInBytes: 5000000,
-        include: [/\.(html|js|css|woff2|json|wasm)/, /static\/.*\.(png|jpg|svg)/],
+        include: [/\.(html|js|css|woff2|json|wasm)$/, /static\/.*\.(png|jpg|svg)$/],
         exclude: [
-          /fontawesome-webfont.*\.svg/,
           /version\.json/,
           /extension-dist/,
           /\.map$/,
-          /^manifest.*\.js(?:on)?$/
+          // Ignore both the webapp manifest and the d1-manifest files
+          /data\/manifest/
         ],
         swSrc: './src/service-worker.js',
         swDest: 'service-worker.js',


### PR DESCRIPTION
When I added the D1 manifest JSON files, the service worker precache script automatically picked them up and started caching them. This can be a *lot* of data, and it's totally unnecessary. In this change I exclude all of those files from the service worker.