### PR TITLE
Move Redux state / dispatch types to its own types-only file

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,7 +3,7 @@ import Header from './shell/Header';
 import clsx from 'clsx';
 import ActivityTracker from './dim-ui/ActivityTracker';
 import { connect } from 'react-redux';
-import { RootState } from './store/reducers';
+import { RootState } from 'app/store/types';
 import ClickOutsideRoot from './dim-ui/ClickOutsideRoot';
 import HotkeysCheatSheet from './hotkeys/HotkeysCheatSheet';
 import NotificationsContainer from './notifications/NotificationsContainer';

--- a/src/app/accounts/MenuAccounts.tsx
+++ b/src/app/accounts/MenuAccounts.tsx
@@ -3,7 +3,7 @@ import './Account.scss';
 import { DestinyAccount } from './destiny-account';
 import { AppIcon, signOutIcon } from '../shell/icons';
 import { currentAccountSelector } from './reducer';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import Account from './Account';

--- a/src/app/accounts/destiny-account.ts
+++ b/src/app/accounts/destiny-account.ts
@@ -15,7 +15,7 @@ import { showNotification } from '../notifications/notifications';
 import { stadiaIcon, battleNetIcon, faXbox, faPlaystation, faSteam } from 'app/shell/icons';
 import { UserInfoCard } from 'bungie-api-ts/user';
 import { loggedOut } from './actions';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 
 // See https://github.com/Bungie-net/api/wiki/FAQ:-Cross-Save-pre-launch-testing,-and-how-it-may-affect-you for more info

--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -15,7 +15,7 @@ import {
   loadAccountsFromIndexedDB,
   accountsLoadedSelector,
 } from './reducer';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { dedupePromise } from 'app/utils/util';
 import { removeToken } from '../bungie-api/oauth-tokens';
 import { deleteDimApiToken } from 'app/dim-api/dim-api-helper';

--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -2,7 +2,7 @@ import { Reducer } from 'redux';
 import { DestinyAccount } from './destiny-account';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
-import { RootState, ThunkResult } from '../store/reducers';
+import { RootState, ThunkResult } from 'app/store/types';
 import { observeStore } from 'app/utils/redux-utils';
 import { set, get } from 'idb-keyval';
 import { dedupePromise } from 'app/utils/util';

--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -10,7 +10,7 @@ import { D2StoresService } from '../inventory/d2-stores';
 import Catalysts from './Catalysts';
 import { connect } from 'react-redux';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
 import { storesSelector, profileResponseSelector } from '../inventory/selectors';
 import { refresh$ } from '../shell/refresh';

--- a/src/app/collections/PresentationNode.tsx
+++ b/src/app/collections/PresentationNode.tsx
@@ -12,7 +12,7 @@ import { deepEqual } from 'fast-equals';
 import { percent } from '../shell/filters';
 import { scrollToPosition } from 'app/dim-ui/scroll';
 import { setSetting } from '../settings/actions';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import Checkbox from '../settings/Checkbox';
 import { connect } from 'react-redux';
 import { t } from 'app/i18next-t';

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -11,7 +11,7 @@ import './compare.scss';
 import { Subscriptions } from '../utils/rx-utils';
 import { connect } from 'react-redux';
 import { ReviewsState, getRating, ratingsSelector, shouldShowRating } from '../item-review/reducer';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import Sheet from '../dim-ui/Sheet';
 import { showNotification } from '../notifications/notifications';
 import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import BungieImage, { bungieBackgroundStyle } from '../../dim-ui/BungieImage';
 import { DimStore, D1Store } from '../../inventory/store-types';
-import { RootState } from '../../store/reducers';
+import { RootState } from 'app/store/types';
 import { sortedStoresSelector } from '../../inventory/selectors';
 import CharacterTileButton from '../../character-tile/CharacterTileButton';
 import CollapsibleTitle from '../../dim-ui/CollapsibleTitle';

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -14,7 +14,7 @@ import _ from 'lodash';
 import { connect } from 'react-redux';
 import { DestinyAccount } from '../../accounts/destiny-account';
 import { D1Store } from '../../inventory/store-types';
-import { RootState } from '../../store/reducers';
+import { RootState } from 'app/store/types';
 import { storesSelector } from '../../inventory/selectors';
 import { currentAccountSelector } from '../../accounts/reducer';
 import { D1StoresService } from '../../inventory/d1-stores';

--- a/src/app/destiny1/record-books/RecordBooks.tsx
+++ b/src/app/destiny1/record-books/RecordBooks.tsx
@@ -8,7 +8,7 @@ import { count } from '../../utils/util';
 import { setSetting } from '../../settings/actions';
 import { D1Store } from '../../inventory/store-types';
 import { storesSelector } from '../../inventory/selectors';
-import { RootState } from '../../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { D1StoresService } from '../../inventory/d1-stores';
 import { refresh$ } from '../../shell/refresh';

--- a/src/app/destinyTrackerApi/bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/bulkFetcher.ts
@@ -8,7 +8,7 @@ import { getWeaponList } from './itemListBuilder';
 import { updateRatings } from '../item-review/actions';
 import { DtrRating } from '../item-review/dtr-api-types';
 import { roundToAtMostOneDecimal } from './d2-bulkFetcher';
