### PR TITLE
Add a setting for making space when pulling from postmaster

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -715,6 +715,7 @@
     "Language": "Language",
     "LogOut": "Log out",
     "Ornaments": "Use ornament icons (D2)",
+    "PullPostmasterMakeSpace": "Make space when collecting from Postmaster",
     "Ratings": "Ratings",
     "ReloadDIM": "Reload DIM to finish switching language",
     "ResetToDefault": "Reset",

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -256,6 +256,13 @@ class SettingsPage extends React.Component<Props> {
                 options={colorA11yOptions}
                 onChange={this.onChange}
               />
+
+              <Checkbox
+                label={t('Settings.PullPostmasterMakeSpace')}
+                name="pullPostmasterMakeSpace"
+                value={settings.pullPostmasterMakeSpace}
+                onChange={this.pullPostmasterMakeSpaceChanged}
+              />
             </section>
 
             <section id="items">
@@ -515,6 +522,11 @@ class SettingsPage extends React.Component<Props> {
 
   private ornamentsChanged: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     this.props.setSetting('ornaments', e.target.checked ? 'unique' : 'none');
+    D2StoresService.reloadStores();
+  };
+
+  private pullPostmasterMakeSpaceChanged: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    this.props.setSetting('pullPostmasterMakeSpace', e.target.checked);
     D2StoresService.reloadStores();
   };
 

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -75,6 +75,9 @@ export interface Settings {
    * In the future we may bring back the universal ornament setting, but not now.
    */
   readonly ornaments: 'none' | 'unique';
+
+  /** Whether to make space when collecting from Postmaster. */
+  readonly pullPostmasterMakeSpace: boolean;
 }
 
 export function defaultItemSize() {
@@ -130,7 +133,8 @@ export const initialState: Settings = {
   language: defaultLanguage(),
 
   colorA11y: '-',
-  ornaments: 'unique'
+  ornaments: 'unique',
+  pullPostmasterMakeSpace: true
 };
 
 export type SettingsAction = ActionType<typeof actions>;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -710,6 +710,7 @@
     "Language": "Language",
     "LogOut": "Log out",
     "Ornaments": "Use ornament icons (D2)",
+    "PullPostmasterMakeSpace": "Make space when collecting from Postmaster",
     "Ratings": "Ratings",
     "ReloadDIM": "Reload DIM to finish switching language",
     "ResetToDefault": "Reset",


### PR DESCRIPTION
This adds a checkbox to the Settings screen in General "Make space when collecting from Postmaster". It defaults to true, which is the current behaviour.

If unchecked, the "Collect from Postmaster" button won't make space by vaulting items and will only collect as many items as there is space for.

The case for this behaviour is the elimination of uncertainty from UI actions. When space is made, the decision on which items to vault is made automatically, usually by picking the lowest power item. This has the effect of potentially removing something from a character that the user wanted there, without allowing them an easy way to know which item that was.

If only items for which there is space are moved, then users can be confident their equipment won't be randomised when clicking the button. In the case of pulling from postmaster for dismantling, this means that desired items don't get replaced by junk items.

I'd argue this is a common scenario for people with full vaults and filled out collections, as postmasters tend to get filled up with blues or junk rolls in that case.

---

I understand that having too many settings is undesirable, and that this will likely not be accepted as is, at least without further discussion or revision. I understand that settings that change the behaviour of a button are also not a great pattern.

Another option might be to have a separate button next to the "Collect from Postmaster" labeled like "If space". This would add clutter to the primary UI though so it's probably also not that desirable.