### PR TITLE
Loadout Optimizer: Incorporate mod stats

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -502,7 +502,6 @@
     "OptimizerExplanation": "Select perks, filter and reorder stats, and lock items to narrow down your potential loadouts.",
     "OptimizerExplanationDesktop": "Shift-click a perk to select it. Shift-click an item to exclude it. Drag items to the sidebar to exclude or lock them.",
     "OptimizerExplanationArmour2Mods": "Armor 2.0 Mods are not included in stat tier calculations.",
-    "RequirePerks": "Try again including sub-Legendary and perk-less items",
     "ResetLocked": "Reset locked items",
     "SearchPlaceholder": "Filter (e.g., \"vigil of heroes\")",
     "SelectMax": "- Max -",

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -55,7 +55,6 @@ interface StoreProps {
 type Props = ProvidedProps & StoreProps;
 
 interface State {
-  requirePerks: boolean;
   lockedMap: LockedMap;
   selectedStoreId?: string;
   statFilters: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>;
@@ -121,7 +120,6 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
   constructor(props: Props) {
     super(props);
     this.state = {
-      requirePerks: true,
       lockedMap: {},
       statFilters: {
         Mobility: { min: 0, max: 10, ignored: false },
@@ -168,15 +166,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       searchConfig,
       filters
     } = this.props;
-    const {
-      lockedMap,
-      selectedStoreId,
-      statFilters,
-      minimumPower,
-      requirePerks,
-      query,
-      statOrder
-    } = this.state;
+    const { lockedMap, selectedStoreId, statFilters, minimumPower, query, statOrder } = this.state;
 
     if (!storesLoaded || !defs) {
       return <Loading />;
@@ -202,12 +192,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
       statKeys.filter((statType) => !this.state.statFilters[statType].ignored)
     );
     try {
-      filteredItems = this.filterItemsMemoized(
-        items[store.classType],
-        requirePerks,
-        lockedMap,
-        filter
-      );
+      filteredItems = this.filterItemsMemoized(items[store.classType], lockedMap, filter);
       const result = this.processMemoized(filteredItems, store.id);
       processedSets = result.sets;
       combos = result.combos;
@@ -279,13 +264,6 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
               <h2>{t('ErrorBoundary.Title')}</h2>
               <div>{processError.message}</div>
             </div>
-          ) : filteredSets.length === 0 && requirePerks ? (
-            <>
-              <h3>{t('LoadoutBuilder.NoBuildsFound')}</h3>
-              <button className="dim-button" onClick={this.setRequiredPerks}>
-                {t('LoadoutBuilder.RequirePerks')}
-              </button>
-            </>
           ) : (
             <GeneratedSets
               sets={filteredSets}
@@ -308,13 +286,6 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
   }
 
   /**
-   * Recomputes matched sets and includes items without additional perks
-   */
-  private setRequiredPerks = () => {
-    this.setState({ requirePerks: false });
-  };
-
-  /**
    * Handle when selected character changes
    * Recomputes matched sets
    */
@@ -322,7 +293,6 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     this.setState({
       selectedStoreId: storeId,
       lockedMap: {},
-      requirePerks: true,
       statFilters: {
         Mobility: { min: 0, max: 10, ignored: false },
         Resilience: { min: 0, max: 10, ignored: false },

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -193,7 +193,7 @@ export class LoadoutBuilder extends React.Component<Props & UIViewInjectedProps,
     );
     try {
       filteredItems = this.filterItemsMemoized(items[store.classType], lockedMap, filter);
-      const result = this.processMemoized(filteredItems, store.id);
+      const result = this.processMemoized(filteredItems, lockedMap, store.id);
       processedSets = result.sets;
       combos = result.combos;
       combosWithoutCaps = result.combosWithoutCaps;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -17,7 +17,7 @@ import { generateMixesFromPerks } from '../process';
  */
 function identifyAltPerkChoicesForChosenStats(item: DimItem, chosenValues: number[]) {
   let altPerks: DimPlug[] = [];
-  generateMixesFromPerks(item, (mix, plugs) => {
+  generateMixesFromPerks(item, {}, (mix, plugs) => {
     if (plugs && mix.every((val, index) => val === chosenValues[index])) {
       altPerks = plugs;
       return false;

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -32,7 +32,6 @@ export const statKeys = Object.keys(statHashes) as StatTypes[];
  */
 export function filterItems(
   items: ItemsByBucket,
-  requirePerks: boolean,
   lockedMap: LockedMap,
   filter: (item: DimItem) => boolean
 ): ItemsByBucket {
@@ -56,20 +55,6 @@ export function filterItems(
     if (!filteredItems[bucket].length) {
       // If nothing matches, just include everything so we can make valid sets
       filteredItems[bucket] = items[bucket];
-    }
-
-    // filter out low-tier items and items without extra perks on them
-    if (requirePerks) {
-      const highTierItems = filteredItems[bucket].filter(
-        (item) =>
-          (item && item.isDestiny2() && ['Exotic', 'Legendary'].includes(item.tier)) ||
-          // If it's a locked item, always let it through
-          (locked && locked.some((l) => l.type === 'item' && l.item.id === item.id))
-      );
-
-      if (highTierItems.length > 0) {
-        filteredItems[bucket] = highTierItems;
-      }
     }
   });
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -495,7 +495,6 @@
     "OptimizerExplanation": "Select perks, filter and reorder stats, and lock items to narrow down your potential loadouts.",
     "OptimizerExplanationArmour2Mods": "Armor 2.0 Mods are not included in stat tier calculations.",
     "OptimizerExplanationDesktop": "Shift-click a perk to select it. Shift-click an item to exclude it. Drag items to the sidebar to exclude or lock them.",
-    "RequirePerks": "Try again including sub-Legendary and perk-less items",
     "ResetLocked": "Reset locked items",
     "SearchPlaceholder": "Filter (e.g., \"vigil of heroes\")",
     "SelectMax": "- Max -",


### PR DESCRIPTION
Now that we can lock mods, the final piece of the puzzle is to actually take into account what the stats of the item would be with that mod applied. Only a few mods affect stats, but when they do they can bump up an entire tier (or more tricky, half a tier - see Traction). This adds in the effect of (Armor 2.0 only) mods to item stats before calculation, so it acts as if you've already applied that mod.

This could be better - I'd love to show the incorporated stats on the item's popup. But that requires somewhat tricky plumbing.