### PR TITLE
Restore get all

### DIFF
--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -86,6 +86,7 @@ const eagerTables = [
 /** These aren't really lazy */
 export interface DefinitionTable<T> {
   get(hash: number): T;
+  getAll(): { [hash: number]: T };
 }
 
 export interface D2ManifestDefinitions extends ManifestDefinitions {
@@ -116,8 +117,8 @@ export interface D2ManifestDefinitions extends ManifestDefinitions {
   Metric: DefinitionTable<DestinyMetricDefinition>;
   Trait: DefinitionTable<DestinyTraitDefinition>;
   DamageType: DefinitionTable<DestinyDamageTypeDefinition>;
+  Collectible: DefinitionTable<DestinyCollectibleDefinition>;
 
-  Collectible: { [hash: number]: DestinyCollectibleDefinition };
   InventoryBucket: { [hash: number]: DestinyInventoryBucketDefinition };
   Class: { [hash: number]: DestinyClassDefinition };
   Gender: { [hash: number]: DestinyGenderDefinition };
@@ -150,6 +151,9 @@ async function getDefinitionsUncached() {
     defs[tableShort] = {
       get(name: number) {
         return D2ManifestService.getRecord(db, table, name);
+      },
+      getAll() {
+        return D2ManifestService.getAllRecords(db, table);
       }
     };
   });

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -111,13 +111,13 @@ export interface D2ManifestDefinitions extends ManifestDefinitions {
   Place: DefinitionTable<DestinyPlaceDefinition>;
   VendorGroup: DefinitionTable<DestinyVendorGroupDefinition>;
   PlugSet: DefinitionTable<DestinyPlugSetDefinition>;
-  Collectible: DefinitionTable<DestinyCollectibleDefinition>;
   PresentationNode: DefinitionTable<DestinyPresentationNodeDefinition>;
   Record: DefinitionTable<DestinyRecordDefinition>;
   Metric: DefinitionTable<DestinyMetricDefinition>;
   Trait: DefinitionTable<DestinyTraitDefinition>;
   DamageType: DefinitionTable<DestinyDamageTypeDefinition>;
 
+  Collectible: { [hash: number]: DestinyCollectibleDefinition };
   InventoryBucket: { [hash: number]: DestinyInventoryBucketDefinition };
   Class: { [hash: number]: DestinyClassDefinition };
   Gender: { [hash: number]: DestinyGenderDefinition };

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -378,7 +378,9 @@ export function makeItem(
     dtrRating: null,
     previewVendor: itemDef.preview?.previewVendorHash,
     ammoType: itemDef.equippingBlock ? itemDef.equippingBlock.ammoType : DestinyAmmunitionType.None,
-    source: itemDef.collectibleHash ? defs.Collectible[itemDef.collectibleHash]?.sourceHash : null,
+    source: itemDef.collectibleHash
+      ? defs.Collectible.get(itemDef.collectibleHash)?.sourceHash
+      : null,
     collectibleState: collectible ? collectible.state : null,
     collectibleHash: itemDef.collectibleHash || null,
     missingSockets: false,

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -47,8 +47,8 @@ const _moveTouchTimestamps = new Map<string, number>();
 
 const SourceToD2Season = D2SeasonToSource.sources;
 
-const collectiblesByItemHash = _.once((Collectible) =>
-  _.keyBy(Collectible.getAll(), (c) => c.itemHash)
+const collectiblesByItemHash = _.once((Collectible: D2ManifestDefinitions['Collectible']) =>
+  _.keyBy(Collectible, (c) => c.itemHash)
 );
 
 /**
@@ -377,9 +377,7 @@ export function makeItem(
     dtrRating: null,
     previewVendor: itemDef.preview?.previewVendorHash,
     ammoType: itemDef.equippingBlock ? itemDef.equippingBlock.ammoType : DestinyAmmunitionType.None,
-    source: itemDef.collectibleHash
-      ? defs.Collectible.get(itemDef.collectibleHash).sourceHash
-      : null,
+    source: itemDef.collectibleHash ? defs.Collectible[itemDef.collectibleHash]?.sourceHash : null,
     collectibleState: collectible ? collectible.state : null,
     collectibleHash: itemDef.collectibleHash || null,
     missingSockets: false,

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -47,8 +47,9 @@ const _moveTouchTimestamps = new Map<string, number>();
 
 const SourceToD2Season = D2SeasonToSource.sources;
 
-const collectiblesByItemHash = _.once((Collectible: D2ManifestDefinitions['Collectible']) =>
-  _.keyBy(Collectible, (c) => c.itemHash)
+const collectiblesByItemHash = _.once(
+  (Collectible: ReturnType<D2ManifestDefinitions['Collectible']['getAll']>) =>
+    _.keyBy(Collectible, (c) => c.itemHash)
 );
 
 /**
@@ -249,7 +250,7 @@ export function makeItem(
   let displayProperties = itemDef.displayProperties;
   if (itemDef.redacted) {
     // Fill in display info from the collectible, sometimes it's not redacted there!
-    const collectibleDef = collectiblesByItemHash(defs.Collectible)[item.itemHash];
+    const collectibleDef = collectiblesByItemHash(defs.Collectible.getAll())[item.itemHash];
     if (collectibleDef) {
       displayProperties = collectibleDef.displayProperties;
     }


### PR DESCRIPTION
i deleted getAll from manifest but it looks like it's still in use some places. would like to investigate further standardizing manifest access. this build looks like recent bugs are all good. weapon elements show up, collections page works, source searches work.