### PR TITLE
Move 'pull from' button behind a feature flag

### DIFF
--- a/src/app/inventory/BucketLabel.tsx
+++ b/src/app/inventory/BucketLabel.tsx
@@ -1,10 +1,13 @@
 import { destinyVersionSelector } from 'app/accounts/selectors';
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { t } from 'app/i18next-t';
+import PullFromBucketButton from 'app/inventory/PullFromBucketButton';
 import { RootState } from 'app/store/types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { InventoryBucket } from './inventory-buckets';
+import { DimStore } from './store-types';
 
 interface StoreProps {
   defs: D2ManifestDefinitions | D1ManifestDefinitions;
@@ -19,8 +22,10 @@ function mapStateToProps(state: RootState): StoreProps {
 
 function BucketLabel({
   defs,
+  store,
   bucket,
 }: {
+  store: DimStore;
   bucket: InventoryBucket;
 } & StoreProps) {
   return (
@@ -31,6 +36,8 @@ function BucketLabel({
             defs.InventoryBucket[bucket.hash]?.title}
         </div>
       )}
+
+      <PullFromBucketButton store={store} bucket={bucket} label={t('StoreBucket.Add')} />
     </div>
   );
 }

--- a/src/app/inventory/PullFromBucketButton.tsx
+++ b/src/app/inventory/PullFromBucketButton.tsx
@@ -1,0 +1,57 @@
+import { t } from 'app/i18next-t';
+import { ThunkDispatchProp } from 'app/store/types';
+import { itemCanBeEquippedBy } from 'app/utils/item-utils';
+import React, { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { showItemPicker } from '../item-picker/item-picker';
+import { addIcon, AppIcon } from '../shell/icons';
+import { InventoryBucket } from './inventory-buckets';
+import { DimItem } from './item-types';
+import { moveItemTo } from './move-item';
+import { DimStore } from './store-types';
+
+interface Props {
+  className?: string;
+  label?: string;
+  store: DimStore;
+  bucket: InventoryBucket;
+}
+
+export default function PullFromBucketButton({ label, className, bucket, store }: Props) {
+  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+
+  const pullItem = useCallback(async () => {
+    try {
+      const { item } = await showItemPicker({
+        filterItems: (item: DimItem) =>
+          item.bucket.hash === bucket.hash &&
+          itemCanBeEquippedBy(item, store) &&
+          item.owner !== store.id, // Filter items that are already on the character
+        prompt: t('MovePopup.PullItem', {
+          bucket: bucket.name,
+          store: store.name,
+        }),
+      });
+
+      dispatch(moveItemTo(item, store));
+    } catch (e) {}
+  }, [bucket.hash, bucket.name, dispatch, store]);
+
+  if (!bucket.hasTransferDestination) {
+    return null;
+  }
+
+  return (
+    <a
+      onClick={pullItem}
+      className={className}
+      title={t('MovePopup.PullItem', {
+        bucket: bucket.name,
+        store: store.name,
+      })}
+    >
+      <AppIcon icon={addIcon} />
+      {label}
+    </a>
+  );
+}

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -1,21 +1,18 @@
-import { t } from 'app/i18next-t';
-import { moveItemTo } from 'app/inventory/item-move-service';
-import { showItemPicker } from 'app/item-picker/item-picker';
+import PullFromBucketButton from 'app/inventory/PullFromBucketButton';
 import { characterOrderSelector } from 'app/settings/character-sort';
 import { isPhonePortraitSelector } from 'app/shell/selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
-import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import emptyEngram from 'destiny-icons/general/empty-engram.svg';
 import _ from 'lodash';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import { sortItems } from '../shell/filters';
-import { addIcon, AppIcon, globeIcon, hunterIcon, titanIcon, warlockIcon } from '../shell/icons';
+import { AppIcon, globeIcon, hunterIcon, titanIcon, warlockIcon } from '../shell/icons';
 import { InventoryBucket } from './inventory-buckets';
 import { DimItem } from './item-types';
 import { sortedStoresSelector } from './selectors';
@@ -76,21 +73,6 @@ function StoreBucket({
 }: Props) {
   const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
 
-  const pickEquipItem = useCallback(async () => {
-    try {
-      const { item } = await showItemPicker({
-        filterItems: (item: DimItem) =>
-          item.bucket.hash === bucket.hash && itemCanBeEquippedBy(item, store),
-        prompt: t('MovePopup.PullItem', {
-          bucket: bucket.name,
-          store: store.name,
-        }),
-      });
-
-      dispatch(moveItemTo(item, store));
-    } catch (e) {}
-  }, [bucket.hash, bucket.name, dispatch, store]);
-
   // The vault divides armor by class
   if (store.isVault && bucket.inArmor) {
     const itemsByClass = _.groupBy(items, (item) => item.classType);
@@ -119,6 +101,7 @@ function StoreBucket({
     items.filter((i) => !i.equipped),
     itemSortOrder
   );
+  const hidePullFromBucket = $featureFlags.mobileCategoryStrip && isPhonePortrait;
 
   return (
     <>
@@ -131,17 +114,8 @@ function StoreBucket({
               isPhonePortrait={isPhonePortrait}
             />
           </div>
-          {bucket.hasTransferDestination && (
-            <a
-              onClick={pickEquipItem}
-              className="pull-item-button"
-              title={t('MovePopup.PullItem', {
-                bucket: bucket.name,
-                store: store.name,
-              })}
-            >
-              <AppIcon icon={addIcon} />
-            </a>
+          {!hidePullFromBucket && (
+            <PullFromBucketButton store={store} bucket={bucket} className="pull-item-button" />
           )}
         </StoreBucketDropTarget>
       )}

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -73,7 +73,7 @@ export function StoreBuckets({
 
   return (
     <div className={`store-row bucket-${bucket.hash}`}>
-      {labels && <BucketLabel bucket={bucket} />}
+      {labels && <BucketLabel store={stores[0]} bucket={bucket} />}
       {content}
     </div>
   );

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -134,12 +134,6 @@ function Stores(this: void, { stores, buckets, isPhonePortrait }: Props) {
 
         <Hammer direction="DIRECTION_HORIZONTAL" onSwipe={handleSwipe}>
           <div>
-            {$featureFlags.unstickyStats && selectedCategoryId === 'Armor' && (
-              <StoreStats
-                store={selectedStore}
-                style={{ ...storeBackgroundColor(selectedStore, 0, true), paddingBottom: 8 }}
-              />
-            )}
             <StoresInventory
               stores={[selectedStore]}
               selectedCategoryId={selectedCategoryId}

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -134,6 +134,12 @@ function Stores(this: void, { stores, buckets, isPhonePortrait }: Props) {
 
         <Hammer direction="DIRECTION_HORIZONTAL" onSwipe={handleSwipe}>
           <div>
+            {$featureFlags.unstickyStats && selectedCategoryId === 'Armor' && (
+              <StoreStats
+                store={selectedStore}
+                style={{ ...storeBackgroundColor(selectedStore, 0, true), paddingBottom: 8 }}
+              />
+            )}
             <StoresInventory
               stores={[selectedStore]}
               selectedCategoryId={selectedCategoryId}


### PR DESCRIPTION
most of this landed in #5871, this PR just has the 
- Move the "Pull from" button (behind a feature flag)

I'm fine w/ closing it this though


------


Some exploratory ideas for mobile, can feel free to cherry pick any/none of the ideas

- Increased button height padding for category strip targets
- Made the color orange instead of bold for selected items (to match desktop)
- Postmaster shows on every character view instead of just inventory, is collapsable.
- Show bucket labels
- Move the "Pull from" button (behind a feature flag)
- ~Filter out items that are on the current character already from the "Pull from"~
- Moved stats to just the armor screen

|Pull From Button|Weapons | Armor|General|Inventory|
|---|---|---|---|---|
|<img width="411" alt="Screen Shot 2020-09-16 at 8 13 57 PM" src="https://user-images.githubusercontent.com/424158/93415840-47498600-f859-11ea-889c-7179be3978ed.png">|<img width="412" alt="Screen Shot 2020-09-16 at 7 48 45 PM" src="https://user-images.githubusercontent.com/424158/93414235-bde48480-f855-11ea-80b0-5baf7d56d0fa.png">|<img width="413" alt="Screen Shot 2020-09-16 at 8 00 35 PM" src="https://user-images.githubusercontent.com/424158/93414977-54657580-f857-11ea-9793-4cf8533f15db.png">|<img width="413" alt="Screen Shot 2020-09-16 at 7 47 50 PM" src="https://user-images.githubusercontent.com/424158/93414243-c210a200-f855-11ea-87f0-bda7bbaf84ab.png">|<img width="413" alt="Screen Shot 2020-09-16 at 7 47 57 PM" src="https://user-images.githubusercontent.com/424158/93414246-c341cf00-f855-11ea-91c2-8d5f6a714293.png">|