### PR TITLE
Nicer looking tooltips?

### DIFF
--- a/src/app/dim-ui/PressTip.scss
+++ b/src/app/dim-ui/PressTip.scss
@@ -2,11 +2,11 @@
 
 .tooltip {
   position: absolute;
-  background: #fb9f28;
-  color: black;
+  background-color: #444;
+  color: white;
   width: fit-content;
   max-width: 250px;
-  border-radius: 3px;
+  border-top: 5px solid #888;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
   padding: 8px;
   text-align: left;
@@ -14,6 +14,7 @@
   white-space: pre-wrap;
 
   h2 {
+    background-color: #444;
     margin: 0 0 4px 0;
     font-size: 14px;
     @include destiny-header;
@@ -29,7 +30,7 @@
 }
 
 .tooltip .tooltip-arrow {
-  border-color: #fb9f28;
+  border-color: #444;
 }
 .tooltip[x-placement^='top'] {
   margin-bottom: 5px;

--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -75,7 +75,6 @@
     }
   }
   img {
-    filter: invert(100%);
     vertical-align: bottom;
     margin-right: 2px;
   }

--- a/src/browsercheck.js
+++ b/src/browsercheck.js
@@ -55,5 +55,5 @@ if (!supported) {
     'Browser ' + browser + ' is not supported by DIM. Supported browsers:',
     browsersSupported
   );
-  document.getElementById('browser-warning').className = '';
+  document.getElementById('browser-warning').style.display = 'block';
 }

--- a/src/index.html
+++ b/src/index.html
@@ -42,15 +42,15 @@
     <% }) %>
   </head>
 
-  <body>
+  <body style="background-color: #313233; color: #999; font-family: sans-serif;">
     <div id="app">
-      <div class="notloaded">
+      <div class="notloaded" style="padding: 1em;">
         DIM hasn't loaded. Something may be wrong with it, or with your browser (maybe you have a
         content blocker, or have disabled JavaScript, or your browser is too old). Try force
         reloading to make sure (Ctrl-F5 or Cmd-R).
       </div>
     </div>
-    <div id="browser-warning" class="hidden">
+    <div id="browser-warning" style="padding: 1em; display: none;">
       Your browser is not supported by DIM. Some or all DIM functionality may not work. Please
       switch to a supported browser.
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -42,7 +42,7 @@
     <% }) %>
   </head>
 
-  <body style="background-color: #313233; color: #999; font-family: sans-serif;">
+  <body style="background-color: #313233; color: white; font-family: sans-serif;">
     <div id="app">
       <div class="notloaded" style="padding: 1em;">
         DIM hasn't loaded. Something may be wrong with it, or with your browser (maybe you have a


### PR DESCRIPTION
Thought I'd de-orange the tooltips:

![image](https://user-images.githubusercontent.com/313208/67630116-7f119e80-f83f-11e9-84c2-9d51075ae1b0.png)

Also @sundevour I ended up darkening the not-loaded screen, once you pointed it out I couldn't unsee it.