### PR TITLE
add valor resets, workaround Bungie-net/api#986

### DIFF
--- a/src/app/progress/CrucibleRank.tsx
+++ b/src/app/progress/CrucibleRank.tsx
@@ -9,11 +9,15 @@ import _ from 'lodash';
 
 interface CrucibleRankProps {
   progress: DestinyProgression;
+  resets: DestinyProgression;
   defs: D2ManifestDefinitions;
 }
 
+/**
+ * displays a single Crucible or Gambit rank for the account
+ */
 export function CrucibleRank(props: CrucibleRankProps) {
-  const { defs, progress } = props;
+  const { defs, progress, resets } = props;
 
   const progressionDef = defs.Progression.get(progress.progressionHash);
 
@@ -38,9 +42,9 @@ export function CrucibleRank(props: CrucibleRankProps) {
             pct: Math.round((progress.currentProgress / rankTotal) * 100)
           })}
         </div>
-        {!!progress.currentResetCount && (
+        {!!resets.currentResetCount && (
           <div className="faction-level">
-            {t('Progress.Resets', { count: progress.currentResetCount })}
+            {t('Progress.Resets', { count: resets.currentResetCount })}
           </div>
         )}
       </div>

--- a/src/app/progress/Ranks.tsx
+++ b/src/app/progress/Ranks.tsx
@@ -4,7 +4,7 @@ import { CrucibleRank } from './CrucibleRank';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
 
 /**
- * Crucible and Gambit ranks for the account.
+ * displays all Crucible and Gambit ranks for the account
  */
 export default function Ranks({
   profileInfo,
@@ -16,21 +16,36 @@ export default function Ranks({
   const firstCharacterProgression = profileInfo.characterProgressions.data
     ? Object.values(profileInfo.characterProgressions.data)[0].progressions
     : {};
-  const crucibleRanks = [
-    // Valor
-    firstCharacterProgression[2626549951],
-    // Glory
-    firstCharacterProgression[2000925172],
-    // Infamy
-    firstCharacterProgression[2772425241]
+  const activityRanks = [
+    {
+      // Valor
+      progressionInfo: firstCharacterProgression[2626549951],
+      resetInfo: firstCharacterProgression[2679551909] // swapped with glory (Bungie-net/api#986)
+    },
+    {
+      // Glory
+      progressionInfo: firstCharacterProgression[2000925172],
+      resetInfo: firstCharacterProgression[3882308435] // swapped with valor (Bungie-net/api#986)
+    },
+    {
+      // Infamy
+      progressionInfo: firstCharacterProgression[2772425241],
+      resetInfo: firstCharacterProgression[2772425241]
+    }
   ];
 
   return (
     <div className="progress-for-character ranks-for-character">
-      {crucibleRanks.map(
-        (progression) =>
-          progression && (
-            <CrucibleRank key={progression.progressionHash} defs={defs} progress={progression} />
+      {activityRanks.map(
+        (activityRank) =>
+          activityRank.progressionInfo &&
+          activityRank.resetInfo && (
+            <CrucibleRank
+              key={activityRank.progressionInfo.progressionHash}
+              defs={defs}
+              progress={activityRank.progressionInfo}
+              resets={activityRank.resetInfo}
+            />
           )
       )}
     </div>

--- a/src/app/progress/Ranks.tsx
+++ b/src/app/progress/Ranks.tsx
@@ -16,16 +16,39 @@ export default function Ranks({
   const firstCharacterProgression = profileInfo.characterProgressions.data
     ? Object.values(profileInfo.characterProgressions.data)[0].progressions
     : {};
+
+  // there are 2 similar DestinyProgression entries for each crucible point system
+  // progressionInfo contains detailed rank names, resetInfo has valor/infamy resets
+  let valorResetInfo = firstCharacterProgression[3882308435];
+  let gloryResetInfo = firstCharacterProgression[2679551909];
+
+  // this map manually places the progression with currentResetCount into valor and other into glory
+  // remove this and put above values directly into activityRanks once Bungie-net/api#986 is resolved
+  [2679551909, 3882308435].map((progHash) => {
+    if (
+      firstCharacterProgression[progHash] &&
+      firstCharacterProgression[progHash].currentResetCount
+    ) {
+      valorResetInfo = firstCharacterProgression[progHash];
+    }
+    if (
+      firstCharacterProgression[progHash] &&
+      !firstCharacterProgression[progHash].currentResetCount
+    ) {
+      gloryResetInfo = firstCharacterProgression[progHash];
+    }
+  });
+
   const activityRanks = [
     {
       // Valor
       progressionInfo: firstCharacterProgression[2626549951],
-      resetInfo: firstCharacterProgression[2679551909] // swapped with glory (Bungie-net/api#986)
+      resetInfo: valorResetInfo
     },
     {
       // Glory
       progressionInfo: firstCharacterProgression[2000925172],
-      resetInfo: firstCharacterProgression[3882308435] // swapped with valor (Bungie-net/api#986)
+      resetInfo: gloryResetInfo
     },
     {
       // Infamy
@@ -38,8 +61,7 @@ export default function Ranks({
     <div className="progress-for-character ranks-for-character">
       {activityRanks.map(
         (activityRank) =>
-          activityRank.progressionInfo &&
-          activityRank.resetInfo && (
+          activityRank.progressionInfo && (
             <CrucibleRank
               key={activityRank.progressionInfo.progressionHash}
               defs={defs}


### PR DESCRIPTION
closes #4046

uses [`2626549951`](https://data.destinysets.com/i/Progression:2626549951) (Valor) and [`2000925172`](https://data.destinysets.com/i/Progression:2000925172) (Glory)
for sub-rank and current rank numbers,

and [`3882308435`](https://data.destinysets.com/i/Progression:3882308435) (Valor) and [`2679551909`](https://data.destinysets.com/i/Progression:2679551909) (Glory)
for their `currentResetCount` data

valor & glory reset hashes are swapped, until resets are moved to the correct object
( see https://github.com/Bungie-net/api/issues/986 )