### PR TITLE
Fix non-base stat search filters using stat's base value

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1312,7 +1312,7 @@ function searchFilters(
       },
       // create a stat filter for each stat name
       ...hashes.allStatNames.reduce((obj, name) => {
-        obj[name] = filterByStats(name, true);
+        obj[name] = filterByStats(name, false);
         return obj;
       }, {}),
       // create a basestat filter for each armor stat name


### PR DESCRIPTION
This PR fixes an issue whereby `stat:*` search filters were filtering based on the stat's base value instead of the stat's current value (base value + contributions from stat mods and masterwork bonus).

Test item [Discipline = 15 (base) + 10 (Discipline mod)]:
![dim-itemwithdisciplinemod](https://user-images.githubusercontent.com/17512262/67613173-dd6e5b00-f806-11e9-9950-ce24d795f1e5.PNG)

![dim-stat-search-values](https://user-images.githubusercontent.com/17512262/67613311-7651a600-f808-11e9-8f3d-adb606fbf7b7.png)

