### PR TITLE
Include plugset unlocks as "owned"

### DIFF
--- a/src/app/collections/Collectible.tsx
+++ b/src/app/collections/Collectible.tsx
@@ -50,7 +50,7 @@ export default function Collectible({
       item={item}
       owned={owned}
       unavailable={!acquired}
-      extraData={{ collectible: collectibleDef, owned, acquired }}
+      extraData={{ owned, acquired }}
     />
   );
 }

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -39,20 +39,29 @@ export const storesLoadedSelector = (state: RootState) => storesSelector(state).
 /** The current (last played) character */
 export const currentStoreSelector = (state: RootState) => getCurrentStore(storesSelector(state));
 
+/** The actual raw profile response from the Bungie.net profile API */
+export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;
+
 /** A set containing all the hashes of owned items. */
 export const ownedItemsSelector = () =>
-  createSelector(storesSelector, (stores) => {
+  createSelector(profileResponseSelector, storesSelector, (profileResponse, stores) => {
     const ownedItemHashes = new Set<number>();
     for (const store of stores) {
       for (const item of store.items) {
         ownedItemHashes.add(item.hash);
       }
     }
+    if (profileResponse?.profilePlugSets?.data) {
+      for (const plugSet of Object.values(profileResponse.profilePlugSets.data.plugs)) {
+        for (const plug of plugSet) {
+          if (plug.canInsert) {
+            ownedItemHashes.add(plug.plugItemHash);
+          }
+        }
+      }
+    }
     return ownedItemHashes;
   });
-
-/** The actual raw profile response from the Bungie.net profile API */
-export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;
 
 /** Item infos (tags/notes) */
 export const itemInfosSelector = (state: RootState): ItemInfos =>

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -193,9 +193,8 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
           </div>
         )}
 
-      {!extraInfo.mod && extraInfo.collectible && (
+      {!extraInfo.mod && (
         <div className="item-details">
-          <div>{extraInfo.collectible.sourceString}</div>
           {extraInfo.owned && (
             <div>
               <AppIcon className="owned-icon" icon={faCheck} /> {t('MovePopup.Owned')}
@@ -211,7 +210,6 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
 
       {extraInfo.mod && (
         <div className="item-details mods">
-          {extraInfo.collectible && <div>{extraInfo.collectible.sourceString}</div>}
           {extraInfo.owned && (
             <div>
               <img className="owned-icon" src={modificationIcon} /> {t('MovePopup.OwnedMod')}

--- a/src/app/item-popup/item-popup.ts
+++ b/src/app/item-popup/item-popup.ts
@@ -1,5 +1,4 @@
 import { DimItem } from '../inventory/item-types';
-import { DestinyCollectibleDefinition } from 'bungie-api-ts/destiny2';
 import { Subject } from 'rxjs';
 
 export const showItemPopup$ = new Subject<{
@@ -10,7 +9,6 @@ export const showItemPopup$ = new Subject<{
 
 // Extra optional info for Vendors/Collectibles.
 export interface ItemPopupExtraInfo {
-  collectible?: DestinyCollectibleDefinition;
   failureStrings?: string[];
   owned?: boolean;
   acquired?: boolean;

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -46,13 +46,6 @@ export default function VendorItemComponent({
     return null;
   }
 
-  const itemDef = defs.InventoryItem.get(item.item.hash);
-
-  const collectible =
-    itemDef.collectibleHash !== undefined
-      ? defs.Collectible.get(itemDef.collectibleHash)
-      : undefined;
-
   const acquired =
     item.item.isDestiny2() &&
     item.item.collectibleState !== null &&
@@ -64,7 +57,7 @@ export default function VendorItemComponent({
       unavailable={!item.canPurchase || !item.canBeSold}
       owned={owned}
       acquired={acquired}
-      extraData={{ failureStrings: item.failureStrings, collectible, owned, acquired }}
+      extraData={{ failureStrings: item.failureStrings, owned, acquired }}
     >
       {item.costs.length > 0 && (
         <div className={styles.vendorCosts}>

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -181,7 +181,7 @@ function Vendors({
   const currencyLookups = vendorsResponse?.currencyLookups.data?.itemQuantities;
 
   if (vendorGroups && filterToUnacquired) {
-    vendorGroups = filterVendorGroupsToUnacquired(vendorGroups);
+    vendorGroups = filterVendorGroupsToUnacquired(vendorGroups, ownedItemHashes);
   }
   if (vendorGroups && searchQuery.length) {
     vendorGroups = filterVendorGroupsToSearch(vendorGroups, searchQuery, filterItems);

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -187,7 +187,10 @@ export function getVendorItems(
   }
 }
 
-export function filterVendorGroupsToUnacquired(vendorGroups: readonly D2VendorGroup[]) {
+export function filterVendorGroupsToUnacquired(
+  vendorGroups: readonly D2VendorGroup[],
+  ownedItemHashes: Set<number>
+) {
   return vendorGroups
     .map((group) => ({
       ...group,
@@ -197,8 +200,10 @@ export function filterVendorGroupsToUnacquired(vendorGroups: readonly D2VendorGr
           items: vendor.items.filter(
             (item) =>
               item.item?.isDestiny2() &&
-              item.item.collectibleState !== null &&
-              item.item.collectibleState & DestinyCollectibleState.NotAcquired
+              (item.item.collectibleState !== null
+                ? item.item.collectibleState & DestinyCollectibleState.NotAcquired
+                : item.item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod) &&
+                  !ownedItemHashes.has(item.item.hash))
           ),
         }))
         .filter((v) => v.items.length),


### PR DESCRIPTION
This needs some testing, but it should allow some items not tracked in collections (emotes and ghost projections) to show as "uncollected" on the vendors screen:

Before:
<img width="1143" alt="Screen Shot 2020-08-30 at 11 19 30 PM" src="https://user-images.githubusercontent.com/313208/91688678-5faa6880-eb17-11ea-941a-10346b280333.png">

After:
<img width="1129" alt="Screen Shot 2020-08-30 at 11 19 24 PM" src="https://user-images.githubusercontent.com/313208/91688681-62a55900-eb17-11ea-9d57-fc5f7740f83d.png">

Fixes #4500