### PR TITLE
Remove default scrollbar styling

### DIFF
--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -67,20 +67,6 @@ $control-color: rgba(255, 255, 255, 0.5);
     padding-bottom: constant(safe-area-inset-bottom);
     padding-bottom: env(safe-area-inset-bottom);
 
-    /*
-    &::-webkit-scrollbar {
-      all: unset;
-    }
-
-    &::-webkit-scrollbar-track {
-      all: unset;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      all: unset;
-    }
-    */
-
     &.sheet-has-footer {
       padding-bottom: 0;
     }

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -169,24 +169,6 @@ body {
   overscroll-behavior: contain;
 }
 
-::-webkit-scrollbar {
-  width: 10px;
-
-  &:horizontal {
-    height: 10px;
-  }
-}
-
-::-webkit-scrollbar-track {
-  background: rgba(228, 228, 228, 0.2);
-  border-radius: 3px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #e4e4e4;
-  border-radius: 3px;
-}
-
 #system {
   outline: none;
   background-color: #fafafa;


### PR DESCRIPTION
At some point in the past, we styled all the scrollbars in the app, I assume to make it clearer when things like the loadout popup could scroll. I think it's a bit excessive, so this changes to only styling scrollbars on dropdowns (I already put those styles in place).