### PR TITLE
Organizer tuning

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -49,6 +49,7 @@ import { source } from 'app/inventory/spreadsheets';
 import { statHashByName } from 'app/search/search-filter-values';
 import { statAllowList } from 'app/inventory/store/stats';
 import styles from './ItemTable.m.scss';
+import itemStatStyle from 'app/item-popup/ItemStat.m.scss';
 import { t } from 'app/i18next-t';
 import { percent, getColor } from 'app/shell/filters';
 import { PowerCapDisclaimer } from 'app/dim-ui/PowerCapDisclaimer';
@@ -151,7 +152,7 @@ export function getColumns(
           id: `base_${column.statHash}`,
           columnGroup: baseStatsGroup,
           value: (item: DimItem) => item.stats?.find((s) => s.statHash === column.statHash)?.base,
-          cell: (value) => value,
+          cell: (value) => <div className={itemStatStyle.value}>{value}</div>,
           filter: (value) => `basestat:${_.invert(statHashByName)[column.statHash]}:>=${value}`,
         }))
       : [];
@@ -570,9 +571,10 @@ function PerksCell({
         s.plugOptions.length > 0 &&
         ((!traitsOnly && s.plug.plugItem.collectibleHash) ||
           (s.isPerk &&
-            (item.isExotic ||
-              (!s.plug.plugItem.itemCategoryHashes?.includes(INTRINSIC_PLUG_CATEGORY) &&
-                (!traitsOnly || s.plug.plugItem.plug.plugCategoryIdentifier === 'frames')))))
+            !s.plug.plugItem.itemCategoryHashes?.includes(INTRINSIC_PLUG_CATEGORY) &&
+            (!traitsOnly ||
+              s.plug.plugItem.plug.plugCategoryIdentifier === 'frames' ||
+              s.plug.plugItem.plug.plugCategoryIdentifier === 'intrinsics')))
     )
   );
 

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -38,7 +38,7 @@ export function getSocketsWithPlugCategoryHash(sockets: DimSockets, categoryHash
 
 /** whether a socket is a mod socket. i.e. those grey things. not perks, not reusables, not shaders */
 export function isModSocket(socket: DimSocket) {
-  return socket.plug && isArmor2Mod(socket.plug?.plugItem);
+  return socket.plug && isArmor2Mod(socket.plug.plugItem);
 }
 
 /** isModSocket and contains its default plug */

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -1,6 +1,7 @@
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import { DimSocketCategory } from 'app/inventory/item-types';
 import { DimSockets, DimSocket } from '../inventory/item-types';
+import { isArmor2Mod } from './item-utils';
 
 export function getMasterworkSocketHashes(
   itemSockets: DimSockets,
@@ -35,6 +36,23 @@ export function getSocketsWithPlugCategoryHash(sockets: DimSockets, categoryHash
   );
 }
 
-// export function isModSocket(socket: DimSocket){
-// return socket.plug.plugItem.collectibleHash
-// }
+/** */
+export function isModSocket(socket: DimSocket) {
+  return socket.plug && isArmor2Mod(socket.plug?.plugItem);
+}
+
+/** */
+export function isEmptyModSocket(socket: DimSocket) {
+  return (
+    isModSocket(socket) &&
+    socket.socketDefinition.singleInitialItemHash === socket.plug?.plugItem.hash
+  );
+}
+
+/** */
+export function isUsedModSocket(socket: DimSocket) {
+  return (
+    isModSocket(socket) &&
+    socket.socketDefinition.singleInitialItemHash !== socket.plug?.plugItem.hash
+  );
+}

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -34,3 +34,7 @@ export function getSocketsWithPlugCategoryHash(sockets: DimSockets, categoryHash
     socket?.plug?.plugItem?.itemCategoryHashes?.includes(categoryHash)
   );
 }
+
+// export function isModSocket(socket: DimSocket){
+// return socket.plug.plugItem.collectibleHash
+// }

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -36,12 +36,12 @@ export function getSocketsWithPlugCategoryHash(sockets: DimSockets, categoryHash
   );
 }
 
-/** */
+/** whether a socket is a mod socket. i.e. those grey things. not perks, not reusables, not shaders */
 export function isModSocket(socket: DimSocket) {
   return socket.plug && isArmor2Mod(socket.plug?.plugItem);
 }
 
-/** */
+/** isModSocket and contains its default plug */
 export function isEmptyModSocket(socket: DimSocket) {
   return (
     isModSocket(socket) &&
@@ -49,7 +49,7 @@ export function isEmptyModSocket(socket: DimSocket) {
   );
 }
 
-/** */
+/** isModSocket and contains something other than its default plug */
 export function isUsedModSocket(socket: DimSocket) {
   return (
     isModSocket(socket) &&


### PR DESCRIPTION
fixes #5464
- basestats were misaligned compared to livestats (left instead of right)

- arrivals mods didn't show up because they don't have collection hashes

- added some socket helpers. we should start replacing repeated socket code with helpers, there's so much duplicate code for sockets.

- exotics were overly-whitelisted in terms of perks to display in the minimal Traits column

before:
![image](https://user-images.githubusercontent.com/31990469/87971264-e4ff1f80-ca79-11ea-8bb2-5a254b6c3780.png)
after:
![image](https://user-images.githubusercontent.com/31990469/87971301-f47e6880-ca79-11ea-8b0f-683774fc2f0e.png)