### PR TITLE
Don't dispatch Redux action for drag performance fix

### DIFF
--- a/src/app/inventory/DragPerformanceFix.scss
+++ b/src/app/inventory/DragPerformanceFix.scss
@@ -9,12 +9,14 @@
 
   z-index: 8;
 
+  display: none;
+
+  .drag-perf-show & {
+    display: block;
+  }
+
   .drag-perf-debug & {
     opacity: 0.1;
     background-color: red;
   }
-}
-
-.drag-perf-fix-hidden {
-  display: none;
 }

--- a/src/app/inventory/DragPerformanceFix.tsx
+++ b/src/app/inventory/DragPerformanceFix.tsx
@@ -1,35 +1,15 @@
 import React from 'react';
-import { RootState } from '../store/reducers';
-import { connect } from 'react-redux';
 import './DragPerformanceFix.scss';
-import clsx from 'clsx';
-import store from 'app/store/store';
-import { itemDrag } from 'app/inventory/actions';
-
-interface Props {
-  isDragging: boolean;
-}
-
-function mapStateToProps(state: RootState) {
-  return {
-    isDragging: state.inventory.isDragging
-  };
-}
 
 function hideOverlay() {
   // Rarely (possibly never in typical usage), a browser will forget to dispatch the dragEnd event
   // So we try not to trap the user here.
-  store.dispatch(itemDrag(false));
+  document.body.classList.remove('drag-perf-show');
 }
 
 /** This is a workaround for sluggish dragging in Chrome (and possibly other browsers) */
-function DragPerformanceFix(props: Props) {
-  return (
-    <div
-      className={clsx('drag-perf-fix', props.isDragging ? false : 'drag-perf-fix-hidden')}
-      onClick={hideOverlay}
-    />
-  );
+function DragPerformanceFix() {
+  return <div className="drag-perf-fix" onClick={hideOverlay} />;
 }
 
-export default connect<Props>(mapStateToProps)(DragPerformanceFix);
+export default DragPerformanceFix;

--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DragSourceSpec, DragSourceConnector, ConnectDragSource, DragSource } from 'react-dnd';
 import { DimItem } from './item-types';
-import { itemDrag, stackableDrag } from './actions';
+import { stackableDrag } from './actions';
 import store from '../store/store';
 import { BehaviorSubject } from 'rxjs';
 
