### PR TITLE
Preserve item notes when performing a bulk tag

### DIFF
--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -119,7 +119,10 @@ export class ItemInfoSource {
     return getInfos(this.key).then((infos) => {
       items.forEach((item) => {
         const key = `${item.hash}-${item.id}`;
-        infos[key] = { tag: item.dimInfo.tag };
+        infos[key] = {
+          tag: item.dimInfo.tag,
+          notes: item.dimInfo.notes
+        };
         store.dispatch(setTagsAndNotesForItem({ key, info: infos[key] }));
       });
       return setInfos(this.key, infos);


### PR DESCRIPTION
This PR fixes a bug whereby an item's notes are cleared when performing a bulk tag operation.

![dim-fix-bulk-tag-item-notes](https://user-images.githubusercontent.com/17512262/61177897-ffffae00-a633-11e9-8beb-4b0a2d444f8e.gif)


Note that this only happens when performing a bulk tag from the search bar, **not** when setting an item's tag directly from the item details popup.