### PR TITLE
Display the correct Armsmaster modifier loadout info for raid lairs.

### DIFF
--- a/src/app/progress/LoadoutRequirementModifier.tsx
+++ b/src/app/progress/LoadoutRequirementModifier.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { DestinyMilestoneChallengeActivity, DestinyItemSubType } from 'bungie-api-ts/destiny2';
+import BungieImage from 'app/dim-ui/BungieImage';
+import PressTip from 'app/dim-ui/PressTip';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
+
+export const armsmasterModifierHash = 3704166961;
+
+/**
+ * This table lets us use localized names for ItemSubTypes, since they only exist as enum values.EquipmentSlot definitions.
+ * Non-weapons are included but set to the null category so TypeScript will tell us if something is added and we don't map it.
+ */
+const itemSubTypeToItemCategoryHash: { [key in DestinyItemSubType]: number } = {
+  // START useless types
+  [DestinyItemSubType.None]: 17,
+  [DestinyItemSubType.Crucible]: 17,
+  [DestinyItemSubType.Vanguard]: 17,
+  [DestinyItemSubType.Exotic]: 17,
+  [DestinyItemSubType.Crm]: 17,
+  [DestinyItemSubType.HelmetArmor]: 17,
+  [DestinyItemSubType.GauntletsArmor]: 17,
+  [DestinyItemSubType.ChestArmor]: 17,
+  [DestinyItemSubType.LegArmor]: 17,
+  [DestinyItemSubType.ClassArmor]: 17,
+  // END useless types
+  [DestinyItemSubType.AutoRifle]: 5,
+  [DestinyItemSubType.Shotgun]: 11,
+  [DestinyItemSubType.Machinegun]: 12,
+  [DestinyItemSubType.HandCannon]: 6,
+  [DestinyItemSubType.RocketLauncher]: 13,
+  [DestinyItemSubType.FusionRifle]: 9,
+  [DestinyItemSubType.SniperRifle]: 10,
+  [DestinyItemSubType.PulseRifle]: 7,
+  [DestinyItemSubType.ScoutRifle]: 8,
+  [DestinyItemSubType.Sidearm]: 14,
+  [DestinyItemSubType.Sword]: 54,
+  [DestinyItemSubType.Mask]: 0,
+  [DestinyItemSubType.Shader]: 0,
+  [DestinyItemSubType.Ornament]: 0,
+  [DestinyItemSubType.FusionRifleLine]: 1504945536,
+  [DestinyItemSubType.GrenadeLauncher]: 153950757,
+  [DestinyItemSubType.SubmachineGun]: 3954685534,
+  [DestinyItemSubType.TraceRifle]: 2489664120,
+  [DestinyItemSubType.Bow]: 3317538576
+};
+
+/**
+ * This table lets us load localized names for equipment slots from the ItemCategory definitions
+ * so we don't have to load the EquipmentSlot definitions.
+ */
+const equipmentSlotHashToItemCategoryHash = {
+  1498876634: 2, // Kinetic
+  2465295065: 3, // Energy
+  953998645: 4 // Power
+};
+
+/**
+ * Displays an alternate form of the "Armsmaster" activity modifier that's
+ * generated from an activity's loadout requirement.
+ *
+ * Raid activities can have required loadouts, which fall under the "armsmaster" modifier. The
+ * actual modifier text doesn't give the right info, so we'll build it ourselves from the loadout
+ * data.
+ */
+export default function LoadoutRequirementModifier({
+  activity,
+  defs
+}: {
+  activity: DestinyMilestoneChallengeActivity;
+  defs: D2ManifestDefinitions;
+}) {
+  if (activity.loadoutRequirementIndex === undefined || activity.loadoutRequirementIndex === null) {
+    return null;
+  }
+
+  const activityDef = defs.Activity.get(activity.activityHash);
+  const modifier = defs.ActivityModifier.get(armsmasterModifierHash);
+
+  // Raid activities can have required loadouts, which fall under the "armsmaster" modifier. The
+  // actual modifier text doesn't give the right info, so we'll build it ourselves from the loadout
+  // data.
+  const loadout = activityDef.loadouts[activity.loadoutRequirementIndex];
+  const requirements = loadout.requirements.map((req) => ({
+    slot: defs.ItemCategory.get(equipmentSlotHashToItemCategoryHash[req.equipmentSlotHash])
+      .displayProperties.name,
+    types: req.allowedWeaponSubTypes.map(
+      (sub) => defs.ItemCategory.get(itemSubTypeToItemCategoryHash[sub]).displayProperties.name
+    )
+  }));
+
+  const description = (
+    <>
+      {modifier.displayProperties.description.split('\n')[0]}
+      <br />
+      {requirements.map((requirement) => (
+        <div key={requirement.slot}>
+          <b>{requirement.slot}:</b> {requirement.types.join(', ')}
+        </div>
+      ))}
+    </>
+  );
+
+  return (
+    <div className="milestone-modifier">
+      <BungieImage src={modifier.displayProperties.icon} />
+      <div className="milestone-modifier-info">
+        <PressTip tooltip={description}>
+          <div className="milestone-modifier-name">{modifier.displayProperties.name}</div>
+        </PressTip>
+      </div>
+    </div>
+  );
+}

