### PR TITLE
Moved LoadoutBuilder to a functional component

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -1,7 +1,7 @@
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
-import React from 'react';
+import React, { useEffect, useMemo, useReducer } from 'react';
 import { connect } from 'react-redux';
 import { DestinyAccount } from '../accounts/destiny-account';
 import CharacterSelect from '../dim-ui/CharacterSelect';
@@ -47,6 +47,7 @@ import { getCurrentStore, getItemAcrossStores } from 'app/inventory/stores-helpe
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { RouteComponentProps, withRouter, StaticContext } from 'react-router';
 import { Loadout } from 'app/loadout/loadout-types';
+import { Location } from 'history';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -78,6 +79,120 @@ interface State {
   query: string;
   statOrder: StatTypes[];
   assumeMasterwork: boolean;
+}
+
+const init = ({
+  stores,
+  location,
+}: {
+  stores: DimStore[];
+  location: Location<{
+    loadout?: Loadout | undefined;
+  }>;
+}): State => {
+  let lockedMap: LockedMap = {};
+
+  if (stores.length && location.state?.loadout) {
+    for (const loadoutItem of location.state.loadout.items) {
+      if (loadoutItem.equipped) {
+        const item = getItemAcrossStores(stores, loadoutItem);
+        if (item && isLoadoutBuilderItem(item)) {
+          lockedMap = {
+            ...lockedMap,
+            [item.bucket.hash]: addLockedItem(
+              { type: 'item', item, bucket: item.bucket },
+              lockedMap[item.bucket.hash]
+            ),
+          };
+        }
+      }
+    }
+  }
+  return {
+    lockedMap,
+    statFilters: {
+      Mobility: { min: 0, max: 10, ignored: false },
+      Resilience: { min: 0, max: 10, ignored: false },
+      Recovery: { min: 0, max: 10, ignored: false },
+      Discipline: { min: 0, max: 10, ignored: false },
+      Intellect: { min: 0, max: 10, ignored: false },
+      Strength: { min: 0, max: 10, ignored: false },
+    },
+    lockedSeasonalMods: [],
+    lockedArmor2Mods: {
+      [ModPickerCategories.general]: [],
+      [ModPickerCategories.helmet]: [],
+      [ModPickerCategories.gauntlets]: [],
+      [ModPickerCategories.chest]: [],
+      [ModPickerCategories.leg]: [],
+      [ModPickerCategories.classitem]: [],
+      [ModPickerCategories.seasonal]: [],
+    },
+    minimumPower: 750,
+    query: '',
+    statOrder: statKeys,
+    selectedStoreId: getCurrentStore(stores)?.id,
+    assumeMasterwork: false,
+  };
+};
+
+export type LoadoutBuilderAction =
+  | { type: 'changeCharacter'; storeId: string }
+  | { type: 'statFiltersChanged'; statFilters: State['statFilters'] }
+  | { type: 'minimumPowerChanged'; minimumPower: number }
+  | { type: 'queryChanged'; query: string }
+  | { type: 'statOrderChanged'; statOrder: StatTypes[] }
+  | { type: 'lockedMapChanged'; lockedMap: LockedMap }
+  | { type: 'lockedSeasonalModsChanged'; lockedSeasonalMods: LockedModBase[] }
+  | {
+      type: 'lockedMapAndSeasonalModsChanged';
+      lockedMap: LockedMap;
+      lockedSeasonalMods: LockedModBase[];
+    }
+  | { type: 'lockedArmor2ModsChanged'; lockedArmor2Mods: LockedArmor2ModMap }
+  | { type: 'assumeMasterworkChanged'; assumeMasterwork: boolean };
+
+// TODO: Move more logic inside the reducer
+function stateReducer(state: State, action: LoadoutBuilderAction): State {
+  switch (action.type) {
+    case 'changeCharacter':
+      return {
+        ...state,
+        selectedStoreId: action.storeId,
+        lockedMap: {},
+        statFilters: {
+          Mobility: { min: 0, max: 10, ignored: false },
+          Resilience: { min: 0, max: 10, ignored: false },
+          Recovery: { min: 0, max: 10, ignored: false },
+          Discipline: { min: 0, max: 10, ignored: false },
+          Intellect: { min: 0, max: 10, ignored: false },
+          Strength: { min: 0, max: 10, ignored: false },
+        },
+        minimumPower: 0,
+      };
+    case 'statFiltersChanged':
+      return { ...state, statFilters: action.statFilters };
+    case 'minimumPowerChanged':
+      return { ...state, minimumPower: action.minimumPower };
+    case 'queryChanged':
+      return { ...state, query: action.query };
+    case 'statOrderChanged':
+      return { ...state, statOrder: action.statOrder };
+    case 'lockedMapChanged':
+      return { ...state, lockedMap: action.lockedMap };
+    case 'lockedSeasonalModsChanged':
+      return { ...state, lockedSeasonalMods: action.lockedSeasonalMods };
+    case 'lockedMapAndSeasonalModsChanged':
+      return {
+        ...state,
+        lockedMap: action.lockedMap,
+        lockedSeasonalMods: action.lockedSeasonalMods,
+      };
+    case 'lockedArmor2ModsChanged':
+      return { ...state, lockedArmor2Mods: action.lockedArmor2Mods };
+    case 'assumeMasterworkChanged':
+      return { ...state, assumeMasterwork: action.assumeMasterwork };
+  }
 }
 
 function mapStateToProps() {
@@ -128,98 +243,32 @@ function mapStateToProps() {
 /**
  * The Loadout Optimizer screen
  */
-class LoadoutBuilder extends React.Component<Props, State> {
-  private subscriptions = new Subscriptions();
-  private filterItemsMemoized = memoizeOne(filterItems);
-  private filterSetsMemoized = memoizeOne(filterGeneratedSets);
-  private processMemoized = memoizeOne(process);
-  private getEnabledStats = memoizeOne(
-    (statFilters: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>) =>
-      new Set(statKeys.filter((statType) => !statFilters[statType].ignored))
+function LoadoutBuilder({
+  account,
+  storesLoaded,
+  stores,
+  isPhonePortrait,
+  items,
+  defs,
+  searchConfig,
+  filters,
+  location,
+}: Props) {
+  // Using useMemo tp ensure these functions are only created once
+  const filterItemsMemoized = useMemo(() => memoizeOne(filterItems), []);
+  const filterSetsMemoized = useMemo(() => memoizeOne(filterGeneratedSets), []);
+  const processMemoized = useMemo(() => memoizeOne(process), []);
+  const getEnabledStats = useMemo(
+    () =>
+      memoizeOne(
+        (statFilters: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>) =>
+          new Set(statKeys.filter((statType) => !statFilters[statType].ignored))
+      ),
+    []
   );
 
-  constructor(props: Props) {
-    super(props);
-
-    let lockedMap: LockedMap = {};
-    const { stores, location } = this.props;
-    if (stores.length && location.state?.loadout) {
-      for (const loadoutItem of location.state.loadout.items) {
-        if (loadoutItem.equipped) {
-          const item = getItemAcrossStores(stores, loadoutItem);
-          if (item && isLoadoutBuilderItem(item)) {
-            lockedMap = {
-              ...lockedMap,
-              [item.bucket.hash]: addLockedItem(
-                { type: 'item', item, bucket: item.bucket },
-                lockedMap[item.bucket.hash]
-              ),
-            };
-          }
-        }
-      }
-    }
-
-    this.state = {
-      lockedMap,
-      statFilters: {
-        Mobility: { min: 0, max: 10, ignored: false },
-        Resilience: { min: 0, max: 10, ignored: false },
-        Recovery: { min: 0, max: 10, ignored: false },
-        Discipline: { min: 0, max: 10, ignored: false },
-        Intellect: { min: 0, max: 10, ignored: false },
-        Strength: { min: 0, max: 10, ignored: false },
-      },
-      lockedSeasonalMods: [],
-      lockedArmor2Mods: {
-        [ModPickerCategories.general]: [],
-        [ModPickerCategories.helmet]: [],
-        [ModPickerCategories.gauntlets]: [],
-        [ModPickerCategories.chest]: [],
-        [ModPickerCategories.leg]: [],
-        [ModPickerCategories.classitem]: [],
-        [ModPickerCategories.seasonal]: [],
-      },
-      minimumPower: 750,
-      query: '',
-      statOrder: statKeys,
-      selectedStoreId: getCurrentStore(props.stores)?.id,
-      assumeMasterwork: false,
-    };
-  }
-
-  componentDidMount() {
-    this.subscriptions.add(
-      D2StoresService.getStoresStream(this.props.account).subscribe((stores) => {
-        if (!stores || !stores.length) {
-          return;
-        }
-
-        if (!this.state.selectedStoreId) {
-          this.onCharacterChanged(getCurrentStore(stores)!.id);
-        }
-      }),
-
-      // Disable refreshing stores, since it resets the scroll offset
-      refresh$.subscribe(() => queueAction(() => D2StoresService.reloadStores()))
-    );
-  }
-
-  componentWillUnmount() {
-    this.subscriptions.unsubscribe();
-  }
-
-  render() {
-    const {
-      storesLoaded,
-      stores,
-      isPhonePortrait,
-      items,
-      defs,
-      searchConfig,
-      filters,
-    } = this.props;
-    const {
+  const [
+    {
       lockedMap,
       lockedSeasonalMods,
       lockedArmor2Mods,
@@ -229,177 +278,169 @@ class LoadoutBuilder extends React.Component<Props, State> {
       query,
       statOrder,
       assumeMasterwork,
-    } = this.state;
+    },
+    stateDispatch,
+  ] = useReducer(stateReducer, { stores, location }, init);
 
-    if (!storesLoaded || !defs || !selectedStoreId) {
-      return <ShowPageLoading message={t('Loading.Profile')} />;
-    }
+  useEffect(() => {
+    const subscriptions = new Subscriptions();
+    subscriptions.add(
+      D2StoresService.getStoresStream(account).subscribe((stores) => {
+        if (!stores || !stores.length) {
+          return;
+        }
 
-    const store = stores.find((s) => s.id === selectedStoreId)!;
+        if (!selectedStoreId) {
+          stateDispatch({ type: 'changeCharacter', storeId: getCurrentStore(stores)!.id });
+        }
+      }),
 
-    if (!items[store.classType]) {
-      return <ShowPageLoading message={t('Loading.Profile')} />;
-    }
-
-    const filter = filters.filterFunction(query);
-
-    let filteredItems: ItemsByBucket = {};
-    let processedSets: readonly ArmorSet[] = [];
-    let filteredSets: readonly ArmorSet[] = [];
-    let combos = 0;
-    let combosWithoutCaps = 0;
-    let processError;
-    const enabledStats = this.getEnabledStats(statFilters);
-    try {
-      filteredItems = this.filterItemsMemoized(
-        items[store.classType],
-        lockedMap,
-        lockedArmor2Mods,
-        filter
-      );
-      const result = this.processMemoized(
-        filteredItems,
-        lockedMap,
-        lockedArmor2Mods,
-        store.id,
-        assumeMasterwork
-      );
-      processedSets = result.sets;
-      combos = result.combos;
-      combosWithoutCaps = result.combosWithoutCaps;
-      filteredSets = this.filterSetsMemoized(
-        processedSets,
-        minimumPower,
-        lockedMap,
-        lockedArmor2Mods,
-        lockedSeasonalMods,
-        statFilters,
-        statOrder,
-        enabledStats
-      );
-    } catch (e) {
-      console.error(e);
-      processError = e;
-    }
-
-    const menuContent = (
-      <div className={styles.menuContent}>
-        <SearchFilterInput
-          searchConfig={searchConfig}
-          placeholder={t('LoadoutBuilder.SearchPlaceholder')}
-          onQueryChanged={this.onQueryChanged}
-        />
-
-        <FilterBuilds
-          sets={processedSets}
-          selectedStore={store as D2Store}
-          minimumPower={minimumPower}
-          stats={statFilters}
-          onMinimumPowerChanged={this.onMinimumPowerChanged}
-          onStatFiltersChanged={this.onStatFiltersChanged}
-          defs={defs}
-          order={statOrder}
-          onStatOrderChanged={this.onStatOrderChanged}
-          assumeMasterwork={assumeMasterwork}
-          onMasterworkAssumptionChange={this.onMasterworkAssumptionChange}
-        />
-
-        <LockArmorAndPerks
-          items={filteredItems}
-          selectedStore={store}
-          lockedMap={lockedMap}
-          lockedSeasonalMods={lockedSeasonalMods}
-          lockedArmor2Mods={lockedArmor2Mods}
-          onLockedMapChanged={this.onLockedMapChanged}
-          onSeasonalModsChanged={this.onSeasonalModsChanged}
-          onArmor2ModsChanged={this.onArmor2ModsChanged}
-        />
-      </div>
+      // Disable refreshing stores, since it resets the scroll offset
+      refresh$.subscribe(() => queueAction(() => D2StoresService.reloadStores()))
     );
 
-    return (
-      <PageWithMenu className={styles.page}>
-        <PageWithMenu.Menu className={styles.menu}>
-          <CharacterSelect
-            selectedStore={store}
-            stores={stores}
-            vertical={!isPhonePortrait}
-            isPhonePortrait={isPhonePortrait}
-            onCharacterChanged={this.onCharacterChanged}
-          />
-          {isPhonePortrait ? (
-            <CollapsibleTitle sectionId="lb-filter" title={t('LoadoutBuilder.Filter')}>
-              {menuContent}
-            </CollapsibleTitle>
-          ) : (
-            menuContent
-          )}
-        </PageWithMenu.Menu>
+    return () => {
+      subscriptions.unsubscribe();
+    };
+  }, [account, selectedStoreId]);
 
-        <PageWithMenu.Contents>
-          {processError ? (
-            <ErrorPanel error={processError} />
-          ) : (
-            <GeneratedSets
-              sets={filteredSets}
-              combos={combos}
-              combosWithoutCaps={combosWithoutCaps}
-              isPhonePortrait={isPhonePortrait}
-              lockedMap={lockedMap}
-              selectedStore={store}
-              onLockedMapChanged={this.onLockedMapChanged}
-              defs={defs}
-              statOrder={statOrder}
-              enabledStats={enabledStats}
-              lockedArmor2Mods={lockedArmor2Mods}
-            />
-          )}
-        </PageWithMenu.Contents>
-
-        <LoadoutDrawer />
-      </PageWithMenu>
-    );
+  if (!storesLoaded || !defs || !selectedStoreId) {
+    return <ShowPageLoading message={t('Loading.Profile')} />;
   }
 
-  /**
-   * Handle when selected character changes
-   * Recomputes matched sets
-   */
-  private onCharacterChanged = (storeId: string) => {
-    this.setState({
-      selectedStoreId: storeId,
-      lockedMap: {},
-      statFilters: {
-        Mobility: { min: 0, max: 10, ignored: false },
-        Resilience: { min: 0, max: 10, ignored: false },
-        Recovery: { min: 0, max: 10, ignored: false },
-        Discipline: { min: 0, max: 10, ignored: false },
-        Intellect: { min: 0, max: 10, ignored: false },
-        Strength: { min: 0, max: 10, ignored: false },
-      },
-      minimumPower: 0,
-    });
-  };
+  const store = stores.find((s) => s.id === selectedStoreId)!;
 
-  private onStatFiltersChanged = (statFilters: State['statFilters']) =>
-    this.setState({ statFilters });
+  if (!items[store.classType]) {
+    return <ShowPageLoading message={t('Loading.Profile')} />;
+  }
 
-  private onMinimumPowerChanged = (minimumPower: number) => this.setState({ minimumPower });
+  const filter = filters.filterFunction(query);
 
-  private onQueryChanged = (query: string) => this.setState({ query });
+  let filteredItems: ItemsByBucket = {};
+  let processedSets: readonly ArmorSet[] = [];
+  let filteredSets: readonly ArmorSet[] = [];
+  let combos = 0;
+  let combosWithoutCaps = 0;
+  let processError;
+  const enabledStats = getEnabledStats(statFilters);
+  try {
+    filteredItems = filterItemsMemoized(
+      items[store.classType],
+      lockedMap,
+      lockedArmor2Mods,
+      filter
+    );
 
-  private onStatOrderChanged = (statOrder: StatTypes[]) => this.setState({ statOrder });
+    const result = processMemoized(
+      filteredItems,
+      lockedMap,
+      lockedArmor2Mods,
+      store.id,
+      assumeMasterwork
+    );
+    processedSets = result.sets;
+    combos = result.combos;
+    combosWithoutCaps = result.combosWithoutCaps;
+    filteredSets = filterSetsMemoized(
+      processedSets,
+      minimumPower,
+      lockedMap,
+      lockedArmor2Mods,
+      lockedSeasonalMods,
+      statFilters,
+      statOrder,
+      enabledStats
+    );
+  } catch (e) {
+    console.error(e);
+    processError = e;
+  }
 
-  private onLockedMapChanged = (lockedMap: State['lockedMap']) => this.setState({ lockedMap });
+  const menuContent = (
+    <div className={styles.menuContent}>
+      <SearchFilterInput
+        searchConfig={searchConfig}
+        placeholder={t('LoadoutBuilder.SearchPlaceholder')}
+        onQueryChanged={(query: string) => stateDispatch({ type: 'queryChanged', query })}
+      />
 
-  private onSeasonalModsChanged = (lockedSeasonalMods: LockedModBase[]) =>
-    this.setState({ lockedSeasonalMods });
+      <FilterBuilds
+        sets={processedSets}
+        selectedStore={store as D2Store}
+        minimumPower={minimumPower}
+        stats={statFilters}
+        onMinimumPowerChanged={(minimumPower: number) =>
+          stateDispatch({ type: 'minimumPowerChanged', minimumPower })
+        }
+        onStatFiltersChanged={(statFilters: State['statFilters']) =>
+          stateDispatch({ type: 'statFiltersChanged', statFilters })
+        }
+        defs={defs}
+        order={statOrder}
+        onStatOrderChanged={(statOrder: StatTypes[]) =>
+          stateDispatch({ type: 'statOrderChanged', statOrder })
+        }
+        assumeMasterwork={assumeMasterwork}
+        onMasterworkAssumptionChange={(assumeMasterwork: boolean) =>
+          stateDispatch({ type: 'assumeMasterworkChanged', assumeMasterwork })
+        }
+      />
 
-  private onArmor2ModsChanged = (lockedArmor2Mods: LockedArmor2ModMap) =>
-    this.setState({ lockedArmor2Mods });
+      <LockArmorAndPerks
+        items={filteredItems}
+        selectedStore={store}
+        lockedMap={lockedMap}
+        lockedSeasonalMods={lockedSeasonalMods}
+        lockedArmor2Mods={lockedArmor2Mods}
+        lbDispatch={stateDispatch}
+      />
+    </div>
+  );
 
-  private onMasterworkAssumptionChange = (assumeMasterwork: boolean) =>
-    this.setState({ assumeMasterwork });
+  return (
+    <PageWithMenu className={styles.page}>
+      <PageWithMenu.Menu className={styles.menu}>
+        <CharacterSelect
+          selectedStore={store}
+          stores={stores}
+          vertical={!isPhonePortrait}
+          isPhonePortrait={isPhonePortrait}
+          onCharacterChanged={(storeId: string) =>
+            stateDispatch({ type: 'changeCharacter', storeId })
+          }
+        />
+        {isPhonePortrait ? (
+          <CollapsibleTitle sectionId="lb-filter" title={t('LoadoutBuilder.Filter')}>
+            {menuContent}
+          </CollapsibleTitle>
+        ) : (
+          menuContent
+        )}
+      </PageWithMenu.Menu>
+
+      <PageWithMenu.Contents>
+        {processError ? (
+          <ErrorPanel error={processError} />
+        ) : (
+          <GeneratedSets
+            sets={filteredSets}
+            combos={combos}
+            combosWithoutCaps={combosWithoutCaps}
+            isPhonePortrait={isPhonePortrait}
+            lockedMap={lockedMap}
+            selectedStore={store}
+            lbDispatch={stateDispatch}
+            defs={defs}
+            statOrder={statOrder}
+            enabledStats={enabledStats}
+            lockedArmor2Mods={lockedArmor2Mods}
+          />
+        )}
+      </PageWithMenu.Contents>
+
+      <LoadoutDrawer />
+    </PageWithMenu>
+  );
 }
 
 export default withRouter(connect<StoreProps>(mapStateToProps)(LoadoutBuilder));

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -254,16 +254,17 @@ function LoadoutBuilder({
   filters,
   location,
 }: Props) {
-  // Using useMemo tp ensure these functions are only created once
-  const filterItemsMemoized = useMemo(() => memoizeOne(filterItems), []);
-  const filterSetsMemoized = useMemo(() => memoizeOne(filterGeneratedSets), []);
-  const processMemoized = useMemo(() => memoizeOne(process), []);
-  const getEnabledStats = useMemo(
-    () =>
+  // Memoizing to ensure these functions are only created once
+  const [filterItemsMemoized, filterSetsMemoized, processMemoized, getEnabledStats] = useMemo(
+    () => [
+      memoizeOne(filterItems),
+      memoizeOne(filterGeneratedSets),
+      memoizeOne(process),
       memoizeOne(
         (statFilters: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>) =>
           new Set(statKeys.filter((statType) => !statFilters[statType].ignored))
       ),
+    ],
     []
   );
 

--- a/src/app/loadout-builder/ModPicker.tsx
+++ b/src/app/loadout-builder/ModPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import Sheet from '../dim-ui/Sheet';
 import '../item-picker/ItemPicker.scss';
 import { DestinyInventoryItemDefinition, DestinyClass } from 'bungie-api-ts/destiny2';
@@ -28,6 +28,7 @@ import ModPickerFooter from './ModPickerFooter';
 import { itemsForPlugSet } from 'app/collections/plugset-helpers';
 import { t } from 'app/i18next-t';
 import { SearchFilterRef } from 'app/search/SearchFilterInput';
+import { LoadoutBuilderAction } from './LoadoutBuilder';
 
 const Armor2ModPlugCategoriesTitles = {
   [ModPickerCategories.general]: t('LB.General'),
@@ -52,7 +53,7 @@ export const sortMods = chainComparator<DestinyInventoryItemDefinition>(
 interface ProvidedProps {
   lockedArmor2Mods: LockedArmor2ModMap;
   classType: DestinyClass;
-  onArmor2ModsChanged(mods: LockedArmor2ModMap): void;
+  lbDispatch: Dispatch<LoadoutBuilderAction>;
   onClose(): void;
 }
 
@@ -287,7 +288,10 @@ class ModPicker extends React.Component<Props, State> {
 
   private onSubmit = (e: React.FormEvent | KeyboardEvent, onClose: () => void) => {
     e.preventDefault();
-    this.props.onArmor2ModsChanged(this.state.lockedArmor2Mods);
+    this.props.lbDispatch({
+      type: 'lockedArmor2ModsChanged',
+      lockedArmor2Mods: this.state.lockedArmor2Mods,
+    });
     onClose();
   };
 

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import Sheet from '../dim-ui/Sheet';
 import '../item-picker/ItemPicker.scss';
 import { DestinyInventoryItemDefinition, DestinyClass, TierType } from 'bungie-api-ts/destiny2';
@@ -40,6 +40,7 @@ import { specialtyModSocketHashes } from 'app/utils/item-utils';
 import SeasonalModPicker from './SeasonalModPicker';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { SearchFilterRef } from 'app/search/SearchFilterInput';
+import { LoadoutBuilderAction } from './LoadoutBuilder';
 
 // to-do: separate mod name from its "enhanced"ness, maybe with d2ai? so they can be grouped better
 export const sortMods = chainComparator<DestinyInventoryItemDefinition>(
@@ -77,8 +78,7 @@ interface ProvidedProps {
   lockedMap: LockedMap;
   lockedSeasonalMods: LockedModBase[];
   classType: DestinyClass;
-  onPerksSelected(perks: LockedMap): void;
-  onSeasonalModsChanged(mods: LockedModBase[]): void;
+  lbDispatch: Dispatch<LoadoutBuilderAction>;
   onClose(): void;
 }
 
@@ -478,8 +478,11 @@ class PerkPicker extends React.Component<Props, State> {
 
   private onSubmit = (e: React.FormEvent | KeyboardEvent, onClose: () => void) => {
     e.preventDefault();
-    this.props.onPerksSelected(this.state.selectedPerks);
-    this.props.onSeasonalModsChanged(this.state.selectedSeasonalMods);
+    this.props.lbDispatch({
+      type: 'lockedMapAndSeasonalModsChanged',
+      lockedMap: this.state.selectedPerks,
+      lockedSeasonalMods: this.state.selectedSeasonalMods,
+    });
     onClose();
   };
 

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import { DimStore } from '../../inventory/store-types';
-import { ArmorSet, LockedItemType, StatTypes, LockedMap, LockedArmor2ModMap } from '../types';
+import { ArmorSet, StatTypes, LockedMap, LockedArmor2ModMap } from '../types';
 import GeneratedSetButtons from './GeneratedSetButtons';
 import GeneratedSetItem from './GeneratedSetItem';
 import { powerIndicatorIcon, AppIcon } from '../../shell/icons';
@@ -16,6 +16,7 @@ import { editLoadout } from 'app/loadout/LoadoutDrawer';
 import { Loadout } from 'app/loadout/loadout-types';
 import { assignModsToArmorSet } from './mod-utils';
 import { Armor2ModPlugCategories } from 'app/utils/item-utils';
+import { LoadoutBuilderAction } from '../LoadoutBuilder';
 
 interface Props {
   set: ArmorSet;
@@ -27,8 +28,7 @@ interface Props {
   forwardedRef?: React.Ref<HTMLDivElement>;
   enabledStats: Set<StatTypes>;
   lockedArmor2Mods: LockedArmor2ModMap;
-  addLockedItem(lockedItem: LockedItemType): void;
-  removeLockedItem(lockedItem: LockedItemType): void;
+  lbDispatch: Dispatch<LoadoutBuilderAction>;
 }
 
 /**
@@ -45,8 +45,7 @@ function GeneratedSet({
   enabledStats,
   forwardedRef,
   lockedArmor2Mods,
-  addLockedItem,
-  removeLockedItem,
+  lbDispatch,
 }: Props) {
   // Set the loadout property to show/hide the loadout menu
   const setCreateLoadout = (loadout: Loadout) => {
@@ -143,8 +142,7 @@ function GeneratedSet({
             defs={defs}
             itemOptions={set.sets.flatMap((subSet) => subSet.armor[index])}
             locked={lockedMap[item.bucket.hash]}
-            addLockedItem={addLockedItem}
-            removeLockedItem={removeLockedItem}
+            lbDispatch={lbDispatch}
             statValues={set.firstValidSetStatChoices[index]}
             lockedMods={assignedMods[item.hash]}
           />

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, Dispatch } from 'react';
 import { DimPlug, DimItem } from '../../inventory/item-types';
 import LoadoutBuilderItem from '../LoadoutBuilderItem';
 import { LockedItemType, LockedArmor2Mod } from '../types';
@@ -15,6 +15,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import './GeneratedSetItemLockedMods.scss';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
+import { LoadoutBuilderAction } from '../LoadoutBuilder';
 
 /**
  * Figure out which (if any) non-selected perks should be selected to get the chosen stat mix.
@@ -41,8 +42,7 @@ export default function GeneratedSetItem({
   statValues,
   itemOptions,
   lockedMods,
-  addLockedItem,
-  removeLockedItem,
+  lbDispatch,
 }: {
   item: DimItem;
   locked?: readonly LockedItemType[];
@@ -50,13 +50,16 @@ export default function GeneratedSetItem({
   statValues: number[];
   itemOptions: DimItem[];
   lockedMods?: LockedArmor2Mod[];
-  addLockedItem(lockedItem: LockedItemType): void;
-  removeLockedItem(lockedItem: LockedItemType): void;
+  lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
   const altPerks = useMemo(() => identifyAltPerkChoicesForChosenStats(item, statValues), [
     item,
     statValues,
   ]);
+
+  const addLockedItem = (item: LockedItemType) => lbDispatch({ type: 'addItemToLockedMap', item });
+  const removeLockedItem = (item: LockedItemType) =>
+    lbDispatch({ type: 'removeItemFromLockedMap', item });
 
   const classesByHash = altPerks.reduce(
     (memo, perk) => ({ ...memo, [perk.plugItem.hash]: styles.altPerk }),

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,14 +1,13 @@
 import { t } from 'app/i18next-t';
 import React, { Dispatch } from 'react';
 import { DimStore } from '../../inventory/store-types';
-import { ArmorSet, LockedItemType, StatTypes, LockedMap, LockedArmor2ModMap } from '../types';
+import { ArmorSet, StatTypes, LockedMap, LockedArmor2ModMap } from '../types';
 import { WindowScroller, List } from 'react-virtualized';
 import GeneratedSet from './GeneratedSet';
 import { newLoadout } from 'app/loadout/loadout-utils';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import styles from './GeneratedSets.m.scss';
 import _ from 'lodash';
-import { addLockedItem, removeLockedItem } from './utils';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { LoadoutBuilderAction } from '../LoadoutBuilder';
@@ -94,6 +93,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
       combosWithoutCaps,
       enabledStats,
       lockedArmor2Mods,
+      lbDispatch,
     } = this.props;
     const { rowHeight, rowWidth, rowColumns } = this.state;
 
@@ -139,8 +139,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
             set={measureSet}
             selectedStore={selectedStore}
             lockedMap={lockedMap}
-            addLockedItem={this.addLockedItemType}
-            removeLockedItem={this.removeLockedItemType}
+            lbDispatch={lbDispatch}
             defs={defs}
             statOrder={statOrder}
             enabledStats={enabledStats}
@@ -165,8 +164,7 @@ export default class GeneratedSets extends React.Component<Props, State> {
                     set={sets[index]}
                     selectedStore={selectedStore}
                     lockedMap={lockedMap}
-                    addLockedItem={this.addLockedItemType}
-                    removeLockedItem={this.removeLockedItemType}
+                    lbDispatch={lbDispatch}
                     defs={defs}
                     statOrder={statOrder}
                     enabledStats={enabledStats}
@@ -191,27 +189,5 @@ export default class GeneratedSets extends React.Component<Props, State> {
         0
       );
     }
-  };
-
-  private addLockedItemType = (item: LockedItemType) => {
-    const { lockedMap, lbDispatch } = this.props;
-    lbDispatch({
-      type: 'lockedMapChanged',
-      lockedMap: {
-        ...lockedMap,
-        [item.bucket.hash]: addLockedItem(item, lockedMap[item.bucket.hash]),
-      },
-    });
-  };
-
-  private removeLockedItemType = (item: LockedItemType) => {
-    const { lockedMap, lbDispatch } = this.props;
-    lbDispatch({
-      type: 'lockedMapChanged',
-      lockedMap: {
-        ...lockedMap,
-        [item.bucket.hash]: removeLockedItem(item, lockedMap[item.bucket.hash]),
-      },
-    });
   };
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,5 +1,5 @@
 import { t } from 'app/i18next-t';
-import React from 'react';
+import React, { Dispatch } from 'react';
 import { DimStore } from '../../inventory/store-types';
 import { ArmorSet, LockedItemType, StatTypes, LockedMap, LockedArmor2ModMap } from '../types';
 import { WindowScroller, List } from 'react-virtualized';
@@ -11,6 +11,7 @@ import _ from 'lodash';
 import { addLockedItem, removeLockedItem } from './utils';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
+import { LoadoutBuilderAction } from '../LoadoutBuilder';
 
 interface Props {
   selectedStore: DimStore;
@@ -23,7 +24,7 @@ interface Props {
   defs: D2ManifestDefinitions;
   enabledStats: Set<StatTypes>;
   lockedArmor2Mods: LockedArmor2ModMap;
-  onLockedMapChanged(lockedMap: Props['lockedMap']): void;
+  lbDispatch: Dispatch<LoadoutBuilderAction>;
 }
 
 interface State {
@@ -193,18 +194,24 @@ export default class GeneratedSets extends React.Component<Props, State> {
   };
 
   private addLockedItemType = (item: LockedItemType) => {
-    const { lockedMap, onLockedMapChanged } = this.props;
-    onLockedMapChanged({
-      ...lockedMap,
-      [item.bucket.hash]: addLockedItem(item, lockedMap[item.bucket.hash]),
+    const { lockedMap, lbDispatch } = this.props;
+    lbDispatch({
+      type: 'lockedMapChanged',
+      lockedMap: {
+        ...lockedMap,
+        [item.bucket.hash]: addLockedItem(item, lockedMap[item.bucket.hash]),
+      },
     });
   };
 
   private removeLockedItemType = (item: LockedItemType) => {
-    const { lockedMap, onLockedMapChanged } = this.props;
-    onLockedMapChanged({
-      ...lockedMap,
-      [item.bucket.hash]: removeLockedItem(item, lockedMap[item.bucket.hash]),
+    const { lockedMap, lbDispatch } = this.props;
+    lbDispatch({
+      type: 'lockedMapChanged',
+      lockedMap: {
+        ...lockedMap,
+        [item.bucket.hash]: removeLockedItem(item, lockedMap[item.bucket.hash]),
+      },
     });
   };
 }


### PR DESCRIPTION
I have been working on moving the LO's process function to a web worker. Part of that includes creating a hook for the process function to abstract all the worker creation and state changes away from the main components. 

To do that I need to move this over to a functional component and have used the useReducer hook to manage state. Currently the actions are quite simple but I plan to move the complex logic inside the reducer and have more 'event' based actions. I will do this following the web worker PR. I didn't do it here as I am trying to keep the PR's a bit smaller than usual.