### PR TITLE
Make DIM Fast Again: Work around sluggish dragging in Chrome

### DIFF
--- a/src/app/inventory/DragPerformanceFix.scss
+++ b/src/app/inventory/DragPerformanceFix.scss
@@ -1,0 +1,20 @@
+.drag-perf-fix {
+  opacity: 0;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  z-index: 8;
+
+  .drag-perf-debug & {
+    opacity: 0.1;
+    background-color: red;
+  }
+}
+
+.drag-perf-fix-hidden {
+  display: none;
+}

--- a/src/app/inventory/DragPerformanceFix.tsx
+++ b/src/app/inventory/DragPerformanceFix.tsx
@@ -3,6 +3,8 @@ import { RootState } from '../store/reducers';
 import { connect } from 'react-redux';
 import './DragPerformanceFix.scss';
 import clsx from 'clsx';
+import store from 'app/store/store';
+import { itemDrag } from 'app/inventory/actions';
 
 interface Props {
   isDragging: boolean;
@@ -14,10 +16,19 @@ function mapStateToProps(state: RootState) {
   };
 }
 
+function hideOverlay() {
+  // Rarely (possibly never in typical usage), a browser will forget to dispatch the dragEnd event
+  // So we try not to trap the user here.
+  store.dispatch(itemDrag(false));
+}
+
 /** This is a workaround for sluggish dragging in Chrome (and possibly other browsers) */
 function DragPerformanceFix(props: Props) {
   return (
-    <div className={clsx('drag-perf-fix', props.isDragging ? false : 'drag-perf-fix-hidden')} />
+    <div
+      className={clsx('drag-perf-fix', props.isDragging ? false : 'drag-perf-fix-hidden')}
+      onClick={hideOverlay}
+    />
   );
 }
 

--- a/src/app/inventory/DragPerformanceFix.tsx
+++ b/src/app/inventory/DragPerformanceFix.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { RootState } from '../store/reducers';
+import { connect } from 'react-redux';
+import './DragPerformanceFix.scss';
+import clsx from 'clsx';
+
+interface Props {
+  isDragging: boolean;
+}
+
+function mapStateToProps(state: RootState) {
+  return {
+    isDragging: state.inventory.isDragging
+  };
+}
+
+/** This is a workaround for sluggish dragging in Chrome (and possibly other browsers) */
+function DragPerformanceFix(props: Props) {
+  return (
+    <div className={clsx('drag-perf-fix', props.isDragging ? false : 'drag-perf-fix-hidden')} />
+  );
+}
+
+export default connect<Props>(mapStateToProps)(DragPerformanceFix);

--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -17,6 +17,7 @@ import D1Farming from '../farming/D1Farming';
 import InfusionFinder from '../infuse/InfusionFinder';
 import { queueAction } from './action-queue';
 import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
