### PR TITLE
Add a dedupePromise helper

### DIFF
--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -32,3 +32,24 @@ export function weakMemoize<T extends object, R>(func: (T) => R): (T) => R {
     return value;
   };
 }
+
+/**
+ * Transform an async function into a version that will only execute once at a time - if there's already
+ * a version going, the existing promise will be returned instead of running it again.
+ */
+export function dedupePromise<T extends any[], K>(
+  func: (...args: T) => Promise<K>
+): (...args: T) => Promise<K> {
+  let promiseCache: Promise<K> | null = null;
+  return async (...args: T) => {
+    if (promiseCache) {
+      return promiseCache;
+    }
+    promiseCache = func(...args);
+    try {
+      return await promiseCache;
+    } finally {
+      promiseCache = null;
+    }
+  };
+}


### PR DESCRIPTION
Another very minor change carved off the big DIM API PR.

This adds a new `dedupePromise` utility that will transform a function that returns a promise into one that will, if there's already a promise going for that function, return the in-progress function until that completes. So, it enforces "one at a time". Good for calling service APIs.

This can be done with complex RxJS operators too, but I'm looking towards removing RxJS whenever possible - I think it's overcomplicated.