### PR TITLE
Save loadout parameters with loadouts created by LO

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -1111,6 +1111,7 @@ function convertDimLoadoutToApiLoadout(dimLoadout: DimLoadout): Loadout {
     clearSpace: dimLoadout.clearSpace || false,
     equipped,
     unequipped,
+    parameters: dimLoadout.parameters,
   };
 }
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -1,4 +1,4 @@
-import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { settingsSelector } from 'app/dim-api/selectors';

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -1,3 +1,4 @@
+import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { settingsSelector } from 'app/dim-api/selectors';
@@ -11,8 +12,10 @@ import { loadoutsSelector } from 'app/loadout/selectors';
 import { ItemFilter } from 'app/search/filter-types';
 import { searchFilterSelector } from 'app/search/search-filter';
 import { AppIcon, refreshIcon } from 'app/shell/icons';
+import { querySelector } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
+import _ from 'lodash';
 import React, { useMemo, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
@@ -32,7 +35,7 @@ import { useProcess } from './hooks/useProcess';
 import styles from './LoadoutBuilder.m.scss';
 import { LoadoutBuilderState, useLbState } from './loadoutBuilderReducer';
 import { filterItems } from './preProcessFilter';
-import { ItemsByBucket, statHashToType, statKeys, StatTypes } from './types';
+import { ItemsByBucket, statHashes, statHashToType, statKeys, StatTypes } from './types';
 import { isLoadoutBuilderItem } from './utils';
 
 interface ProvidedProps {
@@ -53,6 +56,7 @@ interface StoreProps {
   }>;
   loadouts: Loadout[];
   filter: ItemFilter;
+  searchQuery: string;
 }
 
 type Props = ProvidedProps & StoreProps;
@@ -105,6 +109,7 @@ function mapStateToProps() {
       items: itemsSelector(state),
       loadouts: loadoutsSelector(state),
       filter: searchFilterSelector(state),
+      searchQuery: querySelector(state),
     };
   };
 }
