### PR TITLE
Trash lists

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -293,6 +293,7 @@
     },
     "Tracked": "Shows quests/bounties based on their tracked status.",
     "Transferable": "Items that can be moved between characters.",
+    "Trashlist": "Shows items that match your wish list's trash list.",
     "Undo": "Undo",
     "UnlockAllFailed": "Failed to unlock items",
     "UnlockAllSuccess": "Unlocked {{num}} items",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed some bugs that had crept into DIM's logic for moving items aside in order to allow move commands to succeed. Now if your vault is full, DIM will move items to less-frequently-used characters and avoid moving items back onto your active character. The logic for what items to move has been tuned to keep things organized.
 * Clicking on a mod will bring up a menu that shows all applicable mods for that slot. You can see what each mod will do to stats and how much it costs to apply.
 * Perk/mod headers and cosmetic mods are now hidden in Compare and Loadout Optimizer.
+* Added support for trash list rolls in wish list files - see the documentation for more info.
 
 ## 5.55.1 <span className="changelog-date">(2019-11-04)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## Next
 
+* Added support for trash list rolls in wish list files - see the documentation for more info.
+
 ## 5.56.0 <span className="changelog-date">(2019-11-10)</span>
 
 * Fixed some bugs that had crept into DIM's logic for moving items aside in order to allow move commands to succeed. Now if your vault is full, DIM will move items to less-frequently-used characters and avoid moving items back onto your active character. The logic for what items to move has been tuned to keep things organized.
 * Clicking on a mod will bring up a menu that shows all applicable mods for that slot. You can see what each mod will do to stats and how much it costs to apply.
 * Perk/mod headers and cosmetic mods are now hidden in Compare and Loadout Optimizer.
-* Added support for trash list rolls in wish list files - see the documentation for more info.
 
 ## 5.55.1 <span className="changelog-date">(2019-11-04)</span>
 

--- a/docs/COMMUNITY_CURATIONS.md
+++ b/docs/COMMUNITY_CURATIONS.md
@@ -3,7 +3,7 @@ Community Curations (Wish Lists)
 
 If you've ever wanted to have DIM automatically look for specific drops (or share your list of ideal drops with other folks), this will let you do just that.
 
