### PR TITLE
Feature/max mods 10 energy

### DIFF
--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -11,8 +11,9 @@ import {
   MinMax,
   LockedModBase,
   ModPickerCategories,
+  bucketsToCategories,
 } from '../types';
-import { DimItem } from 'app/inventory/item-types';
+import { D2Item } from 'app/inventory/item-types';
 import { ProcessItemsByBucket } from '../processWorker/types';
 import {
   mapDimItemToProcessItem,
@@ -73,13 +74,15 @@ export function useProcess(
     setState({ processing: true, result, currentCleanup: cleanup });
 
     const processItems: ProcessItemsByBucket = {};
-    const itemsById: { [id: string]: DimItem } = {};
+    const itemsById: { [id: string]: D2Item } = {};
 
     for (const [key, items] of Object.entries(filteredItems)) {
       processItems[key] = [];
       for (const item of items) {
         if (item.isDestiny2()) {
-          processItems[key].push(mapDimItemToProcessItem(item));
+          processItems[key].push(
+            mapDimItemToProcessItem(item, lockedArmor2ModMap[bucketsToCategories[item.bucket.hash]])
+          );
           itemsById[item.id] = item;
         }
       }

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -1,6 +1,6 @@
 import { DimItem, D2Item } from '../inventory/item-types';
 import _ from 'lodash';
-import { LockedArmor2ModMap, LockedArmor2Mod } from './types';
+import { LockedArmor2ModMap, LockedArmor2Mod, ModPickerCategories } from './types';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import {
   sortProcessModsOrProcessItems,
@@ -113,5 +113,18 @@ export function assignModsToArmorSet(
   );
 
   const modsByHash = _.keyBy(Object.values(lockedArmor2Mods).flat(), (mod) => mod.mod.hash);
-  return _.mapValues(assignments, (modHashes) => modHashes.map((modHash) => modsByHash[modHash]));
+  return _.mapValues(assignments, (modHashes) =>
+    modHashes
+      .map((modHash) => modsByHash[modHash])
+      .sort((a) => {
+        // Sort the mods so that they appear in the order general, slot specific, seasonal (mimic the game).
+        if (a.category === ModPickerCategories.general) {
+          return -1;
+        } else if (a.category === ModPickerCategories.seasonal) {
+          return 1;
+        } else {
+          return 0;
+        }
+      })
+  );
 }

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -1,4 +1,4 @@
-import { DimItem } from '../inventory/item-types';
+import { DimItem, D2Item } from '../inventory/item-types';
 import _ from 'lodash';
 import { LockedArmor2ModMap, LockedArmor2Mod } from './types';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
@@ -9,6 +9,7 @@ import {
 } from './processWorker/processUtils';
 import { mapArmor2ModToProcessMod, mapDimItemToProcessItem } from './processWorker/mappers';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
+import { ProcessItem } from './processWorker/types';
 
 /**
  * Checks that:
@@ -28,14 +29,14 @@ export const doEnergiesMatch = (mod: LockedArmor2Mod, item: DimItem) =>
  * assignments is mutated in this function as it tracks assigned mods for a particular armour set.
  */
 function assignGeneralMods(
-  setToMatch: readonly DimItem[],
+  setToMatch: ProcessItem[],
   generalMods: LockedArmor2Mod[],
   assignments: Record<string, number[]>
 ): void {
   // Mods need to be sorted before being passed to the assignment function
   const sortedMods = generalMods.map(mapArmor2ModToProcessMod).sort(sortProcessModsOrProcessItems);
 
-  canTakeAllGeneralMods(sortedMods, setToMatch.map(mapDimItemToProcessItem), assignments);
+  canTakeAllGeneralMods(sortedMods, setToMatch, assignments);
 }
 
 /**
@@ -59,14 +60,14 @@ function assignModsForSlot(
  * assignments is mutated in this function as it tracks assigned mods for a particular armour set
  */
 function assignAllSeasonalMods(
-  setToMatch: readonly DimItem[],
+  setToMatch: ProcessItem[],
   seasonalMods: readonly LockedArmor2Mod[],
   assignments: Record<string, number[]>
 ): void {
   // Mods need to be sorted before being passed to the assignment function
   const sortedMods = seasonalMods.map(mapArmor2ModToProcessMod).sort(sortProcessModsOrProcessItems);
 
-  canTakeAllSeasonalMods(sortedMods, setToMatch.map(mapDimItemToProcessItem), assignments);
+  canTakeAllSeasonalMods(sortedMods, setToMatch, assignments);
 }
 
 export function assignModsToArmorSet(
@@ -76,42 +77,40 @@ export function assignModsToArmorSet(
   const assignments: Record<string, number[]> = {};
 
   for (const item of setToMatch) {
-    assignments[item.id] = [];
+    if (!item.isDestiny2()) {
+      return {};
+    } else {
+      assignments[item.id] = [];
+    }
   }
 
-  assignGeneralMods(
-    setToMatch,
-    lockedArmor2Mods[armor2PlugCategoryHashesByName.general],
-    assignments
-  );
+  const [helmet, arms, chest, legs, classItem] = setToMatch as D2Item[];
 
+  assignModsForSlot(helmet, lockedArmor2Mods[armor2PlugCategoryHashesByName.helmet], assignments);
+  assignModsForSlot(arms, lockedArmor2Mods[armor2PlugCategoryHashesByName.gauntlets], assignments);
+  assignModsForSlot(chest, lockedArmor2Mods[armor2PlugCategoryHashesByName.chest], assignments);
+  assignModsForSlot(legs, lockedArmor2Mods[armor2PlugCategoryHashesByName.leg], assignments);
   assignModsForSlot(
-    setToMatch[0],
-    lockedArmor2Mods[armor2PlugCategoryHashesByName.helmet],
-    assignments
-  );
-  assignModsForSlot(
-    setToMatch[1],
-    lockedArmor2Mods[armor2PlugCategoryHashesByName.gauntlets],
-    assignments
-  );
-  assignModsForSlot(
-    setToMatch[2],
-    lockedArmor2Mods[armor2PlugCategoryHashesByName.chest],
-    assignments
-  );
-  assignModsForSlot(
-    setToMatch[3],
-    lockedArmor2Mods[armor2PlugCategoryHashesByName.leg],
-    assignments
-  );
-  assignModsForSlot(
-    setToMatch[4],
+    classItem,
     lockedArmor2Mods[armor2PlugCategoryHashesByName.classitem],
     assignments
   );
 
-  assignAllSeasonalMods(setToMatch, lockedArmor2Mods.seasonal, assignments);
+  const processItems = [
+    mapDimItemToProcessItem(helmet, lockedArmor2Mods[armor2PlugCategoryHashesByName.helmet]),
+    mapDimItemToProcessItem(arms, lockedArmor2Mods[armor2PlugCategoryHashesByName.gauntlets]),
+    mapDimItemToProcessItem(chest, lockedArmor2Mods[armor2PlugCategoryHashesByName.chest]),
+    mapDimItemToProcessItem(legs, lockedArmor2Mods[armor2PlugCategoryHashesByName.leg]),
+    mapDimItemToProcessItem(classItem, lockedArmor2Mods[armor2PlugCategoryHashesByName.classitem]),
+  ];
+
+  assignAllSeasonalMods(processItems, lockedArmor2Mods.seasonal, assignments);
+
+  assignGeneralMods(
+    processItems,
+    lockedArmor2Mods[armor2PlugCategoryHashesByName.general],
+    assignments
+  );
 
   const modsByHash = _.keyBy(Object.values(lockedArmor2Mods).flat(), (mod) => mod.mod.hash);
   return _.mapValues(assignments, (modHashes) => modHashes.map((modHash) => modsByHash[modHash]));

--- a/src/app/loadout-builder/preProcessFilter.ts
+++ b/src/app/loadout-builder/preProcessFilter.ts
@@ -6,22 +6,14 @@ import {
   ItemsByBucket,
   LockedItemType,
   statValues,
+  bucketsToCategories,
 } from './types';
 import { getItemDamageShortName } from 'app/utils/item-utils';
 import { doEnergiesMatch } from './mod-utils';
 import { canSlotMod } from './utils';
 import { DimItem } from 'app/inventory/item-types';
-import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import { getMasterworkSocketHashes } from 'app/utils/socket-utils';
-
-const bucketsToCategories = {
-  [LockableBuckets.helmet]: armor2PlugCategoryHashesByName.helmet,
-  [LockableBuckets.gauntlets]: armor2PlugCategoryHashesByName.gauntlets,
-  [LockableBuckets.chest]: armor2PlugCategoryHashesByName.chest,
-  [LockableBuckets.leg]: armor2PlugCategoryHashesByName.leg,
-  [LockableBuckets.classitem]: armor2PlugCategoryHashesByName.classitem,
-};
 
 /**
  * Filter the items map down given the locking and filtering configs.

--- a/src/app/loadout-builder/processWorker/mappers.ts
+++ b/src/app/loadout-builder/processWorker/mappers.ts
@@ -42,7 +42,7 @@ export function mapSeasonalModsToProcessMods(
       tag: entry.metadata?.tag,
       energy: {
         type: entry.mod.mod.plug.energyCost.energyType,
-        cost: entry.mod.mod.plug.energyCost.energyCost,
+        val: entry.mod.mod.plug.energyCost.energyCost,
       },
       investmentStats: entry.mod.mod.investmentStats.map(({ statTypeHash, value }) => ({
         statTypeHash,
@@ -59,7 +59,7 @@ export function mapArmor2ModToProcessMod(mod: LockedArmor2Mod): ProcessMod {
     hash: mod.mod.hash,
     energy: {
       type: mod.mod.plug.energyCost.energyType,
-      cost: mod.mod.plug.energyCost.energyCost,
+      val: mod.mod.plug.energyCost.energyCost,
     },
     investmentStats: mod.mod.investmentStats,
   };
@@ -151,8 +151,8 @@ export function mapDimItemToProcessItem(
       dimItem.energy && costInitial !== null
         ? {
             type: dimItem.energy.energyType,
-            costInitial, // this is needed to reset energy used after trying to slot mods
-            cost: costInitial,
+            valInitial: costInitial, // this is needed to reset energy used after trying to slot mods
+            val: costInitial,
           }
         : null,
     season: modMetadata?.season,

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -317,7 +317,7 @@ export function process(
               // Reset the used item energy of each item so we can add general and seasonal mod costs again.
               for (const item of firstValidSet) {
                 if (item.energy) {
-                  item.energy.cost = item.energy.costInitial;
+                  item.energy.val = item.energy.valInitial;
                 }
               }
 

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -314,17 +314,26 @@ export function process(
                 }
               }
 
-              // For armour 2 mods we ignore slot specific mods as we prefilter items based on energy requirements
+              // Reset the used item energy of each item so we can add general and seasonal mod costs again.
+              for (const item of firstValidSet) {
+                if (item.energy) {
+                  item.energy.cost = item.energy.costInitial;
+                }
+              }
+
+              // For armour 2 mods we ignore slot specific mods as we prefilter items based on energy requirements.
+              // For mod armour 2 mods we do seasonal first as its more likely to have energy specific mods.
+              // TODO Check validity of this with the energy contraints in.
               if (
                 (processedSeasonalMods.length &&
                   !canTakeAllSeasonalMods(processedSeasonalMods, firstValidSet)) ||
+                (lockedArmor2ModMap.seasonal.length &&
+                  !canTakeAllSeasonalMods(lockedArmor2ModMap.seasonal, firstValidSet)) ||
                 (lockedArmor2ModMap[armor2PlugCategoryHashesByName.general].length &&
                   !canTakeAllGeneralMods(
                     lockedArmor2ModMap[armor2PlugCategoryHashesByName.general],
                     firstValidSet
-                  )) ||
-                (lockedArmor2ModMap.seasonal.length &&
-                  !canTakeAllSeasonalMods(lockedArmor2ModMap.seasonal, firstValidSet))
+                  ))
               ) {
                 continue;
               }
@@ -533,7 +542,7 @@ function generateMixesFromPerksOrStats(
     ),
   ];
 
-  if (stats && item.sockets && item.energyType === undefined) {
+  if (stats && item.sockets && item.energy) {
     for (const socket of item.sockets.sockets) {
       if (socket.plugOptions.length > 1) {
         for (const plug of socket.plugOptions) {
@@ -572,7 +581,7 @@ function getStatValuesWithModsAndMWProcess(
   const baseStats = { ...item.baseStats };
 
   // Checking energy tells us if it is Armour 2.0 (it can have value 0)
-  if (item.sockets && item.energyType !== undefined) {
+  if (item.sockets && item.energy) {
     let masterworkSocketHashes: number[] = [];
 
     // only get masterwork sockets if we aren't manually adding the values

--- a/src/app/loadout-builder/processWorker/processUtils.test.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.test.ts
@@ -15,7 +15,7 @@ function getMod(
   return {
     season,
     tag,
-    energy: { type: energyType, cost: 0 },
+    energy: { type: energyType, val: 0 },
     investmentStats: [],
     hash: hash || 0,
   };
@@ -28,7 +28,7 @@ function getItem(
   id?: string
 ): ProcessItemSubset {
   return {
-    energy: { type: energyType, cost: 0 },
+    energy: { type: energyType, val: 0 },
     season,
     compatibleModSeasons,
     id: id || 'id',

--- a/src/app/loadout-builder/processWorker/processUtils.test.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.test.ts
@@ -12,7 +12,13 @@ function getMod(
   energyType: DestinyEnergyType,
   hash?: number
 ): ProcessMod {
-  return { season, tag, energyType, investmentStats: [], hash: hash || 0 };
+  return {
+    season,
+    tag,
+    energy: { type: energyType, cost: 0 },
+    investmentStats: [],
+    hash: hash || 0,
+  };
 }
 
 function getItem(
@@ -22,7 +28,7 @@ function getItem(
   id?: string
 ): ProcessItemSubset {
   return {
-    energyType,
+    energy: { type: energyType, cost: 0 },
     season,
     compatibleModSeasons,
     id: id || 'id',

--- a/src/app/loadout-builder/processWorker/processUtils.test.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.test.ts
@@ -10,14 +10,14 @@ function getMod(
   season: number,
   tag: string,
   energyType: DestinyEnergyType,
-  hash?: number
+  energyCost: number = 0
 ): ProcessMod {
   return {
     season,
     tag,
-    energy: { type: energyType, val: 0 },
+    energy: { type: energyType, val: energyCost },
     investmentStats: [],
-    hash: hash || 0,
+    hash: 0, // need to mock this unfortunately
   };
 }
 
@@ -25,13 +25,13 @@ function getItem(
   season: number,
   energyType: DestinyEnergyType,
   compatibleModSeasons?: string[],
-  id?: string
+  energyCost: number = 0
 ): ProcessItemSubset {
   return {
-    energy: { type: energyType, val: 0 },
+    energy: { type: energyType, val: energyCost },
     season,
     compatibleModSeasons,
-    id: id || 'id',
+    id: 'id', // need to mock this unfortunately
   };
 }
 
@@ -252,6 +252,59 @@ describe('Sorting works for mods and items', () => {
       getItem(10, 1, ['arrivals', 'worthy', 'dawn']),
       getItem(11, 1, ['arrivals', 'worthy']),
       getItem(9, 1, ['worthy', 'dawn', 'undying']),
+    ];
+
+    const result = canTakeAllSeasonalMods(mods, items);
+    expect(result).toEqual(true);
+  });
+});
+
+/*
+  Ensuring the energy requirement part works
+*/
+describe('Energy requirements correctly filter a set', () => {
+  it('passes when items and mods add up to 10', () => {
+    const mods = [
+      getMod(11, 'arrivals', 2, 5),
+      getMod(11, 'arrivals', 1, 5),
+      getMod(11, 'arrivals', 3, 5),
+    ].sort(sortProcessModsOrProcessItems);
+
+    const items = [
+      getItem(11, 1, ['arrivals', 'worthy'], 5),
+      getItem(11, 2, ['arrivals', 'worthy'], 5),
+      getItem(11, 3, ['arrivals', 'worthy'], 5),
+    ];
+
+    const result = canTakeAllSeasonalMods(mods, items);
+    expect(result).toEqual(true);
+  });
+
+  it('fails when one item and mod add up to more than 10', () => {
+    const mods = [
+      getMod(11, 'arrivals', 2, 5),
+      getMod(11, 'arrivals', 1, 5),
+      getMod(11, 'arrivals', 3, 5),
+    ].sort(sortProcessModsOrProcessItems);
+
+    const items = [
+      getItem(11, 1, ['arrivals', 'worthy'], 5),
+      getItem(11, 2, ['arrivals', 'worthy'], 6),
+      getItem(11, 3, ['arrivals', 'worthy'], 5),
+    ];
+
+    const result = canTakeAllSeasonalMods(mods, items);
+    expect(result).toEqual(false);
+  });
+
+  it('passes when an any mod needs the first mods space', () => {
+    const mods = [getMod(11, 'arrivals', 2, 4), getMod(11, 'arrivals', 0, 5)].sort(
+      sortProcessModsOrProcessItems
+    );
+
+    const items = [
+      getItem(11, 2, ['arrivals', 'worthy'], 5),
+      getItem(11, 2, ['arrivals', 'worthy'], 6),
     ];
 
     const result = canTakeAllSeasonalMods(mods, items);

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -4,7 +4,7 @@ import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 interface SortParam {
   energy: {
     type: DestinyEnergyType;
-    cost: number;
+    val: number;
   } | null;
   season?: number;
 }
@@ -23,7 +23,7 @@ export function sortProcessModsOrProcessItems(a: SortParam, b: SortParam) {
     if (a.season === b.season) {
       if (a.energy && b.energy) {
         if (a.energy.type === b.energy.type) {
-          return b.energy.cost - a.energy.cost;
+          return b.energy.val - a.energy.val;
         } else {
           return b.energy.type - a.energy.type;
         }
@@ -46,7 +46,7 @@ export function sortGeneralModsOrProcessItem(a: SortParam, b: SortParam) {
   // any energy is 0 so check undefined rather than falsey
   if (a.energy && b.energy) {
     if (a.energy.type === b.energy.type) {
-      return b.energy.cost - a.energy.cost;
+      return b.energy.val - a.energy.val;
     } else {
       return b.energy.type - a.energy.type;
     }
@@ -90,13 +90,13 @@ export function canTakeAllSeasonalMods(
     if (
       item.energy &&
       (item.energy.type === energy.type || energy.type === DestinyEnergyType.Any) &&
-      item.energy.cost + energy.cost <= 10 &&
+      item.energy.val + energy.val <= 10 &&
       item.compatibleModSeasons?.includes(tag)
     ) {
       if (assignments) {
         assignments[item.id].push(hash);
       }
-      item.energy.cost += energy.cost;
+      item.energy.val += energy.val;
       sortedItems.splice(itemIndex, 1);
       modIndex += 1;
       itemIndex = 0;
@@ -138,12 +138,12 @@ export function canTakeAllGeneralMods(
     if (
       item.energy &&
       (item.energy.type === energy.type || energy.type === DestinyEnergyType.Any) &&
-      item.energy.cost + energy.cost <= 10
+      item.energy.val + energy.val <= 10
     ) {
       if (assignments) {
         assignments[item.id].push(hash);
       }
-      item.energy.cost += energy.cost;
+      item.energy.val += energy.val;
       sortedItems.splice(itemIndex, 1);
       modIndex += 1;
       itemIndex = 0;

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -2,7 +2,10 @@ import { ProcessMod } from './types';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 
 interface SortParam {
-  energyType?: DestinyEnergyType;
+  energy: {
+    type: DestinyEnergyType;
+    cost: number;
+  } | null;
   season?: number;
 }
 
@@ -17,11 +20,17 @@ export interface ProcessItemSubset extends SortParam {
  */
 export function sortProcessModsOrProcessItems(a: SortParam, b: SortParam) {
   if (a.season && b.season) {
-    // any energy is 0 so check undefined rather than falsey
-    if (a.season === b.season && a.energyType !== undefined && b.energyType !== undefined) {
-      return b.energyType - a.energyType;
+    if (a.season === b.season) {
+      if (a.energy && b.energy) {
+        if (a.energy.type === b.energy.type) {
+          return b.energy.cost - a.energy.cost;
+        } else {
+          return b.energy.type - a.energy.type;
+        }
+      }
+    } else {
+      return b.season - a.season;
     }
-    return b.season - a.season;
     // I don't think the following cases will every happen but I have included them just incase.
   } else if (a.season === undefined) {
     return 1;
@@ -35,9 +44,13 @@ export function sortProcessModsOrProcessItems(a: SortParam, b: SortParam) {
  */
 export function sortGeneralModsOrProcessItem(a: SortParam, b: SortParam) {
   // any energy is 0 so check undefined rather than falsey
-  if (a.energyType !== undefined && b.energyType !== undefined) {
-    return b.energyType - a.energyType;
-  } else if (a.energyType === undefined) {
+  if (a.energy && b.energy) {
+    if (a.energy.type === b.energy.type) {
+      return b.energy.cost - a.energy.cost;
+    } else {
+      return b.energy.type - a.energy.type;
+    }
+  } else if (!a.energy) {
     return 1;
   }
 
@@ -67,19 +80,23 @@ export function canTakeAllSeasonalMods(
   // Loop over the items and mods in parallel and see if they can be slotted.
   // due to Any energy mods needing to consider skipped items we reset item index after each splice.
   while (modIndex < processedMods.length && itemIndex < sortedItems.length) {
-    const { energyType, tag, hash } = processedMods[modIndex];
+    const { energy, tag, hash } = processedMods[modIndex];
+    const item = sortedItems[itemIndex];
     if (!tag) {
       // This should never happen but if it does we ignore seasonal requirements and log the warning.
       console.warn('Optimiser: Found seasonal mod without season details.');
       return true;
     }
     if (
-      (sortedItems[itemIndex].energyType === energyType || energyType === DestinyEnergyType.Any) &&
-      sortedItems[itemIndex].compatibleModSeasons?.includes(tag)
+      item.energy &&
+      (item.energy.type === energy.type || energy.type === DestinyEnergyType.Any) &&
+      item.energy.cost + energy.cost <= 10 &&
+      item.compatibleModSeasons?.includes(tag)
     ) {
       if (assignments) {
-        assignments[sortedItems[itemIndex].id].push(hash);
+        assignments[item.id].push(hash);
       }
+      item.energy.cost += energy.cost;
       sortedItems.splice(itemIndex, 1);
       modIndex += 1;
       itemIndex = 0;
@@ -116,12 +133,17 @@ export function canTakeAllGeneralMods(
   // We need to reset the index after a match to ensure that mods with the Any energy type
   // use up armour items that didn't match an energy type/season first.
   while (modIndex < processedMods.length && itemIndex < sortedItems.length) {
-    const { energyType, hash } = processedMods[modIndex];
-
-    if (sortedItems[itemIndex].energyType === energyType || energyType === DestinyEnergyType.Any) {
+    const { energy, hash } = processedMods[modIndex];
+    const item = sortedItems[itemIndex];
+    if (
+      item.energy &&
+      (item.energy.type === energy.type || energy.type === DestinyEnergyType.Any) &&
+      item.energy.cost + energy.cost <= 10
+    ) {
       if (assignments) {
-        assignments[sortedItems[itemIndex].id].push(hash);
+        assignments[item.id].push(hash);
       }
+      item.energy.cost += energy.cost;
       sortedItems.splice(itemIndex, 1);
       modIndex += 1;
       itemIndex = 0;

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -30,7 +30,15 @@ export interface ProcessItem {
   name: string;
   equippingLabel?: string;
   sockets: ProcessSockets | null;
-  energyType?: DestinyEnergyType;
+  energy: {
+    type: DestinyEnergyType;
+    /** This is used to track the energy used by mods in a build. Using the name cost so that we can use the same sorting
+     * function for ProcessItems and ProcessMods. */
+    cost: number;
+    /** This contains the energy usage by slot specific mods in the mod picker. Those mods are preprocessed so we don't
+     * need to recalculate them over and over. */
+    costInitial: readonly number;
+  } | null;
   basePower: number;
   stats: { [statHash: number]: number };
   baseStats: { [statHash: number]: number };
@@ -99,7 +107,10 @@ interface ProcessStat {
 
 export interface ProcessMod {
   hash: number;
-  energyType: DestinyEnergyType;
+  energy: {
+    type: DestinyEnergyType;
+    cost: number;
+  };
   investmentStats: ProcessStat[];
   /** This should only be available in seasonal mods */
   season?: number;

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -34,10 +34,10 @@ export interface ProcessItem {
     type: DestinyEnergyType;
     /** This is used to track the energy used by mods in a build. Using the name cost so that we can use the same sorting
      * function for ProcessItems and ProcessMods. */
-    cost: number;
+    val: number;
     /** This contains the energy usage by slot specific mods in the mod picker. Those mods are preprocessed so we don't
      * need to recalculate them over and over. */
-    costInitial: readonly number;
+    valInitial: readonly number;
   } | null;
   basePower: number;
   stats: { [statHash: number]: number };
@@ -109,7 +109,8 @@ export interface ProcessMod {
   hash: number;
   energy: {
     type: DestinyEnergyType;
-    cost: number;
+    /** The energy cost of the mod. */
+    val: number;
   };
   investmentStats: ProcessStat[];
   /** This should only be available in seasonal mods */

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -37,7 +37,7 @@ export interface ProcessItem {
     val: number;
     /** This contains the energy usage by slot specific mods in the mod picker. Those mods are preprocessed so we don't
      * need to recalculate them over and over. */
-    valInitial: readonly number;
+    valInitial: number;
   } | null;
   basePower: number;
   stats: { [statHash: number]: number };

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -134,6 +134,14 @@ export const LockableBuckets = {
   classitem: armorBuckets.classitem,
 };
 
+export const bucketsToCategories = {
+  [LockableBuckets.helmet]: armor2PlugCategoryHashesByName.helmet,
+  [LockableBuckets.gauntlets]: armor2PlugCategoryHashesByName.gauntlets,
+  [LockableBuckets.chest]: armor2PlugCategoryHashesByName.chest,
+  [LockableBuckets.leg]: armor2PlugCategoryHashesByName.leg,
+  [LockableBuckets.classitem]: armor2PlugCategoryHashesByName.classitem,
+};
+
 // to-do: deduplicate this and use D2ArmorStatHashByName instead
 export const statHashes: { [type in StatTypes]: number } = {
   Mobility: D2ArmorStatHashByName.mobility,


### PR DESCRIPTION
This fixes the issue where mods can total up to more than 10 energy with the new mod picker stuff. Since I think I am close to replacing the old mod stuff I don't want to mess around with it as its a little harder to do than this was. Largely because the seasonal mods are a bit disconnected from mods tied to specific slots.

Tagging #5532 