### PR TITLE
Fix current triumph interval progress to match in-game UI

### DIFF
--- a/src/app/collections/Record.tsx
+++ b/src/app/collections/Record.tsx
@@ -209,23 +209,27 @@ function getIntervals(
 
   const intervals: RecordInterval[] = [];
   let isPrevIntervalComplete = true;
+  let prevIntervalProgress = 0;
   for (let i = 0; i < intervalDefinitions.length; i++) {
     const def = intervalDefinitions[i];
     const data = intervalObjectives[i];
 
-    const progress = data.progress || 0;
     intervals.push({
       objective: data,
       score: def.intervalScoreValue,
       percentCompleted: isPrevIntervalComplete
         ? data.complete
           ? 1
-          : Math.max(0, progress / data.completionValue)
+          : Math.max(
+              0,
+              (data.progress - prevIntervalProgress) / (data.completionValue - prevIntervalProgress)
+            )
         : 0,
       isRedeemed: record.intervalsRedeemedCount >= i + 1
     });
 
     isPrevIntervalComplete = data.complete;
+    prevIntervalProgress = data.completionValue;
   }
   return intervals;
 }


### PR DESCRIPTION
This PR fixes a bug with interval triumphs whereby the progress bar segment representing the current (first incomplete) interval is inaccurate. It is displaying total progress until the interval's completion value instead of progress **since the last interval** until the interval's completion value.

Before:
![dim-interval-triumph-progress-incorrect](https://user-images.githubusercontent.com/17512262/66712159-09481480-edf5-11e9-8143-92d3fa69ea78.PNG)

`Final interval progress = 11 / 20 = 55%`

After:
![dim-interval-triumph-progress-correct](https://user-images.githubusercontent.com/17512262/66712161-0cdb9b80-edf5-11e9-83d0-bb118ee859c6.PNG)

`Final interval progress = (11 - 10) / 20 = 5%`