### PR TITLE
Add a note icon to the item tile

### DIFF
--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DimItem } from './item-types';
-import { TagValue, getTag } from './dim-item-info';
+import { TagValue, getTag, getNotes } from './dim-item-info';
 import { RootState } from '../store/reducers';
 import { connect } from 'react-redux';
 import InventoryItem from './InventoryItem';
@@ -21,6 +21,7 @@ interface ProvidedProps {
 interface StoreProps {
   isNew: boolean;
   tag?: TagValue;
+  notes?: boolean;
   rating?: number;
   hideRating?: boolean;
   searchHidden?: boolean;
@@ -39,6 +40,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   return {
     isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,
     tag: getTag(item, state.inventory.itemInfos),
+    notes: getNotes(item, state.inventory.itemInfos) ? true : false,
     rating: dtrRating ? dtrRating.overallScore : undefined,
     hideRating: !showRating,
     searchHidden: props.allowFilter && !searchFilterSelector(state)(item),
@@ -59,6 +61,7 @@ class ConnectedInventoryItem extends React.Component<Props> {
       item,
       isNew,
       tag,
+      notes,
       rating,
       hideRating,
       onClick,
@@ -73,6 +76,7 @@ class ConnectedInventoryItem extends React.Component<Props> {
         item={item}
         isNew={isNew}
         tag={tag}
+        notes={notes}
         rating={rating}
         hideRating={hideRating}
         onClick={onClick}

--- a/src/app/inventory/InventoryItem.scss
+++ b/src/app/inventory/InventoryItem.scss
@@ -13,6 +13,7 @@
   0% {
     transform: translate(calc(-1.5 * var(--item-size)), calc(-1.5 * var(--item-size))) scale(2);
   }
+
   100% {
     transform: translate(calc(1.5 * var(--item-size)), calc(1.5 * var(--item-size))) scale(2);
   }
@@ -20,6 +21,7 @@
 
 .new-item {
   display: none;
+
   .show-new-items & {
     display: block;
     width: calc(var(--item-size) * 0.08);
@@ -42,17 +44,21 @@
   width: var(--item-size);
   height: calc(#{$full-height-badge});
   margin: 0 var(--item-margin) var(--item-margin) 0;
+
   &:hover {
     outline: 1px solid #ddd;
+
     @include phone-portrait {
       outline: none;
     }
   }
 }
+
 .no-badge {
   .item-drag-container {
     height: var(--item-size);
   }
+
   .item {
     height: var(--item-size);
   }
@@ -74,6 +80,7 @@
     border: $item-border-width solid #ddd;
     background-size: cover;
     background-repeat: no-repeat;
+
     &:focus {
       outline: none;
     }
@@ -100,12 +107,15 @@
     .item-img {
       border-color: #eade8b;
     }
+
     .item-stat {
       background-color: #eade8b;
     }
+
     &::after {
       display: none;
     }
+
     .overlay {
       background-size: calc((var(--item-size) - #{2 * $item-border-width}) * (96 / 90))
         calc((var(--item-size) - #{2 * $item-border-width}) * (96 / 90));
@@ -124,6 +134,7 @@
     .item-img {
       border-color: $gold;
     }
+
     .item-stat {
       background-color: $gold;
     }
@@ -159,12 +170,14 @@
 
   .item-review {
     display: none;
+
     .show-reviews & {
       display: flex;
     }
 
     text-align: left;
     align-items: center;
+
     .app-icon {
       font-size: 1.3em;
       padding-right: 1px;
@@ -173,11 +186,13 @@
 
   .item-quality {
     display: none;
+
     .itemQuality & {
       display: block;
       padding: 0 2px;
       margin-left: -2px;
     }
+
     .app-icon {
       filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.8));
     }
@@ -197,7 +212,7 @@
     position: static;
     width: calc(var(--item-size) / 5);
     height: calc(var(--item-size) / 5);
-    margin-right: 2px;
+    margin-right: 1px;
     color: #29f36a; // #5eff92;
     filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.8));
   }
@@ -206,10 +221,12 @@
     width: calc(var(--item-size) / 6);
     height: calc(var(--item-size) / 6);
     transform: translateY(0.5px);
+
     &.void {
       filter: brightness(200%);
       background-color: transparent !important;
     }
+
     &.arc {
       filter: brightness(65%) saturate(200%);
     }
@@ -224,6 +241,7 @@
     opacity: 1;
     top: $item-border-width + 2px;
     height: calc(var(--item-size) / 9);
+
     .item-xp-bar-amount {
       height: 100%;
       background-color: $xp;

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -6,7 +6,7 @@ import { TagValue, itemTags } from './dim-item-info';
 import getBadgeInfo from './get-badge-info';
 import BungieImage, { bungieBackgroundStyle } from '../dim-ui/BungieImage';
 import { getColor, percent } from '../shell/filters';
-import { AppIcon, lockIcon, thumbsUpIcon } from '../shell/icons';
+import { AppIcon, lockIcon, thumbsUpIcon, stickyNoteIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { InventoryCuratedRoll } from '../curated-rolls/curatedRollService';
 import RatingIcon from './RatingIcon';
@@ -24,6 +24,8 @@ interface Props {
   isNew?: boolean;
   /** User defined tag */
   tag?: TagValue;
+  /**  */
+  notes?: boolean;
   /** Rating value */
   rating?: number;
   hideRating?: boolean;
@@ -43,6 +45,7 @@ export default class InventoryItem extends React.Component<Props> {
       item,
       isNew,
       tag,
+      notes,
       rating,
       searchHidden,
       hideRating,
@@ -99,11 +102,12 @@ export default class InventoryItem extends React.Component<Props> {
           </div>
         )}
         {item.masterwork && <div className="overlay" />}
-        {(tag || item.locked || treatAsCurated) && (
+        {(tag || item.locked || treatAsCurated || notes) && (
           <div className="icons">
             {item.locked && <AppIcon className="item-tag" icon={lockIcon} />}
             {tag && tagIcons[tag] && <AppIcon className="item-tag" icon={tagIcons[tag]!} />}
             {treatAsCurated && <AppIcon className="item-tag" icon={thumbsUpIcon} />}
+            {notes && <AppIcon className="item-tag" icon={stickyNoteIcon} />}
           </div>
         )}
         {isNew && <div className="new-item" />}

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -46,7 +46,8 @@ import {
   faArrowRight,
   faHeart,
   faStarHalfAlt,
-  faGlobe
+  faGlobe,
+  faStickyNote
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
@@ -114,5 +115,6 @@ export {
   faUpload as revisionsIcon,
   faUpload as uploadIcon,
   faHeart as heartIcon,
-  faGlobe as globeIcon
+  faGlobe as globeIcon,
+  faStickyNote as stickyNoteIcon
 };


### PR DESCRIPTION
With us always telling our users to use notes more, we should make clear if a item have one or not.

On DIM Desktop, default size
![image](https://user-images.githubusercontent.com/32077894/57983292-6f876180-7a26-11e9-870b-3dc506ff2085.png)

On DIM "Mobile", 5 columns (smallest size we have)
![image](https://user-images.githubusercontent.com/32077894/57983313-99408880-7a26-11e9-9b65-99b459f24fa5.png)
