### PR TITLE
Slim down sockets for LO and compare

### DIFF
--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -48,7 +48,7 @@ export default function CompareItem({
         />
       ))}
       {item.talentGrid && <ItemTalentGrid item={item} perksOnly={true} />}
-      {item.isDestiny2() && item.sockets && <ItemSockets item={item} />}
+      {item.isDestiny2() && item.sockets && <ItemSockets item={item} minimal={true} />}
     </div>
   );
 }

--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -133,16 +133,23 @@
     }
   }
 
-  .sockets {
-    flex-direction: column;
-  }
-
   .item-sockets {
     flex-wrap: nowrap;
   }
   .item-socket {
     margin-right: 2px;
+    &:last-child {
+      margin-right: 0;
+    }
   }
+
+  .item-socket-category {
+    margin-right: 12px;
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
   .item-socket-category-Reusable .item-socket {
     border: none;
     padding: 0;

--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -22,6 +22,7 @@
   margin-right: 16px;
   &:last-child {
     margin-bottom: 0;
+    margin-right: 0;
   }
 }
 
@@ -35,6 +36,9 @@
   margin-right: 4px;
   display: flex;
   flex-direction: column;
+  &:last-child {
+    margin-right: 0;
+  }
 
   .chalice & {
     flex-direction: row;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -110,7 +110,7 @@ export default function GeneratedSetItem({
       {item.isDestiny2() && (
         <ItemSockets
           item={item}
-          hideMods={false}
+          minimal={true}
           classesByHash={classesByHash}
           onShiftClick={onShiftClickPerk}
         />


### PR DESCRIPTION
This shows only the first set of sockets of any given category type in LO and compare, which seems to mostly filter out cosmetics (except for Ghosts...). I also made the compare view have no titles and flow horizontally. Not sure if folks will be upset to lose their shader info but this definitely reclaims vertical space.

<img width="1122" alt="Screen Shot 2019-11-05 at 9 25 50 PM" src="https://user-images.githubusercontent.com/313208/68270699-04047100-0013-11ea-9378-97389790d358.png">
<img width="1384" alt="Screen Shot 2019-11-05 at 9 26 18 PM" src="https://user-images.githubusercontent.com/313208/68270701-049d0780-0013-11ea-9e63-e1f6729e4b9e.png">
