### PR TITLE
Item Popup lite

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -701,6 +701,7 @@
     "OwnedMod": "This mod is in your modifications inventory.",
     "PullItem": "Pull from {{bucket}} to {{store}}",
     "ReadLore": "Read lore on Ishtar Collective",
+    "ReadLoreLink": "Read lore",
     "ReviewsTab": "Reviews",
     "Rewards": "Rewards:",
     "Split": "Split",

--- a/src/app/item-popup/ItemDescription.m.scss
+++ b/src/app/item-popup/ItemDescription.m.scss
@@ -32,6 +32,30 @@
 .wishListNotes {
   composes: description;
   font-style: italic;
+  position: relative;
+  max-height: 46px;
+  overflow: hidden;
+  &:hover {
+    cursor: pointer;
+  }
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    box-shadow: inset 0 -31px 20px -20px black;
+  }
+  &:focus {
+    max-height: fit-content;
+    &:hover {
+      cursor: default;
+    }
+    &::after {
+      display: none;
+    }
+  }
 }
 
 .lore {

--- a/src/app/item-popup/ItemDescription.m.scss
+++ b/src/app/item-popup/ItemDescription.m.scss
@@ -11,6 +11,9 @@
 
 .addNote {
   cursor: pointer;
+  display: inline-block;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
   &:hover {
     color: $orange;
   }

--- a/src/app/item-popup/ItemDescription.m.scss
+++ b/src/app/item-popup/ItemDescription.m.scss
@@ -11,11 +11,13 @@
 
 .addNote {
   cursor: pointer;
-  display: inline-block;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
   &:hover {
     color: $orange;
+  }
+  &.noNotesYet {
+    display: inline-block;
   }
 }
 .addNoteTag {
@@ -30,6 +32,7 @@
 .officialDescription {
   composes: description;
   font-style: italic;
+  overflow: auto;
 }
 
 .wishListNotes {
@@ -61,8 +64,10 @@
   }
 }
 
-.lore {
+.loreLink {
+  white-space: nowrap;
   img {
     vertical-align: text-bottom;
+    margin-right: 0.2em;
   }
 }

--- a/src/app/item-popup/ItemDescription.m.scss
+++ b/src/app/item-popup/ItemDescription.m.scss
@@ -35,7 +35,6 @@
 }
 
 .lore {
-  flex: 1;
   img {
     vertical-align: text-bottom;
   }

--- a/src/app/item-popup/ItemDescription.m.scss
+++ b/src/app/item-popup/ItemDescription.m.scss
@@ -37,7 +37,6 @@
 
 .wishListNotes {
   composes: description;
-  font-style: italic;
   position: relative;
   max-height: 46px;
   overflow: hidden;
@@ -61,6 +60,12 @@
     &::after {
       display: none;
     }
+  }
+  .wishListLabel {
+    font-weight: bold;
+  }
+  .wishListTextContent {
+    font-style: italic;
   }
 }
 

--- a/src/app/item-popup/ItemDescription.m.scss.d.ts
+++ b/src/app/item-popup/ItemDescription.m.scss.d.ts
@@ -8,7 +8,9 @@ interface CssExports {
   'loreLink': string;
   'noNotesYet': string;
   'officialDescription': string;
+  'wishListLabel': string;
   'wishListNotes': string;
+  'wishListTextContent': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/item-popup/ItemDescription.m.scss.d.ts
+++ b/src/app/item-popup/ItemDescription.m.scss.d.ts
@@ -5,7 +5,8 @@ interface CssExports {
   'addNoteTag': string;
   'description': string;
   'descriptionTools': string;
-  'lore': string;
+  'loreLink': string;
+  'noNotesYet': string;
   'officialDescription': string;
   'wishListNotes': string;
 }

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -60,7 +60,10 @@ function ItemDescription({ item, inventoryWishListRoll }: Props) {
         )}
       {inventoryWishListRoll?.notes && inventoryWishListRoll.notes.length > 0 && (
         <div tabIndex={-1} className={styles.wishListNotes}>
-          {t('WishListRoll.WishListNotes', { notes: inventoryWishListRoll.notes })}
+          <span className={styles.wishListLabel}>
+            {t('WishListRoll.WishListNotes', { notes: '' })}
+          </span>
+          <span className={styles.wishListTextContent}>{inventoryWishListRoll.notes}</span>
         </div>
       )}
       <NotesArea item={item} />

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -23,8 +23,6 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
     inventoryWishListRoll: inventoryWishListsSelector(state)[props.item.id],
   };
 }
-/**  */
-// const displaySourceIgnoreList: string[] = [];
 
 type Props = ProvidedProps & StoreProps;
 
