### PR TITLE
Bold the selected perk in organizer

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -296,7 +296,7 @@ export function getColumns(
         id: 'wishList',
         header: t('Organizer.Columns.WishList'),
         value: (item) => {
-          const roll = wishList?.[item.id];
+          const roll = wishList[item.id];
           return roll ? (roll.isUndesirable ? false : true) : undefined;
         },
         cell: (value) =>
@@ -592,7 +592,13 @@ function PerksCell({
               key={p.plugDef.hash}
               tooltip={<PlugTooltip item={item} plug={p} defs={defs} />}
             >
-              <div className={styles.modPerk} data-perk-name={p.plugDef.displayProperties.name}>
+              <div
+                className={clsx(styles.modPerk, {
+                  [styles.perkSelected]:
+                    socket.isPerk && socket.plugOptions.length > 1 && p === socket.plugged,
+                })}
+                data-perk-name={p.plugDef.displayProperties.name}
+              >
                 <div className={styles.miniPerkContainer}>
                   <DefItemIcon itemDef={p.plugDef} defs={defs} borderless={true} />
                 </div>{' '}

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -238,6 +238,9 @@ $toolbarHeight: 41px - 16px + 8px;
   margin-left: -1px;
   flex-shrink: 0;
 }
+.perkSelected {
+  font-weight: bold;
+}
 
 .locationCell {
   display: flex;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -26,6 +26,7 @@ interface CssExports {
   'negative': string;
   'new': string;
   'noItems': string;
+  'perkSelected': string;
   'perks': string;
   'positive': string;
   'power': string;


### PR DESCRIPTION
<img width="314" alt="Screen Shot 2020-10-06 at 8 24 58 PM" src="https://user-images.githubusercontent.com/313208/95528843-1824c100-098e-11eb-8950-a05b9fea515b.png">

This is a super minor change which simply bolds the selected perk when there's a choice of multiple. It helps me understand which perk is contributing to the current stats.