### PR TITLE
Bugfix/loadout drawer doesnt optimistically close

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -540,6 +540,8 @@
     "Before": "Before '{{name}}'",
     "ChangeName": "Change name",
     "ChooseItem": "Add {{name}}",
+    "ClashingTitle": "Clashing loadout",
+    "ClashingDescription": "The loadout {{loadoutName}} clashes with a previous one and could not be saved. Click this to open the loadout drawer.",
     "Classified": "Some of your items are classified, and cannot be included in the max power calculation.",
     "ClearSpace": "Move other items away",
     "ConfirmDelete": "Are you sure you want to delete '{{name}}'?",

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -418,8 +418,17 @@ class LoadoutDrawer extends React.Component<Props, State> {
 
   private handleLoadOutSaveResult = (clashingLoadout?: Loadout) => {
     if (clashingLoadout) {
-      this.setState({ show: true, clashingLoadout: copy(clashingLoadout) });
-      loadoutDialogOpen = true;
+      showNotification({
+        type: 'error',
+        title: t('Loadouts.ClashingTitle'),
+        body: t('Loadouts.ClashingDescription', {
+          loadoutName: clashingLoadout.name
+        }),
+        onClick: () => {
+          this.setState({ show: true, clashingLoadout: copy(clashingLoadout) });
+          loadoutDialogOpen = true;
+        }
+      });
     }
   };
 

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -410,16 +410,16 @@ class LoadoutDrawer extends React.Component<Props, State> {
       return;
     }
 
+    this.close();
     saveLoadout(loadout)
       .then(this.handleLoadOutSaveResult)
       .catch((e) => this.handleLoadoutError(e, loadout.name));
   };
 
-  private handleLoadOutSaveResult = (clashingLoadout: Loadout | undefined) => {
+  private handleLoadOutSaveResult = (clashingLoadout?: Loadout) => {
     if (clashingLoadout) {
-      this.setState({ clashingLoadout: copy(clashingLoadout) });
-    } else {
-      this.close();
+      this.setState({ show: true, clashingLoadout: copy(clashingLoadout) });
+      loadoutDialogOpen = true;
     }
   };
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -538,6 +538,8 @@
     "Before": "Before '{{name}}'",
     "ChangeName": "Change name",
     "ChooseItem": "Add {{name}}",
+    "ClashingDescription": "The loadout {{loadoutName}} clashes with a previous one and could not be saved. Click this to open the loadout drawer.",
+    "ClashingTitle": "Clashing loadout",
     "Classified": "Some of your items are classified, and cannot be included in the max power calculation.",
     "ClearSpace": "Move other items away",
     "ConfirmDelete": "Are you sure you want to delete '{{name}}'?",


### PR DESCRIPTION
Made the loadout drawer close optimistically. If there a clash a notification is displayed which will reopen the drawer to deal with the clashing loadout as before.

Fixes #4701 

![loadout-drawer-faster](https://user-images.githubusercontent.com/7344652/74576975-4873b580-4fe1-11ea-808d-6c341bec3981.gif)


