### PR TITLE
Implement a real query parser for our search language

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,19 +9,20 @@ module.exports = {
     ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
     '^.+\\.scss$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      '<rootDir>/src/__mocks__/fileMock.js'
+      '<rootDir>/src/__mocks__/fileMock.js',
   },
   globals: {
     $BROWSERS: [],
+    $DIM_FLAVOR: 'test',
     $featureFlags: {
-      dimApi: true
+      dimApi: true,
     },
     'ts-jest': {
       tsConfig: {
         target: 'ES2015',
         jsx: 'react',
-        allowJs: true
-      }
-    }
-  }
+        allowJs: true,
+      },
+    },
+  },
 };

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -92,19 +92,14 @@ Object {
       "op": "and",
       "operands": Array [
         Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "args": "hunter",
-              "op": "filter",
-              "type": "is",
-            },
-            Object {
-              "args": ">=540",
-              "op": "filter",
-              "type": "power",
-            },
-          ],
+          "args": "hunter",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": ">=540",
+          "op": "filter",
+          "type": "power",
         },
       ],
     },
@@ -181,19 +176,14 @@ Object {
       "op": "and",
       "operands": Array [
         Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "args": "weapon",
-              "op": "filter",
-              "type": "is",
-            },
-            Object {
-              "args": "sniperrifle",
-              "op": "filter",
-              "type": "is",
-            },
-          ],
+          "args": "weapon",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
         },
       ],
     },
@@ -276,19 +266,14 @@ Object {
       "op": "and",
       "operands": Array [
         Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "args": "weapon",
-              "op": "filter",
-              "type": "is",
-            },
-            Object {
-              "args": "sniperrifle",
-              "op": "filter",
-              "type": "is",
-            },
-          ],
+          "args": "weapon",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
         },
       ],
     },
