### PR TITLE
Filter duplicate intrinsic armor perks

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -1234,7 +1234,10 @@ function buildSocket(
           plugOptions.push(plug);
           plugOptions.shift();
         } else {
-          plugOptions.push(reusablePlug);
+          // API Bugfix: Filter out intrinsic perks past the first: https://github.com/Bungie-net/api/issues/927
+          if (!reusablePlug.plugItem.itemCategoryHashes.includes(2237038328)) {
+            plugOptions.push(reusablePlug);
+          }
         }
       }
     });


### PR DESCRIPTION
The API has started returning duplicate perks: https://github.com/Bungie-net/api/issues/927

This filters them out.

Fixes #3815