### PR TITLE
Revert "Use new dupe function to allow selecting Loadout replacements"

### DIFF
--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -36,7 +36,6 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { DimStore } from '../inventory/store-types';
 import LoadoutDrawerContents from './LoadoutDrawerContents';
 import LoadoutDrawerOptions from './LoadoutDrawerOptions';
-import { makeDupeID } from 'app/search/search-filters';
 
 interface StoreProps {
   types: string[];
@@ -268,10 +267,9 @@ class LoadoutDrawer extends React.Component<Props, State> {
     const loadoutClassType = loadout && loadoutClassToClassType[loadout.classType];
 
     try {
-      const warnItemDupeID = makeDupeID(warnItem);
       const { item, equip } = await showItemPicker({
         filterItems: (item: DimItem) =>
-          makeDupeID(item) === warnItemDupeID &&
+          item.hash === warnItem.hash &&
           item.canBeInLoadout() &&
           (!loadout ||
             loadout.classType === LoadoutClass.any ||


### PR DESCRIPTION
This reverts commit 45b1017a31926f33dc575eaed78b333db1a6d945.

Fixes #4458. It was clearly not a valid solution for https://github.com/DestinyItemManager/DIM/issues/4392, because `warnItem`s aren't really full DimItems.