### PR TITLE
3-line milestone description

### DIFF
--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -43,7 +43,8 @@
   .milestone-description {
     color: #a1a2a2;
     white-space: pre-wrap;
-    max-height: 3em;
+    line-height: 1.3;
+    max-height: 3.9em;
     overflow: hidden;
   }
 


### PR DESCRIPTION
the milestone description `em` height was displaying partial lines with cutoff text

this addresses the issue by making `1.3` line-height canonical (relied on browser defaults) and correctly incorporating the `em` height & line-height multiplier to make a description box height that fits a set number of lines.

per @bhollis in #3930, setting it for 3 lines right now.
this may change as redesign progresses.

doesn't fully address #3930 but right now truncating the text is a space-saving design choice.