### PR TITLE
Separate inventory selectors into their own file

### DIFF
--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -14,7 +14,7 @@ import { connect } from 'react-redux';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { RootState } from '../store/reducers';
 import { createSelector } from 'reselect';
-import { storesSelector, profileResponseSelector } from '../inventory/reducer';
+import { storesSelector, profileResponseSelector } from '../inventory/selectors';
 import { refresh$ } from '../shell/refresh';
 import PresentationNodeRoot from './PresentationNodeRoot';
 import Mods from './Mods';

--- a/src/app/collections/Mods.tsx
+++ b/src/app/collections/Mods.tsx
@@ -9,7 +9,7 @@ import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import './collections.scss';
 import { RootState } from 'app/store/reducers';
 import { createSelector } from 'reselect';
-import { storesSelector } from 'app/inventory/reducer';
+import { storesSelector } from 'app/inventory/selectors';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
 import { connect } from 'react-redux';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import BungieImage, { bungieBackgroundStyle } from '../../dim-ui/BungieImage';
 import { DimStore, D1Store } from '../../inventory/store-types';
 import { RootState } from '../../store/reducers';
-import { sortedStoresSelector } from '../../inventory/reducer';
+import { sortedStoresSelector } from '../../inventory/selectors';
 import SimpleCharacterTile from '../../inventory/SimpleCharacterTile';
 import CollapsibleTitle from '../../dim-ui/CollapsibleTitle';
 import { AppIcon, starIcon } from '../../shell/icons';

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -15,7 +15,7 @@ import { connect } from 'react-redux';
 import { DestinyAccount } from '../../accounts/destiny-account';
 import { D1Store } from '../../inventory/store-types';
 import { RootState } from '../../store/reducers';
-import { storesSelector } from '../../inventory/reducer';
+import { storesSelector } from '../../inventory/selectors';
 import { currentAccountSelector } from '../../accounts/reducer';
 import { D1StoresService } from '../../inventory/d1-stores';
 import { Loading } from '../../dim-ui/Loading';

--- a/src/app/destiny1/record-books/RecordBooks.tsx
+++ b/src/app/destiny1/record-books/RecordBooks.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import { count } from '../../utils/util';
 import { setSetting } from '../../settings/actions';
 import { D1Store } from '../../inventory/store-types';
-import { storesSelector } from '../../inventory/reducer';
+import { storesSelector } from '../../inventory/selectors';
 import { RootState } from '../../store/reducers';
 import { connect } from 'react-redux';
 import { Loading } from '../../dim-ui/Loading';

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -13,7 +13,7 @@ import { clearItemsOffCharacter } from '../loadout/loadout-apply';
 import { Subscription, from } from 'rxjs';
 import { filter, tap, map, exhaustMap } from 'rxjs/operators';
 import { settingsSelector } from 'app/settings/reducer';
