### PR TITLE
Retry manifest components

### DIFF
--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -1,17 +1,17 @@
-import _ from 'lodash';
-import { get, set, del } from 'idb-keyval';
+import { DestinyInventoryItemDefinition, DestinyManifest } from 'bungie-api-ts/destiny2';
+import { del, get, set } from 'idb-keyval';
+import { emptyArray, emptyObject } from 'app/utils/empty';
+import { loadingEnd, loadingStart } from 'app/shell/actions';
 
-import { reportException } from '../utils/exceptions';
+import _ from 'lodash';
 import { getManifest as d2GetManifest } from '../bungie-api/destiny2-api';
-import { settingsReady } from '../settings/settings';
-import { t } from 'app/i18next-t';
-import { DestinyManifest, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { deepEqual } from 'fast-equals';
-import { showNotification } from '../notifications/notifications';
+import { reportException } from '../utils/exceptions';
+import { settingsReady } from '../settings/settings';
 import { settingsSelector } from 'app/settings/reducer';
+import { showNotification } from '../notifications/notifications';
 import store from 'app/store/store';
-import { emptyObject, emptyArray } from 'app/utils/empty';
-import { loadingStart, loadingEnd } from 'app/shell/actions';
+import { t } from 'app/i18next-t';
 
 // This file exports D2ManifestService at the bottom of the
 // file (TS wants us to declare classes before using them)!
@@ -199,12 +199,31 @@ class ManifestService {
     store.dispatch(loadingStart(t('Manifest.Download')));
     try {
       const manifest = {};
+      // Adding a cache buster to work around bad cached CloudFlare data: https://github.com/DestinyItemManager/DIM/issues/5101
+      // try canonical component URL which should likely be already cached,
+      // then fall back to appending "?dim" then "?dim-[random numbers]",
+      // in case cloudflare has inappropriately cached another domain's CORS headers or a 404 that's no longer a 404
+      const cacheBusterStrings = [
+        '',
+        '?dim',
+        `?dim-${Math.random().toString().split('.')[1] ?? 'dimCacheBust'}`,
+      ];
       const futures = tableWhitelist
         .map((t) => `Destiny${t}Definition`)
         .map(async (table) => {
-          // Adding a cache buster "?dim" to work around bad cached CloudFlare data: https://github.com/DestinyItemManager/DIM/issues/5101
-          const response = await fetch(`https://www.bungie.net${components[table]}?dim`);
-          const body = await (response.ok ? response.json() : Promise.reject(response));
+          let response: Response | null = null;
+          let error: any;
+
+          for (const query of cacheBusterStrings) {
+            try {
+              response = await fetch(`https://www.bungie.net${components[table]}${query}`);
+              if (response.ok) break;
+              error = response;
+            } catch (e) {
+              error = e;
+            }
+          }
+          const body = await (response?.ok ? response.json() : Promise.reject(error));
           manifest[table] = tableTrimmers[table] ? tableTrimmers[table](body) : body;
         });
 

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -204,9 +204,9 @@ class ManifestService {
       // then fall back to appending "?dim" then "?dim-[random numbers]",
       // in case cloudflare has inappropriately cached another domain's CORS headers or a 404 that's no longer a 404
       const cacheBusterStrings = [
-        '2',
-        '3?dim',
-        `4?dim-${Math.random().toString().split('.')[1] ?? 'dimCacheBust'}`,
+        '',
+        '?dim',
+        `?dim-${Math.random().toString().split('.')[1] ?? 'dimCacheBust'}`,
       ];
       const futures = tableWhitelist
         .map((t) => `Destiny${t}Definition`)

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -1,17 +1,17 @@
-import _ from 'lodash';
-import { get, set, del } from 'idb-keyval';
+import { DestinyInventoryItemDefinition, DestinyManifest } from 'bungie-api-ts/destiny2';
+import { del, get, set } from 'idb-keyval';
+import { emptyArray, emptyObject } from 'app/utils/empty';
+import { loadingEnd, loadingStart } from 'app/shell/actions';
 
-import { reportException } from '../utils/exceptions';
+import _ from 'lodash';
 import { getManifest as d2GetManifest } from '../bungie-api/destiny2-api';
-import { settingsReady } from '../settings/settings';
-import { t } from 'app/i18next-t';
-import { DestinyManifest, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { deepEqual } from 'fast-equals';
-import { showNotification } from '../notifications/notifications';
+import { reportException } from '../utils/exceptions';
+import { settingsReady } from '../settings/settings';
 import { settingsSelector } from 'app/settings/reducer';
+import { showNotification } from '../notifications/notifications';
 import store from 'app/store/store';
-import { emptyObject, emptyArray } from 'app/utils/empty';
-import { loadingStart, loadingEnd } from 'app/shell/actions';
+import { t } from 'app/i18next-t';
 
 // This file exports D2ManifestService at the bottom of the
 // file (TS wants us to declare classes before using them)!
@@ -204,23 +204,23 @@ class ManifestService {
       // then fall back to appending "?dim" then "?dim-[random numbers]",
       // in case cloudflare has inappropriately cached another domain's CORS headers or a 404 that's no longer a 404
       const cacheBusterStrings = [
-        '',
-        '?dim',
-        `?dim-${Math.random().toString().split('.')[1] ?? 'dimCacheBust'}`,
+        '2',
+        '3?dim',
+        `4?dim-${Math.random().toString().split('.')[1] ?? 'dimCacheBust'}`,
       ];
       const futures = tableWhitelist
         .map((t) => `Destiny${t}Definition`)
         .map(async (table) => {
           let response: Response | null = null;
-          let error: any;
+          const error: any[] = [];
 
           for (const query of cacheBusterStrings) {
             try {
               response = await fetch(`https://www.bungie.net${components[table]}${query}`);
               if (response.ok) break;
-              error = response;
+              error.push(response);
             } catch (e) {
-              error = e;
+              error.push(e);
             }
           }
           const body = await (response?.ok ? response.json() : Promise.reject(error));

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -1,17 +1,17 @@
-import { DestinyInventoryItemDefinition, DestinyManifest } from 'bungie-api-ts/destiny2';
-import { del, get, set } from 'idb-keyval';
-import { emptyArray, emptyObject } from 'app/utils/empty';
-import { loadingEnd, loadingStart } from 'app/shell/actions';
-
 import _ from 'lodash';
-import { getManifest as d2GetManifest } from '../bungie-api/destiny2-api';
-import { deepEqual } from 'fast-equals';
+import { get, set, del } from 'idb-keyval';
+
 import { reportException } from '../utils/exceptions';
+import { getManifest as d2GetManifest } from '../bungie-api/destiny2-api';
 import { settingsReady } from '../settings/settings';
-import { settingsSelector } from 'app/settings/reducer';
-import { showNotification } from '../notifications/notifications';
-import store from 'app/store/store';
 import { t } from 'app/i18next-t';
+import { DestinyManifest, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import { deepEqual } from 'fast-equals';
+import { showNotification } from '../notifications/notifications';
+import { settingsSelector } from 'app/settings/reducer';
+import store from 'app/store/store';
+import { emptyObject, emptyArray } from 'app/utils/empty';
+import { loadingStart, loadingEnd } from 'app/shell/actions';
 
 // This file exports D2ManifestService at the bottom of the
 // file (TS wants us to declare classes before using them)!

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -212,15 +212,15 @@ class ManifestService {
         .map((t) => `Destiny${t}Definition`)
         .map(async (table) => {
           let response: Response | null = null;
-          const error: any[] = [];
+          let error: any = null;
 
           for (const query of cacheBusterStrings) {
             try {
               response = await fetch(`https://www.bungie.net${components[table]}${query}`);
               if (response.ok) break;
-              error.push(response);
+              error = error ?? response;
             } catch (e) {
-              error.push(e);
+              error = error ?? e;
             }
           }
           const body = await (response?.ok ? response.json() : Promise.reject(error));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31990469/83716064-af929580-a5e3-11ea-8cba-dafb9aa06b42.png)

tries canonical component URL which should likely be already cached, best performance, eat our community's dogfood or w/e, yadda yadda.
then falls back to appending "?dim" then "?dim-[random numbers]", in case cloudflare has inappropriately cached another domain's CORS headers or a 404 that's no longer a 404.

puts non-`.ok` responses (i.e. 404) or thrown Errors (cors?) into `error:any[]`, then rejects overall with `error` if 3 attempts don't get us the manifest.

this should be near impossible for CORS problems to get past, so i'd expect if we get any rejections, it'll be 404s.
rejecting with an array of `response`s *does* helpfully show console info about all 3 404s:
![image](https://user-images.githubusercontent.com/31990469/83716479-e0bf9580-a5e4-11ea-85eb-cd2f87ea7459.png)

open to thoughts about narrowing or simplifying the format of the error throw, it's not pretty looking, i am just going for thorough here.