### PR TITLE
Fix that circular reference thing

### DIFF
--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -528,7 +528,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       },
     };
 
-    function filterItems(items: D1Item[]) {
+    function filterItems(items: readonly D1Item[]) {
       return items.filter(
         (item) =>
           item.primStat &&

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -855,15 +855,19 @@ export function moveItemTo(
         console.log('Try blind move of', item.name, 'to', target.name);
         return await dispatch(moveToStore(item, target, equip, amount));
       } catch (e) {
-        console.warn(
-          'Tried blindly moving',
-          item.name,
-          'to',
-          target.name,
-          'but the bucket is really full',
-          e.code
-        );
-        lastTimeCurrentStoreWasReallyFull = Date.now();
+        if (e.code === PlatformErrorCodes.DestinyNoRoomInDestination) {
+          console.warn(
+            'Tried blindly moving',
+            item.name,
+            'to',
+            target.name,
+            'but the bucket is really full',
+            e.code
+          );
+          lastTimeCurrentStoreWasReallyFull = Date.now();
+        } else {
+          throw e;
+        }
       }
     }
 

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -427,12 +427,14 @@ function removeItem(store: Draft<DimStore>, item: Draft<DimItem>) {
 
     return true;
   }
+
   return false;
 }
 
 function addItem(store: Draft<DimStore>, item: Draft<DimItem>) {
-  store.items.push(item);
   item.owner = store.id;
+  // Originally this was just "store.items.push(item)" but it caused Immer to think we had circular references
+  store.items = [...store.items, item];
 
   // TODO: replace vaultCounts with a selector
   if (item.location.accountWide && store.current && store.vault) {

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -21,7 +21,7 @@ export interface DimStore<Item = DimItem> {
   /** Localized name for the store. */
   name: string;
   /** All items in the store, across all buckets. */
-  items: Item[];
+  items: readonly Item[];
   /** The Destiny version this store came from. */
   destinyVersion: DestinyVersion;
   /** An icon (emblem) for the store. */

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 /**
  * Count the number of values in the list that pass the predicate.
  */
-export function count<T>(list: T[], predicate: (value: T) => boolean): number {
+export function count<T>(list: readonly T[], predicate: (value: T) => boolean): number {
   return _.sumBy(list, (item) => (predicate(item) ? 1 : 0));
 }
 


### PR DESCRIPTION
This was the "Maximum call stack size exceeded" issue.

This turned out to be weird - immer had a problem with `store.items.push(item)` but not with `store.items = [...store.items, item]`. I could also get the issue to stop working by *printing out all the items to console.log before returning them*.