### PR TITLE
removes additional padding on loadout drawer items

### DIFF
--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -29,8 +29,6 @@
 
 .loadout-item {
   position: relative;
-  margin-right: var(--item-margin);
-  margin-bottom: var(--item-margin);
   .close {
     right: 2px;
   }


### PR DESCRIPTION
before: 
![image](https://user-images.githubusercontent.com/29002828/90283897-04058d00-de3f-11ea-8c32-1519f3950969.png)

after: 
![image](https://user-images.githubusercontent.com/29002828/90283808-d7ea0c00-de3e-11ea-8e56-ded62fbe5531.png)

worth mentioning I can't test if this impacts D1 loadouts... I assume it's fine though. fixes #5598
