### PR TITLE
accent insensitive search

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* Name search is now accent agnostic (i.e. searching for "Jotunn" will return results for Jötunn).
 
 # 5.41.1 (2019-08-16)
 

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "@types/react-virtualized": "^9.21.1",
     "@uirouter/react": "^0.8.2",
     "@uirouter/visualizer": "^7.0.0",
+    "accent-insensitive-search": "^1.0.7",
     "are-you-es5": "^1.2.1",
     "babel-plugin-idx": "^2.4.0",
     "body-scroll-lock": "^2.6.1",

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import idx from 'idx';
+import accentInsensitiveSearch from 'accent-insensitive-search';
 
 import { compareBy, chainComparator, reverseComparator } from '../comparators';
 import { DimItem, D1Item, D2Item } from '../inventory/item-types';
@@ -942,7 +943,7 @@ function searchFilters(
       },
       keyword(item: DimItem, predicate: string) {
         return (
-          item.name.toLowerCase().includes(predicate) ||
+          accentInsensitiveSearch(predicate, item.name) ||
           item.description.toLowerCase().includes(predicate) ||
           // Search notes field
           (item.dimInfo &&
@@ -956,7 +957,7 @@ function searchFilters(
       },
       // name and description searches to narrow search down from "keyword"
       name(item: DimItem, predicate: string) {
-        return item.name.toLowerCase().includes(predicate);
+        return accentInsensitiveSearch(predicate, item.name);
       },
       description(item: DimItem, predicate: string) {
         return item.description.toLowerCase().includes(predicate);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,6 +1352,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+accent-insensitive-search@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/accent-insensitive-search/-/accent-insensitive-search-1.0.7.tgz#109a6943026287d66c498bf77530b24585ce6974"
+  integrity sha512-V2zdjHkTOYjdrEb+YM7UTtIa3E7NP4CBFGgvY9Guo0tzEsQ16GmXk7uwmvzsp/Xboih19UW6yfDT+brmHEOhqg==
+
 accepts@^1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"


### PR DESCRIPTION
Closes #4130 

This only applies to item name ~and item description, as perk uses `regex magic`, any help would be appreciated there.~

![Screenshot from 2019-08-16 19-39-04](https://user-images.githubusercontent.com/4798491/63205147-a983f600-c05d-11e9-9eb9-3d07dc1b8b16.png)
