### PR TITLE
Add DIM API keys to the DIM developer page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "$DIM_WEB_API_KEY": "readonly",
     "$DIM_WEB_CLIENT_ID": "readonly",
     "$DIM_WEB_CLIENT_SECRET": "readonly",
+    "$DIM_API_KEY": "readonly",
     "$BROWSERS": "readonly",
     "workbox": true,
     "React": true,

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -329,6 +329,7 @@ module.exports = (env) => {
         $DIM_WEB_API_KEY: JSON.stringify(process.env.WEB_API_KEY),
         $DIM_WEB_CLIENT_ID: JSON.stringify(process.env.WEB_OAUTH_CLIENT_ID),
         $DIM_WEB_CLIENT_SECRET: JSON.stringify(process.env.WEB_OAUTH_CLIENT_SECRET),
+        $DIM_API_KEY: JSON.stringify(process.env.DIM_API_KEY),
 
         $GOOGLE_DRIVE_CLIENT_ID: JSON.stringify(
           '22022180893-raop2mu1d7gih97t5da9vj26quqva9dc.apps.googleusercontent.com'

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -104,7 +104,7 @@ class FatalTokenError extends Error {
   }
 }
 
-async function getActiveToken(): Promise<Tokens> {
+export async function getActiveToken(): Promise<Tokens> {
   let token = getToken();
   if (!token) {
     removeToken();

--- a/src/app/bungie-api/oauth-tokens.ts
+++ b/src/app/bungie-api/oauth-tokens.ts
@@ -27,11 +27,13 @@ export interface Tokens {
  * Bungie.net OAuth.
  */
 
+const localStorageKey = 'authorization';
+
 /**
  * Get all token information from saved storage.
  */
 export function getToken(): Tokens | null {
-  const tokenString = localStorage.getItem('authorization');
+  const tokenString = localStorage.getItem(localStorageKey);
   return tokenString ? JSON.parse(tokenString) : null;
 }
 
@@ -39,14 +41,14 @@ export function getToken(): Tokens | null {
  * Save all the information about access/refresh tokens.
  */
 export function setToken(token: Tokens) {
-  localStorage.setItem('authorization', JSON.stringify(token));
+  localStorage.setItem(localStorageKey, JSON.stringify(token));
 }
 
 /**
  * Clear any saved token information.
  */
 export function removeToken() {
-  localStorage.removeItem('authorization');
+  localStorage.removeItem(localStorageKey);
 }
 
 /**

--- a/src/app/developer/Developer.tsx
+++ b/src/app/developer/Developer.tsx
@@ -1,20 +1,31 @@
 import React from 'react';
+import { parse } from 'simple-query-string';
+import { registerApp } from 'app/dim-api/register-app';
 
 interface State {
   apiKey?: string;
   clientId?: string;
   clientSecret?: string;
+  dimApiKey?: string;
+  dimAppName?: string;
 }
 
 export default class Developer extends React.Component<{}, State> {
-  state: State = {
-    apiKey: localStorage.getItem('apiKey') || undefined,
-    clientId: localStorage.getItem('oauthClientId') || undefined,
-    clientSecret: localStorage.getItem('oauthClientSecret') || undefined
-  };
+  constructor(props) {
+    super(props);
+    const urlParams = parse(window.location.href);
+    this.state = {
+      apiKey: localStorage.getItem('apiKey') || urlParams.apiKey || undefined,
+      clientId: localStorage.getItem('oauthClientId') || urlParams.oauthClientId || undefined,
+      clientSecret:
+        localStorage.getItem('oauthClientSecret') || urlParams.oauthClientSecret || undefined,
+      dimApiKey: localStorage.getItem('dimApiKey') || urlParams.dimApiKey || undefined,
+      dimAppName: localStorage.getItem('dimAppName') || urlParams.dimAppName || undefined
+    };
+  }
 
   render() {
-    const { apiKey, clientId, clientSecret } = this.state;
+    const { apiKey, clientId, clientSecret, dimAppName, dimApiKey } = this.state;
     const createAppUrl = 'https://www.bungie.net/en/Application/Create';
     const URL = window.location.origin;
     const URLRet = `${URL}/return.html`;
@@ -24,9 +35,20 @@ export default class Developer extends React.Component<{}, State> {
       warning = 'Bungie.net will not accept the http protocol. Serve over https:// and try again.';
     }
 
+    const prefillLink = `${URL}/developer?apiKey=${apiKey}&oauthClientId=${clientId}&oauthClientSecret=${clientSecret}&dimApiKey=${dimApiKey}&dimAppName=${dimAppName}`;
+
     return (
       <div className="dim-page">
         <h1>Developer Settings</h1>
+        <p>
+          To run DIM locally, you need to create and register your own personal app with both the
+          Bungie.net and DIM APIs.
+        </p>
+        {apiKey && clientId && clientSecret && dimAppName && dimApiKey && (
+          <a href={prefillLink}>
+            Open this link in another browser to clone these settings to DIM there
+          </a>
+        )}
         {warning ? (
           <div>
             <h3>Configuration Error</h3>
@@ -34,7 +56,7 @@ export default class Developer extends React.Component<{}, State> {
           </div>
         ) : (
           <form onSubmit={this.save}>
-            <h3>Configure API Key</h3>
+            <h3>Bungie.net API Key</h3>
             <ol>
               <li>
                 Visit{' '}
@@ -54,7 +76,8 @@ export default class Developer extends React.Component<{}, State> {
               </li>
               <li>Select "Confidential" OAuth type.</li>
               <li>
-                After saving, copy the "API Key" here{' '}
+                After saving, copy the "API Key" here:
+                <br />
                 <input
                   name="apiKey"
                   type="text"
@@ -64,7 +87,8 @@ export default class Developer extends React.Component<{}, State> {
                 />
               </li>
               <li>
-                Copy the "OAuth client_id" here{' '}
+                Copy the "OAuth client_id" here:
+                <br />
                 <input
                   name="clientId"
                   type="text"
@@ -74,7 +98,8 @@ export default class Developer extends React.Component<{}, State> {
                 />
               </li>
               <li>
-                Copy the "OAuth client_secret" here{' '}
+                Copy the "OAuth client_secret" here:
+                <br />
                 <input
                   name="clientSecret"
                   type="text"
@@ -83,22 +108,65 @@ export default class Developer extends React.Component<{}, State> {
                   size={50}
                 />
               </li>
+            </ol>
+
+            <h3>DIM API Key</h3>
+            <ol>
               <li>
-                <button>Save</button>
+                Choose a name for your DIM API app (only required to create or recover your API
+                key). This should be in the form of "yourname-dev" and will show up in API audit
+                logs.
+                <br />
+                <input
+                  name="dimAppName"
+                  type="text"
+                  value={dimAppName}
+                  onChange={this.onChange}
+                  size={25}
+                />
+                <button
+                  className="dim-button"
+                  onClick={this.getDimApiKey}
+                  disabled={!apiKey || !dimAppName || dimAppName.length < 6}
+                >
+                  Get API Key
+                </button>
+              </li>
+              <li>
+                DIM API key
+                <br />
+                <input
+                  name="clientSecret"
+                  type="dimApiKey"
+                  value={dimApiKey}
+                  size={36}
+                  readOnly={true}
+                />
               </li>
             </ol>
+            <button
+              className="dim-button"
+              disabled={!(apiKey && clientId && clientSecret && dimAppName && dimApiKey)}
+            >
+              Save API Keys
+            </button>
           </form>
         )}
       </div>
     );
   }
 
-  private save = () => {
-    const { apiKey, clientId, clientSecret } = this.state;
-    if (apiKey && clientId && clientSecret) {
+  private save = (e) => {
+    e.preventDefault();
+    const { apiKey, clientId, clientSecret, dimAppName, dimApiKey } = this.state;
+    if (apiKey && clientId && clientSecret && dimAppName && dimApiKey) {
       localStorage.setItem('apiKey', apiKey);
       localStorage.setItem('oauthClientId', clientId);
       localStorage.setItem('oauthClientSecret', clientSecret);
+      localStorage.setItem('dimAppName', dimAppName);
+      localStorage.setItem('dimApiKey', dimApiKey);
+      localStorage.removeItem('dimApiToken');
+      localStorage.removeItem('authorization');
       window.location.href = `${window.location.origin}/index.html`;
     } else {
       alert('You need to fill in the whole form');
@@ -111,5 +179,12 @@ export default class Developer extends React.Component<{}, State> {
     }
 
     this.setState({ [e.target.name]: e.target.value });
+  };
+
+  private getDimApiKey = async (e) => {
+    e.preventDefault();
+    const { apiKey, dimAppName } = this.state;
+    const app = await registerApp(dimAppName!, apiKey!);
+    this.setState({ dimApiKey: app.dimApiKey });
   };
 }

--- a/src/app/dim-api/dim-api-helper.ts
+++ b/src/app/dim-api/dim-api-helper.ts
@@ -1,11 +1,58 @@
 import { HttpClientConfig } from 'bungie-api-ts/http';
 import { stringify } from 'simple-query-string';
+import { router } from 'app/router';
+import { getActiveToken as getBungieToken } from 'app/bungie-api/authenticated-fetch';
+import { dedupePromise } from 'app/utils/util';
+
+const DIM_API_HOST = 'https://api.destinyitemmanager.com';
+export const API_KEY =
+  $DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta'
+    ? $DIM_API_KEY
+    : localStorage.getItem('dimApiKey')!;
 
 /**
  * Call one of the unauthenticated DIM APIs.
  */
-export async function unauthenticatedApi<T>(config: HttpClientConfig): Promise<T> {
-  let url = `https://api.destinyitemmanager.com${config.url}`;
+export async function unauthenticatedApi<T>(
+  config: HttpClientConfig,
+  noApiKey?: boolean
+): Promise<T> {
+  let url = `${DIM_API_HOST}${config.url}`;
+  if (config.params) {
+    url = `${url}?${stringify(config.params)}`;
+  }
+  const response = await fetch(
+    new Request(url, {
+      method: config.method,
+      body: config.body ? JSON.stringify(config.body) : undefined,
+      headers: noApiKey
+        ? {}
+        : config.body
+        ? {
+            'X-API-Key': API_KEY,
+            'Content-Type': 'application/json'
+          }
+        : {
+            'X-API-Key': API_KEY
+          }
+    })
+  );
+
+  return response.json() as Promise<T>;
+}
+
+/**
+ * Call one of the authenticated DIM APIs.
+ */
+export async function authenticatedApi<T>(config: HttpClientConfig): Promise<T> {
+  if (!API_KEY) {
+    router.stateService.go('developer');
+    throw new Error('No DIM API key configured');
+  }
+
+  const token = await getAuthToken();
+
+  let url = `${DIM_API_HOST}${config.url}`;
   if (config.params) {
     url = `${url}?${stringify(config.params)}`;
   }
@@ -15,13 +62,96 @@ export async function unauthenticatedApi<T>(config: HttpClientConfig): Promise<T
       body: config.body ? JSON.stringify(config.body) : undefined,
       headers: config.body
         ? {
-            // TODO: send an API Key
-            // 'X-API-Key': DIM_API_KEY,
+            Authorization: `Bearer ${token.accessToken}`,
+            'X-API-Key': API_KEY,
             'Content-Type': 'application/json'
           }
-        : undefined
+        : {
+            Authorization: `Bearer ${token.accessToken}`,
+            'X-API-Key': API_KEY
+          }
     })
   );
 
   return response.json() as Promise<T>;
+}
+
+export interface DimAuthToken {
+  /** Your DIM API access token, to be used in further requests. */
+  accessToken: string;
+  /** How many seconds from now the token will expire. */
+  expiresInSeconds: number;
+  /** A UTC epoch milliseconds timestamp representing when the token was acquired. */
+  inception: number;
+}
+
+const localStorageKey = 'dimApiToken';
+
+/**
+ * Get all token information from saved storage.
+ */
+function getToken(): DimAuthToken | undefined {
+  const tokenString = localStorage.getItem(localStorageKey);
+  return tokenString ? JSON.parse(tokenString) : undefined;
+}
+
+/**
+ * Save all the information about access/refresh tokens.
+ */
+function setToken(token: DimAuthToken) {
+  localStorage.setItem(localStorageKey, JSON.stringify(token));
+}
+
+export interface AuthTokenRequest {
+  /** The access token from authenticating with the Bungie.net API */
+  bungieAccessToken: string;
+  /** The user's Bungie.net membership ID */
+  membershipId: string;
+}
+
+const refreshToken = dedupePromise(async () => {
+  const bungieToken = await getBungieToken();
+  const authRequest: AuthTokenRequest = {
+    bungieAccessToken: bungieToken.accessToken.value,
+    membershipId: bungieToken.bungieMembershipId
+  };
+  try {
+    const authToken = await unauthenticatedApi<DimAuthToken>({
+      url: '/auth/token',
+      method: 'POST',
+      body: authRequest
+    });
+
+    authToken.inception = Date.now();
+    setToken(authToken);
+
+    return authToken;
+  } catch (e) {
+    if (!($DIM_FLAVOR === 'release' || $DIM_FLAVOR === 'beta')) {
+      router.stateService.go('developer');
+      throw new Error('DIM API Key Incorrect');
+    }
+    throw e;
+  }
+});
+
+async function getAuthToken(): Promise<DimAuthToken> {
+  const token = getToken();
+  if (!token || hasTokenExpired(token)) {
+    // Get a token!
+    return refreshToken();
+  }
+  return token;
+}
+
+/**
+ * Has the token expired, based on its 'expires' property?
+ */
+function hasTokenExpired(token?: DimAuthToken) {
+  if (!token) {
+    return true;
+  }
+  const expires = token.inception + token.expiresInSeconds * 1000;
+  const now = Date.now();
+  return now > expires;
 }

--- a/src/app/dim-api/register-app.ts
+++ b/src/app/dim-api/register-app.ts
@@ -1,0 +1,16 @@
+import { unauthenticatedApi } from './dim-api-helper';
+import { ApiApp } from '@destinyitemmanager/dim-api-types';
+
+export async function registerApp(dimAppName: string, bungieApiKey: string) {
+  const appResponse = await unauthenticatedApi<{ app: ApiApp }>({
+    url: '/new_app',
+    method: 'POST',
+    body: {
+      id: dimAppName,
+      bungieApiKey,
+      origin: window.location.origin
+    }
+  });
+
+  return appResponse.app;
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,7 @@ declare const $DIM_WEB_API_KEY: string;
 declare const $DIM_WEB_CLIENT_ID: string;
 declare const $DIM_WEB_CLIENT_SECRET: string;
 declare const $GOOGLE_DRIVE_CLIENT_ID: string;
+declare const $DIM_API_KEY: string;
 declare const $BROWSERS: string[];
 
 declare const $featureFlags: {


### PR DESCRIPTION
The first chunk of the DIM API usage changes!

This adds the ability for DIM developers to generate an "app" in the DIM API with their own API key that they can use to talk to the API from localhost. With the DIM API, I decided to treat it a lot like the Bungie.net API - there's one, public version of the API that all apps, even development apps, talk to. This means no more split storage between dev, beta and prod! For local developers, they can just click a button and get their own API key and app name registered with the API, which will be used when auditing where changes came from.

![Screen Shot 2020-03-03 at 11 14 03 PM](https://user-images.githubusercontent.com/313208/75854625-81fc3d00-5da5-11ea-9bb3-5c5db10335c4.jpg)

Before anyone points it out, yes, you can just enter someone else's app name and use it to get their API key. I could add protection to this by binding your Bungie.net account to your personal app, but that'd make the setup process for devs more complicated, and I'm not sure it's really worth it. Be nice, don't impersonate anyone. If I have to lock it down further, I will, and I'll invalidate everyone's keys when I do it.

Oh, and I also added a link to the top of the developer page that you can use to clone your development settings to another browser - just open that link in the other browser and it'll auto set up DIM. Should make cross browser testing easier.