### PR TITLE
Fix for the magazine size issue with mountaintop and militia's birthright.

### DIFF
--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -520,7 +520,7 @@ export function interpolateStatValue(value: number, statDisplay: DestinyStatDisp
   let endIndex = interp.findIndex((p) => p.value > value);
 
   // value < 0 is for mods with negative stats
-  if (endIndex < 0 || value < 0) {
+  if (endIndex < 0 || (value < 0 && armorStats.includes(statDisplay.statHash))) {
     endIndex = interp.length - 1;
   }
   const startIndex = Math.max(0, endIndex - 1);


### PR DESCRIPTION
This seems to just be an issues with special breach grenade launchers. From my understanding it only effects mountaintop and the militia's birthright. FWIW they seem to have a magazine size of -100 in investment stats.