### PR TITLE
Get rid of Bucket ID concept

### DIFF
--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -23,49 +23,48 @@ export const D1Categories = {
   Progress: ['Bounties', 'Quests', 'Missions']
 };
 
-// A mapping from the bucket names to DIM item types
-// Some buckets like vault and currencies have been ommitted
+// A mapping from the bucket hash to DIM item types
 const bucketToType = {
-  BUCKET_CHEST: 'Chest',
-  BUCKET_LEGS: 'Leg',
-  BUCKET_RECOVERY: 'LostItems',
-  BUCKET_SHIP: 'Ship',
-  BUCKET_MISSION: 'Missions',
-  BUCKET_ARTIFACT: 'Artifact',
-  BUCKET_HEAVY_WEAPON: 'Heavy',
-  BUCKET_COMMERCIALIZATION: 'SpecialOrders',
-  BUCKET_CONSUMABLES: 'Consumable',
-  BUCKET_PRIMARY_WEAPON: 'Primary',
-  BUCKET_CLASS_ITEMS: 'ClassItem',
-  BUCKET_BOOK_LARGE: 'RecordBook',
-  BUCKET_BOOK_SMALL: 'RecordBookLegacy',
-  BUCKET_QUESTS: 'Quests',
-  BUCKET_VEHICLE: 'Vehicle',
-  BUCKET_BOUNTIES: 'Bounties',
-  BUCKET_SPECIAL_WEAPON: 'Special',
-  BUCKET_SHADER: 'Shader',
-  BUCKET_MODS: 'Ornaments',
-  BUCKET_EMOTES: 'Emote',
-  BUCKET_MAIL: 'Messages',
-  BUCKET_BUILD: 'Class',
-  BUCKET_HEAD: 'Helmet',
-  BUCKET_ARMS: 'Gauntlets',
-  BUCKET_HORN: 'Horn',
-  BUCKET_MATERIALS: 'Material',
-  BUCKET_GHOST: 'Ghost',
-  BUCKET_EMBLEM: 'Emblem'
+  14239492: 'Chest',
+  20886954: 'Leg',
+  215593132: 'LostItems',
+  284967655: 'Ship',
+  375726501: 'Missions',
+  434908299: 'Artifact',
+  953998645: 'Heavy',
+  1367666825: 'SpecialOrders',
+  1469714392: 'Consumable',
+  1498876634: 'Primary',
+  1585787867: 'ClassItem',
+  2987185182: 'RecordBook',
+  549485690: 'RecordBookLegacy',
+  1801258597: 'Quests',
+  2025709351: 'Vehicle',
+  2197472680: 'Bounties',
+  2465295065: 'Special',
+  2973005342: 'Shader',
+  3313201758: 'Ornaments',
+  3054419239: 'Emote',
+  3161908920: 'Messages',
+  3284755031: 'Class',
+  3448274439: 'Helmet',
+  3551918588: 'Gauntlets',
+  3796357825: 'Horn',
+  3865314626: 'Material',
+  4023194814: 'Ghost',
+  4274335291: 'Emblem'
 };
 
