### PR TITLE
More sync fixes

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -853,6 +853,8 @@
     "LoadoutsD2": "{{value}} Destiny 2 loadouts",
     "MenuTitle": "Sync & Backups",
     "NoData": "No data",
+    "ProfileErrorTitle": "DIM Sync Error",
+    "ProfileErrorBody": "We had a problem loading your DIM Sync data",
     "RestoreRevision": "Restore",
     "RevisionsDescription": "Google Drive saves the last 100 revisions of your settings. Use this page to load old versions and restore them.",
     "Settings": "Your DIM settings and preferences",
@@ -860,6 +862,8 @@
     "TagNotesD1": "{{value}} Destiny 1 items with tags or notes",
     "TagNotesD2": "{{value}} Destiny 2 items with tags or notes",
     "Title": "Data Storage",
+    "UpdateErrorTitle": "DIM Sync Error",
+    "UpdateErrorBody": "We had a problem saving your data to DIM Sync",
     "Usage": "DIM is using {{usage, humanBytes}} out of {{quota, humanBytes}} available to it on this device. This includes the downloaded Destiny item databases from Bungie.net."
   },
   "StoreBucket": {

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -839,7 +839,7 @@
       "AlreadyImportedTitle": "Already Imported",
       "AlreadyImportedBody": "We didn't import your old data into DIM Sync because it has already been imported in the past. If you want to import it again, go to Settings.",
       "SkippedTitle": "Skipped Data Import",
-      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
+      "SkippedBody": "Your old data wasn't imported because you already have settings, loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
       "SuccessTitle": "Import Successful",
       "SuccessBody": "Imported {{loadouts}} loadouts and {{tags}} tagged items from your saved data into DIM Sync."
     },

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -836,8 +836,10 @@
     "ImportConfirm": "Are you sure you want to overwrite your current settings with this version? It has {{stats}}.",
     "ImportConfirmDimApi": "Are you sure you want to overwrite your current tags, loadouts, and settings with this version? It will completely replace what you had.",
     "ImportNotification": {
+      "AlreadyImportedTitle": "Already Imported",
+      "AlreadyImportedBody": "We didn't import your old data into DIM Sync because it has already been imported in the past. If you want to import it again, go to Settings.",
       "SkippedTitle": "Skipped Data Import",
-      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from the Settings page.",
+      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
       "SuccessTitle": "Import Successful",
       "SuccessBody": "Imported {{loadouts}} loadouts and {{tags}} tagged items from your saved data into DIM Sync."
     },

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -836,8 +836,6 @@
     "ImportConfirm": "Are you sure you want to overwrite your current settings with this version? It has {{stats}}.",
     "ImportConfirmDimApi": "Are you sure you want to overwrite your current tags, loadouts, and settings with this version? It will completely replace what you had.",
     "ImportNotification": {
-      "AlreadyImportedTitle": "Already Imported",
-      "AlreadyImportedBody": "We didn't import your old data into DIM Sync because it has already been imported in the past. If you want to import it again, go to Settings.",
       "SkippedTitle": "Skipped Data Import",
       "SkippedBody": "Your old data wasn't imported because you already have settings, loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
       "SuccessTitle": "Import Successful",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -835,6 +835,12 @@
     "Import": "Import Data Backup",
     "ImportConfirm": "Are you sure you want to overwrite your current settings with this version? It has {{stats}}.",
     "ImportConfirmDimApi": "Are you sure you want to overwrite your current tags, loadouts, and settings with this version? It will completely replace what you had.",
+    "ImportNotification": {
+      "SkippedTitle": "Skipped Data Import",
+      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from the Settings page.",
+      "SuccessTitle": "Import Successful",
+      "SuccessBody": "Imported {{loadouts}} loadouts and {{tags}} tagged items from your saved data into DIM Sync."
+    },
     "ImportExport": "Backup & Import",
     "ImportFailed": "Import Failed! {{error}}",
     "ImportNoFile": "No file selected!",

--- a/src/app/bungie-api/error-toaster.tsx
+++ b/src/app/bungie-api/error-toaster.tsx
@@ -29,3 +29,26 @@ export function bungieErrorToaster(e: Error): NotifyInput {
     )
   };
 }
