### PR TITLE
Move more buttons into the sidecar menu

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -633,7 +633,7 @@
     "Rewards": "Rewards:",
     "SendToVault": "Send to Vault",
     "Split": "Split",
-    "Store": "Move",
+    "Store": "Store",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
       "Consumable": "{{classType}} {{typeName}}",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -633,7 +633,7 @@
     "Rewards": "Rewards:",
     "SendToVault": "Send to Vault",
     "Split": "Split",
-    "Store": "Store",
+    "Store": "Move",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
       "Consumable": "{{classType}} {{typeName}}",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -605,6 +605,7 @@
   "MovePopup": {
     "Acquired": "This item is unlocked in collections.",
     "AcquiredMod": "This mod is currently applied to an item in your inventory.",
+    "AddToLoadout": "Loadout",
     "AddNote": "Add a note",
     "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "Consolidate": "Consolidate",
@@ -617,7 +618,9 @@
     "ItemDetailSheet": "Open item details",
     "LockUnlock": {
       "Lock": "Lock {{itemType}}",
-      "Unlock": "Unlock {{itemType}}"
+      "Unlock": "Unlock {{itemType}}",
+      "Locked": "Locked",
+      "Unlocked": "Unlocked"
     },
     "MissingSockets": "Perk and mod details are unavailable while Bungie is updating their services. It will return when they are done, usually in a few hours.",
     "Notes": "Notes:",
@@ -640,7 +643,9 @@
     "Take": "Take",
     "TrackUntrack": {
       "Track": "Track {{itemType}}",
-      "Untrack": "Untrack {{itemType}}"
+      "Untrack": "Untrack {{itemType}}",
+      "Tracked": "Tracked",
+      "Untracked": "Untracked"
     },
     "TriageTab": "Triage",
     "Vault": "Vault"

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -93,3 +93,17 @@
   cursor: default;
   pointer-events: none;
 }
+
+.move,
+.equip {
+  padding-bottom: 6px;
+  padding-top: 6px;
+}
+
+.move {
+  margin-top: 6px;
+}
+
+.equip {
+  margin-bottom: 6px;
+}

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -4,33 +4,78 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background-color: black;
+  background-color: #161626;
+
+  :global(.item-tag-selector) {
+    color: white;
+    background: rgba(255, 255, 255, 0.2);
+    border: none;
+    outline: none;
+    font-size: 12px;
+
+    option {
+      color: white;
+      background: black;
+    }
+  }
 }
 
-.actionButton {
+.entry {
   display: flex;
   flex-direction: row;
   align-items: center;
-  text-transform: uppercase;
-  padding: 8px;
-  font-weight: bold;
-  cursor: pointer;
+  padding: 12px;
 
   img,
-  :global(.app-icon) {
+  :global(.app-icon),
+  .null {
+    display: block;
     margin-right: 8px;
-    height: 24px;
-    width: 24px;
-    font-size: 24px;
+    height: 16px;
+    width: 16px;
+    font-size: 16px;
+    text-align: center;
   }
   :global(.app-icon) {
     color: #eee;
   }
+
+  .classIcon {
+    filter: invert(1);
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+  }
+}
+
+.itemTagSelector {
+  composes: entry;
+  padding-top: 12px;
+  padding-bottom: 6px;
+
+  :global(.app-icon) {
+    margin-top: 1px;
+  }
+}
+
+.actionButton {
+  composes: entry;
+  cursor: pointer;
+
   &:hover {
     background: $orange;
     color: black;
     :global(.app-icon) {
       color: black;
     }
+    .classIcon {
+      filter: none;
+    }
   }
+}
+
+.disabled {
+  opacity: 0.3;
+  cursor: default;
+  pointer-events: none;
 }

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -58,6 +58,20 @@
   }
 }
 
