### PR TITLE
check postmaster items for ownership

### DIFF
--- a/src/app/search/search-filters.ts
+++ b/src/app/search/search-filters.ts
@@ -935,7 +935,7 @@ function searchFilters(
             return false;
         }
 
-        return item.bucket.accountWide
+        return item.bucket.accountWide && !item.location.inPostmaster
           ? item.owner !== 'vault'
           : item.owner === stores[storeIndex].id;
       },


### PR DESCRIPTION
correct issue reported here: https://redd.it/hefomr

this change to inleft/middle/right ignores the "accountwide" flag for postmaster items because they are still separated between chars