### PR TITLE
compare-group-fixes

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -57,6 +57,7 @@
   "Compare": {
     "All": "{{type}} ({{quantity}})",
     "Archetype": "Archetype",
+    "Armor2": "Armor 2.0",
     "ButtonHelp": "Compare Items",
     "Error": {
       "Archetype": "Cannot compare this item as it is not a {{type}}.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -51,6 +51,7 @@
   },
   "Compare": {
     "Archetype": "Archetype",
+    "Armor2": "Armor 2.0",
     "ButtonHelp": "Compare Items",
     "Error": {
       "Archetype": "Cannot compare this item as it is not a {{type}}.",


### PR DESCRIPTION
this adds a narrowing button for "all armor2.0 in this slot" because i am extremely tired of clicking "all armor in this slot" then X-ing the old armor.

this should prevent 0-item comparison buttons from appearing, and does the armor element comparison only on 2.0, it doesn't matter enough on armor 1.5