### PR TITLE
Mod picker cost overlay issue fix.

### DIFF
--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.m.scss
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.m.scss
@@ -80,3 +80,7 @@
     margin-right: 2px;
   }
 }
+
+.iconContainer {
+  height: fit-content;
+}

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.m.scss.d.ts
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'badPerk': string;
   'goodPerk': string;
+  'iconContainer': string;
   'lockedPerk': string;
   'perk': string;
   'perkDescription': string;

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -59,7 +59,7 @@ export function SelectableArmor2Mod({
         role="button"
         tabIndex={0}
       >
-        <SocketDetailsMod className={styles.iconContainer}itemDef={mod.modDef} defs={defs} />
+        <SocketDetailsMod className={styles.iconContainer} itemDef={mod.modDef} defs={defs} />
         <div className={styles.perkInfo}>
           <div className={styles.perkTitle}>{mod.modDef.displayProperties.name}</div>
           <div className={styles.perkDescription}>{mod.modDef.displayProperties.description}</div>

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -59,7 +59,7 @@ export function SelectableArmor2Mod({
         role="button"
         tabIndex={0}
       >
-        <SocketDetailsMod itemDef={mod.modDef} defs={defs} />
+        <SocketDetailsMod className={styles.iconContainer}itemDef={mod.modDef} defs={defs} />
         <div className={styles.perkInfo}>
           <div className={styles.perkTitle}>{mod.modDef.displayProperties.name}</div>
           <div className={styles.perkDescription}>{mod.modDef.displayProperties.description}</div>


### PR DESCRIPTION
Fixed issue where mod cost overlay was being misplaced as the parent had a larger size than the actual icon.

Before
![image](https://user-images.githubusercontent.com/7344652/94353455-ad81a480-00b4-11eb-95e4-a5046c8f0183.png)

After
![image](https://user-images.githubusercontent.com/7344652/94353451-a8245a00-00b4-11eb-88af-8ef3b1ed9eed.png)
