### PR TITLE
Force disable organize imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,21 @@
     "**/data/d1/manifests": true
   },
   "jest.pathToConfig": "jest.config.js",
+  "[javascript]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false
+    }
+  },
+  "[typescript]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false
+    }
+  },
+  "[typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": false
+    }
+  },
   "cSpell.enabledLanguageIds": ["jsonc", "json", "markdown"],
   "cSpell.allowCompoundWords": true,
   "cSpell.ignorePaths": [


### PR DESCRIPTION
This disables the "organize imports on save" feature for the DIM workspace. I don't see much value in it, and this prevents messy diffs if folks happen to have it on.