### PR TITLE
Show Postmaster capacity

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Display Postmaster capacities. Show warning when Postmaster inventory nears its overwrite limit.
+
 # 5.39.0 (2019-07-28)
 
 * Enabled PWA mode for "Add to Homescreen" in iOS Safari (Requires iOS 12.2 or later). If you already have it on your home screen, delete and re-add it.

--- a/src/app/inventory/PostmasterLimits.scss
+++ b/src/app/inventory/PostmasterLimits.scss
@@ -1,0 +1,25 @@
+.postmaster-limits {
+  border-bottom: 1px solid white;
+  display: flex;
+  flex-direction: row;
+
+  &.redzone {
+    background-color: red;
+    border: none;
+  }
+
+  &.text {
+    align-items: center;
+    justify-content: center;
+    border-bottom: 0px;
+    margin-right: 3px;
+
+    &:first-of-type {
+      margin-right: auto;
+    }
+  }
+
+  .icon {
+    margin: 3px 8px;
+  }
+}

--- a/src/app/inventory/PostmasterLimits.tsx
+++ b/src/app/inventory/PostmasterLimits.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import './PostmasterLimits.scss';
+import { InventoryBucket } from './inventory-buckets';
+import { RootState } from 'app/store/reducers';
+import { AppIcon, warningIcon } from 'app/shell/icons';
+
+// Props provided from parents
+interface ProvidedProps {
+  storeId: string;
+  bucketId: string;
+}
+
+// Props from Redux via mapStateToProps
+interface StoreProps {
+  usedCapacity: number;
+  bucket: InventoryBucket;
+}
+
+function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
+  const { storeId, bucketId } = props;
+  const store = state.inventory.stores.find((s) => s.id === storeId)!;
+
+  return {
+    bucket: state.inventory.buckets!.byId[props.bucketId],
+    usedCapacity: store.buckets[bucketId].length
+  };
+}
+
+type Props = ProvidedProps & StoreProps;
+
+class PostmasterLimits extends React.Component<Props> {
+  REDZONE_LIMIT = 0.85;
+
+  render() {
+    const redzone =
+      this.props.bucket.name === 'Lost Items' &&
+      (this.props.usedCapacity / this.props.bucket.capacity >= this.REDZONE_LIMIT ? true : false);
+
+    return (
+      <div className={'postmaster-limits' + (redzone ? ' redzone' : '')}>
+        {redzone && <AppIcon className="fa-3x icon" icon={warningIcon} />}
+        <div className="postmaster-limits text">{this.props.bucket.name.toUpperCase()}</div>
+        <div className="postmaster-limits text">
+          {this.props.usedCapacity}/{this.props.bucket.capacity}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default connect<StoreProps>(mapStateToProps)(PostmasterLimits);

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { PullFromPostmaster } from './PullFromPostmaster';
 import { hasBadge } from './get-badge-info';
 import { storeBackgroundColor } from '../shell/filters';
+import PostmasterLimits from './PostmasterLimits';
 
 /** One row of store buckets, one for each character and vault. */
 export function StoreBuckets({
@@ -58,6 +59,9 @@ export function StoreBuckets({
         })}
         style={storeBackgroundColor(store, index)}
       >
+        {!store.isVault && (bucket.type === 'Engrams' || bucket.type === 'LostItems') && (
+          <PostmasterLimits bucketId={bucket.id} storeId={store.id} />
+        )}
         {(!store.isVault || bucket.vaultBucket) && (
           <StoreBucket bucketId={bucket.id} storeId={store.id} />
         )}

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -47,7 +47,8 @@ import {
   faHeart,
   faStarHalfAlt,
   faGlobe,
-  faStickyNote
+  faStickyNote,
+  faExclamationTriangle
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
@@ -88,6 +89,7 @@ export {
   faDownload as downloadIcon,
   faEnvelope as sendIcon,
   faEraser as clearIcon,
+  faExclamationTriangle as warningIcon,
   faLevelUpAlt as levellingIcon,
   faLock as lockIcon,
   faUnlock as unlockedIcon,


### PR DESCRIPTION
Issue #2921 
![postmaster](https://user-images.githubusercontent.com/8317282/62170927-36f3e600-b2fb-11e9-83c0-ceb0194e98f7.PNG)

This is not included in the issue, but I added a warning sign display for when Lost Items reaches a percent threshold (currently 85% which is 18 items)

![postmaster-capacity](https://user-images.githubusercontent.com/8317282/62170726-7c63e380-b2fa-11e9-8caa-125a2098a8c3.PNG)

It isn't very sophisticated and can be pulled out and workshopped further if need be.