### PR TITLE
Continuing curated->wishlist name change.

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1237,7 +1237,7 @@ function searchFilters(
           })
         );
       },
-      curated(item: D2Item) {
+      wishlist(item: D2Item) {
         return Boolean(inventoryCuratedRolls[item.id]);
       },
       wishlistdupe(item: D2Item) {
@@ -1247,7 +1247,7 @@ function searchFilters(
 
         const itemDupes = _duplicates[item.hash];
 
-        return itemDupes.some(this.curated);
+        return itemDupes.some(this.wishlist);
       },
       ammoType(item: D2Item, predicate: string) {
         return (


### PR DESCRIPTION
The `is:wishlist` (and `is:wishlistdupe`) searches got tripped up by the curated->wishlist audit.

This fixes those searches.