### PR TITLE
Eliminate isDestiny2 and isDestiny1 helpers from DimStore/DimItem

### DIFF
--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -61,7 +61,9 @@ export default function CharacterTile({ store }: { store: DimStore }) {
           ) : (
             <>
               <div className="race-gender">{store.genderRace}</div>
-              {store.isDestiny1() && store.level < 40 && <div className="level">{store.level}</div>}
+              {store.destinyVersion === 1 && store.level < 40 && (
+                <div className="level">{store.level}</div>
+              )}
             </>
           )}
         </div>

--- a/src/app/character-tile/CharacterTileButton.tsx
+++ b/src/app/character-tile/CharacterTileButton.tsx
@@ -19,7 +19,7 @@ export default function CharacterTileButton({
       onClick={handleClick}
       className={clsx('character', {
         current: character.current,
-        destiny2: character.isDestiny2(),
+        destiny2: character.destinyVersion === 2,
       })}
     >
       <CharacterTile store={character} />

--- a/src/app/character-tile/StoreHeading.tsx
+++ b/src/app/character-tile/StoreHeading.tsx
@@ -1,4 +1,5 @@
 import { t } from 'app/i18next-t';
+import { isD1Store } from 'app/inventory/stores-helpers';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -35,8 +36,8 @@ const CharacterHeader = ({
   <div
     className={clsx('character', {
       current: store.current,
-      destiny1: store.isDestiny1(),
-      destiny2: store.isDestiny2(),
+      destiny1: store.destinyVersion === 1,
+      destiny2: store.destinyVersion === 2,
       vault: store.isVault,
     })}
     ref={menuRef}
@@ -50,7 +51,7 @@ const CharacterHeader = ({
     >
       <AppIcon icon={faEllipsisV} title={t('Loadouts.Loadouts')} />
     </div>
-    {!store.isVault && store.isDestiny1() && <CharacterHeaderXPBar store={store} />}
+    {!store.isVault && isD1Store(store) && <CharacterHeaderXPBar store={store} />}
   </div>
 );
 

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -465,7 +465,9 @@ class Compare extends React.Component<Props, State> {
       const itemRpmStat = i.stats?.find(
         (s) =>
           s.statHash ===
-          (exampleItem.isDestiny1() ? exampleItem.stats![0].statHash : StatHashes.RoundsPerMinute)
+          (exampleItem.destinyVersion === 1
+            ? exampleItem.stats![0].statHash
+            : StatHashes.RoundsPerMinute)
       );
       return itemRpmStat?.value || -99999999;
     };
@@ -483,8 +485,8 @@ class Compare extends React.Component<Props, State> {
         (i) =>
           // specifically for destiny 2 grenade launchers, let's not compare special with heavy.
           // all other weapon types with multiple ammos, are novelty exotic exceptions
-          !exampleItem.isDestiny2() ||
-          !i.isDestiny2() ||
+          !(exampleItem.destinyVersion === 2) ||
+          !(i.destinyVersion === 2) ||
           !exampleItem.itemCategoryHashes.includes(ItemCategoryHashes.GrenadeLaunchers) ||
           exampleItem.ammoType === i.ammoType
       );
@@ -505,9 +507,10 @@ class Compare extends React.Component<Props, State> {
       // same weapon type plus matching intrinsic (rpm+impact..... ish)
       {
         buttonLabel: [intrinsicName, exampleItem.typeName].join(' + '),
-        items: exampleItem.isDestiny2()
-          ? allWeapons.filter((i) => i.sockets && getWeaponArchetype(i)?.hash === intrinsicHash)
-          : allWeapons.filter((i) => exampleItemRpm === getRpm(i)),
+        items:
+          exampleItem.destinyVersion === 2
+            ? allWeapons.filter((i) => i.sockets && getWeaponArchetype(i)?.hash === intrinsicHash)
+            : allWeapons.filter((i) => exampleItemRpm === getRpm(i)),
       },
 
       // same weapon type and also matching element (& usually same-slot because same element)
@@ -564,7 +567,7 @@ function getAllStats(comparisonItems: DimItem[], compareBaseStats: boolean) {
     );
   }
   if (
-    firstComparison.isDestiny2() &&
+    firstComparison.destinyVersion === 2 &&
     (firstComparison.bucket.inArmor || firstComparison.bucket.inWeapons)
   ) {
     stats.push(
@@ -575,7 +578,7 @@ function getAllStats(comparisonItems: DimItem[], compareBaseStats: boolean) {
     );
   }
 
-  if (firstComparison.isDestiny2() && firstComparison.bucket.inArmor) {
+  if (firstComparison.destinyVersion === 2 && firstComparison.bucket.inArmor) {
     stats.push(
       makeFakeStat(
         'EnergyCapacity',

--- a/src/app/farming/Farming.tsx
+++ b/src/app/farming/Farming.tsx
@@ -50,9 +50,9 @@ function Farming({ store, makeRoomForItems, dispatch }: Props) {
           <div
             ref={nodeRef}
             id="item-farming"
-            className={clsx({ 'd2-farming': store.isDestiny2() })}
+            className={clsx({ 'd2-farming': store.destinyVersion === 2 })}
           >
-            {store.isDestiny2() ? (
+            {store.destinyVersion === 2 ? (
               <div>
                 <p>
                   {t('FarmingMode.D2Desc', {

--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -4,7 +4,7 @@ import {
   itemInfosSelector,
   storesSelector,
 } from 'app/inventory/selectors';
-import { capacityForItem, getVault } from 'app/inventory/stores-helpers';
+import { capacityForItem, getVault, isD1Store } from 'app/inventory/stores-helpers';
 import { settingsSelector } from 'app/settings/reducer';
 import { refresh } from 'app/shell/refresh';
 import { ThunkResult } from 'app/store/types';
@@ -75,7 +75,7 @@ export function startFarming(storeId: string): ThunkResult {
       if (farmingInterruptedSelector(getState())) {
         console.log('Farming interrupted, will resume when tasks are complete');
       } else {
-        if (farmingStore.isDestiny1()) {
+        if (isD1Store(farmingStore)) {
           dispatch(farmD1(farmingStore));
         } else {
           // In D2 we just make room

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -7,6 +7,7 @@ import SearchBar from 'app/search/SearchBar';
 import { settingsSelector } from 'app/settings/reducer';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { useSubscription } from 'app/utils/hooks';
+import { isD1Item } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import copy from 'fast-copy';
 import React, { useEffect, useReducer } from 'react';
@@ -29,7 +30,7 @@ import './InfusionFinder.scss';
 const itemComparator = chainComparator(
   reverseComparator(compareBy((item: DimItem) => item.primStat!.value)),
   compareBy((item: DimItem) =>
-    item.isDestiny1() && item.talentGrid
+    isD1Item(item) && item.talentGrid
       ? (item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5
       : 0
   )
@@ -326,7 +327,7 @@ function isInfusable(target: DimItem, source: DimItem) {
     return false;
   }
 
-  if (source.isDestiny1() && target.isDestiny1()) {
+  if (source.destinyVersion === 1 && target.destinyVersion === 1) {
     return source.type === target.type && target.primStat!.value < source.primStat!.value;
   } else {
     return (
@@ -369,7 +370,7 @@ async function transferItems(
     convertToLoadoutItem(source, source.equipped),
   ];
 
-  if (source.isDestiny1()) {
+  if (source.destinyVersion === 1) {
     if (target.bucket.sort === 'General') {
       // Mote of Light
       items.push({

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -1,5 +1,6 @@
 import { t } from 'app/i18next-t';
 import iconStyles from 'app/inventory/ElementIcon.m.scss';
+import { isD1Item } from 'app/utils/item-utils';
 import { weakMemoize } from 'app/utils/util';
 import { UiWishListRoll } from 'app/wishlists/wishlists';
 import { DamageType } from 'bungie-api-ts/destiny2';
@@ -49,7 +50,7 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
   const isStackable = Boolean(item.maxStackSize > 1);
   // treat D1 ghosts as generic items
   const isGhost = Boolean(
-    item.isDestiny2?.() && item.itemCategoryHashes?.includes(ItemCategoryHashes.Ghost)
+    item?.destinyVersion === 2 && item.itemCategoryHashes?.includes(ItemCategoryHashes.Ghost)
   );
   const isGeneric = !isBounty && !isStackable && !isGhost;
 
@@ -85,7 +86,7 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
 
   return (
     <div className={clsx(styles.badge, badgeclsx)}>
-      {item.isDestiny1() && item.quality && (
+      {isD1Item(item) && item.quality && (
         <div className={styles.quality} style={getColor(item.quality.min, 'backgroundColor')}>
           {item.quality.min}%
         </div>

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -64,7 +64,7 @@ function InventoryCollapsibleTitle({
         })}
       >
         {stores.map((store, index) => {
-          const storeIsDestiny2 = store.isDestiny2();
+          const storeIsDestiny2 = store.destinyVersion === 2;
           const isPostmasterAlmostFull = postmasterAlmostFull(store);
           const postMasterSpaceUsed = postmasterSpaceUsed(store);
           const showPostmasterFull = checkPostmaster && storeIsDestiny2 && isPostmasterAlmostFull;

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -71,7 +71,7 @@ export default function InventoryItem({
 
   const subclassPath =
     (!ignoreSelectedPerks &&
-      item.isDestiny2?.() &&
+      item?.destinyVersion === 2 &&
       item.talentGrid &&
       selectedSubclassPath(item.talentGrid)) ||
     null;
@@ -155,7 +155,7 @@ export default function InventoryItem({
 
 export function borderless(item: DimItem) {
   return (
-    (item.isDestiny2?.() &&
+    (item?.destinyVersion === 2 &&
       (item.bucket.hash === BucketHashes.Subclass ||
         item.itemCategoryHashes?.includes(ItemCategoryHashes.Packages))) ||
     item.isEngram

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -153,7 +153,7 @@ function StoreBucket({
         {unequippedItems.map((item) => (
           <StoreInventoryItem key={item.index} item={item} isPhonePortrait={isPhonePortrait} />
         ))}
-        {store.isDestiny2() &&
+        {store.destinyVersion === 2 &&
           bucket.hash === BucketHashes.Engrams && // Engrams. D1 uses this same bucket hash for "Missions"
           _.times(bucket.capacity - unequippedItems.length, (index) => (
             <img src={emptyEngram} className="empty-engram" aria-hidden="true" key={index} />

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -53,13 +53,15 @@ export function StoreBuckets({
         className={clsx('store-cell', {
           vault: store.isVault,
           postmasterFull:
-            bucket.sort === 'Postmaster' && store.isDestiny2() && postmasterAlmostFull(store),
+            bucket.sort === 'Postmaster' &&
+            store.destinyVersion === 2 &&
+            postmasterAlmostFull(store),
         })}
         style={storeBackgroundColor(store, index)}
       >
         {(!store.isVault || bucket.vaultBucket) && <StoreBucket bucket={bucket} store={store} />}
         {bucket.type === 'LostItems' &&
-          store.isDestiny2() &&
+          store.destinyVersion === 2 &&
           store.buckets[bucket.hash].length > 0 && <PullFromPostmaster store={store} />}
       </div>
     ));

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -292,7 +292,7 @@ function StoresInventory(props: InventoryContainerProps) {
           inventoryBucket={inventoryBucket}
         />
       ))}
-      {stores[0].isDestiny1() && <D1ReputationSection stores={stores} />}
+      {stores[0].destinyVersion === 1 && <D1ReputationSection stores={stores} />}
     </>
   );
 }

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -70,13 +70,13 @@ export function setItemLockState(
     const storeId =
       item.owner === 'vault' ? getCurrentStore(storesSelector(getState()))!.id : item.owner;
 
-    if (item.isDestiny2()) {
+    if (item.destinyVersion === 2) {
       if (type === 'lock') {
         await d2SetLockState(account, storeId, item, state);
       } else {
         await d2SetTrackedState(account, storeId, item, state);
       }
-    } else if (item.isDestiny1()) {
+    } else if (item.destinyVersion === 1) {
       await d1SetItemState(account, item, storeId, state, type);
     }
 
@@ -104,9 +104,9 @@ function transferApi(item: DimItem): typeof d2Transfer {
 }
 
 function createItemIndex(item: DimItem): string {
-  if (item.isDestiny2()) {
+  if (item.destinyVersion === 2) {
     return d2CreateItemIndex(item);
-  } else if (item.isDestiny1()) {
+  } else if (item.destinyVersion === 1) {
     return d1CreateItemIndex(item);
   } else {
     throw new Error('Destiny 3??');

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -191,11 +191,6 @@ export interface DimItem {
 
   /** "Touch" the item to mark it as having been manually moved. */
   updateManualMoveTimestamp(): void;
-
-  /** Check if this item is from D1. Inside an if statement, this item will be narrowed to type D1Item. */
-  isDestiny1(): this is D1Item;
-  /** Check if this item is from D2. */
-  isDestiny2(): boolean;
 }
 
 /**

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -32,7 +32,7 @@ export interface InventoryState {
   readonly newItemsLoaded: boolean;
 
   /** Are we currently dragging a stack? */
-  readonly isDraggingStack;
+  readonly isDraggingStack: boolean;
 }
 
 export type InventoryAction = ActionType<typeof actions>;
@@ -160,7 +160,7 @@ function updateCharacters(state: InventoryState, characters: actions.CharacterIn
       const { characterId, ...characterInfo } = character;
       return Object.assign(
         // Have to make it into a full object again. TODO: un-object-ify this
-        Object.create(store.isDestiny2() ? D2StoreProto : D1StoreProto),
+        Object.create(store.destinyVersion === 2 ? D2StoreProto : D1StoreProto),
         {
           ...store,
           ...characterInfo,
@@ -279,10 +279,10 @@ function touchItem(state: InventoryState, itemId: string) {
   }
   let store = getStore(state.stores, item.owner)!;
   item = Object.assign(
-    Object.create(store.isDestiny2() ? D2ItemProto : D1ItemProto),
+    Object.create(store.destinyVersion === 2 ? D2ItemProto : D1ItemProto),
     item
   ) as DimItem;
-  store = Object.assign(Object.create(store.isDestiny2() ? D2StoreProto : D1StoreProto), {
+  store = Object.assign(Object.create(store.destinyVersion === 2 ? D2StoreProto : D1StoreProto), {
     ...store,
     items: store.items.map((i) => (i.id === item.id ? item : i)),
     buckets: {

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -7,6 +7,7 @@ import {
   getItemYear,
   getMasterworkStatNames,
   getSpecialtySocketMetadata,
+  isD1Item,
 } from 'app/utils/item-utils';
 import { download } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -302,7 +303,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
       Type: item.typeName,
       Source: source(item),
       Equippable: equippable(item),
-      [item.isDestiny1() ? 'Light' : 'Power']: item.primStat?.value,
+      [item.destinyVersion === 1 ? 'Light' : 'Power']: item.primStat?.value,
     };
     if (item.powerCap) {
       row['Power Limit'] = item.powerCap;
@@ -314,7 +315,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
         : undefined;
     }
     row.Owner = nameMap[item.owner];
-    if (item.isDestiny1()) {
+    if (item.destinyVersion === 1) {
       row['% Leveled'] = (item.percentComplete * 100).toFixed(0);
     }
     if (item.energy) {
@@ -323,18 +324,18 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
     row.Locked = item.locked;
     row.Equipped = item.equipped;
     row.Year = getItemYear(item);
-    if (item.isDestiny2()) {
+    if (item.destinyVersion === 2) {
       row.Season = getSeason(item);
       const event = getEvent(item);
       row.Event = event ? D2EventInfo[event].name : '';
     }
 
-    if (item.isDestiny1()) {
+    if (isD1Item(item)) {
       row['% Quality'] = item.quality?.min ?? 0;
     }
     const stats: { [name: string]: { value: number; pct: number; base: number } } = {};
     if (item.stats) {
-      if (item.isDestiny1()) {
+      if (isD1Item(item)) {
         item.stats.forEach((stat) => {
           let pct = 0;
           if (stat.scaled?.min) {
@@ -356,7 +357,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
         });
       }
     }
-    if (item.isDestiny1()) {
+    if (item.destinyVersion === 1) {
       row['% IntQ'] = stats.Intellect?.pct ?? 0;
       row['% DiscQ'] = stats.Discipline?.pct ?? 0;
       row['% StrQ'] = stats.Strength?.pct ?? 0;
@@ -408,7 +409,7 @@ function downloadWeapons(
       Source: source(item),
       Category: item.bucket.type,
       Element: item.element?.displayProperties.name,
-      [item.isDestiny1() ? 'Light' : 'Power']: item.primStat?.value,
+      [item.destinyVersion === 1 ? 'Light' : 'Power']: item.primStat?.value,
     };
     if (item.powerCap) {
       row['Power Limit'] = item.powerCap;
@@ -420,13 +421,13 @@ function downloadWeapons(
         : undefined;
     }
     row.Owner = nameMap[item.owner];
-    if (item.isDestiny1()) {
+    if (item.destinyVersion === 1) {
       row['% Leveled'] = (item.percentComplete * 100).toFixed(0);
     }
     row.Locked = item.locked;
     row.Equipped = item.equipped;
     row.Year = getItemYear(item);
-    if (item.isDestiny2()) {
+    if (item.destinyVersion === 2) {
       row.Season = getSeason(item);
       const event = getEvent(item);
       row.Event = event ? D2EventInfo[event].name : '';
@@ -513,7 +514,7 @@ function downloadWeapons(
     row.Mag = stats.magazine;
     row.Equip = stats.equipSpeed;
     row['Charge Time'] = stats.chargetime;
-    if (item.isDestiny2()) {
+    if (item.destinyVersion === 2) {
       row['Draw Time'] = stats.drawtime;
       row.Accuracy = stats.accuracy;
     }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -76,11 +76,6 @@ export interface DimStore<Item = DimItem> {
 
   /** Add an item to the store. */
   addItem(item: Item): void;
-
-  /** Check if this store is from D1. Inside an if statement, this item will be narrowed to type D1Store. */
-  isDestiny1(): this is D1Store;
-  /* Check if this store is from D2. */
-  isDestiny2(): boolean;
 }
 
 /** How many items are in each vault bucket. DIM hides the vault bucket concept from users but needs the count to track progress. */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -12,7 +12,7 @@ import { vaultTypes } from '../../destiny1/d1-buckets';
 import { D1ManifestDefinitions } from '../../destiny1/d1-definitions';
 import { reportException } from '../../utils/exceptions';
 import { InventoryBuckets } from '../inventory-buckets';
-import { D1GridNode, D1Item, D1Stat, D1TalentGrid } from '../item-types';
+import { D1GridNode, D1Item, D1Stat, D1TalentGrid, DimItem } from '../item-types';
 import { D1Store } from '../store-types';
 import { getQualityRating } from './armor-quality';
 import { getBonus } from './character-utils';
@@ -453,7 +453,7 @@ function getAmmoType(itemType: string) {
 }
 
 // Set an ID for the item that should be unique across all items
-export function createItemIndex(item: D1Item) {
+export function createItemIndex(item: DimItem) {
   // Try to make a unique, but stable ID. This isn't always possible, such as in the case of consumables.
   let index = item.id;
   if (item.id === '0') {

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
  * Generic helpers for working with whole stores (character inventories) or lists of stores.
  */
 import { DimItem } from './item-types';
-import { DimStore, DimVault } from './store-types';
+import { D1Store, DimStore, DimVault } from './store-types';
 
 /**
  * Get whichever character was last played.
@@ -172,4 +172,13 @@ export function spaceLeftForItem(store: DimStore, item: DimItem, stores: DimStor
     }
     return Math.max(openStacks * maxStackSize - existingAmount, 0);
   }
+}
+
+/**
+ * Is this store a Destiny 1 store? Use this when you want the item to
+ * automatically be typed as D1 store in the "true" branch of a conditional.
+ * Otherwise you can just check "destinyVersion === 1".
+ */
+export function isD1Store(store: DimStore): store is D1Store {
+  return store.destinyVersion === 1;
 }

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -175,7 +175,7 @@ export function spaceLeftForItem(store: DimStore, item: DimItem, stores: DimStor
 }
 
 /**
- * Is this store a Destiny 1 store? Use this when you want the item to
+ * Is this store a Destiny 1 store? Use this when you want the store to
  * automatically be typed as D1 store in the "true" branch of a conditional.
  * Otherwise you can just check "destinyVersion === 1".
  */

--- a/src/app/item-popup/ItemActions.tsx
+++ b/src/app/item-popup/ItemActions.tsx
@@ -71,7 +71,7 @@ export default function ItemActions({
 
   const canConsolidate =
     !item.notransfer && item.location.hasTransferDestination && item.maxStackSize > 1;
-  const canDistribute = item.isDestiny1() && !item.notransfer && item.maxStackSize > 1;
+  const canDistribute = item.destinyVersion === 1 && !item.notransfer && item.maxStackSize > 1;
 
   return (
     <>
@@ -115,7 +115,7 @@ export default function ItemActions({
           <ItemActionButtonGroup vertical={Boolean(mobileInspect)}>
             <ItemActionButton
               className={clsx(styles.infusePerk, {
-                [styles.destiny2]: item.isDestiny2(),
+                [styles.destiny2]: item.destinyVersion === 2,
                 [styles.weapons]: item.bucket.sort === 'Weapons',
                 [styles.armor]: item.bucket.sort === 'Armor',
               })}

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -52,7 +52,7 @@ export default function ItemPopupBody({
   ];
   if (
     $featureFlags.triage &&
-    item.isDestiny2() &&
+    item.destinyVersion === 2 &&
     (item.bucket.inArmor ||
       (item.bucket.sort === 'Weapons' &&
         item.bucket.type !== 'SeasonalArtifacts' &&

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -98,7 +98,7 @@ export default function ItemPopupHeader({
               />
             </div>
           )}
-        {item.isDestiny2() && item.ammoType > 0 && (
+        {item.destinyVersion === 2 && item.ammoType > 0 && (
           <div className={clsx('ammo-type', ammoTypeClass(item.ammoType))} />
         )}
         {item.breakerType && (

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -102,7 +102,7 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
         {displayValue}
       </div>
 
-      {item?.isDestiny2() && statsMs.includes(stat.statHash) && (
+      {item?.destinyVersion === 2 && statsMs.includes(stat.statHash) && (
         <div className={clsx(optionalClasses)}>{t('Stats.Milliseconds')}</div>
       )}
 
@@ -269,7 +269,7 @@ function getModdedStatValue(item: DimItem, stat: DimStat) {
 }
 
 export function isD1Stat(item: DimItem, _stat: DimStat): _stat is D1Stat {
-  return item.isDestiny1();
+  return item.destinyVersion === 1;
 }
 
 /**

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -1,3 +1,4 @@
+import { isD1Item } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import React from 'react';
 import { DimItem, DimStat } from '../inventory/item-types';
@@ -29,7 +30,7 @@ export default function ItemStats({
         <ItemStat key={stat.statHash} stat={stat} item={item} />
       ))}
 
-      {item?.isDestiny1() && item.quality?.min && <D1QualitySummaryStat item={item} />}
+      {item && isD1Item(item) && item.quality?.min && <D1QualitySummaryStat item={item} />}
     </div>
   );
 }

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -144,9 +144,8 @@ function LoadoutPopup({
   const maxLight = getLight(dimStore, maxLightItemSet(stores, dimStore).equippable);
   const artifactLight = getArtifactBonus(dimStore);
 
-  const numPostmasterItems = dimStore.isDestiny2()
-    ? pullablePostmasterItems(dimStore, stores).length
-    : 0;
+  const numPostmasterItems =
+    dimStore.destinyVersion === 2 ? pullablePostmasterItems(dimStore, stores).length : 0;
   const numPostmasterItemsTotal = totalPostmasterItems(dimStore);
 
   const makeNewLoadout = () => {
@@ -182,7 +181,7 @@ function LoadoutPopup({
 
     dispatch(interruptFarming());
     try {
-      return await dispatch(applyLoadout(dimStore, loadout, true));
+      await dispatch(applyLoadout(dimStore, loadout, true));
     } finally {
       dispatch(resumeFarming());
     }
@@ -307,7 +306,7 @@ function LoadoutPopup({
               </span>
             </li>
 
-            {dimStore.isDestiny1() && (
+            {dimStore.destinyVersion === 1 && (
               <>
                 <li className="loadout-set">
                   <span onClick={makeItemLevelingLoadout}>
@@ -327,7 +326,7 @@ function LoadoutPopup({
               </>
             )}
 
-            {dimStore.isDestiny2() && numPostmasterItems > 0 && (
+            {dimStore.destinyVersion === 2 && numPostmasterItems > 0 && (
               <li className="loadout-set">
                 <span onClick={doPullFromPostmaster}>
                   <AppIcon icon={sendIcon} />
@@ -337,18 +336,20 @@ function LoadoutPopup({
                 <span onClick={doMakeRoomForPostmaster}>{t('Loadouts.PullMakeSpace')}</span>
               </li>
             )}
-            {dimStore.isDestiny2() && numPostmasterItems === 0 && numPostmasterItemsTotal > 0 && (
-              <li className="loadout-set">
-                <span onClick={doMakeRoomForPostmaster}>
-                  <AppIcon icon={sendIcon} />
-                  <span>{t('Loadouts.MakeRoom')}</span>
-                </span>
-              </li>
-            )}
+            {dimStore.destinyVersion === 2 &&
+              numPostmasterItems === 0 &&
+              numPostmasterItemsTotal > 0 && (
+                <li className="loadout-set">
+                  <span onClick={doMakeRoomForPostmaster}>
+                    <AppIcon icon={sendIcon} />
+                    <span>{t('Loadouts.MakeRoom')}</span>
+                  </span>
+                </li>
+              )}
           </>
         )}
 
-        {dimStore.isDestiny1() && (
+        {dimStore.destinyVersion === 1 && (
           <li className="loadout-set">
             <span onClick={(e) => gatherEngramsLoadout(e, { exotics: true })}>
               <AppIcon icon={engramIcon} />

--- a/src/app/loadout/auto-loadouts.ts
+++ b/src/app/loadout/auto-loadouts.ts
@@ -1,7 +1,7 @@
 import { t } from 'app/i18next-t';
 import { getAllItems, getCurrentStore } from 'app/inventory/stores-helpers';
 import { ItemFilter } from 'app/search/filter-types';
-import { itemCanBeEquippedBy } from 'app/utils/item-utils';
+import { isD1Item, itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { StatHashes } from 'data/d2/generated-enums';
 import copy from 'fast-copy';
@@ -51,7 +51,7 @@ export function itemLevelingLoadout(stores: DimStore[], store: DimStore): Loadou
     value += ['Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'].indexOf(item.tier) * 10;
 
     // Choose the item w/ the highest XP
-    if (item.isDestiny1() && item.talentGrid) {
+    if (isD1Item(item) && item.talentGrid) {
       value += 10 * (item.talentGrid.totalXP / item.talentGrid.totalXPRequired);
     }
 

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -40,7 +40,7 @@ export function newLoadout(name: string, items: LoadoutItem[]): Loadout {
  */
 export function getLight(store: DimStore, items: DimItem[]): number {
   // https://www.reddit.com/r/DestinyTheGame/comments/6yg4tw/how_overall_power_level_is_calculated/
-  if (store.isDestiny2()) {
+  if (store.destinyVersion === 2) {
     const exactLight = _.sumBy(items, (i) => i.primStat!.value) / items.length;
     return Math.floor(exactLight * 1000) / 1000;
   } else {

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -41,6 +41,7 @@ import {
   getItemYear,
   getMasterworkStatNames,
   getSpecialtySocketMetadata,
+  isD1Item,
   modMetadataByTag,
 } from 'app/utils/item-utils';
 import { isUsedModSocket } from 'app/utils/socket-utils';
@@ -330,14 +331,14 @@ export function getColumns(
     destinyVersion === 2 && {
       id: 'season',
       header: t('Organizer.Columns.Season'),
-      value: (i) => i.isDestiny2() && getSeason(i),
+      value: (i) => getSeason(i),
       filter: (value) => `season:${value}`,
     },
     destinyVersion === 2 && {
       id: 'event',
       header: t('Organizer.Columns.Event'),
       value: (item) => {
-        const event = item.isDestiny2() && getEvent(item);
+        const event = getEvent(item);
         return event ? D2EventInfo[event].name : undefined;
       },
       filter: (value) => `event:${value}`,
@@ -418,7 +419,7 @@ export function getColumns(
         destinyVersion === 2 ? t('Organizer.Columns.PerksMods') : t('Organizer.Columns.Perks'),
       value: () => 0, // TODO: figure out a way to sort perks
       cell: (_, item) =>
-        item.isDestiny1() ? <D1PerksCell item={item} /> : <PerksCell defs={defs} item={item} />,
+        isD1Item(item) ? <D1PerksCell item={item} /> : <PerksCell defs={defs} item={item} />,
       noSort: true,
       gridWidth: 'minmax(324px,max-content)',
       filter: (value) => (value !== 0 ? `perkname:"${value}"` : undefined),
@@ -440,7 +441,7 @@ export function getColumns(
       isArmor && {
         id: 'quality',
         header: t('Organizer.Columns.Quality'),
-        value: (item) => (item.isDestiny1() && item.quality ? item.quality.min : 0),
+        value: (item) => (isD1Item(item) && item.quality ? item.quality.min : 0),
         cell: (value: number) => <span style={getColor(value, 'color')}>{value}%</span>,
         filter: (value) => `quality:>=${value}`,
       },
@@ -596,7 +597,7 @@ function PerksCell({
 }
 
 function D1PerksCell({ item }: { item: D1Item }) {
-  if (!item.isDestiny1() || !item.talentGrid) {
+  if (!isD1Item(item) || !item.talentGrid) {
     return null;
   }
   const sockets = Object.values(
@@ -620,7 +621,7 @@ function D1PerksCell({ item }: { item: D1Item }) {
         >
           {socket.map(
             (p) =>
-              item.isDestiny1() && (
+              isD1Item(item) && (
                 <PressTip
                   key={p.hash}
                   tooltip={

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -151,16 +151,13 @@ function getStringsFromDisplayPropertiesMap<T extends { name: string; descriptio
 /** includes name and description unless you set the arg2 flag */
 export function getStringsFromAllSockets(item, includeDescription = true) {
   return (
-    (item.isDestiny2() &&
-      item.sockets &&
-      item.sockets.allSockets.flatMap((socket) => {
-        const plugAndPerkDisplay = socket.plugOptions.map((plug) => [
-          plug.plugDef.displayProperties,
-          plug.perks.map((perk) => perk.displayProperties),
-        ]);
-        return getStringsFromDisplayPropertiesMap(plugAndPerkDisplay.flat(2), includeDescription);
-      })) ||
-    []
+    item.sockets?.allSockets.flatMap((socket) => {
+      const plugAndPerkDisplay = socket.plugOptions.map((plug) => [
+        plug.plugDef.displayProperties,
+        plug.perks.map((perk) => perk.displayProperties),
+      ]);
+      return getStringsFromDisplayPropertiesMap(plugAndPerkDisplay.flat(2), includeDescription);
+    }) || []
   );
 }
 /** includes name and description unless you set the arg2 flag */

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -1,6 +1,7 @@
 import { factionItemAligns } from 'app/destiny1/d1-factions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import {
+  D1Item,
   DimItem,
   DimMasterwork,
   DimSocket,
@@ -160,7 +161,7 @@ export function itemCanBeEquippedBy(item: DimItem, store: DimStore): boolean {
     // can be moved or is already here
     (!item.notransfer || item.owner === store.id) &&
     !item.location.inPostmaster &&
-    (item.isDestiny1() ? factionItemAligns(store, item) : true)
+    (isD1Item(item) ? factionItemAligns(store, item) : true)
   );
 }
 /** Could this be added to a loadout? */
@@ -221,10 +222,10 @@ const d1YearSourceHashes = {
  * Which "Year" of Destiny did this item come from?
  */
 export function getItemYear(item: DimItem) {
-  if (item.isDestiny2()) {
+  if (item.destinyVersion === 2) {
     // TODO: D2SeasonInfo is only used for year?
     return D2SeasonInfo[getSeason(item)].year;
-  } else if (item.isDestiny1()) {
+  } else if (isD1Item(item)) {
     if (!item.sourceHashes) {
       return 1;
     }
@@ -258,4 +259,13 @@ export function getItemYear(item: DimItem) {
   } else {
     return undefined;
   }
+}
+
+/**
+ * Is this item a Destiny 1 item? Use this when you want the item to
+ * automatically be typed as D1 item in the "true" branch of a conditional.
+ * Otherwise you can just check "destinyVersion === 1".
+ */
+export function isD1Item(item: DimItem): item is D1Item {
+  return item.destinyVersion === 1;
 }

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -44,7 +44,7 @@ export function getInventoryWishListRolls(
     !$featureFlags.wishLists ||
     _.isEmpty(rollsByHash) ||
     !stores.length ||
-    !stores[0].isDestiny2()
+    stores[0].destinyVersion === 1
   ) {
     return {};
   }


### PR DESCRIPTION
This is a bit sad, but it's necessary to turn these from classes into immutable data objects that play well with redux/immer. Good news is that type specialization was only needed in a few places.