### PR TITLE
useLoadStores hook

### DIFF
--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -4,6 +4,7 @@ import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
+import { useLoadStores } from 'app/inventory/store/hooks';
 import { TrackedTriumphs } from 'app/progress/TrackedTriumphs';
 import { ItemFilter } from 'app/search/filter-types';
 import { searchFilterSelector } from 'app/search/search-filter';
@@ -11,16 +12,14 @@ import { setSetting } from 'app/settings/actions';
 import { settingsSelector } from 'app/settings/reducer';
 import { querySelector } from 'app/shell/reducer';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
-import { useSubscription } from 'app/utils/hooks';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { useParams } from 'react-router';
 import { createSelector } from 'reselect';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
-import { D2StoresService } from '../inventory/d2-stores';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import {
   bucketsSelector,
@@ -28,7 +27,6 @@ import {
   profileResponseSelector,
   storesSelector,
 } from '../inventory/selectors';
-import { refresh$ } from '../shell/refresh';
 import Catalysts from './Catalysts';
 import './collections.scss';
 import LegacyTriumphs from './LegacyTriumphs';
@@ -83,11 +81,6 @@ function mapStateToProps() {
   };
 }
 
-const refreshStores = () =>
-  refresh$.subscribe(() => {
-    D2StoresService.reloadStores();
-  });
-
 /**
  * The collections screen that shows items you can get back from the vault, like emblems and exotics.
  */
@@ -105,11 +98,7 @@ function Collections({
   redactedRecordsRevealed,
   dispatch,
 }: Props) {
-  useEffect(() => {
-    D2StoresService.getStoresStream(account);
-  }, [account]);
-
-  useSubscription(refreshStores);
+  useLoadStores(account, Boolean(profileResponse));
 
   const { presentationNodeHashStr } = useParams<{ presentationNodeHashStr: string }>();
   const presentationNodeHash = presentationNodeHashStr

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -1,5 +1,6 @@
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
+import { useLoadStores } from 'app/inventory/store/hooks';
 import { RootState } from 'app/store/types';
 import clsx from 'clsx';
 import _ from 'lodash';
@@ -9,7 +10,6 @@ import { DestinyAccount } from '../../accounts/destiny-account';
 import CharacterTileButton from '../../character-tile/CharacterTileButton';
 import BungieImage, { bungieBackgroundStyle } from '../../dim-ui/BungieImage';
 import CollapsibleTitle from '../../dim-ui/CollapsibleTitle';
-import { D1StoresService } from '../../inventory/d1-stores';
 import { sortedStoresSelector } from '../../inventory/selectors';
 import { D1Store, DimStore } from '../../inventory/store-types';
 import { AppIcon, starIcon } from '../../shell/icons';
@@ -65,169 +65,14 @@ function mapStateToProps(state: RootState): StoreProps {
   };
 }
 
