### PR TITLE
Loadout optimizer tweaks

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.m.scss
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss
@@ -1,3 +1,4 @@
+@import 'ceaser-easing';
 @import '../variables.scss';
 
 .page {
@@ -35,16 +36,19 @@
 }
 
 .processing {
-  align-items: center;
-  background-color: black;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: black;
   font-size: 1.2em;
   padding: 10px 10px;
   position: fixed;
-  right: 14px;
-  top: 50px;
-  white-space: pre-line;
-  z-index: 50;
+  top: $header-height;
+  left: 50%;
+  transform: translateX(-50%);
+
+  white-space: nowrap;
+  z-index: 10;
 
   > div {
     margin-right: 8px;
@@ -53,4 +57,26 @@
   > span {
     font-size: 1.4em;
   }
+
+  @include phone-portrait {
+    width: 100%;
+  }
+}
+
+.processingEnter {
+  transform: translateY(-250px) translateX(-50%);
+}
+
+.processingEnter.processingEnterActive {
+  transform: translateY(-0) translateX(-50%);
+  transition: transform 200ms $easeOutCubic;
+}
+
+.processingExit {
+  transform: translateY(-0) translateX(-50%);
+}
+
+.processingExit.processingExitActive {
+  transform: translateY(-250px) translateX(-50%);
+  transition: transform 200ms $easeInCubic;
 }

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
@@ -5,6 +5,10 @@ interface CssExports {
   'menuContent': string;
   'page': string;
   'processing': string;
+  'processingEnter': string;
+  'processingEnterActive': string;
+  'processingExit': string;
+  'processingExitActive': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -1,7 +1,7 @@
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { connect } from 'react-redux';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import CharacterSelect from '../dim-ui/CharacterSelect';
@@ -34,6 +34,7 @@ import { AppIcon, refreshIcon } from 'app/shell/icons';
 import { Loadout } from 'app/loadout/loadout-types';
 import { LoadoutBuilderState, useLbState } from './loadoutBuilderReducer';
 import { settingsSelector } from 'app/settings/reducer';
+import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
 // Need to force the type as lodash converts the StatTypes type to string.
 const statHashToType = _.invert(statHashes) as { [hash: number]: StatTypes };
@@ -191,6 +192,8 @@ function LoadoutBuilder({
     ]
   );
 
+  const loadingNodeRef = useRef<HTMLDivElement>(null);
+
   // I dont think this can actually happen?
   if (!selectedStore) {
     return null;
@@ -249,12 +252,25 @@ function LoadoutBuilder({
       </PageWithMenu.Menu>
 
       <PageWithMenu.Contents>
-        {filteredSets && processing && (
-          <div className={styles.processing}>
-            <div>{t('LoadoutBuilder.ProcessingSets', { character: selectedStore.name })}</div>
-            <AppIcon icon={refreshIcon} spinning={true} />
-          </div>
-        )}
+        <TransitionGroup component={null}>
+          {filteredSets && processing && (
+            <CSSTransition
+              nodeRef={loadingNodeRef}
+              classNames={{
+                enter: styles.processingEnter,
+                enterActive: styles.processingEnterActive,
+                exit: styles.processingExit,
+                exitActive: styles.processingExitActive,
+              }}
+              timeout={{ enter: 500, exit: 500 }}
+            >
+              <div className={styles.processing} ref={loadingNodeRef}>
+                <div>{t('LoadoutBuilder.ProcessingSets', { character: selectedStore.name })}</div>
+                <AppIcon icon={refreshIcon} spinning={true} />
+              </div>
+            </CSSTransition>
+          )}
+        </TransitionGroup>
         {filteredSets ? (
           <GeneratedSets
             sets={filteredSets}

--- a/src/app/loadout-builder/processWorker/tsconfig.json
+++ b/src/app/loadout-builder/processWorker/tsconfig.json
@@ -1,12 +1,18 @@
 {
   "compilerOptions": {
-    "strict": true,
+    "strictNullChecks": true,
+    "strictBindCallApply": true,
+    "noUnusedParameters": true,
     "target": "esnext",
     "module": "esnext",
     "lib": ["webworker", "esnext"],
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
     "allowJs": false,
     "baseUrl": "."
   }

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -62,3 +62,28 @@ export interface ProcessArmorSet {
   /** The maximum power loadout possible in this stat mix. */
   readonly maxPower: number;
 }
+
+export interface IntermediateProcessArmorSet {
+  /** The overall stats for the loadout as a whole. */
+  stats: { [statType in StatTypes]: number };
+
+  /**
+   * Potential stat mixes that can achieve the overall stats.
+   * Each mix is a particular set of stat choices (and options for each piece within that)
+   * to get to the overall stats.
+   */
+  sets: {
+    /** For each armor type (see LockableBuckets), this is the list of items that could interchangeably be put into this loadout. */
+    armor: ProcessItem[][];
+    /** The chosen stats for each armor type, as a list in the order Mobility/Resiliency/Recovery. */
+    statChoices: number[][];
+    maxPower: number;
+  }[];
+
+  /** The first (highest-power) valid set from this stat mix. */
+  firstValidSet: ProcessItem[];
+  firstValidSetStatChoices: number[][];
+
+  /** The maximum power loadout possible in this stat mix. */
+  maxPower: number;
+}


### PR DESCRIPTION
1. Tweaked the style of the processing indicator, and animated it entering/exiting.
2. Avoided a few `.map` calls in the hot loop - appears to knock ~15% off the wall clock time.