### PR TITLE
Remove inline search help

### DIFF
--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -437,7 +437,7 @@ const Row = React.memo(
           item.query
         )}
       </span>
-      <span className={styles.menuItemHelp}>{item.helpText && <span>{item.helpText}</span>}</span>
+      <span className={styles.menuItemHelp} />
       {!isPhonePortrait && isTabAutocompleteItem && (
         <span className={styles.keyHelp}>{t('Hotkey.Tab')}</span>
       )}


### PR DESCRIPTION
I think I don't like the inline help on search. It'd need a design pass before trying it again.