### PR TITLE
Remove ornament icon code & setting

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -722,7 +722,6 @@
     "Items": "Item Display",
     "Language": "Language",
     "LogOut": "Log out",
-    "Ornaments": "Use ornament icons (D2)",
     "Ratings": "Ratings",
     "ReloadDIM": "Reload DIM to finish switching language",
     "ResetToDefault": "Reset",

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -37,12 +37,9 @@ import { buildMasterwork } from './masterwork';
 import { buildObjectives, buildFlavorObjective } from './objectives';
 import { buildTalentGrid } from './talent-grids';
 import { energyCapacityTypeNames } from 'app/item-popup/EnergyMeter';
-import { settings } from 'app/settings/settings';
 
 // Maps tierType to tierTypeName in English
 const tiers = ['Unknown', 'Currency', 'Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'];
-
-const defaultOrnaments = [2931483505, 1959648454, 702981643, 3807544519];
 
 export const damageTypeNames: { [key in DamageType]: string | null } = {
   [DamageType.None]: null,
@@ -506,26 +503,6 @@ export function makeItem(
 
     if (selectedEmblem) {
       createdItem.secondaryIcon = selectedEmblem.plugItem.secondaryIcon;
-    }
-  }
-
-  // show ornaments - ItemCategory 56 contains "Armor Mods: Ornaments" "Armor Mods: Ornaments/Hunter"
-  // "Armor Mods: Ornaments/Titan" "Armor Mods: Ornaments/Warlock" "Weapon Mods: Ornaments"
-  if (settings.ornaments !== 'none' && createdItem.sockets) {
-    const pluggedOrnament = createdItem.sockets.sockets.find((socket) => {
-      const categories = idx(socket.plug, (p) => p.plugItem.itemCategoryHashes);
-      return (
-        categories &&
-        // categorized as a mod, but not a glow (1875601085)
-        (categories.includes(56) && !categories.includes(1875601085))
-      );
-    });
-    if (
-      pluggedOrnament &&
-      pluggedOrnament.plug!.plugItem.displayProperties.hasIcon &&
-      !defaultOrnaments.includes(pluggedOrnament.plug!.plugItem.hash)
-    ) {
-      createdItem.icon = pluggedOrnament.plug!.plugItem.displayProperties.icon;
     }
   }
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -289,13 +289,6 @@ class SettingsPage extends React.Component<Props> {
               )}
 
               <Checkbox
-                label={t('Settings.Ornaments')}
-                name="ornaments"
-                value={settings.ornaments !== 'none'}
-                onChange={this.ornamentsChanged}
-              />
-
-              <Checkbox
                 label={t('Settings.ShowNewItems')}
                 name="showNewItems"
                 value={settings.showNewItems}
@@ -511,11 +504,6 @@ class SettingsPage extends React.Component<Props> {
     }
   };
 
-  private ornamentsChanged: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    this.props.setSetting('ornaments', e.target.checked ? 'unique' : 'none');
-    D2StoresService.reloadStores();
-  };
-
   private changeLanguage = (e) => {
     const language = e.target.value;
     this.onChange(e);
@@ -603,10 +591,7 @@ class SettingsPage extends React.Component<Props> {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SettingsPage);
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsPage);
 
 function isInputElement(element: HTMLElement): element is HTMLInputElement {
   return element.nodeName === 'INPUT';

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -69,12 +69,6 @@ export interface Settings {
 
   /** Colorblind modes. */
   readonly colorA11y: string;
-
-  /**
-   * Whether to show ornaments instead of the default item tile. 'unique' will show them but skips universal ornaments.
-   * In the future we may bring back the universal ornament setting, but not now.
-   */
-  readonly ornaments: 'none' | 'unique';
 }
 
 export function defaultItemSize() {
@@ -129,8 +123,7 @@ export const initialState: Settings = {
 
   language: defaultLanguage(),
 
-  colorA11y: '-',
-  ornaments: 'unique'
+  colorA11y: '-'
 };
 
 export type SettingsAction = ActionType<typeof actions>;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -715,7 +715,6 @@
     "Items": "Item Display",
     "Language": "Language",
     "LogOut": "Log out",
-    "Ornaments": "Use ornament icons (D2)",
     "Ratings": "Ratings",
     "ReloadDIM": "Reload DIM to finish switching language",
     "ResetToDefault": "Reset",


### PR DESCRIPTION
The good folks at Bungie have rendered this code & setting unnecessary - all ornamented items have their icon set in overrideStyleItemhash already.