### PR TITLE
Switch to using Investment Stats for all stat calculations

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -16,6 +16,7 @@ import { RootState } from '../store/reducers';
 import Sheet from '../dim-ui/Sheet';
 import { showNotification } from '../notifications/notifications';
 import { scrollToPosition } from 'app/dim-ui/scroll';
+import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 
 interface StoreProps {
   ratings: ReviewsState['ratings'];
@@ -42,7 +43,7 @@ interface State {
 
 export interface StatInfo {
   id: string | number;
-  name: string;
+  displayProperties: DestinyDisplayPropertiesDefinition;
   min: number;
   max: number;
   enabled: boolean;
@@ -162,7 +163,7 @@ class Compare extends React.Component<Props, State> {
                   onMouseOver={() => this.setHighlight(stat.id)}
                   onClick={() => this.sort(stat.id)}
                 >
-                  {stat.name}
+                  {stat.displayProperties.name}
                 </div>
               ))}
             </div>
@@ -371,7 +372,9 @@ function getAllStats(comparisons: DimItem[], ratings: ReviewsState['ratings']) {
   if ($featureFlags.reviewsEnabled) {
     stats.push({
       id: 'Rating',
-      name: t('Compare.Rating'),
+      displayProperties: {
+        name: t('Compare.Rating')
+      } as DestinyDisplayPropertiesDefinition,
       min: Number.MAX_SAFE_INTEGER,
       max: 0,
       enabled: false,
@@ -386,7 +389,7 @@ function getAllStats(comparisons: DimItem[], ratings: ReviewsState['ratings']) {
   if (firstComparison.primStat) {
     stats.push({
       id: firstComparison.primStat.statHash,
-      name: firstComparison.primStat.stat.statName,
+      displayProperties: firstComparison.primStat.stat.displayProperties,
       min: Number.MAX_SAFE_INTEGER,
       max: 0,
       enabled: false,
@@ -407,7 +410,7 @@ function getAllStats(comparisons: DimItem[], ratings: ReviewsState['ratings']) {
         if (!statInfo) {
           statInfo = {
             id: stat.statHash,
-            name: stat.name,
+            displayProperties: stat.displayProperties,
             min: Number.MAX_SAFE_INTEGER,
             max: 0,
             enabled: false,

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -318,14 +318,13 @@ class Compare extends React.Component<Props, State> {
 
     let armorSplit = 0;
     if (compare.bucket.inArmor) {
-      armorSplit = _.sumBy(compare.stats, (stat) => (stat.base === 0 ? 0 : stat.statHash));
+      armorSplit = _.sumBy(compare.stats, (stat) => (stat.value === 0 ? 0 : stat.statHash));
     }
 
     const isArchetypeStat = (s: DimStat) =>
-      s.statHash === (compare.isDestiny1 ? compare.stats![0].statHash : 4284893193);
+      // 4284893193 is RPM in D2
+      s.statHash === (compare.isDestiny1() ? compare.stats![0].statHash : 4284893193);
 
-    // TODO: in D2 the first perk is actually what determines the archetype!
-    // 4284893193 is RPM in D2
     const archetypeStat = compare.stats!.find(isArchetypeStat);
 
     const byStat = (item: DimItem) => {
@@ -334,9 +333,9 @@ class Compare extends React.Component<Props, State> {
         if (!archetypeMatch) {
           return false;
         }
-        return archetypeStat && archetypeMatch.base === archetypeStat.base;
+        return archetypeStat && archetypeMatch.value === archetypeStat.value;
       }
-      return _.sumBy(item.stats, (stat) => (stat.base === 0 ? 0 : stat.statHash)) === armorSplit;
+      return _.sumBy(item.stats, (stat) => (stat.value === 0 ? 0 : stat.statHash)) === armorSplit;
     };
 
     if (compare.isDestiny2() && !compare.isExotic && compare.sockets) {

--- a/src/app/d2-loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/d2-loadout-builder/LoadoutBuilder.tsx
@@ -14,7 +14,7 @@ import GeneratedSets from './generated-sets/GeneratedSets';
 import { filterGeneratedSets, isLoadoutBuilderItem } from './generated-sets/utils';
 import { ArmorSet, StatTypes, MinMax, ItemsByBucket, LockedMap } from './types';
 import { sortedStoresSelector, storesLoadedSelector, storesSelector } from '../inventory/reducer';
-import { process, filterItems } from './process';
+import { process, filterItems, statKeys } from './process';
 import { createSelector } from 'reselect';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import FilterBuilds from './generated-sets/FilterBuilds';
@@ -132,7 +132,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       },
       minimumPower: 0,
       query: '',
-      statOrder: ['Mobility', 'Resilience', 'Recovery']
+      statOrder: statKeys
     };
   }
 

--- a/src/app/d2-loadout-builder/LockArmorAndPerks.m.scss
+++ b/src/app/d2-loadout-builder/LockArmorAndPerks.m.scss
@@ -1,7 +1,7 @@
 .itemGrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--item-size));
-  grid-template-rows: repeat(auto-fill, var(--item-size));
+  grid-template-rows: repeat(auto-fill, minmax(var(--item-size), 1fr));
   grid-gap: 4px;
   margin-bottom: 3px;
 

--- a/src/app/d2-loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/FilterBuilds.tsx
@@ -6,6 +6,7 @@ import TierSelect from './TierSelect';
 import _ from 'lodash';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
 import styles from './FilterBuilds.m.scss';
+import { statHashes, statKeys } from '../process';
 
 /**
  * A control for filtering builds by stats, and controlling the priority order of stats.
@@ -32,13 +33,9 @@ export default function FilterBuilds({
   onStatFiltersChanged(stats: { [statType in StatTypes]: MinMax }): void;
 }) {
   const statRanges = useMemo(() => {
-    const statRanges = {
-      Mobility: { min: 10, max: 0 },
-      Resilience: { min: 10, max: 0 },
-      Recovery: { min: 10, max: 0 }
-    };
+    const statRanges = _.mapValues(statHashes, () => ({ min: 10, max: 0 }));
     for (const set of sets) {
-      for (const prop of ['Mobility', 'Resilience', 'Recovery']) {
+      for (const prop of statKeys) {
         statRanges[prop].min = Math.min(set.stats[prop], statRanges[prop].min);
         statRanges[prop].max = Math.max(set.stats[prop], statRanges[prop].max);
       }

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSet.tsx
@@ -55,8 +55,6 @@ function GeneratedSet({
 
   const stats = _.mapValues(statHashes, (statHash) => defs.Stat.get(statHash));
 
-  //console.log('tier', set.stats, Object.values(set.stats), _.sum(Object.values(set.stats)));
-
   return (
     <div className={styles.build} style={style} ref={forwardedRef}>
       <div className={styles.header}>

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSet.tsx
@@ -53,11 +53,9 @@ function GeneratedSet({
   }
   const firstValidSet = set.firstValidSet;
 
-  const stats = {
-    Mobility: defs.Stat.get(statHashes.Mobility),
-    Resilience: defs.Stat.get(statHashes.Resilience),
-    Recovery: defs.Stat.get(statHashes.Recovery)
-  };
+  const stats = _.mapValues(statHashes, (statHash) => defs.Stat.get(statHash));
+
+  //console.log('tier', set.stats, Object.values(set.stats), _.sum(Object.values(set.stats)));
 
   return (
     <div className={styles.build} style={style} ref={forwardedRef}>
@@ -67,7 +65,7 @@ function GeneratedSet({
             <span className={styles.segment}>
               <b>
                 {t('LoadoutBuilder.TierNumber', {
-                  tier: set.stats.Mobility + set.stats.Resilience + set.stats.Recovery
+                  tier: _.sum(Object.values(set.stats))
                 })}
               </b>
             </span>

--- a/src/app/d2-loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -24,9 +24,6 @@ function identifyAltPerkChoicesForChosenStats(item: DimItem, chosenValues: numbe
     }
     return true;
   });
-  if (item.name.toUpperCase() === 'INAUGURAL REVELRY STRIDES') {
-    console.log('altPerks', altPerks);
-  }
   return altPerks;
 }
 /**
@@ -118,7 +115,6 @@ export default function GeneratedSetItem({
           onShiftClick={onShiftClickPerk}
         />
       )}
-      <div>{statValues.toString()}</div>
     </div>
   );
 }

--- a/src/app/d2-loadout-builder/generated-sets/TierSelect.tsx
+++ b/src/app/d2-loadout-builder/generated-sets/TierSelect.tsx
@@ -37,11 +37,7 @@ export default function TierSelect({
     onStatFiltersChanged(newTiers);
   };
 
-  const statDefs = {
-    Mobility: defs.Stat.get(statHashes.Mobility),
-    Resilience: defs.Stat.get(statHashes.Resilience),
-    Recovery: defs.Stat.get(statHashes.Recovery)
-  };
+  const statDefs = _.mapValues(statHashes, (statHash) => defs.Stat.get(statHash));
 
   const onDragEnd = (result: DropResult) => {
     // dropped outside the list

--- a/src/app/d2-loadout-builder/generated-sets/utils.ts
+++ b/src/app/d2-loadout-builder/generated-sets/utils.ts
@@ -75,7 +75,7 @@ export function filterGeneratedSets(
       compareBy(
         (s: ArmorSet) =>
           // Total tier
-          -(s.stats.Mobility + s.stats.Recovery + s.stats.Resilience)
+          -_.sum(Object.values(s.stats))
       ),
       ...statOrder.map((stat) => compareBy((s: ArmorSet) => -s.stats[stat]))
     )
@@ -87,7 +87,7 @@ export function filterGeneratedSets(
 }
 
 /**
- * Get the best sorted computed sets for a specfic tier
+ * Get the best sorted computed sets for a specific tier
  */
 function getBestSets(
   setMap: readonly ArmorSet[],

--- a/src/app/d2-loadout-builder/process.ts
+++ b/src/app/d2-loadout-builder/process.ts
@@ -110,7 +110,6 @@ function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
  */
 export function process(filteredItems: ItemsByBucket): ArmorSet[] {
   const pstart = performance.now();
-  console.time('Grouping');
   const helms = multiGroupBy(
     _.sortBy(filteredItems[LockableBuckets.helmet] || [], (i) => -i.basePower),
     byStatMix
@@ -135,7 +134,6 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
     _.sortBy(filteredItems[LockableBuckets.ghost] || [], (i) => !i.isExotic),
     byStatMix
   );
-  console.timeEnd('Grouping');
   const setMap: ArmorSet[] = [];
 
   const helmsKeys = Object.keys(helms);
@@ -321,7 +319,8 @@ export function generateMixesFromPerks(
               });
 
               if (onMix) {
-                const plugs = _.compact([...(altPerks[mixIndex] || []), plug]);
+                const existingMixAlts = altPerks[mixIndex];
+                const plugs = existingMixAlts ? [...existingMixAlts, plug] : [plug];
                 altPerks.push(plugs);
                 if (!onMix(optionStat, plugs)) {
                   return [];

--- a/src/app/d2-loadout-builder/process.ts
+++ b/src/app/d2-loadout-builder/process.ts
@@ -293,7 +293,7 @@ function byStatMix(item: DimItem) {
     return _.uniq(mixes);
   }
 
-  return [[stat[0].value || 0, stat[1].value || 0, stat[2].value || 0].toString()];
+  return [[stat[0].value, stat[1].value, stat[2].value].toString()];
 }
 
 /**

--- a/src/app/destiny2/d2-definitions.service.ts
+++ b/src/app/destiny2/d2-definitions.service.ts
@@ -26,7 +26,8 @@ import {
   DestinyPlugSetDefinition,
   DestinyCollectibleDefinition,
   DestinyPresentationNodeDefinition,
-  DestinyRecordDefinition
+  DestinyRecordDefinition,
+  DestinyStatGroupDefinition
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { D2ManifestService } from '../manifest/manifest-service-json';
@@ -38,6 +39,7 @@ const lazyTables = [
   'Objective', // DestinyObjectiveDefinition
   'SandboxPerk', // DestinySandboxPerkDefinition
   'Stat', // DestinyStatDefinition
+  'StatGroup',
   'TalentGrid', // DestinyTalentGridDefinition
   'Progression', // DestinyProgressionDefinition
   'ItemCategory', // DestinyItemCategoryDefinition
@@ -77,6 +79,7 @@ export interface D2ManifestDefinitions {
   Objective: LazyDefinition<DestinyObjectiveDefinition>;
   SandboxPerk: LazyDefinition<DestinySandboxPerkDefinition>;
   Stat: LazyDefinition<DestinyStatDefinition>;
+  StatGroup: LazyDefinition<DestinyStatGroupDefinition>;
   TalentGrid: LazyDefinition<DestinyTalentGridDefinition>;
   Progression: LazyDefinition<DestinyProgressionDefinition>;
   ItemCategory: LazyDefinition<DestinyItemCategoryDefinition>;

--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -214,14 +214,14 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }) {
           pct = Math.round((100 * stat.scaled.min) / (stat.split || 1));
         }
         stats[stat.name] = {
-          value: stat.value || 0,
+          value: stat.value,
           pct
         };
       });
     } else if (item.isDestiny2() && item.stats) {
       item.stats.forEach((stat) => {
         stats[stat.name] = {
-          value: stat.value || 0,
+          value: stat.value,
           pct: 0
         };
       });

--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -213,14 +213,14 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }) {
         if (stat.scaled && stat.scaled.min) {
           pct = Math.round((100 * stat.scaled.min) / (stat.split || 1));
         }
-        stats[stat.name] = {
+        stats[stat.displayProperties.name] = {
           value: stat.value,
           pct
         };
       });
     } else if (item.isDestiny2() && item.stats) {
       item.stats.forEach((stat) => {
-        stats[stat.name] = {
+        stats[stat.displayProperties.name] = {
           value: stat.value,
           pct: 0
         };

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -259,8 +259,6 @@ export interface DimMasterwork {
 export interface DimStat {
   /** Base stat without bonuses/mods/plugs applied. */
   base: number;
-  /** Stat bonus total `value - base = bonus` */
-  bonus: number;
   /** DestinyStatDefinition hash. */
   statHash: number;
   /** Localized stat name. */
@@ -275,12 +273,6 @@ export interface DimStat {
   maximumValue: number;
   /** Should this be displayed as a bar or just a number? */
   bar: boolean;
-  /** Stat bonus from plugs */
-  plugBonus?: number;
-  /** Stat bonus from mods */
-  modsBonus?: number;
-  /** Stat bonus from perks */
-  perkBonus?: number;
 }
 
 export interface D1Stat extends DimStat {

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -10,7 +10,8 @@ import {
   DestinyItemTierTypeInfusionBlock,
   DestinyItemQualityBlockDefinition,
   DestinyAmmunitionType,
-  DestinyItemQuantity
+  DestinyItemQuantity,
+  DestinyDisplayPropertiesDefinition
 } from 'bungie-api-ts/destiny2';
 import { DimItemInfo } from './dim-item-info';
 import { DimStore, StoreServiceType, D1StoreServiceType, D2StoreServiceType } from './store-types';
@@ -78,7 +79,7 @@ export interface DimItem {
   /** The primary stat (Attack, Defense, Speed) of the item. */
   primStat:
     | DestinyStat & {
-        stat: DestinyStatDefinition & { statName: string };
+        stat: DestinyStatDefinition;
       }
     | null;
   /** Localized name of this item's type. */
@@ -260,7 +261,7 @@ export interface DimStat {
   /** DestinyStatDefinition hash. */
   statHash: number;
   /** Localized stat name. TODO: Replace with displayProperties */
-  name: string;
+  displayProperties: DestinyDisplayPropertiesDefinition;
   /** Sort order. */
   sort: number;
   /** Absolute stat value. */

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -388,7 +388,7 @@ export interface D1GridNode extends DimGridNode {
 }
 
 /**
- * Dim's view of a "Plug" - an item that can go into a socket.
+ * DIM's view of a "Plug" - an item that can go into a socket.
  * In D2, both perk grids and mods/shaders are sockets with plugs.
  */
 export interface DimPlug {

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -265,7 +265,7 @@ export interface DimStat {
   statHash: number;
   /** Localized stat name. */
   name: string;
-  /** Stat identifier. D1 only. */
+  /** Stat identifier. D1 only. TODO remove */
   id: number;
   /** Sort order. */
   sort: number;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -257,16 +257,10 @@ export interface DimMasterwork {
 }
 
 export interface DimStat {
-  /** Value of the investment stat, which may be different than the base stat. */
-  investmentValue: number;
-  /** Base stat without bonuses/mods/plugs applied. */
-  base: number;
   /** DestinyStatDefinition hash. */
   statHash: number;
-  /** Localized stat name. */
+  /** Localized stat name. TODO: Replace with displayProperties */
   name: string;
-  /** Stat identifier. D1 only. TODO remove */
-  id: number;
   /** Sort order. */
   sort: number;
   /** Absolute stat value. */
@@ -275,9 +269,16 @@ export interface DimStat {
   maximumValue: number;
   /** Should this be displayed as a bar or just a number? */
   bar: boolean;
+  /**
+   * Value of the investment stat, which may be different than the base stat.
+   * This is really just a temporary value while building stats and shouldn't be used anywhere.
+   */
+  investmentValue: number;
 }
 
 export interface D1Stat extends DimStat {
+  /** Base stat without bonus perks applied. */
+  base: number;
   scaled?: {
     max: number;
     min: number;
@@ -404,7 +405,7 @@ export interface DimPlug {
   enableFailReasons: string;
   /** Is this a Masterwork plug? */
   isMasterwork: boolean;
-  /** Stat modifications this plug can affect. */
+  /** Stats this plug modifies. If present, it's a map from the stat hash to the amount the stat is modified. */
   stats: {
     [statHash: number]: number;
   } | null;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -257,6 +257,8 @@ export interface DimMasterwork {
 }
 
 export interface DimStat {
+  /** Value of the investment stat, which may be different than the base stat. */
+  investmentValue: number;
   /** Base stat without bonuses/mods/plugs applied. */
   base: number;
   /** DestinyStatDefinition hash. */
@@ -268,7 +270,7 @@ export interface DimStat {
   /** Sort order. */
   sort: number;
   /** Absolute stat value. */
-  value?: number;
+  value: number;
   /** The maximum value this stat can have. */
   maximumValue: number;
   /** Should this be displayed as a bar or just a number? */
@@ -402,6 +404,10 @@ export interface DimPlug {
   enableFailReasons: string;
   /** Is this a Masterwork plug? */
   isMasterwork: boolean;
+  /** Stat modifications this plug can affect. */
+  stats: {
+    [statHash: number]: number;
+  } | null;
 }
 
 export interface DimSocket {

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -856,7 +856,6 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
 
         const dimStat: D1Stat = {
           base,
-          bonus,
           statHash: stat.statHash,
           name: def.statName,
           id: def.statIdentifier,

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -859,7 +859,6 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
           investmentValue: base,
           statHash: stat.statHash,
           name: def.statName,
-          id: def.statIdentifier,
           sort,
           value: val,
           maximumValue,

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -12,7 +12,7 @@ import { D1Store } from '../store-types';
 import { D1Item, D1TalentGrid, D1GridNode, DimObjective, D1Stat } from '../item-types';
 import { InventoryBuckets } from '../inventory-buckets';
 import { D1StoresService } from '../d1-stores.service';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { DestinyClass, DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 
 const yearHashes = {
   //         tTK       Variks        CoE         FoTL    Kings Fall
@@ -359,7 +359,15 @@ function makeItem(
   }
 
   if (createdItem.primStat) {
-    createdItem.primStat.stat = defs.Stat.get(createdItem.primStat.statHash);
+    const statDef = defs.Stat.get(createdItem.primStat.statHash);
+    createdItem.primStat.stat = statDef;
+    // D2 is much better about display info
+    statDef.displayProperties = {
+      name: statDef.statName,
+      description: statDef.statDescription,
+      icon: statDef.icon,
+      hasIcon: Boolean(statDef.icon)
+    };
   }
 
   // An item is new if it was previously known to be new, or if it's new since the last load (previousItems);
@@ -858,7 +866,10 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
           base,
           investmentValue: base,
           statHash: stat.statHash,
-          name: def.statName,
+          displayProperties: {
+            name: def.statName,
+            description: def.statDescription
+          } as DestinyDisplayPropertiesDefinition,
           sort,
           value: val,
           maximumValue,

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -828,7 +828,7 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
           maximumValue = itemStat.maximumValue;
         }
 
-        const val: number = itemStat ? itemStat.value : stat.value;
+        const val: number = (itemStat ? itemStat.value : stat.value) || 0;
         let base = val;
         let bonus = 0;
 
@@ -856,6 +856,7 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
 
         const dimStat: D1Stat = {
           base,
+          investmentValue: base,
           statHash: stat.statHash,
           name: def.statName,
           id: def.statIdentifier,

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -947,7 +947,8 @@ function buildPlug(
     isMasterwork:
       plugItem.hash !== 236077174 &&
       plugItem.hash !== 1176735155 &&
-      (!plugItem.itemCategoryHashes || plugItem.itemCategoryHashes.includes(141186804))
+      (!plugItem.itemCategoryHashes || plugItem.itemCategoryHashes.includes(141186804)),
+    stats: null
   };
 }
 
@@ -968,7 +969,9 @@ function buildDefinedPlug(
     enableFailReasons: '',
     plugObjectives: [],
     perks: (plugItem.perks || []).map((perk) => defs.SandboxPerk.get(perk.perkHash)),
-    isMasterwork: plugItem.plug && [2109207426, 2989652629].includes(plugItem.plug.plugCategoryHash)
+    isMasterwork:
+      plugItem.plug && [2109207426, 2989652629].includes(plugItem.plug.plugCategoryHash),
+    stats: null
   };
 }
 

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -1,18 +1,13 @@
 import {
   DestinyClass,
   DestinyInventoryItemDefinition,
-  DestinyInventoryItemStatDefinition,
   DestinyItemComponent,
   DestinyItemComponentSetOfint64,
   DestinyItemInstanceComponent,
-  DestinyItemInvestmentStatDefinition,
   DestinyItemObjectivesComponent,
   DestinyItemSocketsComponent,
-  DestinyItemStatsComponent,
   DestinyItemTalentGridComponent,
   DestinyObjectiveDefinition,
-  DestinyStat,
-  DestinyStatDefinition,
   DestinyTalentGridDefinition,
   ItemLocation,
   TransferStatuses,
@@ -38,7 +33,6 @@ import { t } from 'app/i18next-t';
 import {
   D2Item,
   DimPerk,
-  DimStat,
   DimObjective,
   DimFlavorObjective,
   DimTalentGrid,
@@ -52,7 +46,6 @@ import {
 import { D2Store } from '../store-types';
 import { InventoryBuckets } from '../inventory-buckets';
 import { D2StoresService } from '../d2-stores.service';
-import { filterPlugs } from '../../d2-loadout-builder/generated-sets/utils';
 import { D2CalculatedSeason, D2CurrentSeason } from './../d2-season-info';
 import { D2SourcesToEvent } from 'data/d2/d2-event-info';
 import D2Seasons from 'data/d2/seasons.json';
@@ -60,6 +53,7 @@ import D2SeasonToSource from 'data/d2/seasonToSource.json';
 import D2Events from 'data/d2/events.json';
 import idx from 'idx';
 import { compareBy, chainComparator } from 'app/comparators';
+import { buildStats } from './stats';
 
 // Maps tierType to tierTypeName in English
 const tiers = ['Unknown', 'Currency', 'Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'];
@@ -73,37 +67,6 @@ let _idTracker: { [id: string]: number } = {};
 const _moveTouchTimestamps = new Map<string, number>();
 
 const SourceToD2Season = D2SeasonToSource.sources;
-
-const statWhiteList = [
-  4284893193, // Rounds Per Minute
-  2961396640, // Charge Time
-  3614673599, // Blast Radius
-  2523465841, // Velocity
-  4043523819, // Impact
-  1240592695, // Range
-  155624089, // Stability
-  943549884, // Handling
-  4188031367, // Reload Speed
-  1345609583, // Aim Assistance
-  3555269338, // Zoom
-  2715839340, // Recoil Direction
-  3871231066, // Magazine
-  2996146975, // Mobility
-  392767087, // Resilience
-  1943323491, // Recovery
-  447667954, // Draw Time
-  1931675084 // Inventory Size
-  //    1935470627, // Power
-  // there are a few others (even an `undefined` stat)
-];
-
-const statsNoBar = [4284893193, 3871231066, 2961396640, 447667954, 1931675084];
-
-const hiddenStats = [
-  1345609583, // Aim Assistance
-  3555269338, // Zoom
-  2715839340 // Recoil Direction
-];
 
 const resistanceMods = {
   1546607977: DamageType.Kinetic,
@@ -448,26 +411,8 @@ export function makeItem(
   }
 
   try {
-    const statsData = idx(itemComponents, (i) => i.stats.data);
-    if (statsData) {
-      // Instanced stats
-      createdItem.stats = buildStats(item, createdItem.sockets, statsData, defs.Stat);
-      if (itemDef.stats && itemDef.stats.stats) {
-        // Hidden stats
-        createdItem.stats = (createdItem.stats || []).concat(
-          buildDefinitionStats(itemDef, defs.Stat, hiddenStats)
-        );
-      }
-    } else if (itemDef.stats && itemDef.stats.stats) {
-      // Item definition stats
-      createdItem.stats = buildDefinitionStats(itemDef, defs.Stat, statWhiteList);
-    }
-    // Investment stats
-    if (!createdItem.stats && itemDef.investmentStats && itemDef.investmentStats.length) {
-      createdItem.stats = buildInvestmentStats(itemDef.investmentStats, defs.Stat);
-    }
-
-    createdItem.stats = createdItem.stats && createdItem.stats.sort(compareBy((s) => s.sort));
+    // See stats.ts
+    createdItem.stats = buildStats(createdItem, itemDef, defs, item, itemComponents);
   } catch (e) {
     console.error(`Error building stats for ${createdItem.name}`, item, itemDef, e);
     reportException('Stats', e, { itemHash: item.itemHash });
@@ -646,184 +591,6 @@ function getSeason(item: D2Item): number {
   }
 
   return D2Seasons[item.hash] || D2CalculatedSeason || D2CurrentSeason;
-}
-
-/**
- * Stats that come from the base definition - we have no info about how they apply to an instance.
- */
-function buildDefinitionStats(
-  itemDef: DestinyInventoryItemDefinition,
-  statDefs: LazyDefinition<DestinyStatDefinition>,
-  statWhiteList: number[]
-): DimStat[] {
-  const itemStats = itemDef.stats.stats;
-
-  if (!itemStats) {
-    return [];
-  }
-
-  return _.compact(
-    _.map(itemStats, (stat: DestinyInventoryItemStatDefinition): DimStat | undefined => {
-      const def = statDefs.get(stat.statHash);
-
-      if (!statWhiteList.includes(stat.statHash) || !stat.value) {
-        return undefined;
-      }
-
-      return {
-        base: stat.value,
-        bonus: 0,
-        statHash: stat.statHash,
-        name: def.displayProperties.name,
-        id: stat.statHash,
-        sort: statWhiteList.indexOf(stat.statHash),
-        value: stat.value,
-        // Armor stats max out at 5, all others are... probably 100? See https://github.com/Bungie-net/api/issues/448
-        maximumValue: [1943323491, 392767087, 2996146975].includes(stat.statHash) ? 5 : 100,
-        bar: !statsNoBar.includes(stat.statHash)
-      };
-    })
-  );
-}
-
-/**
- * Instanced, precalculated stats.
- */
-function buildStats(
-  item: DestinyItemComponent,
-  sockets: DimSockets | null,
-  stats: { [key: string]: DestinyItemStatsComponent },
-  statDefs: LazyDefinition<DestinyStatDefinition>
-): DimStat[] {
-  if (!item.itemInstanceId || !stats[item.itemInstanceId]) {
-    return [];
-  }
-  const itemStats = stats[item.itemInstanceId].stats;
-
-  // determine bonuses for armor
-  const statBonuses = {};
-  if (sockets) {
-    const bonusPerk = sockets.sockets.find((socket) =>
-      Boolean(
-        // Mobility, Restorative, and Resilience perk
-        idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) === 3313201758
-      )
-    );
-    // If we didn't find one, then it's not armor.
-    if (bonusPerk) {
-      statBonuses[bonusPerk.plug!.plugItem.investmentStats[0].statTypeHash] = {
-        plugs: bonusPerk.plug!.plugItem.investmentStats[0].value,
-        perks: 0,
-        mods: 0
-      };
-
-      // Custom applied mods
-      sockets.sockets
-        .filter((socket) =>
-          Boolean(
-            idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) === 3347429529 &&
-              idx(socket.plug, (p) => p.plugItem.inventory.tierType) !== 2
-          )
-        )
-        .forEach((socket) => {
-          const bonusPerkStat = socket.plug!.plugItem.investmentStats[0];
-          if (bonusPerkStat) {
-            if (!statBonuses[bonusPerkStat.statTypeHash]) {
-              statBonuses[bonusPerkStat.statTypeHash] = { mods: 0 };
-            }
-            statBonuses[bonusPerkStat.statTypeHash].mods += bonusPerkStat.value;
-          }
-        });
-
-      // Look for perks that modify stats (ie. Traction 1818103563)
-      sockets.sockets
-        .filter((socket) =>
-          Boolean(
-            filterPlugs(socket) &&
-              idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) !== 3347429529 &&
-              idx(socket.plug, (p) => p.plugItem.investmentStats.length)
-          )
-        )
-        .forEach((socket) => {
-          const bonusPerkStat = socket.plug!.plugItem.investmentStats[0];
-          if (bonusPerkStat) {
-            if (!statBonuses[bonusPerkStat.statTypeHash]) {
-              statBonuses[bonusPerkStat.statTypeHash] = { perks: 0 };
-            }
-            statBonuses[bonusPerkStat.statTypeHash].perks += bonusPerkStat.value;
-          }
-        });
-    }
-  }
-
-  return _.compact(
-    Object.values(itemStats).map((stat: DestinyStat): DimStat | undefined => {
-      const def = statDefs.get(stat.statHash);
-      const itemStat = itemStats[stat.statHash];
-      if (!def || !itemStat) {
-        return undefined;
-      }
-
-      const value = itemStat ? itemStat.value : stat.value;
-      let base = value;
-      let bonus = 0;
-      let plugBonus = 0;
-      let modsBonus = 0;
-      let perkBonus = 0;
-      if (statBonuses[stat.statHash]) {
-        plugBonus = statBonuses[stat.statHash].plugs || 0;
-        modsBonus = statBonuses[stat.statHash].mods || 0;
-        perkBonus = statBonuses[stat.statHash].perks || 0;
-        bonus = plugBonus + perkBonus + modsBonus;
-        base -= bonus;
-      }
-
-      return {
-        base,
-        bonus,
-        plugBonus,
-        modsBonus,
-        perkBonus,
-        statHash: stat.statHash,
-        name: def.displayProperties.name,
-        id: stat.statHash,
-        sort: statWhiteList.indexOf(stat.statHash),
-        value,
-        maximumValue: itemStat.maximumValue,
-        bar: !statsNoBar.includes(stat.statHash)
-      };
-    })
-  );
-}
-
-/**
- * Build stats from the non-pre-sized investment stats.
- */
-function buildInvestmentStats(
-  itemStats: DestinyItemInvestmentStatDefinition[],
-  statDefs: LazyDefinition<DestinyStatDefinition>
-): DimStat[] {
-  return _.compact(
-    _.map(itemStats, (itemStat): DimStat | undefined => {
-      const def = statDefs.get(itemStat.statTypeHash);
-      /* 1935470627 = Power */
-      if (!def || !itemStat || itemStat.statTypeHash === 1935470627) {
-        return undefined;
-      }
-
-      return {
-        base: itemStat.value,
-        bonus: 0,
-        statHash: itemStat.statTypeHash,
-        name: def.displayProperties.name,
-        id: itemStat.statTypeHash,
-        sort: statWhiteList.indexOf(itemStat.statTypeHash),
-        value: itemStat.value,
-        maximumValue: 0,
-        bar: !statsNoBar.includes(itemStat.statTypeHash)
-      };
-    })
-  );
 }
 
 function buildObjectives(

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -373,7 +373,6 @@ export function makeItem(
   if (createdItem.primStat) {
     const statDef = defs.Stat.get(createdItem.primStat.statHash);
     createdItem.primStat.stat = Object.create(statDef);
-    createdItem.primStat.stat.statName = statDef.displayProperties.name;
   }
 
   // An item is new if it was previously known to be new, or if it's new since the last load (previousItems);

--- a/src/app/inventory/store/d2-item-factory.service.ts
+++ b/src/app/inventory/store/d2-item-factory.service.ts
@@ -411,8 +411,7 @@ export function makeItem(
   }
 
   try {
-    // See stats.ts
-    createdItem.stats = buildStats(createdItem, itemDef, defs, item, itemComponents);
+    createdItem.stats = buildStats(createdItem, itemDef, defs);
   } catch (e) {
     console.error(`Error building stats for ${createdItem.name}`, item, itemDef, e);
     reportException('Stats', e, { itemHash: item.itemHash });

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -429,7 +429,6 @@ function enhanceStatsWithPlugs(
               // values to how much each contributed. Maybe considering perks that don't have options
               // before perks that do...
               console.log(itemDef.displayProperties.name, 'adding', value, statHash);
-              itemStat.value += value;
               itemStat.value = Math.min(Math.max(0, itemStat.value), itemStat.maximumValue);
             }
           });

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -1,6 +1,9 @@
 import {
   DestinyInventoryItemDefinition,
-  DestinyStatDisplayDefinition
+  DestinyStatDisplayDefinition,
+  DestinyStatGroupDefinition,
+  DestinyItemInvestmentStatDefinition,
+  DestinyStatDefinition
 } from 'bungie-api-ts/destiny2';
 import { DimStat, D2Item, DimSocket, DimPlug } from '../item-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
@@ -38,15 +41,8 @@ export const statWhiteList = [
   // there are a few others (even an `undefined` stat)
 ];
 
-/** Stats that should be displayed without a bar (just a number) */
+/** Stats that should be forced to display without a bar (just a number). Mostly this is automatic. */
 const statsNoBar = [
-  /*
-  4284893193, // Rounds Per Minute
-  3871231066, // Magazine
-  2961396640, // Charge Time
-  447667954, // Draw Time
-  1931675084, // Inventory Size
-  */
   2715839340 // Recoil Direction
 ];
 
@@ -57,21 +53,38 @@ const armorStats = [
   2996146975 // Mobility
 ];
 
-/** Built the full list of stats for an item. If the item has no stats, this returns null. */
+/** Build the full list of stats for an item. If the item has no stats, this returns null. */
 export function buildStats(
   createdItem: D2Item,
   itemDef: DestinyInventoryItemDefinition,
   defs: D2ManifestDefinitions
 ) {
-  let investmentStats = buildInvestmentStats(itemDef, defs) || [];
+  if (!itemDef.stats || !itemDef.stats.statGroupHash) {
+    return null;
+  }
+  const statGroup = defs.StatGroup.get(itemDef.stats.statGroupHash);
+  if (!statGroup) {
+    return null;
+  }
+
+  const statDisplays = _.keyBy(statGroup.scaledStats, (s) => s.statHash);
+
+  // We only use the raw "investment" stats to calculate all item stats.
+  let investmentStats = buildInvestmentStats(itemDef, defs, statGroup, statDisplays) || [];
+
+  // Include the contributions from perks and mods
   if (createdItem.sockets && createdItem.sockets.sockets.length) {
     investmentStats = enhanceStatsWithPlugs(
       investmentStats,
       createdItem.sockets.sockets,
-      itemDef,
-      defs
+      defs,
+      statGroup,
+      statDisplays
     );
   }
+
+  // Armor won't have stats it doesn't have any points in, so we need to
+  // fill them in.
   if (
     investmentStats.length &&
     createdItem.bucket.inArmor &&
@@ -84,7 +97,164 @@ export function buildStats(
   return investmentStats.length ? investmentStats.sort(compareBy((s) => s.sort)) : null;
 }
 
-// TODO: not for cloaks though...
+/**
+ * Build stats from the non-pre-sized investment stats. Destiny stats come in two flavors - precalculated
+ * by the API, and "investment stats" which are the raw game values. The latter must be transformed into
+ * what you see in the game, but as a result you can see "hidden" stats at their true value, and calculate
+ * the value that perks and mods contribute to the overall stat value.
+ */
+function buildInvestmentStats(
+  itemDef: DestinyInventoryItemDefinition,
+  defs: D2ManifestDefinitions,
+  statGroup: DestinyStatGroupDefinition,
+  statDisplays: { [key: number]: DestinyStatDisplayDefinition }
+): DimStat[] | null {
+  const itemStats = itemDef.investmentStats || [];
+
+  return _.compact(
+    Object.values(itemStats).map((itemStat): DimStat | undefined => {
+      const statHash = itemStat.statTypeHash;
+      if (!itemStat || !statWhiteList.includes(statHash)) {
+        return undefined;
+      }
+
+      const def = defs.Stat.get(statHash);
+      if (!def) {
+        return undefined;
+      }
+
+      return buildStat(itemStat, statGroup, def, statDisplays);
+    })
+  );
+}
+
+function buildStat(
+  itemStat: DestinyItemInvestmentStatDefinition,
+  statGroup: DestinyStatGroupDefinition,
+  statDef: DestinyStatDefinition,
+  statDisplays: { [key: number]: DestinyStatDisplayDefinition }
+) {
+  const statHash = itemStat.statTypeHash;
+  let value = itemStat.value || 0;
+  let maximumValue = statGroup.maximumValue;
+  let bar = !statsNoBar.includes(statHash);
+  const statDisplay = statDisplays[statHash];
+  if (statDisplay) {
+    maximumValue = statDisplay.maximumValue;
+    bar = !statDisplay.displayAsNumeric;
+    value = interpolateStatValue(value, statDisplay);
+  }
+  value = Math.min(Math.max(0, value), maximumValue);
+
+  return {
+    investmentValue: itemStat.value || 0,
+    statHash,
+    displayProperties: statDef.displayProperties,
+    sort: statWhiteList.indexOf(statHash),
+    value,
+    maximumValue,
+    bar
+  };
+}
+
+function enhanceStatsWithPlugs(
+  stats: DimStat[],
+  sockets: DimSocket[],
+  defs: D2ManifestDefinitions,
+  statGroup: DestinyStatGroupDefinition,
+  statDisplays: { [key: number]: DestinyStatDisplayDefinition }
+) {
+  const statsByHash = _.keyBy(stats, (s) => s.statHash);
+
+  const modifiedStats = new Set<number>();
+
+  // Add the chosen plugs' investment stats to the item's base investment stats
+  for (const socket of sockets) {
+    if (socket.plug) {
+      for (const perkStat of socket.plug.plugItem.investmentStats) {
+        const statHash = perkStat.statTypeHash;
+        const itemStat = statsByHash[statHash];
+        const value = perkStat.value || 0;
+        if (itemStat) {
+          itemStat.investmentValue += value;
+        } else if (statWhiteList.includes(statHash)) {
+          // This stat didn't exist before we modified it, so add it here.
+          const stat = socket.plug.plugItem.investmentStats.find(
+            (s) => s.statTypeHash === statHash
+          );
+
+          if (stat && stat.value) {
+            const statDef = defs.Stat.get(statHash);
+            const builtStat = buildStat(stat, statGroup, statDef, statDisplays);
+            statsByHash[statHash] = builtStat;
+            stats.push(statsByHash[statHash]);
+          }
+        }
+        modifiedStats.add(statHash);
+      }
+    }
+  }
+
+  // Now calculate the actual, interpolated value of all stats after they've been modified
+  for (const stat of stats) {
+    if (modifiedStats.has(stat.statHash)) {
+      const statDisplay = statDisplays[stat.statHash];
+      stat.value = statDisplay
+        ? interpolateStatValue(stat.investmentValue, statDisplays[stat.statHash])
+        : stat.investmentValue;
+    }
+  }
+
+  // We sort the sockets by length so that we count contributions from plugs with fewer options first.
+  // This is because multiple plugs can contribute to the same stat, so we want to sink the non-changeable
+  // stats in first.
+  const sortedSockets = _.sortBy(sockets, (s) => s.plugOptions.length);
+  for (const socket of sortedSockets) {
+    for (const plug of socket.plugOptions) {
+      if (plug.plugItem && plug.plugItem.investmentStats && plug.plugItem.investmentStats.length) {
+        plug.stats = buildPlugStats(plug, statsByHash, statDisplays);
+      }
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * For each stat this plug modified, calculate how much it modifies that stat.
+ *
+ * Returns a map from stat hash to stat value.
+ */
+function buildPlugStats(
+  plug: DimPlug,
+  statsByHash: { [statHash: number]: DimStat },
+  statDisplays: { [statHash: number]: DestinyStatDisplayDefinition }
+) {
+  const stats: {
+    [statHash: number]: number;
+  } = {};
+
+  for (const perkStat of plug.plugItem.investmentStats) {
+    let value = perkStat.value || 0;
+    const itemStat = statsByHash[perkStat.statTypeHash];
+    const statDisplay = statDisplays[perkStat.statTypeHash];
+    if (itemStat && statDisplay) {
+      // This is a scaled stat, so we need to scale it in context of the original investment stat.
+      // Figure out what the interpolated stat value would be without this perk's contribution, and
+      // then take the difference between the total value and that to find the contribution.
+      const valueWithoutPerk = interpolateStatValue(itemStat.investmentValue - value, statDisplay);
+      value = itemStat.value - valueWithoutPerk;
+    }
+    stats[perkStat.statTypeHash] = value;
+  }
+
+  return stats;
+}
+
+/**
+ * Armor won't have stats it doesn't have any points in, so we need to fill them in
+ * based on a hardcoded list.
+ */
 function fillInArmorStats(
   investmentStats: DimStat[],
   itemDef: DestinyInventoryItemDefinition,
@@ -129,65 +299,10 @@ function fillInArmorStats(
 }
 
 /**
- * Build stats from the non-pre-sized investment stats.
+ * Some stats have an item-specific interpolation table, which is defined as
+ * a piecewise linear function mapping input stat values to output stat values.
  */
-function buildInvestmentStats(
-  itemDef: DestinyInventoryItemDefinition,
-  defs: D2ManifestDefinitions
-): DimStat[] | null {
-  const itemStats = itemDef.investmentStats || [];
-  if (!itemDef.stats || !itemDef.stats.statGroupHash) {
-    return null;
-  }
-  const statGroup = defs.StatGroup.get(itemDef.stats.statGroupHash);
-  if (!statGroup) {
-    return null;
-  }
-
-  const statDisplays = _.keyBy(statGroup.scaledStats, (s) => s.statHash);
-
-  // TODO: loadout optimizer is only counting bonuses from switchable perks
-
-  return _.compact(
-    Object.values(itemStats).map((itemStat): DimStat | undefined => {
-      const statHash = itemStat.statTypeHash;
-      if (!itemStat || !statWhiteList.includes(statHash)) {
-        return undefined;
-      }
-
-      const def = defs.Stat.get(statHash);
-      if (!def) {
-        return undefined;
-      }
-
-      // TODO: extract this stat-building code
-      let value = itemStat.value || 0;
-      let maximumValue = statGroup.maximumValue;
-      let bar = !statsNoBar.includes(statHash);
-      const statDisplay = statDisplays[statHash];
-      if (statDisplay) {
-        maximumValue = statDisplay.maximumValue;
-        bar = !statDisplay.displayAsNumeric;
-        value = interpolateStatValue(value, statDisplay);
-      }
-      value = Math.min(Math.max(0, value), maximumValue);
-
-      return {
-        investmentValue: itemStat.value || 0,
-        statHash,
-        displayProperties: def.displayProperties,
-        sort: statWhiteList.indexOf(statHash),
-        value,
-        maximumValue,
-        bar
-      };
-    })
-  );
-}
-
 function interpolateStatValue(value: number, statDisplay: DestinyStatDisplayDefinition) {
-  // Some stats have an item-specific interpolation table, which is defined as
-  // a piecewise linear function mapping input stat values to output stat values.
   const interp = statDisplay.displayInterpolation;
   let endIndex = interp.findIndex((p) => p.value > value);
   if (endIndex < 0) {
@@ -205,147 +320,4 @@ function interpolateStatValue(value: number, statDisplay: DestinyStatDisplayDefi
   const t = (value - start.value) / (end.value - start.value);
 
   return Math.round(start.weight + t * (end.weight - start.weight));
-}
-
-function enhanceStatsWithPlugs(
-  stats: DimStat[],
-  sockets: DimSocket[],
-  itemDef: DestinyInventoryItemDefinition,
-  defs: D2ManifestDefinitions
-) {
-  if (!itemDef.stats || !itemDef.stats.statGroupHash) {
-    return stats;
-  }
-  const statGroup = defs.StatGroup.get(itemDef.stats.statGroupHash);
-  if (!statGroup) {
-    return stats;
-  }
-
-  // TODO: calculate this once...
-  const statDisplays = _.keyBy(statGroup.scaledStats, (s) => s.statHash);
-  const statsByHash = _.keyBy(stats, (s) => s.statHash);
-
-  // Add the chosen plugs' investment stats to the item's base investment stats
-  for (const socket of sockets) {
-    if (socket.plug) {
-      for (const perkStat of socket.plug.plugItem.investmentStats) {
-        const statHash = perkStat.statTypeHash;
-        const itemStat = statsByHash[statHash];
-        const value = perkStat.value || 0;
-        if (itemStat) {
-          itemStat.investmentValue += value;
-        } else if (statWhiteList.includes(statHash)) {
-          // This stat didn't exist before we modified it, so add it here.
-          const stat = socket.plug.plugItem.investmentStats.find(
-            (s) => s.statTypeHash === statHash
-          );
-
-          if (stat && stat.value) {
-            let maximumValue = statGroup.maximumValue;
-            let bar = !statsNoBar.includes(statHash);
-            const statDisplay = statDisplays[statHash];
-            if (statDisplay) {
-              maximumValue = statDisplay.maximumValue;
-              bar = !statDisplay.displayAsNumeric;
-            }
-
-            statsByHash[statHash] = {
-              investmentValue: stat.value || 0,
-              value,
-              statHash,
-              displayProperties: defs.Stat.get(statHash).displayProperties,
-              sort: statWhiteList.indexOf(statHash),
-              maximumValue,
-              bar
-            };
-
-            stats.push(statsByHash[statHash]);
-          }
-        }
-      }
-    }
-  }
-
-  for (const stat of stats) {
-    const statDisplay = statDisplays[stat.statHash];
-    stat.value = statDisplay
-      ? interpolateStatValue(stat.investmentValue, statDisplays[stat.statHash])
-      : stat.investmentValue;
-  }
-
-  // We sort the sockets by length so that we count contributions from plugs with fewer options first.
-  // This is because multiple plugs can contribute to the same stat, so we want to sink the non-changeable
-  // stats in first.
-  const sortedSockets = _.sortBy(sockets, (s) => s.plugOptions.length);
-
-  for (const socket of sortedSockets) {
-    for (const plug of socket.plugOptions) {
-      if (plug.plugItem && plug.plugItem.investmentStats && plug.plugItem.investmentStats.length) {
-        plug.stats = buildPlugStats(plug, statsByHash, statDisplays);
-
-        if (plug === socket.plug) {
-          _.forIn(plug.stats, (value, statHashStr) => {
-            const statHash = parseInt(statHashStr, 10);
-            const itemStat = statsByHash[statHash];
-            if (!itemStat) {
-              if (statWhiteList.includes(statHash)) {
-                // This stat didn't exist before we modified it, so add it here.
-                const stat = plug.plugItem.investmentStats.find((s) => s.statTypeHash === statHash);
-
-                if (stat && stat.value) {
-                  let maximumValue = statGroup.maximumValue;
-                  let bar = !statsNoBar.includes(statHash);
-                  const statDisplay = statDisplays[statHash];
-                  if (statDisplay) {
-                    maximumValue = statDisplay.maximumValue;
-                    bar = !statDisplay.displayAsNumeric;
-                  }
-
-                  statsByHash[statHash] = {
-                    investmentValue: stat.value || 0,
-                    value,
-                    statHash,
-                    displayProperties: defs.Stat.get(statHash).displayProperties,
-                    sort: statWhiteList.indexOf(statHash),
-                    maximumValue,
-                    bar
-                  };
-
-                  stats.push(statsByHash[statHash]);
-                }
-              }
-            } else {
-              itemStat.value = Math.min(Math.max(0, itemStat.value), itemStat.maximumValue);
-            }
-          });
-        }
-      }
-    }
-  }
-
-  return stats;
-}
-
-function buildPlugStats(
-  plug: DimPlug,
-  statsByHash: { [statHash: number]: DimStat },
-  statDisplays: { [statHash: number]: DestinyStatDisplayDefinition }
-) {
-  const stats: {
-    [statHash: number]: number;
-  } = {};
-
-  for (const perkStat of plug.plugItem.investmentStats) {
-    let value = perkStat.value || 0;
-    const itemStat = statsByHash[perkStat.statTypeHash];
-    const statDisplay = statDisplays[perkStat.statTypeHash];
-    if (itemStat && statDisplay) {
-      // This is a scaled stat, so we need to scale it in context of the original investment stat
-      const valueWithoutPerk = interpolateStatValue(itemStat.investmentValue - value, statDisplay);
-      value = itemStat.value - valueWithoutPerk;
-    }
-    stats[perkStat.statTypeHash] = value;
-  }
-
-  return stats;
 }

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -1,0 +1,281 @@
+import {
+  DestinyItemComponent,
+  DestinyInventoryItemDefinition,
+  DestinyItemStatsComponent,
+  DestinyStatDefinition,
+  DestinyStat,
+  DestinyItemInvestmentStatDefinition,
+  DestinyItemComponentSetOfint64
+} from 'bungie-api-ts/destiny2';
+import { DimSockets, DimStat, D2Item } from '../item-types';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
+import idx from 'idx';
+import { compareBy } from 'app/comparators';
+import { LazyDefinition } from 'app/destiny1/d1-definitions.service';
+import { filterPlugs } from 'app/d2-loadout-builder/generated-sets/utils';
+import _ from 'lodash';
+
+/**
+ * These are the utilities that deal with Stats on items - specifically, how to calculate them.
+ *
+ * This is called from within d2-item-factory.service.ts
+ */
+
+/**
+ * Which stats to display, and in which order.
+ */
+const statWhiteList = [
+  4284893193, // Rounds Per Minute
+  2961396640, // Charge Time
+  3614673599, // Blast Radius
+  2523465841, // Velocity
+  4043523819, // Impact
+  1240592695, // Range
+  155624089, // Stability
+  943549884, // Handling
+  4188031367, // Reload Speed
+  1345609583, // Aim Assistance
+  3555269338, // Zoom
+  2715839340, // Recoil Direction
+  3871231066, // Magazine
+  2996146975, // Mobility
+  392767087, // Resilience
+  1943323491, // Recovery
+  447667954, // Draw Time
+  1931675084 // Inventory Size
+  //    1935470627, // Power
+  // there are a few others (even an `undefined` stat)
+];
+
+/** Stats that should be displayed without a bar (just a number) */
+const statsNoBar = [
+  4284893193, // Rounds Per Minute
+  3871231066, // Magazine
+  2961396640, // Charge Time
+  447667954, // Draw Time
+  1931675084 // Inventory Size
+];
+
+/** Additional "hidden" stats that don't come from the precalculated stats but which we still want to display. */
+const hiddenStats = [
+  1345609583, // Aim Assistance
+  3555269338, // Zoom
+  2715839340 // Recoil Direction
+];
+
+/** Stats that max at 5 instead of 100 */
+const statsMax5 = [
+  1943323491, // Recovery
+  392767087, // Resilience
+  2996146975 // Mobility
+];
+
+/** Built the full list of stats for an item. If the item has no stats, this returns null. */
+export function buildStats(
+  createdItem: D2Item,
+  itemDef: DestinyInventoryItemDefinition,
+  defs: D2ManifestDefinitions,
+  item: DestinyItemComponent,
+  itemComponents?: DestinyItemComponentSetOfint64
+) {
+  let stats: DimStat[] | null = null;
+
+  const statsData = idx(itemComponents, (i) => i.stats.data);
+  if (statsData) {
+    // Instanced stats
+    stats = buildPrecalculatedStats(item, createdItem.sockets, statsData, defs.Stat);
+    if (itemDef.stats && itemDef.stats.stats) {
+      // Hidden stats
+      stats = (createdItem.stats || []).concat(
+        buildDefinitionStats(itemDef, defs.Stat, hiddenStats)
+      );
+    }
+  } else if (itemDef.stats && itemDef.stats.stats) {
+    // Item definition stats
+    stats = buildDefinitionStats(itemDef, defs.Stat, statWhiteList);
+  }
+  // Investment stats
+  if (!createdItem.stats && itemDef.investmentStats && itemDef.investmentStats.length) {
+    stats = buildInvestmentStats(itemDef.investmentStats, defs.Stat);
+  }
+
+  return stats && stats.sort(compareBy((s) => s.sort));
+}
+
+/**
+ * Instanced, precalculated stats.
+ */
+function buildPrecalculatedStats(
+  item: DestinyItemComponent,
+  sockets: DimSockets | null,
+  stats: { [key: string]: DestinyItemStatsComponent },
+  statDefs: LazyDefinition<DestinyStatDefinition>
+): DimStat[] {
+  if (!item.itemInstanceId || !stats[item.itemInstanceId]) {
+    return [];
+  }
+  const itemStats = stats[item.itemInstanceId].stats;
+
+  // determine bonuses for armor
+  const statBonuses = {};
+  if (sockets) {
+    const bonusPerk = sockets.sockets.find((socket) =>
+      Boolean(
+        // Mobility, Restorative, and Resilience perk
+        idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) === 3313201758
+      )
+    );
+    // If we didn't find one, then it's not armor.
+    if (bonusPerk) {
+      statBonuses[bonusPerk.plug!.plugItem.investmentStats[0].statTypeHash] = {
+        plugs: bonusPerk.plug!.plugItem.investmentStats[0].value,
+        perks: 0,
+        mods: 0
+      };
+
+      // Custom applied mods
+      sockets.sockets
+        .filter((socket) =>
+          Boolean(
+            idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) === 3347429529 &&
+              idx(socket.plug, (p) => p.plugItem.inventory.tierType) !== 2
+          )
+        )
+        .forEach((socket) => {
+          const bonusPerkStat = socket.plug!.plugItem.investmentStats[0];
+          if (bonusPerkStat) {
+            if (!statBonuses[bonusPerkStat.statTypeHash]) {
+              statBonuses[bonusPerkStat.statTypeHash] = { mods: 0 };
+            }
+            statBonuses[bonusPerkStat.statTypeHash].mods += bonusPerkStat.value;
+          }
+        });
+
+      // Look for perks that modify stats (ie. Traction 1818103563)
+      sockets.sockets
+        .filter((socket) =>
+          Boolean(
+            filterPlugs(socket) &&
+              idx(socket.plug, (p) => p.plugItem.plug.plugCategoryHash) !== 3347429529 &&
+              idx(socket.plug, (p) => p.plugItem.investmentStats.length)
+          )
+        )
+        .forEach((socket) => {
+          const bonusPerkStat = socket.plug!.plugItem.investmentStats[0];
+          if (bonusPerkStat) {
+            if (!statBonuses[bonusPerkStat.statTypeHash]) {
+              statBonuses[bonusPerkStat.statTypeHash] = { perks: 0 };
+            }
+            statBonuses[bonusPerkStat.statTypeHash].perks += bonusPerkStat.value;
+          }
+        });
+    }
+  }
+
+  return _.compact(
+    Object.values(itemStats).map((stat: DestinyStat): DimStat | undefined => {
+      const def = statDefs.get(stat.statHash);
+      const itemStat = itemStats[stat.statHash];
+      if (!def || !itemStat) {
+        return undefined;
+      }
+
+      const value = itemStat ? itemStat.value : stat.value;
+      let base = value;
+      let bonus = 0;
+      let plugBonus = 0;
+      let modsBonus = 0;
+      let perkBonus = 0;
+      if (statBonuses[stat.statHash]) {
+        plugBonus = statBonuses[stat.statHash].plugs || 0;
+        modsBonus = statBonuses[stat.statHash].mods || 0;
+        perkBonus = statBonuses[stat.statHash].perks || 0;
+        bonus = plugBonus + perkBonus + modsBonus;
+        base -= bonus;
+      }
+
+      return {
+        base,
+        bonus,
+        plugBonus,
+        modsBonus,
+        perkBonus,
+        statHash: stat.statHash,
+        name: def.displayProperties.name,
+        id: stat.statHash,
+        sort: statWhiteList.indexOf(stat.statHash),
+        value,
+        maximumValue: itemStat.maximumValue,
+        bar: !statsNoBar.includes(stat.statHash)
+      };
+    })
+  );
+}
+
+/**
+ * Build stats from the non-pre-sized investment stats.
+ */
+function buildInvestmentStats(
+  itemStats: DestinyItemInvestmentStatDefinition[],
+  statDefs: LazyDefinition<DestinyStatDefinition>
+): DimStat[] {
+  return _.compact(
+    _.map(itemStats, (itemStat): DimStat | undefined => {
+      const def = statDefs.get(itemStat.statTypeHash);
+      /* 1935470627 = Power */
+      if (!def || !itemStat || itemStat.statTypeHash === 1935470627) {
+        return undefined;
+      }
+
+      return {
+        base: itemStat.value,
+        bonus: 0,
+        statHash: itemStat.statTypeHash,
+        name: def.displayProperties.name,
+        id: itemStat.statTypeHash,
+        sort: statWhiteList.indexOf(itemStat.statTypeHash),
+        value: itemStat.value,
+        maximumValue: 0,
+        bar: !statsNoBar.includes(itemStat.statTypeHash)
+      };
+    })
+  );
+}
+
+/**
+ * Stats that come from the base definition - we have no info about how they apply to an instance.
+ */
+function buildDefinitionStats(
+  itemDef: DestinyInventoryItemDefinition,
+  statDefs: LazyDefinition<DestinyStatDefinition>,
+  statWhiteList: number[]
+): DimStat[] {
+  const itemStats = itemDef.stats.stats;
+
+  if (!itemStats) {
+    return [];
+  }
+
+  return _.compact(
+    Object.values(itemStats).map((stat): DimStat | undefined => {
+      const def = statDefs.get(stat.statHash);
+
+      if (!stat.value || !statWhiteList.includes(stat.statHash)) {
+        return undefined;
+      }
+
+      return {
+        base: stat.value,
+        bonus: 0,
+        statHash: stat.statHash,
+        name: def.displayProperties.name,
+        id: stat.statHash,
+        sort: statWhiteList.indexOf(stat.statHash),
+        value: stat.value,
+        // Armor stats max out at 5, all others are... probably 100? See https://github.com/Bungie-net/api/issues/448
+        maximumValue: statsMax5.includes(stat.statHash) ? 5 : 100,
+        bar: !statsNoBar.includes(stat.statHash)
+      };
+    })
+  );
+}

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -4,9 +4,10 @@ import {
   DestinyItemStatsComponent,
   DestinyStatDefinition,
   DestinyStat,
-  DestinyItemComponentSetOfint64
+  DestinyItemComponentSetOfint64,
+  DestinyStatDisplayDefinition
 } from 'bungie-api-ts/destiny2';
-import { DimSockets, DimStat, D2Item } from '../item-types';
+import { DimSockets, DimStat, D2Item, DimSocket, DimPlug } from '../item-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions.service';
 import idx from 'idx';
 import { compareBy } from 'app/comparators';
@@ -23,7 +24,7 @@ import _ from 'lodash';
 /**
  * Which stats to display, and in which order.
  */
-const statWhiteList = [
+export const statWhiteList = [
   4284893193, // Rounds Per Minute
   2961396640, // Charge Time
   3614673599, // Blast Radius
@@ -93,7 +94,21 @@ export function buildStats(
   }
   // Investment stats (This never happens!)
   if (itemDef.investmentStats && itemDef.investmentStats.length) {
-    stats = [...(stats || []), ...(buildInvestmentStats(itemDef, defs) || [])];
+    let investmentStats = buildInvestmentStats(itemDef, defs);
+    if (
+      investmentStats &&
+      investmentStats.length &&
+      createdItem.sockets &&
+      createdItem.sockets.sockets.length
+    ) {
+      investmentStats = enhanceStatsWithPlugs(
+        investmentStats,
+        createdItem.sockets.sockets,
+        itemDef,
+        defs
+      );
+    }
+    stats = [...(stats || []), ...(investmentStats || [])];
   }
 
   return stats && stats.sort(compareBy((s) => s.sort));
@@ -177,7 +192,7 @@ function buildPrecalculatedStats(
         return undefined;
       }
 
-      const value = itemStat ? itemStat.value : stat.value;
+      const value = (itemStat ? itemStat.value : stat.value) || 0;
       let base = value;
       let bonus = 0;
       let plugBonus = 0;
@@ -193,6 +208,7 @@ function buildPrecalculatedStats(
 
       return {
         base,
+        investmentValue: base,
         statHash: stat.statHash,
         name: def.displayProperties.name,
         id: stat.statHash,
@@ -238,37 +254,19 @@ function buildInvestmentStats(
         return undefined;
       }
 
-      let value = itemStat.value;
+      let value = itemStat.value || 0;
       let maximumValue = statGroup.maximumValue;
       let bar = !statsNoBar.includes(statHash);
       const statDisplay = statDisplays[statHash];
       if (statDisplay) {
         maximumValue = statDisplay.maximumValue;
         bar = !statDisplay.displayAsNumeric;
-
-        // Some stats have an item-specific interpolation table, which is defined as
-        // a piecewise linear function mapping input stat values to output stat values.
-        const interp = statDisplay.displayInterpolation;
-        const startIndex = Math.max(0, interp.findIndex((p) => p.value <= value));
-        const endIndex = Math.min(startIndex + 1, interp.length - 1);
-
-        const start = interp[startIndex];
-        const end = interp[endIndex];
-        const t = Math.min(1.0, (value - start.value) / (end.value - start.value));
-
-        value = Math.floor(start.weight + t * (end.weight - start.weight));
-        /*
-        console.log(
-          itemDef.displayProperties.name,
-          def.displayProperties.name,
-          { maximumValue, bar, interp },
-          { start, end, t, value, base: itemStat.value }
-        );
-        */
+        value = interpolateStatValue(value, statDisplay);
       }
 
       return {
         base: value,
+        investmentValue: itemStat.value || 0,
         statHash,
         // TODO: replace with displayProperties
         name: '_' + def.displayProperties.name,
@@ -280,6 +278,20 @@ function buildInvestmentStats(
       };
     })
   );
+}
+
+function interpolateStatValue(value: number, statDisplay: DestinyStatDisplayDefinition) {
+  // Some stats have an item-specific interpolation table, which is defined as
+  // a piecewise linear function mapping input stat values to output stat values.
+  const interp = statDisplay.displayInterpolation;
+  const startIndex = Math.max(0, interp.findIndex((p) => p.value > value) - 1);
+  const endIndex = Math.min(startIndex + 1, interp.length - 1);
+
+  const start = interp[startIndex];
+  const end = interp[endIndex];
+  const t = Math.min(1.0, (value - start.value) / (end.value - start.value));
+
+  return Math.round(start.weight + t * (end.weight - start.weight));
 }
 
 /**
@@ -302,12 +314,13 @@ function buildDefinitionStats(
     Object.values(itemStats).map((stat): DimStat | undefined => {
       const def = statDefs.get(stat.statHash);
 
-      if (!stat.value || !whitelist.includes(stat.statHash)) {
+      if (stat.value === undefined || !whitelist.includes(stat.statHash)) {
         return undefined;
       }
 
       return {
         base: stat.value,
+        investmentValue: stat.value,
         statHash: stat.statHash,
         name: def.displayProperties.name,
         id: stat.statHash,
@@ -319,4 +332,93 @@ function buildDefinitionStats(
       };
     })
   );
+}
+
+function enhanceStatsWithPlugs(
+  stats: DimStat[],
+  sockets: DimSocket[],
+  itemDef: DestinyInventoryItemDefinition,
+  defs: D2ManifestDefinitions
+) {
+  if (!itemDef.stats || !itemDef.stats.statGroupHash) {
+    return stats;
+  }
+  const statGroup = defs.StatGroup.get(itemDef.stats.statGroupHash);
+  if (!statGroup) {
+    return stats;
+  }
+
+  // TODO: calculate this once...
+  const statDisplays = _.keyBy(statGroup.scaledStats, (s) => s.statHash);
+  const statsByHash = _.keyBy(stats, (s) => s.statHash);
+
+  for (const socket of sockets) {
+    for (const plug of socket.plugOptions) {
+      if (plug.plugItem && plug.plugItem.investmentStats && plug.plugItem.investmentStats.length) {
+        plug.stats = buildPlugStats(
+          plug,
+          statsByHash,
+          statDisplays,
+          itemDef.displayProperties.name
+        );
+
+        if (plug === socket.plug) {
+          _.forIn(plug.stats, (value, statHash) => {
+            const itemStat = statsByHash[statHash];
+            if (!itemStat) {
+              // TODO add the stat!
+            } else {
+              /*
+              console.log(
+                itemDef.displayProperties.name,
+                defs.Stat.get(parseInt(statHash, 10)).displayProperties.name,
+                value,
+                plug.stats
+              );
+              */
+              itemStat.value += value;
+            }
+          });
+        }
+      }
+    }
+  }
+
+  return stats;
+}
+
+function buildPlugStats(
+  plug: DimPlug,
+  statsByHash: { [statHash: number]: DimStat },
+  statDisplays: { [statHash: number]: DestinyStatDisplayDefinition },
+  name: string
+) {
+  const stats: {
+    [statHash: number]: number;
+  } = {};
+
+  for (const perkStat of plug.plugItem.investmentStats) {
+    let value = perkStat.value || 0;
+    const itemStat = statsByHash[perkStat.statTypeHash];
+    const statDisplay = statDisplays[perkStat.statTypeHash];
+    if (itemStat && statDisplay) {
+      // This is a scaled stat, so we need to scale it in context of the original investment stat
+      const valueWithPerk = interpolateStatValue(value + itemStat.investmentValue, statDisplay);
+      /*
+      console.log(
+        name,
+        perkStat.statTypeHash,
+        value,
+        itemStat.investmentValue,
+        itemStat.base,
+        valueWithPerk,
+        statDisplay.displayInterpolation
+      );
+      */
+      value = valueWithPerk - itemStat.base;
+    }
+    stats[perkStat.statTypeHash] = value;
+  }
+
+  return stats;
 }

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -116,8 +116,7 @@ function fillInArmorStats(
       investmentStats.push({
         investmentValue: 0,
         statHash,
-        // TODO: replace with displayProperties
-        name: def.displayProperties.name,
+        displayProperties: def.displayProperties,
         sort: statWhiteList.indexOf(statHash),
         value,
         maximumValue,
@@ -176,8 +175,7 @@ function buildInvestmentStats(
       return {
         investmentValue: itemStat.value || 0,
         statHash,
-        // TODO: replace with displayProperties
-        name: def.displayProperties.name,
+        displayProperties: def.displayProperties,
         sort: statWhiteList.indexOf(statHash),
         value,
         maximumValue,
@@ -255,7 +253,7 @@ function enhanceStatsWithPlugs(
               investmentValue: stat.value || 0,
               value,
               statHash,
-              name: defs.Stat.get(statHash).displayProperties.name,
+              displayProperties: defs.Stat.get(statHash).displayProperties,
               sort: statWhiteList.indexOf(statHash),
               maximumValue,
               bar
@@ -307,7 +305,7 @@ function enhanceStatsWithPlugs(
                     investmentValue: stat.value || 0,
                     value,
                     statHash,
-                    name: defs.Stat.get(statHash).displayProperties.name,
+                    displayProperties: defs.Stat.get(statHash).displayProperties,
                     sort: statWhiteList.indexOf(statHash),
                     maximumValue,
                     bar

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -83,6 +83,7 @@ export function buildStats(
 ) {
   let stats: DimStat[] | null = null;
 
+  /*
   const statsData = idx(itemComponents, (i) => i.stats.data);
   if (statsData) {
     // Instanced stats
@@ -95,11 +96,9 @@ export function buildStats(
     // Item definition stats
     stats = buildDefinitionStats(itemDef, defs.Stat);
   }
+  */
   // Investment stats (This never happens!)
   let investmentStats = buildInvestmentStats(itemDef, defs) || [];
-  if (createdItem.bucket.inArmor && itemDef.stats && itemDef.stats.statGroupHash) {
-    investmentStats = fillInArmorStats(investmentStats, itemDef, defs);
-  }
   if (createdItem.sockets && createdItem.sockets.sockets.length) {
     investmentStats = enhanceStatsWithPlugs(
       investmentStats,
@@ -108,11 +107,20 @@ export function buildStats(
       defs
     );
   }
+  if (
+    investmentStats.length &&
+    createdItem.bucket.inArmor &&
+    itemDef.stats &&
+    itemDef.stats.statGroupHash
+  ) {
+    investmentStats = fillInArmorStats(investmentStats, itemDef, defs);
+  }
   stats = [...(stats || []), ...investmentStats];
 
   return stats && stats.sort(compareBy((s) => s.sort));
 }
 
+// TODO: not for cloaks though...
 function fillInArmorStats(
   investmentStats: DimStat[],
   itemDef: DestinyInventoryItemDefinition,
@@ -413,12 +421,12 @@ function enhanceStatsWithPlugs(
   defs: D2ManifestDefinitions
 ) {
   if (!itemDef.stats || !itemDef.stats.statGroupHash) {
-    console.log(itemDef.displayProperties.name, 'no stats');
+    //console.log(itemDef.displayProperties.name, 'no stats');
     return stats;
   }
   const statGroup = defs.StatGroup.get(itemDef.stats.statGroupHash);
   if (!statGroup) {
-    console.log(itemDef.displayProperties.name, 'no stat group');
+    //console.log(itemDef.displayProperties.name, 'no stat group');
     return stats;
   }
 
@@ -495,7 +503,7 @@ function enhanceStatsWithPlugs(
                   bar
                 };
 
-                console.log(itemDef.displayProperties.name, 'new stat', statsByHash[statHash]);
+                //console.log(itemDef.displayProperties.name, 'new stat', statsByHash[statHash]);
                 stats.push(statsByHash[statHash]);
               }
             } else {
@@ -503,7 +511,7 @@ function enhanceStatsWithPlugs(
               // they cumulatively add. This can also make it weird when it comes time to assign
               // values to how much each contributed. Maybe considering perks that don't have options
               // before perks that do...
-              console.log(itemDef.displayProperties.name, 'adding', value, statHash);
+              //console.log(itemDef.displayProperties.name, 'adding', value, statHash);
               itemStat.value = Math.min(Math.max(0, itemStat.value), itemStat.maximumValue);
             }
           });

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -104,7 +104,7 @@ export default function ItemPopupHeader({
         <div className="item-type-info">
           {t('MovePopup.Subtitle', {
             light,
-            statName: item.primStat && item.primStat.stat.statName,
+            statName: item.primStat && item.primStat.stat.displayProperties.name,
             classType: classType ? classType : ' ',
             typeName: item.typeName,
             context: light ? 'Gear' : 'Consumable'

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -44,12 +44,15 @@
     display: table-cell;
     height: 12px;
     line-height: 9px;
+    svg {
+      margin-right: 4px;
+    }
   }
   .stat-box-outer {
     display: table-cell;
     height: 12px;
     line-height: 12px;
-    background-color: #333;
+    background-color: #555;
     width: 100%;
   }
   .stat-box-outer--no-bar {
@@ -65,7 +68,7 @@
     height: 100%;
     float: left;
     line-height: 12px;
-    background-color: #333;
+    background-color: #555;
     background-color: white;
     color: black;
     line-height: 20px;

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -100,13 +100,13 @@ function ItemStatRow({
   }
 
   return (
-    <div className="stat-box-row">
+    <div className="stat-box-row" title={stat.displayProperties.description}>
       <span
         className={classNames('stat-box-text', 'stat-box-cell', {
           'stat-box-masterwork': isMasterworkedStat
         })}
       >
-        {stat.name}
+        {stat.displayProperties.name}
       </span>
 
       {stat.statHash === 2715839340 ? (

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -112,6 +112,7 @@ function ItemStatRow({
       {stat.statHash === 2715839340 ? (
         <span className="stat-recoil">
           <RecoilStat stat={stat} />
+          <span className={classNames(higherLowerClasses)}>{value}</span>
         </span>
       ) : (
         <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -63,8 +63,8 @@ function ItemStatRow({
   item: DimItem;
   compareStat?: DimStat;
 }) {
-  const value = stat.value || 0;
-  const compareStatValue = (compareStat ? compareStat.value : 0) || 0;
+  const value = stat.value;
+  const compareStatValue = compareStat ? compareStat.value : 0;
   // lower # is better for drawtime and chargetime stats
   const lowerBetter = [447667954, 2961396640].includes(stat.statHash);
   const isMasterworkedStat =

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -64,14 +64,14 @@ export default function PlugTooltip({
       )}
       {defs && !!idx(plug, (p) => p.plugItem.investmentStats.length) && (
         <div className="plug-stats">
-          {plug.plugItem.investmentStats.map((stat) => (
+          {/*plug.plugItem.investmentStats.map((stat) => (
             <StatValue
               key={stat.statTypeHash}
               statHash={stat.statTypeHash}
               value={stat.value}
               defs={defs}
             />
-          ))}
+          ))*/}
           {plug.stats &&
             _.sortBy(Object.keys(plug.stats), (h) => statWhiteList.indexOf(parseInt(h, 10))).map(
               (statHash) => (

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -64,14 +64,6 @@ export default function PlugTooltip({
       )}
       {defs && !!idx(plug, (p) => p.plugItem.investmentStats.length) && (
         <div className="plug-stats">
-          {/*plug.plugItem.investmentStats.map((stat) => (
-            <StatValue
-              key={stat.statTypeHash}
-              statHash={stat.statTypeHash}
-              value={stat.value}
-              defs={defs}
-            />
-          ))*/}
           {plug.stats &&
             _.sortBy(Object.keys(plug.stats), (h) => statWhiteList.indexOf(parseInt(h, 10))).map(
               (statHash) => (

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -5,10 +5,11 @@ import Objective from '../progress/Objective';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions.service';
 import { D2Item, DimPlug } from '../inventory/item-types';
 import BestRatedIcon from './BestRatedIcon';
-import { DestinyItemInvestmentStatDefinition } from 'bungie-api-ts/destiny2';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { InventoryCuratedRoll } from 'app/curated-rolls/curatedRollService';
 import idx from 'idx';
+import _ from 'lodash';
+import { statWhiteList } from 'app/inventory/store/stats';
 
 // TODO: Connect this to redux
 export default function PlugTooltip({
@@ -64,8 +65,24 @@ export default function PlugTooltip({
       {defs && !!idx(plug, (p) => p.plugItem.investmentStats.length) && (
         <div className="plug-stats">
           {plug.plugItem.investmentStats.map((stat) => (
-            <Stat key={stat.statTypeHash} stat={stat} defs={defs} />
+            <StatValue
+              key={stat.statTypeHash}
+              statHash={stat.statTypeHash}
+              value={stat.value}
+              defs={defs}
+            />
           ))}
+          {plug.stats &&
+            _.sortBy(Object.keys(plug.stats), (h) => statWhiteList.indexOf(parseInt(h, 10))).map(
+              (statHash) => (
+                <StatValue
+                  key={statHash + '_'}
+                  statHash={parseInt(statHash, 10)}
+                  value={plug.stats![statHash]}
+                  defs={defs}
+                />
+              )
+            )}
         </div>
       )}
       {defs && plug.plugObjectives.length > 0 && (
@@ -93,25 +110,27 @@ export default function PlugTooltip({
   );
 }
 
-function Stat({
-  stat,
+function StatValue({
+  value,
+  statHash,
   defs
 }: {
-  stat: DestinyItemInvestmentStatDefinition;
+  value: number;
+  statHash: number;
   defs: D2ManifestDefinitions;
 }) {
-  if (stat.value === 0) {
+  if (value === 0) {
     return null;
   }
-  const statDef = defs.Stat.get(stat.statTypeHash);
+  const statDef = defs.Stat.get(statHash);
   if (!statDef || !statDef.displayProperties.name) {
     return null;
   }
   return (
     <>
       <div>
-        {stat.value < 0 ? '' : '+'}
-        {stat.value}
+        {value < 0 ? '' : '+'}
+        {value}
       </div>
       <div>
         {statDef.displayProperties.hasIcon && (

--- a/src/app/item-popup/RecoilStat.tsx
+++ b/src/app/item-popup/RecoilStat.tsx
@@ -18,7 +18,7 @@ export default function RecoilStat({ stat }: { stat: DimStat }) {
 
   return (
     <svg height="12" viewBox="0 0 2 1">
-      <circle r={1} cx={1} cy={1} fill="#333" />
+      <circle r={1} cx={1} cy={1} fill="#555" />
       {Math.abs(direction) > 0.1 ? (
         <path
           d={`M1,1 L${1 + xSpreadMore},${1 - ySpreadMore} A1,1 0 0,${

--- a/src/app/item-popup/RecoilStat.tsx
+++ b/src/app/item-popup/RecoilStat.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DimStat } from 'app/inventory/item-types';
 
 export default function RecoilStat({ stat }: { stat: DimStat }) {
-  const val = stat.value || 0;
+  const val = stat.value;
   // A value from 100 to -100 where positive is right and negative is left
   // See https://imgur.com/LKwWUNV
   const direction = Math.sin((val + 5) * ((2 * Math.PI) / 20)) * (100 - val) * (Math.PI / 180);

--- a/src/app/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/D1LoadoutBuilder.tsx
@@ -282,7 +282,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
                     {item.stats &&
                       item.stats.map((stat) => (
                         <div
-                          key={stat.id}
+                          key={stat.statHash}
                           style={getColor(
                             item.normalStats![stat.statHash].qualityPercentage,
                             'color'

--- a/src/app/progress/D2SupplementalManifestDefinitions.ts
+++ b/src/app/progress/D2SupplementalManifestDefinitions.ts
@@ -41,6 +41,7 @@ export const D2SupplementalManifestDefinitions = {
   },
   SandboxPerk: { get, getAll },
   Stat: { get, getAll },
+  StatGroup: { get, getAll },
   TalentGrid: { get, getAll },
   Progression: { get, getAll },
   ItemCategory: { get, getAll },

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -914,7 +914,9 @@ function searchFilters(
       stattype(item: DimItem, predicate: string) {
         return (
           item.stats &&
-          item.stats.some((s) => Boolean(s.name.toLowerCase() === predicate && s.value > 0))
+          item.stats.some((s) =>
+            Boolean(s.displayProperties.name.toLowerCase() === predicate && s.value > 0)
+          )
         );
       },
       stackable(item: DimItem) {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -914,9 +914,7 @@ function searchFilters(
       stattype(item: DimItem, predicate: string) {
         return (
           item.stats &&
-          item.stats.some((s) =>
-            Boolean(s.name.toLowerCase() === predicate && s.value && s.value > 0)
-          )
+          item.stats.some((s) => Boolean(s.name.toLowerCase() === predicate && s.value > 0))
         );
       },
       stackable(item: DimItem) {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -486,7 +486,7 @@
     "NumStatMixes": "{{count, number}} stat mix",
     "NumStatMixes_plural": "{{count, number}} stat mixes",
     "OptimizerExplanation": "Select perks, filter and reorder stats, and lock items to narrow down your potential loadouts.",
-    "OptimizerExplanationDesktop": "Shift-click a perk to select it. Shift-click an item or drag it to the sidebar to lock it.",
+    "OptimizerExplanationDesktop": "Shift-click a perk to select it. Shift-click an item to exclude it. Drag items to the sidebar to exclude or lock them.",
     "RequirePerks": "Try again including sub-Legendary and perk-less items",
     "ResetLocked": "Reset locked items",
     "SearchPlaceholder": "Filter (e.g., \"vigil of heroes\")",


### PR DESCRIPTION
This is a big overhaul of how we handle stats! We no longer use any precomputed stats - everything is computed from the raw "investment stats" interpolated by item-specific scaling tables.

* There's now one path for all stats, instead of separate paths for hidden stats.
* "Hidden stats" like magazine size, zoom, etc. now include the effects of mods and perks.
* The bonuses provided by mods and perks (on their tooltip) is now scaled to the correct value. This is most noticeable for Magazine Size, where previously it might say +20 when in reality it increases the mag size by 2.
* Removed a bunch of D1 legacy properties from stats, slimming them down a bunch.
* We now have the full `displayProperties` for all stats, so we show descriptions on hover, and can show icons if we want.
* Loadout Optimizer has been refactored to use the new stats, so it knows about multiple perks and can show multiple alternate perk choices (for example, if you should choose Traction as well as one of the first-column perks).
* Loadout Optimizer has been refactored into dynamically understanding stats, so when Armor 2.0 drops and adds 3 more stats, we can incorporate that without a bunch of code changes.
* The background of stat bars was made a bit lighter to show up against blurred-background item popups.
* Recoil Direction's value has been moved next to the pie.