### PR TITLE
Update htaccess to allow access to /.well-known

### DIFF
--- a/src/htaccess
+++ b/src/htaccess
@@ -519,15 +519,15 @@ AddDefaultCharset utf-8
 # https://www.mnot.net/blog/2010/04/07/well-known
 # https://tools.ietf.org/html/rfc5785
 
-<IfModule mod_rewrite.c>
-    RewriteEngine On
-    RewriteCond %{REQUEST_URI} "!(^|/)\.well-known/([^./]+./?)+$" [NC]
-    RewriteCond %{SCRIPT_FILENAME} -d [OR]
-    RewriteCond %{SCRIPT_FILENAME} -f
-    RewriteRule "(^|/)\." - [F]
-</IfModule>
+# <IfModule mod_rewrite.c>
+#     RewriteEngine On
+#     RewriteCond %{REQUEST_URI} "!(^|/)\.well-known/([^./]+./?)+$" [NC]
+#     RewriteCond %{SCRIPT_FILENAME} -d [OR]
+#     RewriteCond %{SCRIPT_FILENAME} -f
+#     RewriteRule "(^|/)\." - [F]
+# </IfModule>
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -	
 
 # Block access to files that can expose sensitive information.
 #
@@ -738,6 +738,13 @@ AddEncoding br .br
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} !\.(json|wasm|js|css|png|jpg|map)(\.(gz|br))?$
     RewriteRule (.*) index.html [QSA,L]
+    
+    # Block access to all hidden files and directories with the exception of
+    # the visible content from within the `/.well-known/` hidden directory.
+    RewriteCond %{REQUEST_URI} "!(^|/)\.well-known/([^./]+./?)+$" [NC]
+    RewriteCond %{SCRIPT_FILENAME} -d [OR]
+    RewriteCond %{SCRIPT_FILENAME} -f
+    RewriteRule "(^|/)\." - [F]
 </IfModule>
 
 # Our host seems to want to force the .gz files to be application/x-gzip


### PR DESCRIPTION
The `/.well-known` directory needs to resolve its files, currently it redirects to `/index.html`

https://tools.ietf.org/html/rfc8615
https://developers.google.com/digital-asset-links/v1/getting-started