### PR TITLE
Undo scrolling headers

### DIFF
--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -158,7 +158,6 @@ $xp-bar-height: 2px;
 
 .character-box.vault {
   border-bottom: 0;
-  height: 46px + $xp-bar-height;
   .background {
     background-color: black;
     background-position: center right;

--- a/src/app/inventory/StoreHeading.scss
+++ b/src/app/inventory/StoreHeading.scss
@@ -157,6 +157,7 @@ $xp-bar-height: 2px;
 }
 
 .character-box.vault {
+  width: calc(6px + var(--character-column-width) - var(--item-margin));
   border-bottom: 0;
   .background {
     background-color: black;

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -155,6 +155,7 @@
   filter: var(--color-filter);
   .store-cell {
     padding: 8px var(--inventory-column-padding) 6px var(--inventory-column-padding);
+    flex-direction: column;
   }
   @supports (position: sticky) {
     position: sticky;

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -94,6 +94,15 @@ class Stores extends React.Component<Props, State> {
                         onTapped={this.selectStore}
                         loadoutMenuRef={this.detachedLoadoutMenu}
                       />
+                      {isVault(store) ? (
+                        <VaultStats store={store} />
+                      ) : (
+                        <CharacterStats
+                          destinyVersion={store.destinyVersion}
+                          stats={store.stats}
+                          store={store}
+                        />
+                      )}
                     </View>
                   ))}
                 </Track>
@@ -120,6 +129,15 @@ class Stores extends React.Component<Props, State> {
               style={storeBackgroundColor(store, index)}
             >
               <StoreHeading store={store} />
+              {isVault(store) ? (
+                <VaultStats store={store} />
+              ) : (
+                <CharacterStats
+                  destinyVersion={store.destinyVersion}
+                  stats={store.stats}
+                  store={store}
+                />
+              )}
             </div>
           ))}
         </ScrollClassDiv>
@@ -159,27 +177,6 @@ class Stores extends React.Component<Props, State> {
 
     return (
       <>
-        <div className="store-row">
-          {stores.map((store, index) => (
-            <div
-              key={store.id}
-              className={clsx('store-cell', {
-                vault: store.isVault
-              })}
-              style={storeBackgroundColor(store, index)}
-            >
-              {isVault(store) ? (
-                <VaultStats store={store} />
-              ) : (
-                <CharacterStats
-                  destinyVersion={store.destinyVersion}
-                  stats={store.stats}
-                  store={store}
-                />
-              )}
-            </div>
-          ))}
-        </div>
         {Object.keys(buckets.byCategory).map(
           (category) =>
             categoryHasItems(buckets, category, stores, currentStore) && (

--- a/src/app/inventory/VaultStats.m.scss
+++ b/src/app/inventory/VaultStats.m.scss
@@ -7,6 +7,7 @@
   align-items: center;
   font-size: 11px;
   color: #aaa;
+  margin-top: 8px;
 
   img,
   .bucketTag {

--- a/src/app/inventory/VaultStats.m.scss
+++ b/src/app/inventory/VaultStats.m.scss
@@ -35,7 +35,17 @@
 .bucketTag {
   font-weight: bold;
   font-size: 14px;
+  line-height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: #888;
+  img {
+    height: 14px;
+    width: 14px;
+    filter: invert(1);
+    opacity: 0.6;
+  }
 }
 
 .full {

--- a/src/app/inventory/VaultStats.tsx
+++ b/src/app/inventory/VaultStats.tsx
@@ -8,6 +8,17 @@ import { numberFormatter } from 'app/utils/util';
 import { settings } from 'app/settings/settings';
 import _ from 'lodash';
 import styles from './VaultStats.m.scss';
+import modificationsIcon from 'destiny-icons/general/modifications.svg';
+import shadersIcon from 'destiny-icons/general/shaders.svg';
+import consumablesIcon from 'destiny-icons/general/consumables.svg';
+import vaultIcon from 'destiny-icons/armor_types/helmet.svg';
+
+const bucketIcons = {
+  3313201758: modificationsIcon,
+  2973005342: shadersIcon,
+  1469714392: consumablesIcon,
+  138197802: vaultIcon
+};
 
 export default function VaultStats({ store }: { store: DimVault }) {
   return (
@@ -37,7 +48,11 @@ export default function VaultStats({ store }: { store: DimVault }) {
           })}
         >
           <div className={styles.bucketTag}>
-            {store.vaultCounts[bucketId].bucket.name.substring(0, 1)}
+            {bucketIcons[bucketId] ? (
+              <img src={bucketIcons[bucketId]} />
+            ) : (
+              store.vaultCounts[bucketId].bucket.name.substring(0, 1)
+            )}
           </div>
           <PressTip key={bucketId} tooltip={<VaultToolTip counts={store.vaultCounts[bucketId]} />}>
             <div>

--- a/src/app/inventory/dimStats.scss
+++ b/src/app/inventory/dimStats.scss
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-around;
+  margin-top: 8px;
 
   .phone-portrait & {
     margin-left: auto;


### PR DESCRIPTION
I don't really want to make a stink about the headers, so this puts 'em back until we've really hashed out what to do with them.

![image](https://user-images.githubusercontent.com/313208/67739428-adbe7f00-f9cf-11e9-9c05-9d6fecafad94.png)

While I was at it I replaced the poorly-localized letters with icons for vault buckets.