### PR TITLE
Use types from dim-api-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
+    "@destinyitemmanager/dim-api-types": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.12.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.27",
     "@fortawesome/react-fontawesome": "^0.1.8",

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -6,11 +6,7 @@ import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Store } from '../inventory/store-types';
 import { dtrFetch, dtrTextReviewMultiplier, dtrD2ReviewsEndpoint } from './dtr-service-helper';
-import {
-  D2ItemFetchResponse,
-  D2ItemFetchRequest,
-  DtrD2ActivityModes
-} from '../item-review/d2-dtr-api-types';
+import { D2ItemFetchResponse, D2ItemFetchRequest } from '../item-review/d2-dtr-api-types';
 import { getVendorItemList, getItemList } from './d2-itemListBuilder';
 import _ from 'lodash';
 import { updateRatings } from '../item-review/actions';
@@ -20,7 +16,7 @@ import { ThunkResult, RootState } from '../store/reducers';
 import { ratingsSelector, loadReviewsFromIndexedDB } from '../item-review/reducer';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
-import { DtrReviewPlatform } from './platformOptionsFetcher';
+import { DtrD2ActivityModes, DtrReviewPlatform } from '@destinyitemmanager/dim-api-types';
 
 function getBulkFetchPromise(
   ratings: {

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -4,18 +4,14 @@ import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2Errors } from './d2-trackerErrorHandler';
 import { D2Item } from '../inventory/item-types';
 import { dtrFetch, dtrD2ReviewsEndpoint } from './dtr-service-helper';
-import {
-  D2ItemReviewResponse,
-  D2ItemUserReview,
-  DtrD2ActivityModes
-} from '../item-review/d2-dtr-api-types';
+import { D2ItemReviewResponse, D2ItemUserReview } from '../item-review/d2-dtr-api-types';
 import { getRollAndPerks } from './d2-itemTransformer';
 import { conditionallyIgnoreReviews } from './userFilter';
 import { toUtcTime } from './util';
 import { getReviews, getItemReviewsKey } from '../item-review/reducer';
 import { reviewsLoaded } from '../item-review/actions';
 import { ThunkResult } from '../store/reducers';
-import { DtrReviewPlatform } from './platformOptionsFetcher';
+import { DtrD2ActivityModes, DtrReviewPlatform } from '@destinyitemmanager/dim-api-types';
 
 /**
  * Redux action that populates community (which may include the current user's) reviews for a given item.

--- a/src/app/destinyTrackerApi/platformOptionsFetcher.ts
+++ b/src/app/destinyTrackerApi/platformOptionsFetcher.ts
@@ -1,10 +1,4 @@
-export const enum DtrReviewPlatform {
-  All = 0,
-  Xbox = 1,
-  Playstation = 2,
-  AllConsoles = 101,
-  Pc = 3
-}
+import { DtrReviewPlatform } from '@destinyitemmanager/dim-api-types';
 
 export interface DtrPlatformOption {
   platform: DtrReviewPlatform;

--- a/src/app/destinyTrackerApi/reviewModesFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewModesFetcher.ts
@@ -1,6 +1,6 @@
 import { t } from 'app/i18next-t';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
-import { DtrD2ActivityModes } from '../item-review/d2-dtr-api-types';
+import { DtrD2ActivityModes } from '@destinyitemmanager/dim-api-types';
 
 export interface D2ReviewMode {
   mode: DtrD2ActivityModes;

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -26,8 +26,8 @@ import {
 } from '../search/search-filters';
 import { setSetting } from '../settings/actions';
 import { showNotification } from '../notifications/notifications';
-import { InfuseDirection } from './infuse-direction';
 import { applyLoadout } from 'app/loadout/loadout-apply';
+import { InfuseDirection } from '@destinyitemmanager/dim-api-types';
 
 const itemComparator = chainComparator(
   reverseComparator(compareBy((item: DimItem) => item.primStat!.value)),

--- a/src/app/infuse/infuse-direction.ts
+++ b/src/app/infuse/infuse-direction.ts
@@ -1,6 +1,0 @@
-export const enum InfuseDirection {
-  /** infuse something into the query (query = target) */
-  INFUSE,
-  /** infuse the query into the target (query = source) */
-  FUEL
-}

