### PR TITLE
Special orders

### DIFF
--- a/src/app/inventory/d2-stores.service.ts
+++ b/src/app/inventory/d2-stores.service.ts
@@ -332,8 +332,9 @@ function makeD2StoresService(): D2StoreServiceType {
     if (store.current) {
       items = items.concat(
         Object.values(profileInventory).filter((i) => {
+          const bucket = buckets.byHash[i.bucketHash];
           // items that can be stored in a vault
-          return buckets.byHash[i.bucketHash].vaultBucket;
+          return bucket && (bucket.vaultBucket || bucket.type === 'SpecialOrders');
         })
       );
     }
@@ -375,8 +376,9 @@ function makeD2StoresService(): D2StoreServiceType {
     const store = makeVault(profileCurrencies);
 
     const items = Object.values(profileInventory).filter((i) => {
+      const bucket = buckets.byHash[i.bucketHash];
       // items that cannot be stored in the vault, and are therefore *in* a vault
-      return buckets.byHash[i.bucketHash] && !buckets.byHash[i.bucketHash].vaultBucket;
+      return bucket && !bucket.vaultBucket && bucket.type !== 'SpecialOrders';
     });
     const processedItems = await processItems(
       store,

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -300,7 +300,10 @@ export function makeItem(
   // We cheat a bit for items in the vault, since we treat the
   // vault as a character. So put them in the bucket they would
   // have been in if they'd been on a character.
-  if ((owner && owner.isVault) || item.location === ItemLocation.Vault) {
+  if (
+    !currentBucket.inPostmaster &&
+    ((owner && owner.isVault) || item.location === ItemLocation.Vault)
+  ) {
     currentBucket = normalBucket;
   }
 


### PR DESCRIPTION
Special orders come down as profile inventory for a non-vaultable bucket, and as a result we stick them in their normal location (which weirdly enough is mods). This fixes them to show up in postmaster, albeit a bit weirdly since they're account-wide.

<img width="1050" alt="Screen Shot 2019-08-01 at 8 15 11 PM" src="https://user-images.githubusercontent.com/313208/62341622-e2866d00-b498-11e9-9ab9-1c3d4298915c.png">
