### PR TITLE
archive tag

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -714,7 +714,8 @@
     "SortByPrimary": "Power level",
     "SortByRarity": "Rarity",
     "SortByRating": "Community Rating or Armor Quality",
-    "SortByTag": "Tag (Favorite, Keep, Infuse, Trash)",
+    "SortByTag": "Tag ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Type",
     "SortCustom": "Custom Sort",
     "SortName": "Name"
@@ -796,6 +797,7 @@
     "GoogleDriveReAuth": "To re-authorize google drive, you must restart your browser."
   },
   "Tags": {
+    "Archive": "Archive",
     "ClearTag": "Clear",
     "Favorite": "Favorite",
     "Infuse": "Infuse",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -715,7 +715,6 @@
     "SortByRarity": "Rarity",
     "SortByRating": "Community Rating or Armor Quality",
     "SortByTag": "Tag ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Type",
     "SortCustom": "Custom Sort",
     "SortName": "Name"

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -282,6 +282,7 @@
       "Favorite": "Shows favorite items.",
       "Infuse": "Shows items you wish to eventually infuse.",
       "Keep": "Shows keep items.",
+      "Archive": "Dims items you rarely need.",
       "NoTag": "Shows items without a tag."
     },
     "Tracked": "Shows quests/bounties based on their tracked status.",

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { DimItem, DimTalentGrid } from './item-types';
-import { TagValue, itemTags } from './dim-item-info';
+import { TagValue, itemTagList } from './dim-item-info';
 import BadgeInfo from './BadgeInfo';
 import BungieImage from '../dim-ui/BungieImage';
 import { percent } from '../shell/filters';
@@ -15,7 +15,7 @@ import subclassSolar from 'images/subclass-solar.png';
 import subclassVoid from 'images/subclass-void.png';
 
 const tagIcons: { [tag: string]: IconDefinition | undefined } = {};
