### PR TITLE
masterwork synergy fix

### DIFF
--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -32,14 +32,12 @@ export default function PlugTooltip({
     item.masterworkInfo &&
     plug.plugItem.investmentStats &&
     item.masterworkInfo.statHash &&
-    plug.plugItem.investmentStats.some((stat) => {
-      return (
-        stat.value > 0 &&
-        stat.statTypeHash &&
-        item.masterworkInfo &&
-        item.masterworkInfo.statHash === stat.statTypeHash
-      );
-    }) &&
+    plug.plugItem.investmentStats.some((stat) => 
+      stat.value > 0 &&
+      stat.statTypeHash &&
+      item.masterworkInfo &&
+      item.masterworkInfo.statHash === stat.statTypeHash
+    ) &&
     ` (${item.masterworkInfo.statName})`;
 
   return (

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -27,15 +27,26 @@ export default function PlugTooltip({
 }) {
   // TODO: show insertion costs
 
+  // display perk's synergy with masterwork stat
+  const synergyStat =
+    item.masterworkInfo &&
+    plug.plugItem.investmentStats &&
+    item.masterworkInfo.statHash &&
+    plug.plugItem.investmentStats.some((stat) => {
+      return (
+        stat.value > 0 &&
+        stat.statTypeHash &&
+        item.masterworkInfo &&
+        item.masterworkInfo.statHash === stat.statTypeHash
+      );
+    }) &&
+    ` (${item.masterworkInfo.statName})`;
+
   return (
     <>
       <h2>
         {plug.plugItem.displayProperties.name}
-        {item.masterworkInfo &&
-          plug.plugItem.investmentStats &&
-          plug.plugItem.investmentStats[0] &&
-          item.masterworkInfo.statHash === plug.plugItem.investmentStats[0].statTypeHash &&
-          ` (${item.masterworkInfo.statName})`}
+        {synergyStat}
       </h2>
 
       {plug.plugItem.displayProperties.description ? (


### PR DESCRIPTION
this fixes the (parenthetical stat name) in perk tooltips, which is supposed to say whether a perk synergizes with the masterwork

this fix takes into account negative perk effects,
and loops through all stat effects in the perk, not just the first