### PR TITLE
Use store that matches preloaded loadout classtype

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* When opening a loadout in the loadout optimizer from the inventory page, the correct character is now selected rather than the last played character.
+
 ## 6.19.0 <span className="changelog-date">(2020-07-05)</span>
 
 * Loadout Optimizer has been... optimized. It now calculates sets in the background, so you can still interact with it while it works.

--- a/src/app/loadout-builder/loadoutBuilderReducer.ts
+++ b/src/app/loadout-builder/loadoutBuilderReducer.ts
@@ -32,7 +32,11 @@ const lbStateInit = ({
 }): LoadoutBuilderState => {
   let lockedMap: LockedMap = {};
 
+  let selectedStoreId = getCurrentStore(stores)?.id;
+
   if (stores.length && preloadedLoadout) {
+    selectedStoreId = stores.find((store) => store.classType === preloadedLoadout.classType)?.id;
+
     for (const loadoutItem of preloadedLoadout.items) {
       if (loadoutItem.equipped) {
         const item = getItemAcrossStores(stores, loadoutItem);
@@ -70,7 +74,7 @@ const lbStateInit = ({
     },
     minimumPower: 750,
     query: '',
-    selectedStoreId: getCurrentStore(stores)?.id,
+    selectedStoreId: selectedStoreId,
   };
 };
 


### PR DESCRIPTION
This should resolve an issue where, when opening the loadout optimizer
from the inventory page, on a character that you haven't played last,
the loadout optimizer wouldn't select the correct character.

This logic sets the store to use on the loadout optimizer to the store
that matches the preloaded loadout's class type. If there isn't a
preloaded loadout, then the code behaves as it did before