### PR TITLE
Timeouts for API calls

### DIFF
--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -13,6 +13,8 @@ import { t } from 'app/i18next-t';
 
 let cache: Promise<Tokens> | null = null;
 
+const TIMEOUT = 3000;
+
 /**
  * A wrapper around "fetch" that implements Bungie's OAuth scheme. This either
  * includes a cached token, refreshes a token then includes the refreshed token,
@@ -23,6 +25,8 @@ export async function fetchWithBungieOAuth(
   options?: RequestInit,
   triedRefresh = false
 ): Promise<Response> {
+  const controller = typeof AbortController === 'function' ? new AbortController() : null;
+  const signal = controller && controller.signal;
   if (typeof request === 'string') {
     request = new Request(request);
   }
@@ -40,23 +44,34 @@ export async function fetchWithBungieOAuth(
     throw e;
   }
 
-  // clone is us trying to work around "Body has already been consumed." in retry.
-  const response = await fetch(request.clone(), options);
-  if (await responseIndicatesBadToken(response)) {
-    if (triedRefresh) {
-      // Give up
-      removeToken();
-      goToLoginPage();
-      throw new Error("Access token expired, and we've already tried to refresh. Failing.");
-    }
-    // OK, Bungie has told us our access token is expired or
-    // invalid. Refresh it and try again.
-    console.log(`Access token expired, removing access token and trying again`);
-    removeAccessToken();
-    return fetchWithBungieOAuth(request, options, true);
+  let timer;
+  if (controller) {
+    timer = setTimeout(() => controller.abort(), TIMEOUT);
   }
 
-  return response;
+  // clone is us trying to work around "Body has already been consumed." in retry.
+  try {
+    const response = await fetch(request.clone(), { ...options, signal });
+    if (await responseIndicatesBadToken(response)) {
+      if (triedRefresh) {
+        // Give up
+        removeToken();
+        goToLoginPage();
+        throw new Error("Access token expired, and we've already tried to refresh. Failing.");
+      }
+      // OK, Bungie has told us our access token is expired or
+      // invalid. Refresh it and try again.
+      console.log(`Access token expired, removing access token and trying again`);
+      removeAccessToken();
+      return fetchWithBungieOAuth(request, options, true);
+    }
+
+    return response;
+  } finally {
+    if (controller) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 async function responseIndicatesBadToken(response: Response) {

--- a/src/app/destinyTrackerApi/dtr-service-helper.ts
+++ b/src/app/destinyTrackerApi/dtr-service-helper.ts
@@ -48,15 +48,16 @@ export function dtrFetch(url: string, body: object) {
       circuitBreaker.run(
         (success, failure) => {
           Promise.resolve(fetch(request, { signal }))
+            .finally(() => {
+              if (controller) {
+                clearTimeout(timer);
+              }
+            })
             .then((r) => {
               if (r.status === 503) {
                 lastFiveOhThreeCaught = new Date();
                 failure();
                 reject(new Error('HTTP 503 returned'));
-              }
-
-              if (controller) {
-                clearTimeout(timer);
               }
               return r;
             })


### PR DESCRIPTION
This implements request timeouts for all Bungie API calls. Over the weekend I was seeing 20s request times that were blocking the app from loading. This code cuts things off after 3s so we fail quickly. Note that there will be cases when the Bungie API is slow where this will cause failures where waiting could have worked.