### PR TITLE
add formatting to perk tooltip synergy stat

### DIFF
--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -67,6 +67,10 @@
   }
 }
 
+.synergyStat {
+  color: $orange;
+}
+
 .plug-objectives {
   margin: 4px 0;
   padding: 8px;

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -34,8 +34,7 @@ export default function PlugTooltip({
     defs.Collectible.get(plug.plugItem.collectibleHash).sourceString;
 
   // display perk's synergy with masterwork stat
-  const synergyStat =
-    item.masterworkInfo?.statHash &&
+  const synergyStat = item.masterworkInfo?.statHash &&
     plug.plugItem.investmentStats &&
     plug.plugItem.investmentStats.some(
       (stat) =>
@@ -43,8 +42,7 @@ export default function PlugTooltip({
         stat.statTypeHash &&
         item.masterworkInfo &&
         item.masterworkInfo.statHash === stat.statTypeHash
-    ) &&
-    ` (${item.masterworkInfo.statName})`;
+    ) && <span className="synergyStat"> ({item.masterworkInfo.statName})</span>;
 
   return (
     <>


### PR DESCRIPTION
perk tooltips display a statname in parentheses if the perk positively affects the same stat as the weapon's masterwork

i think this adds an important visual hint/connection to an otherwise undocumented(?) and non-obvious mechanic

old:
![image](https://user-images.githubusercontent.com/31990469/85918844-0a05c700-b81b-11ea-85d7-7fd54de09b70.png)

new:
![image](https://user-images.githubusercontent.com/31990469/85918822-de82dc80-b81a-11ea-8eb3-486fa1d6aef9.png)

