### PR TITLE
Convert infusion finder to a function component

### DIFF
--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -177,7 +177,6 @@ function InfusionFinder({
   isPhonePortrait,
   lastInfusionDirection,
 }: Props) {
-  // These bits of state are pretty independent, but should they be in the reducer as well?
   const itemContainer = useRef<HTMLDivElement>(null);
   const [{ direction, query, source, target, height, filter }, stateDispatch] = useReducer(
     stateReducer,
@@ -243,9 +242,9 @@ function InfusionFinder({
   const effectiveSource = source || dupes[0] || items[0];
 
   let result: DimItem | undefined;
-  if (effectiveSource && effectiveTarget && effectiveSource.primStat && effectiveTarget.primStat) {
+  if (effectiveSource?.primStat && effectiveTarget?.primStat) {
     const infused = effectiveSource.primStat?.value || 0;
-    result = copy(target);
+    result = copy(effectiveTarget);
     (result as any).primStat.value = infused;
   }
 

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { useEffect, useRef, useReducer } from 'react';
 import './InfusionFinder.scss';
 import { DimItem } from '../inventory/item-types';
 import { showInfuse$ } from './infuse';
-import { Subscriptions } from '../utils/rx-utils';
 import Sheet from '../dim-ui/Sheet';
 import { AppIcon, plusIcon, helpIcon, faRandom, faEquals, faArrowCircleDown } from '../shell/icons';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
@@ -29,7 +28,8 @@ import { applyLoadout } from 'app/loadout/loadout-apply';
 import { settingsSelector } from 'app/settings/reducer';
 import { InfuseDirection, DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { LoadoutItem } from 'app/loadout/loadout-types';
-import { RouteComponentProps, withRouter } from 'react-router';
+import { useSubscription } from 'app/utils/hooks';
+import { useLocation } from 'react-router';
 
 const itemComparator = chainComparator(
   reverseComparator(compareBy((item: DimItem) => item.primStat!.value)),
@@ -69,315 +69,292 @@ const mapDispatchToProps = {
 };
 type DispatchProps = typeof mapDispatchToProps;
 
-type Props = ProvidedProps & StoreProps & DispatchProps & RouteComponentProps;
+type Props = ProvidedProps & StoreProps & DispatchProps;
 
 interface State {
-  query?: DimItem;
-  source?: DimItem;
-  target?: DimItem;
   direction: InfuseDirection;
-  filter: string;
+  /** The item we're focused on */
+  query?: DimItem;
+  /** The item that will be consumed by infusion */
+  source?: DimItem;
+  /** The item that will have its power increased by infusion */
+  target?: DimItem;
+  /** Initial height of the sheet, to prevent it resizing */
   height?: number;
+  /** Search filter string */
+  filter: string;
 }
 
-class InfusionFinder extends React.Component<Props, State> {
-  state: State = { direction: InfuseDirection.INFUSE, filter: '' };
-  private subscriptions = new Subscriptions();
-  private itemContainer = React.createRef<HTMLDivElement>();
+type Action =
+  /** Reset the tool (for when the sheet is closed) */
+  | { type: 'reset' }
+  /** Set up the tool with a new focus item */
+  | { type: 'init'; item: DimItem; hasInfusables: boolean; hasFuel: boolean }
+  /** Swap infusion direction */
+  | { type: 'swapDirection' }
+  /** Select one of the items in the list */
+  | { type: 'selectItem'; item: DimItem }
+  | { type: 'setHeight'; height: number }
+  | { type: 'setFilter'; filter: string };
 
-  componentDidMount() {
-    this.subscriptions.add(
-      showInfuse$.subscribe(({ item }) => {
-        const hasInfusables = () =>
-          this.props.stores.some((store) => store.items.some((i) => Boolean(isInfusable(item, i))));
-        const hasFuel = () =>
-          this.props.stores.some((store) => store.items.some((i) => Boolean(isInfusable(i, item))));
-
-        const direction =
-          this.props.lastInfusionDirection === InfuseDirection.INFUSE
-            ? hasInfusables()
-              ? InfuseDirection.INFUSE
-              : InfuseDirection.FUEL
-            : hasFuel()
-            ? InfuseDirection.FUEL
-            : InfuseDirection.INFUSE;
-
-        if (direction === InfuseDirection.INFUSE) {
-          this.setState({
-            query: item,
-            source: undefined,
-            target: item,
-            direction: InfuseDirection.INFUSE,
-            height: undefined,
-            filter: '',
-          });
-        } else {
-          this.setState({
-            query: item,
-            source: item,
-            target: undefined,
-            direction: InfuseDirection.FUEL,
-            height: undefined,
-            filter: '',
-          });
-        }
-      })
-    );
-
-    if (this.itemContainer.current) {
-      this.setState({ height: this.itemContainer.current.clientHeight });
-    }
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (this.itemContainer.current && !this.state.height) {
-      this.setState({ height: this.itemContainer.current.clientHeight });
-    }
-    if (prevProps.location.pathname !== this.props.location.pathname) {
-      this.onClose();
-    }
-  }
-
-  componentWillUnmount() {
-    this.subscriptions.unsubscribe();
-  }
-
-  render() {
-    const { stores, searchConfig, filters, isPhonePortrait } = this.props;
-    const { query, direction, filter, height } = this.state;
-    let { target, source } = this.state;
-
-    if (!query) {
-      return null;
-    }
-
-    const filterFn = filters.filterFunction(filter);
-
-    let items = stores.flatMap((store) =>
-      store.items.filter(
-        (item) =>
-          (direction === InfuseDirection.INFUSE
-            ? isInfusable(query, item)
-            : isInfusable(item, query)) && filterFn(item)
-      )
-    );
-
-    const dupes = items.filter((item) => item.hash === query.hash);
-    dupes.sort(itemComparator);
-    items = items.filter((item) => item.hash !== query.hash);
-    items.sort(itemComparator);
-
-    target = target || dupes[0] || items[0];
-    source = source || dupes[0] || items[0];
-
-    let result: DimItem | undefined;
-    if (source && target && source.primStat && target.primStat) {
-      const infused = source.primStat?.value || 0;
-      result = copy(target);
-      (result as any).primStat.value = infused;
-    }
-
-    const missingItem = (
-      <div className="item missingItem">
-        <div className="item-img">
-          <AppIcon icon={helpIcon} />
-        </div>
-        <div className="item-stat">???</div>
-      </div>
-    );
-
-    // On iOS at least, focusing the keyboard pushes the content off the screen
-    const autoFocus =
-      !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
-
-    const header = ({ onClose }: { onClose(): void }) => (
-      <div className="infuseHeader">
-        <h1>
-          {direction === InfuseDirection.INFUSE
-            ? t('Infusion.InfuseTarget', {
-                name: query.name,
-              })
-            : t('Infusion.InfuseSource', {
-                name: query.name,
-              })}
-        </h1>
-        <div className="infusionControls">
-          <div className="infuseTopRow">
-            <div className="infusionEquation">
-              {target ? <ConnectedInventoryItem item={target} /> : missingItem}
-              <div className="icon">
-                <AppIcon icon={plusIcon} />
-              </div>
-              {source ? <ConnectedInventoryItem item={source} /> : missingItem}
-              <div className="icon">
-                <AppIcon icon={faEquals} />
-              </div>
-              {result ? <ConnectedInventoryItem item={result} /> : missingItem}
-            </div>
-            <div className="infuseActions">
-              <button className="dim-button" onClick={this.switchDirection}>
-                <AppIcon icon={faRandom} /> {t('Infusion.SwitchDirection')}
-              </button>
-              {result && source && target && (
-                <button
-                  className="dim-button"
-                  onClick={() => this.transferItems(onClose, source!, target!)}
-                >
-                  <AppIcon icon={faArrowCircleDown} /> {t('Infusion.TransferItems')}
-                </button>
-              )}
-            </div>
-          </div>
-          <div className="infuseSearch">
-            <SearchFilterInput
-              searchConfig={searchConfig}
-              onQueryChanged={this.onQueryChanged}
-              placeholder="Filter items"
-              autoFocus={autoFocus}
-            />
-          </div>
-        </div>
-      </div>
-    );
-
-    return (
-      <Sheet onClose={this.onClose} header={header} sheetClassName="infuseDialog">
-        <div className="infuseSources" ref={this.itemContainer} style={{ height }}>
-          {items.length > 0 || dupes.length > 0 ? (
-            <>
-              <div className="sub-bucket">
-                {dupes.map((item) => (
-                  <div
-                    key={item.id}
-                    className={clsx({ 'infuse-selected': item === target })}
-                    onClick={() => this.setSourceAndTarget(item, query)}
-                  >
-                    <ConnectedInventoryItem item={item} />
-                  </div>
-                ))}
-              </div>
-              <div className="sub-bucket">
-                {items.map((item) => (
-                  <div
-                    key={item.id}
-                    className={clsx({ 'infuse-selected': item === target })}
-                    onClick={() => this.setSourceAndTarget(item, query)}
-                  >
-                    <ConnectedInventoryItem item={item} />
-                  </div>
-                ))}
-              </div>
-            </>
-          ) : (
-            <strong>{t('Infusion.NoItems')}</strong>
-          )}
-        </div>
-      </Sheet>
-    );
-  }
-
-  private onClose = () => {
-    this.setState({
-      query: undefined,
-      source: undefined,
-      target: undefined,
-      height: undefined,
-      filter: '',
-    });
-  };
-
-  private setSourceAndTarget = (source: DimItem, target: DimItem) => {
-    if (this.state.direction === InfuseDirection.INFUSE) {
-      this.setState({ source, target });
-    } else {
-      this.setState({ source: target, target: source });
-    }
-  };
-
-  private onQueryChanged = (filter: string) => {
-    this.setState({ filter });
-  };
-
-  private switchDirection = () => {
-    this.setState(({ direction: oldDirection, query }) => {
-      const direction =
-        oldDirection === InfuseDirection.INFUSE ? InfuseDirection.FUEL : InfuseDirection.INFUSE;
+/**
+ * All state for this component is managed through this reducer and the Actions above.
+ */
+function stateReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'reset':
       return {
-        direction,
-        target: direction === InfuseDirection.INFUSE ? query : undefined,
-        source: direction === InfuseDirection.FUEL ? query : undefined,
+        ...state,
+        query: undefined,
+        source: undefined,
+        target: undefined,
+        filter: '',
+        height: undefined,
       };
-    });
-    this.props.setSetting('infusionDirection', 1);
-  };
+    case 'init': {
+      const direction =
+        state.direction === InfuseDirection.INFUSE
+          ? action.hasInfusables
+            ? InfuseDirection.INFUSE
+            : InfuseDirection.FUEL
+          : action.hasFuel
+          ? InfuseDirection.FUEL
+          : InfuseDirection.INFUSE;
 
-  private transferItems = async (onClose: () => void, source: DimItem, target: DimItem) => {
-    if (!source || !target) {
-      return;
+      return {
+        ...state,
+        direction,
+        query: action.item,
+        target: direction === InfuseDirection.INFUSE ? action.item : undefined,
+        source: direction === InfuseDirection.INFUSE ? undefined : action.item,
+      };
     }
-
-    if (target.notransfer || source.notransfer) {
-      const name = source.notransfer ? source.name : target.name;
-
-      showNotification({ type: 'error', title: t('Infusion.NoTransfer', { target: name }) });
-      return;
+    case 'swapDirection': {
+      const direction =
+        state.direction === InfuseDirection.INFUSE ? InfuseDirection.FUEL : InfuseDirection.INFUSE;
+      return {
+        ...state,
+        direction,
+        target: direction === InfuseDirection.INFUSE ? state.query : undefined,
+        source: direction === InfuseDirection.FUEL ? state.query : undefined,
+      };
     }
-
-    onClose();
-
-    const items: LoadoutItem[] = [
-      convertToLoadoutItem(target, false),
-      // Include the source, since we wouldn't want it to get moved out of the way
-      convertToLoadoutItem(source, source.equipped),
-    ];
-
-    if (source.isDestiny1()) {
-      if (target.bucket.sort === 'General') {
-        // Mote of Light
-        items.push({
-          id: '0',
-          hash: 937555249,
-          amount: 2,
-          equipped: false,
-        });
-      } else if (target.bucket.sort === 'Weapons') {
-        // Weapon Parts
-        items.push({
-          id: '0',
-          hash: 1898539128,
-          amount: 10,
-          equipped: false,
-        });
+    case 'selectItem': {
+      if (state.direction === InfuseDirection.INFUSE) {
+        return {
+          ...state,
+          target: state.query,
+          source: action.item,
+        };
       } else {
-        // Armor Materials
-        items.push({
-          id: '0',
-          hash: 1542293174,
-          amount: 10,
-          equipped: false,
-        });
-      }
-      if (source.isExotic) {
-        // Exotic shard
-        items.push({
-          id: '0',
-          hash: 452597397,
-          amount: 1,
-          equipped: false,
-        });
+        return {
+          ...state,
+          target: action.item,
+          source: state.query,
+        };
       }
     }
-
-    // TODO: another one where we want to respect equipped
-    const loadout = newLoadout(t('Infusion.InfusionMaterials'), items);
-
-    await applyLoadout(this.props.currentStore, loadout);
-  };
+    case 'setHeight': {
+      return {
+        ...state,
+        height: action.height,
+      };
+    }
+    case 'setFilter': {
+      return {
+        ...state,
+        filter: action.filter,
+      };
+    }
+  }
 }
 
-export default withRouter(
-  connect<StoreProps, DispatchProps>(mapStateToProps, mapDispatchToProps)(InfusionFinder)
-);
+function InfusionFinder({
+  stores,
+  currentStore,
+  searchConfig,
+  filters,
+  isPhonePortrait,
+  lastInfusionDirection,
+}: Props) {
+  // These bits of state are pretty independent, but should they be in the reducer as well?
+  const itemContainer = useRef<HTMLDivElement>(null);
+  const [{ direction, query, source, target, height, filter }, stateDispatch] = useReducer(
+    stateReducer,
+    {
+      direction: lastInfusionDirection,
+      filter: '',
+    }
+  );
+
+  const reset = () => stateDispatch({ type: 'reset' });
+  const selectItem = (item: DimItem) => stateDispatch({ type: 'selectItem', item });
+  const onQueryChanged = (filter: string) => stateDispatch({ type: 'setFilter', filter });
+  const switchDirection = () => stateDispatch({ type: 'swapDirection' });
+
+  // Listen for items coming in via showInfuse#
+  useSubscription(() =>
+    showInfuse$.subscribe(({ item }) => {
+      const hasInfusables = stores.some((store) => store.items.some((i) => isInfusable(item, i)));
+      const hasFuel = stores.some((store) => store.items.some((i) => isInfusable(i, item)));
+      stateDispatch({ type: 'init', item, hasInfusables: hasInfusables, hasFuel });
+    })
+  );
+
+  // Track the initial height of the sheet
+  useEffect(() => {
+    if (itemContainer.current && !height) {
+      stateDispatch({ type: 'setHeight', height: itemContainer.current.clientHeight });
+    }
+  }, [height]);
+
+  // Close the sheet on navigation
+  const { pathname } = useLocation();
+  useEffect(reset, [pathname]);
+
+  // Save direction to settings
+  useEffect(() => {
+    if (direction != lastInfusionDirection) {
+      setSetting('infusionDirection', direction);
+    }
+  }, [direction, lastInfusionDirection]);
+
+  if (!query) {
+    return null;
+  }
+
+  const filterFn = filters.filterFunction(filter);
+
+  let items = stores.flatMap((store) =>
+    store.items.filter(
+      (item) =>
+        (direction === InfuseDirection.INFUSE
+          ? isInfusable(query, item)
+          : isInfusable(item, query)) && filterFn(item)
+    )
+  );
+
+  const dupes = items.filter((item) => item.hash === query.hash);
+  dupes.sort(itemComparator);
+  items = items.filter((item) => item.hash !== query.hash);
+  items.sort(itemComparator);
+
+  const effectiveTarget = target || dupes[0] || items[0];
+  const effectiveSource = source || dupes[0] || items[0];
+
+  let result: DimItem | undefined;
+  if (effectiveSource && effectiveTarget && effectiveSource.primStat && effectiveTarget.primStat) {
+    const infused = effectiveSource.primStat?.value || 0;
+    result = copy(target);
+    (result as any).primStat.value = infused;
+  }
+
+  const missingItem = (
+    <div className="item missingItem">
+      <div className="item-img">
+        <AppIcon icon={helpIcon} />
+      </div>
+      <div className="item-stat">???</div>
+    </div>
+  );
+
+  // On iOS at least, focusing the keyboard pushes the content off the screen
+  const autoFocus =
+    !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
+
+  const header = ({ onClose }: { onClose(): void }) => (
+    <div className="infuseHeader">
+      <h1>
+        {direction === InfuseDirection.INFUSE
+          ? t('Infusion.InfuseTarget', {
+              name: query.name,
+            })
+          : t('Infusion.InfuseSource', {
+              name: query.name,
+            })}
+      </h1>
+      <div className="infusionControls">
+        <div className="infuseTopRow">
+          <div className="infusionEquation">
+            {effectiveTarget ? <ConnectedInventoryItem item={effectiveTarget} /> : missingItem}
+            <div className="icon">
+              <AppIcon icon={plusIcon} />
+            </div>
+            {effectiveSource ? <ConnectedInventoryItem item={effectiveSource} /> : missingItem}
+            <div className="icon">
+              <AppIcon icon={faEquals} />
+            </div>
+            {result ? <ConnectedInventoryItem item={result} /> : missingItem}
+          </div>
+          <div className="infuseActions">
+            <button className="dim-button" onClick={switchDirection}>
+              <AppIcon icon={faRandom} /> {t('Infusion.SwitchDirection')}
+            </button>
+            {result && effectiveSource && effectiveTarget && (
+              <button
+                type="button"
+                className="dim-button"
+                onClick={() =>
+                  transferItems(currentStore, onClose, effectiveSource, effectiveTarget)
+                }
+              >
+                <AppIcon icon={faArrowCircleDown} /> {t('Infusion.TransferItems')}
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="infuseSearch">
+          <SearchFilterInput
+            searchConfig={searchConfig}
+            onQueryChanged={onQueryChanged}
+            placeholder="Filter items"
+            autoFocus={autoFocus}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <Sheet onClose={reset} header={header} sheetClassName="infuseDialog">
+      <div className="infuseSources" ref={itemContainer} style={{ height }}>
+        {items.length > 0 || dupes.length > 0 ? (
+          <>
+            <div className="sub-bucket">
+              {dupes.map((item) => (
+                <div
+                  key={item.id}
+                  className={clsx({ 'infuse-selected': item === target })}
+                  onClick={() => selectItem(item)}
+                >
+                  <ConnectedInventoryItem item={item} />
+                </div>
+              ))}
+            </div>
+            <div className="sub-bucket">
+              {items.map((item) => (
+                <div
+                  key={item.id}
+                  className={clsx({ 'infuse-selected': item === target })}
+                  onClick={() => selectItem(item)}
+                >
+                  <ConnectedInventoryItem item={item} />
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          <strong>{t('Infusion.NoItems')}</strong>
+        )}
+      </div>
+    </Sheet>
+  );
+}
+
+export default connect<StoreProps, DispatchProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(InfusionFinder);
 
 /**
  * Can source be infused into target?
@@ -402,4 +379,72 @@ function isInfusable(target: DimItem, source: DimItem) {
 
   // Don't try to apply logic for unknown Destiny versions.
   return false;
+}
+
+async function transferItems(
+  currentStore: DimStore,
+  onClose: () => void,
+  source: DimItem,
+  target: DimItem
+) {
+  if (!source || !target) {
+    return;
+  }
+
+  if (target.notransfer || source.notransfer) {
+    const name = source.notransfer ? source.name : target.name;
+
+    showNotification({ type: 'error', title: t('Infusion.NoTransfer', { target: name }) });
+    return;
+  }
+
+  onClose();
+
+  const items: LoadoutItem[] = [
+    convertToLoadoutItem(target, false),
+    // Include the source, since we wouldn't want it to get moved out of the way
+    convertToLoadoutItem(source, source.equipped),
+  ];
+
+  if (source.isDestiny1()) {
+    if (target.bucket.sort === 'General') {
+      // Mote of Light
+      items.push({
+        id: '0',
+        hash: 937555249,
+        amount: 2,
+        equipped: false,
+      });
+    } else if (target.bucket.sort === 'Weapons') {
+      // Weapon Parts
+      items.push({
+        id: '0',
+        hash: 1898539128,
+        amount: 10,
+        equipped: false,
+      });
+    } else {
+      // Armor Materials
+      items.push({
+        id: '0',
+        hash: 1542293174,
+        amount: 10,
+        equipped: false,
+      });
+    }
+    if (source.isExotic) {
+      // Exotic shard
+      items.push({
+        id: '0',
+        hash: 452597397,
+        amount: 1,
+        equipped: false,
+      });
+    }
+  }
+
+  // TODO: another one where we want to respect equipped
+  const loadout = newLoadout(t('Infusion.InfusionMaterials'), items);
+
+  await applyLoadout(currentStore, loadout);
 }


### PR DESCRIPTION
This rewrites the Infusion Fuel Finder as a functional component with hooks. I used a `useReducer` hook to encapsulate the state logic, which worked really nicely.