--- a/src/app/progress/Raid.tsx
+++ b/src/app/progress/Raid.tsx
@@ -26,10 +26,9 @@ export function Raid({ raid, defs }: { raid: DestinyMilestone; defs: D2ManifestD
       <RaidDisplay displayProperties={raidDef.displayProperties}>
         {activities.map((activity) => (
           <RaidActivity
-            activityHash={activity.activityHash}
+            activity={activity}
             displayName={displayName}
             phases={activity.phases}
-            modifierHashes={activity.modifierHashes}
             defs={defs}
             key={activity.activityHash}
           />

--- a/src/app/progress/RaidDisplay.tsx
+++ b/src/app/progress/RaidDisplay.tsx
@@ -1,12 +1,14 @@
 import {
   DestinyDisplayPropertiesDefinition,
-  DestinyMilestoneActivityPhase
+  DestinyMilestoneActivityPhase,
+  DestinyMilestoneChallengeActivity
 } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import BungieImage from '../dim-ui/BungieImage';
 import Phase from './Phase';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { ActivityModifier } from './ActivityModifier';
+import LoadoutRequirementModifier, { armsmasterModifierHash } from './LoadoutRequirementModifier';
 
 interface Props {
   displayProperties: DestinyDisplayPropertiesDefinition;
@@ -30,32 +32,36 @@ export function RaidDisplay(props: Props) {
 // Raid Activity, describing phases and its difficulty tier if applicable
 export function RaidActivity({
   defs,
-  activityHash,
+  activity,
   displayName,
-  phases,
-  modifierHashes
+  phases
 }: {
   defs: D2ManifestDefinitions;
-  activityHash: number;
+  activity: DestinyMilestoneChallengeActivity;
   displayName: string;
   phases: DestinyMilestoneActivityPhase[];
-  modifierHashes: number[];
 }) {
-  const modifiers = (modifierHashes || []).map((h) => defs.ActivityModifier.get(h));
+  const modifiers = (activity.modifierHashes || []).map((h) => defs.ActivityModifier.get(h));
 
   // manifest-localized string describing raid segments with loot
   const encountersString = defs.Objective.get(3133307686).progressDescription;
 
+  const activityDef = defs.Activity.get(activity.activityHash);
+
   // use milestone name if there's only 1 tier of the raid
-  const activityName = displayName || defs.Activity.get(activityHash).displayProperties.name;
+  const activityName = displayName || activityDef.displayProperties.name;
 
   return (
     <div className="raid-tier">
       <span className="milestone-name">{activityName}</span>
       <div className="quest-modifiers">
-        {modifiers.map((modifier) => (
-          <ActivityModifier key={modifier.hash} modifier={modifier} />
-        ))}
+        {modifiers.map(
+          (modifier) =>
+            modifier.hash !== armsmasterModifierHash && (
+              <ActivityModifier key={modifier.hash} modifier={modifier} />
+            )
+        )}
+        <LoadoutRequirementModifier defs={defs} activity={activity} />
       </div>
       <div className="quest-objectives">
         <div className="objective-row objective-boolean">


### PR DESCRIPTION
This uses the loadouts information from activities to override the description of the "armsmaster" modifier: https://github.com/Bungie-net/api/issues/676

<img width="1168" alt="Screen Shot 2019-07-07 at 4 55 46 PM" src="https://user-images.githubusercontent.com/313208/60775433-004df580-a0d8-11e9-8932-ad724f79c4a7.png">
