### PR TITLE
Crisper shader capacity icon, sort vault capacities

### DIFF
--- a/src/app/inventory/VaultStats.tsx
+++ b/src/app/inventory/VaultStats.tsx
@@ -15,6 +15,18 @@ const bucketIcons = {
   1469714392: consumablesIcon,
   138197802: vaultIcon
 };
+const vaultBucketOrder = [
+  // D1
+  'BUCKET_VAULT_WEAPONS',
+  'BUCKET_VAULT_ARMOR',
+  'BUCKET_VAULT_ITEMS',
+
+  // D2
+  '138197802',
+  '1469714392',
+  '3313201758',
+  '2973005342'
+];
 
 export default function VaultStats({ store }: { store: DimVault }) {
   return (
@@ -37,26 +49,28 @@ export default function VaultStats({ store }: { store: DimVault }) {
           <div />
         </React.Fragment>
       ))}
-      {Object.keys(store.vaultCounts).map((bucketId) => (
-        <React.Fragment key={bucketId}>
-          <div className={styles.bucketTag} title={store.vaultCounts[bucketId].bucket.name}>
-            {bucketIcons[bucketId] ? (
-              <img src={bucketIcons[bucketId]} alt="" />
-            ) : (
-              store.vaultCounts[bucketId].bucket.name.substring(0, 1)
-            )}
-          </div>
-          <div
-            title={store.vaultCounts[bucketId].bucket.name}
-            className={clsx({
-              [styles.full]:
-                store.vaultCounts[bucketId].count === store.vaultCounts[bucketId].bucket.capacity
-            })}
-          >
-            {store.vaultCounts[bucketId].count}/{store.vaultCounts[bucketId].bucket.capacity}
-          </div>
-        </React.Fragment>
-      ))}
+      {_.sortBy(Object.keys(store.vaultCounts), (id) => vaultBucketOrder.indexOf(id)).map(
+        (bucketId) => (
+          <React.Fragment key={bucketId}>
+            <div className={styles.bucketTag} title={store.vaultCounts[bucketId].bucket.name}>
+              {bucketIcons[bucketId] ? (
+                <img src={bucketIcons[bucketId]} alt="" />
+              ) : (
+                store.vaultCounts[bucketId].bucket.name.substring(0, 1)
+              )}
+            </div>
+            <div
+              title={store.vaultCounts[bucketId].bucket.name}
+              className={clsx({
+                [styles.full]:
+                  store.vaultCounts[bucketId].count === store.vaultCounts[bucketId].bucket.capacity
+              })}
+            >
+              {store.vaultCounts[bucketId].count}/{store.vaultCounts[bucketId].bucket.capacity}
+            </div>
+          </React.Fragment>
+        )
+      )}
     </div>
   );
 }

--- a/src/app/inventory/VaultStats.tsx
+++ b/src/app/inventory/VaultStats.tsx
@@ -5,7 +5,7 @@ import BungieImage from 'app/dim-ui/BungieImage';
 import _ from 'lodash';
 import styles from './VaultStats.m.scss';
 import modificationsIcon from 'destiny-icons/general/modifications.svg';
-import shadersIcon from 'destiny-icons/general/shaders.svg';
+import shadersIcon from 'destiny-icons/general/shaders2.svg';
 import consumablesIcon from 'destiny-icons/general/consumables.svg';
 import vaultIcon from 'destiny-icons/armor_types/helmet.svg';
 


### PR DESCRIPTION
This PR replaces the shader icon underneath the vault tile with one that looks crisper at smaller sizes and re-orders the bucket capacities to be consistent with the **Inventory** section.

![dim-shader-icon-update2](https://user-images.githubusercontent.com/17512262/68540824-9a160e00-03fc-11ea-8eff-bcda166d319d.png)
