### PR TITLE
Show stats in the loadout sheet

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -604,6 +604,7 @@
     "AppliedError": "None of the items in your loadout could be transferred.",
     "AppliedWarn": "Your loadout has been partially transferred, but {{failed}} of {{total}} items had errors.",
     "ApplySearch": "Transfer search \"{{query}}\"",
+    "AssumeMaxWeapons": "Assuming max power level weapons",
     "Before": "Before '{{name}}'",
     "ChooseItem": "Add {{name}}",
     "Classified": "Some of your items are classified, and cannot be included in the max power calculation.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Add character stats to loadout sheet if full armor set is added.
+
 ## 6.26.0 <span className="changelog-date">(2020-08-23)</span>
 
 * Better touchscreen support for drag and drop.

--- a/src/app/destiny1/loadout-builder/GeneratedSet.tsx
+++ b/src/app/destiny1/loadout-builder/GeneratedSet.tsx
@@ -7,7 +7,7 @@ import { DimStore } from '../../inventory/store-types';
 import { t } from 'app/i18next-t';
 import LoadoutBuilderItem from './LoadoutBuilderItem';
 import { AppIcon, faMinusSquare, faPlusSquare } from '../../shell/icons';
-import CharacterStats from '../../store-stats/CharacterStats';
+import D1CharacterStats from 'app/store-stats/D1CharacterStats';
 import ItemTalentGrid from '../../item-popup/ItemTalentGrid';
 import { newLoadout, convertToLoadoutItem } from '../../loadout/loadout-utils';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
@@ -49,7 +49,7 @@ export default class GeneratedSet extends React.Component<Props, State> {
             </>
           )}{' '}
           <div className="dim-stats">
-            <CharacterStats destinyVersion={1} stats={setType.tiers[activesets].stats} />
+            <D1CharacterStats stats={setType.tiers[activesets].stats} />
           </div>
         </div>
         <div className="loadout-builder-section">

--- a/src/app/loadout/GeneratedLoadoutStats.tsx
+++ b/src/app/loadout/GeneratedLoadoutStats.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { t } from 'app/i18next-t';
+import _ from 'lodash';
+import { D1ManifestDefinitions } from '../destiny1/d1-definitions';
+import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
+import { SEASONAL_ARTIFACT_BUCKET } from 'app/search/d2-known-values';
+import AppIcon from 'app/shell/icons/AppIcon';
+import FractionalPowerLevel from 'app/dim-ui/FractionalPowerLevel';
+import PressTip from 'app/dim-ui/PressTip';
+import type { DimItem } from '../inventory/item-types';
+import type { InventoryBuckets } from '../inventory/inventory-buckets';
+import type { DimStore } from '../inventory/store-types';
+import type { Loadout } from './loadout-types';
+import { LoadoutStats } from 'app/store-stats/CharacterStats';
+import { getArmorStats, getLight } from './loadout-utils';
+import { powerActionIcon } from 'app/shell/icons';
+import { getArtifactBonus } from 'app/inventory/stores-helpers';
+import { maxLightItemSet } from './auto-loadouts';
+
+function getItemsInListByCategory({
+  buckets,
+  category,
+  items,
+}: {
+  buckets: InventoryBuckets;
+  category: string;
+  items: DimItem[];
+}) {
+  const itemSet: DimItem[] = [];
+  const categoryBuckets = buckets.byCategory[category];
+  const missingBuckets = categoryBuckets.filter((bucket) => {
+    if (bucket.hash === SEASONAL_ARTIFACT_BUCKET) {
+      return;
+    }
+    const item = items.find((item) => bucket.type === item.type);
+    if (item) {
+      if (!item.stats) {
+        return;
+      }
+      itemSet.push(item);
+    }
+
+    return !item;
+  });
+
+  if (missingBuckets.length) {
+    console.log('some missing items', missingBuckets);
+  }
+
+  return { itemSet, missingBuckets };
+}
+
+export function GeneratedLoadoutStats({
+  defs,
+  stores,
+  buckets,
+  items,
+  loadout,
+}: {
+  defs: D1ManifestDefinitions | D2ManifestDefinitions;
+  stores: DimStore[];
+  buckets: InventoryBuckets;
+  items: DimItem[];
+  loadout: Loadout;
+}) {
+  const armorItems = getItemsInListByCategory({ buckets, category: 'Armor', items });
+  const weaponItems = getItemsInListByCategory({ buckets, category: 'Weapons', items });
+  if (weaponItems.missingBuckets) {
+    const subclass = stores.find((store) => store.classType === loadout.classType) ?? stores[0];
+    const maxWeapons: DimItem[] = weaponItems.missingBuckets
+      .map((bucket) => items.find((item) => bucket.type === item.type)!)
+      .flat(0);
+    weaponItems.itemSet.concat(maxWeapons);
+    maxLightItemSet(stores, subclass).unrestricted;
+  }
+
+  if (armorItems.missingBuckets.length) {
+    console.log('missing armor items', armorItems.missingBuckets);
+    return null;
+  }
+
+  const stats = getArmorStats(defs, armorItems.itemSet);
+  const power =
+    getLight(stores[0], weaponItems.itemSet.concat(armorItems.itemSet)) +
+    getArtifactBonus(stores[0]);
+
+  return (
+    <div className="stat-bars destiny2">
+      <div className="power">
+        <PressTip
+          tooltip={weaponItems.missingBuckets.length ? () => t('Assuming max weapons') : null}
+        >
+          <>
+            <AppIcon icon={powerActionIcon} />
+            <FractionalPowerLevel power={power} />
+            {weaponItems.missingBuckets.length ? '*' : null}
+          </>
+        </PressTip>
+      </div>
+      <LoadoutStats stats={stats} />
+    </div>
+  );
+}

