### PR TITLE
Fixed issue with mod picker mod assignment.

### DIFF
--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -78,10 +78,9 @@ export default function PickerSectionMods({
     <div className={styles.bucket} id={`mod-picker-section-${category}`}>
       <div className={styles.header}>{title}</div>
       {Object.entries(modGroups).map(([subTitle, mods]) => (
-        <>
+        <div key={subTitle}>
           {subTitle !== 'nogroup' && <div className={styles.subheader}>{subTitle}</div>}
           <div className={styles.items}>
-            {console.log(mods)}
             {mods.map((item) => (
               <SelectableArmor2Mod
                 key={item.mod.hash}
@@ -96,7 +95,7 @@ export default function PickerSectionMods({
               />
             ))}
           </div>
-        </>
+        </div>
       ))}
     </div>
   );

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -53,7 +53,7 @@ function assignModsForSlot(
   mods: LockedArmor2Mod[],
   assignments: Record<string, number[]>
 ): void {
-  if (!mods?.length || mods.every((mod) => doEnergiesMatch(mod, item))) {
+  if (mods?.length && mods.every((mod) => doEnergiesMatch(mod, item))) {
     assignments[item.id] = [...assignments[item.id], ...mods.map((mod) => mod.mod.hash)];
   }
 }
@@ -96,17 +96,19 @@ export function assignModsToArmorSet(
     }
   }
 
-  assignAllSeasonalMods(processItems, lockedArmor2Mods.seasonal, assignments);
-
   assignGeneralMods(
     processItems,
     lockedArmor2Mods[armor2PlugCategoryHashesByName.general],
     assignments
   );
 
-  const modsByHash = _.keyBy(Object.values(lockedArmor2Mods).flat(), (mod) => mod.mod.hash);
+  assignAllSeasonalMods(processItems, lockedArmor2Mods.seasonal, assignments);
+
+  const modsByHash = _.groupBy(Object.values(lockedArmor2Mods).flat(), (mod) => mod.mod.hash);
   const assignedMods = _.mapValues(assignments, (modHashes) =>
-    modHashes.map((modHash) => modsByHash[modHash])
+    modHashes
+      .map((modHash) => modsByHash[modHash].pop())
+      .filter((x): x is LockedArmor2Mod => Boolean(x))
   );
   const assigned = Object.values(assignedMods).flat();
   const unassignedMods = Object.values(lockedArmor2Mods)

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -256,13 +256,13 @@ export function process(
               // and we do seasonal first as its more likely to have energy specific mods.
               // TODO Check validity of this with the energy contraints in.
               if (
-                (lockedArmor2ModMap.seasonal.length &&
-                  !canTakeAllSeasonalMods(lockedArmor2ModMap.seasonal, armor)) ||
                 (lockedArmor2ModMap[armor2PlugCategoryHashesByName.general].length &&
                   !canTakeAllGeneralMods(
                     lockedArmor2ModMap[armor2PlugCategoryHashesByName.general],
                     armor
-                  ))
+                  )) ||
+                (lockedArmor2ModMap.seasonal.length &&
+                  !canTakeAllSeasonalMods(lockedArmor2ModMap.seasonal, armor))
               ) {
                 continue;
               }

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -229,7 +229,7 @@ export function isLoadoutBuilderItem(item: DimItem) {
 }
 
 export function statTier(stat: number) {
-  return Math.floor(stat / 10);
+  return Math.min(10, Math.max(0, Math.floor(stat / 10)));
 }
 
 /**


### PR DESCRIPTION
I believe the main fix for this is the changing of the order where we assign mods, i.e. in this we now assign general mods before seasonal mods. They should be equivalent from my understanding so there might be something else at play here. 

I have done quite a bit of testing on this and it appears that it works correctly now or at least I haven't been able to break it.

@nev-r since you worked on this with me would you be able to double check the sorting algorithm for me here (https://github.com/DestinyItemManager/DIM/blob/master/src/app/loadout-builder/processWorker/processUtils.ts)? 

Fixes #5805 