### PR TITLE
Bug hasmod search for 2.0mods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+* 2.0 mods should now be filterable when using hasMod: filter option
 
 # 5.50.1 (2019-10-14)
 

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1143,9 +1143,7 @@ function searchFilters(
                 /(v400.weapon.mod_(guns|damage|magazine)|enhancements.)/
               ) &&
               // enforce that this provides a perk (excludes empty slots)
-              socket.plug.plugItem.perks.length &&
-              // enforce that this doesn't have an energy cost (y3 reusables)
-              !socket.plug.plugItem.plug.energyCost
+              socket.plug.plugItem.perks.length
             );
           })
         );


### PR DESCRIPTION
removed the requirement that prevents mods with energy costs from being shown as valid mods in slots.

Issue with bug in question: https://github.com/DestinyItemManager/DIM/issues/4495 

test case: confirm that filter `has:modded stat:total:>60` works for all valid cases 
* equipment should have stats higher than 60 and not have any mods selected. 
* Confirm that the removed y3 constraint is no longer valid.