### PR TITLE
Remove DIM spinner during initial process in optimiser.

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -29,7 +29,6 @@ import LockArmorAndPerks from './LockArmorAndPerks';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
 import { DimItem } from 'app/inventory/item-types';
 import { useProcess } from './hooks/useProcess';
-import { Loading } from 'app/dim-ui/Loading';
 import { AppIcon, refreshIcon } from 'app/shell/icons';
 import { Loadout } from 'app/loadout/loadout-types';
 import { LoadoutBuilderState, useLbState } from './loadoutBuilderReducer';
@@ -257,7 +256,7 @@ function LoadoutBuilder({
 
       <PageWithMenu.Contents>
         <TransitionGroup component={null}>
-          {filteredSets && processing && (
+          {processing && (
             <CSSTransition
               nodeRef={loadingNodeRef}
               classNames={{
@@ -275,7 +274,7 @@ function LoadoutBuilder({
             </CSSTransition>
           )}
         </TransitionGroup>
-        {filteredSets ? (
+        {filteredSets && (
           <GeneratedSets
             sets={filteredSets}
             combos={combos}
@@ -289,8 +288,6 @@ function LoadoutBuilder({
             enabledStats={enabledStats}
             lockedArmor2Mods={lockedArmor2Mods}
           />
-        ) : (
-          <Loading message={'Processing armor sets'} />
         )}
       </PageWithMenu.Contents>
 


### PR DESCRIPTION
Removed the DIM loading spinner when the initial process run is happening as it covers the filters on mobile and seems a bit excessive.