### PR TITLE
mod slot icon fixes

### DIFF
--- a/src/app/dim-ui/SpecialtyModSlotIcon.m.scss
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.m.scss
@@ -3,4 +3,5 @@
   display: inline-block;
   background-size: 159%;
   border-radius: 50%;
+  filter: drop-shadow(0 0 0 white);
 }

--- a/src/app/dim-ui/SpecialtyModSlotIcon.tsx
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.tsx
@@ -28,7 +28,7 @@ function SpecialtyModSlotIcon({ item, className, defs }: Props) {
   return emptySlotIcon ? (
     <div
       className={`${className} ${styles.specialtyModIcon}`}
-      title={emptySlotIcon.displayProperties.name}
+      title={emptySlotIcon.itemTypeDisplayName}
       style={bungieBackgroundStyle(emptySlotIcon.displayProperties.icon)}
     />
   ) : null;


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/31990469/71357238-cbc0df80-2539-11ea-961e-c4e289c00bdc.png)
after
![image](https://user-images.githubusercontent.com/31990469/71357161-8bf9f800-2539-11ea-924d-898d80e4e964.png)

this brightens up the mod slot icon and fixes the hover text to say the slot type, instead of "empty slot"

in my defense these worked in the first draft then got lost in re-doing