### PR TITLE
Account selectors

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -17,14 +17,14 @@ import { safariTouchFix } from './app/safari-touch-fix';
 import Root from './app/Root';
 import setupRateLimiter from './app/bungie-api/rate-limit-config';
 import { watchLanguageChanges } from './app/settings/settings';
-import { saveReviewsToIndexedDB } from './app/item-review/reducer';
-import { saveWishListToIndexedDB } from './app/wishlists/reducer';
-import { saveAccountsToIndexedDB } from 'app/accounts/reducer';
+import { saveReviewsToIndexedDB } from './app/item-review/observers';
+import { saveWishListToIndexedDB } from './app/wishlists/observers';
+import { saveAccountsToIndexedDB } from 'app/accounts/observers';
 import updateCSSVariables from 'app/css-variables';
-import { saveVendorDropsToIndexedDB } from 'app/vendorEngramsXyzApi/reducer';
+import { saveVendorDropsToIndexedDB } from 'app/vendorEngramsXyzApi/observers';
 import store from 'app/store/store';
 import { loadDimApiData } from 'app/dim-api/actions';
-import { saveItemInfosOnStateChange } from 'app/inventory/reducer';
+import { saveItemInfosOnStateChange } from 'app/inventory/observers';
 
 polyfill({
   holdToDrag: 300,

--- a/src/app/accounts/MenuAccounts.tsx
+++ b/src/app/accounts/MenuAccounts.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './Account.scss';
 import { DestinyAccount } from './destiny-account';
 import { AppIcon, signOutIcon } from '../shell/icons';
-import { currentAccountSelector } from './reducer';
+import { currentAccountSelector } from './selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/app/accounts/observers.ts
+++ b/src/app/accounts/observers.ts
@@ -1,0 +1,13 @@
+import { set } from 'idb-keyval';
+import { observeStore } from 'app/utils/redux-utils';
+
+export function saveAccountsToIndexedDB() {
+  return observeStore(
+    (state) => state.accounts,
+    (currentState, nextState) => {
+      if (nextState.loaded && nextState.accounts !== currentState.accounts) {
+        set('accounts', nextState.accounts);
+      }
+    }
+  );
+}

--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -9,17 +9,19 @@ import * as actions from './actions';
 import store from '../store/store';
 import { loadingTracker } from '../shell/loading-tracker';
 import { goToLoginPage } from '../bungie-api/authenticated-fetch';
-import {
-  accountsSelector,
-  currentAccountSelector,
-  loadAccountsFromIndexedDB,
-  accountsLoadedSelector,
-} from './reducer';
+import { accountsSelector, currentAccountSelector, accountsLoadedSelector } from './selectors';
 import { ThunkResult } from 'app/store/types';
 import { dedupePromise } from 'app/utils/util';
 import { removeToken } from '../bungie-api/oauth-tokens';
 import { deleteDimApiToken } from 'app/dim-api/dim-api-helper';
-import { del } from 'idb-keyval';
+import { del, get } from 'idb-keyval';
+
+const loadAccountsFromIndexedDBAction: ThunkResult = dedupePromise(async (dispatch) => {
+  console.log('Load accounts from IDB');
+  const accounts = await get<DestinyAccount[] | undefined>('accounts');
+
+  dispatch(actions.loadFromIDB(accounts || []));
+});
 
 const getPlatformsAction: ThunkResult<readonly DestinyAccount[]> = dedupePromise(
   async (dispatch, getState) => {
@@ -31,7 +33,7 @@ const getPlatformsAction: ThunkResult<readonly DestinyAccount[]> = dedupePromise
 
     if (!getState().accounts.loadedFromIDB) {
       try {
-        await dispatch(loadAccountsFromIndexedDB());
+        await dispatch(loadAccountsFromIndexedDBAction);
       } catch (e) {
         console.error('Unable to load accounts from IDB', e);
       }

--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -2,30 +2,11 @@ import { Reducer } from 'redux';
 import { DestinyAccount } from './destiny-account';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
-import { RootState, ThunkResult } from 'app/store/types';
-import { get } from 'idb-keyval';
-import { dedupePromise } from 'app/utils/util';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { deepEqual } from 'fast-equals';
 import { API_KEY as DIM_API_KEY } from 'app/dim-api/dim-api-helper';
 import { API_KEY as BUNGIE_API_KEY } from 'app/bungie-api/bungie-api-utils';
 import { hasValidAuthTokens } from 'app/bungie-api/oauth-tokens';
-
-export const accountsSelector = (state: RootState) => state.accounts.accounts;
-
-export const currentAccountSelector = (state: RootState) =>
-  state.accounts.currentAccount === -1
-    ? undefined
-    : accountsSelector(state)[state.accounts.currentAccount];
-
-export const destinyVersionSelector = (state: RootState) => {
-  const currentAccount = currentAccountSelector(state);
-  return currentAccount?.destinyVersion || 2;
-};
-
-/** Are the accounts loaded enough to use? */
-export const accountsLoadedSelector = (state: RootState) =>
-  state.accounts.loaded || (state.accounts.loadedFromIDB && accountsSelector(state).length > 0);
 
 export interface AccountsState {
   readonly accounts: readonly DestinyAccount[];
@@ -113,14 +94,3 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
       return state;
   }
 };
-
-const loadAccountsFromIndexedDBAction: ThunkResult = dedupePromise(async (dispatch) => {
-  console.log('Load accounts from IDB');
-  const accounts = await get<DestinyAccount[] | undefined>('accounts');
-
-  dispatch(actions.loadFromIDB(accounts || []));
-});
-
-export function loadAccountsFromIndexedDB(): ThunkResult {
-  return loadAccountsFromIndexedDBAction;
-}

--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -3,8 +3,7 @@ import { DestinyAccount } from './destiny-account';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { RootState, ThunkResult } from 'app/store/types';
-import { observeStore } from 'app/utils/redux-utils';
-import { set, get } from 'idb-keyval';
+import { get } from 'idb-keyval';
 import { dedupePromise } from 'app/utils/util';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { deepEqual } from 'fast-equals';
@@ -114,17 +113,6 @@ export const accounts: Reducer<AccountsState, AccountsAction> = (
       return state;
   }
 };
-
-export function saveAccountsToIndexedDB() {
-  return observeStore(
-    (state) => state.accounts,
-    (currentState, nextState) => {
-      if (nextState.loaded && nextState.accounts !== currentState.accounts) {
-        set('accounts', nextState.accounts);
-      }
-    }
-  );
-}
 
 const loadAccountsFromIndexedDBAction: ThunkResult = dedupePromise(async (dispatch) => {
   console.log('Load accounts from IDB');

--- a/src/app/accounts/selectors.ts
+++ b/src/app/accounts/selectors.ts
@@ -1,0 +1,17 @@
+import { RootState } from 'app/store/types';
+
+export const accountsSelector = (state: RootState) => state.accounts.accounts;
+
+export const currentAccountSelector = (state: RootState) =>
+  state.accounts.currentAccount === -1
+    ? undefined
+    : accountsSelector(state)[state.accounts.currentAccount];
+
+export const destinyVersionSelector = (state: RootState) => {
+  const currentAccount = currentAccountSelector(state);
+  return currentAccount?.destinyVersion || 2;
+};
+
+/** Are the accounts loaded enough to use? */
+export const accountsLoadedSelector = (state: RootState) =>
+  state.accounts.loaded || (state.accounts.loadedFromIDB && accountsSelector(state).length > 0);

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -16,7 +16,7 @@ import { DestinyAccount } from '../../accounts/destiny-account';
 import { D1Store } from '../../inventory/store-types';
 import { RootState } from 'app/store/types';
 import { storesSelector } from '../../inventory/selectors';
-import { currentAccountSelector } from '../../accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 import { D1StoresService } from '../../inventory/d1-stores';
 import CollapsibleTitle from '../../dim-ui/CollapsibleTitle';
 import { t } from 'app/i18next-t';

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -8,7 +8,7 @@ import { RootState, ThunkResult } from 'app/store/types';
 import { DimApiState } from './reducer';
 import { get, set } from 'idb-keyval';
 import { getPlatforms } from '../accounts/platforms';
-import { currentAccountSelector } from '../accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 import { observeStore } from '../utils/redux-utils';
 import _ from 'lodash';
 import {

--- a/src/app/dim-api/selectors.ts
+++ b/src/app/dim-api/selectors.ts
@@ -1,7 +1,7 @@
 import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
 import { makeProfileKeyFromAccount } from './reducer';
-import { currentAccountSelector } from 'app/accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 
 export const apiPermissionGrantedSelector = (state: RootState) =>
   state.dimApi.apiPermissionGranted === true;

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -35,7 +35,7 @@ import xpIcon from '../../images/xpIcon.svg';
 import { maxLightItemSet } from 'app/loadout/auto-loadouts';
 import { storesSelector } from './selectors';
 import { ThunkResult } from 'app/store/types';
-import { currentAccountSelector } from 'app/accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 import { getCharacterStatsData as getD1CharacterStatsData } from './store/character-utils';
 import { getCharacters as d1GetCharacters } from '../bungie-api/destiny1-api';
 import { getArtifactBonus } from './stores-helpers';

--- a/src/app/inventory/observers.ts
+++ b/src/app/inventory/observers.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { observeStore } from 'app/utils/redux-utils';
 import { RootState } from 'app/store/types';
-import { currentAccountSelector } from 'app/accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 import { set } from 'idb-keyval';
 
 /**

--- a/src/app/inventory/observers.ts
+++ b/src/app/inventory/observers.ts
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+import { observeStore } from 'app/utils/redux-utils';
+import { RootState } from 'app/store/types';
+import { currentAccountSelector } from 'app/accounts/reducer';
+import { set } from 'idb-keyval';
+
+/**
+ * Set up an observer on the store that'll save item infos to sync service (google drive).
+ * We specifically watch the legacy state, not the new one.
+ */
+export const saveItemInfosOnStateChange = _.once(() => {
+  // Sneak in another observer for saving new-items to IDB
+  observeStore(
+    (state: RootState) => state.inventory.newItems,
+    _.debounce(async (_, newItems, rootState) => {
+      const account = currentAccountSelector(rootState);
+      if (account) {
+        const key = `newItems-m${account.membershipId}-d${account.destinyVersion}`;
+        try {
+          return await set(key, newItems);
+        } catch (e) {
+          console.error("Couldn't save new items", e);
+        }
+      }
+    }, 1000)
+  );
+});

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -3,40 +3,16 @@ import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { DimStore } from './store-types';
 import { InventoryBuckets } from './inventory-buckets';
-import { AccountsAction, currentAccountSelector } from '../accounts/reducer';
+import { AccountsAction } from '../accounts/reducer';
 import { setCurrentAccount } from '../accounts/actions';
-import { RootState } from 'app/store/types';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
-import { observeStore } from 'app/utils/redux-utils';
 import _ from 'lodash';
-import { set } from 'idb-keyval';
 import { DimItem } from './item-types';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { StoreProto as D2StoreProto, StoreProto } from './store/d2-store-factory';
 import { StoreProto as D1StoreProto } from './store/d1-store-factory';
 import { getItemAcrossStores, getStore } from './stores-helpers';
 import { ItemProto } from './store/d2-item-factory';
-/**
- * Set up an observer on the store that'll save item infos to sync service (google drive).
- * We specifically watch the legacy state, not the new one.
- */
-export const saveItemInfosOnStateChange = _.once(() => {
-  // Sneak in another observer for saving new-items to IDB
-  observeStore(
-    (state: RootState) => state.inventory.newItems,
-    _.debounce(async (_, newItems, rootState) => {
-      const account = currentAccountSelector(rootState);
-      if (account) {
-        const key = `newItems-m${account.membershipId}-d${account.destinyVersion}`;
-        try {
-          return await set(key, newItems);
-        } catch (e) {
-          console.error("Couldn't save new items", e);
-        }
-      }
-    }, 1000)
-  );
-});
 
 // TODO: Should this be by account? Accounts need IDs
 export interface InventoryState {

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -20,7 +20,7 @@ import handCannonIcon from 'destiny-icons/weapons/hand_cannon.svg';
 import modificationIcon from 'destiny-icons/general/modifications.svg';
 import MetricCategories from './MetricCategories';
 import EmblemPreview from './EmblemPreview';
-import { destinyVersionSelector } from 'app/accounts/reducer';
+import { destinyVersionSelector } from 'app/accounts/selectors';
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import Objective from 'app/progress/Objective';
 import { Link, useParams } from 'react-router-dom';

--- a/src/app/item-review/observers.ts
+++ b/src/app/item-review/observers.ts
@@ -1,0 +1,29 @@
+import { observeStore } from 'app/utils/redux-utils';
+import _ from 'lodash';
+import { ReviewsState } from './reducer';
+import { ITEM_RATING_EXPIRATION } from 'app/destinyTrackerApi/d2-itemListBuilder';
+import { set } from 'idb-keyval';
+
+export function saveReviewsToIndexedDB() {
+  return observeStore(
+    (state) => state.reviews,
+    _.debounce((currentState: ReviewsState, nextState: ReviewsState) => {
+      if (nextState.loadedFromIDB) {
+        const cutoff = new Date(Date.now() - ITEM_RATING_EXPIRATION);
+
+        if (!_.isEmpty(nextState.reviews) && nextState.reviews !== currentState.reviews) {
+          set(
+            'reviews',
+            _.pickBy(nextState.reviews, (r) => r.lastUpdated > cutoff)
+          );
+        }
+        if (!_.isEmpty(nextState.ratings) && nextState.ratings !== currentState.ratings) {
+          set(
+            'ratings-v2',
+            _.pickBy(nextState.ratings, (r) => r.lastUpdated > cutoff)
+          );
+        }
+      }
+    }, 1000)
+  );
+}

--- a/src/app/item-review/reducer.ts
+++ b/src/app/item-review/reducer.ts
@@ -8,10 +8,8 @@ import { getReviewKey, getD2Roll } from '../destinyTrackerApi/d2-itemTransformer
 import { RootState, ThunkResult } from 'app/store/types';
 import produce from 'immer';
 import { DtrRating } from './dtr-api-types';
-import { set, get } from 'idb-keyval';
-import { observeStore } from '../utils/redux-utils';
+import { get } from 'idb-keyval';
 import _ from 'lodash';
-import { ITEM_RATING_EXPIRATION } from '../destinyTrackerApi/d2-itemListBuilder';
 import { createSelector } from 'reselect';
 import { getReviewModes } from '../destinyTrackerApi/reviewModesFetcher';
 import { AccountsAction } from '../accounts/reducer';
@@ -204,30 +202,6 @@ function convertToRatingMap(ratings: DtrRating[]) {
     result[getItemStoreKey(rating.referenceId, rating.roll)] = rating;
   }
   return result;
-}
-
-export function saveReviewsToIndexedDB() {
-  return observeStore(
-    (state) => state.reviews,
-    _.debounce((currentState: ReviewsState, nextState: ReviewsState) => {
-      if (nextState.loadedFromIDB) {
-        const cutoff = new Date(Date.now() - ITEM_RATING_EXPIRATION);
-
-        if (!_.isEmpty(nextState.reviews) && nextState.reviews !== currentState.reviews) {
-          set(
-            'reviews',
-            _.pickBy(nextState.reviews, (r) => r.lastUpdated > cutoff)
-          );
-        }
-        if (!_.isEmpty(nextState.ratings) && nextState.ratings !== currentState.ratings) {
-          set(
-            'ratings-v2',
-            _.pickBy(nextState.ratings, (r) => r.lastUpdated > cutoff)
-          );
-        }
-      }
-    }, 1000)
-  );
 }
 
 export function loadReviewsFromIndexedDB(): ThunkResult {

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -11,7 +11,7 @@ import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { destinyVersionSelector, currentAccountSelector } from '../accounts/reducer';
+import { destinyVersionSelector, currentAccountSelector } from 'app/accounts/selectors';
 import { storesSelector } from '../inventory/selectors';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import { InventoryBuckets } from '../inventory/inventory-buckets';

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -4,7 +4,7 @@ import './loadout-popup.scss';
 import { DimStore } from '../inventory/store-types';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { previousLoadoutSelector, loadoutsSelector } from './reducer';
-import { currentAccountSelector } from '../accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 import { getBuckets as d2GetBuckets } from '../destiny2/d2-buckets';
 import { getBuckets as d1GetBuckets } from '../destiny1/d1-buckets';
 import _ from 'lodash';

--- a/src/app/loadout/reducer.ts
+++ b/src/app/loadout/reducer.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
-import { currentAccountSelector } from '../accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 import { Loadout, LoadoutItem } from './loadout-types';
 import { RootState } from 'app/store/types';
 import _ from 'lodash';

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -18,7 +18,7 @@ import styles from './Organizer.m.scss';
 import { t } from 'app/i18next-t';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
-import { destinyVersionSelector } from 'app/accounts/reducer';
+import { destinyVersionSelector } from 'app/accounts/selectors';
 import { D1StoresService } from 'app/inventory/d1-stores';
 
 interface ProvidedProps {

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -3,7 +3,7 @@ import './FilterHelp.scss';
 import React from 'react';
 import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
-import { destinyVersionSelector } from '../accounts/reducer';
+import { destinyVersionSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -7,7 +7,7 @@ import { RootState } from 'app/store/types';
 import { setSearchQuery } from '../shell/actions';
 import _ from 'lodash';
 import './search-filter.scss';
-import { destinyVersionSelector, currentAccountSelector } from '../accounts/reducer';
+import { destinyVersionSelector, currentAccountSelector } from '../accounts/selectors';
 import { SearchConfig, searchFilterSelector, searchConfigSelector } from './search-filter';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { DimItem } from '../inventory/item-types';

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -34,7 +34,7 @@ import { RootState } from 'app/store/types';
 import missingSources from 'data/d2/missing-source-info';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import { destinyVersionSelector } from '../accounts/reducer';
+import { destinyVersionSelector } from '../accounts/selectors';
 import { inventoryWishListsSelector } from '../wishlists/reducer';
 import latinise from 'voca/latinise';
 import { loadoutsSelector } from '../loadout/reducer';

--- a/src/app/settings/AuditLog.tsx
+++ b/src/app/settings/AuditLog.tsx
@@ -6,7 +6,7 @@ import {
 } from '@destinyitemmanager/dim-api-types';
 import { getAuditLog } from 'app/dim-api/dim-api';
 import { DestinyAccount, PLATFORM_ICONS } from 'app/accounts/destiny-account';
-import { accountsSelector } from 'app/accounts/reducer';
+import { accountsSelector } from 'app/accounts/selectors';
 import { connect } from 'react-redux';
 import { RootState } from 'app/store/types';
 import styles from './AuditLog.m.scss';

--- a/src/app/shell/DefaultAccount.tsx
+++ b/src/app/shell/DefaultAccount.tsx
@@ -5,7 +5,7 @@ import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
 import ErrorPanel from './ErrorPanel';
 import { DestinyAccount } from 'app/accounts/destiny-account';
-import { currentAccountSelector, accountsLoadedSelector } from 'app/accounts/reducer';
+import { currentAccountSelector, accountsLoadedSelector } from 'app/accounts/selectors';
 import { getPlatforms } from 'app/accounts/platforms';
 import { accountRoute } from 'app/routes';
 import { Redirect } from 'react-router';

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -17,7 +17,7 @@ import { getToken } from 'app/bungie-api/oauth-tokens';
 import { AppIcon, banIcon } from './icons';
 import { fetchWishList } from 'app/wishlists/wishlist-fetch';
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
-import { accountsSelector, accountsLoadedSelector } from 'app/accounts/reducer';
+import { accountsSelector, accountsLoadedSelector } from 'app/accounts/selectors';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { Switch, Route, Redirect, useRouteMatch } from 'react-router';
 import { setActivePlatform, getPlatforms } from 'app/accounts/platforms';

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -15,7 +15,7 @@ import { installPrompt$ } from './app-install';
 import ExternalLink from '../dim-ui/ExternalLink';
 import { connect } from 'react-redux';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
-import { currentAccountSelector } from 'app/accounts/reducer';
+import { currentAccountSelector } from 'app/accounts/selectors';
 import GlobalHotkeys from '../hotkeys/GlobalHotkeys';
 import MenuAccounts from 'app/accounts/MenuAccounts';
 import ReactDOM from 'react-dom';

--- a/src/app/store/reducers.ts
+++ b/src/app/store/reducers.ts
@@ -1,5 +1,5 @@
 import { combineReducers, Reducer } from 'redux';
-import { accounts, currentAccountSelector } from '../accounts/reducer';
+import { accounts } from '../accounts/reducer';
 import { inventory } from '../inventory/reducer';
 import { shell } from '../shell/reducer';
 import { reviews } from '../item-review/reducer';
@@ -11,6 +11,7 @@ import { DimApiState, dimApi, initialState as dimApiInitialState } from '../dim-
 import { vendorDrops } from 'app/vendorEngramsXyzApi/reducer';
 import { vendors } from 'app/vendors/reducer';
 import { RootState } from './types';
+import { currentAccountSelector } from 'app/accounts/selectors';
 
 const reducer: Reducer<RootState> = (state, action) => {
   const combinedReducers = combineReducers({

--- a/src/app/vendorEngramsXyzApi/observers.ts
+++ b/src/app/vendorEngramsXyzApi/observers.ts
@@ -1,0 +1,13 @@
+import { observeStore } from 'app/utils/redux-utils';
+import { set } from 'idb-keyval';
+
+export function saveVendorDropsToIndexedDB() {
+  return observeStore(
+    (state) => state.vendorDrops,
+    (_, nextState) => {
+      if (nextState.loaded) {
+        set('vendorengrams', nextState);
+      }
+    }
+  );
+}

--- a/src/app/vendorEngramsXyzApi/reducer.ts
+++ b/src/app/vendorEngramsXyzApi/reducer.ts
@@ -3,8 +3,7 @@ import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { ThunkResult } from 'app/store/types';
 import _ from 'lodash';
-import { observeStore } from '../utils/redux-utils';
-import { set, get } from 'idb-keyval';
+import { get } from 'idb-keyval';
 import { VendorDrop } from './vendorDrops';
 import { dropsNeedRefresh } from './vendorEngramsXyzService';
 
@@ -48,17 +47,6 @@ export const vendorDrops: Reducer<VendorDropsState, VendorDropAction> = (
       return state;
   }
 };
-
-export function saveVendorDropsToIndexedDB() {
-  return observeStore(
-    (state) => state.vendorDrops,
-    (_, nextState) => {
-      if (nextState.loaded) {
-        set('vendorengrams', nextState);
-      }
-    }
-  );
-}
 
 export function loadVendorDropsFromIndexedDB(): ThunkResult {
   return async (dispatch, getState) => {

--- a/src/app/wishlists/observers.ts
+++ b/src/app/wishlists/observers.ts
@@ -1,0 +1,16 @@
+import { observeStore } from 'app/utils/redux-utils';
+import { set } from 'idb-keyval';
+
+export function saveWishListToIndexedDB() {
+  return observeStore(
+    (state) => state.wishLists,
+    (_, nextState) => {
+      if (nextState.loaded) {
+        set('wishlist', {
+          wishListAndInfo: nextState.wishListAndInfo,
+          lastFetched: nextState.lastFetched,
+        });
+      }
+    }
+  );
+}

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -4,8 +4,6 @@ import { ActionType, getType } from 'typesafe-actions';
 import { getInventoryWishListRolls } from './wishlists';
 import { RootState } from 'app/store/types';
 import _ from 'lodash';
-import { observeStore } from '../utils/redux-utils';
-import { set } from 'idb-keyval';
 import { WishListAndInfo } from './types';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/selectors';
@@ -78,17 +76,3 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
       return state;
   }
 };
-
-export function saveWishListToIndexedDB() {
-  return observeStore(
-    (state) => state.wishLists,
-    (_, nextState) => {
-      if (nextState.loaded) {
-        set('wishlist', {
-          wishListAndInfo: nextState.wishListAndInfo,
-          lastFetched: nextState.lastFetched,
-        });
-      }
-    }
-  );
-}


### PR DESCRIPTION
More untangling of module dependencies - this pulls the simple account selectors out of the account reducer. It also moves "observers" of the store to their own files to break a circular dependency on the redux store.