### PR TITLE
Fix sort order editor buttons

### DIFF
--- a/src/app/settings/SortOrderEditor.tsx
+++ b/src/app/settings/SortOrderEditor.tsx
@@ -144,12 +144,15 @@ function SortEditorItem(props: { index: number; item: SortProperty }) {
           <span className="name" {...provided.dragHandleProps}>
             {item.displayName}
           </span>
-          <AppIcon icon={moveUpIcon} className="sort-button sort-up" />
-          <AppIcon icon={moveDownIcon} className="sort-button sort-down" />
-          <AppIcon
-            icon={item.enabled ? enabledIcon : unselectedCheckIcon}
-            className="sort-button sort-toggle"
-          />
+          <span className="sort-button sort-up">
+            <AppIcon icon={moveUpIcon} />
+          </span>
+          <span className="sort-button sort-down">
+            <AppIcon icon={moveDownIcon} />
+          </span>
+          <span className="sort-button sort-toggle">
+            <AppIcon icon={item.enabled ? enabledIcon : unselectedCheckIcon} />
+          </span>
         </div>
       )}
     </Draggable>


### PR DESCRIPTION
Fixes #5491 - caused by the no-touch-events on AppIcon. I honestly have no memory of what caused me to do that crazy scheme where actions are driven by class names, I'll fix that later.