### PR TITLE
Prefer moving items to the matching class

### DIFF
--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -15,7 +15,6 @@ import { showNotification } from '../notifications/notifications';
 import { BungieMembershipType } from 'bungie-api-ts/user';
 
 // sortOrder: orders items within a bucket, ascending
-// displacePriority: smaller tends toward vault, higher tends toward characters
 // these exist in comments so i18n       t('Tags.Favorite') t('Tags.Keep') t('Tags.Infuse')
 // doesn't delete the translations       t('Tags.Junk') t('Tags.Archive') t('Tags.TagItem')
 export const tagConfig = {
@@ -23,8 +22,6 @@ export const tagConfig = {
     type: 'favorite' as 'favorite',
     label: 'Tags.Favorite',
     sortOrder: 0,
-    // Favorites you probably want on your character
-    displacePriority: 3,
     hotkey: 'shift+1',
     icon: heartIcon
   },
@@ -32,8 +29,6 @@ export const tagConfig = {
     type: 'keep' as 'keep',
     label: 'Tags.Keep',
     sortOrder: 1,
-    // Keeps are pretty neutral
-    displacePriority: 1,
     hotkey: 'shift+2',
     icon: tagIcon
   },
@@ -41,8 +36,6 @@ export const tagConfig = {
     type: 'infuse' as 'infuse',
     label: 'Tags.Infuse',
     sortOrder: 2,
-    // Infusion fuel belongs in the vault
-    displacePriority: -1,
     hotkey: 'shift+4',
     icon: boltIcon
   },
@@ -50,8 +43,6 @@ export const tagConfig = {
     type: 'junk' as 'junk',
     label: 'Tags.Junk',
     sortOrder: 3,
-    // Junk should probably bubble towards the character so you remember to delete them!
-    displacePriority: 2,
     hotkey: 'shift+3',
     icon: banIcon
   },
@@ -59,14 +50,47 @@ export const tagConfig = {
     type: 'archive' as 'archive',
     label: 'Tags.Archive',
     sortOrder: 4,
-    // Archived items should keep out of the way
-    displacePriority: -2,
     hotkey: 'shift+5',
     icon: archiveIcon
   }
 };
 
 export type TagValue = keyof typeof tagConfig | 'clear' | 'lock' | 'unlock';
