### PR TITLE
Follow up mobile ui

### DIFF
--- a/src/app/dim-ui/CollapsibleTitle.scss
+++ b/src/app/dim-ui/CollapsibleTitle.scss
@@ -40,7 +40,7 @@
   }
 
   .gradientBackground & {
-    background-color: rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, 0.1);
     &:hover,
     &.collapsed {
       background-color: rgba(0, 0, 0, 0.4);

--- a/src/app/dim-ui/CollapsibleTitle.scss
+++ b/src/app/dim-ui/CollapsibleTitle.scss
@@ -40,7 +40,7 @@
   }
 
   .gradientBackground & {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(0, 0, 0, 0.2);
     &:hover,
     &.collapsed {
       background-color: rgba(0, 0, 0, 0.4);

--- a/src/app/inventory/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory/InventoryCollapsibleTitle.scss
@@ -57,3 +57,13 @@
     background-color: rgba(151, 4, 1, 0.75) !important;
   }
 }
+
+@include phone-portrait {
+  .inventory-content .title.postmaster {
+    // TODO clean this up after we remove background colors based on emblem
+    background-color: #222 !important;
+    padding-top: 0;
+    min-height: 34px;
+    opacity: 0.8;
+  }
+}

--- a/src/app/inventory/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory/InventoryCollapsibleTitle.scss
@@ -61,7 +61,7 @@
 @include phone-portrait {
   .inventory-content .title.postmaster {
     // TODO clean this up after we remove background colors based on emblem
-    background-color: #222 !important;
+    background-color: none !important;
     padding-top: 0;
     min-height: 34px;
     opacity: 0.8;

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -86,6 +86,7 @@ function InventoryCollapsibleTitle({
                 collapsed,
                 vault: store.isVault,
                 postmasterFull: showPostmasterFull,
+                postmaster: checkPostmaster,
               })}
               style={storeBackgroundColor(store, index)}
             >

--- a/src/app/inventory/StoreBuckets.tsx
+++ b/src/app/inventory/StoreBuckets.tsx
@@ -16,11 +16,13 @@ export function StoreBuckets({
   vault,
   currentStore,
   labels,
+  isPhonePortrait,
 }: {
   bucket: InventoryBucket;
   stores: DimStore[];
   vault: DimStore;
   currentStore: DimStore;
+  isPhonePortrait?: boolean;
   labels?: boolean;
 }) {
   let content: React.ReactNode;
@@ -61,7 +63,7 @@ export function StoreBuckets({
             store.destinyVersion === 2 &&
             postmasterAlmostFull(store),
         })}
-        style={storeBackgroundColor(store, index, false, labels)}
+        style={storeBackgroundColor(store, index, false, isPhonePortrait)}
       >
         {(!store.isVault || bucket.vaultBucket) && <StoreBucket bucket={bucket} store={store} />}
         {bucket.type === 'LostItems' &&

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -47,9 +47,9 @@
 
     .bucket-label {
       opacity: 0.8;
-      margin: 0px 0 5px;
+      margin: 0;
       z-index: inherit;
-      // background: none; // uncomment to remove transparent background
+      background: none; // comment out to add background background
 
       a {
         text-decoration: none;

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -222,7 +222,12 @@ function CollapsibleContainer({
   currentStore,
   inventoryBucket,
   vault,
-}: { category: string; inventoryBucket: InventoryBucket[] } & InventoryContainerProps) {
+  isPhonePortrait,
+}: {
+  category: string;
+  inventoryBucket: InventoryBucket[];
+  isPhonePortrait?: boolean;
+} & InventoryContainerProps) {
   if (!categoryHasItems(buckets, category, stores, currentStore)) {
     return null;
   }
@@ -243,6 +248,7 @@ function CollapsibleContainer({
           stores={stores}
           vault={vault}
           currentStore={currentStore}
+          isPhonePortrait={isPhonePortrait}
         />
       ))}
     </InventoryCollapsibleTitle>
@@ -255,16 +261,19 @@ function StoresInventory(props: InventoryContainerProps) {
   if (selectedCategoryId) {
     return (
       <>
-        <CollapsibleContainer
-          {...props}
-          buckets={buckets}
-          category={'Postmaster'}
-          inventoryBucket={buckets.byCategory['Postmaster']}
-        />
         {$featureFlags.unstickyStats && selectedCategoryId === 'Armor' && (
           <StoreStats
             store={currentStore}
-            style={{ ...storeBackgroundColor(currentStore, 0, true), paddingBottom: 8 }}
+            style={{ ...storeBackgroundColor(currentStore, 0, true, true), paddingBottom: 8 }}
+          />
+        )}
+        {selectedCategoryId === 'Inventory' && (
+          <CollapsibleContainer
+            {...props}
+            buckets={buckets}
+            category={'Postmaster'}
+            inventoryBucket={buckets.byCategory['Postmaster']}
+            isPhonePortrait={true}
           />
         )}
         {buckets.byCategory[selectedCategoryId].map((bucket) => (
@@ -275,6 +284,7 @@ function StoresInventory(props: InventoryContainerProps) {
             vault={vault}
             currentStore={currentStore}
             labels={true}
+            isPhonePortrait={true}
           />
         ))}
       </>


### PR DESCRIPTION
- remove postmaster background
- style the postmaster collapsible header same as others
- armor stats above postmaster (though postmaster is now just on inventory again)
- removed header background color (shown in weapon and purple columns below)

|Weapon|Armor|Inventory|Purple|
|---|---|---|---|
|<img width="424" alt="Screen Shot 2020-09-23 at 8 07 01 PM" src="https://user-images.githubusercontent.com/424158/94096241-74a5af00-fdd8-11ea-825c-ae5d0063a609.png">|<img width="420" alt="Screen Shot 2020-09-23 at 7 56 39 PM" src="https://user-images.githubusercontent.com/424158/94095686-1b894b80-fdd7-11ea-87ec-626aaa6e4141.png">|<img width="421" alt="Screen Shot 2020-09-23 at 7 56 23 PM" src="https://user-images.githubusercontent.com/424158/94095698-217f2c80-fdd7-11ea-9f8e-7f535d3f8108.png">|<img width="420" alt="Screen Shot 2020-09-23 at 8 06 45 PM" src="https://user-images.githubusercontent.com/424158/94096255-7bccbd00-fdd8-11ea-8424-4571e45929ff.png">|
