### PR TITLE
Experiments in faster moves

### DIFF
--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -255,9 +255,9 @@ export async function handleErrors<T>(response: Response): Promise<ServerRespons
   }
 }
 
-// Handle "DestinyUniquenessViolation" (1648)
+// Handle "DestinyUniquenessViolation"
 export function handleUniquenessViolation(e: DimError, item: DimItem, store: DimStore): never {
-  if (e?.code === 1648) {
+  if (e?.code === PlatformErrorCodes.DestinyUniquenessViolation) {
     throw error(
       t('BungieService.ItemUniquenessExplanation', {
         // t('BungieService.ItemUniquenessExplanation_female')

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -817,7 +817,7 @@ function canMoveToStore(
       storeReservations.vault = amount;
     }
 
-    // How many moves (in amount, not stacks) are needed from each
+    // How many items need to be moved away from each store (in amount, not stacks)
     const movesNeeded: { [storeId: string]: number } = {};
     stores.forEach((s) => {
       if (storeReservations[s.id]) {
@@ -828,7 +828,8 @@ function canMoveToStore(
       }
     });
 
-    if (!Object.values(movesNeeded).some((m) => m > 0)) {
+    if (Object.values(movesNeeded).every((m) => m === 0)) {
+      // If there are no moves needed, we're clear to go
       return true;
     } else if (store.isVault || triedFallback) {
       // Move aside one of the items that's in the way
@@ -905,6 +906,17 @@ function canMoveToStore(
         }
       }
     } else {
+      if ($featureFlags.debugMoves) {
+        console.log(
+          'Reloading stores to see if space has freed up to move',
+          item.name,
+          item.id,
+          'to',
+          store.name,
+          movesNeeded,
+          options
+        );
+      }
       // Refresh the stores to see if anything has changed
       const reloadedStores =
         (await (item.destinyVersion === 2

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -454,6 +454,11 @@ function moveToStore(
       if (e.code === PlatformErrorCodes.DestinyCannotPerformActionOnEquippedItem) {
         await dispatch(dequipItem(item));
         await transferApi(item)(currentAccountSelector(getState())!, item, store, amount);
+      } else if (e.code === PlatformErrorCodes.DestinyItemNotFound) {
+        // If the item wasn't found, it's probably been moved or deleted in-game. We could try to
+        // reload the profile or load just that item, but API caching means we aren't guaranteed to
+        // get the current view. So instead, we just pretend the move succeeded.
+        console.warn('Item', item.name, 'was not found - pretending the move succeeded');
       } else {
         throw e;
       }


### PR DESCRIPTION
We've had a persistent problem where we are trying to make item moves while our view of inventory is out of date. In the past I wrote some code that'd try to reload the profile during the move in order to get an updated view. However, the API is frequently returning cached out-of-date info, and now profile loads have gotten very slow. This PR has a few experiments for other options:

1. Stop reloading stores during moves. If people think their view of the world is out of date, they can refresh themselves. The downside here is that DIM may choose items to move away that no longer exist or have been moved away, and that'll throw an error.
2. When we try to move an item and it isn't there, consider it successfully moved instead of throwing an error. This is a lie, but it's probably the safest thing we can do. We could also just forget about the item - I'm not sure which is worse.
3. When moving from the vault to the *current* account, before we run all the complicated item move logic, just try the move right away. If it fails, fall back to our normal logic. There's a possibility this results in more than 10 items in a bucket, but we'll just have to deal with that. In case we try the move and get the error that there's no space left, don't try the blind move again for 5 seconds.