### PR TITLE
transfer infusion filter string to dim.json

### DIFF
--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -414,6 +414,7 @@
     "ToggleDetails": "Toggle showing full item details"
   },
   "Infusion": {
+    "Filter": "Filter items",
     "InfuseSource": "Select item to infuse {{name}} into",
     "InfuseTarget": "Select item to infuse into {{name}}",
     "Infusion": "Infusion Fuel Finder",


### PR DESCRIPTION
i don't think yarn i18n got run alongside 56f484f23b70cb3eecbb3e0dbed4b829c5e28b45