### PR TITLE
Searching new, optional, wish list notes

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -314,6 +314,7 @@
     "WeaponType": "Shows weapons based on their weapon type.",
     "Wishlist": "Shows items that match your wish list.",
     "WishlistDupe": "Shows duplicate items where at least one of the duplicates is on your wish list.",
+    "WishlistNotes": "Shows wish listed items whose notes match the search.",
     "Year": "Shows items from which year of Destiny they appeared in."
   },
   "Ghost": {

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -94,7 +94,8 @@
     "ImportNoFile": "No file selected.",
     "ImportSuccess": "Wish list loaded with information about one roll.{{titleAndDescription}}",
     "ImportSuccess_plural": "Wish list loaded with information about {{count}} rolls.{{titleAndDescription}}",
-    "Num": "{{num, number}} rolls in your wish list"
+    "Num": "{{num, number}} rolls in your wish list",
+    "WishListNotes": "Wish List Notes: {{notes}}"
   },
   "DtrReview": {
     "AverageRating": "({{itemRating}}) based on {{numRatings}} ratings.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 * `wishlistnotes:` will find wish list items where the underlying wish list item had the given notes on them.
+
 # 5.50.1 (2019-10-14)
 
 * Made it possible to filter to Tier 0 in Loadout Optimizer.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* `wishlistnotes:` will find wish list items where the underlying wish list item had the given notes on them.
+
 # 5.50.0 (2019-10-13)
 
 * It's beginning to feel a lot like Year Three.

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -13,7 +13,7 @@ Feel free to share your curated lists with your fireteam, the raid you're sherpa
 
 ## Premade Lists
 
-If you want to hit the ground running, you can find a collection of breakdowns from u/pandapaxxy and u/mercules904 translated into wish lists over on [48klocs' gists - in particular, the voltron.txt file (that includes armor recommendations from u/HavocsCall) will probably be of interest](https://gist.github.com/48klocs/). Feel free to mix and match the individual files as you like.
+If you want to hit the ground running, you can find a collection of breakdowns from u/pandapaxxy and u/mercules904 translated into wish lists over on [48klocs' DIM wish list sources - in particular, the voltron.txt file (that includes armor recommendations from u/HavocsCall) will probably be of interest](https://github.com/48klocs/dim-wish-list-sources). Feel free to mix and match the individual files as you like.
 
 ## Linking To Banshee-44 from DIM
 
@@ -34,6 +34,10 @@ We only look for title/description in the first few lines of your file, so don't
 
 If you want to add comments in your text file on separate lines, go ahead! We'll ignore any line that isn't a link to banshee-44, so you can put notes for which item+roll you're talking about.
 
+## Notes
+
+If you want to add searchable notes, end the line with `#notes:Here are some notes`.
+
 ## "Expert Mode"
 
 **Please note: you're largely on your own with this option. It's called expert mode for a reason, people.**
@@ -41,6 +45,10 @@ If you want to add comments in your text file on separate lines, go ahead! We'll
 If you're feeling particularly saucy, I've added an "expert mode" line format. You can put add lines with this alternate format in file with banshee-44 links and comments and it'll all be read together. The format looks like...
 
 `dimwishlist:item=1234&perks=456,567`
+
+If you want notes, it'd be...
+
+`dimwishlist:item=1234&perks=456,567#notes:pvp or gambit`
 
 Do not expect it to be flexible with casing or naming (it's not).
 

--- a/src/app/item-popup/ItemDescription.m.scss
+++ b/src/app/item-popup/ItemDescription.m.scss
@@ -34,6 +34,11 @@
   font-style: italic;
 }
 
+.wishListNotes {
+  composes: description;
+  font-style: italic;
+}
+
 .lore {
   flex: 1;
   img {

--- a/src/app/item-popup/ItemDescription.m.scss.d.ts
+++ b/src/app/item-popup/ItemDescription.m.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'descriptionTools': string;
   'lore': string;
   'officialDescription': string;
+  'wishListNotes': string;
 }
 declare const cssExports: CssExports;
 export = cssExports;

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -10,6 +10,8 @@ import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
 import { connect } from 'react-redux';
 import { getNotes } from 'app/inventory/dim-item-info';
 import { RootState } from 'app/store/reducers';
+import { inventoryCuratedRollsSelector } from 'app/wishlists/reducer';
+import { InventoryCuratedRoll } from 'app/wishlists/wishlists';
 
 interface ProvidedProps {
   item: DimItem;
@@ -17,15 +19,19 @@ interface ProvidedProps {
 
 interface StoreProps {
   notes?: string;
+  inventoryCuratedRoll?: InventoryCuratedRoll;
 }
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
-  return { notes: getNotes(props.item, state.inventory.itemInfos) };
+  return {
+    notes: getNotes(props.item, state.inventory.itemInfos),
+    inventoryCuratedRoll: inventoryCuratedRollsSelector(state)[props.item.id]
+  };
 }
 
 type Props = ProvidedProps & StoreProps;
 
-function ItemDescription({ item, notes }: Props) {
+function ItemDescription({ item, notes, inventoryCuratedRoll }: Props) {
   const showDescription = Boolean(item.description && item.description.length);
 
   const loreLink = item.loreHash
@@ -42,6 +48,13 @@ function ItemDescription({ item, notes }: Props) {
       {item.isDestiny2() && item.displaySource && item.displaySource.length > 0 && (
         <div className={styles.officialDescription}>{item.displaySource}</div>
       )}
+      {inventoryCuratedRoll &&
+        inventoryCuratedRoll.notes &&
+        inventoryCuratedRoll.notes.length > 0 && (
+          <div className={styles.wishListNotes}>
+            {t('CuratedRoll.WishListNotes', { notes: inventoryCuratedRoll.notes })}
+          </div>
+        )}
       {notesOpen ? (
         <NotesForm item={item} notes={notes} />
       ) : (

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -182,6 +182,12 @@ function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
             </tr>
             <tr>
               <td>
+                <span>wishlistnotes:value</span>
+              </td>
+              <td>{t('Filter.WishlistNotes')}</td>
+            </tr>
+            <tr>
+              <td>
                 <span>stack:value</span> <span>stack:&gt;=value</span> <span>stack:&gt;value</span>
                 <span>stack:&lt;value</span> <span>stack:&lt;=value</span>
               </td>

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1168,9 +1168,6 @@ function searchFilters(
       wishlistnotes(item: D2Item, predicate: string) {
         const potentialWishListRoll = inventoryCuratedRolls[item.id];
 
-        if (Boolean(potentialWishListRoll)) {
-          console.log(potentialWishListRoll.notes);
-        }
         return (
           Boolean(potentialWishListRoll) &&
           potentialWishListRoll.notes &&

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -309,7 +309,9 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     ...hashes.energyCapacityTypes.filter(Boolean).map((element) => `energycapacity:${element}`),
     ...operators.map((comparison) => `energycapacity:${comparison}`),
     // "source:" keyword plus one for each source
-    ...(isD2 ? ['source:', ...Object.keys(D2Sources).map((word) => `source:${word}`)] : []),
+    ...(isD2
+      ? ['source:', 'wishlistnotes:', ...Object.keys(D2Sources).map((word) => `source:${word}`)]
+      : []),
     // all the free text searches that support quotes
     ...['notes:', 'perk:', 'perkname:', 'name:', 'description:']
   ];
@@ -527,6 +529,7 @@ function searchFilters(
             case 'perkname':
             case 'name':
             case 'description':
+            case 'wishlistnotes':
               addPredicate(filterName, trimQuotes(filterValue), invert);
               break;
             // normalize synonyms
@@ -1161,6 +1164,18 @@ function searchFilters(
         const itemDupes = _duplicates[dupeId];
 
         return itemDupes.some(this.wishlist);
+      },
+      wishlistnotes(item: D2Item, predicate: string) {
+        const potentialWishListRoll = inventoryCuratedRolls[item.id];
+
+        if (Boolean(potentialWishListRoll)) {
+          console.log(potentialWishListRoll.notes);
+        }
+        return (
+          Boolean(potentialWishListRoll) &&
+          potentialWishListRoll.notes &&
+          potentialWishListRoll.notes.toLocaleLowerCase().includes(predicate)
+        );
       },
       ammoType(item: D2Item, predicate: string) {
         return (

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -29,7 +29,7 @@ export interface CuratedRoll {
   isExpertMode: boolean;
 
   /** Optional notes from the curator. */
-  notes: string | undefined;
+  notes?: string;
 }
 
 export interface WishList {

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -27,6 +27,9 @@ export interface CuratedRoll {
    * sure that at least every perk asked for is there.
    */
   isExpertMode: boolean;
+
+  /** Optional notes. */
+  notes: string | null;
 }
 
 export interface WishList {

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -28,7 +28,7 @@ export interface CuratedRoll {
    */
   isExpertMode: boolean;
 
-  /** Optional notes. */
+  /** Optional notes from the curator. */
   notes: string | undefined;
 }
 

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -29,7 +29,7 @@ export interface CuratedRoll {
   isExpertMode: boolean;
 
   /** Optional notes. */
-  notes: string | null;
+  notes: string | undefined;
 }
 
 export interface WishList {

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -29,7 +29,7 @@ function getPerks(matchResults: RegExpMatchArray): Set<number> {
 }
 
 function getNotes(matchResults: RegExpMatchArray): string | undefined {
-  return Boolean(matchResults[4]) ? matchResults[4] : undefined;
+  return Boolean(matchResults[3]) ? matchResults[3] : undefined;
 }
 
 function getItemHash(matchResults: RegExpMatchArray): number {

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -28,8 +28,8 @@ function getPerks(matchResults: RegExpMatchArray): Set<number> {
   );
 }
 
-function getNotes(matchResults: RegExpMatchArray): string | null {
-  return Boolean(matchResults[4]) ? matchResults[4] : null;
+function getNotes(matchResults: RegExpMatchArray): string | undefined {
+  return Boolean(matchResults[4]) ? matchResults[4] : undefined;
 }
 
 function getItemHash(matchResults: RegExpMatchArray): number {

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -29,7 +29,7 @@ function getPerks(matchResults: RegExpMatchArray): Set<number> {
 }
 
 function getNotes(matchResults: RegExpMatchArray): string | undefined {
-  return Boolean(matchResults[3]) ? matchResults[3] : undefined;
+  return matchResults[3] ? matchResults[3] : undefined;
 }
 
 function getItemHash(matchResults: RegExpMatchArray): number {

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -12,6 +12,7 @@ export interface InventoryCuratedRoll {
   /** What perks did the curator pick for the item? */
   curatedPerks: Set<number>;
 
+  /** What notes (if any) did the curator make for this item + roll? */
   notes: string | undefined;
 }
 

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -11,6 +11,8 @@ import { INTRINSIC_PLUG_CATEGORY } from 'app/inventory/store/sockets';
 export interface InventoryCuratedRoll {
   /** What perks did the curator pick for the item? */
   curatedPerks: Set<number>;
+
+  notes: string | undefined;
 }
 
 let previousCuratedRolls: { [itemHash: number]: CuratedRoll[] } | undefined;
@@ -156,7 +158,8 @@ function getInventoryCuratedRoll(
 
   if (matchingCuratedRoll) {
     return {
-      curatedPerks: getCuratedPlugs(item, matchingCuratedRoll)
+      curatedPerks: getCuratedPlugs(item, matchingCuratedRoll),
+      notes: matchingCuratedRoll.notes
     };
   }
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -314,6 +314,7 @@
     "WeaponType": "Shows weapons based on their weapon type.",
     "Wishlist": "Shows items that match your wish list.",
     "WishlistDupe": "Shows duplicate items where at least one of the duplicates is on your wish list.",
+    "WishlistNotes": "Shows wish listed items whose notes match the search.",
     "Year": "Shows items from which year of Destiny they appeared in."
   },
   "Ghost": {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -94,7 +94,8 @@
     "ImportNoFile": "No file selected.",
     "ImportSuccess": "Wish list loaded with information about one roll.{{titleAndDescription}}",
     "ImportSuccess_plural": "Wish list loaded with information about {{count}} rolls.{{titleAndDescription}}",
-    "Num": "{{num, number}} rolls in your wish list"
+    "Num": "{{num, number}} rolls in your wish list",
+    "WishListNotes": "Wish List Notes: {{notes}}"
   },
   "DtrReview": {
     "AverageRating": "({{itemRating}}) based on {{numRatings}} ratings.",


### PR DESCRIPTION
There's a new, optional, line ending: `#notes:value`, where `value` can be, well, whatever value the person wants to tappity tap on in.

This addresses issue #4306 - the rough idea is that if people want to know that a given roll is getting the wish list thumbs up because they thought it'd be good for PvP or raids or whatever, then they can add notes to the rolls in the source file they load and this will match on up as they're found.

Spoiler alert: newer translations I do of panda's/merc's work will probably have PvP/PvE notes on them.