### PR TITLE
fix inventory size overflow

### DIFF
--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -24,13 +24,13 @@ export default function updateCSSVariables() {
       }
       if (currentState.charCol !== nextState.charCol) {
         if (!isPhonePortrait()) {
-          setCSSVariable('--character-columns', nextState.charCol);
+          setCSSVariable('--tiles-per-char-column', nextState.charCol);
         }
       }
       if (currentState.charColMobile !== nextState.charColMobile) {
         // this check is needed so on start up/load this doesn't override the value set above on "normal" mode.
         if (isPhonePortrait()) {
-          setCSSVariable('--character-columns', nextState.charColMobile);
+          setCSSVariable('--tiles-per-char-column', nextState.charColMobile);
         }
       }
 
@@ -50,7 +50,7 @@ export default function updateCSSVariables() {
   isPhonePortraitStream().subscribe((isPhonePortrait) => {
     const settings = store.getState().settings;
     setCSSVariable(
-      '--character-columns',
+      '--tiles-per-char-column',
       isPhonePortrait ? settings.charColMobile : settings.charCol
     );
   });

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -20,7 +20,7 @@
   &.equipped {
     display: flex;
     flex-direction: column;
-    width: calc(var(--item-size) + #{2 * ($equipped-item-border + $equipped-item-padding)});
+    width: calc(var(--item-size) + #{$equipped-item-total-outset});
     margin-right: var(--item-margin);
   }
 

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -26,11 +26,7 @@
   grid-template-columns:
     repeat(
       var(--num-characters),
-      calc(
-        /* Equipped item border */ #{2 * ($equipped-item-border + $equipped-item-padding)} + /* Equipped + unequipped items */
-          ((var(--character-columns) + 1) * (var(--item-size) + var(--item-margin))) + /* Column padding */
-          (2 * var(--inventory-column-padding) - var(--item-margin))
-      )
+      calc(#{$equipped-item-total-outset} + var(--character-column-width) + var(--column-padding))
     )
     // Vault takes the rest
     1fr;
@@ -56,7 +52,7 @@
   }
 
   &.account-wide {
-    grid-column: 1 / span var(--character-columns);
+    grid-column: 1 / span var(--num-characters);
   }
 
   &:nth-child(even) {
@@ -73,7 +69,7 @@
   // Engrams
   .bucket-375726501 & {
     /* prettier-ignore */
-    --engram-size: calc((var(--item-size) + var(--item-margin)) * (var(--character-columns) + 1) / 10);
+    --engram-size: calc(var(--character-column-width) / 10);
 
     .empty-engram {
       border: $item-border-width solid transparent;
@@ -98,7 +94,7 @@
     }
   }
 
-  // Subclasses
+  // Subclasses - hide normal "equipped" effects
   .bucket-3284755031 & {
     .equipped-item {
       border: $item-border-width solid transparent;
@@ -106,7 +102,7 @@
     }
   }
 
-  // Postmaster
+  // Postmaster - items above, collect button below
   .bucket-215593132 & {
     flex-direction: column;
   }

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -156,14 +156,18 @@
     display: flex;
     flex-direction: row;
     align-items: flex-start;
+    /* prettier-ignore */
     max-width: calc(
-      /* Equipped item border */ 6px + /* Equipped + unequipped items */
-        ((var(--character-columns) + 1) * (var(--item-size) + var(--item-margin)))
-    );
+      #{$equipped-item-total-outset} +
+      var(--character-column-width)
+    ); // ↑ fit 1 equipped + 3-5 items
+
+    /* prettier-ignore */
     min-width: calc(
-      /* Equipped item border */ 6px + /* Equipped + unequipped items */ 2 *
-        (var(--item-size) + var(--item-margin))
-    );
+      #{$equipped-item-total-outset} +
+      2 * (var(--item-size) + var(--item-margin))
+    ); // ↑ fit at least 1 equipped + 1 unequipped item
+
     width: max-content;
     @include phone-portrait {
       max-width: 100%;

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -92,10 +92,11 @@
 
 .loadout-menu {
   position: absolute;
+  /* prettier-ignore */
   width: calc(
-    /* Equipped item border */ #{2 * ($equipped-item-border + $equipped-item-padding)} + /* Equipped + unequipped items */
-      ((var(--character-columns) + 1) * (var(--item-size) + var(--item-margin))) /* Column padding */ -
-      var(--item-margin)
+    #{$equipped-item-total-outset} +
+    var(--character-column-width) -
+    var(--item-margin)
   );
   @include phone-portrait {
     max-width: 230px;

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -11,9 +11,16 @@
   --item-margin: 6px;
   // Padding at the ends of inventory column
   --inventory-column-padding: 12px;
+  // ultimately user-determined. default values here
   --num-characters: 3;
-  --character-columns: 3;
+  --tiles-per-char-column: 3;
   --color-filter: '';
+  // equipped item plus character's inventory
+  --character-column-width: calc(
+    (var(--tiles-per-char-column) + 1) * (var(--item-size) + var(--item-margin))
+  );
+  // used for phone protrait mode
+  --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
 }
 
 @media (max-width: 1025px) {
@@ -25,32 +32,37 @@
 @include phone-portrait {
   :root {
     --item-margin: 10px;
+    // Padding at the ends of inventory column
     --inventory-column-padding: 12px;
     /* prettier-ignore */
     --item-size: calc(
       (
-        /* Full width */ 100vw -
-        /* Column padding */ (2 * var(--inventory-column-padding) - var(--item-margin)) -
-        /* Equipped item border */ #{2 * ($equipped-item-border + $equipped-item-padding)} -
-        /* Item margins for each item */ var(--item-margin) * (var(--character-columns) + 1)
-      ) / (var(--character-columns) + 1)
+          100vw - // page width
+          var(--column-padding) -
+          #{$equipped-item-total-outset} -
+          var(--combined-item-margins)
+        ) / (var(--tiles-per-char-column) + 1)
     ) !important;
+    --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
+    --combined-item-margins: calc(var(--item-margin) * (var(--tiles-per-char-column) + 1));
   }
 
   .char-cols-3 {
     --item-margin: 15px;
     // Padding at the ends of inventory column
     --inventory-column-padding: 34px;
-    // TODO: Not sure why I need to repeat this!
+    // this is duplicated for .char-cols-3 to recalculate using local var sjustmenes
     /* prettier-ignore */
     --item-size: calc(
       (
-        /* Full width */ 100vw -
-        /* Column padding */ (2 * var(--inventory-column-padding) - var(--item-margin)) -
-        /* Equipped item border */ #{2 * ($equipped-item-border + $equipped-item-padding)} -
-        /* Item margins for each item */ var(--item-margin) * (var(--character-columns) + 1)
-      ) / (var(--character-columns) + 1)
+        100vw - // page width
+        var(--column-padding) -
+        #{$equipped-item-total-outset} -
+        var(--combined-item-margins)
+      ) / (var(--tiles-per-char-column) + 1)
     ) !important;
+    --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
+    --combined-item-margins: calc(var(--item-margin) * (var(--tiles-per-char-column) + 1));
   }
 }
 

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -19,7 +19,7 @@
   --character-column-width: calc(
     (var(--tiles-per-char-column) + 1) * (var(--item-size) + var(--item-margin))
   );
-  // used for phone portrait mode
+  // used for phone protrait mode
   --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
 }
 
@@ -51,7 +51,7 @@
     --item-margin: 15px;
     // Padding at the ends of inventory column
     --inventory-column-padding: 34px;
-    // this is duplicated for .char-cols-3 to recalculate using local var sjustmenes
+    // this is duplicated for .char-cols-3 to recalculate using local var adjustments
     /* prettier-ignore */
     --item-size: calc(
       (

--- a/src/scss/_style.scss
+++ b/src/scss/_style.scss
@@ -19,7 +19,7 @@
   --character-column-width: calc(
     (var(--tiles-per-char-column) + 1) * (var(--item-size) + var(--item-margin))
   );
-  // used for phone protrait mode
+  // used for phone portrait mode
   --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -30,6 +30,7 @@ $item-border-width: 1px;
 // Border around equipped items
 $equipped-item-border: 1px;
 $equipped-item-padding: 2px;
+$equipped-item-total-outset: #{2 * ($equipped-item-border + $equipped-item-padding)};
 
 // Full tile size including borders
 $badge-font-size: '(var(--item-size) / 5)';


### PR DESCRIPTION
fixes the consumables inventory in 4/5 column-per-char mode. currently it expands char area to the end of the page where the vault stuff should be.

it does rename some variables and introduce 1 or 2 intermediate variables for clarity. this deserves a lot more and a revamp but first the fix