### PR TITLE
Remove platform type

### DIFF
--- a/src/app/accounts/platform.service.ts
+++ b/src/app/accounts/platform.service.ts
@@ -106,23 +106,6 @@ async function loadActivePlatform(): Promise<DestinyAccount | undefined> {
     }
   }
 
-  // TODO: Deprecated
-  if (data && data.platformType) {
-    let active = accounts.find((platform) => {
-      return (
-        platform.originalPlatformType === data.platformType &&
-        platform.destinyVersion === data.destinyVersion
-      );
-    });
-    if (active) {
-      return active;
-    }
-    active = accounts.find((platform) => platform.originalPlatformType === data.platformType);
-    if (active) {
-      return active;
-    }
-  }
-
   return accounts[0];
 }
 

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -89,10 +89,9 @@ export class ItemInfoSource {
     readonly infos: Readonly<{ [itemInstanceId: string]: DimItemInfo }>
   ) {}
 
-  infoForItem(hash: number, id: string): DimItemInfo {
-    const itemKey = `${hash}-${id}`;
-    const info = this.infos[itemKey];
-    return new ItemInfo(itemKey, this.key, info && info.tag, info && info.notes);
+  infoForItem(id: string): DimItemInfo {
+    const info = this.infos[id];
+    return new ItemInfo(id, this.key, info && info.tag, info && info.notes);
   }
 
   // Remove all item info that isn't in stores' items

--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -486,7 +486,7 @@ export async function importTagsNotesFromCsv(files: File[]) {
                 ? (row.Tag as TagValue)
                 : undefined,
               notes: row.Notes,
-              key: `${row.Hash}-${row.Id}`
+              key: row.Id
             };
           }
         })

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -371,7 +371,7 @@ function makeItem(
 
   if (itemInfoService) {
     try {
-      createdItem.dimInfo = itemInfoService.infoForItem(createdItem.hash, createdItem.id);
+      createdItem.dimInfo = itemInfoService.infoForItem(createdItem.id);
     } catch (e) {
       console.error(`Error getting extra DIM info for ${createdItem.name}`, item, itemDef, e);
     }

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -417,7 +417,7 @@ export function makeItem(
 
   if (itemInfoService) {
     try {
-      createdItem.dimInfo = itemInfoService.infoForItem(createdItem.hash, createdItem.id);
+      createdItem.dimInfo = itemInfoService.infoForItem(createdItem.id);
     } catch (e) {
       console.error(`Error getting extra DIM info for ${createdItem.name}`, item, itemDef, e);
       reportException('DimInfo', e, { itemHash: item.itemHash });

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -55,6 +55,7 @@ import PressTip from '../dim-ui/PressTip';
 import { faRandom } from '@fortawesome/free-solid-svg-icons';
 import { showNotification } from '../notifications/notifications';
 import { DestinyAccount } from 'app/accounts/destiny-account.service';
+import { createSelector } from 'reselect';
 
 const loadoutIcon = {
   [LoadoutClass.any]: globeIcon,
@@ -79,30 +80,35 @@ interface StoreProps {
 
 type Props = ProvidedProps & StoreProps;
 
+const loadoutsForPlatform = createSelector(
+  loadoutsSelector,
+  (_, { dimStore }: ProvidedProps) => dimStore,
+  (loadouts, dimStore) => {
+    const classTypeId = LoadoutClass[dimStore.class === 'vault' ? 'any' : dimStore.class];
+
+    return _.sortBy(
+      loadouts.filter(
+        (loadout) =>
+          (dimStore.destinyVersion === 2
+            ? loadout.destinyVersion === 2
+            : loadout.destinyVersion !== 2) &&
+          (classTypeId === LoadoutClass.any ||
+            loadout.classType === LoadoutClass.any ||
+            loadout.classType === classTypeId)
+      ),
+      (l) => l.name
+    );
+  }
+);
+
 function mapStateToProps(state: RootState, ownProps: ProvidedProps): StoreProps {
-  const loadouts = loadoutsSelector(state);
-  const currentAccount = currentAccountSelector(state)!;
   const { dimStore } = ownProps;
 
   const classTypeId = LoadoutClass[dimStore.class === 'vault' ? 'any' : dimStore.class];
 
-  const loadoutsForPlatform = _.sortBy(loadouts, 'name').filter((loadout: Loadout) => {
-    return (
-      (dimStore.destinyVersion === 2
-        ? loadout.destinyVersion === 2
-        : loadout.destinyVersion !== 2) &&
-      (loadout.membershipId === undefined ||
-        loadout.membershipId === currentAccount.membershipId) &&
-      (loadout.platform === undefined || loadout.platform === currentAccount.platformLabel) &&
-      (classTypeId === LoadoutClass.any ||
-        loadout.classType === LoadoutClass.any ||
-        loadout.classType === classTypeId)
-    );
-  });
-
   return {
     previousLoadout: previousLoadoutSelector(state, ownProps.dimStore.id),
-    loadouts: loadoutsForPlatform,
+    loadouts: loadoutsForPlatform(state, ownProps),
     query: querySelector(state),
     searchFilter: searchFilterSelector(state),
     classTypeId,

--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -59,6 +59,7 @@ export interface Loadout {
   items: {
     [type: string]: LoadoutItem[];
   };
+  /** Platform membership ID this loadout is associated with */
   membershipId?: string;
   destinyVersion?: 1 | 2;
   // TODO: deprecate this
@@ -74,6 +75,7 @@ interface DehydratedLoadout {
   name: string;
   items: LoadoutItem[];
   destinyVersion?: 1 | 2;
+  /** Platform membership ID this loadout is associated with */
   membershipId?: string;
   platform?: string;
   /** Whether to move other items not in the loadout off the character when applying the loadout. */


### PR DESCRIPTION
This removes our dependence on platform type in favor of just using the platform membership ID (which is stable and unique between platforms). This is required to preserve user data through the Blizzard to Steam migration, and is generally a good idea in a Cross Save world.

1. Migrate on load from the old tag/notes key (which used platform type) to a new one that doesn't. 2. Also migrate all item infos from being keyed on "hash-id" to just IDs which are unique. 
2. Migrate on load the new items list.
3. Fill in loadouts' membership ID on load. Also, do a better job of loading them from redux.

There are still a few cases where we use platform type:

1. The APIs still require them (this will get fixed with a later revision of the API).
2. Submitting and flagging reviews still uses them.