### PR TITLE
Include react-dnd in babel transformation

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -115,7 +115,8 @@ module.exports = (env) => {
       rules: [
         {
           test: /\.js$/,
-          exclude: [/node_modules/],
+          // Update with npx are-you-es5 check -r .
+          exclude: /\/node_modules\/(?!(idb-keyval|react-dnd|react-dnd-html5-backend|react-with-gesture))/,
           loader: 'babel-loader',
           options: {
             cacheDirectory: true

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -115,8 +115,17 @@ module.exports = (env) => {
       rules: [
         {
           test: /\.js$/,
-          // Update with npx are-you-es5 check -r .
-          exclude: /\/node_modules\/(?!(idb-keyval|react-dnd|react-dnd-html5-backend|react-with-gesture))/,
+          include: [
+            path.resolve('src'),
+            // These dependencies have es6 syntax which edge doesn't like.
+            // Update with npx are-you-es5 check -r .
+            // https://github.com/babel/babel-loader/issues/171
+            path.resolve('node_modules/idb-keyval'),
+            path.resolve('node_modules/react-dnd'),
+            path.resolve('node_modules/dnd-core'),
+            path.resolve('node_modules/react-dnd-html5-backend'),
+            path.resolve('node_modules/react-with-gesture')
+          ],
           loader: 'babel-loader',
           options: {
             cacheDirectory: true


### PR DESCRIPTION
One of our dependencies, react-dnd, started shipping code using new JS syntax. Since we don't run node_modules through babel, we shipped that right along, and Edge couldn't handle it.

This change uses a tool to find all the dependencies that are not ES5 (lowest common denominator) and includes them in the babel party.

Fixes #3983.