@@ -881,14 +866,9 @@ Object {
       "op": "or",
       "operands": Array [
         Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "args": "cluster",
-              "op": "filter",
-              "type": "perk",
-            },
-          ],
+          "args": "cluster",
+          "op": "filter",
+          "type": "perk",
         },
         Object {
           "args": "tracking module",
@@ -1057,26 +1037,26 @@ Array [
 
 exports[`parse |is:weapon and is:sniperrifle or not is:armor and modslot:arrival|: ast 1`] = `
 Object {
-  "op": "and",
+  "op": "or",
   "operands": Array [
     Object {
-      "op": "or",
+      "op": "and",
       "operands": Array [
         Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "args": "weapon",
-              "op": "filter",
-              "type": "is",
-            },
-            Object {
-              "args": "sniperrifle",
-              "op": "filter",
-              "type": "is",
-            },
-          ],
+          "args": "weapon",
+          "op": "filter",
+          "type": "is",
         },
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
+        },
+      ],
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
         Object {
           "op": "not",
           "operand": Object {
@@ -1085,12 +1065,12 @@ Object {
             "type": "is",
           },
         },
+        Object {
+          "args": "arrival",
+          "op": "filter",
+          "type": "modslot",
+        },
       ],
-    },
-    Object {
-      "args": "arrival",
-      "op": "filter",
-      "type": "modslot",
     },
   ],
 }

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -18,6 +18,31 @@ Array [
 ]
 `;
 
+exports[`parse |( power:>1000 and -modslot:arrival ) |: lexer 1`] = `
+Array [
+  Array [
+    "(",
+  ],
+  Array [
+    "word",
+    "power:>1000",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "modslot:arrival",
+  ],
+  Array [
+    ")",
+  ],
+]
+`;
+
 exports[`parse |(is:hunter power:>=540) or (is:warlock power:>=560)|: lexer 1`] = `
 Array [
   Array [
@@ -38,13 +63,7 @@ Array [
     ")",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "or",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "(",
@@ -79,12 +98,6 @@ Array [
     "and",
   ],
   Array [
-    "and",
-  ],
-  Array [
-    "and",
-  ],
-  Array [
     "word",
     "is:sniperrifle",
   ],
@@ -92,19 +105,10 @@ Array [
     ")",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "or",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "not",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "(",
@@ -112,12 +116,6 @@ Array [
   Array [
     "word",
     "is:armor",
-  ],
-  Array [
-    "and",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "and",
@@ -152,13 +150,7 @@ Array [
     ")",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "or",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "(",
@@ -180,8 +172,15 @@ Array [
 ]
 `;
 
-exports[`parse |-(power:>1000 and -modslot:arrival)|: lexer 1`] = `
+exports[`parse |- is:exotic - (power:>1000)|: lexer 1`] = `
 Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "is:exotic",
+  ],
   Array [
     "not",
   ],
@@ -193,10 +192,22 @@ Array [
     "power:>1000",
   ],
   Array [
-    "and",
+    ")",
+  ],
+]
+`;
+
+exports[`parse |-(power:>1000 and -modslot:arrival)|: lexer 1`] = `
+Array [
+  Array [
+    "not",
   ],
   Array [
-    "and",
+    "(",
+  ],
+  Array [
+    "word",
+    "power:>1000",
   ],
   Array [
     "and",
@@ -250,9 +261,6 @@ Array [
     "is:exotic",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "not",
   ],
   Array [
@@ -260,17 +268,11 @@ Array [
     "is:locked",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "not",
   ],
   Array [
     "word",
     "is:maxpower",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "not",
@@ -297,9 +299,6 @@ Array [
   Array [
     "word",
     "source:garden",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "not",
@@ -344,9 +343,6 @@ Array [
     "is:haspower",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "not",
   ],
   Array [
@@ -363,9 +359,6 @@ Array [
     "is:rocketlauncher",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "(",
   ],
   Array [
@@ -373,13 +366,7 @@ Array [
     "perk:\\"cluster\\"",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "or",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "word",
@@ -405,17 +392,11 @@ Array [
     "is:rocketlauncher",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "not",
   ],
   Array [
     "str",
     "cluster",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "not",
@@ -434,17 +415,11 @@ Array [
     "is:rocketlauncher",
   ],
   Array [
-    "and",
-  ],
-  Array [
     "not",
   ],
   Array [
     "str",
     "cluster",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "not",
@@ -515,9 +490,6 @@ exports[`parse |not witherhoard|: lexer 1`] = `
 Array [
   Array [
     "not",
-  ],
-  Array [
-    "and",
   ],
   Array [
     "word",

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -344,25 +344,25 @@ Array [
 
 exports[`parse |- is:exotic - (power:>1000)|: ast 1`] = `
 Object {
-  "op": "not",
-  "operand": Object {
-    "op": "and",
-    "operands": Array [
-      Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "op": "not",
+      "operand": Object {
         "args": "exotic",
         "op": "filter",
         "type": "is",
       },
-      Object {
-        "op": "not",
-        "operand": Object {
-          "args": ">1000",
-          "op": "filter",
-          "type": "power",
-        },
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": ">1000",
+        "op": "filter",
+        "type": "power",
       },
-    ],
-  },
+    },
+  ],
 }
 `;
 
@@ -452,32 +452,32 @@ Array [
 
 exports[`parse |-is:equipped is:haspower is:incurrentchar|: ast 1`] = `
 Object {
-  "op": "not",
-  "operand": Object {
-    "op": "and",
-    "operands": Array [
-      Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "op": "not",
+      "operand": Object {
         "args": "equipped",
         "op": "filter",
         "type": "is",
       },
-      Object {
-        "op": "and",
-        "operands": Array [
-          Object {
-            "args": "haspower",
-            "op": "filter",
-            "type": "is",
-          },
-          Object {
-            "args": "incurrentchar",
-            "op": "filter",
-            "type": "is",
-          },
-        ],
-      },
-    ],
-  },
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "haspower",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "incurrentchar",
+          "op": "filter",
+          "type": "is",
+        },
+      ],
+    },
+  ],
 }
 `;
 
@@ -512,61 +512,61 @@ Array [
 
 exports[`parse |-is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55|: ast 1`] = `
 Object {
-  "op": "not",
-  "operand": Object {
-    "op": "and",
-    "operands": Array [
-      Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "op": "not",
+      "operand": Object {
         "args": "exotic",
         "op": "filter",
         "type": "is",
       },
-      Object {
-        "op": "not",
-        "operand": Object {
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "op": "not",
+          "operand": Object {
+            "args": "locked",
+            "op": "filter",
+            "type": "is",
+          },
+        },
+        Object {
           "op": "and",
           "operands": Array [
             Object {
-              "args": "locked",
-              "op": "filter",
-              "type": "is",
-            },
-            Object {
               "op": "not",
               "operand": Object {
-                "op": "and",
-                "operands": Array [
-                  Object {
-                    "args": "maxpower",
+                "args": "maxpower",
+                "op": "filter",
+                "type": "is",
+              },
+            },
+            Object {
+              "op": "and",
+              "operands": Array [
+                Object {
+                  "op": "not",
+                  "operand": Object {
+                    "args": "tagged",
                     "op": "filter",
                     "type": "is",
                   },
-                  Object {
-                    "op": "not",
-                    "operand": Object {
-                      "op": "and",
-                      "operands": Array [
-                        Object {
-                          "args": "tagged",
-                          "op": "filter",
-                          "type": "is",
-                        },
-                        Object {
-                          "args": "<55",
-                          "op": "filter",
-                          "type": "stat:total",
-                        },
-                      ],
-                    },
-                  },
-                ],
-              },
+                },
+                Object {
+                  "args": "<55",
+                  "op": "filter",
+                  "type": "stat:total",
+                },
+              ],
             },
           ],
         },
-      },
-    ],
-  },
+      ],
+    },
+  ],
 }
 `;
 
@@ -626,35 +626,35 @@ Array [
 
 exports[`parse |-source:garden -source:lastwish sunsetsafter:arrival|: ast 1`] = `
 Object {
-  "op": "not",
-  "operand": Object {
-    "op": "and",
-    "operands": Array [
-      Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "op": "not",
+      "operand": Object {
         "args": "garden",
         "op": "filter",
         "type": "source",
       },
-      Object {
-        "op": "not",
-        "operand": Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "args": "lastwish",
-              "op": "filter",
-              "type": "source",
-            },
-            Object {
-              "args": "arrival",
-              "op": "filter",
-              "type": "sunsetsafter",
-            },
-          ],
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "op": "not",
+          "operand": Object {
+            "args": "lastwish",
+            "op": "filter",
+            "type": "source",
+          },
         },
-      },
-    ],
-  },
+        Object {
+          "args": "arrival",
+          "op": "filter",
+          "type": "sunsetsafter",
+        },
+      ],
+    },
+  ],
 }
 `;
 
@@ -963,25 +963,25 @@ Object {
       "type": "is",
     },
     Object {
-      "op": "not",
-      "operand": Object {
-        "op": "and",
-        "operands": Array [
-          Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "op": "not",
+          "operand": Object {
             "args": "cluster",
             "op": "filter",
             "type": "keyword",
           },
-          Object {
-            "op": "not",
-            "operand": Object {
-              "args": "tracking module",
-              "op": "filter",
-              "type": "keyword",
-            },
+        },
+        Object {
+          "op": "not",
+          "operand": Object {
+            "args": "tracking module",
+            "op": "filter",
+            "type": "keyword",
           },
-        ],
-      },
+        },
+      ],
     },
   ],
 }
@@ -1029,25 +1029,25 @@ Object {
       "type": "is",
     },
     Object {
-      "op": "not",
-      "operand": Object {
-        "op": "and",
-        "operands": Array [
-          Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "op": "not",
+          "operand": Object {
             "args": "cluster",
             "op": "filter",
             "type": "keyword",
           },
-          Object {
-            "op": "not",
-            "operand": Object {
-              "args": "tracking module",
-              "op": "filter",
-              "type": "keyword",
-            },
+        },
+        Object {
+          "op": "not",
+          "operand": Object {
+            "args": "tracking module",
+            "op": "filter",
+            "type": "keyword",
           },
-        ],
-      },
+        },
+      ],
     },
   ],
 }
@@ -1108,22 +1108,22 @@ Object {
           ],
         },
         Object {
-          "op": "not",
-          "operand": Object {
-            "op": "and",
-            "operands": Array [
-              Object {
+          "op": "and",
+          "operands": Array [
+            Object {
+              "op": "not",
+              "operand": Object {
                 "args": "armor",
                 "op": "filter",
                 "type": "is",
               },
-              Object {
-                "args": "arrival",
-                "op": "filter",
-                "type": "modslot",
-              },
-            ],
-          },
+            },
+            Object {
+              "args": "arrival",
+              "op": "filter",
+              "type": "modslot",
+            },
+          ],
         },
       ],
     },

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should parse "grenade launcher reserves": lexer 1`] = `
+exports[`parse |"grenade launcher reserves"|: lexer 1`] = `
 Array [
   Array [
     "str",
@@ -9,67 +9,56 @@ Array [
 ]
 `;
 
-exports[`should parse (is:hunter power:>=540) or (is:warlock power:>=560): lexer 1`] = `
+exports[`parse |"수집가"|: lexer 1`] = `
 Array [
   Array [
-    "(",
-  ],
-  Array [
-    ")",
-  ],
-  Array [
-    "(",
-  ],
-  Array [
-    ")",
+    "str",
+    "수집가",
   ],
 ]
 `;
 
-exports[`should parse (is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival): lexer 1`] = `
+exports[`parse |(is:hunter power:>=540) or (is:warlock power:>=560)|: lexer 1`] = `
 Array [
   Array [
     "(",
   ],
   Array [
-    ")",
+    "word",
+    "is:hunter",
   ],
   Array [
-    "(",
+    "and",
   ],
   Array [
-    ")",
-  ],
-]
-`;
-
-exports[`should parse (is:weapon is:sniperrifle) or (is:armor modslot:arrival): lexer 1`] = `
-Array [
-  Array [
-    "(",
+    "word",
+    "power:>=540",
   ],
   Array [
     ")",
   ],
   Array [
-    "(",
+    "and",
   ],
   Array [
-    ")",
+    "or",
   ],
-]
-`;
-
-exports[`should parse -(power:>1000 and -modslot:arrival): lexer 1`] = `
-Array [
   Array [
-    "not",
+    "and",
   ],
   Array [
     "(",
   ],
   Array [
-    "not",
+    "word",
+    "is:warlock",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "power:>=560",
   ],
   Array [
     ")",
@@ -77,66 +66,356 @@ Array [
 ]
 `;
 
-exports[`should parse -is:equipped is:haspower is:incurrentchar: lexer 1`] = `
+exports[`parse |(is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival)|: lexer 1`] = `
 Array [
   Array [
+    "(",
+  ],
+  Array [
+    "word",
+    "is:weapon",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "is:sniperrifle",
+  ],
+  Array [
+    ")",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
     "not",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "word",
+    "is:armor",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "modslot:arrival",
+  ],
+  Array [
+    ")",
   ],
 ]
 `;
 
-exports[`should parse -is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55: lexer 1`] = `
+exports[`parse |(is:weapon is:sniperrifle) or (is:armor modslot:arrival)|: lexer 1`] = `
 Array [
   Array [
-    "not",
+    "(",
   ],
   Array [
-    "not",
+    "word",
+    "is:weapon",
   ],
   Array [
-    "not",
+    "and",
   ],
   Array [
-    "not",
+    "word",
+    "is:sniperrifle",
+  ],
+  Array [
+    ")",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "word",
+    "is:armor",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "modslot:arrival",
+  ],
+  Array [
+    ")",
   ],
 ]
 `;
 
-exports[`should parse -source:garden -source:lastwish sunsetsafter:arrival: lexer 1`] = `
+exports[`parse |-(power:>1000 and -modslot:arrival)|: lexer 1`] = `
 Array [
   Array [
     "not",
   ],
   Array [
+    "(",
+  ],
+  Array [
+    "word",
+    "power:>1000",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
     "not",
+  ],
+  Array [
+    "word",
+    "modslot:arrival",
+  ],
+  Array [
+    ")",
   ],
 ]
 `;
 
-exports[`should parse -witherhoard: lexer 1`] = `
+exports[`parse |-is:equipped is:haspower is:incurrentchar|: lexer 1`] = `
 Array [
   Array [
     "not",
   ],
-]
-`;
-
-exports[`should parse is:blue is:haspower -is:maxpower: lexer 1`] = `
-Array [
   Array [
-    "not",
+    "word",
+    "is:equipped",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "is:haspower",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "is:incurrentchar",
   ],
 ]
 `;
 
-exports[`should parse is:rocketlauncher -"cluster" -"tracking module": lexer 1`] = `
+exports[`parse |-is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55|: lexer 1`] = `
 Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "is:exotic",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "is:locked",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "is:maxpower",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "is:tagged",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "stat:total:<55",
+  ],
+]
+`;
+
+exports[`parse |-source:garden -source:lastwish sunsetsafter:arrival|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "source:garden",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "source:lastwish",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "sunsetsafter:arrival",
+  ],
+]
+`;
+
+exports[`parse |-witherhoard|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "witherhoard",
+  ],
+]
+`;
+
+exports[`parse |is:blue is:haspower -is:maxpower|: lexer 1`] = `
+Array [
+  Array [
+    "word",
+    "is:blue",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "is:haspower",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "word",
+    "is:maxpower",
+  ],
+]
+`;
+
+exports[`parse |is:rocketlauncher (perk:"cluster" or perk:"tracking module")|: lexer 1`] = `
+Array [
+  Array [
+    "word",
+    "is:rocketlauncher",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "word",
+    "perk:\\"cluster\\"",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "perk:\\"tracking",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "module\\"",
+  ],
+  Array [
+    ")",
+  ],
+]
+`;
+
+exports[`parse |is:rocketlauncher -"cluster" -"tracking module"|: lexer 1`] = `
+Array [
+  Array [
+    "word",
+    "is:rocketlauncher",
+  ],
+  Array [
+    "and",
+  ],
   Array [
     "not",
   ],
   Array [
     "str",
     "cluster",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
@@ -148,14 +427,24 @@ Array [
 ]
 `;
 
-exports[`should parse is:rocketlauncher -"cluster" -'tracking module': lexer 1`] = `
+exports[`parse |is:rocketlauncher -"cluster" -'tracking module'|: lexer 1`] = `
 Array [
+  Array [
+    "word",
+    "is:rocketlauncher",
+  ],
+  Array [
+    "and",
+  ],
   Array [
     "not",
   ],
   Array [
     "str",
     "cluster",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
@@ -167,38 +456,95 @@ Array [
 ]
 `;
 
-exports[`should parse name:"Gahlran's Right Hand": lexer 1`] = `
+exports[`parse |name:"Gahlran's Right Hand"|: lexer 1`] = `
 Array [
   Array [
-    "str",
-    "gahlran's right hand",
+    "word",
+    "name:\\"gahlran's",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "right",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "hand\\"",
   ],
 ]
 `;
 
-exports[`should parse name:"Hard Light": lexer 1`] = `
+exports[`parse |name:"Hard Light"|: lexer 1`] = `
 Array [
   Array [
-    "str",
-    "hard light",
+    "word",
+    "name:\\"hard",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "light\\"",
   ],
 ]
 `;
 
-exports[`should parse name:'Hard Light': lexer 1`] = `
+exports[`parse |name:'Hard Light'|: lexer 1`] = `
 Array [
   Array [
-    "str",
-    "hard light",
+    "word",
+    "name:'hard",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "light'",
   ],
 ]
 `;
 
-exports[`should parse not witherhoard: lexer 1`] = `Array []`;
+exports[`parse |not witherhoard|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "word",
+    "witherhoard",
+  ],
+]
+`;
 
-exports[`should parse perk:수집가: lexer 1`] = `Array []`;
+exports[`parse |perk:"수집가"|: lexer 1`] = `
+Array [
+  Array [
+    "word",
+    "perk:\\"수집가\\"",
+  ],
+]
+`;
 
-exports[`should parse ‘grenade launcher reserves’: lexer 1`] = `
+exports[`parse |perk:수집가|: lexer 1`] = `
+Array [
+  Array [
+    "word",
+    "perk:수집가",
+  ],
+]
+`;
+
+exports[`parse |‘grenade launcher reserves’|: lexer 1`] = `
 Array [
   Array [
     "str",
@@ -207,11 +553,20 @@ Array [
 ]
 `;
 
-exports[`should parse “grenade launcher reserves”: lexer 1`] = `
+exports[`parse |“grenade launcher reserves”|: lexer 1`] = `
 Array [
   Array [
     "str",
     "grenade launcher reserves",
+  ],
+]
+`;
+
+exports[`parse |수집가|: lexer 1`] = `
+Array [
+  Array [
+    "word",
+    "수집가",
   ],
 ]
 `;

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -815,9 +815,9 @@ Object {
     Object {
       "op": "not",
       "operand": Object {
-        "args": ":maxpower",
+        "args": "maxpower",
         "op": "filter",
-        "type": "keyword",
+        "type": "is",
       },
     },
   ],
@@ -843,12 +843,79 @@ Array [
     "implicit_and",
   ],
   Array [
+    "filter",
     "not",
+    "maxpower",
+  ],
+]
+`;
+
+exports[`parse |is:blue is:weapon or is:armor not:maxpower|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "blue",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "or",
+      "operands": Array [
+        Object {
+          "args": "weapon",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "armor",
+          "op": "filter",
+          "type": "is",
+        },
+      ],
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": "maxpower",
+        "op": "filter",
+        "type": "is",
+      },
+    },
+  ],
+}
+`;
+
+exports[`parse |is:blue is:weapon or is:armor not:maxpower|: lexer 1`] = `
+Array [
+  Array [
+    "filter",
+    "is",
+    "blue",
+  ],
+  Array [
+    "implicit_and",
   ],
   Array [
     "filter",
-    "keyword",
-    ":maxpower",
+    "is",
+    "weapon",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
+  ],
+  Array [
+    "implicit_and",
+  ],
+  Array [
+    "filter",
+    "not",
+    "maxpower",
   ],
 ]
 `;
@@ -1113,6 +1180,151 @@ Array [
 ]
 `;
 
+exports[`parse |is:weapon is:sniperrifle or is:armor and modslot:arrival|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "weapon",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "or",
+      "operands": Array [
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "armor",
+              "op": "filter",
+              "type": "is",
+            },
+            Object {
+              "args": "arrival",
+              "op": "filter",
+              "type": "modslot",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`parse |is:weapon is:sniperrifle or is:armor and modslot:arrival|: lexer 1`] = `
+Array [
+  Array [
+    "filter",
+    "is",
+    "weapon",
+  ],
+  Array [
+    "implicit_and",
+  ],
+  Array [
+    "filter",
+    "is",
+    "sniperrifle",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "filter",
+    "modslot",
+    "arrival",
+  ],
+]
+`;
+
+exports[`parse |is:weapon is:sniperrifle or not is:armor modslot:arrival|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "weapon",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "or",
+      "operands": Array [
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "op": "not",
+          "operand": Object {
+            "args": "armor",
+            "op": "filter",
+            "type": "is",
+          },
+        },
+      ],
+    },
+    Object {
+      "args": "arrival",
+      "op": "filter",
+      "type": "modslot",
+    },
+  ],
+}
+`;
+
+exports[`parse |is:weapon is:sniperrifle or not is:armor modslot:arrival|: lexer 1`] = `
+Array [
+  Array [
+    "filter",
+    "is",
+    "weapon",
+  ],
+  Array [
+    "implicit_and",
+  ],
+  Array [
+    "filter",
+    "is",
+    "sniperrifle",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
+  ],
+  Array [
+    "implicit_and",
+  ],
+  Array [
+    "filter",
+    "modslot",
+    "arrival",
+  ],
+]
+`;
+
 exports[`parse |name:"Gahlran's Right Hand"|: ast 1`] = `
 Object {
   "args": "gahlran's right hand",
@@ -1197,9 +1409,9 @@ Object {
   "operand": Object {
     "op": "not",
     "operand": Object {
-      "args": ":maxpower",
+      "args": "maxpower",
       "op": "filter",
-      "type": "keyword",
+      "type": "is",
     },
   },
 }
@@ -1211,12 +1423,30 @@ Array [
     "not",
   ],
   Array [
+    "filter",
     "not",
+    "maxpower",
   ],
+]
+`;
+
+exports[`parse |not:maxpower|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "args": "maxpower",
+    "op": "filter",
+    "type": "is",
+  },
+}
+`;
+
+exports[`parse |not:maxpower|: lexer 1`] = `
+Array [
   Array [
     "filter",
-    "keyword",
-    ":maxpower",
+    "not",
+    "maxpower",
   ],
 ]
 `;

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -1,147 +1,217 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should parse "grenade launcher reserves" 1`] = `
+exports[`should parse "grenade launcher reserves": lexer 1`] = `
 Array [
-  "\\"grenade launcher reserves\\"",
+  Array [
+    "str",
+    "grenade launcher reserves",
+  ],
 ]
 `;
 
-exports[`should parse (is:hunter power>:=540) or (is:warlock power:>=560) 1`] = `
+exports[`should parse (is:hunter power:>=540) or (is:warlock power:>=560): lexer 1`] = `
 Array [
-  "(is:hunter",
-  "power>:=540)",
-  "or",
-  "(is:warlock",
-  "power:>=560)",
+  Array [
+    "(",
+  ],
+  Array [
+    ")",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    ")",
+  ],
 ]
 `;
 
