### PR TITLE
add 'circuit breaker open' to sentry exception

### DIFF
--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -23,7 +23,8 @@ if ($featureFlags.sentry) {
       'Software caused connection abort',
       'Refresh token invalid, clearing auth tokens & going to login',
       'cannot be equipped because the exotic',
-      'No auth token exists, redirect to login'
+      'No auth token exists, redirect to login',
+      'Circuit breaker open'
     ],
     ignoreUrls: [
       // Chrome extensions


### PR DESCRIPTION
do not send `circuit breaker open` errors to sentry

https://sentry.io/organizations/destiny-item-manager/issues/?project=279673&query=is%3Aunresolved+circuit