### PR TITLE
Upload new content in two phases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,23 +75,25 @@ module.exports = function(grunt) {
       options: {
         //dryRun: true,
         args: ["--verbose"],
-        exclude: ["chrome.zip", "stats.html"],
+        excludeFirst: ["chrome.zip", "stats.html"],
         host: process.env.REMOTE_HOST,
-        //port: 2222,
         recursive: true,
         ssh: true,
         privateKey: 'config/dim_travis.rsa',
         sshCmdArgs: ["-o StrictHostKeyChecking=no"]
       },
-      beta: {
+      // Sync everything but the HTML first, so it's ready to go
+      app_content: {
         options: {
+          exclude: ["*.html"],
           src: "dist/",
           dest: process.env.REMOTE_PATH
         }
       },
-      prod: {
+      // Then sync the HTML which will start using the new content
+      app_html: {
         options: {
-          src: "dist/",
+          src: "dist/*.html",
           dest: process.env.REMOTE_PATH
         }
       },
@@ -244,14 +246,16 @@ module.exports = function(grunt) {
     'crowdin-request:upload',
     'log_beta_version',
     'precompress',
-    'rsync:beta',
+    'rsync:app_content',
+    'rsync:app_html',
     'rsync:website'
   ]);
 
   grunt.registerTask('publish_release', [
     'log_release_version',
     'precompress',
-    'rsync:prod'
+    'rsync:app_content',
+    'rsync:app_html'
   ]);
 
   grunt.registerTask('log_beta_version', function() {


### PR DESCRIPTION
I noticed an error in Sentry that I couldn't explain, but I have a theory. Occasionally we'll see errors where the translation files can't be parsed. The only thing that could explain that is if somebody accessed them before they were fully uploaded!

To address this, I've updated our rsync process to work in two phases. First it uploads everything but the HTML files (these will be written as new files side-by-side with the old ones, since they have hashed filenames). Then, in a second pass, update just the HTML. This guarantees that the scripts and data referenced by that HTML is already available. 