### PR TITLE
Spread Custom Total stat everywhere

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -854,7 +854,7 @@
   },
   "Stats": {
     "Custom": "Custom Total",
-    "CustomDesc": "Custom total configured in settings. This only adds up base stats, ignoring mods or masterworking.",
+    "CustomDesc": "Custom total of selected base stats, ignoring mods or masterworks. Visit Settings to configure which stats are included.",
     "Discipline": "Discipline",
     "Intellect": "Intellect",
     "MaxBasePower": "Max Power",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -816,6 +816,7 @@
     "ColumnSize": "{{num}} items",
     "ColumnSizeAuto": "Auto",
     "CsvImport": "Import tags/notes from CSV",
+    "CustomStatDesc": "Choose armor stats to make a custom total stat that will show on the item popup, Organizer, and Compare. Search with stat:custom:>=30.",
     "Data": "Spreadsheets",
     "DefaultItemSizeNote": "An item size of 50px will look the sharpest, without blurring the item picture or text.",
     "DontForgetDupes": "Don't forget you can search is:dupe to quickly find duplicate items, and you can use the comparison tool to evaluate related items.",
@@ -852,6 +853,8 @@
     "SortName": "Name"
   },
   "Stats": {
+    "Custom": "Custom Total",
+    "CustomDesc": "Custom total configured in settings. This only adds up base stats, ignoring mods or masterworking.",
     "Discipline": "Discipline",
     "Intellect": "Intellect",
     "MaxBasePower": "Max Power",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Configure a custom armor stat per-class in Settings, and it'll show up in item popups, Organizer, Compare, and the new `stat:custom:` search.
+
 ## 6.23.0 <span className="changelog-date">(2020-08-02)</span>
 
 * You can add tags and notes to shaders! Keep track of your favorites and which shaders you could do without.

--- a/src/app/dim-ui/CustomStatTotal.m.scss
+++ b/src/app/dim-ui/CustomStatTotal.m.scss
@@ -1,4 +1,5 @@
 .inlineStatIcon {
+  cursor: pointer;
   img {
     display: inline-block;
     vertical-align: bottom;

--- a/src/app/dim-ui/CustomStatTotal.m.scss
+++ b/src/app/dim-ui/CustomStatTotal.m.scss
@@ -1,7 +1,9 @@
 .inlineStatIcon {
-  display: inline-block;
-  vertical-align: bottom;
-  height: 1.5em;
+  img {
+    display: inline-block;
+    vertical-align: bottom;
+    height: 1.5em;
+  }
 }
 .divider::after {
   opacity: 0;

--- a/src/app/dim-ui/CustomStatTotal.tsx
+++ b/src/app/dim-ui/CustomStatTotal.tsx
@@ -99,11 +99,9 @@ function StatToggleButton({
       }
     >
       {stat.displayProperties.hasIcon ? (
-        <BungieImage
-          title={stat.displayProperties.name}
-          className={styles.inlineStatIcon}
-          src={stat.displayProperties.icon}
-        />
+        <span title={stat.displayProperties.name} className={styles.inlineStatIcon}>
+          <BungieImage src={stat.displayProperties.icon} />
+        </span>
       ) : (
         stat.displayProperties.name
       )}

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -17,7 +17,12 @@ import { compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
 import { t } from 'app/i18next-t';
 import { getSocketsWithStyle, getSocketsWithPlugCategoryHash } from '../../utils/socket-utils';
-import { armorBuckets, ARMOR_STAT_CAP, TOTAL_STAT_HASH } from 'app/search/d2-known-values';
+import {
+  armorBuckets,
+  ARMOR_STAT_CAP,
+  TOTAL_STAT_HASH,
+  CUSTOM_TOTAL_STAT_HASH,
+} from 'app/search/d2-known-values';
 import { D1ItemCategoryHashes } from 'app/search/d1-known-values';
 import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import reduxStore from '../../store/store';
@@ -77,6 +82,7 @@ export const statAllowList = [
   StatHashes.AmmoCapacity,
   ...armorStats,
   TOTAL_STAT_HASH,
+  CUSTOM_TOTAL_STAT_HASH,
 ];
 
 /** Stats that are measured in milliseconds. */
@@ -526,22 +532,23 @@ function customStat(stats: DimStat[], destinyClass: DestinyClass): DimStat | und
     destinyClass
   ];
 
-  if (!customStatDef?.length) {
+  if (!customStatDef || customStatDef.length === 0 || customStatDef.length === 6) {
     return undefined;
   }
 
   // TODO: for loop
+  // Custom stat is always base stat
   stats = stats.filter((s) => customStatDef.includes(s.statHash));
-  const total = _.sumBy(stats, (s) => s.value);
-  const baseTotal = _.sumBy(stats, (s) => s.base);
+  const total = _.sumBy(stats, (s) => s.base);
+  const baseTotal = total;
   const baseMayBeWrong = stats.some((stat) => stat.baseMayBeWrong);
   return {
     investmentValue: total,
-    statHash: -1100,
+    statHash: CUSTOM_TOTAL_STAT_HASH,
     displayProperties: ({
       name: t('Stats.Custom'),
     } as any) as DestinyDisplayPropertiesDefinition,
-    sort: statAllowList.indexOf(-1100),
+    sort: statAllowList.indexOf(CUSTOM_TOTAL_STAT_HASH),
     value: total,
     base: baseTotal,
     baseMayBeWrong,

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -547,6 +547,7 @@ function customStat(stats: DimStat[], destinyClass: DestinyClass): DimStat | und
     statHash: CUSTOM_TOTAL_STAT_HASH,
     displayProperties: ({
       name: t('Stats.Custom'),
+      description: t('Stats.CustomDesc'),
     } as any) as DestinyDisplayPropertiesDefinition,
     sort: statAllowList.indexOf(CUSTOM_TOTAL_STAT_HASH),
     value: total,

--- a/src/app/item-popup/ItemStat.m.scss
+++ b/src/app/item-popup/ItemStat.m.scss
@@ -19,6 +19,7 @@
     height: 12px;
     width: 12px;
     vertical-align: bottom;
+    filter: drop-shadow(0 0 0 white);
   }
 }
 
@@ -118,4 +119,14 @@
 .totalStatWarn {
   color: yellow;
   margin-left: 8px;
+}
+
+.smallStatToggle {
+  grid-column: -3 / -1;
+  margin-left: 4px;
+  img {
+    height: 12px !important;
+    width: 12px !important;
+    vertical-align: bottom;
+  }
 }

--- a/src/app/item-popup/ItemStat.m.scss.d.ts
+++ b/src/app/item-popup/ItemStat.m.scss.d.ts
@@ -12,6 +12,7 @@ interface CssExports {
   'quality': string;
   'qualitySummary': string;
   'ratingChartBarColor': string;
+  'smallStatToggle': string;
   'statBar': string;
   'statName': string;
   'totalRow': string;

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -14,8 +14,9 @@ import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import { getSocketsWithStyle } from '../utils/socket-utils';
 import PressTip from 'app/dim-ui/PressTip';
 import { getPossiblyIncorrectStats } from 'app/utils/item-utils';
-import { TOTAL_STAT_HASH } from 'app/search/d2-known-values';
+import { TOTAL_STAT_HASH, CUSTOM_TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import { StatTotalToggle } from 'app/dim-ui/CustomStatTotal';
 
 // used in displaying the modded segments on item stats
 const modItemCategoryHashes = [
@@ -182,6 +183,14 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
             )}
           </div>
         )}
+
+      {item && stat.statHash === CUSTOM_TOTAL_STAT_HASH && (
+        <StatTotalToggle
+          forClass={item.classType}
+          readOnly={true}
+          className={styles.smallStatToggle}
+        />
+      )}
     </>
   );
 }

--- a/src/app/item-popup/ItemStats.m.scss
+++ b/src/app/item-popup/ItemStats.m.scss
@@ -3,7 +3,7 @@
 .stats {
   margin: 10px;
   display: grid;
-  grid-auto-rows: 12px;
+  grid-auto-rows: minmax(12px, auto);
   grid-template-columns: repeat(2, min-content) 1fr;
   gap: 4px 0;
 

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -90,6 +90,7 @@ export const armor2PlugCategoryHashes: number[] = Object.values(armor2PlugCatego
 
 /** the stat hash for DIM's artificial armor stat, "Total" */
 export const TOTAL_STAT_HASH = -1000;
+export const CUSTOM_TOTAL_STAT_HASH = -1100;
 
 /** hashes representing D2 PL stats */
 export const D2LightStats = [StatHashes.Attack, StatHashes.Defense];

--- a/src/app/search/search-filter-values.ts
+++ b/src/app/search/search-filter-values.ts
@@ -5,6 +5,7 @@ import {
   D2LightStats,
   D2WeaponStatHashByName,
   TOTAL_STAT_HASH,
+  CUSTOM_TOTAL_STAT_HASH,
 } from './d2-known-values';
 
 // ✨ magic values ✨
@@ -33,6 +34,7 @@ export const damageTypeNames = Object.values(damageNamesByEnum).filter(
 export const dimArmorStatHashByName = {
   ...D2ArmorStatHashByName,
   total: TOTAL_STAT_HASH,
+  custom: CUSTOM_TOTAL_STAT_HASH,
 };
 
 /** stats names used to create armor-specific filters, real ones plus an "any" keyword */

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -193,7 +193,17 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
     'strength',
     ...(isD1 ? ['rof'] : []),
     ...(isD2
-      ? ['rpm', 'mobility', 'recovery', 'resilience', 'drawtime', 'inventorysize', 'total', 'any']
+      ? [
+          'rpm',
+          'mobility',
+          'recovery',
+          'resilience',
+          'drawtime',
+          'inventorysize',
+          'total',
+          'custom',
+          'any',
+        ]
       : []),
   ];
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -37,6 +37,9 @@ import { fetchRatings } from 'app/item-review/destiny-tracker.service';
 import { emptyArray } from 'app/utils/empty';
 import { storesLoadedSelector } from 'app/inventory/selectors';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
+import { StatTotalToggle } from 'app/dim-ui/CustomStatTotal';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { dimHunterIcon, dimWarlockIcon, dimTitanIcon } from 'app/shell/icons/custom';
 
 interface StoreProps {
   settings: Settings;
@@ -362,6 +365,12 @@ function SettingsPage({
 
               <SortOrderEditor order={itemSortCustom} onSortOrderChanged={itemSortOrderChanged} />
               <div className="fineprint">{t('Settings.DontForgetDupes')}</div>
+            </div>
+            <div className="setting">
+              <label htmlFor="">{t('Organizer.Columns.CustomTotal')}</label>
+              <AppIcon icon={dimTitanIcon} />: <StatTotalToggle forClass={DestinyClass.Titan} />
+              <AppIcon icon={dimHunterIcon} />: <StatTotalToggle forClass={DestinyClass.Hunter} />
+              <AppIcon icon={dimWarlockIcon} />: <StatTotalToggle forClass={DestinyClass.Warlock} />
             </div>
           </section>
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -35,16 +35,24 @@ import DimApiSettings from 'app/storage/DimApiSettings';
 import { clearRatings } from 'app/item-review/actions';
 import { fetchRatings } from 'app/item-review/destiny-tracker.service';
 import { emptyArray } from 'app/utils/empty';
-import { storesLoadedSelector } from 'app/inventory/selectors';
+import { storesLoadedSelector, sortedStoresSelector } from 'app/inventory/selectors';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { StatTotalToggle } from 'app/dim-ui/CustomStatTotal';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { dimHunterIcon, dimWarlockIcon, dimTitanIcon } from 'app/shell/icons/custom';
+import { DimStore } from 'app/inventory/store-types';
+
+const classIcons = {
+  [DestinyClass.Hunter]: dimHunterIcon,
+  [DestinyClass.Titan]: dimTitanIcon,
+  [DestinyClass.Warlock]: dimWarlockIcon,
+};
 
 interface StoreProps {
   settings: Settings;
   isPhonePortrait: boolean;
   storesLoaded: boolean;
+  stores: DimStore[];
   reviewModeOptions: D2ReviewMode[];
 }
 
@@ -52,6 +60,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     settings: settingsSelector(state),
     storesLoaded: storesLoadedSelector(state),
+    stores: sortedStoresSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
     reviewModeOptions: $featureFlags.reviewsEnabled ? reviewModesSelector(state) : emptyArray(),
   };
@@ -149,6 +158,7 @@ function SettingsPage({
   isPhonePortrait,
   reviewModeOptions,
   storesLoaded,
+  stores,
   dispatch,
 }: Props) {
   useEffect(() => {
@@ -280,6 +290,11 @@ function SettingsPage({
     return <ShowPageLoading message={t('Loading.Profile')} />;
   }
 
+  const uniqChars = _.uniqBy(
+    stores.filter((s) => !s.isVault),
+    (s) => s.classType
+  );
+
   return (
     <PageWithMenu>
       <PageWithMenu.Menu>
@@ -368,9 +383,20 @@ function SettingsPage({
             </div>
             <div className="setting">
               <label htmlFor="">{t('Organizer.Columns.CustomTotal')}</label>
-              <AppIcon icon={dimTitanIcon} />: <StatTotalToggle forClass={DestinyClass.Titan} />
-              <AppIcon icon={dimHunterIcon} />: <StatTotalToggle forClass={DestinyClass.Hunter} />
-              <AppIcon icon={dimWarlockIcon} />: <StatTotalToggle forClass={DestinyClass.Warlock} />
+              <div className="fineprint">{t('Settings.CustomStatDesc')}</div>
+              <div className="customStats">
+                {uniqChars.map(
+                  (store) =>
+                    !store.isVault && (
+                      <React.Fragment key={store.classType}>
+                        <div>
+                          <AppIcon icon={classIcons[store.classType]} /> {store.className}:{' '}
+                        </div>
+                        <StatTotalToggle forClass={store.classType} />
+                      </React.Fragment>
+                    )
+                )}
+              </div>
             </div>
           </section>
 

--- a/src/app/settings/settings.scss
+++ b/src/app/settings/settings.scss
@@ -115,4 +115,11 @@
       color: #999;
     }
   }
+
+  .customStats {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    margin: 8px 0 0 0;
+    gap: 4px 8px;
+  }
 }

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -8,6 +8,7 @@ import {
   armor2PlugCategoryHashes,
   energyNamesByEnum,
   TOTAL_STAT_HASH,
+  CUSTOM_TOTAL_STAT_HASH,
 } from 'app/search/d2-known-values';
 import { damageNamesByEnum } from 'app/search/search-filter-values';
 
@@ -97,7 +98,12 @@ export function getPossiblyIncorrectStats(item: DimItem): string[] {
 
   if (stats) {
     for (const stat of stats) {
-      if (stat.statHash !== TOTAL_STAT_HASH && stat.baseMayBeWrong && stat.displayProperties.name) {
+      if (
+        stat.statHash !== TOTAL_STAT_HASH &&
+        stat.statHash !== CUSTOM_TOTAL_STAT_HASH &&
+        stat.baseMayBeWrong &&
+        stat.displayProperties.name
+      ) {
         incorrect.add(stat.displayProperties.name);
       }
     }

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -810,6 +810,7 @@
     "ColumnSize": "{{num}} items",
     "ColumnSizeAuto": "Auto",
     "CsvImport": "Import tags/notes from CSV",
+    "CustomStatDesc": "Choose armor stats to make a custom total stat that will show on the item popup, Organizer, and Compare. Search with stat:custom:>=30.",
     "Data": "Spreadsheets",
     "DefaultItemSizeNote": "An item size of 50px will look the sharpest, without blurring the item picture or text.",
     "DontForgetDupes": "Don't forget you can search is:dupe to quickly find duplicate items, and you can use the comparison tool to evaluate related items.",
@@ -846,6 +847,8 @@
     "SortName": "Name"
   },
   "Stats": {
+    "Custom": "Custom Total",
+    "CustomDesc": "Custom total configured in settings. This only adds up base stats, ignoring mods or masterworking.",
     "Discipline": "Discipline",
     "Intellect": "Intellect",
     "MaxGearPower": "Maximum Power of equippable gear",


### PR DESCRIPTION
Fixes #5350 

This puts Custom Total everywhere stats are found in DIM, and provides an extra configuration for it in Settings. I suppose it could be configured directly in the item popup but I'm afraid of accidentally clicking it all the time.

Notes:
* Custom total is calculated as part of stores refresh so you'll need to refresh stores after changing it.

<img width="397" alt="Screen Shot 2020-08-03 at 10 47 11 PM" src="https://user-images.githubusercontent.com/313208/89257597-55aa4e00-d5db-11ea-8f1b-7d272c60b80a.png">
<img width="491" alt="Screen Shot 2020-08-03 at 10 35 05 PM" src="https://user-images.githubusercontent.com/313208/89256841-d700e100-d5d9-11ea-8a51-6232b41dc51d.png">
<img width="390" alt="Screen Shot 2020-08-03 at 10 35 23 PM" src="https://user-images.githubusercontent.com/313208/89256845-d8320e00-d5d9-11ea-813d-d9eb1c39e443.png">
<img width="426" alt="Screen Shot 2020-08-03 at 10 35 30 PM" src="https://user-images.githubusercontent.com/313208/89256848-d8caa480-d5d9-11ea-988d-72aa72cbf644.png">
