### PR TITLE
New background (dev only)

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -404,6 +404,8 @@ module.exports = (env) => {
         '$featureFlags.newSearch': JSON.stringify(true),
         // Rearrange buckets in categories
         '$featureFlags.newArrangement': JSON.stringify(!env.release),
+        // New background design
+        '$featureFlags.gradientBackground': JSON.stringify(env.dev),
       }),
 
       new WorkerPlugin({

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -119,6 +119,7 @@ function App({
         'show-new-items': showNewItems,
         'ms-edge': /Edge/.test(navigator.userAgent),
         ios: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream,
+        gradientBackground: $featureFlags.gradientBackground,
       })}
     >
       <ScrollToTop />

--- a/src/app/collections/PresentationNode.scss
+++ b/src/app/collections/PresentationNode.scss
@@ -8,8 +8,17 @@
   > .presentation-node {
     margin-left: 10px;
 
-    > .title.collapsed {
-      background-color: #111;
+    > .title {
+      &.collapsed {
+        background-color: #111;
+      }
+      .gradientBackground & {
+        background-color: rgba(0, 0, 0, 0.2);
+        &:hover,
+        &.collapsed {
+          background-color: rgba(0, 0, 0, 0.4);
+        }
+      }
     }
 
     #triumphs & {
@@ -33,8 +42,17 @@
   /* unless they are top children of locked-open top nodes */
   &.always-expanded > .presentation-node {
     margin-left: 0;
-    > .title.collapsed {
-      background-color: #000;
+    > .title {
+      &.collapsed {
+        background-color: #000;
+      }
+      .gradientBackground & {
+        background-color: rgba(0, 0, 0, 0.2);
+        &:hover,
+        &.collapsed {
+          background-color: rgba(0, 0, 0, 0.4);
+        }
+      }
     }
   }
   &.only-child {

--- a/src/app/dim-ui/CollapsibleTitle.scss
+++ b/src/app/dim-ui/CollapsibleTitle.scss
@@ -38,6 +38,14 @@
     color: #ccc;
     background-color: black;
   }
+
+  .gradientBackground & {
+    background-color: rgba(0, 0, 0, 0.2);
+    &:hover,
+    &.collapsed {
+      background-color: rgba(0, 0, 0, 0.4);
+    }
+  }
 }
 
 .collapse-icon {

--- a/src/app/inventory/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory/InventoryCollapsibleTitle.scss
@@ -32,6 +32,9 @@
         background-color: rgba(0, 0, 0, 0.2);
       }
     }
+    .gradientBackground & {
+      background-color: transparent !important;
+    }
   }
 
   &.collapsed {

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -68,6 +68,9 @@
     .phone-portrait & {
       background-color: transparent;
     }
+    .gradientBackground & {
+      background-color: transparent;
+    }
   }
 
   > div {
@@ -212,6 +215,12 @@
         margin: 0 5px;
       }
     }
+  }
+  .gradientBackground & {
+    background: radial-gradient(circle at 50% 70px, #454568 0%, #161626 100%);
+    background-position: center top;
+    background-repeat: no-repeat;
+    background-size: 100vw 100vh;
   }
 }
 

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -414,3 +414,19 @@ a.dim-button {
     margin: auto 0 auto 4px;
   }
 }
+
+.gradientBackground {
+  &::before {
+    @include below-header;
+    background: radial-gradient(circle at 50% 70px, #454568 0%, #161626 100%);
+    background-position: center top;
+    background-repeat: no-repeat;
+    content: '';
+    left: 0;
+    right: 0;
+    bottom: 0;
+    position: fixed;
+    will-change: transform;
+    z-index: -1;
+  }
+}

--- a/src/app/organizer/ItemTypeSelector.m.scss
+++ b/src/app/organizer/ItemTypeSelector.m.scss
@@ -8,6 +8,9 @@
   flex-direction: column;
   align-items: center;
   @include vertical-space-children(8px);
+  :global(.gradientBackground) & {
+    background-color: rgba(0, 0, 0, 0.2);
+  }
 }
 
 .level {

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -264,7 +264,7 @@ export function dtrRatingColor(value: number, property = 'color') {
 }
 
 export function storeBackgroundColor(store: DimStore, index = 0, header = false) {
-  if (!store.isDestiny2() || !store.color) {
+  if ($featureFlags.gradientBackground || !store.isDestiny2() || !store.color) {
     return undefined;
   }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -44,6 +44,8 @@ declare const $featureFlags: {
   newSearch: boolean;
   /** Move subclass out of weapons */
   newArrangement: boolean;
+  /** New background */
+  gradientBackground: boolean;
 };
 
 declare namespace React {


### PR DESCRIPTION
This tests out the new gradient background we'd been talking about in mockups. It's only on in dev. I had to do some tricks to make scrolling performance stay OK - `background-attachment: fixed` causes a repaint on every frame.

Almost every screen updated fine except the Organizer, which needs an opaque background to do its fixed header magic.

<img width="1439" alt="Screen Shot 2020-08-30 at 6 49 47 PM" src="https://user-images.githubusercontent.com/313208/91675677-04b24a80-eaf2-11ea-877a-1c2ce29da75e.png">
