### PR TITLE
Add some more useful timers around major processes

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -185,7 +185,6 @@ function makeD2StoresService(): D2StoreServiceType {
    * Returns a promise for a fresh view of the stores and their items.
    */
   async function loadStores(account: DestinyAccount): Promise<D2Store[] | undefined> {
-    console.time('Load stores');
     // Save a snapshot of all the items before we update
     const previousItems = NewItemsService.buildItemSet(_stores);
 
@@ -199,6 +198,8 @@ function makeD2StoresService(): D2StoreServiceType {
         getItemInfoSource(account),
         getStores(account)
       ]);
+      console.time('Process inventory');
+
       NewItemsService.applyRemovedNewItems(newItems);
 
       // TODO: components may be hidden (privacy)
@@ -267,8 +268,11 @@ function makeD2StoresService(): D2StoreServiceType {
       document
         .querySelector('html')!
         .style.setProperty('--num-characters', String(_stores.length - 1));
+      console.timeEnd('Process inventory');
 
+      console.time('Inventory state update');
       store.dispatch(update({ stores, buckets, newItems, profileResponse: profileInfo }));
+      console.timeEnd('Inventory state update');
 
       return stores;
     } catch (e) {
@@ -280,8 +284,6 @@ function makeD2StoresService(): D2StoreServiceType {
       // around that with some rxjs operators, but it's easier to
       // just make this never fail.
       return undefined;
-    } finally {
-      console.timeEnd('Load stores');
     }
   }
 

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -105,6 +105,7 @@ class ManifestService {
   // This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
   private async doGetManifest(tableWhitelist: string[]) {
     try {
+      console.time('Load manifest');
       const manifest = await this.loadManifest(tableWhitelist);
       if (!manifest.DestinyVendorDefinition) {
         throw new Error('Manifest corrupted, please reload');
@@ -135,6 +136,8 @@ class ManifestService {
       console.error('Manifest loading error', { error: e }, e);
       reportException('manifest load', e);
       throw new Error(message);
+    } finally {
+      console.timeEnd('Load manifest');
     }
   }
 

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -10,11 +10,16 @@ let _blockNotes: string | undefined;
  * a wish list text file.
  */
 export function toWishList(fileText: string): WishListAndInfo {
-  return {
-    wishListRolls: toWishListRolls(fileText),
-    title: getTitle(fileText),
-    description: getDescription(fileText)
-  };
+  try {
+    console.time('Parse wish list');
+    return {
+      wishListRolls: toWishListRolls(fileText),
+      title: getTitle(fileText),
+      description: getDescription(fileText)
+    };
+  } finally {
+    console.timeEnd('Parse wish list');
+  }
 }
 
 function expectedMatchResultsLength(matchResults: RegExpMatchArray): boolean {


### PR DESCRIPTION
We've long had a timer around the whole process of fetching and processing stores, but that covers a bit too much. 

This PR adds timers around some of the most critical sections - loading manifest, transforming the inventory response into stores, parsing wish list, and applying the Redux inventory state update. FYI, that last one is where all our time is spent.

Hopefully this helps us avoid big regressions when we work on these (at least, until I can get live telemetry set up).

Inspired by @as-com's optimization work.