### PR TITLE
Don't attach uninstanced objectives to items

### DIFF
--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -340,10 +340,6 @@ function makeD2StoresService(): D2StoreServiceType {
     // This is pretty much just needed for the xp bar under the character header
     store.progression = progressions ? { progressions: Object.values(progressions) } : null;
 
-    store.uninstancedItemObjectives = uninstancedItemObjectives
-      ? { objectives: uninstancedItemObjectives }
-      : null;
-
     // We work around the weird account-wide buckets by assigning them to the current character
     let items = characterInventory.concat(Object.values(characterEquipment));
     if (store.current) {
@@ -362,7 +358,8 @@ function makeD2StoresService(): D2StoreServiceType {
       previousItems,
       newItems,
       itemInfoService,
-      mergedCollectibles
+      mergedCollectibles,
+      uninstancedItemObjectives
     );
     store.items = processedItems;
     // by type-bucket

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -3,8 +3,7 @@ import {
   DestinyProgression,
   DestinyCharacterComponent,
   DestinyFactionDefinition,
-  DestinyColor,
-  DestinyObjectiveProgress
+  DestinyColor
 } from 'bungie-api-ts/destiny2';
 import { Loadout } from '../loadout/loadout.service';
 import { D1ManifestDefinitions } from '../destiny1/d1-definitions.service';
@@ -105,10 +104,6 @@ export interface DimStore {
   /** Character progression. */
   progression: null | {
     progressions: DestinyProgression[];
-  };
-
-  uninstancedItemObjectives: null | {
-    objectives: { [key: number]: DestinyObjectiveProgress[] };
   };
 
   /** Apply updated character info. */


### PR DESCRIPTION
We didn't need this to be added to `DimStore` - it can just be passed down as an argument.