### PR TITLE
Get rid of the internal cache of stores in store services

### DIFF
--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -19,6 +19,12 @@ export const update = createAction('inventory/UPDATE')<{
 }>();
 
 /**
+ * Force stores to be updated to reflect a change. This is a hack that should go
+ * away as we normalize inventory state.
+ */
+export const touch = createAction('inventory/TOUCH')();
+
+/**
  * Reflect the old stores service data into the Redux store as a migration aid.
  */
 export const error = createAction('inventory/ERROR')<DimError>();

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -102,6 +102,13 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.update):
       return updateInventory(state, action.payload);
 
+    case getType(actions.touch):
+      return {
+        ...state,
+        // Make a new array to break change detection for the root stores components
+        stores: [...state.stores]
+      };
+
     // Buckets
     // TODO: only need to do this once, on loading a new platform.
     case getType(actions.setBuckets):
@@ -209,7 +216,7 @@ function updateInventory(
   // TODO: mark DimItem, DimStore properties as Readonly
   const newState = {
     ...state,
-    stores: [...stores],
+    stores,
     newItems: computeNewItems(state.stores, state.newItems, stores),
     profileError: undefined
   };

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -23,7 +23,7 @@ export interface StoreServiceType<StoreType = DimStore> {
   /** A stream of store updates for a particular account. */
   getStoresStream(account: DestinyAccount): ConnectableObservable<StoreType[] | undefined>;
   /** Refresh just character info (current light/stats, etc.) */
-  updateCharacters(account?: DestinyAccount): Promise<StoreType[]>;
+  updateCharacters(account?: DestinyAccount): Promise<void>;
   /** Reload inventory completely. */
   reloadStores(): Promise<StoreType[] | undefined>;
 


### PR DESCRIPTION
This finally removes the `_stores` internal variable from the StoresService objects and hands over authority for storage entirely to Redux.