### PR TITLE
Implement well-rested for seasonal rank

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -88,6 +88,7 @@ export function getStores(platform: DestinyAccount): Promise<DestinyProfileRespo
 export function getProgression(platform: DestinyAccount): Promise<DestinyProfileResponse> {
   return getProfile(
     platform,
+    DestinyComponentType.Profiles,
     DestinyComponentType.Characters,
     DestinyComponentType.CharacterProgressions,
     DestinyComponentType.ProfileInventories,

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -27,7 +27,8 @@ import {
   DestinyCollectibleDefinition,
   DestinyPresentationNodeDefinition,
   DestinyRecordDefinition,
-  DestinyStatGroupDefinition
+  DestinyStatGroupDefinition,
+  DestinySeasonDefinition
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { D2ManifestService } from '../manifest/manifest-service-json';
@@ -49,6 +50,7 @@ const lazyTables = [
   'Vendor',
   'SocketCategory',
   'SocketType',
+  'Season',
   'Milestone',
   'Destination',
   'Place',
@@ -89,6 +91,7 @@ export interface D2ManifestDefinitions {
   Vendor: LazyDefinition<DestinyVendorDefinition>;
   SocketCategory: LazyDefinition<DestinySocketCategoryDefinition>;
   SocketType: LazyDefinition<DestinySocketTypeDefinition>;
+  Season: LazyDefinition<DestinySeasonDefinition>;
   Milestone: LazyDefinition<DestinyMilestoneDefinition>;
   Destination: LazyDefinition<DestinyDestinationDefinition>;
   Place: LazyDefinition<DestinyPlaceDefinition>;

--- a/src/app/progress/D2SupplementalManifestDefinitions.ts
+++ b/src/app/progress/D2SupplementalManifestDefinitions.ts
@@ -51,6 +51,7 @@ export const D2SupplementalManifestDefinitions = {
   Vendor: { get, getAll },
   SocketCategory: { get, getAll },
   SocketType: { get, getAll },
+  Season: { get, getAll },
   Milestone: { get, getAll },
   Destination: { get, getAll },
   Place: { get, getAll },

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { DimStore } from 'app/inventory/store-types';
-import { DestinyProfileResponse, DestinyMilestone } from 'bungie-api-ts/destiny2';
+import {
+  DestinyProfileResponse,
+  DestinyMilestone,
+  DestinySeasonDefinition
+} from 'bungie-api-ts/destiny2';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import WellRestedPerkIcon from './WellRestedPerkIcon';
 import _ from 'lodash';
@@ -27,6 +31,7 @@ export default function Milestones({
 }) {
   const profileMilestones = milestonesForProfile(defs, profileInfo, store.id);
   const characterProgressions = idx(profileInfo, (p) => p.characterProgressions.data[store.id]);
+  const season = currentSeason(defs);
 
   const milestoneItems = [
     ...milestonesForCharacter(defs, profileInfo, store),
@@ -36,7 +41,7 @@ export default function Milestones({
   return (
     <div className="progress-for-character">
       {characterProgressions && (
-        <WellRestedPerkIcon defs={defs} progressions={characterProgressions} />
+        <WellRestedPerkIcon defs={defs} progressions={characterProgressions} season={season} />
       )}
       {milestoneItems.sort(sortPursuits).map((item) => (
         <Pursuit key={item.hash} item={item} />
@@ -107,4 +112,17 @@ function milestonesForCharacter(
   });
 
   return _.sortBy(filteredMilestones, (milestone) => milestone.order);
+}
+
+/**
+ * Find the currently active Season.
+ */
+function currentSeason(defs: D2ManifestDefinitions): DestinySeasonDefinition | undefined {
+  return Object.values(defs.Season.getAll()).find(
+    (season) =>
+      season.startDate &&
+      season.endDate &&
+      new Date(season.startDate).getTime() < Date.now() &&
+      new Date(season.endDate).getTime() > Date.now()
+  );
 }

--- a/src/app/progress/WellRestedPerkIcon.tsx
+++ b/src/app/progress/WellRestedPerkIcon.tsx
@@ -2,16 +2,21 @@ import React from 'react';
 import { isWellRested } from '../inventory/store/well-rested';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import BungieImage from '../dim-ui/BungieImage';
-import { DestinyCharacterProgressionComponent } from 'bungie-api-ts/destiny2';
+import {
+  DestinyCharacterProgressionComponent,
+  DestinySeasonDefinition
+} from 'bungie-api-ts/destiny2';
 
 export default function WellRestedPerkIcon({
   defs,
-  progressions
+  progressions,
+  season
 }: {
   defs: D2ManifestDefinitions;
   progressions: DestinyCharacterProgressionComponent;
+  season: DestinySeasonDefinition | undefined;
 }) {
-  const wellRestedInfo = isWellRested(defs, progressions);
+  const wellRestedInfo = isWellRested(defs, season, progressions);
 
   if (!wellRestedInfo.wellRested) {
     return null;

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -145,3 +145,7 @@
     margin-top: 2px;
   }
 }
+
+.well-rested {
+  cursor: none;
+}


### PR DESCRIPTION
This uses the current season's rank to calculate well-rested.

@melanieseltzer I think the `currentSeason` helper I added here will help you with your task. From there you can get the season's progression and figure out what the rewards are (see https://github.com/Bungie-net/api/wiki/2.4.0-(Shadowkeep)-API-Changes#seasons-and-season-passes)

![image](https://user-images.githubusercontent.com/313208/66186524-4fec8080-e637-11e9-90b2-a0ce4b8a185e.png)
