### PR TITLE
Better initialize searches

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -176,7 +176,10 @@ export const dimApi = (
             },
             updateQueue: newUpdateQueue,
             itemHashTags: action.payload.itemHashTags || initialState.itemHashTags,
-            searches: action.payload.searches || initialState.searches,
+            searches: {
+              ...state.searches,
+              ...action.payload.searches,
+            },
           }
         : {
             ...state,


### PR DESCRIPTION
When searches were saved in IDB, they could be missing some parts of the structure. This puts them back together.