### PR TITLE
Load manifest from cache if bungie.net is down, instead of erroring

### DIFF
--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -142,20 +142,32 @@ class ManifestService {
   }
 
   private async loadManifest(tableWhitelist: string[]): Promise<any> {
-    const data = await this.getManifestApi();
-    await settingsReady; // wait for settings to be ready
-    const language = settingsSelector(store.getState()).language;
-    const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
+    let version: string | null = null;
+    try {
+      const data = await this.getManifestApi();
+      await settingsReady; // wait for settings to be ready
+      const language = settingsSelector(store.getState()).language;
+      const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
 
-    // Use the path as the version, rather than the "version" field, because
-    // Bungie can update the manifest file without changing that version.
-    const version = path;
-    this.version = version;
+      // Use the path as the version, rather than the "version" field, because
+      // Bungie can update the manifest file without changing that version.
+      version = path;
+      this.version = version;
+    } catch (e) {
+      // If we can't get info about the current manifest, try to just use whatever's already saved.
+      version = localStorage.getItem(this.localStorageKey);
+      if (version) {
+        this.version = version;
+        return this.loadManifestFromCache(version, tableWhitelist);
+      } else {
+        throw e;
+      }
+    }
 
     try {
       return await this.loadManifestFromCache(version, tableWhitelist);
     } catch (e) {
-      return this.loadManifestRemote(version, path, tableWhitelist);
+      return this.loadManifestRemote(version, version, tableWhitelist);
     }
   }
 


### PR DESCRIPTION
Today if we can't check the current manifest version remotely, we error. This switches to trying the cached manifest if available.