### PR TITLE
Recoil direction stat display

### DIFF
--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -83,8 +83,8 @@ const statWhiteList = [
   943549884, // Handling
   4188031367, // Reload Speed
   1345609583, // Aim Assistance
-  2715839340, // Recoil Direction
   3555269338, // Zoom
+  2715839340, // Recoil Direction
   3871231066, // Magazine
   2996146975, // Mobility
   392767087, // Resilience

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -43,6 +43,7 @@
   .stat-recoil {
     display: table-cell;
     height: 12px;
+    line-height: 9px;
   }
   .stat-box-outer {
     display: table-cell;

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -40,6 +40,10 @@
   .lower-stats {
     color: #cc6666;
   }
+  .stat-recoil {
+    display: table-cell;
+    height: 12px;
+  }
   .stat-box-outer {
     display: table-cell;
     height: 12px;

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -108,21 +108,27 @@ function ItemStatRow({
         {stat.name}
       </span>
 
-      <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>
-        <span className="stat-box-container">
-          {stat.bar ? (
-            segments.map(([val, className], index) => (
-              <span
-                key={index}
-                className={classNames('stat-box-inner', className)}
-                style={{ width: percent(val / stat.maximumValue) }}
-              />
-            ))
-          ) : (
-            <span className={classNames(higherLowerClasses)}>{value}</span>
-          )}
+      {stat.statHash === 2715839340 ? (
+        <span className="stat-recoil">
+          <RecoilStat stat={stat} />
         </span>
-      </span>
+      ) : (
+        <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>
+          <span className="stat-box-container">
+            {stat.bar ? (
+              segments.map(([val, className], index) => (
+                <span
+                  key={index}
+                  className={classNames('stat-box-inner', className)}
+                  style={{ width: percent(val / stat.maximumValue) }}
+                />
+              ))
+            ) : (
+              <span className={classNames(higherLowerClasses)}>{value}</span>
+            )}
+          </span>
+        </span>
+      )}
 
       {stat.bar && (
         <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
@@ -143,4 +149,22 @@ function ItemStatRow({
 
 function isD1Stat(item: DimItem, _stat: DimStat): _stat is D1Stat {
   return item.isDestiny1();
+}
+
+function RecoilStat({ stat }: { stat: DimStat }) {
+  const val = stat.value || 0;
+  // A value from 100 to -100 where positive is right and negative is left
+  // See https://imgur.com/LKwWUNV
+  const direction =
+    Math.sin((val + 5) * ((2 * Math.PI) / 20)) * (100 - val) * (Math.PI / 180) * 0.75;
+
+  const x = 5 * Math.sin(direction);
+  const y = 5 * Math.cos(direction);
+
+  return (
+    <svg height="12" viewBox="0 0 10 5">
+      <circle r={5} cx={5} cy={5} fill="#333" />
+      <line x1={5 - x} y1={5 + y} x2={5 + x} y2={5 - y} stroke="white" />
+    </svg>
+  );
 }

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -155,16 +155,32 @@ function RecoilStat({ stat }: { stat: DimStat }) {
   const val = stat.value || 0;
   // A value from 100 to -100 where positive is right and negative is left
   // See https://imgur.com/LKwWUNV
-  const direction =
-    Math.sin((val + 5) * ((2 * Math.PI) / 20)) * (100 - val) * (Math.PI / 180) * 0.75;
+  const direction = Math.sin((val + 5) * ((2 * Math.PI) / 20)) * (100 - val) * (Math.PI / 180);
 
-  const x = 5 * Math.sin(direction);
-  const y = 5 * Math.cos(direction);
+  const x = Math.sin(direction);
+  const y = Math.cos(direction);
+
+  const spread = 0.75;
+  const xSpreadMore = Math.sin(direction + direction * spread);
+  const ySpreadMore = Math.cos(direction + direction * spread);
+  const xSpreadLess = Math.sin(direction - direction * spread);
+  const ySpreadLess = Math.cos(direction - direction * spread);
+
+  console.log(direction);
 
   return (
-    <svg height="12" viewBox="0 0 10 5">
-      <circle r={5} cx={5} cy={5} fill="#333" />
-      <line x1={5 - x} y1={5 + y} x2={5 + x} y2={5 - y} stroke="white" />
+    <svg height="12" viewBox="0 0 2 1">
+      <circle r={1} cx={1} cy={1} fill="#333" />
+      {Math.abs(direction) > 0.1 ? (
+        <path
+          d={`M1,1 L${1 + xSpreadMore},${1 - ySpreadMore} A1,1 0 0,${
+            direction < 0 ? '1' : '0'
+          } ${1 + xSpreadLess},${1 - ySpreadLess} Z`}
+          fill="#FFF"
+        />
+      ) : (
+        <line x1={1 - x} y1={1 + y} x2={1 + x} y2={1 - y} stroke="white" strokeWidth="0.1" />
+      )}
     </svg>
   );
 }


### PR DESCRIPTION
<img width="390" alt="Screen Shot 2019-08-03 at 11 47 49 PM" src="https://user-images.githubusercontent.com/313208/62420556-f7096780-b648-11e9-8ceb-61ea787c0410.png">
<img width="365" alt="Screen Shot 2019-08-03 at 11 47 58 PM" src="https://user-images.githubusercontent.com/313208/62420557-f7a1fe00-b648-11e9-841e-3c0e8b981d23.png">
<img width="376" alt="Screen Shot 2019-08-03 at 11 48 04 PM" src="https://user-images.githubusercontent.com/313208/62420558-f7a1fe00-b648-11e9-83cc-fb8aa8f0d4f0.png">

This adds a new display for the "recoil direction" stat that attempts to actually interpret the recoil pattern implied by the stat. See https://imgur.com/LKwWUNV for the source.

This will require some empirical testing in order to tweak the scaling values. I also believe I'll need to implement stat scaling correctly (including contributions from mods/perks) before this is really useful.