### PR TITLE
Handle system maintenance better in auth

### DIFF
--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -9,6 +9,7 @@ import {
 } from './oauth-tokens';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { router } from '../router';
+import { t } from 'app/i18next-t';
 
 let cache: Promise<Tokens> | null = null;
 
@@ -138,6 +139,18 @@ async function handleRefreshTokenError(response: Error | Response): Promise<Toke
     case 400:
     case 401:
     case 403: {
+      try {
+        const data = await response.json();
+        if (data && data.error === 'server_error') {
+          if (data.error_description === 'SystemDisabled') {
+            throw new Error(t('BungieService.Maintenance'));
+          } else {
+            throw new Error(
+              `Unknown error getting response token: ${data.error}, ${data.error_description}`
+            );
+          }
+        }
+      } catch (e) {}
       throw new FatalTokenError('Refresh token expired or not valid, status ' + response.status);
     }
     default: {

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -139,18 +139,19 @@ async function handleRefreshTokenError(response: Error | Response): Promise<Toke
     case 400:
     case 401:
     case 403: {
+      let data;
       try {
-        const data = await response.json();
-        if (data && data.error === 'server_error') {
-          if (data.error_description === 'SystemDisabled') {
-            throw new Error(t('BungieService.Maintenance'));
-          } else {
-            throw new Error(
-              `Unknown error getting response token: ${data.error}, ${data.error_description}`
-            );
-          }
-        }
+        data = await response.json();
       } catch (e) {}
+      if (data && data.error === 'server_error') {
+        if (data.error_description === 'SystemDisabled') {
+          throw new Error(t('BungieService.Maintenance'));
+        } else {
+          throw new Error(
+            `Unknown error getting response token: ${data.error}, ${data.error_description}`
+          );
+        }
+      }
       throw new FatalTokenError('Refresh token expired or not valid, status ' + response.status);
     }
     default: {

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -67,6 +67,15 @@ export async function handleErrors<T>(response: Response): Promise<ServerRespons
     data = await response.json();
   } catch {}
 
+  // There's an alternate error response that can be returned during maintenance
+  if (data && (data as any).error && (data as any).error_description) {
+    const e = error(
+      t('BungieService.UnknownError', { message: (data as any).error_description }),
+      PlatformErrorCodes.DestinyUnexpectedError
+    );
+    throw e;
+  }
+
   const errorCode = data ? data.ErrorCode : -1;
 
   // See https://github.com/DestinyDevs/BungieNetPlatform/wiki/Enums#platformerrorcodes


### PR DESCRIPTION
https://github.com/Bungie-net/api/issues/1048

During today's maintenance, we logged everyone out because Bungie returned a 400 for "server_error". This adds code that will handle that without logging people out.