### PR TITLE
Remove unstickyStats flag, fix bug with stats

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -379,8 +379,6 @@ module.exports = (env) => {
         '$featureFlags.issueBanner': JSON.stringify(true),
         // Show the triage tab in the item popup
         '$featureFlags.triage': JSON.stringify(env.dev),
-        // Detach stats from the sticky header on mobile
-        '$featureFlags.unstickyStats': JSON.stringify(true),
         // Drag and drop mobile inspect
         '$featureFlags.mobileInspect': JSON.stringify(!env.release),
         // Rearrange buckets in categories

--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -45,15 +45,13 @@ export default function CharacterTile({ store }: { store: DimStore }) {
                 <AppIcon icon={powerActionIcon} />
                 {store.powerLevel}
               </div>
-              {$featureFlags.unstickyStats && isPhonePortrait && (
-                <div className="maxTotalPower">/ {maxTotalPower}</div>
-              )}
+              {isPhonePortrait && <div className="maxTotalPower">/ {maxTotalPower}</div>}
             </>
           )}
         </div>
         <div className="bottom">
           {store.isVault ? (
-            $featureFlags.unstickyStats && isPhonePortrait && <VaultCapacity />
+            isPhonePortrait && <VaultCapacity />
           ) : (
             <>
               <div className="race-gender">{store.genderRace}</div>

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -122,7 +122,6 @@ function Stores(this: void, { stores, buckets, isPhonePortrait }: Props) {
                       onTapped={setSelectedStoreId}
                       loadoutMenuRef={detachedLoadoutMenu}
                     />
-                    {!$featureFlags.unstickyStats && <StoreStats store={store} />}
                   </View>
                 ))}
               </Track>
@@ -261,10 +260,10 @@ function StoresInventory(props: InventoryContainerProps) {
   if (selectedCategoryId) {
     return (
       <>
-        {$featureFlags.unstickyStats && selectedCategoryId === 'Armor' && (
+        {selectedCategoryId === 'Armor' && (
           <StoreStats
-            store={currentStore}
-            style={{ ...storeBackgroundColor(currentStore, 0, true, true), paddingBottom: 8 }}
+            store={stores[0]}
+            style={{ ...storeBackgroundColor(stores[0], 0, true, true), paddingBottom: 8 }}
           />
         )}
         {selectedCategoryId === 'Inventory' &&

--- a/src/app/store-stats/StoreStats.tsx
+++ b/src/app/store-stats/StoreStats.tsx
@@ -9,13 +9,6 @@ import D1CharacterStats from './D1CharacterStats';
 import styles from './StoreStats.m.scss';
 import VaultCapacity from './VaultCapacity';
 
-function shouldShowCapacity(isPhonePortrait: boolean) {
-  if (!isPhonePortrait) {
-    return true;
-  }
-  return !$featureFlags.unstickyStats;
-}
-
 /** Render the store stats for any store type (character or vault) */
 export default function StoreStats({
   store,
@@ -30,7 +23,7 @@ export default function StoreStats({
       {store.isVault ? (
         <div className={styles.vaultStats}>
           <AccountCurrencies />
-          {shouldShowCapacity(isPhonePortrait) && <VaultCapacity />}
+          {!isPhonePortrait && <VaultCapacity />}
         </div>
       ) : store.destinyVersion === 1 ? (
         <D1CharacterStats stats={store.stats} />

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -30,8 +30,6 @@ declare const $featureFlags: {
   issueBanner: boolean;
   /** Show the triage tab in the item popup */
   triage: boolean;
-  /** Enable detached stats from sticky header on mobile */
-  unstickyStats: boolean;
   /** Enable new mobile inspect view when dragging an item */
   mobileInspect: boolean;
   /** Move subclass out of weapons */


### PR DESCRIPTION
This removes the unstickyStats feature flag, which is on everywhere now.

It also fixes a bug where we'd only ever show stats for the current store, instead of the *selected* store.