### PR TITLE
Remove duplicate is:kinetic and not:kinetic filters from search text completion

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -331,7 +331,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
 
   return {
     keywordToFilter,
-    keywords,
+    keywords: [...new Set(keywords)],
     destinyVersion,
     categoryHashFilters
   };


### PR DESCRIPTION
This PR fixes a bug whereby two `is:kinetic` and `not:kinetic` entries appear in the search filter text completion dropdown.

![dim-duplicate-kinetic-filters](https://user-images.githubusercontent.com/17512262/61520501-718b9200-aa62-11e9-8a03-015c7114b398.gif)

The reason two kinetic entries are displayed is because `kinetic` is both a damage type and an item category. My fix is to remove duplicates from the search keywords, but we could alternatively exclude kinetic from either the damage types or item categories.