### PR TITLE
Group properties of store and item by how they change

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -33,18 +33,24 @@ export type Tier = 'Exotic' | 'Legendary' | 'Rare' | 'Uncommon' | 'Common' | 'Un
  */
 // TODO: This interface is clearly too large - break out interfaces for common subsets
 export interface DimItem {
-  /** The ID of the store that currently contains this item. */
-  owner: string;
-  /** The version of Destiny this comes from. */
-  destinyVersion: DestinyVersion;
-  /** The bucket the item is currently in. */
-  location: InventoryBucket;
-  /** The bucket the item normally resides in (even though it may currently be elsewhere, such as in the postmaster). */
-  bucket: InventoryBucket;
+  // Static data - this won't ever change for the lifetime of the item, because it's derived from the definition or is intrinsic to the item's identity. These would only change if the manifest updates.
+
+  /** A synthetic unique ID used to help React tell items apart. Use this as a "key" property. We can't just use "id" because some items don't have one. */
+  index: string;
+  /** Item instance id. Non-instanced items have id "0" for D1 compatibility. */
+  id: string;
   /** The inventoryItemHash, see DestinyInventoryItemDefinition. */
   hash: number;
-  /** This is the type of the item (see InventoryBuckets) regardless of location. This string is a DIM concept with no direct correlation to the API types. */
+  /** Is this classified? Some items are classified in the manifest. */
+  classified: boolean;
+  /** The version of Destiny this comes from. */
+  destinyVersion: DestinyVersion;
+  /** This is the type of the item (see InventoryBuckets) regardless of location. This string is a DIM concept with no direct correlation to the API types. It should generally be avoided in favor of using bucket hash.  */
   type: string;
+  /** Localized name of this item's type. */
+  typeName: string;
+  /** The bucket the item normally resides in (even though it may currently be elsewhere, such as in the postmaster). */
+  bucket: InventoryBucket;
   /** Hashes of DestinyItemCategoryDefinitions this item belongs to */
   itemCategoryHashes: number[];
   /** A readable English name for the rarity of the item (e.g. "Exotic", "Rare"). */
@@ -63,16 +69,8 @@ export interface DimItem {
   iconOverlay?: string;
   /** Some items have a secondary icon, namely Emblems. */
   secondaryIcon?: string;
-  /** The damage type this weapon deals, or energy type of armor, or damage type corresponding to the item's elemental resistance. */
-  element: DestinyDamageTypeDefinition | DestinyEnergyTypeDefinition | null;
-  /** Whether this item CANNOT be transferred. */
-  notransfer: boolean;
   /** Whether we can pull this item from the postmaster */
   canPullFromPostmaster: boolean;
-  /** Item instance id. Non-instanced items have id "0" for D1 compatibility. */
-  id: string;
-  /** Is this item currently equipped? */
-  equipped: boolean;
   /** Is this "equipment" (items that can be equipped). */
   equipment: boolean;
   /**
@@ -85,19 +83,8 @@ export interface DimItem {
    * than the item in the slot that's about to be occupied).
    */
   equippingLabel?: string;
-  /** Is this item complete (leveled, unlocked, objectives complete)? */
-  complete: boolean;
-  /** How many items does this represent? Only greater than one if maxStackSize is greater than one. */
-  amount: number;
-  /** The primary stat (Attack, Defense, Speed) of the item. */
-  primStat:
-    | (DestinyStat & {
-        stat: DestinyStatDefinition;
-      })
-    | null;
+  /** What type of ammo this weapon takes, or None if it isn't a weapon */
   ammoType: DestinyAmmunitionType;
-  /** Localized name of this item's type. */
-  typeName: string;
   /** The level a character must be to equip this item. */
   equipRequiredLevel: number;
   /** The maximum number of items that stack together for this item type. */
@@ -112,78 +99,100 @@ export interface DimItem {
   lockable: boolean;
   /** Can this item be tracked? (For quests/bounties.) */
   trackable: boolean;
-  /** Is this item tracked? (For quests/bounties). */
-  tracked: boolean;
-  /** Is this item locked? */
-  locked: boolean;
-  /** Is this a masterwork? (D2 only) */
-  masterwork: boolean;
-  /** Is this classified? Some items are classified in the manifest. */
-  classified: boolean;
-  /** What percent complete is this item (considers XP and objectives). */
-  percentComplete: number;
-  /** Should we hide the percentage display? */
-  hidePercentage: boolean;
   /** Can this be tagged? */
   taggable: boolean;
   /** Can this be compared with other items? */
   comparable: boolean;
-  /** The "base power" without any power-enhancing mods. */
-  basePower: number;
-  /** A synthetic unique ID used to help React tell items apart. Use this as a "key" property. */
-  index: string;
+  /** Should we hide the percentage display? */
+  hidePercentage: boolean;
   /** Can this be infused? */
   infusable: boolean;
   /** Can this be used as infusion fuel? */
   infusionFuel: boolean;
-  /** The talent grid, used for D1 perks and D1/D2 subclass grids. */
-  talentGrid: DimTalentGrid | null;
-  /** D2 items use sockets and plugs to represent everything from perks to mods to ornaments and shaders. */
-  sockets: DimSockets | null;
   /** Perks, which are specifically called-out special abilities of items shown in the game's popup UI. */
   perks: DimPerk[] | null;
-  /** Detailed stats for the item. */
-  stats: DimStat[] | null;
-  /** Any objectives associated with the item. */
-  objectives: DestinyObjectiveProgress[] | null;
   /** Is this an engram? */
   isEngram: boolean;
   /** The reference hash for lore attached to this item (D2 only). */
   loreHash?: number;
-  /** Sometimes the API doesn't return socket info. This tells whether the item *should* have socket info but doesn't. */
-  missingSockets: boolean;
-  /** Stat Tracker */
-  metricHash?: number;
-  /** Stat Tracker Progress */
-  metricObjective?: DestinyObjectiveProgress;
   /** Metrics that can be used with this item. */
   availableMetricCategoryNodeHashes?: number[];
-  /** for D2 Y3 armor, this is the type and capacity information */
-  energy: DestinyItemInstanceEnergy | null;
-  /** If this item is a masterwork, this will include information about its masterwork properties. */
-  masterworkInfo: DimMasterwork | null;
   /** If this exists, it's the limit of an item's PL. If NOT, display no information. Maybe it's unlimited PL. Maybe it's a weird item. */
   powerCap: number | null;
-  /** an item's current breaker type, if it has one */
-  breakerType: DestinyBreakerTypeDefinition | null;
   /** Information about how this item works with infusion. */
   infusionQuality: DestinyItemQualityBlockDefinition | null;
   /** The DestinyVendorDefinition hash of the vendor that can preview the contents of this item, if there is one. */
   previewVendor?: number;
   /** Localized string for where this item comes from... or other stuff like it not being recoverable from collections */
   displaySource?: string;
-  /** The state of this item in the user's D2 Collection */
-  collectibleState?: DestinyCollectibleState;
   collectibleHash?: number;
-  /** The DestinyCollectibleDefinition sourceHash for a specific item (D2). */
+  /** The DestinyCollectibleDefinition sourceHash for a specific item (D2). Derived entirely from collectibleHash */
   source?: number;
-  /** Extra pursuit info, if this item is a quest or bounty. */
-  pursuit: DimPursuit | null;
   /** Information about this item as a plug. Mostly useful for mod collectibles. */
   plug?: {
     energyCost: number;
     costElementIcon: string;
   };
+  /** Extra pursuit info, if this item is a quest or bounty. */
+  pursuit: DimPursuit | null;
+
+  // "Mutable" data - this may be changed by moving the item around, lock/unlock, etc. Any place DIM updates its view of the world without a profile refresh.
+
+  /** The ID of the store that currently contains this item. */
+  owner: string;
+  /** Is this item currently equipped? */
+  equipped: boolean;
+  /** The bucket the item is currently in. */
+  location: InventoryBucket;
+  /** Is this item tracked? (For quests/bounties). */
+  tracked: boolean;
+  /** Is this item locked? */
+  locked: boolean;
+
+  // Dynamic data - this may change between profile updates
+
+  /** The damage type this weapon deals, or energy type of armor, or damage type corresponding to the item's elemental resistance. */
+  element: DestinyDamageTypeDefinition | DestinyEnergyTypeDefinition | null;
+  /** Whether this item CANNOT be transferred. */
+  notransfer: boolean;
+  /** Is this item complete (leveled, unlocked, objectives complete)? */
+  complete: boolean;
+  /** How many items does this represent? Only greater than one if maxStackSize is greater than one. */
+  amount: number;
+  /** The primary stat (Attack, Defense, Speed) of the item. */
+  primStat:
+    | (DestinyStat & {
+        stat: DestinyStatDefinition;
+      })
+    | null;
+  /** The "base power" without any power-enhancing mods. This is only defined for D2 and is a synonym for (primStat?.value || 0). */
+  basePower: number;
+  /** Is this a masterwork? (D2 only) */
+  masterwork: boolean;
+  /** What percent complete is this item (considers XP and objectives). */
+  percentComplete: number;
+  /** The talent grid, used for D1 perks and D1/D2 subclass grids. */
+  talentGrid: DimTalentGrid | null;
+  /** D2 items use sockets and plugs to represent everything from perks to mods to ornaments and shaders. */
+  sockets: DimSockets | null;
+  /** Sometimes the API doesn't return socket info. This tells whether the item *should* have socket info but doesn't. */
+  missingSockets: boolean;
+  /** Detailed stats for the item. */
+  stats: DimStat[] | null;
+  /** Any objectives associated with the item. */
+  objectives: DestinyObjectiveProgress[] | null;
+  /** Stat Tracker */
+  metricHash?: number;
+  /** Stat Tracker Progress */
+  metricObjective?: DestinyObjectiveProgress;
+  /** for D2 Y3 armor, this is the type and capacity information */
+  energy: DestinyItemInstanceEnergy | null;
+  /** If this item is a masterwork, this will include information about its masterwork properties. */
+  masterworkInfo: DimMasterwork | null;
+  /** an item's current breaker type, if it has one */
+  breakerType: DestinyBreakerTypeDefinition | null;
+  /** The state of this item in the user's D2 Collection */
+  collectibleState?: DestinyCollectibleState;
 }
 
 /**

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -15,28 +15,16 @@ import { D1Item, DimItem } from './item-types';
  * overrides.
  */
 export interface DimStore<Item = DimItem> {
+  // Static data - these properties will never change after the character/store is created
+
   /** An ID for the store. Character ID or 'vault'. */
   id: string;
   /** Localized name for the store. */
   name: string;
-  /** All items in the store, across all buckets. */
-  items: readonly Item[];
+  /** Is this the vault? */
+  isVault: boolean;
   /** The Destiny version this store came from. */
   destinyVersion: DestinyVersion;
-  /** An icon (emblem) for the store. */
-  icon: string;
-  /** Is this the most-recently-played character? */
-  current: boolean;
-  /** The date the character was last played. */
-  lastPlayed: Date;
-  /** Emblem background. */
-  background: string;
-  /** Character level. */
-  level: number;
-  /** Progress towards the next level (or "prestige level") */
-  percentToNextLevel: number;
-  /** Power/light level. */
-  powerLevel: number;
   /** Enum class type. */
   classType: DestinyClass;
   /** Localized class name. */
@@ -45,10 +33,32 @@ export interface DimStore<Item = DimItem> {
   gender: string;
   /** Localized gender and race together. */
   genderRace: string;
-  /** String gender name: 'male' | 'female' | '' */
+  /** String gender name: 'male' | 'female' | '', used exclusively for i18n when translating to gendered languages */
   genderName: 'male' | 'female' | '';
-  /** Is this the vault? */
-  isVault: boolean;
+
+  // "Mutable" data - this may be changed by moving the item around, lock/unlock, etc. Any place DIM updates its view of the world without a profile refresh.
+
+  /** All items in the store, across all buckets. */
+  items: readonly Item[];
+
+  // Dynamic data - this may change between profile updates, (whether that's full or partial profile update)
+
+  /** An icon (emblem) for the store. */
+  icon: string;
+  /** Is this the most-recently-played character? */
+  current: boolean;
+  /** The date the character was last played. */
+  lastPlayed: Date;
+  /** Emblem background image */
+  background: string;
+  /** The background or dominant color of the equipped emblem, if available. */
+  color?: DestinyColor;
+  /** Character level. */
+  level: number;
+  /** Progress towards the next level (or "prestige level") */
+  percentToNextLevel: number;
+  /** Power/light level. */
+  powerLevel: number;
   /** Character stats. */
   stats: {
     /** average of your highest simultaneously equippable gear with bonus fields for rich tooltip content and equippability warnings */
@@ -59,8 +69,6 @@ export interface DimStore<Item = DimItem> {
     maxTotalPower?: DimCharacterStat;
     [hash: number]: DimCharacterStat;
   };
-  /** The background or dominant color of the equipped emblem, if available. */
-  color?: DestinyColor;
 }
 
 /** Account-wide currency counts, e.g. glimmer */


### PR DESCRIPTION
I'm not making use of this info just yet, but this groups/documents properties of both DimStore and DimItem by how they can change over the lifetime of an item. Eventually I plan to leverage this info to reduce the cost of constructing and updating items, but I haven't decided if I'll do that by breaking into separate sub-items (`item.static.bucket` vs `item.live.location`) or just manage them as a type union or something.