### PR TITLE
Fixed issue where negative modded stat bars were incorrect

### DIFF
--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -49,11 +49,7 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
 
   const moddedStatValue = item && getModdedStatValue(item, stat);
 
-  let baseBar = item ? Math.min(stat.base, stat.value) : stat.value;
-
-  if (moddedStatValue && moddedStatValue < 0) {
-    baseBar = Math.max(0, baseBar + moddedStatValue);
-  }
+  const baseBar = item ? Math.min(stat.base, stat.value) : stat.value;
 
   const segments: [number, string?][] = [[baseBar]];
 


### PR DESCRIPTION
It looks like we have both been messing with this.

Before:
![image](https://user-images.githubusercontent.com/7344652/88477904-38480500-cf87-11ea-8701-992b596170c4.png)

After:
![image](https://user-images.githubusercontent.com/7344652/88477905-3bdb8c00-cf87-11ea-89f3-61c96ae48fb5.png)
