### PR TITLE
Don't cache service worker

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,7 @@ module.exports = function(grunt) {
       // Sync everything but the HTML first, so it's ready to go
       app_content: {
         options: {
-          exclude: ["*.html", "service-worker.js"],
+          exclude: ["*.html", "service-worker.js", "version.json"],
           src: "dist/",
           dest: process.env.REMOTE_PATH
         }
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
       // Then sync the HTML which will start using the new content
       app_html: {
         options: {
-          src: ["dist/*.html", "dist/service-worker.js"],
+          src: ["dist/*.html", "dist/service-worker.js", "dist/version.json"],
           dest: process.env.REMOTE_PATH
         }
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,7 @@ module.exports = function(grunt) {
       // Sync everything but the HTML first, so it's ready to go
       app_content: {
         options: {
-          exclude: ["*.html"],
+          exclude: ["*.html", "service-worker.js"],
           src: "dist/",
           dest: process.env.REMOTE_PATH
         }
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
       // Then sync the HTML which will start using the new content
       app_html: {
         options: {
-          src: "dist/*.html",
+          src: ["dist/*.html", "dist/service-worker.js"],
           dest: process.env.REMOTE_PATH
         }
       },

--- a/src/htaccess
+++ b/src/htaccess
@@ -972,7 +972,8 @@ FileETag None
     FileETag None
     <IfModule mod_headers.c>
         Header unset ETag
-        Header set Cache-Control "max-age=0, s-maxage=86400"
+        Header set Cache-Control "max-age=0, s-maxage=86400, no-cache, no-store, must-revalidate"
+        Header set Pragma "no-cache"
         Header unset Expires
     </IfModule>
 </FilesMatch>

--- a/src/register-service-worker.ts
+++ b/src/register-service-worker.ts
@@ -121,6 +121,7 @@ export default function registerServiceWorker() {
           .catch((err) => {
             if ($featureFlags.debugSW) {
               console.error('SW: Unable to update service worker.', err);
+              reportException('service-worker', err);
             }
           })
           .then(() => {


### PR DESCRIPTION
I thought I could get clever with how the service worker was cached, but it looks like Safari really loves holding on to a service worker even when you ask it to update!

I'm also including service-worker.js and version.json in the two-phase upload so they show up last.