### PR TITLE
Add a "Mods" section to collections

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -602,6 +602,7 @@
   },
   "MovePopup": {
     "Acquired": "This item is unlocked in collections.",
+    "AcquiredMod": "This mod is currently applied to an item in your inventory.",
     "AddNote": "Add a note",
     "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "Consolidate": "Consolidate",
@@ -617,6 +618,7 @@
     "Notes": "Notes:",
     "OverviewTab": "Overview",
     "Owned": "This item is in your inventory.",
+    "OwnedMod": "This mod is in your modifications inventory.",
     "PullItem": "Pull from {{bucket}} to {{store}}",
     "ReadLore": "Read lore on Ishtar Collective",
     "ReviewsTab": "Reviews",

--- a/src/app/collections/Catalysts.tsx
+++ b/src/app/collections/Catalysts.tsx
@@ -31,21 +31,19 @@ export default function Catalysts({
     );
 
   return (
-    <>
-      <CollapsibleTitle title={t('Vendors.Catalysts')} sectionId={'catalysts'}>
-        <div className="records catalysts">
-          {catalystRecordHashes.map((catalystRecordHash) => (
-            <Record
-              key={catalystRecordHash}
-              recordHash={catalystRecordHash}
-              defs={defs}
-              profileResponse={profileResponse}
-              completedRecordsHidden={true}
-              redactedRecordsRevealed={true}
-            />
-          ))}
-        </div>
-      </CollapsibleTitle>
-    </>
+    <CollapsibleTitle title={t('Vendors.Catalysts')} sectionId={'catalysts'}>
+      <div className="records catalysts">
+        {catalystRecordHashes.map((catalystRecordHash) => (
+          <Record
+            key={catalystRecordHash}
+            recordHash={catalystRecordHash}
+            defs={defs}
+            profileResponse={profileResponse}
+            completedRecordsHidden={true}
+            redactedRecordsRevealed={true}
+          />
+        ))}
+      </div>
+    </CollapsibleTitle>
   );
 }

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -21,6 +21,7 @@ import { storesSelector } from '../inventory/reducer';
 import { Subscriptions } from '../utils/rx-utils';
 import { refresh$ } from '../shell/refresh';
 import PresentationNodeRoot from './PresentationNodeRoot';
+import Mods from './Mods';
 
 interface ProvidedProps extends UIViewInjectedProps {
   account: DestinyAccount;
@@ -139,6 +140,9 @@ class Collections extends React.Component<Props, State> {
       <div className="vendor d2-vendors dim-page">
         <ErrorBoundary name="Catalysts">
           <Catalysts defs={defs} profileResponse={profileResponse} />
+        </ErrorBoundary>
+        <ErrorBoundary name="Mods">
+          <Mods />
         </ErrorBoundary>
         <ErrorBoundary name="Collections">
           <PresentationNodeRoot

--- a/src/app/collections/Mod.tsx
+++ b/src/app/collections/Mod.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
+import { InventoryBuckets } from '../inventory/inventory-buckets';
+import { makeItem } from '../inventory/store/d2-item-factory';
+import {
+  ItemBindStatus,
+  ItemLocation,
+  TransferStatuses,
+  ItemState,
+  DestinyInventoryItemDefinition
+} from 'bungie-api-ts/destiny2';
+import './Collectible.scss';
+import { VendorItemDisplay } from 'app/vendors/VendorItemComponent';
+
+interface Props {
+  inventoryItem: DestinyInventoryItemDefinition;
+  defs: D2ManifestDefinitions;
+  buckets: InventoryBuckets;
+  ownedItemHashes?: Set<number>;
+  owned: boolean;
+  onAnItem: boolean;
+}
+
+export default function Collectible({ inventoryItem, defs, buckets, owned, onAnItem }: Props) {
+  if (!inventoryItem) {
+    return null;
+  }
+
+  const item = makeItem(
+    defs,
+    buckets,
+    new Set(),
+    new Set(),
+    undefined,
+    undefined,
+    {
+      itemHash: inventoryItem.hash,
+      itemInstanceId: inventoryItem.hash.toString(),
+      quantity: 1,
+      bindStatus: ItemBindStatus.NotBound,
+      location: ItemLocation.Vendor,
+      bucketHash: 0,
+      transferStatus: TransferStatuses.NotTransferrable,
+      lockable: false,
+      state: ItemState.None,
+      isWrapper: false
+    },
+    undefined,
+    undefined // reviewData
+  );
+
+  if (!item) {
+    return null;
+  }
+
+  item.missingSockets = false;
+
+  return (
+    <VendorItemDisplay
+      item={item}
+      acquired={onAnItem}
+      unavailable={!owned}
+      extraData={{ acquired: onAnItem, owned, mod: true }}
+    />
+  );
+}

--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -1,0 +1,134 @@
+import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import React from 'react';
+import _ from 'lodash';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
+import './collections.scss';
+import { RootState } from 'app/store/reducers';
+import { createSelector } from 'reselect';
+import { storesSelector } from 'app/inventory/reducer';
+import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
+import { connect } from 'react-redux';
+import { InventoryBuckets } from 'app/inventory/inventory-buckets';
+import Mod from './Mod';
+import { chainComparator, compareBy } from 'app/utils/comparators';
+
+const sortMods = chainComparator(
+  compareBy((i: DestinyInventoryItemDefinition) => i.itemTypeDisplayName),
+  compareBy((i: DestinyInventoryItemDefinition) => i.displayProperties.name)
+);
+
+interface StoreProps {
+  defs?: D2ManifestDefinitions;
+  buckets?: InventoryBuckets;
+  ownedMods: Set<number>;
+  allMods: DestinyInventoryItemDefinition[];
+  modsOnItems: Set<number>;
+}
+
+const ownedModsSelector = createSelector(
+  storesSelector,
+  (stores) => new Set(stores.flatMap((s) => s.buckets[3313201758].map((i) => i.hash)))
+);
+
+const modsOnitemsSelector = createSelector(
+  storesSelector,
+  (stores) => {
+    const modsOnItems = new Set<number>();
+    for (const store of stores) {
+      for (const item of store.items) {
+        if (item.isDestiny2() && item.sockets && item.sockets.categories.length > 1) {
+          for (const socket of item.sockets.categories[1].sockets) {
+            if (socket.plug) {
+              modsOnItems.add(socket.plug.plugItem.hash);
+            }
+          }
+        }
+      }
+    }
+    return modsOnItems;
+  }
+);
+
+const allModsSelector = createSelector(
+  (state: RootState) => state.manifest.d2Manifest,
+  (defs) => {
+    if (!defs) {
+      return [];
+    }
+    const deprecatedModDescription = defs.InventoryItem.get(2988871238).displayProperties
+      .description;
+
+    return Object.values(defs.InventoryItem.getAll()).filter(
+      (i) =>
+        i.itemCategoryHashes &&
+        i.plug &&
+        i.plug.insertionMaterialRequirementHash &&
+        i.displayProperties.description !== deprecatedModDescription &&
+        ![2600899007, 2323986101, 3851138800].includes(i.hash) &&
+        (i.itemCategoryHashes.includes(610365472) || i.itemCategoryHashes.includes(4104513227))
+    );
+  }
+);
+
+function mapStateToProps(state: RootState): StoreProps {
+  return {
+    defs: state.manifest.d2Manifest,
+    buckets: state.inventory.buckets,
+    ownedMods: ownedModsSelector(state),
+    modsOnItems: modsOnitemsSelector(state),
+    allMods: allModsSelector(state)
+  };
+}
+
+type Props = StoreProps;
+
+function Mods({ defs, buckets, allMods, ownedMods, modsOnItems }: Props) {
+  if (!defs || !buckets) {
+    return null;
+  }
+
+  const byGroup = _.groupBy(allMods, (i) =>
+    i.itemCategoryHashes.includes(610365472) ? 'weapons' : 'armor'
+  );
+
+  const modsTitle = defs.ItemCategory.get(56).displayProperties.name;
+  const weaponModsTitle = defs.ItemCategory.get(610365472).displayProperties.name;
+  const armorModsTitle = defs.ItemCategory.get(4104513227).displayProperties.name;
+
+  return (
+    <CollapsibleTitle title={modsTitle} sectionId="mods">
+      <div className="presentation-node always-expanded mods">
+        <div className="title">{weaponModsTitle}</div>
+        <div className="collectibles">
+          {byGroup.weapons.sort(sortMods).map((mod) => (
+            <Mod
+              key={mod.hash}
+              inventoryItem={mod}
+              defs={defs}
+              buckets={buckets}
+              owned={ownedMods.has(mod.hash)}
+              onAnItem={modsOnItems.has(mod.hash)}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="presentation-node always-expanded mods">
+        <div className="title">{armorModsTitle}</div>
+        <div className="collectibles">
+          {byGroup.armor.sort(sortMods).map((mod) => (
+            <Mod
+              key={mod.hash}
+              inventoryItem={mod}
+              defs={defs}
+              buckets={buckets}
+              owned={ownedMods.has(mod.hash)}
+              onAnItem={modsOnItems.has(mod.hash)}
+            />
+          ))}
+        </div>
+      </div>
+    </CollapsibleTitle>
+  );
+}
+
+export default connect<StoreProps>(mapStateToProps)(Mods);

--- a/src/app/collections/PresentationNode.scss
+++ b/src/app/collections/PresentationNode.scss
@@ -45,6 +45,7 @@
   &.always-expanded > .title {
     background-color: rgba(0, 0, 0, 0);
     cursor: default;
+    padding-left: 0;
   }
   /* always expanded, non-top-level nodes (weapon icons) */
   & .presentation-node.always-expanded {
@@ -122,7 +123,7 @@
   grid-gap: 8px;
   margin: 8px 0;
   @include phone-portrait {
-    margin: 8px 8px 8px 0;
+    margin: 8px;
     grid-template-columns: none;
   }
   .progress-for-character & {
@@ -140,4 +141,11 @@
   .always-expanded & {
     margin: 2px 0 8px;
   }
+  > div {
+    margin-right: 0;
+  }
+}
+
+.mods {
+  margin-left: 10px;
 }

--- a/src/app/destiny1/loadout-builder/utils.ts
+++ b/src/app/destiny1/loadout-builder/utils.ts
@@ -361,7 +361,7 @@ function normalizeStats(item: D1ItemWithNormalStats) {
       statHash: stat.statHash,
       base: stat.base,
       scaled: stat.scaled ? stat.scaled.min : 0,
-      bonus: stat.value - stat.base,
+      bonus: stat.bonus,
       split: stat.split || 0,
       qualityPercentage: stat.qualityPercentage ? stat.qualityPercentage.min : 0
     };

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -279,6 +279,7 @@ export interface DimStat {
 export interface D1Stat extends DimStat {
   /** Base stat without bonus perks applied. */
   base: number;
+  bonus: number;
   scaled?: {
     max: number;
     min: number;

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -864,6 +864,7 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
 
         const dimStat: D1Stat = {
           base,
+          bonus,
           investmentValue: base,
           statHash: stat.statHash,
           displayProperties: {

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -157,6 +157,21 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
         </div>
       )}
 
+      {extraInfo.mod && (
+        <div className="item-details">
+          {extraInfo.owned && (
+            <div>
+              <AppIcon className="owned-icon" icon={faCheck} /> {t('MovePopup.OwnedMod')}
+            </div>
+          )}
+          {extraInfo.acquired && (
+            <div>
+              <AppIcon className="acquired-icon" icon={faCheck} /> {t('MovePopup.AcquiredMod')}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* TODO: show source info via collections */}
     </div>
   );

--- a/src/app/item-popup/item-popup.ts
+++ b/src/app/item-popup/item-popup.ts
@@ -14,6 +14,7 @@ export interface ItemPopupExtraInfo {
   failureStrings?: string[];
   owned?: boolean;
   acquired?: boolean;
+  mod?: boolean;
 }
 
 export function showItemPopup(item: DimItem, element: Element, extraInfo?: ItemPopupExtraInfo) {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -602,6 +602,7 @@
   },
   "MovePopup": {
     "Acquired": "This item is unlocked in collections.",
+    "AcquiredMod": "This mod is currently applied to an item in your inventory.",
     "AddNote": "Add a note",
     "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "Consolidate": "Consolidate",
@@ -617,6 +618,7 @@
     "Notes": "Notes:",
     "OverviewTab": "Overview",
     "Owned": "This item is in your inventory.",
+    "OwnedMod": "This mod is in your modifications inventory.",
     "PullItem": "Pull from {{bucket}} to {{store}}",
     "ReadLore": "Read lore on Ishtar Collective",
     "ReviewsTab": "Reviews",


### PR DESCRIPTION
This adds a "Mods" section to collections, which shows which mods you have as loose mods in inventory, and which ones (with a blue check) are on items. Not sure if this is really a thing, but some people believe that you should be trying to unlock mods (by dismantling items) so they start out unlocked as infinite-use in Shadowkeep.

<img width="911" alt="Screen Shot 2019-09-22 at 9 36 30 PM" src="https://user-images.githubusercontent.com/313208/65402083-17b88880-dd81-11e9-8047-07d9a3e4d6b3.png">
<img width="551" alt="Screen Shot 2019-09-22 at 9 36 34 PM" src="https://user-images.githubusercontent.com/313208/65402084-17b88880-dd81-11e9-9b27-a60b8ba7ef44.png">
