### PR TITLE
Loadout optimizer, now with locked mods

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -492,7 +492,7 @@
     "LimitedCombos": "You have {{combosWithoutCaps, number}} possible stat combinations, but we only looked at {{combos, number}} of them to keep DIM from crashing. As a result, some possibilities are not shown. Lock some items or perks or dismantle some old armor to get under the limit.",
     "LockEquipped": "Equipped",
     "LockItem": "Lock item",
-    "LockPerk": "Select perk",
+    "LockPerk": "Select mod or perk",
     "NewEmptyLoadout": "Create Empty Loadout",
     "NoBuildsFound": "No builds found. Try expanding your filtering criteria.",
     "NumStatMixes": "{{count, number}} stat mix",

--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -27,7 +27,7 @@ const armorPieceGroups = [
 const armorPieceDisplayOrder = [...armorPieceGroups, 4104513227]; // ItemCategory "Armor Mods"
 
 // to-do: separate mod name from its "enhanced"ness, maybe with d2ai? so they can be grouped better
-const sortMods = chainComparator(
+export const sortMods = chainComparator(
   compareBy(
     (i: DestinyInventoryItemDefinition) => i.plug.energyCost && i.plug.energyCost.energyType
   ),

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -211,7 +211,9 @@ function buildDefinedSocket(
   }
 
   // Is this socket a perk-style socket, or something more general (mod-like)?
-  const isPerk = socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Reusable;
+  const isPerk =
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Reusable ||
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Unlockable;
 
   // The currently equipped plug, if any
   const reusablePlugs = _.compact(
@@ -339,7 +341,9 @@ function buildSocket(
   }
 
   // Is this socket a perk-style socket, or something more general (mod-like)?
-  const isPerk = socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Reusable;
+  const isPerk =
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Reusable ||
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Unlockable;
 
   // The currently equipped plug, if any.
   const plug = buildPlug(defs, socket, socketDef, plugObjectivesData);

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -213,7 +213,8 @@ function buildDefinedSocket(
   // Is this socket a perk-style socket, or something more general (mod-like)?
   const isPerk =
     socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Reusable ||
-    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Unlockable;
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Unlockable ||
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.LargePerk;
 
   // The currently equipped plug, if any
   const reusablePlugs = _.compact(
@@ -343,7 +344,8 @@ function buildSocket(
   // Is this socket a perk-style socket, or something more general (mod-like)?
   const isPerk =
     socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Reusable ||
-    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Unlockable;
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.Unlockable ||
+    socketCategoryDef.categoryStyle === DestinySocketCategoryStyle.LargePerk;
 
   // The currently equipped plug, if any.
   const plug = buildPlug(defs, socket, socketDef, plugObjectivesData);

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -205,7 +205,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
         lockedMap,
         filter
       );
-      const result = this.processMemoized(filteredItems);
+      const result = this.processMemoized(filteredItems, store.id);
       processedSets = result.sets;
       combos = result.combos;
       combosWithoutCaps = result.combosWithoutCaps;

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -1,12 +1,7 @@
 import React, { useState } from 'react';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
-import {
-  filterPlugs,
-  isLoadoutBuilderItem,
-  addLockedItem,
-  removeLockedItem
-} from './generated-sets/utils';
+import { isLoadoutBuilderItem, addLockedItem, removeLockedItem } from './generated-sets/utils';
 import {
   LockableBuckets,
   LockedItemType,
@@ -15,13 +10,12 @@ import {
   LockedItemCase,
   ItemsByBucket,
   LockedPerk,
-  LockedMap
+  LockedMap,
+  LockedMod
 } from './types';
-import { DestinyInventoryItemDefinition, DestinyClass } from 'bungie-api-ts/destiny2';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { connect } from 'react-redux';
-import { createSelector } from 'reselect';
 import { storesSelector } from 'app/inventory/reducer';
 import { RootState } from 'app/store/reducers';
 import { DimStore } from 'app/inventory/store-types';
@@ -43,11 +37,6 @@ interface ProvidedProps {
 
 interface StoreProps {
   buckets: InventoryBuckets;
-  perks: Readonly<{
-    [classType: number]: Readonly<{
-      [bucketHash: number]: readonly DestinyInventoryItemDefinition[];
-    }>;
-  }>;
   stores: DimStore[];
   isPhonePortrait: boolean;
   language: string;
@@ -56,54 +45,8 @@ interface StoreProps {
 type Props = ProvidedProps & StoreProps;
 
 function mapStateToProps() {
-  // Get a list of lockable perks by class, then bucket.
-  const perksSelector = createSelector(
-    storesSelector,
-    (stores) => {
-      const perks: {
-        [classType: number]: { [bucketHash: number]: DestinyInventoryItemDefinition[] };
-      } = {};
-      for (const store of stores) {
-        for (const item of store.items) {
-          if (!item || !item.isDestiny2() || !item.sockets || !isLoadoutBuilderItem(item)) {
-            continue;
-          }
-          for (const classType of item.classType === DestinyClass.Unknown
-            ? [DestinyClass.Hunter, DestinyClass.Titan, DestinyClass.Warlock]
-            : [item.classType]) {
-            if (!perks[classType]) {
-              perks[classType] = {};
-            }
-            if (!perks[classType][item.bucket.hash]) {
-              perks[classType][item.bucket.hash] = [];
-            }
-            // build the filtered unique perks item picker
-            item.sockets.sockets.filter(filterPlugs).forEach((socket) => {
-              socket.plugOptions.forEach((option) => {
-                perks[classType][item.bucket.hash].push(option.plugItem);
-              });
-            });
-          }
-        }
-      }
-
-      // sort exotic perks first, then by index
-      Object.keys(perks).forEach((classType) =>
-        Object.keys(perks[classType]).forEach((bucket) => {
-          const bucketPerks = _.uniq<DestinyInventoryItemDefinition>(perks[classType][bucket]);
-          bucketPerks.sort((a, b) => b.index - a.index);
-          bucketPerks.sort((a, b) => b.inventory.tierType - a.inventory.tierType);
-          perks[classType][bucket] = bucketPerks;
-        })
-      );
-
-      return perks;
-    }
-  );
-
   return (state: RootState): StoreProps => ({
     buckets: state.inventory.buckets!,
-    perks: perksSelector(state),
     stores: storesSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
     language: state.settings.language
@@ -118,9 +61,7 @@ function LockArmorAndPerks({
   lockedMap,
   items,
   buckets,
-  perks,
   stores,
-  language,
   isPhonePortrait,
   onLockedMapChanged
 }: Props) {
@@ -225,8 +166,16 @@ function LockArmorAndPerks({
     <div>
       <div className={styles.area}>
         {((flatLockedMap.perk && flatLockedMap.perk.length > 0) ||
+          (flatLockedMap.mod && flatLockedMap.mod.length > 0) ||
           (flatLockedMap.burn && flatLockedMap.burn.length > 0)) && (
           <div className={styles.itemGrid}>
+            {(flatLockedMap.mod || []).map((lockedItem: LockedMod) => (
+              <LockedItem
+                key={`${lockedItem.bucket.hash}.${lockedItem.mod.hash}`}
+                lockedItem={lockedItem}
+                onRemove={removeLockedItemType}
+              />
+            ))}
             {(flatLockedMap.perk || []).map((lockedItem: LockedPerk) => (
               <LockedItem
                 key={`${lockedItem.bucket.hash}.${lockedItem.perk.hash}`}
@@ -250,12 +199,9 @@ function LockArmorAndPerks({
           {filterPerksOpen &&
             ReactDOM.createPortal(
               <PerkPicker
-                perks={perks[selectedStore.classType]}
+                classType={selectedStore.classType}
                 items={items}
                 lockedMap={lockedMap}
-                buckets={buckets}
-                language={language}
-                isPhonePortrait={isPhonePortrait}
                 onClose={() => setFilterPerksOpen(false)}
                 onPerksSelected={onLockedMapChanged}
               />,

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -27,6 +27,7 @@ import PerkPicker from './PerkPicker';
 import ReactDOM from 'react-dom';
 import styles from './LockArmorAndPerks.m.scss';
 import LockedItem from './LockedItem';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 
 interface ProvidedProps {
   selectedStore: DimStore;
@@ -40,6 +41,7 @@ interface StoreProps {
   stores: DimStore[];
   isPhonePortrait: boolean;
   language: string;
+  defs: D2ManifestDefinitions;
 }
 
 type Props = ProvidedProps & StoreProps;
@@ -49,7 +51,8 @@ function mapStateToProps() {
     buckets: state.inventory.buckets!,
     stores: storesSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
-    language: state.settings.language
+    language: state.settings.language,
+    defs: state.manifest.d2Manifest!
   });
 }
 
@@ -58,6 +61,7 @@ function mapStateToProps() {
  */
 function LockArmorAndPerks({
   selectedStore,
+  defs,
   lockedMap,
   items,
   buckets,
@@ -173,6 +177,7 @@ function LockArmorAndPerks({
               <LockedItem
                 key={`${lockedItem.bucket.hash}.${lockedItem.mod.hash}`}
                 lockedItem={lockedItem}
+                defs={defs}
                 onRemove={removeLockedItemType}
               />
             ))}
@@ -180,6 +185,7 @@ function LockArmorAndPerks({
               <LockedItem
                 key={`${lockedItem.bucket.hash}.${lockedItem.perk.hash}`}
                 lockedItem={lockedItem}
+                defs={defs}
                 onRemove={removeLockedItemType}
               />
             ))}
@@ -187,6 +193,7 @@ function LockArmorAndPerks({
               <LockedItem
                 key={`${lockedItem.bucket.hash}.${lockedItem.burn.dmg}`}
                 lockedItem={lockedItem}
+                defs={defs}
                 onRemove={removeLockedItemType}
               />
             ))}
@@ -224,6 +231,7 @@ function LockArmorAndPerks({
               <LockedItem
                 key={lockedItem.item.id}
                 lockedItem={lockedItem}
+                defs={defs}
                 onRemove={removeLockedItemType}
               />
             ))}
@@ -253,6 +261,7 @@ function LockArmorAndPerks({
               <LockedItem
                 key={lockedItem.item.id}
                 lockedItem={lockedItem}
+                defs={defs}
                 onRemove={removeLockedItemType}
               />
             ))}

--- a/src/app/loadout-builder/LockedItem.tsx
+++ b/src/app/loadout-builder/LockedItem.tsx
@@ -7,12 +7,16 @@ import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import styles from './LockedItem.m.scss';
 import ArmorBucketIcon from './ArmorBucketIcon';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { SocketDetailsMod } from 'app/item-popup/SocketDetails';
 
 export default function LockedItem({
   lockedItem,
+  defs,
   onRemove
 }: {
   lockedItem: LockedItemType;
+  defs: D2ManifestDefinitions;
   onRemove(item: LockedItemType): void;
 }) {
   switch (lockedItem.type) {
@@ -34,11 +38,7 @@ export default function LockedItem({
       return (
         <ClosableContainer onClose={() => onRemove(lockedItem)} key={lockedItem.mod.hash}>
           <div className={styles.emptyItem}>
-            <BungieImageAndAmmo
-              hash={lockedItem.mod.hash}
-              title={lockedItem.mod.displayProperties.name}
-              src={lockedItem.mod.displayProperties.icon}
-            />
+            <SocketDetailsMod itemDef={lockedItem.mod} defs={defs} />
             <ArmorBucketIcon bucket={lockedItem.bucket} className={styles.armorIcon} />
           </div>
         </ClosableContainer>

--- a/src/app/loadout-builder/LockedItem.tsx
+++ b/src/app/loadout-builder/LockedItem.tsx
@@ -33,7 +33,6 @@ export default function LockedItem({
           </DraggableInventoryItem>
         </ClosableContainer>
       );
-    // TODO: mod overlay
     case 'mod':
       return (
         <ClosableContainer onClose={() => onRemove(lockedItem)} key={lockedItem.mod.hash}>

--- a/src/app/loadout-builder/LockedItem.tsx
+++ b/src/app/loadout-builder/LockedItem.tsx
@@ -29,6 +29,20 @@ export default function LockedItem({
           </DraggableInventoryItem>
         </ClosableContainer>
       );
+    // TODO: mod overlay
+    case 'mod':
+      return (
+        <ClosableContainer onClose={() => onRemove(lockedItem)} key={lockedItem.mod.hash}>
+          <div className={styles.emptyItem}>
+            <BungieImageAndAmmo
+              hash={lockedItem.mod.hash}
+              title={lockedItem.mod.displayProperties.name}
+              src={lockedItem.mod.displayProperties.icon}
+            />
+            <ArmorBucketIcon bucket={lockedItem.bucket} className={styles.armorIcon} />
+          </div>
+        </ClosableContainer>
+      );
     case 'perk':
       return (
         <ClosableContainer onClose={() => onRemove(lockedItem)} key={lockedItem.perk.hash}>

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -75,6 +75,7 @@ interface StoreProps {
     [bucketHash: number]: readonly {
       item: DestinyInventoryItemDefinition;
       // plugSets this mod appears in
+      // TODO: not a set, a single number
       plugSetHashes: Set<number>;
     }[];
   }>;
@@ -200,7 +201,8 @@ function mapStateToProps() {
           .filter(
             (i) =>
               i.item.inventory.tierType !== TierType.Common &&
-              (!i.item.itemCategoryHashes || !i.item.itemCategoryHashes.includes(56))
+              (!i.item.itemCategoryHashes || !i.item.itemCategoryHashes.includes(56)) &&
+              i.item.collectibleHash
           )
           .sort((a, b) => sortMods(a.item, b.item));
       });

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -104,7 +104,6 @@ function mapStateToProps() {
             perks[item.bucket.hash] = [];
           }
           // build the filtered unique perks item picker
-          // TODO: include old mods but not new mods...
           item.sockets.sockets.filter(filterPlugs).forEach((socket) => {
             socket.plugOptions.forEach((option) => {
               perks[item.bucket.hash].push(option.plugItem);
@@ -125,7 +124,6 @@ function mapStateToProps() {
     }
   );
 
-  // Get a list of unlocked mods by bucket. TODO consolidate with SocketDetails
   /** Build the hashes of all plug set item hashes that are unlocked by any character/profile. */
   const unlockedPlugsSelector = createSelector(
     profileResponseSelector,

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -155,7 +155,6 @@ function mapStateToProps() {
           }
           // build the filtered unique perks item picker
           item.sockets.sockets
-            // TODO: more filtering for sure, get rid of cosmetics/ornaments??
             .filter((s) => !s.isPerk)
             .forEach((socket) => {
               if (socket.socketDefinition.reusablePlugSetHash) {

--- a/src/app/loadout-builder/PerksForBucket.tsx
+++ b/src/app/loadout-builder/PerksForBucket.tsx
@@ -13,6 +13,7 @@ import { getFilteredPerks } from './generated-sets/utils';
 export default function PerksForBucket({
   bucket,
   perks,
+  mods,
   burns,
   locked,
   items,
@@ -20,17 +21,34 @@ export default function PerksForBucket({
 }: {
   bucket: InventoryBucket;
   perks: readonly DestinyInventoryItemDefinition[];
+  mods: readonly DestinyInventoryItemDefinition[];
   burns: BurnItem[];
   locked: readonly LockedItemType[];
   items: readonly DimItem[];
   onPerkSelected(perk: LockedItemType);
 }) {
+  // TODO: adapt to mods
   const filteredPerks = getFilteredPerks(locked, items);
 
   return (
     <div className={styles.bucket} id={`perk-bucket-${bucket.hash}`}>
       <h3>{bucket.name}</h3>
       <div className={styles.perks}>
+        {mods.map((mod) => (
+          /* TODO: mod overlay */
+          /* TODO: perk description */
+          <SelectableBungieImage
+            key={mod.hash}
+            bucket={bucket}
+            selected={Boolean(
+              locked && locked.some((p) => p.type === 'mod' && p.mod.hash === mod.hash)
+            )}
+            unselectable={Boolean(filteredPerks && !filteredPerks.has(mod))}
+            perk={mod}
+            onLockedPerk={onPerkSelected}
+          />
+        ))}
+
         {perks.map((perk) => (
           <SelectableBungieImage
             key={perk.hash}

--- a/src/app/loadout-builder/PerksForBucket.tsx
+++ b/src/app/loadout-builder/PerksForBucket.tsx
@@ -9,7 +9,7 @@ import {
 } from './locked-armor/SelectableBungieImage';
 import styles from './PerksForBucket.m.scss';
 import { DimItem } from 'app/inventory/item-types';
-import { getFilteredPerks, getFilteredPlugSetHashes } from './generated-sets/utils';
+import { getFilteredPerksAndPlugSets } from './generated-sets/utils';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 
 /**
@@ -38,8 +38,7 @@ export default function PerksForBucket({
   items: readonly DimItem[];
   onPerkSelected(perk: LockedItemType);
 }) {
-  const filteredPerks = getFilteredPerks(locked, items);
-  const filteredPlugSetHashes = getFilteredPlugSetHashes(locked, items);
+  const filterInfo = getFilteredPerksAndPlugSets(locked, items);
 
   return (
     <div className={styles.bucket} id={`perk-bucket-${bucket.hash}`}>
@@ -54,7 +53,8 @@ export default function PerksForBucket({
               locked && locked.some((p) => p.type === 'mod' && p.mod.hash === mod.item.hash)
             )}
             unselectable={Boolean(
-              filteredPlugSetHashes && !filteredPlugSetHashes.has(mod.plugSetHash)
+              filterInfo.filteredPlugSetHashes &&
+                !filterInfo.filteredPlugSetHashes.has(mod.plugSetHash)
             )}
             mod={mod.item}
             plugSetHash={mod.plugSetHash}
@@ -70,7 +70,7 @@ export default function PerksForBucket({
             selected={Boolean(
               locked && locked.some((p) => p.type === 'perk' && p.perk.hash === perk.hash)
             )}
-            unselectable={Boolean(filteredPerks && !filteredPerks.has(perk))}
+            unselectable={Boolean(filterInfo.filteredPerks && !filterInfo.filteredPerks.has(perk))}
             perk={perk}
             onLockedPerk={onPerkSelected}
           />

--- a/src/app/loadout-builder/PerksForBucket.tsx
+++ b/src/app/loadout-builder/PerksForBucket.tsx
@@ -28,7 +28,11 @@ export default function PerksForBucket({
   bucket: InventoryBucket;
   defs: D2ManifestDefinitions;
   perks: readonly DestinyInventoryItemDefinition[];
-  mods: readonly DestinyInventoryItemDefinition[];
+  mods: readonly {
+    item: DestinyInventoryItemDefinition;
+    // plugSets this mod appears in
+    plugSetHashes: Set<number>;
+  }[];
   burns: BurnItem[];
   locked: readonly LockedItemType[];
   items: readonly DimItem[];
@@ -45,14 +49,15 @@ export default function PerksForBucket({
           /* TODO: mod overlay */
           /* TODO: perk description */
           <SelectableMod
-            key={mod.hash}
+            key={mod.item.hash}
             defs={defs}
             bucket={bucket}
             selected={Boolean(
-              locked && locked.some((p) => p.type === 'mod' && p.mod.hash === mod.hash)
+              locked && locked.some((p) => p.type === 'mod' && p.mod.hash === mod.item.hash)
             )}
-            unselectable={Boolean(filteredPerks && !filteredPerks.has(mod))}
-            mod={mod}
+            unselectable={Boolean(filteredPerks && !filteredPerks.has(mod.item))}
+            mod={mod.item}
+            plugSetHashes={mod.plugSetHashes}
             onLockedPerk={onPerkSelected}
           />
         ))}

--- a/src/app/loadout-builder/PerksForBucket.tsx
+++ b/src/app/loadout-builder/PerksForBucket.tsx
@@ -2,16 +2,22 @@ import React from 'react';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { LockedItemType, BurnItem } from './types';
-import SelectableBungieImage, { SelectableBurn } from './locked-armor/SelectableBungieImage';
+import {
+  SelectableBurn,
+  SelectablePerk,
+  SelectableMod
+} from './locked-armor/SelectableBungieImage';
 import styles from './PerksForBucket.m.scss';
 import { DimItem } from 'app/inventory/item-types';
 import { getFilteredPerks } from './generated-sets/utils';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 
 /**
  * A list of selectable perks for a bucket (chest, helmet, etc) for use in PerkPicker.
  */
 export default function PerksForBucket({
   bucket,
+  defs,
   perks,
   mods,
   burns,
@@ -20,6 +26,7 @@ export default function PerksForBucket({
   onPerkSelected
 }: {
   bucket: InventoryBucket;
+  defs: D2ManifestDefinitions;
   perks: readonly DestinyInventoryItemDefinition[];
   mods: readonly DestinyInventoryItemDefinition[];
   burns: BurnItem[];
@@ -37,20 +44,21 @@ export default function PerksForBucket({
         {mods.map((mod) => (
           /* TODO: mod overlay */
           /* TODO: perk description */
-          <SelectableBungieImage
+          <SelectableMod
             key={mod.hash}
+            defs={defs}
             bucket={bucket}
             selected={Boolean(
               locked && locked.some((p) => p.type === 'mod' && p.mod.hash === mod.hash)
             )}
             unselectable={Boolean(filteredPerks && !filteredPerks.has(mod))}
-            perk={mod}
+            mod={mod}
             onLockedPerk={onPerkSelected}
           />
         ))}
 
         {perks.map((perk) => (
-          <SelectableBungieImage
+          <SelectablePerk
             key={perk.hash}
             bucket={bucket}
             selected={Boolean(

--- a/src/app/loadout-builder/PerksForBucket.tsx
+++ b/src/app/loadout-builder/PerksForBucket.tsx
@@ -30,8 +30,8 @@ export default function PerksForBucket({
   perks: readonly DestinyInventoryItemDefinition[];
   mods: readonly {
     item: DestinyInventoryItemDefinition;
-    // plugSets this mod appears in
-    plugSetHashes: Set<number>;
+    // plugSet this mod appears in
+    plugSetHash: number;
   }[];
   burns: BurnItem[];
   locked: readonly LockedItemType[];
@@ -54,11 +54,10 @@ export default function PerksForBucket({
               locked && locked.some((p) => p.type === 'mod' && p.mod.hash === mod.item.hash)
             )}
             unselectable={Boolean(
-              filteredPlugSetHashes &&
-                !Array.from(mod.plugSetHashes).some((h) => filteredPlugSetHashes.has(h))
+              filteredPlugSetHashes && !filteredPlugSetHashes.has(mod.plugSetHash)
             )}
             mod={mod.item}
-            plugSetHashes={mod.plugSetHashes}
+            plugSetHash={mod.plugSetHash}
             onLockedPerk={onPerkSelected}
           />
         ))}

--- a/src/app/loadout-builder/PerksForBucket.tsx
+++ b/src/app/loadout-builder/PerksForBucket.tsx
@@ -9,7 +9,7 @@ import {
 } from './locked-armor/SelectableBungieImage';
 import styles from './PerksForBucket.m.scss';
 import { DimItem } from 'app/inventory/item-types';
-import { getFilteredPerks } from './generated-sets/utils';
+import { getFilteredPerks, getFilteredPlugSetHashes } from './generated-sets/utils';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 
 /**
@@ -38,16 +38,14 @@ export default function PerksForBucket({
   items: readonly DimItem[];
   onPerkSelected(perk: LockedItemType);
 }) {
-  // TODO: adapt to mods
   const filteredPerks = getFilteredPerks(locked, items);
+  const filteredPlugSetHashes = getFilteredPlugSetHashes(locked, items);
 
   return (
     <div className={styles.bucket} id={`perk-bucket-${bucket.hash}`}>
       <h3>{bucket.name}</h3>
       <div className={styles.perks}>
         {mods.map((mod) => (
-          /* TODO: mod overlay */
-          /* TODO: perk description */
           <SelectableMod
             key={mod.item.hash}
             defs={defs}
@@ -55,7 +53,10 @@ export default function PerksForBucket({
             selected={Boolean(
               locked && locked.some((p) => p.type === 'mod' && p.mod.hash === mod.item.hash)
             )}
-            unselectable={Boolean(filteredPerks && !filteredPerks.has(mod.item))}
+            unselectable={Boolean(
+              filteredPlugSetHashes &&
+                !Array.from(mod.plugSetHashes).some((h) => filteredPlugSetHashes.has(h))
+            )}
             mod={mod.item}
             plugSetHashes={mod.plugSetHashes}
             onLockedPerk={onPerkSelected}
@@ -65,6 +66,7 @@ export default function PerksForBucket({
         {perks.map((perk) => (
           <SelectablePerk
             key={perk.hash}
+            defs={defs}
             bucket={bucket}
             selected={Boolean(
               locked && locked.some((p) => p.type === 'perk' && p.perk.hash === perk.hash)

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -27,13 +27,6 @@ const unwantedSockets = new Set([
  *  Filter out plugs that we don't want to show in the perk picker.
  */
 export function filterPlugs(socket: DimSocket) {
-  // We should also include mods for Armor 1.0....
-  /*
-  if (!socket.isPerk) {
-    return false;
-  }
-  */
-
   if (!socket.plug) {
     return false;
   }

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -215,6 +215,8 @@ export function lockedItemsEqual(first: LockedItemType, second: LockedItemType) 
       return second.type === 'item' && first.item.id === second.item.id;
     case 'exclude':
       return second.type === 'exclude' && first.item.id === second.item.id;
+    case 'mod':
+      return second.type === 'mod' && first.mod.hash === second.mod.hash;
     case 'perk':
       return second.type === 'perk' && first.perk.hash === second.perk.hash;
     case 'burn':

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -2,7 +2,11 @@ import _ from 'lodash';
 import { DimSocket, DimItem } from '../../inventory/item-types';
 import { ArmorSet, LockedItemType, MinMax, StatTypes, LockedMap } from '../types';
 import { count } from '../../utils/util';
-import { DestinyInventoryItemDefinition, TierType } from 'bungie-api-ts/destiny2';
+import {
+  DestinyInventoryItemDefinition,
+  TierType,
+  DestinyItemSubType
+} from 'bungie-api-ts/destiny2';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 
 /**
@@ -31,6 +35,13 @@ export function filterPlugs(socket: DimSocket) {
     return false;
   }
 
+  if (
+    plugItem.itemSubType === DestinyItemSubType.Ornament ||
+    plugItem.itemSubType === DestinyItemSubType.Shader
+  ) {
+    return false;
+  }
+
   // Remove unwanted sockets by category hash
   if (
     unwantedSockets.has(plugItem.plug.plugCategoryHash) ||
@@ -50,7 +61,10 @@ export function filterPlugs(socket: DimSocket) {
   }
 
   // Remove empty mod slots
-  if (plugItem.plug.plugCategoryHash === 3347429529 && plugItem.inventory.tierType === 2) {
+  if (
+    plugItem.plug.plugCategoryHash === 3347429529 &&
+    plugItem.inventory.tierType === TierType.Basic
+  ) {
     return false;
   }
 

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -26,6 +26,10 @@ const unwantedSockets = new Set([
  *  Filter out plugs that we don't want to show in the perk picker.
  */
 export function filterPlugs(socket: DimSocket) {
+  if (!socket.isPerk) {
+    return false;
+  }
+
   if (!socket.plug) {
     return false;
   }
@@ -270,6 +274,7 @@ export function getFilteredPerks(
     return undefined;
   }
 
+  // TODO: support mods
   for (const item of items) {
     // flat list of plugs per item
     const itemPlugs: DestinyInventoryItemDefinition[] = [];

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -361,6 +361,9 @@ export function getFilteredPlugSetHashes(
             matches = false;
             break;
           }
+        } else {
+          matches = false;
+          break;
         }
       }
     }

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -30,6 +30,7 @@ const badPerk = new Set([
  */
 export function SelectableMod({
   mod,
+  plugSetHashes,
   defs,
   bucket,
   selected,
@@ -37,6 +38,8 @@ export function SelectableMod({
   onLockedPerk
 }: {
   mod: DestinyInventoryItemDefinition;
+  // plugSets this mod appears in
+  plugSetHashes: Set<number>;
   defs: D2ManifestDefinitions;
   bucket: InventoryBucket;
   selected: boolean;
@@ -45,7 +48,7 @@ export function SelectableMod({
 }) {
   const handleClick = (e) => {
     e.preventDefault();
-    onLockedPerk({ type: 'mod', mod, bucket });
+    onLockedPerk({ type: 'mod', mod, plugSetHashes, bucket });
   };
 
   const perk = mod.perks && mod.perks.length > 0 && defs.SandboxPerk.get(mod.perks[0].perkHash);

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -6,6 +6,8 @@ import { LockedItemType, BurnItem } from '../types';
 import BungieImageAndAmmo from '../../dim-ui/BungieImageAndAmmo';
 import styles from './SelectableBungieImage.m.scss';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { SocketDetailsMod } from 'app/item-popup/SocketDetails';
 
 const badPerk = new Set([
   3201772785, // power weapon targeting
@@ -24,9 +26,55 @@ const badPerk = new Set([
 ]);
 
 /**
+ * A mod option in the PerkPicker.
+ */
+export function SelectableMod({
+  mod,
+  defs,
+  bucket,
+  selected,
+  unselectable,
+  onLockedPerk
+}: {
+  mod: DestinyInventoryItemDefinition;
+  defs: D2ManifestDefinitions;
+  bucket: InventoryBucket;
+  selected: boolean;
+  unselectable: boolean;
+  onLockedPerk(perk: LockedItemType): void;
+}) {
+  const handleClick = (e) => {
+    e.preventDefault();
+    onLockedPerk({ type: 'mod', mod, bucket });
+  };
+
+  const perk = mod.perks && mod.perks.length > 0 && defs.SandboxPerk.get(mod.perks[0].perkHash);
+
+  return (
+    <div
+      className={clsx(styles.perk, {
+        [styles.lockedPerk]: selected,
+        [styles.unselectable]: unselectable
+      })}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+    >
+      <SocketDetailsMod itemDef={mod} defs={defs} />
+      <div className={styles.perkInfo}>
+        <div className={styles.perkTitle}>{mod.displayProperties.name}</div>
+        <div className={styles.perkDescription}>
+          {perk ? perk.displayProperties.description : mod.displayProperties.description}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
  * A perk option in the PerkPicker.
  */
-export default function SelectableBungieImage({
+export function SelectablePerk({
   perk,
   bucket,
   selected,

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -80,17 +80,21 @@ export function SelectableMod({
 export function SelectablePerk({
   perk,
   bucket,
+  defs,
   selected,
   unselectable,
   onLockedPerk
 }: {
   perk: DestinyInventoryItemDefinition;
   bucket: InventoryBucket;
+  defs: D2ManifestDefinitions;
   selected: boolean;
   unselectable: boolean;
   onLockedPerk(perk: LockedItemType): void;
 }) {
   const isBadPerk = badPerk.has(perk.hash);
+  const sandboxPerk =
+    perk.perks && perk.perks.length > 0 && defs.SandboxPerk.get(perk.perks[0].perkHash);
 
   const handleClick = (e) => {
     e.preventDefault();
@@ -119,7 +123,9 @@ export function SelectablePerk({
       <div className={styles.perkInfo}>
         <div className={styles.perkTitle}>{perk.displayProperties.name}</div>
         <div className={styles.perkDescription}>
-          {perk.displayProperties.description}
+          {sandboxPerk
+            ? sandboxPerk.displayProperties.description
+            : perk.displayProperties.description}
           {isBadPerk && <p>{t('LoadoutBuilder.BadPerk')}</p>}
           {perk.hash === 1818103563 && t('LoadoutBuilder.Traction')}
         </div>

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -30,7 +30,7 @@ const badPerk = new Set([
  */
 export function SelectableMod({
   mod,
-  plugSetHashes,
+  plugSetHash,
   defs,
   bucket,
   selected,
@@ -38,8 +38,8 @@ export function SelectableMod({
   onLockedPerk
 }: {
   mod: DestinyInventoryItemDefinition;
-  // plugSets this mod appears in
-  plugSetHashes: Set<number>;
+  // plugSet this mod appears in
+  plugSetHash: number;
   defs: D2ManifestDefinitions;
   bucket: InventoryBucket;
   selected: boolean;
@@ -48,7 +48,7 @@ export function SelectableMod({
 }) {
   const handleClick = (e) => {
     e.preventDefault();
-    onLockedPerk({ type: 'mod', mod, plugSetHashes, bucket });
+    onLockedPerk({ type: 'mod', mod, plugSetHash, bucket });
   };
 
   const perk = mod.perks && mod.perks.length > 0 && defs.SandboxPerk.get(mod.perks[0].perkHash);

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -9,12 +9,12 @@ import {
   ItemsByBucket,
   LockedMap
 } from './types';
-import { statTier } from './generated-sets/utils';
+import { statTier, canSlotMod } from './generated-sets/utils';
 import { reportException } from 'app/utils/exceptions';
 import { compareBy } from 'app/utils/comparators';
 import { DimStat } from 'app/inventory/item-types';
 import { getMasterworkSocketHashes } from '../utils/socket-utils';
-import { DestinySocketCategoryStyle, DestinyEnergyType } from 'bungie-api-ts/destiny2';
+import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 
 export const statHashes: { [type in StatTypes]: number } = {
   Mobility: 2996146975,
@@ -94,27 +94,8 @@ function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
       return item.id !== lockedItem.item.id;
     case 'burn':
       return item.dmg === lockedItem.burn.dmg;
-    case 'mod': {
-      const mod = lockedItem.mod;
-      return (
-        item.isDestiny2() &&
-        // Matches energy
-        (!mod.plug ||
-          !mod.plug.energyCost ||
-          !item.energy ||
-          mod.plug.energyCost.energyType === item.energy.energyType ||
-          mod.plug.energyCost.energyType === DestinyEnergyType.Any) &&
-        // Matches socket plugsets
-        item.sockets &&
-        item.sockets.sockets.some(
-          (socket) =>
-            (socket.socketDefinition.reusablePlugSetHash &&
-              lockedItem.plugSetHashes.has(socket.socketDefinition.reusablePlugSetHash)) ||
-            (socket.socketDefinition.randomizedPlugSetHash &&
-              lockedItem.plugSetHashes.has(socket.socketDefinition.randomizedPlugSetHash))
-        )
-      );
-    }
+    case 'mod':
+      return canSlotMod(item, lockedItem);
     case 'perk':
       return (
         item.isDestiny2() &&

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -114,7 +114,8 @@ function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
  * @param filteredItems pared down list of items to process sets from
  */
 export function process(
-  filteredItems: ItemsByBucket
+  filteredItems: ItemsByBucket,
+  selectedStoreId: string
 ): { sets: ArmorSet[]; combos: number; combosWithoutCaps: number } {
   const pstart = performance.now();
 
@@ -134,28 +135,52 @@ export function process(
   };
 
   const helms = multiGroupBy(
-    _.sortBy(filteredItems[LockableBuckets.helmet] || [], (i) => -i.basePower),
+    _.sortBy(
+      filteredItems[LockableBuckets.helmet] || [],
+      (i) => -i.basePower,
+      (i) => !i.equipped
+    ),
     byStatMix
   );
   const gaunts = multiGroupBy(
-    _.sortBy(filteredItems[LockableBuckets.gauntlets] || [], (i) => -i.basePower),
+    _.sortBy(
+      filteredItems[LockableBuckets.gauntlets] || [],
+      (i) => -i.basePower,
+      (i) => !i.equipped
+    ),
     byStatMix
   );
   const chests = multiGroupBy(
-    _.sortBy(filteredItems[LockableBuckets.chest] || [], (i) => -i.basePower),
+    _.sortBy(
+      filteredItems[LockableBuckets.chest] || [],
+      (i) => -i.basePower,
+      (i) => !i.equipped
+    ),
     byStatMix
   );
   const legs = multiGroupBy(
-    _.sortBy(filteredItems[LockableBuckets.leg] || [], (i) => -i.basePower),
+    _.sortBy(
+      filteredItems[LockableBuckets.leg] || [],
+      (i) => -i.basePower,
+      (i) => !i.equipped
+    ),
     byStatMix
   );
   const classitems = multiGroupBy(
-    _.sortBy(filteredItems[LockableBuckets.classitem] || [], (i) => -i.basePower),
+    _.sortBy(
+      filteredItems[LockableBuckets.classitem] || [],
+      (i) => -i.basePower,
+      (i) => !i.equipped
+    ),
     byStatMix
   );
+
   // Ghosts don't have power, so sort them with exotics first
   const ghosts = multiGroupBy(
-    _.sortBy(filteredItems[LockableBuckets.ghost] || [], (i) => !i.isExotic),
+    _.sortBy(
+      filteredItems[LockableBuckets.ghost] || [],
+      (i) => !(i.owner === selectedStoreId && i.equipped)
+    ),
     byStatMix
   );
 

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -14,7 +14,7 @@ import { reportException } from 'app/utils/exceptions';
 import { compareBy } from 'app/utils/comparators';
 import { DimStat } from 'app/inventory/item-types';
 import { getMasterworkSocketHashes } from '../utils/socket-utils';
-import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
+import { DestinySocketCategoryStyle, DestinyEnergyType } from 'bungie-api-ts/destiny2';
 
 export const statHashes: { [type in StatTypes]: number } = {
   Mobility: 2996146975,
@@ -94,15 +94,18 @@ function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
       return item.id !== lockedItem.item.id;
     case 'burn':
       return item.dmg === lockedItem.burn.dmg;
-    case 'mod':
-      // TODO: match on mod requirements, not the mod itself
+    case 'mod': {
+      const mod = lockedItem.mod;
+      // This just matches on energy type, but we should use a plugset
       return (
         item.isDestiny2() &&
         item.energy &&
-        item.sockets.sockets.some((slot) =>
-          slot.plugOptions.some((plug) => lockedItem.perk.hash === plug.plugItem.hash)
-        )
+        (!mod.plug ||
+          !mod.plug.energyCost ||
+          mod.plug.energyCost.energyType === item.energy.energyType ||
+          mod.plug.energyCost.energyType === DestinyEnergyType.Any)
       );
+    }
     case 'perk':
       return (
         item.isDestiny2() &&

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -96,14 +96,23 @@ function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
       return item.dmg === lockedItem.burn.dmg;
     case 'mod': {
       const mod = lockedItem.mod;
-      // This just matches on energy type, but we should use a plugset
       return (
         item.isDestiny2() &&
-        item.energy &&
+        // Matches energy
         (!mod.plug ||
           !mod.plug.energyCost ||
+          !item.energy ||
           mod.plug.energyCost.energyType === item.energy.energyType ||
-          mod.plug.energyCost.energyType === DestinyEnergyType.Any)
+          mod.plug.energyCost.energyType === DestinyEnergyType.Any) &&
+        // Matches socket plugsets
+        item.sockets &&
+        item.sockets.sockets.some(
+          (socket) =>
+            (socket.socketDefinition.reusablePlugSetHash &&
+              lockedItem.plugSetHashes.has(socket.socketDefinition.reusablePlugSetHash)) ||
+            (socket.socketDefinition.randomizedPlugSetHash &&
+              lockedItem.plugSetHashes.has(socket.socketDefinition.randomizedPlugSetHash))
+        )
       );
     }
     case 'perk':

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -94,6 +94,15 @@ function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
       return item.id !== lockedItem.item.id;
     case 'burn':
       return item.dmg === lockedItem.burn.dmg;
+    case 'mod':
+      // TODO: match on mod requirements, not the mod itself
+      return (
+        item.isDestiny2() &&
+        item.energy &&
+        item.sockets.sockets.some((slot) =>
+          slot.plugOptions.some((plug) => lockedItem.perk.hash === plug.plugItem.hash)
+        )
+      );
     case 'perk':
       return (
         item.isDestiny2() &&

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -37,6 +37,7 @@ export interface LockedPerk {
 export interface LockedMod {
   type: 'mod';
   mod: DestinyInventoryItemDefinition;
+  plugSetHashes: Set<number>;
   bucket: InventoryBucket;
 }
 export interface LockedBurn {

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -34,6 +34,11 @@ export interface LockedPerk {
   perk: DestinyInventoryItemDefinition;
   bucket: InventoryBucket;
 }
+export interface LockedMod {
+  type: 'mod';
+  mod: DestinyInventoryItemDefinition;
+  bucket: InventoryBucket;
+}
 export interface LockedBurn {
   type: 'burn';
   burn: BurnItem;
@@ -45,7 +50,7 @@ export interface LockedExclude {
   bucket: InventoryBucket;
 }
 
-export type LockedItemType = LockedItemCase | LockedPerk | LockedBurn | LockedExclude;
+export type LockedItemType = LockedItemCase | LockedPerk | LockedMod | LockedBurn | LockedExclude;
 
 /** A map from bucket to the list of locked and excluded perks, items, and burns. */
 export type LockedMap = Readonly<{ [bucketHash: number]: readonly LockedItemType[] | undefined }>;

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -37,7 +37,7 @@ export interface LockedPerk {
 export interface LockedMod {
   type: 'mod';
   mod: DestinyInventoryItemDefinition;
-  plugSetHashes: Set<number>;
+  plugSetHash: number;
   bucket: InventoryBucket;
 }
 export interface LockedBurn {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -47,7 +47,7 @@ const isLatinBased = ['de', 'en', 'es', 'es-mx', 'fr', 'it', 'pl', 'pt-br'].incl
 );
 
 /** escape special characters for a regex */
-const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+export const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /** Make a Regexp that searches starting at a word boundary */
 const startWordRegexp = memoizeOne(

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -485,7 +485,7 @@
     "LimitedCombos": "You have {{combosWithoutCaps, number}} possible stat combinations, but we only looked at {{combos, number}} of them to keep DIM from crashing. As a result, some possibilities are not shown. Lock some items or perks or dismantle some old armor to get under the limit.",
     "LockEquipped": "Equipped",
     "LockItem": "Lock item",
-    "LockPerk": "Select perk",
+    "LockPerk": "Select mod or perk",
     "NewEmptyLoadout": "Create Empty Loadout",
     "NoBuildsFound": "No builds found. Try expanding your filtering criteria.",
     "NumStatMixes": "{{count, number}} stat mix",


### PR DESCRIPTION
This adds "Locked Mods" to the Loadout Optimizer. They appear in the perk picker ahead of regular perks. Locking a mod behaves slightly different - you see a list of all unlocked mods (instead of only mods that are actively applied to items), and when you lock a mod, you see items that *can* slot the mod.

Legacy mods still work like perks - they select only items that have them applied.

I put a fair amount of effort into the exclusion logic - you can only choose a combination of both perks and mods that can be satisfied by at least one item you own. This takes into account things like multiple duplicate mod slots of the same type (e.g. it will allow you to slot two gauntlet mods before cutting you off).

There's also quite a bit of cleanup around cleaning out undesirable perks/mods from the list, and categorizing perks correctly. 

This is the last bit of work I wanted to do for Loadout Optimizer before finally recording a tutorial video!