-itemTags.forEach((tag) => {
+itemTagList.forEach((tag) => {
   if (tag.type) {
     tagIcons[tag.type] = tag.icon;
   }

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -21,7 +21,7 @@ import { D2StoresService } from './d2-stores';
 import { t } from 'app/i18next-t';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { getTag } from './dim-item-info';
+import { getTag, tagDisplacePriority } from './dim-item-info';
 import reduxStore from '../store/store';
 
 /**
@@ -597,17 +597,6 @@ function ItemService(): ItemServiceType {
       Exotic: 4
     };
 
-    const tagValue = {
-      // Infusion fuel belongs in the vault
-      infuse: -1,
-      // These are still good
-      keep: 1,
-      // Junk should probably bubble towards the character so you remember to delete them!
-      junk: 2,
-      // Favorites you want on your character
-      favorite: 3
-    };
-
     // A sort for items to use for ranking which item to move
     // aside. When moving from the vault we'll choose the
     // "largest" item, while moving from a character to the
@@ -627,7 +616,7 @@ function ItemService(): ItemServiceType {
       // Tagged items sort by the value of their tags
       compareBy((i) => {
         const tag = getTag(i, reduxStore.getState().inventory.itemInfos);
-        return tag ? tagValue[tag] : 0;
+        return tag ? tagDisplacePriority[tag] : 0;
       }),
       // Prefer moving lower-tier
       compareBy((i) => tierValue[i.tier]),

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -3,7 +3,7 @@ import { DimItem, DimSockets, DimGridNode } from './item-types';
 import { t } from 'app/i18next-t';
 import Papa from 'papaparse';
 import { getActivePlatform } from '../accounts/platforms';
-import { getItemInfoSource, TagValue, getTag, getNotes, DimItemInfo } from './dim-item-info';
+import { getItemInfoSource, tagConfig, getTag, getNotes, DimItemInfo } from './dim-item-info';
 import store from '../store/store';
 import { D2SeasonInfo } from './d2-season-info';
 import { D2EventInfo } from 'data/d2/d2-event-info';
@@ -139,9 +139,7 @@ export async function importTagsNotesFromCsv(files: File[]) {
             row.Tag = row.Tag.toLowerCase();
             row.Id = row.Id.replace(/"/g, ''); // strip quotes from row.Id
             return {
-              tag: ['favorite', 'keep', 'infuse', 'junk'].includes(row.Tag)
-                ? (row.Tag as TagValue)
-                : undefined,
+              tag: row.Tag in tagConfig ? tagConfig[row.Tag].type : undefined,
               notes: row.Notes,
               key: row.Id
             };

--- a/src/app/item-popup/ItemTagHotkeys.tsx
+++ b/src/app/item-popup/ItemTagHotkeys.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { itemTags, TagValue } from '../inventory/dim-item-info';
+import { itemTagList, TagValue } from '../inventory/dim-item-info';
 import { DimItem } from '../inventory/item-types';
 import { Hotkey } from '../hotkeys/hotkeys';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
@@ -19,7 +19,7 @@ export default class ItemTagHotkeys extends React.Component<Props> {
 
     const hotkeys: Hotkey[] = [];
 
-    itemTags.forEach((tag) => {
+    itemTagList.forEach((tag) => {
       if (tag.hotkey) {
         hotkeys.push({
           combo: tag.hotkey,

--- a/src/app/item-popup/ItemTagSelector.tsx
+++ b/src/app/item-popup/ItemTagSelector.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { itemTags, TagValue, getTag } from '../inventory/dim-item-info';
-import { t } from 'app/i18next-t';
+import { itemTagSelectorList, TagValue, getTag } from '../inventory/dim-item-info';
 import { connect } from 'react-redux';
 import { DimItem } from '../inventory/item-types';
 import { RootState } from '../store/reducers';
+import { t } from 'app/i18next-t';
 import './ItemTagSelector.scss';
 
 interface ProvidedProps {
@@ -26,7 +26,7 @@ class ItemTagSelector extends React.Component<Props> {
 
     return (
       <select className="item-tag-selector" onChange={this.onTagUpdated} value={tag || 'none'}>
-        {itemTags.map((tagOption) => (
+        {itemTagSelectorList.map((tagOption) => (
           <option key={tagOption.type || 'reset'} value={tagOption.type || 'none'}>
             {t(tagOption.label)}
           </option>

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -144,7 +144,7 @@ function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
             <tr>
               <td>
                 <span>tag:none</span> <span>tag:favorite</span> <span>tag:keep</span>
-                <span>tag:junk</span> <span>tag:infuse</span>
+                <span>tag:junk</span> <span>tag:infuse</span> <span>tag:archive</span>
               </td>
               <td>
                 <ul>
@@ -153,6 +153,7 @@ function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
                   <li>{t('Filter.Tags.Keep')}</li>
                   <li>{t('Filter.Tags.Dismantle')}</li>
                   <li>{t('Filter.Tags.Infuse')}</li>
+                  <li>{t('Filter.Tags.Archive')}</li>
                 </ul>
               </td>
             </tr>

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -3,12 +3,7 @@ import { t } from 'app/i18next-t';
 import { AppIcon, tagIcon } from '../shell/icons';
 import { faClone } from '@fortawesome/free-regular-svg-icons';
 import { faUndo } from '@fortawesome/free-solid-svg-icons';
-import {
-  itemTagSelectorList,
-  getItemInfoSource,
-  TagValue,
-  TagInfo
-} from '../inventory/dim-item-info';
+import { itemTagSelectorList, getItemInfoSource, TagValue } from '../inventory/dim-item-info';
 import { connect } from 'react-redux';
 import { RootState } from '../store/reducers';
 import { setSearchQuery } from '../shell/actions';
@@ -31,7 +26,7 @@ import { CompareService } from '../compare/compare.service';
 
 // these exist in comments so i18n       t('Tags.TagItems') t('Tags.ClearTag')
 // doesn't delete the translations       t('Tags.LockAll') t('Tags.UnlockAll')
-const bulkItemTags = Array.from(itemTagSelectorList) as TagInfo[];
+const bulkItemTags = Array.from(itemTagSelectorList);
 bulkItemTags.shift();
 bulkItemTags.unshift({ label: 'Tags.TagItems' });
 bulkItemTags.push({ type: 'clear', label: 'Tags.ClearTag' });
@@ -162,7 +157,7 @@ class SearchFilter extends React.Component<Props, State> {
                   await itemInfoService.bulkSaveByKeys(
                     previousState.map(({ item, setTag }) => ({
                       key: item.id,
-                      tag: selectedTag === 'clear' ? undefined : (setTag as TagValue)
+                      tag: selectedTag === 'clear' ? undefined : setTag
                     }))
                   );
                   showNotification({

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -143,15 +143,11 @@ class SearchFilter extends React.Component<Props, State> {
           type: 'success',
           duration: 30000,
           title: t('Header.BulkTag'),
-          // this comment included to help not confuse i18n
-          // t('Filter.BulkClear', { count: tagItems.length,  })
-          // t('Filter.BulkTag', { count: tagItems.length,  })
           body: (
             <>
-              {t(appliedTagInfo.type === 'clear' ? 'Filter.BulkClear' : 'Filter.BulkTag', {
-                count: tagItems.length,
-                tag: t(appliedTagInfo.label)
-              })}
+              {appliedTagInfo.type === 'clear'
+                ? t('Filter.BulkClear', { count: tagItems.length, tag: t(appliedTagInfo.label) })
+                : t('Filter.BulkTag', { count: tagItems.length, tag: t(appliedTagInfo.label) })}
               <NotificationButton
                 onClick={async () => {
                   await itemInfoService.bulkSaveByKeys(

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -3,7 +3,12 @@ import { t } from 'app/i18next-t';
 import { AppIcon, tagIcon } from '../shell/icons';
 import { faClone } from '@fortawesome/free-regular-svg-icons';
 import { faUndo } from '@fortawesome/free-solid-svg-icons';
-import { itemTags, getItemInfoSource, TagValue } from '../inventory/dim-item-info';
+import {
+  itemTagSelectorList,
+  getItemInfoSource,
+  TagValue,
+  TagInfo
+} from '../inventory/dim-item-info';
 import { connect } from 'react-redux';
 import { RootState } from '../store/reducers';
 import { setSearchQuery } from '../shell/actions';
@@ -24,12 +29,9 @@ import { showNotification } from '../notifications/notifications';
 import NotificationButton from '../notifications/NotificationButton';
 import { CompareService } from '../compare/compare.service';
 
-const bulkItemTags = Array.from(itemTags) as any[];
-// t('Tags.TagItems')
-// t('Tags.ClearTag')
-// t('Tags.LockAll')
-// t('Tags.UnlockAll')
-
+// these exist in comments so i18n       t('Tags.TagItems') t('Tags.ClearTag')
+// doesn't delete the translations       t('Tags.LockAll') t('Tags.UnlockAll')
+const bulkItemTags = Array.from(itemTagSelectorList) as TagInfo[];
 bulkItemTags.shift();
 bulkItemTags.unshift({ label: 'Tags.TagItems' });
 bulkItemTags.push({ type: 'clear', label: 'Tags.ClearTag' });
@@ -126,9 +128,9 @@ class SearchFilter extends React.Component<Props, State> {
       } else {
         // Bulk tagging
         const itemInfoService = await getItemInfoSource(this.props.account!);
-        const selectedTagString = bulkItemTags.find(
+        const appliedTagInfo = bulkItemTags.find(
           (tagInfo) => tagInfo.type && tagInfo.type === selectedTag
-        ).label;
+        ) || { type: 'error', label: '[applied tag not found in tag list]' };
         const tagItems = this.getStoresService()
           .getAllItems()
           .filter((i) => i.taggable && this.props.searchFilter(i));
@@ -146,13 +148,14 @@ class SearchFilter extends React.Component<Props, State> {
           type: 'success',
           duration: 30000,
           title: t('Header.BulkTag'),
-          // t('Filter.BulkClear', { count: tagItems.length })
-          // t('Filter.BulkTag', { count: tagItems.length })
+          // this comment included to help not confuse i18n
+          // t('Filter.BulkClear', { count: tagItems.length,  })
+          // t('Filter.BulkTag', { count: tagItems.length,  })
           body: (
             <>
-              {t(selectedTagString === 'Tags.ClearTag' ? 'Filter.BulkClear' : 'Filter.BulkTag', {
+              {t(appliedTagInfo.type === 'clear' ? 'Filter.BulkClear' : 'Filter.BulkTag', {
                 count: tagItems.length,
-                tag: t(selectedTagString)
+                tag: t(appliedTagInfo.label)
               })}
               <NotificationButton
                 onClick={async () => {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -19,7 +19,7 @@ import { D2Categories } from '../destiny2/d2-buckets';
 import { querySelector } from '../shell/reducer';
 import { sortedStoresSelector } from '../inventory/reducer';
 import { maxLightLoadout, maxStatLoadout } from '../loadout/auto-loadouts';
-import { itemTags, DimItemInfo, getTag, getNotes } from '../inventory/dim-item-info';
+import { itemTagSelectorList, DimItemInfo, getTag, getNotes } from '../inventory/dim-item-info';
 import store from '../store/store';
 import { loadoutsSelector } from '../loadout/reducer';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
@@ -60,9 +60,6 @@ const plainString = (s: string): string => (isLatinBased ? latinise(s) : s).toLo
 
 /** remove starting and ending quotes ('") e.g. for notes:"this string" */
 const trimQuotes = (s: string) => s.replace(/(^['"]|['"]$)/g, '');
-
-/** filter function to use when there's no query */
-const alwaysTrue = () => true;
 
 /** strings representing math checks */
 const operators = ['<', '>', '<=', '>=', '='];
@@ -295,7 +292,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     ...Object.values(filterTrans)
       .flat()
       .flatMap((word) => [`is:${word}`, `not:${word}`]),
-    ...itemTags.map((tag) => (tag.type ? `tag:${tag.type}` : 'tag:none')),
+    ...itemTagSelectorList.map((tag) => (tag.type ? `tag:${tag.type}` : 'tag:none')),
     // a keyword for every combination of an item stat name and mathmatical operator
     ...stats.flatMap((stat) => operators.map((comparison) => `stat:${stat}:${comparison}`)),
     // additional basestat searches for armor stats
@@ -517,11 +514,11 @@ function searchFilters(
      * Build a complex predicate function from a full query string.
      */
     filterFunction(query: string): (item: DimItem) => boolean {
+      query = query.trim().toLowerCase();
       if (!query.length) {
-        return alwaysTrue;
+        query = '-tag:archive';
       }
 
-      query = query.trim().toLowerCase();
       // http://blog.tatedavies.com/2012/08/28/replace-microsoft-chars-in-javascript/
       query = query.replace(/[\u2018|\u2019|\u201A]/g, "'");
       query = query.replace(/[\u201C|\u201D|\u201E]/g, '"');

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -35,7 +35,7 @@ import { reviewModesSelector } from '../item-review/reducer';
 import WishListSettings from 'app/settings/WishListSettings';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import { DimStore } from 'app/inventory/store-types';
-import { DimItemInfo } from 'app/inventory/dim-item-info';
+import { DimItemInfo, itemTagList } from 'app/inventory/dim-item-info';
 
 interface StoreProps {
   settings: Settings;
@@ -129,6 +129,7 @@ const languageOptions = mapToOptions({
   'zh-chs': '简体中文' // Chinese (Simplified)
 });
 
+const tagLabelList = itemTagList.map((tagLabel) => t(tagLabel.label));
 const itemSortProperties = {
   typeName: t('Settings.SortByType'),
   rarity: t('Settings.SortByRarity'),
@@ -137,7 +138,7 @@ const itemSortProperties = {
   rating: t('Settings.SortByRating'),
   classType: t('Settings.SortByClassType'),
   name: t('Settings.SortName'),
-  tag: t('Settings.SortByTag')
+  tag: t('Settings.SortByTag', { taglist: tagLabelList.join(t('Settings.SortByTagListSeparator')) })
   // archetype: 'Archetype'
 };
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -130,6 +130,8 @@ const languageOptions = mapToOptions({
 });
 
 const tagLabelList = itemTagList.map((tagLabel) => t(tagLabel.label));
+const listSeparator = ['ja', 'zh-cht', 'zh-chs'].includes(settings.language) ? '、' : ', ';
+const tagListString = tagLabelList.join(listSeparator);
 const itemSortProperties = {
   typeName: t('Settings.SortByType'),
   rarity: t('Settings.SortByRarity'),
@@ -138,10 +140,9 @@ const itemSortProperties = {
   rating: t('Settings.SortByRating'),
   classType: t('Settings.SortByClassType'),
   name: t('Settings.SortName'),
-  tag: t('Settings.SortByTag', { taglist: tagLabelList.join(t('Settings.SortByTagListSeparator')) })
+  tag: t('Settings.SortByTag', { taglist: tagListString })
   // archetype: 'Archetype'
 };
-
 const colorA11yOptions = $featureFlags.colorA11y
   ? listToOptions([
       '-',

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -7,7 +7,7 @@ import ItemPickerContainer from '../item-picker/ItemPickerContainer';
 import MoveAmountPopupContainer from '../inventory/MoveAmountPopupContainer';
 import { t } from 'app/i18next-t';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
-import { itemTags } from '../inventory/dim-item-info';
+import { itemTagList } from '../inventory/dim-item-info';
 import { Hotkey } from '../hotkeys/hotkeys';
 import { DispatchProp, connect } from 'react-redux';
 import { loadWishListAndInfoFromIndexedDB } from 'app/wishlists/reducer';
@@ -36,7 +36,7 @@ class Destiny extends React.Component<Props> {
       }
     ];
 
-    itemTags.forEach((tag) => {
+    itemTagList.forEach((tag) => {
       if (tag.hotkey) {
         hotkeys.push({
           combo: tag.hotkey,

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -140,6 +140,10 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
     const tag = getTag(item, store.getState().inventory.itemInfos);
     return tag ? tagSortOrder[tag] : 1000;
   }),
+  archive: compareBy((item: DimItem) => {
+    const tag = getTag(item, store.getState().inventory.itemInfos);
+    return tag === 'archive';
+  }),
   default: () => 0
 };
 
@@ -196,8 +200,9 @@ export function sortItems(items: DimItem[], itemSortOrder = itemSortOrderFn(sett
     );
   }
 
+  // always sort by archive first
   const comparator = chainComparator(
-    ...itemSortOrder.map((o) => ITEM_COMPARATORS[o] || ITEM_COMPARATORS.default)
+    ...['archive', ...itemSortOrder].map((o) => ITEM_COMPARATORS[o] || ITEM_COMPARATORS.default)
   );
   return items.sort(comparator);
 }

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -6,9 +6,8 @@ import { DimStore } from '../inventory/store-types';
 import { itemSortOrder as itemSortOrderFn } from '../settings/item-sort';
 import { characterSortSelector } from '../settings/character-sort';
 import store from '../store/store';
-import { TagValue, getTag } from '../inventory/dim-item-info';
+import { tagSortOrder, getTag } from '../inventory/dim-item-info';
 import { getRating } from '../item-review/reducer';
-
 // This file defines filters for DIM that may be shared among
 // different parts of DIM.
 
@@ -116,13 +115,6 @@ const ITEM_SORT_BLACKLIST = new Set([
   'BUCKET_POSTMASTER',
   '215593132' // LostItems
 ]);
-
-const tagSortOrder: { [key in TagValue]: number } = {
-  favorite: 0,
-  keep: 1,
-  infuse: 2,
-  junk: 3
-};
 
 // TODO: pass in state
 const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -8,6 +8,7 @@ import {
   faTrashAlt
 } from '@fortawesome/free-regular-svg-icons';
 import {
+  faArchive,
   faArrowCircleUp,
   faBars,
   faCheckCircle,
@@ -70,6 +71,7 @@ export {
   dimHunterIcon as hunterIcon,
   dimTitanIcon as titanIcon,
   dimWarlockIcon as warlockIcon,
+  faArchive as archiveIcon,
   faArrowAltCircleUp as raiseReputationIcon,
   faArrowCircleUp as updateIcon,
   faArrowRight as rightArrowIcon,

--- a/src/locale/de/dim.json
+++ b/src/locale/de/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "Powerlevel",
     "SortByRarity": "Seltenheit",
     "SortByRating": "Community-Bewertung oder Rüstungsqualität",
-    "SortByTag": "Tag (Favorite, Keep, Infuse, Trash)",
+    "SortByTag": "Tag ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Typ",
     "SortCustom": "Benutzerdefinierte Sortierung",
     "SortName": "Name"

--- a/src/locale/de/dim.json
+++ b/src/locale/de/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "Seltenheit",
     "SortByRating": "Community-Bewertung oder Rüstungsqualität",
     "SortByTag": "Tag ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Typ",
     "SortCustom": "Benutzerdefinierte Sortierung",
     "SortName": "Name"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -711,7 +711,6 @@
     "SortByRarity": "Rarity",
     "SortByRating": "Community Rating or Armor Quality",
     "SortByTag": "Tag ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Type",
     "SortCustom": "Custom Sort",
     "SortName": "Name"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -689,6 +689,8 @@
     "General": "General",
     "Inventory": "Inventory Display",
     "InventoryColumns": "Character inventory width",
+    "InventoryColumnsMobile": "Character inventory width on mobile portrait",
+    "InventoryColumnsMobileLine2": "The items will be resized to accommodate the new setting",
     "Items": "Item Display",
     "Language": "Language",
     "LogOut": "Log out",
@@ -708,7 +710,8 @@
     "SortByPrimary": "Power level",
     "SortByRarity": "Rarity",
     "SortByRating": "Community Rating or Armor Quality",
-    "SortByTag": "Tag (Favorite, Keep, Infuse, Trash)",
+    "SortByTag": "Tag ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Type",
     "SortCustom": "Custom Sort",
     "SortName": "Name"
@@ -788,6 +791,7 @@
     "GoogleDriveReAuth": "To re-authorize google drive, you must restart your browser."
   },
   "Tags": {
+    "Archive": "Archive",
     "ClearTag": "Clear",
     "Favorite": "Favorite",
     "Infuse": "Infuse",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -273,6 +273,7 @@
     "StatsLoadout": "Finds a set of items to equip for the maximum total value of a specific stat.",
     "StatsMax": "Finds armor with the highest number for a specific stat. Includes all items with the highest stat.",
     "Tags": {
+      "Archive": "Dims items you rarely need.",
       "Dismantle": "Shows items you wish to eventually dismantle.",
       "Favorite": "Shows favorite items.",
       "Infuse": "Shows items you wish to eventually infuse.",

--- a/src/locale/es-ES/dim.json
+++ b/src/locale/es-ES/dim.json
@@ -718,7 +718,6 @@
     "SortByRarity": "Rareza",
     "SortByRating": "Calificación de la comunidad o calidad de armadura",
     "SortByTag": "Etiqueta ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Orden Personalizado",
     "SortName": "Nombre"

--- a/src/locale/es-ES/dim.json
+++ b/src/locale/es-ES/dim.json
@@ -717,7 +717,8 @@
     "SortByPrimary": "Nivel de Poder",
     "SortByRarity": "Rareza",
     "SortByRating": "Calificación de la comunidad o calidad de armadura",
-    "SortByTag": "Etiqueta (Favorito, Guardar, Infundir, Basura)",
+    "SortByTag": "Etiqueta ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Orden Personalizado",
     "SortName": "Nombre"

--- a/src/locale/es-MX/dim.json
+++ b/src/locale/es-MX/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "Nivel de Poder",
     "SortByRarity": "Rareza",
     "SortByRating": "Calificación de la comunidad o calidad de armadura",
-    "SortByTag": "Etiquetar (Favorito, Guardar, Infundir, Basura)",
+    "SortByTag": "Etiquetar ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Orden Personalizado",
     "SortName": "Nombre"

--- a/src/locale/es-MX/dim.json
+++ b/src/locale/es-MX/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "Rareza",
     "SortByRating": "Calificación de la comunidad o calidad de armadura",
     "SortByTag": "Etiquetar ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Orden Personalizado",
     "SortName": "Nombre"

--- a/src/locale/fr/dim.json
+++ b/src/locale/fr/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "Niveau de puissance",
     "SortByRarity": "Rareté",
     "SortByRating": "Note de la communauté ou qualité de l'armure",
-    "SortByTag": "Tag (Favoris, Garder, Infuser, Jeter)",
+    "SortByTag": "Tag ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Type",
     "SortCustom": "Tri personnalisé",
     "SortName": "Nom"

--- a/src/locale/fr/dim.json
+++ b/src/locale/fr/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "Rareté",
     "SortByRating": "Note de la communauté ou qualité de l'armure",
     "SortByTag": "Tag ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Type",
     "SortCustom": "Tri personnalisé",
     "SortName": "Nom"

--- a/src/locale/it/dim.json
+++ b/src/locale/it/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "Rarità",
     "SortByRating": "Giudizio della comunità o Qualità Armatura",
     "SortByTag": "Etichetta ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Ordinamento Personalizzato",
     "SortName": "Nome"

--- a/src/locale/it/dim.json
+++ b/src/locale/it/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "Livello di Potere",
     "SortByRarity": "Rarità",
     "SortByRating": "Giudizio della comunità o Qualità Armatura",
-    "SortByTag": "Etichetta (Preferito, Tieni, Smantella, Infondi)",
+    "SortByTag": "Etichetta ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Ordinamento Personalizzato",
     "SortName": "Nome"

--- a/src/locale/ja/dim.json
+++ b/src/locale/ja/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "パワーレベル",
     "SortByRarity": "希少性",
     "SortByRating": "コミュニティの評価や鎧の品質",
-    "SortByTag": "タグ (お気に入り、保存、融合、ゴミ箱)",
+    "SortByTag": "タグ ({{taglist}})",
+    "SortByTagListSeparator": "、",
     "SortByType": "種類",
     "SortCustom": "カスタムソート",
     "SortName": "名前"

--- a/src/locale/ja/dim.json
+++ b/src/locale/ja/dim.json
@@ -706,8 +706,6 @@
     "SortByRarity": "希少性",
     "SortByRating": "コミュニティの評価や鎧の品質",
     "SortByTag": "タグ ({{taglist}})",
-    "SortByTagListSeparator": "、",
-    "SortByType": "種類",
     "SortCustom": "カスタムソート",
     "SortName": "名前"
   },

--- a/src/locale/ko/dim.json
+++ b/src/locale/ko/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "전투력",
     "SortByRarity": "희귀도",
     "SortByRating": "커뮤니티 평가나 방어구 품질",
-    "SortByTag": "태그 (즐겨찾기, 보관, 주입, 쓰레기)",
+    "SortByTag": "태그 ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "유형",
     "SortCustom": "사용자 지정 정렬",
     "SortName": "이름"

--- a/src/locale/ko/dim.json
+++ b/src/locale/ko/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "희귀도",
     "SortByRating": "커뮤니티 평가나 방어구 품질",
     "SortByTag": "태그 ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "유형",
     "SortCustom": "사용자 지정 정렬",
     "SortName": "이름"

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "Poziom mocy",
     "SortByRarity": "Rzadkość",
     "SortByRating": "Ocena społeczności lub Jakość Pancerza",
-    "SortByTag": "Tagi (Ulubione, Zachowaj, Nasyć, Śmieci)",
+    "SortByTag": "Tagi ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Rodzaj",
     "SortCustom": "Sortowanie niestandardowe",
     "SortName": "Nazwa"

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "Rzadkość",
     "SortByRating": "Ocena społeczności lub Jakość Pancerza",
     "SortByTag": "Tagi ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Rodzaj",
     "SortCustom": "Sortowanie niestandardowe",
     "SortName": "Nazwa"

--- a/src/locale/pt-BR/dim.json
+++ b/src/locale/pt-BR/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "Nível de poder",
     "SortByRarity": "Raridade",
     "SortByRating": "Avaliação da Comunidade ou Qualidade da Armadura",
-    "SortByTag": "Marca (Favorito, Manter, Infundir, Lixo)",
+    "SortByTag": "Marca ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Ordenação Personalizada",
     "SortName": "Nome"

--- a/src/locale/pt-BR/dim.json
+++ b/src/locale/pt-BR/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "Raridade",
     "SortByRating": "Avaliação da Comunidade ou Qualidade da Armadura",
     "SortByTag": "Marca ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Tipo",
     "SortCustom": "Ordenação Personalizada",
     "SortName": "Nome"

--- a/src/locale/ru/dim.json
+++ b/src/locale/ru/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "Редкость",
     "SortByRating": "Рейтинги Сообщества или Качество Брони",
     "SortByTag": "Тег ({{taglist}})",
-    "SortByTagListSeparator": ", ",
     "SortByType": "Тип",
     "SortCustom": "Свой порядок",
     "SortName": "Имя"

--- a/src/locale/ru/dim.json
+++ b/src/locale/ru/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "По Силе",
     "SortByRarity": "Редкость",
     "SortByRating": "Рейтинги Сообщества или Качество Брони",
-    "SortByTag": "Тег (Избранное, Оставить, Мусор, На синтез)",
+    "SortByTag": "Тег ({{taglist}})",
+    "SortByTagListSeparator": ", ",
     "SortByType": "Тип",
     "SortCustom": "Свой порядок",
     "SortName": "Имя"

--- a/src/locale/zh-CN/dim.json
+++ b/src/locale/zh-CN/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "稀有度",
     "SortByRating": "社区评分或装备质量指数",
     "SortByTag": "标签 ({{taglist}})",
-    "SortByTagListSeparator": "、",
     "SortByType": "类型",
     "SortCustom": "自定义排序",
     "SortName": "名称"

--- a/src/locale/zh-CN/dim.json
+++ b/src/locale/zh-CN/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "光等",
     "SortByRarity": "稀有度",
     "SortByRating": "社区评分或装备质量指数",
-    "SortByTag": "标签 (收藏夹、保留、信息、废纸篓)",
+    "SortByTag": "标签 ({{taglist}})",
+    "SortByTagListSeparator": "、",
     "SortByType": "类型",
     "SortCustom": "自定义排序",
     "SortName": "名称"

--- a/src/locale/zh-TW/dim.json
+++ b/src/locale/zh-TW/dim.json
@@ -705,7 +705,8 @@
     "SortByPrimary": "光等",
     "SortByRarity": "稀有度",
     "SortByRating": "社區評分或裝備品質指數",
-    "SortByTag": "标签 (收藏夹、保留、信息、废纸篓)",
+    "SortByTag": "标签 ({{taglist}})",
+    "SortByTagListSeparator": "、",
     "SortByType": "類型",
     "SortCustom": "自訂排序",
     "SortName": "名稱"

--- a/src/locale/zh-TW/dim.json
+++ b/src/locale/zh-TW/dim.json
@@ -706,7 +706,6 @@
     "SortByRarity": "稀有度",
     "SortByRating": "社區評分或裝備品質指數",
     "SortByTag": "标签 ({{taglist}})",
-    "SortByTagListSeparator": "、",
     "SortByType": "類型",
     "SortCustom": "自訂排序",
     "SortName": "名稱"


### PR DESCRIPTION
the answer to "why no pvp tag?" is that tags are meant for inventory management, not denoting what you like about an item. notes, wishlists, etc are the answer.
tags are a to-do list. they demonstrate the user's intention for the item.

one "inventory management" intention that i don't feel we cover,
is "not going to delete but not actively using it"
"keep" is extremely broad, and if it's not worth "highlight as favorite", the vast majority of stuff ends up in keep.

let's face it, compared to the innumerable players not using an app at all, we cater to hoarders.
everyone has some items they aren't ready to part with,
but which clutter up the Giant Wall Of Items that the DIM inventory can become.

can't Infuse these, they'd intermingle with actual Infuse.
can't Junk these, it would remove the ease of moving then deleting all your Junk without thinking too hard.

so, Archive. the hope is to distinguish this use case very clearly from other tags.
Archived items are dimmed by default so you can skip them as you speedread your inventory.
they sort to the end of all other tags.
the user sees their intention ("set this aside") expressed visually.

![2999J4](https://user-images.githubusercontent.com/31990469/67580203-c9d5ce00-f6fa-11e9-9c89-2d082e87a0fe.gif)

using search overrides the dimming, and they show up normally if the filter would include them.