### PR TITLE
Remove forsaken masterwork override hack

### DIFF
--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -114,12 +114,6 @@ function buildForsakenMasterworkStats(
       ] as typeof createdItem.dmg;
     }
 
-    if (
-      (createdItem.bucket.sort === 'Armor' && masterwork.value === 5) ||
-      (createdItem.bucket.sort === 'Weapon' && masterwork.value === 10)
-    ) {
-      createdItem.masterwork = true;
-    }
     const statDef = defs.Stat.get(masterwork.statTypeHash);
 
     return {


### PR DESCRIPTION
I'm not sure exactly why this was added, but it causes Armor 2.0 to show up as masterworked. I'd rather trust the masterwork bit from the API.

Fixes https://github.com/DestinyItemManager/DIM/issues/4333