-import { ThunkResult, RootState } from '../store/reducers';
+import { RootState, ThunkResult } from 'app/store/types';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
 import { ratingsSelector, loadReviewsFromIndexedDB } from '../item-review/reducer';

--- a/src/app/destinyTrackerApi/d2-bulkFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-bulkFetcher.ts
@@ -12,7 +12,7 @@ import _ from 'lodash';
 import { updateRatings } from '../item-review/actions';
 import { DtrRating } from '../item-review/dtr-api-types';
 import { getD2Roll } from './d2-itemTransformer';
-import { ThunkResult, RootState } from '../store/reducers';
+import { RootState, ThunkResult } from 'app/store/types';
 import { ratingsSelector, loadReviewsFromIndexedDB } from '../item-review/reducer';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';

--- a/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/d2-reviewsFetcher.ts
@@ -10,7 +10,7 @@ import { conditionallyIgnoreReviews } from './userFilter';
 import { toUtcTime } from './util';
 import { getReviews, getItemReviewsKey } from '../item-review/reducer';
 import { reviewsLoaded } from '../item-review/actions';
-import { ThunkResult } from '../store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { DtrD2ActivityModes, DtrReviewPlatform } from '@destinyitemmanager/dim-api-types';
 
 /**

--- a/src/app/destinyTrackerApi/reviewSubmitter.ts
+++ b/src/app/destinyTrackerApi/reviewSubmitter.ts
@@ -7,7 +7,7 @@ import { WorkingD2Rating } from '../item-review/d2-dtr-api-types';
 import { getRollAndPerks as getRollAndPerksD2 } from './d2-itemTransformer';
 import { getItemReviewsKey } from '../item-review/reducer';
 import { markReviewSubmitted, purgeCachedReview } from '../item-review/actions';
-import { ThunkResult } from '../store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { handleSubmitErrors } from './trackerErrorHandler';
 import { WorkingD1Rating } from '../item-review/d1-dtr-api-types';
 import { getRollAndPerks as getRollAndPerksD1 } from './itemTransformer';

--- a/src/app/destinyTrackerApi/reviewsFetcher.ts
+++ b/src/app/destinyTrackerApi/reviewsFetcher.ts
@@ -13,7 +13,7 @@ import { conditionallyIgnoreReviews } from './userFilter';
 import { toUtcTime } from './util';
 import { getReviews, getItemReviewsKey } from '../item-review/reducer';
 import { reviewsLoaded } from '../item-review/actions';
-import { ThunkResult } from '../store/reducers';
+import { ThunkResult } from 'app/store/types';
 
 /**
  * Redux action that populates community (which may include the current user's) reviews for a given item.

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -4,7 +4,7 @@ import {
   postUpdates,
   deleteAllData,
 } from '../dim-api/dim-api';
-import { ThunkResult, RootState } from '../store/reducers';
+import { RootState, ThunkResult } from 'app/store/types';
 import { DimApiState } from './reducer';
 import { get, set } from 'idb-keyval';
 import { getPlatforms } from '../accounts/platforms';

--- a/src/app/dim-api/import.ts
+++ b/src/app/dim-api/import.ts
@@ -1,5 +1,5 @@
 import { DimData } from 'app/storage/sync.service';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { importData } from './dim-api';
 import { loadDimApiData } from './actions';
 import { DimApiState, makeProfileKey } from './reducer';

--- a/src/app/dim-api/selectors.ts
+++ b/src/app/dim-api/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
 import { makeProfileKeyFromAccount } from './reducer';
 import { currentAccountSelector } from 'app/accounts/reducer';

--- a/src/app/dim-ui/ActivityTracker.tsx
+++ b/src/app/dim-ui/ActivityTracker.tsx
@@ -8,7 +8,7 @@ import { filter, take } from 'rxjs/operators';
 import { dimNeedsUpdate } from 'app/register-service-worker';
 import { reloadDIM } from 'app/whats-new/WhatsNewLink';
 import { connect } from 'react-redux';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 
 interface StoreProps {
   /** Don't allow refresh more often than this many seconds. */

--- a/src/app/dim-ui/CollapsibleTitle.tsx
+++ b/src/app/dim-ui/CollapsibleTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { toggleCollapsedSection } from '../settings/actions';
 import { Dispatch } from 'redux';

--- a/src/app/dim-ui/CustomStatTotal.tsx
+++ b/src/app/dim-ui/CustomStatTotal.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import BungieImage from 'app/dim-ui/BungieImage';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { useDispatch, useSelector } from 'react-redux';
 import styles from './CustomStatTotal.m.scss';
 import { armorStats } from 'app/inventory/store/stats';

--- a/src/app/dim-ui/PageLoading.tsx
+++ b/src/app/dim-ui/PageLoading.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { connect } from 'react-redux';
-import { ThunkDispatchProp, RootState } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { Loading } from './Loading';
 import _ from 'lodash';
 import styles from './PageLoading.m.scss';

