### PR TITLE
Optimiser seasonal mod assignment fix

### DIFF
--- a/src/app/loadout-builder/processWorker/processUtils.test.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.test.ts
@@ -91,6 +91,21 @@ describe('Can slot seasonal mods', () => {
     const result = canTakeAllSeasonalMods(mods, items);
     expect(result).toEqual(true);
   });
+
+  it('passes when the first item takes no mods', () => {
+    const mods = [getMod(7, 'opulent', 0), getMod(7, 'opulent', 0)].sort(
+      sortProcessModMetadataOrProcessItem
+    );
+
+    const items = [
+      getItem(8, 2, ['undying', 'dawn', 'worthy']),
+      getItem(11, 3, ['arrivals', 'worthy']),
+      getItem(8, 2, ['opulent', 'undying', 'dawn']),
+    ];
+
+    const result = canTakeAllSeasonalMods(mods, items);
+    expect(result).toEqual(false);
+  });
 });
 
 /*
@@ -140,6 +155,21 @@ describe("Can't slot seasonal mods", () => {
       getItem(11, 3, ['arrivals', 'worthy']),
       getItem(11, 3, ['arrivals', 'worthy']),
       getItem(8, 3, undefined),
+    ];
+
+    const result = canTakeAllSeasonalMods(mods, items);
+    expect(result).toEqual(false);
+  });
+
+  it('fails when two any energy items and only one slot that can take them', () => {
+    const mods = [getMod(7, 'opulent', 0), getMod(7, 'opulent', 0)].sort(
+      sortProcessModMetadataOrProcessItem
+    );
+
+    const items = [
+      getItem(9, 2, ['undying', 'dawn', 'worthy']),
+      getItem(11, 3, ['arrivals', 'worthy']),
+      getItem(8, 2, ['opulent', 'undying', 'dawn']),
     ];
 
     const result = canTakeAllSeasonalMods(mods, items);

--- a/src/app/loadout-builder/processWorker/processUtils.test.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.test.ts
@@ -161,7 +161,7 @@ describe("Can't slot seasonal mods", () => {
     expect(result).toEqual(false);
   });
 
-  it('fails when two any energy items and only one slot that can take them', () => {
+  it('fails when first slot cant be used and only one item to take both mods', () => {
     const mods = [getMod(7, 'opulent', 0), getMod(7, 'opulent', 0)].sort(
       sortProcessModMetadataOrProcessItem
     );

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -47,9 +47,9 @@ export function canTakeAllSeasonalMods(
       (sortedItems[itemIndex].energyType === energyType || energyType === DestinyEnergyType.Any) &&
       sortedItems[itemIndex].compatibleModSeasons?.includes(tag)
     ) {
+      sortedItems.splice(itemIndex, 1);
       modIndex += 1;
       itemIndex = 0;
-      sortedItems.splice(itemIndex, 1);
     } else {
       itemIndex += 1;
     }


### PR DESCRIPTION
In process mod assignment, fixed an issue where we were resetting an item index before we used it to remove an allocate a mod to an item.

Wrote tests for it.

Fixes #5495 