### PR TITLE
Encode category selection and search query into Organizer URL

### DIFF
--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -23,7 +23,7 @@ import sniperRifle from 'destiny-icons/weapons/sniper_rifle.svg';
 import sword from 'destiny-icons/weapons/sword_heavy.svg';
 import lFusionRifle from 'destiny-icons/weapons/wire_rifle.svg';
 import _ from 'lodash';
-import React, { useMemo } from 'react';
+import React from 'react';
 import legs from '../../../destiny-icons/armor_types/boots.svg';
 import chest from '../../../destiny-icons/armor_types/chest.svg';
 import classItem from '../../../destiny-icons/armor_types/class.svg';
@@ -60,7 +60,7 @@ const armorHashes = {
  * Generate a tree of all the drilldown options for item filtering. This tree is
  * used to generate the list of selected subcategories.
  */
-export const getD2SelectionTree = (defs: D2ManifestDefinitions): ItemCategoryTreeNode => {
+const getD2SelectionTree = (defs: D2ManifestDefinitions): ItemCategoryTreeNode => {
   const armorCategory = defs.ItemCategory.get(ItemCategoryHashes.Armor);
 
   // Each class has the same armor
@@ -248,7 +248,7 @@ export const getD2SelectionTree = (defs: D2ManifestDefinitions): ItemCategoryTre
  * Generate a tree of all the drilldown options for item filtering. This tree is
  * used to generate the list of selected subcategories.
  */
-export const getD1SelectionTree = (): ItemCategoryTreeNode => {
+const getD1SelectionTree = (): ItemCategoryTreeNode => {
   // Each class has the same armor
   const armorCategories = [
     {
@@ -400,24 +400,26 @@ export const getD1SelectionTree = (): ItemCategoryTreeNode => {
   };
 };
 
+export function getSelectionTree(defs: D2ManifestDefinitions | D1ManifestDefinitions) {
+  return defs.isDestiny2() ? getD2SelectionTree(defs) : getD1SelectionTree();
+}
+
 /**
  * This component offers a means for narrowing down your selection to a single item type
  * (hunter helmets, hand cannons, etc.) for the Organizer table.
  */
 export default function ItemTypeSelector({
   defs,
+  selectionTree,
   selection,
   onSelection,
 }: {
   defs: D2ManifestDefinitions | D1ManifestDefinitions;
+  selectionTree: ItemCategoryTreeNode;
   selection: ItemCategoryTreeNode[];
   onSelection(selection: ItemCategoryTreeNode[]): void;
 }) {
-  const types = useMemo(
-    () => (defs.isDestiny2() ? getD2SelectionTree(defs) : getD1SelectionTree()),
-    [defs]
-  );
-  selection = selection.length ? selection : [types];
+  selection = selection.length ? selection : [selectionTree];
 
   const handleSelection = (depth: number, subCategory: ItemCategoryTreeNode) =>
     onSelection([..._.take(selection, depth + 1), subCategory]);

--- a/src/app/shell/AccountRedirectRoute.tsx
+++ b/src/app/shell/AccountRedirectRoute.tsx
@@ -5,7 +5,7 @@ import { t } from 'app/i18next-t';
 import { RootState } from 'app/store/types';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Redirect, useRouteMatch } from 'react-router';
+import { Redirect, useLocation, useRouteMatch } from 'react-router';
 import ErrorPanel from './ErrorPanel';
 
 /**
@@ -28,6 +28,7 @@ export default function AccountRedirectRoute() {
   }, [dispatch, accountsLoaded]);
 
   const { path } = useRouteMatch();
+  const { search } = useLocation();
 
   if (!account) {
     return accountsLoaded ? (
@@ -61,5 +62,5 @@ export default function AccountRedirectRoute() {
     );
   }
 
-  return <Redirect to={`/${account.membershipId}/d${account.destinyVersion}${path}`} />;
+  return <Redirect to={`/${account.membershipId}/d${account.destinyVersion}${path}${search}`} />;
 }

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -56,7 +56,7 @@ export const shell: Reducer<ShellState, ShellAction> = (
 
       return {
         ...state,
-        searchQuery: newQuery.replace(/\s+/, ' '),
+        searchQuery: newQuery.replace(/\s+/, ' ').trim(),
         searchQueryVersion: state.searchQueryVersion + 1,
       };
     }


### PR DESCRIPTION
This adds the currently selected category and search query from the Organizer to its URL as query parameters. I'm using `history.replace` so this does not add history entries, because I thought it might be annoying, but it might be nice to be able to go back.

This has two benefits. The immediate one is that if you reload the page, you don't lose your selection. The second is that we can now link to a specific view (from Compare, or from a search). We can also generate account-independent "share" URLs if we want to, though I'm not sure yet how we'd intend for that to be used.

<img width="547" alt="Screen Shot 2020-09-22 at 9 26 10 PM" src="https://user-images.githubusercontent.com/313208/93966740-4c577b00-fd1a-11ea-88a3-9bca68684807.png">
