### PR TITLE
Don't update page on visibility change if there's a query

### DIFF
--- a/src/app/dim-ui/ActivityTracker.tsx
+++ b/src/app/dim-ui/ActivityTracker.tsx
@@ -5,8 +5,7 @@ import { refresh as triggerRefresh, refresh$ } from '../shell/refresh';
 import { isDragging } from '../inventory/DraggableInventoryItem';
 import { Subscription } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
-import { dimNeedsUpdate } from 'app/register-service-worker';
-import { reloadDIM } from 'app/whats-new/WhatsNewLink';
+import { dimNeedsUpdate, reloadDIM } from 'app/register-service-worker';
 import { connect } from 'react-redux';
 import { RootState } from 'app/store/types';
 
@@ -19,6 +18,7 @@ interface StoreProps {
   autoRefresh: boolean;
   /** Whether to refresh profile when the page becomes visible after being in the background. */
   refreshProfileOnVisible: boolean;
+  hasSearchQuery: boolean;
 }
 
 function mapStateToProps(state: RootState): StoreProps {
@@ -34,6 +34,7 @@ function mapStateToProps(state: RootState): StoreProps {
     destinyProfileMinimumRefreshInterval,
     autoRefresh,
     refreshProfileOnVisible,
+    hasSearchQuery: Boolean(state.shell.searchQuery),
   };
 }
 
@@ -117,7 +118,7 @@ class ActivityTracker extends React.Component<Props> {
       if (this.props.refreshProfileOnVisible) {
         this.refreshAccountData();
       }
-    } else if (dimNeedsUpdate) {
+    } else if (dimNeedsUpdate && !this.props.hasSearchQuery) {
       // Sneaky updates - if DIM is hidden and needs an update, do the update.
       reloadDIM();
     }

--- a/src/app/shell/SneakyUpdates.tsx
+++ b/src/app/shell/SneakyUpdates.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
-import { dimNeedsUpdate } from 'app/register-service-worker';
-import { reloadDIM } from 'app/whats-new/WhatsNewLink';
+import { dimNeedsUpdate, reloadDIM } from 'app/register-service-worker';
 
 /**
  * "Sneaky Updates" - reload on navigation if DIM needs an update.

--- a/src/app/whats-new/WhatsNewLink.tsx
+++ b/src/app/whats-new/WhatsNewLink.tsx
@@ -4,7 +4,7 @@ import { alerts$ } from './BungieAlerts';
 import { GlobalAlert } from '../bungie-api/bungie-core-api';
 import './WhatsNewLink.scss';
 import { t } from 'app/i18next-t';
-import { dimNeedsUpdate$ } from '../register-service-worker';
+import { dimNeedsUpdate$, reloadDIM } from '../register-service-worker';
 import { AppIcon, updateIcon } from '../shell/icons';
 import { Subscriptions } from '../utils/rx-utils';
 import { NavLink } from 'react-router-dom';
@@ -79,48 +79,5 @@ export default class WhatsNewLink extends React.Component<{}, State> {
         {t('Header.WhatsNew')}
       </NavLink>
     );
-  }
-}
-
-export async function reloadDIM() {
-  try {
-    const registration = await navigator.serviceWorker.getRegistration();
-
-    if (!registration) {
-      console.error('SW: No registration!');
-      window.location.reload();
-      return;
-    }
-
-    if (!registration.waiting) {
-      // Just to ensure registration.waiting is available before
-      // calling postMessage()
-      console.error('SW: registration.waiting is null!');
-
-      const installingWorker = registration.installing!;
-      if (installingWorker) {
-        console.log('SW: found an installing service worker');
-        installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
-            console.log('SW: installing service worker installed, skip waiting');
-            installingWorker.postMessage('skipWaiting');
-          }
-        };
-      } else {
-        window.location.reload();
-      }
-      return;
-    }
-
-    console.log('SW: posting skip waiting');
-    registration.waiting.postMessage('skipWaiting');
-
-    // insurance!
-    setTimeout(() => {
-      window.location.reload();
-    }, 2000);
-  } catch (e) {
-    console.error('SW: Error checking registration:', e);
-    window.location.reload();
   }
 }


### PR DESCRIPTION
I really like having "sneaky updates" that forces the app to pick up new versions quickly. But it can be annoying if you have a search open on the Organizer or Inventory and the page reloads on you when visibility changes. This suppresses the update if there's an active query.