### PR TITLE
Record GA page views for infuse, compare

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -102,7 +102,10 @@ class Compare extends React.Component<Props, State> {
     this.subscriptions.add(
       CompareService.compareItems$.subscribe((args) => {
         this.setState({ show: true });
-        CompareService.dialogOpen = true;
+        if (CompareService.dialogOpen == false) {
+          CompareService.dialogOpen = true;
+          ga('send', 'pageview', '/profileMembershipId/compare');
+        }
 
         this.add(args);
       })

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -166,6 +166,10 @@ function InfusionFinder({
   const onQueryChanged = (filter: string) => stateDispatch({ type: 'setFilter', filter });
   const switchDirection = () => stateDispatch({ type: 'swapDirection' });
 
+  useEffect(() => {
+    ga('send', 'pageview', '/profileMembershipId/infuse');
+  }, []);
+
   // Listen for items coming in via showInfuse#
   useSubscription(() =>
     showInfuse$.subscribe(({ item }) => {


### PR DESCRIPTION
This collects page view metrics for the Infusion Fuel Finder and Compare screens, as if they were separate pages that people visited. I'm a bit worried we'll go over our GA budget, but I really want to know how often these are used.