+
+export function dimErrorToaster(title: string, message: string, e: Error): NotifyInput {
+  return {
+    type: 'error',
+    title,
+    body: (
+      <>
+        <div>
+          {message}: {e.message}
+        </div>
+        <div>
+          {t('BungieService.Twitter')}{' '}
+          <ExternalLink href="http://twitter.com/ThisIsDIM">Twitter</ExternalLink>{' '}
+          <ExternalLink href="http://twitter.com/ThisIsDIM">
+            <span style={{ fontSize: '1.5em', verticalAlign: 'middle' }}>
+              <AppIcon icon={twitterIcon} />
+            </span>
+          </ExternalLink>
+        </div>
+      </>
+    )
+  };
+}

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -289,6 +289,14 @@ export function importLegacyData(data?: DimData, force = false): ThunkResult<any
       return;
     }
 
+    if (isLegacyDataEmpty(data)) {
+      console.log(
+        "[importLegacyData] Don't need to import, there are no tags or loadouts in the legacy data"
+      );
+      // Silently return
+      return;
+    }
+
     dimApiData = getState().dimApi;
 
     if (
@@ -334,6 +342,24 @@ export function deleteAllApiData(): ThunkResult<any> {
 
     return result;
   };
+}
+
+/** Does the legacy data contain any loadouts or tags? We don't check settings. */
+function isLegacyDataEmpty(data: DimData) {
+  if (data['loadouts-v3.0']?.length) {
+    return false;
+  }
+
+  for (const key in importData) {
+    const match = /dimItemInfo-m(\d+)-d(1|2)/.exec(key);
+    if (match && !_.isEmpty(importData[key])) {
+      return false;
+    }
+  }
+
+  // TODO: we could look for different settings, but I suspect that'll be noisy
+
+  return true;
 }
 
 function showBackupDownloadedNotification() {

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -128,7 +128,9 @@ let getProfileBackoff = 0;
 export function loadDimApiData(forceLoad = false): ThunkResult<void> {
   return async (dispatch, getState) => {
     const getPlatformsPromise = getPlatforms(); // in parallel, we'll wait later
-    dispatch(loadProfileFromIndexedDB()); // In parallel, no waiting
+    if (!getState().dimApi.profileLoadedFromIndexedDb && !getState().dimApi.profileLoaded) {
+      dispatch(loadProfileFromIndexedDB()); // In parallel, no waiting
+    }
     installObservers(dispatch); // idempotent
 
     if (!getState().dimApi.globalSettingsLoaded) {

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -285,7 +285,6 @@ export function importLegacyData(data?: DimData, force = false): ThunkResult<any
 
     if (!force && data.importedToDimApi) {
       console.log("[importLegacyData] Don't need to import, this legacy data has already imported");
-      showAlreadyImportedNotification();
       return;
     }
 
@@ -387,13 +386,5 @@ function showImportSuccessNotification(result: { loadouts: number; tags: number 
     type: 'success',
     title: t('Storage.ImportNotification.SuccessTitle'),
     body: t('Storage.ImportNotification.SuccessBody', result)
-  });
-}
-
-function showAlreadyImportedNotification() {
-  showNotification({
-    type: 'warning',
-    title: t('Storage.ImportNotification.AlreadyImportedTitle'),
-    body: t('Storage.ImportNotification.AlreadyImportedBody')
   });
 }

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -114,11 +114,7 @@ export function loadDimApiData(forceLoad = false): ThunkResult<void> {
       const useApi = await promptForApiPermission();
       dispatch(setApiPermissionGranted(useApi));
       if (useApi) {
-        showNotification({
-          type: 'success',
-          title: t('Storage.DimSyncEnabled'),
-          body: t('Storage.AutoBackup')
-        });
+        showBackupDownloadedNotification();
       }
     }
 
@@ -289,6 +285,7 @@ export function importLegacyData(data?: DimData, force = false): ThunkResult<any
 
     if (!force && data.importedToDimApi) {
       console.log("[importLegacyData] Don't need to import, this legacy data has already imported");
+      showAlreadyImportedNotification();
       return;
     }
 
@@ -339,7 +336,15 @@ export function deleteAllApiData(): ThunkResult<any> {
   };
 }
 
-export function showImportSkippedNotification() {
+function showBackupDownloadedNotification() {
+  showNotification({
+    type: 'success',
+    title: t('Storage.DimSyncEnabled'),
+    body: t('Storage.AutoBackup')
+  });
+}
+
+function showImportSkippedNotification() {
   showNotification({
     type: 'warning',
     title: t('Storage.ImportNotification.SkippedTitle'),
@@ -347,10 +352,18 @@ export function showImportSkippedNotification() {
   });
 }
 
-export function showImportSuccessNotification(result: { loadouts: number; tags: number }) {
+function showImportSuccessNotification(result: { loadouts: number; tags: number }) {
   showNotification({
     type: 'success',
     title: t('Storage.ImportNotification.SuccessTitle'),
     body: t('Storage.ImportNotification.SuccessBody', result)
+  });
+}
+
+function showAlreadyImportedNotification() {
+  showNotification({
+    type: 'warning',
+    title: t('Storage.ImportNotification.AlreadyImportedTitle'),
+    body: t('Storage.ImportNotification.AlreadyImportedBody')
   });
 }

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -85,6 +85,15 @@ const installObservers = _.once((dispatch: ThunkDispatch<RootState, {}, AnyActio
       }
     }
   );
+
+  // Observe the current account and reload data
+  // Another one that should probably be a thunk action once account transitions are actions
+  observeStore(currentAccountSelector, (oldAccount) => {
+    // Force load profile data if the account changed
+    if (oldAccount) {
+      dispatch(loadDimApiData(true));
+    }
+  });
 });
 
 /**
@@ -347,9 +356,9 @@ export function importLegacyData(data?: DimData, force = false): ThunkResult<any
     dimApiData = getState().dimApi;
 
     if (
-      (!force &&
-        Object.values(dimApiData.profiles).some((p) => p.loadouts?.length || p.tags?.length)) ||
-      !_.isEmpty(subtractObject(dimApiData.settings, initialSettingsState))
+      !force &&
+      (Object.values(dimApiData.profiles).some((p) => p.loadouts?.length || p.tags?.length) ||
+        !_.isEmpty(subtractObject(dimApiData.settings, initialSettingsState)))
     ) {
       console.warn(
         '[importLegacyData] Skipping legacy data import because there are already settings, loadouts or tags in the DIM API profile data'

--- a/src/app/dim-api/api-permission-prompt.tsx
+++ b/src/app/dim-api/api-permission-prompt.tsx
@@ -30,6 +30,7 @@ export function promptForApiPermission() {
 
   showNotification({
     type: 'success',
+    onClick: () => false,
     promise,
     title: t('Storage.ApiPermissionPrompt.Title'),
     body: (

--- a/src/app/dim-api/api-permission-prompt.tsx
+++ b/src/app/dim-api/api-permission-prompt.tsx
@@ -32,6 +32,7 @@ export function promptForApiPermission() {
     type: 'success',
     onClick: () => false,
     promise,
+    duration: 0, // close immediately on click
     title: t('Storage.ApiPermissionPrompt.Title'),
     body: (
       <>

--- a/src/app/dim-api/basic-actions.ts
+++ b/src/app/dim-api/basic-actions.ts
@@ -23,6 +23,8 @@ export const profileLoaded = createAction('dim-api/PROFILE_LOADED')<{
   account?: DestinyAccount;
 }>();
 
+export const profileLoadError = createAction('dim-api/PROFILE_ERROR')<Error>();
+
 export type ProfileIndexedDBState = Pick<DimApiState, 'settings' | 'profiles' | 'updateQueue'>;
 export const profileLoadedFromIDB = createAction('dim-api/LOADED_PROFILE_FROM_IDB')<
   ProfileIndexedDBState | undefined

--- a/src/app/dim-api/dim-api-helper.ts
+++ b/src/app/dim-api/dim-api-helper.ts
@@ -17,6 +17,11 @@ export async function unauthenticatedApi<T>(
   config: HttpClientConfig,
   noApiKey?: boolean
 ): Promise<T> {
+  if (!API_KEY) {
+    router.stateService.go('developer');
+    throw new Error('No DIM API key configured');
+  }
+
   let url = `${DIM_API_HOST}${config.url}`;
   if (config.params) {
     url = `${url}?${stringify(config.params)}`;

--- a/src/app/dim-api/dim-api.ts
+++ b/src/app/dim-api/dim-api.ts
@@ -41,7 +41,10 @@ export async function getDimApiProfile(account?: DestinyAccount) {
 }
 
 export async function importData(data: DimData) {
-  const response = await authenticatedApi<ProfileResponse>({
+  const response = await authenticatedApi<{
+    loadouts: number;
+    tags: number;
+  }>({
     url: '/import',
     method: 'POST',
     body: data

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -30,7 +30,6 @@ export interface DimApiState {
 
   profileLoadedFromIndexedDb: boolean;
   profileLoaded: boolean;
-  // TODO: set this from an action
   profileLoadedError?: Error;
 
   /**
@@ -174,6 +173,7 @@ export const dimApi = (
       return {
         ...state,
         profileLoaded: true,
+        profileLoadedError: undefined,
         settings: {
           ...state.settings,
           ...profileResponse.settings
@@ -188,6 +188,13 @@ export const dimApi = (
               }
             }
           : state.profiles
+      };
+    }
+
+    case getType(actions.profileLoadError): {
+      return {
+        ...state,
+        profileLoadedError: action.payload
       };
     }
 

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -192,8 +192,6 @@ export const dimApi = (
     }
 
     case getType(actions.setApiPermissionGranted): {
-      // This is bad, but whatever
-      localStorage.setItem('dim-api-enabled', action.payload ? 'true' : 'false');
       return {
         ...state,
         apiPermissionGranted: action.payload

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -121,9 +121,11 @@ export const dimApi = (
   account?: DestinyAccount
 ): DimApiState => {
   if (
-    !$featureFlags.dimApi ||
-    state.apiPermissionGranted !== true ||
-    !state.globalSettings.dimApiEnabled
+    (!$featureFlags.dimApi ||
+      state.apiPermissionGranted !== true ||
+      !state.globalSettings.dimApiEnabled) &&
+    // Let through the ability to change the API permission
+    action.type !== getType(actions.setApiPermissionGranted)
   ) {
     // If the API is off, don't track state. We will want to tweak this when we start using
     // this state as the local state even when Sync is off, but for now it avoids us doing the

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -31,6 +31,8 @@ export interface DimApiState {
   profileLoadedFromIndexedDb: boolean;
   profileLoaded: boolean;
   profileLoadedError?: Error;
+  // unix timestamp for when the profile was last loaded
+  profileLastLoaded: number;
 
   /**
    * App settings. Settings are global, not per-platform-membership
@@ -97,6 +99,7 @@ export const initialState: DimApiState = {
 
   profileLoaded: false,
   profileLoadedFromIndexedDb: false,
+  profileLastLoaded: 0,
 
   settings: initialSettingsState,
 
@@ -174,6 +177,7 @@ export const dimApi = (
         ...state,
         profileLoaded: true,
         profileLoadedError: undefined,
+        profileLastLoaded: Date.now(),
         settings: {
           ...state.settings,
           ...profileResponse.settings

--- a/src/app/notifications/Notification.tsx
+++ b/src/app/notifications/Notification.tsx
@@ -45,8 +45,9 @@ export default function Notification({ notification, style, onClose }: Props) {
   }, [setupTimer]);
 
   const onClick = (event: React.MouseEvent) => {
-    notification.onClick?.(event);
-    onClose(notification);
+    if (notification.onClick?.(event) !== false) {
+      onClose(notification);
+    }
   };
 
   const onMouseOver = () => {

--- a/src/app/notifications/notifications.ts
+++ b/src/app/notifications/notifications.ts
@@ -13,7 +13,8 @@ export interface NotifyInput {
   promise?: Promise<any>;
   /** The notification will show for the given number of milliseconds. */
   duration?: number;
-  onClick?(event: React.MouseEvent): void;
+  /** Return false to not close the notification on click. */
+  onClick?(event: React.MouseEvent): boolean | void;
 }
 
 export interface Notify {
@@ -26,7 +27,7 @@ export interface Notify {
   promise?: Promise<any>;
   /** The notification will show for either the given number of milliseconds, or when the provided promise completes. */
   duration: number;
-  onClick?(event: React.MouseEvent): void;
+  onClick?(event: React.MouseEvent): boolean | void;
 }
 
 export const notifications$ = new Subject<Notify>();

--- a/src/app/storage/DimApiSettings.tsx
+++ b/src/app/storage/DimApiSettings.tsx
@@ -22,11 +22,13 @@ import { exportDimApiData } from 'app/dim-api/dim-api';
 
 interface StoreProps {
   apiPermissionGranted: boolean;
+  profileLoadedError?: Error;
 }
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    apiPermissionGranted: apiPermissionGrantedSelector(state)
+    apiPermissionGranted: apiPermissionGrantedSelector(state),
+    profileLoadedError: state.dimApi.profileLoadedError
   };
 }
 
