### PR TITLE
fallback for undefined power levels

### DIFF
--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -120,7 +120,7 @@ const ITEM_SORT_BLACKLIST = new Set([
 const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
   typeName: compareBy((item: DimItem) => item.typeName),
   rarity: compareBy(rarity),
-  primStat: reverseComparator(compareBy((item: DimItem) => item.primStat?.value)),
+  primStat: reverseComparator(compareBy((item: DimItem) => item.primStat?.value ?? 0)),
   basePower: reverseComparator(
     compareBy((item: DimItem) => item.basePower || item.primStat?.value)
   ),


### PR DESCRIPTION
provide a fallback number for primStat value, because
![image](https://user-images.githubusercontent.com/31990469/74059246-85fe9000-499c-11ea-8fed-8f90161cc406.png)
😐