@@ -33,16 +33,14 @@ let dragTimeout: number | null = null;
 const dragSpec: DragSourceSpec<Props, DragObject> = {
   beginDrag(props) {
     if (props.item.maxStackSize > 1 && props.item.amount > 1 && !props.item.uniqueStack) {
-      dragTimeout = requestAnimationFrame(() => {
-        dragTimeout = null;
-        store.dispatch(stackableDrag(true));
-      });
-    } else {
-      dragTimeout = requestAnimationFrame(() => {
-        dragTimeout = null;
-        store.dispatch(itemDrag(true));
-      });
+      store.dispatch(stackableDrag(true));
     }
+
+    dragTimeout = requestAnimationFrame(() => {
+      dragTimeout = null;
+      document.body.classList.add('drag-perf-show');
+    });
+
     isDragging = true;
     isDragging$.next(true);
     return { item: props.item };
@@ -55,9 +53,10 @@ const dragSpec: DragSourceSpec<Props, DragObject> = {
 
     if (props.item.maxStackSize > 1 && props.item.amount > 1 && !props.item.uniqueStack) {
       store.dispatch(stackableDrag(false));
-    } else {
-      store.dispatch(itemDrag(false));
     }
+
+    document.body.classList.remove('drag-perf-show');
+
     isDragging = false;
     isDragging$.next(false);
   },

--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -23,7 +23,7 @@
     box-shadow: inset 0 0 6px 0 rgba(200, 200, 200, 0.7);
   }
 
-  &.on-global-dragging:before {
+  &:before {
     content: '';
 
     opacity: 0;
@@ -35,9 +35,15 @@
 
     z-index: 9;
 
+    display: none;
+
     .drag-perf-debug & {
       opacity: 0.2;
       background-color: green;
+    }
+
+    .drag-perf-show & {
+      display: block;
     }
   }
 

--- a/src/app/inventory/StoreBucketDropTarget.tsx
+++ b/src/app/inventory/StoreBucketDropTarget.tsx
@@ -11,10 +11,6 @@ import { InventoryBucket } from './inventory-buckets';
 import { DimStore } from './store-types';
 import { DimItem } from './item-types';
 import moveDroppedItem from './move-dropped-item';
-import { connect } from 'react-redux';
-import { RootState } from 'app/store/reducers';
-import store from 'app/store/store';
-import { itemDrag } from 'app/inventory/actions';
 
 interface ExternalProps {
   bucket: InventoryBucket;
@@ -22,7 +18,6 @@ interface ExternalProps {
   equip?: boolean;
   children?: React.ReactNode;
   className?: string;
-  isDragging?: boolean;
 }
 
 // These are all provided by the DropTarget HOC function
@@ -79,16 +74,7 @@ class StoreBucketDropTarget extends React.Component<Props> {
   private element?: HTMLDivElement;
 
   render() {
-    const {
-      connectDropTarget,
-      children,
-      isOver,
-      canDrop,
-      equip,
-      className,
-      bucket,
-      isDragging
-    } = this.props;
+    const { connectDropTarget, children, isOver, canDrop, equip, className, bucket } = this.props;
 
     // TODO: I don't like that we're managing the classes for sub-bucket here
 
@@ -97,8 +83,7 @@ class StoreBucketDropTarget extends React.Component<Props> {
         ref={this.captureRef}
         className={clsx('sub-bucket', className, equip ? 'equipped' : 'unequipped', {
           'on-drag-hover': canDrop && isOver,
-          'on-drag-enter': canDrop,
-          'on-global-dragging': isDragging
+          'on-drag-enter': canDrop
         })}
         onClick={this.onClick}
         aria-label={bucket.name}
@@ -122,18 +107,8 @@ class StoreBucketDropTarget extends React.Component<Props> {
   };
 
   private onClick = () => {
-    if (this.props.isDragging) {
-      store.dispatch(itemDrag(false));
-    }
+    document.body.classList.remove('drag-perf-show');
   };
 }
 
-function mapStateToProps(state: RootState): any {
-  return {
-    isDragging: state.inventory.isDragging
-  };
-}
-
-export default connect(mapStateToProps)(
-  DropTarget(dragType, dropSpec, collect)(StoreBucketDropTarget)
-);
+export default DropTarget(dragType, dropSpec, collect)(StoreBucketDropTarget);

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -53,6 +53,3 @@ export const setTagsAndNotesForItem = createAction('tag_notes/UPDATE_ITEM')<{
 
 /** Notify that a stackable stack has begun or ended dragging. A bit overkill to put this in redux but eh. */
 export const stackableDrag = createAction('stackable_drag/DRAG')<boolean>();
-
-/** Notify that any item in the inventory view has begun or ended dragging. */
-export const itemDrag = createAction('item_drag/DRAG')<boolean>();

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -56,9 +56,6 @@ export interface InventoryState {
 
   /** Are we currently dragging a stack? */
   readonly isDraggingStack;
-
-  /** Are we currently dragging anything? */
-  readonly isDragging;
 }
 
 export type InventoryAction = ActionType<typeof actions>;
@@ -67,8 +64,7 @@ const initialState: InventoryState = {
   stores: [],
   newItems: new Set(),
   itemInfos: {},
-  isDraggingStack: false,
-  isDragging: false
+  isDraggingStack: false
 };
 
 export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction> = (
@@ -140,14 +136,7 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.stackableDrag):
       return {
         ...state,
-        isDraggingStack: action.payload,
-        isDragging: action.payload
-      };
-
-    case getType(actions.itemDrag):
-      return {
-        ...state,
-        isDragging: action.payload
+        isDraggingStack: action.payload
       };
 
     case getType(setCurrentAccount):


### PR DESCRIPTION
why didn't I think to do this earlier 🤦‍♂ 

tl;dr: Use CSS to show/hide the drag performance fix overlay rather than going through a bunch of Redux code. This reduces the initial dragging delay introduced by the initial performance fix.