### PR TITLE
Change icon for compare

### DIFF
--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -4,7 +4,7 @@ import { getTag } from 'app/inventory/dim-item-info';
 import { amountOfItem, getStore } from 'app/inventory/stores-helpers';
 import TagIcon from 'app/inventory/TagIcon';
 import { addItemToLoadout } from 'app/loadout/LoadoutDrawer';
-import { addIcon, AppIcon, faClone } from 'app/shell/icons';
+import { addIcon, AppIcon, compareIcon } from 'app/shell/icons';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -203,7 +203,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
         ))}
         {item.comparable && (
           <div className={styles.actionButton} onClick={openCompare} role="button" tabIndex={-1}>
-            <AppIcon icon={faClone} /> {t('Compare.Button')}
+            <AppIcon icon={compareIcon} /> {t('Compare.Button')}
           </div>
         )}
         {canConsolidate && (

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -81,6 +81,7 @@ const faGripLinesVertical = 'fas fa-grip-lines-vertical';
 const faExternalLinkAlt = 'fas fa-external-link-alt';
 const faBookmarkSolid = 'fas fa-bookmark';
 const faBookmark = 'far fa-bookmark';
+const faBalanceScaleLeft = 'fas fa-balance-scale-left';
 
 const faXbox = 'fab fa-xbox';
 const faPlaystation = 'fab fa-playstation';
@@ -106,6 +107,7 @@ export {
   faBars as menuIcon,
   faBars as reorderIcon,
   faBolt as boltIcon,
+  faBalanceScaleLeft as compareIcon,
   faCheck,
   faCheckCircle as enabledIcon,
   faCheckCircle as redeemedIcon,


### PR DESCRIPTION
This changes the icon to "scales" from "copy". It only affects the sidecar for now.

<img width="531" alt="Screen Shot 2020-09-30 at 6 40 01 PM" src="https://user-images.githubusercontent.com/313208/94756679-066b6a00-034d-11eb-81fb-1bc3052cd170.png">
