### PR TITLE
wrapping change for milestones

### DIFF
--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -78,7 +78,7 @@
   .quest-modifiers {
     margin-top: 4px;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     > * {
       margin-right: 8px;
       &:last-child {


### PR DESCRIPTION
just a quick fix for overlap issue milestones has with modifiers.
before:
![image](https://user-images.githubusercontent.com/29002828/59545123-2e308780-8ee8-11e9-8576-98e61847f92e.png)

after:
![image](https://user-images.githubusercontent.com/29002828/59545129-3c7ea380-8ee8-11e9-923a-3a2d9d041e07.png)
  