### PR TITLE
Prevent notification toasts from obscuring search dropdowns

### DIFF
--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -25,7 +25,7 @@ body {
 #header {
   padding: 0 0 0 2px;
   position: fixed;
-  z-index: 15;
+  z-index: 1001;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
Raise the header's zIndex so search dropdowns arent obscured by the notification toasts.

Not ideal, but its better than the current behaviour which regressed when the native browser select was dropped.

I made this change from the github interface, so I've barely tested this apart from a few smoke tests from making the change in my inspector.