### PR TITLE
Fix D1 accounts for cross save

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -51,7 +51,8 @@ export async function getLinkedAccounts(
 ): Promise<DestinyLinkedProfilesResponse> {
   const response = await getLinkedProfiles(httpAdapter, {
     membershipId: bungieMembershipId,
-    membershipType: BungieMembershipType.BungieNext
+    membershipType: BungieMembershipType.BungieNext,
+    getAllMemberships: true
   });
   return response.Response;
 }


### PR DESCRIPTION
This should fix D1 accounts showing all the cross-save platforms, and D1 accounts not showing up when you've activated cross save.