-exports[`should parse (is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival) 1`] = `
+exports[`should parse (is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival): lexer 1`] = `
 Array [
-  "(is:weapon",
-  "and",
-  "is:sniperrifle)",
-  "or",
-  "not",
-  "(is:armor",
-  "and",
-  "modslot:arrival)",
+  Array [
+    "(",
+  ],
+  Array [
+    ")",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    ")",
+  ],
 ]
 `;
 
-exports[`should parse (is:weapon is:sniperrifle) or (is:armor modslot:arrival) 1`] = `
+exports[`should parse (is:weapon is:sniperrifle) or (is:armor modslot:arrival): lexer 1`] = `
 Array [
-  "(is:weapon",
-  "is:sniperrifle)",
-  "or",
-  "(is:armor",
-  "modslot:arrival)",
+  Array [
+    "(",
+  ],
+  Array [
+    ")",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    ")",
+  ],
 ]
 `;
 
-exports[`should parse -(power:>1000 and -modslot:arrival) 1`] = `
+exports[`should parse -(power:>1000 and -modslot:arrival): lexer 1`] = `
 Array [
-  "-(power:>1000",
-  "and",
-  "-modslot:arrival)",
+  Array [
+    "not",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    ")",
+  ],
 ]
 `;
 
-exports[`should parse -is:equipped is:haspower is:incurrentchar 1`] = `
+exports[`should parse -is:equipped is:haspower is:incurrentchar: lexer 1`] = `
 Array [
-  "-is:equipped",
-  "is:haspower",
-  "is:incurrentchar",
+  Array [
+    "not",
+  ],
 ]
 `;
 
-exports[`should parse -is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55 1`] = `
+exports[`should parse -is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55: lexer 1`] = `
 Array [
-  "-is:exotic",
-  "-is:locked",
-  "-is:maxpower",
-  "-is:tagged",
-  "stat:total:<55",
+  Array [
+    "not",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "not",
+  ],
 ]
 `;
 
-exports[`should parse -source:garden -source:lastwish sunsetsafter:arrival 1`] = `
+exports[`should parse -source:garden -source:lastwish sunsetsafter:arrival: lexer 1`] = `
 Array [
-  "-source:garden",
-  "-source:lastwish",
-  "sunsetsafter:arrival",
+  Array [
+    "not",
+  ],
+  Array [
+    "not",
+  ],
 ]
 `;
 
-exports[`should parse -witherhoard 1`] = `
+exports[`should parse -witherhoard: lexer 1`] = `
 Array [
-  "-witherhoard",
+  Array [
+    "not",
+  ],
 ]
 `;
 
-exports[`should parse is:blue is:haspower -is:maxpower 1`] = `
+exports[`should parse is:blue is:haspower -is:maxpower: lexer 1`] = `
 Array [
-  "is:blue",
-  "is:haspower",
-  "-is:maxpower",
+  Array [
+    "not",
+  ],
 ]
 `;
 
-exports[`should parse is:rocketlauncher -"cluster" -"tracking module" 1`] = `
+exports[`should parse is:rocketlauncher -"cluster" -"tracking module": lexer 1`] = `
 Array [
-  "is:rocketlauncher",
-  "-\\"cluster\\"",
-  "-\\"tracking module\\"",
+  Array [
+    "not",
+  ],
+  Array [
+    "str",
+    "cluster",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "str",
+    "tracking module",
+  ],
 ]
 `;
 
-exports[`should parse is:rocketlauncher -"cluster" -'tracking module' 1`] = `
+exports[`should parse is:rocketlauncher -"cluster" -'tracking module': lexer 1`] = `
 Array [
-  "is:rocketlauncher",
-  "-\\"cluster\\"",
-  "-'tracking module'",
+  Array [
+    "not",
+  ],
+  Array [
+    "str",
+    "cluster",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "str",
+    "tracking module",
+  ],
 ]
 `;
 
-exports[`should parse name:"Gahlran's Right Hand" 1`] = `
+exports[`should parse name:"Gahlran's Right Hand": lexer 1`] = `
 Array [
-  "name:\\"gahlran's right hand\\"",
+  Array [
+    "str",
+    "gahlran's right hand",
+  ],
 ]
 `;
 
-exports[`should parse name:"Hard Light" 1`] = `
+exports[`should parse name:"Hard Light": lexer 1`] = `
 Array [
-  "name:\\"hard light\\"",
+  Array [
+    "str",
+    "hard light",
+  ],
 ]
 `;
 
-exports[`should parse name:'Hard Light' 1`] = `
+exports[`should parse name:'Hard Light': lexer 1`] = `
 Array [
-  "name:'hard light'",
+  Array [
+    "str",
+    "hard light",
+  ],
 ]
 `;
 
-exports[`should parse not witherhoard 1`] = `
+exports[`should parse not witherhoard: lexer 1`] = `Array []`;
+
+exports[`should parse perk:수집가: lexer 1`] = `Array []`;
+
+exports[`should parse ‘grenade launcher reserves’: lexer 1`] = `
 Array [
-  "not",
-  "witherhoard",
+  Array [
+    "str",
+    "grenade launcher reserves",
+  ],
 ]
 `;
 
-exports[`should parse perk:수집가 1`] = `
+exports[`should parse “grenade launcher reserves”: lexer 1`] = `
 Array [
-  "perk:수집가",
-]
-`;
-
-exports[`should parse ‘grenade launcher reserves’ 1`] = `
-Array [
-  "'grenade launcher reserves'",
-]
-`;
-
-exports[`should parse “grenade launcher reserves” 1`] = `
-Array [
-  "\\"grenade launcher reserves\\"",
+  Array [
+    "str",
+    "grenade launcher reserves",
+  ],
 ]
 `;

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -1102,6 +1102,90 @@ Array [
 ]
 `;
 
