### PR TITLE
acquirable has no 'e'

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -741,7 +741,7 @@
       "Energy": "Energy",
       "Tag": "Tag",
       "WishList": "Wish List",
-      "Reacquireable": "Reacquireable",
+      "Reacquirable": "Reacquirable",
       "PercentComplete": "% Complete",
       "StatQuality": "Stat Quality",
       "StatQualityStat": "{{stat}}%",

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -307,8 +307,8 @@ export function getColumns(
           value === true ? 'is:wishlist' : value === false ? 'is:trashlist' : 'not:wishlist',
       },
     destinyVersion === 2 && {
-      id: 'reacquireable',
-      header: t('Organizer.Columns.Reacquireable'),
+      id: 'reacquirable',
+      header: t('Organizer.Columns.Reacquirable'),
       value: (item) =>
         item.isDestiny2() &&
         item.collectibleState !== null &&
@@ -316,7 +316,7 @@ export function getColumns(
         !(item.collectibleState & DestinyCollectibleState.PurchaseDisabled),
       defaultSort: SortDirection.DESC,
       cell: booleanCell,
-      filter: (value) => (value ? 'is:reacquireable' : 'not:reaquireable'),
+      filter: (value) => (value ? 'is:reacquirable' : 'not:reaquireable'),
     },
     $featureFlags.reviewsEnabled && {
       id: 'rating',

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -113,7 +113,7 @@ $toolbarHeight: 41px - 16px + 8px;
 .wishList,
 .energy,
 .dmg,
-.reacquireable,
+.reacquirable,
 .year,
 .season,
 .customstat {

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -31,7 +31,7 @@ interface CssExports {
   'positive': string;
   'power': string;
   'rating': string;
-  'reacquireable': string;
+  'reacquirable': string;
   'season': string;
   'selection': string;
   'shiftHeld': string;

--- a/src/locale/de/dim.json
+++ b/src/locale/de/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Perks, Mods & Shader",
       "Quality": "Qualität %",
       "Rating": "Bewertung",
-      "Reacquireable": "Zurückgewinnbar",
+      "Reacquirable": "Zurückgewinnbar",
       "Season": "Saison",
       "Source": "Quelle",
       "StatQuality": "Wert-Qualität",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -737,7 +737,7 @@
       "PerksMods": "Perks, Mods & Shaders",
       "Quality": "Quality %",
       "Rating": "Rating",
-      "Reacquireable": "Reacquireable",
+      "Reacquirable": "Reacquirable",
       "Season": "Season",
       "Source": "Source",
       "StatQuality": "Stat Quality",

--- a/src/locale/es-mx/dim.json
+++ b/src/locale/es-mx/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Perks, Mods & Shaders",
       "Quality": "% Calidad",
       "Rating": "Calificación",
-      "Reacquireable": "Readquirible",
+      "Reacquirable": "Readquirible",
       "Season": "Temporada",
       "Source": "Fuente",
       "StatQuality": "Calidad de las Estadísticas",

--- a/src/locale/es/dim.json
+++ b/src/locale/es/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Ventajas, Modificadores y Shaders",
       "Quality": "% Calidad",
       "Rating": "Calificación",
-      "Reacquireable": "Readquirible",
+      "Reacquirable": "Readquirible",
       "Season": "Temporada",
       "Source": "Fuente",
       "StatQuality": "Calidad de las Estadísticas",

--- a/src/locale/fr/dim.json
+++ b/src/locale/fr/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Compétences, mods et revêtements",
       "Quality": "Quality %",
       "Rating": "Évaluation",
-      "Reacquireable": "Réobtenable",
+      "Reacquirable": "Réobtenable",
       "Season": "Saison",
       "Source": "Origine",
       "StatQuality": "Stat Quality",

--- a/src/locale/it/dim.json
+++ b/src/locale/it/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Perk, Modifiche & Shader",
       "Quality": "Qualità %",
       "Rating": "Giudizio",
-      "Reacquireable": "Riacquisibile",
+      "Reacquirable": "Riacquisibile",
       "Season": "Stagione",
       "Source": "Fonte",
       "StatQuality": "Qualità Statistiche",

--- a/src/locale/ja/dim.json
+++ b/src/locale/ja/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "パーク、改造パーツとシェーダー",
       "Quality": "クオリティ %",
       "Rating": "評価",
-      "Reacquireable": "再取得する",
+      "Reacquirable": "再取得する",
       "Season": "シーズン",
       "Source": "ソース",
       "StatQuality": "Statsクオリティ",

--- a/src/locale/ko/dim.json
+++ b/src/locale/ko/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "특성, 개조 부품 & 안료",
       "Quality": "품질 %",
       "Rating": "평점",
-      "Reacquireable": "재습득 가능",
+      "Reacquirable": "재습득 가능",
       "Season": "시즌",
       "Source": "출처",
       "StatQuality": "스탯 품질",

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Perki, Modyfikacje i Barwy",
       "Quality": "Jakość %",
       "Rating": "Ocena",
-      "Reacquireable": "Odkupialne",
+      "Reacquirable": "Odkupialne",
       "Season": "Sezon",
       "Source": "Źródło",
       "StatQuality": "Jakość statystyki",

--- a/src/locale/pt-br/dim.json
+++ b/src/locale/pt-br/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Perks, Mods e Tonalizadores",
       "Quality": "Qualidade %",
       "Rating": "Avaliação",
-      "Reacquireable": "Recuperável",
+      "Reacquirable": "Recuperável",
       "Season": "Temporada",
       "Source": "Fonte",
       "StatQuality": "Qualidade dos Atributos",

--- a/src/locale/ru/dim.json
+++ b/src/locale/ru/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Perks, Mods & Shaders",
       "Quality": "Quality %",
       "Rating": "Rating",
-      "Reacquireable": "Reacquireable",
+      "Reacquirable": "Reacquirable",
       "Season": "Season",
       "Source": "Source",
       "StatQuality": "Stat Quality",

--- a/src/locale/zh-chs/dim.json
+++ b/src/locale/zh-chs/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "特性、模组与着色器",
       "Quality": "质量 %",
       "Rating": "评分",
-      "Reacquireable": "可重新获取",
+      "Reacquirable": "可重新获取",
       "Season": "赛季",
       "Source": "来源",
       "StatQuality": "属性质量",

--- a/src/locale/zh-cht/dim.json
+++ b/src/locale/zh-cht/dim.json
@@ -730,7 +730,7 @@
       "PerksMods": "Perks, Mods & Shaders",
       "Quality": "Quality %",
       "Rating": "Rating",
-      "Reacquireable": "Reacquireable",
+      "Reacquirable": "Reacquirable",
       "Season": "Season",
       "Source": "Source",
       "StatQuality": "Stat Quality",


### PR DESCRIPTION
'acquirable' has been spelled correctly and incorrectly in the repository in various places. In particular, shift-clicking in the organizer on the reacquirable checkmark sets the filter to 'is:reacquireable', but 'acquireable' is not a valid filter.

This also updates the translation mapping to use the correct spelling, but only on the English side. I don't speak other languages but I think this is probably a safe assumption.