### PR TITLE
Disable move amounts in beta only

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -391,6 +391,8 @@ module.exports = (env) => {
         '$featureFlags.movePullFromButton': JSON.stringify(env.dev),
         // Move the item popup actions
         '$featureFlags.newItemPopupActions': JSON.stringify(!env.release),
+        // Enable move amounts
+        '$featureFlags.moveAmounts': JSON.stringify(env.release),
       }),
 
       new WorkerPlugin({

--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -61,7 +61,7 @@ function Inventory({ storesLoaded, account, isPhonePortrait }: Props) {
       <Stores />
       <LoadoutDrawer />
       <Compare />
-      <StackableDragHelp />
+      {$featureFlags.moveAmounts && <StackableDragHelp />}
       <DragPerformanceFix />
       <Farming />
       {account.destinyVersion === 2 && <GearPower />}

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -127,6 +127,7 @@ export function moveItemTo(
 
       // Select how much of a stack to move
       if (
+        $featureFlags.moveAmounts &&
         chooseAmount &&
         item.maxStackSize > 1 &&
         item.amount > 1 &&

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -139,7 +139,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
   return (
     <>
       <div className={styles.interaction} ref={containerRef}>
-        {item.destinyVersion === 1 && maximum > 1 && (
+        {$featureFlags.moveAmounts && item.destinyVersion === 1 && maximum > 1 && (
           <ItemMoveAmount
             amount={amount}
             maximum={maximum}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -40,6 +40,8 @@ declare const $featureFlags: {
   mobileCategoryStrip: boolean;
   /** Move the item popup actions */
   newItemPopupActions: boolean;
+  /** Enable move amounts */
+  moveAmounts: boolean;
 };
 
 declare namespace React {


### PR DESCRIPTION
I'm a bit scared to just rip out move amounts entirely, so this feature-flags it so we can chill in beta for a while.