### PR TITLE
Introduce an inlined marker function for translation labels

### DIFF
--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -6,8 +6,8 @@ module.exports = {
     removeUnusedKeys: true,
     sort: true,
     func: {
-      list: ['t', 'i18next.t'],
-      extensions: ['.js', '.jsx', '.ts', '.tsx']
+      list: ['t', 'i18next.t', 'tl'],
+      extensions: ['.js', '.jsx', '.ts', '.tsx'],
     },
     lngs: ['en'],
     ns: ['translation'],
@@ -16,8 +16,8 @@ module.exports = {
       loadPath: 'config/i18n.json',
       savePath: 'src/locale/dim.json',
       jsonIndent: 2,
-      lineEnding: '\n'
+      lineEnding: '\n',
     },
-    context: false
-  }
+    context: false,
+  },
 };

--- a/src/app/destinyTrackerApi/platformOptionsFetcher.ts
+++ b/src/app/destinyTrackerApi/platformOptionsFetcher.ts
@@ -1,4 +1,5 @@
 import { DtrReviewPlatform } from '@destinyitemmanager/dim-api-types';
+import { tl } from 'app/i18next-t';
 
 export interface DtrPlatformOption {
   platform: DtrReviewPlatform;
@@ -8,22 +9,22 @@ export interface DtrPlatformOption {
 export const reviewPlatformOptions: DtrPlatformOption[] = [
   {
     platform: DtrReviewPlatform.All,
-    description: 'DtrReview.Platforms.All', // t('DtrReview.Platforms.All')
+    description: tl('DtrReview.Platforms.All'),
   },
   {
     platform: DtrReviewPlatform.Xbox,
-    description: 'DtrReview.Platforms.Xbox', // t('DtrReview.Platforms.Xbox')
+    description: tl('DtrReview.Platforms.Xbox'),
   },
   {
     platform: DtrReviewPlatform.Playstation,
-    description: 'DtrReview.Platforms.Playstation', // t('DtrReview.Platforms.Playstation')
+    description: tl('DtrReview.Platforms.Playstation'),
   },
   {
     platform: DtrReviewPlatform.AllConsoles,
-    description: 'DtrReview.Platforms.AllConsoles', // t('DtrReview.Platforms.AllConsoles')
+    description: tl('DtrReview.Platforms.AllConsoles'),
   },
   {
     platform: DtrReviewPlatform.Pc,
-    description: 'DtrReview.Platforms.Pc', // t('DtrReview.Platforms.Pc')
+    description: tl('DtrReview.Platforms.Pc'),
   },
 ];

--- a/src/app/i18next-t.ts
+++ b/src/app/i18next-t.ts
@@ -6,3 +6,13 @@ import i18next, { TOptions } from 'i18next';
  */
 export const t = (key: string | string[], options?: string | TOptions | undefined) =>
   i18next.t(key, options || { skipInterpolation: true });
+
+/**
+ * This is a "marker function" that tells our i18next-scanner that you will translate this string later (tl = translate later).
+ * This way you don't need to pre-translate everything or include redundant comments. This function is inlined and
+ * has no runtime presence.
+ */
+/*@__INLINE__*/
+export function tl<T extends string>(key: T): T {
+  return key;
+}


### PR DESCRIPTION
There are cases where we'd like to have lists of definitions that include some i18next key that will be translated later, but in order to keep i18next-scanner working we're stuck with two options - either translate them as part of building the definition (which means it can't be a static definition) or put comments next to it like `// t('Foo')` in order to trick the scanner. This introduces a third option, the function `tl` which returns the input string, but serves as a marker for i18next-scanner. This lets us apply the actual translation later, without losing the string, at no runtime overhead because the `tl` function is inlined.