### PR TITLE
is:onwrongclass will no longer highlight items in the postmaster

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -897,7 +897,8 @@ function searchFilters(
           !item.bucket.accountWide &&
           item.classType !== DestinyClass.Unknown &&
           ownerStore &&
-          !item.canBeEquippedBy(ownerStore)
+          !item.canBeEquippedBy(ownerStore) &&
+          !item.location?.inPostmaster
         );
       },
       classType(item: DimItem, predicate: string) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4798491/69488082-10196c80-0e22-11ea-9c63-5c2f5a2b5248.png)


After:
![image](https://user-images.githubusercontent.com/4798491/69488093-21627900-0e22-11ea-8347-c7788d73c0ee.png)

