### PR TITLE
Loadout Optimizer: Consolidate stats

### DIFF
--- a/src/app/d2-loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/d2-loadout-builder/LoadoutBuilder.tsx
@@ -130,7 +130,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       },
       minimumPower: 0,
       query: '',
-      statOrder: ['Resilience', 'Recovery', 'Mobility']
+      statOrder: ['Mobility', 'Resilience', 'Recovery']
     };
   }
 

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSet.tsx
@@ -46,7 +46,7 @@ function GeneratedSet({
     dimLoadoutService.editLoadout(loadout, { showClass: false });
   };
 
-  const numSets = getNumValidSets(set);
+  const numSets = _.sumBy(set.sets, (setSlice) => getNumValidSets(setSlice.armor));
   if (!numSets) {
     console.error('No valid sets!');
     return null;
@@ -92,11 +92,11 @@ function GeneratedSet({
           <GeneratedSetItem
             key={item.index}
             item={item}
-            itemOptions={set.armor[index]}
+            itemOptions={set.sets.flatMap((subSet) => subSet.armor[index])}
             locked={lockedMap[item.bucket.hash]}
             addLockedItem={addLockedItem}
             removeLockedItem={removeLockedItem}
-            statValues={set.statChoices[index]}
+            statValues={set.firstValidSetStatChoices[index]}
           />
         ))}
       </div>

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -1,4 +1,3 @@
-import copy from 'fast-copy';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import React from 'react';
@@ -52,14 +51,10 @@ export default function GeneratedSetButtons({
 function createLoadout(classType: DimStore['class'], set: ArmorSet): Loadout {
   const loadout = newLoadout(
     t('Loadouts.Generated', { ...set.stats, tier: _.sum(Object.values(set.stats)) }),
-    copy({
-      helmet: [set.armor[0][0]],
-      gauntlets: [set.armor[1][0]],
-      chest: [set.armor[2][0]],
-      leg: [set.armor[3][0]],
-      classitem: [set.armor[4][0]],
-      ghost: [set.armor[5][0]]
-    })
+    _.zipObject(
+      ['helmet', 'gauntlets', 'chest', 'leg', 'classitem', 'ghost'],
+      set.firstValidSet.map((i) => [i])
+    )
   );
   loadout.classType = LoadoutClass[classType];
 

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.m.scss
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.m.scss
@@ -8,7 +8,7 @@
       margin-right: 12px;
     }
     p {
-      margin: 0 12px;
+      margin: 0 12px 4px 12px;
     }
   }
 }
@@ -25,6 +25,11 @@
 
 .key {
   margin-right: 1em;
+  white-space: nowrap;
+  @include phone-portrait {
+    margin-top: 4px;
+    display: inline-block;
+  }
   &::before {
     content: '';
     display: inline-block;

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSets.tsx
@@ -141,7 +141,10 @@ export default class GeneratedSets extends React.Component<Props, State> {
 
   private setRowHeight = (element: HTMLDivElement | null) => {
     if (element && !this.state.rowHeight) {
-      this.setState({ rowHeight: element.clientHeight, rowWidth: element.clientWidth });
+      setTimeout(
+        () => this.setState({ rowHeight: element.clientHeight, rowWidth: element.clientWidth }),
+        0
+      );
     }
   };
 

--- a/src/app/d2-loadout-builder/generated-sets/utils.ts
+++ b/src/app/d2-loadout-builder/generated-sets/utils.ts
@@ -130,8 +130,7 @@ function getBestSets(
     }
     // Sort based on what sets have the most matched perks
     sortedSets = _.sortBy(sortedSets, (set) => {
-      return -_.sumBy(set.armor, (item) => {
-        const firstItem = item[0];
+      return -_.sumBy(set.firstValidSet, (firstItem) => {
         if (!firstItem || !firstItem.isDestiny2() || !firstItem.sockets) {
           return 0;
         }
@@ -207,11 +206,11 @@ export function lockedItemsEqual(first: LockedItemType, second: LockedItemType) 
 /**
  * Calculate the number of valid permutations of a stat mix, without enumerating them.
  */
-export function getNumValidSets(set: ArmorSet) {
-  const exotics = new Array(set.armor.length).fill(0);
-  const nonExotics = new Array(set.armor.length).fill(0);
+export function getNumValidSets(armors: readonly DimItem[][]) {
+  const exotics = new Array(armors.length).fill(0);
+  const nonExotics = new Array(armors.length).fill(0);
   let index = 0;
-  for (const armor of set.armor) {
+  for (const armor of armors) {
     for (const item of armor) {
       if (item.equippingLabel) {
         exotics[index]++;
@@ -225,7 +224,7 @@ export function getNumValidSets(set: ArmorSet) {
   // Sets that are all legendary
   let total = nonExotics.reduce((memo, num) => num * memo, 1);
   // Sets that include one exotic
-  for (index = 0; index < set.armor.length; index++) {
+  for (index = 0; index < armors.length; index++) {
     total += exotics[index]
       ? nonExotics.reduce((memo, num, idx) => (idx === index ? exotics[idx] : num) * memo, 1)
       : 0;

--- a/src/app/d2-loadout-builder/types.ts
+++ b/src/app/d2-loadout-builder/types.ts
@@ -48,16 +48,25 @@ export type LockedMap = Readonly<{ [bucketHash: number]: readonly LockedItemType
  * An individual "stat mix" of loadouts where each slot has a list of items with the same stat options.
  */
 export interface ArmorSet {
-  readonly id: number;
-  /** For each armor type (see LockableBuckets), this is the list of items that could interchangeably be put into this loadout. */
-  readonly armor: readonly DimItem[][];
   /** The overall stats for the loadout as a whole. */
   readonly stats: Readonly<{ [statType in StatTypes]: number }>;
-  /** The chosen stats for each armor type, as a list in the order Mobility/Resiliency/Recovery. */
-  readonly statChoices: readonly number[][];
+
+  /**
+   * Potential stat mixes that can achieve the overall stats.
+   * Each mix is a particular set of stat choices (and options for each piece within that)
+   * to get to the overall stats.
+   */
+  readonly sets: {
+    /** For each armor type (see LockableBuckets), this is the list of items that could interchangeably be put into this loadout. */
+    readonly armor: readonly DimItem[][];
+    /** The chosen stats for each armor type, as a list in the order Mobility/Resiliency/Recovery. */
+    readonly statChoices: readonly number[][];
+  }[];
 
   /** The first (highest-power) valid set from this stat mix. */
   readonly firstValidSet: readonly DimItem[];
+  readonly firstValidSetStatChoices: readonly number[][];
+
   /** The maximum power loadout possible in this stat mix. */
   readonly maxPower: number;
 }

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -208,18 +208,22 @@ function convertToRatingMap(ratings: DtrRating[]) {
 export function saveReviewsToIndexedDB() {
   return observeStore(
     (state) => state.reviews,
-    (currentState, nextState) => {
-      if (nextState.loadedFromIDB) {
-        const cutoff = new Date(Date.now() - ITEM_RATING_EXPIRATION);
+    _.throttle(
+      (currentState: ReviewsState, nextState: ReviewsState) => {
+        if (nextState.loadedFromIDB) {
+          const cutoff = new Date(Date.now() - ITEM_RATING_EXPIRATION);
 
-        if (!_.isEmpty(nextState.reviews) && nextState.reviews !== currentState.reviews) {
-          set('reviews', _.pickBy(nextState.reviews, (r) => r.lastUpdated > cutoff));
+          if (!_.isEmpty(nextState.reviews) && nextState.reviews !== currentState.reviews) {
+            set('reviews', _.pickBy(nextState.reviews, (r) => r.lastUpdated > cutoff));
+          }
+          if (!_.isEmpty(nextState.ratings) && nextState.ratings !== currentState.ratings) {
+            set('ratings-v2', _.pickBy(nextState.ratings, (r) => r.lastUpdated > cutoff));
+          }
         }
-        if (!_.isEmpty(nextState.ratings) && nextState.ratings !== currentState.ratings) {
-          set('ratings-v2', _.pickBy(nextState.ratings, (r) => r.lastUpdated > cutoff));
-        }
-      }
-    }
+      },
+      1000,
+      { leading: true, trailing: true }
+    )
   );
 }
 

--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -2,60 +2,68 @@ import { RootState } from '../store/reducers';
 import { DimStore } from '../inventory/store-types';
 import _ from 'lodash';
 import { DestinyCharacterComponent } from 'bungie-api-ts/destiny2';
+import { createSelector } from 'reselect';
 
-export const characterSortSelector = (state: RootState) => {
-  const order = state.settings.characterOrder;
+const characterOrderSelector = (state: RootState) => state.settings.characterOrder;
+const customCharacterSortSelector = (state: RootState) => state.settings.customCharacterSort;
 
-  switch (order) {
-    case 'mostRecent':
-      return (stores: DimStore[]) => _.sortBy(stores, (store) => store.lastPlayed).reverse();
+export const characterSortSelector = createSelector(
+  characterOrderSelector,
+  customCharacterSortSelector,
+  (order, customCharacterSort) => {
+    switch (order) {
+      case 'mostRecent':
+        return (stores: DimStore[]) => _.sortBy(stores, (store) => store.lastPlayed).reverse();
 
-    case 'mostRecentReverse':
-      return (stores: DimStore[]) =>
-        _.sortBy(stores, (store) => {
-          if (store.isVault) {
-            return Infinity;
-          } else {
-            return store.lastPlayed;
-          }
-        });
+      case 'mostRecentReverse':
+        return (stores: DimStore[]) =>
+          _.sortBy(stores, (store) => {
+            if (store.isVault) {
+              return Infinity;
+            } else {
+              return store.lastPlayed;
+            }
+          });
 
-    case 'custom': {
-      const customSortOrder = state.settings.customCharacterSort;
-      return (stores: DimStore[]) =>
-        _.sortBy(stores, (s) => (s.isVault ? 999 : customSortOrder.indexOf(s.id)));
+      case 'custom': {
+        const customSortOrder = customCharacterSort;
+        return (stores: DimStore[]) =>
+          _.sortBy(stores, (s) => (s.isVault ? 999 : customSortOrder.indexOf(s.id)));
+      }
+
+      default:
+      case 'fixed': // "Age"
+        // https://github.com/Bungie-net/api/issues/614
+        return (stores: DimStore[]) => _.sortBy(stores, (s) => s.id);
     }
-
-    default:
-    case 'fixed': // "Age"
-      // https://github.com/Bungie-net/api/issues/614
-      return (stores: DimStore[]) => _.sortBy(stores, (s) => s.id);
   }
-};
+);
 
-export const characterComponentSortSelector = (state: RootState) => {
-  const order = state.settings.characterOrder;
+export const characterComponentSortSelector = createSelector(
+  characterOrderSelector,
+  customCharacterSortSelector,
+  (order, customCharacterSort) => {
+    switch (order) {
+      case 'mostRecent':
+        return (stores: DestinyCharacterComponent[]) =>
+          _.sortBy(stores, (store) => new Date(store.dateLastPlayed)).reverse();
 
-  switch (order) {
-    case 'mostRecent':
-      return (stores: DestinyCharacterComponent[]) =>
-        _.sortBy(stores, (store) => new Date(store.dateLastPlayed)).reverse();
+      case 'mostRecentReverse':
+        return (stores: DestinyCharacterComponent[]) =>
+          _.sortBy(stores, (store) => {
+            return new Date(store.dateLastPlayed);
+          });
 
-    case 'mostRecentReverse':
-      return (stores: DestinyCharacterComponent[]) =>
-        _.sortBy(stores, (store) => {
-          return new Date(store.dateLastPlayed);
-        });
+      case 'custom': {
+        const customSortOrder = customCharacterSort;
+        return (stores: DestinyCharacterComponent[]) =>
+          _.sortBy(stores, (s) => customSortOrder.indexOf(s.characterId));
+      }
 
-    case 'custom': {
-      const customSortOrder = state.settings.customCharacterSort;
-      return (stores: DestinyCharacterComponent[]) =>
-        _.sortBy(stores, (s) => customSortOrder.indexOf(s.characterId));
+      default:
+      case 'fixed': // "Age"
+        // https://github.com/Bungie-net/api/issues/614
+        return (stores: DestinyCharacterComponent[]) => _.sortBy(stores, (s) => s.characterId);
     }
-
-    default:
-    case 'fixed': // "Age"
-      // https://github.com/Bungie-net/api/issues/614
-      return (stores: DestinyCharacterComponent[]) => _.sortBy(stores, (s) => s.characterId);
   }
-};
+);


### PR DESCRIPTION
This consolidates "duplicate" stat mixes into one, so every row represents a unique combination of stats. This should reduce some of the confusion (and some of the choices!). On my main character I'm down to 65 unique mixes of stats.

I also fixed a major bug in how I memoized the stores selector, which should improve perf all across DIM, and fixed a bug where entering the loadout optimizer from another page might leave you with improperly measured rows.

Fixes #3824