### PR TITLE
Tidy mods

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -817,7 +817,8 @@
     "DestinySets": "Browse more item sets at Destiny Sets",
     "Engram": "Reward Engram",
     "FilterToUnacquired": "Only show uncollected items",
-    "Vendors": "Vendors"
+    "Vendors": "Vendors",
+    "Year2Mods": "Year 2 Mods"
   },
   "Views": {
     "About": {

--- a/src/app/collections/Mod.tsx
+++ b/src/app/collections/Mod.tsx
@@ -56,6 +56,12 @@ export default function Collectible({ inventoryItem, defs, buckets, owned, onAnI
 
   item.missingSockets = false;
 
+  // for y3 mods, hide the icon for being equipped on an item
+  // all weapon mods (ItemCategory [610365472] Weapon Mods) are now y3 mods
+  const modDef = defs.InventoryItem.get(item.hash);
+  if (modDef.itemCategoryHashes.includes(610365472) || modDef.plug.energyCost) {
+    onAnItem = false;
+  }
   return (
     <VendorItemDisplay
       item={item}

--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import Mod from './Mod';
 import { chainComparator, compareBy } from 'app/utils/comparators';
+import { t } from 'app/i18next-t';
 
 const armorPieceGroups = [
   1362265421, // ItemCategory "Armor Mods: Helmet"
@@ -235,7 +236,7 @@ function Mods({ defs, buckets, allMods, ownedMods, modsOnItems, profileResponse 
             </div>
           </>
         ))}
-        <div className="title">Old Mods</div>
+        <div className="title">{t('Vendors.Year2Mods')}</div>
         <div className="collectibles">
           {byGroup.armor1.sort(sortMods).map((mod) => (
             <Mod

--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -16,6 +16,16 @@ import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import Mod from './Mod';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 
+const armorPieceGroups = [
+  1362265421, // ItemCategory "Armor Mods: Helmet"
+  3872696960, // ItemCategory "Armor Mods: Gauntlets"
+  3723676689, // ItemCategory "Armor Mods: Chest"
+  3607371986, // ItemCategory "Armor Mods: Legs"
+  3196106184 // ItemCategory "Armor Mods: Class"
+];
+const armorPieceDisplayOrder = [...armorPieceGroups, 4104513227]; // ItemCategory "Armor Mods"
+
+// to-do: separate mod name from its "enhanced"ness, maybe with d2ai? so they can be grouped better
 const sortMods = chainComparator(
   compareBy((i: DestinyInventoryItemDefinition) => i.itemTypeDisplayName),
   compareBy((i: DestinyInventoryItemDefinition) => i.displayProperties.name)
@@ -135,15 +145,40 @@ function Mods({ defs, buckets, allMods, ownedMods, modsOnItems, profileResponse 
     mods.add(mod.hash);
   }
 
-  allMods = Array.from(mods).map((i) => defs.InventoryItem.get(i));
+  allMods = Array.from(mods)
+    .map((i) => defs.InventoryItem.get(i))
+    // exclude artifact mods. they aren't earned or kept, just rented from the artifact for seasonal use
+    .filter((mod) => mod.inventory.bucketTypeHash !== 2401704334);
+
+  // make a list of seasonal mod types like ["Opulent Armor Mod"]
+  const seasonalModCategories = [
+    ...new Set(
+      allMods
+        .filter((mod) => /^enhancements\.season_/.test(mod.plug.plugCategoryIdentifier))
+        .map((mod) => mod.itemTypeDisplayName)
+    )
+  ];
 
   const byGroup = _.groupBy(allMods, (i) =>
-    i.itemCategoryHashes.includes(610365472) ? 'weapons' : 'armor'
+    i.itemCategoryHashes.includes(610365472)
+      ? 'weapons'
+      : i.itemCategoryHashes.includes(4104513227) && i.plug.energyCost
+      ? 'armor2'
+      : i.itemCategoryHashes.includes(4104513227) && !i.plug.energyCost
+      ? 'armor1'
+      : 'reject_bin'
+  );
+  // group by armor piece, seasonal mod slot, or fallback to general armor
+  const armorV2ByPieceCategoryHash = _.groupBy(
+    byGroup.armor2,
+    (i) =>
+      i.itemCategoryHashes.find((hash) => armorPieceGroups.includes(hash)) ||
+      (seasonalModCategories.includes(i.itemTypeDisplayName) && i.itemTypeDisplayName) ||
+      4104513227
   );
 
   const modsTitle = defs.ItemCategory.get(56).displayProperties.name;
   const weaponModsTitle = defs.ItemCategory.get(610365472).displayProperties.name;
-  const armorModsTitle = defs.ItemCategory.get(4104513227).displayProperties.name;
 
   return (
     <CollapsibleTitle title={modsTitle} sectionId="mods">
@@ -163,9 +198,46 @@ function Mods({ defs, buckets, allMods, ownedMods, modsOnItems, profileResponse 
         </div>
       </div>
       <div className="presentation-node always-expanded mods">
-        <div className="title">{armorModsTitle}</div>
+        {armorPieceDisplayOrder.map((categoryHash) => (
+          <>
+            <div className="title">
+              {defs.ItemCategory.get(categoryHash) &&
+                defs.ItemCategory.get(categoryHash).displayProperties.name}
+            </div>
+            <div key={categoryHash} className="collectibles">
+              {armorV2ByPieceCategoryHash[categoryHash].sort(sortMods).map((mod) => (
+                <Mod
+                  key={mod.hash}
+                  inventoryItem={mod}
+                  defs={defs}
+                  buckets={buckets}
+                  owned={ownedMods.has(mod.hash)}
+                  onAnItem={modsOnItems.has(mod.hash)}
+                />
+              ))}
+            </div>
+          </>
+        ))}
+        {seasonalModCategories.map((seasonalModName) => (
+          <>
+            <div className="title">{seasonalModName}</div>
+            <div key={seasonalModName} className="collectibles">
+              {armorV2ByPieceCategoryHash[seasonalModName].sort(sortMods).map((mod) => (
+                <Mod
+                  key={mod.hash}
+                  inventoryItem={mod}
+                  defs={defs}
+                  buckets={buckets}
+                  owned={ownedMods.has(mod.hash)}
+                  onAnItem={modsOnItems.has(mod.hash)}
+                />
+              ))}
+            </div>
+          </>
+        ))}
+        <div className="title">Old Mods</div>
         <div className="collectibles">
-          {byGroup.armor.sort(sortMods).map((mod) => (
+          {byGroup.armor1.sort(sortMods).map((mod) => (
             <Mod
               key={mod.hash}
               inventoryItem={mod}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -816,7 +816,8 @@
     "DestinySets": "Browse more item sets at Destiny Sets",
     "Engram": "Reward Engram",
     "FilterToUnacquired": "Only show uncollected items",
-    "Vendors": "Vendors"
+    "Vendors": "Vendors",
+    "Year2Mods": "Year 2 Mods"
   },
   "Views": {
     "About": {


### PR DESCRIPTION
closes #4446
categorizes mods section of collection screen. @vivekhnz is right levi & riven mods should be filtered but i think that'll end up being a per-mod blacklist thing or maybe based on slot compatibility so a step at a time
note: contrary to screenshot  "old mods" string actually says "year 2 mods"
![image](https://user-images.githubusercontent.com/31990469/66722908-0f73cc00-edc8-11e9-8b55-d35ce3d10e2c.png)
