### PR TITLE
Rearrange buckets - move subclass to general

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -402,6 +402,8 @@ module.exports = (env) => {
         '$featureFlags.mobileInspect': JSON.stringify(!env.release),
         // New search bar
         '$featureFlags.newSearch': JSON.stringify(!env.release),
+        // Rearrange buckets in categories
+        '$featureFlags.newArrangement': JSON.stringify(!env.release),
       }),
 
       new WorkerPlugin({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+### Beta Only
+* Move Sub-class out of Weapons to the General category
+
 ## 6.26.0 <span className="changelog-date">(2020-08-23)</span>
 
 * Better touchscreen support for drag and drop.

--- a/src/app/destiny2/d2-bucket-categories.ts
+++ b/src/app/destiny2/d2-bucket-categories.ts
@@ -1,7 +1,24 @@
-export const D2Categories = {
-  Postmaster: ['Engrams', 'LostItems', 'Messages', 'SpecialOrders'],
-  Weapons: ['Class', 'Kinetic', 'Energy', 'Power', 'SeasonalArtifacts'],
-  Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
-  General: ['Ghost', 'ClanBanners', 'Vehicle', 'Ships', 'Emblems', 'Finishers'],
-  Inventory: ['Consumables', 'Modifications', 'Shaders'],
-};
+export const D2Categories = $featureFlags.newArrangement
+  ? {
+      Postmaster: ['Engrams', 'LostItems', 'Messages', 'SpecialOrders'],
+      Weapons: ['Kinetic', 'Energy', 'Power'],
+      Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
+      General: [
+        'Class',
+        'Ghost',
+        'Emblems',
+        'Ships',
+        'Vehicle',
+        'Finishers',
+        'SeasonalArtifacts',
+        'ClanBanners',
+      ],
+      Inventory: ['Consumables', 'Modifications', 'Shaders'],
+    }
+  : {
+      Postmaster: ['Engrams', 'LostItems', 'Messages', 'SpecialOrders'],
+      Weapons: ['Class', 'Kinetic', 'Energy', 'Power', 'SeasonalArtifacts'],
+      Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
+      General: ['Ghost', 'ClanBanners', 'Vehicle', 'Ships', 'Emblems', 'Finishers'],
+      Inventory: ['Consumables', 'Modifications', 'Shaders'],
+    };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -42,6 +42,8 @@ declare const $featureFlags: {
   mobileInspect: boolean;
   /** New search bar */
   newSearch: boolean;
+  /** Move subclass out of weapons */
+  newArrangement: boolean;
 };
 
 declare namespace React {


### PR DESCRIPTION
This is flagged to be Beta only while we adjust for turbulence, encouraging devs/testers to try it out before we make a decision. Personally, I've never moved the subclasses around. The subclass row takes up a lot of space, including the blank space in the vault column. I've also moved the seasonal artifact to the general section.

Moving them to general feels like a better fit, as you can now get to your gear that you actually manage a lot quicker.  

Ben has also suggested that we could add another collapsable section, splitting the 'flair' from general.
|View|Before |After |
|---|---|---|
|Desktop|<img width="759" alt="Screen Shot 2020-08-30 at 10 25 12 AM" src="https://user-images.githubusercontent.com/424158/91665625-d90c7180-eaab-11ea-980e-4d359c6e96f2.png">|<img width="757" alt="Screen Shot 2020-08-30 at 10 24 07 AM" src="https://user-images.githubusercontent.com/424158/91665642-fa6d5d80-eaab-11ea-9ed4-e06627960d55.png">|
|3 item mobile|<img width="414" alt="Screen Shot 2020-08-30 at 10 31 59 AM" src="https://user-images.githubusercontent.com/424158/91665692-59cb6d80-eaac-11ea-81ba-46666cb9de2f.png">| <img width="410" alt="Screen Shot 2020-08-30 at 10 33 53 AM" src="https://user-images.githubusercontent.com/424158/91665696-618b1200-eaac-11ea-8452-0d9c296f34f6.png">|
|5 item mobile (need to adjust stats/postmaster padding) |<img width="413" alt="Screen Shot 2020-08-30 at 10 36 17 AM" src="https://user-images.githubusercontent.com/424158/91665742-bb8bd780-eaac-11ea-89e0-f27f749b8a6a.png">|<img width="412" alt="Screen Shot 2020-08-30 at 10 34 57 AM" src="https://user-images.githubusercontent.com/424158/91665720-9dbe7280-eaac-11ea-9d52-98308c28943c.png">|