### PR TITLE
Detect and display errors from Bungie when setting up API keys.

### DIFF
--- a/src/app/developer/Developer.tsx
+++ b/src/app/developer/Developer.tsx
@@ -184,7 +184,11 @@ export default class Developer extends React.Component<{}, State> {
   private getDimApiKey = async (e) => {
     e.preventDefault();
     const { apiKey, dimAppName } = this.state;
-    const app = await registerApp(dimAppName!, apiKey!);
-    this.setState({ dimApiKey: app.dimApiKey });
+    try {
+      const app = await registerApp(dimAppName!, apiKey!);
+      this.setState({ dimApiKey: app.dimApiKey });
+    } catch (e) {
+      alert(e.message);
+    }
   };
 }

--- a/src/app/dim-api/register-app.ts
+++ b/src/app/dim-api/register-app.ts
@@ -15,5 +15,10 @@ export async function registerApp(dimAppName: string, bungieApiKey: string) {
     true
   );
 
+  // Check if request failed for various possible reasons
+  if("error" in appResponse){
+    const failResponse: any = appResponse; // Unexpected result, recast
+    throw new Error("Could not register app: " + failResponse.error + " - " + failResponse.message);
+  }
   return appResponse.app;
 }


### PR DESCRIPTION
Clicking the "Get API Key" button wasn't doing anything, and it turns out that I was getting an error from Bungie services which were not being displayed. This PR makes the messages visible. 

* Regular `alert()` seemed like the simplest appropriate option in this case, since it's a developer-only special page. Please let me know if there's a preferred alternative.
* Rather than `any`, it it worth defining a new error-type in `@destinyitemmanager/dim-api-types`?
* An example of a different-than-expected `appResponse` is `{"error":"InvalidRequest","message":"An app already exists with that id"}`


