### PR TITLE
Update InventoryItem.m.scss

### DIFF
--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -3,7 +3,7 @@
 // Items hidden by search.
 .searchHidden {
   opacity: 0.2;
-  transform: scale(0.85);
+  transform: scale(0.75);
 }
 
 // The wrapper for draggable items. Global because it's referenced by other styles.


### PR DESCRIPTION
Initially, I didn't even notice non-matching search results would shrink and I found it very annoying to identify what I don't own over what doesn't match the search result. I think changing the shirking to `0.75` would help users more easily notice/see the differences.