### PR TITLE
fix bug in compare sort logic

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -125,13 +125,14 @@ class Compare extends React.Component<Props, State> {
                 ? { value: showRating || 0 }
                 : (item.stats || []).find((s) => s.statHash === sortedHash);
 
-            if (!stat || !isDimStat(stat)) {
+            if (!stat) {
               return -1;
             }
 
-            const shouldReverse = this.state.sortBetterFirst
-              ? stat.smallerIsBetter
-              : !stat.smallerIsBetter;
+            const shouldReverse =
+              isDimStat(stat) && stat.smallerIsBetter
+                ? this.state.sortBetterFirst
+                : !this.state.sortBetterFirst;
             return shouldReverse ? -stat.value : stat.value;
           }),
           compareBy((i) => i.index),


### PR DESCRIPTION
With https://github.com/DestinyItemManager/DIM/pull/4531 I did some light refactoring to the comparisons code that wasn't quite right. This resulted in items not being sorted correctly when using the "Attack" stat (#4562). Just needed a small tweak, should be working properly now for all stats.