### PR TITLE
Sneaky updates on location transitions when update is needed

### DIFF
--- a/src/app/dim-ui/ActivityTracker.tsx
+++ b/src/app/dim-ui/ActivityTracker.tsx
@@ -5,6 +5,8 @@ import { refresh as triggerRefresh, refresh$ } from '../shell/refresh';
 import { isDragging } from '../inventory/DraggableInventoryItem';
 import { Subscription } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
+import { dimNeedsUpdate } from 'app/register-service-worker';
+import { reloadDIM } from 'app/whats-new/WhatsNewLink';
 
 const MIN_REFRESH_INTERVAL = 1 * 1000;
 const AUTO_REFRESH_INTERVAL = 30 * 1000;
@@ -68,6 +70,9 @@ export class ActivityTracker extends React.Component {
   private visibilityHandler = () => {
     if (!document.hidden) {
       this.refreshAccountData();
+    } else if (dimNeedsUpdate) {
+      // Sneaky updates - if DIM is hidden and needs an update, do the update.
+      reloadDIM();
     }
   };
 

--- a/src/app/router.config.ts
+++ b/src/app/router.config.ts
@@ -1,5 +1,7 @@
 import { UIRouterReact, servicesPlugin, hashLocationPlugin } from '@uirouter/react';
 import { states } from './routes';
+import { dimNeedsUpdate } from './register-service-worker';
+import { reloadDIM } from './whats-new/WhatsNewLink';
 
 export default function makeRouter() {
   const router = new UIRouterReact();
@@ -26,6 +28,15 @@ export default function makeRouter() {
     if (document.documentElement) {
       document.documentElement.scrollTop = 0;
     }
+  });
+
+  let initialLoad = true;
+  // "Sneaky Updates" - update on navigation if DIM needs an update
+  router.transitionService.onSuccess({}, () => {
+    if (!initialLoad && dimNeedsUpdate) {
+      reloadDIM();
+    }
+    initialLoad = false;
   });
 
   if ($featureFlags.googleAnalyticsForRouter) {

--- a/src/app/whats-new/WhatsNewLink.tsx
+++ b/src/app/whats-new/WhatsNewLink.tsx
@@ -77,7 +77,7 @@ export default class WhatsNewLink extends React.Component<{}, State> {
   }
 }
 
-async function reloadDIM() {
+export async function reloadDIM() {
   try {
     const registration = await navigator.serviceWorker.getRegistration();
 


### PR DESCRIPTION
This implements https://github.com/DestinyItemManager/DIM/issues/4315 by reloading the page if there's an update required and the page either goes into the background or the user navigates to a different page.