### PR TITLE
Set the number of slots to clear in farming mode

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -132,6 +132,7 @@
     "Desc_female": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "Desc_male": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "FarmingMode": "Farming Mode (make space)",
+    "FreeSlots": "Set the number of slots to clear",
     "MakeRoom": {
       "Desc": "DIM is moving only Engram and Glimmer items from {{store}} to the vault or other characters to prevent anything from going to the Postmaster.",
       "Desc_female": "DIM is moving only Engram and Glimmer items from {{store}} to the vault or other characters to prevent anything from going to the Postmaster.",

--- a/src/app/farming/D2Farming.tsx
+++ b/src/app/farming/D2Farming.tsx
@@ -12,6 +12,7 @@ import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
 interface StoreProps {
   moveTokens: boolean;
+  freeSlots: number;
   store?: DimStore;
 }
 
@@ -19,6 +20,7 @@ function mapStateToProps() {
   const storeSelector = farmingStoreSelector();
   return (state: RootState): StoreProps => ({
     moveTokens: state.settings.farming.moveTokens,
+    freeSlots: state.settings.farming.freeSlots,
     store: storeSelector(state)
   });
 }
@@ -59,6 +61,17 @@ class D2Farming extends React.Component<Props> {
                   />
                   <label htmlFor="move-tokens">{t('FarmingMode.MoveTokens')}</label>
                 </p>
+                <p>
+                  <input
+                    name="free-slots"
+                    className="free-slots"
+                    type="text"
+                    value={this.props.freeSlots}
+                    onChange={this.changeFreeSlots}
+                    onFocus={(e) => e.target.select()}
+                  />
+                  <label htmlFor="free-slots">{t('FarmingMode.FreeSlots')}</label>
+                </p>
               </span>
 
               <span>
@@ -74,6 +87,12 @@ class D2Farming extends React.Component<Props> {
   private toggleMoveTokens = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.currentTarget.checked;
     this.props.setFarmingSetting('moveTokens', value);
+  };
+
+  private changeFreeSlots = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.currentTarget.value, 10);
+    const validValue = Number.isNaN(value) ? 1 : value < 0 ? 0 : value > 9 ? 9 : value;
+    this.props.setFarmingSetting('freeSlots', validValue);
   };
 }
 

--- a/src/app/farming/farming.scss
+++ b/src/app/farming/farming.scss
@@ -21,6 +21,11 @@
   padding-bottom: calc(0.5rem + constant(safe-area-inset-bottom));
   padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
 
+  .free-slots {
+    width: 1rem;
+    text-align: center;
+    margin-right: 0.5rem;
+  }
   button {
     color: white;
     background-color: rgba(128, 128, 128, 0.4);

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -46,6 +46,7 @@ export interface Settings {
     /** Whether to keep one slot per item type open */
     readonly makeRoomForItems: boolean;
     readonly moveTokens: boolean;
+    readonly freeSlots: number;
   };
   /** Destiny 2 platform selection for ratings + reviews */
   readonly reviewsPlatformSelectionV2: DtrReviewPlatform;
@@ -108,7 +109,8 @@ export const initialState: Settings = {
   farming: {
     // Whether to keep one slot per item type open
     makeRoomForItems: true,
-    moveTokens: false
+    moveTokens: false,
+    freeSlots: 1
   },
   // Destiny 2 platform selection for ratings + reviews
   reviewsPlatformSelectionV2: 0,

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -130,6 +130,7 @@
     "Desc_female": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "Desc_male": "DIM is moving Engram and Glimmer items from {{store}} to the vault and leaving one space open per item type to prevent anything from going to the Postmaster.",
     "FarmingMode": "Farming Mode (make space)",
+    "FreeSlots": "Set the number of slots to clear",
     "MakeRoom": {
       "Desc": "DIM is moving only Engram and Glimmer items from {{store}} to the vault or other characters to prevent anything from going to the Postmaster.",
       "Desc_female": "DIM is moving only Engram and Glimmer items from {{store}} to the vault or other characters to prevent anything from going to the Postmaster.",


### PR DESCRIPTION
Allows the number of slots to be set for farming mode. My post master seems to fill up even with farming on so I'm hoping this will help.

This is my first time adding anything to DIM, so let me know how I can improve things. I'm not totally happy with the input box, I feel like it would be better with a +/- widget but this was easy to do.

![image](https://user-images.githubusercontent.com/140492/71248387-98d2ec00-237f-11ea-84c9-f893dd8503ca.png)
