### PR TITLE
Avoid updating accounts to the same value, don't reload dim-api on same account

### DIFF
--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -7,6 +7,7 @@ import { observeStore } from 'app/utils/redux-utils';
 import { set, get } from 'idb-keyval';
 import { dedupePromise } from 'app/utils/util';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
+import { deepEqual } from 'fast-equals';
 
 export const accountsSelector = (state: RootState) => state.accounts.accounts;
 
@@ -47,7 +48,7 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
     case getType(actions.accountsLoaded):
       return {
         ...state,
-        accounts: action.payload || [],
+        accounts: deepEqual(action.payload, state.accounts) ? state.accounts : action.payload || [],
         loaded: true,
         accountsError: undefined
       };
@@ -61,11 +62,14 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
         : state;
     }
     case getType(actions.loadFromIDB):
+      console.log('load from IDB', action.payload);
       return state.loaded
         ? state
         : {
             ...state,
-            accounts: action.payload || [],
+            accounts: deepEqual(action.payload, state.accounts)
+              ? state.accounts
+              : action.payload || [],
             loadedFromIDB: true
           };
     case getType(actions.error):

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -39,6 +39,7 @@ import { t } from 'app/i18next-t';
 import { dimErrorToaster } from 'app/bungie-api/error-toaster';
 import { refresh$ } from 'app/shell/refresh';
 import { getActiveToken as getBungieToken } from 'app/bungie-api/authenticated-fetch';
+import { compareAccounts } from 'app/accounts/destiny-account';
 
 const installApiPermissionObserver = _.once(() => {
   // Observe API permission and reflect it into local storage
@@ -94,9 +95,9 @@ const installObservers = _.once((dispatch: ThunkDispatch<RootState, {}, AnyActio
 
   // Observe the current account and reload data
   // Another one that should probably be a thunk action once account transitions are actions
-  observeStore(currentAccountSelector, (oldAccount) => {
+  observeStore(currentAccountSelector, (oldAccount, newAccount) => {
     // Force load profile data if the account changed
-    if (oldAccount) {
+    if (oldAccount && newAccount && !compareAccounts(oldAccount, newAccount)) {
       dispatch(loadDimApiData(true));
     }
   });


### PR DESCRIPTION
I was noticing that we were loading the profile from DIM API *twice* on load. This is because the refactored accounts stuff would load twice, and the DIM API observer wasn't smart enough to realize that the current account was the same.

I changed it to make sure the account was really changing, and also made the accounts reducer smarter so it wouldn't replace identical lists, which avoids some needless re-rendering.