### PR TITLE
Add eslint arrow-body-style rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,6 +63,9 @@
       }
     ],
     "arrow-body-style": ["error", "as-needed"],
+    "no-return-await": "error",
+    "prefer-regex-literals": "error",
+    "prefer-promise-reject-errors": "error",
     "require-atomic-updates": "off",
     "react/no-unescaped-entities": "off",
     "react/jsx-no-target-blank": "off",
@@ -100,6 +103,7 @@
     "@typescript-eslint/no-unnecessary-qualifier": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -62,6 +62,7 @@
         "message": "Please use the native js filter."
       }
     ],
+    "arrow-body-style": ["error", "as-needed"],
     "require-atomic-updates": "off",
     "react/no-unescaped-entities": "off",
     "react/jsx-no-target-blank": "off",

--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -95,12 +95,11 @@ async function loadActivePlatform(): Promise<DestinyAccount | undefined> {
   }
 
   if (data && data.membershipId) {
-    const active = accounts.find((platform) => {
-      return (
+    const active = accounts.find(
+      (platform) =>
         platform.membershipId === data.membershipId &&
         platform.destinyVersion === data.destinyVersion
-      );
-    });
+    );
     if (active) {
       return active;
     }

--- a/src/app/bungie-api/bungie-core-api.ts
+++ b/src/app/bungie-api/bungie-core-api.ts
@@ -22,14 +22,12 @@ const GlobalAlertLevelsToToastLevels = [
 export async function getGlobalAlerts(): Promise<GlobalAlert[]> {
   const response = await httpAdapter(bungieApiQuery(`/Platform/GlobalAlerts/`));
   if (response && response.Response) {
-    return response.Response.map((alert) => {
-      return {
-        key: alert.AlertKey,
-        type: GlobalAlertLevelsToToastLevels[alert.AlertLevel],
-        body: alert.AlertHtml,
-        timestamp: alert.AlertTimestamp
-      };
-    });
+    return response.Response.map((alert) => ({
+      key: alert.AlertKey,
+      type: GlobalAlertLevelsToToastLevels[alert.AlertLevel],
+      body: alert.AlertHtml,
+      timestamp: alert.AlertTimestamp
+    }));
   }
   return [];
 }

--- a/src/app/bungie-api/destiny1-api.ts
+++ b/src/app/bungie-api/destiny1-api.ts
@@ -68,13 +68,13 @@ function processInventoryResponse(character, response: ServerResponse<any>) {
 
 function getDestinyInventories(platform: DestinyAccount, characters: any[]) {
   // Guardians
-  const promises = characters.map((character) => {
-    return httpAdapter(
+  const promises = characters.map((character) =>
+    httpAdapter(
       bungieApiQuery(
         `/D1/Platform/Destiny/${platform.originalPlatformType}/Account/${platform.membershipId}/Character/${character.id}/Inventory/`
       )
-    ).then((response) => processInventoryResponse(character, response));
-  });
+    ).then((response) => processInventoryResponse(character, response))
+  );
 
   // Vault
   const vault = {

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -447,9 +447,7 @@ class Compare extends React.Component<Props, State> {
             matchingIntrisics &&
             matchingIntrisics.includes(getIntrinsicPerk(i))
         )
-      : filteredSets[n.sameWeaponType].filter((i) => {
-          return rpm === getRpm(i);
-        });
+      : filteredSets[n.sameWeaponType].filter((i) => rpm === getRpm(i));
 
     filteredSets[n.sameWeaponTypeAndElement] = filteredSets[n.sameWeaponTypeAndSlot].filter(
       (i) => i.dmg === compare.dmg

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -208,9 +208,7 @@ class Activities extends React.Component<Props> {
     };
 
     if (rawActivity.extended) {
-      activity.skulls = rawActivity.extended.skullCategories.map((s) => {
-        return s.skulls.flat();
-      });
+      activity.skulls = rawActivity.extended.skullCategories.map((s) => s.skulls.flat());
     }
 
     const rawSkullCategories = rawActivity.activityTiers[0].skullCategories;

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -138,11 +138,7 @@ export const getBuckets = _.once(async () => {
     }
   });
   _.forIn(D1Categories, (types, category) => {
-    buckets.byCategory[category] = _.compact(
-      types.map((type) => {
-        return buckets.byType[type];
-      })
-    );
+    buckets.byCategory[category] = _.compact(types.map((type) => buckets.byType[type]));
   });
   return buckets;
 });

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -528,15 +528,14 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
     };
 
     function filterItems(items: D1Item[]) {
-      return items.filter((item) => {
-        return (
+      return items.filter(
+        (item) =>
           item.primStat &&
           item.primStat.statHash === 3897883278 && // has defense hash
           item.talentGrid &&
           item.talentGrid.nodes &&
           item.stats
-        );
-      });
+      );
     }
 
     let allItems: D1Item[] = [];

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -208,9 +208,9 @@ export function getSetBucketsStep(
         g = 0;
       }
 
-      const tiers = _.groupBy(Array.from(tiersSet.keys()), (tierString: string) => {
-        return _.sumBy(tierString.split('/'), (num) => parseInt(num, 10));
-      });
+      const tiers = _.groupBy(Array.from(tiersSet.keys()), (tierString: string) =>
+        _.sumBy(tierString.split('/'), (num) => parseInt(num, 10))
+      );
       _.forIn(tiers, (tier) => {
         tier.sort().reverse();
       });

--- a/src/app/destiny1/loadout-builder/utils.ts
+++ b/src/app/destiny1/loadout-builder/utils.ts
@@ -188,9 +188,9 @@ export function getBestArmor(
       }
 
       // Filter out excluded and non-wanted perks
-      const filtered = combined.filter((item) => {
-        return !excludedIndices.has(item.index) && hasPerks(item); // Not excluded and has the correct locked perks
-      });
+      const filtered = combined.filter(
+        (item) => !excludedIndices.has(item.index) && hasPerks(item) // Not excluded and has the correct locked perks
+      );
 
       statHashes.forEach((hash, index) => {
         if (!fullMode && index > 2) {
@@ -316,41 +316,13 @@ export function loadBucket(currentStore: DimStore, stores: D1Store[]): ItemBucke
 
 function getBuckets(items: D1Item[]): ItemBucket {
   return {
-    Helmet: items
-      .filter((item) => {
-        return item.type === 'Helmet';
-      })
-      .map(normalizeStats),
-    Gauntlets: items
-      .filter((item) => {
-        return item.type === 'Gauntlets';
-      })
-      .map(normalizeStats),
-    Chest: items
-      .filter((item) => {
-        return item.type === 'Chest';
-      })
-      .map(normalizeStats),
-    Leg: items
-      .filter((item) => {
-        return item.type === 'Leg';
-      })
-      .map(normalizeStats),
-    ClassItem: items
-      .filter((item) => {
-        return item.type === 'ClassItem';
-      })
-      .map(normalizeStats),
-    Artifact: items
-      .filter((item) => {
-        return item.type === 'Artifact';
-      })
-      .map(normalizeStats),
-    Ghost: items
-      .filter((item) => {
-        return item.type === 'Ghost';
-      })
-      .map(normalizeStats)
+    Helmet: items.filter((item) => item.type === 'Helmet').map(normalizeStats),
+    Gauntlets: items.filter((item) => item.type === 'Gauntlets').map(normalizeStats),
+    Chest: items.filter((item) => item.type === 'Chest').map(normalizeStats),
+    Leg: items.filter((item) => item.type === 'Leg').map(normalizeStats),
+    ClassItem: items.filter((item) => item.type === 'ClassItem').map(normalizeStats),
+    Artifact: items.filter((item) => item.type === 'Artifact').map(normalizeStats),
+    Ghost: items.filter((item) => item.type === 'Ghost').map(normalizeStats)
   };
 }
 

--- a/src/app/destiny1/vendors/vendor.service.ts
+++ b/src/app/destiny1/vendors/vendor.service.ts
@@ -354,9 +354,7 @@ function VendorService(): VendorServiceType {
   function factionLevel(store: D1Store, factionHash: number) {
     const rep =
       store.progression &&
-      store.progression.progressions.find((rep) => {
-        return rep.faction && rep.faction.hash === factionHash;
-      });
+      store.progression.progressions.find((rep) => rep.faction && rep.faction.hash === factionHash);
     return (rep && rep.level) || 0;
   }
 
@@ -526,17 +524,15 @@ function VendorService(): VendorServiceType {
               return {
                 index: saleItem.vendorItemIndex,
                 costs: saleItem.costs
-                  .map((cost) => {
-                    return {
-                      value: cost.value,
-                      currency: _.pick(
-                        defs.InventoryItem.get(cost.itemHash),
-                        'itemName',
-                        'icon',
-                        'itemHash'
-                      )
-                    };
-                  })
+                  .map((cost) => ({
+                    value: cost.value,
+                    currency: _.pick(
+                      defs.InventoryItem.get(cost.itemHash),
+                      'itemName',
+                      'icon',
+                      'itemHash'
+                    )
+                  }))
                   .filter((c) => c.value > 0),
                 item: itemsById[`vendor-${vendorDef.hash}-${saleItem.vendorItemIndex}`],
                 // TODO: caveat, this won't update very often!
@@ -612,9 +608,9 @@ function VendorService(): VendorServiceType {
           )!.quantity;
           break;
         default:
-          totalCoins[currencyHash] = _.sumBy(stores, (store) => {
-            return store.amountOfItem({ hash: currencyHash } as any);
-          });
+          totalCoins[currencyHash] = _.sumBy(stores, (store) =>
+            store.amountOfItem({ hash: currencyHash } as any)
+          );
           break;
       }
     });

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -128,11 +128,7 @@ async function getBucketsUncached() {
     }
   });
   _.forIn(D2Categories, (types, category) => {
-    buckets.byCategory[category] = _.compact(
-      types.map((type) => {
-        return buckets.byType[type];
-      })
-    );
+    buckets.byCategory[category] = _.compact(types.map((type) => buckets.byType[type]));
   });
   return buckets;
 }

--- a/src/app/destinyTrackerApi/d2-itemTransformer.ts
+++ b/src/app/destinyTrackerApi/d2-itemTransformer.ts
@@ -123,13 +123,12 @@ function isVendorSaleItem(
 
 function getPowerMods(item: D2Item): DestinyInventoryItemDefinition[] {
   return item.sockets
-    ? _.compact(item.sockets.sockets.map((p) => p.plug && p.plug.plugItem)).filter((plug) => {
-        return (
+    ? _.compact(item.sockets.sockets.map((p) => p.plug && p.plug.plugItem)).filter(
+        (plug) =>
           plug.itemCategoryHashes &&
           plug.investmentStats &&
           plug.itemCategoryHashes.includes(MOD_CATEGORY) &&
           plug.investmentStats.some((s) => s.statTypeHash === POWER_STAT_HASH)
-        );
-      })
+      )
     : [];
 }

--- a/src/app/destinyTrackerApi/d2-perkRater.ts
+++ b/src/app/destinyTrackerApi/d2-perkRater.ts
@@ -80,10 +80,9 @@ function getPlugRatingsAndReviewCount(
 }
 
 function getMatchingReviews(plugOptionHash: number, reviews: D2ItemUserReview[]) {
-  return reviews.filter((review) => {
-    return (
+  return reviews.filter(
+    (review) =>
       (review.selectedPerks && review.selectedPerks.includes(plugOptionHash)) ||
       (review.attachedMods && review.attachedMods.includes(plugOptionHash))
-    );
-  });
+  );
 }

--- a/src/app/destinyTrackerApi/trackerErrorHandler.ts
+++ b/src/app/destinyTrackerApi/trackerErrorHandler.ts
@@ -5,9 +5,7 @@ export function handleErrors(response: Response) {
     throw new Error(t('DtrReview.ServiceCallError'));
   }
 
-  return response.text().then((text) => {
-    return text ? JSON.parse(text) : {};
-  });
+  return response.text().then((text) => (text ? JSON.parse(text) : {}));
 }
 
 /**
@@ -21,7 +19,5 @@ export function handleSubmitErrors(response: Response) {
   }
 
   // https://github.com/github/fetch/issues/268
-  return response.text().then((text) => {
-    return text ? JSON.parse(text) : {};
-  });
+  return response.text().then((text) => (text ? JSON.parse(text) : {}));
 }

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -214,8 +214,8 @@ function useLockSheetContents(sheetContents: React.MutableRefObject<HTMLDivEleme
     [blockEvents, sheetContents]
   );
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       if (sheetContents.current) {
         document.body.classList.remove('body-scroll-lock');
         sheetContents.current.removeEventListener('touchstart', blockEvents);
@@ -223,8 +223,9 @@ function useLockSheetContents(sheetContents: React.MutableRefObject<HTMLDivEleme
           enableBodyScroll(sheetContents.current);
         }
       }
-    };
-  }, [blockEvents, sheetContents]);
+    },
+    [blockEvents, sheetContents]
+  );
 
   return sheetContentsRefFn;
 }

--- a/src/app/farming/d2farming.service.ts
+++ b/src/app/farming/d2farming.service.ts
@@ -14,11 +14,9 @@ import { moveItemsToVault } from './farming.service';
 import { filter, map, tap, exhaustMap } from 'rxjs/operators';
 
 function getMakeRoomBuckets() {
-  return getBuckets().then((buckets) => {
-    return Object.values(buckets.byHash).filter(
-      (b) => b.category === BucketCategory.Equippable && b.type
-    );
-  });
+  return getBuckets().then((buckets) =>
+    Object.values(buckets.byHash).filter((b) => b.category === BucketCategory.Equippable && b.type)
+  );
 }
 
 /**

--- a/src/app/inventory/action-queue.ts
+++ b/src/app/inventory/action-queue.ts
@@ -7,14 +7,7 @@ export function queueAction(fn: () => Promise<any>) {
   // Execute fn regardless of the result of the existing promise. We
   // don't use finally here because finally can't modify the return value.
   promise = promise
-    .then(
-      () => {
-        return fn();
-      },
-      () => {
-        return fn();
-      }
-    )
+    .then((..._args) => fn(), (..._args) => fn())
     .then(
       (value) => {
         _queue.shift();
@@ -35,9 +28,5 @@ export function queuedAction<T extends any[], K>(
   fn: (...args: T) => Promise<K>,
   context?
 ): (...args: T) => Promise<any> {
-  return (...args: T) => {
-    return queueAction(() => {
-      return fn.apply(context, args);
-    });
-  };
+  return (...args: T) => queueAction(() => fn.apply(context, args));
 }

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -252,9 +252,7 @@ function StoreService(): D1StoreServiceType {
       store.items = items;
 
       // by type-bucket
-      store.buckets = _.groupBy(items, (i) => {
-        return i.location.id;
-      });
+      store.buckets = _.groupBy(items, (i) => i.location.id);
 
       // Fill in any missing buckets
       Object.values(buckets.byType).forEach((bucket) => {

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -439,12 +439,11 @@ function makeD2StoresService(): D2StoreServiceType {
       const def = defs.Stat.get(1935470627);
       const maxBasePower = getLight(store, maxBasePowerLoadout(stores, store));
       const hasClassified = _stores.some((s) =>
-        s.items.some((i) => {
-          return (
+        s.items.some(
+          (i) =>
             i.classified &&
             (i.location.sort === 'Weapons' || i.location.sort === 'Armor' || i.type === 'Ghost')
-          );
-        })
+        )
       );
 
       store.stats.maxGearPower = {

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -73,21 +73,13 @@ function ItemService(): ItemServiceType {
   // thrown away or moved and we just don't have up to date info. But let's
   // throttle these calls so we don't just keep refreshing over and over.
   // This needs to be up here because of how we return the service object.
-  const throttledReloadStores = _.throttle(
-    () => {
-      return D1StoresService.reloadStores();
-    },
-    10000,
-    { trailing: false }
-  );
+  const throttledReloadStores = _.throttle(() => D1StoresService.reloadStores(), 10000, {
+    trailing: false
+  });
 
-  const throttledD2ReloadStores = _.throttle(
-    () => {
-      return D2StoresService.reloadStores();
-    },
-    10000,
-    { trailing: false }
-  );
+  const throttledD2ReloadStores = _.throttle(() => D2StoresService.reloadStores(), 10000, {
+    trailing: false
+  });
 
   return {
     getSimilarItem,
@@ -279,8 +271,8 @@ function ItemService(): ItemServiceType {
   ): DimItem | null {
     const exclusionsList = exclusions || [];
 
-    let candidates = store.items.filter((i) => {
-      return (
+    let candidates = store.items.filter(
+      (i) =>
         i.canBeEquippedBy(target) &&
         i.location.id === item.location.id &&
         !i.equipped &&
@@ -288,8 +280,7 @@ function ItemService(): ItemServiceType {
         i.id !== item.id &&
         // Not on the exclusion list
         !exclusionsList.some((item) => item.id === i.id && item.hash === i.hash)
-      );
-    });
+    );
 
     if (!candidates.length) {
       return null;
@@ -631,9 +622,7 @@ function ItemService(): ItemServiceType {
 
     // A cached version of the space-left function
     const cachedSpaceLeft = _.memoize(
-      (store: DimStore, item: DimItem) => {
-        return moveContext.spaceLeft(store, item);
-      },
+      (store: DimStore, item: DimItem) => moveContext.spaceLeft(store, item),
       (store, item) => {
         // cache key
         if (item.maxStackSize > 1) {

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -792,9 +792,9 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
   let armorNodes: D1GridNode[] = [];
   let activeArmorNode;
   if (grid && grid.nodes && item.primaryStat && item.primaryStat.statHash === 3897883278) {
-    armorNodes = grid.nodes.filter((node) => {
-      return [1034209669, 1263323987, 193091484].includes(node.hash); // ['Increase Intellect', 'Increase Discipline', 'Increase Strength']
-    });
+    armorNodes = grid.nodes.filter(
+      (node) => [1034209669, 1263323987, 193091484].includes(node.hash) // ['Increase Intellect', 'Increase Discipline', 'Increase Strength']
+    );
     if (armorNodes) {
       activeArmorNode = armorNodes.find((n) => n.activated) || { hash: 0 };
     }

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -47,9 +47,7 @@ const StoreProto = {
    */
   amountOfItem(this: D1Store, item: D1Item) {
     return _.sumBy(
-      this.items.filter((i) => {
-        return i.hash === item.hash && !i.location.inPostmaster;
-      }),
+      this.items.filter((i) => i.hash === item.hash && !i.location.inPostmaster),
       (i) => i.amount
     );
   },

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -63,9 +63,9 @@ const _moveTouchTimestamps = new Map<string, number>();
 
 const SourceToD2Season = D2SeasonToSource.sources;
 
-const collectiblesByItemHash = _.once((Collectible) => {
-  return _.keyBy(Collectible.getAll(), (c) => c.itemHash);
-});
+const collectiblesByItemHash = _.once((Collectible) =>
+  _.keyBy(Collectible.getAll(), (c) => c.itemHash)
+);
 
 /**
  * Prototype for Item objects - add methods to this to add them to all
@@ -466,9 +466,10 @@ export function makeItem(
   if (itemDef.perks && itemDef.perks.length) {
     createdItem.perks = itemDef.perks
       .map(
-        (p): DimPerk => {
-          return { requirement: p.requirementDisplayString, ...defs.SandboxPerk.get(p.perkHash) };
-        }
+        (p): DimPerk => ({
+          requirement: p.requirementDisplayString,
+          ...defs.SandboxPerk.get(p.perkHash)
+        })
       )
       .filter((p) => p.isDisplayable);
     if (createdItem.perks.length === 0) {

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -32,9 +32,9 @@ const StoreProto = {
    * excluding stuff in the postmaster.
    */
   amountOfItem(this: D2Store, item: D2Item) {
-    return _.sumBy(this.items, (i) => {
-      return i.hash === item.hash && (!i.location || !i.location.inPostmaster) ? i.amount : 0;
-    });
+    return _.sumBy(this.items, (i) =>
+      i.hash === item.hash && (!i.location || !i.location.inPostmaster) ? i.amount : 0
+    );
   },
 
   /**
@@ -219,13 +219,11 @@ export function makeVault(
   defs: D2ManifestDefinitions,
   profileCurrencies: DestinyItemComponent[]
 ): D2Vault {
-  const currencies = profileCurrencies.map((c) => {
-    return {
-      itemHash: c.itemHash,
-      quantity: c.quantity,
-      displayProperties: defs.InventoryItem.get(c.itemHash).displayProperties
-    };
-  });
+  const currencies = profileCurrencies.map((c) => ({
+    itemHash: c.itemHash,
+    quantity: c.quantity,
+    displayProperties: defs.InventoryItem.get(c.itemHash).displayProperties
+  }));
 
   return Object.assign(Object.create(StoreProto), {
     destinyVersion: 2,

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -137,14 +137,12 @@ export function buildInstancedSockets(
   );
 
   const categories = itemDef.sockets.socketCategories.map(
-    (category): DimSocketCategory => {
-      return {
-        category: defs.SocketCategory.get(category.socketCategoryHash),
-        sockets: category.socketIndexes
-          .map((index) => realSockets[index])
-          .filter(Boolean) as DimSocket[]
-      };
-    }
+    (category): DimSocketCategory => ({
+      category: defs.SocketCategory.get(category.socketCategoryHash),
+      sockets: category.socketIndexes
+        .map((index) => realSockets[index])
+        .filter(Boolean) as DimSocket[]
+    })
   );
 
   return {
@@ -169,14 +167,12 @@ function buildDefinedSockets(
   // TODO: check out intrinsicsockets as well
 
   const categories = itemDef.sockets.socketCategories.map(
-    (category): DimSocketCategory => {
-      return {
-        category: defs.SocketCategory.get(category.socketCategoryHash),
-        sockets: _.compact(category.socketIndexes.map((index) => realSockets[index])).filter(
-          (s) => s.plugOptions.length
-        )
-      };
-    }
+    (category): DimSocketCategory => ({
+      category: defs.SocketCategory.get(category.socketCategoryHash),
+      sockets: _.compact(category.socketIndexes.map((index) => realSockets[index])).filter(
+        (s) => s.plugOptions.length
+      )
+    })
   );
 
   return {

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -172,9 +172,7 @@ export function D1QualitySummaryStat({ item }: { item: D1Item }) {
 
 function getPlugHashesFromCategory(category: DimSocketCategory) {
   return category.sockets
-    .map((socket) => {
-      return idx(socket, (socket) => socket.plug.plugItem.hash) || null;
-    })
+    .map((socket) => idx(socket, (socket) => socket.plug.plugItem.hash) || null)
     .filter(Boolean);
 }
 
@@ -187,9 +185,9 @@ function getNonReuseableModSockets(item: DimItem) {
     return [];
   }
 
-  const reusableSocketCategory = item.sockets.categories.find((category) => {
-    return category.category.categoryStyle === DestinySocketCategoryStyle.Reusable;
-  });
+  const reusableSocketCategory = item.sockets.categories.find(
+    (category) => category.category.categoryStyle === DestinySocketCategoryStyle.Reusable
+  );
 
   const reusableSocketHashes =
     (reusableSocketCategory && getPlugHashesFromCategory(reusableSocketCategory)) || [];
@@ -209,11 +207,9 @@ function getNonReuseableModSockets(item: DimItem) {
  * Returns the total value the stat is modified by, or 0 if it is not being modified.
  */
 function getModdedStatValue(item: DimItem, stat: DimStat) {
-  const modSockets = getNonReuseableModSockets(item).filter((socket) => {
-    return Object.keys(idx(socket, (socket) => socket.plug.stats) || {}).includes(
-      String(stat.statHash)
-    );
-  });
+  const modSockets = getNonReuseableModSockets(item).filter((socket) =>
+    Object.keys(idx(socket, (socket) => socket.plug.stats) || {}).includes(String(stat.statHash))
+  );
 
   // _.sum returns 0 for empty array
   return _.sum(
@@ -236,9 +232,9 @@ function getArmor2MasterworkSockets(item: D2Item) {
     return [];
   }
 
-  const masterworkSocketCategory = item.sockets.categories.find((category) => {
-    return category.category.categoryStyle === DestinySocketCategoryStyle.EnergyMeter;
-  });
+  const masterworkSocketCategory = item.sockets.categories.find(
+    (category) => category.category.categoryStyle === DestinySocketCategoryStyle.EnergyMeter
+  );
   const masterworkSocketHashes =
     (masterworkSocketCategory && getPlugHashesFromCategory(masterworkSocketCategory)) || [];
 
@@ -252,11 +248,12 @@ function getArmor2MasterworkSockets(item: D2Item) {
  * Sums up all the armor statistics from the plug in the socket.
  */
 function getSumOfArmorStats(sockets: DimSocket[], armorStatHashes: number[]) {
-  return _.sumBy(sockets, (socket) => {
-    return _.sumBy(armorStatHashes, (armorStatHash) => {
-      return (socket.plug && socket.plug.stats && socket.plug.stats[armorStatHash]) || 0;
-    });
-  });
+  return _.sumBy(sockets, (socket) =>
+    _.sumBy(
+      armorStatHashes,
+      (armorStatHash) => (socket.plug && socket.plug.stats && socket.plug.stats[armorStatHash]) || 0
+    )
+  );
 }
 
 function breakDownTotalValue(statValue: number, item: DimItem) {

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -98,17 +98,15 @@ function mapStateToProps() {
     }
   );
 
-  return (state: RootState): StoreProps => {
-    return {
-      storesLoaded: storesLoadedSelector(state),
-      stores: sortedStoresSelector(state),
-      isPhonePortrait: state.shell.isPhonePortrait,
-      items: itemsSelector(state),
-      defs: state.manifest.d2Manifest,
-      searchConfig: searchConfigSelector(state),
-      filters: searchFiltersConfigSelector(state)
-    };
-  };
+  return (state: RootState): StoreProps => ({
+    storesLoaded: storesLoadedSelector(state),
+    stores: sortedStoresSelector(state),
+    isPhonePortrait: state.shell.isPhonePortrait,
+    items: itemsSelector(state),
+    defs: state.manifest.d2Manifest,
+    searchConfig: searchConfigSelector(state),
+    filters: searchFiltersConfigSelector(state)
+  });
 }
 
 /**

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -101,15 +101,13 @@ function mapStateToProps() {
     }
   );
 
-  return (state: RootState): StoreProps => {
-    return {
-      buckets: state.inventory.buckets!,
-      perks: perksSelector(state),
-      stores: storesSelector(state),
-      isPhonePortrait: state.shell.isPhonePortrait,
-      language: state.settings.language
-    };
-  };
+  return (state: RootState): StoreProps => ({
+    buckets: state.inventory.buckets!,
+    perks: perksSelector(state),
+    stores: storesSelector(state),
+    isPhonePortrait: state.shell.isPhonePortrait,
+    language: state.settings.language
+  });
 }
 
 /**

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -111,12 +111,12 @@ function getBestSets(
   if (Object.values(stats).every((s) => s.min === 0 && s.max === 10)) {
     sortedSets = Array.from(setMap);
   } else {
-    sortedSets = setMap.filter((set) => {
-      return _.every(stats, (value, key) => {
+    sortedSets = setMap.filter((set) =>
+      _.every(stats, (value, key) => {
         const tier = statTier(set.stats[key]);
         return value.min <= tier && value.max >= tier;
-      });
-    });
+      })
+    );
   }
 
   // Prioritize list based on number of matched perks
@@ -132,21 +132,23 @@ function getBestSets(
       return;
     }
     // Sort based on what sets have the most matched perks
-    sortedSets = _.sortBy(sortedSets, (set) => {
-      return -_.sumBy(set.firstValidSet, (firstItem) => {
-        if (!firstItem || !firstItem.isDestiny2() || !firstItem.sockets) {
-          return 0;
-        }
-        return count(firstItem.sockets.sockets, (slot) =>
-          slot.plugOptions.some((perk) =>
-            lockedPerks.some(
-              (lockedPerk) =>
-                lockedPerk.type === 'perk' && lockedPerk.perk.hash === perk.plugItem.hash
+    sortedSets = _.sortBy(
+      sortedSets,
+      (set) =>
+        -_.sumBy(set.firstValidSet, (firstItem) => {
+          if (!firstItem || !firstItem.isDestiny2() || !firstItem.sockets) {
+            return 0;
+          }
+          return count(firstItem.sockets.sockets, (slot) =>
+            slot.plugOptions.some((perk) =>
+              lockedPerks.some(
+                (lockedPerk) =>
+                  lockedPerk.type === 'perk' && lockedPerk.perk.hash === perk.plugItem.hash
+              )
             )
-          )
-        );
-      });
-    });
+          );
+        })
+    );
   });
 
   return sortedSets;

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -418,9 +418,7 @@ export function generateMixesFromPerks(
 
 function getPlugHashesFromCategory(category: DimSocketCategory) {
   return category.sockets
-    .map((socket) => {
-      return idx(socket, (socket) => socket.plug.plugItem.hash) || null;
-    })
+    .map((socket) => idx(socket, (socket) => socket.plug.plugItem.hash) || null)
     .filter(Boolean);
 }
 
@@ -433,9 +431,9 @@ function getBaseStatValues(stats: Dictionary<DimStat>, item: DimItem) {
 
   // Checking energy tells us if it is Armour 2.0
   if (item.isDestiny2() && item.sockets && item.energy) {
-    const masterworkSocketCategory = item.sockets.categories.find((category) => {
-      return category.category.categoryStyle === DestinySocketCategoryStyle.EnergyMeter;
-    });
+    const masterworkSocketCategory = item.sockets.categories.find(
+      (category) => category.category.categoryStyle === DestinySocketCategoryStyle.EnergyMeter
+    );
     const masterworkSocketHashes =
       (masterworkSocketCategory && getPlugHashesFromCategory(masterworkSocketCategory)) || [];
 

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -131,12 +131,11 @@ class LoadoutPopup extends React.Component<Props> {
     const hasClassified = dimStore
       .getStoresService()
       .getAllItems()
-      .some((i) => {
-        return (
+      .some(
+        (i) =>
           i.classified &&
           (i.location.sort === 'Weapons' || i.location.sort === 'Armor' || i.type === 'Ghost')
-        );
-      });
+      );
 
     const maxLight = getLight(dimStore, maxLightLoadout(dimStore.getStoresService(), dimStore));
     const artifactLight = getArtifactBonus(dimStore);

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -11,8 +11,8 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
  *  A dynamic loadout set up to level weapons and armor
  */
 export function itemLevelingLoadout(storeService: StoreServiceType, store: DimStore): Loadout {
-  const applicableItems = storeService.getAllItems().filter((i) => {
-    return (
+  const applicableItems = storeService.getAllItems().filter(
+    (i) =>
       i.canBeEquippedBy(store) &&
       i.talentGrid &&
       !(i.talentGrid as any).xpComplete && // Still need XP
@@ -20,8 +20,7 @@ export function itemLevelingLoadout(storeService: StoreServiceType, store: DimSt
         i.hash !== 3783480580 &&
         i.hash !== 2576945954 &&
         i.hash !== 1425539750)
-    );
-  });
+  );
 
   const bestItemFn = (item) => {
     let value = 0;
@@ -67,8 +66,8 @@ export function maxLightLoadout(storeService: StoreServiceType, store: DimStore)
     368428387 // D1 Attack
   ]);
 
-  const applicableItems = storeService.getAllItems().filter((i) => {
-    return (
+  const applicableItems = storeService.getAllItems().filter(
+    (i) =>
       (i.canBeEquippedBy(store) ||
         (i.location.inPostmaster &&
           (i.classType === DestinyClass.Unknown || i.classType === store.classType) &&
@@ -76,9 +75,8 @@ export function maxLightLoadout(storeService: StoreServiceType, store: DimStore)
           i.equipRequiredLevel <= store.level)) &&
       i.primStat &&
       i.primStat.value && // has a primary stat (sanity check)
-      statHashes.has(i.primStat.statHash)
-    ); // one of our selected stats
-  });
+      statHashes.has(i.primStat.statHash) // one of our selected stats
+  );
 
   const bestItemFn = (item) => {
     let value = item.primStat.value;
@@ -156,9 +154,11 @@ export function gatherEngramsLoadout(
   storeService: StoreServiceType,
   options: { exotics: boolean } = { exotics: false }
 ): Loadout {
-  const engrams = storeService.getAllItems().filter((i) => {
-    return i.isEngram && !i.location.inPostmaster && (options.exotics ? true : !i.isExotic);
-  });
+  const engrams = storeService
+    .getAllItems()
+    .filter(
+      (i) => i.isEngram && !i.location.inPostmaster && (options.exotics ? true : !i.isExotic)
+    );
 
   if (engrams.length === 0) {
     let engramWarning = t('Loadouts.NoEngrams');
@@ -170,9 +170,7 @@ export function gatherEngramsLoadout(
 
   const itemsByType = _.mapValues(_.groupBy(engrams, (e) => e.type), (items) => {
     // Sort exotic engrams to the end so they don't crowd out other types
-    items = _.sortBy(items, (i) => {
-      return i.isExotic ? 1 : 0;
-    });
+    items = _.sortBy(items, (i) => (i.isExotic ? 1 : 0));
     // No more than 9 engrams of a type
     return _.take(items, 9);
   });
@@ -181,9 +179,7 @@ export function gatherEngramsLoadout(
   const finalItems = {};
   _.forIn(itemsByType, (items, type) => {
     if (items) {
-      finalItems[type.toLowerCase()] = items.map((i) => {
-        return copy(i);
-      });
+      finalItems[type.toLowerCase()] = items.map((i, ..._args) => copy(i));
     }
   });
 
@@ -191,9 +187,9 @@ export function gatherEngramsLoadout(
 }
 
 export function gatherTokensLoadout(storeService: StoreServiceType): Loadout {
-  let tokens = storeService.getAllItems().filter((i) => {
-    return i.isDestiny2() && i.itemCategoryHashes.includes(2088636411) && !i.notransfer;
-  });
+  let tokens = storeService
+    .getAllItems()
+    .filter((i) => i.isDestiny2() && i.itemCategoryHashes.includes(2088636411) && !i.notransfer);
 
   if (tokens.length === 0) {
     throw new Error(t('Loadouts.NoTokens'));
@@ -222,9 +218,9 @@ export function searchLoadout(
   store: DimStore,
   searchFilter: (item: DimItem) => boolean
 ): Loadout {
-  let items = storeService.getAllItems().filter((i) => {
-    return !i.location.inPostmaster && !i.notransfer && searchFilter(i);
-  });
+  let items = storeService
+    .getAllItems()
+    .filter((i) => !i.location.inPostmaster && !i.notransfer && searchFilter(i));
 
   items = addUpStackables(items);
 

--- a/src/app/loadout/loadout.service.ts
+++ b/src/app/loadout/loadout.service.ts
@@ -174,9 +174,7 @@ function LoadoutService(): LoadoutServiceType {
     const containsLoadoutGuids = (item) => loadoutGuids.has(item.id);
 
     const orphanIds = Object.values(data)
-      .filter((item) => {
-        return objectTest(item) && hasGuid(item) && !containsLoadoutGuids(item);
-      })
+      .filter((item) => objectTest(item) && hasGuid(item) && !containsLoadoutGuids(item))
       .map((i: DehydratedLoadout) => i.id);
 
     if (orphanIds.length > 0) {
@@ -352,12 +350,10 @@ function LoadoutService(): LoadoutServiceType {
 
     let items: DimItem[] = copy(Object.values(loadout.items)).flat();
 
-    const loadoutItemIds = items.map((i) => {
-      return {
-        id: i.id,
-        hash: i.hash
-      };
-    });
+    const loadoutItemIds = items.map((i) => ({
+      id: i.id,
+      hash: i.hash
+    }));
 
     // Only select stuff that needs to change state
     let totalItems = items.length;
@@ -448,9 +444,7 @@ function LoadoutService(): LoadoutServiceType {
     }
 
     if (equippedItems.length < itemsToEquip.length) {
-      const failedItems = itemsToEquip.filter((i) => {
-        return !equippedItems.find((it) => it.id === i.id);
-      });
+      const failedItems = itemsToEquip.filter((i) => !equippedItems.find((it) => it.id === i.id));
       failedItems.forEach((item) => {
         scope.failed++;
         scope.errors.push({
@@ -522,12 +516,10 @@ function LoadoutService(): LoadoutServiceType {
               .getStores()
               .filter((otherStore) => store.id !== otherStore.id);
             const storesByAmount = _.sortBy(
-              otherStores.map((store) => {
-                return {
-                  store,
-                  amount: store.amountOfItem(pseudoItem)
-                };
-              }),
+              otherStores.map((store) => ({
+                store,
+                amount: store.amountOfItem(pseudoItem)
+              })),
               'amount'
             ).reverse();
 
@@ -647,14 +639,12 @@ function LoadoutService(): LoadoutServiceType {
 
   function dehydrate(loadout: Loadout): DehydratedLoadout {
     const allItems = Object.values(loadout.items).flat();
-    const items = allItems.map((item) => {
-      return {
-        id: item.id,
-        hash: item.hash,
-        amount: item.amount,
-        equipped: item.equipped
-      };
-    }) as DimItem[];
+    const items = allItems.map((item) => ({
+      id: item.id,
+      hash: item.hash,
+      amount: item.amount,
+      equipped: item.equipped
+    })) as DimItem[];
 
     return {
       id: loadout.id,
@@ -699,12 +689,13 @@ export function getLight(store: DimStore, loadout: Loadout): number {
     .filter((i) => i.equipped);
 
   const exactLight =
-    items.reduce((memo, item) => {
-      return (
+    items.reduce(
+      (memo, item) =>
         memo +
-        item.primStat!.value * itemWeight[item.type === 'ClassItem' ? 'General' : item.bucket.sort!]
-      );
-    }, 0) / itemWeightDenominator;
+        item.primStat!.value *
+          itemWeight[item.type === 'ClassItem' ? 'General' : item.bucket.sort!],
+      0
+    ) / itemWeightDenominator;
 
   return Math.floor(exactLight * 10) / 10;
 }

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -72,14 +72,13 @@ export async function makeRoomForPostmaster(
 
 // D2 only
 export function pullablePostmasterItems(store: DimStore) {
-  return (store.buckets[215593132] || []).filter((i) => {
-    // Can be pulled
-    return (
+  return (store.buckets[215593132] || []).filter(
+    (i) =>
+      // Can be pulled
       i.canPullFromPostmaster &&
       // Either has space, or is going to a bucket we can make room in
       ((i.bucket.vaultBucket && !i.notransfer) || store.spaceLeftForItem(i) > 0)
-    );
-  });
+  );
 }
 
 // We should load this from the manifest but it's hard to get it in here

--- a/src/app/progress/Faction.tsx
+++ b/src/app/progress/Faction.tsx
@@ -78,9 +78,11 @@ function calculateEngramsAvailable(
   factionDef: DestinyFactionDefinition,
   factionProgress: DestinyFactionProgression
 ): number {
-  const totalXPAvailable: number = _.sumBy(profileInventory.items, (item: DestinyItemComponent) => {
-    return ((factionDef.tokenValues && factionDef.tokenValues[item.itemHash]) || 0) * item.quantity;
-  });
+  const totalXPAvailable: number = _.sumBy(
+    profileInventory.items,
+    (item: DestinyItemComponent) =>
+      ((factionDef.tokenValues && factionDef.tokenValues[item.itemHash]) || 0) * item.quantity
+  );
 
   return Math.floor(
     (factionProgress.progressToNextLevel + totalXPAvailable) / factionProgress.nextLevelAt

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -77,14 +77,13 @@ function milestonesForProfile(
     ? Object.values(profileMilestoneData)
     : [];
 
-  const filteredMilestones = allMilestones.filter((milestone) => {
-    return (
+  const filteredMilestones = allMilestones.filter(
+    (milestone) =>
       !milestone.availableQuests &&
       !milestone.activities &&
       (milestone.vendors || milestone.rewards) &&
       defs.Milestone.get(milestone.milestoneHash)
-    );
-  });
+  );
 
   return _.sortBy(filteredMilestones, (milestone) => milestone.order);
 }

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -11,11 +11,11 @@ export const sortPursuits = chainComparator(
   compareBy(showPursuitAsExpired),
   compareBy((item) => !item.tracked),
   compareBy((item) => item.complete),
-  compareBy((item) => {
-    return item.isDestiny2() && item.pursuit && item.pursuit.expirationDate
+  compareBy((item) =>
+    item.isDestiny2() && item.pursuit && item.pursuit.expirationDate
       ? item.pursuit.expirationDate
-      : new Date(8640000000000000);
-  }),
+      : new Date(8640000000000000)
+  ),
   compareBy((item) => item.typeName),
   compareBy((item) => item.icon),
   compareBy((item) => item.name)

--- a/src/app/progress/Raids.tsx
+++ b/src/app/progress/Raids.tsx
@@ -42,9 +42,10 @@ export default function Raids({
     const milestoneActivities = (defs.Milestone.get(milestone.milestoneHash) || {}).activities;
     return (
       milestoneActivities &&
-      milestoneActivities.some((activity) => {
-        return (defs.Activity.get(activity.activityHash) || {}).activityTypeHash === 2043403989;
-      })
+      milestoneActivities.some(
+        (activity) =>
+          (defs.Activity.get(activity.activityHash) || {}).activityTypeHash === 2043403989
+      )
     );
   });
 

--- a/src/app/safari-touch-fix.ts
+++ b/src/app/safari-touch-fix.ts
@@ -1,10 +1,8 @@
+import _ from 'lodash';
+
 // https://github.com/timruffles/mobile-drag-drop/issues/77
 // https://github.com/timruffles/mobile-drag-drop/issues/124
 export function safariTouchFix() {
-  const noop = () => {
-    return;
-  };
-
   // Test via a getter in the options object to see if the passive property is accessed
   let supportsPassive = false;
   try {
@@ -14,12 +12,12 @@ export function safariTouchFix() {
         return supportsPassive;
       }
     });
-    window.addEventListener('testPassive', noop, opts);
-    window.removeEventListener('testPassive', noop, opts);
+    window.addEventListener('testPassive', _.noop, opts);
+    window.removeEventListener('testPassive', _.noop, opts);
     // tslint:disable-next-line:no-empty
   } catch (e) {}
 
   supportsPassive
-    ? window.addEventListener('touchmove', noop, { passive: false })
-    : window.addEventListener('touchmove', noop);
+    ? window.addEventListener('touchmove', _.noop, { passive: false })
+    : window.addEventListener('touchmove', _.noop);
 }

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -130,9 +130,10 @@ class SearchFilter extends React.Component<Props, State> {
           .getAllItems()
           .filter((i) => i.taggable && this.props.searchFilter(i));
         // existing tags are later passed to buttonEffect so the notif button knows what to revert
-        const previousState = tagItems.map((item) => {
-          return { item, setTag: item.dimInfo.tag as TagValue | 'clear' | 'lock' | 'unlock' };
-        });
+        const previousState = tagItems.map((item) => ({
+          item,
+          setTag: item.dimInfo.tag as TagValue | 'clear' | 'lock' | 'unlock'
+        }));
         await itemInfoService.bulkSaveByKeys(
           tagItems.map((item) => ({
             key: item.id,
@@ -256,9 +257,8 @@ class SearchFilter extends React.Component<Props, State> {
     this.props.onClear && this.props.onClear();
   };
 
-  private getStoresService = (): StoreServiceType => {
-    return this.props.destinyVersion === 2 ? D2StoresService : D1StoresService;
-  };
+  private getStoresService = (): StoreServiceType =>
+    this.props.destinyVersion === 2 ? D2StoresService : D1StoresService;
 }
 
 export default connect<StoreProps, DispatchProps>(

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -118,9 +118,7 @@ export default class SearchFilterInput extends React.Component<Props, State> {
           type="text"
           name="filter"
           value={liveQuery}
-          onChange={() => {
-            return;
-          }}
+          onChange={_.noop}
           onInput={this.onQueryChange}
           onKeyDown={this.onKeyDown}
           onBlur={() => this.textcomplete && this.textcomplete.hide()}

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -979,9 +979,9 @@ function searchFilters(
         const regex = startWordRegexp(predicate);
         return (
           (item.talentGrid &&
-            item.talentGrid.nodes.some((node) => {
-              return regex.test(node.name) || regex.test(node.description);
-            })) ||
+            item.talentGrid.nodes.some(
+              (node) => regex.test(node.name) || regex.test(node.description)
+            )) ||
           (item.isDestiny2() &&
             item.sockets &&
             item.sockets.sockets.some((socket) =>
@@ -1003,10 +1003,7 @@ function searchFilters(
       perkname(item: DimItem, predicate: string) {
         const regex = startWordRegexp(predicate);
         return (
-          (item.talentGrid &&
-            item.talentGrid.nodes.some((node) => {
-              return regex.test(node.name);
-            })) ||
+          (item.talentGrid && item.talentGrid.nodes.some((node) => regex.test(node.name))) ||
           (item.isDestiny2() &&
             item.sockets &&
             item.sockets.sockets.some((socket) =>
@@ -1256,21 +1253,21 @@ function searchFilters(
       hasShader(item: D2Item) {
         return (
           item.sockets &&
-          item.sockets.sockets.some((socket) => {
-            return Boolean(
+          item.sockets.sockets.some((socket) =>
+            Boolean(
               socket.plug &&
                 socket.plug.plugItem.plug &&
                 socket.plug.plugItem.plug.plugCategoryHash === hashes.shaderBucket &&
                 socket.plug.plugItem.hash !== DEFAULT_SHADER
-            );
-          })
+            )
+          )
         );
       },
       hasMod(item: D2Item) {
         return (
           item.sockets &&
-          item.sockets.sockets.some((socket) => {
-            return Boolean(
+          item.sockets.sockets.some((socket) =>
+            Boolean(
               socket.plug &&
                 !hashes.emptySocketHashes.includes(socket.plug.plugItem.hash) &&
                 socket.plug.plugItem.plug &&
@@ -1281,8 +1278,8 @@ function searchFilters(
                 socket.plug.plugItem.perks.length &&
                 // enforce that this doesn't have an energy cost (y3 reusables)
                 !socket.plug.plugItem.plug.energyCost
-            );
-          })
+            )
+          )
         );
       },
       wishlist(item: D2Item) {

--- a/src/app/settings/Select.tsx
+++ b/src/app/settings/Select.tsx
@@ -33,12 +33,10 @@ export default function Select({
 }
 
 export function mapToOptions(map: { [key: string]: string }) {
-  return _.map(map, (value, key) => {
-    return {
-      name: value,
-      value: key
-    };
-  });
+  return _.map(map, (value, key) => ({
+    name: value,
+    value: key
+  }));
 }
 
 export function listToOptions(list: string[]) {

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -193,13 +193,11 @@ class SettingsPage extends React.Component<Props> {
     const itemSortCustom = _.sortBy(
       _.map(
         itemSortProperties,
-        (displayName, id): SortProperty => {
-          return {
-            id,
-            displayName,
-            enabled: sortOrder.includes(id)
-          };
-        }
+        (displayName, id): SortProperty => ({
+          id,
+          displayName,
+          enabled: sortOrder.includes(id)
+        })
       ),
       (o) => {
         const index = sortOrder.indexOf(o.id);

--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -50,9 +50,7 @@ export const characterComponentSortSelector = createSelector(
 
       case 'mostRecentReverse':
         return (stores: DestinyCharacterComponent[]) =>
-          _.sortBy(stores, (store) => {
-            return new Date(store.dateLastPlayed);
-          });
+          _.sortBy(stores, (store) => new Date(store.dateLastPlayed));
 
       case 'custom': {
         const customSortOrder = customCharacterSort;

--- a/src/app/settings/settings.ts
+++ b/src/app/settings/settings.ts
@@ -13,11 +13,13 @@ export const settingsReady = new Promise((resolve) => (readyResolve = resolve));
 // This is a backwards-compatibility shim for all the code that directly uses settings
 export let settings = initialState;
 
-const saveSettings = _.throttle((settings) => {
-  return SyncService.set({
-    'settings-v1.0': settings
-  });
-}, 1000);
+const saveSettings = _.throttle(
+  (settings) =>
+    SyncService.set({
+      'settings-v1.0': settings
+    }),
+  1000
+);
 
 function saveSettingsOnUpdate() {
   return observeStore(

--- a/src/app/shell/Link.tsx
+++ b/src/app/shell/Link.tsx
@@ -28,9 +28,7 @@ export default class Link extends React.Component<Props, State> {
   componentDidMount() {
     this.unregisterTransitionHooks = [
       router.stateRegistry.onStatesChanged(() => {
-        this.setState((state) => {
-          return { generation: state.generation + 1 };
-        });
+        this.setState((state) => ({ generation: state.generation + 1 }));
       })
     ];
   }

--- a/src/app/shell/loading-tracker.ts
+++ b/src/app/shell/loading-tracker.ts
@@ -26,12 +26,10 @@ class PromiseTracker {
   /** Convert a function that returns a promise into a function that tracks that promise then returns it. */
   trackPromise = <T extends any[], K>(
     promiseFn: (...args: T) => Promise<K>
-  ): ((...args: T) => Promise<K>) => {
-    return (...args: T) => {
-      const promise = promiseFn(...args);
-      this.addPromise(promise);
-      return promise;
-    };
+  ): ((...args: T) => Promise<K>) => (...args: T) => {
+    const promise = promiseFn(...args);
+    this.addPromise(promise);
+    return promise;
   };
 
   private countDown = () => {

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -1,7 +1,7 @@
+import _ from 'lodash';
+
 /** Sentry.io exception reporting */
-export let reportException: (name: string, e: Error, errorInfo?: {}) => void = () => {
-  return;
-};
+export let reportException: (name: string, e: Error, errorInfo?: {}) => void = _.noop;
 
 if ($featureFlags.sentry) {
   // The require instead of import helps us trim this from the production bundle

--- a/src/app/utils/media-queries.ts
+++ b/src/app/utils/media-queries.ts
@@ -18,8 +18,8 @@ export function isPhonePortraitFromMediaQuery() {
  * Return an observable sequence of phone-portrait statuses.
  */
 function isPhonePortraitStream(): Observable<boolean> {
-  return defer(() => {
-    return fromEventPattern<MediaQueryList>(
+  return defer(() =>
+    fromEventPattern<MediaQueryList>(
       (h: (this: MediaQueryList, ev: MediaQueryListEvent) => any) => phoneWidthQuery.addListener(h),
       (h: (this: MediaQueryList, ev: MediaQueryListEvent) => any) =>
         phoneWidthQuery.removeListener(h)
@@ -27,8 +27,8 @@ function isPhonePortraitStream(): Observable<boolean> {
       map((e: MediaQueryList) => e.matches),
       startWith(phoneWidthQuery.matches),
       subscribeOn(asapScheduler)
-    );
-  });
+    )
+  );
 }
 
 isPhonePortraitStream().subscribe((isPhonePortrait) =>

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -4,9 +4,7 @@ import _ from 'lodash';
  * Count the number of values in the list that pass the predicate.
  */
 export function count<T>(list: T[], predicate: (value: T) => boolean): number {
-  return _.sumBy(list, (item) => {
-    return predicate(item) ? 1 : 0;
-  });
+  return _.sumBy(list, (item) => (predicate(item) ? 1 : 0));
 }
 
 /** A shallow copy (just top level properties) of an object, preserving its prototype. */

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -189,26 +189,21 @@ export function getVendorItems(
 
 export function filterVendorGroupsToUnacquired(vendorGroups: readonly D2VendorGroup[]) {
   return vendorGroups
-    .map((group) => {
-      return {
-        ...group,
-        vendors: group.vendors
-          .map((vendor) => {
-            return {
-              ...vendor,
-              items: vendor.items.filter((item) => {
-                return (
-                  item.item &&
-                  item.item.isDestiny2() &&
-                  item.item.collectibleState !== null &&
-                  item.item.collectibleState & DestinyCollectibleState.NotAcquired
-                );
-              })
-            };
-          })
-          .filter((v) => v.items.length)
-      };
-    })
+    .map((group) => ({
+      ...group,
+      vendors: group.vendors
+        .map((vendor) => ({
+          ...vendor,
+          items: vendor.items.filter(
+            (item) =>
+              item.item &&
+              item.item.isDestiny2() &&
+              item.item.collectibleState !== null &&
+              item.item.collectibleState & DestinyCollectibleState.NotAcquired
+          )
+        }))
+        .filter((v) => v.items.length)
+    }))
     .filter((g) => g.vendors.length);
 }
 
@@ -218,22 +213,16 @@ export function filterVendorGroupsToSearch(
   filterItems: (item: DimItem) => boolean
 ) {
   return vendorGroups
-    .map((group) => {
-      return {
-        ...group,
-        vendors: group.vendors
-          .map((vendor) => {
-            return {
-              ...vendor,
-              items: vendor.def.displayProperties.name
-                .toLowerCase()
-                .includes(searchQuery.toLowerCase())
-                ? vendor.items
-                : vendor.items.filter((i) => i.item && filterItems(i.item))
-            };
-          })
-          .filter((v) => v.items.length)
-      };
-    })
+    .map((group) => ({
+      ...group,
+      vendors: group.vendors
+        .map((vendor) => ({
+          ...vendor,
+          items: vendor.def.displayProperties.name.toLowerCase().includes(searchQuery.toLowerCase())
+            ? vendor.items
+            : vendor.items.filter((i) => i.item && filterItems(i.item))
+        }))
+        .filter((v) => v.items.length)
+    }))
     .filter((g) => g.vendors.length);
 }


### PR DESCRIPTION
This adds an autofixing eslint rule that converts all arrow functions to the return-less version, which is a bit more compact. Mostly just going for consistency.

There is an option to retain the `return` when returning an object (which can be a bit subtle because you have to return the result wrapped in parentheses) but I think it's OK.