### PR TITLE
Introduced a shared empty structure helper

### DIFF
--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -16,6 +16,7 @@ import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { ModCollectible } from './Mod';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { t } from 'app/i18next-t';
+import { emptyArray } from 'app/utils/empty';
 
 const armorPieceGroups = [
   1362265421, // ItemCategory "Armor Mods: Helmet"
@@ -71,7 +72,7 @@ function mapStateToProps() {
     (state: RootState) => state.manifest.d2Manifest,
     (defs) => {
       if (!defs) {
-        return [];
+        return emptyArray<DestinyInventoryItemDefinition>();
       }
       //                                    InventoryItem "Void Damage Mod"
       const deprecatedModDescription = defs.InventoryItem.get(3728733956)?.displayProperties

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -15,6 +15,7 @@ import { observeStore } from 'app/utils/redux-utils';
 import _ from 'lodash';
 import { SyncService } from 'app/storage/sync.service';
 import { apiPermissionGrantedSelector, currentProfileSelector } from 'app/dim-api/selectors';
+import { emptyObject } from 'app/utils/empty';
 
 export const storesSelector = (state: RootState) => state.inventory.stores;
 export const sortedStoresSelector = createSelector(
@@ -37,10 +38,9 @@ export const ownedItemsSelector = () =>
 
 export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;
 
-const EMPTY_MAP = {};
 export const itemInfosSelector = (state: RootState) =>
   $featureFlags.dimApi && apiPermissionGrantedSelector(state)
-    ? ((currentProfileSelector(state)?.tags || EMPTY_MAP) as InventoryState['itemInfos'])
+    ? ((currentProfileSelector(state)?.tags || emptyObject()) as InventoryState['itemInfos'])
     : state.inventory.itemInfos;
 
 /**

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -22,6 +22,7 @@ import { createSelector } from 'reselect';
 import { itemsForPlugSet } from 'app/collections/PresentationNodeRoot';
 import _ from 'lodash';
 import SocketDetailsSelectedPlug from './SocketDetailsSelectedPlug';
+import { emptySet } from 'app/utils/empty';
 
 interface ProvidedProps {
   item: D2Item;
@@ -35,8 +36,6 @@ interface StoreProps {
   unlockedPlugs: Set<number>;
 }
 
-const EMPTY_SET = new Set<number>();
-
 function mapStateToProps() {
   /** Build the hashes of all plug set item hashes that are unlocked by any character/profile. */
   const unlockedPlugsSelector = createSelector(
@@ -46,7 +45,7 @@ function mapStateToProps() {
       props.socket.socketDefinition.randomizedPlugSetHash,
     (profileResponse, plugSetHash) => {
       if (!plugSetHash || !profileResponse) {
-        return EMPTY_SET;
+        return emptySet<number>();
       }
       const unlockedPlugs = new Set<number>();
       const plugSetItems = itemsForPlugSet(profileResponse, plugSetHash);
@@ -71,7 +70,7 @@ function mapStateToProps() {
           socketType.plugWhitelist
         )
       ) {
-        return EMPTY_SET;
+        return emptySet<number>();
       }
 
       const modHashes = new Set<number>();

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -12,8 +12,7 @@ import {
   DestinyVersion
 } from '@destinyitemmanager/dim-api-types';
 import { currentProfileSelector, apiPermissionGrantedSelector } from 'app/dim-api/selectors';
-
-const EMPTY_ARRAY = [];
+import { emptyArray } from 'app/utils/empty';
 
 const reportOldLoadout = _.once(() => ga('send', 'event', 'Loadouts', 'No Membership ID'));
 
@@ -33,7 +32,7 @@ export const loadoutsSelector = createSelector(
               loadout
             )
           )
-        : EMPTY_ARRAY
+        : emptyArray<Loadout>()
       : currentAccount
       ? legacyLoadouts.filter((loadout) => {
           if (loadout.membershipId !== undefined) {
@@ -58,7 +57,7 @@ export const loadoutsSelector = createSelector(
             return currentAccount.destinyVersion === 1;
           }
         })
-      : EMPTY_ARRAY
+      : emptyArray<Loadout>()
 );
 export const previousLoadoutSelector = (state: RootState, storeId: string): Loadout | undefined => {
   if (state.loadouts.previousLoadouts[storeId]) {

--- a/src/app/utils/empty.ts
+++ b/src/app/utils/empty.ts
@@ -1,0 +1,25 @@
+/**
+ * Stable empty versions of common data structures, to use in reducers.
+ *
+ * These always return the same instance so they'll always be referentially equal.
+ */
+
+const EMPTY_OBJ = {};
+export function emptyObject<T extends object>(): T {
+  return EMPTY_OBJ as T;
+}
+
+const EMPTY_ARRAY = [];
+export function emptyArray<T>(): T[] {
+  return EMPTY_ARRAY as T[];
+}
+
+const EMPTY_SET = new Set();
+export function emptySet<T>(): Set<T> {
+  return EMPTY_SET as Set<T>;
+}
+
+const EMPTY_MAP = new Map();
+export function emptyMap<K, V>(): Map<K, V> {
+  return EMPTY_MAP as Map<K, V>;
+}

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -2,7 +2,8 @@ import {
   DestinyVendorsResponse,
   DestinyProfileResponse,
   DestinyCurrenciesComponent,
-  DestinyItemPlug
+  DestinyItemPlug,
+  DestinyCollectibleComponent
 } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -44,6 +45,7 @@ import Hammer from 'react-hammerjs';
 import _ from 'lodash';
 import { VendorDrop } from 'app/vendorEngramsXyzApi/vendorDrops';
 import { getAllVendorDrops } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
+import { emptyArray, emptyObject } from 'app/utils/empty';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -84,9 +86,6 @@ interface State {
 
 type Props = ProvidedProps & StoreProps & UIViewInjectedProps & ThunkDispatchProp;
 
-const EMPTY_MAP = {};
-const EMPTY_ARRAY = [];
-
 /**
  * The "All Vendors" page for D2 that shows all the rotating vendors.
  */
@@ -102,7 +101,9 @@ class Vendors extends React.Component<Props, State> {
             profileResponse.profileCollectibles,
             profileResponse.characterCollectibles
           )
-        : EMPTY_MAP
+        : emptyObject<{
+            [x: number]: DestinyCollectibleComponent;
+          }>()
   );
   private vendorGroupsSelector = createSelector(
     (state: State) => state.vendorsResponse,
@@ -113,7 +114,7 @@ class Vendors extends React.Component<Props, State> {
     (vendorsResponse, defs, buckets, account, mergedCollectibles): readonly D2VendorGroup[] =>
       vendorsResponse && defs && buckets
         ? toVendorGroups(vendorsResponse, defs, buckets, account, mergedCollectibles)
-        : EMPTY_ARRAY
+        : emptyArray<D2VendorGroup>()
   );
 
   async loadVendors() {

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -1,6 +1,6 @@
 import { WishListRoll, DimWishList, WishListAndInfo } from './types';
+import { emptySet } from 'app/utils/empty';
 
-const EMPTY_NUMBER_SET = new Set<number>();
 let _blockNotes: string | undefined;
 
 /* Utilities for reading a wishlist file */
@@ -39,7 +39,7 @@ function parseBlockNoteLine(blockNoteLine: string): null {
 
 function getPerks(matchResults: RegExpMatchArray): Set<number> {
   if (!matchResults.groups || matchResults.groups.itemPerks === undefined) {
-    return EMPTY_NUMBER_SET;
+    return emptySet<number>();
   }
 
   const split = matchResults[2].split(',');


### PR DESCRIPTION
This lets us get a shared single instance of common types, so when you write a reducer that defaults to nothing it doesn't cause re-renders every time just because it's a new unique empty array.