### PR TITLE
Remove store/equip selector on item picker

### DIFF
--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -73,7 +73,7 @@ function StoreBucket({
 }: Props) {
   const pickEquipItem = useCallback(async () => {
     try {
-      const { item, equip } = await showItemPicker({
+      const { item } = await showItemPicker({
         filterItems: (item: DimItem) =>
           item.bucket.hash === bucket.hash && item.canBeEquippedBy(store),
         prompt: t('MovePopup.PullItem', {
@@ -82,7 +82,7 @@ function StoreBucket({
         }),
       });
 
-      moveItemTo(item, store, equip, item.amount);
+      moveItemTo(item, store, false, item.amount);
     } catch (e) {}
   }, [bucket.hash, bucket.name, store]);
 

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -11,12 +11,10 @@ import { SearchFilters, searchFiltersConfigSelector } from '../search/search-fil
 import SearchFilterInput, { SearchFilterRef } from '../search/SearchFilterInput';
 import { sortItems } from '../shell/filters';
 import { itemSortOrderSelector } from '../settings/item-sort';
-import clsx from 'clsx';
 import { t } from 'app/i18next-t';
 import './ItemPicker.scss';
 import { setSetting } from '../settings/actions';
 import _ from 'lodash';
-import { settingsSelector } from 'app/settings/reducer';
 import SearchBar from 'app/search/SearchBar';
 
 type ProvidedProps = ItemPickerState & {
@@ -28,7 +26,6 @@ interface StoreProps {
   filters: SearchFilters;
   itemSortOrder: string[];
   isPhonePortrait: boolean;
-  preferEquip: boolean;
 }
 
 function mapStateToProps(): MapStateToProps<StoreProps, ProvidedProps, RootState> {
@@ -44,7 +41,6 @@ function mapStateToProps(): MapStateToProps<StoreProps, ProvidedProps, RootState
     filters: searchFiltersConfigSelector(state),
     itemSortOrder: itemSortOrderSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
-    preferEquip: settingsSelector(state).itemPickerEquip,
   });
 }
 
@@ -56,23 +52,18 @@ type DispatchProps = typeof mapDispatchToProps;
 type Props = ProvidedProps & StoreProps & DispatchProps;
 
 function ItemPicker({
-  equip,
-  preferEquip,
   allItems,
   prompt,
   filters,
   itemSortOrder,
-  hideStoreEquip,
   sortBy,
   isPhonePortrait,
   ignoreSelectedPerks,
   onItemSelected,
   onCancel,
   onSheetClosed,
-  setSetting,
 }: Props) {
   const [query, setQuery] = useState('');
-  const [equipToggled, setEquipToggled] = useState(equip ?? preferEquip);
   const [height, setHeight] = useState<number | undefined>(undefined);
 
   const itemContainer = useRef<HTMLDivElement>(null);
@@ -89,22 +80,13 @@ function ItemPicker({
     !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
 
   const onItemSelectedFn = (item: DimItem, onClose: () => void) => {
-    onItemSelected({ item, equip: equipToggled });
+    onItemSelected({ item });
     onClose();
   };
 
   const onSheetClosedFn = () => {
     onCancel();
     onSheetClosed();
-  };
-
-  const setEquip = () => {
-    setEquipToggled(true);
-    setSetting('itemPickerEquip', true);
-  };
-  const setStore = () => {
-    setEquipToggled(false);
-    setSetting('itemPickerEquip', false);
   };
 
   const header = (
@@ -125,24 +107,6 @@ function ItemPicker({
             autoFocus={autoFocus}
             onQueryChanged={setQuery}
           />
-        )}
-        {!hideStoreEquip && (
-          <div className="split-buttons">
-            <button
-              type="button"
-              className={clsx('dim-button', { selected: equipToggled })}
-              onClick={setEquip}
-            >
-              {t('MovePopup.Equip')}
-            </button>
-            <button
-              type="button"
-              className={clsx('dim-button', { selected: !equipToggled })}
-              onClick={setStore}
-            >
-              {t('MovePopup.Store')}
-            </button>
-          </div>
         )}
       </div>
     </div>

--- a/src/app/item-picker/item-picker.ts
+++ b/src/app/item-picker/item-picker.ts
@@ -4,10 +4,6 @@ import { Subject } from 'rxjs';
 export interface ItemPickerOptions {
   /** Override the default "Choose an Item" prompt. */
   prompt?: string;
-  /** Override the default equip/store selector */
-  equip?: boolean;
-  /** Hide the store/equip buttons. */
-  hideStoreEquip?: boolean;
   /** Don't show information that relates to currently selected perks. */
   ignoreSelectedPerks?: boolean;
   /** Optionally restrict items to a particular subset. */
@@ -18,7 +14,6 @@ export interface ItemPickerOptions {
 
 interface ItemSelectResult {
   item: DimItem;
-  equip: boolean;
 }
 
 export type ItemPickerState = ItemPickerOptions & {

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -118,7 +118,6 @@ function LockArmorAndPerks({
     const order = Object.values(LockableBuckets);
     try {
       const { item } = await showItemPicker({
-        hideStoreEquip: true,
         filterItems: (item: DimItem) =>
           Boolean(
             isLoadoutBuilderItem(item) &&

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -67,7 +67,6 @@ export default function GeneratedSetItem({
     try {
       const { item } = await showItemPicker({
         prompt: t('LoadoutBuilder.ChooseAlternate'),
-        hideStoreEquip: true,
         filterItems: (item: DimItem) => ids.has(item.id),
       });
 

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -105,7 +105,7 @@ type Action =
   /** Replace the current loadout with an updated one */
   | { type: 'update'; loadout: Loadout }
   /** Add an item to the loadout */
-  | { type: 'addItem'; item: DimItem; equip?: boolean; shift: boolean; items: DimItem[] }
+  | { type: 'addItem'; item: DimItem; shift: boolean; items: DimItem[] }
   /** Remove an item from the loadout */
   | { type: 'removeItem'; item: DimItem; shift: boolean; items: DimItem[] }
   /** Make an item that's already in the loadout equipped */
@@ -148,7 +148,7 @@ function stateReducer(state: State, action: Action): State {
 
     case 'addItem': {
       const { loadout } = state;
-      const { item, equip, shift, items } = action;
+      const { item, shift, items } = action;
 
       if (!item.canBeInLoadout()) {
         showNotification({ type: 'warning', title: t('Loadouts.OnlyItems') });
@@ -158,7 +158,7 @@ function stateReducer(state: State, action: Action): State {
       return loadout
         ? {
             ...state,
-            loadout: addItem(loadout, item, equip, shift, items),
+            loadout: addItem(loadout, item, shift, items),
           }
         : state;
     }
@@ -193,8 +193,6 @@ function stateReducer(state: State, action: Action): State {
 function addItem(
   loadout: Readonly<Loadout>,
   item: DimItem,
-  /** Whether the item should be equipped in the loadout or not. Leave undefined for a sensible default. */
-  equip: boolean | undefined,
   shift: boolean,
   items: DimItem[]
 ): Loadout {
@@ -216,8 +214,7 @@ function addItem(
 
     if (!dupe) {
       if (typeInventory.length < maxSlots) {
-        loadoutItem.equipped =
-          equip === undefined ? item.equipment && typeInventory.length === 0 : equip;
+        loadoutItem.equipped = item.equipment && typeInventory.length === 0;
         if (loadoutItem.equipped) {
           for (const otherItem of typeInventory) {
             findItem(otherItem).equipped = false;
@@ -445,8 +442,8 @@ function LoadoutDrawer({
     stores,
   ]);
 
-  const onAddItem = (item: DimItem, e?: MouseEvent, equip?: boolean) =>
-    stateDispatch({ type: 'addItem', item, shift: Boolean(e?.shiftKey), equip, items });
+  const onAddItem = (item: DimItem, e?: MouseEvent) =>
+    stateDispatch({ type: 'addItem', item, shift: Boolean(e?.shiftKey), items });
 
   const onRemoveItem = (item: DimItem, e?: React.MouseEvent) =>
     stateDispatch({ type: 'removeItem', item, shift: Boolean(e?.shiftKey), items });
@@ -476,7 +473,7 @@ function LoadoutDrawer({
     const loadoutClassType = loadout?.classType;
 
     try {
-      const { item, equip } = await showItemPicker({
+      const { item } = await showItemPicker({
         filterItems: (item: DimItem) =>
           item.hash === warnItem.hash &&
           item.canBeInLoadout() &&
@@ -485,14 +482,13 @@ function LoadoutDrawer({
             item.classType === loadoutClassType ||
             item.classType === DestinyClass.Unknown),
         prompt: t('Loadouts.FindAnother', { name: warnItem.name }),
-        equip: warnItem.equipped,
 
         // don't show information related to selected perks so we don't give the impression
         // that we will update perk selections when applying the loadout
         ignoreSelectedPerks: true,
       });
 
-      onAddItem(item, undefined, equip);
+      onAddItem(item);
       onRemoveItem(warnItem);
     } catch (e) {}
   };

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -78,7 +78,7 @@ export default function LoadoutDrawerContents(
     itemSortOrder: string[];
     equip(item: DimItem, e: React.MouseEvent): void;
     remove(item: DimItem, e: React.MouseEvent): void;
-    add(item: DimItem, e?: MouseEvent, equip?: boolean): void;
+    add(item: DimItem, e?: MouseEvent): void;
   }
 ) {
   const itemsByBucket = _.groupBy(items, (i) => i.bucket.hash);
@@ -109,7 +109,7 @@ export default function LoadoutDrawerContents(
           {typesWithoutItems.map((bucket) => (
             <a
               key={bucket.type}
-              onClick={() => pickLoadoutItem(loadout, itemsByBucket, bucket, add)}
+              onClick={() => pickLoadoutItem(loadout, bucket, add)}
               className="dim-button loadout-add"
             >
               <AppIcon icon={addIcon} /> {bucket.name}
@@ -125,7 +125,7 @@ export default function LoadoutDrawerContents(
             loadoutItems={loadout.items}
             items={itemsByBucket[bucket.hash] || []}
             itemSortOrder={itemSortOrder}
-            pickLoadoutItem={(bucket) => pickLoadoutItem(loadout, itemsByBucket, bucket, add)}
+            pickLoadoutItem={(bucket) => pickLoadoutItem(loadout, bucket, add)}
             equip={equip}
             remove={remove}
           />
@@ -137,9 +137,8 @@ export default function LoadoutDrawerContents(
 
 async function pickLoadoutItem(
   loadout: Loadout,
-  itemsByBucket: { [bucketId: string]: DimItem[] },
   bucket: InventoryBucket,
-  add: (item: DimItem, e?: MouseEvent, equip?: boolean) => void
+  add: (item: DimItem, e?: MouseEvent) => void
 ) {
   const loadoutClassType = loadout?.classType;
 
@@ -147,10 +146,8 @@ async function pickLoadoutItem(
     return loadout?.items.some((i) => i.id === item.id && i.hash === i.hash);
   }
 
-  const hasEquippedItem = (itemsByBucket[bucket.hash] || []).some((i) => i.equipped);
-
   try {
-    const { item, equip } = await showItemPicker({
+    const { item } = await showItemPicker({
       filterItems: (item: DimItem) =>
         item.bucket.hash === bucket.hash &&
         (!loadout ||
@@ -160,14 +157,13 @@ async function pickLoadoutItem(
         item.canBeInLoadout() &&
         !loadoutHasItem(item),
       prompt: t('Loadouts.ChooseItem', { name: bucket.name }),
-      equip: !hasEquippedItem,
 
       // don't show information related to selected perks so we don't give the impression
       // that we will update perk selections when applying the loadout
       ignoreSelectedPerks: true,
     });
 
-    add(item, undefined, equip);
+    add(item);
   } catch (e) {}
 }
 


### PR DESCRIPTION
Only about 1% of users have selected "Equip", and it can cause problems if selected. Easier to always store and you can equip as a second action or in-game. This also gives more room for the search bar on mobile.

Fixes #3592 by removing the ability to equip.