### PR TITLE
Search improvements

### DIFF
--- a/src/app/search/FilterHelp.scss
+++ b/src/app/search/FilterHelp.scss
@@ -1,6 +1,8 @@
 @import '../../scss/variables.scss';
 
 .filter-view {
+  padding: 0 10px 1em 10px !important;
+
   td span {
     margin: 2px 4px;
     color: #eee;

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -17,7 +17,6 @@ function mapStateToProps(state: RootState) {
 function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
   return (
     <div className="dim-page dim-static-page filter-view">
-      <h1>{t('Header.Filters')}</h1>
       <div>
         <p>{t('Filter.Combine', { example: 'is:arc light:>300' })}</p>
         <p>{t('Filter.Negate', { notexample: '-is:engram' })}</p>

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -148,7 +148,7 @@ export default class SearchFilterInput extends React.Component<Props, State> {
   };
 
   private clearFilter = () => {
-    this.props.onQueryChanged('');
+    this.debouncedUpdateQuery('');
     this.setState({ liveQuery: '' });
     this.textcomplete && this.textcomplete.trigger('');
     this.props.onClear && this.props.onClear();

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -90,7 +90,7 @@ export default class SearchFilterInput extends React.Component<Props, State> {
         <AppIcon icon={searchIcon} />
         <input
           ref={this.inputElement}
-          className="filter-input"
+          className="filter-input mousetrap"
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { t } from 'app/i18next-t';
 import { AppIcon, helpIcon, disabledIcon, searchIcon } from '../shell/icons';
 import _ from 'lodash';
@@ -6,8 +6,10 @@ import './search-filter.scss';
 import Textcomplete from 'textcomplete/lib/textcomplete';
 import Textarea from 'textcomplete/lib/textarea';
 import { SearchConfig } from './search-filters';
-import { UISref } from '@uirouter/react';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
+import Sheet from 'app/dim-ui/Sheet';
+import ReactDOM from 'react-dom';
+import { Loading } from 'app/dim-ui/Loading';
 
 interface ProvidedProps {
   alwaysShowClearButton?: boolean;
@@ -24,14 +26,19 @@ type Props = ProvidedProps;
 
 interface State {
   liveQuery: string;
+  filterHelpOpen: boolean;
 }
+
+const LazyFilterHelp = React.lazy(() =>
+  import(/* webpackChunkName: "filter-help" */ './FilterHelp')
+);
 
 /**
  * A reusable, autocompleting item search input. This is an uncontrolled input that
  * announces its query has changed only after some delay.
  */
 export default class SearchFilterInput extends React.Component<Props, State> {
-  state: State = { liveQuery: '' };
+  state: State = { liveQuery: '', filterHelpOpen: false };
   private textcomplete: Textcomplete;
   private inputElement = React.createRef<HTMLInputElement>();
   private debouncedUpdateQuery = _.debounce(this.props.onQueryChanged, 500);
@@ -51,7 +58,7 @@ export default class SearchFilterInput extends React.Component<Props, State> {
 
   render() {
     const { alwaysShowClearButton, placeholder, children } = this.props;
-    const { liveQuery } = this.state;
+    const { liveQuery, filterHelpOpen } = this.state;
 
     return (
       <div className="search-filter" role="search">
@@ -105,11 +112,9 @@ export default class SearchFilterInput extends React.Component<Props, State> {
         />
 
         {liveQuery.length === 0 ? (
-          <UISref to="filters">
-            <span className="filter-help" title={t('Header.Filters')}>
-              <AppIcon icon={helpIcon} />
-            </span>
-          </UISref>
+          <span onClick={this.showFilterHelp} className="filter-help" title={t('Header.Filters')}>
+            <AppIcon icon={helpIcon} />
+          </span>
         ) : (
           children
         )}
@@ -120,6 +125,19 @@ export default class SearchFilterInput extends React.Component<Props, State> {
             </a>
           </span>
         )}
+        {filterHelpOpen &&
+          ReactDOM.createPortal(
+            <Sheet
+              onClose={() => this.setState({ filterHelpOpen: false })}
+              header={<h1>{t('Header.Filters')}</h1>}
+              sheetClassName="filterHelp"
+            >
+              <Suspense fallback={<Loading />}>
+                <LazyFilterHelp />
+              </Suspense>
+            </Sheet>,
+            document.body
+          )}
       </div>
     );
   }
@@ -152,6 +170,10 @@ export default class SearchFilterInput extends React.Component<Props, State> {
     this.setState({ liveQuery: '' });
     this.textcomplete && this.textcomplete.trigger('');
     this.props.onClear && this.props.onClear();
+  };
+
+  private showFilterHelp = () => {
+    this.setState({ filterHelpOpen: true });
   };
 
   private setupTextcomplete = () => {

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -10,6 +10,11 @@
   font-size: 13px;
 }
 
+.filterHelp {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
 .search-filter {
   display: flex;
   flex-direction: row;

--- a/src/app/shell/routes.ts
+++ b/src/app/shell/routes.ts
@@ -1,7 +1,6 @@
 import { ReactStateDeclaration } from '@uirouter/react';
 import About from './About';
 import Support from './Support';
-import FilterHelp from '../search/FilterHelp';
 
 export const states: ReactStateDeclaration[] = [
   {
@@ -13,10 +12,5 @@ export const states: ReactStateDeclaration[] = [
     name: 'support',
     component: Support,
     url: '/backers'
-  },
-  {
-    name: 'filters',
-    component: FilterHelp,
-    url: '/search-help'
   }
 ];

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -333,7 +333,7 @@
     "CheatSheetTitle": "Keyboard Shortcuts:",
     "ClearNewItems": "Clear new items",
     "ClearNewItemsTitle": "Keyboard shortcut: X",
-    "ClearSearch": "Clear search or dismiss dialog",
+    "ClearSearch": "Dismiss dialog or clear focused search input",
     "MarkItemAs": "Mark item as '{{tag}}'",
     "Menu": "Toggle menu",
     "RefreshInventory": "Refresh inventory",


### PR DESCRIPTION
1. Fix an issue where the ESC key wouldn't clear search inputs when they are focused.
2. Switch the clear search button to work async, so it'll appear cleared without having to wait to re-render everything.
3. Move Filter Help into a Sheet, instead of a separate page.

<img width="981" alt="Screen Shot 2019-07-20 at 2 06 31 PM" src="https://user-images.githubusercontent.com/313208/61584119-72bace80-aaf7-11e9-8497-70e3978067b8.png">
