### PR TITLE
Enable category strip on Beta

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -388,7 +388,7 @@ module.exports = (env) => {
         // New background design
         '$featureFlags.gradientBackground': JSON.stringify(env.dev),
         // Use a category strip on mobile inventory instead of collapsable headers
-        '$featureFlags.mobileCategoryStrip': JSON.stringify(env.dev),
+        '$featureFlags.mobileCategoryStrip': JSON.stringify(!env.release),
       }),
 
       new WorkerPlugin({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@
 * Armor 1.0 mods and Elemental Affinities removed from the perk picker in Loadout Optimizer.
 * Improved search performance.
 
+### Beta Only
+
+* On mobile, there is now a bar to quickly swap between different item categories on the inventory screen.
+
 ## 6.30.0 <span className="changelog-date">(2020-09-13)</span>
 
 * Compare loadouts in Loadout Optimizer to your existing loadout by clicking the "Compare Loadout" button next to a build.

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -20,6 +20,8 @@
   );
   @include phone-portrait {
     min-width: auto;
+    // Give room for the category selector strip
+    padding-bottom: 50px;
   }
 
   .body-scroll-lock & {
@@ -241,26 +243,29 @@
 .category-options {
   display: flex;
   background-color: black;
-  height: 50px;
   position: fixed;
+  align-items: center;
   bottom: 0;
   top: inherit;
   left: 0;
-  width: 94%;
-  padding: 0 3%;
+  right: 0;
+  $vpadding: 15px;
+  padding: ($vpadding + 1) 10px ($vpadding - 1) 10px;
   justify-content: space-around;
+  padding-bottom: calc(#{($vpadding - 1)} + constant(safe-area-inset-bottom));
+  padding-bottom: calc(#{($vpadding - 1)} + env(safe-area-inset-bottom));
 
   > div {
-    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
     text-transform: uppercase;
     font-size: 12px;
     letter-spacing: 1.2px;
-    padding-bottom: 1px;
+    border-bottom: 2px solid transparent;
   }
   .selected {
     font-weight: bold;
+    border-bottom: 2px solid $orange;
   }
 }

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -29,11 +29,11 @@ import { updateLoadout } from './actions';
 import { GeneratedLoadoutStats } from './GeneratedLoadoutStats';
 import './loadout-drawer.scss';
 import { Loadout, LoadoutItem } from './loadout-types';
+import { getItemsFromLoadoutItems } from './loadout-utils';
 import LoadoutDrawerContents from './LoadoutDrawerContents';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import LoadoutDrawerOptions from './LoadoutDrawerOptions';
 import { loadoutsSelector } from './reducer';
-import { getItemsFromLoadoutItems } from './loadout-utils';
 
 // TODO: Consider moving editLoadout/addItemToLoadout/loadoutDialogOpen into Redux (actions + state)
 

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -225,10 +225,6 @@ input[type='search'] {
   padding-right: constant(safe-area-inset-right);
   padding-right: env(safe-area-inset-right);
   scroll-margin-top: $header-height;
-  // TODO: Find a better way to make room for the inventory category selector
-  @include phone-portrait {
-    margin-bottom: 30px;
-  }
 }
 
 h2,

--- a/src/app/search/search-filters/range-numeric.tsx
+++ b/src/app/search/search-filters/range-numeric.tsx
@@ -1,6 +1,5 @@
 import { tl } from 'app/i18next-t';
 import { getItemYear } from 'app/utils/item-utils';
-import _ from 'lodash';
 import { FilterDefinition } from '../filter-types';
 
 const rangeStringRegex = /^([<=>]{0,2})(\d+)$/;


### PR DESCRIPTION
This cleans up the category strip a bit, and enables it on beta only. I want to start getting a feel for it. I also added a yellow underline to the active category which calls back to our header design.

<img width="308" alt="Screen Shot 2020-09-15 at 3 10 25 PM" src="https://user-images.githubusercontent.com/313208/93270451-0755a680-f766-11ea-90b4-7c082a425e19.png">


