### PR TITLE
Add subclass icons

### DIFF
--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -125,3 +125,11 @@
     filter: none !important;
   }
 }
+
+.subclass {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  height: 13px;
+  margin-right: -1px;
+}

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -130,6 +130,7 @@
   position: absolute;
   bottom: 0;
   right: 0;
-  height: 13px;
   margin-right: -1px;
+  width: 23px;
+  height: 18px;
 }

--- a/src/app/inventory/InventoryItem.m.scss.d.ts
+++ b/src/app/inventory/InventoryItem.m.scss.d.ts
@@ -9,6 +9,7 @@ interface CssExports {
   'masterwork': string;
   'masterworkOverlay': string;
   'searchHidden': string;
+  'subclass': string;
   'xpBar': string;
   'xpBarAmount': string;
 }

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { DimItem } from './item-types';
+import { DimItem, DimTalentGrid } from './item-types';
 import { TagValue, itemTags } from './dim-item-info';
 import BadgeInfo from './BadgeInfo';
 import BungieImage from '../dim-ui/BungieImage';
@@ -72,6 +72,8 @@ export default function InventoryItem({
     };
   }
 
+  const subclassIconImage = item.isDestiny2() && item.talentGrid && subclassIcon(item.talentGrid);
+
   return (
     <div
       id={item.index}
@@ -107,6 +109,7 @@ export default function InventoryItem({
         </div>
       )}
       {isNew && <NewItemIndicator />}
+      {subclassIconImage && <BungieImage className={styles.subclass} src={subclassIconImage} />}
     </div>
   );
 }
@@ -119,4 +122,60 @@ export function borderless(item: DimItem) {
         (item.itemCategoryHashes && item.itemCategoryHashes.includes(268598612)))) ||
     item.isEngram
   );
+}
+
+const hunterTop = '/common/destiny2_content/icons/7df81508fc637789baf1ef30f20e99e9.png';
+const hunterBottom = '/common/destiny2_content/icons/473693b8031f6fcc467d26e75dc9a2f4.png';
+const hunterMid = '/common/destiny2_content/icons/d290f8ed26ef2d7c0f7c25379900fb0c.png';
+const warlockTop = '/common/destiny2_content/icons/fc7b144288afef1e121f41c7b7f01761.png';
+const warlockMid = '/common/destiny2_content/icons/aae8f402db148a92d1404e29610e038b.png';
+const warlockBottom = '/common/destiny2_content/icons/ef55b744a0fcc02dee7a7b97edab24f3.png';
+const titanTop = '/common/destiny2_content/icons/53b46914177002c901af24230fb23ab2.png';
+const titanMid = '/common/destiny2_content/icons/1c168489dacb81871a93b784c7ebec2f.png';
+const titanBottom = '/common/destiny2_content/icons/2d4c50d2485012564e8e271a2aece1fb.png';
+
+const nodeHashToImage = {
+  // Arcstrider
+  1690891826: hunterTop,
+  3006627468: hunterMid,
+  313617030: hunterBottom,
+  // Gunslinger
+  637433069: hunterTop,
+  1590824323: hunterMid,
+  2382523579: hunterBottom,
+  // Nightstalker
+  277476372: hunterTop,
+  499823166: hunterMid,
+  4025960910: hunterBottom,
+  // Dawnblade
+  3352782816: warlockTop,
+  966868917: warlockBottom,
+  // Stormcaller
+  487158888: warlockTop,
+  3297679786: warlockBottom,
+  // Voidwalker
+  2718724912: warlockTop,
+  1389184794: warlockBottom,
+  // Striker
+  4099943028: titanTop,
+  2795355746: titanMid,
+  4293830764: titanBottom,
+  // Sentinel
+  3806272138: titanTop,
+  3504292102: titanMid,
+  1347995538: titanBottom,
+  // Sunbreaker
+  3928207649: titanTop,
+  1323416107: titanMid,
+  1236431642: titanBottom
+};
+
+function subclassIcon(talentGrid: DimTalentGrid) {
+  for (const node of talentGrid.nodes) {
+    if (node.activated && nodeHashToImage[node.hash]) {
+      return nodeHashToImage[node.hash];
+    }
+  }
+
+  return null;
 }

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -149,12 +149,15 @@ const nodeHashToImage = {
   4025960910: hunterBottom,
   // Dawnblade
   3352782816: warlockTop,
+  935376049: warlockMid,
   966868917: warlockBottom,
   // Stormcaller
   487158888: warlockTop,
+  3882393894: warlockMid,
   3297679786: warlockBottom,
   // Voidwalker
   2718724912: warlockTop,
+  194702279: warlockMid,
   1389184794: warlockBottom,
   // Striker
   4099943028: titanTop,
@@ -171,6 +174,7 @@ const nodeHashToImage = {
 };
 
 function subclassIcon(talentGrid: DimTalentGrid) {
+  console.log(talentGrid);
   for (const node of talentGrid.nodes) {
     if (node.activated && nodeHashToImage[node.hash]) {
       return nodeHashToImage[node.hash];

--- a/src/app/item-popup/ItemTalentGrid.tsx
+++ b/src/app/item-popup/ItemTalentGrid.tsx
@@ -106,6 +106,7 @@ function ItemTalentGrid({ item, perksOnly, bestPerks }: Props) {
                 r="16"
                 cx="-17"
                 cy="17"
+                id={node.hash.toString()}
                 transform="rotate(-90)"
                 className="talent-node-xp"
                 strokeWidth={isD1GridNode(node) && node.xp ? 2 : 0}


### PR DESCRIPTION
This adds icons for the currently selected subclass to subclasses.

Still to do:

1. [ ] Identify the node hashes of the middle path Warlock subtrees. My warlock hasn't unlocked them. This PR includes code to add the node ID to the SVG, so you can just load it up and inspect to find them.
2. [ ] Draw the 9 subclass icons as SVGs and add them to destiny-icons. I don't want to have to load the entire Lore table just for these image references.

<img width="712" alt="Screen Shot 2019-09-22 at 10 16 05 PM" src="https://user-images.githubusercontent.com/313208/65403024-e6db5200-dd86-11e9-97c6-20114c37dde8.png">
