### PR TITLE
Holdsmod2

### DIFF
--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -14,7 +14,7 @@ import _ from 'lodash';
 import { getActivePlatform } from '../accounts/platforms';
 import { getClass } from './store/character-utils';
 import { getRating } from '../item-review/reducer';
-import modMetadataBySlotTag from 'data/d2/specialty-modslot-metadata.json';
+import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
 import store from '../store/store';
 import { t } from 'app/i18next-t';
 
@@ -303,14 +303,6 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
   // We need to always emit enough columns for all perks
   const maxPerks = getMaxPerks(items);
 
-  const seasonalModsByHash = {};
-  for (const mod in modMetadataBySlotTag) {
-    const hashes = modMetadataBySlotTag[mod].thisSlotPlugCategoryHashes;
-    hashes.forEach((hash) => {
-      seasonalModsByHash[hash] = mod;
-    });
-  }
-
   const data = items.map((item) => {
     const row: any = {
       Name: item.name,
@@ -399,12 +391,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
       });
 
       if (item.isDestiny2() && item.sockets) {
-        const seasonalMods = item.sockets.sockets
-          .map((socket) => socket?.plug?.plugItem?.plug?.plugCategoryHash)
-          .map((hash) => hash && seasonalModsByHash[hash])
-          .filter((mod) => mod)
-          .sort();
-        row['Seasonal Mod'] = seasonalMods.length > 0 ? seasonalMods.join(',') : '';
+        row['Seasonal Mod'] = getSpecialtySocketMetadata(item)?.tag ?? '';
       }
     }
 

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -1035,19 +1035,16 @@ function searchFilters(
       modslot(item: DimItem, predicate: string) {
         const modSocketTypeHash = getSpecialtySocketMetadata(item);
         return (
-          modSocketTypeHash &&
-          (Boolean(predicate === 'any' && modSocketTypeHash) ||
-            (predicate === 'none' && !modSocketTypeHash) ||
-            modSocketTypeHash.tag === predicate)
+          (predicate === 'none' && !modSocketTypeHash) ||
+          (modSocketTypeHash && (predicate === 'any' || modSocketTypeHash.tag === predicate))
         );
       },
       holdsmod(item: DimItem, predicate: string) {
         const modSocketTypeHash = getSpecialtySocketMetadata(item);
         return (
-          modSocketTypeHash &&
-          (Boolean(predicate === 'any' && modSocketTypeHash) ||
-            (predicate === 'none' && !modSocketTypeHash) ||
-            modSocketTypeHash.compatibleTags.includes(predicate))
+          (predicate === 'none' && !modSocketTypeHash) ||
+          (modSocketTypeHash &&
+            (predicate === 'any' || modSocketTypeHash.compatibleTags.includes(predicate)))
         );
       },
       powerfulreward(item: D2Item) {

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -16,7 +16,11 @@ import {
 import { ItemInfos, getNotes, getTag, itemTagSelectorList } from '../inventory/dim-item-info';
 import { ReviewsState, getRating, ratingsSelector, shouldShowRating } from '../item-review/reducer';
 import { chainComparator, compareBy, reverseComparator } from '../utils/comparators';
-import { getItemDamageShortName, getSpecialtySocketCategoryHash } from 'app/utils/item-utils';
+import {
+  getItemDamageShortName,
+  getSpecialtySocketMetadata,
+  modSlotTags
+} from 'app/utils/item-utils';
 import { itemInfosSelector, sortedStoresSelector } from '../inventory/reducer';
 import { maxLightItemSet, maxStatLoadout } from '../loadout/auto-loadouts';
 
@@ -37,7 +41,6 @@ import { inventoryWishListsSelector } from '../wishlists/reducer';
 import latinise from 'voca/latinise';
 import { loadoutsSelector } from '../loadout/reducer';
 import memoizeOne from 'memoize-one';
-import modMetadataBySlotTag from 'data/d2/specialty-modslot-metadata.json';
 import { querySelector } from '../shell/reducer';
 import seasonTags from 'data/d2/season-tags.json';
 import { settingsSelector } from 'app/settings/reducer';
@@ -316,12 +319,8 @@ export function buildSearchConfig(destinyVersion: 1 | 2): SearchConfig {
       .reverse()
       .map((tag) => `season:${tag}`),
     // keywords for seasonal mod slots
-    ...Object.keys(modMetadataBySlotTag)
-      .concat(['any', 'none'])
-      .map((modSlotName) => `modslot:${modSlotName}`),
-    ...Object.keys(modMetadataBySlotTag)
-      .concat(['any', 'none'])
-      .map((modSlotName) => `holdsmod:${modSlotName}`),
+    ...modSlotTags.concat(['any', 'none']).map((modSlotName) => `modslot:${modSlotName}`),
+    ...modSlotTags.concat(['any', 'none']).map((modSlotName) => `holdsmod:${modSlotName}`),
     // a keyword for every combination of a DIM-processed stat and mathmatical operator
     ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
     // energy capacity elements and ranges
@@ -1034,19 +1033,21 @@ function searchFilters(
         );
       },
       modslot(item: DimItem, predicate: string) {
-        const modSocketTypeHash = getSpecialtySocketCategoryHash(item);
+        const modSocketTypeHash = getSpecialtySocketMetadata(item);
         return (
-          Boolean(predicate === 'any' && modSocketTypeHash) ||
-          (predicate === 'none' && !modSocketTypeHash) ||
-          modMetadataBySlotTag[predicate]?.thisSlotPlugCategoryHashes.includes(modSocketTypeHash)
+          modSocketTypeHash &&
+          (Boolean(predicate === 'any' && modSocketTypeHash) ||
+            (predicate === 'none' && !modSocketTypeHash) ||
+            modSocketTypeHash.tag === predicate)
         );
       },
       holdsmod(item: DimItem, predicate: string) {
-        const modSocketTypeHash = getSpecialtySocketCategoryHash(item);
+        const modSocketTypeHash = getSpecialtySocketMetadata(item);
         return (
-          Boolean(predicate === 'any' && modSocketTypeHash) ||
-          (predicate === 'none' && !modSocketTypeHash) ||
-          modMetadataBySlotTag[predicate]?.compatiblePlugCategoryHashes.includes(modSocketTypeHash)
+          modSocketTypeHash &&
+          (Boolean(predicate === 'any' && modSocketTypeHash) ||
+            (predicate === 'none' && !modSocketTypeHash) ||
+            modSocketTypeHash.compatibleTags.includes(predicate))
         );
       },
       powerfulreward(item: D2Item) {

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -17,6 +17,31 @@ export function preventNaN(testValue, defaultValue) {
 }
 
 /**
+ * given @key 'key', turns
+ * [           { key: '1' },      { key: '2' } ]
+ * into { '1': { key: '1' }, '2': { key: '2' } }
+ */
+// i should be able to make this work though
+// export function objectifyArray<T, K extends keyof T>( array: T[],  key: string ): { [k: T[K]]: T };
+// export function objectifyArray<T>(  array: T[],  key: ((obj: any) => number)): { [k: number]: T };
+// export function objectifyArray<T>(  array: T[],  key: ((obj: any) => string)): { [k: string]: T };
+export function objectifyArray<T>(
+  array: T[],
+  key: string | ((obj: any) => number)
+): { [key: number]: T };
+export function objectifyArray<T>(
+  array: T[],
+  key: string | ((obj: any) => string)
+): { [key: string]: T };
+export function objectifyArray<T>(array: T[], key: string | ((obj: any) => string | number)) {
+  return array.reduce((acc, val) => {
+    if (typeof key === 'string') acc[val[key]] = val;
+    else acc[key(val)] = val;
+    return acc;
+  }, {});
+}
+
+/**
  * Produce a function that can memoize a calculation about an item. The cache is backed by
  * a WeakMap so when the item is garbage collected the cache is freed up too.
  */

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -21,10 +21,6 @@ export function preventNaN(testValue, defaultValue) {
  * [           { key: '1' },      { key: '2' } ]
  * into { '1': { key: '1' }, '2': { key: '2' } }
  */
-// i should be able to make this work though
-// export function objectifyArray<T, K extends keyof T>( array: T[],  key: string ): { [k: T[K]]: T };
-// export function objectifyArray<T>(  array: T[],  key: ((obj: any) => number)): { [k: number]: T };
-// export function objectifyArray<T>(  array: T[],  key: ((obj: any) => string)): { [k: string]: T };
 export function objectifyArray<T>(
   array: T[],
   key: string | ((obj: any) => number)

--- a/src/data/d2/specialty-modslot-metadata.json
+++ b/src/data/d2/specialty-modslot-metadata.json
@@ -1,26 +1,44 @@
 {
-  "forge": {
+  "720857": {
+    "tag": "forge",
     "thisSlotPlugCategoryHashes": [65589297],
-    "compatiblePlugCategoryHashes": [2149155760, 13646368, 65589297]
+    "compatiblePlugCategoryHashes": [2149155760, 13646368, 65589297],
+    "compatibleTags": ["forge", "outlaw"],
+    "emptySlotItemHash": 720857
   },
-  "opulent": {
+  "4106547009": {
+    "tag": "opulent",
     "thisSlotPlugCategoryHashes": [1962317640, 2712224971, 1202876185],
-    "compatiblePlugCategoryHashes": [1962317640, 2712224971, 1202876185, 1081029832]
+    "compatiblePlugCategoryHashes": [1962317640, 2712224971, 1202876185, 1081029832],
+    "compatibleTags": ["undying", "opulent"],
+    "emptySlotItemHash": 4106547009
   },
-  "worthy": {
+  "2655746324": {
+    "tag": "worthy",
     "thisSlotPlugCategoryHashes": [426869514],
-    "compatiblePlugCategoryHashes": [208760563, 426869514]
+    "compatiblePlugCategoryHashes": [208760563, 426869514],
+    "compatibleTags": ["undying", "worthy"],
+    "emptySlotItemHash": 2655746324
   },
-  "outlaw": {
+  "3625698764": {
+    "tag": "outlaw",
     "thisSlotPlugCategoryHashes": [2149155760, 13646368],
-    "compatiblePlugCategoryHashes": [2149155760, 13646368, 65589297]
+    "compatiblePlugCategoryHashes": [2149155760, 13646368, 65589297],
+    "compatibleTags": ["forge", "outlaw"],
+    "emptySlotItemHash": 3625698764
   },
-  "undying": {
+  "2620967748": {
+    "tag": "undying",
     "thisSlotPlugCategoryHashes": [1081029832],
-    "compatiblePlugCategoryHashes": [1962317640, 2712224971, 1202876185, 1081029832, 208760563]
+    "compatiblePlugCategoryHashes": [1962317640, 2712224971, 1202876185, 1081029832, 208760563],
+    "compatibleTags": ["opulent", "undying", "worthy"],
+    "emptySlotItemHash": 2620967748
   },
-  "dawn": {
+  "2357307006": {
+    "tag": "dawn",
     "thisSlotPlugCategoryHashes": [208760563],
-    "compatiblePlugCategoryHashes": [1081029832, 208760563, 426869514]
+    "compatiblePlugCategoryHashes": [1081029832, 208760563, 426869514],
+    "compatibleTags": ["undying", "dawn", "worthy"],
+    "emptySlotItemHash": 2357307006
   }
 }

--- a/src/data/d2/specialty-modslot-metadata.json
+++ b/src/data/d2/specialty-modslot-metadata.json
@@ -1,44 +1,50 @@
-{
-  "720857": {
-    "tag": "forge",
-    "thisSlotPlugCategoryHashes": [65589297],
-    "compatiblePlugCategoryHashes": [2149155760, 13646368, 65589297],
-    "compatibleTags": ["forge", "outlaw"],
-    "emptySlotItemHash": 720857
-  },
-  "4106547009": {
-    "tag": "opulent",
-    "thisSlotPlugCategoryHashes": [1962317640, 2712224971, 1202876185],
-    "compatiblePlugCategoryHashes": [1962317640, 2712224971, 1202876185, 1081029832],
-    "compatibleTags": ["undying", "opulent"],
-    "emptySlotItemHash": 4106547009
-  },
-  "2655746324": {
-    "tag": "worthy",
-    "thisSlotPlugCategoryHashes": [426869514],
-    "compatiblePlugCategoryHashes": [208760563, 426869514],
-    "compatibleTags": ["undying", "worthy"],
-    "emptySlotItemHash": 2655746324
-  },
-  "3625698764": {
+[
+  {
+    "season": 4,
     "tag": "outlaw",
+    "compatibleTags": ["outlaw", "forge"],
     "thisSlotPlugCategoryHashes": [2149155760, 13646368],
     "compatiblePlugCategoryHashes": [2149155760, 13646368, 65589297],
-    "compatibleTags": ["forge", "outlaw"],
-    "emptySlotItemHash": 3625698764
+    "emptyModSocketHash": 3625698764
   },
-  "2620967748": {
+  {
+    "season": 5,
+    "tag": "forge",
+    "compatibleTags": ["outlaw", "forge"],
+    "thisSlotPlugCategoryHashes": [65589297],
+    "compatiblePlugCategoryHashes": [2149155760, 13646368, 65589297],
+    "emptyModSocketHash": 720857
+  },
+  {
+    "season": 7,
+    "tag": "opulent",
+    "compatibleTags": ["opulent", "undying"],
+    "thisSlotPlugCategoryHashes": [1962317640, 2712224971, 1202876185],
+    "compatiblePlugCategoryHashes": [1962317640, 2712224971, 1202876185, 1081029832],
+    "emptyModSocketHash": 4106547009
+  },
+  {
+    "season": 8,
     "tag": "undying",
+    "compatibleTags": ["opulent", "undying", "dawn"],
     "thisSlotPlugCategoryHashes": [1081029832],
     "compatiblePlugCategoryHashes": [1962317640, 2712224971, 1202876185, 1081029832, 208760563],
-    "compatibleTags": ["opulent", "undying", "worthy"],
-    "emptySlotItemHash": 2620967748
+    "emptyModSocketHash": 2620967748
   },
-  "2357307006": {
+  {
+    "season": 9,
     "tag": "dawn",
+    "compatibleTags": ["undying", "dawn", "worthy"],
     "thisSlotPlugCategoryHashes": [208760563],
     "compatiblePlugCategoryHashes": [1081029832, 208760563, 426869514],
-    "compatibleTags": ["undying", "dawn", "worthy"],
-    "emptySlotItemHash": 2357307006
+    "emptyModSocketHash": 2357307006
+  },
+  {
+    "season": 10,
+    "tag": "worthy",
+    "compatibleTags": ["dawn", "worthy"],
+    "thisSlotPlugCategoryHashes": [426869514],
+    "compatiblePlugCategoryHashes": [208760563, 426869514],
+    "emptyModSocketHash": 2655746324
   }
-}
+]


### PR DESCRIPTION
this fixes up the `holdsmod`
to depend on the socket's `singleInitialItemHash`
instead of the slotted mod's `plugCategoryHash`

this way we can't be fooled into thinking a `dawn` slot containing a `worthy` mod, is a `worthy` slot

also, much happier with this way of fetching mod metadata