### PR TITLE
Use TransitionGroup to animate out mobile inspect

### DIFF
--- a/src/app/mobile-inspect/MobileInspect.m.scss
+++ b/src/app/mobile-inspect/MobileInspect.m.scss
@@ -1,17 +1,7 @@
+@import 'ceaser-easing';
 @import '../variables.scss';
 
 $animationSpeed: 150ms;
-
-@keyframes zoom {
-  from {
-    transform: scale(0.85);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
 
 .sheetBackground {
   position: fixed;
@@ -36,7 +26,6 @@ $animationSpeed: 150ms;
   top: 25%;
   backface-visibility: hidden;
   z-index: 13;
-  animation: zoom $animationSpeed;
 }
 
 .container {
@@ -98,4 +87,28 @@ $animationSpeed: 150ms;
   height: 30px;
   min-width: 30px;
   margin-right: 10px;
+}
+
+// CSS show/hide transition
+
+.enter {
+  transform: scale(0.85);
+  opacity: 0;
+}
+
+.enter.enterActive {
+  transform: scale(1);
+  opacity: 1;
+  transition: all $animationSpeed $easeOutCubic;
+}
+
+.exit {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.exit.exitActive {
+  transform: scale(0.85);
+  opacity: 0;
+  transition: all $animationSpeed $easeOutCubic;
 }

--- a/src/app/mobile-inspect/MobileInspect.m.scss.d.ts
+++ b/src/app/mobile-inspect/MobileInspect.m.scss.d.ts
@@ -3,6 +3,10 @@
 interface CssExports {
   'container': string;
   'content': string;
+  'enter': string;
+  'enterActive': string;
+  'exit': string;
+  'exitActive': string;
   'header': string;
   'headerInfo': string;
   'inspectActive': string;
@@ -11,7 +15,6 @@ interface CssExports {
   'locations': string;
   'mobileInspectSheet': string;
   'sheetBackground': string;
-  'zoom': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/mobile-inspect/MobileInspect.tsx
+++ b/src/app/mobile-inspect/MobileInspect.tsx
@@ -4,7 +4,9 @@ import ItemActions from 'app/item-popup/ItemActions';
 import ItemSockets from 'app/item-popup/ItemSockets';
 import { ItemSubHeader } from 'app/item-popup/ItemSubHeader';
 import { useSubscription } from 'app/utils/hooks';
-import React, { useState } from 'react';
+import clsx from 'clsx';
+import React, { useRef, useState } from 'react';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { showMobileInspect$ } from './mobile-inspect';
 import styles from './MobileInspect.m.scss';
 
@@ -16,6 +18,7 @@ export const enum Inspect {
 export default function MobileInspect() {
   const [item, setItem] = useState<DimItem | undefined>();
   const [inspectType, setInspectType] = useState<Inspect>(Inspect.default);
+  const nodeRef = useRef<HTMLDivElement>(null);
   // TODO: In some very rare cases the popup doesn't close. Allow tapping to reset/close.
   const reset = () => setItem(undefined);
 
@@ -26,34 +29,45 @@ export default function MobileInspect() {
     })
   );
 
-  if (!item) {
-    return <div className={styles.sheetBackground} />;
-  }
-
   return (
     <>
-      <div className={`${styles.sheetBackground} ${styles.inspectActive}`} />
-      <div className={styles.mobileInspectSheet} onClick={reset}>
-        <div className={styles.container}>
-          <div className={styles.header}>
-            <BungieImage className={styles.itemImg} src={item.icon} />
-            <div className={styles.headerInfo}>
-              <div>{item.name}</div>
-              <ItemSubHeader item={item} />
-            </div>
-          </div>
-          <div className={styles.content}>
-            <div className={styles.inspectRow}>
-              {item.sockets && <ItemSockets item={item} minimal={true} />}
-            </div>
-            {inspectType === Inspect.showMoveLocations && (
-              <div className={styles.inspectRow}>
-                <ItemActions key={item.index} item={item} mobileInspect={true} />
+      <div className={clsx(styles.sheetBackground, { [styles.inspectActive]: item })} />
+      <TransitionGroup component={null}>
+        {item && (
+          <CSSTransition
+            nodeRef={nodeRef}
+            timeout={{ enter: 150, exit: 150 }}
+            classNames={{
+              enter: styles.enter,
+              enterActive: styles.enterActive,
+              exit: styles.exit,
+              exitActive: styles.exitActive,
+            }}
+          >
+            <div ref={nodeRef} className={styles.mobileInspectSheet} onClick={reset}>
+              <div className={styles.container}>
+                <div className={styles.header}>
+                  <BungieImage className={styles.itemImg} src={item.icon} />
+                  <div className={styles.headerInfo}>
+                    <div>{item.name}</div>
+                    <ItemSubHeader item={item} />
+                  </div>
+                </div>
+                <div className={styles.content}>
+                  <div className={styles.inspectRow}>
+                    {item.sockets && <ItemSockets item={item} minimal={true} />}
+                  </div>
+                  {inspectType === Inspect.showMoveLocations && (
+                    <div className={styles.inspectRow}>
+                      <ItemActions key={item.index} item={item} mobileInspect={true} />
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </div>
-        </div>
-      </div>
+            </div>
+          </CSSTransition>
+        )}
+      </TransitionGroup>
     </>
   );
 }


### PR DESCRIPTION
The mobile inspect menu animated in, but wouldn't animate out because its DOM node just gets deleted. This PR uses TransitionGroup to apply CSS transitions to both enter and exit, for a smoother experience.