--- a/src/app/dim-ui/ShowPageLoading.tsx
+++ b/src/app/dim-ui/ShowPageLoading.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { ThunkDispatchProp } from 'app/store/reducers';
+import { ThunkDispatchProp } from 'app/store/types';
 import { loadingStart, loadingEnd } from 'app/shell/actions';
 
 interface ProvidedProps {

--- a/src/app/dim-ui/SpecialtyModSlotIcon.tsx
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.tsx
@@ -1,7 +1,7 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, DimSocket } from 'app/inventory/item-types';
 import React from 'react';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { bungieBackgroundStyle } from 'app/dim-ui/BungieImage';
 import { connect } from 'react-redux';
 import { getSpecialtySocket } from 'app/utils/item-utils';

--- a/src/app/farming/D1Farming.tsx
+++ b/src/app/farming/D1Farming.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { DimStore } from '../inventory/store-types';
 import { t } from 'app/i18next-t';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import { farmingStoreSelector } from './reducer';

--- a/src/app/farming/D2Farming.tsx
+++ b/src/app/farming/D2Farming.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { DimStore } from '../inventory/store-types';
 import { t } from 'app/i18next-t';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import { farmingStoreSelector } from './reducer';

--- a/src/app/farming/reducer.ts
+++ b/src/app/farming/reducer.ts
@@ -4,7 +4,7 @@ import { ActionType, getType } from 'typesafe-actions';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/selectors';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 
 export const farmingStoreSelector = () =>
   createSelector(

--- a/src/app/gear-power/GearPower.tsx
+++ b/src/app/gear-power/GearPower.tsx
@@ -3,7 +3,7 @@ import { showGearPower$ } from './gear-power';
 import Sheet from '../dim-ui/Sheet';
 import { storesSelector } from '../inventory/selectors';
 import { D2Store } from '../inventory/store-types';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import styles from './GearPower.m.scss';
 import { useSelector } from 'react-redux';
 import { t } from 'app/i18next-t';

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -8,7 +8,7 @@ import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import copy from 'fast-copy';
 import { storesSelector, currentStoreSelector } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import _ from 'lodash';
 import { reverseComparator, compareBy, chainComparator } from '../utils/comparators';
 import { newLoadout, convertToLoadoutItem } from '../loadout/loadout-utils';

--- a/src/app/inventory/ClearNewItems.tsx
+++ b/src/app/inventory/ClearNewItems.tsx
@@ -3,7 +3,7 @@ import { DestinyAccount } from '../accounts/destiny-account';
 import { t } from 'app/i18next-t';
 import './ClearNewItems.scss';
 import { connect } from 'react-redux';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import NewItemIndicator from './NewItemIndicator';
 import { settingsSelector } from 'app/settings/reducer';

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DimItem } from './item-types';
 import { TagValue, getTag, getNotes } from './dim-item-info';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import InventoryItem from './InventoryItem';
 import { getRating, shouldShowRating, ratingsSelector } from '../item-review/reducer';

--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -4,7 +4,7 @@ import Stores from './Stores';
 import { D1StoresService } from './d1-stores';
 import { D2StoresService } from './d2-stores';
 import { connect } from 'react-redux';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import ClearNewItems from './ClearNewItems';
 import StackableDragHelp from './StackableDragHelp';
 import LoadoutDrawer from '../loadout/LoadoutDrawer';

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { toggleCollapsedSection } from '../settings/actions';
 import { Dispatch } from 'redux';

