### PR TITLE
Really ignore weapon mods.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Fixed a bug where weapon mods were causing Banshee-44 wish list items to fail to highlight.
 
 # 5.32.0 (2019-06-09)
 * Fixed a crash when expanding catalysts under the progress tab.

--- a/src/app/curated-rolls/curatedRollService.ts
+++ b/src/app/curated-rolls/curatedRollService.ts
@@ -74,6 +74,11 @@ function isWeaponOrArmorOrGhostMod(plug: DimPlug): boolean {
     return false;
   }
 
+  // if it's a modification, ignore it
+  if (plug.plugItem.inventory && plug.plugItem.inventory.bucketTypeHash === 3313201758) {
+    return false;
+  }
+
   return plug.plugItem.itemCategoryHashes.some(
     (ich) => ich === 610365472 || ich === 4104513227 || ich === 303512563 || ich === 4176831154
   ); // weapon, then armor, then bonus (found on armor perks), then ghost mod


### PR DESCRIPTION
I initially carved out masterworks and ornaments as things that we'd ignore from wish lists. I forgot that item mods are a thing - we'll ignore them as well now (they're too finicky to key on and you can swap them around after the fact).

This addresses #3871 