### PR TITLE
Feature/open mod picker from item socket

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -29,6 +29,8 @@ import { Loadout } from 'app/loadout/loadout-types';
 import { LoadoutBuilderState, useLbState } from './loadoutBuilderReducer';
 import { settingsSelector } from 'app/settings/reducer';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
+import ModPicker from './filter/ModPicker';
+import ReactDOM from 'react-dom';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -120,7 +122,7 @@ function LoadoutBuilder({
   preloadedLoadout,
 }: Props) {
   const [
-    { lockedMap, lockedSeasonalMods, lockedArmor2Mods, selectedStoreId, statFilters },
+    { lockedMap, lockedSeasonalMods, lockedArmor2Mods, selectedStoreId, statFilters, modPicker },
     lbDispatch,
   ] = useLbState(stores, preloadedLoadout);
 
@@ -254,8 +256,17 @@ function LoadoutBuilder({
             lockedSeasonalMods={lockedSeasonalMods}
           />
         )}
+        {modPicker.open &&
+          ReactDOM.createPortal(
+            <ModPicker
+              classType={selectedStore.classType}
+              lockedArmor2Mods={lockedArmor2Mods}
+              initialCategoryHash={modPicker.initialCategoryHash}
+              lbDispatch={lbDispatch}
+            />,
+            document.body
+          )}
       </PageWithMenu.Contents>
-
       <LoadoutDrawer />
     </PageWithMenu>
   );

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -263,6 +263,7 @@ function LoadoutBuilder({
               lockedArmor2Mods={lockedArmor2Mods}
               initialQuery={modPicker.initialQuery}
               lbDispatch={lbDispatch}
+              onClose={() => lbDispatch({ type: 'closeModPicker' })}
             />,
             document.body
           )}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -261,7 +261,7 @@ function LoadoutBuilder({
             <ModPicker
               classType={selectedStore.classType}
               lockedArmor2Mods={lockedArmor2Mods}
-              initialCategoryHash={modPicker.initialCategoryHash}
+              initialQuery={modPicker.initialQuery}
               lbDispatch={lbDispatch}
             />,
             document.body

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -33,7 +33,6 @@ import LockedItem from './LockedItem';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { settingsSelector } from 'app/settings/reducer';
 import LockedArmor2ModIcon from './LockedArmor2ModIcon';
-import ModPicker from './ModPicker';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 
 interface ProvidedProps {
@@ -81,7 +80,6 @@ function LockArmorAndPerks({
   lbDispatch,
 }: Props) {
   const [filterPerksOpen, setFilterPerksOpen] = useState(false);
-  const [filterModsOpen, setFilterModsOpen] = useState(false);
 
   /**
    * Lock currently equipped items on a character
@@ -283,19 +281,13 @@ function LockArmorAndPerks({
             </div>
           )}
           <div className={styles.buttons}>
-            <button type="button" className="dim-button" onClick={() => setFilterModsOpen(true)}>
+            <button
+              type="button"
+              className="dim-button"
+              onClick={() => lbDispatch({ type: 'openModPicker' })}
+            >
               <AppIcon icon={addIcon} /> {t('LB.ModLockButton')}
             </button>
-            {filterModsOpen &&
-              ReactDOM.createPortal(
-                <ModPicker
-                  classType={selectedStore.classType}
-                  lockedArmor2Mods={lockedArmor2Mods}
-                  onClose={() => setFilterModsOpen(false)}
-                  lbDispatch={lbDispatch}
-                />,
-                document.body
-              )}
           </div>
         </div>
       )}

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -19,7 +19,7 @@ import {
   isModPickerCategory,
 } from '../types';
 import _ from 'lodash';
-import { isLoadoutBuilderItem } from '../utils';
+import { isLoadoutBuilderItem, Armor2ModPlugCategoriesTitles } from '../utils';
 import copy from 'fast-copy';
 import { createSelector } from 'reselect';
 import { storesSelector, profileResponseSelector, bucketsSelector } from 'app/inventory/selectors';
@@ -35,36 +35,25 @@ import { chainComparator, compareBy } from 'app/utils/comparators';
 import ModPickerHeader from './ModPickerHeader';
 import ModPickerFooter from './ModPickerFooter';
 import { itemsForPlugSet } from 'app/collections/plugset-helpers';
-import { t } from 'app/i18next-t';
 import { SearchFilterRef } from 'app/search/SearchFilterInput';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-
-const Armor2ModPlugCategoriesTitles = {
-  [ModPickerCategories.general]: t('LB.General'),
-  [ModPickerCategories.helmet]: t('LB.Helmet'),
-  [ModPickerCategories.gauntlets]: t('LB.Gauntlets'),
-  [ModPickerCategories.chest]: t('LB.Chest'),
-  [ModPickerCategories.leg]: t('LB.Legs'),
-  [ModPickerCategories.classitem]: t('LB.ClassItem'),
-  [ModPickerCategories.seasonal]: t('LB.Seasonal'),
-};
 
 /** Used for generating the key attribute of the lockedArmor2Mods */
 let modKey = 0;
 
 // to-do: separate mod name from its "enhanced"ness, maybe with d2ai? so they can be grouped better
-export const sortMods = chainComparator<PluggableInventoryItemDefinition>(
-  compareBy((i) => i.plug.energyCost?.energyType),
-  compareBy((i) => i.plug.energyCost?.energyCost),
-  compareBy((i) => i.displayProperties.name)
+const sortMods = chainComparator<LockedArmor2Mod>(
+  compareBy((l) => (l.season ? -l.season : 0)),
+  compareBy((l) => l.mod.plug.energyCost?.energyType),
+  compareBy((l) => l.mod.plug.energyCost?.energyCost),
+  compareBy((l) => l.mod.displayProperties.name)
 );
 
 interface ProvidedProps {
   lockedArmor2Mods: LockedArmor2ModMap;
   classType: DestinyClass;
-  initialCategoryHash?: ModPickerCategory;
+  initialQuery?: string;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }
 
@@ -73,7 +62,7 @@ interface StoreProps {
   isPhonePortrait: boolean;
   defs: D2ManifestDefinitions;
   buckets: InventoryBuckets;
-  mods: PluggableInventoryItemDefinition[];
+  mods: LockedArmor2Mod[];
 }
 
 type Props = ProvidedProps & StoreProps;
@@ -133,14 +122,34 @@ function mapStateToProps() {
           }
         }
 
-        return unlockedPlugs
-          .map((i) => defs.InventoryItem.get(i))
-          .filter(isPluggableItem)
-          .filter((item) => isArmor2Mod(item) && item.plug.insertionMaterialRequirementHash !== 0)
-          .sort(sortMods);
+        const transformedMods: LockedArmor2Mod[] = [];
+
+        for (const plug of unlockedPlugs) {
+          const def = defs.InventoryItem.get(plug);
+
+          if (
+            isPluggableItem(def) &&
+            isArmor2Mod(def) &&
+            def.plug.insertionMaterialRequirementHash !== 0
+          ) {
+            const metadata = getSpecialtySocketMetadataByPlugCategoryHash(
+              def.plug.plugCategoryHash
+            );
+            const category =
+              (isModPickerCategory(def.plug.plugCategoryHash) && def.plug.plugCategoryHash) ||
+              (metadata && ModPickerCategories.seasonal) ||
+              undefined;
+
+            if (category) {
+              transformedMods.push({ mod: def, category, season: metadata?.season });
+            }
+          }
+        }
+
+        return transformedMods.sort(sortMods);
       });
 
-      return _.uniqBy(allMods, (mod) => mod.hash);
+      return _.uniqBy(allMods, (mod) => mod.mod.hash);
     }
   );
 
