### PR TITLE
Fix item source in organizer, spreadsheets

### DIFF
--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -277,7 +277,7 @@ function equippable(item: DimItem) {
 }
 
 export function source(item: DimItem) {
-  if (item.source) {
+  if (item.destinyVersion === 2) {
     return (
       sourceKeys.find(
         (src) =>


### PR DESCRIPTION
Fixes #5851. I had misread the code and thought it all used `source`, when a lot of it just uses `hash`.