-To build a list of your own, go to [Banshee-44.com](https://banshee-44.com/) - it lets you look for items and select the perks that you're looking for. Once you find an item that you like, copy the URL that it generates into a text file. Keep looking and finding those items that you're hunting for and paste them into that file, separating each with a new line.
+To build a list of your own, go to [Destiny Tracker's items DB](https://destinytracker.com/destiny-2/db/items/weapon) - it lets you look for items and select the perks that you're looking for. Once you find an item that you like, copy the URL that it generates into a text file. Keep looking and finding those items that you're hunting for and paste them into that file, separating each with a new line.
 
 If there's a few rolls of that Better Devils that you've got your eye on, feel free to put bunches of them in your file. We'll match the first of them that we can find. If you want one Better Devils roll for PvE and another for PvP, put one in a file for PvE items and the other in a file for PvP items and load them one at a time.
 
@@ -73,3 +73,13 @@ If there are multiple perks for a given slot that you'd be happy to get, and fur
 For wishlist line items, we'll ignore comments at the end of the line. Destiny Tracker + Banshee-44 URLs are expected to be copy/paste friendly, so comments on those lines (outside of the faux-anchor notes) will break them.
 
 As a final note, shaders/ornaments/masterworks are ignored.
+
+**Trash Lists**
+
+For expert mode rolls, we've also added "trash lists", a way to say that particular items/perk combos are undesirable, and let DIM automatically find them for you. By way of example...
+
+`dimwishlist:item=-1234&#notes:I don't care for it.`
+
+This would find an item with the manifest hash of 1234, put notes on it, but also mark it as undesirable (it'll give it a thumbs down in the inventory-level view), and you can search for `is:trashlist` to find it. For these rolls, perks are optional - you may want to say that, for example, all `Ten Paces` are trash. Wildcards are supported.
+
+You should also be able to mark some `Ten Paces` as wish list and others as trash list; put the specific wish list versions at the top of your file and the generic versions at the bottom; the first roll we come across that matches will be the one we apply.

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -11,14 +11,14 @@ import clsx from 'clsx';
 import styles from './BadgeInfo.m.scss';
 import ElementIcon from './ElementIcon';
 import { energyCapacityTypeNames } from '../item-popup/EnergyMeter';
+import { UiWishListRoll } from 'app/wishlists/wishlists';
 
 interface Props {
   item: DimItem;
   isCapped: boolean;
   /** Rating value */
   rating?: number;
-  isWishListRoll: boolean;
-  isUndesirableWishListRoll?: boolean;
+  uiWishListRoll?: UiWishListRoll;
 }
 
 const getGhostInfos = weakMemoize((item: DimItem) =>
@@ -49,13 +49,7 @@ export function hasBadge(item?: DimItem | null): boolean {
   );
 }
 
-export default function BadgeInfo({
-  item,
-  isCapped,
-  rating,
-  isWishListRoll,
-  isUndesirableWishListRoll
-}: Props) {
+export default function BadgeInfo({ item, isCapped, rating, uiWishListRoll }: Props) {
   const isBounty = Boolean(!item.primStat && item.objectives);
   const isStackable = Boolean(item.maxStackSize > 1);
   // treat D1 ghosts as generic items
@@ -95,7 +89,7 @@ export default function BadgeInfo({
 
   const reviewclsx = {
     [styles.review]: true,
-    [styles.wishlistRoll]: isWishListRoll
+    [styles.wishlistRoll]: uiWishListRoll && uiWishListRoll === UiWishListRoll.Good
   };
 
   const badgeElement =
@@ -110,13 +104,9 @@ export default function BadgeInfo({
           {item.quality.min}%
         </div>
       )}
-      {(rating !== undefined || isWishListRoll) && (
+      {(rating !== undefined || uiWishListRoll) && (
         <div className={clsx(reviewclsx)}>
-          <RatingIcon
-            rating={rating || 1}
-            isWishListRoll={isWishListRoll}
-            isUndesirableWishListRoll={isUndesirableWishListRoll}
-          />
+          <RatingIcon rating={rating || 1} uiWishListRoll={uiWishListRoll} />
         </div>
       )}
       <div className={styles.primaryStat}>

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -18,6 +18,7 @@ interface Props {
   /** Rating value */
   rating?: number;
   isWishListRoll: boolean;
+  isUndesirableWishListRoll?: boolean;
 }
 
 const getGhostInfos = weakMemoize((item: DimItem) =>
@@ -48,7 +49,13 @@ export function hasBadge(item?: DimItem | null): boolean {
   );
 }
 
-export default function BadgeInfo({ item, isCapped, rating, isWishListRoll }: Props) {
+export default function BadgeInfo({
+  item,
+  isCapped,
+  rating,
+  isWishListRoll,
+  isUndesirableWishListRoll
+}: Props) {
   const isBounty = Boolean(!item.primStat && item.objectives);
   const isStackable = Boolean(item.maxStackSize > 1);
   // treat D1 ghosts as generic items
@@ -105,7 +112,11 @@ export default function BadgeInfo({ item, isCapped, rating, isWishListRoll }: Pr
       )}
       {(rating !== undefined || isWishListRoll) && (
         <div className={clsx(reviewclsx)}>
-          <RatingIcon rating={rating || 1} isWishListRoll={isWishListRoll} />
+          <RatingIcon
+            rating={rating || 1}
+            isWishListRoll={isWishListRoll}
+            isUndesirableWishListRoll={isUndesirableWishListRoll}
+          />
         </div>
       )}
       <div className={styles.primaryStat}>

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -7,7 +7,7 @@ import BungieImage, { bungieNetPath } from '../dim-ui/BungieImage';
 import { percent } from '../shell/filters';
 import { AppIcon, lockIcon, stickyNoteIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { InventoryWishListRoll } from '../wishlists/wishlists';
+import { InventoryWishListRoll, UiWishListRoll } from '../wishlists/wishlists';
 import styles from './InventoryItem.m.scss';
 import NewItemIndicator from './NewItemIndicator';
 import subclassArc from 'images/subclass-arc.png';
@@ -60,10 +60,13 @@ export default function InventoryItem({
   innerRef
 }: Props) {
   const isCapped = item.maxStackSize > 1 && item.amount === item.maxStackSize && item.uniqueStack;
-  const isWishListRoll = Boolean(wishListsEnabled && inventoryWishListRoll);
-  const isUndesirableWishListRoll = Boolean(
-    isWishListRoll && inventoryWishListRoll && inventoryWishListRoll.isUndesirable
-  );
+
+  const uiWishListRoll =
+    wishListsEnabled && inventoryWishListRoll
+      ? UiWishListRoll.Good
+      : wishListsEnabled && inventoryWishListRoll && inventoryWishListRoll.isUndesirable
+      ? UiWishListRoll.Bad
+      : undefined;
 
   let enhancedOnClick = onClick;
   if (onShiftClick) {
@@ -112,13 +115,7 @@ export default function InventoryItem({
       {(subclassPath && subclassPath.base && (
         <img src={subclassPath.base} className={itemImageStyles} />
       )) || <BungieImage src={item.icon} className={itemImageStyles} alt="" />}
-      <BadgeInfo
-        item={item}
-        rating={rating}
-        isCapped={isCapped}
-        isWishListRoll={isWishListRoll}
-        isUndesirableWishListRoll={isUndesirableWishListRoll}
-      />
+      <BadgeInfo item={item} rating={rating} isCapped={isCapped} uiWishListRoll={uiWishListRoll} />
       {item.masterwork && (
         <div className={clsx(styles.masterworkOverlay, { [styles.exotic]: item.isExotic })} />
       )}

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -7,7 +7,7 @@ import BungieImage, { bungieNetPath } from '../dim-ui/BungieImage';
 import { percent } from '../shell/filters';
 import { AppIcon, lockIcon, stickyNoteIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { InventoryWishListRoll, UiWishListRoll } from '../wishlists/wishlists';
+import { InventoryWishListRoll, toUiWishListRoll } from '../wishlists/wishlists';
 import styles from './InventoryItem.m.scss';
 import NewItemIndicator from './NewItemIndicator';
 import subclassArc from 'images/subclass-arc.png';
@@ -61,12 +61,7 @@ export default function InventoryItem({
 }: Props) {
   const isCapped = item.maxStackSize > 1 && item.amount === item.maxStackSize && item.uniqueStack;
 
-  const uiWishListRoll =
-    wishListsEnabled && inventoryWishListRoll
-      ? UiWishListRoll.Good
-      : wishListsEnabled && inventoryWishListRoll && inventoryWishListRoll.isUndesirable
-      ? UiWishListRoll.Bad
-      : undefined;
+  const uiWishListRoll = wishListsEnabled ? toUiWishListRoll(inventoryWishListRoll) : undefined;
 
   let enhancedOnClick = onClick;
   if (onShiftClick) {

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -61,6 +61,9 @@ export default function InventoryItem({
 }: Props) {
   const isCapped = item.maxStackSize > 1 && item.amount === item.maxStackSize && item.uniqueStack;
   const isWishListRoll = Boolean(wishListsEnabled && inventoryWishListRoll);
+  const isUndesirableWishListRoll = Boolean(
+    isWishListRoll && inventoryWishListRoll && inventoryWishListRoll.isUndesirable
+  );
 
   let enhancedOnClick = onClick;
   if (onShiftClick) {
@@ -109,7 +112,13 @@ export default function InventoryItem({
       {(subclassPath && subclassPath.base && (
         <img src={subclassPath.base} className={itemImageStyles} />
       )) || <BungieImage src={item.icon} className={itemImageStyles} alt="" />}
-      <BadgeInfo item={item} rating={rating} isCapped={isCapped} isWishListRoll={isWishListRoll} />
+      <BadgeInfo
+        item={item}
+        rating={rating}
+        isCapped={isCapped}
+        isWishListRoll={isWishListRoll}
+        isUndesirableWishListRoll={isUndesirableWishListRoll}
+      />
       {item.masterwork && (
         <div className={clsx(styles.masterworkOverlay, { [styles.exotic]: item.isExotic })} />
       )}

--- a/src/app/inventory/RatingIcon.scss
+++ b/src/app/inventory/RatingIcon.scss
@@ -13,4 +13,8 @@
   &.goodroll {
     color: #028f76;
   }
+  &.trashlist {
+    color: #d14334;
+    font-size: 0.8em !important;
+  }
 }

--- a/src/app/inventory/RatingIcon.tsx
+++ b/src/app/inventory/RatingIcon.tsx
@@ -14,7 +14,7 @@ export default function RatingIcon({
 }) {
   if (isWishListRoll) {
     if (isUndesirableWishListRoll) {
-      return <AppIcon className="dogroll rating-icon" icon={thumbsDownIcon} />;
+      return <AppIcon className="trashlist rating-icon" icon={thumbsDownIcon} />;
     }
 
     return <AppIcon className="godroll rating-icon" icon={thumbsUpIcon} />;

--- a/src/app/inventory/RatingIcon.tsx
+++ b/src/app/inventory/RatingIcon.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 import { AppIcon, starIcon, thumbsUpIcon, thumbsDownIcon } from '../shell/icons';
 import { faCaretDown, faCaretUp, faMinus } from '@fortawesome/free-solid-svg-icons';
 import './RatingIcon.scss';
+import { UiWishListRoll } from 'app/wishlists/wishlists';
 
 export default function RatingIcon({
   rating,
-  isWishListRoll,
-  isUndesirableWishListRoll
+  uiWishListRoll
 }: {
   rating: number;
-  isWishListRoll: boolean;
-  isUndesirableWishListRoll?: boolean;
+  uiWishListRoll?: UiWishListRoll;
 }) {
-  if (isWishListRoll) {
-    if (isUndesirableWishListRoll) {
+  if (uiWishListRoll) {
+    if (uiWishListRoll === UiWishListRoll.Bad) {
       return <AppIcon className="trashlist rating-icon" icon={thumbsDownIcon} />;
     }
 

--- a/src/app/inventory/RatingIcon.tsx
+++ b/src/app/inventory/RatingIcon.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
-import { AppIcon, starIcon, thumbsUpIcon } from '../shell/icons';
+import { AppIcon, starIcon, thumbsUpIcon, thumbsDownIcon } from '../shell/icons';
 import { faCaretDown, faCaretUp, faMinus } from '@fortawesome/free-solid-svg-icons';
 import './RatingIcon.scss';
 
 export default function RatingIcon({
   rating,
-  isWishListRoll
+  isWishListRoll,
+  isUndesirableWishListRoll
 }: {
   rating: number;
   isWishListRoll: boolean;
+  isUndesirableWishListRoll?: boolean;
 }) {
   if (isWishListRoll) {
+    if (isUndesirableWishListRoll) {
+      return <AppIcon className="godroll rating-icon" icon={thumbsDownIcon} />;
+    }
+
     return <AppIcon className="godroll rating-icon" icon={thumbsUpIcon} />;
   }
 

--- a/src/app/inventory/RatingIcon.tsx
+++ b/src/app/inventory/RatingIcon.tsx
@@ -14,7 +14,7 @@ export default function RatingIcon({
 }) {
   if (isWishListRoll) {
     if (isUndesirableWishListRoll) {
-      return <AppIcon className="godroll rating-icon" icon={thumbsDownIcon} />;
+      return <AppIcon className="dogroll rating-icon" icon={thumbsDownIcon} />;
     }
 
     return <AppIcon className="godroll rating-icon" icon={thumbsUpIcon} />;

--- a/src/app/item-popup/ExpandedRating.tsx
+++ b/src/app/item-popup/ExpandedRating.tsx
@@ -29,7 +29,7 @@ function ExpandedRating({ dtrRating }: Props) {
   }
   return (
     <div className="item-review-average">
-      <RatingIcon rating={dtrRating.overallScore} isWishListRoll={false} />{' '}
+      <RatingIcon rating={dtrRating.overallScore} uiWishListRoll={undefined} />{' '}
       {t('DtrReview.AverageRating', {
         itemRating: dtrRating.overallScore.toFixed(1),
         numRatings: dtrRating.ratingCount || 0

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -157,7 +157,10 @@ function bestRatedIcon(
   const returnAsWishlisted =
     (!curationEnabled || !inventoryCuratedRoll) && anyBestRatedUnselected(category, bestPerks)
       ? false // false for a review recommendation
-      : curationEnabled && inventoryCuratedRoll && anyWishListRolls(category, inventoryCuratedRoll)
+      : curationEnabled &&
+        inventoryCuratedRoll &&
+        !inventoryCuratedRoll.isUndesirable &&
+        anyWishListRolls(category, inventoryCuratedRoll)
       ? true // true for a wishlisted perk
       : null; // don't give a thumbs up at all
 

--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -125,7 +125,7 @@ class ItemReviews extends React.Component<Props, State> {
               <span>
                 {shouldShowRating(dtrRating) ? (
                   <>
-                    <RatingIcon rating={dtrRating.overallScore} isWishListRoll={false} /> (
+                    <RatingIcon rating={dtrRating.overallScore} uiWishListRoll={undefined} /> (
                     {dtrRating.overallScore.toFixed(1)})
                   </>
                 ) : (

--- a/src/app/item-review/RatingsKey.tsx
+++ b/src/app/item-review/RatingsKey.tsx
@@ -6,16 +6,16 @@ export default function RatingsKey() {
   return (
     <div className="ratings-key">
       <span>
-        <RatingIcon rating={5} isWishListRoll={false} /> 5.0
+        <RatingIcon rating={5} uiWishListRoll={undefined} /> 5.0
       </span>
       <span>
-        <RatingIcon rating={4.9} isWishListRoll={false} /> 4.7+
+        <RatingIcon rating={4.9} uiWishListRoll={undefined} /> 4.7+
       </span>
       <span>
-        <RatingIcon rating={4.5} isWishListRoll={false} /> 4.0+
+        <RatingIcon rating={4.5} uiWishListRoll={undefined} /> 4.0+
       </span>
       <span>
-        <RatingIcon rating={1} isWishListRoll={false} /> &lt; 4.0
+        <RatingIcon rating={1} uiWishListRoll={undefined} /> &lt; 4.0
       </span>
     </div>
   );

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -173,6 +173,12 @@ function FilterHelp({ destinyVersion }: { destinyVersion: 1 | 2 }) {
             </tr>
             <tr>
               <td>
+                <span>is:trashlist</span>
+              </td>
+              <td>{t('Filter.Trashlist')}</td>
+            </tr>
+            <tr>
+              <td>
                 <span>is:wishlist</span>
               </td>
               <td>{t('Filter.Wishlist')}</td>

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -80,10 +80,7 @@ export const makeDupeID = (item: DimItem) =>
  * Selectors
  */
 
-export const searchConfigSelector = createSelector(
-  destinyVersionSelector,
-  buildSearchConfig
-);
+export const searchConfigSelector = createSelector(destinyVersionSelector, buildSearchConfig);
 
 /** A selector for the search config for a particular destiny version. */
 export const searchFiltersConfigSelector = createSelector(
@@ -270,6 +267,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
           powerfulreward: ['powerfulreward'],
           randomroll: ['randomroll'],
           reacquirable: ['reacquirable'],
+          trashlist: ['trashlist'],
           wishlist: ['wishlist'],
           wishlistdupe: ['wishlistdupe']
         }
@@ -1301,8 +1299,15 @@ function searchFilters(
           )
         );
       },
+      trashlist(item: D2Item) {
+        return Boolean(
+          inventoryWishListRolls[item.id] && inventoryWishListRolls[item.id].isUndesirable
+        );
+      },
       wishlist(item: D2Item) {
-        return Boolean(inventoryWishListRolls[item.id]);
+        return Boolean(
+          inventoryWishListRolls[item.id] && !inventoryWishListRolls[item.id].isUndesirable
+        );
       },
       wishlistdupe(item: D2Item) {
         if (!this.dupe(item) || !_duplicates) {

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -28,6 +28,14 @@ export interface WishListRoll {
    */
   isExpertMode: boolean;
 
+  /**
+   * Is this an undesirable item/roll?
+   * By default, we expect things in the wish list to be desired rolls, but
+   * it's possible that you might have some items/rolls that you want no part of.
+   * We'll mark undesirable items with a thumbs down instead.
+   */
+  isUndesirable?: boolean;
+
   /** Optional notes from the curator. */
   notes?: string;
 }

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -1,6 +1,8 @@
 import { WishListRoll, DimWishList, WishListAndInfo } from './types';
 import _ from 'lodash';
 
+const EMPTY_NUMBER_SET = new Set<number>();
+
 /* Utilities for reading a wishlist file */
 
 /**
@@ -21,7 +23,7 @@ function expectedMatchResultsLength(matchResults: RegExpMatchArray): boolean {
 
 function getPerks(matchResults: RegExpMatchArray): Set<number> {
   if (matchResults[2] === undefined) {
-    return new Set();
+    return EMPTY_NUMBER_SET;
   }
 
   return new Set(

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -22,7 +22,7 @@ function expectedMatchResultsLength(matchResults: RegExpMatchArray): boolean {
 }
 
 function getPerks(matchResults: RegExpMatchArray): Set<number> {
-  if (matchResults[2] === undefined) {
+  if (!matchResults.groups || matchResults.groups.itemPerks === undefined) {
     return EMPTY_NUMBER_SET;
   }
 
@@ -35,11 +35,17 @@ function getPerks(matchResults: RegExpMatchArray): Set<number> {
 }
 
 function getNotes(matchResults: RegExpMatchArray): string | undefined {
-  return matchResults[3] ? matchResults[3] : undefined;
+  return matchResults.groups && matchResults.groups.wishListNotes
+    ? matchResults.groups.wishListNotes
+    : undefined;
 }
 
 function getItemHash(matchResults: RegExpMatchArray): number {
-  return Number(matchResults[1]);
+  if (!matchResults.groups) {
+    return 0;
+  }
+
+  return Number(matchResults.groups.itemHash);
 }
 
 function toDtrWishListRoll(dtrTextLine: string): WishListRoll | null {
@@ -52,7 +58,7 @@ function toDtrWishListRoll(dtrTextLine: string): WishListRoll | null {
   }
 
   const matchResults = dtrTextLine.match(
-    /^https:\/\/destinytracker\.com\/destiny-2\/db\/items\/(\d+)(?:.*)?perks=([\d,]*)(?:#notes:)?(.*)?/
+    /^https:\/\/destinytracker\.com\/destiny-2\/db\/items\/(?<itemHash>\d+)(?:.*)?perks=(?<itemPerks>[\d,]*)(?:#notes:)?(?<wishListNotes>.*)?/
   );
 
   if (!matchResults || !expectedMatchResultsLength(matchResults)) {
@@ -82,7 +88,7 @@ function toBansheeWishListRoll(bansheeTextLine: string): WishListRoll | null {
   }
 
   const matchResults = bansheeTextLine.match(
-    /^https:\/\/banshee-44\.com\/\?weapon=(\d.+)&socketEntries=([\d,]*)(?:#notes:)?(.*)?/
+    /^https:\/\/banshee-44\.com\/\?weapon=(?<itemHash>\d.+)&socketEntries=(?<itemPerks>[\d,]*)(?:#notes:)?(?<wishListNotes>.*)?/
   );
 
   if (!matchResults || !expectedMatchResultsLength(matchResults)) {
@@ -111,7 +117,7 @@ function toDimWishListRoll(textLine: string): WishListRoll | null {
   }
 
   const matchResults = textLine.match(
-    /^dimwishlist:item=(-?\d+)(?:&perks=)?([\d|,]*)?(?:#notes:)?(.*)?/
+    /^dimwishlist:item=(?<itemHash>-?\d+)(?:&perks=)?(?<itemPerks>[\d|,]*)?(?:#notes:)?(?<wishListNotes>.*)?/
   );
 
   if (!matchResults || !expectedMatchResultsLength(matchResults)) {

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -13,6 +13,8 @@ export interface InventoryWishListRoll {
   wishListPerks: Set<number>;
   /** What notes (if any) did the curator make for this item + roll? */
   notes: string | undefined;
+  /** Is this an undesirable roll? */
+  isUndesirable?: boolean;
 }
 
 let previousWishListRolls: { [itemHash: number]: WishListRoll[] } | undefined;
@@ -159,7 +161,8 @@ function getInventoryWishListRoll(
   if (matchingWishListRoll) {
     return {
       wishListPerks: getWishListPlugs(item, matchingWishListRoll),
-      notes: matchingWishListRoll.notes
+      notes: matchingWishListRoll.notes,
+      isUndesirable: matchingWishListRoll.isUndesirable
     };
   }
 

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -4,6 +4,11 @@ import { D2Item, DimPlug, DimItem } from '../inventory/item-types';
 import _ from 'lodash';
 import { INTRINSIC_PLUG_CATEGORY } from 'app/inventory/store/sockets';
 
+export enum UiWishListRoll {
+  Good = 1,
+  Bad
+}
+
 /**
  * An inventory wish list roll - for an item instance ID, is the item known to be on the wish list?
  * If it is on the wish list, what perks are responsible for it being there?

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -9,6 +9,15 @@ export enum UiWishListRoll {
   Bad
 }
 
+export function toUiWishListRoll(
+  inventoryWishListRoll?: InventoryWishListRoll
+): UiWishListRoll | undefined {
+  if (!inventoryWishListRoll) {
+    return undefined;
+  }
+  return inventoryWishListRoll.isUndesirable ? UiWishListRoll.Bad : UiWishListRoll.Good;
+}
+
 /**
  * An inventory wish list roll - for an item instance ID, is the item known to be on the wish list?
  * If it is on the wish list, what perks are responsible for it being there?

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -286,6 +286,7 @@
     },
     "Tracked": "Shows quests/bounties based on their tracked status.",
     "Transferable": "Items that can be moved between characters.",
+    "Trashlist": "Shows items that match your wish list's trash list.",
     "Undo": "Undo",
     "UnlockAllFailed": "Failed to unlock items",
     "UnlockAllSuccess": "Unlocked {{num}} items",


### PR DESCRIPTION
This extends wish lists to allow for wish list rolls and trash list rolls to live side-by-side in a single file (with some limitations). The short version - a negative item hash ID in an expert roll tells us that the user does not want that item.

It adds a new `is:trashlist` filter, and in this screenshot, you can see that it's possible to do things like express "every Bygones but one with these particular perks is a piece of trash", and DIM will honor your commitment to being exceedingly particular.

Along with this, I'll probably bake in @sundevour 's no keep list ( https://gist.github.com/sundevour/7c1fba63f521404e651b6e6983e827df ) into voltron.txt.

![Screenshot_2019-11-12 DIM](https://user-images.githubusercontent.com/606888/68726889-d7130980-0590-11ea-9b15-2061de6db410.png)
