### PR TITLE
Update browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,8 @@
     "last 2 ChromeAndroid versions",
     "last 2 FirefoxAndroid versions",
     "last 2 Firefox versions",
-    "Firefox ESR",
     "last 2 Safari versions",
-    "iOS >= 11",
+    "iOS >= 12",
     "last 2 Edge versions",
     "last 2 Opera versions"
   ],


### PR DESCRIPTION
Drop Firefox ESR (Firefox 68) and iOS 11 (all iOS 11 users can upgrade to iOS 12, usage is < 0.5% of our iOS users)