### PR TITLE
Touch wishlists on load to prevent loading more than once a day

### DIFF
--- a/src/app/wishlists/actions.ts
+++ b/src/app/wishlists/actions.ts
@@ -8,3 +8,5 @@ export const loadWishLists = createAction('wishlists/LOAD')<{
 }>();
 
 export const clearWishLists = createAction('wishlists/CLEAR')();
+
+export const touchWishLists = createAction('wishlists/TOUCH')();

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -68,6 +68,12 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
         loaded: true,
       };
     }
+    case getType(actions.touchWishLists): {
+      return {
+        ...state,
+        lastFetched: new Date(),
+      };
+    }
     default:
       return state;
   }

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -2,7 +2,7 @@ import { toWishList } from './wishlist-file';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import { showNotification } from 'app/notifications/notifications';
-import { loadWishLists } from './actions';
+import { loadWishLists, touchWishLists } from './actions';
 import { ThunkResult } from 'app/store/reducers';
 import { WishListAndInfo } from './types';
 import { wishListsSelector, WishListsState } from './reducer';
@@ -48,8 +48,14 @@ export function fetchWishList(newWishlistSource?: string): ThunkResult {
       return;
     }
 
-    const wishListResponse = await fetch(wishListSource);
-    const wishListText = await wishListResponse.text();
+    let wishListText: string;
+    try {
+      const wishListResponse = await fetch(wishListSource);
+      wishListText = await wishListResponse.text();
+    } catch (e) {
+      console.error('Unable to load wish list', e);
+      return;
+    }
 
     const wishListAndInfo = toWishList(wishListText);
     wishListAndInfo.source = wishListSource;
@@ -65,6 +71,7 @@ export function fetchWishList(newWishlistSource?: string): ThunkResult {
       dispatch(transformAndStoreWishList(wishListAndInfo));
     } else {
       console.log('Refreshed wishlist, but it matched the one we already have');
+      dispatch(touchWishLists());
     }
   };
 }


### PR DESCRIPTION
We were loading wishlists all the time, because we only measured the time since the original wishlist was loaded, and once that exceeded 24 hours it'd always pass but wouldn't update the timestamp because the wishlist hadn't changed. This adds a "touch" action that updates the last fetched date even if the contents are the same, so we only check once per 24 hours.