### PR TITLE
Display filtered item count in search bar

### DIFF
--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -165,6 +165,9 @@ class SearchFilter extends React.Component<Props, State> {
         onClear={this.clearFilter}
       >
         <>
+          <span className="filter-match-count">
+            {t('Header.FilterMatchCount', { count: filteredItems.length })}
+          </span>
           {isComparable && (
             <span className="filter-help">
               <a onClick={this.compareMatching}>

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -142,6 +142,14 @@
   }
 }
 
+.filter-match-count {
+  color: #999;
+
+  @media (max-width: 1445px) {
+    display: none;
+  }
+}
+
 /* Textcomplete */
 
 .dropdown-menu {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -312,6 +312,8 @@
     "CompareMatching": "Compare filtered items",
     "FilterHelp": "Search item/perk or {{example}}",
     "FilterHelpBrief": "Search items",
+    "FilterMatchCount": "1 item",
+    "FilterMatchCount_plural": "{{count}} items",
     "Filters": "Filters",
     "InstallDIM": "Install DIM",
     "Inventory": "Inventory",


### PR DESCRIPTION
This PR displays the number of items that match the current search filter. This closes #4001 and closes #3478.

![dim-search-match-count-2](https://user-images.githubusercontent.com/17512262/61369850-1f713200-a8e5-11e9-92aa-908c3c56449c.gif)
