### PR TITLE
fix some lookup errors

### DIFF
--- a/src/app/collections/Mod.tsx
+++ b/src/app/collections/Mod.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-optional-chain */
 import React from 'react';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 
@@ -5,6 +6,10 @@ import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import '../progress/milestone.scss';
 import { D2Item } from 'app/inventory/item-types';
 import { bungieNetPath } from 'app/dim-ui/BungieImage';
+import {
+  DestinyEnergyTypeDefinition,
+  DestinyInventoryItemDefinition,
+} from 'bungie-api-ts/destiny2';
 
 interface ModProps {
   item: D2Item;
@@ -21,10 +26,7 @@ export default function Mod({ item, defs, allowFilter, innerRef, onClick, childr
     return null;
   }
 
-  const modDef = defs.InventoryItem.get(item.hash);
-  const energyType = defs.EnergyType.get(modDef?.plug.energyCost?.energyTypeHash);
-  const energyCostStat = defs.Stat.get(energyType?.costStatHash);
-  const costElementIcon = energyCostStat?.displayProperties.icon;
+  const { energyCost, energyCostElementOverlay } = getModCostInfo(item.hash, defs);
 
   return (
     <div>
@@ -35,15 +37,48 @@ export default function Mod({ item, defs, allowFilter, innerRef, onClick, childr
         onClick={onClick}
       />
       {children}
-      {costElementIcon && (
+      {energyCostElementOverlay && (
         <>
           <div
-            style={{ backgroundImage: `url("${bungieNetPath(costElementIcon)}")` }}
+            style={{ backgroundImage: `url("${bungieNetPath(energyCostElementOverlay)}")` }}
             className="energyCostOverlay"
           />
-          <div className="energyCost">{modDef.plug.energyCost.energyCost}</div>
+          <div className="energyCost">{energyCost}</div>
         </>
       )}
     </div>
   );
+}
+
+/**
+ * given a mod definition or hash, returns destructurable energy cost information
+ */
+export function getModCostInfo(
+  mod: DestinyInventoryItemDefinition | number,
+  defs: D2ManifestDefinitions
+) {
+  const modCostInfo: {
+    energyCost?: number;
+    energyCostElement?: DestinyEnergyTypeDefinition;
+    energyCostElementOverlay?: string;
+  } = {};
+
+  if (typeof mod === 'number') {
+    mod = defs.InventoryItem.get(mod);
+  }
+
+  if (mod) {
+    modCostInfo.energyCost = mod.plug.energyCost.energyCost;
+  }
+
+  if (mod?.plug.energyCost?.energyTypeHash) {
+    modCostInfo.energyCostElement = defs.EnergyType.get(mod.plug.energyCost.energyTypeHash);
+  }
+  if (modCostInfo.energyCostElement?.costStatHash) {
+    modCostInfo.energyCostElementOverlay = defs.Stat.get(
+      modCostInfo.energyCostElement.costStatHash
+    )?.displayProperties.icon;
+  }
+
+  return modCostInfo;
 }

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -43,6 +43,7 @@ import { ManifestDefinitions } from './definitions';
 import _ from 'lodash';
 import { setD2Manifest } from '../manifest/actions';
 import store from '../store/store';
+import { reportException } from 'app/utils/exceptions';
 
 const lazyTables = [
   'InventoryItem',
@@ -89,7 +90,12 @@ const eagerTables = [
 
 /** These aren't really lazy */
 export interface DefinitionTable<T> {
-  get(hash: number): T;
+  /**
+   * for troubleshooting/questionable lookups, include second arg
+   * and sentry can gather info about the source of the invalid hash.
+   * `requestor` ideally a string/number, or a definition including a "hash" key
+   */
+  get(hash: number, requestor?: any): T;
   getAll(): { [hash: number]: T };
 }
 
@@ -155,10 +161,19 @@ async function getDefinitionsUncached() {
   lazyTables.forEach((tableShort) => {
     const table = `Destiny${tableShort}Definition`;
     defs[tableShort] = {
-      get(id: number) {
+      get(id: number, requestor?: any) {
         const dbTable = db[table];
         if (!dbTable) {
           throw new Error(`Table ${table} does not exist in the manifest`);
+        }
+        if (!dbTable[id]) {
+          const requestingEntryInfo =
+            typeof requestor === 'object' ? requestor.hash : String(requestor);
+          reportException('hashLookupFailure', new Error('hash lookup failure'), {
+            requestingEntryInfo,
+            failedHash: id,
+            failedComponent: table,
+          });
         }
         return dbTable[id];
       },

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -166,7 +166,8 @@ async function getDefinitionsUncached() {
         if (!dbTable) {
           throw new Error(`Table ${table} does not exist in the manifest`);
         }
-        if (!dbTable[id]) {
+        const dbEntry = dbTable[id];
+        if (!dbEntry) {
           const requestingEntryInfo =
             typeof requestor === 'object' ? requestor.hash : String(requestor);
           reportException('hashLookupFailure', new Error('hash lookup failure'), {
@@ -175,7 +176,7 @@ async function getDefinitionsUncached() {
             failedComponent: table,
           });
         }
-        return dbTable[id];
+        return dbEntry;
       },
       getAll() {
         return db[table];

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -150,7 +150,7 @@ function buildDefinedSockets(
 
   for (let i = 0; i < sockets.length; i++) {
     const socket = sockets[i];
-    realSockets.push(buildDefinedSocket(defs, socket, i));
+    realSockets.push(buildDefinedSocket(defs, socket, i, itemDef));
   }
 
   const categories: DimSocketCategory[] = [];
@@ -194,17 +194,18 @@ function filterReusablePlug(reusablePlug: DimPlug) {
 function buildDefinedSocket(
   defs: D2ManifestDefinitions,
   socketDef: DestinyItemSocketEntryDefinition,
-  index: number
+  index: number,
+  forThisItem?: DestinyInventoryItemDefinition
 ): DimSocket | undefined {
   if (!socketDef) {
     return undefined;
   }
 
-  const socketTypeDef = defs.SocketType.get(socketDef.socketTypeHash);
+  const socketTypeDef = defs.SocketType.get(socketDef.socketTypeHash, forThisItem);
   if (!socketTypeDef) {
     return undefined;
   }
-  const socketCategoryDef = defs.SocketCategory.get(socketTypeDef.socketCategoryHash);
+  const socketCategoryDef = defs.SocketCategory.get(socketTypeDef.socketCategoryHash, forThisItem);
   if (!socketCategoryDef) {
     return undefined;
   }
@@ -223,11 +224,13 @@ function buildDefinedSocket(
   // we will only populate plugOptions with the currently inserted plug.
   if (isPerk) {
     if (socketDef.reusablePlugSetHash) {
-      const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash);
-      for (const reusablePlug of plugSet.reusablePlugItems) {
-        const built = buildDefinedPlug(defs, reusablePlug);
-        if (built) {
-          reusablePlugs.push(built);
+      const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash, forThisItem);
+      if (plugSet) {
+        for (const reusablePlug of plugSet.reusablePlugItems) {
+          const built = buildDefinedPlug(defs, reusablePlug);
+          if (built) {
+            reusablePlugs.push(built);
+          }
         }
       }
     } else if (socketDef.reusablePlugItems) {

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -104,7 +104,8 @@ export function buildInstancedSockets(
       itemDef.sockets.socketEntries[i],
       i,
       reusablePlugData?.[i],
-      plugObjectivesData
+      plugObjectivesData,
+      itemDef
     );
 
     realSockets.push(built);
@@ -366,7 +367,8 @@ function buildSocket(
   reusablePlugs?: DestinyItemPlugBase[],
   plugObjectivesData?: {
     [plugItemHash: number]: DestinyObjectiveProgress[];
-  }
+  },
+  forThisItem?: DestinyInventoryItemDefinition
 ): DimSocket | undefined {
   if (
     !socketDef ||
@@ -378,11 +380,11 @@ function buildSocket(
     return undefined;
   }
 
-  const socketTypeDef = defs.SocketType.get(socketDef.socketTypeHash);
+  const socketTypeDef = defs.SocketType.get(socketDef.socketTypeHash, forThisItem);
   if (!socketTypeDef) {
     return undefined;
   }
-  const socketCategoryDef = defs.SocketCategory.get(socketTypeDef.socketCategoryHash);
+  const socketCategoryDef = defs.SocketCategory.get(socketTypeDef.socketCategoryHash, forThisItem);
   if (!socketCategoryDef) {
     return undefined;
   }
@@ -410,10 +412,12 @@ function buildSocket(
       }
     } else if (socketDef.reusablePlugSetHash) {
       // Get options from plug set, instead of live info
-      const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash);
-      for (const reusablePlug of plugSet.reusablePlugItems) {
-        const built = buildDefinedPlug(defs, reusablePlug);
-        addPlugOption(built, plug, plugOptions);
+      const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash, forThisItem);
+      if (plugSet) {
+        for (const reusablePlug of plugSet.reusablePlugItems) {
+          const built = buildDefinedPlug(defs, reusablePlug);
+          addPlugOption(built, plug, plugOptions);
+        }
       }
     } else if (socketDef.reusablePlugItems) {
       // Get options from definition itself

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -23,6 +23,7 @@ import { itemsForPlugSet } from 'app/collections/plugset-helpers';
 import _ from 'lodash';
 import SocketDetailsSelectedPlug from './SocketDetailsSelectedPlug';
 import { emptySet } from 'app/utils/empty';
+import { getModCostInfo } from 'app/collections/Mod';
 
 interface ProvidedProps {
   item: D2Item;
@@ -256,9 +257,7 @@ export const SocketDetailsMod = React.memo(
     className?: string;
     onClick?(mod: DestinyInventoryItemDefinition): void;
   }) => {
-    const energyType = defs.EnergyType.get(itemDef?.plug?.energyCost?.energyTypeHash);
-    const energyCostStat = defs.Stat.get(energyType?.costStatHash);
-    const costElementIcon = energyCostStat?.displayProperties.icon;
+    const { energyCost, energyCostElementOverlay } = getModCostInfo(itemDef, defs);
 
     const onClickFn = onClick && (() => onClick(itemDef));
 
@@ -271,13 +270,13 @@ export const SocketDetailsMod = React.memo(
         tabIndex={0}
       >
         <BungieImage className="item-img" src={itemDef.displayProperties.icon} />
-        {costElementIcon && (
+        {energyCostElementOverlay && (
           <>
             <div
-              style={{ backgroundImage: `url("${bungieNetPath(costElementIcon)}")` }}
+              style={{ backgroundImage: `url("${bungieNetPath(energyCostElementOverlay)}")` }}
               className="energyCostOverlay"
             />
-            <div className="energyCost">{itemDef.plug.energyCost.energyCost}</div>
+            <div className="energyCost">{energyCost}</div>
           </>
         )}
       </div>

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -37,7 +37,8 @@ export default function SocketDetailsSelectedPlug({
       defs.MaterialRequirementSet.get(plug.plug.insertionMaterialRequirementHash)) ||
     undefined;
 
-  const sourceString = defs.Collectible.get(plug?.collectibleHash || 0)?.sourceString;
+  const sourceString =
+    plug.collectibleHash && defs.Collectible.get(plug.collectibleHash)?.sourceString;
 
   const stats = _.compact(
     plug.investmentStats.map((stat) => {


### PR DESCRIPTION
adds sentry error reporting to `defs.*.get()` so that we can review failed lookups

makes socket building slightly more resilient based on some reported errors