### PR TITLE
naming clarity for mod slots

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -19,7 +19,7 @@ import { scrollToPosition } from 'app/dim-ui/scroll';
 import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import { makeDupeID } from 'app/search/search-filters';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
-import { getItemDamageType, getItemSeasonalModSlotDisplayName } from 'app/utils/item-utils';
+import { getItemDamageType, getItemSpecialtyModSlotDisplayName } from 'app/utils/item-utils';
 import intrinsicLookupTable from 'data/d2/intrinsic-perk-lookup.json';
 import { INTRINSIC_PLUG_CATEGORY } from 'app/inventory/store/sockets';
 import BungieImage from 'app/dim-ui/BungieImage';
@@ -346,12 +346,12 @@ class Compare extends React.Component<Props, State> {
     const exampleItemElementIcon = exampleItemDamageType && (
       <BungieImage src={exampleItemDamageType.displayProperties.icon} />
     );
-    const exampleItemModSlot = getItemSeasonalModSlotDisplayName(exampleItem);
+    const exampleItemModSlot = getItemSpecialtyModSlotDisplayName(exampleItem);
 
     // helper functions for filtering items
     const matchesExample = (key: string) => (item: DimItem) => item[key] === exampleItem[key];
     const matchingModSlot = (item: DimItem) =>
-      exampleItemModSlot === getItemSeasonalModSlotDisplayName(item);
+      exampleItemModSlot === getItemSpecialtyModSlotDisplayName(item);
     const hasEnergy = (item: DimItem) => Boolean(item.isDestiny2() && item.energy);
 
     // minimum filter: make sure it's all armor, and can go in the same slot on the same class

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -33,7 +33,10 @@ import * as hashes from './search-filter-hashes';
 import D2Sources from 'data/d2/source-info';
 import S8Sources from 'data/d2/s8-source-info';
 import seasonTags from 'data/d2/season-tags.json';
-import { getItemSeasonalModSlotFilterName, seasonalModSlotFilterNames } from 'app/utils/item-utils';
+import {
+  getItemSpecialtyModSlotFilterName,
+  specialtyModSlotFilterNames
+} from 'app/utils/item-utils';
 import { DEFAULT_SHADER } from 'app/inventory/store/sockets';
 
 /**
@@ -307,7 +310,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
       .reverse()
       .map((tag) => `season:${tag}`),
     // keywords for seaqsonal mod slots
-    ...seasonalModSlotFilterNames
+    ...specialtyModSlotFilterNames
       .concat(['any', 'none'])
       .map((modSlotName) => `modslot:${modSlotName}`),
     // a keyword for every combination of a DIM-processed stat and mathmatical operator
@@ -1020,7 +1023,7 @@ function searchFilters(
         );
       },
       modslot(item: DimItem, predicate: string) {
-        const modSlotType = getItemSeasonalModSlotFilterName(item);
+        const modSlotType = getItemSpecialtyModSlotFilterName(item);
         return (
           Boolean(predicate === 'any' && modSlotType) ||
           (predicate === 'none' && !modSlotType) ||

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -6,6 +6,9 @@ import _ from 'lodash';
 import memoizeOne from 'memoize-one';
 import modSlotsByName from 'data/d2/seasonal-mod-slots.json';
 
+// a file for utilities where item goes in, info about the item comes out.
+// but not necessarily info worth wedging into the DimItem
+
 const dmgToEnum = _.invert(damageTypeNames);
 const generateEnumToDef: (
   defs: D2ManifestDefinitions
@@ -15,7 +18,6 @@ const generateEnumToDef: (
     return obj;
   }, {})
 );
-
 /** convert DimItem's .dmg back to a DamageType */
 export const getItemDamageType: (
   item: DimItem,
@@ -25,33 +27,32 @@ export const getItemDamageType: (
   return (item.dmg && dmgToEnum[item.dmg] && enumToDef[dmgToEnum[item.dmg]]) || null;
 };
 
-/** */
-const seasonalModSocketHashes = Object.values(modSlotsByName).flat();
-export const seasonalModSlotFilterNames = Object.keys(modSlotsByName);
-
-/** verifies an item is d2 armor and has a seasonal mod slot, which is returned */
-const getSeasonalPlug: (item: DimItem) => DimSocket | false = (item) =>
+// specialty slots are seasonal-ish, thus-far. some correspond to a season, some to an expansion
+const specialtyModSocketHashes = Object.values(modSlotsByName).flat();
+export const specialtyModSlotFilterNames = Object.keys(modSlotsByName);
+/** verifies an item is d2 armor and has a specialty mod slot, which is returned */
+export const getSpecialtySocket: (item: DimItem) => DimSocket | false = (item) =>
   (item.isDestiny2() &&
     item.bucket?.sort === 'Armor' &&
     item.sockets?.sockets.find((socket) =>
-      seasonalModSocketHashes.includes(socket?.plug?.plugItem?.plug?.plugCategoryHash ?? -99999999)
+      specialtyModSocketHashes.includes(socket?.plug?.plugItem?.plug?.plugCategoryHash ?? -99999999)
     )) ??
   false;
 
-/** returns a matched filter name or false */
-export const getItemSeasonalModSlotFilterName: (item: DimItem) => string | false = (item) => {
-  const seasonalSocket = getSeasonalPlug(item);
+/** returns a matched filter name or false if not found */
+export const getItemSpecialtyModSlotFilterName: (item: DimItem) => string | false = (item) => {
+  const specialtySocket = getSpecialtySocket(item);
   return (
-    (seasonalSocket &&
-      seasonalModSlotFilterNames.find((key) =>
-        modSlotsByName[key].includes(seasonalSocket.plug!.plugItem.plug.plugCategoryHash)
+    (specialtySocket &&
+      specialtyModSlotFilterNames.find((key) =>
+        modSlotsByName[key].includes(specialtySocket.plug!.plugItem.plug.plugCategoryHash)
       )) ||
     false
   );
 };
 
 /** this returns a string for easy printing purposes. '' if not found */
-export const getItemSeasonalModSlotDisplayName: (item: DimItem) => string = (item) => {
-  const seasonalSocket = getSeasonalPlug(item);
-  return (seasonalSocket && seasonalSocket.plug!.plugItem.itemTypeDisplayName) || '';
+export const getItemSpecialtyModSlotDisplayName: (item: DimItem) => string = (item) => {
+  const specialtySocket = getSpecialtySocket(item);
+  return (specialtySocket && specialtySocket.plug!.plugItem.itemTypeDisplayName) || '';
 };


### PR DESCRIPTION
forge/undying/etc mod slots aren't exactly seasonal, so i am renaming them specialty mod slots before the verbiage gets away from me

also i used "plug" where "socket" was the correct word. the function returns the entire mod slot, not just its contents