### PR TITLE
New Search Bar: Implement tab completion and keyboard help

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -407,12 +407,14 @@
     "ClearDialog": "Dismiss dialog",
     "ClearNewItems": "Clear new items",
     "ClearNewItemsTitle": "Keyboard shortcut: X",
+    "Enter": "ENTER",
     "MarkItemAs": "Mark item as '{{tag}}'",
     "Menu": "Toggle menu",
     "RefreshInventory": "Refresh inventory",
     "ShowHotkeys": "Show keyboard shortcuts",
     "StartSearch": "Start a search",
     "StartSearchClear": "Start a fresh search",
+    "Tab": "TAB",
     "ToggleDetails": "Toggle showing full item details"
   },
   "Infusion": {

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -98,3 +98,17 @@
     border-bottom-color: #222;
   }
 }
+
+.keyHelp {
+  border-radius: 2px;
+  display: inline-block;
+  padding: 2px 4px;
+  margin-left: 4px;
+  font-size: 8px;
+  color: #ddd;
+  border: 1px solid #ddd;
+  .highlightedItem & {
+    color: #222;
+    border-color: #222;
+  }
+}

--- a/src/app/search/SearchBar.m.scss.d.ts
+++ b/src/app/search/SearchBar.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'deleteIcon': string;
   'highlightedItem': string;
+  'keyHelp': string;
   'menu': string;
   'menuItem': string;
   'menuItemHelp': string;

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -179,22 +179,15 @@ export function autocompleteTermSuggestions(
   if (match) {
     const term = match[1];
     const candidates = filterComplete(term);
-
-    const replace = (word: string) => {
-      word = word.toLowerCase();
-      return word.startsWith('is:') && word.startsWith('not:') ? `${word} ` : word;
-    };
-
     const base = query.slice(0, match.index);
 
     // new query is existing query minus match plus suggestion
     return candidates.map((word) => {
-      const replacement = replace(word);
-      const newQuery = base + replacement + query.slice(caretIndex);
+      const newQuery = base + word + query.slice(caretIndex);
       return {
         query: newQuery,
         type: SearchItemType.Autocomplete,
-        highlightRange: [match.index, match.index + replacement.length],
+        highlightRange: [match.index, match.index + word.length],
         // TODO: help from the matched query
       };
     });

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -403,12 +403,14 @@
     "ClearDialog": "Dismiss dialog",
     "ClearNewItems": "Clear new items",
     "ClearNewItemsTitle": "Keyboard shortcut: X",
+    "Enter": "ENTER",
     "MarkItemAs": "Mark item as '{{tag}}'",
     "Menu": "Toggle menu",
     "RefreshInventory": "Refresh inventory",
     "ShowHotkeys": "Show keyboard shortcuts",
     "StartSearch": "Start a search",
     "StartSearchClear": "Start a fresh search",
+    "Tab": "TAB",
     "ToggleDetails": "Toggle showing full item details"
   },
   "Infusion": {


### PR DESCRIPTION
This reintroduces the ability to tab-complete suggested terms in the new search bar. To make things clearer, I added keyboard shortcut help to the dropdown:

![image](https://user-images.githubusercontent.com/313208/90969368-7b28ca00-e4ac-11ea-9971-f16fdb7ad3dd.png)

Hitting tab while typing will autocomplete either the underlined completion in the highlighted item (if you've used the keyboard to highlight one) or the first row with an underlined term suggestion.

Fixes #5634 