### PR TITLE
Provide colored backgrounds for items/characters

### DIFF
--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -28,7 +28,17 @@ export default function CharacterTile({ store }: { store: DimStore }) {
 
   return (
     <div className="character-tile">
-      <div className="background" style={{ backgroundImage: `url("${store.background}")` }} />
+      <div
+        className="background"
+        style={{
+          backgroundImage: `url("${store.background}")`,
+          backgroundColor: store.isDestiny2()
+            ? `rgb(${Math.round(store.color.red)}, ${Math.round(store.color.green)}, ${Math.round(
+                store.color.blue
+              )}`
+            : 'black',
+        }}
+      />
       <CharacterEmblem store={store} />
       <div className="character-text">
         <div className="top">

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -1,5 +1,11 @@
 @import '../variables.scss';
 
+$legendaryBg: #522f65;
+$exoticBg: #ceae33;
+$basicBg: #c3bcb4;
+$rareBg: #5076a3;
+$commonBg: #366f42;
+
 // Items hidden by search.
 .searchHidden {
   opacity: 0.2;
@@ -44,6 +50,22 @@
   &:global(.transparent) {
     border-color: transparent;
   }
+}
+
+.legendary :global(.item-img) {
+  background-color: $legendaryBg;
+}
+.exotic :global(.item-img) {
+  background-color: $exoticBg;
+}
+.basic :global(.item-img) {
+  background-color: $basicBg;
+}
+.rare :global(.item-img) {
+  background-color: $rareBg;
+}
+.common :global(.item-img) {
+  background-color: $commonBg;
 }
 
 .touchActive {
@@ -126,20 +148,20 @@
     top: calc((var(--item-size) - #{2 * $item-border-width}) * -0.665);
     background: #444;
   }
-  &.legendary::before {
-    background: #522f65;
+  .legendary &::before {
+    background: $legendaryBg;
   }
-  &.exotic::before {
-    background: #ceae33;
+  .exotic &::before {
+    background: $exoticBg;
   }
-  &.basic::before {
-    background: #c3bcb4;
+  .basic &::before {
+    background: $basicBg;
   }
-  &.rare::before {
-    background: #5076a3;
+  .rare &::before {
+    background: $rareBg;
   }
-  &.common::before {
-    background: #366f42;
+  .common &::before {
+    background: $commonBg;
   }
 }
 

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -14,7 +14,7 @@ import { selectedSubclassPath } from './subclass';
 import { SUBCLASS_BUCKET } from 'app/search/d2-known-values';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 
-const itemTierDogearStyles = {
+const itemTierStyles = {
   Legendary: styles.legendary,
   Exotic: styles.exotic,
   Common: styles.basic,
@@ -85,16 +85,18 @@ export default function InventoryItem({
       item.talentGrid &&
       selectedSubclassPath(item.talentGrid)) ||
     null;
+  const noBorder = borderless(item);
   const itemStyles = {
     [styles.touchActive]: touchActive,
     [styles.searchHidden]: searchHidden,
     [styles.subclassPathTop]: subclassPath?.position === 'top',
     [styles.subclassPathMiddle]: subclassPath?.position === 'middle',
     [styles.subclassPathBottom]: subclassPath?.position === 'bottom',
+    [itemTierStyles[item.tier]]: !noBorder && !(item.isDestiny2?.() && item.plug),
   };
   const itemImageStyles = clsx('item-img', {
     [styles.complete]: item.complete || isCapped,
-    [styles.borderless]: borderless(item),
+    [styles.borderless]: noBorder,
     [styles.masterwork]: item.masterwork,
   });
 
@@ -136,7 +138,7 @@ export default function InventoryItem({
         />
       )}
       {item.iconOverlay && (
-        <div className={clsx(styles.iconOverlay, itemTierDogearStyles[item.tier])}>
+        <div className={clsx(styles.iconOverlay)}>
           <BungieImage src={item.iconOverlay} />
         </div>
       )}


### PR DESCRIPTION
I don't like how DIM looks as images pop in from loading, but I also don't like the approach some sites use where they fade in images. As a compromise, this PR colors in a background for items and characters based on rarity, so the icons don't look as "empty" while they're loading:

<img width="1436" alt="Screen Shot 2020-08-29 at 11 52 26 AM" src="https://user-images.githubusercontent.com/313208/91644233-0f37eb80-e9ef-11ea-8e55-164a235ff61d.png">
