### PR TITLE
Progress bars, badges/seals, tracked triumph

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,10 @@
 * Updated our shop link to point to our new store with DIM logo clothing and mugs.
 * The Weekly Clan Engrams milestone will hide when all rewards have been redeemed.
 * Moved raids below quests.
+* Pursuits in the progress page now show exact progress numbers if the pursuit only has a single progress bar.
+* Show tracked Triumph.
 * Mark a wider variety of Chrome-based browsers as supported.
+* Added Seals and Badges to Triumphs/Collections.
 
 # 5.36.2 (2019-07-11)
 

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -77,9 +77,6 @@ export function getProgression(platform: DestinyAccount): Promise<DestinyProfile
     DestinyComponentType.Characters,
     DestinyComponentType.CharacterProgressions,
     DestinyComponentType.ProfileInventories,
-    DestinyComponentType.CharacterInventories,
-    DestinyComponentType.ItemObjectives,
-    DestinyComponentType.ItemSockets,
     DestinyComponentType.Records
   );
 }

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -157,6 +157,14 @@ class Collections extends React.Component<Props, State> {
               plugSetHashes={plugSetHashes}
               openedPresentationHash={presentationNodeHash}
             />
+            <PresentationNodeRoot
+              presentationNodeHash={498211331}
+              defs={defs}
+              profileResponse={profileResponse}
+              buckets={buckets}
+              ownedItemHashes={ownedItemHashes}
+              openedPresentationHash={presentationNodeHash}
+            />
           </div>
         </ErrorBoundary>
         <div className="collections-partners">

--- a/src/app/collections/PresentationNode.scss
+++ b/src/app/collections/PresentationNode.scss
@@ -59,7 +59,7 @@
 
 .records {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   grid-gap: 8px;
   margin: 8px 0;
 }

--- a/src/app/collections/PresentationNode.scss
+++ b/src/app/collections/PresentationNode.scss
@@ -25,7 +25,6 @@
   .node-name {
     img {
       height: 24px;
-      width: 24px;
       vertical-align: middle;
     }
   }

--- a/src/app/collections/PresentationNodeRoot.tsx
+++ b/src/app/collections/PresentationNodeRoot.tsx
@@ -11,7 +11,8 @@ import { count } from '../util';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import PlugSet from './PlugSet';
 import _ from 'lodash';
-import { getRecordComponent } from './Record';
+import Record, { getRecordComponent } from './Record';
+import idx from 'idx';
 
 interface Props {
   presentationNodeHash: number;
@@ -62,8 +63,16 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
 
     const collectionCounts = countCollectibles(defs, presentationNodeHash, profileResponse);
 
+    const trackedRecordHash = idx(profileResponse, (p) => p.profileRecords.data.trackedRecordHash);
+
     return (
       <>
+        {presentationNodeHash === 1024788583 && !!trackedRecordHash && (
+          <div className="records">
+            <Record recordHash={trackedRecordHash} defs={defs} profileResponse={profileResponse} />
+          </div>
+        )}
+
         <PresentationNode
           collectionCounts={collectionCounts}
           presentationNodeHash={presentationNodeHash}

--- a/src/app/collections/Record.scss
+++ b/src/app/collections/Record.scss
@@ -3,7 +3,7 @@
 .triumph-record {
   background: #282828;
   border: 1px solid #666;
-  padding: 8px 8px 8px 4px;
+  padding: 12px;
   display: flex;
   flex-direction: row;
 
@@ -34,6 +34,7 @@
   .record-value {
     float: right;
     color: #a1a2a2;
+    margin-left: 4px;
   }
 
   &.obscured h3 {
@@ -43,6 +44,7 @@
   &.redeemed {
     border-color: $gold;
     background-color: scale-color($gold, $alpha: -90%);
+    opacity: 0.7;
     .record-value {
       display: none;
     }
@@ -50,6 +52,25 @@
 
   &.unlocked {
     border-color: $blue;
+  }
+
+  &.tracked {
+    position: relative;
+    border-color: #bdfc7f;
+    border-width: 2px;
+    background: linear-gradient(
+      scale-color(#bdfc7f, $alpha: -100%) 0%,
+      scale-color(#bdfc7f, $alpha: -90%) 100%
+    );
+  }
+
+  .trackedIcon {
+    position: absolute;
+    display: block;
+    width: calc(var(--item-size) / 3.1) !important;
+    height: auto !important;
+    right: 50px;
+    top: -2px;
   }
 
   .record-lore img {
@@ -61,6 +82,6 @@
     width: 40px;
     height: 40px;
     flex-shrink: 0;
-    margin-right: 4px;
+    margin-right: 8px;
   }
 }

--- a/src/app/collections/Record.tsx
+++ b/src/app/collections/Record.tsx
@@ -15,6 +15,8 @@ import BungieImage from '../dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
 import ishtarIcon from '../../images/ishtar-collective.svg';
 import ExternalLink from '../dim-ui/ExternalLink';
+import idx from 'idx';
+import trackedIcon from 'images/trackedIcon.svg';
 
 interface Props {
   recordHash: number;
@@ -38,6 +40,8 @@ export default class Record extends React.Component<Props> {
     const acquired = Boolean(record.state & DestinyRecordState.RecordRedeemed);
     const unlocked = !acquired && !(record.state & DestinyRecordState.ObjectiveNotCompleted);
     const obscured = !unlocked && !acquired && Boolean(record.state & DestinyRecordState.Obscured);
+    const tracked =
+      idx(profileResponse, (p) => p.profileRecords.data.trackedRecordHash) === recordHash;
     const loreLink =
       !obscured &&
       recordDef.loreHash &&
@@ -62,7 +66,8 @@ export default class Record extends React.Component<Props> {
         className={classNames('triumph-record', {
           redeemed: acquired,
           unlocked,
-          obscured
+          obscured,
+          tracked
         })}
       >
         {recordDef.displayProperties.icon && (
@@ -91,6 +96,7 @@ export default class Record extends React.Component<Props> {
               <ExternalLink href={loreLink}>{t('MovePopup.ReadLore')}</ExternalLink>
             </div>
           )}
+          {tracked && <img className="trackedIcon" src={trackedIcon} />}
         </div>
       </div>
     );

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -12,9 +12,6 @@ import ItemTalentGrid from './ItemTalentGrid';
 import { AppIcon } from '../shell/icons';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import ItemDescription from './ItemDescription';
-import { SupplementalObjectives } from 'app/progress/SupplementalObjectives';
-import Objective from 'app/progress/Objective';
-import { D2SupplementalManifestDefinitions } from 'app/progress/D2SupplementalManifestDefinitions';
 import ItemExpiration from './ItemExpiration';
 import { Reward } from 'app/progress/Reward';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
@@ -102,15 +99,7 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
         </div>
       )}
 
-      <ItemObjectives objectives={item.objectives} defs={defs} />
-
-      {SupplementalObjectives.get(item.hash).map((objective) => (
-        <Objective
-          defs={D2SupplementalManifestDefinitions}
-          objective={objective}
-          key={objective.objectiveHash}
-        />
-      ))}
+      <ItemObjectives itemHash={item.hash} objectives={item.objectives} defs={defs} />
 
       {item.isDestiny2() && item.flavorObjective && (
         <div className="item-objectives item-details">

--- a/src/app/item-popup/ItemObjectives.tsx
+++ b/src/app/item-popup/ItemObjectives.tsx
@@ -21,57 +21,60 @@ export default function ItemObjectives({
   objectives: DimObjective[] | null;
   defs?: D2ManifestDefinitions;
 }) {
-  if (!objectives || !objectives.length) {
+  const supplementalObjectives = SupplementalObjectives.get(itemHash);
+
+  if ((!objectives || !objectives.length) && !supplementalObjectives.length) {
     return null;
   }
 
   return (
     <div className="item-objectives item-details">
-      {objectives.map((objective) => (
-        <div
-          key={objective.displayName}
-          title={objective.description}
-          className={classNames('objective-row', {
-            'objective-complete': objective.complete,
-            'objective-boolean': objective.boolean
-          })}
-        >
-          {objective.displayStyle === 'trials' ? (
-            <div>
-              {_.times(objective.completionValue, ($index) => (
-                <AppIcon
-                  icon={faCircle}
-                  className={classNames('trials', {
-                    incomplete: $index >= objective.progress,
-                    wins: objective.completionValue === 9
-                  })}
-                />
-              ))}
-              {objective.completionValue === 9 && objective.progress > 9 && (
-                <span>+ {objective.progress - 9}</span>
-              )}
-            </div>
-          ) : objective.displayStyle === 'integer' ? (
-            <div className="objective-integer">
-              <ObjectiveDescription displayName={objective.displayName} defs={defs} />
-              <div className="objective-text">{objective.display}</div>
-            </div>
-          ) : (
-            <>
-              <div className="objective-checkbox" />
-              <div className="objective-progress">
-                <div
-                  className="objective-progress-bar"
-                  style={{ width: percent(objective.progress / objective.completionValue) }}
-                />
+      {objectives &&
+        objectives.map((objective) => (
+          <div
+            key={objective.displayName}
+            title={objective.description}
+            className={classNames('objective-row', {
+              'objective-complete': objective.complete,
+              'objective-boolean': objective.boolean
+            })}
+          >
+            {objective.displayStyle === 'trials' ? (
+              <div>
+                {_.times(objective.completionValue, ($index) => (
+                  <AppIcon
+                    icon={faCircle}
+                    className={classNames('trials', {
+                      incomplete: $index >= objective.progress,
+                      wins: objective.completionValue === 9
+                    })}
+                  />
+                ))}
+                {objective.completionValue === 9 && objective.progress > 9 && (
+                  <span>+ {objective.progress - 9}</span>
+                )}
+              </div>
+            ) : objective.displayStyle === 'integer' ? (
+              <div className="objective-integer">
                 <ObjectiveDescription displayName={objective.displayName} defs={defs} />
                 <div className="objective-text">{objective.display}</div>
               </div>
-            </>
-          )}
-        </div>
-      ))}
-      {SupplementalObjectives.get(itemHash).map((objective) => (
+            ) : (
+              <>
+                <div className="objective-checkbox" />
+                <div className="objective-progress">
+                  <div
+                    className="objective-progress-bar"
+                    style={{ width: percent(objective.progress / objective.completionValue) }}
+                  />
+                  <ObjectiveDescription displayName={objective.displayName} defs={defs} />
+                  <div className="objective-text">{objective.display}</div>
+                </div>
+              </>
+            )}
+          </div>
+        ))}
+      {supplementalObjectives.map((objective) => (
         <Objective
           defs={D2SupplementalManifestDefinitions}
           objective={objective}

--- a/src/app/item-popup/ItemObjectives.tsx
+++ b/src/app/item-popup/ItemObjectives.tsx
@@ -8,11 +8,16 @@ import './ItemObjectives.scss';
 import ObjectiveDescription from '../progress/ObjectiveDescription';
 import { percent } from '../shell/filters';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
+import { SupplementalObjectives } from 'app/progress/SupplementalObjectives';
+import Objective from 'app/progress/Objective';
+import { D2SupplementalManifestDefinitions } from 'app/progress/D2SupplementalManifestDefinitions';
 
 export default function ItemObjectives({
+  itemHash,
   objectives,
   defs
 }: {
+  itemHash: number;
   objectives: DimObjective[] | null;
   defs?: D2ManifestDefinitions;
 }) {
@@ -65,6 +70,13 @@ export default function ItemObjectives({
             </>
           )}
         </div>
+      ))}
+      {SupplementalObjectives.get(itemHash).map((objective) => (
+        <Objective
+          defs={D2SupplementalManifestDefinitions}
+          objective={objective}
+          key={objective.objectiveHash}
+        />
       ))}
     </div>
   );

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -73,8 +73,13 @@ class ItemSockets extends React.Component<Props> {
       return null;
     }
 
+    // Lay out Chalice of Opulence and Synthesizers a bit differently
+    const chalice = [1115550924, 1160544508, 1160544509, 1160544511, 3633698719].includes(
+      item.hash
+    );
+
     return (
-      <div className={classNames('item-details', 'sockets', { chalice: item.hash === 1115550924 })}>
+      <div className={classNames('item-details', 'sockets', { chalice })}>
         {item.sockets.categories.map(
           (category, index) =>
             (!hideMods || index === 0) &&

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -236,6 +236,11 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets }: Props) {
               defs={defs}
               profileResponse={profileInfo}
             />
+            <PresentationNodeRoot
+              presentationNodeHash={1652422747}
+              defs={defs}
+              profileResponse={profileInfo}
+            />
           </ErrorBoundary>
         </section>
         <hr />

--- a/src/app/progress/Pursuit.tsx
+++ b/src/app/progress/Pursuit.tsx
@@ -27,7 +27,7 @@ export default function Pursuit({ item }: { item: DimItem }) {
         {!item.complete && !expired && item.percentComplete > 0 && (
           <span>
             {item.objectives && showObjectiveDetail
-              ? `${item.objectives[0].progress}/${item.objectives[0].completionValue}`
+              ? `${item.objectives[0].progress.toLocaleString()}/${item.objectives[0].completionValue.toLocaleString()}`
               : percent(item.percentComplete)}
           </span>
         )}

--- a/src/app/progress/Pursuit.tsx
+++ b/src/app/progress/Pursuit.tsx
@@ -11,6 +11,13 @@ import { percent } from 'app/shell/filters';
  */
 export default function Pursuit({ item }: { item: DimItem }) {
   const expired = showPursuitAsExpired(item);
+
+  const showObjectiveDetail =
+    item.objectives &&
+    item.objectives.length === 1 &&
+    !item.objectives[0].boolean &&
+    item.objectives[0].displayStyle !== 'integer';
+
   return (
     <div className="milestone-quest" key={item.index}>
       <div className="milestone-icon">
@@ -18,7 +25,11 @@ export default function Pursuit({ item }: { item: DimItem }) {
           <PursuitItem item={item} />
         </ItemPopupTrigger>
         {!item.complete && !expired && item.percentComplete > 0 && (
-          <span>{percent(item.percentComplete)}</span>
+          <span>
+            {item.objectives && showObjectiveDetail
+              ? `${item.objectives[0].progress}/${item.objectives[0].completionValue}`
+              : percent(item.percentComplete)}
+          </span>
         )}
       </div>
       <div className="milestone-info">

--- a/src/app/progress/PursuitItem.tsx
+++ b/src/app/progress/PursuitItem.tsx
@@ -12,6 +12,7 @@ import { showPursuitAsExpired } from './Pursuit';
 import { RootState } from 'app/store/reducers';
 import { searchFilterSelector } from 'app/search/search-filters';
 import { connect } from 'react-redux';
+import { count } from 'app/util';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -45,7 +46,9 @@ function PursuitItem({ item, isNew, searchHidden }: Props) {
     item.objectives.length > 0 &&
     !item.complete &&
     !expired &&
-    item.objectives.some((o) => o.displayStyle !== 'integer');
+    // Either there's a counter progress bar, or multiple checkboxes
+    (item.objectives.some((o) => o.displayStyle !== 'integer' && !o.boolean) ||
+      count(item.objectives, (o) => o.boolean) > 1);
   const itemImageStyles = {
     'search-hidden': searchHidden,
     [styles.tracked]: item.tracked

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -42,7 +42,7 @@ export default function Pursuits({
   // that represent milestones.
   const filteredItems = store.buckets[1345459588].concat(
     // Include prophecy tablets, which are in consumables
-    store.buckets[1345459588].filter((item) => item.itemCategoryHashes.includes(2250046497))
+    store.buckets[1469714392].filter((item) => item.itemCategoryHashes.includes(2250046497))
   );
 
   const pursuits = _.groupBy(filteredItems, (item) => {

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -55,7 +55,7 @@
 
     // HACK
     .item-details {
-      margin: 2px 0 0 0;
+      margin: 2px 0 0 4px;
     }
 
     // ALSOHACK


### PR DESCRIPTION
* Added Badges/Seals to Triumphs/Collections.
* Added the tracked triumph just above Triumphs (Triumphs displays are weird so it's hard to put it under the collapsing title, I need to redo all that).
* Style tracked Triumph and update Triumphs styling a bit.
* Remove progress bars from single-step Pursuits.
* Add exact progress numbers from single-progress-bar Pursuits.

<img width="496" alt="Screen Shot 2019-07-14 at 8 45 34 PM" src="https://user-images.githubusercontent.com/313208/61194764-7de5a880-a678-11e9-807a-9dcfffdd4b00.png">
<img width="1166" alt="Screen Shot 2019-07-14 at 8 45 42 PM" src="https://user-images.githubusercontent.com/313208/61194765-7de5a880-a678-11e9-8a5f-d6e91287d0b3.png">
