### PR TITLE
Shadowkeep loadout optimizer

### DIFF
--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -82,7 +82,7 @@ class ItemSockets extends React.Component<Props> {
       <div className={clsx('item-details', 'sockets', { chalice })}>
         {item.sockets.categories.map(
           (category, index) =>
-            (!hideMods || index === 0) &&
+            (!hideMods || index < 2) &&
             category.sockets.length > 0 && (
               <div
                 key={category.category.hash}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -126,12 +126,12 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       requirePerks: true,
       lockedMap: {},
       statFilters: {
-        Mobility: { min: 0, max: 100 },
-        Resilience: { min: 0, max: 100 },
-        Recovery: { min: 0, max: 100 },
-        Discipline: { min: 0, max: 100 },
-        Intellect: { min: 0, max: 100 },
-        Strength: { min: 0, max: 100 }
+        Mobility: { min: 0, max: 10 },
+        Resilience: { min: 0, max: 10 },
+        Recovery: { min: 0, max: 10 },
+        Discipline: { min: 0, max: 10 },
+        Intellect: { min: 0, max: 10 },
+        Strength: { min: 0, max: 10 }
       },
       minimumPower: 0,
       query: '',
@@ -314,12 +314,12 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       lockedMap: {},
       requirePerks: true,
       statFilters: {
-        Mobility: { min: 0, max: 100 },
-        Resilience: { min: 0, max: 100 },
-        Recovery: { min: 0, max: 100 },
-        Discipline: { min: 0, max: 100 },
-        Intellect: { min: 0, max: 100 },
-        Strength: { min: 0, max: 100 }
+        Mobility: { min: 0, max: 10 },
+        Resilience: { min: 0, max: 10 },
+        Recovery: { min: 0, max: 10 },
+        Discipline: { min: 0, max: 10 },
+        Intellect: { min: 0, max: 10 },
+        Strength: { min: 0, max: 10 }
       },
       minimumPower: 0
     });

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -126,12 +126,12 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       requirePerks: true,
       lockedMap: {},
       statFilters: {
-        Mobility: { min: 0, max: 10 },
-        Resilience: { min: 0, max: 10 },
-        Recovery: { min: 0, max: 10 },
-        Discipline: { min: 0, max: 10 },
-        Intellect: { min: 0, max: 10 },
-        Strength: { min: 0, max: 10 }
+        Mobility: { min: 0, max: 100 },
+        Resilience: { min: 0, max: 100 },
+        Recovery: { min: 0, max: 100 },
+        Discipline: { min: 0, max: 100 },
+        Intellect: { min: 0, max: 100 },
+        Strength: { min: 0, max: 100 }
       },
       minimumPower: 0,
       query: '',
@@ -314,12 +314,12 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       lockedMap: {},
       requirePerks: true,
       statFilters: {
-        Mobility: { min: 0, max: 10 },
-        Resilience: { min: 0, max: 10 },
-        Recovery: { min: 0, max: 10 },
-        Discipline: { min: 0, max: 10 },
-        Intellect: { min: 0, max: 10 },
-        Strength: { min: 0, max: 10 }
+        Mobility: { min: 0, max: 100 },
+        Resilience: { min: 0, max: 100 },
+        Recovery: { min: 0, max: 100 },
+        Discipline: { min: 0, max: 100 },
+        Intellect: { min: 0, max: 100 },
+        Strength: { min: 0, max: 100 }
       },
       minimumPower: 0
     });

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -128,7 +128,10 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       statFilters: {
         Mobility: { min: 0, max: 10 },
         Resilience: { min: 0, max: 10 },
-        Recovery: { min: 0, max: 10 }
+        Recovery: { min: 0, max: 10 },
+        Discipline: { min: 0, max: 10 },
+        Intellect: { min: 0, max: 10 },
+        Strength: { min: 0, max: 10 }
       },
       minimumPower: 0,
       query: '',
@@ -313,7 +316,10 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       statFilters: {
         Mobility: { min: 0, max: 10 },
         Resilience: { min: 0, max: 10 },
-        Recovery: { min: 0, max: 10 }
+        Recovery: { min: 0, max: 10 },
+        Discipline: { min: 0, max: 10 },
+        Intellect: { min: 0, max: 10 },
+        Strength: { min: 0, max: 10 }
       },
       minimumPower: 0
     });

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.m.scss
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.m.scss
@@ -7,6 +7,12 @@
   grid-template-columns: 6px 1fr 25% 25%;
   grid-gap: 4px 4px;
   margin-bottom: 4px;
