### PR TITLE
Don't serve index.html for assets

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -319,6 +319,12 @@ module.exports = (env) => {
         chunks: ['gdriveReturn'],
       }),
 
+      new HtmlWebpackPlugin({
+        inject: false,
+        filename: '404.html',
+        template: '!html-loader!src/404.html',
+      }),
+
       // Generate the .htaccess file (kind of an abuse of HtmlWebpack plugin just for templating)
       new HtmlWebpackPlugin({
         filename: '.htaccess',

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="">
+  <head>
+    <meta charset="utf-8" />
+    <title>Not Found</title>
+  </head>
+
+  <body>
+    <h1>Not Found</h1>
+    <p>That URL doesn't go anywhere</p>
+  </body>
+</html>

--- a/src/htaccess
+++ b/src/htaccess
@@ -736,6 +736,7 @@ AddEncoding br .br
     # Redirect unknown paths to index.html
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} !\.(json|wasm|js|css|png|jpg|map)(\.(gz|br))?$
     RewriteRule (.*) index.html [QSA,L]
 </IfModule>
 

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -35,7 +35,7 @@ const handler = createHandlerBoundToURL('/index.html');
 const navigationRoute = new NavigationRoute(handler, {
   // These have their own pages (return.html and gdrive-return.html)
   // This regex matches on query string too, so no anchors!
-  denylist: [/return\.html/, /\.well-known/],
+  denylist: [/return\.html/, /\.well-known/, /\.(json|wasm|js|css|png|jpg|map)(\.(gz|br))?$/],
 });
 registerRoute(navigationRoute);
 


### PR DESCRIPTION
This should protect us against poisoned caches in the future:

1. It won't serve index.html for things that look like JS, CSS, etc.
2. It *will* serve a 404 document instead of trying to find the 404 document, looping back around, and serving `index.html` anyway.
3. Our service worker won't serve `index.html` for asset-like files either.