### PR TITLE
Document why we don't catch 500s

### DIFF
--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -200,8 +200,9 @@ export async function handleErrors<T>(response: Response): Promise<ServerRespons
     goToLoginPage();
     throw error(t('BungieService.NotLoggedIn'), errorCode);
   }
-  /* 526 = cloudflare */
-  if (response.status >= 500 && response.status <= 526) {
+  // 526 = cloudflare
+  // We don't catch 500s because the Bungie.net API started returning 500 for legitimate game conditions
+  if (response.status >= 502 && response.status <= 526) {
     throw error(t('BungieService.Difficulties'), errorCode);
   }
   if (errorCode === -1 && (response.status < 200 || response.status >= 400)) {

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -9,6 +9,7 @@ import { loadingTracker } from '../shell/loading-tracker';
 import { showNotification } from '../notifications/notifications';
 import { hideItemPopup } from 'app/item-popup/item-popup';
 import { moveItemNotification } from './MoveNotifications';
+import { PlatformErrorCodes } from 'bungie-api-ts/common';
 
 /**
  * Move the item to the specified store. Equip it if equip is true.
@@ -42,7 +43,7 @@ export const moveItemTo = queuedAction(
         if (
           e.code !== 'wrong-level' &&
           e.code !== 'no-space' &&
-          e.code !== 1671 /* PlatformErrorCodes.DestinyCannotPerformActionAtThisLocation */
+          e.code !== PlatformErrorCodes.DestinyCannotPerformActionAtThisLocation
         ) {
           reportException('moveItem', e);
         }


### PR DESCRIPTION
I knew there had to be a reason I hadn't been catching all 500s, and it's because for some reason the API started returning 500 for normal stuff like "you're out of space". This puts it back the way it was and documents why it was that way. Fixes #5019 .