### PR TITLE
Put energy constraints on seasonal mods in perk picker.

### DIFF
--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -136,7 +136,8 @@ function canAllModsBeUsed(set: ArmorSet, seasonalMods: readonly LockedModBase[])
       if (
         itemModCategories.includes(mod.mod.plug.plugCategoryHash) &&
         item.isDestiny2() &&
-        mod.mod.plug.energyCost.energyType === item.energy?.energyType
+        (mod.mod.plug.energyCost.energyType === DestinyEnergyType.Any ||
+          mod.mod.plug.energyCost.energyType === item.energy?.energyType)
       ) {
         if (!modArrays[item.bucket.hash]) {
           modArrays[item.bucket.hash] = [];

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -133,8 +133,11 @@ function canAllModsBeUsed(set: ArmorSet, seasonalMods: readonly LockedModBase[])
       const itemModCategories =
         getSpecialtySocketMetadata(item)?.compatiblePlugCategoryHashes || [];
 
-      // Not currently checking energy of mod and armour matches.
-      if (itemModCategories.includes(mod.mod.plug.plugCategoryHash)) {
+      if (
+        itemModCategories.includes(mod.mod.plug.plugCategoryHash) &&
+        item.isDestiny2() &&
+        mod.mod.plug.energyCost.energyType === item.energy?.energyType
+      ) {
         if (!modArrays[item.bucket.hash]) {
           modArrays[item.bucket.hash] = [];
         }


### PR DESCRIPTION
As per my comment in #5421 here is the restriction of the seasonal mods in the perk picker to having the correct energy. I think we are getting close to getting the new mod picket stuff in beta at least so I think it would be good to sync this behaviour before I build the energy match threshold setting. 