### PR TITLE
remove fusion rifle type from linear fusion rifles

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -539,6 +539,16 @@ export function makeItem(
     }
   }
 
+  // linear fusion rifles always seem to contain the "fusion rifle" category as well.
+  // it's a fascinating "did you know", but ultimately not useful to us, so we remove it
+  // because we don't want to filter FRs and see LFRs
+  if (createdItem.itemCategoryHashes.includes(ItemCategoryHashes.LinearFusionRifles)) {
+    const fusionRifleLocation = createdItem.itemCategoryHashes.indexOf(
+      ItemCategoryHashes.FusionRifle
+    );
+    fusionRifleLocation !== -1 && createdItem.itemCategoryHashes.splice(fusionRifleLocation, 1);
+  }
+
   // Infusion
   const tier = itemDef.inventory ? defs.ItemTierType[itemDef.inventory.tierTypeHash] : null;
   createdItem.infusionFuel = Boolean(


### PR DESCRIPTION
fixes https://github.com/DestinyItemManager/DIM/issues/5668

screenshots of the change aren't really interesting but it works as intended in collections/inventory/organizer