### PR TITLE
Highlight store headings with a box instead of lightness

### DIFF
--- a/src/app/character-tile/StoreHeading.scss
+++ b/src/app/character-tile/StoreHeading.scss
@@ -33,8 +33,16 @@
 
   &:hover,
   &:active {
-    .background {
-      filter: brightness(130%) !important;
+    position: relative;
+    &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: -4px;
+      left: -4px;
+      right: -4px;
+      bottom: -4px;
+      border: 1px solid white;
     }
   }
 }


### PR DESCRIPTION
This is a change I'd been sitting on a while. I think the highlight on hover for store headings is a bit too subtle, so I replaced the lightening effect with a box around the tile, which calls back to the character select screen in Destiny.

![image](https://user-images.githubusercontent.com/313208/95008038-f6f95480-05ca-11eb-9594-d832e2ec2f24.png)
