### PR TITLE
Move some potentially slow calls to async

### DIFF
--- a/src/app/bungie-api/rate-limit-config.ts
+++ b/src/app/bungie-api/rate-limit-config.ts
@@ -21,6 +21,13 @@ export default function setupRateLimiter() {
     )
   );
   RateLimiterConfig.addLimiter(
+    new RateLimiterQueue(
+      /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/PullFromPostmaster/,
+      1,
+      100
+    )
+  );
+  RateLimiterConfig.addLimiter(
     new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100)
   );
 }

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -477,20 +477,23 @@ function ItemService(): ItemServiceType {
     item = newItem.owner !== 'vault' && equip ? await equipItem(newItem) : newItem;
 
     if (overrideLockState !== undefined) {
-      console.log(
-        'Resetting lock status of',
-        item.name,
-        'to',
-        overrideLockState,
-        'when moving to',
-        store.name,
-        'to work around Bungie.net lock state bug'
-      );
-      try {
-        await setItemLockState(item, overrideLockState);
-      } catch (e) {
-        console.error('Lock state override failed', e);
-      }
+      // Run this async, without waiting for the result
+      (async () => {
+        console.log(
+          'Resetting lock status of',
+          item.name,
+          'to',
+          overrideLockState,
+          'when moving to',
+          store.name,
+          'to work around Bungie.net lock state bug'
+        );
+        try {
+          await setItemLockState(item, overrideLockState);
+        } catch (e) {
+          console.error('Lock state override failed', e);
+        }
+      })();
     }
 
     return item;

--- a/src/app/inventory/move-dropped-item.ts
+++ b/src/app/inventory/move-dropped-item.ts
@@ -102,7 +102,7 @@ export default queuedAction(
 
         const reload = item.equipped || equip;
         if (reload) {
-          await (rxStore.dispatch(updateCharacters()) as any);
+          rxStore.dispatch(updateCharacters());
         }
 
         item.updateManualMoveTimestamp();

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -31,7 +31,7 @@ export const moveItemTo = queuedAction(
         if (reload) {
           // TODO: only reload the character that changed?
           // Refresh light levels and such
-          await (rxStore.dispatch(updateCharacters()) as any);
+          rxStore.dispatch(updateCharacters());
         }
 
         item.updateManualMoveTimestamp();

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -209,7 +209,7 @@ async function doApplyLoadout(
   // We need to do this until https://github.com/DestinyItemManager/DIM/issues/323
   // is fixed on Bungie's end. When that happens, just remove this call.
   if (scope.successfulItems.length > 0) {
-    await (reduxStore.dispatch(updateCharacters()) as any);
+    reduxStore.dispatch(updateCharacters());
   }
 
   if (loadout.clearSpace) {


### PR DESCRIPTION
A partial workaround to #5759, fixes #5756. Anecdotally, transfers are snappier now, but they still bog down if you do enough of them.