### PR TITLE
Undefined fix in organizer disclaimer

### DIFF
--- a/src/app/dim-ui/PowerCapDisclaimer.tsx
+++ b/src/app/dim-ui/PowerCapDisclaimer.tsx
@@ -15,13 +15,15 @@ export const powerCapDisclaimer = [
 ];
 
 export function PowerCapDisclaimer({ item }: { item: DimItem }) {
+  console.log('hello');
+  console.log(D2Sources);
   if (
     // rule out easy stuff first, to try and avoid doing hash lookups
     item.isDestiny2() &&
     item.powerCap === 1060 &&
     // if this is any raid armor
     ((item.bucket.inArmor &&
-      (D2Sources.raid.sourceHashes.includes(item.source) ||
+      (D2Sources?.raid?.sourceHashes?.includes(item.source) ||
         missingSources.raid.includes(item.hash))) ||
       // or last wish and garden weapons
       (item.bucket.inWeapons &&

--- a/src/app/dim-ui/PowerCapDisclaimer.tsx
+++ b/src/app/dim-ui/PowerCapDisclaimer.tsx
@@ -15,15 +15,13 @@ export const powerCapDisclaimer = [
 ];
 
 export function PowerCapDisclaimer({ item }: { item: DimItem }) {
-  console.log('hello');
-  console.log(D2Sources);
   if (
     // rule out easy stuff first, to try and avoid doing hash lookups
     item.isDestiny2() &&
     item.powerCap === 1060 &&
     // if this is any raid armor
     ((item.bucket.inArmor &&
-      (D2Sources?.raid?.sourceHashes?.includes(item.source) ||
+      (D2Sources.raid.sourceHashes.includes(item.source) ||
         missingSources.raid.includes(item.hash))) ||
       // or last wish and garden weapons
       (item.bucket.inWeapons &&

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -44,8 +44,7 @@ const FILTER_NODE_NAMES = [
 ];
 
 // ignore raid & calus sources in favor of more detailed sources
-delete D2Sources.raid;
-delete D2Sources.calus;
+const sourceKeys = Object.keys(D2Sources).filter((k) => !['raid', 'calus'].includes(k));
 
 export function downloadCsvFiles(
   stores: DimStore[],
@@ -276,7 +275,7 @@ function equippable(item: DimItem) {
 export function source(item: DimItem) {
   if (item.isDestiny2()) {
     return (
-      Object.keys(D2Sources).find(
+      sourceKeys.find(
         (src) =>
           D2Sources[src].sourceHashes.includes(item.source) ||
           D2Sources[src].itemHashes.includes(item.hash) ||


### PR DESCRIPTION
spreadsheet code was removing raid globally from d2sources import, but disclaimer relied on its presence