### PR TITLE
energy in compare sheet

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -127,12 +127,7 @@ class Compare extends React.Component<Props, State> {
                 ? { value: showRating || 0 }
                 : sortedHash === 'EnergyCapacity'
                 ? {
-                    value:
-                      (item.isDestiny2() &&
-                        item.energy &&
-                        // this math is to fully separate energy types
-                        item.energy.energyType * 100 + item.energy.energyCapacity) ||
-                      0
+                    value: (item.isDestiny2() && item.energy && item.energy.energyCapacity) || 0
                   }
                 : (item.stats || []).find((s) => s.statHash === sortedHash);
 
@@ -448,7 +443,8 @@ class Compare extends React.Component<Props, State> {
           !i.isDestiny2() ||
           // specifically for grenade launchers, let's not compare special with heavy
           // all other weapon types with multiple ammos, are novelty exotic exceptions
-          !compare.itemCategoryHashes.includes(153950757) || compare.ammoType === i.ammoType)
+          !compare.itemCategoryHashes.includes(153950757) ||
+          compare.ammoType === i.ammoType)
     );
     filteredSets[n.sameWeaponTypeAndSlot] = filteredSets[n.sameWeaponType].filter(
       (i) => i.bucket.name === compare.bucket.name

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -125,6 +125,15 @@ class Compare extends React.Component<Props, State> {
                 ? item.primStat
                 : sortedHash === 'Rating'
                 ? { value: showRating || 0 }
+                : sortedHash === 'EnergyCapacity'
+                ? {
+                    value:
+                      (item.isDestiny2() &&
+                        item.energy &&
+                        // this math is to fully separate energy types
+                        item.energy.energyType * 100 + item.energy.energyCapacity) ||
+                      0
+                  }
                 : (item.stats || []).find((s) => s.statHash === sortedHash);
 
             if (!stat) {
@@ -439,7 +448,7 @@ class Compare extends React.Component<Props, State> {
           !i.isDestiny2() ||
           // specifically for grenade launchers, let's not compare special with heavy
           // all other weapon types with multiple ammos, are novelty exotic exceptions
-          (!compare.itemCategoryHashes.includes(153950757) || compare.ammoType === i.ammoType))
+          !compare.itemCategoryHashes.includes(153950757) || compare.ammoType === i.ammoType)
     );
     filteredSets[n.sameWeaponTypeAndSlot] = filteredSets[n.sameWeaponType].filter(
       (i) => i.bucket.name === compare.bucket.name
@@ -520,7 +529,28 @@ function getAllStats(comparisons: DimItem[], ratings: ReviewsState['ratings']) {
       }
     });
   }
-
+  if (firstComparison.bucket.inArmor) {
+    stats.push({
+      id: 'EnergyCapacity',
+      displayProperties: {
+        name: t('EnergyMeter.Energy')
+      } as DestinyDisplayPropertiesDefinition,
+      min: Number.MAX_SAFE_INTEGER,
+      max: 0,
+      enabled: false,
+      lowerBetter: false,
+      getStat(item: DimItem) {
+        return (
+          (item.isDestiny2() &&
+            item.energy && {
+              statHash: item.energy.energyType,
+              value: item.energy.energyCapacity
+            }) ||
+          undefined
+        );
+      }
+    });
+  }
   // Todo: map of stat id => stat object
   // add 'em up
   const statsByHash: { [statHash: string]: StatInfo } = {};

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -37,7 +37,7 @@ export default function CompareItem({
       <div className="item-name" onClick={() => itemClick(item)}>
         {item.name} <AppIcon icon={searchIcon} />
       </div>
-      <ConnectedInventoryItem item={item} />
+      <ConnectedInventoryItem item={item} onClick={() => itemClick(item)} />
       {stats.map((stat) => (
         <CompareStat
           key={stat.id}

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -6,6 +6,8 @@ import { AppIcon, starIcon } from '../shell/icons';
 import clsx from 'clsx';
 import { t } from 'app/i18next-t';
 import RecoilStat from 'app/item-popup/RecoilStat';
+import { energyCapacityTypeNames } from '../item-popup/EnergyMeter';
+import ElementIcon from 'app/inventory/ElementIcon';
 
 export default function CompareStat({
   stat,
@@ -28,6 +30,9 @@ export default function CompareStat({
     >
       <span>
         {stat.id === 'Rating' && <AppIcon icon={starIcon} />}
+        {stat.id === 'EnergyCapacity' && itemStat && (
+          <ElementIcon element={energyCapacityTypeNames[itemStat.statHash]} />
+        )}
         {itemStat && itemStat.value !== undefined ? (
           itemStat.statHash === 2715839340 ? (
             <span className="stat-recoil">

--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -69,7 +69,7 @@
     float: right;
     padding: 0;
     margin-right: 4px;
-    z-index: -10;
+    z-index: 10;
   }
   > div {
     padding-left: 4px;


### PR DESCRIPTION
this puts energy in the compare sheet
accompanies it with the element icon
skipping some of the goofy icon css filters in anticipation of globally styling element images instead

:warning: this puts the item image
![image](https://user-images.githubusercontent.com/31990469/68537014-d456b100-0311-11ea-80f4-05b8af7f9b6a.png)
above the stat table lines.
it's now clickable just like the item name, to scroll/highlight the item in your inventory.
it really didn't make sense to click through the inventoryitem to the lines beneath. there's plenty to aim anyway, at even on mobile

![image](https://user-images.githubusercontent.com/31990469/68536982-2b0fbb00-0311-11ea-909b-ad85207daf40.png)
![image](https://user-images.githubusercontent.com/31990469/68536988-39f66d80-0311-11ea-87c2-623a26ada7d8.png)
