### PR TITLE
Allow tagging mods

### DIFF
--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -150,22 +150,20 @@
   top: calc(var(--item-size) - #{$badge-height} - #{$item-border-width});
   display: flex;
   flex-direction: row;
-}
+  > * {
+    display: block;
+    position: static;
+    width: calc(var(--item-size) / 5);
+    height: calc(var(--item-size) / 5);
+    font-size: calc(var(--item-size) / 5);
+    margin-right: 1px;
+    color: #29f36a; // #5eff92;
+    filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.8));
 
-// Individual icons in the icon tray
-.icon {
-  display: block;
-  position: static;
-  width: calc(var(--item-size) / 5);
-  height: calc(var(--item-size) / 5);
-  font-size: calc(var(--item-size) / 5);
-  margin-right: 1px;
-  color: #29f36a; // #5eff92;
-  filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.8));
-
-  :global(.ms-edge .item) & {
-    // https://github.com/DestinyItemManager/DIM/issues/3291
-    filter: none !important;
+    :global(.ms-edge) & {
+      // https://github.com/DestinyItemManager/DIM/issues/3291
+      filter: none !important;
+    }
   }
 }
 

--- a/src/app/inventory/InventoryItem.m.scss.d.ts
+++ b/src/app/inventory/InventoryItem.m.scss.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'complete': string;
   'exotic': string;
   'exoticMasterwork': string;
-  'icon': string;
   'iconOverlay': string;
   'icons': string;
   'legendary': string;

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -141,11 +141,11 @@ export default function InventoryItem({
         </div>
       )}
       {(tag || item.locked || notes) && (
-        <div className={styles.icons}>
-          {item.locked && <AppIcon className={styles.icon} icon={lockIcon} />}
-          {tag && <TagIcon className={styles.icon} tag={tag} />}
-          {notes && <AppIcon className={styles.icon} icon={stickyNoteIcon} />}
-        </div>
+        <IconsContainer>
+          {item.locked && <AppIcon icon={lockIcon} />}
+          {tag && <TagIcon tag={tag} />}
+          {notes && <AppIcon icon={stickyNoteIcon} />}
+        </IconsContainer>
       )}
       {isNew && <NewItemIndicator />}
       {subclassPath?.super && (
@@ -171,4 +171,8 @@ export function borderless(item: DimItem) {
         item.itemCategoryHashes?.includes(ItemCategoryHashes.Packages))) ||
     item.isEngram
   );
+}
+
+export function IconsContainer({ children }: { children: React.ReactNode }) {
+  return <div className={styles.icons}>{children}</div>;
 }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -445,7 +445,8 @@ export function makeItem(
     createdItem.lockable ||
       createdItem.classified ||
       // Shaders
-      createdItem.bucket.hash === SHADERS_BUCKET
+      createdItem.bucket.hash === SHADERS_BUCKET ||
+      createdItem.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod)
   );
   createdItem.comparable = Boolean(createdItem.equipment && createdItem.lockable);
   createdItem.reviewable = Boolean(

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -12,8 +12,12 @@ import {
 } from 'bungie-api-ts/destiny2';
 import BungieImage, { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { RootState } from 'app/store/types';
-import { storesSelector, profileResponseSelector } from 'app/inventory/selectors';
-import { connect } from 'react-redux';
+import {
+  storesSelector,
+  profileResponseSelector,
+  itemHashTagsSelector,
+} from 'app/inventory/selectors';
+import { connect, useSelector } from 'react-redux';
 import clsx from 'clsx';
 import styles from './SocketDetails.m.scss';
 import ElementIcon from 'app/inventory/ElementIcon';
@@ -25,6 +29,10 @@ import SocketDetailsSelectedPlug from './SocketDetailsSelectedPlug';
 import { emptySet } from 'app/utils/empty';
 import { getModCostInfo } from 'app/collections/Mod';
 import { isPluggableItem } from 'app/inventory/store/sockets';
+import TagIcon from 'app/inventory/TagIcon';
+import AppIcon from 'app/shell/icons/AppIcon';
+import { stickyNoteIcon } from 'app/shell/icons';
+import { IconsContainer } from 'app/inventory/InventoryItem';
 
 interface ProvidedProps {
   item: D2Item;
@@ -273,6 +281,11 @@ export const SocketDetailsMod = React.memo(
   }) => {
     const { energyCost, energyCostElementOverlay } = getModCostInfo(itemDef, defs);
 
+    const itemHashTags = useSelector(itemHashTagsSelector);
+
+    const tag = itemHashTags?.[itemDef.hash]?.tag;
+    const notes = itemHashTags?.[itemDef.hash]?.notes;
+
     const onClickFn = onClick && (() => onClick(itemDef));
 
     return (
@@ -293,6 +306,13 @@ export const SocketDetailsMod = React.memo(
             />
             <div className="energyCost">{energyCost}</div>
           </>
+        )}
+
+        {(tag || notes) && (
+          <IconsContainer>
+            {tag && <TagIcon tag={tag} />}
+            {notes && <AppIcon icon={stickyNoteIcon} />}
+          </IconsContainer>
         )}
       </div>
     );


### PR DESCRIPTION
This is pretty basic, but it allows tagging mods from the Collections page, and the tags will show up in the Socket Details menu and in the Loadout Optimizer mod picker. It doesn't show up for slotted mods and you can't tag from anywhere except collections, though that would be easy to add to the Socket Details page at least.

* [ ] Show notes on mod details
* [ ] Show notes on LO mod picker
* [ ] Allow changing tag/notes from mod details
* [ ] Allow changing tag/notes from LO mod picker