### PR TITLE
Add faction level to vendor listing in vendors view (if available)

### DIFF
--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -88,7 +88,7 @@ export default function VendorItems({
         </div>
       )}
       <div className={styles.itemCategories}>
-        {!filtering && rewardVendorHash && rewardItem && (
+        {!filtering && ((rewardVendorHash && rewardItem) || (factionProgress && faction)) && (
           <div className={styles.vendorRow}>
             <h3 className={styles.categoryTitle}>{t('Vendors.Engram')}</h3>
             <div className={styles.vendorItems}>
@@ -105,14 +105,16 @@ export default function VendorItems({
                   </div>
                 </PressTip>
               )}
-              <UISref to="destiny2.vendor" params={{ id: rewardVendorHash }}>
-                <div className="item" title={rewardItem.displayProperties.name}>
-                  <BungieImage
-                    className="item-img transparent"
-                    src={rewardItem.displayProperties.icon}
-                  />
-                </div>
-              </UISref>
+              {rewardVendorHash && rewardItem && (
+                <UISref to="destiny2.vendor" params={{ id: rewardVendorHash }}>
+                  <div className="item" title={rewardItem.displayProperties.name}>
+                    <BungieImage
+                      className="item-img transparent"
+                      src={rewardItem.displayProperties.icon}
+                    />
+                  </div>
+                </UISref>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
This is my quick & dirty fix for #4816

It will force a display of the "Rewards engram" block for vendors if they *either* have a faction level or reward engram associated (and show the appropriate level and/or engram reference).

_Technically_ the "Rewards engram" header would be incorrect for "level only" vendors, but I don't know enough about DIM's text definitions (or react) to want to stick my toes in too deep here.

This should work for what I personally wanted: obelisk levels on vendors in DIM 😀 

Also: I _totally_ did this dry with notepad only without setting up any dev or test environment. So if I somehow made things blow up ...  🤷‍♂ 