-class Activities extends React.Component<Props> {
-  componentDidMount() {
-    D1StoresService.getStoresStream(this.props.account);
+function Activities({ account, defs, stores }: Props) {
+  useLoadStores(account, stores.length > 0);
+
+  if (!defs || !stores.length) {
+    return <ShowPageLoading message={t('Loading.Profile')} />;
   }
 
-  render() {
-    const { stores, defs } = this.props;
-
-    if (!defs || !stores.length) {
-      return <ShowPageLoading message={t('Loading.Profile')} />;
-    }
-
-    const characters = stores.filter((s) => !s.isVault);
-
-    const activities = this.init(characters as D1Store[], defs);
-
-    return (
-      <div className="activities dim-page">
-        <div className="activities-characters">
-          {characters.map((store) => (
-            <div key={store.id} className="activities-character">
-              <CharacterTileButton character={store} />
-            </div>
-          ))}
-        </div>
-
-        {activities.map((activity) => (
-          <div key={activity.hash} className="activity">
-            <CollapsibleTitle
-              style={bungieBackgroundStyle(activity.image)}
-              className={clsx('title activity-header', {
-                'activity-featured': activity.featured,
-              })}
-              sectionId={`activities-${activity.hash}`}
-              title={
-                <>
-                  <BungieImage src={activity.icon} className="small-icon" />
-                  <span className="activity-name">{activity.name}</span>
-                  {activity.featured && <AppIcon icon={starIcon} />}
-                </>
-              }
-              extra={<span className="activity-type">{activity.type}</span>}
-            >
-              <div className="activity-info">
-                {activity.tiers.map((tier) => (
-                  <div key={tier.name} className="activity-progress">
-                    {activity.tiers.length > 1 && <div className="tier-title">{tier.name}</div>}
-                    <div className="tier-characters">
-                      {_.sortBy(tier.characters, (c) =>
-                        characters.findIndex((s) => s.id === c.id)
-                      ).map((character) => (
-                        <div key={character.id} className="tier-row">
-                          {character.steps.map((step, index) => (
-                            <span
-                              key={index}
-                              className={clsx('step-icon', { complete: step.complete })}
-                            />
-                          ))}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-
-                {activity.skulls?.map((skull) => (
-                  <div key={skull.displayName} className="activity-skulls">
-                    <BungieImage src={skull.icon} className="small-icon" />
-                    {skull.displayName}
-                    <span className="weak"> - {skull.description}</span>
-                  </div>
-                ))}
-              </div>
-            </CollapsibleTitle>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  // TODO: Ideally there would be an Advisors service that would
-  // lazily load advisor info, and we'd get that info
-  // here. Unfortunately we're also using advisor info to populate
-  // extra info in Trials cards in Store service, and it's more
-  // efficient to just fish the info out of there.
-
-  private init = (stores: D1Store[], defs: D1ManifestDefinitions) => {
-    const allowList = [
-      'vaultofglass',
-      'crota',
-      'kingsfall',
-      'wrathofthemachine',
-      // 'elderchallenge',
-      'nightfall',
-      'heroicstrike',
-    ];
-
-    const rawActivities = Object.values(stores[0].advisors.activities).filter(
-      (a: any) => a.activityTiers && allowList.includes(a.identifier)
-    );
-    const activities = _.sortBy(rawActivities, (a: any) => {
-      const ix = allowList.indexOf(a.identifier);
-      return ix === -1 ? 999 : ix;
-    }).map((a) => this.processActivities(defs, stores, a));
-
-    activities.forEach((a) => {
-      a.tiers.forEach((t) => {
-        if (t.hash === stores[0].advisors.activities.weeklyfeaturedraid.display.activityHash) {
-          a.featured = true;
-          t.name = t.hash === 1387993552 ? '390' : t.name;
-        }
-      });
-    });
-
-    return activities;
-  };
-
-  private processActivities = (
-    defs: D1ManifestDefinitions,
-    stores: D1Store[],
-    rawActivity
-  ): Activity => {
-    const def = defs.Activity.get(rawActivity.display.activityHash);
-    const activity = {
-      hash: rawActivity.display.activityHash,
-      name: def.activityName,
-      icon: rawActivity.display.icon,
-      image: rawActivity.display.image,
-      type:
-        rawActivity.identifier === 'nightfall'
-          ? t('Activities.Nightfall')
-          : rawActivity.identifier === 'heroicstrike'
-          ? t('Activities.WeeklyHeroic')
-          : defs.ActivityType.get(def.activityTypeHash).activityTypeName,
-      skulls: null as Skull[] | null,
-      tiers: [] as ActivityTier[],
-    };
-
-    if (rawActivity.extended) {
-      activity.skulls = rawActivity.extended.skullCategories.map((s) => s.skulls.flat());
-    }
-
-    const rawSkullCategories = rawActivity.activityTiers[0].skullCategories;
-    if (rawSkullCategories?.length) {
-      activity.skulls = rawSkullCategories[0].skulls.flat();
-    }
-
-    if (activity.skulls) {
-      activity.skulls = i18nActivitySkulls(activity.skulls, defs);
-    }
-
-    // flatten modifiers and bonuses for now.
-    if (activity.skulls) {
-      activity.skulls = activity.skulls.flat();
-    }
-
-    activity.tiers = rawActivity.activityTiers.map((r, i) =>
-      this.processActivity(defs, rawActivity.identifier, stores, r, i)
-    );
-
-    return activity;
-  };
-
-  private processActivity = (
+  const processActivity = (
     defs: D1ManifestDefinitions,
     activityId: string,
     stores: D1Store[],
@@ -272,6 +117,149 @@ class Activities extends React.Component<Props> {
       characters,
     };
   };
+
+  const processActivities = (
+    defs: D1ManifestDefinitions,
+    stores: D1Store[],
+    rawActivity
+  ): Activity => {
+    const def = defs.Activity.get(rawActivity.display.activityHash);
+    const activity = {
+      hash: rawActivity.display.activityHash,
+      name: def.activityName,
+      icon: rawActivity.display.icon,
+      image: rawActivity.display.image,
+      type:
+        rawActivity.identifier === 'nightfall'
+          ? t('Activities.Nightfall')
+          : rawActivity.identifier === 'heroicstrike'
+          ? t('Activities.WeeklyHeroic')
+          : defs.ActivityType.get(def.activityTypeHash).activityTypeName,
+      skulls: null as Skull[] | null,
+      tiers: [] as ActivityTier[],
+    };
+
+    if (rawActivity.extended) {
+      activity.skulls = rawActivity.extended.skullCategories.map((s) => s.skulls.flat());
+    }
+
+    const rawSkullCategories = rawActivity.activityTiers[0].skullCategories;
+    if (rawSkullCategories?.length) {
+      activity.skulls = rawSkullCategories[0].skulls.flat();
+    }
+
+    if (activity.skulls) {
+      activity.skulls = i18nActivitySkulls(activity.skulls, defs);
+    }
+
+    // flatten modifiers and bonuses for now.
+    if (activity.skulls) {
+      activity.skulls = activity.skulls.flat();
+    }
+
+    activity.tiers = rawActivity.activityTiers.map((r, i) =>
+      processActivity(defs, rawActivity.identifier, stores, r, i)
+    );
+
+    return activity;
+  };
+
+  const init = (stores: D1Store[], defs: D1ManifestDefinitions) => {
+    const allowList = [
+      'vaultofglass',
+      'crota',
+      'kingsfall',
+      'wrathofthemachine',
+      // 'elderchallenge',
+      'nightfall',
+      'heroicstrike',
+    ];
+
+    const rawActivities = Object.values(stores[0].advisors.activities).filter(
+      (a: any) => a.activityTiers && allowList.includes(a.identifier)
+    );
+    const activities = _.sortBy(rawActivities, (a: any) => {
+      const ix = allowList.indexOf(a.identifier);
+      return ix === -1 ? 999 : ix;
+    }).map((a) => processActivities(defs, stores, a));
+
+    activities.forEach((a) => {
+      a.tiers.forEach((t) => {
+        if (t.hash === stores[0].advisors.activities.weeklyfeaturedraid.display.activityHash) {
+          a.featured = true;
+          t.name = t.hash === 1387993552 ? '390' : t.name;
+        }
+      });
+    });
+
+    return activities;
+  };
+
+  const characters = stores.filter((s) => !s.isVault);
+
+  const activities = init(characters as D1Store[], defs);
+
+  return (
+    <div className="activities dim-page">
+      <div className="activities-characters">
+        {characters.map((store) => (
+          <div key={store.id} className="activities-character">
+            <CharacterTileButton character={store} />
+          </div>
+        ))}
+      </div>
+
+      {activities.map((activity) => (
+        <div key={activity.hash} className="activity">
+          <CollapsibleTitle
+            style={bungieBackgroundStyle(activity.image)}
+            className={clsx('title activity-header', {
+              'activity-featured': activity.featured,
+            })}
+            sectionId={`activities-${activity.hash}`}
+            title={
+              <>
+                <BungieImage src={activity.icon} className="small-icon" />
+                <span className="activity-name">{activity.name}</span>
+                {activity.featured && <AppIcon icon={starIcon} />}
+              </>
+            }
+            extra={<span className="activity-type">{activity.type}</span>}
+          >
+            <div className="activity-info">
+              {activity.tiers.map((tier) => (
+                <div key={tier.name} className="activity-progress">
+                  {activity.tiers.length > 1 && <div className="tier-title">{tier.name}</div>}
+                  <div className="tier-characters">
+                    {_.sortBy(tier.characters, (c) =>
+                      characters.findIndex((s) => s.id === c.id)
+                    ).map((character) => (
+                      <div key={character.id} className="tier-row">
+                        {character.steps.map((step, index) => (
+                          <span
+                            key={index}
+                            className={clsx('step-icon', { complete: step.complete })}
+                          />
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+
+              {activity.skulls?.map((skull) => (
+                <div key={skull.displayName} className="activity-skulls">
+                  <BungieImage src={skull.icon} className="small-icon" />
+                  {skull.displayName}
+                  <span className="weak"> - {skull.description}</span>
+                </div>
+              ))}
+            </div>
+          </CollapsibleTitle>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 const skullHashesByName: { [name: string]: number | undefined } = {

--- a/src/app/destiny1/record-books/RecordBooks.tsx
+++ b/src/app/destiny1/record-books/RecordBooks.tsx
@@ -1,7 +1,8 @@
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
+import { useLoadStores } from 'app/inventory/store/hooks';
 import { settingsSelector } from 'app/settings/reducer';
-import { RootState } from 'app/store/types';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React from 'react';
@@ -9,13 +10,10 @@ import { connect } from 'react-redux';
 import { DestinyAccount } from '../../accounts/destiny-account';
 import BungieImage, { bungieBackgroundStyle } from '../../dim-ui/BungieImage';
 import CollapsibleTitle from '../../dim-ui/CollapsibleTitle';
-import { D1StoresService } from '../../inventory/d1-stores';
 import { storesSelector } from '../../inventory/selectors';
 import { D1Store } from '../../inventory/store-types';
 import Objective from '../../progress/Objective';
 import { setSetting } from '../../settings/actions';
-import { refresh$ } from '../../shell/refresh';
-import { Subscriptions } from '../../utils/rx-utils';
 import { count } from '../../utils/util';
 import { D1ManifestDefinitions } from '../d1-definitions';
 import './record-books.scss';
@@ -30,11 +28,6 @@ interface StoreProps {
   defs?: D1ManifestDefinitions;
 }
 
-const mapDispatchToProps = {
-  setSetting,
-};
-type DispatchProps = typeof mapDispatchToProps;
-
 function mapStateToProps(state: RootState): StoreProps {
   const settings = settingsSelector(state);
   return {
@@ -44,7 +37,7 @@ function mapStateToProps(state: RootState): StoreProps {
   };
 }
 
-type Props = ProvidedProps & StoreProps & DispatchProps;
+type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 
 interface RecordBook {
   hash: string;
@@ -70,127 +63,14 @@ interface RecordBookPage {
   completedCount: number;
 }
 
-class RecordBooks extends React.Component<Props> {
-  private subscriptions = new Subscriptions();
+function RecordBooks({ account, defs, stores, hideCompletedRecords, dispatch }: Props) {
+  useLoadStores(account, stores.length > 0);
 
-  componentDidMount() {
-    D1StoresService.getStoresStream(this.props.account);
-    this.subscriptions.add(
-      refresh$.subscribe(() => {
-        D1StoresService.reloadStores();
-      })
-    );
+  if (!defs || !stores.length) {
+    return <ShowPageLoading message={t('Loading.Profile')} />;
   }
-
-  componentWillUnmount() {
-    this.subscriptions.unsubscribe();
-  }
-
-  render() {
-    const { defs, stores, hideCompletedRecords } = this.props;
-
-    if (!defs || !stores.length) {
-      return <ShowPageLoading message={t('Loading.Profile')} />;
-    }
-
-    const rawRecordBooks = stores[0].advisors.recordBooks;
-    const recordBooks = _.sortBy(
-      _.map(rawRecordBooks, (rb) => this.processRecordBook(defs, rb)),
-      (rb) => [rb.complete, new Date(rb.startDate).getTime()]
-    );
-
-    return (
-      <div
-        className={clsx('record-books', 'dim-page', {
-          'hide-complete': hideCompletedRecords,
-        })}
-      >
-        <h1>
-          <div className="hide-completed">
-            <label>
-              <input
-                type="checkbox"
-                checked={hideCompletedRecords}
-                onChange={this.hideCompletedRecordsChanged}
-              />
-              <span>{t('RecordBooks.HideCompleted')}</span>
-            </label>
-          </div>
-        </h1>
-
-        {recordBooks.map((book) => (
-          <CollapsibleTitle
-            key={book.hash}
-            sectionId={'rb-' + book.hash}
-            title={
-              <>
-                <BungieImage src={book.icon} className="book-icon" /> {book.name}
-              </>
-            }
-            extra={
-              <span className="record-book-completion">
-                {book.completedCount} / {book.recordCount}
-              </span>
-            }
-          >
-            <div className="record-book">
-              {book.pages.map(
-                (page) =>
-                  !page.rewardsPage && (
-                    <div
-                      key={page.id}
-                      className={clsx('record-book-page', { complete: page.complete })}
-                    >
-                      <CollapsibleTitle
-                        sectionId={'rbpage-' + page.id}
-                        title={<span className="record-book-page-title">{page.name}</span>}
-                        extra={
-                          <span className="record-book-completion">
-                            {page.completedCount} / {page.records.length}
-                          </span>
-                        }
-                      >
-                        <p>{page.description}</p>
-
-                        {page.records.length && (
-                          <div className="record-page-records">
-                            {page.records.map((record) => (
-                              <div
-                                key={record.hash}
-                                className={clsx('record', { complete: record.complete })}
-                              >
-                                <div
-                                  className="record-icon"
-                                  style={bungieBackgroundStyle(record.icon)}
-                                />
-                                <div className="record-info">
-                                  <h3>{record.name}</h3>
-                                  <p>{record.description}</p>
-                                  {record.objectives.map((objective) => (
-                                    <Objective
-                                      key={objective.objectiveHash}
-                                      defs={defs}
-                                      objective={objective}
-                                    />
-                                  ))}
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </CollapsibleTitle>
-                    </div>
-                  )
-              )}
-            </div>
-          </CollapsibleTitle>
-        ))}
-      </div>
-    );
-  }
-
-  private hideCompletedRecordsChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.props.setSetting('hideCompletedRecords', e.currentTarget.checked);
+  const hideCompletedRecordsChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setSetting('hideCompletedRecords', e.currentTarget.checked));
   };
 
   // TODO: Ideally there would be an Advisors service that would
@@ -199,7 +79,7 @@ class RecordBooks extends React.Component<Props> {
   // extra info in Trials cards in Store service, and it's more
   // efficient to just fish the info out of there.
 
-  private processRecordBook = (defs: D1ManifestDefinitions, rawRecordBook): RecordBook => {
+  const processRecordBook = (defs: D1ManifestDefinitions, rawRecordBook): RecordBook => {
     // TODO: rewards are in "spotlights"
     // TODO: rank
 
@@ -218,7 +98,20 @@ class RecordBooks extends React.Component<Props> {
       percentComplete: undefined as number | undefined,
     };
 
-    const records = Object.values(rawRecordBook.records).map((r) => this.processRecord(defs, r));
+    const processRecord = (defs: D1ManifestDefinitions, record) => {
+      const recordDef = defs.Record.get(record.recordHash);
+
+      return {
+        hash: record.recordHash,
+        icon: recordDef.icon,
+        description: recordDef.description,
+        name: recordDef.displayName,
+        objectives: record.objectives,
+        complete: record.objectives.every((o) => o.isComplete),
+      };
+    };
+
+    const records = Object.values(rawRecordBook.records).map((r) => processRecord(defs, r));
     const recordByHash = _.keyBy(records, (r) => r.hash);
 
     let i = 0;
@@ -260,18 +153,100 @@ class RecordBooks extends React.Component<Props> {
     return recordBook;
   };
 
-  private processRecord = (defs: D1ManifestDefinitions, record) => {
-    const recordDef = defs.Record.get(record.recordHash);
+  const rawRecordBooks = stores[0].advisors.recordBooks;
+  const recordBooks = _.sortBy(
+    _.map(rawRecordBooks, (rb) => processRecordBook(defs, rb)),
+    (rb) => [rb.complete, new Date(rb.startDate).getTime()]
+  );
 
-    return {
-      hash: record.recordHash,
-      icon: recordDef.icon,
-      description: recordDef.description,
-      name: recordDef.displayName,
-      objectives: record.objectives,
-      complete: record.objectives.every((o) => o.isComplete),
-    };
-  };
+  return (
+    <div
+      className={clsx('record-books', 'dim-page', {
+        'hide-complete': hideCompletedRecords,
+      })}
+    >
+      <h1>
+        <div className="hide-completed">
+          <label>
+            <input
+              type="checkbox"
+              checked={hideCompletedRecords}
+              onChange={hideCompletedRecordsChanged}
+            />
+            <span>{t('RecordBooks.HideCompleted')}</span>
+          </label>
+        </div>
+      </h1>
+
+      {recordBooks.map((book) => (
+        <CollapsibleTitle
+          key={book.hash}
+          sectionId={'rb-' + book.hash}
+          title={
+            <>
+              <BungieImage src={book.icon} className="book-icon" /> {book.name}
+            </>
+          }
+          extra={
+            <span className="record-book-completion">
+              {book.completedCount} / {book.recordCount}
+            </span>
+          }
+        >
+          <div className="record-book">
+            {book.pages.map(
+              (page) =>
+                !page.rewardsPage && (
+                  <div
+                    key={page.id}
+                    className={clsx('record-book-page', { complete: page.complete })}
+                  >
+                    <CollapsibleTitle
+                      sectionId={'rbpage-' + page.id}
+                      title={<span className="record-book-page-title">{page.name}</span>}
+                      extra={
+                        <span className="record-book-completion">
+                          {page.completedCount} / {page.records.length}
+                        </span>
+                      }
+                    >
+                      <p>{page.description}</p>
+
+                      {page.records.length && (
+                        <div className="record-page-records">
+                          {page.records.map((record) => (
+                            <div
+                              key={record.hash}
+                              className={clsx('record', { complete: record.complete })}
+                            >
+                              <div
+                                className="record-icon"
+                                style={bungieBackgroundStyle(record.icon)}
+                              />
+                              <div className="record-info">
+                                <h3>{record.name}</h3>
+                                <p>{record.description}</p>
+                                {record.objectives.map((objective) => (
+                                  <Objective
+                                    key={objective.objectiveHash}
+                                    defs={defs}
+                                    objective={objective}
+                                  />
+                                ))}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </CollapsibleTitle>
+                  </div>
+                )
+            )}
+          </div>
+        </CollapsibleTitle>
+      ))}
+    </div>
+  );
 }
 
-export default connect<StoreProps, DispatchProps>(mapStateToProps, mapDispatchToProps)(RecordBooks);
+export default connect<StoreProps>(mapStateToProps)(RecordBooks);

--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -1,27 +1,23 @@
 import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
+import D1Farming from 'app/farming/D1Farming';
+import D2Farming from 'app/farming/D2Farming';
 import { t } from 'app/i18next-t';
 import DragPerformanceFix from 'app/inventory/DragPerformanceFix';
 import MobileInspect from 'app/mobile-inspect/MobileInspect';
 import { RootState } from 'app/store/types';
-import { useSubscription } from 'app/utils/hooks';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { DestinyAccount } from '../accounts/destiny-account';
 import Compare from '../compare/Compare';
-import D1Farming from '../farming/D1Farming';
-import D2Farming from '../farming/D2Farming';
 import GearPower from '../gear-power/GearPower';
 import InfusionFinder from '../infuse/InfusionFinder';
 import LoadoutDrawer from '../loadout/LoadoutDrawer';
-import { refresh$ } from '../shell/refresh';
-import { queueAction } from './action-queue';
 import ClearNewItems from './ClearNewItems';
-import { D1StoresService } from './d1-stores';
-import { D2StoresService } from './d2-stores';
 import DragGhostItem from './DragGhostItem';
 import { isPhonePortraitSelector, storesLoadedSelector } from './selectors';
 import StackableDragHelp from './StackableDragHelp';
+import { useLoadStores } from './store/hooks';
 import Stores from './Stores';
 
 interface ProvidedProps {
@@ -42,23 +38,8 @@ function mapStateToProps(state: RootState): StoreProps {
   };
 }
 
-function getStoresService(account: DestinyAccount) {
-  return account.destinyVersion === 1 ? D1StoresService : D2StoresService;
-}
-
 function Inventory({ storesLoaded, account, isPhonePortrait }: Props) {
-  useSubscription(() => {
-    const storesService = getStoresService(account);
-    return refresh$.subscribe(() => queueAction<any>(() => storesService.reloadStores()));
-  });
-
-  useEffect(() => {
-    const storesService = getStoresService(account);
-    if (!storesLoaded) {
-      // TODO: Dispatch an action to load stores instead
-      storesService.getStoresStream(account);
-    }
-  }, [account, storesLoaded]);
+  useLoadStores(account, storesLoaded);
 
   if (!storesLoaded) {
     return <ShowPageLoading message={t('Loading.Profile')} />;

--- a/src/app/inventory/store/hooks.ts
+++ b/src/app/inventory/store/hooks.ts
@@ -1,0 +1,36 @@
+import { DestinyAccount } from 'app/accounts/destiny-account';
+import { refresh$ } from 'app/shell/refresh';
+import { useSubscription } from 'app/utils/hooks';
+import { useEffect } from 'react';
+import { queueAction } from '../action-queue';
+import { D1StoresService } from '../d1-stores';
+import { D2StoresService } from '../d2-stores';
+
+/**
+ * A simple hook (probably too simple!) that loads and refreshes stores. This is
+ * meant for use by top level pages. It could have used useSubscription to be
+ * extra cool, but I'm trying to avoid having both useSubscription and connect()
+ * in the same component. useDispatch() is cheap because it just listens to a
+ * context that never changes.
+ */
+export function useLoadStores(account: DestinyAccount | undefined, loaded: boolean) {
+  useEffect(() => {
+    if (account && !loaded) {
+      account.destinyVersion === 2
+        ? D2StoresService.getStoresStream(account)
+        : D1StoresService.getStoresStream(account);
+    }
+  }, [account, loaded]);
+
+  useSubscription(() =>
+    refresh$.subscribe(() => {
+      if (account) {
+        queueAction<any>(() =>
+          account.destinyVersion === 2
+            ? D2StoresService.reloadStores()
+            : D1StoresService.reloadStores()
+        );
+      }
+    })
+  );
+}

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -7,15 +7,11 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
-import { queueAction } from 'app/inventory/action-queue';
-import { D1StoresService } from 'app/inventory/d1-stores';
-import { D2StoresService } from 'app/inventory/d2-stores';
 import { storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
-import { refresh$ } from 'app/shell/refresh';
+import { useLoadStores } from 'app/inventory/store/hooks';
 import { RootState } from 'app/store/types';
-import { useSubscription } from 'app/utils/hooks';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import ItemTable from './ItemTable';
 import ItemTypeSelector, { ItemCategoryTreeNode } from './ItemTypeSelector';
@@ -42,20 +38,8 @@ function mapStateToProps() {
 
 type Props = ProvidedProps & StoreProps;
 
-function getStoresService(account: DestinyAccount) {
-  return account.destinyVersion === 1 ? D1StoresService : D2StoresService;
-}
-
 function Organizer({ account, defs, stores, isPhonePortrait }: Props) {
-  useEffect(() => {
-    if (!stores.length) {
-      getStoresService(account).getStoresStream(account);
-    }
-  });
-
-  useSubscription(() =>
-    refresh$.subscribe(() => queueAction<any>(() => getStoresService(account).reloadStores()))
-  );
+  useLoadStores(account, stores.length > 0);
 
   const [selection, onSelection] = useState<ItemCategoryTreeNode[]>([]);
 

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -3,23 +3,21 @@ import CharacterSelect from 'app/dim-ui/CharacterSelect';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
-import { queueAction } from 'app/inventory/action-queue';
-import { D2StoresService } from 'app/inventory/d2-stores';
 import {
   bucketsSelector,
   profileResponseSelector,
   sortedStoresSelector,
 } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
+import { useLoadStores } from 'app/inventory/store/hooks';
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { RAID_NODE } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
 import { searchFilterSelector } from 'app/search/search-filter';
 import { querySelector } from 'app/shell/reducer';
 import { RootState } from 'app/store/types';
-import { useSubscription } from 'app/utils/hooks';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Hammer from 'react-hammerjs';
 import { connect } from 'react-redux';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -28,7 +26,6 @@ import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import CollapsibleTitle from '../dim-ui/CollapsibleTitle';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
-import { refresh$ } from '../shell/refresh';
 import Milestones from './Milestones';
 import './progress.scss';
 import Pursuits from './Pursuits';
@@ -67,9 +64,6 @@ function mapStateToProps(state: RootState): StoreProps {
   };
 }
 
-const refreshStores = () =>
-  refresh$.subscribe(() => queueAction(() => D2StoresService.reloadStores()));
-
 function Progress({
   account,
   defs,
@@ -82,13 +76,7 @@ function Progress({
 }: Props) {
   const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(undefined);
 
-  useEffect(() => {
-    if (!profileInfo) {
-      D2StoresService.getStoresStream(account);
-    }
-  });
-
-  useSubscription(refreshStores);
+  useLoadStores(account, Boolean(profileInfo));
 
   if (!defs || !profileInfo || !stores.length) {
     return <ShowPageLoading message={t('Loading.Profile')} />;

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -1,5 +1,6 @@
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
+import { useLoadStores } from 'app/inventory/store/hooks';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import ErrorPanel from 'app/shell/ErrorPanel';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
@@ -13,7 +14,7 @@ import { DestinyAccount } from '../accounts/destiny-account';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import Countdown from '../dim-ui/Countdown';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
-import { D2StoresService, mergeCollectibles } from '../inventory/d2-stores';
+import { mergeCollectibles } from '../inventory/d2-stores';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import {
   bucketsSelector,
@@ -101,9 +102,7 @@ function SingleVendor({
     }
   }, [account, characterId, defs, dispatch, vendorHash]);
 
-  useEffect(() => {
-    D2StoresService.getStoresStream(account);
-  }, [account]);
+  useLoadStores(account, stores.length > 0);
 
   if (!defs || !buckets) {
     return <ShowPageLoading message={t('Manifest.Load')} />;

--- a/src/app/vendors/Vendors.tsx
+++ b/src/app/vendors/Vendors.tsx
@@ -2,6 +2,7 @@ import CheckButton from 'app/dim-ui/CheckButton';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
+import { useLoadStores } from 'app/inventory/store/hooks';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { ItemFilter } from 'app/search/filter-types';
 import { searchFilterSelector } from 'app/search/search-filter';
@@ -24,7 +25,7 @@ import { DestinyAccount } from '../accounts/destiny-account';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import CharacterSelect from '../dim-ui/CharacterSelect';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
-import { D2StoresService, mergeCollectibles } from '../inventory/d2-stores';
+import { mergeCollectibles } from '../inventory/d2-stores';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import {
   bucketsSelector,
@@ -103,8 +104,9 @@ function Vendors({
 
   const selectedStoreId = characterId || getCurrentStore(stores)?.id;
 
+  useLoadStores(account, stores.length > 0);
+
   useEffect(() => {
-    D2StoresService.getStoresStream(account);
     if (selectedStoreId) {
       dispatch(loadAllVendors(account, selectedStoreId));
     }


### PR DESCRIPTION
This is a simpler alternative to https://github.com/DestinyItemManager/DIM/pull/5735 that I pulled together while working on a big disentanglement project (https://github.com/DestinyItemManager/DIM/compare/reduxpocalypse?expand=1) just so I could get all the stores loading logic in one place to be able to change it easily. This doesn't preclude doing #5735 - that could just be a further refactoring of this.