### PR TITLE
dim.json alphabetized

### DIFF
--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -71,8 +71,8 @@
     "Super": "Super cooldown: {{cooldown}}"
   },
   "Countdown": {
-    "DaysCompact": "{{count}}d",
     "Days": "{{count}} Day",
+    "DaysCompact": "{{count}}d",
     "Days_plural": "{{count}} Days"
   },
   "Csv": {
@@ -620,8 +620,8 @@
     "ProfileMilestones": "Account Milestones",
     "ProfileQuests": "Account Quests",
     "Progress": "Progress",
-    "QuestExpires": "Expires in ",
     "QuestExpired": "Expired",
+    "QuestExpires": "Expires in ",
     "Quests": "Quests",
     "RecordValue": "{{value}}pts",
     "RewardEarned": "Reward earned but not redeemed",


### PR DESCRIPTION
`yarn lint` on a fresh install immediately causes a file modification,
because a couple items in `dim.json` are out of order and then get fixed