### PR TITLE
Fix masterwork stats not showing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * The tag and compare button on the search bar have been replaced with a dropdown menu (three dots) with a lot more options for things you can do with the items that match your search.
 * On mobile, your equipped emblem no longer affects the color of your screen.
 * Loadout Optimizer has a nicer layout on mobile and narrower screens.
+* Fix some masterwork stats not showing.
 
 ### Beta Only
 

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -28,82 +28,50 @@ export function buildMasterwork(
     return null;
   }
 
-  let masterworkInfo: DimMasterwork | null = null;
-
-  // Pre-Forsaken Masterwork
-  if (createdItem.masterwork) {
-    masterworkInfo = buildMasterworkInfo(createdItem.sockets, defs);
-  }
-
-  // Forsaken Masterwork
-  if (!masterworkInfo) {
-    masterworkInfo = buildForsakenMasterworkStats(createdItem, defs);
-  }
-
-  return masterworkInfo;
-}
-
-function buildForsakenMasterworkStats(
-  createdItem: DimItem,
-  defs: D2ManifestDefinitions
-): DimMasterwork | null {
-  const masterworkSocket = createdItem.sockets!.allSockets.find((socket) =>
-    Boolean(
-      socket.plugged?.plugDef.plug &&
-        (socket.plugged.plugDef.plug.plugCategoryIdentifier.includes('masterworks.stat') ||
-          socket.plugged.plugDef.plug.plugCategoryIdentifier.endsWith('_masterwork'))
-    )
-  );
-  if (masterworkSocket?.plugged?.plugDef.investmentStats.length) {
-    const masterwork = masterworkSocket.plugged.plugDef.investmentStats[0];
-    if (!createdItem.element && createdItem.bucket?.sort === 'Armor') {
-      createdItem.element =
-        Object.values(defs.DamageType).find(
-          (damageType) => damageType.enumValue === resistanceMods[masterwork.statTypeHash]
-        ) ?? null;
-    }
-
-    return {
-      tier: masterwork.value,
-      stats: [
-        {
-          hash: masterwork.statTypeHash,
-          name: defs.Stat.get(masterwork.statTypeHash).displayProperties.name,
-          value: masterworkSocket.plugged.stats?.[masterwork.statTypeHash] || 0,
-        },
-      ],
-    };
-  }
-  return null;
+  return buildMasterworkInfo(createdItem, createdItem.sockets, defs);
 }
 
 /**
- * Pre-Forsaken weapons store their masterwork info on an objective of a plug.
+ * Figure out what tier the masterwork is at, if any, and what stats are affected.
  */
 function buildMasterworkInfo(
+  createdItem: DimItem,
   sockets: DimSockets,
   defs: D2ManifestDefinitions
 ): DimMasterwork | null {
-  const socket = sockets.allSockets.find((socket) =>
-    Boolean(socket.plugged?.plugObjectives.length)
+  const socket = sockets.allSockets.find(
+    (socket) =>
+      socket?.plugged?.plugDef.plug &&
+      (socket.plugged.plugDef.plug.uiPlugLabel === 'masterwork' ||
+        socket.plugged.plugDef.plug.plugCategoryIdentifier.includes('masterworks.stat') ||
+        socket.plugged.plugDef.plug.plugCategoryIdentifier.endsWith('_masterwork'))
   );
-  if (!socket?.plugged?.plugObjectives?.length) {
+  if (!socket || !socket.plugged) {
     return null;
   }
-  const plugObjective = socket.plugged.plugObjectives[0];
   const investmentStats = socket.plugged.plugDef.investmentStats;
-  const objectiveDef = defs.Objective.get(plugObjective.objectiveHash);
 
-  if (!investmentStats?.length || !objectiveDef) {
+  if (!investmentStats?.length) {
     return null;
   }
 
-  const stats = investmentStats.map((stat) => ({
-    hash: stat.statTypeHash,
-    name: defs.Stat.get(stat.statTypeHash).displayProperties.name,
-    value: socket.plugged?.stats?.[stat.statTypeHash] || 0,
-  }));
+  const stats: DimMasterwork['stats'] = [];
 
+  for (const stat of investmentStats) {
+    if (!createdItem.element && createdItem.bucket?.sort === 'Armor') {
+      createdItem.element =
+        Object.values(defs.DamageType).find(
+          (damageType) => damageType.enumValue === resistanceMods[stat.statTypeHash]
+        ) ?? null;
+    }
+    stats.push({
+      hash: stat.statTypeHash,
+      name: defs.Stat.get(stat.statTypeHash).displayProperties.name,
+      value: socket.plugged?.stats?.[stat.statTypeHash] || 0,
+    });
+  }
+
+  // TODO: Tier is wrong. We need a table of masterwork mods from d2ai
   return {
     tier: socket.plugged?.plugDef.investmentStats[0].value,
     stats,


### PR DESCRIPTION
Fixes #5868. Also replaces our weird two masterwork functions with just one - the secret was not gating on `createdItem.masterwork`.

@delphiactual I noticed another thing, which is that we use the first modified stat as the "masterwork tier" but that isn't always correct - for example Trinity Ghoul is tier 30 because it gives a +30 to charge time. The only way I can think to fix this is to build a table of masterwork mod to tier number in D2AI based on their English titles.