### PR TITLE
Re-adding bounty progress bars.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Fixed failing to show progress bar for bounty steps.
 
 # 5.33.1 (2019-06-20)
 * Fixed issue with item cards and farming mode were under the St Jude overlay.

--- a/src/app/progress/Pursuit.tsx
+++ b/src/app/progress/Pursuit.tsx
@@ -3,6 +3,7 @@ import { DimItem } from 'app/inventory/item-types';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import ItemExpiration from 'app/item-popup/ItemExpiration';
+import ItemObjectives from 'app/item-popup/ItemObjectives';
 
 export default function Pursuit({ item }: { item: DimItem }) {
   // Suppress description when expiration is shown
@@ -26,6 +27,7 @@ export default function Pursuit({ item }: { item: DimItem }) {
       <div className="milestone-info">
         <span className="milestone-name">{item.name}</span>
         <ItemExpiration item={item} />
+        <ItemObjectives objectives={item.objectives} />
         {!expired && <div className="milestone-description">{item.description}</div>}
       </div>
     </div>


### PR DESCRIPTION
This addresses issue #3910 - we weren't showing objectives on some bounties.

![Screenshot_2019-06-21 DIM](https://user-images.githubusercontent.com/606888/59958252-7d8b3080-9471-11e9-852d-6bfcae43d5d3.png)
