### PR TITLE
fix length of stat bars

### DIFF
--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -48,7 +48,7 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
 
   const moddedStatValue = item && getModdedStatValue(item, stat);
 
-  let baseBar = item ? stat.base : stat.value;
+  let baseBar = item ? Math.min(stat.base, stat.value) : stat.value;
 
   if (moddedStatValue && moddedStatValue < 0) {
     baseBar = Math.max(0, baseBar + moddedStatValue);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31990469/88045878-1290ab00-cb04-11ea-8d32-0807d25540a3.png)
bar-type stats were showing their base (perk-less) stat even if perks lowered it, which is why 26 is longer than 37 above

this uses the stat's modified value if it's smaller
![image](https://user-images.githubusercontent.com/31990469/88046122-72875180-cb04-11ea-98bc-3e605f5bc821.png)
