### PR TITLE
fix misdetection of seasonal mods in compare

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -21,7 +21,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { makeDupeID } from 'app/search/search-filters';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
-import { getItemSpecialtyModSlotDisplayName } from 'app/utils/item-utils';
+import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
 // import intrinsicLookupTable from 'data/d2/intrinsic-perk-lookup.json';
 // we are falling back to using just an exactly matching intrinsic perk for now
 // archetypes are difficult.
@@ -355,13 +355,16 @@ class Compare extends React.Component<Props, State> {
   ) => {
     const exampleItem = comparisonItems[0];
     const exampleItemElementIcon = <ElementIcon element={exampleItem.element} />;
-    const exampleItemModSlot = getItemSpecialtyModSlotDisplayName(exampleItem);
+    const exampleItemModSlot = getSpecialtySocketMetadata(exampleItem);
+    const specialtyModSlotName = this.props.defs?.InventoryItem.get(
+      exampleItemModSlot?.emptyModSocketHashes[0] ?? -99999999
+    )?.itemTypeDisplayName;
 
     // helper functions for filtering items
     const matchesExample = (key: keyof DimItem) => (item: DimItem) =>
       item[key] === exampleItem[key];
     const matchingModSlot = (item: DimItem) =>
-      exampleItemModSlot === getItemSpecialtyModSlotDisplayName(item);
+      exampleItemModSlot?.tag === getSpecialtySocketMetadata(item)?.tag;
     const hasEnergy = (item: DimItem) => Boolean(item.isDestiny2() && item.energy);
 
     // minimum filter: make sure it's all armor, and can go in the same slot on the same class
@@ -385,7 +388,7 @@ class Compare extends React.Component<Props, State> {
 
       // above but also the same seasonal mod slot, if it has one
       {
-        buttonLabel: <>{[exampleItemModSlot].join(' + ')}</>,
+        buttonLabel: <>{[specialtyModSlotName].join(' + ')}</>,
         items:
           hasEnergy(exampleItem) && exampleItemModSlot
             ? allArmors.filter(hasEnergy).filter(matchingModSlot)
@@ -401,7 +404,7 @@ class Compare extends React.Component<Props, State> {
       },
       // above but also the same seasonal mod slot, if it has one
       {
-        buttonLabel: <>{[exampleItemElementIcon, exampleItemModSlot]}</>,
+        buttonLabel: <>{[exampleItemElementIcon, specialtyModSlotName]}</>,
         items:
           hasEnergy(exampleItem) && exampleItemModSlot
             ? allArmors.filter(hasEnergy).filter(matchingModSlot).filter(matchesExample('element'))


### PR DESCRIPTION
this uses the new metadata getter for deciding what seasonal slot an armor has,
instead of string detection from its currently slotted  mod.
fixes #5154 

need to dump or rewrite getItemSpecialtyModSlotDisplayName but one thing at a time.