### PR TITLE
Chore/move mod filters to worker sort solution

### DIFF
--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -18,7 +18,7 @@ import {
   ProcessSocket,
   ProcessSockets,
 } from '../processWorker/types';
-import { getSpecialtySocketCategoryHash } from 'app/utils/item-utils';
+import { getSpecialtySocketCategoryHash, getSpecialtySocketMetadata } from 'app/utils/item-utils';
 
 interface ProcessState {
   processing: boolean;
@@ -217,6 +217,7 @@ function mapDimItemToProcessItem(dimItem: D2Item): ProcessItem {
     stats: statMap,
     sockets: dimItem.sockets && mapDimSocketsToProcessSockets(dimItem.sockets),
     energyType: dimItem.energy?.energyType,
+    season: getSpecialtySocketMetadata(dimItem)?.tag,
     specialtySocketCategoryHash: getSpecialtySocketCategoryHash(dimItem),
   };
 }

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -246,7 +246,7 @@ function mapDimItemToProcessItem(dimItem: D2Item): ProcessItem {
     sockets: dimItem.sockets && mapDimSocketsToProcessSockets(dimItem.sockets),
     energyType: dimItem.energy?.energyType,
     season: modMetadata?.season,
-    modSeasons: modMetadata?.compatibleTags,
+    compatibleModSeasons: modMetadata?.compatibleTags,
   };
 }
 

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -18,7 +18,11 @@ import {
   ProcessSocket,
   ProcessSockets,
 } from '../processWorker/types';
-import { getSpecialtySocketCategoryHash, getSpecialtySocketMetadata } from 'app/utils/item-utils';
+import {
+  getSpecialtySocketCategoryHash,
+  getSpecialtySocketMetadata,
+  getSpecialtySocketMetadataByPlugCategoryHash,
+} from 'app/utils/item-utils';
 
 interface ProcessState {
   processing: boolean;
@@ -88,7 +92,7 @@ export function useProcess(
       .process(
         processItems,
         lockedItems,
-        lockedSeasonalMods,
+        mapSeasonalModToSeasonsArray(lockedSeasonalMods),
         lockedArmor2ModMap,
         assumeMasterwork,
         statOrder,
@@ -185,6 +189,21 @@ function mapDimSocketToProcessSocket(dimSocket: DimSocket): ProcessSocket {
       plugItemHash: dimPlug.plugItem.hash,
     })),
   };
