### PR TITLE
Fix parent container animating when finding a compared item

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -278,10 +278,7 @@ class Compare extends React.Component<Props, State> {
 
   private itemClick = (item: DimItem) => {
     // TODO: this is tough to do with an ID since we'll have multiple
-    const element = idx(
-      document.getElementById(item.index),
-      (e) => e.parentNode.parentNode
-    ) as HTMLElement;
+    const element = idx(document.getElementById(item.index), (e) => e.parentNode) as HTMLElement;
     if (!element) {
       throw new Error(`No element with id ${item.index}`);
     }


### PR DESCRIPTION
This PR fixes an issue whereby the wrong element is animated when clicking on the magnifying glass in the compare sheet:

![dim-compare-item-parent-pop](https://user-images.githubusercontent.com/17512262/65368736-21ff5780-dc99-11e9-9c2f-47cf8c423a4c.gif)

#4221 flattened the DOM structure for the item grid - notably, a **`div`** between the draggable container and the inventory item was removed.

![image](https://user-images.githubusercontent.com/17512262/65368686-ae5d4a80-dc98-11e9-81b7-97722fb0ebae.png)

This caused the logic which locates the item to apply the 'pop' effect to when clicking the magnifying glass in the compare sheet to traverse one parent too far.