### PR TITLE
Remove stackable info from headers

### DIFF
--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -83,7 +83,7 @@ export default class BadgeInfo extends React.Component<Props> {
 
     const badgeContent =
       (itemIs.bounty && `${Math.floor(100 * item.percentComplete)}%`) ||
-      (itemIs.stackable && (isCapped ? t('Badge.Max') : item.amount.toString())) ||
+      (itemIs.stackable && (isCapped ? `${t('Badge.Max')} ` : '') + item.amount.toString()) ||
       (itemIs.ghost && ghostBadgeContent(item)) ||
       (itemIs.generic && item.primStat && item.primStat.value.toString()) ||
       (item.classified && '???');

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -83,7 +83,7 @@ export default class BadgeInfo extends React.Component<Props> {
 
     const badgeContent =
       (itemIs.bounty && `${Math.floor(100 * item.percentComplete)}%`) ||
-      (itemIs.stackable && (isCapped ? `${t('Badge.Max')} ` : '') + item.amount.toString()) ||
+      (itemIs.stackable && item.amount.toString()) ||
       (itemIs.ghost && ghostBadgeContent(item)) ||
       (itemIs.generic && item.primStat && item.primStat.value.toString()) ||
       (item.classified && '???');

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -116,9 +116,6 @@ export default function ItemPopupHeader({
             t('MovePopup.Subtitle_Stackable_UniqueMax')
            */}
         </div>
-        {item.objectives && !item.hidePercentage && (
-          <div>{t('ItemService.PercentComplete', { percent: item.percentComplete })}</div>
-        )}
         {item.taggable && <ItemTagSelector item={item} />}
       </div>
 

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -123,18 +123,6 @@ export default function ItemPopupHeader({
       </div>
 
       {item.reviewable && <ExpandedRating item={item} />}
-
-      {item.uniqueStack && !item.bucket.inArmor && !(item.isDestiny2() && item.pursuit) && (
-        <div>
-          {item.amount === item.maxStackSize
-            ? t('MovePopup.Subtitle', { amount: item.amount, context: 'Stackable_UniqueMax' })
-            : t('MovePopup.Subtitle', {
-                amount: item.amount,
-                maxStackSize: item.maxStackSize,
-                context: 'Stackable_Unique'
-              })}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/app/progress/PursuitItem.tsx
+++ b/src/app/progress/PursuitItem.tsx
@@ -3,7 +3,6 @@ import { DimItem } from 'app/inventory/item-types';
 import classNames from 'classnames';
 import { percent } from 'app/shell/filters';
 import BungieImage from 'app/dim-ui/BungieImage';
-import { t } from 'app/i18next-t';
 import styles from './PursuitItem.m.scss';
 import pursuitComplete from 'images/pursuitComplete.svg';
 import pursuitExpired from 'images/pursuitExpired.svg';
@@ -39,7 +38,7 @@ export default function PursuitItem({ item, isNew }: { item: DimItem; isNew: boo
             [styles.fullstack]: item.maxStackSize > 1 && item.amount === item.maxStackSize
           })}
         >
-          {isCapped ? t('Badge.Max') : item.amount.toString()}
+          {isCapped && item.amount.toString()}
         </div>
       )}
       {isNew && <div className={styles.newItem} />}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -624,8 +624,6 @@
     "Subtitle": "",
     "Subtitle_Consumable": "{{classType}} {{typeName}}",
     "Subtitle_Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
-    "Subtitle_Stackable_Unique": "Quantity: {{amount}}/{{maxStackSize}} (MAX).",
-    "Subtitle_Stackable_UniqueMax": "Quantity: {{amount}} (MAX).",
     "Take": "Take",
     "TrackUntrack": "",
     "TrackUntrack_Track": "Track {{itemType}}",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -16,9 +16,6 @@
     "Normal": "Normal",
     "WeeklyHeroic": "Weekly Heroic Strike"
   },
-  "Badge": {
-    "Max": "MAX"
-  },
   "Bucket": {
     "Armor": "Armor",
     "General": "General",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -401,7 +401,6 @@
     "NotEnoughRoom": "There's nothing we can move out of {{store}} to make room for {{itemname}}",
     "OnlyEquippedClassLevel": "This can only be equipped on a {{class}} at or above level {{level}}.",
     "OnlyEquippedLevel": "This can only be equipped on characters at or above level {{level}}.",
-    "PercentComplete": "({{percent, pct}} Complete)",
     "PreviewVendor": "Preview {{type}} contents",
     "StackFull": "You already have a full stack of {{name}}",
     "StoreName": "{{genderRace}} {{className}}",


### PR DESCRIPTION
This removes the "Quantity: 20 (MAX)." text from item headers and puts all the info in the badge. Previously it would just show "MAX" once you maxed a stack. This is part of cleaning out the item headers.

<img width="205" alt="Screen Shot 2019-09-02 at 7 43 39 PM" src="https://user-images.githubusercontent.com/313208/64140659-174c5380-cdba-11e9-8737-cac80a241cc7.png">
