### PR TITLE
Update faction.scss

### DIFF
--- a/src/app/progress/faction.scss
+++ b/src/app/progress/faction.scss
@@ -36,16 +36,18 @@
 }
 
 .item-faction {
-  border-radius: 50%;
-  background-color: #ddd;
-  color: black;
-  width: calc((var(--item-size) / 2.5));
-  height: calc((var(--item-size) / 2.5));
+  box-sizing: border-box;
+  border-radius: calc((var(--item-size) / 6));
+  min-width: calc((var(--item-size) / 3));
+  height: calc((var(--item-size) / 3));
   font-size: calc(#{$badge-font-size});
+  padding: 0 .2em;
   display: flex;
   align-items: center;
   justify-content: center;
   position: absolute;
-  bottom: -4px;
-  right: -4px;
+  bottom: calc((var(--item-size) / -12));
+  right: calc((var(--item-size) / -12));
+  background-color: #ddd;
+  color: black;
 }


### PR DESCRIPTION
css fix for vendor/faction level bubbles

this makes 2 digit numbers a circle and 3+ expand into rounded rectangles.
tightens up the height because they can get unwieldy at longer numbers and sort of photobomb the faction icon
![image](https://user-images.githubusercontent.com/31990469/76122142-3b2b6480-5faa-11ea-9a9c-3f7ff1d90a40.png)
