### PR TITLE
Negative stats adjustments

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -571,7 +571,7 @@
     "SelectPerks": "Select Perks",
     "SelectPower": "Minimum Power",
     "SelectPowerDescription": "Sets a minimum power level for the entire loadout (not individual pieces)",
-    "StatIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}} on some included items. This is a limitation of the information sent by bungie.net.\n\nPlease remove any mods with negative stat values to get accurate results.",
+    "StatIncorrectWarning": "Please remove any mods with negative stat values to get accurate results.\n\nDue to negative stat modifiers, DIM cannot determine the base value of {{stats}} on some included items. This is a limitation of the information sent by Bungie.net.",
     "StatTierIgnoreOption": "Ignore",
     "StatTierIncludeOption": "Include",
     "TierNumber": "T{{tier}}",
@@ -869,7 +869,7 @@
     "TierProgress": "T{{tier}} {{statName}} ({{progress}}/60 for T{{nextTier}})\n",
     "TierProgress_Max": "T{{tier}} {{statName}} ({{progress}}/300)\n",
     "Total": "Total",
-    "TotalIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of the total stat. This is a limitation of the information sent by bungie.net."
+    "TotalIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}}. This is a limitation of the information sent by Bungie.net."
   },
   "Storage": {
     "ApiPermissionPrompt": {

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -559,7 +559,7 @@
     "NumStatMixes_plural": "{{count, number}} stat mixes",
     "OptimizerExplanation": "Select perks, filter and reorder stats, and lock items to narrow down your potential loadouts.",
     "OptimizerExplanationDesktop": "Shift-click a perk to select it. Shift-click an item to exclude it. Drag items to the sidebar to exclude or lock them.",
-    "OptimizerExplanationArmour2Mods": "Armor 2.0 Mods are not included where possible, to get accurate results remove all mods with negative stat contributions.",
+    "OptimizerExplanationArmour2Mods": "Stat changes from Armor 2.0 Mods are excluded where possible. To get accurate results, remove all mods with negative stat contributions.",
     "ProcessingSets": "Processing sets for\n{{character}}",
     "ResetLocked": "Reset locked items",
     "SearchPlaceholder": "Filter (e.g., \"vigil of heroes\")",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -571,7 +571,7 @@
     "SelectPerks": "Select Perks",
     "SelectPower": "Minimum Power",
     "SelectPowerDescription": "Sets a minimum power level for the entire loadout (not individual pieces)",
-    "StatIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}}. Please remove any mods with negative stat values to get accurate results. This is a limitation of the information sent by bungie.net.",
+    "StatIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}} on some included items. This is a limitation of the information sent by bungie.net.\n\nPlease remove any mods with negative stat values to get accurate results.",
     "StatTierIgnoreOption": "Ignore",
     "StatTierIncludeOption": "Include",
     "TierNumber": "T{{tier}}",

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -93,6 +93,13 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
     [styles.totalRow]: Boolean(totalDetails),
   };
 
+  const incorrectStats = _.uniq(
+    item?.stats
+      ?.filter((stat) => stat.statHash !== -1000)
+      .map((stat) => stat.baseMayBeWrong && stat.displayProperties.name)
+      .filter(Boolean)
+  );
+
   return (
     <>
       <div
@@ -172,7 +179,12 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
               </span>
             )}
             {stat.baseMayBeWrong && (
-              <PressTip elementType="span" tooltip={t('Stats.TotalIncorrectWarning')}>
+              <PressTip
+                elementType="span"
+                tooltip={t('Stats.TotalIncorrectWarning', {
+                  stats: incorrectStats.join('/'),
+                })}
+              >
                 <AppIcon className={styles.totalStatWarn} icon={faExclamationTriangle} />
               </PressTip>
             )}

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -93,9 +93,13 @@ function GeneratedSet({
 
   const incorrectStats = _.uniq(
     set.firstValidSet
-      .map((item) => item.stats?.map((stat) => stat.baseMayBeWrong && stat.displayProperties.name))
+      .map((item) =>
+        item.stats
+          ?.filter((stat) => stat.statHash !== -1000)
+          .map((stat) => stat.baseMayBeWrong && stat.displayProperties.name)
+      )
       .flat()
-      .filter((statName) => Boolean(statName))
+      .filter(Boolean)
   );
 
   return (
@@ -107,8 +111,7 @@ function GeneratedSet({
               <PressTip
                 elementType="span"
                 tooltip={t('LoadoutBuilder.StatIncorrectWarning', {
-                  stats: incorrectStats,
-                  arrayJoin: ', ',
+                  stats: incorrectStats.join('/'),
                 })}
               >
                 <AppIcon className={styles.warning} icon={faExclamationTriangle} />

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -568,7 +568,7 @@
     "SelectPower": "Minimum Power",
     "SelectPowerDescription": "Sets a minimum power level for the entire loadout (not individual pieces)",
     "SelectedPerkKey": "Selected perk",
-    "StatIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}}. Please remove any mods with negative stat values to get accurate results. This is a limitation of the information sent by bungie.net.",
+    "StatIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}} on some included items. This is a limitation of the information sent by bungie.net.\n\nPlease remove any mods with negative stat values to get accurate results.",
     "StatTierIgnoreOption": "Ignore",
     "StatTierIncludeOption": "Include",
     "TierNumber": "T{{tier}}",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -568,7 +568,7 @@
     "SelectPower": "Minimum Power",
     "SelectPowerDescription": "Sets a minimum power level for the entire loadout (not individual pieces)",
     "SelectedPerkKey": "Selected perk",
-    "StatIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}} on some included items. This is a limitation of the information sent by bungie.net.\n\nPlease remove any mods with negative stat values to get accurate results.",
+    "StatIncorrectWarning": "Please remove any mods with negative stat values to get accurate results.\n\nDue to negative stat modifiers, DIM cannot determine the base value of {{stats}} on some included items. This is a limitation of the information sent by Bungie.net.",
     "StatTierIgnoreOption": "Ignore",
     "StatTierIncludeOption": "Include",
     "TierNumber": "T{{tier}}",
@@ -861,7 +861,7 @@
     "TierProgress": "T{{tier}} {{statName}} ({{progress}}/60 for T{{nextTier}})\n",
     "TierProgress_Max": "T{{tier}} {{statName}} ({{progress}}/300)\n",
     "Total": "Total",
-    "TotalIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of the total stat. This is a limitation of the information sent by bungie.net."
+    "TotalIncorrectWarning": "Due to negative stat modifiers, DIM cannot determine the base value of {{stats}}. This is a limitation of the information sent by Bungie.net."
   },
   "Storage": {
     "ApiPermissionPrompt": {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -555,7 +555,7 @@
     "NumStatMixes": "{{count, number}} stat mix",
     "NumStatMixes_plural": "{{count, number}} stat mixes",
     "OptimizerExplanation": "Select perks, filter and reorder stats, and lock items to narrow down your potential loadouts.",
-    "OptimizerExplanationArmour2Mods": "Armor 2.0 Mods are not included where possible, to get accurate results remove all mods with negative stat contributions.",
+    "OptimizerExplanationArmour2Mods": "Stat changes from Armor 2.0 Mods are excluded where possible. To get accurate results, remove all mods with negative stat contributions.",
     "OptimizerExplanationDesktop": "Shift-click a perk to select it. Shift-click an item to exclude it. Drag items to the sidebar to exclude or lock them.",
     "ProcessingSets": "Processing sets for\n{{character}}",
     "ResetLocked": "Reset locked items",


### PR DESCRIPTION
StatIncorrectWarning -- be clearer that *items within this set* are what needs addressing.
bring the API explanation closer to the first part of the explanation.
separate out the Call to Action ("maybe remove these mods??") and move it to the top, because honestly i zone out during reading the explanation even though it's important.
![image](https://user-images.githubusercontent.com/31990469/87852169-7d4ba780-c8b4-11ea-8c26-7f5709b6b9ad.png)

GeneratedSet.tsx -- separate stat names with `/` instead of `, ` because it's not going to be super grammatically sound as a sentence either way. use JS to join these for now until we investigate i18next stuff.

ItemStat.tsx -- add affected stats to this tooltip just for extreme clarity.
![image](https://user-images.githubusercontent.com/31990469/87852251-2a262480-c8b5-11ea-8352-62e42bc2681f.png)

general i18n -- match other formatting of Bungie.net