### PR TITLE
tighter checking for item w/ classified perks

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -755,7 +755,10 @@ function buildStats(
     const bonusPerk = sockets.sockets.find((socket) =>
       Boolean(
         // Mobility, Restorative, and Resilience perk
-        socket.plug && socket.plug.plugItem.plug.plugCategoryHash === 3313201758
+        socket.plug &&
+          socket.plug.plugItem &&
+          socket.plug.plugItem.plug &&
+          socket.plug.plugItem.plug.plugCategoryHash === 3313201758
       )
     );
     // If we didn't find one, then it's not armor.

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -38,14 +38,17 @@ export default function Plug({
         onShiftClick(plug);
       }
     });
-
+  const tempHashesList =
+    plug && plug.plugItem && plug.plugItem.itemCategoryHashes
+      ? plug.plugItem.itemCategoryHashes
+      : [];
   return (
     <div
       key={plug.plugItem.hash}
       className={classNames('socket-container', className, {
         disabled: !plug.enabled,
         notChosen: plug !== socketInfo.plug,
-        notIntrinsic: !plug.plugItem.itemCategoryHashes.includes(2237038328)
+        notIntrinsic: tempHashesList.includes(2237038328)
       })}
       onClick={handleShiftClick}
     >

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -32,11 +32,12 @@ export default function PlugTooltip({
     item.masterworkInfo &&
     plug.plugItem.investmentStats &&
     item.masterworkInfo.statHash &&
-    plug.plugItem.investmentStats.some((stat) => 
-      stat.value > 0 &&
-      stat.statTypeHash &&
-      item.masterworkInfo &&
-      item.masterworkInfo.statHash === stat.statTypeHash
+    plug.plugItem.investmentStats.some(
+      (stat) =>
+        stat.value > 0 &&
+        stat.statTypeHash &&
+        item.masterworkInfo &&
+        item.masterworkInfo.statHash === stat.statTypeHash
     ) &&
     ` (${item.masterworkInfo.statName})`;
 
@@ -59,13 +60,17 @@ export default function PlugTooltip({
           </div>
         ))
       )}
-      {defs && plug.plugItem.investmentStats.length > 0 && (
-        <div className="plug-stats">
-          {plug.plugItem.investmentStats.map((stat) => (
-            <Stat key={stat.statTypeHash} stat={stat} defs={defs} />
-          ))}
-        </div>
-      )}
+      {defs &&
+        plug &&
+        plug.plugItem &&
+        plug.plugItem.investmentStats &&
+        plug.plugItem.investmentStats.length > 0 && (
+          <div className="plug-stats">
+            {plug.plugItem.investmentStats.map((stat) => (
+              <Stat key={stat.statTypeHash} stat={stat} defs={defs} />
+            ))}
+          </div>
+        )}
       {defs && plug.plugObjectives.length > 0 && (
         <div className="plug-objectives">
           {plug.plugObjectives.map((objective) => (


### PR DESCRIPTION
bad juju is crashing DIM right now because it's unclassified but its perks are still classified. this fixes item popup/tooltip logic so that it doesn't assume all perks are unclassified