### PR TITLE
remove outline on ios focus state

### DIFF
--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -157,6 +157,12 @@
   .store-cell {
     padding: 8px var(--inventory-column-padding) 6px var(--inventory-column-padding);
     flex-direction: column;
+    &:focus {
+      outline: none;
+    }
+  }
+  &:focus {
+    outline: none;
   }
   @supports (position: sticky) {
     position: sticky;


### PR DESCRIPTION
This should fix #5584 I set outline to none on focus of both the store header and the store cell as I'm not exactly sure which is being focused and this is hard to test with a PC as I can't really debug my phone without a mac! If you all know which is being focused I can remove one. Bust shouldn't hurt to have both. I didn't add a different state because the menu pops and that is essentially our focus state. 