### PR TITLE
Clean up new wishlists functionality

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -927,7 +927,7 @@
     "ImportFailed": "No wish list information found.",
     "ImportNoFile": "No file selected.",
     "ImportSuccess": "Wish list loaded with information about one roll.{{titleAndDescription}}",
-    "ImportSuccess_plural": "Wish list loaded with information about {{count}} rolls.{{titleAndDescription}}",
+    "ImportSuccess_plural": "Wish list loaded with information about {{count, number}} rolls.{{titleAndDescription}}",
     "InvalidExternalSource": "Please enter a valid URL for your external wish list source. The URL must start with https://raw.githubusercontent.com",
     "Num": "{{num, number}} rolls in your wish list",
     "UpdateExternalSource": "Update Wish List Source",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -928,7 +928,7 @@
     "ImportNoFile": "No file selected.",
     "ImportSuccess": "Wish list loaded with information about one roll.{{titleAndDescription}}",
     "ImportSuccess_plural": "Wish list loaded with information about {{count}} rolls.{{titleAndDescription}}",
-    "InvalidExternalSource": "Please enter a valid URL for your external wish list source.",
+    "InvalidExternalSource": "Please enter a valid URL for your external wish list source. The URL must start with https://raw.githubusercontent.com",
     "Num": "{{num, number}} rolls in your wish list",
     "UpdateExternalSource": "Update Wish List Source",
     "WishListNotes": "Wish List Notes: {{notes}}"

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -117,8 +117,7 @@ class WishListSettings extends React.Component<Props, State> {
   }
 
   private wishListUpdateEvent = () => {
-    let wishListSource = this.state.wishListSource;
-
+    const wishListSource = this.state.wishListSource?.trim();
     if (
       !isUri(wishListSource) ||
       !wishListSource?.startsWith('https://raw.githubusercontent.com/')
@@ -126,8 +125,6 @@ class WishListSettings extends React.Component<Props, State> {
       alert(t('WishListRoll.InvalidExternalSource'));
       return;
     }
-
-    wishListSource = wishListSource?.trim();
 
     if (this.props.wishListSource === wishListSource) {
       return;

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { t } from 'app/i18next-t';
-import { connect } from 'react-redux';
+import { connect, DispatchProp } from 'react-redux';
 import { RootState } from '../store/reducers';
 import { clearWishLists } from '../wishlists/actions';
 import HelpLink from '../dim-ui/HelpLink';
@@ -11,7 +11,7 @@ import _ from 'lodash';
 import { setSetting } from './actions';
 import { transformAndStoreWishList, fetchWishList } from 'app/wishlists/wishlist-fetch';
 import { isUri } from 'valid-url';
-import store from '../store/store';
+import { toWishList } from 'app/wishlists/wishlist-file';
 
 interface StoreProps {
   wishListsEnabled: boolean;
@@ -21,14 +21,7 @@ interface StoreProps {
   wishListSource?: string;
 }
 
-const mapDispatchToProps = {
-  clearWishListAndInfo: clearWishLists,
-  loadWishListAndInfoFromIndexedDB: loadWishListAndInfoFromIndexedDB as any,
-  setSetting
-};
-type DispatchProps = typeof mapDispatchToProps;
-
-type Props = StoreProps & DispatchProps;
+type Props = StoreProps & DispatchProp;
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
@@ -51,7 +44,7 @@ class WishListSettings extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    this.props.loadWishListAndInfoFromIndexedDB();
+    this.props.dispatch(loadWishListAndInfoFromIndexedDB() as any);
   }
 
   render() {
@@ -126,7 +119,10 @@ class WishListSettings extends React.Component<Props, State> {
   private wishListUpdateEvent = () => {
     let wishListSource = this.state.wishListSource;
 
-    if (!isUri(wishListSource)) {
+    if (
+      !isUri(wishListSource) ||
+      !wishListSource?.startsWith('https://raw.githubusercontent.com/')
+    ) {
       alert(t('WishListRoll.InvalidExternalSource'));
       return;
     }
@@ -137,19 +133,23 @@ class WishListSettings extends React.Component<Props, State> {
       return;
     }
 
-    this.props.setSetting('wishListSource', wishListSource);
+    this.props.dispatch(setSetting('wishListSource', wishListSource));
 
-    store.dispatch(fetchWishList());
+    this.props.dispatch(fetchWishList() as any);
+
+    ga('send', 'event', 'WishList', 'From URL');
   };
 
   private loadWishList: DropzoneOptions['onDrop'] = (acceptedFiles) => {
-    this.props.setSetting('wishListSource', undefined);
+    this.props.dispatch(setSetting('wishListSource', undefined));
     this.setState({ wishListSource: '' });
 
     const reader = new FileReader();
     reader.onload = () => {
       if (reader.result && typeof reader.result === 'string') {
-        store.dispatch(transformAndStoreWishList(reader.result, 'Load Wish List'));
+        const wishListAndInfo = toWishList(reader.result);
+        this.props.dispatch(transformAndStoreWishList(wishListAndInfo) as any);
+        ga('send', 'event', 'WishList', 'From File');
       }
     };
 
@@ -163,9 +163,9 @@ class WishListSettings extends React.Component<Props, State> {
   };
 
   private clearWishListEvent = () => {
-    this.props.setSetting('wishListSource', undefined);
+    ga('send', 'event', 'WishList', 'Clear');
     this.setState({ wishListSource: '' });
-    this.props.clearWishListAndInfo();
+    this.props.dispatch(clearWishLists());
   };
 
   private updateWishListSourceState = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -174,7 +174,4 @@ class WishListSettings extends React.Component<Props, State> {
   };
 }
 
-export default connect<StoreProps, DispatchProps>(
-  mapStateToProps,
-  mapDispatchToProps
-)(WishListSettings);
+export default connect<StoreProps>(mapStateToProps)(WishListSettings);

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -18,7 +18,7 @@ interface StoreProps {
   numWishListRolls: number;
   title?: string;
   description?: string;
-  wishListSource?: string;
+  wishListSource: string;
 }
 
 type Props = StoreProps & DispatchProp;

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -75,8 +75,9 @@ export interface Settings {
    * External source for wish lists.
    * Expected to be a valid URL.
    * initialState should hold the current location of a reasonably-useful collection of rolls.
+   * Set to empty string to not use wishListSource.
    */
-  readonly wishListSource?: string;
+  readonly wishListSource: string;
 }
 
 export function defaultItemSize() {
@@ -201,7 +202,7 @@ export const settings: Reducer<Settings, SettingsAction> = (
     case getType(clearWishLists): {
       return {
         ...state,
-        wishListSource: undefined
+        wishListSource: ''
       };
     }
 

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -6,6 +6,7 @@ import { defaultLanguage } from '../i18n';
 import { DtrD2ActivityModes } from '../item-review/d2-dtr-api-types';
 import { InfuseDirection } from '../infuse/infuse-direction';
 import { DtrReviewPlatform } from 'app/destinyTrackerApi/platformOptionsFetcher';
+import { clearWishLists } from 'app/wishlists/actions';
 
 export type CharacterOrder = 'mostRecent' | 'mostRecentReverse' | 'fixed' | 'custom';
 
@@ -135,7 +136,7 @@ export const initialState: Settings = {
     'https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/voltron.txt'
 };
 
-export type SettingsAction = ActionType<typeof actions>;
+type SettingsAction = ActionType<typeof actions> | ActionType<typeof clearWishLists>;
 
 export const settings: Reducer<Settings, SettingsAction> = (
   state: Settings = initialState,
@@ -193,6 +194,14 @@ export const settings: Reducer<Settings, SettingsAction> = (
         customCharacterSort: state.customCharacterSort
           .filter((id) => !order.includes(id))
           .concat(order)
+      };
+    }
+
+    // Clearing wish lists also clears the wishListSource setting
+    case getType(clearWishLists): {
+      return {
+        ...state,
+        wishListSource: undefined
       };
     }
 

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -11,7 +11,6 @@ import { itemTagList } from '../inventory/dim-item-info';
 import { Hotkey } from '../hotkeys/hotkeys';
 import { DispatchProp, connect } from 'react-redux';
 import { loadWishListAndInfoFromIndexedDB } from 'app/wishlists/reducer';
-import { fetchWishList } from 'app/wishlists/wishlist-fetch';
 import { loadVendorDropsFromIndexedDB } from 'app/vendorEngramsXyzApi/reducer';
 
 interface Props extends DispatchProp {
@@ -23,9 +22,7 @@ interface Props extends DispatchProp {
  */
 class Destiny extends React.Component<Props> {
   componentDidMount() {
-    this.props.dispatch(loadWishListAndInfoFromIndexedDB() as any).then(() => {
-      this.props.dispatch(fetchWishList() as any);
-    });
+    this.props.dispatch(loadWishListAndInfoFromIndexedDB() as any);
     this.props.dispatch(loadVendorDropsFromIndexedDB() as any);
   }
 

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -23,8 +23,9 @@ interface Props extends DispatchProp {
  */
 class Destiny extends React.Component<Props> {
   componentDidMount() {
-    this.props.dispatch(loadWishListAndInfoFromIndexedDB() as any);
-    this.props.dispatch(fetchWishList() as any);
+    this.props.dispatch(loadWishListAndInfoFromIndexedDB() as any).then(() => {
+      this.props.dispatch(fetchWishList() as any);
+    });
     this.props.dispatch(loadVendorDropsFromIndexedDB() as any);
   }
 

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -18,7 +18,7 @@ import { Subscriptions } from '../utils/rx-utils';
 import { installPrompt$ } from './app-install';
 import ExternalLink from '../dim-ui/ExternalLink';
 import SearchFilterInput from '../search/SearchFilterInput';
-import { connect } from 'react-redux';
+import { connect, DispatchProp } from 'react-redux';
 import { RootState } from 'app/store/reducers';
 import { currentAccountSelector } from 'app/accounts/reducer';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
@@ -27,7 +27,6 @@ import ReactDOM from 'react-dom';
 import Sheet from 'app/dim-ui/Sheet';
 import _ from 'lodash';
 import { isDroppingHigh, getAllVendorDrops } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
-import store from 'app/store/store';
 
 const destiny1Links = [
   {
@@ -98,7 +97,7 @@ interface StoreProps {
   vendorEngramDropActive: boolean;
 }
 
-type Props = StoreProps;
+type Props = StoreProps & DispatchProp;
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
@@ -338,7 +337,7 @@ class Header extends React.PureComponent<Props, State> {
         return;
       }
 
-      store.dispatch(getAllVendorDrops());
+      this.props.dispatch(getAllVendorDrops() as any);
     }
   };
 

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -9,6 +9,7 @@ import { set, get } from 'idb-keyval';
 import { WishListAndInfo } from './types';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/reducer';
+import { fetchWishList } from './wishlist-fetch';
 
 export const wishListsSelector = (state: RootState) => state.wishLists;
 
@@ -89,23 +90,24 @@ export function loadWishListAndInfoFromIndexedDB(): ThunkResult<Promise<void>> {
             wishListRolls: wishListAndInfo.wishListRolls
           })
         );
+      } else {
+        // transition from old to new interface
+        if (wishListAndInfo && (wishListAndInfo as any).curatedRolls) {
+          wishListAndInfo.wishListRolls = (wishListAndInfo as any).curatedRolls;
+        }
 
-        return;
+        dispatch(
+          actions.loadWishLists({
+            title: undefined,
+            description: undefined,
+            wishListRolls: [],
+            ...wishListAndInfo
+          })
+        );
       }
 
-      // transition from old to new interface
-      if (wishListAndInfo && (wishListAndInfo as any).curatedRolls) {
-        wishListAndInfo.wishListRolls = (wishListAndInfo as any).curatedRolls;
-      }
-
-      dispatch(
-        actions.loadWishLists({
-          title: undefined,
-          description: undefined,
-          wishListRolls: [],
-          ...wishListAndInfo
-        })
-      );
+      // Refresh the wish list from source if necessary
+      dispatch(fetchWishList());
     }
   };
 }

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -10,7 +10,7 @@ import { WishListAndInfo } from './types';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/reducer';
 
-const wishListsSelector = (state: RootState) => state.wishLists;
+export const wishListsSelector = (state: RootState) => state.wishLists;
 
 const wishListsByHashSelector = createSelector(wishListsSelector, (wls) =>
   _.groupBy(wls.wishListAndInfo.wishListRolls?.filter(Boolean), (r) => r.itemHash)

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -29,6 +29,8 @@ export function fetchWishList(): ThunkResult<Promise<void>> {
       wishListAndInfo.wishListRolls.length
     ) {
       dispatch(transformAndStoreWishList(wishListAndInfo));
+    } else {
+      console.log('Refreshed wishlist, but it matched the one we already have');
     }
   };
 }

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -4,6 +4,8 @@ import _ from 'lodash';
 import { showNotification } from 'app/notifications/notifications';
 import { loadWishLists } from './actions';
 import { ThunkResult } from 'app/store/reducers';
+import { WishListAndInfo } from './types';
+import { wishListsSelector } from './reducer';
 
 export function fetchWishList(): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
@@ -16,18 +18,25 @@ export function fetchWishList(): ThunkResult<Promise<void>> {
     const wishListResponse = await fetch(wishListSource);
     const wishListText = await wishListResponse.text();
 
-    dispatch(transformAndStoreWishList(wishListText, 'Fetch Wish List'));
+    const wishListAndInfo = toWishList(wishListText);
+
+    const existingWishLists = wishListsSelector(getState());
+
+    // Only update if the length changed. The wish list may actually be different - we don't do a deep check -
+    // but this is good enough to avoid re-doing the work over and over.
+    if (
+      existingWishLists?.wishListAndInfo?.wishListRolls?.length !==
+      wishListAndInfo.wishListRolls.length
+    ) {
+      dispatch(transformAndStoreWishList(wishListAndInfo));
+    }
   };
 }
 
 export function transformAndStoreWishList(
-  wishListResult: string,
-  eventName: string
+  wishListAndInfo: WishListAndInfo
 ): ThunkResult<Promise<void>> {
   return async (dispatch) => {
-    const wishListAndInfo = toWishList(wishListResult);
-    ga('send', 'event', 'Rating Options', eventName);
-
     if (wishListAndInfo.wishListRolls.length > 0) {
       dispatch(loadWishLists(wishListAndInfo));
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -923,7 +923,7 @@
     "ImportNoFile": "No file selected.",
     "ImportSuccess": "Wish list loaded with information about one roll.{{titleAndDescription}}",
     "ImportSuccess_plural": "Wish list loaded with information about {{count}} rolls.{{titleAndDescription}}",
-    "InvalidExternalSource": "Please enter a valid URL for your external wish list source.",
+    "InvalidExternalSource": "Please enter a valid URL for your external wish list source. The URL must start with https://raw.githubusercontent.com",
     "Num": "{{num, number}} rolls in your wish list",
     "UpdateExternalSource": "Update Wish List Source",
     "WishListNotes": "Wish List Notes: {{notes}}"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -922,7 +922,7 @@
     "ImportFailed": "No wish list information found.",
     "ImportNoFile": "No file selected.",
     "ImportSuccess": "Wish list loaded with information about one roll.{{titleAndDescription}}",
-    "ImportSuccess_plural": "Wish list loaded with information about {{count}} rolls.{{titleAndDescription}}",
+    "ImportSuccess_plural": "Wish list loaded with information about {{count, number}} rolls.{{titleAndDescription}}",
     "InvalidExternalSource": "Please enter a valid URL for your external wish list source. The URL must start with https://raw.githubusercontent.com",
     "Num": "{{num, number}} rolls in your wish list",
     "UpdateExternalSource": "Update Wish List Source",


### PR DESCRIPTION
1. Avoid updating wish lists if they have the same number of rolls, which is a cheap-and-dirty heuristic for "hasn't changed". It doesn't save the processing time of parsing the file, but it does save the heavy state update of saving them (and the notification).
2. Remove GA event on every wish list fetch - this basically would double our pageviews and lead to exhausting our GA event budget. New events are in place to actually measure interactions with wish lists.
3. Disallow URLs that wouldn't possibly load (they must be in our CSP).
3. Use Redux actions correctly from within components rather than grabbing the global `store` instance.
4. Make clearing `wishListSource` from settings a part of the clear wish list action, instead of dispatching two actions.
5. Wait for wish lists to be loaded from IndexedDB before refreshing, so we have something to compare against.
5. Make it possible to clear wish lists. Before, we were setting `wishListSource` to `undefined`, which wouldn't actually be saved. Setting it to empty string works.