### PR TITLE
Currencies

### DIFF
--- a/src/app/bungie-api/destiny1-api.ts
+++ b/src/app/bungie-api/destiny1-api.ts
@@ -42,7 +42,7 @@ export async function getCharacters(platform: DestinyAccount) {
   });
 }
 
-export async function getStores(platform: DestinyAccount): Promise<any> {
+export async function getStores(platform: DestinyAccount): Promise<any[]> {
   const characters = await getCharacters(platform);
   const data = await Promise.all([
     getDestinyInventories(platform, characters),

--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -1,5 +1,5 @@
 import { isPhonePortraitSelector } from 'app/inventory/selectors';
-import type { DimStore, DimVault } from 'app/inventory/store-types';
+import type { DimStore } from 'app/inventory/store-types';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
 import VaultCapacity from 'app/store-stats/VaultCapacity';
 import clsx from 'clsx';
@@ -13,10 +13,6 @@ const CharacterEmblem = ({ store }: { store: DimStore }) => (
     style={{ backgroundImage: `url("${store.icon}")` }}
   />
 );
-
-function isVault(store: DimStore): store is DimVault {
-  return store.isVault;
-}
 
 /**
  * Render a basic character tile without any event handlers
@@ -56,7 +52,7 @@ export default function CharacterTile({ store }: { store: DimStore }) {
           )}
         </div>
         <div className="bottom">
-          {isVault(store) ? (
+          {store.isVault ? (
             $featureFlags.unstickyStats && isPhonePortrait && <VaultCapacity />
           ) : (
             <>

--- a/src/app/destiny1/vendors/D1Vendors.tsx
+++ b/src/app/destiny1/vendors/D1Vendors.tsx
@@ -1,13 +1,13 @@
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
-import { storesSelector } from 'app/inventory/selectors';
+import { currenciesSelector, storesSelector } from 'app/inventory/selectors';
 import { useLoadStores } from 'app/inventory/store/hooks';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { DestinyAccount } from '../../accounts/destiny-account';
-import { D1Store } from '../../inventory/store-types';
+import { AccountCurrency, D1Store } from '../../inventory/store-types';
 import D1Vendor from './D1Vendor';
 import styles from './D1Vendors.m.scss';
 import { countCurrencies, loadVendors, Vendor } from './vendor.service';
@@ -18,11 +18,13 @@ interface ProvidedProps {
 
 interface StoreProps {
   stores: D1Store[];
+  currencies: AccountCurrency[];
 }
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
     stores: storesSelector(state) as D1Store[],
+    currencies: currenciesSelector(state),
   };
 }
 
@@ -31,7 +33,7 @@ type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 /**
  * The "All Vendors" page for D1 that shows all the rotating vendors.
  */
-function D1Vendors({ account, stores, dispatch }: Props) {
+function D1Vendors({ account, stores, currencies, dispatch }: Props) {
   const [vendors, setVendors] = useState<{
     [vendorHash: number]: Vendor;
   }>();
@@ -49,7 +51,7 @@ function D1Vendors({ account, stores, dispatch }: Props) {
     return <ShowPageLoading message={t('Loading.Profile')} />;
   }
 
-  const totalCoins = countCurrencies(stores, vendors);
+  const totalCoins = countCurrencies(stores, vendors, currencies);
   const ownedItemHashes = new Set<number>();
   for (const store of stores) {
     for (const item of store.items) {

--- a/src/app/destiny1/vendors/vendor.service.ts
+++ b/src/app/destiny1/vendors/vendor.service.ts
@@ -3,14 +3,13 @@ import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
 import { amountOfItem } from 'app/inventory/stores-helpers';
 import { ThunkResult } from 'app/store/types';
-import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import copy from 'fast-copy';
 import { get, set } from 'idb-keyval';
 import _ from 'lodash';
 import { DestinyAccount } from '../../accounts/destiny-account';
 import { getVendorForCharacter } from '../../bungie-api/destiny1-api';
 import { D1Item } from '../../inventory/item-types';
-import { D1Store } from '../../inventory/store-types';
+import { AccountCurrency, D1Store } from '../../inventory/store-types';
 import { processItems } from '../../inventory/store/d1-item-factory';
 import { loadingTracker } from '../../shell/loading-tracker';
 import { D1ManifestDefinitions } from '../d1-definitions';
@@ -440,11 +439,7 @@ function isSaleItemUnlocked(saleItem) {
 export function countCurrencies(
   stores: D1Store[],
   vendors: { [vendorHash: number]: Vendor },
-  currencies: {
-    readonly itemHash: number;
-    readonly displayProperties: DestinyDisplayPropertiesDefinition;
-    readonly quantity: number;
-  }[]
+  currencies: AccountCurrency[]
 ) {
   if (!stores || !vendors || !stores.length || _.isEmpty(vendors)) {
     return {};

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { storeBackgroundColor } from '../shell/filters';
 import { InventoryBucket } from './inventory-buckets';
 import { PullFromPostmaster } from './PullFromPostmaster';
-import { DimStore, DimVault } from './store-types';
+import { DimStore } from './store-types';
 import StoreBucket from './StoreBucket';
 import { findItemsByBucket } from './stores-helpers';
 
@@ -17,7 +17,7 @@ export function StoreBuckets({
 }: {
   bucket: InventoryBucket;
   stores: DimStore[];
-  vault: DimVault;
+  vault: DimStore;
   currentStore: DimStore;
 }) {
   let content: React.ReactNode;

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -15,7 +15,7 @@ import D1ReputationSection from './D1ReputationSection';
 import { InventoryBucket, InventoryBuckets } from './inventory-buckets';
 import InventoryCollapsibleTitle from './InventoryCollapsibleTitle';
 import { bucketsSelector, sortedStoresSelector } from './selectors';
-import { DimStore, DimVault } from './store-types';
+import { DimStore } from './store-types';
 import { StoreBuckets } from './StoreBuckets';
 import { findItemsByBucket, getCurrentStore, getStore, getVault } from './stores-helpers';
 import './Stores.scss';
@@ -218,7 +218,7 @@ interface InventoryContainerProps {
   buckets: InventoryBuckets;
   stores: DimStore[];
   currentStore: DimStore;
-  vault: DimVault;
+  vault: DimStore;
 }
 
 function CollapsibleContainer({

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -6,13 +6,14 @@ import { get } from 'idb-keyval';
 import { createAction } from 'typesafe-actions';
 import { TagValue } from './dim-item-info';
 import { DimItem } from './item-types';
-import { DimCharacterStat, DimStore } from './store-types';
+import { AccountCurrency, DimCharacterStat, DimStore } from './store-types';
 
 /**
- * Reflect the old stores service data into the Redux store as a migration aid.
+ * Update the current profile (D2 only) and the computed/massaged state of inventory, plus account-wide info like currencies.
  */
 export const update = createAction('inventory/UPDATE')<{
   stores: DimStore[];
+  currencies: AccountCurrency[];
   profileResponse?: DestinyProfileResponse;
 }>();
 

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -31,7 +31,7 @@ import { cleanInfos } from './dim-item-info';
 import { InventoryBuckets } from './inventory-buckets';
 import { ItemPowerSet } from './ItemPowerSet';
 import { bucketsSelector, storesSelector } from './selectors';
-import { DimStore, DimVault } from './store-types';
+import { DimStore } from './store-types';
 import { getCharacterStatsData as getD1CharacterStatsData } from './store/character-utils';
 import { processItems } from './store/d2-item-factory';
 import { getCharacterStatsData, makeCharacter, makeVault } from './store/d2-store-factory';
@@ -295,7 +295,7 @@ function processVault(
   mergedCollectibles: {
     [hash: number]: DestinyCollectibleComponent;
   }
-): DimVault {
+): DimStore {
   const profileInventory = profileInfo.profileInventory.data
     ? profileInfo.profileInventory.data.items
     : [];

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -8,7 +8,7 @@ import { setCurrentAccount } from '../accounts/actions';
 import { AccountsAction } from '../accounts/reducer';
 import * as actions from './actions';
 import { DimItem } from './item-types';
-import { DimStore } from './store-types';
+import { AccountCurrency, DimStore } from './store-types';
 import { createItemIndex } from './store/item-index';
 import { findItemsByBucket, getStore } from './stores-helpers';
 
@@ -19,6 +19,12 @@ export interface InventoryState {
   // Updates to items need to deeply modify their store though.
   // TODO: ReadonlyArray<Readonly<DimStore>>
   readonly stores: DimStore[];
+
+  /**
+   * Account-wide currencies (glimmer, shards, etc.). Silver is only available
+   * while the player is in game.
+   */
+  readonly currencies: AccountCurrency[];
 
   readonly profileResponse?: DestinyProfileResponse;
 
@@ -38,6 +44,7 @@ export type InventoryAction = ActionType<typeof actions>;
 
 const initialState: InventoryState = {
   stores: [],
+  currencies: [],
   newItems: new Set(),
   newItemsLoaded: false,
   isDraggingStack: false,
@@ -118,9 +125,11 @@ function updateInventory(
   {
     stores,
     profileResponse,
+    currencies,
   }: {
     stores: DimStore[];
-    profileResponse?: DestinyProfileResponse | undefined;
+    currencies: AccountCurrency[];
+    profileResponse?: DestinyProfileResponse;
   }
 ) {
   // TODO: we really want to decompose these, drive out all deep mutation
@@ -128,6 +137,7 @@ function updateInventory(
   const newState = {
     ...state,
     stores,
+    currencies,
     newItems: computeNewItems(state.stores, state.newItems, stores),
     profileError: undefined,
   };

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -41,6 +41,9 @@ export const currentStoreSelector = (state: RootState) => getCurrentStore(stores
 /** The vault */
 export const vaultSelector = (state: RootState) => getVault(storesSelector(state));
 
+/** Account wide currencies */
+export const currenciesSelector = (state: RootState) => state.inventory.currencies;
+
 /** The actual raw profile response from the Bungie.net profile API */
 export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;
 

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -67,22 +67,16 @@ export interface DimStore<Item = DimItem> {
   color?: DestinyColor;
 }
 
-export interface DimVault extends DimStore {
-  // TODO: move to top level? Drive off profile?
-  currencies: {
-    itemHash: number;
-    displayProperties: DestinyDisplayPropertiesDefinition;
-    quantity: number;
-  }[];
+/** Account-wide currency counts, e.g. glimmer */
+export interface AccountCurrency {
+  readonly itemHash: number;
+  readonly displayProperties: DestinyDisplayPropertiesDefinition;
+  readonly quantity: number;
 }
 
-export interface D1Vault extends D1Store {
-  currencies: {
-    itemHash: number;
-    displayProperties: DestinyDisplayPropertiesDefinition;
-    quantity: number;
-  }[];
-}
+export type DimVault = DimStore;
+
+export type D1Vault = D1Store;
 
 /** A character-level stat. */
 export interface DimCharacterStat {

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -74,10 +74,6 @@ export interface AccountCurrency {
   readonly quantity: number;
 }
 
-export type DimVault = DimStore;
-
-export type D1Vault = D1Store;
-
 /** A character-level stat. */
 export interface DimCharacterStat {
   /** The DestinyStatDefinition hash for the stat. */

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -4,7 +4,7 @@ import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import _ from 'lodash';
 import { D1ManifestDefinitions } from '../../destiny1/d1-definitions';
-import { D1Store, D1Vault, DimStore } from '../store-types';
+import { D1Store, DimStore } from '../store-types';
 import { getCharacterStatsData } from './character-utils';
 
 // Label isn't used, but it helps us understand what each one is
@@ -121,10 +121,10 @@ export function makeCharacter(
 export function makeVault(
   raw
 ): {
-  store: D1Vault;
+  store: D1Store;
   items: any[];
 } {
-  const store: D1Vault = {
+  const store: D1Store = {
     destinyVersion: 1,
     id: 'vault',
     name: t('Bucket.Vault'),

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -4,7 +4,7 @@ import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import _ from 'lodash';
 import { D1ManifestDefinitions } from '../../destiny1/d1-definitions';
-import { D1Store, D1Vault, DimStore, DimVault } from '../store-types';
+import { D1Store, D1Vault, DimStore } from '../store-types';
 import { getCharacterStatsData } from './character-utils';
 
 // Label isn't used, but it helps us understand what each one is
@@ -26,35 +26,12 @@ const progressionMeta = {
 export function makeCharacter(
   raw,
   defs: D1ManifestDefinitions,
-  mostRecentLastPlayed: Date,
-  currencies: DimVault['currencies']
+  mostRecentLastPlayed: Date
 ): {
   store: D1Store;
   items: any[];
 } {
   const character = raw.character.base;
-  if (!currencies.length) {
-    try {
-      currencies.push(
-        ...character.inventory.currencies.map((c) => {
-          const itemDef = defs.InventoryItem.get(c.itemHash);
-          return {
-            itemHash: c.itemHash,
-            quantity: c.value,
-            displayProperties: {
-              name: itemDef.itemName,
-              description: itemDef.itemDescription,
-              icon: itemDef.icon,
-              hasIcon: Boolean(itemDef.icon),
-            },
-          };
-        })
-      );
-    } catch (e) {
-      console.log('error', e);
-    }
-  }
-
   const race = defs.Race[character.characterBase.raceHash];
   let genderRace = '';
   let className = '';
@@ -142,8 +119,7 @@ export function makeCharacter(
 }
 
 export function makeVault(
-  raw,
-  currencies: DimVault['currencies']
+  raw
 ): {
   store: D1Vault;
   items: any[];
@@ -160,7 +136,6 @@ export function makeVault(
     icon: vaultIcon,
     background: vaultBackground,
     items: [],
-    currencies,
     isVault: true,
     progression: {
       progressions: [],

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -5,7 +5,7 @@ import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
 import { bungieNetPath } from '../../dim-ui/BungieImage';
-import { DimCharacterStat, DimStore, DimVault } from '../store-types';
+import { DimCharacterStat, DimStore } from '../store-types';
 
 /**
  * A factory service for producing "stores" (characters or the vault).
@@ -61,7 +61,7 @@ export function makeCharacter(
   };
 }
 
-export function makeVault(): DimVault {
+export function makeVault(): DimStore {
   return {
     destinyVersion: 2,
     id: 'vault',

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -1,11 +1,6 @@
 import { t } from 'app/i18next-t';
 import { armorStats } from 'app/search/d2-known-values';
-import {
-  DestinyCharacterComponent,
-  DestinyClass,
-  DestinyGender,
-  DestinyItemComponent,
-} from 'bungie-api-ts/destiny2';
+import { DestinyCharacterComponent, DestinyClass, DestinyGender } from 'bungie-api-ts/destiny2';
 import vaultBackground from 'images/vault-background.svg';
 import vaultIcon from 'images/vault.svg';
 import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
@@ -66,16 +61,7 @@ export function makeCharacter(
   };
 }
 
-export function makeVault(
-  defs: D2ManifestDefinitions,
-  profileCurrencies: DestinyItemComponent[]
-): DimVault {
-  const currencies = profileCurrencies.map((c) => ({
-    itemHash: c.itemHash,
-    quantity: c.quantity,
-    displayProperties: defs.InventoryItem.get(c.itemHash).displayProperties,
-  }));
-
+export function makeVault(): DimVault {
   return {
     destinyVersion: 2,
     id: 'vault',
@@ -88,7 +74,6 @@ export function makeVault(
     icon: vaultIcon,
     background: vaultBackground,
     items: [],
-    currencies,
     isVault: true,
     color: { red: 49, green: 50, blue: 51, alpha: 1 },
     level: 0,

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -6,7 +6,7 @@ import _ from 'lodash';
  * Generic helpers for working with whole stores (character inventories) or lists of stores.
  */
 import { DimItem } from './item-types';
-import { D1Store, DimStore, DimVault } from './store-types';
+import { D1Store, DimStore } from './store-types';
 
 /**
  * Get whichever character was last played.
@@ -23,8 +23,7 @@ export const getStore = <Store extends DimStore>(stores: Store[], id: string) =>
 /**
  * Get the Vault from a list of stores.
  */
-export const getVault = (stores: DimStore[]): DimVault | undefined =>
-  stores.find((s) => s.isVault) as DimVault | undefined;
+export const getVault = (stores: DimStore[]): DimStore | undefined => stores.find((s) => s.isVault);
 
 /**
  * Get all items from all stores as a flat list.

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -205,12 +205,3 @@ export function spaceLeftForItem(store: DimStore, item: DimItem, stores: DimStor
 export function isD1Store(store: DimStore): store is D1Store {
   return store.destinyVersion === 1;
 }
-
-/**
- * Is this store the vault? Use this when you want the store to
- * automatically be typed as DimVault in the "true" branch of a conditional.
- * Otherwise you can just check "store.isVault".
- */
-export function isVault(store: DimStore): store is DimVault {
-  return store.isVault;
-}

--- a/src/app/store-stats/AccountCurrencies.tsx
+++ b/src/app/store-stats/AccountCurrencies.tsx
@@ -1,14 +1,16 @@
 import BungieImage from 'app/dim-ui/BungieImage';
+import { currenciesSelector } from 'app/inventory/selectors';
 import _ from 'lodash';
 import React from 'react';
-import type { DimVault } from '../inventory/store-types';
+import { useSelector } from 'react-redux';
 import styles from './AccountCurrencies.m.scss';
 
 /** The account currencies (glimmer, shards, etc.) */
-export default function AccountCurrency({ store }: { store: DimVault }) {
+export default React.memo(function AccountCurrency() {
+  const currencies = useSelector(currenciesSelector);
   return (
     <>
-      {store.currencies.map((currency) => (
+      {currencies.map((currency) => (
         <React.Fragment key={currency.itemHash}>
           <BungieImage
             className={styles.currency}
@@ -20,7 +22,7 @@ export default function AccountCurrency({ store }: { store: DimVault }) {
           </div>
         </React.Fragment>
       ))}
-      {_.times(4 - store.currencies.length, (i) => (
+      {_.times(4 - currencies.length, (i) => (
         <React.Fragment key={i}>
           <div />
           <div />
@@ -28,4 +30,4 @@ export default function AccountCurrency({ store }: { store: DimVault }) {
       ))}
     </>
   );
-}
+});

--- a/src/app/store-stats/StoreStats.tsx
+++ b/src/app/store-stats/StoreStats.tsx
@@ -1,5 +1,5 @@
 import { isPhonePortraitSelector } from 'app/inventory/selectors';
-import type { DimStore, DimVault } from 'app/inventory/store-types';
+import type { DimStore } from 'app/inventory/store-types';
 import clsx from 'clsx';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -8,10 +8,6 @@ import AccountCurrencies from './AccountCurrencies';
 import D1CharacterStats from './D1CharacterStats';
 import styles from './StoreStats.m.scss';
 import VaultCapacity from './VaultCapacity';
-
-function isVault(store: DimStore): store is DimVault {
-  return store.isVault;
-}
 
 function shouldShowCapacity(isPhonePortrait: boolean) {
   if (!isPhonePortrait) {
@@ -31,9 +27,9 @@ export default function StoreStats({
   const isPhonePortrait = useSelector(isPhonePortraitSelector);
   return (
     <div className={clsx({ ['store-cell']: Boolean(style), vault: store.isVault })} style={style}>
-      {isVault(store) ? (
+      {store.isVault ? (
         <div className={styles.vaultStats}>
-          <AccountCurrencies store={store} />
+          <AccountCurrencies />
           {shouldShowCapacity(isPhonePortrait) && <VaultCapacity />}
         </div>
       ) : store.destinyVersion === 1 ? (

--- a/src/app/store-stats/VaultCapacity.tsx
+++ b/src/app/store-stats/VaultCapacity.tsx
@@ -1,6 +1,6 @@
 import { InventoryBucket, InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { bucketsSelector, currentStoreSelector, vaultSelector } from 'app/inventory/selectors';
-import { DimStore, DimVault } from 'app/inventory/store-types';
+import { DimStore } from 'app/inventory/store-types';
 import { findItemsByBucket } from 'app/inventory/stores-helpers';
 import clsx from 'clsx';
 import vaultIcon from 'destiny-icons/armor_types/helmet.svg';
@@ -44,7 +44,7 @@ interface VaultCounts {
  * buckets are, for display. We could calculate this straight from the profile, but we want to be able to recompute it
  * when items move without reloading the profile.
  */
-function computeVaultCounts(activeStore: DimStore, vault: DimVault, buckets: InventoryBuckets) {
+function computeVaultCounts(activeStore: DimStore, vault: DimStore, buckets: InventoryBuckets) {
   const vaultCounts: VaultCounts = {};
 
   for (const bucket of Object.values(buckets.byType)) {


### PR DESCRIPTION
This moves currencies, which were previously attached to the vault store, to a top level part of the state, since they're really profile-wide. I didn't compute them on demand because they come from a slightly different place in the profile, and it's different in D2 vs D1. Plus, I have upcoming reasons to want to be able to modify the currency counts...

This was the last thing making DimVault a type, so it's gone now. There's only DimStore.