### PR TITLE
Support new Chrome lazy image loading

### DIFF
--- a/src/app/d2-vendors/VendorItems.tsx
+++ b/src/app/d2-vendors/VendorItems.tsx
@@ -2,7 +2,7 @@ import { t } from 'app/i18next-t';
 import React from 'react';
 import _ from 'lodash';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
-import BungieImage, { bungieBackgroundStyle } from '../dim-ui/BungieImage';
+import BungieImage from '../dim-ui/BungieImage';
 import VendorItemComponent from './VendorItemComponent';
 import { VendorItem } from './vendor-item';
 import { UISref } from '@uirouter/react';
@@ -101,9 +101,9 @@ export default function VendorItems({
               )}
               <UISref to="destiny2.vendor" params={{ id: rewardVendorHash }}>
                 <div className="item" title={rewardItem.displayProperties.name}>
-                  <div
+                  <BungieImage
                     className="item-img transparent"
-                    style={bungieBackgroundStyle(rewardItem.displayProperties.icon)}
+                    src={rewardItem.displayProperties.icon}
                   />
                 </div>
               </UISref>

--- a/src/app/dim-ui/BungieImage.tsx
+++ b/src/app/dim-ui/BungieImage.tsx
@@ -17,7 +17,7 @@ export default function BungieImage(
 ) {
   const { src, ...otherProps } = props;
 
-  return <img src={bungieNetPath(src)} {...otherProps} />;
+  return <img src={bungieNetPath(src)} loading="lazy" {...otherProps} />;
 }
 
 /**

--- a/src/app/inventory/InventoryItem.scss
+++ b/src/app/inventory/InventoryItem.scss
@@ -74,12 +74,11 @@
   margin: 0 var(--item-margin) var(--item-margin) 0;
 
   .item-img {
+    display: block;
     width: var(--item-size);
     height: var(--item-size);
     box-sizing: border-box;
     border: $item-border-width solid #ddd;
-    background-size: cover;
-    background-repeat: no-repeat;
 
     &:focus {
       outline: none;

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -4,7 +4,7 @@ import { DimItem } from './item-types';
 import './InventoryItem.scss';
 import { TagValue, itemTags } from './dim-item-info';
 import BadgeInfo from './BadgeInfo';
-import { bungieBackgroundStyle } from '../dim-ui/BungieImage';
+import BungieImage from '../dim-ui/BungieImage';
 import { percent } from '../shell/filters';
 import { AppIcon, lockIcon, thumbsUpIcon, stickyNoteIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
@@ -81,7 +81,7 @@ export default class InventoryItem extends React.Component<Props> {
             <div className="item-xp-bar-amount" style={{ width: percent(item.percentComplete) }} />
           </div>
         )}
-        <div style={bungieBackgroundStyle(item.icon)} className="item-img" />
+        <BungieImage src={item.icon} className="item-img" />
         <BadgeInfo item={item} rating={rating} hideRating={hideRating} isCapped={isCapped} />
         {item.masterwork && <div className="overlay" />}
         {(tag || item.locked || treatAsCurated || notes) && (

--- a/src/app/inventory/MoveAmountPopupContainer.tsx
+++ b/src/app/inventory/MoveAmountPopupContainer.tsx
@@ -5,7 +5,7 @@ import './MoveAmountPopupContainer.scss';
 import { MoveAmountPopupOptions, showMoveAmountPopup$ } from './move-dropped-item';
 import { t } from 'app/i18next-t';
 import ItemMoveAmount from '../item-popup/ItemMoveAmount';
-import { bungieBackgroundStyle } from '../dim-ui/BungieImage';
+import BungieImage from '../dim-ui/BungieImage';
 
 interface State {
   options?: MoveAmountPopupOptions;
@@ -53,7 +53,7 @@ export default class MoveAmountPopupContainer extends React.Component<{}, State>
           <>
             <h1 className="no-badge">
               <div className="item">
-                <div className="item-img" style={bungieBackgroundStyle(item.icon)} />
+                <BungieImage className="item-img" src={item.icon} />
               </div>
               <span>{t('StoreBucket.HowMuch', { itemname: item.name })}</span>
             </h1>

--- a/src/app/progress/AvailableQuest.tsx
+++ b/src/app/progress/AvailableQuest.tsx
@@ -75,7 +75,7 @@ export default function AvailableQuest({
   return (
     <div className="milestone-quest">
       <div className="milestone-icon" title={tooltip}>
-        <BungieImage src={displayProperties.icon} />
+        <BungieImage className="milestone-img" src={displayProperties.icon} />
         <MilestoneObjectiveStatus
           objective={objective}
           status={availableQuest.status}

--- a/src/app/progress/MilestoneDisplay.tsx
+++ b/src/app/progress/MilestoneDisplay.tsx
@@ -15,7 +15,9 @@ export default function MilestoneDisplay(props: Props) {
   return (
     <div className="milestone-quest">
       <div className="milestone-icon">
-        {displayProperties.hasIcon && <BungieImage src={displayProperties.icon} />}
+        {displayProperties.hasIcon && (
+          <BungieImage className="milestone-img" src={displayProperties.icon} />
+        )}
         {progress}
       </div>
       <div className="milestone-info">

--- a/src/app/progress/PursuitItem.tsx
+++ b/src/app/progress/PursuitItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DimItem } from 'app/inventory/item-types';
 import classNames from 'classnames';
 import { percent } from 'app/shell/filters';
-import { bungieBackgroundStyle } from 'app/dim-ui/BungieImage';
+import BungieImage from 'app/dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
 import styles from './PursuitItem.m.scss';
 import pursuitComplete from 'images/pursuitComplete.svg';
@@ -60,7 +60,7 @@ function PursuitItem({ item, isNew, searchHidden }: Props) {
           <div className={styles.progressAmount} style={{ width: percent(item.percentComplete) }} />
         </div>
       )}
-      <div style={bungieBackgroundStyle(item.icon)} className={styles.image} />
+      <BungieImage src={item.icon} className={styles.image} />
       {item.maxStackSize > 1 && item.amount > 1 && (
         <div
           className={classNames(styles.amount, {

--- a/src/app/progress/RaidDisplay.tsx
+++ b/src/app/progress/RaidDisplay.tsx
@@ -23,7 +23,9 @@ export function RaidDisplay(props: Props) {
   return (
     <div className="milestone-quest">
       <div className="milestone-icon">
-        {displayProperties.hasIcon && <BungieImage src={displayProperties.icon} />}
+        {displayProperties.hasIcon && (
+          <BungieImage className="milestone-img" src={displayProperties.icon} />
+        )}
       </div>
       <div className="milestone-info">{children}</div>
     </div>

--- a/src/app/progress/WellRestedPerkIcon.tsx
+++ b/src/app/progress/WellRestedPerkIcon.tsx
@@ -21,7 +21,11 @@ export default function WellRestedPerkIcon({
   return (
     <div className="well-rested milestone-quest">
       <div className="milestone-icon">
-        <BungieImage className="perk" src={perkDisplay.icon} title={perkDisplay.description} />
+        <BungieImage
+          className="perk milestone-img"
+          src={perkDisplay.icon}
+          title={perkDisplay.description}
+        />
         <span>
           {formatter.format(wellRestedInfo.progress!)}
           <wbr />/<wbr />

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -11,7 +11,7 @@
   }
 
   .milestone-icon {
-    img {
+    .milestone-img {
       height: 36px;
       width: 36px;
     }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,6 +35,14 @@ declare const $featureFlags: {
   curatedRolls: boolean;
 };
 
+/* tslint:disable */
+declare namespace React {
+  interface ImgHTMLAttributes {
+    loading?: 'lazy';
+  }
+}
+/* tslint:enable */
+
 declare function ga(...params: string[]);
 
 interface Window {


### PR DESCRIPTION
Chrome supports a new `loading="lazy"` property that will defer loading `img` contents until they're onscreen (or close to onscreen). This can help avoid loading stuff you don't see! I've tested that this works on the latest Chrome. Note that I had to change a lot of stuff from background-image to just img, so some display might need to be fixed.