### PR TITLE
Updating SearchInputFilter to sort 'armor' above 'armor2.0'

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Removed community reviews and ratings functionality. It may return in the future, but it was broken since Shadowkeep.
+* Updated Search suggestions to sorth "armor" above "armor2.0"
 
 ## 5.69.0 <span className="changelog-date">(2020-02-09)</span>
 

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -137,8 +137,8 @@ export default class SearchFilterInput extends React.Component<Props, State> {
             <AppIcon icon={helpIcon} />
           </span>
         ) : (
-          children
-        )}
+            children
+          )}
         {(liveQuery.length > 0 || alwaysShowClearButton) && (
           <span className="filter-help">
             <a onClick={this.clearFilter} title={t('Header.Clear')}>
@@ -223,6 +223,8 @@ export default class SearchFilterInput extends React.Component<Props, State> {
                 (word: string) => !word.includes('maxpower'),
                 // prioritize things we might be typing out from their beginning
                 (word: string) => word.indexOf(term.toLowerCase()) === 0,
+                // prioritize primary type 'armor' over qualifier 'armor2.0'
+                (word: string) => !word.endsWith('armor'),
                 // prioritize is: & not: because they can take up at most 2 slots at the top
                 (word: string) => word.startsWith('is:') || word.startsWith('not:'),
                 // push math operators to the front


### PR DESCRIPTION
Fixes #4877 

- Updating SearchInputFilter sorting to prioritize 'is:armor' over 'is:armor2.0'
- Updating CHANGELOG.md to reflect this

![armorsorting](https://user-images.githubusercontent.com/6667803/74590498-e0d06100-5006-11ea-8952-1a74e6d35832.PNG)
