### PR TITLE
Use nodeRef property of CSSTransition

### DIFF
--- a/src/app/dim-ui/ClickOutside.tsx
+++ b/src/app/dim-ui/ClickOutside.tsx
@@ -10,11 +10,14 @@ export const ClickOutsideContext = React.createContext(new Subject<React.MouseEv
 export default function ClickOutside({
   onClickOutside,
   children,
+  ref,
   ...other
 }: React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.RefObject<HTMLDivElement>;
   onClickOutside(event: React.MouseEvent): void;
 }) {
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const localRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = ref || localRef;
   const context = useContext(ClickOutsideContext);
 
   const subscribeFn = useCallback(() => {
@@ -27,7 +30,7 @@ export default function ClickOutside({
       }
     };
     return context.subscribe(handleClickOutside);
-  }, [context, onClickOutside]);
+  }, [context, onClickOutside, wrapperRef]);
 
   useSubscription(subscribeFn);
 

--- a/src/app/dim-ui/Loading.tsx
+++ b/src/app/dim-ui/Loading.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import './Loading.scss';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
 export function Loading({ message }: { message?: string }) {
+  const nodeRef = useRef<HTMLDivElement>(null);
   return (
     <section className="dim-loading">
       <div className="logo-container">
@@ -28,10 +29,13 @@ export function Loading({ message }: { message?: string }) {
         <TransitionGroup className="loading-text-container">
           <CSSTransition
             key={message}
+            nodeRef={nodeRef}
             classNames="loading-text"
             timeout={{ enter: 200, exit: 200 }}
           >
-            <div className="loading-text">{message}</div>
+            <div ref={nodeRef} className="loading-text">
+              {message}
+            </div>
           </CSSTransition>
         </TransitionGroup>
       )}

--- a/src/app/dim-ui/PageLoading.tsx
+++ b/src/app/dim-ui/PageLoading.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatchProp, RootState } from 'app/store/reducers';
 import { Loading } from './Loading';
@@ -30,11 +30,16 @@ const transitionClasses = {
  * This displays the page-level loading screen. React Suspense can make this obsolete once it's available.
  */
 function PageLoading({ message }: Props) {
+  const nodeRef = useRef<HTMLDivElement>(null);
   return (
     <TransitionGroup component={null}>
       {message !== undefined && (
-        <CSSTransition classNames={transitionClasses} timeout={{ enter: 600, exit: 300 }}>
-          <div className={clsx('dim-page', styles.pageLoading)}>
+        <CSSTransition
+          nodeRef={nodeRef}
+          classNames={transitionClasses}
+          timeout={{ enter: 600, exit: 300 }}
+        >
+          <div ref={nodeRef} className={clsx('dim-page', styles.pageLoading)}>
             <Loading message={message} />
           </div>
         </CSSTransition>

--- a/src/app/farming/D1Farming.tsx
+++ b/src/app/farming/D1Farming.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { DimStore } from '../inventory/store-types';
 import { t } from 'app/i18next-t';
 import { RootState } from '../store/reducers';
@@ -42,11 +42,13 @@ function D1Farming({ store, makeRoomForItems, setSetting }: Props) {
     setSetting('farmingMakeRoomForItems', value);
   };
 
+  const nodeRef = useRef<HTMLDivElement>(null);
+
   return (
     <TransitionGroup component={null}>
       {store && (
-        <CSSTransition classNames="farming" timeout={{ enter: 500, exit: 500 }}>
-          <div id="item-farming">
+        <CSSTransition nodeRef={nodeRef} classNames="farming" timeout={{ enter: 500, exit: 500 }}>
+          <div ref={nodeRef} id="item-farming">
             <div>
               <p>
                 {makeRoomForItems

--- a/src/app/farming/D2Farming.tsx
+++ b/src/app/farming/D2Farming.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { DimStore } from '../inventory/store-types';
 import { t } from 'app/i18next-t';
 import { RootState } from '../store/reducers';
@@ -23,11 +23,12 @@ function mapStateToProps() {
 type Props = StoreProps;
 
 function D2Farming({ store }: Props) {
+  const nodeRef = useRef<HTMLDivElement>(null);
   return (
     <TransitionGroup component={null}>
       {store && (
-        <CSSTransition classNames="farming" timeout={{ enter: 500, exit: 500 }}>
-          <div id="item-farming" className="d2-farming">
+        <CSSTransition nodeRef={nodeRef} classNames="farming" timeout={{ enter: 500, exit: 500 }}>
+          <div ref={nodeRef} id="item-farming" className="d2-farming">
             <span>
               <p>
                 {t('FarmingMode.D2Desc', {

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -135,6 +135,8 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
 
   const history = useHistory();
 
+  const nodeRef = useRef<HTMLDivElement>(null);
+
   const bugReportLink = $DIM_FLAVOR !== 'release';
 
   const isStandalone =
@@ -266,8 +268,13 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
       </GlobalHotkeys>
       <TransitionGroup component={null}>
         {dropdownOpen && (
-          <CSSTransition classNames="dropdown" timeout={{ enter: 500, exit: 500 }}>
+          <CSSTransition
+            nodeRef={nodeRef}
+            classNames="dropdown"
+            timeout={{ enter: 500, exit: 500 }}
+          >
             <ClickOutside
+              ref={nodeRef}
               key="dropdown"
               className="dropdown"
               onClickOutside={hideDropdown}


### PR DESCRIPTION
The react CSS transitions library gained a new property that if used, provides compatibility with React's "Strict Mode" lints. That in turn prepares us for upcoming React features like Suspense.