### PR TITLE
mod cost overlays

### DIFF
--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -28,7 +28,12 @@ const armorPieceDisplayOrder = [...armorPieceGroups, 4104513227]; // ItemCategor
 
 // to-do: separate mod name from its "enhanced"ness, maybe with d2ai? so they can be grouped better
 const sortMods = chainComparator(
-  compareBy((i: DestinyInventoryItemDefinition) => i.itemTypeDisplayName),
+  compareBy(
+    (i: DestinyInventoryItemDefinition) => i.plug.energyCost && i.plug.energyCost.energyType
+  ),
+  compareBy(
+    (i: DestinyInventoryItemDefinition) => i.plug.energyCost && i.plug.energyCost.energyCost
+  ),
   compareBy((i: DestinyInventoryItemDefinition) => i.displayProperties.name)
 );
 

--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -13,7 +13,7 @@ import { storesSelector } from 'app/inventory/reducer';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
 import { connect } from 'react-redux';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
-import Mod from './Mod';
+import { ModCollectible } from './Mod';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { t } from 'app/i18next-t';
 
@@ -192,7 +192,7 @@ function Mods({ defs, buckets, allMods, ownedMods, modsOnItems, profileResponse 
         <div className="title">{weaponModsTitle}</div>
         <div className="collectibles">
           {byGroup.weapons.sort(sortMods).map((mod) => (
-            <Mod
+            <ModCollectible
               key={mod.hash}
               inventoryItem={mod}
               defs={defs}
@@ -212,7 +212,7 @@ function Mods({ defs, buckets, allMods, ownedMods, modsOnItems, profileResponse 
             </div>
             <div key={categoryHash} className="collectibles">
               {armorV2ByPieceCategoryHash[categoryHash].sort(sortMods).map((mod) => (
-                <Mod
+                <ModCollectible
                   key={mod.hash}
                   inventoryItem={mod}
                   defs={defs}
@@ -229,7 +229,7 @@ function Mods({ defs, buckets, allMods, ownedMods, modsOnItems, profileResponse 
             <div className="title">{seasonalModName}</div>
             <div key={seasonalModName} className="collectibles">
               {armorV2ByPieceCategoryHash[seasonalModName].sort(sortMods).map((mod) => (
-                <Mod
+                <ModCollectible
                   key={mod.hash}
                   inventoryItem={mod}
                   defs={defs}
@@ -244,7 +244,7 @@ function Mods({ defs, buckets, allMods, ownedMods, modsOnItems, profileResponse 
         <div className="title">{t('Vendors.Year2Mods')}</div>
         <div className="collectibles">
           {byGroup.armor1.sort(sortMods).map((mod) => (
-            <Mod
+            <ModCollectible
               key={mod.hash}
               inventoryItem={mod}
               defs={defs}

--- a/src/app/collections/collections.scss
+++ b/src/app/collections/collections.scss
@@ -1,3 +1,4 @@
+@import '../variables.scss';
 .collections-partners {
   display: flex;
   flex-direction: row;
@@ -24,4 +25,28 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+}
+.modWrapper {
+  position: relative;
+}
+.energyCostOverlay {
+  box-sizing: border-box;
+  top: $item-border-width;
+  left: $item-border-width;
+  border-width: 0px;
+  height: calc(var(--item-size) - #{2 * $item-border-width});
+  width: calc(var(--item-size) - #{2 * $item-border-width});
+  position: absolute;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: var(--item-size) var(--item-size);
+  pointer-events: none;
+}
+.energyCost {
+  top: calc(#{$item-border-width} + (var(--item-size) / 13));
+  right: calc(#{$item-border-width} + (var(--item-size) / 10.5));
+  position: absolute;
+  pointer-events: none;
+  font-size: calc(var(--item-size) / 5.5);
+  line-height: 1;
 }

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -17,6 +17,7 @@ import {
   DestinySocketCategoryDefinition,
   DestinySocketTypeDefinition,
   DestinyStatDefinition,
+  DestinyEnergyTypeDefinition,
   DestinyTalentGridDefinition,
   DestinyVendorDefinition,
   DestinyDestinationDefinition,
@@ -41,6 +42,7 @@ const lazyTables = [
   'SandboxPerk', // DestinySandboxPerkDefinition
   'Stat', // DestinyStatDefinition
   'StatGroup',
+  'EnergyType',
   'TalentGrid', // DestinyTalentGridDefinition
   'Progression', // DestinyProgressionDefinition
   'ItemCategory', // DestinyItemCategoryDefinition
@@ -82,6 +84,7 @@ export interface D2ManifestDefinitions {
   SandboxPerk: LazyDefinition<DestinySandboxPerkDefinition>;
   Stat: LazyDefinition<DestinyStatDefinition>;
   StatGroup: LazyDefinition<DestinyStatGroupDefinition>;
+  EnergyType: LazyDefinition<DestinyEnergyTypeDefinition>;
   TalentGrid: LazyDefinition<DestinyTalentGridDefinition>;
   Progression: LazyDefinition<DestinyProgressionDefinition>;
   ItemCategory: LazyDefinition<DestinyItemCategoryDefinition>;
@@ -112,14 +115,14 @@ export interface D2ManifestDefinitions {
 
 /**
  * Manifest database definitions. This returns a promise for an
- * objet that has a property named after each of the tables listed
+ * object that has a property named after each of the tables listed
  * above (defs.TalentGrid, etc.).
  */
 export const getDefinitions = _.once(getDefinitionsUncached);
 
 /**
  * Manifest database definitions. This returns a promise for an
- * objet that has a property named after each of the tables listed
+ * object that has a property named after each of the tables listed
  * above (defs.TalentGrid, etc.).
  */
 async function getDefinitionsUncached() {

--- a/src/app/progress/D2SupplementalManifestDefinitions.ts
+++ b/src/app/progress/D2SupplementalManifestDefinitions.ts
@@ -42,6 +42,7 @@ export const D2SupplementalManifestDefinitions = {
   SandboxPerk: { get, getAll },
   Stat: { get, getAll },
   StatGroup: { get, getAll },
+  EnergyType: { get, getAll },
   TalentGrid: { get, getAll },
   Progression: { get, getAll },
   ItemCategory: { get, getAll },

--- a/src/app/vendors/VendorItem.m.scss
+++ b/src/app/vendors/VendorItem.m.scss
@@ -59,7 +59,9 @@
 }
 
 .unavailable {
-  :global(.item) {
+  :global(.item),
+  :global(.energyCostOverlay),
+  :global(.energyCost) {
     opacity: 0.3;
   }
 }


### PR DESCRIPTION
brings EnergyType into the defs object, then uses it to do mod cost overlays on mods page

with a little fine tuning, this component could also be used to display mods later in the socket sheet

opened https://github.com/DestinyItemManager/d2-additional-info/issues/65 because we could do way more meaningful mod sorting if we didn't rely on the alphabet

![image](https://user-images.githubusercontent.com/31990469/67159815-ac6dc200-f2fe-11e9-9e3a-a4cc7b4c1771.png)
