### PR TITLE
Fixed expert mode wish list's ability to find single digit item categories.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Next
+* Fixed a bug with expert mode wish lists and dealing with single digit item categories.
 
 # 5.32.0 (2019-06-09)
 * Fixed a crash when expanding catalysts under the progress tab.
-* Fixed a bug with expert mode wish lists and dealing with single digit item categories.
 
 # 5.31.0 (2019-06-02)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 5.32.0 (2019-06-09)
 * Fixed a crash when expanding catalysts under the progress tab.
+* Fixed a bug with expert mode wish lists and dealing with single digit item categories.
 
 # 5.31.0 (2019-06-02)
 

--- a/src/app/curated-rolls/curated-roll-reader.ts
+++ b/src/app/curated-rolls/curated-roll-reader.ts
@@ -36,7 +36,9 @@ function toDimWishListCuratedRoll(textLine: string): CuratedRoll | null {
     return null;
   }
 
-  const matchResults = textLine.match(/dimwishlist:item=(-?\d.+)&perks=([\d|,]*).*/);
+  const matchResults = textLine.match(/dimwishlist:item=(-?\d+)&perks=([\d|,]*).*/);
+
+  console.log(matchResults);
 
   if (!matchResults || matchResults.length !== 3) {
     return null;

--- a/src/app/curated-rolls/curated-roll-reader.ts
+++ b/src/app/curated-rolls/curated-roll-reader.ts
@@ -38,8 +38,6 @@ function toDimWishListCuratedRoll(textLine: string): CuratedRoll | null {
 
   const matchResults = textLine.match(/dimwishlist:item=(-?\d+)&perks=([\d|,]*).*/);
 
-  console.log(matchResults);
-
   if (!matchResults || matchResults.length !== 3) {
     return null;
   }


### PR DESCRIPTION
Single digit item categories weren't working in wish lists. Fixed the regex.

This addresses #3889 