### PR TITLE
Use a different error message for manifest problems

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -10,12 +10,13 @@
     "Stadia": "Stadia",
     "Steam": "Steam",
     "Xbox": "XB1",
-    "ErrorLoading": "Unable to load Destiny Accounts from Bungie.net",
+    "ErrorLoading": "Unable to load Destiny accounts from Bungie.net",
     "MissingTitle": "Account Not Found",
     "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile.",
     "UnlinkTwitch": "Linking your Twitch account to Bungie.net will cause your D1 accounts to stop working.",
     "UnlinkTwitchButton": "Unlink Twitch",
-    "ErrorLoadInventory": "Unable to load your Destiny profile"
+    "ErrorLoadInventory": "Unable to load your Destiny characters and inventory",
+    "ErrorLoadManifest": "Unable to load Destiny info database from Bungie"
   },
   "Activities": {
     "Activities": "Activities",
@@ -145,7 +146,7 @@
     "Title": "Something went wrong"
   },
   "ErrorPanel": {
-    "Description": "This is likely an issue that affects all third-party apps -- check to see if Bungie.net loads, or the Destiny 2 Companion App works."
+    "Description": "This is likely an issue that affects all third-party apps. Check to see if Bungie.net loads, or the Destiny 2 Companion App works."
   },
   "FarmingMode": {
     "D2Desc": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -174,7 +174,9 @@ class ManifestService {
       this.setState({ error: e, statusText });
       console.error('Manifest loading error', { error: e }, e);
       reportException('manifest load', e);
-      throw new Error(message);
+      const error = new Error(message);
+      error.name = 'ManifestError';
+      throw error;
     } finally {
       console.timeEnd('Load manifest');
     }

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -69,16 +69,20 @@ class Destiny extends React.Component<Props> {
     }
 
     if (profileError) {
+      const isManifestError = profileError.name === 'ManifestError';
       const token = getToken()!;
       return (
         <div className="dim-page">
           <ErrorPanel
-            title={t('Accounts.ErrorLoadInventory')}
+            title={
+              isManifestError ? t('Accounts.ErrorLoadManifest') : t('Accounts.ErrorLoadInventory')
+            }
             error={profileError}
             showTwitters={true}
             showReload={true}
           >
-            {account.destinyVersion === 1 &&
+            {!isManifestError &&
+              account.destinyVersion === 1 &&
               profileError.code === PlatformErrorCodes.DestinyUnexpectedError && (
                 <p>
                   <ExternalLink

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -5,8 +5,9 @@
   },
   "Accounts": {
     "Blizzard": "PC",
-    "ErrorLoadInventory": "Unable to load Destiny profile",
-    "ErrorLoading": "Unable to load Destiny Accounts from Bungie.net",
+    "ErrorLoadInventory": "Unable to load your Destiny characters and inventory",
+    "ErrorLoadManifest": "Unable to load Destiny info database from Bungie",
+    "ErrorLoading": "Unable to load Destiny accounts from Bungie.net",
     "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile.",
     "MissingTitle": "Account Not Found",
     "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account.",
@@ -143,7 +144,7 @@
     "Title": "Something went wrong"
   },
   "ErrorPanel": {
-    "Description": "This is likely an issue that affects all third-party apps - check to see if Bungie.net or the Companion App works."
+    "Description": "This is likely an issue that affects all third-party apps. Check to see if Bungie.net loads, or the Destiny 2 Companion App works."
   },
   "FarmingMode": {
     "D2Desc": "DIM is preventing items from going to the Postmaster by making sure there's always one empty space per item type on {{store}}. It is moving items to the vault to make room.",


### PR DESCRIPTION
This shows a different error message if the problem is with loading the manifest, vs. loading the profile.