### PR TITLE
Load all vendors to show any vendor

### DIFF
--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -160,7 +160,7 @@ export function getVendorItems(
     [hash: number]: DestinyCollectibleComponent;
   }
 ): VendorItem[] {
-  if (sales && itemComponents) {
+  if (sales) {
     const components = Object.values(sales);
     return components.map((component) =>
       VendorItem.forVendorSaleItem(


### PR DESCRIPTION
It turns out the problem with https://github.com/DestinyItemManager/DIM/issues/5533 was that the single-vendor API errors on the seasonal artifact vendor. So instead, we load the entire vendors list into Redux, because the overall API does return it.

This isn't especially satisfying - the API doesn't know that the seasonal artifact isn't the gate lord's eye https://data.destinysets.com/i/Vendor:2894222926 and since this season's mods didn't make it into collections, it won't tell you what you've got unlocked.

![image](https://user-images.githubusercontent.com/313208/89261070-4da1dc80-d5e2-11ea-8d33-faab53836e64.png)
