### PR TITLE
Switch items to use CSS grid

### DIFF
--- a/src/app/collections/Catalysts.tsx
+++ b/src/app/collections/Catalysts.tsx
@@ -24,7 +24,7 @@ export default function Catalysts({
   const catalysts = getCatalysts(defs, profileResponse);
 
   return (
-    <div className="no-badge">
+    <div>
       <CollapsibleTitle title={t('Vendors.Catalysts')} sectionId={'catalysts'}>
         <div className="ornaments-disclaimer">{t('Vendors.CatalystsDisclaimer')}</div>
         <div className="collectionItems">

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -146,7 +146,7 @@ class Collections extends React.Component<Props, State> {
           <Ornaments defs={defs} buckets={buckets} profileResponse={profileResponse} />
         </ErrorBoundary>
         <ErrorBoundary name="Collections">
-          <div className={`${vendorStyles.vendorRow} no-badge`}>
+          <div className={vendorStyles.vendorRow}>
             <h3 className={vendorStyles.categoryTitle}>{t('Vendors.Collections')}</h3>
             <PresentationNodeRoot
               presentationNodeHash={3790247699}

--- a/src/app/collections/Ornaments.tsx
+++ b/src/app/collections/Ornaments.tsx
@@ -26,13 +26,13 @@ export default function Ornaments({
 
   return (
     <div>
-      <div className={`${vendorStyles.vendorRow} no-badge`}>
+      <div className={vendorStyles.vendorRow}>
         <CollapsibleTitle
           title={defs.Vendor.get(2107783226).displayProperties.name}
           sectionId="ornaments"
         >
           <div className="ornaments-disclaimer">{t('Vendors.OrnamentsDisclaimer')}</div>
-          <div className={`${vendorStyles.vendorItems} no-badge`}>
+          <div className={vendorStyles.vendorItems}>
             {ornaments.map((ornament) => (
               <VendorItemComponent
                 key={ornament.itemHash}

--- a/src/app/collections/PresentationNode.scss
+++ b/src/app/collections/PresentationNode.scss
@@ -74,4 +74,8 @@
   grid-template-rows: repeat(auto-fill, var(--item-size));
   grid-gap: 4px;
   margin: 8px 0;
+
+  > div {
+    margin: 0;
+  }
 }

--- a/src/app/d2-vendors/VendorItem.m.scss
+++ b/src/app/d2-vendors/VendorItem.m.scss
@@ -17,7 +17,7 @@
   z-index: 3;
   position: absolute;
   top: $item-border-width + 2px;
-  right: calc(var(--item-margin) + #{$item-border-width + 2px});
+  right: $item-border-width + 2px;
   pointer-events: none;
 }
 
@@ -36,6 +36,7 @@
   flex-direction: column;
   align-items: center;
   position: relative;
+  margin-right: var(--item-margin);
 }
 
 .unavailable {

--- a/src/app/d2-vendors/VendorItems.m.scss
+++ b/src/app/d2-vendors/VendorItems.m.scss
@@ -49,7 +49,10 @@
 }
 
 .vendorItems {
-  composes: flexWrap from '../dim-ui/common.m.scss';
+  min-height: var(--item-size);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, var(--item-size));
+  grid-gap: var(--item-margin);
 
   :global(.item) {
     cursor: pointer;

--- a/src/app/d2-vendors/VendorItems.m.scss
+++ b/src/app/d2-vendors/VendorItems.m.scss
@@ -49,10 +49,7 @@
 }
 
 .vendorItems {
-  min-height: var(--item-size);
-  display: grid;
-  grid-template-columns: repeat(auto-fit, var(--item-size));
-  grid-gap: var(--item-margin);
+  composes: flexWrap from '../dim-ui/common.m.scss';
 
   :global(.item) {
     cursor: pointer;

--- a/src/app/d2-vendors/VendorItems.tsx
+++ b/src/app/d2-vendors/VendorItems.tsx
@@ -8,8 +8,6 @@ import { VendorItem } from './vendor-item';
 import { UISref } from '@uirouter/react';
 import FactionIcon from '../progress/FactionIcon';
 import PressTip from '../dim-ui/PressTip';
-import classNames from 'classnames';
-import { hasBadge } from '../inventory/BadgeInfo';
 import { D2Vendor } from './d2-vendors';
 import styles from './VendorItems.m.scss';
 import { chainComparator, compareBy } from 'app/comparators';
@@ -129,11 +127,7 @@ export default function VendorItems({
                     vendor.def.displayCategories[categoryIndex].displayProperties.name) ||
                     'Unknown'}
                 </h3>
-                <div
-                  className={classNames(styles.vendorItems, {
-                    'no-badge': items.every((i) => !hasBadge(i.item))
-                  })}
-                >
+                <div className={styles.vendorItems}>
                   {items
                     .sort(itemSort)
                     .map(

--- a/src/app/inventory/InventoryItem.scss
+++ b/src/app/inventory/InventoryItem.scss
@@ -38,13 +38,9 @@
 }
 
 .item-drag-container {
-  contain: strict;
+  contain: content;
   cursor: pointer;
   box-sizing: border-box;
-  width: var(--item-size);
-  height: calc(#{$full-height-badge});
-  margin: 0 var(--item-margin) var(--item-margin) 0;
-
   &:hover {
     outline: 1px solid #ddd;
 
@@ -54,24 +50,11 @@
   }
 }
 
-.no-badge {
-  .item-drag-container {
-    height: var(--item-size);
-  }
-
-  .item {
-    height: var(--item-size);
-  }
-}
-
 .item {
   position: relative;
-  contain: strict;
+  contain: content;
   transition: opacity 0.2s, transform 0.2s;
   box-sizing: border-box;
-  width: var(--item-size);
-  height: calc(#{$full-height-badge});
-  margin: 0 var(--item-margin) var(--item-margin) 0;
 
   .item-img {
     display: block;

--- a/src/app/inventory/InventoryItem.scss
+++ b/src/app/inventory/InventoryItem.scss
@@ -38,7 +38,7 @@
 }
 
 .item-drag-container {
-  contain: content;
+  contain: layout paint style;
   cursor: pointer;
   box-sizing: border-box;
   &:hover {
@@ -52,9 +52,10 @@
 
 .item {
   position: relative;
-  contain: content;
+  contain: layout paint style;
   transition: opacity 0.2s, transform 0.2s;
   box-sizing: border-box;
+  width: var(--item-size);
 
   .item-img {
     display: block;

--- a/src/app/inventory/MoveAmountPopupContainer.tsx
+++ b/src/app/inventory/MoveAmountPopupContainer.tsx
@@ -51,7 +51,7 @@ export default class MoveAmountPopupContainer extends React.Component<{}, State>
       <Sheet onClose={this.onClose} sheetClassName="move-amount-popup">
         {({ onClose }) => (
           <>
-            <h1 className="no-badge">
+            <h1>
               <div className="item">
                 <BungieImage className="item-img" src={item.icon} />
               </div>

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -21,10 +21,6 @@
     border: $equipped-item-border solid #ddd;
     height: fit-content;
     padding: $equipped-item-padding;
-
-    .item-drag-container {
-      margin: 0;
-    }
   }
 
   &.not-equippable {
@@ -89,20 +85,20 @@
 }
 
 .sub-bucket {
-  min-height: calc(#{$full-height-badge});
-  display: flex;
-  flex-wrap: wrap;
+  min-height: var(--item-size);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, var(--item-size));
+  grid-gap: var(--item-margin);
   align-content: flex-start;
   padding: 4px 0;
 
   &.on-drag-hover {
     box-shadow: inset 0 0 6px 0 rgba(200, 200, 200, 0.7);
   }
-  .no-badge & {
-    min-height: calc(var(--item-size) + 5px);
-  }
 
   &.equipped {
+    display: flex;
+    flex-direction: column;
     width: calc(var(--item-size) + #{2 * ($equipped-item-border + $equipped-item-padding)});
     margin-right: var(--item-margin);
   }

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -38,19 +38,17 @@
       box-sizing: border-box;
       height: var(--item-size);
       width: var(--item-size);
-      margin-right: var(--item-margin);
     }
 
     .sub-bucket {
       min-height: 0;
+      grid-template-columns: repeat(auto-fill, var(--engram-size));
+      grid-gap: 0;
     }
-
-    --old-item-margin: var(--item-margin);
 
     .item-drag-container,
     .empty-engram {
       --item-size: var(--engram-size);
-      --item-margin: 0px;
       @include phone-portrait {
         --item-size: calc((100vw - (2 * var(--inventory-column-padding))) / 10);
       }
@@ -59,24 +57,6 @@
 
   // Subclasses
   &.bucket-3284755031 {
-    /*
-    .sub-bucket {
-      min-height: 0;
-      &.equipped {
-        justify-content: center;
-      }
-    }
-
-    .item-drag-container {
-      --item-size: 32px;
-      @include phone-portrait {
-        --item-size: calc(
-          ((100vw - 40px - 5px * var(--character-columns)) / (var(--character-columns) + 1)) * 0.6
-        );
-      }
-    }
-    */
-
     .equipped-item {
       border: none;
       padding-top: 0;
@@ -90,7 +70,7 @@
   grid-template-columns: repeat(auto-fill, var(--item-size));
   grid-gap: var(--item-margin);
   align-content: flex-start;
-  padding: 4px 0;
+  padding: 4px 0 calc(var(--item-margin) + 4px) 0;
 
   &.on-drag-hover {
     box-shadow: inset 0 0 6px 0 rgba(200, 200, 200, 0.7);
@@ -117,7 +97,6 @@
     box-sizing: border-box;
     width: var(--item-size);
     height: calc((var(--item-size) + ((var(--item-size) / 5) + 4px) - 1px));
-    margin: 0 var(--item-margin) var(--item-margin) 0;
     padding: 8px;
     color: #999;
   }

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -4,7 +4,6 @@ import StoreBucket from './StoreBucket';
 import { InventoryBucket } from './inventory-buckets';
 import classNames from 'classnames';
 import { PullFromPostmaster } from './PullFromPostmaster';
-import { hasBadge } from './BadgeInfo';
 import { storeBackgroundColor } from '../shell/filters';
 
 /** One row of store buckets, one for each character and vault. */
@@ -29,8 +28,6 @@ export function StoreBuckets({
     return null;
   }
 
-  const noBadges = stores.every((s) => s.buckets[bucket.id].every((i) => !hasBadge(i)));
-
   if (bucket.accountWide) {
     // If we're in mobile view, we only render one store
     const allStoresView = stores.length > 1;
@@ -53,8 +50,7 @@ export function StoreBuckets({
       <div
         key={store.id}
         className={classNames('store-cell', {
-          vault: store.isVault,
-          'no-badge': noBadges
+          vault: store.isVault
         })}
         style={storeBackgroundColor(store, index)}
       >

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -42,9 +42,7 @@
     (2 * var(--inventory-column-padding) - var(--item-margin))
   );
   flex-direction: column;
-  /* Total horizontal padding ends up being (2 * var(--inventory-column-padding) - var(--item-margin)) */
-  padding: 0 calc(var(--inventory-column-padding) - var(--item-margin)) 0
-    var(--inventory-column-padding);
+  padding: 0 var(--inventory-column-padding);
   box-sizing: border-box;
 
   &.vault {

--- a/src/app/vendors/D1VendorItems.tsx
+++ b/src/app/vendors/D1VendorItems.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import _ from 'lodash';
 import BungieImage from '../dim-ui/BungieImage';
-import classNames from 'classnames';
 import { Vendor, VendorCost } from './vendor.service';
 import D1VendorItem from './D1VendorItem';
-import { hasBadge } from '../inventory/BadgeInfo';
 import styles from '../d2-vendors/VendorItems.m.scss';
 
 /**
@@ -45,11 +43,7 @@ export default function D1VendorItems({
         {_.map(vendor.categories, (category) => (
           <div className={styles.vendorRow} key={category.index}>
             <h3 className={styles.categoryTitle}>{category.title || 'Unknown'}</h3>
-            <div
-              className={classNames(styles.vendorItems, {
-                'no-badge': category.saleItems.every((i) => !hasBadge(i.item))
-              })}
-            >
+            <div className={styles.vendorItems}>
               {_.sortBy(category.saleItems, (i) => i.item.name).map((item) => (
                 <D1VendorItem
                   key={item.index}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -31,7 +31,6 @@ $equipped-item-padding: 2px;
 // Full tile size including borders
 $badge-font-size: '(var(--item-size) / 5)';
 $badge-height: '(#{$badge-font-size} + 4px)';
-$full-height-badge: '(var(--item-size) + #{$badge-height} - #{$item-border-width})';
 
 @mixin phone-portrait {
   // This seems like a good breakpoint for portrait based on https://material.io/devices/


### PR DESCRIPTION
This switches most item grid displays to actually use CSS grid. I think it's a bit simpler - especially since we don't need to account for the badge being there or not.