@@ -40,14 +38,16 @@ function ItemDescription({ item, inventoryWishListRoll }: Props) {
     <>
       {showDescription && (
         <div className={styles.officialDescription}>
-          {item.description}
+          {item.description}{' '}
           {loreLink && (
             <ExternalLink
-              className={styles.lore}
+              className={styles.loreLink}
               href={loreLink}
+              title={t('MovePopup.ReadLore')}
               onClick={() => ga('send', 'event', 'Item Popup', 'Read Lore')}
             >
-              <img src={ishtarLogo} height="16" width="16" /> {t('MovePopup.ReadLore')}
+              <img src={ishtarLogo} height="16" width="16" />
+              {t('MovePopup.ReadLoreLink')}
             </ExternalLink>
           )}
         </div>

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -29,7 +29,8 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
 type Props = ProvidedProps & StoreProps;
 
 function ItemDescription({ item, inventoryWishListRoll }: Props) {
-  const showDescription = Boolean(item.description?.length);
+  const showDescription =
+    !item.bucket.inWeapons && !item.bucket.inArmor && Boolean(item.description?.length);
 
   const loreLink = item.loreHash
     ? `http://www.ishtar-collective.net/entries/${item.loreHash}`
@@ -51,17 +52,18 @@ function ItemDescription({ item, inventoryWishListRoll }: Props) {
           )}
         </div>
       )}
-      {item.isDestiny2() && true && Boolean(item.displaySource?.length) && (
-        <div className={styles.officialDescription}>{item.displaySource}</div>
-      )}
+      {item.isDestiny2() &&
+        !item.bucket.inWeapons &&
+        !item.bucket.inArmor &&
+        Boolean(item.displaySource?.length) && (
+          <div className={styles.officialDescription}>{item.displaySource}</div>
+        )}
       {inventoryWishListRoll?.notes && inventoryWishListRoll.notes.length > 0 && (
-        <div className={styles.wishListNotes}>
+        <div tabIndex={-1} className={styles.wishListNotes}>
           {t('WishListRoll.WishListNotes', { notes: inventoryWishListRoll.notes })}
         </div>
       )}
-      <div className={styles.descriptionTools}>
-        <NotesArea item={item} />
-      </div>
+      <NotesArea item={item} />
     </>
   );
 }

--- a/src/app/item-popup/NotesArea.tsx
+++ b/src/app/item-popup/NotesArea.tsx
@@ -10,6 +10,7 @@ import { setItemHashNote, setItemNote } from 'app/inventory/actions';
 import { AppIcon, editIcon } from 'app/shell/icons';
 // import { RichNotes } from 'app/dim-ui/RichNotes';
 import styles from './ItemDescription.m.scss';
+import clsx from 'clsx';
 
 const maxLength = 120;
 
@@ -29,12 +30,12 @@ export default function NotesArea({ item }: { item: DimItem }) {
     return <NotesEditor notes={savedNotes} item={item} />;
   }
 
