### PR TITLE
Swap Banshee for DTR

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+* Wish lists support integrating with DTR's item database URLs.
+
 # 5.51.0 (2019-10-20)
 
 * Added an option to disable using ornament icons. Even when enabled, ornaments will only show for items where the ornament is specific to that item - not universal ornaments.

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -15,9 +15,9 @@ Feel free to share your curated lists with your fireteam, the raid you're sherpa
 
 If you want to hit the ground running, you can find a collection of breakdowns from u/pandapaxxy and u/mercules904 translated into wish lists over on [48klocs' DIM wish list sources - in particular, the voltron.txt file (that includes armor recommendations from u/HavocsCall) will probably be of interest](https://github.com/48klocs/dim-wish-list-sources). Feel free to mix and match the individual files as you like.
 
-## Linking To Banshee-44 from DIM
+## Linking To Destiny Tracker's items database from DIM
 
-If you have a roll in your inventory that you'd like to add to your wish list to share, you can do it from inside of DIM. Find your item, make sure you have the perks you think are important selected (this is important!) and click the little gift icon on the top right hand corner of the item's pop-up. It'll bring you to banshee-44 to double-check if you want, or just copy and paste it into your file.
+If you have a roll in your inventory that you'd like to add to your wish list to share, you can do it from inside of DIM. Find your item, make sure you have the perks you think are important selected (this is important!) and click the name of the item in the title bar of the item's pop-up. It'll bring you to Destiny Tracker's items database. You can double-check if you want, change the perks (for the roll you wish you had), or just copy and paste it into your file.
 
 ## Title and Description
 You can optionally add a title and/or description to your wish lists. For title, add a line that looks like...
@@ -70,6 +70,6 @@ This lets you do things like, for example, wish list all armor pieces that have 
 
 If there are multiple perks for a given slot that you'd be happy to get, and further there are multiple slots where multiple perks would be nice, then [48klocs built a little tool that will help you build out all of those permutations](https://48klocs.github.io/wish-list-magic-wand/fingerwave.html).
 
-For wishlist line items, we'll ignore comments at the end of the line. Banshee-44 URLs are expected to be copy/paste friendly, so comments on those lines will break them.
+For wishlist line items, we'll ignore comments at the end of the line. Destiny Tracker + Banshee-44 URLs are expected to be copy/paste friendly, so comments on those lines (outside of the faux-anchor notes) will break them.
 
 As a final note, shaders/ornaments/masterworks are ignored.

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -7,7 +7,7 @@ import LockButton from './LockButton';
 import ExternalLink from '../dim-ui/ExternalLink';
 import { settings } from '../settings/settings';
 import { AppIcon } from '../shell/icons';
-import { faGift, faChevronCircleUp, faChevronCircleDown } from '@fortawesome/free-solid-svg-icons';
+import { faChevronCircleUp, faChevronCircleDown } from '@fortawesome/free-solid-svg-icons';
 import { faClone } from '@fortawesome/free-regular-svg-icons';
 import { CompareService } from '../compare/compare.service';
 import { ammoTypeClass } from './ammo-type';
@@ -29,7 +29,6 @@ export default function ItemPopupHeader({
   onToggleExpanded(): void;
 }) {
   const hasLeftIcon = (item.isDestiny1() && item.trackable) || item.lockable || item.dmg;
-  const b44Link = banshee44Link(item);
   const openCompare = () => {
     hideItemPopup();
     CompareService.addItemsToCompare([item], true);
@@ -86,11 +85,6 @@ export default function ItemPopupHeader({
             {item.name}
           </ExternalLink>
         </div>
-        {b44Link && (
-          <ExternalLink href={b44Link} className="info">
-            <AppIcon icon={faGift} title={t('WishListRoll.Header')} />
-          </ExternalLink>
-        )}
         {item.comparable && (
           <a className="compare-button info" title={t('Compare.ButtonHelp')} onClick={openCompare}>
             <AppIcon icon={faClone} />
@@ -156,18 +150,6 @@ function destinyDBLink(item: DimItem) {
   }
 
   return `https://destinytracker.com/destiny-2/db/items/${item.hash}${perkQueryString}`;
-}
-
-function banshee44Link(item: DimItem) {
-  if (
-    item.isDestiny2() &&
-    item.primStat &&
-    item.primStat.statHash === 1480404414 && // weapon
-    item.sockets &&
-    item.sockets.sockets
-  ) {
-    return `https://banshee-44.com/?weapon=${item.hash}&socketEntries=${buildPerksCsv(item)}`;
-  }
 }
 
 /**

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -46,7 +46,7 @@ function toDtrWishListRoll(dtrTextLine: string): WishListRoll | null {
   }
 
   const matchResults = dtrTextLine.match(
-    /^^https:\/\/destinytracker\.com\/destiny-2\/db\/items\/(\d+)(?:.*)?perks=([\d,]*)(?:#notes:)?(.*)?/
+    /^https:\/\/destinytracker\.com\/destiny-2\/db\/items\/(\d+)(?:.*)?perks=([\d,]*)(?:#notes:)?(.*)?/
   );
 
   if (!matchResults || !expectedMatchResultsLength(matchResults)) {


### PR DESCRIPTION
Banshee-44 is still lagging behind Shadowkeep's API changes a bit, plus DTR's item database has been updated and allows you to search and configure the perks you want. It's pretty slick!

This adds support for DTR's item DB URLs for wish lists, and removes the gift icon from the header. I updated the documentation as well. B-44 link lines in a wish list file still work.

![dtr wish list integration](https://user-images.githubusercontent.com/606888/67620627-f101cd80-f7d6-11e9-9e20-d30c73272ce1.png)

This resolves #4534 