### PR TITLE
Turn off blurred backdrop on Windows

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -47,7 +47,8 @@ class App extends React.Component<Props> {
             itemQuality: this.props.itemQuality,
             'show-new-items': this.props.showNewItems,
             'ms-edge': /Edge/.test(navigator.userAgent),
-            ios: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
+            ios: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream,
+            windows: /Windows/.test(navigator.userAgent)
           }
         )}
       >

--- a/src/app/item-popup/ItemPopupContainer.scss
+++ b/src/app/item-popup/ItemPopupContainer.scss
@@ -35,6 +35,10 @@
       background-color: #{'hsla(var(--backgroundColor), 0.75)'};
       backdrop-filter: brightness(1.2) blur(30px);
     }
+    .windows & {
+      background-color: #{'hsl(var(--backgroundColor))'};
+      backdrop-filter: none;
+    }
   }
   box-shadow: 0 -1px 24px 4px #222;
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -70,4 +70,8 @@ $header-height: 44px;
     background-color: rgba(0, 0, 0, 0.75);
     backdrop-filter: blur(30px);
   }
+  .windows & {
+    background-color: rgba(0, 0, 0, 0.9);
+    backdrop-filter: none;
+  }
 }


### PR DESCRIPTION
Chrome released support for backdrop-filter, but their implementation of blur is terrible on Windows and leaves everything looking 🤢🤮

This disables backdrop filter on Windows (it looks great on macOS and mobile).