-import { itemInfosSelector } from 'app/inventory/reducer';
+import { itemInfosSelector } from 'app/inventory/selectors';
 
 const glimmerHashes = new Set([
   269776572, // -house-banners

--- a/src/app/farming/reducer.ts
+++ b/src/app/farming/reducer.ts
@@ -3,7 +3,7 @@ import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import { storesSelector } from '../inventory/reducer';
+import { storesSelector } from '../inventory/selectors';
 import { RootState } from '../store/reducers';
 
 export const farmingStoreSelector = () =>

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -8,7 +8,7 @@ import Sheet from '../dim-ui/Sheet';
 import { AppIcon, plusIcon, helpIcon, faRandom, faEquals, faArrowCircleDown } from '../shell/icons';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import copy from 'fast-copy';
-import { storesSelector } from '../inventory/reducer';
+import { storesSelector } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
 import { RootState } from '../store/reducers';
 import _ from 'lodash';

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -9,7 +9,7 @@ import { searchFilterSelector } from '../search/search-filters';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import { wishListsEnabledSelector, inventoryWishListsSelector } from '../wishlists/reducer';
 import { settingsSelector } from 'app/settings/reducer';
-import { itemInfosSelector } from './reducer';
+import { itemInfosSelector } from './selectors';
 
 // Props provided from parents
 interface ProvidedProps {

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import emptyEngram from 'destiny-icons/general/empty-engram.svg';
 import _ from 'lodash';
-import { sortedStoresSelector } from './reducer';
+import { sortedStoresSelector } from './selectors';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { globeIcon, hunterIcon, warlockIcon, titanIcon, AppIcon, addIcon } from '../shell/icons';
 import { showItemPicker } from '../item-picker/item-picker';

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -11,7 +11,7 @@ import ScrollClassDiv from '../dim-ui/ScrollClassDiv';
 import { StoreBuckets } from './StoreBuckets';
 import D1ReputationSection from './D1ReputationSection';
 import Hammer from 'react-hammerjs';
-import { sortedStoresSelector } from './reducer';
+import { sortedStoresSelector } from './selectors';
 import { hideItemPopup } from '../item-popup/item-popup';
 import { storeBackgroundColor } from '../shell/filters';
 import InventoryCollapsibleTitle from './InventoryCollapsibleTitle';

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -7,9 +7,10 @@ import { tagCleanup, tagsAndNotesLoaded } from './actions';
 import { heartIcon, banIcon, tagIcon, boltIcon, archiveIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { DestinyAccount } from '../accounts/destiny-account';
-import { InventoryState, itemInfosSelector } from './reducer';
+import { InventoryState } from './reducer';
 import { BungieMembershipType } from 'bungie-api-ts/user';
 import { ThunkResult } from 'app/store/reducers';
+import { itemInfosSelector } from './selectors';
 
 // sortOrder: orders items within a bucket, ascending
 // these exist in comments so i18n       t('Tags.Favorite') t('Tags.Keep') t('Tags.Infuse')

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -31,7 +31,7 @@ import {
 } from './dim-item-info';
 import reduxStore from '../store/store';
 import { count } from 'app/utils/util';
-import { itemInfosSelector } from './reducer';
+import { itemInfosSelector } from './selectors';
 
 /**
  * You can reserve a number of each type of item in each store.

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -7,41 +7,11 @@ import { TagValue } from './dim-item-info';
 import { AccountsAction, currentAccountSelector } from '../accounts/reducer';
 import { setCurrentAccount } from '../accounts/actions';
 import { RootState } from '../store/reducers';
-import { createSelector } from 'reselect';
-import { characterSortSelector } from '../settings/character-sort';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import produce, { Draft } from 'immer';
 import { observeStore } from 'app/utils/redux-utils';
 import _ from 'lodash';
 import { SyncService } from 'app/storage/sync.service';
-import { apiPermissionGrantedSelector, currentProfileSelector } from 'app/dim-api/selectors';
-import { emptyObject } from 'app/utils/empty';
-
-export const storesSelector = (state: RootState) => state.inventory.stores;
-export const sortedStoresSelector = createSelector(
-  storesSelector,
-  characterSortSelector,
-  (stores, sortStores) => sortStores(stores)
-);
-export const storesLoadedSelector = (state: RootState) => storesSelector(state).length > 0;
-
-export const ownedItemsSelector = () =>
-  createSelector(storesSelector, (stores) => {
-    const ownedItemHashes = new Set<number>();
-    for (const store of stores) {
-      for (const item of store.items) {
-        ownedItemHashes.add(item.hash);
-      }
-    }
-    return ownedItemHashes;
-  });
-
-export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;
-
-export const itemInfosSelector = (state: RootState) =>
-  $featureFlags.dimApi && apiPermissionGrantedSelector(state)
-    ? ((currentProfileSelector(state)?.tags || emptyObject()) as InventoryState['itemInfos'])
-    : state.inventory.itemInfos;
 
 /**
  * Set up an observer on the store that'll save item infos to sync service (google drive).

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -1,0 +1,41 @@
+import { RootState } from '../store/reducers';
+import { createSelector } from 'reselect';
+import { characterSortSelector } from '../settings/character-sort';
+import _ from 'lodash';
+import { apiPermissionGrantedSelector, currentProfileSelector } from 'app/dim-api/selectors';
+import { InventoryState } from './reducer';
+import { emptyObject } from 'app/utils/empty';
+
+/** All stores, unsorted. */
+export const storesSelector = (state: RootState) => state.inventory.stores;
+
+/** All stores, sorted according to user preference. */
+export const sortedStoresSelector = createSelector(
+  storesSelector,
+  characterSortSelector,
+  (stores, sortStores) => sortStores(stores)
+);
+
+/** Have stores been loaded? */
+export const storesLoadedSelector = (state: RootState) => storesSelector(state).length > 0;
+
+/** A set containing all the hashes of owned items. */
+export const ownedItemsSelector = () =>
+  createSelector(storesSelector, (stores) => {
+    const ownedItemHashes = new Set<number>();
+    for (const store of stores) {
+      for (const item of store.items) {
+        ownedItemHashes.add(item.hash);
+      }
+    }
+    return ownedItemHashes;
+  });
+
+/** The actual raw profile response from the Bungie.net profile API */
+export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;
+
+/** Item infos (tags/notes) */
+export const itemInfosSelector = (state: RootState) =>
+  $featureFlags.dimApi && apiPermissionGrantedSelector(state)
+    ? ((currentProfileSelector(state)?.tags || emptyObject()) as InventoryState['itemInfos'])
+    : state.inventory.itemInfos;

--- a/src/app/inventory/tag-items.tsx
+++ b/src/app/inventory/tag-items.tsx
@@ -7,7 +7,7 @@ import { AppIcon, undoIcon } from 'app/shell/icons';
 import { DimItem } from './item-types';
 import { ThunkResult } from 'app/store/reducers';
 import { setItemTagsBulk } from './actions';
-import { itemInfosSelector } from './reducer';
+import { itemInfosSelector } from './selectors';
 
 export function bulkTagItems(itemsToBeTagged: DimItem[], selectedTag: TagValue): ThunkResult {
   return async (dispatch, getState) => {

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -6,7 +6,7 @@ import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { connect, MapStateToProps } from 'react-redux';
 import { RootState } from '../store/reducers';
 import { createSelector } from 'reselect';
-import { storesSelector } from '../inventory/reducer';
+import { storesSelector } from '../inventory/selectors';
 import {
   SearchConfig,
   searchConfigSelector,

--- a/src/app/item-popup/ItemActions.tsx
+++ b/src/app/item-popup/ItemActions.tsx
@@ -7,7 +7,7 @@ import styles from './ItemActions.m.scss';
 import { hideItemPopup } from './item-popup';
 import { moveItemTo, consolidate, distribute } from '../inventory/move-item';
 import { RootState } from '../store/reducers';
-import { storesSelector, sortedStoresSelector } from '../inventory/reducer';
+import { storesSelector, sortedStoresSelector } from '../inventory/selectors';
 import { connect } from 'react-redux';
 import ItemMoveAmount from './ItemMoveAmount';
 import { createSelector } from 'reselect';

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -12,7 +12,7 @@ import { RootState, ThunkDispatchProp } from 'app/store/reducers';
 import { inventoryWishListsSelector } from 'app/wishlists/reducer';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import { setItemNote } from 'app/inventory/actions';
-import { itemInfosSelector } from 'app/inventory/reducer';
+import { itemInfosSelector } from 'app/inventory/selectors';
 
 interface ProvidedProps {
   item: DimItem;

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -15,7 +15,7 @@ import './ItemPopupContainer.scss';
 import ItemTagHotkeys from './ItemTagHotkeys';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import { t } from 'app/i18next-t';
-import { storesSelector } from 'app/inventory/reducer';
+import { storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import ItemActions from './ItemActions';
 import { settingsSelector } from 'app/settings/reducer';

--- a/src/app/item-popup/ItemTagHotkeys.tsx
+++ b/src/app/item-popup/ItemTagHotkeys.tsx
@@ -7,7 +7,7 @@ import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import { t } from 'app/i18next-t';
 import { connect } from 'react-redux';
 import { RootState } from 'app/store/reducers';
-import { itemInfosSelector } from 'app/inventory/reducer';
+import { itemInfosSelector } from 'app/inventory/selectors';
 
 interface ProvidedProps {
   item: DimItem;

--- a/src/app/item-popup/ItemTagSelector.tsx
+++ b/src/app/item-popup/ItemTagSelector.tsx
@@ -6,7 +6,7 @@ import { RootState, ThunkDispatchProp } from '../store/reducers';
 import { t } from 'app/i18next-t';
 import './ItemTagSelector.scss';
 import { setItemTag } from 'app/inventory/actions';
-import { itemInfosSelector } from 'app/inventory/reducer';
+import { itemInfosSelector } from 'app/inventory/selectors';
 
 interface ProvidedProps {
   item: DimItem;

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -12,7 +12,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import BungieImage, { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { RootState } from 'app/store/reducers';
-import { storesSelector, profileResponseSelector } from 'app/inventory/reducer';
+import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { connect } from 'react-redux';
 import clsx from 'clsx';
 import styles from './SocketDetails.m.scss';

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -13,7 +13,7 @@ import { RootState } from '../store/reducers';
 import GeneratedSets from './generated-sets/GeneratedSets';
 import { filterGeneratedSets, isLoadoutBuilderItem } from './generated-sets/utils';
 import { ArmorSet, StatTypes, ItemsByBucket, LockedMap, MinMaxIgnored } from './types';
-import { sortedStoresSelector, storesLoadedSelector, storesSelector } from '../inventory/reducer';
+import { sortedStoresSelector, storesLoadedSelector, storesSelector } from '../inventory/selectors';
 import { process, filterItems, statKeys } from './process';
 import { createSelector } from 'reselect';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -16,7 +16,7 @@ import {
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { connect } from 'react-redux';
-import { storesSelector } from 'app/inventory/reducer';
+import { storesSelector } from 'app/inventory/selectors';
 import { RootState } from 'app/store/reducers';
 import { DimStore } from 'app/inventory/store-types';
 import { AppIcon, addIcon, faTimesCircle } from 'app/shell/icons';

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -22,7 +22,7 @@ import { AppIcon, searchIcon } from 'app/shell/icons';
 import copy from 'fast-copy';
 import ArmorBucketIcon from './ArmorBucketIcon';
 import { createSelector } from 'reselect';
-import { storesSelector, profileResponseSelector } from 'app/inventory/reducer';
+import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { RootState } from 'app/store/reducers';
 import { connect } from 'react-redux';
 import { itemsForPlugSet } from 'app/collections/PresentationNodeRoot';

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -13,7 +13,7 @@ import { itemSortOrderSelector } from '../settings/item-sort';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { destinyVersionSelector, currentAccountSelector } from '../accounts/reducer';
-import { storesSelector } from '../inventory/reducer';
+import { storesSelector } from '../inventory/selectors';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import LoadoutEditPopup from './LoadoutEditPopup';
 import { InventoryBuckets } from '../inventory/inventory-buckets';

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -59,7 +59,7 @@ import { editLoadout } from './LoadoutDrawer';
 import { deleteLoadout } from './loadout-storage';
 import { applyLoadout } from './loadout-apply';
 import { fromEquippedTypes } from './LoadoutDrawerContents';
-import { storesSelector } from 'app/inventory/reducer';
+import { storesSelector } from 'app/inventory/selectors';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 const loadoutIcon = {

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -32,7 +32,7 @@ import { bulkTagItems } from 'app/inventory/tag-items';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { RootState, ThunkDispatchProp } from 'app/store/reducers';
-import { storesSelector, itemInfosSelector } from 'app/inventory/reducer';
+import { storesSelector, itemInfosSelector } from 'app/inventory/selectors';
 import { searchFilterSelector } from 'app/search/search-filters';
 import { inventoryWishListsSelector } from 'app/wishlists/reducer';
 import { toggleSearchQueryComponent } from 'app/shell/actions';

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -8,7 +8,7 @@ import { useSubscription } from 'app/utils/hooks';
 import { queueAction } from 'app/inventory/action-queue';
 import { refresh$ } from 'app/shell/refresh';
 import { Loading } from 'app/dim-ui/Loading';
-import { storesSelector } from 'app/inventory/reducer';
+import { storesSelector } from 'app/inventory/selectors';
 import ItemTypeSelector, { SelectionTreeNode } from './ItemTypeSelector';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import ErrorBoundary from 'app/dim-ui/ErrorBoundary';

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -14,7 +14,7 @@ import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import { DimStore } from 'app/inventory/store-types';
-import { sortedStoresSelector, profileResponseSelector } from 'app/inventory/reducer';
+import { sortedStoresSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { D2StoresService } from 'app/inventory/d2-stores';
 import CharacterSelect from 'app/dim-ui/CharacterSelect';
 import { AppIcon, faExternalLinkAlt } from 'app/shell/icons';

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -21,7 +21,7 @@ import {
   getSpecialtySocketMetadata,
   modSlotTags
 } from 'app/utils/item-utils';
-import { itemInfosSelector, sortedStoresSelector } from '../inventory/reducer';
+import { itemInfosSelector, sortedStoresSelector } from '../inventory/selectors';
 import { maxLightItemSet, maxStatLoadout } from '../loadout/auto-loadouts';
 
 import { D1Categories } from '../destiny1/d1-buckets';

--- a/src/app/settings/CharacterOrderEditor.tsx
+++ b/src/app/settings/CharacterOrderEditor.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { DimStore } from '../inventory/store-types';
 import { connect } from 'react-redux';
 import { RootState } from '../store/reducers';
-import { sortedStoresSelector } from '../inventory/reducer';
+import { sortedStoresSelector } from '../inventory/selectors';
 import './CharacterOrderEditor.scss';
 import { AppIcon, refreshIcon } from '../shell/icons';
 

--- a/src/app/settings/Spreadsheets.tsx
+++ b/src/app/settings/Spreadsheets.tsx
@@ -7,7 +7,7 @@ import { DropzoneOptions } from 'react-dropzone';
 import { DimStore } from 'app/inventory/store-types';
 import { TagValue } from 'app/inventory/dim-item-info';
 import { connect } from 'react-redux';
-import { storesSelector, storesLoadedSelector, itemInfosSelector } from 'app/inventory/reducer';
+import { storesSelector, storesLoadedSelector, itemInfosSelector } from 'app/inventory/selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/reducers';
 
 interface StoreProps {

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -6,7 +6,7 @@ import { characterSortSelector } from '../settings/character-sort';
 import store from '../store/store';
 import { getTag, tagConfig } from '../inventory/dim-item-info';
 import { getRating } from '../item-review/reducer';
-import { itemInfosSelector } from 'app/inventory/reducer';
+import { itemInfosSelector } from 'app/inventory/selectors';
 // This file defines filters for DIM that may be shared among
 // different parts of DIM.
 

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -16,7 +16,11 @@ import { Subscriptions } from '../utils/rx-utils';
 import { refresh$ } from '../shell/refresh';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { connect } from 'react-redux';
-import { storesSelector, ownedItemsSelector, profileResponseSelector } from '../inventory/reducer';
+import {
+  storesSelector,
+  ownedItemsSelector,
+  profileResponseSelector
+} from '../inventory/selectors';
 import { RootState, ThunkDispatchProp } from '../store/reducers';
 import { toVendor } from './d2-vendors';
 import styles from './SingleVendor.m.scss';

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -27,7 +27,7 @@ import {
   ownedItemsSelector,
   sortedStoresSelector,
   profileResponseSelector
-} from '../inventory/reducer';
+} from '../inventory/selectors';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import {

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -8,7 +8,7 @@ import { observeStore } from '../utils/redux-utils';
 import { set, get } from 'idb-keyval';
 import { WishListAndInfo } from './types';
 import { createSelector } from 'reselect';
-import { storesSelector } from '../inventory/reducer';
+import { storesSelector } from '../inventory/selectors';
 import { fetchWishList } from './wishlist-fetch';
 
 export const wishListsSelector = (state: RootState) => state.wishLists;


### PR DESCRIPTION
I hadn't done this at first despite it being a popular scheme in Redux codebases, but I think I've come around to having selectors in their own file. Not only is it easier to pick apart, it does have some module dependency order benefits.