### PR TITLE
Allow Escape key to close item popup containers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Added Escape hotkey to close open item details dialog.
+
 # 5.29.0 (2019-05-19)
 
 * Items with notes now have a note icon on them.

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -13,6 +13,8 @@ import { setSetting } from '../settings/actions';
 import ItemPopupBody, { ItemPopupTab } from './ItemPopupBody';
 import './ItemPopupContainer.scss';
 import ItemTagHotkeys from './ItemTagHotkeys';
+import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
+import { t } from 'app/i18next-t';
 
 interface ProvidedProps {
   boundarySelector?: string;
@@ -155,6 +157,17 @@ class ItemPopupContainer extends React.Component<Props, State> {
           </ItemTagHotkeys>
         </ClickOutside>
         <div className={`arrow is-${item.tier}`} />
+        <GlobalHotkeys
+          hotkeys={[
+            {
+              combo: 'esc',
+              description: t('Hotkey.ClearSearch'),
+              callback: () => {
+                this.onClose();
+              }
+            }
+          ]}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Addresses #3812 

This is currently re-using the i18n text for `ClearSearch`. I originally wanted to add a new entry in `dim.json` named something along the lines of `CloseItemPopup` but I wasn't sure how the i18n process works in regards to getting that new string translated into all the other language files.