### PR TITLE
Organizer polish

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -264,7 +264,7 @@ module.exports = (env) => {
         }
       ],
 
-      noParse: function(path) {
+      noParse: function (path) {
         return false;
       }
     },
@@ -388,7 +388,7 @@ module.exports = (env) => {
         // Notifications for item moves
         '$featureFlags.moveNotifications': JSON.stringify(true),
         // Item organizer
-        '$featureFlags.organizer': JSON.stringify(env.dev),
+        '$featureFlags.organizer': JSON.stringify(!env.release),
         // Enable vendorengrams.xyz integration
         '$featureFlags.vendorEngrams': JSON.stringify(true),
         // Enable the new DIM API

--- a/src/app/dim-ui/CustomStatTotal.tsx
+++ b/src/app/dim-ui/CustomStatTotal.tsx
@@ -7,7 +7,6 @@ import styles from './CustomStatTotal.m.scss';
 import { armorStats } from 'app/inventory/store/stats';
 import { DestinyStatDefinition, DestinyClass } from 'bungie-api-ts/destiny2';
 import { setSetting } from '../settings/actions';
-import { D2Item } from 'app/inventory/item-types';
 import clsx from 'clsx';
 import { settingsSelector } from 'app/settings/reducer';
 
@@ -18,44 +17,23 @@ interface ProvidedProps {
   forClass?: DestinyClass;
   readOnly?: boolean;
 }
-interface StoreDefs {
+interface StoreProps {
   defs: D2ManifestDefinitions;
-}
-interface StoreStats {
   customTotalStatsByClass: KeyedStatHashLists;
 }
-type StoreDefsAndStats = StoreDefs & StoreStats;
 
 const mapDispatchToProps = {
   setSetting
 };
 type DispatchProps = typeof mapDispatchToProps;
 
-type ToggleProps = ProvidedProps & StoreDefsAndStats & DispatchProps;
-type TotalProps = { item: D2Item } & ProvidedProps & StoreDefsAndStats;
+type ToggleProps = ProvidedProps & StoreProps & DispatchProps;
 
 function mapStateToProps() {
-  return (state: RootState): StoreDefsAndStats => ({
+  return (state: RootState): StoreProps => ({
     defs: state.manifest.d2Manifest!,
     customTotalStatsByClass: settingsSelector(state).customTotalStatsByClass
   });
-}
-
-function GetItemCustomTotalPreConnect({
-  item,
-  forClass = DestinyClass.Unknown,
-  customTotalStatsByClass
-}: TotalProps) {
-  const collectedStats =
-    item.stats?.filter((s) => customTotalStatsByClass[forClass]?.includes(s.statHash)) ?? [];
-
-  return (
-    <>
-      {collectedStats.length && collectedStats.length === customTotalStatsByClass[forClass]?.length
-        ? collectedStats.reduce((a, b) => a + b.base, 0)
-        : '--'}
-    </>
-  );
 }
 
 function StatTotalTogglePreConnect({
@@ -103,14 +81,10 @@ function StatTotalTogglePreConnect({
   );
 }
 
-export const StatTotalToggle = connect<StoreDefsAndStats, DispatchProps>(
+export const StatTotalToggle = connect<StoreProps, DispatchProps>(
   mapStateToProps,
   mapDispatchToProps
 )(StatTotalTogglePreConnect);
-
-export const GetItemCustomTotal = connect<StoreDefsAndStats>(mapStateToProps)(
-  GetItemCustomTotalPreConnect
-);
 
 /**
  * this check shouldn't be necessary :|
@@ -124,7 +98,7 @@ function StatToggleButton({
   readOnly = false
 }: {
   stat: DestinyStatDefinition;
-  setSetting;
+  setSetting: DispatchProps['setSetting'];
   currentSettings: KeyedStatHashLists;
   currentClass: DestinyClass;
   readOnly: boolean;

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -147,7 +147,7 @@ export function getColumns(
         <ItemPopupTrigger item={item}>
           {(ref, onClick) => (
             <div ref={ref} onClick={onClick}>
-              <BungieImage src={value} className={styles.icon} />
+              <BungieImage src={value} />
             </div>
           )}
         </ItemPopupTrigger>
@@ -243,14 +243,12 @@ export function getColumns(
       defaultSort: SortDirection.DESC,
       filter: (value) => `rating:>=${value}`
     },
-    /*
     {
       id: 'tier',
       header: 'Tier',
       value: (i) => i.tier,
-      sort: compareBy((item) => rarity(item))
+      filter: (value) => `is:${value}`
     },
-    */
     {
       id: 'source',
       header: 'Source',
@@ -289,7 +287,7 @@ export function getColumns(
         value && <SpecialtyModSlotIcon className={styles.modSlot} item={item} />,
       filter: (value) => `modslot:${value}`
     },
-    {
+    items[0]?.bucket.inWeapons && {
       id: 'archetype',
       header: 'Archetype',
       value: (item) =>
@@ -409,7 +407,7 @@ export function getColumns(
       id: 'notes',
       header: 'Notes',
       value: (item) => getNotes(item, itemInfos),
-      gridWidth: '1fr',
+      gridWidth: 'minmax(200px, 1fr)',
       filter: (value) => `notes:"${value}"`
     },
     items[0]?.bucket.inWeapons &&
@@ -417,7 +415,7 @@ export function getColumns(
         id: 'wishListNote',
         header: 'Wish List Note',
         value: (item) => wishList?.[item.id]?.notes,
-        gridWidth: '1fr',
+        gridWidth: 'minmax(200px, 1fr)',
         filter: (value) => `wishlistnotes:"${value}"`
       }
   ]);

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -38,6 +38,7 @@ import { ColumnDefinition, SortDirection, ColumnGroup } from './table-types';
 import { TagValue } from '@destinyitemmanager/dim-api-types';
 import clsx from 'clsx';
 import { statHashByName } from 'app/search/search-filter-hashes';
+import { StatTotalToggle } from 'app/dim-ui/CustomStatTotal';
 // TODO: drop wishlist columns if no wishlist loaded
 // TODO: d1/d2 columns
 // TODO: stat ranges
@@ -63,7 +64,8 @@ export function getColumns(
   ratings: { [key: string]: DtrRating },
   wishList: {
     [key: string]: InventoryWishListRoll;
-  }
+  },
+  customTotalStat: number[]
 ): ColumnDefinition[] {
   const hasWishList = !_.isEmpty(wishList);
 
@@ -356,8 +358,7 @@ export function getColumns(
       },
       noSort: true
     },
-    ...statColumns, // TODO: column groups!
-    /*
+    ...statColumns,
     items[0]?.bucket.inArmor && {
       id: 'customstat',
       header: (
@@ -366,10 +367,10 @@ export function getColumns(
           <StatTotalToggle forClass={items[0]?.classType} readOnly={true} />
         </>
       ),
-      value: (item) => customStatTotal(),
-      cell: (_, item: D2Item) => <GetItemCustomTotal item={item} forClass={items[0]?.classType} />
+      value: (item) =>
+        _.sumBy(item.stats, (s) => (customTotalStat.includes(s.statHash) ? s.value : 0)),
+      defaultSort: SortDirection.DESC
     },
-    */
     ...baseStatColumns,
     {
       id: 'masterworkTier',

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -284,9 +284,9 @@ export function getColumns(
       id: 'modslot',
       header: 'Mod Slot',
       // TODO: only show if there are mod slots
-      value: getItemSpecialtyModSlotDisplayName, //
+      value: getItemSpecialtyModSlotDisplayName,
       cell: (value, item) =>
-        value && <SpecialtyModSlotIcon className={styles.modSlot} item={item} />,
+        value && <SpecialtyModSlotIcon className={styles.modslotIcon} item={item} />,
       filter: (value) => `modslot:${value}`
     },
     items[0]?.bucket.inWeapons && {

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -164,6 +164,13 @@ export function getColumns(
       filter: (name) => `name:"${name}"`
     },
     {
+      id: 'power',
+      header: <AppIcon icon={powerIndicatorIcon} />,
+      value: (item) => item.primStat?.value,
+      defaultSort: SortDirection.DESC,
+      filter: (value) => `power:>=${value}`
+    },
+    {
       id: 'dmg',
       header: items[0]?.bucket.inArmor ? 'Element' : 'Damage',
       value: (item) => item.element?.displayProperties.name,
@@ -176,13 +183,6 @@ export function getColumns(
       value: (item) => item.isDestiny2() && item.energy?.energyCapacity,
       defaultSort: SortDirection.DESC,
       filter: (value) => `energycapacity>=:${value}`
-    },
-    {
-      id: 'power',
-      header: <AppIcon icon={powerIndicatorIcon} />,
-      value: (item) => item.primStat?.value,
-      defaultSort: SortDirection.DESC,
-      filter: (value) => `power:>=${value}`
     },
     {
       id: 'locked',

--- a/src/app/organizer/EnabledColumnsSelector.tsx
+++ b/src/app/organizer/EnabledColumnsSelector.tsx
@@ -4,6 +4,7 @@ import DropDown, { DropDownItem } from './DropDown';
 import { t } from 'app/i18next-t';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { ColumnDefinition } from './table-types';
+import { getColumnSelectionId } from './Columns';
 
 /**
  * Component for selection of which columns are displayed in the organizer table.
@@ -29,7 +30,7 @@ export default React.memo(function EnabledColumnsSelector({
   const items: { [id: string]: DropDownItem } = {};
 
   for (const column of columns) {
-    const id = column.columnGroup ? column.columnGroup.id : column.id;
+    const id = getColumnSelectionId(column);
     const header = column.columnGroup ? column.columnGroup.header : column.header;
     if (id === 'selection') {
       continue;

--- a/src/app/organizer/EnabledColumnsSelector.tsx
+++ b/src/app/organizer/EnabledColumnsSelector.tsx
@@ -32,7 +32,7 @@ export default React.memo(function EnabledColumnsSelector({
   for (const column of columns) {
     const id = getColumnSelectionId(column);
     const header = column.columnGroup ? column.columnGroup.header : column.header;
-    if (id === 'selection') {
+    if (id === 'selection' || column.noHide) {
       continue;
     }
 

--- a/src/app/organizer/ItemActions.tsx
+++ b/src/app/organizer/ItemActions.tsx
@@ -66,6 +66,7 @@ function ItemActions({
           dropDownItems={moveItems}
         />
       </span>
+      <span>Tip: Hold the Shift key and click on a cell</span>
     </div>
   );
 }

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -7,8 +7,7 @@
 
   > div {
     padding: 4px 8px;
-    padding-top: calc(var(--item-size) * 0.75 * 0.5 - 6px);
-    transition: opacity 200ms;
+    padding-top: calc(var(--item-size) * 0.75 * 0.5 - 4px);
     background-color: #313233;
   }
 }
@@ -44,8 +43,7 @@
 }
 
 .mods,
-.perks,
-.archetype {
+.perks {
   padding-top: calc(var(--item-size) * 0.5 * 0.5 - 5px) !important;
 }
 
@@ -86,6 +84,13 @@
 .wishList,
 .dmg {
   text-align: center !important;
+}
+
+.dmg {
+  padding-top: calc(var(--item-size) * 0.75 * 0.5 - 2px) !important;
+  &.header {
+    padding-top: 4px !important;
+  }
 }
 
 .icon {
@@ -166,8 +171,5 @@
     &:hover {
       background-color: #999;
     }
-  }
-  .noFilter {
-    opacity: 0.3;
   }
 }

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -9,6 +9,7 @@
     padding: 4px 8px;
     padding-top: calc(var(--item-size) * 0.75 * 0.5 - 6px);
     transition: opacity 200ms;
+    background-color: #313233;
   }
 }
 
@@ -39,7 +40,7 @@
 }
 
 .alternateRow {
-  background-color: #464748;
+  background-color: #464748 !important;
 }
 
 .mods,
@@ -64,6 +65,14 @@
   padding-left: 8px !important;
   padding-right: 2px !important;
   cursor: pointer;
+  width: 20px;
+  left: 0;
+  position: sticky;
+  top: $header-height + 30px;
+  &.header {
+    top: $header-height;
+  }
+  z-index: 1;
 }
 
 .rating {
@@ -82,6 +91,14 @@
 .icon {
   padding-top: 4px !important;
   width: calc(var(--item-size) * 0.75);
+  left: 30px;
+  position: sticky;
+  top: $header-height + 30px;
+  &.header {
+    top: $header-height;
+    padding-top: 0;
+  }
+  z-index: 1;
   img {
     display: block;
     width: calc(var(--item-size) * 0.75);
@@ -89,9 +106,6 @@
     box-sizing: border-box;
     pointer-events: none;
     border: 1px solid #ddd;
-  }
-  &.header {
-    padding-top: 0;
   }
 }
 

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -82,6 +82,7 @@
 .locked,
 .tag,
 .wishList,
+.energy,
 .dmg {
   text-align: center !important;
 }

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -132,6 +132,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, min-content);
   gap: 8px;
+  align-items: flex-start;
   &.header {
     display: block;
   }

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -8,6 +8,7 @@
   > div {
     padding: 4px 8px;
     padding-top: calc(var(--item-size) * 0.75 * 0.5 - 6px);
+    transition: opacity 200ms;
   }
 }
 
@@ -148,9 +149,11 @@
 // Indicate cells that can be filtered on shift-click
 .shiftHeld {
   .hasFilter {
-    background-color: #6666ff;
     &:hover {
-      background-color: #3333ff;
+      background-color: #999;
     }
+  }
+  .noFilter {
+    opacity: 0.3;
   }
 }

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -161,7 +161,11 @@
   }
 }
 
-.modSlot {
+.modslot {
+  display: flex;
+  justify-content: center;
+}
+.modslotIcon {
   height: 24px;
   width: 24px;
 }

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -11,8 +11,9 @@ interface CssExports {
   'locked': string;
   'modPerk': string;
   'modPerks': string;
-  'modSlot': string;
   'mods': string;
+  'modslot': string;
+  'modslotIcon': string;
   'name': string;
   'negative': string;
   'perks': string;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -15,6 +15,7 @@ interface CssExports {
   'mods': string;
   'name': string;
   'negative': string;
+  'noFilter': string;
   'perks': string;
   'positive': string;
   'power': string;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -15,7 +15,6 @@ interface CssExports {
   'mods': string;
   'name': string;
   'negative': string;
-  'noFilter': string;
   'perks': string;
   'positive': string;
   'power': string;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'alternateRow': string;
   'archetype': string;
   'dmg': string;
+  'energy': string;
   'hasFilter': string;
   'header': string;
   'icon': string;

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -145,7 +145,14 @@ function ItemTable({
   // TODO: hide columns if all undefined
   const columns: ColumnDefinition[] = useMemo(
     () =>
-      getColumns(items, defs, itemInfos, ratings, wishList, customTotalStatsByClass[classIfAny]),
+      getColumns(
+        items,
+        defs,
+        itemInfos,
+        ratings,
+        wishList,
+        customTotalStatsByClass[classIfAny] ?? []
+      ),
     [wishList, items, itemInfos, ratings, defs, customTotalStatsByClass, classIfAny]
   );
 

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -420,13 +420,10 @@ function ItemTable({
               <div
                 key={column.id}
                 onClick={narrowQueryFunction(row, column)}
-                className={clsx(
-                  styles[column.id],
-                  column.filter ? styles.hasFilter : styles.noFilter,
-                  {
-                    [styles.alternateRow]: i % 2
-                  }
-                )}
+                className={clsx(styles[column.id], {
+                  [styles.hasFilter]: column.filter,
+                  [styles.alternateRow]: i % 2
+                })}
                 role="cell"
               >
                 {column.cell ? column.cell(row.values[column.id], row.item) : row.values[column.id]}

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -210,11 +210,6 @@ function ItemTable({
     },
     [setEnabledColumns, columns]
   );
-
-  if (!terminal) {
-    return <div>No items match the current filters.</div>;
-  }
-
   // TODO: stolen from SearchFilter, should probably refactor into a shared thing
   const onLock = loadingTracker.trackPromise(async (e) => {
     const selectedTag = e.currentTarget.name;
@@ -258,6 +253,15 @@ function ItemTable({
     column.filter
       ? (e) => {
           if (e.shiftKey) {
+            console.log(e, e.target, e.currentTarget);
+            if ((e.target as Element).hasAttribute('data-perk-name')) {
+              dispatch(
+                toggleSearchQueryComponent(
+                  column.filter!((e.target as Element).getAttribute('data-perk-name')!, row.item)
+                )
+              );
+              return;
+            }
             const filter = column.filter!(row.values[column.id], row.item);
             if (filter !== undefined) {
               dispatch(toggleSearchQueryComponent(filter));
@@ -432,9 +436,13 @@ function ItemTable({
               <div
                 key={column.id}
                 onClick={narrowQueryFunction(row, column)}
-                className={clsx(styles[column.id], column.filter && styles.hasFilter, {
-                  [styles.alternateRow]: i % 2
-                })}
+                className={clsx(
+                  styles[column.id],
+                  column.filter ? styles.hasFilter : styles.noFilter,
+                  {
+                    [styles.alternateRow]: i % 2
+                  }
+                )}
                 role="cell"
               >
                 {column.cell ? column.cell(row.values[column.id], row.item) : row.values[column.id]}

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -5,10 +5,27 @@ import { KeyedStatHashLists } from 'app/dim-ui/CustomStatTotal';
 export interface Settings extends DimApiSettings {
   /** list of stat hashes of interest, keyed by class enum */
   readonly customTotalStatsByClass: KeyedStatHashLists;
+
+  /** Selected columns for the Vault Organizer */
+  readonly organizerColumns: string[];
 }
 
 export const initialSettingsState: Settings = {
   ...defaultSettings,
   language: defaultLanguage(),
-  customTotalStatsByClass: {}
+  customTotalStatsByClass: {},
+  organizerColumns: [
+    'icon',
+    'name',
+    'dmg',
+    'power',
+    'locked',
+    'tag',
+    'wishList',
+    'rating',
+    'archetype',
+    'perks',
+    'mods',
+    'notes'
+  ]
 };

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -7,14 +7,15 @@ export interface Settings extends DimApiSettings {
   readonly customTotalStatsByClass: KeyedStatHashLists;
 
   /** Selected columns for the Vault Organizer */
-  readonly organizerColumns: string[];
+  readonly organizerColumnsWeapons: string[];
+  readonly organizerColumnsArmor: string[];
 }
 
 export const initialSettingsState: Settings = {
   ...defaultSettings,
   language: defaultLanguage(),
   customTotalStatsByClass: {},
-  organizerColumns: [
+  organizerColumnsWeapons: [
     'icon',
     'name',
     'dmg',
@@ -22,10 +23,23 @@ export const initialSettingsState: Settings = {
     'locked',
     'tag',
     'wishList',
-    'rating',
     'archetype',
     'perks',
+    'notes'
+  ],
+  organizerColumnsArmor: [
+    'icon',
+    'name',
+    'power',
+    'dmg',
+    'energy',
+    'locked',
+    'tag',
+    'modslot',
+    'perks',
     'mods',
+    'stats',
+    'customstat',
     'notes'
   ]
 };

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -23,7 +23,7 @@ export const energyNamesByEnum: { [key in DestinyEnergyType]: string } = {
   [DestinyEnergyType.Void]: 'void'
 };
 
-export const getItemDamageShortName: (item: DimItem) => string | undefined = (item) =>
+export const getItemDamageShortName = (item: DimItem): string | undefined =>
   item.isDestiny2() && item.energy
     ? energyNamesByEnum[item.element?.enumValue ?? -1]
     : damageNamesByEnum[item.element?.enumValue ?? -1];
@@ -57,7 +57,7 @@ export const specialtyModSocketHashes = Object.values(modMetadataBySlotTag)
   .flat();
 
 /** verifies an item is d2 armor and has a specialty mod slot, which is returned */
-export const getSpecialtySocket: (item: DimItem) => DimSocket | undefined = (item) =>
+export const getSpecialtySocket = (item: DimItem): DimSocket | undefined =>
   (item.isDestiny2() &&
     item.bucket?.sort === 'Armor' &&
     item.sockets?.sockets.find((socket) =>
@@ -66,15 +66,15 @@ export const getSpecialtySocket: (item: DimItem) => DimSocket | undefined = (ite
   undefined;
 
 /** just gives you the hash that defines what socket a plug can fit into */
-export const getSpecialtySocketCategoryHash: (item: DimItem) => number | undefined = (item) =>
+export const getSpecialtySocketCategoryHash = (item: DimItem): number | undefined =>
   getSpecialtySocket(item)?.socketDefinition.singleInitialItemHash;
 
 /** returns ModMetadata if the item has a specialty mod slot */
-export const getSpecialtySocketMetadata: (item: DimItem) => ModMetadata | undefined = (item) =>
+export const getSpecialtySocketMetadata = (item: DimItem): ModMetadata | undefined =>
   modMetadataIndexedByEmptySlotHash[
     getSpecialtySocket(item)?.socketDefinition.singleInitialItemHash || -99999999
   ];
 
 /** this returns a string for easy printing purposes. '' if not found */
-export const getItemSpecialtyModSlotDisplayName: (item: DimItem) => string = (item) =>
-  getSpecialtySocket(item)?.plug!.plugItem.itemTypeDisplayName || '';
+export const getItemSpecialtyModSlotDisplayName = (item: DimItem) =>
+  getSpecialtySocket(item)?.plug?.plugItem.itemTypeDisplayName || '';


### PR DESCRIPTION
Bunch of fixes to Organizer, enough that I think it can be used on Beta now. It's still not pretty but it's at least useful.

* Fixes to column selection
* Sticky the checkbox and icon to the left of the screen
* Save columns in settings
* Bring back custom stat total
* Fill in filter expressions for most of the columns
* Allow shift-clicking on an individual perk to narrow to items containing that perk