### PR TITLE
Tweak wishlist perk icons

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -960,8 +960,8 @@
     }
   },
   "WishListRoll": {
-    "BestRatedKey": " = curator-suggested perk",
-    "BestRatedTip": "This perk was selected by the curator.",
+    "BestRatedKey": " = wishlist perk",
+    "BestRatedTip": "This perk is part of a weapon roll that was was selected by the author of your wishlist.",
     "Clear": "Clear Wish List",
     "ExternalSource": "Optionally, supply the URL for a wish list",
     "Header": "Wish List",

--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -30,6 +30,10 @@
     border-color: #888;
   }
 
+  p {
+    margin-bottom: 0;
+  }
+
   &[data-popper-placement='top'] .arrow {
     border-width: 5px 5px 0 5px;
     border-left-color: transparent;

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -67,12 +67,6 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
     return null;
   }
 
-  const badgeclsx = {
-    [styles.fullstack]: isStackable && item.amount === item.maxStackSize,
-    [styles.capped]: isCapped,
-    [styles.masterwork]: item.masterwork,
-  };
-
   const badgeContent =
     (isBounty && `${Math.floor(100 * item.percentComplete)}%`) ||
     (isStackable && item.amount.toString()) ||
@@ -80,19 +74,25 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
     (isGeneric && item.primStat?.value.toString()) ||
     (item.classified && '???');
 
-  const reviewclsx = {
-    [styles.wishlistRoll]: uiWishListRoll,
-  };
-
   return (
-    <div className={clsx(styles.badge, badgeclsx)}>
+    <div
+      className={clsx(styles.badge, {
+        [styles.fullstack]: isStackable && item.amount === item.maxStackSize,
+        [styles.capped]: isCapped,
+        [styles.masterwork]: item.masterwork,
+      })}
+    >
       {isD1Item(item) && item.quality && (
         <div className={styles.quality} style={getColor(item.quality.min, 'backgroundColor')}>
           {item.quality.min}%
         </div>
       )}
       {uiWishListRoll && (
-        <div className={clsx(reviewclsx)}>
+        <div
+          className={clsx({
+            [styles.wishlistRoll]: uiWishListRoll,
+          })}
+        >
           <RatingIcon uiWishListRoll={uiWishListRoll} />
         </div>
       )}

--- a/src/app/inventory/RatingIcon.scss
+++ b/src/app/inventory/RatingIcon.scss
@@ -3,16 +3,6 @@
     color: #0b486b;
     font-size: 0.8em !important;
   }
-  &.mehroll {
-    color: #313233;
-    font-size: 0.7em !important;
-  }
-  &.dogroll {
-    color: #d14334;
-  }
-  &.goodroll {
-    color: #028f76;
-  }
   &.trashlist {
     color: #d14334;
     font-size: 0.8em !important;

--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -106,12 +106,15 @@
 }
 
 .thumbs-up {
-  color: #6dcc66;
+  background: #ddd;
+  border-radius: 50%;
+  color: #0b486b;
+  padding: 3px;
   font-size: calc(var(--item-size) / 5) !important;
   .socket-container & {
     position: absolute;
-    top: -3px;
-    right: -3px;
+    top: -6px;
+    right: -6px;
     filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.9));
   }
 }

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -1,7 +1,5 @@
-import { t } from 'app/i18next-t';
 import { LockedItemType } from 'app/loadout-builder/types';
 import { CHALICE_OF_OPULENCE, synthesizerHashes } from 'app/search/d2-known-values';
-import { AppIcon, thumbsUpIcon } from 'app/shell/icons';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -10,7 +8,7 @@ import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import { DimAdjustedItemPlug } from '../compare/types';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
-import { DimItem, DimPlug, DimSocket, DimSocketCategory } from '../inventory/item-types';
+import { DimItem, DimPlug, DimSocket } from '../inventory/item-types';
 import { inventoryWishListsSelector, wishListsEnabledSelector } from '../wishlists/selectors';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import './ItemSockets.scss';
