### PR TITLE
compare sheet category buttons rework

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -275,8 +275,7 @@ class Compare extends React.Component<Props, State> {
     // else,this is a fresh comparison sheet spawn, so let's generate comparisonSets
     else {
       const allItems = exampleItem.getStoresService().getAllItems();
-      // comparisonSets is a map so that the buttons are ordered, and have labels
-      // maybe it should be an array of {buttonLabel, DimItem[]}, but.. ick.
+      // comparisonSets is an array so that it has order, filled with {label, setOfItems} objects
       const comparisonSets = exampleItem.bucket.inArmor
         ? this.findSimilarArmors(allItems, additionalItems)
         : exampleItem.bucket.inWeapons
@@ -482,19 +481,19 @@ class Compare extends React.Component<Props, State> {
       );
 
     let comparisonSets = [
-      // sameWeaponType:
+      // same weapon type
       {
         buttonLabel: exampleItem.typeName,
         items: allWeapons
       },
 
-      // sameWeaponTypeAndSlot:
+      // above, but also same (kinetic/energy/heavy) slot
       {
         buttonLabel: [exampleItem.bucket.name, exampleItem.typeName].join(' + '),
         items: allWeapons.filter((i) => i.bucket.name === exampleItem.bucket.name)
       },
 
-      // sameWeaponTypeAndArchetype:
+      // same weapon type plus matching intrinsic (rpm+impact..... ish)
       {
         buttonLabel: [intrinsicName, exampleItem.typeName].join(' + '),
         items: exampleItem.isDestiny2()
@@ -508,13 +507,13 @@ class Compare extends React.Component<Props, State> {
           : allWeapons.filter((i) => exampleItemRpm === getRpm(i))
       },
 
-      // sameWeaponTypeAndElement:
+      // same weapon type and also matching element (& usually same-slot because same element)
       {
         buttonLabel: [exampleItemElementName, exampleItem.typeName].join(' + '),
         items: allWeapons.filter(matchesExample('dmg'))
       },
 
-      // sameWeapon:
+      // exact same weapon, judging by name. might span multiple expansions.
       {
         buttonLabel: exampleItem.name,
         items: allWeapons.filter(matchesExample('name'))

--- a/src/app/compare/compare.service.ts
+++ b/src/app/compare/compare.service.ts
@@ -4,10 +4,10 @@ import { Subject } from 'rxjs';
 export const CompareService = {
   dialogOpen: false,
   compareItems$: new Subject<{
-    items: DimItem[];
-    dupes: boolean;
+    additionalItems: DimItem[];
+    showSomeDupes: boolean;
   }>(),
-  addItemsToCompare(items: DimItem[], dupes = false) {
-    this.compareItems$.next({ items, dupes });
+  addItemsToCompare(additionalItems: DimItem[], showSomeDupes = false) {
+    this.compareItems$.next({ additionalItems, showSomeDupes });
   }
 };

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -246,7 +246,7 @@ class SearchFilter extends React.Component<Props, State> {
     const comparableItems = this.getStoresService()
       .getAllItems()
       .filter(this.props.searchFilter);
-    CompareService.addItemsToCompare(comparableItems);
+    CompareService.addItemsToCompare(comparableItems, false);
   };
 
   private onTagClicked = () => {


### PR DESCRIPTION
#.1 - no longer filter out the 1-item category. much nicer imo.
it's a fast way to delete everything else, if you're unhappy that extras spawned.
by default though, it autoclicks the leftmost button with 2+ items, to get you started comparing
![image](https://user-images.githubusercontent.com/31990469/69828699-b7efbb00-11d1-11ea-8a0d-b3d81b52c933.png)

#,2 - by popular demand i.e. 2 people who bothered to say anything,
compare spawned from filter bar, is now strict comparison.
no items are automatically added to the compare bar. fixes #4685 

#.3 - weaned myself off Map, massively reworked comparisonSet building so it made way more sense to me. more stacked filters to show how each category is made. renamed a bunch of variables for clarity.