### PR TITLE
Fix the `is:curated` filter

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -432,6 +432,8 @@ export interface DimSocket {
    * Look at TODO to figure out the full list of possible plugs for this socket.
    */
   plugOptions: DimPlug[];
+  /** Plug hashes in this item visible in the collections roll, if this is a perk */
+  curatedRoll: number[] | null;
   /** Reusable plug items from runtime info, for the plug viewer. */
   reusablePlugItems?: DestinyItemPlugBase[];
   /** Does the socket contain randomized plug items? */

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -266,6 +266,7 @@ function buildDefinedSocket(
     socketIndex: index,
     plugged: null,
     plugOptions,
+    curatedRoll: null,
     reusablePlugItems: [],
     hasRandomizedPlugItems:
       Boolean(socketDef.randomizedPlugSetHash) || socketTypeDef.alwaysRandomizeSockets,
@@ -421,6 +422,7 @@ function buildSocket(
   // We only build a larger list of plug options if this is a perk socket, since users would
   // only want to see (and search) the plug options for perks. For other socket types (mods, shaders, etc.)
   // we will only populate plugOptions with the currently inserted plug.
+  let curatedRoll: number[] | null = null;
   if (isPerk) {
     if (reusablePlugs) {
       // Get options from live info
@@ -428,6 +430,7 @@ function buildSocket(
         const built = buildPlug(defs, reusablePlug, socketDef, plugObjectivesData);
         addPlugOption(built, plugged, plugOptions);
       }
+      curatedRoll = socketDef.reusablePlugItems.map((p) => p.plugItemHash);
     } else if (socketDef.reusablePlugSetHash) {
       // Get options from plug set, instead of live info
       const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash, forThisItem);
@@ -437,12 +440,14 @@ function buildSocket(
           addPlugOption(built, plugged, plugOptions);
         }
       }
+      curatedRoll = plugSet?.reusablePlugItems.map((p) => p.plugItemHash) || [];
     } else if (socketDef.reusablePlugItems) {
       // Get options from definition itself
       for (const reusablePlug of socketDef.reusablePlugItems) {
         const built = buildDefinedPlug(defs, reusablePlug);
         addPlugOption(built, plugged, plugOptions);
       }
+      curatedRoll = socketDef.reusablePlugItems.map((p) => p.plugItemHash);
     }
   }
 
@@ -454,6 +459,7 @@ function buildSocket(
     socketIndex: index,
     plugged,
     plugOptions,
+    curatedRoll,
     hasRandomizedPlugItems,
     reusablePlugItems: reusablePlugs,
     isPerk,

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -58,19 +58,15 @@ export const emptySocketHashes = [
   791435474, // InventoryItem "Empty Activity Mod Socket"
 ];
 
-/** these are checked against default rolls to determine if something's curated */
-export const curatedPlugsAllowList = [
-  PlugCategoryHashes.Frames,
-  PlugCategoryHashes.Guards,
-  PlugCategoryHashes.Blades,
-  PlugCategoryHashes.Tubes,
-  PlugCategoryHashes.Arrows,
-  PlugCategoryHashes.Batteries,
-  PlugCategoryHashes.Magazines,
-  PlugCategoryHashes.Scopes,
-  PlugCategoryHashes.MagazinesGl,
-  PlugCategoryHashes.Barrels,
-  PlugCategoryHashes.Bowstrings,
+/** if a socket is one of these, do not compare against
+ * collections roll for purposes of curatedness
+ */
+export const curatedIgnoreSocketHashes = [
+  3956125808, // intrinsic
+  1288200359, // shader
+  2572269636, // radiance
+  2218962841, // masterwork
+  3939863699, // mod slot
 ];
 
 export const armor2PlugCategoryHashesByName = {


### PR DESCRIPTION
Fixes #4011. This marks as curated:

* Any Y1 static rolls
* All Y2 and Y3 curated weapons (even those with multiple perks in a column like Ringing Nail or Heretic)
* All Y2 pinnacle and Y3 ritual weapons
* Vendor rolls such as the S4-5 Distant Relation or S6 Last Perdition

<details><summary>Vault screenshot</summary>

![grafik](https://user-images.githubusercontent.com/14299449/90677960-5d662580-e25e-11ea-90a6-bf2ef5aa7fec.png)

</details>