@@ -112,7 +110,6 @@ function ItemSockets({
           {!minimal && (
             <div className="item-socket-category-name">
               {category.category.displayProperties.name}
-              {bestRatedIcon(category, wishListsEnabled, inventoryWishListRoll)}
             </div>
           )}
           <div className="item-sockets">
@@ -150,36 +147,6 @@ function ItemSockets({
 
 export default connect<StoreProps>(mapStateToProps)(ItemSockets);
 
-/** returns BestRatedIcon with appropriate label if this is the recommended perk */
-function bestRatedIcon(
-  category: DimSocketCategory,
-  wishlistEnabled?: boolean,
-  inventoryWishListRoll?: InventoryWishListRoll
-) {
-  const returnAsWishlisted =
-    wishlistEnabled &&
-    inventoryWishListRoll &&
-    !inventoryWishListRoll.isUndesirable &&
-    anyWishListRolls(category, inventoryWishListRoll)
-      ? true // true for a wishlisted perk
-      : null; // don't give a thumbs up at all
-
-  return (
-    returnAsWishlisted !== null && (
-      <div className="best-rated-key">
-        <div className="tip-text">
-          <AppIcon
-            className="thumbs-up"
-            icon={thumbsUpIcon}
-            title={t('WishListRoll.BestRatedTip')}
-          />{' '}
-          {t('WishListRoll.BestRatedKey')}
-        </div>
-      </div>
-    )
-  );
-}
-
 /** converts a socket category to a valid css class name */
 function categoryStyle(categoryStyle: DestinySocketCategoryStyle) {
   switch (categoryStyle) {
@@ -198,19 +165,6 @@ function categoryStyle(categoryStyle: DestinySocketCategoryStyle) {
     default:
       return null;
   }
-}
-
-function anyWishListRolls(
-  category: DimSocketCategory,
-  inventoryWishListRoll: InventoryWishListRoll
-) {
-  return category.sockets.some((socket) =>
-    socket.plugOptions.some(
-      (plugOption) =>
-        plugOption !== socket.plugged &&
-        inventoryWishListRoll.wishListPerks.has(plugOption.plugDef.hash)
-    )
-  );
 }
 
 function Socket({

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -117,15 +117,9 @@ export default function Plug({
       ) : (
         contents
       )}
-      {wishListsEnabled &&
-        inventoryWishListRoll &&
-        inventoryWishListRoll.wishListPerks.has(plug.plugDef.hash) && (
-          <AppIcon
-            className="thumbs-up"
-            icon={thumbsUpIcon}
-            title={t('WishListRoll.BestRatedTip')}
-          />
-        )}
+      {wishListsEnabled && inventoryWishListRoll?.wishListPerks.has(plug.plugDef.hash) && (
+        <AppIcon className="thumbs-up" icon={thumbsUpIcon} title={t('WishListRoll.BestRatedTip')} />
+      )}
     </div>
   );
 }

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -84,14 +84,14 @@ export default function PlugTooltip({
       {wishListsEnabled &&
         inventoryWishListRoll &&
         inventoryWishListRoll.wishListPerks.has(plug.plugDef.hash) && (
-          <>
+          <p>
             <AppIcon
               className="thumbs-up"
               icon={thumbsUpIcon}
               title={t('WishListRoll.BestRatedTip')}
             />{' '}
             = {t('WishListRoll.BestRatedTip')}
-          </>
+          </p>
         )}
     </>
   );

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -936,8 +936,8 @@
     }
   },
   "WishListRoll": {
-    "BestRatedKey": " = curator-suggested perk",
-    "BestRatedTip": "This perk was selected by the curator.",
+    "BestRatedKey": " = wishlist perk",
+    "BestRatedTip": "This perk is part of a weapon roll that was was selected by the author of your wishlist.",
     "Clear": "Clear Wish List",
     "ExternalSource": "Optionally, supply the URL for a wish list",
     "Header": "Wish List",


### PR DESCRIPTION
I've noticed a few people having trouble connecting wishlists to the thumbs up on icon tiles, to the thumbs up on perks. To help with that, I'm proposing some tweaks:

1. Instead of talking about "curators", just talk about "wishlists".
2. Keep the same color for the thumb icon everywhere. This necessitated a background for the perk highlights.
3. Remove the redundant key for the thumbs in the perks display - this didn't look great, is redundant with the tooltip, and prevented tighter packing of perk categories.

Before:
<img width="417" alt="Screen Shot 2020-10-06 at 8 28 11 PM" src="https://user-images.githubusercontent.com/313208/95284244-99efdf80-0812-11eb-9feb-d07ab02635cc.png">

After:
<img width="399" alt="Screen Shot 2020-10-06 at 8 25 13 PM" src="https://user-images.githubusercontent.com/313208/95284097-28b02c80-0812-11eb-8c0c-693ab2c51294.png">
