### PR TITLE
Load manifest from multiple files and reduce memory usage.

### DIFF
--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -24,27 +24,27 @@ const lazyTables = [
 
 const eagerTables = ['InventoryBucket', 'Class', 'Race', 'Faction', 'Vendor'];
 
-export interface LazyDefinition<T> {
+export interface DefinitionTable<T> {
   get(hash: number): T;
 }
 
 // D1 types don't exist yet
 export interface D1ManifestDefinitions extends ManifestDefinitions {
-  InventoryItem: LazyDefinition<any>;
-  Objective: LazyDefinition<any>;
-  SandboxPerk: LazyDefinition<any>;
-  Stat: LazyDefinition<any>;
-  TalentGrid: LazyDefinition<any>;
-  Progression: LazyDefinition<any>;
-  Record: LazyDefinition<any>;
-  ItemCategory: LazyDefinition<any>;
-  VendorCategory: LazyDefinition<any>;
-  RecordBook: LazyDefinition<any>;
-  ActivityCategory: LazyDefinition<any>;
-  ScriptedSkull: LazyDefinition<any>;
-  Activity: LazyDefinition<any>;
-  ActivityType: LazyDefinition<any>;
-  DamageType: LazyDefinition<any>;
+  InventoryItem: DefinitionTable<any>;
+  Objective: DefinitionTable<any>;
+  SandboxPerk: DefinitionTable<any>;
+  Stat: DefinitionTable<any>;
+  TalentGrid: DefinitionTable<any>;
+  Progression: DefinitionTable<any>;
+  Record: DefinitionTable<any>;
+  ItemCategory: DefinitionTable<any>;
+  VendorCategory: DefinitionTable<any>;
+  RecordBook: DefinitionTable<any>;
+  ActivityCategory: DefinitionTable<any>;
+  ScriptedSkull: DefinitionTable<any>;
+  Activity: DefinitionTable<any>;
+  ActivityType: DefinitionTable<any>;
+  DamageType: DefinitionTable<any>;
 
   InventoryBucket: { [hash: number]: any };
   Class: { [hash: number]: any };

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -1,7 +1,6 @@
 import {
   DestinyActivityDefinition,
   DestinyActivityModifierDefinition,
-  DestinyActivityTypeDefinition,
   DestinyClassDefinition,
   DestinyFactionDefinition,
   DestinyGenderDefinition,
@@ -43,18 +42,17 @@ import store from '../store/store';
 import { setD2Manifest } from '../manifest/actions';
 
 const lazyTables = [
-  'InventoryItem', // DestinyInventoryItemDefinition
-  'Objective', // DestinyObjectiveDefinition
-  'SandboxPerk', // DestinySandboxPerkDefinition
-  'Stat', // DestinyStatDefinition
+  'InventoryItem',
+  'Objective',
+  'SandboxPerk',
+  'Stat',
   'StatGroup',
   'EnergyType',
   'DamageType',
-  'TalentGrid', // DestinyTalentGridDefinition
-  'Progression', // DestinyProgressionDefinition
-  'ItemCategory', // DestinyItemCategoryDefinition
-  'Activity', // DestinyActivityDefinition
-  'ActivityType', // DestinyActivityTypeDefinition
+  'TalentGrid',
+  'Progression',
+  'ItemCategory',
+  'Activity',
   'ActivityModifier',
   'Vendor',
   'SocketCategory',
@@ -75,50 +73,48 @@ const lazyTables = [
 ];
 
 const eagerTables = [
-  'InventoryBucket', // DestinyInventoryBucketDefinition
-  'Class', // DestinyClassDefinition
-  'Gender', // DestinyGenderDefinition
-  'Race', // DestinyRaceDefinition
-  'Faction', // DestinyFactionDefinition
-  'ItemTierType', // DestinyItemTierTypeDefinition
-  'ActivityMode' // DestinyActivityModeDefinition
+  'InventoryBucket',
+  'Class',
+  'Gender',
+  'Race',
+  'Faction',
+  'ItemTierType',
+  'ActivityMode'
 ];
 
-export interface LazyDefinition<T> {
+/** These aren't really lazy */
+export interface DefinitionTable<T> {
   get(hash: number): T;
-  getAll(): { [hash: number]: T };
 }
 
 export interface D2ManifestDefinitions extends ManifestDefinitions {
-  InventoryItem: LazyDefinition<DestinyInventoryItemDefinition>;
-  Objective: LazyDefinition<DestinyObjectiveDefinition>;
-  SandboxPerk: LazyDefinition<DestinySandboxPerkDefinition>;
-  Stat: LazyDefinition<DestinyStatDefinition>;
-  StatGroup: LazyDefinition<DestinyStatGroupDefinition>;
-  EnergyType: LazyDefinition<DestinyEnergyTypeDefinition>;
-  DamageType: LazyDefinition<DestinyDamageTypeDefinition>;
-  TalentGrid: LazyDefinition<DestinyTalentGridDefinition>;
-  Progression: LazyDefinition<DestinyProgressionDefinition>;
-  ItemCategory: LazyDefinition<DestinyItemCategoryDefinition>;
-  Activity: LazyDefinition<DestinyActivityDefinition>;
-  ActivityType: LazyDefinition<DestinyActivityTypeDefinition>;
-  ActivityModifier: LazyDefinition<DestinyActivityModifierDefinition>;
-  Vendor: LazyDefinition<DestinyVendorDefinition>;
-  SocketCategory: LazyDefinition<DestinySocketCategoryDefinition>;
-  SocketType: LazyDefinition<DestinySocketTypeDefinition>;
-  MaterialRequirementSet: LazyDefinition<DestinyMaterialRequirementSetDefinition>;
-  Season: LazyDefinition<DestinySeasonDefinition>;
-  SeasonPass: LazyDefinition<DestinySeasonPassDefinition>;
-  Milestone: LazyDefinition<DestinyMilestoneDefinition>;
-  Destination: LazyDefinition<DestinyDestinationDefinition>;
-  Place: LazyDefinition<DestinyPlaceDefinition>;
-  VendorGroup: LazyDefinition<DestinyVendorGroupDefinition>;
-  PlugSet: LazyDefinition<DestinyPlugSetDefinition>;
-  Collectible: LazyDefinition<DestinyCollectibleDefinition>;
-  PresentationNode: LazyDefinition<DestinyPresentationNodeDefinition>;
-  Record: LazyDefinition<DestinyRecordDefinition>;
-  Metric: LazyDefinition<DestinyMetricDefinition>;
-  Trait: LazyDefinition<DestinyTraitDefinition>;
+  InventoryItem: DefinitionTable<DestinyInventoryItemDefinition>;
+  Objective: DefinitionTable<DestinyObjectiveDefinition>;
+  SandboxPerk: DefinitionTable<DestinySandboxPerkDefinition>;
+  Stat: DefinitionTable<DestinyStatDefinition>;
+  StatGroup: DefinitionTable<DestinyStatGroupDefinition>;
+  EnergyType: DefinitionTable<DestinyEnergyTypeDefinition>;
+  TalentGrid: DefinitionTable<DestinyTalentGridDefinition>;
+  Progression: DefinitionTable<DestinyProgressionDefinition>;
+  ItemCategory: DefinitionTable<DestinyItemCategoryDefinition>;
+  Activity: DefinitionTable<DestinyActivityDefinition>;
+  ActivityModifier: DefinitionTable<DestinyActivityModifierDefinition>;
+  Vendor: DefinitionTable<DestinyVendorDefinition>;
+  SocketCategory: DefinitionTable<DestinySocketCategoryDefinition>;
+  SocketType: DefinitionTable<DestinySocketTypeDefinition>;
+  MaterialRequirementSet: DefinitionTable<DestinyMaterialRequirementSetDefinition>;
+  Season: DefinitionTable<DestinySeasonDefinition>;
+  SeasonPass: DefinitionTable<DestinySeasonPassDefinition>;
+  Milestone: DefinitionTable<DestinyMilestoneDefinition>;
+  Destination: DefinitionTable<DestinyDestinationDefinition>;
+  Place: DefinitionTable<DestinyPlaceDefinition>;
+  VendorGroup: DefinitionTable<DestinyVendorGroupDefinition>;
+  PlugSet: DefinitionTable<DestinyPlugSetDefinition>;
+  Collectible: DefinitionTable<DestinyCollectibleDefinition>;
+  PresentationNode: DefinitionTable<DestinyPresentationNodeDefinition>;
+  Record: DefinitionTable<DestinyRecordDefinition>;
+  Metric: DefinitionTable<DestinyMetricDefinition>;
+  Trait: DefinitionTable<DestinyTraitDefinition>;
 
   InventoryBucket: { [hash: number]: DestinyInventoryBucketDefinition };
   Class: { [hash: number]: DestinyClassDefinition };
@@ -127,6 +123,7 @@ export interface D2ManifestDefinitions extends ManifestDefinitions {
   Faction: { [hash: number]: DestinyFactionDefinition };
   ItemTierType: { [hash: number]: DestinyItemTierTypeDefinition };
   ActivityMode: { [hash: number]: DestinyActivityModeDefinition };
+  DamageType: { [hash: number]: DestinyDamageTypeDefinition };
 }
 
 /**

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -291,8 +291,7 @@ export function makeItem(
 
   // if a damageType isn't found, use the item's energy capacity element instead
   const element =
-    (instanceDef?.damageTypeHash !== undefined &&
-      defs.DamageType.get(instanceDef.damageTypeHash)) ||
+    (instanceDef?.damageTypeHash !== undefined && defs.DamageType[instanceDef.damageTypeHash]) ||
     (instanceDef?.energy?.energyTypeHash !== undefined &&
       defs.EnergyType.get(instanceDef.energy.energyTypeHash)) ||
     null;

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -8,7 +8,7 @@ import {
 import _ from 'lodash';
 import { bungieNetPath } from '../../dim-ui/BungieImage';
 import { count } from '../../utils/util';
-import { D2ManifestDefinitions, LazyDefinition } from '../../destiny2/d2-definitions';
+import { D2ManifestDefinitions, DefinitionTable } from '../../destiny2/d2-definitions';
 import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import { t } from 'app/i18next-t';
@@ -292,7 +292,7 @@ export function makeVault(
  * Compute character-level stats.
  */
 export function getCharacterStatsData(
-  statDefs: LazyDefinition<DestinyStatDefinition>,
+  statDefs: DefinitionTable<DestinyStatDefinition>,
   stats: {
     [key: number]: number;
   }

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -109,7 +109,7 @@ function buildForsakenMasterworkStats(
     const masterwork = masterworkSocket.plug.plugItem.investmentStats[0];
     if (!createdItem.element && createdItem.bucket?.sort === 'Armor') {
       createdItem.element =
-        Object.values(defs.DamageType.getAll()).find(
+        Object.values(defs.DamageType).find(
           (damageType) => damageType.enumValue === resistanceMods[masterwork.statTypeHash]
         ) ?? null;
     }

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -42,7 +42,6 @@ export default function SocketDetailsSelectedPlug({
       if (!itemStat) {
         return null;
       }
-      // const statDef = defs.Stat.get(stat.statTypeHash);
       const statGroupDef = defs.StatGroup.get(
         defs.InventoryItem.get(item.hash).stats.statGroupHash!
       );

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -240,8 +240,6 @@ class ManifestService {
 
     this.statusText = `${t('Manifest.Build')}...`;
 
-    // TODO: trim specific tables
-
     // We intentionally don't wait on this promise
     this.saveManifestToIndexedDB(manifest, version, tableWhitelist);
 


### PR DESCRIPTION
This makes two big changes to manifest loading:

1. We now load individual files per-table and stitch them together, instead of loading the mega combined JSON and stripping out what we don't want. This should reduce peak memory usage and help avoid crashes on Chrome.
2. Carefully trim down the InventoryItem table before saving it to cache or using it further, reducing total memory usage. This can't reduce the peak memory usage of this table (~61MB) but it reduces the sustained memory cost and the cost on subsequent loads (from cache) to about 27MB (a 56% reduction). I've only removed properties we weren't using.

Load times are about the same or slightly better (I had messed up my measurement before). However, now there are many more opportunities for one file failing to download to kill the whole app load.

Fixes #5095