### PR TITLE
Remove unneeded curly brace in Item Reviews settings UI

### DIFF
--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -96,7 +96,7 @@ class ItemReviews extends React.Component<Props, State> {
     }
 
     if (!canReview) {
-      return <div>{!canReview && <ItemReviewSettings item={item} />}}</div>;
+      return <div>{!canReview && <ItemReviewSettings item={item} />}</div>;
     }
 
     const canCreateReview = canReview && item.owner;


### PR DESCRIPTION
This PR removes an extra closing curly brace `}` that is being displayed in the Item Reviews settings pane UI.

![dim-itemreviews-curlybrace](https://user-images.githubusercontent.com/17512262/57963376-77d49380-7977-11e9-93aa-b5f8123c3f1f.png)