### PR TITLE
Arrivals Mods Missing From LO

### DIFF
--- a/src/app/loadout-builder/PerkPicker.tsx
+++ b/src/app/loadout-builder/PerkPicker.tsx
@@ -204,7 +204,7 @@ function mapStateToProps() {
             (i) =>
               i.item.inventory.tierType !== TierType.Common &&
               (!i.item.itemCategoryHashes || !i.item.itemCategoryHashes.includes(56)) &&
-              i.item.collectibleHash
+              i.item.plug.insertionMaterialRequirementHash !== 0 // not the empty mod sockets
           )
           .sort((a, b) => sortMods(a.item, b.item));
       });


### PR DESCRIPTION
Changed the collectible hash requirement for displayed plugs to be a plug.insertionMaterialRequirementHash. This allows the arrival mods to show as they don't have a collectible hash, but filters out the empty mod socket plugs.

Fixes #5324 

For reference,
Empty mod - https://data.destinysets.com/i/InventoryItem:2620967748
Arrival Mod - https://data.destinysets.com/i/InventoryItem:2979815165