### PR TITLE
Chore/cleanup optimiser functions

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -168,6 +168,7 @@ function GeneratedSet({
             lbDispatch={lbDispatch}
             statValues={set.firstValidSetStatChoices[index]}
             lockedMods={assignedMods[item.hash]}
+            statOrder={statOrder}
           />
         ))}
       </div>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, Dispatch } from 'react';
 import { DimItem } from '../../inventory/item-types';
 import LoadoutBuilderItem from '../LoadoutBuilderItem';
-import { LockedItemType, LockedArmor2Mod } from '../types';
+import { LockedItemType, LockedArmor2Mod, StatTypes } from '../types';
 import ItemSockets from 'app/item-popup/ItemSockets';
 import _ from 'lodash';
 import styles from './GeneratedSetItem.m.scss';
@@ -28,6 +28,7 @@ export default function GeneratedSetItem({
   defs,
   statValues,
   itemOptions,
+  statOrder,
   lockedMods,
   lbDispatch,
 }: {
@@ -36,10 +37,15 @@ export default function GeneratedSetItem({
   defs: D2ManifestDefinitions;
   statValues: number[];
   itemOptions: DimItem[];
+  statOrder: StatTypes[];
   lockedMods?: LockedArmor2Mod[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
-  const altPerks = useMemo(() => generateMixesFromPerks(item, statValues), [item, statValues]);
+  const altPerks = useMemo(() => generateMixesFromPerks(item, statValues, statOrder), [
+    item,
+    statValues,
+    statOrder,
+  ]);
 
   const addLockedItem = (item: LockedItemType) => lbDispatch({ type: 'addItemToLockedMap', item });
   const removeLockedItem = (item: LockedItemType) =>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -23,7 +23,7 @@ import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
  */
 function identifyAltPerkChoicesForChosenStats(item: DimItem, chosenValues: number[]) {
   let altPerks: DimPlug[] = [];
-  generateMixesFromPerks(item, {}, (mix, plugs) => {
+  generateMixesFromPerks(item, (mix, plugs) => {
     if (plugs && mix.every((val, index) => val === chosenValues[index])) {
       altPerks = plugs;
       return false;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, Dispatch } from 'react';
-import { DimPlug, DimItem } from '../../inventory/item-types';
+import { DimItem } from '../../inventory/item-types';
 import LoadoutBuilderItem from '../LoadoutBuilderItem';
 import { LockedItemType, LockedArmor2Mod } from '../types';
 import ItemSockets from 'app/item-popup/ItemSockets';
@@ -18,20 +18,6 @@ import clsx from 'clsx';
 import { matchLockedItem } from '../preProcessFilter';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 
-/**
- * Figure out which (if any) non-selected perks should be selected to get the chosen stat mix.
- */
-function identifyAltPerkChoicesForChosenStats(item: DimItem, chosenValues: number[]) {
-  let altPerks: DimPlug[] = [];
-  generateMixesFromPerks(item, (mix, plugs) => {
-    if (plugs && mix.every((val, index) => val === chosenValues[index])) {
-      altPerks = plugs;
-      return false;
-    }
-    return true;
-  });
-  return altPerks;
-}
 /**
  * An individual item in a generated set. Includes a perk display and a button for selecting
  * alternative items with the same stat mix.
@@ -53,10 +39,7 @@ export default function GeneratedSetItem({
   lockedMods?: LockedArmor2Mod[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
-  const altPerks = useMemo(() => identifyAltPerkChoicesForChosenStats(item, statValues), [
-    item,
-    statValues,
-  ]);
+  const altPerks = useMemo(() => generateMixesFromPerks(item, statValues), [item, statValues]);
 
   const addLockedItem = (item: LockedItemType) => lbDispatch({ type: 'addItemToLockedMap', item });
   const removeLockedItem = (item: LockedItemType) =>

--- a/src/app/loadout-builder/preProcessFilter.ts
+++ b/src/app/loadout-builder/preProcessFilter.ts
@@ -103,6 +103,13 @@ export function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
   }
 }
 
+/**
+ * This gets the total of the total of the base stats plus any masterwork values. The two cases for
+ * masterwork values are,
+ * 1. When assume masterwork is selected we add 2 onto each stat of each armour item
+ * 2. When not assume masterwork we add on the the masterwork stat values for any items that have actually
+ *   been masterworked since it cannot be removed from the item.
+ */
 export function getTotalBaseStatsWithMasterwork(item: DimItem, assumeMasterwork: boolean | null) {
   const stats = _.keyBy(item.stats, (stat) => stat.statHash);
   const baseStats = {};
@@ -113,8 +120,12 @@ export function getTotalBaseStatsWithMasterwork(item: DimItem, assumeMasterwork:
 
   // Checking energy tells us if it is Armour 2.0
   if (item.isDestiny2() && item.sockets && item.energy) {
-    // If not assume masterwork add on mw stats as they can't be removed.
-    if (!assumeMasterwork) {
+    if (assumeMasterwork) {
+      for (const statHash of statValues) {
+        baseStats[statHash] += 2;
+      }
+    } else {
+      // If not assume masterwork add on mw stats as they can't be removed.
       const masterworkSocketHashes = getMasterworkSocketHashes(
         item.sockets,
         DestinySocketCategoryStyle.EnergyMeter
@@ -130,12 +141,6 @@ export function getTotalBaseStatsWithMasterwork(item: DimItem, assumeMasterwork:
             }
           }
         }
-      }
-    }
-
-    if (assumeMasterwork) {
-      for (const statHash of statValues) {
-        baseStats[statHash] += 2;
       }
     }
   }

--- a/src/app/loadout-builder/preProcessFilter.ts
+++ b/src/app/loadout-builder/preProcessFilter.ts
@@ -104,8 +104,7 @@ export function matchLockedItem(item: DimItem, lockedItem: LockedItemType) {
 }
 
 /**
- * This gets the total of the total of the base stats plus any masterwork values. The two cases for
- * masterwork values are,
+ * This gets the total of the base stats plus any masterwork values. The two cases for masterwork values are,
  * 1. When assume masterwork is selected we add 2 onto each stat of each armour item
  * 2. When not assume masterwork we add on the the masterwork stat values for any items that have actually
  *   been masterworked since it cannot be removed from the item.

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -495,6 +495,11 @@ function getPower(items: ProcessItem[]) {
   return Math.floor(power / numPoweredItems);
 }
 
+/**
+ * This creates stat mixes from either perks (armor 1.0) or stats (armor 2.0).
+ * This uses a similar algorithm to loadout-builder/util#generateMixesFromPerks so the two should
+ * be kept in sync if this changes.
+ */
 function generateMixesFromPerksOrStats(
   item: ProcessItem,
   assumeArmor2IsMasterwork: boolean | null,

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -298,31 +298,9 @@ export function statTier(stat: number) {
  */
 export function generateMixesFromPerks(
   item: DimItem,
-  onMix: (mix: number[], plug: DimPlug[] | null) => boolean
-) {
-  return generateMixesFromPerksOrStats(item, onMix);
-}
-
-/**
- * This is an awkward helper used by both byStatMix (to generate the list of
- * stat mixes) and GeneratedSetItem#identifyAltPerkChoicesForChosenStats. It figures out
- * which perks need to be selected to get that stat mix or in the case of Armour 2.0, it
- * calculates them directly from the stats.
- *
- * It has two modes depending on whether an "onMix" callback is provided - if it is, it
- * assumes we're looking for perks, not mixes, and keeps track of what perks are necessary
- * to fulfill a stat-mix, and lets the callback stop the function early. If not, it just
- * returns all the mixes. This is like this so we can share this complicated bit of logic
- * and not get it out of sync.
- *
- * TODO This is now only used for Armor 1.0 alt perk mixes. It should probably have the
- * stat mix functionality removed and the onMix function merged into this.
- */
-function generateMixesFromPerksOrStats(
-  item: DimItem,
   /** Callback when a new mix is found. */
-  onMix: (mix: number[], plug: DimPlug[] | null) => boolean
-) {
+  chosenValues: number[]
+): DimPlug[] {
   const stats = item.stats;
 
   if (!stats || stats.length < 3) {
@@ -351,8 +329,8 @@ function generateMixesFromPerksOrStats(
               const existingMixAlts = altPerks[mixIndex];
               const plugs = existingMixAlts ? [...existingMixAlts, plug] : [plug];
               altPerks.push(plugs);
-              if (!onMix(optionStat, plugs)) {
-                return [];
+              if (plugs && optionStat.every((val, index) => val === chosenValues[index])) {
+                return plugs;
               }
               mixes.push(optionStat);
             }
@@ -362,7 +340,7 @@ function generateMixesFromPerksOrStats(
     }
   }
 
-  return mixes;
+  return [];
 }
 
 /**

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -288,17 +288,12 @@ export function statTier(stat: number) {
 }
 
 /**
- * This is a wrapper for the awkward helper used by
- * GeneratedSetItem#identifyAltPerkChoicesForChosenStats. It figures out which perks need
- * to be selected to get that stat mix.
- *
- * It assumes we're looking for perks, not mixes, and keeps track of what perks are necessary
- * to fulfill a stat-mix, and the callback stops the function early. This is like this
- * so we can share this complicated bit of logic and not get it out of sync.
+ * This figures out which perks need to be selected on specific armor 1.0 items to achieve the desired stat mix.
+ * process#generateMixesFromPerksOrStats uses a very similar algorithm to generate the stat mixes initially so the
+ * two should be kept in sync if this changes.
  */
 export function generateMixesFromPerks(
   item: DimItem,
-  /** Callback when a new mix is found. */
   chosenValues: number[],
   statOrder: StatTypes[]
 ): DimPlug[] {

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { DimPlug, DimItem, D2Item, DimSocket } from 'app/inventory/item-types';
-import { statValues, LockedItemType, LockedMod, LockedArmor2Mod } from './types';
+import { statValues, LockedItemType, LockedMod, LockedArmor2Mod, StatTypes } from './types';
 import {
   DestinyInventoryItemDefinition,
   TierType,
@@ -299,7 +299,8 @@ export function statTier(stat: number) {
 export function generateMixesFromPerks(
   item: DimItem,
   /** Callback when a new mix is found. */
-  chosenValues: number[]
+  chosenValues: number[],
+  statOrder: StatTypes[]
 ): DimPlug[] {
   const stats = item.stats;
 
@@ -307,7 +308,7 @@ export function generateMixesFromPerks(
     return [];
   }
 
-  const mixes: number[][] = [getOrderedStatValues(item)];
+  const mixes: number[][] = [getOrderedStatValues(item, statOrder)];
 
   const altPerks: (DimPlug[] | null)[] = [null];
 
@@ -344,18 +345,11 @@ export function generateMixesFromPerks(
 }
 
 /**
- * This gets stat values for an item ordered by the statValues array.
+ * This gets stat values for an item ordered by the statOrder array.
  */
-function getOrderedStatValues(item: DimItem) {
+function getOrderedStatValues(item: DimItem, statOrder: StatTypes[]) {
   const stats = _.keyBy(item.stats, (stat) => stat.statHash);
-  const keyedStats = {};
-
-  for (const statHash of statValues) {
-    keyedStats[statHash] = stats[statHash]?.value || 0;
-  }
-
-  // mapping out from stat values to ensure ordering
-  return statValues.map((statHash) => keyedStats[statHash]);
+  return statOrder.map((statHash) => stats[statHash]?.value || 0);
 }
 
 /**


### PR DESCRIPTION
@bhollis The first commit to this is something I definitely want in as it is more correct for the minimum total filter. The second commit I am a little hamstrung as the only armour 1.0 item I have left is a bond.

FYI this is the armour 1.0 support I was talking about removing the other day. If we don't care about alternative perk mixes anymore we could remove it and one of the harder to maintain functions would be gone.