### PR TITLE
Clarifying behind-the scenes review behavior.

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -103,7 +103,7 @@
     "DaysAgo": "{{count}} day ago on {{platform}}",
     "DaysAgo_plural": "{{count}} days ago on {{platform}}",
     "ForGameMode": "For game mode {{mode}}",
-    "Help": "Write a review for this specific roll (optional)",
+    "Help": "Write a review for this specific roll (optional). Note: available and selected perks are automatically sent.",
     "ModeNotSpecified": "Not Specified",
     "NoReviews": "There are no reviews for this item, be the first!",
     "Platforms": {

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -104,7 +104,6 @@
     "DaysAgo_plural": "{{count}} days ago on {{platform}}",
     "ForGameMode": "For game mode {{mode}}",
     "ForGameModeLabel": "For game mode",
-    "Help": "Write a review for this specific roll (optional)",
     "Help": "Write a review for this specific roll (optional). Note: available and selected perks are automatically sent.",
     "ModeNotSpecified": "Not Specified",
     "NoReviews": "There are no reviews for this item, be the first!",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -103,7 +103,7 @@
     "DaysAgo": "{{count}} day ago on {{platform}}",
     "DaysAgo_plural": "{{count}} days ago on {{platform}}",
     "ForGameMode": "For game mode {{mode}}",
-    "Help": "Write a review for this specific roll (optional)",
+    "Help": "Write a review for this specific roll (optional). Note: available and selected perks are automatically sent.",
     "ModeNotSpecified": "Not Specified",
     "NoReviews": "There are no reviews for this item, be the first!",
     "Platforms": {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -104,7 +104,6 @@
     "DaysAgo_plural": "{{count}} days ago on {{platform}}",
     "ForGameMode": "For game mode {{mode}}",
     "ForGameModeLabel": "For game mode",
-    "Help": "Write a review for this specific roll (optional)",
     "Help": "Write a review for this specific roll (optional). Note: available and selected perks are automatically sent.",
     "ModeNotSpecified": "Not Specified",
     "NoReviews": "There are no reviews for this item, be the first!",


### PR DESCRIPTION
Added `Note: available and selected perks are automatically sent.` to the review placeholder. I have no doubt people will crow about their rolls anyway.

![Screenshot_2019-09-29 DIM](https://user-images.githubusercontent.com/606888/65840434-20601000-e2e7-11e9-93b9-945702da61b4.png)