### PR TITLE
Loadouts fixes

### DIFF
--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -49,7 +49,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
 
 type Props = ProvidedProps & StoreProps;
 
-const classIcons = {
+export const classIcons = {
   [DestinyClass.Unknown]: globeIcon,
   [DestinyClass.Hunter]: hunterIcon,
   [DestinyClass.Warlock]: warlockIcon,

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -105,7 +105,7 @@ type Action =
   /** Replace the current loadout with an updated one */
   | { type: 'update'; loadout: Loadout }
   /** Add an item to the loadout */
-  | { type: 'addItem'; item: DimItem; equip: boolean | undefined; shift: boolean; items: DimItem[] }
+  | { type: 'addItem'; item: DimItem; equip?: boolean; shift: boolean; items: DimItem[] }
   /** Remove an item from the loadout */
   | { type: 'removeItem'; item: DimItem; shift: boolean; items: DimItem[] }
   /** Make an item that's already in the loadout equipped */
@@ -224,13 +224,14 @@ function addItem(
           }
         }
 
-        // Only allow one subclass per element
+        // Only allow one subclass to be present per class (to allow for making a loadout that specifies a subclass for each class)
         if (item.type === 'Class') {
           const conflictingItem = items.find(
-            (i) => i.type === item.type && i.element?.hash === item.element?.hash
+            (i) => i.type === item.type && i.classType === item.classType
           );
+          console.log('Class', typeInventory, dupe, conflictingItem);
           if (conflictingItem) {
-            draftLoadout.items = draftLoadout.items.filter((i) => i.id === conflictingItem.id);
+            draftLoadout.items = draftLoadout.items.filter((i) => i.id !== conflictingItem.id);
           }
           loadoutItem.equipped = true;
         }
@@ -242,7 +243,7 @@ function addItem(
           title: t('Loadouts.MaxSlots', { slots: maxSlots }),
         });
       }
