### PR TITLE
Enable trailing commas in prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,5 @@
     {
       "files": "*.html"
     }
-  ],
-  "trailingComma": "none"
+  ]
 }

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -29,7 +29,7 @@ import { saveItemInfosOnStateChange } from 'app/inventory/reducer';
 
 polyfill({
   holdToDrag: 300,
-  dragImageCenterOnTouch: true
+  dragImageCenterOnTouch: true,
 });
 
 safariTouchFix();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,14 +32,14 @@ const WhatsNew = React.lazy(() =>
 
 // These three are all from the same chunk
 const SettingsPage = React.lazy(async () => ({
-  default: (await import(/* webpackChunkName: "settings" */ './settings/components')).SettingsPage
+  default: (await import(/* webpackChunkName: "settings" */ './settings/components')).SettingsPage,
 }));
 const GDriveRevisions = React.lazy(async () => ({
   default: (await import(/* webpackChunkName: "settings" */ './settings/components'))
-    .GDriveRevisions
+    .GDriveRevisions,
 }));
 const AuditLog = React.lazy(async () => ({
-  default: (await import(/* webpackChunkName: "settings" */ './settings/components')).AuditLog
+  default: (await import(/* webpackChunkName: "settings" */ './settings/components')).AuditLog,
 }));
 
 interface StoreProps {
@@ -63,7 +63,7 @@ function mapStateToProps(state: RootState): StoreProps {
     charColMobile: settings.charColMobile,
     needsLogin: state.accounts.needsLogin,
     reauth: state.accounts.reauth,
-    needsDeveloper: state.accounts.needsDeveloper
+    needsDeveloper: state.accounts.needsDeveloper,
   };
 }
 
@@ -77,7 +77,7 @@ function App({
   showNewItems,
   needsLogin,
   reauth,
-  needsDeveloper
+  needsDeveloper,
 }: Props) {
   useEffect(() => {
     testFeatureCompatibility();
@@ -91,7 +91,7 @@ function App({
         itemQuality: itemQuality,
         'show-new-items': showNewItems,
         'ms-edge': /Edge/.test(navigator.userAgent),
-        ios: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
+        ios: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream,
       })}
     >
       <ScrollToTop />

--- a/src/app/accounts/MenuAccounts.tsx
+++ b/src/app/accounts/MenuAccounts.tsx
@@ -26,7 +26,7 @@ interface StoreProps {
 function mapStateToProps(state: RootState): StoreProps {
   return {
     currentAccount: currentAccountSelector(state),
-    accounts: state.accounts.accounts
+    accounts: state.accounts.accounts,
   };
 }
 

--- a/src/app/accounts/actions.ts
+++ b/src/app/accounts/actions.ts
@@ -12,7 +12,7 @@ export const loadFromIDB = createAction('accounts/LOAD_FROM_IDB')<DestinyAccount
 export const error = createAction('accounts/ERROR')<DimError>();
 
 export const loggedOut = createAction('accounts/LOG_OUT', (reauth?: boolean) => ({
-  reauth: reauth || false
+  reauth: reauth || false,
 }))();
 
 export const needsDeveloper = createAction('accounts/DEV_INFO_NEEDED')();

--- a/src/app/accounts/bungie-account.ts
+++ b/src/app/accounts/bungie-account.ts
@@ -21,7 +21,7 @@ export function getBungieAccount(): BungieAccount | undefined {
 
   if (token?.bungieMembershipId) {
     return {
-      membershipId: token.bungieMembershipId
+      membershipId: token.bungieMembershipId,
     };
   }
 }

--- a/src/app/accounts/destiny-account.ts
+++ b/src/app/accounts/destiny-account.ts
@@ -3,7 +3,7 @@ import {
   PlatformErrorCodes,
   DestinyGameVersions,
   DestinyLinkedProfilesResponse,
-  DestinyProfileUserInfoCard
+  DestinyProfileUserInfoCard,
 } from 'bungie-api-ts/destiny2';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
@@ -35,7 +35,7 @@ export const PLATFORM_LABELS = {
   [BungieMembershipType.TigerSteam]: 'Steam',
   // t('Accounts.Stadia')
   [BungieMembershipType.TigerStadia]: 'Stadia',
-  [BungieMembershipType.BungieNext]: 'Bungie.net'
+  [BungieMembershipType.BungieNext]: 'Bungie.net',
 };
 
 export const PLATFORM_LABEL_TO_MEMBERSHIP_TYPE = {
@@ -49,7 +49,7 @@ export const PLATFORM_LABEL_TO_MEMBERSHIP_TYPE = {
   Steam: BungieMembershipType.TigerSteam,
   // t('Accounts.Stadia')
   Stadia: BungieMembershipType.TigerStadia,
-  'Bungie.net': BungieMembershipType.BungieNext
+  'Bungie.net': BungieMembershipType.BungieNext,
 };
 
 export const PLATFORM_ICONS = {
@@ -59,7 +59,7 @@ export const PLATFORM_ICONS = {
   [BungieMembershipType.TigerDemon]: 'Demon',
   [BungieMembershipType.TigerSteam]: faSteam,
   [BungieMembershipType.TigerStadia]: stadiaIcon,
-  [BungieMembershipType.BungieNext]: 'Bungie.net'
+  [BungieMembershipType.BungieNext]: 'Bungie.net',
 };
 
 /** A specific Destiny account (one per platform and Destiny version) */
@@ -105,7 +105,7 @@ export function getDestinyAccountsForBungieAccount(
       if (platforms.length === 0) {
         showNotification({
           type: 'warning',
-          title: t('Accounts.NoCharacters')
+          title: t('Accounts.NoCharacters'),
         });
         removeToken();
         dispatch(loggedOut(true));
@@ -146,7 +146,7 @@ async function generatePlatforms(
         platformLabel: PLATFORM_LABELS[destinyAccount.membershipType],
         destinyVersion: 2,
         platforms: destinyAccount.applicableMembershipTypes,
-        lastPlayed: new Date(destinyAccount.dateLastPlayed)
+        lastPlayed: new Date(destinyAccount.dateLastPlayed),
       };
 
       // For accounts that were folded into Cross Save, only consider them as D1 accounts.
@@ -169,7 +169,7 @@ async function generatePlatforms(
           platformLabel: PLATFORM_LABELS[destinyAccount.membershipType],
           destinyVersion: 1,
           platforms: [destinyAccount.membershipType],
-          lastPlayed: new Date()
+          lastPlayed: new Date(),
         };
 
         if (
@@ -200,7 +200,7 @@ async function findD1Characters(account: DestinyAccount): Promise<any | null> {
         destinyVersion: 1,
         // D1 didn't support cross-save!
         platforms: [account.originalPlatformType],
-        lastPlayed: getLastPlayedD1Character(response)
+        lastPlayed: getLastPlayedD1Character(response),
       };
       return result;
     }
@@ -222,7 +222,7 @@ async function findD1Characters(account: DestinyAccount): Promise<any | null> {
       destinyVersion: 1,
       // D1 didn't support cross-save!
       platforms: [account.originalPlatformType],
-      lastPlayed: new Date(0)
+      lastPlayed: new Date(0),
     };
   }
 }

--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {
   compareAccounts,
   DestinyAccount,
-  getDestinyAccountsForBungieAccount
+  getDestinyAccountsForBungieAccount,
 } from './destiny-account';
 import { getBungieAccount } from './bungie-account';
 import * as actions from './actions';
@@ -13,7 +13,7 @@ import {
   accountsSelector,
   currentAccountSelector,
   loadAccountsFromIndexedDB,
-  accountsLoadedSelector
+  accountsLoadedSelector,
 } from './reducer';
 import { ThunkResult } from 'app/store/reducers';
 import { dedupePromise } from 'app/utils/util';

--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -58,7 +58,7 @@ const initialState: AccountsState = {
     !DIM_API_KEY ||
     !BUNGIE_API_KEY ||
     ($DIM_FLAVOR === 'dev' &&
-      (!localStorage.getItem('oauthClientId') || !localStorage.getItem('oauthClientSecret')))
+      (!localStorage.getItem('oauthClientId') || !localStorage.getItem('oauthClientSecret'))),
 };
 
 export const accounts: Reducer<AccountsState, AccountsAction> = (
@@ -71,14 +71,14 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
         ...state,
         accounts: deepEqual(action.payload, state.accounts) ? state.accounts : action.payload || [],
         loaded: true,
-        accountsError: undefined
+        accountsError: undefined,
       };
     case getType(actions.setCurrentAccount): {
       const newCurrentAccount = action.payload ? state.accounts.indexOf(action.payload) : -1;
       return newCurrentAccount !== state.currentAccount
         ? {
             ...state,
-            currentAccount: newCurrentAccount
+            currentAccount: newCurrentAccount,
           }
         : state;
     }
@@ -90,24 +90,24 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
             accounts: deepEqual(action.payload, state.accounts)
               ? state.accounts
               : action.payload || [],
-            loadedFromIDB: true
+            loadedFromIDB: true,
           };
     case getType(actions.error):
       return {
         ...state,
-        accountsError: action.payload
+        accountsError: action.payload,
       };
     case getType(actions.loggedOut):
       return {
         ...initialState,
         reauth: action.payload.reauth,
-        needsLogin: true
+        needsLogin: true,
       };
 
     case getType(actions.needsDeveloper):
       return {
         ...state,
-        needsDeveloper: true
+        needsDeveloper: true,
       };
 
     default:

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -5,7 +5,7 @@ import {
   setToken,
   getToken,
   hasTokenExpired,
-  removeAccessToken
+  removeAccessToken,
 } from './oauth-tokens';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { t } from 'app/i18next-t';

--- a/src/app/bungie-api/bungie-api-utils.ts
+++ b/src/app/bungie-api/bungie-api-utils.ts
@@ -9,7 +9,7 @@ export function bungieApiUpdate(path: string, data?: object): HttpClientConfig {
   return {
     method: 'POST',
     url: `https://www.bungie.net${path}`,
-    body: data
+    body: data,
   };
 }
 
@@ -17,7 +17,7 @@ export function bungieApiQuery(path: string, params?: object): HttpClientConfig 
   return {
     method: 'GET',
     url: `https://www.bungie.net${path}`,
-    params
+    params,
   };
 }
 

--- a/src/app/bungie-api/bungie-core-api.ts
+++ b/src/app/bungie-api/bungie-core-api.ts
@@ -13,7 +13,7 @@ const GlobalAlertLevelsToToastLevels = [
   'info', // Unknown
   'info', // Blue
   'warn', // Yellow
-  'error' // Red
+  'error', // Red
 ];
 
 /**
@@ -26,7 +26,7 @@ export async function getGlobalAlerts(): Promise<GlobalAlert[]> {
       key: alert.AlertKey,
       type: GlobalAlertLevelsToToastLevels[alert.AlertLevel],
       body: alert.AlertHtml,
-      timestamp: alert.AlertTimestamp
+      timestamp: alert.AlertTimestamp,
     }));
   }
   return [];

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -78,12 +78,12 @@ export function buildOptions(config: HttpClientConfig, skipAuth?: boolean): Requ
     headers: config.body
       ? {
           'X-API-Key': API_KEY,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         }
       : {
-          'X-API-Key': API_KEY
+          'X-API-Key': API_KEY,
         },
-    credentials: skipAuth ? 'omit' : 'include'
+    credentials: skipAuth ? 'omit' : 'include',
   });
 }
 
@@ -176,7 +176,7 @@ export async function handleErrors<T>(response: Response): Promise<ServerRespons
         const account = getActivePlatform();
         throw error(
           t('BungieService.NoAccount', {
-            platform: account ? t(`Accounts.${account.platformLabel}`) : 'Unknown'
+            platform: account ? t(`Accounts.${account.platformLabel}`) : 'Unknown',
           }),
           errorCode
         );
@@ -215,7 +215,7 @@ export async function handleErrors<T>(response: Response): Promise<ServerRespons
     throw error(
       t('BungieService.NetworkError', {
         status: response.status,
-        statusText: response.statusText
+        statusText: response.statusText,
       }),
       errorCode
     );
@@ -242,7 +242,7 @@ export function handleUniquenessViolation(e: DimError, item: DimItem, store: Dim
         name: item.name,
         type: item.type.toLowerCase(),
         character: store.name,
-        context: store.genderName
+        context: store.genderName,
       }),
       e.code
     );

--- a/src/app/bungie-api/destiny1-api.ts
+++ b/src/app/bungie-api/destiny1-api.ts
@@ -28,7 +28,7 @@ export async function getCharacters(platform: DestinyAccount) {
   if (!response || Object.keys(response.Response).length === 0) {
     throw error(
       t('BungieService.NoAccountForPlatform', {
-        platform: platform.platformLabel
+        platform: platform.platformLabel,
       }),
       PlatformErrorCodes.DestinyAccountNotFound
     );
@@ -38,7 +38,7 @@ export async function getCharacters(platform: DestinyAccount) {
     return {
       id: c.characterBase.characterId,
       base: c,
-      dateLastPlayed: c.characterBase.dateLastPlayed
+      dateLastPlayed: c.characterBase.dateLastPlayed,
     };
   });
 }
@@ -52,7 +52,7 @@ export async function getStores(platform: DestinyAccount): Promise<any> {
       .catch((e) => console.error('Failed to load character progression', e)),
     getDestinyAdvisors(platform, characters)
       // Don't let failure of advisors fail other requests.
-      .catch((e) => console.error('Failed to load advisors', e))
+      .catch((e) => console.error('Failed to load advisors', e)),
   ]);
   return data[0];
 }
@@ -79,7 +79,7 @@ function getDestinyInventories(platform: DestinyAccount, characters: any[]) {
   // Vault
   const vault = {
     id: 'vault',
-    base: null
+    base: null,
   };
 
   const vaultPromise = httpAdapter(
@@ -149,7 +149,7 @@ export function transfer(item: D1Item, store: D1Store, amount: number) {
       itemId: item.id,
       itemReferenceHash: item.hash,
       stackSize: amount || item.amount,
-      transferToVault: store.isVault
+      transferToVault: store.isVault,
     })
   ).catch((e) => handleUniquenessViolation(e, item, store));
 
@@ -162,7 +162,7 @@ export function equip(item: DimItem) {
     bungieApiUpdate('/D1/Platform/Destiny/EquipItem/', {
       characterId: item.owner,
       membershipType: platform!.originalPlatformType,
-      itemId: item.id
+      itemId: item.id,
     })
   );
 }
@@ -177,7 +177,7 @@ export async function equipItems(store: D1Store, items: D1Item[]) {
     bungieApiUpdate('/D1/Platform/Destiny/EquipItems/', {
       characterId: store.id,
       membershipType: platform!.originalPlatformType,
-      itemIds: items.map((i) => i.id)
+      itemIds: items.map((i) => i.id),
     })
   );
   const data = response.Response;
@@ -209,7 +209,7 @@ export function setItemState(
       characterId: store.isVault ? item.owner : store.id,
       membershipType: platform!.originalPlatformType,
       itemId: item.id,
-      state: lockState
+      state: lockState,
     })
   );
 }

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -23,7 +23,7 @@ import {
   DestinyLinkedProfilesResponse,
   BungieMembershipType,
   getItem,
-  DestinyItemResponse
+  DestinyItemResponse,
 } from 'bungie-api-ts/destiny2';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
@@ -54,7 +54,7 @@ export async function getLinkedAccounts(
   const response = await getLinkedProfiles(httpAdapter, {
     membershipId: bungieMembershipId,
     membershipType: BungieMembershipType.BungieNext,
-    getAllMemberships: true
+    getAllMemberships: true,
   });
   return response.Response;
 }
@@ -108,13 +108,13 @@ async function getProfile(
   const response = await getProfileApi(httpAdapter, {
     destinyMembershipId: platform.membershipId,
     membershipType: platform.originalPlatformType,
-    components
+    components,
   });
   // TODO: what does it actually look like to not have an account?
   if (Object.keys(response.Response).length === 0) {
     throw new Error(
       t('BungieService.NoAccountForPlatform', {
-        platform: platform.platformLabel
+        platform: platform.platformLabel,
       })
     );
   }
@@ -135,8 +135,8 @@ export async function getItemDetails(
     itemInstanceId,
     components: [
       // Get plug objectives (kill trackers and catalysts)
-      DestinyComponentType.ItemPlugObjectives
-    ]
+      DestinyComponentType.ItemPlugObjectives,
+    ],
   });
   return response.Response;
 }
@@ -163,9 +163,9 @@ export async function getVendor(
       DestinyComponentType.ItemPlugStates,
       DestinyComponentType.ItemReusablePlugs,
       // TODO: We should try to defer this until the popup is open!
-      DestinyComponentType.ItemPlugObjectives
+      DestinyComponentType.ItemPlugObjectives,
     ],
-    vendorHash
+    vendorHash,
   });
   return response.Response;
 }
@@ -191,8 +191,8 @@ export async function getVendors(
       DestinyComponentType.ItemPlugStates,
       DestinyComponentType.ItemReusablePlugs,
       // TODO: We should try to defer this until the popup is open!
-      DestinyComponentType.ItemPlugObjectives
-    ]
+      DestinyComponentType.ItemPlugObjectives,
+    ],
   });
   return response.Response;
 }
@@ -206,7 +206,7 @@ export async function getVendorsMinimal(
     characterId,
     destinyMembershipId: account.membershipId,
     membershipType: account.originalPlatformType,
-    components: [DestinyComponentType.Vendors]
+    components: [DestinyComponentType.Vendors],
   });
   return response.Response;
 }
@@ -226,7 +226,7 @@ export async function transfer(
     itemId: item.id,
     itemReferenceHash: item.hash,
     stackSize: amount || item.amount,
-    transferToVault: store.isVault
+    transferToVault: store.isVault,
   };
 
   const response = item.location.inPostmaster
@@ -252,7 +252,7 @@ export function equip(item: DimItem): Promise<ServerResponse<number>> {
   return equipItem(httpAdapter, {
     characterId: item.owner,
     membershipType: platform!.originalPlatformType,
-    itemId: item.id
+    itemId: item.id,
   });
 }
 
@@ -269,7 +269,7 @@ export async function equipItems(store: DimStore, items: DimItem[]): Promise<Dim
   const response = await equipItemsApi(httpAdapter, {
     characterId: store.id,
     membershipType: platform!.originalPlatformType,
-    itemIds: items.map((i) => i.id)
+    itemIds: items.map((i) => i.id),
   });
   const data: DestinyEquipItemResults = response.Response;
   return items.filter((i) => {
@@ -292,7 +292,7 @@ export function setLockState(
     characterId: store.isVault ? item.owner : store.id,
     membershipType: account!.originalPlatformType,
     itemId: item.id,
-    state: lockState
+    state: lockState,
   });
 }
 
@@ -306,10 +306,10 @@ export async function requestAdvancedWriteActionToken(
     type: action,
     membershipType: account.originalPlatformType,
     affectedItemId: item ? item.id : undefined,
-    characterId: item ? item.owner : undefined
+    characterId: item ? item.owner : undefined,
   });
   const awaTokenResult = await awaGetActionToken(httpAdapter, {
-    correlationId: awaInitResult.Response.correlationId
+    correlationId: awaInitResult.Response.correlationId,
   });
   return awaTokenResult.Response;
 }

--- a/src/app/bungie-api/error-toaster.tsx
+++ b/src/app/bungie-api/error-toaster.tsx
@@ -26,7 +26,7 @@ export function bungieErrorToaster(e: Error): NotifyInput {
           </ExternalLink>
         </div>
       </>
-    )
+    ),
   };
 }
 
@@ -49,6 +49,6 @@ export function dimErrorToaster(title: string, message: string, e: Error): Notif
           </ExternalLink>
         </div>
       </>
-    )
+    ),
   };
 }

--- a/src/app/bungie-api/oauth.ts
+++ b/src/app/bungie-api/oauth.ts
@@ -15,11 +15,11 @@ export function getAccessTokenFromRefreshToken(refreshToken: Token): Promise<Tok
         grant_type: 'refresh_token', // eslint-disable-line @typescript-eslint/camelcase
         refresh_token: refreshToken.value, // eslint-disable-line @typescript-eslint/camelcase
         client_id: oauthClientId(), // eslint-disable-line @typescript-eslint/camelcase
-        client_secret: oauthClientSecret() // eslint-disable-line @typescript-eslint/camelcase
+        client_secret: oauthClientSecret(), // eslint-disable-line @typescript-eslint/camelcase
       }),
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
     })
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then(handleAccessToken)
@@ -34,11 +34,11 @@ export function getAccessTokenFromCode(code: number): Promise<Tokens> {
         grant_type: 'authorization_code', // eslint-disable-line @typescript-eslint/camelcase
         code,
         client_id: oauthClientId(), // eslint-disable-line @typescript-eslint/camelcase
-        client_secret: oauthClientSecret() // eslint-disable-line @typescript-eslint/camelcase
+        client_secret: oauthClientSecret(), // eslint-disable-line @typescript-eslint/camelcase
       }),
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      }
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
     })
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then(handleAccessToken)
@@ -54,12 +54,12 @@ function handleAccessToken(response): Tokens {
       value: data.access_token,
       expires: data.expires_in,
       name: 'access',
-      inception
+      inception,
     };
 
     const tokens: Tokens = {
       accessToken,
-      bungieMembershipId: data.membership_id
+      bungieMembershipId: data.membership_id,
     };
 
     if (data.refresh_token) {
@@ -67,7 +67,7 @@ function handleAccessToken(response): Tokens {
         value: data.refresh_token,
         expires: data.refresh_expires_in,
         name: 'refresh',
-        inception
+        inception,
       };
     }
 

--- a/src/app/bungie-api/rate-limiter.ts
+++ b/src/app/bungie-api/rate-limiter.ts
@@ -38,7 +38,7 @@ export class RateLimiterQueue {
       request,
       options,
       resolver,
-      rejecter
+      rejecter,
     });
     this.processQueue();
 
@@ -95,7 +95,7 @@ export const RateLimiterConfig = {
 
   addLimiter(queue: RateLimiterQueue) {
     this.limiters.push(queue);
-  }
+  },
 };
 
 /**

--- a/src/app/collections/Catalysts.tsx
+++ b/src/app/collections/Catalysts.tsx
@@ -9,7 +9,7 @@ import Record from './Record';
 
 export default function Catalysts({
   defs,
-  profileResponse
+  profileResponse,
 }: {
   defs: D2ManifestDefinitions;
   profileResponse: DestinyProfileResponse;

--- a/src/app/collections/Collectible.tsx
+++ b/src/app/collections/Collectible.tsx
@@ -6,7 +6,7 @@ import {
   DestinyProfileResponse,
   DestinyScope,
   DestinyCollectibleState,
-  DestinyCollectibleDefinition
+  DestinyCollectibleDefinition,
 } from 'bungie-api-ts/destiny2';
 import { VendorItemDisplay } from 'app/vendors/VendorItemComponent';
 import _ from 'lodash';
@@ -24,7 +24,7 @@ export default function Collectible({
   defs,
   buckets,
   profileResponse,
-  ownedItemHashes
+  ownedItemHashes,
 }: Props) {
   const collectibleDef = defs.Collectible.get(collectibleHash);
   if (!collectibleDef) {

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -49,7 +49,7 @@ function mapStateToProps() {
     buckets: state.inventory.buckets,
     defs: state.manifest.d2Manifest,
     ownedItemHashes: ownedItemHashesSelector(state),
-    profileResponse: profileResponseSelector(state)
+    profileResponse: profileResponseSelector(state),
   });
 }
 

--- a/src/app/collections/Metric.tsx
+++ b/src/app/collections/Metric.tsx
@@ -3,7 +3,7 @@ import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import {
   DestinyProfileResponse,
   DestinyMetricDefinition,
-  DestinyMetricComponent
+  DestinyMetricComponent,
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import styles from './Metric.m.scss';

--- a/src/app/collections/Metrics.tsx
+++ b/src/app/collections/Metrics.tsx
@@ -3,7 +3,7 @@ import Metric from './Metric';
 import _ from 'lodash';
 import {
   DestinyPresentationNodeMetricChildEntry,
-  DestinyProfileResponse
+  DestinyProfileResponse,
 } from 'bungie-api-ts/destiny2';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import styles from './Metrics.m.scss';
@@ -12,7 +12,7 @@ import BungieImage from 'app/dim-ui/BungieImage';
 export default function Metrics({
   metrics,
   defs,
-  profileResponse
+  profileResponse,
 }: {
   metrics: DestinyPresentationNodeMetricChildEntry[];
   defs: D2ManifestDefinitions;

--- a/src/app/collections/PlugSet.tsx
+++ b/src/app/collections/PlugSet.tsx
@@ -39,7 +39,7 @@ export default function PlugSet({
   plugSetCollection,
   items,
   path,
-  onNodePathSelected
+  onNodePathSelected,
 }: Props) {
   const plugSetHash = plugSetCollection.hash;
   const plugSetDef = defs.PlugSet.get(plugSetHash);

--- a/src/app/collections/PresentationNode.tsx
+++ b/src/app/collections/PresentationNode.tsx
@@ -48,11 +48,11 @@ function mapStateToProps(state: RootState): StoreProps {
   const settings = settingsSelector(state);
   return {
     completedRecordsHidden: settings.completedRecordsHidden,
-    redactedRecordsRevealed: settings.redactedRecordsRevealed
+    redactedRecordsRevealed: settings.redactedRecordsRevealed,
   };
 }
 const mapDispatchToProps = {
-  setSetting
+  setSetting,
 };
 
 type DispatchProps = typeof mapDispatchToProps;
@@ -75,7 +75,7 @@ class PresentationNode extends React.Component<Props> {
       scrollToPosition({
         top: window.scrollY + clientRect.top - 50,
         left: 0,
-        behavior: 'smooth'
+        behavior: 'smooth',
       });
     }
     this.lastPath = this.props.path;
@@ -92,7 +92,7 @@ class PresentationNode extends React.Component<Props> {
       completedRecordsHidden,
       redactedRecordsRevealed,
       collectionCounts,
-      onNodePathSelected
+      onNodePathSelected,
     } = this.props;
     const presentationNodeDef = defs.PresentationNode.get(presentationNodeHash);
     if (presentationNodeDef.redacted) {
@@ -148,20 +148,20 @@ class PresentationNode extends React.Component<Props> {
       1: 'Badge',
       2: 'Medals',
       3: 'Collectible',
-      4: 'Record'
+      4: 'Record',
     };
 
     const screenStyle = {
       0: 'Default',
       1: 'CategorySets',
-      2: 'Badge'
+      2: 'Badge',
     };
 
     const nodeStyle = {
       0: 'Default',
       1: 'Category',
       2: 'Collectibles',
-      3: 'Records'
+      3: 'Records',
     };
 
     // TODO: need more info on what iconSequences are
@@ -190,7 +190,7 @@ class PresentationNode extends React.Component<Props> {
           `level-${thisAndParents.length}`,
           {
             'only-child': onlyChild,
-            'always-expanded': alwaysExpanded
+            'always-expanded': alwaysExpanded,
           }
         )}
       >
@@ -199,7 +199,7 @@ class PresentationNode extends React.Component<Props> {
             className={clsx('title', {
               collapsed: !childrenExpanded,
               'hide-complete': completedRecordsHidden,
-              completed
+              completed,
             })}
             onClick={this.expandChildren}
             ref={this.headerRef}

--- a/src/app/collections/PresentationNodeRoot.tsx
+++ b/src/app/collections/PresentationNodeRoot.tsx
@@ -4,7 +4,7 @@ import PresentationNode from './PresentationNode';
 import {
   DestinyProfileResponse,
   DestinyCollectibleState,
-  DestinyRecordState
+  DestinyRecordState,
 } from 'bungie-api-ts/destiny2';
 import { getCollectibleState } from './Collectible';
 import { count } from '../utils/util';
@@ -45,7 +45,7 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
       buckets,
       profileResponse,
       ownedItemHashes,
-      showPlugSets
+      showPlugSets,
     } = this.props;
     const { nodePath } = this.state;
 
@@ -70,7 +70,7 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
       // Emotes
       { hash: 1155321287, displayItem: 3960522253 },
       // Projections
-      { hash: 499268600, displayItem: 2544954628 }
+      { hash: 499268600, displayItem: 2544954628 },
     ];
 
     return (
@@ -121,7 +121,7 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
   // TODO: onNodeDeselected!
   private onNodePathSelected = (nodePath: number[]): void => {
     this.setState({
-      nodePath
+      nodePath,
     });
   };
 }
@@ -169,8 +169,8 @@ export function countCollectibles(
     return {
       [node]: {
         acquired: acquiredCollectibles,
-        visible: visibleCollectibles
-      }
+        visible: visibleCollectibles,
+      },
     };
   } else if (presentationNodeDef.children.records?.length) {
     const recordDefs = presentationNodeDef.children.records.map((c) =>
@@ -195,8 +195,8 @@ export function countCollectibles(
     return {
       [node]: {
         acquired: acquiredCollectibles,
-        visible: visibleCollectibles
-      }
+        visible: visibleCollectibles,
+      },
     };
   } else if (presentationNodeDef.children.metrics?.length) {
     const metricDefs = presentationNodeDef.children.metrics.map((c) =>
@@ -217,8 +217,8 @@ export function countCollectibles(
     return {
       [node]: {
         acquired,
-        visible
-      }
+        visible,
+      },
     };
   } else {
     // call for all children, then add 'em up
@@ -239,8 +239,8 @@ export function countCollectibles(
     Object.assign(ret, {
       [node]: {
         acquired,
-        visible
-      }
+        visible,
+      },
     });
     return ret;
   }

--- a/src/app/collections/Record.tsx
+++ b/src/app/collections/Record.tsx
@@ -7,7 +7,7 @@ import {
   DestinyRecordState,
   DestinyRecordComponent,
   DestinyUnlockValueUIStyle,
-  DestinyObjectiveProgress
+  DestinyObjectiveProgress,
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import './Record.scss';
@@ -43,7 +43,7 @@ export default function Record({
   defs,
   profileResponse,
   completedRecordsHidden,
-  redactedRecordsRevealed
+  redactedRecordsRevealed,
 }: Props) {
   const recordDef = defs.Record.get(recordHash);
   if (!recordDef) {
@@ -83,13 +83,13 @@ export default function Record({
 
   const intervals = getIntervals(recordDef, record);
   const intervalBarStyle = {
-    width: `calc((100% / ${intervals.length}) - 2px)`
+    width: `calc((100% / ${intervals.length}) - 2px)`,
   };
   const allIntervalsCompleted = intervals.every((i) => i.percentCompleted >= 1.0);
   const intervalProgressBar = !obscured && intervals.length > 0 && (
     <div
       className={clsx('record-interval-container', {
-        complete: allIntervalsCompleted
+        complete: allIntervalsCompleted,
       })}
     >
       {!allIntervalsCompleted &&
@@ -101,7 +101,7 @@ export default function Record({
               key={i.objective.objectiveHash}
               className={clsx('record-interval', {
                 redeemed,
-                unlocked: unlocked && !redeemed
+                unlocked: unlocked && !redeemed,
               })}
               style={intervalBarStyle}
             >
@@ -152,7 +152,7 @@ export default function Record({
         unlocked,
         obscured,
         tracked,
-        multistep: intervals.length > 0
+        multistep: intervals.length > 0,
       })}
     >
       {recordIcon && <BungieImage className="record-icon" src={recordIcon} />}
@@ -224,7 +224,7 @@ function getIntervals(
                 (data.completionValue - prevIntervalProgress)
             )
         : 0,
-      isRedeemed: record.intervalsRedeemedCount >= i + 1
+      isRedeemed: record.intervalsRedeemedCount >= i + 1,
     });
 
     isPrevIntervalComplete = data.complete;

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -17,7 +17,7 @@ import { showNotification } from '../notifications/notifications';
 import { scrollToPosition } from 'app/dim-ui/scroll';
 import {
   DestinyDisplayPropertiesDefinition,
-  DestinyInventoryItemDefinition
+  DestinyInventoryItemDefinition,
 } from 'bungie-api-ts/destiny2';
 import { makeDupeID } from 'app/search/search-filters';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
@@ -43,7 +43,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     ratings: ratingsSelector(state),
     stores: storesSelector(state),
-    defs: state.manifest.d2Manifest
+    defs: state.manifest.d2Manifest,
   };
 }
 
@@ -73,7 +73,7 @@ class Compare extends React.Component<Props, State> {
     comparisonItems: [],
     comparisonSets: [],
     show: false,
-    sortBetterFirst: true
+    sortBetterFirst: true,
   };
   private subscriptions = new Subscriptions();
 
@@ -113,7 +113,7 @@ class Compare extends React.Component<Props, State> {
       comparisonItems: unsortedComparisonItems,
       sortedHash,
       highlight,
-      comparisonSets
+      comparisonSets,
     } = this.state;
 
     if (!show || unsortedComparisonItems.length === 0) {
@@ -139,7 +139,7 @@ class Compare extends React.Component<Props, State> {
                 ? { value: showRating || 0 }
                 : sortedHash === 'EnergyCapacity'
                 ? {
-                    value: (item.isDestiny2() && item.energy?.energyCapacity) || 0
+                    value: (item.isDestiny2() && item.energy?.energyCapacity) || 0,
                   }
                 : (item.stats || []).find((s) => s.statHash === sortedHash);
 
@@ -187,7 +187,7 @@ class Compare extends React.Component<Props, State> {
                   key={stat.id}
                   className={clsx('compare-stat-label', {
                     highlight: stat.id === highlight,
-                    sorted: stat.id === sortedHash
+                    sorted: stat.id === sortedHash,
                   })}
                   onMouseOver={() => this.setHighlight(stat.id)}
                   onClick={() => this.sort(stat.id)}
@@ -231,7 +231,7 @@ class Compare extends React.Component<Props, State> {
       show: false,
       comparisonItems: [],
       highlight: undefined,
-      sortedHash: undefined
+      sortedHash: undefined,
     });
     CompareService.dialogOpen = false;
   };
@@ -239,19 +239,19 @@ class Compare extends React.Component<Props, State> {
   private compareSimilar = (e: React.MouseEvent, comparisonSetItems: DimItem[]) => {
     e.preventDefault();
     this.setState({
-      comparisonItems: comparisonSetItems
+      comparisonItems: comparisonSetItems,
     });
   };
 
   private sort = (sortedHash?: string | number) => {
     this.setState((prevState) => ({
       sortedHash,
-      sortBetterFirst: prevState.sortedHash === sortedHash ? !prevState.sortBetterFirst : true
+      sortBetterFirst: prevState.sortedHash === sortedHash ? !prevState.sortBetterFirst : true,
     }));
   };
   private add = ({
     additionalItems,
-    showSomeDupes
+    showSomeDupes,
   }: {
     additionalItems: DimItem[];
     showSomeDupes: boolean;
@@ -270,7 +270,7 @@ class Compare extends React.Component<Props, State> {
         body:
           comparisonItems[0].classType && exampleItem.classType !== comparisonItems[0].classType
             ? t('Compare.Error.Class', { class: comparisonItems[0].classTypeNameLocalized })
-            : t('Compare.Error.Archetype', { type: comparisonItems[0].typeName })
+            : t('Compare.Error.Archetype', { type: comparisonItems[0].typeName }),
       });
       return;
     }
@@ -301,7 +301,7 @@ class Compare extends React.Component<Props, State> {
         const comparisonItems = comparisonSets[0]?.items ?? additionalItems;
         this.setState({
           comparisonSets,
-          comparisonItems
+          comparisonItems,
         });
       }
       // otherwise, compare only the items we were asked to compare
@@ -338,7 +338,7 @@ class Compare extends React.Component<Props, State> {
         'webkitAnimationEnd',
         'oanimationend',
         'msAnimationEnd',
-        'animationend'
+        'animationend',
       ]) {
         element.removeEventListener(event, removePop);
       }
@@ -374,13 +374,13 @@ class Compare extends React.Component<Props, State> {
       // same slot on the same class
       {
         buttonLabel: <>{exampleItem.typeName}</>,
-        items: allArmors
+        items: allArmors,
       },
 
       // above but also has to be armor 2.0
       {
         buttonLabel: <>{[t('Compare.Armor2'), exampleItem.typeName].join(' + ')}</>,
-        items: hasEnergy(exampleItem) ? allArmors.filter(hasEnergy) : []
+        items: hasEnergy(exampleItem) ? allArmors.filter(hasEnergy) : [],
       },
 
       // above but also the same seasonal mod slot, if it has one
@@ -389,7 +389,7 @@ class Compare extends React.Component<Props, State> {
         items:
           hasEnergy(exampleItem) && exampleItemModSlot
             ? allArmors.filter(hasEnergy).filter(matchingModSlot)
-            : []
+            : [],
       },
 
       // armor 2.0 and needs to match energy capacity element
@@ -397,7 +397,7 @@ class Compare extends React.Component<Props, State> {
         buttonLabel: <>{[exampleItemElementIcon, exampleItem.typeName]}</>,
         items: hasEnergy(exampleItem)
           ? allArmors.filter(hasEnergy).filter(matchesExample('element'))
-          : []
+          : [],
       },
       // above but also the same seasonal mod slot, if it has one
       {
@@ -405,13 +405,13 @@ class Compare extends React.Component<Props, State> {
         items:
           hasEnergy(exampleItem) && exampleItemModSlot
             ? allArmors.filter(hasEnergy).filter(matchingModSlot).filter(matchesExample('element'))
-            : []
+            : [],
       },
 
       // basically stuff with the same name & categories
       {
         buttonLabel: <>{exampleItem.name}</>,
-        items: allArmors.filter((i) => makeDupeID(i) === makeDupeID(exampleItem))
+        items: allArmors.filter((i) => makeDupeID(i) === makeDupeID(exampleItem)),
       },
 
       // above, but also needs to match energy capacity element
@@ -422,8 +422,8 @@ class Compare extends React.Component<Props, State> {
               .filter(hasEnergy)
               .filter(matchesExample('element'))
               .filter((i) => makeDupeID(i) === makeDupeID(exampleItem))
-          : []
-      }
+          : [],
+      },
     ];
 
     // here, we dump some buttons if they aren't worth displaying
@@ -524,13 +524,13 @@ class Compare extends React.Component<Props, State> {
       // same weapon type
       {
         buttonLabel: <>{exampleItem.typeName}</>,
-        items: allWeapons
+        items: allWeapons,
       },
 
       // above, but also same (kinetic/energy/heavy) slot
       {
         buttonLabel: <>{[exampleItem.bucket.name, exampleItem.typeName].join(' + ')}</>,
-        items: allWeapons.filter((i) => i.bucket.name === exampleItem.bucket.name)
+        items: allWeapons.filter((i) => i.bucket.name === exampleItem.bucket.name),
       },
 
       // same weapon type plus matching intrinsic (rpm+impact..... ish)
@@ -540,20 +540,20 @@ class Compare extends React.Component<Props, State> {
           ? allWeapons.filter(
               (i) => i.isDestiny2() && i.sockets && getIntrinsicPerk(i)?.hash === intrinsicHash
             )
-          : allWeapons.filter((i) => exampleItemRpm === getRpm(i))
+          : allWeapons.filter((i) => exampleItemRpm === getRpm(i)),
       },
 
       // same weapon type and also matching element (& usually same-slot because same element)
       {
         buttonLabel: <>{[exampleItemElementIcon, exampleItem.typeName]}</>,
-        items: allWeapons.filter(matchesExample('element'))
+        items: allWeapons.filter(matchesExample('element')),
       },
 
       // exact same weapon, judging by name. might span multiple expansions.
       {
         buttonLabel: <>{exampleItem.name}</>,
-        items: allWeapons.filter(matchesExample('name'))
-      }
+        items: allWeapons.filter(matchesExample('name')),
+      },
     ];
     comparisonSets = comparisonSets.reverse();
     comparisonSets = comparisonSets.filter((comparisonSet, index) => {
@@ -589,7 +589,7 @@ function getAllStats(comparisonItems: DimItem[], ratings: ReviewsState['ratings'
     stats.push({
       id: 'Rating',
       displayProperties: {
-        name: t('Compare.Rating')
+        name: t('Compare.Rating'),
       } as DestinyDisplayPropertiesDefinition,
       min: Number.MAX_SAFE_INTEGER,
       max: 0,
@@ -599,7 +599,7 @@ function getAllStats(comparisonItems: DimItem[], ratings: ReviewsState['ratings'
         const dtrRating = getRating(item, ratings);
         const showRating = dtrRating && shouldShowRating(dtrRating) && dtrRating.overallScore;
         return { statHash: 0, value: showRating || undefined };
-      }
+      },
     });
   }
   if (firstComparison.primStat) {
@@ -612,14 +612,14 @@ function getAllStats(comparisonItems: DimItem[], ratings: ReviewsState['ratings'
       lowerBetter: false,
       getStat(item: DimItem) {
         return item.primStat || undefined;
-      }
+      },
     });
   }
   if (firstComparison.bucket.inArmor) {
     stats.push({
       id: 'EnergyCapacity',
       displayProperties: {
-        name: t('EnergyMeter.Energy')
+        name: t('EnergyMeter.Energy'),
       } as DestinyDisplayPropertiesDefinition,
       min: Number.MAX_SAFE_INTEGER,
       max: 0,
@@ -630,11 +630,11 @@ function getAllStats(comparisonItems: DimItem[], ratings: ReviewsState['ratings'
           (item.isDestiny2() &&
             item.energy && {
               statHash: item.energy.energyType,
-              value: item.energy.energyCapacity
+              value: item.energy.energyCapacity,
             }) ||
           undefined
         );
-      }
+      },
     });
   }
   // Todo: map of stat id => stat object
@@ -654,7 +654,7 @@ function getAllStats(comparisonItems: DimItem[], ratings: ReviewsState['ratings'
             lowerBetter: false,
             getStat(item: DimItem) {
               return item.stats ? item.stats.find((s) => s.statHash === stat.statHash) : undefined;
-            }
+            },
           };
           statsByHash[stat.statHash] = statInfo;
           stats.push(statInfo);

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -15,7 +15,7 @@ export default function CompareItem({
   itemClick,
   remove,
   highlight,
-  setHighlight
+  setHighlight,
 }: {
   item: DimItem;
   stats: StatInfo[];

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -12,7 +12,7 @@ export default function CompareStat({
   stat,
   item,
   highlight,
-  setHighlight
+  setHighlight,
 }: {
   stat: StatInfo;
   item: DimItem;

--- a/src/app/compare/compare.service.ts
+++ b/src/app/compare/compare.service.ts
@@ -9,5 +9,5 @@ export const CompareService = {
   }>(),
   addItemsToCompare(additionalItems: DimItem[], showSomeDupes = false) {
     this.compareItems$.next({ additionalItems, showSomeDupes });
-  }
+  },
 };

--- a/src/app/compatibility.ts
+++ b/src/app/compatibility.ts
@@ -8,7 +8,7 @@ const notifyStorageFull = _.throttle(() => {
     showNotification({
       type: 'error',
       title: t('Help.NoStorage'),
-      body: t('Help.NoStorageMessage')
+      body: t('Help.NoStorageMessage'),
     });
   });
 }, 5 * 60 * 1000);

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -61,7 +61,7 @@ type Props = ProvidedProps & StoreProps;
 function mapStateToProps(state: RootState): StoreProps {
   return {
     stores: sortedStoresSelector(state),
-    defs: state.manifest.d1Manifest
+    defs: state.manifest.d1Manifest,
   };
 }
 
@@ -96,7 +96,7 @@ class Activities extends React.Component<Props> {
             <CollapsibleTitle
               style={bungieBackgroundStyle(activity.image)}
               className={clsx('title activity-header', {
-                'activity-featured': activity.featured
+                'activity-featured': activity.featured,
               })}
               sectionId={`activities-${activity.hash}`}
               title={
@@ -159,7 +159,7 @@ class Activities extends React.Component<Props> {
       'wrathofthemachine',
       // 'elderchallenge',
       'nightfall',
-      'heroicstrike'
+      'heroicstrike',
     ];
 
     const rawActivities = Object.values(stores[0].advisors.activities).filter(
@@ -200,7 +200,7 @@ class Activities extends React.Component<Props> {
           ? t('Activities.WeeklyHeroic')
           : defs.ActivityType.get(def.activityTypeHash).activityTypeName,
       skulls: null as Skull[] | null,
-      tiers: [] as ActivityTier[]
+      tiers: [] as ActivityTier[],
     };
 
     if (rawActivity.extended) {
@@ -261,7 +261,7 @@ class Activities extends React.Component<Props> {
               lastPlayed: store.lastPlayed,
               id: store.id,
               icon: store.icon,
-              steps
+              steps,
             };
           });
 
@@ -270,7 +270,7 @@ class Activities extends React.Component<Props> {
       icon: tierDef.icon,
       name,
       complete: tier.activityData.isCompleted,
-      characters
+      characters,
     };
   };
 }
@@ -295,13 +295,13 @@ const skullHashesByName: { [name: string]: number | undefined } = {
   Exposure: 16,
   Airborne: 17,
   Catapult: 18,
-  Epic: 20
+  Epic: 20,
 };
 
 function i18nActivitySkulls(skulls: Skull[], defs: D1ManifestDefinitions): Skull[] {
   const activity = {
     heroic: defs.Activity.get(870614351),
-    epic: defs.Activity.get(2234107290)
+    epic: defs.Activity.get(2234107290),
   };
 
   skulls.forEach((skull) => {

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -18,9 +18,9 @@ export const D1Categories = {
     'Emote',
     'Ship',
     'Vehicle',
-    'Horn'
+    'Horn',
   ],
-  Progress: ['Bounties', 'Quests', 'Missions']
+  Progress: ['Bounties', 'Quests', 'Missions'],
 };
 
 // A mapping from the bucket hash to DIM item types
@@ -52,19 +52,19 @@ const bucketToType = {
   3796357825: 'Horn',
   3865314626: 'Material',
   4023194814: 'Ghost',
-  4274335291: 'Emblem'
+  4274335291: 'Emblem',
 };
 
 export const vaultTypes = {
   3003523923: 'Armor',
   4046403665: 'Weapons',
-  138197802: 'General'
+  138197802: 'General',
 };
 
 const sortToVault = {
   Armor: 3003523923,
   Weapons: 4046403665,
-  General: 138197802
+  General: 138197802,
 };
 
 const typeToSort = {};
@@ -89,12 +89,12 @@ export const getBuckets = _.once(async () => {
       capacity: Number.MAX_SAFE_INTEGER,
       sort: 'Unknown',
       type: 'Unknown',
-      accountWide: false
+      accountWide: false,
     },
     setHasUnknown() {
       this.byCategory[this.unknown.sort] = [this.unknown];
       this.byType[this.unknown.type] = this.unknown;
-    }
+    },
   };
   _.forIn(defs.InventoryBucket, (def: any) => {
     if (def.enabled) {
@@ -114,7 +114,7 @@ export const getBuckets = _.once(async () => {
         accountWide: false,
         category: BucketCategory.Item,
         type: bucketToType[def.hash],
-        sort
+        sort,
       };
       if (bucket.type) {
         buckets.byType[bucket.type] = bucket;

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -19,7 +19,7 @@ const lazyTables = [
   'ScriptedSkull',
   'Activity',
   'ActivityType',
-  'DamageType'
+  'DamageType',
 ];
 
 const eagerTables = ['InventoryBucket', 'Class', 'Race', 'Faction', 'Vendor'];
@@ -65,7 +65,7 @@ async function getUncachedDefinitions() {
     const db = await D1ManifestService.getManifest();
     const defs = {
       isDestiny1: () => true,
-      isDestiny2: () => false
+      isDestiny2: () => false,
     };
     // Load objects that lazily load their properties from the sqlite DB.
     lazyTables.forEach((tableShort) => {
@@ -78,7 +78,7 @@ async function getUncachedDefinitions() {
           const val = D1ManifestService.getRecord(db, table, name);
           this[name] = val;
           return val;
-        }
+        },
       };
     });
     // Resources that need to be fully loaded (because they're iterated over)

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -8,7 +8,7 @@ import {
   ClassTypes,
   SetType,
   PerkCombination,
-  D1ItemWithNormalStats
+  D1ItemWithNormalStats,
 } from './types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
@@ -29,7 +29,7 @@ import {
   getActiveBuckets,
   loadVendorsBucket,
   mergeBuckets,
-  getActiveHighestSets
+  getActiveHighestSets,
 } from './utils';
 import LoadoutBuilderItem from './LoadoutBuilderItem';
 import { getSetBucketsStep } from './calculate';
@@ -60,7 +60,7 @@ function mapStateToProps(state: RootState): StoreProps {
     buckets: state.inventory.buckets,
     stores: storesSelector(state) as D1Store[],
     defs: state.manifest.d1Manifest,
-    isPhonePortrait: state.shell.isPhonePortrait
+    isPhonePortrait: state.shell.isPhonePortrait,
   };
 }
 
@@ -108,7 +108,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       Leg: null,
       ClassItem: null,
       Artifact: null,
-      Ghost: null
+      Ghost: null,
     },
     lockedperks: {
       Helmet: {},
@@ -117,12 +117,12 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       Leg: {},
       ClassItem: {},
       Artifact: {},
-      Ghost: {}
-    }
+      Ghost: {},
+    },
   };
 
   private cancelToken: { cancelled: boolean } = {
-    cancelled: false
+    cancelled: false,
   };
 
   componentDidMount() {
@@ -137,7 +137,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       );
       if (felwinters.length) {
         this.setState(({ excludeditems }) => ({
-          excludeditems: _.uniqBy([...excludeditems, ...felwinters], (i) => i.id)
+          excludeditems: _.uniqBy([...excludeditems, ...felwinters], (i) => i.id),
         }));
       }
     }
@@ -151,7 +151,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       );
       if (felwinters.length) {
         this.setState(({ excludeditems }) => ({
-          excludeditems: _.uniqBy([...excludeditems, ...felwinters], (i) => i.id)
+          excludeditems: _.uniqBy([...excludeditems, ...felwinters], (i) => i.id),
         }));
       }
     }
@@ -178,7 +178,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
           excludeditems: _.uniqBy(
             [...excludeditems, ...felwinters.map((si) => si.item)],
             (i) => i.id
-          )
+          ),
         }));
       }
     }
@@ -201,7 +201,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       lockeditems,
       lockedperks,
       highestsets,
-      vendors
+      vendors,
     } = this.state;
 
     if (!stores.length || !buckets || !defs) {
@@ -476,7 +476,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: [],
         ClassItem: [],
         Ghost: [],
-        Artifact: []
+        Artifact: [],
       },
       [DestinyClass.Titan]: {
         Helmet: [],
@@ -485,7 +485,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: [],
         ClassItem: [],
         Ghost: [],
-        Artifact: []
+        Artifact: [],
       },
       [DestinyClass.Hunter]: {
         Helmet: [],
@@ -494,8 +494,8 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: [],
         ClassItem: [],
         Ghost: [],
-        Artifact: []
-      }
+        Artifact: [],
+      },
     };
 
     const vendorPerks: { [classType in ClassTypes]: PerkCombination } = {
@@ -506,7 +506,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: [],
         ClassItem: [],
         Ghost: [],
-        Artifact: []
+        Artifact: [],
       },
       [DestinyClass.Titan]: {
         Helmet: [],
@@ -515,7 +515,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: [],
         ClassItem: [],
         Ghost: [],
-        Artifact: []
+        Artifact: [],
       },
       [DestinyClass.Hunter]: {
         Helmet: [],
@@ -524,8 +524,8 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: [],
         ClassItem: [],
         Ghost: [],
-        Artifact: []
-      }
+        Artifact: [],
+      },
     };
 
     function filterItems(items: D1Item[]) {
@@ -613,7 +613,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
     const active = this.getSelectedCharacter();
     this.cancelToken.cancelled = true;
     this.cancelToken = {
-      cancelled: false
+      cancelled: false,
     };
     getSetBucketsStep(
       active,
@@ -655,7 +655,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
   private onActiveSetsChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
     const activesets = e.target.value;
     this.setState({
-      activesets
+      activesets,
     });
   };
 
@@ -663,7 +663,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
     // TODO: reset more state??
     this.setState({
       selectedCharacter: this.props.stores.find((s) => s.id === storeId),
-      progress: 0
+      progress: 0,
     });
   };
 
@@ -690,7 +690,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         lockedperks[type][perk.hash] = {
           icon: perk.icon,
           description: perk.description,
-          lockType: activeType
+          lockType: activeType,
         };
       }
     });
@@ -701,28 +701,28 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
   private onItemLocked = (item: DimItem) => {
     this.setState(({ lockeditems }) => ({
       lockeditems: { ...lockeditems, [item.type]: item },
-      progress: 0
+      progress: 0,
     }));
   };
 
   private onRemove = ({ type }: { type: ArmorTypes }) => {
     this.setState(({ lockeditems }) => ({
       lockeditems: { ...lockeditems, [type]: null },
-      progress: 0
+      progress: 0,
     }));
   };
 
   private excludeItem = (item: D1Item) => {
     this.setState(({ excludeditems }) => ({
       excludeditems: [...excludeditems, item],
-      progress: 0
+      progress: 0,
     }));
   };
 
   private onExcludedRemove = (item: DimItem) => {
     this.setState(({ excludeditems }) => ({
       excludeditems: excludeditems.filter((excludeditem) => excludeditem.index !== item.index),
-      progress: 0
+      progress: 0,
     }));
   };
 
@@ -735,7 +735,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       'leg',
       'classitem',
       'artifact',
-      'ghost'
+      'ghost',
     ];
     const items = _.groupBy(
       store.items.filter(
@@ -760,9 +760,9 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: nullWithoutStats(items.leg),
         ClassItem: nullWithoutStats(items.classitem),
         Artifact: nullWithoutStats(items.artifact),
-        Ghost: nullWithoutStats(items.ghost)
+        Ghost: nullWithoutStats(items.ghost),
       },
-      progress: 0
+      progress: 0,
     });
   };
 
@@ -775,10 +775,10 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
         Leg: null,
         ClassItem: null,
         Artifact: null,
-        Ghost: null
+        Ghost: null,
       },
       activesets: '',
-      progress: 0
+      progress: 0,
     });
   };
 }
@@ -797,7 +797,7 @@ const unwantedPerkHashes = [
   1034209669,
   1263323987,
   193091484,
-  2133116599
+  2133116599,
 ];
 
 function filterPerks(perks: D1GridNode[], item: D1Item) {

--- a/src/app/destiny1/loadout-builder/ExcludeItemsDropTarget.tsx
+++ b/src/app/destiny1/loadout-builder/ExcludeItemsDropTarget.tsx
@@ -5,7 +5,7 @@ import {
   DropTarget,
   DropTargetConnector,
   DropTargetMonitor,
-  DropTargetSpec
+  DropTargetSpec,
 } from 'react-dnd';
 import { DimItem } from '../../inventory/item-types';
 
@@ -29,7 +29,7 @@ const dropSpec: DropTargetSpec<Props> = {
   drop(props, monitor) {
     const item = monitor.getItem().item as DimItem;
     props.onExcluded(item);
-  }
+  },
 };
 
 // This forwards drag and drop state into props on the component
@@ -40,7 +40,7 @@ function collect(connect: DropTargetConnector, monitor: DropTargetMonitor): Inte
     connectDropTarget: connect.dropTarget(),
     // You can ask the monitor about the current drag state:
     isOver: monitor.isOver(),
-    canDrop: monitor.canDrop()
+    canDrop: monitor.canDrop(),
   };
 }
 
@@ -52,7 +52,7 @@ class ExcludeItemsDropTarget extends React.Component<Props> {
       <div
         className={clsx(className, {
           'on-drag-hover': canDrop && isOver,
-          'on-drag-enter': canDrop
+          'on-drag-enter': canDrop,
         })}
       >
         {children}

--- a/src/app/destiny1/loadout-builder/GeneratedSet.tsx
+++ b/src/app/destiny1/loadout-builder/GeneratedSet.tsx
@@ -130,7 +130,7 @@ export default class GeneratedSet extends React.Component<Props, State> {
 
   private newLoadout = (set: ArmorSet) => {
     editLoadout(this.makeLoadoutFromSet(set), {
-      showClass: false
+      showClass: false,
     });
   };
   private equipItems = (set: ArmorSet) =>

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderDropTarget.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderDropTarget.tsx
@@ -5,7 +5,7 @@ import {
   DropTarget,
   DropTargetConnector,
   DropTargetMonitor,
-  DropTargetSpec
+  DropTargetSpec,
 } from 'react-dnd';
 import { DimItem } from '../../inventory/item-types';
 
@@ -39,7 +39,7 @@ const dropSpec: DropTargetSpec<Props> = {
     // can only drop on a matching bucket
     const item = monitor.getItem().item as DimItem;
     return item.bucket.type === props.bucketType;
-  }
+  },
 };
 
 // This forwards drag and drop state into props on the component
@@ -50,7 +50,7 @@ function collect(connect: DropTargetConnector, monitor: DropTargetMonitor): Inte
     connectDropTarget: connect.dropTarget(),
     // You can ask the monitor about the current drag state:
     isOver: monitor.isOver(),
-    canDrop: monitor.canDrop()
+    canDrop: monitor.canDrop(),
   };
 }
 
@@ -62,7 +62,7 @@ class LoadoutBucketDropTarget extends React.Component<Props> {
       <div
         className={clsx({
           'on-drag-hover': canDrop && isOver,
-          'on-drag-enter': canDrop
+          'on-drag-enter': canDrop,
         })}
       >
         {children}

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
@@ -34,7 +34,7 @@ export default class LoadoutBuilderLockPerk extends React.Component<Props, State
       activePerks,
       lockedPerks,
       onRemove,
-      onItemLocked
+      onItemLocked,
     } = this.props;
     const { dialogOpen } = this.state;
 

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -4,7 +4,7 @@ import {
   D1ItemWithNormalStats,
   LockedPerkHash,
   ItemBucket,
-  ArmorSet
+  ArmorSet,
 } from './types';
 import intellectIcon from 'images/intellect.png';
 import disciplineIcon from 'images/discipline.png';
@@ -15,7 +15,7 @@ import {
   genSetHash,
   calcArmorStats,
   getBonusConfig,
-  getActiveHighestSets
+  getActiveHighestSets,
 } from './utils';
 
 import _ from 'lodash';
@@ -96,7 +96,7 @@ export function getSetBucketsStep(
       activesets: '',
       highestsets: {},
       activeHighestSets: {},
-      collapsedConfigs: []
+      collapsedConfigs: [],
     });
   }
 
@@ -125,7 +125,7 @@ export function getSetBucketsStep(
                           Leg: legs[l],
                           ClassItem: classItems[ci],
                           Artifact: artifacts[ar],
-                          Ghost: ghosts[gh]
+                          Ghost: ghosts[gh],
                         },
                         stats: {
                           144602215: {
@@ -133,25 +133,25 @@ export function getSetBucketsStep(
                             value: 0,
                             name: 'Intellect',
                             description: '',
-                            icon: intellectIcon
+                            icon: intellectIcon,
                           },
                           1735777505: {
                             hash: 1735777505,
                             value: 0,
                             name: 'Discipline',
                             description: '',
-                            icon: disciplineIcon
+                            icon: disciplineIcon,
                           },
                           4244567218: {
                             hash: 4244567218,
                             value: 0,
                             name: 'Strength',
                             description: '',
-                            icon: strengthIcon
-                          }
+                            icon: strengthIcon,
+                          },
                         },
                         setHash: '',
-                        includesVendorItems: false
+                        includesVendorItems: false,
                       };
 
                       const pieces = Object.values(set.armor);
@@ -173,14 +173,14 @@ export function getSetBucketsStep(
                         } else {
                           setMap[set.setHash].tiers[tiersString] = {
                             stats: set.stats,
-                            configs: [getBonusConfig(set.armor)]
+                            configs: [getBonusConfig(set.armor)],
                           };
                         }
                       } else {
                         setMap[set.setHash] = { set, tiers: {} };
                         setMap[set.setHash].tiers[tiersString] = {
                           stats: set.stats,
-                          configs: [getBonusConfig(set.armor)]
+                          configs: [getBonusConfig(set.armor)],
                         };
                       }
 
@@ -246,7 +246,7 @@ export function getSetBucketsStep(
         false,
         false,
         false,
-        false
+        false,
       ];
 
       if (cancelToken.cancelled) {
@@ -263,7 +263,7 @@ export function getSetBucketsStep(
         activesets,
         activeHighestSets,
         collapsedConfigs,
-        highestsets: setMap
+        highestsets: setMap,
       });
     }
     setTimeout(() => step(activeGuardian, 0, 0, 0, 0, 0, 0, 0, 0));

--- a/src/app/destiny1/loadout-builder/utils.ts
+++ b/src/app/destiny1/loadout-builder/utils.ts
@@ -4,7 +4,7 @@ import {
   ItemBucket,
   SetType,
   ArmorSet,
-  LockedPerkHash
+  LockedPerkHash,
 } from './types';
 
 import { D1Item } from '../../inventory/item-types';
@@ -49,7 +49,7 @@ function getBestItem(
       }
       return total + bonus;
     })!,
-    bonusType: type
+    bonusType: type,
   };
 }
 
@@ -101,7 +101,7 @@ export function getBonusConfig(armor: ArmorSet['armor']): { [armorType in ArmorT
     Leg: armor.Leg.bonusType,
     ClassItem: armor.ClassItem.bonusType,
     Artifact: armor.Artifact.bonusType,
-    Ghost: armor.Ghost.bonusType
+    Ghost: armor.Ghost.bonusType,
   };
 }
 
@@ -129,7 +129,7 @@ export function getBestArmor(
     { stats: [1735777505, 4244567218], type: 'disstr' },
     { stats: [144602215], type: 'int' },
     { stats: [1735777505], type: 'dis' },
-    { stats: [4244567218], type: 'str' }
+    { stats: [4244567218], type: 'str' },
   ];
   const armor = {};
   let best: { item: D1ItemWithNormalStats; bonusType: string }[] = [];
@@ -267,7 +267,7 @@ export function loadVendorsBucket(
       Leg: [],
       ClassItem: [],
       Artifact: [],
-      Ghost: []
+      Ghost: [],
     };
   }
   return _.map(vendors, (vendor) =>
@@ -304,7 +304,7 @@ function getBuckets(items: D1Item[]): ItemBucket {
     Leg: items.filter((item) => item.type === 'Leg').map(normalizeStats),
     ClassItem: items.filter((item) => item.type === 'ClassItem').map(normalizeStats),
     Artifact: items.filter((item) => item.type === 'Artifact').map(normalizeStats),
-    Ghost: items.filter((item) => item.type === 'Ghost').map(normalizeStats)
+    Ghost: items.filter((item) => item.type === 'Ghost').map(normalizeStats),
   };
 }
 
@@ -317,7 +317,7 @@ function normalizeStats(item: D1ItemWithNormalStats) {
       scaled: stat.scaled ? stat.scaled.min : 0,
       bonus: stat.bonus,
       split: stat.split || 0,
-      qualityPercentage: stat.qualityPercentage ? stat.qualityPercentage.min : 0
+      qualityPercentage: stat.qualityPercentage ? stat.qualityPercentage.min : 0,
     };
   }
   return item;

--- a/src/app/destiny1/record-books/RecordBooks.tsx
+++ b/src/app/destiny1/record-books/RecordBooks.tsx
@@ -31,7 +31,7 @@ interface StoreProps {
 }
 
 const mapDispatchToProps = {
-  setSetting
+  setSetting,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -40,7 +40,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     hideCompletedRecords: settings.hideCompletedRecords,
     stores: storesSelector(state) as D1Store[],
-    defs: state.manifest.d1Manifest
+    defs: state.manifest.d1Manifest,
   };
 }
 
@@ -102,7 +102,7 @@ class RecordBooks extends React.Component<Props> {
     return (
       <div
         className={clsx('record-books', 'dim-page', {
-          'hide-complete': hideCompletedRecords
+          'hide-complete': hideCompletedRecords,
         })}
       >
         <h1>
@@ -215,7 +215,7 @@ class RecordBooks extends React.Component<Props> {
       expirationDate: rawRecordBook.expirationDate,
       pages: [] as RecordBookPage[],
       complete: false,
-      percentComplete: undefined as number | undefined
+      percentComplete: undefined as number | undefined,
     };
 
     const records = Object.values(rawRecordBook.records).map((r) => this.processRecord(defs, r));
@@ -233,7 +233,7 @@ class RecordBooks extends React.Component<Props> {
         // ItemFactory.processItems({ id: null }
         // may have to extract store service bits...
         complete: false,
-        completedCount: 0
+        completedCount: 0,
       };
 
       createdPage.complete = createdPage.records.every((r) => r.complete);
@@ -245,7 +245,7 @@ class RecordBooks extends React.Component<Props> {
     if (rawRecordBook.progression) {
       rawRecordBook.progression = {
         ...rawRecordBook.progression,
-        ...defs.Progression.get(rawRecordBook.progression.progressionHash)
+        ...defs.Progression.get(rawRecordBook.progression.progressionHash),
       };
       rawRecordBook.progress = rawRecordBook.progression;
       rawRecordBook.percentComplete =
@@ -269,7 +269,7 @@ class RecordBooks extends React.Component<Props> {
       description: recordDef.description,
       name: recordDef.displayName,
       objectives: record.objectives,
-      complete: record.objectives.every((o) => o.isComplete)
+      complete: record.objectives.every((o) => o.isComplete),
     };
   };
 }

--- a/src/app/destiny1/vendors/D1VendorItem.tsx
+++ b/src/app/destiny1/vendors/D1VendorItem.tsx
@@ -34,7 +34,7 @@ export default function D1VendorItem({ saleItem, owned, totalCoins }: Props) {
 
 function D1VendorItemCost({
   cost,
-  totalCoins
+  totalCoins,
 }: {
   cost: VendorCost;
   totalCoins: {
@@ -44,7 +44,7 @@ function D1VendorItemCost({
   return (
     <div
       className={clsx(styles.cost, {
-        [styles.notEnough]: totalCoins[cost.currency.itemHash] < cost.value
+        [styles.notEnough]: totalCoins[cost.currency.itemHash] < cost.value,
       })}
     >
       {cost.value}{' '}

--- a/src/app/destiny1/vendors/D1VendorItems.tsx
+++ b/src/app/destiny1/vendors/D1VendorItems.tsx
@@ -11,7 +11,7 @@ import styles from '../../vendors/VendorItems.m.scss';
 export default function D1VendorItems({
   vendor,
   totalCoins,
-  ownedItemHashes
+  ownedItemHashes,
 }: {
   vendor: Vendor;
   totalCoins: {

--- a/src/app/destiny1/vendors/vendor.service.ts
+++ b/src/app/destiny1/vendors/vendor.service.ts
@@ -59,7 +59,7 @@ const allVendors = [
 
 // Vendors we don't want to load by default
 const vendorBlackList = [
-  2021251983 // Postmaster,
+  2021251983, // Postmaster,
 ];
 
 // Hashes for 'Decode Engram'
@@ -152,7 +152,7 @@ function VendorService(): VendorServiceType {
     totalVendors: 0,
     loadedVendors: 0,
     requestRatings,
-    countCurrencies
+    countCurrencies,
     // TODO: expose getVendor promise, idempotently?
   };
 
@@ -345,7 +345,7 @@ function VendorService(): VendorServiceType {
     const factionsByHash = {
       489342053: 'Future War Cult',
       2397602219: 'Dead Orbit',
-      3197190122: 'New Monarchy'
+      3197190122: 'New Monarchy',
     };
     const factionAlignment = store.factionAlignment();
 
@@ -411,7 +411,7 @@ function VendorService(): VendorServiceType {
                   status: e.status,
                   expires: Date.now() + 60 * 60 * 1000 + (Math.random() - 0.5) * (60 * 60 * 1000),
                   factionLevel: factionLevel(store, vendorDef.summary.factionHash),
-                  factionAligned: factionAligned(store, vendorDef.summary.factionHash)
+                  factionAligned: factionAligned(store, vendorDef.summary.factionHash),
                 };
 
                 return set(key, vendor)
@@ -468,8 +468,8 @@ function VendorService(): VendorServiceType {
         [store.id]: {
           expires: vendor.expires,
           factionLevel: vendor.factionLevel,
-          factionAligned: vendor.factionAligned
-        }
+          factionAligned: vendor.factionAligned,
+        },
       },
       vendorOrder: def.vendorSubcategoryHash + def.vendorOrder,
       faction: def.factionHash, // TODO: show rep!
@@ -480,7 +480,7 @@ function VendorService(): VendorServiceType {
       factionLevel: 0,
       factionAligned: false,
       allItems: [],
-      categories: []
+      categories: [],
     };
 
     const saleItems = vendor.saleItemCategories.flatMap((categoryData) => categoryData.saleItems);
@@ -514,7 +514,7 @@ function VendorService(): VendorServiceType {
                       'itemName',
                       'icon',
                       'itemHash'
-                    )
+                    ),
                   }))
                   .filter((c) => c.value > 0),
                 item: itemsById[`vendor-${vendorDef.hash}-${saleItem.vendorItemIndex}`],
@@ -523,7 +523,7 @@ function VendorService(): VendorServiceType {
                 unlockedByCharacter: unlocked ? [store.id] : [],
                 failureStrings: saleItem.failureIndexes
                   .map((i) => vendorDef.failureStrings[i])
-                  .join('. ')
+                  .join('. '),
               };
             })
           );
@@ -531,7 +531,7 @@ function VendorService(): VendorServiceType {
           return {
             index: category.categoryIndex,
             title: categoryInfo.displayTitle,
-            saleItems: categoryItems
+            saleItems: categoryItems,
           };
         })
       );

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -9,7 +9,7 @@ export const D2Categories = {
   Weapons: ['Class', 'Kinetic', 'Energy', 'Power', 'SeasonalArtifacts'],
   Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
   General: ['Ghost', 'ClanBanners', 'Vehicle', 'Ships', 'Emblems', 'Finishers'],
-  Inventory: ['Consumables', 'Modifications', 'Shaders']
+  Inventory: ['Consumables', 'Modifications', 'Shaders'],
 };
 
 // A mapping from the bucket hash to DIM item types
@@ -47,7 +47,7 @@ const bucketToType: { [hash: number]: string | undefined } = {
   1107761855: 'Emotes',
   1345459588: 'Pursuits',
   1506418338: 'SeasonalArtifacts',
-  3683254069: 'Finishers'
+  3683254069: 'Finishers',
 };
 
 const typeToSort: { [type: string]: string } = {};
@@ -74,12 +74,12 @@ async function getBucketsUncached() {
       sort: 'Unknown',
       type: 'Unknown',
       accountWide: false,
-      category: BucketCategory.Item
+      category: BucketCategory.Item,
     },
     setHasUnknown() {
       this.byCategory[this.unknown.sort] = [this.unknown];
       this.byType[this.unknown.type] = this.unknown;
-    }
+    },
   };
   _.forIn(defs.InventoryBucket, (def: DestinyInventoryBucketDefinition) => {
     const type = bucketToType[def.hash];
@@ -96,7 +96,7 @@ async function getBucketsUncached() {
       accountWide: def.scope === 1,
       category: def.category,
       type,
-      sort
+      sort,
     };
     if (bucket.type) {
       buckets.byType[bucket.type] = bucket;

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -33,7 +33,7 @@ import {
   DestinyTalentGridDefinition,
   DestinyTraitDefinition,
   DestinyVendorDefinition,
-  DestinyVendorGroupDefinition
+  DestinyVendorGroupDefinition,
 } from 'bungie-api-ts/destiny2';
 
 import { D2ManifestService } from '../manifest/manifest-service-json';
@@ -70,7 +70,7 @@ const lazyTables = [
   'PresentationNode',
   'Record',
   'Metric',
-  'Trait'
+  'Trait',
 ];
 
 const eagerTables = [
@@ -80,7 +80,7 @@ const eagerTables = [
   'Race',
   'Faction',
   'ItemTierType',
-  'ActivityMode'
+  'ActivityMode',
 ];
 
 /** These aren't really lazy */
@@ -144,7 +144,7 @@ async function getDefinitionsUncached() {
   const db = await D2ManifestService.getManifest([...eagerTables, ...lazyTables]);
   const defs = {
     isDestiny1: () => false,
-    isDestiny2: () => true
+    isDestiny2: () => true,
   };
   lazyTables.forEach((tableShort) => {
     const table = `Destiny${tableShort}Definition`;
@@ -158,7 +158,7 @@ async function getDefinitionsUncached() {
       },
       getAll() {
         return db[table];
-      }
+      },
     };
   });
   // Resources that need to be fully loaded (because they're iterated over)

--- a/src/app/destinyTrackerApi/bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/bulkFetcher.ts
@@ -81,7 +81,7 @@ function makeRating(dtrRating: D1ItemFetchResponse): DtrRating {
     overallScore: dtrRating.rating || 0,
     ratingCount: dtrRating.ratingCount,
     highlightedRatingCount: dtrRating.highlightedRatingCount,
-    roll: dtrRating.roll
+    roll: dtrRating.roll,
   };
 }
 

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -1,6 +1,6 @@
 import {
   DestinyVendorSaleItemComponent,
-  DestinyVendorItemDefinition
+  DestinyVendorItemDefinition,
 } from 'bungie-api-ts/destiny2';
 import { loadingTracker } from '../shell/loading-tracker';
 import { handleD2Errors } from './d2-trackerErrorHandler';
@@ -91,8 +91,8 @@ export async function getBulkItems(
               upvotes: 0,
               downvotes: 0,
               total: 0,
-              score: 0
-            }
+              score: 0,
+            },
           });
         }
       }
@@ -218,6 +218,6 @@ function makeRating(dtrRating: D2ItemFetchResponse): DtrRating {
     ratingCount: dtrRating.votes.total,
     votes: dtrRating.votes,
     reviewVotes: dtrRating.reviewVotes,
-    highlightedRatingCount: 0 // bugbug: D2 API doesn't seem to be returning highlighted ratings in fetch
+    highlightedRatingCount: 0, // bugbug: D2 API doesn't seem to be returning highlighted ratings in fetch
   };
 }

--- a/src/app/destinyTrackerApi/d2-itemListBuilder.ts
+++ b/src/app/destinyTrackerApi/d2-itemListBuilder.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {
   DestinyVendorSaleItemComponent,
-  DestinyVendorItemDefinition
+  DestinyVendorItemDefinition,
 } from 'bungie-api-ts/destiny2';
 import { D2Item } from '../inventory/item-types';
 import { D2Store } from '../inventory/store-types';
@@ -46,7 +46,7 @@ export function getVendorItemList(
     return getNewItemsFromFetchRequests(allVendorItems, ratings);
   } else if (vendorItems) {
     const allVendorItems = vendorItems.map((vi) => ({
-      referenceId: vi.itemHash
+      referenceId: vi.itemHash,
     })) as D2ItemFetchRequest[];
 
     return getNewItemsFromFetchRequests(allVendorItems, ratings);

--- a/src/app/destinyTrackerApi/d2-itemTransformer.ts
+++ b/src/app/destinyTrackerApi/d2-itemTransformer.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {
   DestinyVendorSaleItemComponent,
-  DestinyInventoryItemDefinition
+  DestinyInventoryItemDefinition,
 } from 'bungie-api-ts/destiny2';
 import { D2Item } from '../inventory/item-types';
 import { DtrD2BasicItem, D2ItemFetchRequest } from '../item-review/d2-dtr-api-types';
@@ -29,11 +29,11 @@ export function getReviewKey(
 
     return {
       referenceId: dtrItem.referenceId,
-      availablePerks: dtrItem.availablePerks
+      availablePerks: dtrItem.availablePerks,
     };
   } else if (itemHash) {
     return {
-      referenceId: itemHash
+      referenceId: itemHash,
     };
   } else {
     throw new Error('No data supplied to find a matching item from our stores.');
@@ -58,7 +58,7 @@ export function translateToDtrItem(
 ): D2ItemFetchRequest {
   return {
     referenceId: isVendorSaleItem(item) ? item.itemHash : item.hash,
-    availablePerks: getAvailablePerks(item)
+    availablePerks: getAvailablePerks(item),
   };
 }
 
@@ -75,7 +75,7 @@ export function getRollAndPerks(item: D2Item): DtrD2BasicItem {
     attachedMods: powerModHashes,
     referenceId: item.hash,
     instanceId: item.id,
-    availablePerks: getAvailablePerks(item)
+    availablePerks: getAvailablePerks(item),
   };
 }
 

--- a/src/app/destinyTrackerApi/d2-perkRater.ts
+++ b/src/app/destinyTrackerApi/d2-perkRater.ts
@@ -76,7 +76,7 @@ function getPlugRatingsAndReviewCount(
   const ratingAndReview = {
     ratingCount,
     averageReview,
-    plugOptionHash
+    plugOptionHash,
   };
 
   return ratingAndReview;

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -42,7 +42,7 @@ export function getItemReviewsD2(
     dispatch(
       reviewsLoaded({
         key: getItemReviewsKey(item),
-        reviews: reviewData
+        reviews: reviewData,
       })
     );
     return reviewData;
@@ -78,7 +78,7 @@ function translateReview(returnedUserReview: D2ItemUserReview): D2ItemUserReview
 
   return {
     ...returnedUserReview,
-    timestamp
+    timestamp,
   };
 }
 

--- a/src/app/destinyTrackerApi/dtr-service-helper.ts
+++ b/src/app/destinyTrackerApi/dtr-service-helper.ts
@@ -11,7 +11,7 @@ const HTTP_503_TIMEOUT = 10 * 60 * 1000;
 const circuitBreaker = new CircuitBreaker({
   timeoutDuration: TIMEOUT,
   windowDuration: 1 * 60 * 1000, // 1 minute
-  volumeThreshold: 2
+  volumeThreshold: 2,
 });
 
 let lastFiveOhThreeCaught: Date | null;
@@ -32,8 +32,8 @@ export function dtrFetch(url: string, body: object) {
     method: 'POST',
     body: JSON.stringify(body),
     headers: {
-      'Content-Type': 'application/json'
-    }
+      'Content-Type': 'application/json',
+    },
   });
 
   let timer;

--- a/src/app/destinyTrackerApi/itemTransformer.ts
+++ b/src/app/destinyTrackerApi/itemTransformer.ts
@@ -8,7 +8,7 @@ import { D1ItemFetchRequest, D1ItemReviewRequest } from '../item-review/d1-dtr-a
 export function translateToDtrWeapon(weapon: D1Item): D1ItemFetchRequest {
   return {
     referenceId: weapon.hash.toString(),
-    roll: getDtrRoll(weapon)
+    roll: getDtrRoll(weapon),
   };
 }
 
@@ -20,7 +20,7 @@ export function getRollAndPerks(weapon: D1Item): D1ItemReviewRequest {
   return {
     ...translateToDtrWeapon(weapon),
     selectedPerks: getDtrPerks(weapon),
-    instanceId: weapon.id
+    instanceId: weapon.id,
   };
 }
 

--- a/src/app/destinyTrackerApi/perkRater.ts
+++ b/src/app/destinyTrackerApi/perkRater.ts
@@ -78,7 +78,7 @@ function getPerkRatingsAndReviewCount(
   const ratingAndReview = {
     ratingCount,
     averageReview,
-    perkNode
+    perkNode,
   };
 
   return ratingAndReview;

--- a/src/app/destinyTrackerApi/platformOptionsFetcher.ts
+++ b/src/app/destinyTrackerApi/platformOptionsFetcher.ts
@@ -8,22 +8,22 @@ export interface DtrPlatformOption {
 export const reviewPlatformOptions: DtrPlatformOption[] = [
   {
     platform: DtrReviewPlatform.All,
-    description: 'DtrReview.Platforms.All' // t('DtrReview.Platforms.All')
+    description: 'DtrReview.Platforms.All', // t('DtrReview.Platforms.All')
   },
   {
     platform: DtrReviewPlatform.Xbox,
-    description: 'DtrReview.Platforms.Xbox' // t('DtrReview.Platforms.Xbox')
+    description: 'DtrReview.Platforms.Xbox', // t('DtrReview.Platforms.Xbox')
   },
   {
     platform: DtrReviewPlatform.Playstation,
-    description: 'DtrReview.Platforms.Playstation' // t('DtrReview.Platforms.Playstation')
+    description: 'DtrReview.Platforms.Playstation', // t('DtrReview.Platforms.Playstation')
   },
   {
     platform: DtrReviewPlatform.AllConsoles,
-    description: 'DtrReview.Platforms.AllConsoles' // t('DtrReview.Platforms.AllConsoles')
+    description: 'DtrReview.Platforms.AllConsoles', // t('DtrReview.Platforms.AllConsoles')
   },
   {
     platform: DtrReviewPlatform.Pc,
-    description: 'DtrReview.Platforms.Pc' // t('DtrReview.Platforms.Pc')
-  }
+    description: 'DtrReview.Platforms.Pc', // t('DtrReview.Platforms.Pc')
+  },
 ];

--- a/src/app/destinyTrackerApi/reviewModesFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewModesFetcher.ts
@@ -12,7 +12,7 @@ const enum ActivityModeHashes {
   playerVersusPlayer = 1164760504,
   raid = 2043403989,
   trials = 1370326378,
-  gambit = 1848252830
+  gambit = 1848252830,
 }
 
 export function getReviewModes(defs?: D2ManifestDefinitions): D2ReviewMode[] {
@@ -24,20 +24,20 @@ export function getReviewModes(defs?: D2ManifestDefinitions): D2ReviewMode[] {
     { mode: DtrD2ActivityModes.notSpecified, description: t('DtrReview.ModeNotSpecified') },
     {
       mode: DtrD2ActivityModes.playerVersusEnemy,
-      description: defs.ActivityMode[ActivityModeHashes.playerVersusEnemy].displayProperties.name
+      description: defs.ActivityMode[ActivityModeHashes.playerVersusEnemy].displayProperties.name,
     },
     {
       mode: DtrD2ActivityModes.playerVersusPlayer,
-      description: defs.ActivityMode[ActivityModeHashes.playerVersusPlayer].displayProperties.name
+      description: defs.ActivityMode[ActivityModeHashes.playerVersusPlayer].displayProperties.name,
     },
     {
       mode: DtrD2ActivityModes.raid,
-      description: defs.ActivityMode[ActivityModeHashes.raid].displayProperties.name
+      description: defs.ActivityMode[ActivityModeHashes.raid].displayProperties.name,
     },
     // { mode: DtrD2ActivityModes.trials, description: defs.ActivityMode[ActivityModeHashes.trials].displayProperties.name }
     {
       mode: DtrD2ActivityModes.gambit,
-      description: defs.ActivityMode[ActivityModeHashes.gambit].displayProperties.name
-    }
+      description: defs.ActivityMode[ActivityModeHashes.gambit].displayProperties.name,
+    },
   ];
 }

--- a/src/app/destinyTrackerApi/reviewReporter.ts
+++ b/src/app/destinyTrackerApi/reviewReporter.ts
@@ -10,7 +10,7 @@ function getReporter(membershipInfo: DestinyAccount): DtrReviewer {
   return {
     membershipId: membershipInfo.membershipId,
     membershipType: membershipInfo.originalPlatformType,
-    displayName: membershipInfo.displayName
+    displayName: membershipInfo.displayName,
   };
 }
 
@@ -20,7 +20,7 @@ function generateD1ReviewReport(reviewId: string, membershipInfo: DestinyAccount
   return {
     reviewId,
     report: '',
-    reporter
+    reporter,
   };
 }
 
@@ -30,7 +30,7 @@ function generateD2ReviewReport(reviewId: string, membershipInfo: DestinyAccount
   return {
     reviewId,
     text: '',
-    reporter
+    reporter,
   };
 }
 

--- a/src/app/destinyTrackerApi/reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/reviewSubmitter.ts
@@ -28,7 +28,7 @@ export function submitReview(
 
     dispatch(
       markReviewSubmitted({
-        key: getItemReviewsKey(item)
+        key: getItemReviewsKey(item),
       })
     );
 
@@ -55,7 +55,7 @@ function submitReviewPromise(
   const reviewer = {
     membershipId: membershipInfo.membershipId,
     membershipType: membershipInfo.originalPlatformType,
-    displayName: membershipInfo.displayName
+    displayName: membershipInfo.displayName,
   };
 
   const review = isD2UserReview(item, userReview)
@@ -64,13 +64,13 @@ function submitReviewPromise(
         text: userReview.text,
         pros: userReview.pros,
         cons: userReview.cons,
-        mode: userReview.mode
+        mode: userReview.mode,
       }
     : {
         rating: userReview.rating,
         review: userReview.review,
         pros: userReview.pros,
-        cons: userReview.cons
+        cons: userReview.cons,
       };
 
   const rating = { ...rollAndPerks, ...review, reviewer };

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -6,7 +6,7 @@ import {
   D1ItemReviewResponse,
   D1ItemUserReview,
   ActualD1ItemReviewResponse,
-  ActualD1ItemUserReview
+  ActualD1ItemUserReview,
 } from '../item-review/d1-dtr-api-types';
 import { getRollAndPerks } from './itemTransformer';
 import { conditionallyIgnoreReviews } from './userFilter';
@@ -41,7 +41,7 @@ export function getItemReviewsD1(item: D1Item): ThunkResult<D1ItemReviewResponse
     dispatch(
       reviewsLoaded({
         key: getItemReviewsKey(item),
-        reviews: reviewData
+        reviews: reviewData,
       })
     );
 

--- a/src/app/developer/Developer.tsx
+++ b/src/app/developer/Developer.tsx
@@ -20,7 +20,7 @@ export default class Developer extends React.Component<{}, State> {
       clientSecret:
         localStorage.getItem('oauthClientSecret') || urlParams.oauthClientSecret || undefined,
       dimApiKey: localStorage.getItem('dimApiKey') || urlParams.dimApiKey || undefined,
-      dimAppName: localStorage.getItem('dimAppName') || urlParams.dimAppName || undefined
+      dimAppName: localStorage.getItem('dimAppName') || urlParams.dimAppName || undefined,
     };
   }
 

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -3,7 +3,7 @@ import {
   getDimApiProfile,
   importData,
   postUpdates,
-  deleteAllData
+  deleteAllData,
 } from '../dim-api/dim-api';
 import { ThunkResult, RootState } from '../store/reducers';
 import { DimApiState } from './reducer';
@@ -22,7 +22,7 @@ import {
   flushUpdatesFailed,
   allDataDeleted,
   setApiPermissionGranted,
-  profileLoadError
+  profileLoadError,
 } from './basic-actions';
 import { deepEqual } from 'fast-equals';
 import { DimData, SyncService } from 'app/storage/sync.service';
@@ -75,7 +75,7 @@ const installObservers = _.once((dispatch: ThunkDispatch<RootState, {}, AnyActio
         const savedState: ProfileIndexedDBState = {
           settings: settingsToSave,
           profiles: nextState.profiles,
-          updateQueue: nextState.updateQueue
+          updateQueue: nextState.updateQueue,
         };
         console.log('Saving profile data to IDB');
         set('dim-api-profile', savedState);
@@ -481,7 +481,7 @@ export function showBackupDownloadedNotification() {
     type: 'success',
     title: t('Storage.DimSyncEnabled'),
     body: t('Storage.AutoBackup'),
-    duration: 15000
+    duration: 15000,
   });
 }
 
@@ -490,7 +490,7 @@ function showImportSkippedNotification() {
     type: 'warning',
     title: t('Storage.ImportNotification.SkippedTitle'),
     body: t('Storage.ImportNotification.SkippedBody'),
-    duration: 15000
+    duration: 15000,
   });
 }
 
@@ -504,7 +504,7 @@ function showImportSuccessNotification(
     body: forceImport
       ? t('Storage.ImportNotification.SuccessBodyForced', result)
       : t('Storage.ImportNotification.SuccessBody', result),
-    duration: 15000
+    duration: 15000,
   });
 }
 

--- a/src/app/dim-api/api-permission-prompt.tsx
+++ b/src/app/dim-api/api-permission-prompt.tsx
@@ -49,7 +49,7 @@ export function promptForApiPermission() {
           </NotificationButton>
         </div>
       </>
-    )
+    ),
   });
 
   return promise;

--- a/src/app/dim-api/api-types.ts
+++ b/src/app/dim-api/api-types.ts
@@ -2,7 +2,7 @@ import {
   ProfileUpdate,
   DeleteLoadoutUpdate,
   Loadout,
-  DestinyVersion
+  DestinyVersion,
 } from '@destinyitemmanager/dim-api-types';
 
 // https://stackoverflow.com/questions/51691235/typescript-map-union-type-to-another-union-type

--- a/src/app/dim-api/basic-actions.ts
+++ b/src/app/dim-api/basic-actions.ts
@@ -3,7 +3,7 @@ import { DimApiState } from './reducer';
 import {
   GlobalSettings,
   ProfileResponse,
-  ProfileUpdateResult
+  ProfileUpdateResult,
 } from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 

--- a/src/app/dim-api/dim-api-helper.ts
+++ b/src/app/dim-api/dim-api-helper.ts
@@ -41,7 +41,7 @@ export async function unauthenticatedApi<T>(
     new Request(url, {
       method: config.method,
       body: config.body ? JSON.stringify(config.body) : undefined,
-      headers
+      headers,
     })
   );
 
@@ -65,7 +65,7 @@ export async function authenticatedApi<T>(config: HttpClientConfig): Promise<T> 
 
   const headers = {
     Authorization: `Bearer ${token.accessToken}`,
-    'X-API-Key': API_KEY
+    'X-API-Key': API_KEY,
   };
   if (config.body) {
     headers['Content-Type'] = 'application/json';
@@ -75,7 +75,7 @@ export async function authenticatedApi<T>(config: HttpClientConfig): Promise<T> 
     new Request(url, {
       method: config.method,
       body: config.body ? JSON.stringify(config.body) : undefined,
-      headers
+      headers,
     })
   );
 
@@ -136,13 +136,13 @@ const refreshToken = dedupePromise(async () => {
   const bungieToken = await getBungieToken();
   const authRequest: AuthTokenRequest = {
     bungieAccessToken: bungieToken.accessToken.value,
-    membershipId: bungieToken.bungieMembershipId
+    membershipId: bungieToken.bungieMembershipId,
   };
   try {
     const authToken = await unauthenticatedApi<DimAuthToken>({
       url: '/auth/token',
       method: 'POST',
-      body: authRequest
+      body: authRequest,
     });
 
     authToken.inception = Date.now();

--- a/src/app/dim-api/dim-api.ts
+++ b/src/app/dim-api/dim-api.ts
@@ -10,7 +10,7 @@ import {
   ImportResponse,
   ProfileUpdateResponse,
   AuditLogResponse,
-  DeleteAllResponse
+  DeleteAllResponse,
 } from '@destinyitemmanager/dim-api-types';
 import { DimData } from 'app/storage/sync.service';
 
@@ -18,7 +18,7 @@ export async function getGlobalSettings() {
   const response = await unauthenticatedApi<PlatformInfoResponse>(
     {
       url: '/platform_info',
-      method: 'GET'
+      method: 'GET',
     },
     true
   );
@@ -33,11 +33,11 @@ export async function getDimApiProfile(account?: DestinyAccount) {
       ? {
           platformMembershipId: account.membershipId,
           destinyVersion: account.destinyVersion,
-          components: 'settings,loadouts,tags'
+          components: 'settings,loadouts,tags',
         }
       : {
-          components: 'settings'
-        }
+          components: 'settings',
+        },
   });
   return response;
 }
@@ -46,7 +46,7 @@ export async function importData(data: DimData) {
   const response = await authenticatedApi<ImportResponse>({
     url: '/import',
     method: 'POST',
-    body: data
+    body: data,
   });
   return response;
 }
@@ -64,15 +64,15 @@ export async function postUpdates(
       ? {
           platformMembershipId,
           destinyVersion,
-          updates
+          updates,
         }
       : {
-          updates
+          updates,
         };
   const response = await authenticatedApi<ProfileUpdateResponse>({
     url: '/profile',
     method: 'POST',
-    body: request
+    body: request,
   });
   return response.results;
 }
@@ -80,7 +80,7 @@ export async function postUpdates(
 export async function getAuditLog() {
   const response = await authenticatedApi<AuditLogResponse>({
     url: '/audit',
-    method: 'GET'
+    method: 'GET',
   });
   return response.log;
 }
@@ -88,7 +88,7 @@ export async function getAuditLog() {
 export async function deleteAllData() {
   const response = await authenticatedApi<DeleteAllResponse>({
     url: '/delete_all_data',
-    method: 'POST'
+    method: 'POST',
   });
   return response.deleted;
 }
@@ -96,7 +96,7 @@ export async function deleteAllData() {
 export async function exportDimApiData() {
   const response = await authenticatedApi<ExportResponse>({
     url: '/export',
-    method: 'GET'
+    method: 'GET',
   });
   return response;
 }

--- a/src/app/dim-api/reducer.test.ts
+++ b/src/app/dim-api/reducer.test.ts
@@ -13,13 +13,13 @@ const currentAccount: DestinyAccount = {
   displayName: 'Foobar',
   originalPlatformType: BungieMembershipType.TigerPsn,
   platformLabel: 'PlayStation',
-  platforms: [BungieMembershipType.TigerPsn]
+  platforms: [BungieMembershipType.TigerPsn],
 };
 const currentAccountKey = '98765-d2';
 
 const initialState: DimApiState = {
   ...apiInitialState,
-  apiPermissionGranted: true
+  apiPermissionGranted: true,
 };
 
 describe('setSetting', () => {
@@ -33,12 +33,12 @@ describe('setSetting', () => {
       {
         action: 'setting',
         payload: {
-          showNewItems: true
+          showNewItems: true,
         },
         before: {
-          showNewItems: false
-        }
-      }
+          showNewItems: false,
+        },
+      },
     ]);
   });
 });
@@ -59,11 +59,11 @@ describe('setItemTag', () => {
         action: 'tag',
         payload: {
           id: '1234',
-          tag: 'favorite'
+          tag: 'favorite',
         },
         platformMembershipId: currentAccount.membershipId,
-        destinyVersion: currentAccount.destinyVersion
-      }
+        destinyVersion: currentAccount.destinyVersion,
+      },
     ]);
   });
 
@@ -88,24 +88,24 @@ describe('setItemTag', () => {
         action: 'tag',
         payload: {
           id: '1234',
-          tag: 'favorite'
+          tag: 'favorite',
         },
         platformMembershipId: currentAccount.membershipId,
-        destinyVersion: currentAccount.destinyVersion
+        destinyVersion: currentAccount.destinyVersion,
       },
       {
         action: 'tag',
         payload: {
           id: '1234',
-          tag: null
+          tag: null,
         },
         before: {
           id: '1234',
-          tag: 'favorite'
+          tag: 'favorite',
         },
         platformMembershipId: currentAccount.membershipId,
-        destinyVersion: currentAccount.destinyVersion
-      }
+        destinyVersion: currentAccount.destinyVersion,
+      },
     ]);
   });
 });
@@ -119,33 +119,33 @@ describe('prepareToFlushUpdates', () => {
         {
           action: 'setting',
           payload: {
-            showNewItems: true
+            showNewItems: true,
           },
           before: {
-            showNewItems: false
-          }
+            showNewItems: false,
+          },
         },
         // Modify another setting
         {
           action: 'setting',
           payload: {
-            itemSize: 50
+            itemSize: 50,
           },
           before: {
-            itemSize: 48
-          }
+            itemSize: 48,
+          },
         },
         // Turn new items back off
         {
           action: 'setting',
           payload: {
-            showNewItems: false
+            showNewItems: false,
           },
           before: {
-            showNewItems: true
-          }
-        }
-      ]
+            showNewItems: true,
+          },
+        },
+      ],
     };
 
     const updatedState = dimApi(state, prepareToFlushUpdates());
@@ -156,12 +156,12 @@ describe('prepareToFlushUpdates', () => {
       {
         action: 'setting',
         payload: {
-          itemSize: 50
+          itemSize: 50,
         },
         before: {
-          itemSize: 48
-        }
-      }
+          itemSize: 48,
+        },
+      },
     ];
     expect(copy(updatedState.updateQueue)).toEqual(expected);
   });
@@ -174,52 +174,52 @@ describe('prepareToFlushUpdates', () => {
         {
           action: 'setting',
           payload: {
-            showNewItems: true
+            showNewItems: true,
           },
           before: {
-            showNewItems: false
-          }
+            showNewItems: false,
+          },
         },
         // Save a tag for D2
         {
           action: 'tag',
           payload: {
             id: '1234',
-            tag: 'favorite'
+            tag: 'favorite',
           },
           before: {
-            id: '1234'
+            id: '1234',
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
+          destinyVersion: 2,
         },
         // Save a tag for D1, same profile
         {
           action: 'tag',
           payload: {
             id: '1231903',
-            tag: 'keep'
+            tag: 'keep',
           },
           before: {
-            id: '1231903'
+            id: '1231903',
           },
           platformMembershipId: '3456',
-          destinyVersion: 1
+          destinyVersion: 1,
         },
         // Save a tag for D2, same profile
         {
           action: 'tag',
           payload: {
             id: '76543',
-            tag: 'junk'
+            tag: 'junk',
           },
           before: {
-            id: '76543'
+            id: '76543',
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
-        }
-      ]
+          destinyVersion: 2,
+        },
+      ],
     };
 
     const updatedState = dimApi(state, prepareToFlushUpdates());
@@ -231,51 +231,51 @@ describe('prepareToFlushUpdates', () => {
       {
         action: 'setting',
         payload: {
-          showNewItems: true
+          showNewItems: true,
         },
         before: {
-          showNewItems: false
-        }
+          showNewItems: false,
+        },
       },
       // Save a tag for D2
       {
         action: 'tag',
         payload: {
           id: '1234',
-          tag: 'favorite'
+          tag: 'favorite',
         },
         before: {
-          id: '1234'
+          id: '1234',
         },
         platformMembershipId: '3456',
-        destinyVersion: 2
+        destinyVersion: 2,
       },
       // Save a tag for D2
       {
         action: 'tag',
         payload: {
           id: '76543',
-          tag: 'junk'
+          tag: 'junk',
         },
         before: {
-          id: '76543'
+          id: '76543',
         },
         platformMembershipId: '3456',
-        destinyVersion: 2
+        destinyVersion: 2,
       },
       // Save a tag for D1
       {
         action: 'tag',
         payload: {
           id: '1231903',
-          tag: 'keep'
+          tag: 'keep',
         },
         before: {
-          id: '1231903'
+          id: '1231903',
         },
         platformMembershipId: '3456',
-        destinyVersion: 1
-      }
+        destinyVersion: 1,
+      },
     ];
     expect(copy(updatedState.updateQueue)).toEqual(expected);
   });
@@ -289,38 +289,38 @@ describe('prepareToFlushUpdates', () => {
           action: 'tag',
           payload: {
             id: '1234',
-            tag: 'favorite'
+            tag: 'favorite',
           },
           before: {
-            id: '1234'
+            id: '1234',
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
+          destinyVersion: 2,
         },
         // Save a tag for D2, same profile
         {
           action: 'tag',
           payload: {
             id: '76543',
-            tag: 'junk'
+            tag: 'junk',
           },
           before: {
-            id: '76543'
+            id: '76543',
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
+          destinyVersion: 2,
         },
         // Turn new items on
         {
           action: 'setting',
           payload: {
-            showNewItems: true
+            showNewItems: true,
           },
           before: {
-            showNewItems: false
-          }
-        }
-      ]
+            showNewItems: false,
+          },
+        },
+      ],
     };
 
     const updatedState = dimApi(state, prepareToFlushUpdates());
@@ -333,37 +333,37 @@ describe('prepareToFlushUpdates', () => {
         action: 'tag',
         payload: {
           id: '1234',
-          tag: 'favorite'
+          tag: 'favorite',
         },
         before: {
-          id: '1234'
+          id: '1234',
         },
         platformMembershipId: '3456',
-        destinyVersion: 2
+        destinyVersion: 2,
       },
       // Save a tag for D2
       {
         action: 'tag',
         payload: {
           id: '76543',
-          tag: 'junk'
+          tag: 'junk',
         },
         before: {
-          id: '76543'
+          id: '76543',
         },
         platformMembershipId: '3456',
-        destinyVersion: 2
+        destinyVersion: 2,
       },
       // Turn new items on
       {
         action: 'setting',
         payload: {
-          showNewItems: true
+          showNewItems: true,
         },
         before: {
-          showNewItems: false
-        }
-      }
+          showNewItems: false,
+        },
+      },
     ];
     expect(copy(updatedState.updateQueue)).toEqual(expected);
   });
@@ -381,7 +381,7 @@ describe('prepareToFlushUpdates', () => {
             classType: DestinyClass.Warlock,
             equipped: [],
             unequipped: [],
-            clearSpace: false
+            clearSpace: false,
           },
           before: {
             id: '1234',
@@ -389,10 +389,10 @@ describe('prepareToFlushUpdates', () => {
             classType: DestinyClass.Unknown,
             equipped: [],
             unequipped: [],
-            clearSpace: false
+            clearSpace: false,
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
+          destinyVersion: 2,
         },
         // Update the name
         {
@@ -403,7 +403,7 @@ describe('prepareToFlushUpdates', () => {
             classType: DestinyClass.Warlock,
             equipped: [],
             unequipped: [],
-            clearSpace: false
+            clearSpace: false,
           },
           before: {
             id: '1234',
@@ -411,10 +411,10 @@ describe('prepareToFlushUpdates', () => {
             classType: DestinyClass.Warlock,
             equipped: [],
             unequipped: [],
-            clearSpace: false
+            clearSpace: false,
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
+          destinyVersion: 2,
         },
         // Delete it
         {
@@ -426,12 +426,12 @@ describe('prepareToFlushUpdates', () => {
             classType: DestinyClass.Warlock,
             equipped: [],
             unequipped: [],
-            clearSpace: false
+            clearSpace: false,
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
-        } as DeleteLoadoutUpdateWithRollback
-      ]
+          destinyVersion: 2,
+        } as DeleteLoadoutUpdateWithRollback,
+      ],
     };
 
     const updatedState = dimApi(state, prepareToFlushUpdates());
@@ -449,11 +449,11 @@ describe('prepareToFlushUpdates', () => {
           classType: DestinyClass.Unknown,
           equipped: [],
           unequipped: [],
-          clearSpace: false
+          clearSpace: false,
         },
         platformMembershipId: '3456',
-        destinyVersion: 2
-      }
+        destinyVersion: 2,
+      },
     ];
     expect(copy(updatedState.updateQueue)).toEqual(expected);
   });
@@ -466,43 +466,43 @@ describe('prepareToFlushUpdates', () => {
           action: 'tag',
           payload: {
             id: '1234',
-            tag: 'favorite'
+            tag: 'favorite',
           },
           before: {
             id: '1234',
-            tag: 'junk'
+            tag: 'junk',
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
+          destinyVersion: 2,
         },
         {
           action: 'tag',
           payload: {
             id: '1234',
-            notes: 'woohoo'
-          },
-          before: {
-            id: '1234',
-            tag: 'favorite'
-          },
-          platformMembershipId: '3456',
-          destinyVersion: 2
-        },
-        {
-          action: 'tag',
-          payload: {
-            id: '1234',
-            tag: null
+            notes: 'woohoo',
           },
           before: {
             id: '1234',
             tag: 'favorite',
-            notes: 'woohoo'
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
-        }
-      ]
+          destinyVersion: 2,
+        },
+        {
+          action: 'tag',
+          payload: {
+            id: '1234',
+            tag: null,
+          },
+          before: {
+            id: '1234',
+            tag: 'favorite',
+            notes: 'woohoo',
+          },
+          platformMembershipId: '3456',
+          destinyVersion: 2,
+        },
+      ],
     };
 
     const updatedState = dimApi(state, prepareToFlushUpdates());
@@ -514,15 +514,15 @@ describe('prepareToFlushUpdates', () => {
         payload: {
           id: '1234',
           tag: null,
-          notes: 'woohoo'
+          notes: 'woohoo',
         },
         before: {
           id: '1234',
-          tag: 'junk'
+          tag: 'junk',
         },
         platformMembershipId: '3456',
-        destinyVersion: 2
-      }
+        destinyVersion: 2,
+      },
     ];
     expect(copy(updatedState.updateQueue)).toEqual(expected);
   });
@@ -536,27 +536,27 @@ describe('finishedUpdates', () => {
         {
           action: 'setting',
           payload: {
-            showNewItems: true
+            showNewItems: true,
           },
           before: {
-            showNewItems: false
-          }
+            showNewItems: false,
+          },
         },
         // Save a tag for D2
         {
           action: 'tag',
           payload: {
             id: '1234',
-            tag: 'favorite'
+            tag: 'favorite',
           },
           before: {
-            id: '1234'
+            id: '1234',
           },
           platformMembershipId: '3456',
-          destinyVersion: 2
-        }
+          destinyVersion: 2,
+        },
       ],
-      updateInProgressWatermark: 2
+      updateInProgressWatermark: 2,
     };
     const updatedState = dimApi(
       state,

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -15,7 +15,7 @@ import {
   Loadout,
   DestinyVersion,
   LoadoutItem,
-  ItemAnnotation
+  ItemAnnotation,
 } from '@destinyitemmanager/dim-api-types';
 import { Loadout as DimLoadout, LoadoutItem as DimLoadoutItem } from '../loadout/loadout-types';
 import produce, { Draft } from 'immer';
@@ -92,7 +92,7 @@ export const initialState: DimApiState = {
   globalSettings: {
     ...defaultGlobalSettings,
     // 2019-12-17 we've been asked to disable auto-refresh
-    autoRefresh: false
+    autoRefresh: false,
   },
 
   apiPermissionGranted: getInitialApiPermissionSetting(),
@@ -106,7 +106,7 @@ export const initialState: DimApiState = {
   profiles: {},
 
   updateQueue: [],
-  updateInProgressWatermark: 0
+  updateInProgressWatermark: 0,
 };
 
 type DimApiAction =
@@ -142,8 +142,8 @@ export const dimApi = (
         globalSettingsLoaded: true,
         globalSettings: {
           ...state.globalSettings,
-          ...action.payload
-        }
+          ...action.payload,
+        },
       };
 
     case getType(actions.profileLoadedFromIDB): {
@@ -157,17 +157,17 @@ export const dimApi = (
             profileLoadedFromIndexedDb: true,
             settings: {
               ...state.settings,
-              ...action.payload.settings
+              ...action.payload.settings,
             },
             profiles: {
               ...state.profiles,
-              ...action.payload.profiles
+              ...action.payload.profiles,
             },
-            updateQueue: newUpdateQueue
+            updateQueue: newUpdateQueue,
           }
         : {
             ...state,
-            profileLoadedFromIndexedDb: true
+            profileLoadedFromIndexedDb: true,
           };
     }
 
@@ -180,7 +180,7 @@ export const dimApi = (
         profileLastLoaded: Date.now(),
         settings: {
           ...state.settings,
-          ...profileResponse.settings
+          ...profileResponse.settings,
         },
         profiles: account
           ? {
@@ -188,17 +188,17 @@ export const dimApi = (
               // Overwrite just this account's profile
               [makeProfileKeyFromAccount(account)]: {
                 loadouts: _.keyBy(profileResponse.loadouts || [], (l) => l.id),
-                tags: _.keyBy(profileResponse.tags || [], (t) => t.id)
-              }
+                tags: _.keyBy(profileResponse.tags || [], (t) => t.id),
+              },
             }
-          : state.profiles
+          : state.profiles,
       };
     }
 
     case getType(actions.profileLoadError): {
       return {
         ...state,
-        profileLoadedError: action.payload
+        profileLoadedError: action.payload,
       };
     }
 
@@ -207,7 +207,7 @@ export const dimApi = (
       return apiPermissionGranted
         ? {
             ...state,
-            apiPermissionGranted
+            apiPermissionGranted,
           }
         : // If we're disabling DIM Sync, reset local state to the initial state, as if we'd never loaded
           {
@@ -215,7 +215,7 @@ export const dimApi = (
             apiPermissionGranted,
             profiles: initialState.profiles,
             settings: initialState.settings,
-            profileLoaded: false
+            profileLoaded: false,
           };
     }
 
@@ -229,7 +229,7 @@ export const dimApi = (
         profiles: initialState.profiles,
         settings: initialState.settings,
         updateQueue: [],
-        updateInProgressWatermark: 0
+        updateInProgressWatermark: 0,
       };
     }
 
@@ -241,7 +241,7 @@ export const dimApi = (
     case getType(actions.flushUpdatesFailed):
       return {
         ...state,
-        updateInProgressWatermark: 0
+        updateInProgressWatermark: 0,
       };
 
     // *** Settings ***
@@ -252,7 +252,7 @@ export const dimApi = (
     case getType(settingsActions.toggleCollapsedSection):
       return changeSetting(state, 'collapsedSections', {
         ...state.settings.collapsedSections,
-        [action.payload]: !state.settings.collapsedSections[action.payload]
+        [action.payload]: !state.settings.collapsedSections[action.payload],
       });
 
     case getType(settingsActions.setCharacterOrder): {
@@ -311,11 +311,11 @@ function changeSetting<V extends keyof Settings>(state: DimApiState, prop: V, va
     draft.updateQueue.push({
       action: 'setting',
       payload: {
-        [prop]: value
+        [prop]: value,
       },
       before: {
-        [prop]: beforeValue
-      }
+        [prop]: beforeValue,
+      },
     });
   });
 }
@@ -425,12 +425,12 @@ function compactUpdate(
         const payload = {
           // Merge settings, newer overwriting older
           ...existingUpdate.payload,
-          ...update.payload
+          ...update.payload,
         };
         const before = {
           // Reversed order
           ...update.before,
-          ...existingUpdate.before
+          ...existingUpdate.before,
         };
 
         // Eliminate chains of settings that get back to the initial state
@@ -447,7 +447,7 @@ function compactUpdate(
         combinedUpdate = {
           ...existingUpdate,
           payload,
-          before
+          before,
         };
       }
       break;
@@ -458,7 +458,7 @@ function compactUpdate(
         combinedUpdate = {
           ...existingUpdate,
           // Combine into a unique set
-          payload: Array.from(new Set([...existingUpdate.payload, ...update.payload]))
+          payload: Array.from(new Set([...existingUpdate.payload, ...update.payload])),
         };
       }
       break;
@@ -469,7 +469,7 @@ function compactUpdate(
         combinedUpdate = {
           ...existingUpdate,
           // Loadouts completely overwrite
-          payload: update.payload
+          payload: update.payload,
           // We keep the "before" from the existing update
         };
       } else if (existingUpdate.action === 'delete_loadout') {
@@ -477,7 +477,7 @@ function compactUpdate(
         combinedUpdate = {
           ...update,
           // Before is whatever loadout existed before being deleted.
-          before: existingUpdate.before as Loadout
+          before: existingUpdate.before as Loadout,
         };
       }
       break;
@@ -494,7 +494,7 @@ function compactUpdate(
           // Turn it into a delete loadout
           ...update,
           // Loadouts completely overwrite
-          before: existingUpdate.before
+          before: existingUpdate.before,
           // We keep the "before" from the existing update
         } as DeleteLoadoutUpdateWithRollback;
       } else if (existingUpdate.action === 'delete_loadout') {
@@ -510,9 +510,9 @@ function compactUpdate(
           ...existingUpdate,
           payload: {
             ...existingUpdate.payload,
-            ...update.payload
+            ...update.payload,
           },
-          before: existingUpdate.before
+          before: existingUpdate.before,
         };
       }
       break;
@@ -584,7 +584,7 @@ function deleteLoadout(state: DimApiState, loadoutId: string) {
       payload: loadoutId,
       before: loadout,
       platformMembershipId,
-      destinyVersion
+      destinyVersion,
     });
   });
 }
@@ -602,7 +602,7 @@ function updateLoadout(state: DimApiState, loadout: DimLoadout) {
       action: 'loadout',
       payload: newLoadout,
       platformMembershipId: loadout.membershipId,
-      destinyVersion: loadout.destinyVersion || 2
+      destinyVersion: loadout.destinyVersion || 2,
     };
 
     if (loadouts[loadout.id]) {
@@ -631,11 +631,11 @@ function setTag(
     action: 'tag',
     payload: {
       id: itemId,
-      tag: tag ?? null
+      tag: tag ?? null,
     },
     before: existingTag ? { ...existingTag } : undefined,
     platformMembershipId: account.membershipId,
-    destinyVersion: account.destinyVersion
+    destinyVersion: account.destinyVersion,
   };
 
   if (tag) {
@@ -644,7 +644,7 @@ function setTag(
     } else {
       tags[itemId] = {
         id: itemId,
-        tag
+        tag,
       };
     }
   } else {
@@ -672,11 +672,11 @@ function setNote(
     action: 'tag',
     payload: {
       id: itemId,
-      notes: notes && notes.length > 0 ? notes : null
+      notes: notes && notes.length > 0 ? notes : null,
     },
     before: existingTag ? { ...existingTag } : undefined,
     platformMembershipId: account.membershipId,
-    destinyVersion: account.destinyVersion
+    destinyVersion: account.destinyVersion,
   };
 
   if (notes && notes.length > 0) {
@@ -685,7 +685,7 @@ function setNote(
     } else {
       tags[itemId] = {
         id: itemId,
-        notes
+        notes,
       };
     }
   } else {
@@ -715,7 +715,7 @@ function tagCleanup(state: DimApiState, itemIdsToRemove: string[], account: Dest
       payload: itemIdsToRemove,
       // "before" isn't really valuable here
       platformMembershipId: account.membershipId,
-      destinyVersion: account.destinyVersion
+      destinyVersion: account.destinyVersion,
     });
   });
 }
@@ -758,13 +758,13 @@ function convertDimLoadoutToApiLoadout(dimLoadout: DimLoadout): Loadout {
     name: dimLoadout.name,
     clearSpace: dimLoadout.clearSpace || false,
     equipped,
-    unequipped
+    unequipped,
   };
 }
 
 function convertDimLoadoutItemToLoadoutItem(item: DimLoadoutItem): LoadoutItem {
   const result: LoadoutItem = {
-    hash: item.hash
+    hash: item.hash,
   };
   if (item.id && item.id !== '0') {
     result.id = item.id;
@@ -779,7 +779,7 @@ function ensureProfile(draft: Draft<DimApiState>, profileKey: string) {
   if (!draft.profiles[profileKey]) {
     draft.profiles[profileKey] = {
       loadouts: {},
-      tags: {}
+      tags: {},
     };
   }
   return draft.profiles[profileKey];

--- a/src/app/dim-api/register-app.ts
+++ b/src/app/dim-api/register-app.ts
@@ -9,8 +9,8 @@ export async function registerApp(dimAppName: string, bungieApiKey: string) {
       body: {
         id: dimAppName,
         bungieApiKey,
-        origin: window.location.origin
-      }
+        origin: window.location.origin,
+      },
     },
     true
   );

--- a/src/app/dim-ui/ActivityTracker.tsx
+++ b/src/app/dim-ui/ActivityTracker.tsx
@@ -26,14 +26,14 @@ function mapStateToProps(state: RootState): StoreProps {
     destinyProfileMinimumRefreshInterval,
     destinyProfileRefreshInterval,
     autoRefresh,
-    refreshProfileOnVisible
+    refreshProfileOnVisible,
   } = state.dimApi.globalSettings;
 
   return {
     destinyProfileRefreshInterval,
     destinyProfileMinimumRefreshInterval,
     autoRefresh,
-    refreshProfileOnVisible
+    refreshProfileOnVisible,
   };
 }
 

--- a/src/app/dim-ui/BungieImage.tsx
+++ b/src/app/dim-ui/BungieImage.tsx
@@ -26,7 +26,7 @@ export default React.memo(function BungieImage(
 export function bungieBackgroundStyle(src: BungieImagePath, additionalBackground?: string) {
   additionalBackground = additionalBackground ? `, ${additionalBackground}` : '';
   return {
-    backgroundImage: `url("${bungieNetPath(src)}")${additionalBackground}`
+    backgroundImage: `url("${bungieNetPath(src)}")${additionalBackground}`,
   };
 }
 

--- a/src/app/dim-ui/CharacterSelect.tsx
+++ b/src/app/dim-ui/CharacterSelect.tsx
@@ -13,7 +13,7 @@ export default function CharacterSelect({
   selectedStore,
   vertical,
   isPhonePortrait,
-  onCharacterChanged
+  onCharacterChanged,
 }: {
   stores: DimStore[];
   selectedStore: DimStore;
@@ -56,7 +56,7 @@ export default function CharacterSelect({
           <div
             key={store.id}
             className={clsx(styles.tile, {
-              [styles.unselected]: store.id !== selectedStore.id
+              [styles.unselected]: store.id !== selectedStore.id,
             })}
           >
             <SimpleCharacterTile character={store} onClick={onCharacterChanged} />

--- a/src/app/dim-ui/CollapsibleTitle.tsx
+++ b/src/app/dim-ui/CollapsibleTitle.tsx
@@ -29,7 +29,7 @@ interface DispatchProps {
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   const collapsed = settingsSelector(state).collapsedSections[props.sectionId];
   return {
-    collapsed: collapsed === undefined ? Boolean(props.defaultCollapsed) : collapsed
+    collapsed: collapsed === undefined ? Boolean(props.defaultCollapsed) : collapsed,
   };
 }
 
@@ -37,7 +37,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: ProvidedProps): Dispat
   return {
     toggle: () => {
       dispatch(toggleCollapsedSection(ownProps.sectionId));
-    }
+    },
   };
 }
 

--- a/src/app/dim-ui/CustomStatTotal.tsx
+++ b/src/app/dim-ui/CustomStatTotal.tsx
@@ -23,7 +23,7 @@ interface StoreProps {
 }
 
 const mapDispatchToProps = {
-  setSetting
+  setSetting,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -32,7 +32,7 @@ type ToggleProps = ProvidedProps & StoreProps & DispatchProps;
 function mapStateToProps() {
   return (state: RootState): StoreProps => ({
     defs: state.manifest.d2Manifest!,
-    customTotalStatsByClass: settingsSelector(state).customTotalStatsByClass
+    customTotalStatsByClass: settingsSelector(state).customTotalStatsByClass,
   });
 }
 
@@ -41,7 +41,7 @@ function StatTotalTogglePreConnect({
   readOnly = false,
   defs,
   customTotalStatsByClass,
-  setSetting
+  setSetting,
 }: ToggleProps) {
   const activeStats = customTotalStatsByClass[forClass]?.length
     ? customTotalStatsByClass[forClass]
@@ -52,7 +52,7 @@ function StatTotalTogglePreConnect({
       {addDividers(
         [
           { className: 'activeStatLabels', includesCheck: true },
-          { className: 'inactiveStatLabels', includesCheck: false }
+          { className: 'inactiveStatLabels', includesCheck: false },
         ].map(({ className, includesCheck }) => (
           <span
             key={className}
@@ -95,7 +95,7 @@ function StatToggleButton({
   setSetting,
   currentSettings,
   currentClass,
-  readOnly = false
+  readOnly = false,
 }: {
   stat: DestinyStatDefinition;
   setSetting: DispatchProps['setSetting'];
@@ -115,8 +115,8 @@ function StatToggleButton({
                   [currentClass]: toggleArrayElement(
                     stat.hash,
                     currentSettings[currentClass] ?? armorStats
-                  )
-                }
+                  ),
+                },
               });
             }
           : undefined

--- a/src/app/dim-ui/DiamondProgress.tsx
+++ b/src/app/dim-ui/DiamondProgress.tsx
@@ -16,7 +16,7 @@ interface Props {
  */
 export default function DiamondProgres({ progress, level, icon, className }: Props) {
   const style = {
-    strokeDashoffset: 121.622368 - 121.622368 * progress
+    strokeDashoffset: 121.622368 - 121.622368 * progress,
   };
 
   // TODO: redo classes

--- a/src/app/dim-ui/FileUpload.tsx
+++ b/src/app/dim-ui/FileUpload.tsx
@@ -8,7 +8,7 @@ import { AppIcon, uploadIcon } from 'app/shell/icons';
 export default function FileUpload({
   accept,
   title,
-  onDrop
+  onDrop,
 }: {
   accept?: string;
   title: string;

--- a/src/app/dim-ui/PageLoading.tsx
+++ b/src/app/dim-ui/PageLoading.tsx
@@ -13,7 +13,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    message: _.last(state.shell.loadingMessages)
+    message: _.last(state.shell.loadingMessages),
   };
 }
 
@@ -23,7 +23,7 @@ const transitionClasses = {
   enter: styles.pageLoadingEnter,
   enterActive: styles.pageLoadingEnterActive,
   exit: styles.pageLoadingExit,
-  exitActive: styles.pageLoadingExitActive
+  exitActive: styles.pageLoadingExitActive,
 };
 
 /**

--- a/src/app/dim-ui/PageWithMenu.tsx
+++ b/src/app/dim-ui/PageWithMenu.tsx
@@ -5,7 +5,7 @@ import { scrollToHref } from './scroll';
 
 const PageWithMenu = ({
   children,
-  className
+  className,
 }: {
   children: React.ReactNode;
   className?: string;
@@ -13,7 +13,7 @@ const PageWithMenu = ({
 
 PageWithMenu.Menu = ({
   children,
-  className
+  className,
 }: {
   children: React.ReactNode;
   className?: string;
@@ -21,7 +21,7 @@ PageWithMenu.Menu = ({
 
 PageWithMenu.Contents = ({
   children,
-  className
+  className,
 }: {
   children: React.ReactNode;
   className?: string;
@@ -29,7 +29,7 @@ PageWithMenu.Contents = ({
 
 PageWithMenu.MenuHeader = ({
   children,
-  className
+  className,
 }: {
   children: React.ReactNode;
   className?: string;

--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -31,8 +31,8 @@ const createPopper = popperGenerator({
     applyStyles,
     flip,
     preventOverflow,
-    arrow
-  ]
+    arrow,
+  ],
 });
 
 const popperOptions = (): Partial<Options> => {
@@ -41,7 +41,7 @@ const popperOptions = (): Partial<Options> => {
     left: 0,
     top: headerHeight + 5,
     right: 0,
-    bottom: 0
+    bottom: 0,
   };
 
   return {
@@ -52,30 +52,30 @@ const popperOptions = (): Partial<Options> => {
         options: {
           priority: ['bottom', 'top', 'right', 'left'],
           boundariesElement: 'viewport',
-          padding
-        }
+          padding,
+        },
       },
       {
         name: 'flip',
         options: {
           behavior: ['top', 'bottom', 'right', 'left'],
           boundariesElement: 'viewport',
-          padding
-        }
+          padding,
+        },
       },
       {
         name: 'offset',
         options: {
-          offset: [0, 5]
-        }
+          offset: [0, 5],
+        },
       },
       {
         name: 'arrow',
         options: {
-          element: '.' + styles.arrow
-        }
-      }
-    ]
+          element: '.' + styles.arrow,
+        },
+      },
+    ],
   };
 };
 
@@ -104,7 +104,7 @@ export default class PressTip extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      isOpen: false
+      isOpen: false,
     };
   }
 

--- a/src/app/dim-ui/RichDestinyText.tsx
+++ b/src/app/dim-ui/RichDestinyText.tsx
@@ -158,7 +158,7 @@ const replaceWithIcon = (
  */
 export default function RichDestinyText({
   text,
-  defs
+  defs,
 }: {
   text: string;
   defs?: D1ManifestDefinitions | D2ManifestDefinitions;

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 const spring = {
   ...config.stiff,
-  clamp: true
+  clamp: true,
 };
 
 // The sheet is dismissed if it's flicked at a velocity above dismissVelocity or dragged down more than dismissAmount times the height of the sheet.
@@ -37,7 +37,7 @@ export default function Sheet({
   footer,
   children,
   sheetClassName,
-  onClose: onCloseCallback
+  onClose: onCloseCallback,
 }: Props) {
   // This component basically doesn't render - it works entirely through setSpring and useDrag.
   // As a result, our "state" is in refs.
@@ -69,7 +69,7 @@ export default function Sheet({
     from: { transform: `translateY(${windowHeight}px)` },
     to: { transform: `translateY(0px)` },
     config: spring,
-    onRest
+    onRest,
   }));
 
   /**

--- a/src/app/dim-ui/SpecialtyModSlotIcon.tsx
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.tsx
@@ -16,7 +16,7 @@ interface StoreProps {
 }
 function mapStateToProps() {
   return (state: RootState): StoreProps => ({
-    defs: state.manifest.d2Manifest!
+    defs: state.manifest.d2Manifest!,
   });
 }
 type Props = ProvidedProps & StoreProps;

--- a/src/app/dim-ui/scroll.ts
+++ b/src/app/dim-ui/scroll.ts
@@ -20,7 +20,7 @@ export function scrollToElement(elem: Element | null) {
     scrollToPosition({
       top: window.scrollY + rect.top - (headerHeight + 6),
       left: 0,
-      behavior: 'smooth'
+      behavior: 'smooth',
     });
   }
 }

--- a/src/app/farming/D1Farming.tsx
+++ b/src/app/farming/D1Farming.tsx
@@ -20,12 +20,12 @@ function mapStateToProps() {
   const storeSelector = farmingStoreSelector();
   return (state: RootState): StoreProps => ({
     makeRoomForItems: settingsSelector(state).farmingMakeRoomForItems,
-    store: storeSelector(state)
+    store: storeSelector(state),
   });
 }
 
 const mapDispatchToProps = {
-  setSetting
+  setSetting,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -34,7 +34,7 @@ type Props = StoreProps & DispatchProps;
 function D1Farming({ store, makeRoomForItems, setSetting }: Props) {
   const i18nData = {
     store: store?.name,
-    context: store?.genderName
+    context: store?.genderName,
   };
 
   const makeRoomForItemsChanged = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/farming/D2Farming.tsx
+++ b/src/app/farming/D2Farming.tsx
@@ -16,7 +16,7 @@ interface StoreProps {
 function mapStateToProps() {
   const storeSelector = farmingStoreSelector();
   return (state: RootState): StoreProps => ({
-    store: storeSelector(state)
+    store: storeSelector(state),
   });
 }
 
@@ -32,7 +32,7 @@ function D2Farming({ store }: Props) {
               <p>
                 {t('FarmingMode.D2Desc', {
                   store: store.name,
-                  context: store.genderName
+                  context: store.genderName,
                 })}
                 {/*
                     t('FarmingMode.D2Desc_male')

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -20,7 +20,7 @@ const glimmerHashes = new Set([
   269776572, // -house-banners
   3632619276, // -silken-codex
   2904517731, // -axiomatic-beads
-  1932910919 // -network-keys
+  1932910919, // -network-keys
 ]);
 
 // These are things you may pick up frequently out in the wild
@@ -36,7 +36,7 @@ const makeRoomTypes = [
   434908299, // Artifact
   4023194814, // Ghost
   1469714392, // Consumable
-  3865314626 // Material
+  3865314626, // Material
 ];
 
 /**

--- a/src/app/farming/reducer.ts
+++ b/src/app/farming/reducer.ts
@@ -30,13 +30,13 @@ export const farming: Reducer<FarmingState, FarmingAction> = (
     case getType(actions.start):
       return {
         ...state,
-        storeId: action.payload
+        storeId: action.payload,
       };
 
     case getType(actions.stop):
       return {
         ...state,
-        storeId: undefined
+        storeId: undefined,
       };
 
     default:

--- a/src/app/hotkeys/HotkeysCheatSheet.tsx
+++ b/src/app/hotkeys/HotkeysCheatSheet.tsx
@@ -20,8 +20,8 @@ export default class HotkeysCheatSheet extends React.Component<{}, State> {
           {
             combo: '?',
             description: t('Hotkey.ShowHotkeys'),
-            callback: this.toggle
-          }
+            callback: this.toggle,
+          },
         ]}
       />
     );
@@ -40,8 +40,8 @@ export default class HotkeysCheatSheet extends React.Component<{}, State> {
             {
               combo: 'esc',
               description: '',
-              callback: this.hide
-            }
+              callback: this.hide,
+            },
           ]}
         />
         <div className="cfp-hotkeys">
@@ -67,7 +67,7 @@ export default class HotkeysCheatSheet extends React.Component<{}, State> {
 
   private toggle = () =>
     this.setState((state) => ({
-      visible: !state.visible
+      visible: !state.visible,
     }));
 
   private hide = () => this.setState({ visible: false });

--- a/src/app/hotkeys/hotkeys.ts
+++ b/src/app/hotkeys/hotkeys.ts
@@ -9,7 +9,7 @@ const map = {
   up: '\u2191', // ↑
   down: '\u2193', // ↓
   return: '\u23CE', // ⏎
-  backspace: '\u232B' // ⌫
+  backspace: '\u232B', // ⌫
 };
 
 /**

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -31,7 +31,7 @@ export function defaultLanguage(): string {
     'ru',
     'ko',
     'zh-cht',
-    'zh-chs'
+    'zh-chs',
   ];
 
   const storedLanguage = localStorage.getItem('dimLanguage');
@@ -66,7 +66,7 @@ export function initi18n(): Promise<never> {
                 return parseInt(val, 10).toLocaleString();
             }
             return val;
-          }
+          },
         },
         backend: {
           loadPath(lng) {
@@ -83,15 +83,15 @@ export function initi18n(): Promise<never> {
               ru,
               ko,
               'zh-cht': zhCHT,
-              'zh-chs': zhCHS
+              'zh-chs': zhCHS,
             }[lng];
             if (!path) {
               throw new Error(`unsupported language ${lng}`);
             }
             return path;
-          }
+          },
         },
-        returnObjects: true
+        returnObjects: true,
       },
       (error) => {
         if (error) {

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -21,7 +21,7 @@ import {
   SearchConfig,
   searchConfigSelector,
   SearchFilters,
-  searchFiltersConfigSelector
+  searchFiltersConfigSelector,
 } from '../search/search-filters';
 import { setSetting } from '../settings/actions';
 import { showNotification } from '../notifications/notifications';
@@ -60,12 +60,12 @@ function mapStateToProps(state: RootState): StoreProps {
     searchConfig: searchConfigSelector(state),
     filters: searchFiltersConfigSelector(state),
     lastInfusionDirection: settingsSelector(state).infusionDirection,
-    isPhonePortrait: state.shell.isPhonePortrait
+    isPhonePortrait: state.shell.isPhonePortrait,
   };
 }
 
 const mapDispatchToProps = {
-  setSetting
+  setSetting,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -109,7 +109,7 @@ class InfusionFinder extends React.Component<Props, State> {
             target: item,
             direction: InfuseDirection.INFUSE,
             height: undefined,
-            filter: ''
+            filter: '',
           });
         } else {
           this.setState({
@@ -118,7 +118,7 @@ class InfusionFinder extends React.Component<Props, State> {
             target: undefined,
             direction: InfuseDirection.FUEL,
             height: undefined,
-            filter: ''
+            filter: '',
           });
         }
       })
@@ -195,10 +195,10 @@ class InfusionFinder extends React.Component<Props, State> {
         <h1>
           {direction === InfuseDirection.INFUSE
             ? t('Infusion.InfuseTarget', {
-                name: query.name
+                name: query.name,
               })
             : t('Infusion.InfuseSource', {
-                name: query.name
+                name: query.name,
               })}
         </h1>
         <div className="infusionControls">
@@ -282,7 +282,7 @@ class InfusionFinder extends React.Component<Props, State> {
       source: undefined,
       target: undefined,
       height: undefined,
-      filter: ''
+      filter: '',
     });
   };
 
@@ -305,7 +305,7 @@ class InfusionFinder extends React.Component<Props, State> {
       return {
         direction,
         target: direction === InfuseDirection.INFUSE ? query : undefined,
-        source: direction === InfuseDirection.FUEL ? query : undefined
+        source: direction === InfuseDirection.FUEL ? query : undefined,
       };
     });
     this.props.setSetting('infusionDirection', 1);
@@ -328,7 +328,7 @@ class InfusionFinder extends React.Component<Props, State> {
     const items: LoadoutItem[] = [
       convertToLoadoutItem(target, false),
       // Include the source, since we wouldn't want it to get moved out of the way
-      convertToLoadoutItem(source, source.equipped)
+      convertToLoadoutItem(source, source.equipped),
     ];
 
     if (source.isDestiny1()) {
@@ -338,7 +338,7 @@ class InfusionFinder extends React.Component<Props, State> {
           id: '0',
           hash: 937555249,
           amount: 2,
-          equipped: false
+          equipped: false,
         });
       } else if (target.bucket.sort === 'Weapons') {
         // Weapon Parts
@@ -346,7 +346,7 @@ class InfusionFinder extends React.Component<Props, State> {
           id: '0',
           hash: 1898539128,
           amount: 10,
-          equipped: false
+          equipped: false,
         });
       } else {
         // Armor Materials
@@ -354,7 +354,7 @@ class InfusionFinder extends React.Component<Props, State> {
           id: '0',
           hash: 1542293174,
           amount: 10,
-          equipped: false
+          equipped: false,
         });
       }
       if (source.isExotic) {
@@ -363,7 +363,7 @@ class InfusionFinder extends React.Component<Props, State> {
           id: '0',
           hash: 452597397,
           amount: 1,
-          equipped: false
+          equipped: false,
         });
       }
     }

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -74,7 +74,7 @@ export default function BadgeInfo({ item, isCapped, rating, uiWishListRoll }: Pr
   const badgeclsx = {
     [styles.fullstack]: isStackable && item.amount === item.maxStackSize,
     [styles.capped]: isCapped,
-    [styles.masterwork]: item.masterwork
+    [styles.masterwork]: item.masterwork,
   };
 
   const badgeContent =
@@ -86,7 +86,7 @@ export default function BadgeInfo({ item, isCapped, rating, uiWishListRoll }: Pr
 
   const reviewclsx = {
     [styles.review]: true,
-    [styles.wishlistRoll]: uiWishListRoll
+    [styles.wishlistRoll]: uiWishListRoll,
   };
 
   return (

--- a/src/app/inventory/CharacterStats.tsx
+++ b/src/app/inventory/CharacterStats.tsx
@@ -34,7 +34,7 @@ export default class CharacterStats extends React.PureComponent<Props> {
             progress: tier === 5 ? stat.value : stat.value % 60,
             tier,
             nextTier: tier + 1,
-            statName: stat.name
+            statName: stat.name,
           });
           let cooldown = stat.cooldown || '';
           if (cooldown) {
@@ -57,7 +57,7 @@ export default class CharacterStats extends React.PureComponent<Props> {
                   <div key={index} className="bar">
                     <div
                       className={clsx('progress', {
-                        complete: n / 60 === 1
+                        complete: n / 60 === 1,
                       })}
                       style={{ width: percent(n / 60) }}
                     />
@@ -74,7 +74,7 @@ export default class CharacterStats extends React.PureComponent<Props> {
       const powerInfos = _.compact([
         stats.maxTotalPower,
         stats.maxGearPower,
-        stats.powerModifier
+        stats.powerModifier,
       ]).map((stat) => ({ stat, tooltip: powerTooltip(stat) }));
 
       const statTooltip = (stat: DimCharacterStat): string =>

--- a/src/app/inventory/ClearNewItems.tsx
+++ b/src/app/inventory/ClearNewItems.tsx
@@ -21,12 +21,12 @@ interface StoreProps {
 function mapStateToProps(state: RootState): StoreProps {
   return {
     showNewItems: settingsSelector(state).showNewItems,
-    hasNewItems: state.inventory.newItems.size > 0
+    hasNewItems: state.inventory.newItems.size > 0,
   };
 }
 
 const mapDispatchToProps = {
-  clearAllNewItems
+  clearAllNewItems,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -44,8 +44,8 @@ function ClearNewItems({ showNewItems, hasNewItems, clearAllNewItems }: Props) {
           {
             combo: 'x',
             description: t('Hotkey.ClearNewItems'),
-            callback: clearAllNewItems
-          }
+            callback: clearAllNewItems,
+          },
         ]}
       />
       <button onClick={clearAllNewItems} title={t('Hotkey.ClearNewItemsTitle')}>

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -50,7 +50,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
     rating: dtrRating && showRating ? dtrRating.overallScore : undefined,
     searchHidden: props.allowFilter && !searchFilterSelector(state)(item),
     wishListsEnabled: wishListsEnabledSelector(state),
-    inventoryWishListRoll: inventoryWishListsSelector(state)[item.id]
+    inventoryWishListRoll: inventoryWishListsSelector(state)[item.id],
   };
 }
 
@@ -73,7 +73,7 @@ function ConnectedInventoryItem({
   inventoryWishListRoll,
   wishListsEnabled,
   ignoreSelectedPerks,
-  innerRef
+  innerRef,
 }: Props) {
   return (
     <InventoryItem

--- a/src/app/inventory/D1ReputationSection.tsx
+++ b/src/app/inventory/D1ReputationSection.tsx
@@ -13,7 +13,7 @@ export default function D1ReputationSection({ stores }: { stores: DimStore[] }) 
           <div
             key={store.id}
             className={clsx('store-cell', {
-              vault: store.isVault
+              vault: store.isVault,
             })}
           >
             <D1Reputation store={store} />

--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -71,14 +71,14 @@ const dragSpec: DragSourceSpec<Props, DragObject> = {
     return (!item.location.inPostmaster || item.destinyVersion === 2) && item.notransfer
       ? item.equipment
       : item.equipment || item.bucket.hasTransferDestination;
-  }
+  },
 };
 
 function collect(connect: DragSourceConnector): InternalProps {
   return {
     // Call this function inside render()
     // to let React DnD handle the drag events:
-    connectDragSource: connect.dragSource()
+    connectDragSource: connect.dragSource(),
     // TODO: The monitor param has interesting things for doing animation
   };
 }

--- a/src/app/inventory/ElementIcon.tsx
+++ b/src/app/inventory/ElementIcon.tsx
@@ -6,7 +6,7 @@ import { DestinyDamageTypeDefinition, DestinyEnergyTypeDefinition } from 'bungie
 
 export default function ElementIcon({
   element,
-  className
+  className,
 }: {
   element: DestinyDamageTypeDefinition | DestinyEnergyTypeDefinition | null;
   className?: string;

--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -33,7 +33,7 @@ type Props = ProvidedProps & StoreProps;
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    storesLoaded: storesLoadedSelector(state)
+    storesLoaded: storesLoadedSelector(state),
   };
 }
 

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -31,7 +31,7 @@ interface DispatchProps {
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   return {
-    collapsed: settingsSelector(state).collapsedSections[props.sectionId]
+    collapsed: settingsSelector(state).collapsedSections[props.sectionId],
   };
 }
 
@@ -39,7 +39,7 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: ProvidedProps): Dispat
   return {
     toggle: () => {
       dispatch(toggleCollapsedSection(ownProps.sectionId));
-    }
+    },
   };
 }
 
@@ -52,7 +52,7 @@ function InventoryCollapsibleTitle({
   children,
   toggle,
   className,
-  stores
+  stores,
 }: Props) {
   const checkPostmaster = sectionId === 'Postmaster';
 
@@ -60,7 +60,7 @@ function InventoryCollapsibleTitle({
     <>
       <div
         className={clsx('store-row', 'inventory-title', {
-          collapsed
+          collapsed,
         })}
       >
         {stores.map((store, index) => {
@@ -71,7 +71,7 @@ function InventoryCollapsibleTitle({
 
           const data = {
             number: postMasterSpaceUsed,
-            postmasterSize: POSTMASTER_SIZE
+            postmasterSize: POSTMASTER_SIZE,
           };
 
           const text =
@@ -85,7 +85,7 @@ function InventoryCollapsibleTitle({
               className={clsx('title', 'store-cell', className, {
                 collapsed,
                 vault: store.isVault,
-                postmasterFull: showPostmasterFull
+                postmasterFull: showPostmasterFull,
               })}
               style={storeBackgroundColor(store, index)}
             >

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -50,7 +50,7 @@ export default function InventoryItem({
   onClick,
   onShiftClick,
   onDoubleClick,
-  innerRef
+  innerRef,
 }: Props) {
   const isCapped = item.maxStackSize > 1 && item.amount === item.maxStackSize && item.uniqueStack;
 
@@ -78,12 +78,12 @@ export default function InventoryItem({
     [styles.searchHidden]: searchHidden,
     [styles.subclassPathTop]: subclassPath?.position === 'top',
     [styles.subclassPathMiddle]: subclassPath?.position === 'middle',
-    [styles.subclassPathBottom]: subclassPath?.position === 'bottom'
+    [styles.subclassPathBottom]: subclassPath?.position === 'bottom',
   };
   const itemImageStyles = clsx('item-img', {
     [styles.complete]: item.complete || isCapped,
     [styles.borderless]: borderless(item),
-    [styles.masterwork]: item.masterwork
+    [styles.masterwork]: item.masterwork,
   });
 
   return (
@@ -160,7 +160,7 @@ const superIconNodeHashes = {
   sentinelShield: 368405360,
   bannerShield: 3504292102,
   hammerOfSol: 1722642322,
-  burningMaul: 1323416107
+  burningMaul: 1323416107,
 };
 
 // prettier-ignore
@@ -217,7 +217,7 @@ function selectedSubclassPath(talentGrid: DimTalentGrid) {
       return {
         base: def.base,
         position: def.position,
-        super: superNode?.icon
+        super: superNode?.icon,
       };
     }
   }

--- a/src/app/inventory/MoveNotifications.tsx
+++ b/src/app/inventory/MoveNotifications.tsx
@@ -34,8 +34,8 @@ export function moveItemNotification(
     body: t('ItemMove.MovingItem', {
       name: item.name,
       target: target.name,
-      context: target.genderName
-    })
+      context: target.genderName,
+    }),
   };
 }
 
@@ -63,8 +63,8 @@ export function loadoutNotification(
       // t('Loadouts.NotificationMessage_female_plural')
       count,
       store: store.name,
-      context: store.genderName
-    })
+      context: store.genderName,
+    }),
   };
 }
 
@@ -90,20 +90,20 @@ export function postmasterNotification(
       // t('Loadouts.PullFromPostmasterNotification_female_plural')
       count,
       store: store.name,
-      context: store.genderName
-    })
+      context: store.genderName,
+    }),
   };
 }
 
 const enum MoveState {
   InProgress,
   Failed,
-  Succeeded
+  Succeeded,
 }
 
 const moveStateClasses = {
   [MoveState.Failed]: styles.failed,
-  [MoveState.Succeeded]: styles.succeeded
+  [MoveState.Succeeded]: styles.succeeded,
 };
 
 function MoveItemNotificationIcon({ completion }: { completion: Promise<any> }) {

--- a/src/app/inventory/RatingIcon.tsx
+++ b/src/app/inventory/RatingIcon.tsx
@@ -6,14 +6,14 @@ import {
   thumbsDownIcon,
   faCaretDown,
   faCaretUp,
-  faMinus
+  faMinus,
 } from '../shell/icons';
 import './RatingIcon.scss';
 import { UiWishListRoll } from 'app/wishlists/wishlists';
 
 export default function RatingIcon({
   rating,
-  uiWishListRoll
+  uiWishListRoll,
 }: {
   rating: number;
   uiWishListRoll?: UiWishListRoll;

--- a/src/app/inventory/SimpleCharacterTile.tsx
+++ b/src/app/inventory/SimpleCharacterTile.tsx
@@ -6,7 +6,7 @@ import './StoreHeading.scss';
 
 export default function SimpleCharacterTile({
   character,
-  onClick
+  onClick,
 }: {
   character: DimStore;
   onClick?(id: string): void;
@@ -17,7 +17,7 @@ export default function SimpleCharacterTile({
     <div onClick={handleClick} className={clsx('character', { current: character.current })}>
       <div
         className={clsx('character-box', {
-          destiny2: character.isDestiny2()
+          destiny2: character.isDestiny2(),
         })}
       >
         <div className="background" style={{ backgroundImage: `url("${character.background}")` }} />

--- a/src/app/inventory/StackableDragHelp.tsx
+++ b/src/app/inventory/StackableDragHelp.tsx
@@ -14,7 +14,7 @@ interface State {
 
 function mapStateToProps(state: RootState) {
   return {
-    isDraggingStack: state.inventory.isDraggingStack
+    isDraggingStack: state.inventory.isDraggingStack,
   };
 }
 
@@ -35,7 +35,7 @@ class StackableDragHelp extends React.Component<Props, State> {
 
     const classes = {
       'drag-help-hidden': !isDraggingStack,
-      'drag-shift-activated': shiftKeyDown
+      'drag-shift-activated': shiftKeyDown,
     };
 
     // TODO: CSS Transition group? would have to handle attach/detach

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -43,7 +43,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
     itemSortOrder: itemSortOrderSelector(state),
     // We only need this property when this is a vault armor bucket
     allStores: store.isVault && bucket.inArmor ? sortedStoresSelector(state) : emptyArray(),
-    characterOrder: characterOrderSelector(state)
+    characterOrder: characterOrderSelector(state),
   };
 }
 
@@ -53,7 +53,7 @@ const classIcons = {
   [DestinyClass.Unknown]: globeIcon,
   [DestinyClass.Hunter]: hunterIcon,
   [DestinyClass.Warlock]: warlockIcon,
-  [DestinyClass.Titan]: titanIcon
+  [DestinyClass.Titan]: titanIcon,
 };
 
 /**
@@ -105,7 +105,7 @@ class StoreBucket extends React.Component<Props> {
                 className="pull-item-button"
                 title={t('MovePopup.PullItem', {
                   bucket: bucket.name,
-                  store: store.name
+                  store: store.name,
                 })}
               >
                 <AppIcon icon={addIcon} />
@@ -141,8 +141,8 @@ class StoreBucket extends React.Component<Props> {
           item.bucket.hash === bucket.hash && item.canBeEquippedBy(store),
         prompt: t('MovePopup.PullItem', {
           bucket: bucket.name,
-          store: store.name
-        })
+          store: store.name,
+        }),
       });
 
       moveItemTo(item, store, equip, item.amount);

--- a/src/app/inventory/StoreBucketDropTarget.tsx
+++ b/src/app/inventory/StoreBucketDropTarget.tsx
@@ -4,7 +4,7 @@ import {
   DropTargetSpec,
   DropTargetConnector,
   DropTargetMonitor,
-  ConnectDropTarget
+  ConnectDropTarget,
 } from 'react-dnd';
 import clsx from 'clsx';
 import { InventoryBucket } from './inventory-buckets';
@@ -51,7 +51,7 @@ const dropSpec: DropTargetSpec<Props> = {
     // But equipping has requirements
     const item = monitor.getItem().item as DimItem;
     return item.canBeEquippedBy(props.store);
-  }
+  },
 };
 
 // This forwards drag and drop state into props on the component
@@ -64,7 +64,7 @@ function collect(connect: DropTargetConnector, monitor: DropTargetMonitor): Inte
     // You can ask the monitor about the current drag state:
     isOver: monitor.isOver(),
     canDrop: monitor.canDrop(),
-    item: item && (item.item as DimItem)
+    item: item && (item.item as DimItem),
   };
 }
 
@@ -83,7 +83,7 @@ class StoreBucketDropTarget extends React.Component<Props> {
         ref={this.captureRef}
         className={clsx('sub-bucket', className, equip ? 'equipped' : 'unequipped', {
           'on-drag-hover': canDrop && isOver,
-          'on-drag-enter': canDrop
+          'on-drag-enter': canDrop,
         })}
         onClick={this.onClick}
         aria-label={bucket.name}

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -12,7 +12,7 @@ export function StoreBuckets({
   bucket,
   stores,
   vault,
-  currentStore
+  currentStore,
 }: {
   bucket: InventoryBucket;
   stores: DimStore[];
@@ -53,7 +53,7 @@ export function StoreBuckets({
         className={clsx('store-cell', {
           vault: store.isVault,
           postmasterFull:
-            bucket.sort === 'Postmaster' && store.isDestiny2() && postmasterAlmostFull(store)
+            bucket.sort === 'Postmaster' && store.isDestiny2() && postmasterAlmostFull(store),
         })}
         style={storeBackgroundColor(store, index)}
       >

--- a/src/app/inventory/StoreHeading.tsx
+++ b/src/app/inventory/StoreHeading.tsx
@@ -89,7 +89,7 @@ export default class StoreHeading extends React.Component<Props, State> {
       <div className={clsx('character', { current: store.current })}>
         <div
           className={clsx('character-box', {
-            destiny2: store.isDestiny2()
+            destiny2: store.isDestiny2(),
           })}
           aria-label={store.name}
           onClick={this.openLoadoutPopup}
@@ -120,7 +120,7 @@ export default class StoreHeading extends React.Component<Props, State> {
               <div className="level-bar">
                 <div
                   className={clsx('level-bar-progress', {
-                    'mote-progress': !store.percentToNextLevel
+                    'mote-progress': !store.percentToNextLevel,
                   })}
                   style={{ width: percent(levelBar) }}
                 />
@@ -156,13 +156,13 @@ function getLevelBar(store: DimStore) {
   if (store.isDestiny2()) {
     return {
       levelBar: 0,
-      xpTillMote: undefined
+      xpTillMote: undefined,
     };
   }
   if (store.percentToNextLevel) {
     return {
       levelBar: store.percentToNextLevel,
-      xpTillMote: undefined
+      xpTillMote: undefined,
     };
   }
   if (store.progression?.progressions) {
@@ -170,16 +170,16 @@ function getLevelBar(store: DimStore) {
     if (prestige) {
       const data = {
         level: prestige.level,
-        exp: prestige.nextLevelAt - prestige.progressToNextLevel
+        exp: prestige.nextLevelAt - prestige.progressToNextLevel,
       };
       return {
         xpTillMote: t('Stats.Prestige', data),
-        levelBar: prestige.progressToNextLevel / prestige.nextLevelAt
+        levelBar: prestige.progressToNextLevel / prestige.nextLevelAt,
       };
     }
   }
   return {
     levelBar: 0,
-    xpTillMote: undefined
+    xpTillMote: undefined,
   };
 }

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -30,7 +30,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     stores: sortedStoresSelector(state),
     buckets: state.inventory.buckets!,
-    isPhonePortrait: state.shell.isPhonePortrait
+    isPhonePortrait: state.shell.isPhonePortrait,
   };
 }
 
@@ -182,7 +182,7 @@ function StoresInventory({
   buckets,
   stores,
   currentStore,
-  vault
+  vault,
 }: {
   buckets: InventoryBuckets;
   stores: DimStore[];

--- a/src/app/inventory/VaultStats.tsx
+++ b/src/app/inventory/VaultStats.tsx
@@ -13,7 +13,7 @@ const bucketIcons = {
   3313201758: modificationsIcon,
   2973005342: shadersIcon,
   1469714392: consumablesIcon,
-  138197802: vaultIcon
+  138197802: vaultIcon,
 };
 const vaultBucketOrder = [
   // D1
@@ -25,7 +25,7 @@ const vaultBucketOrder = [
   138197802,
   1469714392,
   3313201758,
-  2973005342
+  2973005342,
 ];
 
 export default function VaultStats({ store }: { store: DimVault }) {
@@ -64,7 +64,7 @@ export default function VaultStats({ store }: { store: DimVault }) {
             title={store.vaultCounts[bucketId].bucket.name}
             className={clsx({
               [styles.full]:
-                store.vaultCounts[bucketId].count === store.vaultCounts[bucketId].bucket.capacity
+                store.vaultCounts[bucketId].count === store.vaultCounts[bucketId].bucket.capacity,
             })}
           >
             {store.vaultCounts[bucketId].count}/{store.vaultCounts[bucketId].bucket.capacity}

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -4,7 +4,7 @@ import {
   AwaAuthorizationResult,
   AwaUserSelection,
   insertSocketPlug,
-  DestinySocketArrayType
+  DestinySocketArrayType,
 } from 'bungie-api-ts/destiny2';
 import { requestAdvancedWriteActionToken } from '../bungie-api/destiny2-api';
 import { get, set } from 'idb-keyval';
@@ -35,10 +35,10 @@ export async function insertPlug(
     plug: {
       socketIndex: socket.socketIndex,
       socketArrayType: DestinySocketArrayType.Default,
-      plugItemHash
+      plugItemHash,
     },
     characterId: item.owner,
-    membershipType: account.originalPlatformType
+    membershipType: account.originalPlatformType,
   });
 
   // TODO: need to update the item after modifying, and signal that it has changed (Redux?)
@@ -69,12 +69,12 @@ export async function getAwaToken(
       showNotification({
         type: 'info',
         title: t('AWA.ConfirmTitle'),
-        body: t('AWA.ConfirmDescription')
+        body: t('AWA.ConfirmDescription'),
       });
 
       info = awaCache[action] = {
         ...(await requestAdvancedWriteActionToken(account, action, item)),
-        used: 0
+        used: 0,
       };
 
       // Deletes of "group A" require an item and shouldn't be cached

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -49,7 +49,7 @@ function StoreService(): D1StoreServiceType {
   const service = {
     getStores: () => storesSelector(store.getState()) as D1Store[],
     getStoresStream,
-    reloadStores
+    reloadStores,
   };
 
   return service;
@@ -96,7 +96,7 @@ function StoreService(): D1StoreServiceType {
       getBuckets(),
       store.dispatch(loadNewItems(account)),
       store.dispatch(loadItemInfos(account)),
-      getStores(account)
+      getStores(account),
     ])
       .then(([defs, buckets, , , rawStores]) => {
         const lastPlayedDate = findLastPlayedDate(rawStores);
@@ -195,7 +195,7 @@ function StoreService(): D1StoreServiceType {
         const vaultBucketOrder = [
           4046403665, // Weapons
           3003523923, // Armor
-          138197802 // General
+          138197802, // General
         ];
 
         _.sortBy(
@@ -205,7 +205,7 @@ function StoreService(): D1StoreServiceType {
           const vaultBucketId = bucket.vaultBucket!.hash;
           vault.vaultCounts[vaultBucketId] = vault.vaultCounts[vaultBucketId] || {
             count: 0,
-            bucket: bucket.accountWide ? bucket : bucket.vaultBucket
+            bucket: bucket.accountWide ? bucket : bucket.vaultBucket,
           };
           vault.vaultCounts[vaultBucketId].count += store.buckets[bucket.hash].length;
         });

--- a/src/app/inventory/d2-season-info.ts
+++ b/src/app/inventory/d2-season-info.ts
@@ -8,7 +8,7 @@ export enum D2SeasonEnum {
   PENUMBRA,
   SHADOWKEEP,
   DAWN,
-  WORTHY
+  WORTHY,
 }
 
 // TODO: Update on season change
@@ -25,7 +25,7 @@ export const D2SeasonInfo = {
     softCap: 0,
     releaseDate: '2017-09-06',
     resetTime: '09:00:00Z',
-    numWeeks: 0
+    numWeeks: 0,
   },
   1: {
     DLCName: 'Red War',
@@ -37,7 +37,7 @@ export const D2SeasonInfo = {
     softCap: 285,
     releaseDate: '2017-09-06',
     resetTime: '09:00:00Z',
-    numWeeks: 13
+    numWeeks: 13,
   },
   2: {
     DLCName: 'Curse of Osiris',
@@ -49,7 +49,7 @@ export const D2SeasonInfo = {
     softCap: 320,
     releaseDate: '2017-12-05',
     resetTime: '17:00:00Z',
-    numWeeks: 22
+    numWeeks: 22,
   },
   3: {
     DLCName: 'Warmind',
@@ -61,7 +61,7 @@ export const D2SeasonInfo = {
     softCap: 340,
     releaseDate: '2018-05-08',
     resetTime: '18:00:00Z',
-    numWeeks: 17
+    numWeeks: 17,
   },
   4: {
     DLCName: 'Forsaken',
@@ -73,7 +73,7 @@ export const D2SeasonInfo = {
     softCap: 500,
     releaseDate: '2018-09-04',
     resetTime: '17:00:00Z',
-    numWeeks: 13
+    numWeeks: 13,
   },
   5: {
     DLCName: 'Black Armory',
@@ -85,7 +85,7 @@ export const D2SeasonInfo = {
     softCap: 500,
     releaseDate: '2018-11-27',
     resetTime: '17:00:00Z',
-    numWeeks: 12
+    numWeeks: 12,
   },
   6: {
     DLCName: "Joker's Wild",
@@ -97,7 +97,7 @@ export const D2SeasonInfo = {
     softCap: 500,
     releaseDate: '2019-03-05',
     resetTime: '17:00:00Z',
-    numWeeks: 14
+    numWeeks: 14,
   },
   7: {
     DLCName: 'Penumbra',
@@ -109,7 +109,7 @@ export const D2SeasonInfo = {
     softCap: 500,
     releaseDate: '2019-06-04',
     resetTime: '17:00:00Z',
-    numWeeks: 13
+    numWeeks: 13,
   },
   8: {
     DLCName: 'Shadowkeep',
@@ -121,7 +121,7 @@ export const D2SeasonInfo = {
     softCap: 900,
     releaseDate: '2019-10-01',
     resetTime: '17:00:00Z',
-    numWeeks: 10
+    numWeeks: 10,
   },
   9: {
     DLCName: '',
@@ -133,7 +133,7 @@ export const D2SeasonInfo = {
     softCap: 900,
     releaseDate: '2019-12-10',
     resetTime: '17:00:00Z',
-    numWeeks: 13
+    numWeeks: 13,
   },
   10: {
     DLCName: '',
@@ -145,8 +145,8 @@ export const D2SeasonInfo = {
     softCap: 950,
     releaseDate: '2020-03-10',
     resetTime: '17:00:00Z',
-    numWeeks: 13
-  }
+    numWeeks: 13,
+  },
 };
 
 function enumLength(enumName: object): number {

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -6,7 +6,7 @@ import {
   DestinyProfileCollectiblesComponent,
   DestinyProfileResponse,
   DestinyCollectibleComponent,
-  DestinyItemComponent
+  DestinyItemComponent,
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -76,7 +76,7 @@ export function updateCharacters(): ThunkResult {
             background: bungieNetPath(character.emblemBackgroundPath),
             icon: bungieNetPath(character.emblemPath),
             stats: getCharacterStatsData(getState().manifest.d2Manifest!, character.stats),
-            color: character.emblemColor
+            color: character.emblemColor,
           }))
         : [];
     } else {
@@ -91,7 +91,7 @@ export function updateCharacters(): ThunkResult {
         stats: getD1CharacterStatsData(
           getState().manifest.d1Manifest!,
           character.base.characterBase
-        )
+        ),
       }));
     }
 
@@ -104,7 +104,7 @@ export function mergeCollectibles(
   characterCollectibles: DictionaryComponentResponse<DestinyCollectiblesComponent>
 ) {
   const allCollectibles = {
-    ...profileCollectibles.data?.collectibles
+    ...profileCollectibles.data?.collectibles,
   };
 
   _.forIn(characterCollectibles.data || {}, ({ collectibles }) => {
@@ -148,7 +148,7 @@ function makeD2StoresService(): D2StoreServiceType {
   const service = {
     getStores: () => storesSelector(store.getState()) as D2Store[],
     getStoresStream,
-    reloadStores
+    reloadStores,
   };
 
   return service;
@@ -196,7 +196,7 @@ function makeD2StoresService(): D2StoreServiceType {
         getBuckets(),
         store.dispatch(loadNewItems(account)),
         store.dispatch(loadItemInfos(account)),
-        getStores(account)
+        getStores(account),
       ]);
       console.time('Process inventory');
 
@@ -389,7 +389,7 @@ function makeD2StoresService(): D2StoreServiceType {
         const vaultBucketId = bucket.vaultBucket.hash;
         store.vaultCounts[vaultBucketId] = store.vaultCounts[vaultBucketId] || {
           count: 0,
-          bucket: bucket.accountWide ? bucket : bucket.vaultBucket
+          bucket: bucket.accountWide ? bucket : bucket.vaultBucket,
         };
         store.vaultCounts[vaultBucketId].count += store.buckets[bucket.hash].length;
       }
@@ -429,7 +429,7 @@ function makeD2StoresService(): D2StoreServiceType {
         hasClassified,
         description: def.displayProperties.description,
         value: maxBasePower,
-        icon: helmetIcon
+        icon: helmetIcon,
       };
 
       const artifactPower = getArtifactBonus(store);
@@ -439,7 +439,7 @@ function makeD2StoresService(): D2StoreServiceType {
         hasClassified: false,
         description: def.displayProperties.description,
         value: artifactPower,
-        icon: xpIcon
+        icon: xpIcon,
       };
 
       store.stats.maxTotalPower = {
@@ -448,7 +448,7 @@ function makeD2StoresService(): D2StoreServiceType {
         hasClassified,
         description: def.displayProperties.description,
         value: maxBasePower + artifactPower,
-        icon: bungieNetPath(def.displayProperties.icon)
+        icon: bungieNetPath(def.displayProperties.icon),
       };
     }
   }
@@ -462,7 +462,7 @@ function makeD2StoresService(): D2StoreServiceType {
         const vaultBucketId = bucket.hash;
         vault.vaultCounts[vaultBucketId] = vault.vaultCounts[vaultBucketId] || {
           count: 0,
-          bucket
+          bucket,
         };
         vault.vaultCounts[vaultBucketId].count += activeStore.buckets[bucket.hash].length;
       }

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -21,36 +21,36 @@ export const tagConfig = {
     label: 'Tags.Favorite',
     sortOrder: 0,
     hotkey: 'shift+1',
-    icon: heartIcon
+    icon: heartIcon,
   },
   keep: {
     type: 'keep' as const,
     label: 'Tags.Keep',
     sortOrder: 1,
     hotkey: 'shift+2',
-    icon: tagIcon
+    icon: tagIcon,
   },
   infuse: {
     type: 'infuse' as const,
     label: 'Tags.Infuse',
     sortOrder: 2,
     hotkey: 'shift+4',
-    icon: boltIcon
+    icon: boltIcon,
   },
   junk: {
     type: 'junk' as const,
     label: 'Tags.Junk',
     sortOrder: 3,
     hotkey: 'shift+3',
-    icon: banIcon
+    icon: banIcon,
   },
   archive: {
     type: 'archive' as const,
     label: 'Tags.Archive',
     sortOrder: 4,
     hotkey: 'shift+5',
-    icon: archiveIcon
-  }
+    icon: archiveIcon,
+  },
 };
 
 export type TagValue = keyof typeof tagConfig | 'clear' | 'lock' | 'unlock';
@@ -78,7 +78,7 @@ export const characterDisplacePriority: (TagValue | 'none')[] = [
   'junk',
   'keep',
   // Favorites you probably want to keep on your character
-  'favorite'
+  'favorite',
 ];
 
 /**
@@ -96,7 +96,7 @@ export const vaultDisplacePriority: (TagValue | 'none')[] = [
   // Infusion fuel belongs in the vault
   'infuse',
   // Archived items should absolutely stay in the vault
-  'archive'
+  'archive',
 ];
 
 /**
@@ -128,7 +128,7 @@ export const itemTagList: TagInfo[] = Object.values(tagConfig);
 // t(Tags.TagItem) is the dropdown selector text hint for untagged things
 export const itemTagSelectorList: TagInfo[] = [
   { label: 'Tags.TagItem' },
-  ...Object.values(tagConfig)
+  ...Object.values(tagConfig),
 ];
 
 /**

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -5,13 +5,13 @@ import {
   equip as d1equip,
   equipItems as d1EquipItems,
   transfer as d1Transfer,
-  setItemState as d1SetItemState
+  setItemState as d1SetItemState,
 } from '../bungie-api/destiny1-api';
 import {
   equip as d2equip,
   equipItems as d2EquipItems,
   transfer as d2Transfer,
-  setLockState as d2SetLockState
+  setLockState as d2SetLockState,
 } from '../bungie-api/destiny2-api';
 import { chainComparator, compareBy, reverseComparator } from '../utils/comparators';
 import { createItemIndex as d2CreateItemIndex } from './store/d2-item-factory';
@@ -27,7 +27,7 @@ import {
   getTag,
   vaultDisplacePriority,
   characterDisplacePriority,
-  ItemInfos
+  ItemInfos,
 } from './dim-item-info';
 import reduxStore from '../store/store';
 import { count } from 'app/utils/util';
@@ -102,17 +102,17 @@ function ItemService(): ItemServiceType {
   // throttle these calls so we don't just keep refreshing over and over.
   // This needs to be up here because of how we return the service object.
   const throttledReloadStores = _.throttle(() => D1StoresService.reloadStores(), 10000, {
-    trailing: false
+    trailing: false,
   });
 
   const throttledD2ReloadStores = _.throttle(() => D2StoresService.reloadStores(), 10000, {
-    trailing: false
+    trailing: false,
   });
 
   return {
     getSimilarItem,
     moveTo,
-    equipItems
+    equipItems,
   };
 
   function equipApi(item: DimItem): (item: DimItem) => Promise<any> {
@@ -326,7 +326,7 @@ function ItemService(): ItemServiceType {
         Rare: 3,
         Uncommon: 2,
         Common: 1,
-        Exotic: 0
+        Exotic: 0,
       }[i.tier];
       if (item.isExotic && i.isExotic) {
         value += 5;
@@ -507,7 +507,7 @@ function ItemService(): ItemServiceType {
           t('ItemService.ExoticError', {
             itemname: item.name,
             slot: otherExotic.type,
-            error: e.message
+            error: e.message,
           })
         );
       }
@@ -634,7 +634,7 @@ function ItemService(): ItemServiceType {
     if (stackable && otherStore) {
       return {
         item: stackable,
-        target: otherStore
+        target: otherStore,
       };
     }
 
@@ -684,7 +684,7 @@ function ItemService(): ItemServiceType {
           if (candidate.amount <= spaceLeft) {
             moveAsideCandidate = {
               item: candidate,
-              target: targetStore
+              target: targetStore,
             };
             return true;
           }
@@ -703,7 +703,7 @@ function ItemService(): ItemServiceType {
           if (openVaultSlotsBeforeMove === 1 && openVaultSlotsAfterMove === 0 && spaceLeft) {
             moveAsideCandidate = {
               item: candidate,
-              target: targetStore
+              target: targetStore,
             };
             return true;
           }
@@ -718,7 +718,7 @@ function ItemService(): ItemServiceType {
     if (!moveAsideCandidate && !store.isVault) {
       moveAsideCandidate = {
         item: moveAsideCandidates[0],
-        target: vault
+        target: vault,
       };
     }
 
@@ -818,7 +818,7 @@ function ItemService(): ItemServiceType {
             left = left - storeReservations[s.id];
           }
           return Math.max(0, left);
-        }
+        },
       };
 
       // Move starting from the vault (which is always last)
@@ -845,7 +845,7 @@ function ItemService(): ItemServiceType {
         const errorData = {
           itemtype,
           store: moveAsideTarget.name,
-          context: moveAsideTarget.genderName
+          context: moveAsideTarget.genderName,
         };
 
         const error: DimError = new Error(
@@ -907,7 +907,7 @@ function ItemService(): ItemServiceType {
           ? t('ItemService.OnlyEquippedLevel', { level: item.equipRequiredLevel })
           : t('ItemService.OnlyEquippedClassLevel', {
               class: item.classTypeNameLocalized.toLowerCase(),
-              level: item.equipRequiredLevel
+              level: item.equipRequiredLevel,
             });
 
       const error: DimError = new Error(message);
@@ -1024,7 +1024,7 @@ export function sortMoveAsideCandidatesForStore(
     Uncommon: 1,
     Rare: 2,
     Legendary: 4,
-    Exotic: 3
+    Exotic: 3,
   };
 
   // A sort for items to use for ranking *which item to move*

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -16,7 +16,7 @@ import {
   DestinyItemSocketEntryDefinition,
   DestinyItemPlugBase,
   DestinyDamageTypeDefinition,
-  DestinyEnergyTypeDefinition
+  DestinyEnergyTypeDefinition,
 } from 'bungie-api-ts/destiny2';
 import { DimStore, StoreServiceType, D1StoreServiceType, D2StoreServiceType } from './store-types';
 import { InventoryBucket } from './inventory-buckets';

--- a/src/app/inventory/move-dropped-item.ts
+++ b/src/app/inventory/move-dropped-item.ts
@@ -38,7 +38,7 @@ export function showMoveAmountPopup(
       amount: item.amount,
       maximum,
       onAmountSelected: resolve,
-      onCancel: reject
+      onCancel: reject,
     });
   });
 }

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -138,13 +138,13 @@ export const distribute = queuedAction(
         vaultMoves.push({
           source: stores[index],
           target: vault,
-          amount: -delta
+          amount: -delta,
         });
       } else if (delta > 0) {
         targetMoves.push({
           source: vault,
           target: stores[index],
-          amount: delta
+          amount: delta,
         });
       }
     });
@@ -162,7 +162,7 @@ export const distribute = queuedAction(
       await applyMoves(targetMoves);
       showNotification({
         type: 'success',
-        title: t('ItemMove.Distributed', { name: actionableItem.name })
+        title: t('ItemMove.Distributed', { name: actionableItem.name }),
       });
     } catch (a) {
       showNotification({ type: 'error', title: actionableItem.name, body: a.message });

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -92,7 +92,7 @@ const initialState: InventoryState = {
   newItems: new Set(),
   newItemsLoaded: false,
   itemInfos: {},
-  isDraggingStack: false
+  isDraggingStack: false,
 };
 
 export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction> = (
@@ -107,7 +107,7 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
       return {
         ...state,
         // Make a new array to break change detection for the root stores components
-        stores: [...state.stores]
+        stores: [...state.stores],
       };
 
     case getType(actions.charactersUpdated):
@@ -118,13 +118,13 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.setBuckets):
       return {
         ...state,
-        buckets: action.payload
+        buckets: action.payload,
       };
 
     case getType(actions.error):
       return {
         ...state,
-        profileError: action.payload
+        profileError: action.payload,
       };
 
     // *** New items ***
@@ -133,7 +133,7 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
       return {
         ...state,
         newItems: action.payload,
-        newItemsLoaded: true
+        newItemsLoaded: true,
       };
 
     case getType(actions.clearNewItem):
@@ -143,7 +143,7 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
 
         return {
           ...state,
-          newItems
+          newItems,
         };
       } else {
         return state;
@@ -152,7 +152,7 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.clearAllNewItems):
       return {
         ...state,
-        newItems: new Set()
+        newItems: new Set(),
       };
 
     // *** Tags and notes ***
@@ -160,7 +160,7 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.tagsAndNotesLoaded):
       return {
         ...state,
-        itemInfos: action.payload
+        itemInfos: action.payload,
       };
 
     case getType(actions.setItemTag):
@@ -191,7 +191,7 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.stackableDrag):
       return {
         ...state,
-        isDraggingStack: action.payload
+        isDraggingStack: action.payload,
       };
 
     case getType(setCurrentAccount):
@@ -207,7 +207,7 @@ function updateInventory(
   {
     stores,
     buckets,
-    profileResponse
+    profileResponse,
   }: {
     stores: DimStore[];
     buckets?: InventoryBuckets | undefined;
@@ -220,7 +220,7 @@ function updateInventory(
     ...state,
     stores,
     newItems: computeNewItems(state.stores, state.newItems, stores),
-    profileError: undefined
+    profileError: undefined,
   };
   if (buckets) {
     newState.buckets = buckets;
@@ -251,11 +251,11 @@ function updateCharacters(state: InventoryState, characters: actions.CharacterIn
           ...characterInfo,
           stats: {
             ...store.stats,
-            ...characterInfo.stats
-          }
+            ...characterInfo.stats,
+          },
         }
       );
-    })
+    }),
   };
 }
 
@@ -264,7 +264,7 @@ function setTag(draft: Draft<InventoryState>, itemId: string, tag?: TagValue) {
   if (tag) {
     if (!existingTag) {
       draft.itemInfos[itemId] = {
-        tag
+        tag,
       };
     } else {
       existingTag.tag = tag;
@@ -282,7 +282,7 @@ function setNote(draft: Draft<InventoryState>, itemId: string, notes?: string) {
   if (notes && notes.length > 0) {
     if (!existingTag) {
       draft.itemInfos[itemId] = {
-        notes
+        notes,
       };
     } else {
       existingTag.notes = notes;

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -39,7 +39,7 @@ const FILTER_NODE_NAMES = [
   'Default Shader',
   'Default Ornament',
   'Empty Mod Socket',
-  'No Projection'
+  'No Projection',
 ];
 
 // ignore raid sources in favor of more detailed sources
@@ -119,7 +119,7 @@ export function importTagsNotesFromCsv(files: File[]): ThunkResult<any> {
         Papa.parse(file, {
           header: true,
           complete: resolve,
-          error: reject
+          error: reject,
         })
       );
       if (
@@ -149,7 +149,7 @@ export function importTagsNotesFromCsv(files: File[]): ThunkResult<any> {
                 row.Id = row.Id.replace(/"/g, ''); // strip quotes from row.Id
                 return {
                   tag: row.Tag in tagConfig ? tagConfig[row.Tag].type : undefined,
-                  itemId: row.Id
+                  itemId: row.Id,
                 };
               }
             })
@@ -164,7 +164,7 @@ export function importTagsNotesFromCsv(files: File[]): ThunkResult<any> {
           dispatch(
             setItemNote({
               note: row.Notes,
-              itemId: row.Id
+              itemId: row.Id,
             })
           );
         }
@@ -257,7 +257,7 @@ function downloadGhost(items: DimItem[], nameMap: { [key: string]: string }, ite
       Owner: nameMap[item.owner],
       Locked: item.locked,
       Equipped: item.equipped,
-      Notes: getNotes(item, itemInfos)
+      Notes: getNotes(item, itemInfos),
     };
 
     addPerks(row, item, maxPerks);
@@ -291,7 +291,7 @@ export const armorStatHashes = {
   Discipline: 1735777505,
   Intellect: 144602215,
   Strength: 4244567218,
-  Total: -1000
+  Total: -1000,
 };
 
 function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, itemInfos: ItemInfos) {
@@ -308,7 +308,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
       Type: item.typeName,
       Source: source(item),
       Equippable: equippable(item),
-      [item.isDestiny1() ? 'Light' : 'Power']: item.primStat?.value
+      [item.isDestiny1() ? 'Light' : 'Power']: item.primStat?.value,
     };
     if (item.isDestiny2()) {
       row['Masterwork Type'] = item.masterworkInfo?.statName;
@@ -360,7 +360,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
         stats[stat.statHash] = {
           value: stat.value,
           pct,
-          base: 0
+          base: 0,
         };
       });
     } else if (item.isDestiny2() && item.stats) {
@@ -368,7 +368,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
         stats[stat.statHash] = {
           value: stat.value,
           base: stat.base,
-          pct: 0
+          pct: 0,
         };
       });
     }
@@ -382,7 +382,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
     } else {
       const armorStats = Object.keys(armorStatHashes).map((statName) => ({
         name: statName,
-        stat: stats[armorStatHashes[statName]]
+        stat: stats[armorStatHashes[statName]],
       }));
       armorStats.forEach((stat) => {
         row[stat.name] = stat.stat ? stat.stat.value : 0;
@@ -428,7 +428,7 @@ function downloadWeapons(
       Source: source(item),
       [item.isDestiny1() ? 'Light' : 'Power']: item.primStat?.value,
       Category: item.bucket.type,
-      Element: item.element?.displayProperties.name
+      Element: item.element?.displayProperties.name,
     };
     if (item.isDestiny2()) {
       row['Masterwork Type'] = item.masterworkInfo?.statName;
@@ -478,7 +478,7 @@ function downloadWeapons(
       accuracy: 0,
       recoil: 0,
       blastRadius: 0,
-      velocity: 0
+      velocity: 0,
     };
 
     if (item.stats) {

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -3,7 +3,7 @@ import {
   DestinyProgression,
   DestinyFactionDefinition,
   DestinyColor,
-  DestinyDisplayPropertiesDefinition
+  DestinyDisplayPropertiesDefinition,
 } from 'bungie-api-ts/destiny2';
 import { DimItem, D2Item, D1Item } from './item-types';
 import { DestinyAccount } from '../accounts/destiny-account';

--- a/src/app/inventory/store/armor-quality.ts
+++ b/src/app/inventory/store/armor-quality.ts
@@ -52,16 +52,16 @@ export function getQualityRating(
   const ret = {
     total: {
       min: 0,
-      max: 0
+      max: 0,
     },
-    max: split * 2
+    max: split * 2,
   };
 
   let pure = 0;
   stats.forEach((stat) => {
     let scaled = {
       min: 0,
-      max: 0
+      max: 0,
     };
     if (stat.base) {
       scaled = getScaledStat(stat.base, light.value);
@@ -72,7 +72,7 @@ export function getQualityRating(
     stat.qualityPercentage = {
       range: '',
       min: Math.round((100 * stat.scaled.min) / stat.split),
-      max: Math.round((100 * stat.scaled.max) / stat.split)
+      max: Math.round((100 * stat.scaled.max) / stat.split),
     };
     ret.total.min += scaled.min || 0;
     ret.total.max += scaled.max || 0;
@@ -83,13 +83,13 @@ export function getQualityRating(
       if (stat.scaled) {
         stat.scaled = {
           min: Math.floor(stat.scaled.min / 2),
-          max: Math.floor(stat.scaled.max / 2)
+          max: Math.floor(stat.scaled.max / 2),
         };
         if (stat.split) {
           stat.qualityPercentage = {
             range: '',
             min: Math.round((100 * stat.scaled.min) / stat.split),
-            max: Math.round((100 * stat.scaled.max) / stat.split)
+            max: Math.round((100 * stat.scaled.max) / stat.split),
           };
         }
       }
@@ -99,7 +99,7 @@ export function getQualityRating(
   let quality = {
     min: Math.round((ret.total.min / ret.max) * 100),
     max: Math.round((ret.total.max / ret.max) * 100),
-    range: ''
+    range: '',
   };
 
   if (type.toLowerCase() !== 'artifact') {
@@ -108,14 +108,14 @@ export function getQualityRating(
         stat.qualityPercentage = {
           range: '',
           min: Math.min(100, stat.qualityPercentage.min),
-          max: Math.min(100, stat.qualityPercentage.max)
+          max: Math.min(100, stat.qualityPercentage.max),
         };
       }
     });
     quality = {
       min: Math.min(100, quality.min),
       max: Math.min(100, quality.max),
-      range: ''
+      range: '',
     };
   }
 
@@ -163,6 +163,6 @@ function getScaledStat(base, light) {
 
   return {
     min: Math.floor(base * (fitValue(max) / fitValue(light))),
-    max: Math.floor((base + 1) * (fitValue(max) / fitValue(light)))
+    max: Math.floor((base + 1) * (fitValue(max) / fitValue(light))),
   };
 }

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -81,7 +81,7 @@ export function getBonus(light: number, type: string): number {
 export const statsWithTiers = [
   1735777505, // Discipline
   144602215, // Intellect
-  4244567218 // Strength
+  4244567218, // Strength
 ];
 export function getD1CharacterStatTiers(stat: DimCharacterStat) {
   if (!statsWithTiers.includes(stat.hash)) {
@@ -101,7 +101,7 @@ const stats = [
   'STAT_STRENGTH',
   'STAT_ARMOR',
   'STAT_RECOVERY',
-  'STAT_AGILITY'
+  'STAT_AGILITY',
 ];
 
 /**
@@ -119,7 +119,7 @@ export function getCharacterStatsData(defs: D1ManifestDefinitions, data) {
       hash: rawStat.statHash,
       value: rawStat.value,
       name: '',
-      description: ''
+      description: '',
     };
 
     switch (statId) {

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -14,14 +14,14 @@ import {
   DestinyClass,
   DestinyDisplayPropertiesDefinition,
   DestinyDamageTypeDefinition,
-  DestinyAmmunitionType
+  DestinyAmmunitionType,
 } from 'bungie-api-ts/destiny2';
 
 const yearHashes = {
   //         tTK       Variks        CoE         FoTL    Kings Fall
   year2: [2659839637, 512830513, 1537575125, 3475869915, 1662673928],
   //         RoI       WoTM         FoTl       Dawning    Raid Reprise
-  year3: [2964550958, 4160622434, 3475869915, 3131490494, 4161861381]
+  year3: [2964550958, 4160622434, 3475869915, 3131490494, 4161861381],
 };
 
 // Maps tierType to tierTypeName in English
@@ -35,7 +35,7 @@ const _moveTouchTimestamps = new Map<string, number>();
 const factionNodes = {
   652505621: 'New Monarchy',
   2669659850: 'Future War Cult',
-  2794386410: 'Dead Orbit'
+  2794386410: 'Dead Orbit',
 };
 
 /**
@@ -95,7 +95,7 @@ const ItemProto = {
   },
   getStoresService() {
     return D1StoresService;
-  }
+  },
 };
 
 export function resetIdTracker() {
@@ -178,14 +178,14 @@ const toD2DamageType = _.memoize(
         icon: damageType.iconPath,
         hasIcon: true,
         highResIcon: '',
-        iconSequences: []
+        iconSequences: [],
       },
       transparentIconPath: damageType.transparentIconPath,
       hash: damageType.hash,
       showIcon: damageType.showIcon,
       enumValue: damageType.enumValue,
       index: damageType.index,
-      redacted: damageType.redacted
+      redacted: damageType.redacted,
     }
 );
 
@@ -210,7 +210,7 @@ function makeItem(
     // maybe it is redacted...
     itemDef = {
       itemName: 'Missing Item',
-      redacted: true
+      redacted: true,
     };
   }
 
@@ -257,7 +257,7 @@ function makeItem(
             maximum: defaultMinMax.maximum,
             minimum: defaultMinMax.minimum,
             statHash: val,
-            value: 0
+            value: 0,
           };
         }
       });
@@ -373,7 +373,7 @@ function makeItem(
     stats: null, // filled in later
     objectives: null, // filled in later
     quality: null, // filled in later
-    dtrRating: null
+    dtrRating: null,
   });
 
   // *able
@@ -398,7 +398,7 @@ function makeItem(
       name: statDef.statName,
       description: statDef.statDescription,
       icon: statDef.icon,
-      hasIcon: Boolean(statDef.icon)
+      hasIcon: Boolean(statDef.icon),
     };
   }
 
@@ -651,7 +651,7 @@ function buildTalentGrid(item, talentDefs, progressDefs): D1TalentGrid | null {
       hidden: node.hidden,
 
       dtrHash,
-      dtrRoll
+      dtrRoll,
 
       // Whether (and in which order) this perk should be
       // "featured" on an abbreviated info panel, as in the
@@ -714,7 +714,7 @@ function buildTalentGrid(item, talentDefs, progressDefs): D1TalentGrid | null {
     dtrRoll: _.compact(gridNodes.map((i) => i.dtrRoll)).join(';'),
     complete:
       totalXPRequired <= totalXP &&
-      _.every(gridNodes, (n: any) => n.unlocked || (n.xpRequired === 0 && n.column === maxColumn))
+      _.every(gridNodes, (n: any) => n.unlocked || (n.xpRequired === 0 && n.column === maxColumn)),
   };
 }
 
@@ -831,14 +831,14 @@ function buildStats(item, itemDef, statDefs, grid: D1TalentGrid | null, type): D
           statHash: stat.statHash,
           displayProperties: {
             name: def.statName,
-            description: def.statDescription
+            description: def.statDescription,
           } as DestinyDisplayPropertiesDefinition,
           sort,
           value: val,
           maximumValue,
           bar: identifier !== 'STAT_MAGAZINE_SIZE' && identifier !== 'STAT_ATTACK_ENERGY', // energy == magazine for swords
           smallerIsBetter: [447667954, 2961396640].includes(stat.statHash),
-          additive: item.primaryStat.stat.statIdentifier === 'STAT_DEFENSE'
+          additive: item.primaryStat.stat.statIdentifier === 'STAT_DEFENSE',
         };
 
         return dimStat;

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -23,13 +23,13 @@ const progressionMeta = {
   807090922: { label: "Queen's Wrath", order: 8 },
   3641985238: { label: 'House of Judgment', order: 9 },
   2335631936: { label: 'Gunsmith', order: 10 },
-  2576753410: { label: 'SRL', order: 11 }
+  2576753410: { label: 'SRL', order: 11 },
 };
 
 const factionBadges = {
   969832704: 'Future War Cult',
   27411484: 'Dead Orbit',
-  2954371221: 'New Monarchy'
+  2954371221: 'New Monarchy',
 };
 
 /**
@@ -129,7 +129,7 @@ export const StoreProto = {
 
   getStoresService() {
     return D1StoresService;
-  }
+  },
 };
 
 export function makeCharacter(
@@ -154,8 +154,8 @@ export function makeCharacter(
               name: itemDef.itemName,
               description: itemDef.itemDescription,
               icon: itemDef.icon,
-              hasIcon: Boolean(itemDef.icon)
-            }
+              hasIcon: Boolean(itemDef.icon),
+            },
           };
         })
       );
@@ -188,7 +188,7 @@ export function makeCharacter(
     id: raw.id,
     name: t('ItemService.StoreName', {
       genderRace,
-      className
+      className,
     }),
     icon: `https://www.bungie.net/${character.emblemPath}`,
     current: mostRecentLastPlayed.getTime() === lastPlayed.getTime(),
@@ -205,7 +205,7 @@ export function makeCharacter(
     percentToNextLevel: character.percentToNextLevel / 100,
     progression: raw.character.progression,
     advisors: raw.character.advisors,
-    isVault: false
+    isVault: false,
   });
 
   if (store.progression) {
@@ -245,7 +245,7 @@ export function makeCharacter(
 
   return {
     store,
-    items
+    items,
   };
 }
 
@@ -308,7 +308,7 @@ export function makeVault(
       if (item.location.vaultBucket) {
         this.vaultCounts[item.location.vaultBucket.hash].count++;
       }
-    }
+    },
   });
 
   let items: any[] = [];
@@ -323,6 +323,6 @@ export function makeVault(
 
   return {
     store,
-    items
+    items,
   };
 }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -12,7 +12,7 @@ import {
   ItemBindStatus,
   ItemLocation,
   ItemState,
-  TransferStatuses
+  TransferStatuses,
 } from 'bungie-api-ts/destiny2';
 import { buildFlavorObjective, buildObjectives } from './objectives';
 
@@ -88,7 +88,7 @@ export const ItemProto = {
   },
   getStoresService() {
     return D2StoresService;
-  }
+  },
 };
 
 export function resetIdTracker() {
@@ -190,7 +190,7 @@ export function makeFakeItem(
       state: ItemState.None,
       isWrapper: false,
       tooltipNotificationIndexes: [],
-      metricObjective: {} as DestinyObjectiveProgress
+      metricObjective: {} as DestinyObjectiveProgress,
     },
     undefined,
     mergedCollectibles
@@ -386,11 +386,11 @@ export function makeItem(
         energyCost: itemDef.plug.energyCost.energyCost,
         costElementIcon: defs.Stat.get(
           defs.EnergyType.get(itemDef.plug.energyCost.energyTypeHash).costStatHash
-        ).displayProperties.icon
+        ).displayProperties.icon,
       },
     metricHash: item.metricHash,
     metricObjective: item.metricObjective,
-    availableMetricCategoryNodeHashes: itemDef.metrics?.availableMetricCategoryNodeHashes
+    availableMetricCategoryNodeHashes: itemDef.metrics?.availableMetricCategoryNodeHashes,
   });
 
   createdItem.season = getSeason(createdItem);
@@ -467,7 +467,7 @@ export function makeItem(
       .map(
         (p): DimPerk => ({
           requirement: p.requirementDisplayString,
-          ...defs.SandboxPerk.get(p.perkHash)
+          ...defs.SandboxPerk.get(p.perkHash),
         })
       )
       .filter((p) => p.isDisplayable);
@@ -568,7 +568,7 @@ function buildPursuitInfo(
       expiredInActivityMessage: itemDef.inventory.expiredInActivityMessage,
       places: [],
       activityTypes: [],
-      modifierHashes: []
+      modifierHashes: [],
     };
   }
   const rewards = itemDef.value ? itemDef.value.itemValue.filter((v) => v.itemHash) : [];
@@ -579,7 +579,7 @@ function buildPursuitInfo(
       activityTypes: [],
       modifierHashes: [],
       ...createdItem.pursuit,
-      rewards
+      rewards,
     };
   }
 }

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -2,7 +2,7 @@ import {
   DestinyCharacterComponent,
   DestinyItemComponent,
   DestinyClass,
-  DestinyGender
+  DestinyGender,
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { bungieNetPath } from '../../dim-ui/BungieImage';
@@ -25,7 +25,7 @@ import { getCurrentStore } from '../stores-helpers';
 const genderTypeToEnglish = {
   [DestinyGender.Male]: 'male',
   [DestinyGender.Female]: 'female',
-  [DestinyGender.Unknown]: ''
+  [DestinyGender.Unknown]: '',
 };
 
 // Prototype for Store objects - add methods to this to add them to all
@@ -163,7 +163,7 @@ export const StoreProto = {
 
   getStoresService() {
     return D2StoresService;
-  }
+  },
 };
 
 export function makeCharacter(
@@ -185,7 +185,7 @@ export function makeCharacter(
     icon: bungieNetPath(character.emblemPath),
     name: t('ItemService.StoreName', {
       genderRace,
-      className
+      className,
     }),
     current: mostRecentLastPlayed.getTime() === lastPlayed.getTime(),
     lastPlayed,
@@ -201,7 +201,7 @@ export function makeCharacter(
     genderRace,
     genderName: genderTypeToEnglish[gender.genderType] ?? '',
     isVault: false,
-    color: character.emblemColor
+    color: character.emblemColor,
   });
 
   return store;
@@ -214,7 +214,7 @@ export function makeVault(
   const currencies = profileCurrencies.map((c) => ({
     itemHash: c.itemHash,
     quantity: c.quantity,
-    displayProperties: defs.InventoryItem.get(c.itemHash).displayProperties
+    displayProperties: defs.InventoryItem.get(c.itemHash).displayProperties,
   }));
 
   return Object.assign(Object.create(StoreProto), {
@@ -270,7 +270,7 @@ export function makeVault(
       if (item.location.vaultBucket) {
         this.vaultCounts[item.location.vaultBucket.hash].count++;
       }
-    }
+    },
   });
 }
 
@@ -297,7 +297,7 @@ export function getCharacterStatsData(
       name: def.displayProperties.name,
       description: def.displayProperties.description,
       value,
-      icon: bungieNetPath(def.displayProperties.icon)
+      icon: bungieNetPath(def.displayProperties.icon),
     };
     ret[statHash] = stat;
   });

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -12,7 +12,7 @@ const resistanceMods = {
   1546607977: DamageType.Kinetic,
   1546607980: DamageType.Void,
   1546607978: DamageType.Arc,
-  1546607979: DamageType.Thermal
+  1546607979: DamageType.Thermal,
 };
 
 /**
@@ -79,7 +79,7 @@ function buildForsakenKillTracker(
       typeDesc: objectiveDef.progressDescription,
       typeName: [3244015567, 2285636663, 38912240].includes(killTrackerSocket.plug.plugItem.hash)
         ? 'Crucible'
-        : 'Vanguard'
+        : 'Vanguard',
     };
   }
   return null;
@@ -116,7 +116,7 @@ function buildForsakenMasterworkStats(
       statValue: masterworkSocket.plug.stats
         ? masterworkSocket.plug.stats[masterwork.statTypeHash]
         : 0,
-      tier: masterwork.value
+      tier: masterwork.value,
     };
   }
   return null;
@@ -160,6 +160,6 @@ function buildMasterworkInfo(
     statHash,
     statName: statDef.displayProperties.name,
     statValue: socket.plug.stats ? socket.plug.stats[statHash] : 0,
-    tier: investmentStats[0].value
+    tier: investmentStats[0].value,
   };
 }

--- a/src/app/inventory/store/objectives.ts
+++ b/src/app/inventory/store/objectives.ts
@@ -3,7 +3,7 @@ import {
   DestinyItemObjectivesComponent,
   DestinyObjectiveProgress,
   DestinyObjectiveDefinition,
-  DestinyUnlockValueUIStyle
+  DestinyUnlockValueUIStyle,
 } from 'bungie-api-ts/destiny2';
 import { DimFlavorObjective } from '../item-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
@@ -71,7 +71,7 @@ export function buildFlavorObjective(
     progress:
       def.valueStyle === 5
         ? (flavorObjective.progress || 0) / flavorObjective.completionValue
-        : (def.valueStyle === 6 || def.valueStyle === 0 ? flavorObjective.progress : 0) || 0
+        : (def.valueStyle === 6 || def.valueStyle === 0 ? flavorObjective.progress : 0) || 0,
   };
 }
 

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -7,7 +7,7 @@ import {
   DestinyItemComponentSetOfint64,
   DestinyItemPlugBase,
   DestinyObjectiveProgress,
-  DestinySocketCategoryStyle
+  DestinySocketCategoryStyle,
 } from 'bungie-api-ts/destiny2';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimSockets, DimSocketCategory, DimSocket, DimPlug } from '../item-types';
@@ -36,7 +36,7 @@ const EXCLUDED_PLUGS = new Set([
   1961001474,
   3612467353,
   // Default Shader
-  4248210736
+  4248210736,
 ]);
 
 /** The item category hash for "intrinsic perk" */
@@ -157,13 +157,13 @@ export function buildInstancedSockets(
 
     categories.push({
       category: defs.SocketCategory.get(category.socketCategoryHash),
-      sockets
+      sockets,
     });
   }
 
   return {
     sockets: _.compact(realSockets), // Flat list of sockets
-    categories: categories.sort(compareBy((c) => c.category.index)) // Sockets organized by category
+    categories: categories.sort(compareBy((c) => c.category.index)), // Sockets organized by category
   };
 }
 
@@ -201,13 +201,13 @@ function buildDefinedSockets(
 
     categories.push({
       category: defs.SocketCategory.get(category.socketCategoryHash),
-      sockets
+      sockets,
     });
   }
 
   return {
     sockets: _.compact(realSockets), // Flat list of sockets
-    categories: categories.sort(compareBy((c) => c.category.index)) // Sockets organized by category
+    categories: categories.sort(compareBy((c) => c.category.index)), // Sockets organized by category
   };
 }
 
@@ -292,7 +292,7 @@ function buildDefinedSocket(
     hasRandomizedPlugItems:
       Boolean(socketDef.randomizedPlugSetHash) || socketTypeDef.alwaysRandomizeSockets,
     isPerk,
-    socketDefinition: socketDef
+    socketDefinition: socketDef,
   };
 }
 
@@ -338,7 +338,7 @@ function buildPlug(
     enableFailReasons: failReasons,
     plugObjectives: plugObjectivesData?.[plugHash] || [],
     perks: plugItem.perks ? plugItem.perks.map((perk) => defs.SandboxPerk.get(perk.perkHash)) : [],
-    stats: null
+    stats: null,
   };
 }
 
@@ -359,7 +359,7 @@ function buildDefinedPlug(
     enableFailReasons: '',
     plugObjectives: [],
     perks: (plugItem.perks || []).map((perk) => defs.SandboxPerk.get(perk.perkHash)),
-    stats: null
+    stats: null,
   };
 }
 
@@ -441,6 +441,6 @@ function buildSocket(
     hasRandomizedPlugItems,
     reusablePlugItems: reusablePlugs,
     isPerk,
-    socketDefinition: socketDef
+    socketDefinition: socketDef,
   };
 }

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -8,7 +8,7 @@ import {
   DestinyDisplayPropertiesDefinition,
   DestinyStatAggregationType,
   DestinyStatCategory,
-  DestinySocketCategoryStyle
+  DestinySocketCategoryStyle,
 } from 'bungie-api-ts/destiny2';
 import { D2Item, DimSocket, DimPlug, DimStat, DimSockets } from '../item-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
@@ -41,7 +41,7 @@ export const armorStats = [
   1943323491, // Recovery
   1735777505, // Discipline
   144602215, // Intellect
-  4244567218 // Strength
+  4244567218, // Strength
 ];
 
 /**
@@ -69,7 +69,7 @@ export const statWhiteList = [
   1931675084, // Inventory Size
   925767036, // Ammo Capacity
   ...armorStats,
-  -1000 // Total
+  -1000, // Total
 ];
 
 /** Stats that should be forced to display without a bar (just a number). */
@@ -79,20 +79,20 @@ const statsNoBar = [
   2961396640, // Charge Time
   447667954, // Draw Time
   1931675084, // Recovery
-  2715839340 // Recoil Direction
+  2715839340, // Recoil Direction
 ];
 
 /** Stats that are measured in milliseconds. */
 export const statsMs = [
   447667954, // Draw Time
-  2961396640 // Charge Time
+  2961396640, // Charge Time
 ];
 
 /** Show these stats in addition to any "natural" stats */
 const hiddenStatsWhitelist = [
   1345609583, // Aim Assistance
   3555269338, // Zoom
-  2715839340 // Recoil Direction
+  2715839340, // Recoil Direction
 ];
 
 /** Build the full list of stats for an item. If the item has no stats, this returns null. */
@@ -195,7 +195,7 @@ function buildStatsFromMods(
   for (const statHash of armorStats) {
     const hashAndValue = {
       statTypeHash: statHash,
-      value: statTracker[statHash]
+      value: statTracker[statHash],
     };
     const builtStat = buildStat(hashAndValue, statGroup, defs.Stat.get(statHash), statDisplays);
     builtStat.maximumValue = 42;
@@ -297,7 +297,7 @@ function buildStat(
     // set to use DestinyStatAggregationType.Character
     additive:
       statDef.statCategory === DestinyStatCategory.Defense &&
-      statDef.aggregationType === DestinyStatAggregationType.Character
+      statDef.aggregationType === DestinyStatAggregationType.Character,
   };
 }
 
@@ -444,7 +444,7 @@ function buildLiveStats(
       maximumValue,
       bar,
       smallerIsBetter,
-      additive: statDef.aggregationType === DestinyStatAggregationType.Character
+      additive: statDef.aggregationType === DestinyStatAggregationType.Character,
     });
   }
 
@@ -483,7 +483,7 @@ function totalStat(stats: DimStat[]): DimStat {
     investmentValue: total,
     statHash: -1000,
     displayProperties: ({
-      name: t('Stats.Total')
+      name: t('Stats.Total'),
     } as any) as DestinyDisplayPropertiesDefinition,
     sort: statWhiteList.indexOf(-1000),
     value: total,
@@ -491,7 +491,7 @@ function totalStat(stats: DimStat[]): DimStat {
     maximumValue: 100,
     bar: false,
     smallerIsBetter: false,
-    additive: false
+    additive: false,
   };
 }
 

--- a/src/app/inventory/store/talent-grids.ts
+++ b/src/app/inventory/store/talent-grids.ts
@@ -76,7 +76,7 @@ export function buildTalentGrid(
         // Whether or not the material cost has been paid for the node
         unlocked: true,
         // Some nodes don't show up in the grid, like purchased ascend nodes
-        hidden: node.hidden
+        hidden: node.hidden,
       };
     })
   );
@@ -104,6 +104,6 @@ export function buildTalentGrid(
         compareBy((node) => node.row)
       )
     ),
-    complete: gridNodes.every((n) => n.unlocked)
+    complete: gridNodes.every((n) => n.unlocked),
   };
 }

--- a/src/app/inventory/store/well-rested.ts
+++ b/src/app/inventory/store/well-rested.ts
@@ -2,7 +2,7 @@ import {
   DestinyCharacterProgressionComponent,
   DestinyProgressionDefinition,
   DestinySeasonDefinition,
-  DestinySeasonPassDefinition
+  DestinySeasonPassDefinition,
 } from 'bungie-api-ts/destiny2';
 import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
 
@@ -23,7 +23,7 @@ export function isWellRested(
 } {
   if (!season || !season.seasonPassProgressionHash) {
     return {
-      wellRested: false
+      wellRested: false,
     };
   }
 
@@ -33,7 +33,7 @@ export function isWellRested(
 
   if (!seasonPassProgressionHash || !prestigeProgressionHash) {
     return {
-      wellRested: false
+      wellRested: false,
     };
   }
 
@@ -66,7 +66,7 @@ export function isWellRested(
   return {
     wellRested: progress < requiredXP,
     progress,
-    requiredXP
+    requiredXP,
   };
 }
 

--- a/src/app/inventory/tag-items.tsx
+++ b/src/app/inventory/tag-items.tsx
@@ -17,14 +17,14 @@ export function bulkTagItems(itemsToBeTagged: DimItem[], selectedTag: TagValue):
     // existing tags are later passed to buttonEffect so the notif button knows what to revert
     const previousState = itemsToBeTagged.map((item) => ({
       item,
-      setTag: getTag(item, itemInfos)
+      setTag: getTag(item, itemInfos),
     }));
 
     dispatch(
       setItemTagsBulk(
         itemsToBeTagged.map((item) => ({
           itemId: item.id,
-          tag: selectedTag === 'clear' ? undefined : selectedTag
+          tag: selectedTag === 'clear' ? undefined : selectedTag,
         }))
       )
     );
@@ -37,11 +37,11 @@ export function bulkTagItems(itemsToBeTagged: DimItem[], selectedTag: TagValue):
         <>
           {selectedTag === 'clear'
             ? t('Filter.BulkClear', {
-                count: itemsToBeTagged.length
+                count: itemsToBeTagged.length,
               })
             : t('Filter.BulkTag', {
                 count: itemsToBeTagged.length,
-                tag: t(appliedTagInfo.label)
+                tag: t(appliedTagInfo.label),
               })}
           <NotificationButton
             onClick={async () => {
@@ -49,21 +49,21 @@ export function bulkTagItems(itemsToBeTagged: DimItem[], selectedTag: TagValue):
                 setItemTagsBulk(
                   previousState.map(({ item, setTag }) => ({
                     itemId: item.id,
-                    tag: setTag
+                    tag: setTag,
                   }))
                 )
               );
               showNotification({
                 type: 'success',
                 title: t('Header.BulkTag'),
-                body: t('Filter.BulkRevert', { count: previousState.length })
+                body: t('Filter.BulkRevert', { count: previousState.length }),
               });
             }}
           >
             <AppIcon icon={undoIcon} /> {t('Filter.Undo')}
           </NotificationButton>
         </>
-      )
+      ),
     });
   };
 }

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -11,7 +11,7 @@ import {
   SearchConfig,
   searchConfigSelector,
   SearchFilters,
-  searchFiltersConfigSelector
+  searchFiltersConfigSelector,
 } from '../search/search-filters';
 import SearchFilterInput from '../search/SearchFilterInput';
 import { sortItems } from '../shell/filters';
@@ -50,12 +50,12 @@ function mapStateToProps(): MapStateToProps<StoreProps, ProvidedProps, RootState
     filters: searchFiltersConfigSelector(state),
     itemSortOrder: itemSortOrderSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
-    preferEquip: settingsSelector(state).itemPickerEquip
+    preferEquip: settingsSelector(state).itemPickerEquip,
   });
 }
 
 const mapDispatchToProps = {
-  setSetting
+  setSetting,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -70,7 +70,7 @@ interface State {
 class ItemPicker extends React.Component<Props, State> {
   state: State = {
     query: '',
-    equip: this.props.equip === undefined ? this.props.preferEquip : this.props.equip
+    equip: this.props.equip === undefined ? this.props.preferEquip : this.props.equip,
   };
   private itemContainer = React.createRef<HTMLDivElement>();
   private filterInput = React.createRef<SearchFilterInput>();
@@ -95,7 +95,7 @@ class ItemPicker extends React.Component<Props, State> {
       filters,
       itemSortOrder,
       hideStoreEquip,
-      sortBy
+      sortBy,
     } = this.props;
     const { query, equip, height } = this.state;
 

--- a/src/app/item-popup/EmblemPreview.tsx
+++ b/src/app/item-popup/EmblemPreview.tsx
@@ -7,7 +7,7 @@ import styles from './EmblemPreview.m.scss';
 
 export default function EmblemPreview({
   item,
-  defs
+  defs,
 }: {
   item: DimItem;
   defs: D2ManifestDefinitions;

--- a/src/app/item-popup/ExpandedRating.tsx
+++ b/src/app/item-popup/ExpandedRating.tsx
@@ -17,7 +17,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   return {
-    dtrRating: getRating(props.item, state.reviews.ratings)
+    dtrRating: getRating(props.item, state.reviews.ratings),
   };
 }
 
@@ -32,7 +32,7 @@ function ExpandedRating({ dtrRating }: Props) {
       <RatingIcon rating={dtrRating.overallScore} uiWishListRoll={undefined} />{' '}
       {t('DtrReview.AverageRating', {
         itemRating: dtrRating.overallScore.toFixed(1),
-        numRatings: dtrRating.ratingCount || 0
+        numRatings: dtrRating.ratingCount || 0,
       })}
     </div>
   );

--- a/src/app/item-popup/ItemActionButton.tsx
+++ b/src/app/item-popup/ItemActionButton.tsx
@@ -15,7 +15,7 @@ export default function ItemActionButton({
   label,
   icon,
   className,
-  onClick
+  onClick,
 }: {
   title: string;
   label: string;

--- a/src/app/item-popup/ItemActions.tsx
+++ b/src/app/item-popup/ItemActions.tsx
@@ -27,7 +27,7 @@ interface StoreProps {
 function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps {
   return {
     store: storesSelector(state).find((s) => s.id === item.owner),
-    stores: sortedStoresSelector(state)
+    stores: sortedStoresSelector(state),
   };
 }
 
@@ -39,7 +39,7 @@ interface State {
 
 class ItemActions extends React.Component<Props, State> {
   state: State = {
-    amount: this.props.item.amount
+    amount: this.props.item.amount,
   };
 
   private maximumSelector = createSelector(
@@ -109,7 +109,7 @@ class ItemActions extends React.Component<Props, State> {
                 className={clsx(styles.infusePerk, {
                   [styles.destiny2]: item.isDestiny2(),
                   [styles.weapons]: item.bucket.sort === 'Weapons',
-                  [styles.armor]: item.bucket.sort === 'Armor'
+                  [styles.armor]: item.bucket.sort === 'Armor',
                 })}
                 onClick={this.infuse}
                 title={t('Infusion.Infusion')}

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -26,7 +26,7 @@ interface StoreProps {
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   return {
     notes: getNotes(props.item, itemInfosSelector(state)),
-    inventoryWishListRoll: inventoryWishListsSelector(state)[props.item.id]
+    inventoryWishListRoll: inventoryWishListsSelector(state)[props.item.id],
   };
 }
 

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -39,7 +39,7 @@ type Props = ProvidedProps & StoreProps;
 function mapStateToProps(state: RootState): StoreProps {
   return {
     defs:
-      destinyVersionSelector(state) === 2 ? state.manifest.d2Manifest! : state.manifest.d1Manifest!
+      destinyVersionSelector(state) === 2 ? state.manifest.d2Manifest! : state.manifest.d1Manifest!,
   };
 }
 

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -12,7 +12,7 @@ import './ItemPopupBody.scss';
 
 export const enum ItemPopupTab {
   Overview,
-  Reviews
+  Reviews,
 }
 
 const spring = { stiffness: 200, damping: 22 };
@@ -25,7 +25,7 @@ export default function ItemPopupBody({
   tab,
   expanded,
   onTabChanged,
-  onToggleExpanded
+  onToggleExpanded,
 }: {
   item: DimItem;
   failureStrings?: string[];
@@ -47,14 +47,14 @@ export default function ItemPopupBody({
     {
       tab: ItemPopupTab.Overview,
       title: t('MovePopup.OverviewTab'),
-      component: <ItemDetails item={item} extraInfo={extraInfo} />
-    }
+      component: <ItemDetails item={item} extraInfo={extraInfo} />,
+    },
   ];
   if ($featureFlags.reviewsEnabled && item.reviewable) {
     tabs.push({
       tab: ItemPopupTab.Reviews,
       title: t('MovePopup.ReviewsTab'),
-      component: <ItemReviews item={item} />
+      component: <ItemReviews item={item} />,
     });
   }
 
@@ -87,7 +87,7 @@ export default function ItemPopupBody({
                   <span
                     key={ta.tab}
                     className={clsx('move-popup-tab', {
-                      selected: tab === ta.tab
+                      selected: tab === ta.tab,
                     })}
                     onClick={() => onTabChanged(ta.tab)}
                   >

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -47,12 +47,12 @@ function mapStateToProps(state: RootState): StoreProps {
     stores: storesSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
     itemDetails: settings.itemDetails,
-    language: settings.language
+    language: settings.language,
   };
 }
 
 const mapDispatchToProps = {
-  setSetting
+  setSetting,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -74,8 +74,8 @@ const createPopper = popperGenerator({
     applyStyles,
     flip,
     preventOverflow,
-    arrow
-  ]
+    arrow,
+  ],
 });
 
 const popperOptions = (boundarySelector: string | undefined): Partial<Options> => {
@@ -85,7 +85,7 @@ const popperOptions = (boundarySelector: string | undefined): Partial<Options> =
     left: 0,
     top: headerHeight + (boundaryElement ? boundaryElement.clientHeight : 0) + 5,
     right: 0,
-    bottom: 0
+    bottom: 0,
   };
   return {
     placement: 'auto',
@@ -95,30 +95,30 @@ const popperOptions = (boundarySelector: string | undefined): Partial<Options> =
         options: {
           priority: ['bottom', 'top', 'right', 'left'],
           boundariesElement: 'viewport',
-          padding
-        }
+          padding,
+        },
       },
       {
         name: 'flip',
         options: {
           behavior: ['top', 'bottom', 'right', 'left'],
           boundariesElement: 'viewport',
-          padding
-        }
+          padding,
+        },
       },
       {
         name: 'offset',
         options: {
-          offset: [0, 5]
-        }
+          offset: [0, 5],
+        },
       },
       {
         name: 'arrow',
         options: {
-          element: '.' + styles.arrow
-        }
-      }
-    ]
+          element: '.' + styles.arrow,
+        },
+      },
+    ],
   };
 };
 
@@ -127,7 +127,7 @@ const tierClasses: { [key in DimItem['tier']]: string } = {
   Legendary: styles.legendary,
   Rare: styles.rare,
   Uncommon: styles.uncommon,
-  Common: styles.common
+  Common: styles.common,
 } as const;
 
 /**
@@ -151,7 +151,7 @@ class ItemPopupContainer extends React.Component<Props, State> {
             item,
             element,
             extraInfo,
-            tab: !item.reviewable && tab === ItemPopupTab.Reviews ? ItemPopupTab.Overview : tab
+            tab: !item.reviewable && tab === ItemPopupTab.Reviews ? ItemPopupTab.Overview : tab,
           }));
           if ($DIM_FLAVOR !== 'release') {
             console.log(item);
@@ -238,8 +238,8 @@ class ItemPopupContainer extends React.Component<Props, State> {
               description: t('Hotkey.ClearDialog'),
               callback: () => {
                 this.onClose();
-              }
-            }
+              },
+            },
           ]}
         />
       </div>

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -21,7 +21,7 @@ export default function ItemPopupHeader({
   expanded,
   showToggle,
   language,
-  onToggleExpanded
+  onToggleExpanded,
 }: {
   item: DimItem;
   expanded: boolean;
@@ -60,18 +60,18 @@ export default function ItemPopupHeader({
     light,
     statName: item.primStat?.stat.displayProperties.name,
     classType: classType ? classType : ' ',
-    typeName: item.typeName
+    typeName: item.typeName,
   };
 
   return (
     <div
       className={clsx('item-header', `is-${item.tier}`, {
-        masterwork: item.isDestiny2() && item.masterwork
+        masterwork: item.isDestiny2() && item.masterwork,
       })}
     >
       <GlobalHotkeys
         hotkeys={[
-          { combo: 't', description: t('Hotkey.ToggleDetails'), callback: onToggleExpanded }
+          { combo: 't', description: t('Hotkey.ToggleDetails'), callback: onToggleExpanded },
         ]}
       />
       <div className="item-title-container">

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -50,7 +50,7 @@ function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps 
     inventoryWishListRoll: inventoryWishListsSelector(state)[item.id],
     bestPerks,
     defs: state.manifest.d2Manifest,
-    isPhonePortrait: state.shell.isPhonePortrait
+    isPhonePortrait: state.shell.isPhonePortrait,
   };
 }
 
@@ -66,7 +66,7 @@ function ItemSockets({
   classesByHash,
   isPhonePortrait,
   onShiftClick,
-  dispatch
+  dispatch,
 }: Props) {
   if ($featureFlags.reviewsEnabled) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -238,7 +238,7 @@ function Socket({
   bestPerks,
   isPhonePortrait,
   onClick,
-  onShiftClick
+  onShiftClick,
 }: {
   defs: D2ManifestDefinitions;
   item: D2Item;
@@ -257,7 +257,7 @@ function Socket({
   return (
     <div
       className={clsx('item-socket', {
-        hasMenu
+        hasMenu,
       })}
     >
       {socket.plugOptions.map((plug) => (

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -17,7 +17,7 @@ import { getSocketsWithStyle } from '../utils/socket-utils';
 const modItemCategoryHashes = [
   1052191496, // weapon mods
   4062965806, // armor mods (pre-2.0)
-  4104513227 // armor 2.0 mods
+  4104513227, // armor 2.0 mods
 ];
 
 const TOTAL_STAT_HASH = -1000;
@@ -74,7 +74,7 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
   const optionalClasses = {
     [styles.masterworked]: isMasterworkedStat,
     [styles.modded]: Boolean(moddedStatValue),
-    [styles.totalRow]: Boolean(totalDetails)
+    [styles.totalRow]: Boolean(totalDetails),
   };
 
   return (
@@ -199,7 +199,7 @@ export function ItemStatValue({ stat, item }: { stat: DimStat; item?: DimItem })
 
   const optionalClasses = {
     [styles.masterworked]: isMasterworkedStat,
-    [styles.modded]: Boolean(moddedStatValue)
+    [styles.modded]: Boolean(moddedStatValue),
   };
 
   return (

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -9,7 +9,7 @@ export default function ItemStats({
   stats,
   item,
   quality,
-  className
+  className,
 }: {
   stats?: DimStat[];
   item?: DimItem;

--- a/src/app/item-popup/ItemTagHotkeys.tsx
+++ b/src/app/item-popup/ItemTagHotkeys.tsx
@@ -20,12 +20,12 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   return {
-    itemTag: getTag(props.item, itemInfosSelector(state))
+    itemTag: getTag(props.item, itemInfosSelector(state)),
   };
 }
 
 const mapDispatchToProps = {
-  setItemTag
+  setItemTag,
 };
 type DispatchProps = typeof mapDispatchToProps;
 
@@ -44,7 +44,7 @@ function ItemTagHotkeys({ item, children, itemTag, setItemTag }: Props) {
         combo: tag.hotkey,
         description: t('Hotkey.MarkItemAs', { tag: tag.type }),
         callback: () =>
-          setItemTag({ itemId: item.id, tag: itemTag === tag.type ? undefined : tag.type })
+          setItemTag({ itemId: item.id, tag: itemTag === tag.type ? undefined : tag.type }),
       });
     }
   });

--- a/src/app/item-popup/ItemTalentGrid.tsx
+++ b/src/app/item-popup/ItemTalentGrid.tsx
@@ -30,7 +30,7 @@ function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps 
       ? ratePerks(item, reviews as D1ItemUserReview[])
       : emptySet<number>();
   return {
-    bestPerks
+    bestPerks,
   };
 }
 
@@ -98,7 +98,7 @@ function ItemTalentGrid({ item, perksOnly, bestPerks }: Props) {
                   node.activated &&
                   (!isD1GridNode(node) || !node.xpRequired) &&
                   !node.exclusiveInColumn &&
-                  node.column < 1
+                  node.column < 1,
               })}
             >
               {isD1GridNode(node) && bestPerks.has(node.hash) && !node.activated && (

--- a/src/app/item-popup/MetricCategories.tsx
+++ b/src/app/item-popup/MetricCategories.tsx
@@ -5,7 +5,7 @@ import styles from './MetricCategories.m.scss';
 
 export default function MetricCategories({
   availableMetricCategoryNodeHashes,
-  defs
+  defs,
 }: {
   availableMetricCategoryNodeHashes: number[];
   defs: D2ManifestDefinitions;
@@ -21,7 +21,7 @@ export default function MetricCategories({
 
 function MetricCategory({
   categoryHash,
-  defs
+  defs,
 }: {
   categoryHash: number;
   defs: D2ManifestDefinitions;

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -24,7 +24,7 @@ export default function Plug({
   hasMenu,
   isPhonePortrait,
   onClick,
-  onShiftClick
+  onShiftClick,
 }: {
   defs: D2ManifestDefinitions;
   plug: DimPlug;
@@ -96,7 +96,7 @@ export default function Plug({
       className={clsx('socket-container', className, {
         disabled: !plug.enabled,
         notChosen: plug !== socketInfo.plug,
-        notIntrinsic: !itemCategories.includes(INTRINSIC_PLUG_CATEGORY)
+        notIntrinsic: !itemCategories.includes(INTRINSIC_PLUG_CATEGORY),
       })}
       onClick={handleShiftClick}
     >

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -17,7 +17,7 @@ export default function PlugTooltip({
   defs,
   wishListsEnabled,
   inventoryWishListRoll,
-  bestPerks
+  bestPerks,
 }: {
   item: D2Item;
   plug: DimPlug;
@@ -110,7 +110,7 @@ export default function PlugTooltip({
 export function StatValue({
   value,
   statHash,
-  defs
+  defs,
 }: {
   value: number;
   statHash: number;

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -8,7 +8,7 @@ import {
   DestinyInventoryItemDefinition,
   DestinyEnergyType,
   DestinyItemPlug,
-  DestinyItemPlugBase
+  DestinyItemPlugBase,
 } from 'bungie-api-ts/destiny2';
 import BungieImage, { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { RootState } from 'app/store/reducers';
@@ -92,7 +92,7 @@ function mapStateToProps() {
   return (state: RootState, props: ProvidedProps): StoreProps => ({
     defs: state.manifest.d2Manifest!,
     inventoryPlugs: inventoryPlugs(state, props),
-    unlockedPlugs: unlockedPlugsSelector(state, props)
+    unlockedPlugs: unlockedPlugsSelector(state, props),
   });
 }
 
@@ -229,7 +229,7 @@ function SocketDetails({ defs, item, socket, unlockedPlugs, inventoryPlugs, onCl
             className={clsx(styles.clickableMod, {
               [styles.selected]: selectedPlug === mod,
               [styles.notUnlocked]:
-                !unlockedPlugs.has(mod.hash) && !otherUnlockedPlugs.has(mod.hash)
+                !unlockedPlugs.has(mod.hash) && !otherUnlockedPlugs.has(mod.hash),
             })}
             itemDef={mod}
             defs={defs}
@@ -249,7 +249,7 @@ export const SocketDetailsMod = React.memo(
     itemDef,
     defs,
     className,
-    onClick
+    onClick,
   }: {
     itemDef: DestinyInventoryItemDefinition;
     defs: D2ManifestDefinitions;

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -16,7 +16,7 @@ export default function SocketDetailsSelectedPlug({
   plug,
   defs,
   item,
-  currentPlug
+  currentPlug,
 }: {
   plug: DestinyInventoryItemDefinition;
   defs: D2ManifestDefinitions;
@@ -63,8 +63,8 @@ export default function SocketDetailsSelectedPlug({
         modValue,
         dimStat: {
           ...itemStat,
-          value: itemStatValue
-        } as DimStat
+          value: itemStatValue,
+        } as DimStat,
       };
     })
   );

--- a/src/app/item-popup/ammo-type.ts
+++ b/src/app/item-popup/ammo-type.ts
@@ -4,6 +4,6 @@ export function ammoTypeClass(ammoType: DestinyAmmunitionType) {
   return {
     [DestinyAmmunitionType.Primary]: 'ammo-primary',
     [DestinyAmmunitionType.Special]: 'ammo-special',
-    [DestinyAmmunitionType.Heavy]: 'ammo-heavy'
+    [DestinyAmmunitionType.Heavy]: 'ammo-heavy',
   }[ammoType];
 }

--- a/src/app/item-review/ItemReview.tsx
+++ b/src/app/item-review/ItemReview.tsx
@@ -9,7 +9,7 @@ import {
   faFlag,
   faPenSquare,
   faExclamationTriangle,
-  banIcon
+  banIcon,
 } from '../shell/icons';
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
@@ -64,7 +64,7 @@ export default class ItemReview extends React.Component<Props, State> {
         <div>
           <div
             className={clsx({
-              'link community-review--clickable': review.isReviewer
+              'link community-review--clickable': review.isReviewer,
             })}
             onClick={this.editReview}
           >
@@ -85,7 +85,7 @@ export default class ItemReview extends React.Component<Props, State> {
                 )}{' '}
                 <span
                   className={clsx('community-review--review-author', {
-                    'community-review--who__special': review.isHighlighted
+                    'community-review--who__special': review.isHighlighted,
                   })}
                 >
                   {review.reviewer.displayName}
@@ -108,7 +108,7 @@ export default class ItemReview extends React.Component<Props, State> {
               review.mode !== DtrD2ActivityModes.notSpecified && (
                 <div className="community-review--game-mode">
                   {t('DtrReview.ForGameMode', {
-                    mode: translateReviewMode(reviewModeOptions, review)
+                    mode: translateReviewMode(reviewModeOptions, review),
                   })}
                 </div>
               )}

--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -9,7 +9,7 @@ import {
   thumbsUpIcon,
   thumbsDownIcon,
   faThumbsUpRegular,
-  faThumbsDownRegular
+  faThumbsDownRegular,
 } from '../shell/icons';
 import { getRating, ratingsSelector, getReviews, getUserReview, shouldShowRating } from './reducer';
 import { D2ItemUserReview, WorkingD2Rating } from './d2-dtr-api-types';
@@ -47,7 +47,9 @@ function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps 
     dtrRating: getRating(item, ratingsSelector(state)),
     reviews: reviewsResponse ? reviewsResponse.reviews : EMPTY,
     userReview: getUserReview(item, state),
-    reviewModeOptions: state.manifest.d2Manifest ? getReviewModes(state.manifest.d2Manifest) : EMPTY
+    reviewModeOptions: state.manifest.d2Manifest
+      ? getReviewModes(state.manifest.d2Manifest)
+      : EMPTY,
   };
 }
 
@@ -243,7 +245,7 @@ class ItemReviews extends React.Component<Props, State> {
 
   private cancelEdit = () => {
     this.setState((state) => ({
-      expandReview: !state.expandReview
+      expandReview: !state.expandReview,
     }));
   };
 
@@ -252,7 +254,7 @@ class ItemReviews extends React.Component<Props, State> {
     if (userReview && isD2UserReview(item, userReview)) {
       const newUserReview = {
         ...userReview,
-        mode: parseInt(e.currentTarget.value, 10)
+        mode: parseInt(e.currentTarget.value, 10),
       };
       dispatch(saveUserReview({ item, review: newUserReview }));
     }
@@ -263,7 +265,7 @@ class ItemReviews extends React.Component<Props, State> {
 
     const newUserReview = {
       ...userReview,
-      [isD2UserReview(item, userReview) ? 'text' : 'review']: e.currentTarget.value
+      [isD2UserReview(item, userReview) ? 'text' : 'review']: e.currentTarget.value,
     };
     dispatch(saveUserReview({ item, review: newUserReview }));
   };
@@ -276,7 +278,7 @@ class ItemReviews extends React.Component<Props, State> {
 
     // TODO: handle empty starting review
     this.setState({
-      expandReview: true
+      expandReview: true,
     });
   };
 
@@ -303,11 +305,11 @@ class ItemReviews extends React.Component<Props, State> {
     }
     const updatedUserReview = {
       ...userReview,
-      rating
+      rating,
     };
 
     this.setState({
-      expandReview: true
+      expandReview: true,
     });
 
     dispatch(saveUserReview({ item, review: updatedUserReview }));
@@ -341,11 +343,11 @@ class ItemReviews extends React.Component<Props, State> {
     const updatedUserReview = {
       ...userReview,
       voted: newVote,
-      treatAsSubmitted: !treatAsTouched
+      treatAsSubmitted: !treatAsTouched,
     };
 
     this.setState({
-      expandReview: treatAsTouched
+      expandReview: treatAsTouched,
     });
 
     dispatch(saveUserReview({ item, review: updatedUserReview }));

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -2,11 +2,11 @@ import { getItemReviewsD1 } from '../destinyTrackerApi/reviewsFetcher';
 import { getActivePlatform } from '../accounts/platforms';
 import {
   bulkFetch as bulkFetchD2,
-  bulkFetchVendorItems as bulkFetchD2VendorItems
+  bulkFetchVendorItems as bulkFetchD2VendorItems,
 } from '../destinyTrackerApi/d2-bulkFetcher';
 import {
   DestinyVendorSaleItemComponent,
-  DestinyVendorItemDefinition
+  DestinyVendorItemDefinition,
 } from 'bungie-api-ts/destiny2';
 import { DimStore, D2Store, D1Store } from '../inventory/store-types';
 import { DimItem } from '../inventory/item-types';
@@ -19,7 +19,7 @@ import { ThunkResult } from '../store/reducers';
 import { submitReview as doSubmitReview } from '../destinyTrackerApi/reviewSubmitter';
 import {
   bulkFetchVendorItems as bulkFetchD1VendorItems,
-  bulkFetch as bulkFetchD1
+  bulkFetch as bulkFetchD1,
 } from '../destinyTrackerApi/bulkFetcher';
 import { reportReview as doReportReview } from '../destinyTrackerApi/reviewReporter';
 import { settingsSelector } from 'app/settings/reducer';

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -35,7 +35,7 @@ const initialState: ReviewsState = {
   ratings: {},
   userReviews: {},
   reviews: {},
-  loadedFromIDB: false
+  loadedFromIDB: false,
 };
 
 export const ratingsSelector = (state: RootState) => state.reviews.ratings;
@@ -55,14 +55,14 @@ export const reviews: Reducer<ReviewsState, ReviewsAction | AccountsAction> = (
         ...state,
         ratings: {
           ...state.ratings,
-          ...convertToRatingMap(action.payload.ratings)
-        }
+          ...convertToRatingMap(action.payload.ratings),
+        },
       };
 
     case getType(setCurrentAccount):
     case getType(actions.clearRatings):
       return {
-        ...initialState
+        ...initialState,
       };
 
     case getType(actions.reviewsLoaded): {
@@ -88,8 +88,8 @@ export const reviews: Reducer<ReviewsState, ReviewsAction | AccountsAction> = (
         ...state,
         userReviews: {
           ...state.userReviews,
-          [getItemReviewsKey(action.payload.item)]: action.payload.review
-        }
+          [getItemReviewsKey(action.payload.item)]: action.payload.review,
+        },
       };
 
     case getType(actions.markReviewSubmitted): {
@@ -122,13 +122,13 @@ export const reviews: Reducer<ReviewsState, ReviewsAction | AccountsAction> = (
         ...state,
         reviews: {
           ...state.reviews,
-          ...action.payload.reviews
+          ...action.payload.reviews,
         },
         ratings: {
           ...state.ratings,
-          ...action.payload.ratings
+          ...action.payload.ratings,
         },
-        loadedFromIDB: true
+        loadedFromIDB: true,
       };
     }
 
@@ -176,7 +176,7 @@ export function getUserReview(item: DimItem, state: RootState): WorkingD2Rating 
           pros: '',
           review: '',
           cons: '',
-          treatAsSubmitted: false
+          treatAsSubmitted: false,
         }
       : {
           voted: 0,
@@ -184,7 +184,7 @@ export function getUserReview(item: DimItem, state: RootState): WorkingD2Rating 
           cons: '',
           text: '',
           mode: settingsSelector(state).reviewsModeSelection,
-          treatAsSubmitted: false
+          treatAsSubmitted: false,
         })
   );
 }

--- a/src/app/loadout-builder/ArmorBucketIcon.tsx
+++ b/src/app/loadout-builder/ArmorBucketIcon.tsx
@@ -9,7 +9,7 @@ import { InventoryBucket } from 'app/inventory/inventory-buckets';
 
 export default function ArmorBucketIcon({
   bucket,
-  className
+  className,
 }: {
   bucket: InventoryBucket;
   className?: string;

--- a/src/app/loadout-builder/ClosableContainer.tsx
+++ b/src/app/loadout-builder/ClosableContainer.tsx
@@ -6,7 +6,7 @@ import styles from './ClosableContainer.m.scss';
  */
 export default function ClosableContainer({
   children,
-  onClose
+  onClose,
 }: {
   children: React.ReactNode;
   onClose(): void;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -18,7 +18,7 @@ import {
   MinMaxIgnored,
   LockedModBase,
   LockedArmor2ModMap,
-  ModPickerCategories
+  ModPickerCategories,
 } from './types';
 import { sortedStoresSelector, storesLoadedSelector, storesSelector } from '../inventory/selectors';
 import { process, filterItems, statKeys } from './process';
@@ -32,7 +32,7 @@ import {
   SearchConfig,
   SearchFilters,
   searchConfigSelector,
-  searchFiltersConfigSelector
+  searchFiltersConfigSelector,
 } from 'app/search/search-filters';
 import memoizeOne from 'memoize-one';
 import styles from './LoadoutBuilder.m.scss';
@@ -117,7 +117,7 @@ function mapStateToProps() {
     items: itemsSelector(state),
     defs: state.manifest.d2Manifest,
     searchConfig: searchConfigSelector(state),
-    filters: searchFiltersConfigSelector(state)
+    filters: searchFiltersConfigSelector(state),
   });
 }
 
@@ -144,7 +144,7 @@ class LoadoutBuilder extends React.Component<Props, State> {
         Recovery: { min: 0, max: 10, ignored: false },
         Discipline: { min: 0, max: 10, ignored: false },
         Intellect: { min: 0, max: 10, ignored: false },
-        Strength: { min: 0, max: 10, ignored: false }
+        Strength: { min: 0, max: 10, ignored: false },
       },
       lockedSeasonalMods: [],
       lockedArmor2Mods: {
@@ -154,13 +154,13 @@ class LoadoutBuilder extends React.Component<Props, State> {
         [ModPickerCategories.chest]: [],
         [ModPickerCategories.leg]: [],
         [ModPickerCategories.classitem]: [],
-        [ModPickerCategories.seasonal]: []
+        [ModPickerCategories.seasonal]: [],
       },
       minimumPower: 750,
       query: '',
       statOrder: statKeys,
       selectedStoreId: getCurrentStore(props.stores)?.id,
-      assumeMasterwork: false
+      assumeMasterwork: false,
     };
   }
 
@@ -193,7 +193,7 @@ class LoadoutBuilder extends React.Component<Props, State> {
       items,
       defs,
       searchConfig,
-      filters
+      filters,
     } = this.props;
     const {
       lockedMap,
@@ -204,7 +204,7 @@ class LoadoutBuilder extends React.Component<Props, State> {
       minimumPower,
       query,
       statOrder,
-      assumeMasterwork
+      assumeMasterwork,
     } = this.state;
 
     if (!storesLoaded || !defs || !selectedStoreId) {
@@ -351,9 +351,9 @@ class LoadoutBuilder extends React.Component<Props, State> {
         Recovery: { min: 0, max: 10, ignored: false },
         Discipline: { min: 0, max: 10, ignored: false },
         Intellect: { min: 0, max: 10, ignored: false },
-        Strength: { min: 0, max: 10, ignored: false }
+        Strength: { min: 0, max: 10, ignored: false },
       },
-      minimumPower: 0
+      minimumPower: 0,
     });
   };
 

--- a/src/app/loadout-builder/LoadoutBuilderItem.tsx
+++ b/src/app/loadout-builder/LoadoutBuilderItem.tsx
@@ -12,7 +12,7 @@ import DraggableInventoryItem from '../inventory/DraggableInventoryItem';
 export default function LoadoutBuilderItem({
   item,
   locked,
-  addLockedItem
+  addLockedItem,
 }: {
   item: DimItem;
   locked?: readonly LockedItemType[];
@@ -31,7 +31,7 @@ export default function LoadoutBuilderItem({
             className={clsx({
               'excluded-item': locked?.some(
                 (p) => p.type === 'exclude' && p.item.index === item.index
-              )
+              ),
             })}
           >
             <ConnectedInventoryItem

--- a/src/app/loadout-builder/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/LockArmorAndPerks.tsx
@@ -15,7 +15,7 @@ import {
   LockedModBase,
   LockedArmor2ModMap,
   LockedArmor2Mod,
-  ModPickerCategories
+  ModPickerCategories,
 } from './types';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
@@ -62,7 +62,7 @@ function mapStateToProps() {
     stores: storesSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
     language: settingsSelector(state).language,
-    defs: state.manifest.d2Manifest!
+    defs: state.manifest.d2Manifest!,
   });
 }
 
@@ -81,7 +81,7 @@ function LockArmorAndPerks({
   isPhonePortrait,
   onLockedMapChanged,
   onSeasonalModsChanged,
-  onArmor2ModsChanged
+  onArmor2ModsChanged,
 }: Props) {
   const [filterPerksOpen, setFilterPerksOpen] = useState(false);
   const [filterModsOpen, setFilterModsOpen] = useState(false);
@@ -98,8 +98,8 @@ function LockArmorAndPerks({
           {
             type: 'item',
             item,
-            bucket: item.bucket
-          }
+            bucket: item.bucket,
+          },
         ];
       }
     });
@@ -131,7 +131,7 @@ function LockArmorAndPerks({
               item.canBeEquippedBy(selectedStore) &&
               (!filter || filter(item))
           ),
-        sortBy: (item) => order.indexOf(item.bucket.hash)
+        sortBy: (item) => order.indexOf(item.bucket.hash),
       });
 
       updateFunc(item);
@@ -142,7 +142,7 @@ function LockArmorAndPerks({
     if (item.bucket) {
       onLockedMapChanged({
         ...lockedMap,
-        [item.bucket.hash]: addLockedItem(item, lockedMap[item.bucket.hash])
+        [item.bucket.hash]: addLockedItem(item, lockedMap[item.bucket.hash]),
       });
     }
   };
@@ -151,7 +151,7 @@ function LockArmorAndPerks({
     if (item.bucket) {
       onLockedMapChanged({
         ...lockedMap,
-        [item.bucket.hash]: removeLockedItem(item, lockedMap[item.bucket.hash])
+        [item.bucket.hash]: removeLockedItem(item, lockedMap[item.bucket.hash]),
       });
     }
   };
@@ -161,7 +161,7 @@ function LockArmorAndPerks({
       ...lockedArmor2Mods,
       [item.category]: lockedArmor2Mods[item.category]?.filter(
         (ex) => ex.mod.hash !== item.mod.hash
-      )
+      ),
     });
   };
 

--- a/src/app/loadout-builder/LockedItem.tsx
+++ b/src/app/loadout-builder/LockedItem.tsx
@@ -13,7 +13,7 @@ import { SocketDetailsMod } from 'app/item-popup/SocketDetails';
 export default function LockedItem({
   lockedItem,
   defs,
-  onRemove
+  onRemove,
 }: {
   lockedItem: LockedItemType;
   defs: D2ManifestDefinitions;

--- a/src/app/loadout-builder/ModPicker.tsx
+++ b/src/app/loadout-builder/ModPicker.tsx
@@ -8,7 +8,7 @@ import {
   LockedArmor2Mod,
   LockedArmor2ModMap,
   ModPickerCategories,
-  ModPickerCategory
+  ModPickerCategory,
 } from './types';
 import _ from 'lodash';
 import { isLoadoutBuilderItem } from './generated-sets/utils';
@@ -36,7 +36,7 @@ const Armor2ModPlugCategoriesTitles = {
   [ModPickerCategories.chest]: t('LB.Chest'),
   [ModPickerCategories.leg]: t('LB.Legs'),
   [ModPickerCategories.classitem]: t('LB.ClassItem'),
-  [ModPickerCategories.seasonal]: t('LB.Seasonal')
+  [ModPickerCategories.seasonal]: t('LB.Seasonal'),
 };
 
 // to-do: separate mod name from its "enhanced"ness, maybe with d2ai? so they can be grouped better
@@ -133,7 +133,7 @@ function mapStateToProps() {
     buckets: state.inventory.buckets!,
     language: settingsSelector(state).language,
     mods: unlockedModsSelector(state, props),
-    defs: state.manifest.d2Manifest!
+    defs: state.manifest.d2Manifest!,
   });
 }
 
@@ -149,7 +149,7 @@ interface State {
 class ModPicker extends React.Component<Props, State> {
   state: State = {
     query: '',
-    lockedArmor2Mods: copy(this.props.lockedArmor2Mods)
+    lockedArmor2Mods: copy(this.props.lockedArmor2Mods),
   };
   private itemContainer = React.createRef<HTMLDivElement>();
   private filterInput = React.createRef<SearchFilterInput>();
@@ -175,7 +175,7 @@ class ModPicker extends React.Component<Props, State> {
 
     const order = Object.values(ModPickerCategories).map((category) => ({
       category,
-      translatedName: Armor2ModPlugCategoriesTitles[category]
+      translatedName: Armor2ModPlugCategoriesTitles[category],
     }));
 
     // Only some languages effectively use the \b regex word boundary
@@ -259,15 +259,15 @@ class ModPicker extends React.Component<Props, State> {
           ...lockedArmor2Mods,
           [item.category]: lockedArmor2Mods[item.category]?.filter(
             (li) => li.mod.hash !== item.mod.hash
-          )
-        }
+          ),
+        },
       });
     } else {
       this.setState({
         lockedArmor2Mods: {
           ...lockedArmor2Mods,
-          [item.category]: [...(lockedArmor2Mods[item.category] || []), item]
-        }
+          [item.category]: [...(lockedArmor2Mods[item.category] || []), item],
+        },
       });
     }
   };

--- a/src/app/loadout-builder/ModPickerFooter.tsx
+++ b/src/app/loadout-builder/ModPickerFooter.tsx
@@ -48,8 +48,8 @@ function ModPickerFooter(props: Props) {
             {
               combo: 'enter',
               description: t('LB.SelectMods'),
-              callback: onSubmit
-            }
+              callback: onSubmit,
+            },
           ]}
         />
       </div>

--- a/src/app/loadout-builder/ModPickerSection.tsx
+++ b/src/app/loadout-builder/ModPickerSection.tsx
@@ -13,7 +13,7 @@ export default function ModPickerSection({
   category,
   maximumSelectable,
   energyMustMatch,
-  onModSelected
+  onModSelected,
 }: {
   defs: D2ManifestDefinitions;
   mods: readonly LockedArmor2Mod[];

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -10,7 +10,7 @@ import {
   BurnItem,
   LockedMap,
   ItemsByBucket,
-  LockedModBase
+  LockedModBase,
 } from './types';
 import _ from 'lodash';
 import { t } from 'app/i18next-t';
@@ -20,7 +20,7 @@ import {
   lockedItemsEqual,
   addLockedItem,
   isLoadoutBuilderItem,
-  filterPlugs
+  filterPlugs,
 } from './generated-sets/utils';
 import BungieImageAndAmmo from 'app/dim-ui/BungieImageAndAmmo';
 import styles from './PerkPicker.m.scss';
@@ -53,23 +53,23 @@ const burns: BurnItem[] = [
     dmg: 'arc',
     displayProperties: {
       name: t('LoadoutBuilder.BurnTypeArc'),
-      icon: 'https://www.bungie.net/img/destiny_content/damage_types/destiny2/arc.png'
-    }
+      icon: 'https://www.bungie.net/img/destiny_content/damage_types/destiny2/arc.png',
+    },
   },
   {
     dmg: 'solar',
     displayProperties: {
       name: t('LoadoutBuilder.BurnTypeSolar'),
-      icon: 'https://www.bungie.net/img/destiny_content/damage_types/destiny2/thermal.png'
-    }
+      icon: 'https://www.bungie.net/img/destiny_content/damage_types/destiny2/thermal.png',
+    },
   },
   {
     dmg: 'void',
     displayProperties: {
       name: t('LoadoutBuilder.BurnTypeVoid'),
-      icon: 'https://www.bungie.net/img/destiny_content/damage_types/destiny2/void.png'
-    }
-  }
+      icon: 'https://www.bungie.net/img/destiny_content/damage_types/destiny2/void.png',
+    },
+  },
 ];
 
 interface ProvidedProps {
@@ -198,7 +198,7 @@ function mapStateToProps() {
         return Object.entries(unlockedPlugs)
           .map(([i, plugSetHash]) => ({
             item: defs.InventoryItem.get(parseInt(i, 10)),
-            plugSetHash
+            plugSetHash,
           }))
           .filter(
             (i) =>
@@ -217,7 +217,7 @@ function mapStateToProps() {
     language: settingsSelector(state).language,
     perks: perksSelector(state, props),
     mods: unlockedPlugsSelector(state, props),
-    defs: state.manifest.d2Manifest!
+    defs: state.manifest.d2Manifest!,
   });
 }
 
@@ -235,7 +235,7 @@ class PerkPicker extends React.Component<Props, State> {
   state: State = {
     query: '',
     selectedPerks: copy(this.props.lockedMap),
-    selectedSeasonalMods: copy(this.props.lockedSeasonalMods)
+    selectedSeasonalMods: copy(this.props.lockedSeasonalMods),
   };
   private itemContainer = React.createRef<HTMLDivElement>();
   private filterInput = React.createRef<SearchFilterInput>();
@@ -399,8 +399,8 @@ class PerkPicker extends React.Component<Props, State> {
                       description: t('LoadoutBuilder.SelectPerks'),
                       callback: (event) => {
                         this.onSubmit(event, onClose);
-                      }
-                    }
+                      },
+                    },
                   ]}
                 />
               </div>
@@ -447,15 +447,15 @@ class PerkPicker extends React.Component<Props, State> {
       this.setState({
         selectedPerks: {
           ...selectedPerks,
-          [bucket.hash]: removeLockedItem(item, selectedPerks[bucket.hash])
-        }
+          [bucket.hash]: removeLockedItem(item, selectedPerks[bucket.hash]),
+        },
       });
     } else {
       this.setState({
         selectedPerks: {
           ...selectedPerks,
-          [bucket.hash]: addLockedItem(item, selectedPerks[bucket.hash])
-        }
+          [bucket.hash]: addLockedItem(item, selectedPerks[bucket.hash]),
+        },
       });
     }
   };
@@ -467,11 +467,11 @@ class PerkPicker extends React.Component<Props, State> {
       this.setState({
         selectedSeasonalMods: selectedSeasonalMods.filter(
           (existing) => existing.mod.hash !== item.mod.hash
-        )
+        ),
       });
     } else {
       this.setState({
-        selectedSeasonalMods: [...selectedSeasonalMods, item]
+        selectedSeasonalMods: [...selectedSeasonalMods, item],
       });
     }
   };
@@ -496,7 +496,7 @@ export default connect<StoreProps>(mapStateToProps)(PerkPicker);
 function LockedItemIcon({
   lockedItem,
   defs,
-  onClick
+  onClick,
 }: {
   lockedItem: LockedItemType;
   defs: D2ManifestDefinitions;

--- a/src/app/loadout-builder/PerksForBucket.tsx
+++ b/src/app/loadout-builder/PerksForBucket.tsx
@@ -5,7 +5,7 @@ import { LockedItemType, BurnItem } from './types';
 import {
   SelectableBurn,
   SelectablePerk,
-  SelectableMod
+  SelectableMod,
 } from './locked-armor/SelectableBungieImage';
 import styles from './PerksForBucket.m.scss';
 import { DimItem } from 'app/inventory/item-types';
@@ -23,7 +23,7 @@ export default function PerksForBucket({
   burns,
   locked,
   items,
-  onPerkSelected
+  onPerkSelected,
 }: {
   bucket: InventoryBucket;
   defs: D2ManifestDefinitions;

--- a/src/app/loadout-builder/SeasonalModPicker.tsx
+++ b/src/app/loadout-builder/SeasonalModPicker.tsx
@@ -12,7 +12,7 @@ export default function SeasonalModPicker({
   defs,
   mods,
   locked,
-  onSeasonalModSelected
+  onSeasonalModSelected,
 }: {
   defs: D2ManifestDefinitions;
   mods: readonly LockedModBase[];

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -23,7 +23,7 @@ export default function FilterBuilds({
   onMinimumPowerChanged,
   onStatOrderChanged,
   onStatFiltersChanged,
-  onMasterworkAssumptionChange
+  onMasterworkAssumptionChange,
 }: {
   sets: readonly ArmorSet[];
   minimumPower: number;
@@ -96,7 +96,7 @@ function RangeSelector({
   min,
   max,
   initialValue,
-  onChange
+  onChange,
 }: {
   min: number;
   max: number;

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -46,7 +46,7 @@ function GeneratedSet({
   forwardedRef,
   lockedArmor2Mods,
   addLockedItem,
-  removeLockedItem
+  removeLockedItem,
 }: Props) {
   // Set the loadout property to show/hide the loadout menu
   const setCreateLoadout = (loadout: Loadout) => {
@@ -101,7 +101,7 @@ function GeneratedSet({
               <span>
                 <b>
                   {t('LoadoutBuilder.TierNumber', {
-                    tier: enabledTier
+                    tier: enabledTier,
                   })}
                 </b>
               </span>
@@ -109,7 +109,7 @@ function GeneratedSet({
                 <span className={styles.nonActiveStat}>
                   <b>
                     {` (${t('LoadoutBuilder.TierNumber', {
-                      tier: totalTier
+                      tier: totalTier,
                     })})`}
                   </b>
                 </span>
@@ -158,7 +158,7 @@ function GeneratedSet({
 function Stat({
   stat,
   isActive,
-  value
+  value,
 }: {
   stat: DestinyStatDefinition;
   isActive: boolean;
@@ -170,7 +170,7 @@ function Stat({
     >
       <b>
         {t('LoadoutBuilder.TierNumber', {
-          tier: statTier(value)
+          tier: statTier(value),
         })}
       </b>{' '}
       <BungieImage src={stat.displayProperties.icon} /> {stat.displayProperties.name}

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -16,7 +16,7 @@ export default function GeneratedSetButtons({
   store,
   set,
   numSets,
-  onLoadoutSet
+  onLoadoutSet,
 }: {
   store: DimStore;
   set: ArmorSet;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -40,7 +40,7 @@ export default function GeneratedSetItem({
   itemOptions,
   lockedMods,
   addLockedItem,
-  removeLockedItem
+  removeLockedItem,
 }: {
   item: DimItem;
   locked?: readonly LockedItemType[];
@@ -53,7 +53,7 @@ export default function GeneratedSetItem({
 }) {
   const altPerks = useMemo(() => identifyAltPerkChoicesForChosenStats(item, statValues), [
     item,
-    statValues
+    statValues,
   ]);
 
   const classesByHash = altPerks.reduce(
@@ -75,7 +75,7 @@ export default function GeneratedSetItem({
       const { item } = await showItemPicker({
         prompt: t('LoadoutBuilder.ChooseAlternate'),
         hideStoreEquip: true,
-        filterItems: (item: DimItem) => ids.has(item.id)
+        filterItems: (item: DimItem) => ids.has(item.id),
       });
 
       addLockedItem({ type: 'item', item, bucket: item.bucket });

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -56,7 +56,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
 
   private handleWindowResize = _.throttle(() => this.setState({ rowHeight: 0, rowWidth: 0 }), 300, {
     leading: false,
-    trailing: true
+    trailing: true,
   });
 
   constructor(props: Props) {
@@ -96,7 +96,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
       combos,
       combosWithoutCaps,
       enabledStats,
-      lockedArmor2Mods
+      lockedArmor2Mods,
     } = this.props;
     const { rowHeight, rowWidth, rowColumns } = this.state;
 
@@ -202,7 +202,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
     const { lockedMap, onLockedMapChanged } = this.props;
     onLockedMapChanged({
       ...lockedMap,
-      [item.bucket.hash]: addLockedItem(item, lockedMap[item.bucket.hash])
+      [item.bucket.hash]: addLockedItem(item, lockedMap[item.bucket.hash]),
     });
   };
 
@@ -210,7 +210,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
     const { lockedMap, onLockedMapChanged } = this.props;
     onLockedMapChanged({
       ...lockedMap,
-      [item.bucket.hash]: removeLockedItem(item, lockedMap[item.bucket.hash])
+      [item.bucket.hash]: removeLockedItem(item, lockedMap[item.bucket.hash]),
     });
   };
 }

--- a/src/app/loadout-builder/generated-sets/TierSelect.tsx
+++ b/src/app/loadout-builder/generated-sets/TierSelect.tsx
@@ -24,7 +24,7 @@ export default function TierSelect({
   rowClassName,
   order,
   onStatOrderChanged,
-  onStatFiltersChanged
+  onStatFiltersChanged,
 }: {
   stats: { [statType in StatTypes]: MinMaxIgnored };
   statRanges: { [statType in StatTypes]: MinMax };
@@ -109,7 +109,7 @@ function DraggableItem({
   index,
   name,
   className,
-  children
+  children,
 }: {
   id: string;
   index: number;
@@ -144,7 +144,7 @@ function MinMaxSelectInner({
   max,
   ignored,
   stats,
-  handleTierChange
+  handleTierChange,
 }: {
   stat: string;
   type: 'Min' | 'Max';
@@ -160,7 +160,7 @@ function MinMaxSelectInner({
       update = {
         min: stats[stat].min,
         max: stats[stat].max,
-        ignored: e.target.value === IGNORE
+        ignored: e.target.value === IGNORE,
       };
     } else {
       const value = parseInt(e.target.value, 10);
@@ -170,7 +170,7 @@ function MinMaxSelectInner({
         [lower]: value,
         [opposite]:
           opposite === 'min' ? Math.min(stats[stat].min, value) : Math.max(stats[stat].max, value),
-        ignored: false
+        ignored: false,
       };
     }
 
@@ -188,7 +188,7 @@ function MinMaxSelectInner({
       {_.range(min, max + 1).map((tier) => (
         <option key={tier} value={tier}>
           {t('LoadoutBuilder.TierNumber', {
-            tier
+            tier,
           })}
         </option>
       ))}

--- a/src/app/loadout-builder/generated-sets/mod-utils.ts
+++ b/src/app/loadout-builder/generated-sets/mod-utils.ts
@@ -8,7 +8,7 @@ const energyOrder = [
   DestinyEnergyType.Void,
   DestinyEnergyType.Thermal,
   DestinyEnergyType.Arc,
-  DestinyEnergyType.Any
+  DestinyEnergyType.Any,
 ];
 
 /**

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -7,7 +7,7 @@ import {
   DestinyInventoryItemDefinition,
   TierType,
   DestinyItemSubType,
-  DestinyEnergyType
+  DestinyEnergyType,
 } from 'bungie-api-ts/destiny2';
 import { chainComparator, compareBy, Comparator } from 'app/utils/comparators';
 import { statKeys } from '../process';
@@ -24,7 +24,7 @@ const unwantedSockets = new Set([
   1514141500, // Solar damage resistance
   2973005342, // Shaders
   3356843615, // Ornaments
-  2457930460 // Empty masterwork slot
+  2457930460, // Empty masterwork slot
 ]);
 
 /**

--- a/src/app/loadout-builder/locked-armor/LoadoutBucketDropTarget.tsx
+++ b/src/app/loadout-builder/locked-armor/LoadoutBucketDropTarget.tsx
@@ -5,7 +5,7 @@ import {
   DropTarget,
   DropTargetConnector,
   DropTargetMonitor,
-  DropTargetSpec
+  DropTargetSpec,
 } from 'react-dnd';
 import { DimItem } from '../../inventory/item-types';
 
@@ -38,7 +38,7 @@ const dropSpec: DropTargetSpec<Props> = {
   drop(props, monitor) {
     const item = monitor.getItem().item as DimItem;
     props.onItemLocked(item);
-  }
+  },
 };
 
 // This forwards drag and drop state into props on the component
@@ -49,7 +49,7 @@ function collect(connect: DropTargetConnector, monitor: DropTargetMonitor): Inte
     connectDropTarget: connect.dropTarget(),
     // You can ask the monitor about the current drag state:
     isOver: monitor.isOver(),
-    canDrop: monitor.canDrop()
+    canDrop: monitor.canDrop(),
   };
 }
 
@@ -64,7 +64,7 @@ class LoadoutBucketDropTarget extends React.Component<Props> {
       <div
         className={clsx(className, {
           'on-drag-hover': canDrop && isOver,
-          'on-drag-enter': canDrop
+          'on-drag-enter': canDrop,
         })}
       >
         {children}

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -7,7 +7,7 @@ import {
   BurnItem,
   LockedModBase,
   LockedArmor2Mod,
-  ModPickerCategory
+  ModPickerCategory,
 } from '../types';
 import BungieImageAndAmmo from '../../dim-ui/BungieImageAndAmmo';
 import styles from './SelectableBungieImage.m.scss';
@@ -28,7 +28,7 @@ const badPerk = new Set([
   527286589, // unflinching kinetic aim
   952165152, // power dexterity
   377666359, // energy dexterity
-  2326218464 // kinetic dexterity
+  2326218464, // kinetic dexterity
 ]);
 
 /**
@@ -42,7 +42,7 @@ export function SelectableMod({
   selected,
   unselectable,
   onLockedPerk,
-  onLockedModBase
+  onLockedModBase,
 }: {
   mod: DestinyInventoryItemDefinition;
   // plugSet this mod appears in
@@ -69,7 +69,7 @@ export function SelectableMod({
     <div
       className={clsx(styles.perk, {
         [styles.lockedPerk]: selected,
-        [styles.unselectable]: unselectable
+        [styles.unselectable]: unselectable,
       })}
       onClick={handleClick}
       role="button"
@@ -92,7 +92,7 @@ export function SelectableArmor2Mod({
   defs,
   selected,
   unselectable,
-  onLockedArmor2Mod
+  onLockedArmor2Mod,
 }: {
   mod: DestinyInventoryItemDefinition;
   category: ModPickerCategory;
@@ -109,7 +109,7 @@ export function SelectableArmor2Mod({
     <div
       className={clsx(styles.perk, {
         [styles.lockedPerk]: selected,
-        [styles.unselectable]: unselectable
+        [styles.unselectable]: unselectable,
       })}
       onClick={handleClick}
       role="button"
@@ -133,7 +133,7 @@ export function SelectablePerk({
   defs,
   selected,
   unselectable,
-  onLockedPerk
+  onLockedPerk,
 }: {
   perk: DestinyInventoryItemDefinition;
   bucket: InventoryBucket;
@@ -154,7 +154,7 @@ export function SelectablePerk({
     <div
       className={clsx(styles.perk, {
         [styles.lockedPerk]: selected,
-        [styles.unselectable]: unselectable
+        [styles.unselectable]: unselectable,
       })}
       onClick={handleClick}
       role="button"
@@ -163,7 +163,7 @@ export function SelectablePerk({
       <BungieImageAndAmmo
         className={clsx({
           [styles.goodPerk]: perk.hash === 1818103563,
-          [styles.badPerk]: isBadPerk
+          [styles.badPerk]: isBadPerk,
         })}
         hash={perk.hash}
         alt=""
@@ -191,7 +191,7 @@ export function SelectableBurn({
   bucket,
   selected,
   unselectable,
-  onLockedPerk
+  onLockedPerk,
 }: {
   burn: BurnItem;
   bucket: InventoryBucket;
@@ -208,7 +208,7 @@ export function SelectableBurn({
     <div
       className={clsx(styles.perk, {
         [styles.lockedPerk]: selected,
-        [styles.unselectable]: unselectable
+        [styles.unselectable]: unselectable,
       })}
       onClick={handleClick}
       role="button"

--- a/src/app/loadout-builder/process.ts
+++ b/src/app/loadout-builder/process.ts
@@ -9,7 +9,7 @@ import {
   ItemsByBucket,
   LockedMap,
   LockedArmor2Mod,
-  LockedArmor2ModMap
+  LockedArmor2ModMap,
 } from './types';
 import { statTier, canSlotMod } from './generated-sets/utils';
 import { reportException } from 'app/utils/exceptions';
@@ -25,7 +25,7 @@ export const statHashes: { [type in StatTypes]: number } = {
   Recovery: 1943323491,
   Discipline: 1735777505,
   Intellect: 144602215,
-  Strength: 4244567218
+  Strength: 4244567218,
 };
 export const statValues = Object.values(statHashes);
 export const statKeys = Object.keys(statHashes) as StatTypes[];
@@ -35,7 +35,7 @@ const bucketsToCategories = {
   [LockableBuckets.gauntlets]: Armor2ModPlugCategories.gauntlets,
   [LockableBuckets.chest]: Armor2ModPlugCategories.chest,
   [LockableBuckets.leg]: Armor2ModPlugCategories.leg,
-  [LockableBuckets.classitem]: Armor2ModPlugCategories.classitem
+  [LockableBuckets.classitem]: Armor2ModPlugCategories.classitem,
 };
 
 /**
@@ -255,7 +255,7 @@ export function process(
       'combinations'
     );
     reportException('Loadout Optimizer', new Error('Loadout Optimizer crash while processing'), {
-      combos: existingTask
+      combos: existingTask,
     });
   }
   localStorage.setItem('loadout-optimizer', combos.toString());
@@ -279,7 +279,7 @@ export function process(
                 chests[chestsKey],
                 legs[legsKey],
                 classitems[classItemsKey],
-                ghosts[ghostsKey]
+                ghosts[ghostsKey],
               ];
 
               const firstValidSet = getFirstValidSet(armor);
@@ -290,7 +290,7 @@ export function process(
                   keyToStats(chestsKey),
                   keyToStats(legsKey),
                   keyToStats(classItemsKey),
-                  keyToStats(ghostsKey)
+                  keyToStats(ghostsKey),
                 ];
 
                 const maxPower = getPower(firstValidSet);
@@ -320,7 +320,7 @@ export function process(
                 if (existingSetAtTier) {
                   existingSetAtTier.sets.push({
                     armor,
-                    statChoices
+                    statChoices,
                   });
                   if (maxPower > existingSetAtTier.maxPower) {
                     existingSetAtTier.firstValidSet = firstValidSet;
@@ -333,8 +333,8 @@ export function process(
                     sets: [
                       {
                         armor,
-                        statChoices
-                      }
+                        statChoices,
+                      },
                     ],
                     stats: stats as {
                       [statType in StatTypes]: number;
@@ -342,7 +342,7 @@ export function process(
                     // TODO: defer calculating first valid set / statchoices / maxpower?
                     firstValidSet,
                     firstValidSetStatChoices: statChoices,
-                    maxPower
+                    maxPower,
                   };
                 }
               }
@@ -475,7 +475,7 @@ function generateMixesFromPerksOrStats(
 
   const statsByHash = _.keyBy(stats, (stat) => stat.statHash);
   const mixes: number[][] = [
-    getBaseStatValues(statsByHash, item, assumeArmor2IsMasterwork, lockedModStats)
+    getBaseStatValues(statsByHash, item, assumeArmor2IsMasterwork, lockedModStats),
   ];
 
   const altPerks: (DimPlug[] | null)[] = [null];

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -120,5 +120,5 @@ export const LockableBuckets = {
   chest: 14239492,
   leg: 20886954,
   classitem: 1585787867,
-  ghost: 4023194814
+  ghost: 4023194814,
 };

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -52,14 +52,14 @@ export function editLoadout(loadout: Loadout, { showClass = true, isNew = true }
   editLoadout$.next({
     loadout,
     showClass,
-    isNew
+    isNew,
   });
 }
 
 export function addItemToLoadout(item: DimItem, $event) {
   addItem$.next({
     item,
-    clickEvent: $event
+    clickEvent: $event,
   });
 }
 
@@ -104,7 +104,7 @@ function mapStateToProps() {
     stores: storesSelector(state),
     buckets: state.inventory.buckets!,
     defs:
-      destinyVersionSelector(state) === 2 ? state.manifest.d2Manifest! : state.manifest.d1Manifest!
+      destinyVersionSelector(state) === 2 ? state.manifest.d2Manifest! : state.manifest.d1Manifest!,
   });
 }
 
@@ -113,7 +113,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
     show: false,
     showClass: true,
     isNew: false,
-    clashingLoadout: null
+    clashingLoadout: null,
   };
   private subscriptions = new Subscriptions();
 
@@ -255,7 +255,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
           warnitems.push({
             ...loadoutItem,
             icon: itemDef.displayProperties.icon,
-            name: itemDef.displayProperties.name
+            name: itemDef.displayProperties.name,
           } as DimItem);
         }
       }
@@ -279,7 +279,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
       show: true,
       loadout,
       showClass: Boolean(args.showClass),
-      isNew: Boolean(args.isNew)
+      isNew: Boolean(args.isNew),
     });
   };
 
@@ -302,7 +302,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
 
         // don't show information related to selected perks so we don't give the impression
         // that we will update perk selections when applying the loadout
-        ignoreSelectedPerks: true
+        ignoreSelectedPerks: true,
       });
 
       this.add(item, undefined, equip);
@@ -326,7 +326,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
         id: item.id,
         hash: item.hash,
         amount: Math.min(item.amount, e?.shiftKey ? 5 : 1),
-        equipped: false
+        equipped: false,
       };
 
       // Other items of the same type (as DimItem)
@@ -365,7 +365,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
           } else {
             showNotification({
               type: 'warning',
-              title: t('Loadouts.MaxSlots', { slots: maxSlots })
+              title: t('Loadouts.MaxSlots', { slots: maxSlots }),
             });
           }
         } else if (dupe && item.maxStackSize > 1) {
@@ -382,7 +382,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
         }
       });
       return {
-        loadout: newLoadout
+        loadout: newLoadout,
       };
     });
   };
@@ -451,12 +451,12 @@ class LoadoutDrawer extends React.Component<Props, State> {
         type: 'error',
         title: t('Loadouts.ClashingTitle'),
         body: t('Loadouts.ClashingDescription', {
-          loadoutName: clashingLoadout.name
+          loadoutName: clashingLoadout.name,
         }),
         onClick: () => {
           this.setState({ show: true, clashingLoadout: copy(clashingLoadout) });
           loadoutDialogOpen = true;
-        }
+        },
       });
     }
   };
@@ -467,9 +467,9 @@ class LoadoutDrawer extends React.Component<Props, State> {
       this.setState({
         loadout: {
           ...loadout,
-          name: ''
+          name: '',
         },
-        clashingLoadout: null
+        clashingLoadout: null,
       });
     }
   }
@@ -480,8 +480,8 @@ class LoadoutDrawer extends React.Component<Props, State> {
       title: t('Loadouts.SaveErrorTitle'),
       body: t('Loadouts.SaveErrorDescription', {
         loadoutName: name,
-        error: e.message
-      })
+        error: e.message,
+      }),
     });
     console.error(e);
     this.close(e);
@@ -496,7 +496,7 @@ class LoadoutDrawer extends React.Component<Props, State> {
     }
     const newLoadout = {
       ...copy(loadout),
-      id: uuidv4() // Let it be a new ID
+      id: uuidv4(), // Let it be a new ID
     };
     this.setState({ loadout: newLoadout, isNew: true });
     this.saveLoadout(e, newLoadout);
@@ -513,8 +513,8 @@ class LoadoutDrawer extends React.Component<Props, State> {
     this.setState((state) => ({
       loadout: {
         ...state.loadout!,
-        items: state.loadout!.items.filter((i) => !(i.hash === item.hash && i.id === item.id))
-      }
+        items: state.loadout!.items.filter((i) => !(i.hash === item.hash && i.id === item.id)),
+      },
     }));
   };
 

--- a/src/app/loadout/LoadoutDrawerBucket.tsx
+++ b/src/app/loadout/LoadoutDrawerBucket.tsx
@@ -13,7 +13,7 @@ export default function LoadoutDrawerBucket({
   itemSortOrder,
   pickLoadoutItem,
   equip,
-  remove
+  remove,
 }: {
   bucket: InventoryBucket;
   loadoutItems: LoadoutItem[];

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -37,7 +37,7 @@ const loadoutTypes = [
   'Ship',
   'Ships',
   'Vehicle',
-  'Horn'
+  'Horn',
 ];
 
 // We don't want to prepopulate the loadout with a bunch of cosmetic junk
@@ -56,7 +56,7 @@ export const fromEquippedTypes = [
   'Leg',
   'ClassItem',
   'Artifact',
-  'Ghost'
+  'Ghost',
 ];
 
 export default function LoadoutDrawerContents(
@@ -69,7 +69,7 @@ export default function LoadoutDrawerContents(
     itemSortOrder,
     equip,
     remove,
-    add
+    add,
   }: {
     loadout: Loadout;
     buckets: InventoryBuckets;
@@ -164,7 +164,7 @@ async function pickLoadoutItem(
 
       // don't show information related to selected perks so we don't give the impression
       // that we will update perk selections when applying the loadout
-      ignoreSelectedPerks: true
+      ignoreSelectedPerks: true,
     });
 
     add(item, undefined, equip);

--- a/src/app/loadout/LoadoutDrawerDropTarget.tsx
+++ b/src/app/loadout/LoadoutDrawerDropTarget.tsx
@@ -4,7 +4,7 @@ import {
   DropTargetSpec,
   DropTargetConnector,
   DropTargetMonitor,
-  ConnectDropTarget
+  ConnectDropTarget,
 } from 'react-dnd';
 import clsx from 'clsx';
 import { DimItem } from '../inventory/item-types';
@@ -42,14 +42,14 @@ const dropSpec: DropTargetSpec<Props> = {
     // But equipping has requirements
     const item = monitor.getItem().item as DimItem;
     return item.canBeInLoadout();
-  }
+  },
 };
 
 // This forwards drag and drop state into props on the component
 function collect(connect: DropTargetConnector, monitor: DropTargetMonitor): InternalProps {
   return {
     connectDropTarget: connect.dropTarget(),
-    isOver: monitor.isOver() && monitor.canDrop()
+    isOver: monitor.isOver() && monitor.canDrop(),
   };
 }
 
@@ -60,7 +60,7 @@ class LoadoutDrawerDropTarget extends React.Component<Props> {
     return connectDropTarget(
       <div
         className={clsx('loadout-drop', {
-          'on-drag-hover': isOver
+          'on-drag-hover': isOver,
         })}
       >
         {children}

--- a/src/app/loadout/LoadoutDrawerItem.tsx
+++ b/src/app/loadout/LoadoutDrawerItem.tsx
@@ -5,7 +5,7 @@ import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 export default function LoadoutDrawerItem({
   item,
   equip,
-  remove
+  remove,
 }: {
   item: DimItem;
   equip(item: DimItem, e: React.MouseEvent): void;

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -13,7 +13,7 @@ export default function LoadoutDrawerOptions({
   classTypeOptions,
   updateLoadout,
   saveLoadout,
-  saveAsNew
+  saveAsNew,
 }: {
   loadout?: Loadout;
   showClass: boolean;
@@ -34,21 +34,21 @@ export default function LoadoutDrawerOptions({
   const setName = (e: React.ChangeEvent<HTMLInputElement>) => {
     updateLoadout({
       ...loadout,
-      name: e.target.value
+      name: e.target.value,
     });
   };
 
   const setClassType = (e: React.ChangeEvent<HTMLSelectElement>) => {
     updateLoadout({
       ...loadout,
-      classType: parseInt(e.target.value, 10)
+      classType: parseInt(e.target.value, 10),
     });
   };
 
   const setClearSpace = (e: React.ChangeEvent<HTMLInputElement>) => {
     updateLoadout({
       ...loadout,
-      clearSpace: e.target.checked
+      clearSpace: e.target.checked,
     });
   };
 

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -15,7 +15,7 @@ import {
   gatherEngramsLoadout,
   searchLoadout,
   randomLoadout,
-  maxLightItemSet
+  maxLightItemSet,
 } from './auto-loadouts';
 import { querySelector } from '../shell/reducer';
 import { newLoadout, getLight, convertToLoadoutItem } from './loadout-utils';
@@ -25,7 +25,7 @@ import {
   makeRoomForPostmaster,
   pullFromPostmaster,
   pullablePostmasterItems,
-  totalPostmasterItems
+  totalPostmasterItems,
 } from './postmaster';
 import { queueAction } from '../inventory/action-queue';
 import {
@@ -45,7 +45,7 @@ import {
   faRandom,
   hunterIcon,
   warlockIcon,
-  titanIcon
+  titanIcon,
 } from '../shell/icons';
 import { DimItem } from '../inventory/item-types';
 import { searchFilterSelector } from '../search/search-filters';
@@ -67,7 +67,7 @@ const loadoutIcon = {
   [DestinyClass.Unknown]: globeIcon,
   [DestinyClass.Hunter]: hunterIcon,
   [DestinyClass.Warlock]: warlockIcon,
-  [DestinyClass.Titan]: titanIcon
+  [DestinyClass.Titan]: titanIcon,
 };
 
 interface ProvidedProps {
@@ -124,7 +124,7 @@ function mapStateToProps() {
       classTypeId: dimStore.classType,
       account: currentAccountSelector(state)!,
       stores: storesSelector(state),
-      hasClassified: hasClassifiedSelector(state)
+      hasClassified: hasClassifiedSelector(state),
     };
   };
 }
@@ -138,7 +138,7 @@ class LoadoutPopup extends React.Component<Props> {
       loadouts,
       query,
       onClick,
-      hasClassified
+      hasClassified,
     } = this.props;
 
     // For the most part we don't need to memoize this - this menu is destroyed when closed
@@ -334,8 +334,8 @@ class LoadoutPopup extends React.Component<Props> {
           title: t('Loadouts.DeleteErrorTitle'),
           body: t('Loadouts.DeleteErrorDescription', {
             loadoutName: loadout.name,
-            error: e.message
-          })
+            error: e.message,
+          }),
         });
         console.error(e);
       }
@@ -452,6 +452,6 @@ export default connect<StoreProps>(mapStateToProps)(LoadoutPopup);
 export function filterLoadoutToEquipped(loadout: Loadout) {
   return {
     ...loadout,
-    items: loadout.items.filter((i) => i.equipped)
+    items: loadout.items.filter((i) => i.equipped),
   };
 }

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -74,7 +74,7 @@ export function maxLightLoadout(stores: DimStore[], store: DimStore): Loadout {
 const powerStatHashes = [
   1480404414, // D2 Attack
   3897883278, // D1 & D2 Defense
-  368428387 // D1 Attack
+  368428387, // D1 Attack
 ];
 
 /**
@@ -274,7 +274,7 @@ const randomLoadoutTypes = new Set([
   'Leg',
   'ClassItem',
   'Artifact',
-  'Ghost'
+  'Ghost',
 ]);
 
 /**

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -19,7 +19,7 @@ const outOfSpaceWarning = _.throttle((store) => {
   showNotification({
     type: 'info',
     title: t('FarmingMode.OutOfRoomTitle'),
-    body: t('FarmingMode.OutOfRoom', { character: store.name })
+    body: t('FarmingMode.OutOfRoom', { character: store.name }),
   });
 }, 60000);
 
@@ -75,7 +75,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
       savePreviousLoadout({
         storeId: store.id,
         loadoutId: loadout.id,
-        previousLoadout: loadoutFromAllItems(store, t('Loadouts.Before', { name: loadout.name }))
+        previousLoadout: loadoutFromAllItems(store, t('Loadouts.Before', { name: loadout.name })),
       })
     );
   }
@@ -84,7 +84,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
 
   const loadoutItemIds = items.map((i) => ({
     id: i.id,
-    hash: i.hash
+    hash: i.hash,
   }));
 
   // Only select stuff that needs to change state
@@ -145,7 +145,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
       item: DimItem | null;
       message: string;
       level: string;
-    }[]
+    }[],
   };
 
   if (itemsToDequip.length > 1) {
@@ -186,7 +186,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
       scope.errors.push({
         level: 'error',
         item,
-        message: t('Loadouts.CouldNotEquip', { itemname: item.name })
+        message: t('Loadouts.CouldNotEquip', { itemname: item.name }),
       });
     });
   }
@@ -248,7 +248,7 @@ async function applyLoadoutItems(
           const storesByAmount = _.sortBy(
             otherStores.map((store) => ({
               store,
-              amount: store.amountOfItem(pseudoItem)
+              amount: store.amountOfItem(pseudoItem),
             })),
             (v) => v.amount
           ).reverse();
@@ -264,7 +264,7 @@ async function applyLoadoutItems(
                 t('Loadouts.TooManyRequested', {
                   total: totalAmount,
                   itemname: item.name,
-                  requested: pseudoItem.amount
+                  requested: pseudoItem.amount,
                 })
               );
               error.level = 'warn';
@@ -295,7 +295,7 @@ async function applyLoadoutItems(
     scope.errors.push({
       item,
       level: e.level,
-      message: e.message
+      message: e.message,
     });
   }
 

--- a/src/app/loadout/loadout-storage.ts
+++ b/src/app/loadout/loadout-storage.ts
@@ -15,21 +15,21 @@ const enum LoadoutClass {
   any = -1,
   warlock = 0,
   titan = 1,
-  hunter = 2
+  hunter = 2,
 }
 
 const loadoutClassToClassType = {
   [LoadoutClass.warlock]: DestinyClass.Warlock,
   [LoadoutClass.titan]: DestinyClass.Titan,
   [LoadoutClass.hunter]: DestinyClass.Hunter,
-  [LoadoutClass.any]: DestinyClass.Unknown
+  [LoadoutClass.any]: DestinyClass.Unknown,
 };
 
 const classTypeToLoadoutClass = {
   [DestinyClass.Titan]: LoadoutClass.titan,
   [DestinyClass.Hunter]: LoadoutClass.hunter,
   [DestinyClass.Warlock]: LoadoutClass.warlock,
-  [DestinyClass.Unknown]: LoadoutClass.any
+  [DestinyClass.Unknown]: LoadoutClass.any,
 };
 
 /** The format loadouts are stored in. */
@@ -78,7 +78,7 @@ export function deleteLoadout(loadout: Loadout): ThunkResult {
     await SyncService.remove(loadout.id);
     // remove the loadout ID from the list of loadout IDs
     await SyncService.set({
-      'loadouts-v3.0': getState().loadouts.loadouts.map((l) => l.id)
+      'loadouts-v3.0': getState().loadouts.loadouts.map((l) => l.id),
     });
   };
 }
@@ -92,7 +92,7 @@ async function saveLoadouts(
 
   const data = {
     'loadouts-v3.0': loadoutPrimitives.map((l) => l.id),
-    ..._.keyBy(loadoutPrimitives, (l) => l.id)
+    ..._.keyBy(loadoutPrimitives, (l) => l.id),
   };
 
   await SyncService.set(data);
@@ -151,9 +151,9 @@ function convertToInMemoryFormat(loadoutPrimitive: DehydratedLoadout): Loadout {
       id: item.id || '0',
       hash: item.hash,
       amount: item.amount || 1,
-      equipped: Boolean(item.equipped)
+      equipped: Boolean(item.equipped),
     })),
-    clearSpace: loadoutPrimitive.clearSpace
+    clearSpace: loadoutPrimitive.clearSpace,
   };
 
   // Blizzard.net is no more, they're all Steam now
@@ -173,7 +173,7 @@ function convertToStorageFormat(
     id: item.id,
     hash: item.hash,
     amount: item.amount,
-    equipped: item.equipped
+    equipped: item.equipped,
   })) as DimItem[];
 
   // Try to fix up the membership IDs of old accounts.
@@ -196,7 +196,7 @@ function convertToStorageFormat(
     membershipId: loadout.membershipId,
     destinyVersion: loadout.destinyVersion,
     clearSpace: loadout.clearSpace,
-    items
+    items,
   };
 }
 

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -15,7 +15,7 @@ export function newLoadout(name: string, items: LoadoutItem[]): Loadout {
     // This gets overwritten in any path that'd save a real loadout, and apply doesn't care
     destinyVersion: 2,
     name,
-    items
+    items,
   };
 }
 
@@ -33,7 +33,7 @@ export function getLight(store: DimStore, items: DimItem[]): number {
     const itemWeight = {
       Weapons: 6,
       Armor: 5,
-      General: 4
+      General: 4,
     };
 
     const itemWeightDenominator = items.reduce(
@@ -142,6 +142,6 @@ export function convertToLoadoutItem(item: LoadoutItem, equipped: boolean) {
     id: item.id,
     hash: item.hash,
     amount: item.amount,
-    equipped
+    equipped,
   };
 }

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -34,7 +34,7 @@ export async function makeRoomForPostmaster(
               Uncommon: 1,
               Rare: 2,
               Legendary: 3,
-              Exotic: 4
+              Exotic: 4,
             }[i.tier];
             // And low-stat
             if (i.primStat) {
@@ -66,14 +66,14 @@ export async function makeRoomForPostmaster(
         count: postmasterItems.length,
         movedNum: itemsToMove.length,
         store: store.name,
-        context: store.genderName
-      })
+        context: store.genderName,
+      }),
     });
   } catch (e) {
     showNotification({
       type: 'error',
       title: t('Loadouts.MakeRoom'),
-      body: t('Loadouts.MakeRoomError', { error: e.message })
+      body: t('Loadouts.MakeRoomError', { error: e.message }),
     });
     throw e;
   }
@@ -114,7 +114,7 @@ const showNoSpaceError = _.throttle(
     showNotification({
       type: 'error',
       title: t('Loadouts.PullFromPostmasterPopupTitle'),
-      body: t('Loadouts.PullFromPostmasterError', { error: e.message })
+      body: t('Loadouts.PullFromPostmasterError', { error: e.message }),
     }),
   1000,
   { leading: true, trailing: false }
@@ -129,7 +129,7 @@ export async function pullFromPostmaster(store: DimStore): Promise<void> {
     showNotification({
       type: 'error',
       title: t('Loadouts.PullFromPostmasterPopupTitle'),
-      body: t('Loadouts.PullFromPostmasterError', { error: message })
+      body: t('Loadouts.PullFromPostmasterError', { error: message }),
     });
   });
 

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -9,7 +9,7 @@ import { createSelector } from 'reselect';
 import {
   Loadout as DimApiLoadout,
   LoadoutItem as DimApiLoadoutItem,
-  DestinyVersion
+  DestinyVersion,
 } from '@destinyitemmanager/dim-api-types';
 import { currentProfileSelector, apiPermissionGrantedSelector } from 'app/dim-api/selectors';
 import { emptyArray } from 'app/utils/empty';
@@ -76,7 +76,7 @@ export type LoadoutsAction = ActionType<typeof actions>;
 
 const initialState: LoadoutsState = {
   loadouts: [],
-  previousLoadouts: {}
+  previousLoadouts: {},
 };
 
 export const loadouts: Reducer<LoadoutsState, LoadoutsAction> = (
@@ -87,20 +87,20 @@ export const loadouts: Reducer<LoadoutsState, LoadoutsAction> = (
     case getType(actions.loaded):
       return {
         ...state,
-        loadouts: action.payload
+        loadouts: action.payload,
       };
 
     case getType(actions.deleteLoadout):
       return {
         ...state,
-        loadouts: state.loadouts.filter((l) => l.id !== action.payload)
+        loadouts: state.loadouts.filter((l) => l.id !== action.payload),
       };
 
     case getType(actions.updateLoadout): {
       const loadout = action.payload;
       return {
         ...state,
-        loadouts: [...state.loadouts.filter((l) => l.id !== loadout.id), loadout]
+        loadouts: [...state.loadouts.filter((l) => l.id !== loadout.id), loadout],
       };
     }
 
@@ -118,8 +118,8 @@ export const loadouts: Reducer<LoadoutsState, LoadoutsAction> = (
         ...state,
         previousLoadouts: {
           ...state.previousLoadouts,
-          [storeId]: previousLoadouts
-        }
+          [storeId]: previousLoadouts,
+        },
       };
     }
 
@@ -146,8 +146,8 @@ function convertDimApiLoadoutToLoadout(
     destinyVersion,
     items: [
       ...loadout.equipped.map((i) => convertDimApiLoadoutItemToLoadoutItem(i, true)),
-      ...loadout.unequipped.map((i) => convertDimApiLoadoutItemToLoadoutItem(i, false))
-    ]
+      ...loadout.unequipped.map((i) => convertDimApiLoadoutItemToLoadoutItem(i, false)),
+    ],
   };
 }
 
@@ -162,6 +162,6 @@ export function convertDimApiLoadoutItemToLoadoutItem(
     id: item.id || '0',
     hash: item.hash,
     amount: item.amount || 1,
-    equipped
+    equipped,
   };
 }

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -66,7 +66,7 @@ class ManifestService {
       } else if (e.status < 200 || e.status >= 400) {
         message = t('BungieService.NetworkError', {
           status: e.status,
-          statusText: e.statusText
+          statusText: e.statusText,
         });
       } else {
         // Something may be wrong with the manifest
@@ -130,7 +130,7 @@ class ManifestService {
       showNotification({
         title: t('Help.NoStorage'),
         body: t('Help.NoStorageMessage'),
-        type: 'error'
+        type: 'error',
       });
     }
   }

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -56,7 +56,7 @@ const tableTrimmers = {
     }
 
     return table;
-  }
+  },
 };
 
 class ManifestService {
@@ -79,7 +79,7 @@ class ManifestService {
           showNotification({
             type: 'warning',
             title: t('Manifest.Outdated'),
-            body: t('Manifest.OutdatedExplanation')
+            body: t('Manifest.OutdatedExplanation'),
           });
         }
       });
@@ -87,7 +87,7 @@ class ManifestService {
     10000,
     {
       leading: true,
-      trailing: false
+      trailing: false,
     }
   );
 
@@ -131,7 +131,7 @@ class ManifestService {
       } else if (e.status < 200 || e.status >= 400) {
         message = t('BungieService.NetworkError', {
           status: e.status,
-          statusText: e.statusText
+          statusText: e.statusText,
         });
       } else {
         // Something may be wrong with the manifest
@@ -234,7 +234,7 @@ class ManifestService {
       showNotification({
         title: t('Help.NoStorage'),
         body: t('Help.NoStorageMessage'),
-        type: 'error'
+        type: 'error',
       });
     }
   }

--- a/src/app/manifest/reducer.ts
+++ b/src/app/manifest/reducer.ts
@@ -22,14 +22,14 @@ export const manifest: Reducer<ManifestState, ManifestAction | AccountsAction> =
     case getType(actions.setD1Manifest): {
       return {
         ...state,
-        d1Manifest: action.payload
+        d1Manifest: action.payload,
       };
     }
 
     case getType(actions.setD2Manifest): {
       return {
         ...state,
-        d2Manifest: action.payload
+        d2Manifest: action.payload,
       };
     }
 

--- a/src/app/notifications/Notification.tsx
+++ b/src/app/notifications/Notification.tsx
@@ -65,7 +65,7 @@ export default function Notification({ notification, style, onClose }: Props) {
   const progressBarProps = useSpring({
     from: { width: '0%' },
     to: { width: mouseover || Boolean(!error && !success && notification.promise) ? '0%' : '100%' },
-    config: mouseover ? config.default : { ...config.default, duration: notification.duration }
+    config: mouseover ? config.default : { ...config.default, duration: notification.duration },
   });
 
   return (

--- a/src/app/notifications/NotificationButton.tsx
+++ b/src/app/notifications/NotificationButton.tsx
@@ -8,7 +8,7 @@ import styles from './NotificationButton.m.scss';
  */
 export default function NotificationButton({
   children,
-  onClick
+  onClick,
 }: {
   children: React.ReactChild | React.ReactChild[];
   onClick(e: React.MouseEvent): void;

--- a/src/app/notifications/NotificationsContainer.tsx
+++ b/src/app/notifications/NotificationsContainer.tsx
@@ -28,7 +28,7 @@ export default function NotificationsContainer() {
     config: spring,
     from: { opacity: 0, height: 0 },
     enter: [{ height: 'auto' }, { opacity: 1 }],
-    leave: [{ opacity: 0 }, { height: 0 }]
+    leave: [{ opacity: 0 }, { height: 0 }],
   });
 
   return (

--- a/src/app/notifications/notifications.ts
+++ b/src/app/notifications/notifications.ts
@@ -38,6 +38,6 @@ export function showNotification(notification: NotifyInput) {
     id: notificationId++,
     duration: 5000,
     type: 'info',
-    ...notification
+    ...notification,
   });
 }

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -4,7 +4,7 @@ import {
   lockIcon,
   powerIndicatorIcon,
   thumbsDownIcon,
-  thumbsUpIcon
+  thumbsUpIcon,
 } from 'app/shell/icons';
 import { ColumnDefinition, ColumnGroup, SortDirection } from './table-types';
 import { DestinyClass, DestinyCollectibleState } from 'bungie-api-ts/destiny2';
@@ -77,11 +77,11 @@ export function getColumns(
 
   const statsGroup: ColumnGroup = {
     id: 'stats',
-    header: t('Organizer.Columns.Stats')
+    header: t('Organizer.Columns.Stats'),
   };
   const baseStatsGroup: ColumnGroup = {
     id: 'baseStats',
-    header: t('Organizer.Columns.BaseStats')
+    header: t('Organizer.Columns.BaseStats'),
   };
 
   // Some stat labels are long. This lets us replace them with i18n
@@ -90,7 +90,7 @@ export function getColumns(
     4188031367: t('Organizer.Stats.Reload'), // Reload Speed
     1345609583: t('Organizer.Stats.Aim'), // Aim Assistance
     2715839340: t('Organizer.Stats.Recoil'), // Recoil Direction
-    1931675084: t('Organizer.Stats.Inventory') // Inventory Size
+    1931675084: t('Organizer.Stats.Inventory'), // Inventory Size
   };
 
   type ColumnWithStat = ColumnDefinition & { statHash: number };
@@ -119,7 +119,7 @@ export function getColumns(
             }
             return <ItemStatValue stat={stat} item={item} />;
           },
-          filter: (value) => `stat:${_.invert(statHashByName)[statHash]}:>=${value}`
+          filter: (value) => `stat:${_.invert(statHashByName)[statHash]}:>=${value}`,
         };
       }
     ),
@@ -132,7 +132,7 @@ export function getColumns(
     columnGroup: baseStatsGroup,
     value: (item: DimItem) => item.stats?.find((s) => s.statHash === column.statHash)?.base,
     cell: (value) => value,
-    filter: (value) => `basestat:${_.invert(statHashByName)[column.statHash]}:>=${value}`
+    filter: (value) => `basestat:${_.invert(statHashByName)[column.statHash]}:>=${value}`,
   }));
 
   const isGhost = itemsType === 'ghost';
@@ -159,34 +159,34 @@ export function getColumns(
         </ItemPopupTrigger>
       ),
       noSort: true,
-      noHide: true
+      noHide: true,
     },
     {
       id: 'name',
       header: t('Organizer.Columns.Name'),
       value: (i) => i.name,
-      filter: (name) => `name:"${name}"`
+      filter: (name) => `name:"${name}"`,
     },
     !isGhost && {
       id: 'power',
       header: <AppIcon icon={powerIndicatorIcon} />,
       value: (item) => item.primStat?.value,
       defaultSort: SortDirection.DESC,
-      filter: (value) => `power:>=${value}`
+      filter: (value) => `power:>=${value}`,
     },
     !isGhost && {
       id: 'dmg',
       header: isArmor ? t('Organizer.Columns.Element') : t('Organizer.Columns.Damage'),
       value: (item) => item.element?.displayProperties.name,
       cell: (_, item) => <ElementIcon className={styles.inlineIcon} element={item.element} />,
-      filter: (_, item) => `is:${getItemDamageShortName(item)}`
+      filter: (_, item) => `is:${getItemDamageShortName(item)}`,
     },
     isArmor && {
       id: 'energy',
       header: t('Organizer.Columns.Energy'),
       value: (item) => item.isDestiny2() && item.energy?.energyCapacity,
       defaultSort: SortDirection.DESC,
-      filter: (value) => `energycapacity>=:${value}`
+      filter: (value) => `energycapacity>=:${value}`,
     },
     {
       id: 'locked',
@@ -194,7 +194,7 @@ export function getColumns(
       value: (i) => i.locked,
       cell: (value) => (value ? <AppIcon icon={lockIcon} /> : undefined),
       defaultSort: SortDirection.DESC,
-      filter: (value) => (value ? 'is:locked' : 'not:locked')
+      filter: (value) => (value ? 'is:locked' : 'not:locked'),
     },
     {
       id: 'tag',
@@ -202,7 +202,7 @@ export function getColumns(
       value: (item) => getTag(item, itemInfos),
       cell: (value: TagValue) => <TagIcon tag={value} />,
       sort: compareBy((tag: TagValue) => (tag && tagConfig[tag] ? tagConfig[tag].sortOrder : 1000)),
-      filter: (value) => `tag:${value || 'none'}`
+      filter: (value) => `tag:${value || 'none'}`,
     },
     {
       id: 'new',
@@ -210,7 +210,7 @@ export function getColumns(
       value: (item) => newItems.has(item.id),
       cell: (value) => (value ? <NewItemIndicator /> : undefined),
       defaultSort: SortDirection.DESC,
-      filter: (value) => (value ? 'is:new' : 'not:new')
+      filter: (value) => (value ? 'is:new' : 'not:new'),
     },
     isWeapon &&
       hasWishList && {
@@ -229,7 +229,7 @@ export function getColumns(
           ) : undefined,
         sort: compareBy((wishList) => (wishList === undefined ? 0 : wishList === true ? -1 : 1)),
         filter: (value) =>
-          value === true ? 'is:wishlist' : value === false ? 'is:trashlist' : 'not:wishlist'
+          value === true ? 'is:wishlist' : value === false ? 'is:trashlist' : 'not:wishlist',
       },
     {
       id: 'reacquireable',
@@ -241,7 +241,7 @@ export function getColumns(
         !(item.collectibleState & DestinyCollectibleState.PurchaseDisabled),
       defaultSort: SortDirection.DESC,
       cell: booleanCell,
-      filter: (value) => (value ? 'is:reacquireable' : 'not:reaquireable')
+      filter: (value) => (value ? 'is:reacquireable' : 'not:reaquireable'),
     },
     $featureFlags.reviewsEnabled && {
       id: 'rating',
@@ -255,19 +255,19 @@ export function getColumns(
           </>
         ) : undefined,
       defaultSort: SortDirection.DESC,
-      filter: (value) => `rating:>=${value}`
+      filter: (value) => `rating:>=${value}`,
     },
     {
       id: 'tier',
       header: t('Organizer.Columns.Tier'),
       value: (i) => i.tier,
-      filter: (value) => `is:${value}`
+      filter: (value) => `is:${value}`,
     },
     {
       id: 'source',
       header: t('Organizer.Columns.Source'),
       value: source,
-      filter: (value) => `source:${value}`
+      filter: (value) => `source:${value}`,
     },
     {
       id: 'year',
@@ -278,24 +278,24 @@ export function getColumns(
           : item.isDestiny2()
           ? D2SeasonInfo[item.season].year
           : undefined,
-      filter: (value) => `year:${value}`
+      filter: (value) => `year:${value}`,
     },
     {
       id: 'season',
       header: t('Organizer.Columns.Season'),
       value: (i) => i.isDestiny2() && i.season,
-      filter: (value) => `season:${value}`
+      filter: (value) => `season:${value}`,
     },
     {
       id: 'event',
       header: t('Organizer.Columns.Event'),
       value: (item) => (item.isDestiny2() && item.event ? D2EventInfo[item.event].name : undefined),
-      filter: (value) => `event:${value}`
+      filter: (value) => `event:${value}`,
     },
     isGhost && {
       id: 'ghost',
       header: t('Organizer.Columns.Ghost'),
-      value: (item) => ghostBadgeContent(item).join('')
+      value: (item) => ghostBadgeContent(item).join(''),
     },
     isArmor && {
       id: 'modslot',
@@ -304,7 +304,7 @@ export function getColumns(
       value: getItemSpecialtyModSlotDisplayName,
       cell: (value, item) =>
         value && <SpecialtyModSlotIcon className={styles.modslotIcon} item={item} />,
-      filter: (value) => `modslot:${value}`
+      filter: (value) => `modslot:${value}`,
     },
     isWeapon && {
       id: 'archetype',
@@ -318,7 +318,8 @@ export function getColumns(
         !item.isExotic && item.isDestiny2() && !item.energy ? (
           <div>
             {_.compact([
-              item.sockets?.categories.find((c) => c.category.hash === 3956125808)?.sockets[0]?.plug
+              item.sockets?.categories.find((c) => c.category.hash === 3956125808)?.sockets[0]
+                ?.plug,
             ]).map((p) => (
               <PressTip
                 key={p.plugItem.hash}
@@ -332,7 +333,7 @@ export function getColumns(
             ))}
           </div>
         ) : undefined,
-      filter: (value) => `perkname:"${value}"`
+      filter: (value) => `perkname:"${value}"`,
     },
     {
       id: 'perks',
@@ -341,7 +342,7 @@ export function getColumns(
       cell: (_, item) => <PerksCell defs={defs} item={item} />,
       noSort: true,
       gridWidth: 'minmax(324px,max-content)',
-      filter: (value) => `perkname:"${value}"`
+      filter: (value) => `perkname:"${value}"`,
     },
     isWeapon && {
       id: 'traits',
@@ -350,7 +351,7 @@ export function getColumns(
       cell: (_, item) => <PerksCell defs={defs} item={item} traitsOnly={true} />,
       noSort: true,
       gridWidth: 'minmax(180px,max-content)',
-      filter: (value) => `perkname:"${value}"`
+      filter: (value) => `perkname:"${value}"`,
     },
     ...statColumns,
     ...baseStatColumns,
@@ -364,19 +365,19 @@ export function getColumns(
       ),
       value: (item) =>
         _.sumBy(item.stats, (s) => (customTotalStat.includes(s.statHash) ? s.base : 0)),
-      defaultSort: SortDirection.DESC
+      defaultSort: SortDirection.DESC,
     },
     isWeapon && {
       id: 'masterworkTier',
       header: t('Organizer.Columns.MasterworkTier'),
       value: (item) => (item.isDestiny2() ? item.masterworkInfo?.tier : undefined),
       defaultSort: SortDirection.DESC,
-      filter: (value) => `masterwork:>=${value}`
+      filter: (value) => `masterwork:>=${value}`,
     },
     isWeapon && {
       id: 'masterworkStat',
       header: t('Organizer.Columns.MasterworkStat'),
-      value: (item) => (item.isDestiny2() ? item.masterworkInfo?.statName : undefined)
+      value: (item) => (item.isDestiny2() ? item.masterworkInfo?.statName : undefined),
     },
     isWeapon && {
       id: 'killTracker',
@@ -396,7 +397,7 @@ export function getColumns(
             {value}
           </div>
         ),
-      defaultSort: SortDirection.DESC
+      defaultSort: SortDirection.DESC,
     },
     {
       id: 'loadouts',
@@ -414,14 +415,14 @@ export function getColumns(
           )
         );
       },
-      noSort: true
+      noSort: true,
     },
     {
       id: 'notes',
       header: t('Organizer.Columns.Notes'),
       value: (item) => getNotes(item, itemInfos),
       gridWidth: 'minmax(200px, 1fr)',
-      filter: (value) => `notes:"${value}"`
+      filter: (value) => `notes:"${value}"`,
     },
     isWeapon &&
       hasWishList && {
@@ -429,8 +430,8 @@ export function getColumns(
         header: t('Organizer.Columns.WishListNotes'),
         value: (item) => wishList?.[item.id]?.notes,
         gridWidth: 'minmax(200px, 1fr)',
-        filter: (value) => `wishlistnotes:"${value}"`
-      }
+        filter: (value) => `wishlistnotes:"${value}"`,
+      },
   ]);
 
   return columns;
@@ -439,7 +440,7 @@ export function getColumns(
 function PerksCell({
   defs,
   item,
-  traitsOnly
+  traitsOnly,
 }: {
   defs: D2ManifestDefinitions;
   item: DimItem;
@@ -470,7 +471,7 @@ function PerksCell({
         <div
           key={socket.socketIndex}
           className={clsx(styles.modPerks, {
-            [styles.isPerk]: socket.isPerk && socket.plugOptions.length > 1
+            [styles.isPerk]: socket.isPerk && socket.plugOptions.length > 1,
           })}
         >
           {socket.plugOptions.map(

--- a/src/app/organizer/DropDown.tsx
+++ b/src/app/organizer/DropDown.tsx
@@ -38,7 +38,7 @@ function DropDown({
   buttonDisabled,
   dropDownItems,
   forClass,
-  right
+  right,
 }: {
   buttonText: ReactNode;
   buttonDisabled?: boolean;

--- a/src/app/organizer/EnabledColumnsSelector.tsx
+++ b/src/app/organizer/EnabledColumnsSelector.tsx
@@ -20,7 +20,7 @@ export default React.memo(function EnabledColumnsSelector({
   columns,
   enabledColumns,
   forClass,
-  onChangeEnabledColumn
+  onChangeEnabledColumn,
 }: {
   columns: ColumnDefinition[];
   enabledColumns: string[];
@@ -43,7 +43,7 @@ export default React.memo(function EnabledColumnsSelector({
         id,
         content: header,
         checked,
-        onItemSelect: () => onChangeEnabledColumn({ id, checked: !checked })
+        onItemSelect: () => onChangeEnabledColumn({ id, checked: !checked }),
       };
     }
   }

--- a/src/app/organizer/ItemActions.tsx
+++ b/src/app/organizer/ItemActions.tsx
@@ -15,7 +15,7 @@ function ItemActions({
   onLock,
   onNote,
   onTagSelectedItems,
-  onMoveSelectedItems
+  onMoveSelectedItems,
 }: {
   stores: DimStore[];
   itemsAreSelected: boolean;
@@ -31,7 +31,7 @@ function ItemActions({
         {tagInfo.icon && <AppIcon icon={tagInfo.icon} />} {t(tagInfo.label)}
       </>
     ),
-    onItemSelect: () => onTagSelectedItems(tagInfo)
+    onItemSelect: () => onTagSelectedItems(tagInfo),
   }));
 
   const moveItems: DropDownItem[] = stores.map((store) => ({
@@ -41,7 +41,7 @@ function ItemActions({
         <img height="16" width="16" src={store.icon} /> {store.name}
       </>
     ),
-    onItemSelect: () => onMoveSelectedItems(store)
+    onItemSelect: () => onMoveSelectedItems(store),
   }));
 
   const noted = () => {

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -47,7 +47,7 @@ import Dropzone, { DropzoneOptions } from 'react-dropzone';
 const categoryToClass = {
   23: DestinyClass.Hunter,
   22: DestinyClass.Titan,
-  21: DestinyClass.Warlock
+  21: DestinyClass.Warlock,
 };
 
 interface ProvidedProps {
@@ -109,7 +109,7 @@ function mapStateToProps() {
       ],
       customTotalStatsByClass: settingsSelector(state).customTotalStatsByClass,
       loadouts: loadoutsSelector(state),
-      newItems: state.inventory.newItems
+      newItems: state.inventory.newItems,
     };
   };
 }
@@ -130,10 +130,10 @@ function ItemTable({
   customTotalStatsByClass,
   loadouts,
   newItems,
-  dispatch
+  dispatch,
 }: Props) {
   const [columnSorts, setColumnSorts] = useState<ColumnSort[]>([
-    { columnId: 'name', sort: SortDirection.ASC }
+    { columnId: 'name', sort: SortDirection.ASC },
   ]);
   const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
   // Track the last selection for shift-selecting
@@ -198,7 +198,7 @@ function ItemTable({
       customStatTotal,
       classIfAny,
       loadouts,
-      newItems
+      newItems,
     ]
   );
 
@@ -216,12 +216,12 @@ function ItemTable({
   // process items into Rows
   const unsortedRows: Row[] = useMemo(() => buildRows(items, filteredColumns), [
     filteredColumns,
-    items
+    items,
   ]);
   const rows = useMemo(() => sortRows(unsortedRows, columnSorts, filteredColumns), [
     unsortedRows,
     filteredColumns,
-    columnSorts
+    columnSorts,
   ]);
 
   const shiftHeld = useShiftHeld();
@@ -264,13 +264,13 @@ function ItemTable({
         type: 'success',
         title: state
           ? t('Filter.LockAllSuccess', { num: selectedItems.length })
-          : t('Filter.UnlockAllSuccess', { num: selectedItems.length })
+          : t('Filter.UnlockAllSuccess', { num: selectedItems.length }),
       });
     } catch (e) {
       showNotification({
         type: 'error',
         title: state ? t('Filter.LockAllFailed') : t('Filter.UnlockAllFailed'),
-        body: e.message
+        body: e.message,
       });
     } finally {
       // Touch the stores service to update state
@@ -358,7 +358,7 @@ function ItemTable({
         if (columnSort.columnId === column.id) {
           newColumnSorts[index] = {
             ...columnSort,
-            sort: columnSort.sort === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC
+            sort: columnSort.sort === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC,
           };
           found = true;
           break;
@@ -368,7 +368,7 @@ function ItemTable({
       if (!found) {
         newColumnSorts.push({
           columnId: column.id,
-          sort: column.defaultSort || SortDirection.ASC
+          sort: column.defaultSort || SortDirection.ASC,
         });
       }
       return newColumnSorts;
@@ -576,7 +576,7 @@ function buildRows(items: DimItem[], filteredColumns: ColumnDefinition[]) {
     values: filteredColumns.reduce((memo, col) => {
       memo[col.id] = col.value(item);
       return memo;
-    }, {})
+    }, {}),
   }));
   return unsortedRows;
 }
@@ -639,7 +639,7 @@ function buildStatInfo(
             lowerBetter: stat.smallerIsBetter,
             getStat(item) {
               return item.stats ? item.stats.find((s) => s.statHash === stat.statHash) : undefined;
-            }
+            },
           };
         }
       }
@@ -651,7 +651,7 @@ function buildStatInfo(
 function TableRow({
   row,
   filteredColumns,
-  narrowQueryFunction
+  narrowQueryFunction,
 }: {
   row: Row;
   filteredColumns: ColumnDefinition[];
@@ -667,7 +667,7 @@ function TableRow({
           key={column.id}
           onClick={narrowQueryFunction(row, column)}
           className={clsx(styles[column.id], {
-            [styles.hasFilter]: column.filter
+            [styles.hasFilter]: column.filter,
           })}
           role="cell"
         >

--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -53,7 +53,7 @@ const armorHashes = {
   46: gauntlets,
   47: chest,
   48: legs,
-  49: classItem
+  49: classItem,
 };
 
 /**
@@ -72,7 +72,7 @@ export const getSelectionTree = memoizeOne(
           id: category.originBucketIdentifier,
           itemCategoryHash: categoryHash,
           terminal: true,
-          icon: armorHashes[categoryHash]
+          icon: armorHashes[categoryHash],
         };
       }
     );
@@ -82,19 +82,19 @@ export const getSelectionTree = memoizeOne(
       id: 'kinetic',
       itemCategoryHash: 2,
       terminal: true,
-      icon: dmgKinetic
+      icon: dmgKinetic,
     };
     const energy = {
       id: 'energy',
       itemCategoryHash: 3,
       terminal: true,
-      icon: energyWeapon
+      icon: energyWeapon,
     };
     const power = {
       id: 'power',
       itemCategoryHash: 4,
       terminal: true,
-      icon: powerWeapon
+      icon: powerWeapon,
     };
 
     return {
@@ -111,111 +111,111 @@ export const getSelectionTree = memoizeOne(
               itemCategoryHash: 5,
               subCategories: [kinetic, energy],
               terminal: true,
-              icon: autoRifle
+              icon: autoRifle,
             },
             {
               id: 'handcannon',
               itemCategoryHash: 6,
               subCategories: [kinetic, energy],
               terminal: true,
-              icon: handCannon
+              icon: handCannon,
             },
             {
               id: 'pulserifle',
               itemCategoryHash: 7,
               subCategories: [kinetic, energy],
               terminal: true,
-              icon: pulseRifle
+              icon: pulseRifle,
             },
             {
               id: 'scoutrifle',
               itemCategoryHash: 8,
               subCategories: [kinetic, energy],
               terminal: true,
-              icon: scoutRifle
+              icon: scoutRifle,
             },
             {
               id: 'fusionrifle',
               itemCategoryHash: 9,
               subCategories: [energy, power],
               terminal: true,
-              icon: fusionRifle
+              icon: fusionRifle,
             },
             {
               id: 'sniperrifle',
               itemCategoryHash: 10,
               subCategories: [kinetic, energy, power],
               terminal: true,
-              icon: sniperRifle
+              icon: sniperRifle,
             },
             {
               id: 'shotgun',
               itemCategoryHash: 11,
               subCategories: [kinetic, energy, power],
               terminal: true,
-              icon: shotgun
+              icon: shotgun,
             },
             {
               id: 'machinegun',
               itemCategoryHash: 12,
               terminal: true,
-              icon: machinegun
+              icon: machinegun,
             },
             {
               id: 'rocketlauncher',
               itemCategoryHash: 13,
               terminal: true,
-              icon: rLauncher
+              icon: rLauncher,
             },
             {
               id: 'sidearm',
               itemCategoryHash: 14,
               subCategories: [kinetic, energy],
               terminal: true,
-              icon: sidearm
+              icon: sidearm,
             },
             {
               id: 'sword',
               itemCategoryHash: 54,
               terminal: true,
-              icon: sword
+              icon: sword,
             },
             {
               id: 'grenadelauncher',
               itemCategoryHash: 153950757,
               subCategories: [kinetic, energy, power],
               terminal: true,
-              icon: gLauncher
+              icon: gLauncher,
             },
             {
               id: 'tracerifle',
               itemCategoryHash: 2489664120,
               subCategories: [kinetic, energy],
               terminal: true,
-              icon: traceRifle
+              icon: traceRifle,
             },
             {
               id: 'linearfusionrifle',
               itemCategoryHash: 1504945536,
               subCategories: [kinetic, power],
               terminal: true,
-              icon: lFusionRifle
+              icon: lFusionRifle,
             },
             {
               id: 'submachine',
               itemCategoryHash: 3954685534,
               subCategories: [kinetic, energy],
               terminal: true,
-              icon: smg
+              icon: smg,
             },
             {
               id: 'bow',
               itemCategoryHash: 3317538576,
               subCategories: [kinetic, energy, power],
               terminal: true,
-              icon: bow
-            }
-          ]
+              icon: bow,
+            },
+          ],
         },
         {
           id: 'armor',
@@ -226,29 +226,29 @@ export const getSelectionTree = memoizeOne(
               id: 'hunter',
               itemCategoryHash: 23,
               subCategories: armorCategories,
-              icon: hunter
+              icon: hunter,
             },
             {
               id: 'titan',
               itemCategoryHash: 22,
               subCategories: armorCategories,
-              icon: titan
+              icon: titan,
             },
             {
               id: 'warlock',
               itemCategoryHash: 21,
               subCategories: armorCategories,
-              icon: warlock
-            }
-          ]
+              icon: warlock,
+            },
+          ],
         },
         {
           id: 'ghosts',
           itemCategoryHash: 39,
           icon: ghost,
-          terminal: true
-        }
-      ]
+          terminal: true,
+        },
+      ],
     };
   }
 );
@@ -260,7 +260,7 @@ export const getSelectionTree = memoizeOne(
 export default function ItemTypeSelector({
   defs,
   selection,
-  onSelection
+  onSelection,
 }: {
   defs: D2ManifestDefinitions;
   selection: ItemCategoryTreeNode[];
@@ -281,7 +281,7 @@ export default function ItemTypeSelector({
                 <label
                   key={subCategory.itemCategoryHash}
                   className={clsx(styles.button, {
-                    [styles.checked]: selection[depth + 1] === subCategory
+                    [styles.checked]: selection[depth + 1] === subCategory,
                   })}
                 >
                   <input

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -32,7 +32,7 @@ function mapStateToProps() {
   return (state: RootState): StoreProps => ({
     defs: state.manifest.d2Manifest!,
     stores: storesSelector(state),
-    isPhonePortrait: state.shell.isPhonePortrait
+    isPhonePortrait: state.shell.isPhonePortrait,
   });
 }
 

--- a/src/app/organizer/table-types.ts
+++ b/src/app/organizer/table-types.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 export const enum SortDirection {
   ASC,
-  DESC
+  DESC,
 }
 
 type Value = string | number | boolean | undefined;

--- a/src/app/progress/CompletionCheckbox.tsx
+++ b/src/app/progress/CompletionCheckbox.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 
 export default function CompletionCheckbox({ completed }: { completed: boolean }) {
   const classes = clsx('objective-checkbox', {
-    'objective-complete': completed
+    'objective-complete': completed,
   });
 
   return <div className={classes} />;

--- a/src/app/progress/CrucibleRank.tsx
+++ b/src/app/progress/CrucibleRank.tsx
@@ -54,7 +54,7 @@ export function CrucibleRank(props: CrucibleRankProps) {
         </div>
         <div className="faction-level">
           {t('Progress.PercentPrestige', {
-            pct: Math.round((progress.currentProgress / rankTotal) * 100)
+            pct: Math.round((progress.currentProgress / rankTotal) * 100),
           })}
         </div>
         {Boolean(resets.currentResetCount) && (

--- a/src/app/progress/FactionIcon.tsx
+++ b/src/app/progress/FactionIcon.tsx
@@ -1,7 +1,7 @@
 import {
   DestinyFactionDefinition,
   DestinyProgression,
-  DestinyVendorComponent
+  DestinyVendorComponent,
 } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { bungieNetPath } from '../dim-ui/BungieImage';

--- a/src/app/progress/LoadoutRequirementModifier.tsx
+++ b/src/app/progress/LoadoutRequirementModifier.tsx
@@ -42,7 +42,7 @@ const itemSubTypeToItemCategoryHash: { [key in DestinyItemSubType]: number } = {
   [DestinyItemSubType.GrenadeLauncher]: 153950757,
   [DestinyItemSubType.SubmachineGun]: 3954685534,
   [DestinyItemSubType.TraceRifle]: 2489664120,
-  [DestinyItemSubType.Bow]: 3317538576
+  [DestinyItemSubType.Bow]: 3317538576,
 };
 
 /**
@@ -52,7 +52,7 @@ const itemSubTypeToItemCategoryHash: { [key in DestinyItemSubType]: number } = {
 const equipmentSlotHashToItemCategoryHash = {
   1498876634: 2, // Kinetic
   2465295065: 3, // Energy
-  953998645: 4 // Power
+  953998645: 4, // Power
 };
 
 /**
@@ -65,7 +65,7 @@ const equipmentSlotHashToItemCategoryHash = {
  */
 export default function LoadoutRequirementModifier({
   activity,
-  defs
+  defs,
 }: {
   activity: DestinyMilestoneChallengeActivity;
   defs: D2ManifestDefinitions;
@@ -86,7 +86,7 @@ export default function LoadoutRequirementModifier({
       .displayProperties.name,
     types: req.allowedWeaponSubTypes.map(
       (sub) => defs.ItemCategory.get(itemSubTypeToItemCategoryHash[sub]).displayProperties.name
-    )
+    ),
   }));
 
   const description = (

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -18,7 +18,7 @@ export default function Milestones({
   profileInfo,
   store,
   defs,
-  buckets
+  buckets,
 }: {
   store: DimStore;
   profileInfo: DestinyProfileResponse;
@@ -36,7 +36,7 @@ export default function Milestones({
 
   const milestoneItems = [
     ...milestonesForCharacter(defs, profileInfo, store),
-    ...profileMilestones
+    ...profileMilestones,
   ].flatMap((milestone) => milestoneToItems(milestone, defs, buckets, store.classType));
 
   return (

--- a/src/app/progress/Objective.tsx
+++ b/src/app/progress/Objective.tsx
@@ -4,7 +4,7 @@ import { D1ManifestDefinitions } from '../destiny1/d1-definitions';
 import {
   DestinyObjectiveProgress,
   DestinyUnlockValueUIStyle,
-  DestinyObjectiveDefinition
+  DestinyObjectiveDefinition,
 } from 'bungie-api-ts/destiny2';
 import ObjectiveDescription from './ObjectiveDescription';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
@@ -18,7 +18,7 @@ import '../item-popup/ItemObjectives.scss';
 export default function Objective({
   defs,
   objective,
-  suppressObjectiveDescription
+  suppressObjectiveDescription,
 }: {
   defs: D2ManifestDefinitions | D1ManifestDefinitions;
   objective: DestinyObjectiveProgress;
@@ -68,11 +68,11 @@ export default function Objective({
 
   const classes = clsx('objective-row', {
     'objective-complete': complete,
-    'objective-boolean': isBoolean
+    'objective-boolean': isBoolean,
   });
 
   const progressBarStyle = {
-    width: percent(progress / completionValue)
+    width: percent(progress / completionValue),
   };
 
   // TODO: green pips, red pips
@@ -102,7 +102,7 @@ export default function Objective({
 export function ObjectiveValue({
   objectiveDef,
   progress,
-  completionValue = 0
+  completionValue = 0,
 }: {
   objectiveDef: DestinyObjectiveDefinition | undefined;
   progress: number;

--- a/src/app/progress/ObjectiveDescription.tsx
+++ b/src/app/progress/ObjectiveDescription.tsx
@@ -9,7 +9,7 @@ import RichDestinyText from 'app/dim-ui/RichDestinyText';
 export default function ObjectiveDescription({
   progressDescription,
   objectiveDef,
-  defs
+  defs,
 }: {
   progressDescription: string;
   objectiveDef?: DestinyObjectiveDefinition;

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -51,7 +51,7 @@ function mapStateToProps(state: RootState): StoreProps {
     stores: sortedStoresSelector(state),
     defs: state.manifest.d2Manifest,
     buckets: state.inventory.buckets,
-    profileInfo: profileResponseSelector(state)
+    profileInfo: profileResponseSelector(state),
   };
 }
 
@@ -137,21 +137,21 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets, profileInfo
     { id: 'Items', title: t('Progress.Items') },
     { id: 'raids', title: raidTitle },
     { id: 'triumphs', title: triumphTitle },
-    { id: 'seals', title: sealTitle }
+    { id: 'seals', title: sealTitle },
   ];
   const externalLinks = [
     {
       href: `https://braytech.org/${account.originalPlatformType}/${account.membershipId}/${selectedStore.id}/`,
       title: 'BrayTech.org',
-      logo: braytechLogo
+      logo: braytechLogo,
     },
     { href: 'https://destinysets.com/', title: 'DestinySets', logo: destinySetsLogo },
     { href: 'https://lowlidev.com.au/destiny/maps', title: 'lowlidev maps' },
     {
       href: `https://www.d2checklist.com/${account.originalPlatformType}/${account.membershipId}`,
       title: 'D2Checklist',
-      logo: d2ChecklistLogo
-    }
+      logo: d2ChecklistLogo,
+    },
   ];
 
   return (

--- a/src/app/progress/Pursuit.tsx
+++ b/src/app/progress/Pursuit.tsx
@@ -33,7 +33,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
 
   return {
     isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,
-    searchHidden: !searchFilterSelector(state)(item)
+    searchHidden: !searchFilterSelector(state)(item),
   };
 }
 

--- a/src/app/progress/PursuitItem.tsx
+++ b/src/app/progress/PursuitItem.tsx
@@ -34,7 +34,7 @@ function PursuitItem(
     !expired &&
     showProgressBoolean(item.objectives);
   const itemImageStyles = {
-    [styles.tracked]: item.tracked
+    [styles.tracked]: item.tracked,
   };
   return (
     <div
@@ -52,7 +52,7 @@ function PursuitItem(
       {item.maxStackSize > 1 && item.amount > 1 && (
         <div
           className={clsx(styles.amount, {
-            [styles.fullstack]: item.maxStackSize > 1 && item.amount === item.maxStackSize
+            [styles.fullstack]: item.maxStackSize > 1 && item.amount === item.maxStackSize,
           })}
         >
           {item.amount.toString()}

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -26,7 +26,7 @@ const pursuitsOrder = ['Bounties', 'Quests', 'Items'];
  */
 export default function Pursuits({
   store,
-  defs
+  defs,
 }: {
   store: DimStore;
   defs?: D2ManifestDefinitions;

--- a/src/app/progress/RaidDisplay.tsx
+++ b/src/app/progress/RaidDisplay.tsx
@@ -1,6 +1,6 @@
 import {
   DestinyDisplayPropertiesDefinition,
-  DestinyMilestoneChallengeActivity
+  DestinyMilestoneChallengeActivity,
 } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import BungieImage from '../dim-ui/BungieImage';
@@ -42,7 +42,7 @@ export function RaidDisplay(props: Props) {
 export function RaidActivity({
   defs,
   activity,
-  displayName
+  displayName,
 }: {
   defs: D2ManifestDefinitions;
   activity: DestinyMilestoneChallengeActivity;

--- a/src/app/progress/Raids.tsx
+++ b/src/app/progress/Raids.tsx
@@ -12,7 +12,7 @@ const raidOrder = [
   2683538554, // sos
   3181387331, // wish
   1342567285, // scourge
-  2590427074 // crown
+  2590427074, // crown
 ];
 
 /**
@@ -22,7 +22,7 @@ const raidOrder = [
 export default function Raids({
   store,
   defs,
-  profileInfo
+  profileInfo,
 }: {
   store: DimStore;
   defs: D2ManifestDefinitions;

--- a/src/app/progress/Ranks.tsx
+++ b/src/app/progress/Ranks.tsx
@@ -8,7 +8,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
  */
 export default function Ranks({
   profileInfo,
-  defs
+  defs,
 }: {
   profileInfo: DestinyProfileResponse;
   defs: D2ManifestDefinitions;
@@ -24,20 +24,20 @@ export default function Ranks({
       // Valor
       progressionInfo: firstCharacterProgression[2626549951],
       resetInfo: firstCharacterProgression[3882308435],
-      streakInfo: firstCharacterProgression[2203850209]
+      streakInfo: firstCharacterProgression[2203850209],
     },
     {
       // Glory
       progressionInfo: firstCharacterProgression[2000925172],
       resetInfo: firstCharacterProgression[2679551909],
-      streakInfo: firstCharacterProgression[2572719399]
+      streakInfo: firstCharacterProgression[2572719399],
     },
     {
       // Infamy
       progressionInfo: firstCharacterProgression[2772425241],
       resetInfo: firstCharacterProgression[2772425241],
-      streakInfo: firstCharacterProgression[2939151659]
-    }
+      streakInfo: firstCharacterProgression[2939151659],
+    },
   ];
 
   return (

--- a/src/app/progress/Reward.tsx
+++ b/src/app/progress/Reward.tsx
@@ -6,7 +6,7 @@ import BungieImage from '../dim-ui/BungieImage';
 
 export function Reward({
   reward,
-  defs
+  defs,
 }: {
   reward: DestinyItemQuantity;
   defs: D2ManifestDefinitions;

--- a/src/app/progress/SeasonalRank.tsx
+++ b/src/app/progress/SeasonalRank.tsx
@@ -6,7 +6,7 @@ import {
   DestinySeasonDefinition,
   DestinySeasonPassDefinition,
   DestinyProfileResponse,
-  DestinyClass
+  DestinyClass,
 } from 'bungie-api-ts/destiny2';
 import Countdown from 'app/dim-ui/Countdown';
 import { t } from 'app/i18next-t';
@@ -22,7 +22,7 @@ export default function SeasonalRank({
   characterProgressions,
   season,
   seasonPass,
-  profileInfo
+  profileInfo,
 }: {
   store: DimStore;
   defs: D2ManifestDefinitions;
@@ -99,7 +99,7 @@ export default function SeasonalRank({
   return (
     <div
       className={clsx('seasonal-rank', 'milestone-quest', {
-        'has-premium-rewards': hasPremiumRewards
+        'has-premium-rewards': hasPremiumRewards,
       })}
     >
       <div className="milestone-icon">
@@ -121,7 +121,7 @@ export default function SeasonalRank({
               <div
                 className={clsx('seasonal-reward-wrapper', styles.pursuit, {
                   free: item.uiDisplayStyle === 'free',
-                  premium: item.uiDisplayStyle === 'premium'
+                  premium: item.uiDisplayStyle === 'premium',
                 })}
                 key={itemInfo.hash}
               >
@@ -185,6 +185,6 @@ function fakeReward(hash: number, level: number) {
     itemHash: hash,
     quantity: 1,
     rewardedAtProgressionLevel: level,
-    uiDisplayStyle: 'free'
+    uiDisplayStyle: 'free',
   };
 }

--- a/src/app/progress/WellRestedPerkIcon.tsx
+++ b/src/app/progress/WellRestedPerkIcon.tsx
@@ -5,14 +5,14 @@ import BungieImage from '../dim-ui/BungieImage';
 import {
   DestinyCharacterProgressionComponent,
   DestinySeasonDefinition,
-  DestinySeasonPassDefinition
+  DestinySeasonPassDefinition,
 } from 'bungie-api-ts/destiny2';
 
 export default function WellRestedPerkIcon({
   defs,
   progressions,
   season,
-  seasonPass
+  seasonPass,
 }: {
   defs: D2ManifestDefinitions;
   progressions: DestinyCharacterProgressionComponent;

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -10,7 +10,7 @@ import {
   DestinyMilestoneRewardEntry,
   DestinyMilestoneRewardCategoryDefinition,
   DestinyMilestoneType,
-  DestinyObjectiveProgress
+  DestinyObjectiveProgress,
 } from 'bungie-api-ts/destiny2';
 import { t } from 'app/i18next-t';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
@@ -101,7 +101,7 @@ function availableQuestToItem(
       places: [],
       activityTypes: [],
       modifierHashes: availableQuest?.activity?.modifierHashes || [],
-      rewards: questRewards.map((r) => ({ itemHash: r.hash, quantity: 1 }))
+      rewards: questRewards.map((r) => ({ itemHash: r.hash, quantity: 1 })),
     };
   }
 
@@ -139,7 +139,7 @@ function activityMilestoneToItem(
       places: [],
       activityTypes: [],
       modifierHashes: milestone.activities[0].modifierHashes || [],
-      rewards
+      rewards,
     };
   }
 
@@ -158,7 +158,7 @@ function weeklyClanMilestoneToItems(
 
   const displayProperties = {
     ...milestoneDef.displayProperties,
-    ...reward.displayProperties
+    ...reward.displayProperties,
   };
 
   const dimItem = makeFakePursuitItem(
@@ -174,7 +174,7 @@ function weeklyClanMilestoneToItems(
     places: [],
     activityTypes: [],
     modifierHashes: [],
-    rewards: reward.items
+    rewards: reward.items,
   };
 
   return dimItem;
@@ -237,7 +237,7 @@ function makeFakePursuitItem(
     source: null,
     collectibleState: null,
     collectibleHash: null,
-    missingSockets: false
+    missingSockets: false,
   });
 
   return dimItem;

--- a/src/app/safari-touch-fix.ts
+++ b/src/app/safari-touch-fix.ts
@@ -10,7 +10,7 @@ export function safariTouchFix() {
       get() {
         supportsPassive = true;
         return supportsPassive;
-      }
+      },
     });
     window.addEventListener('testPassive', _.noop, opts);
     window.removeEventListener('testPassive', _.noop, opts);

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -12,7 +12,7 @@ const youTubeLink =
 
 function mapStateToProps(state: RootState) {
   return {
-    destinyVersion: destinyVersionSelector(state)
+    destinyVersion: destinyVersionSelector(state),
   };
 }
 
@@ -592,89 +592,89 @@ function FilterHelp({ destinyVersion }: { destinyVersion: DestinyVersion }) {
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.FWC'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.DO'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.NM'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.Speaker'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Vendor', { vendor: 'Variks', context: 'noname' })
+                      __html: t('Filter.Vendor', { vendor: 'Variks', context: 'noname' }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.Shipwright'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Vendor', { vendor: 'Osiris', context: 'noname' })
+                      __html: t('Filter.Vendor', { vendor: 'Osiris', context: 'noname' }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Vendor', { vendor: 'Xûr', context: 'noname' })
+                      __html: t('Filter.Vendor', { vendor: 'Xûr', context: 'noname' }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Vendor', { vendor: 'Shaxx', context: 'noname' })
+                      __html: t('Filter.Vendor', { vendor: 'Shaxx', context: 'noname' }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.CQ'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Vendor', { vendor: 'Eris Morn', context: 'noname' })
+                      __html: t('Filter.Vendor', { vendor: 'Eris Morn', context: 'noname' }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.EV'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
                       __html: t('Filter.Vendor', {
                         vendor: t('Filter.Vendors.Gunsmith'),
-                        context: 'noname'
-                      })
+                        context: 'noname',
+                      }),
                     }}
                   />
                 </td>
@@ -751,87 +751,87 @@ function FilterHelp({ destinyVersion }: { destinyVersion: DestinyVersion }) {
                 <td>
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Release', { release: t('Filter.Releases.Vanilla') })
+                      __html: t('Filter.Release', { release: t('Filter.Releases.Vanilla') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.QW') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.QW') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.IB') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.IB') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.VoG') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.VoG') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.CE') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.CE') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.PoE') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.PoE') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.ToO') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.ToO') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Release', { release: t('Filter.Releases.tTK') })
+                      __html: t('Filter.Release', { release: t('Filter.Releases.tTK') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.CoE') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.CoE') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.KF') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.KF') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.SRL') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.SRL') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.CD') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.CD') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Release', { release: t('Filter.Releases.RoI') })
+                      __html: t('Filter.Release', { release: t('Filter.Releases.RoI') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.AF') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.AF') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.WotM') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.WotM') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.Dawning') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.Dawning') }),
                     }}
                   />
                   <span
                     dangerouslySetInnerHTML={{
-                      __html: t('Filter.Activity', { release: t('Filter.Activities.AoT') })
+                      __html: t('Filter.Activity', { release: t('Filter.Activities.AoT') }),
                     }}
                   />
                 </td>

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -56,7 +56,7 @@ type DispatchProps = {
 const mapDispatchToProps: MapDispatchToPropsFunction<DispatchProps, StoreProps> = (dispatch) => ({
   setSearchQuery: (query) => dispatch(setSearchQuery(query, true)),
   bulkTagItems: (items, tag) => dispatch(bulkTagItems(items, tag) as any),
-  touchStores: touch
+  touchStores: touch,
 });
 
 type Props = ProvidedProps & StoreProps & DispatchProps;
@@ -85,7 +85,7 @@ function mapStateToProps(state: RootState): StoreProps {
     searchQuery: querySelector(state),
     searchQueryVersion: searchQueryVersionSelector(state),
     filteredItems,
-    isComparable
+    isComparable,
   };
 }
 
@@ -115,13 +115,13 @@ export class SearchFilter extends React.Component<Props, State> {
             type: 'success',
             title: state
               ? t('Filter.LockAllSuccess', { num: lockables.length })
-              : t('Filter.UnlockAllSuccess', { num: lockables.length })
+              : t('Filter.UnlockAllSuccess', { num: lockables.length }),
           });
         } catch (e) {
           showNotification({
             type: 'error',
             title: state ? t('Filter.LockAllFailed') : t('Filter.UnlockAllFailed'),
-            body: e.message
+            body: e.message,
           });
         } finally {
           // Touch the stores service to update state
@@ -149,7 +149,7 @@ export class SearchFilter extends React.Component<Props, State> {
       searchQuery,
       searchQueryVersion,
       filteredItems,
-      isComparable
+      isComparable,
     } = this.props;
     const { showSelect } = this.state;
 
@@ -224,5 +224,5 @@ export class SearchFilter extends React.Component<Props, State> {
 }
 
 export default connect<StoreProps, DispatchProps>(mapStateToProps, mapDispatchToProps, null, {
-  forwardRef: true
+  forwardRef: true,
 })(SearchFilter);

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -55,7 +55,7 @@ const filterNames = [
   'perk',
   'perkname',
   'name',
-  'description'
+  'description',
 ];
 
 /**
@@ -102,7 +102,7 @@ export default class SearchFilterInput extends React.Component<Props, State> {
                 this.focusFilterInput();
                 event.preventDefault();
                 event.stopPropagation();
-              }
+              },
             },
             {
               combo: 'shift+f',
@@ -112,8 +112,8 @@ export default class SearchFilterInput extends React.Component<Props, State> {
                 this.focusFilterInput();
                 event.preventDefault();
                 event.stopPropagation();
-              }
-            }
+              },
+            },
           ]}
         />
         <AppIcon icon={searchIcon} />
@@ -259,11 +259,11 @@ export default class SearchFilterInput extends React.Component<Props, State> {
           replace(word: string) {
             word = word.toLowerCase();
             return word.startsWith('is:') && word.startsWith('not:') ? `${word} ` : word;
-          }
-        }
+          },
+        },
       ],
       {
-        zIndex: 1000
+        zIndex: 1000,
       }
     );
 

--- a/src/app/search/search-filter-hashes.ts
+++ b/src/app/search/search-filter-hashes.ts
@@ -23,7 +23,7 @@ export const D1CategoryHashes = {
   machinegun: 12,
   rocketlauncher: 13,
   sidearm: 14,
-  sword: 54
+  sword: 54,
 };
 
 /** D2 has these item types but D1 doesn't */
@@ -36,7 +36,7 @@ export const D2CategoryHashes = {
   transmat: 208981632,
   weaponmod: 610365472,
   armormod: 4104513227,
-  reptoken: 2088636411
+  reptoken: 2088636411,
 };
 
 /** these are checked against default rolls to determine if something's curated */
@@ -51,14 +51,14 @@ export const curatedPlugsWhitelist = [
   2619833294, // scopes
   2718120384, // magazines_gl
   2833605196, // barrels
-  3809303875 // bowstring
+  3809303875, // bowstring
 ];
 
 /** write something here */
 export const lightStats = [
   1480404414, // D2 Attack
   3897883278, // D1 & D2 Defense
-  368428387 // D1 Attack
+  368428387, // D1 Attack
 ];
 
 /** compare against DimItem.type in EN */
@@ -76,7 +76,7 @@ export const cosmeticTypes = [
   'Ship',
   'Ships',
   'ClanBanners',
-  'Finishers'
+  'Finishers',
 ];
 
 /** sublime engrams */
@@ -90,7 +90,7 @@ export const sublimeEngrams = [
   3592189221, // -leg-armor
   738642122,
   3797169075, // -helmet
-  838904328
+  838904328,
 ];
 
 /** powerful rewards listed in quests or bounties */
@@ -108,7 +108,7 @@ export const powerfulSources = [
   3829523414, // InventoryItem "Luminous Planetary Engram"
   4143344829, // InventoryItem "Luminous Engram"
   4039143015, // InventoryItem "Powerful Gear"
-  4249081773 // InventoryItem "Powerful Armor"
+  4249081773, // InventoryItem "Powerful Armor"
 ];
 
 /** season 3 swag from rasputin */
@@ -117,21 +117,21 @@ export const ikelos = [
   1723472487, // InventoryItem "IKELOS_SMG_v1.0.1"
   1887808042, // InventoryItem "IKELOS_SG_v1.0.1"
   3866356643, // InventoryItem "IKELOS_HC_v1.0.1"
-  4036115577 //  InventoryItem "Sleeper Simulant"
+  4036115577, //  InventoryItem "Sleeper Simulant"
 ];
 
 export const boosts = [
   1043138475, // -black-wax-idol
   1772853454, // -blue-polyphage
   3783295803, // -ether-seeds
-  3446457162 // -resupply-codes
+  3446457162, // -resupply-codes
 ];
 
 export const supplies = [
   269776572, // -house-banners
   3632619276, // -silken-codex
   2904517731, // -axiomatic-beads
-  1932910919 // -network-keys
+  1932910919, // -network-keys
 ];
 
 /** for D1 items: used to calculate which vendor an item could have come from */
@@ -150,15 +150,15 @@ export const vendorHashes = {
     cq: [1362425043], // SOURCE_VENDOR_CRUCIBLE_QUARTERMASTER / Crucible Quartermaster
     eris: [1374970038], // SOURCE_VENDOR_CROTAS_BANE / Eris Morn
     ev: [3559790162], // SOURCE_VENDOR_SPECIAL_ORDERS / Eververse
-    gunsmith: [353834582] // SOURCE_VENDOR_GUNSMITH /
+    gunsmith: [353834582], // SOURCE_VENDOR_GUNSMITH /
   },
   restricted: {
     fwc: [353834582], // remove motes of light & strange coins
     do: [353834582],
     nm: [353834582],
     speaker: [353834582],
-    cq: [353834582, 2682516238] // remove ammo synths and planetary materials
-  }
+    cq: [353834582, 2682516238], // remove ammo synths and planetary materials
+  },
 };
 
 /** for D1 items: used to calculate which activity an item could have come from
@@ -181,7 +181,7 @@ export const D1ActivityHashes = {
     coe: [1537575125], // SOURCE_POE_ELDER_CHALLENGE / Challenge of Elders
     af: [3667653533], // SOURCE_ARCHON_FORGE / Archon Forge
     dawning: [3131490494], // SOURCE_DAWNING /
-    aot: [3068521220, 4161861381, 440710167] // SOURCE_AGES_OF_TRIUMPH && SOURCE_RAID_REPRISE
+    aot: [3068521220, 4161861381, 440710167], // SOURCE_AGES_OF_TRIUMPH && SOURCE_RAID_REPRISE
   },
   restricted: {
     trials: [2179714245, 2682516238, 560942287], // remove xur exotics and patrol items
@@ -194,8 +194,8 @@ export const D1ActivityHashes = {
     coe: [3602080346, 2682516238], // remove engrams
     af: [2682516238], // remove engrams
     dawning: [2682516238, 1111209135], // remove engrams, planetary materials, & chroma
-    aot: [2964550958, 2659839637, 353834582, 560942287] // Remove ROI, TTK, motes, & glimmer items
-  }
+    aot: [2964550958, 2659839637, 353834582, 560942287], // Remove ROI, TTK, motes, & glimmer items
+  },
 };
 
 /** if a plug contains these, consider it empty */
@@ -204,7 +204,7 @@ export const emptySocketHashes = [
   2600899007, // InventoryItem "Empty Mod Socket"
   1835369552, // InventoryItem "Empty Mod Socket"
   3851138800, // InventoryItem "Empty Mod Socket"
-  791435474 // InventoryItem "Empty Activity Mod Socket"
+  791435474, // InventoryItem "Empty Activity Mod Socket"
 ];
 
 /** these stats actually exist on D2 armor */
@@ -214,7 +214,7 @@ const d2ArmorStatHashByName = {
   recovery: 1943323491,
   discipline: 1735777505,
   intellect: 144602215,
-  strength: 4244567218
+  strength: 4244567218,
 };
 
 /**
@@ -223,7 +223,7 @@ const d2ArmorStatHashByName = {
  */
 const dimArmorStatHashByName = {
   ...d2ArmorStatHashByName,
-  total: -1000
+  total: -1000,
 };
 
 /** stats names used to create armor-specific filters */
@@ -254,7 +254,7 @@ export const statHashByName = {
   drawtime: 447667954,
   zoom: 3555269338,
   inventorysize: 1931675084,
-  ...dimArmorStatHashByName
+  ...dimArmorStatHashByName,
 };
 
 /** all-stat list, to generate filters from */

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -5,13 +5,13 @@ import {
   DEFAULT_GLOW,
   DEFAULT_GLOW_CATEGORY,
   DEFAULT_ORNAMENTS,
-  DEFAULT_SHADER
+  DEFAULT_SHADER,
 } from 'app/inventory/store/sockets';
 import {
   DestinyAmmunitionType,
   DestinyClass,
   DestinyCollectibleState,
-  DestinyItemSubType
+  DestinyItemSubType,
 } from 'bungie-api-ts/destiny2';
 import { ItemInfos, getNotes, getTag, itemTagSelectorList } from '../inventory/dim-item-info';
 import { ReviewsState, getRating, ratingsSelector, shouldShowRating } from '../item-review/reducer';
@@ -19,12 +19,12 @@ import { chainComparator, compareBy, reverseComparator } from '../utils/comparat
 import {
   getItemDamageShortName,
   getSpecialtySocketMetadata,
-  modSlotTags
+  modSlotTags,
 } from 'app/utils/item-utils';
 import {
   itemInfosSelector,
   sortedStoresSelector,
-  currentStoreSelector
+  currentStoreSelector,
 } from '../inventory/selectors';
 import { maxLightItemSet, maxStatLoadout } from '../loadout/auto-loadouts';
 
@@ -142,7 +142,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
   // Add new ItemCategoryHash hashes to this, to add new category searches
   const categoryHashFilters: { [key: string]: number } = {
     ...hashes.D1CategoryHashes,
-    ...(isD2 ? hashes.D2CategoryHashes : {})
+    ...(isD2 ? hashes.D2CategoryHashes : {}),
   };
 
   const stats = [
@@ -165,7 +165,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
     ...(isD1 ? ['rof'] : []),
     ...(isD2
       ? ['rpm', 'mobility', 'recovery', 'resilience', 'drawtime', 'inventorysize', 'total', 'any']
-      : [])
+      : []),
   ];
 
   /**
@@ -188,7 +188,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
       'green',
       'blue',
       'purple',
-      'yellow'
+      'yellow',
     ],
     classType: ['titan', 'hunter', 'warlock'],
     dupe: ['dupe', 'duplicate'],
@@ -246,7 +246,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
             'cq',
             'eris',
             'ev',
-            'gunsmith'
+            'gunsmith',
           ],
           activity: [
             'vanilla',
@@ -265,8 +265,8 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
             'coe',
             'af',
             'dawning',
-            'aot'
-          ]
+            'aot',
+          ],
         }
       : {}),
     ...(isD2
@@ -287,10 +287,10 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
           reacquirable: ['reacquirable'],
           trashlist: ['trashlist'],
           wishlist: ['wishlist'],
-          wishlistdupe: ['wishlistdupe']
+          wishlistdupe: ['wishlistdupe'],
         }
       : {}),
-    ...($featureFlags.reviewsEnabled ? { hasRating: ['rated', 'hasrating'] } : {})
+    ...($featureFlags.reviewsEnabled ? { hasRating: ['rated', 'hasrating'] } : {}),
   };
 
   // Filters that operate on numeric ranges with comparison operators
@@ -302,7 +302,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
     'year',
     ...(isD1 ? ['level', 'quality', 'percentage'] : []),
     ...(isD2 ? ['masterwork', 'season'] : []),
-    ...($featureFlags.reviewsEnabled ? ['rating', 'ratingcount'] : [])
+    ...($featureFlags.reviewsEnabled ? ['rating', 'ratingcount'] : []),
   ];
 
   // Filters that operate with fixed predicate values or freeform text, plus the processed above ranges
@@ -348,11 +348,11 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
           // maximum stat finders
           ...hashes.armorStatNames.map((armorStat) => `maxbasestatvalue:${armorStat}`),
           ...hashes.armorStatNames.map((armorStat) => `maxstatvalue:${armorStat}`),
-          ...hashes.armorStatNames.map((armorStat) => `maxstatloadout:${armorStat}`)
+          ...hashes.armorStatNames.map((armorStat) => `maxstatloadout:${armorStat}`),
         ]
       : []),
     // all the free text searches that support quotes
-    ...['notes:', 'perk:', 'perkname:', 'name:', 'description:']
+    ...['notes:', 'perk:', 'perkname:', 'name:', 'description:'],
   ];
 
   // create suggestion stubs for filter names
@@ -380,7 +380,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
     keywordToFilter,
     keywords: [...new Set(keywords)], // de-dupe kinetic (dmg) & kinetic (slot)
     destinyVersion,
-    categoryHashFilters
+    categoryHashFilters,
   };
 }
 /**
@@ -522,7 +522,7 @@ function searchFilters(
                     : // else we are looking for the biggest stat
                       {
                         value: Math.max(_maxStatValues[itemSlot][stat.statHash].value, stat.value),
-                        base: Math.max(_maxStatValues[itemSlot][stat.statHash].base, stat.base)
+                        base: Math.max(_maxStatValues[itemSlot][stat.statHash].base, stat.base),
                       };
               }
             }
@@ -590,7 +590,7 @@ function searchFilters(
             predicate: 'or',
             invert: false,
             value: '',
-            orFilters: [...(lastFilter!.orFilters! || [lastFilter]), filterDef]
+            orFilters: [...(lastFilter!.orFilters! || [lastFilter]), filterDef],
           });
         } else {
           filterStack.push(filterDef);
@@ -723,7 +723,7 @@ function searchFilters(
           green: 'uncommon',
           blue: 'rare',
           purple: 'legendary',
-          yellow: 'exotic'
+          yellow: 'exotic',
         };
         return item.tier.toLowerCase() === (tierMap[predicate] || predicate);
       },
@@ -1376,7 +1376,7 @@ function searchFilters(
           {
             primary: DestinyAmmunitionType.Primary,
             special: DestinyAmmunitionType.Special,
-            heavy: DestinyAmmunitionType.Heavy
+            heavy: DestinyAmmunitionType.Heavy,
           }[predicate]
         );
       },
@@ -1389,7 +1389,7 @@ function searchFilters(
       ...hashes.armorStatNames.reduce((obj, name) => {
         obj[`base${name}`] = filterByStats(name, true);
         return obj;
-      }, {})
-    }
+      }, {}),
+    },
   };
 }

--- a/src/app/settings/AuditLog.tsx
+++ b/src/app/settings/AuditLog.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   AuditLogEntry,
   ItemAnnotationLogEntry,
-  SettingsLogEntry
+  SettingsLogEntry,
 } from '@destinyitemmanager/dim-api-types';
 import { getAuditLog } from 'app/dim-api/dim-api';
 import { DestinyAccount, PLATFORM_ICONS } from 'app/accounts/destiny-account';
@@ -20,7 +20,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    accounts: accountsSelector(state)
+    accounts: accountsSelector(state),
   };
 }
 

--- a/src/app/settings/CharacterOrderEditor.tsx
+++ b/src/app/settings/CharacterOrderEditor.tsx
@@ -20,7 +20,7 @@ type Props = ProvidedProps & StoreProps;
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    characters: sortedStoresSelector(state)
+    characters: sortedStoresSelector(state),
   };
 }
 
@@ -60,7 +60,7 @@ class CharacterOrderEditor extends React.Component<Props> {
                     {(provided, snapshot) => (
                       <div
                         className={clsx('character-order-editor-item', {
-                          'is-dragging': snapshot.isDragging
+                          'is-dragging': snapshot.isDragging,
                         })}
                         ref={provided.innerRef}
                         {...provided.draggableProps}

--- a/src/app/settings/Checkbox.tsx
+++ b/src/app/settings/Checkbox.tsx
@@ -8,7 +8,7 @@ export default function Checkbox({
   value,
   helpLink,
   name,
-  onChange
+  onChange,
 }: {
   label: string;
   value: boolean;

--- a/src/app/settings/Select.tsx
+++ b/src/app/settings/Select.tsx
@@ -7,7 +7,7 @@ export default function Select({
   value,
   name,
   onChange,
-  options
+  options,
 }: {
   label: string;
   value: string | number;
@@ -35,7 +35,7 @@ export default function Select({
 export function mapToOptions(map: { [key: string]: string }) {
   return _.map(map, (value, key) => ({
     name: value,
-    value: key
+    value: key,
   }));
 }
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -50,7 +50,7 @@ function mapStateToProps(state: RootState): StoreProps {
     settings: settingsSelector(state),
     storesLoaded: storesLoadedSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
-    reviewModeOptions: $featureFlags.reviewsEnabled ? reviewModesSelector(state) : emptyArray()
+    reviewModeOptions: $featureFlags.reviewsEnabled ? reviewModesSelector(state) : emptyArray(),
   };
 }
 
@@ -62,50 +62,50 @@ const fakeWeapon = {
   dtrRatingCount: 100,
   element: {
     displayProperties: {
-      icon: '/img/destiny_content/damage_types/destiny2/thermal.png'
-    }
+      icon: '/img/destiny_content/damage_types/destiny2/thermal.png',
+    },
   },
   isNew: true,
   location: {
-    type: 'energy'
+    type: 'energy',
   },
   bucket: {
-    type: 'energy'
+    type: 'energy',
   },
   visible: true,
   primStat: {
-    value: 300
+    value: 300,
   },
   isDestiny2() {
     return true;
   },
   isDestiny1() {
     return false;
-  }
+  },
 };
 
 const fakeArmor = {
   icon: `~${exampleArmorImage}`,
   quality: {
-    min: 96
+    min: 96,
   },
   isNew: true,
   location: {
-    type: 'energy'
+    type: 'energy',
   },
   bucket: {
-    type: 'energy'
+    type: 'energy',
   },
   visible: true,
   primStat: {
-    value: 300
+    value: 300,
   },
   isDestiny2() {
     return false;
   },
   isDestiny1() {
     return true;
-  }
+  },
 };
 
 const languageOptions = mapToOptions({
@@ -121,7 +121,7 @@ const languageOptions = mapToOptions({
   ru: 'Русский',
   ja: '日本語',
   'zh-cht': '繁體中文', // Chinese (Traditional)
-  'zh-chs': '简体中文' // Chinese (Simplified)
+  'zh-chs': '简体中文', // Chinese (Simplified)
 });
 
 const colorA11yOptions = $featureFlags.colorA11y
@@ -134,7 +134,7 @@ const colorA11yOptions = $featureFlags.colorA11y
       'Tritanopia',
       'Tritanomaly',
       'Achromatopsia',
-      'Achromatomaly'
+      'Achromatomaly',
     ])
   : [];
 
@@ -146,7 +146,7 @@ function SettingsPage({
   isPhonePortrait,
   reviewModeOptions,
   storesLoaded,
-  dispatch
+  dispatch,
 }: Props) {
   useEffect(() => {
     getDefinitions();
@@ -232,17 +232,17 @@ function SettingsPage({
     rating: t('Settings.SortByRating'),
     classType: t('Settings.SortByClassType'),
     name: t('Settings.SortName'),
-    tag: t('Settings.SortByTag', { taglist: tagListString })
+    tag: t('Settings.SortByTag', { taglist: tagListString }),
     // archetype: 'Archetype'
   };
 
   const charColOptions = _.range(3, 6).map((num) => ({
     value: num,
-    name: t('Settings.ColumnSize', { num })
+    name: t('Settings.ColumnSize', { num }),
   }));
   const vaultColOptions = _.range(5, 21).map((num) => ({
     value: num,
-    name: t('Settings.ColumnSize', { num })
+    name: t('Settings.ColumnSize', { num }),
   }));
   vaultColOptions.unshift({ value: 999, name: t('Settings.ColumnSizeAuto') });
 
@@ -254,7 +254,7 @@ function SettingsPage({
       (displayName, id): SortProperty => ({
         id,
         displayName,
-        enabled: sortOrder.includes(id)
+        enabled: sortOrder.includes(id),
       })
     ),
     (o) => {
@@ -270,7 +270,7 @@ function SettingsPage({
     $featureFlags.wishLists ? { id: 'wishlist', title: t('WishListRoll.Header') } : undefined,
     { id: 'ratings', title: t('Settings.Ratings') },
     { id: 'storage', title: t('Storage.MenuTitle') },
-    { id: 'spreadsheets', title: t('Settings.Data') }
+    { id: 'spreadsheets', title: t('Settings.Data') },
   ]);
 
   if (!storesLoaded) {
@@ -486,7 +486,7 @@ function SettingsPage({
                       value={settings.reviewsPlatformSelectionV2}
                       options={reviewPlatformOptions.map((o) => ({
                         name: t(o.description),
-                        value: o.platform
+                        value: o.platform,
                       }))}
                       onChange={saveAndReloadReviews}
                     />
@@ -497,7 +497,7 @@ function SettingsPage({
                       value={settings.reviewsModeSelection}
                       options={reviewModeOptions.map((m) => ({
                         name: m.description,
-                        value: m.mode
+                        value: m.mode,
                       }))}
                       onChange={saveAndReloadReviews}
                     />

--- a/src/app/settings/SortOrderEditor.tsx
+++ b/src/app/settings/SortOrderEditor.tsx
@@ -8,7 +8,7 @@ import {
   enabledIcon,
   moveUpIcon,
   moveDownIcon,
-  unselectedCheckIcon
+  unselectedCheckIcon,
 } from '../shell/icons';
 
 export interface SortProperty {
@@ -85,7 +85,7 @@ export default class SortOrderEditor extends React.Component<Props> {
     if (fromDrag) {
       order[newIndex] = {
         ...order[newIndex],
-        enabled: newIndex === 0 || order[newIndex - 1].enabled
+        enabled: newIndex === 0 || order[newIndex - 1].enabled,
       };
     }
     this.fireOrderChanged(order);
@@ -132,7 +132,7 @@ function SortEditorItem(props: { index: number; item: SortProperty }) {
         <div
           className={clsx('sort-order-editor-item', {
             'is-dragging': snapshot.isDragging,
-            disabled: !item.enabled
+            disabled: !item.enabled,
           })}
           data-index={index}
           ref={provided.innerRef}

--- a/src/app/settings/Spreadsheets.tsx
+++ b/src/app/settings/Spreadsheets.tsx
@@ -25,7 +25,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     disabled: !storesLoadedSelector(state),
     stores: storesSelector(state),
-    itemInfos: itemInfosSelector(state)
+    itemInfos: itemInfosSelector(state),
   };
 }
 

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -9,7 +9,7 @@ import FileUpload from '../dim-ui/FileUpload';
 import {
   wishListsEnabledSelector,
   wishListsSelector,
-  wishListsLastFetchedSelector
+  wishListsLastFetchedSelector,
 } from '../wishlists/reducer';
 import _ from 'lodash';
 import { transformAndStoreWishList, fetchWishList } from 'app/wishlists/wishlist-fetch';
@@ -38,7 +38,7 @@ function mapStateToProps(state: RootState): StoreProps {
     title: wishList.title,
     description: wishList.description,
     wishListSource: settingsSelector(state).wishListSource,
-    wishListLastUpdated: wishListsLastFetchedSelector(state)
+    wishListLastUpdated: wishListsLastFetchedSelector(state),
   };
 }
 
@@ -49,7 +49,7 @@ function WishListSettings({
   title,
   description,
   wishListLastUpdated,
-  dispatch
+  dispatch,
 }: Props) {
   const [liveWishListSource, setLiveWishListSource] = useState(wishListSource);
   useEffect(() => {
@@ -78,7 +78,7 @@ function WishListSettings({
       showNotification({
         type: 'error',
         title: t('WishListRoll.Header'),
-        body: t('WishListRoll.ImportError', { error: e.message })
+        body: t('WishListRoll.ImportError', { error: e.message }),
       });
     }
   };
@@ -146,7 +146,7 @@ function WishListSettings({
           <div className="fineprint">
             {t('WishListRoll.LastUpdated', {
               lastUpdatedDate: wishListLastUpdated.toLocaleDateString(),
-              lastUpdatedTime: wishListLastUpdated.toLocaleTimeString()
+              lastUpdatedTime: wishListLastUpdated.toLocaleTimeString(),
             })}
           </div>
         )}
@@ -158,7 +158,7 @@ function WishListSettings({
             <div className="horizontal">
               <label>
                 {t('WishListRoll.Num', {
-                  num: numWishListRolls
+                  num: numWishListRolls,
                 })}
               </label>
               <button className="dim-button" onClick={clearWishListEvent}>

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -9,7 +9,7 @@ export const setSetting = createAction(
   'settings/SET',
   <V extends keyof Settings>(property: V, value: Settings[V]) => ({
     property,
-    value
+    value,
   })
 )() as <V extends keyof Settings>(
   property: V,

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -25,7 +25,7 @@ export const initialSettingsState: Settings = {
     'wishList',
     'archetype',
     'perks',
-    'notes'
+    'notes',
   ],
   organizerColumnsArmor: [
     'icon',
@@ -40,6 +40,6 @@ export const initialSettingsState: Settings = {
     'perks',
     'stats',
     'customstat',
-    'notes'
-  ]
+    'notes',
+  ],
 };

--- a/src/app/settings/item-sort.ts
+++ b/src/app/settings/item-sort.ts
@@ -9,7 +9,7 @@ const itemSortPresets = {
   quality: ['rating', 'name'],
   name: ['name'],
   typeThenPrimary: ['typeName', 'classType', 'primStat', 'name'],
-  typeThenName: ['typeName', 'classType', 'name']
+  typeThenName: ['typeName', 'classType', 'name'],
 };
 
 export const itemSortOrder = (settings: Settings): string[] =>

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -26,7 +26,7 @@ export const settings: Reducer<Settings, SettingsAction> = (
     case getType(actions.loaded):
       return {
         ...state,
-        ...action.payload
+        ...action.payload,
       };
 
     case getType(actions.toggleCollapsedSection):
@@ -34,15 +34,15 @@ export const settings: Reducer<Settings, SettingsAction> = (
         ...state,
         collapsedSections: {
           ...state.collapsedSections,
-          [action.payload]: !state.collapsedSections[action.payload]
-        }
+          [action.payload]: !state.collapsedSections[action.payload],
+        },
       };
 
     case getType(actions.setSetting):
       if (state[action.payload.property] !== action.payload.value) {
         return {
           ...state,
-          [action.payload.property]: action.payload.value
+          [action.payload.property]: action.payload.value,
         };
       } else {
         return state;
@@ -56,7 +56,7 @@ export const settings: Reducer<Settings, SettingsAction> = (
         // to the end of the list
         customCharacterSort: state.customCharacterSort
           .filter((id) => !order.includes(id))
-          .concat(order)
+          .concat(order),
       };
     }
 
@@ -64,7 +64,7 @@ export const settings: Reducer<Settings, SettingsAction> = (
     case getType(clearWishLists): {
       return {
         ...state,
-        wishListSource: ''
+        wishListSource: '',
       };
     }
 

--- a/src/app/settings/settings.ts
+++ b/src/app/settings/settings.ts
@@ -15,7 +15,7 @@ export const settingsReady = new Promise((resolve) => (readyResolve = resolve));
 const saveSettings = _.debounce(
   (settings) =>
     SyncService.set({
-      'settings-v1.0': settings
+      'settings-v1.0': settings,
     }),
   1000
 );

--- a/src/app/shell/About.tsx
+++ b/src/app/shell/About.tsx
@@ -13,7 +13,7 @@ import {
   faGithub,
   faReddit,
   faTshirt,
-  heartIcon
+  heartIcon,
 } from './icons';
 import { Link } from 'react-router-dom';
 
@@ -61,7 +61,7 @@ export default function About() {
             {t('Views.About.Version', {
               version: $DIM_VERSION,
               flavor: $DIM_FLAVOR,
-              date: new Date($DIM_BUILD_DATE).toLocaleString()
+              date: new Date($DIM_BUILD_DATE).toLocaleString(),
             })}
           </span>
         </Link>
@@ -93,7 +93,7 @@ export default function About() {
           </h2>
           <div
             dangerouslySetInnerHTML={{
-              __html: t('Views.Support.OpenCollective', { link: openCollectiveLink })
+              __html: t('Views.Support.OpenCollective', { link: openCollectiveLink }),
             }}
           />
         </div>
@@ -105,7 +105,7 @@ export default function About() {
           </h2>
           <div
             dangerouslySetInnerHTML={{
-              __html: t('Views.Support.Store', { link: storeLink })
+              __html: t('Views.Support.Store', { link: storeLink }),
             }}
           />
         </div>
@@ -152,7 +152,7 @@ export default function About() {
           </h2>
           <div
             dangerouslySetInnerHTML={{
-              __html: t('Views.About.GitHubHelp', { link: githubLink })
+              __html: t('Views.About.GitHubHelp', { link: githubLink }),
             }}
           />
         </div>
@@ -162,7 +162,7 @@ export default function About() {
           </h2>
           <div
             dangerouslySetInnerHTML={{
-              __html: t('Views.About.TranslationText', { link: crowdinLink })
+              __html: t('Views.About.TranslationText', { link: crowdinLink }),
             }}
           />
         </div>
@@ -180,7 +180,7 @@ export default function About() {
         <dd>
           <div
             dangerouslySetInnerHTML={{
-              __html: t('Views.About.FAQLostItemAnswer', { link: bungieLink })
+              __html: t('Views.About.FAQLostItemAnswer', { link: bungieLink }),
             }}
           />
           {token && (
@@ -202,7 +202,7 @@ export default function About() {
       <p>
         <span
           dangerouslySetInnerHTML={{
-            __html: t('Views.Support.OpenCollective', { link: openCollectiveLink })
+            __html: t('Views.Support.OpenCollective', { link: openCollectiveLink }),
           }}
         />{' '}
         {t('Views.Support.BackersDetail')}

--- a/src/app/shell/DefaultAccount.tsx
+++ b/src/app/shell/DefaultAccount.tsx
@@ -21,7 +21,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     activeAccount: currentAccountSelector(state),
     accountsLoaded: accountsLoadedSelector(state),
-    accountsError: state.accounts.accountsError
+    accountsError: state.accounts.accountsError,
   };
 }
 

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -37,10 +37,10 @@ const D1LoadoutBuilder = React.lazy(() =>
   import(/* webpackChunkName: "d1LoadoutBuilder" */ 'app/destiny1/loadout-builder/D1LoadoutBuilder')
 );
 const Vendors = React.lazy(async () => ({
-  default: (await import(/* webpackChunkName: "vendors" */ 'app/vendors/components')).Vendors
+  default: (await import(/* webpackChunkName: "vendors" */ 'app/vendors/components')).Vendors,
 }));
 const SingleVendor = React.lazy(async () => ({
-  default: (await import(/* webpackChunkName: "vendors" */ 'app/vendors/components')).SingleVendor
+  default: (await import(/* webpackChunkName: "vendors" */ 'app/vendors/components')).SingleVendor,
 }));
 const D1Vendors = React.lazy(() =>
   import(/* webpackChunkName: "d1vendors" */ 'app/destiny1/vendors/D1Vendors')
@@ -77,7 +77,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
         account.membershipId === props.platformMembershipId &&
         account.destinyVersion === props.destinyVersion
     ),
-    profileError: state.inventory.profileError
+    profileError: state.inventory.profileError,
   };
 }
 
@@ -163,8 +163,8 @@ function Destiny({ accountsLoaded, account, dispatch, profileError }: Props) {
       description: t('Hotkey.ToggleDetails'),
       callback() {
         // Empty - this gets redefined in dimMoveItemProperties
-      }
-    }
+      },
+    },
   ];
 
   itemTagList.forEach((tag) => {
@@ -172,11 +172,11 @@ function Destiny({ accountsLoaded, account, dispatch, profileError }: Props) {
       hotkeys.push({
         combo: tag.hotkey,
         description: t('Hotkey.MarkItemAs', {
-          tag: t(tag.label)
+          tag: t(tag.label),
         }),
         callback() {
           // Empty - this gets redefined in item-tag.component.ts
-        }
+        },
       });
     }
   });

--- a/src/app/shell/ErrorPanel.tsx
+++ b/src/app/shell/ErrorPanel.tsx
@@ -18,25 +18,25 @@ const twitters = (
       <Timeline
         dataSource={{
           sourceType: 'profile',
-          screenName: 'BungieHelp'
+          screenName: 'BungieHelp',
         }}
         options={{
           dnt: true,
           via: 'BungieHelp',
           username: 'BungieHelp',
-          height: '100%'
+          height: '100%',
         }}
       />
       <Timeline
         dataSource={{
           sourceType: 'profile',
-          screenName: 'ThisIsDIM'
+          screenName: 'ThisIsDIM',
         }}
         options={{
           dnt: true,
           via: 'ThisIsDIM',
           username: 'ThisIsDIM',
-          height: '100%'
+          height: '100%',
         }}
       />
     </React.Suspense>
@@ -49,7 +49,7 @@ export default function ErrorPanel({
   fallbackMessage,
   showTwitters,
   children,
-  showReload
+  showReload,
 }: {
   title?: string;
   error?: DimError;

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -45,7 +45,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     account: currentAccountSelector(state),
     vendorEngramDropActive: state.vendorDrops.vendorDrops.some(isDroppingHigh),
-    isPhonePortrait: state.shell.isPhonePortrait
+    isPhonePortrait: state.shell.isPhonePortrait,
   };
 }
 
@@ -69,7 +69,7 @@ class Header extends React.PureComponent<Props, State> {
     this.state = {
       dropdownOpen: false,
       showSearch: false,
-      promptIosPwa: false
+      promptIosPwa: false,
     };
   }
 
@@ -149,12 +149,12 @@ class Header extends React.PureComponent<Props, State> {
               {
                 to: `${path}/inventory`,
                 text: t('Header.Inventory'),
-                hotkey: 'i'
+                hotkey: 'i',
               },
               {
                 to: `${path}/progress`,
                 text: t('Progress.Progress'),
-                hotkey: 'p'
+                hotkey: 'p',
               },
               {
                 to: `${path}/vendors`,
@@ -162,48 +162,48 @@ class Header extends React.PureComponent<Props, State> {
                 hotkey: 'v',
                 badge: vendorEngramDropActive && (
                   <img src={vendorEngramSvg} className={styles.vendorEngramBadge} />
-                )
+                ),
               },
               {
                 to: `${path}/collections`,
                 text: t('Vendors.Collections'),
-                hotkey: 'c'
+                hotkey: 'c',
               },
               {
                 to: `${path}/optimizer`,
                 text: t('LB.LB'),
-                hotkey: 'b'
+                hotkey: 'b',
               },
               !isPhonePortrait && {
                 to: `${path}/organizer`,
                 text: t('Organizer.Organizer'),
-                hotkey: 'o'
-              }
+                hotkey: 'o',
+              },
             ])
           : [
               {
                 to: `${path}/inventory`,
                 text: t('Header.Inventory'),
-                hotkey: 'i'
+                hotkey: 'i',
               },
               {
                 to: `${path}/optimizer`,
                 text: t('LB.LB'),
-                hotkey: 'o'
+                hotkey: 'o',
               },
               {
                 to: `${path}/vendors`,
                 text: t('Vendors.Vendors'),
-                hotkey: 'v'
+                hotkey: 'v',
               },
               {
                 to: `${path}/record-books`,
-                text: t('RecordBooks.RecordBooks')
+                text: t('RecordBooks.RecordBooks'),
               },
               {
                 to: `${path}/activities`,
-                text: t('Activities.Activities')
-              }
+                text: t('Activities.Activities'),
+              },
             ];
     }
 
@@ -222,7 +222,7 @@ class Header extends React.PureComponent<Props, State> {
       {
         combo: 'm',
         description: t('Hotkey.Menu'),
-        callback: this.toggleDropdown
+        callback: this.toggleDropdown,
       },
       ..._.compact(
         links.map(
@@ -230,10 +230,10 @@ class Header extends React.PureComponent<Props, State> {
             link.hotkey && {
               combo: link.hotkey,
               description: link.text,
-              callback: () => history.push(link.to)
+              callback: () => history.push(link.to),
             }
         )
-      )
+      ),
     ];
 
     const iosPwaAvailable =

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -73,7 +73,7 @@ const D1_CONSUMABLE_SORT_ORDER = [
   //
   2575095887, // Splicer Intel Relay
   3815757277, // Splicer Cache Key
-  4244618453 // Splicer Key
+  4244618453, // Splicer Key
 ];
 
 const D1_MATERIAL_SORT_ORDER = [
@@ -101,7 +101,7 @@ const D1_MATERIAL_SORT_ORDER = [
   342707700, // Stolen Rune
   2906158273, // Antiquated Rune
   2620224196, // Stolen Rune (Charging)
-  2906158273 // Antiquated Rune (Charging)
+  2906158273, // Antiquated Rune (Charging)
 ];
 
 // Bucket IDs that'll never be sorted.
@@ -111,7 +111,7 @@ const ITEM_SORT_BLACKLIST = new Set([
   2197472680, // Bounties (D1)
   375726501, // Mission (D1)
   1801258597, // Quests (D1)
-  215593132 // LostItems
+  215593132, // LostItems
 ]);
 
 // TODO: pass in state
@@ -144,7 +144,7 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
     const tag = getTag(item, itemInfosSelector(store.getState()));
     return tag === 'archive';
   }),
-  default: () => 0
+  default: () => 0,
 };
 
 /**
@@ -226,7 +226,7 @@ export function getColor(value: number, property = 'background-color') {
     color = 190;
   }
   return {
-    [property]: `hsla(${color},65%,50%, 1)`
+    [property]: `hsla(${color},65%,50%, 1)`,
   };
 }
 
@@ -250,7 +250,7 @@ export function dtrRatingColor(value: number, property = 'color') {
     color = 'hsl(190,90%,45%)';
   }
   return {
-    [property]: color
+    [property]: color,
   };
 }
 
@@ -266,14 +266,14 @@ export function storeBackgroundColor(store: DimStore, index = 0, header = false)
       red: color.red * 0.75,
       green: color.green * 0.75,
       blue: color.blue * 0.75,
-      alpha: 1
+      alpha: 1,
     };
   } else if (header) {
     color = {
       red: color.red * 0.25 + 49 * 0.75,
       green: color.green * 0.25 + 50 * 0.75,
       blue: color.blue * 0.25 + 51 * 0.75,
-      alpha: 1
+      alpha: 1,
     };
   }
 
@@ -284,6 +284,6 @@ export function storeBackgroundColor(store: DimStore, index = 0, header = false)
   )}, ${alpha})`;
 
   return {
-    backgroundColor
+    backgroundColor,
   };
 }

--- a/src/app/shell/icons/AppIcon.tsx
+++ b/src/app/shell/icons/AppIcon.tsx
@@ -11,7 +11,7 @@ export default React.memo(function AppIcon({
   icon,
   className,
   title,
-  spinning
+  spinning,
 }: {
   icon: string | IconDefinition;
   className?: string;

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -6,7 +6,7 @@ import {
   dimTitanIcon,
   dimWarlockIcon,
   stadiaIcon,
-  battleNetIcon
+  battleNetIcon,
 } from './custom';
 
 const faArchive = 'fas fa-archive';
@@ -179,5 +179,5 @@ export {
   faYoutube,
   faDiscord,
   faGithub,
-  faReddit
+  faReddit,
 };

--- a/src/app/shell/icons/custom/utils.ts
+++ b/src/app/shell/icons/custom/utils.ts
@@ -3,5 +3,5 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 export const makeCustomIcon = (name, width, height, pathData): IconDefinition => ({
   iconName: `dim${name}` as any,
   prefix: 'dim' as any,
-  icon: [width, height, [], '', pathData]
+  icon: [width, height, [], '', pathData],
 });

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -29,7 +29,7 @@ const initialState: ShellState = {
   isPhonePortrait: isPhonePortraitFromMediaQuery(),
   searchQuery: '',
   searchQueryVersion: 0,
-  loadingMessages: []
+  loadingMessages: [],
 };
 
 export const shell: Reducer<ShellState, ShellAction> = (
@@ -40,7 +40,7 @@ export const shell: Reducer<ShellState, ShellAction> = (
     case getType(actions.setPhonePortrait):
       return {
         ...state,
-        isPhonePortrait: action.payload
+        isPhonePortrait: action.payload,
       };
     case getType(actions.setSearchQuery):
       return {
@@ -48,7 +48,7 @@ export const shell: Reducer<ShellState, ShellAction> = (
         searchQuery: action.payload.query,
         searchQueryVersion: action.payload.doNotUpdateVersion
           ? state.searchQueryVersion
-          : state.searchQueryVersion + 1
+          : state.searchQueryVersion + 1,
       };
 
     case getType(actions.toggleSearchQueryComponent): {
@@ -61,21 +61,21 @@ export const shell: Reducer<ShellState, ShellAction> = (
       return {
         ...state,
         searchQuery: newQuery,
-        searchQueryVersion: state.searchQueryVersion + 1
+        searchQueryVersion: state.searchQueryVersion + 1,
       };
     }
 
     case getType(actions.loadingStart): {
       return {
         ...state,
-        loadingMessages: _.uniq([...state.loadingMessages, action.payload])
+        loadingMessages: _.uniq([...state.loadingMessages, action.payload]),
       };
     }
 
     case getType(actions.loadingEnd): {
       return {
         ...state,
-        loadingMessages: state.loadingMessages.filter((m) => m !== action.payload)
+        loadingMessages: state.loadingMessages.filter((m) => m !== action.payload),
       };
     }
 

--- a/src/app/shell/refresh.tsx
+++ b/src/app/shell/refresh.tsx
@@ -53,8 +53,8 @@ export default function Refresh() {
           {
             combo: 'r',
             description: t('Hotkey.RefreshInventory'),
-            callback: refresh
-          }
+            callback: refresh,
+          },
         ]}
       />
       <AppIcon icon={refreshIcon} spinning={active} />

--- a/src/app/storage/DimApiSettings.tsx
+++ b/src/app/storage/DimApiSettings.tsx
@@ -16,7 +16,7 @@ import {
   importLegacyData,
   deleteAllApiData,
   loadDimApiData,
-  showBackupDownloadedNotification
+  showBackupDownloadedNotification,
 } from 'app/dim-api/actions';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
 import LegacyGoogleDriveSettings from './LegacyGoogleDriveSettings';
@@ -34,7 +34,7 @@ interface StoreProps {
 function mapStateToProps(state: RootState): StoreProps {
   return {
     apiPermissionGranted: apiPermissionGrantedSelector(state),
-    profileLoadedError: state.dimApi.profileLoadedError
+    profileLoadedError: state.dimApi.profileLoadedError,
   };
 }
 

--- a/src/app/storage/GDriveRevisions.tsx
+++ b/src/app/storage/GDriveRevisions.tsx
@@ -71,7 +71,7 @@ class GDriveRevisionComponent extends React.Component<
   constructor(props) {
     super(props);
     this.state = {
-      loading: false
+      loading: false,
     };
     // There's a Safari bug that makes "private restore = async() => {}" throw "Can't find private variable: @derivedConstructor". It's fixed in the latest iOS but not all of them.
     this.restore = this.restore.bind(this);

--- a/src/app/storage/GoogleDriveInfo.tsx
+++ b/src/app/storage/GoogleDriveInfo.tsx
@@ -18,13 +18,13 @@ export function GoogleDriveInfo({ driveInfo }: { driveInfo: DriveAboutResource }
             full:
               driveInfo.storageQuota.usage /
                 (driveInfo.storageQuota.limit || Number.MAX_SAFE_INTEGER) >
-              0.9
+              0.9,
           })}
           style={{
             width: percent(
               driveInfo.storageQuota.usage /
                 (driveInfo.storageQuota.limit || Number.MAX_SAFE_INTEGER)
-            )
+            ),
           }}
         />
         {driveInfo.storageQuota.dimQuotaUsed && (
@@ -34,7 +34,7 @@ export function GoogleDriveInfo({ driveInfo }: { driveInfo: DriveAboutResource }
               width: percent(
                 driveInfo.storageQuota.dimQuotaUsed /
                   (driveInfo.storageQuota.limit || Number.MAX_SAFE_INTEGER)
-              )
+              ),
             }}
           />
         )}

--- a/src/app/storage/GoogleDriveSettings.tsx
+++ b/src/app/storage/GoogleDriveSettings.tsx
@@ -13,7 +13,7 @@ import {
   disabledIcon,
   signOutIcon,
   signInIcon,
-  restoreIcon
+  restoreIcon,
 } from '../shell/icons';
 import { Subscriptions } from '../utils/rx-utils';
 import { DriveAboutResource } from './google-drive-storage';
@@ -35,7 +35,7 @@ interface State {
 
 class GoogleDriveSettings extends React.Component<RouteComponentProps, State> {
   state: State = {
-    adapterStats: {}
+    adapterStats: {},
   };
   private subscriptions = new Subscriptions();
 
@@ -173,10 +173,10 @@ class GoogleDriveSettings extends React.Component<RouteComponentProps, State> {
         this.setState((state) => {
           const adapterStats = {
             ...state.adapterStats,
-            [adapter.name]: data ? dataStats(data) : null
+            [adapter.name]: data ? dataStats(data) : null,
           };
           return {
-            adapterStats
+            adapterStats,
           };
         });
         return;
@@ -188,10 +188,10 @@ class GoogleDriveSettings extends React.Component<RouteComponentProps, State> {
     this.setState((state) => {
       const adapterStats = {
         ...state.adapterStats,
-        [adapter.name]: null
+        [adapter.name]: null,
       };
       return {
-        adapterStats
+        adapterStats,
       };
     });
     return;

--- a/src/app/storage/ImportExport.tsx
+++ b/src/app/storage/ImportExport.tsx
@@ -17,7 +17,7 @@ const supportsExport = !iOS;
 
 export default function ImportExport({
   onExportData,
-  onImportData
+  onImportData,
 }: {
   onExportData(): void;
   onImportData(data: object): Promise<any>;

--- a/src/app/storage/LegacyGoogleDriveSettings.tsx
+++ b/src/app/storage/LegacyGoogleDriveSettings.tsx
@@ -29,7 +29,7 @@ interface State {
 
 class LegacyGoogleDriveSettings extends React.Component<Props, State> {
   state: State = {
-    adapterStats: {}
+    adapterStats: {},
   };
   private subscriptions = new Subscriptions();
 
@@ -151,10 +151,10 @@ class LegacyGoogleDriveSettings extends React.Component<Props, State> {
         this.setState((state) => {
           const adapterStats = {
             ...state.adapterStats,
-            [adapter.name]: data ? dataStats(data) : null
+            [adapter.name]: data ? dataStats(data) : null,
           };
           return {
-            adapterStats
+            adapterStats,
           };
         });
         return;
@@ -166,10 +166,10 @@ class LegacyGoogleDriveSettings extends React.Component<Props, State> {
     this.setState((state) => {
       const adapterStats = {
         ...state.adapterStats,
-        [adapter.name]: null
+        [adapter.name]: null,
       };
       return {
-        adapterStats
+        adapterStats,
       };
     });
     return;

--- a/src/app/storage/LocalStorageInfo.tsx
+++ b/src/app/storage/LocalStorageInfo.tsx
@@ -45,7 +45,7 @@ export default function LocalStorageInfo({ showDetails }: { showDetails: boolean
           <div className="storage-guage">
             <div
               className={clsx({
-                full: quota.usage / quota.quota > 0.9
+                full: quota.usage / quota.quota > 0.9,
               })}
               style={{ width: percent(Math.max(quota.usage / quota.quota, 0.01)) }}
             />

--- a/src/app/storage/data-stats.ts
+++ b/src/app/storage/data-stats.ts
@@ -30,6 +30,6 @@ export function dataStats(data) {
     TagNotesD1: taggedItemsD1,
     TagNotesD2: taggedItemsD2,
     Settings: _.size(data['settings-v1.0']),
-    IgnoredUsers: _.size(data.ignoredUsers)
+    IgnoredUsers: _.size(data.ignoredUsers),
   };
 }

--- a/src/app/storage/google-drive-storage.ts
+++ b/src/app/storage/google-drive-storage.ts
@@ -52,7 +52,7 @@ export class GoogleDriveStorage implements StorageAdapter {
     discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
     fetch_basic_profile: false, // eslint-disable-line @typescript-eslint/camelcase
     ux_mode: 'redirect', // eslint-disable-line @typescript-eslint/camelcase
-    redirect_uri: `${window.location.origin}/gdrive-return.html` // eslint-disable-line @typescript-eslint/camelcase
+    redirect_uri: `${window.location.origin}/gdrive-return.html`, // eslint-disable-line @typescript-eslint/camelcase
   };
 
   // The Google Drive ID of the file we use to save data.
@@ -92,9 +92,9 @@ export class GoogleDriveStorage implements StorageAdapter {
         method: 'PATCH',
         params: {
           uploadType: 'media',
-          alt: 'json'
+          alt: 'json',
         },
-        body: value
+        body: value,
       });
     } catch (resp) {
       // TODO: error handling
@@ -243,9 +243,9 @@ export class GoogleDriveStorage implements StorageAdapter {
       file = await gapi.client.drive.files.create({
         name: fileName,
         media: {
-          mimeType: 'application/json'
+          mimeType: 'application/json',
         },
-        parents: ['appDataFolder']
+        parents: ['appDataFolder'],
       });
       if ($featureFlags.debugSync) {
         console.log('created file in Google Drive', file);
@@ -300,7 +300,7 @@ export class GoogleDriveStorage implements StorageAdapter {
       const file = await gapi.client.drive.revisions.get({
         fileId,
         revisionId,
-        alt: 'media'
+        alt: 'media',
       });
 
       if (file.status === 200) {
@@ -337,7 +337,7 @@ export class GoogleDriveStorage implements StorageAdapter {
       const fileId = await this.getFileId();
       const resp = await gapi.client.drive.files.get({
         fileId,
-        alt: 'media'
+        alt: 'media',
       });
       return resp.result;
     } catch (e) {
@@ -357,7 +357,7 @@ export class GoogleDriveStorage implements StorageAdapter {
       const fileId = await this.getFileId();
       const resp = await gapi.client.drive.files.get({
         fileId,
-        fields: 'quotaBytesUsed'
+        fields: 'quotaBytesUsed',
       });
       return resp.result;
     } catch (e) {

--- a/src/app/storage/sync.service.ts
+++ b/src/app/storage/sync.service.ts
@@ -188,7 +188,7 @@ export const SyncService = {
         await adapter.set(cached);
       }
     }
-  }
+  },
 };
 
 async function getAndCacheFromAdapters(): Promise<DimData> {

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -47,7 +47,7 @@ const reducer: Reducer<RootState> = (state, action) => {
     manifest,
     vendorDrops,
     // Dummy reducer to get the types to work
-    dimApi: (state: DimApiState = dimApiInitialState) => state
+    dimApi: (state: DimApiState = dimApiInitialState) => state,
   });
 
   const intermediateState = combinedReducers(state, action);
@@ -62,7 +62,7 @@ const reducer: Reducer<RootState> = (state, action) => {
   if (intermediateState.dimApi !== dimApiState) {
     return {
       ...intermediateState,
-      dimApi: dimApiState
+      dimApi: dimApiState,
     };
   }
 

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -16,7 +16,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
       serialize: false,
       actionsBlacklist: [getType(update), getType(setD1Manifest), getType(setD2Manifest)],
       stateSanitizer: (state: RootState) =>
-        state.inventory ? { ...state, inventory: '<<EXCLUDED>>', manifest: '<<EXCLUDED>>' } : state
+        state.inventory ? { ...state, inventory: '<<EXCLUDED>>', manifest: '<<EXCLUDED>>' } : state,
     })
   : compose;
 

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -29,17 +29,17 @@ if ($featureFlags.sentry) {
       'Bungie.net was too slow to respond.',
       /AbortError/,
       /Non-Error promise rejection/,
-      'VendorEngrams.xyz service call failed.'
+      'VendorEngrams.xyz service call failed.',
     ],
     ignoreUrls: [
       // Chrome extensions
       /extensions\//i,
       /^chrome:\/\//i,
-      /^moz-extension:\/\//i
+      /^moz-extension:\/\//i,
     ],
     attachStackTrace: true,
     // We're flooding Sentry for some reason
-    sampleRate: 0.05
+    sampleRate: 0.05,
   });
 
   reportException = (name: string, e: Error, errorInfo?: {}) => {

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -1,7 +1,7 @@
 import {
   DamageType,
   DestinyEnergyType,
-  DestinyInventoryItemDefinition
+  DestinyInventoryItemDefinition,
 } from 'bungie-api-ts/destiny2';
 import { DimItem, DimSocket } from 'app/inventory/item-types';
 
@@ -17,14 +17,14 @@ export const damageNamesByEnum: { [key in DamageType]: string | null } = {
   2: 'arc',
   3: 'solar',
   4: 'void',
-  5: 'raid'
+  5: 'raid',
 };
 
 export const energyNamesByEnum: { [key in DestinyEnergyType]: string } = {
   [DestinyEnergyType.Any]: 'any',
   [DestinyEnergyType.Arc]: 'arc',
   [DestinyEnergyType.Thermal]: 'solar',
-  [DestinyEnergyType.Void]: 'void'
+  [DestinyEnergyType.Void]: 'void',
 };
 
 export const Armor2ModPlugCategories = {
@@ -33,7 +33,7 @@ export const Armor2ModPlugCategories = {
   gauntlets: 3422420680,
   chest: 1526202480,
   leg: 2111701510,
-  classitem: 912441879
+  classitem: 912441879,
 } as const;
 
 export const getItemDamageShortName = (item: DimItem): string | undefined =>

--- a/src/app/vendorEngramsXyzApi/reducer.ts
+++ b/src/app/vendorEngramsXyzApi/reducer.ts
@@ -21,7 +21,7 @@ export type VendorDropAction = ActionType<typeof actions>;
 const initialState: VendorDropsState = {
   loaded: false,
   vendorDrops: [],
-  lastUpdated: unloadedDate
+  lastUpdated: unloadedDate,
 };
 
 export const vendorDrops: Reducer<VendorDropsState, VendorDropAction> = (
@@ -34,14 +34,14 @@ export const vendorDrops: Reducer<VendorDropsState, VendorDropAction> = (
         ...state,
         loaded: true,
         vendorDrops: action.payload,
-        lastUpdated: new Date()
+        lastUpdated: new Date(),
       };
     case getType(actions.clearVendorDrops): {
       return {
         ...state,
         loaded: false,
         vendorDrops: [],
-        lastUpdated: unloadedDate
+        lastUpdated: unloadedDate,
       };
     }
     default:

--- a/src/app/vendorEngramsXyzApi/vendorDrops.ts
+++ b/src/app/vendorEngramsXyzApi/vendorDrops.ts
@@ -11,13 +11,13 @@ export interface VendorDropXyz {
 export const enum VendorDropTypeXyz {
   NoData = '0',
   DroppingLow = '1',
-  DroppingHigh = '2'
+  DroppingHigh = '2',
 }
 
 export const enum VendorDropType {
   NoData = 0,
   DroppingLow = 1,
-  DroppingHigh = 2
+  DroppingHigh = 2,
 }
 
 export function toVendorDrop(vendorDropXyz: VendorDropXyz): VendorDrop {
@@ -35,7 +35,7 @@ export function toVendorDrop(vendorDropXyz: VendorDropXyz): VendorDrop {
     shorthand: vendorDropXyz.shorthand,
     nextRefresh: new Date(vendorDropXyz.nextRefresh),
     drop: dropType,
-    interval: Number(vendorDropXyz.interval)
+    interval: Number(vendorDropXyz.interval),
   };
 }
 

--- a/src/app/vendorEngramsXyzApi/vendorEngramsXyzService.ts
+++ b/src/app/vendorEngramsXyzApi/vendorEngramsXyzService.ts
@@ -35,8 +35,8 @@ function vendorEngramsFetch(url: string) {
   const request = new Request(url, {
     method: 'POST',
     headers: {
-      Accept: 'application/json'
-    }
+      Accept: 'application/json',
+    },
   });
 
   return Promise.resolve(fetch(request));

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -17,7 +17,7 @@ import { connect } from 'react-redux';
 import {
   storesSelector,
   ownedItemsSelector,
-  profileResponseSelector
+  profileResponseSelector,
 } from '../inventory/selectors';
 import { RootState, ThunkDispatchProp } from '../store/reducers';
 import { toVendor } from './d2-vendors';
@@ -49,7 +49,7 @@ function mapStateToProps() {
     ownedItemHashes: ownedItemSelectorInstance(state),
     buckets: state.inventory.buckets,
     defs: state.manifest.d2Manifest,
-    profileResponse: profileResponseSelector(state)
+    profileResponse: profileResponseSelector(state),
   });
 }
 

--- a/src/app/vendors/Vendor.tsx
+++ b/src/app/vendors/Vendor.tsx
@@ -22,7 +22,7 @@ export default function Vendor({
   ownedItemHashes,
   currencyLookups,
   filtering,
-  vendorDrops
+  vendorDrops,
 }: {
   vendor: D2Vendor;
   defs: D2ManifestDefinitions;
@@ -62,7 +62,7 @@ export default function Vendor({
                 <a target="_blank" rel="noopener noreferrer" href="https://vendorengrams.xyz/">
                   <img
                     className={clsx(styles.xyzEngram, {
-                      [styles.xyzActiveThrob]: dropActive
+                      [styles.xyzActiveThrob]: dropActive,
                     })}
                     src={vendorEngramSvg}
                     title={vendorLinkTitle}

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -18,7 +18,7 @@ import { Link } from 'react-router-dom';
 export default function VendorItemComponent({
   item,
   defs,
-  owned
+  owned,
 }: {
   defs: D2ManifestDefinitions;
   item: VendorItem;
@@ -80,7 +80,7 @@ export function VendorItemDisplay({
   acquired,
   item,
   extraData,
-  children
+  children,
 }: {
   unavailable?: boolean;
   owned?: boolean;
@@ -100,7 +100,7 @@ export function VendorItemDisplay({
   return (
     <div
       className={clsx(styles.vendorItem, {
-        [styles.unavailable]: unavailable
+        [styles.unavailable]: unavailable,
       })}
     >
       {owned ? <AppIcon className={styles.ownedIcon} icon={faCheck} /> : acquired && acquiredIcon}
@@ -116,7 +116,7 @@ export function VendorItemDisplay({
 
 function VendorItemCost({
   cost,
-  defs
+  defs,
 }: {
   defs: D2ManifestDefinitions;
   cost: DestinyItemQuantity;

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -28,7 +28,7 @@ export default function VendorItems({
   vendor,
   ownedItemHashes,
   currencyLookups,
-  filtering
+  filtering,
 }: {
   defs: D2ManifestDefinitions;
   vendor: D2Vendor;
@@ -53,7 +53,7 @@ export default function VendorItems({
         ...Object.keys(faction.tokenValues)
           .map((h) => defs.InventoryItem.get(parseInt(h, 10)))
           .filter(Boolean),
-        ...currencies
+        ...currencies,
       ],
       (i) => i.hash
     );

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -3,7 +3,7 @@ import {
   DestinyProfileResponse,
   DestinyCurrenciesComponent,
   DestinyItemPlug,
-  DestinyCollectibleComponent
+  DestinyCollectibleComponent,
 } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -24,7 +24,7 @@ import { RootState, ThunkDispatchProp } from '../store/reducers';
 import {
   ownedItemsSelector,
   sortedStoresSelector,
-  profileResponseSelector
+  profileResponseSelector,
 } from '../inventory/selectors';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -32,7 +32,7 @@ import {
   D2VendorGroup,
   toVendorGroups,
   filterVendorGroupsToUnacquired,
-  filterVendorGroupsToSearch
+  filterVendorGroupsToSearch,
 } from './d2-vendors';
 import styles from './Vendors.m.scss';
 import { searchFilterSelector } from 'app/search/search-filters';
@@ -76,7 +76,7 @@ function mapStateToProps() {
     searchQuery: state.shell.searchQuery,
     filterItems: searchFilterSelector(state),
     profileResponse: profileResponseSelector(state),
-    vendorEngramDrops: state.vendorDrops.vendorDrops
+    vendorEngramDrops: state.vendorDrops.vendorDrops,
   });
 }
 
@@ -201,7 +201,7 @@ class Vendors extends React.Component<Props, State> {
       searchQuery,
       filterItems,
       profileResponse,
-      vendorEngramDrops
+      vendorEngramDrops,
     } = this.props;
 
     if (error) {
@@ -316,7 +316,7 @@ function VendorGroup({
   currencyLookups,
   defs,
   filtering,
-  vendorDrops
+  vendorDrops,
 }: {
   defs: D2ManifestDefinitions;
   group: D2VendorGroup;

--- a/src/app/vendors/VendorsMenu.tsx
+++ b/src/app/vendors/VendorsMenu.tsx
@@ -11,7 +11,7 @@ import vendorEngramSvg from '../../images/engram.svg';
 
 export default function VendorsMenu({
   groups,
-  vendorEngramDrops
+  vendorEngramDrops,
 }: {
   groups: readonly D2VendorGroup[];
   vendorEngramDrops: readonly VendorDrop[] | undefined;

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -10,7 +10,7 @@ import {
   DestinyPlaceDefinition,
   DestinyVendorGroupDefinition,
   DestinyInventoryItemDefinition,
-  DestinyCollectibleState
+  DestinyCollectibleState,
 } from 'bungie-api-ts/destiny2';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
@@ -39,7 +39,7 @@ const vendorOrder = [
   1265988377, // benedict
   672118013, // banshee
   248695599, // drifter
-  2917531897 // ada
+  2917531897, // ada
 ];
 
 export function toVendorGroups(
@@ -79,7 +79,7 @@ export function toVendorGroups(
             const index = vendorOrder.indexOf(v.def.hash);
             return index >= 0 ? index : v.def.hash;
           }
-        )
+        ),
       };
     }),
     (g) => g.def.order
@@ -141,7 +141,7 @@ export function toVendor(
     destination: destinationDef,
     place: placeDef,
     items: vendorItems,
-    currencies
+    currencies,
   };
 }
 
@@ -198,9 +198,9 @@ export function filterVendorGroupsToUnacquired(vendorGroups: readonly D2VendorGr
               item.item.isDestiny2() &&
               item.item.collectibleState !== null &&
               item.item.collectibleState & DestinyCollectibleState.NotAcquired
-          )
+          ),
         }))
-        .filter((v) => v.items.length)
+        .filter((v) => v.items.length),
     }))
     .filter((g) => g.vendors.length);
 }
@@ -218,9 +218,9 @@ export function filterVendorGroupsToSearch(
           ...vendor,
           items: vendor.def.displayProperties.name.toLowerCase().includes(searchQuery.toLowerCase())
             ? vendor.items
-            : vendor.items.filter((i) => i.item && filterItems(i.item))
+            : vendor.items.filter((i) => i.item && filterItems(i.item)),
         }))
-        .filter((v) => v.items.length)
+        .filter((v) => v.items.length),
     }))
     .filter((g) => g.vendors.length);
 }

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -6,7 +6,7 @@ import {
   DestinyItemSocketEntryPlugItemDefinition,
   DestinyDisplayPropertiesDefinition,
   DestinyItemQuantity,
-  DestinyCollectibleComponent
+  DestinyCollectibleComponent,
 } from 'bungie-api-ts/destiny2';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { makeFakeItem } from '../inventory/store/d2-item-factory';

--- a/src/app/vendors/vendor-ratings.ts
+++ b/src/app/vendors/vendor-ratings.ts
@@ -4,7 +4,7 @@ import {
   DestinyVendorSaleItemComponent,
   DestinyVendorResponse,
   DestinyVendorItemDefinition,
-  DestinyVendorDefinition
+  DestinyVendorDefinition,
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';

--- a/src/app/whats-new/BungieAlerts.tsx
+++ b/src/app/whats-new/BungieAlerts.tsx
@@ -10,7 +10,7 @@ import {
   startWith,
   distinctUntilChanged,
   shareReplay,
-  catchError
+  catchError,
 } from 'rxjs/operators';
 import { useSubscription } from 'app/utils/hooks';
 

--- a/src/app/whats-new/WhatsNew.tsx
+++ b/src/app/whats-new/WhatsNew.tsx
@@ -13,7 +13,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    language: settingsSelector(state).language
+    language: settingsSelector(state).language,
   };
 }
 
@@ -31,14 +31,14 @@ function WhatsNew({ language }: Props) {
         <Timeline
           dataSource={{
             sourceType: 'profile',
-            screenName: 'ThisIsDIM'
+            screenName: 'ThisIsDIM',
           }}
           options={{
             lang: language,
             dnt: true,
             via: 'ThisIsDIM',
             username: 'ThisIsDIM',
-            height: '100%'
+            height: '100%',
           }}
         />
       </div>

--- a/src/app/whats-new/WhatsNewLink.tsx
+++ b/src/app/whats-new/WhatsNewLink.tsx
@@ -26,7 +26,7 @@ export default class WhatsNewLink extends React.Component<{}, State> {
     this.state = {
       dimNeedsUpdate: false,
       alerts: [],
-      showChangelog: false
+      showChangelog: false,
     };
   }
 

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -39,7 +39,7 @@ export type WishListAction = ActionType<typeof actions>;
 const initialState: WishListsState = {
   loaded: false,
   wishListAndInfo: { title: undefined, description: undefined, wishListRolls: [] },
-  lastFetched: undefined
+  lastFetched: undefined,
 };
 
 export const wishLists: Reducer<WishListsState, WishListAction> = (
@@ -52,7 +52,7 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
         ...state,
         wishListAndInfo: { ...initialState.wishListAndInfo, ...action.payload.wishListAndInfo },
         loaded: true,
-        lastFetched: action.payload.lastFetched || new Date()
+        lastFetched: action.payload.lastFetched || new Date(),
       };
     case getType(actions.clearWishLists): {
       return {
@@ -61,11 +61,11 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
           title: undefined,
           description: undefined,
           wishListRolls: [],
-          source: ''
+          source: '',
         },
         lastFetched: undefined,
         wishListSource: undefined,
-        loaded: true
+        loaded: true,
       };
     }
     default:
@@ -80,7 +80,7 @@ export function saveWishListToIndexedDB() {
       if (nextState.loaded) {
         set('wishlist', {
           wishListAndInfo: nextState.wishListAndInfo,
-          lastFetched: nextState.lastFetched
+          lastFetched: nextState.lastFetched,
         });
       }
     }

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -1,5 +1,5 @@
 export const enum DimWishList {
-  WildcardItemId = -69420 // nice
+  WildcardItemId = -69420, // nice
 }
 
 /**

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -76,7 +76,7 @@ export function transformAndStoreWishList(wishListAndInfo: WishListAndInfo): Thu
 
       const titleAndDescription = _.compact([
         wishListAndInfo.title,
-        wishListAndInfo.description
+        wishListAndInfo.description,
       ]).join('\n');
 
       showNotification({
@@ -84,14 +84,14 @@ export function transformAndStoreWishList(wishListAndInfo: WishListAndInfo): Thu
         title: t('WishListRoll.Header'),
         body: t('WishListRoll.ImportSuccess', {
           count: wishListAndInfo.wishListRolls.length,
-          titleAndDescription
-        })
+          titleAndDescription,
+        }),
       });
     } else {
       showNotification({
         type: 'warning',
         title: t('WishListRoll.Header'),
-        body: t('WishListRoll.ImportFailed')
+        body: t('WishListRoll.ImportFailed'),
       });
     }
   };
@@ -113,7 +113,7 @@ function loadWishListAndInfoFromIndexedDB(): ThunkResult {
       dispatch(
         loadWishLists({
           lastFetched: wishListState.lastFetched,
-          wishListAndInfo: wishListState.wishListAndInfo
+          wishListAndInfo: wishListState.wishListAndInfo,
         })
       );
     }

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -15,7 +15,7 @@ export function toWishList(fileText: string): WishListAndInfo {
     return {
       wishListRolls: toWishListRolls(fileText),
       title: getTitle(fileText),
-      description: getDescription(fileText)
+      description: getDescription(fileText),
     };
   } finally {
     console.timeEnd('Parse wish list');
@@ -93,7 +93,7 @@ function toDtrWishListRoll(dtrTextLine: string): WishListRoll | null {
     itemHash,
     recommendedPerks,
     isExpertMode: false,
-    notes
+    notes,
   };
 }
 
@@ -123,7 +123,7 @@ function toBansheeWishListRoll(bansheeTextLine: string): WishListRoll | null {
     itemHash,
     recommendedPerks,
     isExpertMode: false,
-    notes
+    notes,
   };
 }
 
@@ -157,7 +157,7 @@ function toDimWishListRoll(textLine: string): WishListRoll | null {
     recommendedPerks,
     isExpertMode: true,
     notes,
-    isUndesirable
+    isUndesirable,
   };
 }
 

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -6,7 +6,7 @@ import { INTRINSIC_PLUG_CATEGORY } from 'app/inventory/store/sockets';
 
 export const enum UiWishListRoll {
   Good = 1,
-  Bad
+  Bad,
 }
 
 export function toUiWishListRoll(
@@ -185,7 +185,7 @@ function getInventoryWishListRoll(
     return {
       wishListPerks: getWishListPlugs(item, matchingWishListRoll),
       notes: matchingWishListRoll.notes,
-      isUndesirable: matchingWishListRoll.isUndesirable
+      isUndesirable: matchingWishListRoll.isUndesirable,
     };
   }
 

--- a/src/browsercheck.test.ts
+++ b/src/browsercheck.test.ts
@@ -20,45 +20,45 @@ const browsersSupported = [
   'opera 64',
   'opera 63',
   'safari 13',
-  'safari 12.1'
+  'safari 12.1',
 ];
 
 test.each([
   [
     'Firefox 72',
     'Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0',
-    true
+    true,
   ],
   [
     'Chrome 79',
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36',
-    true
+    true,
   ],
   [
     'iOS 12',
     'Mozilla/5.0 (iPod; CPU iPhone OS 12_0 like macOS) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/12.0 Mobile/14A5335d Safari/602.1.50',
-    true
+    true,
   ],
   [
     'Edge 18',
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362',
-    true
+    true,
   ],
   [
     'Vivaldi',
     'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36 Vivaldi/2.10',
-    true
+    true,
   ],
   [
     'Opera',
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36 OPR/65.0.3467.78',
-    true
+    true,
   ],
   [
     'Old Chrome',
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36',
-    false
-  ]
+    false,
+  ],
 ])('%s: User agent %s, supported: %s', (_, userAgent, shouldBeSupported) => {
   expect(isSupported(browsersSupported, userAgent)).toStrictEqual(shouldBeSupported);
 });

--- a/src/data/d2/d2-event-info.ts
+++ b/src/data/d2/d2-event-info.ts
@@ -4,7 +4,7 @@ export const enum D2EventEnum {
   SOLSTICE_OF_HEROES,
   FESTIVAL_OF_THE_LOST,
   REVELRY,
-  GUARDIAN_GAMES
+  GUARDIAN_GAMES,
 }
 
 export const D2EventInfo = {
@@ -12,38 +12,38 @@ export const D2EventInfo = {
     name: 'The Dawning',
     shortname: 'dawning',
     sources: [3952847349, 4054646289],
-    engram: [1170720694, 3151770741]
+    engram: [1170720694, 3151770741],
   },
   2: {
     name: 'Crimson Days',
     shortname: 'crimsondays',
     sources: [2502262376],
-    engram: [191363032, 3373123597]
+    engram: [191363032, 3373123597],
   },
   3: {
     name: 'Solstice of Heroes',
     shortname: 'solstice',
     sources: [641018908, 3724111213],
-    engram: [821844118]
+    engram: [821844118],
   },
   4: {
     name: 'Festival of the Lost',
     shortname: 'fotl',
     sources: [1677921161, 3190938946],
-    engram: [1451959506]
+    engram: [1451959506],
   },
   5: {
     name: 'The Revelry',
     shortname: 'revelry',
     sources: [2187511136],
-    engram: [1974821348, 2570200927]
+    engram: [1974821348, 2570200927],
   },
   6: {
     name: 'Guardian Games',
     shortname: 'games',
     sources: [611838069, 3388021959],
-    engram: []
-  }
+    engram: [],
+  },
 };
 
 export const D2EventPredicateLookup = {
@@ -52,7 +52,7 @@ export const D2EventPredicateLookup = {
   solstice: D2EventEnum.SOLSTICE_OF_HEROES,
   fotl: D2EventEnum.FESTIVAL_OF_THE_LOST,
   revelry: D2EventEnum.REVELRY,
-  games: D2EventEnum.GUARDIAN_GAMES
+  games: D2EventEnum.GUARDIAN_GAMES,
 };
 
 export const D2SourcesToEvent = {
@@ -65,5 +65,5 @@ export const D2SourcesToEvent = {
   3190938946: D2EventEnum.FESTIVAL_OF_THE_LOST,
   2187511136: D2EventEnum.REVELRY,
   611838069: D2EventEnum.GUARDIAN_GAMES,
-  3388021959: D2EventEnum.GUARDIAN_GAMES
+  3388021959: D2EventEnum.GUARDIAN_GAMES,
 };

--- a/src/data/d2/missing-source-info.ts
+++ b/src/data/d2/missing-source-info.ts
@@ -2,7 +2,7 @@ const missingSources: { [key: string]: number[] } = {
   adventure: [
     1589569998, // Gearhead Gauntlets
     1886391431, // Gearhead Gloves
-    2290569618 // Gearhead Grips
+    2290569618, // Gearhead Grips
   ],
   blackarmory: [
     78664642, // Annealed Shaper Gloves
@@ -19,19 +19,19 @@ const missingSources: { [key: string]: number[] } = {
     3322192806, // Annealed Shaper Robes
     3363625697, // Woven Firesmith Grips
     3607521808, // Woven Firesmith Mask
-    4064641551 // Annealed Shaper Bond
+    4064641551, // Annealed Shaper Bond
   ],
   calus: [
     784492908, // Hive Armaments
     2249025553, // Hive Invigoration
     3425422485, // Hive Repurposing
-    3888848980 // Hive Barrier
+    3888848980, // Hive Barrier
   ],
   crownofsorrow: [
     784492908, // Hive Armaments
     2249025553, // Hive Invigoration
     3425422485, // Hive Repurposing
-    3888848980 // Hive Barrier
+    3888848980, // Hive Barrier
   ],
   crucible: [
     85800627, // Ankaa Seeker IV
@@ -123,7 +123,7 @@ const missingSources: { [key: string]: number[] } = {
     4136212668, // Wing Discipline
     4144133120, // Wing Theorem
     4211218181, // Ankaa Seeker IV
-    4269346472 // Binary Phoenix Bond
+    4269346472, // Binary Phoenix Bond
   ],
   do: [
     102368695, // Anti-Extinction Mask
@@ -140,7 +140,7 @@ const missingSources: { [key: string]: number[] } = {
     3373566763, // Anti-Extinction Robes
     3470850110, // Anti-Extinction Grasps
     3890232472, // Anti-Extinction Legs
-    3940923523 // Stella Incognita Cloak
+    3940923523, // Stella Incognita Cloak
   ],
   dreaming: [
     99549082, // Reverie Dawn Helm
@@ -157,7 +157,7 @@ const missingSources: { [key: string]: number[] } = {
     3250140572, // Reverie Dawn Cloak
     3343583008, // Reverie Dawn Mark
     3711557785, // Reverie Dawn Strides
-    4257800469 // Reverie Dawn Greaves
+    4257800469, // Reverie Dawn Greaves
   ],
   drifter: [
     9767416, // Ancient Apocalypse Bond
@@ -204,12 +204,12 @@ const missingSources: { [key: string]: number[] } = {
     3804360785, // Ancient Apocalypse Mark
     3825427923, // Ancient Apocalypse Helm
     3925589496, // Ancient Apocalypse Hood
-    4255727106 // Ancient Apocalypse Hood
+    4255727106, // Ancient Apocalypse Hood
   ],
   edz: [
     1589569998, // Gearhead Gauntlets
     1886391431, // Gearhead Gloves
-    2290569618 // Gearhead Grips
+    2290569618, // Gearhead Grips
   ],
   eow: [
     75025442, // Boots of Feltroc
@@ -226,7 +226,7 @@ const missingSources: { [key: string]: number[] } = {
     3681852889, // Mark of Nohr
     3693007688, // Grips of Feltroc
     3731175213, // Mask of Nohr
-    4240859456 // Vest of Feltroc
+    4240859456, // Vest of Feltroc
   ],
   ep: [
     425390008, // Midnight Exigent Greaves
@@ -243,7 +243,7 @@ const missingSources: { [key: string]: number[] } = {
     3691605010, // Midnight Exigent Plate
     3792637803, // Abhorrent Imperative Mask
     3876414174, // Midnight Exigent Gauntlets
-    4286845987 // Midnight Exigent Mark
+    4286845987, // Midnight Exigent Mark
   ],
   eververse: [
     138961800, // Helm of Optimacy
@@ -295,7 +295,7 @@ const missingSources: { [key: string]: number[] } = {
     3850655136, // Winterhart Vest
     3866715933, // Dawning Warmth
     3947596543, // Green Dawning Lanterns
-    4059030097 // Winterhart Mask
+    4059030097, // Winterhart Mask
   ],
   fwc: [
     79417130, // Simulator Grips
@@ -312,7 +312,7 @@ const missingSources: { [key: string]: number[] } = {
     2657180960, // Entanglement Bond
     2915206011, // Simulator Mask
     3030715588, // Simulator Boots
-    3762717334 // Simulator Gauntlets
+    3762717334, // Simulator Gauntlets
   ],
   gambit: [
     9767416, // Ancient Apocalypse Bond
@@ -359,7 +359,7 @@ const missingSources: { [key: string]: number[] } = {
     3804360785, // Ancient Apocalypse Mark
     3825427923, // Ancient Apocalypse Helm
     3925589496, // Ancient Apocalypse Hood
-    4255727106 // Ancient Apocalypse Hood
+    4255727106, // Ancient Apocalypse Hood
   ],
   gambitprime: [
     95332289, // Notorious Collector Strides
@@ -541,7 +541,7 @@ const missingSources: { [key: string]: number[] } = {
     4245233855, // Illicit Sentry Grips
     4266990316, // Notorious Sentry Boots
     4266990318, // Illicit Sentry Boots
-    4266990319 // Outlawed Sentry Boots
+    4266990319, // Outlawed Sentry Boots
   ],
   garden: [],
   gunsmith: [],
@@ -560,12 +560,12 @@ const missingSources: { [key: string]: number[] } = {
     3758301014, // Noble Constant Type 2
     4146629762, // Frumious Strides
     4208352991, // Ego Talon IV
-    4225579453 // Noble Constant Type 2
+    4225579453, // Noble Constant Type 2
   ],
   io: [
     1445420672, // Mindbreaker Boots
     2025523685, // Mindbreaker Boots
-    2164070257 // Mindbreaker Boots
+    2164070257, // Mindbreaker Boots
   ],
   ironbanner: [
     21320325, // Bond of Remembrance
@@ -672,7 +672,7 @@ const missingSources: { [key: string]: number[] } = {
     4144217282, // Iron Fellowship Strides
     4156963223, // Iron Symmachy Vest
     4211068696, // Iron Truage Legs
-    4248834293 // Iron Remembrance Vest
+    4248834293, // Iron Remembrance Vest
   ],
   lastwish: [
     16387641, // Mark of the Great Hunt
@@ -689,7 +689,7 @@ const missingSources: { [key: string]: number[] } = {
     3445582154, // Hood of the Great Hunt
     3492720019, // Gloves of the Great Hunt
     3874578566, // Greaves of the Great Hunt
-    4219088013 // Helm of the Great Hunt
+    4219088013, // Helm of the Great Hunt
   ],
   legendaryengram: [
     24598504, // Red Moon Phantom Vest
@@ -811,7 +811,7 @@ const missingSources: { [key: string]: number[] } = {
     4079913195, // Dead End Cure 2.1
     4097652774, // Tangled Web Plate
     4146408011, // Tangled Web Gloves
-    4166246718 // Insight Vikti Robes
+    4166246718, // Insight Vikti Robes
   ],
   leviathan: [
     311429764, // Shadow's Mark
@@ -843,7 +843,7 @@ const missingSources: { [key: string]: number[] } = {
     3530284424, // Wraps of the Fulminator
     3530284425, // Wraps of the Emperor's Minister
     3853397100, // Boots of the Emperor's Agent
-    3853397101 // Boots of the Ace-Defiant
+    3853397101, // Boots of the Ace-Defiant
   ],
   mars: [
     425390008, // Midnight Exigent Greaves
@@ -860,7 +860,7 @@ const missingSources: { [key: string]: number[] } = {
     3691605010, // Midnight Exigent Plate
     3792637803, // Abhorrent Imperative Mask
     3876414174, // Midnight Exigent Gauntlets
-    4286845987 // Midnight Exigent Mark
+    4286845987, // Midnight Exigent Mark
   ],
   menagerie: [
     56157064, // Exodus Down Gauntlets
@@ -892,7 +892,7 @@ const missingSources: { [key: string]: number[] } = {
     3960258378, // Exodus Down Hood
     4007396243, // Exodus Down Gloves
     4060742749, // Exodus Down Mask
-    4130486121 // Exodus Down Mask
+    4130486121, // Exodus Down Mask
   ],
   mercury: [
     61987238, // Kairos Function Mask
@@ -909,13 +909,13 @@ const missingSources: { [key: string]: number[] } = {
     3873109093, // Kairos Function Plate
     4148237373, // Kairos Function Greaves
     4240041208, // Kairos Function Boots
-    4252342556 // Kairos Function Cloak
+    4252342556, // Kairos Function Cloak
   ],
   moon: [],
   nessus: [
     2866378042, // Unethical Experiments Bond
     2940586725, // Unethical Experiments Mark
-    3144980977 // Unethical Experiments Cloak
+    3144980977, // Unethical Experiments Cloak
   ],
   nightfall: [],
   nightmare: [],
@@ -934,7 +934,7 @@ const missingSources: { [key: string]: number[] } = {
     2165598463, // Coronation Bond
     2835971286, // Sovereign Robes
     3060679667, // Sovereign Vest
-    4119718816 // Sovereign Helm
+    4119718816, // Sovereign Helm
   ],
   prestige: [],
   prophecy: [],
@@ -953,7 +953,7 @@ const missingSources: { [key: string]: number[] } = {
     2719710110, // Bulletsmith's Ire Helm
     2750983488, // Bladesmith's Memory Cloak
     3491990569, // Bulletsmith's Ire Plate
-    4092373800 // Gunsmith's Devotion Robes
+    4092373800, // Gunsmith's Devotion Robes
   ],
   scourge: [
     96643258, // Bladesmith's Memory Mask
@@ -970,7 +970,7 @@ const missingSources: { [key: string]: number[] } = {
     2719710110, // Bulletsmith's Ire Helm
     2750983488, // Bladesmith's Memory Cloak
     3491990569, // Bulletsmith's Ire Plate
-    4092373800 // Gunsmith's Devotion Robes
+    4092373800, // Gunsmith's Devotion Robes
   ],
   seasonpass: [
     238618944, // Righteous Helm
@@ -1033,7 +1033,7 @@ const missingSources: { [key: string]: number[] } = {
     4026120124, // Substitutional Alloy Grips
     4026120127, // Substitutional Alloy Grips
     4078925541, // Substitutional Alloy Mask
-    4078925542 // Substitutional Alloy Mask
+    4078925542, // Substitutional Alloy Mask
   ],
   shaxx: [
     85800627, // Ankaa Seeker IV
@@ -1125,7 +1125,7 @@ const missingSources: { [key: string]: number[] } = {
     4136212668, // Wing Discipline
     4144133120, // Wing Theorem
     4211218181, // Ankaa Seeker IV
-    4269346472 // Binary Phoenix Bond
+    4269346472, // Binary Phoenix Bond
   ],
   shipwright: [],
   sos: [
@@ -1143,7 +1143,7 @@ const missingSources: { [key: string]: number[] } = {
     3518692432, // Equitis Shade Cowl
     3862230571, // Insigne Shade Bond
     4151496279, // Turris Shade Greaves
-    4213777114 // Insigne Shade Robes
+    4213777114, // Insigne Shade Robes
   ],
   strikes: [
     358599471, // Vigil of Heroes
@@ -1207,7 +1207,7 @@ const missingSources: { [key: string]: number[] } = {
     4074662489, // Vigil of Heroes
     4087433052, // The Took Offense
     4138296191, // The Shelter in Place
-    4288492921 // Vigil of Heroes
+    4288492921, // Vigil of Heroes
   ],
   sundial: [],
   tangled: [
@@ -1216,7 +1216,7 @@ const missingSources: { [key: string]: number[] } = {
     1566911695, // Scorned Baron Plate
     2944336620, // Nea-Thonis Breather
     3523809305, // Eimin-Tin Ritual Mask
-    4245441464 // Scorned Baron Robes
+    4245441464, // Scorned Baron Robes
   ],
   titan: [
     66047450, // Lost Pacific Gloves
@@ -1233,7 +1233,7 @@ const missingSources: { [key: string]: number[] } = {
     3283642233, // Lost Pacific Plate
     3416618798, // Lost Pacific Robes
     3734713335, // Lost Pacific Bond
-    4105480824 // Lost Pacific Cape
+    4105480824, // Lost Pacific Cape
   ],
   trials: [
     72827962, // Focusing Robes
@@ -1265,7 +1265,7 @@ const missingSources: { [key: string]: number[] } = {
     4100217958, // Focusing Boots
     4100217959, // Flowing Treads
     4177448932, // Focusing Wraps
-    4177448933 // Channeling Wraps
+    4177448933, // Channeling Wraps
   ],
   vexoffensive: [],
   zavala: [
@@ -1330,8 +1330,8 @@ const missingSources: { [key: string]: number[] } = {
     4074662489, // Vigil of Heroes
     4087433052, // The Took Offense
     4138296191, // The Shelter in Place
-    4288492921 // Vigil of Heroes
-  ]
+    4288492921, // Vigil of Heroes
+  ],
 };
 
 export default missingSources;

--- a/src/data/d2/source-info.ts
+++ b/src/data/d2/source-info.ts
@@ -22,8 +22,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2553369674, // Source: Adventure "Exodus Siege" on Nessus.
       3427537854, // Source: Adventure "Road Rage" on Io.
       3754173885, // Source: Adventure "Getting Your Hands Dirty" in the European Dead Zone.
-      4214471686 // Source: Adventure "Unsafe at Any Speed" in the European Dead Zone.
-    ]
+      4214471686, // Source: Adventure "Unsafe at Any Speed" in the European Dead Zone.
+    ],
   },
   blackarmory: {
     itemHashes: [
@@ -35,7 +35,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3650581586, // Rasmussen Clan
       3650581587, // House of Meyrin
       3650581588, // Satou Tribe
-      3650581589 // Bergusian Night
+      3650581589, // Bergusian Night
     ],
     sourceHashes: [
       75031309, // Source: Found in forge ignitions.
@@ -56,14 +56,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3764925750, // Source: Complete an Izanami Forge ignition.
       4101102010, // Source: Found by completing Bergusia Forge ignitions.
       4247521481, // Source: Complete the "Beautiful but Deadly" Triumph.
-      4290227252 // Source: Complete a Volundr Forge ignition.
-    ]
+      4290227252, // Source: Complete a Volundr Forge ignition.
+    ],
   },
   calus: {
     itemHashes: [
       1661191192, // The Tribute Hall
       2816212794, // Bad Juju
-      3580904580 // Legend of Acrius
+      3580904580, // Legend of Acrius
     ],
     sourceHashes: [
       705895461, // Acquired from the Menagerie.
@@ -76,20 +76,20 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2937902448, // Source: Leviathan, Eater of Worlds raid lair.
       3147603678, // Acquired from the raid "Crown of Sorrow."
       4009509410, // Source: Complete challenges in the Leviathan raid.
-      4066007318 // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
-    ]
+      4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
+    ],
   },
   crownofsorrow: {
     itemHashes: [
       947448544, // Shadow of Earth Shell
       1661191193, // Crown of Sorrow
       2027598066, // Imperial Opulence
-      2027598067 // Imperial Dress
+      2027598067, // Imperial Dress
     ],
     sourceHashes: [
       2399751101, // Acquired from the raid "Crown of Sorrow."
-      3147603678 // Acquired from the raid "Crown of Sorrow."
-    ]
+      3147603678, // Acquired from the raid "Crown of Sorrow."
+    ],
   },
   crucible: {
     itemHashes: [
@@ -102,7 +102,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2588739579, // Crucible Metallic
       2632846356, // Rain of Ashes
       3928440584, // Crucible Carmine
-      3928440585 // Crucible Redjack
+      3928440585, // Crucible Redjack
     ],
     sourceHashes: [
       454115234, // Source: Complete this weapon's associated Crucible quest.
@@ -116,24 +116,24 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2537301256, // Source: Reach a Glory rank of "Fabled" in the Crucible.
       2641169841, // Source: Purchased from Lord Shaxx.
       2658055900, // Source: Complete the "Season 8: Battle Drills" quest.
-      2821852478 // Source: Complete this weapon's associated Crucible quest.
-    ]
+      2821852478, // Source: Complete this weapon's associated Crucible quest.
+    ],
   },
   do: {
     itemHashes: [],
     sourceHashes: [
-      146504277 // Source: Earn rank-up packages from Arach Jalaal.
-    ]
+      146504277, // Source: Earn rank-up packages from Arach Jalaal.
+    ],
   },
   dreaming: {
     itemHashes: [
       185321779, // Ennead
-      3352019292 // Secret Victories
+      3352019292, // Secret Victories
     ],
     sourceHashes: [
       2559145507, // Source: Complete activities in the Dreaming City.
-      3874934421 // Source: Complete Nightfall strike "The Corrupted."
-    ]
+      3874934421, // Source: Complete Nightfall strike "The Corrupted."
+    ],
   },
   drifter: {
     itemHashes: [
@@ -146,7 +146,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2224920148, // Gambit Blackguard
       2224920149, // Gambit Steel
       2394866220, // Keep on Drifting
-      3217477988 // Gambit Duds
+      3217477988, // Gambit Duds
     ],
     sourceHashes: [
       571102497, // Source: Complete this weapon's associated Gambit quest.
@@ -156,8 +156,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2601524261, // Source: Complete this reward's associated Gambit quest.
       2883838366, // Source: Complete the "Breakneck" quest from the Drifter.
       3422985544, // Source: Complete this reward's associated Gambit quest.
-      3494247523 // Source: Complete the "Season 8: Keepin' On" quest.
-    ]
+      3494247523, // Source: Complete the "Season 8: Keepin' On" quest.
+    ],
   },
   edz: {
     itemHashes: [],
@@ -172,35 +172,35 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2096915131, // Source: Adventure "Poor Reception" in the European Dead Zone.
       3754173885, // Source: Adventure "Getting Your Hands Dirty" in the European Dead Zone.
       4214471686, // Source: Adventure "Unsafe at Any Speed" in the European Dead Zone.
-      4292996207 // Source: World Quest "Enhance!" in the European Dead Zone.
-    ]
+      4292996207, // Source: World Quest "Enhance!" in the European Dead Zone.
+    ],
   },
   eow: {
     itemHashes: [],
     sourceHashes: [
       2937902448, // Source: Leviathan, Eater of Worlds raid lair.
-      4066007318 // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
-    ]
+      4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
+    ],
   },
   ep: {
     itemHashes: [],
     sourceHashes: [
-      4137108180 // Source: Escalation Protocol on Mars.
-    ]
+      4137108180, // Source: Escalation Protocol on Mars.
+    ],
   },
   eververse: {
     itemHashes: [],
     sourceHashes: [
       269962496, // Source: Eververse package.
       860688654, // Source: Eververse
-      4036739795 // Source: Bright Engrams.
-    ]
+      4036739795, // Source: Bright Engrams.
+    ],
   },
   fwc: {
     itemHashes: [],
     sourceHashes: [
-      3569603185 // Source: Earn rank-up packages from Lakshmi-2.
-    ]
+      3569603185, // Source: Earn rank-up packages from Lakshmi-2.
+    ],
   },
   gambit: {
     itemHashes: [
@@ -213,7 +213,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2224920148, // Gambit Blackguard
       2224920149, // Gambit Steel
       2394866220, // Keep on Drifting
-      3217477988 // Gambit Duds
+      3217477988, // Gambit Duds
     ],
     sourceHashes: [
       571102497, // Source: Complete this weapon's associated Gambit quest.
@@ -223,8 +223,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2601524261, // Source: Complete this reward's associated Gambit quest.
       2883838366, // Source: Complete the "Breakneck" quest from the Drifter.
       3422985544, // Source: Complete this reward's associated Gambit quest.
-      3494247523 // Source: Complete the "Season 8: Keepin' On" quest.
-    ]
+      3494247523, // Source: Complete the "Season 8: Keepin' On" quest.
+    ],
   },
   gambitprime: {
     itemHashes: [
@@ -233,31 +233,31 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2868525742, // The Reaper
       2868525743, // The Sentry
       3735277403, // Prime Palette
-      3808901541 // Viper Strike
+      3808901541, // Viper Strike
     ],
     sourceHashes: [
-      1952675042 // Source: Complete Gambit Prime matches and increase your rank.
-    ]
+      1952675042, // Source: Complete Gambit Prime matches and increase your rank.
+    ],
   },
   garden: {
     itemHashes: [
-      4103414242 // Divinity
+      4103414242, // Divinity
     ],
     sourceHashes: [
-      1491707941 // Source: "Garden of Salvation" raid.
-    ]
+      1491707941, // Source: "Garden of Salvation" raid.
+    ],
   },
   gunsmith: {
     itemHashes: [],
     sourceHashes: [
-      1788267693 // Source: Earn rank-up packages from Banshee-44.
-    ]
+      1788267693, // Source: Earn rank-up packages from Banshee-44.
+    ],
   },
   ikora: {
     itemHashes: [],
     sourceHashes: [
-      3075817319 // Source: Earn rank-up packages from Ikora Rey.
-    ]
+      3075817319, // Source: Earn rank-up packages from Ikora Rey.
+    ],
   },
   io: {
     itemHashes: [],
@@ -267,8 +267,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1832642406, // Source: World Quest "Dynasty" on Io.
       2392127416, // Source: Adventure "Cliffhanger" on Io.
       2717017239, // Source: Complete Nightfall strike "The Pyramidion."
-      3427537854 // Source: Adventure "Road Rage" on Io.
-    ]
+      3427537854, // Source: Adventure "Road Rage" on Io.
+    ],
   },
   ironbanner: {
     itemHashes: [
@@ -278,39 +278,39 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1448664467, // Iron Gold
       1661191199, // Grizzled Wolf
       1987234560, // Iron Ruby
-      2448092902 // Rusted Iron
+      2448092902, // Rusted Iron
     ],
     sourceHashes: [
       1027607603, // Source: Complete this reward's associated Iron Banner quest.
       1828622510, // Source: Chance to acquire when you win Iron Banner matches.
       2648408612, // Acquired by competing in the Iron Banner when the wolves were loud.
       3072862693, // Source: Complete Iron Banner matches and earn rank-up packages from Lord Saladin.
-      3966667255 // Source: Complete Iron Banner's Season 9 Seasonal Pursuit.
-    ]
+      3966667255, // Source: Complete Iron Banner's Season 9 Seasonal Pursuit.
+    ],
   },
   lastwish: {
     itemHashes: [
-      3668669364 // Dreaming Spectrum
+      3668669364, // Dreaming Spectrum
     ],
     sourceHashes: [
-      2455011338 // Source: Last Wish raid.
-    ]
+      2455011338, // Source: Last Wish raid.
+    ],
   },
   legendaryengram: {
     itemHashes: [],
     sourceHashes: [
-      3334812276 // Source: Open Legendary engrams and earn faction rank-up packages.
-    ]
+      3334812276, // Source: Open Legendary engrams and earn faction rank-up packages.
+    ],
   },
   leviathan: {
     itemHashes: [
-      3580904580 // Legend of Acrius
+      3580904580, // Legend of Acrius
     ],
     sourceHashes: [
       2653618435, // Source: Leviathan raid.
       2765304727, // Source: Leviathan raid on Prestige difficulty.
-      4009509410 // Source: Complete challenges in the Leviathan raid.
-    ]
+      4009509410, // Source: Complete challenges in the Leviathan raid.
+    ],
   },
   mars: {
     itemHashes: [],
@@ -320,8 +320,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1924238751, // Source: Complete Nightfall strike "Will of the Thousands."
       2310754348, // Source: World Quest "Data Recovery" on Mars.
       2926805810, // Source: Complete Nightfall strike "Strange Terrain."
-      4137108180 // Source: Escalation Protocol on Mars.
-    ]
+      4137108180, // Source: Escalation Protocol on Mars.
+    ],
   },
   menagerie: {
     itemHashes: [
@@ -332,13 +332,13 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3841416153, // Goldleaf
       3841416154, // Shadow Gilt
       3841416155, // Cinderchar
-      3875444086 // The Emperor's Chosen
+      3875444086, // The Emperor's Chosen
     ],
     sourceHashes: [
       705895461, // Acquired from the Menagerie.
       2511152325, // Acquired from the Menagerie aboard the Leviathan.
-      4130543671 // Acquired from the Menagerie aboard the Leviathan with the requisite combination of runes in the Chalice of Opulence.
-    ]
+      4130543671, // Acquired from the Menagerie aboard the Leviathan with the requisite combination of runes in the Chalice of Opulence.
+    ],
   },
   mercury: {
     itemHashes: [],
@@ -354,15 +354,15 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2487203690, // Source: Complete Nightfall strike "Tree of Probabilities."
       3079246067, // Source: Complete Osiris' Lost Prophecies for Brother Vance on Mercury.
       3964663093, // Source: Rare drop from high-scoring Nightfall strikes on Mercury.
-      4263201695 // Source: Complete Nightfall strike "A Garden World."
-    ]
+      4263201695, // Source: Complete Nightfall strike "A Garden World."
+    ],
   },
   moon: {
     itemHashes: [],
     sourceHashes: [
       1253026984, // Source: Among the lost Ghosts of the Moon.
-      1999000205 // Source: Found by exploring the Moon.
-    ]
+      1999000205, // Source: Found by exploring the Moon.
+    ],
   },
   nessus: {
     itemHashes: [],
@@ -376,8 +376,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2345202459, // Source: Adventure "Invitation from the Emperor" on Nessus.
       2553369674, // Source: Adventure "Exodus Siege" on Nessus.
       3022766747, // Source: Complete Nightfall strike "The Insight Terminus."
-      3067146211 // Source: Complete Nightfall strike "Exodus Crash."
-    ]
+      3067146211, // Source: Complete Nightfall strike "Exodus Crash."
+    ],
   },
   nightfall: {
     itemHashes: [],
@@ -400,35 +400,35 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3874934421, // Source: Complete Nightfall strike "The Corrupted."
       3964663093, // Source: Rare drop from high-scoring Nightfall strikes on Mercury.
       4208190159, // Source: Complete a Nightfall strike.
-      4263201695 // Source: Complete Nightfall strike "A Garden World."
-    ]
+      4263201695, // Source: Complete Nightfall strike "A Garden World."
+    ],
   },
   nightmare: {
     itemHashes: [],
     sourceHashes: [
       550270332, // Source: Complete all Nightmare Hunt time trials on Master difficulty.
-      2778435282 // Source: Nightmare Hunts
-    ]
+      2778435282, // Source: Nightmare Hunts
+    ],
   },
   nm: {
     itemHashes: [],
     sourceHashes: [
-      1464399708 // Source: Earn rank-up packages from Executor Hideo.
-    ]
+      1464399708, // Source: Earn rank-up packages from Executor Hideo.
+    ],
   },
   prestige: {
     itemHashes: [],
     sourceHashes: [
       2765304727, // Source: Leviathan raid on Prestige difficulty.
       2812190367, // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
-      4066007318 // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
-    ]
+      4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
+    ],
   },
   prophecy: {
     itemHashes: [],
     sourceHashes: [
-      3079246067 // Source: Complete Osiris' Lost Prophecies for Brother Vance on Mercury.
-    ]
+      3079246067, // Source: Complete Osiris' Lost Prophecies for Brother Vance on Mercury.
+    ],
   },
   raid: {
     itemHashes: [
@@ -437,7 +437,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2027598066, // Imperial Opulence
       2557722678, // Midnight Smith
       3580904580, // Legend of Acrius
-      3668669364 // Dreaming Spectrum
+      3668669364, // Dreaming Spectrum
     ],
     sourceHashes: [
       1483048674, // Source: Complete the "Scourge of the Past" raid.
@@ -454,26 +454,26 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3147603678, // Acquired from the raid "Crown of Sorrow."
       4009509410, // Source: Complete challenges in the Leviathan raid.
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
-      4246883461 // Source: Found in the "Scourge of the Past" raid.
-    ]
+      4246883461, // Source: Found in the "Scourge of the Past" raid.
+    ],
   },
   scourge: {
     itemHashes: [
-      2557722678 // Midnight Smith
+      2557722678, // Midnight Smith
     ],
     sourceHashes: [
       1483048674, // Source: Complete the "Scourge of the Past" raid.
       2085016678, // Source: Complete the "Scourge of the Past" raid within the first 24 hours after its launch.
-      4246883461 // Source: Found in the "Scourge of the Past" raid.
-    ]
+      4246883461, // Source: Found in the "Scourge of the Past" raid.
+    ],
   },
   seasonpass: {
     itemHashes: [],
     sourceHashes: [
       594540014, // Source: Exotic quest "Make Bows, Not War." Available only to Season Pass owners.
       1593696611, // Source: Season Pass Reward
-      1838401392 // Source: Earned as a Season Pass reward.
-    ]
+      1838401392, // Source: Earned as a Season Pass reward.
+    ],
   },
   shaxx: {
     itemHashes: [
@@ -486,7 +486,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2588739579, // Crucible Metallic
       2632846356, // Rain of Ashes
       3928440584, // Crucible Carmine
-      3928440585 // Crucible Redjack
+      3928440585, // Crucible Redjack
     ],
     sourceHashes: [
       454115234, // Source: Complete this weapon's associated Crucible quest.
@@ -500,21 +500,21 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2537301256, // Source: Reach a Glory rank of "Fabled" in the Crucible.
       2641169841, // Source: Purchased from Lord Shaxx.
       2658055900, // Source: Complete the "Season 8: Battle Drills" quest.
-      2821852478 // Source: Complete this weapon's associated Crucible quest.
-    ]
+      2821852478, // Source: Complete this weapon's associated Crucible quest.
+    ],
   },
   shipwright: {
     itemHashes: [],
     sourceHashes: [
-      96303009 // Source: Purchased from Amanda Holliday.
-    ]
+      96303009, // Source: Purchased from Amanda Holliday.
+    ],
   },
   sos: {
     itemHashes: [],
     sourceHashes: [
       1675483099, // Source: Leviathan, Spire of Stars raid lair.
-      2812190367 // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
-    ]
+      2812190367, // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
+    ],
   },
   strikes: {
     itemHashes: [
@@ -525,7 +525,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2788911997, // Vanguard Divide
       2788911998, // Vanguard Metallic
       2788911999, // Vanguard Veteran
-      3215252549 // Determination
+      3215252549, // Determination
     ],
     sourceHashes: [
       288436121, // Source: Complete this weapon's associated Vanguard quest.
@@ -535,28 +535,28 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1244908294, // Source: Complete the "Loaded Question" quest from Zavala.
       1564061133, // Source: Complete this reward's associated Vanguard quest.
       2317365255, // Source: Complete the "A Loud Racket" quest.
-      2527168932 // Source: Complete strikes and earn rank-up packages from Commander Zavala.
-    ]
+      2527168932, // Source: Complete strikes and earn rank-up packages from Commander Zavala.
+    ],
   },
   sundial: {
     itemHashes: [],
     sourceHashes: [
       1618754228, // Source: Acquired from the Sundial activity on Mercury.
-      2627087475 // Source: Complete obelisk bounties and increase the Resonance Rank of obelisks across the system.
-    ]
+      2627087475, // Source: Complete obelisk bounties and increase the Resonance Rank of obelisks across the system.
+    ],
   },
   tangled: {
     itemHashes: [
       1226584228, // Tangled Rust
       1226584229, // Tangled Bronze
-      4085986809 // Secret Treasure
+      4085986809, // Secret Treasure
     ],
     sourceHashes: [
       110159004, // Source: Complete Nightfall strike "Warden of Nothing."
       1771326504, // Source: Complete activities and earn rank-up packages on the Tangled Shore.
       2805208672, // Source: Complete Nightfall strike "The Hollowed Lair."
-      4140654910 // Source: Eliminate all Barons on the Tangled Shore.
-    ]
+      4140654910, // Source: Eliminate all Barons on the Tangled Shore.
+    ],
   },
   titan: {
     itemHashes: [],
@@ -565,14 +565,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       354493557, // Source: Complete Nightfall strike "Savathûn's Song."
       482012099, // Source: Adventure "Thief of Thieves" on Saturn's Moon, Titan.
       636474187, // Source: Adventure "Deathless" on Saturn's Moon, Titan.
-      3534706087 // Source: Complete activities and earn rank-up packages on Saturn's Moon, Titan.
-    ]
+      3534706087, // Source: Complete activities and earn rank-up packages on Saturn's Moon, Titan.
+    ],
   },
   trials: {
     itemHashes: [
       1983519830, // Hardened by Trial
       2071635914, // Light for the Lost
-      2071635915 // Flawless Empyrean
+      2071635915, // Flawless Empyrean
     ],
     sourceHashes: [
       139599745, // Source: Earn seven wins on a single Trials ticket.
@@ -581,8 +581,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1607607347, // Source: Complete Trials tickets and earn rank-up packages from the Emissary of the Nine.
       3390015730, // Source: Earned by completing challenges in the Trials of Osiris.
       3471208558, // Source: Win matches in the Trials of Osiris.
-      3543690049 // Source: Complete a flawless Trials ticket.
-    ]
+      3543690049, // Source: Complete a flawless Trials ticket.
+    ],
   },
   vexoffensive: {
     itemHashes: [
@@ -630,11 +630,11 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4026120127, // Substitutional Alloy Grips
       4078925540, // Substitutional Alloy Mask
       4078925541, // Substitutional Alloy Mask
-      4078925542 // Substitutional Alloy Mask
+      4078925542, // Substitutional Alloy Mask
     ],
     sourceHashes: [
-      4122810030 // Source: Complete seasonal activities during Season of the Undying.
-    ]
+      4122810030, // Source: Complete seasonal activities during Season of the Undying.
+    ],
   },
   zavala: {
     itemHashes: [
@@ -645,7 +645,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2788911997, // Vanguard Divide
       2788911998, // Vanguard Metallic
       2788911999, // Vanguard Veteran
-      3215252549 // Determination
+      3215252549, // Determination
     ],
     sourceHashes: [
       288436121, // Source: Complete this weapon's associated Vanguard quest.
@@ -655,9 +655,9 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1244908294, // Source: Complete the "Loaded Question" quest from Zavala.
       1564061133, // Source: Complete this reward's associated Vanguard quest.
       2317365255, // Source: Complete the "A Loud Racket" quest.
-      2527168932 // Source: Complete strikes and earn rank-up packages from Commander Zavala.
-    ]
-  }
+      2527168932, // Source: Complete strikes and earn rank-up packages from Commander Zavala.
+    ],
+  },
 };
 
 export default D2Sources;

--- a/src/gdriveReturn.ts
+++ b/src/gdriveReturn.ts
@@ -6,7 +6,7 @@ const drive = {
   client_id: $GOOGLE_DRIVE_CLIENT_ID, // eslint-disable-line @typescript-eslint/camelcase
   scope: 'https://www.googleapis.com/auth/drive.appdata',
   discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
-  fetch_basic_profile: false // eslint-disable-line @typescript-eslint/camelcase
+  fetch_basic_profile: false, // eslint-disable-line @typescript-eslint/camelcase
 };
 
 const returnUrl = '/settings?gdrive=true';

--- a/src/postcss.config.js
+++ b/src/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('autoprefixer')]
+  plugins: [require('autoprefixer')],
 };

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,7 +1,7 @@
 import {
   createHandlerBoundToURL,
   precacheAndRoute,
-  cleanupOutdatedCaches
+  cleanupOutdatedCaches,
 } from 'workbox-precaching';
 import { clientsClaim } from 'workbox-core';
 import { NavigationRoute, registerRoute } from 'workbox-routing';
@@ -24,8 +24,8 @@ registerRoute(
     cacheName: 'googleapis',
     plugins: [
       new ExpirationPlugin({ maxEntries: 20, purgeOnQuotaError: false }),
-      new CacheableResponsePlugin({ statuses: [0, 200] })
-    ]
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+    ],
   }),
   'GET'
 );
@@ -35,7 +35,7 @@ const handler = createHandlerBoundToURL('/index.html');
 const navigationRoute = new NavigationRoute(handler, {
   // These have their own pages (return.html and gdrive-return.html)
   // This regex matches on query string too, so no anchors!
-  denylist: [/return\.html/, /\.well-known/]
+  denylist: [/return\.html/, /\.well-known/],
 });
 registerRoute(navigationRoute);
 


### PR DESCRIPTION
Prettier now has as a default to include trailing commas on arrays and objects that aren't smashed into one line. It's a lot of changes, but overall I like this default because it makes it easier to add and remove lines, and keeps diffs cleaner.