### PR TITLE
spider planetary mats

### DIFF
--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -62,10 +62,15 @@ export default function VendorItems({
   if (vendor?.component?.vendorHash === 863940356) {
     currencies = _.uniqBy(
       [
-        ...vendor.def.itemList
-          .filter((i) => i.currencies.length && i.currencies[0].quantity === 5)
-          .map((i) => defs.InventoryItem.get(i.currencies[0].itemHash))
-          .filter((i) => i.itemCategoryHashes?.includes(2088636411)), // "Reputation Tokens"
+        defs.InventoryItem.get(950899352), // dusklight shards
+        defs.InventoryItem.get(2014411539), // alkane dust
+        defs.InventoryItem.get(3487922223), //  datalattice
+        defs.InventoryItem.get(1305274547), // phaseglass
+        defs.InventoryItem.get(49145143), // sim seed
+        defs.InventoryItem.get(31293053), // seraphite
+        defs.InventoryItem.get(1177810185), // etheric spiral
+        defs.InventoryItem.get(592227263), // baryon bough
+        defs.InventoryItem.get(3592324052), // helium filaments
         ...currencies
       ],
       (i) => i.hash


### PR DESCRIPTION
Spider is currently not showing planetary mats, he is selling, but sometimes showing items he is not currently selling. This changes to showing all he can possibly sell.

Before:
![image](https://user-images.githubusercontent.com/4798491/77176574-e8fa4100-6a89-11ea-822d-f8ea4b37d944.png)

After:
![image](https://user-images.githubusercontent.com/4798491/77176659-0202f200-6a8a-11ea-9b7f-9eb312e38935.png)


EDIT:
Possibly have d2ai maintain this list automatically