### PR TITLE
Remove store background colors on mobile

### DIFF
--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -14,11 +14,13 @@ export function StoreBuckets({
   stores,
   vault,
   currentStore,
+  isPhonePortrait,
 }: {
   bucket: InventoryBucket;
   stores: DimStore[];
   vault: DimStore;
   currentStore: DimStore;
+  isPhonePortrait: boolean;
 }) {
   let content: React.ReactNode;
 
@@ -58,7 +60,7 @@ export function StoreBuckets({
             store.destinyVersion === 2 &&
             postmasterAlmostFull(store),
         })}
-        style={storeBackgroundColor(store, index)}
+        style={storeBackgroundColor(store, index, false, isPhonePortrait)}
       >
         {(!store.isVault || bucket.vaultBucket) && <StoreBucket bucket={bucket} store={store} />}
         {bucket.type === 'LostItems' &&

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -103,7 +103,7 @@ function Stores(this: void, { stores, buckets, isPhonePortrait }: Props) {
         <ScrollClassDiv
           className="store-row store-header"
           scrollClass="sticky"
-          style={storeBackgroundColor(selectedStore, 0, true)}
+          style={storeBackgroundColor(selectedStore, 0, true, isPhonePortrait)}
           onTouchStart={(e) => e.stopPropagation()}
         >
           <ViewPager>
@@ -137,7 +137,10 @@ function Stores(this: void, { stores, buckets, isPhonePortrait }: Props) {
             {$featureFlags.unstickyStats && (
               <StoreStats
                 store={selectedStore}
-                style={{ ...storeBackgroundColor(selectedStore, 0, true), paddingBottom: 8 }}
+                style={{
+                  ...storeBackgroundColor(selectedStore, 0, true, isPhonePortrait),
+                  paddingBottom: 8,
+                }}
               />
             )}
             <StoresInventory
@@ -249,6 +252,7 @@ function CollapsibleContainer({
           stores={stores}
           vault={vault}
           currentStore={currentStore}
+          isPhonePortrait={false}
         />
       ))}
     </InventoryCollapsibleTitle>
@@ -276,6 +280,7 @@ function StoresInventory(props: InventoryContainerProps) {
             stores={stores}
             vault={vault}
             currentStore={currentStore}
+            isPhonePortrait={true}
           />
         ))}
       </>

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -224,8 +224,13 @@ export function getColor(value: number, property = 'background-color') {
   };
 }
 
-export function storeBackgroundColor(store: DimStore, index = 0, header = false) {
-  if ($featureFlags.gradientBackground || !store.color) {
+export function storeBackgroundColor(
+  store: DimStore,
+  index = 0,
+  header = false,
+  isPhonePortrait = false
+) {
+  if ($featureFlags.gradientBackground || !store.color || isPhonePortrait) {
     return undefined;
   }
 


### PR DESCRIPTION
Because we're using the gradient BG on dev we didn't see that enabling the new mobile strip causes some issues w/ the background colors cutting off.

For the interm, I've just added a param to the `storeBackgroundColor` for `isPhonePortrait` which just turns off the background color. 

| Before | After | 
| --- | --- |
| <img width="413" alt="Screen Shot 2020-09-16 at 12 22 13 PM" src="https://user-images.githubusercontent.com/424158/93382750-6d4e3680-f817-11ea-8b7d-bdf1bd6a0930.png"> | <img width="413" alt="Screen Shot 2020-09-16 at 12 21 47 PM" src="https://user-images.githubusercontent.com/424158/93382735-66272880-f817-11ea-8b8e-e97f63f0418c.png">|