### PR TITLE
Fix season rank after season rank 100

### DIFF
--- a/src/app/progress/SeasonalRank.tsx
+++ b/src/app/progress/SeasonalRank.tsx
@@ -114,7 +114,7 @@ export default function SeasonalRank({
             const itemInfo = prestigeMode
               ? getBrightEngram
                 ? defs.InventoryItem.get(brightEngramHash)
-                : season // make fake item out of season info for prestigeMode
+                : defs.InventoryItem.get(season.artifactItemHash || 0) // make fake item out of season info for prestigeMode
               : defs.InventoryItem.get(item.itemHash);
 
             return (


### PR DESCRIPTION
season does not necessarily have an associated icon, falling back to seasonal artifact, in the stead.