### PR TITLE
Show (mobile) search below header, instead of on top of it

### DIFF
--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -62,7 +62,7 @@
     position: absolute;
     left: 0;
     right: 0;
-    top: 0;
+    top: $header-height;
     height: $header-height;
     padding-left: constant(safe-area-inset-left);
     padding-left: env(safe-area-inset-left);

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -133,6 +133,7 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
     if (searchFilter.current && showSearch) {
       searchFilter.current.focusFilterInput();
     }
+    document.body.classList.toggle('search-open', showSearch);
   }, [showSearch]);
 
   const history = useHistory();

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -21,6 +21,12 @@ body {
   padding-top: calc(#{$header-height} + env(safe-area-inset-top));
   box-sizing: border-box;
   min-height: 100vh;
+
+  &.search-open {
+    padding-top: 2 * $header-height;
+    padding-top: calc(#{2 * $header-height} + constant(safe-area-inset-top));
+    padding-top: calc(#{2 * $header-height} + env(safe-area-inset-top));
+  }
 }
 #header {
   padding: 0 0 0 2px;


### PR DESCRIPTION
This moves the mobile search box to appear under the header, and push down the page, instead of displaying on top of it.

<img width="207" alt="Screen Shot 2020-09-26 at 9 18 08 PM" src="https://user-images.githubusercontent.com/313208/94355965-e5013a00-003d-11eb-8cea-1cc0e90a8656.png">
