### PR TITLE
Revert "Upgrade body-scroll-lock"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,9 +2844,9 @@ body-parser@1.19.0:
     type-is "~1.6.17"
 
 body-scroll-lock@^3.0.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.3.tgz#cf78cc04d82328bb54276e104bda66dc93cb3695"
-  integrity sha512-KMV9MT96y2PFUL2C98e2nx/Gs2mhCAzYP6Gsu/9r7Rhn27qxu1yTnQBqHogUuvwVSbstEHNXTaToPNsL7oBZ9g==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz#221d87435bcfb50e27ab5d4508735f622aed11a2"
+  integrity sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ==
 
 bonjour@^3.5.0:
   version "3.5.0"


### PR DESCRIPTION
Reverts DestinyItemManager/DIM#5714

It seems the behavior changed, when scroll-body-lock is added, a `overflow: hidden;` style is also added to the body. When the class is removed, the style persists (previously it would also be removed.) This causes the sticky header to break. 

I'm reverting for now and can help investigate what's going on