### PR TITLE
Move all settings access into redux, use selector

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -17,7 +17,7 @@ import { safariTouchFix } from './app/safari-touch-fix';
 import Root from './app/Root';
 import setupRateLimiter from './app/bungie-api/rate-limit-config';
 import { SyncService } from './app/storage/sync.service';
-import { initSettings } from './app/settings/settings';
+import { initSettings, watchLanguageChanges } from './app/settings/settings';
 import { saveReviewsToIndexedDB } from './app/item-review/reducer';
 import { saveWishListToIndexedDB } from './app/wishlists/reducer';
 import { saveAccountsToIndexedDB } from 'app/accounts/reducer';
@@ -56,6 +56,7 @@ SyncService.init();
 
 initi18n().then(() => {
   // Settings depends on i18n
+  watchLanguageChanges();
   initSettings();
 
   console.log(

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,6 +10,7 @@ import ClickOutsideRoot from './dim-ui/ClickOutsideRoot';
 import HotkeysCheatSheet from './hotkeys/HotkeysCheatSheet';
 import NotificationsContainer from './notifications/NotificationsContainer';
 import styles from './App.m.scss';
+import { settingsSelector } from './settings/reducer';
 
 interface Props {
   language: string;
@@ -20,7 +21,7 @@ interface Props {
 }
 
 function mapStateToProps(state: RootState): Props {
-  const settings = state.settings;
+  const settings = settingsSelector(state);
   return {
     language: settings.language,
     showReviews: settings.showReviews,

--- a/src/app/collections/PresentationNode.tsx
+++ b/src/app/collections/PresentationNode.tsx
@@ -16,6 +16,7 @@ import { RootState } from '../store/reducers';
 import Checkbox from '../settings/Checkbox';
 import { connect } from 'react-redux';
 import { t } from 'app/i18next-t';
+import { settingsSelector } from 'app/settings/reducer';
 
 /** root PresentationNodes to lock in expanded state */
 const rootNodes = [3790247699];
@@ -42,9 +43,10 @@ interface ProvidedProps {
 }
 
 function mapStateToProps(state: RootState): StoreProps {
+  const settings = settingsSelector(state);
   return {
-    completedRecordsHidden: state.settings.completedRecordsHidden,
-    redactedRecordsRevealed: state.settings.redactedRecordsRevealed
+    completedRecordsHidden: settings.completedRecordsHidden,
+    redactedRecordsRevealed: settings.redactedRecordsRevealed
   };
 }
 const mapDispatchToProps = {

--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -1,4 +1,5 @@
 import { observeStore } from './utils/redux-utils';
+import { settingsSelector } from './settings/reducer';
 
 function setCSSVariable(property: string, value: any) {
   if (value) {
@@ -10,45 +11,42 @@ function setCSSVariable(property: string, value: any) {
  * Update a set of CSS variables depending on the settings of the app and whether we're in portrait mode.
  */
 export default function updateCSSVariables() {
-  observeStore(
-    (state) => state.settings,
-    (currentState, nextState, state) => {
-      if (!currentState) {
-        return;
-      }
+  observeStore(settingsSelector, (currentState, nextState, state) => {
+    if (!currentState) {
+      return;
+    }
 
-      if (currentState.itemSize !== nextState.itemSize) {
-        setCSSVariable('--item-size', `${Math.max(48, nextState.itemSize)}px`);
-      }
-      if (currentState.charCol !== nextState.charCol) {
-        if (!state.shell.isPhonePortrait) {
-          setCSSVariable('--tiles-per-char-column', nextState.charCol);
-        }
-      }
-      if (currentState.charColMobile !== nextState.charColMobile) {
-        // this check is needed so on start up/load this doesn't override the value set above on "normal" mode.
-        if (state.shell.isPhonePortrait) {
-          setCSSVariable('--tiles-per-char-column', nextState.charColMobile);
-        }
-      }
-
-      if ($featureFlags.colorA11y && currentState.colorA11y !== nextState.colorA11y) {
-        const color = nextState.colorA11y;
-        if (color && color !== '-') {
-          setCSSVariable('--color-filter', `url(#${color.toLowerCase()})`);
-        } else {
-          document.querySelector('html')!.style.removeProperty('--color-filter');
-        }
+    if (currentState.itemSize !== nextState.itemSize) {
+      setCSSVariable('--item-size', `${Math.max(48, nextState.itemSize)}px`);
+    }
+    if (currentState.charCol !== nextState.charCol) {
+      if (!state.shell.isPhonePortrait) {
+        setCSSVariable('--tiles-per-char-column', nextState.charCol);
       }
     }
-  );
+    if (currentState.charColMobile !== nextState.charColMobile) {
+      // this check is needed so on start up/load this doesn't override the value set above on "normal" mode.
+      if (state.shell.isPhonePortrait) {
+        setCSSVariable('--tiles-per-char-column', nextState.charColMobile);
+      }
+    }
+
+    if ($featureFlags.colorA11y && currentState.colorA11y !== nextState.colorA11y) {
+      const color = nextState.colorA11y;
+      if (color && color !== '-') {
+        setCSSVariable('--color-filter', `url(#${color.toLowerCase()})`);
+      } else {
+        document.querySelector('html')!.style.removeProperty('--color-filter');
+      }
+    }
+  });
 
   // a subscribe on isPhonePortrait is needed when the user on mobile changes from portrait to landscape
   // or a user on desktop shrinks the browser window below isphoneportrait treshold value
   observeStore(
     (state) => state.shell.isPhonePortrait,
     (_, isPhonePortrait, state) => {
-      const settings = state.settings;
+      const settings = settingsSelector(state);
       setCSSVariable(
         '--tiles-per-char-column',
         isPhonePortrait ? settings.charColMobile : settings.charCol

--- a/src/app/destiny1/record-books/RecordBooks.tsx
+++ b/src/app/destiny1/record-books/RecordBooks.tsx
@@ -18,6 +18,7 @@ import Objective from '../../progress/Objective';
 import { DestinyAccount } from '../../accounts/destiny-account';
 import { Subscriptions } from '../../utils/rx-utils';
 import './record-books.scss';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -35,8 +36,9 @@ const mapDispatchToProps = {
 type DispatchProps = typeof mapDispatchToProps;
 
 function mapStateToProps(state: RootState): StoreProps {
+  const settings = settingsSelector(state);
   return {
-    hideCompletedRecords: state.settings.hideCompletedRecords,
+    hideCompletedRecords: settings.hideCompletedRecords,
     stores: storesSelector(state) as D1Store[],
     defs: state.manifest.d1Manifest
   };

--- a/src/app/dim-ui/CollapsibleTitle.tsx
+++ b/src/app/dim-ui/CollapsibleTitle.tsx
@@ -6,6 +6,7 @@ import { Dispatch } from 'redux';
 import { AppIcon, expandIcon, collapseIcon } from '../shell/icons';
 import clsx from 'clsx';
 import './CollapsibleTitle.scss';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface ProvidedProps {
   sectionId: string;
@@ -26,7 +27,7 @@ interface DispatchProps {
 }
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
-  const collapsed = state.settings.collapsedSections[props.sectionId];
+  const collapsed = settingsSelector(state).collapsedSections[props.sectionId];
   return {
     collapsed: collapsed === undefined ? Boolean(props.defaultCollapsed) : collapsed
   };

--- a/src/app/dim-ui/CustomStatTotal.tsx
+++ b/src/app/dim-ui/CustomStatTotal.tsx
@@ -9,6 +9,7 @@ import { DestinyStatDefinition, DestinyClass } from 'bungie-api-ts/destiny2';
 import { setSetting } from '../settings/actions';
 import { D2Item } from 'app/inventory/item-types';
 import clsx from 'clsx';
+import { settingsSelector } from 'app/settings/reducer';
 
 export interface KeyedStatHashLists {
   [key: number]: number[];
@@ -36,7 +37,7 @@ type TotalProps = { item: D2Item } & ProvidedProps & StoreDefsAndStats;
 function mapStateToProps() {
   return (state: RootState): StoreDefsAndStats => ({
     defs: state.manifest.d2Manifest!,
-    customTotalStatsByClass: state.settings.customTotalStatsByClass
+    customTotalStatsByClass: settingsSelector(state).customTotalStatsByClass
   });
 }
 

--- a/src/app/farming/D1Farming.tsx
+++ b/src/app/farming/D1Farming.tsx
@@ -9,6 +9,7 @@ import './farming.scss';
 import { D1FarmingService } from './farming.service';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { setSetting } from '../settings/actions';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface StoreProps {
   makeRoomForItems: boolean;
@@ -18,7 +19,7 @@ interface StoreProps {
 function mapStateToProps() {
   const storeSelector = farmingStoreSelector();
   return (state: RootState): StoreProps => ({
-    makeRoomForItems: state.settings.farmingMakeRoomForItems,
+    makeRoomForItems: settingsSelector(state).farmingMakeRoomForItems,
     store: storeSelector(state)
   });
 }

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -1,4 +1,3 @@
-import { settings } from '../settings/settings';
 import _ from 'lodash';
 import { MoveReservations, sortMoveAsideCandidatesForStore } from '../inventory/item-move-service';
 import { DimItem } from '../inventory/item-types';
@@ -13,6 +12,7 @@ import { InventoryBucket } from '../inventory/inventory-buckets';
 import { clearItemsOffCharacter } from '../loadout/loadout-apply';
 import { Subscription, from } from 'rxjs';
 import { filter, tap, map, exhaustMap } from 'rxjs/operators';
+import { settingsSelector } from 'app/settings/reducer';
 
 const glimmerHashes = new Set([
   269776572, // -house-banners
@@ -112,7 +112,7 @@ export const D1FarmingService = new D1Farming();
 
 async function farm(store: D1Store) {
   await farmItems(store);
-  if (settings.farmingMakeRoomForItems) {
+  if (settingsSelector(rxStore.getState()).farmingMakeRoomForItems) {
     await makeRoomForItems(store);
   }
 }

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -28,6 +28,7 @@ import { setSetting } from '../settings/actions';
 import { showNotification } from '../notifications/notifications';
 import { InfuseDirection } from './infuse-direction';
 import { applyLoadout } from 'app/loadout/loadout-apply';
+import { settingsSelector } from 'app/settings/reducer';
 
 const itemComparator = chainComparator(
   reverseComparator(compareBy((item: DimItem) => item.primStat!.value)),
@@ -55,7 +56,7 @@ function mapStateToProps(state: RootState): StoreProps {
     stores: storesSelector(state),
     searchConfig: searchConfigSelector(state),
     filters: searchFiltersConfigSelector(state),
-    lastInfusionDirection: state.settings.infusionDirection,
+    lastInfusionDirection: settingsSelector(state).infusionDirection,
     isPhonePortrait: state.shell.isPhonePortrait
   };
 }

--- a/src/app/inventory/ClearNewItems.tsx
+++ b/src/app/inventory/ClearNewItems.tsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { RootState } from '../store/reducers';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import NewItemIndicator from './NewItemIndicator';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -23,7 +24,7 @@ type Props = ProvidedProps & StoreProps;
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    showNewItems: state.settings.showNewItems,
+    showNewItems: settingsSelector(state).showNewItems,
     hasNewItems: state.inventory.newItems.size > 0
   };
 }

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -8,6 +8,7 @@ import { getRating, shouldShowRating, ratingsSelector } from '../item-review/red
 import { searchFilterSelector } from '../search/search-filters';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import { wishListsEnabledSelector, inventoryWishListsSelector } from '../wishlists/reducer';
+import { settingsSelector } from 'app/settings/reducer';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -34,7 +35,7 @@ interface StoreProps {
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   const { item } = props;
 
-  const settings = state.settings;
+  const settings = settingsSelector(state);
 
   const dtrRating = getRating(item, ratingsSelector(state));
   const showRating = shouldShowRating(dtrRating);

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -11,6 +11,7 @@ import { DimStore } from './store-types';
 import { storeBackgroundColor } from '../shell/filters';
 import { t } from 'app/i18next-t';
 import { postmasterAlmostFull, POSTMASTER_SIZE, postmasterSpaceUsed } from 'app/loadout/postmaster';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface ProvidedProps {
   sectionId: string;
@@ -30,7 +31,7 @@ interface DispatchProps {
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   return {
-    collapsed: state.settings.collapsedSections[props.sectionId]
+    collapsed: settingsSelector(state).collapsedSections[props.sectionId]
   };
 }
 

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -81,7 +81,7 @@ class StoreBucket extends React.Component<Props> {
           {classTypeOrder.map((classType) => (
             <React.Fragment key={classType}>
               <AppIcon icon={classIcons[classType]} className="armor-class-icon" />
-              {sortItems(itemsByClass[classType]).map((item) => (
+              {sortItems(itemsByClass[classType], itemSortOrder).map((item) => (
                 <StoreInventoryItem key={item.index} item={item} />
               ))}
             </React.Fragment>

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -21,6 +21,7 @@ import { t } from 'app/i18next-t';
 import './ItemPicker.scss';
 import { setSetting } from '../settings/actions';
 import _ from 'lodash';
+import { settingsSelector } from 'app/settings/reducer';
 
 type ProvidedProps = ItemPickerState & {
   onSheetClosed(): void;
@@ -49,7 +50,7 @@ function mapStateToProps(): MapStateToProps<StoreProps, ProvidedProps, RootState
     filters: searchFiltersConfigSelector(state),
     itemSortOrder: itemSortOrderSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
-    preferEquip: state.settings.itemPickerEquip
+    preferEquip: settingsSelector(state).itemPickerEquip
   });
 }
 

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -18,6 +18,7 @@ import { t } from 'app/i18next-t';
 import { storesSelector } from 'app/inventory/reducer';
 import { DimStore } from 'app/inventory/store-types';
 import ItemActions from './ItemActions';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface ProvidedProps {
   boundarySelector?: string;
@@ -27,13 +28,16 @@ interface StoreProps {
   isPhonePortrait: boolean;
   itemDetails: boolean;
   stores: DimStore[];
+  language: string;
 }
 
 function mapStateToProps(state: RootState): StoreProps {
+  const settings = settingsSelector(state);
   return {
+    stores: storesSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
-    itemDetails: state.settings.itemDetails,
-    stores: storesSelector(state)
+    itemDetails: settings.itemDetails,
+    language: settings.language
   };
 }
 
@@ -118,7 +122,7 @@ class ItemPopupContainer extends React.Component<Props, State> {
   }
 
   render() {
-    const { isPhonePortrait, itemDetails, stores } = this.props;
+    const { isPhonePortrait, itemDetails, stores, language } = this.props;
     const { extraInfo = {}, tab } = this.state;
     let { item } = this.state;
 
@@ -132,6 +136,7 @@ class ItemPopupContainer extends React.Component<Props, State> {
     const header = (
       <ItemPopupHeader
         item={item}
+        language={language}
         expanded={isPhonePortrait || itemDetails}
         showToggle={!isPhonePortrait}
         onToggleExpanded={this.toggleItemDetails}

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx';
 import { t } from 'app/i18next-t';
 import LockButton from './LockButton';
 import ExternalLink from '../dim-ui/ExternalLink';
-import { settings } from '../settings/settings';
 import { AppIcon, faClone, faChevronCircleUp, openDropdownIcon } from '../shell/icons';
 import { CompareService } from '../compare/compare.service';
 import { ammoTypeClass } from './ammo-type';
@@ -21,11 +20,13 @@ export default function ItemPopupHeader({
   item,
   expanded,
   showToggle,
+  language,
   onToggleExpanded
 }: {
   item: DimItem;
   expanded: boolean;
   showToggle: boolean;
+  language: string;
   onToggleExpanded(): void;
 }) {
   const hasLeftIcon = (item.isDestiny1() && item.trackable) || item.lockable || item.element;
@@ -81,7 +82,7 @@ export default function ItemPopupHeader({
           </div>
         )}
         <div className="item-title-link">
-          <ExternalLink href={destinyDBLink(item)} className="item-title">
+          <ExternalLink href={destinyDBLink(item, language)} className="item-title">
             {item.name}
           </ExternalLink>
         </div>
@@ -125,9 +126,8 @@ export default function ItemPopupHeader({
   );
 }
 
-function destinyDBLink(item: DimItem) {
+function destinyDBLink(item: DimItem, language: string) {
   // DTR 404s on the new D2 languages for D1 items
-  let language = settings.language;
   if (item.destinyVersion === 1) {
     switch (language) {
       case 'es-mx':
@@ -141,7 +141,7 @@ function destinyDBLink(item: DimItem) {
         break;
     }
 
-    return `http://db.destinytracker.com/d${item.destinyVersion}/${settings.language}/items/${item.hash}`;
+    return `http://db.destinytracker.com/d${item.destinyVersion}/${language}/items/${item.hash}`;
   }
 
   const d2Item = item as D2Item;

--- a/src/app/item-review/ItemReview.tsx
+++ b/src/app/item-review/ItemReview.tsx
@@ -14,7 +14,6 @@ import {
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
 import { StarRatingDisplay } from '../shell/star-rating/StarRatingDisplay';
-import { reportReview } from './destiny-tracker.service';
 import { D2ReviewMode } from '../destinyTrackerApi/reviewModesFetcher';
 import { translateReviewMode } from './reviewModeTranslator';
 import { PLATFORM_LABELS } from '../accounts/destiny-account';
@@ -25,6 +24,7 @@ interface Props {
   review: D2ItemUserReview | D1ItemUserReview;
   reviewModeOptions?: D2ReviewMode[];
   onEditReview(review: D2ItemUserReview | D1ItemUserReview): void;
+  onReportReview(review: D2ItemUserReview | D1ItemUserReview): void;
 }
 
 interface State {
@@ -164,12 +164,13 @@ export default class ItemReview extends React.Component<Props, State> {
   };
 
   private reportReview = () => {
+    const { onReportReview } = this.props;
     const { reportSent } = this.state;
     if (!reportSent) {
       this.setState({ reportSent: true });
 
       const { review } = this.props;
-      reportReview(review);
+      onReportReview(review);
     }
   };
 }

--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -18,11 +18,12 @@ import ItemReview from './ItemReview';
 import ItemReviewSettings from './ItemReviewSettings';
 import { StarRatingEditor } from '../shell/star-rating/StarRatingEditor';
 import { getReviewModes, D2ReviewMode } from '../destinyTrackerApi/reviewModesFetcher';
-import { getItemReviews, submitReview } from './destiny-tracker.service';
+import { getItemReviews, submitReview, reportReview } from './destiny-tracker.service';
 import { DtrRating } from './dtr-api-types';
 import { saveUserReview } from './actions';
 import { isD1UserReview, isD2UserReview } from '../destinyTrackerApi/reviewSubmitter';
 import RatingIcon from '../inventory/RatingIcon';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface ProvidedProps {
   item: DimItem;
@@ -39,7 +40,7 @@ interface StoreProps {
 const EMPTY = [];
 
 function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps {
-  const settings = state.settings;
+  const settings = settingsSelector(state);
   const reviewsResponse = getReviews(item, state);
   return {
     canReview: settings.allowIdPostToDtr,
@@ -231,6 +232,7 @@ class ItemReviews extends React.Component<Props, State> {
                     review={review}
                     reviewModeOptions={reviewModeOptions}
                     onEditReview={this.editReview}
+                    onReportReview={this.reportReview}
                   />
                 ))
             )}
@@ -277,6 +279,11 @@ class ItemReviews extends React.Component<Props, State> {
     this.setState({
       expandReview: true
     });
+  };
+
+  private reportReview = (review: D2ItemUserReview | D1ItemUserReview) => {
+    const { dispatch } = this.props;
+    dispatch(reportReview(review));
   };
 
   private submitReview = async () => {

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -1,5 +1,4 @@
 import { getItemReviewsD1 } from '../destinyTrackerApi/reviewsFetcher';
-import { settings } from '../settings/settings';
 import { getActivePlatform } from '../accounts/platforms';
 import {
   bulkFetch as bulkFetchD2,
@@ -23,19 +22,22 @@ import {
   bulkFetch as bulkFetchD1
 } from '../destinyTrackerApi/bulkFetcher';
 import { reportReview as doReportReview } from '../destinyTrackerApi/reviewReporter';
+import { settingsSelector } from 'app/settings/reducer';
 
 /** Redux thunk action that populates item reviews for an item if necessary. */
 export function getItemReviews(item: DimItem): ThunkResult<Promise<any>> {
-  if (settings.allowIdPostToDtr) {
-    if (item.isDestiny1()) {
-      return getItemReviewsD1(item);
-    } else if (item.isDestiny2()) {
-      const platformSelection = settings.reviewsPlatformSelectionV2;
-      const mode = settings.reviewsModeSelection;
-      return getItemReviewsD2(item, platformSelection, mode);
+  return async (dispatch, getState) => {
+    const settings = settingsSelector(getState());
+    if (settings.allowIdPostToDtr) {
+      if (item.isDestiny1()) {
+        return dispatch(getItemReviewsD1(item));
+      } else if (item.isDestiny2()) {
+        const platformSelection = settings.reviewsPlatformSelectionV2;
+        const mode = settings.reviewsModeSelection;
+        return dispatch(getItemReviewsD2(item, platformSelection, mode));
+      }
     }
-  }
-  return () => Promise.resolve();
+  };
 }
 
 /** Redux thunk action that submits a review. */
@@ -43,67 +45,83 @@ export function submitReview(
   item: DimItem,
   userReview?: WorkingD1Rating | WorkingD2Rating
 ): ThunkResult<Promise<any>> {
-  if (settings.allowIdPostToDtr) {
-    const membershipInfo = getActivePlatform();
+  return async (dispatch, getState) => {
+    if (settingsSelector(getState()).allowIdPostToDtr) {
+      const membershipInfo = getActivePlatform();
 
-    return doSubmitReview(item, membershipInfo, userReview);
-  }
-  return () => Promise.resolve();
+      return dispatch(doSubmitReview(item, membershipInfo, userReview));
+    }
+  };
 }
 
 export function bulkFetchVendorItems(
   vendorSaleItems: DestinyVendorSaleItemComponent[]
 ): ThunkResult<Promise<DtrRating[]>> {
-  if (settings.showReviews) {
-    const platformSelection = settings.reviewsPlatformSelectionV2;
-    const mode = settings.reviewsModeSelection;
-    return bulkFetchD2VendorItems(platformSelection, mode, vendorSaleItems);
-  }
-  return () => Promise.resolve([]);
+  return async (dispatch, getState) => {
+    const settings = settingsSelector(getState());
+    if (settings.showReviews) {
+      const platformSelection = settings.reviewsPlatformSelectionV2;
+      const mode = settings.reviewsModeSelection;
+      return dispatch(bulkFetchD2VendorItems(platformSelection, mode, vendorSaleItems));
+    }
+    return [];
+  };
 }
 
 export function bulkFetchKioskItems(
   vendorItems: DestinyVendorItemDefinition[]
 ): ThunkResult<Promise<DtrRating[]>> {
-  if (settings.showReviews) {
-    const platformSelection = settings.reviewsPlatformSelectionV2;
-    const mode = settings.reviewsModeSelection;
-    return bulkFetchD2VendorItems(platformSelection, mode, undefined, vendorItems);
-  }
-  return () => Promise.resolve([]);
+  return async (dispatch, getState) => {
+    const settings = settingsSelector(getState());
+    if (settings.showReviews) {
+      const platformSelection = settings.reviewsPlatformSelectionV2;
+      const mode = settings.reviewsModeSelection;
+      return dispatch(bulkFetchD2VendorItems(platformSelection, mode, undefined, vendorItems));
+    }
+    return [];
+  };
 }
 
 export function updateVendorRankings(vendors: {
   [key: number]: Vendor;
 }): ThunkResult<Promise<DtrRating[]>> {
-  if (settings.showReviews) {
-    bulkFetchD1VendorItems(vendors);
-  }
-  return () => Promise.resolve([]);
+  return async (dispatch, getState) => {
+    const settings = settingsSelector(getState());
+    if (settings.showReviews) {
+      return dispatch(bulkFetchD1VendorItems(vendors));
+    }
+    return [];
+  };
 }
 
 export function fetchRatings(stores: DimStore[]): ThunkResult<Promise<DtrRating[]>> {
-  if (!settings.showReviews || !stores || !stores[0]) {
-    return () => Promise.resolve([]);
-  }
+  return async (dispatch, getState) => {
+    const settings = settingsSelector(getState());
+    if (!settings.showReviews || !stores || !stores[0]) {
+      return [];
+    }
 
-  if (stores[0].isDestiny1()) {
-    return bulkFetchD1(stores as D1Store[]);
-  } else if (stores[0].isDestiny2()) {
-    const platformSelection = settings.reviewsPlatformSelectionV2;
-    const mode = settings.reviewsModeSelection;
-    return bulkFetchD2(stores as D2Store[], platformSelection, mode);
-  }
+    if (stores[0].isDestiny1()) {
+      return dispatch(bulkFetchD1(stores as D1Store[]));
+    } else if (stores[0].isDestiny2()) {
+      const platformSelection = settings.reviewsPlatformSelectionV2;
+      const mode = settings.reviewsModeSelection;
+      return dispatch(bulkFetchD2(stores as D2Store[], platformSelection, mode));
+    }
 
-  return () => Promise.resolve([]);
+    return [];
+  };
 }
 
-export async function reportReview(review: DimUserReview) {
-  if (settings.allowIdPostToDtr) {
-    const membershipInfo = getActivePlatform();
+export function reportReview(review: DimUserReview): ThunkResult<Promise<any>> {
+  return async (_dispatch, getState) => {
+    if (settingsSelector(getState()).allowIdPostToDtr) {
+      const membershipInfo = getActivePlatform();
 
-    if (membershipInfo) {
-      doReportReview(review, membershipInfo);
+      if (membershipInfo) {
+        // TODO: dispatch actions to update state in reaction to report
+        doReportReview(review, membershipInfo);
+      }
     }
-  }
+  };
 }

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -16,6 +16,7 @@ import { createSelector } from 'reselect';
 import { getReviewModes } from '../destinyTrackerApi/reviewModesFetcher';
 import { AccountsAction } from '../accounts/reducer';
 import { setCurrentAccount } from '../accounts/actions';
+import { settingsSelector } from 'app/settings/reducer';
 
 /** Each of the states here is keyed by an "item store key" - see getItemStoreKey */
 export interface ReviewsState {
@@ -182,7 +183,7 @@ export function getUserReview(item: DimItem, state: RootState): WorkingD2Rating 
           pros: '',
           cons: '',
           text: '',
-          mode: state.settings.reviewsModeSelection,
+          mode: settingsSelector(state).reviewsModeSelection,
           treatAsSubmitted: false
         })
   );

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -27,6 +27,7 @@ import ReactDOM from 'react-dom';
 import styles from './LockArmorAndPerks.m.scss';
 import LockedItem from './LockedItem';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { settingsSelector } from 'app/settings/reducer';
 
 interface ProvidedProps {
   selectedStore: DimStore;
@@ -50,7 +51,7 @@ function mapStateToProps() {
     buckets: state.inventory.buckets!,
     stores: storesSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
-    language: state.settings.language,
+    language: settingsSelector(state).language,
     defs: state.manifest.d2Manifest!
   });
 }

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -30,6 +30,7 @@ import { sortMods } from 'app/collections/Mods';
 import { escapeRegExp } from 'app/search/search-filters';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { SocketDetailsMod, plugIsInsertable } from 'app/item-popup/SocketDetails';
+import { settingsSelector } from 'app/settings/reducer';
 
 const burns: BurnItem[] = [
   {
@@ -195,7 +196,7 @@ function mapStateToProps() {
   return (state: RootState, props: ProvidedProps): StoreProps => ({
     isPhonePortrait: state.shell.isPhonePortrait,
     buckets: state.inventory.buckets!,
-    language: state.settings.language,
+    language: settingsSelector(state).language,
     perks: perksSelector(state, props),
     mods: unlockedPlugsSelector(state, props),
     defs: state.manifest.d2Manifest!

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -2,10 +2,12 @@ import _ from 'lodash';
 import { get, set, del } from 'idb-keyval';
 
 import { reportException } from '../utils/exceptions';
-import { settings, settingsReady } from '../settings/settings';
+import { settingsReady } from '../settings/settings';
 import { t } from 'app/i18next-t';
 import { showNotification } from '../notifications/notifications';
 import { BehaviorSubject, Subject } from 'rxjs';
+import { settingsSelector } from 'app/settings/reducer';
+import store from 'app/store/store';
 
 // This file exports D1ManifestService at the bottom of the
 // file (TS wants us to declare classes before using them)!
@@ -103,7 +105,7 @@ class ManifestService {
 
   private async loadManifest(): Promise<any> {
     await settingsReady; // wait for settings to be ready
-    const language = settings.language;
+    const language = settingsSelector(store.getState()).language;
     const manifestLang = manifestLangs.has(language) ? language : 'en';
     const path = `/data/d1/manifests/d1-manifest-${manifestLang}.json?v=2020-02-17`;
 

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -3,12 +3,14 @@ import { get, set, del } from 'idb-keyval';
 
 import { reportException } from '../utils/exceptions';
 import { getManifest as d2GetManifest } from '../bungie-api/destiny2-api';
-import { settings, settingsReady } from '../settings/settings';
+import { settingsReady } from '../settings/settings';
 import { t } from 'app/i18next-t';
 import { DestinyManifest } from 'bungie-api-ts/destiny2';
 import { deepEqual } from 'fast-equals';
 import { showNotification } from '../notifications/notifications';
 import { BehaviorSubject, Subject } from 'rxjs';
+import { settingsSelector } from 'app/settings/reducer';
+import store from 'app/store/store';
 
 // This file exports D2ManifestService at the bottom of the
 // file (TS wants us to declare classes before using them)!
@@ -40,7 +42,7 @@ class ManifestService {
     // This is not async because of https://bugs.webkit.org/show_bug.cgi?id=166879
     () => {
       this.getManifestApi().then((data) => {
-        const language = settings.language;
+        const language = settingsSelector(store.getState()).language;
         const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
 
         // The manifest has updated!
@@ -139,7 +141,7 @@ class ManifestService {
   private async loadManifest(tableWhitelist: string[]): Promise<any> {
     const data = await this.getManifestApi();
     await settingsReady; // wait for settings to be ready
-    const language = settings.language;
+    const language = settingsSelector(store.getState()).language;
     const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
 
     // Use the path as the version, rather than the "version" field, because

--- a/src/app/progress/Pursuit.tsx
+++ b/src/app/progress/Pursuit.tsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import clsx from 'clsx';
+import { settingsSelector } from 'app/settings/reducer';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -26,7 +27,7 @@ interface StoreProps {
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   const { item } = props;
 
-  const settings = state.settings;
+  const settings = settingsSelector(state);
 
   return {
     isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -227,8 +227,6 @@ class SettingsPage extends React.Component<Props> {
       { id: 'spreadsheets', title: t('Settings.Data') }
     ]);
 
-    console.log(initialLanguage, settings.language);
-
     return (
       <PageWithMenu>
         <PageWithMenu.Menu>

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -16,14 +16,13 @@ import { reviewPlatformOptions } from '../destinyTrackerApi/platformOptionsFetch
 import { D2ReviewMode } from '../destinyTrackerApi/reviewModesFetcher';
 import { D2StoresService } from '../inventory/d2-stores';
 import { D1StoresService } from '../inventory/d1-stores';
-import { settings } from './settings';
 import { storesLoadedSelector, storesSelector } from '../inventory/reducer';
 import Checkbox from './Checkbox';
 import Select, { mapToOptions, listToOptions } from './Select';
 import StorageSettings from '../storage/StorageSettings';
 import { getPlatforms, getActivePlatform } from '../accounts/platforms';
 import { itemSortOrder } from './item-sort';
-import { Settings, defaultItemSize } from './reducer';
+import { Settings, defaultItemSize, settingsSelector } from './reducer';
 import { AppIcon, refreshIcon } from '../shell/icons';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import RatingsKey from '../item-review/RatingsKey';
@@ -46,7 +45,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState) {
   return {
-    settings: state.settings,
+    settings: settingsSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
     storesLoaded: storesLoadedSelector(state),
     reviewModeOptions: reviewModesSelector(state),
@@ -131,20 +130,6 @@ const languageOptions = mapToOptions({
   'zh-chs': '简体中文' // Chinese (Simplified)
 });
 
-const tagLabelList = itemTagList.map((tagLabel) => t(tagLabel.label));
-const listSeparator = ['ja', 'zh-cht', 'zh-chs'].includes(settings.language) ? '、' : ', ';
-const tagListString = tagLabelList.join(listSeparator);
-const itemSortProperties = {
-  typeName: t('Settings.SortByType'),
-  rarity: t('Settings.SortByRarity'),
-  primStat: t('Settings.SortByPrimary'),
-  amount: t('Settings.SortByAmount'),
-  rating: t('Settings.SortByRating'),
-  classType: t('Settings.SortByClassType'),
-  name: t('Settings.SortName'),
-  tag: t('Settings.SortByTag', { taglist: tagListString })
-  // archetype: 'Archetype'
-};
 const colorA11yOptions = $featureFlags.colorA11y
   ? listToOptions([
       '-',
@@ -163,7 +148,7 @@ const colorA11yOptions = $featureFlags.colorA11y
 const supportsCssVar = window?.CSS?.supports('(--foo: red)');
 
 class SettingsPage extends React.Component<Props> {
-  private initialLanguage = settings.language;
+  private initialLanguage = this.props.settings.language;
 
   componentDidMount() {
     getDefinitions();
@@ -186,6 +171,21 @@ class SettingsPage extends React.Component<Props> {
       stores,
       itemInfos
     } = this.props;
+
+    const tagLabelList = itemTagList.map((tagLabel) => t(tagLabel.label));
+    const listSeparator = ['ja', 'zh-cht', 'zh-chs'].includes(settings.language) ? '、' : ', ';
+    const tagListString = tagLabelList.join(listSeparator);
+    const itemSortProperties = {
+      typeName: t('Settings.SortByType'),
+      rarity: t('Settings.SortByRarity'),
+      primStat: t('Settings.SortByPrimary'),
+      amount: t('Settings.SortByAmount'),
+      rating: t('Settings.SortByRating'),
+      classType: t('Settings.SortByClassType'),
+      name: t('Settings.SortName'),
+      tag: t('Settings.SortByTag', { taglist: tagListString })
+      // archetype: 'Archetype'
+    };
 
     const charColOptions = _.range(3, 6).map((num) => ({
       value: num,

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -147,10 +147,13 @@ const colorA11yOptions = $featureFlags.colorA11y
 // Edge doesn't support these
 const supportsCssVar = window?.CSS?.supports('(--foo: red)');
 
-class SettingsPage extends React.Component<Props> {
-  private initialLanguage = this.props.settings.language;
+let initialLanguage: string;
 
+class SettingsPage extends React.Component<Props> {
   componentDidMount() {
+    if (!initialLanguage) {
+      initialLanguage = this.props.settings.language;
+    }
     getDefinitions();
     getPlatforms().then(() => {
       const account = getActivePlatform();
@@ -224,6 +227,8 @@ class SettingsPage extends React.Component<Props> {
       { id: 'spreadsheets', title: t('Settings.Data') }
     ]);
 
+    console.log(initialLanguage, settings.language);
+
     return (
       <PageWithMenu>
         <PageWithMenu.Menu>
@@ -247,7 +252,7 @@ class SettingsPage extends React.Component<Props> {
                   options={languageOptions}
                   onChange={this.changeLanguage}
                 />
-                {this.initialLanguage !== settings.language && (
+                {initialLanguage !== settings.language && (
                   <div>
                     <button className="dim-button" onClick={this.reloadDim}>
                       <AppIcon icon={refreshIcon} /> <span>{t('Settings.ReloadDIM')}</span>

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -12,6 +12,7 @@ import { setSetting } from './actions';
 import { transformAndStoreWishList, fetchWishList } from 'app/wishlists/wishlist-fetch';
 import { isUri } from 'valid-url';
 import { toWishList } from 'app/wishlists/wishlist-file';
+import { settingsSelector } from './reducer';
 
 interface StoreProps {
   wishListsEnabled: boolean;
@@ -29,7 +30,7 @@ function mapStateToProps(state: RootState): StoreProps {
     numWishListRolls: state.wishLists.wishListAndInfo.wishListRolls.length,
     title: state.wishLists.wishListAndInfo.title,
     description: state.wishLists.wishListAndInfo.description,
-    wishListSource: state.settings.wishListSource
+    wishListSource: settingsSelector(state).wishListSource
   };
 }
 
@@ -138,7 +139,7 @@ class WishListSettings extends React.Component<Props, State> {
   };
 
   private loadWishList: DropzoneOptions['onDrop'] = (acceptedFiles) => {
-    this.props.dispatch(setSetting('wishListSource', undefined));
+    this.props.dispatch(clearWishLists());
     this.setState({ wishListSource: '' });
 
     const reader = new FileReader();

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -1,14 +1,20 @@
-import { createAction } from 'typesafe-actions';
+import { createAction, PayloadAction } from 'typesafe-actions';
 import { Settings } from './reducer';
 
 /** Bulk update settings after they've been loaded. */
 export const loaded = createAction('settings/LOADED')<Partial<Settings>>();
 
 /** This one seems a bit like cheating, but it lets us set a specific property. */
-export const setSetting = createAction('settings/SET', (property: keyof Settings, value: any) => ({
-  property,
-  value
-}))();
+export const setSetting = createAction(
+  'settings/SET',
+  <V extends keyof Settings>(property: V, value: Settings[V]) => ({
+    property,
+    value
+  })
+)() as <V extends keyof Settings>(
+  property: V,
+  value: Settings[V]
+) => PayloadAction<'settings/SET', { property: V; value: Settings[V] }>;
 
 /** Update a collapsible section */
 export const toggleCollapsedSection = createAction('settings/COLLAPSIBLE')<string>();

--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -3,9 +3,11 @@ import { DimStore } from '../inventory/store-types';
 import _ from 'lodash';
 import { DestinyCharacterComponent } from 'bungie-api-ts/destiny2';
 import { createSelector } from 'reselect';
+import { settingsSelector } from './reducer';
 
-export const characterOrderSelector = (state: RootState) => state.settings.characterOrder;
-const customCharacterSortSelector = (state: RootState) => state.settings.customCharacterSort;
+export const characterOrderSelector = (state: RootState) => settingsSelector(state).characterOrder;
+const customCharacterSortSelector = (state: RootState) =>
+  settingsSelector(state).customCharacterSort;
 
 export const characterSortSelector = createSelector(
   characterOrderSelector,

--- a/src/app/settings/item-sort.ts
+++ b/src/app/settings/item-sort.ts
@@ -1,5 +1,5 @@
 import { RootState } from '../store/reducers';
-import { Settings } from './reducer';
+import { Settings, settingsSelector } from './reducer';
 
 const itemSortPresets = {
   primaryStat: ['primStat', 'name'],
@@ -16,4 +16,4 @@ export const itemSortOrder = (settings: Settings): string[] =>
     ? settings.itemSortOrderCustom
     : itemSortPresets[settings.itemSort]) || itemSortPresets.primaryStat;
 
-export const itemSortOrderSelector = (state: RootState) => itemSortOrder(state.settings);
+export const itemSortOrderSelector = (state: RootState) => itemSortOrder(settingsSelector(state));

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -8,6 +8,7 @@ import { InfuseDirection } from '../infuse/infuse-direction';
 import { DtrReviewPlatform } from 'app/destinyTrackerApi/platformOptionsFetcher';
 import { clearWishLists } from 'app/wishlists/actions';
 import { KeyedStatHashLists } from 'app/dim-ui/CustomStatTotal';
+import { RootState } from 'app/store/reducers';
 
 export type CharacterOrder = 'mostRecent' | 'mostRecentReverse' | 'fixed' | 'custom';
 
@@ -79,6 +80,8 @@ export interface Settings {
   /** list of stat hashes of interest, keyed by class enum */
   readonly customTotalStatsByClass: KeyedStatHashLists;
 }
+
+export const settingsSelector = (state: RootState) => state.settings;
 
 export function defaultItemSize() {
   return 50;

--- a/src/app/settings/routes.lazy.ts
+++ b/src/app/settings/routes.lazy.ts
@@ -1,12 +1,16 @@
 import SettingsPage from './SettingsPage';
 import { ReactStateDeclaration } from '@uirouter/react';
+import { settingsReady } from './settings';
 import GDriveRevisions from '../storage/GDriveRevisions';
 
 export const states: ReactStateDeclaration[] = [
   {
     name: 'settings',
     url: '/settings?gdrive',
-    component: SettingsPage
+    component: SettingsPage,
+    resolve: {
+      settings: () => settingsReady
+    }
   },
   {
     name: 'gdrive-revisions',

--- a/src/app/settings/routes.lazy.ts
+++ b/src/app/settings/routes.lazy.ts
@@ -1,16 +1,12 @@
 import SettingsPage from './SettingsPage';
 import { ReactStateDeclaration } from '@uirouter/react';
-import { settingsReady } from './settings';
 import GDriveRevisions from '../storage/GDriveRevisions';
 
 export const states: ReactStateDeclaration[] = [
   {
     name: 'settings',
     url: '/settings?gdrive',
-    component: SettingsPage,
-    resolve: {
-      settings: () => settingsReady
-    }
+    component: SettingsPage
   },
   {
     name: 'gdrive-revisions',

--- a/src/app/settings/settings.ts
+++ b/src/app/settings/settings.ts
@@ -5,13 +5,10 @@ import store from '../store/store';
 import { loaded } from './actions';
 import { observeStore } from '../utils/redux-utils';
 import { Unsubscribe } from 'redux';
-import { initialState } from './reducer';
+import { settingsSelector } from './reducer';
 
-let readyResolve;
+export let readyResolve;
 export const settingsReady = new Promise((resolve) => (readyResolve = resolve));
-
-// This is a backwards-compatibility shim for all the code that directly uses settings
-export let settings = initialState;
 
 const saveSettings = _.throttle(
   (settings) =>
@@ -25,8 +22,20 @@ function saveSettingsOnUpdate() {
   return observeStore(
     (state) => state.settings,
     (_currentState, nextState) => {
-      settings = nextState;
       saveSettings(nextState);
+    }
+  );
+}
+
+export function watchLanguageChanges() {
+  return observeStore(
+    (state) => settingsSelector(state).language,
+    (_, language) => {
+      const languageChanged = language !== i18next.language;
+      localStorage.setItem('dimLanguage', language);
+      if (languageChanged) {
+        i18next.changeLanguage(language);
+      }
     }
   );
 }
@@ -44,16 +53,10 @@ export function initSettings() {
     data = data || {};
 
     const savedSettings = data['settings-v1.0'] || {};
-
-    const languageChanged = savedSettings.language !== i18next.language;
     store.dispatch(loaded(savedSettings));
-    const settings = store.getState().settings;
-    localStorage.setItem('dimLanguage', settings.language);
-    if (languageChanged) {
-      i18next.changeLanguage(settings.language);
-    }
 
     readyResolve();
+
     // Start saving settings changes
     unsubscribe = saveSettingsOnUpdate();
   });

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -1,9 +1,7 @@
 import _ from 'lodash';
 import { compareBy, reverseComparator, chainComparator, Comparator } from '../utils/comparators';
-import { settings } from '../settings/settings';
 import { DimItem } from '../inventory/item-types';
 import { DimStore } from '../inventory/store-types';
-import { itemSortOrder as itemSortOrderFn } from '../settings/item-sort';
 import { characterSortSelector } from '../settings/character-sort';
 import store from '../store/store';
 import { getTag, tagConfig } from '../inventory/dim-item-info';
@@ -150,7 +148,7 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
 /**
  * Sort items according to the user's preferences (via the sort parameter).
  */
-export function sortItems(items: DimItem[], itemSortOrder = itemSortOrderFn(settings)) {
+export function sortItems(items: DimItem[], itemSortOrder: string[]) {
   if (!items.length) {
     return items;
   }

--- a/src/app/whats-new/WhatsNew.tsx
+++ b/src/app/whats-new/WhatsNew.tsx
@@ -2,13 +2,27 @@ import React from 'react';
 import ChangeLog from './ChangeLog';
 import BungieAlerts from './BungieAlerts';
 import { Timeline } from 'react-twitter-widgets';
-import { settings } from '../settings/settings';
 import './WhatsNew.scss';
+import { connect } from 'react-redux';
+import { settingsSelector } from 'app/settings/reducer';
+import { RootState } from 'app/store/reducers';
+
+interface StoreProps {
+  language: string;
+}
+
+function mapStateToProps(state: RootState): StoreProps {
+  return {
+    language: settingsSelector(state).language
+  };
+}
+
+type Props = StoreProps;
 
 /**
  * What's new in the world of DIM?
  */
-export default function WhatsNew() {
+function WhatsNew({ language }: Props) {
   return (
     <div className="dim-page dim-static-page">
       <BungieAlerts />
@@ -20,7 +34,7 @@ export default function WhatsNew() {
             screenName: 'ThisIsDIM'
           }}
           options={{
-            lang: settings.language,
+            lang: language,
             dnt: true,
             via: 'ThisIsDIM',
             username: 'ThisIsDIM',
@@ -33,3 +47,4 @@ export default function WhatsNew() {
     </div>
   );
 }
+export default connect<StoreProps>(mapStateToProps)(WhatsNew);


### PR DESCRIPTION
This finishes the work of moving settings behind Redux - the hack of having a global settings object that can be accessed by non-Redux means has been eradicated. I've also added a selector function for all access of settings, to abstract away its place in the state.

This change is extracted from the upcoming PR to move to DIM API - I needed to consolidate settings access behind a consistent selector so I could easily switch to a different part of state to use the settings that come from DIM API.