### PR TITLE
don't show glows as item icons

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -503,12 +503,17 @@ export function makeItem(
       createdItem.secondaryIcon = selectedEmblem.plugItem.secondaryIcon;
     }
   }
+  
   // show ornaments - ItemCategory 56 contains "Armor Mods: Ornaments" "Armor Mods: Ornaments/Hunter"
   // "Armor Mods: Ornaments/Titan" "Armor Mods: Ornaments/Warlock" "Weapon Mods: Ornaments"
+  // we include these but exclude glows (1875601085)
   const defaultOrnaments = [2931483505, 1959648454, 702981643];
   if (createdItem.sockets) {
     const pluggedOrnament = createdItem.sockets.sockets.find(
-      (socket) => socket.plug && socket.plug.plugItem.itemCategoryHashes.includes(56)
+      (socket) =>
+        socket.plug &&
+        socket.plug.plugItem.itemCategoryHashes.includes(56) &&
+        !socket.plug.plugItem.itemCategoryHashes.includes(1875601085)
     );
     if (
       pluggedOrnament &&


### PR DESCRIPTION
can either whitelist or blacklist here

i'd rather we blacklist glows, and maybe unexpectedly/pleasantly include a new addition to `Armor Mods: Ornaments`
than get too restrictive with a whitelist of specific armor ornament subcategories