### PR TITLE
pads the logout button away from accounts

### DIFF
--- a/src/app/accounts/AccountSelect.scss
+++ b/src/app/accounts/AccountSelect.scss
@@ -119,8 +119,7 @@
 
   .account-select {
     height: auto;
-    flex: 1;
-    flex-shrink: 0;
+    flex: 1 0 auto;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;

--- a/src/app/accounts/AccountSelect.scss
+++ b/src/app/accounts/AccountSelect.scss
@@ -17,6 +17,10 @@
   padding-top: 6px;
   padding-bottom: 4px;
 
+  &.log-out {
+    margin-top: 20px;
+  }
+
   .account-details {
     font-size: 12px !important;
     color: #aaa;


### PR DESCRIPTION
This just adds a bit of top margin to the logout menu item as it's a bit close to the account selection for comfort. Specially for touch devices. Was requested from the discord. 

![image](https://user-images.githubusercontent.com/29002828/65374188-fd818c00-dc54-11e9-9173-d1f4bdc5b35b.png)
