### PR TITLE
Use questline as the title of quests

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -323,6 +323,17 @@ export function makeItem(
     overrideStyleItem = null;
   }
 
+  // Quest steps display their title as the quest line name, and their step name in the type position
+  let name = displayProperties.name;
+  let typeName = itemDef.itemTypeDisplayName || 'Unknown';
+  if (
+    itemDef.setData?.questLineName &&
+    itemDef.setData?.questLineName !== itemDef.displayProperties.name
+  ) {
+    typeName = itemDef.displayProperties.name;
+    name = itemDef.setData.questLineName;
+  }
+
   const createdItem: D2Item = Object.assign(Object.create(ItemProto), {
     // figure out what year this item is probably from
     destinyVersion: 2,
@@ -337,7 +348,7 @@ export function makeItem(
     tier: tiers[itemDef.inventory.tierType] || 'Common',
     isExotic: tiers[itemDef.inventory.tierType] === 'Exotic',
     isVendorItem: !owner || owner.id === null,
-    name: displayProperties.name,
+    name,
     description: displayProperties.description,
     icon:
       overrideStyleItem?.displayProperties.icon ||
@@ -356,7 +367,7 @@ export function makeItem(
     complete: false,
     amount: item.quantity,
     primStat: primaryStat,
-    typeName: itemDef.itemTypeDisplayName || 'Unknown',
+    typeName,
     equipRequiredLevel: instanceDef?.equipRequiredLevel ?? 0,
     maxStackSize: Math.max(itemDef.inventory.maxStackSize, 1),
     uniqueStack: Boolean(itemDef.inventory.stackUniqueLabel?.length),


### PR DESCRIPTION
It's now easy to get the questline name for quest step items, so this displays them more like in game - the title is the overall questline, and the quest step is a subtitle:

<img width="443" alt="Screen Shot 2020-03-13 at 11 03 21 PM" src="https://user-images.githubusercontent.com/313208/76676236-b5498380-657e-11ea-9f28-65e6ff96a285.png">
<img width="468" alt="Screen Shot 2020-03-13 at 11 04 03 PM" src="https://user-images.githubusercontent.com/313208/76676239-b7abdd80-657e-11ea-9c9f-e023dca01e24.png">
