### PR TITLE
Redux inventory

### DIFF
--- a/src/app/destiny1/d1-factions.ts
+++ b/src/app/destiny1/d1-factions.ts
@@ -1,5 +1,6 @@
 import { D1Item } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
+import { findItemsByBucket } from 'app/inventory/stores-helpers';
 
 // In D1 there were exotic ghosts that you could only equip if you also had a "Faction Badge" equipped
 // that matched that faction. These functions help identify what faction badge is equipped on the character
@@ -28,7 +29,7 @@ const factionsByHash = {
 
 /** What faction is this character aligned with (by equipping that faction's badge)? */
 export function factionAlignment(store: DimStore): string | null {
-  const badge = store.buckets[375726501].find((i) => factionBadges[i.hash]);
+  const badge = findItemsByBucket(store, 375726501).find((i) => factionBadges[i.hash]);
   if (!badge) {
     return null;
   }

--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -4,7 +4,12 @@ import {
   itemInfosSelector,
   storesSelector,
 } from 'app/inventory/selectors';
-import { capacityForItem, getVault, isD1Store } from 'app/inventory/stores-helpers';
+import {
+  capacityForItem,
+  findItemsByBucket,
+  getVault,
+  isD1Store,
+} from 'app/inventory/stores-helpers';
 import { settingsSelector } from 'app/settings/reducer';
 import { refresh } from 'app/shell/refresh';
 import { ThunkResult } from 'app/store/types';
@@ -158,7 +163,7 @@ export function makeRoomForItemsInBuckets(
     const itemInfos = itemInfosSelector(getState());
     const itemHashTags = itemHashTagsSelector(getState());
     makeRoomBuckets.forEach((bucket) => {
-      const items = store.buckets[bucket.hash];
+      const items = findItemsByBucket(store, bucket.hash);
       if (items.length > 0 && items.length >= capacityForItem(store, items[0])) {
         const moveAsideCandidates = items.filter((i) => !i.equipped && !i.notransfer);
         const prioritizedMoveAsideCandidates = sortMoveAsideCandidatesForStore(

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -22,6 +22,7 @@ import { DimStore } from './store-types';
 import './StoreBucket.scss';
 import StoreBucketDropTarget from './StoreBucketDropTarget';
 import StoreInventoryItem from './StoreInventoryItem';
+import { findItemsByBucket } from './stores-helpers';
 
 // Props provided from parents
 interface ProvidedProps {
@@ -42,12 +43,12 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   const { store, bucket } = props;
 
   return {
-    items: store.buckets[bucket.hash] ?? emptyArray(),
     itemSortOrder: itemSortOrderSelector(state),
     // We only need this property when this is a vault armor bucket
     allStores: store.isVault && bucket.inArmor ? sortedStoresSelector(state) : emptyArray(),
     characterOrder: characterOrderSelector(state),
     isPhonePortrait: isPhonePortraitSelector(state),
+    items: findItemsByBucket(store, bucket.hash),
   };
 }
 

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -6,6 +6,7 @@ import { InventoryBucket } from './inventory-buckets';
 import { PullFromPostmaster } from './PullFromPostmaster';
 import { DimStore, DimVault } from './store-types';
 import StoreBucket from './StoreBucket';
+import { findItemsByBucket } from './stores-helpers';
 
 /** One row of store buckets, one for each character and vault. */
 export function StoreBuckets({
@@ -24,7 +25,7 @@ export function StoreBuckets({
   // Don't show buckets with no items
   if (
     (!bucket.accountWide || bucket.type === 'SpecialOrders') &&
-    !stores.some((s) => s.buckets[bucket.hash].length > 0)
+    !stores.some((s) => findItemsByBucket(s, bucket.hash).length > 0)
   ) {
     return null;
   }
@@ -62,7 +63,7 @@ export function StoreBuckets({
         {(!store.isVault || bucket.vaultBucket) && <StoreBucket bucket={bucket} store={store} />}
         {bucket.type === 'LostItems' &&
           store.destinyVersion === 2 &&
-          store.buckets[bucket.hash].length > 0 && <PullFromPostmaster store={store} />}
+          findItemsByBucket(store, bucket.hash).length > 0 && <PullFromPostmaster store={store} />}
       </div>
     ));
   }

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -17,7 +17,7 @@ import InventoryCollapsibleTitle from './InventoryCollapsibleTitle';
 import { bucketsSelector, sortedStoresSelector } from './selectors';
 import { DimStore, DimVault } from './store-types';
 import { StoreBuckets } from './StoreBuckets';
-import { getCurrentStore, getStore, getVault } from './stores-helpers';
+import { findItemsByBucket, getCurrentStore, getStore, getVault } from './stores-helpers';
 import './Stores.scss';
 
 interface StoreProps {
@@ -207,7 +207,7 @@ function categoryHasItems(
   const buckets = allBuckets.byCategory[category];
   return buckets.some((bucket) => {
     const storesToSearch = bucket.accountWide && !stores[0].isVault ? [currentStore] : stores;
-    return storesToSearch.some((s) => s.buckets[bucket.hash] && s.buckets[bucket.hash].length > 0);
+    return storesToSearch.some((s) => findItemsByBucket(s, bucket.hash).length > 0);
   });
 }
 

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -35,18 +35,6 @@ export interface CharacterInfo {
 export const charactersUpdated = createAction('inventory/CHARACTERS')<CharacterInfo[]>();
 
 /**
- * Force stores to be updated to reflect a change. This is a hack that should go
- * away as we normalize inventory state.
- */
-export const touch = createAction('inventory/TOUCH')();
-
-/**
- * Force stores to be updated to reflect a change in a single item by instance ID. This is a hack that should go
- * away as we normalize inventory state.
- */
-export const touchItem = createAction('inventory/TOUCH_ITEM')<string>();
-
-/**
  * Reflect the old stores service data into the Redux store as a migration aid.
  */
 export const error = createAction('inventory/ERROR')<DimError>();
@@ -60,6 +48,16 @@ export const itemMoved = createAction('inventory/MOVE_ITEM')<{
   target: DimStore;
   equip: boolean;
   amount: number;
+}>();
+
+/*
+ * An item has been locked or unlocked (or tracked/untracked)
+ */
+export const itemLockStateChanged = createAction('inventory/ITEM_LOCK')<{
+  item: DimItem;
+
+  state: boolean;
+  type: 'lock' | 'track';
 }>();
 
 /** Update the set of new items. */

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -5,7 +5,6 @@ import { DestinyColor, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { get } from 'idb-keyval';
 import { createAction } from 'typesafe-actions';
 import { TagValue } from './dim-item-info';
-import { InventoryBuckets } from './inventory-buckets';
 import { DimItem } from './item-types';
 import { DimCharacterStat, DimStore } from './store-types';
 
@@ -53,14 +52,9 @@ export const touchItem = createAction('inventory/TOUCH_ITEM')<string>();
 export const error = createAction('inventory/ERROR')<DimError>();
 
 /**
- * Set the bucket info.
+ * An item has moved (or equipped/dequipped)
  */
-export const setBuckets = createAction('inventory/SET_BUCKETS')<InventoryBuckets>();
-
-/**
- * Move an item from one store to another.
- */
-export const moveItem = createAction('inventory/MOVE_ITEM')<{
+export const itemMoved = createAction('inventory/MOVE_ITEM')<{
   item: DimItem;
   source: DimStore;
   target: DimStore;

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -24,7 +24,7 @@ import {
   transfer as d2Transfer,
 } from '../bungie-api/destiny2-api';
 import { chainComparator, compareBy, reverseComparator } from '../utils/comparators';
-import { itemMoved, touchItem } from './actions';
+import { itemLockStateChanged, itemMoved } from './actions';
 import {
   characterDisplacePriority,
   getTag,
@@ -78,14 +78,7 @@ export function setItemLockState(
       await d1SetItemState(account, item, storeId, state, type);
     }
 
-    if (type === 'lock') {
-      item.locked = state;
-    } else if (type === 'track') {
-      item.tracked = state;
-    }
-
-    // TODO: dispatch a better action to mutate the item!
-    dispatch(touchItem(item.id));
+    dispatch(itemLockStateChanged({ item, state, type }));
   };
 }
 

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -32,6 +32,7 @@ import {
   vaultDisplacePriority,
 } from './dim-item-info';
 import { DimItem } from './item-types';
+import { getLastManuallyMoved } from './manual-moves';
 import { itemHashTagsSelector, itemInfosSelector, storesSelector } from './selectors';
 import { DimStore } from './store-types';
 import {
@@ -948,7 +949,7 @@ export function sortMoveAsideCandidatesForStore(
       // or at least same category
       compareBy((i) => item && i.bucket.sort === item.bucket.sort),
       // Always prefer keeping something that was manually moved where it is
-      compareBy((i) => -i.lastManuallyMoved),
+      compareBy((i) => -getLastManuallyMoved(i)),
       // Engrams prefer to be in the vault, so not-engram is larger than engram
       compareBy((i) => (fromStore.isVault ? !i.isEngram : i.isEngram)),
       // Prefer moving things the target store can use

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -150,8 +150,6 @@ export interface DimItem {
   isEngram: boolean;
   /** The reference hash for lore attached to this item (D2 only). */
   loreHash?: number;
-  /** A timestamp of when, in this session, the item was last manually moved */
-  lastManuallyMoved: number;
   /** Sometimes the API doesn't return socket info. This tells whether the item *should* have socket info but doesn't. */
   missingSockets: boolean;
   /** Stat Tracker */
@@ -188,9 +186,6 @@ export interface DimItem {
     energyCost: number;
     costElementIcon: string;
   };
-
-  /** "Touch" the item to mark it as having been manually moved. */
-  updateManualMoveTimestamp(): void;
 }
 
 /**

--- a/src/app/inventory/manual-moves.ts
+++ b/src/app/inventory/manual-moves.ts
@@ -1,0 +1,19 @@
+import { DimItem } from './item-types';
+
+/**
+ * A map from item index to the last time it was manually moved in this
+ * session. We use this to avoid auto-moving things you just moved manually.
+ * This could be in Redux, but it doesn't affect anything visually, so it's
+ * a bit easier to just have it be a global.
+ */
+const moveTouchTimestamps = new Map<string, number>();
+
+export function updateManualMoveTimestamp(item: DimItem) {
+  moveTouchTimestamps.set(item.index, Date.now());
+}
+
+export function getLastManuallyMoved(item: DimItem) {
+  return moveTouchTimestamps.get(item.index) ?? 0;
+}
+
+// TODO: do it for loadouts too!

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -13,6 +13,7 @@ import { queueAction } from './action-queue';
 import { updateCharacters } from './d2-stores';
 import { moveItemTo as moveTo } from './item-move-service';
 import { DimItem } from './item-types';
+import { updateManualMoveTimestamp } from './manual-moves';
 import { moveItemNotification } from './MoveNotifications';
 import { storesSelector } from './selectors';
 import { DimStore } from './store-types';
@@ -132,7 +133,7 @@ export function moveItemTo(
         dispatch(updateCharacters());
       }
 
-      item.updateManualMoveTimestamp();
+      updateManualMoveTimestamp(item);
     } catch (e) {
       console.error('error moving item', item.name, 'to', store.name, e);
       // Some errors aren't worth reporting

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -48,14 +48,12 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
   action: InventoryAction | AccountsAction
 ): InventoryState => {
   switch (action.type) {
-    // TODO: rename to "replace inventory"
     case getType(actions.update):
       return updateInventory(state, action.payload);
 
     case getType(actions.charactersUpdated):
       return updateCharacters(state, action.payload);
 
-    // TODO: lock/unlock, track/untrack, etc
     case getType(actions.itemMoved): {
       const { item, source, target, equip, amount } = action.payload;
       return produce(state, (draft) => itemMoved(draft, item, source.id, target.id, equip, amount));
@@ -263,7 +261,6 @@ function setsEqual<T>(first: Set<T>, second: Set<T>) {
 
 /**
  * Update our item and store models after an item has been moved (or equipped/dequipped).
- * @return the new or updated item (it may create a new item!)
  */
 function itemMoved(
   draft: Draft<InventoryState>,
@@ -278,7 +275,7 @@ function itemMoved(
   const source = getStore(stores, sourceStoreId);
   const target = getStore(stores, targetStoreId);
   if (!source || !target) {
-    // TODO: log error
+    console.warn('Either source or target store not found', source, target);
     return;
   }
 
@@ -286,7 +283,7 @@ function itemMoved(
     (i) => i.hash === item.hash && i.id === item.id && i.location.hash === item.location.hash
   )!;
   if (!item) {
-    // TODO: log error
+    console.warn('Moved item not found', item);
     return;
   }
 
@@ -331,7 +328,7 @@ function itemMoved(
     while (removeAmount > 0) {
       const sourceItem = sourceItems.shift();
       if (!sourceItem) {
-        // TODO: log error
+        console.warn('Source item missing', item);
         return;
       }
 
@@ -392,14 +389,14 @@ function itemLockStateChanged(
 ) {
   const source = getStore(draft.stores, item.owner);
   if (!source) {
-    // TODO: log error
+    console.warn('Store', item.owner, 'not found');
     return;
   }
 
   // Only instanced items can be locked/tracked
   item = source.items.find((i) => i.id === item.id)!;
   if (!item) {
-    // TODO: log error
+    console.warn('Item not found in stores', item);
     return;
   }
 

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -1,5 +1,7 @@
 import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
+import produce, { Draft } from 'immer';
+import _ from 'lodash';
 import { Reducer } from 'redux';
 import { ActionType, getType } from 'typesafe-actions';
 import { setCurrentAccount } from '../accounts/actions';
@@ -8,10 +10,9 @@ import * as actions from './actions';
 import { DimItem } from './item-types';
 import { DimStore } from './store-types';
 import { ItemProto as D1ItemProto } from './store/d1-item-factory';
-import { StoreProto as D1StoreProto } from './store/d1-store-factory';
 import { ItemProto as D2ItemProto } from './store/d2-item-factory';
-import { StoreProto as D2StoreProto } from './store/d2-store-factory';
-import { getItemAcrossStores, getStore } from './stores-helpers';
+import { createItemIndex } from './store/item-index';
+import { findItemsByBucket, getItemAcrossStores, getStore, isVault } from './stores-helpers';
 
 // TODO: Should this be by account? Accounts need IDs
 export interface InventoryState {
@@ -47,8 +48,9 @@ const initialState: InventoryState = {
 export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction> = (
   state: InventoryState = initialState,
   action: InventoryAction | AccountsAction
-) => {
+): InventoryState => {
   switch (action.type) {
+    // TODO: rename to "replace inventory"
     case getType(actions.update):
       return updateInventory(state, action.payload);
 
@@ -65,13 +67,11 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.charactersUpdated):
       return updateCharacters(state, action.payload);
 
-    // Buckets
-    // TODO: only need to do this once, on loading a new platform.
-    case getType(actions.setBuckets):
-      return {
-        ...state,
-        buckets: action.payload,
-      };
+    // TODO: lock/unlock, track/untrack, etc
+    case getType(actions.itemMoved): {
+      const { item, source, target, equip, amount } = action.payload;
+      return produce(state, (draft) => itemMoved(draft, item, source.id, target.id, equip, amount));
+    }
 
     case getType(actions.error):
       return {
@@ -158,18 +158,14 @@ function updateCharacters(state: InventoryState, characters: actions.CharacterIn
         return store;
       }
       const { characterId, ...characterInfo } = character;
-      return Object.assign(
-        // Have to make it into a full object again. TODO: un-object-ify this
-        Object.create(store.destinyVersion === 2 ? D2StoreProto : D1StoreProto),
-        {
-          ...store,
-          ...characterInfo,
-          stats: {
-            ...store.stats,
-            ...characterInfo.stats,
-          },
-        }
-      );
+      return {
+        ...store,
+        ...characterInfo,
+        stats: {
+          ...store.stats,
+          ...characterInfo.stats,
+        },
+      };
     }),
   };
 }
@@ -282,19 +278,167 @@ function touchItem(state: InventoryState, itemId: string) {
     Object.create(store.destinyVersion === 2 ? D2ItemProto : D1ItemProto),
     item
   ) as DimItem;
-  store = Object.assign(Object.create(store.destinyVersion === 2 ? D2StoreProto : D1StoreProto), {
+  store = {
     ...store,
     items: store.items.map((i) => (i.id === item.id ? item : i)),
-    buckets: {
-      ...store.buckets,
-      [item.location.hash]: store.buckets[item.location.hash].map((i) =>
-        i.id === item.id ? item : i
-      ),
-    },
-  });
+  };
 
   return {
     ...state,
     stores: state.stores.map((s) => (s.id === store.id ? store : s)),
   };
+}
+
+/**
+ * Update our item and store models after an item has been moved (or equipped/dequipped).
+ * @return the new or updated item (it may create a new item!)
+ */
+function itemMoved(
+  draft: Draft<InventoryState>,
+  item: DimItem,
+  sourceStoreId: string,
+  targetStoreId: string,
+  equip: boolean,
+  amount: number
+): void {
+  // Refresh all the items - they may have been reloaded!
+  const stores = draft.stores;
+  const source = getStore(stores, sourceStoreId);
+  const target = getStore(stores, targetStoreId);
+  if (!source || !target) {
+    // TODO: log error
+    return;
+  }
+
+  item = source.items.find(
+    (i) => i.hash === item.hash && i.id === item.id && i.location.hash === item.location.hash
+  )!;
+  if (!item) {
+    // TODO: log error
+    return;
+  }
+
+  // If we've moved to a new place
+  if (source.id !== target.id || item.location.inPostmaster) {
+    // We handle moving stackable and nonstackable items almost exactly the same!
+    const stackable = item.maxStackSize > 1;
+    // Items to be decremented
+    const sourceItems = stackable
+      ? // For stackables, pull from all the items as a pool
+        _.sortBy(
+          findItemsByBucket(source, item.location.hash).filter(
+            (i) => i.hash === item.hash && i.id === item.id
+          ),
+          (i) => i.amount
+        )
+      : // Otherwise we're moving the exact item we passed in
+        [item];
+
+    // Items to be incremented. There's really only ever at most one of these, but
+    // it's easier to deal with as a list. An empty list means we'll vivify a new item there.
+    const targetItems = stackable
+      ? _.sortBy(
+          findItemsByBucket(target, item.bucket.hash).filter(
+            (i) =>
+              i.hash === item.hash &&
+              i.id === item.id &&
+              // Don't consider full stacks as targets
+              i.amount !== i.maxStackSize
+          ),
+          (i) => i.amount
+        )
+      : [];
+
+    // moveAmount could be more than maxStackSize if there is more than one stack on a character!
+    const moveAmount = amount || item.amount || 1;
+    let addAmount = moveAmount;
+    let removeAmount = moveAmount;
+    let removedSourceItem = false;
+
+    // Remove inventory from the source
+    while (removeAmount > 0) {
+      const sourceItem = sourceItems.shift();
+      if (!sourceItem) {
+        // TODO: log error
+        return;
+      }
+
+      const amountToRemove = Math.min(removeAmount, sourceItem.amount);
+      sourceItem.amount -= amountToRemove;
+      if (sourceItem.amount <= 0) {
+        // Completely remove the source item
+        if (removeItem(source, sourceItem)) {
+          removedSourceItem = sourceItem.index === item.index;
+        }
+      }
+
+      removeAmount -= amountToRemove;
+    }
+
+    // Add inventory to the target (destination)
+    let targetItem = item;
+    while (addAmount > 0) {
+      targetItem = targetItems.shift()!;
+
+      if (!targetItem) {
+        targetItem = item;
+        if (!removedSourceItem) {
+          // This assumes (as we shouldn't) that we have no nested mutable state in the item
+          targetItem = { ...item };
+          targetItem.index = createItemIndex(targetItem);
+        }
+        removedSourceItem = false; // only move without cloning once
+        targetItem.amount = 0; // We'll increment amount below
+        if (targetItem.location.inPostmaster) {
+          targetItem.location = targetItem.bucket;
+        }
+        addItem(target, targetItem);
+      }
+
+      const amountToAdd = Math.min(addAmount, targetItem.maxStackSize - targetItem.amount);
+      targetItem.amount += amountToAdd;
+      addAmount -= amountToAdd;
+    }
+    item = targetItem; // The item we're operating on switches to the last target
+  }
+
+  if (equip) {
+    for (const i of target.items) {
+      // Set equipped for all items in the bucket
+      if (i.location.hash === item.bucket.hash) {
+        i.equipped = i.index === item.index;
+      }
+    }
+  }
+}
+
+// Remove an item from this store. Returns whether it actually removed anything.
+function removeItem(store: Draft<DimStore>, item: Draft<DimItem>) {
+  // Completely remove the source item
+  const sourceIndex = store.items.findIndex((i: DimItem) => item.index === i.index);
+  if (sourceIndex >= 0) {
+    store.items.splice(sourceIndex, 1);
+
+    if (
+      item.location.accountWide &&
+      store.current &&
+      store.vault?.vaultCounts[item.location.hash]
+    ) {
+      store.vault.vaultCounts[item.location.hash].count--;
+    }
+
+    return true;
+  }
+  return false;
+}
+
+function addItem(store: Draft<DimStore>, item: Draft<DimItem>) {
+  store.items.push(item);
+  item.owner = store.id;
+
+  if (item.location.accountWide && store.current && store.vault) {
+    store.vault.vaultCounts[item.location.hash].count++;
+  } else if (isVault(store) && item.location.vaultBucket) {
+    store.vaultCounts[item.location.vaultBucket.hash].count++;
+  }
 }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -61,7 +61,6 @@ export interface DimStore<Item = DimItem> {
     [hash: number]: DimCharacterStat;
   };
   /** Character progression. */
-  // TODO: wtf
   progression: null | {
     progressions: DestinyProgression[];
   };

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -22,8 +22,6 @@ export interface DimStore<Item = DimItem> {
   name: string;
   /** All items in the store, across all buckets. */
   items: Item[];
-  /** All items, grouped by their bucket. */
-  buckets: { [bucketHash: number]: Item[] };
   /** The Destiny version this store came from. */
   destinyVersion: DestinyVersion;
   /** An icon (emblem) for the store. */
@@ -63,6 +61,7 @@ export interface DimStore<Item = DimItem> {
     [hash: number]: DimCharacterStat;
   };
   /** Character progression. */
+  // TODO: wtf
   progression: null | {
     progressions: DestinyProgression[];
   };
@@ -70,12 +69,6 @@ export interface DimStore<Item = DimItem> {
   /** The vault associated with this store. */
   vault?: DimVault;
   color?: DestinyColor;
-
-  /** Remove an item from this store. Returns whether it actually removed anything. */
-  removeItem(item: Item): boolean;
-
-  /** Add an item to the store. */
-  addItem(item: Item): void;
 }
 
 /** How many items are in each vault bucket. DIM hides the vault bucket concept from users but needs the count to track progress. */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -21,21 +21,6 @@ import { createItemIndex } from './item-index';
 // Maps tierType to tierTypeName in English
 const tiers = ['Unknown', 'Unknown', 'Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'] as const;
 
-// A map from instance id to the last time it was manually moved this session
-const _moveTouchTimestamps = new Map<string, number>();
-
-// Prototype for Item objects - add methods to this to add them to all
-// items.
-export const ItemProto = {
-  // Mark that this item has been moved manually
-  updateManualMoveTimestamp(this: D1Item) {
-    this.lastManuallyMoved = Date.now();
-    if (this.id !== '0') {
-      _moveTouchTimestamps.set(this.id, this.lastManuallyMoved);
-    }
-  },
-};
-
 /**
  * Process an entire list of items into DIM items.
  * @param owner the ID of the owning store.
@@ -245,7 +230,7 @@ function makeItem(
     itemDef.sourceHashes = _.union(itemDef.sourceHashes, missingSource);
   }
 
-  const itemProps: Omit<D1Item, 'isDestiny2' | 'isDestiny1' | 'updateManualMoveTimestamp'> = {
+  const createdItem: D1Item = {
     owner: owner.id,
     // figure out what year this item is probably from
     destinyVersion: 1,
@@ -303,8 +288,6 @@ function makeItem(
     tracked: item.state === 2,
     locked: item.locked,
     classified: Boolean(itemDef.classified),
-    lastManuallyMoved:
-      item.itemInstanceId === '0' ? 0 : _moveTouchTimestamps.get(item.itemInstanceId) || 0,
     // These get filled in later or aren't relevant to D1 items
     percentComplete: 0,
     talentGrid: null,
@@ -332,8 +315,6 @@ function makeItem(
     powerCap: null,
     pursuit: null,
   };
-
-  const createdItem: D1Item = Object.assign(Object.create(ItemProto), itemProps);
 
   // *able
   createdItem.taggable = Boolean(createdItem.lockable && !createdItem.isEngram);

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -12,15 +12,15 @@ import { vaultTypes } from '../../destiny1/d1-buckets';
 import { D1ManifestDefinitions } from '../../destiny1/d1-definitions';
 import { reportException } from '../../utils/exceptions';
 import { InventoryBuckets } from '../inventory-buckets';
-import { D1GridNode, D1Item, D1Stat, D1TalentGrid, DimItem } from '../item-types';
+import { D1GridNode, D1Item, D1Stat, D1TalentGrid } from '../item-types';
 import { D1Store } from '../store-types';
 import { getQualityRating } from './armor-quality';
 import { getBonus } from './character-utils';
+import { createItemIndex } from './item-index';
 
 // Maps tierType to tierTypeName in English
 const tiers = ['Unknown', 'Unknown', 'Common', 'Uncommon', 'Rare', 'Legendary', 'Exotic'] as const;
 
-let _idTracker: { [id: string]: number } = {};
 // A map from instance id to the last time it was manually moved this session
 const _moveTouchTimestamps = new Map<string, number>();
 
@@ -34,17 +34,7 @@ export const ItemProto = {
       _moveTouchTimestamps.set(this.id, this.lastManuallyMoved);
     }
   },
-  isDestiny1(this: D1Item) {
-    return true;
-  },
-  isDestiny2(this: D1Item) {
-    return false;
-  },
 };
-
-export function resetIdTracker() {
-  _idTracker = {};
-}
 
 /**
  * Process an entire list of items into DIM items.
@@ -450,18 +440,6 @@ function getAmmoType(itemType: string) {
   }
 
   return DestinyAmmunitionType.None;
-}
-
-// Set an ID for the item that should be unique across all items
-export function createItemIndex(item: DimItem) {
-  // Try to make a unique, but stable ID. This isn't always possible, such as in the case of consumables.
-  let index = item.id;
-  if (item.id === '0') {
-    _idTracker[index] = (_idTracker[index] || 0) + 1;
-    index = `${index}-t${_idTracker[index]}`;
-  }
-
-  return index;
 }
 
 function buildTalentGrid(item, talentDefs, progressDefs): D1TalentGrid | null {

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -4,8 +4,7 @@ import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import _ from 'lodash';
 import { D1ManifestDefinitions } from '../../destiny1/d1-definitions';
-import { D1Item } from '../item-types';
-import { D1Store, D1Vault, DimVault } from '../store-types';
+import { D1Store, D1Vault, DimStore, DimVault } from '../store-types';
 import { getCharacterStatsData } from './character-utils';
 
 // Label isn't used, but it helps us understand what each one is
@@ -22,47 +21,6 @@ const progressionMeta = {
   3641985238: { label: 'House of Judgment', order: 9 },
   2335631936: { label: 'Gunsmith', order: 10 },
   2576753410: { label: 'SRL', order: 11 },
-};
-
-/**
- * A factory service for producing "stores" (characters or the vault).
- * The job of filling in their items is left to other code - this is just the basic store itself.
- */
-
-// Prototype for Store objects - add methods to this to add them to all
-// stores.
-export const StoreProto = {
-  // Remove an item from this store. Returns whether it actually removed anything.
-  removeItem(this: D1Store, item: D1Item) {
-    // Completely remove the source item
-    const match = (i: D1Item) => item.index === i.index;
-    const sourceIndex = this.items.findIndex(match);
-    if (sourceIndex >= 0) {
-      this.items = [...this.items.slice(0, sourceIndex), ...this.items.slice(sourceIndex + 1)];
-
-      let bucketItems = this.buckets[item.location.hash];
-      const bucketIndex = bucketItems.findIndex(match);
-      bucketItems = [...bucketItems.slice(0, bucketIndex), ...bucketItems.slice(bucketIndex + 1)];
-      this.buckets[item.location.hash] = bucketItems;
-
-      return true;
-    }
-    return false;
-  },
-
-  addItem(this: D1Store, item: D1Item) {
-    this.items = [...this.items, item];
-    this.buckets[item.location.hash] = [...this.buckets[item.location.hash], item];
-    item.owner = this.id;
-  },
-
-  isDestiny1(this: D1Store) {
-    return true;
-  },
-
-  isDestiny2(this: D1Store) {
-    return false;
-  },
 };
 
 export function makeCharacter(
@@ -100,23 +58,23 @@ export function makeCharacter(
   const race = defs.Race[character.characterBase.raceHash];
   let genderRace = '';
   let className = '';
-  let gender = '';
-  let genderName = '';
+  let gender: DimStore['gender'] = '';
+  let genderName: DimStore['genderName'] = '';
   if (character.characterBase.genderType === 0) {
     gender = 'male';
-    genderName = gender;
+    genderName = 'male';
     genderRace = race.raceNameMale;
     className = defs.Class[character.characterBase.classHash].classNameMale;
   } else {
     gender = 'female';
-    genderName = gender;
+    genderName = 'female';
     genderRace = race.raceNameFemale;
     className = defs.Class[character.characterBase.classHash].classNameFemale;
   }
 
   const lastPlayed = new Date(character.characterBase.dateLastPlayed);
 
-  const store: D1Store = Object.assign(Object.create(StoreProto), {
+  const store: D1Store = {
     destinyVersion: 1,
     id: raw.id,
     name: t('ItemService.StoreName', {
@@ -139,7 +97,8 @@ export function makeCharacter(
     progression: raw.character.progression,
     advisors: raw.character.advisors,
     isVault: false,
-  });
+    items: [],
+  };
 
   if (store.progression) {
     store.progression.progressions.forEach((prog) => {
@@ -189,7 +148,7 @@ export function makeVault(
   store: D1Vault;
   items: any[];
 } {
-  const store: D1Vault = Object.assign(Object.create(StoreProto), {
+  const store: D1Vault = {
     destinyVersion: 1,
     id: 'vault',
     name: t('Bucket.Vault'),
@@ -203,20 +162,18 @@ export function makeVault(
     items: [],
     currencies,
     isVault: true,
-    removeItem(this: D1Vault, item: D1Item) {
-      const result = StoreProto.removeItem.call(this, item);
-      if (item.location.vaultBucket) {
-        this.vaultCounts[item.location.vaultBucket.hash].count--;
-      }
-      return result;
+    vaultCounts: {},
+    progression: {
+      progressions: [],
     },
-    addItem(this: D1Vault, item: D1Item) {
-      StoreProto.addItem.call(this, item);
-      if (item.location.vaultBucket) {
-        this.vaultCounts[item.location.vaultBucket.hash].count++;
-      }
-    },
-  });
+    advisors: {},
+    level: 0,
+    percentToNextLevel: 0,
+    powerLevel: 0,
+    gender: '',
+    genderRace: '',
+    stats: [],
+  };
 
   let items: any[] = [];
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -494,6 +494,16 @@ export function makeItem(
     }
   }
 
+  // linear fusion rifles always seem to contain the "fusion rifle" category as well.
+  // it's a fascinating "did you know", but ultimately not useful to us, so we remove it
+  // because we don't want to filter FRs and see LFRs
+  if (createdItem.itemCategoryHashes.includes(ItemCategoryHashes.LinearFusionRifles)) {
+    const fusionRifleLocation = createdItem.itemCategoryHashes.indexOf(
+      ItemCategoryHashes.FusionRifle
+    );
+    fusionRifleLocation !== -1 && createdItem.itemCategoryHashes.splice(fusionRifleLocation, 1);
+  }
+
   // Infusion
   const tier = itemDef.inventory ? defs.ItemTierType[itemDef.inventory.tierTypeHash] : null;
   createdItem.infusionFuel = Boolean(

--- a/src/app/inventory/store/item-index.ts
+++ b/src/app/inventory/store/item-index.ts
@@ -1,0 +1,19 @@
+import { DimItem } from '../item-types';
+
+let _idTracker: { [id: string]: number } = {};
+
+export function resetItemIndexGenerator() {
+  _idTracker = {};
+}
+
+/** Set an ID for the item that should be unique across all items */
+export function createItemIndex(item: DimItem): string {
+  // Try to make a unique, but stable ID. This isn't always possible, such as in the case of consumables.
+  let index = item.id;
+  if (item.id === '0') {
+    _idTracker[index] = (_idTracker[index] || 0) + 1;
+    index = `${index}-t${_idTracker[index]}`;
+  }
+
+  return index;
+}

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -144,7 +144,7 @@ export function spaceLeftForItem(store: DimStore, item: DimItem, stores: DimStor
     if (item.bucket.accountWide && !store.current) {
       return 0;
     }
-    occupiedStacks = itemsByBucket(store)[item.bucket.hash]?.length ?? 10;
+    occupiedStacks = itemsByBucket(store)[item.bucket.hash].length;
   }
 
   // The open stacks are just however many you *could* fit, minus how many are occupied

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -1,4 +1,6 @@
-import { count } from 'app/utils/util';
+import { emptyArray } from 'app/utils/empty';
+import { count, weakMemoize } from 'app/utils/util';
+import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 /**
  * Generic helpers for working with whole stores (character inventories) or lists of stores.
@@ -33,6 +35,27 @@ export const getAllItems = <Item extends DimItem, Store extends DimStore<Item>>(
 ) => stores.flatMap((s) => (filter ? s.items.filter(filter) : s.items));
 
 /**
+ * This is a memoized function that generates a map of items by their bucket
+ * location. It could be a redux selector but I didn't want to have to thread it
+ * through everywhere, so instead we do our own weak memoization to avoid
+ * recalculation and memory leaks. The items by buckets used to be stored
+ * directly on DimStore, but that violates the rules that allow Immer to work.
+ * An alternative to this would be to have items stored in a map based on their
+ * index and then have buckets reference items by index. This is slightly worse
+ * than what we had before, because it recreates all buckets for the store whenever
+ * the store changes for any reason.
+ */
+const itemsByBucket = weakMemoize((store: DimStore) =>
+  _.groupBy(store.items, (i) => i.location.hash)
+);
+
+/**
+ * Find items in a specific store bucket, taking into account that there may not be any in that bucket!
+ */
+export const findItemsByBucket = (store: DimStore, bucketId: number): DimItem[] =>
+  itemsByBucket(store)[bucketId] ?? emptyArray();
+
+/**
  * Find an item among all stores that matches the params provided.
  */
 export function getItemAcrossStores<Item extends DimItem, Store extends DimStore<Item>>(
@@ -62,7 +85,7 @@ export function getItemAcrossStores<Item extends DimItem, Store extends DimStore
 
 /** Get the bonus power from the Seasonal Artifact */
 export function getArtifactBonus(store: DimStore) {
-  const artifact = (store.buckets[1506418338] || []).find((i) => i.equipped);
+  const artifact = findItemsByBucket(store, BucketHashes.SeasonalArtifact).find((i) => i.equipped);
   return artifact?.primStat?.value || 0;
 }
 
@@ -121,7 +144,7 @@ export function spaceLeftForItem(store: DimStore, item: DimItem, stores: DimStor
     if (item.bucket.accountWide && !store.current) {
       return 0;
     }
-    occupiedStacks = store.buckets[item.bucket.hash] ? store.buckets[item.bucket.hash].length : 10;
+    occupiedStacks = itemsByBucket(store)[item.bucket.hash]?.length ?? 10;
   }
 
   // The open stacks are just however many you *could* fit, minus how many are occupied
@@ -181,4 +204,13 @@ export function spaceLeftForItem(store: DimStore, item: DimItem, stores: DimStor
  */
 export function isD1Store(store: DimStore): store is D1Store {
   return store.destinyVersion === 1;
+}
+
+/**
+ * Is this store the vault? Use this when you want the store to
+ * automatically be typed as DimVault in the "true" branch of a conditional.
+ * Otherwise you can just check "store.isVault".
+ */
+export function isVault(store: DimStore): store is DimVault {
+  return store.isVault;
 }

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -13,6 +13,7 @@ import { storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import {
   amountOfItem,
+  findItemsByBucket,
   getItemAcrossStores,
   getStore,
   getVault,
@@ -366,7 +367,8 @@ function clearSpaceAfterLoadout(store: DimStore, items: DimItem[]) {
       return;
     }
     let numUnequippedLoadoutItems = 0;
-    for (const existingItem of store.buckets[bucketId]) {
+    const bucketHash = parseInt(bucketId, 10);
+    for (const existingItem of findItemsByBucket(store, bucketHash)) {
       if (existingItem.equipped) {
         // ignore equipped items
         continue;

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -8,6 +8,7 @@ import {
   MoveReservations,
 } from 'app/inventory/item-move-service';
 import { DimItem } from 'app/inventory/item-types';
+import { updateManualMoveTimestamp } from 'app/inventory/manual-moves';
 import { loadoutNotification } from 'app/inventory/MoveNotifications';
 import { storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
@@ -311,6 +312,7 @@ function applyLoadoutItems(
 
       if (item) {
         scope.successfulItems.push(item);
+        updateManualMoveTimestamp(item);
       }
     } catch (e) {
       const level = e.level || 'error';

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -2,8 +2,9 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
 import { t } from 'app/i18next-t';
 import { DimStore } from 'app/inventory/store-types';
+import { findItemsByBucket } from 'app/inventory/stores-helpers';
 import { chainComparator, compareBy } from 'app/utils/comparators';
-import { ItemCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
 import Pursuit, { showPursuitAsExpired } from './Pursuit';
@@ -39,9 +40,9 @@ export default function Pursuits({
   // Get all items in this character's inventory that represent quests - some are actual items that take
   // up inventory space, others are in the "Progress" bucket and need to be separated from the quest items
   // that represent milestones.
-  const filteredItems = store.buckets[1345459588].concat(
+  const filteredItems = findItemsByBucket(store, BucketHashes.Quests).concat(
     // Include prophecy tablets, which are in consumables
-    store.buckets[1469714392].filter((item) =>
+    findItemsByBucket(store, BucketHashes.Consumables).filter((item) =>
       item.itemCategoryHashes.includes(ItemCategoryHashes.ProphecyTablets)
     )
   );

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -2,7 +2,6 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
-import { ItemProto } from 'app/inventory/store/d2-item-factory';
 import {
   DestinyAmmunitionType,
   DestinyClass,
@@ -189,7 +188,7 @@ function makeFakePursuitItem(
   hash: number,
   typeName: string
 ) {
-  const dimItem: DimItem = Object.assign(Object.create(ItemProto), {
+  const dimItem: DimItem = {
     // figure out what year this item is probably from
     destinyVersion: 2,
     // The bucket the item is currently in
@@ -222,26 +221,38 @@ function makeFakePursuitItem(
     classType: 3,
     classTypeNameLocalized: 'Any',
     element: null,
-    visible: true,
     lockable: false,
     tracked: false,
     locked: false,
     masterwork: false,
     classified: false,
     isEngram: false,
-    lastManuallyMoved: 0,
     percentComplete: 0, // filled in later
     hidePercentage: false,
     talentGrid: null, // filled in later
     stats: null, // filled in later
     objectives: null, // filled in later
-    dtrRating: null,
     ammoType: DestinyAmmunitionType.None,
-    source: null,
-    collectibleState: null,
-    collectibleHash: null,
     missingSockets: false,
-  });
+    breakerType: null,
+    pursuit: null,
+    taggable: false,
+    comparable: false,
+    basePower: 0,
+    index: '',
+    infusable: false,
+    infusionFuel: false,
+    sockets: null,
+    perks: null,
+    masterworkInfo: null,
+    flavorObjective: null,
+    infusionQuality: null,
+    owner: 'unknown',
+    uniqueStack: false,
+    trackable: false,
+    energy: null,
+    powerCap: null,
+  };
 
   return dimItem;
 }

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -103,7 +103,7 @@ const ITEM_SORT_DENYLIST = new Set([
   2197472680, // Bounties (D1)
   375726501, // Mission (D1)
   1801258597, // Quests (D1)
-  215593132, // LostItems
+  BucketHashes.LostItems, // LostItems
 ]);
 
 // TODO: pass in state


### PR DESCRIPTION
This finally moves inventory mutation (reflecting item moves, equip, lock/unlock) fully into Redux, as immutable updates powered by Immer. This also includes making it so there's only one reference to an Item per list of stores, instead of both a flat list and a list of buckets (I got rid of the buckets). In the future I want to try switching this to a dictionary of items by index, and then have assignments of item to location be by-index-reference, but that's not in this change. Now both items and stores are just plain objects, with no special prototype.

This puts us in a good place to start doing some performance optimizations that were possible but annoying before, and to break out some of the weird state in stores and items.