### PR TITLE
Always show filter help, even if there's a query

### DIFF
--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -269,13 +269,12 @@ export default React.forwardRef(function SearchFilterInput(
         onBlur={() => textcomplete.current?.hide()}
       />
 
-      {liveQuery.length === 0 ? (
-        <span onClick={showFilterHelp} className="filter-bar-button" title={t('Header.Filters')}>
-          <AppIcon icon={helpIcon} />
-        </span>
-      ) : (
-        children
-      )}
+      {liveQuery.length !== 0 && children}
+
+      <span onClick={showFilterHelp} className="filter-bar-button" title={t('Header.Filters')}>
+        <AppIcon icon={helpIcon} />
+      </span>
+
       {(liveQuery.length > 0 || alwaysShowClearButton) && (
         <span className="filter-bar-button" onClick={clearFilter} title={t('Header.Clear')}>
           <AppIcon icon={disabledIcon} />


### PR DESCRIPTION
Instead of hiding the filter help button while there's an active search, leave it up, so people can click it. It eats into space on mobile, but I have a plan for that soon.

![image](https://user-images.githubusercontent.com/313208/86492744-f929e980-bd23-11ea-810f-cd8e534558a6.png)
<img width="1034" alt="Screen Shot 2020-07-03 at 11 54 21 AM" src="https://user-images.githubusercontent.com/313208/86492754-034be800-bd24-11ea-8d8e-8f6dc314856b.png">
