### PR TITLE
Improve idb-keyval for iOS PWA

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -231,7 +231,8 @@ module.exports = (env) => {
         app: path.resolve('./src/app/'),
         data: path.resolve('./src/data/'),
         images: path.resolve('./src/images/'),
-        'destiny-icons': path.resolve('./destiny-icons/')
+        'destiny-icons': path.resolve('./destiny-icons/'),
+        'idb-keyval': path.resolve('./src/app/storage/idb-keyval.ts')
       }
     },
 

--- a/src/app/inventory/store/new-items.service.ts
+++ b/src/app/inventory/store/new-items.service.ts
@@ -60,7 +60,7 @@ export const NewItemsService = {
   loadNewItems(account: DestinyAccount): Promise<Set<string>> {
     if (account) {
       const key = newItemsKey(account);
-      return Promise.resolve(get(key)).then((v) => (v as Set<string>) || new Set<string>());
+      return Promise.resolve(get<Set<string> | undefined>(key)).then((v) => v || new Set<string>());
     }
     return Promise.resolve(new Set<string>());
   },

--- a/src/app/storage/idb-keyval.ts
+++ b/src/app/storage/idb-keyval.ts
@@ -1,0 +1,114 @@
+export class Store {
+  private readonly _dbName: string;
+  private readonly _storeName: string;
+  private _dbp: Promise<IDBDatabase> | undefined;
+
+  constructor(dbName = 'keyval-store', readonly storeName = 'keyval') {
+    this._dbName = dbName;
+    this._storeName = storeName;
+    this._init();
+  }
+
+  _init(): void {
+    if (this._dbp) {
+      return;
+    }
+    this._dbp = new Promise((resolve, reject) => {
+      const openreq = indexedDB.open(this._dbName, 1);
+      openreq.onerror = () => reject(openreq.error);
+      openreq.onsuccess = () => resolve(openreq.result);
+
+      // First time setup: create an empty object store
+      openreq.onupgradeneeded = () => {
+        openreq.result.createObjectStore(this._storeName);
+      };
+    });
+  }
+
+  _withIDBStore(
+    type: IDBTransactionMode,
+    callback: (store: IDBObjectStore) => void
+  ): Promise<void> {
+    this._init();
+    return (this._dbp as Promise<IDBDatabase>).then(
+      (db) =>
+        new Promise<void>((resolve, reject) => {
+          const transaction = db.transaction(this.storeName, type);
+          // tslint:disable-next-line: no-unnecessary-callback-wrapper
+          transaction.oncomplete = () => resolve();
+          transaction.onabort = transaction.onerror = () => reject(transaction.error);
+          callback(transaction.objectStore(this.storeName));
+        })
+    );
+  }
+
+  _close(): Promise<void> {
+    this._init();
+    return (this._dbp as Promise<IDBDatabase>).then((db) => {
+      db.close();
+      this._dbp = undefined;
+    });
+  }
+}
+
+let store: Store;
+
+function getDefaultStore() {
+  if (!store) {
+    store = new Store();
+  }
+  return store;
+}
+
+export function get<Type>(key: IDBValidKey, store = getDefaultStore()): Promise<Type> {
+  let req: IDBRequest;
+  return store
+    ._withIDBStore('readonly', (store) => {
+      req = store.get(key);
+    })
+    .then(() => req.result);
+}
+
+export function set(key: IDBValidKey, value: any, store = getDefaultStore()): Promise<void> {
+  return store._withIDBStore('readwrite', (store) => {
+    store.put(value, key);
+  });
+}
+
+export function del(key: IDBValidKey, store = getDefaultStore()): Promise<void> {
+  return store._withIDBStore('readwrite', (store) => {
+    store.delete(key);
+  });
+}
+
+export function clear(store = getDefaultStore()): Promise<void> {
+  return store._withIDBStore('readwrite', (store) => {
+    store.clear();
+  });
+}
+
+export function keys(store = getDefaultStore()): Promise<IDBValidKey[]> {
+  const keys: IDBValidKey[] = [];
+
+  return store
+    ._withIDBStore('readonly', (store) => {
+      // This would be store.getAllKeys(), but it isn't supported by Edge or Safari.
+      // And openKeyCursor isn't supported by Safari.
+      (store.openKeyCursor || store.openCursor).call(store).onsuccess = function() {
+        if (!this.result) {
+          return;
+        }
+        keys.push(this.result.key);
+        this.result.continue();
+      };
+    })
+    .then(() => keys);
+}
+
+export function close(store = getDefaultStore()): Promise<void> {
+  return store._close();
+}
+
+window.addEventListener('freeze', () => {
+  close();
+});

--- a/src/register-service-worker.ts
+++ b/src/register-service-worker.ts
@@ -65,6 +65,8 @@ export default function registerServiceWorker() {
         };
 
         updateChannel.addEventListener('message', updateMessage);
+
+        // TODO: close and reopen the broadcast channel on freeze/unfreeze
       } else {
         // We have to assume a newly installed service worker means new content. This isn't
         // as good since we may say we updated when the content is the same.


### PR DESCRIPTION
This makes a private copy of idb-keyval until https://github.com/jakearchibald/idb-keyval/pull/65 and https://github.com/jakearchibald/idb-keyval/pull/50 get merged. It enhances the original library with:

1. Reconnect if the database is closed (by people clearing cache, for example).
2. Close the connection if the app is "frozen" (like when a PWA app is backgrounded).

This hopefully will reduce the frequent errors we see that look like `InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.`