### PR TITLE
Remove XP bar from store tiles

### DIFF
--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -141,6 +141,8 @@ $xp-bar-height: 2px;
   }
 
   &.destiny2 {
+    border-bottom: none;
+
     .emblem {
       visibility: hidden;
     }

--- a/src/app/inventory/StoreHeading.tsx
+++ b/src/app/inventory/StoreHeading.tsx
@@ -149,16 +149,18 @@ export default class StoreHeading extends React.Component<Props, State> {
             </div>
             {loadoutButton}
           </div>
-          <PressTip tooltip={xpTillMote}>
-            <div className="level-bar">
-              <div
-                className={classNames('level-bar-progress', {
-                  'mote-progress': !store.percentToNextLevel
-                })}
-                style={{ width: percent(levelBar) }}
-              />
-            </div>
-          </PressTip>
+          {store.isDestiny1() && (
+            <PressTip tooltip={xpTillMote}>
+              <div className="level-bar">
+                <div
+                  className={classNames('level-bar-progress', {
+                    'mote-progress': !store.percentToNextLevel
+                  })}
+                  style={{ width: percent(levelBar) }}
+                />
+              </div>
+            </PressTip>
+          )}
         </div>
         {loadoutMenu}
         <CharacterStats destinyVersion={store.destinyVersion} stats={store.stats} />
@@ -195,6 +197,12 @@ function VaultToolTip({ counts }: { counts: { bucket: InventoryBucket; count: nu
 }
 
 function getLevelBar(store: DimStore) {
+  if (store.isDestiny2()) {
+    return {
+      levelBar: 0,
+      xpTillMote: undefined
+    };
+  }
   if (store.percentToNextLevel) {
     return {
       levelBar: store.percentToNextLevel,
@@ -209,8 +217,7 @@ function getLevelBar(store: DimStore) {
         exp: prestige.nextLevelAt - prestige.progressToNextLevel
       };
       return {
-        xpTillMote:
-          store.destinyVersion === 1 ? t('Stats.Prestige', data) : t('Stats.PrestigeD2', data),
+        xpTillMote: t('Stats.Prestige', data),
         levelBar: prestige.progressToNextLevel / prestige.nextLevelAt
       };
     }


### PR DESCRIPTION
<img width="1008" alt="Screen Shot 2019-10-04 at 12 25 02 AM" src="https://user-images.githubusercontent.com/313208/66188985-8deca300-e63d-11e9-94d8-6f1f6c71490a.png">

This simply removes the XP bar from store tiles (for D2 only) since it doesn't provide any useful info. I suppose I could put season level progress here, but IMO it belongs in Progress, which is what #4296 is about.