### PR TITLE
Switch to pushstate (html5) routing instead of hash locations

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -75,7 +75,8 @@ module.exports = (env) => {
           https: {
             key: fs.readFileSync('key.pem'), // Private keys in PEM format.
             cert: fs.readFileSync('cert.pem') // Cert chains in PEM format.
-          }
+          },
+          historyApiFallback: true
         }
       : {},
 

--- a/src/app/router.config.ts
+++ b/src/app/router.config.ts
@@ -1,4 +1,4 @@
-import { UIRouterReact, servicesPlugin, hashLocationPlugin } from '@uirouter/react';
+import { UIRouterReact, servicesPlugin, pushStateLocationPlugin } from '@uirouter/react';
 import { states } from './routes';
 import { dimNeedsUpdate } from './register-service-worker';
 import { reloadDIM } from './whats-new/WhatsNewLink';
@@ -6,7 +6,7 @@ import { reloadDIM } from './whats-new/WhatsNewLink';
 export default function makeRouter() {
   const router = new UIRouterReact();
   router.plugin(servicesPlugin);
-  router.plugin(hashLocationPlugin);
+  router.plugin(pushStateLocationPlugin);
 
   // Debug visualizer
   if ($featureFlags.debugRouter) {

--- a/src/gdriveReturn.ts
+++ b/src/gdriveReturn.ts
@@ -9,7 +9,7 @@ const drive = {
   fetch_basic_profile: false // eslint-disable-line @typescript-eslint/camelcase
 };
 
-const returnUrl = '/index.html#!/settings?gdrive=true';
+const returnUrl = '/settings?gdrive=true';
 
 if (window.gapi) {
   gapi.load('client:auth2', () => {

--- a/src/htaccess
+++ b/src/htaccess
@@ -720,6 +720,11 @@ AddEncoding br .br
     RewriteEngine On
     RewriteBase /
 
+    # Redirect unknown paths to index.html
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule (.*) index.html
+
     # Serve pre-gzipped stuff if we got it
     # for any request, search for pre-compressed versions (gzip or brotli) and serve that directly if it's supported
 


### PR DESCRIPTION
This switches us away from "hash URLs" towards regular paths. It's not a big deal, but it looks a little nicer and we get to use the HTML5 navigation APIs instead of modifying the hash.