### PR TITLE
Contrast tweaks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Tweaked contrast on search bar.
+
 # 5.30.0 (2019-05-26)
 
 * Brand new Loadout Optimizer with tons of improvements and fixes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 5.30.0 (2019-05-26)
 
+* Brand new Loadout Optimizer with tons of improvements and fixes.
+* Redesigned search bar.
+* Updated DIM logos.
 * Added Escape hotkey to close open item details dialog.
 
 # 5.29.0 (2019-05-19)

--- a/src/app/d2-loadout-builder/LockArmorAndPerks.m.scss
+++ b/src/app/d2-loadout-builder/LockArmorAndPerks.m.scss
@@ -10,17 +10,17 @@
 }
 
 .area {
-  border: 1px solid #999;
+  background-color: #222;
   padding: 4px;
   margin-bottom: 8px;
 
   &:global(.on-drag-enter),
   &:global(.on-drag-hover) {
-    background-color: rgba(128, 128, 128, 0.2);
+    background-color: black;
   }
 
   &:global(.on-drag-hover) {
-    border-color: white;
+    background-color: rgba(128, 128, 128, 0.2);
   }
 }
 

--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -39,13 +39,13 @@
   }
 
   .sheet-header {
-    padding: 14px 38px 8px 10px;
+    padding: 14px 10px 8px 10px;
     border-bottom: 1px solid #333;
 
     h1 {
       @include destiny-header;
       font-size: 16px;
-      margin: 0 0 8px 0;
+      margin: 0 28px 8px 0;
       display: block;
     }
   }

--- a/src/app/item-picker/ItemPicker.scss
+++ b/src/app/item-picker/ItemPicker.scss
@@ -9,6 +9,7 @@
       flex: 1;
       margin-right: 8px;
       margin-left: 0;
+      min-width: 0;
     }
   }
   .sheet-contents > div {

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -14,7 +14,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  background: #1d1c1c;
+  background: #313233;
   padding-left: 5px;
   margin-left: -3px;
   height: 32px;

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -90,6 +90,7 @@
     flex: 1;
     margin-right: 0;
     align-items: center;
+    justify-content: flex-end;
     flex-direction: row;
     height: 100%;
   }
@@ -137,15 +138,18 @@
       font-size: 18px;
       margin: 0;
 
-      @include phone-portrait {
-        font-size: 18px;
-        padding: 6px 2rem;
-      }
-
       &.active {
         color: white;
         border-left: 4px solid $orange;
         padding-left: calc(1rem - 4px);
+      }
+
+      @include phone-portrait {
+        font-size: 18px;
+        padding: 6px 2rem;
+        &.active {
+          padding-left: calc(2rem - 4px);
+        }
       }
 
       &:hover,


### PR DESCRIPTION
Some styling tweaks to the search bar and loadout optimizer drop targets.

<img width="444" alt="Screen Shot 2019-05-27 at 12 14 44 PM" src="https://user-images.githubusercontent.com/313208/58436220-0f716a80-8079-11e9-8d76-b9f40f79b57f.png">
<img width="258" alt="Screen Shot 2019-05-27 at 12 14 55 PM" src="https://user-images.githubusercontent.com/313208/58436221-0f716a80-8079-11e9-8cc7-3c88d1233be7.png">
