### PR TITLE
Organizer: filter on cell shift-click

### DIFF
--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -200,3 +200,13 @@
   height: calc(var(--item-size) * 0.5);
   width: calc(var(--item-size) * 0.5);
 }
+
+// Indicate cells that can be filtered on shift-click
+.shiftHeld {
+  .hasFilter {
+    background-color: #6666ff;
+    &:hover {
+      background-color: #3333ff;
+    }
+  }
+}

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'dmg': string;
   'enabledColumns': string;
   'event': string;
+  'hasFilter': string;
   'icon': string;
   'inlineIcon': string;
   'lock': string;
@@ -24,6 +25,7 @@ interface CssExports {
   'reacquireable': string;
   'season': string;
   'selection': string;
+  'shiftHeld': string;
   'source': string;
   'table': string;
   'tableContainer': string;

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -64,6 +64,8 @@ import { storesSelector } from 'app/inventory/reducer';
 import { searchFilterSelector } from 'app/search/search-filters';
 import { inventoryWishListsSelector } from 'app/wishlists/reducer';
 import { toggleSearchQueryComponent } from 'app/shell/actions';
+import clsx from 'clsx';
+import { useShiftHeld } from 'app/utils/hooks';
 
 const initialState = {
   sortBy: [{ id: 'name' }]
@@ -161,6 +163,8 @@ function ItemTable({
     'mods',
     'notes'
   ]);
+
+  const shiftHeld = useShiftHeld();
 
   // TODO: drop wishlist columns if no wishlist loaded
   // TODO: d1/d2 columns
@@ -646,7 +650,7 @@ function ItemTable({
           Move To
         </button>
       </div>
-      <div className={styles.tableContainer}>
+      <div className={clsx(styles.tableContainer, shiftHeld && styles.shiftHeld)}>
         <table className={styles.table} {...getTableProps()}>
           <thead>
             {headerGroups.map((headerGroup) => (
@@ -674,7 +678,10 @@ function ItemTable({
                     <td
                       {...cell.getCellProps()}
                       onClick={narrowQueryFunction(row, cell)}
-                      className={styles[cell.column.id]}
+                      className={clsx(
+                        styles[cell.column.id],
+                        cell.column.filter && styles.hasFilter
+                      )}
                     >
                       {cell.render('Cell')}
                     </td>

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-key, react/prop-types */
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import { DimItem } from 'app/inventory/item-types';
 import { RootState } from 'app/store/reducers';
 import { D2StoresService } from 'app/inventory/d2-stores';
 import { DestinyAccount } from 'app/accounts/destiny-account';
@@ -9,9 +8,7 @@ import { useSubscription } from 'app/utils/hooks';
 import { queueAction } from 'app/inventory/action-queue';
 import { refresh$ } from 'app/shell/refresh';
 import { Loading } from 'app/dim-ui/Loading';
-import { createSelector } from 'reselect';
 import { storesSelector } from 'app/inventory/reducer';
-import { searchFilterSelector } from 'app/search/search-filters';
 import ItemTypeSelector, { SelectionTreeNode } from './ItemTypeSelector';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
@@ -19,10 +16,6 @@ import ItemTable from './ItemTable';
 import Spreadsheets from '../settings/Spreadsheets';
 import { DimItemInfo } from 'app/inventory/dim-item-info';
 import { DimStore } from 'app/inventory/store-types';
-import { DtrRating } from 'app/item-review/dtr-api-types';
-import { ratingsSelector } from 'app/item-review/reducer';
-import { InventoryWishListRoll } from 'app/wishlists/wishlists';
-import { inventoryWishListsSelector } from 'app/wishlists/reducer';
 import styles from './Organizer.m.scss';
 
 interface ProvidedProps {
@@ -31,49 +24,25 @@ interface ProvidedProps {
 
 interface StoreProps {
   stores: DimStore[];
-  items: DimItem[];
   defs: D2ManifestDefinitions;
   itemInfos: { [key: string]: DimItemInfo };
-  ratings: { [key: string]: DtrRating };
-  wishList: {
-    [key: string]: InventoryWishListRoll;
-  };
   isPhonePortrait: boolean;
 }
 
 function mapStateToProps() {
-  const allItemsSelector = createSelector(storesSelector, (stores) =>
-    stores.flatMap((s) => s.items).filter((i) => i.comparable && i.primStat)
-  );
-  // TODO: make the table a subcomponent so it can take the subtype as an argument?
-  return (state: RootState): StoreProps => {
-    const searchFilter = searchFilterSelector(state);
-    return {
-      items: allItemsSelector(state).filter(searchFilter),
-      defs: state.manifest.d2Manifest!,
-      stores: storesSelector(state),
-      itemInfos: state.inventory.itemInfos,
-      ratings: ratingsSelector(state),
-      wishList: inventoryWishListsSelector(state),
-      isPhonePortrait: state.shell.isPhonePortrait
-    };
-  };
+  return (state: RootState): StoreProps => ({
+    defs: state.manifest.d2Manifest!,
+    stores: storesSelector(state),
+    itemInfos: state.inventory.itemInfos,
+    isPhonePortrait: state.shell.isPhonePortrait
+  });
 }
 
 type Props = ProvidedProps & StoreProps;
 
-function Organizer({
-  account,
-  items,
-  defs,
-  itemInfos,
-  stores,
-  ratings,
-  wishList,
-  isPhonePortrait
-}: Props) {
+function Organizer({ account, defs, itemInfos, stores, isPhonePortrait }: Props) {
   useEffect(() => {
-    if (!items.length) {
+    if (!stores.length) {
       D2StoresService.getStoresStream(account);
     }
   });
@@ -88,23 +57,15 @@ function Organizer({
     return <div className={styles.page}>This view isn't great on mobile.</div>;
   }
 
-  if (!items.length) {
+  if (!stores.length) {
     return <Loading />;
   }
 
-  // TODO: bulk edit
   return (
     <div className={styles.page}>
       <ErrorBoundary name="Organizer">
         <ItemTypeSelector defs={defs} selection={selection} onSelection={setSelection} />
-        <ItemTable
-          items={items}
-          selection={selection}
-          itemInfos={itemInfos}
-          wishList={wishList}
-          ratings={ratings}
-          defs={defs}
-        />
+        <ItemTable selection={selection} />
         <Spreadsheets stores={stores} itemInfos={itemInfos} />
       </ErrorBoundary>
     </div>

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -4,7 +4,7 @@ import { AppIcon, tagIcon } from '../shell/icons';
 import { faClone } from '@fortawesome/free-regular-svg-icons';
 import { faUndo } from '@fortawesome/free-solid-svg-icons';
 import { itemTagSelectorList, getItemInfoSource, TagValue } from '../inventory/dim-item-info';
-import { connect } from 'react-redux';
+import { connect, MapDispatchToPropsFunction } from 'react-redux';
 import { RootState } from '../store/reducers';
 import { setSearchQuery } from '../shell/actions';
 import _ from 'lodash';
@@ -23,6 +23,7 @@ import SearchFilterInput from './SearchFilterInput';
 import { showNotification } from '../notifications/notifications';
 import NotificationButton from '../notifications/NotificationButton';
 import { CompareService } from '../compare/compare.service';
+import { searchQueryVersionSelector, querySelector } from 'app/shell/reducer';
 
 // these exist in comments so i18n       t('Tags.TagItems') t('Tags.ClearTag')
 // doesn't delete the translations       t('Tags.LockAll') t('Tags.UnlockAll')
@@ -44,14 +45,18 @@ interface StoreProps {
   destinyVersion: 1 | 2;
   account?: DestinyAccount;
   searchConfig: SearchConfig;
+  searchQueryVersion: number;
+  searchQuery: string;
   searchFilter(item: DimItem): boolean;
 }
 
-const mapDispatchToProps = {
-  setSearchQuery
+type DispatchProps = {
+  setSearchQuery(query: string): void;
 };
 
-type DispatchProps = typeof mapDispatchToProps;
+const mapDispatchToProps: MapDispatchToPropsFunction<DispatchProps, StoreProps> = (dispatch) => ({
+  setSearchQuery: (query) => dispatch(setSearchQuery(query, true))
+});
 
 type Props = ProvidedProps & StoreProps & DispatchProps;
 
@@ -65,7 +70,9 @@ function mapStateToProps(state: RootState): StoreProps {
     destinyVersion: destinyVersionSelector(state),
     account: currentAccountSelector(state),
     searchConfig: searchConfigSelector(state),
-    searchFilter: searchFilterSelector(state)
+    searchFilter: searchFilterSelector(state),
+    searchQuery: querySelector(state),
+    searchQueryVersion: searchQueryVersionSelector(state)
   };
 }
 
@@ -177,7 +184,14 @@ class SearchFilter extends React.Component<Props, State> {
   );
 
   render() {
-    const { isPhonePortrait, mobile, searchConfig, setSearchQuery } = this.props;
+    const {
+      isPhonePortrait,
+      mobile,
+      searchConfig,
+      setSearchQuery,
+      searchQuery,
+      searchQueryVersion
+    } = this.props;
     const { showSelect } = this.state;
 
     const filteredItems = this.getStoresService()
@@ -204,6 +218,8 @@ class SearchFilter extends React.Component<Props, State> {
         placeholder={placeholder}
         searchConfig={searchConfig}
         onClear={this.onClearFilter}
+        searchQueryVersion={searchQueryVersion}
+        searchQuery={searchQuery}
       >
         <>
           <span className="filter-match-count">

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -16,6 +16,8 @@ interface ProvidedProps {
   placeholder: string;
   searchConfig: SearchConfig;
   autoFocus?: boolean;
+  searchQueryVersion?: number;
+  searchQuery?: string;
   /** Children are used as optional extra action buttons when there is a query. */
   children?: React.ReactChild;
   /** TODO: have an initialQuery prop */
@@ -73,6 +75,12 @@ export default class SearchFilterInput extends React.Component<Props, State> {
   componentDidUpdate(prevProps) {
     if (prevProps.searchConfig !== this.props.searchConfig) {
       this.setupTextcomplete();
+    }
+    if (
+      prevProps.searchQueryVersion !== this.props.searchQueryVersion &&
+      this.props.searchQuery !== undefined
+    ) {
+      this.setState({ liveQuery: this.props.searchQuery });
     }
   }
 

--- a/src/app/shell/actions.ts
+++ b/src/app/shell/actions.ts
@@ -3,5 +3,11 @@ import { createAction } from 'typesafe-actions';
 /** Set whether we're in phonePortrait view mode. */
 export const setPhonePortrait = createAction('shell/PHONE_PORTRAIT')<boolean>();
 
-/** Set the current search query text. */
-export const setSearchQuery = createAction('shell/SEARCH_QUERY')<string>();
+/**
+ * Set the current search query text. Only the search filter input component should set
+ * doNotUpdateVersion - all other uses should ignore that parameter.
+ */
+export const setSearchQuery = createAction(
+  'shell/SEARCH_QUERY',
+  (query: string, doNotUpdateVersion?: boolean) => ({ query, doNotUpdateVersion })
+)();

--- a/src/app/shell/actions.ts
+++ b/src/app/shell/actions.ts
@@ -11,3 +11,10 @@ export const setSearchQuery = createAction(
   'shell/SEARCH_QUERY',
   (query: string, doNotUpdateVersion?: boolean) => ({ query, doNotUpdateVersion })
 )();
+
+/**
+ * Toggle in or out a specific search query component from the existing search.
+ */
+export const toggleSearchQueryComponent = createAction('shell/TOGGLE_SEARCH_QUERY_COMPONENT')<
+  string
+>();

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -45,6 +45,21 @@ export const shell: Reducer<ShellState, ShellAction> = (
           ? state.searchQueryVersion
           : state.searchQueryVersion + 1
       };
+
+    case getType(actions.toggleSearchQueryComponent): {
+      const existingQuery = state.searchQuery;
+      const queryComponent = action.payload.trim();
+      const newQuery = existingQuery.includes(queryComponent)
+        ? existingQuery.replace(queryComponent, '').replace(/\s+/, ' ')
+        : `${existingQuery} ${queryComponent}`;
+
+      return {
+        ...state,
+        searchQuery: newQuery,
+        searchQueryVersion: state.searchQueryVersion + 1
+      };
+    }
+
     default:
       return state;
   }

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -5,17 +5,26 @@ import { isPhonePortraitFromMediaQuery } from '../utils/media-queries';
 import { RootState } from '../store/reducers';
 
 export const querySelector = (state: RootState) => state.shell.searchQuery;
+export const searchQueryVersionSelector = (state: RootState) => state.shell.searchQueryVersion;
 
 export interface ShellState {
   readonly isPhonePortrait: boolean;
   readonly searchQuery: string;
+  /**
+   * This is a workaround for the fact that our search query input is debounced. When setting the
+   * query text from outside of the search input, this version will be updated, which tells the
+   * search input component to reset its internal state. Otherwise if we listened to every
+   * change of the search query text, your typing would be undone when the redux store updates.
+   */
+  readonly searchQueryVersion: number;
 }
 
 export type ShellAction = ActionType<typeof actions>;
 
 const initialState: ShellState = {
   isPhonePortrait: isPhonePortraitFromMediaQuery(),
-  searchQuery: ''
+  searchQuery: '',
+  searchQueryVersion: 0
 };
 
 export const shell: Reducer<ShellState, ShellAction> = (
@@ -31,7 +40,10 @@ export const shell: Reducer<ShellState, ShellAction> = (
     case getType(actions.setSearchQuery):
       return {
         ...state,
-        searchQuery: action.payload
+        searchQuery: action.payload.query,
+        searchQueryVersion: action.payload.doNotUpdateVersion
+          ? state.searchQueryVersion
+          : state.searchQueryVersion + 1
       };
     default:
       return state;

--- a/src/app/utils/hooks.ts
+++ b/src/app/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Subscription } from 'rxjs';
 
 /**
@@ -11,4 +11,29 @@ export function useSubscription(subscribeFn: () => Subscription) {
     const subscription = subscribeFn();
     return () => subscription.unsubscribe();
   }, [subscribeFn]);
+}
+
+/**
+ * Returns whether the shift key is held down (ignores focus)
+ */
+export function useShiftHeld() {
+  const [shiftHeld, setShiftHeld] = useState(false);
+  useEffect(() => {
+    const shiftTrue = (e) => {
+      console.log('shiftTrue', e.shiftKey);
+      e.shiftKey && setShiftHeld(true);
+    };
+    const shiftFalse = (e) => {
+      console.log('shiftFalse', e.shiftKey);
+      !e.shiftKey && setShiftHeld(false);
+    };
+    document.addEventListener('keydown', shiftTrue);
+    document.addEventListener('keyup', shiftFalse);
+    return () => {
+      document.removeEventListener('keydown', shiftTrue);
+      document.removeEventListener('keyup', shiftFalse);
+    };
+  }, []);
+
+  return shiftHeld;
 }


### PR DESCRIPTION
This introduces a feature for the organizer that makes filtering items (and learning filter syntax!) much easier. Shift-click on a cell, and the search query will be amended to filter down to items matching that value. Shift click one of those fields again, and that query component will be removed.

I've filled in filter generator functions for just a couple columns, plus a crude visual indicator for which columns can be filtered:

![organizer-narrow](https://user-images.githubusercontent.com/313208/71314681-b3e64000-2401-11ea-8135-9705797c5f30.gif)
