### PR TITLE
show mod slot type when it's an empty seasonal socket

### DIFF
--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -15,11 +15,15 @@
   box-sizing: border-box;
   user-select: none;
 
-  h2 {
+  h2,
+  h3 {
     background-color: #444;
     margin: 0 0 4px 0;
     font-size: 14px;
     @include destiny-header;
+  }
+  h3 {
+    font-size: 12px;
   }
 
   hr {

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -2,6 +2,7 @@ import BungieImage from 'app/dim-ui/BungieImage';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { t } from 'app/i18next-t';
 import { statAllowList } from 'app/inventory/store/stats';
+import { emptySpecialtySocketHashes } from 'app/utils/item-utils';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import _ from 'lodash';
 import React from 'react';
@@ -36,6 +37,9 @@ export default function PlugTooltip({
   return (
     <>
       <h2>{plug.plugDef.displayProperties.name}</h2>
+      {emptySpecialtySocketHashes.includes(plug.plugDef.hash) && (
+        <h3>{plug.plugDef.itemTypeDisplayName}</h3>
+      )}
 
       {plug.plugDef.displayProperties.description ? (
         <div>

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -106,7 +106,9 @@ export default function SocketDetailsSelectedPlug({
       <div className={styles.modDescription}>
         <h3>
           {plug.displayProperties.name}
-          {emptySpecialtySocketHashes.includes(plug.hash) && ` -- ${plug.itemTypeDisplayName}`}
+          {emptySpecialtySocketHashes.includes(plug.hash) && (
+            <> &mdash; {plug.itemTypeDisplayName}</>
+          )}
         </h3>
         {selectedPlugPerk ? (
           <div>{selectedPlugPerk.displayProperties.description}</div>

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -7,6 +7,7 @@ import {
   PluggableInventoryItemDefinition,
 } from 'app/inventory/item-types';
 import { interpolateStatValue } from 'app/inventory/store/stats';
+import { emptySpecialtySocketHashes } from 'app/utils/item-utils';
 import { StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
@@ -103,7 +104,10 @@ export default function SocketDetailsSelectedPlug({
         })}
       </div>
       <div className={styles.modDescription}>
-        <h3>{plug.displayProperties.name}</h3>
+        <h3>
+          {plug.displayProperties.name}
+          {emptySpecialtySocketHashes.includes(plug.hash) && ` -- ${plug.itemTypeDisplayName}`}
+        </h3>
         {selectedPlugPerk ? (
           <div>{selectedPlugPerk.displayProperties.description}</div>
         ) : (

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -177,9 +177,9 @@ export function ItemTriage({ item }: { item: D2Item }) {
           factorCombosLabels.map((comboDisplay, i) => (
             <React.Fragment key={i}>
               {comboDisplay}
-              <div className={styles.comboCount}>{itemFactors?.[i].count}</div>
+              <div className={styles.comboCount}>{itemFactors?.[i]?.count}</div>
               <div className={styles.keepMeter}>
-                {itemFactors && <KeepJunkDial value={itemFactors[i].quality} />}
+                {itemFactors && <KeepJunkDial value={itemFactors[i]?.quality} />}
               </div>
             </React.Fragment>
           ))}

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -44,6 +44,10 @@ export const specialtyModPlugCategoryHashes = modSocketMetadata.flatMap(
   (modMetadata) => modMetadata.compatiblePlugCategoryHashes
 );
 
+export const emptySpecialtySocketHashes = modSocketMetadata.map(
+  (modMetadata) => modMetadata.emptyModSocketHash
+);
+
 /** verifies an item is d2 armor and has a specialty mod slot, which is returned */
 export const getSpecialtySocket = (item: DimItem): DimSocket | undefined => {
   if (item.isDestiny2() && item.bucket.inArmor) {


### PR DESCRIPTION
closes #5744 
we already know from d2ai which plug hashes are the seasonal "empty mod slot" items, so this checks for that and adds some text

shown here are the additional 2 places that text (**Arrival Armor Mod**) will appear
![image](https://user-images.githubusercontent.com/68782081/92646893-f1467280-f29b-11ea-8cbb-6f5edf5c6689.png)
