### PR TITLE
Don't globally apply sans-serif font

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="">
   <!-- DIM v<%= version %>, built <%= date %> -->
+
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -42,15 +43,15 @@
     <% }) %>
   </head>
 
-  <body style="background-color: #313233; color: white; font-family: sans-serif;">
+  <body style="background-color: #313233; color: white;">
     <div id="app">
-      <div class="notloaded" style="padding: 1em;">
+      <div class="notloaded" style="padding: 1em; font-family: sans-serif;">
         DIM hasn't loaded. Something may be wrong with it, or with your browser (maybe you have a
         content blocker, or have disabled JavaScript, or your browser is too old). Try force
         reloading to make sure (Ctrl-F5 or Cmd-R).
       </div>
     </div>
-    <div id="browser-warning" style="padding: 1em; display: none;">
+    <div id="browser-warning" style="padding: 1em; display: none; font-family: sans-serif;">
       Your browser is not supported by DIM. Some or all DIM functionality may not work. Please
       switch to a supported browser.
     </div>


### PR DESCRIPTION
This PR fixes an issue whereby the sans-serif font is being globally applied to the app instead of only to the **Not Loaded** or **Not Supported** views.

![dim-global-font](https://user-images.githubusercontent.com/17512262/67644753-30701b80-f989-11e9-80a7-cfff4d036612.gif)
