### PR TITLE
Change window chrome to black

### DIFF
--- a/src/manifest-webapp-6-2018.json
+++ b/src/manifest-webapp-6-2018.json
@@ -13,8 +13,8 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#404141",
-  "background_color": "#434444",
+  "theme_color": "black",
+  "background_color": "black",
   "display": "standalone",
   "start_url": "/index.html?utm_source=homescreen"
 }


### PR DESCRIPTION
Navigation bar has some opacity on android and the background_color set in the manifest bleeds through to a deeper gray color. If we set it to black it may look nicer. Can re-consider colors for the purple design as well. 

|Loading|Loaded|
|---|---|
|![Screenshot_20200901-165703](https://user-images.githubusercontent.com/424158/91923906-51c72580-ec86-11ea-8688-118429133815.png)|![Screenshot_20200901-124249](https://user-images.githubusercontent.com/424158/91923912-57bd0680-ec86-11ea-988d-d2f18baecbc5.png)|