### PR TITLE
Another fix for mod picker assignment.

### DIFF
--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -9,6 +9,10 @@ import {
   mapArmor2ModToProcessMod,
   mapDimItemToProcessItem,
 } from '../processWorker/mappers';
+import {
+  sortGeneralModsOrProcessItem,
+  sortProcessModsOrProcessItems,
+} from '../processWorker/processUtils';
 import { ProcessItemsByBucket } from '../processWorker/types';
 import {
   ArmorSet,
@@ -89,12 +93,20 @@ export function useProcess(
       }
     }
 
+    const lockedProcessMods = _.mapValues(lockedArmor2ModMap, (mods) =>
+      mods.map((mod) => mapArmor2ModToProcessMod(mod))
+    );
+    lockedProcessMods.seasonal = lockedProcessMods.seasonal.sort(sortProcessModsOrProcessItems);
+    lockedProcessMods[ModPickerCategories.general] = lockedProcessMods[
+      ModPickerCategories.general
+    ].sort(sortGeneralModsOrProcessItem);
+
     const workerStart = performance.now();
     worker
       .process(
         processItems,
         getTotalModStatChanges(lockedArmor2ModMap),
-        _.mapValues(lockedArmor2ModMap, (mods) => mods.map((mod) => mapArmor2ModToProcessMod(mod))),
+        lockedProcessMods,
         assumeMasterwork,
         statOrder,
         statFilters,

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -96,10 +96,8 @@ export function useProcess(
     const lockedProcessMods = _.mapValues(lockedArmor2ModMap, (mods) =>
       mods.map((mod) => mapArmor2ModToProcessMod(mod))
     );
-    lockedProcessMods.seasonal = lockedProcessMods.seasonal.sort(sortForSeasonalProcessMods);
-    lockedProcessMods[ModPickerCategories.general] = lockedProcessMods[
-      ModPickerCategories.general
-    ].sort(sortForGeneralProcessMods);
+    lockedProcessMods.seasonal.sort(sortForSeasonalProcessMods);
+    lockedProcessMods[ModPickerCategories.general].sort(sortForGeneralProcessMods);
 
     const workerStart = performance.now();
     worker

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -10,8 +10,8 @@ import {
   mapDimItemToProcessItem,
 } from '../processWorker/mappers';
 import {
-  sortGeneralModsOrProcessItem,
-  sortProcessModsOrProcessItems,
+  sortForGeneralProcessMods,
+  sortForSeasonalProcessMods,
 } from '../processWorker/processUtils';
 import { ProcessItemsByBucket } from '../processWorker/types';
 import {
@@ -96,10 +96,10 @@ export function useProcess(
     const lockedProcessMods = _.mapValues(lockedArmor2ModMap, (mods) =>
       mods.map((mod) => mapArmor2ModToProcessMod(mod))
     );
-    lockedProcessMods.seasonal = lockedProcessMods.seasonal.sort(sortProcessModsOrProcessItems);
+    lockedProcessMods.seasonal = lockedProcessMods.seasonal.sort(sortForSeasonalProcessMods);
     lockedProcessMods[ModPickerCategories.general] = lockedProcessMods[
       ModPickerCategories.general
-    ].sort(sortGeneralModsOrProcessItem);
+    ].sort(sortForGeneralProcessMods);
 
     const workerStart = performance.now();
     worker

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -96,13 +96,13 @@ export function assignModsToArmorSet(
     }
   }
 
+  assignAllSeasonalMods(processItems, lockedArmor2Mods.seasonal, assignments);
+
   assignGeneralMods(
     processItems,
     lockedArmor2Mods[armor2PlugCategoryHashesByName.general],
     assignments
   );
-
-  assignAllSeasonalMods(processItems, lockedArmor2Mods.seasonal, assignments);
 
   const modsByHash = _.groupBy(Object.values(lockedArmor2Mods).flat(), (mod) => mod.modDef.hash);
   const assignedMods = _.mapValues(assignments, (modHashes) =>

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -6,7 +6,7 @@ import { mapArmor2ModToProcessMod, mapDimItemToProcessItem } from './processWork
 import {
   canTakeAllGeneralMods,
   canTakeAllSeasonalMods,
-  sortProcessModsOrProcessItems,
+  sortForSeasonalProcessMods,
 } from './processWorker/processUtils';
 import { ProcessItem } from './processWorker/types';
 import {
@@ -38,7 +38,7 @@ function assignGeneralMods(
   assignments: Record<string, number[]>
 ): void {
   // Mods need to be sorted before being passed to the assignment function
-  const sortedMods = generalMods.map(mapArmor2ModToProcessMod).sort(sortProcessModsOrProcessItems);
+  const sortedMods = generalMods.map(mapArmor2ModToProcessMod).sort(sortForSeasonalProcessMods);
 
   canTakeAllGeneralMods(sortedMods, setToMatch, assignments);
 }
@@ -69,7 +69,7 @@ function assignAllSeasonalMods(
   assignments: Record<string, number[]>
 ): void {
   // Mods need to be sorted before being passed to the assignment function
-  const sortedMods = seasonalMods.map(mapArmor2ModToProcessMod).sort(sortProcessModsOrProcessItems);
+  const sortedMods = seasonalMods.map(mapArmor2ModToProcessMod).sort(sortForSeasonalProcessMods);
 
   canTakeAllSeasonalMods(sortedMods, setToMatch, assignments);
 }

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -256,13 +256,13 @@ export function process(
               // and we do seasonal first as its more likely to have energy specific mods.
               // TODO Check validity of this with the energy contraints in.
               if (
+                (lockedArmor2ModMap.seasonal.length &&
+                  !canTakeAllSeasonalMods(lockedArmor2ModMap.seasonal, armor)) ||
                 (lockedArmor2ModMap[armor2PlugCategoryHashesByName.general].length &&
                   !canTakeAllGeneralMods(
                     lockedArmor2ModMap[armor2PlugCategoryHashesByName.general],
                     armor
-                  )) ||
-                (lockedArmor2ModMap.seasonal.length &&
-                  !canTakeAllSeasonalMods(lockedArmor2ModMap.seasonal, armor))
+                  ))
               ) {
                 continue;
               }

--- a/src/app/loadout-builder/processWorker/processUtils.test.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.test.ts
@@ -2,7 +2,7 @@ import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import {
   canTakeAllSeasonalMods,
   ProcessItemSubset,
-  sortProcessModsOrProcessItems,
+  sortForSeasonalProcessMods,
 } from './processUtils';
 import { ProcessMod } from './types';
 
@@ -46,7 +46,7 @@ describe('Can slot seasonal mods', () => {
       getMod(11, 'arrivals', 3),
       getMod(11, 'arrivals', 3),
       getMod(10, 'worthy', 3),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 3, ['arrivals', 'worthy']),
@@ -63,7 +63,7 @@ describe('Can slot seasonal mods', () => {
       getMod(11, 'arrivals', 2),
       getMod(11, 'arrivals', 1),
       getMod(11, 'arrivals', 0),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 3, ['arrivals', 'worthy']),
@@ -80,7 +80,7 @@ describe('Can slot seasonal mods', () => {
       getMod(11, 'arrivals', 0),
       getMod(11, 'arrivals', 0),
       getMod(11, 'arrivals', 0),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 3, ['arrivals', 'worthy']),
@@ -93,7 +93,7 @@ describe('Can slot seasonal mods', () => {
   });
 
   it('passes with a single mod', () => {
-    const mods = [getMod(11, 'arrivals', 1)].sort(sortProcessModsOrProcessItems);
+    const mods = [getMod(11, 'arrivals', 1)].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 3, ['arrivals', 'worthy']),
@@ -107,7 +107,7 @@ describe('Can slot seasonal mods', () => {
 
   it('passes when the first item takes no mods', () => {
     const mods = [getMod(7, 'opulent', 0), getMod(7, 'opulent', 0)].sort(
-      sortProcessModsOrProcessItems
+      sortForSeasonalProcessMods
     );
 
     const items = [
@@ -130,7 +130,7 @@ describe("Can't slot seasonal mods", () => {
       getMod(11, 'arrivals', 3),
       getMod(11, 'arrivals', 3),
       getMod(11, 'arrivals', 1),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 3, ['arrivals', 'worthy']),
@@ -144,7 +144,7 @@ describe("Can't slot seasonal mods", () => {
 
   it('fails when a season mismatches', () => {
     const mods = [getMod(11, 'arrivals', 3), getMod(11, 'arrivals', 3), getMod(9, 'dawn', 3)].sort(
-      sortProcessModsOrProcessItems
+      sortForSeasonalProcessMods
     );
 
     const items = [
@@ -162,7 +162,7 @@ describe("Can't slot seasonal mods", () => {
       getMod(11, 'arrivals', 3),
       getMod(11, 'arrivals', 3),
       getMod(11, 'arrivals', 3),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 3, ['arrivals', 'worthy']),
@@ -176,7 +176,7 @@ describe("Can't slot seasonal mods", () => {
 
   it('fails when first slot cant be used and only one item to take both mods', () => {
     const mods = [getMod(7, 'opulent', 0), getMod(7, 'opulent', 0)].sort(
-      sortProcessModsOrProcessItems
+      sortForSeasonalProcessMods
     );
 
     const items = [
@@ -199,7 +199,7 @@ describe('Sorting works for mods and items', () => {
       getMod(11, 'arrivals', 3),
       getMod(11, 'arrivals', 2),
       getMod(11, 'arrivals', 1),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 1, ['arrivals', 'worthy']),
@@ -216,7 +216,7 @@ describe('Sorting works for mods and items', () => {
       getMod(11, 'arrivals', 1),
       getMod(11, 'arrivals', 2),
       getMod(11, 'arrivals', 3),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 3, ['arrivals', 'worthy']),
@@ -230,7 +230,7 @@ describe('Sorting works for mods and items', () => {
 
   it('passes when mods are sorted for season', () => {
     const mods = [getMod(9, 'dawn', 1), getMod(10, 'worthy', 1), getMod(11, 'arrivals', 1)].sort(
-      sortProcessModsOrProcessItems
+      sortForSeasonalProcessMods
     );
 
     const items = [
@@ -245,7 +245,7 @@ describe('Sorting works for mods and items', () => {
 
   it('passes when items are sorted for season', () => {
     const mods = [getMod(11, 'arrivals', 1), getMod(10, 'worthy', 1), getMod(9, 'dawn', 1)].sort(
-      sortProcessModsOrProcessItems
+      sortForSeasonalProcessMods
     );
 
     const items = [
@@ -268,7 +268,7 @@ describe('Energy requirements correctly filter a set', () => {
       getMod(11, 'arrivals', 2, 5),
       getMod(11, 'arrivals', 1, 5),
       getMod(11, 'arrivals', 3, 5),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 1, ['arrivals', 'worthy'], 5),
@@ -285,7 +285,7 @@ describe('Energy requirements correctly filter a set', () => {
       getMod(11, 'arrivals', 2, 5),
       getMod(11, 'arrivals', 1, 5),
       getMod(11, 'arrivals', 3, 5),
-    ].sort(sortProcessModsOrProcessItems);
+    ].sort(sortForSeasonalProcessMods);
 
     const items = [
       getItem(11, 1, ['arrivals', 'worthy'], 5),
@@ -299,7 +299,7 @@ describe('Energy requirements correctly filter a set', () => {
 
   it('passes when an any mod needs the first mods space', () => {
     const mods = [getMod(11, 'arrivals', 2, 4), getMod(11, 'arrivals', 0, 5)].sort(
-      sortProcessModsOrProcessItems
+      sortForSeasonalProcessMods
     );
 
     const items = [

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -17,9 +17,10 @@ export interface ProcessItemSubset extends SortParam {
 
 /**
  * This sorting function is pivitol in the algorithm to figure out it seasonal mods can be slotted into
- * a list of items. It sorts by season and then energyType in descending order.
+ * a list of items. It sorts by season and then energyType in descending order. Both mods and items
+ * should be sorted by this algorithms.
  */
-export function sortProcessModsOrProcessItems(a: SortParam, b: SortParam) {
+export function sortForSeasonalProcessMods(a: SortParam, b: SortParam) {
   if (a.season && b.season) {
     if (a.season === b.season) {
       if (a.energy && b.energy) {
@@ -41,9 +42,10 @@ export function sortProcessModsOrProcessItems(a: SortParam, b: SortParam) {
 
 /**
  * This sorting function is pivitol in the algorithm to figure out it general mods can be slotted into
- * a list of items. It sorts by energyType in descending order.
+ * a list of items. It sorts by energyType in descending order. Both mods and items should be sorted
+ * by this algorithms.
  */
-export function sortGeneralModsOrProcessItem(a: SortParam, b: SortParam) {
+export function sortForGeneralProcessMods(a: SortParam, b: SortParam) {
   // any energy is 0 so check undefined rather than falsey
   if (a.energy && b.energy) {
     if (a.energy.type === b.energy.type) {
@@ -73,7 +75,7 @@ export function canTakeAllSeasonalMods(
   items: ProcessItemSubset[],
   assignments?: Record<string, number[]>
 ) {
-  const sortedItems = Array.from(items).sort(sortProcessModsOrProcessItems);
+  const sortedItems = Array.from(items).sort(sortForSeasonalProcessMods);
 
   let modIndex = 0;
   let itemIndex = 0;
@@ -125,7 +127,7 @@ export function canTakeAllGeneralMods(
   items: ProcessItemSubset[],
   assignments?: Record<string, number[]>
 ) {
-  const sortedItems = Array.from(items).sort(sortGeneralModsOrProcessItem);
+  const sortedItems = Array.from(items).sort(sortForGeneralProcessMods);
 
   let modIndex = 0;
   let itemIndex = 0;


### PR DESCRIPTION
I tracked it down properly this time. It seems like we weren't pre sorting the mods going into process. 

Both mods and items need to be sorted by the same algorithm. The items are sorted in the internal process function but I have pulled the sorting of the mods out so we don't continually sort them and for performance. 

I wonder if I should set up some kind of failsafe to stop this from happening. Like a flag that gets change when two sorts are equal and stops further sorting in the algorithm itself.

Either way I am pretty sure this fixes the issue as its back to the original design.

Fixes #5805 