### PR TITLE
Fix size of subclass hover border in Firefox

### DIFF
--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -114,8 +114,8 @@
         @include draggable-hover-border;
         content: '';
         position: absolute;
-        width: 100%;
-        height: 100%;
+        width: var(--item-size);
+        height: var(--item-size);
         transform: rotate(45deg) scale(0.75);
         box-sizing: border-box;
       }


### PR DESCRIPTION
This PR fixes the size of the diamond-shaped subclass hover border (added by #4258 ) in Firefox. Tested in Chrome, Firefox and Edge (EdgeHTML).