+exports[`parse |is:weapon (is:sniperrifle or (is:armor and modslot:arrival))|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "weapon",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "or",
+      "operands": Array [
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "armor",
+              "op": "filter",
+              "type": "is",
+            },
+            Object {
+              "args": "arrival",
+              "op": "filter",
+              "type": "modslot",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`parse |is:weapon (is:sniperrifle or (is:armor and modslot:arrival))|: lexer 1`] = `
+Array [
+  Array [
+    "filter",
+    "is",
+    "weapon",
+  ],
+  Array [
+    "implicit_and",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "filter",
+    "is",
+    "sniperrifle",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "filter",
+    "modslot",
+    "arrival",
+  ],
+  Array [
+    ")",
+  ],
+  Array [
+    ")",
+  ],
+]
+`;
+
 exports[`parse |is:weapon and is:sniperrifle or not is:armor and modslot:arrival|: ast 1`] = `
 Object {
   "op": "or",
@@ -1379,6 +1463,39 @@ Array [
 ]
 `;
 
+exports[`parse |not -not:maxpower|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "not",
+    "operand": Object {
+      "op": "not",
+      "operand": Object {
+        "args": "maxpower",
+        "op": "filter",
+        "type": "is",
+      },
+    },
+  },
+}
+`;
+
+exports[`parse |not -not:maxpower|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "filter",
+    "not",
+    "maxpower",
+  ],
+]
+`;
+
 exports[`parse |not forgotten|: ast 1`] = `
 Object {
   "op": "not",
@@ -1399,6 +1516,39 @@ Array [
     "filter",
     "keyword",
     "forgotten",
+  ],
+]
+`;
+
+exports[`parse |not not not:maxpower|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "not",
+    "operand": Object {
+      "op": "not",
+      "operand": Object {
+        "args": "maxpower",
+        "op": "filter",
+        "type": "is",
+      },
+    },
+  },
+}
+`;
+
+exports[`parse |not not not:maxpower|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "filter",
+    "not",
+    "maxpower",
   ],
 ]
 `;

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -92,14 +92,19 @@ Object {
       "op": "and",
       "operands": Array [
         Object {
-          "args": "hunter",
-          "op": "filter",
-          "type": "is",
-        },
-        Object {
-          "args": ">=540",
-          "op": "filter",
-          "type": "power",
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "hunter",
+              "op": "filter",
+              "type": "is",
+            },
+            Object {
+              "args": ">=540",
+              "op": "filter",
+              "type": "power",
+            },
+          ],
         },
       ],
     },
@@ -176,14 +181,19 @@ Object {
       "op": "and",
       "operands": Array [
         Object {
-          "args": "weapon",
-          "op": "filter",
-          "type": "is",
-        },
-        Object {
-          "args": "sniperrifle",
-          "op": "filter",
-          "type": "is",
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "weapon",
+              "op": "filter",
+              "type": "is",
+            },
+            Object {
+              "args": "sniperrifle",
+              "op": "filter",
+              "type": "is",
+            },
+          ],
         },
       ],
     },
@@ -266,14 +276,19 @@ Object {
       "op": "and",
       "operands": Array [
         Object {
-          "args": "weapon",
-          "op": "filter",
-          "type": "is",
-        },
-        Object {
-          "args": "sniperrifle",
-          "op": "filter",
-          "type": "is",
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "weapon",
+              "op": "filter",
+              "type": "is",
+            },
+            Object {
+              "args": "sniperrifle",
+              "op": "filter",
+              "type": "is",
+            },
+          ],
         },
       ],
     },

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should parse "grenade launcher reserves" 1`] = `
+Array [
+  "\\"grenade launcher reserves\\"",
+]
+`;
+
+exports[`should parse (is:hunter power>:=540) or (is:warlock power:>=560) 1`] = `
+Array [
+  "(is:hunter",
+  "power>:=540)",
+  "or",
+  "(is:warlock",
+  "power:>=560)",
+]
+`;
+
+exports[`should parse (is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival) 1`] = `
+Array [
+  "(is:weapon",
+  "and",
+  "is:sniperrifle)",
+  "or",
+  "not",
+  "(is:armor",
+  "and",
+  "modslot:arrival)",
+]
+`;
+
+exports[`should parse (is:weapon is:sniperrifle) or (is:armor modslot:arrival) 1`] = `
+Array [
+  "(is:weapon",
+  "is:sniperrifle)",
+  "or",
+  "(is:armor",
+  "modslot:arrival)",
+]
+`;
+
+exports[`should parse -(power:>1000 and -modslot:arrival) 1`] = `
+Array [
+  "-(power:>1000",
+  "and",
+  "-modslot:arrival)",
+]
+`;
+
+exports[`should parse -is:equipped is:haspower is:incurrentchar 1`] = `
+Array [
+  "-is:equipped",
+  "is:haspower",
+  "is:incurrentchar",
+]
+`;
+
+exports[`should parse -is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55 1`] = `
+Array [
+  "-is:exotic",
+  "-is:locked",
+  "-is:maxpower",
+  "-is:tagged",
+  "stat:total:<55",
+]
+`;
+
+exports[`should parse -source:garden -source:lastwish sunsetsafter:arrival 1`] = `
+Array [
+  "-source:garden",
+  "-source:lastwish",
+  "sunsetsafter:arrival",
+]
+`;
+
+exports[`should parse -witherhoard 1`] = `
+Array [
+  "-witherhoard",
+]
+`;
+
+exports[`should parse is:blue is:haspower -is:maxpower 1`] = `
+Array [
+  "is:blue",
+  "is:haspower",
+  "-is:maxpower",
+]
+`;
+
+exports[`should parse is:rocketlauncher -"cluster" -"tracking module" 1`] = `
+Array [
+  "is:rocketlauncher",
+  "-\\"cluster\\"",
+  "-\\"tracking module\\"",
+]
+`;
+
+exports[`should parse is:rocketlauncher -"cluster" -'tracking module' 1`] = `
+Array [
+  "is:rocketlauncher",
+  "-\\"cluster\\"",
+  "-'tracking module'",
+]
+`;
+
+exports[`should parse name:"Gahlran's Right Hand" 1`] = `
+Array [
+  "name:\\"gahlran's right hand\\"",
+]
+`;
+
+exports[`should parse name:"Hard Light" 1`] = `
+Array [
+  "name:\\"hard light\\"",
+]
+`;
+
+exports[`should parse name:'Hard Light' 1`] = `
+Array [
+  "name:'hard light'",
+]
+`;
+
+exports[`should parse not witherhoard 1`] = `
+Array [
+  "not",
+  "witherhoard",
+]
+`;
+
+exports[`should parse perk:수집가 1`] = `
+Array [
+  "perk:수집가",
+]
+`;
+
+exports[`should parse ‘grenade launcher reserves’ 1`] = `
+Array [
+  "'grenade launcher reserves'",
+]
+`;
+
+exports[`should parse “grenade launcher reserves” 1`] = `
+Array [
+  "\\"grenade launcher reserves\\"",
+]
+`;

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -133,7 +133,7 @@ Array [
     "hunter",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -155,7 +155,7 @@ Array [
     "warlock",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -307,7 +307,7 @@ Array [
     "weapon",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -329,7 +329,7 @@ Array [
     "armor",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -377,7 +377,7 @@ Array [
     "exotic",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -487,7 +487,7 @@ Array [
     "equipped",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -495,7 +495,7 @@ Array [
     "haspower",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -561,7 +561,7 @@ Array [
     "exotic",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -572,7 +572,7 @@ Array [
     "locked",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -583,7 +583,7 @@ Array [
     "maxpower",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -594,7 +594,7 @@ Array [
     "tagged",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -644,7 +644,7 @@ Array [
     "garden",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -655,7 +655,7 @@ Array [
     "lastwish",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -715,7 +715,7 @@ Array [
     "cluster",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -777,7 +777,7 @@ Array [
     "blue",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -785,7 +785,7 @@ Array [
     "haspower",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -832,7 +832,7 @@ Array [
     "blue",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "filter",
@@ -840,7 +840,7 @@ Array [
     "haspower",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -894,7 +894,7 @@ Array [
     "rocketlauncher",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "(",
@@ -955,7 +955,7 @@ Array [
     "rocketlauncher",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -966,7 +966,7 @@ Array [
     "cluster",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -1016,7 +1016,7 @@ Array [
     "rocketlauncher",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",
@@ -1027,7 +1027,7 @@ Array [
     "cluster",
   ],
   Array [
-    "and",
+    "implicit_and",
   ],
   Array [
     "not",

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -1,21 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parse |"grenade launcher reserves"|: ast 1`] = `
+Object {
+  "args": "grenade launcher reserves",
+  "op": "filter",
+  "type": "keyword",
+}
+`;
+
 exports[`parse |"grenade launcher reserves"|: lexer 1`] = `
 Array [
   Array [
-    "str",
+    "filter",
+    "keyword",
     "grenade launcher reserves",
   ],
 ]
 `;
 
+exports[`parse |"수집가"|: ast 1`] = `
+Object {
+  "args": "수집가",
+  "op": "filter",
+  "type": "keyword",
+}
+`;
+
 exports[`parse |"수집가"|: lexer 1`] = `
 Array [
   Array [
-    "str",
+    "filter",
+    "keyword",
     "수집가",
   ],
 ]
+`;
+
+exports[`parse |( power:>1000 and -modslot:arrival ) |: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": ">1000",
+      "op": "filter",
+      "type": "power",
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": "arrival",
+        "op": "filter",
+        "type": "modslot",
+      },
+    },
+  ],
+}
 `;
 
 exports[`parse |( power:>1000 and -modslot:arrival ) |: lexer 1`] = `
@@ -24,7 +63,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "power",
     ">1000",
   ],
@@ -35,7 +74,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "modslot",
     "arrival",
   ],
@@ -45,13 +84,51 @@ Array [
 ]
 `;
 
+exports[`parse |(is:hunter power:>=540) or (is:warlock power:>=560)|: ast 1`] = `
+Object {
+  "op": "or",
+  "operands": Array [
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "hunter",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": ">=540",
+          "op": "filter",
+          "type": "power",
+        },
+      ],
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "warlock",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": ">=560",
+          "op": "filter",
+          "type": "power",
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`parse |(is:hunter power:>=540) or (is:warlock power:>=560)|: lexer 1`] = `
 Array [
   Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "hunter",
   ],
@@ -59,7 +136,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "power",
     ">=540",
   ],
@@ -73,7 +150,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "warlock",
   ],
@@ -81,7 +158,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "power",
     ">=560",
   ],
@@ -91,13 +168,54 @@ Array [
 ]
 `;
 
+exports[`parse |(is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival)|: ast 1`] = `
+Object {
+  "op": "or",
+  "operands": Array [
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "weapon",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
+        },
+      ],
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "op": "and",
+        "operands": Array [
+          Object {
+            "args": "armor",
+            "op": "filter",
+            "type": "is",
+          },
+          Object {
+            "args": "arrival",
+            "op": "filter",
+            "type": "modslot",
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
 exports[`parse |(is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival)|: lexer 1`] = `
 Array [
   Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "weapon",
   ],
@@ -105,7 +223,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "sniperrifle",
   ],
@@ -122,7 +240,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "armor",
   ],
@@ -130,7 +248,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "modslot",
     "arrival",
   ],
@@ -138,6 +256,44 @@ Array [
     ")",
   ],
 ]
+`;
+
+exports[`parse |(is:weapon is:sniperrifle) or (is:armor modslot:arrival)|: ast 1`] = `
+Object {
+  "op": "or",
+  "operands": Array [
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "weapon",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "sniperrifle",
+          "op": "filter",
+          "type": "is",
+        },
+      ],
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "armor",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "arrival",
+          "op": "filter",
+          "type": "modslot",
+        },
+      ],
+    },
+  ],
+}
 `;
 
 exports[`parse |(is:weapon is:sniperrifle) or (is:armor modslot:arrival)|: lexer 1`] = `
@@ -146,7 +302,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "weapon",
   ],
@@ -154,7 +310,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "sniperrifle",
   ],
@@ -168,7 +324,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "armor",
   ],
@@ -176,7 +332,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "modslot",
     "arrival",
   ],
@@ -186,13 +342,37 @@ Array [
 ]
 `;
 
+exports[`parse |- is:exotic - (power:>1000)|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "and",
+    "operands": Array [
+      Object {
+        "args": "exotic",
+        "op": "filter",
+        "type": "is",
+      },
+      Object {
+        "op": "not",
+        "operand": Object {
+          "args": ">1000",
+          "op": "filter",
+          "type": "power",
+        },
+      },
+    ],
+  },
+}
+`;
+
 exports[`parse |- is:exotic - (power:>1000)|: lexer 1`] = `
 Array [
   Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "exotic",
   ],
@@ -206,7 +386,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "power",
     ">1000",
   ],
@@ -214,6 +394,30 @@ Array [
     ")",
   ],
 ]
+`;
+
+exports[`parse |-(power:>1000 and -modslot:arrival)|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "and",
+    "operands": Array [
+      Object {
+        "args": ">1000",
+        "op": "filter",
+        "type": "power",
+      },
+      Object {
+        "op": "not",
+        "operand": Object {
+          "args": "arrival",
+          "op": "filter",
+          "type": "modslot",
+        },
+      },
+    ],
+  },
+}
 `;
 
 exports[`parse |-(power:>1000 and -modslot:arrival)|: lexer 1`] = `
@@ -225,7 +429,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "power",
     ">1000",
   ],
@@ -236,7 +440,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "modslot",
     "arrival",
   ],
