### PR TITLE
Fetch fewer profile api components for inventory first load

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -62,9 +62,11 @@ export async function getLinkedAccounts(
 /**
  * Get the user's stores on this platform. This includes characters, vault, and item information.
  */
-export function getStores(platform: DestinyAccount): Promise<DestinyProfileResponse> {
-  return getProfile(
-    platform,
+export function getStores(
+  platform: DestinyAccount,
+  components?: DestinyComponentType[]
+): Promise<DestinyProfileResponse> {
+  const defaultComponents = [
     DestinyComponentType.Profiles,
     DestinyComponentType.ProfileInventories,
     DestinyComponentType.ProfileCurrencies,
@@ -86,8 +88,10 @@ export function getStores(platform: DestinyAccount): Promise<DestinyProfileRespo
     DestinyComponentType.ItemPlugObjectives,
     // TODO: we should defer this unless you're on the collections screen
     DestinyComponentType.Records,
-    DestinyComponentType.Metrics
-  );
+    DestinyComponentType.Metrics,
+  ];
+
+  return getProfile(platform, ...(components || defaultComponents));
 }
 
 /**

--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -6,6 +6,7 @@ import DragPerformanceFix from 'app/inventory/DragPerformanceFix';
 import MobileInspect from 'app/mobile-inspect/MobileInspect';
 import { isPhonePortraitSelector } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
+import { DestinyComponentType } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { connect } from 'react-redux';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -37,8 +38,17 @@ function mapStateToProps(state: RootState): StoreProps {
   };
 }
 
+const components = [
+  DestinyComponentType.ProfileInventories,
+  DestinyComponentType.ProfileCurrencies,
+  DestinyComponentType.Characters,
+  DestinyComponentType.CharacterInventories,
+  DestinyComponentType.CharacterEquipment,
+  DestinyComponentType.ItemInstances,
+];
+
 function Inventory({ storesLoaded, account, isPhonePortrait }: Props) {
-  useLoadStores(account, storesLoaded);
+  useLoadStores(account, storesLoaded, components);
 
   if (!storesLoaded) {
     return <ShowPageLoading message={t('Loading.Profile')} />;

--- a/src/app/inventory/store/hooks.ts
+++ b/src/app/inventory/store/hooks.ts
@@ -2,6 +2,7 @@ import { DestinyAccount } from 'app/accounts/destiny-account';
 import { refresh$ } from 'app/shell/refresh';
 import { ThunkDispatchProp } from 'app/store/types';
 import { useSubscription } from 'app/utils/hooks';
+import { DestinyComponentType } from 'bungie-api-ts/destiny2';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { queueAction } from '../action-queue';
@@ -15,18 +16,22 @@ import { loadStores as d2LoadStores } from '../d2-stores';
  * in the same component. useDispatch() is cheap because it just listens to a
  * context that never changes.
  */
-export function useLoadStores(account: DestinyAccount | undefined, loaded: boolean) {
+export function useLoadStores(
+  account: DestinyAccount | undefined,
+  loaded: boolean,
+  components?: DestinyComponentType[]
+) {
   const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
 
   useEffect(() => {
     if (account && !loaded) {
       if (account?.destinyVersion == 2) {
-        dispatch(d2LoadStores());
+        dispatch(d2LoadStores(components));
       } else {
         dispatch(d1LoadStores());
       }
     }
-  }, [account, dispatch, loaded]);
+  }, [account, dispatch, components, loaded]);
 
   useSubscription(() =>
     refresh$.subscribe(() => {


### PR DESCRIPTION
Another PoC for stripping down the components in the `getStores` call #5689 / #5735

Tried to keep changes pretty minimal, only set it up for the inventory screen for now