### PR TITLE
Add a PWA prompt for iOS

### DIFF
--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -26,6 +26,8 @@ import { connect } from 'react-redux';
 import { RootState } from 'app/store/reducers';
 import { currentAccountSelector } from 'app/accounts/reducer';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
+import ReactDOM from 'react-dom';
+import Sheet from 'app/dim-ui/Sheet';
 
 const destiny1Links = [
   {
@@ -96,6 +98,7 @@ interface State {
   dropdownOpen: boolean;
   showSearch: boolean;
   installPromptEvent?: any;
+  promptIosPwa: boolean;
 }
 
 class Header extends React.PureComponent<Props, State> {
@@ -110,7 +113,8 @@ class Header extends React.PureComponent<Props, State> {
 
     this.state = {
       dropdownOpen: false,
-      showSearch: false
+      showSearch: false,
+      promptIosPwa: false
     };
   }
 
@@ -133,7 +137,7 @@ class Header extends React.PureComponent<Props, State> {
 
   render() {
     const { account } = this.props;
-    const { showSearch, dropdownOpen, installPromptEvent } = this.state;
+    const { showSearch, dropdownOpen, installPromptEvent, promptIosPwa } = this.state;
 
     // TODO: new fontawesome
     const bugReportLink = $DIM_FLAVOR !== 'release';
@@ -202,6 +206,11 @@ class Header extends React.PureComponent<Props, State> {
       </>
     );
 
+    const iosPwaAvailable =
+      /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+      !window.MSStream &&
+      (window.navigator as any).standalone !== true;
+
     return (
       <nav id="header" className={showSearch ? 'search-expanded' : ''}>
         <GlobalHotkeys
@@ -237,11 +246,21 @@ class Header extends React.PureComponent<Props, State> {
                 role="menu"
               >
                 {destinyLinks}
+                <hr />
                 <Link state="settings" text={t('Settings.Settings')} />
-                {installPromptEvent && (
+                {installPromptEvent ? (
                   <a className="link" onClick={this.installDim}>
                     {t('Header.InstallDIM')}
                   </a>
+                ) : (
+                  iosPwaAvailable && (
+                    <a
+                      className="link"
+                      onClick={() => this.setState({ promptIosPwa: true, dropdownOpen: false })}
+                    >
+                      {t('Header.InstallDIM')}
+                    </a>
+                  )
                 )}
                 {dimLinks}
               </ClickOutside>
@@ -284,6 +303,16 @@ class Header extends React.PureComponent<Props, State> {
           </span>
           <AccountSelect />
         </span>
+        {promptIosPwa &&
+          ReactDOM.createPortal(
+            <Sheet
+              header={<h1>{t('Header.InstallDIM')}</h1>}
+              onClose={() => this.setState({ promptIosPwa: false })}
+            >
+              <p className="pwa-prompt">{t('Header.IosPwaPrompt')}</p>
+            </Sheet>,
+            document.body
+          )}
       </nav>
     );
   }

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -218,3 +218,8 @@
   float: right;
   text-align: right;
 }
+
+.pwa-prompt {
+  margin: 10px;
+  font-size: 1.2em;
+}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -318,6 +318,7 @@
     "Filters": "Filters",
     "InstallDIM": "Install DIM",
     "Inventory": "Inventory",
+    "IosPwaPrompt": "In Mobile Safari, click the share icon (middle button on the bottom) and select \"Add to Home Screen\".",
     "Menu": "Menu",
     "Refresh": "Refresh Destiny Data",
     "ReloadApp": "Reload App",


### PR DESCRIPTION
<img width="231" alt="Screen Shot 2019-08-03 at 10 01 49 PM" src="https://user-images.githubusercontent.com/313208/62419640-2cf31f80-b63a-11e9-83ea-03e61cd51989.png">

Something simple to help iOS users understand how to install DIM. This is accessed via an "Install DIM" menu item that appears on non-installed iOS browsers.