### PR TITLE
On mobile, put the vault on the left of the first character

### DIFF
--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -10,31 +10,33 @@ const customCharacterSortSelector = (state: RootState) => state.settings.customC
 export const characterSortSelector = createSelector(
   characterOrderSelector,
   customCharacterSortSelector,
-  (order, customCharacterSort) => {
+  (state) => state.shell.isPhonePortrait,
+  (order, customCharacterSort, isPhonePortrait) => {
+    const vaultPlacement = isPhonePortrait ? -Infinity : Infinity;
+
     switch (order) {
       case 'mostRecent':
-        return (stores: DimStore[]) => _.sortBy(stores, (store) => store.lastPlayed).reverse();
+        return (stores: DimStore[]) =>
+          _.sortBy(stores, (store) =>
+            store.isVault ? -vaultPlacement : store.lastPlayed.getTime()
+          ).reverse();
 
       case 'mostRecentReverse':
         return (stores: DimStore[]) =>
-          _.sortBy(stores, (store) => {
-            if (store.isVault) {
-              return Infinity;
-            } else {
-              return store.lastPlayed;
-            }
-          });
+          _.sortBy(stores, (store) =>
+            store.isVault ? vaultPlacement : store.lastPlayed.getTime()
+          );
 
       case 'custom': {
         const customSortOrder = customCharacterSort;
         return (stores: DimStore[]) =>
-          _.sortBy(stores, (s) => (s.isVault ? 999 : customSortOrder.indexOf(s.id)));
+          _.sortBy(stores, (s) => (s.isVault ? vaultPlacement : customSortOrder.indexOf(s.id)));
       }
 
       default:
       case 'fixed': // "Age"
         // https://github.com/Bungie-net/api/issues/614
-        return (stores: DimStore[]) => _.sortBy(stores, (s) => s.id);
+        return (stores: DimStore[]) => _.sortBy(stores, (s) => (s.isVault ? vaultPlacement : s.id));
     }
   }
 );


### PR DESCRIPTION
This rearranges the vault on mobile such that it's always next to the first character, so it's easier to get to.

The problem with this, which I haven't figured out, is that the sorta-offscreen vault tile doesn't really look like anything, so how would people know to go there?

<img width="232" alt="Screen Shot 2019-08-03 at 11 12 56 PM" src="https://user-images.githubusercontent.com/313208/62420267-223d8800-b644-11e9-8fc2-709f8955505e.png">


