### PR TITLE
restyle vengramsxyz icons

### DIFF
--- a/src/app/shell/Link.m.scss
+++ b/src/app/shell/Link.m.scss
@@ -9,3 +9,11 @@
   margin: 0 4px 0 0 !important;
   vertical-align: middle;
 }
+
+.vendors {
+  height: 12px;
+  width: 12px;
+  margin: 0 4px 0 0px !important;
+  filter: invert(100%) invert(71%) sepia(96%) saturate(475%) hue-rotate(333deg) brightness(95%)
+    contrast(91%);
+}

--- a/src/app/shell/Link.m.scss.d.ts
+++ b/src/app/shell/Link.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'badgeNew': string;
+  'vendors': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/shell/Link.tsx
+++ b/src/app/shell/Link.tsx
@@ -3,6 +3,7 @@ import styles from './Link.m.scss';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { UISrefActive, UISref } from '@uirouter/react';
 import { router } from '../router';
+import vendorEngramSvg from '../../images/engram.svg';
 
 export default function Link({
   state,
@@ -21,12 +22,18 @@ export default function Link({
   // it can't handle lazy states, and we need to use "key" to nuke the whole component tree on updates.
   const [generation, setGeneration] = useState(0);
   useEffect(() => router.stateRegistry.onStatesChanged(() => setGeneration((g) => g + 1)), []);
+  const isVendors = state === 'destiny2.vendors';
 
   return (
     <UISrefActive key={generation} class="active">
       <UISref to={state} params={account}>
         <a className="link">
-          {showWhatsNew && <span className={styles.badgeNew} />}
+          {showWhatsNew &&
+            (isVendors ? (
+              <img src={vendorEngramSvg} className={styles.vendors} />
+            ) : (
+              <span className={styles.badgeNew} />
+            ))}
           {children}
           {text}
         </a>

--- a/src/app/vendors/Vendor.m.scss
+++ b/src/app/vendors/Vendor.m.scss
@@ -4,7 +4,7 @@
   width: 30px;
   height: 30px;
   vertical-align: middle;
-  margin: 5px 8px 5px 0;
+  margin: 5px 22px 5px 0;
 }
 
 .location {
@@ -45,28 +45,29 @@
     margin-right: 6px;
   }
 }
-
+.vendorIconWrapper {
+  position: relative;
+}
 .xyz-active-throb {
   opacity: 0.9 !important;
-  width: 25px;
-  height: 25px;
   border-radius: 100px;
-  margin-right: 10px;
   animation: glow 1s infinite alternate;
 }
 
 .xyz-engram {
-  width: 25px;
-  height: 25px;
-  margin-right: 10px;
-  opacity: 0.7;
+  width: 14px;
+  height: 14px;
+  opacity: 0.5;
+  position: absolute;
+  left: 26px;
+  top: 6px;
 }
 
 @keyframes glow {
   from {
-    box-shadow: 0 0 10px -10px rgba(174, 244, 175, 0.6);
+    box-shadow: 0 0 6px -10px rgba(174, 244, 175, 0.6);
   }
   to {
-    box-shadow: 0 0 10px 10px rgba(174, 244, 175, 0.6);
+    box-shadow: 0 0 6px 6px rgba(174, 244, 175, 0.6);
   }
 }

--- a/src/app/vendors/Vendor.m.scss.d.ts
+++ b/src/app/vendors/Vendor.m.scss.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'location': string;
   'title': string;
   'titleDetails': string;
+  'vendorIconWrapper': string;
   'xyzActiveThrob': string;
   'xyzEngram': string;
 }

--- a/src/app/vendors/Vendor.tsx
+++ b/src/app/vendors/Vendor.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
-import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import BungieImage from '../dim-ui/BungieImage';
-import Countdown from '../dim-ui/Countdown';
-import VendorItems from './VendorItems';
 import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
+import Countdown from '../dim-ui/Countdown';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { D2Vendor } from './d2-vendors';
-import styles from './Vendor.m.scss';
-import _ from 'lodash';
-import { isDroppingHigh } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
-import vendorEngramSvg from '../../images/engram.svg';
-import clsx from 'clsx';
-import { t } from 'app/i18next-t';
+import React from 'react';
 import { VendorDrop } from 'app/vendorEngramsXyzApi/vendorDrops';
+import VendorItems from './VendorItems';
+import _ from 'lodash';
+import clsx from 'clsx';
+import { isDroppingHigh } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
+import styles from './Vendor.m.scss';
+import { t } from 'app/i18next-t';
+import vendorEngramSvg from '../../images/engram.svg';
 
 /**
  * An individual Vendor in the "all vendors" page. Use SingleVendor for a page that only has one vendor on it.
@@ -56,18 +56,20 @@ export default function Vendor({
         className={styles.title}
         title={
           <>
-            {$featureFlags.vendorEngrams && vendorEngramDrops.length > 0 && (
-              <a target="_blank" rel="noopener noreferrer" href="https://vendorengrams.xyz/">
-                <img
-                  className={clsx(styles.xyzEngram, {
-                    [styles.xyzActiveThrob]: dropActive
-                  })}
-                  src={vendorEngramSvg}
-                  title={vendorLinkTitle}
-                />
-              </a>
-            )}
-            <BungieImage src={vendor.def.displayProperties.icon} className={styles.icon} />
+            <span className={styles.vendorIconWrapper}>
+              <BungieImage src={vendor.def.displayProperties.icon} className={styles.icon} />
+              {$featureFlags.vendorEngrams && vendorEngramDrops.length > 0 && (
+                <a target="_blank" rel="noopener noreferrer" href="https://vendorengrams.xyz/">
+                  <img
+                    className={clsx(styles.xyzEngram, {
+                      [styles.xyzActiveThrob]: dropActive
+                    })}
+                    src={vendorEngramSvg}
+                    title={vendorLinkTitle}
+                  />
+                </a>
+              )}
+            </span>
             <div className={styles.titleDetails}>
               <div>{vendor.def.displayProperties.name}</div>
               <div className={styles.location}>{placeString}</div>


### PR DESCRIPTION
equispaces vendor icons and their names, and tucks the vendorengrams icon more neatly into a position as supplemental info to the header
![image](https://user-images.githubusercontent.com/31990469/76690046-a522ba00-65f9-11ea-9bb0-8a4d49f355af.png)

also replaces the alert dot in the header
![image](https://user-images.githubusercontent.com/31990469/76692382-ed9aa180-6612-11ea-8579-afdabfcf9e3b.png)


