### PR TITLE
Add keys to item popup components so they mount/unmount

### DIFF
--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -220,6 +220,7 @@ function ItemPopupContainer({
   const header = (
     <ItemPopupHeader
       item={item}
+      key={item.index}
       language={language}
       expanded={isPhonePortrait || itemDetails}
       showToggle={!isPhonePortrait}
@@ -230,6 +231,7 @@ function ItemPopupContainer({
   const body = (
     <ItemPopupBody
       item={item}
+      key={item.index}
       extraInfo={currentItem.extraInfo}
       tab={tab}
       expanded={isPhonePortrait || itemDetails}

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -220,7 +220,7 @@ function ItemPopupContainer({
   const header = (
     <ItemPopupHeader
       item={item}
-      key={item.index}
+      key={`header${item.index}`}
       language={language}
       expanded={isPhonePortrait || itemDetails}
       showToggle={!isPhonePortrait}
@@ -231,7 +231,7 @@ function ItemPopupContainer({
   const body = (
     <ItemPopupBody
       item={item}
-      key={item.index}
+      key={`body${item.index}`}
       extraInfo={currentItem.extraInfo}
       tab={tab}
       expanded={isPhonePortrait || itemDetails}


### PR DESCRIPTION
The item popup components will get reused if you click on a different item while one is already open. Adding `key` forces them to unmount and remount between items.