### PR TITLE
Sharper sheets

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -136,8 +136,9 @@ class Compare extends React.Component<Props, State> {
     const stats = this.getAllStatsSelector(this.state, this.props);
 
     return (
-      <Sheet onClose={this.cancel}>
-        <div id="loadout-drawer" className="compare">
+      <Sheet
+        onClose={this.cancel}
+        header={
           <div className="compare-options">
             {archetypes.length > 1 && (
               <button className="dim-button" onClick={(e) => this.compareSimilar(e, 'archetype')}>
@@ -155,6 +156,9 @@ class Compare extends React.Component<Props, State> {
               </button>
             )}
           </div>
+        }
+      >
+        <div id="loadout-drawer" className="compare">
           <div className="compare-bucket" onMouseLeave={() => this.setHighlight(undefined)}>
             <div className="compare-item fixed-left">
               <div className="spacer" />

--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -1,9 +1,8 @@
 @import '../variables.scss';
 
 #loadout-drawer.compare {
-  padding-left: 1em;
-  padding-right: 1em;
-  padding-top: 14px;
+  padding-left: 10px;
+  padding-top: 8px;
   @include max-sheet-height;
 }
 
@@ -19,6 +18,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     padding-right: 4px;
+    padding-left: 0;
   }
   .talent-grid {
     padding: 4px 2px 0 2px;
@@ -38,7 +38,7 @@
     margin-bottom: 4px;
   }
   .sheet & {
-    padding-right: 38px;
+    padding-right: 48px;
   }
 }
 

--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -3,8 +3,6 @@
 $control-color: rgba(255, 255, 255, 0.5);
 
 .sheet {
-  $corner-radius: 15px;
-
   // 100vh isn't really useful on Safari. We'll do this in code.
   // max-height: calc(100vh - #{$header-height} - 88px);
   left: 0;
@@ -16,33 +14,14 @@ $control-color: rgba(255, 255, 255, 0.5);
   background-color: black;
   color: #e0e0e0;
   box-shadow: 0 -1px 24px 0px #222;
-  // 10px below the character header
-  border-top-left-radius: $corner-radius;
-  border-top-right-radius: $corner-radius;
   user-select: none;
   overflow: hidden;
-
-  .sheet-handle {
-    z-index: 1;
-    position: absolute;
-    top: -3px;
-    left: 50%;
-    margin-left: -18px;
-    height: 5px;
-    width: 36px;
-    padding: 8px;
-    cursor: ns-resize;
-    > div {
-      width: 100%;
-      height: 100%;
-      background-color: $control-color;
-      border-radius: 2.5px;
-    }
-  }
 
   .sheet-header {
     padding: 14px 10px 8px 10px;
     border-bottom: 1px solid #333;
+    border-top: 5px solid $control-color;
+    cursor: grab;
 
     h1 {
       @include destiny-header;
@@ -108,7 +87,7 @@ $control-color: rgba(255, 255, 255, 0.5);
     position: absolute;
     right: 0;
     top: 0;
-    padding: 8px;
+    padding: 18px 12px 12px 12px;
     color: $control-color;
     .app-icon {
       height: 24px;

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -110,13 +110,9 @@ class Sheet extends React.Component<Props & GestureState> {
               <AppIcon icon={disabledIcon} />
             </div>
 
-            <div className="sheet-handle" ref={this.dragHandle}>
-              <div />
-            </div>
-
             <div className="sheet-container" style={{ maxHeight }}>
               {header && (
-                <div className="sheet-header">
+                <div className="sheet-header" ref={this.dragHandle}>
                   {_.isFunction(header) ? header({ onClose: this.onClose }) : header}
                 </div>
               )}
@@ -163,7 +159,7 @@ class Sheet extends React.Component<Props & GestureState> {
     }
 
     if (
-      this.dragHandle.current!.contains(e.target as Node) ||
+      (this.dragHandle.current && this.dragHandle.current.contains(e.target as Node)) ||
       this.sheetContents.current!.scrollTop === 0
     ) {
       this.setState({ dragging: true });

--- a/src/app/inventory/MoveAmountPopupContainer.scss
+++ b/src/app/inventory/MoveAmountPopupContainer.scss
@@ -4,17 +4,10 @@
   max-width: 375px;
   margin: 0 auto;
 
-  h1 {
-    display: flex;
-    align-items: flex-start;
-    padding-bottom: 1em;
-    padding-left: 10px;
-    font-size: 1.5em;
-    padding-right: 38px;
-  }
   .item {
     margin-right: 0.5em;
     flex-shrink: 0;
+    float: left;
   }
   .buttons {
     text-align: center;

--- a/src/app/inventory/MoveAmountPopupContainer.tsx
+++ b/src/app/inventory/MoveAmountPopupContainer.tsx
@@ -48,15 +48,20 @@ export default class MoveAmountPopupContainer extends React.Component<{}, State>
     const stacksWorth = Math.min(Math.max(-targetAmount, 0), maximum);
 
     return (
-      <Sheet onClose={this.onClose} sheetClassName="move-amount-popup">
+      <Sheet
+        onClose={this.onClose}
+        header={
+          <h1>
+            <div className="item">
+              <BungieImage className="item-img" src={item.icon} />
+            </div>
+            <span>{t('StoreBucket.HowMuch', { itemname: item.name })}</span>
+          </h1>
+        }
+        sheetClassName="move-amount-popup"
+      >
         {({ onClose }) => (
           <>
-            <h1>
-              <div className="item">
-                <BungieImage className="item-img" src={item.icon} />
-              </div>
-              <span>{t('StoreBucket.HowMuch', { itemname: item.name })}</span>
-            </h1>
             <ItemMoveAmount
               amount={amount}
               maximum={maximum}

--- a/src/app/item-popup/ItemPopupHeader.scss
+++ b/src/app/item-popup/ItemPopupHeader.scss
@@ -142,7 +142,7 @@ $icon-bg-shadow: rgba(0, 0, 0, 1);
 
   .sheet & {
     padding-top: 14px;
-    padding-right: 38px;
+    padding-right: 48px;
   }
 
   &.masterwork {


### PR DESCRIPTION
Following some discussion on the design channel, here's an alternate look for sheets.

1. No round corners.
2. A grey bar at the top (which could be colored) for separating from the background (and calling back to Destiny UI).
3. No more grab handle. The entire header will use the grab cursor.
4. Spaced out the close button a bit more.

<img width="847" alt="Screen Shot 2019-10-13 at 6 30 34 PM" src="https://user-images.githubusercontent.com/313208/66725501-a69c4c00-ede7-11e9-8c82-d3497c6cb601.png">
<img width="279" alt="Screen Shot 2019-10-13 at 6 30 49 PM" src="https://user-images.githubusercontent.com/313208/66725502-a69c4c00-ede7-11e9-9fbc-ee183b67bbba.png">
<img width="284" alt="Screen Shot 2019-10-13 at 6 30 59 PM" src="https://user-images.githubusercontent.com/313208/66725503-a69c4c00-ede7-11e9-83d6-d416c14cebd8.png">
