### PR TITLE
add Firefox ESR to supported list

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "last 2 ChromeAndroid versions",
     "last 2 FirefoxAndroid versions",
     "last 2 Firefox versions",
+    "Firefox ESR",
     "last 2 Safari versions",
     "iOS >= 11",
     "last 2 Edge versions",


### PR DESCRIPTION
Closes #4648 
`npx browserlist`
Before:
```
and_chr 76
and_ff 68
chrome 81
chrome 80
chrome 79
chrome 78
chrome 77
edge 76
edge 18
edge 17
firefox 72
firefox 71
firefox 70
firefox 69
ios_saf 13.0-13.1
ios_saf 12.2-12.4
ios_saf 12.0-12.1
ios_saf 11.3-11.4
ios_saf 11.0-11.2
opera 62
opera 60
safari TP
safari 13
safari 12.1
```
After:
```
and_chr 76
and_ff 68
chrome 81
chrome 80
chrome 79
chrome 78
chrome 77
edge 76
edge 18
edge 17
firefox 72
firefox 71
firefox 70
firefox 69
firefox 68
ios_saf 13.0-13.1
ios_saf 12.2-12.4
ios_saf 12.0-12.1
ios_saf 11.3-11.4
ios_saf 11.0-11.2
opera 62
opera 60
safari TP
safari 13
safari 12.1
```