### PR TITLE
Improvements to farming mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Changing language now properly updates the UI language and prompts to reload.
 * Update search filters to include 'is:hasornament' and 'is:ornamented'
 * Filter autocomplete should now work in increments, and suggest a wider variety of filters
+* Farming mode now uses the same logic as regular item moves to choose your lowest-value item to send to the vault when a bucket is full. Favorite/keep your items and they'll stay put!
+* Removed the option to move tokens to the vault in farming mode.
 
 ## 5.70.0 <span className="changelog-date">(2020-02-16)</span>
 

--- a/src/app/farming/D1Farming.tsx
+++ b/src/app/farming/D1Farming.tsx
@@ -3,12 +3,12 @@ import { DimStore } from '../inventory/store-types';
 import { t } from 'app/i18next-t';
 import { RootState } from '../store/reducers';
 import { connect } from 'react-redux';
-import { setFarmingSetting } from '../settings/actions';
 import _ from 'lodash';
 import { farmingStoreSelector } from './reducer';
 import './farming.scss';
 import { D1FarmingService } from './farming.service';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
+import { setSetting } from '../settings/actions';
 
 interface StoreProps {
   makeRoomForItems: boolean;
@@ -18,70 +18,67 @@ interface StoreProps {
 function mapStateToProps() {
   const storeSelector = farmingStoreSelector();
   return (state: RootState): StoreProps => ({
-    makeRoomForItems: state.settings.farming.makeRoomForItems,
+    makeRoomForItems: state.settings.farmingMakeRoomForItems,
     store: storeSelector(state)
   });
 }
 
 const mapDispatchToProps = {
-  setFarmingSetting
+  setSetting
 };
 type DispatchProps = typeof mapDispatchToProps;
 
 type Props = StoreProps & DispatchProps;
 
-class D1Farming extends React.Component<Props> {
-  render() {
-    const { store, makeRoomForItems } = this.props;
-    const i18nData = {
-      store: store?.name,
-      context: store?.genderName
-    };
+function D1Farming({ store, makeRoomForItems, setSetting }: Props) {
+  const i18nData = {
+    store: store?.name,
+    context: store?.genderName
+  };
 
-    return (
-      <TransitionGroup component={null}>
-        {store && (
-          <CSSTransition clsx="farming" timeout={{ enter: 500, exit: 500 }}>
-            <div id="item-farming">
-              <div>
-                <p>
-                  {makeRoomForItems
-                    ? t('FarmingMode.Desc', i18nData)
-                    : t('FarmingMode.MakeRoom.Desc', i18nData)}
-                  {/*
+  const makeRoomForItemsChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.checked;
+    setSetting('farmingMakeRoomForItems', value);
+  };
+
+  return (
+    <TransitionGroup component={null}>
+      {store && (
+        <CSSTransition clsx="farming" timeout={{ enter: 500, exit: 500 }}>
+          <div id="item-farming">
+            <div>
+              <p>
+                {makeRoomForItems
+                  ? t('FarmingMode.Desc', i18nData)
+                  : t('FarmingMode.MakeRoom.Desc', i18nData)}
+                {/*
                     t('FarmingMode.Desc_male')
                     t('FarmingMode.Desc_female')
                     t('FarmingMode.MakeRoom.Desc_male')
                     t('FarmingMode.MakeRoom.Desc_female')
                   */}
-                </p>
-                <p>
-                  <input
-                    name="make-room-for-items"
-                    type="checkbox"
-                    checked={makeRoomForItems}
-                    onChange={this.makeRoomForItemsChanged}
-                  />
-                  <label htmlFor="make-room-for-items" title={t('FarmingMode.MakeRoom.Tooltip')}>
-                    {t('FarmingMode.MakeRoom.MakeRoom')}
-                  </label>
-                </p>
-              </div>
-
-              <div>
-                <button onClick={D1FarmingService.stop}>{t('FarmingMode.Stop')}</button>
-              </div>
+              </p>
+              <p>
+                <input
+                  name="make-room-for-items"
+                  type="checkbox"
+                  checked={makeRoomForItems}
+                  onChange={makeRoomForItemsChanged}
+                />
+                <label htmlFor="make-room-for-items" title={t('FarmingMode.MakeRoom.Tooltip')}>
+                  {t('FarmingMode.MakeRoom.MakeRoom')}
+                </label>
+              </p>
             </div>
-          </CSSTransition>
-        )}
-      </TransitionGroup>
-    );
-  }
 
-  private makeRoomForItemsChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.currentTarget.checked;
-    this.props.setFarmingSetting('makeRoomForItems', value);
-  };
+            <div>
+              <button onClick={D1FarmingService.stop}>{t('FarmingMode.Stop')}</button>
+            </div>
+          </div>
+        </CSSTransition>
+      )}
+    </TransitionGroup>
+  );
 }
 
 export default connect<StoreProps, DispatchProps>(mapStateToProps, mapDispatchToProps)(D1Farming);

