### PR TITLE
Enforce braces for all conditionals in eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,6 +64,7 @@
       }
     ],
     "arrow-body-style": ["error", "as-needed"],
+    "curly": ["error", "all"],
     "no-return-await": "error",
     "prefer-regex-literals": "error",
     "prefer-promise-reject-errors": "error",

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -688,8 +688,9 @@ function makeFakeStat(
   getStat: StatGetter,
   lowerBetter = false
 ) {
-  if (typeof displayProperties === 'string')
+  if (typeof displayProperties === 'string') {
     displayProperties = { name: displayProperties } as DestinyDisplayPropertiesDefinition;
+  }
   return {
     id,
     displayProperties,

--- a/src/app/dim-ui/PowerCapDisclaimer.tsx
+++ b/src/app/dim-ui/PowerCapDisclaimer.tsx
@@ -26,12 +26,13 @@ export function PowerCapDisclaimer({ item }: { item: DimItem }) {
       // or last wish and garden weapons
       (item.bucket.inWeapons &&
         (powerCapDisclaimer.includes(item.source) || missingSources.lastwish.includes(item.hash))))
-  )
+  ) {
     return (
       <PressTip elementType="span" tooltip={t('Stats.PowerCapDisclaimer')}>
         <AppIcon className="powerCapDisclaimer" icon={faExclamationTriangle} />
       </PressTip>
     );
+  }
 
   return null;
 }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -303,7 +303,9 @@ export function makeItem(
 
   // here is where we need to manually adjust unreasonable powerCap values,
   // which are used for things that aren't currently set to ever cap
-  if (powerCap && powerCap > 50000) powerCap = null;
+  if (powerCap && powerCap > 50000) {
+    powerCap = null;
+  }
 
   // null out falsy values like a blank string for a url
   const iconOverlay =
@@ -538,7 +540,9 @@ export function makeItem(
     const breakerTypeHash = createdItem.sockets.sockets.find(
       (s) => s.plug?.plugItem.breakerTypeHash
     )?.plug?.plugItem.breakerTypeHash;
-    if (breakerTypeHash) createdItem.breakerType = defs.BreakerType.get(breakerTypeHash);
+    if (breakerTypeHash) {
+      createdItem.breakerType = defs.BreakerType.get(breakerTypeHash);
+    }
   }
 
   // Infusion

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -217,7 +217,9 @@ class ManifestService {
           for (const query of cacheBusterStrings) {
             try {
               response = await fetch(`https://www.bungie.net${components[table]}${query}`);
-              if (response.ok) break;
+              if (response.ok) {
+                break;
+              }
               error = error ?? response;
             } catch (e) {
               error = error ?? e;

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -39,13 +39,16 @@ export function objectifyArray<T>(array: T[], key: string | ((obj: any) => strin
           ? JSON.stringify(val[key])
           : false;
 
-      if (keyName !== false) acc[keyName] = val;
-      else {
+      if (keyName !== false) {
+        acc[keyName] = val;
+      } else {
         for (const eachKeyName of val[key]) {
           acc[eachKeyName] = val;
         }
       }
-    } else acc[key(val)] = val;
+    } else {
+      acc[key(val)] = val;
+    }
     return acc;
   }, {});
 }


### PR DESCRIPTION
I thought this was handled by prettier, but apparently it doesn't do that. This enforces it in eslint.