### PR TITLE
Update exclusions for .well-known folder

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -434,7 +434,9 @@ module.exports = (env) => {
           /\.map$/,
           // Ignore both the webapp manifest and the d1-manifest files
           /data\/d1\/manifests/,
-          /manifest-webapp/
+          /manifest-webapp/,
+          // Android manifest
+          /\.well-known/
         ],
         swSrc: './src/service-worker.js',
         swDest: 'service-worker.js',

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -28,7 +28,7 @@ workbox.routing.registerNavigationRoute(
   {
     // These have their own pages (return.html and gdrive-return.html)
     // This regex matches on query string too, so no anchors!
-    blacklist: [/return\.html/]
+    blacklist: [/return\.html/, /\.well-known/]
   }
 );
 


### PR DESCRIPTION
I think this was added for the Android wrapper, but we don't want to precache it OR include it in our SPA rule.

@kyleshay not sure how the Android thing is going, but this may have been why it didn't work (assuming it didn't).