--- a/src/app/item-review/ItemReview.tsx
+++ b/src/app/item-review/ItemReview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DimItem } from '../inventory/item-types';
-import { D2ItemUserReview, DtrD2ActivityModes } from './d2-dtr-api-types';
+import { D2ItemUserReview } from './d2-dtr-api-types';
 import { D1ItemUserReview } from './d1-dtr-api-types';
 import {
   AppIcon,
@@ -19,6 +19,7 @@ import { D2ReviewMode } from '../destinyTrackerApi/reviewModesFetcher';
 import { translateReviewMode } from './reviewModeTranslator';
 import { PLATFORM_LABELS } from '../accounts/destiny-account';
 import { getIgnoredUsers } from 'app/destinyTrackerApi/userFilter';
+import { DtrD2ActivityModes } from '@destinyitemmanager/dim-api-types';
 
 interface Props {
   item: DimItem;

--- a/src/app/item-review/d2-dtr-api-types.ts
+++ b/src/app/item-review/d2-dtr-api-types.ts
@@ -1,5 +1,5 @@
 import { DimWorkingUserReview, DimUserReview } from './dtr-api-types';
-import { DestinyActivityModeType } from 'bungie-api-ts/destiny2';
+import { DtrD2ActivityModes } from '@destinyitemmanager/dim-api-types';
 
 /**
  * A "basic" item.
@@ -120,14 +120,4 @@ export interface D2ItemReviewResponse {
   reviews: D2ItemUserReview[];
 
   lastUpdated: Date;
-}
-
-/** The subset of DestinyActivityModeType that we use for game modes. */
-export const enum DtrD2ActivityModes {
-  notSpecified = DestinyActivityModeType.None,
-  playerVersusEnemy = DestinyActivityModeType.AllPvE,
-  playerVersusPlayer = DestinyActivityModeType.AllPvP,
-  raid = DestinyActivityModeType.Raid,
-  // trials = DestinyActivityModeType.TrialsOfTheNine
-  gambit = DestinyActivityModeType.Gambit
 }

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -3,79 +3,13 @@ import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import _ from 'lodash';
 import { defaultLanguage } from '../i18n';
-import { DtrD2ActivityModes } from '../item-review/d2-dtr-api-types';
-import { InfuseDirection } from '../infuse/infuse-direction';
-import { DtrReviewPlatform } from 'app/destinyTrackerApi/platformOptionsFetcher';
 import { clearWishLists } from 'app/wishlists/actions';
 import { KeyedStatHashLists } from 'app/dim-ui/CustomStatTotal';
+import { Settings as DimApiSettings, defaultSettings } from '@destinyitemmanager/dim-api-types';
 
 export type CharacterOrder = 'mostRecent' | 'mostRecentReverse' | 'fixed' | 'custom';
 
-export interface Settings {
-  /** Show full details in item popup */
-  readonly itemDetails: boolean;
-  /** Show item quality percentages */
-  readonly itemQuality: boolean;
-  /** Show new items with an overlay */
-  readonly showNewItems: boolean;
-  /** Show item reviews */
-  readonly showReviews: boolean;
-  /** Can we post identifying information to DTR? */
-  readonly allowIdPostToDtr: boolean;
-  /** Sort characters (mostRecent, mostRecentReverse, fixed) */
-  readonly characterOrder: CharacterOrder;
-  /**
-   * Sort items in buckets (primaryStat, rarityThenPrimary, quality).
-   * This used to let you set a preset but now it's always "custom"
-   * unless loaded from an older settings.
-   */
-  readonly itemSort: string;
-  readonly itemSortOrderCustom: string[];
-  /** How many columns to display character buckets */
-  readonly charCol: number;
-  /** How many columns to display character buckets on Mobile */
-  readonly charColMobile: number;
-  /** How big in pixels to draw items - start smaller for iPad */
-  readonly itemSize: number;
-  /** Which categories or buckets should be collapsed? */
-  readonly collapsedSections: { [key: string]: boolean };
-  /** Hide triumphs once they're completed */
-  readonly completedRecordsHidden: boolean;
-  /** Show triumphs the manifest recommends be redacted */
-  readonly redactedRecordsRevealed: boolean;
-  /** Whether to keep one slot per item type open (D1 only) */
-  readonly farmingMakeRoomForItems: boolean;
-  /** Destiny 2 platform selection for ratings + reviews */
-  readonly reviewsPlatformSelectionV2: DtrReviewPlatform;
-  /** Destiny 2 play mode selection for ratings + reviews - see DestinyActivityModeType for values */
-  readonly reviewsModeSelection: DtrD2ActivityModes;
-
-  /** Hide completed Destiny 1 records */
-  readonly hideCompletedRecords: boolean;
-
-  /** Custom character sort - across all accounts and characters! */
-  readonly customCharacterSort: string[];
-
-  /** The last direction the infusion fuel finder was set to. */
-  readonly infusionDirection: InfuseDirection;
-
-  /** Whether the item picker should equip or store. */
-  readonly itemPickerEquip: boolean;
-
-  /** The user's preferred language. */
-  readonly language: string;
-
-  /** Colorblind modes. */
-  readonly colorA11y: string;
-
-  /**
-   * External source for wish lists.
-   * Expected to be a valid URL.
-   * initialState should hold the current location of a reasonably-useful collection of rolls.
-   * Set to empty string to not use wishListSource.
-   */
-  readonly wishListSource: string;
-
+export interface Settings extends DimApiSettings {
   /** list of stat hashes of interest, keyed by class enum */
   readonly customTotalStatsByClass: KeyedStatHashLists;
 }
@@ -85,51 +19,8 @@ export function defaultItemSize() {
 }
 
 export const initialState: Settings = {
-  // Show full details in item popup
-  itemDetails: true,
-  // Show item quality percentages
-  itemQuality: true,
-  // Show new items with a red dot
-  showNewItems: false,
-  // Show item reviews
-  showReviews: true,
-  // Can we post identifying information to DTR?
-  allowIdPostToDtr: true,
-  // Sort characters (mostRecent, mostRecentReverse, fixed)
-  characterOrder: 'mostRecent',
-  // Sort items in buckets (primaryStat, rarityThenPrimary, quality)
-  itemSort: 'custom',
-  itemSortOrderCustom: ['primStat', 'name'],
-  // How many columns to display character buckets
-  charCol: 3,
-  // How many columns to display character buckets on Mobile
-  charColMobile: 4,
-  // How big in pixels to draw items - start smaller for iPad
-  itemSize: defaultItemSize(),
-  // Which categories or buckets should be collapsed?
-  collapsedSections: {},
-  // Hide triumphs once they're completed
-  completedRecordsHidden: false,
-  // Hide show triumphs the manifest recommends be redacted
-  redactedRecordsRevealed: false,
-  // Whether to keep one slot per item type open (D1 only)
-  farmingMakeRoomForItems: true,
-  // Destiny 2 platform selection for ratings + reviews
-  reviewsPlatformSelectionV2: 0,
-  // Destiny 2 play mode selection for ratings + reviews - see DestinyActivityModeType for values
-  reviewsModeSelection: DtrD2ActivityModes.notSpecified,
-  hideCompletedRecords: false,
-
-  customCharacterSort: [],
-
-  infusionDirection: InfuseDirection.INFUSE,
-  itemPickerEquip: true,
-
+  ...defaultSettings,
   language: defaultLanguage(),
-
-  colorA11y: '-',
-  wishListSource:
-    'https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/voltron.txt',
   customTotalStatsByClass: {}
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,6 +827,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@destinyitemmanager/dim-api-types@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@destinyitemmanager/dim-api-types/-/dim-api-types-1.1.0.tgz#d7fd73064b39de54af671d88a0159b8cb49ba02c"
+  integrity sha512-xmtDdscCVPuxyccfDuC6ZbcnS1XTjz57aTTKmBPxYKCGIr+XTpzAvaEEecrD2QTusZdrSn5E1o9VfDNJWCtkBA==
+
 "@fortawesome/fontawesome-common-types@^0.2.27":
   version "0.2.27"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.27.tgz#19706345859fc46adf3684ed01d11b40903b87e9"


### PR DESCRIPTION
As part of the DIM API push, I've published the types used in the API as [@destinyitemmanager/dim-api-types](https://www.npmjs.com/package/@destinyitemmanager/dim-api-types) on NPM. This lets us share types between the two projects.

In this PR I've switched over as much of DIM to use that types package as possible. This is another independent chunk of the eventual PR to actually use the DIM API.