### PR TITLE
Better support logout

### DIFF
--- a/src/app/accounts/MenuAccounts.tsx
+++ b/src/app/accounts/MenuAccounts.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
-import { removeToken } from '../bungie-api/oauth-tokens';
 import './Account.scss';
 import { DestinyAccount } from './destiny-account';
 import { UISref } from '@uirouter/react';
-import { router } from '../router';
 import { AppIcon, signOutIcon } from '../shell/icons';
 import { currentAccountSelector } from './reducer';
-import { RootState } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from '../store/reducers';
 import { connect } from 'react-redux';
 import Account from './Account';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
+import { logOut } from './platforms';
 
 interface ProvidedProps {
   closeDropdown(e: React.MouseEvent<HTMLDivElement>): void;
@@ -28,19 +27,14 @@ function mapStateToProps(state: RootState): StoreProps {
   };
 }
 
-type Props = ProvidedProps & StoreProps;
+type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 
-function MenuAccounts({ currentAccount, closeDropdown, accounts }: Props) {
+function MenuAccounts({ currentAccount, closeDropdown, accounts, dispatch }: Props) {
   if (!currentAccount) {
     return null;
   }
 
   const sortedAccounts = _.sortBy(accounts, (a) => -(a.lastPlayed?.getTime() || 0));
-
-  const logOut = () => {
-    removeToken();
-    router.stateService.go('login', { reauth: true });
-  };
 
   return (
     <div className="account-select">
@@ -58,7 +52,7 @@ function MenuAccounts({ currentAccount, closeDropdown, accounts }: Props) {
           />
         </UISref>
       ))}
-      <div className="account log-out" onClick={logOut}>
+      <div className="account log-out" onClick={() => dispatch(logOut())}>
         <AppIcon icon={signOutIcon} />
         &nbsp;
         {t('Settings.LogOut')}

--- a/src/app/accounts/actions.ts
+++ b/src/app/accounts/actions.ts
@@ -10,3 +10,5 @@ export const setCurrentAccount = createAction('accounts/SET_CURRENT_ACCOUNT')<
 export const loadFromIDB = createAction('accounts/LOAD_FROM_IDB')<DestinyAccount[]>();
 
 export const error = createAction('accounts/ERROR')<DimError>();
+
+export const loggedOut = createAction('accounts/LOG_OUT')();

--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -62,7 +62,6 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
         : state;
     }
     case getType(actions.loadFromIDB):
-      console.log('load from IDB', action.payload);
       return state.loaded
         ? state
         : {
@@ -77,6 +76,8 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
         ...state,
         accountsError: action.payload
       };
+    case getType(actions.loggedOut):
+      return initialState;
 
     default:
       return state;

--- a/src/app/dim-api/dim-api-helper.ts
+++ b/src/app/dim-api/dim-api-helper.ts
@@ -82,7 +82,7 @@ export async function authenticatedApi<T>(config: HttpClientConfig): Promise<T> 
 
   if (response.status === 401) {
     // Delete our token
-    localStorage.removeItem(localStorageKey);
+    deleteDimApiToken();
   }
   if (response.ok) {
     return response.json();
@@ -120,6 +120,10 @@ function getToken(): DimAuthToken | undefined {
  */
 function setToken(token: DimAuthToken) {
   localStorage.setItem(localStorageKey, JSON.stringify(token));
+}
+
+export function deleteDimApiToken() {
+  localStorage.removeItem(localStorageKey);
 }
 
 export interface AuthTokenRequest {


### PR DESCRIPTION
I'd created a couple bugs around logout:

1. We still had accounts cached, so if you logged in as another user it'd try to load the wrong stuff.
2. We didn't clean out the DIM API key so it'd use the old account's token.

This implements a logOut action that fixes those issues.