### PR TITLE
troubleshooting logging for makeItem collectible lookup

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -413,7 +413,7 @@ export function makeItem(
     previewVendor: itemDef.preview?.previewVendorHash,
     ammoType: itemDef.equippingBlock ? itemDef.equippingBlock.ammoType : DestinyAmmunitionType.None,
     source: itemDef.collectibleHash
-      ? defs.Collectible.get(itemDef.collectibleHash)?.sourceHash
+      ? defs.Collectible.get(itemDef.collectibleHash, itemDef.hash)?.sourceHash
       : null,
     collectibleState: collectible ? collectible.state : null,
     collectibleHash: itemDef.collectibleHash || null,


### PR DESCRIPTION
investigate https://sentry.io/organizations/destiny-item-manager/issues/1834368675/
are we handling a number incorrectly?? i can't find anything in manifest with an unusually formatted collectible hash