### PR TITLE
Few gradientBackground tweaks

### DIFF
--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -212,7 +212,7 @@
     padding: 8px var(--inventory-column-padding) 6px var(--inventory-column-padding);
     flex-direction: column;
     .gradientBackground & {
-      padding-top: 12px;
+      padding-top: 16px;
     }
     &:focus {
       outline: none;

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -252,7 +252,7 @@
     background: radial-gradient(circle at 50% 70px, #454568 0%, #161626 100%);
     background-position: center top;
     background-repeat: no-repeat;
-    background-size: 100vw 100vh;
+    background-size: 100% 100vh;
   }
 }
 

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -211,6 +211,9 @@
   .store-cell {
     padding: 8px var(--inventory-column-padding) 6px var(--inventory-column-padding);
     flex-direction: column;
+    .gradientBackground & {
+      padding-top: 12px;
+    }
     &:focus {
       outline: none;
     }

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -419,8 +419,10 @@ a.dim-button {
     will-change: transform;
     z-index: -1;
   }
-  --inventory-column-padding: 24px;
-  --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
+  @media (min-width: 1079px) {
+    --inventory-column-padding: 24px;
+    --column-padding: calc(2 * var(--inventory-column-padding) - var(--item-margin));
+  }
   @include phone-portrait {
     --inventory-column-padding: 12px;
   }

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -221,9 +221,6 @@ input[type='search'] {
   padding-right: constant(safe-area-inset-right);
   padding-right: env(safe-area-inset-right);
   scroll-margin-top: $header-height;
-  .gradientBackground & {
-    padding-top: 12px;
-  }
 }
 
 h2,

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -246,10 +246,14 @@ body {
       display: flex;
       align-items: center;
       direction: ltr;
+      border-bottom: 2px solid transparent;
+
+      .gradientBackground & {
+        height: 32px;
+      }
 
       &.active {
         border-bottom: 2px solid $orange;
-        border-top: 2px solid black;
         box-sizing: border-box;
       }
     }

--- a/src/app/store-stats/VaultCapacity.m.scss
+++ b/src/app/store-stats/VaultCapacity.m.scss
@@ -15,7 +15,6 @@
 }
 
 .full {
-  color: #e12929;
+  color: white;
   font-weight: bold;
-  text-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
Happy to tweak/undo/add any:

- Made the bottom of the orange border line-up with the bottom of the searchbox when flag is on. 


|existing|new|
|---|---|
|<img width="169" alt="Screen Shot 2020-09-30 at 11 23 48 PM" src="https://user-images.githubusercontent.com/424158/94775111-13e81a80-0374-11eb-9dce-b59588fd8bd3.png">|<img width="185" alt="Screen Shot 2020-09-30 at 11 23 41 PM" src="https://user-images.githubusercontent.com/424158/94775105-10549380-0374-11eb-986b-c98388e1089c.png">|


- The vault-full color bold white for flag on and off, because the red color felt a bit much. We'll likely be updating all of the text colors, but wanted to land this for now.

- Moved where the new padding top was between character tiles and the header to fix the sticky scroll issue.

- Gradient header width background for the character tiles 100% instead of 100vw, which means now the header is no longer transparent in parts on 'tablet resolutions'. - but it's still not perfect at this resolution. 

- Made the character column padding increase only happen when the resolution is over 1080px. Under 1080px was making the number of columns in the vault lower.


||Changes|
|---|---|
|Flag off|<img width="1400" alt="Screen Shot 2020-09-30 at 11 13 19 PM" src="https://user-images.githubusercontent.com/424158/94774485-dc2ca300-0372-11eb-82ed-9b8df3eb67f9.png">|
|Flag on|<img width="1120" alt="Screen Shot 2020-10-01 at 12 08 41 AM" src="https://user-images.githubusercontent.com/424158/94778527-4dbc1f80-037a-11eb-9326-bc4e71e5aba8.png">|
|Beta|<img width="1165" alt="Screen Shot 2020-09-30 at 11 20 41 PM" src="https://user-images.githubusercontent.com/424158/94774894-99b79600-0373-11eb-9758-45398b048705.png">|
|Prod|<img width="1091" alt="Screen Shot 2020-09-30 at 11 19 46 PM" src="https://user-images.githubusercontent.com/424158/94774823-7bea3100-0373-11eb-8704-d315c2c709fd.png">|