### PR TITLE
search count appears on smaller window sizes

### DIFF
--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -156,7 +156,7 @@
 .filter-match-count {
   color: #999;
 
-  @media (max-width: 1445px) {
+  @media (max-width: 1000px) {
     display: none;
   }
 }


### PR DESCRIPTION
now that the search bar is larger, the match count can stay for longer when scaling down to smaller screens. This does that. 
![image](https://user-images.githubusercontent.com/29002828/62583691-391bee80-b87f-11e9-961f-b2436905ed11.png)