-    } else if (dupe && item.maxStackSize > 1) {
+    } else if (item.maxStackSize > 1) {
       const increment = Math.min(dupe.amount + item.amount, item.maxStackSize) - dupe.amount;
       dupe.amount = dupe.amount + increment;
       // TODO: handle stack splits
@@ -296,19 +297,25 @@ function removeItem(
 }
 
 /**
- * Produce a new loadout with the given item switched to being equipped.
+ * Produce a new loadout with the given item switched to being equipped (or unequipped if it's already equipped).
  */
 function equipItem(loadout: Readonly<Loadout>, item: DimItem, items: DimItem[]) {
   return produce(loadout, (draftLoadout) => {
     const findItem = (item: DimItem) =>
       draftLoadout.items.find((i) => i.id === item.id && i.hash === item.hash)!;
+
+    // Classes are always equipped
+    if (item.type === 'Class') {
+      return;
+    }
+
     const loadoutItem = findItem(item);
     if (item.equipment) {
-      if (item.type === 'Class' && !loadoutItem.equipped) {
-        loadoutItem.equipped = true;
-      } else if (loadoutItem.equipped) {
+      if (loadoutItem.equipped) {
+        // It's equipped, mark it unequipped
         loadoutItem.equipped = false;
       } else {
+        // It's unequipped - mark all the other items and conflicting exotics unequipped, then mark this equipped
         items
           .filter(
             (i) =>
@@ -439,7 +446,7 @@ function LoadoutDrawer({
     stores,
   ]);
 
-  const onAddItem = (item: DimItem, e?: MouseEvent, equip = false) =>
+  const onAddItem = (item: DimItem, e?: MouseEvent, equip?: boolean) =>
     stateDispatch({ type: 'addItem', item, shift: Boolean(e?.shiftKey), equip, items });
 
   const onRemoveItem = (item: DimItem, e?: React.MouseEvent) =>

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -229,7 +229,6 @@ function addItem(
           const conflictingItem = items.find(
             (i) => i.type === item.type && i.classType === item.classType
           );
-          console.log('Class', typeInventory, dupe, conflictingItem);
           if (conflictingItem) {
             draftLoadout.items = draftLoadout.items.filter((i) => i.id !== conflictingItem.id);
           }

--- a/src/app/loadout/LoadoutDrawerBucket.tsx
+++ b/src/app/loadout/LoadoutDrawerBucket.tsx
@@ -27,8 +27,11 @@ export default function LoadoutDrawerBucket({
     return null;
   }
 
-  const equippedItem = items.find((i) =>
-    loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && li.equipped)
+  const equippedItems = sortItems(
+    items.filter((i) =>
+      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && li.equipped)
+    ),
+    itemSortOrder
   );
   const unequippedItems = sortItems(
     items.filter((i) =>
@@ -39,14 +42,16 @@ export default function LoadoutDrawerBucket({
 
   return (
     <div className="loadout-bucket">
-      {equippedItem || unequippedItems.length > 0 ? (
+      {equippedItems.length > 0 || unequippedItems.length > 0 ? (
         <>
           <div className="loadout-bucket-name">{bucket.name}</div>
           <div className={`loadout-bucket-items bucket-${bucket.type}`}>
             <div className="sub-bucket equipped">
               <div className="equipped-item">
-                {equippedItem ? (
-                  <LoadoutDrawerItem item={equippedItem} equip={equip} remove={remove} />
+                {equippedItems.length > 0 ? (
+                  equippedItems.map((item) => (
+                    <LoadoutDrawerItem key={item.index} item={item} equip={equip} remove={remove} />
+                  ))
                 ) : (
                   <a onClick={() => pickLoadoutItem(bucket)} className="pull-item-button">
                     <AppIcon icon={addIcon} />
@@ -54,16 +59,18 @@ export default function LoadoutDrawerBucket({
                 )}
               </div>
             </div>
-            {(equippedItem || unequippedItems.length > 0) && bucket.type !== 'Class' && (
+            {(equippedItems.length > 0 || unequippedItems.length > 0) && bucket.type !== 'Class' && (
               <div className="sub-bucket">
                 {unequippedItems.map((item) => (
                   <LoadoutDrawerItem key={item.index} item={item} equip={equip} remove={remove} />
                 ))}
-                {equippedItem && unequippedItems.length < 9 && bucket.type !== 'Class' && (
-                  <a onClick={() => pickLoadoutItem(bucket)} className="pull-item-button">
-                    <AppIcon icon={addIcon} />
-                  </a>
-                )}
+                {equippedItems.length > 0 &&
+                  unequippedItems.length < bucket.capacity - 1 &&
+                  bucket.type !== 'Class' && (
+                    <a onClick={() => pickLoadoutItem(bucket)} className="pull-item-button">
+                      <AppIcon icon={addIcon} />
+                    </a>
+                  )}
               </div>
             )}
           </div>

--- a/src/app/loadout/LoadoutDrawerItem.tsx
+++ b/src/app/loadout/LoadoutDrawerItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { DimItem } from '../inventory/item-types';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
+import AppIcon from 'app/shell/icons/AppIcon';
+import { classIcons } from 'app/inventory/StoreBucket';
 
 export default function LoadoutDrawerItem({
   item,
@@ -20,6 +22,9 @@ export default function LoadoutDrawerItem({
     <div onClick={(e) => equip(item, e)} className="loadout-item">
       <ConnectedInventoryItem item={item} ignoreSelectedPerks={true} />
       <div className="close" onClick={onClose} />
+      {item.type === 'Class' && (
+        <AppIcon icon={classIcons[item.classType]} className="loadout-item-class-icon" />
+      )}
     </div>
   );
 }

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -107,6 +107,15 @@ export default function LoadoutDrawerOptions({
               className="dim-button"
               onClick={saveAsNew}
               type="button"
+              title={
+                clashingLoadout
+                  ? clashingLoadout.classType !== DestinyClass.Unknown
+                    ? t('Loadouts.AlreadyExistsClass', {
+                        className: getClass(clashingLoadout.classType),
+                      })
+                    : t('Loadouts.AlreadyExistsGlobal')
+                  : t('Loadouts.SaveAsNew')
+              }
               disabled={saveAsNewDisabled}
             >
               {t('Loadouts.SaveAsNew')}

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -23,6 +23,17 @@ const outOfSpaceWarning = _.throttle((store) => {
   });
 }, 60000);
 
+interface Scope {
+  failed: number;
+  total: number;
+  successfulItems: DimItem[];
+  errors: {
+    item: DimItem | null;
+    message: string;
+    level: string;
+  }[];
+}
+
 /**
  * Apply a loadout - a collection of items to be moved and possibly equipped all at once.
  * @param allowUndo whether to include this loadout in the "undo loadout" menu stack.
@@ -52,6 +63,7 @@ export async function applyLoadout(
       // TODO: allow for an error view function to be passed in
       // TODO: cancel button!
       loadoutPromise.then((scope) => {
+        console.log('Done', scope);
         if (scope.failed > 0) {
           if (scope.failed === scope.total) {
             throw new Error(t('Loadouts.AppliedError'));
@@ -68,7 +80,11 @@ export async function applyLoadout(
   await loadoutPromise;
 }
 
-async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = false) {
+async function doApplyLoadout(
+  store: DimStore,
+  loadout: Loadout,
+  allowUndo = false
+): Promise<Scope> {
   const storeService = store.getStoresService();
   if (allowUndo && !store.isVault) {
     reduxStore.dispatch(
@@ -97,9 +113,9 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
       return false;
     }
 
-    // only try to equip subclasses that are equippable, since we allow multiple in a loadout
+    // only try to equip items that are equippable - otherwise ignore them
     const applicableSubclass =
-      item.type !== 'Class' || (!item.equipped && !store.isVault) || item.canBeEquippedBy(store);
+      item.type !== 'Class' || (pseudoItem.equipped && item.canBeEquippedBy(store));
     if (!applicableSubclass) {
       totalItems--;
       return false;
@@ -137,7 +153,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
     return item?.equipped && item.owner !== store.id;
   });
 
-  const scope = {
+  const scope: Scope = {
     failed: 0,
     total: totalItems,
     successfulItems: [] as DimItem[],
@@ -181,6 +197,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
         .filter((i) => !equippedItems.find((it) => it.id === i.id))
         .map((i) => getLoadoutItem(i, store))
     );
+    console.log('failedItems', failedItems);
     failedItems.forEach((item) => {
       scope.failed++;
       scope.errors.push({
@@ -290,6 +307,7 @@ async function applyLoadoutItems(
   } catch (e) {
     const level = e.level || 'error';
     if (level === 'error') {
+      console.error('Failed to apply loadout item', item?.name, e);
       scope.failed++;
     }
     scope.errors.push({

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -99,7 +99,7 @@ async function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = fal
 
     // only try to equip subclasses that are equippable, since we allow multiple in a loadout
     const applicableSubclass =
-      item.type !== 'Class' || !item.equipped || item.canBeEquippedBy(store);
+      item.type !== 'Class' || (!item.equipped && !store.isVault) || item.canBeEquippedBy(store);
     if (!applicableSubclass) {
       totalItems--;
       return false;

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -63,7 +63,6 @@ export async function applyLoadout(
       // TODO: allow for an error view function to be passed in
       // TODO: cancel button!
       loadoutPromise.then((scope) => {
-        console.log('Done', scope);
         if (scope.failed > 0) {
           if (scope.failed === scope.total) {
             throw new Error(t('Loadouts.AppliedError'));
@@ -197,7 +196,6 @@ async function doApplyLoadout(
         .filter((i) => !equippedItems.find((it) => it.id === i.id))
         .map((i) => getLoadoutItem(i, store))
     );
-    console.log('failedItems', failedItems);
     failedItems.forEach((item) => {
       scope.failed++;
       scope.errors.push({

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -36,6 +36,19 @@
   }
 }
 
+.loadout-item-class-icon {
+  box-sizing: border-box;
+  width: calc(var(--item-size) / 4) !important;
+  height: calc(var(--item-size) / 4) !important;
+  font-size: calc(var(--item-size) * 0.71);
+  color: white;
+  position: absolute;
+  z-index: 1;
+  left: 1px;
+  bottom: 1px;
+  display: block;
+}
+
 .loadout-content {
   .dim-select {
     height: 23px;

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -463,7 +463,7 @@ function searchFilters(
         compareBy((item) => item.locked),
         compareBy((item) => {
           const tag = getTag(item, itemInfos);
-          return tag && ['favorite', 'keep'].includes(tag);
+          return Boolean(tag && ['favorite', 'keep'].includes(tag));
         }),
         compareBy((i) => i.id) // tiebreak by ID
       )

--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -463,7 +463,7 @@ function searchFilters(
         compareBy((item) => item.locked),
         compareBy((item) => {
           const tag = getTag(item, itemInfos);
-          return Boolean(tag && ['favorite', 'keep'].includes(tag));
+          return tag && ['favorite', 'keep'].includes(tag);
         }),
         compareBy((i) => i.id) // tiebreak by ID
       )

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -279,7 +279,7 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
                 {t('Settings.Settings')}
               </NavLink>
               {installPromptEvent ? (
-                <a className="link" onClick={installDim}>
+                <a className="link menuItem" onClick={installDim}>
                   {t('Header.InstallDIM')}
                 </a>
               ) : (


### PR DESCRIPTION
1. Fix the issue where subclasses would fail to transfer (they shouldn't even try).
2. Fix adding subclasses to loadouts generally - you can add one per class type, and they're always equipped. Adding an unequipped subclass to a loadout makes no sense.
3. Fix a bug introduced in the functionalization refactor that made items not auto-equip when they're the first ones.
4. Add a class icon to subclasses so you can tell them apart.

<img width="362" alt="Screen Shot 2020-05-25 at 2 37 38 PM" src="https://user-images.githubusercontent.com/313208/82844580-dccd9e00-9e95-11ea-8fba-299261c8ad4e.png">
