### PR TITLE
For records, the obscured string may be null.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Fixed a crash when expanding catalysts under the progress tab.
 
 # 5.31.0 (2019-06-02)
 

--- a/src/app/collections/Record.tsx
+++ b/src/app/collections/Record.tsx
@@ -75,7 +75,7 @@ export default class Record extends React.Component<Props> {
             </div>
           )}
           <h3>{name}</h3>
-          {description.length > 0 && <p>{description}</p>}
+          {description && description.length > 0 && <p>{description}</p>}
           {showObjectives && (
             <div className="record-objectives">
               {record.objectives.map((objective) => (


### PR DESCRIPTION
This addresses issue #3866 

We could key use `obscured` instead here, but there might be `obscuredString`s associated with some other  records, so I went with a null check instead.