### PR TITLE
Sync fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,9 @@ module.exports = {
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
   globals: {
     $BROWSERS: [],
+    $featureFlags: {
+      dimApi: true
+    },
     'ts-jest': {
       tsConfig: {
         target: 'ES2015',

--- a/src/app/dim-api/reducer.test.ts
+++ b/src/app/dim-api/reducer.test.ts
@@ -1,4 +1,4 @@
-import { DimApiState, initialState, dimApi } from './reducer';
+import { DimApiState, initialState as apiInitialState, dimApi } from './reducer';
 import { DestinyClass, BungieMembershipType } from 'bungie-api-ts/destiny2';
 import { DeleteLoadoutUpdateWithRollback } from './api-types';
 import { prepareToFlushUpdates, finishedUpdates } from './basic-actions';
@@ -16,6 +16,11 @@ const currentAccount: DestinyAccount = {
   platforms: [BungieMembershipType.TigerPsn]
 };
 const currentAccountKey = '98765-d2';
+
+const initialState: DimApiState = {
+  ...apiInitialState,
+  apiPermissionGranted: true
+};
 
 describe('setSetting', () => {
   it('changes settings', () => {

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -20,7 +20,6 @@ import {
 import { Loadout as DimLoadout, LoadoutItem as DimLoadoutItem } from '../loadout/loadout-types';
 import produce, { Draft } from 'immer';
 import { DestinyAccount } from 'app/accounts/destiny-account';
-import { apiPermissionGrantedSelector } from './selectors';
 
 export interface DimApiState {
   globalSettings: GlobalSettings;

--- a/src/app/storage/sync.service.ts
+++ b/src/app/storage/sync.service.ts
@@ -88,7 +88,7 @@ export const SyncService = {
       });
     } else {
       const apiScript = document.createElement('script');
-      apiScript.setAttribute('src', 'https://apis.google.com/js/api.js?callback=googleApiInit');
+      apiScript.setAttribute('src', 'https://apis.google.com/js/api.js');
       apiScript.defer = true;
       apiScript.async = true;
       document.body.append(apiScript);


### PR DESCRIPTION
This turns off all Redux state updates for the dim-api state if the API is disabled. I had changed my mind about how this worked at the last minute to allow opt-out to go back to the old system, and I forgot that I had also made the two states write in parallel. This makes it so those updates (and the flushing of those updates to the Sync API) don't happen if Sync is off.

I'll have to do a followup change that locally migrates the old state into the new state and switches to only using the new state, but I'll do that later. Originally I was planning on making Sync the only way to have data saved which would have made all this simpler and that's why I forgot to seal all the entry points.