### PR TITLE
More contrast in gradient land

### DIFF
--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -103,8 +103,8 @@
 
   // Engrams. D1 uses this same bucket hash for "Missions"
   .destiny2 .bucket-375726501 & {
-    /* prettier-ignore */
     --engram-size: calc(var(--character-column-width) / 10);
+    padding-bottom: 8px;
 
     .empty-engram {
       border: $item-border-width solid transparent;

--- a/src/app/shell/header.scss
+++ b/src/app/shell/header.scss
@@ -250,6 +250,10 @@ body {
       border-bottom: 2px solid transparent;
       box-sizing: border-box;
 
+      .gradientBackground & {
+        height: 26px;
+      }
+
       &.active {
         border-bottom: 2px solid $orange;
       }

--- a/src/app/store-stats/CharacterStats.scss
+++ b/src/app/store-stats/CharacterStats.scss
@@ -7,6 +7,9 @@
   flex-direction: row;
   justify-content: space-around;
   margin-top: 8px;
+  .gradientBackground & {
+    opacity: 1;
+  }
 
   .phone-portrait & {
     margin-left: auto;
@@ -58,6 +61,9 @@
       width: 14px;
       margin-right: 2px;
       opacity: 0.8;
+      .gradientBackground & {
+        opacity: 1;
+      }
     }
   }
 
@@ -111,6 +117,9 @@
       color: #aaa;
       &.pointerCursor {
         cursor: pointer;
+      }
+      .gradientBackground & {
+        color: #ccc;
       }
     }
   }

--- a/src/app/store-stats/StoreStats.m.scss
+++ b/src/app/store-stats/StoreStats.m.scss
@@ -3,11 +3,15 @@
   display: grid;
   grid-template-columns: repeat(4, 16px minmax(min-content, 1fr));
   grid-auto-rows: 16px;
-  gap: 3px 2px;
+  gap: 4px 2px;
   align-items: center;
   font-size: 11px;
   color: #aaa;
-  margin-top: 8px;
+  margin-top: 9px;
+
+  :global(.gradientBackground) & {
+    color: #ccc;
+  }
 
   img,
   .bucketTag {

--- a/src/app/store-stats/VaultCapacity.m.scss
+++ b/src/app/store-stats/VaultCapacity.m.scss
@@ -11,6 +11,10 @@
     width: 14px;
     filter: invert(1);
     opacity: 0.5;
+
+    :global(.gradientBackground) & {
+      opacity: 0.7;
+    }
   }
 }
 


### PR DESCRIPTION
This makes the stats under the character tile a bit brighter (I didn't turn 'em up to 100% both because the Bungie stat images are transparent and because it was really distracting).

I also gave engrams a bit of breathing room below them, before the lost items.

Before:
![image](https://user-images.githubusercontent.com/313208/95008949-e64cdc80-05d2-11eb-8ed7-4c6b0526f960.png)

After:
![image](https://user-images.githubusercontent.com/313208/95008924-ae459980-05d2-11eb-88ab-dda5a58a360b.png)
