### PR TITLE
Tweaks to item popup

### DIFF
--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -30,7 +30,7 @@ export default function ItemDetails({
     : undefined;
 
   return (
-    <div>
+    <div className="item-details-body">
       {item.taggable && <NotesForm item={item} />}
 
       {showDescription && <div className="item-description">{item.description}</div>}

--- a/src/app/item-popup/ItemPopupContainer.scss
+++ b/src/app/item-popup/ItemPopupContainer.scss
@@ -116,7 +116,7 @@
   justify-content: space-around;
 }
 .move-popup-tab {
-  opacity: 0.8;
+  color: hsl(0, 0%, 80%);
   padding: 5px 0 3px;
   cursor: pointer;
   width: 100%;
@@ -127,7 +127,8 @@
     border-bottom: 2px solid $orange;
   }
   &:hover {
-    opacity: 1;
+    color: white;
+    background-color: #3f3f3f;
   }
 }
 
@@ -139,6 +140,10 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
+}
+
+.item-details-body {
+  overflow: hidden;
 }
 
 .item-details {
@@ -159,6 +164,7 @@
 .item-description {
   margin: 5px 10px;
   white-space: pre-wrap;
+  font-style: italic;
 }
 
 .item-lore {

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -45,7 +45,7 @@ interface State {
 }
 
 const popperOptions = {
-  placement: 'top-start',
+  placement: 'right',
   eventsEnabled: false,
   modifiers: {
     preventOverflow: {

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -4,6 +4,7 @@
   width: 100%;
   display: table;
   border-spacing: 0 4px;
+  margin: 5px 0 10px 0;
 
   .stat-box-row {
     overflow: hidden;
@@ -15,7 +16,7 @@
   }
   .stat-box-cell {
     display: table-cell;
-    line-height: 14px;
+    line-height: 12px;
     white-space: nowrap;
     vertical-align: middle;
   }
@@ -41,8 +42,8 @@
   }
   .stat-box-outer {
     display: table-cell;
-    height: 14px;
-    line-height: 14px;
+    height: 12px;
+    line-height: 12px;
     background-color: #333;
     width: 100%;
   }
@@ -58,7 +59,7 @@
     display: block;
     height: 100%;
     float: left;
-    line-height: 14px;
+    line-height: 12px;
     background-color: #333;
     background-color: white;
     color: black;


### PR DESCRIPTION
I'm still working on a refresh of the item popup. Here's some more minor changes that I figured I could merge early:

1. Fixed the thing where the popup would slightly resize after opening.
2. The popup now prefers to open on the side, which tends to center it on the screen better.
3. Italicized the description text like the popup in game.
4. Added hover highlighting to the tabs.
5. Shrunk the stats by 2px so they take up less space (we print a lot of stats these days).

<img width="393" alt="Screen Shot 2019-05-19 at 8 02 05 PM" src="https://user-images.githubusercontent.com/313208/57998453-76de5780-7a86-11e9-8ea8-52f655814679.png">