+}
+
+function mapSeasonalModToSeasonsArray(lockedSeasonalMods: readonly LockedModBase[]): string[][] {
+  const processedSeasonalMods: string[][] = [];
+  for (const mod of lockedSeasonalMods) {
+    const compatibleTags = getSpecialtySocketMetadataByPlugCategoryHash(
+      mod.mod.plug.plugCategoryHash
+    )?.compatibleTags;
+
+    if (compatibleTags) {
+      processedSeasonalMods.push(compatibleTags);
+    }
+  }
+
+  return processedSeasonalMods;
 }
 
 function mapDimSocketsToProcessSockets(dimSockets: DimSockets): ProcessSockets {

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -8,14 +8,10 @@ import {
   LockedArmor2ModMap,
   MinMaxIgnored,
   MinMax,
-  LockedModBase,
 } from '../types';
 import { statTier } from '../generated-sets/utils';
 import { compareBy } from '../../utils/comparators';
-import {
-  Armor2ModPlugCategories,
-  getSpecialtySocketMetadataByPlugCategoryHash,
-} from '../../utils/item-utils';
+import { Armor2ModPlugCategories } from '../../utils/item-utils';
 import { statHashes } from '../types';
 import {
   ProcessItemsByBucket,
@@ -95,7 +91,7 @@ function insertIntoSetTracker(
 export function process(
   filteredItems: ProcessItemsByBucket,
   lockedItems: LockedMap,
-  lockedSeasonalMods: readonly LockedModBase[],
+  processedSeasonalMods: string[][],
   lockedArmor2ModMap: LockedArmor2ModMap,
   assumeMasterwork: boolean,
   statOrder: StatTypes[],
@@ -107,22 +103,6 @@ export function process(
   statRanges?: { [stat in StatTypes]: MinMax };
 } {
   const pstart = performance.now();
-
-  const processedSeasonalMods: string[][] = [];
-  for (const mod of lockedSeasonalMods) {
-    const compatibleTags = getSpecialtySocketMetadataByPlugCategoryHash(
-      mod.mod.plug.plugCategoryHash
-    )?.compatibleTags;
-
-    if (compatibleTags) {
-      processedSeasonalMods.push(compatibleTags);
-    }
-  }
-
-  lockedSeasonalMods.map(
-    (mod) =>
-      getSpecialtySocketMetadataByPlugCategoryHash(mod.mod.plug.plugCategoryHash)?.compatibleTags
-  );
 
   // Memoize the function that turns string stat-keys back into numbers to save garbage.
   // Writing our own memoization instead of using _.memoize is 2x faster.
@@ -320,7 +300,7 @@ export function process(
               }
 
               if (
-                lockedSeasonalMods.length &&
+                processedSeasonalMods.length &&
                 !findUntilExhausted(processedSeasonalMods, [...firstValidSet])
               ) {
                 continue;

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -620,7 +620,8 @@ function findUntilExhausted(needles: string[][], haystack: ProcessItem[]) {
   }
 
   // for each possible used armor, recurse this function with remaining haystack and remaining needles
-  return candidates.some((candidate) =>
-    findUntilExhausted(needles.slice(1), haystack.splice(candidate, 1))
-  );
+  return candidates.some((candidate) => {
+    haystack.splice(candidate, 1);
+    return findUntilExhausted(needles.slice(1), haystack);
+  });
 }

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -299,6 +299,9 @@ export function process(
                 }
               }
 
+              // Spreading firstValidSet would generally be unwanted but findUntilExhausted modifies it in place.
+              // The alternative would be that it creates a new one with each recursion leading to more new arrays.
+              // More arrays bad.
               if (
                 processedSeasonalMods.length &&
                 !findUntilExhausted(processedSeasonalMods, [...firstValidSet])

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -301,7 +301,7 @@ export function process(
 
               if (
                 processedSeasonalMods.length &&
-                !findUntilExhausted(processedSeasonalMods, firstValidSet)
+                !canTakeAllSeasonalMods(processedSeasonalMods, firstValidSet)
               ) {
                 continue;
               }
@@ -592,8 +592,8 @@ function flattenSets(sets: IntermediateProcessArmorSet[]): ProcessArmorSet[] {
   }));
 }
 
-function findUntilExhausted(sortedModSeasons: string[], items: ProcessItem[]) {
-  const itemModSeasons = [...items]
+function canTakeAllSeasonalMods(sortedModSeasons: string[], items: ProcessItem[]) {
+  const itemCompatibleModSeasons = [...items]
     .sort((a, b) => {
       if (a.season && b.season) {
         return a.season - b.season;
@@ -602,13 +602,13 @@ function findUntilExhausted(sortedModSeasons: string[], items: ProcessItem[]) {
       }
       return -1;
     })
-    .map((item) => item.modSeasons);
+    .map((item) => item.compatibleModSeasons);
 
   let modIndex = 0;
   let itemIndex = 0;
 
   while (modIndex < sortedModSeasons.length && itemIndex < items.length) {
-    if (itemModSeasons[itemIndex]?.includes(sortedModSeasons[modIndex])) {
+    if (itemCompatibleModSeasons[itemIndex]?.includes(sortedModSeasons[modIndex])) {
       modIndex += 1;
     }
     itemIndex += 1;

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -34,7 +34,7 @@ export interface ProcessItem {
   basePower: number;
   stats: { [statHash: number]: number };
   season?: number;
-  modSeasons?: string[];
+  compatibleModSeasons?: string[];
 }
 
 export type ProcessItemsByBucket = Readonly<{

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -33,8 +33,8 @@ export interface ProcessItem {
   energyType?: DestinyEnergyType;
   basePower: number;
   stats: { [statHash: number]: number };
-  season?: string;
-  specialtySocketCategoryHash?: number;
+  season?: number;
+  modSeasons?: string[];
 }
 
 export type ProcessItemsByBucket = Readonly<{

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -33,6 +33,7 @@ export interface ProcessItem {
   energyType?: DestinyEnergyType;
   basePower: number;
   stats: { [statHash: number]: number };
+  season?: string;
   specialtySocketCategoryHash?: number;
 }
 

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -96,6 +96,12 @@ export const getSpecialtySocketMetadataByCategoryHash = (
 ): ModMetadata | undefined =>
   modMetadataIndexedByEmptySlotHash[specialtySocketCategoryHash || -99999999];
 
+/** returns ModMetadata if the category hash is known */
+export const getSpecialtySocketMetadataByPlugCategoryHash = (
+  plugCategoryHash: number
+): ModMetadata | undefined =>
+  modMetadataBySlotTag.find((meta) => meta.thisSlotPlugCategoryHashes.includes(plugCategoryHash));
+
 /** this returns a string for easy printing purposes. '' if not found */
 export const getItemSpecialtyModSlotDisplayName = (item: DimItem) =>
   getSpecialtySocket(item)?.plug?.plugItem.itemTypeDisplayName || '';

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -91,12 +91,6 @@ export const getSpecialtySocketMetadata = (item: DimItem): ModMetadata | undefin
   ];
 
 /** returns ModMetadata if the category hash is known */
-export const getSpecialtySocketMetadataByCategoryHash = (
-  specialtySocketCategoryHash?: number
-): ModMetadata | undefined =>
-  modMetadataIndexedByEmptySlotHash[specialtySocketCategoryHash || -99999999];
-
-/** returns ModMetadata if the category hash is known */
 export const getSpecialtySocketMetadataByPlugCategoryHash = (
   plugCategoryHash: number
 ): ModMetadata | undefined =>


### PR DESCRIPTION
Hey peeps. This solution is really fast (as in I can't tell the difference) and I haven't seen any sets come through that shouldn't be there.

I am doubting correctness as it seems too fast and easy so I would love other opinions.

The idea for the algorithm is this,

Consider having 5 items that can take the following mods.
`[[9, 10, 11], [9, 10, 11], [10, 11, 12], [10, 11, 12], [8, 9, 10]]`

and having 5 mods `[9, 10, 11, 11, 12]`.

What we want to do is figure out if all those mods can fit into an item each. To solve this we take advantage of the ability to order both the mods and items. Doing so gives

`[[10, 11, 12],  [10, 11, 12],  [9, 10, 11], [9, 10, 11], [8, 9, 10]]`
and 
`[12, 11, 11, 10, 9]`

We then loop using an itemIndex and a modIndex looking for matches. If we have a match we move to the next modIndex and itemIndex. If we dont find one we just move to the next itemIndex. If the indexes ever get larger than their appropriate arrays we exit. We succeed if the modIndex is the last index in the mod array and we find a match.

In the example above this would give us 
[[10, 11, **_12_**],  [10, **_11_**, 12],  [9, 10, **_11_**], [9, **_10_**, 11], [8, **_9_**, 10]]

Two easy failure cases to consider would be all season 8 mods, in that case we would finish and the modIndex would be 1. Similarly if we had all arrivals mods the modIndex would be 2 at finish.