### PR TITLE
Add "Armor2.0" column to spreadsheet export

### DIFF
--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -320,6 +320,9 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
     if (item.isDestiny1()) {
       row['% Leveled'] = (item.percentComplete * 100).toFixed(0);
     }
+    if (item.isDestiny2()) {
+      row['Armor2.0'] = Boolean(item.energy);
+    }
     row.Locked = item.locked;
     row.Equipped = item.equipped;
     if (item.isDestiny1()) {


### PR DESCRIPTION
For D2 armor, indicates whether the armor has a fixed set of perk-choices versus the newer mod-slots. Equivalent to the `is:armor2.0` filter.

Fixes #5118