### PR TITLE
Add redirect routes for all account-specific routes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,6 +27,7 @@ import { t } from './i18next-t';
 import IssueBanner from './banner/IssueBanner';
 import { set } from 'idb-keyval';
 import ErrorPanel from './shell/ErrorPanel';
+import AccountRedirectRoute from './shell/AccountRedirectRoute';
 
 const WhatsNew = React.lazy(
   () => import(/* webpackChunkName: "whatsNew" */ './whats-new/WhatsNew')
@@ -183,6 +184,22 @@ function App({
                     <Developer />
                   </Route>
                 )}
+                <Route
+                  path={[
+                    '/inventory',
+                    '/progress',
+                    '/collections',
+                    '/optimizer',
+                    '/organizer',
+                    '/vendors/:vendorId',
+                    '/vendors',
+                    '/record-books',
+                    '/activities',
+                  ]}
+                  exact
+                >
+                  <AccountRedirectRoute />
+                </Route>
                 <Route>
                   <DefaultAccount />
                 </Route>

--- a/src/app/shell/AccountRedirectRoute.tsx
+++ b/src/app/shell/AccountRedirectRoute.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect } from 'react';
+import { t } from 'app/i18next-t';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'app/store/types';
+import ErrorPanel from './ErrorPanel';
+import { accountsLoadedSelector, currentAccountSelector } from 'app/accounts/selectors';
+import { Redirect, useRouteMatch } from 'react-router';
+import { getPlatforms } from 'app/accounts/platforms';
+import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
+
+/**
+ * When rendered at a particular path, this component will wait for the last-used account to be loaded
+ * (showing a loading indicator if necessary) and when it is loaded, will redirect to the account-specific
+ * form of the current path.
+ *
+ * e.g. /organizer => /2131244124151/d2/organizer
+ */
+export default function AccountRedirectRoute() {
+  const account = useSelector(currentAccountSelector);
+  const accountsLoaded = useSelector(accountsLoadedSelector);
+  const profileError = useSelector((state: RootState) => state.inventory.profileError);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!accountsLoaded) {
+      dispatch(getPlatforms());
+    }
+  }, [dispatch, accountsLoaded]);
+
+  const { path } = useRouteMatch();
+
+  if (!account) {
+    return accountsLoaded ? (
+      <div className="dim-page">
+        <ErrorPanel
+          title={t('Accounts.MissingTitle')}
+          fallbackMessage={t('Accounts.MissingDescription')}
+          showTwitters={true}
+        />
+      </div>
+    ) : (
+      <ShowPageLoading message={t('Loading.Accounts')} />
+    );
+  }
+
+  if (profileError) {
+    const isManifestError = profileError.name === 'ManifestError';
+    return (
+      <div className="dim-page">
+        <ErrorPanel
+          title={
+            isManifestError
+              ? t('Accounts.ErrorLoadManifest')
+              : t('Accounts.ErrorLoadInventory', { version: account.destinyVersion })
+          }
+          error={profileError}
+          showTwitters={true}
+          showReload={true}
+        />
+      </div>
+    );
+  }
+
+  return <Redirect to={`/${account.membershipId}/d${account.destinyVersion}${path}`} />;
+}


### PR DESCRIPTION
This adds in new redirects for all the account-specific URLs - if you link to them, they'll load profiles and immediately redirect to the last-used-profile's version of that path, if possible.

Note that this only works if the last-used profile was for the Destiny version of the path. So if you link to /record-books and the user last used D2, they won't load to D1 record books, they'll just end up at their D2 inventory.

Fixes #5721 
