### PR TITLE
Reversable stat sort in comparison, fixes #4524

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -232,9 +232,10 @@ class Compare extends React.Component<Props, State> {
   };
 
   private sort = (sortedHash?: string | number) => {
-    const sortBetterFirst =
-      this.state.sortedHash === sortedHash ? !this.state.sortBetterFirst : true;
-    this.setState({ sortedHash, sortBetterFirst });
+    this.setState((prevState) => ({
+      sortedHash,
+      sortBetterFirst: prevState.sortedHash === sortedHash ? !prevState.sortBetterFirst : true
+    }));
   };
 
   private add = ({ items, dupes }: { items: DimItem[]; dupes: boolean }) => {

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -124,13 +124,15 @@ class Compare extends React.Component<Props, State> {
                 : sortedHash === 'Rating'
                 ? { value: showRating || 0 }
                 : (item.stats || []).find((s) => s.statHash === sortedHash);
-            return (
-              (stat &&
-                (isDimStat(stat) && (stat.smallerIsBetter || !this.state.sortBetterFirst)
-                  ? -stat.value
-                  : stat.value)) ||
-              -1
-            );
+
+            if (!stat || !isDimStat(stat)) {
+              return -1;
+            }
+
+            const shouldReverse = this.state.sortBetterFirst
+              ? stat.smallerIsBetter
+              : !stat.smallerIsBetter;
+            return shouldReverse ? -stat.value : stat.value;
           }),
           compareBy((i) => i.index),
           compareBy((i) => i.name)

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -40,6 +40,7 @@ interface State {
   comparisons: DimItem[];
   highlight?: string | number;
   sortedHash?: string | number;
+  sortBetterFirst: boolean;
   similarTypes: DimItem[];
   archetypes: DimItem[];
 }
@@ -59,7 +60,8 @@ class Compare extends React.Component<Props, State> {
     comparisons: [],
     similarTypes: [],
     archetypes: [],
-    show: false
+    show: false,
+    sortBetterFirst: true
   };
   private subscriptions = new Subscriptions();
   // tslint:disable-next-line:ban-types
@@ -123,7 +125,11 @@ class Compare extends React.Component<Props, State> {
                 ? { value: showRating || 0 }
                 : (item.stats || []).find((s) => s.statHash === sortedHash);
             return (
-              (stat && (isDimStat(stat) && stat.smallerIsBetter ? -stat.value : stat.value)) || -1
+              (stat &&
+                (isDimStat(stat) && (stat.smallerIsBetter || !this.state.sortBetterFirst)
+                  ? -stat.value
+                  : stat.value)) ||
+              -1
             );
           }),
           compareBy((i) => i.index),
@@ -224,7 +230,9 @@ class Compare extends React.Component<Props, State> {
   };
 
   private sort = (sortedHash?: string | number) => {
-    this.setState({ sortedHash });
+    const sortBetterFirst =
+      this.state.sortedHash === sortedHash ? !this.state.sortBetterFirst : true;
+    this.setState({ sortedHash, sortBetterFirst });
   };
 
   private add = ({ items, dupes }: { items: DimItem[]; dupes: boolean }) => {


### PR DESCRIPTION
[![Image from Gyazo](https://i.gyazo.com/4f7c1db50d126576c62a590fc4fb82a3.gif)](https://gyazo.com/4f7c1db50d126576c62a590fc4fb82a3)

#4524 Fairly straightforward. Click a stat once to sort "better first". Click again to sort "worst first". Charge time on fusion rifles was the main exception to the "higher = better" stat rule, so I made sure it was working with that. 

I'd thought about adding some up/down arrows inline with the sort stat to convey sort direction, but the fact that some stats are _not_ "higher = better" makes that a bit tricky. May not be necessary though really. The "click again to reverse sort direction" is a fairly common pattern found throughout the web so I think it will be pretty intuitive for most users.