### PR TITLE
Bugix for missing sets after ignoring stat in optimiser

### DIFF
--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -1,7 +1,7 @@
 import { t } from 'app/i18next-t';
 import React, { useMemo, useCallback, useState } from 'react';
 import { D2Store } from '../../inventory/store-types';
-import { ArmorSet, MinMax, StatTypes, MinMaxIgnored } from '../types';
+import { ArmorSet, StatTypes, MinMaxIgnored } from '../types';
 import TierSelect from './TierSelect';
 import _ from 'lodash';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
@@ -34,7 +34,7 @@ export default function FilterBuilds({
   assumeMasterwork: boolean;
   onMinimumPowerChanged(minimumPower: number): void;
   onStatOrderChanged(order: StatTypes[]): void;
-  onStatFiltersChanged(stats: { [statType in StatTypes]: MinMax }): void;
+  onStatFiltersChanged(stats: { [statType in StatTypes]: MinMaxIgnored }): void;
   onMasterworkAssumptionChange(assumeMasterwork: boolean): void;
 }) {
   const statRanges = useMemo(() => {

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { DimSocket, DimItem, D2Item } from '../../inventory/item-types';
-import { ArmorSet, LockedItemType, MinMax, StatTypes, LockedMap, LockedMod } from '../types';
+import { ArmorSet, LockedItemType, StatTypes, LockedMap, LockedMod, MinMaxIgnored } from '../types';
 import { count } from '../../utils/util';
 import {
   DestinyInventoryItemDefinition,
@@ -118,7 +118,7 @@ export function filterGeneratedSets(
   sets: readonly ArmorSet[],
   minimumPower: number,
   lockedMap: LockedMap,
-  stats: Readonly<{ [statType in StatTypes]: MinMax }>,
+  stats: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>,
   statOrder: StatTypes[],
   enabledStats: Set<StatTypes>
 ) {
@@ -143,7 +143,7 @@ export function filterGeneratedSets(
 function getBestSets(
   setMap: readonly ArmorSet[],
   lockedMap: LockedMap,
-  stats: Readonly<{ [statType in StatTypes]: MinMax }>
+  stats: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>
 ): ArmorSet[] {
   // Remove sets that do not match tier filters
   let sortedSets: ArmorSet[];
@@ -153,7 +153,7 @@ function getBestSets(
     sortedSets = setMap.filter((set) =>
       _.every(stats, (value, key) => {
         const tier = statTier(set.stats[key]);
-        return value.min <= tier && value.max >= tier;
+        return value.ignored || (value.min <= tier && value.max >= tier);
       })
     );
   }


### PR DESCRIPTION
Stopped filtering on min max values, when stat is ignored, when calculating base sets.

Fixes #4848 