### PR TITLE
Fix 3-column mobile view

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Next
 
+* Fix too-large item icons on mobile view in 3 column mode.
+
 # 5.30.2 (2019-05-31)
+
+* Add St. Jude donation banner.
 
 # 5.30.1 (2019-05-27)
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -37,7 +37,7 @@
     ) !important;
   }
 
-  .app.char-cols-3 {
+  .char-cols-3 {
     --item-margin: 15px;
     // Padding at the ends of inventory column
     --inventory-column-padding: 34px;


### PR DESCRIPTION
I'd mistakenly removed the class this depended on, which removed the size correction for the three-column view. This fixes the CSS rule.