-const vaultTypes = {
-  BUCKET_VAULT_ARMOR: 'Armor',
-  BUCKET_VAULT_WEAPONS: 'Weapons',
-  BUCKET_VAULT_ITEMS: 'General'
+export const vaultTypes = {
+  3003523923: 'Armor',
+  4046403665: 'Weapons',
+  138197802: 'General'
 };
-// TODO: use hashes
+
 const sortToVault = {
-  Armor: 'BUCKET_VAULT_ARMOR',
-  Weapons: 'BUCKET_VAULT_WEAPONS',
-  General: 'BUCKET_VAULT_ITEMS'
+  Armor: 3003523923,
+  Weapons: 4046403665,
+  General: 138197802
 };
 
 const typeToSort = {};
@@ -108,7 +107,6 @@ export const getBuckets = _.once(async () => {
       } else if (vaultTypes[id]) {
         sort = vaultTypes[id];
       }
-      console.log('bucket', id, def.hash);
       const bucket: InventoryBucket = {
         description: def.bucketDescription,
         name: def.bucketName,

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -61,6 +61,7 @@ const vaultTypes = {
   BUCKET_VAULT_WEAPONS: 'Weapons',
   BUCKET_VAULT_ITEMS: 'General'
 };
+// TODO: use hashes
 const sortToVault = {
   Armor: 'BUCKET_VAULT_ARMOR',
   Weapons: 'BUCKET_VAULT_WEAPONS',
@@ -78,11 +79,9 @@ export const getBuckets = _.once(async () => {
   const defs = await getDefinitions();
   const buckets: InventoryBuckets = {
     byHash: {},
-    byId: {},
     byType: {},
     byCategory: {},
     unknown: {
-      id: 'BUCKET_UNKNOWN',
       description: 'Unknown items. DIM needs a manifest update.',
       name: 'Unknown',
       hash: -1,
@@ -109,8 +108,8 @@ export const getBuckets = _.once(async () => {
       } else if (vaultTypes[id]) {
         sort = vaultTypes[id];
       }
+      console.log('bucket', id, def.hash);
       const bucket: InventoryBucket = {
-        id,
         description: def.bucketDescription,
         name: def.bucketName,
         hash: def.hash,
@@ -129,12 +128,11 @@ export const getBuckets = _.once(async () => {
         bucket[`in${sort}`] = true;
       }
       buckets.byHash[bucket.hash] = bucket;
-      buckets.byId[bucket.id] = bucket;
     }
   });
   _.forIn(buckets.byHash, (bucket: InventoryBucket) => {
     if (bucket.sort && sortToVault[bucket.sort]) {
-      bucket.vaultBucket = buckets.byId[sortToVault[bucket.sort]];
+      bucket.vaultBucket = buckets.byHash[sortToVault[bucket.sort]];
     }
   });
   _.forIn(D1Categories, (types, category) => {

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -99,13 +99,12 @@ export const getBuckets = _.once(async () => {
   };
   _.forIn(defs.InventoryBucket, (def: any) => {
     if (def.enabled) {
-      const id = def.bucketIdentifier;
-      const type = bucketToType[def.bucketIdentifier];
+      const type = bucketToType[def.hash];
       let sort: string | undefined;
       if (type) {
         sort = typeToSort[type];
-      } else if (vaultTypes[id]) {
-        sort = vaultTypes[id];
+      } else if (vaultTypes[def.hash]) {
+        sort = vaultTypes[def.hash];
       }
       const bucket: InventoryBucket = {
         description: def.bucketDescription,
@@ -115,7 +114,7 @@ export const getBuckets = _.once(async () => {
         capacity: def.itemCount,
         accountWide: false,
         category: BucketCategory.Item,
-        type: bucketToType[def.bucketIdentifier],
+        type: bucketToType[def.hash],
         sort
       };
       if (bucket.type) {

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -90,14 +90,12 @@ async function getBucketsUncached() {
     }
   };
   _.forIn(defs.InventoryBucket, (def: DestinyInventoryBucketDefinition) => {
-    const id = def.hash.toString();
     const type = bucketToType[def.hash];
     let sort: string | undefined;
     if (type) {
       sort = typeToSort[type];
     }
     const bucket: InventoryBucket = {
-      id,
       description: def.displayProperties.description,
       name: def.displayProperties.name,
       hash: def.hash,
@@ -116,7 +114,6 @@ async function getBucketsUncached() {
       bucket[`in${bucket.sort}`] = true;
     }
     buckets.byHash[bucket.hash] = bucket;
-    buckets.byId[bucket.id] = bucket;
   });
   const vaultMappings = {};
   defs.Vendor.get(1037843411).acceptedItems.forEach((items) => {

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import { getDefinitions } from './d2-definitions';
 import { InventoryBuckets, InventoryBucket } from '../inventory/inventory-buckets';
 
-// TODO: These have to change
 // TODO: We can generate this based on making a tree from DestinyItemCategoryDefinitions
 export const D2Categories = {
   Postmaster: ['Engrams', 'LostItems', 'Messages', 'SpecialOrders'],
@@ -13,16 +12,11 @@ export const D2Categories = {
   Inventory: ['Consumables', 'Modifications', 'Shaders']
 };
 
-// A mapping from the bucket names to DIM item types
-// Some buckets like vault and currencies have been ommitted
-// TODO: These have to change
-// TODO: retire "DIM types" in favor of DestinyItemCategoryDefinitions
-// TODO: there are no more bucket IDs... gotta update all this
-// bucket hash to DIM type
+// A mapping from the bucket hash to DIM item types
 const bucketToType: { [hash: number]: string | undefined } = {
   2465295065: 'Energy',
-  2689798304: 'Upgrade Point',
-  2689798305: 'Strange Coin',
+  2689798304: 'UpgradePoint',
+  2689798305: 'StrangeCoin',
   2689798308: 'Glimmer',
   2689798309: 'Legendary Shards',
   2689798310: 'Silver',
@@ -70,12 +64,10 @@ async function getBucketsUncached() {
   const buckets: InventoryBuckets = {
     byHash: {},
     byType: {},
-    byId: {},
     byCategory: {},
     unknown: {
       description: 'Unknown items. DIM needs a manifest update.',
       name: 'Unknown',
-      id: '-1',
       hash: -1,
       hasTransferDestination: false,
       capacity: Number.MAX_SAFE_INTEGER,

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -24,18 +24,18 @@ const glimmerHashes = new Set([
 
 // These are things you may pick up frequently out in the wild
 const makeRoomTypes = [
-  'BUCKET_PRIMARY_WEAPON',
-  'BUCKET_SPECIAL_WEAPON',
-  'BUCKET_HEAVY_WEAPON',
-  'BUCKET_HEAD',
-  'BUCKET_ARMS',
-  'BUCKET_CHEST',
-  'BUCKET_LEGS',
-  'BUCKET_CLASS_ITEMS',
-  'BUCKET_ARTIFACT',
-  'BUCKET_GHOST',
-  'BUCKET_CONSUMABLES',
-  'BUCKET_MATERIALS'
+  1498876634, // Primary
+  2465295065, // Special
+  953998645, // Heavy
+  3448274439, // Helmet
+  3551918588, // Gauntlets
+  14239492, // Chest
+  20886954, // Legs
+  1585787867, // ClassItem
+  434908299, // Artifact
+  4023194814, // Ghost
+  1469714392, // Consumable
+  3865314626 // Material
 ];
 
 /**
@@ -136,7 +136,7 @@ async function farmItems(store: D1Store) {
 // hold an item, so they don't go to the postmaster.
 async function makeRoomForItems(store: D1Store) {
   const buckets = await getBuckets();
-  const makeRoomBuckets = makeRoomTypes.map((type) => buckets.byId[type]);
+  const makeRoomBuckets = makeRoomTypes.map((type) => buckets.byHash[type]);
   makeRoomForItemsInBuckets(store, makeRoomBuckets, D1StoresService);
 }
 

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -151,7 +151,7 @@ export async function makeRoomForItemsInBuckets(
   const itemsToMove: DimItem[] = [];
   const itemInfos = itemInfosSelector(rxStore.getState());
   makeRoomBuckets.forEach((bucket) => {
-    const items = store.buckets[bucket.id];
+    const items = store.buckets[bucket.hash];
     if (items.length > 0 && items.length >= store.capacityForItem(items[0])) {
       const moveAsideCandidates = items.filter((i) => !i.equipped && !i.notransfer);
       const prioritizedMoveAsideCandidates = sortMoveAsideCandidatesForStore(

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -22,31 +22,28 @@ import { characterOrderSelector } from 'app/settings/character-sort';
 
 // Props provided from parents
 interface ProvidedProps {
-  storeId: string;
-  bucketId: string;
+  store: DimStore;
+  bucket: InventoryBucket;
 }
 
 // Props from Redux via mapStateToProps
 interface StoreProps {
-  // TODO: which of these will actually update purely?
   items: DimItem[];
-  bucket: InventoryBucket;
-  store: DimStore;
   itemSortOrder: string[];
   allStores: DimStore[];
   characterOrder: string;
 }
 
+const EMPTY_ARRAY = [];
+
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
-  const { storeId, bucketId } = props;
-  const store = state.inventory.stores.find((s) => s.id === storeId)!;
+  const { store, bucket } = props;
 
   return {
-    items: store.buckets[bucketId],
-    bucket: state.inventory.buckets!.byId[props.bucketId],
-    store,
+    items: store.buckets[bucket.hash],
     itemSortOrder: itemSortOrderSelector(state),
-    allStores: sortedStoresSelector(state),
+    // We only need this property when this is a vault armor bucket
+    allStores: store.isVault && bucket.inArmor ? sortedStoresSelector(state) : EMPTY_ARRAY,
     characterOrder: characterOrderSelector(state)
   };
 }
@@ -126,7 +123,7 @@ class StoreBucket extends React.Component<Props> {
           {unequippedItems.map((item) => (
             <StoreInventoryItem key={item.index} item={item} />
           ))}
-          {bucket.id === '375726501' &&
+          {bucket.hash === 375726501 &&
             _.times(bucket.capacity - unequippedItems.length, (index) => (
               <img src={emptyEngram} className="empty-engram" aria-hidden="true" key={index} />
             ))}
@@ -140,7 +137,8 @@ class StoreBucket extends React.Component<Props> {
 
     try {
       const { item, equip } = await showItemPicker({
-        filterItems: (item: DimItem) => item.bucket.id === bucket.id && item.canBeEquippedBy(store),
+        filterItems: (item: DimItem) =>
+          item.bucket.hash === bucket.hash && item.canBeEquippedBy(store),
         prompt: t('MovePopup.PullItem', {
           bucket: bucket.name,
           store: store.name

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -123,7 +123,8 @@ class StoreBucket extends React.Component<Props> {
           {unequippedItems.map((item) => (
             <StoreInventoryItem key={item.index} item={item} />
           ))}
-          {bucket.hash === 375726501 &&
+          {store.isDestiny2() &&
+          bucket.hash === 375726501 && // Engrams. D1 uses this same bucket hash for "Missions"
             _.times(bucket.capacity - unequippedItems.length, (index) => (
               <img src={emptyEngram} className="empty-engram" aria-hidden="true" key={index} />
             ))}

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -24,7 +24,7 @@ export function StoreBuckets({
   // Don't show buckets with no items
   if (
     (!bucket.accountWide || bucket.type === 'SpecialOrders') &&
-    !stores.some((s) => s.buckets[bucket.id].length > 0)
+    !stores.some((s) => s.buckets[bucket.hash].length > 0)
   ) {
     return null;
   }
@@ -36,12 +36,12 @@ export function StoreBuckets({
       <>
         {(allStoresView || stores[0] !== vault) && (
           <div className="store-cell account-wide">
-            <StoreBucket bucketId={bucket.id} storeId={currentStore.id} />
+            <StoreBucket bucket={bucket} store={currentStore} />
           </div>
         )}
         {(allStoresView || stores[0] === vault) && (
           <div className="store-cell vault">
-            <StoreBucket bucketId={bucket.id} storeId={vault.id} />
+            <StoreBucket bucket={bucket} store={vault} />
           </div>
         )}
       </>
@@ -57,15 +57,13 @@ export function StoreBuckets({
         })}
         style={storeBackgroundColor(store, index)}
       >
-        {(!store.isVault || bucket.vaultBucket) && (
-          <StoreBucket bucketId={bucket.id} storeId={store.id} />
-        )}
+        {(!store.isVault || bucket.vaultBucket) && <StoreBucket bucket={bucket} store={store} />}
         {bucket.type === 'LostItems' &&
           store.isDestiny2() &&
-          store.buckets[bucket.id].length > 0 && <PullFromPostmaster store={store} />}
+          store.buckets[bucket.hash].length > 0 && <PullFromPostmaster store={store} />}
       </div>
     ));
   }
 
-  return <div className={`store-row bucket-${bucket.id}`}>{content}</div>;
+  return <div className={`store-row bucket-${bucket.hash}`}>{content}</div>;
 }

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -67,8 +67,8 @@
     white-space: normal;
   }
 
-  // Engrams
-  .bucket-375726501 & {
+  // Engrams. D1 uses this same bucket hash for "Missions"
+  .destiny2 .bucket-375726501 & {
     /* prettier-ignore */
     --engram-size: calc(var(--character-column-width) / 10);
 

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -68,7 +68,7 @@ class Stores extends React.Component<Props, State> {
     if (isPhonePortrait) {
       return (
         <div
-          className="inventory-content phone-portrait"
+          className={`inventory-content phone-portrait destiny${selectedStore.destinyVersion}`}
           role="main"
           aria-label={t('Header.Inventory')}
         >
@@ -116,7 +116,11 @@ class Stores extends React.Component<Props, State> {
     }
 
     return (
-      <div className="inventory-content" role="main" aria-label={t('Header.Inventory')}>
+      <div
+        className={`inventory-content destiny${selectedStore.destinyVersion}`}
+        role="main"
+        aria-label={t('Header.Inventory')}
+      >
         <ScrollClassDiv className="store-row store-header" scrollClass="sticky">
           {stores.map((store, index) => (
             <div

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -187,7 +187,7 @@ class Stores extends React.Component<Props, State> {
                 */}
                 {buckets.byCategory[category].map((bucket) => (
                   <StoreBuckets
-                    key={bucket.id}
+                    key={bucket.hash}
                     bucket={bucket}
                     stores={stores}
                     vault={vault}
@@ -213,7 +213,7 @@ function categoryHasItems(
   const buckets = allBuckets.byCategory[category];
   return buckets.some((bucket) => {
     const storesToSearch = bucket.accountWide && !stores[0].isVault ? [currentStore] : stores;
-    return storesToSearch.some((s) => s.buckets[bucket.id] && s.buckets[bucket.id].length > 0);
+    return storesToSearch.some((s) => s.buckets[bucket.hash] && s.buckets[bucket.hash].length > 0);
   });
 }
 

--- a/src/app/inventory/VaultStats.tsx
+++ b/src/app/inventory/VaultStats.tsx
@@ -17,15 +17,15 @@ const bucketIcons = {
 };
 const vaultBucketOrder = [
   // D1
-  'BUCKET_VAULT_WEAPONS',
-  'BUCKET_VAULT_ARMOR',
-  'BUCKET_VAULT_ITEMS',
+  3003523923, // Armor
+  4046403665, // Weapons
+  138197802, // General
 
   // D2
-  '138197802',
-  '1469714392',
-  '3313201758',
-  '2973005342'
+  138197802,
+  1469714392,
+  3313201758,
+  2973005342
 ];
 
 export default function VaultStats({ store }: { store: DimVault }) {
@@ -49,28 +49,28 @@ export default function VaultStats({ store }: { store: DimVault }) {
           <div />
         </React.Fragment>
       ))}
-      {_.sortBy(Object.keys(store.vaultCounts), (id) => vaultBucketOrder.indexOf(id)).map(
-        (bucketId) => (
-          <React.Fragment key={bucketId}>
-            <div className={styles.bucketTag} title={store.vaultCounts[bucketId].bucket.name}>
-              {bucketIcons[bucketId] ? (
-                <img src={bucketIcons[bucketId]} alt="" />
-              ) : (
-                store.vaultCounts[bucketId].bucket.name.substring(0, 1)
-              )}
-            </div>
-            <div
-              title={store.vaultCounts[bucketId].bucket.name}
-              className={clsx({
-                [styles.full]:
-                  store.vaultCounts[bucketId].count === store.vaultCounts[bucketId].bucket.capacity
-              })}
-            >
-              {store.vaultCounts[bucketId].count}/{store.vaultCounts[bucketId].bucket.capacity}
-            </div>
-          </React.Fragment>
-        )
-      )}
+      {_.sortBy(Object.keys(store.vaultCounts), (id) =>
+        vaultBucketOrder.indexOf(parseInt(id, 10))
+      ).map((bucketId) => (
+        <React.Fragment key={bucketId}>
+          <div className={styles.bucketTag} title={store.vaultCounts[bucketId].bucket.name}>
+            {bucketIcons[bucketId] ? (
+              <img src={bucketIcons[bucketId]} alt="" />
+            ) : (
+              store.vaultCounts[bucketId].bucket.name.substring(0, 1)
+            )}
+          </div>
+          <div
+            title={store.vaultCounts[bucketId].bucket.name}
+            className={clsx({
+              [styles.full]:
+                store.vaultCounts[bucketId].count === store.vaultCounts[bucketId].bucket.capacity
+            })}
+          >
+            {store.vaultCounts[bucketId].count}/{store.vaultCounts[bucketId].bucket.capacity}
+          </div>
+        </React.Fragment>
+      ))}
     </div>
   );
 }

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -257,9 +257,9 @@ function StoreService(): D1StoreServiceType {
         const vault = store;
         vault.vaultCounts = {};
         const vaultBucketOrder = [
-          'BUCKET_VAULT_WEAPONS',
-          'BUCKET_VAULT_ARMOR',
-          'BUCKET_VAULT_ITEMS'
+          4046403665, // Weapons
+          3003523923, // Armor
+          138197802 // General
         ];
 
         _.sortBy(

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -244,12 +244,12 @@ function StoreService(): D1StoreServiceType {
       store.items = items;
 
       // by type-bucket
-      store.buckets = _.groupBy(items, (i) => i.location.id);
+      store.buckets = _.groupBy(items, (i) => i.location.hash);
 
       // Fill in any missing buckets
       Object.values(buckets.byType).forEach((bucket) => {
-        if (!store.buckets[bucket.id]) {
-          store.buckets[bucket.id] = [];
+        if (!store.buckets[bucket.hash]) {
+          store.buckets[bucket.hash] = [];
         }
       });
 
@@ -264,14 +264,14 @@ function StoreService(): D1StoreServiceType {
 
         _.sortBy(
           Object.values(buckets.byType).filter((b) => b.vaultBucket),
-          (b) => vaultBucketOrder.indexOf(b.vaultBucket!.id)
+          (b) => vaultBucketOrder.indexOf(b.vaultBucket!.hash)
         ).forEach((bucket) => {
-          const vaultBucketId = bucket.vaultBucket!.id;
+          const vaultBucketId = bucket.vaultBucket!.hash;
           vault.vaultCounts[vaultBucketId] = vault.vaultCounts[vaultBucketId] || {
             count: 0,
             bucket: bucket.accountWide ? bucket : bucket.vaultBucket
           };
-          vault.vaultCounts[vaultBucketId].count += store.buckets[bucket.id].length;
+          vault.vaultCounts[vaultBucketId].count += store.buckets[bucket.hash].length;
         });
       }
 

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -246,6 +246,8 @@ function StoreService(): D1StoreServiceType {
       // by type-bucket
       store.buckets = _.groupBy(items, (i) => i.location.hash);
 
+      console.log(store.items, store.buckets);
+
       // Fill in any missing buckets
       Object.values(buckets.byType).forEach((bucket) => {
         if (!store.buckets[bucket.hash]) {

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -339,11 +339,11 @@ function makeD2StoresService(): D2StoreServiceType {
     );
     store.items = processedItems;
     // by type-bucket
-    store.buckets = _.groupBy(store.items, (i) => i.location.id);
+    store.buckets = _.groupBy(store.items, (i) => i.location.hash);
     // Fill in any missing buckets
     Object.values(buckets.byType).forEach((bucket) => {
-      if (!store.buckets[bucket.id]) {
-        store.buckets[bucket.id] = [];
+      if (!store.buckets[bucket.hash]) {
+        store.buckets[bucket.hash] = [];
       }
     });
     return store;
@@ -386,20 +386,20 @@ function makeD2StoresService(): D2StoreServiceType {
     );
     store.items = processedItems;
     // by type-bucket
-    store.buckets = _.groupBy(store.items, (i) => i.location.id);
+    store.buckets = _.groupBy(store.items, (i) => i.location.hash);
     store.vaultCounts = {};
     // Fill in any missing buckets
     Object.values(buckets.byType).forEach((bucket) => {
-      if (!store.buckets[bucket.id]) {
-        store.buckets[bucket.id] = [];
+      if (!store.buckets[bucket.hash]) {
+        store.buckets[bucket.hash] = [];
       }
       if (bucket.vaultBucket) {
-        const vaultBucketId = bucket.vaultBucket.id;
+        const vaultBucketId = bucket.vaultBucket.hash;
         store.vaultCounts[vaultBucketId] = store.vaultCounts[vaultBucketId] || {
           count: 0,
           bucket: bucket.accountWide ? bucket : bucket.vaultBucket
         };
-        store.vaultCounts[vaultBucketId].count += store.buckets[bucket.id].length;
+        store.vaultCounts[vaultBucketId].count += store.buckets[bucket.hash].length;
       }
     });
     return store;
@@ -495,12 +495,12 @@ function makeD2StoresService(): D2StoreServiceType {
     // Fill in any missing buckets
     Object.values(buckets.byType).forEach((bucket) => {
       if (bucket.accountWide && bucket.vaultBucket) {
-        const vaultBucketId = bucket.id;
+        const vaultBucketId = bucket.hash;
         vault.vaultCounts[vaultBucketId] = vault.vaultCounts[vaultBucketId] || {
           count: 0,
           bucket
         };
-        vault.vaultCounts[vaultBucketId].count += activeStore.buckets[bucket.id].length;
+        vault.vaultCounts[vaultBucketId].count += activeStore.buckets[bucket.hash].length;
       }
     });
     activeStore.vault = vault; // god help me

--- a/src/app/inventory/inventory-buckets.ts
+++ b/src/app/inventory/inventory-buckets.ts
@@ -1,8 +1,6 @@
 import { BucketCategory } from 'bungie-api-ts/destiny2';
 
 export interface InventoryBucket {
-  /** @deprecated */
-  readonly id: string; // stringified hash
   readonly description: string;
   readonly name: string;
   readonly hash: number;
@@ -24,8 +22,6 @@ export interface InventoryBucket {
 export interface InventoryBuckets {
   byHash: { [hash: number]: InventoryBucket };
   byType: { [type: string]: InventoryBucket };
-  /** @deprecated */
-  byId: { [hash: number]: InventoryBucket };
   byCategory: { [category: string]: InventoryBucket[] };
   unknown: InventoryBucket; // TODO: get rid of this?
   setHasUnknown();

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -162,7 +162,7 @@ function ItemService(): ItemServiceType {
       // Items to be decremented
       const sourceItems = stackable
         ? _.sortBy(
-            source.buckets[item.location.id].filter(
+            source.buckets[item.location.hash].filter(
               (i) => i.hash === item.hash && i.id === item.id
             ),
             (i) => i.amount
@@ -172,7 +172,7 @@ function ItemService(): ItemServiceType {
       // it's easier to deal with as a list.
       const targetItems = stackable
         ? _.sortBy(
-            target.buckets[item.bucket.id].filter(
+            target.buckets[item.bucket.hash].filter(
               (i) =>
                 i.hash === item.hash &&
                 i.id === item.id &&
@@ -244,7 +244,7 @@ function ItemService(): ItemServiceType {
     }
 
     if (equip) {
-      target.buckets[item.bucket.id] = target.buckets[item.bucket.id].map((i) => {
+      target.buckets[item.bucket.hash] = target.buckets[item.bucket.hash].map((i) => {
         // TODO: this state needs to be moved out
         i.equipped = i.index === item.index;
         return i;
@@ -300,7 +300,7 @@ function ItemService(): ItemServiceType {
     let candidates = store.items.filter(
       (i) =>
         i.canBeEquippedBy(target) &&
-        i.location.id === item.location.id &&
+        i.location.hash === item.location.hash &&
         !i.equipped &&
         // Not the same item
         i.id !== item.id &&
@@ -449,7 +449,7 @@ function ItemService(): ItemServiceType {
     // Note that this can result in the wrong lock state if DIM is out of date (they've locked/unlocked in game but we haven't refreshed).
     // Only apply this hack if the source bucket contains duplicates of the same item hash.
     const overrideLockState =
-      count(ownerStore.buckets[item.location.id], (i) => i.hash === item.hash) > 1
+      count(ownerStore.buckets[item.location.hash], (i) => i.hash === item.hash) > 1
         ? item.locked
         : undefined;
 
@@ -526,7 +526,7 @@ function ItemService(): ItemServiceType {
     // Find an item that's not in the slot we're equipping, but has a matching equipping label
     return store.items.find(
       (i) =>
-        i.equipped && i.equippingLabel === item.equippingLabel && i.bucket.id !== item.bucket.id
+        i.equipped && i.equippingLabel === item.equippingLabel && i.bucket.hash !== item.bucket.hash
     );
   }
 
@@ -581,9 +581,9 @@ function ItemService(): ItemServiceType {
             (i) =>
               i.bucket.vaultBucket &&
               item.bucket.vaultBucket &&
-              i.bucket.vaultBucket.id === item.bucket.vaultBucket.id
+              i.bucket.vaultBucket.hash === item.bucket.vaultBucket.hash
           )
-        : store.buckets[item.bucket.id];
+        : store.buckets[item.bucket.hash];
     } catch (e) {
       if (store.isVault && !item.bucket.vaultBucket) {
         console.error(

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -70,7 +70,7 @@ export interface DimStore {
   /** All items in the store, across all buckets. */
   items: DimItem[];
   /** All items, grouped by their bucket. */
-  buckets: { [bucketId: string]: DimItem[] };
+  buckets: { [bucketHash: number]: DimItem[] };
   /** The Destiny version this store came from. */
   destinyVersion: 1 | 2;
   /** An icon (emblem) for the store. */
@@ -149,7 +149,7 @@ export interface DimStore {
 
 /** How many items are in each vault bucket. DIM hides the vault bucket concept from users but needs the count to track progress. */
 interface VaultCounts {
-  [bucketId: number]: { count: number; bucket: InventoryBucket };
+  [bucketHash: number]: { count: number; bucket: InventoryBucket };
 }
 
 export interface DimVault extends DimStore {

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -4,7 +4,7 @@ import { getBonus } from './character-utils';
 import { getQualityRating } from './armor-quality';
 import { reportException } from '../../utils/exceptions';
 import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions';
-import { getBuckets } from '../../destiny1/d1-buckets';
+import { getBuckets, vaultTypes } from '../../destiny1/d1-buckets';
 import { NewItemsService } from './new-items';
 import { t } from 'app/i18next-t';
 import { D1Store } from '../store-types';
@@ -231,16 +231,20 @@ function makeItem(
   // We cheat a bit for items in the vault, since we treat the
   // vault as a character. So put them in the bucket they would
   // have been in if they'd been on a character.
-  if (currentBucket.id.startsWith('BUCKET_VAULT')) {
+  if (currentBucket.hash in vaultTypes) {
     // TODO: Remove this if Bungie ever returns bucket.id for classified
     // items in the vault.
     if (itemDef.classified && itemDef.itemTypeName === 'Unknown') {
-      if (currentBucket.id.endsWith('WEAPONS')) {
-        currentBucket = buckets.byType.Heavy;
-      } else if (currentBucket.id.endsWith('ARMOR')) {
-        currentBucket = buckets.byType.ClassItem;
-      } else if (currentBucket.id.endsWith('ITEMS')) {
-        currentBucket = buckets.byType.Artifact;
+      switch (currentBucket.hash) {
+        case 4046403665:
+          currentBucket = buckets.byType.Heavy;
+          break;
+        case 3003523923:
+          currentBucket = buckets.byType.ClassItem;
+          break;
+        case 138197802:
+          currentBucket = buckets.byType.Artifact;
+          break;
       }
     } else {
       currentBucket = normalBucket;

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -124,7 +124,7 @@ const StoreProto = {
   },
 
   factionAlignment(this: D1Store) {
-    const badge = this.buckets.BUCKET_MISSION.find((i) => factionBadges[i.hash]);
+    const badge = this.buckets[375726501].find((i) => factionBadges[i.hash]);
     if (!badge) {
       return null;
     }

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -74,7 +74,7 @@ const StoreProto = {
     }
     const openStacks = Math.max(
       0,
-      this.capacityForItem(item) - this.buckets[item.location.id].length
+      this.capacityForItem(item) - this.buckets[item.location.hash].length
     );
     const maxStackSize = item.maxStackSize || 1;
     if (maxStackSize === 1) {
@@ -107,10 +107,10 @@ const StoreProto = {
     if (sourceIndex >= 0) {
       this.items = [...this.items.slice(0, sourceIndex), ...this.items.slice(sourceIndex + 1)];
 
-      let bucketItems = this.buckets[item.location.id];
+      let bucketItems = this.buckets[item.location.hash];
       const bucketIndex = bucketItems.findIndex(match);
       bucketItems = [...bucketItems.slice(0, bucketIndex), ...bucketItems.slice(bucketIndex + 1)];
-      this.buckets[item.location.id] = bucketItems;
+      this.buckets[item.location.hash] = bucketItems;
 
       return true;
     }
@@ -119,7 +119,7 @@ const StoreProto = {
 
   addItem(this: D1Store, item: D1Item) {
     this.items = [...this.items, item];
-    this.buckets[item.location.id] = [...this.buckets[item.location.id], item];
+    this.buckets[item.location.hash] = [...this.buckets[item.location.hash], item];
     item.owner = this.id;
   },
 
@@ -312,14 +312,14 @@ export function makeVault(
     removeItem(this: D1Vault, item: D1Item) {
       const result = StoreProto.removeItem.call(this, item);
       if (item.location.vaultBucket) {
-        this.vaultCounts[item.location.vaultBucket.id].count--;
+        this.vaultCounts[item.location.vaultBucket.hash].count--;
       }
       return result;
     },
     addItem(this: D1Vault, item: D1Item) {
       StoreProto.addItem.call(this, item);
       if (item.location.vaultBucket) {
-        this.vaultCounts[item.location.vaultBucket.id].count++;
+        this.vaultCounts[item.location.vaultBucket.hash].count++;
       }
     }
   });

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -106,7 +106,7 @@ function LockArmorAndPerks({
   ) => async (e: React.MouseEvent) => {
     e.preventDefault();
 
-    const order = Object.values(LockableBuckets).map((v) => v.toString());
+    const order = Object.values(LockableBuckets);
     try {
       const { item } = await showItemPicker({
         hideStoreEquip: true,
@@ -145,7 +145,7 @@ function LockArmorAndPerks({
     addLockItem,
     // Exclude types that already have a locked item represented
     (item) =>
-      !lockedMap[item.bucket.hash] || !lockedMap[item.bucket.hash].some((li) => li.type === 'item')
+      !lockedMap[item.bucket.hash] || !lockedMap[item.bucket.hash]!.some((li) => li.type === 'item')
   );
   const chooseExcludeItem = chooseItem(addExcludeItem);
 

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -116,7 +116,7 @@ function LockArmorAndPerks({
               item.canBeEquippedBy(selectedStore) &&
               (!filter || filter(item))
           ),
-        sortBy: (item) => order.indexOf(item.bucket.id)
+        sortBy: (item) => order.indexOf(item.bucket.hash)
       });
 
       updateFunc(item);
@@ -145,7 +145,7 @@ function LockArmorAndPerks({
     addLockItem,
     // Exclude types that already have a locked item represented
     (item) =>
-      !lockedMap[item.bucket.id] || !lockedMap[item.bucket.id].some((li) => li.type === 'item')
+      !lockedMap[item.bucket.hash] || !lockedMap[item.bucket.hash].some((li) => li.type === 'item')
   );
   const chooseExcludeItem = chooseItem(addExcludeItem);
 

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -80,7 +80,7 @@ export default function LoadoutDrawerContents(
     add(item: DimItem, e?: MouseEvent, equip?: boolean): void;
   }
 ) {
-  const itemsByBucket = _.groupBy(items, (i) => i.bucket.id);
+  const itemsByBucket = _.groupBy(items, (i) => i.bucket.hash);
 
   function doFillLoadoutFromEquipped(e: React.MouseEvent) {
     e.preventDefault();
@@ -91,7 +91,7 @@ export default function LoadoutDrawerContents(
 
   const [typesWithItems, typesWithoutItems] = _.partition(
     availableTypes,
-    (bucket) => bucket.id && itemsByBucket[bucket.id] && itemsByBucket[bucket.id].length
+    (bucket) => bucket.hash && itemsByBucket[bucket.hash] && itemsByBucket[bucket.hash].length
   );
 
   const showFillFromEquipped = typesWithoutItems.some((b) => fromEquippedTypes.includes(b.type!));
@@ -122,7 +122,7 @@ export default function LoadoutDrawerContents(
             key={bucket.type}
             bucket={bucket}
             loadoutItems={loadout.items}
-            items={itemsByBucket[bucket.id] || []}
+            items={itemsByBucket[bucket.hash] || []}
             itemSortOrder={itemSortOrder}
             pickLoadoutItem={(bucket) => pickLoadoutItem(loadout, itemsByBucket, bucket, add)}
             equip={equip}
@@ -146,12 +146,12 @@ async function pickLoadoutItem(
     return loadout && loadout.items.some((i) => i.id === item.id && i.hash === i.hash);
   }
 
-  const hasEquippedItem = (itemsByBucket[bucket.id] || []).some((i) => i.equipped);
+  const hasEquippedItem = (itemsByBucket[bucket.hash] || []).some((i) => i.equipped);
 
   try {
     const { item, equip } = await showItemPicker({
       filterItems: (item: DimItem) =>
-        item.bucket.id === bucket.id &&
+        item.bucket.hash === bucket.hash &&
         (!loadout ||
           loadout.classType === DestinyClass.Unknown ||
           item.classType === loadoutClassType ||
@@ -192,10 +192,13 @@ function fillLoadoutFromEquipped(
 
   console.log({ items, loadout, dimStore });
   for (const item of items) {
-    if (!itemsByBucket[item.bucket.id] || !itemsByBucket[item.bucket.id].some((i) => i.equipped)) {
+    if (
+      !itemsByBucket[item.bucket.hash] ||
+      !itemsByBucket[item.bucket.hash].some((i) => i.equipped)
+    ) {
       add(item, undefined, true);
     } else {
-      console.log('Skipping', item, { itemsByBucket, bucketId: item.bucket.id });
+      console.log('Skipping', item, { itemsByBucket, bucketId: item.bucket.hash });
     }
   }
 }

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -366,7 +366,7 @@ function clearSpaceAfterLoadout(
   items: DimItem[],
   storesService: StoreServiceType
 ) {
-  const itemsByType = _.groupBy(items, (i) => i.bucket.id);
+  const itemsByType = _.groupBy(items, (i) => i.bucket.hash);
 
   const reservations: MoveReservations = {};
   // reserve one space in the active character

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -13,9 +13,9 @@ export async function makeRoomForPostmaster(
 ): Promise<void> {
   const buckets = await bucketsService();
   const postmasterItems: DimItem[] = buckets.byCategory.Postmaster.flatMap(
-    (bucket: InventoryBucket) => store.buckets[bucket.id]
+    (bucket: InventoryBucket) => store.buckets[bucket.hash]
   );
-  const postmasterItemCountsByType = _.countBy(postmasterItems, (i) => i.bucket.id);
+  const postmasterItemCountsByType = _.countBy(postmasterItems, (i) => i.bucket.hash);
   // If any category is full, we'll move enough aside
   const itemsToMove: DimItem[] = [];
   _.forIn(postmasterItemCountsByType, (count, bucket) => {

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -92,10 +92,7 @@ export function postmasterAlmostFull(store: DimStore) {
 }
 
 export function postmasterSpaceLeft(store: DimStore) {
-  return Math.max(
-    0,
-    POSTMASTER_SIZE - (store.buckets[215593132] && store.buckets[215593132].length)
-  );
+  return Math.max(0, POSTMASTER_SIZE - totalPostmasterItems(store));
 }
 export function postmasterSpaceUsed(store: DimStore) {
   return POSTMASTER_SIZE - postmasterSpaceLeft(store);
@@ -103,10 +100,7 @@ export function postmasterSpaceUsed(store: DimStore) {
 
 // to-do: either typing is wrong and this can return undefined, or this doesn't need &&s and ?.s
 export function totalPostmasterItems(store: DimStore) {
-  return (
-    (store.buckets[215593132] && store.buckets[215593132].length) ||
-    store.buckets.BUCKET_RECOVERY?.length
-  );
+  return store.buckets[215593132]?.length || 0;
 }
 
 const showNoSpaceError = _.throttle(

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -142,32 +142,20 @@ class ManifestService {
   }
 
   private async loadManifest(tableWhitelist: string[]): Promise<any> {
-    let version: string | null = null;
-    try {
-      const data = await this.getManifestApi();
-      await settingsReady; // wait for settings to be ready
-      const language = settingsSelector(store.getState()).language;
-      const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
+    const data = await this.getManifestApi();
+    await settingsReady; // wait for settings to be ready
+    const language = settingsSelector(store.getState()).language;
+    const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
 
-      // Use the path as the version, rather than the "version" field, because
-      // Bungie can update the manifest file without changing that version.
-      version = path;
-      this.version = version;
-    } catch (e) {
-      // If we can't get info about the current manifest, try to just use whatever's already saved.
-      version = localStorage.getItem(this.localStorageKey);
-      if (version) {
-        this.version = version;
-        return this.loadManifestFromCache(version, tableWhitelist);
-      } else {
-        throw e;
-      }
-    }
+    // Use the path as the version, rather than the "version" field, because
+    // Bungie can update the manifest file without changing that version.
+    const version = path;
+    this.version = version;
 
     try {
       return await this.loadManifestFromCache(version, tableWhitelist);
     } catch (e) {
-      return this.loadManifestRemote(version, version, tableWhitelist);
+      return this.loadManifestRemote(version, path, tableWhitelist);
     }
   }
 

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -142,20 +142,32 @@ class ManifestService {
   }
 
   private async loadManifest(tableWhitelist: string[]): Promise<any> {
-    const data = await this.getManifestApi();
-    await settingsReady; // wait for settings to be ready
-    const language = settingsSelector(store.getState()).language;
-    const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
+    let version: string | null = null;
+    try {
+      const data = await this.getManifestApi();
+      await settingsReady; // wait for settings to be ready
+      const language = settingsSelector(store.getState()).language;
+      const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
 
-    // Use the path as the version, rather than the "version" field, because
-    // Bungie can update the manifest file without changing that version.
-    const version = path;
-    this.version = version;
+      // Use the path as the version, rather than the "version" field, because
+      // Bungie can update the manifest file without changing that version.
+      version = path;
+      this.version = version;
+    } catch (e) {
+      // If we can't get info about the current manifest, try to just use whatever's already saved.
+      version = localStorage.getItem(this.localStorageKey);
+      if (version) {
+        this.version = version;
+        return this.loadManifestFromCache(version, tableWhitelist);
+      } else {
+        throw e;
+      }
+    }
 
     try {
       return await this.loadManifestFromCache(version, tableWhitelist);
     } catch (e) {
-      return this.loadManifestRemote(version, path, tableWhitelist);
+      return this.loadManifestRemote(version, version, tableWhitelist);
     }
   }
 

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -108,11 +108,10 @@ const D1_MATERIAL_SORT_ORDER = [
 // Don't resort postmaster items - that way people can see
 // what'll get bumped when it's full.
 const ITEM_SORT_BLACKLIST = new Set([
-  'BUCKET_BOUNTIES',
-  'BUCKET_MISSION',
-  'BUCKET_QUESTS',
-  'BUCKET_POSTMASTER',
-  '215593132' // LostItems
+  2197472680, // Bounties (D1)
+  375726501, // Mission (D1)
+  1801258597, // Quests (D1)
+  215593132 // LostItems
 ]);
 
 // TODO: pass in state
@@ -161,12 +160,12 @@ export function sortItems(items: DimItem[], itemSortOrder: string[]) {
 
   let specificSortOrder: number[] = [];
   // Group like items in the General Section
-  if (itemLocationId === 'BUCKET_CONSUMABLES') {
+  if (itemLocationId === 1469714392) {
     specificSortOrder = D1_CONSUMABLE_SORT_ORDER;
   }
 
   // Group like items in the General Section
-  if (itemLocationId === 'BUCKET_MATERIALS') {
+  if (itemLocationId === 3865314626) {
     specificSortOrder = D1_MATERIAL_SORT_ORDER;
   }
 
@@ -179,7 +178,7 @@ export function sortItems(items: DimItem[], itemSortOrder: string[]) {
   }
 
   // Re-sort mods
-  if (itemLocationId === '3313201758') {
+  if (itemLocationId === 3313201758) {
     const comparators = [ITEM_COMPARATORS.typeName, ITEM_COMPARATORS.name];
     if (itemSortOrder.includes('rarity')) {
       comparators.unshift(ITEM_COMPARATORS.rarity);
@@ -188,7 +187,7 @@ export function sortItems(items: DimItem[], itemSortOrder: string[]) {
   }
 
   // Re-sort consumables
-  if (itemLocationId === '1469714392') {
+  if (itemLocationId === 1469714392) {
     return items.sort(
       chainComparator(
         ITEM_COMPARATORS.typeName,

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -154,7 +154,7 @@ export function sortItems(items: DimItem[], itemSortOrder: string[]) {
     return items;
   }
 
-  const itemLocationId = items[0].location.id.toString();
+  const itemLocationId = items[0].location.hash;
   if (!items.length || ITEM_SORT_BLACKLIST.has(itemLocationId)) {
     return items;
   }


### PR DESCRIPTION
Back in the D1 days we hadn't discovered bucket hash, so we used the (human-readable) `bucketIdentifier`, which didn't make it to D2. This removes all usage of that bucket ID in favor of hashes so D1 and D2 work more similarly.