+
+  label {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 .powerSelect {

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import styles from './FilterBuilds.m.scss';
 import { statHashes, statKeys } from '../process';
+import { statTier } from './utils';
 
 /**
  * A control for filtering builds by stats, and controlling the priority order of stats.
@@ -36,8 +37,10 @@ export default function FilterBuilds({
     const statRanges = _.mapValues(statHashes, () => ({ min: 10, max: 0 }));
     for (const set of sets) {
       for (const prop of statKeys) {
-        statRanges[prop].min = Math.min(set.stats[prop], statRanges[prop].min);
-        statRanges[prop].max = Math.max(set.stats[prop], statRanges[prop].max);
+        const tier = statTier(set.stats[prop]);
+        const range = statRanges[prop];
+        range.min = Math.min(tier, range.min);
+        range.max = Math.max(tier, range.max);
       }
     }
     return statRanges;

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -6,7 +6,7 @@ import GeneratedSetButtons from './GeneratedSetButtons';
 import GeneratedSetItem from './GeneratedSetItem';
 import { powerIndicatorIcon, AppIcon } from '../../shell/icons';
 import _ from 'lodash';
-import { getNumValidSets, calculateTier } from './utils';
+import { getNumValidSets, calculateTier, statTier } from './utils';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
@@ -105,7 +105,12 @@ function GeneratedSet({
 function Stat({ stat, value }: { stat: DestinyStatDefinition; value: number }) {
   return (
     <span className={styles.segment} title={stat.displayProperties.description}>
-      <b>{value}</b> <BungieImage src={stat.displayProperties.icon} /> {stat.displayProperties.name}
+      <b>
+        {t('LoadoutBuilder.TierNumber', {
+          tier: statTier(value)
+        })}
+      </b>{' '}
+      <BungieImage src={stat.displayProperties.icon} /> {stat.displayProperties.name}
     </span>
   );
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -6,7 +6,7 @@ import GeneratedSetButtons from './GeneratedSetButtons';
 import GeneratedSetItem from './GeneratedSetItem';
 import { powerIndicatorIcon, AppIcon } from '../../shell/icons';
 import _ from 'lodash';
-import { getNumValidSets } from './utils';
+import { getNumValidSets, calculateTier } from './utils';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
@@ -55,6 +55,8 @@ function GeneratedSet({
 
   const stats = _.mapValues(statHashes, (statHash) => defs.Stat.get(statHash));
 
+  const tier = calculateTier(set.stats);
+
   return (
     <div className={styles.build} style={style} ref={forwardedRef}>
       <div className={styles.header}>
@@ -63,7 +65,7 @@ function GeneratedSet({
             <span className={styles.segment}>
               <b>
                 {t('LoadoutBuilder.TierNumber', {
-                  tier: _.sum(Object.values(set.stats))
+                  tier
                 })}
               </b>
             </span>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -110,7 +110,7 @@ export default function GeneratedSetItem({
       {item.isDestiny2() && (
         <ItemSockets
           item={item}
-          hideMods={false}
+          hideMods={true}
           classesByHash={classesByHash}
           onShiftClick={onShiftClickPerk}
         />

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -110,7 +110,7 @@ export default function GeneratedSetItem({
       {item.isDestiny2() && (
         <ItemSockets
           item={item}
-          hideMods={true}
+          hideMods={false}
           classesByHash={classesByHash}
           onShiftClick={onShiftClickPerk}
         />

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -30,7 +30,11 @@ interface State {
 function numColumns(set: ArmorSet) {
   return _.sumBy(
     set.firstValidSet,
-    (item) => (item.isDestiny2() && item.sockets && item.sockets.categories[0].sockets.length) || 0
+    (item) =>
+      (item.isDestiny2() &&
+        item.sockets &&
+        _.max(item.sockets.categories.map((c) => c.sockets.length))) ||
+      0
   );
 }
 

--- a/src/app/loadout-builder/generated-sets/TierSelect.m.scss
+++ b/src/app/loadout-builder/generated-sets/TierSelect.m.scss
@@ -3,20 +3,8 @@
   height: 17px;
   width: 17px;
   background-size: 100%;
-  filter: invert(1);
   vertical-align: middle;
-}
-.iconMobility {
-  composes: iconStat;
-  background-image: url('~destiny-icons/general/mobility.svg');
-}
-.iconResilience {
-  composes: iconStat;
-  background-image: url('~destiny-icons/general/resilience.svg');
-}
-.iconRecovery {
-  composes: iconStat;
-  background-image: url('~destiny-icons/general/recovery.svg');
+  margin-right: 2px;
 }
 
 .grip {

--- a/src/app/loadout-builder/generated-sets/TierSelect.m.scss.d.ts
+++ b/src/app/loadout-builder/generated-sets/TierSelect.m.scss.d.ts
@@ -2,9 +2,6 @@
 // Please do not change this file!
 interface CssExports {
   'grip': string;
-  'iconMobility': string;
-  'iconRecovery': string;
-  'iconResilience': string;
   'iconStat': string;
 }
 declare const cssExports: CssExports;

--- a/src/app/loadout-builder/generated-sets/TierSelect.tsx
+++ b/src/app/loadout-builder/generated-sets/TierSelect.tsx
@@ -8,6 +8,7 @@ import { AppIcon } from 'app/shell/icons';
 import styles from './TierSelect.m.scss';
 import _ from 'lodash';
 import { faGripLinesVertical } from '@fortawesome/free-solid-svg-icons';
+import BungieImage from 'app/dim-ui/BungieImage';
 
 const MinMaxSelect = React.memo(MinMaxSelectInner);
 
@@ -61,7 +62,10 @@ export default function TierSelect({
                 className={rowClassName}
                 name={
                   <>
-                    <span className={styles[`icon${stat}`]} />{' '}
+                    <BungieImage
+                      className={styles.iconStat}
+                      src={statDefs[stat].displayProperties.icon}
+                    />
                     {statDefs[stat].displayProperties.name}
                   </>
                 }

--- a/src/app/loadout-builder/generated-sets/TierSelect.tsx
+++ b/src/app/loadout-builder/generated-sets/TierSelect.tsx
@@ -139,7 +139,7 @@ function MinMaxSelectInner({
   handleTierChange
 }: {
   stat: string;
-  type: string;
+  type: 'Min' | 'Max';
   min: number;
   max: number;
   stats: { [statType in StatTypes]: MinMax };
@@ -167,7 +167,11 @@ function MinMaxSelectInner({
         t('LoadoutBuilder.SelectMax')
        */}
       {_.range(min, max + 1).map((tier) => (
-        <option key={tier}>{tier}</option>
+        <option key={tier} value={tier}>
+          {t('LoadoutBuilder.TierNumber', {
+            tier
+          })}
+        </option>
       ))}
     </select>
   );

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -75,7 +75,7 @@ export function filterGeneratedSets(
       compareBy(
         (s: ArmorSet) =>
           // Total tier
-          -_.sum(Object.values(s.stats))
+          -calculateTier(s.stats)
       ),
       ...statOrder.map((stat) => compareBy((s: ArmorSet) => -s.stats[stat]))
     )
