### PR TITLE
more varied search suggestions & incremental autocomplete

### DIFF
--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -213,14 +213,18 @@ export default class SearchFilterInput extends React.Component<Props, State> {
           match: /\b([\w:"']{3,})$/i,
           search(term, callback) {
             if (term) {
+              console.log(this.words);
               let words = this.words.filter((word: string) => word.includes(term.toLowerCase()));
               // to do: this could be extremely cool if we got it to suggest
               // a variety of options by specifically opposite-of-sorting it
               words = _.sortBy(words, [
+                // sort search suggestions (ending with ':') to the front
+                (word: string) => !word.endsWith(':'),
+                (word: string) => word.split(':').length,
                 // tags are UGC and therefore important
                 (word: string) => !word.startsWith('tag:'),
-                // push maxpower to top because maxstat overwhelms it
-                (word: string) => !word.includes('maxpower'),
+                // push maxpower to top because maxstat overwhelms it (maybe not needed)
+                // (word: string) => !word.includes('maxpower'),
                 // prioritize things we might be typing out from their beginning
                 (word: string) => word.indexOf(term.toLowerCase()) === 0,
                 // prioritize primary type 'armor' over qualifier 'armor2.0'

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -317,7 +317,7 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     ...Object.keys(seasonTags)
       .reverse()
       .map((tag) => `season:${tag}`),
-    // keywords for seaqsonal mod slots
+    // keywords for seasonal mod slots
     ...specialtyModSlotFilterNames
       .concat(['any', 'none'])
       .map((modSlotName) => `modslot:${modSlotName}`),
@@ -341,6 +341,19 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
     // all the free text searches that support quotes
     ...['notes:', 'perk:', 'perkname:', 'name:', 'description:']
   ];
+
+  // create suggestion stubs for filter names
+  const keywordStubs = keywords.flatMap((keyword) => {
+    const keywordSegments = keyword //   'basestat:mobility:<='
+      .split(':') //                   [ 'basestat' , 'mobility' , '<=']
+      .slice(0, -1); //                [ 'basestat' , 'mobility' ]
+    const stubs: string[] = [];
+    for (let i = 1; i <= keywordSegments.length; i++) {
+      stubs.push(keywordSegments.slice(0, i).join(':') + ':');
+    }
+    return stubs; //                   [ 'basestat:' , 'basestat:mobility:' ]
+  });
+  keywords.push(...new Set(keywordStubs));
 
   // Build an inverse mapping of keyword to function name
   const keywordToFilter: { [key: string]: string } = {};


### PR DESCRIPTION
improving the search experience by pushing interesting results to the top
this way typing `stat` shows there's other filters, instead of showing a bunch of `stat:x` variations.

this also allows you to complete a partial suggestion, and get more options for how to complete that suggestion

![935Vrc](https://user-images.githubusercontent.com/31990469/75021265-f1d70300-5448-11ea-9144-a61949ab8311.gif)
