### PR TITLE
adds lock / unlock  to comparison sheet.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "destiny-icons"]
 	path = destiny-icons
 	url = https://github.com/justrealmilk/destiny-icons
-[submodule "src/data/d2"]
-	path = src/data/d2
-	url = https://github.com/delphiactual/d2-additional-info-module

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DimItem } from '../inventory/item-types';
 import ItemTagSelector from '../item-popup/ItemTagSelector';
+import LockButton from '../item-popup/LockButton';
 import { AppIcon, searchIcon } from '../shell/icons';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import ItemSockets from '../item-popup/ItemSockets';
@@ -26,6 +27,10 @@ export default function CompareItem({
   return (
     <div className="compare-item">
       <div className="compare-item-header">
+        <div className="icon comp-lock-icon">
+          {item.lockable && <LockButton item={item} type="lock" />}
+          {item.isDestiny1() && item.trackable && <LockButton item={item} type="track" />}
+        </div>
         <ItemTagSelector item={item} />
         <div className="close" onClick={() => remove(item)} />
       </div>

--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -58,6 +58,12 @@
 .compare-item {
   border-left: 1px solid $lightgray;
 
+  .comp-lock-icon .app-icon {
+    font-size: 12px;
+    margin: 0 5px 0 2px;
+    vertical-align: middle;
+  }
+
   .item {
     float: right;
     padding: 0 4px 0 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29002828/61596877-e7b10580-abd6-11e9-90ea-4f387919ef82.png)

This adds the ability to lock / unlock from the comparison sheet. only thing I couldn't really figure out is that the green lock icon that appears on an item does not update on the item image inside the comparison sheet automatically. The item in the actual inventory updates fine, but inside the comparison window it only updates if you change the item in some other way (add a tag, remove a tag, remove it from comparison and add it back in, etc.) 

The icon that you click updates fine so the feedback from your action is present. Not sure if making the item image update is super easy and I just couldn't figure it out... but, putting this here for feedback on that piece  