### PR TITLE
Try out tighter CSP

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -10,10 +10,6 @@ module.exports = function csp(env) {
     defaultSrc: ['none'],
     scriptSrc: [
       SELF,
-      // For Webpack?
-      "'unsafe-eval'",
-      "'unsafe-inline'",
-      'data:',
       // Include a snippet of inline scripts
       "'report-sample'",
       // Google API (Drive)
@@ -26,8 +22,6 @@ module.exports = function csp(env) {
     ],
     styleSrc: [
       SELF,
-      // For Webpack's inserted styles
-      "'unsafe-inline'",
       // Google Fonts
       'https://fonts.googleapis.com/css',
       // Twitter Widget
@@ -41,10 +35,13 @@ module.exports = function csp(env) {
       // Bungie.net API
       'https://www.bungie.net',
       // DTR Reviews API
-      'https://reviews-api.destinytracker.net',
-      'https://api.tracker.gg',
+      //'https://reviews-api.destinytracker.net',
+      //'https://api.tracker.gg',
+      // VendorEngrams
       'https://api.vendorengrams.xyz',
+      // Wishlists
       'https://raw.githubusercontent.com',
+      // DIM Sync
       'https://api.destinyitemmanager.com',
     ],
     imgSrc: [
@@ -63,8 +60,6 @@ module.exports = function csp(env) {
       'https://syndication.twitter.com',
       'https://platform.twitter.com',
       'https://*.twimg.com/',
-      // User profile info in storage settings
-      'https://*.googleusercontent.com/',
     ],
     fontSrc: [
       SELF,


### PR DESCRIPTION
I'd like to try out a smaller CSP list and see if webpack is doing better now. I don't know if there's a way to validate this ahead of time in devtools, I wish there was.