### PR TITLE
hidden overflow on badges

### DIFF
--- a/src/app/inventory/InventoryItem.scss
+++ b/src/app/inventory/InventoryItem.scss
@@ -162,6 +162,7 @@
     align-items: center;
     justify-content: flex-end;
     line-height: calc(#{$badge-height});
+    overflow: hidden;
   }
 
   .primary-stat {


### PR DESCRIPTION
closes #4119 

not sure what chrome's deal is, this should have looked wrong on all browsers