+.null {
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  &::before {
+    content: '';
+    display: block;
+    height: 6px;
+    width: 6px;
+    border-radius: 3px;
+    background-color: white;
+  }
+}
+
 .actionButton {
   composes: entry;
   cursor: pointer;

--- a/src/app/item-popup/DesktopItemActions.m.scss.d.ts
+++ b/src/app/item-popup/DesktopItemActions.m.scss.d.ts
@@ -2,7 +2,12 @@
 // Please do not change this file!
 interface CssExports {
   'actionButton': string;
+  'classIcon': string;
+  'disabled': string;
+  'entry': string;
   'interaction': string;
+  'itemTagSelector': string;
+  'null': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/item-popup/DesktopItemActions.m.scss.d.ts
+++ b/src/app/item-popup/DesktopItemActions.m.scss.d.ts
@@ -5,8 +5,10 @@ interface CssExports {
   'classIcon': string;
   'disabled': string;
   'entry': string;
+  'equip': string;
   'interaction': string;
   'itemTagSelector': string;
+  'move': string;
   'null': string;
 }
 export const cssExports: CssExports;

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -1,9 +1,17 @@
 import { CompareService } from 'app/compare/compare.service';
 import { t } from 'app/i18next-t';
+import { getTag } from 'app/inventory/dim-item-info';
 import { amountOfItem, getStore } from 'app/inventory/stores-helpers';
-import { AppIcon, faClone } from 'app/shell/icons';
-import { ThunkDispatchProp } from 'app/store/types';
-import { itemCanBeEquippedBy } from 'app/utils/item-utils';
+import TagIcon from 'app/inventory/TagIcon';
+import { addItemToLoadout } from 'app/loadout/LoadoutDrawer';
+import { addIcon, AppIcon, faClone } from 'app/shell/icons';
+import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
+import clsx from 'clsx';
+import hunter from 'destiny-icons/general/class_hunter.svg';
+import titan from 'destiny-icons/general/class_titan.svg';
+import warlock from 'destiny-icons/general/class_warlock.svg';
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import arrowsIn from '../../images/arrows-in.png';
@@ -12,18 +20,33 @@ import d2Infuse from '../../images/d2infuse.png';
 import { showInfuse } from '../infuse/infuse';
 import { DimItem } from '../inventory/item-types';
 import { consolidate, distribute, moveItemTo } from '../inventory/move-item';
-import { sortedStoresSelector } from '../inventory/selectors';
+import {
+  itemHashTagsSelector,
+  itemInfosSelector,
+  sortedStoresSelector,
+} from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
 import styles from './DesktopItemActions.m.scss';
 import { hideItemPopup } from './item-popup';
 import ItemMoveAmount from './ItemMoveAmount';
 import { canShowStore, canShowVault } from './ItemMoveLocation';
+import ItemTagSelector from './ItemTagSelector';
+import LockButton from './LockButton';
+
+const classIcons = {
+  [DestinyClass.Hunter]: hunter,
+  [DestinyClass.Warlock]: warlock,
+  [DestinyClass.Titan]: titan,
+} as const;
 
 export default function DesktopItemActions({ item }: { item: DimItem }) {
   const [amount, setAmount] = useState(item.amount);
   const stores = useSelector(sortedStoresSelector);
   const itemOwner = getStore(stores, item.owner);
   const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const itemTag = useSelector((state: RootState) =>
+    getTag(item, itemInfosSelector(state), itemHashTagsSelector(state))
+  );
 
   // If the item can't be transferred (or is unique) don't show the move amount slider
   const maximum = useMemo(
@@ -108,6 +131,11 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
     CompareService.addItemsToCompare([item], true);
   };
 
+  const addToLoadout = (e) => {
+    hideItemPopup();
+    addItemToLoadout(item, e);
+  };
+
   return (
     <>
       <div className={styles.interaction} ref={containerRef}>
@@ -119,6 +147,21 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
             onAmountChanged={onAmountChanged}
           />
         )}
+        {item.taggable && (
+          <div className={styles.itemTagSelector}>
+            {itemTag ? <TagIcon tag={itemTag} /> : <div className={styles.null} />}
+            <ItemTagSelector item={item} />
+          </div>
+        )}
+        {(item.lockable || item.trackable) && (
+          <LockButton
+            className={styles.actionButton}
+            item={item}
+            type={item.lockable ? 'lock' : 'track'}
+          >
+            {lockButtonTitle(item, item.lockable ? 'lock' : 'track')}
+          </LockButton>
+        )}
         {stores.map((store) => (
           <React.Fragment key={store.id}>
             {canShowVault(store, itemOwner, item) && (
@@ -128,63 +171,32 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                 role="button"
                 tabIndex={-1}
               >
-                <img
-                  src={store.icon}
-                  height="32"
-                  width="32"
-                  style={{
-                    backgroundColor: store.color
-                      ? `rgb(${Math.round(store.color.red)}, ${Math.round(
-                          store.color.green
-                        )}, ${Math.round(store.color.blue)}`
-                      : 'black',
-                  }}
-                />{' '}
+                <StoreIcon store={store} />
                 {t('MovePopup.Vault')}
               </div>
             )}
-            {!(item.owner === store.id && item.equipped) && itemCanBeEquippedBy(item, store) && (
+            {itemCanBeEquippedBy(item, store) && (
               <div
-                className={styles.actionButton}
+                className={clsx(styles.actionButton, {
+                  [styles.disabled]: item.owner === store.id && item.equipped,
+                })}
                 onClick={() => onMoveItemTo(store, true)}
                 role="button"
                 tabIndex={-1}
               >
-                <img
-                  src={store.icon}
-                  height="32"
-                  width="32"
-                  style={{
-                    backgroundColor: store.color
-                      ? `rgb(${Math.round(store.color.red)}, ${Math.round(
-                          store.color.green
-                        )}, ${Math.round(store.color.blue)}`
-                      : 'black',
-                  }}
-                />{' '}
-                {t('MovePopup.Equip')}
+                <StoreIcon store={store} /> {t('MovePopup.Equip')}
               </div>
             )}
             {canShowStore(store, itemOwner, item) && (
               <div
-                className={styles.actionButton}
+                className={clsx(styles.actionButton, {
+                  [styles.disabled]: item.owner === store.id && !item.equipped,
+                })}
                 onClick={() => onMoveItemTo(store)}
                 role="button"
                 tabIndex={-1}
               >
-                <img
-                  src={store.icon}
-                  height="32"
-                  width="32"
-                  style={{
-                    backgroundColor: store.color
-                      ? `rgb(${Math.round(store.color.red)}, ${Math.round(
-                          store.color.green
-                        )}, ${Math.round(store.color.blue)}`
-                      : 'black',
-                  }}
-                />{' '}
-                {t('MovePopup.Store')}
+                <StoreIcon store={store} /> {t('MovePopup.Store')}
               </div>
             )}
           </React.Fragment>
@@ -204,6 +216,11 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
             <img src={arrowsOut} height="32" width="32" /> {t('MovePopup.DistributeEvenly')}
           </div>
         )}
+        {itemCanBeInLoadout(item) && (
+          <div className={styles.actionButton} onClick={addToLoadout} role="button" tabIndex={-1}>
+            <AppIcon icon={addIcon} /> {t('MovePopup.AddToLoadout')}
+          </div>
+        )}
         {item.infusionFuel && (
           <div className={styles.actionButton} onClick={infuse} role="button" tabIndex={-1}>
             <img src={d2Infuse} height="32" width="32" /> {t('MovePopup.Infuse')}
@@ -212,4 +229,34 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
       </div>
     </>
   );
+}
+
+function StoreIcon({ store }: { store: DimStore }) {
+  return (
+    <>
+      <img
+        src={store.icon}
+        height="32"
+        width="32"
+        style={{
+          backgroundColor: store.color
+            ? `rgb(${Math.round(store.color.red)}, ${Math.round(store.color.green)}, ${Math.round(
+                store.color.blue
+              )}`
+            : 'black',
+        }}
+      />
+      {!store.isVault && <img src={classIcons[store.classType]} className={styles.classIcon} />}
+    </>
+  );
+}
+
+export function lockButtonTitle(item: DimItem, type: 'lock' | 'track') {
+  return type === 'lock'
+    ? item.locked
+      ? t('MovePopup.LockUnlock.Locked')
+      : t('MovePopup.LockUnlock.Unlocked')
+    : item.tracked
+    ? t('MovePopup.TrackUntrack.Tracked')
+    : t('MovePopup.TrackUntrack.Untracked');
 }

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -175,19 +175,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                 {t('MovePopup.Vault')}
               </div>
             )}
-            {itemCanBeEquippedBy(item, store) && (
-              <div
-                className={clsx(styles.actionButton, {
-                  [styles.disabled]: item.owner === store.id && item.equipped,
-                })}
-                onClick={() => onMoveItemTo(store, true)}
-                role="button"
-                tabIndex={-1}
-              >
-                <StoreIcon store={store} /> {t('MovePopup.Equip')}
-              </div>
-            )}
-            {canShowStore(store, itemOwner, item) && (
+            {(itemOwner !== store || item.equipped) && canShowStore(store, itemOwner, item) && (
               <div
                 className={clsx(styles.actionButton, {
                   [styles.disabled]: item.owner === store.id && !item.equipped,
@@ -199,6 +187,19 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                 <StoreIcon store={store} /> {t('MovePopup.Store')}
               </div>
             )}
+            {((itemOwner === store && !item.equipped) || store.current) &&
+              itemCanBeEquippedBy(item, store) && (
+                <div
+                  className={clsx(styles.actionButton, {
+                    [styles.disabled]: item.owner === store.id && item.equipped,
+                  })}
+                  onClick={() => onMoveItemTo(store, true)}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <StoreIcon store={store} /> {t('MovePopup.Equip')}
+                </div>
+              )}
           </React.Fragment>
         ))}
         {item.comparable && (

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -175,9 +175,9 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                 {t('MovePopup.Vault')}
               </div>
             )}
-            {(itemOwner !== store || item.equipped) && canShowStore(store, itemOwner, item) && (
+            {canShowStore(store, itemOwner, item) && (
               <div
-                className={clsx(styles.actionButton, {
+                className={clsx(styles.actionButton, styles.move, {
                   [styles.disabled]: item.owner === store.id && !item.equipped,
                 })}
                 onClick={() => onMoveItemTo(store)}
@@ -187,19 +187,18 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                 <StoreIcon store={store} /> {t('MovePopup.Store')}
               </div>
             )}
-            {((itemOwner === store && !item.equipped) || store.current) &&
-              itemCanBeEquippedBy(item, store) && (
-                <div
-                  className={clsx(styles.actionButton, {
-                    [styles.disabled]: item.owner === store.id && item.equipped,
-                  })}
-                  onClick={() => onMoveItemTo(store, true)}
-                  role="button"
-                  tabIndex={-1}
-                >
-                  <StoreIcon store={store} /> {t('MovePopup.Equip')}
-                </div>
-              )}
+            {itemCanBeEquippedBy(item, store) && (
+              <div
+                className={clsx(styles.actionButton, styles.equip, {
+                  [styles.disabled]: item.owner === store.id && item.equipped,
+                })}
+                onClick={() => onMoveItemTo(store, true)}
+                role="button"
+                tabIndex={-1}
+              >
+                <StoreIcon store={store} /> {t('MovePopup.Equip')}
+              </div>
+            )}
           </React.Fragment>
         ))}
         {item.comparable && (

--- a/src/app/item-popup/ItemMoveLocation.tsx
+++ b/src/app/item-popup/ItemMoveLocation.tsx
@@ -66,7 +66,7 @@ export const canShowStore = (
     if (item.equipped && store.id === buttonStore.id) {
       return true;
     }
-  } else if (store.id !== buttonStore.id || item.equipped) {
+  } else {
     // Only show one store for account wide items
     if (item.bucket?.accountWide && !buttonStore.current) {
       return false;
@@ -118,14 +118,15 @@ export default function ItemMoveLocation({
           label={t('MovePopup.Equip')}
         />
       )}
-      {canShowStore(store, itemOwnerStore, item) && (
-        <ItemActionButton
-          title={t('MovePopup.StoreWithName', { character: store.name })}
-          onClick={moveItem}
-          icon={store.icon}
-          label={t('MovePopup.Store')}
-        />
-      )}
+      {!(item.owner === store.id && !item.equipped) &&
+        canShowStore(store, itemOwnerStore, item) && (
+          <ItemActionButton
+            title={t('MovePopup.StoreWithName', { character: store.name })}
+            onClick={moveItem}
+            icon={store.icon}
+            label={t('MovePopup.Store')}
+          />
+        )}
     </ItemActionButtonGroup>
   );
 }

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -10,7 +10,8 @@
   cursor: pointer;
   width: 100%;
   text-align: center;
-  border-bottom: 2px solid transparent;
+  border-bottom: 2px solid #222;
+  background-color: black;
   &.selected {
     opacity: 1;
     border-bottom: 2px solid $orange;

--- a/src/app/item-popup/ItemPopupContainer.m.scss
+++ b/src/app/item-popup/ItemPopupContainer.m.scss
@@ -91,11 +91,17 @@
 .popupBackground {
   background-color: #{'hsl(var(--backgroundColor))'};
   contain: content;
-  box-shadow: 0 -1px 24px 4px #222;
+  box-shadow: 0 -1px 24px 4px #161626;
+  @include phone-portrait {
+    box-shadow: none;
+  }
 }
 
 .desktopPopupRoot {
   pointer-events: none;
+  .arrow {
+    border-color: #161626;
+  }
 }
 
 .desktopPopup {

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -107,7 +107,9 @@ export default function ItemPopupHeader({
         <div className="item-type-info">
           <ItemSubHeader item={item} />
         </div>
-        {item.taggable && <ItemTagSelector item={item} />}
+        {(isPhonePortrait || !$featureFlags.newItemPopupActions) && item.taggable && (
+          <ItemTagSelector item={item} />
+        )}
       </div>
       {powerCapString && (
         <div className="item-subtitle">

--- a/src/app/item-popup/LockButton.tsx
+++ b/src/app/item-popup/LockButton.tsx
@@ -11,9 +11,11 @@ import styles from './LockButton.m.scss';
 interface Props {
   item: DimItem;
   type: 'lock' | 'track';
+  children?: React.ReactNode;
+  className?: string;
 }
 
-export default function LockButton({ type, item }: Props) {
+export default function LockButton({ type, item, className, children }: Props) {
   const [locking, setLocking] = useState(false);
   const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
 
@@ -38,16 +40,7 @@ export default function LockButton({ type, item }: Props) {
     }
   };
 
-  const data = { itemType: item.typeName };
-
-  const title =
-    type === 'lock'
-      ? !item.locked
-        ? t('MovePopup.LockUnlock.Lock', data)
-        : t('MovePopup.LockUnlock.Unlock', data)
-      : !item.tracked
-      ? t('MovePopup.TrackUntrack.Track', data)
-      : t('MovePopup.TrackUntrack.Untrack', data);
+  const title = lockButtonTitle(item, type);
 
   const icon =
     type === 'lock'
@@ -58,9 +51,28 @@ export default function LockButton({ type, item }: Props) {
       ? trackedIcon
       : unTrackedIcon;
 
+  const iconElem = <AppIcon className={clsx({ [styles.inProgress]: locking })} icon={icon} />;
+
   return (
-    <div onClick={lockUnlock} title={title}>
-      <AppIcon className={clsx({ [styles.inProgress]: locking })} icon={icon} />
+    <div onClick={lockUnlock} title={title} className={className}>
+      {children ? (
+        <>
+          {iconElem} {children}
+        </>
+      ) : (
+        iconElem
+      )}
     </div>
   );
+}
+
+export function lockButtonTitle(item: DimItem, type: 'lock' | 'track') {
+  const data = { itemType: item.typeName };
+  return type === 'lock'
+    ? !item.locked
+      ? t('MovePopup.LockUnlock.Lock', data)
+      : t('MovePopup.LockUnlock.Unlock', data)
+    : !item.tracked
+    ? t('MovePopup.TrackUntrack.Track', data)
+    : t('MovePopup.TrackUntrack.Untrack', data);
 }

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -29,7 +29,7 @@ import { updateLoadout } from './actions';
 import { GeneratedLoadoutStats } from './GeneratedLoadoutStats';
 import './loadout-drawer.scss';
 import { Loadout, LoadoutItem } from './loadout-types';
-import { getItemsFromLoadoutItems } from './loadout-utils';
+import { getItemsFromLoadoutItems, newLoadout } from './loadout-utils';
 import LoadoutDrawerContents from './LoadoutDrawerContents';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import LoadoutDrawerOptions from './LoadoutDrawerOptions';
@@ -89,7 +89,6 @@ type Props = StoreProps & ThunkDispatchProp;
 
 interface State {
   loadout?: Readonly<Loadout>;
-  show: boolean;
   showClass: boolean;
   isNew: boolean;
 }
@@ -121,7 +120,6 @@ function stateReducer(state: State, action: Action): State {
   switch (action.type) {
     case 'reset':
       return {
-        show: false,
         showClass: true,
         isNew: false,
         loadout: undefined,
@@ -139,7 +137,6 @@ function stateReducer(state: State, action: Action): State {
         },
         isNew,
         showClass,
-        show: true,
       };
     }
 
@@ -158,12 +155,11 @@ function stateReducer(state: State, action: Action): State {
         return state;
       }
 
-      return loadout
-        ? {
-            ...state,
-            loadout: addItem(loadout, item, shift, items),
-          }
-        : state;
+      return {
+        ...state,
+        loadout: addItem(loadout || newLoadout('', []), item, shift, items),
+        isNew: !loadout,
+      };
     }
 
     case 'removeItem': {
@@ -375,8 +371,7 @@ function LoadoutDrawer({
   dispatch,
 }: Props) {
   // All state and the state of the loadout is managed through this reducer
-  const [{ show, loadout, showClass, isNew }, stateDispatch] = useReducer(stateReducer, {
-    show: false,
+  const [{ loadout, showClass, isNew }, stateDispatch] = useReducer(stateReducer, {
     showClass: true,
     isNew: false,
   });
@@ -478,7 +473,7 @@ function LoadoutDrawer({
     onSaveLoadout(e, newLoadout);
   };
 
-  if (!loadout || !show) {
+  if (!loadout) {
     return null;
   }
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -591,6 +591,7 @@
     "Acquired": "This item is unlocked in collections.",
     "AcquiredMod": "This mod is currently applied to an item in your inventory.",
     "AddNote": "Add a note",
+    "AddToLoadout": "Loadout",
     "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "Consolidate": "Consolidate",
     "Details": "Popup",
@@ -602,7 +603,9 @@
     "ItemDetailSheet": "Open item details",
     "LockUnlock": {
       "Lock": "Lock {{itemType}}",
-      "Unlock": "Unlock {{itemType}}"
+      "Locked": "Locked",
+      "Unlock": "Unlock {{itemType}}",
+      "Unlocked": "Unlocked"
     },
     "MissingSockets": "Perk and mod details are unavailable while Bungie is updating their services. It will return when they are done, usually in a few hours.",
     "Notes": "Notes:",
@@ -625,7 +628,9 @@
     "Take": "Take",
     "TrackUntrack": {
       "Track": "Track {{itemType}}",
-      "Untrack": "Untrack {{itemType}}"
+      "Tracked": "Tracked",
+      "Untrack": "Untrack {{itemType}}",
+      "Untracked": "Untracked"
     },
     "TriageTab": "Triage",
     "Vault": "Vault"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -619,7 +619,7 @@
     "Rewards": "Rewards:",
     "SendToVault": "Send to Vault",
     "Split": "Split",
-    "Store": "Store",
+    "Store": "Move",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
       "Consumable": "{{classType}} {{typeName}}",


### PR DESCRIPTION
<img width="522" alt="Screen Shot 2020-09-26 at 4 50 05 PM" src="https://user-images.githubusercontent.com/313208/94352484-72cb2e00-001a-11eb-88f3-119c7d889e6f.png">

This moves tags and lock into the sidecar, and adds a new "Add to Loadout" button. I also leave the move buttons in and just disable them if you can't move, instead of omitting them. This is getting pretty tall!