### PR TITLE
Feature/clicking perk opens perk picker

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -31,6 +31,7 @@ import { settingsSelector } from 'app/settings/reducer';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import ModPicker from './filter/ModPicker';
 import ReactDOM from 'react-dom';
+import PerkPicker from './filter/PerkPicker';
 
 interface ProvidedProps {
   account: DestinyAccount;
@@ -122,7 +123,15 @@ function LoadoutBuilder({
   preloadedLoadout,
 }: Props) {
   const [
-    { lockedMap, lockedSeasonalMods, lockedArmor2Mods, selectedStoreId, statFilters, modPicker },
+    {
+      lockedMap,
+      lockedSeasonalMods,
+      lockedArmor2Mods,
+      selectedStoreId,
+      statFilters,
+      modPicker,
+      perkPickerOpen,
+    },
     lbDispatch,
   ] = useLbState(stores, preloadedLoadout);
 
@@ -191,7 +200,6 @@ function LoadoutBuilder({
       />
 
       <LockArmorAndPerks
-        items={filteredItems}
         selectedStore={selectedStore}
         lockedMap={lockedMap}
         lockedSeasonalMods={lockedSeasonalMods}
@@ -264,6 +272,18 @@ function LoadoutBuilder({
               initialQuery={modPicker.initialQuery}
               lbDispatch={lbDispatch}
               onClose={() => lbDispatch({ type: 'closeModPicker' })}
+            />,
+            document.body
+          )}
+        {perkPickerOpen &&
+          ReactDOM.createPortal(
+            <PerkPicker
+              classType={selectedStore.classType}
+              items={filteredItems}
+              lockedMap={lockedMap}
+              lockedSeasonalMods={lockedSeasonalMods}
+              onClose={() => lbDispatch({ type: 'closePerkPicker' })}
+              lbDispatch={lbDispatch}
             />,
             document.body
           )}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -130,7 +130,7 @@ function LoadoutBuilder({
       selectedStoreId,
       statFilters,
       modPicker,
-      perkPickerOpen,
+      perkPicker,
     },
     lbDispatch,
   ] = useLbState(stores, preloadedLoadout);
@@ -275,13 +275,14 @@ function LoadoutBuilder({
             />,
             document.body
           )}
-        {perkPickerOpen &&
+        {perkPicker.open &&
           ReactDOM.createPortal(
             <PerkPicker
               classType={selectedStore.classType}
               items={filteredItems}
               lockedMap={lockedMap}
               lockedSeasonalMods={lockedSeasonalMods}
+              initialQuery={perkPicker.initialQuery}
               onClose={() => lbDispatch({ type: 'closePerkPicker' })}
               lbDispatch={lbDispatch}
             />,

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Dispatch } from 'react';
+import React, { Dispatch } from 'react';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import { isLoadoutBuilderItem, addLockedItem, removeLockedItem } from '../utils';
@@ -8,7 +8,6 @@ import {
   LockedExclude,
   LockedBurn,
   LockedItemCase,
-  ItemsByBucket,
   LockedPerk,
   LockedMap,
   LockedMod,
@@ -26,8 +25,6 @@ import { DimStore } from 'app/inventory/store-types';
 import { AppIcon, addIcon, faTimesCircle } from 'app/shell/icons';
 import LoadoutBucketDropTarget from '../locked-armor/LoadoutBucketDropTarget';
 import { showItemPicker } from 'app/item-picker/item-picker';
-import PerkPicker from './PerkPicker';
-import ReactDOM from 'react-dom';
 import styles from './LockArmorAndPerks.m.scss';
 import LockedItem from './LockedItem';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
@@ -37,7 +34,6 @@ import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 
 interface ProvidedProps {
   selectedStore: DimStore;
-  items: ItemsByBucket;
   lockedMap: LockedMap;
   lockedSeasonalMods: LockedModBase[];
   lockedArmor2Mods: LockedArmor2ModMap;
@@ -73,14 +69,11 @@ function LockArmorAndPerks({
   lockedMap,
   lockedSeasonalMods,
   lockedArmor2Mods,
-  items,
   buckets,
   stores,
   isPhonePortrait,
   lbDispatch,
 }: Props) {
-  const [filterPerksOpen, setFilterPerksOpen] = useState(false);
-
   /**
    * Lock currently equipped items on a character
    * Recomputes matched sets
@@ -249,21 +242,13 @@ function LockArmorAndPerks({
           </div>
         )}
         <div className={styles.buttons}>
-          <button type="button" className="dim-button" onClick={() => setFilterPerksOpen(true)}>
+          <button
+            type="button"
+            className="dim-button"
+            onClick={() => lbDispatch({ type: 'openPerkPicker' })}
+          >
             <AppIcon icon={addIcon} /> {t('LoadoutBuilder.LockPerk')}
           </button>
-          {filterPerksOpen &&
-            ReactDOM.createPortal(
-              <PerkPicker
-                classType={selectedStore.classType}
-                items={items}
-                lockedMap={lockedMap}
-                lockedSeasonalMods={lockedSeasonalMods}
-                onClose={() => setFilterPerksOpen(false)}
-                lbDispatch={lbDispatch}
-              />,
-              document.body
-            )}
         </div>
       </div>
       {$featureFlags.armor2ModPicker && (

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch } from 'react';
+import React, { Dispatch, useRef, useState, useLayoutEffect, useEffect } from 'react';
 import Sheet from '../../dim-ui/Sheet';
 import '../../item-picker/ItemPicker.scss';
 import { DestinyClass, TierType } from 'bungie-api-ts/destiny2';
@@ -223,283 +223,262 @@ function mapStateToProps() {
   });
 }
 
-interface State {
-  query: string;
-  height?: number;
-  selectedPerks: LockedMap;
-  selectedSeasonalMods: LockedModBase[];
-}
-
 /**
  * A sheet that allows picking a perk.
  */
-class PerkPicker extends React.Component<Props, State> {
-  state: State = {
-    query: '',
-    selectedPerks: copy(this.props.lockedMap),
-    selectedSeasonalMods: copy(this.props.lockedSeasonalMods),
-  };
-  private itemContainer = React.createRef<HTMLDivElement>();
-  private filterInput = React.createRef<SearchFilterRef>();
+function PerkPicker({
+  defs,
+  lockedMap,
+  lockedSeasonalMods,
+  perks,
+  mods,
+  buckets,
+  items,
+  language,
+  isPhonePortrait,
+  onClose,
+  lbDispatch,
+}: Props) {
+  const [height, setHeight] = useState<number | undefined>(undefined);
+  const [query, setQuery] = useState('');
+  const [selectedPerks, setSelectedPerks] = useState(copy(lockedMap));
+  const [selectedSeasonalMods, setSelectedSeasonalMods] = useState(copy(lockedSeasonalMods));
+  const itemContainer = useRef<HTMLDivElement>(null);
+  const filterInput = useRef<SearchFilterRef>(null);
 
-  componentDidMount() {
-    if (this.itemContainer.current) {
-      this.setState({ height: this.itemContainer.current.clientHeight });
+  const order = Object.values(LockableBuckets);
+
+  useLayoutEffect(() => {
+    if (itemContainer.current) {
+      setHeight(itemContainer.current.clientHeight);
     }
-    if (!this.props.isPhonePortrait && this.filterInput.current) {
-      this.filterInput.current.focusFilterInput();
+  }, [itemContainer]);
+
+  useEffect(() => {
+    if (!isPhonePortrait && filterInput.current) {
+      filterInput.current.focusFilterInput();
     }
-  }
+  }, [isPhonePortrait, filterInput]);
 
-  componentDidUpdate() {
-    if (this.itemContainer.current && !this.state.height) {
-      this.setState({ height: this.itemContainer.current.clientHeight });
-    }
-  }
-
-  render() {
-    const { defs, perks, mods, buckets, items, language, onClose, isPhonePortrait } = this.props;
-    const { query, height, selectedPerks, selectedSeasonalMods } = this.state;
-
-    const order = Object.values(LockableBuckets);
-
-    // On iOS at least, focusing the keyboard pushes the content off the screen
-    const autoFocus =
-      !this.props.isPhonePortrait &&
-      !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
-
-    const header = (
-      <div>
-        <h1>{t('LB.ChooseAPerk')}</h1>
-        <div className="item-picker-search">
-          <div className="search-filter" role="search">
-            <AppIcon icon={searchIcon} />
-            <input
-              className="filter-input"
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              autoFocus={autoFocus}
-              placeholder="Search perk name and description"
-              type="text"
-              name="filter"
-              value={query}
-              onChange={(e) => this.setState({ query: e.currentTarget.value })}
-            />
-          </div>
-        </div>
-        <div className={styles.tabs}>
-          {order.map((bucketId) => (
-            <div
-              key={bucketId}
-              className={styles.tab}
-              onClick={() => this.scrollToBucket(bucketId)}
-            >
-              <ArmorBucketIcon bucket={buckets.byHash[bucketId]} />
-              {buckets.byHash[bucketId].name}
-            </div>
-          ))}
-          <div className={styles.tab} onClick={() => this.scrollToBucket('seasonal')}>
-            {t('LB.Season')}
-          </div>
-        </div>
-      </div>
-    );
-
-    // Only some languages effectively use the \b regex word boundary
-    const regexp = ['de', 'en', 'es', 'es-mx', 'fr', 'it', 'pl', 'pt-br'].includes(language)
-      ? new RegExp(`\\b${escapeRegExp(query)}`, 'i')
-      : new RegExp(escapeRegExp(query), 'i');
-
-    const queryFilteredPerks = query.length
-      ? _.mapValues(perks, (bucketPerks) =>
-          bucketPerks.filter(
-            (perk) =>
-              regexp.test(perk.displayProperties.name) ||
-              regexp.test(perk.displayProperties.description)
-          )
-        )
-      : perks;
-
-    const queryFilteredMods = query.length
-      ? _.mapValues(mods, (bucketMods) =>
-          bucketMods.filter(
-            (mod) =>
-              regexp.test(mod.item.displayProperties.name) ||
-              regexp.test(mod.item.displayProperties.description)
-          )
-        )
-      : mods;
-
-    const queryFilteredBurns = query.length
-      ? burns.filter((burn) => regexp.test(burn.displayProperties.name))
-      : burns;
-
-    const queryFilteredSeasonalMods = _.uniqBy(
-      Object.values(queryFilteredMods).flatMap((bucktedMods) =>
-        bucktedMods
-          .filter(({ item }) =>
-            getSpecialtySocketMetadataByPlugCategoryHash(item.plug.plugCategoryHash)
-          )
-          .map(({ item, plugSetHash }) => ({ mod: item, plugSetHash }))
-      ),
-      ({ mod }) => mod.hash
-    );
-
-    const footer =
-      Object.values(selectedPerks).some((f) => Boolean(f?.length)) || selectedSeasonalMods.length
-        ? ({ onClose }) => (
-            <div className={styles.footer}>
-              <div>
-                <button
-                  type="button"
-                  className={styles.submitButton}
-                  onClick={(e) => this.onSubmit(e, onClose)}
-                >
-                  {!isPhonePortrait && '⏎ '}
-                  {t('LoadoutBuilder.SelectPerks')}
-                </button>
-              </div>
-              <div className={styles.selectedPerks}>
-                {order.map(
-                  (bucketHash) =>
-                    selectedPerks[bucketHash] && (
-                      <React.Fragment key={bucketHash}>
-                        <ArmorBucketIcon
-                          bucket={buckets.byHash[bucketHash]}
-                          className={styles.armorIcon}
-                        />
-                        {selectedPerks[bucketHash]!.map((lockedItem) => (
-                          <LockedItemIcon
-                            key={
-                              (lockedItem.type === 'mod' && lockedItem.mod.hash) ||
-                              (lockedItem.type === 'perk' && lockedItem.perk.hash) ||
-                              (lockedItem.type === 'burn' && lockedItem.burn.dmg) ||
-                              'unknown'
-                            }
-                            defs={defs}
-                            lockedItem={lockedItem}
-                            onClick={() => {
-                              if (lockedItem.bucket) {
-                                this.onPerkSelected(lockedItem, lockedItem.bucket);
-                              }
-                            }}
-                          />
-                        ))}
-                      </React.Fragment>
-                    )
-                )}
-                <span className={styles.seasonalFooterIndicator}>{t('LB.Season')}</span>
-                {selectedSeasonalMods.map((item) => (
-                  <SocketDetailsMod
-                    key={item.mod.hash}
-                    itemDef={item.mod}
-                    defs={defs}
-                    className={styles.selectedPerk}
-                  />
-                ))}
-                <GlobalHotkeys
-                  hotkeys={[
-                    {
-                      combo: 'enter',
-                      description: t('LoadoutBuilder.SelectPerks'),
-                      callback: (event) => {
-                        this.onSubmit(event, onClose);
-                      },
-                    },
-                  ]}
-                />
-              </div>
-            </div>
-          )
-        : undefined;
-
-    return (
-      <Sheet onClose={onClose} header={header} footer={footer} sheetClassName="item-picker">
-        <div ref={this.itemContainer} style={{ height }}>
-          {order.map(
-            (bucketId) =>
-              ((queryFilteredPerks[bucketId] && queryFilteredPerks[bucketId].length > 0) ||
-                (queryFilteredMods[bucketId] && queryFilteredMods[bucketId].length > 0)) && (
-                <PerksForBucket
-                  key={bucketId}
-                  defs={defs}
-                  bucket={buckets.byHash[bucketId]}
-                  mods={queryFilteredMods[bucketId] || []}
-                  perks={queryFilteredPerks[bucketId]}
-                  burns={bucketId !== 4023194814 ? queryFilteredBurns : []}
-                  locked={selectedPerks[bucketId] || []}
-                  items={items[bucketId]}
-                  onPerkSelected={(perk) => this.onPerkSelected(perk, buckets.byHash[bucketId])}
-                />
-              )
-          )}
-          {!$featureFlags.armor2ModPicker && (
-            <SeasonalModPicker
-              mods={queryFilteredSeasonalMods}
-              defs={defs}
-              locked={selectedSeasonalMods}
-              onSeasonalModSelected={this.onSeasonalModSelected}
-            />
-          )}
-        </div>
-      </Sheet>
-    );
-  }
-
-  private onPerkSelected = (item: LockedItemType, bucket: InventoryBucket) => {
-    const { selectedPerks } = this.state;
-
+  const onPerkSelected = (item: LockedItemType, bucket: InventoryBucket) => {
     const perksForBucket = selectedPerks[bucket.hash];
     if (perksForBucket?.some((li) => lockedItemsEqual(li, item))) {
-      this.setState({
-        selectedPerks: {
-          ...selectedPerks,
-          [bucket.hash]: removeLockedItem(item, selectedPerks[bucket.hash]),
-        },
+      setSelectedPerks({
+        ...selectedPerks,
+        [bucket.hash]: removeLockedItem(item, selectedPerks[bucket.hash]),
       });
     } else {
-      this.setState({
-        selectedPerks: {
-          ...selectedPerks,
-          [bucket.hash]: addLockedItem(item, selectedPerks[bucket.hash]),
-        },
+      setSelectedPerks({
+        ...selectedPerks,
+        [bucket.hash]: addLockedItem(item, selectedPerks[bucket.hash]),
       });
     }
   };
 
-  private onSeasonalModSelected = (item: LockedModBase): void => {
-    const { selectedSeasonalMods } = this.state;
-
+  const onSeasonalModSelected = (item: LockedModBase): void => {
     if (selectedSeasonalMods.some((li) => li.mod.hash === item.mod.hash)) {
-      this.setState({
-        selectedSeasonalMods: selectedSeasonalMods.filter(
-          (existing) => existing.mod.hash !== item.mod.hash
-        ),
-      });
+      setSelectedSeasonalMods(
+        selectedSeasonalMods.filter((existing) => existing.mod.hash !== item.mod.hash)
+      );
     } else {
-      this.setState({
-        selectedSeasonalMods: [...selectedSeasonalMods, item],
-      });
+      setSelectedSeasonalMods([...selectedSeasonalMods, item]);
     }
   };
 
-  private onSubmit = (e: React.FormEvent | KeyboardEvent, onClose: () => void) => {
+  const onSubmit = (e: React.FormEvent | KeyboardEvent, onClose: () => void) => {
     e.preventDefault();
-    this.props.lbDispatch({
+    lbDispatch({
       type: 'lockedMapAndSeasonalModsChanged',
-      lockedMap: this.state.selectedPerks,
-      lockedSeasonalMods: this.state.selectedSeasonalMods,
+      lockedMap: selectedPerks,
+      lockedSeasonalMods: selectedSeasonalMods,
     });
     onClose();
   };
 
-  private scrollToBucket = (bucketIdOrSeasonal: number | string) => {
+  const scrollToBucket = (bucketIdOrSeasonal: number | string) => {
     const elementId =
       bucketIdOrSeasonal === 'seasonal' ? bucketIdOrSeasonal : `perk-bucket-${bucketIdOrSeasonal}`;
     const elem = document.getElementById(elementId)!;
     elem?.scrollIntoView();
   };
+
+  // On iOS at least, focusing the keyboard pushes the content off the screen
+  const autoFocus =
+    !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
+
+  const header = (
+    <div>
+      <h1>{t('LB.ChooseAPerk')}</h1>
+      <div className="item-picker-search">
+        <div className="search-filter" role="search">
+          <AppIcon icon={searchIcon} />
+          <input
+            className="filter-input"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            autoFocus={autoFocus}
+            placeholder="Search perk name and description"
+            type="text"
+            name="filter"
+            value={query}
+            onChange={(e) => setQuery(e.currentTarget.value)}
+          />
+        </div>
+      </div>
+      <div className={styles.tabs}>
+        {order.map((bucketId) => (
+          <div key={bucketId} className={styles.tab} onClick={() => scrollToBucket(bucketId)}>
+            <ArmorBucketIcon bucket={buckets.byHash[bucketId]} />
+            {buckets.byHash[bucketId].name}
+          </div>
+        ))}
+        <div className={styles.tab} onClick={() => scrollToBucket('seasonal')}>
+          {t('LB.Season')}
+        </div>
+      </div>
+    </div>
+  );
+
+  // Only some languages effectively use the \b regex word boundary
+  const regexp = ['de', 'en', 'es', 'es-mx', 'fr', 'it', 'pl', 'pt-br'].includes(language)
+    ? new RegExp(`\\b${escapeRegExp(query)}`, 'i')
+    : new RegExp(escapeRegExp(query), 'i');
+
+  const queryFilteredPerks = query.length
+    ? _.mapValues(perks, (bucketPerks) =>
+        bucketPerks.filter(
+          (perk) =>
+            regexp.test(perk.displayProperties.name) ||
+            regexp.test(perk.displayProperties.description)
+        )
+      )
+    : perks;
+
+  const queryFilteredMods = query.length
+    ? _.mapValues(mods, (bucketMods) =>
+        bucketMods.filter(
+          (mod) =>
+            regexp.test(mod.item.displayProperties.name) ||
+            regexp.test(mod.item.displayProperties.description)
+        )
+      )
+    : mods;
+
+  const queryFilteredBurns = query.length
+    ? burns.filter((burn) => regexp.test(burn.displayProperties.name))
+    : burns;
+
+  const queryFilteredSeasonalMods = _.uniqBy(
+    Object.values(queryFilteredMods).flatMap((bucktedMods) =>
+      bucktedMods
+        .filter(({ item }) =>
+          getSpecialtySocketMetadataByPlugCategoryHash(item.plug.plugCategoryHash)
+        )
+        .map(({ item, plugSetHash }) => ({ mod: item, plugSetHash }))
+    ),
+    ({ mod }) => mod.hash
+  );
+
+  const footer =
+    Object.values(selectedPerks).some((f) => Boolean(f?.length)) || selectedSeasonalMods.length
+      ? ({ onClose }) => (
+          <div className={styles.footer}>
+            <div>
+              <button
+                type="button"
+                className={styles.submitButton}
+                onClick={(e) => onSubmit(e, onClose)}
+              >
+                {!isPhonePortrait && '⏎ '}
+                {t('LoadoutBuilder.SelectPerks')}
+              </button>
+            </div>
+            <div className={styles.selectedPerks}>
+              {order.map(
+                (bucketHash) =>
+                  selectedPerks[bucketHash] && (
+                    <React.Fragment key={bucketHash}>
+                      <ArmorBucketIcon
+                        bucket={buckets.byHash[bucketHash]}
+                        className={styles.armorIcon}
+                      />
+                      {selectedPerks[bucketHash]!.map((lockedItem) => (
+                        <LockedItemIcon
+                          key={
+                            (lockedItem.type === 'mod' && lockedItem.mod.hash) ||
+                            (lockedItem.type === 'perk' && lockedItem.perk.hash) ||
+                            (lockedItem.type === 'burn' && lockedItem.burn.dmg) ||
+                            'unknown'
+                          }
+                          defs={defs}
+                          lockedItem={lockedItem}
+                          onClick={() => {
+                            if (lockedItem.bucket) {
+                              onPerkSelected(lockedItem, lockedItem.bucket);
+                            }
+                          }}
+                        />
+                      ))}
+                    </React.Fragment>
+                  )
+              )}
+              <span className={styles.seasonalFooterIndicator}>{t('LB.Season')}</span>
+              {selectedSeasonalMods.map((item) => (
+                <SocketDetailsMod
+                  key={item.mod.hash}
+                  itemDef={item.mod}
+                  defs={defs}
+                  className={styles.selectedPerk}
+                />
+              ))}
+              <GlobalHotkeys
+                hotkeys={[
+                  {
+                    combo: 'enter',
+                    description: t('LoadoutBuilder.SelectPerks'),
+                    callback: (event) => {
+                      onSubmit(event, onClose);
+                    },
+                  },
+                ]}
+              />
+            </div>
+          </div>
+        )
+      : undefined;
+
+  return (
+    <Sheet onClose={onClose} header={header} footer={footer} sheetClassName="item-picker">
+      <div ref={itemContainer} style={{ height }}>
+        {order.map(
+          (bucketId) =>
+            ((queryFilteredPerks[bucketId] && queryFilteredPerks[bucketId].length > 0) ||
+              (queryFilteredMods[bucketId] && queryFilteredMods[bucketId].length > 0)) && (
+              <PerksForBucket
+                key={bucketId}
+                defs={defs}
+                bucket={buckets.byHash[bucketId]}
+                mods={queryFilteredMods[bucketId] || []}
+                perks={queryFilteredPerks[bucketId]}
+                burns={bucketId !== 4023194814 ? queryFilteredBurns : []}
+                locked={selectedPerks[bucketId] || []}
+                items={items[bucketId]}
+                onPerkSelected={(perk) => onPerkSelected(perk, buckets.byHash[bucketId])}
+              />
+            )
+        )}
+        {!$featureFlags.armor2ModPicker && (
+          <SeasonalModPicker
+            mods={queryFilteredSeasonalMods}
+            defs={defs}
+            locked={selectedSeasonalMods}
+            onSeasonalModSelected={onSeasonalModSelected}
+          />
+        )}
+      </div>
+    </Sheet>
+  );
 }
 
 export default connect<StoreProps>(mapStateToProps)(PerkPicker);

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -80,6 +80,7 @@ interface ProvidedProps {
   lockedMap: LockedMap;
   lockedSeasonalMods: LockedModBase[];
   classType: DestinyClass;
+  initialQuery?: string;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
   onClose(): void;
 }
@@ -236,11 +237,12 @@ function PerkPicker({
   items,
   language,
   isPhonePortrait,
+  initialQuery,
   onClose,
   lbDispatch,
 }: Props) {
   const [height, setHeight] = useState<number | undefined>(undefined);
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(initialQuery || '');
   const [selectedPerks, setSelectedPerks] = useState(copy(lockedMap));
   const [selectedSeasonalMods, setSelectedSeasonalMods] = useState(copy(lockedSeasonalMods));
   const itemContainer = useRef<HTMLDivElement>(null);

--- a/src/app/loadout-builder/generated-sets/GeneratedSetMod.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetMod.m.scss
@@ -34,7 +34,6 @@
 }
 
 .perk {
-  cursor: default;
   img {
     border: none;
   }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
@@ -80,7 +80,11 @@ function GeneratedSetSockets({ item, lockedMods, defs, lbDispatch }: Props) {
     }
   }
 
-  const getOnClick = (category?: ModPickerCategory, season?: number) => {
+  const getOnClick = (
+    plugDef: PluggableInventoryItemDefinition,
+    category?: ModPickerCategory,
+    season?: number
+  ) => {
     if (category) {
       const initialQuery =
         category === ModPickerCategories.seasonal
@@ -88,7 +92,8 @@ function GeneratedSetSockets({ item, lockedMods, defs, lbDispatch }: Props) {
           : t(armor2ModPlugCategoriesTitles[category]);
       return () => lbDispatch({ type: 'openModPicker', initialQuery });
     } else {
-      return () => lbDispatch({ type: 'openPerkPicker' });
+      return () =>
+        lbDispatch({ type: 'openPerkPicker', initialQuery: plugDef.displayProperties.name });
     }
   };
 
@@ -101,7 +106,7 @@ function GeneratedSetSockets({ item, lockedMods, defs, lbDispatch }: Props) {
             gridColumn={(index % 2) + 1}
             plugDef={plugDef}
             defs={defs}
-            onClick={getOnClick(category, season)}
+            onClick={getOnClick(plugDef, category, season)}
           />
         ))}
       </div>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetSockets.tsx
@@ -80,6 +80,18 @@ function GeneratedSetSockets({ item, lockedMods, defs, lbDispatch }: Props) {
     }
   }
 
+  const getOnClick = (category?: ModPickerCategory, season?: number) => {
+    if (category) {
+      const initialQuery =
+        category === ModPickerCategories.seasonal
+          ? season?.toString()
+          : t(armor2ModPlugCategoriesTitles[category]);
+      return () => lbDispatch({ type: 'openModPicker', initialQuery });
+    } else {
+      return () => lbDispatch({ type: 'openPerkPicker' });
+    }
+  };
+
   return (
     <>
       <div className={styles.lockedItems}>
@@ -89,18 +101,7 @@ function GeneratedSetSockets({ item, lockedMods, defs, lbDispatch }: Props) {
             gridColumn={(index % 2) + 1}
             plugDef={plugDef}
             defs={defs}
-            onClick={
-              category
-                ? () =>
-                    lbDispatch({
-                      type: 'openModPicker',
-                      initialQuery:
-                        category === ModPickerCategories.seasonal
-                          ? season?.toString()
-                          : t(armor2ModPlugCategoriesTitles[category]),
-                    })
-                : undefined
-            }
+            onClick={getOnClick(category, season)}
           />
         ))}
       </div>

--- a/src/app/loadout-builder/loadoutBuilderReducer.ts
+++ b/src/app/loadout-builder/loadoutBuilderReducer.ts
@@ -24,7 +24,10 @@ export interface LoadoutBuilderState {
     open: boolean;
     initialQuery?: string;
   };
-  perkPickerOpen: boolean;
+  perkPicker: {
+    open: boolean;
+    initialQuery?: string;
+  };
 }
 
 const lbStateInit = ({
@@ -81,7 +84,9 @@ const lbStateInit = ({
     modPicker: {
       open: false,
     },
-    perkPickerOpen: false,
+    perkPicker: {
+      open: false,
+    },
   };
 };
 
@@ -101,7 +106,7 @@ export type LoadoutBuilderAction =
   | { type: 'lockedArmor2ModsChanged'; lockedArmor2Mods: LockedArmor2ModMap }
   | { type: 'openModPicker'; initialQuery?: string }
   | { type: 'closeModPicker' }
-  | { type: 'openPerkPicker' }
+  | { type: 'openPerkPicker'; initialQuery?: string }
   | { type: 'closePerkPicker' };
 
 // TODO: Move more logic inside the reducer
@@ -171,9 +176,9 @@ function lbStateReducer(
     case 'closeModPicker':
       return { ...state, modPicker: { open: false } };
     case 'openPerkPicker':
-      return { ...state, perkPickerOpen: true };
+      return { ...state, perkPicker: { open: true, initialQuery: action.initialQuery } };
     case 'closePerkPicker':
-      return { ...state, perkPickerOpen: false };
+      return { ...state, perkPicker: { open: false } };
   }
 }
 

--- a/src/app/loadout-builder/loadoutBuilderReducer.ts
+++ b/src/app/loadout-builder/loadoutBuilderReducer.ts
@@ -24,6 +24,7 @@ export interface LoadoutBuilderState {
     open: boolean;
     initialQuery?: string;
   };
+  perkPickerOpen: boolean;
 }
 
 const lbStateInit = ({
@@ -80,6 +81,7 @@ const lbStateInit = ({
     modPicker: {
       open: false,
     },
+    perkPickerOpen: false,
   };
 };
 
@@ -98,7 +100,9 @@ export type LoadoutBuilderAction =
     }
   | { type: 'lockedArmor2ModsChanged'; lockedArmor2Mods: LockedArmor2ModMap }
   | { type: 'openModPicker'; initialQuery?: string }
-  | { type: 'closeModPicker' };
+  | { type: 'closeModPicker' }
+  | { type: 'openPerkPicker' }
+  | { type: 'closePerkPicker' };
 
 // TODO: Move more logic inside the reducer
 function lbStateReducer(
@@ -166,6 +170,10 @@ function lbStateReducer(
       };
     case 'closeModPicker':
       return { ...state, modPicker: { open: false } };
+    case 'openPerkPicker':
+      return { ...state, perkPickerOpen: true };
+    case 'closePerkPicker':
+      return { ...state, perkPickerOpen: false };
   }
 }
 


### PR DESCRIPTION
Hooked up perk icons to open perk picker. There are 3 distinct commits here so we can remove some functionality if we think its not needed. So the commits are

1. Set up the click of a perk to open the perk picker. Basically just a copy of how we did it with mod picker.
2. Functionise the perk picker, also a copy of how mod picker was done a while ago.
3. Set up the initial query to filter only said perk.

The initial query is the park I am not sure of. Another option would be to filter by the bucket name and show all perks in said bucket (i.e. all chest perks). Another option would be to just not do this, so we could back out the last commit and keep the first two.

I personally would click a perk to lock it, but then I wonder if we should just bypass the whole perk picker and lock it directly. That seems like it might be too easy to accidentally lock a perk though. Thoughts?

Edit: Maybe showing just said perk isn't so bad, at least you can read the description.

![image](https://user-images.githubusercontent.com/7344652/91632284-2db7da00-ea23-11ea-86f5-621936c978b6.png)
