### PR TITLE
Use reusablePlugSetHash for defined sockets

### DIFF
--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -222,6 +222,9 @@ function filterReusablePlug(reusablePlug: DimPlug) {
   );
 }
 
+/**
+ * Build a socket from definitions, without the benefit of live profile info.
+ */
 function buildDefinedSocket(
   defs: D2ManifestDefinitions,
   socketDef: DestinyItemSocketEntryDefinition,
@@ -249,11 +252,24 @@ function buildDefinedSocket(
   // The currently equipped plug, if any
   const reusablePlugs: DimPlug[] = [];
 
-  if (socketDef.reusablePlugItems) {
-    for (const reusablePlug of socketDef.reusablePlugItems) {
-      const built = buildDefinedPlug(defs, reusablePlug);
-      if (built) {
-        reusablePlugs.push(built);
+  // We only build a larger list of plug options if this is a perk socket, since users would
+  // only want to see (and search) the plug options for perks. For other socket types (mods, shaders, etc.)
+  // we will only populate plugOptions with the currently inserted plug.
+  if (isPerk) {
+    if (socketDef.reusablePlugSetHash) {
+      const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash);
+      for (const reusablePlug of plugSet.reusablePlugItems) {
+        const built = buildDefinedPlug(defs, reusablePlug);
+        if (built) {
+          reusablePlugs.push(built);
+        }
+      }
+    } else if (socketDef.reusablePlugItems) {
+      for (const reusablePlug of socketDef.reusablePlugItems) {
+        const built = buildDefinedPlug(defs, reusablePlug);
+        if (built) {
+          reusablePlugs.push(built);
+        }
       }
     }
   }


### PR DESCRIPTION
@sundevour correctly pointed out that I'd failed to use `reusablePlugSetHash` from `buildDefinedSocket`. Once we do that, collections look a bit more complete. I couldn't find anything else that was affected.

Now:
<img width="464" alt="Screen Shot 2020-04-06 at 10 28 40 PM" src="https://user-images.githubusercontent.com/313208/78633054-6c22e180-7855-11ea-813b-594360983f4a.png">

Before:
<img width="421" alt="Screen Shot 2020-04-06 at 10 28 46 PM" src="https://user-images.githubusercontent.com/313208/78633059-6e853b80-7855-11ea-96dd-7940d584c48d.png">
