### PR TITLE
Show perk stat modifiers in perk tooltip

### DIFF
--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -54,7 +54,16 @@
 }
 
 .plug-stats {
+  display: grid;
+  grid-template: auto / auto 1fr;
+  grid-column-gap: 4px;
   margin-top: 4px;
+  > div {
+    &:nth-child(2n + 1) {
+      font-weight: bold;
+      justify-self: end;
+    }
+  }
   img {
     filter: invert(100%);
     vertical-align: bottom;

--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -53,6 +53,15 @@
   border-radius: 4px;
 }
 
+.plug-stats {
+  margin-top: 4px;
+  img {
+    filter: invert(100%);
+    vertical-align: bottom;
+    margin-right: 2px;
+  }
+}
+
 .category-name {
   display: inline-block;
 }

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -5,6 +5,8 @@ import Objective from '../progress/Objective';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { D2Item, DimPlug } from '../inventory/item-types';
 import BestRatedIcon from './BestRatedIcon';
+import { DestinyItemInvestmentStatDefinition } from 'bungie-api-ts/destiny2';
+import BungieImage from 'app/dim-ui/BungieImage';
 
 // TODO: Connect this to redux
 export default function PlugTooltip({
@@ -45,6 +47,13 @@ export default function PlugTooltip({
           </div>
         ))
       )}
+      {defs && plug.plugItem.investmentStats.length > 0 && (
+        <div className="plug-stats">
+          {plug.plugItem.investmentStats.map((stat) => (
+            <Stat key={stat.statTypeHash} stat={stat} defs={defs} />
+          ))}
+        </div>
+      )}
       {defs && plug.plugObjectives.length > 0 && (
         <div className="plug-objectives">
           {plug.plugObjectives.map((objective) => (
@@ -59,5 +68,31 @@ export default function PlugTooltip({
         </div>
       )}
     </>
+  );
+}
+
+function Stat({
+  stat,
+  defs
+}: {
+  stat: DestinyItemInvestmentStatDefinition;
+  defs: D2ManifestDefinitions;
+}) {
+  if (stat.value === 0) {
+    return null;
+  }
+  const statDef = defs.Stat.get(stat.statTypeHash);
+  if (!statDef || !statDef.displayProperties.name) {
+    return null;
+  }
+  return (
+    <div>
+      {stat.value < 0 ? '' : '+'}
+      {stat.value}{' '}
+      {statDef.displayProperties.hasIcon && (
+        <BungieImage height={16} width={16} src={statDef.displayProperties.icon} />
+      )}
+      {statDef.displayProperties.name}
+    </div>
   );
 }

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -86,13 +86,17 @@ function Stat({
     return null;
   }
   return (
-    <div>
-      {stat.value < 0 ? '' : '+'}
-      {stat.value}{' '}
-      {statDef.displayProperties.hasIcon && (
-        <BungieImage height={16} width={16} src={statDef.displayProperties.icon} />
-      )}
-      {statDef.displayProperties.name}
-    </div>
+    <>
+      <div>
+        {stat.value < 0 ? '' : '+'}
+        {stat.value}
+      </div>
+      <div>
+        {statDef.displayProperties.hasIcon && (
+          <BungieImage height={16} width={16} src={statDef.displayProperties.icon} />
+        )}
+        {statDef.displayProperties.name}
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
This adds perk values to the perk tooltip. Should take the guesswork out of what things like "Slightly increases range" means. Note that these are the "investment stats" so they don't necessarily map exactly to what's shown on the screen - they're more for relative comparison.

<img width="199" alt="Screen Shot 2019-04-29 at 10 47 26 PM" src="https://user-images.githubusercontent.com/313208/56943062-aaa30e80-6ad2-11e9-95e5-4deb7776464e.png">
