### PR TITLE
Start reducing reliance on DimStore#items

### DIFF
--- a/src/app/collections/Collections.tsx
+++ b/src/app/collections/Collections.tsx
@@ -15,12 +15,15 @@ import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { connect } from 'react-redux';
 import { useParams } from 'react-router';
-import { createSelector } from 'reselect';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
-import { bucketsSelector, profileResponseSelector, storesSelector } from '../inventory/selectors';
+import {
+  bucketsSelector,
+  ownedItemsSelector,
+  profileResponseSelector,
+} from '../inventory/selectors';
 import Catalysts from './Catalysts';
 import './collections.scss';
 import LegacyTriumphs from './LegacyTriumphs';
@@ -46,24 +49,13 @@ interface StoreProps {
 type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 
 function mapStateToProps() {
-  const ownedItemHashesSelector = createSelector(storesSelector, (stores) => {
-    const ownedItemHashes = new Set<number>();
-    if (stores) {
-      for (const store of stores) {
-        for (const item of store.items) {
-          ownedItemHashes.add(item.hash);
-        }
-      }
-    }
-    return ownedItemHashes;
-  });
-
+  const ownedItemsSelectorInstance = ownedItemsSelector();
   return (state: RootState): StoreProps => {
     const settings = settingsSelector(state);
     return {
       buckets: bucketsSelector(state),
       defs: state.manifest.d2Manifest,
-      ownedItemHashes: ownedItemHashesSelector(state),
+      ownedItemHashes: ownedItemsSelectorInstance(state),
       profileResponse: profileResponseSelector(state),
       searchQuery: querySelector(state),
       searchFilter: searchFilterSelector(state),

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -3,9 +3,7 @@ import { itemPop } from 'app/dim-ui/scroll';
 import { getWeaponArchetype } from 'app/dim-ui/WeaponArchetype';
 import { t } from 'app/i18next-t';
 import ElementIcon from 'app/inventory/ElementIcon';
-import { storesSelector } from 'app/inventory/selectors';
-import { DimStore } from 'app/inventory/store-types';
-import { getAllItems } from 'app/inventory/stores-helpers';
+import { allItemsSelector } from 'app/inventory/selectors';
 import { powerCapPlugSetHash } from 'app/search/d2-known-values';
 import { makeDupeID } from 'app/search/search-filters/dupes';
 import { setSetting } from 'app/settings/actions';
@@ -33,7 +31,7 @@ import { CompareService } from './compare.service';
 import CompareItem from './CompareItem';
 
 interface StoreProps {
-  stores: DimStore[];
+  allItems: DimItem[];
   defs?: D2ManifestDefinitions;
   compareBaseStats: boolean;
 }
@@ -47,7 +45,7 @@ type Props = StoreProps & RouteComponentProps & DispatchProps;
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    stores: storesSelector(state),
+    allItems: allItemsSelector(state),
     defs: state.manifest.d2Manifest,
     compareBaseStats: settingsSelector(state).compareBaseStats,
   };
@@ -310,7 +308,7 @@ class Compare extends React.Component<Props, State> {
 
     // else,this is a fresh comparison sheet spawn, so let's generate comparisonSets
     else {
-      const allItems = getAllItems(this.props.stores);
+      const allItems = this.props.allItems;
       // comparisonSets is an array so that it has order, filled with {label, setOfItems} objects
       const comparisonSets = exampleItem.bucket.inArmor
         ? this.findSimilarArmors(allItems, additionalItems)

--- a/src/app/gear-power/GearPower.tsx
+++ b/src/app/gear-power/GearPower.tsx
@@ -5,13 +5,12 @@ import BucketIcon from 'app/dim-ui/svgs/BucketIcon';
 import { t } from 'app/i18next-t';
 import { maxLightItemSet } from 'app/loadout/auto-loadouts';
 import { getLight } from 'app/loadout/loadout-utils';
-import { RootState } from 'app/store/types';
 import { useSubscription } from 'app/utils/hooks';
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import Sheet from '../dim-ui/Sheet';
-import { storesSelector } from '../inventory/selectors';
+import { allItemsSelector, storesSelector } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
 import { showGearPower$ } from './gear-power';
 import styles from './GearPower.m.scss';
@@ -28,7 +27,8 @@ const bucketClassNames = {
 };
 
 export default function GearPower() {
-  const stores = useSelector<RootState, DimStore[]>((state) => storesSelector(state));
+  const stores = useSelector(storesSelector);
+  const allItems = useSelector(allItemsSelector);
   const [selectedStore, setSelectedStore] = useState<DimStore | undefined>();
   const reset = () => {
     setSelectedStore(undefined);
@@ -44,7 +44,7 @@ export default function GearPower() {
     return null;
   }
 
-  const { unrestricted, equippable } = maxLightItemSet(stores, selectedStore);
+  const { unrestricted, equippable } = maxLightItemSet(allItems, selectedStore);
   const maxBasePower = getLight(selectedStore, unrestricted);
   const equippableMaxBasePower = getLight(selectedStore, equippable);
   const powerFloor = Math.floor(maxBasePower);

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -30,6 +30,13 @@ export const sortedStoresSelector = createSelector(
   (stores, sortStores) => sortStores(stores)
 );
 
+/**
+ * Get a flat list of all items.
+ */
+export const allItemsSelector = createSelector(storesSelector, (stores) =>
+  stores.flatMap((s) => s.items)
+);
+
 /** Have stores been loaded? */
 export const storesLoadedSelector = (state: RootState) => storesSelector(state).length > 0;
 

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -54,12 +54,10 @@ export const profileResponseSelector = (state: RootState) => state.inventory.pro
 
 /** A set containing all the hashes of owned items. */
 export const ownedItemsSelector = () =>
-  createSelector(profileResponseSelector, storesSelector, (profileResponse, stores) => {
+  createSelector(profileResponseSelector, allItemsSelector, (profileResponse, allItems) => {
     const ownedItemHashes = new Set<number>();
-    for (const store of stores) {
-      for (const item of store.items) {
-        ownedItemHashes.add(item.hash);
-      }
+    for (const item of allItems) {
+      ownedItemHashes.add(item.hash);
     }
     if (profileResponse?.profilePlugSets?.data) {
       for (const plugSet of Object.values(profileResponse.profilePlugSets.data.plugs)) {

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -26,14 +26,6 @@ export const getStore = <Store extends DimStore>(stores: Store[], id: string) =>
 export const getVault = (stores: DimStore[]): DimStore | undefined => stores.find((s) => s.isVault);
 
 /**
- * Get all items from all stores as a flat list.
- */
-export const getAllItems = <Item extends DimItem, Store extends DimStore<Item>>(
-  stores: Store[],
-  filter?: (item: Item) => unknown
-) => stores.flatMap((s) => (filter ? s.items.filter(filter) : s.items));
-
-/**
  * This is a memoized function that generates a map of items by their bucket
  * location. It could be a redux selector but I didn't want to have to thread it
  * through everywhere, so instead we do our own weak memoization to avoid

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -5,7 +5,7 @@ import BungieImage, { bungieNetPath } from 'app/dim-ui/BungieImage';
 import Sheet from 'app/dim-ui/Sheet';
 import ElementIcon from 'app/inventory/ElementIcon';
 import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { profileResponseSelector, storesSelector } from 'app/inventory/selectors';
+import { allItemsSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { RootState } from 'app/store/types';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
@@ -61,10 +61,10 @@ function mapStateToProps() {
   );
 
   const inventoryPlugs = createSelector(
-    storesSelector,
+    allItemsSelector,
     (_: RootState, props: ProvidedProps) => props.socket,
     (state: RootState) => state.manifest.d2Manifest!,
-    (stores, socket, defs) => {
+    (allItems, socket, defs) => {
       const socketType = defs.SocketType.get(socket.socketDefinition.socketTypeHash);
       if (
         !(
@@ -78,12 +78,10 @@ function mapStateToProps() {
       const modHashes = new Set<number>();
 
       const plugAllowList = new Set(socketType.plugWhitelist.map((e) => e.categoryHash));
-      for (const store of stores) {
-        for (const item of store.items) {
-          const itemDef = defs.InventoryItem.get(item.hash);
-          if (itemDef.plug && plugAllowList.has(itemDef.plug.plugCategoryHash)) {
-            modHashes.add(item.hash);
-          }
+      for (const item of allItems) {
+        const itemDef = defs.InventoryItem.get(item.hash);
+        if (itemDef.plug && plugAllowList.has(itemDef.plug.plugCategoryHash)) {
+          modHashes.add(item.hash);
         }
       }
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -19,7 +19,7 @@ import { connect } from 'react-redux';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { createSelector } from 'reselect';
 import CharacterSelect from '../dim-ui/CharacterSelect';
-import { storesSelector } from '../inventory/selectors';
+import { allItemsSelector } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
 import FilterBuilds from './filter/FilterBuilds';
 import LockArmorAndPerks from './filter/LockArmorAndPerks';
@@ -59,31 +59,29 @@ type Props = ProvidedProps & StoreProps;
 
 function mapStateToProps() {
   const itemsSelector = createSelector(
-    storesSelector,
+    allItemsSelector,
     (
-      stores
+      allItems
     ): Readonly<{
       [classType: number]: ItemsByBucket;
     }> => {
       const items: {
         [classType: number]: { [bucketHash: number]: DimItem[] };
       } = {};
-      for (const store of stores) {
-        for (const item of store.items) {
-          if (!item || !isLoadoutBuilderItem(item)) {
-            continue;
+      for (const item of allItems) {
+        if (!item || !isLoadoutBuilderItem(item)) {
+          continue;
+        }
+        for (const classType of item.classType === DestinyClass.Unknown
+          ? [DestinyClass.Hunter, DestinyClass.Titan, DestinyClass.Warlock]
+          : [item.classType]) {
+          if (!items[classType]) {
+            items[classType] = {};
           }
-          for (const classType of item.classType === DestinyClass.Unknown
-            ? [DestinyClass.Hunter, DestinyClass.Titan, DestinyClass.Warlock]
-            : [item.classType]) {
-            if (!items[classType]) {
-              items[classType] = {};
-            }
-            if (!items[classType][item.bucket.hash]) {
-              items[classType][item.bucket.hash] = [];
-            }
-            items[classType][item.bucket.hash].push(item);
+          if (!items[classType][item.bucket.hash]) {
+            items[classType][item.bucket.hash] = [];
           }
+          items[classType][item.bucket.hash].push(item);
         }
       }
 

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -5,7 +5,7 @@ import GlobalHotkeys from 'app/hotkeys/GlobalHotkeys';
 import { t } from 'app/i18next-t';
 import { InventoryBucket, InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
+import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { escapeRegExp } from 'app/search/search-filters/freeform';
 import { SearchFilterRef } from 'app/search/SearchBar';
 import { AppIcon, searchIcon } from 'app/shell/icons';
@@ -55,30 +55,28 @@ type Props = ProvidedProps & StoreProps;
 function mapStateToProps() {
   // Get a list of lockable perks by bucket.
   const perksSelector = createSelector(
-    storesSelector,
+    allItemsSelector,
     (_: RootState, props: ProvidedProps) => props.classType,
-    (stores, classType) => {
+    (allItems, classType) => {
       const perks: { [bucketHash: number]: PluggableInventoryItemDefinition[] } = {};
-      for (const store of stores) {
-        for (const item of store.items) {
-          if (
-            !item ||
-            !item.sockets ||
-            !isLoadoutBuilderItem(item) ||
-            !(item.classType === DestinyClass.Unknown || item.classType === classType)
-          ) {
-            continue;
-          }
-          if (!perks[item.bucket.hash]) {
-            perks[item.bucket.hash] = [];
-          }
-          // build the filtered unique perks item picker
-          item.sockets.allSockets.filter(filterPlugs).forEach((socket) => {
-            socket.plugOptions.forEach((option) => {
-              perks[item.bucket.hash].push(option.plugDef);
-            });
-          });
+      for (const item of allItems) {
+        if (
+          !item ||
+          !item.sockets ||
+          !isLoadoutBuilderItem(item) ||
+          !(item.classType === DestinyClass.Unknown || item.classType === classType)
+        ) {
+          continue;
         }
+        if (!perks[item.bucket.hash]) {
+          perks[item.bucket.hash] = [];
+        }
+        // build the filtered unique perks item picker
+        item.sockets.allSockets.filter(filterPlugs).forEach((socket) => {
+          socket.plugOptions.forEach((option) => {
+            perks[item.bucket.hash].push(option.plugDef);
+          });
+        });
       }
 
       // sort exotic perks first, then by index

--- a/src/app/loadout/GeneratedLoadoutStats.tsx
+++ b/src/app/loadout/GeneratedLoadoutStats.tsx
@@ -49,12 +49,14 @@ function getItemsInListByCategory({
 export function GeneratedLoadoutStats({
   defs,
   stores,
+  allItems,
   buckets,
   items,
   loadout,
 }: {
   defs: D1ManifestDefinitions | D2ManifestDefinitions;
   stores: DimStore[];
+  allItems: DimItem[];
   buckets: InventoryBuckets;
   items: DimItem[];
   loadout: Loadout;
@@ -74,7 +76,7 @@ export function GeneratedLoadoutStats({
   if (weaponItems.missingBuckets) {
     // If any weapon types are missing, fill them in with max weapons to assume light level
     const subclass = stores.find((store) => store.classType === loadout.classType) ?? stores[0];
-    const maxPowerItems = maxLightItemSet(stores, subclass).unrestricted;
+    const maxPowerItems = maxLightItemSet(allItems, subclass).unrestricted;
     const maxWeapons = _.compact(
       weaponItems.missingBuckets.map(
         (bucket) => maxPowerItems.find((item) => bucket.type === item.type)!

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -20,7 +20,7 @@ import Sheet from '../dim-ui/Sheet';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import InventoryItem from '../inventory/InventoryItem';
 import { DimItem } from '../inventory/item-types';
-import { bucketsSelector, storesSelector } from '../inventory/selectors';
+import { allItemsSelector, bucketsSelector, storesSelector } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
 import { showItemPicker } from '../item-picker/item-picker';
 import { showNotification } from '../notifications/notifications';
@@ -79,6 +79,7 @@ interface StoreProps {
     value: number;
   }[];
   stores: DimStore[];
+  allItems: DimItem[];
   buckets: InventoryBuckets;
   defs: D1ManifestDefinitions | D2ManifestDefinitions;
   loadouts: Loadout[];
@@ -350,6 +351,7 @@ function mapStateToProps() {
     account: currentAccountSelector(state)!,
     classTypeOptions: classTypeOptionsSelector(state),
     stores: storesSelector(state),
+    allItems: allItemsSelector(state),
     buckets: bucketsSelector(state)!,
     defs:
       destinyVersionSelector(state) === 2 ? state.manifest.d2Manifest! : state.manifest.d1Manifest!,
@@ -366,6 +368,7 @@ function LoadoutDrawer({
   buckets,
   classTypeOptions,
   stores,
+  allItems,
   itemSortOrder,
   defs,
   loadouts,
@@ -510,6 +513,7 @@ function LoadoutDrawer({
         buckets={buckets}
         items={items}
         loadout={loadout}
+        allItems={allItems}
       />
     </div>
   );

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -11,7 +11,7 @@ import { setItemNote } from 'app/inventory/actions';
 import { bulkLockItems, bulkTagItems } from 'app/inventory/bulk-actions';
 import { ItemInfos, TagInfo } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
-import { itemInfosSelector, storesSelector } from 'app/inventory/selectors';
+import { allItemsSelector, itemInfosSelector, storesSelector } from 'app/inventory/selectors';
 import { downloadCsvFiles, importTagsNotesFromCsv } from 'app/inventory/spreadsheets';
 import { DimStore } from 'app/inventory/store-types';
 import { applyLoadout } from 'app/loadout/loadout-apply';
@@ -82,22 +82,20 @@ interface StoreProps {
 
 function mapStateToProps() {
   const itemsSelector = createSelector(
-    storesSelector,
+    allItemsSelector,
     searchFilterSelector,
     (_, props: ProvidedProps) => props.categories,
-    (stores, searchFilter, categories) => {
+    (allItems, searchFilter, categories) => {
       const terminal = Boolean(_.last(categories)?.terminal);
       if (!terminal) {
         return emptyArray<DimItem>();
       }
       const categoryHashes = categories.map((s) => s.itemCategoryHash).filter((h) => h > 0);
-      const items = stores.flatMap((s) =>
-        s.items.filter(
-          (i) =>
-            i.comparable &&
-            categoryHashes.every((h) => i.itemCategoryHashes.includes(h)) &&
-            searchFilter(i)
-        )
+      const items = allItems.filter(
+        (i) =>
+          i.comparable &&
+          categoryHashes.every((h) => i.itemCategoryHashes.includes(h)) &&
+          searchFilter(i)
       );
       return items;
     }

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -1,9 +1,7 @@
 import { t, tl } from 'app/i18next-t';
 import { bulkLockItems, bulkTagItems } from 'app/inventory/bulk-actions';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
-import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
-import { DimStore } from 'app/inventory/store-types';
-import { getAllItems } from 'app/inventory/stores-helpers';
+import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { querySelector } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray, emptySet } from 'app/utils/empty';
@@ -30,7 +28,7 @@ interface ProvidedProps {
 
 interface StoreProps {
   searchQuery: string;
-  stores: DimStore[];
+  allItems: DimItem[];
   buckets?: InventoryBuckets;
   searchFilter: ItemFilter;
 }
@@ -51,7 +49,7 @@ function mapStateToProps(state: RootState): StoreProps {
   return {
     searchQuery: querySelector(state),
     searchFilter: searchFilterSelector(state),
-    stores: storesSelector(state),
+    allItems: allItemsSelector(state),
     buckets: bucketsSelector(state),
   };
 }
@@ -63,7 +61,7 @@ function mapStateToProps(state: RootState): StoreProps {
  */
 function MainSearchBarActions({
   searchQuery,
-  stores,
+  allItems,
   buckets,
   searchFilter,
   bulkTagItems,
@@ -98,12 +96,11 @@ function MainSearchBarActions({
   const filteredItems = useMemo(
     () =>
       !onProgress && displayableBuckets.size
-        ? getAllItems(
-            stores,
+        ? allItems.filter(
             (item: DimItem) => displayableBuckets.has(item.bucket.hash) && searchFilter(item)
           )
         : emptyArray<DimItem>(),
-    [displayableBuckets, onProgress, searchFilter, stores]
+    [displayableBuckets, onProgress, searchFilter, allItems]
   );
 
   let isComparable = false;

--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -20,6 +20,7 @@ export type ItemFilter = (item: DimItem) => ValidFilterOutput;
  */
 export interface FilterContext {
   stores: DimStore[];
+  allItems: DimItem[];
   currentStore: DimStore;
   loadouts: Loadout[];
   inventoryWishListRolls: { [key: string]: InventoryWishListRoll };

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 import { getTag, ItemInfos } from '../inventory/dim-item-info';
 import { DimItem } from '../inventory/item-types';
 import {
+  allItemsSelector,
   currentStoreSelector,
   itemHashTagsSelector,
   itemInfosSelector,
@@ -32,6 +33,7 @@ import { SearchConfig, searchConfigSelector } from './search-config';
 export const searchFiltersConfigSelector = createSelector(
   searchConfigSelector,
   sortedStoresSelector,
+  allItemsSelector,
   currentStoreSelector,
   loadoutsSelector,
   inventoryWishListsSelector,
@@ -52,6 +54,7 @@ export const searchFilterSelector = createSelector(
 function makeSearchFilterFactory(
   { filters }: SearchConfig,
   stores: DimStore[],
+  allItems: DimItem[],
   currentStore: DimStore,
   loadouts: Loadout[],
   inventoryWishListRolls: { [key: string]: InventoryWishListRoll },
@@ -64,6 +67,7 @@ function makeSearchFilterFactory(
 ) {
   const filterContext: FilterContext = {
     stores,
+    allItems,
     currentStore,
     loadouts,
     inventoryWishListRolls,

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -35,8 +35,8 @@ const statFilters: FilterDefinition[] = [
     format: 'query',
     suggestions: searchableArmorStatNames,
     destinyVersion: 2,
-    filter: ({ filterValue, stores }) => {
-      const maxStatLoadout = findMaxStatLoadout(stores, filterValue);
+    filter: ({ filterValue, stores, allItems }) => {
+      const maxStatLoadout = findMaxStatLoadout(stores, allItems, filterValue);
       return (item) => {
         // filterValue stat must exist, and this must be armor
         if (!item.bucket.inArmor || !statHashByName[filterValue]) {
@@ -73,8 +73,8 @@ const statFilters: FilterDefinition[] = [
     keywords: 'maxpower',
     description: tl('Filter.MaxPower'),
     destinyVersion: 2,
-    filter: ({ stores }) => {
-      const maxPowerLoadoutItems = calculateMaxPowerLoadoutItems(stores);
+    filter: ({ stores, allItems }) => {
+      const maxPowerLoadoutItems = calculateMaxPowerLoadoutItems(stores, allItems);
       return (item: DimItem) => maxPowerLoadoutItems.includes(item.id);
     },
   },
@@ -108,10 +108,10 @@ function statFilterFromString(
   };
 }
 
-function findMaxStatLoadout(stores: DimStore[], statName: string) {
+function findMaxStatLoadout(stores: DimStore[], allItems: DimItem[], statName: string) {
   const maxStatHash = statHashByName[statName];
   return stores.flatMap((store) =>
-    maxStatLoadout(maxStatHash, stores, store).items.map((i) => i.id)
+    maxStatLoadout(maxStatHash, allItems, store).items.map((i) => i.id)
   );
 }
 
@@ -171,6 +171,6 @@ function gatherHighestStatsPerSlot(stores: DimStore[]) {
   return maxStatValues;
 }
 
-function calculateMaxPowerLoadoutItems(stores: DimStore[]) {
-  return stores.flatMap((store) => maxLightItemSet(stores, store).equippable.map((i) => i.id));
+function calculateMaxPowerLoadoutItems(stores: DimStore[], allItems: DimItem[]) {
+  return stores.flatMap((store) => maxLightItemSet(allItems, store).equippable.map((i) => i.id));
 }

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -1,4 +1,4 @@
-import { storesSelector } from 'app/inventory/selectors';
+import { allItemsSelector } from 'app/inventory/selectors';
 import { RootState } from 'app/store/types';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
@@ -17,7 +17,7 @@ export const wishListsEnabledSelector = (state: RootState) =>
   (wishListsSelector(state)?.wishListAndInfo?.wishListRolls?.length || 0) > 0;
 
 export const inventoryWishListsSelector = createSelector(
-  storesSelector,
+  allItemsSelector,
   wishListsByHashSelector,
   getInventoryWishListRolls
 );

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -1,7 +1,6 @@
 import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { DimItem, DimPlug } from '../inventory/item-types';
-import { DimStore } from '../inventory/store-types';
 import { DimWishList, WishListRoll } from './types';
 
 export const enum UiWishListRoll {
@@ -37,14 +36,14 @@ let inventoryRolls: { [key: string]: InventoryWishListRoll } = {};
 
 /** Get InventoryWishListRolls for every item in the stores. */
 export function getInventoryWishListRolls(
-  stores: DimStore[],
+  allItems: DimItem[],
   rollsByHash: { [itemHash: number]: WishListRoll[] }
 ): { [key: string]: InventoryWishListRoll } {
   if (
     !$featureFlags.wishLists ||
     _.isEmpty(rollsByHash) ||
-    !stores.length ||
-    stores[0].destinyVersion === 1
+    !allItems.length ||
+    allItems[0].destinyVersion === 1
   ) {
     return {};
   }
@@ -55,15 +54,13 @@ export function getInventoryWishListRolls(
     inventoryRolls = {};
   }
 
-  for (const store of stores) {
-    for (const item of store.items) {
-      if (item.sockets && !seenItemIds.has(item.id)) {
-        const wishListRoll = getInventoryWishListRoll(item, rollsByHash);
-        if (wishListRoll) {
-          inventoryRolls[item.id] = wishListRoll;
-        }
-        seenItemIds.add(item.id);
+  for (const item of allItems) {
+    if (item.sockets && !seenItemIds.has(item.id)) {
+      const wishListRoll = getInventoryWishListRoll(item, rollsByHash);
+      if (wishListRoll) {
+        inventoryRolls[item.id] = wishListRoll;
       }
+      seenItemIds.add(item.id);
     }
   }
 


### PR DESCRIPTION
I'm starting to blaze a trail to not having items hanging off stores anymore, so that we can have more granular updates for inventory state. Step one is to introduce some new redux selectors to take over for where we were iterating through all items.