### PR TITLE
y3 armor search

### DIFF
--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -10,7 +10,6 @@ import RatingIcon from './RatingIcon';
 import classNames from 'classnames';
 import styles from './BadgeInfo.m.scss';
 import ElementIcon from './ElementIcon';
-import { energyCapacitiesByName } from '../search/search-filter-hashes';
 
 interface Props {
   item: DimItem;
@@ -33,11 +32,6 @@ const getGhostInfos = weakMemoize((item: DimItem) =>
         })
       )
     : []
-);
-
-const armorElements = Object.entries(energyCapacitiesByName).reduce(
-  (obj, [key, value]) => ({ ...obj, [value]: key }),
-  {}
 );
 
 export function hasBadge(item?: DimItem | null): boolean {
@@ -109,13 +103,7 @@ export default function BadgeInfo({ item, isCapped, rating, isWishListRoll }: Pr
         </div>
       )}
       <div className={styles.primaryStat}>
-        {(item.dmg && <ElementIcon element={item.dmg} />) ||
-          (item.isDestiny2() &&
-            item.masterworkInfo &&
-            item.masterworkInfo.statHash &&
-            item.masterworkInfo.statHash in armorElements && (
-              <ElementIcon element={armorElements[item.masterworkInfo.statHash]} />
-            ))}
+        {item.dmg && <ElementIcon element={item.dmg} />}
         {badgeContent}
       </div>
     </div>

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -10,6 +10,7 @@ import RatingIcon from './RatingIcon';
 import classNames from 'classnames';
 import styles from './BadgeInfo.m.scss';
 import ElementIcon from './ElementIcon';
+import { energyCapacitiesByName } from '../search/search-filter-hashes';
 
 interface Props {
   item: DimItem;
@@ -32,6 +33,11 @@ const getGhostInfos = weakMemoize((item: DimItem) =>
         })
       )
     : []
+);
+
+const armorElements = Object.entries(energyCapacitiesByName).reduce(
+  (obj, [key, value]) => ({ ...obj, [value]: key }),
+  {}
 );
 
 export function hasBadge(item?: DimItem | null): boolean {
@@ -103,7 +109,13 @@ export default function BadgeInfo({ item, isCapped, rating, isWishListRoll }: Pr
         </div>
       )}
       <div className={styles.primaryStat}>
-        {item.dmg && <ElementIcon element={item.dmg} />}
+        {(item.dmg && <ElementIcon element={item.dmg} />) ||
+          (item.isDestiny2() &&
+            item.masterworkInfo &&
+            item.masterworkInfo.statHash &&
+            item.masterworkInfo.statHash in armorElements && (
+              <ElementIcon element={armorElements[item.masterworkInfo.statHash]} />
+            ))}
         {badgeContent}
       </div>
     </div>

--- a/src/app/inventory/ElementIcon.tsx
+++ b/src/app/inventory/ElementIcon.tsx
@@ -11,7 +11,7 @@ export default function ElementIcon({ element }: { element: DimItem['dmg'] }) {
     void: 'void'
   };
 
