### PR TITLE
Back to yellow power

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -17,7 +17,7 @@ $exotic: #c3a019;
 $xp: #5ea16a;
 // Border for completed items/quests/bounties
 $gold: #f5dc56;
-$power: #09d7d0;
+$power: $gold;
 
 $character-box-height: 46px;
 


### PR DESCRIPTION
<img width="758" alt="Screen Shot 2019-08-17 at 9 47 55 PM" src="https://user-images.githubusercontent.com/313208/63220275-bd505a80-c138-11e9-9eba-0629cba7cc92.png">

In Shadowkeep power goes back to yellow from teal. Let's get a jump on it.