### PR TITLE
Remove "smoked glass" effect

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -47,8 +47,7 @@ class App extends React.Component<Props> {
             itemQuality: this.props.itemQuality,
             'show-new-items': this.props.showNewItems,
             'ms-edge': /Edge/.test(navigator.userAgent),
-            ios: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream,
-            windows: /Windows/.test(navigator.userAgent)
+            ios: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
           }
         )}
       >

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -70,20 +70,6 @@ $header-height: 44px;
   font-family: 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
 }
 
-// A dark, translucent "glass" effect
-@mixin smoked-glass {
-  background-color: rgba(0, 0, 0, 0.9);
-  @supports (backdrop-filter: blur(30px)) {
-    background-color: rgba(0, 0, 0, 0.75);
-    backdrop-filter: blur(30px);
-  }
-  // Chrome on Windows does not render the blur effect well
-  .windows & {
-    background-color: rgba(0, 0, 0, 0.9);
-    backdrop-filter: none;
-  }
-}
-
 @mixin draggable-hover-border {
   outline: 1px solid #ddd;
 

--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -13,7 +13,7 @@ $control-color: rgba(255, 255, 255, 0.5);
   backface-visibility: hidden;
   z-index: 12;
   bottom: 0;
-  @include smoked-glass;
+  background-color: black;
   color: #e0e0e0;
   box-shadow: 0 -1px 24px 0px #222;
   // 10px below the character header

--- a/src/app/farming/farming.scss
+++ b/src/app/farming/farming.scss
@@ -5,7 +5,7 @@
   position: fixed;
   backface-visibility: hidden;
   bottom: 0;
-  @include smoked-glass;
+  background-color: black;
   width: 43rem;
   padding: 0.5rem 1rem;
   color: #e0e0e0;

--- a/src/app/item-popup/ItemPopupContainer.scss
+++ b/src/app/item-popup/ItemPopupContainer.scss
@@ -32,14 +32,6 @@
     height: 100%;
     background-color: #{'hsl(var(--backgroundColor))'};
     overflow: auto;
-    @supports (backdrop-filter: blur(30px)) {
-      background-color: #{'hsla(var(--backgroundColor), 0.75)'};
-      backdrop-filter: brightness(1.2) blur(30px);
-    }
-    .windows & {
-      background-color: #{'hsl(var(--backgroundColor))'};
-      backdrop-filter: none;
-    }
   }
   box-shadow: 0 -1px 24px 4px #222;
 

--- a/src/app/notifications/Notification.scss
+++ b/src/app/notifications/Notification.scss
@@ -9,7 +9,6 @@
   box-shadow: 0 -1px 24px 4px #222;
 
   .notification-inner {
-    @include smoked-glass;
     color: white;
     box-sizing: border-box;
     border-top: 4px solid black;
@@ -70,17 +69,21 @@
   .notification-info,
   .notification-progress {
     border-top-color: #2f96b4;
+    background-color: scale-color(#2f96b4, $lightness: -90%);
   }
 
   .notification-error {
     border-top-color: #bd362f;
+    background-color: scale-color(#bd362f, $lightness: -90%);
   }
 
   .notification-warning {
     border-top-color: #f89406;
+    background-color: scale-color(#f89406, $lightness: -90%);
   }
 
   .notification-success {
     border-top-color: #51a351;
+    background-color: scale-color(#51a351, $lightness: -90%);
   }
 }

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -113,7 +113,6 @@ body {
   }
   .dropdown {
     @include below-header;
-    @include smoked-glass;
     position: absolute;
     display: block;
     overflow: auto;


### PR DESCRIPTION
This removes the translucent "smoked glass" effect from all dialogs and sheets and everything else, in favor of just solid opaque black. After having fun with the blurred backgrounds for a while, I think it's less distracting to just have solid colors.

I also tweaked the notifications to have a slight tint of their accent color, which looks nice.