### PR TITLE
baseValue in item info & base stat filters

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -199,6 +199,8 @@ export interface D1Item extends DimItem {
  * A Destiny 2 item. Use this type when you need specific D2 properties.
  */
 export interface D2Item extends DimItem {
+  /** D2 items store a base stat for comparing unmodified armor */
+  stats: D2Stat[] | null;
   /** D2 items use sockets and plugs to represent everything from perks to mods to ornaments and shaders. */
   sockets: DimSockets | null;
   /** Some items have a "flavor objective", such as emblems that track stats. */
@@ -298,6 +300,11 @@ export interface D1Stat extends DimStat {
     min: number;
     range: string;
   };
+}
+
+export interface D2Stat extends DimStat {
+  /** Base stat without bonus perks applied. Important for armor. */
+  baseValue: number;
 }
 
 export interface DimObjective {

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -199,8 +199,6 @@ export interface D1Item extends DimItem {
  * A Destiny 2 item. Use this type when you need specific D2 properties.
  */
 export interface D2Item extends DimItem {
-  /** D2 items store a base stat for comparing unmodified armor */
-  stats: DimStat[] | null;
   /** D2 items use sockets and plugs to represent everything from perks to mods to ornaments and shaders. */
   sockets: DimSockets | null;
   /** Some items have a "flavor objective", such as emblems that track stats. */

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -200,7 +200,7 @@ export interface D1Item extends DimItem {
  */
 export interface D2Item extends DimItem {
   /** D2 items store a base stat for comparing unmodified armor */
-  stats: D2Stat[] | null;
+  stats: DimStat[] | null;
   /** D2 items use sockets and plugs to represent everything from perks to mods to ornaments and shaders. */
   sockets: DimSockets | null;
   /** Some items have a "flavor objective", such as emblems that track stats. */
@@ -268,6 +268,8 @@ export interface DimStat {
   sort: number;
   /** Absolute stat value. */
   value: number;
+  /** Base stat without bonus perks applied. Important in D2 for armor. */
+  base: number;
   /** The maximum value this stat can have. */
   maximumValue: number;
   /** Should this be displayed as a bar or just a number? */
@@ -287,8 +289,6 @@ export interface DimStat {
 }
 
 export interface D1Stat extends DimStat {
-  /** Base stat without bonus perks applied. */
-  base: number;
   bonus: number;
   scaled?: {
     max: number;
@@ -300,11 +300,6 @@ export interface D1Stat extends DimStat {
     min: number;
     range: string;
   };
-}
-
-export interface D2Stat extends DimStat {
-  /** Base stat without bonus perks applied. Important for armor. */
-  baseValue: number;
 }
 
 export interface DimObjective {

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -341,29 +341,6 @@ function buildPlugStats(
 }
 
 /**
- * THIS RELIES ON FOLLOWING buildLiveStats, and runs only for armor
- *
- * this takes .base, currently equal to .value, and adjusts it down to make a de-adjusted value
- * representing the raw armor stats before mods changed them
- */
-function buildBaseStats(stats: DimStat[], sockets: DimSocket[]) {
-  for (const socket of sockets) {
-    if (socket.plug && socket.plug.plugItem.investmentStats) {
-      for (const perkStat of socket.plug.plugItem.investmentStats) {
-        const statHash = perkStat.statTypeHash;
-        const itemStat = stats.find((stat) => stat.statHash === statHash);
-        const perkValue = perkStat.value || 0;
-        if (itemStat && itemStat.base > perkValue) {
-          itemStat.base -= perkValue;
-        }
-      }
-    }
-  }
-
-  return stats;
-}
-
-/**
  * Builds stats based on live values API tells us about an item,
  * instead of constructing stuff from manifest, plugs, etc
  */
@@ -413,6 +390,30 @@ function buildLiveStats(
       };
     })
   );
+}
+
+/**
+ * THIS RELIES ON BEING RUN FOLLOWING buildLiveStats, and runs only for armor
+ *
+ * this assumes unenriched live stats, single values based off API reported stats
+ * it takes .base, currently equal to .value, and adjusts it down to make a de-adjusted value
+ * representing the raw armor stats before mods changed them
+ */
+function buildBaseStats(stats: DimStat[], sockets: DimSocket[]) {
+  for (const socket of sockets) {
+    if (socket.plug && socket.plug.plugItem.investmentStats) {
+      for (const perkStat of socket.plug.plugItem.investmentStats) {
+        const statHash = perkStat.statTypeHash;
+        const itemStat = stats.find((stat) => stat.statHash === statHash);
+        const perkValue = perkStat.value || 0;
+        if (itemStat && itemStat.base > perkValue) {
+          itemStat.base -= perkValue;
+        }
+      }
+    }
+  }
+
+  return stats;
 }
 
 function totalStat(stats: DimStat[]): DimStat {

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -235,6 +235,9 @@ function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
                   {destinyVersion === 2 && <li>stat:resilience:</li>}
                   {destinyVersion === 2 && <li>stat:recovery:</li>}
                   {destinyVersion === 2 && <li>stat:total:</li>}
+                  {destinyVersion === 2 && <li>basestat:total:</li>}
+                  {destinyVersion === 2 && <li>basestat:discipline:</li>}
+                  {destinyVersion === 2 && <li>basestat:resilience:</li>}
                 </ul>
               </td>
             </tr>
@@ -243,6 +246,7 @@ function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
                 <span>maxstatvalue:strength</span>
                 <span>maxstatvalue:resilience</span>
                 <span>maxstatvalue:total</span>
+                <span>maxbasestatvalue:total</span>
               </td>
               <td>{t('Filter.StatsMax')}</td>
             </tr>

--- a/src/app/search/search-filter-hashes.ts
+++ b/src/app/search/search-filter-hashes.ts
@@ -201,9 +201,9 @@ export const emptySocketHashes = [
 
 /** translate search terms to corresponding hashes */
 export const armorStatHashByName = {
-  handling: 943549884,
   mobility: 2996146975,
   resilience: 392767087,
+  recovery: 1943323491,
   discipline: 1735777505,
   intellect: 144602215,
   strength: 4244567218,
@@ -214,13 +214,13 @@ export const statHashByName = {
   rof: 4284893193,
   charge: 2961396640,
   impact: 4043523819,
+  handling: 943549884,
   range: 1240592695,
   stability: 155624089,
   reload: 4188031367,
   magazine: 3871231066,
   aimassist: 1345609583,
   equipspeed: 943549884,
-  recovery: 1943323491,
   velocity: 2523465841,
   blastradius: 3614673599,
   recoildirection: 2715839340,

--- a/src/app/search/search-filter-hashes.ts
+++ b/src/app/search/search-filter-hashes.ts
@@ -229,6 +229,7 @@ export const statHashByName = {
   inventorysize: 1931675084,
   ...armorStatHashByName
 };
+export const armorStatNames = Object.keys(armorStatHashByName);
 
 export const energyCapacityTypes = Object.values(energyCapacityTypeNames);
 

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -402,7 +402,7 @@ function searchFilters(
   const _maxPowerLoadoutItems: string[] = [];
   const _maxStatLoadoutItems: { [key: string]: string[] } = {};
   let _maxStatValues: {
-    [key: string]: { [key: string]: { value: number; baseValue: number } };
+    [key: string]: { [key: string]: { value: number; base: number } };
   } | null = null;
   const _lowerDupes = {};
   let _loadoutItemIds: Set<string> | undefined;
@@ -473,14 +473,11 @@ function searchFilters(
                 _maxStatValues[itemSlot][stat.statHash] =
                   // just assign if this is the first
                   !(stat.statHash in _maxStatValues[itemSlot])
-                    ? { value: stat.value, baseValue: stat.baseValue }
+                    ? { value: stat.value, base: stat.base }
                     : // else we are looking for the biggest stat
                       {
                         value: Math.max(_maxStatValues[itemSlot][stat.statHash].value, stat.value),
-                        baseValue: Math.max(
-                          _maxStatValues[itemSlot][stat.statHash].baseValue,
-                          stat.baseValue
-                        )
+                        base: Math.max(_maxStatValues[itemSlot][stat.statHash].base, stat.base)
                       };
               }
             }
@@ -498,7 +495,7 @@ function searchFilters(
     return (item: DimItem, predicate: string) => {
       if (item.isDestiny2() && byBaseValue) {
         const foundStat = item.stats && item.stats.find((s) => s.statHash === statHash);
-        const foundStatValue = foundStat && foundStat.baseValue;
+        const foundStatValue = foundStat && foundStat.base;
         return foundStatValue && compareByOperator(foundStatValue, predicate);
       } else {
         const foundStat = item.stats && item.stats.find((s) => s.statHash === statHash);
@@ -785,12 +782,12 @@ function searchFilters(
       /** purer search than above, for highest stats ignoring equippability. includes tied 1st places */
       maxstatvalue(item: D2Item, predicate: string, byBaseValue = false) {
         // predicate stat must exist, and this must be armor
-        const searchStatHash = hashes.armorStatHashByName[predicate];
+        const searchStatHash = predicate === 'any' ? 'any' : hashes.armorStatHashByName[predicate];
         if (!searchStatHash || !item.bucket.inArmor || !item.isDestiny2() || !item.stats) {
           return false;
         }
         gatherHighestStatsPerSlot();
-        const byWhichValue = byBaseValue ? 'baseValue' : 'value';
+        const byWhichValue = byBaseValue ? 'base' : 'value';
         const itemSlot = `${item.classType}${item.typeName}`;
         const itemStat = item.stats && item.stats.find((s) => s.statHash === searchStatHash);
         const itemStatValue = itemStat && itemStat[byWhichValue];


### PR DESCRIPTION
this will definitely be a bake next week thing, but here are:

`basestat` to accompany `stat`, ignoring plugs which change stats

`maxbasestatvalue` to accompany `maxstatvalue`, for clearer mod-free comparison of armor stats

a `baseValue` in `D2Stat` so more features can be developed with easy access to mod-less stats.
hopefully a renaissance in Y3 item comparison

no crashes or anything weird in the loadout builder, loadout optimizer, collections, etc

note the different results for this chest piece:
![image](https://user-images.githubusercontent.com/31990469/67158123-d9af7580-f2e8-11e9-84fa-cf087151430f.png)
![image](https://user-images.githubusercontent.com/31990469/67158124-dcaa6600-f2e8-11e9-8984-e137e353876f.png)

closes #4541