### PR TITLE
progress CSS fixes

### DIFF
--- a/src/app/item-popup/ItemObjectives.scss
+++ b/src/app/item-popup/ItemObjectives.scss
@@ -17,12 +17,15 @@
   background-color: rgba(0, 0, 0, 0.3);
 }
 
-.objective-checkbox.objective-complete div {
+.objective-checkbox.objective-complete::after {
+  content: '';
+  display: block;
   margin: 2px;
   height: 11px;
   width: 11px;
   background-color: #6dcc66;
 }
+
 .objective-complete {
   opacity: 0.5;
   .objective-progress {
@@ -31,7 +34,9 @@
   .objective-progress-bar {
     display: none;
   }
-  .objective-checkbox div {
+  .objective-checkbox::after {
+    content: '';
+    display: block;
     margin: 2px;
     height: 11px;
     width: 11px;

--- a/src/app/item-popup/ItemObjectives.tsx
+++ b/src/app/item-popup/ItemObjectives.tsx
@@ -53,9 +53,7 @@ export default function ItemObjectives({
             </div>
           ) : (
             <>
-              <div className="objective-checkbox">
-                <div />
-              </div>
+              <div className="objective-checkbox" />
               <div className="objective-progress">
                 <div
                   className="objective-progress-bar"

--- a/src/app/progress/Objective.tsx
+++ b/src/app/progress/Objective.tsx
@@ -73,9 +73,7 @@ export default function Objective({
 
   return (
     <div className={classes}>
-      <div className="objective-checkbox">
-        <div />
-      </div>
+      <div className="objective-checkbox" />
       <div className="objective-progress">
         <div className="objective-progress-bar" style={progressBarStyle} />
         <div className="objective-description">{displayName}</div>

--- a/src/app/progress/Phase.tsx
+++ b/src/app/progress/Phase.tsx
@@ -11,9 +11,5 @@ export default function Phase({ completed }: { completed: boolean }) {
     'objective-complete': completed
   });
 
-  return (
-    <div className={classes}>
-      <div />
-    </div>
-  );
+  return <div className={classes} />;
 }

--- a/src/app/progress/faction.scss
+++ b/src/app/progress/faction.scss
@@ -40,8 +40,10 @@
   border-radius: 50%;
   background-color: #ddd;
   color: black;
-  width: calc(#{$badge-font-size} + 8px);
-  height: calc(#{$badge-font-size} + 8px);
+  width: calc(#{$badge-font-size} * 2);
+  height: calc(#{$badge-font-size} * 2);
+  width: calc((var(--item-size) / 2.5));
+  height: calc((var(--item-size) / 2.5));
   font-size: calc(#{$badge-font-size});
   display: flex;
   align-items: center;


### PR DESCRIPTION
this removes some semantic divs which were being used as presentation elements
replaces the completed checkbox styling so it's pure CSS instead of an empty extra element

the number bubble showing ...faction level? was set with an additive adjustment instead of multiplicative.
8px was enough on small icons but if the icon size slider's at max, 3 digit numbers overflow out of the bubble.