### PR TITLE
Make stats work for Armor 2.0

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -401,7 +401,8 @@ export function makeItem(
   }
 
   try {
-    createdItem.stats = buildStats(createdItem, itemDef, defs);
+    const stats = idx(itemComponents, (i) => i.stats.data);
+    createdItem.stats = buildStats(createdItem, stats || null, itemDef, defs);
   } catch (e) {
     console.error(`Error building stats for ${createdItem.name}`, item, itemDef, e);
     reportException('Stats', e, { itemHash: item.itemHash });

--- a/src/app/item-popup/ItemPopupContainer.scss
+++ b/src/app/item-popup/ItemPopupContainer.scss
@@ -31,6 +31,7 @@
   > div:first-child {
     height: 100%;
     background-color: #{'hsl(var(--backgroundColor))'};
+    overflow: auto;
     @supports (backdrop-filter: blur(30px)) {
       background-color: #{'hsla(var(--backgroundColor), 0.75)'};
       backdrop-filter: brightness(1.2) blur(30px);

--- a/src/app/item-popup/ItemStats.scss
+++ b/src/app/item-popup/ItemStats.scss
@@ -38,7 +38,7 @@
     text-align: right;
   }
   .stat-box-val {
-    text-align: left;
+    text-align: right;
     padding-right: 10px;
     padding-left: 5px;
   }


### PR DESCRIPTION
Unfortunately, all the work I did to move over to investment stats is useless in the face of Armor 2.0, where there are no more investment stats because the same armor can roll with different stats.

So, I brought back "live stats" just for them. I'll probably have to do more to show the effects of stat-modifying mods.