### PR TITLE
Improvements for DIM Sync disablers

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -888,12 +888,14 @@
     "ImportConfirmDimApi": "Are you sure you want to overwrite your current tags, loadouts, and settings with this version? It will completely replace what you had.",
     "ImportNotification": {
       "SuccessTitle": "Import Successful",
-      "SuccessBodyForced": "Imported settings, {{loadouts}} loadouts, and {{tags}} tagged items from your backup into DIM Sync, replacing what was already there."
+      "SuccessBodyForced": "Imported settings, {{loadouts}} loadouts, and {{tags}} tagged items from your backup into DIM Sync, replacing what was already there.",
+      "FailedTitle": "Import Failed",
+      "FailedBody": "Unable to import data. {{error}}",
+      "NoData": "No loadouts or tags found in the backup"
     },
     "ImportExport": "Backup & Import",
     "ImportFailed": "Import Failed! {{error}}",
     "ImportNoFile": "No file selected!",
-    "ImportSuccess": "Imported DIM data!",
     "ImportTooManyFiles": "Please only select one file to import.",
     "ImportWrongFileType": "File is not a JSON file. It may not be a DIM backup.",
     "IndexedDBStorage": "Local Browser Storage",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -889,6 +889,7 @@
     "ImportNotification": {
       "SuccessTitle": "Import Successful",
       "SuccessBodyForced": "Imported settings, {{loadouts}} loadouts, and {{tags}} tagged items from your backup into DIM Sync, replacing what was already there.",
+      "SuccessBodyLocal": "Imported settings, {{loadouts}} loadouts, and {{tags}} tagged items from your backup into local storage, replacing what was already there. We cannot guarantee that local storage won't be lost - consider enabling DIM Sync.",
       "FailedTitle": "Import Failed",
       "FailedBody": "Unable to import data. {{error}}",
       "NoData": "No loadouts or tags found in the backup"

--- a/src/app/dim-api/import.ts
+++ b/src/app/dim-api/import.ts
@@ -37,7 +37,7 @@ export function importDataBackup(data: DimData | ExportResponse): ThunkResult {
         console.log('[importLegacyData] Attempting to import legacy data into DIM API');
         const result = await importData(data);
         console.log('[importLegacyData] Successfully imported legacy data into DIM API', result);
-        showImportSuccessNotification(result);
+        showImportSuccessNotification(result, true);
 
         // Reload from the server
         return dispatch(loadDimApiData(true));
@@ -97,10 +97,13 @@ export function importDataBackup(data: DimData | ExportResponse): ThunkResult {
           updateQueue: [],
         })
       );
-      showImportSuccessNotification({
-        loadouts: loadouts.length,
-        tags: tags.length,
-      });
+      showImportSuccessNotification(
+        {
+          loadouts: loadouts.length,
+          tags: tags.length,
+        },
+        false
+      );
     }
   };
 }
@@ -120,11 +123,16 @@ function waitForProfileLoad() {
   });
 }
 
-function showImportSuccessNotification(result: { loadouts: number; tags: number }) {
+function showImportSuccessNotification(
+  result: { loadouts: number; tags: number },
+  dimSync: boolean
+) {
   showNotification({
     type: 'success',
     title: t('Storage.ImportNotification.SuccessTitle'),
-    body: t('Storage.ImportNotification.SuccessBodyForced', result),
+    body: dimSync
+      ? t('Storage.ImportNotification.SuccessBodyForced', result)
+      : t('Storage.ImportNotification.SuccessBodyLocal', result),
     duration: 15000,
   });
 }

--- a/src/app/storage/DimApiSettings.tsx
+++ b/src/app/storage/DimApiSettings.tsx
@@ -69,7 +69,6 @@ function DimApiSettings({ apiPermissionGranted, dispatch, profileLoadedError }: 
   const onImportData = async (data: object) => {
     if (confirm(t('Storage.ImportConfirmDimApi'))) {
       await dispatch(importDataBackup(data));
-      alert(t('Storage.ImportSuccess'));
     }
   };
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -854,7 +854,7 @@
     },
     "AuditLog": "DIM Sync Change History",
     "AuditLogLabel": "View past data changes",
-    "AutoBackup": "We've backed up your data to a file called dim-data.json, just in case.",
+    "AutoBackup": "We've backed up your data to a file in your downloads folder called dim-data.json, just in case.",
     "BackUpFirst": "You MUST back up your data first, before you delete it all. Just in case.",
     "BrowserMayClearData": "The browser may delete this information if you run out of space or don't visit DIM frequently.",
     "DeleteAllData": "Delete ALL Data from DIM Sync Servers",
@@ -881,10 +881,12 @@
     "ImportFailed": "Import Failed! {{error}}",
     "ImportNoFile": "No file selected!",
     "ImportNotification": {
+      "FailedBody": "Unable to import data. {{error}}",
+      "FailedTitle": "Import Failed",
+      "NoData": "No loadouts or tags found in the backup",
       "SuccessBodyForced": "Imported settings, {{loadouts}} loadouts, and {{tags}} tagged items from your backup into DIM Sync, replacing what was already there.",
       "SuccessTitle": "Import Successful"
     },
-    "ImportSuccess": "Imported DIM data!",
     "ImportTooManyFiles": "Please only select one file to import.",
     "ImportWrongFileType": "File is not a JSON file. It may not be a DIM backup.",
     "IndexedDBStorage": "Local Browser Storage",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -885,6 +885,7 @@
       "FailedTitle": "Import Failed",
       "NoData": "No loadouts or tags found in the backup",
       "SuccessBodyForced": "Imported settings, {{loadouts}} loadouts, and {{tags}} tagged items from your backup into DIM Sync, replacing what was already there.",
+      "SuccessBodyLocal": "Imported settings, {{loadouts}} loadouts, and {{tags}} tagged items from your backup into local storage, replacing what was already there. We cannot guarantee that local storage won't be lost - consider enabling DIM Sync.",
       "SuccessTitle": "Import Successful"
     },
     "ImportTooManyFiles": "Please only select one file to import.",


### PR DESCRIPTION
I realized that if users have DIM Sync off, with our last update they'd just suddenly be missing their data without a clear idea of what to do. This PR makes two changes:

1. Fixes some bugs in the import process that could tell you an import succeeded when it didn't.
2. Tries to automatically (if somewhat jankily) import legacy data (from gdrive or idb) to the new storage model, only if they have DIM Sync off.