### PR TITLE
is:curated -- use whitelist instead of blacklist and a regex

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -406,6 +406,20 @@ function searchFilters(
     }
   }
 
+  const curatedPlugsWhitelist = [
+    7906839, // frames
+    683359327, // guards
+    1041766312, // blades
+    1202604782, // tubes
+    1257608559, // arrows
+    1757026848, // batteries
+    1806783418, // magazines
+    2619833294, // scopes
+    2718120384, // magazines_gl
+    2833605196, // barrels
+    3809303875 // bowstring
+  ];
+
   const statHashes = new Set([
     1480404414, // D2 Attack
     3897883278, // D1 & D2 Defense
@@ -1186,26 +1200,7 @@ function searchFilters(
 
         const legendaryWeapon =
           item.bucket && item.bucket.sort === 'Weapons' && item.tier.toLowerCase() === 'legendary';
-        /* const plugBlacklist = [
-          2947756142, // Ornaments
-          3940152116, // Trackers
-          2019022937, // Base Radiance
-          797011344 // Radiance
-        ];
-        */
-        const plugWhitelist = [
-          2619833294, // scopes
-          2833605196, // barrels
-          1202604782, // tubes
-          1806783418, // magazines
-          2718120384, // magazines_gl
-          7906839, // frames
-          3809303875, // bowstring
-          1257608559, // arrows
-          1757026848, // batteries
-          1041766312, // blades
-          683359327 // guards
-        ];
+
         const oneSocketPerPlug =
           item.sockets &&
           item.sockets.sockets
@@ -1213,16 +1208,8 @@ function searchFilters(
               (socket) =>
                 socket &&
                 socket.plug &&
-                plugWhitelist.includes(socket.plug.plugItem.plug.plugCategoryHash)
-            ) /*
-            .filter(
-              // Plug category hash changes from ornament to v400_activities_gambit_hand_cannon0_skins
-              (socket) =>
-                socket &&
-                socket.plug &&
-                socket.plug.plugItem &&
-                !socket.plug.plugItem.plug.plugCategoryIdentifier.match(/(skins$)/)
-            )*/
+                curatedPlugsWhitelist.includes(socket.plug.plugItem.plug.plugCategoryHash)
+            )
             .every((socket) => socket && socket.plugOptions.length === 1);
 
         return (

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1186,17 +1186,43 @@ function searchFilters(
 
         const legendaryWeapon =
           item.bucket && item.bucket.sort === 'Weapons' && item.tier.toLowerCase() === 'legendary';
-
+        /* const plugBlacklist = [
+          2947756142, // Ornaments
+          3940152116, // Trackers
+          2019022937, // Base Radiance
+          797011344 // Radiance
+        ];
+        */
+        const plugWhitelist = [
+          2619833294, // scopes
+          2833605196, // barrels
+          1202604782, // tubes
+          1806783418, // magazines
+          2718120384, // magazines_gl
+          7906839, // frames
+          3809303875, // bowstring
+          1257608559, // arrows
+          1757026848, // batteries
+          1041766312, // blades
+          683359327 // guards
+        ];
         const oneSocketPerPlug =
           item.sockets &&
           item.sockets.sockets
             .filter(
-              // Remove Ornaments and Trackers
               (socket) =>
                 socket &&
                 socket.plug &&
-                ![2947756142, 3940152116].includes(socket.plug.plugItem.plug.plugCategoryHash)
-            )
+                plugWhitelist.includes(socket.plug.plugItem.plug.plugCategoryHash)
+            ) /*
+            .filter(
+              // Plug category hash changes from ornament to v400_activities_gambit_hand_cannon0_skins
+              (socket) =>
+                socket &&
+                socket.plug &&
+                socket.plug.plugItem &&
+                !socket.plug.plugItem.plug.plugCategoryIdentifier.match(/(skins$)/)
+            )*/
             .every((socket) => socket && socket.plugOptions.length === 1);
 
         return (


### PR DESCRIPTION
left other working example in code for comparison, will remove once approved

closes #3961 

excluding radiance because after one is installed it has the option to be removed => length !== 0
excluding ornaments only works when one is not applied, would need to apply a regex to match `v400_activities...skins`

whitelist ***should*** be easier to maintain