### PR TITLE
use data urls for download

### DIFF
--- a/src/app/storage/StorageSettings.tsx
+++ b/src/app/storage/StorageSettings.tsx
@@ -1,33 +1,36 @@
-import React from 'react';
-import { t } from 'app/i18next-t';
 import './storage.scss';
-import { clearIgnoredUsers } from '../destinyTrackerApi/userFilter';
-import { StorageAdapter, SyncService } from './sync.service';
-import { router } from '../router';
-import clsx from 'clsx';
-import _ from 'lodash';
-import { reportException } from '../utils/exceptions';
-import { dataStats } from './data-stats';
+
 import {
   AppIcon,
-  saveIcon,
   clearIcon,
-  enabledIcon,
   disabledIcon,
-  signOutIcon,
-  uploadIcon,
+  downloadIcon,
+  enabledIcon,
+  saveIcon,
   signInIcon,
-  downloadIcon
+  signOutIcon,
+  uploadIcon
 } from '../shell/icons';
-import { Subscriptions } from '../utils/rx-utils';
-import { initSettings } from '../settings/settings';
+import { StorageAdapter, SyncService } from './sync.service';
+
 import { DriveAboutResource } from './google-drive-storage';
-import { GoogleDriveInfo } from './GoogleDriveInfo';
 import { DropzoneOptions } from 'react-dropzone';
 import FileUpload from '../dim-ui/FileUpload';
-import { percent } from '../shell/filters';
+import { GoogleDriveInfo } from './GoogleDriveInfo';
+import React from 'react';
+import { Subscriptions } from '../utils/rx-utils';
+import _ from 'lodash';
+import { clearIgnoredUsers } from '../destinyTrackerApi/userFilter';
+import clsx from 'clsx';
+import { dataStats } from './data-stats';
+import { download } from 'app/utils/util';
 import { importLegacyData } from 'app/dim-api/actions';
+import { initSettings } from '../settings/settings';
+import { percent } from '../shell/filters';
+import { reportException } from '../utils/exceptions';
+import { router } from '../router';
 import store from 'app/store/store';
+import { t } from 'app/i18next-t';
 
 declare global {
   interface Window {
@@ -233,21 +236,6 @@ export default class StorageSettings extends React.Component<{}, State> {
 
   private exportData = (e) => {
     e.preventDefault();
-    // Function to download data to a file
-    function download(data, filename, type) {
-      const a = document.createElement('a');
-      const file = new Blob([data], { type });
-      const url = URL.createObjectURL(file);
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      setTimeout(() => {
-        document.body.removeChild(a);
-        window.URL.revokeObjectURL(url);
-      });
-    }
-
     SyncService.get().then((data) => {
       download(JSON.stringify(data), 'dim-data.json', 'application/json');
     });

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -94,14 +94,10 @@ export default function copyString(str: string) {
 /** Download a string as a file */
 export function download(data: string, filename: string, type: string) {
   const a = document.createElement('a');
-  const file = new Blob([data], { type });
-  const url = URL.createObjectURL(file);
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
+  a.setAttribute('href', `data:${type};charset=utf-8,${encodeURIComponent(data)}`);
+  a.setAttribute('download', filename);
   a.click();
   setTimeout(() => {
     document.body.removeChild(a);
-    window.URL.revokeObjectURL(url);
   });
 }


### PR DESCRIPTION
collapsed 1 more duplicate implementation of a download function, and converted download back to using `data:` url since ios devices were choking on the blob implementation. maybe because of the link deletion immediately afterwards? big shrug