### PR TITLE
Only include MobileInspect when feature-flagged and in mobile view

### DIFF
--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -17,7 +17,7 @@ import GearPower from '../gear-power/GearPower';
 import { queueAction } from './action-queue';
 import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import DragPerformanceFix from 'app/inventory/DragPerformanceFix';
-import { storesLoadedSelector } from './selectors';
+import { storesLoadedSelector, isPhonePortraitSelector } from './selectors';
 import { useSubscription } from 'app/utils/hooks';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import DragGhostItem from './DragGhostItem';
@@ -30,6 +30,7 @@ interface ProvidedProps {
 
 interface StoreProps {
   storesLoaded: boolean;
+  isPhonePortrait: boolean;
 }
 
 type Props = ProvidedProps & StoreProps;
@@ -37,6 +38,7 @@ type Props = ProvidedProps & StoreProps;
 function mapStateToProps(state: RootState): StoreProps {
   return {
     storesLoaded: storesLoadedSelector(state),
+    isPhonePortrait: isPhonePortraitSelector(state),
   };
 }
 
@@ -44,7 +46,7 @@ function getStoresService(account: DestinyAccount) {
   return account.destinyVersion === 1 ? D1StoresService : D2StoresService;
 }
 
-function Inventory({ storesLoaded, account }: Props) {
+function Inventory({ storesLoaded, account, isPhonePortrait }: Props) {
   useSubscription(() => {
     const storesService = getStoresService(account);
     return refresh$.subscribe(() => queueAction(() => storesService.reloadStores()));
@@ -71,7 +73,7 @@ function Inventory({ storesLoaded, account }: Props) {
       <DragPerformanceFix />
       {account.destinyVersion === 1 ? <D1Farming /> : <D2Farming />}
       {account.destinyVersion === 2 && <GearPower />}
-      <MobileInspect />
+      {$featureFlags.mobileInspect && isPhonePortrait && <MobileInspect />}
       <DragGhostItem />
       <InfusionFinder destinyVersion={account.destinyVersion} />
       <ClearNewItems account={account} />


### PR DESCRIPTION
It got included in the build/tree even if it wasn't used.