### PR TITLE
Correctly quote urls and undo lodash change

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -389,8 +389,8 @@ module.exports = (env) => {
       new LodashModuleReplacementPlugin({
         collections: true,
         memoizing: true,
-        shorthands: false,
-        flattening: false
+        shorthands: true,
+        flattening: true
       }),
 
       new webpack.WatchIgnorePlugin([/scss\.d\.ts$/])
@@ -434,7 +434,7 @@ module.exports = (env) => {
     // env.beta and env.release
     config.plugins.push(
       new CleanWebpackPlugin({
-        cleanOnceBeforeBuildPatterns: ['.awcache', 'node_modules/.cache']
+        cleanOnceBeforeBuildPatterns: ['node_modules/.cache']
       }),
 
       // Tell React we're in Production mode

--- a/src/app/collections/Mod.tsx
+++ b/src/app/collections/Mod.tsx
@@ -38,7 +38,7 @@ export default function Mod({ item, defs, allowFilter, innerRef, onClick, childr
       {costElementIcon && (
         <>
           <div
-            style={{ backgroundImage: `url(${bungieNetPath(costElementIcon)}` }}
+            style={{ backgroundImage: `url("${bungieNetPath(costElementIcon)}")` }}
             className="energyCostOverlay"
           />
           <div className="energyCost">{modDef.plug.energyCost.energyCost}</div>

--- a/src/app/dim-ui/BungieImage.test.tsx
+++ b/src/app/dim-ui/BungieImage.test.tsx
@@ -23,6 +23,6 @@ test('bungie net path ', () => {
 
 test('bungie background direct link ', () => {
   let testString: BungieImagePath = '~test';
-  const data = { backgroundImage: `url(test)` };
+  const data = { backgroundImage: `url("test")` };
   expect(bungieBackgroundStyle(testString)).toStrictEqual(data);
 });

--- a/src/app/dim-ui/BungieImage.tsx
+++ b/src/app/dim-ui/BungieImage.tsx
@@ -24,7 +24,7 @@ export default React.memo(function BungieImage(
  * Produce a style object that sets the background image to an image on bungie.net.
  */
 export function bungieBackgroundStyle(src: BungieImagePath) {
-  return { backgroundImage: `url(${bungieNetPath(src)})` };
+  return { backgroundImage: `url("${bungieNetPath(src)}")` };
 }
 
 /**

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -121,7 +121,7 @@ export default function InventoryItem({
       {item.isDestiny2 && item.isDestiny2() && item.plug?.costElementIcon && (
         <>
           <div
-            style={{ backgroundImage: `url(${bungieNetPath(item.plug.costElementIcon)}` }}
+            style={{ backgroundImage: `url("${bungieNetPath(item.plug.costElementIcon)}")` }}
             className="energyCostOverlay"
           />
           <div className="energyCost">{item.plug.energyCost}</div>

--- a/src/app/inventory/SimpleCharacterTile.tsx
+++ b/src/app/inventory/SimpleCharacterTile.tsx
@@ -19,9 +19,9 @@ export default function SimpleCharacterTile({
           destiny2: character.isDestiny2()
         })}
       >
-        <div className="background" style={{ backgroundImage: `url(${character.background})` }} />
+        <div className="background" style={{ backgroundImage: `url("${character.background}")` }} />
         <div className="details">
-          <div className="emblem" style={{ backgroundImage: `url(${character.icon})` }} />
+          <div className="emblem" style={{ backgroundImage: `url("${character.icon}")` }} />
           <div className="character-text">
             <div className="top">
               <div className="class">{character.className}</div>

--- a/src/app/inventory/StoreHeading.tsx
+++ b/src/app/inventory/StoreHeading.tsx
@@ -53,9 +53,9 @@ export default class StoreHeading extends React.Component<Props, State> {
       <AppIcon className="loadout-button" icon={openDropdownIcon} title={t('Loadouts.Loadouts')} />
     );
     const background = (
-      <div className="background" style={{ backgroundImage: `url(${store.background})` }} />
+      <div className="background" style={{ backgroundImage: `url("${store.background}")` }} />
     );
-    const emblem = <div className="emblem" style={{ backgroundImage: `url(${store.icon})` }} />;
+    const emblem = <div className="emblem" style={{ backgroundImage: `url("${store.icon}")` }} />;
 
     // TODO: break up into some pure components
 

--- a/src/app/item-popup/ItemActionButton.tsx
+++ b/src/app/item-popup/ItemActionButton.tsx
@@ -28,7 +28,7 @@ export default function ItemActionButton({
       className={clsx(styles.button, className)}
       title={title}
       onClick={onClick}
-      style={icon ? { backgroundImage: `url(${icon})` } : undefined}
+      style={icon ? { backgroundImage: `url("${icon}")` } : undefined}
     >
       <span>{label}</span>
     </div>

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -84,7 +84,7 @@ export default function Plug({
       {costElementIcon && (
         <>
           <div
-            style={{ backgroundImage: `url(${bungieNetPath(costElementIcon)}` }}
+            style={{ backgroundImage: `url("${bungieNetPath(costElementIcon)}")` }}
             className="energyCostOverlay"
           />
           <div className="energyCost">{modDef.plug.energyCost.energyCost}</div>

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -274,7 +274,7 @@ export const SocketDetailsMod = React.memo(
         {costElementIcon && (
           <>
             <div
-              style={{ backgroundImage: `url(${bungieNetPath(costElementIcon)}` }}
+              style={{ backgroundImage: `url("${bungieNetPath(costElementIcon)}")` }}
               className="energyCostOverlay"
             />
             <div className="energyCost">{itemDef.plug.energyCost.energyCost}</div>


### PR DESCRIPTION
The vault banner was gone because the data URL wasn't correctly quoted. Found a bunch of those.

The lodash change is unexpectedly acting up and I don't have the patience to figure out why.