### PR TITLE
Attempt to work around https://github.com/Bungie-net/api/issues/1151

### DIFF
--- a/src/app/accounts/destiny-account.ts
+++ b/src/app/accounts/destiny-account.ts
@@ -182,7 +182,8 @@ async function findD1Characters(account: DestinyAccount): Promise<any | null> {
     if (
       e.code &&
       (e.code === PlatformErrorCodes.DestinyAccountNotFound ||
-        e.code === PlatformErrorCodes.DestinyLegacyPlatformInaccessible)
+        e.code === PlatformErrorCodes.DestinyLegacyPlatformInaccessible ||
+        e.code === PlatformErrorCodes.DestinyUnexpectedError)
     ) {
       return null;
     }

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -75,6 +75,12 @@ export async function fetchWithBungieOAuth(
 }
 
 async function responseIndicatesBadToken(response: Response) {
+  // https://github.com/Bungie-net/api/issues/1151: D1 endpoints have a bug where they can return 401 if you've logged in via Stadia.
+  // This hack prevents a login loop
+  if (/\/D1\/Platform\/Destiny\/\d+\/Account\/\d+\/$/.test(response.url)) {
+    return false;
+  }
+
   if (response.status === 401) {
     return true;
   }


### PR DESCRIPTION
Hopeful fix for https://github.com/DestinyItemManager/DIM/issues/4842, caused by https://github.com/Bungie-net/api/issues/1151. Users of Stadia login still won't see their D1 account, but at least they shouldn't be put into a login loop.