### PR TITLE
Don't keep the menu open when clearing input

### DIFF
--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -212,21 +212,6 @@ function SearchBar(
         }
       }
     },
-    stateReducer: (state, actionAndChanges) => {
-      const { type, changes } = actionAndChanges;
-      switch (type) {
-        case useCombobox.stateChangeTypes.FunctionReset:
-          // Keep the menu open when we clear the input
-          return changes.inputValue !== undefined
-            ? {
-                ...changes, // default Downshift new state changes on item selection.
-                isOpen: state.isOpen, // but keep menu open
-              }
-            : changes;
-        default:
-          return changes; // otherwise business as usual.
-      }
-    },
     onInputValueChange: ({ inputValue }) => {
       setLiveQuery(inputValue || '');
       debouncedUpdateQuery(inputValue || '');
@@ -243,10 +228,7 @@ function SearchBar(
     debouncedUpdateQuery('');
     reset();
     onClear?.();
-    if (!isPhonePortrait) {
-      openMenu();
-    }
-  }, [onClear, reset, openMenu, debouncedUpdateQuery, isPhonePortrait]);
+  }, [onClear, reset, debouncedUpdateQuery]);
 
   // Reset live query when search version changes
   useEffect(() => {


### PR DESCRIPTION
I had specifically overridden Downshift's default behavior to leave the menu open when clearing it (so you could select another search) but it seems most people are just clearing it?