### PR TITLE
Add "freezeInitialHeight" property to Sheet

### DIFF
--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useMemo, useCallback } from 'react';
+import React, { useRef, useEffect, useMemo, useCallback, useState } from 'react';
 import './Sheet.scss';
 import { AppIcon, disabledIcon } from '../shell/icons';
 import { config, animated, useSpring } from 'react-spring';
@@ -12,6 +12,8 @@ interface Props {
   footer?: React.ReactNode | ((args: { onClose(): void }) => React.ReactNode);
   children?: React.ReactNode | ((args: { onClose(): void }) => React.ReactNode);
   sheetClassName?: string;
+  /** If set, the sheet will always be whatever height it was when first rendered, even if the contents change size. */
+  freezeInitialHeight?: boolean;
   onClose(): void;
 }
 
@@ -37,6 +39,7 @@ export default function Sheet({
   footer,
   children,
   sheetClassName,
+  freezeInitialHeight,
   onClose: onCloseCallback,
 }: Props) {
   // This component basically doesn't render - it works entirely through setSpring and useDrag.
@@ -45,6 +48,7 @@ export default function Sheet({
   const closing = useRef(false);
   // Should we be dragging?
   const dragging = useRef(false);
+  const [frozenHeight, setFrozenHeight] = useState<number | undefined>(undefined);
 
   const windowHeight = window.innerHeight;
   const headerHeight = useMemo(() => document.getElementById('header')!.clientHeight, []);
@@ -52,6 +56,12 @@ export default function Sheet({
 
   const sheetContents = useRef<HTMLDivElement | null>(null);
   const sheetContentsRefFn = useLockSheetContents(sheetContents);
+
+  useEffect(() => {
+    if (freezeInitialHeight && sheetContents.current && !frozenHeight) {
+      setFrozenHeight(sheetContents.current.clientHeight);
+    }
+  }, [freezeInitialHeight, frozenHeight]);
 
   const sheet = useRef<HTMLDivElement>(null);
   const height = () => sheet.current?.clientHeight || 0;
@@ -165,6 +175,7 @@ export default function Sheet({
 
         <div
           className={clsx('sheet-contents', { 'sheet-has-footer': footer })}
+          style={frozenHeight ? { flexBasis: frozenHeight, flexShrink: 0 } : undefined}
           ref={sheetContentsRefFn}
         >
           {_.isFunction(children) ? children({ onClose }) : children}

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import './InfusionFinder.scss';
 import { DimItem } from '../inventory/item-types';
 import { showInfuse$ } from './infuse';
@@ -73,8 +73,6 @@ interface State {
   source?: DimItem;
   /** The item that will have its power increased by infusion */
   target?: DimItem;
-  /** Initial height of the sheet, to prevent it resizing */
-  height?: number;
   /** Search filter string */
   filter: string;
 }
@@ -88,7 +86,6 @@ type Action =
   | { type: 'swapDirection' }
   /** Select one of the items in the list */
   | { type: 'selectItem'; item: DimItem }
-  | { type: 'setHeight'; height: number }
   | { type: 'setFilter'; filter: string };
 
 /**
@@ -103,7 +100,6 @@ function stateReducer(state: State, action: Action): State {
         source: undefined,
         target: undefined,
         filter: '',
-        height: undefined,
       };
     case 'init': {
       const direction =
@@ -148,12 +144,6 @@ function stateReducer(state: State, action: Action): State {
         };
       }
     }
-    case 'setHeight': {
-      return {
-        ...state,
-        height: action.height,
-      };
-    }
     case 'setFilter': {
       return {
         ...state,
@@ -170,14 +160,10 @@ function InfusionFinder({
   isPhonePortrait,
   lastInfusionDirection,
 }: Props) {
-  const itemContainer = useRef<HTMLDivElement>(null);
-  const [{ direction, query, source, target, height, filter }, stateDispatch] = useReducer(
-    stateReducer,
-    {
-      direction: lastInfusionDirection,
-      filter: '',
-    }
-  );
+  const [{ direction, query, source, target, filter }, stateDispatch] = useReducer(stateReducer, {
+    direction: lastInfusionDirection,
+    filter: '',
+  });
 
   const reset = () => stateDispatch({ type: 'reset' });
   const selectItem = (item: DimItem) => stateDispatch({ type: 'selectItem', item });
@@ -192,13 +178,6 @@ function InfusionFinder({
       stateDispatch({ type: 'init', item, hasInfusables: hasInfusables, hasFuel });
     })
   );
-
-  // Track the initial height of the sheet
-  useEffect(() => {
-    if (itemContainer.current && !height) {
-      stateDispatch({ type: 'setHeight', height: itemContainer.current.clientHeight });
-    }
-  }, [height]);
 
   // Close the sheet on navigation
   const { pathname } = useLocation();
@@ -315,8 +294,8 @@ function InfusionFinder({
   );
 
   return (
-    <Sheet onClose={reset} header={header} sheetClassName="infuseDialog">
-      <div className="infuseSources" ref={itemContainer} style={{ height }}>
+    <Sheet onClose={reset} header={header} sheetClassName="infuseDialog" freezeInitialHeight={true}>
+      <div className="infuseSources">
         {items.length > 0 || dupes.length > 0 ? (
           <>
             <div className="sub-bucket">

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { DimItem } from '../inventory/item-types';
 import { ItemPickerState } from './item-picker';
 import Sheet from '../dim-ui/Sheet';
@@ -8,7 +8,7 @@ import { RootState } from 'app/store/types';
 import { createSelector } from 'reselect';
 import { storesSelector } from '../inventory/selectors';
 import { SearchFilters, searchFiltersConfigSelector } from '../search/search-filter';
-import SearchFilterInput, { SearchFilterRef } from '../search/SearchFilterInput';
+import SearchFilterInput from '../search/SearchFilterInput';
 import { sortItems } from '../shell/filters';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import clsx from 'clsx';
@@ -73,16 +73,6 @@ function ItemPicker({
 }: Props) {
   const [query, setQuery] = useState('');
   const [equipToggled, setEquipToggled] = useState(equip ?? preferEquip);
-  const [height, setHeight] = useState<number | undefined>(undefined);
-
-  const itemContainer = useRef<HTMLDivElement>(null);
-  const filterInput = useRef<SearchFilterRef>(null);
-
-  useEffect(() => {
-    if (itemContainer.current && !height) {
-      setHeight(itemContainer.current.clientHeight);
-    }
-  }, [height]);
 
   // On iOS at least, focusing the keyboard pushes the content off the screen
   const autoFocus =
@@ -113,14 +103,12 @@ function ItemPicker({
       <div className="item-picker-search">
         {$featureFlags.newSearch ? (
           <SearchBar
-            ref={filterInput}
             placeholder={t('ItemPicker.SearchPlaceholder')}
             autoFocus={autoFocus}
             onQueryChanged={setQuery}
           />
         ) : (
           <SearchFilterInput
-            ref={filterInput}
             placeholder={t('ItemPicker.SearchPlaceholder')}
             autoFocus={autoFocus}
             onQueryChanged={setQuery}
@@ -158,9 +146,14 @@ function ItemPicker({
   }, [allItems, filter, itemSortOrder, sortBy]);
 
   return (
-    <Sheet onClose={onSheetClosedFn} header={header} sheetClassName="item-picker">
+    <Sheet
+      onClose={onSheetClosedFn}
+      header={header}
+      sheetClassName="item-picker"
+      freezeInitialHeight={true}
+    >
       {({ onClose }) => (
-        <div className="sub-bucket" ref={itemContainer} style={{ height }}>
+        <div className="sub-bucket">
           {items.map((item) => (
             <ConnectedInventoryItem
               key={item.index}

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -1,12 +1,4 @@
-import React, {
-  Dispatch,
-  useState,
-  useRef,
-  useLayoutEffect,
-  useCallback,
-  useMemo,
-  useEffect,
-} from 'react';
+import React, { Dispatch, useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import Sheet from '../../dim-ui/Sheet';
 import '../../item-picker/ItemPicker.scss';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -177,17 +169,9 @@ function ModPicker({
   lbDispatch,
   onClose,
 }: Props) {
-  const [height, setHeight] = useState<number | undefined>(undefined);
   const [query, setQuery] = useState(initialQuery || '');
   const [lockedArmor2ModsInternal, setLockedArmor2ModsInternal] = useState(copy(lockedArmor2Mods));
   const filterInput = useRef<SearchFilterRef | null>(null);
-  const itemContainer = useRef<HTMLDivElement | null>(null);
-
-  useLayoutEffect(() => {
-    if (itemContainer.current) {
-      setHeight(itemContainer.current.clientHeight);
-    }
-  }, [itemContainer]);
 
   useEffect(() => {
     if (!isPhonePortrait && filterInput.current) {
@@ -310,22 +294,20 @@ function ModPicker({
       footer={footer}
       sheetClassName="item-picker"
     >
-      <div ref={itemContainer} style={{ height }}>
-        {Object.values(ModPickerCategories).map((category) => (
-          <ModPickerSection
-            key={category}
-            mods={modsByCategory[category]}
-            defs={defs}
-            locked={lockedArmor2ModsInternal[category]}
-            title={t(armor2ModPlugCategoriesTitles[category])}
-            category={category}
-            maximumSelectable={isGeneralOrSeasonal(category) ? 5 : 2}
-            energyMustMatch={!isGeneralOrSeasonal(category)}
-            onModSelected={onModSelected}
-            onModRemoved={onModRemoved}
-          />
-        ))}
-      </div>
+      {Object.values(ModPickerCategories).map((category) => (
+        <ModPickerSection
+          key={category}
+          mods={modsByCategory[category]}
+          defs={defs}
+          locked={lockedArmor2ModsInternal[category]}
+          title={t(armor2ModPlugCategoriesTitles[category])}
+          category={category}
+          maximumSelectable={isGeneralOrSeasonal(category) ? 5 : 2}
+          energyMustMatch={!isGeneralOrSeasonal(category)}
+          onModSelected={onModSelected}
+          onModRemoved={onModRemoved}
+        />
+      ))}
     </Sheet>
   );
 }

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -241,20 +241,12 @@ function PerkPicker({
   onClose,
   lbDispatch,
 }: Props) {
-  const [height, setHeight] = useState<number | undefined>(undefined);
   const [query, setQuery] = useState(initialQuery || '');
   const [selectedPerks, setSelectedPerks] = useState(copy(lockedMap));
   const [selectedSeasonalMods, setSelectedSeasonalMods] = useState(copy(lockedSeasonalMods));
-  const itemContainer = useRef<HTMLDivElement>(null);
   const filterInput = useRef<SearchFilterRef>(null);
 
   const order = Object.values(LockableBuckets);
-
-  useLayoutEffect(() => {
-    if (itemContainer.current) {
-      setHeight(itemContainer.current.clientHeight);
-    }
-  }, [itemContainer]);
 
   useEffect(() => {
     if (!isPhonePortrait && filterInput.current) {
@@ -451,34 +443,38 @@ function PerkPicker({
       : undefined;
 
   return (
-    <Sheet onClose={onClose} header={header} footer={footer} sheetClassName="item-picker">
-      <div ref={itemContainer} style={{ height }}>
-        {order.map(
-          (bucketId) =>
-            ((queryFilteredPerks[bucketId] && queryFilteredPerks[bucketId].length > 0) ||
-              (queryFilteredMods[bucketId] && queryFilteredMods[bucketId].length > 0)) && (
-              <PerksForBucket
-                key={bucketId}
-                defs={defs}
-                bucket={buckets.byHash[bucketId]}
-                mods={queryFilteredMods[bucketId] || []}
-                perks={queryFilteredPerks[bucketId]}
-                burns={bucketId !== 4023194814 ? queryFilteredBurns : []}
-                locked={selectedPerks[bucketId] || []}
-                items={items[bucketId]}
-                onPerkSelected={(perk) => onPerkSelected(perk, buckets.byHash[bucketId])}
-              />
-            )
-        )}
-        {!$featureFlags.armor2ModPicker && (
-          <SeasonalModPicker
-            mods={queryFilteredSeasonalMods}
-            defs={defs}
-            locked={selectedSeasonalMods}
-            onSeasonalModSelected={onSeasonalModSelected}
-          />
-        )}
-      </div>
+    <Sheet
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      sheetClassName="item-picker"
+      freezeInitialHeight={true}
+    >
+      {order.map(
+        (bucketId) =>
+          ((queryFilteredPerks[bucketId] && queryFilteredPerks[bucketId].length > 0) ||
+            (queryFilteredMods[bucketId] && queryFilteredMods[bucketId].length > 0)) && (
+            <PerksForBucket
+              key={bucketId}
+              defs={defs}
+              bucket={buckets.byHash[bucketId]}
+              mods={queryFilteredMods[bucketId] || []}
+              perks={queryFilteredPerks[bucketId]}
+              burns={bucketId !== 4023194814 ? queryFilteredBurns : []}
+              locked={selectedPerks[bucketId] || []}
+              items={items[bucketId]}
+              onPerkSelected={(perk) => onPerkSelected(perk, buckets.byHash[bucketId])}
+            />
+          )
+      )}
+      {!$featureFlags.armor2ModPicker && (
+        <SeasonalModPicker
+          mods={queryFilteredSeasonalMods}
+          defs={defs}
+          locked={selectedSeasonalMods}
+          onSeasonalModSelected={onSeasonalModSelected}
+        />
+      )}
     </Sheet>
   );
 }

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, useRef, useState, useLayoutEffect, useEffect } from 'react';
+import React, { Dispatch, useRef, useState, useEffect } from 'react';
 import Sheet from '../../dim-ui/Sheet';
 import '../../item-picker/ItemPicker.scss';
 import { DestinyClass, TierType } from 'bungie-api-ts/destiny2';


### PR DESCRIPTION
A few different Sheet implementations had code to "freeze" the initial height of the sheet contents so that things like filtering items wouldn't cause the height of the sheet to jump. This PR builds that into the Sheet itself. I had to pull some weird flex tricks for this, so it probably needs some testing.

Fixes #5583