### PR TITLE
Restrict mod cost to 10 in mod picker

### DIFF
--- a/src/app/loadout-builder/filter/ModPickerSection.tsx
+++ b/src/app/loadout-builder/filter/ModPickerSection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import _ from 'lodash';
 import { SelectableArmor2Mod } from '../locked-armor/SelectableBungieImage';
 import styles from './PerksForBucket.m.scss';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { LockedArmor2Mod, ModPickerCategory } from '../types';
+import { LockedArmor2Mod, ModPickerCategory, ModPickerCategories } from '../types';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 
 export default function ModPickerSection({
@@ -26,17 +27,26 @@ export default function ModPickerSection({
   onModSelected(mod: LockedArmor2Mod);
   onModRemoved(mod: LockedArmor2Mod);
 }) {
+  const lockedModCost = _.sumBy(locked, (l) => l.mod.plug.energyCost?.energyCost || 0);
+  const isNotGeneralOrSeasonal =
+    category !== ModPickerCategories.general && category !== ModPickerCategories.seasonal;
+  const allLockedAreAnyEnergy = locked?.every(
+    (locked) => locked.mod.plug.energyCost!.energyType === DestinyEnergyType.Any
+  );
+
   const isModUnSelectable = (item: LockedArmor2Mod) => {
-    if (locked && locked.length >= maximumSelectable) {
+    const itemEnergyCost = item.mod.plug.energyCost?.energyCost || 0;
+    if (
+      locked &&
+      (locked.length >= maximumSelectable ||
+        (isNotGeneralOrSeasonal && lockedModCost + itemEnergyCost > 10))
+    ) {
       return true;
     }
 
     if (energyMustMatch) {
       // cases where item is any energy or all mods are any energy
-      if (
-        item.mod.plug.energyCost!.energyType === DestinyEnergyType.Any ||
-        locked?.every((locked) => locked.mod.plug.energyCost!.energyType === DestinyEnergyType.Any)
-      ) {
+      if (item.mod.plug.energyCost!.energyType === DestinyEnergyType.Any || allLockedAreAnyEnergy) {
         return false;
       }
 

--- a/src/app/loadout-builder/filter/ModPickerSection.tsx
+++ b/src/app/loadout-builder/filter/ModPickerSection.tsx
@@ -5,6 +5,7 @@ import styles from './PerksForBucket.m.scss';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { LockedArmor2Mod, ModPickerCategory, ModPickerCategories } from '../types';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
+import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
 
 export default function ModPickerSection({
   defs,
@@ -39,7 +40,7 @@ export default function ModPickerSection({
     if (
       locked &&
       (locked.length >= maximumSelectable ||
-        (isNotGeneralOrSeasonal && lockedModCost + itemEnergyCost > 10))
+        (isNotGeneralOrSeasonal && lockedModCost + itemEnergyCost > MAX_ARMOR_ENERGY_CAPACITY))
     ) {
       return true;
     }

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -1,5 +1,6 @@
 import { ProcessMod } from './types';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
+import { MAX_ARMOR_ENERGY_CAPACITY } from '../../search/d2-known-values';
 
 interface SortParam {
   energy: {
@@ -90,7 +91,7 @@ export function canTakeAllSeasonalMods(
     if (
       item.energy &&
       (item.energy.type === energy.type || energy.type === DestinyEnergyType.Any) &&
-      item.energy.val + energy.val <= 10 &&
+      item.energy.val + energy.val <= MAX_ARMOR_ENERGY_CAPACITY &&
       item.compatibleModSeasons?.includes(tag)
     ) {
       if (assignments) {
@@ -138,7 +139,7 @@ export function canTakeAllGeneralMods(
     if (
       item.energy &&
       (item.energy.type === energy.type || energy.type === DestinyEnergyType.Any) &&
-      item.energy.val + energy.val <= 10
+      item.energy.val + energy.val <= MAX_ARMOR_ENERGY_CAPACITY
     ) {
       if (assignments) {
         assignments[item.id].push(hash);

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -278,3 +278,5 @@ export const breakerTypes = {
 };
 
 export const powerCapPlugSetHash = 573;
+
+export const MAX_ARMOR_ENERGY_CAPACITY = 10;


### PR DESCRIPTION
This comes about when selecting mods for a particular slot, i.e. helmet. This ensure two slot specific mods don't add up to more than 10, like two enhanced targeting mods.