### PR TITLE
Hotkeys for pages

### DIFF
--- a/src/app/hotkeys/GlobalHotkeys.tsx
+++ b/src/app/hotkeys/GlobalHotkeys.tsx
@@ -15,6 +15,11 @@ export default class GlobalHotkeys extends React.Component<Props> {
     hotkeys.register(this.id, this.props.hotkeys);
   }
 
+  componentDidUpdate() {
+    hotkeys.unregister(this.id);
+    hotkeys.register(this.id, this.props.hotkeys);
+  }
+
   componentWillUnmount() {
     hotkeys.unregister(this.id);
   }

--- a/src/app/hotkeys/HotkeysCheatSheet.scss
+++ b/src/app/hotkeys/HotkeysCheatSheet.scss
@@ -30,14 +30,12 @@
   vertical-align: middle;
 }
 
-.cfp-hotkeys table {
-  margin: auto;
+.cfp-hotkeys-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 75px minmax(200px, 1fr));
+  margin: 0 auto;
+  max-width: 800px;
   color: #333;
-}
-
-.cfp-content {
-  display: table-cell;
-  vertical-align: middle;
 }
 
 .cfp-hotkeys-keys {
@@ -61,6 +59,7 @@
 .cfp-hotkeys-text {
   padding-left: 10px;
   font-size: 1em;
+  align-self: center;
 }
 
 @media all and (max-width: 500px) {

--- a/src/app/hotkeys/HotkeysCheatSheet.tsx
+++ b/src/app/hotkeys/HotkeysCheatSheet.tsx
@@ -46,22 +46,20 @@ export default class HotkeysCheatSheet extends React.Component<{}, State> {
         />
         <div className="cfp-hotkeys">
           <h4 className="cfp-hotkeys-title">{t('Hotkey.CheatSheetTitle')}</h4>
-          <table>
-            <tbody>
-              {_.map(
-                appKeyMap,
-                (description, combo) =>
-                  description.length > 0 && (
-                    <tr key={combo}>
-                      <td className="cfp-hotkeys-keys">
-                        <span className="cfp-hotkeys-key">{combo}</span>
-                      </td>
-                      <td className="cfp-hotkeys-text">{description}</td>
-                    </tr>
-                  )
-              )}
-            </tbody>
-          </table>
+          <div className="cfp-hotkeys-list">
+            {_.map(
+              appKeyMap,
+              (description, combo) =>
+                description.length > 0 && (
+                  <React.Fragment key={combo}>
+                    <div className="cfp-hotkeys-keys">
+                      <span className="cfp-hotkeys-key">{combo}</span>
+                    </div>
+                    <div className="cfp-hotkeys-text">{description}</div>
+                  </React.Fragment>
+                )
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/app/inventory/dimItemMoveService.factory.ts
+++ b/src/app/inventory/dimItemMoveService.factory.ts
@@ -7,6 +7,7 @@ import { dimItemService } from './dimItemService.factory';
 import { t } from 'app/i18next-t';
 import { loadingTracker } from '../shell/loading-tracker';
 import { showNotification } from '../notifications/notifications';
+import { hideItemPopup } from 'app/item-popup/item-popup';
 
 /**
  * Move the item to the specified store. Equip it if equip is true.
@@ -14,6 +15,7 @@ import { showNotification } from '../notifications/notifications';
 export const moveItemTo = queuedAction(
   loadingTracker.trackPromise(
     async (item: DimItem, store: DimStore, equip: boolean, amount: number) => {
+      hideItemPopup();
       const reload = item.equipped || equip;
       try {
         item = await dimItemService.moveTo(item, store, equip, amount);

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -58,7 +58,7 @@ export default function ItemPopupHeader({
     <div className={classNames('item-header', `is-${item.tier}`)}>
       <GlobalHotkeys
         hotkeys={[
-          { combo: 'i', description: t('Hotkey.ToggleDetails'), callback: onToggleExpanded }
+          { combo: 't', description: t('Hotkey.ToggleDetails'), callback: onToggleExpanded }
         ]}
       />
       <div className="item-title-container">

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -102,6 +102,7 @@ export default class SearchFilterInput extends React.Component<Props, State> {
             return;
           }}
           onInput={this.onQueryChange}
+          onKeyDown={this.onKeyDown}
           onBlur={() => this.textcomplete && this.textcomplete.hide()}
         />
 
@@ -158,6 +159,14 @@ export default class SearchFilterInput extends React.Component<Props, State> {
 
   private showFilterHelp = () => {
     this.setState({ filterHelpOpen: true });
+  };
+
+  private onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.keyCode === 27) {
+      e.stopPropagation();
+      e.preventDefault();
+      this.clearFilter();
+    }
   };
 
   private setupTextcomplete = () => {

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -28,7 +28,7 @@ class Destiny extends React.Component<Props> {
     // Define some hotkeys without implementation, so they show up in the help
     const hotkeys: Hotkey[] = [
       {
-        combo: 'i',
+        combo: 't',
         description: t('Hotkey.ToggleDetails'),
         callback() {
           // Empty - this gets redefined in dimMoveItemProperties

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -26,19 +26,23 @@ import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import MenuAccounts from 'app/accounts/MenuAccounts';
 import ReactDOM from 'react-dom';
 import Sheet from 'app/dim-ui/Sheet';
+import _ from 'lodash';
 
 const destiny1Links = [
   {
     state: 'destiny1.inventory',
-    text: 'Header.Inventory' // t('Header.Inventory')
+    text: 'Header.Inventory', // t('Header.Inventory')
+    hotkey: 'i'
   },
   {
     state: 'destiny1.loadout-builder',
-    text: 'LB.LB' // t('LB.LB')
+    text: 'LB.LB', // t('LB.LB')
+    hotkey: 'o'
   },
   {
     state: 'destiny1.vendors',
-    text: 'Vendors.Vendors' // t('Vendors.Vendors')
+    text: 'Vendors.Vendors', // t('Vendors.Vendors')
+    hotkey: 'v'
   },
   {
     state: 'destiny1.record-books',
@@ -53,23 +57,28 @@ const destiny1Links = [
 const destiny2Links = [
   {
     state: 'destiny2.inventory',
-    text: 'Header.Inventory' // t('Header.Inventory')
+    text: 'Header.Inventory', // t('Header.Inventory')
+    hotkey: 'i'
   },
   {
     state: 'destiny2.progress',
-    text: 'Progress.Progress' // t('Progress.Progress')
+    text: 'Progress.Progress', // t('Progress.Progress')
+    hotkey: 'p'
   },
   {
     state: 'destiny2.vendors',
-    text: 'Vendors.Vendors' // t('Vendors.Vendors')
+    text: 'Vendors.Vendors', // t('Vendors.Vendors')
+    hotkey: 'v'
   },
   {
     state: 'destiny2.collections',
-    text: 'Vendors.Collections' // t('Vendors.Collections')
+    text: 'Vendors.Collections', // t('Vendors.Collections')
+    hotkey: 'c'
   },
   {
     state: 'destiny2.loadoutbuilder',
-    text: 'LB.LB' // t('LB.LB')
+    text: 'LB.LB', // t('LB.LB')
+    hotkey: 'o'
   }
 ];
 
@@ -179,6 +188,26 @@ class Header extends React.PureComponent<Props, State> {
       </>
     );
 
+    const hotkeys = [
+      {
+        combo: 'm',
+        description: t('Hotkey.Menu'),
+        callback: this.toggleDropdown
+      },
+      ..._.compact(
+        links.map(
+          (link) =>
+            link.hotkey && {
+              combo: link.hotkey,
+              description: t(link.text),
+              callback: () => router.stateService.go(link.state, account)
+            }
+        )
+      )
+    ];
+
+    console.log(hotkeys);
+
     const iosPwaAvailable =
       /iPad|iPhone|iPod/.test(navigator.userAgent) &&
       !window.MSStream &&
@@ -186,15 +215,7 @@ class Header extends React.PureComponent<Props, State> {
 
     return (
       <header id="header" className={showSearch ? 'search-expanded' : ''}>
-        <GlobalHotkeys
-          hotkeys={[
-            {
-              combo: 'm',
-              description: t('Hotkey.Menu'),
-              callback: this.toggleDropdown
-            }
-          ]}
-        >
+        <GlobalHotkeys hotkeys={hotkeys}>
           <a
             className="menu link"
             ref={this.dropdownToggler}
@@ -251,11 +272,6 @@ class Header extends React.PureComponent<Props, State> {
         </UISref>
         <div className="header-links">{reverseDestinyLinks}</div>
         <span className="header-right">
-          {account && (
-            <span className={classNames('search-link', { show: showSearch })}>
-              <SearchFilter onClear={this.hideSearch} ref={this.searchFilter} mobile={showSearch} />
-            </span>
-          )}
           <Refresh />
           <UISref to="settings">
             <a className="link" title={t('Settings.Settings')}>
@@ -265,6 +281,11 @@ class Header extends React.PureComponent<Props, State> {
           <span className="link search-button" onClick={this.toggleSearch}>
             <AppIcon icon={searchIcon} />
           </span>
+          {account && (
+            <span className={classNames('search-link', { show: showSearch })}>
+              <SearchFilter onClear={this.hideSearch} ref={this.searchFilter} mobile={showSearch} />
+            </span>
+          )}
         </span>
         {promptIosPwa &&
           ReactDOM.createPortal(


### PR DESCRIPTION
This adds hotkeys for going directly to the different pages. Also:

* Redesigned the hotkey cheat sheet a bit
* Close item popups when moving items
* ESC on the search input will clear it

<img width="688" alt="Screen Shot 2019-08-17 at 10 44 52 PM" src="https://user-images.githubusercontent.com/313208/63220660-6bf89900-c141-11e9-9f3e-95edee6703ff.png">
