### PR TITLE
Improve header responsiveness

### DIFF
--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -20,7 +20,7 @@
   padding-right: 5px;
   height: 32px;
   border-radius: 4px;
-  min-width: 275px;
+  min-width: 350px;
   ::placeholder {
     color: #999;
   }

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -199,7 +199,7 @@ body {
     @include phone-portrait {
       display: none;
     }
-    @media (max-width: 700px) {
+    @media (max-width: 1080px) {
       display: none;
     }
 


### PR DESCRIPTION
@inexorableAce not sure which values are best, but this tries to prevent the search bar from being crushed as much, and hides the header links right at the point where "Progress" would fall off.