### PR TITLE
Improvements to search-restricted random loadout

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -604,6 +604,8 @@
     "Random": "Random",
     "Randomize": "Randomize",
     "RandomizePrompt": "Randomize your equipped class, weapons, armor and ghost?",
+    "RandomizeSearch": "Randomize from Search",
+    "RandomizeSearchPrompt": "Randomize your equipped items from search \"{{query}}\"?",
     "RandomizeWeapons": "Randomize your equipped class and weapons?",
     "RestoreAllItems": "All Items",
     "Save": "Save",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* You can now restrict what items get chosen by the random loadout feature by having an active search first. Try typing "tag:favorite" or "is:pulserifle" and then choosing Randomize.
+
 ## 5.72.0 <span className="changelog-date">(2020-03-01)</span>
 
 * Worked around a long-standing Bungie.net bug where items would change lock state when moved. One caveat is that DIM will always preserve the lock state as it sees it, so if you've locked/unlocked in game and haven't refreshed DIM, it may revert your lock.

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -242,11 +242,15 @@ class LoadoutPopup extends React.Component<Props> {
           <li className="loadout-set">
             <span onClick={this.randomLoadout}>
               <AppIcon icon={faRandom} />
-              <span>{t('Loadouts.Randomize')}</span>
+              <span>
+                {query.length > 0 ? t('Loadouts.RandomizeSearch') : t('Loadouts.Randomize')}
+              </span>
             </span>
-            <span onClick={(e) => this.randomLoadout(e, true)}>
-              <span>{t('Loadouts.WeaponsOnly')}</span>
-            </span>
+            {query.length === 0 && (
+              <span onClick={(e) => this.randomLoadout(e, true)}>
+                <span>{t('Loadouts.WeaponsOnly')}</span>
+              </span>
+            )}
           </li>
 
           {!dimStore.isVault && (
@@ -397,16 +401,25 @@ class LoadoutPopup extends React.Component<Props> {
   };
 
   private randomLoadout = (e, weaponsOnly = false) => {
-    const { dimStore } = this.props;
+    const { dimStore, searchFilter, query } = this.props;
     if (
-      !window.confirm(weaponsOnly ? t('Loadouts.RandomizeWeapons') : t('Loadouts.RandomizePrompt'))
+      !window.confirm(
+        weaponsOnly
+          ? t('Loadouts.RandomizeWeapons')
+          : query.length > 0
+          ? t('Loadouts.RandomizeSearchPrompt', { query })
+          : t('Loadouts.RandomizePrompt')
+      )
     ) {
       e.preventDefault();
       return;
     }
     let loadout;
     try {
-      loadout = randomLoadout(dimStore.getStoresService(), weaponsOnly);
+      loadout = randomLoadout(
+        dimStore.getStoresService(),
+        weaponsOnly ? (i) => i.bucket?.sort === 'Weapons' && searchFilter(i) : searchFilter
+      );
     } catch (e) {
       showNotification({ type: 'warning', title: t('Loadouts.Random'), body: e.message });
       return;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -137,7 +137,6 @@
       "MakeRoom": "Make room to pick up items by moving equipment",
       "Tooltip": "If checked, DIM will move weapons and armor around to make space in the vault for engrams."
     },
-    "MoveTokens": "Send reputation items to the vault",
     "OutOfRoom": "You're out of space to move items off of {{character}}. Time to decrypt some engrams and clear out the trash!",
     "OutOfRoomTitle": "Out of Room",
     "Stop": "Stop"
@@ -601,6 +600,8 @@
     "Random": "Random",
     "Randomize": "Randomize",
     "RandomizePrompt": "Randomize your equipped class, weapons, armor and ghost?",
+    "RandomizeSearch": "Randomize from Search",
+    "RandomizeSearchPrompt": "Randomize your equipped items from search \"{{query}}\"?",
     "RandomizeWeapons": "Randomize your equipped class and weapons?",
     "RestoreAllItems": "All Items",
     "Save": "Save",


### PR DESCRIPTION
Some improvements to the new search-based loadout feature:

1. Don't grab Redux store out of nowhere.
2. Change the label to "Randomize from Search" when a search is active and remove "Weapons" button when search is active.
3. Fold the weapons-only feature into the search feature.
4. Show a different prompt when randomizing from a search.

cc @maxlesser 