### PR TITLE
Introduce mod:, modname: as synonyms for perk:, perkname:

### DIFF
--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -46,6 +46,8 @@ const filterNames = [
   'source',
   'perk',
   'perkname',
+  'mod',
+  'modname',
   'name',
   'description',
 ];

--- a/src/app/search/search-config.ts
+++ b/src/app/search/search-config.ts
@@ -277,7 +277,7 @@ export function buildSearchConfig(destinyVersion: DestinyVersion): SearchConfig 
         ]
       : []),
     // all the free text searches that support quotes
-    ...['notes:', 'perk:', 'perkname:', 'name:', 'description:'],
+    ...['notes:', 'perk:', 'perkname:', 'mod:', 'modname:', 'name:', 'description:'],
   ];
 
   // create suggestion stubs for filter names

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -782,6 +782,12 @@ function searchFilters(
             ))
         );
       },
+      mod(item: DimItem, filterValue: string) {
+        return this.perk(item, filterValue);
+      },
+      modname(item: DimItem, filterValue: string) {
+        return this.perkname(item, filterValue);
+      },
       modslot(item: DimItem, filterValue: string) {
         const modSocketTypeHash = getSpecialtySocketMetadata(item);
         return (


### PR DESCRIPTION
This adds `mod:` and `modname:` as synonyms for the perk searches, because people keep asking how to search for mods.