### PR TITLE
Highlight pullable postmaster items on hover

### DIFF
--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -18,6 +18,10 @@
   }
 }
 
+:global(.item-postmaster-hover) {
+  outline: 1px solid #ddd;
+}
+
 // The top-level item container. Global because it's referenced by other styles.
 :global(.item) {
   position: relative;

--- a/src/app/inventory/PullFromPostmaster.tsx
+++ b/src/app/inventory/PullFromPostmaster.tsx
@@ -4,6 +4,7 @@ import { pullablePostmasterItems, pullFromPostmaster } from '../loadout/postmast
 import { queueAction } from './action-queue';
 import { t } from 'app/i18next-t';
 import { AppIcon, refreshIcon, sendIcon } from '../shell/icons';
+import idx from 'idx';
 
 interface Props {
   store: D2Store;
@@ -26,7 +27,12 @@ export class PullFromPostmaster extends React.Component<Props, State> {
     }
 
     return (
-      <div className="dim-button bucket-button" onClick={this.onClick}>
+      <div
+        className="dim-button bucket-button"
+        onClick={this.onClick}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      >
         <AppIcon spinning={working} icon={working ? refreshIcon : sendIcon} />{' '}
         <span className="badge">{numPullablePostmasterItems}</span>{' '}
         {t('Loadouts.PullFromPostmaster')}
@@ -42,6 +48,23 @@ export class PullFromPostmaster extends React.Component<Props, State> {
       } finally {
         this.setState({ working: false });
       }
+    });
+  };
+
+  private onMouseEnter = () => {
+    const pullableItems = pullablePostmasterItems(this.props.store);
+    pullableItems.forEach((item) => {
+      const element = idx(document.getElementById(item.index), (e) => e.parentNode) as HTMLElement;
+      if (!element) {
+        throw new Error(`No element with id ${item.index}`);
+      }
+      element.classList.add('item-postmaster-hover');
+    });
+  };
+
+  private onMouseLeave = () => {
+    [].forEach.call(document.querySelectorAll('.item-postmaster-hover'), (el) => {
+      (el as HTMLElement).classList.remove('item-postmaster-hover');
     });
   };
 }


### PR DESCRIPTION
It would be useful to know exactly which items will be pulled when clicking "Collect Postmaster". This adds a small outline effect to the items when hovering the button to indicate it.

This is probably not the best way to implement this, with querySelectorAll etc, but it shows the desired effect.