### PR TITLE
Improve Loadout Optimizer memory usage

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -493,6 +493,7 @@
     "ExcludeItem": "Exclude Item",
     "Filter": "Filters",
     "GeneratedBuilds": "Builds",
+    "LimitedCombos": "You have {{combosWithoutCaps, number}} possible stat combinations, but we only looked at {{combos, number}} of them to keep DIM from crashing. As a result, some possibilities are not shown. Lock some items or perks or dismantle some old armor to get under the limit.",
     "LockEquipped": "Equipped",
     "LockItem": "Lock item",
     "LockPerk": "Select perk",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -510,6 +510,7 @@
     "SelectMin": "- Min -",
     "SelectPerks": "Select Perks",
     "SelectPower": "Minimum Power",
+    "SelectPowerDescription": "Sets a minimum power level for the entire loadout (not individual pieces)",
     "SelectedPerkKey": "Selected perk",
     "TierNumber": "T{{tier}}",
     "Traction": "The Traction perk provides +1 Mobility.",

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -3,6 +3,7 @@
 // DIM orange and blue, accent colors
 $orange: #e8a534;
 $blue: #68a0b7;
+$red: #bd362f; // For warnings/errors
 
 // Elemental damage types
 $arc: #85c5ec;

--- a/src/app/dim-ui/ErrorBoundary.scss
+++ b/src/app/dim-ui/ErrorBoundary.scss
@@ -1,3 +1,5 @@
+@import '../variables.scss';
+
 .dim-error {
   margin: 1em 0;
   padding: 1em;
@@ -9,5 +11,5 @@
     color: white;
     font-size: 12px;
   }
-  background-color: #bd362f !important;
+  background-color: $red !important;
 }

--- a/src/app/inventory/MoveNotifications.m.scss
+++ b/src/app/inventory/MoveNotifications.m.scss
@@ -22,5 +22,5 @@
 }
 
 .failed {
-  background-color: #bd362f;
+  background-color: $red;
 }