--- a/src/app/farming/D2Farming.tsx
+++ b/src/app/farming/D2Farming.tsx
@@ -3,7 +3,6 @@ import { DimStore } from '../inventory/store-types';
 import { t } from 'app/i18next-t';
 import { RootState } from '../store/reducers';
 import { connect } from 'react-redux';
-import { setFarmingSetting } from '../settings/actions';
 import _ from 'lodash';
 import { farmingStoreSelector } from './reducer';
 import { D2FarmingService } from './d2farming.service';
@@ -11,70 +10,45 @@ import './farming.scss';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
 interface StoreProps {
-  moveTokens: boolean;
   store?: DimStore;
 }
 
 function mapStateToProps() {
   const storeSelector = farmingStoreSelector();
   return (state: RootState): StoreProps => ({
-    moveTokens: state.settings.farming.moveTokens,
     store: storeSelector(state)
   });
 }
 
-const mapDispatchToProps = {
-  setFarmingSetting
-};
-type DispatchProps = typeof mapDispatchToProps;
+type Props = StoreProps;
 
-type Props = StoreProps & DispatchProps;
-
-class D2Farming extends React.Component<Props> {
-  render() {
-    const { store, moveTokens } = this.props;
-
-    return (
-      <TransitionGroup component={null}>
-        {store && (
-          <CSSTransition clsx="farming" timeout={{ enter: 500, exit: 500 }}>
-            <div id="item-farming" className="d2-farming">
-              <span>
-                <p>
-                  {t('FarmingMode.D2Desc', {
-                    store: store.name,
-                    context: store.genderName
-                  })}
-                  {/*
+function D2Farming({ store }: Props) {
+  return (
+    <TransitionGroup component={null}>
+      {store && (
+        <CSSTransition clsx="farming" timeout={{ enter: 500, exit: 500 }}>
+          <div id="item-farming" className="d2-farming">
+            <span>
+              <p>
+                {t('FarmingMode.D2Desc', {
+                  store: store.name,
+                  context: store.genderName
+                })}
+                {/*
                     t('FarmingMode.D2Desc_male')
                     t('FarmingMode.D2Desc_female')
                   */}
-                </p>
-                <p>
-                  <input
-                    name="move-tokens"
-                    type="checkbox"
-                    checked={moveTokens}
-                    onChange={this.toggleMoveTokens}
-                  />
-                  <label htmlFor="move-tokens">{t('FarmingMode.MoveTokens')}</label>
-                </p>
-              </span>
+              </p>
+            </span>
 
-              <span>
-                <button onClick={D2FarmingService.stop}>{t('FarmingMode.Stop')}</button>
-              </span>
-            </div>
-          </CSSTransition>
-        )}
-      </TransitionGroup>
-    );
-  }
-
-  private toggleMoveTokens = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.currentTarget.checked;
-    this.props.setFarmingSetting('moveTokens', value);
-  };
+            <span>
+              <button onClick={D2FarmingService.stop}>{t('FarmingMode.Stop')}</button>
+            </span>
+          </div>
+        </CSSTransition>
+      )}
+    </TransitionGroup>
+  );
 }
 
-export default connect<StoreProps, DispatchProps>(mapStateToProps, mapDispatchToProps)(D2Farming);
+export default connect<StoreProps>(mapStateToProps)(D2Farming);

