### PR TITLE
Mobile header tweaks

### DIFF
--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -355,9 +355,11 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
           </span>
         )}
         <Refresh />
-        <Link className="link menuItem" to="/settings" title={t('Settings.Settings')}>
-          <AppIcon icon={settingsIcon} />
-        </Link>
+        {!isPhonePortrait && (
+          <Link className="link menuItem" to="/settings" title={t('Settings.Settings')}>
+            <AppIcon icon={settingsIcon} />
+          </Link>
+        )}
         <span className="link search-button menuItem" onClick={toggleSearch}>
           <AppIcon icon={searchIcon} />
         </span>

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -4,6 +4,10 @@
 .logo {
   height: 24px;
   width: 68px;
+  @include phone-portrait {
+    height: 24px * 1.2;
+    width: 68px * 1.2;
+  }
   color: $orange !important;
   font-size: 16px !important;
   font-weight: bold;
@@ -56,6 +60,9 @@ body {
 
   .app-icon {
     font-size: 1.33em;
+    @include phone-portrait {
+      font-size: 24px;
+    }
     &:hover {
       color: $orange;
       cursor: pointer;
@@ -69,6 +76,12 @@ body {
 
   .logoLink {
     height: 24px;
+    @include phone-portrait {
+      height: 44px;
+      margin: 0 4px !important;
+      display: flex;
+      align-items: center;
+    }
   }
 
   .menuItem {
@@ -79,6 +92,9 @@ body {
     user-select: none;
     outline: none;
     white-space: nowrap;
+    @include phone-portrait {
+      margin: 0 12px;
+    }
   }
 
   .link {


### PR DESCRIPTION
This tweaks the mobile header a bit - removes the settings button (it's in the menu), and makes the icons and logo both larger and more spaced out. I don't quite know how it'll feel on a real phone. 

Before:
![image](https://user-images.githubusercontent.com/313208/94356283-64443d00-0041-11eb-8fe7-e4dea7cdc08b.png)

After:
![image](https://user-images.githubusercontent.com/313208/94356279-58587b00-0041-11eb-9ff8-d5a49703b785.png)
