### PR TITLE
Loadout Optimizer improvements

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -277,7 +277,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
               <h2>{t('ErrorBoundary.Title')}</h2>
               <div>{processError.message}</div>
             </div>
-          ) : processedSets.length === 0 && requirePerks ? (
+          ) : filteredSets.length === 0 && requirePerks ? (
             <>
               <h3>{t('LoadoutBuilder.NoBuildsFound')}</h3>
               <button className="dim-button" onClick={this.setRequiredPerks}>

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -56,6 +56,7 @@ interface StoreProps {
 type Props = ProvidedProps & StoreProps;
 
 function mapStateToProps() {
+  // Get a list of lockable perks by class, then bucket.
   const perksSelector = createSelector(
     storesSelector,
     (stores) => {

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -34,6 +34,9 @@ export default function FilterBuilds({
   onStatFiltersChanged(stats: { [statType in StatTypes]: MinMax }): void;
 }) {
   const statRanges = useMemo(() => {
+    if (!sets.length) {
+      return _.mapValues(statHashes, () => ({ min: 0, max: 10 }));
+    }
     const statRanges = _.mapValues(statHashes, () => ({ min: 10, max: 0 }));
     for (const set of sets) {
       for (const prop of statKeys) {

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
@@ -102,7 +102,10 @@
 .selectedPerk {
   background-color: scale-color($xp, $alpha: -50%) !important;
   border: 1px solid $xp !important;
-  border-radius: 50%;
+
+  :global(.item-socket-category-Reusable) & {
+    border-radius: 50%;
+  }
 }
 
 .swapButton {

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -51,6 +51,10 @@ export function filterPlugs(socket: DimSocket) {
   if (plugItem.plug.plugCategoryHash === 3347429529 && plugItem.inventory.tierType === 2) {
     return false;
   }
+
+  if (plugItem.plug.plugCategoryIdentifier.match(/masterworks/)) {
+    return false;
+  }
   return true;
 }
 

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -279,9 +279,7 @@ export function getFilteredPerks(
 /** Whether this item is eligible for being in loadout builder */
 export function isLoadoutBuilderItem(item: DimItem) {
   // Armor and Ghosts
-  return (
-    item.isDestiny2() && item.sockets && (item.bucket.inArmor || item.bucket.hash === 4023194814)
-  );
+  return item.bucket.inArmor || item.bucket.hash === 4023194814;
 }
 
 /**

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { DimSocket, DimItem } from '../../inventory/item-types';
 import { ArmorSet, LockedItemType, MinMax, StatTypes, LockedMap } from '../types';
 import { count } from '../../utils/util';
-import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import { DestinyInventoryItemDefinition, TierType } from 'bungie-api-ts/destiny2';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 
 /**
@@ -34,7 +34,9 @@ export function filterPlugs(socket: DimSocket) {
   // Remove unwanted sockets by category hash
   if (
     unwantedSockets.has(plugItem.plug.plugCategoryHash) ||
-    plugItem.itemCategoryHashes.includes(1742617626) // exotic armor ornanments
+    (plugItem.itemCategoryHashes &&
+      (plugItem.itemCategoryHashes.includes(1742617626) || // exotic armor ornanments
+        plugItem.itemCategoryHashes.includes(1875601085))) // glows
   ) {
     return false;
   }
@@ -52,7 +54,13 @@ export function filterPlugs(socket: DimSocket) {
     return false;
   }
 
+  // Remove masterwork mods and energy mods
   if (plugItem.plug.plugCategoryIdentifier.match(/masterworks/)) {
+    return false;
+  }
+
+  // Remove empty sockets, which are common tier
+  if (plugItem.inventory.tierType <= TierType.Common) {
     return false;
   }
   return true;

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -57,9 +57,13 @@ export function filterItems(
 
     // filter out low-tier items and items without extra perks on them
     if (requirePerks) {
-      filteredItems[bucket] = filteredItems[bucket].filter(
+      const highTierItems = filteredItems[bucket].filter(
         (item) => item && item.isDestiny2() && ['Exotic', 'Legendary'].includes(item.tier)
       );
+
+      if (highTierItems.length > 0) {
+        filteredItems[bucket] = highTierItems;
+      }
     }
   });
 

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -58,7 +58,10 @@ export function filterItems(
     // filter out low-tier items and items without extra perks on them
     if (requirePerks) {
       const highTierItems = filteredItems[bucket].filter(
-        (item) => item && item.isDestiny2() && ['Exotic', 'Legendary'].includes(item.tier)
+        (item) =>
+          (item && item.isDestiny2() && ['Exotic', 'Legendary'].includes(item.tier)) ||
+          // If it's a locked item, always let it through
+          (locked && locked.some((l) => l.type === 'item' && l.item.id === item.id))
       );
 
       if (highTierItems.length > 0) {


### PR DESCRIPTION
1. If a bucket doesn't have any legendary/exotic items available, fall back to all types.
2. Exclude a bunch of junk mods like masterworks and empties from the perk picker.
3. Don't try to put a round highlight on selected mods.

Once I have the mod inspector / plug viewer finished I'll implement a thing where you can select from available mods to filter LO down to items that could use those mods (as opposed to ones that have it equipped).