### PR TITLE
Use debounce instead of throttle for saving data

### DIFF
--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -207,28 +207,24 @@ function convertToRatingMap(ratings: DtrRating[]) {
 export function saveReviewsToIndexedDB() {
   return observeStore(
     (state) => state.reviews,
-    _.throttle(
-      (currentState: ReviewsState, nextState: ReviewsState) => {
-        if (nextState.loadedFromIDB) {
-          const cutoff = new Date(Date.now() - ITEM_RATING_EXPIRATION);
+    _.debounce((currentState: ReviewsState, nextState: ReviewsState) => {
+      if (nextState.loadedFromIDB) {
+        const cutoff = new Date(Date.now() - ITEM_RATING_EXPIRATION);
 
-          if (!_.isEmpty(nextState.reviews) && nextState.reviews !== currentState.reviews) {
-            set(
-              'reviews',
-              _.pickBy(nextState.reviews, (r) => r.lastUpdated > cutoff)
-            );
-          }
-          if (!_.isEmpty(nextState.ratings) && nextState.ratings !== currentState.ratings) {
-            set(
-              'ratings-v2',
-              _.pickBy(nextState.ratings, (r) => r.lastUpdated > cutoff)
-            );
-          }
+        if (!_.isEmpty(nextState.reviews) && nextState.reviews !== currentState.reviews) {
+          set(
+            'reviews',
+            _.pickBy(nextState.reviews, (r) => r.lastUpdated > cutoff)
+          );
         }
-      },
-      1000,
-      { leading: true, trailing: true }
-    )
+        if (!_.isEmpty(nextState.ratings) && nextState.ratings !== currentState.ratings) {
+          set(
+            'ratings-v2',
+            _.pickBy(nextState.ratings, (r) => r.lastUpdated > cutoff)
+          );
+        }
+      }
+    }, 1000)
   );
 }
 

--- a/src/app/settings/settings.ts
+++ b/src/app/settings/settings.ts
@@ -13,7 +13,7 @@ export const settingsReady = new Promise((resolve) => (readyResolve = resolve));
 // This is a backwards-compatibility shim for all the code that directly uses settings
 export let settings = initialState;
 
-const saveSettings = _.throttle(
+const saveSettings = _.debounce(
   (settings) =>
     SyncService.set({
       'settings-v1.0': settings


### PR DESCRIPTION
While working on the DIM API PR, I realized that for functions that observe the store and then save data (to IndexedDB or to Google Drive or to DIM API), we want to use `debounce`, not `throttle`, to coalesce events. `debounce` will keep waiting until no more changes come in for a time period (1 second), then will do the action (saving the data) while the way we were using throttle it'd save immediately on the first event, then once every time period (1 second), then once again at the end, which is wasteful.