@@ -124,6 +129,7 @@ function LoadoutBuilder({
   loadouts,
   filter,
   preloadedLoadout,
+  searchQuery,
 }: Props) {
   const [
     {
@@ -168,6 +174,38 @@ function LoadoutBuilder({
     statOrder,
     statFilters,
     minimumPower
+  );
+
+  // A representation of the current loadout optimizer parameters that can be saved with generated loadouts
+  // TODO: replace some of these individual params with this object
+  const params: LoadoutParameters = useMemo(
+    () => ({
+      statConstraints: _.compact(
+        _.sortBy(Object.entries(statFilters), ([statName]) =>
+          statOrder.indexOf(statName as StatTypes)
+        ).map(([statName, minMax]) => {
+          if (minMax.ignored) {
+            return undefined;
+          }
+          const stat: StatConstraint = {
+            statHash: statHashes[statName],
+          };
+          if (minMax.min > 0) {
+            stat.minTier = minMax.min;
+          }
+          if (minMax.max < 10) {
+            stat.maxTier = minMax.max;
+          }
+          return stat;
+        })
+      ),
+      mods: Object.values(lockedArmor2Mods)
+        .flat()
+        .map((m) => m.modDef.hash),
+      query: searchQuery,
+      assumeMasterworked: assumeMasterwork,
+    }),
+    [assumeMasterwork, lockedArmor2Mods, searchQuery, statFilters, statOrder]
   );
 
   const combos = result?.combos || 0;
@@ -266,6 +304,7 @@ function LoadoutBuilder({
             enabledStats={enabledStats}
             lockedArmor2Mods={lockedArmor2Mods}
             loadouts={loadouts}
+            params={params}
           />
         )}
         {modPicker.open &&

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -59,42 +59,44 @@ export default function TierSelect({
       <Droppable droppableId="droppable">
         {(provided) => (
           <div ref={provided.innerRef}>
-            {_.sortBy(Object.keys(stats), (s: StatTypes) => order.indexOf(s)).map((stat, index) => (
-              <DraggableItem
-                key={stat}
-                id={stat}
-                index={index}
-                className={rowClassName}
-                name={
-                  <span className={stats[stat].ignored ? styles.ignored : ''}>
-                    <BungieImage
-                      className={styles.iconStat}
-                      src={statDefs[stat].displayProperties.icon}
-                    />
-                    {statDefs[stat].displayProperties.name}
-                  </span>
-                }
-              >
-                <MinMaxSelect
-                  stat={stat}
-                  stats={stats}
-                  type="Min"
-                  min={statRanges[stat].min}
-                  max={statRanges[stat].max}
-                  ignored={stats[stat].ignored}
-                  handleTierChange={handleTierChange}
-                />
-                <MinMaxSelect
-                  stat={stat}
-                  stats={stats}
-                  type="Max"
-                  min={statRanges[stat].min}
-                  max={statRanges[stat].max}
-                  ignored={stats[stat].ignored}
-                  handleTierChange={handleTierChange}
-                />
-              </DraggableItem>
-            ))}
+            {_.sortBy(Object.keys(stats), (s: StatTypes) => order.indexOf(s)).map(
+              (stat: StatTypes, index) => (
+                <DraggableItem
+                  key={stat}
+                  id={stat}
+                  index={index}
+                  className={rowClassName}
+                  name={
+                    <span className={stats[stat].ignored ? styles.ignored : ''}>
+                      <BungieImage
+                        className={styles.iconStat}
+                        src={statDefs[stat].displayProperties.icon}
+                      />
+                      {statDefs[stat].displayProperties.name}
+                    </span>
+                  }
+                >
+                  <MinMaxSelect
+                    stat={stat}
+                    stats={stats}
+                    type="Min"
+                    min={statRanges[stat].min}
+                    max={statRanges[stat].max}
+                    ignored={stats[stat].ignored}
+                    handleTierChange={handleTierChange}
+                  />
+                  <MinMaxSelect
+                    stat={stat}
+                    stats={stats}
+                    type="Max"
+                    min={statRanges[stat].min}
+                    max={statRanges[stat].max}
+                    ignored={stats[stat].ignored}
+                    handleTierChange={handleTierChange}
+                  />
+                </DraggableItem>
+              )
+            )}
 
             {provided.placeholder}
           </div>
@@ -146,7 +148,7 @@ function MinMaxSelectInner({
   stats,
   handleTierChange,
 }: {
-  stat: string;
+  stat: StatTypes;
   type: 'Min' | 'Max';
   min: number;
   max: number;

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -1,3 +1,4 @@
+import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { Loadout } from 'app/loadout/loadout-types';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
@@ -23,6 +24,7 @@ interface Props {
   lockedArmor2Mods: LockedArmor2ModMap;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
+  params: LoadoutParameters;
 }
 
 /**
@@ -41,10 +43,14 @@ function GeneratedSet({
   lockedArmor2Mods,
   loadouts,
   lbDispatch,
+  params,
 }: Props) {
   // Set the loadout property to show/hide the loadout menu
   const setCreateLoadout = (loadout: Loadout) => {
-    editLoadout(loadout, { showClass: false });
+    loadout.parameters = params;
+    editLoadout(loadout, {
+      showClass: false,
+    });
   };
 
   if (set.armor.some((items) => !items.length)) {

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,3 +1,4 @@
+import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t } from 'app/i18next-t';
@@ -31,6 +32,7 @@ interface Props {
   lockedArmor2Mods: LockedArmor2ModMap;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
+  params: LoadoutParameters;
 }
 
 function numColumns(set: ArmorSet) {
@@ -56,6 +58,7 @@ export default function GeneratedSets({
   lockedArmor2Mods,
   loadouts,
   lbDispatch,
+  params,
 }: Props) {
   const windowScroller = useRef<WindowScroller>(null);
   const [{ rowHeight, rowWidth }, setRowSize] = useState<{
@@ -172,6 +175,7 @@ export default function GeneratedSets({
           enabledStats={enabledStats}
           lockedArmor2Mods={lockedArmor2Mods}
           loadouts={loadouts}
+          params={params}
         />
       ) : sets.length > 0 ? (
         <WindowScroller ref={windowScroller}>
@@ -198,6 +202,7 @@ export default function GeneratedSets({
                   enabledStats={enabledStats}
                   lockedArmor2Mods={lockedArmor2Mods}
                   loadouts={loadouts}
+                  params={params}
                 />
               )}
               scrollTop={scrollTop}

--- a/src/app/loadout/loadout-types.ts
+++ b/src/app/loadout/loadout-types.ts
@@ -1,4 +1,4 @@
-import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
+import { DestinyVersion, LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 
 export interface LoadoutItem {
@@ -21,4 +21,6 @@ export interface Loadout {
   platform?: string;
   /** Whether to move other items not in the loadout off the character when applying the loadout. */
   clearSpace?: boolean;
+  /** Information about the desired properties of this loadout - used to drive the Loadout Optimizer or apply Mod Loadouts */
+  parameters?: LoadoutParameters;
 }

--- a/src/app/loadout/selectors.ts
+++ b/src/app/loadout/selectors.ts
@@ -53,6 +53,7 @@ function convertDimApiLoadoutToLoadout(
       ...loadout.equipped.map((i) => convertDimApiLoadoutItemToLoadoutItem(i, true)),
       ...loadout.unequipped.map((i) => convertDimApiLoadoutItemToLoadoutItem(i, false)),
     ],
+    parameters: loadout.parameters,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,9 +992,9 @@
     minimist "^1.2.0"
 
 "@destinyitemmanager/dim-api-types@^1.0.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@destinyitemmanager/dim-api-types/-/dim-api-types-1.7.0.tgz#ab9233a32185a5878dba00df84b6c01f4632c0eb"
-  integrity sha512-pFcZWG3YY0BjqVfCADh/B5CTtnmGmyLEvJtNuqvgsXXT+qigT/mfmFHLsMp/ychXIZPYr19d7bEov3yXedk/tg==
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@destinyitemmanager/dim-api-types/-/dim-api-types-1.7.1.tgz#5d5cecaa042b48f3d59e81a8812229b467cf3d66"
+  integrity sha512-GtTc5DjHG6+9lquj9ggfwOwBn6TmA23sLdjinBiEWkW0gPh1McaKJNk0JwT0100b2zAJyUO/9BR6my6iE5O6HA==
 
 "@eslint/eslintrc@^0.1.3":
   version "0.1.3"


### PR DESCRIPTION
This starts saving relevant loadout parameters from LO into loadouts created from that tool. They'll get saved in DIM sync, and we can use them later - this PR doesn't include any changes to display or logic.