### PR TITLE
Fall back to another source for questline info

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -333,6 +333,12 @@ export function makeItem(
   ) {
     typeName = itemDef.displayProperties.name;
     name = itemDef.setData.questLineName;
+  } else if (itemDef.objectives?.questlineItemHash) {
+    const questLineItem = defs.InventoryItem.get(itemDef.objectives.questlineItemHash);
+    if (questLineItem && questLineItem.displayProperties.name !== itemDef.displayProperties.name) {
+      typeName = itemDef.displayProperties.name;
+      name = questLineItem.displayProperties.name;
+    }
   }
 
   const createdItem: D2Item = Object.assign(Object.create(ItemProto), {


### PR DESCRIPTION
Some old quests don't have `questLineName` populated so we need to load up their questline item def. This fixes some (old) quests to match what's shown in-game.