@@ -35,9 +37,7 @@ type Props = StoreProps & ThunkDispatchProp;
 export const dimApiHelpLink =
   'https://github.com/DestinyItemManager/DIM/wiki/DIM-Sync-(new-storage-for-tags,-loadouts,-and-settings)';
 
-function DimApiSettings({ apiPermissionGranted, dispatch }: Props) {
-  // TODO: Show any sync errors here
-
+function DimApiSettings({ apiPermissionGranted, dispatch, profileLoadedError }: Props) {
   const [hasBackedUp, setHasBackedUp] = useState(false);
 
   const onApiPermissionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -116,6 +116,12 @@ function DimApiSettings({ apiPermissionGranted, dispatch }: Props) {
         </div>
         <div className="fineprint">{t('Storage.DimApiFinePrint')}</div>
       </div>
+      {profileLoadedError && (
+        <div className="dim-error">
+          <h2>{t('Storage.ProfileErrorTitle')}</h2>
+          <div>{profileLoadedError.message}</div>
+        </div>
+      )}
       {$featureFlags.dimApi && apiPermissionGranted && (
         <div className="setting horizontal">
           <label>{t('Storage.AuditLogLabel')}</label>

--- a/src/app/storage/DimApiSettings.tsx
+++ b/src/app/storage/DimApiSettings.tsx
@@ -41,8 +41,11 @@ function DimApiSettings({ apiPermissionGranted, dispatch }: Props) {
   const [hasBackedUp, setHasBackedUp] = useState(false);
 
   const onApiPermissionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    dispatch(setApiPermissionGranted(event.target.checked));
-    dispatch(loadDimApiData());
+    const granted = event.target.checked;
+    dispatch(setApiPermissionGranted(granted));
+    if (granted) {
+      dispatch(loadDimApiData());
+    }
   };
 
   const onExportData = async () => {

--- a/src/app/storage/StorageSettings.tsx
+++ b/src/app/storage/StorageSettings.tsx
@@ -24,12 +24,10 @@ import { clearIgnoredUsers } from '../destinyTrackerApi/userFilter';
 import clsx from 'clsx';
 import { dataStats } from './data-stats';
 import { download } from 'app/utils/util';
-import { importLegacyData } from 'app/dim-api/actions';
 import { initSettings } from '../settings/settings';
 import { percent } from '../shell/filters';
 import { reportException } from '../utils/exceptions';
 import { router } from '../router';
-import store from 'app/store/store';
 import { t } from 'app/i18next-t';
 
 declare global {
@@ -282,9 +280,6 @@ export default class StorageSettings extends React.Component<{}, State> {
             await SyncService.set(data, true);
             await Promise.all(SyncService.adapters.map(this.refreshAdapter));
             initSettings();
-            if ($featureFlags.dimApi) {
-              await ((store.dispatch(importLegacyData(data, true)) as any) as Promise<any>);
-            }
             alert(t('Storage.ImportSuccess'));
           }
         } catch (e) {

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -96,8 +96,7 @@ export function download(data: string, filename: string, type: string) {
   const a = document.createElement('a');
   a.setAttribute('href', `data:${type};charset=utf-8,${encodeURIComponent(data)}`);
   a.setAttribute('download', filename);
+  document.body.appendChild(a);
   a.click();
-  setTimeout(() => {
-    document.body.removeChild(a);
-  });
+  setTimeout(() => document.body.removeChild(a));
 }

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -834,7 +834,7 @@
     "ImportNotification": {
       "AlreadyImportedBody": "We didn't import your old data into DIM Sync because it has already been imported in the past. If you want to import it again, go to Settings.",
       "AlreadyImportedTitle": "Already Imported",
-      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
+      "SkippedBody": "Your old data wasn't imported because you already have settings, loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
       "SkippedTitle": "Skipped Data Import",
       "SuccessBody": "Imported {{loadouts}} loadouts and {{tags}} tagged items from your saved data into DIM Sync.",
       "SuccessTitle": "Import Successful"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -832,7 +832,9 @@
     "ImportFailed": "Import Failed! {{error}}",
     "ImportNoFile": "No file selected!",
     "ImportNotification": {
-      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from the Settings page.",
+      "AlreadyImportedBody": "We didn't import your old data into DIM Sync because it has already been imported in the past. If you want to import it again, go to Settings.",
+      "AlreadyImportedTitle": "Already Imported",
+      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
       "SkippedTitle": "Skipped Data Import",
       "SuccessBody": "Imported {{loadouts}} loadouts and {{tags}} tagged items from your saved data into DIM Sync.",
       "SuccessTitle": "Import Successful"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -832,8 +832,6 @@
     "ImportFailed": "Import Failed! {{error}}",
     "ImportNoFile": "No file selected!",
     "ImportNotification": {
-      "AlreadyImportedBody": "We didn't import your old data into DIM Sync because it has already been imported in the past. If you want to import it again, go to Settings.",
-      "AlreadyImportedTitle": "Already Imported",
       "SkippedBody": "Your old data wasn't imported because you already have settings, loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from Settings.",
       "SkippedTitle": "Skipped Data Import",
       "SuccessBody": "Imported {{loadouts}} loadouts and {{tags}} tagged items from your saved data into DIM Sync.",
@@ -848,6 +846,8 @@
     "LoadoutsD2": "{{value}} Destiny 2 loadouts",
     "MenuTitle": "Sync & Backups",
     "NoData": "No data",
+    "ProfileErrorBody": "We had a problem loading your DIM Sync data",
+    "ProfileErrorTitle": "DIM Sync Error",
     "RestoreRevision": "Restore",
     "RevisionsDescription": "Google Drive saves the last 100 revisions of your settings. Use this page to load old versions and restore them.",
     "Settings": "Your DIM settings and preferences",
@@ -855,6 +855,8 @@
     "TagNotesD1": "{{value}} Destiny 1 items with tags or notes",
     "TagNotesD2": "{{value}} Destiny 2 items with tags or notes",
     "Title": "Data Storage",
+    "UpdateErrorBody": "We had a problem saving your data to DIM Sync",
+    "UpdateErrorTitle": "DIM Sync Error",
     "Usage": "DIM is using {{usage, humanBytes}} out of {{quota, humanBytes}} available to it on this device. This includes the downloaded Destiny item databases from Bungie.net."
   },
   "StoreBucket": {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -208,6 +208,7 @@
     "HasNotes": "Show items that have notes applied.",
     "HasOrnament": "Shows items that have an ornament applied.",
     "HasShader": "Shows items that have a shader applied.",
+    "HoldsMod": "Shows armor compatible with a specific type of Seasonal Mod.",
     "InLoadout": "Shows items that are included in any loadout.",
     "Infusable": "Shows items that can be infused.",
     "Leveling": {
@@ -224,7 +225,7 @@
     "LockAllSuccess": "Locked {{num}} items",
     "Locked": "Shows items based on their locked status.",
     "MaxPower": "Shows the items which would maximize Power Level for each character class.",
-    "ModSlot": "Shows armor compatible with a specific type of Seasonal Mod.",
+    "ModSlot": "Shows armor with a specific Seasonal Mod slot.",
     "Mods": {
       "Y2": "Shows items with a Year 2 mod attached.",
       "Y3": "Shows items with any Armor 2.0 mods selected."
@@ -830,6 +831,12 @@
     "ImportExport": "Backup & Import",
     "ImportFailed": "Import Failed! {{error}}",
     "ImportNoFile": "No file selected!",
+    "ImportNotification": {
+      "SkippedBody": "Your old data wasn't imported because you already have loadouts or tags saved in DIM Sync. If you want to replace that data, you can use the backup that was just saved, or from the Settings page.",
+      "SkippedTitle": "Skipped Data Import",
+      "SuccessBody": "Imported {{loadouts}} loadouts and {{tags}} tagged items from your saved data into DIM Sync.",
+      "SuccessTitle": "Import Successful"
+    },
     "ImportSuccess": "Imported DIM data!",
     "ImportTooManyFiles": "Please only select one file to import.",
     "ImportWrongFileType": "File is not a JSON file. It may not be a DIM backup.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,9 +830,9 @@
     minimist "^1.2.0"
 
 "@destinyitemmanager/dim-api-types@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@destinyitemmanager/dim-api-types/-/dim-api-types-1.1.0.tgz#d7fd73064b39de54af671d88a0159b8cb49ba02c"
-  integrity sha512-xmtDdscCVPuxyccfDuC6ZbcnS1XTjz57aTTKmBPxYKCGIr+XTpzAvaEEecrD2QTusZdrSn5E1o9VfDNJWCtkBA==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@destinyitemmanager/dim-api-types/-/dim-api-types-1.2.0.tgz#985b95d301bbdee85e0043be33518bbcdf1faf2c"
+  integrity sha512-7AhtaLTisHk8sA+nhNS/a4/1TvtbyXkTC2ZMBblqWq/rEmsYoL5JnE/4Vz8Ea29JX7HX6bxBOl1PV9pMoZr5FQ==
 
 "@fortawesome/fontawesome-common-types@^0.2.27":
   version "0.2.27"


### PR DESCRIPTION
1. My previous fix had actually disabled the ability to enable sync at all since it ignored all actions when API permission was off.
2. Download data had some bugs that caused console errors and may not have played nice with some browsers that expect links to be attached to the document.
3. Don't allow dismissing the sync prompt with a click - you gotta choose.
4. Add notifications when we import, and notifications when we *don't* import. Basically over-communicate.
5. Don't try to import if DIM Sync data has customized settings.
6. Don't try to import if the legacy data has nothing interesting (e.g. a brand new user).
7. Clear the "imported" flag from legacy data when we turn off Sync, since it can drift from there.
8. Error handling and notification, including retry of fetch profile. If there's a problem the error will be notified plus appear in the settings page.
9. Load API data when changing profile - otherwise you'd have to reload after switching profiles.
10. Periodically refresh DIM Sync data, tied to our refresh button. The minimum interval is controlled by server settings, defaults to 5 minutes.