### PR TITLE
Records styling changes

### DIFF
--- a/src/app/collections/Record.scss
+++ b/src/app/collections/Record.scss
@@ -56,7 +56,6 @@
     border-color: #c4b578;
     color: #c4b578;
     background: transparent;
-    //opacity: 0.7;
     .record-value {
       display: none;
     }
@@ -75,7 +74,7 @@
   &.trackedInDim {
     position: relative;
     border-color: $orange;
-    border-width: 2px;
+    outline: 1px solid $orange;
     background: linear-gradient(
       scale-color($orange, $alpha: -100%) 0%,
       scale-color($orange, $alpha: -80%) 100%
@@ -85,7 +84,7 @@
   &.tracked {
     position: relative;
     border-color: #bdfc7f;
-    border-width: 2px;
+    outline: 1px solid #bdfc7f;
     background: linear-gradient(
       scale-color(#bdfc7f, $alpha: -100%) 0%,
       scale-color(#bdfc7f, $alpha: -90%) 100%

--- a/src/app/collections/Record.scss
+++ b/src/app/collections/Record.scss
@@ -2,11 +2,12 @@
 
 .triumph-record {
   position: relative;
-  background: #282828;
+  background: rgba(255, 255, 255, 0.05);
   border: 1px solid #666;
   padding: 12px;
   display: flex;
   flex-direction: row;
+  align-items: flex-start;
   box-sizing: border-box;
 
   @include phone-portrait {
@@ -52,16 +53,23 @@
   }
 
   &.redeemed {
-    border-color: $gold;
-    background-color: scale-color($gold, $alpha: -90%);
-    opacity: 0.7;
+    border-color: #c4b578;
+    color: #c4b578;
+    background: transparent;
+    //opacity: 0.7;
     .record-value {
       display: none;
+    }
+    p {
+      color: scale-color(#c4b578, $lightness: -40%);
+    }
+    .record-interval-container {
+      background-color: scale-color(#c4b578, $lightness: -20%) !important;
     }
   }
 
   &.unlocked {
-    border-color: $blue;
+    border-color: #56ecff;
   }
 
   &.trackedInDim {
@@ -70,7 +78,7 @@
     border-width: 2px;
     background: linear-gradient(
       scale-color($orange, $alpha: -100%) 0%,
-      scale-color($orange, $alpha: -90%) 100%
+      scale-color($orange, $alpha: -80%) 100%
     );
   }
 
@@ -100,7 +108,7 @@
   .dimTrackedIcon {
     position: absolute;
     display: none;
-    right: calc(58px + var(--item-size) / 3.1);
+    right: calc(50px + var(--item-size) / 3.1);
     top: -9px;
     cursor: pointer;
     width: fit-content;
@@ -134,7 +142,7 @@
 
   .record-icon {
     width: 40px;
-    height: 40px;
+    height: auto;
     flex-shrink: 0;
     margin-right: 8px;
   }

--- a/src/app/collections/Record.scss
+++ b/src/app/collections/Record.scss
@@ -73,8 +73,8 @@
 
   &.trackedInDim {
     position: relative;
-    border-color: $orange;
-    outline: 1px solid $orange;
+    border-color: #f37423;
+    outline: 1px solid #f37423;
     background: linear-gradient(
       scale-color($orange, $alpha: -100%) 0%,
       scale-color($orange, $alpha: -80%) 100%

--- a/src/app/collections/Record.tsx
+++ b/src/app/collections/Record.tsx
@@ -1,6 +1,7 @@
 import { trackTriumph } from 'app/dim-api/basic-actions';
 import { trackedTriumphsSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
+import { Reward } from 'app/progress/Reward';
 import { percent } from 'app/shell/filters';
 import { RootState } from 'app/store/types';
 import {
@@ -188,6 +189,12 @@ export default function Record({
             <ExternalLink href={loreLink}>{t('MovePopup.ReadLore')}</ExternalLink>
           </div>
         )}
+        {recordDef.rewardItems?.length > 0 &&
+          !acquired &&
+          !obscured &&
+          recordDef.rewardItems.map((reward) => (
+            <Reward key={reward.itemHash} reward={reward} defs={defs} />
+          ))}
         {trackedInGame && <img className="trackedIcon" src={trackedIcon} />}
         {(!acquired || trackedInDim) && (
           <div role="button" onClick={toggleTracked} className="dimTrackedIcon">

--- a/src/app/collections/collections.scss
+++ b/src/app/collections/collections.scss
@@ -1,7 +1,8 @@
 @import '../variables.scss';
 
 .collections-page {
-  margin-top: 16px;
+  margin-top: 8px;
+  user-select: text;
 }
 
 .collections-partners {

--- a/src/app/progress/TrackedTriumphs.tsx
+++ b/src/app/progress/TrackedTriumphs.tsx
@@ -21,7 +21,7 @@ export function TrackedTriumphs({
   searchQuery?: string;
 }) {
   const recordHashes = trackedRecordHash
-    ? [trackedRecordHash, ...trackedTriumphs]
+    ? [...new Set([trackedRecordHash, ...trackedTriumphs])]
     : trackedTriumphs;
   let records = _.compact(recordHashes.map((h) => toRecord(defs, profileResponse, h)));
 

--- a/src/images/dimTrackedIcon.svg
+++ b/src/images/dimTrackedIcon.svg
@@ -1,16 +1,1 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="0 0 30 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <g transform="matrix(1,0,0,1,-124.539,-376.021)">
-        <path d="M124.539,376.021L124.539,399.083L139.38,408.71L154.22,399.484L154.22,376.021L124.539,376.021Z" style="fill:rgb(243,116,35);"/>
-        <circle cx="139.48" cy="390.761" r="11.933" style="fill:rgb(86,43,15);"/>
-        <g transform="matrix(0.0607322,0,0,0.0607322,122.136,357.843)">
-            <g transform="matrix(0.7071,-0.7071,0.7071,0.7071,54.3334,538.494)">
-                <rect x="138.3" y="143.2" width="45.5" height="45.5" style="fill:rgb(243,116,35);fill-rule:nonzero;"/>
-            </g>
-            <g transform="matrix(1,0,0,1,124.539,376.021)">
-                <path d="M161,5L128.8,37.2L257.7,166L161,262.6L64.4,166L128.8,101.6L96.6,69.4L0,166L161,327L322.1,166L161,5Z" style="fill:rgb(243,116,35);fill-rule:nonzero;"/>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" viewBox="0 0 30 33" xmlns="http://www.w3.org/2000/svg"><g transform="translate(-124.539 -376.021)"><path d="m124.539 376.021v23.062l14.841 9.627 14.84-9.226v-23.463z" fill="#f37423"/><circle cx="139.48" cy="390.761" fill="#562b0f" r="11.933"/><g fill="#f37423" fill-rule="nonzero"><path d="m138.3 143.2h45.5v45.5h-45.5z" transform="matrix(.04294373862 -.04294373862 .04294373862 .04294373862 125.43578691548 390.5469253068)"/><path d="m161 5-32.2 32.2 128.9 128.8-96.7 96.6-96.6-96.6 64.4-64.4-32.2-32.2-96.6 96.6 161 161 161.1-161z" transform="matrix(.0607322 0 0 .0607322 129.6995274558 380.6795825762)"/></g></g></svg>


### PR DESCRIPTION
Tweaks to both match the in-game UI better, and distinguish our different record states:

<img width="1201" alt="Screen Shot 2020-09-05 at 10 37 08 PM" src="https://user-images.githubusercontent.com/313208/92319352-f2418080-efcb-11ea-8e0d-45df93c043b5.png">
<img width="1183" alt="Screen Shot 2020-09-05 at 10 37 14 PM" src="https://user-images.githubusercontent.com/313208/92319353-f53c7100-efcb-11ea-8b93-cf7d32f03596.png">
<img width="1166" alt="Screen Shot 2020-09-05 at 10 54 57 PM" src="https://user-images.githubusercontent.com/313208/92319354-f5d50780-efcb-11ea-8320-baa4cab7ef95.png">
