### PR TITLE
fix crash on malformed DimItem

### DIFF
--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -19,6 +19,7 @@ interface Props {
 }
 
 const getGhostInfos = weakMemoize((item: DimItem) =>
+  item.isDestiny2 &&
   item.isDestiny2() &&
   item.sockets &&
   item.itemCategoryHashes &&


### PR DESCRIPTION
LoadoutDrawer creates a malformed DimItem from saved loadouts, and sends them to InventoryItem to display

BadgeInfo now quietly bails when an item is too messed up to even check if it isDestiny2()

fixes #4112 4112