### PR TITLE
Add configuration to support debugging in VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
     "dbaeumer.vscode-eslint",
-    "orta.vscode-jest"
+    "orta.vscode-jest",
+    "msjsdiag.debugger-for-chrome"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "https://127.0.0.1:8080/index.html",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,7 @@
     {
       "type": "chrome",
       "request": "launch",
+      "preLaunchTask": "start",
       "name": "Launch Chrome against localhost",
       "url": "https://127.0.0.1:8080/index.html",
       "webRoot": "${workspaceFolder}"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "start",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["start"],
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": [
+          {
+            "regexp": "\\b\\B",
+            "file": 1,
+            "location": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "==> Webpack is starting to build.*",
+          "endsPattern": "==> Webpack finished building.*"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds **launch.json** and **tasks.json** files to allow debugging of DIM in Visual Studio Code. It is configured to use the project defaults. When you hit F5:

1. The Webpack server is started if not already running (`yarn start`)
2. A new instance of Chrome is launched, pointing to `https://127.0.0.1:8080/index.html`
3. The VS Code debugger is attached to the new Chrome instance - this allows you to hit breakpoints set in VS Code

Attaching the VS Code debugger to Chrome requires Microsoft's [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) extension, so I have added it to the list of recommended extensions in **.vscode/extensions.json**.

I think this would be helpful for new contributors, especially because **CONTRIBUTING.md** recommends VS Code for working on DIM.