### PR TITLE
Wait for settings to be available before loading wishlists

### DIFF
--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -163,7 +163,7 @@ class WishListSettings extends React.Component<Props, State> {
     reader.onload = () => {
       if (reader.result && typeof reader.result === 'string') {
         const wishListAndInfo = toWishList(reader.result);
-        this.props.dispatch(transformAndStoreWishList(wishListAndInfo));
+        this.props.dispatch(transformAndStoreWishList('', wishListAndInfo));
         ga('send', 'event', 'WishList', 'From File');
       }
     };

--- a/src/app/wishlists/actions.ts
+++ b/src/app/wishlists/actions.ts
@@ -2,7 +2,7 @@ import { createAction } from 'typesafe-actions';
 import { WishListAndInfo } from './types';
 
 export const loadWishLists = createAction('wishlists/LOAD')<{
-  wishList: WishListAndInfo;
+  wishListAndInfo: WishListAndInfo;
   // Defaults to "now" but can be set if we're loading from IndexedDB
   lastFetched?: Date;
 }>();

--- a/src/app/wishlists/actions.ts
+++ b/src/app/wishlists/actions.ts
@@ -5,6 +5,7 @@ export const loadWishLists = createAction('wishlists/LOAD')<{
   wishListAndInfo: WishListAndInfo;
   // Defaults to "now" but can be set if we're loading from IndexedDB
   lastFetched?: Date;
+  wishListSource?: string;
 }>();
 
 export const clearWishLists = createAction('wishlists/CLEAR')();

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -50,7 +50,7 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
     case getType(actions.loadWishLists):
       return {
         ...state,
-        wishListAndInfo: action.payload.wishListAndInfo,
+        wishListAndInfo: { ...initialState.wishListAndInfo, ...action.payload.wishListAndInfo },
         loaded: true,
         lastFetched: action.payload.lastFetched || new Date()
       };
@@ -60,9 +60,11 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
         wishListAndInfo: {
           title: undefined,
           description: undefined,
-          wishListRolls: []
+          wishListRolls: [],
+          source: ''
         },
-        lastFetched: undefined
+        lastFetched: undefined,
+        wishListSource: undefined
       };
     }
     default:

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -50,7 +50,7 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
     case getType(actions.loadWishLists):
       return {
         ...state,
-        wishListAndInfo: action.payload.wishList,
+        wishListAndInfo: action.payload.wishListAndInfo,
         loaded: true,
         lastFetched: action.payload.lastFetched || new Date()
       };

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -44,4 +44,6 @@ export interface WishListAndInfo {
   wishListRolls: WishListRoll[];
   title?: string;
   description?: string;
+  /** The URL we fetched the wish list from */
+  source?: string;
 }

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -2,7 +2,7 @@ import { toWishList } from './wishlist-file';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import { showNotification } from 'app/notifications/notifications';
-import { loadWishLists } from './actions';
+import { loadWishLists, clearWishLists } from './actions';
 import { ThunkResult } from 'app/store/reducers';
 import { WishListAndInfo } from './types';
 import { wishListsSelector, WishListsState } from './reducer';
@@ -32,13 +32,22 @@ export function fetchWishList(newWishlistSource?: string): ThunkResult {
     const wishListSource = settingsSelector(getState()).wishListSource;
 
     if (!wishListSource) {
+      // Clear out any stored wish list if settings has flipped to "no wish list"
+      dispatch(clearWishLists());
       return;
     }
 
     const wishListLastUpdated = wishListsSelector(getState()).lastFetched;
+    const existingWishListSource = wishListsSelector(getState()).wishListAndInfo.source;
 
     // Don't throttle updates if we're changing source
-    if (!newWishlistSource && hoursAgo(wishListLastUpdated) < 24) {
+    if (
+      !newWishlistSource &&
+      hoursAgo(wishListLastUpdated) < 24 &&
+      // Allow changes to settings to cause wish list updates - if the source is different
+      // from the existing source we'll continue to load even if we're within the window
+      (existingWishListSource === undefined || existingWishListSource === wishListSource)
+    ) {
       return;
     }
 
@@ -55,17 +64,20 @@ export function fetchWishList(newWishlistSource?: string): ThunkResult {
       existingWishLists?.wishListAndInfo?.wishListRolls?.length !==
       wishListAndInfo.wishListRolls.length
     ) {
-      dispatch(transformAndStoreWishList(wishListAndInfo));
+      dispatch(transformAndStoreWishList(wishListSource, wishListAndInfo));
     } else {
       console.log('Refreshed wishlist, but it matched the one we already have');
     }
   };
 }
 
-export function transformAndStoreWishList(wishListAndInfo: WishListAndInfo): ThunkResult {
+export function transformAndStoreWishList(
+  wishListSource: string,
+  wishListAndInfo: WishListAndInfo
+): ThunkResult {
   return async (dispatch) => {
     if (wishListAndInfo.wishListRolls.length > 0) {
-      dispatch(loadWishLists({ wishListAndInfo }));
+      dispatch(loadWishLists({ wishListAndInfo, wishListSource }));
 
       const titleAndDescription = _.compact([
         wishListAndInfo.title,


### PR DESCRIPTION
I think this solves three problems:

1. The wishlist popup showing up even when the wishlist hasn't changed.
2. Clearing wishlist but it still shows up.
3. Changing wishlist setting on another device doesn't get reflected when settings get synced.

What I think is happening is this action gets launched very early, and runs before settings are loaded from dim-api. This means it loads the default wishlist, which can be different from whatever loads from IDB.