### PR TITLE
Lock/track

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -24,6 +24,7 @@ import {
   BungieMembershipType,
   getItem,
   DestinyItemResponse,
+  setQuestTrackedState,
 } from 'bungie-api-ts/destiny2';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
@@ -293,6 +294,28 @@ export function setLockState(
     membershipType: account!.originalPlatformType,
     itemId: item.id,
     state: lockState,
+  });
+}
+
+/**
+ * Set the tracked state of an item.
+ */
+export function setTrackedState(
+  store: DimStore,
+  item: DimItem,
+  trackedState: boolean
+): Promise<ServerResponse<number>> {
+  const account = getActivePlatform();
+
+  if (item.id === '0') {
+    throw new Error("Can't track non-instanced items");
+  }
+
+  return setQuestTrackedState(httpAdapter, {
+    characterId: store.isVault ? item.owner : store.id,
+    membershipType: account!.originalPlatformType,
+    itemId: item.id,
+    state: trackedState,
   });
 }
 

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -29,7 +29,7 @@ export default function CompareItem({
       <div className="compare-item-header">
         <div className="icon comp-lock-icon">
           {item.lockable && <LockButton item={item} type="lock" />}
-          {item.isDestiny1() && item.trackable && <LockButton item={item} type="track" />}
+          {item.trackable && <LockButton item={item} type="track" />}
         </div>
         <ItemTagSelector item={item} />
         <div className="close" onClick={() => remove(item)} />

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -43,6 +43,12 @@ export const charactersUpdated = createAction('inventory/CHARACTERS')<CharacterI
 export const touch = createAction('inventory/TOUCH')();
 
 /**
+ * Force stores to be updated to reflect a change in a single item by instance ID. This is a hack that should go
+ * away as we normalize inventory state.
+ */
+export const touchItem = createAction('inventory/TOUCH_ITEM')<string>();
+
+/**
  * Reflect the old stores service data into the Redux store as a migration aid.
  */
 export const error = createAction('inventory/ERROR')<DimError>();

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -12,6 +12,7 @@ import {
   equipItems as d2EquipItems,
   transfer as d2Transfer,
   setLockState as d2SetLockState,
+  setTrackedState as d2SetTrackedState,
 } from '../bungie-api/destiny2-api';
 import { chainComparator, compareBy, reverseComparator } from '../utils/comparators';
 import { createItemIndex as d2CreateItemIndex } from './store/d2-item-factory';
@@ -83,7 +84,11 @@ export async function setItemLockState(
   const store = item.owner === 'vault' ? getCurrentStore(stores)! : getStore(stores, item.owner)!;
 
   if (item.isDestiny2()) {
-    await d2SetLockState(store, item, state);
+    if (type === 'lock') {
+      await d2SetLockState(store, item, state);
+    } else {
+      await d2SetTrackedState(store, item, state);
+    }
   } else if (item.isDestiny1()) {
     await d1SetItemState(item, store, state, type);
   }

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -110,7 +110,9 @@ export interface DimItem {
   classTypeNameLocalized: string;
   /** Whether this item can be locked. */
   lockable: boolean;
-  /** Is this item tracked? (D1 quests/bounties). */
+  /** Can this item be tracked? (For quests/bounties.) */
+  trackable: boolean;
+  /** Is this item tracked? (For quests/bounties). */
   tracked: boolean;
   /**
    * Is this item locked?
@@ -197,8 +199,6 @@ export interface D1Item extends DimItem {
   year: number;
   /** Hashes that allow us to figure out where this item can be found (what activities, locations, etc.) */
   sourceHashes: number[];
-  /** Can this item be tracked? (For quests/bounties.) */
-  trackable: boolean;
 
   getStoresService(): D1StoreServiceType;
 }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -381,7 +381,7 @@ export function makeItem(
     breakerType: null,
     visible: true,
     lockable: item.lockable,
-    trackable: item.itemInstanceId && normalBucket.hash === 1345459588,
+    trackable: Boolean(item.itemInstanceId && itemDef.objectives?.questlineItemHash),
     tracked: Boolean(item.state & ItemState.Tracked),
     locked: Boolean(item.state & ItemState.Locked),
     masterwork: Boolean(item.state & ItemState.Masterwork) && itemType !== 'Class',

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -381,6 +381,7 @@ export function makeItem(
     breakerType: null,
     visible: true,
     lockable: item.lockable,
+    trackable: item.itemInstanceId && normalBucket.hash === 1345459588,
     tracked: Boolean(item.state & ItemState.Tracked),
     locked: Boolean(item.state & ItemState.Locked),
     masterwork: Boolean(item.state & ItemState.Masterwork) && itemType !== 'Class',

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -32,7 +32,7 @@ export default function ItemPopupHeader({
   language: string;
   onToggleExpanded(): void;
 }) {
-  const hasLeftIcon = (item.isDestiny1() && item.trackable) || item.lockable || item.element;
+  const hasLeftIcon = item.trackable || item.lockable || item.element;
   const openCompare = () => {
     hideItemPopup();
     CompareService.addItemsToCompare([item], true);
@@ -94,7 +94,7 @@ export default function ItemPopupHeader({
         {hasLeftIcon && (
           <div className="icon">
             {item.lockable && <LockButton item={item} type="lock" />}
-            {item.isDestiny1() && item.trackable && <LockButton item={item} type="track" />}
+            {item.trackable && <LockButton item={item} type="track" />}
           </div>
         )}
         <div className="item-title-link">

--- a/src/app/item-popup/LockButton.tsx
+++ b/src/app/item-popup/LockButton.tsx
@@ -3,8 +3,10 @@ import { DimItem } from '../inventory/item-types';
 import { t } from 'app/i18next-t';
 import styles from './LockButton.m.scss';
 import clsx from 'clsx';
-import { lockIcon, unlockedIcon, starIcon, starOutlineIcon, AppIcon } from '../shell/icons';
+import { lockIcon, unlockedIcon, AppIcon, trackedIcon, unTrackedIcon } from '../shell/icons';
 import { setItemLockState } from 'app/inventory/item-move-service';
+import reduxStore from '../store/store';
+import { touchItem } from 'app/inventory/actions';
 
 interface Props {
   item: DimItem;
@@ -39,8 +41,8 @@ export default class LockButton extends React.Component<Props, State> {
           ? lockIcon
           : unlockedIcon
         : item.tracked
-        ? starIcon
-        : starOutlineIcon;
+        ? trackedIcon
+        : unTrackedIcon;
 
     return (
       <div onClick={this.lockUnlock} title={title}>
@@ -74,6 +76,7 @@ export default class LockButton extends React.Component<Props, State> {
       }
     } finally {
       this.setState({ locking: false });
+      reduxStore.dispatch(touchItem(item.id));
     }
   };
 }

--- a/src/app/item-popup/LockButton.tsx
+++ b/src/app/item-popup/LockButton.tsx
@@ -1,64 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { DimItem } from '../inventory/item-types';
 import { t } from 'app/i18next-t';
 import styles from './LockButton.m.scss';
 import clsx from 'clsx';
 import { lockIcon, unlockedIcon, AppIcon, trackedIcon, unTrackedIcon } from '../shell/icons';
 import { setItemLockState } from 'app/inventory/item-move-service';
-import reduxStore from '../store/store';
 import { touchItem } from 'app/inventory/actions';
+import { useDispatch } from 'react-redux';
 
 interface Props {
   item: DimItem;
   type: 'lock' | 'track';
 }
 
-interface State {
-  locking: boolean;
-}
+export default function LockButton({ type, item }: Props) {
+  const [locking, setLocking] = useState(false);
+  const dispatch = useDispatch();
 
-export default class LockButton extends React.Component<Props, State> {
-  state: State = { locking: false };
-
-  render() {
-    const { type, item } = this.props;
-    const { locking } = this.state;
-
-    const data = { itemType: item.typeName };
-
-    const title =
-      type === 'lock'
-        ? !item.locked
-          ? t('MovePopup.LockUnlock.Lock', data)
-          : t('MovePopup.LockUnlock.Unlock', data)
-        : !item.tracked
-        ? t('MovePopup.TrackUntrack.Track', data)
-        : t('MovePopup.TrackUntrack.Untrack', data);
-
-    const icon =
-      type === 'lock'
-        ? item.locked
-          ? lockIcon
-          : unlockedIcon
-        : item.tracked
-        ? trackedIcon
-        : unTrackedIcon;
-
-    return (
-      <div onClick={this.lockUnlock} title={title}>
-        <AppIcon className={clsx({ [styles.inProgress]: locking })} icon={icon} />
-      </div>
-    );
-  }
-
-  private lockUnlock = async () => {
-    const { item, type } = this.props;
-    const { locking } = this.state;
+  const lockUnlock = async () => {
     if (locking) {
       return;
     }
 
-    this.setState({ locking: true });
+    setLocking(true);
 
     let state = false;
     if (type === 'lock') {
@@ -75,8 +39,34 @@ export default class LockButton extends React.Component<Props, State> {
         item.tracked = state;
       }
     } finally {
-      this.setState({ locking: false });
-      reduxStore.dispatch(touchItem(item.id));
+      setLocking(false);
+      dispatch(touchItem(item.id));
     }
   };
+
+  const data = { itemType: item.typeName };
+
+  const title =
+    type === 'lock'
+      ? !item.locked
+        ? t('MovePopup.LockUnlock.Lock', data)
+        : t('MovePopup.LockUnlock.Unlock', data)
+      : !item.tracked
+      ? t('MovePopup.TrackUntrack.Track', data)
+      : t('MovePopup.TrackUntrack.Untrack', data);
+
+  const icon =
+    type === 'lock'
+      ? item.locked
+        ? lockIcon
+        : unlockedIcon
+      : item.tracked
+      ? trackedIcon
+      : unTrackedIcon;
+
+  return (
+    <div onClick={lockUnlock} title={title}>
+      <AppIcon className={clsx({ [styles.inProgress]: locking })} icon={icon} />
+    </div>
+  );
 }

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -34,7 +34,7 @@ import { setItemLockState } from 'app/inventory/item-move-service';
 import { emptyObject, emptyArray } from 'app/utils/empty';
 import { Row, ColumnDefinition, SortDirection, ColumnSort } from './table-types';
 import { compareBy, chainComparator, reverseComparator } from 'app/utils/comparators';
-import { touch, setItemNote } from 'app/inventory/actions';
+import { touch, setItemNote, touchItem } from 'app/inventory/actions';
 import { settingsSelector } from 'app/settings/reducer';
 import { setSetting } from 'app/settings/actions';
 import { StatHashListsKeyedByDestinyClass } from 'app/dim-ui/CustomStatTotal';
@@ -263,6 +263,7 @@ function ItemTable({
 
         // TODO: Gotta do this differently in react land
         item.locked = lock;
+        dispatch(touchItem(item.id));
       }
       showNotification({
         type: 'success',

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -20,7 +20,7 @@ import { searchQueryVersionSelector, querySelector } from 'app/shell/reducer';
 import { setItemLockState } from 'app/inventory/item-move-service';
 import { storesSelector } from 'app/inventory/selectors';
 import { getAllItems } from 'app/inventory/stores-helpers';
-import { touch } from 'app/inventory/actions';
+import { touch, touchItem } from 'app/inventory/actions';
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { useLocation } from 'react-router';
 import { emptyArray, emptySet } from 'app/utils/empty';
@@ -55,12 +55,14 @@ type DispatchProps = {
   setSearchQuery(query: string): void;
   bulkTagItems(items: DimItem[], tag: TagValue): void;
   touchStores(): void;
+  touchItem(id: string): void;
 };
 
 const mapDispatchToProps: MapDispatchToPropsFunction<DispatchProps, StoreProps> = (dispatch) => ({
   setSearchQuery: (query) => dispatch(setSearchQuery(query, true)),
   bulkTagItems: (items, tag) => dispatch(bulkTagItems(items, tag) as any),
   touchStores: touch,
+  touchItem: (id) => dispatch(touchItem(id)),
 });
 
 type Props = ProvidedProps & StoreProps & DispatchProps;
@@ -153,6 +155,7 @@ export function SearchFilter(
 
             // TODO: Gotta do this differently in react land
             item.locked = state;
+            touchItem(item.id);
           }
           showNotification({
             type: 'success',

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -232,11 +232,11 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
     onwrongclass: ['onwrongclass'],
     hasnotes: ['hasnotes'],
     cosmetic: ['cosmetic'],
+    tracked: ['tracked'],
+    untracked: ['untracked'],
     ...(isD1
       ? {
           hasLight: ['light', 'haslight'],
-          tracked: ['tracked'],
-          untracked: ['untracked'],
           sublime: ['sublime'],
           incomplete: ['incomplete'],
           complete: ['complete'],
@@ -797,10 +797,10 @@ function searchFilters(
           return complete || missing;
         }
       },
-      untracked(item: D1Item) {
+      untracked(item: DimItem) {
         return item.trackable && !item.tracked;
       },
-      tracked(item: D1Item) {
+      tracked(item: DimItem) {
         return item.trackable && item.tracked;
       },
       unlocked(item: DimItem) {

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -78,6 +78,8 @@ const faExclamationTriangle = 'fas fa-exclamation-triangle';
 const faTshirt = 'fas fa-tshirt';
 const faGripLinesVertical = 'fas fa-grip-lines-vertical';
 const faExternalLinkAlt = 'fas fa-external-link-alt';
+const faBookmarkSolid = 'fas fa-bookmark';
+const faBookmark = 'far fa-bookmark';
 
 const faXbox = 'fab fa-xbox';
 const faPlaystation = 'fab fa-playstation';
@@ -155,6 +157,8 @@ export {
   faGlobe as globeIcon,
   faStickyNote as stickyNoteIcon,
   faArrowRight as moveIcon,
+  faBookmark as unTrackedIcon,
+  faBookmarkSolid as trackedIcon,
   faMinusSquare,
   faRandom,
   faEquals,


### PR DESCRIPTION
This does two things:

1. It makes pursuits that are lockable through the API, lockable through DIM. This turns out to be just quests, and only quests with instances, not bounties or anything. It feels pretty random. But hey there it is. I chose a "bookmark" icon I thought got the point across.
2. It fixes locking/unlocking (and now tracking/untracking) to be reflected on items right away, instead of waiting for the next refresh. This is a long-standing issue and I'm still not solving it the right way (which requires a big set of changes to stores/items structure) but it does make the UI update.

![image](https://user-images.githubusercontent.com/313208/87865110-fdf6bc00-c925-11ea-84b7-7f8d7f4b2602.png)
