### PR TITLE
make images longpress-proof

### DIFF
--- a/src/app/App.m.scss
+++ b/src/app/App.m.scss
@@ -11,3 +11,7 @@
   height: 100%;
   box-sizing: border-box;
 }
+
+.no-pointer-events {
+  pointer-events: none;
+}

--- a/src/app/App.m.scss
+++ b/src/app/App.m.scss
@@ -12,6 +12,6 @@
   box-sizing: border-box;
 }
 
-.no-pointer-events {
+:global(.no-pointer-events) {
   pointer-events: none;
 }

--- a/src/app/App.m.scss.d.ts
+++ b/src/app/App.m.scss.d.ts
@@ -3,7 +3,6 @@
 interface CssExports {
   'container': string;
   'filters': string;
-  'noPointerEvents': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/App.m.scss.d.ts
+++ b/src/app/App.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'container': string;
   'filters': string;
+  'noPointerEvents': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/destiny1/loadout-builder/loadout-builder.scss
+++ b/src/app/destiny1/loadout-builder/loadout-builder.scss
@@ -261,7 +261,6 @@
   }
 
   .vendor-icon-background {
-    pointer-events: none;
     background-color: rgba(100, 100, 100, 0.6);
     position: absolute;
     width: 20px;

--- a/src/app/dim-ui/BungieImage.test.tsx
+++ b/src/app/dim-ui/BungieImage.test.tsx
@@ -6,6 +6,7 @@ test('bungie image prefixes with ', () => {
   const { container } = render(<BungieImage src="/foo.jpg" />);
   expect(container.firstChild).toMatchInlineSnapshot(`
     <img
+      class="no-pointer-events"
       loading="lazy"
       src="https://www.bungie.net/foo.jpg"
     />

--- a/src/app/dim-ui/BungieImage.tsx
+++ b/src/app/dim-ui/BungieImage.tsx
@@ -5,16 +5,14 @@ import React from 'react';
  */
 export type BungieImagePath = string;
 
-interface BungieImageProps {
+export type BungieImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'onClick'> & {
   src: BungieImagePath;
-}
+};
 
 /**
  * An image tag that links its src to bungie.net. Other props pass through to the underlying image.
  */
-export default React.memo(function BungieImage(
-  props: BungieImageProps & React.ImgHTMLAttributes<HTMLImageElement>
-) {
+export default React.memo(function BungieImage(props: BungieImageProps) {
   const { src, ...otherProps } = props;
 
   return <img src={bungieNetPath(src)} loading="lazy" {...otherProps} />;

--- a/src/app/dim-ui/BungieImage.tsx
+++ b/src/app/dim-ui/BungieImage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-
+import clsx from 'clsx';
+clsx;
 /**
  * A relative path to a Bungie.net image asset.
  */
@@ -14,8 +15,14 @@ export type BungieImageProps = Omit<React.ImgHTMLAttributes<HTMLImageElement>, '
  */
 export default React.memo(function BungieImage(props: BungieImageProps) {
   const { src, ...otherProps } = props;
-
-  return <img src={bungieNetPath(src)} loading="lazy" {...otherProps} />;
+  return (
+    <img
+      src={bungieNetPath(src)}
+      loading="lazy"
+      {...otherProps}
+      className={clsx(otherProps.className, 'no-pointer-events')}
+    />
+  );
 });
 
 /**

--- a/src/app/dim-ui/BungieImage.tsx
+++ b/src/app/dim-ui/BungieImage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-clsx;
+
 /**
  * A relative path to a Bungie.net image asset.
  */

--- a/src/app/dim-ui/BungieImageAndAmmo.test.tsx
+++ b/src/app/dim-ui/BungieImageAndAmmo.test.tsx
@@ -11,6 +11,7 @@ it('should have an extra class name ', () => {
       class="test-class-name container"
     >
       <img
+        class="no-pointer-events"
         loading="lazy"
         src="https://www.bungie.net/foo.png"
       />
@@ -28,6 +29,7 @@ it('should not have an extra class name ', () => {
       class="container"
     >
       <img
+        class="no-pointer-events"
         loading="lazy"
         src="https://www.bungie.net/foo.png"
       />
@@ -45,6 +47,7 @@ it('should be a primary ammo image ', () => {
       class="container"
     >
       <img
+        class="no-pointer-events"
         loading="lazy"
         src="https://www.bungie.net/foo.png"
       />
@@ -62,6 +65,7 @@ it('should be a special ammo image ', () => {
       class="container"
     >
       <img
+        class="no-pointer-events"
         loading="lazy"
         src="https://www.bungie.net/foo.png"
       />
@@ -79,6 +83,7 @@ it('should be a heavy ammo image ', () => {
       class="container"
     >
       <img
+        class="no-pointer-events"
         loading="lazy"
         src="https://www.bungie.net/foo.png"
       />
@@ -96,6 +101,7 @@ it('should have no ammo image if hashes do not match ', () => {
       class="container"
     >
       <img
+        class="no-pointer-events"
         loading="lazy"
         src="https://www.bungie.net/foo.png"
       />

--- a/src/app/dim-ui/BungieImageAndAmmo.tsx
+++ b/src/app/dim-ui/BungieImageAndAmmo.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
 import styles from './BungieImageAndAmmo.m.scss';
-import BungieImage, { BungieImagePath } from './BungieImage';
+import BungieImage, { BungieImageProps } from './BungieImage';
 import clsx from 'clsx';
 
-interface BungieImageProps {
-  src: BungieImagePath;
+type BungieImageAndAmmoProps = BungieImageProps & {
   hash: number;
-}
+};
 
 /**
  * A display for perk images that knows about certain items that have
  * corresponding ammo types.
  */
-export default function BungieImageAndAmmo(
-  props: BungieImageProps & React.ImgHTMLAttributes<HTMLImageElement>
-) {
+export default function BungieImageAndAmmo(props: BungieImageAndAmmoProps) {
   const { hash, className, ...otherProps } = props;
 
   let ammoImage;

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -35,7 +35,6 @@
   height: var(--item-size);
   box-sizing: border-box;
   border: $item-border-width solid #ddd;
-  pointer-events: none;
 
   &:focus {
     outline: none;
@@ -150,7 +149,6 @@
 
 // Individual icons in the icon tray
 .icon {
-  pointer-events: none;
   display: block;
   position: static;
   width: calc(var(--item-size) / 5);

--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -512,13 +512,14 @@ function LockedItemIcon({
       );
     case 'perk':
       return (
-        <BungieImageAndAmmo
-          onClick={onClick}
-          className={styles.selectedPerk}
-          hash={lockedItem.perk.hash}
-          title={lockedItem.perk.displayProperties.name}
-          src={lockedItem.perk.displayProperties.icon}
-        />
+        <span onClick={onClick}>
+          <BungieImageAndAmmo
+            className={styles.selectedPerk}
+            hash={lockedItem.perk.hash}
+            title={lockedItem.perk.displayProperties.name}
+            src={lockedItem.perk.displayProperties.icon}
+          />
+        </span>
       );
     case 'burn':
       return (

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -155,7 +155,6 @@ $toolbarHeight: 41px - 16px + 8px;
     height: calc(var(--item-size) * 0.75);
     display: block;
     box-sizing: border-box;
-    pointer-events: none;
     border: 1px solid #ddd;
   }
 }

--- a/src/app/shell/icons/AppIcon.tsx
+++ b/src/app/shell/icons/AppIcon.tsx
@@ -21,7 +21,13 @@ export default React.memo(function AppIcon({
   if (typeof icon === 'string') {
     return (
       <span
-        className={clsx(icon, 'app-icon', className, spinning ? 'fa-spin' : false)}
+        className={clsx(
+          icon,
+          'app-icon',
+          'no-pointer-events',
+          className,
+          spinning ? 'fa-spin' : false
+        )}
         title={title}
       />
     );

--- a/src/app/vendors/VendorItem.m.scss
+++ b/src/app/vendors/VendorItem.m.scss
@@ -19,7 +19,6 @@
   position: absolute;
   top: $item-border-width + 2px;
   right: $item-border-width + 2px;
-  pointer-events: none;
 }
 
 .acquiredIcon {


### PR DESCRIPTION
this replaces a lot of adhoc `pointer-events:none;`
with a single global one affecting all BungieImage and AppIcon.

it omits onClick prop from BungieImage (AppIcon already doesn't have it) so that onClicks must be applied to a wrapper, and images serve a focused purpose of just displaying images rather than being interactive

this should prevent the need to individually find and prevent default mouseclick functions on images, like the "save as" prompt occasionally popping up on some mobile browsers