### PR TITLE
Fix mods and plugsets on collections page

### DIFF
--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -119,21 +119,6 @@ class Collections extends React.Component<Props, State> {
       );
     }
 
-    // TODO: a lot of this processing should happen at setState, not render?
-
-    const plugSetHashes = new Set(
-      profileResponse.profilePlugSets.data
-        ? Object.keys(profileResponse.profilePlugSets.data.plugs)
-        : []
-    );
-    if (profileResponse.characterPlugSets.data) {
-      _.forIn(profileResponse.characterPlugSets.data, (plugSet) => {
-        Object.keys(plugSet.plugs).forEach((plugSetHash) => {
-          plugSetHashes.add(plugSetHash);
-        });
-      });
-    }
-
     const presentationNodeHash = transition && transition.params().presentationNodeHash;
 
     return (
@@ -142,7 +127,7 @@ class Collections extends React.Component<Props, State> {
           <Catalysts defs={defs} profileResponse={profileResponse} />
         </ErrorBoundary>
         <ErrorBoundary name="Mods">
-          <Mods />
+          <Mods profileResponse={profileResponse} />
         </ErrorBoundary>
         <ErrorBoundary name="Collections">
           <PresentationNodeRoot
@@ -151,8 +136,8 @@ class Collections extends React.Component<Props, State> {
             profileResponse={profileResponse}
             buckets={buckets}
             ownedItemHashes={ownedItemHashes}
-            plugSetHashes={plugSetHashes}
             openedPresentationHash={presentationNodeHash}
+            showPlugSets={true}
           />
           <PresentationNodeRoot
             presentationNodeHash={498211331}

--- a/src/app/collections/PlugSet.tsx
+++ b/src/app/collections/PlugSet.tsx
@@ -11,11 +11,20 @@ import BungieImage from '../dim-ui/BungieImage';
 import { AppIcon, expandIcon, collapseIcon } from '../shell/icons';
 import { percent } from '../shell/filters';
 import clsx from 'clsx';
+import { chainComparator, compareBy } from 'app/utils/comparators';
+
+const plugSetOrder = chainComparator(
+  compareBy((i: VendorItem) => i.item && i.item.tier),
+  compareBy((i: VendorItem) => i.item && i.item.name)
+);
 
 interface Props {
   defs: D2ManifestDefinitions;
   buckets: InventoryBuckets;
-  plugSetHash: number;
+  plugSetCollection: {
+    hash: number;
+    displayItem: number;
+  };
   items: DestinyItemPlug[];
   path: number[];
   onNodePathSelected(nodePath: number[]);
@@ -27,11 +36,12 @@ interface Props {
 export default function PlugSet({
   defs,
   buckets,
-  plugSetHash,
+  plugSetCollection,
   items,
   path,
   onNodePathSelected
 }: Props) {
+  const plugSetHash = plugSetCollection.hash;
   const plugSetDef = defs.PlugSet.get(plugSetHash);
 
   const vendorItems = plugSetDef.reusablePlugItems.map((i) =>
@@ -43,13 +53,15 @@ export default function PlugSet({
     )
   );
 
+  vendorItems.sort(plugSetOrder);
+
   const acquired = count(vendorItems, (i) => i.canPurchase);
   const childrenExpanded = path.includes(plugSetHash);
+  const displayItem = defs.InventoryItem.get(plugSetCollection.displayItem);
 
   const title = (
     <span className="node-name">
-      <BungieImage src={defs.InventoryItem.get(3960522253).displayProperties.icon} />{' '}
-      {plugSetDef.displayProperties.name}
+      <BungieImage src={displayItem.displayProperties.icon} /> {displayItem.displayProperties.name}
     </span>
   );
 
@@ -77,7 +89,7 @@ export default function PlugSet({
       </div>
       {childrenExpanded && (
         <div className="collectibles plugset">
-          {_.sortBy(vendorItems, (i) => i.displayProperties.name).map((item) => (
+          {vendorItems.map((item) => (
             <VendorItemComponent key={item.key} defs={defs} item={item} owned={false} />
           ))}
         </div>

--- a/src/app/collections/PresentationNodeRoot.tsx
+++ b/src/app/collections/PresentationNodeRoot.tsx
@@ -22,8 +22,8 @@ interface Props {
   buckets?: InventoryBuckets;
   defs: D2ManifestDefinitions;
 
-  // This is a hack because emotes aren't in the Collections
-  plugSetHashes?: Set<string>;
+  /** Whether to show extra plugsets */
+  showPlugSets?: boolean;
 }
 
 interface State {
@@ -44,7 +44,7 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
       buckets,
       profileResponse,
       ownedItemHashes,
-      plugSetHashes
+      showPlugSets
     } = this.props;
     const { nodePath } = this.state;
 
@@ -64,6 +64,13 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
     const collectionCounts = countCollectibles(defs, presentationNodeHash, profileResponse);
 
     const trackedRecordHash = idx(profileResponse, (p) => p.profileRecords.data.trackedRecordHash);
+
+    const plugSetCollections = [
+      // Emotes
+      { hash: 1155321287, displayItem: 3960522253 },
+      // Projections
+      { hash: 499268600, displayItem: 2544954628 }
+    ];
 
     return (
       <>
@@ -94,14 +101,14 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
         />
 
         {buckets &&
-          plugSetHashes &&
-          Array.from(plugSetHashes).map((plugSetHash) => (
+          showPlugSets &&
+          plugSetCollections.map((plugSetCollection) => (
             <PlugSet
-              key={plugSetHash}
+              key={plugSetCollection.hash}
               defs={defs}
               buckets={buckets}
-              plugSetHash={Number(plugSetHash)}
-              items={itemsForPlugSet(profileResponse, Number(plugSetHash))}
+              plugSetCollection={plugSetCollection}
+              items={itemsForPlugSet(profileResponse, Number(plugSetCollection.hash))}
               path={fullNodePath}
               onNodePathSelected={this.onNodePathSelected}
             />

--- a/src/app/shell/page.scss
+++ b/src/app/shell/page.scss
@@ -3,6 +3,7 @@
 .dim-static-page {
   padding: 16px 1em;
   font-size: 14px;
+  user-select: auto;
 
   .about-logo {
     float: left;


### PR DESCRIPTION
This fixes the collections page post-Shadowkeep:

1. Mods light up when you own them again, even if they're just an unlock.
2. We don't show a ton of useless plugsets in collections.
3. Added Ghost Projections to collections.