### PR TITLE
Remove pointer cursor from around search field

### DIFF
--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -266,7 +266,7 @@ class Header extends React.PureComponent<Props, State> {
             </a>
           </UISref>
           {account && (
-            <span className={classNames('link', 'search-link', { show: showSearch })}>
+            <span className={classNames('search-link', { show: showSearch })}>
               <SearchFilter onClear={this.hideSearch} ref={this.searchFilter} mobile={showSearch} />
             </span>
           )}


### PR DESCRIPTION
Search field is wrapped in a .link span, where .link is only being used to apply text color and pointer finger to clickable buttons. This means a border around search field where a functionally meaningless pointer finger cursor is applied. Commit removes the styling.