### PR TITLE
idx instead

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -543,7 +543,7 @@ export function makeItem(
   const tier = itemDef.inventory ? defs.ItemTierType[itemDef.inventory.tierTypeHash] : null;
   createdItem.infusionProcess = tier && tier.infusionProcess;
   createdItem.infusionFuel = Boolean(
-    createdItem.infusionProcess && idx(itemDef, (i) => i.quality.infusionCategoryHashes.length)
+    createdItem.infusionProcess && idx(itemDef.quality, (q) => q.infusionCategoryHashes.length)
   );
   createdItem.infusable = createdItem.infusionFuel && isLegendaryOrBetter(createdItem);
   createdItem.infusionQuality = itemDef.quality || null;
@@ -733,7 +733,7 @@ function buildStats(
     const bonusPerk = sockets.sockets.find((socket) =>
       Boolean(
         // Mobility, Restorative, and Resilience perk
-        idx(socket.plug, (plug) => plug.plugItem.plug.plugCategoryHash) === 3313201758
+        idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) === 3313201758
       )
     );
     // If we didn't find one, then it's not armor.
@@ -767,8 +767,8 @@ function buildStats(
         .filter(filterPlugs)
         .filter((socket) =>
           Boolean(
-            idx(socket, (x) => x.plug.plugItem.plug.plugCategoryHash) !== 3347429529 &&
-              idx(socket, (x) => x.plug.plugItem.investmentStats.length)
+            idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) !== 3347429529 &&
+              idx(socket.plug, (p) => p.plugItem.investmentStats.length)
           )
         )
         .forEach((socket) => {
@@ -1304,7 +1304,7 @@ function buildForsakenMasterworkInfo(createdItem: D2Item, defs: D2ManifestDefini
     }
 
     const killTracker = createdItem.sockets!.sockets.find((socket) =>
-      Boolean(idx(socket, (s) => s.plug.plugObjectives.length))
+      Boolean(idx(socket.plug, (p) => p.plugObjectives.length))
     );
 
     if (

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -426,17 +426,12 @@ export function makeItem(
 
   try {
     // TODO: move socket handling and stuff into a different file
-    if (itemComponents && itemComponents.sockets && itemComponents.sockets.data) {
-      createdItem.sockets = buildSockets(item, itemComponents.sockets.data, defs, itemDef);
+    const socketData = idx(itemComponents, (i) => i.sockets.data);
+    if (socketData) {
+      createdItem.sockets = buildSockets(item, socketData, defs, itemDef);
     }
     if (!createdItem.sockets && itemDef.sockets) {
-      if (
-        itemComponents &&
-        itemComponents.sockets &&
-        itemComponents.sockets.data &&
-        item.itemInstanceId &&
-        !itemComponents.sockets.data[item.itemInstanceId]
-      ) {
+      if (item.itemInstanceId && socketData && !socketData[item.itemInstanceId]) {
         createdItem.missingSockets = true;
       }
       createdItem.sockets = buildDefinedSockets(defs, itemDef);
@@ -447,14 +442,10 @@ export function makeItem(
   }
 
   try {
-    if (itemComponents && itemComponents.stats && itemComponents.stats.data) {
+    const statsData = idx(itemComponents, (i) => i.stats.data);
+    if (statsData) {
       // Instanced stats
-      createdItem.stats = buildStats(
-        item,
-        createdItem.sockets,
-        itemComponents.stats.data,
-        defs.Stat
-      );
+      createdItem.stats = buildStats(item, createdItem.sockets, statsData, defs.Stat);
       if (itemDef.stats && itemDef.stats.stats) {
         // Hidden stats
         createdItem.stats = (createdItem.stats || []).concat(buildHiddenStats(itemDef, defs.Stat));
@@ -475,26 +466,19 @@ export function makeItem(
   }
 
   try {
-    if (itemComponents && itemComponents.talentGrids && itemComponents.talentGrids.data) {
-      createdItem.talentGrid = buildTalentGrid(
-        item,
-        itemComponents.talentGrids.data,
-        defs.TalentGrid
-      );
+    const talentData = idx(itemComponents, (i) => i.talentGrids.data);
+    if (talentData) {
+      createdItem.talentGrid = buildTalentGrid(item, talentData, defs.TalentGrid);
     }
   } catch (e) {
     console.error(`Error building talent grid for ${createdItem.name}`, item, itemDef, e);
     reportException('TalentGrid', e, { itemHash: item.itemHash });
   }
 
+  const objectiveData = idx(itemComponents, (i) => i.objectives.data);
   try {
-    if (itemComponents && itemComponents.objectives && itemComponents.objectives.data) {
-      createdItem.objectives = buildObjectives(
-        item,
-        owner,
-        itemComponents.objectives.data,
-        defs.Objective
-      );
+    if (objectiveData) {
+      createdItem.objectives = buildObjectives(item, owner, objectiveData, defs.Objective);
     }
   } catch (e) {
     console.error(`Error building objectives for ${createdItem.name}`, item, itemDef, e);
@@ -502,12 +486,8 @@ export function makeItem(
   }
 
   try {
-    if (itemComponents && itemComponents.objectives && itemComponents.objectives.data) {
-      createdItem.flavorObjective = buildFlavorObjective(
-        item,
-        itemComponents.objectives.data,
-        defs.Objective
-      );
+    if (objectiveData) {
+      createdItem.flavorObjective = buildFlavorObjective(item, objectiveData, defs.Objective);
     }
   } catch (e) {
     console.error(`Error building flavor objectives for ${createdItem.name}`, item, itemDef, e);
@@ -563,10 +543,7 @@ export function makeItem(
   const tier = itemDef.inventory ? defs.ItemTierType[itemDef.inventory.tierTypeHash] : null;
   createdItem.infusionProcess = tier && tier.infusionProcess;
   createdItem.infusionFuel = Boolean(
-    createdItem.infusionProcess &&
-      itemDef.quality &&
-      itemDef.quality.infusionCategoryHashes &&
-      itemDef.quality.infusionCategoryHashes.length
+    createdItem.infusionProcess && idx(itemDef, (i) => i.quality.infusionCategoryHashes.length)
   );
   createdItem.infusable = createdItem.infusionFuel && isLegendaryOrBetter(createdItem);
   createdItem.infusionQuality = itemDef.quality || null;
@@ -771,9 +748,8 @@ function buildStats(
       sockets.sockets
         .filter((socket) =>
           Boolean(
-            socket.plug &&
-              socket.plug.plugItem.plug.plugCategoryHash === 3347429529 &&
-              socket.plug.plugItem.inventory.tierType !== 2
+            idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) === 3347429529 &&
+              idx(socket.plug, (p) => p.plugItem.inventory.tierType) !== 2
           )
         )
         .forEach((socket) => {
@@ -791,10 +767,8 @@ function buildStats(
         .filter(filterPlugs)
         .filter((socket) =>
           Boolean(
-            socket.plug &&
-              socket.plug.plugItem.plug.plugCategoryHash !== 3347429529 &&
-              socket.plug.plugItem.investmentStats &&
-              socket.plug.plugItem.investmentStats.length
+            idx(socket, (x) => x.plug.plugItem.plug.plugCategoryHash) !== 3347429529 &&
+              idx(socket, (x) => x.plug.plugItem.investmentStats.length)
           )
         )
         .forEach((socket) => {
@@ -1330,7 +1304,7 @@ function buildForsakenMasterworkInfo(createdItem: D2Item, defs: D2ManifestDefini
     }
 
     const killTracker = createdItem.sockets!.sockets.find((socket) =>
-      Boolean(socket.plug && socket.plug.plugObjectives.length)
+      Boolean(idx(socket, (s) => s.plug.plugObjectives.length))
     );
 
     if (

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -30,17 +30,15 @@ export default function PlugTooltip({
 
   // display perk's synergy with masterwork stat
   const synergyStat =
-    item.masterworkInfo &&
-    item.masterworkInfo.statHash &&
+    idx(item, (i) => i.masterworkInfo.statHash) &&
     plug.plugItem.investmentStats &&
     plug.plugItem.investmentStats.some(
       (stat) =>
         stat.value > 0 &&
         stat.statTypeHash &&
-        item.masterworkInfo &&
-        item.masterworkInfo.statHash === stat.statTypeHash
+        idx(item, (x) => x.masterworkInfo.statHash) === stat.statTypeHash
     ) &&
-    ` (${item.masterworkInfo.statName})`;
+    ` (${idx(item, (i) => i.masterworkInfo.statName)})`;
 
   return (
     <>

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -59,7 +59,7 @@ export default function PlugTooltip({
           </div>
         ))
       )}
-      {defs && (idx(plug, (p) => p.plugItem.investmentStats.length) || 0) > 0 && (
+      {defs && !!idx(plug, (p) => p.plugItem.investmentStats.length) && (
         <div className="plug-stats">
           {plug.plugItem.investmentStats.map((stat) => (
             <Stat key={stat.statTypeHash} stat={stat} defs={defs} />

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -30,15 +30,17 @@ export default function PlugTooltip({
 
   // display perk's synergy with masterwork stat
   const synergyStat =
-    idx(item, (i) => i.masterworkInfo.statHash) &&
+    item.masterworkInfo &&
+    item.masterworkInfo.statHash &&
     plug.plugItem.investmentStats &&
     plug.plugItem.investmentStats.some(
       (stat) =>
         stat.value > 0 &&
         stat.statTypeHash &&
-        idx(item, (x) => x.masterworkInfo.statHash) === stat.statTypeHash
+        item.masterworkInfo &&
+        item.masterworkInfo.statHash === stat.statTypeHash
     ) &&
-    ` (${idx(item, (i) => i.masterworkInfo.statName)})`;
+    ` (${item.masterworkInfo.statName})`;
 
   return (
     <>

--- a/src/app/progress/AvailableQuest.tsx
+++ b/src/app/progress/AvailableQuest.tsx
@@ -32,7 +32,6 @@ export default function AvailableQuest({
   const questDef = milestoneDef.quests[availableQuest.questItemHash];
   const displayProperties: DestinyDisplayPropertiesDefinition =
     questDef.displayProperties || milestoneDef.displayProperties;
-
   let activityDef: DestinyActivityDefinition | null = null;
   let modifiers: DestinyActivityModifierDefinition[] = [];
   if (availableQuest.activity) {
@@ -41,6 +40,7 @@ export default function AvailableQuest({
       modifiers = availableQuest.activity.modifierHashes.map((h) => defs.ActivityModifier.get(h));
     }
   }
+  const activityName = activityDef && activityDef.displayProperties.name;
 
   // Only look at the first reward, the rest are screwy (old engram versions, etc)
   const questRewards = questDef.questRewards
@@ -84,8 +84,8 @@ export default function AvailableQuest({
       </div>
       <div className="milestone-info">
         <span className="milestone-name">{displayProperties.name}</span>
-        {activityDef && activityDef.displayProperties.name !== displayProperties.name && (
-          <div className="milestone-location">{activityDef.displayProperties.name}</div>
+        {activityName !== displayProperties.name && (
+          <div className="milestone-location">{activityName}</div>
         )}
         <div className="milestone-description">{displayProperties.description}</div>
         <div className="quest-modifiers">

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -5,6 +5,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
 import WellRestedPerkIcon from './WellRestedPerkIcon';
 import { Milestone } from './Milestone';
 import _ from 'lodash';
+import idx from 'idx';
 
 /**
  * The list of Milestones for a character. Milestones are different from pursuits and
@@ -54,8 +55,12 @@ function milestonesForProfile(
   profileInfo: DestinyProfileResponse,
   characterId: string
 ): DestinyMilestone[] {
-  const allMilestones: DestinyMilestone[] = profileInfo.characterProgressions.data
-    ? Object.values(profileInfo.characterProgressions.data[characterId].milestones)
+  const profileMilestoneData = idx(
+    profileInfo.characterProgressions,
+    (p) => p.data[characterId].milestones
+  );
+  const allMilestones: DestinyMilestone[] = profileMilestoneData
+    ? Object.values(profileMilestoneData)
     : [];
 
   const filteredMilestones = allMilestones.filter((milestone) => {
@@ -63,7 +68,6 @@ function milestonesForProfile(
       !milestone.availableQuests &&
       !milestone.activities &&
       (milestone.vendors || milestone.rewards) &&
-      defs &&
       defs.Milestone.get(milestone.milestoneHash)
     );
   });
@@ -79,15 +83,16 @@ function milestonesForCharacter(
   profileInfo: DestinyProfileResponse,
   character: DimStore
 ): DestinyMilestone[] {
-  const allMilestones: DestinyMilestone[] =
-    profileInfo.characterProgressions &&
-    profileInfo.characterProgressions.data &&
-    profileInfo.characterProgressions.data[character.id]
-      ? Object.values(profileInfo.characterProgressions.data[character.id].milestones)
-      : [];
+  const characterMilestoneData = idx(
+    profileInfo.characterProgressions,
+    (p) => p.data[character.id].milestones
+  );
+  const allMilestones: DestinyMilestone[] = characterMilestoneData
+    ? Object.values(characterMilestoneData)
+    : [];
 
   const filteredMilestones = allMilestones.filter((milestone) => {
-    const def = defs && defs.Milestone.get(milestone.milestoneHash);
+    const def = defs.Milestone.get(milestone.milestoneHash);
     return (
       def &&
       (def.showInExplorer || def.showInMilestones) &&

--- a/src/app/progress/Raids.tsx
+++ b/src/app/progress/Raids.tsx
@@ -39,18 +39,11 @@ export default function Raids({
 
   // filter to milestones with child activities of type <ActivityType "Raid" 2043403989>
   const filteredMilestones = allMilestones.filter((milestone) => {
-    const milestoneActivities = idx(
-      defs.Milestone.get(milestone.milestoneHash),
-      (m) => m.activities
-    );
+    const milestoneActivities = (defs.Milestone.get(milestone.milestoneHash) || {}).activities;
     return (
       milestoneActivities &&
       milestoneActivities.some((activity) => {
-        const activityTypeHash = idx(
-          defs.Activity.get(activity.activityHash),
-          (a) => a.activityTypeHash
-        );
-        return activityTypeHash === 2043403989;
+        return (defs.Activity.get(activity.activityHash) || {}).activityTypeHash === 2043403989;
       })
     );
   });

--- a/src/app/progress/Reward.tsx
+++ b/src/app/progress/Reward.tsx
@@ -11,11 +11,13 @@ export function Reward({
   reward: DestinyItemQuantity;
   defs: D2ManifestDefinitions;
 }) {
+  const rewardDisplay = defs.InventoryItem.get(reward.itemHash).displayProperties;
+
   return (
     <div className="milestone-reward">
-      <BungieImage src={defs.InventoryItem.get(reward.itemHash).displayProperties.icon} />
+      <BungieImage src={rewardDisplay.icon} />
       <span>
-        {defs.InventoryItem.get(reward.itemHash).displayProperties.name}
+        {rewardDisplay.name}
         {reward.quantity > 1 && ` +${reward.quantity}`}
       </span>
     </div>

--- a/src/app/progress/RewardActivity.tsx
+++ b/src/app/progress/RewardActivity.tsx
@@ -19,7 +19,8 @@ export default function RewardActivity({
   rewardEntry: DestinyMilestoneRewardEntry;
   milestoneRewardDef: DestinyMilestoneRewardCategoryDefinition;
 }) {
-  const rewardDef = milestoneRewardDef.rewardEntries[rewardEntry.rewardEntryHash];
+  const rewardDisplay =
+    milestoneRewardDef.rewardEntries[rewardEntry.rewardEntryHash].displayProperties;
 
   const checkIcon = rewardEntry.redeemed
     ? redeemedIcon
@@ -39,8 +40,8 @@ export default function RewardActivity({
       title={tooltip}
     >
       <AppIcon icon={checkIcon} />
-      {rewardDef.displayProperties.icon && <BungieImage src={rewardDef.displayProperties.icon} />}
-      <span>{rewardDef.displayProperties.name}</span>
+      {rewardDisplay.icon && <BungieImage src={rewardDisplay.icon} />}
+      <span>{rewardDisplay.name}</span>
     </div>
   );
 }

--- a/src/app/progress/WellRestedPerkIcon.tsx
+++ b/src/app/progress/WellRestedPerkIcon.tsx
@@ -17,15 +17,11 @@ export default function WellRestedPerkIcon({
     return null;
   }
   const formatter = new Intl.NumberFormat(window.navigator.language);
-  const perkDef = defs.SandboxPerk.get(1519921522);
+  const perkDisplay = defs.SandboxPerk.get(1519921522).displayProperties;
   return (
     <div className="well-rested milestone-quest">
       <div className="milestone-icon">
-        <BungieImage
-          className="perk"
-          src={perkDef.displayProperties.icon}
-          title={perkDef.displayProperties.description}
-        />
+        <BungieImage className="perk" src={perkDisplay.icon} title={perkDisplay.description} />
         <span>
           {formatter.format(wellRestedInfo.progress!)}
           <wbr />/<wbr />
@@ -33,8 +29,8 @@ export default function WellRestedPerkIcon({
         </span>
       </div>
       <div className="milestone-info">
-        <span className="milestone-name">{perkDef.displayProperties.name}</span>
-        <div className="milestone-description">{perkDef.displayProperties.description}</div>
+        <span className="milestone-name">{perkDisplay.name}</span>
+        <div className="milestone-description">{perkDisplay.description}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
imported `idx` where it would help save some lines and clarify code and could be used more than once
used `idx()` where code indexed into objects at least 2 keys deep

this covers everything in src/app that suggested itself by having a bunch of chained `&&`s. filters is full of them but they are not really compatible since `includes`, `some`, etc alert about typing issues

cleaned up some small react elements to use an intermediate variable instead of indexing into displayProperties repeatedly

didn't touch a few d1 specific files since i have no way of verifying working, and some of the logic is head scratchy to me
