### PR TITLE
Redesign stats

### DIFF
--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -5,6 +5,7 @@ import RecoilStat from './RecoilStat';
 import { percent, getColor } from 'app/shell/filters';
 import classNames from 'classnames';
 import { t } from 'app/i18next-t';
+import BungieImage from 'app/dim-ui/BungieImage';
 
 /**
  * A single stat line.
@@ -90,6 +91,9 @@ export default function ItemStat({
       {stat.bar && (
         <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
           {displayValue}
+          {stat.displayProperties.hasIcon && (
+            <BungieImage className="stat-icon" src={stat.displayProperties.icon} />
+          )}
           {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
             <span
               className="item-stat-quality"

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { DimStat, DimItem, D1Stat } from 'app/inventory/item-types';
+import { statsMs } from 'app/inventory/store/stats';
+import RecoilStat from './RecoilStat';
+import { percent, getColor } from 'app/shell/filters';
+import classNames from 'classnames';
+import { t } from 'app/i18next-t';
+
+/**
+ * A single stat line.
+ */
+export default function ItemStat({
+  stat,
+  item,
+  compareStat
+}: {
+  stat: DimStat;
+  item: DimItem;
+  compareStat?: DimStat;
+}) {
+  const value = stat.value;
+  const compareStatValue = compareStat ? compareStat.value : 0;
+  const isMasterworkedStat =
+    item.isDestiny2() && item.masterworkInfo && stat.statHash === item.masterworkInfo.statHash;
+  const masterworkValue =
+    (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
+  const higherLowerClasses = {
+    'higher-stats': stat.smallerIsBetter
+      ? value < compareStatValue && compareStat
+      : value > compareStatValue && compareStat,
+    'lower-stats': stat.smallerIsBetter
+      ? value > compareStatValue && compareStat
+      : value < compareStatValue && compareStat
+  };
+
+  let baseBar = compareStat ? Math.min(compareStatValue, value) : value;
+  if (isMasterworkedStat && masterworkValue > 0) {
+    baseBar -= masterworkValue;
+  }
+
+  const segments: [number, string?][] = [[baseBar]];
+
+  if (isMasterworkedStat && masterworkValue > 0) {
+    segments.push([masterworkValue, 'masterwork-stats']);
+  }
+
+  if (compareStat) {
+    if (compareStatValue > value) {
+      segments.push([compareStatValue - value, 'lower-stats']);
+    } else if (value > compareStatValue) {
+      segments.push([value - compareStatValue, 'higher-stats']);
+    }
+  }
+
+  const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
+
+  return (
+    <div className="stat-box-row" title={stat.displayProperties.description}>
+      <span
+        className={classNames('stat-box-text', 'stat-box-cell', {
+          'stat-box-masterwork': isMasterworkedStat
+        })}
+      >
+        {stat.displayProperties.name}
+      </span>
+
+      {stat.statHash === 2715839340 ? (
+        <span className="stat-recoil">
+          <RecoilStat stat={stat} />
+          <span className={classNames(higherLowerClasses)}>{value}</span>
+        </span>
+      ) : (
+        <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>
+          <span className="stat-box-container">
+            {stat.bar ? (
+              segments.map(([val, className], index) => (
+                <span
+                  key={index}
+                  className={classNames('stat-box-inner', className)}
+                  style={{ width: percent(val / stat.maximumValue) }}
+                />
+              ))
+            ) : (
+              <span className={classNames(higherLowerClasses)}>{displayValue}</span>
+            )}
+          </span>
+        </span>
+      )}
+
+      {stat.bar && (
+        <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
+          {displayValue}
+          {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
+            <span
+              className="item-stat-quality"
+              style={getColor(stat.qualityPercentage.min, 'color')}
+            >
+              ({stat.qualityPercentage.range})
+            </span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function isD1Stat(item: DimItem, _stat: DimStat): _stat is D1Stat {
+  return item.isDestiny1();
+}

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -52,7 +52,7 @@
     display: table-cell;
     height: 12px;
     line-height: 12px;
-    background-color: #555;
+    background-color: rgba(255, 255, 255, 0.15);
     width: 100%;
   }
   .stat-box-outer--no-bar {
@@ -69,7 +69,6 @@
     height: 100%;
     float: left;
     line-height: 12px;
-    background-color: #555;
     background-color: white;
     color: black;
     line-height: 20px;

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -62,6 +62,7 @@
     display: flex;
     width: 100%;
     height: 100%;
+    position: relative;
   }
   .stat-box-inner {
     display: block;
@@ -84,6 +85,13 @@
     &.rating-chart-bar-color {
       background-color: $orange;
     }
+  }
+
+  .stat-box-inner-compare {
+    left: 0;
+    bottom: 0;
+    position: absolute;
+    height: 3px;
   }
 
   .stat-icon {

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -85,6 +85,13 @@
       background-color: $orange;
     }
   }
+
+  .stat-icon {
+    height: 12px;
+    width: 12px;
+    vertical-align: bottom;
+    margin-left: 4px;
+  }
 }
 
 .item-stat-quality {

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { DimItem, DimStat, D1Stat } from '../inventory/item-types';
-import classNames from 'classnames';
+import { DimItem } from '../inventory/item-types';
 import { t } from 'app/i18next-t';
 import './ItemStats.scss';
-import { getColor, percent } from '../shell/filters';
+import { getColor } from '../shell/filters';
 import { AppIcon, helpIcon } from '../shell/icons';
 import ExternalLink from '../dim-ui/ExternalLink';
 import _ from 'lodash';
-import RecoilStat from './RecoilStat';
-import { statsMs } from 'app/inventory/store/stats';
+import ItemStat from './ItemStat';
 
 export default function ItemStats({
   item,
@@ -29,7 +27,7 @@ export default function ItemStats({
   return (
     <div className="stats">
       {item.stats.map((stat) => (
-        <ItemStatRow
+        <ItemStat
           key={stat.statHash}
           stat={stat}
           item={item}
@@ -53,103 +51,4 @@ export default function ItemStats({
       )}
     </div>
   );
-}
-
-function ItemStatRow({
-  stat,
-  item,
-  compareStat
-}: {
-  stat: DimStat;
-  item: DimItem;
-  compareStat?: DimStat;
-}) {
-  const value = stat.value;
-  const compareStatValue = compareStat ? compareStat.value : 0;
-  const isMasterworkedStat =
-    item.isDestiny2() && item.masterworkInfo && stat.statHash === item.masterworkInfo.statHash;
-  const masterworkValue =
-    (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
-  const higherLowerClasses = {
-    'higher-stats': stat.smallerIsBetter
-      ? value < compareStatValue && compareStat
-      : value > compareStatValue && compareStat,
-    'lower-stats': stat.smallerIsBetter
-      ? value > compareStatValue && compareStat
-      : value < compareStatValue && compareStat
-  };
-
-  let baseBar = compareStat ? Math.min(compareStatValue, value) : value;
-  if (isMasterworkedStat && masterworkValue > 0) {
-    baseBar -= masterworkValue;
-  }
-
-  const segments: [number, string?][] = [[baseBar]];
-
-  if (isMasterworkedStat && masterworkValue > 0) {
-    segments.push([masterworkValue, 'masterwork-stats']);
-  }
-
-  if (compareStat) {
-    if (compareStatValue > value) {
-      segments.push([compareStatValue - value, 'lower-stats']);
-    } else if (value > compareStatValue) {
-      segments.push([value - compareStatValue, 'higher-stats']);
-    }
-  }
-
-  const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
-
-  return (
-    <div className="stat-box-row" title={stat.displayProperties.description}>
-      <span
-        className={classNames('stat-box-text', 'stat-box-cell', {
-          'stat-box-masterwork': isMasterworkedStat
-        })}
-      >
-        {stat.displayProperties.name}
-      </span>
-
-      {stat.statHash === 2715839340 ? (
-        <span className="stat-recoil">
-          <RecoilStat stat={stat} />
-          <span className={classNames(higherLowerClasses)}>{value}</span>
-        </span>
-      ) : (
-        <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>
-          <span className="stat-box-container">
-            {stat.bar ? (
-              segments.map(([val, className], index) => (
-                <span
-                  key={index}
-                  className={classNames('stat-box-inner', className)}
-                  style={{ width: percent(val / stat.maximumValue) }}
-                />
-              ))
-            ) : (
-              <span className={classNames(higherLowerClasses)}>{displayValue}</span>
-            )}
-          </span>
-        </span>
-      )}
-
-      {stat.bar && (
-        <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
-          {displayValue}
-          {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
-            <span
-              className="item-stat-quality"
-              style={getColor(stat.qualityPercentage.min, 'color')}
-            >
-              ({stat.qualityPercentage.range})
-            </span>
-          )}
-        </span>
-      )}
-    </div>
-  );
-}
-
-function isD1Stat(item: DimItem, _stat: DimStat): _stat is D1Stat {
-  return item.isDestiny1();
 }

--- a/src/app/item-popup/RecoilStat.tsx
+++ b/src/app/item-popup/RecoilStat.tsx
@@ -1,11 +1,40 @@
 import React from 'react';
 import { DimStat } from 'app/inventory/item-types';
 
-export default function RecoilStat({ stat }: { stat: DimStat }) {
+export default function RecoilStat({
+  stat,
+  compareStat
+}: {
+  stat: DimStat;
+  compareStat?: DimStat;
+}) {
   const val = stat.value;
+
+  return (
+    <svg height="12" viewBox="0 0 2 1">
+      <circle r={1} cx={1} cy={1} fill="#555" />
+      <Wedge val={val} />
+      {compareStat && <Wedge val={compareStat.value} compare={val} />}
+    </svg>
+  );
+}
+
+export function recoilDirection(val: number) {
   // A value from 100 to -100 where positive is right and negative is left
   // See https://imgur.com/LKwWUNV
-  const direction = Math.sin((val + 5) * ((2 * Math.PI) / 20)) * (100 - val) * (Math.PI / 180);
+  return Math.sin((val + 5) * ((2 * Math.PI) / 20)) * (100 - val) * (Math.PI / 180);
+}
+
+function Wedge({ val, compare }: { val: number; compare?: number }) {
+  let color = '#FFF';
+  let opacity = 1.0;
+  const direction = recoilDirection(val);
+
+  if (compare !== undefined) {
+    const compareDirection = recoilDirection(compare);
+    color = Math.abs(compareDirection) < Math.abs(direction) ? '#6dcc66' : '#cc6666';
+    opacity = 0.7;
+  }
 
   const x = Math.sin(direction);
   const y = Math.cos(direction);
@@ -16,19 +45,22 @@ export default function RecoilStat({ stat }: { stat: DimStat }) {
   const xSpreadLess = Math.sin(direction - direction * spread);
   const ySpreadLess = Math.cos(direction - direction * spread);
 
-  return (
-    <svg height="12" viewBox="0 0 2 1">
-      <circle r={1} cx={1} cy={1} fill="#555" />
-      {Math.abs(direction) > 0.1 ? (
-        <path
-          d={`M1,1 L${1 + xSpreadMore},${1 - ySpreadMore} A1,1 0 0,${
-            direction < 0 ? '1' : '0'
-          } ${1 + xSpreadLess},${1 - ySpreadLess} Z`}
-          fill="#FFF"
-        />
-      ) : (
-        <line x1={1 - x} y1={1 + y} x2={1 + x} y2={1 - y} stroke="white" strokeWidth="0.1" />
-      )}
-    </svg>
+  return Math.abs(direction) > 0.1 ? (
+    <path
+      d={`M1,1 L${1 + xSpreadMore},${1 - ySpreadMore} A1,1 0 0,${direction < 0 ? '1' : '0'} ${1 +
+        xSpreadLess},${1 - ySpreadLess} Z`}
+      fill={color}
+      opacity={opacity}
+    />
+  ) : (
+    <line
+      x1={1 - x}
+      y1={1 + y}
+      x2={1 + x}
+      y2={1 - y}
+      stroke={color}
+      strokeWidth="0.1"
+      opacity={opacity}
+    />
   );
 }


### PR DESCRIPTION
<img width="515" alt="Screen Shot 2019-09-14 at 5 04 58 PM" src="https://user-images.githubusercontent.com/313208/64915043-d259e280-d712-11e9-9c60-bb464fc55aac.png">
<img width="394" alt="Screen Shot 2019-09-14 at 5 05 05 PM" src="https://user-images.githubusercontent.com/313208/64915044-d259e280-d712-11e9-9bed-a5a5d8d4a842.png">

This redesigns the stats display to use a separate bar for comparisons, instead of incrementally adding red/green to the existing bar. IMO it makes it clearer what your actual stats look like. The downside is I don't know how clear the red/green is now - you'll get longer bars colored red because your stat is worse than that one. It lines up with the numbers' coloring but it's a bit weird.

I also added comparison to recoil direction, including understanding that higher isn't just better for recoil - closer to the center is.

And I added icons for armor stats, since they're represented with icons in game.
