### PR TITLE
Disable community ratings/reviews

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -32,8 +32,8 @@ module.exports = (env) => {
   if (process.env.WEBPACK_DEV_SERVER) {
     if (!fs.existsSync('key.pem') || !fs.existsSync('cert.pem')) {
       console.log('Generating certificate');
-      execSync('mkcert create-ca --validity 3650');
-      execSync('mkcert create-cert --validity 3650 --key key.pem --cert cert.pem');
+      execSync('mkcert create-ca --validity 825');
+      execSync('mkcert create-cert --validity 825 --key key.pem --cert cert.pem');
     }
   }
 
@@ -340,7 +340,7 @@ module.exports = (env) => {
 
         // Print debug info to console about item moves
         '$featureFlags.debugMoves': JSON.stringify(!env.release),
-        '$featureFlags.reviewsEnabled': JSON.stringify(true),
+        '$featureFlags.reviewsEnabled': JSON.stringify(false),
         // Sync data over gdrive
         '$featureFlags.gdrive': JSON.stringify(true),
         '$featureFlags.debugSync': JSON.stringify(!env.release),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Removed community reviews and ratings functionality. It may return in the future, but it was broken since Shadowkeep.
+
 ## 5.68.0 <span className="changelog-date">(2020-02-02)</span>
 
 * `wishlistnotes` autocompletes in the search filters now.

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -38,10 +38,16 @@ if ($DIM_FLAVOR !== 'dev') {
 }
 
 setupRateLimiter();
-saveReviewsToIndexedDB();
-saveWishListToIndexedDB();
+if ($featureFlags.reviewsEnabled) {
+  saveReviewsToIndexedDB();
+}
+if ($featureFlags.wishLists) {
+  saveWishListToIndexedDB();
+}
 saveAccountsToIndexedDB();
-saveVendorDropsToIndexedDB();
+if ($featureFlags.vendorEngrams) {
+  saveVendorDropsToIndexedDB();
+}
 updateCSSVariables();
 store.dispatch(loadGlobalSettings());
 

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -191,7 +191,9 @@ function StoreService(): D1StoreServiceType {
 
         _stores = stores;
 
-        store.dispatch(fetchRatings(stores));
+        if ($featureFlags.reviewsEnabled) {
+          store.dispatch(fetchRatings(stores));
+        }
 
         itemInfoService.cleanInfos(stores);
 

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -254,7 +254,9 @@ function makeD2StoresService(): D2StoreServiceType {
 
       updateVaultCounts(buckets, characters.find((c) => c.current)!, vault);
 
-      store.dispatch(fetchRatings(stores));
+      if ($featureFlags.reviewsEnabled) {
+        store.dispatch(fetchRatings(stores));
+      }
 
       itemInfoService.cleanInfos(stores);
 
@@ -551,8 +553,10 @@ function makeD2StoresService(): D2StoreServiceType {
   }
 
   function refreshRatingsData() {
-    store.dispatch(clearRatings());
-    store.dispatch(fetchRatings(_stores));
+    if ($featureFlags.reviewsEnabled) {
+      store.dispatch(clearRatings());
+      store.dispatch(fetchRatings(_stores));
+    }
   }
 }
 

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -50,7 +50,7 @@ export default function ItemPopupBody({
       component: <ItemOverview item={item} extraInfo={extraInfo} />
     }
   ];
-  if (item.reviewable) {
+  if ($featureFlags.reviewsEnabled && item.reviewable) {
     tabs.push({
       tab: ItemPopupTab.Reviews,
       title: t('MovePopup.ReviewsTab'),

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -114,7 +114,7 @@ export default function ItemPopupHeader({
         {item.taggable && <ItemTagSelector item={item} />}
       </div>
 
-      {item.reviewable && <ExpandedRating item={item} />}
+      {$featureFlags.reviewsEnabled && item.reviewable && <ExpandedRating item={item} />}
     </div>
   );
 }

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -65,12 +65,15 @@ function ItemSockets({
   onShiftClick,
   dispatch
 }: Props) {
-  useEffect(() => {
-    // TODO: want to prevent double loading these
-    if (!bestPerks.size) {
-      dispatch(getItemReviews(item));
-    }
-  }, [item, bestPerks.size, dispatch]);
+  if ($featureFlags.reviewsEnabled) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      // TODO: want to prevent double loading these
+      if (!bestPerks.size) {
+        dispatch(getItemReviews(item));
+      }
+    }, [item, bestPerks.size, dispatch]);
+  }
 
   const [socketInMenu, setSocketInMenu] = useState<DimSocket | null>(null);
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -210,15 +210,15 @@ class SettingsPage extends React.Component<Props> {
       }
     );
 
-    const menuItems = [
+    const menuItems = _.compact([
       { id: 'general', title: t('Settings.General') },
       { id: 'items', title: t('Settings.Items') },
       { id: 'inventory', title: t('Settings.Inventory') },
-      { id: 'wishlist', title: t('WishListRoll.Header') },
+      $featureFlags.wishLists ? { id: 'wishlist', title: t('WishListRoll.Header') } : undefined,
       { id: 'ratings', title: t('Settings.Ratings') },
       { id: 'storage', title: t('Storage.MenuTitle') },
       { id: 'spreadsheets', title: t('Settings.Data') }
-    ];
+    ]);
 
     return (
       <PageWithMenu>

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -22,8 +22,12 @@ interface Props extends DispatchProp {
  */
 class Destiny extends React.Component<Props> {
   componentDidMount() {
-    this.props.dispatch(loadWishListAndInfoFromIndexedDB() as any);
-    this.props.dispatch(loadVendorDropsFromIndexedDB() as any);
+    if ($featureFlags.wishLists) {
+      this.props.dispatch(loadWishListAndInfoFromIndexedDB() as any);
+    }
+    if ($featureFlags.vendorEngrams) {
+      this.props.dispatch(loadVendorDropsFromIndexedDB() as any);
+    }
   }
 
   render() {

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -196,9 +196,13 @@ class SingleVendor extends React.Component<Props, State> {
 
       this.setState({ vendorResponse });
 
-      dispatch(fetchRatingsForVendor(defs, vendorResponse));
+      if ($featureFlags.reviewsEnabled) {
+        dispatch(fetchRatingsForVendor(defs, vendorResponse));
+      }
     } else {
-      dispatch(fetchRatingsForVendorDef(defs, vendorDef));
+      if ($featureFlags.reviewsEnabled) {
+        dispatch(fetchRatingsForVendorDef(defs, vendorDef));
+      }
     }
   }
 

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -151,7 +151,7 @@ class Vendors extends React.Component<Props, State> {
       this.setState({ error });
     }
 
-    if (vendorsResponse) {
+    if ($featureFlags.reviewsEnabled && vendorsResponse) {
       dispatch(fetchRatingsForVendors(defs, vendorsResponse));
     }
   }


### PR DESCRIPTION
This disables the community ratings & reviews feature. To get this to properly disable everything, I had to add a bunch of checks for the feature flag that were missing. With this, we can reenable after we've figured out what's up with rating matching.

Note that this also disables ratings for D1. 🤷‍♂ 