### PR TITLE
Remove stat comparison in item popup

### DIFF
--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -112,7 +112,7 @@ class StoreBucket extends React.Component<Props> {
           className={classNames({ 'not-equippable': !store.isVault && !equippedItem })}
         >
           {unequippedItems.map((item) => (
-            <StoreInventoryItem key={item.index} item={item} equippedItem={equippedItem} />
+            <StoreInventoryItem key={item.index} item={item} />
           ))}
           {bucket.id === '375726501' &&
             _.times(bucket.capacity - unequippedItems.length, (index) => (

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -9,7 +9,6 @@ import ConnectedInventoryItem from './ConnectedInventoryItem';
 
 interface Props {
   item: DimItem;
-  equippedItem?: DimItem;
 }
 
 /**
@@ -17,11 +16,11 @@ interface Props {
  */
 export default class StoreInventoryItem extends React.PureComponent<Props> {
   render() {
-    const { item, equippedItem } = this.props;
+    const { item } = this.props;
 
     return (
       <DraggableInventoryItem item={item}>
-        <ItemPopupTrigger item={item} extraData={{ compareItem: equippedItem }}>
+        <ItemPopupTrigger item={item}>
           {(ref, onClick) => (
             <ConnectedInventoryItem
               item={item}

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -74,7 +74,7 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
 
       {item.classified && <div className="item-details">{t('ItemService.Classified2')}</div>}
 
-      <ItemStats item={item} compareItem={extraInfo.compareItem} />
+      <ItemStats item={item} />
 
       {item.talentGrid && (
         <div className="item-details item-perks">

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -5,6 +5,7 @@ import RecoilStat from './RecoilStat';
 import { percent, getColor } from 'app/shell/filters';
 import classNames from 'classnames';
 import { t } from 'app/i18next-t';
+import BungieImage from 'app/dim-ui/BungieImage';
 
 /**
  * A single stat line.
@@ -63,6 +64,9 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item: DimItem 
       {stat.bar && (
         <span className="stat-box-val stat-box-cell">
           {displayValue}
+          {stat.displayProperties.hasIcon && (
+            <BungieImage className="stat-icon" src={stat.displayProperties.icon} />
+          )}
           {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
             <span
               className="item-stat-quality"

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { DimStat, DimItem, D1Stat } from 'app/inventory/item-types';
+import { statsMs } from 'app/inventory/store/stats';
+import { t } from 'i18next';
+import RecoilStat from './RecoilStat';
+import { percent, getColor } from 'app/shell/filters';
+
+/**
+ * A single stat line.
+ */
+export default function ItemStat({
+  stat,
+  item,
+  compareStat
+}: {
+  stat: DimStat;
+  item: DimItem;
+  compareStat?: DimStat;
+}) {
+  const value = stat.value;
+  const compareStatValue = compareStat ? compareStat.value : 0;
+  const isMasterworkedStat =
+    item.isDestiny2() && item.masterworkInfo && stat.statHash === item.masterworkInfo.statHash;
+  const masterworkValue =
+    (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
+  const higherLowerClasses = {
+    'higher-stats': stat.smallerIsBetter
+      ? value < compareStatValue && compareStat
+      : value > compareStatValue && compareStat,
+    'lower-stats': stat.smallerIsBetter
+      ? value > compareStatValue && compareStat
+      : value < compareStatValue && compareStat
+  };
+
+  let baseBar = compareStat ? Math.min(compareStatValue, value) : value;
+  if (isMasterworkedStat && masterworkValue > 0) {
+    baseBar -= masterworkValue;
+  }
+
+  const segments: [number, string?][] = [[baseBar]];
+
+  if (isMasterworkedStat && masterworkValue > 0) {
+    segments.push([masterworkValue, 'masterwork-stats']);
+  }
+
+  if (compareStat) {
+    if (compareStatValue > value) {
+      segments.push([compareStatValue - value, 'lower-stats']);
+    } else if (value > compareStatValue) {
+      segments.push([value - compareStatValue, 'higher-stats']);
+    }
+  }
+
+  const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
+
+  return (
+    <div className="stat-box-row" title={stat.displayProperties.description}>
+      <span
+        className={classNames('stat-box-text', 'stat-box-cell', {
+          'stat-box-masterwork': isMasterworkedStat
+        })}
+      >
+        {stat.displayProperties.name}
+      </span>
+
+      {stat.statHash === 2715839340 ? (
+        <span className="stat-recoil">
+          <RecoilStat stat={stat} />
+          <span className={classNames(higherLowerClasses)}>{value}</span>
+        </span>
+      ) : (
+        <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>
+          <span className="stat-box-container">
+            {stat.bar ? (
+              segments.map(([val, className], index) => (
+                <span
+                  key={index}
+                  className={classNames('stat-box-inner', className)}
+                  style={{ width: percent(val / stat.maximumValue) }}
+                />
+              ))
+            ) : (
+              <span className={classNames(higherLowerClasses)}>{displayValue}</span>
+            )}
+          </span>
+        </span>
+      )}
+
+      {stat.bar && (
+        <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
+          {displayValue}
+          {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
+            <span
+              className="item-stat-quality"
+              style={getColor(stat.qualityPercentage.min, 'color')}
+            >
+              ({stat.qualityPercentage.range})
+            </span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function isD1Stat(item: DimItem, _stat: DimStat): _stat is D1Stat {
+  return item.isDestiny1();
+}

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -1,38 +1,22 @@
 import React from 'react';
 import { DimStat, DimItem, D1Stat } from 'app/inventory/item-types';
 import { statsMs } from 'app/inventory/store/stats';
-import { t } from 'i18next';
 import RecoilStat from './RecoilStat';
 import { percent, getColor } from 'app/shell/filters';
+import classNames from 'classnames';
+import { t } from 'app/i18next-t';
 
 /**
  * A single stat line.
  */
-export default function ItemStat({
-  stat,
-  item,
-  compareStat
-}: {
-  stat: DimStat;
-  item: DimItem;
-  compareStat?: DimStat;
-}) {
+export default function ItemStat({ stat, item }: { stat: DimStat; item: DimItem }) {
   const value = stat.value;
-  const compareStatValue = compareStat ? compareStat.value : 0;
   const isMasterworkedStat =
     item.isDestiny2() && item.masterworkInfo && stat.statHash === item.masterworkInfo.statHash;
   const masterworkValue =
     (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
-  const higherLowerClasses = {
-    'higher-stats': stat.smallerIsBetter
-      ? value < compareStatValue && compareStat
-      : value > compareStatValue && compareStat,
-    'lower-stats': stat.smallerIsBetter
-      ? value > compareStatValue && compareStat
-      : value < compareStatValue && compareStat
-  };
 
-  let baseBar = compareStat ? Math.min(compareStatValue, value) : value;
+  let baseBar = value;
   if (isMasterworkedStat && masterworkValue > 0) {
     baseBar -= masterworkValue;
   }
@@ -41,14 +25,6 @@ export default function ItemStat({
 
   if (isMasterworkedStat && masterworkValue > 0) {
     segments.push([masterworkValue, 'masterwork-stats']);
-  }
-
-  if (compareStat) {
-    if (compareStatValue > value) {
-      segments.push([compareStatValue - value, 'lower-stats']);
-    } else if (value > compareStatValue) {
-      segments.push([value - compareStatValue, 'higher-stats']);
-    }
   }
 
   const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
@@ -66,28 +42,26 @@ export default function ItemStat({
       {stat.statHash === 2715839340 ? (
         <span className="stat-recoil">
           <RecoilStat stat={stat} />
-          <span className={classNames(higherLowerClasses)}>{value}</span>
+          {value}
         </span>
       ) : (
         <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>
           <span className="stat-box-container">
-            {stat.bar ? (
-              segments.map(([val, className], index) => (
-                <span
-                  key={index}
-                  className={classNames('stat-box-inner', className)}
-                  style={{ width: percent(val / stat.maximumValue) }}
-                />
-              ))
-            ) : (
-              <span className={classNames(higherLowerClasses)}>{displayValue}</span>
-            )}
+            {stat.bar
+              ? segments.map(([val, className], index) => (
+                  <span
+                    key={index}
+                    className={classNames('stat-box-inner', className)}
+                    style={{ width: percent(val / stat.maximumValue) }}
+                  />
+                ))
+              : displayValue}
           </span>
         </span>
       )}
 
       {stat.bar && (
-        <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
+        <span className="stat-box-val stat-box-cell">
           {displayValue}
           {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
             <span

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -34,12 +34,6 @@
     padding-right: 10px;
     padding-left: 5px;
   }
-  .higher-stats {
-    color: #6dcc66;
-  }
-  .lower-stats {
-    color: #cc6666;
-  }
   .stat-recoil {
     display: table-cell;
     height: 12px;
@@ -72,12 +66,6 @@
     background-color: white;
     color: black;
     line-height: 20px;
-    &.higher-stats {
-      background-color: #6dcc66;
-    }
-    &.lower-stats {
-      background-color: #cc6666;
-    }
     &.masterwork-stats {
       background-color: $orange;
     }

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -73,6 +73,13 @@
       background-color: $orange;
     }
   }
+
+  .stat-icon {
+    height: 12px;
+    width: 12px;
+    vertical-align: bottom;
+    margin-left: 4px;
+  }
 }
 
 .item-stat-quality {

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -8,31 +8,15 @@ import ExternalLink from '../dim-ui/ExternalLink';
 import _ from 'lodash';
 import ItemStat from './ItemStat';
 
-export default function ItemStats({
-  item,
-  /** Another item to compare stats against. Usually the equipped item. */
-  compareItem
-}: {
-  item: DimItem;
-  compareItem?: DimItem;
-}) {
+export default function ItemStats({ item }: { item: DimItem }) {
   if (!item.stats || !item.stats.length) {
     return null;
   }
 
-  const compareStatsByStatHash = compareItem
-    ? _.keyBy(compareItem.stats, (stat) => stat.statHash)
-    : {};
-
   return (
     <div className="stats">
       {item.stats.map((stat) => (
-        <ItemStat
-          key={stat.statHash}
-          stat={stat}
-          item={item}
-          compareStat={compareStatsByStatHash[stat.statHash]}
-        />
+        <ItemStat key={stat.statHash} stat={stat} item={item} />
       ))}
 
       {item.isDestiny1() && item.quality && item.quality.min && (

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { DimItem, DimStat, D1Stat } from '../inventory/item-types';
-import classNames from 'classnames';
+import { DimItem } from '../inventory/item-types';
 import { t } from 'app/i18next-t';
 import './ItemStats.scss';
-import { getColor, percent } from '../shell/filters';
+import { getColor } from '../shell/filters';
 import { AppIcon, helpIcon } from '../shell/icons';
 import ExternalLink from '../dim-ui/ExternalLink';
 import _ from 'lodash';
-import RecoilStat from './RecoilStat';
-import { statsMs } from 'app/inventory/store/stats';
+import ItemStat from './ItemStat';
 
 export default function ItemStats({
   item,
@@ -29,7 +27,7 @@ export default function ItemStats({
   return (
     <div className="stats">
       {item.stats.map((stat) => (
-        <ItemStatRow
+        <ItemStat
           key={stat.statHash}
           stat={stat}
           item={item}
@@ -53,103 +51,4 @@ export default function ItemStats({
       )}
     </div>
   );
-}
-
-function ItemStatRow({
-  stat,
-  item,
-  compareStat
-}: {
-  stat: DimStat;
-  item: DimItem;
-  compareStat?: DimStat;
-}) {
-  const value = stat.value;
-  const compareStatValue = compareStat ? compareStat.value : 0;
-  const isMasterworkedStat =
-    item.isDestiny2() && item.masterworkInfo && stat.statHash === item.masterworkInfo.statHash;
-  const masterworkValue =
-    (item.isDestiny2() && item.masterworkInfo && item.masterworkInfo.statValue) || 0;
-  const higherLowerClasses = {
-    'higher-stats': stat.smallerIsBetter
-      ? value < compareStatValue && compareStat
-      : value > compareStatValue && compareStat,
-    'lower-stats': stat.smallerIsBetter
-      ? value > compareStatValue && compareStat
-      : value < compareStatValue && compareStat
-  };
-
-  let baseBar = compareStat ? Math.min(compareStatValue, value) : value;
-  if (isMasterworkedStat && masterworkValue > 0) {
-    baseBar -= masterworkValue;
-  }
-
-  const segments: [number, string?][] = [[baseBar]];
-
-  if (isMasterworkedStat && masterworkValue > 0) {
-    segments.push([masterworkValue, 'masterwork-stats']);
-  }
-
-  if (compareStat) {
-    if (compareStatValue > value) {
-      segments.push([compareStatValue - value, 'lower-stats']);
-    } else if (value > compareStatValue) {
-      segments.push([value - compareStatValue, 'higher-stats']);
-    }
-  }
-
-  const displayValue = statsMs.includes(stat.statHash) ? t('Stats.Milliseconds', { value }) : value;
-
-  return (
-    <div className="stat-box-row" title={stat.displayProperties.description}>
-      <span
-        className={classNames('stat-box-text', 'stat-box-cell', {
-          'stat-box-masterwork': isMasterworkedStat
-        })}
-      >
-        {stat.displayProperties.name}
-      </span>
-
-      {stat.statHash === 2715839340 ? (
-        <span className="stat-recoil">
-          <RecoilStat stat={stat} />
-          <span className={classNames(higherLowerClasses)}>{value}</span>
-        </span>
-      ) : (
-        <span className={classNames('stat-box-outer', { 'stat-box-outer--no-bar': !stat.bar })}>
-          <span className="stat-box-container">
-            {stat.bar ? (
-              segments.map(([val, className], index) => (
-                <span
-                  key={index}
-                  className={classNames('stat-box-inner', className)}
-                  style={{ width: percent(val / stat.maximumValue) }}
-                />
-              ))
-            ) : (
-              <span className={classNames(higherLowerClasses)}>{displayValue}</span>
-            )}
-          </span>
-        </span>
-      )}
-
-      {stat.bar && (
-        <span className={classNames('stat-box-val', 'stat-box-cell', higherLowerClasses)}>
-          {displayValue}
-          {isD1Stat(item, stat) && stat.qualityPercentage && stat.qualityPercentage.min && (
-            <span
-              className="item-stat-quality"
-              style={getColor(stat.qualityPercentage.min, 'color')}
-            >
-              ({stat.qualityPercentage.range})
-            </span>
-          )}
-        </span>
-      )}
-    </div>
-  );
-}
-
-function isD1Stat(item: DimItem, _stat: DimStat): _stat is D1Stat {
-  return item.isDestiny1();
 }

--- a/src/app/item-popup/item-popup.ts
+++ b/src/app/item-popup/item-popup.ts
@@ -14,7 +14,6 @@ export interface ItemPopupExtraInfo {
   failureStrings?: string[];
   owned?: boolean;
   acquired?: boolean;
-  compareItem?: DimItem;
 }
 
 export function showItemPopup(item: DimItem, element: Element, extraInfo?: ItemPopupExtraInfo) {


### PR DESCRIPTION
In line with our earlier discussion about inline comparison. I like it. I *could* add back in a button you could hover or press to show the comparisons, but I kinda agree that they're better off in the compare tool

<img width="392" alt="Screen Shot 2019-09-17 at 11 55 43 PM" src="https://user-images.githubusercontent.com/313208/65122843-c71ee500-d9a6-11e9-850e-7d1d79bd0d2e.png">
