### PR TITLE
Prevent press-tip selection

### DIFF
--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -13,6 +13,7 @@
   z-index: 99999;
   white-space: pre-wrap;
   box-sizing: border-box;
+  user-select: none;
 
   h2 {
     background-color: #444;

--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -143,7 +143,7 @@ function Control({
   }, [open, triggerRef]);
 
   if (!tooltip) {
-    return <div>{children}</div>;
+    return <Component>{children}</Component>;
   }
 
   // TODO: if we reuse a stable tooltip container instance we could animate between them


### PR DESCRIPTION
This should prevent iOS from trying to select text inside of presstips on long/force press.

Fixes #5619