### PR TITLE
display ornaments as icon

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -4,6 +4,7 @@ import {
   DestinyItemComponent,
   DestinyItemComponentSetOfint64,
   DestinyItemInstanceComponent,
+  DestinyItemType,
   ItemLocation,
   TransferStatuses,
   DestinyAmmunitionType,
@@ -490,12 +491,27 @@ export function makeItem(
   // Secondary Icon
   if (createdItem.sockets) {
     const multiEmblem = createdItem.sockets.sockets.filter(
-      (plug) => plug.plug && plug.plug.plugItem.itemType === 14
+      (plug) => plug.plug && plug.plug.plugItem.itemType === DestinyItemType.Emblem
     );
     const selectedEmblem = multiEmblem[0] && multiEmblem[0].plug;
 
     if (selectedEmblem) {
       createdItem.secondaryIcon = selectedEmblem.plugItem.secondaryIcon;
+    }
+  }
+  // show ornaments - ItemCategory 56 contains "Armor Mods: Ornaments" "Armor Mods: Ornaments/Hunter"
+  // "Armor Mods: Ornaments/Titan" "Armor Mods: Ornaments/Warlock" "Weapon Mods: Ornaments"
+  const defaultOrnaments = [2931483505, 1959648454, 702981643];
+  if (createdItem.sockets) {
+    const pluggedOrnament = createdItem.sockets.sockets.find(
+      (socket) => socket.plug && socket.plug.plugItem.itemCategoryHashes.includes(56)
+    );
+    if (
+      pluggedOrnament &&
+      pluggedOrnament.plug!.plugItem.displayProperties.hasIcon &&
+      !defaultOrnaments.includes(pluggedOrnament.plug!.plugItem.hash)
+    ) {
+      createdItem.icon = pluggedOrnament.plug!.plugItem.displayProperties.icon;
     }
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31990469/66530737-e13b7700-eabd-11e9-8cdd-aae5bbf10fb6.png)
it's not bad looking.
it looks different which i know is always scary,

and the downside is that some armor ornaments are *slightly* different size/angle from their unornamented counterparts
![image](https://user-images.githubusercontent.com/31990469/66530784-1f389b00-eabe-11e9-9465-b895a88dc22c.png)
![image](https://user-images.githubusercontent.com/31990469/66530804-2c558a00-eabe-11e9-9168-d81d826411f2.png)

but this is a *great* change that will respect people's aesthetic choices more, and help them distinguish between their items better without using up any extra layout space