### PR TITLE
Fewer components in getStores call

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -82,7 +82,6 @@ export function getStores(platform: DestinyAccount): Promise<DestinyProfileRespo
 export function getStoresDetails(platform: DestinyAccount): Promise<DestinyProfileResponse> {
   return getProfile(
     platform,
-    DestinyComponentType.Profiles, // Likely missing it, but not seeing where this is used
     DestinyComponentType.ProfileInventories,
     DestinyComponentType.ProfileCurrencies,
     DestinyComponentType.Characters,
@@ -101,6 +100,8 @@ export function getStoresDetails(platform: DestinyAccount): Promise<DestinyProfi
     DestinyComponentType.ItemReusablePlugs,
     // TODO: We should try to defer this until the popup is open!
     DestinyComponentType.ItemPlugObjectives,
+    // TODO: We should defer, used in /vendors (Milestones.tsx) for current season hash
+    DestinyComponentType.Profiles,
     // TODO: we should defer this unless you're on the collections screen
     DestinyComponentType.Records,
     DestinyComponentType.Metrics

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -67,7 +67,22 @@ export async function getLinkedAccounts(
 export function getStores(platform: DestinyAccount): Promise<DestinyProfileResponse> {
   return getProfile(
     platform,
-    DestinyComponentType.Profiles,
+    DestinyComponentType.ProfileInventories,
+    DestinyComponentType.ProfileCurrencies,
+    DestinyComponentType.Characters,
+    DestinyComponentType.CharacterInventories,
+    DestinyComponentType.CharacterEquipment,
+    DestinyComponentType.ItemInstances
+  );
+}
+
+/**
+ * Get the rest of the user's stores on this platform. This includes characters, vault, and item information.
+ */
+export function getStoresDetails(platform: DestinyAccount): Promise<DestinyProfileResponse> {
+  return getProfile(
+    platform,
+    DestinyComponentType.Profiles, // Likely missing it, but not seeing where this is used
     DestinyComponentType.ProfileInventories,
     DestinyComponentType.ProfileCurrencies,
     DestinyComponentType.Characters,

--- a/src/app/collections/Catalysts.tsx
+++ b/src/app/collections/Catalysts.tsx
@@ -15,6 +15,10 @@ export default function Catalysts({
   defs: D2ManifestDefinitions;
   profileResponse: DestinyProfileResponse;
 }) {
+  if (!profileResponse.characterRecords) {
+    return null;
+  }
+
   const catalystPresentationNode = defs.PresentationNode.get(CATALYSTS_ROOT_NODE);
   const firstCharacterRecords = Object.values(profileResponse.characterRecords.data || {})[0]
     .records;

--- a/src/app/collections/Collectible.tsx
+++ b/src/app/collections/Collectible.tsx
@@ -60,7 +60,7 @@ export function getCollectibleState(
   profileResponse: DestinyProfileResponse
 ) {
   return collectibleDef.scope === DestinyScope.Character
-    ? profileResponse.characterCollectibles.data
+    ? profileResponse.characterCollectibles?.data
       ? _.minBy(
           // Find the version of the collectible that's unlocked, if any
           Object.values(profileResponse.characterCollectibles.data)
@@ -69,7 +69,7 @@ export function getCollectibleState(
           (state) => state & DestinyCollectibleState.NotAcquired
         )
       : undefined
-    : profileResponse.profileCollectibles.data
+    : profileResponse.profileCollectibles?.data
     ? profileResponse.profileCollectibles.data.collectibles[collectibleDef.hash].state
     : undefined;
 }

--- a/src/app/collections/Record.tsx
+++ b/src/app/collections/Record.tsx
@@ -187,10 +187,10 @@ export function getRecordComponent(
   profileResponse: DestinyProfileResponse
 ): DestinyRecordComponent | undefined {
   return recordDef.scope === DestinyScope.Character
-    ? profileResponse.characterRecords.data
+    ? profileResponse.characterRecords?.data
       ? Object.values(profileResponse.characterRecords.data)[0].records[recordDef.hash]
       : undefined
-    : profileResponse.profileRecords.data
+    : profileResponse.profileRecords?.data
     ? profileResponse.profileRecords.data.records[recordDef.hash]
     : undefined;
 }

--- a/src/app/collections/plugset-helpers.ts
+++ b/src/app/collections/plugset-helpers.ts
@@ -1,8 +1,8 @@
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 
 export function itemsForPlugSet(profileResponse: DestinyProfileResponse, plugSetHash: number) {
-  return (profileResponse.profilePlugSets.data?.plugs[plugSetHash] || []).concat(
-    Object.values(profileResponse.characterPlugSets.data || {})
+  return (profileResponse.profilePlugSets?.data?.plugs[plugSetHash] || []).concat(
+    Object.values(profileResponse.characterPlugSets?.data || {})
       .filter((d) => d.plugs?.[plugSetHash])
       .flatMap((d) => d.plugs[plugSetHash])
   );

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -41,6 +41,8 @@ import { getArtifactBonus } from './stores-helpers';
 import { ItemPowerSet } from './ItemPowerSet';
 import { StatHashes } from 'data/d2/generated-enums';
 
+let isFirstLoad = true;
+
 /**
  * Update the high level character information for all the stores
  * (level, power, stats, etc.). This does not update the
@@ -281,10 +283,15 @@ function makeD2StoresService(): D2StoreServiceType {
   async function loadStores(account: DestinyAccount): Promise<D2Store[] | undefined> {
     resetIdTracker();
 
-    const stores = await loadData(account, getStores);
+    const storePromise = loadData(account, isFirstLoad ? getStores : getStoresDetails);
 
-    // async load the rest (no await)
-    loadData(account, getStoresDetails);
+    const stores = await storePromise;
+
+    if (isFirstLoad) {
+      // async load the rest (no await)
+      loadData(account, getStoresDetails);
+      isFirstLoad = false;
+    }
 
     return stores;
   }

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -27,7 +27,7 @@ export default function Milestones({
 }) {
   const profileMilestones = milestonesForProfile(defs, profileInfo, store.id);
   const characterProgressions = profileInfo?.characterProgressions?.data?.[store.id];
-  const season = profileInfo.profile.data?.currentSeasonHash
+  const season = profileInfo.profile?.data?.currentSeasonHash
     ? defs.Season.get(profileInfo.profile.data.currentSeasonHash)
     : undefined;
   const seasonPass = season?.seasonPassHash

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -297,11 +297,11 @@ function enhanceOwnedItemsWithPlugSets(
     });
   };
 
-  if (profileResponse.profilePlugSets.data) {
+  if (profileResponse.profilePlugSets?.data) {
     processPlugSet(profileResponse.profilePlugSets.data.plugs);
   }
 
-  if (profileResponse.characterPlugSets.data) {
+  if (profileResponse.characterPlugSets?.data) {
     for (const plugSetData of Object.values(profileResponse.characterPlugSets.data)) {
       processPlugSet(plugSetData.plugs);
     }


### PR DESCRIPTION
Just tried experimenting with stripping down the `getStores` call. Knocks off ~1.3s the API request, items also process quicker so initial load is less. When stores refresh another call kicks off to mimic the behavior before. Ideally would only request for the remaining components needed instead of asking for everything again. Leaving as a draft PR just as a test before making more progress towards that.

Was also thinking of doing the same thing on mobile, except just hitting the endpoint for the single character instead of fetching the other characters/vault/etc. Then loading the rest async after the initial 'active' character loads. 

![demo](https://user-images.githubusercontent.com/424158/91653345-b56a0c80-ea54-11ea-9851-cb59135890e0.gif)
