### PR TITLE
Search refactor - separate search-configs

### DIFF
--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -16,12 +16,7 @@ import { connect } from 'react-redux';
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
 import SearchFilterInput from '../search/SearchFilterInput';
-import {
-  SearchConfig,
-  searchConfigSelector,
-  SearchFilters,
-  searchFiltersConfigSelector,
-} from '../search/search-filter';
+import { SearchFilters, searchFiltersConfigSelector } from '../search/search-filter';
 import { setSetting } from '../settings/actions';
 import { showNotification } from '../notifications/notifications';
 import { applyLoadout } from 'app/loadout/loadout-apply';
@@ -47,7 +42,6 @@ interface ProvidedProps {
 interface StoreProps {
   stores: DimStore[];
   currentStore: DimStore;
-  searchConfig: SearchConfig;
   filters: SearchFilters;
   lastInfusionDirection: InfuseDirection;
   isPhonePortrait: boolean;
@@ -57,7 +51,6 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     stores: storesSelector(state),
     currentStore: currentStoreSelector(state)!,
-    searchConfig: searchConfigSelector(state),
     filters: searchFiltersConfigSelector(state),
     lastInfusionDirection: settingsSelector(state).infusionDirection,
     isPhonePortrait: state.shell.isPhonePortrait,
@@ -172,7 +165,6 @@ function stateReducer(state: State, action: Action): State {
 function InfusionFinder({
   stores,
   currentStore,
-  searchConfig,
   filters,
   isPhonePortrait,
   lastInfusionDirection,
@@ -304,7 +296,6 @@ function InfusionFinder({
         </div>
         <div className="infuseSearch">
           <SearchFilterInput
-            searchConfig={searchConfig}
             onQueryChanged={onQueryChanged}
             placeholder="Filter items"
             autoFocus={autoFocus}

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -7,12 +7,7 @@ import { connect, MapStateToProps } from 'react-redux';
 import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/selectors';
-import {
-  SearchConfig,
-  searchConfigSelector,
-  SearchFilters,
-  searchFiltersConfigSelector,
-} from '../search/search-filter';
+import { SearchFilters, searchFiltersConfigSelector } from '../search/search-filter';
 import SearchFilterInput, { SearchFilterRef } from '../search/SearchFilterInput';
 import { sortItems } from '../shell/filters';
 import { itemSortOrderSelector } from '../settings/item-sort';
@@ -29,7 +24,6 @@ type ProvidedProps = ItemPickerState & {
 
 interface StoreProps {
   allItems: DimItem[];
-  searchConfig: SearchConfig;
   filters: SearchFilters;
   itemSortOrder: string[];
   isPhonePortrait: boolean;
@@ -46,7 +40,6 @@ function mapStateToProps(): MapStateToProps<StoreProps, ProvidedProps, RootState
 
   return (state, ownProps) => ({
     allItems: filteredItemsSelector(state, ownProps),
-    searchConfig: searchConfigSelector(state),
     filters: searchFiltersConfigSelector(state),
     itemSortOrder: itemSortOrderSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
@@ -66,7 +59,6 @@ function ItemPicker({
   preferEquip,
   allItems,
   prompt,
-  searchConfig,
   filters,
   itemSortOrder,
   hideStoreEquip,
@@ -120,7 +112,6 @@ function ItemPicker({
       <div className="item-picker-search">
         <SearchFilterInput
           ref={filterInput}
-          searchConfig={searchConfig}
           placeholder={t('ItemPicker.SearchPlaceholder')}
           autoFocus={autoFocus}
           onQueryChanged={setQuery}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -19,12 +19,7 @@ import FilterBuilds from './filter/FilterBuilds';
 import LoadoutDrawer from 'app/loadout/LoadoutDrawer';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import SearchFilterInput from 'app/search/SearchFilterInput';
-import {
-  SearchConfig,
-  SearchFilters,
-  searchConfigSelector,
-  searchFiltersConfigSelector,
-} from 'app/search/search-filter';
+import { SearchFilters, searchFiltersConfigSelector } from 'app/search/search-filter';
 import styles from './LoadoutBuilder.m.scss';
 import LockArmorAndPerks from './filter/LockArmorAndPerks';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
@@ -52,7 +47,6 @@ interface StoreProps {
   items: Readonly<{
     [classType: number]: ItemsByBucket;
   }>;
-  searchConfig: SearchConfig;
   filters: SearchFilters;
 }
 
@@ -106,7 +100,6 @@ function mapStateToProps() {
       minimumStatTotal: loMinStatTotal,
       isPhonePortrait: state.shell.isPhonePortrait,
       items: itemsSelector(state),
-      searchConfig: searchConfigSelector(state),
       filters: searchFiltersConfigSelector(state),
     };
   };
@@ -124,7 +117,6 @@ function LoadoutBuilder({
   isPhonePortrait,
   items,
   defs,
-  searchConfig,
   filters,
   preloadedLoadout,
 }: Props) {
@@ -186,7 +178,6 @@ function LoadoutBuilder({
   const menuContent = (
     <div className={styles.menuContent}>
       <SearchFilterInput
-        searchConfig={searchConfig}
         placeholder={t('LoadoutBuilder.SearchPlaceholder')}
         onQueryChanged={(query: string) => lbDispatch({ type: 'queryChanged', query })}
       />

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -8,7 +8,7 @@ import { setSearchQuery } from '../shell/actions';
 import _ from 'lodash';
 import './search-filter.scss';
 import { destinyVersionSelector, currentAccountSelector } from '../accounts/selectors';
-import { SearchConfig, searchFilterSelector, searchConfigSelector } from './search-filter';
+import { searchFilterSelector } from './search-filter';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { DimItem } from '../inventory/item-types';
 import { loadingTracker } from '../shell/loading-tracker';
@@ -43,7 +43,6 @@ interface StoreProps {
   isPhonePortrait: boolean;
   destinyVersion: DestinyVersion;
   account?: DestinyAccount;
-  searchConfig: SearchConfig;
   searchQueryVersion: number;
   searchQuery: string;
   stores: DimStore[];
@@ -76,7 +75,6 @@ function mapStateToProps(state: RootState): StoreProps {
     isPhonePortrait: state.shell.isPhonePortrait,
     destinyVersion: destinyVersionSelector(state),
     account: currentAccountSelector(state),
-    searchConfig: searchConfigSelector(state),
     searchFilter,
     searchQuery: querySelector(state),
     searchQueryVersion: searchQueryVersionSelector(state),
@@ -89,7 +87,6 @@ export function SearchFilter(
   {
     isPhonePortrait,
     mobile,
-    searchConfig,
     setSearchQuery,
     searchQuery,
     searchQueryVersion,
@@ -209,7 +206,6 @@ export function SearchFilter(
       onQueryChanged={setSearchQuery}
       alwaysShowClearButton={mobile}
       placeholder={placeholder}
-      searchConfig={searchConfig}
       onClear={onClearFilter}
       searchQueryVersion={searchQueryVersion}
       searchQuery={searchQuery}

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -13,7 +13,7 @@ import React, {
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import { Loading } from 'app/dim-ui/Loading';
 import ReactDOM from 'react-dom';
-import { searchConfigSelector } from './search-filter';
+import { searchConfigSelector } from './search-config';
 import Sheet from 'app/dim-ui/Sheet';
 import Textarea from 'textcomplete/lib/textarea';
 import Textcomplete from 'textcomplete/lib/textcomplete';

--- a/src/app/search/SearchFilterInput.tsx
+++ b/src/app/search/SearchFilterInput.tsx
@@ -13,18 +13,18 @@ import React, {
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import { Loading } from 'app/dim-ui/Loading';
 import ReactDOM from 'react-dom';
-import { SearchConfig } from './search-filter';
+import { searchConfigSelector } from './search-filter';
 import Sheet from 'app/dim-ui/Sheet';
 import Textarea from 'textcomplete/lib/textarea';
 import Textcomplete from 'textcomplete/lib/textcomplete';
 import _ from 'lodash';
 import { t } from 'app/i18next-t';
 import { chainComparator, compareBy } from 'app/utils/comparators';
+import { useSelector } from 'react-redux';
 
 interface ProvidedProps {
   alwaysShowClearButton?: boolean;
   placeholder: string;
-  searchConfig: SearchConfig;
   autoFocus?: boolean;
   searchQueryVersion?: number;
   searchQuery?: string;
@@ -72,7 +72,6 @@ export interface SearchFilterRef {
 export default React.forwardRef(function SearchFilterInput(
   {
     searchQueryVersion,
-    searchConfig,
     searchQuery,
     alwaysShowClearButton,
     placeholder,
@@ -86,6 +85,7 @@ export default React.forwardRef(function SearchFilterInput(
   const [liveQuery, setLiveQuery] = useState('');
   const [filterHelpOpen, setFilterHelpOpen] = useState(false);
 
+  const searchConfig = useSelector(searchConfigSelector);
   const textcomplete = useRef<Textcomplete>();
   const inputElement = useRef<HTMLInputElement>(null);
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/search/search-config.ts
+++ b/src/app/search/search-config.ts
@@ -1,0 +1,311 @@
+import { itemTagSelectorList } from '../inventory/dim-item-info';
+import { modSlotTags } from 'app/utils/item-utils';
+
+import { D1Categories } from '../destiny1/d1-buckets';
+import { D2Categories } from '../destiny2/d2-buckets';
+import { D2EventPredicateLookup } from 'data/d2/d2-event-info';
+import D2Sources from 'data/d2/source-info';
+import _ from 'lodash';
+import seasonTags from 'data/d2/season-tags.json';
+import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
+import { D1ItemCategoryHashes } from './d1-known-values';
+import {
+  breakerTypes,
+  D2ItemCategoryHashesByName,
+  energyCapacityTypeNames,
+} from './d2-known-values';
+import { damageTypeNames, searchableStatNames } from './search-filter-values';
+import { createSelector } from 'reselect';
+import { destinyVersionSelector } from 'app/accounts/selectors';
+
+export const searchConfigSelector = createSelector(destinyVersionSelector, buildSearchConfig);
+
+//
+// SearchConfig
+//
+
+export interface SearchConfig {
+  destinyVersion: DestinyVersion;
+  keywords: string[];
+  categoryHashFilters: { [key: string]: number };
+  keywordToFilter: { [key: string]: string };
+}
+
+const operators = ['<', '>', '<=', '>=', '='];
+
+/** Builds an object that describes the available search keywords and category mappings. */
+export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig {
+  const isD1 = destinyVersion === 1;
+  const isD2 = destinyVersion === 2;
+  const categories = isD1 ? D1Categories : D2Categories;
+  const itemTypes = Object.values(categories).flatMap((l: string[]) =>
+    l.map((v) => v.toLowerCase())
+  );
+
+  // Add new ItemCategoryHash hashes to this, to add new category searches
+  const categoryHashFilters: { [key: string]: number } = {
+    ...D1ItemCategoryHashes,
+    ...(isD2 ? D2ItemCategoryHashesByName : {}),
+  };
+
+  const stats = [
+    'charge',
+    'impact',
+    'range',
+    'stability',
+    'reload',
+    'magazine',
+    'aimassist',
+    'equipspeed',
+    'handling',
+    'blastradius',
+    'recoildirection',
+    'velocity',
+    'zoom',
+    'discipline',
+    'intellect',
+    'strength',
+    ...(isD1 ? ['rof'] : []),
+    ...(isD2
+      ? [
+          'rpm',
+          'mobility',
+          'recovery',
+          'resilience',
+          'drawtime',
+          'inventorysize',
+          'total',
+          'custom',
+          'any',
+        ]
+      : []),
+  ];
+
+  /**
+   * sets of single key -> multiple values
+   *
+   * keys: the filter to run
+   *
+   * values: the strings that trigger this filter, and the value to feed into that filter
+   *
+   */
+  // i.e. { dmg: ['arc', 'solar', 'void'] }
+  // so search string 'arc' runs dmg('arc'), search string 'solar' runs dmg('solar') etc
+  const singleTermFilters: {
+    [key: string]: string[];
+  } = {
+    dmg: damageTypeNames,
+    type: itemTypes,
+    tier: [
+      'common',
+      'uncommon',
+      'rare',
+      'legendary',
+      'exotic',
+      'white',
+      'green',
+      'blue',
+      'purple',
+      'yellow',
+    ],
+    classType: ['titan', 'hunter', 'warlock'],
+    dupe: ['dupe', 'duplicate'],
+    seasonaldupe: ['seasonaldupe', 'seasonalduplicate'],
+    dupelower: ['dupelower'],
+    locked: ['locked'],
+    unlocked: ['unlocked'],
+    stackable: ['stackable'],
+    weapon: ['weapon'],
+    armor: ['armor'],
+    categoryHash: Object.keys(categoryHashFilters),
+    inloadout: ['inloadout'],
+    maxpower: ['maxpower'],
+    new: ['new'],
+    tagged: ['tagged'],
+    level: ['level'],
+    equipment: ['equipment', 'equippable'],
+    postmaster: ['postmaster', 'inpostmaster'],
+    equipped: ['equipped'],
+    transferable: ['transferable', 'movable'],
+    infusable: ['infusable', 'infuse'],
+    owner: ['invault', 'incurrentchar'],
+    location: ['inleftchar', 'inmiddlechar', 'inrightchar'],
+    onwrongclass: ['onwrongclass'],
+    hasnotes: ['hasnotes'],
+    cosmetic: ['cosmetic'],
+    tracked: ['tracked'],
+    untracked: ['untracked'],
+    ...(isD1
+      ? {
+          hasLight: ['light', 'haslight'],
+          sublime: ['sublime'],
+          incomplete: ['incomplete'],
+          complete: ['complete'],
+          xpcomplete: ['xpcomplete'],
+          xpincomplete: ['xpincomplete', 'needsxp'],
+          upgraded: ['upgraded'],
+          unascended: ['unascended', 'unassended', 'unasscended'],
+          ascended: ['ascended', 'assended', 'asscended'],
+          reforgeable: ['reforgeable', 'reforge', 'rerollable', 'reroll'],
+          ornament: ['ornamentable', 'ornamentmissing', 'ornamentunlocked'],
+          engram: ['engram'],
+          stattype: ['intellect', 'discipline', 'strength'],
+          glimmer: ['glimmeritem', 'glimmerboost', 'glimmersupply'],
+          vendor: [
+            'fwc',
+            'do',
+            'nm',
+            'speaker',
+            'variks',
+            'shipwright',
+            'vanguard',
+            'osiris',
+            'xur',
+            'shaxx',
+            'cq',
+            'eris',
+            'ev',
+            'gunsmith',
+          ],
+          activity: [
+            'vanilla',
+            'trials',
+            'ib',
+            'qw',
+            'cd',
+            'srl',
+            'vog',
+            'ce',
+            'ttk',
+            'kf',
+            'roi',
+            'wotm',
+            'poe',
+            'coe',
+            'af',
+            'dawning',
+            'aot',
+          ],
+        }
+      : {}),
+    ...(isD2
+      ? {
+          ammoType: ['special', 'primary', 'heavy'],
+          hascapacity: ['hascapacity', 'armor2.0'],
+          complete: ['goldborder', 'yellowborder', 'complete'],
+          curated: ['curated'],
+          hasLight: ['light', 'haslight', 'haspower'],
+          hasMod: ['hasmod'],
+          modded: ['modded'],
+          hasShader: ['shaded', 'hasshader'],
+          hasOrnament: ['ornamented', 'hasornament'],
+          masterworked: ['masterwork', 'masterworks'],
+          powerfulreward: ['powerfulreward'],
+          randomroll: ['randomroll'],
+          reacquirable: ['reacquirable'],
+          trashlist: ['trashlist'],
+          wishlist: ['wishlist'],
+          wishlistdupe: ['wishlistdupe'],
+        }
+      : {}),
+    ...($featureFlags.reviewsEnabled ? { hasRating: ['rated', 'hasrating'] } : {}),
+  };
+
+  // Filters that operate on numeric ranges with comparison operators
+  const ranges = [
+    'light',
+    'power',
+    'stack',
+    'count',
+    'year',
+    ...(isD1 ? ['level', 'quality', 'percentage'] : []),
+    ...(isD2 ? ['masterwork', 'season', 'powerlimit', 'sunsetsafter', 'powerlimitseason'] : []),
+    ...($featureFlags.reviewsEnabled ? ['rating', 'ratingcount'] : []),
+  ];
+
+  // build search suggestions for single-term filters, or freeform text, or the above ranges
+  const keywords: string[] = [
+    // an "is:" and a "not:" for every filter and its synonyms
+    ...Object.values(singleTermFilters)
+      .flat()
+      .flatMap((word) => [`is:${word}`, `not:${word}`]),
+    ...itemTagSelectorList.map((tag) => (tag.type ? `tag:${tag.type}` : 'tag:none')),
+    // a keyword for every combination of an item stat name and mathmatical operator
+    ...stats.flatMap((stat) => operators.map((comparison) => `stat:${stat}:${comparison}`)),
+    // additional basestat searches for armor stats
+    ...searchableStatNames.flatMap((stat) =>
+      operators.map((comparison) => `basestat:${stat}:${comparison}`)
+    ),
+    // keywords for checking which stat is masterworked
+    ...(isD2 ? stats.map((stat) => `masterwork:${stat}`) : []),
+    // keywords for named seasons. reverse so newest seasons are first
+    ...(isD2
+      ? Object.keys(seasonTags)
+          .reverse()
+          .map((tag) => `season:${tag}`)
+      : []),
+    // keywords for seasonal mod slots
+    ...(isD2
+      ? modSlotTags.concat(['any', 'none']).map((modSlotName) => `modslot:${modSlotName}`)
+      : []),
+    ...(isD2
+      ? modSlotTags.concat(['any', 'none']).map((modSlotName) => `holdsmod:${modSlotName}`)
+      : []),
+    // a keyword for every combination of a DIM-processed stat and mathmatical operator
+    ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
+    // energy capacity elements and ranges
+    ...(isD2 ? energyCapacityTypeNames.map((element) => `energycapacity:${element}`) : []),
+    ...(isD2 ? operators.map((comparison) => `energycapacity:${comparison}`) : []),
+    // keywords for checking when an item hits power limit. s11 is the first valid season for this
+    ...(isD2
+      ? Object.entries(seasonTags)
+          .filter(([, seasonNumber]) => seasonNumber > 10)
+          .reverse()
+          .map(([tag]) => `sunsetsafter:${tag}`)
+      : []),
+    ...(isD2 ? Object.keys(breakerTypes).map((breakerType) => `breaker:${breakerType}`) : []),
+    // "source:" keyword plus one for each source
+    ...(isD2
+      ? [
+          'source:',
+          'wishlistnotes:',
+          ...Object.keys(D2Sources).map((word) => `source:${word}`),
+          ...Object.keys(D2EventPredicateLookup).map((word) => `source:${word}`),
+          // maximum stat finders
+          ...searchableStatNames.map((armorStat) => `maxbasestatvalue:${armorStat}`),
+          ...searchableStatNames.map((armorStat) => `maxstatvalue:${armorStat}`),
+          ...searchableStatNames.map((armorStat) => `maxstatloadout:${armorStat}`),
+        ]
+      : []),
+    // all the free text searches that support quotes
+    ...['notes:', 'perk:', 'perkname:', 'name:', 'description:'],
+  ];
+
+  // create suggestion stubs for filter names
+  const keywordStubs = keywords.flatMap((keyword) => {
+    const keywordSegments = keyword //   'basestat:mobility:<='
+      .split(':') //                   [ 'basestat' , 'mobility' , '<=']
+      .slice(0, -1); //                [ 'basestat' , 'mobility' ]
+    const stubs: string[] = [];
+    for (let i = 1; i <= keywordSegments.length; i++) {
+      stubs.push(keywordSegments.slice(0, i).join(':') + ':');
+    }
+    return stubs; //                   [ 'basestat:' , 'basestat:mobility:' ]
+  });
+  keywords.push(...new Set(keywordStubs));
+
+  // Build an inverse mapping of keyword to function name
+  const keywordToFilter: { [key: string]: string } = {};
+  _.forIn(singleTermFilters, (keywords, functionName) => {
+    for (const keyword of keywords) {
+      keywordToFilter[keyword] = functionName;
+    }
+  });
+
+  return {
+    keywordToFilter,
+    keywords: [...new Set(keywords)], // de-dupe kinetic (dmg) & kinetic (slot)
+    destinyVersion,
+    categoryHashFilters,
+  };
+}

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -5,13 +5,12 @@ import {
   DestinyCollectibleState,
   DestinyItemSubType,
 } from 'bungie-api-ts/destiny2';
-import { ItemInfos, getNotes, getTag, itemTagSelectorList } from '../inventory/dim-item-info';
+import { ItemInfos, getNotes, getTag } from '../inventory/dim-item-info';
 import { ReviewsState, getRating, ratingsSelector, shouldShowRating } from '../item-review/reducer';
 import { chainComparator, compareBy, reverseComparator } from '../utils/comparators';
 import {
   getItemDamageShortName,
   getSpecialtySocketMetadata,
-  modSlotTags,
   getItemPowerCapFinalSeason,
 } from 'app/utils/item-utils';
 import {
@@ -22,8 +21,6 @@ import {
 } from '../inventory/selectors';
 import { maxLightItemSet, maxStatLoadout } from '../loadout/auto-loadouts';
 
-import { D1Categories } from '../destiny1/d1-buckets';
-import { D2Categories } from '../destiny2/d2-buckets';
 import { D2EventPredicateLookup } from 'data/d2/d2-event-info';
 import { D2SeasonInfo } from 'data/d2/d2-season-info';
 import D2Sources from 'data/d2/source-info';
@@ -34,7 +31,6 @@ import { RootState } from 'app/store/types';
 import missingSources from 'data/d2/missing-source-info';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import { destinyVersionSelector } from '../accounts/selectors';
 import { inventoryWishListsSelector } from '../wishlists/reducer';
 import latinise from 'voca/latinise';
 import { loadoutsSelector } from '../loadout/reducer';
@@ -44,12 +40,11 @@ import seasonTags from 'data/d2/season-tags.json';
 import { settingsSelector } from 'app/settings/reducer';
 import store from '../store/store';
 import { getStore } from 'app/inventory/stores-helpers';
-import { DestinyVersion, ItemHashTag } from '@destinyitemmanager/dim-api-types';
+import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { parseQuery, QueryAST } from './query-parser';
 import {
   boosts,
   D1ActivityHashes,
-  D1ItemCategoryHashes,
   sublimeEngrams,
   supplies,
   vendorHashes,
@@ -57,12 +52,10 @@ import {
 import {
   breakerTypes,
   curatedPlugsAllowList,
-  D2ItemCategoryHashesByName,
   DEFAULT_GLOW,
   DEFAULT_ORNAMENTS,
   DEFAULT_SHADER,
   emptySocketHashes,
-  energyCapacityTypeNames,
   energyNamesByEnum,
   powerfulSources,
   SEASONAL_ARTIFACT_BUCKET,
@@ -73,12 +66,12 @@ import {
   armorAnyStatHashes,
   armorStatHashes,
   cosmeticTypes,
-  damageTypeNames,
   lightStats,
   searchableStatNames,
   statHashByName,
 } from './search-filter-values';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
+import { SearchConfig, searchConfigSelector } from './search-config';
 
 /**
  * (to the tune of TMNT) ♪ string processing helper functions ♫
@@ -131,8 +124,6 @@ export const makeSeasonalDupeID = (item: DimItem) =>
 // Selectors
 //
 
-export const searchConfigSelector = createSelector(destinyVersionSelector, buildSearchConfig);
-
 /** A selector for the search config for a particular destiny version. */
 export const searchFiltersConfigSelector = createSelector(
   searchConfigSelector,
@@ -154,293 +145,6 @@ export const searchFilterSelector = createSelector(
   (query, filters) => filters.filterFunction(query)
 );
 
-//
-// SearchConfig
-//
-
-export interface SearchConfig {
-  destinyVersion: DestinyVersion;
-  keywords: string[];
-  categoryHashFilters: { [key: string]: number };
-  keywordToFilter: { [key: string]: string };
-}
-
-/** Builds an object that describes the available search keywords and category mappings. */
-export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig {
-  const isD1 = destinyVersion === 1;
-  const isD2 = destinyVersion === 2;
-  const categories = isD1 ? D1Categories : D2Categories;
-  const itemTypes = Object.values(categories).flatMap((l: string[]) =>
-    l.map((v) => v.toLowerCase())
-  );
-
-  // Add new ItemCategoryHash hashes to this, to add new category searches
-  const categoryHashFilters: { [key: string]: number } = {
-    ...D1ItemCategoryHashes,
-    ...(isD2 ? D2ItemCategoryHashesByName : {}),
-  };
-
-  const stats = [
-    'charge',
-    'impact',
-    'range',
-    'stability',
-    'reload',
-    'magazine',
-    'aimassist',
-    'equipspeed',
-    'handling',
-    'blastradius',
-    'recoildirection',
-    'velocity',
-    'zoom',
-    'discipline',
-    'intellect',
-    'strength',
-    ...(isD1 ? ['rof'] : []),
-    ...(isD2
-      ? [
-          'rpm',
-          'mobility',
-          'recovery',
-          'resilience',
-          'drawtime',
-          'inventorysize',
-          'total',
-          'custom',
-          'any',
-        ]
-      : []),
-  ];
-
-  /**
-   * sets of single key -> multiple values
-   *
-   * keys: the filter to run
-   *
-   * values: the strings that trigger this filter, and the value to feed into that filter
-   *
-   */
-  // i.e. { dmg: ['arc', 'solar', 'void'] }
-  // so search string 'arc' runs dmg('arc'), search string 'solar' runs dmg('solar') etc
-  const singleTermFilters: {
-    [key: string]: string[];
-  } = {
-    dmg: damageTypeNames,
-    type: itemTypes,
-    tier: [
-      'common',
-      'uncommon',
-      'rare',
-      'legendary',
-      'exotic',
-      'white',
-      'green',
-      'blue',
-      'purple',
-      'yellow',
-    ],
-    classType: ['titan', 'hunter', 'warlock'],
-    dupe: ['dupe', 'duplicate'],
-    seasonaldupe: ['seasonaldupe', 'seasonalduplicate'],
-    dupelower: ['dupelower'],
-    locked: ['locked'],
-    unlocked: ['unlocked'],
-    stackable: ['stackable'],
-    weapon: ['weapon'],
-    armor: ['armor'],
-    categoryHash: Object.keys(categoryHashFilters),
-    inloadout: ['inloadout'],
-    maxpower: ['maxpower'],
-    new: ['new'],
-    tagged: ['tagged'],
-    level: ['level'],
-    equipment: ['equipment', 'equippable'],
-    postmaster: ['postmaster', 'inpostmaster'],
-    equipped: ['equipped'],
-    transferable: ['transferable', 'movable'],
-    infusable: ['infusable', 'infuse'],
-    owner: ['invault', 'incurrentchar'],
-    location: ['inleftchar', 'inmiddlechar', 'inrightchar'],
-    onwrongclass: ['onwrongclass'],
-    hasnotes: ['hasnotes'],
-    cosmetic: ['cosmetic'],
-    tracked: ['tracked'],
-    untracked: ['untracked'],
-    ...(isD1
-      ? {
-          hasLight: ['light', 'haslight'],
-          sublime: ['sublime'],
-          incomplete: ['incomplete'],
-          complete: ['complete'],
-          xpcomplete: ['xpcomplete'],
-          xpincomplete: ['xpincomplete', 'needsxp'],
-          upgraded: ['upgraded'],
-          unascended: ['unascended', 'unassended', 'unasscended'],
-          ascended: ['ascended', 'assended', 'asscended'],
-          reforgeable: ['reforgeable', 'reforge', 'rerollable', 'reroll'],
-          ornament: ['ornamentable', 'ornamentmissing', 'ornamentunlocked'],
-          engram: ['engram'],
-          stattype: ['intellect', 'discipline', 'strength'],
-          glimmer: ['glimmeritem', 'glimmerboost', 'glimmersupply'],
-          vendor: [
-            'fwc',
-            'do',
-            'nm',
-            'speaker',
-            'variks',
-            'shipwright',
-            'vanguard',
-            'osiris',
-            'xur',
-            'shaxx',
-            'cq',
-            'eris',
-            'ev',
-            'gunsmith',
-          ],
-          activity: [
-            'vanilla',
-            'trials',
-            'ib',
-            'qw',
-            'cd',
-            'srl',
-            'vog',
-            'ce',
-            'ttk',
-            'kf',
-            'roi',
-            'wotm',
-            'poe',
-            'coe',
-            'af',
-            'dawning',
-            'aot',
-          ],
-        }
-      : {}),
-    ...(isD2
-      ? {
-          ammoType: ['special', 'primary', 'heavy'],
-          hascapacity: ['hascapacity', 'armor2.0'],
-          complete: ['goldborder', 'yellowborder', 'complete'],
-          curated: ['curated'],
-          hasLight: ['light', 'haslight', 'haspower'],
-          hasMod: ['hasmod'],
-          modded: ['modded'],
-          hasShader: ['shaded', 'hasshader'],
-          hasOrnament: ['ornamented', 'hasornament'],
-          masterworked: ['masterwork', 'masterworks'],
-          powerfulreward: ['powerfulreward'],
-          randomroll: ['randomroll'],
-          reacquirable: ['reacquirable'],
-          trashlist: ['trashlist'],
-          wishlist: ['wishlist'],
-          wishlistdupe: ['wishlistdupe'],
-        }
-      : {}),
-    ...($featureFlags.reviewsEnabled ? { hasRating: ['rated', 'hasrating'] } : {}),
-  };
-
-  // Filters that operate on numeric ranges with comparison operators
-  const ranges = [
-    'light',
-    'power',
-    'stack',
-    'count',
-    'year',
-    ...(isD1 ? ['level', 'quality', 'percentage'] : []),
-    ...(isD2 ? ['masterwork', 'season', 'powerlimit', 'sunsetsafter', 'powerlimitseason'] : []),
-    ...($featureFlags.reviewsEnabled ? ['rating', 'ratingcount'] : []),
-  ];
-
-  // build search suggestions for single-term filters, or freeform text, or the above ranges
-  const keywords: string[] = [
-    // an "is:" and a "not:" for every filter and its synonyms
-    ...Object.values(singleTermFilters)
-      .flat()
-      .flatMap((word) => [`is:${word}`, `not:${word}`]),
-    ...itemTagSelectorList.map((tag) => (tag.type ? `tag:${tag.type}` : 'tag:none')),
-    // a keyword for every combination of an item stat name and mathmatical operator
-    ...stats.flatMap((stat) => operators.map((comparison) => `stat:${stat}:${comparison}`)),
-    // additional basestat searches for armor stats
-    ...searchableStatNames.flatMap((stat) =>
-      operators.map((comparison) => `basestat:${stat}:${comparison}`)
-    ),
-    // keywords for checking which stat is masterworked
-    ...(isD2 ? stats.map((stat) => `masterwork:${stat}`) : []),
-    // keywords for named seasons. reverse so newest seasons are first
-    ...(isD2
-      ? Object.keys(seasonTags)
-          .reverse()
-          .map((tag) => `season:${tag}`)
-      : []),
-    // keywords for seasonal mod slots
-    ...(isD2
-      ? modSlotTags.concat(['any', 'none']).map((modSlotName) => `modslot:${modSlotName}`)
-      : []),
-    ...(isD2
-      ? modSlotTags.concat(['any', 'none']).map((modSlotName) => `holdsmod:${modSlotName}`)
-      : []),
-    // a keyword for every combination of a DIM-processed stat and mathmatical operator
-    ...ranges.flatMap((range) => operators.map((comparison) => `${range}:${comparison}`)),
-    // energy capacity elements and ranges
-    ...(isD2 ? energyCapacityTypeNames.map((element) => `energycapacity:${element}`) : []),
-    ...(isD2 ? operators.map((comparison) => `energycapacity:${comparison}`) : []),
-    // keywords for checking when an item hits power limit. s11 is the first valid season for this
-    ...(isD2
-      ? Object.entries(seasonTags)
-          .filter(([, seasonNumber]) => seasonNumber > 10)
-          .reverse()
-          .map(([tag]) => `sunsetsafter:${tag}`)
-      : []),
-    ...(isD2 ? Object.keys(breakerTypes).map((breakerType) => `breaker:${breakerType}`) : []),
-    // "source:" keyword plus one for each source
-    ...(isD2
-      ? [
-          'source:',
-          'wishlistnotes:',
-          ...Object.keys(D2Sources).map((word) => `source:${word}`),
-          ...Object.keys(D2EventPredicateLookup).map((word) => `source:${word}`),
-          // maximum stat finders
-          ...searchableStatNames.map((armorStat) => `maxbasestatvalue:${armorStat}`),
-          ...searchableStatNames.map((armorStat) => `maxstatvalue:${armorStat}`),
-          ...searchableStatNames.map((armorStat) => `maxstatloadout:${armorStat}`),
-        ]
-      : []),
-    // all the free text searches that support quotes
-    ...['notes:', 'perk:', 'perkname:', 'name:', 'description:'],
-  ];
-
-  // create suggestion stubs for filter names
-  const keywordStubs = keywords.flatMap((keyword) => {
-    const keywordSegments = keyword //   'basestat:mobility:<='
-      .split(':') //                   [ 'basestat' , 'mobility' , '<=']
-      .slice(0, -1); //                [ 'basestat' , 'mobility' ]
-    const stubs: string[] = [];
-    for (let i = 1; i <= keywordSegments.length; i++) {
-      stubs.push(keywordSegments.slice(0, i).join(':') + ':');
-    }
-    return stubs; //                   [ 'basestat:' , 'basestat:mobility:' ]
-  });
-  keywords.push(...new Set(keywordStubs));
-
-  // Build an inverse mapping of keyword to function name
-  const keywordToFilter: { [key: string]: string } = {};
-  _.forIn(singleTermFilters, (keywords, functionName) => {
-    for (const keyword of keywords) {
-      keywordToFilter[keyword] = functionName;
-    }
-  });
-
-  return {
-    keywordToFilter,
-    keywords: [...new Set(keywords)], // de-dupe kinetic (dmg) & kinetic (slot)
-    destinyVersion,
-    categoryHashFilters,
-  };
-}
 /**
  * compares a number to a parsed string which contains a math operator and a number.
  * compare is safe to be a non-number value, just something can be ==='d or <'d


### PR DESCRIPTION
Move search-configs into its own file to separate it from search-filters, and use `useSelector` to automatically inject it into search fields.