### PR TITLE
Switch to a squiggly equals for rating calculation

### DIFF
--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -121,7 +121,7 @@ class ItemReviews extends React.Component<Props, State> {
                 <AppIcon icon={thumbsDownIcon} className="community-review--thumbs-down" />{' '}
                 {dtrRating.votes.downvotes}
               </span>
-              <span>=</span>
+              <span>≈</span>
               <span>
                 {shouldShowRating(dtrRating) ? (
                   <>


### PR DESCRIPTION
When we show it in the ratings tab - folks think 5 up and 5 down should equal zero. I'm open to other symbols but this is at least an easy way to say "Something other than straight math is happening here"