### PR TITLE
Always show compare on mobile

### DIFF
--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -138,6 +138,7 @@ function ItemPopupContainer({
       language={language}
       expanded={isPhonePortrait || itemDetails || $featureFlags.newItemPopupActions}
       showToggle={!isPhonePortrait}
+      isPhonePortrait={isPhonePortrait}
       onToggleExpanded={toggleItemDetails}
     />
   );

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -22,12 +22,14 @@ export default function ItemPopupHeader({
   expanded,
   showToggle,
   language,
+  isPhonePortrait,
   onToggleExpanded,
 }: {
   item: DimItem;
   expanded: boolean;
   showToggle: boolean;
   language: string;
+  isPhonePortrait: boolean;
   onToggleExpanded(): void;
 }) {
   const hasLeftIcon = item.trackable || item.lockable || item.element;
@@ -70,7 +72,7 @@ export default function ItemPopupHeader({
             {item.name}
           </ExternalLink>
         </div>
-        {!$featureFlags.newItemPopupActions && item.comparable && (
+        {(isPhonePortrait || !$featureFlags.newItemPopupActions) && item.comparable && (
           <a className="compare-button info" title={t('Compare.ButtonHelp')} onClick={openCompare}>
             <AppIcon icon={faClone} />
           </a>


### PR DESCRIPTION
When the new featureFlag is turned on, it hides the compare button. Because we haven't added the compare button to the mobile action bar, this PR will just show the compare button in the old spot for mobile sheets