### PR TITLE
Rename 'Intelligence' stat in spreadsheet export to 'Intellect'

### DIFF
--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -369,9 +369,7 @@ function downloadArmor(
       row.Resilience = stats[armorStatHashes.Resilience]
         ? stats[armorStatHashes.Resilience].value
         : 0;
-      row.Intelligence = stats[armorStatHashes.Intellect]
-        ? stats[armorStatHashes.Intellect].value
-        : 0;
+      row.Intellect = stats[armorStatHashes.Intellect] ? stats[armorStatHashes.Intellect].value : 0;
       row.Discipline = stats[armorStatHashes.Discipline]
         ? stats[armorStatHashes.Discipline].value
         : 0;


### PR DESCRIPTION
The PR renames the **Intelligence** stat column in exported armour spreadsheet to **Intellect**.