### PR TITLE
Rework loadouts to prepare for DIM API

### DIFF
--- a/src/app/accounts/destiny-account.ts
+++ b/src/app/accounts/destiny-account.ts
@@ -37,6 +37,20 @@ export const PLATFORM_LABELS = {
   [BungieMembershipType.BungieNext]: 'Bungie.net'
 };
 
+export const PLATFORM_LABEL_TO_MEMBERSHIP_TYPE = {
+  Xbox: BungieMembershipType.TigerXbox,
+  // t('Accounts.PlayStation')
+  PlayStation: BungieMembershipType.TigerPsn,
+  // t('Accounts.Blizzard')
+  Blizzard: BungieMembershipType.TigerBlizzard,
+  Demon: BungieMembershipType.TigerDemon,
+  // t('Accounts.Steam')
+  Steam: BungieMembershipType.TigerSteam,
+  // t('Accounts.Stadia')
+  Stadia: BungieMembershipType.TigerStadia,
+  'Bungie.net': BungieMembershipType.BungieNext
+};
+
 export const PLATFORM_ICONS = {
   [BungieMembershipType.TigerXbox]: faXbox,
   [BungieMembershipType.TigerPsn]: faPlaystation,

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -41,7 +41,6 @@ import LoadoutBuilderLockPerk from './LoadoutBuilderLockPerk';
 import ExcludeItemsDropTarget from './ExcludeItemsDropTarget';
 import { dimVendorService, Vendor } from '../vendors/vendor.service';
 import ErrorBoundary from '../../dim-ui/ErrorBoundary';
-import { filterLoadoutToEquipped } from '../../loadout/LoadoutPopup';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 interface StoreProps {
@@ -728,9 +727,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
 
   private lockEquipped = () => {
     const store = this.getSelectedCharacter();
-    const loadout = filterLoadoutToEquipped(store.loadoutFromCurrentlyEquipped(''));
-    const items = _.pick(
-      loadout.items,
+    const lockEquippedTypes = [
       'helmet',
       'gauntlets',
       'chest',
@@ -738,6 +735,15 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       'classitem',
       'artifact',
       'ghost'
+    ];
+    const items = _.groupBy(
+      store.items.filter(
+        (item) =>
+          item.canBeInLoadout() &&
+          item.equipped &&
+          lockEquippedTypes.includes(item.type.toLowerCase())
+      ),
+      (i) => i.type.toLowerCase()
     );
 
     function nullWithoutStats(items: DimItem[]) {

--- a/src/app/destiny1/loadout-builder/GeneratedSet.tsx
+++ b/src/app/destiny1/loadout-builder/GeneratedSet.tsx
@@ -10,7 +10,6 @@ import { AppIcon, faMinusSquare, faPlusSquare } from '../../shell/icons';
 import CharacterStats from '../../inventory/CharacterStats';
 import ItemTalentGrid from '../../item-popup/ItemTalentGrid';
 import { newLoadout } from '../../loadout/loadout-utils';
-import { LoadoutClass } from 'app/loadout/loadout-types';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
 import { applyLoadout } from 'app/loadout/loadout-apply';
 
@@ -122,7 +121,7 @@ export default class GeneratedSet extends React.Component<Props, State> {
     ).map((si) => si.item);
 
     const loadout = newLoadout('', items);
-    loadout.classType = LoadoutClass[this.props.store.class];
+    loadout.classType = this.props.store.classType;
     return loadout;
   };
 

--- a/src/app/destiny1/loadout-builder/GeneratedSet.tsx
+++ b/src/app/destiny1/loadout-builder/GeneratedSet.tsx
@@ -9,7 +9,7 @@ import LoadoutBuilderItem from './LoadoutBuilderItem';
 import { AppIcon, faMinusSquare, faPlusSquare } from '../../shell/icons';
 import CharacterStats from '../../inventory/CharacterStats';
 import ItemTalentGrid from '../../item-popup/ItemTalentGrid';
-import { newLoadout } from '../../loadout/loadout-utils';
+import { newLoadout, convertToLoadoutItem } from '../../loadout/loadout-utils';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
 import { applyLoadout } from 'app/loadout/loadout-apply';
 
@@ -120,7 +120,10 @@ export default class GeneratedSet extends React.Component<Props, State> {
       _.pick(set.armor, 'Helmet', 'Chest', 'Gauntlets', 'Leg', 'ClassItem', 'Ghost', 'Artifact')
     ).map((si) => si.item);
 
-    const loadout = newLoadout('', items);
+    const loadout = newLoadout(
+      '',
+      items.map((i) => convertToLoadoutItem(i, true))
+    );
     loadout.classType = this.props.store.classType;
     return loadout;
   };

--- a/src/app/destiny1/loadout-builder/GeneratedSet.tsx
+++ b/src/app/destiny1/loadout-builder/GeneratedSet.tsx
@@ -10,8 +10,7 @@ import { AppIcon, faMinusSquare, faPlusSquare } from '../../shell/icons';
 import CharacterStats from '../../inventory/CharacterStats';
 import ItemTalentGrid from '../../item-popup/ItemTalentGrid';
 import { newLoadout } from '../../loadout/loadout-utils';
-import copy from 'fast-copy';
-import { LoadoutClass, Loadout } from 'app/loadout/loadout-types';
+import { LoadoutClass } from 'app/loadout/loadout-types';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
 import { applyLoadout } from 'app/loadout/loadout-apply';
 
@@ -117,55 +116,21 @@ export default class GeneratedSet extends React.Component<Props, State> {
 
   private toggle = () => this.setState((state) => ({ collapsed: !state.collapsed }));
 
-  private newLoadout = (set: ArmorSet) => {
-    const loadout = newLoadout('', {});
-    loadout.classType = LoadoutClass[this.props.store.class];
-    const items = _.pick(
-      set.armor,
-      'Helmet',
-      'Chest',
-      'Gauntlets',
-      'Leg',
-      'ClassItem',
-      'Ghost',
-      'Artifact'
-    );
-    _.forIn(items, (itemContainer, itemType) => {
-      loadout.items[itemType.toString().toLowerCase()] = [itemContainer.item];
-    });
+  private makeLoadoutFromSet = (set: ArmorSet) => {
+    const items = Object.values(
+      _.pick(set.armor, 'Helmet', 'Chest', 'Gauntlets', 'Leg', 'ClassItem', 'Ghost', 'Artifact')
+    ).map((si) => si.item);
 
-    editLoadout(loadout, {
-      equipAll: true,
+    const loadout = newLoadout('', items);
+    loadout.classType = LoadoutClass[this.props.store.class];
+    return loadout;
+  };
+
+  private newLoadout = (set: ArmorSet) => {
+    editLoadout(this.makeLoadoutFromSet(set), {
       showClass: false
     });
   };
-  private equipItems = (set: ArmorSet) => {
-    let loadout: Loadout = newLoadout(t('Loadouts.AppliedAuto'), {});
-    loadout.classType = LoadoutClass[this.props.store.class];
-    const items = _.pick(
-      set.armor,
-      'Helmet',
-      'Chest',
-      'Gauntlets',
-      'Leg',
-      'ClassItem',
-      'Ghost',
-      'Artifact'
-    );
-    loadout.items.helmet = [items.Helmet.item];
-    loadout.items.chest = [items.Chest.item];
-    loadout.items.gauntlets = [items.Gauntlets.item];
-    loadout.items.leg = [items.Leg.item];
-    loadout.items.classitem = [items.ClassItem.item];
-    loadout.items.ghost = [items.Ghost.item];
-    loadout.items.artifact = [items.Artifact.item];
-
-    loadout = copy(loadout);
-
-    _.forIn(loadout.items, (val) => {
-      val[0].equipped = true;
-    });
-
-    return applyLoadout(this.props.store, loadout, true);
-  };
+  private equipItems = (set: ArmorSet) =>
+    applyLoadout(this.props.store, this.makeLoadoutFromSet(set), true);
 }

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -13,7 +13,7 @@ import { DimStore } from '../inventory/store-types';
 import { RootState } from '../store/reducers';
 import _ from 'lodash';
 import { reverseComparator, compareBy, chainComparator } from '../utils/comparators';
-import { newLoadout } from '../loadout/loadout-utils';
+import { newLoadout, convertToLoadoutItem } from '../loadout/loadout-utils';
 import { connect } from 'react-redux';
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
@@ -29,6 +29,7 @@ import { showNotification } from '../notifications/notifications';
 import { applyLoadout } from 'app/loadout/loadout-apply';
 import { settingsSelector } from 'app/settings/reducer';
 import { InfuseDirection } from '@destinyitemmanager/dim-api-types';
+import { LoadoutItem } from 'app/loadout/loadout-types';
 
 const itemComparator = chainComparator(
   reverseComparator(compareBy((item: DimItem) => item.primStat!.value)),
@@ -327,21 +328,15 @@ class InfusionFinder extends React.Component<Props, State> {
     onClose();
 
     const store = source.getStoresService().getActiveStore()!;
-    const items: { [key: string]: any[] } = {};
-    const targetKey = target.type.toLowerCase();
-    items[targetKey] = items[targetKey] || [];
-    const itemCopy = copy(target);
-    itemCopy.equipped = false;
-    items[targetKey].push(itemCopy);
-    // Include the source, since we wouldn't want it to get moved out of the way
-    const sourceKey = source.type.toLowerCase();
-    items[sourceKey] = items[sourceKey] || [];
-    items[sourceKey].push(source);
+    const items: LoadoutItem[] = [
+      convertToLoadoutItem(target, false),
+      // Include the source, since we wouldn't want it to get moved out of the way
+      convertToLoadoutItem(source, source.equipped)
+    ];
 
-    items.material = [];
     if (target.bucket.sort === 'General') {
       // Mote of Light
-      items.material.push({
+      items.push({
         id: '0',
         hash: 937555249,
         amount: 2,
@@ -349,7 +344,7 @@ class InfusionFinder extends React.Component<Props, State> {
       });
     } else if (source.isDestiny1() && source.primStat!.stat.statIdentifier === 'STAT_DAMAGE') {
       // Weapon Parts
-      items.material.push({
+      items.push({
         id: '0',
         hash: 1898539128,
         amount: 10,
@@ -357,7 +352,7 @@ class InfusionFinder extends React.Component<Props, State> {
       });
     } else {
       // Armor Materials
-      items.material.push({
+      items.push({
         id: '0',
         hash: 1542293174,
         amount: 10,
@@ -366,7 +361,7 @@ class InfusionFinder extends React.Component<Props, State> {
     }
     if (source.isExotic) {
       // Exotic shard
-      items.material.push({
+      items.push({
         id: '0',
         hash: 452597397,
         amount: 1,

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -369,6 +369,7 @@ class InfusionFinder extends React.Component<Props, State> {
       });
     }
 
+    // TODO: another one where we want to respect equipped
     const loadout = newLoadout(t('Infusion.InfusionMaterials'), items);
 
     await applyLoadout(store, loadout);

--- a/src/app/inventory/MoveNotifications.tsx
+++ b/src/app/inventory/MoveNotifications.tsx
@@ -47,7 +47,7 @@ export function loadoutNotification(
   store: DimStore,
   loadoutPromise: Promise<any>
 ): NotifyInput {
-  const count = _.sumBy(Object.values(loadout.items), (i) => i.length);
+  const count = loadout.items.length;
 
   // TODO: pass in a state updater that can communicate application state
 

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -6,8 +6,7 @@ import {
   DestinyProfileCollectiblesComponent,
   DestinyProfileResponse,
   DestinyGameVersions,
-  DestinyCollectibleComponent,
-  DestinyClass
+  DestinyCollectibleComponent
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { compareAccounts, DestinyAccount } from '../accounts/destiny-account';
@@ -17,14 +16,14 @@ import { getBuckets } from '../destiny2/d2-buckets';
 import { getDefinitions, D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { bungieNetPath } from '../dim-ui/BungieImage';
 import { reportException } from '../utils/exceptions';
-import { optimalLoadout, getLight } from '../loadout/loadout-utils';
+import { getLight } from '../loadout/loadout-utils';
 import { resetIdTracker, processItems } from './store/d2-item-factory';
 import { makeVault, makeCharacter } from './store/d2-store-factory';
 import { NewItemsService } from './store/new-items';
 import { getItemInfoSource, ItemInfoSource } from './dim-item-info';
 import { t } from 'app/i18next-t';
 import { D2Vault, D2Store, D2StoreServiceType, DimStore } from './store-types';
-import { DimItem, D2Item } from './item-types';
+import { DimItem } from './item-types';
 import { InventoryBuckets } from './inventory-buckets';
 import { fetchRatings } from '../item-review/destiny-tracker.service';
 import store from '../store/store';
@@ -38,6 +37,7 @@ import { distinctUntilChanged, switchMap, publishReplay, merge, take } from 'rxj
 import { getActivePlatform } from 'app/accounts/platforms';
 import helmetIcon from '../../../destiny-icons/armor_types/helmet.svg';
 import xpIcon from '../../images/xpIcon.svg';
+import { maxLightItemSet } from 'app/loadout/auto-loadouts';
 
 export function mergeCollectibles(
   profileCollectibles: SingleComponentResponse<DestinyProfileCollectiblesComponent>,
@@ -433,7 +433,7 @@ function makeD2StoresService(): D2StoreServiceType {
   ) {
     if (!store.isVault) {
       const def = defs.Stat.get(1935470627);
-      const maxBasePower = getLight(store, maxBasePowerLoadout(stores, store));
+      const maxBasePower = getLight(store, maxLightItemSet(stores, store));
       const hasClassified = _stores.some((s) =>
         s.items.some(
           (i) =>
@@ -441,6 +441,7 @@ function makeD2StoresService(): D2StoreServiceType {
             (i.location.sort === 'Weapons' || i.location.sort === 'Armor' || i.type === 'Ghost')
         )
       );
+      const maxPossibleBasePower = getCurrentMaxBasePower(account);
 
       store.stats.maxGearPower = {
         id: -3,
@@ -450,7 +451,7 @@ function makeD2StoresService(): D2StoreServiceType {
         value: maxPowerString(maxBasePower, hasClassified),
         icon: helmetIcon,
         tiers: [maxBasePower],
-        tierMax: getCurrentMaxBasePower(account)
+        tierMax: maxPossibleBasePower
       };
 
       const artifactPower = getArtifactBonus(store);
@@ -462,7 +463,7 @@ function makeD2StoresService(): D2StoreServiceType {
         value: artifactPower,
         icon: xpIcon,
         tiers: [maxBasePower],
-        tierMax: getCurrentMaxBasePower(account)
+        tierMax: maxPossibleBasePower
       };
 
       store.stats.maxTotalPower = {
@@ -473,7 +474,7 @@ function makeD2StoresService(): D2StoreServiceType {
         value: maxPowerString(maxBasePower, hasClassified, artifactPower),
         icon: bungieNetPath(def.displayProperties.icon),
         tiers: [maxBasePower],
-        tierMax: getCurrentMaxBasePower(account)
+        tierMax: maxPossibleBasePower
       };
     }
   }
@@ -492,49 +493,6 @@ function makeD2StoresService(): D2StoreServiceType {
       return D2SeasonInfo[D2SeasonEnum.RED_WAR].maxPower;
     }
     return D2SeasonInfo[D2SeasonEnum.FORSAKEN].maxPower;
-  }
-
-  function maxBasePowerLoadout(stores: D2Store[], store: D2Store) {
-    const statHashes = new Set([
-      1480404414, // Attack
-      3897883278 // Defense
-    ]);
-
-    const applicableItems = stores.flatMap((s) =>
-      s.items.filter(
-        (i) =>
-          (i.canBeEquippedBy(store) ||
-            (i.location.inPostmaster &&
-              (i.classType === DestinyClass.Unknown || i.classType === store.classType) &&
-              // nothing we are too low-level to equip
-              i.equipRequiredLevel <= store.level)) &&
-          i.primStat?.value && // has a primary stat (sanity check)
-          statHashes.has(i.primStat.statHash) // one of our selected stats
-      )
-    );
-
-    const bestItemFn = (item: D2Item) => {
-      let value = item.basePower;
-
-      // Break ties when items have the same stats. Note that this should only
-      // add less than 0.25 total, since in the exotics special case there can be
-      // three items in consideration and you don't want to go over 1 total.
-      if (item.owner === store.id) {
-        // Prefer items owned by this character
-        value += 0.1;
-        if (item.equipped) {
-          // Prefer them even more if they're already equipped
-          value += 0.1;
-        }
-      } else if (item.owner === 'vault') {
-        // Prefer items in the vault over items owned by a different character
-        // (but not as much as items owned by this character)
-        value += 0.05;
-      }
-      return value;
-    };
-
-    return optimalLoadout(applicableItems, bestItemFn, '');
   }
 
   // TODO: vault counts are silly and convoluted. We really need an

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -13,6 +13,7 @@ import { getRating } from '../item-review/reducer';
 import { DtrRating } from '../item-review/dtr-api-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { DimStore } from './store-types';
+import { getClass } from './store/character-utils';
 
 // step node names we'll hide, we'll leave "* Chroma" for now though, since we don't otherwise indicate Chroma
 const FILTER_NODE_NAMES = [
@@ -55,7 +56,9 @@ export function downloadCsvFiles(
   stores.forEach((store) => {
     allItems = allItems.concat(store.items);
     nameMap[store.id] =
-      store.id === 'vault' ? 'Vault' : `${capitalizeFirstLetter(store.class)}(${store.powerLevel})`;
+      store.id === 'vault'
+        ? 'Vault'
+        : `${capitalizeFirstLetter(getClass(store.classType))}(${store.powerLevel})`;
   });
   const items: DimItem[] = [];
   allItems.forEach((item) => {

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -138,9 +138,6 @@ export interface DimStore {
   /** Add an item to the store. */
   addItem(item: DimItem): void;
 
-  /** Create a loadout from this store's equipped items. */
-  loadoutFromCurrentlyEquipped(name: string): Loadout;
-
   /** Check if this store is from D1. Inside an if statement, this item will be narrowed to type D1Store. */
   isDestiny1(): this is D1Store;
   /* Check if this store is from D2. Inside an if statement, this item will be narrowed to type D2Store. */

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -116,7 +116,7 @@ export interface DimStore {
    * Get the total amount of this item in the store, across all stacks,
    * excluding stuff in the postmaster.
    */
-  amountOfItem(item: DimItem): number;
+  amountOfItem(item: { hash: number }): number;
   /**
    * How much of items like this item can fit in this store? For
    * stackables, this is in stacks, not individual pieces.

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -12,7 +12,6 @@ import { DimItem, D2Item, D1Item } from './item-types';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { InventoryBucket } from './inventory-buckets';
 import { ConnectableObservable } from 'rxjs';
-import { Loadout } from 'app/loadout/loadout-types';
 
 /**
  * A generic store service that produces stores and items that are the same across D1 and D2. Use this

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -87,9 +87,7 @@ export interface DimStore {
   percentToNextLevel: number;
   /** Power/light level. */
   powerLevel: number;
-  /** String class name. */
-  class: 'titan' | 'warlock' | 'hunter' | 'vault';
-  /** Integer class type. */
+  /** Enum class type. */
   classType: DestinyClass;
   /** Localized class name. */
   className: string;

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -2,6 +2,7 @@ import intellectIcon from 'images/intellect.png';
 import disciplineIcon from 'images/discipline.png';
 import strengthIcon from 'images/strength.png';
 import { D1CharacterStat } from '../store-types';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 // Cooldowns
 const cooldownsSuperA = ['5:00', '4:46', '4:31', '4:15', '3:58', '3:40'];
@@ -180,13 +181,13 @@ export function getAbilityCooldown(subclass, ability, tier) {
   }
 }
 
-export function getClass(type: number) {
+export function getClass(type: DestinyClass) {
   switch (type) {
-    case 0:
+    case DestinyClass.Titan:
       return 'titan';
-    case 1:
+    case DestinyClass.Hunter:
       return 'hunter';
-    case 2:
+    case DestinyClass.Warlock:
       return 'warlock';
   }
   return 'unknown';

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -2,14 +2,12 @@ import _ from 'lodash';
 import { count } from '../../utils/util';
 import { getCharacterStatsData, getClass } from './character-utils';
 import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions';
-import copy from 'fast-copy';
 import { t } from 'app/i18next-t';
 import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import { D1Store, D1Vault, DimVault } from '../store-types';
 import { D1Item } from '../item-types';
 import { D1StoresService } from '../d1-stores';
-import { newLoadout } from '../../loadout/loadout-utils';
 
 // Label isn't used, but it helps us understand what each one is
 const progressionMeta = {
@@ -122,16 +120,6 @@ const StoreProto = {
     this.items = [...this.items, item];
     this.buckets[item.location.id] = [...this.buckets[item.location.id], item];
     item.owner = this.id;
-  },
-
-  // Create a loadout from this store's equipped items
-  loadoutFromCurrentlyEquipped(this: D1Store, name: string) {
-    // tslint:disable-next-line:no-unnecessary-callback-wrapper
-    const allItems = this.items.filter((item) => item.canBeInLoadout()).map((item) => copy(item));
-    return newLoadout(
-      name,
-      _.groupBy(allItems, (i) => i.type.toLowerCase())
-    );
   },
 
   factionAlignment(this: D1Store) {

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { count } from '../../utils/util';
-import { getCharacterStatsData, getClass } from './character-utils';
+import { getCharacterStatsData } from './character-utils';
 import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions';
 import { t } from 'app/i18next-t';
 import vaultBackground from 'images/vault-background.svg';
@@ -8,6 +8,7 @@ import vaultIcon from 'images/vault.svg';
 import { D1Store, D1Vault, DimVault } from '../store-types';
 import { D1Item } from '../item-types';
 import { D1StoresService } from '../d1-stores';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 // Label isn't used, but it helps us understand what each one is
 const progressionMeta = {
@@ -209,7 +210,6 @@ export function makeCharacter(
     level: character.characterLevel,
     powerLevel: character.characterBase.powerLevel,
     stats: getCharacterStatsData(defs.Stat, character.characterBase),
-    class: getClass(character.characterBase.classType),
     classType: character.characterBase.classType,
     className,
     gender,
@@ -273,7 +273,7 @@ export function makeVault(
     destinyVersion: 1,
     id: 'vault',
     name: t('Bucket.Vault'),
-    class: 'vault',
+    classType: DestinyClass.Unknown,
     current: false,
     genderName: '',
     className: t('Bucket.Vault'),

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -44,7 +44,7 @@ const StoreProto = {
    * Get the total amount of this item in the store, across all stacks,
    * excluding stuff in the postmaster.
    */
-  amountOfItem(this: D1Store, item: D1Item) {
+  amountOfItem(this: D1Store, item: { hash: number }) {
     return _.sumBy(
       this.items.filter((i) => i.hash === item.hash && !i.location.inPostmaster),
       (i) => i.amount

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -8,7 +8,6 @@ import _ from 'lodash';
 import { bungieNetPath } from '../../dim-ui/BungieImage';
 import { count } from '../../utils/util';
 import { D2ManifestDefinitions, LazyDefinition } from '../../destiny2/d2-definitions';
-import { getClass } from './character-utils';
 import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import { t } from 'app/i18next-t';
@@ -201,7 +200,6 @@ export function makeCharacter(
       character.levelProgression.progressToNextLevel / character.levelProgression.nextLevelAt,
     powerLevel: character.light,
     stats: getCharacterStatsData(defs.Stat, character.stats),
-    class: getClass(classy.classType),
     classType: classy.classType,
     className,
     gender: genderLocalizedName,
@@ -228,7 +226,6 @@ export function makeVault(
     destinyVersion: 2,
     id: 'vault',
     name: t('Bucket.Vault'),
-    class: 'vault',
     classType: DestinyClass.Unknown,
     current: false,
     className: t('Bucket.Vault'),

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -33,7 +33,7 @@ const StoreProto = {
    * Get the total amount of this item in the store, across all stacks,
    * excluding stuff in the postmaster.
    */
-  amountOfItem(this: D2Store, item: D2Item) {
+  amountOfItem(this: D2Store, item: { hash: number }) {
     return _.sumBy(this.items, (i) =>
       i.hash === item.hash && (!i.location || !i.location.inPostmaster) ? i.amount : 0
     );

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -1,4 +1,3 @@
-import copy from 'fast-copy';
 import {
   DestinyCharacterComponent,
   DestinyItemComponent,
@@ -16,9 +15,7 @@ import { t } from 'app/i18next-t';
 import { D2Store, D2Vault, D2CharacterStat } from '../store-types';
 import { D2Item } from '../item-types';
 import { D2StoresService } from '../d2-stores';
-import { newLoadout } from '../../loadout/loadout-utils';
 import { armorStats } from './stats';
-import { Loadout } from 'app/loadout/loadout-types';
 
 /**
  * A factory service for producing "stores" (characters or the vault).
@@ -160,18 +157,6 @@ const StoreProto = {
     if (this.current && item.location.accountWide && this.vault) {
       this.vault.vaultCounts[item.location.id].count++;
     }
-  },
-
-  // Create a loadout from this store's equipped items
-  loadoutFromCurrentlyEquipped(this: D2Store, name: string): Loadout {
-    const allItems = this.items
-      .filter((item) => item.canBeInLoadout())
-      // tslint:disable-next-line:no-unnecessary-callback-wrapper
-      .map((item) => copy(item));
-    return newLoadout(
-      name,
-      _.groupBy(allItems, (i) => i.type.toLowerCase())
-    );
   },
 
   isDestiny1(this: D2Store) {

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -2,7 +2,7 @@ import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import React from 'react';
 import { DimStore } from '../../inventory/store-types';
-import { newLoadout } from '../../loadout/loadout-utils';
+import { newLoadout, convertToLoadoutItem } from '../../loadout/loadout-utils';
 import { ArmorSet } from '../types';
 import styles from './GeneratedSetButtons.m.scss';
 import { Loadout } from 'app/loadout/loadout-types';
@@ -52,7 +52,10 @@ export default function GeneratedSetButtons({
  */
 function createLoadout(classType: DestinyClass, set: ArmorSet): Loadout {
   const data = { ...set.stats, tier: _.sum(Object.values(set.stats)) };
-  const loadout = newLoadout(t('Loadouts.Generated', data), set.firstValidSet);
+  const loadout = newLoadout(
+    t('Loadouts.Generated', data),
+    set.firstValidSet.map((i) => convertToLoadoutItem(i, true))
+  );
   loadout.classType = classType;
   return loadout;
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -5,7 +5,6 @@ import { DimStore } from '../../inventory/store-types';
 import { newLoadout } from '../../loadout/loadout-utils';
 import { ArmorSet } from '../types';
 import styles from './GeneratedSetButtons.m.scss';
-import copy from 'fast-copy';
 import { Loadout, LoadoutClass } from 'app/loadout/loadout-types';
 import { applyLoadout } from 'app/loadout/loadout-apply';
 
@@ -52,18 +51,7 @@ export default function GeneratedSetButtons({
  */
 function createLoadout(classType: DimStore['class'], set: ArmorSet): Loadout {
   const data = { ...set.stats, tier: _.sum(Object.values(set.stats)) };
-  const loadout = newLoadout(
-    t('Loadouts.Generated', data),
-    _.zipObject(
-      ['helmet', 'gauntlets', 'chest', 'leg', 'classitem', 'ghost'],
-      set.firstValidSet.map((i) => [copy(i)])
-    )
-  );
+  const loadout = newLoadout(t('Loadouts.Generated', data), set.firstValidSet);
   loadout.classType = LoadoutClass[classType];
-
-  _.forIn(loadout.items, (val) => {
-    val[0].equipped = true;
-  });
-
   return loadout;
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -5,8 +5,9 @@ import { DimStore } from '../../inventory/store-types';
 import { newLoadout } from '../../loadout/loadout-utils';
 import { ArmorSet } from '../types';
 import styles from './GeneratedSetButtons.m.scss';
-import { Loadout, LoadoutClass } from 'app/loadout/loadout-types';
+import { Loadout } from 'app/loadout/loadout-types';
 import { applyLoadout } from 'app/loadout/loadout-apply';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 /**
  * Renders the Create Loadout and Equip Items buttons for each generated set
@@ -24,12 +25,12 @@ export default function GeneratedSetButtons({
 }) {
   // Opens the loadout menu for the generated set
   const openLoadout = () => {
-    onLoadoutSet(createLoadout(store.class, set));
+    onLoadoutSet(createLoadout(store.classType, set));
   };
 
   // Automatically equip items for this generated set to the active store
   const equipItems = () => {
-    const loadout = createLoadout(store.class, set);
+    const loadout = createLoadout(store.classType, set);
     return applyLoadout(store, loadout, true);
   };
 
@@ -49,9 +50,9 @@ export default function GeneratedSetButtons({
 /**
  * Create a Loadout object, used for equipping or creating a new saved loadout
  */
-function createLoadout(classType: DimStore['class'], set: ArmorSet): Loadout {
+function createLoadout(classType: DestinyClass, set: ArmorSet): Loadout {
   const data = { ...set.stats, tier: _.sum(Object.values(set.stats)) };
   const loadout = newLoadout(t('Loadouts.Generated', data), set.firstValidSet);
-  loadout.classType = LoadoutClass[classType];
+  loadout.classType = classType;
   return loadout;
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -112,7 +112,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
           </span>
           <button
             className={`dim-button ${styles.newLoadout}`}
-            onClick={() => editLoadout(newLoadout('', {}), { showClass: true, isNew: true })}
+            onClick={() => editLoadout(newLoadout('', []), { showClass: true, isNew: true })}
           >
             {t('LoadoutBuilder.NewEmptyLoadout')}
           </button>

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -149,7 +149,6 @@ class LoadoutDrawer extends React.Component<Props, State> {
   }
 
   render() {
-    console.log('Render Loadout Drawer');
     const { buckets, classTypeOptions, stores, itemSortOrder } = this.props;
     const { show, loadout, showClass, isNew, clashingLoadout } = this.state;
 

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -279,7 +279,6 @@ class LoadoutDrawer extends React.Component<Props, State> {
     }
     loadout.items = loadout.items || {};
     loadout.destinyVersion = account.destinyVersion;
-    loadout.platform = account.platformLabel;
     loadout.membershipId = account.membershipId;
 
     this.setState({

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -367,9 +367,8 @@ class LoadoutDrawer extends React.Component<Props, State> {
           });
         }
       } else if (dupe && item.maxStackSize > 1) {
-        const increment =
-          Math.min((dupe.amount || 1) + item.amount, item.maxStackSize) - (dupe.amount || 1);
-        dupe.amount = (dupe.amount || 1) + increment;
+        const increment = Math.min(dupe.amount + item.amount, item.maxStackSize) - dupe.amount;
+        dupe.amount = dupe.amount + increment;
         // TODO: handle stack splits
       }
 

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -10,7 +10,7 @@ import uuidv4 from 'uuid/v4';
 import { D2Categories } from '../destiny2/d2-buckets';
 import { D1Categories } from '../destiny1/d1-buckets';
 import { router } from '../router';
-import { RootState } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from '../store/reducers';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -85,7 +85,7 @@ interface StoreProps {
   buckets: InventoryBuckets;
 }
 
-type Props = StoreProps;
+type Props = StoreProps & ThunkDispatchProp;
 
 interface State {
   loadout?: Loadout;
@@ -403,17 +403,21 @@ class LoadoutDrawer extends React.Component<Props, State> {
     this.setState({ loadout });
   };
 
-  private saveLoadout = (e) => {
+  private saveLoadout = async (e) => {
     e.preventDefault();
+    const { dispatch } = this.props;
     const { loadout } = this.state;
     if (!loadout) {
       return;
     }
 
     this.close();
-    saveLoadout(loadout)
-      .then(this.handleLoadOutSaveResult)
-      .catch((e) => this.handleLoadoutError(e, loadout.name));
+    try {
+      const clashingLoadout = await dispatch(saveLoadout(loadout));
+      this.handleLoadOutSaveResult(clashingLoadout);
+    } catch (e) {
+      this.handleLoadoutError(e, loadout.name);
+    }
   };
 
   private handleLoadOutSaveResult = (clashingLoadout?: Loadout) => {

--- a/src/app/loadout/LoadoutDrawerBucket.tsx
+++ b/src/app/loadout/LoadoutDrawerBucket.tsx
@@ -3,42 +3,43 @@ import { DimItem } from '../inventory/item-types';
 import { InventoryBucket } from '../inventory/inventory-buckets';
 import { AppIcon, addIcon } from '../shell/icons';
 import LoadoutDrawerItem from './LoadoutDrawerItem';
-import { Loadout } from './loadout-types';
+import { LoadoutItem } from './loadout-types';
 import { sortItems } from '../shell/filters';
 
-export default function LoadoutDrawerBucket(
-  this: never,
-  {
-    bucket,
-    loadout,
-    itemSortOrder,
-    pickLoadoutItem,
-    equip,
-    remove
-  }: {
-    bucket: InventoryBucket;
-    loadout: Loadout;
-    itemSortOrder: string[];
-    pickLoadoutItem(bucket: InventoryBucket): void;
-    equip(item: DimItem, e: React.MouseEvent): void;
-    remove(item: DimItem, e: React.MouseEvent): void;
-  }
-) {
+export default function LoadoutDrawerBucket({
+  bucket,
+  loadoutItems,
+  items,
+  itemSortOrder,
+  pickLoadoutItem,
+  equip,
+  remove
+}: {
+  bucket: InventoryBucket;
+  loadoutItems: LoadoutItem[];
+  items: DimItem[];
+  itemSortOrder: string[];
+  pickLoadoutItem(bucket: InventoryBucket): void;
+  equip(item: DimItem, e: React.MouseEvent): void;
+  remove(item: DimItem, e: React.MouseEvent): void;
+}) {
   if (!bucket.type) {
     return null;
   }
 
-  const loadoutItems = loadout.items[bucket.type.toLowerCase()] || [];
-
-  const equippedItem = loadoutItems.find((i) => i.equipped);
+  const equippedItem = items.find((i) =>
+    loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && li.equipped)
+  );
   const unequippedItems = sortItems(
-    loadoutItems.filter((i) => !i.equipped),
+    items.filter((i) =>
+      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && !li.equipped)
+    ),
     itemSortOrder
   );
 
   return (
     <div className="loadout-bucket">
-      {loadoutItems.length > 0 ? (
+      {equippedItem || unequippedItems.length > 0 ? (
         <>
           <div className="loadout-bucket-name">{bucket.name}</div>
           <div className={`loadout-bucket-items bucket-${bucket.type}`}>

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Loadout, loadoutClassToClassType, LoadoutClass } from './loadout-types';
+import { Loadout } from './loadout-types';
 import _ from 'lodash';
 import { AppIcon, addIcon } from '../shell/icons';
 import LoadoutDrawerBucket from './LoadoutDrawerBucket';
@@ -142,7 +142,7 @@ async function pickLoadoutItem(
   bucket: InventoryBucket,
   add: (item: DimItem, e?: MouseEvent, equip?: boolean) => void
 ) {
-  const loadoutClassType = loadout && loadoutClassToClassType[loadout.classType];
+  const loadoutClassType = loadout?.classType;
 
   function loadoutHasItem(item: DimItem) {
     return loadout && loadout.items.some((i) => i.id === item.id && i.hash === i.hash);
@@ -155,7 +155,7 @@ async function pickLoadoutItem(
       filterItems: (item: DimItem) =>
         item.bucket.id === bucket.id &&
         (!loadout ||
-          loadout.classType === LoadoutClass.any ||
+          loadout.classType === DestinyClass.Unknown ||
           item.classType === loadoutClassType ||
           item.classType === DestinyClass.Unknown) &&
         item.canBeInLoadout() &&
@@ -182,11 +182,10 @@ function fillLoadoutFromEquipped(
     return;
   }
 
-  const loadoutClass = loadout && loadoutClassToClassType[loadout.classType];
-
   // TODO: need to know which character "launched" the builder
   const dimStore =
-    (loadoutClass !== DestinyClass.Unknown && stores.find((s) => s.classType === loadoutClass)) ||
+    (loadout.classType !== DestinyClass.Unknown &&
+      stores.find((s) => s.classType === loadout.classType)) ||
     stores.find((s) => s.current)!;
 
   const items = dimStore.items.filter(

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -8,7 +8,6 @@ import { DimItem } from '../inventory/item-types';
 import { showItemPicker } from '../item-picker/item-picker';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { t } from 'app/i18next-t';
-import { filterLoadoutToEquipped } from './LoadoutPopup';
 import { DimStore } from '../inventory/store-types';
 
 const loadoutTypes = [
@@ -42,7 +41,7 @@ const loadoutTypes = [
 
 // We don't want to prepopulate the loadout with a bunch of cosmetic junk
 // like emblems and ships and horns.
-const fromEquippedTypes = [
+export const fromEquippedTypes = [
   'class',
   'kinetic',
   'energy',
@@ -64,6 +63,7 @@ export default function LoadoutDrawerContents(
   {
     loadout,
     buckets,
+    items,
     stores,
     itemSortOrder,
     equip,
@@ -73,25 +73,25 @@ export default function LoadoutDrawerContents(
     loadout: Loadout;
     buckets: InventoryBuckets;
     stores: DimStore[];
+    items: DimItem[];
     itemSortOrder: string[];
     equip(item: DimItem, e: React.MouseEvent): void;
     remove(item: DimItem, e: React.MouseEvent): void;
     add(item: DimItem, e?: MouseEvent, equip?: boolean): void;
   }
 ) {
+  const itemsByBucket = _.groupBy(items, (i) => i.bucket.id);
+
   function doFillLoadoutFromEquipped(e: React.MouseEvent) {
     e.preventDefault();
-    fillLoadoutFromEquipped(loadout, stores, add);
+    fillLoadoutFromEquipped(loadout, itemsByBucket, stores, add);
   }
 
   const availableTypes = _.compact(loadoutTypes.map((type) => buckets.byType[type]));
 
   const [typesWithItems, typesWithoutItems] = _.partition(
     availableTypes,
-    (bucket) =>
-      bucket.type &&
-      loadout.items[bucket.type.toLowerCase()] &&
-      loadout.items[bucket.type.toLowerCase()].length
+    (bucket) => bucket.id && itemsByBucket[bucket.id] && itemsByBucket[bucket.id].length
   );
 
   const showFillFromEquipped = typesWithoutItems.some((b) =>
@@ -110,7 +110,7 @@ export default function LoadoutDrawerContents(
           {typesWithoutItems.map((bucket) => (
             <a
               key={bucket.type}
-              onClick={() => pickLoadoutItem(loadout, bucket, add)}
+              onClick={() => pickLoadoutItem(loadout, itemsByBucket, bucket, add)}
               className="dim-button loadout-add"
             >
               <AppIcon icon={addIcon} /> {bucket.name}
@@ -123,9 +123,10 @@ export default function LoadoutDrawerContents(
           <LoadoutDrawerBucket
             key={bucket.type}
             bucket={bucket}
-            loadout={loadout}
+            loadoutItems={loadout.items}
+            items={itemsByBucket[bucket.id] || []}
             itemSortOrder={itemSortOrder}
-            pickLoadoutItem={(bucket) => pickLoadoutItem(loadout, bucket, add)}
+            pickLoadoutItem={(bucket) => pickLoadoutItem(loadout, itemsByBucket, bucket, add)}
             equip={equip}
             remove={remove}
           />
@@ -137,20 +138,17 @@ export default function LoadoutDrawerContents(
 
 async function pickLoadoutItem(
   loadout: Loadout,
+  itemsByBucket: { [bucketId: string]: DimItem[] },
   bucket: InventoryBucket,
   add: (item: DimItem, e?: MouseEvent, equip?: boolean) => void
 ) {
   const loadoutClassType = loadout && loadoutClassToClassType[loadout.classType];
 
   function loadoutHasItem(item: DimItem) {
-    return (
-      loadout &&
-      loadout.items[item.bucket.type!.toLowerCase()] &&
-      loadout.items[item.bucket.type!.toLowerCase()].some((i) => i.id === item.id)
-    );
+    return loadout && loadout.items.some((i) => i.id === item.id && i.hash === i.hash);
   }
 
-  const hasEquippedItem = (loadout.items[bucket.type!.toLowerCase()] || []).some((i) => i.equipped);
+  const hasEquippedItem = (itemsByBucket[bucket.id] || []).some((i) => i.equipped);
 
   try {
     const { item, equip } = await showItemPicker({
@@ -176,6 +174,7 @@ async function pickLoadoutItem(
 
 function fillLoadoutFromEquipped(
   loadout: Loadout,
+  itemsByBucket: { [bucketId: string]: DimItem[] },
   stores: DimStore[],
   add: (item: DimItem, e?: MouseEvent, equip?: boolean) => void
 ) {
@@ -190,12 +189,13 @@ function fillLoadoutFromEquipped(
     (loadoutClass !== DestinyClass.Unknown && stores.find((s) => s.classType === loadoutClass)) ||
     stores.find((s) => s.current)!;
 
-  const equippedLoadout = filterLoadoutToEquipped(dimStore.loadoutFromCurrentlyEquipped(''));
-  equippedLoadout.items = _.pick(equippedLoadout.items, ...fromEquippedTypes);
+  const items = dimStore.items.filter(
+    (item) => item.canBeInLoadout() && item.equipped && fromEquippedTypes.includes(item.type)
+  );
 
-  _.forIn(equippedLoadout.items, (items, type) => {
-    if (items.length && (!loadout.items[type] || !loadout.items[type].some((i) => i.equipped))) {
+  for (const item of items) {
+    if (!itemsByBucket[item.bucket.id] || !itemsByBucket[item.bucket.id].some((i) => i.equipped)) {
       add(items[0], undefined, true);
     }
-  });
+  }
 }

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -4,30 +4,27 @@ import _ from 'lodash';
 import { Loadout } from './loadout-types';
 import { router } from '../router';
 
-export default function LoadoutDrawerOptions(
-  this: void,
-  {
-    loadout,
-    showClass,
-    isNew,
-    classTypeOptions,
-    updateLoadout,
-    saveLoadout,
-    saveAsNew
-  }: {
-    loadout?: Loadout;
-    showClass: boolean;
-    isNew: boolean;
-    clashingLoadout?: Loadout;
-    classTypeOptions: {
-      label: string;
-      value: number;
-    }[];
-    updateLoadout(loadout: Loadout);
-    saveLoadout(e);
-    saveAsNew(e);
-  }
-) {
+export default function LoadoutDrawerOptions({
+  loadout,
+  showClass,
+  isNew,
+  classTypeOptions,
+  updateLoadout,
+  saveLoadout,
+  saveAsNew
+}: {
+  loadout?: Loadout;
+  showClass: boolean;
+  isNew: boolean;
+  clashingLoadout?: Loadout;
+  classTypeOptions: {
+    label: string;
+    value: number;
+  }[];
+  updateLoadout(loadout: Loadout);
+  saveLoadout(e);
+  saveAsNew(e);
+}) {
   if (!loadout) {
     return null;
   }

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -3,6 +3,7 @@ import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import { Loadout } from './loadout-types';
 import { router } from '../router';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 export default function LoadoutDrawerOptions({
   loadout,
@@ -19,7 +20,7 @@ export default function LoadoutDrawerOptions({
   clashingLoadout?: Loadout;
   classTypeOptions: {
     label: string;
-    value: number;
+    value: DestinyClass;
   }[];
   updateLoadout(loadout: Loadout);
   saveLoadout(e);

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -81,10 +81,7 @@ export default function LoadoutDrawerOptions({
           )}
         </div>
         <div className="input-group">
-          <button
-            className="dim-button"
-            disabled={!loadout.name.length || _.isEmpty(loadout.items)}
-          >
+          <button className="dim-button" disabled={!loadout.name.length || !loadout.items.length}>
             {t('Loadouts.Save')}
           </button>
           {!isNew && (

--- a/src/app/loadout/LoadoutEditPopup.tsx
+++ b/src/app/loadout/LoadoutEditPopup.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { t } from 'app/i18next-t';
-import { getLoadoutClassDisplay, LoadoutClass } from './loadout-types';
+import { getLoadoutClassDisplay } from './loadout-types';
 import './loadout-edit-popup.scss';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 interface Props {
-  loadoutClass: LoadoutClass;
+  loadoutClass: DestinyClass;
   loadoutName: string;
   changeNameHandler(): void;
   editHandler(): void;
 }
 
-function getAlreadyExistsTranslation(loadoutClassType: number) {
+function getAlreadyExistsTranslation(loadoutClassType: DestinyClass) {
   if (loadoutClassType >= 0) {
     const className = getLoadoutClassDisplay(loadoutClassType);
     return t('Loadouts.AlreadyExistsClass', { className });

--- a/src/app/loadout/LoadoutEditPopup.tsx
+++ b/src/app/loadout/LoadoutEditPopup.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { t } from 'app/i18next-t';
-import { getLoadoutClassDisplay } from './loadout-types';
 import './loadout-edit-popup.scss';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { getClass } from 'app/inventory/store/character-utils';
 
 interface Props {
   loadoutClass: DestinyClass;
@@ -12,8 +12,8 @@ interface Props {
 }
 
 function getAlreadyExistsTranslation(loadoutClassType: DestinyClass) {
-  if (loadoutClassType >= 0) {
-    const className = getLoadoutClassDisplay(loadoutClassType);
+  if (loadoutClassType !== DestinyClass.Unknown) {
+    const className = getClass(loadoutClassType);
     return t('Loadouts.AlreadyExistsClass', { className });
   }
 

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -79,7 +79,7 @@ interface StoreProps {
   previousLoadout?: Loadout;
   loadouts: Loadout[];
   query: string;
-  classTypeId: number;
+  classTypeId: DestinyClass;
   stores: DimStore[];
   searchFilter(item: DimItem): boolean;
 }
@@ -94,12 +94,9 @@ function mapStateToProps() {
       _.sortBy(
         loadouts.filter(
           (loadout) =>
-            (dimStore.destinyVersion === 2
-              ? loadout.destinyVersion === 2
-              : loadout.destinyVersion !== 2) &&
-            (dimStore.classType === DestinyClass.Unknown ||
-              loadout.classType === DestinyClass.Unknown ||
-              loadout.classType === dimStore.classType)
+            dimStore.classType === DestinyClass.Unknown ||
+            loadout.classType === DestinyClass.Unknown ||
+            loadout.classType === dimStore.classType
         ),
         (l) => l.name
       )

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -54,18 +54,19 @@ import { showNotification } from '../notifications/notifications';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { createSelector } from 'reselect';
 import { getArtifactBonus, maxPowerString } from 'app/inventory/d2-stores';
-import { LoadoutClass, Loadout } from './loadout-types';
+import { Loadout } from './loadout-types';
 import { editLoadout } from './LoadoutDrawer';
 import { deleteLoadout } from './loadout-storage';
 import { applyLoadout } from './loadout-apply';
 import { fromEquippedTypes } from './LoadoutDrawerContents';
 import { storesSelector } from 'app/inventory/reducer';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 const loadoutIcon = {
-  [LoadoutClass.any]: globeIcon,
-  [LoadoutClass.hunter]: hunterIcon,
-  [LoadoutClass.warlock]: warlockIcon,
-  [LoadoutClass.titan]: titanIcon
+  [DestinyClass.Unknown]: globeIcon,
+  [DestinyClass.Hunter]: hunterIcon,
+  [DestinyClass.Warlock]: warlockIcon,
+  [DestinyClass.Titan]: titanIcon
 };
 
 interface ProvidedProps {
@@ -89,35 +90,30 @@ function mapStateToProps() {
   const loadoutsForPlatform = createSelector(
     loadoutsSelector,
     (_, { dimStore }: ProvidedProps) => dimStore,
-    (loadouts, dimStore) => {
-      const classTypeId = LoadoutClass[dimStore.class === 'vault' ? 'any' : dimStore.class];
-
-      return _.sortBy(
+    (loadouts, dimStore) =>
+      _.sortBy(
         loadouts.filter(
           (loadout) =>
             (dimStore.destinyVersion === 2
               ? loadout.destinyVersion === 2
               : loadout.destinyVersion !== 2) &&
-            (classTypeId === LoadoutClass.any ||
-              loadout.classType === LoadoutClass.any ||
-              loadout.classType === classTypeId)
+            (dimStore.classType === DestinyClass.Unknown ||
+              loadout.classType === DestinyClass.Unknown ||
+              loadout.classType === dimStore.classType)
         ),
         (l) => l.name
-      );
-    }
+      )
   );
 
   return (state: RootState, ownProps: ProvidedProps): StoreProps => {
     const { dimStore } = ownProps;
-
-    const classTypeId = LoadoutClass[dimStore.class === 'vault' ? 'any' : dimStore.class];
 
     return {
       previousLoadout: previousLoadoutSelector(state, ownProps.dimStore.id),
       loadouts: loadoutsForPlatform(state, ownProps),
       query: querySelector(state),
       searchFilter: searchFilterSelector(state),
-      classTypeId,
+      classTypeId: dimStore.classType,
       account: currentAccountSelector(state)!,
       stores: storesSelector(state)
     };

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -18,7 +18,7 @@ import {
   maxLightItemSet
 } from './auto-loadouts';
 import { querySelector } from '../shell/reducer';
-import { newLoadout, getLight } from './loadout-utils';
+import { newLoadout, getLight, convertToLoadoutItem } from './loadout-utils';
 import { D1FarmingService } from '../farming/farming.service';
 import { D2FarmingService } from '../farming/d2farming.service';
 import {
@@ -308,7 +308,10 @@ class LoadoutPopup extends React.Component<Props> {
         item.equipped &&
         fromEquippedTypes.includes(item.type.toLowerCase())
     );
-    const loadout = newLoadout('', items);
+    const loadout = newLoadout(
+      '',
+      items.map((i) => convertToLoadoutItem(i, true))
+    );
     loadout.classType = classTypeId;
     this.editLoadout(loadout);
   };

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -75,8 +75,6 @@ const powerStatHashes = [
  * A loadout that's dynamically calculated to maximize Light level (preferring not to change currently-equipped items)
  */
 export function maxLightItemSet(stores: DimStore[], store: DimStore): DimItem[] {
-  console.log('calculating max light for ' + store.name);
-
   const applicableItems: DimItem[] = [];
   for (const s of stores) {
     for (const i of s.items) {

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -61,8 +61,10 @@ export function itemLevelingLoadout(storeService: StoreServiceType, store: DimSt
  */
 export function maxLightLoadout(stores: DimStore[], store: DimStore): Loadout {
   const items = maxLightItemSet(stores, store);
-  const finalItems = items.map((item) => convertToLoadoutItem(item, true));
-  return newLoadout(name, finalItems);
+  return newLoadout(
+    name,
+    items.map((i) => convertToLoadoutItem(i, true))
+  );
 }
 
 const powerStatHashes = [
@@ -220,7 +222,7 @@ export function searchLoadout(
   // Copy the items and mark them equipped and put them in arrays, so they look like a loadout
   const finalItems = Object.values(itemsByType)
     .flat()
-    .map((i) => convertToLoadoutItem(i, true));
+    .map((i) => convertToLoadoutItem(i, false));
 
   return newLoadout(t('Loadouts.FilteredItems'), finalItems);
 }

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -1,7 +1,7 @@
 import copy from 'fast-copy';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
-import { optimalLoadout, newLoadout } from './loadout-utils';
+import { optimalLoadout, newLoadout, convertToLoadoutItem } from './loadout-utils';
 import { StoreServiceType, DimStore } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -176,13 +176,9 @@ export function gatherEngramsLoadout(
     }
   );
 
-  // Copy the items and mark them equipped and put them in arrays, so they look like a loadout
-  const finalItems = {};
-  _.forIn(itemsByType, (items, type) => {
-    if (items) {
-      finalItems[type.toLowerCase()] = items.map((i, ..._args) => copy(i));
-    }
-  });
+  const finalItems = Object.values(itemsByType)
+    .flat()
+    .map((i) => convertToLoadoutItem(i, false));
 
   return newLoadout(t('Loadouts.GatherEngrams'), finalItems);
 }
@@ -207,21 +203,14 @@ export function searchLoadout(
   );
 
   // Copy the items and mark them equipped and put them in arrays, so they look like a loadout
-  const finalItems = {};
-  _.forIn(itemsByType, (items, type) => {
-    if (items) {
-      finalItems[type.toLowerCase()] = items.map((i) => {
-        const copiedItem = copy(i);
-        copiedItem.equipped = false;
-        return copiedItem;
-      });
-    }
-  });
+  const finalItems = Object.values(itemsByType)
+    .flat()
+    .map((i) => convertToLoadoutItem(i, true));
 
   return newLoadout(t('Loadouts.FilteredItems'), finalItems);
 }
 
-function limitToBucketSize(items: DimItem[], isVault) {
+function limitToBucketSize(items: DimItem[], isVault: boolean) {
   if (!items.length) {
     return [];
   }

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -11,6 +11,7 @@ import { dimItemService, MoveReservations } from 'app/inventory/item-move-servic
 import { default as reduxStore } from '../store/store';
 import { savePreviousLoadout } from './actions';
 import copy from 'fast-copy';
+import { loadoutFromAllItems } from './loadout-utils';
 
 const outOfSpaceWarning = _.throttle((store) => {
   showNotification({
@@ -100,9 +101,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
       savePreviousLoadout({
         storeId: store.id,
         loadoutId: loadout.id,
-        previousLoadout: store.loadoutFromCurrentlyEquipped(
-          t('Loadouts.Before', { name: loadout.name })
-        )
+        previousLoadout: loadoutFromAllItems(store, t('Loadouts.Before', { name: loadout.name }))
       })
     );
   }

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -31,6 +31,9 @@
   position: relative;
   margin-right: var(--item-margin);
   margin-bottom: var(--item-margin);
+  .close {
+    right: 2px;
+  }
 }
 
 .loadout-content {
@@ -196,9 +199,6 @@
   .equipped {
     .item {
       margin: 0;
-    }
-    .close {
-      right: 2px;
     }
     .pull-item-button {
       width: var(--item-size);

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -98,9 +98,7 @@
     var(--character-column-width) -
     var(--item-margin)
   );
-  @include phone-portrait {
-    max-width: 230px;
-  }
+  max-width: 230px;
   box-sizing: border-box;
   max-height: calc(100vh - #{77px + $header-height});
   max-height: calc(100vh - #{77px + $header-height} - constant(safe-area-inset-top));

--- a/src/app/loadout/loadout-storage.ts
+++ b/src/app/loadout/loadout-storage.ts
@@ -136,8 +136,7 @@ function hydratev3d0(loadoutPrimitive: DehydratedLoadout): Loadout {
 
 /** Transform the loadout into its storage format. */
 function dehydrate(loadout: Loadout): DehydratedLoadout {
-  const allItems = Object.values(loadout.items).flat();
-  const items = allItems.map((item) => ({
+  const items = loadout.items.map((item) => ({
     id: item.id,
     hash: item.hash,
     amount: item.amount,

--- a/src/app/loadout/loadout-storage.ts
+++ b/src/app/loadout/loadout-storage.ts
@@ -1,17 +1,13 @@
 import copy from 'fast-copy';
 import _ from 'lodash';
-import { SyncService } from '../storage/sync.service';
+import { SyncService, DimData } from '../storage/sync.service';
 import { DimItem } from '../inventory/item-types';
-import { DimStore, StoreServiceType } from '../inventory/store-types';
 import { D2StoresService } from '../inventory/d2-stores';
 import { D1StoresService } from '../inventory/d1-stores';
-import { dimItemService, MoveReservations } from '../inventory/item-move-service';
-import { t } from 'app/i18next-t';
-import { default as reduxStore } from '../store/store';
 import * as actions from './actions';
-import { loadoutsSelector } from './reducer';
-import { showNotification } from '../notifications/notifications';
 import { LoadoutClass, LoadoutItem, Loadout } from './loadout-types';
+import { ThunkResult } from 'app/store/reducers';
+import { loadoutsSelector } from './reducer';
 
 /** The format loadouts are stored in. */
 interface DehydratedLoadout {
@@ -28,22 +24,42 @@ interface DehydratedLoadout {
   version: 'v3.0';
 }
 
-export async function getLoadouts(getLatest = false): Promise<Loadout[]> {
-  const loadouts = loadoutsSelector(reduxStore.getState());
-  // Avoids the hit going to data store if we have data already.
-  if (!getLatest && loadouts.length) {
-    return loadouts;
-  }
-
-  const data = await SyncService.get();
-  const newLoadouts = 'loadouts-v3.0' in data ? processLoadout(data, 'v3.0') : [];
-  if (getLatest || newLoadouts.length) {
-    reduxStore.dispatch(actions.loaded(newLoadouts));
-  }
-  return loadoutsSelector(reduxStore.getState());
+/** Called when sync service is loaded to populate loadouts in Redux */
+export function loadLoadouts(data: DimData): ThunkResult<void> {
+  return async (dispatch) => {
+    const newLoadouts = 'loadouts-v3.0' in data ? processLoadout(data, 'v3.0') : [];
+    if (newLoadouts.length) {
+      dispatch(actions.loaded(newLoadouts));
+    }
+  };
 }
 
-export async function saveLoadouts(loadouts: Loadout[]): Promise<Loadout[]> {
+export function saveLoadout(loadout: Loadout): ThunkResult<Loadout | undefined> {
+  return async (dispatch, getState) => {
+    const clashingLoadout = getClashingLoadout(loadoutsSelector(getState()), loadout);
+
+    if (!clashingLoadout) {
+      dispatch(actions.updateLoadout(loadout));
+      await saveLoadouts(getState().loadouts.loadouts);
+    }
+
+    return clashingLoadout;
+  };
+}
+
+export function deleteLoadout(loadout: Loadout): ThunkResult<void> {
+  return async (dispatch, getState) => {
+    dispatch(actions.deleteLoadout(loadout.id));
+
+    await SyncService.remove(loadout.id);
+    // remove the loadout ID from the list of loadout IDs
+    await SyncService.set({
+      'loadouts-v3.0': getState().loadouts.loadouts.map((l) => l.id)
+    });
+  };
+}
+
+async function saveLoadouts(loadouts: Loadout[]): Promise<Loadout[]> {
   const loadoutPrimitives = loadouts.map(dehydrate);
 
   const data = {
@@ -55,27 +71,8 @@ export async function saveLoadouts(loadouts: Loadout[]): Promise<Loadout[]> {
   return loadouts;
 }
 
-export async function saveLoadout(loadout: Loadout): Promise<Loadout | undefined> {
-  const loadouts = await getLoadouts();
-  const clashingLoadout = getClashingLoadout(loadouts, loadout);
-
-  if (!clashingLoadout) {
-    reduxStore.dispatch(actions.updateLoadout(loadout));
-    await saveLoadouts(reduxStore.getState().loadouts.loadouts);
-  }
-
-  return clashingLoadout;
-}
-
-export async function deleteLoadout(loadout: Loadout): Promise<void> {
-  await getLoadouts(); // make sure we have loaded all loadouts first!
-  reduxStore.dispatch(actions.deleteLoadout(loadout.id));
-  await SyncService.remove(loadout.id);
-  await saveLoadouts(reduxStore.getState().loadouts.loadouts);
-}
-
 /** Find other loadouts that have the same name as a proposed new loadout. */
-export function getClashingLoadout(loadouts: Loadout[], newLoadout: Loadout): Loadout | undefined {
+function getClashingLoadout(loadouts: Loadout[], newLoadout: Loadout): Loadout | undefined {
   return loadouts.find(
     (loadout) =>
       loadout.name === newLoadout.name &&
@@ -211,85 +208,4 @@ function isGuid(stringToTest: string) {
   const regexGuid = /^(\{){0,1}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(\}){0,1}$/gi;
 
   return regexGuid.test(stringToTest);
-}
-
-const outOfSpaceWarning = _.throttle((store) => {
-  showNotification({
-    type: 'info',
-    title: t('FarmingMode.OutOfRoomTitle'),
-    body: t('FarmingMode.OutOfRoom', { character: store.name })
-  });
-}, 60000);
-
-/**
- * Move a list of items off of a character to the vault (or to other characters if the vault is full).
- *
- * Shows a warning if there isn't any space.
- */
-export async function clearItemsOffCharacter(
-  store: DimStore,
-  items: DimItem[],
-  reservations: MoveReservations,
-  storesService: StoreServiceType
-) {
-  for (const item of items) {
-    try {
-      // Move a single item. We reevaluate each time in case something changed.
-      const vault = storesService.getVault()!;
-      const vaultSpaceLeft = vault.spaceLeftForItem(item);
-      if (vaultSpaceLeft <= 1) {
-        // If we're down to one space, try putting it on other characters
-        const otherStores = storesService
-          .getStores()
-          .filter((s) => !s.isVault && s.id !== store.id);
-        const otherStoresWithSpace = otherStores.filter((store) => store.spaceLeftForItem(item));
-
-        if (otherStoresWithSpace.length) {
-          if ($featureFlags.debugMoves) {
-            console.log(
-              'clearItemsOffCharacter initiated move:',
-              item.amount,
-              item.name,
-              item.type,
-              'to',
-              otherStoresWithSpace[0].name,
-              'from',
-              storesService.getStore(item.owner)!.name
-            );
-          }
-          await dimItemService.moveTo(
-            item,
-            otherStoresWithSpace[0],
-            false,
-            item.amount,
-            items,
-            reservations
-          );
-          continue;
-        } else if (vaultSpaceLeft === 0) {
-          outOfSpaceWarning(store);
-          continue;
-        }
-      }
-      if ($featureFlags.debugMoves) {
-        console.log(
-          'clearItemsOffCharacter initiated move:',
-          item.amount,
-          item.name,
-          item.type,
-          'to',
-          vault.name,
-          'from',
-          storesService.getStore(item.owner)!.name
-        );
-      }
-      await dimItemService.moveTo(item, vault, false, item.amount, items, reservations);
-    } catch (e) {
-      if (e.code === 'no-space') {
-        outOfSpaceWarning(store);
-      } else {
-        showNotification({ type: 'error', title: item.name, body: e.message });
-      }
-    }
-  }
 }

--- a/src/app/loadout/loadout-storage.ts
+++ b/src/app/loadout/loadout-storage.ts
@@ -86,7 +86,7 @@ function getStoresService(destinyVersion) {
   return destinyVersion === 2 ? D2StoresService : D1StoresService;
 }
 
-function processLoadout(data, version): Loadout[] {
+function processLoadout(data: DimData, version: string): Loadout[] {
   if (!data) {
     return [];
   }
@@ -94,7 +94,7 @@ function processLoadout(data, version): Loadout[] {
   let loadouts: Loadout[] = [];
   if (version === 'v3.0') {
     const ids = data['loadouts-v3.0'];
-    loadouts = ids.filter((id) => data[id]).map((id) => hydrate(data[id]));
+    loadouts = ids ? ids.filter((id) => data[id]).map((id) => hydrate(data[id])) : [];
   }
 
   const objectTest = (item) => _.isObject(item) && !(Array.isArray(item) || _.isFunction(item));

--- a/src/app/loadout/loadout-storage.ts
+++ b/src/app/loadout/loadout-storage.ts
@@ -140,7 +140,12 @@ function hydrate(loadoutPrimitive: DehydratedLoadout): Loadout {
       loadoutClassToClassType[
         loadoutPrimitive.classType === undefined ? -1 : loadoutPrimitive.classType
       ],
-    items: loadoutPrimitive.items,
+    items: loadoutPrimitive.items.map((item) => ({
+      id: item.id || '0',
+      hash: item.hash,
+      amount: item.amount || 1,
+      equipped: Boolean(item.equipped)
+    })),
     clearSpace: loadoutPrimitive.clearSpace
   };
 

--- a/src/app/loadout/loadout-types.ts
+++ b/src/app/loadout/loadout-types.ts
@@ -16,7 +16,7 @@ export interface Loadout {
   items: LoadoutItem[];
   /** Platform membership ID this loadout is associated with */
   membershipId?: string;
-  destinyVersion?: DestinyVersion;
+  destinyVersion: DestinyVersion;
   // TODO: deprecate this
   platform?: string;
   /** Whether to move other items not in the loadout off the character when applying the loadout. */

--- a/src/app/loadout/loadout-types.ts
+++ b/src/app/loadout/loadout-types.ts
@@ -2,9 +2,9 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 
 export interface LoadoutItem {
-  id?: string;
+  id: string;
   hash: number;
-  amount?: number;
+  amount: number;
   equipped: boolean;
 }
 

--- a/src/app/loadout/loadout-types.ts
+++ b/src/app/loadout/loadout-types.ts
@@ -1,5 +1,4 @@
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { DimItem } from 'app/inventory/item-types';
 
 export enum LoadoutClass {
   any = -1,
@@ -34,16 +33,19 @@ export function getLoadoutClassDisplay(loadoutClass: LoadoutClass) {
   return 'any';
 }
 
-export type LoadoutItem = DimItem;
+export interface LoadoutItem {
+  id?: string;
+  hash: number;
+  amount?: number;
+  equipped: boolean;
+}
 
 /** In memory loadout structure. */
 export interface Loadout {
   id: string;
   classType: LoadoutClass;
   name: string;
-  items: {
-    [type: string]: LoadoutItem[];
-  };
+  items: LoadoutItem[];
   /** Platform membership ID this loadout is associated with */
   membershipId?: string;
   destinyVersion?: 1 | 2;

--- a/src/app/loadout/loadout-types.ts
+++ b/src/app/loadout/loadout-types.ts
@@ -1,33 +1,13 @@
 import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 
-export enum LoadoutClass {
-  any = -1,
-  warlock = 0,
-  titan = 1,
-  hunter = 2
-}
-
-export const loadoutClassToClassType = {
-  [LoadoutClass.hunter]: DestinyClass.Hunter,
-  [LoadoutClass.titan]: DestinyClass.Titan,
-  [LoadoutClass.warlock]: DestinyClass.Warlock,
-  [LoadoutClass.any]: DestinyClass.Unknown
-};
-
-export const classTypeToLoadoutClass = {
-  [DestinyClass.Hunter]: LoadoutClass.hunter,
-  [DestinyClass.Titan]: LoadoutClass.titan,
-  [DestinyClass.Warlock]: LoadoutClass.warlock,
-  [DestinyClass.Unknown]: LoadoutClass.any
-};
-
-export function getLoadoutClassDisplay(loadoutClass: LoadoutClass) {
+export function getLoadoutClassDisplay(loadoutClass: DestinyClass) {
   switch (loadoutClass) {
-    case 0:
+    case DestinyClass.Warlock:
       return 'warlock';
-    case 1:
+    case DestinyClass.Titan:
       return 'titan';
-    case 2:
+    case DestinyClass.Hunter:
       return 'hunter';
   }
   return 'any';
@@ -43,12 +23,12 @@ export interface LoadoutItem {
 /** In memory loadout structure. */
 export interface Loadout {
   id: string;
-  classType: LoadoutClass;
+  classType: DestinyClass;
   name: string;
   items: LoadoutItem[];
   /** Platform membership ID this loadout is associated with */
   membershipId?: string;
-  destinyVersion?: 1 | 2;
+  destinyVersion?: DestinyVersion;
   // TODO: deprecate this
   platform?: string;
   /** Whether to move other items not in the loadout off the character when applying the loadout. */

--- a/src/app/loadout/loadout-types.ts
+++ b/src/app/loadout/loadout-types.ts
@@ -1,18 +1,6 @@
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 
-export function getLoadoutClassDisplay(loadoutClass: DestinyClass) {
-  switch (loadoutClass) {
-    case DestinyClass.Warlock:
-      return 'warlock';
-    case DestinyClass.Titan:
-      return 'titan';
-    case DestinyClass.Hunter:
-      return 'hunter';
-  }
-  return 'any';
-}
-
 export interface LoadoutItem {
   id?: string;
   hash: number;

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -18,11 +18,11 @@ export function newLoadout(name: string, items: readonly LoadoutItem[], equipped
 }
 
 /*
- * Calculates the light level for a full loadout. loadout should have all types of weapon and armor
+ * Calculates the light level for a list of items, one per type of weapon and armor
  * or it won't be accurate. function properly supports guardians w/o artifacts
  * returns to tenth decimal place.
  */
-export function getLight(store: DimStore, loadout: Loadout): number {
+export function getLight(store: DimStore, items: DimItem[]): number {
   // https://www.reddit.com/r/DestinyTheGame/comments/6yg4tw/how_overall_power_level_is_calculated/
   let itemWeight = {
     Weapons: 6,
@@ -44,10 +44,6 @@ export function getLight(store: DimStore, loadout: Loadout): number {
     itemWeightDenominator = 50;
   }
 
-  const items = Object.values(loadout.items)
-    .flat()
-    .filter((i) => i.equipped);
-
   const exactLight =
     items.reduce(
       (memo, item) =>
@@ -60,12 +56,11 @@ export function getLight(store: DimStore, loadout: Loadout): number {
   return Math.floor(exactLight * 10) / 10;
 }
 
-// Generate an optimized loadout based on a filtered set of items and a value function
-export function optimalLoadout(
+// Generate an optimized item set (loadout items) based on a filtered set of items and a value function
+export function optimalItemSet(
   applicableItems: DimItem[],
-  bestItemFn: (item: DimItem) => number,
-  name: string
-): Loadout {
+  bestItemFn: (item: DimItem) => number
+): DimItem[] {
   const itemsByType = _.groupBy(applicableItems, (i) => i.type);
 
   // Pick the best item
@@ -111,9 +106,16 @@ export function optimalLoadout(
     }
   });
 
-  // Copy the items and mark them equipped
-  const finalItems = Object.values(items).map((item) => convertToLoadoutItem(item, true));
+  return Object.values(items);
+}
 
+export function optimalLoadout(
+  applicableItems: DimItem[],
+  bestItemFn: (item: DimItem) => number,
+  name: string
+): Loadout {
+  const items = optimalItemSet(applicableItems, bestItemFn);
+  const finalItems = items.map((item) => convertToLoadoutItem(item, true));
   return newLoadout(name, finalItems);
 }
 /** Create a loadout from all of this character's items that can be in loadouts */

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -129,7 +129,6 @@ export function loadoutFromAllItems(
   const allItems = store.items.filter(
     (item) => item.canBeInLoadout() && (!onlyEquipped || item.equipped)
   );
-  // TODO: want to preserve their equipped-ness
   return newLoadout(
     name,
     allItems.map((i) => convertToLoadoutItem(i, i.equipped))

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -12,6 +12,8 @@ export function newLoadout(name: string, items: LoadoutItem[]): Loadout {
   return {
     id: uuidv4(),
     classType: DestinyClass.Unknown,
+    // This gets overwritten in any path that'd save a real loadout, and apply doesn't care
+    destinyVersion: 2,
     name,
     items
   };

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -3,6 +3,7 @@ import { Loadout, LoadoutItem } from './loadout-types';
 import { DimItem } from '../inventory/item-types';
 import uuidv4 from 'uuid/v4';
 import { DimStore } from 'app/inventory/store-types';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 /**
  * Creates a new loadout, with all of the items equipped.
@@ -11,7 +12,7 @@ import { DimStore } from 'app/inventory/store-types';
 export function newLoadout(name: string, items: readonly LoadoutItem[], equipped = true): Loadout {
   return {
     id: uuidv4(),
-    classType: -1,
+    classType: DestinyClass.Unknown,
     name,
     items: items.map((i) => convertToLoadoutItem(i, equipped))
   };

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -8,13 +8,12 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 /**
  * Creates a new loadout, with all of the items equipped.
  */
-// TODO: check that all usages expect all-equipped
-export function newLoadout(name: string, items: readonly LoadoutItem[], equipped = true): Loadout {
+export function newLoadout(name: string, items: LoadoutItem[]): Loadout {
   return {
     id: uuidv4(),
     classType: DestinyClass.Unknown,
     name,
-    items: items.map((i) => convertToLoadoutItem(i, equipped))
+    items
   };
 }
 
@@ -116,8 +115,10 @@ export function optimalLoadout(
   name: string
 ): Loadout {
   const items = optimalItemSet(applicableItems, bestItemFn);
-  const finalItems = items.map((item) => convertToLoadoutItem(item, true));
-  return newLoadout(name, finalItems);
+  return newLoadout(
+    name,
+    items.map((i) => convertToLoadoutItem(i, true))
+  );
 }
 /** Create a loadout from all of this character's items that can be in loadouts */
 export function loadoutFromAllItems(
@@ -128,7 +129,11 @@ export function loadoutFromAllItems(
   const allItems = store.items.filter(
     (item) => item.canBeInLoadout() && (!onlyEquipped || item.equipped)
   );
-  return newLoadout(name, allItems);
+  // TODO: want to preserve their equipped-ness
+  return newLoadout(
+    name,
+    allItems.map((i) => convertToLoadoutItem(i, i.equipped))
+  );
 }
 
 /**
@@ -138,7 +143,7 @@ export function convertToLoadoutItem(item: LoadoutItem, equipped: boolean) {
   return {
     id: item.id,
     hash: item.hash,
-    amount: 1,
+    amount: item.amount,
     equipped
   };
 }

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -19,12 +19,16 @@ export const loadoutsSelector = createSelector(
     currentAccount
       ? allLoadouts.filter((loadout) => {
           if (loadout.membershipId !== undefined) {
-            return loadout.membershipId === currentAccount.membershipId;
+            return (
+              loadout.membershipId === currentAccount.membershipId &&
+              loadout.destinyVersion === currentAccount.destinyVersion
+            );
           } else if (loadout.platform !== undefined) {
             reportOldLoadout();
             if (loadout.platform === currentAccount.platformLabel) {
               // Take this opportunity to fix up the membership ID
               loadout.membershipId = currentAccount.membershipId;
+              loadout.destinyVersion = currentAccount.destinyVersion;
               return true;
             } else {
               return false;

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -2,63 +2,39 @@ import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { currentAccountSelector } from '../accounts/reducer';
-import { Loadout, classTypeToLoadoutClass } from './loadout-types';
+import { Loadout } from './loadout-types';
 import { RootState } from '../store/reducers';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import {
-  Loadout as DimApiLoadout,
-  LoadoutItem as DimApiLoadoutItem,
-  DestinyVersion
-} from '@destinyitemmanager/dim-api-types';
-import { StoreServiceType } from 'app/inventory/store-types';
-import copy from 'fast-copy';
-import { DimItem } from 'app/inventory/item-types';
-import { D2StoresService } from 'app/inventory/d2-stores';
-import { D1StoresService } from 'app/inventory/d1-stores';
-import { currentProfileSelector } from 'app/dim-api/selectors';
 
 const EMPTY_ARRAY = [];
 
 const reportOldLoadout = _.once(() => ga('send', 'event', 'Loadouts', 'No Membership ID'));
 
 /** All loadouts relevant to the current account */
-export const loadoutsSelector = $featureFlags.dimApi
-  ? createSelector(
-      currentAccountSelector,
-      currentProfileSelector,
-      (currentAccount, profile) =>
-        profile?.loadouts?.map((loadout) =>
-          convertDimApiLoadoutToLoadout(
-            currentAccount!.membershipId,
-            currentAccount!.destinyVersion,
-            loadout
-          )
-        ) || EMPTY_ARRAY
-    )
-  : createSelector(
-      (state: RootState) => state.loadouts.loadouts,
-      currentAccountSelector,
-      (allLoadouts, currentAccount) =>
-        currentAccount
-          ? allLoadouts.filter((loadout) => {
-              if (loadout.membershipId !== undefined) {
-                return loadout.membershipId === currentAccount.membershipId;
-              } else if (loadout.platform !== undefined) {
-                reportOldLoadout();
-                if (loadout.platform === currentAccount.platformLabel) {
-                  // Take this opportunity to fix up the membership ID
-                  loadout.membershipId = currentAccount.membershipId;
-                  return true;
-                } else {
-                  return false;
-                }
-              } else {
-                return true;
-              }
-            })
-          : EMPTY_ARRAY
-    );
+export const loadoutsSelector = createSelector(
+  (state: RootState) => state.loadouts.loadouts,
+  currentAccountSelector,
+  (allLoadouts, currentAccount) =>
+    currentAccount
+      ? allLoadouts.filter((loadout) => {
+          if (loadout.membershipId !== undefined) {
+            return loadout.membershipId === currentAccount.membershipId;
+          } else if (loadout.platform !== undefined) {
+            reportOldLoadout();
+            if (loadout.platform === currentAccount.platformLabel) {
+              // Take this opportunity to fix up the membership ID
+              loadout.membershipId = currentAccount.membershipId;
+              return true;
+            } else {
+              return false;
+            }
+          } else {
+            return true;
+          }
+        })
+      : EMPTY_ARRAY
+);
 export const previousLoadoutSelector = (state: RootState, storeId: string): Loadout | undefined => {
   if (state.loadouts.previousLoadouts[storeId]) {
     return _.last(state.loadouts.previousLoadouts[storeId]);
@@ -127,70 +103,3 @@ export const loadouts: Reducer<LoadoutsState, LoadoutsAction> = (
       return state;
   }
 };
-
-/**
- * DIM API stores loadouts in a new format, but the app still uses the old format everywhere. This converts the API
- * storage format to the old loadout format.
- */
-function convertDimApiLoadoutToLoadout(
-  platformMembershipId: string,
-  destinyVersion: DestinyVersion,
-  loadout: DimApiLoadout
-): Loadout {
-  const result: Loadout = {
-    id: loadout.id,
-    classType: classTypeToLoadoutClass[loadout.classType],
-    name: loadout.name,
-    clearSpace: loadout.clearSpace || false,
-    membershipId: platformMembershipId,
-    destinyVersion,
-    items: {
-      unknown: []
-    }
-  };
-
-  // It'll be great to stop using this stuff
-  const storesService = getStoresService(destinyVersion);
-  convertItemsToLoadoutItems(storesService, result, loadout.equipped, true);
-  convertItemsToLoadoutItems(storesService, result, loadout.unequipped, false);
-  return result;
-}
-
-function convertItemsToLoadoutItems(
-  storesService: StoreServiceType,
-  result: Loadout,
-  items: DimApiLoadoutItem[],
-  equipped: boolean
-) {
-  for (const item of items) {
-    const LoadoutItem = copy(
-      storesService.getItemAcrossStores({
-        id: item.id || '0',
-        hash: item.hash
-      })
-    );
-
-    if (LoadoutItem) {
-      const discriminator = LoadoutItem.type.toLowerCase();
-      LoadoutItem.equipped = equipped;
-      LoadoutItem.amount = item.amount || 1;
-
-      result.items[discriminator] = result.items[discriminator] || [];
-      result.items[discriminator].push(LoadoutItem);
-    } else {
-      const loadoutItem = {
-        id: item.id || '0',
-        hash: item.hash,
-        amount: item.amount,
-        equipped
-      };
-
-      result.items.unknown.push(loadoutItem as DimItem);
-    }
-  }
-}
-
-function getStoresService(destinyVersion) {
-  // TODO: this needs to use account, store, or item version
-  return destinyVersion === 2 ? D2StoresService : D1StoresService;
-}

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -25,7 +25,12 @@ export const loadoutsSelector = createSelector(
             );
           } else if (loadout.platform !== undefined) {
             reportOldLoadout();
-            if (loadout.platform === currentAccount.platformLabel) {
+            if (
+              loadout.platform === currentAccount.platformLabel &&
+              (currentAccount.destinyVersion === 2
+                ? loadout.destinyVersion === 2
+                : loadout.destinyVersion !== 2)
+            ) {
               // Take this opportunity to fix up the membership ID
               loadout.membershipId = currentAccount.membershipId;
               loadout.destinyVersion = currentAccount.destinyVersion;
@@ -34,7 +39,7 @@ export const loadoutsSelector = createSelector(
               return false;
             }
           } else {
-            return true;
+            return currentAccount.destinyVersion === 1;
           }
         })
       : EMPTY_ARRAY

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -27,18 +27,16 @@ export const loadoutsSelector = createSelector(
             reportOldLoadout();
             if (
               loadout.platform === currentAccount.platformLabel &&
-              (currentAccount.destinyVersion === 2
-                ? loadout.destinyVersion === 2
-                : loadout.destinyVersion !== 2)
+              loadout.destinyVersion === currentAccount.destinyVersion
             ) {
               // Take this opportunity to fix up the membership ID
               loadout.membershipId = currentAccount.membershipId;
-              loadout.destinyVersion = currentAccount.destinyVersion;
               return true;
             } else {
               return false;
             }
           } else {
+            // In D1 loadouts could get saved without platform or membership ID
             return currentAccount.destinyVersion === 1;
           }
         })

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -40,7 +40,7 @@ import { toggleSearchQueryComponent } from 'app/shell/actions';
 import clsx from 'clsx';
 import { useShiftHeld } from 'app/utils/hooks';
 import { currentAccountSelector } from 'app/accounts/reducer';
-import { newLoadout } from 'app/loadout/loadout-utils';
+import { newLoadout, convertToLoadoutItem } from 'app/loadout/loadout-utils';
 import { applyLoadout } from 'app/loadout/loadout-apply';
 import { getColumns } from './Columns';
 import { ratingsSelector } from 'app/item-review/reducer';
@@ -286,7 +286,10 @@ function ItemTable({
         loadoutItems[item.type].push(item);
       }
 
-      const loadout = newLoadout(t('Organizer.BulkMoveLoadoutName'), items, false);
+      const loadout = newLoadout(
+        t('Organizer.BulkMoveLoadoutName'),
+        items.map((i) => convertToLoadoutItem(i, false))
+      );
 
       applyLoadout(store, loadout, true);
     }

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -278,7 +278,7 @@ function ItemTable({
   const onMoveSelectedItems = (store: DimStore) => {
     if (selectedFlatRows?.length) {
       const items = selectedFlatRows?.map((d) => d.original);
-      const loadoutItems: { [type: string]: DimItem[] } = {};
+      const loadoutItems: DimItem[] = [];
 
       for (const item of items) {
         if (!loadoutItems[item.type]) {

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -42,7 +42,6 @@ import { useShiftHeld } from 'app/utils/hooks';
 import { currentAccountSelector } from 'app/accounts/reducer';
 import { newLoadout } from 'app/loadout/loadout-utils';
 import { applyLoadout } from 'app/loadout/loadout-apply';
-import { LoadoutClass } from 'app/loadout/loadout-types';
 import { getColumns } from './Columns';
 import { ratingsSelector } from 'app/item-review/reducer';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -288,9 +287,6 @@ function ItemTable({
       }
 
       const loadout = newLoadout(t('Organizer.BulkMoveLoadoutName'), items, false);
-      if (store.class !== 'vault') {
-        loadout.classType = LoadoutClass[store.class];
-      }
 
       applyLoadout(store, loadout, true);
     }

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -287,7 +287,7 @@ function ItemTable({
         loadoutItems[item.type].push(item);
       }
 
-      const loadout = newLoadout(t('Organizer.BulkMoveLoadoutName'), loadoutItems);
+      const loadout = newLoadout(t('Organizer.BulkMoveLoadoutName'), items, false);
       if (store.class !== 'vault') {
         loadout.classType = LoadoutClass[store.class];
       }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1186,11 +1186,9 @@ function searchFilters(
         if (!_loadoutItemIds) {
           _loadoutItemIds = new Set<string>();
           for (const loadout of loadouts) {
-            if (loadout.destinyVersion === searchConfig.destinyVersion) {
-              for (const item of loadout.items) {
-                if (item.id && item.id !== '0') {
-                  _loadoutItemIds.add(item.id);
-                }
+            for (const item of loadout.items) {
+              if (item.id && item.id !== '0') {
+                _loadoutItemIds.add(item.id);
               }
             }
           }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -796,9 +796,7 @@ function searchFilters(
         if (!_maxStatLoadoutItems[predicate].length) {
           stores.forEach((store) => {
             _maxStatLoadoutItems[predicate].push(
-              ...maxStatLoadout(maxStatHash, store.getStoresService(), store).items.map(
-                (i) => i.id || '0'
-              )
+              ...maxStatLoadout(maxStatHash, store.getStoresService(), store).items.map((i) => i.id)
             );
           });
         }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -427,6 +427,7 @@ function searchFilters(
   newItems: Set<string>,
   itemInfos: { [key: string]: DimItemInfo }
 ): SearchFilters {
+  // TODO: do these with memoize-one
   let _duplicates: { [dupeID: string]: DimItem[] } | null = null; // Holds a map from item hash to count of occurrances of that hash
   const _maxPowerLoadoutItems: string[] = [];
   const _maxStatLoadoutItems: { [key: string]: string[] } = {};
@@ -1190,11 +1191,11 @@ function searchFilters(
           _loadoutItemIds = new Set<string>();
           for (const loadout of loadouts) {
             if (loadout.destinyVersion === searchConfig.destinyVersion) {
-              _.forIn(loadout.items, (items) => {
-                for (const item of items) {
-                  _loadoutItemIds!.add(item.id);
+              for (const item of loadout.items) {
+                if (item.id && item.id !== '0') {
+                  _loadoutItemIds.add(item.id);
                 }
-              });
+              }
             }
           }
         }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -27,8 +27,6 @@ import { inventoryWishListsSelector } from '../wishlists/reducer';
 import { D2SeasonInfo } from '../inventory/d2-season-info';
 import { getRating, ratingsSelector, ReviewsState, shouldShowRating } from '../item-review/reducer';
 import { RootState } from '../store/reducers';
-import { getLoadouts as getLoadoutsFromStorage } from '../loadout/loadout-storage';
-
 import { D2EventPredicateLookup } from 'data/d2/d2-event-info';
 import * as hashes from './search-filter-hashes';
 import D2Sources from 'data/d2/source-info';
@@ -437,7 +435,6 @@ function searchFilters(
   } | null = null;
   const _lowerDupes = {};
   let _loadoutItemIds: Set<string> | undefined;
-  const getLoadouts = _.once(getLoadoutsFromStorage);
 
   function initDupes() {
     // The comparator for sorting dupes - the first item will be the "best" and all others are "dupelower".
@@ -1190,10 +1187,6 @@ function searchFilters(
       inloadout(item: DimItem) {
         // Lazy load loadouts and re-trigger
         if (!_loadoutItemIds) {
-          if (loadouts.length === 0) {
-            getLoadouts();
-            return false;
-          }
           _loadoutItemIds = new Set<string>();
           for (const loadout of loadouts) {
             if (loadout.destinyVersion === searchConfig.destinyVersion) {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -796,9 +796,9 @@ function searchFilters(
         if (!_maxStatLoadoutItems[predicate].length) {
           stores.forEach((store) => {
             _maxStatLoadoutItems[predicate].push(
-              ...Object.values(maxStatLoadout(maxStatHash, store.getStoresService(), store).items)
-                .flat()
-                .map((i) => i.id)
+              ...maxStatLoadout(maxStatHash, store.getStoresService(), store).items.map(
+                (i) => i.id || '0'
+              )
             );
           });
         }

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -18,7 +18,7 @@ import { D1Categories } from '../destiny1/d1-buckets';
 import { D2Categories } from '../destiny2/d2-buckets';
 import { querySelector } from '../shell/reducer';
 import { sortedStoresSelector } from '../inventory/reducer';
-import { maxLightLoadout, maxStatLoadout } from '../loadout/auto-loadouts';
+import { maxStatLoadout, maxLightItemSet } from '../loadout/auto-loadouts';
 import { itemTagSelectorList, DimItemInfo, getTag, getNotes } from '../inventory/dim-item-info';
 import store from '../store/store';
 import { loadoutsSelector } from '../loadout/reducer';
@@ -777,11 +777,7 @@ function searchFilters(
       maxpower(item: DimItem) {
         if (!_maxPowerLoadoutItems.length) {
           stores.forEach((store) => {
-            _maxPowerLoadoutItems.push(
-              ...Object.values(maxLightLoadout(store.getStoresService(), store).items)
-                .flat()
-                .map((i) => i.id)
-            );
+            _maxPowerLoadoutItems.push(...maxLightItemSet(stores, store).map((i) => i.id));
           });
         }
 

--- a/src/app/settings/settings.ts
+++ b/src/app/settings/settings.ts
@@ -6,6 +6,7 @@ import { loaded } from './actions';
 import { observeStore } from '../utils/redux-utils';
 import { Unsubscribe } from 'redux';
 import { settingsSelector } from './reducer';
+import { loadLoadouts } from 'app/loadout/loadout-storage';
 
 export let readyResolve;
 export const settingsReady = new Promise((resolve) => (readyResolve = resolve));
@@ -54,6 +55,7 @@ export function initSettings() {
 
     const savedSettings = data['settings-v1.0'] || {};
     store.dispatch(loaded(savedSettings));
+    store.dispatch(loadLoadouts(data));
 
     readyResolve();
 

--- a/src/app/storage/GDriveRevisions.tsx
+++ b/src/app/storage/GDriveRevisions.tsx
@@ -8,7 +8,6 @@ import { SyncService } from './sync.service';
 import { UIViewInjectedProps } from '@uirouter/react';
 import { refreshIcon, AppIcon } from '../shell/icons';
 import { initSettings } from '../settings/settings';
-import { getLoadouts } from 'app/loadout/loadout-storage';
 
 interface State {
   revisions?: any;
@@ -164,7 +163,6 @@ class GDriveRevisionComponent extends React.Component<
         await SyncService.set(content, true);
         alert(t('Storage.ImportSuccess'));
         initSettings();
-        getLoadouts(true);
         this.props.onRestoreSuccess();
       }
     }

--- a/src/app/storage/StorageSettings.tsx
+++ b/src/app/storage/StorageSettings.tsx
@@ -26,7 +26,6 @@ import { GoogleDriveInfo } from './GoogleDriveInfo';
 import { DropzoneOptions } from 'react-dropzone';
 import FileUpload from '../dim-ui/FileUpload';
 import { percent } from '../shell/filters';
-import { getLoadouts } from 'app/loadout/loadout-storage';
 
 declare global {
   interface Window {
@@ -293,7 +292,6 @@ export default class StorageSettings extends React.Component<{}, State> {
             await SyncService.set(data, true);
             await Promise.all(SyncService.adapters.map(this.refreshAdapter));
             initSettings();
-            getLoadouts(true);
             alert(t('Storage.ImportSuccess'));
           }
         } catch (e) {


### PR DESCRIPTION
This unfortunately massive PR is a refactoring of the Loadouts code to make it easier to transition to being backed by the DIM API.

1. More Redux-y
2. Ditched the `items` structure where it was grouped by type in favor of a flat list.
3. Stopped pretending they were full `DimItem`s (and stopped trying to match them up on load). Now `LoadoutDrawer` and `loadout-apply` do all the work to load corresponding items on demand.
4. Dropped `LoadoutClass` in favor of just `DestinyClass`.
5. Dropped `class` (the string version) from `DimStore`.

I'm gonna need a lot of help testing this - it touches a lot and loadouts are tricky.