### PR TITLE
Fixing issue #4734 (object.flat())

### DIFF
--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -107,7 +107,11 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
     );
   }
 
-  let items: DimItem[] = copy(Object.values(loadout.items)).flat();
+  const itemCopies = copy(Object.values(loadout.items));
+
+  let items: DimItem[] = Object.keys(itemCopies)
+    .map((i) => itemCopies[i])
+    .flat();
 
   const loadoutItemIds = items.map((i) => ({
     id: i.id,


### PR DESCRIPTION
Casting to `DimItem[][]` inside of the `copy()` didn't work, so coercing the object of arrays into a jagged array.

This address issue #4734 and works on my machine.