### PR TITLE
Separate masterwork value from tier

### DIFF
--- a/src/app/inventory/dimCsvService.factory.ts
+++ b/src/app/inventory/dimCsvService.factory.ts
@@ -179,10 +179,8 @@ function downloadArmor(
     if (item.isDestiny2()) {
       row['Masterwork Type'] = item.masterworkInfo && item.masterworkInfo.statName;
       row['Masterwork Tier'] =
-        item.masterworkInfo && item.masterworkInfo.statValue
-          ? item.masterworkInfo.statValue <= 5
-            ? item.masterworkInfo.statValue
-            : 5
+        item.masterworkInfo && item.masterworkInfo.tier
+          ? Math.min(5, item.masterworkInfo.tier)
           : undefined;
     }
     row.Owner = nameMap[item.owner];
@@ -282,10 +280,8 @@ function downloadWeapons(
     if (item.isDestiny2()) {
       row['Masterwork Type'] = item.masterworkInfo && item.masterworkInfo.statName;
       row['Masterwork Tier'] =
-        item.masterworkInfo && item.masterworkInfo.statValue
-          ? item.masterworkInfo.statValue <= 10
-            ? item.masterworkInfo.statValue
-            : 10
+        item.masterworkInfo && item.masterworkInfo.tier
+          ? Math.min(10, item.masterworkInfo.tier)
           : undefined;
     }
     row.Owner = nameMap[item.owner];

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -248,6 +248,8 @@ export interface DimMasterwork {
   statHash?: number;
   /** The name of the stat enhanced by this masterwork. */
   statName?: string;
+  /** The tier of the masterwork (not the same as the stat!). */
+  tier?: number;
   /** How much the stat is enhanced by this masterwork. */
   statValue?: number;
 }

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -82,7 +82,10 @@ function buildForsakenMasterworkInfo(
         typeDesc: masterworkSocket.plug.plugItem.displayProperties.description,
         statHash: masterwork.statTypeHash,
         statName: statDef.displayProperties.name,
-        statValue: masterwork.value
+        statValue: masterworkSocket.plug.stats
+          ? masterworkSocket.plug.stats[masterwork.statTypeHash]
+          : 0,
+        tier: masterwork.value
       };
     }
 
@@ -154,6 +157,7 @@ function buildMasterworkInfo(
     typeDesc: objectiveDef.progressDescription,
     statHash,
     statName: statDef.displayProperties.name,
-    statValue: investmentStats[0].value
+    statValue: socket.plug.stats ? socket.plug.stats[statHash] : 0,
+    tier: investmentStats[0].value
   };
 }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -878,9 +878,7 @@ function searchFilters(
           return false;
         }
         return compareByOperator(
-          item.masterworkInfo.statValue && item.masterworkInfo.statValue < 11
-            ? item.masterworkInfo.statValue
-            : 10,
+          item.masterworkInfo.tier && item.masterworkInfo.tier < 11 ? item.masterworkInfo.tier : 10,
           predicate
         );
       },


### PR DESCRIPTION
I realized we were using the masterwork tier (investment value) instead of its calculated stat contribution to draw stat graphs. However, we also use it as tier in some places. So I split the definitions and used the caculated stat for "value".