### PR TITLE
Redux manifest

### DIFF
--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
-import { storesSelector, profileResponseSelector } from '../inventory/selectors';
+import { storesSelector, profileResponseSelector, bucketsSelector } from '../inventory/selectors';
 import { refresh$ } from '../shell/refresh';
 import PresentationNodeRoot from './PresentationNodeRoot';
 import { useSubscription } from 'app/utils/hooks';
@@ -46,7 +46,7 @@ function mapStateToProps() {
   });
 
   return (state: RootState): StoreProps => ({
-    buckets: state.inventory.buckets,
+    buckets: bucketsSelector(state),
     defs: state.manifest.d2Manifest,
     ownedItemHashes: ownedItemHashesSelector(state),
     profileResponse: profileResponseSelector(state),

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { getDefinitions } from './d1-definitions';
+import { D1ManifestDefinitions } from './d1-definitions';
 import { InventoryBuckets, InventoryBucket } from '../inventory/inventory-buckets';
 import { BucketCategory } from 'bungie-api-ts/destiny2';
 import { D1Categories } from './d1-bucket-categories';
@@ -55,8 +55,7 @@ _.forIn(D1Categories, (types, category) => {
   });
 });
 
-export const getBuckets = _.once(async () => {
-  const defs = await getDefinitions();
+export function getBuckets(defs: D1ManifestDefinitions) {
   const buckets: InventoryBuckets = {
     byHash: {},
     byType: {},
@@ -116,4 +115,4 @@ export const getBuckets = _.once(async () => {
     buckets.byCategory[category] = _.compact(types.map((type) => buckets.byType[type]));
   });
   return buckets;
-});
+}

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -15,7 +15,7 @@ import { connect } from 'react-redux';
 import { DestinyAccount } from '../../accounts/destiny-account';
 import { D1Store } from '../../inventory/store-types';
 import { RootState } from 'app/store/types';
-import { storesSelector } from '../../inventory/selectors';
+import { storesSelector, bucketsSelector } from '../../inventory/selectors';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { D1StoresService } from '../../inventory/d1-stores';
 import CollapsibleTitle from '../../dim-ui/CollapsibleTitle';
@@ -57,7 +57,7 @@ type Props = StoreProps;
 function mapStateToProps(state: RootState): StoreProps {
   return {
     account: currentAccountSelector(state)!,
-    buckets: state.inventory.buckets,
+    buckets: bucketsSelector(state),
     stores: storesSelector(state) as D1Store[],
     defs: state.manifest.d1Manifest,
     isPhonePortrait: state.shell.isPhonePortrait,

--- a/src/app/destiny1/vendors/vendor.service.ts
+++ b/src/app/destiny1/vendors/vendor.service.ts
@@ -216,7 +216,9 @@ function VendorService(): VendorServiceType {
   ): Promise<[D1Store[], { [vendorHash: number]: Vendor }]> {
     const characters = stores.filter((s) => !s.isVault);
 
-    const reloadPromise = getDefinitions()
+    const reloadPromise = ((store.dispatch(getDefinitions()) as any) as Promise<
+      D1ManifestDefinitions
+    >)
       .then((defs) => {
         // Narrow down to only visible vendors (not packages and such)
         const vendorList = Object.values(defs.Vendor).filter((v) => v.summary.visible);
@@ -484,7 +486,8 @@ function VendorService(): VendorServiceType {
 
     return processItems(
       { id: null } as any,
-      saleItems.map((i) => i.item)
+      saleItems.map((i) => i.item),
+      defs
     ).then((items) => {
       const itemsById = _.keyBy(items, (i) => i.id);
       const categories = _.compact(

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -1,6 +1,6 @@
 import { BucketCategory, DestinyInventoryBucketDefinition } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
-import { getDefinitions } from './d2-definitions';
+import { D2ManifestDefinitions } from './d2-definitions';
 import { InventoryBuckets, InventoryBucket } from '../inventory/inventory-buckets';
 import { VENDORS } from 'app/search/d2-known-values';
 import { D2Categories } from './d2-bucket-categories';
@@ -50,10 +50,7 @@ _.forIn(D2Categories, (types, category) => {
   });
 });
 
-export const getBuckets = _.once(getBucketsUncached);
-
-async function getBucketsUncached() {
-  const defs = await getDefinitions();
+export function getBuckets(defs: D2ManifestDefinitions) {
   const buckets: InventoryBuckets = {
     byHash: {},
     byType: {},

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -38,7 +38,7 @@ import {
   DestinyBreakerTypeDefinition,
 } from 'bungie-api-ts/destiny2';
 
-import { D2ManifestService } from '../manifest/manifest-service-json';
+import { getManifest } from '../manifest/manifest-service-json';
 import { ManifestDefinitions } from './definitions';
 import _ from 'lodash';
 import { setD2Manifest } from '../manifest/actions';
@@ -153,7 +153,7 @@ export const getDefinitions = _.once(getDefinitionsUncached);
  * above (defs.TalentGrid, etc.).
  */
 async function getDefinitionsUncached() {
-  const db = await D2ManifestService.getManifest([...eagerTables, ...lazyTables]);
+  const db = await getManifest([...eagerTables, ...lazyTables]);
   const defs = {
     isDestiny1: () => false,
     isDestiny2: () => true,

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -42,8 +42,8 @@ import { getManifest } from '../manifest/manifest-service-json';
 import { ManifestDefinitions } from './definitions';
 import _ from 'lodash';
 import { setD2Manifest } from '../manifest/actions';
-import store from '../store/store';
 import { reportException } from 'app/utils/exceptions';
+import { ThunkResult } from 'app/store/types';
 
 const lazyTables = [
   'InventoryItem',
@@ -145,54 +145,57 @@ export interface D2ManifestDefinitions extends ManifestDefinitions {
  * object that has a property named after each of the tables listed
  * above (defs.TalentGrid, etc.).
  */
-export const getDefinitions = _.once(getDefinitionsUncached);
-
-/**
- * Manifest database definitions. This returns a promise for an
- * object that has a property named after each of the tables listed
- * above (defs.TalentGrid, etc.).
- */
-async function getDefinitionsUncached() {
-  const db = await getManifest([...eagerTables, ...lazyTables]);
-  const defs = {
-    isDestiny1: () => false,
-    isDestiny2: () => true,
-  };
-  lazyTables.forEach((tableShort) => {
-    const table = `Destiny${tableShort}Definition`;
-    defs[tableShort] = {
-      get(id: number, requestor?: any) {
-        const dbTable = db[table];
-        if (!dbTable) {
-          throw new Error(`Table ${table} does not exist in the manifest`);
-        }
-        const dbEntry = dbTable[id];
-        if (!dbEntry) {
-          const requestingEntryInfo =
-            typeof requestor === 'object' ? requestor.hash : String(requestor);
-          reportException(
-            `hashLookupFailure: ${table}[${id}]`,
-            new Error(`hashLookupFailure: ${table}[${id}]`),
-            {
-              requestingEntryInfo,
-              failedHash: id,
-              failedComponent: table,
-            }
-          );
-        }
-        return dbEntry;
-      },
-      getAll() {
-        return db[table];
-      },
+export function getDefinitions(): ThunkResult<D2ManifestDefinitions> {
+  return async (dispatch, getState) => {
+    let existingManifest = getState().manifest.d2Manifest;
+    if (existingManifest) {
+      return existingManifest;
+    }
+    const db = await dispatch(getManifest([...eagerTables, ...lazyTables]));
+    existingManifest = getState().manifest.d2Manifest;
+    if (existingManifest) {
+      return existingManifest;
+    }
+    const defs = {
+      isDestiny1: () => false,
+      isDestiny2: () => true,
     };
-  });
-  // Resources that need to be fully loaded (because they're iterated over)
-  eagerTables.forEach((tableShort) => {
-    const table = `Destiny${tableShort}Definition`;
-    defs[tableShort] = db[table];
-  });
+    lazyTables.forEach((tableShort) => {
+      const table = `Destiny${tableShort}Definition`;
+      defs[tableShort] = {
+        get(id: number, requestor?: any) {
+          const dbTable = db[table];
+          if (!dbTable) {
+            throw new Error(`Table ${table} does not exist in the manifest`);
+          }
+          const dbEntry = dbTable[id];
+          if (!dbEntry) {
+            const requestingEntryInfo =
+              typeof requestor === 'object' ? requestor.hash : String(requestor);
+            reportException(
+              `hashLookupFailure: ${table}[${id}]`,
+              new Error(`hashLookupFailure: ${table}[${id}]`),
+              {
+                requestingEntryInfo,
+                failedHash: id,
+                failedComponent: table,
+              }
+            );
+          }
+          return dbEntry;
+        },
+        getAll() {
+          return db[table];
+        },
+      };
+    });
+    // Resources that need to be fully loaded (because they're iterated over)
+    eagerTables.forEach((tableShort) => {
+      const table = `Destiny${tableShort}Definition`;
+      defs[tableShort] = db[table];
+    });
 
-  store.dispatch(setD2Manifest(defs as D2ManifestDefinitions));
-  return defs as D2ManifestDefinitions;
+    dispatch(setD2Manifest(defs as D2ManifestDefinitions));
+    return defs as D2ManifestDefinitions;
+  };
 }

--- a/src/app/farming/d2farming.service.ts
+++ b/src/app/farming/d2farming.service.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { getBuckets } from '../destiny2/d2-buckets';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { D2Store } from '../inventory/store-types';
 import { BucketCategory } from 'bungie-api-ts/destiny2';
@@ -10,6 +9,7 @@ import rxStore from '../store/store';
 import * as actions from './actions';
 import { makeRoomForItemsInBuckets } from './farming.service';
 import { filter, map, tap, exhaustMap } from 'rxjs/operators';
+import { bucketsSelector } from 'app/inventory/selectors';
 
 /**
  * A service for "farming" items by moving them continuously off a character,
@@ -86,7 +86,7 @@ export const D2FarmingService = new D2Farming();
 // Ensure that there's one open space in each category that could
 // hold an item, so they don't go to the postmaster.
 async function makeRoomForItems(store: D2Store) {
-  const buckets = await getBuckets();
+  const buckets = bucketsSelector(rxStore.getState())!;
   const makeRoomBuckets = Object.values(buckets.byHash).filter(
     (b) => b.category === BucketCategory.Equippable && b.type
   );

--- a/src/app/farming/farming.service.ts
+++ b/src/app/farming/farming.service.ts
@@ -3,7 +3,6 @@ import { MoveReservations, sortMoveAsideCandidatesForStore } from '../inventory/
 import { DimItem } from '../inventory/item-types';
 import { D1StoresService } from '../inventory/d1-stores';
 import { DestinyAccount } from '../accounts/destiny-account';
-import { getBuckets } from '../destiny1/d1-buckets';
 import { refresh } from '../shell/refresh';
 import { D1Store, DimStore } from '../inventory/store-types';
 import * as actions from './actions';
@@ -13,7 +12,7 @@ import { clearItemsOffCharacter } from '../loadout/loadout-apply';
 import { Subscription, from } from 'rxjs';
 import { filter, tap, map, exhaustMap } from 'rxjs/operators';
 import { settingsSelector } from 'app/settings/reducer';
-import { itemInfosSelector, itemHashTagsSelector } from 'app/inventory/selectors';
+import { itemInfosSelector, itemHashTagsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { getVault } from 'app/inventory/stores-helpers';
 
 const glimmerHashes = new Set([
@@ -136,7 +135,7 @@ async function farmItems(store: D1Store) {
 // Ensure that there's one open space in each category that could
 // hold an item, so they don't go to the postmaster.
 async function makeRoomForItems(store: D1Store) {
-  const buckets = await getBuckets();
+  const buckets = bucketsSelector(rxStore.getState())!;
   const makeRoomBuckets = makeRoomTypes.map((type) => buckets.byHash[type]);
   makeRoomForItemsInBuckets(store.getStoresService().getStores(), store, makeRoomBuckets);
 }

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -11,7 +11,7 @@ import ScrollClassDiv from '../dim-ui/ScrollClassDiv';
 import { StoreBuckets } from './StoreBuckets';
 import D1ReputationSection from './D1ReputationSection';
 import Hammer from 'react-hammerjs';
-import { sortedStoresSelector } from './selectors';
+import { sortedStoresSelector, bucketsSelector } from './selectors';
 import { hideItemPopup } from '../item-popup/item-popup';
 import { storeBackgroundColor } from '../shell/filters';
 import InventoryCollapsibleTitle from './InventoryCollapsibleTitle';
@@ -28,7 +28,7 @@ interface StoreProps {
 function mapStateToProps(state: RootState): StoreProps {
   return {
     stores: sortedStoresSelector(state),
-    buckets: state.inventory.buckets!,
+    buckets: bucketsSelector(state)!,
     isPhonePortrait: state.shell.isPhonePortrait,
   };
 }

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -14,7 +14,6 @@ import { DimError } from 'app/bungie-api/bungie-service-helper';
  */
 export const update = createAction('inventory/UPDATE')<{
   stores: DimStore[];
-  buckets?: InventoryBuckets;
   profileResponse?: DestinyProfileResponse;
 }>();
 

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -4,7 +4,6 @@ import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { reportException } from '../utils/exceptions';
 import { getStores } from '../bungie-api/destiny1-api';
 import { getDefinitions, D1ManifestDefinitions } from '../destiny1/d1-definitions';
-import { getBuckets } from '../destiny1/d1-buckets';
 import { cleanInfos } from './dim-item-info';
 import { makeCharacter, makeVault } from './store/d1-store-factory';
 import { resetIdTracker, processItems } from './store/d1-item-factory';
@@ -18,7 +17,7 @@ import { loadingTracker } from '../shell/loading-tracker';
 import { showNotification } from '../notifications/notifications';
 import { BehaviorSubject, Subject, ConnectableObservable } from 'rxjs';
 import { take, switchMap, publishReplay, merge } from 'rxjs/operators';
-import { storesSelector } from './selectors';
+import { storesSelector, bucketsSelector } from './selectors';
 
 export const D1StoresService = StoreService();
 
@@ -93,12 +92,12 @@ function StoreService(): D1StoreServiceType {
 
     const reloadPromise = Promise.all([
       getDefinitions(),
-      getBuckets(),
       store.dispatch(loadNewItems(account)),
       getStores(account),
     ])
-      .then(([defs, buckets, , rawStores]) => {
+      .then(([defs, , rawStores]) => {
         const lastPlayedDate = findLastPlayedDate(rawStores);
+        const buckets = bucketsSelector(store.getState())!;
 
         // Currencies object gets mutated by processStore
         const currencies: DimVault['currencies'] = [];
@@ -111,9 +110,9 @@ function StoreService(): D1StoreServiceType {
           )
         );
 
-        return Promise.all([buckets, processStorePromises]);
+        return processStorePromises;
       })
-      .then(([buckets, stores]) => {
+      .then((stores) => {
         if ($featureFlags.reviewsEnabled) {
           store.dispatch(fetchRatings(stores));
         }
@@ -125,7 +124,7 @@ function StoreService(): D1StoreServiceType {
           .querySelector('html')!
           .style.setProperty('--num-characters', String(stores.length - 1));
 
-        store.dispatch(update({ stores, buckets }));
+        store.dispatch(update({ stores }));
 
         return stores;
       })

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -91,7 +91,7 @@ function StoreService(): D1StoreServiceType {
     resetIdTracker();
 
     const reloadPromise = Promise.all([
-      getDefinitions(),
+      (store.dispatch(getDefinitions()) as any) as Promise<D1ManifestDefinitions>,
       store.dispatch(loadNewItems(account)),
       getStores(account),
     ])
@@ -174,7 +174,7 @@ function StoreService(): D1StoreServiceType {
       items = result.items;
     }
 
-    return processItems(store, items).then((items) => {
+    return processItems(store, items, defs).then((items) => {
       store.items = items;
 
       // by type-bucket

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -2,7 +2,6 @@ import { Reducer } from 'redux';
 import * as actions from './actions';
 import { ActionType, getType } from 'typesafe-actions';
 import { DimStore } from './store-types';
-import { InventoryBuckets } from './inventory-buckets';
 import { AccountsAction } from '../accounts/reducer';
 import { setCurrentAccount } from '../accounts/actions';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
@@ -21,8 +20,6 @@ export interface InventoryState {
   // Updates to items need to deeply modify their store though.
   // TODO: ReadonlyArray<Readonly<DimStore>>
   readonly stores: DimStore[];
-
-  readonly buckets?: InventoryBuckets;
 
   readonly profileResponse?: DestinyProfileResponse;
 
@@ -129,11 +126,9 @@ function updateInventory(
   state: InventoryState,
   {
     stores,
-    buckets,
     profileResponse,
   }: {
     stores: DimStore[];
-    buckets?: InventoryBuckets | undefined;
     profileResponse?: DestinyProfileResponse | undefined;
   }
 ) {
@@ -145,9 +140,6 @@ function updateInventory(
     newItems: computeNewItems(state.stores, state.newItems, stores),
     profileError: undefined,
   };
-  if (buckets) {
-    newState.buckets = buckets;
-  }
   if (profileResponse) {
     newState.profileResponse = profileResponse;
   }

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -7,9 +7,22 @@ import { emptyObject } from 'app/utils/empty';
 import { getCurrentStore } from './stores-helpers';
 import { ItemInfos } from './dim-item-info';
 import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
+import { destinyVersionSelector } from 'app/accounts/selectors';
+import { getBuckets as getBucketsD2 } from '../destiny2/d2-buckets';
+import { getBuckets as getBucketsD1 } from '../destiny1/d1-buckets';
 
 /** All stores, unsorted. */
 export const storesSelector = (state: RootState) => state.inventory.stores;
+
+export const bucketsSelector = createSelector(
+  destinyVersionSelector,
+  (state: RootState) => state.manifest.d1Manifest,
+  (state: RootState) => state.manifest.d2Manifest,
+  (destinyVersion, d1Manifest, d2Manifest) =>
+    destinyVersion === 2
+      ? d2Manifest && getBucketsD2(d2Manifest)
+      : d1Manifest && getBucketsD1(d1Manifest)
+);
 
 /** All stores, sorted according to user preference. */
 export const sortedStoresSelector = createSelector(

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -3,7 +3,7 @@ import missingSources from 'data/d1/missing_sources.json';
 import { getBonus } from './character-utils';
 import { getQualityRating } from './armor-quality';
 import { reportException } from '../../utils/exceptions';
-import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions';
+import { D1ManifestDefinitions } from '../../destiny1/d1-definitions';
 import { vaultTypes } from '../../destiny1/d1-buckets';
 import { t } from 'app/i18next-t';
 import { D1Store } from '../store-types';
@@ -110,25 +110,27 @@ export function resetIdTracker() {
  * @param items a list of "raw" items from the Destiny API
  * @return a promise for the list of items
  */
-export function processItems(owner: D1Store, items: any[]): Promise<D1Item[]> {
-  return Promise.all([getDefinitions()]).then(([defs]) => {
-    const buckets = bucketsSelector(store.getState())!;
-    const result: D1Item[] = [];
-    for (const item of items) {
-      let createdItem: D1Item | null = null;
-      try {
-        createdItem = makeItem(defs, buckets, item, owner);
-      } catch (e) {
-        console.error('Error processing item', item, e);
-        reportException('Processing D1 item', e);
-      }
-      if (createdItem !== null) {
-        createdItem.owner = owner.id;
-        result.push(createdItem);
-      }
+export async function processItems(
+  owner: D1Store,
+  items: any[],
+  defs: D1ManifestDefinitions
+): Promise<D1Item[]> {
+  const buckets = bucketsSelector(store.getState())!;
+  const result: D1Item[] = [];
+  for (const item of items) {
+    let createdItem: D1Item | null = null;
+    try {
+      createdItem = makeItem(defs, buckets, item, owner);
+    } catch (e) {
+      console.error('Error processing item', item, e);
+      reportException('Processing D1 item', e);
     }
-    return result;
-  });
+    if (createdItem !== null) {
+      createdItem.owner = owner.id;
+      result.push(createdItem);
+    }
+  }
+  return result;
 }
 
 const getClassTypeNameLocalized = _.memoize((type: DestinyClass, defs: D1ManifestDefinitions) => {

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -4,7 +4,7 @@ import { getBonus } from './character-utils';
 import { getQualityRating } from './armor-quality';
 import { reportException } from '../../utils/exceptions';
 import { getDefinitions, D1ManifestDefinitions } from '../../destiny1/d1-definitions';
-import { getBuckets, vaultTypes } from '../../destiny1/d1-buckets';
+import { vaultTypes } from '../../destiny1/d1-buckets';
 import { t } from 'app/i18next-t';
 import { D1Store } from '../store-types';
 import { D1Item, D1TalentGrid, D1GridNode, D1Stat } from '../item-types';
@@ -16,6 +16,8 @@ import {
   DestinyDamageTypeDefinition,
   DestinyAmmunitionType,
 } from 'bungie-api-ts/destiny2';
+import { bucketsSelector } from '../selectors';
+import store from 'app/store/store';
 
 const yearHashes = {
   //         tTK       Variks        CoE         FoTL    Kings Fall
@@ -109,7 +111,8 @@ export function resetIdTracker() {
  * @return a promise for the list of items
  */
 export function processItems(owner: D1Store, items: any[]): Promise<D1Item[]> {
-  return Promise.all([getDefinitions(), getBuckets()]).then(([defs, buckets]) => {
+  return Promise.all([getDefinitions()]).then(([defs]) => {
+    const buckets = bucketsSelector(store.getState())!;
     const result: D1Item[] = [];
     for (const item of items) {
       let createdItem: D1Item | null = null;

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -18,7 +18,7 @@ import { buildFlavorObjective, buildObjectives } from './objectives';
 
 import D2Events from 'data/d2/events.json';
 import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
-import { D2ManifestService } from '../../manifest/manifest-service-json';
+import { warnMissingDefinition } from '../../manifest/manifest-service-json';
 import { D2SourcesToEvent } from 'data/d2/d2-event-info';
 import { D2Store } from '../store-types';
 import { D2StoresService } from '../d2-stores';
@@ -234,7 +234,7 @@ export function makeItem(
       : {};
   // Missing definition?
   if (!itemDef) {
-    D2ManifestService.warnMissingDefinition();
+    warnMissingDefinition();
     return null;
   }
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -38,7 +38,6 @@ import {
   THE_FORBIDDEN_BUCKET,
 } from 'app/search/d2-known-values';
 import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
-import store from 'app/store/store';
 
 // Maps tierType to tierTypeName in English
 const tiers = ['Unknown', 'Currency', 'Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'];
@@ -235,7 +234,7 @@ export function makeItem(
       : {};
   // Missing definition?
   if (!itemDef) {
-    store.dispatch(warnMissingDefinition);
+    warnMissingDefinition();
     return null;
   }
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -38,6 +38,7 @@ import {
   THE_FORBIDDEN_BUCKET,
 } from 'app/search/d2-known-values';
 import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import store from 'app/store/store';
 
 // Maps tierType to tierTypeName in English
 const tiers = ['Unknown', 'Currency', 'Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'];
@@ -234,7 +235,7 @@ export function makeItem(
       : {};
   // Missing definition?
   if (!itemDef) {
-    warnMissingDefinition();
+    store.dispatch(warnMissingDefinition);
     return null;
   }
 

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -20,7 +20,7 @@ import {
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { connect } from 'react-redux';
-import { storesSelector } from 'app/inventory/selectors';
+import { storesSelector, bucketsSelector } from 'app/inventory/selectors';
 import { RootState } from 'app/store/types';
 import { DimStore } from 'app/inventory/store-types';
 import { AppIcon, addIcon, faTimesCircle } from 'app/shell/icons';
@@ -57,7 +57,7 @@ type Props = ProvidedProps & StoreProps;
 
 function mapStateToProps() {
   return (state: RootState): StoreProps => ({
-    buckets: state.inventory.buckets!,
+    buckets: bucketsSelector(state)!,
     stores: storesSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
     language: settingsSelector(state).language,

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -13,7 +13,7 @@ import _ from 'lodash';
 import { isLoadoutBuilderItem } from '../utils';
 import copy from 'fast-copy';
 import { createSelector } from 'reselect';
-import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
+import { storesSelector, profileResponseSelector, bucketsSelector } from 'app/inventory/selectors';
 import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { escapeRegExp } from 'app/search/search-filter';
@@ -137,7 +137,7 @@ function mapStateToProps() {
 
   return (state: RootState, props: ProvidedProps): StoreProps => ({
     isPhonePortrait: state.shell.isPhonePortrait,
-    buckets: state.inventory.buckets!,
+    buckets: bucketsSelector(state)!,
     language: settingsSelector(state).language,
     mods: unlockedModsSelector(state, props),
     defs: state.manifest.d2Manifest!,

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -28,7 +28,7 @@ import { AppIcon, searchIcon } from 'app/shell/icons';
 import copy from 'fast-copy';
 import ArmorBucketIcon from '../ArmorBucketIcon';
 import { createSelector } from 'reselect';
-import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
+import { storesSelector, profileResponseSelector, bucketsSelector } from 'app/inventory/selectors';
 import { RootState } from 'app/store/types';
 import { connect } from 'react-redux';
 import { itemsForPlugSet } from 'app/collections/plugset-helpers';
@@ -215,7 +215,7 @@ function mapStateToProps() {
 
   return (state: RootState, props: ProvidedProps): StoreProps => ({
     isPhonePortrait: state.shell.isPhonePortrait,
-    buckets: state.inventory.buckets!,
+    buckets: bucketsSelector(state)!,
     language: settingsSelector(state).language,
     perks: perksSelector(state, props),
     mods: unlockedPlugsSelector(state, props),

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -12,7 +12,7 @@ import { itemSortOrderSelector } from '../settings/item-sort';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { destinyVersionSelector, currentAccountSelector } from 'app/accounts/selectors';
-import { storesSelector } from '../inventory/selectors';
+import { storesSelector, bucketsSelector } from '../inventory/selectors';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import './loadout-drawer.scss';
@@ -399,7 +399,7 @@ function mapStateToProps() {
     account: currentAccountSelector(state)!,
     classTypeOptions: classTypeOptionsSelector(state),
     stores: storesSelector(state),
-    buckets: state.inventory.buckets!,
+    buckets: bucketsSelector(state)!,
     defs:
       destinyVersionSelector(state) === 2 ? state.manifest.d2Manifest! : state.manifest.d1Manifest!,
     loadouts: loadoutsSelector(state),

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -5,8 +5,6 @@ import { DimStore } from '../inventory/store-types';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { previousLoadoutSelector, loadoutsSelector } from './reducer';
 import { currentAccountSelector } from 'app/accounts/selectors';
-import { getBuckets as d2GetBuckets } from '../destiny2/d2-buckets';
-import { getBuckets as d1GetBuckets } from '../destiny1/d1-buckets';
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import {
@@ -58,12 +56,13 @@ import { Loadout } from './loadout-types';
 import { editLoadout } from './LoadoutDrawer';
 import { applyLoadout } from './loadout-apply';
 import { fromEquippedTypes } from './LoadoutDrawerContents';
-import { storesSelector } from 'app/inventory/selectors';
+import { storesSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { getAllItems } from 'app/inventory/stores-helpers';
 import { deleteLoadout } from './actions';
 import helmetIcon from 'destiny-icons/armor_types/helmet.svg';
 import xpIcon from 'images/xpIcon.svg';
+import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 
 const loadoutIcon = {
   [DestinyClass.Unknown]: globeIcon,
@@ -85,6 +84,7 @@ interface StoreProps {
   classTypeId: DestinyClass;
   stores: DimStore[];
   hasClassified: boolean;
+  buckets: InventoryBuckets;
   searchFilter(item: DimItem): boolean;
 }
 
@@ -126,6 +126,7 @@ function mapStateToProps() {
       classTypeId: dimStore.classType,
       account: currentAccountSelector(state)!,
       stores: storesSelector(state),
+      buckets: bucketsSelector(state)!,
       hasClassified: hasClassifiedSelector(state),
     };
   };
@@ -431,9 +432,8 @@ class LoadoutPopup extends React.Component<Props> {
   };
 
   private makeRoomForPostmaster = () => {
-    const { dimStore } = this.props;
-    const bucketsService = dimStore.destinyVersion === 1 ? d1GetBuckets : d2GetBuckets;
-    return queueAction(() => makeRoomForPostmaster(dimStore, bucketsService));
+    const { dimStore, buckets } = this.props;
+    return queueAction(() => makeRoomForPostmaster(dimStore, buckets));
   };
 
   private pullFromPostmaster = () => {

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -10,9 +10,8 @@ import { getVault } from 'app/inventory/stores-helpers';
 
 export async function makeRoomForPostmaster(
   store: DimStore,
-  bucketsService: () => Promise<InventoryBuckets>
+  buckets: InventoryBuckets
 ): Promise<void> {
-  const buckets = await bucketsService();
   const postmasterItems: DimItem[] = buckets.byCategory.Postmaster.flatMap(
     (bucket: InventoryBucket) => store.buckets[bucket.hash]
   );

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -6,8 +6,9 @@ import { settingsReady } from '../settings/settings';
 import { t } from 'app/i18next-t';
 import { showNotification } from '../notifications/notifications';
 import { settingsSelector } from 'app/settings/reducer';
-import store from 'app/store/store';
 import { loadingEnd, loadingStart } from 'app/shell/actions';
+import { ThunkResult } from 'app/store/types';
+import { dedupePromise } from 'app/utils/util';
 
 // This file exports D1ManifestService at the bottom of the
 // file (TS wants us to declare classes before using them)!
@@ -18,90 +19,91 @@ const alwaysLoadRemote = false;
 const manifestLangs = new Set(['en', 'fr', 'es', 'de', 'it', 'ja', 'pt-br']);
 const localStorageKey = 'd1-manifest-version';
 const idbKey = 'd1-manifest';
-let manifestPromise: Promise<object> | null = null;
 let version: string | null = null;
 
-export function getManifest(): Promise<object> {
-  if (manifestPromise) {
-    return manifestPromise;
-  }
+const getManifestAction: ThunkResult<object> = dedupePromise((dispatch) =>
+  dispatch(doGetManifest())
+);
 
-  manifestPromise = doGetManifest();
-
-  return manifestPromise;
+export function getManifest(): ThunkResult<object> {
+  return getManifestAction;
 }
 
-// This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
-async function doGetManifest() {
-  store.dispatch(loadingStart(t('Manifest.Load')));
-  try {
-    const manifest = await loadManifest();
-    if (!manifest.DestinyVendorDefinition) {
-      throw new Error('Manifest corrupted, please reload');
-    }
-    return manifest;
-  } catch (e) {
-    let message = e.message || e;
+function doGetManifest(): ThunkResult<object> {
+  return async (dispatch) => {
+    dispatch(loadingStart(t('Manifest.Load')));
+    try {
+      const manifest = await dispatch(loadManifest());
+      if (!manifest.DestinyVendorDefinition) {
+        throw new Error('Manifest corrupted, please reload');
+      }
+      return manifest;
+    } catch (e) {
+      let message = e.message || e;
 
-    if (e instanceof TypeError || e.status === -1) {
-      message = navigator.onLine
-        ? t('BungieService.NotConnectedOrBlocked')
-        : t('BungieService.NotConnected');
-    } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
-      message = t('BungieService.Difficulties');
-    } else if (e.status < 200 || e.status >= 400) {
-      message = t('BungieService.NetworkError', {
-        status: e.status,
-        statusText: e.statusText,
-      });
-    } else {
-      // Something may be wrong with the manifest
-      deleteManifestFile();
-    }
+      if (e instanceof TypeError || e.status === -1) {
+        message = navigator.onLine
+          ? t('BungieService.NotConnectedOrBlocked')
+          : t('BungieService.NotConnected');
+      } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
+        message = t('BungieService.Difficulties');
+      } else if (e.status < 200 || e.status >= 400) {
+        message = t('BungieService.NetworkError', {
+          status: e.status,
+          statusText: e.statusText,
+        });
+      } else {
+        // Something may be wrong with the manifest
+        deleteManifestFile();
+      }
 
-    const statusText = t('Manifest.Error', { error: message });
-    manifestPromise = null;
-    console.error('Manifest loading error', { error: e }, e);
-    reportException('manifest load', e);
-    throw new Error(statusText);
-  } finally {
-    store.dispatch(loadingEnd(t('Manifest.Load')));
-  }
+      const statusText = t('Manifest.Error', { error: message });
+      console.error('Manifest loading error', { error: e }, e);
+      reportException('manifest load', e);
+      throw new Error(statusText);
+    } finally {
+      dispatch(loadingEnd(t('Manifest.Load')));
+    }
+  };
 }
 
-async function loadManifest(): Promise<any> {
-  await settingsReady; // wait for settings to be ready
-  const language = settingsSelector(store.getState()).language;
-  const manifestLang = manifestLangs.has(language) ? language : 'en';
-  const path = `/data/d1/manifests/d1-manifest-${manifestLang}.json?v=2020-02-17`;
+function loadManifest(): ThunkResult<any> {
+  return async (dispatch, getState) => {
+    await settingsReady; // wait for settings to be ready
+    const language = settingsSelector(getState()).language;
+    const manifestLang = manifestLangs.has(language) ? language : 'en';
+    const path = `/data/d1/manifests/d1-manifest-${manifestLang}.json?v=2020-02-17`;
 
-  // Use the path as the version
-  version = path;
+    // Use the path as the version
+    version = path;
 
-  try {
-    return await loadManifestFromCache(version);
-  } catch (e) {
-    return loadManifestRemote(version, path);
-  }
+    try {
+      return await loadManifestFromCache(version);
+    } catch (e) {
+      return dispatch(loadManifestRemote(version, path));
+    }
+  };
 }
 
 /**
  * Returns a promise for the manifest data as a Uint8Array. Will cache it on succcess.
  */
-async function loadManifestRemote(version: string, path: string): Promise<object> {
-  store.dispatch(loadingStart(t('Manifest.Download')));
+function loadManifestRemote(version: string, path: string): ThunkResult<object> {
+  return async (dispatch) => {
+    dispatch(loadingStart(t('Manifest.Download')));
 
-  try {
-    const response = await fetch(path);
-    const manifest = await (response.ok ? response.json() : Promise.reject(response));
+    try {
+      const response = await fetch(path);
+      const manifest = await (response.ok ? response.json() : Promise.reject(response));
 
-    // We intentionally don't wait on this promise
-    saveManifestToIndexedDB(manifest, version);
+      // We intentionally don't wait on this promise
+      saveManifestToIndexedDB(manifest, version);
 
-    return manifest;
-  } finally {
-    store.dispatch(loadingEnd(t('Manifest.Download')));
-  }
+      return manifest;
+    } finally {
+      dispatch(loadingEnd(t('Manifest.Download')));
+    }
+  };
 }
 
 // This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -16,150 +16,132 @@ import { loadingEnd, loadingStart } from 'app/shell/actions';
 const alwaysLoadRemote = false;
 
 const manifestLangs = new Set(['en', 'fr', 'es', 'de', 'it', 'ja', 'pt-br']);
+const localStorageKey = 'd1-manifest-version';
+const idbKey = 'd1-manifest';
+let manifestPromise: Promise<object> | null = null;
+let version: string | null = null;
 
-class ManifestService {
-  version: string | null = null;
+export function getManifest(): Promise<object> {
+  if (manifestPromise) {
+    return manifestPromise;
+  }
 
-  private manifestPromise: Promise<object> | null = null;
+  manifestPromise = doGetManifest();
 
-  constructor(readonly localStorageKey: string, readonly idbKey: string) {}
+  return manifestPromise;
+}
 
-  getManifest(): Promise<object> {
-    if (this.manifestPromise) {
-      return this.manifestPromise;
+// This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
+async function doGetManifest() {
+  store.dispatch(loadingStart(t('Manifest.Load')));
+  try {
+    const manifest = await loadManifest();
+    if (!manifest.DestinyVendorDefinition) {
+      throw new Error('Manifest corrupted, please reload');
     }
+    return manifest;
+  } catch (e) {
+    let message = e.message || e;
 
-    this.manifestPromise = this.doGetManifest();
-
-    return this.manifestPromise;
-  }
-
-  getRecord(db: object, table: string, id: number): object | null {
-    if (!db[table]) {
-      throw new Error(`Table ${table} does not exist in the manifest`);
-    }
-    return db[table][id];
-  }
-
-  getAllRecords(db: object, table: string): object {
-    return db[table];
-  }
-
-  // This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
-  private async doGetManifest() {
-    store.dispatch(loadingStart(t('Manifest.Load')));
-    try {
-      const manifest = await this.loadManifest();
-      if (!manifest.DestinyVendorDefinition) {
-        throw new Error('Manifest corrupted, please reload');
-      }
-      return manifest;
-    } catch (e) {
-      let message = e.message || e;
-
-      if (e instanceof TypeError || e.status === -1) {
-        message = navigator.onLine
-          ? t('BungieService.NotConnectedOrBlocked')
-          : t('BungieService.NotConnected');
-      } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
-        message = t('BungieService.Difficulties');
-      } else if (e.status < 200 || e.status >= 400) {
-        message = t('BungieService.NetworkError', {
-          status: e.status,
-          statusText: e.statusText,
-        });
-      } else {
-        // Something may be wrong with the manifest
-        this.deleteManifestFile();
-      }
-
-      const statusText = t('Manifest.Error', { error: message });
-      this.manifestPromise = null;
-      console.error('Manifest loading error', { error: e }, e);
-      reportException('manifest load', e);
-      throw new Error(statusText);
-    } finally {
-      store.dispatch(loadingEnd(t('Manifest.Load')));
-    }
-  }
-
-  private async loadManifest(): Promise<any> {
-    await settingsReady; // wait for settings to be ready
-    const language = settingsSelector(store.getState()).language;
-    const manifestLang = manifestLangs.has(language) ? language : 'en';
-    const path = `/data/d1/manifests/d1-manifest-${manifestLang}.json?v=2020-02-17`;
-
-    // Use the path as the version
-    const version = path;
-    this.version = version;
-
-    try {
-      return await this.loadManifestFromCache(version);
-    } catch (e) {
-      return this.loadManifestRemote(version, path);
-    }
-  }
-
-  /**
-   * Returns a promise for the manifest data as a Uint8Array. Will cache it on succcess.
-   */
-  private async loadManifestRemote(version: string, path: string): Promise<object> {
-    store.dispatch(loadingStart(t('Manifest.Download')));
-
-    try {
-      const response = await fetch(path);
-      const manifest = await (response.ok ? response.json() : Promise.reject(response));
-
-      // We intentionally don't wait on this promise
-      this.saveManifestToIndexedDB(manifest, version);
-
-      return manifest;
-    } finally {
-      store.dispatch(loadingEnd(t('Manifest.Download')));
-    }
-  }
-
-  // This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
-  private async saveManifestToIndexedDB(typedArray: object, version: string) {
-    try {
-      await set(this.idbKey, typedArray);
-      console.log(`Sucessfully stored manifest file.`);
-      localStorage.setItem(this.localStorageKey, version);
-    } catch (e) {
-      console.error('Error saving manifest file', e);
-      showNotification({
-        title: t('Help.NoStorage'),
-        body: t('Help.NoStorageMessage'),
-        type: 'error',
+    if (e instanceof TypeError || e.status === -1) {
+      message = navigator.onLine
+        ? t('BungieService.NotConnectedOrBlocked')
+        : t('BungieService.NotConnected');
+    } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
+      message = t('BungieService.Difficulties');
+    } else if (e.status < 200 || e.status >= 400) {
+      message = t('BungieService.NetworkError', {
+        status: e.status,
+        statusText: e.statusText,
       });
-    }
-  }
-
-  private deleteManifestFile() {
-    localStorage.removeItem(this.localStorageKey);
-    del(this.idbKey);
-  }
-
-  /**
-   * Returns a promise for the cached manifest of the specified
-   * version as a Uint8Array, or rejects.
-   */
-  private async loadManifestFromCache(version: string): Promise<object> {
-    if (alwaysLoadRemote) {
-      throw new Error('Testing - always load remote');
-    }
-
-    const currentManifestVersion = localStorage.getItem(this.localStorageKey);
-    if (currentManifestVersion === version) {
-      const manifest = await get<object>(this.idbKey);
-      if (!manifest) {
-        throw new Error('Empty cached manifest file');
-      }
-      return manifest;
     } else {
-      throw new Error(`version mismatch: ${version} ${currentManifestVersion}`);
+      // Something may be wrong with the manifest
+      deleteManifestFile();
     }
+
+    const statusText = t('Manifest.Error', { error: message });
+    manifestPromise = null;
+    console.error('Manifest loading error', { error: e }, e);
+    reportException('manifest load', e);
+    throw new Error(statusText);
+  } finally {
+    store.dispatch(loadingEnd(t('Manifest.Load')));
   }
 }
 
-export const D1ManifestService = new ManifestService('d1-manifest-version', 'd1-manifest');
+async function loadManifest(): Promise<any> {
+  await settingsReady; // wait for settings to be ready
+  const language = settingsSelector(store.getState()).language;
+  const manifestLang = manifestLangs.has(language) ? language : 'en';
+  const path = `/data/d1/manifests/d1-manifest-${manifestLang}.json?v=2020-02-17`;
+
+  // Use the path as the version
+  version = path;
+
+  try {
+    return await loadManifestFromCache(version);
+  } catch (e) {
+    return loadManifestRemote(version, path);
+  }
+}
+
+/**
+ * Returns a promise for the manifest data as a Uint8Array. Will cache it on succcess.
+ */
+async function loadManifestRemote(version: string, path: string): Promise<object> {
+  store.dispatch(loadingStart(t('Manifest.Download')));
+
+  try {
+    const response = await fetch(path);
+    const manifest = await (response.ok ? response.json() : Promise.reject(response));
+
+    // We intentionally don't wait on this promise
+    saveManifestToIndexedDB(manifest, version);
+
+    return manifest;
+  } finally {
+    store.dispatch(loadingEnd(t('Manifest.Download')));
+  }
+}
+
+// This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
+async function saveManifestToIndexedDB(typedArray: object, version: string) {
+  try {
+    await set(idbKey, typedArray);
+    console.log(`Sucessfully stored manifest file.`);
+    localStorage.setItem(localStorageKey, version);
+  } catch (e) {
+    console.error('Error saving manifest file', e);
+    showNotification({
+      title: t('Help.NoStorage'),
+      body: t('Help.NoStorageMessage'),
+      type: 'error',
+    });
+  }
+}
+
+function deleteManifestFile() {
+  localStorage.removeItem(localStorageKey);
+  del(idbKey);
+}
+
+/**
+ * Returns a promise for the cached manifest of the specified
+ * version as a Uint8Array, or rejects.
+ */
+async function loadManifestFromCache(version: string): Promise<object> {
+  if (alwaysLoadRemote) {
+    throw new Error('Testing - always load remote');
+  }
+
+  const currentManifestVersion = localStorage.getItem(localStorageKey);
+  if (currentManifestVersion === version) {
+    const manifest = await get<object>(idbKey);
+    if (!manifest) {
+      throw new Error('Empty cached manifest file');
+    }
+    return manifest;
+  } else {
+    throw new Error(`version mismatch: ${version} ${currentManifestVersion}`);
+  }
+}

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -5,7 +5,7 @@ import { reportException } from '../utils/exceptions';
 import { getManifest as d2GetManifest } from '../bungie-api/destiny2-api';
 import { settingsReady } from '../settings/settings';
 import { t } from 'app/i18next-t';
-import { DestinyManifest, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { deepEqual } from 'fast-equals';
 import { showNotification } from '../notifications/notifications';
 import { settingsSelector } from 'app/settings/reducer';
@@ -60,242 +60,225 @@ const tableTrimmers = {
   },
 };
 
-class ManifestService {
-  version: string | null = null;
+// Module-local state
+const localStorageKey = 'd2-manifest-version';
+const idbKey = 'd2-manifest';
+let manifestPromise: Promise<object> | null = null;
+let version: string | null = null;
 
-  /**
-   * This tells users to reload the app. It fires no more
-   * often than every 10 seconds, and only warns if the manifest
-   * version has actually changed.
-   */
-  warnMissingDefinition = _.debounce(
-    // This is not async because of https://bugs.webkit.org/show_bug.cgi?id=166879
-    () => {
-      this.getManifestApi().then((data) => {
-        const language = settingsSelector(store.getState()).language;
-        const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
-
-        // The manifest has updated!
-        if (path !== this.version) {
-          showNotification({
-            type: 'warning',
-            title: t('Manifest.Outdated'),
-            body: t('Manifest.OutdatedExplanation'),
-          });
-        }
-      });
-    },
-    10000,
-    {
-      leading: true,
-      trailing: false,
-    }
-  );
-
-  private manifestPromise: Promise<object> | null = null;
-
-  constructor(
-    readonly localStorageKey: string,
-    readonly idbKey: string,
-    readonly getManifestApi: () => Promise<DestinyManifest>
-  ) {}
-
-  getManifest(tableAllowList: string[]): Promise<object> {
-    if (this.manifestPromise) {
-      return this.manifestPromise;
-    }
-
-    this.manifestPromise = this.doGetManifest(tableAllowList);
-
-    return this.manifestPromise;
-  }
-
-  // This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
-  private async doGetManifest(tableAllowList: string[]) {
-    store.dispatch(loadingStart(t('Manifest.Load')));
-    try {
-      console.time('Load manifest');
-      const manifest = await this.loadManifest(tableAllowList);
-      if (!manifest.DestinyVendorDefinition) {
-        throw new Error('Manifest corrupted, please reload');
-      }
-      return manifest;
-    } catch (e) {
-      let message = e.message || e;
-
-      if (e instanceof TypeError || e.status === -1) {
-        message = navigator.onLine
-          ? t('BungieService.NotConnectedOrBlocked')
-          : t('BungieService.NotConnected');
-      } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
-        message = t('BungieService.Difficulties');
-      } else if (e.status < 200 || e.status >= 400) {
-        message = t('BungieService.NetworkError', {
-          status: e.status,
-          statusText: e.statusText,
-        });
-      } else {
-        // Something may be wrong with the manifest
-        await this.deleteManifestFile();
-      }
-
-      const statusText = t('Manifest.Error', { error: message });
-      this.manifestPromise = null;
-      console.error('Manifest loading error', { error: e }, e);
-      reportException('manifest load', e);
-      const error = new Error(statusText);
-      error.name = 'ManifestError';
-      throw error;
-    } finally {
-      store.dispatch(loadingEnd(t('Manifest.Load')));
-      console.timeEnd('Load manifest');
-    }
-  }
-
-  private async loadManifest(tableAllowList: string[]): Promise<any> {
-    let version: string | null = null;
-    let components: {
-      [key: string]: string;
-    } | null = null;
-    try {
-      const data = await this.getManifestApi();
-      await settingsReady; // wait for settings to be ready
+/**
+ * This tells users to reload the app. It fires no more
+ * often than every 10 seconds, and only warns if the manifest
+ * version has actually changed.
+ */
+export const warnMissingDefinition = _.debounce(
+  // This is not async because of https://bugs.webkit.org/show_bug.cgi?id=166879
+  () => {
+    d2GetManifest().then((data) => {
       const language = settingsSelector(store.getState()).language;
       const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
-      components =
-        data.jsonWorldComponentContentPaths[language] || data.jsonWorldComponentContentPaths.en;
 
-      // Use the path as the version, rather than the "version" field, because
-      // Bungie can update the manifest file without changing that version.
-      version = path;
-      this.version = version;
-    } catch (e) {
-      // If we can't get info about the current manifest, try to just use whatever's already saved.
-      version = localStorage.getItem(this.localStorageKey);
-      if (version) {
-        this.version = version;
-        return this.loadManifestFromCache(version, tableAllowList);
-      } else {
-        throw e;
-      }
-    }
-
-    try {
-      return await this.loadManifestFromCache(version, tableAllowList);
-    } catch (e) {
-      return this.loadManifestRemote(version, components, tableAllowList);
-    }
-  }
-
-  /**
-   * Returns a promise for the manifest data as a Uint8Array. Will cache it on succcess.
-   */
-  private async loadManifestRemote(
-    version: string,
-    components: {
-      [key: string]: string;
-    },
-    tableAllowList: string[]
-  ): Promise<object> {
-    store.dispatch(loadingStart(t('Manifest.Download')));
-    try {
-      const manifest = {};
-      // Adding a cache buster to work around bad cached CloudFlare data: https://github.com/DestinyItemManager/DIM/issues/5101
-      // try canonical component URL which should likely be already cached,
-      // then fall back to appending "?dim" then "?dim-[random numbers]",
-      // in case cloudflare has inappropriately cached another domain's CORS headers or a 404 that's no longer a 404
-      const cacheBusterStrings = [
-        '',
-        '?dim',
-        `?dim-${Math.random().toString().split('.')[1] ?? 'dimCacheBust'}`,
-      ];
-      const futures = tableAllowList
-        .map((t) => `Destiny${t}Definition`)
-        .map(async (table) => {
-          let response: Response | null = null;
-          let error: any = null;
-
-          for (const query of cacheBusterStrings) {
-            try {
-              response = await fetch(`https://www.bungie.net${components[table]}${query}`);
-              if (response.ok) {
-                break;
-              }
-              error = error ?? response;
-            } catch (e) {
-              error = error ?? e;
-            }
-          }
-          const body = await (response?.ok ? response.json() : Promise.reject(error));
-          manifest[table] = tableTrimmers[table] ? tableTrimmers[table](body) : body;
+      // The manifest has updated!
+      if (path !== version) {
+        showNotification({
+          type: 'warning',
+          title: t('Manifest.Outdated'),
+          body: t('Manifest.OutdatedExplanation'),
         });
-
-      await Promise.all(futures);
-
-      // We intentionally don't wait on this promise
-      this.saveManifestToIndexedDB(manifest, version, tableAllowList);
-      return manifest;
-    } finally {
-      store.dispatch(loadingEnd(t('Manifest.Download')));
-    }
-  }
-
-  // This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
-  private async saveManifestToIndexedDB(
-    typedArray: object,
-    version: string,
-    tableAllowList: string[]
-  ) {
-    try {
-      await set(this.idbKey, typedArray);
-      console.log(`Sucessfully stored manifest file.`);
-      localStorage.setItem(this.localStorageKey, version);
-      localStorage.setItem(this.localStorageKey + '-whitelist', JSON.stringify(tableAllowList));
-    } catch (e) {
-      console.error('Error saving manifest file', e);
-      showNotification({
-        title: t('Help.NoStorage'),
-        body: t('Help.NoStorageMessage'),
-        type: 'error',
-      });
-    }
-  }
-
-  private deleteManifestFile() {
-    localStorage.removeItem(this.localStorageKey);
-    return del(this.idbKey);
-  }
-
-  /**
-   * Returns a promise for the cached manifest of the specified
-   * version as a Uint8Array, or rejects.
-   */
-  private async loadManifestFromCache(version: string, tableAllowList: string[]): Promise<object> {
-    if (alwaysLoadRemote) {
-      throw new Error('Testing - always load remote');
-    }
-
-    const currentManifestVersion = localStorage.getItem(this.localStorageKey);
-    const currentAllowList = JSON.parse(
-      localStorage.getItem(this.localStorageKey + '-whitelist') || '[]'
-    );
-    if (currentManifestVersion === version && deepEqual(currentAllowList, tableAllowList)) {
-      const manifest = await get<object>(this.idbKey);
-      if (!manifest) {
-        await this.deleteManifestFile();
-        throw new Error('Empty cached manifest file');
       }
-      return manifest;
-    } else {
-      // Delete the existing manifest first, to make space
-      await this.deleteManifestFile();
-      throw new Error(`version mismatch: ${version} ${currentManifestVersion}`);
+    });
+  },
+  10000,
+  {
+    leading: true,
+    trailing: false,
+  }
+);
+
+export function getManifest(tableAllowList: string[]): Promise<object> {
+  if (manifestPromise) {
+    return manifestPromise;
+  }
+
+  manifestPromise = doGetManifest(tableAllowList);
+
+  return manifestPromise;
+}
+
+// This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
+async function doGetManifest(tableAllowList: string[]) {
+  store.dispatch(loadingStart(t('Manifest.Load')));
+  try {
+    console.time('Load manifest');
+    const manifest = await loadManifest(tableAllowList);
+    if (!manifest.DestinyVendorDefinition) {
+      throw new Error('Manifest corrupted, please reload');
     }
+    return manifest;
+  } catch (e) {
+    let message = e.message || e;
+
+    if (e instanceof TypeError || e.status === -1) {
+      message = navigator.onLine
+        ? t('BungieService.NotConnectedOrBlocked')
+        : t('BungieService.NotConnected');
+    } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
+      message = t('BungieService.Difficulties');
+    } else if (e.status < 200 || e.status >= 400) {
+      message = t('BungieService.NetworkError', {
+        status: e.status,
+        statusText: e.statusText,
+      });
+    } else {
+      // Something may be wrong with the manifest
+      await deleteManifestFile();
+    }
+
+    const statusText = t('Manifest.Error', { error: message });
+    manifestPromise = null;
+    console.error('Manifest loading error', { error: e }, e);
+    reportException('manifest load', e);
+    const error = new Error(statusText);
+    error.name = 'ManifestError';
+    throw error;
+  } finally {
+    store.dispatch(loadingEnd(t('Manifest.Load')));
+    console.timeEnd('Load manifest');
   }
 }
 
-export const D2ManifestService = new ManifestService(
-  'd2-manifest-version',
-  'd2-manifest',
-  d2GetManifest
-);
+async function loadManifest(tableAllowList: string[]): Promise<any> {
+  let components: {
+    [key: string]: string;
+  } | null = null;
+  try {
+    const data = await d2GetManifest();
+    await settingsReady; // wait for settings to be ready
+    const language = settingsSelector(store.getState()).language;
+    const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
+    components =
+      data.jsonWorldComponentContentPaths[language] || data.jsonWorldComponentContentPaths.en;
+
+    // Use the path as the version, rather than the "version" field, because
+    // Bungie can update the manifest file without changing that version.
+    version = path;
+  } catch (e) {
+    // If we can't get info about the current manifest, try to just use whatever's already saved.
+    version = localStorage.getItem(localStorageKey);
+    if (version) {
+      return loadManifestFromCache(version, tableAllowList);
+    } else {
+      throw e;
+    }
+  }
+
+  try {
+    return await loadManifestFromCache(version, tableAllowList);
+  } catch (e) {
+    return loadManifestRemote(version, components, tableAllowList);
+  }
+}
+
+/**
+ * Returns a promise for the manifest data as a Uint8Array. Will cache it on succcess.
+ */
+async function loadManifestRemote(
+  version: string,
+  components: {
+    [key: string]: string;
+  },
+  tableAllowList: string[]
+): Promise<object> {
+  store.dispatch(loadingStart(t('Manifest.Download')));
+  try {
+    const manifest = {};
+    // Adding a cache buster to work around bad cached CloudFlare data: https://github.com/DestinyItemManager/DIM/issues/5101
+    // try canonical component URL which should likely be already cached,
+    // then fall back to appending "?dim" then "?dim-[random numbers]",
+    // in case cloudflare has inappropriately cached another domain's CORS headers or a 404 that's no longer a 404
+    const cacheBusterStrings = [
+      '',
+      '?dim',
+      `?dim-${Math.random().toString().split('.')[1] ?? 'dimCacheBust'}`,
+    ];
+    const futures = tableAllowList
+      .map((t) => `Destiny${t}Definition`)
+      .map(async (table) => {
+        let response: Response | null = null;
+        let error: any = null;
+
+        for (const query of cacheBusterStrings) {
+          try {
+            response = await fetch(`https://www.bungie.net${components[table]}${query}`);
+            if (response.ok) {
+              break;
+            }
+            error = error ?? response;
+          } catch (e) {
+            error = error ?? e;
+          }
+        }
+        const body = await (response?.ok ? response.json() : Promise.reject(error));
+        manifest[table] = tableTrimmers[table] ? tableTrimmers[table](body) : body;
+      });
+
+    await Promise.all(futures);
+
+    // We intentionally don't wait on this promise
+    saveManifestToIndexedDB(manifest, version, tableAllowList);
+    return manifest;
+  } finally {
+    store.dispatch(loadingEnd(t('Manifest.Download')));
+  }
+}
+
+// This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
+async function saveManifestToIndexedDB(
+  typedArray: object,
+  version: string,
+  tableAllowList: string[]
+) {
+  try {
+    await set(idbKey, typedArray);
+    console.log(`Sucessfully stored manifest file.`);
+    localStorage.setItem(localStorageKey, version);
+    localStorage.setItem(localStorageKey + '-whitelist', JSON.stringify(tableAllowList));
+  } catch (e) {
+    console.error('Error saving manifest file', e);
+    showNotification({
+      title: t('Help.NoStorage'),
+      body: t('Help.NoStorageMessage'),
+      type: 'error',
+    });
+  }
+}
+
+function deleteManifestFile() {
+  localStorage.removeItem(localStorageKey);
+  return del(idbKey);
+}
+
+/**
+ * Returns a promise for the cached manifest of the specified
+ * version as a Uint8Array, or rejects.
+ */
+async function loadManifestFromCache(version: string, tableAllowList: string[]): Promise<object> {
+  if (alwaysLoadRemote) {
+    throw new Error('Testing - always load remote');
+  }
+
+  const currentManifestVersion = localStorage.getItem(localStorageKey);
+  const currentAllowList = JSON.parse(localStorage.getItem(localStorageKey + '-whitelist') || '[]');
+  if (currentManifestVersion === version && deepEqual(currentAllowList, tableAllowList)) {
+    const manifest = await get<object>(idbKey);
+    if (!manifest) {
+      await deleteManifestFile();
+      throw new Error('Empty cached manifest file');
+    }
+    return manifest;
+  } else {
+    // Delete the existing manifest first, to make space
+    await deleteManifestFile();
+    throw new Error(`version mismatch: ${version} ${currentManifestVersion}`);
+  }
+}

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -73,13 +73,11 @@ let version: string | null = null;
  * version has actually changed.
  */
 export const warnMissingDefinition = _.debounce(
-  async (_, getState) => {
+  async () => {
     const data = await d2GetManifest();
-    const language = settingsSelector(getState()).language;
-    const path = data.jsonWorldContentPaths[language] || data.jsonWorldContentPaths.en;
-
-    // The manifest has updated!
-    if (path !== version) {
+    // If none of the paths (for any language) matches what we downloaded...
+    if (version && !Object.values(data.jsonWorldContentPaths).includes(version)) {
+      // The manifest has updated!
       showNotification({
         type: 'warning',
         title: t('Manifest.Outdated'),

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -10,10 +10,14 @@ import { refresh$ } from '../shell/refresh';
 import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
 import PresentationNodeRoot from '../collections/PresentationNodeRoot';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
-import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import { DimStore } from 'app/inventory/store-types';
-import { sortedStoresSelector, profileResponseSelector } from 'app/inventory/selectors';
+import {
+  sortedStoresSelector,
+  profileResponseSelector,
+  bucketsSelector,
+} from 'app/inventory/selectors';
 import { D2StoresService } from 'app/inventory/d2-stores';
 import CharacterSelect from 'app/dim-ui/CharacterSelect';
 import { queueAction } from 'app/inventory/action-queue';
@@ -48,7 +52,7 @@ function mapStateToProps(state: RootState): StoreProps {
     isPhonePortrait: state.shell.isPhonePortrait,
     stores: sortedStoresSelector(state),
     defs: state.manifest.d2Manifest,
-    buckets: state.inventory.buckets,
+    buckets: bucketsSelector(state),
     profileInfo: profileResponseSelector(state),
   };
 }
@@ -58,12 +62,6 @@ const refreshStores = () =>
 
 function Progress({ account, defs, stores, isPhonePortrait, buckets, profileInfo }: Props) {
   const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!defs) {
-      getDefinitions();
-    }
-  }, [defs]);
 
   useEffect(() => {
     if (!profileInfo) {

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -18,7 +18,7 @@ import { CompareService } from '../compare/compare.service';
 import { bulkTagItems } from 'app/inventory/tag-items';
 import { searchQueryVersionSelector, querySelector } from 'app/shell/reducer';
 import { setItemLockState } from 'app/inventory/item-move-service';
-import { storesSelector } from 'app/inventory/selectors';
+import { storesSelector, bucketsSelector } from 'app/inventory/selectors';
 import { getAllItems } from 'app/inventory/stores-helpers';
 import { touch, touchItem } from 'app/inventory/actions';
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
@@ -67,19 +67,15 @@ const mapDispatchToProps: MapDispatchToPropsFunction<DispatchProps, StoreProps> 
 type Props = ProvidedProps & StoreProps & DispatchProps;
 
 function mapStateToProps(state: RootState): StoreProps {
-  const searchFilter = searchFilterSelector(state);
-  const stores = storesSelector(state);
-  const buckets = state.inventory.buckets;
-
   return {
     isPhonePortrait: state.shell.isPhonePortrait,
     destinyVersion: destinyVersionSelector(state),
     account: currentAccountSelector(state),
-    searchFilter,
+    searchFilter: searchFilterSelector(state),
     searchQuery: querySelector(state),
     searchQueryVersion: searchQueryVersionSelector(state),
-    stores,
-    buckets,
+    stores: storesSelector(state),
+    buckets: bucketsSelector(state),
   };
 }
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -163,7 +163,7 @@ function SettingsPage({
   dispatch,
 }: Props) {
   useEffect(() => {
-    getDefinitions();
+    dispatch(getDefinitions());
     dispatch(getPlatforms()).then(() => {
       const account = getActivePlatform();
       if (account) {

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -15,6 +15,7 @@ import {
   storesSelector,
   ownedItemsSelector,
   profileResponseSelector,
+  bucketsSelector,
 } from '../inventory/selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { toVendor } from './d2-vendors';
@@ -50,7 +51,7 @@ function mapStateToProps() {
   return (state: RootState): StoreProps => ({
     stores: storesSelector(state),
     ownedItemHashes: ownedItemSelectorInstance(state),
-    buckets: state.inventory.buckets,
+    buckets: bucketsSelector(state),
     defs: state.manifest.d2Manifest,
     profileResponse: profileResponseSelector(state),
     vendors: state.vendors.vendorsByCharacter,

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -21,6 +21,7 @@ import {
   ownedItemsSelector,
   sortedStoresSelector,
   profileResponseSelector,
+  bucketsSelector,
 } from '../inventory/selectors';
 import { connect } from 'react-redux';
 import {
@@ -67,7 +68,7 @@ function mapStateToProps() {
   return (state: RootState): StoreProps => ({
     stores: sortedStoresSelector(state),
     ownedItemHashes: ownedItemSelectorInstance(state),
-    buckets: state.inventory.buckets,
+    buckets: bucketsSelector(state),
     defs: state.manifest.d2Manifest,
     isPhonePortrait: state.shell.isPhonePortrait,
     searchQuery: state.shell.searchQuery,


### PR DESCRIPTION
This rewrites the manifest fetching and definitions processing as Redux actions, for both D1 and D2. No more class! I also replaced the weird setup where InventoryBuckets tried to load definitions on its own and then got saved back into state with a selector, since buckets are really derived state from the manifest and don't need to be stored separately. This moves us closer to the still-somewhat-far-away Redux ideal and also breaks some dependencies on `store` which then brings in the whole universe.