### PR TITLE
improved masterwork and season filters

### DIFF
--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -34,6 +34,25 @@ const LazyFilterHelp = React.lazy(() =>
   import(/* webpackChunkName: "filter-help" */ './FilterHelp')
 );
 
+/** matches a keyword that's probably a math comparison */
+const mathCheck = /[\d<>=]/;
+
+/** if one of these has been typed, stop guessing which filter and just offer this filter's values */
+const completedFilterNames = [
+  'is:',
+  'not:',
+  'tag:',
+  'notes:',
+  'stat:',
+  'stack:',
+  'count:',
+  'source:',
+  'perk:',
+  'perkname:',
+  'name:',
+  'description:'
+];
+
 /**
  * A reusable, autocompleting item search input. This is an uncontrolled input that
  * announces its query has changed only after some delay.
@@ -189,12 +208,13 @@ export default class SearchFilterInput extends React.Component<Props, State> {
           search(term, callback) {
             if (term) {
               let words = this.words.filter((word: string) => word.includes(term.toLowerCase()));
-              words = _.sortBy(words, (word: string) => word.indexOf(term.toLowerCase()));
-              if (
-                term.match(
-                  /\b((is:|not:|tag:|notes:|stat:|stack:|count:|source:|perk:|perkname:|name:|description:)\w*)$/i
-                )
-              ) {
+              words = _.sortBy(words, [
+                // prioritize things we might be typing out from their beginning
+                (word: string) => word.indexOf(term.toLowerCase()),
+                // push math operators to the front
+                (word: string) => !mathCheck.test(word)
+              ]);
+              if (completedFilterNames.includes(term)) {
                 callback(words);
               } else if (words.length) {
                 callback([term, ...words]);

--- a/src/app/search/search-filter-hashes.ts
+++ b/src/app/search/search-filter-hashes.ts
@@ -210,6 +210,7 @@ export const statHashByName = {
   magazine: 3871231066,
   aimassist: 1345609583,
   equipspeed: 943549884,
+  handling: 943549884,
   mobility: 2996146975,
   resilience: 392767087,
   recovery: 1943323491,

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -21,11 +21,13 @@ import { loadoutsSelector } from '../loadout/reducer';
 import { InventoryCuratedRoll } from '../wishlists/wishlists';
 import { inventoryCuratedRollsSelector } from '../wishlists/reducer';
 import { D2SeasonInfo } from '../inventory/d2-season-info';
-import { D2EventPredicateLookup } from 'data/d2/d2-event-info';
 import { getRating, ratingsSelector, ReviewsState, shouldShowRating } from '../item-review/reducer';
 import { RootState } from '../store/reducers';
+
+import { D2EventPredicateLookup } from 'data/d2/d2-event-info';
 import * as hashes from './search-filter-hashes';
 import D2Sources from 'data/d2/source-info';
+import seasonTags from 'data/d2/season-tags.json';
 import { DEFAULT_SHADER } from 'app/inventory/store/sockets';
 
 /**
@@ -56,6 +58,11 @@ const trimQuotes = (s: string) => s.replace(/(^['"]|['"]$)/g, '');
 
 /** filter function to use when there's no query */
 const alwaysTrue = () => true;
