### PR TITLE
have i18n bot create a PR instead of commit directly

### DIFF
--- a/.github/workflows/i18n-bot-download.yml
+++ b/.github/workflows/i18n-bot-download.yml
@@ -35,12 +35,26 @@ jobs:
         id: porcelain
         run: echo ::set-output name=porcelain::"$(git status --porcelain)"
 
-      - name: Push changes (DIM)
+#      - name: Push changes (DIM)
+#        if: steps.porcelain.outputs.porcelain
+#        uses: delphiactual/github-push-action@master
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          commit_message: "i18n"
+#          user_email: "destinyitemmanager@gmail.com"
+#          user_name: "DIM i18n Bot"
+#          branch: master
+
+      - name: Create Pull Request (DIM)
         if: steps.porcelain.outputs.porcelain
-        uses: delphiactual/github-push-action@master
+        uses: peter-evans/create-pull-request@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_message: "i18n"
-          user_email: "destinyitemmanager@gmail.com"
-          user_name: "DIM i18n Bot"
-          branch: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: i18n - ${{ env.GITHUB_SHA_SHORT }}
+          committer: DIM i18n Bot <destinyitemmanager@gmail.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: '[i18n] Updates'
+          body: i18n updates
+          labels: i18n, automated pr
+          reviewers: delphiactual
+          branch: i18n


### PR DESCRIPTION
i18n bot cannot commit directly to master branch in a Github Action, either due to Github Actions or a permissions issue with required statuses.



```
Push to branch master
remote: error: GH006: Protected branch update failed for refs/heads/master.        
remote: error: Required status check "continuous-integration/travis-ci" is expected.  
```

https://github.community/t5/GitHub-Actions/How-to-push-to-protected-branches-in-a-GitHub-Action/td-p/29609