+
+/**
+ * Priority order for which items should get moved off a character (into the vault or another character)
+ * when the character is full and you want to move something new in. Tag values earlier in this list
+ * are more likely to be moved.
+ */
+export const characterDisplacePriority: (TagValue | 'none')[] = [
+  // Archived items should move to the vault
+  'archive',
+  // Infusion fuel belongs in the vault
+  'infuse',
+  'none',
+  'junk',
+  'keep',
+  // Favorites you probably want to keep on your character
+  'favorite'
+];
+
+/**
+ * Priority order for which items should get moved out of the vault (onto a character)
+ * when the vault is full and you want to move something new in. Tag values earlier in this list
+ * are more likely to be moved.
+ */
+export const vaultDisplacePriority: (TagValue | 'none')[] = [
+  // Junk should probably bubble towards the character so you remember to delete them!
+  'junk',
+  'none',
+  'keep',
+  // Favorites you probably want to keep in the vault if you put them there
+  'favorite',
+  // Infusion fuel belongs in the vault
+  'infuse',
+  // Archived items should absolutely stay in the vault
+  'archive'
+];
 
 /**
  * Extra DIM-specific info, stored per item.
@@ -93,22 +117,6 @@ export const itemTagSelectorList: TagInfo[] = [
   { label: 'Tags.TagItem' },
   ...Object.values(tagConfig)
 ];
-
-// populate tagSortOrder & tagDisplacePriority from tag config info
-export const tagSortOrder: { [key in TagValue]: number } = Object.values(tagConfig).reduce(
-  (result, tagDef) => {
-    result[tagDef.type] = tagDef.sortOrder;
-    return result;
-  },
-  {} as { [key in TagValue]: number }
-);
-export const tagDisplacePriority: { [key in TagValue]: number } = Object.values(tagConfig).reduce(
-  (result, tagDef) => {
-    result[tagDef.type] = tagDef.displacePriority;
-    return result;
-  },
-  {} as { [key in TagValue]: number }
-);
 
 class ItemInfo implements DimItemInfo {
   constructor(

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -684,10 +684,17 @@ function ItemService(): ItemServiceType {
         // we're not moving the original item *from* the vault, put
         // the candidate on another character in order to avoid
         // gumming up the vault.
-        const openVaultSlots = Math.floor(
-          cachedSpaceLeft(vault, candidate) / candidate.maxStackSize
+        const openVaultAmount = cachedSpaceLeft(vault, candidate);
+        const openVaultSlotsBeforeMove = Math.floor(openVaultAmount / candidate.maxStackSize);
+        const openVaultSlotsAfterMove = Math.max(
+          0,
+          Math.floor((openVaultAmount - candidate.amount) / candidate.maxStackSize)
         );
-        if (openVaultSlots === 1 && otherCharacterWithSpace) {
+        if (
+          openVaultSlotsBeforeMove === 1 &&
+          openVaultSlotsAfterMove === 0 &&
+          otherCharacterWithSpace
+        ) {
           moveAsideCandidate = {
             item: candidate,
             target: otherCharacterWithSpace

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -516,7 +516,7 @@ function ItemService(): ItemServiceType {
 
     // Start with candidates of the same type (or vault bucket if it's vault)
     // TODO: This try/catch is to help debug https://sentry.io/destiny-item-manager/dim/issues/484361056/
-    let allItems;
+    let allItems: DimItem[];
     try {
       allItems = store.isVault
         ? store.items.filter(
@@ -648,8 +648,13 @@ function ItemService(): ItemServiceType {
       // available space for the candidate item.
       const otherNonVaultStores = _.sortBy(
         otherStores.filter((s) => !s.isVault && s.id !== item.owner),
-        (s) => cachedSpaceLeft(s, candidate)
-      ).reverse();
+        [
+          // If the item has a class affinity, prefer to send it to a matching character.
+          (s) =>
+            candidate.classType === DestinyClass.Unknown || candidate.classType === s.classType,
+          (s) => cachedSpaceLeft(s, candidate)
+        ]
+      ).reverse(); // <= Note that we're reversing the result
       otherNonVaultStores.push(storeService.getStore(item.owner)!);
       const otherCharacterWithSpace = otherNonVaultStores.find(
         (s) => cachedSpaceLeft(s, candidate) > 0

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -604,6 +604,8 @@ function ItemService(): ItemServiceType {
         compareBy((i) => !i.equipped),
         // prefer same type over everything
         compareBy((i) => i.type === item.type),
+        // or at least same category
+        compareBy((i) => i.bucket.sort === item.bucket.sort),
         // Always prefer keeping something that was manually moved where it is
         compareBy((i) => -i.lastManuallyMoved),
         // Engrams prefer to be in the vault, so not-engram is larger than engram
@@ -656,13 +658,10 @@ function ItemService(): ItemServiceType {
       // owner ranked last, but otherwise sorted by the
       // available space for the candidate item.
       const otherNonVaultStores = _.sortBy(
-        otherStores.filter((s) => !s.isVault && s.id !== item.owner),
-        [
-          // If the item has a class affinity, prefer to send it to a matching character.
-          (s) =>
-            candidate.classType === DestinyClass.Unknown || candidate.classType === s.classType,
-          (s) => cachedSpaceLeft(s, candidate)
-        ]
+        otherStores.filter((s) => !s.isVault && s.id !== item.owner && s.id !== currentChar.id),
+        // If the item has a class affinity, prefer to send it to a matching character.
+        (s) => candidate.classType === DestinyClass.Unknown || candidate.classType === s.classType,
+        (s) => cachedSpaceLeft(s, candidate)
       ).reverse(); // <= Note that we're reversing the result
       otherNonVaultStores.push(storeService.getStore(item.owner)!);
       const otherCharacterWithSpace = otherNonVaultStores.find(

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -132,7 +132,7 @@ class SearchFilter extends React.Component<Props, State> {
         // existing tags are later passed to buttonEffect so the notif button knows what to revert
         const previousState = tagItems.map((item) => ({
           item,
-          setTag: item.dimInfo.tag as TagValue | 'clear' | 'lock' | 'unlock'
+          setTag: item.dimInfo.tag as TagValue
         }));
         await itemInfoService.bulkSaveByKeys(
           tagItems.map((item) => ({

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -6,7 +6,7 @@ import { DimStore } from '../inventory/store-types';
 import { itemSortOrder as itemSortOrderFn } from '../settings/item-sort';
 import { characterSortSelector } from '../settings/character-sort';
 import store from '../store/store';
-import { tagSortOrder, getTag } from '../inventory/dim-item-info';
+import { getTag, tagConfig } from '../inventory/dim-item-info';
 import { getRating } from '../item-review/reducer';
 // This file defines filters for DIM that may be shared among
 // different parts of DIM.
@@ -138,7 +138,7 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
   amount: reverseComparator(compareBy((item: DimItem) => item.amount)),
   tag: compareBy((item: DimItem) => {
     const tag = getTag(item, store.getState().inventory.itemInfos);
-    return tag ? tagSortOrder[tag] : 1000;
+    return tag ? tagConfig[tag].sortOrder : 1000;
   }),
   archive: compareBy((item: DimItem) => {
     const tag = getTag(item, store.getState().inventory.itemInfos);


### PR DESCRIPTION
I still need to test this out (and I need to clear out vault space to do that), but this should fix https://github.com/DestinyItemManager/DIM/issues/4419 by preferring to move items with class affinity to characters of the same class. Keep in mind that when we have to move something from the vault, we already prioritize characters other than the item's current owner first, and then sort by free space. This just changes that to sorting by class type before free space.