### PR TITLE
Auto-scale action buttons on mobile

### DIFF
--- a/src/app/item-popup/ItemActionButton.m.scss
+++ b/src/app/item-popup/ItemActionButton.m.scss
@@ -1,12 +1,24 @@
+@import '../variables.scss';
+
 .button {
-  background-size: cover;
-  width: 44px;
-  height: 44px;
-  text-align: center;
-  line-height: 10px;
+  > div {
+    background-size: cover;
+    width: 44px;
+    height: 44px;
+    text-align: center;
+    line-height: 10px;
+    // Auto-scale on mobile to fit screen width
+    @include phone-portrait {
+      width: calc((100vw - 20px - 9 * 4px) / 7);
+      height: calc((100vw - 20px - 9 * 4px) / 7);
+    }
+  }
   margin-right: 4px;
   cursor: pointer;
   user-select: none;
+  &:last-child {
+    margin-right: 0;
+  }
 
   &:focus {
     outline-width: 5px;

--- a/src/app/item-popup/ItemActionButton.tsx
+++ b/src/app/item-popup/ItemActionButton.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import clsx from 'clsx';
 import { useDrop } from 'react-dnd';
 import { mobileDragType } from 'app/inventory/DraggableInventoryItem';
 import styles from './ItemActionButton.m.scss';
@@ -35,13 +34,13 @@ export default function ItemActionButton({
   const ref = useRef<HTMLDivElement>(null);
 
   return (
-    <PressTip.Control tooltip={title} triggerRef={ref} open={hovering}>
+    <PressTip.Control tooltip={title} triggerRef={ref} open={hovering} className={styles.button}>
       <div
         ref={drop}
-        className={clsx(styles.button, className)}
         title={title}
         aria-label={title}
         onClick={onClick}
+        className={className}
         style={icon ? { backgroundImage: `url("${icon}")` } : undefined}
       >
         <span>{label}</span>


### PR DESCRIPTION
Fixes #3502 by responsively autoscaling the buttons on mobile - they'll get bigger for wider screens and smaller for narrower screens.