### PR TITLE
New D2 reviews endpoint

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -42,7 +42,7 @@ module.exports = function csp(env) {
       'https://www.bungie.net',
       // DTR Reviews API
       'https://reviews-api.destinytracker.net',
-      'https://db-api.destinytracker.com'
+      'https://api.tracker.gg'
     ],
     imgSrc: [
       SELF,

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -6,7 +6,7 @@ import {
 import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Store } from '../inventory/store-types';
-import { dtrFetch, dtrTextReviewMultiplier } from './dtr-service-helper';
+import { dtrFetch, dtrTextReviewMultiplier, dtrD2Endpoint } from './dtr-service-helper';
 import {
   D2ItemFetchResponse,
   D2ItemFetchRequest,
@@ -71,7 +71,7 @@ export async function getBulkItems(
 
   for (const arraySlice of arrayOfArrays) {
     const promiseSlice = dtrFetch(
-      `https://db-api.destinytracker.com/api/external/reviews/fetch?platform=${platformSelection}&mode=${mode}`,
+      `${dtrD2Endpoint}/fetch?platform=${platformSelection}&mode=${mode}`,
       arraySlice
     ).then(handleD2Errors, handleD2Errors);
 

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -6,7 +6,7 @@ import {
 import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Store } from '../inventory/store-types';
-import { dtrFetch, dtrTextReviewMultiplier, dtrD2Endpoint } from './dtr-service-helper';
+import { dtrFetch, dtrTextReviewMultiplier, dtrD2ReviewsEndpoint } from './dtr-service-helper';
 import {
   D2ItemFetchResponse,
   D2ItemFetchRequest,
@@ -71,7 +71,7 @@ export async function getBulkItems(
 
   for (const arraySlice of arrayOfArrays) {
     const promiseSlice = dtrFetch(
-      `${dtrD2Endpoint}/fetch?platform=${platformSelection}&mode=${mode}`,
+      `${dtrD2ReviewsEndpoint}/fetch?platform=${platformSelection}&mode=${mode}`,
       arraySlice
     ).then(handleD2Errors, handleD2Errors);
 

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -3,7 +3,7 @@ import { getActivePlatform } from '../accounts/platforms';
 import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
-import { dtrFetch, dtrD2Endpoint } from './dtr-service-helper';
+import { dtrFetch, dtrD2ReviewsEndpoint } from './dtr-service-helper';
 import {
   D2ItemReviewResponse,
   D2ItemUserReview,
@@ -62,7 +62,7 @@ function getItemReviewsPromise(
 
   const queryString = `page=1&platform=${platformSelection}&mode=${mode}`;
   const promise = dtrFetch(
-    `${dtrD2Endpoint}?${queryString}`, // TODO: pagination
+    `${dtrD2ReviewsEndpoint}?${queryString}`, // TODO: pagination
     dtrItem
   ).then(handleD2Errors, handleD2Errors);
 

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -3,7 +3,7 @@ import { getActivePlatform } from '../accounts/platforms';
 import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
-import { dtrFetch } from './dtr-service-helper';
+import { dtrFetch, dtrD2Endpoint } from './dtr-service-helper';
 import {
   D2ItemReviewResponse,
   D2ItemUserReview,
@@ -62,7 +62,7 @@ function getItemReviewsPromise(
 
   const queryString = `page=1&platform=${platformSelection}&mode=${mode}`;
   const promise = dtrFetch(
-    `https://db-api.destinytracker.com/api/external/reviews?${queryString}`, // TODO: pagination
+    `${dtrD2Endpoint}?${queryString}`, // TODO: pagination
     dtrItem
   ).then(handleD2Errors, handleD2Errors);
 

--- a/src/app/destinyTrackerApi/dtr-service-helper.ts
+++ b/src/app/destinyTrackerApi/dtr-service-helper.ts
@@ -3,6 +3,8 @@ import CircuitBreaker from 'circuit-breaker-js';
 /** We give more weight to ratings with reviews than those without. */
 export const dtrTextReviewMultiplier = 10;
 
+export const dtrD2Endpoint = 'https://api.tracker.gg/api/v1/destiny-2/db/reviews';
+
 const TIMEOUT = 3000;
 
 const circuitBreaker = new CircuitBreaker({

--- a/src/app/destinyTrackerApi/dtr-service-helper.ts
+++ b/src/app/destinyTrackerApi/dtr-service-helper.ts
@@ -3,7 +3,7 @@ import CircuitBreaker from 'circuit-breaker-js';
 /** We give more weight to ratings with reviews than those without. */
 export const dtrTextReviewMultiplier = 10;
 
-export const dtrD2Endpoint = 'https://api.tracker.gg/api/v1/destiny-2/db/reviews';
+export const dtrD2ReviewsEndpoint = 'https://api.tracker.gg/api/v1/destiny-2/db/reviews';
 
 const TIMEOUT = 3000;
 

--- a/src/app/destinyTrackerApi/reviewReporter.ts
+++ b/src/app/destinyTrackerApi/reviewReporter.ts
@@ -1,7 +1,7 @@
 import { DestinyAccount } from '../accounts/destiny-account';
 import { handleSubmitErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../shell/loading-tracker';
-import { dtrFetch } from './dtr-service-helper';
+import { dtrFetch, dtrD2Endpoint } from './dtr-service-helper';
 import { DtrReviewer, DimUserReview } from '../item-review/dtr-api-types';
 import { ignoreUser } from './userFilter';
 import { handleD2SubmitErrors } from './d2-trackerErrorHandler';
@@ -46,7 +46,7 @@ function submitReportReviewPromise(reviewId: string, membershipInfo: DestinyAcco
   const promise = dtrFetch(
     membershipInfo.destinyVersion === 1
       ? 'https://reviews-api.destinytracker.net/api/weaponChecker/reviews/report'
-      : 'https://db-api.destinytracker.com/api/external/reviews/report',
+      : `${dtrD2Endpoint}/report`,
     reviewReport
   ).then(errorHandler, errorHandler);
 

--- a/src/app/destinyTrackerApi/reviewReporter.ts
+++ b/src/app/destinyTrackerApi/reviewReporter.ts
@@ -1,7 +1,7 @@
 import { DestinyAccount } from '../accounts/destiny-account';
 import { handleSubmitErrors } from './trackerErrorHandler';
 import { loadingTracker } from '../shell/loading-tracker';
-import { dtrFetch, dtrD2Endpoint } from './dtr-service-helper';
+import { dtrFetch, dtrD2ReviewsEndpoint } from './dtr-service-helper';
 import { DtrReviewer, DimUserReview } from '../item-review/dtr-api-types';
 import { ignoreUser } from './userFilter';
 import { handleD2SubmitErrors } from './d2-trackerErrorHandler';
@@ -46,7 +46,7 @@ function submitReportReviewPromise(reviewId: string, membershipInfo: DestinyAcco
   const promise = dtrFetch(
     membershipInfo.destinyVersion === 1
       ? 'https://reviews-api.destinytracker.net/api/weaponChecker/reviews/report'
-      : `${dtrD2Endpoint}/report`,
+      : `${dtrD2ReviewsEndpoint}/report`,
     reviewReport
   ).then(errorHandler, errorHandler);
 

--- a/src/app/destinyTrackerApi/reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/reviewSubmitter.ts
@@ -2,7 +2,7 @@ import { DestinyAccount } from '../accounts/destiny-account';
 import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2SubmitErrors } from './d2-trackerErrorHandler';
 import { DimItem } from '../inventory/item-types';
-import { dtrFetch, dtrD2Endpoint } from './dtr-service-helper';
+import { dtrFetch, dtrD2ReviewsEndpoint } from './dtr-service-helper';
 import { WorkingD2Rating } from '../item-review/d2-dtr-api-types';
 import { getRollAndPerks as getRollAndPerksD2 } from './d2-itemTransformer';
 import { getItemReviewsKey } from '../item-review/reducer';
@@ -75,7 +75,10 @@ function submitReviewPromise(
   const rating = { ...rollAndPerks, ...review, reviewer };
 
   const promise = item.isDestiny2()
-    ? dtrFetch(`${dtrD2Endpoint}/submit`, rating).then(handleD2SubmitErrors, handleD2SubmitErrors)
+    ? dtrFetch(`${dtrD2ReviewsEndpoint}/submit`, rating).then(
+        handleD2SubmitErrors,
+        handleD2SubmitErrors
+      )
     : dtrFetch(
         'https://reviews-api.destinytracker.net/api/weaponChecker/reviews/submit',
         rating

--- a/src/app/destinyTrackerApi/reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/reviewSubmitter.ts
@@ -2,7 +2,7 @@ import { DestinyAccount } from '../accounts/destiny-account';
 import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2SubmitErrors } from './d2-trackerErrorHandler';
 import { DimItem } from '../inventory/item-types';
-import { dtrFetch } from './dtr-service-helper';
+import { dtrFetch, dtrD2Endpoint } from './dtr-service-helper';
 import { WorkingD2Rating } from '../item-review/d2-dtr-api-types';
 import { getRollAndPerks as getRollAndPerksD2 } from './d2-itemTransformer';
 import { getItemReviewsKey } from '../item-review/reducer';
@@ -75,10 +75,7 @@ function submitReviewPromise(
   const rating = { ...rollAndPerks, ...review, reviewer };
 
   const promise = item.isDestiny2()
-    ? dtrFetch(`https://db-api.destinytracker.com/api/external/reviews/submit`, rating).then(
-        handleD2SubmitErrors,
-        handleD2SubmitErrors
-      )
+    ? dtrFetch(`${dtrD2Endpoint}/submit`, rating).then(handleD2SubmitErrors, handleD2SubmitErrors)
     : dtrFetch(
         'https://reviews-api.destinytracker.net/api/weaponChecker/reviews/submit',
         rating


### PR DESCRIPTION
DTR will be cutting over its reviews API to a new implementation/endpoint to go along with the Shadowkeep launch.

I wanted to get this patch ready for when they're ready to cut over, but it shouldn't be merged until then.