### PR TITLE
Tweak loadout dropdown and drawer styles

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -110,8 +110,7 @@ $header-height: 44px;
   }
 
   &::-webkit-scrollbar-track {
-    background: rgba(228, 228, 228, 0.2);
-    border-radius: 3px;
+    background: #555;
   }
 
   &::-webkit-scrollbar-thumb {

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -25,7 +25,7 @@ import { DimStore } from '../inventory/store-types';
 import { showItemPicker } from '../item-picker/item-picker';
 import { showNotification } from '../notifications/notifications';
 import { itemSortOrderSelector } from '../settings/item-sort';
-import { updateLoadout } from './actions';
+import { deleteLoadout, updateLoadout } from './actions';
 import { GeneratedLoadoutStats } from './GeneratedLoadoutStats';
 import './loadout-drawer.scss';
 import { Loadout, LoadoutItem } from './loadout-types';
@@ -477,6 +477,12 @@ function LoadoutDrawer({
     return null;
   }
 
+  const onDeleteLoadout = () => {
+    if (confirm(t('Loadouts.ConfirmDelete', { name: loadout.name }))) {
+      dispatch(deleteLoadout(loadout.id));
+    }
+  };
+
   const bucketTypes = Object.keys(buckets.byType);
 
   // Find a loadout with the same name that could overlap with this one
@@ -501,6 +507,7 @@ function LoadoutDrawer({
         saveLoadout={onSaveLoadout}
         saveAsNew={saveAsNew}
         clashingLoadout={clashingLoadout}
+        deleteLoadout={onDeleteLoadout}
       />
       <GeneratedLoadoutStats
         defs={defs}

--- a/src/app/loadout/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout/LoadoutDrawerOptions.tsx
@@ -1,5 +1,6 @@
 import { t } from 'app/i18next-t';
 import { getClass } from 'app/inventory/store/character-utils';
+import { AppIcon, deleteIcon } from 'app/shell/icons';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { Prompt } from 'react-router';
@@ -15,6 +16,7 @@ export default function LoadoutDrawerOptions({
   clashingLoadout,
   saveLoadout,
   saveAsNew,
+  deleteLoadout,
 }: {
   loadout?: Readonly<Loadout>;
   showClass: boolean;
@@ -27,6 +29,7 @@ export default function LoadoutDrawerOptions({
   updateLoadout(loadout: Loadout);
   saveLoadout(e);
   saveAsNew(e);
+  deleteLoadout(e);
 }) {
   if (!loadout) {
     return null;
@@ -121,6 +124,18 @@ export default function LoadoutDrawerOptions({
             </button>
           )}
         </div>
+        {!isNew && (
+          <div className="input-group">
+            <button
+              className="dim-button danger"
+              onClick={deleteLoadout}
+              type="button"
+              title={t('Loadouts.Delete')}
+            >
+              <AppIcon icon={deleteIcon} />
+            </button>
+          </div>
+        )}
         <div className="input-group">
           <Link className="dim-button" to={{ pathname: 'optimizer', state: { loadout } }}>
             {t('Loadouts.OpenInOptimizer')}

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -24,7 +24,6 @@ import {
   addIcon,
   AppIcon,
   banIcon,
-  deleteIcon,
   editIcon,
   engramIcon,
   faRandom,
@@ -40,7 +39,6 @@ import {
   warlockIcon,
 } from '../shell/icons';
 import { querySelector } from '../shell/selectors';
-import { deleteLoadout } from './actions';
 import {
   gatherEngramsLoadout,
   itemLevelingLoadout,
@@ -166,12 +164,6 @@ function LoadoutPopup({
     );
     loadout.classType = classTypeId;
     editLoadout(loadout, { isNew: true });
-  };
-
-  const deleteExistingLoadout = async (loadout: Loadout) => {
-    if (confirm(t('Loadouts.ConfirmDelete', { name: loadout.name }))) {
-      dispatch(deleteLoadout(loadout.id));
-    }
   };
 
   // TODO: move all these fancy loadouts to a new service
@@ -404,13 +396,6 @@ function LoadoutPopup({
             <span title={loadout.name} onClick={(e) => onApplyLoadout(loadout, e)}>
               <AppIcon className="loadout-type-icon" icon={loadoutIcon[loadout.classType]} />
               {loadout.name}
-            </span>
-            <span
-              className="delete"
-              title={t('Loadouts.Delete')}
-              onClick={() => deleteExistingLoadout(loadout)}
-            >
-              <AppIcon icon={deleteIcon} />
             </span>
             <span title={t('Loadouts.Edit')} onClick={() => editLoadout(loadout, { isNew: false })}>
               <AppIcon icon={editIcon} />

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -69,12 +69,17 @@
   display: block;
 }
 
-.loadout-content {
-  .dim-select {
-    height: 23px;
-    padding: 4px 0;
-    vertical-align: top;
-  }
+.dim-select {
+  vertical-align: top;
+  background-color: #555;
+  padding: 3px 0px;
+  display: inline-block;
+  border: none;
+  color: white;
+  font-size: 12px;
+  font-family: 'Open Sans', sans-serif;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
+  border-radius: 2px;
 }
 
 .loadout-options {
@@ -85,9 +90,7 @@
   }
 
   .loadout-name {
-    flex: 1;
-    max-width: 20em;
-    min-width: 10em;
+    width: 26em;
   }
 
   .dim-input {
@@ -129,6 +132,7 @@
 .loadout-warn-items {
   display: flex;
   flex-direction: row;
+  @include horizontal-space-children(4px);
 }
 
 .loadout-contents {

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -22,7 +22,11 @@
   }
 
   &:hover {
-    background-color: #151515;
+    background-color: $orange;
+    color: black !important;
+    > span:first-child > .app-icon {
+      color: black !important;
+    }
   }
 
   > span:first-child {
@@ -32,6 +36,7 @@
     text-overflow: ellipsis;
     white-space: nowrap !important;
     line-height: 35px;
+    margin-right: 4px;
     .app-icon,
     .fa {
       width: 12px;
@@ -40,10 +45,14 @@
     }
   }
 
+  > span:nth-child(2) {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+  }
+
   > span:not(:first-child) {
-    margin: 6px 4px 6px 4px;
+    margin: 6px 0;
     padding: 0 6px;
-    border-radius: 4px;
     text-align: center;
     color: #888;
     background-color: #222;
@@ -58,9 +67,17 @@
       color: #222;
 
       &.delete {
-        background-color: #ff9294;
+        background-color: $red;
+        color: white;
       }
     }
+  }
+
+  > span:last-child {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    margin-right: 4px;
+    border-right: none;
   }
 }
 
@@ -108,7 +125,7 @@
     var(--item-margin)
   );
   box-sizing: border-box;
-  max-height: 90vh;
+  max-height: calc(100vh - 125px);
   overflow: auto;
   z-index: 2;
   color: rgba(245, 245, 245, 0.6);

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -36,7 +36,6 @@
     text-overflow: ellipsis;
     white-space: nowrap !important;
     line-height: 35px;
-    margin-right: 4px;
     .app-icon,
     .fa {
       width: 12px;
@@ -45,14 +44,10 @@
     }
   }
 
-  > span:nth-child(2) {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-  }
-
   > span:not(:first-child) {
-    margin: 6px 0;
+    margin: 6px 4px 6px 4px;
     padding: 0 6px;
+    border-radius: 4px;
     text-align: center;
     color: #888;
     background-color: #222;
@@ -71,13 +66,6 @@
         color: white;
       }
     }
-  }
-
-  > span:last-child {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-    margin-right: 4px;
-    border-right: none;
   }
 }
 

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -350,6 +350,11 @@ select {
     margin: 0 0.3em;
     filter: drop-shadow(0 0 1px black);
   }
+  &.danger {
+    &:hover {
+      background-color: $red;
+    }
+  }
 }
 
 a.dim-button {


### PR DESCRIPTION
This makes some adjustments to the loadout popup and drawer:

1. Make the hover highlight orange, like we are doing with other dropdowns.
2. Remove "delete" from loadout menu, move it to loadout drawer. So now you have to edit, then delete.
3. Restyle the class dropdown to not be weirdly shorter than the buttons.

<img width="248" alt="Screen Shot 2020-10-03 at 3 31 39 PM" src="https://user-images.githubusercontent.com/313208/95002859-97308880-058d-11eb-8454-242aa14c38da.png">
<img width="560" alt="Screen Shot 2020-10-03 at 3 31 50 PM" src="https://user-images.githubusercontent.com/313208/95002864-a7e0fe80-058d-11eb-9347-c00987cb99f2.png">

