### PR TITLE
Ignore minimum stat total filter for locked items.

### DIFF
--- a/src/app/loadout-builder/preProcessFilter.ts
+++ b/src/app/loadout-builder/preProcessFilter.ts
@@ -10,7 +10,7 @@ import { Armor2ModPlugCategories, getItemDamageShortName } from 'app/utils/item-
 import { doEnergiesMatch } from './generated-sets/mod-utils';
 import { canSlotMod } from './generated-sets/utils';
 import { DimItem } from 'app/inventory/item-types';
-import { getLockedModStats, getBaseStatValues } from './utils';
+import { getBaseStatValues } from './utils';
 
 const bucketsToCategories = {
   [LockableBuckets.helmet]: Armor2ModPlugCategories.helmet,
@@ -62,18 +62,17 @@ export function filterItems(
   Object.values(LockableBuckets).forEach((bucket) => {
     const locked = lockedMap[bucket];
     const lockedMods = lockedArmor2ModMap[bucketsToCategories[bucket]];
-    const lockedModStats = getLockedModStats(locked, lockedMods);
 
     if (filteredItems[bucket]) {
       filteredItems[bucket] = filteredItems[bucket].filter(
         (item) =>
-          // if the item is not a class item, make sure it meets the minimum total stat
-          (bucket === LockableBuckets.classitem ||
-            _.sum(Object.values(getBaseStatValues(item, assumeMasterwork, lockedModStats))) >=
-              minimumStatTotal) &&
           // handle locked items and mods cases
           (!locked || locked.every((lockedItem) => matchLockedItem(item, lockedItem))) &&
-          (!lockedMods || lockedMods.every((mod) => doEnergiesMatch(mod, item)))
+          (!lockedMods || lockedMods.every((mod) => doEnergiesMatch(mod, item))) &&
+          // if the item is not a class item, and its not locked, make sure it meets the minimum total stat without locked mods
+          (bucket === LockableBuckets.classitem ||
+            locked?.length ||
+            _.sum(Object.values(getBaseStatValues(item, assumeMasterwork))) >= minimumStatTotal)
       );
     }
   });

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -87,7 +87,7 @@ export function generateMixesFromPerksOrStats(
 export function getBaseStatValues(
   item: DimItem,
   assumeMasterwork: boolean | null,
-  lockedModStats: { [statHash: number]: number }
+  lockedModStats?: { [statHash: number]: number }
 ) {
   const stats = _.keyBy(item.stats, (stat) => stat.statHash);
   const baseStats = {};
@@ -126,9 +126,11 @@ export function getBaseStatValues(
       }
     }
     // For Armor 2.0 mods, include the stat values of any locked mods in the item's stats
-    _.forIn(lockedModStats, (value, statHash) => {
-      baseStats[statHash] += value;
-    });
+    if (lockedModStats) {
+      _.forIn(lockedModStats, (value, statHash) => {
+        baseStats[statHash] += value;
+      });
+    }
   }
   // mapping out from stat values to ensure ordering and that values don't fall below 0 from locked mods
   return statValues.map((statHash) => Math.max(baseStats[statHash], 0));


### PR DESCRIPTION
It would probably be a bit nicer to filter out those items from the item pickers altogether but people also might find it confusing that they can't see their items. This is the path of least resistance for now I feel.