### PR TITLE
standardize search bar button dom

### DIFF
--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -183,10 +183,8 @@ export function SearchFilter(
           {t('Header.FilterMatchCount', { count: filteredItems.length })}
         </span>
         {isComparable && (
-          <span className="filter-help">
-            <a onClick={compareMatching}>
-              <AppIcon icon={faClone} title={t('Header.CompareMatching')} />
-            </a>
+          <span onClick={compareMatching} className="filter-help">
+            <AppIcon icon={faClone} title={t('Header.CompareMatching')} />
           </span>
         )}
         <span className="filter-help">
@@ -199,9 +197,9 @@ export function SearchFilter(
               ))}
             </select>
           ) : (
-            <a onClick={onTagClicked}>
+            <span onClick={onTagClicked}>
               <AppIcon icon={tagIcon} title={t('Header.BulkTag')} />
-            </a>
+            </span>
           )}
         </span>
       </>

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -183,8 +183,12 @@ export function SearchFilter(
           {t('Header.FilterMatchCount', { count: filteredItems.length })}
         </span>
         {isComparable && (
-          <span onClick={compareMatching} className="filter-help">
-            <AppIcon icon={faClone} title={t('Header.CompareMatching')} />
+          <span
+            onClick={compareMatching}
+            className="filter-help"
+            title={t('Header.CompareMatching')}
+          >
+            <AppIcon icon={faClone} />
           </span>
         )}
         <span className="filter-help">
@@ -197,8 +201,8 @@ export function SearchFilter(
               ))}
             </select>
           ) : (
-            <span onClick={onTagClicked}>
-              <AppIcon icon={tagIcon} title={t('Header.BulkTag')} />
+            <span onClick={onTagClicked} title={t('Header.BulkTag')}>
+              <AppIcon icon={tagIcon} />
             </span>
           )}
         </span>

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -277,10 +277,8 @@ export default React.forwardRef(function SearchFilterInput(
         children
       )}
       {(liveQuery.length > 0 || alwaysShowClearButton) && (
-        <span className="filter-help">
-          <a onClick={clearFilter} title={t('Header.Clear')}>
-            <AppIcon icon={disabledIcon} />
-          </a>
+        <span className="filter-help" onClick={clearFilter} title={t('Header.Clear')}>
+          <AppIcon icon={disabledIcon} />
         </span>
       )}
       {filterHelpOpen &&


### PR DESCRIPTION
this may take care of
#5322
but regardless, there was a mixture of `<span>`, `<span><a>`, and `<a>` representing search bar buttons. this changes them all to spans