### PR TITLE
Remove double-click to equip

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Improved drag and drop performance on some browsers.
+* Removed the behavior that equips an item when you double-click it - it was too hard to discover and surprising when triggered by accident.
 
 ## 5.72.0 <span className="changelog-date">(2020-03-01)</span>
 

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -18,7 +18,6 @@ interface ProvidedProps {
   innerRef?: React.Ref<HTMLDivElement>;
   onClick?(e): void;
   onShiftClick?(e): void;
-  onDoubleClick?(e): void;
 }
 
 // Props from Redux via mapStateToProps
@@ -54,8 +53,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
 type Props = ProvidedProps & StoreProps;
 
 /**
- * An item that can load its auxiliary state directly from Redux. Not suitable
- * for showing a ton of items, but useful!
+ * An item that can load its auxiliary state directly from Redux.
  */
 function ConnectedInventoryItem({
   item,
@@ -65,7 +63,6 @@ function ConnectedInventoryItem({
   rating,
   onClick,
   onShiftClick,
-  onDoubleClick,
   searchHidden,
   inventoryWishListRoll,
   wishListsEnabled,
@@ -81,7 +78,6 @@ function ConnectedInventoryItem({
       rating={rating}
       onClick={onClick}
       onShiftClick={onShiftClick}
-      onDoubleClick={onDoubleClick}
       searchHidden={searchHidden}
       wishListsEnabled={wishListsEnabled}
       inventoryWishListRoll={inventoryWishListRoll}

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -34,7 +34,6 @@ interface Props {
   /** TODO: item locked needs to be passed in */
   onClick?(e);
   onShiftClick?(e): void;
-  onDoubleClick?(e);
 }
 
 export default function InventoryItem({
@@ -49,7 +48,6 @@ export default function InventoryItem({
   ignoreSelectedPerks,
   onClick,
   onShiftClick,
-  onDoubleClick,
   innerRef
 }: Props) {
   const isCapped = item.maxStackSize > 1 && item.amount === item.maxStackSize && item.uniqueStack;
@@ -90,7 +88,6 @@ export default function InventoryItem({
     <div
       id={item.index}
       onClick={enhancedOnClick}
-      onDoubleClick={onDoubleClick}
       title={`${item.name}\n${item.typeName}`}
       className={clsx('item', itemStyles)}
       ref={innerRef}

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -2,49 +2,19 @@ import React from 'react';
 import { DimItem } from './item-types';
 import DraggableInventoryItem from './DraggableInventoryItem';
 import ItemPopupTrigger from './ItemPopupTrigger';
-import { CompareService } from '../compare/compare.service';
-import { moveItemTo } from './move-item';
 import ConnectedInventoryItem from './ConnectedInventoryItem';
-import { loadoutDialogOpen } from 'app/loadout/LoadoutDrawer';
-
-interface Props {
-  item: DimItem;
-}
 
 /**
  * The "full" inventory item, which can be dragged around and which pops up a move popup when clicked.
  */
-export default class StoreInventoryItem extends React.PureComponent<Props> {
-  render() {
-    const { item } = this.props;
-
-    return (
-      <DraggableInventoryItem item={item}>
-        <ItemPopupTrigger item={item}>
-          {(ref, onClick) => (
-            <ConnectedInventoryItem
-              item={item}
-              allowFilter={true}
-              innerRef={ref}
-              onClick={onClick}
-              onDoubleClick={this.doubleClicked}
-            />
-          )}
-        </ItemPopupTrigger>
-      </DraggableInventoryItem>
-    );
-  }
-
-  private doubleClicked = (e) => {
-    const item = this.props.item;
-    if (!loadoutDialogOpen && !CompareService.dialogOpen) {
-      e.stopPropagation();
-      const active = item.getStoresService().getActiveStore()!;
-
-      // Equip if it's not equipped or it's on another character
-      const equip = !item.equipped || item.owner !== active.id;
-
-      moveItemTo(item, active, item.canBeEquippedBy(active) ? equip : false, item.amount);
-    }
-  };
+export default function StoreInventoryItem({ item }: { item: DimItem }) {
+  return (
+    <DraggableInventoryItem item={item}>
+      <ItemPopupTrigger item={item}>
+        {(ref, onClick) => (
+          <ConnectedInventoryItem item={item} allowFilter={true} innerRef={ref} onClick={onClick} />
+        )}
+      </ItemPopupTrigger>
+    </DraggableInventoryItem>
+  );
 }


### PR DESCRIPTION
Removed the behavior that equips an item when you double-click it - it was too hard to discover and surprising when triggered by accident.