### PR TITLE
Fix width of sidebar on pages with menus

### DIFF
--- a/src/app/dim-ui/CharacterSelect.m.scss
+++ b/src/app/dim-ui/CharacterSelect.m.scss
@@ -37,7 +37,7 @@
 
 .tile {
   height: 46px;
-  min-width: 230px;
+  width: 100%;
   @include phone-portrait {
     min-width: 260px;
     margin-bottom: 6px;

--- a/src/app/dim-ui/PageWithMenu.m.scss
+++ b/src/app/dim-ui/PageWithMenu.m.scss
@@ -37,7 +37,8 @@
 .menu {
   font-size: 14px;
   flex-shrink: 0;
-  margin-right: 16px;
+  margin-right: 12px;
+  padding-right: 4px;
   margin-top: 8px;
   position: sticky;
   top: 52px;

--- a/src/app/vendors/Vendors.m.scss
+++ b/src/app/vendors/Vendors.m.scss
@@ -2,11 +2,13 @@
 
 // TODO: Move to common button library!
 .checkButton {
-  width: 230px;
+  width: 100%;
   margin-top: 8px;
   @include phone-portrait {
     display: block;
-    margin: 8px auto 0 auto;
+    width: auto;
+    margin: 8px calc(var(--inventory-column-padding) - var(--item-margin)) 0
+      var(--inventory-column-padding);
   }
 
   box-sizing: border-box;


### PR DESCRIPTION
|scroll | no-scroll| mobile |
|---|---|---|
| <img width="953" alt="Screen Shot 2020-08-25 at 7 30 00 PM" src="https://user-images.githubusercontent.com/424158/91248470-96444580-e709-11ea-9e18-55c66df398ce.png"> | <img width="953" alt="Screen Shot 2020-08-25 at 7 30 11 PM" src="https://user-images.githubusercontent.com/424158/91248481-9e03ea00-e709-11ea-87e3-61f86b64d787.png"> | <img width="498" alt="Screen Shot 2020-08-25 at 7 35 00 PM" src="https://user-images.githubusercontent.com/424158/91248766-46b24980-e70a-11ea-8c9d-402eec54b83d.png"> |