### PR TITLE
Remove some mobile settings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,7 +16,6 @@ interface Props {
   showReviews: boolean;
   itemQuality: boolean;
   showNewItems: boolean;
-  charColMobile: number;
 }
 
 function mapStateToProps(state: RootState): Props {
@@ -25,8 +24,7 @@ function mapStateToProps(state: RootState): Props {
     language: settings.language,
     showReviews: settings.showReviews,
     itemQuality: settings.itemQuality,
-    showNewItems: settings.showNewItems,
-    charColMobile: settings.charColMobile
+    showNewItems: settings.showNewItems
   };
 }
 
@@ -39,7 +37,7 @@ class App extends React.Component<Props> {
     return (
       <div
         key={`lang-${this.props.language}`}
-        className={clsx(`lang-${this.props.language}`, `char-cols-${this.props.charColMobile}`, {
+        className={clsx(`lang-${this.props.language}`, {
           'show-reviews': $featureFlags.reviewsEnabled && this.props.showReviews,
           itemQuality: this.props.itemQuality,
           'show-new-items': this.props.showNewItems,

--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -25,11 +25,9 @@ export default function updateCSSVariables() {
           setCSSVariable('--tiles-per-char-column', nextState.charCol);
         }
       }
-      if (currentState.charColMobile !== nextState.charColMobile) {
-        // this check is needed so on start up/load this doesn't override the value set above on "normal" mode.
-        if (state.shell.isPhonePortrait) {
-          setCSSVariable('--tiles-per-char-column', nextState.charColMobile);
-        }
+      // this check is needed so on start up/load this doesn't override the value set above on "normal" mode.
+      if (state.shell.isPhonePortrait) {
+        setCSSVariable('--tiles-per-char-column', 4);
       }
 
       if ($featureFlags.colorA11y && currentState.colorA11y !== nextState.colorA11y) {
@@ -49,10 +47,7 @@ export default function updateCSSVariables() {
     (state) => state.shell.isPhonePortrait,
     (_, isPhonePortrait, state) => {
       const settings = state.settings;
-      setCSSVariable(
-        '--tiles-per-char-column',
-        isPhonePortrait ? settings.charColMobile : settings.charCol
-      );
+      setCSSVariable('--tiles-per-char-column', isPhonePortrait ? 4 : settings.charCol);
     }
   );
 }

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -53,24 +53,6 @@
     // sets scroll bar back to auto as the content shift an issue at this size.
     overflow-y: auto;
   }
-
-  .char-cols-3 {
-    --item-margin: 15px;
-    // Padding at the ends of inventory column
-    --inventory-column-padding: 34px;
-    // this is duplicated for .char-cols-3 to recalculate using local var adjustments
-    /* prettier-ignore */
-    --item-size: calc(
-      (
-        100vw -
-        var(--column-padding) -
-        #{$equipped-item-total-outset} -
-        var(--combined-item-margins)
-      ) / (var(--tiles-per-char-column) + 1)
-    ) !important;
-    --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
-    --combined-item-margins: calc(var(--item-margin) * (var(--tiles-per-char-column) + 1));
-  }
 }
 
 @keyframes fade-in {

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -308,54 +308,56 @@ class SettingsPage extends React.Component<Props> {
 
             <section id="inventory">
               <h2>{t('Settings.Inventory')}</h2>
-              <div className="setting">
-                <label>{t('Settings.CharacterOrder')}</label>
-                <div className="radioOptions">
-                  <label>
-                    <input
-                      type="radio"
-                      name="characterOrder"
-                      checked={settings.characterOrder === 'mostRecent'}
-                      value="mostRecent"
-                      onChange={this.onChange}
-                    />
-                    <span>{t('Settings.CharacterOrderRecent')}</span>
-                  </label>
-                  <label>
-                    <input
-                      type="radio"
-                      name="characterOrder"
-                      checked={settings.characterOrder === 'mostRecentReverse'}
-                      value="mostRecentReverse"
-                      onChange={this.onChange}
-                    />
-                    <span>{t('Settings.CharacterOrderReversed')}</span>
-                  </label>
-                  <label>
-                    <input
-                      type="radio"
-                      name="characterOrder"
-                      checked={settings.characterOrder === 'fixed'}
-                      value="fixed"
-                      onChange={this.onChange}
-                    />
-                    <span>{t('Settings.CharacterOrderFixed')}</span>
-                  </label>
-                  <label>
-                    <input
-                      type="radio"
-                      name="characterOrder"
-                      checked={settings.characterOrder === 'custom'}
-                      value="custom"
-                      onChange={this.onChange}
-                    />
-                    <span>{t('Settings.SortCustom')}</span>
-                  </label>
-                  {settings.characterOrder === 'custom' && (
-                    <CharacterOrderEditor onSortOrderChanged={this.characterSortOrderChanged} />
-                  )}
+              {!isPhonePortrait && (
+                <div className="setting">
+                  <label>{t('Settings.CharacterOrder')}</label>
+                  <div className="radioOptions">
+                    <label>
+                      <input
+                        type="radio"
+                        name="characterOrder"
+                        checked={settings.characterOrder === 'mostRecent'}
+                        value="mostRecent"
+                        onChange={this.onChange}
+                      />
+                      <span>{t('Settings.CharacterOrderRecent')}</span>
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        name="characterOrder"
+                        checked={settings.characterOrder === 'mostRecentReverse'}
+                        value="mostRecentReverse"
+                        onChange={this.onChange}
+                      />
+                      <span>{t('Settings.CharacterOrderReversed')}</span>
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        name="characterOrder"
+                        checked={settings.characterOrder === 'fixed'}
+                        value="fixed"
+                        onChange={this.onChange}
+                      />
+                      <span>{t('Settings.CharacterOrderFixed')}</span>
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        name="characterOrder"
+                        checked={settings.characterOrder === 'custom'}
+                        value="custom"
+                        onChange={this.onChange}
+                      />
+                      <span>{t('Settings.SortCustom')}</span>
+                    </label>
+                    {settings.characterOrder === 'custom' && (
+                      <CharacterOrderEditor onSortOrderChanged={this.characterSortOrderChanged} />
+                    )}
+                  </div>
                 </div>
-              </div>
+              )}
 
               {supportsCssVar &&
                 (isPhonePortrait ? (

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -356,18 +356,7 @@ class SettingsPage extends React.Component<Props> {
                 </div>
               )}
 
-              {isPhonePortrait ? (
-                <div className="setting">
-                  <Select
-                    label={t('Settings.InventoryColumnsMobile')}
-                    name="charColMobile"
-                    value={settings.charColMobile}
-                    options={charColOptions}
-                    onChange={this.onChange}
-                  />
-                  <div className="fineprint">{t('Settings.InventoryColumnsMobileLine2')}</div>
-                </div>
-              ) : (
+              {!isPhonePortrait && (
                 <Select
                   label={t('Settings.InventoryColumns')}
                   name="charCol"

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -155,9 +155,6 @@ const colorA11yOptions = $featureFlags.colorA11y
     ])
   : [];
 
-// Edge doesn't support these
-const supportsCssVar = window.CSS && window.CSS.supports && window.CSS.supports('(--foo: red)');
-
 class SettingsPage extends React.Component<Props> {
   private initialLanguage = settings.language;
 
@@ -267,7 +264,7 @@ class SettingsPage extends React.Component<Props> {
                 />
               </div>
 
-              {supportsCssVar && !isPhonePortrait && (
+              {!isPhonePortrait && (
                 <div className="setting">
                   <div className="horizontal itemSize">
                     <label htmlFor="itemSize">{t('Settings.SizeItem')}</label>
@@ -359,27 +356,26 @@ class SettingsPage extends React.Component<Props> {
                 </div>
               )}
 
-              {supportsCssVar &&
-                (isPhonePortrait ? (
-                  <div className="setting">
-                    <Select
-                      label={t('Settings.InventoryColumnsMobile')}
-                      name="charColMobile"
-                      value={settings.charColMobile}
-                      options={charColOptions}
-                      onChange={this.onChange}
-                    />
-                    <div className="fineprint">{t('Settings.InventoryColumnsMobileLine2')}</div>
-                  </div>
-                ) : (
+              {isPhonePortrait ? (
+                <div className="setting">
                   <Select
-                    label={t('Settings.InventoryColumns')}
-                    name="charCol"
-                    value={settings.charCol}
+                    label={t('Settings.InventoryColumnsMobile')}
+                    name="charColMobile"
+                    value={settings.charColMobile}
                     options={charColOptions}
                     onChange={this.onChange}
                   />
-                ))}
+                  <div className="fineprint">{t('Settings.InventoryColumnsMobileLine2')}</div>
+                </div>
+              ) : (
+                <Select
+                  label={t('Settings.InventoryColumns')}
+                  name="charCol"
+                  value={settings.charCol}
+                  options={charColOptions}
+                  onChange={this.onChange}
+                />
+              )}
             </section>
 
             <WishListSettings />

--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -10,7 +10,13 @@ const customCharacterSortSelector = (state: RootState) => state.settings.customC
 export const characterSortSelector = createSelector(
   characterOrderSelector,
   customCharacterSortSelector,
-  (order, customCharacterSort) => {
+  (state: RootState) => state.shell.isPhonePortrait,
+  (order, customCharacterSort, isPhonePortrait) => {
+    // Mobile works best with most-recent, reversed
+    if (isPhonePortrait) {
+      order = 'mostRecentReverse';
+    }
+
     switch (order) {
       case 'mostRecent':
         return (stores: DimStore[]) => _.sortBy(stores, (store) => store.lastPlayed).reverse();

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -31,8 +31,6 @@ export interface Settings {
   readonly itemSortOrderCustom: string[];
   /** How many columns to display character buckets */
   readonly charCol: number;
-  /** How many columns to display character buckets on Mobile */
-  readonly charColMobile: number;
   /** How big in pixels to draw items - start smaller for iPad */
   readonly itemSize: number;
   /** Which categories or buckets should be collapsed? */
@@ -91,8 +89,6 @@ export const initialState: Settings = {
   itemSortOrderCustom: ['primStat', 'name'],
   // How many columns to display character buckets
   charCol: 3,
-  // How many columns to display character buckets on Mobile
-  charColMobile: 4,
   // How big in pixels to draw items - start smaller for iPad
   itemSize: defaultItemSize(),
   // Which categories or buckets should be collapsed?


### PR DESCRIPTION
This removes two settings from phone portrait mode in favor of what I believe are the right settings:

1. Remove character order in favor of most-recent-reversed.
2. Remove number of columns in favor of always using 4.

I recognize that if we end up redesigning the character headers to be more of a buttons/tabs thing this might change again, but for now this seems to have maximum utility.