### PR TITLE
centralize known values

### DIFF
--- a/src/app/collections/MetricBanner.tsx
+++ b/src/app/collections/MetricBanner.tsx
@@ -6,6 +6,7 @@ import styles from './MetricBanner.m.scss';
 import masterworkOverlay from 'images/masterwork-metric.png';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import clsx from 'clsx';
+import { ALL_TRAIT } from 'app/search/d2-known-values';
 
 interface Props {
   metricHash: number;
@@ -22,7 +23,7 @@ export default function MetricBanner({ metricHash, defs, objectiveProgress, clas
   const metricIcon = metricDef.displayProperties.icon;
 
   const metricScope = metricDef.traitHashes
-    .filter((h) => h !== 1434215347)
+    .filter((h) => h !== ALL_TRAIT)
     .map((h) => defs.Trait.get(h))[0];
   const parentNode = defs.PresentationNode.get(metricDef.parentNodeHashes[0]);
 

--- a/src/app/collections/Metrics.tsx
+++ b/src/app/collections/Metrics.tsx
@@ -8,6 +8,7 @@ import {
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import styles from './Metrics.m.scss';
 import BungieImage from 'app/dim-ui/BungieImage';
+import { ALL_TRAIT } from 'app/search/d2-known-values';
 
 export default function Metrics({
   metrics,
@@ -25,7 +26,7 @@ export default function Metrics({
       if (!metricDef) {
         return null;
       }
-      return metricDef.traitHashes.filter((h) => h !== 1434215347)[0];
+      return metricDef.traitHashes.filter((h) => h !== ALL_TRAIT)[0];
     }
   );
 

--- a/src/app/collections/PresentationNode.tsx
+++ b/src/app/collections/PresentationNode.tsx
@@ -19,6 +19,7 @@ import { t } from 'app/i18next-t';
 import { settingsSelector } from 'app/settings/reducer';
 import Metrics from './Metrics';
 import ErrorPanel from 'app/shell/ErrorPanel';
+import { TRIUMPHS_ROOT_NODE } from 'app/search/d2-known-values';
 
 /** root PresentationNodes to lock in expanded state */
 const rootNodes = [3790247699];
@@ -127,7 +128,7 @@ class PresentationNode extends React.Component<Props> {
     // todo: export this hash/depth and clean up the boolean string
     const alwaysExpanded =
       // if we're not in triumphs
-      (thisAndParents[0] !== 1024788583 &&
+      (thisAndParents[0] !== TRIUMPHS_ROOT_NODE &&
         // & we're 4 levels deep(collections:weapon), or in CategorySet & 5 deep (collections:armor)
         thisAndParents.length >= (aParentIsCategorySetStyle ? 5 : 4)) ||
       // or this is manually selected to be forced expanded
@@ -228,7 +229,7 @@ class PresentationNode extends React.Component<Props> {
             </div>
           </div>
         )}
-        {childrenExpanded && presentationNodeHash === 1024788583 && (
+        {childrenExpanded && presentationNodeHash === TRIUMPHS_ROOT_NODE && (
           <div className="presentationNodeOptions">
             <Checkbox
               label={t('Triumphs.HideCompleted')}

--- a/src/app/collections/PresentationNodeRoot.tsx
+++ b/src/app/collections/PresentationNodeRoot.tsx
@@ -14,6 +14,7 @@ import _ from 'lodash';
 import Record, { getRecordComponent } from './Record';
 import { getMetricComponent } from './Metric';
 import { itemsForPlugSet } from './plugset-helpers';
+import { TRIUMPHS_ROOT_NODE } from 'app/search/d2-known-values';
 
 interface Props {
   presentationNodeHash: number;
@@ -75,7 +76,7 @@ export default class PresentationNodeRoot extends React.Component<Props, State> 
 
     return (
       <>
-        {presentationNodeHash === 1024788583 && trackedRecordHash !== undefined && (
+        {presentationNodeHash === TRIUMPHS_ROOT_NODE && trackedRecordHash !== undefined && (
           <div className="progress-for-character">
             <div className="records">
               <Record

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -454,25 +454,6 @@ class Compare extends React.Component<Props, State> {
       return itemRpmStat?.value || -99999999;
     };
 
-    /* disabled for now
-    const weaponTypes = Object.keys(intrinsicLookupTable).map(Number);
-    const thisWeaponsType =
-      weaponTypes.find((h) => exampleItem.itemCategoryHashes.includes(h)) || -99999999;
-      const matchingIntrisics = intrinsicLookupTable[thisWeaponsType]?.[exampleItemRpm];
-      const intrinsicPerk =
-        matchingIntrisics &&
-        this.props.defs &&
-        this.props.defs.InventoryItem.get(matchingIntrisics[0]);
-      const intrinsicName = intrinsicPerk?.displayProperties.name || t('Compare.Archetype');
-      const getIntrinsicPerk: (item: D2Item) => number = (item) => {
-      const intrinsic =
-        item.sockets &&
-        item.sockets.sockets.find((s) =>
-          s.plug?.plugItem.itemCategoryHashes?.includes(INTRINSIC_PLUG_CATEGORY)
-        );
-      return intrinsic?.plug?.plugItem.hash || -99999999;
-    };
-      */
     const exampleItemRpm = getRpm(exampleItem);
     const intrinsic = exampleItem.isDestiny2() ? getWeaponArchetype(exampleItem) : undefined;
     const intrinsicName = intrinsic?.displayProperties.name || t('Compare.Archetype');

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -8,6 +8,7 @@ import { t } from 'app/i18next-t';
 import RecoilStat from 'app/item-popup/RecoilStat';
 import ElementIcon from 'app/inventory/ElementIcon';
 import { PowerCapDisclaimer } from 'app/dim-ui/PowerCapDisclaimer';
+import { RECOIL_DIRECTION } from 'app/search/d2-known-values';
 
 export default function CompareStat({
   stat,
@@ -34,7 +35,7 @@ export default function CompareStat({
           <ElementIcon element={item.element} />
         )}
         {itemStat?.value !== undefined ? (
-          itemStat.statHash === 2715839340 ? (
+          itemStat.statHash === RECOIL_DIRECTION ? (
             <span className="stat-recoil">
               <span>{itemStat.value}</span>
               <RecoilStat value={itemStat.value} />

--- a/src/app/destinyTrackerApi/d2-itemTransformer.ts
+++ b/src/app/destinyTrackerApi/d2-itemTransformer.ts
@@ -5,9 +5,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { D2Item } from '../inventory/item-types';
 import { DtrD2BasicItem, D2ItemFetchRequest } from '../item-review/d2-dtr-api-types';
-
-const MOD_CATEGORY = 59;
-const POWER_STAT_HASH = 1935470627;
+import { MOD_CATEGORY, POWER_STAT } from 'app/search/d2-known-values';
 
 /**
  * Lookup keys for review data in the cache.
@@ -145,7 +143,7 @@ function getPowerMods(item: D2Item): DestinyInventoryItemDefinition[] {
     ? _.compact(item.sockets.sockets.map((p) => p.plug?.plugItem ?? null)).filter(
         (plug) =>
           plug.itemCategoryHashes?.includes(MOD_CATEGORY) &&
-          plug.investmentStats?.some((s) => s.statTypeHash === POWER_STAT_HASH)
+          plug.investmentStats?.some((s) => s.statTypeHash === POWER_STAT)
       )
     : [];
 }

--- a/src/app/destinyTrackerApi/d2-perkRater.ts
+++ b/src/app/destinyTrackerApi/d2-perkRater.ts
@@ -3,7 +3,11 @@ import { count } from '../utils/util';
 import { D2Item } from '../inventory/item-types';
 import { D2ItemUserReview } from '../item-review/d2-dtr-api-types';
 import { dtrTextReviewMultiplier } from './dtr-service-helper';
-import { MASTERWORK_MOD_CATEGORY } from 'app/inventory/store/sockets';
+import {
+  MASTERWORK_MOD_CATEGORY,
+  UPGRADE_MASTERWORK,
+  WEAPON_ORNAMENTS,
+} from 'app/search/d2-known-values';
 
 export interface RatingAndReview {
   ratingCount: number;
@@ -32,8 +36,8 @@ export function ratePerks(item: D2Item, itemReviews?: D2ItemUserReview[]): Set<n
       const anyOrnamentsOrCatalysts = socket.plugOptions.some(
         (po) =>
           po.plugItem.itemCategoryHashes?.some(
-            (ich) => ich === 3124752623 || ich === MASTERWORK_MOD_CATEGORY // weapon mods: ornaments, masterworks mods
-          ) || po.plugItem.hash === 3547298846 // upgrade masterwork
+            (ich) => ich === WEAPON_ORNAMENTS || ich === MASTERWORK_MOD_CATEGORY // weapon mods: ornaments, masterworks mods
+          ) || po.plugItem.hash === UPGRADE_MASTERWORK // upgrade masterwork
       );
 
       if (!anyOrnamentsOrCatalysts) {

--- a/src/app/dim-ui/WeaponArchetype.ts
+++ b/src/app/dim-ui/WeaponArchetype.ts
@@ -1,9 +1,11 @@
 import { D2Item } from 'app/inventory/item-types';
+import { INTRINSIC_TRAITS_SOCKET_CATEGORY } from 'app/search/d2-known-values';
 
 export const getWeaponArchetypeSocket = (item: D2Item) =>
   (item.bucket.inWeapons &&
     !item.isExotic &&
-    item.sockets?.categories.find((c) => c.category.hash === 3956125808)?.sockets[0]) ||
+    item.sockets?.categories.find((c) => c.category.hash === INTRINSIC_TRAITS_SOCKET_CATEGORY)
+      ?.sockets[0]) ||
   undefined;
 
 export const getWeaponArchetype = (item: D2Item) => getWeaponArchetypeSocket(item)?.plug?.plugItem;

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -11,6 +11,7 @@ import styles from './InventoryItem.m.scss';
 import NewItemIndicator from './NewItemIndicator';
 import TagIcon from './TagIcon';
 import { selectedSubclassPath } from './subclass';
+import { SUBCLASS_BUCKET } from 'app/search/d2-known-values';
 
 const itemTierDogearStyles = {
   Legendary: styles.legendary,
@@ -147,7 +148,7 @@ export default function InventoryItem({
 export function borderless(item: DimItem) {
   return (
     (item.isDestiny2?.() &&
-      (item.bucket.hash === 3284755031 || item.itemCategoryHashes?.includes(268598612))) ||
+      (item.bucket.hash === SUBCLASS_BUCKET || item.itemCategoryHashes?.includes(268598612))) ||
     item.isEngram
   );
 }

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -20,6 +20,7 @@ import { t } from 'app/i18next-t';
 import clsx from 'clsx';
 import { characterOrderSelector } from 'app/settings/character-sort';
 import { emptyArray } from 'app/utils/empty';
+import { ENGRAMS_BUCKET } from 'app/search/d2-known-values';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -123,7 +124,7 @@ class StoreBucket extends React.Component<Props> {
             <StoreInventoryItem key={item.index} item={item} />
           ))}
           {store.isDestiny2() &&
-          bucket.hash === 375726501 && // Engrams. D1 uses this same bucket hash for "Missions"
+          bucket.hash === ENGRAMS_BUCKET && // Engrams. D1 uses this same bucket hash for "Missions"
             _.times(bucket.capacity - unequippedItems.length, (index) => (
               <img src={emptyEngram} className="empty-engram" aria-hidden="true" key={index} />
             ))}

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -19,6 +19,7 @@ import { getRating } from '../item-review/reducer';
 import { getSpecialtySocketMetadata, getMasterworkStatNames } from 'app/utils/item-utils';
 import store from '../store/store';
 import { t } from 'app/i18next-t';
+import { dimArmorStatHashByName } from 'app/search/search-filter-values';
 
 // step node names we'll hide, we'll leave "* Chroma" for now though, since we don't otherwise indicate Chroma
 const FILTER_NODE_NAMES = [
@@ -285,16 +286,6 @@ export function source(item: DimItem) {
   }
 }
 
-export const armorStatHashes = {
-  Mobility: 2996146975,
-  Resilience: 392767087,
-  Recovery: 1943323491,
-  Discipline: 1735777505,
-  Intellect: 144602215,
-  Strength: 4244567218,
-  Total: -1000,
-};
-
 function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, itemInfos: ItemInfos) {
   // We need to always emit enough columns for all perks
   const maxPerks = getMaxPerks(items);
@@ -384,9 +375,9 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
       row.Disc = stats.Discipline ? stats.Discipline.value : 0;
       row.Str = stats.Strength ? stats.Strength.value : 0;
     } else {
-      const armorStats = Object.keys(armorStatHashes).map((statName) => ({
+      const armorStats = Object.keys(dimArmorStatHashByName).map((statName) => ({
         name: statName,
-        stat: stats[armorStatHashes[statName]],
+        stat: stats[dimArmorStatHashByName[statName]],
       }));
       armorStats.forEach((stat) => {
         row[stat.name] = stat.stat ? stat.stat.value : 0;

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -31,6 +31,14 @@ import { buildTalentGrid } from './talent-grids';
 import { reportException } from '../../utils/exceptions';
 import { t } from 'app/i18next-t';
 import { getSeason } from './season';
+import {
+  ATTACK_STAT,
+  DEFENSE_STAT,
+  ENGRAMS_BUCKET,
+  MODIFICATIONS_BUCKET,
+  SHADERS_BUCKET,
+  THE_FORBIDDEN_BUCKET,
+} from 'app/search/d2-known-values';
 
 // Maps tierType to tierTypeName in English
 const tiers = ['Unknown', 'Currency', 'Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'];
@@ -256,8 +264,8 @@ export function makeItem(
   let normalBucket = buckets.byHash[itemDef.inventory.bucketTypeHash];
 
   // https://github.com/Bungie-net/api/issues/687
-  if (itemDef.inventory.bucketTypeHash === 2422292810) {
-    normalBucket = buckets.byHash[3313201758];
+  if (itemDef.inventory.bucketTypeHash === THE_FORBIDDEN_BUCKET) {
+    normalBucket = buckets.byHash[MODIFICATIONS_BUCKET];
   }
 
   // item.bucket is where it IS right now
@@ -278,7 +286,7 @@ export function makeItem(
 
   // 34 = category hash for engrams
   const isEngram =
-    itemDef.itemCategoryHashes?.includes(34) || normalBucket.hash === 375726501 || false;
+    itemDef.itemCategoryHashes?.includes(34) || normalBucket.hash === ENGRAMS_BUCKET || false;
 
   // https://github.com/Bungie-net/api/issues/134, class items had a primary stat
   // https://github.com/Bungie-net/api/issues/1079, engrams had a primary stat
@@ -436,7 +444,7 @@ export function makeItem(
     createdItem.lockable ||
       createdItem.classified ||
       // Shaders
-      createdItem.bucket.hash === 2973005342
+      createdItem.bucket.hash === SHADERS_BUCKET
   );
   createdItem.comparable = Boolean(createdItem.equipment && createdItem.lockable);
   createdItem.reviewable = Boolean(
@@ -594,8 +602,8 @@ export function makeItem(
 function isWeaponOrArmor1OrExoticArmor2(item: D2Item) {
   return (
     item.primStat &&
-    (item.primStat.statHash === 1480404414 || // weapon
-      (item.primStat.statHash === 3897883278 && // armor
+    (item.primStat.statHash === ATTACK_STAT || // weapon
+      (item.primStat.statHash === DEFENSE_STAT && // armor
         (!item.energy || // energy is an armor 2.0 signifier
           item.isExotic))) // but we want to allow exotic armor 2.0 reviews
   );

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -1,6 +1,7 @@
 import { D2Item, DimSockets, DimMasterwork } from '../item-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DamageType } from 'bungie-api-ts/destiny2';
+import { VANGUARD_MASTERWORK_PCH } from 'app/search/d2-known-values';
 
 /**
  * These are the utilities that deal with figuring out Masterwork info.
@@ -148,7 +149,10 @@ function buildMasterworkInfo(
 
   return {
     progress: plugObjective.progress,
-    typeName: socket.plug.plugItem.plug.plugCategoryHash === 2109207426 ? 'Vanguard' : 'Crucible',
+    typeName:
+      socket.plug.plugItem.plug.plugCategoryHash === VANGUARD_MASTERWORK_PCH
+        ? 'Vanguard'
+        : 'Crucible',
     typeIcon: objectiveDef.displayProperties.icon,
     typeDesc: objectiveDef.progressDescription,
     tier: socket.plug?.plugItem.investmentStats[0].value,

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -13,49 +13,19 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimSockets, DimSocketCategory, DimSocket, DimPlug } from '../item-types';
 import { compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
+import {
+  EXCLUDED_PLUGS,
+  GHOST_MOD_CATEGORY,
+  INTRINSIC_ITEM_CATEGORY,
+  MASTERWORK_MOD_CATEGORY,
+} from 'app/search/d2-known-values';
 
-/**
- * These are the utilities that deal with Sockets and Plugs on items. Sockets and Plugs
- * are how perks, mods, and many other things are implemented on items.
- *
- * This is called from within d2-item-factory.service.ts
- */
-
-/**
- * Plugs to hide from plug options (if not socketed)
- * removes the "Default Ornament" plug, "Default Shader" and "Rework Masterwork"
- * TODO: with AWA we may want to put some of these back
- */
-const EXCLUDED_PLUGS = new Set([
-  // Default ornament
-  2931483505,
-  1959648454,
-  702981643,
-  // Rework Masterwork
-  39869035,
-  1961001474,
-  3612467353,
-  // Default Shader
-  4248210736,
-]);
-
-/** The item category hash for "intrinsic perk" */
-export const INTRINSIC_PLUG_CATEGORY = 2237038328;
-/** The item category hash for "masterwork mods" */
-export const MASTERWORK_MOD_CATEGORY = 141186804;
-/** The item category hash for "ghost projections" */
-const GHOST_MOD_CATEGORY = 1404791674;
-
-/** the default shader InventoryItem in every empty shader slot */
-export const DEFAULT_SHADER = 4248210736;
-
-/** the default glow InventoryItem in every empty glow slot */
-export const DEFAULT_GLOW = 3807544519;
-/** The item category hash for "glows" */
-export const DEFAULT_GLOW_CATEGORY = 1875601085;
-
-/** An array of default ornament hashes */
-export const DEFAULT_ORNAMENTS: number[] = [2931483505, 1959648454, 702981643];
+//
+// These are the utilities that deal with Sockets and Plugs on items. Sockets and Plugs
+// are how perks, mods, and many other things are implemented on items.
+//
+// This is called from within d2-item-factory.service.ts
+//
 
 /**
  * Calculate all the sockets we want to display (or make searchable). Sockets represent perks,
@@ -379,7 +349,7 @@ function addPlugOption(
       plugOptions.push(plug);
     } else {
       // API Bugfix: Filter out intrinsic perks past the first: https://github.com/Bungie-net/api/issues/927
-      if (!built.plugItem.itemCategoryHashes?.includes(INTRINSIC_PLUG_CATEGORY)) {
+      if (!built.plugItem.itemCategoryHashes?.includes(INTRINSIC_ITEM_CATEGORY)) {
         plugOptions.push(built);
       }
     }

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -16,7 +16,16 @@ import { compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
 import { t } from 'app/i18next-t';
 import { getSocketsWithStyle, getSocketsWithPlugCategoryHash } from '../../utils/socket-utils';
-import { D2ItemCategoryHashes } from 'app/search/d2-known-values';
+import {
+  ACCURACY,
+  armorBuckets,
+  D2ArmorStatHashByName,
+  D2ItemCategoryHashes,
+  D2WeaponStatHashByName,
+  swordStats,
+  TOTAL_STAT_HASH,
+} from 'app/search/d2-known-values';
+import { D1ItemCategoryHashes } from 'app/search/d1-known-values';
 
 /**
  * These are the utilities that deal with Stats on items - specifically, how to calculate them.
@@ -36,65 +45,65 @@ import { D2ItemCategoryHashes } from 'app/search/d2-known-values';
 
 /** Stats that all armor should have. */
 export const armorStats = [
-  2996146975, // Mobility
-  392767087, // Resilience
-  1943323491, // Recovery
-  1735777505, // Discipline
-  144602215, // Intellect
-  4244567218, // Strength
+  D2ArmorStatHashByName.mobility, // Mobility
+  D2ArmorStatHashByName.resilience, // Resilience
+  D2ArmorStatHashByName.recovery, // Recovery
+  D2ArmorStatHashByName.discipline, // Discipline
+  D2ArmorStatHashByName.intellect, // Intellect
+  D2ArmorStatHashByName.strength, // Strength
 ];
 
 /**
  * Which stats to display, and in which order.
  */
 export const statAllowList = [
-  4284893193, // Rounds Per Minute
-  2961396640, // Charge Time
-  447667954, // Draw Time
-  3614673599, // Blast Radius
-  2523465841, // Velocity
-  2837207746, // Swing Speed (sword)
-  4043523819, // Impact
-  1240592695, // Range
-  2762071195, // Efficiency (sword)
-  209426660, // Defense (sword)
-  1591432999, // Accuracy
-  155624089, // Stability
-  943549884, // Handling
-  3022301683, // Charge Rate (Sword)
-  3736848092, // Guard Endurance
-  4188031367, // Reload Speed
-  1345609583, // Aim Assistance
-  3555269338, // Zoom
-  2715839340, // Recoil Direction
-  3871231066, // Magazine
-  1931675084, // Inventory Size
-  925767036, // Ammo Capacity
+  D2WeaponStatHashByName.rpm, // Rounds Per Minute
+  D2WeaponStatHashByName.charge, // Charge Time
+  D2WeaponStatHashByName.drawtime, // Draw Time
+  D2WeaponStatHashByName.blastradius, // Blast Radius
+  D2WeaponStatHashByName.velocity, // Velocity
+  swordStats.swingSpeed, // Swing Speed (sword)
+  D2WeaponStatHashByName.impact, // Impact
+  D2WeaponStatHashByName.range, // Range
+  swordStats.guardEfficiency, // Efficiency (sword)
+  swordStats.guardResistance, // Defense (sword)
+  ACCURACY, // Accuracy
+  D2WeaponStatHashByName.stability, // Stability
+  D2WeaponStatHashByName.handling, // Handling
+  swordStats.chargeRate, // Charge Rate (Sword)
+  swordStats.guardEndurance, // Guard Endurance
+  D2WeaponStatHashByName.reload, // Reload Speed
+  D2WeaponStatHashByName.aimassist, // Aim Assistance
+  D2WeaponStatHashByName.zoom, // Zoom
+  D2WeaponStatHashByName.recoildirection, // Recoil Direction
+  D2WeaponStatHashByName.magazine, // Magazine
+  D2WeaponStatHashByName.inventorysize, // Inventory Size
+  swordStats.ammoCapacity, // Ammo Capacity
   ...armorStats,
-  -1000, // Total
+  TOTAL_STAT_HASH, // Total
 ];
 
 /** Stats that should be forced to display without a bar (just a number). */
 const statsNoBar = [
-  4284893193, // Rounds Per Minute
-  3871231066, // Magazine
-  2961396640, // Charge Time
-  447667954, // Draw Time
-  1931675084, // Recovery
-  2715839340, // Recoil Direction
+  D2WeaponStatHashByName.rpm, // Rounds Per Minute
+  D2WeaponStatHashByName.magazine, // Magazine
+  D2WeaponStatHashByName.charge, // Charge Time
+  D2WeaponStatHashByName.drawtime, // Draw Time
+  D2WeaponStatHashByName.inventorysize, // Recovery
+  D2WeaponStatHashByName.recoildirection, // Recoil Direction
 ];
 
 /** Stats that are measured in milliseconds. */
 export const statsMs = [
-  447667954, // Draw Time
-  2961396640, // Charge Time
+  D2WeaponStatHashByName.drawtime, // Draw Time
+  D2WeaponStatHashByName.charge, // Charge Time
 ];
 
 /** Show these stats in addition to any "natural" stats */
 const hiddenStatsAllowList = [
-  1345609583, // Aim Assistance
-  3555269338, // Zoom
-  2715839340, // Recoil Direction
+  D2WeaponStatHashByName.aimassist, // Aim Assistance
+  D2WeaponStatHashByName.zoom, // Zoom
+  D2WeaponStatHashByName.recoildirection, // Recoil Direction
 ];
 
 /** Build the full list of stats for an item. If the item has no stats, this returns null. */
@@ -213,12 +222,15 @@ function shouldShowStat(
   statDisplays: { [key: number]: DestinyStatDisplayDefinition }
 ) {
   // Bows have a charge time stat that nobody asked for
-  if (statHash === 2961396640 && itemDef.itemCategoryHashes?.includes(3317538576)) {
+  if (
+    statHash === D2WeaponStatHashByName.charge &&
+    itemDef.itemCategoryHashes?.includes(D2ItemCategoryHashes.bow)
+  ) {
     return false;
   }
 
   // Swords shouldn't show any hidden stats
-  const includeHiddenStats = !itemDef.itemCategoryHashes?.includes(54);
+  const includeHiddenStats = !itemDef.itemCategoryHashes?.includes(D1ItemCategoryHashes.sword);
 
   return (
     // Must be on the AllowList
@@ -463,7 +475,7 @@ function buildBaseStats(
   item: D2Item
 ) {
   // Class Items always have a base stat of 0;
-  if (item.bucket.hash === 1585787867) {
+  if (item.bucket.hash === armorBuckets.classitem) {
     for (const stat of stats) {
       stat.base = 0;
     }
@@ -492,11 +504,11 @@ function totalStat(stats: DimStat[]): DimStat {
   const baseMayBeWrong = stats.some((stat) => stat.baseMayBeWrong);
   return {
     investmentValue: total,
-    statHash: -1000,
+    statHash: TOTAL_STAT_HASH,
     displayProperties: ({
       name: t('Stats.Total'),
     } as any) as DestinyDisplayPropertiesDefinition,
-    sort: statAllowList.indexOf(-1000),
+    sort: statAllowList.indexOf(TOTAL_STAT_HASH),
     value: total,
     base: baseTotal,
     baseMayBeWrong,
@@ -538,7 +550,9 @@ export function interpolateStatValue(value: number, statDisplay: DestinyStatDisp
 
   // vthorn has a hunch that magazine size doesn't use banker's rounding, but the rest definitely do:
   // https://github.com/Bungie-net/api/issues/1029#issuecomment-531849137
-  return statDisplay.statHash === 3871231066 ? Math.round(interpValue) : bankersRound(interpValue);
+  return statDisplay.statHash === D2WeaponStatHashByName.magazine
+    ? Math.round(interpValue)
+    : bankersRound(interpValue);
 }
 
 /**

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -16,7 +16,7 @@ import { compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
 import { t } from 'app/i18next-t';
 import { getSocketsWithStyle, getSocketsWithPlugCategoryHash } from '../../utils/socket-utils';
-import { D2CategoryHashes } from 'app/search/search-filter-values';
+import { D2ItemCategoryHashes } from 'app/search/d2-known-values';
 
 /**
  * These are the utilities that deal with Stats on items - specifically, how to calculate them.
@@ -167,7 +167,7 @@ function buildStatsFromMods(
 ): DimStat[] {
   const statTracker: { stat: number; value: number } | {} = {};
   const investmentStats: DimStat[] = [];
-  const modSockets = getSocketsWithPlugCategoryHash(itemSockets, D2CategoryHashes.armormod);
+  const modSockets = getSocketsWithPlugCategoryHash(itemSockets, D2ItemCategoryHashes.armormod);
   const masterworkSockets = getSocketsWithStyle(
     itemSockets,
     DestinySocketCategoryStyle.EnergyMeter

--- a/src/app/item-popup/EnergyMeter.tsx
+++ b/src/app/item-popup/EnergyMeter.tsx
@@ -4,7 +4,7 @@ import './EnergyMeter.scss';
 import { t } from 'app/i18next-t';
 import React from 'react';
 import ElementIcon from 'app/inventory/ElementIcon';
-import { energyNamesByEnum } from 'app/utils/item-utils';
+import { energyNamesByEnum } from 'app/search/d2-known-values';
 
 export default function EnergyMeter({ defs, item }: { defs: D2ManifestDefinitions; item: D2Item }) {
   if (!item.energy) {

--- a/src/app/item-popup/ItemMoveLocation.tsx
+++ b/src/app/item-popup/ItemMoveLocation.tsx
@@ -4,6 +4,7 @@ import { DimStore } from '../inventory/store-types';
 import { t } from 'app/i18next-t';
 import ItemActionButton, { ItemActionButtonGroup } from './ItemActionButton';
 import styles from './ItemMoveLocation.m.scss';
+import { FINISHERS_BUCKET, SEASONAL_ARTIFACT_BUCKET } from 'app/search/d2-known-values';
 
 interface Props {
   item: DimItem;
@@ -93,8 +94,8 @@ export default class ItemMoveLocation extends React.PureComponent<Props> {
     // Don't show "Store" for finishers, seasonal artifacts, or clan banners
     if (
       item.location.capacity === 1 ||
-      item.location.hash === 1506418338 ||
-      item.location.hash === 3683254069
+      item.location.hash === SEASONAL_ARTIFACT_BUCKET ||
+      item.location.hash === FINISHERS_BUCKET
     ) {
       return false;
     }

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -19,6 +19,7 @@ import ReactDOM from 'react-dom';
 import SocketDetails from './SocketDetails';
 import { LockedItemType } from 'app/loadout-builder/types';
 import { emptySet } from 'app/utils/empty';
+import { CHALICE_OF_OPULENCE, synthesizerHashes } from 'app/search/d2-known-values';
 
 interface ProvidedProps {
   item: D2Item;
@@ -85,9 +86,9 @@ function ItemSockets({
   }
 
   // special top level class for styling some specific items' popups differently
-  const itemSpecificClass = [1160544508, 1160544509, 1160544511, 3633698719].includes(item.hash)
+  const itemSpecificClass = synthesizerHashes.includes(item.hash)
     ? 'chalice' // to-do, maybe, someday: this should be 'synthesizer' but they share classes rn
-    : item.hash === 1115550924
+    : item.hash === CHALICE_OF_OPULENCE
     ? 'chalice'
     : null;
 

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -14,6 +14,7 @@ import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import { getSocketsWithStyle } from '../utils/socket-utils';
 import PressTip from 'app/dim-ui/PressTip';
 import { getPossiblyIncorrectStats } from 'app/utils/item-utils';
+import { RECOIL_DIRECTION, TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 
 // used in displaying the modded segments on item stats
 const modItemCategoryHashes = [
@@ -21,8 +22,6 @@ const modItemCategoryHashes = [
   4062965806, // armor mods (pre-2.0)
   4104513227, // armor 2.0 mods
 ];
-
-const TOTAL_STAT_HASH = -1000;
 
 /**
  * A single stat line.
@@ -123,7 +122,7 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
         </div>
       )}
 
-      {stat.statHash === 2715839340 && (
+      {stat.statHash === RECOIL_DIRECTION && (
         <div className={styles.statBar}>
           <RecoilStat value={stat.value} />
         </div>

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -8,9 +8,9 @@ import { InventoryWishListRoll } from '../wishlists/wishlists';
 import BungieImageAndAmmo from '../dim-ui/BungieImageAndAmmo';
 import BestRatedIcon from './BestRatedIcon';
 import PlugTooltip from './PlugTooltip';
-import { INTRINSIC_PLUG_CATEGORY } from 'app/inventory/store/sockets';
 import { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { LockedItemType } from 'app/loadout-builder/types';
+import { INTRINSIC_ITEM_CATEGORY } from 'app/search/d2-known-values';
 
 export default function Plug({
   defs,
@@ -96,7 +96,7 @@ export default function Plug({
       className={clsx('socket-container', className, {
         disabled: !plug.enabled,
         notChosen: plug !== socketInfo.plug,
-        notIntrinsic: !itemCategories.includes(INTRINSIC_PLUG_CATEGORY),
+        notIntrinsic: !itemCategories.includes(INTRINSIC_ITEM_CATEGORY),
       })}
       onClick={handleShiftClick}
     >

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -8,9 +8,10 @@ import { ArmorSet, statHashes, LockedArmor2ModMap, StatTypes } from '../types';
 import { calculateTotalTier, sumEnabledStats } from './utils';
 import { t } from 'app/i18next-t';
 import { statTier } from '../utils';
-import { Armor2ModPlugCategories, getPossiblyIncorrectStats } from 'app/utils/item-utils';
+import { getPossiblyIncorrectStats } from 'app/utils/item-utils';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import styles from './SetStats.m.scss';
+import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 
 interface Props {
   defs: D2ManifestDefinitions;
@@ -30,7 +31,7 @@ function SetStats({ defs, set, statOrder, enabledStats, lockedArmor2Mods }: Prop
 
   // Add general mod vaues for display purposes
   if ($featureFlags.armor2ModPicker) {
-    for (const lockedMod of lockedArmor2Mods[Armor2ModPlugCategories.general]) {
+    for (const lockedMod of lockedArmor2Mods[armor2PlugCategoryHashesByName.general]) {
       for (const stat of lockedMod.mod.investmentStats) {
         if (stat.statTypeHash === statHashes.Mobility) {
           displayStats.Mobility += stat.value;

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -9,6 +9,7 @@ import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { SocketDetailsMod } from 'app/item-popup/SocketDetails';
 import ClosableContainer from '../ClosableContainer';
+import { TRACTION_PERK } from 'app/search/d2-known-values';
 
 const badPerk = new Set([
   3201772785, // power weapon targeting
@@ -159,7 +160,7 @@ export function SelectablePerk({
     >
       <BungieImageAndAmmo
         className={clsx({
-          [styles.goodPerk]: perk.hash === 1818103563,
+          [styles.goodPerk]: perk.hash === TRACTION_PERK,
           [styles.badPerk]: isBadPerk,
         })}
         hash={perk.hash}
@@ -173,7 +174,7 @@ export function SelectablePerk({
             ? sandboxPerk.displayProperties.description
             : perk.displayProperties.description}
           {isBadPerk && <p>{t('LoadoutBuilder.BadPerk')}</p>}
-          {perk.hash === 1818103563 && t('LoadoutBuilder.Traction')}
+          {perk.hash === TRACTION_PERK && t('LoadoutBuilder.Traction')}
         </div>
       </div>
     </div>

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -2,7 +2,8 @@ import { DimItem } from '../inventory/item-types';
 import _ from 'lodash';
 import { LockableBuckets, LockedArmor2ModMap, LockedArmor2Mod } from './types';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
-import { getSpecialtySocketMetadata, Armor2ModPlugCategories } from 'app/utils/item-utils';
+import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
+import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 
 const energyOrder = [
   DestinyEnergyType.Void,
@@ -159,19 +160,35 @@ export function assignModsToArmorSet(
     assignments[item.hash] = [];
   }
 
-  assignGeneralMods(setToMatch, lockedArmor2Mods[Armor2ModPlugCategories.general], assignments);
-
-  assignModsForSlot(setToMatch[0], lockedArmor2Mods[Armor2ModPlugCategories.helmet], assignments);
-  assignModsForSlot(
-    setToMatch[1],
-    lockedArmor2Mods[Armor2ModPlugCategories.gauntlets],
+  assignGeneralMods(
+    setToMatch,
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.general],
     assignments
   );
-  assignModsForSlot(setToMatch[2], lockedArmor2Mods[Armor2ModPlugCategories.chest], assignments);
-  assignModsForSlot(setToMatch[3], lockedArmor2Mods[Armor2ModPlugCategories.leg], assignments);
+
+  assignModsForSlot(
+    setToMatch[0],
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.helmet],
+    assignments
+  );
+  assignModsForSlot(
+    setToMatch[1],
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.gauntlets],
+    assignments
+  );
+  assignModsForSlot(
+    setToMatch[2],
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.chest],
+    assignments
+  );
+  assignModsForSlot(
+    setToMatch[3],
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.leg],
+    assignments
+  );
   assignModsForSlot(
     setToMatch[4],
-    lockedArmor2Mods[Armor2ModPlugCategories.classitem],
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.classitem],
     assignments
   );
 
@@ -192,7 +209,7 @@ export function canSetTakeGeneralAndSeasonalMods(
   }
 
   // we ignore slot specific mods as they are prefiltered so should match up
-  assignGeneralMods(set, lockedArmor2Mods[Armor2ModPlugCategories.general], assignments);
+  assignGeneralMods(set, lockedArmor2Mods[armor2PlugCategoryHashesByName.general], assignments);
   assignAllSeasonalMods(set, lockedArmor2Mods.seasonal, assignments);
 
   let assignmentCount = 0;
@@ -202,6 +219,7 @@ export function canSetTakeGeneralAndSeasonalMods(
 
   return (
     assignmentCount ===
-    lockedArmor2Mods[Armor2ModPlugCategories.general].length + lockedArmor2Mods.seasonal.length
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.general].length +
+      lockedArmor2Mods.seasonal.length
   );
 }

--- a/src/app/loadout-builder/preProcessFilter.ts
+++ b/src/app/loadout-builder/preProcessFilter.ts
@@ -6,17 +6,18 @@ import {
   ItemsByBucket,
   LockedItemType,
 } from './types';
-import { Armor2ModPlugCategories, getItemDamageShortName } from 'app/utils/item-utils';
+import { getItemDamageShortName } from 'app/utils/item-utils';
 import { doEnergiesMatch } from './mod-utils';
 import { canSlotMod, getBaseStatValues } from './utils';
 import { DimItem } from 'app/inventory/item-types';
+import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 
 const bucketsToCategories = {
-  [LockableBuckets.helmet]: Armor2ModPlugCategories.helmet,
-  [LockableBuckets.gauntlets]: Armor2ModPlugCategories.gauntlets,
-  [LockableBuckets.chest]: Armor2ModPlugCategories.chest,
-  [LockableBuckets.leg]: Armor2ModPlugCategories.leg,
-  [LockableBuckets.classitem]: Armor2ModPlugCategories.classitem,
+  [LockableBuckets.helmet]: armor2PlugCategoryHashesByName.helmet,
+  [LockableBuckets.gauntlets]: armor2PlugCategoryHashesByName.gauntlets,
+  [LockableBuckets.chest]: armor2PlugCategoryHashesByName.chest,
+  [LockableBuckets.leg]: armor2PlugCategoryHashesByName.leg,
+  [LockableBuckets.classitem]: armor2PlugCategoryHashesByName.classitem,
 };
 
 /**

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -11,7 +11,6 @@ import {
 } from '../types';
 import { statTier } from '../utils';
 import { compareBy } from '../../utils/comparators';
-import { Armor2ModPlugCategories } from '../../utils/item-utils';
 import { statHashes } from '../types';
 import {
   ProcessItemsByBucket,
@@ -22,6 +21,7 @@ import {
 } from './types';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import { canTakeAllSeasonalMods, sortProcessModMetadataOrProcessItem } from './processUtils';
+import { armor2PlugCategoryHashesByName } from '../../search/d2-known-values';
 
 const RETURNED_ARMOR_SETS = 200;
 
@@ -141,7 +141,7 @@ export function process(
       assumeMasterwork,
       orderedStatValues,
       lockedItems[LockableBuckets.helmet],
-      lockedArmor2ModMap[Armor2ModPlugCategories.helmet]
+      lockedArmor2ModMap[armor2PlugCategoryHashesByName.helmet]
     )
   );
   const gaunts = multiGroupBy(
@@ -150,7 +150,7 @@ export function process(
       assumeMasterwork,
       orderedStatValues,
       lockedItems[LockableBuckets.gauntlets],
-      lockedArmor2ModMap[Armor2ModPlugCategories.gauntlets]
+      lockedArmor2ModMap[armor2PlugCategoryHashesByName.gauntlets]
     )
   );
   const chests = multiGroupBy(
@@ -159,7 +159,7 @@ export function process(
       assumeMasterwork,
       orderedStatValues,
       lockedItems[LockableBuckets.chest],
-      lockedArmor2ModMap[Armor2ModPlugCategories.chest]
+      lockedArmor2ModMap[armor2PlugCategoryHashesByName.chest]
     )
   );
   const legs = multiGroupBy(
@@ -168,7 +168,7 @@ export function process(
       assumeMasterwork,
       orderedStatValues,
       lockedItems[LockableBuckets.leg],
-      lockedArmor2ModMap[Armor2ModPlugCategories.leg]
+      lockedArmor2ModMap[armor2PlugCategoryHashesByName.leg]
     )
   );
   const classitems = multiGroupBy(
@@ -177,7 +177,7 @@ export function process(
       assumeMasterwork,
       orderedStatValues,
       lockedItems[LockableBuckets.classitem],
-      lockedArmor2ModMap[Armor2ModPlugCategories.classitem]
+      lockedArmor2ModMap[armor2PlugCategoryHashesByName.classitem]
     )
   );
 

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -1,9 +1,14 @@
 import _ from 'lodash';
-import { Armor2ModPlugCategories } from 'app/utils/item-utils';
 import { DimItem } from '../inventory/item-types';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
+import {
+  armor2PlugCategoryHashesByName,
+  armorBuckets,
+  D2ArmorStatHashByName,
+} from 'app/search/d2-known-values';
 
+// todo: get this from d2-known-values
 export type StatTypes =
   | 'Mobility'
   | 'Resilience'
@@ -12,6 +17,7 @@ export type StatTypes =
   | 'Intellect'
   | 'Strength';
 
+// todo: and this?
 export type BurnTypes = 'arc' | 'solar' | 'void';
 
 export interface MinMax {
@@ -69,7 +75,10 @@ export type LockedMap = Readonly<{
   [bucketHash: number]: readonly LockedItemType[] | undefined;
 }>;
 
-export const ModPickerCategories = { ...Armor2ModPlugCategories, seasonal: 'seasonal' } as const;
+export const ModPickerCategories = {
+  ...armor2PlugCategoryHashesByName,
+  seasonal: 'seasonal',
+} as const;
 export type ModPickerCategory = typeof ModPickerCategories[keyof typeof ModPickerCategories];
 
 export interface LockedArmor2Mod {
@@ -118,20 +127,21 @@ export type ItemsByBucket = Readonly<{
  * Bucket lookup, also used for ordering of the buckets.
  */
 export const LockableBuckets = {
-  helmet: 3448274439,
-  gauntlets: 3551918588,
-  chest: 14239492,
-  leg: 20886954,
-  classitem: 1585787867,
+  helmet: armorBuckets.helmet,
+  gauntlets: armorBuckets.gauntlets,
+  chest: armorBuckets.chest,
+  leg: armorBuckets.leg,
+  classitem: armorBuckets.classitem,
 };
 
+// to-do: deduplicate this and use D2ArmorStatHashByName instead
 export const statHashes: { [type in StatTypes]: number } = {
-  Mobility: 2996146975,
-  Resilience: 392767087,
-  Recovery: 1943323491,
-  Discipline: 1735777505,
-  Intellect: 144602215,
-  Strength: 4244567218,
+  Mobility: D2ArmorStatHashByName.mobility,
+  Resilience: D2ArmorStatHashByName.resilience,
+  Recovery: D2ArmorStatHashByName.recovery,
+  Discipline: D2ArmorStatHashByName.discipline,
+  Intellect: D2ArmorStatHashByName.intellect,
+  Strength: D2ArmorStatHashByName.strength,
 };
 
 export const statValues = Object.values(statHashes);

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -10,6 +10,11 @@ import {
   DestinyEnergyType,
 } from 'bungie-api-ts/destiny2';
 import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
+import {
+  INTRINSIC_PLUG_CATEGORY,
+  MODIFICATIONS_BUCKET,
+  Y1_ARMOR_MODS_PLUG_CATEGORY,
+} from 'app/search/d2-known-values';
 
 /**
  * Plug item hashes that should be excluded from the list of selectable perks.
@@ -64,7 +69,7 @@ export function filterPlugs(socket: DimSocket) {
 
   // Remove Archetype/Inherit perk
   if (
-    plugItem.plug.plugCategoryHash === 1744546145 &&
+    plugItem.plug.plugCategoryHash === INTRINSIC_PLUG_CATEGORY &&
     plugItem.inventory.tierType !== 6 // keep exotics
   ) {
     return false;
@@ -72,7 +77,7 @@ export function filterPlugs(socket: DimSocket) {
 
   // Remove empty mod slots
   if (
-    plugItem.plug.plugCategoryHash === 3347429529 &&
+    plugItem.plug.plugCategoryHash === Y1_ARMOR_MODS_PLUG_CATEGORY &&
     plugItem.inventory.tierType === TierType.Basic
   ) {
     return false;
@@ -91,7 +96,8 @@ export function filterPlugs(socket: DimSocket) {
   // Only real mods
   if (
     !socket.isPerk &&
-    (plugItem.inventory.bucketTypeHash !== 3313201758 || !plugItem.inventory.recoveryBucketTypeHash)
+    (plugItem.inventory.bucketTypeHash !== MODIFICATIONS_BUCKET ||
+      !plugItem.inventory.recoveryBucketTypeHash)
   ) {
     return false;
   }

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -12,6 +12,7 @@ import { settingsSelector } from 'app/settings/reducer';
 import store from 'app/store/store';
 import { emptyObject, emptyArray } from 'app/utils/empty';
 import { loadingStart, loadingEnd } from 'app/shell/actions';
+import { SUBCLASS_BUCKET } from 'app/search/d2-known-values';
 
 // This file exports D2ManifestService at the bottom of the
 // file (TS wants us to declare classes before using them)!
@@ -41,7 +42,7 @@ const tableTrimmers = {
       if (def.preview?.derivedItemCategories?.length) {
         def.preview.derivedItemCategories = emptyArray();
       }
-      if (def.inventory.bucketTypeHash !== 3284755031) {
+      if (def.inventory.bucketTypeHash !== SUBCLASS_BUCKET) {
         def.talentGrid = emptyObject();
       }
 

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -24,7 +24,6 @@ import { D2SeasonInfo } from 'data/d2/d2-season-info';
 import { DimItem, D1Item } from 'app/inventory/item-types';
 import { DtrRating } from 'app/item-review/dtr-api-types';
 import ElementIcon from 'app/inventory/ElementIcon';
-import { INTRINSIC_PLUG_CATEGORY } from 'app/inventory/store/sockets';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { ItemStatValue } from 'app/item-popup/ItemStat';
@@ -55,6 +54,7 @@ import { percent, getColor } from 'app/shell/filters';
 import { PowerCapDisclaimer } from 'app/dim-ui/PowerCapDisclaimer';
 import { getWeaponArchetype, getWeaponArchetypeSocket } from 'app/dim-ui/WeaponArchetype';
 import { isUsedModSocket } from 'app/utils/socket-utils';
+import { D2WeaponStatHashByName, INTRINSIC_ITEM_CATEGORY } from 'app/search/d2-known-values';
 
 /**
  * Get the ID used to select whether this column is shown or not.
@@ -102,11 +102,11 @@ export function getColumns(
 
   // Some stat labels are long. This lets us replace them with i18n
   const statLabels = {
-    4284893193: t('Organizer.Stats.RPM'),
-    4188031367: t('Organizer.Stats.Reload'), // Reload Speed
-    1345609583: t('Organizer.Stats.Aim'), // Aim Assistance
-    2715839340: t('Organizer.Stats.Recoil'), // Recoil Direction
-    1931675084: t('Organizer.Stats.Inventory'), // Inventory Size
+    [D2WeaponStatHashByName.rpm]: t('Organizer.Stats.RPM'),
+    [D2WeaponStatHashByName.reload]: t('Organizer.Stats.Reload'), // Reload Speed
+    [D2WeaponStatHashByName.aimassist]: t('Organizer.Stats.Aim'), // Aim Assistance
+    [D2WeaponStatHashByName.recoildirection]: t('Organizer.Stats.Recoil'), // Recoil Direction
+    [D2WeaponStatHashByName.inventorysize]: t('Organizer.Stats.Inventory'), // Inventory Size
   };
 
   type ColumnWithStat = ColumnDefinition & { statHash: number };
@@ -575,7 +575,7 @@ function PerksCell({
         isUsedModSocket(s) || // but we catch additional mods missing collectibleHash (arrivals)
           (s.isPerk &&
             (item.isExotic || // ignore archetype if it's not exotic
-              !s.plug.plugItem.itemCategoryHashes?.includes(INTRINSIC_PLUG_CATEGORY))))
+              !s.plug.plugItem.itemCategoryHashes?.includes(INTRINSIC_ITEM_CATEGORY))))
     )
   );
 

--- a/src/app/progress/LoadoutRequirementModifier.tsx
+++ b/src/app/progress/LoadoutRequirementModifier.tsx
@@ -4,8 +4,7 @@ import BungieImage from 'app/dim-ui/BungieImage';
 import PressTip from 'app/dim-ui/PressTip';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import './ActivityModifier.scss';
-
-export const armsmasterModifierHash = 3704166961;
+import { ARMSMASTER_ACTIVITY_MODIFIER } from 'app/search/d2-known-values';
 
 /**
  * This table lets us use localized names for ItemSubTypes, since they only exist as enum values.EquipmentSlot definitions.
@@ -75,7 +74,7 @@ export default function LoadoutRequirementModifier({
   }
 
   const activityDef = defs.Activity.get(activity.activityHash);
-  const modifier = defs.ActivityModifier.get(armsmasterModifierHash);
+  const modifier = defs.ActivityModifier.get(ARMSMASTER_ACTIVITY_MODIFIER);
 
   // Raid activities can have required loadouts, which fall under the "armsmaster" modifier. The
   // actual modifier text doesn't give the right info, so we'll build it ourselves from the loadout

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -26,6 +26,7 @@ import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { useSubscription } from 'app/utils/hooks';
 import { getStore, getCurrentStore } from 'app/inventory/stores-helpers';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
+import { RAID_NODE, SEALS_ROOT_NODE, TRIUMPHS_ROOT_NODE } from 'app/search/d2-known-values';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -121,9 +122,9 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets, profileInfo
     return null;
   }
 
-  const triumphTitle = defs.PresentationNode.get(1024788583).displayProperties.name;
-  const sealTitle = defs.PresentationNode.get(1652422747).displayProperties.name;
-  const raidTitle = defs.PresentationNode.get(2975760062).displayProperties.name;
+  const triumphTitle = defs.PresentationNode.get(TRIUMPHS_ROOT_NODE).displayProperties.name;
+  const sealTitle = defs.PresentationNode.get(SEALS_ROOT_NODE).displayProperties.name;
+  const raidTitle = defs.PresentationNode.get(RAID_NODE).displayProperties.name;
 
   const menuItems = [
     { id: 'ranks', title: t('Progress.CrucibleRank') },
@@ -205,7 +206,7 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets, profileInfo
               <section id="triumphs">
                 <ErrorBoundary name="Triumphs">
                   <PresentationNodeRoot
-                    presentationNodeHash={1024788583}
+                    presentationNodeHash={TRIUMPHS_ROOT_NODE}
                     defs={defs}
                     profileResponse={profileInfo}
                   />
@@ -215,7 +216,7 @@ function Progress({ account, defs, stores, isPhonePortrait, buckets, profileInfo
               <section id="seals">
                 <ErrorBoundary name="Seals">
                   <PresentationNodeRoot
-                    presentationNodeHash={1652422747}
+                    presentationNodeHash={SEALS_ROOT_NODE}
                     defs={defs}
                     profileResponse={profileInfo}
                   />

--- a/src/app/progress/RaidDisplay.tsx
+++ b/src/app/progress/RaidDisplay.tsx
@@ -7,7 +7,11 @@ import BungieImage from '../dim-ui/BungieImage';
 import CompletionCheckbox from './CompletionCheckbox';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { ActivityModifier } from './ActivityModifier';
-import LoadoutRequirementModifier, { armsmasterModifierHash } from './LoadoutRequirementModifier';
+import LoadoutRequirementModifier from './LoadoutRequirementModifier';
+import {
+  ARMSMASTER_ACTIVITY_MODIFIER,
+  ENCOUNTERS_COMPLETED_OBJECTIVE,
+} from 'app/search/d2-known-values';
 
 interface Props {
   displayProperties: DestinyDisplayPropertiesDefinition;
@@ -49,7 +53,7 @@ export function RaidActivity({
   displayName: string;
 }) {
   // a manifest-localized string describing raid segments with loot. "Encounters completed"
-  const encountersString = defs.Objective.get(3133307686).progressDescription;
+  const encountersString = defs.Objective.get(ENCOUNTERS_COMPLETED_OBJECTIVE).progressDescription;
 
   // convert character's DestinyMilestoneChallengeActivity to manifest's DestinyActivityDefinition
   const activityDef = defs.Activity.get(activity.activityHash);
@@ -63,7 +67,7 @@ export function RaidActivity({
       <div className="quest-modifiers">
         {activity.modifierHashes?.map(
           (modifierHash) =>
-            modifierHash !== armsmasterModifierHash && (
+            modifierHash !== ARMSMASTER_ACTIVITY_MODIFIER && (
               <ActivityModifier key={modifierHash} modifierHash={modifierHash} defs={defs} />
             )
         )}

--- a/src/app/progress/Raids.tsx
+++ b/src/app/progress/Raids.tsx
@@ -4,16 +4,7 @@ import { DestinyMilestone, DestinyProfileResponse } from 'bungie-api-ts/destiny2
 import _ from 'lodash';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimStore } from 'app/inventory/store-types';
-
-// unfortunately the API's raid .order attribute is odd
-const raidOrder = [
-  3660836525, // levi
-  2986584050, // eow
-  2683538554, // sos
-  3181387331, // wish
-  1342567285, // scourge
-  2590427074, // crown
-];
+import { raidOrder, RAID_ACTIVITY_TYPE } from 'app/search/d2-known-values';
 
 /**
  * Displays all of the raids available to a user as milestones
@@ -37,7 +28,8 @@ export default function Raids({
   const filteredMilestones = allMilestones.filter((milestone) => {
     const milestoneActivities = (defs.Milestone.get(milestone.milestoneHash) || {}).activities;
     return milestoneActivities?.some(
-      (activity) => (defs.Activity.get(activity.activityHash) || {}).activityTypeHash === 2043403989
+      (activity) =>
+        defs.Activity.get(activity.activityHash)?.activityTypeHash === RAID_ACTIVITY_TYPE
     );
   });
 

--- a/src/app/search/d1-known-values.ts
+++ b/src/app/search/d1-known-values.ts
@@ -2,11 +2,19 @@
 // this file has non-programatically decided information
 // hashes, names, & enums, hand-crafted and chosen by us
 
+//
+// STATS KNOWN VALUES
+//
+
 /** hashes representing D1 PL stats */
 export const D1LightStats = [
   3897883278, // Defense
   368428387, // Attack
 ];
+
+//
+// ITEMS / ITEMCATERGORY KNOWN VALUES
+//
 
 /** these weapons exist in D1&2 */
 export const D1ItemCategoryHashes = {
@@ -22,6 +30,10 @@ export const D1ItemCategoryHashes = {
   sidearm: 14,
   sword: 54,
 };
+
+//
+// OTHER STUFF
+//
 
 /** sublime engrams */
 export const sublimeEngrams = [

--- a/src/app/search/d1-known-values.ts
+++ b/src/app/search/d1-known-values.ts
@@ -1,0 +1,116 @@
+// ✨ magic values ✨
+// this file has non-programatically decided information
+// hashes, names, & enums, hand-crafted and chosen by us
+
+/** hashes representing D1 PL stats */
+export const D1LightStats = [
+  3897883278, // Defense
+  368428387, // Attack
+];
+
+/** these weapons exist in D1&2 */
+export const D1ItemCategoryHashes = {
+  autorifle: 5,
+  handcannon: 6,
+  pulserifle: 7,
+  scoutrifle: 8,
+  fusionrifle: 9,
+  sniperrifle: 10,
+  shotgun: 11,
+  machinegun: 12,
+  rocketlauncher: 13,
+  sidearm: 14,
+  sword: 54,
+};
+
+/** sublime engrams */
+export const sublimeEngrams = [
+  1986458096, // -gauntlet
+  2218811091,
+  2672986950, // -body-armor
+  779347563,
+  3497374572, // -class-item
+  808079385,
+  3592189221, // -leg-armor
+  738642122,
+  3797169075, // -helmet
+  838904328,
+];
+
+export const boosts = [
+  1043138475, // -black-wax-idol
+  1772853454, // -blue-polyphage
+  3783295803, // -ether-seeds
+  3446457162, // -resupply-codes
+];
+
+export const supplies = [
+  269776572, // -house-banners
+  3632619276, // -silken-codex
+  2904517731, // -axiomatic-beads
+  1932910919, // -network-keys
+];
+
+/** for D1 items: used to calculate which vendor an item could have come from */
+export const vendorHashes = {
+  required: {
+    fwc: [995344558], // SOURCE_VENDOR_FUTURE_WAR_CULT / Future War Cult
+    do: [103311758], // SOURCE_VENDOR_DEAD_ORBIT / Dead Orbit
+    nm: [3072854931], // SOURCE_VENDOR_NEW_MONARCHY / New Monarchy
+    speaker: [4241664776], // SOURCE_VENDOR_SPEAKER / Speaker
+    variks: [512830513], // SOURCE_VENDOR_FALLEN / Variks
+    shipwright: [3721473564], // SOURCE_VENDOR_SHIPWRIGHT / Shipwright
+    vanguard: [1482793537], // SOURCE_VENDOR_VANGUARD /
+    osiris: [3378481830], // SOURCE_VENDOR_OSIRIS / Osiris
+    xur: [2179714245], // SOURCE_VENDOR_BLACK_MARKET / Shaxx
+    shaxx: [4134961255], // SOURCE_VENDOR_CRUCIBLE_HANDLER /
+    cq: [1362425043], // SOURCE_VENDOR_CRUCIBLE_QUARTERMASTER / Crucible Quartermaster
+    eris: [1374970038], // SOURCE_VENDOR_CROTAS_BANE / Eris Morn
+    ev: [3559790162], // SOURCE_VENDOR_SPECIAL_ORDERS / Eververse
+    gunsmith: [353834582], // SOURCE_VENDOR_GUNSMITH /
+  },
+  restricted: {
+    fwc: [353834582], // remove motes of light & strange coins
+    do: [353834582],
+    nm: [353834582],
+    speaker: [353834582],
+    cq: [353834582, 2682516238], // remove ammo synths and planetary materials
+  },
+};
+
+/** for D1 items: used to calculate which activity an item could have come from
+ * "vanilla" has no hash but checks for year == 1
+ */
+export const D1ActivityHashes = {
+  required: {
+    trials: [2650556703], // SOURCE_TRIALS_OF_OSIRIS / Trials
+    ib: [1322283879], // SOURCE_IRON_BANNER / Iron Banner
+    qw: [1983234046], // SOURCE_QUEENS_EMISSARY_QUEST / Queen's Wrath
+    cd: [2775576620], // SOURCE_CRIMSON_DOUBLES / Crimson Doubles
+    srl: [1234918199], // SOURCE_SRL / Sparrow Racing League
+    vog: [440710167], // SOURCE_VAULT_OF_GLASS / Vault of Glass
+    ce: [2585003248], // SOURCE_CROTAS_END / Crota's End
+    ttk: [2659839637], // SOURCE_TTK / The Taken King
+    kf: [1662673928], // SOURCE_KINGS_FALL / King's Fall
+    roi: [2964550958], // SOURCE_RISE_OF_IRON / Rise of Iron
+    wotm: [4160622434], // SOURCE_WRATH_OF_THE_MACHINE / Wrath of the Machine
+    poe: [2784812137], // SOURCE_PRISON_ELDERS / Prison of Elders
+    coe: [1537575125], // SOURCE_POE_ELDER_CHALLENGE / Challenge of Elders
+    af: [3667653533], // SOURCE_ARCHON_FORGE / Archon Forge
+    dawning: [3131490494], // SOURCE_DAWNING /
+    aot: [3068521220, 4161861381, 440710167], // SOURCE_AGES_OF_TRIUMPH && SOURCE_RAID_REPRISE
+  },
+  restricted: {
+    trials: [2179714245, 2682516238, 560942287], // remove xur exotics and patrol items
+    ib: [3602080346], // remove engrams and random blue drops (Strike)
+    qw: [3602080346], // remove engrams and random blue drops (Strike)
+    cd: [3602080346], // remove engrams and random blue drops (Strike)
+    kf: [2179714245, 2682516238, 560942287], // remove xur exotics and patrol items
+    wotm: [2179714245, 2682516238, 560942287], // remove xur exotics and patrol items
+    poe: [3602080346, 2682516238], // remove engrams
+    coe: [3602080346, 2682516238], // remove engrams
+    af: [2682516238], // remove engrams
+    dawning: [2682516238, 1111209135], // remove engrams, planetary materials, & chroma
+    aot: [2964550958, 2659839637, 353834582, 560942287], // Remove ROI, TTK, motes, & glimmer items
+  },
+};

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -4,24 +4,117 @@ import { DestinyEnergyType, DamageType } from 'bungie-api-ts/destiny2';
 // this file has non-programatically decided information
 // hashes, names, & enums, hand-crafted and chosen by us
 
-/** hashes representing D2 PL stats */
-export const D2LightStats = [
-  1480404414, // Attack
-  3897883278, // Defense
+//
+// SOCKETS KNOWN VALUES
+//
+
+/**
+ * Plugs to hide from plug options (if not socketed)
+ * removes the "Default Ornament" plug, "Default Shader" and "Rework Masterwork"
+ * TODO: with AWA we may want to put some of these back
+ */
+export const EXCLUDED_PLUGS = new Set([
+  // Default ornament
+  2931483505,
+  1959648454,
+  702981643,
+  // Rework Masterwork
+  39869035,
+  1961001474,
+  3612467353,
+  // Default Shader
+  4248210736,
+]);
+
+/** The item category hash for "intrinsic perk" */
+export const INTRINSIC_ITEM_CATEGORY = 2237038328;
+/** The plug category hash for "intrinsic perk" */
+export const INTRINSIC_PLUG_CATEGORY = 1744546145;
+/** The socket category hash for holding intrinsic perks */
+export const INTRINSIC_TRAITS_SOCKET_CATEGORY = 3956125808;
+
+/** The item category hash for "masterwork mods" */
+export const MASTERWORK_MOD_CATEGORY = 141186804;
+/** The item category hash for "ghost projections" */
+export const GHOST_MOD_CATEGORY = 1404791674;
+
+/** the default shader InventoryItem in every empty shader slot */
+export const DEFAULT_SHADER = 4248210736;
+
+/** the default glow InventoryItem in every empty glow slot */
+export const DEFAULT_GLOW = 3807544519;
+/** The item category hash for "glows" */
+export const DEFAULT_GLOW_CATEGORY = 1875601085;
+
+/** An array of default ornament hashes */
+export const DEFAULT_ORNAMENTS: number[] = [2931483505, 1959648454, 702981643];
+
+export const MOD_CATEGORY = 59;
+export const WEAPON_GAMEPLAY_MODS_CATEGORY = 945330047;
+export const WEAPON_MODS_CATEGORY = 610365472;
+export const BONUS_MODS_CATEGORY = 303512563;
+
+export const ARMOR_MODS_CATEGORY = 4104513227;
+export const Y1_ARMOR_MODS_PLUG_CATEGORY = 3347429529;
+
+export const GHOST_PERKS_CATEGORY = 4176831154;
+
+export const WEAPON_ORNAMENTS = 3124752623;
+// the "upgrade masterwork" plug item
+export const UPGRADE_MASTERWORK = 3547298846;
+
+/** plugCategoryHash for the type of masterwork that tracks your PVE kills */
+export const VANGUARD_MASTERWORK_PCH = 2109207426;
+
+/** if a socket contains these, consider it empty */
+export const emptySocketHashes = [
+  2323986101, // InventoryItem "Empty Mod Socket"
+  2600899007, // InventoryItem "Empty Mod Socket"
+  1835369552, // InventoryItem "Empty Mod Socket"
+  3851138800, // InventoryItem "Empty Mod Socket"
+  791435474, // InventoryItem "Empty Activity Mod Socket"
 ];
 
-/** D2 has these item types but D1 doesn't */
-export const D2ItemCategoryHashes = {
-  grenadelauncher: 153950757,
-  tracerifle: 2489664120,
-  linearfusionrifle: 1504945536,
-  submachine: 3954685534,
-  bow: 3317538576,
-  transmat: 208981632,
-  weaponmod: 610365472,
-  armormod: 4104513227,
-  reptoken: 2088636411,
-};
+/** these are checked against default rolls to determine if something's curated */
+export const curatedPlugsAllowList = [
+  7906839, // frames
+  683359327, // guards
+  1041766312, // blades
+  1202604782, // tubes
+  1257608559, // arrows
+  1757026848, // batteries
+  1806783418, // magazines
+  2619833294, // scopes
+  2718120384, // magazines_gl
+  2833605196, // barrels
+  3809303875, // bowstring
+];
+
+export const armor2PlugCategoryHashesByName = {
+  general: 2487827355,
+  helmet: 2912171003,
+  gauntlets: 3422420680,
+  chest: 1526202480,
+  leg: 2111701510,
+  classitem: 912441879,
+} as const;
+
+export const armor2PlugCategoryHashes: number[] = Object.values(armor2PlugCategoryHashesByName);
+
+//
+// STATS KNOWN VALUES
+//
+
+/** the stat hash for DIM's artificial armor stat, "Total" */
+export const TOTAL_STAT_HASH = -1000;
+
+/** a weapon would have this */
+export const ATTACK_STAT = 1480404414;
+/** a piece of armor would have this */
+export const DEFENSE_STAT = 3897883278;
+
+/** hashes representing D2 PL stats */
+export const D2LightStats = [ATTACK_STAT, DEFENSE_STAT];
 
 /** these stats canonically exist on D2 armor */
 export const D2ArmorStatHashByName = {
@@ -53,29 +146,40 @@ export const D2WeaponStatHashByName = {
   inventorysize: 1931675084, // Stat "Inventory Size"
 };
 
-/** if a plug contains these, consider it empty */
-export const emptySocketHashes = [
-  2323986101, // InventoryItem "Empty Mod Socket"
-  2600899007, // InventoryItem "Empty Mod Socket"
-  1835369552, // InventoryItem "Empty Mod Socket"
-  3851138800, // InventoryItem "Empty Mod Socket"
-  791435474, // InventoryItem "Empty Activity Mod Socket"
-];
+export const swordStats = {
+  swingSpeed: 2837207746, // Swing Speed (sword)
+  guardEfficiency: 2762071195, // Efficiency (sword)
+  guardResistance: 209426660, // Defense (sword)
+  chargeRate: 3022301683, // Charge Rate (Sword)
+  guardEndurance: 3736848092, // Guard Endurance
+  ammoCapacity: 925767036, // Ammo Capacity
+};
 
-/** these are checked against default rolls to determine if something's curated */
-export const curatedPlugsAllowList = [
-  7906839, // frames
-  683359327, // guards
-  1041766312, // blades
-  1202604782, // tubes
-  1257608559, // arrows
-  1757026848, // batteries
-  1806783418, // magazines
-  2619833294, // scopes
-  2718120384, // magazines_gl
-  2833605196, // barrels
-  3809303875, // bowstring
-];
+export const ACCURACY = 1591432999; // Accuracy
+export const RECOIL_DIRECTION = D2WeaponStatHashByName.recoildirection;
+export const POWER_STAT = 1935470627;
+
+//
+// ITEMS / ITEMCATERGORY KNOWN VALUES
+//
+
+/** D2 has these item types but D1 doesn't */
+export const D2ItemCategoryHashes = {
+  grenadelauncher: 153950757,
+  tracerifle: 2489664120,
+  linearfusionrifle: 1504945536,
+  submachine: 3954685534,
+  bow: 3317538576,
+  transmat: 208981632,
+  weaponmod: 610365472,
+  armormod: 4104513227,
+  reptoken: 2088636411,
+};
+
+// these specific items have socket display exceptions. see ItemSockets.tsx
+// review the need for this after season 12 starts
+export const synthesizerHashes = [1160544508, 1160544509, 1160544511, 3633698719];
+export const CHALICE_OF_OPULENCE = 1115550924;
 
 /** powerful rewards listed in quests or bounties */
 // TODO: generate in d2ai
@@ -95,7 +199,68 @@ export const powerfulSources = [
   4249081773, // InventoryItem "Powerful Armor"
 ];
 
-export const shaderBucket = 2973005342;
+//
+// BUCKETS KNOWN VALUES
+//
+
+/** a weird bucket for holding dummies, which items show up in only temporarily */
+export const THE_FORBIDDEN_BUCKET = 2422292810;
+
+export const SHADERS_BUCKET = 2973005342;
+export const SUBCLASS_BUCKET = 3284755031;
+export const ENGRAMS_BUCKET = 375726501;
+export const MODIFICATIONS_BUCKET = 3313201758;
+export const CONSUMABLES_BUCKET = 1469714392;
+export const MATERIALS_BUCKET = 3865314626;
+export const SEASONAL_ARTIFACT_BUCKET = 1506418338;
+export const FINISHERS_BUCKET = 3683254069;
+
+export const armorBuckets = {
+  helmet: 3448274439,
+  gauntlets: 3551918588,
+  chest: 14239492,
+  leg: 20886954,
+  classitem: 1585787867,
+};
+
+//
+// PRESENTATION NODE KNOWN VALUES
+//
+
+export const TRIUMPHS_ROOT_NODE = 1024788583;
+export const SEALS_ROOT_NODE = 1652422747;
+export const RAID_NODE = 2975760062;
+
+//
+// MISC KNOWN VALUES
+//
+
+export const ENCOUNTERS_COMPLETED_OBJECTIVE = 3133307686;
+
+export const ARMSMASTER_ACTIVITY_MODIFIER = 3704166961;
+
+export const TRACTION_PERK = 1818103563;
+
+// unfortunately the API's raid .order attribute is odd
+export const raidOrder = [
+  3660836525, // levi
+  2986584050, // eow
+  2683538554, // sos
+  3181387331, // wish
+  1342567285, // scourge
+  2590427074, // crown
+];
+
+/** used for checking if something is a raid */
+export const RAID_ACTIVITY_TYPE = 2043403989;
+
+/** "The Spider", from whom we calculate planetmat info */
+export const SPIDER_VENDOR = 863940356;
+/** rahool. we override how his vendor FakeItems are displayed */
+export const RAHOOL_VENDOR = 2255782930;
+
+/** an "All" trait we want to filter out of trait lists */
+export const ALL_TRAIT = 1434215347;
 
 export const energyNamesByEnum: { [key in DestinyEnergyType]: string } = {
   [DestinyEnergyType.Any]: 'any',
@@ -113,15 +278,6 @@ export const damageNamesByEnum: { [key in DamageType]: string | null } = {
   4: 'void',
   5: 'raid',
 };
-
-export const Armor2ModPlugCategories = {
-  general: 2487827355,
-  helmet: 2912171003,
-  gauntlets: 3422420680,
-  chest: 1526202480,
-  leg: 2111701510,
-  classitem: 912441879,
-} as const;
 
 export const breakerTypes = {
   barrier: 485622768,

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -1,0 +1,134 @@
+import { DestinyEnergyType, DamageType } from 'bungie-api-ts/destiny2';
+
+// ✨ magic values ✨
+// this file has non-programatically decided information
+// hashes, names, & enums, hand-crafted and chosen by us
+
+/** hashes representing D2 PL stats */
+export const D2LightStats = [
+  1480404414, // Attack
+  3897883278, // Defense
+];
+
+/** D2 has these item types but D1 doesn't */
+export const D2ItemCategoryHashes = {
+  grenadelauncher: 153950757,
+  tracerifle: 2489664120,
+  linearfusionrifle: 1504945536,
+  submachine: 3954685534,
+  bow: 3317538576,
+  transmat: 208981632,
+  weaponmod: 610365472,
+  armormod: 4104513227,
+  reptoken: 2088636411,
+};
+
+/** these stats canonically exist on D2 armor */
+export const D2ArmorStatHashByName = {
+  mobility: 2996146975,
+  resilience: 392767087,
+  recovery: 1943323491,
+  discipline: 1735777505,
+  intellect: 144602215,
+  strength: 4244567218,
+};
+
+export const D2WeaponStatHashByName = {
+  rpm: 4284893193, // Stat "Rounds Per Minute"
+  rof: 4284893193, // Stat "Rounds Per Minute"
+  charge: 2961396640, // Stat "Charge Time"
+  impact: 4043523819, // Stat "Impact"
+  handling: 943549884, // Stat "Handling"
+  range: 1240592695, // Stat "Range"
+  stability: 155624089, // Stat "Stability"
+  reload: 4188031367, // Stat "Reload Speed"
+  magazine: 3871231066, // Stat "Magazine"
+  aimassist: 1345609583, // Stat "Aim Assistance"
+  equipspeed: 943549884, // Stat "Handling"
+  velocity: 2523465841, // Stat "Velocity"
+  blastradius: 3614673599, // Stat "Blast Radius"
+  recoildirection: 2715839340, // Stat "Recoil Direction"
+  drawtime: 447667954, // Stat "Draw Time"
+  zoom: 3555269338, // Stat "Zoom"
+  inventorysize: 1931675084, // Stat "Inventory Size"
+};
+
+/** if a plug contains these, consider it empty */
+export const emptySocketHashes = [
+  2323986101, // InventoryItem "Empty Mod Socket"
+  2600899007, // InventoryItem "Empty Mod Socket"
+  1835369552, // InventoryItem "Empty Mod Socket"
+  3851138800, // InventoryItem "Empty Mod Socket"
+  791435474, // InventoryItem "Empty Activity Mod Socket"
+];
+
+/** these are checked against default rolls to determine if something's curated */
+export const curatedPlugsAllowList = [
+  7906839, // frames
+  683359327, // guards
+  1041766312, // blades
+  1202604782, // tubes
+  1257608559, // arrows
+  1757026848, // batteries
+  1806783418, // magazines
+  2619833294, // scopes
+  2718120384, // magazines_gl
+  2833605196, // barrels
+  3809303875, // bowstring
+];
+
+/** powerful rewards listed in quests or bounties */
+// TODO: generate in d2ai
+export const powerfulSources = [
+  993006552, // InventoryItem "Luminous Crucible Engram"
+  1204101093, // InventoryItem "Luminous Vanguard Engram"
+  1800172820, // InventoryItem "Luminous Vanguard Engram"
+  2481239683, // InventoryItem "Luminous Vanguard Engram"
+  2484791497, // InventoryItem "Luminous Planetary Engram"
+  2558839803, // InventoryItem "Luminous Planetary Engram"
+  2566956006, // InventoryItem "Luminous Crucible Engram"
+  2646629159, // InventoryItem "Luminous Engram"
+  2770239081, // InventoryItem "Luminous Crucible Engram"
+  3829523414, // InventoryItem "Luminous Planetary Engram"
+  4143344829, // InventoryItem "Luminous Engram"
+  4039143015, // InventoryItem "Powerful Gear"
+  4249081773, // InventoryItem "Powerful Armor"
+];
+
+export const shaderBucket = 2973005342;
+
+export const energyNamesByEnum: { [key in DestinyEnergyType]: string } = {
+  [DestinyEnergyType.Any]: 'any',
+  [DestinyEnergyType.Arc]: 'arc',
+  [DestinyEnergyType.Thermal]: 'solar',
+  [DestinyEnergyType.Void]: 'void',
+};
+export const energyCapacityTypeNames = Object.values(energyNamesByEnum);
+
+export const damageNamesByEnum: { [key in DamageType]: string | null } = {
+  0: null,
+  1: 'kinetic',
+  2: 'arc',
+  3: 'solar',
+  4: 'void',
+  5: 'raid',
+};
+
+export const Armor2ModPlugCategories = {
+  general: 2487827355,
+  helmet: 2912171003,
+  gauntlets: 3422420680,
+  chest: 1526202480,
+  leg: 2111701510,
+  classitem: 912441879,
+} as const;
+
+export const breakerTypes = {
+  barrier: 485622768,
+  antibarrier: 485622768,
+  shieldpiercing: 485622768,
+  overload: 2611060930,
+  disruption: 2611060930,
+  unstoppable: 3178805705,
+  stagger: 3178805705,
+};

--- a/src/app/search/search-filter-values.ts
+++ b/src/app/search/search-filter-values.ts
@@ -1,65 +1,54 @@
-import { energyNamesByEnum, damageNamesByEnum } from 'app/utils/item-utils';
+import { DamageType } from 'bungie-api-ts/destiny2';
+import { D1LightStats } from './d1-known-values';
+import { D2ArmorStatHashByName, D2LightStats, D2WeaponStatHashByName } from './d2-known-values';
 
 // ✨ magic values ✨
 // this file has non-programatically decided information
-// hashes, names, & enums
-// i would like to separate these into a general Knowledge file,
-// less specific to search
+// hashes, names, & enums, hand-crafted and chosen by us
+
+// this correlation is solely for element filter names
+export const damageNamesByEnum: { [key in DamageType]: string | null } = {
+  0: null,
+  1: 'kinetic',
+  2: 'arc',
+  3: 'solar',
+  4: 'void',
+  5: 'raid',
+};
 
 // typescript doesn't understand array.filter
 export const damageTypeNames = Object.values(damageNamesByEnum).filter(
   (d) => ![null, 'raid'].includes(d)
 ) as string[];
 
-/** these weapons exist in D1&2 */
-export const D1CategoryHashes = {
-  autorifle: 5,
-  handcannon: 6,
-  pulserifle: 7,
-  scoutrifle: 8,
-  fusionrifle: 9,
-  sniperrifle: 10,
-  shotgun: 11,
-  machinegun: 12,
-  rocketlauncher: 13,
-  sidearm: 14,
-  sword: 54,
+/**
+ * these stats exist on DIM armor. the 6 real API ones, supplemented by a synthetic Total stat.
+ * these are the armor stats that can be looked up by name
+ */
+export const dimArmorStatHashByName = {
+  ...D2ArmorStatHashByName,
+  total: -1000,
 };
 
-/** D2 has these item types but D1 doesn't */
-export const D2CategoryHashes = {
-  grenadelauncher: 153950757,
-  tracerifle: 2489664120,
-  linearfusionrifle: 1504945536,
-  submachine: 3954685534,
-  bow: 3317538576,
-  transmat: 208981632,
-  weaponmod: 610365472,
-  armormod: 4104513227,
-  reptoken: 2088636411,
+/** stats names used to create armor-specific filters, real ones plus an "any" keyword */
+export const searchableStatNames = [...Object.keys(dimArmorStatHashByName), 'any'];
+
+/** armor stat hashes to check for the "any" keyword */
+export const armorAnyStatHashes = Object.values(D2ArmorStatHashByName);
+
+/** stat hashes to calculate max values for */
+export const armorStatHashes = Object.values(dimArmorStatHashByName);
+
+/** all-stat table, for looking up stat hashes given a queried stat name */
+export const statHashByName = {
+  ...D2WeaponStatHashByName,
+  ...dimArmorStatHashByName,
 };
 
-/** these are checked against default rolls to determine if something's curated */
-export const curatedPlugsAllowList = [
-  7906839, // frames
-  683359327, // guards
-  1041766312, // blades
-  1202604782, // tubes
-  1257608559, // arrows
-  1757026848, // batteries
-  1806783418, // magazines
-  2619833294, // scopes
-  2718120384, // magazines_gl
-  2833605196, // barrels
-  3809303875, // bowstring
-];
+/** all-stat list, to generate filters from */
+export const allStatNames = [...Object.keys(statHashByName), 'any'];
 
-/** write something here */
-export const lightStats = [
-  1480404414, // D2 Attack
-  3897883278, // D1 & D2 Defense
-  368428387, // D1 Attack
-];
+export const lightStats = [...D2LightStats, ...D1LightStats];
 
 /** compare against DimItem.type in EN */
 export const cosmeticTypes = [
@@ -78,189 +67,3 @@ export const cosmeticTypes = [
   'ClanBanners',
   'Finishers',
 ];
-
-/** sublime engrams */
-export const sublimeEngrams = [
-  1986458096, // -gauntlet
-  2218811091,
-  2672986950, // -body-armor
-  779347563,
-  3497374572, // -class-item
-  808079385,
-  3592189221, // -leg-armor
-  738642122,
-  3797169075, // -helmet
-  838904328,
-];
-
-/** powerful rewards listed in quests or bounties */
-// TODO: generate in d2ai
-export const powerfulSources = [
-  993006552, // InventoryItem "Luminous Crucible Engram"
-  1204101093, // InventoryItem "Luminous Vanguard Engram"
-  1800172820, // InventoryItem "Luminous Vanguard Engram"
-  2481239683, // InventoryItem "Luminous Vanguard Engram"
-  2484791497, // InventoryItem "Luminous Planetary Engram"
-  2558839803, // InventoryItem "Luminous Planetary Engram"
-  2566956006, // InventoryItem "Luminous Crucible Engram"
-  2646629159, // InventoryItem "Luminous Engram"
-  2770239081, // InventoryItem "Luminous Crucible Engram"
-  3829523414, // InventoryItem "Luminous Planetary Engram"
-  4143344829, // InventoryItem "Luminous Engram"
-  4039143015, // InventoryItem "Powerful Gear"
-  4249081773, // InventoryItem "Powerful Armor"
-];
-
-export const boosts = [
-  1043138475, // -black-wax-idol
-  1772853454, // -blue-polyphage
-  3783295803, // -ether-seeds
-  3446457162, // -resupply-codes
-];
-
-export const supplies = [
-  269776572, // -house-banners
-  3632619276, // -silken-codex
-  2904517731, // -axiomatic-beads
-  1932910919, // -network-keys
-];
-
-/** for D1 items: used to calculate which vendor an item could have come from */
-export const vendorHashes = {
-  required: {
-    fwc: [995344558], // SOURCE_VENDOR_FUTURE_WAR_CULT / Future War Cult
-    do: [103311758], // SOURCE_VENDOR_DEAD_ORBIT / Dead Orbit
-    nm: [3072854931], // SOURCE_VENDOR_NEW_MONARCHY / New Monarchy
-    speaker: [4241664776], // SOURCE_VENDOR_SPEAKER / Speaker
-    variks: [512830513], // SOURCE_VENDOR_FALLEN / Variks
-    shipwright: [3721473564], // SOURCE_VENDOR_SHIPWRIGHT / Shipwright
-    vanguard: [1482793537], // SOURCE_VENDOR_VANGUARD /
-    osiris: [3378481830], // SOURCE_VENDOR_OSIRIS / Osiris
-    xur: [2179714245], // SOURCE_VENDOR_BLACK_MARKET / Shaxx
-    shaxx: [4134961255], // SOURCE_VENDOR_CRUCIBLE_HANDLER /
-    cq: [1362425043], // SOURCE_VENDOR_CRUCIBLE_QUARTERMASTER / Crucible Quartermaster
-    eris: [1374970038], // SOURCE_VENDOR_CROTAS_BANE / Eris Morn
-    ev: [3559790162], // SOURCE_VENDOR_SPECIAL_ORDERS / Eververse
-    gunsmith: [353834582], // SOURCE_VENDOR_GUNSMITH /
-  },
-  restricted: {
-    fwc: [353834582], // remove motes of light & strange coins
-    do: [353834582],
-    nm: [353834582],
-    speaker: [353834582],
-    cq: [353834582, 2682516238], // remove ammo synths and planetary materials
-  },
-};
-
-/** for D1 items: used to calculate which activity an item could have come from
- * "vanilla" has no hash but checks for year == 1
- */
-export const D1ActivityHashes = {
-  required: {
-    trials: [2650556703], // SOURCE_TRIALS_OF_OSIRIS / Trials
-    ib: [1322283879], // SOURCE_IRON_BANNER / Iron Banner
-    qw: [1983234046], // SOURCE_QUEENS_EMISSARY_QUEST / Queen's Wrath
-    cd: [2775576620], // SOURCE_CRIMSON_DOUBLES / Crimson Doubles
-    srl: [1234918199], // SOURCE_SRL / Sparrow Racing League
-    vog: [440710167], // SOURCE_VAULT_OF_GLASS / Vault of Glass
-    ce: [2585003248], // SOURCE_CROTAS_END / Crota's End
-    ttk: [2659839637], // SOURCE_TTK / The Taken King
-    kf: [1662673928], // SOURCE_KINGS_FALL / King's Fall
-    roi: [2964550958], // SOURCE_RISE_OF_IRON / Rise of Iron
-    wotm: [4160622434], // SOURCE_WRATH_OF_THE_MACHINE / Wrath of the Machine
-    poe: [2784812137], // SOURCE_PRISON_ELDERS / Prison of Elders
-    coe: [1537575125], // SOURCE_POE_ELDER_CHALLENGE / Challenge of Elders
-    af: [3667653533], // SOURCE_ARCHON_FORGE / Archon Forge
-    dawning: [3131490494], // SOURCE_DAWNING /
-    aot: [3068521220, 4161861381, 440710167], // SOURCE_AGES_OF_TRIUMPH && SOURCE_RAID_REPRISE
-  },
-  restricted: {
-    trials: [2179714245, 2682516238, 560942287], // remove xur exotics and patrol items
-    ib: [3602080346], // remove engrams and random blue drops (Strike)
-    qw: [3602080346], // remove engrams and random blue drops (Strike)
-    cd: [3602080346], // remove engrams and random blue drops (Strike)
-    kf: [2179714245, 2682516238, 560942287], // remove xur exotics and patrol items
-    wotm: [2179714245, 2682516238, 560942287], // remove xur exotics and patrol items
-    poe: [3602080346, 2682516238], // remove engrams
-    coe: [3602080346, 2682516238], // remove engrams
-    af: [2682516238], // remove engrams
-    dawning: [2682516238, 1111209135], // remove engrams, planetary materials, & chroma
-    aot: [2964550958, 2659839637, 353834582, 560942287], // Remove ROI, TTK, motes, & glimmer items
-  },
-};
-
-/** if a plug contains these, consider it empty */
-export const emptySocketHashes = [
-  2323986101, // InventoryItem "Empty Mod Socket"
-  2600899007, // InventoryItem "Empty Mod Socket"
-  1835369552, // InventoryItem "Empty Mod Socket"
-  3851138800, // InventoryItem "Empty Mod Socket"
-  791435474, // InventoryItem "Empty Activity Mod Socket"
-];
-
-/** these stats actually exist on D2 armor */
-const d2ArmorStatHashByName = {
-  mobility: 2996146975,
-  resilience: 392767087,
-  recovery: 1943323491,
-  discipline: 1735777505,
-  intellect: 144602215,
-  strength: 4244567218,
-};
-
-/**
- * these stats exist on DIM armor. the 6 originals supplemented by a sum total.
- * these are the armor stats that can be looked up by name
- */
-const dimArmorStatHashByName = {
-  ...d2ArmorStatHashByName,
-  total: -1000,
-};
-
-/** stats names used to create armor-specific filters */
-export const armorStatNames = [...Object.keys(dimArmorStatHashByName), 'any'];
-
-/** stat hashes to check in armor "any" filters */
-export const anyArmorStatHashes = Object.values(d2ArmorStatHashByName);
-
-/** stats to check the max values of */
-export const armorStatHashes = Object.values(dimArmorStatHashByName);
-
-/** all-stat table, for looking up stat hashes given a queried stat name */
-export const statHashByName = {
-  rpm: 4284893193,
-  rof: 4284893193,
-  charge: 2961396640,
-  impact: 4043523819,
-  handling: 943549884,
-  range: 1240592695,
-  stability: 155624089,
-  reload: 4188031367,
-  magazine: 3871231066,
-  aimassist: 1345609583,
-  equipspeed: 943549884,
-  velocity: 2523465841,
-  blastradius: 3614673599,
-  recoildirection: 2715839340,
-  drawtime: 447667954,
-  zoom: 3555269338,
-  inventorysize: 1931675084,
-  ...dimArmorStatHashByName,
-};
-
-/** all-stat list, to generate filters from */
-export const allStatNames = [...Object.keys(statHashByName), 'any'];
-
-export const energyCapacityTypes = Object.values(energyNamesByEnum);
-
-export const shaderBucket = 2973005342;
-
-export const breakerTypes = {
-  barrier: 485622768,
-  antibarrier: 485622768,
-  shieldpiercing: 485622768,
-  overload: 2611060930,
-  disruption: 2611060930,
-  unstoppable: 3178805705,
-  stagger: 3178805705,
-};

--- a/src/app/search/search-filter-values.ts
+++ b/src/app/search/search-filter-values.ts
@@ -1,6 +1,11 @@
 import { DamageType } from 'bungie-api-ts/destiny2';
 import { D1LightStats } from './d1-known-values';
-import { D2ArmorStatHashByName, D2LightStats, D2WeaponStatHashByName } from './d2-known-values';
+import {
+  D2ArmorStatHashByName,
+  D2LightStats,
+  D2WeaponStatHashByName,
+  TOTAL_STAT_HASH,
+} from './d2-known-values';
 
 // ✨ magic values ✨
 // this file has non-programatically decided information
@@ -27,7 +32,7 @@ export const damageTypeNames = Object.values(damageNamesByEnum).filter(
  */
 export const dimArmorStatHashByName = {
   ...D2ArmorStatHashByName,
-  total: -1000,
+  total: TOTAL_STAT_HASH,
 };
 
 /** stats names used to create armor-specific filters, real ones plus an "any" keyword */

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -1,5 +1,3 @@
-import * as hashes from './search-filter-values';
-
 import { D1Item, D2Item, DimItem } from '../inventory/item-types';
 import {
   DEFAULT_GLOW,
@@ -54,6 +52,34 @@ import store from '../store/store';
 import { getStore } from 'app/inventory/stores-helpers';
 import { DestinyVersion, ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { parseQuery, QueryAST } from './query-parser';
+import {
+  boosts,
+  D1ActivityHashes,
+  D1ItemCategoryHashes,
+  sublimeEngrams,
+  supplies,
+  vendorHashes,
+} from './d1-known-values';
+import {
+  breakerTypes,
+  curatedPlugsAllowList,
+  D2ItemCategoryHashes,
+  emptySocketHashes,
+  energyCapacityTypeNames,
+  energyNamesByEnum,
+  powerfulSources,
+  shaderBucket,
+} from './d2-known-values';
+import {
+  allStatNames,
+  armorAnyStatHashes,
+  armorStatHashes,
+  cosmeticTypes,
+  damageTypeNames,
+  lightStats,
+  searchableStatNames,
+  statHashByName,
+} from './search-filter-values';
 
 /**
  * (to the tune of TMNT) ♪ string processing helper functions ♫
@@ -145,8 +171,8 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
 
   // Add new ItemCategoryHash hashes to this, to add new category searches
   const categoryHashFilters: { [key: string]: number } = {
-    ...hashes.D1CategoryHashes,
-    ...(isD2 ? hashes.D2CategoryHashes : {}),
+    ...D1ItemCategoryHashes,
+    ...(isD2 ? D2ItemCategoryHashes : {}),
   };
 
   const stats = [
@@ -185,7 +211,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
   const singleTermFilters: {
     [key: string]: string[];
   } = {
-    dmg: hashes.damageTypeNames,
+    dmg: damageTypeNames,
     type: itemTypes,
     tier: [
       'common',
@@ -323,7 +349,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
     // a keyword for every combination of an item stat name and mathmatical operator
     ...stats.flatMap((stat) => operators.map((comparison) => `stat:${stat}:${comparison}`)),
     // additional basestat searches for armor stats
-    ...hashes.armorStatNames.flatMap((stat) =>
+    ...searchableStatNames.flatMap((stat) =>
       operators.map((comparison) => `basestat:${stat}:${comparison}`)
     ),
     // keywords for checking which stat is masterworked
@@ -344,7 +370,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
     // a keyword for every combination of a DIM-processed stat and mathmatical operator
     ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
     // energy capacity elements and ranges
-    ...(isD2 ? hashes.energyCapacityTypes.map((element) => `energycapacity:${element}`) : []),
+    ...(isD2 ? energyCapacityTypeNames.map((element) => `energycapacity:${element}`) : []),
     ...(isD2 ? operators.map((comparison) => `energycapacity:${comparison}`) : []),
     // keywords for checking when an item hits power limit. s11 is the first valid season for this
     ...(isD2
@@ -353,9 +379,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
           .reverse()
           .map(([tag]) => `sunsetsafter:${tag}`)
       : []),
-    ...(isD2
-      ? Object.keys(hashes.breakerTypes).map((breakerType) => `breaker:${breakerType}`)
-      : []),
+    ...(isD2 ? Object.keys(breakerTypes).map((breakerType) => `breaker:${breakerType}`) : []),
     // "source:" keyword plus one for each source
     ...(isD2
       ? [
@@ -364,9 +388,9 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
           ...Object.keys(D2Sources).map((word) => `source:${word}`),
           ...Object.keys(D2EventPredicateLookup).map((word) => `source:${word}`),
           // maximum stat finders
-          ...hashes.armorStatNames.map((armorStat) => `maxbasestatvalue:${armorStat}`),
-          ...hashes.armorStatNames.map((armorStat) => `maxstatvalue:${armorStat}`),
-          ...hashes.armorStatNames.map((armorStat) => `maxstatloadout:${armorStat}`),
+          ...searchableStatNames.map((armorStat) => `maxbasestatvalue:${armorStat}`),
+          ...searchableStatNames.map((armorStat) => `maxstatvalue:${armorStat}`),
+          ...searchableStatNames.map((armorStat) => `maxstatloadout:${armorStat}`),
         ]
       : []),
     // all the free text searches that support quotes
@@ -534,7 +558,7 @@ function searchFilters(
           }
           if (i.stats) {
             for (const stat of i.stats) {
-              if (hashes.armorStatHashes.includes(stat.statHash)) {
+              if (armorStatHashes.includes(stat.statHash)) {
                 _maxStatValues[itemSlot][stat.statHash] =
                   // just assign if this is the first
                   !(stat.statHash in _maxStatValues[itemSlot])
@@ -558,7 +582,7 @@ function searchFilters(
   const filterByStats = (statType: string, byBaseValue = false) => {
     const byWhichValue = byBaseValue ? 'base' : 'value';
     const statHashes: number[] =
-      statType === 'any' ? hashes.anyArmorStatHashes : [hashes.statHashByName[statType]];
+      statType === 'any' ? armorAnyStatHashes : [statHashByName[statType]];
     return (item: DimItem, filterValue: string) => {
       const matchingStats = item.stats?.filter(
         (s) => statHashes.includes(s.statHash) && compareByOperator(s[byWhichValue], filterValue)
@@ -705,7 +729,7 @@ function searchFilters(
         return item.tier.toLowerCase() === (tierMap[filterValue] || filterValue);
       },
       sublime(item: DimItem) {
-        return hashes.sublimeEngrams.includes(item.hash);
+        return sublimeEngrams.includes(item.hash);
       },
       // Incomplete will show items that are not fully leveled.
       incomplete(item: DimItem) {
@@ -776,7 +800,7 @@ function searchFilters(
       /** looks for a loadout (simultaneously equippable) maximized for this stat */
       maxstatloadout(item: D2Item, filterValue: string) {
         // filterValue stat must exist, and this must be armor
-        const maxStatHash = hashes.statHashByName[filterValue];
+        const maxStatHash = statHashByName[filterValue];
         if (!maxStatHash || !item.bucket.inArmor) {
           return false;
         }
@@ -802,7 +826,7 @@ function searchFilters(
           return false;
         }
         const statHashes: number[] =
-          filterValue === 'any' ? hashes.armorStatHashes : [hashes.statHashByName[filterValue]];
+          filterValue === 'any' ? armorStatHashes : [statHashByName[filterValue]];
         const byWhichValue = byBaseValue ? 'base' : 'value';
         const itemSlot = `${item.classType}${item.type}`;
 
@@ -919,11 +943,11 @@ function searchFilters(
       glimmer(item: DimItem, filterValue: string) {
         switch (filterValue) {
           case 'glimmerboost':
-            return hashes.boosts.includes(item.hash);
+            return boosts.includes(item.hash);
           case 'glimmersupply':
-            return hashes.supplies.includes(item.hash);
+            return supplies.includes(item.hash);
           case 'glimmeritem':
-            return hashes.boosts.includes(item.hash) || hashes.supplies.includes(item.hash);
+            return boosts.includes(item.hash) || supplies.includes(item.hash);
         }
         return false;
       },
@@ -1036,7 +1060,7 @@ function searchFilters(
         );
       },
       powerfulreward(item: D2Item) {
-        return item.pursuit?.rewards.some((r) => hashes.powerfulSources.includes(r.itemHash));
+        return item.pursuit?.rewards.some((r) => powerfulSources.includes(r.itemHash));
       },
       light(item: DimItem, filterValue: string) {
         if (!item.primStat) {
@@ -1056,9 +1080,7 @@ function searchFilters(
             filterValue
           );
         }
-        return item.masterworkInfo?.stats?.some(
-          (s) => s.hash === hashes.statHashByName?.[filterValue]
-        );
+        return item.masterworkInfo?.stats?.some((s) => s.hash === statHashByName?.[filterValue]);
       },
       season(item: D2Item, filterValue: string) {
         return compareByOperator(item.season, filterValue);
@@ -1078,13 +1100,13 @@ function searchFilters(
           return (
             (mathCheck.test(filterValue) &&
               compareByOperator(item.energy.energyCapacity, filterValue)) ||
-            filterValue === hashes.energyCapacityTypes[item.energy.energyType]
+            filterValue === energyNamesByEnum[item.energy.energyType]
           );
         }
       },
       breaker(item: D2Item, filterValue: string) {
         if (item.breakerType) {
-          return hashes.breakerTypes[filterValue] === item.breakerType.hash;
+          return breakerTypes[filterValue] === item.breakerType.hash;
         }
       },
       hascapacity(item: D2Item) {
@@ -1130,17 +1152,17 @@ function searchFilters(
         if (!item) {
           return false;
         }
-        if (hashes.vendorHashes.restricted[filterValue]) {
+        if (vendorHashes.restricted[filterValue]) {
           return (
-            hashes.vendorHashes.required[filterValue].some((vendorHash) =>
+            vendorHashes.required[filterValue].some((vendorHash) =>
               item.sourceHashes.includes(vendorHash)
             ) &&
-            !hashes.vendorHashes.restricted[filterValue].some((vendorHash) =>
+            !vendorHashes.restricted[filterValue].some((vendorHash) =>
               item.sourceHashes.includes(vendorHash)
             )
           );
         } else {
-          return hashes.vendorHashes.required[filterValue].some((vendorHash) =>
+          return vendorHashes.required[filterValue].some((vendorHash) =>
             item.sourceHashes.includes(vendorHash)
           );
         }
@@ -1166,17 +1188,17 @@ function searchFilters(
         }
         if (filterValue === 'vanilla') {
           return item.year === 1;
-        } else if (hashes.D1ActivityHashes.restricted[filterValue]) {
+        } else if (D1ActivityHashes.restricted[filterValue]) {
           return (
-            hashes.D1ActivityHashes.required[filterValue].some((sourceHash) =>
+            D1ActivityHashes.required[filterValue].some((sourceHash) =>
               item.sourceHashes.includes(sourceHash)
             ) &&
-            !hashes.D1ActivityHashes.restricted[filterValue].some((sourceHash) =>
+            !D1ActivityHashes.restricted[filterValue].some((sourceHash) =>
               item.sourceHashes.includes(sourceHash)
             )
           );
         } else {
-          return hashes.D1ActivityHashes.required[filterValue].some((sourceHash) =>
+          return D1ActivityHashes.required[filterValue].some((sourceHash) =>
             item.sourceHashes.includes(sourceHash)
           );
         }
@@ -1203,7 +1225,7 @@ function searchFilters(
         return Boolean(getTag(item, itemInfos, itemHashTags));
       },
       hasLight(item: DimItem) {
-        return item.primStat && hashes.lightStats.includes(item.primStat.statHash);
+        return item.primStat && lightStats.includes(item.primStat.statHash);
       },
       curated(item: D2Item) {
         if (!item) {
@@ -1219,9 +1241,7 @@ function searchFilters(
 
         const oneSocketPerPlug = item.sockets?.sockets
           .filter((socket) =>
-            hashes.curatedPlugsAllowList.includes(
-              socket?.plug?.plugItem?.plug?.plugCategoryHash || 0
-            )
+            curatedPlugsAllowList.includes(socket?.plug?.plugItem?.plug?.plugCategoryHash || 0)
           )
           .every((socket) => socket?.plugOptions.length === 1);
 
@@ -1242,7 +1262,7 @@ function searchFilters(
         return item.bucket?.sort === 'Armor';
       },
       cosmetic(item: DimItem) {
-        return hashes.cosmeticTypes.includes(item.type);
+        return cosmeticTypes.includes(item.type);
       },
       equipment(item: DimItem) {
         return item.equipment;
@@ -1260,7 +1280,7 @@ function searchFilters(
         return item.sockets?.sockets.some((socket) =>
           Boolean(
             socket.plug?.plugItem.plug &&
-              socket.plug.plugItem.plug.plugCategoryHash === hashes.shaderBucket &&
+              socket.plug.plugItem.plug.plugCategoryHash === shaderBucket &&
               socket.plug.plugItem.hash !== DEFAULT_SHADER
           )
         );
@@ -1280,7 +1300,7 @@ function searchFilters(
         return item.sockets?.sockets.some((socket) =>
           Boolean(
             socket.plug &&
-              !hashes.emptySocketHashes.includes(socket.plug.plugItem.hash) &&
+              !emptySocketHashes.includes(socket.plug.plugItem.hash) &&
               socket.plug.plugItem.plug &&
               socket.plug.plugItem.plug.plugCategoryIdentifier.match(
                 /(v400.weapon.mod_(guns|damage|magazine)|enhancements.)/
@@ -1299,7 +1319,7 @@ function searchFilters(
           item.sockets.sockets.some((socket) =>
             Boolean(
               socket.plug &&
-                !hashes.emptySocketHashes.includes(socket.plug.plugItem.hash) &&
+                !emptySocketHashes.includes(socket.plug.plugItem.hash) &&
                 socket.plug.plugItem.plug &&
                 socket.plug.plugItem.plug.plugCategoryIdentifier.match(
                   /(v400.weapon.mod_(guns|damage|magazine)|enhancements.)/
@@ -1347,12 +1367,12 @@ function searchFilters(
         );
       },
       // create a stat filter for each stat name
-      ...hashes.allStatNames.reduce((obj, name) => {
+      ...allStatNames.reduce((obj, name) => {
         obj[name] = filterByStats(name, false);
         return obj;
       }, {}),
-      // create a basestat filter for each armor stat name
-      ...hashes.armorStatNames.reduce((obj, name) => {
+      // create a basestat filter for each ARMOR stat name
+      ...searchableStatNames.reduce((obj, name) => {
         obj[`base${name}`] = filterByStats(name, true);
         return obj;
       }, {}),

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -1,11 +1,5 @@
 import { D1Item, D2Item, DimItem } from '../inventory/item-types';
 import {
-  DEFAULT_GLOW,
-  DEFAULT_GLOW_CATEGORY,
-  DEFAULT_ORNAMENTS,
-  DEFAULT_SHADER,
-} from 'app/inventory/store/sockets';
-import {
   DestinyAmmunitionType,
   DestinyClass,
   DestinyCollectibleState,
@@ -64,11 +58,16 @@ import {
   breakerTypes,
   curatedPlugsAllowList,
   D2ItemCategoryHashes,
+  DEFAULT_GLOW,
+  DEFAULT_GLOW_CATEGORY,
+  DEFAULT_ORNAMENTS,
+  DEFAULT_SHADER,
   emptySocketHashes,
   energyCapacityTypeNames,
   energyNamesByEnum,
   powerfulSources,
-  shaderBucket,
+  SEASONAL_ARTIFACT_BUCKET,
+  SHADERS_BUCKET,
 } from './d2-known-values';
 import {
   allStatNames,
@@ -122,9 +121,9 @@ export const makeDupeID = (item: DimItem) =>
   (item.classified && String(item.hash)) ||
   `${item.name}${item.classType}${item.tier}${item.itemCategoryHashes.join('.')}`;
 
-/**
- * Selectors
- */
+//
+// Selectors
+//
 
 export const searchConfigSelector = createSelector(destinyVersionSelector, buildSearchConfig);
 
@@ -149,9 +148,9 @@ export const searchFilterSelector = createSelector(
   (query, filters) => filters.filterFunction(query)
 );
 
-/**
- * SearchConfig
- */
+//
+// SearchConfig
+//
 
 export interface SearchConfig {
   destinyVersion: DestinyVersion;
@@ -865,7 +864,7 @@ function searchFilters(
           _duplicates &&
           !item.itemCategoryHashes.includes(58) &&
           item.hash !== DEFAULT_SHADER &&
-          item.bucket.hash !== 1506418338 &&
+          item.bucket.hash !== SEASONAL_ARTIFACT_BUCKET &&
           _duplicates[dupeId] &&
           _duplicates[dupeId].length > 1
         );
@@ -1280,7 +1279,7 @@ function searchFilters(
         return item.sockets?.sockets.some((socket) =>
           Boolean(
             socket.plug?.plugItem.plug &&
-              socket.plug.plugItem.plug.plugCategoryHash === shaderBucket &&
+              socket.plug.plugItem.plug.plugCategoryHash === SHADERS_BUCKET &&
               socket.plug.plugItem.hash !== DEFAULT_SHADER
           )
         );

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -7,6 +7,11 @@ import store from '../store/store';
 import { getTag, tagConfig } from '../inventory/dim-item-info';
 import { getRating } from '../item-review/reducer';
 import { itemInfosSelector, itemHashTagsSelector } from 'app/inventory/selectors';
+import {
+  CONSUMABLES_BUCKET,
+  MATERIALS_BUCKET,
+  MODIFICATIONS_BUCKET,
+} from 'app/search/d2-known-values';
 // This file defines filters for DIM that may be shared among
 // different parts of DIM.
 
@@ -166,12 +171,12 @@ export function sortItems(items: DimItem[], itemSortOrder: string[]) {
 
   let specificSortOrder: number[] = [];
   // Group like items in the General Section
-  if (itemLocationId === 1469714392) {
+  if (itemLocationId === CONSUMABLES_BUCKET) {
     specificSortOrder = D1_CONSUMABLE_SORT_ORDER;
   }
 
   // Group like items in the General Section
-  if (itemLocationId === 3865314626) {
+  if (itemLocationId === MATERIALS_BUCKET) {
     specificSortOrder = D1_MATERIAL_SORT_ORDER;
   }
 
@@ -184,7 +189,7 @@ export function sortItems(items: DimItem[], itemSortOrder: string[]) {
   }
 
   // Re-sort mods
-  if (itemLocationId === 3313201758) {
+  if (itemLocationId === MODIFICATIONS_BUCKET) {
     const comparators = [ITEM_COMPARATORS.typeName, ITEM_COMPARATORS.name];
     if (itemSortOrder.includes('rarity')) {
       comparators.unshift(ITEM_COMPARATORS.rarity);
@@ -193,7 +198,7 @@ export function sortItems(items: DimItem[], itemSortOrder: string[]) {
   }
 
   // Re-sort consumables
-  if (itemLocationId === 1469714392) {
+  if (itemLocationId === CONSUMABLES_BUCKET) {
     return items.sort(
       chainComparator(
         ITEM_COMPARATORS.typeName,

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -4,7 +4,11 @@ import _ from 'lodash';
 import modSocketMetadata from 'data/d2/specialty-modslot-metadata';
 import powerCapToSeason from 'data/d2/lightcap-to-season.json';
 import { objectifyArray } from './util';
-import { energyNamesByEnum } from 'app/search/d2-known-values';
+import {
+  armor2PlugCategoryHashes,
+  energyNamesByEnum,
+  TOTAL_STAT_HASH,
+} from 'app/search/d2-known-values';
 import { damageNamesByEnum } from 'app/search/search-filter-values';
 
 // damage is a mess!
@@ -15,16 +19,6 @@ export const getItemDamageShortName = (item: DimItem): string | undefined =>
   item.isDestiny2() && item.energy
     ? energyNamesByEnum[item.element?.enumValue ?? -1]
     : damageNamesByEnum[item.element?.enumValue ?? -1];
-
-export const Armor2ModPlugCategories = {
-  general: 2487827355,
-  helmet: 2912171003,
-  gauntlets: 3422420680,
-  chest: 1526202480,
-  leg: 2111701510,
-  classitem: 912441879,
-} as const;
-const armor2PlugCategoryHashes: number[] = Object.values(Armor2ModPlugCategories);
 
 // these are helpers for identifying SpecialtySockets (seasonal mods).
 // i would like this file to be the only one that interfaces with
@@ -103,7 +97,7 @@ export function getPossiblyIncorrectStats(item: DimItem): string[] {
 
   if (stats) {
     for (const stat of stats) {
-      if (stat.statHash !== -1000 && stat.baseMayBeWrong && stat.displayProperties.name) {
+      if (stat.statHash !== TOTAL_STAT_HASH && stat.baseMayBeWrong && stat.displayProperties.name) {
         incorrect.add(stat.displayProperties.name);
       }
     }

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -1,32 +1,15 @@
-import {
-  DamageType,
-  DestinyEnergyType,
-  DestinyInventoryItemDefinition,
-} from 'bungie-api-ts/destiny2';
+import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { DimItem, DimMasterwork } from 'app/inventory/item-types';
 import _ from 'lodash';
 import modSocketMetadata from 'data/d2/specialty-modslot-metadata';
 import powerCapToSeason from 'data/d2/lightcap-to-season.json';
 import { objectifyArray } from './util';
+import { energyNamesByEnum } from 'app/search/d2-known-values';
+import { damageNamesByEnum } from 'app/search/search-filter-values';
 
 // damage is a mess!
-// this section supports turning a destiny DamageType or EnergyType into a known english name
+// this function supports turning a destiny DamageType or EnergyType into a known english name
 // mainly for most css purposes and the filter names
-export const damageNamesByEnum: { [key in DamageType]: string | null } = {
-  0: null,
-  1: 'kinetic',
-  2: 'arc',
-  3: 'solar',
-  4: 'void',
-  5: 'raid',
-};
-
-export const energyNamesByEnum: { [key in DestinyEnergyType]: string } = {
-  [DestinyEnergyType.Any]: 'any',
-  [DestinyEnergyType.Arc]: 'arc',
-  [DestinyEnergyType.Thermal]: 'solar',
-  [DestinyEnergyType.Void]: 'void',
-};
 
 export const getItemDamageShortName = (item: DimItem): string | undefined =>
   item.isDestiny2() && item.energy

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -12,6 +12,7 @@ import styles from './VendorItems.m.scss';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { Link } from 'react-router-dom';
 import spiderMats from 'data/d2/spider-mats.json';
+import { SPIDER_VENDOR } from 'app/search/d2-known-values';
 
 const itemSort = chainComparator<VendorItem>(
   compareBy((item) => item.item?.typeName),
@@ -62,7 +63,7 @@ export default function VendorItems({
   }
 
   // add all traded planetmats if this vendor is the spider
-  if (vendor?.component?.vendorHash === 863940356) {
+  if (vendor?.component?.vendorHash === SPIDER_VENDOR) {
     currencies = _.uniqBy(
       [...spiderMats.map((h) => defs.InventoryItem.get(h)), ...currencies],
       (i) => i.hash

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -13,6 +13,7 @@ import { makeFakeItem } from '../inventory/store/d2-item-factory';
 import { DimItem } from '../inventory/item-types';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import _ from 'lodash';
+import { RAHOOL_VENDOR } from 'app/search/d2-known-values';
 
 /**
  * A displayable vendor item.
@@ -145,7 +146,7 @@ export class VendorItem {
     }
 
     // only apply for 2255782930, master rahool
-    if (vendorHash === 2255782930 && saleItem?.overrideStyleItemHash && this.item) {
+    if (vendorHash === RAHOOL_VENDOR && saleItem?.overrideStyleItemHash && this.item) {
       const itemDef = defs.InventoryItem.get(saleItem.overrideStyleItemHash);
       if (itemDef) {
         const display = itemDef.displayProperties;

--- a/src/app/vendors/vendor-ratings.ts
+++ b/src/app/vendors/vendor-ratings.ts
@@ -10,6 +10,7 @@ import _ from 'lodash';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { ThunkResult } from '../store/reducers';
 import { DtrRating } from '../item-review/dtr-api-types';
+import { ATTACK_STAT, DEFENSE_STAT } from 'app/search/d2-known-values';
 
 function isWeaponOrArmor(
   defs: D2ManifestDefinitions,
@@ -19,8 +20,8 @@ function isWeaponOrArmor(
   const inventoryItemStats = itemDef?.stats;
   return (
     inventoryItemStats &&
-    (inventoryItemStats.primaryBaseStatHash === 1480404414 || // weapon
-      inventoryItemStats.primaryBaseStatHash === 3897883278)
+    (inventoryItemStats.primaryBaseStatHash === ATTACK_STAT || // weapon
+      inventoryItemStats.primaryBaseStatHash === DEFENSE_STAT)
   ); // armor
 }
 

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -2,7 +2,15 @@ import { DimStore } from '../inventory/store-types';
 import { DimWishList, WishListRoll } from './types';
 import { D2Item, DimItem, DimPlug } from '../inventory/item-types';
 import _ from 'lodash';
-import { INTRINSIC_PLUG_CATEGORY } from 'app/inventory/store/sockets';
+import {
+  ARMOR_MODS_CATEGORY,
+  BONUS_MODS_CATEGORY,
+  GHOST_PERKS_CATEGORY,
+  INTRINSIC_ITEM_CATEGORY,
+  MODIFICATIONS_BUCKET,
+  WEAPON_GAMEPLAY_MODS_CATEGORY,
+  WEAPON_MODS_CATEGORY,
+} from 'app/search/d2-known-values';
 
 export const enum UiWishListRoll {
   Good = 1,
@@ -79,8 +87,8 @@ function isWeaponOrArmorOrGhostMod(plug: DimPlug): boolean {
   if (
     plug.plugItem.itemCategoryHashes?.find(
       (ich) =>
-        ich === INTRINSIC_PLUG_CATEGORY || // intrinsics
-        ich === 945330047 || // weapon gameplay socket
+        ich === INTRINSIC_ITEM_CATEGORY || // intrinsics
+        ich === WEAPON_GAMEPLAY_MODS_CATEGORY || // weapon gameplay socket
         ich === 3851138800 // armor gameplay socket
     )
   ) {
@@ -88,13 +96,17 @@ function isWeaponOrArmorOrGhostMod(plug: DimPlug): boolean {
   }
 
   // if it's a modification, ignore it
-  if (plug.plugItem.inventory?.bucketTypeHash === 3313201758) {
+  if (plug.plugItem.inventory?.bucketTypeHash === MODIFICATIONS_BUCKET) {
     return false;
   }
 
   return (
     plug.plugItem.itemCategoryHashes?.some(
-      (ich) => ich === 610365472 || ich === 4104513227 || ich === 303512563 || ich === 4176831154
+      (ich) =>
+        ich === WEAPON_MODS_CATEGORY ||
+        ich === ARMOR_MODS_CATEGORY ||
+        ich === BONUS_MODS_CATEGORY ||
+        ich === GHOST_PERKS_CATEGORY
     ) ?? false
   ); // weapon, then armor, then bonus (found on armor perks), then ghost mod
 }


### PR DESCRIPTION
this separates out search's known values into d1, d2, and combined files,

and centralizes/commonizes some non-search known values, so there's fewer hard-coded numbers out in files

this spiraled out of control a little, and the diff ended up really big. it's ultimately just substituting variables for a bunch of numbers. i would like to follow this up by generating some enums with d2ai, and converting other things in the known values files to enums.

if this diff is too wild i could break it out into the split "known" files and separately subbing in variables for numbers.

if this is an overall bad idea that's fine.