--- a/src/app/farming/d2farming.service.ts
+++ b/src/app/farming/d2farming.service.ts
@@ -1,24 +1,15 @@
 import _ from 'lodash';
 import { getBuckets } from '../destiny2/d2-buckets';
 import { DestinyAccount } from '../accounts/destiny-account';
-import { settings } from '../settings/settings';
 import { D2Store } from '../inventory/store-types';
-import { DimItem } from '../inventory/item-types';
 import { BucketCategory } from 'bungie-api-ts/destiny2';
 import { D2StoresService } from '../inventory/d2-stores';
 import { refresh } from '../shell/refresh';
 import { Subscription, from } from 'rxjs';
 import rxStore from '../store/store';
 import * as actions from './actions';
-import { moveItemsToVault } from './farming.service';
+import { makeRoomForItemsInBuckets } from './farming.service';
 import { filter, map, tap, exhaustMap } from 'rxjs/operators';
-import { sortMoveAsideCandidatesForStore } from 'app/inventory/item-move-service';
-
-function getMakeRoomBuckets() {
-  return getBuckets().then((buckets) =>
-    Object.values(buckets.byHash).filter((b) => b.category === BucketCategory.Equippable && b.type)
-  );
-}
 
 /**
  * A service for "farming" items by moving them continuously off a character,
@@ -51,7 +42,7 @@ class D2Farming {
         }),
         filter(Boolean),
         tap((store: D2Store) => rxStore.dispatch(actions.start(store.id))),
-        exhaustMap((store: D2Store) => from(makeRoomForItems(store, settings.farming.moveTokens)))
+        exhaustMap((store: D2Store) => from(makeRoomForItems(store)))
       )
       .subscribe();
     this.subscription.add(() => rxStore.dispatch(actions.stop()));
@@ -94,43 +85,10 @@ export const D2FarmingService = new D2Farming();
 
 // Ensure that there's one open space in each category that could
 // hold an item, so they don't go to the postmaster.
-async function makeRoomForItems(store: D2Store, moveTokens: boolean) {
-  const makeRoomBuckets = await getMakeRoomBuckets();
-
-  console.log('Making room');
-
-  const itemInfos = rxStore.getState().inventory.itemInfos;
-  // If any category is full, we'll move one aside
-  let itemsToMove: DimItem[] = [];
-  makeRoomBuckets.forEach((makeRoomBucket) => {
-    const items = store.buckets[makeRoomBucket.id];
-    if (items.length > 0 && items.length >= makeRoomBucket.capacity) {
-      const moveAsideCandidates = items.filter((i) => !i.equipped && !i.notransfer);
-      const prioritizedMoveAsideCandidates = sortMoveAsideCandidatesForStore(
-        moveAsideCandidates,
-        store,
-        D2StoresService.getVault()!,
-        itemInfos
-      );
-      // We'll move the first one to the vault
-      const itemToMove = prioritizedMoveAsideCandidates[0];
-      if (itemToMove) {
-        itemsToMove.push(itemToMove);
-      }
-    }
-  });
-
-  if (moveTokens) {
-    itemsToMove = itemsToMove.concat(
-      store.items.filter(
-        (i) => i.isDestiny2() && i.itemCategoryHashes.includes(2088636411) && !i.notransfer
-      )
-    );
-  }
-
-  if (itemsToMove.length === 0) {
-    return;
-  }
-
-  return moveItemsToVault(store, itemsToMove, makeRoomBuckets, D2StoresService);
+async function makeRoomForItems(store: D2Store) {
+  const buckets = await getBuckets();
+  const makeRoomBuckets = Object.values(buckets.byHash).filter(
+    (b) => b.category === BucketCategory.Equippable && b.type
+  );
+  return makeRoomForItemsInBuckets(store, makeRoomBuckets, D2StoresService);
 }

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -149,8 +149,8 @@ export async function makeRoomForItemsInBuckets(
   // If any category is full, we'll move one aside
   const itemsToMove: DimItem[] = [];
   const itemInfos = rxStore.getState().inventory.itemInfos;
-  makeRoomTypes.forEach((makeRoomType) => {
-    const items = store.buckets[makeRoomType];
+  makeRoomBuckets.forEach((bucket) => {
+    const items = store.buckets[bucket.id];
     if (items.length > 0 && items.length >= store.capacityForItem(items[0])) {
       const moveAsideCandidates = items.filter((i) => !i.equipped && !i.notransfer);
       const prioritizedMoveAsideCandidates = sortMoveAsideCandidatesForStore(

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -112,7 +112,7 @@ export const D1FarmingService = new D1Farming();
 
 async function farm(store: D1Store) {
   await farmItems(store);
-  if (settings.farming.makeRoomForItems) {
+  if (settings.farmingMakeRoomForItems) {
     await makeRoomForItems(store);
   }
 }

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -134,6 +134,18 @@ async function farmItems(store: D1Store) {
 // Ensure that there's one open space in each category that could
 // hold an item, so they don't go to the postmaster.
 async function makeRoomForItems(store: D1Store) {
+  const buckets = await getBuckets();
+  const makeRoomBuckets = makeRoomTypes.map((type) => buckets.byId[type]);
+  makeRoomForItemsInBuckets(store, makeRoomBuckets, D1StoresService);
+}
+
+// Ensure that there's one open space in each category that could
+// hold an item, so they don't go to the postmaster.
+export async function makeRoomForItemsInBuckets(
+  store: DimStore,
+  makeRoomBuckets: InventoryBucket[],
+  storeService: StoreServiceType
+) {
   // If any category is full, we'll move one aside
   const itemsToMove: DimItem[] = [];
   const itemInfos = rxStore.getState().inventory.itemInfos;
@@ -144,7 +156,7 @@ async function makeRoomForItems(store: D1Store) {
       const prioritizedMoveAsideCandidates = sortMoveAsideCandidatesForStore(
         moveAsideCandidates,
         store,
-        D1StoresService.getVault()!,
+        storeService.getVault()!,
         itemInfos
       );
       // We'll move the first one to the vault
@@ -159,12 +171,10 @@ async function makeRoomForItems(store: D1Store) {
     return;
   }
 
-  const buckets = await getBuckets();
-  const makeRoomBuckets = makeRoomTypes.map((type) => buckets.byId[type]);
-  return moveItemsToVault(store, itemsToMove, makeRoomBuckets, D1StoresService);
+  return moveItemsToVault(store, itemsToMove, makeRoomBuckets, storeService);
 }
 
-export async function moveItemsToVault(
+async function moveItemsToVault(
   store: DimStore,
   items: DimItem[],
   makeRoomBuckets: InventoryBucket[],

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -21,7 +21,12 @@ import { D2StoresService } from './d2-stores';
 import { t } from 'app/i18next-t';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { getTag, vaultDisplacePriority, characterDisplacePriority } from './dim-item-info';
+import {
+  getTag,
+  vaultDisplacePriority,
+  characterDisplacePriority,
+  DimItemInfo
+} from './dim-item-info';
 import reduxStore from '../store/store';
 
 /**
@@ -584,56 +589,7 @@ function ItemService(): ItemServiceType {
       };
     }
 
-    const tierValue = {
-      Common: 0,
-      Uncommon: 1,
-      Rare: 2,
-      Legendary: 4,
-      Exotic: 3
-    };
-
     const itemInfos = reduxStore.getState().inventory.itemInfos;
-
-    /** Come up with a prioritized list of items to move assuming they'll end up in targetStore. */
-    const sortCandidatesForStore = (targetStore: DimStore) => {
-      // A sort for items to use for ranking *which item to move*
-      // aside. The highest ranked items are the most likely to be moved.
-      // Note that this is reversed, so higher values (including true over false)
-      // come first in the list.
-      const itemValueComparator: (a: DimItem, b: DimItem) => number = reverseComparator(
-        chainComparator(
-          // Try our hardest never to unequip something
-          compareBy((i) => !i.equipped),
-          // prefer same type over everything
-          compareBy((i) => i.type === item.type),
-          // or at least same category
-          compareBy((i) => i.bucket.sort === item.bucket.sort),
-          // Always prefer keeping something that was manually moved where it is
-          compareBy((i) => -i.lastManuallyMoved),
-          // Engrams prefer to be in the vault, so not-engram is larger than engram
-          compareBy((i) => (store.isVault ? !i.isEngram : i.isEngram)),
-          // Prefer moving things the target store can use
-          compareBy((i) => !targetStore.isVault && i.canBeEquippedBy(targetStore)),
-          // Prefer moving things this character can't use
-          compareBy((i) => !store.isVault && !i.canBeEquippedBy(store)),
-          // Tagged items sort by orders defined in dim-item-info
-          compareBy((i) => {
-            const tag = getTag(i, itemInfos);
-            return -(store.isVault ? vaultDisplacePriority : characterDisplacePriority).indexOf(
-              tag || 'none'
-            );
-          }),
-          // Prefer moving lower-tier into the vault and higher tier out
-          compareBy((i) => (store.isVault ? tierValue[i.tier] : -tierValue[i.tier])),
-          // Prefer keeping higher-stat items on characters
-          compareBy((i) => i.primStat && (store.isVault ? i.primStat.value : -i.primStat.value))
-        )
-      );
-
-      // Sort all candidates
-      moveAsideCandidates.sort(itemValueComparator);
-      return moveAsideCandidates;
-    };
 
     // A cached version of the space-left function
     const cachedSpaceLeft = _.memoize(
@@ -664,7 +620,13 @@ function ItemService(): ItemServiceType {
       otherStores.filter((s) => !s.isVault),
       (s) => s.lastPlayed.getTime()
     ).find((targetStore) =>
-      sortCandidatesForStore(targetStore).find((candidate) => {
+      sortMoveAsideCandidatesForStore(
+        moveAsideCandidates,
+        store,
+        targetStore,
+        itemInfos,
+        item
+      ).find((candidate) => {
         const spaceLeft = cachedSpaceLeft(targetStore, candidate);
 
         if (store.isVault) {
@@ -994,4 +956,65 @@ function ItemService(): ItemServiceType {
     }
     return item;
   }
+}
+
+/**
+ * Sort a list of items to determine a prioritized order for which should be moved from fromStore
+ * assuming they'll end up in targetStore.
+ */
+export function sortMoveAsideCandidatesForStore(
+  moveAsideCandidates: DimItem[],
+  fromStore: DimStore,
+  targetStore: DimStore,
+  itemInfos: {
+    [key: string]: DimItemInfo;
+  },
+  /** The item we're trying to make space for. May be missing. */
+  item?: DimItem
+) {
+  const tierValue = {
+    Common: 0,
+    Uncommon: 1,
+    Rare: 2,
+    Legendary: 4,
+    Exotic: 3
+  };
+
+  // A sort for items to use for ranking *which item to move*
+  // aside. The highest ranked items are the most likely to be moved.
+  // Note that this is reversed, so higher values (including true over false)
+  // come first in the list.
+  const itemValueComparator: (a: DimItem, b: DimItem) => number = reverseComparator(
+    chainComparator(
+      // Try our hardest never to unequip something
+      compareBy((i) => !i.equipped),
+      // prefer same type over everything
+      compareBy((i) => item && i.type === item.type),
+      // or at least same category
+      compareBy((i) => item && i.bucket.sort === item.bucket.sort),
+      // Always prefer keeping something that was manually moved where it is
+      compareBy((i) => -i.lastManuallyMoved),
+      // Engrams prefer to be in the vault, so not-engram is larger than engram
+      compareBy((i) => (fromStore.isVault ? !i.isEngram : i.isEngram)),
+      // Prefer moving things the target store can use
+      compareBy((i) => !targetStore.isVault && i.canBeEquippedBy(targetStore)),
+      // Prefer moving things this character can't use
+      compareBy((i) => !fromStore.isVault && !i.canBeEquippedBy(fromStore)),
+      // Tagged items sort by orders defined in dim-item-info
+      compareBy((i) => {
+        const tag = getTag(i, itemInfos);
+        return -(fromStore.isVault ? vaultDisplacePriority : characterDisplacePriority).indexOf(
+          tag || 'none'
+        );
+      }),
+      // Prefer moving lower-tier into the vault and higher tier out
+      compareBy((i) => (fromStore.isVault ? tierValue[i.tier] : -tierValue[i.tier])),
+      // Prefer keeping higher-stat items on characters
+      compareBy((i) => i.primStat && (fromStore.isVault ? i.primStat.value : -i.primStat.value))
+    )
+  );
+
+  // Sort all candidates
+  moveAsideCandidates.sort(itemValueComparator);
+  return moveAsideCandidates;
 }

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -10,12 +10,6 @@ export const setSetting = createAction('settings/SET', (property: keyof Settings
   value
 }))();
 
-/** This one seems a bit like cheating, but it lets us set a specific property of the farming settings. */
-export const setFarmingSetting = createAction(
-  'settings/SET_FARMING',
-  (property: keyof Settings['farming'], value: any) => ({ property, value })
-)();
-
 /** Update a collapsible section */
 export const toggleCollapsedSection = createAction('settings/COLLAPSIBLE')<string>();
 

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -43,11 +43,8 @@ export interface Settings {
   readonly completedRecordsHidden: boolean;
   /** Show triumphs the manifest recommends be redacted */
   readonly redactedRecordsRevealed: boolean;
-  /** What settings for farming mode */
-  readonly farming: {
-    /** Whether to keep one slot per item type open */
-    readonly makeRoomForItems: boolean;
-  };
+  /** Whether to keep one slot per item type open (D1 only) */
+  readonly farmingMakeRoomForItems: boolean;
   /** Destiny 2 platform selection for ratings + reviews */
   readonly reviewsPlatformSelectionV2: DtrReviewPlatform;
   /** Destiny 2 play mode selection for ratings + reviews - see DestinyActivityModeType for values */
@@ -115,12 +112,8 @@ export const initialState: Settings = {
   completedRecordsHidden: false,
   // Hide show triumphs the manifest recommends be redacted
   redactedRecordsRevealed: false,
-
-  // What settings for farming mode
-  farming: {
-    // Whether to keep one slot per item type open
-    makeRoomForItems: true
-  },
+  // Whether to keep one slot per item type open (D1 only)
+  farmingMakeRoomForItems: true,
   // Destiny 2 platform selection for ratings + reviews
   reviewsPlatformSelectionV2: 0,
   // Destiny 2 play mode selection for ratings + reviews - see DestinyActivityModeType for values
@@ -150,11 +143,7 @@ export const settings: Reducer<Settings, SettingsAction> = (
     case getType(actions.loaded):
       return {
         ...state,
-        ...action.payload,
-        farming: {
-          ...state.farming,
-          ...action.payload.farming
-        }
+        ...action.payload
       };
 
     case getType(actions.toggleCollapsedSection):
@@ -171,19 +160,6 @@ export const settings: Reducer<Settings, SettingsAction> = (
         return {
           ...state,
           [action.payload.property]: action.payload.value
-        };
-      } else {
-        return state;
-      }
-
-    case getType(actions.setFarmingSetting):
-      if (state.farming[action.payload.property] !== action.payload.value) {
-        return {
-          ...state,
-          farming: {
-            ...state.farming,
-            [action.payload.property]: action.payload.value
-          }
         };
       } else {
         return state;

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -47,7 +47,6 @@ export interface Settings {
   readonly farming: {
     /** Whether to keep one slot per item type open */
     readonly makeRoomForItems: boolean;
-    readonly moveTokens: boolean;
   };
   /** Destiny 2 platform selection for ratings + reviews */
   readonly reviewsPlatformSelectionV2: DtrReviewPlatform;
@@ -120,8 +119,7 @@ export const initialState: Settings = {
   // What settings for farming mode
   farming: {
     // Whether to keep one slot per item type open
-    makeRoomForItems: true,
-    moveTokens: false
+    makeRoomForItems: true
   },
   // Destiny 2 platform selection for ratings + reviews
   reviewsPlatformSelectionV2: 0,


### PR DESCRIPTION
I realized we weren't using our smart move prioritization logic for farming mode!

This makes a few improvements:

1. Use the same logic as item moves for choosing the "lowest value" item to move aside when making space for farming.
2. Remove the option to move reputation tokens when farming.
3. Flatten the farming settings so they don't have to be specially handled.