@@ -162,13 +171,11 @@ function ModPicker({
   language,
   isPhonePortrait,
   lockedArmor2Mods,
-  initialCategoryHash,
+  initialQuery,
   lbDispatch,
 }: Props) {
   const [height, setHeight] = useState<number | undefined>(undefined);
-  const [query, setQuery] = useState(
-    initialCategoryHash ? Armor2ModPlugCategoriesTitles[initialCategoryHash] : ''
-  );
+  const [query, setQuery] = useState(initialQuery || '');
   const [lockedArmor2ModsInternal, setLockedArmor2ModsInternal] = useState(copy(lockedArmor2Mods));
   const filterInput = useRef<SearchFilterRef | null>(null);
   const itemContainer = useRef<HTMLDivElement | null>(null);
@@ -242,9 +249,10 @@ function ModPicker({
     return query.length
       ? mods.filter(
           (mod) =>
-            regexp.test(mod.displayProperties.name) ||
-            regexp.test(mod.displayProperties.description) ||
-            regexp.test(Armor2ModPlugCategoriesTitles[mod.plug.plugCategoryHash])
+            regexp.test(mod.mod.displayProperties.name) ||
+            regexp.test(mod.mod.displayProperties.description) ||
+            (mod.season && regexp.test(mod.season.toString())) ||
+            regexp.test(Armor2ModPlugCategoriesTitles[mod.category])
         )
       : mods;
   }, [language, query, mods]);
@@ -261,14 +269,7 @@ function ModPicker({
     };
 
     for (const mod of queryFilteredMods) {
-      if (getSpecialtySocketMetadataByPlugCategoryHash(mod.plug.plugCategoryHash)) {
-        rtn.seasonal.push({ mod, category: 'seasonal' });
-      } else if (isModPickerCategory(mod.plug.plugCategoryHash)) {
-        rtn[mod.plug.plugCategoryHash].push({
-          mod,
-          category: mod.plug.plugCategoryHash,
-        });
-      }
+      rtn[mod.category].push(mod);
     }
 
     return rtn;

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -64,8 +64,8 @@ export const sortMods = chainComparator<PluggableInventoryItemDefinition>(
 interface ProvidedProps {
   lockedArmor2Mods: LockedArmor2ModMap;
   classType: DestinyClass;
+  initialCategoryHash?: ModPickerCategory;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
-  onClose(): void;
 }
 
 interface StoreProps {
@@ -160,13 +160,15 @@ function ModPicker({
   defs,
   mods,
   language,
-  onClose,
   isPhonePortrait,
   lockedArmor2Mods,
+  initialCategoryHash,
   lbDispatch,
 }: Props) {
   const [height, setHeight] = useState<number | undefined>(undefined);
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(
+    initialCategoryHash ? Armor2ModPlugCategoriesTitles[initialCategoryHash] : ''
+  );
   const [lockedArmor2ModsInternal, setLockedArmor2ModsInternal] = useState(copy(lockedArmor2Mods));
   const filterInput = useRef<SearchFilterRef | null>(null);
   const itemContainer = useRef<HTMLDivElement | null>(null);
@@ -213,13 +215,12 @@ function ModPicker({
     [setLockedArmor2ModsInternal]
   );
 
-  const onSubmit = (e: React.FormEvent | KeyboardEvent, onClose: () => void) => {
+  const onSubmit = (e: React.FormEvent | KeyboardEvent) => {
     e.preventDefault();
     lbDispatch({
       type: 'lockedArmor2ModsChanged',
       lockedArmor2Mods: lockedArmor2ModsInternal,
     });
-    onClose();
   };
 
   const scrollToBucket = (categoryOrSeasonal: number | string) => {
@@ -242,7 +243,8 @@ function ModPicker({
       ? mods.filter(
           (mod) =>
             regexp.test(mod.displayProperties.name) ||
-            regexp.test(mod.displayProperties.description)
+            regexp.test(mod.displayProperties.description) ||
+            regexp.test(Armor2ModPlugCategoriesTitles[mod.plug.plugCategoryHash])
         )
       : mods;
   }, [language, query, mods]);
@@ -276,13 +278,13 @@ function ModPicker({
     category === ModPickerCategories.general || category === ModPickerCategories.seasonal;
 
   const footer = Object.values(lockedArmor2ModsInternal).some((f) => Boolean(f?.length))
-    ? ({ onClose }) => (
+    ? () => (
         <ModPickerFooter
           defs={defs}
           categoryOrder={order}
           lockedArmor2Mods={lockedArmor2ModsInternal}
           isPhonePortrait={isPhonePortrait}
-          onSubmit={(e) => onSubmit(e, onClose)}
+          onSubmit={(e) => onSubmit(e)}
           onModSelected={onModRemoved}
         />
       )
@@ -290,7 +292,7 @@ function ModPicker({
 
   return (
     <Sheet
-      onClose={onClose}
+      onClose={() => lbDispatch({ type: 'closeModPicker' })}
       header={
         <ModPickerHeader
           categoryOrder={order}

--- a/src/app/loadout-builder/filter/ModPickerSection.tsx
+++ b/src/app/loadout-builder/filter/ModPickerSection.tsx
@@ -28,6 +28,9 @@ export default function ModPickerSection({
   onModSelected(mod: LockedArmor2Mod);
   onModRemoved(mod: LockedArmor2Mod);
 }) {
+  if (!mods.length) {
+    return null;
+  }
   const lockedModCost = _.sumBy(locked, (l) => l.mod.plug.energyCost?.energyCost || 0);
   const isNotGeneralOrSeasonal =
     category !== ModPickerCategories.general && category !== ModPickerCategories.seasonal;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -131,7 +131,12 @@ export default function GeneratedSetItem({
       )}
       {$featureFlags.armor2ModPicker && (
         <div className={styles.lockedSockets}>
-          <GeneratedSetSockets item={item} lockedMods={lockedMods} defs={defs} />
+          <GeneratedSetSockets
+            item={item}
+            lockedMods={lockedMods}
+            defs={defs}
+            lbDispatch={lbDispatch}
+          />
         </div>
       )}
     </div>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetMod.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetMod.m.scss
@@ -34,6 +34,7 @@
 }
 
 .perk {
+  cursor: default;
   img {
     border: none;
   }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetMod.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetMod.tsx
@@ -11,7 +11,7 @@ interface Props {
   plugDef: PluggableInventoryItemDefinition;
   defs: D2ManifestDefinitions;
   gridColumn: number;
-  onClick(): void;
+  onClick?(): void;
 }
 
 function GeneratedSetMod({ plugDef, defs, gridColumn, onClick }: Props) {

--- a/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
@@ -14,7 +14,8 @@ import styles from './GeneratedSetSockets.m.scss';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 import { getSpecialtySocketMetadataByPlugCategoryHash } from 'app/utils/item-utils';
-import { Armor2ModPlugCategoriesTitles } from '../utils';
+import { armor2ModPlugCategoriesTitles } from '../utils';
+import { t } from 'app/i18next-t';
 
 const undesireablePlugs = [
   PlugCategoryHashes.ArmorSkinsEmpty,
@@ -96,7 +97,7 @@ function GeneratedSetSockets({ item, lockedMods, defs, lbDispatch }: Props) {
                       initialQuery:
                         category === ModPickerCategories.seasonal
                           ? season?.toString()
-                          : Armor2ModPlugCategoriesTitles[category],
+                          : t(armor2ModPlugCategoriesTitles[category]),
                     })
                 : undefined
             }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
@@ -82,11 +82,14 @@ function GeneratedSetSockets({ item, lockedMods, defs, lbDispatch }: Props) {
             gridColumn={(index % 2) + 1}
             plugDef={plugDef}
             defs={defs}
-            onClick={() =>
-              lbDispatch({
-                type: 'openModPicker',
-                initialCategoryHash: category,
-              })
+            onClick={
+              category
+                ? () =>
+                    lbDispatch({
+                      type: 'openModPicker',
+                      initialCategoryHash: category,
+                    })
+                : undefined
             }
           />
         ))}

--- a/src/app/loadout-builder/loadoutBuilderReducer.ts
+++ b/src/app/loadout-builder/loadoutBuilderReducer.ts
@@ -6,6 +6,7 @@ import {
   MinMaxIgnored,
   LockedItemType,
   ModPickerCategories,
+  ModPickerCategory,
 } from './types';
 import { DimStore } from 'app/inventory/store-types';
 import { getItemAcrossStores, getCurrentStore } from 'app/inventory/stores-helpers';
@@ -20,6 +21,10 @@ export interface LoadoutBuilderState {
   selectedStoreId?: string;
   statFilters: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>;
   minimumPower: number;
+  modPicker: {
+    open: boolean;
+    initialCategoryHash?: ModPickerCategory;
+  };
 }
 
 const lbStateInit = ({
@@ -73,6 +78,9 @@ const lbStateInit = ({
     },
     minimumPower: 750,
     selectedStoreId: selectedStoreId,
+    modPicker: {
+      open: false,
+    },
   };
 };
 
@@ -89,7 +97,9 @@ export type LoadoutBuilderAction =
       lockedMap: LockedMap;
       lockedSeasonalMods: LockedModBase[];
     }
-  | { type: 'lockedArmor2ModsChanged'; lockedArmor2Mods: LockedArmor2ModMap };
+  | { type: 'lockedArmor2ModsChanged'; lockedArmor2Mods: LockedArmor2ModMap }
+  | { type: 'openModPicker'; initialCategoryHash?: ModPickerCategory }
+  | { type: 'closeModPicker' };
 
 // TODO: Move more logic inside the reducer
 function lbStateReducer(
@@ -150,6 +160,13 @@ function lbStateReducer(
       };
     case 'lockedArmor2ModsChanged':
       return { ...state, lockedArmor2Mods: action.lockedArmor2Mods };
+    case 'openModPicker':
+      return {
+        ...state,
+        modPicker: { open: true, initialCategoryHash: action.initialCategoryHash },
+      };
+    case 'closeModPicker':
+      return { ...state, modPicker: { open: false } };
   }
 }
 

--- a/src/app/loadout-builder/loadoutBuilderReducer.ts
+++ b/src/app/loadout-builder/loadoutBuilderReducer.ts
@@ -6,7 +6,6 @@ import {
   MinMaxIgnored,
   LockedItemType,
   ModPickerCategories,
-  ModPickerCategory,
 } from './types';
 import { DimStore } from 'app/inventory/store-types';
 import { getItemAcrossStores, getCurrentStore } from 'app/inventory/stores-helpers';
@@ -23,7 +22,7 @@ export interface LoadoutBuilderState {
   minimumPower: number;
   modPicker: {
     open: boolean;
-    initialCategoryHash?: ModPickerCategory;
+    initialQuery?: string;
   };
 }
 
@@ -98,7 +97,7 @@ export type LoadoutBuilderAction =
       lockedSeasonalMods: LockedModBase[];
     }
   | { type: 'lockedArmor2ModsChanged'; lockedArmor2Mods: LockedArmor2ModMap }
-  | { type: 'openModPicker'; initialCategoryHash?: ModPickerCategory }
+  | { type: 'openModPicker'; initialQuery?: string }
   | { type: 'closeModPicker' };
 
 // TODO: Move more logic inside the reducer
@@ -163,7 +162,7 @@ function lbStateReducer(
     case 'openModPicker':
       return {
         ...state,
-        modPicker: { open: true, initialCategoryHash: action.initialCategoryHash },
+        modPicker: { open: true, initialQuery: action.initialQuery },
       };
     case 'closeModPicker':
       return { ...state, modPicker: { open: false } };

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -100,6 +100,7 @@ export interface LockedArmor2Mod {
   key?: number;
   mod: PluggableInventoryItemDefinition;
   category: ModPickerCategory;
+  season?: number;
 }
 
 export type LockedArmor2ModMap = {

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -6,7 +6,14 @@ import {
   DimSocket,
   PluggableInventoryItemDefinition,
 } from 'app/inventory/item-types';
-import { statValues, LockedItemType, LockedMod, LockedArmor2Mod, StatTypes } from './types';
+import {
+  statValues,
+  LockedItemType,
+  LockedMod,
+  LockedArmor2Mod,
+  StatTypes,
+  ModPickerCategories,
+} from './types';
 import {
   DestinyInventoryItemDefinition,
   TierType,
@@ -16,6 +23,7 @@ import {
 import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
 import { MODIFICATIONS_BUCKET } from 'app/search/d2-known-values';
 import { ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
+import { t } from 'app/i18next-t';
 
 /**
  * Plug item hashes that should be excluded from the list of selectable perks.
@@ -401,3 +409,13 @@ export function someModHasEnergyRequirement(
 ) {
   return mods.some((mod) => mod.mod.plug.energyCost!.energyType !== DestinyEnergyType.Any);
 }
+
+export const Armor2ModPlugCategoriesTitles = {
+  [ModPickerCategories.general]: t('LB.General'),
+  [ModPickerCategories.helmet]: t('LB.Helmet'),
+  [ModPickerCategories.gauntlets]: t('LB.Gauntlets'),
+  [ModPickerCategories.chest]: t('LB.Chest'),
+  [ModPickerCategories.leg]: t('LB.Legs'),
+  [ModPickerCategories.classitem]: t('LB.ClassItem'),
+  [ModPickerCategories.seasonal]: t('LB.Seasonal'),
+};

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -23,7 +23,7 @@ import {
 import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
 import { MODIFICATIONS_BUCKET } from 'app/search/d2-known-values';
 import { ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
-import { t } from 'app/i18next-t';
+import { tl } from 'app/i18next-t';
 
 /**
  * Plug item hashes that should be excluded from the list of selectable perks.
@@ -410,12 +410,12 @@ export function someModHasEnergyRequirement(
   return mods.some((mod) => mod.mod.plug.energyCost!.energyType !== DestinyEnergyType.Any);
 }
 
-export const Armor2ModPlugCategoriesTitles = {
-  [ModPickerCategories.general]: t('LB.General'),
-  [ModPickerCategories.helmet]: t('LB.Helmet'),
-  [ModPickerCategories.gauntlets]: t('LB.Gauntlets'),
-  [ModPickerCategories.chest]: t('LB.Chest'),
-  [ModPickerCategories.leg]: t('LB.Legs'),
-  [ModPickerCategories.classitem]: t('LB.ClassItem'),
-  [ModPickerCategories.seasonal]: t('LB.Seasonal'),
+export const armor2ModPlugCategoriesTitles = {
+  [ModPickerCategories.general]: tl('LB.General'),
+  [ModPickerCategories.helmet]: tl('LB.Helmet'),
+  [ModPickerCategories.gauntlets]: tl('LB.Gauntlets'),
+  [ModPickerCategories.chest]: tl('LB.Chest'),
+  [ModPickerCategories.leg]: tl('LB.Legs'),
+  [ModPickerCategories.classitem]: tl('LB.ClassItem'),
+  [ModPickerCategories.seasonal]: tl('LB.Seasonal'),
 };


### PR DESCRIPTION
- Allows clicking on the mods/sockets in the optimiser sets to open the mod picker. 
- Filtering is done by section name (so we can keep searches localised) or season number.
- I also sorted seasonal mods by descending season, this only has an effect of seasonal mods in the unfiltered picker.

![image](https://user-images.githubusercontent.com/7344652/91167868-fb9f3300-e717-11ea-97d7-097fca8a5f27.png)

![image](https://user-images.githubusercontent.com/7344652/91167786-e2968200-e717-11ea-8619-93b5f4a5b015.png)

![image](https://user-images.githubusercontent.com/7344652/91167296-11f8bf00-e717-11ea-8e0d-98c82cd335fd.png)
