### PR TITLE
Unsticky stats

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -380,7 +380,7 @@ module.exports = (env) => {
         // Show the triage tab in the item popup
         '$featureFlags.triage': JSON.stringify(env.dev),
         // Detach stats from the sticky header on mobile
-        '$featureFlags.unstickyStats': JSON.stringify(!env.release),
+        '$featureFlags.unstickyStats': JSON.stringify(true),
         // Drag and drop mobile inspect
         '$featureFlags.mobileInspect': JSON.stringify(!env.release),
         // Rearrange buckets in categories

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Armor 1.0 mods and Elemental Affinities removed from the perk picker in Loadout Optimizer.
 * Improved search performance.
 * Items in collections now show their power cap.
+* Character stats now scroll with items on mobile, instead of always being visible. Max power is still shown in the character header.
 
 ### Beta Only
 


### PR DESCRIPTION
I haven't heard any complaints about scrolling character stats on beta, so let's turn it on for release.