### PR TITLE
bye, byId

### DIFF
--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -93,7 +93,6 @@ export const getBuckets = _.once(async () => {
     },
     setHasUnknown() {
       this.byCategory[this.unknown.sort] = [this.unknown];
-      this.byId[this.unknown.id] = this.unknown;
       this.byType[this.unknown.type] = this.unknown;
     }
   };


### PR DESCRIPTION
looks like `byId` was intended to be removed, but it was still referenced here