### PR TITLE
Stat fixes

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -119,7 +119,9 @@ class Compare extends React.Component<Props, State> {
                 : sortedHash === 'Rating'
                 ? { value: showRating || 0 }
                 : (item.stats || []).find((s) => s.statHash === sortedHash);
-            return (stat && stat.value) || -1;
+            return (
+              (stat && (isDimStat(stat) && stat.smallerIsBetter ? -stat.value : stat.value)) || -1
+            );
           }),
           compareBy((i) => i.index),
           compareBy((i) => i.name)
@@ -433,13 +435,16 @@ function getAllStats(comparisons: DimItem[], ratings: ReviewsState['ratings']) {
         stat.min = Math.min(stat.min, itemStat.value || 0);
         stat.max = Math.max(stat.max, itemStat.value || 0);
         stat.enabled = stat.min !== stat.max;
-        // lower # is better for drawtime and chargetime stats
-        stat.lowerBetter = [447667954, 2961396640].includes(itemStat.statHash);
+        stat.lowerBetter = isDimStat(itemStat) ? itemStat.smallerIsBetter : false;
       }
     }
   });
 
   return stats;
+}
+
+function isDimStat(stat: DimStat | any): stat is DimStat {
+  return Object.prototype.hasOwnProperty.call(stat as DimStat, 'smallerIsBetter');
 }
 
 export default connect<StoreProps>(mapStateToProps)(Compare);

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -265,6 +265,8 @@ export interface DimStat {
   maximumValue: number;
   /** Should this be displayed as a bar or just a number? */
   bar: boolean;
+  /** Most stats, bigger is better. Exceptions are things like Charge Time. */
+  smallerIsBetter: boolean;
   /**
    * Value of the investment stat, which may be different than the base stat.
    * This is really just a temporary value while building stats and shouldn't be used anywhere.

--- a/src/app/inventory/store/d1-item-factory.service.ts
+++ b/src/app/inventory/store/d1-item-factory.service.ts
@@ -873,7 +873,8 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
           sort,
           value: val,
           maximumValue,
-          bar: identifier !== 'STAT_MAGAZINE_SIZE' && identifier !== 'STAT_ATTACK_ENERGY' // energy == magazine for swords
+          bar: identifier !== 'STAT_MAGAZINE_SIZE' && identifier !== 'STAT_ATTACK_ENERGY', // energy == magazine for swords
+          smallerIsBetter: [447667954, 2961396640].includes(stat.statHash)
         };
         return dimStat;
       })

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -339,6 +339,10 @@ function fillInArmorStats(
  */
 function interpolateStatValue(value: number, statDisplay: DestinyStatDisplayDefinition) {
   const interp = statDisplay.displayInterpolation;
+
+  // Clamp the value to prevent overfilling
+  value = Math.max(0, Math.min(value, statDisplay.maximumValue));
+
   let endIndex = interp.findIndex((p) => p.value > value);
   if (endIndex < 0) {
     endIndex = interp.length - 1;

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -20,29 +20,34 @@ import _ from 'lodash';
  * Which stats to display, and in which order.
  */
 export const statWhiteList = [
-  4284893193, // Rounds Per Minute
-  2961396640, // Charge Time
   3614673599, // Blast Radius
   2523465841, // Velocity
   4043523819, // Impact
   1240592695, // Range
+  1591432999, // Accuracy
   155624089, // Stability
   943549884, // Handling
   4188031367, // Reload Speed
   1345609583, // Aim Assistance
   3555269338, // Zoom
+  4284893193, // Rounds Per Minute
+  447667954, // Draw Time
+  2961396640, // Charge Time
   2715839340, // Recoil Direction
   3871231066, // Magazine
+  1931675084, // Inventory Size
   2996146975, // Mobility
   392767087, // Resilience
-  1943323491, // Recovery
-  447667954 // Draw Time
-  //    1935470627, // Power
-  // there are a few others (even an `undefined` stat)
+  1943323491 // Recovery
 ];
 
-/** Stats that should be forced to display without a bar (just a number). Mostly this is automatic. */
+/** Stats that should be forced to display without a bar (just a number). */
 const statsNoBar = [
+  4284893193, // Rounds Per Minute
+  3871231066, // Magazine
+  2961396640, // Charge Time
+  447667954, // Draw Time
+  1931675084, // Recovery
   2715839340 // Recoil Direction
 ];
 
@@ -51,6 +56,19 @@ const armorStats = [
   1943323491, // Recovery
   392767087, // Resilience
   2996146975 // Mobility
+];
+
+/** Stats that are measured in milliseconds. */
+export const statsMs = [
+  447667954, // Draw Time
+  2961396640 // Charge Time
+];
+
+/** Show these stats in addition to any "natural" stats */
+const hiddenStatsWhitelist = [
+  1345609583, // Aim Assistance
+  3555269338, // Zoom
+  2715839340 // Recoil Direction
 ];
 
 /** Build the full list of stats for an item. If the item has no stats, this returns null. */
@@ -75,6 +93,7 @@ export function buildStats(
   // Include the contributions from perks and mods
   if (createdItem.sockets && createdItem.sockets.sockets.length) {
     investmentStats = enhanceStatsWithPlugs(
+      itemDef,
       investmentStats,
       createdItem.sockets.sockets,
       defs,
@@ -97,6 +116,28 @@ export function buildStats(
   return investmentStats.length ? investmentStats.sort(compareBy((s) => s.sort)) : null;
 }
 
+function shouldShowStat(
+  itemDef: DestinyInventoryItemDefinition,
+  statHash: number,
+  statDisplays: { [key: number]: DestinyStatDisplayDefinition }
+) {
+  // Bows have a charge time stat that nobody asked for
+  if (
+    statHash === 2961396640 &&
+    itemDef.itemCategoryHashes &&
+    itemDef.itemCategoryHashes.includes(3317538576)
+  ) {
+    return false;
+  }
+
+  return (
+    // Must be on the whitelist
+    statWhiteList.includes(statHash) &&
+    // Must be on the list of interpolated stats, or included in the hardcoded hidden stats list
+    (statDisplays[statHash] || hiddenStatsWhitelist.includes(statHash))
+  );
+}
+
 /**
  * Build stats from the non-pre-sized investment stats. Destiny stats come in two flavors - precalculated
  * by the API, and "investment stats" which are the raw game values. The latter must be transformed into
@@ -114,7 +155,7 @@ function buildInvestmentStats(
   return _.compact(
     Object.values(itemStats).map((itemStat): DimStat | undefined => {
       const statHash = itemStat.statTypeHash;
-      if (!itemStat || !statWhiteList.includes(statHash)) {
+      if (!itemStat || !shouldShowStat(itemDef, statHash, statDisplays)) {
         return undefined;
       }
 
@@ -138,13 +179,18 @@ function buildStat(
   let value = itemStat.value || 0;
   let maximumValue = statGroup.maximumValue;
   let bar = !statsNoBar.includes(statHash);
+  let smallerIsBetter = false;
   const statDisplay = statDisplays[statHash];
   if (statDisplay) {
-    maximumValue = statDisplay.maximumValue;
+    const firstInterp = statDisplay.displayInterpolation[0];
+    const lastInterp =
+      statDisplay.displayInterpolation[statDisplay.displayInterpolation.length - 1];
+    smallerIsBetter = firstInterp.weight > lastInterp.weight;
+    maximumValue = Math.max(statDisplay.maximumValue, firstInterp.weight, lastInterp.weight);
     bar = !statDisplay.displayAsNumeric;
     value = interpolateStatValue(value, statDisplay);
   }
-  value = Math.min(Math.max(0, value), maximumValue);
+  value = Math.max(0, value);
 
   return {
     investmentValue: itemStat.value || 0,
@@ -153,11 +199,13 @@ function buildStat(
     sort: statWhiteList.indexOf(statHash),
     value,
     maximumValue,
-    bar
+    bar,
+    smallerIsBetter
   };
 }
 
 function enhanceStatsWithPlugs(
+  itemDef: DestinyInventoryItemDefinition,
   stats: DimStat[],
   sockets: DimSocket[],
   defs: D2ManifestDefinitions,
@@ -177,7 +225,7 @@ function enhanceStatsWithPlugs(
         const value = perkStat.value || 0;
         if (itemStat) {
           itemStat.investmentValue += value;
-        } else if (statWhiteList.includes(statHash)) {
+        } else if (shouldShowStat(itemDef, statHash, statDisplays)) {
           // This stat didn't exist before we modified it, so add it here.
           const stat = socket.plug.plugItem.investmentStats.find(
             (s) => s.statTypeHash === statHash
@@ -271,27 +319,14 @@ function fillInArmorStats(
   const statDisplays = _.keyBy(statGroup.scaledStats, (s) => s.statHash);
   for (const statHash of armorStats) {
     if (!investmentStats.some((s) => s.statHash === statHash)) {
-      const def = defs.Stat.get(statHash);
-      let value = 0;
-      let maximumValue = statGroup.maximumValue;
-      let bar = !statsNoBar.includes(statHash);
-      const statDisplay = statDisplays[statHash];
-      if (statDisplay) {
-        maximumValue = statDisplay.maximumValue;
-        bar = !statDisplay.displayAsNumeric;
-        value = interpolateStatValue(value, statDisplay);
-      }
-      value = Math.min(Math.max(0, value), maximumValue);
-
-      investmentStats.push({
-        investmentValue: 0,
-        statHash,
-        displayProperties: def.displayProperties,
-        sort: statWhiteList.indexOf(statHash),
-        value,
-        maximumValue,
-        bar
-      });
+      const statDef = defs.Stat.get(statHash);
+      const stat = buildStat(
+        { statTypeHash: statHash, value: 0, isConditionallyActive: false },
+        statGroup,
+        statDef,
+        statDisplays
+      );
+      investmentStats.push(stat);
     }
   }
 

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -101,12 +101,7 @@ function ItemStatRow({
   const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
 
   return (
-    <div
-      className="stat-box-row"
-      title={`${stat.displayProperties.description} ${t('Stats.MaxValue', {
-        value: stat.maximumValue
-      })}`}
-    >
+    <div className="stat-box-row" title={stat.displayProperties.description}>
       <span
         className={classNames('stat-box-text', 'stat-box-cell', {
           'stat-box-masterwork': isMasterworkedStat

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -8,6 +8,7 @@ import { AppIcon, helpIcon } from '../shell/icons';
 import ExternalLink from '../dim-ui/ExternalLink';
 import _ from 'lodash';
 import RecoilStat from './RecoilStat';
+import { statsMs } from 'app/inventory/store/stats';
 
 export default function ItemStats({
   item,
@@ -65,17 +66,15 @@ function ItemStatRow({
 }) {
   const value = stat.value;
   const compareStatValue = compareStat ? compareStat.value : 0;
-  // lower # is better for drawtime and chargetime stats
-  const lowerBetter = [447667954, 2961396640].includes(stat.statHash);
   const isMasterworkedStat =
     item.isDestiny2() && item.masterworkInfo && stat.statHash === item.masterworkInfo.statHash;
   const masterworkValue =
     (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
   const higherLowerClasses = {
-    'higher-stats': lowerBetter
+    'higher-stats': stat.smallerIsBetter
       ? value < compareStatValue && compareStat
       : value > compareStatValue && compareStat,
-    'lower-stats': lowerBetter
+    'lower-stats': stat.smallerIsBetter
       ? value > compareStatValue && compareStat
       : value < compareStatValue && compareStat
   };
@@ -99,8 +98,15 @@ function ItemStatRow({
     }
   }
 
+  const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
+
   return (
-    <div className="stat-box-row" title={stat.displayProperties.description}>
+    <div
+      className="stat-box-row"
+      title={`${stat.displayProperties.description} ${t('Stats.MaxValue', {
+        value: stat.maximumValue
+      })}`}
+    >
       <span
         className={classNames('stat-box-text', 'stat-box-cell', {
           'stat-box-masterwork': isMasterworkedStat
@@ -126,7 +132,7 @@ function ItemStatRow({
                 />
               ))
             ) : (
-              <span className={classNames(higherLowerClasses)}>{value}</span>
+              <span className={classNames(higherLowerClasses)}>{displayValue}</span>
             )}
           </span>
         </span>
@@ -134,7 +140,7 @@ function ItemStatRow({
 
       {stat.bar && (
         <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
-          {value}
+          {displayValue}
           {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
             <span
               className="item-stat-quality"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -715,7 +715,6 @@
     "Discipline": "Discipline",
     "Intellect": "Intellect",
     "MaxBasePower": "Max Power",
-    "MaxValue": "Max {{value}}.",
     "Milliseconds": "{{value}} ms",
     "NoBonus": "No Bonus",
     "NotApplicable": "N/A",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -715,6 +715,8 @@
     "Discipline": "Discipline",
     "Intellect": "Intellect",
     "MaxBasePower": "Max Power",
+    "MaxValue": "Max {{value}}.",
+    "Milliseconds": "{{value}} ms",
     "NoBonus": "No Bonus",
     "NotApplicable": "N/A",
     "OfMaxRoll": "{{range}} of max roll",


### PR DESCRIPTION
1. Removed the incorrect cap of 100 on... all stats.
2. Derive which stats are better when the value is lower (charge time, etc) by looking at what direction their interpolation table goes.
3. Reorder some of the stats.
4. Only show the stats that an item is "supposed" to have, plus hand-curated hidden stats. Plus, banish "charge time" from bows even though they really do have that stat.
5. Show time-based stats (Charge Time, Draw Time) with units next to them (ms) because I didn't realize they were an absolute millisecond value.
6. Reduce some code duplication.
7. Clamp investment values to their max (practically always 0-100) before computing, to avoid allowing mods/perks to push above the stat cap.

Note: As part of investigating this I discovered that both the pre-calculated stats from the API and banshee-44 actually do interpolation incorrectly, and DIM beta agrees with the game.

This should fix all of #4174.