### PR TITLE
Remove 100% height

### DIFF
--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -51,7 +51,6 @@
   flex-direction: row;
   justify-content: flex-start;
   overscroll-behavior: contain;
-  -webkit-overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   contain: content;
 }

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -230,7 +230,9 @@ function useLockSheetContents(sheetContents: React.MutableRefObject<HTMLDivEleme
   useEffect(
     () => () => {
       if (sheetContents.current) {
-        document.body.classList.remove('body-scroll-lock');
+        setTimeout(() => {
+          document.body.classList.remove('body-scroll-lock');
+        }, 0);
         sheetContents.current.removeEventListener('touchstart', blockEvents);
         if (mobile) {
           enableBodyScroll(sheetContents.current);

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -21,6 +21,10 @@
   @include phone-portrait {
     min-width: auto;
   }
+
+  .body-scroll-lock & {
+    margin-top: var(--store-header-height);
+  }
 }
 
 .store-row {
@@ -182,13 +186,7 @@
     }
   }
 }
-.stores {
-  display: block; // 77px margin to make room for the fixed header
-  margin-top: 77px;
-  @supports (position: sticky) {
-    margin-top: 0;
-  }
-}
+
 .dim-button.bucket-button {
   align-self: center;
   margin-bottom: 8px;

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useLayoutEffect } from 'react';
 import { DimStore, DimVault } from './store-types';
 import { InventoryBuckets } from './inventory-buckets';
 import { t } from 'app/i18next-t';
@@ -45,6 +45,16 @@ function Stores(this: void, { stores, buckets, isPhonePortrait }: Props) {
 
   const [selectedStoreId, setSelectedStoreId] = useState(currentStore?.id);
   const detachedLoadoutMenu = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    /* Set a CSS variable so we can style things based on the height of the header */
+    const element = document.querySelector('.store-header');
+    if (element) {
+      document
+        .querySelector('html')!
+        .style.setProperty('--store-header-height', element.clientHeight + 'px');
+    }
+  });
 
   if (!stores.length || !buckets) {
     return null;

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -120,9 +120,9 @@
     top: calc(#{54px + $header-height} + constant(safe-area-inset-top));
     top: calc(#{54px + $header-height} + env(safe-area-inset-top));
     z-index: 1000;
-    max-height: calc(100vh - #{177px + $header-height});
-    max-height: calc(100vh - #{177px + $header-height} - constant(safe-area-inset-top));
-    max-height: calc(100vh - #{177px + $header-height} - env(safe-area-inset-top));
+    max-height: calc(100vh - #{120px + $header-height});
+    max-height: calc(100vh - #{120px + $header-height} - constant(safe-area-inset-top));
+    max-height: calc(100vh - #{120px + $header-height} - env(safe-area-inset-top));
     left: calc((100% - 230px) / 2);
   }
 }

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -73,11 +73,6 @@
   }
 }
 
-html,
-body {
-  height: 100%;
-}
-
 // Suppress outline on focusable divs
 div[tabindex='-1']:focus {
   outline: 0;

--- a/src/app/organizer/DropDown.m.scss
+++ b/src/app/organizer/DropDown.m.scss
@@ -17,9 +17,9 @@
   position: absolute;
   z-index: 5;
   left: 0;
-  max-height: calc(100vh - #{77px + $header-height});
-  max-height: calc(100vh - #{77px + $header-height} - constant(safe-area-inset-top));
-  max-height: calc(100vh - #{77px + $header-height} - env(safe-area-inset-top));
+  max-height: calc(100vh - #{120px + $header-height});
+  max-height: calc(100vh - #{120px + $header-height} - constant(safe-area-inset-top));
+  max-height: calc(100vh - #{120px + $header-height} - env(safe-area-inset-top));
   overflow: auto;
   margin-top: 2px;
   width: max-content;


### PR DESCRIPTION
My previous fix for ClickOutside not working inadvertantly triggered a bug when body-scroll-lock applies `overflow: hidden` to stop scrolling. On Android, this causes the page to scroll to the top.

I have some more improvements but this fixes #5319 for now.