### PR TITLE
Work around Bungie.net lock state bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Removed "Gather Reputation Tokens" feature. You can do the same thing with an "is:reptoken" search.
 * Changing language now properly updates the UI language and prompts to reload.
 * Update search filters to include 'is:hasornament' and 'is:ornamented'
-* Filter autocomplete should now work in increments, and suggest a wider variety of filters
+* Filter autocomplete should now work in increments, and suggest a wider variety of filters.
+* Worked around a long-standing Bungie.net bug where items would change lock state when moved. One caveat is that DIM will always preserve the lock state as it sees it, so if you've locked/unlocked in game and haven't refreshed DIM, it may revert your lock.
 
 ## 5.70.0 <span className="changelog-date">(2020-02-16)</span>
 

--- a/src/app/item-popup/LockButton.tsx
+++ b/src/app/item-popup/LockButton.tsx
@@ -4,8 +4,7 @@ import { t } from 'app/i18next-t';
 import styles from './LockButton.m.scss';
 import clsx from 'clsx';
 import { lockIcon, unlockedIcon, starIcon, starOutlineIcon, AppIcon } from '../shell/icons';
-import { setItemState as d1SetItemState } from '../bungie-api/destiny1-api';
-import { setLockState as d2SetLockState } from '../bungie-api/destiny2-api';
+import { setItemLockState } from 'app/inventory/item-move-service';
 
 interface Props {
   item: DimItem;
@@ -57,11 +56,6 @@ export default class LockButton extends React.Component<Props, State> {
       return;
     }
 
-    const store =
-      item.owner === 'vault'
-        ? item.getStoresService().getActiveStore()!
-        : item.getStoresService().getStore(item.owner)!;
-
     this.setState({ locking: true });
 
     let state = false;
@@ -72,17 +66,11 @@ export default class LockButton extends React.Component<Props, State> {
     }
 
     try {
-      if (item.isDestiny2()) {
-        await d2SetLockState(store, item, state);
-        // TODO: this doesn't work in React land
+      await setItemLockState(item, state, type);
+      if (type === 'lock') {
         item.locked = state;
-      } else if (item.isDestiny1()) {
-        await d1SetItemState(item, store, state, type);
-        if (type === 'lock') {
-          item.locked = state;
-        } else if (type === 'track') {
-          item.tracked = state;
-        }
+      } else if (type === 'track') {
+        item.tracked = state;
       }
     } finally {
       this.setState({ locking: false });

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -23,8 +23,6 @@ import { DtrRating } from 'app/item-review/dtr-api-types';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import { faCaretUp, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import { loadingTracker } from 'app/shell/loading-tracker';
-import { setItemState as d1SetItemState } from '../bungie-api/destiny1-api';
-import { setLockState as d2SetLockState } from '../bungie-api/destiny2-api';
 import { showNotification } from 'app/notifications/notifications';
 import { t } from 'app/i18next-t';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
@@ -49,6 +47,7 @@ import { LoadoutClass } from 'app/loadout/loadout-types';
 import { getColumns } from './Columns';
 import { ratingsSelector } from 'app/item-review/reducer';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { setItemLockState } from 'app/inventory/item-move-service';
 
 // TODO maybe move this to utils?
 function isDefined<T>(val: T | undefined): val is T {
@@ -234,16 +233,7 @@ function ItemTable({
     const state = selectedTag === 'lock';
     try {
       for (const item of items) {
-        const store =
-          item.owner === 'vault'
-            ? item.getStoresService().getActiveStore()!
-            : item.getStoresService().getStore(item.owner)!;
-
-        if (item.isDestiny2()) {
-          await d2SetLockState(store, item, state);
-        } else if (item.isDestiny1()) {
-          await d1SetItemState(item, store, state, 'lock');
-        }
+        await setItemLockState(item, state);
 
         // TODO: Gotta do this differently in react land
         item.locked = state;

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -10,8 +10,6 @@ import _ from 'lodash';
 import './search-filter.scss';
 import { destinyVersionSelector, currentAccountSelector } from '../accounts/reducer';
 import { SearchConfig, searchFilterSelector, searchConfigSelector } from './search-filters';
-import { setItemState as d1SetItemState } from '../bungie-api/destiny1-api';
-import { setLockState as d2SetLockState } from '../bungie-api/destiny2-api';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { D2StoresService } from '../inventory/d2-stores';
 import { D1StoresService } from '../inventory/d1-stores';
@@ -23,6 +21,7 @@ import { showNotification } from '../notifications/notifications';
 import { CompareService } from '../compare/compare.service';
 import { bulkTagItems } from 'app/inventory/tag-items';
 import { searchQueryVersionSelector, querySelector } from 'app/shell/reducer';
+import { setItemLockState } from 'app/inventory/item-move-service';
 
 // these exist in comments so i18n       t('Tags.TagItems') t('Tags.ClearTag')
 // doesn't delete the translations       t('Tags.LockAll') t('Tags.UnlockAll')
@@ -92,16 +91,7 @@ class SearchFilter extends React.Component<Props, State> {
           .filter((i) => i.lockable && this.props.searchFilter(i));
         try {
           for (const item of lockables) {
-            const store =
-              item.owner === 'vault'
-                ? item.getStoresService().getActiveStore()!
-                : item.getStoresService().getStore(item.owner)!;
-
-            if (item.isDestiny2()) {
-              await d2SetLockState(store, item, state);
-            } else if (item.isDestiny1()) {
-              await d1SetItemState(item, store, state, 'lock');
-            }
+            await setItemLockState(item, state);
 
             // TODO: Gotta do this differently in react land
             item.locked = state;


### PR DESCRIPTION
https://github.com/DestinyItemManager/DIM/issues/4386

Bungie.net has had a bug since the beginning where when you move an item, it may copy the lock state of an item from a different instance of that item in the source bucket.

This works around that by forcing the lock state to be the same as it was when you moved the item, with an extra API call. This only kicks in if the conditions that trigger the bug (multiples of the same hash in the source bucket) are true. This *can* override the true lock state of the item if the user has changed lock state in-game without refreshing DIM, but I think it's better than the super-broken current behavior.