### PR TITLE
Quieting empty reviews.

### DIFF
--- a/src/app/item-review/ItemReview.tsx
+++ b/src/app/item-review/ItemReview.tsx
@@ -32,6 +32,12 @@ export default class ItemReview extends React.Component<Props, State> {
     const { item, review, reviewModeOptions } = this.props;
     const { flagged } = this.state;
 
+    const reviewText = isD2Review(item, review) ? review.text : review.review;
+
+    if (!reviewText || reviewText.length === 0) {
+      return null;
+    }
+
     return (
       <div className="community-review">
         <div>
@@ -85,9 +91,7 @@ export default class ItemReview extends React.Component<Props, State> {
                   })}
                 </div>
               )}
-            <div className="community-review--review">
-              {isD2Review(item, review) ? review.text : review.review}
-            </div>
+            <div className="community-review--review">{reviewText}</div>
           </div>
           {flagged && (
             <div className="community-revew--report-container">


### PR DESCRIPTION
Not sure if the API's changed (I'm pretty sure it wasn't sending reviews without text before), but we can hide the blank ones on our end.