--- a/src/app/item-popup/ItemPopupContainer.scss
+++ b/src/app/item-popup/ItemPopupContainer.scss
@@ -148,7 +148,7 @@
   box-sizing: border-box;
 
   &.warning {
-    background-color: #bd362f !important;
+    background-color: $red !important;
     padding: 8px;
     border: 2px solid rgba(255, 255, 255, 0.5);
     a {

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -197,6 +197,8 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     let filteredItems: ItemsByBucket = {};
     let processedSets: readonly ArmorSet[] = [];
     let filteredSets: readonly ArmorSet[] = [];
+    let combos = 0;
+    let combosWithoutCaps = 0;
     let processError;
     try {
       filteredItems = this.filterItemsMemoized(
@@ -205,7 +207,10 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
         lockedMap,
         filter
       );
-      processedSets = this.processMemoized(filteredItems);
+      const result = this.processMemoized(filteredItems);
+      processedSets = result.sets;
+      combos = result.combos;
+      combosWithoutCaps = result.combosWithoutCaps;
       filteredSets = this.filterSetsMemoized(
         processedSets,
         minimumPower,
@@ -282,6 +287,8 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
           ) : (
             <GeneratedSets
               sets={filteredSets}
+              combos={combos}
+              combosWithoutCaps={combosWithoutCaps}
               isPhonePortrait={isPhonePortrait}
               lockedMap={lockedMap}
               selectedStore={store}

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -46,6 +46,8 @@ export default function FilterBuilds({
     return statRanges;
   }, [sets]);
 
+  // TODO: select whether power or energy is most important?
+
   return (
     <div>
       <div className={styles.filters}>

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -46,8 +46,6 @@ export default function FilterBuilds({
     return statRanges;
   }, [sets]);
 
-  // TODO: select whether power or energy is most important?
-
   return (
     <div>
       <div className={styles.filters}>

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -61,7 +61,9 @@ export default function FilterBuilds({
           onStatOrderChanged={onStatOrderChanged}
         />
         <div className={styles.powerSelect}>
-          <label id="minPower">{t('LoadoutBuilder.SelectPower')}</label>
+          <label id="minPower" title={t('LoadoutBuilder.SelectPowerDescription')}>
+            {t('LoadoutBuilder.SelectPower')}
+          </label>
           <RangeSelector
             min={750}
             max={selectedStore.stats.maxTotalPower!.tierMax!}

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -110,7 +110,7 @@ export default function GeneratedSetItem({
       {item.isDestiny2() && (
         <ItemSockets
           item={item}
-          hideMods={true}
+          hideMods={false}
           classesByHash={classesByHash}
           onShiftClick={onShiftClickPerk}
         />

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.m.scss
@@ -59,3 +59,8 @@
   }
   color: $xp;
 }
+
+.warning {
+  color: $red;
+  font-weight: bold;
+}

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.m.scss.d.ts
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.m.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'numSets': string;
   'selectedPerkKey': string;
   'sets': string;
+  'warning': string;
 }
 declare const cssExports: CssExports;
 export = cssExports;

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -14,6 +14,8 @@ import { addLockedItem, removeLockedItem } from './utils';
 interface Props {
   selectedStore: DimStore;
   sets: readonly ArmorSet[];
+  combos: number;
+  combosWithoutCaps: number;
   isPhonePortrait: boolean;
   lockedMap: LockedMap;
   statOrder: StatTypes[];
@@ -77,7 +79,16 @@ export default class GeneratedSets extends React.Component<Props, State> {
   }
 
   render() {
-    const { lockedMap, selectedStore, sets, defs, statOrder, isPhonePortrait } = this.props;
+    const {
+      lockedMap,
+      selectedStore,
+      sets,
+      defs,
+      statOrder,
+      isPhonePortrait,
+      combos,
+      combosWithoutCaps
+    } = this.props;
     const { rowHeight, rowWidth, rowColumns } = this.state;
 
     let measureSet: ArmorSet | undefined;
@@ -101,6 +112,11 @@ export default class GeneratedSets extends React.Component<Props, State> {
             {t('LoadoutBuilder.NewEmptyLoadout')}
           </button>
         </h2>
+        {combos !== combosWithoutCaps && (
+          <p className={styles.warning}>
+            {t('LoadoutBuilder.LimitedCombos', { combos, combosWithoutCaps })}
+          </p>
+        )}
         <p>
           {t('LoadoutBuilder.OptimizerExplanation')}{' '}
           {!isPhonePortrait && t('LoadoutBuilder.OptimizerExplanationDesktop')}

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -72,6 +72,18 @@ export function filterItems(
     }
   });
 
+  // Trim down the amount of items so we can actually render
+  /*
+  _.mapValues(filteredItems, (items) => {
+    return _.sortBy(items, (i) => [
+      -1 * (i.stats ? i.stats.find((s) => s.statHash === -1000)!.value : -1),
+      -1 * (i.isDestiny2() && i.energy ? i.energy.energyCapacity : 0)
+    ]);
+  });
+
+  _.forIn(filteredItems, (items, type) => console.log(type, items.length));
+*/
+
   return filteredItems;
 }
 
@@ -100,6 +112,8 @@ function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
  */
 export function process(filteredItems: ItemsByBucket): ArmorSet[] {
   const pstart = performance.now();
+  // TODO: these used to be sorted by basePower, but should be sorted by energy!
+  // TODO: at least have a sorting function
   const helms = multiGroupBy(
     _.sortBy(filteredItems[LockableBuckets.helmet] || [], (i) => -i.basePower),
     byStatMix
@@ -132,6 +146,8 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
   const legsKeys = Object.keys(legs);
   const classItemsKeys = Object.keys(classitems);
   const ghostsKeys = Object.keys(ghosts);
+  // Sort keys by total and cap at 20
+  // Indicate which were capped
 
   const combos =
     helmsKeys.length *
@@ -140,6 +156,17 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
     legsKeys.length *
     classItemsKeys.length *
     ghostsKeys.length;
+
+  // TODO: if combos is too much, cap the keys (40 max?)
+  console.log(
+    helmsKeys.length,
+    gauntsKeys.length,
+    chestsKeys.length,
+    legsKeys.length,
+    classItemsKeys.length,
+    ghostsKeys.length,
+    combos
+  );
 
   if (combos === 0) {
     return [];
@@ -164,6 +191,8 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
                 ghosts[ghostsKey]
               ];
 
+              // TODO: maybe don't add if there's already a better tier in all stats?
+
               const firstValidSet = getFirstValidSet(armor);
               const statChoices = [
                 helmsKey,
@@ -181,7 +210,10 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
                       statChoices
                     }
                   ],
+                  // TODO: use flat array for stats
                   stats,
+                  // TODO: calculate tier string here?
+                  // TODO: defer calculating first valid set / statchoices / maxpower?
                   firstValidSet,
                   firstValidSetStatChoices: statChoices,
                   maxPower: getPower(firstValidSet)
@@ -211,6 +243,8 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
   );
 
   type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+  // TODO: figure out max power after the fact?
 
   const finalSets = Object.values(groupedSets).map((sets) => {
     const combinedSet = sets.shift()! as Mutable<ArmorSet>;

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -120,8 +120,6 @@ export function process(
     return value;
   };
 
-  // TODO: these used to be sorted by basePower, but should be sorted by energy!
-  // TODO: at least have a sorting function
   const helms = multiGroupBy(
     _.sortBy(filteredItems[LockableBuckets.helmet] || [], (i) => -i.basePower),
     byStatMix
@@ -228,8 +226,6 @@ export function process(
                 ghosts[ghostsKey]
               ];
 
-              // TODO: maybe don't add if there's already a better tier in all stats?
-
               const firstValidSet = getFirstValidSet(armor);
               const statChoices = [
                 keyToStats(helmsKey),
@@ -286,7 +282,6 @@ export function process(
                         statChoices
                       }
                     ],
-                    // TODO: use flat array for stats
                     stats,
                     // TODO: defer calculating first valid set / statchoices / maxpower?
                     firstValidSet,
@@ -302,8 +297,6 @@ export function process(
     }
   }
 
-  // TODO: figure out max power after the fact?
-
   const finalSets = Object.values(groupedSets);
 
   console.log(
@@ -318,7 +311,6 @@ export function process(
 
   localStorage.removeItem('loadout-optimizer');
 
-  // TODO: return total combos, trimmed combos
   return { sets: finalSets, combos, combosWithoutCaps };
 }
 

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -115,9 +115,19 @@ export function process(filteredItems: ItemsByBucket): ArmorSet[] {
   const pstart = performance.now();
 
   const emptyStats = _.mapValues(statHashes, () => 0);
-  // Memoize the function that turns string stat-keys back into numbers.
-  // It turns out this is actually slightly slower, but generates way less garbage.
-  const keyToStats = _.memoize((key: string) => key.split(',').map((val) => parseInt(val, 10)));
+
+  // Memoize the function that turns string stat-keys back into numbers to save garbage.
+  // Writing our own memoization instead of using _.memoize is 2x faster.
+  const keyToStatsCache = new Map<string, number[]>();
+  const keyToStats = (key: string) => {
+    let value = keyToStatsCache.get(key);
+    if (value) {
+      return value;
+    }
+    value = key.split(',').map((val) => parseInt(val, 10));
+    keyToStatsCache.set(key, value);
+    return value;
+  };
 
   // TODO: these used to be sorted by basePower, but should be sorted by energy!
   // TODO: at least have a sorting function

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -290,7 +290,7 @@ h4 {
 
 .warning-block {
   color: white;
-  background: #bd362f;
+  background: $red;
   padding: 0.5em 1em;
   display: inline-block;
 }

--- a/src/app/notifications/Notification.scss
+++ b/src/app/notifications/Notification.scss
@@ -79,8 +79,8 @@
   }
 
   .notification-error {
-    border-top-color: #bd362f;
-    background-color: scale-color(#bd362f, $lightness: -90%);
+    border-top-color: $red;
+    background-color: scale-color($red, $lightness: -90%);
   }
 
   .notification-warning {

--- a/src/app/whats-new/BungieAlerts.scss
+++ b/src/app/whats-new/BungieAlerts.scss
@@ -1,3 +1,5 @@
+@import '../variables.scss';
+
 .bungie-alert {
   margin: 1em 0;
   padding: 1em;
@@ -9,7 +11,7 @@
 }
 
 .bungie-alert-error {
-  background-color: #bd362f !important;
+  background-color: $red !important;
 }
 .bungie-alert-info {
   background-color: #2f96b4 !important;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -506,6 +506,7 @@
     "SelectMin": "- Min -",
     "SelectPerks": "Select Perks",
     "SelectPower": "Minimum Power",
+    "SelectPowerDescription": "Sets a minimum power level for the entire loadout (not individual pieces)",
     "SelectedPerkKey": "Selected perk",
     "TierNumber": "T{{tier}}",
     "Traction": "The Traction perk provides +1 Mobility.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -4,12 +4,7 @@
     "ConfirmTitle": "Confirm Action"
   },
   "Accounts": {
-    "Blizzard": "PC",
-    "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account.",
-    "PlayStation": "PS4",
-    "Stadia": "Stadia",
-    "Steam": "Steam",
-    "Xbox": "XB1"
+    "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account."
   },
   "Activities": {
     "Activities": "Activities",
@@ -494,6 +489,7 @@
     "ExcludeItem": "Exclude Item",
     "Filter": "Filters",
     "GeneratedBuilds": "Builds",
+    "LimitedCombos": "You have {{combosWithoutCaps, number}} possible stat combinations, but we only looked at {{combos, number}} of them to keep DIM from crashing. As a result, some possibilities are not shown. Lock some items or perks or dismantle some old armor to get under the limit.",
     "LockEquipped": "Equipped",
     "LockItem": "Lock item",
     "LockPerk": "Select perk",
@@ -702,8 +698,6 @@
     "General": "General",
     "Inventory": "Inventory Display",
     "InventoryColumns": "Character inventory width",
-    "InventoryColumnsMobile": "Character inventory width on mobile portrait",
-    "InventoryColumnsMobileLine2": "The items will be resized to accommodate the new setting",
     "Items": "Item Display",
     "Language": "Language",
     "LogOut": "Log out",


### PR DESCRIPTION
I took a pretty extreme pass at reducing memory/CPU usage/garbage on the loadout optimizer, which looks like it will make it much easier to run on big sets. Plus a few more things:

1. I'm now tracking "Oh, Snap!" crashes as best I can, and reporting them to Sentry along with how many combos we were attempting.
2. Once a user has half a million possible stat combos, I'll start excluding some of their gear with until we get under that limit (prioritizing armor types that have a ton of options, starting with the lowest total stats). On my machine half a million combos can be calculated in about 2 seconds. We can monitor this and tweak that limit over time, or even maybe make it dynamic.

For this screenshot I set the limit to 5,000:
<img width="1143" alt="Screen Shot 2019-10-20 at 4 00 05 PM" src="https://user-images.githubusercontent.com/313208/67167941-b7067680-f353-11e9-8dbd-479640ca05f9.png">

Fixes https://github.com/DestinyItemManager/DIM/issues/4466