### PR TITLE
change quoting around dev SSL cert request

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -32,7 +32,7 @@ module.exports = (env) => {
     if (!fs.existsSync('key.pem') || !fs.existsSync('cert.pem')) {
       console.log('Generating certificate');
       execSync(
-        "openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem -subj '/CN=www.mydom.com/O=My Company Name LTD./C=US'"
+        'openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem -subj "/CN=www.mydom.com/O=My Company Name LTD./C=US"'
       );
     }
   }


### PR DESCRIPTION
On Win8 and Win10 development environments, the certificate request in `config/webpack.js` is failing, at least for me.

From what I can tell and stack overflow, this is due to node `execSync` seeing all the slashes and trying to parse/expand the certificate's subject as a file path. Changing to single quotes fixes this.