### PR TITLE
Loadout fixes again

### DIFF
--- a/src/app/d2-loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/d2-loadout-builder/LoadoutBuilder.tsx
@@ -33,8 +33,6 @@ import LockArmorAndPerks from './LockArmorAndPerks';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
 import { DimItem } from 'app/inventory/item-types';
 import { Subscriptions } from 'app/rx-utils';
-import { refresh$ } from 'app/shell/refresh';
-import { queueAction } from 'app/inventory/action-queue';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -149,9 +147,10 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
           const selectedStore = stores.find((s) => s.id === this.state.selectedStore!.id)!;
           this.setState({ selectedStore });
         }
-      }),
+      })
 
-      refresh$.subscribe(() => queueAction(() => D2StoresService.reloadStores()))
+      // Disable refreshing stores, since it resets the scroll offset
+      // refresh$.subscribe(() => queueAction(() => D2StoresService.reloadStores()))
     );
   }
 

--- a/src/app/d2-loadout-builder/PerksForBucket.tsx
+++ b/src/app/d2-loadout-builder/PerksForBucket.tsx
@@ -48,6 +48,9 @@ export default function PerksForBucket({
             selected={Boolean(
               locked && locked.some((p) => p.type === 'burn' && p.burn.dmg === burn.dmg)
             )}
+            unselectable={Boolean(
+              locked && locked.some((p) => p.type === 'burn' && p.burn.dmg !== burn.dmg)
+            )}
             onLockedPerk={onPerkSelected}
           />
         ))}

--- a/src/app/d2-loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/d2-loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -87,26 +87,34 @@ export function SelectableBurn({
   burn,
   bucket,
   selected,
+  unselectable,
   onLockedPerk
 }: {
   burn: BurnItem;
   bucket: InventoryBucket;
   selected: boolean;
+  unselectable: boolean;
   onLockedPerk(burn: LockedItemType): void;
 }) {
-  const handleClick = () => {
+  const handleClick = (e) => {
+    e.preventDefault();
+    if (unselectable) {
+      return;
+    }
     onLockedPerk({ type: 'burn', burn, bucket });
   };
 
   return (
-    <div className={styles.perk} onClick={handleClick} role="button" tabIndex={0}>
-      <img
-        className={classNames(`perk-image ${burn.dmg}`, {
-          [styles.lockedPerk]: selected
-        })}
-        alt=""
-        src={burn.displayProperties.icon}
-      />
+    <div
+      className={classNames(styles.perk, {
+        [styles.lockedPerk]: selected,
+        [styles.unselectable]: unselectable
+      })}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+    >
+      <img className={`perk-image ${burn.dmg}`} alt="" src={burn.displayProperties.icon} />
       <div className={styles.perkInfo}>
         <div className={styles.perkTitle}>{burn.displayProperties.name}</div>
       </div>


### PR DESCRIPTION
A couple more:

1. Correctly dim out burns when you've already selected one.
2. Disable refresh since it causes a scroll-to-top.