### PR TITLE
localhost url & reference to lodash vs underscore

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Here are some tips to make sure your pull request can be merged smoothly:
 1. If you want to add a feature or make some change to DIM, consider [filing an issue](https://github.com/DestinyItemManager/DIM/issues/new) describing your idea first. This will give the DIM community a chance to discuss the idea, offer suggestions and pointers, and make sure what you're thinking of fits with the style and direction of DIM. If you want a more free-form chat, [join our Discord](https://discordapp.com/invite/UK2GWC7).
 1. Resist the temptation to change more than one thing in your PR. Keeping PRs focused on a single change makes them much easier to review and accept. If you want to change multiple things, or clean up/refactor the code, make a new branch and submit those changes as a separate PR.
 1. All of our code is written in [TypeScript](https://typescriptlang.org) and uses React to build UI components..
-1. Take advantage of the [native JavaScript Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) and the [Underscore](http://underscorejs.org) library to write compact, easy-to-understand code.
+1. Take advantage of the [native JavaScript Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) and the [Lodash](https://lodash.com/) library to write compact, easy-to-understand code.
 1. Be sure to run `yarn run lint` before submitting your PR - it'll catch most style problems and make things much easier to merge.
 1. Don't forget to add a description of your change to `CHANGELOG.md` so it'll be included in the release notes!
 
@@ -55,14 +55,14 @@ Here are some tips to make sure your pull request can be merged smoothly:
 This step will need to be done each time you clear your browser cache. You will be automatically redirected to a screen to enter these credentials
 if the app can't load them from local storage when it starts.
 
-1. Open your browser and navigate to [https://localhost:8080]()
+1. Open your browser and navigate to https://localhost:8080
 1. Copy your API-key, Oauth Client_id, and OAuth client_secret from bungie.net into DIM developer settings panel when it is loaded.
 
 ### Development
 
 **Overview**
 
-The `yarn start` step will create a hot-loading webserver, and a TLS cert/key pair. You will access your local development site by visiting [https://localhost:8080]().
+The `yarn start` step will create a hot-loading webserver, and a TLS cert/key pair. You will access your local development site by visiting https://localhost:8080.
 You will likely get a security warning about the certificate not being trusted. This is because it's a self-signed cert generated dynamically for your environment,
 and is not signed by a recognized authority. Dismass/advance past these warning to view your local DIM application.
 


### PR DESCRIPTION
the localhost links currently re-direct to the [docs folder](https://github.com/DestinyItemManager/DIM/tree/master/docs) and we use lodash now