### PR TITLE
Don't send auth when it's not needed

### DIFF
--- a/src/app/bungie-api/bungie-core-api.ts
+++ b/src/app/bungie-api/bungie-core-api.ts
@@ -20,7 +20,7 @@ const GlobalAlertLevelsToToastLevels = [
  * Get global alerts (like maintenance warnings) from Bungie.
  */
 export async function getGlobalAlerts(): Promise<GlobalAlert[]> {
-  const response = await httpAdapter(bungieApiQuery(`/Platform/GlobalAlerts/`));
+  const response = await httpAdapter(bungieApiQuery(`/Platform/GlobalAlerts/`), true);
   if (response?.Response) {
     return response.Response.map((alert) => ({
       key: alert.AlertKey,

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -24,7 +24,10 @@ function delay(ms: number) {
 
 let numThrottled = 0;
 
-export async function httpAdapter(config: HttpClientConfig): Promise<ServerResponse<any>> {
+export async function httpAdapter(
+  config: HttpClientConfig,
+  skipAuth?: boolean
+): Promise<ServerResponse<any>> {
   if (numThrottled > 0) {
     // Double the wait time, starting with 1 second, until we reach 5 minutes.
     const waitTime = Math.min(5 * 60 * 1000, Math.pow(2, numThrottled) * 500);
@@ -38,8 +41,10 @@ export async function httpAdapter(config: HttpClientConfig): Promise<ServerRespo
     );
     await delay(waitTime);
   }
+
+  const whichFetch = skipAuth ? fetch : ourFetch;
   try {
-    const result = await Promise.resolve(ourFetch(buildOptions(config))).then(
+    const result = await Promise.resolve(whichFetch(buildOptions(config, skipAuth))).then(
       handleErrors,
       handleErrors
     );
@@ -64,7 +69,7 @@ export async function httpAdapter(config: HttpClientConfig): Promise<ServerRespo
   }
 }
 
-function buildOptions(config: HttpClientConfig): Request {
+export function buildOptions(config: HttpClientConfig, skipAuth?: boolean): Request {
   let url = config.url;
   if (config.params) {
     url = `${url}?${stringify(config.params)}`;
@@ -72,12 +77,16 @@ function buildOptions(config: HttpClientConfig): Request {
 
   return new Request(url, {
     method: config.method,
-    body: JSON.stringify(config.body),
-    headers: {
-      'X-API-Key': API_KEY,
-      'Content-Type': 'application/json'
-    },
-    credentials: 'include'
+    body: config.body ? JSON.stringify(config.body) : undefined,
+    headers: config.body
+      ? {
+          'X-API-Key': API_KEY,
+          'Content-Type': 'application/json'
+        }
+      : {
+          'X-API-Key': API_KEY
+        },
+    credentials: skipAuth ? 'omit' : 'include'
   });
 }
 

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -44,7 +44,7 @@ import { reportException } from '../utils/exceptions';
  * Get the information about the current manifest.
  */
 export async function getManifest(): Promise<DestinyManifest> {
-  const response = await getDestinyManifest(httpAdapter);
+  const response = await getDestinyManifest((config) => httpAdapter(config, true));
   return response.Response;
 }
 

--- a/src/app/dim-api/dim-api-helper.ts
+++ b/src/app/dim-api/dim-api-helper.ts
@@ -12,12 +12,14 @@ export async function unauthenticatedApi<T>(config: HttpClientConfig): Promise<T
   const response = await fetch(
     new Request(url, {
       method: config.method,
-      body: JSON.stringify(config.body),
-      headers: {
-        // TODO: send an API Key
-        // 'X-API-Key': DIM_API_KEY,
-        'Content-Type': 'application/json'
-      }
+      body: config.body ? JSON.stringify(config.body) : undefined,
+      headers: config.body
+        ? {
+            // TODO: send an API Key
+            // 'X-API-Key': DIM_API_KEY,
+            'Content-Type': 'application/json'
+          }
+        : undefined
     })
   );
 


### PR DESCRIPTION
This takes the auth path out of manifest and global alerts, so we can request them without having to load anything else.