### PR TITLE
Consider both items and dupes when infusing

### DIFF
--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -168,8 +168,8 @@ class InfusionFinder extends React.Component<Props, State> {
     items = items.filter((item) => item.hash !== query.hash);
     items.sort(itemComparator);
 
-    target = target || items[0];
-    source = source || items[0];
+    target = target || dupes[0] || items[0];
+    source = source || dupes[0] || items[0];
 
     let result: DimItem | undefined;
     if (source && target && source.primStat && target.primStat) {
@@ -244,7 +244,7 @@ class InfusionFinder extends React.Component<Props, State> {
     return (
       <Sheet onClose={this.onClose} header={header} sheetClassName="infuseDialog">
         <div className="infuseSources" ref={this.itemContainer} style={{ height }}>
-          {items.length > 0 ? (
+          {items.length > 0 || dupes.length > 0 ? (
             <>
               <div className="sub-bucket">
                 {dupes.map((item) => (


### PR DESCRIPTION
When infusing, DIM separates dupe items into their own array. If there are only duplicates that are available for infusing, this makes items array to be zero length. Finally, the infuser inventory is only shown if `items.lenght > 0`.

This change makes DIM check the length of dupes in addition to items array. This PR also changes infuser to prefer dupes over non-dupes. Reasoning for this is the glimmer only cost when infusing legendary 2.0 items.

Fixes DestinyItemManager/DIM#4893