--- a/src/app/loadout/GeneratedLoadoutStats.tsx
+++ b/src/app/loadout/GeneratedLoadoutStats.tsx
@@ -43,10 +43,6 @@ function getItemsInListByCategory({
     return !item;
   });
 
-  if (missingBuckets.length) {
-    console.log('some missing items', missingBuckets);
-  }
-
   return { itemSet, missingBuckets };
 }
 
@@ -75,7 +71,6 @@ export function GeneratedLoadoutStats({
   }
 
   if (armorItems.missingBuckets.length) {
-    console.log('missing armor items', armorItems.missingBuckets);
     return null;
   }
 

--- a/src/app/loadout/GeneratedLoadoutStats.tsx
+++ b/src/app/loadout/GeneratedLoadoutStats.tsx
@@ -64,15 +64,13 @@ export function GeneratedLoadoutStats({
     return null;
   }
 
-  // Get items in current loadout per category
   const armorItems = getItemsInListByCategory({ buckets, category: 'Armor', items });
-  const weaponItems = getItemsInListByCategory({ buckets, category: 'Weapons', items });
-
   if (armorItems.missingBuckets.length) {
     // If any armor types are missing, don't compute stats or power levels.
     return null;
   }
 
+  const weaponItems = getItemsInListByCategory({ buckets, category: 'Weapons', items });
   if (weaponItems.missingBuckets) {
     // If any weapon types are missing, fill them in with max weapons to assume light level
     const subclass = stores.find((store) => store.classType === loadout.classType) ?? stores[0];
@@ -94,9 +92,7 @@ export function GeneratedLoadoutStats({
   return (
     <div className="stat-bars destiny2">
       <div className="power">
-        <PressTip
-          tooltip={weaponItems.missingBuckets.length ? () => t('Loadouts.AssumeMaxWeapons') : null}
-        >
+        <PressTip tooltip={weaponItems.missingBuckets.length && t('Loadouts.AssumeMaxWeapons')}>
           <>
             <AppIcon icon={powerActionIcon} />
             <FractionalPowerLevel power={power} />

--- a/src/app/loadout/GeneratedLoadoutStats.tsx
+++ b/src/app/loadout/GeneratedLoadoutStats.tsx
@@ -59,6 +59,10 @@ export function GeneratedLoadoutStats({
   items: DimItem[];
   loadout: Loadout;
 }) {
+  if (defs.isDestiny1()) {
+    // just D2, for now
+    return null;
+  }
   const armorItems = getItemsInListByCategory({ buckets, category: 'Armor', items });
   const weaponItems = getItemsInListByCategory({ buckets, category: 'Weapons', items });
   if (weaponItems.missingBuckets) {

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -32,6 +32,7 @@ import { useLocation } from 'react-router';
 import { emptyArray } from 'app/utils/empty';
 import { loadoutsSelector } from './reducer';
 import { updateLoadout } from './actions';
+import { GeneratedLoadoutStats } from './GeneratedLoadoutStats';
 
 // TODO: Consider moving editLoadout/addItemToLoadout/loadoutDialogOpen into Redux (actions + state)
 
@@ -551,6 +552,13 @@ function LoadoutDrawer({
         saveLoadout={onSaveLoadout}
         saveAsNew={saveAsNew}
         clashingLoadout={clashingLoadout}
+      />
+      <GeneratedLoadoutStats
+        defs={defs}
+        stores={stores}
+        buckets={buckets}
+        items={items}
+        loadout={loadout}
       />
     </div>
   );

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -20,6 +20,7 @@
 
 .loadout-drawer-header {
   .stat-bars.destiny2 {
+    cursor: default;
     max-width: 280px;
     flex-direction: row;
     opacity: 1;

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -18,6 +18,27 @@
   }
 }
 
+.loadout-drawer-header {
+  .stat-bars.destiny2 {
+    max-width: 280px;
+    flex-direction: row;
+    opacity: 1;
+  }
+  .power {
+    color: $gold;
+    flex: inherit;
+    margin-right: 20px;
+    svg {
+      vertical-align: top;
+      margin-top: 4px;
+      font-size: 0.5em;
+    }
+  }
+  .stat-row {
+    justify-content: space-between;
+  }
+}
+
 .loadout-equip-help {
   border: 1px solid #333;
   background-color: #f00;

--- a/src/app/store-stats/CharacterStats.scss
+++ b/src/app/store-stats/CharacterStats.scss
@@ -68,7 +68,8 @@
       flex-direction: row;
       justify-items: left;
       align-items: center;
-      &:first-child {
+      &.powerFormula {
+        margin-bottom: 3px;
         img {
           opacity: 0.6;
           height: 17px;
@@ -101,7 +102,6 @@
         }
       }
       &:nth-child(n + 2) {
-        margin-top: 3px;
         justify-content: space-between;
       }
     }

--- a/src/app/store-stats/CharacterStats.tsx
+++ b/src/app/store-stats/CharacterStats.tsx
@@ -66,7 +66,7 @@ function CharacterStat({ stats, storeId, className }: CharacterStatProps) {
   );
 }
 
-export const PowerFormula = React.memo(function ({ stats, storeId }: Props) {
+export function PowerFormula({ stats, storeId }: Props) {
   const powerTooltip = (stat: DimCharacterStat): React.ReactNode => (
     <>
       {`${stat.name}${stat.hasClassified ? `\n\n${t('Loadouts.Classified')}` : ''}`}
@@ -92,9 +92,9 @@ export const PowerFormula = React.memo(function ({ stats, storeId }: Props) {
   );
 
   return <CharacterStat stats={statInfos} storeId={storeId} className="powerFormula" />;
-});
+}
 
-export const LoadoutStats = React.memo(function ({ stats, storeId }: Props) {
+export function LoadoutStats({ stats, storeId }: Props) {
   const statTooltip = (stat: DimCharacterStat): React.ReactNode =>
     `${stat.name}: ${stat.value}\n${stat.description}`;
 
@@ -103,4 +103,4 @@ export const LoadoutStats = React.memo(function ({ stats, storeId }: Props) {
     .map((stat) => ({ stat, tooltip: statTooltip(stat) }));
 
   return <CharacterStat stats={statInfos} storeId={storeId} />;
-});
+}

--- a/src/app/store-stats/CharacterStats.tsx
+++ b/src/app/store-stats/CharacterStats.tsx
@@ -2,161 +2,105 @@ import React from 'react';
 import clsx from 'clsx';
 import _ from 'lodash';
 import { t } from 'app/i18next-t';
-import type { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import type { DimCharacterStat, DimStore } from 'app/inventory/store-types';
 import FractionalPowerLevel from 'app/dim-ui/FractionalPowerLevel';
 import PressTip from 'app/dim-ui/PressTip';
-import { percent } from 'app/shell/filters';
 import { showGearPower } from 'app/gear-power/gear-power';
 import { armorStats } from 'app/inventory/store/stats';
-import { getD1CharacterStatTiers, statsWithTiers } from 'app/inventory/store/character-utils';
 import './CharacterStats.scss';
 
 interface Props {
-  stats?: DimStore['stats'];
-  destinyVersion: DestinyVersion;
+  stats: DimStore['stats'];
   storeId?: string;
 }
 
-function CharacterStat({ stat }: { stat: DimCharacterStat }) {
+interface CharacterStatProps {
+  stats: {
+    stat: DimCharacterStat;
+    tooltip: React.ReactNode;
+  }[];
+  storeId?: string;
+  className?: string;
+}
+
+function CharacterStat({ stats, storeId, className }: CharacterStatProps) {
   return (
-    <>
-      <img src={stat.icon} alt={stat.name} />
-      <div>
-        {stat.hash < 0 ? (
-          <span className="powerStat">
-            <FractionalPowerLevel power={stat.value} />
-          </span>
-        ) : (
-          stat.value
-        )}
-        {(stat.hasClassified || stat.differentEquippableMaxGearPower) && (
-          <sup className="asterisk">*</sup>
-        )}
-      </div>
-    </>
+    <div className={clsx('stat-row', className)}>
+      {stats.map(({ stat, tooltip }) => {
+        // if this is the "max gear power" stat (hash -3),
+        // add in an onClick and an extra class
+        const isMaxGearPower = stat.hash === -3 && storeId;
+
+        return (
+          <PressTip key={stat.hash} tooltip={tooltip} allowClickThrough={true}>
+            <div
+              className={clsx('stat', { pointerCursor: isMaxGearPower })}
+              aria-label={`${stat.name} ${stat.value}`}
+              role={isMaxGearPower ? 'button' : 'group'}
+              onClick={
+                isMaxGearPower
+                  ? () => {
+                      showGearPower(storeId!);
+                    }
+                  : undefined
+              }
+            >
+              <img src={stat.icon} alt={stat.name} />
+              <div>
+                {stat.hash < 0 ? (
+                  <span className="powerStat">
+                    <FractionalPowerLevel power={stat.value} />
+                  </span>
+                ) : (
+                  stat.value
+                )}
+                {(stat.hasClassified || stat.differentEquippableMaxGearPower) && (
+                  <sup className="asterisk">*</sup>
+                )}
+              </div>
+            </div>
+          </PressTip>
+        );
+      })}
+    </div>
   );
 }
 
-/**
- * Render the character information: Max Power/Stat points.
- * May want to consider splitting D1 from D2 at some point.
- */
-function CharacterStats({ stats, destinyVersion, storeId }: Props) {
-  if (!stats) {
-    return null;
-  }
+export const PowerFormula = React.memo(function ({ stats, storeId }: Props) {
+  const powerTooltip = (stat: DimCharacterStat): React.ReactNode => (
+    <>
+      {`${stat.name}${stat.hasClassified ? `\n\n${t('Loadouts.Classified')}` : ''}`}
+      {stat.richTooltip && (
+        <>
+          <hr />
+          <div className="richTooltipWrapper">
+            {stat.richTooltip}
+            {stat.differentEquippableMaxGearPower && (
+              <div className="tooltipFootnote">* {t('General.ClickForDetails')}</div>
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
 
-  if (destinyVersion === 1) {
-    const statList = statsWithTiers.map((h) => stats[h]);
-    const tooltips = statList.map((stat) => {
-      if (stat) {
-        const tier = Math.floor(Math.min(300, stat.value) / 60);
-        // t('Stats.TierProgress_Max')
-        const next = t('Stats.TierProgress', {
-          context: tier === 5 ? 'Max' : '',
-          progress: tier === 5 ? stat.value : stat.value % 60,
-          tier,
-          nextTier: tier + 1,
-          statName: stat.name,
-        });
-        let cooldown = stat.cooldown || '';
-        if (cooldown) {
-          cooldown = t(`Cooldown.${stat.effect}`, { cooldown });
-          // t('Cooldown.Grenade')
-          // t('Cooldown.Melee')
-          // t('Cooldown.Super')
-        }
-        return next + cooldown;
-      }
-    });
-
-    return (
-      <div className="stat-bars">
-        {statList.map((stat, index) => (
-          <PressTip key={stat.hash} tooltip={tooltips[index]}>
-            <div className="stat">
-              <img src={stat.icon} alt={stat.name} />
-              {getD1CharacterStatTiers(stat).map((n, index) => (
-                <div key={index} className="bar">
-                  <div
-                    className={clsx('progress', {
-                      complete: n / 60 === 1,
-                    })}
-                    style={{ width: percent(n / 60) }}
-                  />
-                </div>
-              ))}
-            </div>
-          </PressTip>
-        ))}
-      </div>
-    );
-  } else {
-    const powerTooltip = (stat: DimCharacterStat): React.ReactNode => (
-      <>
-        {`${stat.name}${stat.hasClassified ? `\n\n${t('Loadouts.Classified')}` : ''}`}
-        {stat.richTooltip && (
-          <>
-            <hr />
-            <div className="richTooltipWrapper">
-              {stat.richTooltip}
-              {stat.differentEquippableMaxGearPower && (
-                <div className="tooltipFootnote">* {t('General.ClickForDetails')}</div>
-              )}
-            </div>
-          </>
-        )}
-      </>
-    );
-    const powerInfos: {
-      stat: DimCharacterStat;
-      tooltip: React.ReactNode;
-    }[] = _.compact([stats.maxTotalPower, stats.maxGearPower, stats.powerModifier]).map((stat) => ({
+  const statInfos = _.compact([stats.maxTotalPower, stats.maxGearPower, stats.powerModifier]).map(
+    (stat) => ({
       stat,
       tooltip: powerTooltip(stat),
-    }));
+    })
+  );
 
-    const statTooltip = (stat: DimCharacterStat): React.ReactNode =>
-      `${stat.name}: ${stat.value}\n${stat.description}`;
-    const statInfos: {
-      stat: DimCharacterStat;
-      tooltip: React.ReactNode;
-    }[] = armorStats.map((h) => stats[h]).map((stat) => ({ stat, tooltip: statTooltip(stat) }));
+  return <CharacterStat stats={statInfos} storeId={storeId} className="powerFormula" />;
+});
 
-    return (
-      <div className="stat-bars destiny2">
-        {[powerInfos, statInfos].map((stats, index) => (
-          <div key={index} className="stat-row">
-            {stats.map(({ stat, tooltip }) => {
-              // if this is the "max gear power" stat (hash -3),
-              // add in an onClick and an extra class
-              const isMaxGearPower = stat.hash === -3 && storeId;
+export const LoadoutStats = React.memo(function ({ stats, storeId }: Props) {
+  const statTooltip = (stat: DimCharacterStat): React.ReactNode =>
+    `${stat.name}: ${stat.value}\n${stat.description}`;
 
-              return (
-                <PressTip key={stat.hash} tooltip={tooltip} allowClickThrough={true}>
-                  <div
-                    className={clsx('stat', { pointerCursor: isMaxGearPower })}
-                    aria-label={`${stat.name} ${stat.value}`}
-                    role={isMaxGearPower ? 'button' : 'group'}
-                    onClick={
-                      isMaxGearPower
-                        ? () => {
-                            showGearPower(storeId!);
-                          }
-                        : undefined
-                    }
-                  >
-                    <CharacterStat stat={stat} />
-                  </div>
-                </PressTip>
-              );
-            })}
-          </div>
-        ))}
-      </div>
-    );
-  }
-}
+  const statInfos = armorStats
+    .map((h) => stats[h])
+    .map((stat) => ({ stat, tooltip: statTooltip(stat) }));
 
-export default React.memo(CharacterStats);
+  return <CharacterStat stats={statInfos} storeId={storeId} />;
+});

--- a/src/app/store-stats/D1CharacterStats.tsx
+++ b/src/app/store-stats/D1CharacterStats.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import clsx from 'clsx';
+import _ from 'lodash';
+import { t } from 'app/i18next-t';
+import type { DimStore } from 'app/inventory/store-types';
+import PressTip from 'app/dim-ui/PressTip';
+import { percent } from 'app/shell/filters';
+import { getD1CharacterStatTiers, statsWithTiers } from 'app/inventory/store/character-utils';
+import './CharacterStats.scss';
+
+interface Props {
+  stats: DimStore['stats'];
+}
+
+function D1CharacterStats({ stats }: Props) {
+  const statList = statsWithTiers.map((h) => stats[h]);
+  const tooltips = statList.map((stat) => {
+    if (stat) {
+      const tier = Math.floor(Math.min(300, stat.value) / 60);
+      // t('Stats.TierProgress_Max')
+      const next = t('Stats.TierProgress', {
+        context: tier === 5 ? 'Max' : '',
+        progress: tier === 5 ? stat.value : stat.value % 60,
+        tier,
+        nextTier: tier + 1,
+        statName: stat.name,
+      });
+      let cooldown = stat.cooldown || '';
+      if (cooldown) {
+        cooldown = t(`Cooldown.${stat.effect}`, { cooldown });
+        // t('Cooldown.Grenade')
+        // t('Cooldown.Melee')
+        // t('Cooldown.Super')
+      }
+      return next + cooldown;
+    }
+  });
+
+  return (
+    <div className="stat-bars">
+      {statList.map((stat, index) => (
+        <PressTip key={stat.hash} tooltip={tooltips[index]}>
+          <div className="stat">
+            <img src={stat.icon} alt={stat.name} />
+            {getD1CharacterStatTiers(stat).map((n, index) => (
+              <div key={index} className="bar">
+                <div
+                  className={clsx('progress', {
+                    complete: n / 60 === 1,
+                  })}
+                  style={{ width: percent(n / 60) }}
+                />
+              </div>
+            ))}
+          </div>
+        </PressTip>
+      ))}
+    </div>
+  );
+}
+
+export default React.memo(D1CharacterStats);

--- a/src/app/store-stats/D1CharacterStats.tsx
+++ b/src/app/store-stats/D1CharacterStats.tsx
@@ -12,7 +12,7 @@ interface Props {
   stats: DimStore['stats'];
 }
 
-function D1CharacterStats({ stats }: Props) {
+export default function D1CharacterStats({ stats }: Props) {
   const statList = statsWithTiers.map((h) => stats[h]);
   const tooltips = statList.map((stat) => {
     if (stat) {
@@ -58,5 +58,3 @@ function D1CharacterStats({ stats }: Props) {
     </div>
   );
 }
-
-export default React.memo(D1CharacterStats);

--- a/src/app/store-stats/StoreStats.tsx
+++ b/src/app/store-stats/StoreStats.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import clsx from 'clsx';
 import type { DimStore, DimVault } from 'app/inventory/store-types';
-import CharacterStats from '../store-stats/CharacterStats';
+import { PowerFormula, LoadoutStats } from '../store-stats/CharacterStats';
+import D1CharacterStats from './D1CharacterStats';
 import AccountCurrencies from './AccountCurrencies';
 import VaultCapacity from './VaultCapacity';
 import styles from './StoreStats.m.scss';
@@ -35,12 +36,13 @@ export default function StoreStats({
           <AccountCurrencies store={store} />
           {shouldShowCapacity(isPhonePortrait) && <VaultCapacity store={store} />}
         </div>
+      ) : store.destinyVersion === 1 ? (
+        <D1CharacterStats stats={store.stats} />
       ) : (
-        <CharacterStats
-          destinyVersion={store.destinyVersion}
-          stats={store.stats}
-          storeId={store.id}
-        />
+        <div className="stat-bars destiny2">
+          <PowerFormula stats={store.stats} storeId={store.id} />
+          <LoadoutStats stats={store.stats} storeId={store.id} />
+        </div>
       )}
     </div>
   );

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -594,6 +594,7 @@
     "AppliedError": "None of the items in your loadout could be transferred.",
     "AppliedWarn": "Your loadout has been partially transferred, but {{failed}} of {{total}} items had errors.",
     "ApplySearch": "Transfer search \"{{query}}\"",
+    "AssumeMaxWeapons": "Assuming max power level weapons",
     "Before": "Before '{{name}}'",
     "ChooseItem": "Add {{name}}",
     "Classified": "Some of your items are classified, and cannot be included in the max power calculation.",


### PR DESCRIPTION
This works by summing the stat totals together in the loadout. The power level is computed using the armor + weapons. if any armor is hidden, all stats are hidden. If any weapons are missing, we look at the max loadout and fill in any missing weapons and update the tooltip to let them know that's the max power. 

This PR also splits up the character stats component.

| | |
|---|---|
|armor + weapons|<img width="761" alt="Screen Shot 2020-08-26 at 12 15 53 PM" src="https://user-images.githubusercontent.com/424158/91346918-63945e80-e796-11ea-972d-bfd8bca5228f.png">|
|armor + no weapons |<img width="772" alt="Screen Shot 2020-08-26 at 12 16 25 PM" src="https://user-images.githubusercontent.com/424158/91347015-86267780-e796-11ea-92f6-894d943b0b19.png">|
|missing armor|<img width="657" alt="Screen Shot 2020-08-26 at 12 16 43 PM" src="https://user-images.githubusercontent.com/424158/91347073-99394780-e796-11ea-87c3-f2724ef1dc85.png">|