### PR TITLE
Get rid of store-bounds

### DIFF
--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -207,13 +207,18 @@ class ItemPopupContainer extends React.Component<Props, State> {
       if (this.popper) {
         this.popper.scheduleUpdate();
       } else {
-        const boundariesElement = boundarySelector
-          ? document.querySelector(boundarySelector)
-          : undefined;
-        if (boundariesElement) {
-          popperOptions.modifiers.preventOverflow.boundariesElement = boundariesElement;
-          popperOptions.modifiers.flip.boundariesElement = boundariesElement;
-        }
+        const headerHeight = document.getElementById('header')!.clientHeight;
+        const boundaryElement = boundarySelector && document.querySelector(boundarySelector);
+        const padding = {
+          left: 0,
+          top: headerHeight + (boundaryElement ? boundaryElement.clientHeight : 0) + 5,
+          right: 0,
+          bottom: 0
+        };
+        popperOptions.modifiers.preventOverflow.padding = padding;
+        popperOptions.modifiers.preventOverflow.boundariesElement = 'viewport';
+        popperOptions.modifiers.flip.padding = padding;
+        popperOptions.modifiers.flip.boundariesElement = 'viewport';
 
         this.popper = new Popper(element, this.popupRef.current, popperOptions);
         this.popper.scheduleUpdate(); // helps fix arrow position

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -52,12 +52,11 @@ class Destiny extends React.Component<Props> {
 
     return (
       <>
-        <div className="store-bounds" />
         <div id="content">
           <UIView />
         </div>
         <GlobalHotkeys hotkeys={hotkeys} />
-        <ItemPopupContainer boundarySelector=".store-bounds" />
+        <ItemPopupContainer boundarySelector=".store-header" />
         <ItemPickerContainer />
         <MoveAmountPopupContainer />
         <ManifestProgress destinyVersion={this.props.account.destinyVersion} />

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -232,22 +232,6 @@ input[type='search'] {
   padding-right: env(safe-area-inset-right);
 }
 
-.store-bounds {
-  position: fixed;
-  backface-visibility: hidden;
-  pointer-events: none;
-  bottom: 0px;
-  left: 0;
-  right: 0;
-  top: 124px;
-  top: calc(128px + constant(safe-area-inset-top));
-  top: calc(128px + env(safe-area-inset-top));
-}
-
-.ng-hide {
-  display: none;
-}
-
 h2,
 h3,
 h4 {
@@ -260,10 +244,6 @@ h4 {
 
 .drag-hover {
   background-color: rgba(255, 255, 255, 0.2);
-}
-
-.ng-hide {
-  display: none !important;
 }
 
 .close {


### PR DESCRIPTION
This gets rid of the invisible page-covering "store-bounds" element, which was only used to constrain the item popup from going out of bounds. Instead, we now just compute the bounds directly.

This has several advantages:
1. No more random div.
2. That div actually caused a lot of spurious paints (even though it was transparent). With it gone, scrolling and dragging should be a bit faster.
3. We now allow the popup to go quite a bit higher if the inventory header isn't present.

@sundevour I'd love to see if this helps with your dragging performance.