### PR TITLE
Replace stat color scale with just highlighting best stats.

### DIFF
--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { StatInfo } from './Compare';
 import { DimItem, D1Stat } from '../inventory/item-types';
-import { getColor } from '../shell/filters';
 import { AppIcon, starIcon } from '../shell/icons';
 import clsx from 'clsx';
 import { t } from 'app/i18next-t';
@@ -24,9 +23,11 @@ export default function CompareStat({
 
   return (
     <div
-      className={clsx({ highlight: stat.id === highlight })}
+      className={clsx({
+        highlight: stat.id === highlight,
+        'highest-stat': statRange(itemStat, stat) >= 100
+      })}
       onMouseOver={() => setHighlight?.(stat.id)}
-      style={getColor(statRange(itemStat, stat), 'color')}
     >
       <span>
         {stat.id === 'Rating' && <AppIcon icon={starIcon} />}

--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -164,6 +164,10 @@
     margin-left: 5px;
     vertical-align: middle;
   }
+
+  .highest-stat {
+    color: hsla(190, 65%, 50%, 1);
+  }
 }
 
 @keyframes pop {


### PR DESCRIPTION
I don't really like the attempt at a color scale for stats in the compare view. This replaces them with just white text, and a highlight for the best value. The only thing this really loses is cases where all the stats are the same (those used to be the only white stats).

<img width="788" alt="Screen Shot 2020-01-11 at 12 07 19 PM" src="https://user-images.githubusercontent.com/313208/72210094-f633f780-346a-11ea-9a9f-4cb73abc8f4b.png">
