### PR TITLE
Present character header similarly x-browser

### DIFF
--- a/src/app/character-tile/CharacterTile.scss
+++ b/src/app/character-tile/CharacterTile.scss
@@ -65,7 +65,6 @@
 
   .class,
   .race-gender {
-    text-transform: capitalize;
     flex: 1;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -79,6 +78,7 @@
   .powerLevel,
   .light {
     color: $power;
+    margin-top: 1px;
 
     .app-icon {
       vertical-align: 70%;
@@ -97,12 +97,10 @@
     flex-wrap: nowrap;
     flex-direction: row;
     align-items: center;
-    font-weight: 400;
   }
 
   .top {
     font-size: 20px;
-    font-weight: 400;
 
     @include phone-portrait {
       .maxTotalPower {

--- a/src/app/character-tile/CharacterTile.scss
+++ b/src/app/character-tile/CharacterTile.scss
@@ -23,7 +23,7 @@
     text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5), 0px 0px 10px rgba(0, 0, 0, 0.5);
     display: flex;
     flex-direction: column;
-    margin: 4px 6px 2px 0px;
+    margin: 0 6px;
 
     .vault & {
       flex-direction: row;
@@ -69,7 +69,6 @@
     flex: 1;
     text-overflow: ellipsis;
     overflow: hidden;
-    line-height: 1.4em;
   }
 
   .powerLevel {
@@ -94,7 +93,6 @@
 
   .top,
   .bottom {
-    flex: 1;
     display: flex;
     flex-wrap: nowrap;
     flex-direction: row;
@@ -105,7 +103,6 @@
   .top {
     font-size: 20px;
     font-weight: 400;
-    height: 24px;
 
     @include phone-portrait {
       .maxTotalPower {
@@ -120,7 +117,6 @@
 .bottom {
   font-size: 12px;
   color: white;
-  height: 14px;
   @include phone-portrait {
     .vault & {
       display: grid;


### PR DESCRIPTION
Spacing should be more consistent. Just removed some of the original styling from the header. No clue what's going on with the colors. Think it's just the browsers showin off their flair. 

|Chrome|FF|Safari|
|---|---|---|
| <img width="409" alt="Screen Shot 2020-08-20 at 7 37 26 PM" src="https://user-images.githubusercontent.com/424158/90846245-a1b7fb00-e31c-11ea-965e-f3d5b8e46804.png"> | <img width="406" alt="Screen Shot 2020-08-20 at 7 35 36 PM" src="https://user-images.githubusercontent.com/424158/90846149-72a18980-e31c-11ea-9d82-63f9dd45d895.png"> | <img width="402" alt="Screen Shot 2020-08-20 at 7 35 44 PM" src="https://user-images.githubusercontent.com/424158/90846172-78976a80-e31c-11ea-988c-c14c5d37c874.png">

This resolves #5621 thanks @nev-r for the report!