+import DragPerformanceFix from 'app/inventory/DragPerformanceFix';
 
 interface Props {
   account: DestinyAccount;
@@ -73,6 +74,7 @@ class Inventory extends React.Component<Props> {
         <LoadoutDrawer />
         <Compare />
         <StackableDragHelp />
+        <DragPerformanceFix />
         {account.destinyVersion === 1 ? <D1Farming /> : <D2Farming />}
         <InfusionFinder destinyVersion={account.destinyVersion} />
         <ClearNewItems account={account} />

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -12,6 +12,7 @@
   gap: var(--item-margin);
   align-content: flex-start;
   padding: 4px 0 calc(var(--item-margin) + 4px) 0;
+  position: relative;
 
   &:empty {
     min-height: 0;
@@ -20,6 +21,24 @@
 
   &.on-drag-hover {
     box-shadow: inset 0 0 6px 0 rgba(200, 200, 200, 0.7);
+  }
+
+  &.on-global-dragging:before {
+    content: '';
+
+    opacity: 0;
+
+    width: 100%;
+    height: 100%;
+
+    position: absolute;
+
+    z-index: 9;
+
+    .drag-perf-debug & {
+      opacity: 0.2;
+      background-color: green;
+    }
   }
 
   &.equipped {

--- a/src/app/inventory/StoreBucketDropTarget.tsx
+++ b/src/app/inventory/StoreBucketDropTarget.tsx
@@ -11,6 +11,8 @@ import { InventoryBucket } from './inventory-buckets';
 import { DimStore } from './store-types';
 import { DimItem } from './item-types';
 import moveDroppedItem from './move-dropped-item';
+import { connect } from 'react-redux';
+import { RootState } from 'app/store/reducers';
 
 interface ExternalProps {
   bucket: InventoryBucket;
@@ -18,6 +20,7 @@ interface ExternalProps {
   equip?: boolean;
   children?: React.ReactNode;
   className?: string;
+  isDragging?: boolean;
 }
 
 // These are all provided by the DropTarget HOC function
@@ -74,7 +77,16 @@ class StoreBucketDropTarget extends React.Component<Props> {
   private element?: HTMLDivElement;
 
   render() {
-    const { connectDropTarget, children, isOver, canDrop, equip, className, bucket } = this.props;
+    const {
+      connectDropTarget,
+      children,
+      isOver,
+      canDrop,
+      equip,
+      className,
+      bucket,
+      isDragging
+    } = this.props;
 
     // TODO: I don't like that we're managing the classes for sub-bucket here
 
@@ -83,7 +95,8 @@ class StoreBucketDropTarget extends React.Component<Props> {
         ref={this.captureRef}
         className={clsx('sub-bucket', className, equip ? 'equipped' : 'unequipped', {
           'on-drag-hover': canDrop && isOver,
-          'on-drag-enter': canDrop
+          'on-drag-enter': canDrop,
+          'on-global-dragging': isDragging
         })}
         aria-label={bucket.name}
       >
@@ -106,4 +119,12 @@ class StoreBucketDropTarget extends React.Component<Props> {
   };
 }
 
-export default DropTarget(dragType, dropSpec, collect)(StoreBucketDropTarget);
+function mapStateToProps(state: RootState): any {
+  return {
+    isDragging: state.inventory.isDragging
+  };
+}
+
+export default connect(mapStateToProps)(
+  DropTarget(dragType, dropSpec, collect)(StoreBucketDropTarget)
+);

--- a/src/app/inventory/StoreBucketDropTarget.tsx
+++ b/src/app/inventory/StoreBucketDropTarget.tsx
@@ -13,6 +13,8 @@ import { DimItem } from './item-types';
 import moveDroppedItem from './move-dropped-item';
 import { connect } from 'react-redux';
 import { RootState } from 'app/store/reducers';
+import store from 'app/store/store';
+import { itemDrag } from 'app/inventory/actions';
 
 interface ExternalProps {
   bucket: InventoryBucket;
@@ -98,6 +100,7 @@ class StoreBucketDropTarget extends React.Component<Props> {
           'on-drag-enter': canDrop,
           'on-global-dragging': isDragging
         })}
+        onClick={this.onClick}
         aria-label={bucket.name}
       >
         {children}
@@ -116,6 +119,12 @@ class StoreBucketDropTarget extends React.Component<Props> {
 
   private onDrag = (e: DragEvent) => {
     this.shiftKeyDown = e.shiftKey;
+  };
+
+  private onClick = () => {
+    if (this.props.isDragging) {
+      store.dispatch(itemDrag(false));
+    }
   };
 }
 

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -53,3 +53,6 @@ export const setTagsAndNotesForItem = createAction('tag_notes/UPDATE_ITEM')<{
 
 /** Notify that a stackable stack has begun or ended dragging. A bit overkill to put this in redux but eh. */
 export const stackableDrag = createAction('stackable_drag/DRAG')<boolean>();
+
+/** Notify that any item in the inventory view has begun or ended dragging. */
+export const itemDrag = createAction('item_drag/DRAG')<boolean>();

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -56,6 +56,9 @@ export interface InventoryState {
 
   /** Are we currently dragging a stack? */
   readonly isDraggingStack;
+
+  /** Are we currently dragging anything? */
+  readonly isDragging;
 }
 
 export type InventoryAction = ActionType<typeof actions>;
@@ -64,7 +67,8 @@ const initialState: InventoryState = {
   stores: [],
   newItems: new Set(),
   itemInfos: {},
-  isDraggingStack: false
+  isDraggingStack: false,
+  isDragging: false
 };
 
 export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction> = (
@@ -136,7 +140,14 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.stackableDrag):
       return {
         ...state,
-        isDraggingStack: action.payload
+        isDraggingStack: action.payload,
+        isDragging: action.payload
+      };
+
+    case getType(actions.itemDrag):
+      return {
+        ...state,
+        isDragging: action.payload
       };
 
     case getType(setCurrentAccount):


### PR DESCRIPTION
There appears to be an issue with Chrome (and possibly other browsers) where dragging inventory items around is extremely sluggish. I added a workaround for this that blocks out the entire screen with an overlay so Chrome doesn't kill itself with hit testing. 

NB: Adding the class `drag-perf-debug` to the body (or other enclosing element) will show how this works and possibly help debug issues. 