@@ -246,13 +450,44 @@ Array [
 ]
 `;
 
+exports[`parse |-is:equipped is:haspower is:incurrentchar|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "and",
+    "operands": Array [
+      Object {
+        "args": "equipped",
+        "op": "filter",
+        "type": "is",
+      },
+      Object {
+        "op": "and",
+        "operands": Array [
+          Object {
+            "args": "haspower",
+            "op": "filter",
+            "type": "is",
+          },
+          Object {
+            "args": "incurrentchar",
+            "op": "filter",
+            "type": "is",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`parse |-is:equipped is:haspower is:incurrentchar|: lexer 1`] = `
 Array [
   Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "equipped",
   ],
@@ -260,7 +495,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "haspower",
   ],
@@ -268,11 +503,71 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "incurrentchar",
   ],
 ]
+`;
+
+exports[`parse |-is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "and",
+    "operands": Array [
+      Object {
+        "args": "exotic",
+        "op": "filter",
+        "type": "is",
+      },
+      Object {
+        "op": "not",
+        "operand": Object {
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "locked",
+              "op": "filter",
+              "type": "is",
+            },
+            Object {
+              "op": "not",
+              "operand": Object {
+                "op": "and",
+                "operands": Array [
+                  Object {
+                    "args": "maxpower",
+                    "op": "filter",
+                    "type": "is",
+                  },
+                  Object {
+                    "op": "not",
+                    "operand": Object {
+                      "op": "and",
+                      "operands": Array [
+                        Object {
+                          "args": "tagged",
+                          "op": "filter",
+                          "type": "is",
+                        },
+                        Object {
+                          "args": "<55",
+                          "op": "filter",
+                          "type": "stat:total",
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+}
 `;
 
 exports[`parse |-is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55|: lexer 1`] = `
@@ -281,7 +576,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "exotic",
   ],
@@ -292,7 +587,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "locked",
   ],
@@ -303,7 +598,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "maxpower",
   ],
@@ -314,7 +609,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "tagged",
   ],
@@ -322,11 +617,45 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "stat:total",
     "<55",
   ],
 ]
+`;
+
+exports[`parse |-source:garden -source:lastwish sunsetsafter:arrival|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "and",
+    "operands": Array [
+      Object {
+        "args": "garden",
+        "op": "filter",
+        "type": "source",
+      },
+      Object {
+        "op": "not",
+        "operand": Object {
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "lastwish",
+              "op": "filter",
+              "type": "source",
+            },
+            Object {
+              "args": "arrival",
+              "op": "filter",
+              "type": "sunsetsafter",
+            },
+          ],
+        },
+      },
+    ],
+  },
+}
 `;
 
 exports[`parse |-source:garden -source:lastwish sunsetsafter:arrival|: lexer 1`] = `
@@ -335,7 +664,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "source",
     "garden",
   ],
@@ -346,7 +675,7 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "source",
     "lastwish",
   ],
@@ -354,11 +683,22 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "sunsetsafter",
     "arrival",
   ],
 ]
+`;
+
+exports[`parse |-witherhoard|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "args": "witherhoard",
+    "op": "filter",
+    "type": "keyword",
+  },
+}
 `;
 
 exports[`parse |-witherhoard|: lexer 1`] = `
@@ -367,42 +707,102 @@ Array [
     "not",
   ],
   Array [
-    "str",
+    "filter",
+    "keyword",
     "witherhoard",
   ],
 ]
 `;
 
+exports[`parse |cluster tracking|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "cluster",
+      "op": "filter",
+      "type": "keyword",
+    },
+    Object {
+      "args": "tracking",
+      "op": "filter",
+      "type": "keyword",
+    },
+  ],
+}
+`;
+
 exports[`parse |cluster tracking|: lexer 1`] = `
 Array [
   Array [
-    "str",
+    "filter",
+    "keyword",
     "cluster",
   ],
   Array [
     "and",
   ],
   Array [
-    "str",
+    "filter",
+    "keyword",
     "tracking",
   ],
 ]
 `;
 
+exports[`parse |is:armor2.0|: ast 1`] = `
+Object {
+  "args": "armor2.0",
+  "op": "filter",
+  "type": "is",
+}
+`;
+
 exports[`parse |is:armor2.0|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "is",
     "armor2.0",
   ],
 ]
 `;
 
+exports[`parse |is:blue is:haspower -is:maxpower|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "blue",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "haspower",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "op": "not",
+          "operand": Object {
+            "args": "maxpower",
+            "op": "filter",
+            "type": "is",
+          },
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`parse |is:blue is:haspower -is:maxpower|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "is",
     "blue",
   ],
@@ -410,7 +810,7 @@ Array [
     "and",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "haspower",
   ],
@@ -421,17 +821,110 @@ Array [
     "not",
   ],
   Array [
-    "keyword",
+    "filter",
     "is",
     "maxpower",
   ],
 ]
 `;
 
+exports[`parse |is:blue is:haspower not:maxpower|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "blue",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "haspower",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "op": "not",
+          "operand": Object {
+            "args": ":maxpower",
+            "op": "filter",
+            "type": "keyword",
+          },
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`parse |is:blue is:haspower not:maxpower|: lexer 1`] = `
+Array [
+  Array [
+    "filter",
+    "is",
+    "blue",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "filter",
+    "is",
+    "haspower",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "filter",
+    "keyword",
+    ":maxpower",
+  ],
+]
+`;
+
+exports[`parse |is:rocketlauncher (perk:"cluster" or perk:"tracking module")|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "rocketlauncher",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "or",
+      "operands": Array [
+        Object {
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "cluster",
+              "op": "filter",
+              "type": "perk",
+            },
+          ],
+        },
+        Object {
+          "args": "tracking module",
+          "op": "filter",
+          "type": "perk",
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`parse |is:rocketlauncher (perk:"cluster" or perk:"tracking module")|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "is",
     "rocketlauncher",
   ],
@@ -442,7 +935,7 @@ Array [
     "(",
   ],
   Array [
-    "keyword",
+    "filter",
     "perk",
     "cluster",
   ],
@@ -450,7 +943,7 @@ Array [
     "or",
   ],
   Array [
-    "keyword",
+    "filter",
     "perk",
     "tracking module",
   ],
@@ -460,10 +953,44 @@ Array [
 ]
 `;
 
+exports[`parse |is:rocketlauncher -"cluster" -"tracking module"|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "rocketlauncher",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "op": "and",
+        "operands": Array [
+          Object {
+            "args": "cluster",
+            "op": "filter",
+            "type": "keyword",
+          },
+          Object {
+            "op": "not",
+            "operand": Object {
+              "args": "tracking module",
+              "op": "filter",
+              "type": "keyword",
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
 exports[`parse |is:rocketlauncher -"cluster" -"tracking module"|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "is",
     "rocketlauncher",
   ],
@@ -474,7 +1001,8 @@ Array [
     "not",
   ],
   Array [
-    "str",
+    "filter",
+    "keyword",
     "cluster",
   ],
   Array [
@@ -484,16 +1012,51 @@ Array [
     "not",
   ],
   Array [
-    "str",
+    "filter",
+    "keyword",
     "tracking module",
   ],
 ]
+`;
+
+exports[`parse |is:rocketlauncher -"cluster" -'tracking module'|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "rocketlauncher",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "op": "and",
+        "operands": Array [
+          Object {
+            "args": "cluster",
+            "op": "filter",
+            "type": "keyword",
+          },
+          Object {
+            "op": "not",
+            "operand": Object {
+              "args": "tracking module",
+              "op": "filter",
+              "type": "keyword",
+            },
+          },
+        ],
+      },
+    },
+  ],
+}
 `;
 
 exports[`parse |is:rocketlauncher -"cluster" -'tracking module'|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "is",
     "rocketlauncher",
   ],
@@ -504,7 +1067,8 @@ Array [
     "not",
   ],
   Array [
-    "str",
+    "filter",
+    "keyword",
     "cluster",
   ],
   Array [
@@ -514,40 +1078,159 @@ Array [
     "not",
   ],
   Array [
-    "str",
+    "filter",
+    "keyword",
     "tracking module",
   ],
 ]
 `;
 
+exports[`parse |is:weapon and is:sniperrifle or not is:armor and modslot:arrival|: ast 1`] = `
+Object {
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "weapon",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "or",
+      "operands": Array [
+        Object {
+          "op": "and",
+          "operands": Array [
+            Object {
+              "args": "sniperrifle",
+              "op": "filter",
+              "type": "is",
+            },
+          ],
+        },
+        Object {
+          "op": "not",
+          "operand": Object {
+            "op": "and",
+            "operands": Array [
+              Object {
+                "args": "armor",
+                "op": "filter",
+                "type": "is",
+              },
+              Object {
+                "args": "arrival",
+                "op": "filter",
+                "type": "modslot",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`parse |is:weapon and is:sniperrifle or not is:armor and modslot:arrival|: lexer 1`] = `
+Array [
+  Array [
+    "filter",
+    "is",
+    "weapon",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "filter",
+    "is",
+    "sniperrifle",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "filter",
+    "modslot",
+    "arrival",
+  ],
+]
+`;
+
+exports[`parse |name:"Gahlran's Right Hand"|: ast 1`] = `
+Object {
+  "args": "gahlran's right hand",
+  "op": "filter",
+  "type": "name",
+}
+`;
+
 exports[`parse |name:"Gahlran's Right Hand"|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "name",
     "gahlran's right hand",
   ],
 ]
 `;
 
+exports[`parse |name:"Hard Light"|: ast 1`] = `
+Object {
+  "args": "hard light",
+  "op": "filter",
+  "type": "name",
+}
+`;
+
 exports[`parse |name:"Hard Light"|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "name",
     "hard light",
   ],
 ]
 `;
 
+exports[`parse |name:'Hard Light'|: ast 1`] = `
+Object {
+  "args": "hard light",
+  "op": "filter",
+  "type": "name",
+}
+`;
+
 exports[`parse |name:'Hard Light'|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "name",
     "hard light",
   ],
 ]
+`;
+
+exports[`parse |not forgotten|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "args": "forgotten",
+    "op": "filter",
+    "type": "keyword",
+  },
+}
 `;
 
 exports[`parse |not forgotten|: lexer 1`] = `
@@ -556,54 +1239,128 @@ Array [
     "not",
   ],
   Array [
-    "str",
+    "filter",
+    "keyword",
     "forgotten",
   ],
 ]
 `;
 
+exports[`parse |not not:maxpower|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "op": "not",
+    "operand": Object {
+      "args": ":maxpower",
+      "op": "filter",
+      "type": "keyword",
+    },
+  },
+}
+`;
+
+exports[`parse |not not:maxpower|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "filter",
+    "keyword",
+    ":maxpower",
+  ],
+]
+`;
+
+exports[`parse |perk:"수집가"|: ast 1`] = `
+Object {
+  "args": "수집가",
+  "op": "filter",
+  "type": "perk",
+}
+`;
+
 exports[`parse |perk:"수집가"|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "perk",
     "수집가",
   ],
 ]
+`;
+
+exports[`parse |perk:수집가|: ast 1`] = `
+Object {
+  "args": "수집가",
+  "op": "filter",
+  "type": "perk",
+}
 `;
 
 exports[`parse |perk:수집가|: lexer 1`] = `
 Array [
   Array [
-    "keyword",
+    "filter",
     "perk",
     "수집가",
   ],
 ]
 `;
 
+exports[`parse |‘grenade launcher reserves’|: ast 1`] = `
+Object {
+  "args": "grenade launcher reserves",
+  "op": "filter",
+  "type": "keyword",
+}
+`;
+
 exports[`parse |‘grenade launcher reserves’|: lexer 1`] = `
 Array [
   Array [
-    "str",
+    "filter",
+    "keyword",
     "grenade launcher reserves",
   ],
 ]
