### PR TITLE
Accept a wider variety of browsers as long as it's Chrome or Safari underneath

### DIFF
--- a/src/browsercheck.js
+++ b/src/browsercheck.js
@@ -9,10 +9,7 @@ function getBrowserName(agent) {
     return 'and_chr';
   } else if (agent.browser.name === 'Firefox' && agent.os.name === 'Android') {
     return 'and_ff';
-  } else if (
-    agent.browser.name === 'Mobile Safari' ||
-    (agent.browser.name === 'Safari' && agent.os.name === 'iOS')
-  ) {
+  } else if (agent.browser.name === 'Mobile Safari' || agent.os.name === 'iOS') {
     return 'ios_saf';
   } else if (agent.browser.name === 'Chromium') {
     return 'chrome';
@@ -23,6 +20,14 @@ function getBrowserName(agent) {
 }
 
 function getBrowserVersionFromUserAgent(agent) {
+  if (agent.os.name !== 'Android') {
+    // Detect anything based on chrome as if it were chrome
+    var chromeMatch = /Chrome\/(\d+)/.exec(agent.ua);
+    if (chromeMatch) {
+      return 'chrome ' + chromeMatch[1];
+    }
+  }
+
   var browserName = getBrowserName(agent);
   var version = (browserName === 'ios_saf'
     ? agent.os.version
@@ -40,17 +45,14 @@ function getBrowserVersionFromUserAgent(agent) {
 }
 
 var agent = parser(navigator.userAgent);
-if (agent !== 'Vivaldi') {
-  // Vivaldi users can just live on the edge
-  var browsersSupported = browserslist($BROWSERS);
-  var browser = getBrowserVersionFromUserAgent(agent);
-  var supported = browsersSupported.indexOf(browser) >= 0;
+var browsersSupported = browserslist($BROWSERS);
+var browser = getBrowserVersionFromUserAgent(agent);
+var supported = browsersSupported.indexOf(browser) >= 0;
 
-  if (!supported) {
-    console.warn(
-      'Browser ' + browser + ' is not supported by DIM. Supported browsers:',
-      browsersSupported
-    );
-    document.getElementById('browser-warning').className = '';
-  }
+if (!supported) {
+  console.warn(
+    'Browser ' + browser + ' is not supported by DIM. Supported browsers:',
+    browsersSupported
+  );
+  document.getElementById('browser-warning').className = '';
 }


### PR DESCRIPTION
This short-circuits the browser check process if we think the browser is based on Chrome (Blink) or Mobile Safari underneath. This should end up supporting a lot more browsers like Edge Chromium, Vivaldi, Opera, Firefox Mobile, etc.

Fixes #3936.