### PR TITLE
Enhance CDN cacheability of DIM files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,7 +98,7 @@ module.exports = function(grunt) {
       website: {
         options: {
           src: "destinyitemmanager.com/",
-          dest: "public_html/destinyitemmanager.com"
+          dest: "destinyitemmanager.com"
         }
       }
     },

--- a/build/travis_build.sh
+++ b/build/travis_build.sh
@@ -12,6 +12,14 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   VERSION=$(node -p -e "require('./package.json').version + '.' + process.env.TRAVIS_BUILD_NUMBER")
   npx sentry-cli releases new "$VERSION" --finalize
   npx sentry-cli releases set-commits "$VERSION" --auto
+
+  if [[ -n "$CLOUDFLARE_KEY" ]]; then
+    curl -X POST "https://api.cloudflare.com/client/v4/zones/2c34c69276ed0f6eb2b9e1518fe56f74/purge_cache" \
+        -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+        -H "X-Auth-Key: $CLOUDFLARE_KEY" \
+        -H "Content-Type: application/json" \
+        --data '{"files":["https://beta.destinyitemmanager.com/index.html", "https://beta.destinyitemmanager.com/version.json", "https://beta.destinyitemmanager.com/service-worker.js", "https://beta.destinyitemmanager.com/gdrive-return.html", "https://beta.destinyitemmanager.com/return.html", "https://beta.destinyitemmanager.com/manifest-webapp-6-2018.json", "https://beta.destinyitemmanager.com/manifest-webapp-6-2018-ios.json"]}'
+  fi
 else
   # PRs should just check if the app builds
   yarn run build-beta

--- a/src/htaccess
+++ b/src/htaccess
@@ -972,8 +972,18 @@ FileETag None
     FileETag None
     <IfModule mod_headers.c>
         Header unset ETag
-        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
-        Header set Pragma "no-cache"
+        Header set Cache-Control "max-age=0, s-maxage=86400"
+        Header unset Expires
+    </IfModule>
+</FilesMatch>
+
+# Do not cache html
+
+<FilesMatch "\.html(\.(gz|br))?">
+    FileETag None
+    <IfModule mod_headers.c>
+        Header unset ETag
+        Header set Cache-Control "max-age=0, s-maxage=86400"
         Header unset Expires
     </IfModule>
 </FilesMatch>
@@ -984,7 +994,7 @@ FileETag None
     FileETag None
     <IfModule mod_headers.c>
         Header unset ETag
-        Header set Cache-Control "max-age=900"
+        Header set Cache-Control "max-age=900, s-maxage=86400"
         Header unset Expires
     </IfModule>
 </FilesMatch>
@@ -995,7 +1005,7 @@ FileETag None
     FileETag None
     <IfModule mod_headers.c>
         Header unset ETag
-        Header set Cache-Control "max-age=900"
+        Header set Cache-Control "max-age=900, s-maxage=86400"
         Header set Vary "User-Agent"
         Header unset Expires
     </IfModule>


### PR DESCRIPTION
We had a situation recently where we were serving too much data (CloudFlare is supposed to cache it!). This came from a few things:

1. We had a bug (that I thought I'd fixed a long time ago) where the service worker's precache manifest included all the D1 manifest JSON files. That's a ton of storage nobody needs. I fixed that now.
2. Turns out CloudFlare [*doesn't* always respect cache control headers](https://support.cloudflare.com/hc/en-us/articles/202775670-How-Do-I-Tell-Cloudflare-What-to-Cache-). Specifically, it only caches images, JavaScript, and CSS by default. I've switched on a page rule that makes it cache *everything* according to the cache headers we set.
3. Our HTML, service-worker.js, and version.json files shouldn't be cached because they could change when we deploy. This PR fixes that by setting a different cache expiration (`s-maxage`) for our CDN than for browsers (which only look at `max-age`), and then scripting a call to the CloudFlare API on deployments that forcefully purges the edge cache after deployments.

After this, we should see the traffic back to our origin drop to very, very low levels.