### PR TITLE
Prevent Sheet drag from item-tag-selector (safari), fixes #3942

### DIFF
--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -153,6 +153,11 @@ class Sheet extends React.Component<Props & GestureState> {
   private dragHandleDown = (
     e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
   ) => {
+    // prevent item-tag-selector dropdown from triggering drag (Safari)
+    if ((e.target as HTMLElement).classList.contains('item-tag-selector')) {
+      return;
+    }
+
     if (
       this.dragHandle.current!.contains(e.target as Node) ||
       this.sheetContents.current!.scrollTop === 0


### PR DESCRIPTION
This is my attempt at addressing #3942 
There may be a more elegant solution, but this worked fine for me locally. I'm also not really familiar with TypeScript (or React for that matter) so open to any and all feedback here.
