### PR TITLE
Compute vault counts in VaultCapacity component, remove from DimVault

### DIFF
--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -57,7 +57,7 @@ export default function CharacterTile({ store }: { store: DimStore }) {
         </div>
         <div className="bottom">
           {isVault(store) ? (
-            $featureFlags.unstickyStats && isPhonePortrait && <VaultCapacity store={store} />
+            $featureFlags.unstickyStats && isPhonePortrait && <VaultCapacity />
           ) : (
             <>
               <div className="race-gender">{store.genderRace}</div>

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -36,7 +36,7 @@ import { getCharacterStatsData as getD1CharacterStatsData } from './store/charac
 import { processItems } from './store/d2-item-factory';
 import { getCharacterStatsData, makeCharacter, makeVault } from './store/d2-store-factory';
 import { resetItemIndexGenerator } from './store/item-index';
-import { findItemsByBucket, getArtifactBonus } from './stores-helpers';
+import { getArtifactBonus } from './stores-helpers';
 
 /**
  * Update the high level character information for all the stores
@@ -178,8 +178,6 @@ export function loadStores(): ThunkResult<DimStore[] | undefined> {
 
         const stores = [...characters, vault];
 
-        updateVaultCounts(buckets, characters.find((c) => c.current)!, vault);
-
         dispatch(cleanInfos(stores));
 
         for (const s of stores) {
@@ -312,19 +310,6 @@ function processVault(
     mergedCollectibles
   );
   store.items = processedItems;
-  // by type-bucket
-  store.vaultCounts = {};
-  // Fill in any missing buckets
-  Object.values(buckets.byType).forEach((bucket) => {
-    if (bucket.vaultBucket) {
-      const vaultBucketId = bucket.vaultBucket.hash;
-      store.vaultCounts[vaultBucketId] = store.vaultCounts[vaultBucketId] || {
-        count: 0,
-        bucket: bucket.accountWide ? bucket : bucket.vaultBucket,
-      };
-      store.vaultCounts[vaultBucketId].count += findItemsByBucket(store, bucket.hash).length;
-    }
-  });
   return store;
 }
 
@@ -392,21 +377,4 @@ function updateBasePower(stores: DimStore[], store: DimStore, defs: D2ManifestDe
       icon: bungieNetPath(def.displayProperties.icon),
     };
   }
-}
-
-// TODO: vault counts are silly and convoluted. We really need an
-// object to represent a Profile.
-function updateVaultCounts(buckets: InventoryBuckets, activeStore: DimStore, vault: DimVault) {
-  // Fill in any missing buckets
-  Object.values(buckets.byType).forEach((bucket) => {
-    if (bucket.accountWide && bucket.vaultBucket) {
-      const vaultBucketId = bucket.hash;
-      vault.vaultCounts[vaultBucketId] = vault.vaultCounts[vaultBucketId] || {
-        count: 0,
-        bucket,
-      };
-      vault.vaultCounts[vaultBucketId].count += findItemsByBucket(activeStore, bucket.hash).length;
-    }
-  });
-  activeStore.vault = vault; // god help me
 }

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -10,7 +10,7 @@ import * as actions from './actions';
 import { DimItem } from './item-types';
 import { DimStore } from './store-types';
 import { createItemIndex } from './store/item-index';
-import { findItemsByBucket, getStore, isVault } from './stores-helpers';
+import { findItemsByBucket, getStore } from './stores-helpers';
 
 // TODO: Should this be by account? Accounts need IDs
 export interface InventoryState {
@@ -413,18 +413,6 @@ function removeItem(store: Draft<DimStore>, item: Draft<DimItem>) {
   const sourceIndex = store.items.findIndex((i: DimItem) => item.index === i.index);
   if (sourceIndex >= 0) {
     store.items.splice(sourceIndex, 1);
-
-    // TODO: replace vaultCounts with a selector
-    if (
-      item.location.accountWide &&
-      store.current &&
-      store.vault?.vaultCounts[item.location.hash]
-    ) {
-      store.vault.vaultCounts[item.location.hash].count--;
-    } else if (isVault(store) && item.location.vaultBucket) {
-      store.vaultCounts[item.location.vaultBucket.hash].count--;
-    }
-
     return true;
   }
 
@@ -435,11 +423,4 @@ function addItem(store: Draft<DimStore>, item: Draft<DimItem>) {
   item.owner = store.id;
   // Originally this was just "store.items.push(item)" but it caused Immer to think we had circular references
   store.items = [...store.items, item];
-
-  // TODO: replace vaultCounts with a selector
-  if (item.location.accountWide && store.current && store.vault) {
-    store.vault.vaultCounts[item.location.hash].count++;
-  } else if (isVault(store) && item.location.vaultBucket) {
-    store.vaultCounts[item.location.vaultBucket.hash].count++;
-  }
 }

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -8,7 +8,7 @@ import { getBuckets as getBucketsD1 } from '../destiny1/d1-buckets';
 import { getBuckets as getBucketsD2 } from '../destiny2/d2-buckets';
 import { characterSortSelector } from '../settings/character-sort';
 import { ItemInfos } from './dim-item-info';
-import { getCurrentStore } from './stores-helpers';
+import { getCurrentStore, getVault } from './stores-helpers';
 
 /** All stores, unsorted. */
 export const storesSelector = (state: RootState) => state.inventory.stores;
@@ -37,6 +37,9 @@ export const storesLoadedSelector = (state: RootState) => storesSelector(state).
 
 /** The current (last played) character */
 export const currentStoreSelector = (state: RootState) => getCurrentStore(storesSelector(state));
+
+/** The vault */
+export const vaultSelector = (state: RootState) => getVault(storesSelector(state));
 
 /** The actual raw profile response from the Bungie.net profile API */
 export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -6,7 +6,6 @@ import {
   DestinyFactionDefinition,
   DestinyProgression,
 } from 'bungie-api-ts/destiny2';
-import { InventoryBucket } from './inventory-buckets';
 import { D1Item, DimItem } from './item-types';
 
 /**
@@ -64,19 +63,12 @@ export interface DimStore<Item = DimItem> {
   progression: null | {
     progressions: DestinyProgression[];
   };
-
-  /** The vault associated with this store. */
-  vault?: DimVault;
+  /** The background or dominant color of the equipped emblem, if available. */
   color?: DestinyColor;
 }
 
-/** How many items are in each vault bucket. DIM hides the vault bucket concept from users but needs the count to track progress. */
-interface VaultCounts {
-  [bucketHash: number]: { count: number; bucket: InventoryBucket };
-}
-
 export interface DimVault extends DimStore {
-  vaultCounts: VaultCounts;
+  // TODO: move to top level? Drive off profile?
   currencies: {
     itemHash: number;
     displayProperties: DestinyDisplayPropertiesDefinition;
@@ -85,7 +77,6 @@ export interface DimVault extends DimStore {
 }
 
 export interface D1Vault extends D1Store {
-  vaultCounts: VaultCounts;
   currencies: {
     itemHash: number;
     displayProperties: DestinyDisplayPropertiesDefinition;

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -162,7 +162,6 @@ export function makeVault(
     items: [],
     currencies,
     isVault: true,
-    vaultCounts: {},
     progression: {
       progressions: [],
     },

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -91,7 +91,6 @@ export function makeVault(
     currencies,
     isVault: true,
     color: { red: 49, green: 50, blue: 51, alpha: 1 },
-    vaultCounts: {},
     level: 0,
     percentToNextLevel: 0,
     powerLevel: 0,

--- a/src/app/store-stats/StoreStats.tsx
+++ b/src/app/store-stats/StoreStats.tsx
@@ -34,7 +34,7 @@ export default function StoreStats({
       {isVault(store) ? (
         <div className={styles.vaultStats}>
           <AccountCurrencies store={store} />
-          {shouldShowCapacity(isPhonePortrait) && <VaultCapacity store={store} />}
+          {shouldShowCapacity(isPhonePortrait) && <VaultCapacity />}
         </div>
       ) : store.destinyVersion === 1 ? (
         <D1CharacterStats stats={store.stats} />

--- a/src/app/store-stats/VaultCapacity.tsx
+++ b/src/app/store-stats/VaultCapacity.tsx
@@ -1,4 +1,7 @@
-import type { DimVault } from 'app/inventory/store-types';
+import { InventoryBucket, InventoryBuckets } from 'app/inventory/inventory-buckets';
+import { bucketsSelector, currentStoreSelector, vaultSelector } from 'app/inventory/selectors';
+import { DimStore, DimVault } from 'app/inventory/store-types';
+import { findItemsByBucket } from 'app/inventory/stores-helpers';
 import clsx from 'clsx';
 import vaultIcon from 'destiny-icons/armor_types/helmet.svg';
 import consumablesIcon from 'destiny-icons/general/consumables.svg';
@@ -6,6 +9,8 @@ import modificationsIcon from 'destiny-icons/general/modifications.svg';
 import shadersIcon from 'destiny-icons/general/shaders2.svg';
 import _ from 'lodash';
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { createSelector } from 'reselect';
 import styles from './VaultCapacity.m.scss';
 
 const bucketIcons = {
@@ -28,32 +33,86 @@ const vaultBucketOrder = [
   2973005342,
 ];
 
+/** How many items are in each vault bucket. DIM hides the vault bucket concept from users but needs the count to track progress. */
+interface VaultCounts {
+  [bucketHash: number]: { count: number; bucket: InventoryBucket };
+}
+
+/**
+ * DIM represents items in the vault different from how they actually are - we separate them by inventory bucket as if
+ * the vault were a character, when really they're just big undifferentiated buckets. This re-calculates how full those
+ * buckets are, for display. We could calculate this straight from the profile, but we want to be able to recompute it
+ * when items move without reloading the profile.
+ */
+function computeVaultCounts(activeStore: DimStore, vault: DimVault, buckets: InventoryBuckets) {
+  const vaultCounts: VaultCounts = {};
+
+  for (const bucket of Object.values(buckets.byType)) {
+    // If this bucket can have items placed in the vault, count up how many of
+    // that type are in the vault.
+    if (bucket.vaultBucket) {
+      // D2 has "account wide" buckets that are shared between characters but are
+      // not the vault, and the items in them can *also* be vaulted. We represent
+      // these as being owned by the "current character", and we consider them a
+      // separate type of "vault" for the purposes of vault counts.
+      if (bucket.accountWide) {
+        const vaultBucketId = bucket.hash;
+        vaultCounts[vaultBucketId] ??= {
+          count: 0,
+          bucket,
+        };
+        vaultCounts[vaultBucketId].count += findItemsByBucket(activeStore, bucket.hash).length;
+      }
+
+      const vaultBucketId = bucket.vaultBucket.hash;
+      vaultCounts[vaultBucketId] ??= {
+        count: 0,
+        bucket: bucket.accountWide ? bucket : bucket.vaultBucket,
+      };
+      vaultCounts[vaultBucketId].count += findItemsByBucket(vault, bucket.hash).length;
+    }
+  }
+
+  return vaultCounts;
+}
+
+const vaultCountsSelector = createSelector(
+  currentStoreSelector,
+  vaultSelector,
+  bucketsSelector,
+  computeVaultCounts
+);
+
 /** Current amounts and maximum capacities of the vault */
-export default function VaultCapacity({ store }: { store: DimVault }) {
+export default React.memo(function VaultCapacity() {
+  const vaultCounts = useSelector(vaultCountsSelector);
+
   return (
     <>
-      {_.sortBy(Object.keys(store.vaultCounts), (id) =>
-        vaultBucketOrder.indexOf(parseInt(id, 10))
-      ).map((bucketId) => (
-        <React.Fragment key={bucketId}>
-          <div className={styles.bucketTag} title={store.vaultCounts[bucketId].bucket.name}>
-            {bucketIcons[bucketId] ? (
-              <img src={bucketIcons[bucketId]} alt="" />
-            ) : (
-              store.vaultCounts[bucketId].bucket.name.substring(0, 1)
-            )}
-          </div>
-          <div
-            title={store.vaultCounts[bucketId].bucket.name}
-            className={clsx({
-              [styles.full]:
-                store.vaultCounts[bucketId].count === store.vaultCounts[bucketId].bucket.capacity,
-            })}
-          >
-            {store.vaultCounts[bucketId].count}/{store.vaultCounts[bucketId].bucket.capacity}
-          </div>
-        </React.Fragment>
-      ))}
+      {_.sortBy(Object.keys(vaultCounts), (id) => vaultBucketOrder.indexOf(parseInt(id, 10))).map(
+        (bucketId) => {
+          const { count, bucket } = vaultCounts[bucketId];
+          return (
+            <React.Fragment key={bucketId}>
+              <div className={styles.bucketTag} title={bucket.name}>
+                {bucketIcons[bucketId] ? (
+                  <img src={bucketIcons[bucketId]} alt="" />
+                ) : (
+                  bucket.name.substring(0, 1)
+                )}
+              </div>
+              <div
+                title={bucket.name}
+                className={clsx({
+                  [styles.full]: count === bucket.capacity,
+                })}
+              >
+                {count}/{bucket.capacity}
+              </div>
+            </React.Fragment>
+          );
+        }
+      )}
     </>
   );
-}
+});


### PR DESCRIPTION
Vault counts were always weird - we computed them and put them on DimVault, and kept them up to date when we move items, but you can always figure them out by looking at the current inventory state. This PR changes to do just that - compute vault counts in one place, in a memoized selector, based on inventory. No more bookkeeping!