+`;
+
+exports[`parse |“grenade launcher reserves”|: ast 1`] = `
+Object {
+  "args": "grenade launcher reserves",
+  "op": "filter",
+  "type": "keyword",
+}
 `;
 
 exports[`parse |“grenade launcher reserves”|: lexer 1`] = `
 Array [
   Array [
-    "str",
+    "filter",
+    "keyword",
     "grenade launcher reserves",
   ],
 ]
 `;
 
+exports[`parse |수집가|: ast 1`] = `
+Object {
+  "args": "수집가",
+  "op": "filter",
+  "type": "keyword",
+}
+`;
+
 exports[`parse |수집가|: lexer 1`] = `
 Array [
   Array [
-    "str",
+    "filter",
+    "keyword",
     "수집가",
   ],
 ]

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -24,8 +24,9 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "power:>1000",
+    "keyword",
+    "power",
+    ">1000",
   ],
   Array [
     "and",
@@ -34,8 +35,9 @@ Array [
     "not",
   ],
   Array [
-    "word",
-    "modslot:arrival",
+    "keyword",
+    "modslot",
+    "arrival",
   ],
   Array [
     ")",
@@ -49,15 +51,17 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "is:hunter",
+    "keyword",
+    "is",
+    "hunter",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "power:>=540",
+    "keyword",
+    "power",
+    ">=540",
   ],
   Array [
     ")",
@@ -69,15 +73,17 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "is:warlock",
+    "keyword",
+    "is",
+    "warlock",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "power:>=560",
+    "keyword",
+    "power",
+    ">=560",
   ],
   Array [
     ")",
@@ -91,15 +97,17 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "is:weapon",
+    "keyword",
+    "is",
+    "weapon",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "is:sniperrifle",
+    "keyword",
+    "is",
+    "sniperrifle",
   ],
   Array [
     ")",
@@ -114,15 +122,17 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "is:armor",
+    "keyword",
+    "is",
+    "armor",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "modslot:arrival",
+    "keyword",
+    "modslot",
+    "arrival",
   ],
   Array [
     ")",
@@ -136,15 +146,17 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "is:weapon",
+    "keyword",
+    "is",
+    "weapon",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "is:sniperrifle",
+    "keyword",
+    "is",
+    "sniperrifle",
   ],
   Array [
     ")",
@@ -156,15 +168,17 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "is:armor",
+    "keyword",
+    "is",
+    "armor",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "modslot:arrival",
+    "keyword",
+    "modslot",
+    "arrival",
   ],
   Array [
     ")",
@@ -178,8 +192,12 @@ Array [
     "not",
   ],
   Array [
-    "word",
-    "is:exotic",
+    "keyword",
+    "is",
+    "exotic",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
@@ -188,8 +206,9 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "power:>1000",
+    "keyword",
+    "power",
+    ">1000",
   ],
   Array [
     ")",
@@ -206,8 +225,9 @@ Array [
     "(",
   ],
   Array [
-    "word",
-    "power:>1000",
+    "keyword",
+    "power",
+    ">1000",
   ],
   Array [
     "and",
@@ -216,8 +236,9 @@ Array [
     "not",
   ],
   Array [
-    "word",
-    "modslot:arrival",
+    "keyword",
+    "modslot",
+    "arrival",
   ],
   Array [
     ")",
@@ -231,22 +252,25 @@ Array [
     "not",
   ],
   Array [
-    "word",
-    "is:equipped",
+    "keyword",
+    "is",
+    "equipped",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "is:haspower",
+    "keyword",
+    "is",
+    "haspower",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "is:incurrentchar",
+    "keyword",
+    "is",
+    "incurrentchar",
   ],
 ]
 `;
@@ -257,36 +281,50 @@ Array [
     "not",
   ],
   Array [
-    "word",
-    "is:exotic",
-  ],
-  Array [
-    "not",
-  ],
-  Array [
-    "word",
-    "is:locked",
-  ],
-  Array [
-    "not",
-  ],
-  Array [
-    "word",
-    "is:maxpower",
-  ],
-  Array [
-    "not",
-  ],
-  Array [
-    "word",
-    "is:tagged",
+    "keyword",
+    "is",
+    "exotic",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "stat:total:<55",
+    "not",
+  ],
+  Array [
+    "keyword",
+    "is",
+    "locked",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "keyword",
+    "is",
+    "maxpower",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "not",
+  ],
+  Array [
+    "keyword",
+    "is",
+    "tagged",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "keyword",
+    "stat:total",
+    "<55",
   ],
 ]
 `;
@@ -297,22 +335,28 @@ Array [
     "not",
   ],
   Array [
-    "word",
-    "source:garden",
-  ],
-  Array [
-    "not",
-  ],
-  Array [
-    "word",
-    "source:lastwish",
+    "keyword",
+    "source",
+    "garden",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "sunsetsafter:arrival",
+    "not",
+  ],
+  Array [
+    "keyword",
+    "source",
+    "lastwish",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "keyword",
+    "sunsetsafter",
+    "arrival",
   ],
 ]
 `;
@@ -323,8 +367,34 @@ Array [
     "not",
   ],
   Array [
-    "word",
+    "str",
     "witherhoard",
+  ],
+]
+`;
+
+exports[`parse |cluster tracking|: lexer 1`] = `
+Array [
+  Array [
+    "str",
+    "cluster",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "str",
+    "tracking",
+  ],
+]
+`;
+
+exports[`parse |is:armor2.0|: lexer 1`] = `
+Array [
+  Array [
+    "keyword",
+    "is",
+    "armor2.0",
   ],
 ]
 `;
@@ -332,22 +402,28 @@ Array [
 exports[`parse |is:blue is:haspower -is:maxpower|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "is:blue",
+    "keyword",
+    "is",
+    "blue",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "is:haspower",
+    "keyword",
+    "is",
+    "haspower",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
   ],
   Array [
-    "word",
-    "is:maxpower",
+    "keyword",
+    "is",
+    "maxpower",
   ],
 ]
 `;
@@ -355,29 +431,28 @@ Array [
 exports[`parse |is:rocketlauncher (perk:"cluster" or perk:"tracking module")|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "is:rocketlauncher",
-  ],
-  Array [
-    "(",
-  ],
-  Array [
-    "word",
-    "perk:\\"cluster\\"",
-  ],
-  Array [
-    "or",
-  ],
-  Array [
-    "word",
-    "perk:\\"tracking",
+    "keyword",
+    "is",
+    "rocketlauncher",
   ],
   Array [
     "and",
   ],
   Array [
-    "word",
-    "module\\"",
+    "(",
+  ],
+  Array [
+    "keyword",
+    "perk",
+    "cluster",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "keyword",
+    "perk",
+    "tracking module",
   ],
   Array [
     ")",
@@ -388,8 +463,12 @@ Array [
 exports[`parse |is:rocketlauncher -"cluster" -"tracking module"|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "is:rocketlauncher",
+    "keyword",
+    "is",
+    "rocketlauncher",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
@@ -397,6 +476,9 @@ Array [
   Array [
     "str",
     "cluster",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
@@ -411,8 +493,12 @@ Array [
 exports[`parse |is:rocketlauncher -"cluster" -'tracking module'|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "is:rocketlauncher",
+    "keyword",
+    "is",
+    "rocketlauncher",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
@@ -420,6 +506,9 @@ Array [
   Array [
     "str",
     "cluster",
+  ],
+  Array [
+    "and",
   ],
   Array [
     "not",
@@ -434,22 +523,9 @@ Array [
 exports[`parse |name:"Gahlran's Right Hand"|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "name:\\"gahlran's",
-  ],
-  Array [
-    "and",
-  ],
-  Array [
-    "word",
-    "right",
-  ],
-  Array [
-    "and",
-  ],
-  Array [
-    "word",
-    "hand\\"",
+    "keyword",
+    "name",
+    "gahlran's right hand",
   ],
 ]
 `;
@@ -457,15 +533,9 @@ Array [
 exports[`parse |name:"Hard Light"|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "name:\\"hard",
-  ],
-  Array [
-    "and",
-  ],
-  Array [
-    "word",
-    "light\\"",
+    "keyword",
+    "name",
+    "hard light",
   ],
 ]
 `;
@@ -473,27 +543,21 @@ Array [
 exports[`parse |name:'Hard Light'|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "name:'hard",
-  ],
-  Array [
-    "and",
-  ],
-  Array [
-    "word",
-    "light'",
+    "keyword",
+    "name",
+    "hard light",
   ],
 ]
 `;
 
-exports[`parse |not witherhoard|: lexer 1`] = `
+exports[`parse |not forgotten|: lexer 1`] = `
 Array [
   Array [
     "not",
   ],
   Array [
-    "word",
-    "witherhoard",
+    "str",
+    "forgotten",
   ],
 ]
 `;
@@ -501,8 +565,9 @@ Array [
 exports[`parse |perk:"수집가"|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "perk:\\"수집가\\"",
+    "keyword",
+    "perk",
+    "수집가",
   ],
 ]
 `;
@@ -510,8 +575,9 @@ Array [
 exports[`parse |perk:수집가|: lexer 1`] = `
 Array [
   Array [
-    "word",
-    "perk:수집가",
+    "keyword",
+    "perk",
+    "수집가",
   ],
 ]
 `;
@@ -537,7 +603,7 @@ Array [
 exports[`parse |수집가|: lexer 1`] = `
 Array [
   Array [
-    "word",
+    "str",
     "수집가",
   ],
 ]

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -463,19 +463,14 @@ Object {
       },
     },
     Object {
-      "op": "and",
-      "operands": Array [
-        Object {
-          "args": "haspower",
-          "op": "filter",
-          "type": "is",
-        },
-        Object {
-          "args": "incurrentchar",
-          "op": "filter",
-          "type": "is",
-        },
-      ],
+      "args": "haspower",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "args": "incurrentchar",
+      "op": "filter",
+      "type": "is",
     },
   ],
 }
@@ -523,48 +518,33 @@ Object {
       },
     },
     Object {
-      "op": "and",
-      "operands": Array [
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": "locked",
-            "op": "filter",
-            "type": "is",
-          },
-        },
-        Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "op": "not",
-              "operand": Object {
-                "args": "maxpower",
-                "op": "filter",
-                "type": "is",
-              },
-            },
-            Object {
-              "op": "and",
-              "operands": Array [
-                Object {
-                  "op": "not",
-                  "operand": Object {
-                    "args": "tagged",
-                    "op": "filter",
-                    "type": "is",
-                  },
-                },
-                Object {
-                  "args": "<55",
-                  "op": "filter",
-                  "type": "stat:total",
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      "op": "not",
+      "operand": Object {
+        "args": "locked",
+        "op": "filter",
+        "type": "is",
+      },
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": "maxpower",
+        "op": "filter",
+        "type": "is",
+      },
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": "tagged",
+        "op": "filter",
+        "type": "is",
+      },
+    },
+    Object {
+      "args": "<55",
+      "op": "filter",
+      "type": "stat:total",
     },
   ],
 }
@@ -637,22 +617,17 @@ Object {
       },
     },
     Object {
-      "op": "and",
-      "operands": Array [
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": "lastwish",
-            "op": "filter",
-            "type": "source",
-          },
-        },
-        Object {
-          "args": "arrival",
-          "op": "filter",
-          "type": "sunsetsafter",
-        },
-      ],
+      "op": "not",
+      "operand": Object {
+        "args": "lastwish",
+        "op": "filter",
+        "type": "source",
+      },
+    },
+    Object {
+      "args": "arrival",
+      "op": "filter",
+      "type": "sunsetsafter",
     },
   ],
 }
@@ -778,22 +753,17 @@ Object {
       "type": "is",
     },
     Object {
-      "op": "and",
-      "operands": Array [
-        Object {
-          "args": "haspower",
-          "op": "filter",
-          "type": "is",
-        },
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": "maxpower",
-            "op": "filter",
-            "type": "is",
-          },
-        },
-      ],
+      "args": "haspower",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": "maxpower",
+        "op": "filter",
+        "type": "is",
+      },
     },
   ],
 }
@@ -838,22 +808,17 @@ Object {
       "type": "is",
     },
     Object {
-      "op": "and",
-      "operands": Array [
-        Object {
-          "args": "haspower",
-          "op": "filter",
-          "type": "is",
-        },
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": ":maxpower",
-            "op": "filter",
-            "type": "keyword",
-          },
-        },
-      ],
+      "args": "haspower",
+      "op": "filter",
+      "type": "is",
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": ":maxpower",
+        "op": "filter",
+        "type": "keyword",
+      },
     },
   ],
 }
@@ -963,25 +928,20 @@ Object {
       "type": "is",
     },
     Object {
-      "op": "and",
-      "operands": Array [
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": "cluster",
-            "op": "filter",
-            "type": "keyword",
-          },
-        },
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": "tracking module",
-            "op": "filter",
-            "type": "keyword",
-          },
-        },
-      ],
+      "op": "not",
+      "operand": Object {
+        "args": "cluster",
+        "op": "filter",
+        "type": "keyword",
+      },
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": "tracking module",
+        "op": "filter",
+        "type": "keyword",
+      },
     },
   ],
 }
@@ -1029,25 +989,20 @@ Object {
       "type": "is",
     },
     Object {
-      "op": "and",
-      "operands": Array [
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": "cluster",
-            "op": "filter",
-            "type": "keyword",
-          },
-        },
-        Object {
-          "op": "not",
-          "operand": Object {
-            "args": "tracking module",
-            "op": "filter",
-            "type": "keyword",
-          },
-        },
-      ],
+      "op": "not",
+      "operand": Object {
+        "args": "cluster",
+        "op": "filter",
+        "type": "keyword",
+      },
+    },
+    Object {
+      "op": "not",
+      "operand": Object {
+        "args": "tracking module",
+        "op": "filter",
+        "type": "keyword",
+      },
     },
   ],
 }
@@ -1090,16 +1045,16 @@ Object {
   "op": "and",
   "operands": Array [
     Object {
-      "args": "weapon",
-      "op": "filter",
-      "type": "is",
-    },
-    Object {
       "op": "or",
       "operands": Array [
         Object {
           "op": "and",
           "operands": Array [
+            Object {
+              "args": "weapon",
+              "op": "filter",
+              "type": "is",
+            },
             Object {
               "args": "sniperrifle",
               "op": "filter",
@@ -1108,24 +1063,19 @@ Object {
           ],
         },
         Object {
-          "op": "and",
-          "operands": Array [
-            Object {
-              "op": "not",
-              "operand": Object {
-                "args": "armor",
-                "op": "filter",
-                "type": "is",
-              },
-            },
-            Object {
-              "args": "arrival",
-              "op": "filter",
-              "type": "modslot",
-            },
-          ],
+          "op": "not",
+          "operand": Object {
+            "args": "armor",
+            "op": "filter",
+            "type": "is",
+          },
         },
       ],
+    },
+    Object {
+      "args": "arrival",
+      "op": "filter",
+      "type": "modslot",
     },
   ],
 }

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -5,6 +5,7 @@ import { parseQuery, lexer, Token } from './query-parser';
 
 // TODO: explicit "and" should have higher precedence than "or", but implicit "and" should have *lower* precedence than "or"
 // TODO: test "not not not", nested parens, etc
+// TODO: failed parse - a failed parse should return the parts that didn't fail plus an error code??
 
 // Some of these are contrived, some are from past search parsing issues
 const cases = [

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -1,0 +1,30 @@
+import { parseQuery } from './query-parser';
+
+// Some of these are contrived, some are from past search parsing issues
+const cases = [
+  ['is:blue is:haspower -is:maxpower'],
+  ['-is:equipped is:haspower is:incurrentchar'],
+  ['-source:garden -source:lastwish sunsetsafter:arrival'],
+  ['-is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55'],
+  ['(is:weapon is:sniperrifle) or (is:armor modslot:arrival)'],
+  ['(is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival)'],
+  ['-(power:>1000 and -modslot:arrival)'],
+  ['name:"Hard Light"'],
+  ["name:'Hard Light'"],
+  ['name:"Gahlran\'s Right Hand"'],
+  ['not witherhoard'],
+  ['-witherhoard'],
+  ['perk:수집가'],
+  ['is:rocketlauncher -"cluster" -"tracking module"'],
+  ['is:rocketlauncher -"cluster" -\'tracking module\''],
+  ['(is:hunter power>:=540) or (is:warlock power:>=560)'],
+  ['"grenade launcher reserves"'],
+  // These test copy/pasting from somewhere that automatically converts quotes to "smart quotes"
+  ['“grenade launcher reserves”'],
+  ['‘grenade launcher reserves’'],
+];
+
+test.each(cases)('should parse %s', (query) => {
+  const parsed = parseQuery(query);
+  expect(parsed).toMatchSnapshot();
+});

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -1,15 +1,21 @@
 import { parseQuery, lexer, Token } from './query-parser';
 
-// TODO: crazy whitespace combinations
+// To update the snapshots, run:
+// npx jest --updateSnapshot src/app/search/query-parser.test.ts
+
+// TODO: explicit "and" should have higher precedence than "or", but implicit "and" should have *lower* precedence than "or"
 
 // Some of these are contrived, some are from past search parsing issues
 const cases = [
   ['is:blue is:haspower -is:maxpower'],
+  ['is:blue is:haspower not:maxpower'],
+  ['not not:maxpower'],
   ['-is:equipped is:haspower is:incurrentchar'],
   ['-source:garden -source:lastwish sunsetsafter:arrival'],
   ['-is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55'],
   ['(is:weapon is:sniperrifle) or (is:armor modslot:arrival)'],
   ['(is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival)'],
+  ['is:weapon and is:sniperrifle or not is:armor and modslot:arrival'], // => is:weapon (is:sniperrifle or -is:armor) modslot:arrival
   ['-(power:>1000 and -modslot:arrival)'],
   ['( power:>1000 and -modslot:arrival ) '],
   ['- is:exotic - (power:>1000)'],
@@ -43,5 +49,6 @@ test.each(cases)('parse |%s|', (query) => {
   expect(tokens).toMatchSnapshot('lexer');
 
   // Test the full parse tree
-  parseQuery(query);
+  const ast = parseQuery(query);
+  expect(ast).toMatchSnapshot('ast');
 });

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -13,10 +13,12 @@ const cases = [
   ['-(power:>1000 and -modslot:arrival)'],
   ['( power:>1000 and -modslot:arrival ) '],
   ['- is:exotic - (power:>1000)'],
+  ['is:armor2.0'],
+  ['not forgotten'], // => -"forgotten"
+  ['cluster tracking'], // => "cluster" and "tracking"
   ['name:"Hard Light"'],
   ["name:'Hard Light'"],
   ['name:"Gahlran\'s Right Hand"'],
-  ['not witherhoard'],
   ['-witherhoard'],
   ['perk:수집가'],
   ['perk:"수집가"'],

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -4,6 +4,7 @@ import { parseQuery, lexer, Token } from './query-parser';
 // npx jest --updateSnapshot src/app/search/query-parser.test.ts
 
 // TODO: explicit "and" should have higher precedence than "or", but implicit "and" should have *lower* precedence than "or"
+// TODO: test "not not not", nested parens, etc
 
 // Some of these are contrived, some are from past search parsing issues
 const cases = [

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -11,6 +11,8 @@ const cases = [
   ['(is:weapon is:sniperrifle) or (is:armor modslot:arrival)'],
   ['(is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival)'],
   ['-(power:>1000 and -modslot:arrival)'],
+  ['( power:>1000 and -modslot:arrival ) '],
+  ['- is:exotic - (power:>1000)'],
   ['name:"Hard Light"'],
   ["name:'Hard Light'"],
   ['name:"Gahlran\'s Right Hand"'],

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -1,4 +1,6 @@
-import { parseQuery } from './query-parser';
+import { parseQuery, lexer, Token } from './query-parser';
+
+// TODO: crazy whitespace combinations
 
 // Some of these are contrived, some are from past search parsing issues
 const cases = [
@@ -15,8 +17,12 @@ const cases = [
   ['not witherhoard'],
   ['-witherhoard'],
   ['perk:수집가'],
+  ['perk:"수집가"'],
+  ['"수집가"'],
+  ['수집가'],
   ['is:rocketlauncher -"cluster" -"tracking module"'],
   ['is:rocketlauncher -"cluster" -\'tracking module\''],
+  ['is:rocketlauncher (perk:"cluster" or perk:"tracking module")'],
   ['(is:hunter power:>=540) or (is:warlock power:>=560)'],
   ['"grenade launcher reserves"'],
   // These test copy/pasting from somewhere that automatically converts quotes to "smart quotes"
@@ -24,7 +30,14 @@ const cases = [
   ['‘grenade launcher reserves’'],
 ];
 
-test.each(cases)('should parse %s', (query) => {
-  const parsed = parseQuery(query);
-  expect(parsed).toMatchSnapshot('lexer');
+test.each(cases)('parse |%s|', (query) => {
+  // Test just the lexer
+  const tokens: Token[] = [];
+  for (const t of lexer(query)) {
+    tokens.push(t);
+  }
+  expect(tokens).toMatchSnapshot('lexer');
+
+  // Test the full parse tree
+  parseQuery(query);
 });

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -3,15 +3,15 @@ import { parseQuery, lexer, Token } from './query-parser';
 // To update the snapshots, run:
 // npx jest --updateSnapshot src/app/search/query-parser.test.ts
 
-// TODO: explicit "and" should have higher precedence than "or", but implicit "and" should have *lower* precedence than "or"
-// TODO: test "not not not", nested parens, etc
 // TODO: failed parse - a failed parse should return the parts that didn't fail plus an error code??
 
 // Some of these are contrived, some are from past search parsing issues
 const cases = [
   ['is:blue is:haspower -is:maxpower'],
   ['is:blue is:haspower not:maxpower'],
-  ['not:maxpower'], // => is:blue and (is:weapon or is:armor) and -is:maxpower
+  ['not:maxpower'],
+  ['not -not:maxpower'],
+  ['not not not:maxpower'],
   ['is:blue is:weapon or is:armor not:maxpower'], // => is:blue and (is:weapon or is:armor) and -is:maxpower
   ['not not:maxpower'],
   ['-is:equipped is:haspower is:incurrentchar'],
@@ -22,6 +22,7 @@ const cases = [
   ['is:weapon and is:sniperrifle or not is:armor and modslot:arrival'], // => (is:weapon and is:sniperrifle) or (-is:armor and modslot:arrival)
   ['is:weapon is:sniperrifle or not is:armor modslot:arrival'], // => is:weapon and (is:sniperrifle or -is:armor) and modslot:arrival
   ['is:weapon is:sniperrifle or is:armor and modslot:arrival'], // => is:weapon and (is:sniperrifle or (-is:armor modslot:arrival))
+  ['is:weapon (is:sniperrifle or (is:armor and modslot:arrival))'], // => is:weapon and (is:sniperrifle or (-is:armor modslot:arrival))
   ['-(power:>1000 and -modslot:arrival)'],
   ['( power:>1000 and -modslot:arrival ) '],
   ['- is:exotic - (power:>1000)'],
@@ -65,6 +66,10 @@ const equivalentSearches = [
   [
     'is:weapon is:sniperrifle or is:armor and modslot:arrival',
     'is:weapon and (is:sniperrifle or (is:armor and modslot:arrival))',
+  ],
+  [
+    'is:rocketlauncher perk:"cluster" or perk:"tracking module"',
+    'is:rocketlauncher (perk:"cluster" or perk:"tracking module")',
   ],
 ];
 

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -17,7 +17,7 @@ const cases = [
   ['perk:수집가'],
   ['is:rocketlauncher -"cluster" -"tracking module"'],
   ['is:rocketlauncher -"cluster" -\'tracking module\''],
-  ['(is:hunter power>:=540) or (is:warlock power:>=560)'],
+  ['(is:hunter power:>=540) or (is:warlock power:>=560)'],
   ['"grenade launcher reserves"'],
   // These test copy/pasting from somewhere that automatically converts quotes to "smart quotes"
   ['“grenade launcher reserves”'],
@@ -26,5 +26,5 @@ const cases = [
 
 test.each(cases)('should parse %s', (query) => {
   const parsed = parseQuery(query);
-  expect(parsed).toMatchSnapshot();
+  expect(parsed).toMatchSnapshot('lexer');
 });

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -1,0 +1,41 @@
+/*
+is:blue is:haspower -is:maxpower
+-is:equipped is:haspower is:incurrentchar
+-source:garden -source:lastwish sunsetsafter:arrival
+-is:exotic -is:locked -is:maxpower -is:tagged stat:total:<55
+(is:weapon is:sniperrifle) or (is:armor modslot:arrival)
+(is:weapon and is:sniperrifle) or not (is:armor and modslot:arrival)
+-(power:>1000 and -modslot:arrival)
+*/
+
+/*
+; Lazy BNF diagram of our search grammar
+<query> ::= <term> | <term> <term>
+<clause> ::= <opt-whitespace> <clause>
+<terms> ::= <term> { " " <term>}
+<term> ::= <string> | <filter> | <group> | <boolean>
+<filter> ::= ["-"]<filterName>:<filterValue>[<operator><number>]
+<filterName> ::= <the set of known filter names - is, notes, perks, tag, stat, etc.>
+<filterValue> ::= <keyword> | "stat:" <statName> | <string>
+<keyword> ::= <the set of known keyword filters - locked, sniperrifle, tagged, etc.>
+<statName> ::= <the set of known stat keywords - charge, impact, resilience, etc.>
+<operator> ::= "none" | "=" | "<" | "<=" | ">" | ">="
+; Numbers are positive only, but don't need to be
+<number> ::= DIGIT{DIGIT}
+<group> ::= "(" <query> ")"
+<boolean> ::= "or" | "not" | "and"
+; Strings are basically anything within matching quotes, either single or double
+<string> ::= WORD | "\"" WORD {" " WORD} "\"" | "'" WORD {" " WORD} "'\"'"
+*/
+
+export function parseQuery(query: string) {
+  query = query.trim().toLowerCase();
+
+  // http://blog.tatedavies.com/2012/08/28/replace-microsoft-chars-in-javascript/
+  query = query.replace(/[\u2018|\u2019|\u201A]/g, "'");
+  query = query.replace(/[\u201C|\u201D|\u201E]/g, '"');
+  // \S*?(["']).*?\1 -> match `is:"stuff here"` or `is:'stuff here'`
+  // [^\s"']+ -> match is:stuff
+  const searchTerms = query.match(/\S*?(["']).*?\1|[^\s"']+/g) || [];
+  return searchTerms;
+}

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -28,8 +28,12 @@ is:blue is:haspower -is:maxpower
 <string> ::= WORD | "\"" WORD {" " WORD} "\"" | "'" WORD {" " WORD} "'\"'"
 */
 
-type Token = [TokenType] | [TokenType, string];
+export type Token = [TokenType] | [TokenType, string];
 
+/**
+ * The query parser first lexes the string, then parses it into an AST representing the logical
+ * structure of the query.
+ */
 export function parseQuery(query: string) {
   query = query.trim().toLowerCase();
 
@@ -51,8 +55,12 @@ export function parseQuery(query: string) {
   return tokens;
 }
 
-type TokenType = '(' | ')' | 'not' | 'str';
+type TokenType = '(' | ')' | 'not' | 'or' | 'and' | 'str' | 'word';
 
+/**
+ * The lexer yields a series of tokens representing the linear structure of the search query.
+ * This throws an exception if it finds an invalid input.
+ */
 export function* lexer(query: string): Generator<Token> {
   query = query.trim().toLowerCase();
 
@@ -60,46 +68,99 @@ export function* lexer(query: string): Generator<Token> {
   query = query.replace(/[\u2018|\u2019|\u201A]/g, "'");
   query = query.replace(/[\u201C|\u201D|\u201E]/g, '"');
 
+  let match: string | undefined;
   let i = 0;
+
+  const consume = (str: string) => (i += str.length);
+
   while (i < query.length) {
     const char = query[i];
+    const startingIndex = i;
 
-    switch (char) {
-      case '(':
-      case ')':
-        yield [char];
-        break;
-      case '"':
-      case "'":
-        {
-          const quote = char;
-          const remain = query.slice(i + 1);
-          const re = new RegExp('(.*?)' + quote, 'g');
-          re.lastIndex = i + 1;
-          if (re.test(query)) {
-            const str = query.slice(i + 1, re.lastIndex - 1);
-            console.log(i, remain, str);
-            if (str) {
-              i += str.length + 1;
-              yield ['str', str];
-            } else {
-              throw new Error('Unterminated quotes: |' + remain + '| ' + i);
-            }
-          }
-        }
-        break;
-      case '-':
-        yield ['not'];
-        break;
-      case ' ':
-        break;
+    if (char === '(' || char === ')') {
+      // Start/end group
+      // TODO: use whitespace tolerant regex??
+      consume(char);
+      yield [char];
+    } else if (char === '"' || char === "'") {
+      // Quoted string
+      consume(char);
+      const quote = char;
+      // TODO: cache regexp?
+      if ((match = extract(query, i, new RegExp('(.*?)' + quote, 'y'))) !== undefined) {
+        consume(match);
+        // Slice off the last character
+        yield ['str', match.slice(0, match.length - 1)];
+      } else {
+        throw new Error('Unterminated quotes: |' + query.slice(i) + '| ' + i);
+      }
+    } else if (char === '-') {
+      // TODO: whitespace-tolerant regex
+      // minus sign is the same as "not"
+      consume(char);
+      yield ['not'];
+    } else if ((match = extract(query, i, /(not|or|and)/y)) !== undefined) {
+      // boolean keywords
+      consume(match);
+      yield [match as TokenType];
+    } else if ((match = extract(query, i, /[^\s)]+/y)) !== undefined) {
+      // bare words that aren't keywords
+      consume(match);
+      yield ['word', match];
+    } else if ((match = extract(query, i, /\s+/y)) !== undefined) {
+      consume(match);
+      yield ['and'];
+    } else {
+      throw new Error(
+        'unrecognized: |' +
+          query.slice(i) +
+          '| ' +
+          i +
+          ' wtf: ' +
+          /^[^\s)]+/g.test(query.slice(i)) +
+          '|' +
+          (match = extract(query, i, /^[^\s)]+/g)) +
+          '|' +
+          ' :: ' +
+          /^\s+/g.test(query.slice(i)) +
+          '|' +
+          (match = extract(query, i, /^\s+/g)) +
+          '|'
+      );
     }
 
-    i++;
+    if (startingIndex === i) {
+      throw new Error('bug: forgot to consume characters');
+    }
+  }
+}
+
+/**
+ * If `str` matches `re` starting at `index`, return the matched portion of the string. Otherwise return undefined.
+ * This avoids having to make slices of strings just to start the regex in the middle of a string.
+ *
+ * Note that regexes passed to this must have the "sticky" flag set (y) and should not use ^, which will match the
+ * beginning of the string, ignoring the index we want to start from. The sticky flag ensures our regex will match
+ * based on the beginning of the string.
+ */
+function extract(str: string, index: number, re: RegExp): string | undefined {
+  // These checks only run in unit tests
+  if ($DIM_FLAVOR === 'test') {
+    if (!re.sticky) {
+      throw new Error('regexp must be sticky');
+    }
+    if (re.source.startsWith('^')) {
+      throw new Error('regexp cannot start with ^ and be repositioned');
+    }
   }
 
-  // \S*?(["']).*?\1 -> match `is:"stuff here"` or `is:'stuff here'`
-  // [^\s"']+ -> match is:stuff
-  //const searchTerms = query.match(/\S*?(["']).*?\1|[^\s"']+/g) || [];
-  //return searchTerms;
+  re.lastIndex = index;
+  const match = re.exec(str);
+  if (match) {
+    const result = match[0];
+    if (result.length > 0) {
+      return result;
+    }
+  }
+  return undefined;
 }

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -77,11 +77,11 @@ export function* lexer(query: string): Generator<Token> {
     const char = query[i];
     const startingIndex = i;
 
-    if (char === '(' || char === ')') {
+    if ((match = extract(query, i, /\s*(\(|\))\s*/y)) !== undefined) {
       // Start/end group
       // TODO: use whitespace tolerant regex??
-      consume(char);
-      yield [char];
+      consume(match);
+      yield [match.trim() as TokenType];
     } else if (char === '"' || char === "'") {
       // Quoted string
       consume(char);
@@ -94,15 +94,14 @@ export function* lexer(query: string): Generator<Token> {
       } else {
         throw new Error('Unterminated quotes: |' + query.slice(i) + '| ' + i);
       }
-    } else if (char === '-') {
-      // TODO: whitespace-tolerant regex
+    } else if ((match = extract(query, i, /\s*-\s*/y)) !== undefined) {
       // minus sign is the same as "not"
-      consume(char);
+      consume(match);
       yield ['not'];
-    } else if ((match = extract(query, i, /(not|or|and)/y)) !== undefined) {
+    } else if ((match = extract(query, i, /\s*(not|or|and)\s*/y)) !== undefined) {
       // boolean keywords
       consume(match);
-      yield [match as TokenType];
+      yield [match.trim() as TokenType];
     } else if ((match = extract(query, i, /[^\s)]+/y)) !== undefined) {
       // bare words that aren't keywords
       consume(match);

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -103,7 +103,6 @@ const operators = {
 export function parseQuery(query: string): QueryAST {
   // This implements operator precedence via this mechanism:
   // https://eli.thegreenplace.net/2012/08/02/parsing-expressions-by-precedence-climbing
-  // TODO: stop and return what we have in case of an error
 
   /**
    * This extracts the next "atom" aka "value" from the token stream. An atom is either
@@ -301,7 +300,6 @@ export function* lexer(query: string): Generator<Token> {
   const consumeString = (startingQuoteChar: string) => {
     // Quoted string
     consume(startingQuoteChar);
-    // TODO: cache regexp?
     if ((match = extract(quoteRegexes[startingQuoteChar])) !== undefined) {
       // Slice off the last character
       return match.slice(0, match.length - 1);

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -152,6 +152,7 @@ export function parseQuery(query: string): QueryAST {
           }
           break;
         case 'and':
+        case 'implicit_and':
           {
             if (ast.op === 'and') {
               ast.operands.push(parse(tokens, true));
@@ -214,7 +215,7 @@ export function parseQuery(query: string): QueryAST {
   return ast;
 }
 
-type NoArgTokenType = '(' | ')' | 'not' | 'or' | 'and';
+type NoArgTokenType = '(' | ')' | 'not' | 'or' | 'and' | 'implicit_and';
 export type Token = [NoArgTokenType] | ['filter', string, string];
 
 /**
@@ -364,7 +365,7 @@ export function* lexer(query: string): Generator<Token> {
       // bare words that aren't keywords are effectively "keyword" type filters
       yield ['filter', 'keyword', match];
     } else if ((match = extract(whitespace)) !== undefined) {
-      yield ['and'];
+      yield ['implicit_and'];
     } else {
       throw new Error('unrecognized tokens: |' + query.slice(i) + '| ' + i);
     }


### PR DESCRIPTION
This implements a brand new, real query parser for our search syntax, instead of the fragile regex-based system we had before. I'm not using it anywhere, but it has tests which is new :-). Please look at the tests to see how this is behaving. This code produces an abstract syntax tree (AST) which can then be passed on to a separate function that builds a filter function out of it by mapping filters to our table of filter function definitions.

There are some changes and new capabilities. In general I favored compatibility with what we had, so every old search will work with the same semantics under this new system.

* Queries now support parentheses for grouping subqueries: `(is:weapon is:sniperrifle) or (is:armor modslot:arrival)` - this is something we couldn't achieve before.
* There are now `and` and `not` keywords to complement `or`. 
  * `not` is exactly equivalent to `-` (which still works), though you may now have whitespace after `-` as well (e.g `- is:maxpower`)
  * As a weird consequence of having a `not` keyword, the search `not forgotten` now means `-"forgotten"` which is the only non-backwards-compatible semantic change. We could conceivably special case queries that have no keywords and no filter functions mentioned and treat them as a complete string search (`not forgotten` => `"not forgotten"`) but that gets rid of the ability to just lazily type words and mostly get to what you want (e.g. `hammerhead surrounded`)
  * `and` has higher precedence than `or`, which in turn has higher precedence than the original "implicit" and which was just a space. Thus `is:weapon is:sniperrifle or is:armor modslot:arrival` is equivalent to `is:weapon and (is:sniperrifle or is:armor) and modslot:arrival`, while `is:weapon and is:sniperrifle or is:armor and modslot:arrival` is equivalent to `(is:weapon and is:sniperrifle) or (is:armor and modslot:arrival)`.
* `not:` queries (not to be confused with the `not` keyword) are automatically translated into `-is:` queries during parsing, so the filter function generator doesn't need to know about that anymore. (e.g. `not:haspower` gets parsed as if it were `-is:haspower`)
* Query parsing tries to be error-resilient - you should still get part of a usable query even if some of it is invalid.
* There is a `canonicalizeQuery` function which can take the parsed AST and turn it back into a string, but in a stable format. This is intended for saved/recent searches so we save a "standardized" form of the query, the better to be able to count them across different usages and users (e.g. if you type a semantically equivalent query as one of your favorites it'll count as a usage of that favorite instead of adding a new recent entry).
* Tests use Jest's snapshot testing ability, which means you simply regenerate snapshots after changing code and then look at the diffs and decide if it's still doing what you want. It's a nice way to assert the behavior of a lot of complex stuff.