### PR TITLE
fixes for sentry errors

### DIFF
--- a/src/app/dim-ui/CustomStatTotal.tsx
+++ b/src/app/dim-ui/CustomStatTotal.tsx
@@ -43,38 +43,39 @@ export function StatTotalToggle({
   const activeStats = customTotalStatsByClass[forClass]?.length
     ? customTotalStatsByClass[forClass]
     : [];
+
+  if (!defs) {
+    return null;
+  }
   return (
-    (defs && (
-      <div className={clsx(className)}>
-        {addDividers(
-          [
-            { className: 'activeStatLabels', includesCheck: true },
-            { className: 'inactiveStatLabels', includesCheck: false },
-          ].map(({ className, includesCheck }) => (
-            <span
-              key={className}
-              className={clsx(styles[className], { [styles.readOnly]: readOnly })}
-            >
-              {addDividers(
-                armorStats
-                  .filter((statHash) => activeStats.includes(statHash) === includesCheck)
-                  .map((statHash) => (
-                    <StatToggleButton
-                      key={statHash}
-                      stat={defs.Stat.get(statHash)}
-                      toggleStat={toggleStat}
-                      readOnly={readOnly}
-                    />
-                  )),
-                <span className={styles.divider} />
-              )}
-            </span>
-          )),
-          <span className={styles.divider} />
-        )}
-      </div>
-    )) ||
-    null
+    <div className={clsx(className)}>
+      {addDividers(
+        [
+          { className: 'activeStatLabels', includesCheck: true },
+          { className: 'inactiveStatLabels', includesCheck: false },
+        ].map(({ className, includesCheck }) => (
+          <span
+            key={className}
+            className={clsx(styles[className], { [styles.readOnly]: readOnly })}
+          >
+            {addDividers(
+              armorStats
+                .filter((statHash) => activeStats.includes(statHash) === includesCheck)
+                .map((statHash) => (
+                  <StatToggleButton
+                    key={statHash}
+                    stat={defs.Stat.get(statHash)}
+                    toggleStat={toggleStat}
+                    readOnly={readOnly}
+                  />
+                )),
+              <span className={styles.divider} />
+            )}
+          </span>
+        )),
+        <span className={styles.divider} />
+      )}
+    </div>
   );
 }
 

--- a/src/app/dim-ui/CustomStatTotal.tsx
+++ b/src/app/dim-ui/CustomStatTotal.tsx
@@ -21,7 +21,9 @@ export function StatTotalToggle({
   forClass?: DestinyClass;
   readOnly?: boolean;
 }) {
-  const defs = useSelector<RootState, D2ManifestDefinitions>((state) => state.manifest.d2Manifest!);
+  const defs = useSelector<RootState, D2ManifestDefinitions | undefined>(
+    (state) => state.manifest.d2Manifest
+  );
   const customTotalStatsByClass = useSelector<RootState, StatHashListsKeyedByDestinyClass>(
     (state) => settingsSelector(state).customTotalStatsByClass
   );
@@ -41,36 +43,38 @@ export function StatTotalToggle({
   const activeStats = customTotalStatsByClass[forClass]?.length
     ? customTotalStatsByClass[forClass]
     : [];
-
   return (
-    <div className={clsx(className)}>
-      {addDividers(
-        [
-          { className: 'activeStatLabels', includesCheck: true },
-          { className: 'inactiveStatLabels', includesCheck: false },
-        ].map(({ className, includesCheck }) => (
-          <span
-            key={className}
-            className={clsx(styles[className], { [styles.readOnly]: readOnly })}
-          >
-            {addDividers(
-              armorStats
-                .filter((statHash) => activeStats.includes(statHash) === includesCheck)
-                .map((statHash) => (
-                  <StatToggleButton
-                    key={statHash}
-                    stat={defs.Stat.get(statHash)}
-                    toggleStat={toggleStat}
-                    readOnly={readOnly}
-                  />
-                )),
-              <span className={styles.divider} />
-            )}
-          </span>
-        )),
-        <span className={styles.divider} />
-      )}
-    </div>
+    (defs && (
+      <div className={clsx(className)}>
+        {addDividers(
+          [
+            { className: 'activeStatLabels', includesCheck: true },
+            { className: 'inactiveStatLabels', includesCheck: false },
+          ].map(({ className, includesCheck }) => (
+            <span
+              key={className}
+              className={clsx(styles[className], { [styles.readOnly]: readOnly })}
+            >
+              {addDividers(
+                armorStats
+                  .filter((statHash) => activeStats.includes(statHash) === includesCheck)
+                  .map((statHash) => (
+                    <StatToggleButton
+                      key={statHash}
+                      stat={defs.Stat.get(statHash)}
+                      toggleStat={toggleStat}
+                      readOnly={readOnly}
+                    />
+                  )),
+                <span className={styles.divider} />
+              )}
+            </span>
+          )),
+          <span className={styles.divider} />
+        )}
+      </div>
+    )) ||
+    null
   );
 }
 

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -129,14 +129,14 @@ export function buildInstancedSockets(
     }
 
     categories.push({
-      category: defs.SocketCategory.get(category.socketCategoryHash),
+      category: defs.SocketCategory.get(category.socketCategoryHash, itemDef),
       sockets,
     });
   }
 
   return {
     allSockets: _.compact(realSockets), // Flat list of sockets
-    categories: categories.sort(compareBy((c) => c.category.index)), // Sockets organized by category
+    categories: categories.sort(compareBy((c) => c.category?.index)), // Sockets organized by category
   };
 }
 

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -71,9 +71,9 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
 
       <ItemExpiration item={item} />
 
-      {!item.stats && item.collectibleHash && isD2Manifest(defs) && (
+      {!item.stats && Boolean(item.collectibleHash) && isD2Manifest(defs) && (
         <div className="item-details">
-          {defs.Collectible.get(item.collectibleHash).sourceString}
+          {defs.Collectible.get(item.collectibleHash!).sourceString}
         </div>
       )}
 

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -71,7 +71,7 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
 
       <ItemExpiration item={item} />
 
-      {!item.stats && item.collectibleHash !== undefined && isD2Manifest(defs) && (
+      {!item.stats && item.collectibleHash && isD2Manifest(defs) && (
         <div className="item-details">
           {defs.Collectible.get(item.collectibleHash).sourceString}
         </div>


### PR DESCRIPTION
#### src/app/inventory/store/sockets.ts 
DIM-KM0 shows socketcategoryhash `590099475.8437034` failing to lookup,
leading to undefined error DIM-KKZ
added optional chain and logging to try and catch the culprit socket/item

#### CustomStatTotal.tsx
DIM-KAQ prevent component from undefined erroring if definitions are unavailable

#### src/app/item-popup/ItemDetails.tsx 
DIM-KNP can't read sourceString undefined error,
caused by failed `[null]` lookup DIM-KNA.
probably resolved by some item factory changes, but removed explicit `===undefined` check in favor of a falsiness check

