### PR TITLE
Allow selecting two columns for character inventory

### DIFF
--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -250,7 +250,7 @@ function SettingsPage({
     // archetype: 'Archetype'
   };
 
-  const charColOptions = _.range(3, 6).map((num) => ({
+  const charColOptions = _.range(2, 6).map((num) => ({
     value: num,
     name: t('Settings.ColumnSize', { num }),
   }));


### PR DESCRIPTION
A while back somebody suggested that allowing two columns in character inventory would make better use of space on iPad. I'd still like to get rid of all the columns settings in favor of automatic best-use-of-space, and #2872 is the issue for that, but in the meantime this doesn't seem like it'd hurt anything.