### PR TITLE
Display shader icon in item details popup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed a bug with expert mode wish lists and dealing with single digit item categories.
 * CSV exports now include item sources. These match the DIM filter you can use to find the item.
 * Include more items in the "filter to uncollected" search in Vendors.
+* Added shader icons to the item details popup.
 
 # 5.32.0 (2019-06-09)
 

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -42,7 +42,7 @@ function mapStateToProps(state: RootState): StoreProps {
 function ItemDetails({ item, extraInfo = {}, defs }: Props) {
   return (
     <div className="item-details-body">
-      {item.type === 'Shaders' && (
+      {item.itemCategoryHashes.includes(41) && (
         <BungieImage className="item-shader" src={item.icon} width="96" height="96" />
       )}
 
@@ -50,7 +50,7 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
 
       <ItemExpiration item={item} />
 
-      {(item.type === 'Emblems' || item.type === 'Emblem') && (
+      {item.itemCategoryHashes.includes(19) && (
         <BungieImage className="item-details" src={item.secondaryIcon} width="237" height="48" />
       )}
 

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -42,6 +42,10 @@ function mapStateToProps(state: RootState): StoreProps {
 function ItemDetails({ item, extraInfo = {}, defs }: Props) {
   return (
     <div className="item-details-body">
+      {item.type === 'Shaders' && (
+        <BungieImage className="item-shader" src={item.icon} width="96" height="96" />
+      )}
+
       <ItemDescription item={item} />
 
       <ItemExpiration item={item} />

--- a/src/app/item-popup/ItemPopupContainer.scss
+++ b/src/app/item-popup/ItemPopupContainer.scss
@@ -174,6 +174,11 @@
   }
 }
 
+.item-shader {
+  display: block;
+  margin: 15px auto;
+}
+
 .masterwork-progress {
   margin: 4px 0px;
   padding: 4px 10px 4px;


### PR DESCRIPTION
Addresses #3873 

Adds a large shader icon to the item details popup.

From what I can tell, the dimensions of `item.icon` for shaders is always 96x96, so that's what I've displayed it as. Happy to revise if there's a way to fetch a larger version of this icon that I've missed.

![image](https://user-images.githubusercontent.com/60681/59573814-0f084480-90f8-11e9-8480-c4af016bb8df.png)

![image](https://user-images.githubusercontent.com/60681/59573996-d61c9f80-90f8-11e9-8041-5300b985710f.png)