### PR TITLE
Handle stat range values and ignored status in the process worker.

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -165,7 +165,8 @@ function LoadoutBuilder({
     lockedMap,
     lockedArmor2Mods,
     assumeMasterwork,
-    statOrder
+    statOrder,
+    statFilters
   );
 
   const combos = result?.combos || 0;
@@ -211,7 +212,7 @@ function LoadoutBuilder({
       />
 
       <FilterBuilds
-        sets={result?.sets}
+        statRanges={result?.statRanges}
         selectedStore={selectedStore as D2Store}
         minimumPower={minimumPower}
         minimumStatTotal={minimumStatTotal}

--- a/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
+++ b/src/app/loadout-builder/generated-sets/FilterBuilds.tsx
@@ -1,21 +1,20 @@
 import { t } from 'app/i18next-t';
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { D2Store } from '../../inventory/store-types';
-import { ArmorSet, StatTypes, MinMaxIgnored } from '../types';
+import { StatTypes, MinMaxIgnored, MinMax } from '../types';
 import TierSelect from './TierSelect';
 import _ from 'lodash';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import styles from './FilterBuilds.m.scss';
-import { statTier } from './utils';
 import { useDispatch } from 'react-redux';
 import { setSetting } from 'app/settings/actions';
-import { statHashes, statKeys } from '../types';
+import { statHashes } from '../types';
 
 /**
  * A control for filtering builds by stats, and controlling the priority order of stats.
  */
 export default function FilterBuilds({
-  sets,
+  statRanges,
   minimumPower,
   minimumStatTotal,
   selectedStore,
@@ -25,7 +24,7 @@ export default function FilterBuilds({
   assumeMasterwork,
   onStatFiltersChanged,
 }: {
-  sets?: readonly ArmorSet[];
+  statRanges?: { [statType in StatTypes]: MinMax };
   minimumPower: number;
   minimumStatTotal: number;
   selectedStore: D2Store;
@@ -46,21 +45,8 @@ export default function FilterBuilds({
     );
   };
 
-  const statRanges = useMemo(() => {
-    if (!sets || !sets.length) {
-      return _.mapValues(statHashes, () => ({ min: 0, max: 10, ignored: false }));
-    }
-    const statRanges = _.mapValues(statHashes, () => ({ min: 10, max: 0, ignored: false }));
-    for (const set of sets) {
-      for (const prop of statKeys) {
-        const tier = statTier(set.stats[prop]);
-        const range = statRanges[prop];
-        range.min = Math.min(tier, range.min);
-        range.max = Math.max(tier, range.max);
-      }
-    }
-    return statRanges;
-  }, [sets]);
+  const workingStatRanges =
+    statRanges || _.mapValues(statHashes, () => ({ min: 0, max: 10, ignored: false }));
 
   return (
     <div>
@@ -68,7 +54,7 @@ export default function FilterBuilds({
         <TierSelect
           rowClassName={styles.row}
           stats={stats}
-          statRanges={statRanges}
+          statRanges={workingStatRanges}
           defs={defs}
           order={order}
           onStatFiltersChanged={onStatFiltersChanged}

--- a/src/app/loadout-builder/generated-sets/TierSelect.tsx
+++ b/src/app/loadout-builder/generated-sets/TierSelect.tsx
@@ -8,6 +8,7 @@ import { AppIcon, faGripLinesVertical } from 'app/shell/icons';
 import styles from './TierSelect.m.scss';
 import _ from 'lodash';
 import BungieImage from 'app/dim-ui/BungieImage';
+import clsx from 'clsx';
 
 const IGNORE = 'ignore';
 const INCLUDE = 'include';
@@ -186,7 +187,7 @@ function MinMaxSelectInner({
         t('LoadoutBuilder.SelectMax')
        */}
       {_.range(min, max + 1).map((tier) => (
-        <option key={tier} value={tier}>
+        <option key={tier} value={tier} className={clsx(ignored && styles.hiddenOption)}>
           {t('LoadoutBuilder.TierNumber', {
             tier,
           })}
@@ -195,10 +196,10 @@ function MinMaxSelectInner({
       <option key="-" value="-" className={styles.hiddenOption}>
         -
       </option>
-      <option key={IGNORE} value={IGNORE} className={ignored ? styles.hiddenOption : ''}>
+      <option key={IGNORE} value={IGNORE} className={clsx(ignored && styles.hiddenOption)}>
         {t('LoadoutBuilder.StatTierIgnoreOption')}
       </option>
-      <option key={INCLUDE} value={INCLUDE} className={ignored ? '' : styles.hiddenOption}>
+      <option key={INCLUDE} value={INCLUDE} className={clsx(!ignored && styles.hiddenOption)}>
         {t('LoadoutBuilder.StatTierIncludeOption')}
       </option>
     </select>

--- a/src/app/loadout-builder/generated-sets/TierSelect.tsx
+++ b/src/app/loadout-builder/generated-sets/TierSelect.tsx
@@ -187,7 +187,13 @@ function MinMaxSelectInner({
         t('LoadoutBuilder.SelectMax')
        */}
       {_.range(min, max + 1).map((tier) => (
-        <option key={tier} value={tier} className={clsx(ignored && styles.hiddenOption)}>
+        <option
+          key={tier}
+          value={tier}
+          className={clsx({
+            [styles.hiddenOption]: ignored,
+          })}
+        >
           {t('LoadoutBuilder.TierNumber', {
             tier,
           })}
@@ -196,10 +202,22 @@ function MinMaxSelectInner({
       <option key="-" value="-" className={styles.hiddenOption}>
         -
       </option>
-      <option key={IGNORE} value={IGNORE} className={clsx(ignored && styles.hiddenOption)}>
+      <option
+        key={IGNORE}
+        value={IGNORE}
+        className={clsx({
+          [styles.hiddenOption]: ignored,
+        })}
+      >
         {t('LoadoutBuilder.StatTierIgnoreOption')}
       </option>
-      <option key={INCLUDE} value={INCLUDE} className={clsx(!ignored && styles.hiddenOption)}>
+      <option
+        key={INCLUDE}
+        value={INCLUDE}
+        className={clsx({
+          [styles.hiddenOption]: !ignored,
+        })}
+      >
         {t('LoadoutBuilder.StatTierIncludeOption')}
       </option>
     </select>

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -340,9 +340,6 @@ export function process(
     }
   }
 
-  console.log(`totalTiers: ${setTracker.map((set) => set.tier)}`);
-  console.log(`totalSets: ${setCount}`);
-
   const finalSets = setTracker.map((set) => set.statMixes.map((mix) => mix.armorSet)).flat();
 
   console.log(

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -6,6 +6,8 @@ import {
   LockedMap,
   LockedArmor2Mod,
   LockedArmor2ModMap,
+  MinMaxIgnored,
+  MinMax,
 } from '../types';
 import { statTier } from '../generated-sets/utils';
 import { compareBy } from '../../utils/comparators';
@@ -91,8 +93,14 @@ export function process(
   lockedItems: LockedMap,
   lockedArmor2ModMap: LockedArmor2ModMap,
   assumeMasterwork: boolean,
-  statOrder: StatTypes[]
-): { sets: ProcessArmorSet[]; combos: number; combosWithoutCaps: number } {
+  statOrder: StatTypes[],
+  statFilters: { [stat in StatTypes]: MinMaxIgnored }
+): {
+  sets: ProcessArmorSet[];
+  combos: number;
+  combosWithoutCaps: number;
+  statRanges?: { [stat in StatTypes]: MinMax };
+} {
   const pstart = performance.now();
 
   // Memoize the function that turns string stat-keys back into numbers to save garbage.
@@ -109,6 +117,16 @@ export function process(
   };
 
   const orderedStatValues = statOrder.map((statType) => statHashes[statType]);
+  const orderedConsideredStats = statOrder.filter((statType) => !statFilters[statType].ignored);
+
+  const statRanges: { [stat in StatTypes]: MinMax } = {
+    Mobility: statFilters.Mobility.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
+    Resilience: statFilters.Resilience.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
+    Recovery: statFilters.Recovery.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
+    Discipline: statFilters.Discipline.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
+    Intellect: statFilters.Intellect.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
+    Strength: statFilters.Strength.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
+  };
 
   const helms = multiGroupBy(
     _.sortBy(filteredItems[LockableBuckets.helmet] || [], (i) => -i.basePower),
@@ -243,13 +261,32 @@ export function process(
               let tiers = '';
               let totalTier = 0;
               let index = 1;
-              for (const statKey in stats) {
-                tiers += statTier(stats[statKey]);
-                totalTier += statTier(stats[statKey]);
+              let statRangeExceeded = false;
+              for (const statKey of orderedConsideredStats) {
+                const tier = statTier(stats[statKey]);
+
+                if (tier > statRanges[statKey].max) {
+                  statRanges[statKey].max = tier;
+                }
+
+                if (tier < statRanges[statKey].min) {
+                  statRanges[statKey].min = tier;
+                }
+
+                if (tier > statFilters[statKey].max || tier < statFilters[statKey].min) {
+                  statRangeExceeded = true;
+                  break;
+                }
+                tiers += tier;
+                totalTier += tier;
                 if (index < statOrder.length) {
                   tiers += ',';
                 }
                 index++;
+              }
+
+              if (statRangeExceeded) {
+                continue;
               }
 
               // While we have less than RETURNED_ARMOR_SETS sets keep adding and keep track of the lowest total tier.
@@ -303,6 +340,9 @@ export function process(
     }
   }
 
+  console.log(`totalTiers: ${setTracker.map((set) => set.tier)}`);
+  console.log(`totalSets: ${setCount}`);
+
   const finalSets = setTracker.map((set) => set.statMixes.map((mix) => mix.armorSet)).flat();
 
   console.log(
@@ -315,7 +355,7 @@ export function process(
     'ms'
   );
 
-  return { sets: flattenSets(finalSets), combos, combosWithoutCaps };
+  return { sets: flattenSets(finalSets), combos, combosWithoutCaps, statRanges };
 }
 
 function multiGroupBy<T>(items: T[], mapper: (item: T) => string[]) {


### PR DESCRIPTION
This incorporates the stat filters into the process run, rather than having them just filter the results. The main motivation behind this is we now have a smaller set of results coming back so this will make them have more of an impact.

This is doing three things
1. Ignored stats will no longer factor into the total tier calculation or the stat mix in process. Thus if I don't care about resilience it wont effect my results. The total tier will now be the total shown in the Optimisers generated set stat display, i.e. if only Recovery wasn't ignored, the total would be the Recovery tier. 
Similar for the stat mix, the keys generated for sets will only include the non-ignored stats. This means it is more likely we will get more sets in a single stat mix. The downside is the greyed out tiers in the UI may not be representative if some amour piece is changed through the switch icon (I don't think this is an issue as it will be reprocessed). 
2. Stat Mixes that don't meet the filter constraints will not be included in the results. Thus if I set my filter to have minimum T7 Mobility, only results with T7 or higher mobility will be returned.
3. Keeping track of the stat ranges it finds during process. This means the user gets a wider variation in stats ranges and can refine their search to get closer to the values they want. For example if some stat mix had 10 Recovery, but it doesn't show up in the default search as the total tier is too low, then they can set minimum to 10 to ensure they can see any sets with 10.

I think this just about covers it. I also tried my best to make it as efficient as possible in the hot part of the loop.