### PR TITLE
MinPower causes process fix

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -94,12 +94,15 @@ function mapStateToProps() {
     }
   );
 
+  const statOrderSelector = createSelector(
+    (state: RootState) => settingsSelector(state).loStatSortOrder,
+    (loStatSortOrder: number[]) => loStatSortOrder.map((hash) => statHashToType[hash])
+  );
+
   return (state: RootState): StoreProps => {
-    const { loStatSortOrder, loAssumeMasterwork, loMinPower, loMinStatTotal } = settingsSelector(
-      state
-    );
+    const { loAssumeMasterwork, loMinPower, loMinStatTotal } = settingsSelector(state);
     return {
-      statOrder: loStatSortOrder.map((hash) => statHashToType[hash]),
+      statOrder: statOrderSelector(state),
       assumeMasterwork: loAssumeMasterwork,
       minimumPower: loMinPower,
       minimumStatTotal: loMinStatTotal,


### PR DESCRIPTION
Fixed an issue where stat sort order in the optimiser would cause a process retrigger on any prop change.

Was torn between useMemo and reselect but went this was as it moves some scope into the state mapping. Let me know if you prefer the other, or have already done this.