### PR TITLE
Visualize stat impact of weapon mods, re-order stat bar "segments"

### DIFF
--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -40,6 +40,9 @@
   .lower-stats {
     color: #cc6666;
   }
+  .modded-stats:not(.higher-stats):not(.lower-stats) {
+    color: $blue;
+  }
   .stat-recoil {
     display: table-cell;
     height: 12px;
@@ -80,6 +83,9 @@
     }
     &.masterwork-stats {
       background-color: $orange;
+    }
+    &.modded-stats {
+      background-color: $blue;
     }
     &.rating-chart-bar-color {
       background-color: $orange;

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -29,6 +29,10 @@
     color: $orange;
     font-weight: bold;
   }
+  .stat-box-modded {
+    color: $blue;
+    font-weight: bold;
+  }
   .stat-box-val {
     text-align: left;
     padding-right: 10px;

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -102,6 +102,13 @@ function ItemStatRow({
   };
 
   let baseBar = compareStat ? Math.min(compareStatValue, value) : value;
+  if (isMasterworkedStat && masterworkValue > 0) {
+    baseBar -= masterworkValue;
+  }
+  if (isModdedStat) {
+    baseBar -= moddedStatValue;
+  }
+
   const segments: [number, string?][] = [[baseBar]];
 
   if (compareStat) {
@@ -113,12 +120,10 @@ function ItemStatRow({
   }
 
   if (isMasterworkedStat && masterworkValue > 0) {
-    baseBar -= masterworkValue;
     segments.push([masterworkValue, 'masterwork-stats']);
   }
 
   if (isModdedStat) {
-    baseBar -= moddedStatValue;
     segments.push([moddedStatValue, 'modded-stats']);
   }
 

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -104,6 +104,14 @@ function ItemStatRow({
   let baseBar = compareStat ? Math.min(compareStatValue, value) : value;
   const segments: [number, string?][] = [[baseBar]];
 
+  if (compareStat) {
+    if (compareStatValue > value) {
+      segments.push([compareStatValue - value, 'lower-stats']);
+    } else if (value > compareStatValue) {
+      segments.push([value - compareStatValue, 'higher-stats']);
+    }
+  }
+
   if (isMasterworkedStat && masterworkValue > 0) {
     baseBar -= masterworkValue;
     segments.push([masterworkValue, 'masterwork-stats']);
@@ -114,21 +122,14 @@ function ItemStatRow({
     segments.push([moddedStatValue, 'modded-stats']);
   }
 
-  if (compareStat) {
-    if (compareStatValue > value) {
-      segments.push([compareStatValue - value, 'lower-stats']);
-    } else if (value > compareStatValue) {
-      segments.push([value - compareStatValue, 'higher-stats']);
-    }
-  }
-
   const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
 
   return (
     <div className="stat-box-row" title={stat.displayProperties.description}>
       <span
         className={classNames('stat-box-text', 'stat-box-cell', {
-          'stat-box-masterwork': isMasterworkedStat
+          'stat-box-masterwork': isMasterworkedStat,
+          'stat-box-modded': isModdedStat
         })}
       >
         {stat.displayProperties.name}

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -79,13 +79,17 @@ function ItemStatRow({
 }) {
   const value = stat.value;
   const compareStatValue = compareStat ? compareStat.value : 0;
+
   const isMasterworkedStat =
     item.isDestiny2() && item.masterworkInfo && stat.statHash === item.masterworkInfo.statHash;
-  const modSocket = modSocketFor(item);
-  const isModdedStat = modSocket && _.keys(modSocket.plug.stats).includes(String(stat.statHash));
-  const moddedStatValue = modSocket.plug.stats[stat.statHash];
   const masterworkValue =
     (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
+
+  const modSocket = modSocketFor(item);
+  const isModdedStat = modSocket
+    ? _.keys(modSocket.plug.stats).includes(String(stat.statHash))
+    : false;
+  const moddedStatValue = isModdedStat ? modSocket.plug.stats[stat.statHash] : 0;
 
   const statValueClasses = {
     'higher-stats': stat.smallerIsBetter

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -55,15 +55,12 @@ export default function ItemStats({
   );
 }
 
-// returns the socket associated with a mod that increases a displayed stat, specficially:
-// backup mag (magazine size), counterbalance stock (recoil direction), and targeting adjustor (aim assist)
+// returns the socket associated with an applied wepaon mod
 function modSocketFor(item) {
   return (
     item.sockets &&
     item.sockets.sockets.find((socket) => {
-      return (
-        socket.plug && [3336648220, 1588595445, 3228611386].includes(socket.plug.plugItem.hash)
-      );
+      return socket.plug && socket.plug.plugItem.itemTypeDisplayName === 'Weapon Mod';
     })
   );
 }
@@ -86,10 +83,9 @@ function ItemStatRow({
     (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
 
   const modSocket = modSocketFor(item);
-  const isModdedStat = modSocket
-    ? _.keys(modSocket.plug.stats).includes(String(stat.statHash))
-    : false;
-  const moddedStatValue = isModdedStat ? modSocket.plug.stats[stat.statHash] : 0;
+  const isModdedStat =
+    modSocket && modSocket.plug.stats && modSocket.plug.stats[stat.statHash] !== undefined;
+  const moddedStatValue = (isModdedStat && modSocket.plug.stats[stat.statHash]) || 0;
 
   const statValueClasses = {
     'higher-stats': stat.smallerIsBetter

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -55,12 +55,12 @@ export default function ItemStats({
   );
 }
 
-// returns the socket associated with an applied wepaon mod
+// returns the socket associated with an applied weapon mod
 function modSocketFor(item) {
   return (
     item.sockets &&
     item.sockets.sockets.find((socket) => {
-      return socket.plug && socket.plug.plugItem.itemTypeDisplayName === 'Weapon Mod';
+      return socket.plug && socket.plug.plugItem.itemCategoryHashes.includes(1052191496);
     })
   );
 }


### PR DESCRIPTION
This is my attempt to more fully address https://github.com/DestinyItemManager/DIM/issues/3738

There are really only 3 weapon mods that directly impact displayed stats, targeting adjustor (aim assist), backup mag (magazine size), and counterbalance stock (recoil direction). When any of these three mods are applied to a weapon, the appropriate stat is highlighted in a very similar way to the masterworked stat.

![image](https://user-images.githubusercontent.com/11082871/64803057-0211ba80-d55a-11e9-835c-300b17f5f87f.png)

Since recoil direction/magazine dont have stat bars, they just get the blue colorization.
![image](https://user-images.githubusercontent.com/11082871/64803108-1a81d500-d55a-11e9-85b5-82a3c22d7426.png)

I chose to not have this override the comparison colorization when viewing a non-equipped weapon. The stat name will be blue but the stat value will be unaffected.
![image](https://user-images.githubusercontent.com/11082871/64803164-371e0d00-d55a-11e9-8523-63cfcc567005.png)

Since I was already working with that code, I also went ahead and reordered the stat "segments". For instance, previously the gold masterworked segment was placed before the "comparison" segment:
![image](https://user-images.githubusercontent.com/11082871/64803403-abf14700-d55a-11e9-8601-de47ccf624b0.png)

Moving the masterworked segment after this comparison segment more accurately reflects the stat change produced by the masterwork.
![image](https://user-images.githubusercontent.com/11082871/64803229-5026be00-d55a-11e9-96f6-a4593137116c.png)

I know some of these changes weren't really "approved" so I'm open to any feedback on this. Thanks!