### PR TITLE
Avoid spurious notifications for wish lists

### DIFF
--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -8,7 +8,6 @@ import { DropzoneOptions } from 'react-dropzone';
 import FileUpload from '../dim-ui/FileUpload';
 import {
   wishListsEnabledSelector,
-  loadWishListAndInfoFromIndexedDB,
   wishListsSelector,
   wishListsLastFetchedSelector
 } from '../wishlists/reducer';
@@ -55,7 +54,7 @@ class WishListSettings extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    this.props.dispatch(loadWishListAndInfoFromIndexedDB());
+    this.props.dispatch(fetchWishList());
   }
 
   render() {

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -10,7 +10,6 @@ import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import { itemTagList } from '../inventory/dim-item-info';
 import { Hotkey } from '../hotkeys/hotkeys';
 import { connect } from 'react-redux';
-import { loadWishListAndInfoFromIndexedDB } from 'app/wishlists/reducer';
 import { loadVendorDropsFromIndexedDB } from 'app/vendorEngramsXyzApi/reducer';
 import { ThunkDispatchProp, RootState } from 'app/store/reducers';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
@@ -19,6 +18,7 @@ import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
 import ExternalLink from 'app/dim-ui/ExternalLink';
 import { getToken } from 'app/bungie-api/oauth-tokens';
 import { AppIcon, banIcon } from './icons';
+import { fetchWishList } from 'app/wishlists/wishlist-fetch';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -45,10 +45,10 @@ class Destiny extends React.Component<Props> {
     if (!account) {
       return;
     }
-    if ($featureFlags.wishLists) {
-      dispatch(loadWishListAndInfoFromIndexedDB());
+    if ($featureFlags.wishLists && account.destinyVersion === 2) {
+      dispatch(fetchWishList());
     }
-    if ($featureFlags.vendorEngrams) {
+    if ($featureFlags.vendorEngrams && account.destinyVersion === 2) {
       dispatch(loadVendorDropsFromIndexedDB());
     }
   }

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -2,14 +2,13 @@ import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { getInventoryWishListRolls } from './wishlists';
-import { RootState, ThunkResult } from '../store/reducers';
+import { RootState } from '../store/reducers';
 import _ from 'lodash';
 import { observeStore } from '../utils/redux-utils';
-import { set, get } from 'idb-keyval';
+import { set } from 'idb-keyval';
 import { WishListAndInfo } from './types';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/selectors';
-import { fetchWishList } from './wishlist-fetch';
 
 export const wishListsSelector = (state: RootState) => state.wishLists;
 
@@ -83,36 +82,4 @@ export function saveWishListToIndexedDB() {
       }
     }
   );
-}
-
-export function loadWishListAndInfoFromIndexedDB(): ThunkResult {
-  return async (dispatch, getState) => {
-    if (getState().wishLists.loaded) {
-      return;
-    }
-
-    const wishListState = await get<WishListsState>('wishlist');
-
-    if (getState().wishLists.loaded) {
-      return;
-    }
-
-    // easing the transition from the old state (just an array) to the new state
-    // (object containing an array)
-    if (Array.isArray(wishListState?.wishListAndInfo?.wishListRolls)) {
-      dispatch(
-        actions.loadWishLists({
-          wishList: {
-            title: undefined,
-            description: undefined,
-            wishListRolls: wishListState.wishListAndInfo.wishListRolls
-          },
-          lastFetched: wishListState.lastFetched
-        })
-      );
-    }
-
-    // Refresh the wish list from source if necessary
-    dispatch(fetchWishList());
-  };
 }


### PR DESCRIPTION
Fixes #5028.

My hypothesis around the excessive notifications was that we were managing to load the remote file faster than the IndexedDB cache sometimes. This changes the flow so we always try to load IndexedDB before going remote.