-  // show notes if they exist
-  if (savedNotes) {
-    return (
+  // show notes if they exist, and an "add" or "edit" prompt
+  return (
+    <div className={styles.description}>
       <div
-        className={[styles.addNote, styles.description].join(' ')}
         role="button"
+        className={clsx(styles.addNote, { [styles.noNotesYet]: !savedNotes })}
         onClick={() => {
           setNotesOpen(true);
           ga('send', 'event', 'Item Popup', 'Edit Notes');
@@ -42,21 +43,11 @@ export default function NotesArea({ item }: { item: DimItem }) {
         tabIndex={0}
       >
         <AppIcon icon={editIcon} />{' '}
-        <span className={styles.addNoteTag}>{t('MovePopup.Notes')}</span> {savedNotes}
+        <span className={styles.addNoteTag}>
+          {savedNotes ? t('MovePopup.Notes') : t('MovePopup.AddNote')}
+        </span>{' '}
+        {savedNotes}
       </div>
-    );
-  }
-
-  // no other condition was met, show a message offering to add a note
-  return (
-    <div
-      role="button"
-      className={[styles.addNote, styles.description].join(' ')}
-      onClick={() => setNotesOpen(true)}
-      tabIndex={0}
-    >
-      <AppIcon icon={editIcon} />{' '}
-      <span className={styles.addNoteTag}>{t('MovePopup.AddNote')}</span>
     </div>
   );
 }

--- a/src/app/item-popup/NotesArea.tsx
+++ b/src/app/item-popup/NotesArea.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { t } from 'app/i18next-t';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'app/store/reducers';
+import { getNotes } from 'app/inventory/dim-item-info';
+import { itemHashTagsSelector, itemInfosSelector } from 'app/inventory/selectors';
+import { DimItem } from 'app/inventory/item-types';
+import { itemIsInstanced } from 'app/utils/item-utils';
+import { setItemHashNote, setItemNote } from 'app/inventory/actions';
+import { AppIcon, editIcon } from 'app/shell/icons';
+// import { RichNotes } from 'app/dim-ui/RichNotes';
+import styles from './ItemDescription.m.scss';
+
+const maxLength = 120;
+
+export default function NotesArea({ item }: { item: DimItem }) {
+  const savedNotes = useSelector<RootState, string>(
+    (state) => getNotes(item, itemInfosSelector(state), itemHashTagsSelector(state)) ?? ''
+  );
+  const [notesOpen, setNotesOpen] = useState(false);
+
+  // nothing to do if it can't be tagged (/noted)
+  if (!item.taggable) {
+    return null;
+  }
+
+  // text area for note editing
+  if (notesOpen) {
+    return <NotesEditor notes={savedNotes} item={item} />;
+  }
+
+  // show notes if they exist
+  if (savedNotes) {
+    return (
+      <div
+        className={[styles.addNote, styles.description].join(' ')}
+        role="button"
+        onClick={() => {
+          setNotesOpen(true);
+          ga('send', 'event', 'Item Popup', 'Edit Notes');
+        }}
+        tabIndex={0}
+      >
+        <AppIcon icon={editIcon} />{' '}
+        <span className={styles.addNoteTag}>{t('MovePopup.Notes')}</span> {savedNotes}
+      </div>
+    );
+  }
+
+  // no other condition was met, show a message offering to add a note
+  return (
+    <div
+      role="button"
+      className={[styles.addNote, styles.description].join(' ')}
+      onClick={() => setNotesOpen(true)}
+      tabIndex={0}
+    >
+      <AppIcon icon={editIcon} />{' '}
+      <span className={styles.addNoteTag}>{t('MovePopup.AddNote')}</span>
+    </div>
+  );
+}
+
+function NotesEditor({ notes, item }: { notes?: string; item: DimItem }) {
+  const [liveNotes, setLiveNotes] = useState(notes ?? '');
+  const dispatch = useDispatch();
+  const saveNotes = useCallback(() => {
+    dispatch(
+      itemIsInstanced(item)
+        ? setItemNote({ itemId: item.id, note: liveNotes })
+        : setItemHashNote({ itemHash: item.hash, note: liveNotes })
+    );
+  }, [dispatch, item, liveNotes]);
+
+  const stopEvents = (e) => {
+    e.stopPropagation();
+  };
+  const onNotesUpdated = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setLiveNotes(e.target.value);
+  };
+  useEffect(() => saveNotes, [saveNotes]);
+
+  return (
+    <form name="notes">
+      <textarea
+        name="data"
+        autoFocus={true}
+        placeholder={t('Notes.Help')}
+        maxLength={maxLength}
+        value={liveNotes}
+        onChange={onNotesUpdated}
+        onBlur={saveNotes}
+        onKeyDown={stopEvents}
+        onTouchStart={stopEvents}
+        onMouseDown={stopEvents}
+      />
+      {liveNotes && liveNotes.length > maxLength && (
+        <span className="textarea-error">{t('Notes.Error')}</span>
+      )}
+    </form>
+  );
+}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -696,6 +696,7 @@
     "PowerCap": "",
     "PullItem": "Pull from {{bucket}} to {{store}}",
     "ReadLore": "Read lore on Ishtar Collective",
+    "ReadLoreLink": "Read lore",
     "ReviewsTab": "Reviews",
     "Rewards": "Rewards:",
     "Split": "Split",


### PR DESCRIPTION
- slim down lore external link, leave Ishtar in hover for the curious
- drop it inline with the blurb.
- get GA to properly recognize the entire link.

![image](https://user-images.githubusercontent.com/68782081/89392879-f0c82400-d6be-11ea-900f-434a223a87bf.png)

<hr/>

- give "Add a note" some room to breathe: stop making the entire width of ItemPopup clickable.
- safe, clickable whitespace to dismiss wishlist notes.
- fewer weird, seemingly blank areas that give you pointer cursor and turn text orange.
- GA for adding notes, not just editing notes.

![image](https://user-images.githubusercontent.com/68782081/89394065-739dae80-d6c0-11ea-997a-34981207577c.png)

<hr/>

- for now, suppress lore, and useless additional text "random rolls etc etc" on weapons and armor
(still there on bounties & quests, where it's meaningful)
- preview 2.5 lines of wishlist notes, click to expand

before & after:
![image](https://user-images.githubusercontent.com/68782081/89394287-bbbcd100-d6c0-11ea-98f3-6e9168fe1c0c.png)![image](https://user-images.githubusercontent.com/68782081/89394318-c8d9c000-d6c0-11ea-82e2-aaaf1d76e3c4.png)

<hr/>

regarding wishlist notes expansion:
yes this could be managed via state but, i want to try it with CSS.
this is an _extremely simple and dependable mechanic_, i wouldn't propose it if i didn't think it would work reliably. it's fine for me in windows and fake mobile, we just need to confirm it works on mobile.