--- a/src/app/inventory/StackableDragHelp.tsx
+++ b/src/app/inventory/StackableDragHelp.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 
 interface Props {

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -6,7 +6,7 @@ import StoreBucketDropTarget from './StoreBucketDropTarget';
 import { InventoryBucket } from './inventory-buckets';
 import { DimStore } from './store-types';
 import StoreInventoryItem from './StoreInventoryItem';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import emptyEngram from 'destiny-icons/general/empty-engram.svg';

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -4,7 +4,7 @@ import { InventoryBuckets } from './inventory-buckets';
 import { t } from 'app/i18next-t';
 import './Stores.scss';
 import StoreHeading from '../character-tile/StoreHeading';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { Frame, Track, View, ViewPager } from 'react-view-pager';
 import ScrollClassDiv from '../dim-ui/ScrollClassDiv';

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -4,7 +4,7 @@ import { DimItem } from './item-types';
 import { InventoryBuckets } from './inventory-buckets';
 import { TagValue } from './dim-item-info';
 import { DestinyProfileResponse, DestinyColor } from 'bungie-api-ts/destiny2';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { get } from 'idb-keyval';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { DimError } from 'app/bungie-api/bungie-service-helper';

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -34,7 +34,7 @@ import helmetIcon from '../../../destiny-icons/armor_types/helmet.svg';
 import xpIcon from '../../images/xpIcon.svg';
 import { maxLightItemSet } from 'app/loadout/auto-loadouts';
 import { storesSelector } from './selectors';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { currentAccountSelector } from 'app/accounts/reducer';
 import { getCharacterStatsData as getD1CharacterStatsData } from './store/character-utils';
 import { getCharacters as d1GetCharacters } from '../bungie-api/destiny1-api';

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -5,7 +5,7 @@ import { DimItem } from './item-types';
 import { tagCleanup } from './actions';
 import { heartIcon, banIcon, tagIcon, boltIcon, archiveIcon } from '../shell/icons';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { itemInfosSelector } from './selectors';
 import { ItemAnnotation, ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { itemIsInstanced } from 'app/utils/item-utils';

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -5,7 +5,7 @@ import { DimStore } from './store-types';
 import { InventoryBuckets } from './inventory-buckets';
 import { AccountsAction, currentAccountSelector } from '../accounts/reducer';
 import { setCurrentAccount } from '../accounts/actions';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { observeStore } from 'app/utils/redux-utils';
 import _ from 'lodash';

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
 import { characterSortSelector } from '../settings/character-sort';
 import _ from 'lodash';

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -10,7 +10,7 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { DimStore } from './store-types';
 import { DtrRating } from '../item-review/dtr-api-types';
 import Papa from 'papaparse';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import _ from 'lodash';
 import { getActivePlatform } from '../accounts/platforms';
 import { getClass } from './store/character-utils';

--- a/src/app/inventory/tag-items.tsx
+++ b/src/app/inventory/tag-items.tsx
@@ -5,7 +5,7 @@ import { t } from 'app/i18next-t';
 import NotificationButton from 'app/notifications/NotificationButton';
 import { AppIcon, undoIcon } from 'app/shell/icons';
 import { DimItem } from './item-types';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { setItemTagsBulk, setItemHashTag } from './actions';
 import { itemInfosSelector, itemHashTagsSelector } from './selectors';
 import _ from 'lodash';

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -4,7 +4,7 @@ import { ItemPickerState } from './item-picker';
 import Sheet from '../dim-ui/Sheet';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { connect, MapStateToProps } from 'react-redux';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/selectors';
 import {

--- a/src/app/item-popup/ExpandedRating.tsx
+++ b/src/app/item-popup/ExpandedRating.tsx
@@ -3,7 +3,7 @@ import RatingIcon from '../inventory/RatingIcon';
 import { DimItem } from '../inventory/item-types';
 import { connect } from 'react-redux';
 import { getRating, shouldShowRating } from '../item-review/reducer';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { t } from 'app/i18next-t';
 import { DtrRating } from '../item-review/dtr-api-types';
 

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -6,7 +6,7 @@ import { t } from 'app/i18next-t';
 import ishtarLogo from '../../images/ishtar-collective.svg';
 import styles from './ItemDescription.m.scss';
 import { connect } from 'react-redux';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { inventoryWishListsSelector } from 'app/wishlists/reducer';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import { ExpandableTextBlock } from 'app/dim-ui/ExpandableTextBlock';

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -12,7 +12,7 @@ import ItemDescription from './ItemDescription';
 import ItemExpiration from './ItemExpiration';
 import { Reward } from 'app/progress/Reward';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { ActivityModifier } from 'app/progress/ActivityModifier';
 import helmetIcon from 'destiny-icons/armor_types/helmet.svg';

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -19,7 +19,7 @@ import popperOffsets from '@popperjs/core/lib/modifiers/popperOffsets';
 import offset from '@popperjs/core/lib/modifiers/offset';
 import arrow from '@popperjs/core/lib/modifiers/arrow';
 import React, { useState, useRef, useEffect } from 'react';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import Sheet from '../dim-ui/Sheet';
 import { connect } from 'react-redux';
 import { setSetting } from '../settings/actions';

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -8,7 +8,7 @@ import { D2Item, DimSocketCategory, DimPlug, DimSocket } from '../inventory/item
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import { connect } from 'react-redux';
 import { wishListsEnabledSelector, inventoryWishListsSelector } from '../wishlists/reducer';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { getReviews } from '../item-review/reducer';
 import { D2ItemUserReview } from '../item-review/d2-dtr-api-types';
 import { ratePerks } from '../destinyTrackerApi/d2-perkRater';

--- a/src/app/item-popup/ItemTagHotkeys.tsx
+++ b/src/app/item-popup/ItemTagHotkeys.tsx
@@ -6,7 +6,7 @@ import { Hotkey } from '../hotkeys/hotkeys';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import { t } from 'app/i18next-t';
 import { connect } from 'react-redux';
-import { RootState, ThunkDispatchProp } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemInfosSelector, itemHashTagsSelector } from 'app/inventory/selectors';
 import { itemIsInstanced } from 'app/utils/item-utils';
 

--- a/src/app/item-popup/ItemTagSelector.tsx
+++ b/src/app/item-popup/ItemTagSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { itemTagSelectorList, TagValue, getTag } from '../inventory/dim-item-info';
 import { connect } from 'react-redux';
 import { DimItem } from '../inventory/item-types';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { t } from 'app/i18next-t';
 import './ItemTagSelector.scss';
 import { setItemTag, setItemHashTag } from 'app/inventory/actions';

--- a/src/app/item-popup/ItemTalentGrid.tsx
+++ b/src/app/item-popup/ItemTalentGrid.tsx
@@ -7,7 +7,7 @@ import { bungieNetPath } from '../dim-ui/BungieImage';
 import './ItemTalentGrid.scss';
 import { ratePerks } from '../destinyTrackerApi/perkRater';
 import { connect } from 'react-redux';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { getReviews } from '../item-review/reducer';
 import { D1ItemUserReview } from '../item-review/d1-dtr-api-types';
 import { emptySet, emptyArray } from 'app/utils/empty';

--- a/src/app/item-popup/NotesArea.tsx
+++ b/src/app/item-popup/NotesArea.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { t } from 'app/i18next-t';
 import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { getNotes } from 'app/inventory/dim-item-info';
 import { itemHashTagsSelector, itemInfosSelector } from 'app/inventory/selectors';
 import { DimItem } from 'app/inventory/item-types';

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -11,7 +11,7 @@ import {
   DestinyItemPlugBase,
 } from 'bungie-api-ts/destiny2';
 import BungieImage, { bungieNetPath } from 'app/dim-ui/BungieImage';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { connect } from 'react-redux';
 import clsx from 'clsx';

--- a/src/app/item-review/ItemReviewSettings.tsx
+++ b/src/app/item-review/ItemReviewSettings.tsx
@@ -6,7 +6,7 @@ import { DimItem } from '../inventory/item-types';
 import { setSetting } from '../settings/actions';
 import { getItemReviews } from './destiny-tracker.service';
 import { connect } from 'react-redux';
-import { ThunkDispatchProp } from 'app/store/reducers';
+import { ThunkDispatchProp } from 'app/store/types';
 
 interface ProvidedProps {
   item: DimItem;

--- a/src/app/item-review/ItemReviews.tsx
+++ b/src/app/item-review/ItemReviews.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DimItem } from '../inventory/item-types';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { t } from 'app/i18next-t';
 import './item-review.scss';
 import { connect } from 'react-redux';

--- a/src/app/item-review/destiny-tracker.service.ts
+++ b/src/app/item-review/destiny-tracker.service.ts
@@ -15,7 +15,7 @@ import { WorkingD1Rating } from './d1-dtr-api-types';
 import { DimUserReview, DtrRating } from './dtr-api-types';
 import { Vendor } from '../destiny1/vendors/vendor.service';
 import { getItemReviewsD2 } from '../destinyTrackerApi/d2-reviewsFetcher';
-import { ThunkResult } from '../store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { submitReview as doSubmitReview } from '../destinyTrackerApi/reviewSubmitter';
 import {
   bulkFetchVendorItems as bulkFetchD1VendorItems,

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -5,7 +5,7 @@ import { WorkingD2Rating, D2ItemReviewResponse, D2ItemUserReview } from './d2-dt
 import { WorkingD1Rating, D1ItemReviewResponse, D1ItemUserReview } from './d1-dtr-api-types';
 import { DimItem } from '../inventory/item-types';
 import { getReviewKey, getD2Roll } from '../destinyTrackerApi/d2-itemTransformer';
-import { RootState, ThunkResult } from '../store/reducers';
+import { RootState, ThunkResult } from 'app/store/types';
 import produce from 'immer';
 import { DtrRating } from './dtr-api-types';
 import { set, get } from 'idb-keyval';

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -20,7 +20,7 @@ import PressTip from 'app/dim-ui/PressTip';
 import { getWeaponSvgIcon } from 'app/dim-ui/svgs/itemCategory';
 import clsx from 'clsx';
 import { settingsSelector } from 'app/settings/reducer';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { useSelector } from 'react-redux';
 import { StatHashListsKeyedByDestinyClass, StatTotalToggle } from 'app/dim-ui/CustomStatTotal';
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import CharacterSelect from '../dim-ui/CharacterSelect';
 import { DimStore, D2Store } from '../inventory/store-types';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import GeneratedSets from './generated-sets/GeneratedSets';
 import { sortGeneratedSets } from './generated-sets/utils';
 import { isLoadoutBuilderItem } from './utils';

--- a/src/app/loadout-builder/LoadoutBuilderContainer.tsx
+++ b/src/app/loadout-builder/LoadoutBuilderContainer.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { D2StoresService } from '../inventory/d2-stores';
 import { DimStore } from '../inventory/store-types';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { sortedStoresSelector } from '../inventory/selectors';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { refresh$ } from 'app/shell/refresh';

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -21,7 +21,7 @@ import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { connect } from 'react-redux';
 import { storesSelector } from 'app/inventory/selectors';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { DimStore } from 'app/inventory/store-types';
 import { AppIcon, addIcon, faTimesCircle } from 'app/shell/icons';
 import LoadoutBucketDropTarget from '../locked-armor/LoadoutBucketDropTarget';

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -14,7 +14,7 @@ import { isLoadoutBuilderItem } from '../utils';
 import copy from 'fast-copy';
 import { createSelector } from 'reselect';
 import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { escapeRegExp } from 'app/search/search-filter';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -29,7 +29,7 @@ import copy from 'fast-copy';
 import ArmorBucketIcon from '../ArmorBucketIcon';
 import { createSelector } from 'reselect';
 import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { itemsForPlugSet } from 'app/collections/plugset-helpers';
 import { escapeRegExp } from 'app/search/search-filter';

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -7,7 +7,7 @@ import { D1ManifestDefinitions } from '../destiny1/d1-definitions';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { DimItem } from '../inventory/item-types';
 import { v4 as uuidv4 } from 'uuid';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { t } from 'app/i18next-t';
 import './loadout-popup.scss';
 import { DimStore } from '../inventory/store-types';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { previousLoadoutSelector, loadoutsSelector } from './reducer';
 import { currentAccountSelector } from '../accounts/reducer';
 import { getBuckets as d2GetBuckets } from '../destiny2/d2-buckets';

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -3,7 +3,7 @@ import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { currentAccountSelector } from '../accounts/reducer';
 import { Loadout, LoadoutItem } from './loadout-types';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
 import {

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -18,7 +18,7 @@ import EnabledColumnsSelector from './EnabledColumnsSelector';
 import { bulkTagItems } from 'app/inventory/tag-items';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { RootState, ThunkDispatchProp } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { storesSelector, itemInfosSelector } from 'app/inventory/selectors';
 import { searchFilterSelector } from 'app/search/search-filter';
 import { inventoryWishListsSelector } from 'app/wishlists/reducer';

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-key, react/prop-types */
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { D2StoresService } from 'app/inventory/d2-stores';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { useSubscription } from 'app/utils/hooks';

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -5,7 +5,7 @@ import { DestinyAccount } from '../accounts/destiny-account';
 import './progress.scss';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import { connect } from 'react-redux';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { refresh$ } from '../shell/refresh';
 import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
 import PresentationNodeRoot from '../collections/PresentationNodeRoot';

--- a/src/app/progress/Pursuit.tsx
+++ b/src/app/progress/Pursuit.tsx
@@ -4,7 +4,7 @@ import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import ItemExpiration from 'app/item-popup/ItemExpiration';
 import PursuitItem from './PursuitItem';
 import { percent } from 'app/shell/filters';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import { searchFilterSelector } from 'app/search/search-filter';
 import { connect } from 'react-redux';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -1,7 +1,7 @@
 import './FilterHelp.scss';
 
 import React from 'react';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { destinyVersionSelector } from '../accounts/reducer';
 import { t } from 'app/i18next-t';

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import { AppIcon, tagIcon, faClone } from '../shell/icons';
 import { itemTagSelectorList, isTagValue, TagValue } from '../inventory/dim-item-info';
 import { connect, MapDispatchToPropsFunction } from 'react-redux';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { setSearchQuery } from '../shell/actions';
 import _ from 'lodash';
 import './search-filter.scss';

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -30,7 +30,7 @@ import D2Sources from 'data/d2/source-info';
 import { DimStore } from '../inventory/store-types';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import { Loadout } from '../loadout/loadout-types';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import missingSources from 'data/d2/missing-source-info';
 import _ from 'lodash';
 import { createSelector } from 'reselect';

--- a/src/app/settings/AuditLog.tsx
+++ b/src/app/settings/AuditLog.tsx
@@ -8,7 +8,7 @@ import { getAuditLog } from 'app/dim-api/dim-api';
 import { DestinyAccount, PLATFORM_ICONS } from 'app/accounts/destiny-account';
 import { accountsSelector } from 'app/accounts/reducer';
 import { connect } from 'react-redux';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 import styles from './AuditLog.m.scss';
 import { AppIcon } from 'app/shell/icons';
 import { t } from 'app/i18next-t';

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { t } from 'app/i18next-t';
 import i18next from 'i18next';
 import { setSetting, setCharacterOrder } from './actions';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import InventoryItem from '../inventory/InventoryItem';
 import SortOrderEditor, { SortProperty } from './SortOrderEditor';
 import CharacterOrderEditor from './CharacterOrderEditor';

--- a/src/app/settings/Spreadsheets.tsx
+++ b/src/app/settings/Spreadsheets.tsx
@@ -8,7 +8,7 @@ import { DimStore } from 'app/inventory/store-types';
 import { ItemInfos } from 'app/inventory/dim-item-info';
 import { connect } from 'react-redux';
 import { storesSelector, storesLoadedSelector, itemInfosSelector } from 'app/inventory/selectors';
-import { RootState, ThunkDispatchProp } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 
 interface StoreProps {
   disabled?: boolean;

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { t } from 'app/i18next-t';
 import { connect } from 'react-redux';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { clearWishLists } from '../wishlists/actions';
 import HelpLink from '../dim-ui/HelpLink';
 import { DropzoneOptions } from 'react-dropzone';

--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -1,4 +1,4 @@
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { DimStore } from '../inventory/store-types';
 import _ from 'lodash';
 import { DestinyCharacterComponent } from 'bungie-api-ts/destiny2';

--- a/src/app/settings/item-sort.ts
+++ b/src/app/settings/item-sort.ts
@@ -1,4 +1,4 @@
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import { settingsSelector } from './reducer';
 import { Settings } from './initial-settings';
 

--- a/src/app/settings/reducer.ts
+++ b/src/app/settings/reducer.ts
@@ -1,4 +1,4 @@
 import _ from 'lodash';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 
 export const settingsSelector = (state: RootState) => state.dimApi.settings;

--- a/src/app/shell/DefaultAccount.tsx
+++ b/src/app/shell/DefaultAccount.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { t } from 'app/i18next-t';
 import { connect } from 'react-redux';
-import { ThunkDispatchProp, RootState } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
 import ErrorPanel from './ErrorPanel';
 import { DestinyAccount } from 'app/accounts/destiny-account';

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -8,7 +8,7 @@ import { itemTagList } from '../inventory/dim-item-info';
 import { Hotkey } from '../hotkeys/hotkeys';
 import { connect } from 'react-redux';
 import { loadVendorDropsFromIndexedDB } from 'app/vendorEngramsXyzApi/reducer';
-import { ThunkDispatchProp, RootState } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
 import ErrorPanel from './ErrorPanel';
 import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -14,7 +14,7 @@ import { default as SearchFilter } from '../search/SearchFilter';
 import { installPrompt$ } from './app-install';
 import ExternalLink from '../dim-ui/ExternalLink';
 import { connect } from 'react-redux';
-import { RootState, ThunkDispatchProp } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { currentAccountSelector } from 'app/accounts/reducer';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import MenuAccounts from 'app/accounts/MenuAccounts';

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -2,7 +2,7 @@ import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { isPhonePortraitFromMediaQuery } from '../utils/media-queries';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import _ from 'lodash';
 
 export const querySelector = (state: RootState) => state.shell.searchQuery;

--- a/src/app/storage/DimApiSettings.tsx
+++ b/src/app/storage/DimApiSettings.tsx
@@ -5,7 +5,7 @@ import { t } from 'app/i18next-t';
 import ImportExport from './ImportExport';
 import { apiPermissionGrantedSelector } from 'app/dim-api/selectors';
 import { connect } from 'react-redux';
-import { RootState, ThunkDispatchProp, ThunkResult } from 'app/store/reducers';
+import { RootState, ThunkDispatchProp, ThunkResult } from 'app/store/types';
 import { setApiPermissionGranted } from 'app/dim-api/basic-actions';
 import _ from 'lodash';
 import { deleteAllApiData, loadDimApiData } from 'app/dim-api/actions';

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -1,37 +1,16 @@
-import { combineReducers, AnyAction, Reducer } from 'redux';
-import { AccountsState, accounts, currentAccountSelector } from '../accounts/reducer';
-import { InventoryState, inventory } from '../inventory/reducer';
-import { ShellState, shell } from '../shell/reducer';
-import { ReviewsState, reviews } from '../item-review/reducer';
-import { LoadoutsState, loadouts } from '../loadout/reducer';
-import { WishListsState, wishLists } from '../wishlists/reducer';
-import { FarmingState, farming } from '../farming/reducer';
-import { ManifestState, manifest } from '../manifest/reducer';
+import { combineReducers, Reducer } from 'redux';
+import { accounts, currentAccountSelector } from '../accounts/reducer';
+import { inventory } from '../inventory/reducer';
+import { shell } from '../shell/reducer';
+import { reviews } from '../item-review/reducer';
+import { loadouts } from '../loadout/reducer';
+import { wishLists } from '../wishlists/reducer';
+import { farming } from '../farming/reducer';
+import { manifest } from '../manifest/reducer';
 import { DimApiState, dimApi, initialState as dimApiInitialState } from '../dim-api/reducer';
-import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import { VendorDropsState, vendorDrops } from 'app/vendorEngramsXyzApi/reducer';
-import { VendorsState, vendors } from 'app/vendors/reducer';
-
-// See https://github.com/piotrwitek/react-redux-typescript-guide#redux
-
-export interface RootState {
-  readonly accounts: AccountsState;
-  readonly inventory: InventoryState;
-  readonly reviews: ReviewsState;
-  readonly shell: ShellState;
-  readonly loadouts: LoadoutsState;
-  readonly wishLists: WishListsState;
-  readonly farming: FarmingState;
-  readonly manifest: ManifestState;
-  readonly vendorDrops: VendorDropsState;
-  readonly vendors: VendorsState;
-  readonly dimApi: DimApiState;
-}
-
-export type ThunkResult<R = void> = ThunkAction<Promise<R>, RootState, undefined, AnyAction>;
-export type ThunkDispatchProp = {
-  dispatch: ThunkDispatch<RootState, undefined, AnyAction>;
-};
+import { vendorDrops } from 'app/vendorEngramsXyzApi/reducer';
+import { vendors } from 'app/vendors/reducer';
+import { RootState } from './types';
 
 const reducer: Reducer<RootState> = (state, action) => {
   const combinedReducers = combineReducers({

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -1,9 +1,10 @@
 import { applyMiddleware, createStore, compose } from 'redux';
-import allReducers, { RootState } from './reducers';
+import allReducers from './reducers';
 import thunk from 'redux-thunk';
 import { getType } from 'typesafe-actions';
 import { update } from '../inventory/actions';
 import { setD1Manifest, setD2Manifest } from '../manifest/actions';
+import { RootState } from './types';
 
 declare global {
   interface Window {

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -1,0 +1,34 @@
+import type { AnyAction } from 'redux';
+import type { AccountsState } from '../accounts/reducer';
+import type { InventoryState } from '../inventory/reducer';
+import type { ShellState } from '../shell/reducer';
+import type { ReviewsState } from '../item-review/reducer';
+import type { LoadoutsState } from '../loadout/reducer';
+import type { WishListsState } from '../wishlists/reducer';
+import type { FarmingState } from '../farming/reducer';
+import type { ManifestState } from '../manifest/reducer';
+import type { DimApiState } from '../dim-api/reducer';
+import type { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import type { VendorDropsState } from 'app/vendorEngramsXyzApi/reducer';
+import type { VendorsState } from 'app/vendors/reducer';
+
+// See https://github.com/piotrwitek/react-redux-typescript-guide#redux
+
+export interface RootState {
+  readonly accounts: AccountsState;
+  readonly inventory: InventoryState;
+  readonly reviews: ReviewsState;
+  readonly shell: ShellState;
+  readonly loadouts: LoadoutsState;
+  readonly wishLists: WishListsState;
+  readonly farming: FarmingState;
+  readonly manifest: ManifestState;
+  readonly vendorDrops: VendorDropsState;
+  readonly vendors: VendorsState;
+  readonly dimApi: DimApiState;
+}
+
+export type ThunkResult<R = void> = ThunkAction<Promise<R>, RootState, undefined, AnyAction>;
+export type ThunkDispatchProp = {
+  dispatch: ThunkDispatch<RootState, undefined, AnyAction>;
+};

--- a/src/app/utils/redux-utils.ts
+++ b/src/app/utils/redux-utils.ts
@@ -1,4 +1,4 @@
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import store from '../store/store';
 
 /**

--- a/src/app/vendorEngramsXyzApi/reducer.ts
+++ b/src/app/vendorEngramsXyzApi/reducer.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
-import { ThunkResult } from '../store/reducers';
+import { ThunkResult } from 'app/store/types';
 import _ from 'lodash';
 import { observeStore } from '../utils/redux-utils';
 import { set, get } from 'idb-keyval';

--- a/src/app/vendorEngramsXyzApi/vendorEngramsXyzService.ts
+++ b/src/app/vendorEngramsXyzApi/vendorEngramsXyzService.ts
@@ -1,6 +1,6 @@
 import { VendorDrop, VendorDropType, VendorDropXyz, toVendorDrop } from './vendorDrops';
 import { t } from 'app/i18next-t';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { loadVendorDrops } from './actions';
 import { VendorDropsState } from './reducer';
 

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -16,7 +16,7 @@ import {
   ownedItemsSelector,
   profileResponseSelector,
 } from '../inventory/selectors';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { toVendor } from './d2-vendors';
 import styles from './SingleVendor.m.scss';
 import vendorStyles from './Vendor.m.scss';

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -16,7 +16,7 @@ import { t } from 'app/i18next-t';
 import { refresh$ } from '../shell/refresh';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import CharacterSelect from '../dim-ui/CharacterSelect';
-import { RootState, ThunkDispatchProp } from '../store/reducers';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import {
   ownedItemsSelector,
   sortedStoresSelector,

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -1,6 +1,6 @@
 import { DestinyVendorsResponse } from 'bungie-api-ts/destiny2';
 import { createAction } from 'typesafe-actions';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { getAllVendorDrops } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
 import { getVendors as getVendorsApi } from '../bungie-api/destiny2-api';
 import { fetchRatingsForVendors } from './vendor-ratings';

--- a/src/app/vendors/vendor-ratings.ts
+++ b/src/app/vendors/vendor-ratings.ts
@@ -8,7 +8,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
-import { ThunkResult } from '../store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { DtrRating } from '../item-review/dtr-api-types';
 import { StatHashes } from 'data/d2/generated-enums';
 

--- a/src/app/whats-new/WhatsNew.tsx
+++ b/src/app/whats-new/WhatsNew.tsx
@@ -5,7 +5,7 @@ import { Timeline } from 'react-twitter-widgets';
 import './WhatsNew.scss';
 import { connect } from 'react-redux';
 import { settingsSelector } from 'app/settings/reducer';
-import { RootState } from 'app/store/reducers';
+import { RootState } from 'app/store/types';
 
 interface StoreProps {
   language: string;

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -2,7 +2,7 @@ import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { getInventoryWishListRolls } from './wishlists';
-import { RootState } from '../store/reducers';
+import { RootState } from 'app/store/types';
 import _ from 'lodash';
 import { observeStore } from '../utils/redux-utils';
 import { set } from 'idb-keyval';

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import { showNotification } from 'app/notifications/notifications';
 import { loadWishLists, touchWishLists } from './actions';
-import { ThunkResult } from 'app/store/reducers';
+import { ThunkResult } from 'app/store/types';
 import { WishListAndInfo } from './types';
 import { wishListsSelector, WishListsState } from './reducer';
 import { settingsSelector } from 'app/settings/reducer';


### PR DESCRIPTION
Step 1 of ??? of untangling inter-module dependencies to improve build times and make running Jest tests not have to build the whole app.