-  if (images[element]) {
+  if (element && images[element]) {
     return (
       <BungieImage
         className={classNames(styles.element, styles[element])}

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -11,7 +11,8 @@ import {
   DestinyItemQualityBlockDefinition,
   DestinyAmmunitionType,
   DestinyItemQuantity,
-  DestinyDisplayPropertiesDefinition
+  DestinyDisplayPropertiesDefinition,
+  DestinyItemInstanceEnergy
 } from 'bungie-api-ts/destiny2';
 import { DimItemInfo } from './dim-item-info';
 import { DimStore, StoreServiceType, D1StoreServiceType, D2StoreServiceType } from './store-types';
@@ -205,7 +206,7 @@ export interface D2Item extends DimItem {
   /** If this item is a masterwork, this will include information about its masterwork properties. */
   masterworkInfo: DimMasterwork | null;
   /** for y3 armor, this is the type and capacity information */
-  energy: DimEnergyCapacity | null;
+  energy: DestinyItemInstanceEnergy | null;
   /** Information about how this item works with infusion. */
   infusionQuality: DestinyItemQualityBlockDefinition | null;
   /** More infusion information about what can be infused with the item. */
@@ -254,19 +255,6 @@ export interface DimMasterwork {
   tier?: number;
   /** How much the stat is enhanced by this masterwork. */
   statValue?: number;
-}
-
-export interface DimEnergyCapacity {
-  /** total energy on this item for use by mods */
-  capacity: number;
-  /** energy type, currently an element name, not guaranteed to be that way forever */
-  type: 'arc' | 'solar' | 'void' | null;
-  /** hash for the type of armor capacity energy. again, might not correspond to an element forever */
-  typehash: number;
-  /** energy left for new mods to use */
-  unused: number;
-  /** mods currently applied are taking up this much energy */
-  used: number;
 }
 
 export interface DimStat {

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -95,7 +95,7 @@ export interface DimItem {
   /** The localized name of the class this item is restricted to. */
   classTypeNameLocalized: string;
   /** The readable name of the damage type associated with this item. */
-  dmg: 'kinetic' | 'arc' | 'solar' | 'void' | 'heroic';
+  dmg: 'kinetic' | 'arc' | 'solar' | 'void' | 'heroic' | null;
   /** Whether this item can be locked. */
   lockable: boolean;
   /** Is this item tracked? (D1 quests/bounties). */
@@ -204,6 +204,8 @@ export interface D2Item extends DimItem {
   flavorObjective: DimFlavorObjective | null;
   /** If this item is a masterwork, this will include information about its masterwork properties. */
   masterworkInfo: DimMasterwork | null;
+  /** for y3 armor, this is the type and capacity information */
+  energy: DimEnergyCapacity | null;
   /** Information about how this item works with infusion. */
   infusionQuality: DestinyItemQualityBlockDefinition | null;
   /** More infusion information about what can be infused with the item. */
@@ -252,6 +254,19 @@ export interface DimMasterwork {
   tier?: number;
   /** How much the stat is enhanced by this masterwork. */
   statValue?: number;
+}
+
+export interface DimEnergyCapacity {
+  /** total energy on this item for use by mods */
+  capacity: number;
+  /** energy type, currently an element name, not guaranteed to be that way forever */
+  type: 'arc' | 'solar' | 'void' | null;
+  /** hash for the type of armor capacity energy. again, might not correspond to an element forever */
+  typehash: number;
+  /** energy left for new mods to use */
+  unused: number;
+  /** mods currently applied are taking up this much energy */
+  used: number;
 }
 
 export interface DimStat {

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -275,10 +275,6 @@ export function makeItem(
   }
 
   const itemType = normalBucket.type || 'Unknown';
-  const dmgName =
-    damageTypeNames[
-      (instanceDef ? instanceDef.damageType : itemDef.defaultDamageType) || DamageType.None
-    ];
 
   // https://github.com/Bungie-net/api/issues/134, class items had a primary stat
   const primaryStat =
@@ -286,13 +282,22 @@ export function makeItem(
       ? null
       : (instanceDef && instanceDef.primaryStat) || null;
 
-  const energyInfo = instanceDef.energy && {
-    capacity: instanceDef.energy.energyCapacity,
-    type: energyCapacityTypeNames[instanceDef.energy.energyType] || null,
-    typehash: instanceDef.energy.energyTypeHash,
-    unused: instanceDef.energy.energyUnused,
-    used: instanceDef.energy.energyUsed
-  };
+  const energyInfo =
+    (instanceDef.energy && {
+      capacity: instanceDef.energy.energyCapacity,
+      type: energyCapacityTypeNames[instanceDef.energy.energyType] || null,
+      typehash: instanceDef.energy.energyTypeHash,
+      unused: instanceDef.energy.energyUnused,
+      used: instanceDef.energy.energyUsed
+    }) ||
+    null;
+
+  const dmgName =
+    damageTypeNames[
+      (instanceDef ? instanceDef.damageType : itemDef.defaultDamageType) || DamageType.None
+    ] ||
+    (energyInfo && energyInfo.type) ||
+    null;
 
   const collectible =
     itemDef.collectibleHash && mergedCollectibles && mergedCollectibles[itemDef.collectibleHash];
@@ -525,11 +530,6 @@ export function makeItem(
   } catch (e) {
     console.error(`Error building Quest info for ${createdItem.name}`, item, itemDef, e);
     reportException('Quest', e, { itemHash: item.itemHash });
-  }
-
-  // now that we have mw info, try again if we weren't able to pick a dmg icon
-  if (!createdItem.dmg && createdItem.energy) {
-    createdItem.dmg = createdItem.energy.type;
   }
 
   // TODO: Phase out "base power"

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -282,21 +282,12 @@ export function makeItem(
       ? null
       : (instanceDef && instanceDef.primaryStat) || null;
 
-  const energyInfo =
-    (instanceDef.energy && {
-      capacity: instanceDef.energy.energyCapacity,
-      type: energyCapacityTypeNames[instanceDef.energy.energyType] || null,
-      typehash: instanceDef.energy.energyTypeHash,
-      unused: instanceDef.energy.energyUnused,
-      used: instanceDef.energy.energyUsed
-    }) ||
-    null;
-
+  // if a damageType isn't found, use the item's energy capacity element instead
   const dmgName =
     damageTypeNames[
       (instanceDef ? instanceDef.damageType : itemDef.defaultDamageType) || DamageType.None
     ] ||
-    (energyInfo && energyInfo.type) ||
+    (instanceDef.energy && energyCapacityTypeNames[instanceDef.energy.energyType]) ||
     null;
 
   const collectible =
@@ -353,7 +344,7 @@ export function makeItem(
     classType: itemDef.classType,
     classTypeNameLocalized: getClassTypeNameLocalized(itemDef.classType, defs),
     dmg: dmgName,
-    energy: energyInfo,
+    energy: instanceDef.energy || null,
     visible: true,
     lockable: item.lockable,
     tracked: Boolean(item.state & ItemState.Tracked),

--- a/src/app/search/search-filter-hashes.ts
+++ b/src/app/search/search-filter-hashes.ts
@@ -198,15 +198,6 @@ export const emptySocketHashes = [
   791435474 // InventoryItem "Empty Activity Mod Socket"
 ];
 
-// armor elements for y3 mods
-export const energyCapacitiesByName = {
-  void: 16120457, // Stat "Void Energy Capacity"
-  arc: 3625423501, // Stat "Arc Energy Capacity"
-  solar: 2018193158 // Stat "Solar Energy Capacity"
-};
-export const energyCapacityNames = Object.keys(energyCapacitiesByName);
-export const energyCapacities = Object.values(energyCapacitiesByName);
-
 /** translate search terms to corresponding hashes */
 export const statHashByName = {
   rpm: 4284893193,
@@ -230,5 +221,7 @@ export const statHashByName = {
   zoom: 3555269338,
   inventorysize: 1931675084
 };
+
+export const energyCapacityTypes = ['void', 'arc', 'solar'];
 
 export const shaderBucket = 2973005342;

--- a/src/app/search/search-filter-hashes.ts
+++ b/src/app/search/search-filter-hashes.ts
@@ -198,6 +198,15 @@ export const emptySocketHashes = [
   791435474 // InventoryItem "Empty Activity Mod Socket"
 ];
 
+// armor elements for y3 mods
+export const energyCapacitiesByName = {
+  void: 16120457, // Stat "Void Energy Capacity"
+  arc: 3625423501, // Stat "Arc Energy Capacity"
+  solar: 2018193158 // Stat "Solar Energy Capacity"
+};
+export const energyCapacityNames = Object.keys(energyCapacitiesByName);
+export const energyCapacities = Object.values(energyCapacitiesByName);
+
 /** translate search terms to corresponding hashes */
 export const statHashByName = {
   rpm: 4284893193,

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -238,20 +238,20 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
       : {}),
     ...(isD2
       ? {
-          reacquirable: ['reacquirable'],
-          hasLight: ['light', 'haslight', 'haspower'],
+          ammoType: ['special', 'primary', 'heavy'],
           complete: ['goldborder', 'yellowborder', 'complete'],
           curated: ['curated'],
-          wishlist: ['wishlist'],
-          wishlistdupe: ['wishlistdupe'],
-          masterwork: ['masterwork', 'masterworks'],
-          hasShader: ['shaded', 'hasshader'],
-          hasMod: ['modded', 'hasmod'],
-          ikelos: ['ikelos'],
-          randomroll: ['randomroll'],
-          ammoType: ['special', 'primary', 'heavy'],
           event: ['dawning', 'crimsondays', 'solstice', 'fotl', 'revelry'],
-          powerfulreward: ['powerfulreward']
+          hasLight: ['light', 'haslight', 'haspower'],
+          hasMod: ['modded', 'hasmod'],
+          hasShader: ['shaded', 'hasshader'],
+          ikelos: ['ikelos'],
+          masterwork: ['masterwork', 'masterworks'],
+          powerfulreward: ['powerfulreward'],
+          randomroll: ['randomroll'],
+          reacquirable: ['reacquirable'],
+          wishlist: ['wishlist'],
+          wishlistdupe: ['wishlistdupe']
         }
       : {}),
     ...($featureFlags.reviewsEnabled ? { hasRating: ['rated', 'hasrating'] } : {})
@@ -287,6 +287,9 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
       .map((tag) => `season:${tag}`),
     // a keyword for every combination of a DIM-processed stat and mathmatical operator
     ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
+    // energy capacity elements and ranges
+    ...hashes.energyCapacityNames.map((element) => `energycapacity:${element}`),
+    ...operators.map((comparison) => `energycapacity:${comparison}`),
     // "source:" keyword plus one for each source
     ...(isD2 ? ['source:', ...Object.keys(D2Sources).map((word) => `source:${word}`)] : []),
     // all the free text searches that support quotes
@@ -526,6 +529,7 @@ function searchFilters(
             case 'year':
             case 'stack':
             case 'count':
+            case 'energycapacity':
             case 'level':
             case 'rating':
             case 'ratingcount':
@@ -914,6 +918,20 @@ function searchFilters(
       level(item: DimItem, predicate: string) {
         return compareByOperator(item.equipRequiredLevel, predicate);
       },
+      energycapacity(item: D2Item, predicate: string) {
+        // ensure this item has an energy capacity first
+        if (
+          item.masterworkInfo &&
+          item.masterworkInfo.statHash &&
+          hashes.energyCapacities.includes(item.masterworkInfo.statHash)
+        ) {
+          return (
+            (mathCheck.test(predicate) &&
+              compareByOperator(item.masterworkInfo.statValue, predicate)) ||
+            hashes.energyCapacitiesByName[predicate] === item.masterworkInfo.statHash
+          );
+        }
+      },
       quality(item: D1Item, predicate: string) {
         if (!item.quality) {
           return false;
@@ -1098,7 +1116,11 @@ function searchFilters(
               socket.plug.plugItem.plug &&
               socket.plug.plugItem.plug.plugCategoryIdentifier.match(
                 /(v400.weapon.mod_(guns|damage|magazine)|enhancements.)/
-              )
+              ) &&
+              // enforce that this provides a perk (excludes empty slots)
+              socket.plug.plugItem.perks.length &&
+              // enforce that this doesn't have an energy cost (y3 reusables)
+              !socket.plug.plugItem.plug.energyCost
             );
           })
         );

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -921,7 +921,6 @@ function searchFilters(
       },
       energycapacity(item: D2Item, predicate: string) {
         if (item.energy) {
-          console.log(`${item.name} - has:${item.energy} - searching:${predicate}`);
           return (
             (mathCheck.test(predicate) &&
               compareByOperator(item.energy.energyCapacity, predicate)) ||

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -239,6 +239,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     ...(isD2
       ? {
           ammoType: ['special', 'primary', 'heavy'],
+          hascapacity: ['hascapacity', 'armor2.0'],
           complete: ['goldborder', 'yellowborder', 'complete'],
           curated: ['curated'],
           event: ['dawning', 'crimsondays', 'solstice', 'fotl', 'revelry'],
@@ -288,7 +289,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     // a keyword for every combination of a DIM-processed stat and mathmatical operator
     ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
     // energy capacity elements and ranges
-    ...hashes.energyCapacityNames.map((element) => `energycapacity:${element}`),
+    ...hashes.energyCapacityTypes.map((element) => `energycapacity:${element}`),
     ...operators.map((comparison) => `energycapacity:${comparison}`),
     // "source:" keyword plus one for each source
     ...(isD2 ? ['source:', ...Object.keys(D2Sources).map((word) => `source:${word}`)] : []),
@@ -920,17 +921,15 @@ function searchFilters(
       },
       energycapacity(item: D2Item, predicate: string) {
         // ensure this item has an energy capacity first
-        if (
-          item.masterworkInfo &&
-          item.masterworkInfo.statHash &&
-          hashes.energyCapacities.includes(item.masterworkInfo.statHash)
-        ) {
+        if (item.energy) {
           return (
-            (mathCheck.test(predicate) &&
-              compareByOperator(item.masterworkInfo.statValue, predicate)) ||
-            hashes.energyCapacitiesByName[predicate] === item.masterworkInfo.statHash
+            (mathCheck.test(predicate) && compareByOperator(item.energy.capacity, predicate)) ||
+            predicate === item.dmg
           );
         }
+      },
+      hascapacity(item: D2Item) {
+        return !!item.energy;
       },
       quality(item: D1Item, predicate: string) {
         if (!item.quality) {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -920,10 +920,11 @@ function searchFilters(
         return compareByOperator(item.equipRequiredLevel, predicate);
       },
       energycapacity(item: D2Item, predicate: string) {
-        // ensure this item has an energy capacity first
         if (item.energy) {
+          console.log(`${item.name} - has:${item.energy} - searching:${predicate}`);
           return (
-            (mathCheck.test(predicate) && compareByOperator(item.energy.capacity, predicate)) ||
+            (mathCheck.test(predicate) &&
+              compareByOperator(item.energy.energyCapacity, predicate)) ||
             predicate === item.dmg
           );
         }


### PR DESCRIPTION
not a big rework but this is some incremental changes i'd really like to be able to use right away
![image](https://user-images.githubusercontent.com/31990469/66243048-efe9ee80-e6b7-11e9-8e04-026b43712924.png)
search by energy capacity amount
![image](https://user-images.githubusercontent.com/31990469/66243040-e5c7f000-e6b7-11e9-8965-9a4e7379a720.png)
or element
![image](https://user-images.githubusercontent.com/31990469/66243058-f8422980-e6b7-11e9-8cfe-b77c77274c7c.png)

and displays element on badges for armor because now it is much more important

fixes hasmod to only highlight y2 mods, and ignore y3 empty slots