+
+/** strings representing math checks */
+const operators = ['<', '>', '<=', '>=', '='];
+/** matches a predicate that's probably a math check */
+const mathCheck = /^[\d<>=]/;
 
 /**
  * Selectors
@@ -249,8 +256,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     ...($featureFlags.reviewsEnabled ? { hasRating: ['rated', 'hasrating'] } : {})
   };
 
-  const comparisons = [':<', ':>', ':<=', ':>=', ':='];
-  // Filters that operate on numeric ranges with ↑ these operators
+  // Filters that operate on numeric ranges with comparison operators
   const ranges = [
     'light',
     'power',
@@ -271,9 +277,13 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
       .flatMap((word) => [`is:${word}`, `not:${word}`]),
     ...itemTags.map((tag) => (tag.type ? `tag:${tag.type}` : 'tag:none')),
     // a keyword for every combination of an item stat name and mathmatical operator
-    ...stats.flatMap((word) => comparisons.map((comparison) => `stat:${word}` + comparison)),
+    ...stats.flatMap((stat) => operators.map((comparison) => `stat:${stat}:${comparison}`)),
+    // keywords for checking which stat is masterworked
+    ...stats.map((stat) => `masterwork:${stat}`),
+    // keywords for named seasons
+    ...Object.keys(seasonTags).map((tag) => `season:${tag}`),
     // a keyword for every combination of a DIM-processed stat and mathmatical operator
-    ...ranges.flatMap((range) => comparisons.map((comparison) => range + comparison)),
+    ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
     // "source:" keyword plus one for each source
     ...(isD2 ? ['source:', ...Object.keys(D2Sources).map((word) => `source:${word}`)] : []),
     // all the free text searches that support quotes
@@ -387,7 +397,6 @@ function searchFilters(
       return false;
     }
 
-    const operators = ['<=', '>=', '=', '>', '<'];
     let operator = 'none';
 
     operators.forEach((element) => {
@@ -509,6 +518,7 @@ function searchFilters(
               addPredicate('quality', filterValue, invert);
               break;
             // filter names with "Value" in the actual filter name but not in search bar
+            // currently just masterworkValue but depends on name collisions
             case 'masterwork':
               addPredicate(`${filterName}Value`, filterValue, invert);
               break;
@@ -765,7 +775,7 @@ function searchFilters(
       },
       notes(item: DimItem, predicate: string) {
         const notes = getNotes(item, itemInfos);
-        return notes && notes.toLocaleLowerCase().includes(predicate.toLocaleLowerCase());
+        return notes && notes.toLocaleLowerCase().includes(predicate);
       },
       stattype(item: DimItem, predicate: string) {
         return (
@@ -788,8 +798,7 @@ function searchFilters(
         return item.infusable;
       },
       categoryHash(item: D2Item, predicate: string) {
-        const categoryHash =
-          searchConfig.categoryHashFilters[predicate.toLowerCase().replace(/\s/g, '')];
+        const categoryHash = searchConfig.categoryHashFilters[predicate.replace(/\s/g, '')];
 
         if (!categoryHash) {
           return false;
@@ -802,7 +811,7 @@ function searchFilters(
           plainString(item.name).includes(predicate) ||
           item.description.toLowerCase().includes(predicate) ||
           // Search notes field
-          (notes && notes.toLocaleLowerCase().includes(predicate.toLocaleLowerCase())) ||
+          (notes && notes.toLocaleLowerCase().includes(predicate)) ||
           // Search for typeName (itemTypeDisplayName of modifications)
           item.typeName.toLowerCase().includes(predicate) ||
           // Search perks as well
@@ -877,13 +886,24 @@ function searchFilters(
         if (!item.masterworkInfo) {
           return false;
         }
-        return compareByOperator(
-          item.masterworkInfo.tier && item.masterworkInfo.tier < 11 ? item.masterworkInfo.tier : 10,
-          predicate
+        if (mathCheck.test(predicate)) {
+          return compareByOperator(
+            item.masterworkInfo.tier && item.masterworkInfo.tier < 11
+              ? item.masterworkInfo.tier
+              : 10,
+            predicate
+          );
+        }
+        return (
+          hashes.statHashByName[predicate] && // make sure it exists or undefined can match undefined
+          hashes.statHashByName[predicate] === item.masterworkInfo.statHash
         );
       },
       season(item: D2Item, predicate: string) {
-        return compareByOperator(item.season, predicate);
+        if (mathCheck.test(predicate)) {
+          return compareByOperator(item.season, predicate);
+        }
+        return seasonTags[predicate] && seasonTags[predicate] === item.season;
       },
       year(item: DimItem, predicate: string) {
         if (item.isDestiny1()) {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -280,8 +280,10 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     ...stats.flatMap((stat) => operators.map((comparison) => `stat:${stat}:${comparison}`)),
     // keywords for checking which stat is masterworked
     ...stats.map((stat) => `masterwork:${stat}`),
-    // keywords for named seasons
-    ...Object.keys(seasonTags).map((tag) => `season:${tag}`),
+    // keywords for named seasons. reverse so newest seasons are first
+    ...Object.keys(seasonTags)
+      .reverse()
+      .map((tag) => `season:${tag}`),
     // a keyword for every combination of a DIM-processed stat and mathmatical operator
     ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
     // "source:" keyword plus one for each source

--- a/src/data/d2/season-tags.json
+++ b/src/data/d2/season-tags.json
@@ -1,0 +1,9 @@
+{
+  "redwar": 1,
+  "osiris": 2,
+  "warmind": 3,
+  "outlaw": 4,
+  "forge": 5,
+  "drifter": 6,
+  "opulence": 7
+}


### PR DESCRIPTION
:warning: merge https://github.com/DestinyItemManager/d2-additional-info/pull/52 alongside & after this

adds filters for which stat is masterworked on a gun, and for season-by-name

overloads these new terms into the existing math filters using a regex that performs at 25mil ops/sec for me

![image](https://user-images.githubusercontent.com/31990469/65397507-81c33480-dd65-11e9-85b5-a124b8d05ad9.png)

![image](https://user-images.githubusercontent.com/31990469/65397504-7d971700-dd65-11e9-9d7a-1f7964ceb606.png)

supporting changes:
- "handling" synonym in stat-to-name converter
- search suggest sorting changes:
 - - list.includes instead of a messy long regex
  - - pushes math operators to the top lest they get lost and never learned by users
- de-duplicated the definition of the math operator strings
- removed redundant lowercasing of the already-lowercase predicate