### PR TITLE
raids below quests&items/show complete activities

### DIFF
--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -141,10 +141,10 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets }: Props) {
   const menuItems = [
     { id: 'ranks', title: t('Progress.CrucibleRank') },
     { id: 'milestones', title: t('Progress.Milestones') },
-    { id: 'raids', title: raidTitle },
     { id: 'Bounties', title: t('Progress.Bounties') },
     { id: 'Quests', title: t('Progress.Quests') },
     { id: 'Items', title: t('Progress.Items') },
+    { id: 'raids', title: raidTitle },
     { id: 'triumphs', title: triumphTitle },
     { id: 'factions', title: t('Progress.Factions') }
   ];

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -215,6 +215,10 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets }: Props) {
           </CollapsibleTitle>
         </section>
 
+        <ErrorBoundary name="Pursuits">
+          <Pursuits store={selectedStore} defs={defs} />
+        </ErrorBoundary>
+
         <section id="raids">
           <CollapsibleTitle title={raidTitle} sectionId="raids">
             <div className="progress-row">
@@ -224,10 +228,6 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets }: Props) {
             </div>
           </CollapsibleTitle>
         </section>
-
-        <ErrorBoundary name="Pursuits">
-          <Pursuits store={selectedStore} defs={defs} />
-        </ErrorBoundary>
 
         <section id="triumphs">
           <ErrorBoundary name="Triumphs">

--- a/src/app/progress/Raid.tsx
+++ b/src/app/progress/Raid.tsx
@@ -5,37 +5,33 @@ import './milestone.scss';
 import { RaidDisplay, RaidActivity } from './RaidDisplay';
 
 /**
- * Raids offer powerful rewards. Unlike Milestones, raids have multiple tiers,
+ * Raids offer powerful rewards. Unlike Milestones, some raids have multiple tiers,
  * so this function enumerates the Activities within the Milstones
  */
 export function Raid({ raid, defs }: { raid: DestinyMilestone; defs: D2ManifestDefinitions }) {
+  // convert character's DestinyMilestone to manifest's DestinyMilestoneDefinition
   const raidDef = defs.Milestone.get(raid.milestoneHash);
 
-  if (raid.activities && raid.activities.length) {
-    const activities = raid.activities.filter((activity) => activity.phases);
-
-    // check all phases of all activities
-    if (activities.every((activity) => activity.phases.every((phase) => phase.complete))) {
-      return null;
-    }
-
-    // set a canonical raid name if there's only 1 tier of the raid
-    const displayName = activities.length === 1 ? raidDef.displayProperties.name : '';
-
-    return (
-      <RaidDisplay displayProperties={raidDef.displayProperties}>
-        {activities.map((activity) => (
-          <RaidActivity
-            activity={activity}
-            displayName={displayName}
-            phases={activity.phases}
-            defs={defs}
-            key={activity.activityHash}
-          />
-        ))}
-      </RaidDisplay>
-    );
+  // nothing to display if there are no activities
+  if (!(raid.activities && raid.activities.length)) {
+    return null;
   }
 
-  return null;
+  const activities = raid.activities.filter((activity) => activity.phases);
+
+  // override the sometimes cryptic individual activity names, if there's only 1 tier of the raid
+  const displayName = activities.length === 1 ? raidDef.displayProperties.name : '';
+
+  return (
+    <RaidDisplay displayProperties={raidDef.displayProperties}>
+      {activities.map((activity) => (
+        <RaidActivity
+          activity={activity}
+          displayName={displayName}
+          defs={defs}
+          key={activity.activityHash}
+        />
+      ))}
+    </RaidDisplay>
+  );
 }

--- a/src/app/progress/RaidDisplay.tsx
+++ b/src/app/progress/RaidDisplay.tsx
@@ -1,6 +1,5 @@
 import {
   DestinyDisplayPropertiesDefinition,
-  DestinyMilestoneActivityPhase,
   DestinyMilestoneChallengeActivity
 } from 'bungie-api-ts/destiny2';
 import React from 'react';
@@ -15,7 +14,9 @@ interface Props {
   children?: React.ReactNode;
 }
 
-// outer wrapper of a Raid & its icon
+/**
+ * Outer wrapper of a Raid type (example: EoW) with icon
+ */
 export function RaidDisplay(props: Props) {
   const { displayProperties, children } = props;
 
@@ -29,33 +30,37 @@ export function RaidDisplay(props: Props) {
   );
 }
 
-// Raid Activity, describing phases and its difficulty tier if applicable
+/**
+ * a Raid Activity, (examples: "EoW", or "EoW Prestige")
+ * describes its phases and difficulty tier if applicable
+ */
 export function RaidActivity({
   defs,
   activity,
-  displayName,
-  phases
+  displayName
 }: {
   defs: D2ManifestDefinitions;
   activity: DestinyMilestoneChallengeActivity;
   displayName: string;
-  phases: DestinyMilestoneActivityPhase[];
 }) {
-  const modifiers = (activity.modifierHashes || []).map((h) => defs.ActivityModifier.get(h));
+  const activityModifiers = (activity.modifierHashes || []).map((h) =>
+    defs.ActivityModifier.get(h)
+  );
 
-  // manifest-localized string describing raid segments with loot
+  // a manifest-localized string describing raid segments with loot. "Encounters completed"
   const encountersString = defs.Objective.get(3133307686).progressDescription;
 
+  // convert character's DestinyMilestoneChallengeActivity to manifest's DestinyActivityDefinition
   const activityDef = defs.Activity.get(activity.activityHash);
 
-  // use milestone name if there's only 1 tier of the raid
+  // override individual activity name if there's only 1 tier of the raid
   const activityName = displayName || activityDef.displayProperties.name;
 
   return (
     <div className="raid-tier">
       <span className="milestone-name">{activityName}</span>
       <div className="quest-modifiers">
-        {modifiers.map(
+        {activityModifiers.map(
           (modifier) =>
             modifier.hash !== armsmasterModifierHash && (
               <ActivityModifier key={modifier.hash} modifier={modifier} />
@@ -65,7 +70,7 @@ export function RaidActivity({
       </div>
       <div className="quest-objectives">
         <div className="objective-row objective-boolean">
-          {phases.map((phase) => (
+          {activity.phases.map((phase) => (
             <Phase key={phase.phaseHash} completed={phase.complete} />
           ))}
           <div className="objective-progress">

--- a/src/app/progress/Raids.tsx
+++ b/src/app/progress/Raids.tsx
@@ -15,7 +15,10 @@ const raidOrder = [
   2590427074 // crown
 ];
 
-/** Displays all of the raids available to a user as milestones. */
+/**
+ * Displays all of the raids available to a user as milestones
+ * reverses raid release order for maximum relevance first
+ */
 export default function Raids({
   store,
   defs,
@@ -49,7 +52,8 @@ export default function Raids({
 
   const raids = _.sortBy(filteredMilestones, (f) => {
     const order = raidOrder.indexOf(f.milestoneHash);
-    return order >= 0 ? order : 999 + f.order;
+    // return reverse order by index
+    return order >= 0 ? -order : -999 - f.order;
   });
 
   return (


### PR DESCRIPTION
closes #3982
goes with the advice of team to move Raids downward in the list, so to-do-style sections are on top
orders raid newest first as they are most relevant

\+ more comments, code clarification, avoid passing in an extraneous hash


![image](https://user-images.githubusercontent.com/31990469/61132667-b3b84080-a470-11e9-96cb-282f08aef408.png)
