### PR TITLE
Enabled HMR for Web Worker

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -396,7 +396,9 @@ module.exports = (env) => {
         '$featureFlags.issueBanner': JSON.stringify(true),
       }),
 
-      new WorkerPlugin(),
+      new WorkerPlugin({
+        globalObject: 'self',
+      }),
 
       new LodashModuleReplacementPlugin({
         collections: true,


### PR DESCRIPTION
Enabled hot module replacement by setting worker plugin to use the default value.

@bhollis I dare say you will understand the webpack config better than I will. From what I was reading DIM must use `output.globalObject = 'window'`. The default setting for the worker plugin is apparently `'self'` so from what I can see if wont have any adverse effects. I was reading about it here https://www.npmjs.com/package/worker-plugin.