@@ -281,4 +281,12 @@ export function isLoadoutBuilderItem(item: DimItem) {
   return (
     item.isDestiny2() && item.sockets && (item.bucket.inArmor || item.bucket.hash === 4023194814)
   );
+}
+
+/**
+ * The "Tier" of a set takes into account that each stat only ticks over to a new effective value
+ * every 10.
+ */
+export function calculateTier(stats: ArmorSet['stats']) {
+  return _.sum(Object.values(stats).map((s) => Math.floor(s / 10)));
 }

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -96,24 +96,13 @@ function getBestSets(
 ): ArmorSet[] {
   // Remove sets that do not match tier filters
   let sortedSets: ArmorSet[];
-  if (
-    stats.Mobility.min === 0 &&
-    stats.Resilience.min === 0 &&
-    stats.Recovery.min === 0 &&
-    stats.Mobility.max === 10 &&
-    stats.Resilience.max === 10 &&
-    stats.Recovery.max === 10
-  ) {
+  if (Object.values(stats).every((s) => s.min === 0 && s.max === 100)) {
     sortedSets = Array.from(setMap);
   } else {
     sortedSets = setMap.filter((set) => {
-      return (
-        stats.Mobility.min <= set.stats.Mobility &&
-        stats.Mobility.max >= set.stats.Mobility &&
-        stats.Resilience.min <= set.stats.Resilience &&
-        stats.Resilience.max >= set.stats.Resilience &&
-        stats.Recovery.min <= set.stats.Recovery &&
-        stats.Recovery.max >= set.stats.Recovery
+      return _.every(
+        stats,
+        (value, key) => value.min <= set.stats[key] && value.max >= set.stats[key]
       );
     });
   }

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -96,13 +96,13 @@ function getBestSets(
 ): ArmorSet[] {
   // Remove sets that do not match tier filters
   let sortedSets: ArmorSet[];
-  if (Object.values(stats).every((s) => s.min === 0 && s.max === 100)) {
+  if (Object.values(stats).every((s) => s.min === 0 && s.max === 10)) {
     sortedSets = Array.from(setMap);
   } else {
     sortedSets = setMap.filter((set) => {
       return _.every(
         stats,
-        (value, key) => value.min <= set.stats[key] && value.max >= set.stats[key]
+        (value, key) => 10 * value.min <= set.stats[key] && 10 * value.max >= set.stats[key]
       );
     });
   }
@@ -277,5 +277,9 @@ export function isLoadoutBuilderItem(item: DimItem) {
  * every 10.
  */
 export function calculateTier(stats: ArmorSet['stats']) {
-  return _.sum(Object.values(stats).map((s) => Math.floor(s / 10)));
+  return _.sum(Object.values(stats).map(statTier));
+}
+
+export function statTier(stat: number) {
+  return Math.floor(stat / 10);
 }

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -8,6 +8,7 @@ import {
   ItemsByBucket,
   LockedMap
 } from './types';
+import { statTier } from './generated-sets/utils';
 
 export const statHashes: { [type in StatTypes]: number } = {
   Mobility: 2996146975,
@@ -203,7 +204,11 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
     }
   }
 
-  const groupedSets = _.groupBy(setMap, (set) => Object.values(set.stats).join(','));
+  const groupedSets = _.groupBy(setMap, (set) =>
+    Object.values(set.stats)
+      .map(statTier)
+      .join(',')
+  );
 
   type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -8,12 +8,14 @@ import {
   ItemsByBucket,
   LockedMap
 } from './types';
-import { filterPlugs } from './generated-sets/utils';
 
 export const statHashes: { [type in StatTypes]: number } = {
   Mobility: 2996146975,
   Resilience: 392767087,
-  Recovery: 1943323491
+  Recovery: 1943323491,
+  Discipline: 1735777505,
+  Intellect: 144602215,
+  Strength: 4244567218
 };
 export const statValues = Object.values(statHashes);
 export const statKeys = Object.keys(statHashes) as StatTypes[];
@@ -52,20 +54,7 @@ export function filterItems(
     // filter out low-tier items and items without extra perks on them
     if (requirePerks) {
       filteredItems[bucket] = filteredItems[bucket].filter(
-        (item) =>
-          item &&
-          item.isDestiny2() &&
-          ['Exotic', 'Legendary'].includes(item.tier) &&
-          item.sockets &&
-          item.sockets.categories &&
-          item.sockets.categories.length === 2 &&
-          item.sockets.sockets
-            .filter(filterPlugs)
-            // this will exclude the deprecated pre-forsaken mods
-            .filter(
-              (socket) =>
-                socket.plug && !socket.plug.plugItem.itemCategoryHashes.includes(4104513227)
-            ).length
+        (item) => item && item.isDestiny2() && ['Exotic', 'Legendary'].includes(item.tier)
       );
     }
   });

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -2,7 +2,13 @@ import { DimItem } from '../inventory/item-types';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 
-export type StatTypes = 'Mobility' | 'Resilience' | 'Recovery';
+export type StatTypes =
+  | 'Mobility'
+  | 'Resilience'
+  | 'Recovery'
+  | 'Discipline'
+  | 'Intellect'
+  | 'Strength';
 export type BurnTypes = 'arc' | 'solar' | 'void';
 
 export interface MinMax {


### PR DESCRIPTION
This fixes up the loadout optimizer for Shadowkeep:

1. Don't filter out Armor 2.0.
2. Include new stats everywhere.
2. Group and filter by tiers, not by raw stat values.

<img width="1403" alt="Screen Shot 2019-10-10 at 9 58 57 PM" src="https://user-images.githubusercontent.com/313208/66625476-33a59200-eba9-11e9-9fa4-c67e0aca85ad.png">