### PR TITLE
Fix up old PC loadouts to report as being from Steam

### DIFF
--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -558,6 +558,11 @@ function LoadoutService(): LoadoutServiceType {
       clearSpace: loadoutPrimitive.clearSpace
     };
 
+    // Blizzard.net is no more, they're all Steam now
+    if (result.platform && result.platform === 'Blizzard') {
+      result.platform = 'Steam';
+    }
+
     for (const itemPrimitive of loadoutPrimitive.items) {
       const item = copy(
         getStoresService(result.destinyVersion).getItemAcrossStores({


### PR DESCRIPTION
Blizzard got hard-reset to Steam, which means our platform-matching logic for really old loadouts won't work.

Fixes #4337.