### PR TITLE
Replace accounts menu dropdown triangle with an icon

### DIFF
--- a/src/app/accounts/account-select.scss
+++ b/src/app/accounts/account-select.scss
@@ -33,13 +33,12 @@
 
   &.selected-account {
     margin: 0 0 0 2px;
-    padding-right: 22px;
+    padding-right: 24px;
     border-bottom: 2px solid $orange;
     height: 100%;
     box-sizing: border-box;
 
-    &::after {
-      content: '▼';
+    .app-icon {
       position: absolute;
       right: 7px;
       top: 13px;

--- a/src/app/accounts/account-select.tsx
+++ b/src/app/accounts/account-select.tsx
@@ -8,7 +8,7 @@ import { getPlatforms } from './platform.service';
 import classNames from 'classnames';
 import { UISref } from '@uirouter/react';
 import { router } from '../../router';
-import { AppIcon, signOutIcon } from '../shell/icons';
+import { AppIcon, signOutIcon, collapseIcon } from '../shell/icons';
 import { loadAccountsFromIndexedDB, currentAccountSelector, accountsSelector } from './reducer';
 import { connect } from 'react-redux';
 import { RootState } from 'app/store/reducers';
@@ -16,16 +16,23 @@ import { RootState } from 'app/store/reducers';
 function AccountComp(
   {
     account,
+    selected,
     className,
     ...other
   }: {
     account: DestinyAccount;
+    selected?: boolean;
     className?: string;
   } & React.HTMLAttributes<HTMLDivElement>,
   ref?: React.Ref<HTMLDivElement>
 ) {
   return (
-    <div ref={ref} className={classNames('account', className)} {...other} role="menuitem">
+    <div
+      ref={ref}
+      className={classNames('account', className, { 'selected-account': selected })}
+      {...other}
+      role="menuitem"
+    >
       <div className="account-name">
         Destiny {account.destinyVersion === 1 ? '1' : '2'} •{' '}
         <span>{t(`Accounts.${account.platformLabel}`)}</span>
@@ -36,6 +43,7 @@ function AccountComp(
         */}
       </div>
       <div className="account-details">{account.displayName}</div>
+      {selected && <AppIcon className="collapse" icon={collapseIcon} />}
     </div>
   );
 }
@@ -101,7 +109,7 @@ class AccountSelect extends React.Component<Props, State> {
     return (
       <div className="account-select">
         <Account
-          className="selected-account"
+          selected={true}
           ref={this.dropdownToggler}
           account={currentAccount}
           onClick={this.toggleDropdown}


### PR DESCRIPTION
<img width="146" alt="Screen Shot 2019-07-15 at 9 39 08 PM" src="https://user-images.githubusercontent.com/313208/61266493-dedcb180-a748-11e9-8a30-eb28600387dd.png">

Minor change that replaces the triangle in the accounts dropdown.