### PR TITLE
Disable pull to refresh in mobile chrome/browsers

### DIFF
--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -157,6 +157,12 @@ h3 {
   margin-bottom: 15px;
 }
 
+html,
+body {
+  // Disable pull to refresh in Android
+  overscroll-behavior: none;
+}
+
 body {
   margin: 0 auto;
   background-color: #313233;
@@ -165,8 +171,6 @@ body {
   font-size: 12px;
   // Disable drag and drop so we can use our polyfill
   -webkit-user-drag: none;
-  // Disable pull to refresh in Android
-  overscroll-behavior: contain;
 }
 
 #system {


### PR DESCRIPTION
I'm experiencing an issue where if I swipe down on a sheet quickly, the page refreshes because of the native pull to refresh on Android. It seems that applying the overscroll-behavior property to html fixes it. I tried removing it from the body, and it still worked, but I didn't want to risk breaking it if it was working for some browsers.

I changed the value from `contain` to `none` -the difference is that none will disable the 'glow'.

https://developers.google.com/web/updates/2017/11/overscroll-behavior#disableglow