### PR TITLE
Replace console.log with our own wrapper

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,8 @@
     "react-redux"
   ],
   "rules": {
-    "no-console": "off",
+    "no-console": "error",
+    "no-debugger": "error",
     "no-empty": "off",
     "no-implicit-coercion": "error",
     "no-restricted-properties": [

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -3,6 +3,7 @@ import updateCSSVariables from 'app/css-variables';
 import { loadDimApiData } from 'app/dim-api/actions';
 import { saveItemInfosOnStateChange } from 'app/inventory/observers';
 import store from 'app/store/store';
+import { infoLog } from 'app/utils/log';
 import { saveVendorDropsToIndexedDB } from 'app/vendorEngramsXyzApi/observers';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -41,7 +42,8 @@ initi18n().then(() => {
   // Settings depends on i18n
   watchLanguageChanges();
 
-  console.log(
+  infoLog(
+    'app',
     `DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.github.com/DestinyItemManager/DIM/issues`
   );
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,6 +28,7 @@ import Header from './shell/Header';
 import Privacy from './shell/Privacy';
 import ScrollToTop from './shell/ScrollToTop';
 import SneakyUpdates from './shell/SneakyUpdates';
+import { errorLog } from './utils/log';
 
 const WhatsNew = React.lazy(
   () => import(/* webpackChunkName: "whatsNew" */ './whats-new/WhatsNew')
@@ -93,7 +94,7 @@ function App({
         }
         await set('idb-test', true);
       } catch (e) {
-        console.error('Failed Storage Test', e);
+        errorLog('storage', 'Failed Storage Test', e);
         setStorageWorks(false);
       }
     })();

--- a/src/app/accounts/destiny-account.ts
+++ b/src/app/accounts/destiny-account.ts
@@ -2,6 +2,7 @@ import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { t } from 'app/i18next-t';
 import { battleNetIcon, faPlaystation, faSteam, faXbox, stadiaIcon } from 'app/shell/icons';
 import { ThunkResult } from 'app/store/types';
+import { errorLog } from 'app/utils/log';
 import { BungieMembershipType } from 'bungie-api-ts/common';
 import {
   DestinyGameVersions,
@@ -213,7 +214,7 @@ async function findD1Characters(account: DestinyAccount): Promise<any | null> {
     ) {
       return null;
     }
-    console.error('Error getting D1 characters for', account, e);
+    errorLog('accounts', 'Error getting D1 characters for', account, e);
     reportException('findD1Characters', e);
 
     // Return the account as if it had succeeded so it shows up in the menu

--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -1,5 +1,6 @@
 import { deleteDimApiToken } from 'app/dim-api/dim-api-helper';
 import { ThunkResult } from 'app/store/types';
+import { errorLog } from 'app/utils/log';
 import { dedupePromise } from 'app/utils/util';
 import { del, get } from 'idb-keyval';
 import _ from 'lodash';
@@ -16,9 +17,7 @@ import {
 import { accountsLoadedSelector, accountsSelector, currentAccountSelector } from './selectors';
 
 const loadAccountsFromIndexedDBAction: ThunkResult = dedupePromise(async (dispatch) => {
-  console.log('Load accounts from IDB');
   const accounts = await get<DestinyAccount[] | undefined>('accounts');
-
   dispatch(actions.loadFromIDB(accounts || []));
 });
 
@@ -34,7 +33,7 @@ const getPlatformsAction: ThunkResult<readonly DestinyAccount[]> = dedupePromise
       try {
         await dispatch(loadAccountsFromIndexedDBAction);
       } catch (e) {
-        console.error('Unable to load accounts from IDB', e);
+        errorLog('accounts', 'Unable to load accounts from IDB', e);
       }
     }
 
@@ -44,7 +43,7 @@ const getPlatformsAction: ThunkResult<readonly DestinyAccount[]> = dedupePromise
         await realAccountsPromise;
       } catch (e) {
         dispatch(actions.error(e));
-        console.error('Unable to load accounts from Bungie.net', e);
+        errorLog('accounts', 'Unable to load accounts from Bungie.net', e);
       }
     }
 

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -123,7 +123,7 @@ export async function getActiveToken(): Promise<Tokens> {
   try {
     token = await (cache || getAccessTokenFromRefreshToken(token.refreshToken!));
     setToken(token);
-    infoLog('Successfully updated auth token from refresh token.');
+    infoLog('bungie auth', 'Successfully updated auth token from refresh token.');
     return token;
   } catch (e) {
     return await handleRefreshTokenError(e);

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -1,6 +1,7 @@
 import { loggedOut } from 'app/accounts/actions';
 import { t } from 'app/i18next-t';
 import store from 'app/store/store';
+import { infoLog, warnLog } from 'app/utils/log';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { getAccessTokenFromRefreshToken } from './oauth';
 import {
@@ -34,7 +35,11 @@ export async function fetchWithBungieOAuth(
   } catch (e) {
     // Note: instanceof doesn't work due to a babel bug:
     if (e.name === 'FatalTokenError') {
-      console.warn('Unable to get auth token, clearing auth tokens & going to login: ', e);
+      warnLog(
+        'bungie auth',
+        'Unable to get auth token, clearing auth tokens & going to login: ',
+        e
+      );
       removeToken();
       goToLoginPage();
     }
@@ -52,7 +57,7 @@ export async function fetchWithBungieOAuth(
     }
     // OK, Bungie has told us our access token is expired or
     // invalid. Refresh it and try again.
-    console.log(`Access token expired, removing access token and trying again`);
+    infoLog('bungie auth', 'Access token expired, removing access token and trying again');
     removeAccessToken();
     return fetchWithBungieOAuth(request, options, true);
   }
@@ -118,7 +123,7 @@ export async function getActiveToken(): Promise<Tokens> {
   try {
     token = await (cache || getAccessTokenFromRefreshToken(token.refreshToken!));
     setToken(token);
-    console.log('Successfully updated auth token from refresh token.');
+    infoLog('Successfully updated auth token from refresh token.');
     return token;
   } catch (e) {
     return await handleRefreshTokenError(e);
@@ -129,14 +134,16 @@ export async function getActiveToken(): Promise<Tokens> {
 
 async function handleRefreshTokenError(response: Error | Response): Promise<Tokens> {
   if (response instanceof TypeError) {
-    console.warn(
+    warnLog(
+      'bungie auth',
       "Error getting auth token from refresh token because there's no internet connection (or a permissions issue). Not clearing token.",
       response
     );
     throw response;
   }
   if (response instanceof Error) {
-    console.warn(
+    warnLog(
+      'bungie auth',
       'Other error getting auth token from refresh token. Not clearing auth tokens',
       response
     );

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -2,6 +2,7 @@ import { needsDeveloper } from 'app/accounts/actions';
 import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
 import store from 'app/store/store';
+import { errorLog, infoLog } from 'app/utils/log';
 import { PlatformErrorCodes } from 'bungie-api-ts/common';
 import { HttpClient, HttpClientConfig } from 'bungie-api-ts/http';
 import _ from 'lodash';
@@ -42,7 +43,15 @@ const notifyTimeout = _.throttle(
 );
 
 const logThrottle = (timesThrottled: number, waitTime: number, url: string) =>
-  console.log('Throttled', timesThrottled, 'times, waiting', waitTime, 'ms before calling', url);
+  infoLog(
+    'bungie api',
+    'Throttled',
+    timesThrottled,
+    'times, waiting',
+    waitTime,
+    'ms before calling',
+    url
+  );
 
 // it would be really great if they implemented the pipeline operator soon
 /** used for most Bungie API requests */
@@ -104,7 +113,7 @@ export function handleErrors(error: Error) {
   }
 
   if (error instanceof SyntaxError) {
-    console.error('Error parsing Bungie.net response', error);
+    errorLog('bungie api', 'Error parsing Bungie.net response', error);
     throw new Error(t('BungieService.Difficulties'));
   }
 
@@ -210,7 +219,7 @@ export function handleErrors(error: Error) {
   }
 
   // Any other error
-  console.error('No response data:', error);
+  errorLog('bungie api', 'No response data:', error);
   throw new Error(t('BungieService.Difficulties'));
 }
 

--- a/src/app/bungie-api/destiny1-api.ts
+++ b/src/app/bungie-api/destiny1-api.ts
@@ -1,4 +1,5 @@
 import { t } from 'app/i18next-t';
+import { errorLog } from 'app/utils/log';
 import { DestinyManifest, PlatformErrorCodes, ServerResponse } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -52,10 +53,10 @@ export async function getStores(platform: DestinyAccount): Promise<any[]> {
     getDestinyInventories(platform, characters),
     getDestinyProgression(platform, characters)
       // Don't let failure of progression fail other requests.
-      .catch((e) => console.error('Failed to load character progression', e)),
+      .catch((e) => errorLog('bungie api', 'Failed to load character progression', e)),
     getDestinyAdvisors(platform, characters)
       // Don't let failure of advisors fail other requests.
-      .catch((e) => console.error('Failed to load advisors', e)),
+      .catch((e) => errorLog('bungie api', 'Failed to load advisors', e)),
   ]);
   return data[0];
 }

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -1,4 +1,5 @@
 import { t } from 'app/i18next-t';
+import { errorLog } from 'app/utils/log';
 import {
   AwaAuthorizationResult,
   awaGetActionToken,
@@ -257,7 +258,7 @@ export async function transfer(
 export function equip(account: DestinyAccount, item: DimItem): Promise<ServerResponse<number>> {
   if (item.owner === 'vault') {
     // TODO: trying to track down https://sentry.io/destiny-item-manager/dim/issues/541412672/?query=is:unresolved
-    console.error('Cannot equip to vault!');
+    errorLog('bungie api', 'Cannot equip to vault!');
     reportException('equipVault', new Error('Cannot equip to vault'));
     return Promise.resolve({}) as Promise<ServerResponse<number>>;
   }

--- a/src/app/bungie-api/oauth-tokens.ts
+++ b/src/app/bungie-api/oauth-tokens.ts
@@ -109,7 +109,7 @@ export function hasTokenExpired(token?: Token) {
   const now = Date.now();
 
   // if (token)
-  //   { console.log("Expires: " + token.name + " " + ((expires <= now)) + " " + ((expires - now) / 1000 / 60)); }
+  //   { log("Expires: " + token.name + " " + ((expires <= now)) + " " + ((expires - now) / 1000 / 60)); }
 
   return now > expires;
 }

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -60,57 +60,52 @@ export interface D1ManifestDefinitions extends ManifestDefinitions {
  */
 export function getDefinitions(): ThunkResult<D1ManifestDefinitions> {
   return async (dispatch, getState) => {
-    try {
-      let existingManifest = getState().manifest.d1Manifest;
-      if (existingManifest) {
-        return existingManifest;
-      }
-      const db = await dispatch(getManifest());
-      existingManifest = getState().manifest.d1Manifest;
-      if (existingManifest) {
-        return existingManifest;
-      }
-      const defs = {
-        isDestiny1: () => true,
-        isDestiny2: () => false,
-      };
-      // Load objects that lazily load their properties from the sqlite DB.
-      lazyTables.forEach((tableShort) => {
-        const table = `Destiny${tableShort}Definition`;
-        defs[tableShort] = {
-          get(id: number, requestor?: any) {
-            const dbTable = db[table];
-            if (!dbTable) {
-              throw new Error(`Table ${table} does not exist in the manifest`);
-            }
-            const dbEntry = dbTable[id];
-            if (!dbEntry) {
-              const requestingEntryInfo =
-                typeof requestor === 'object' ? requestor.hash : String(requestor);
-              reportException(
-                `hashLookupFailureD1: ${table}[${id}]`,
-                new Error(`hashLookupFailureD1: ${table}[${id}]`),
-                {
-                  requestingEntryInfo,
-                  failedHash: id,
-                  failedComponent: table,
-                }
-              );
-            }
-            return dbEntry;
-          },
-        };
-      });
-      // Resources that need to be fully loaded (because they're iterated over)
-      eagerTables.forEach((tableShort) => {
-        const table = `Destiny${tableShort}Definition`;
-        defs[tableShort] = db[table];
-      });
-      dispatch(setD1Manifest(defs as D1ManifestDefinitions));
-      return defs as D1ManifestDefinitions;
-    } catch (e) {
-      console.error(e);
-      throw e;
+    let existingManifest = getState().manifest.d1Manifest;
+    if (existingManifest) {
+      return existingManifest;
     }
+    const db = await dispatch(getManifest());
+    existingManifest = getState().manifest.d1Manifest;
+    if (existingManifest) {
+      return existingManifest;
+    }
+    const defs = {
+      isDestiny1: () => true,
+      isDestiny2: () => false,
+    };
+    // Load objects that lazily load their properties from the sqlite DB.
+    lazyTables.forEach((tableShort) => {
+      const table = `Destiny${tableShort}Definition`;
+      defs[tableShort] = {
+        get(id: number, requestor?: any) {
+          const dbTable = db[table];
+          if (!dbTable) {
+            throw new Error(`Table ${table} does not exist in the manifest`);
+          }
+          const dbEntry = dbTable[id];
+          if (!dbEntry) {
+            const requestingEntryInfo =
+              typeof requestor === 'object' ? requestor.hash : String(requestor);
+            reportException(
+              `hashLookupFailureD1: ${table}[${id}]`,
+              new Error(`hashLookupFailureD1: ${table}[${id}]`),
+              {
+                requestingEntryInfo,
+                failedHash: id,
+                failedComponent: table,
+              }
+            );
+          }
+          return dbEntry;
+        },
+      };
+    });
+    // Resources that need to be fully loaded (because they're iterated over)
+    eagerTables.forEach((tableShort) => {
+      const table = `Destiny${tableShort}Definition`;
+      defs[tableShort] = db[table];
+    });
+    dispatch(setD1Manifest(defs as D1ManifestDefinitions));
+    return defs as D1ManifestDefinitions;
   };
 }

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -4,6 +4,7 @@ import { t } from 'app/i18next-t';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
+import { errorLog } from 'app/utils/log';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { produce } from 'immer';
 import _ from 'lodash';
@@ -642,7 +643,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
 
   private onChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (e) => {
     if (e.target.name.length === 0) {
-      console.error(new Error('You need to have a name on the form input'));
+      errorLog('loadout optimizer', new Error('You need to have a name on the form input'));
     }
 
     if (isInputElement(e.target) && e.target.type === 'checkbox') {

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -1,3 +1,4 @@
+import { infoLog } from 'app/utils/log';
 import disciplineIcon from 'images/discipline.png';
 import intellectIcon from 'images/intellect.png';
 import strengthIcon from 'images/strength.png';
@@ -187,11 +188,11 @@ export function getSetBucketsStep(
 
                     processedCount++;
                     if (cancelToken.cancelled) {
-                      console.log('cancelled processing');
+                      infoLog('loadout optimizer', 'cancelled processing');
                       return;
                     }
                     if (processedCount % 50000 === 0) {
-                      console.log('50,000 combinations processed, still going...');
+                      infoLog('loadout optimizer', '50,000 combinations processed, still going...');
                       setTimeout(() =>
                         step(activeGuardian, h, g, c, l, ci, gh, ar, processedCount)
                       );
@@ -248,12 +249,12 @@ export function getSetBucketsStep(
       ];
 
       if (cancelToken.cancelled) {
-        console.log('cancelled processing');
+        infoLog('loadout optimizer', 'cancelled processing');
         return;
       }
 
       // Finish progress
-      console.log('processed', combos, 'combinations.');
+      infoLog('loadout optimizer', 'processed', combos, 'combinations.');
 
       resolve({
         activeGuardian,

--- a/src/app/developer/Developer.tsx
+++ b/src/app/developer/Developer.tsx
@@ -1,4 +1,5 @@
 import { registerApp } from 'app/dim-api/register-app';
+import { errorLog } from 'app/utils/log';
 import React from 'react';
 
 interface State {
@@ -180,7 +181,7 @@ export default class Developer extends React.Component<{}, State> {
 
   private onChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (e) => {
     if (e.target.name.length === 0) {
-      console.error(new Error('You need to have a name on the form input'));
+      errorLog('developer', new Error('You need to have a name on the form input'));
     }
 
     this.setState({ [e.target.name]: e.target.value });

--- a/src/app/dim-api/import.ts
+++ b/src/app/dim-api/import.ts
@@ -8,6 +8,7 @@ import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
 import { initialSettingsState } from 'app/settings/initial-settings';
 import { ThunkResult } from 'app/store/types';
+import { errorLog, infoLog } from 'app/utils/log';
 import { observeStore } from 'app/utils/redux-utils';
 import _ from 'lodash';
 import { loadDimApiData } from './actions';
@@ -34,16 +35,16 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
 
     if (dimApiData.globalSettings.dimApiEnabled && dimApiData.apiPermissionGranted) {
       try {
-        console.log('[importLegacyData] Attempting to import legacy data into DIM API');
+        infoLog('importLegacyData', 'Attempting to import legacy data into DIM API');
         const result = await importData(data);
-        console.log('[importLegacyData] Successfully imported legacy data into DIM API', result);
+        infoLog('importLegacyData', 'Successfully imported legacy data into DIM API', result);
         showImportSuccessNotification(result, true);
 
         // Reload from the server
         return await dispatch(loadDimApiData(true));
       } catch (e) {
         if (!silent) {
-          console.error('[importLegacyData] Error importing legacy data into DIM API', e);
+          errorLog('importLegacyData', 'Error importing legacy data into DIM API', e);
           showImportFailedNotification(e);
         }
         return;
@@ -59,10 +60,7 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
 
       if (!loadouts.length && !tags.length) {
         if (!silent) {
-          console.error(
-            '[importLegacyData] Error importing legacy data into DIM API - no data',
-            data
-          );
+          errorLog('importLegacyData', 'Error importing legacy data into DIM API - no data', data);
           showImportFailedNotification(new Error(t('Storage.ImportNotification.NoData')));
         }
         return;

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -16,6 +16,7 @@ import { searchConfigSelector } from 'app/search/search-config';
 import { validateQuery } from 'app/search/search-utils';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
+import { errorLog, infoLog, timer } from 'app/utils/log';
 import { clearWishLists } from 'app/wishlists/actions';
 import produce, { Draft } from 'immer';
 import _ from 'lodash';
@@ -390,7 +391,7 @@ function changeSetting<V extends keyof Settings>(state: DimApiState, prop: V, va
  * the update watermark.
  */
 function prepareUpdateQueue(state: DimApiState) {
-  console.time('prepareUpdateQueue');
+  const stopTimer = timer('prepareUpdateQueue');
   try {
     return produce(state, (draft) => {
       // If the user only wants to save data locally, then throw away the update queue.
@@ -441,7 +442,7 @@ function prepareUpdateQueue(state: DimApiState) {
       draft.updateQueue.push(...rest);
     });
   } finally {
-    console.timeEnd('prepareUpdateQueue');
+    stopTimer();
   }
 }
 
@@ -668,8 +669,9 @@ function applyFinishedUpdatesToQueue(state: DimApiState, results: ProfileUpdateR
       const result = results[i];
 
       if (!(result.status === 'Success' || result.status === 'NotFound')) {
-        console.error(
-          '[applyFinishedUpdatesToQueue] failed to update:',
+        errorLog(
+          'applyFinishedUpdatesToQueue',
+          'failed to update:',
           result.status,
           ':',
           result.message,
@@ -752,7 +754,7 @@ function setTag(
   account: DestinyAccount
 ) {
   if (!itemId || itemId === '0') {
-    console.error('Cannot tag a non-instanced item. Use setItemHashTag instead');
+    errorLog('setTag', 'Cannot tag a non-instanced item. Use setItemHashTag instead');
     return;
   }
 
@@ -837,7 +839,7 @@ function setNote(
   account: DestinyAccount
 ) {
   if (!itemId || itemId === '0') {
-    console.error('Cannot note a non-instanced item. Use setItemHashNote instead');
+    errorLog('setNote', 'Cannot note a non-instanced item. Use setItemHashNote instead');
     return;
   }
   const profileKey = makeProfileKeyFromAccount(account);
@@ -979,7 +981,7 @@ function searchUsed(draft: Draft<DimApiState>, destinyVersion: DestinyVersion, q
     }
     query = canonicalizeQuery(ast);
   } catch (e) {
-    console.error('Query not parseable - not saving', query, e);
+    errorLog('searchUsed', 'Query not parseable - not saving', query, e);
     return;
   }
 
@@ -1034,12 +1036,12 @@ function saveSearch(
   try {
     const ast = parseQuery(query);
     if (!validateQuery(ast, searchConfigs)) {
-      console.error('Query not valid - not saving', query);
+      errorLog('saveSearch', 'Query not valid - not saving', query);
       return;
     }
     query = canonicalizeQuery(ast);
   } catch (e) {
-    console.error('Query not parseable - not saving', query, e);
+    errorLog('saveSearch', 'Query not parseable - not saving', query, e);
     return;
   }
 
@@ -1081,7 +1083,7 @@ function deleteSearch(draft: Draft<DimApiState>, destinyVersion: DestinyVersion,
 
 function reverseEffects(draft: Draft<DimApiState>, update: ProfileUpdateWithRollback) {
   // TODO: put things back the way they were
-  console.log('TODO: Reversing', draft, update);
+  infoLog('reverseEffects', 'TODO: Reversing', draft, update);
 }
 
 export function parseProfileKey(profileKey: string): [string, DestinyVersion] {

--- a/src/app/dim-ui/ErrorBoundary.tsx
+++ b/src/app/dim-ui/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import ErrorPanel from 'app/shell/ErrorPanel';
+import { errorLog } from 'app/utils/log';
 import React from 'react';
 import { reportException } from '../utils/exceptions';
 
@@ -18,7 +19,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo) {
     this.setState({ error });
-    console.error(error, errorInfo);
+    errorLog(this.props.name, error, errorInfo);
     reportException(this.props.name, error, errorInfo);
   }
 

--- a/src/app/dim-ui/usePopper.ts
+++ b/src/app/dim-ui/usePopper.ts
@@ -109,7 +109,7 @@ export function usePopper({
   };
 
   useLayoutEffect(() => {
-    // console.log('Effect', name, contents.current, reference.current);
+    // log('Effect', name, contents.current, reference.current);
     // Reposition the popup as it is shown or if its size changes
     if (!contents.current || !reference.current) {
       return destroy();

--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -13,6 +13,7 @@ import {
 } from 'app/inventory/stores-helpers';
 import { refresh } from 'app/shell/refresh';
 import { ThunkResult } from 'app/store/types';
+import { infoLog } from 'app/utils/log';
 import { observeStore } from 'app/utils/redux-utils';
 import { BucketCategory } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
@@ -67,7 +68,7 @@ export function startFarming(storeId: string): ThunkResult {
       return;
     }
 
-    console.log('Started farming', farmingStore.name);
+    infoLog('farming', 'Started farming', farmingStore.name);
 
     let unsubscribe = _.noop;
 
@@ -78,7 +79,7 @@ export function startFarming(storeId: string): ThunkResult {
       }
 
       if (farmingInterruptedSelector(getState())) {
-        console.log('Farming interrupted, will resume when tasks are complete');
+        infoLog('farming', 'Farming interrupted, will resume when tasks are complete');
       } else {
         if (isD1Store(farmingStore)) {
           dispatch(farmD1(farmingStore));

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -1,6 +1,7 @@
 import { getPlatforms } from 'app/accounts/platforms';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { ThunkResult } from 'app/store/types';
+import { errorLog, infoLog } from 'app/utils/log';
 import _ from 'lodash';
 import { getStores } from '../bungie-api/destiny1-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
@@ -60,7 +61,7 @@ export function loadStores(): ThunkResult<D1Store[] | undefined> {
 
         return stores;
       } catch (e) {
-        console.error('Error loading stores', e);
+        errorLog('d1-stores', 'Error loading stores', e);
         reportException('D1StoresService', e);
         if (storesSelector(getState()).length > 0) {
           // don't replace their inventory with the error, just notify
@@ -96,7 +97,7 @@ function processCurrencies(rawStores: any[], defs: D1ManifestDefinitions) {
       };
     });
   } catch (e) {
-    console.log('error', e);
+    infoLog('d1-stores', 'error processing currencies', e);
   }
   return [];
 }

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -4,6 +4,7 @@ import { showItemPicker } from 'app/item-picker/item-picker';
 import { hideItemPopup } from 'app/item-popup/item-popup';
 import { ThunkResult } from 'app/store/types';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
+import { errorLog, infoLog } from 'app/utils/log';
 import { PlatformErrorCodes } from 'bungie-api-ts/common';
 import _ from 'lodash';
 import { Subject } from 'rxjs';
@@ -146,7 +147,8 @@ export function moveItemTo(
       }
 
       if ($featureFlags.debugMoves) {
-        console.log(
+        infoLog(
+          'move',
           'User initiated move:',
           moveAmount,
           item.name,
@@ -173,7 +175,7 @@ export function moveItemTo(
 
       updateManualMoveTimestamp(item);
     } catch (e) {
-      console.error('error moving item', item.name, 'to', store.name, e);
+      errorLog('move', 'error moving item', item.name, 'to', store.name, e);
       // Some errors aren't worth reporting
       if (
         e.code !== 'wrong-level' &&
@@ -235,7 +237,7 @@ export function consolidate(actionableItem: DimItem, store: DimStore): ThunkResu
             });
           } catch (a) {
             showNotification({ type: 'error', title: actionableItem.name, body: a.message });
-            console.error('error consolidating', actionableItem, a);
+            errorLog('move', 'error consolidating', actionableItem, a);
           }
         })()
       )
@@ -317,7 +319,7 @@ export function distribute(actionableItem: DimItem): ThunkResult {
             });
           } catch (a) {
             showNotification({ type: 'error', title: actionableItem.name, body: a.message });
-            console.error('error distributing', actionableItem, a);
+            errorLog('move', 'error distributing', actionableItem, a);
           }
         })()
       )

--- a/src/app/inventory/observers.ts
+++ b/src/app/inventory/observers.ts
@@ -1,5 +1,6 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { RootState } from 'app/store/types';
+import { errorLog } from 'app/utils/log';
 import { observeStore } from 'app/utils/redux-utils';
 import { set } from 'idb-keyval';
 import _ from 'lodash';
@@ -19,7 +20,7 @@ export const saveItemInfosOnStateChange = _.once(() => {
         try {
           return await set(key, newItems);
         } catch (e) {
-          console.error("Couldn't save new items", e);
+          errorLog('new-items', "Couldn't save new items", e);
         }
       }
     }, 1000)

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -1,4 +1,5 @@
 import { DimError } from 'app/bungie-api/bungie-service-helper';
+import { warnLog } from 'app/utils/log';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import produce, { Draft } from 'immer';
 import _ from 'lodash';
@@ -285,7 +286,7 @@ function itemMoved(
   const source = getStore(stores, sourceStoreId);
   const target = getStore(stores, targetStoreId);
   if (!source || !target) {
-    console.warn('Either source or target store not found', source, target);
+    warnLog('move', 'Either source or target store not found', source, target);
     return;
   }
 
@@ -293,7 +294,7 @@ function itemMoved(
     (i) => i.hash === item.hash && i.id === item.id && i.location.hash === item.location.hash
   )!;
   if (!item) {
-    console.warn('Moved item not found', item);
+    warnLog('move', 'Moved item not found', item);
     return;
   }
 
@@ -338,7 +339,7 @@ function itemMoved(
     while (removeAmount > 0) {
       const sourceItem = sourceItems.shift();
       if (!sourceItem) {
-        console.warn('Source item missing', item);
+        warnLog('move', 'Source item missing', item);
         return;
       }
 
@@ -399,14 +400,14 @@ function itemLockStateChanged(
 ) {
   const source = getStore(draft.stores, item.owner);
   if (!source) {
-    console.warn('Store', item.owner, 'not found');
+    warnLog('move', 'Store', item.owner, 'not found');
     return;
   }
 
   // Only instanced items can be locked/tracked
   item = source.items.find((i) => i.id === item.id)!;
   if (!item) {
-    console.warn('Item not found in stores', item);
+    warnLog('move', 'Item not found in stores', item);
     return;
   }
 

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -1,4 +1,5 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
+import { warnLog } from 'app/utils/log';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { StatHashes } from 'data/d2/generated-enums';
 import disciplineIcon from 'images/discipline.png';
@@ -75,7 +76,7 @@ export function getBonus(light: number, type: string): number {
         ? 42
         : 43;
   }
-  console.warn('item bonus not found', type);
+  warnLog('getBonus', 'item bonus not found', type);
   return 0;
 }
 

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -1,5 +1,6 @@
 import { t } from 'app/i18next-t';
 import { getItemYear } from 'app/utils/item-utils';
+import { errorLog, warnLog } from 'app/utils/log';
 import {
   DestinyAmmunitionType,
   DestinyClass,
@@ -39,7 +40,7 @@ export async function processItems(
     try {
       createdItem = makeItem(defs, buckets, item, owner);
     } catch (e) {
-      console.error('Error processing item', item, e);
+      errorLog('d1-stores', 'Error processing item', item, e);
       reportException('Processing D1 item', e);
     }
     if (createdItem !== null) {
@@ -150,7 +151,8 @@ function makeItem(
   }
 
   if (itemDef.redacted) {
-    console.warn(
+    warnLog(
+      'd1-stores',
       'Missing Item Definition:\n\n',
       item,
       '\n\nThis item is not in the current manifest and will be added at a later time by Bungie.'
@@ -341,7 +343,7 @@ function makeItem(
   try {
     createdItem.talentGrid = buildTalentGrid(item, defs.TalentGrid, defs.Progression);
   } catch (e) {
-    console.error(`Error building talent grid for ${createdItem.name}`, item, itemDef, e);
+    errorLog('d1-stores', `Error building talent grid for ${createdItem.name}`, item, itemDef, e);
   }
 
   createdItem.infusable = Boolean(createdItem.talentGrid?.infusable);
@@ -358,7 +360,7 @@ function makeItem(
       createdItem.stats = buildStats(item, item, defs.Stat, createdItem.talentGrid, itemType);
     }
   } catch (e) {
-    console.error(`Error building stats for ${createdItem.name}`, item, itemDef, e);
+    errorLog('d1-stores', `Error building stats for ${createdItem.name}`, item, itemDef, e);
   }
 
   createdItem.objectives = item.objectives?.length > 0 ? item.objectives : null;
@@ -367,7 +369,13 @@ function makeItem(
     try {
       createdItem.quality = getQualityRating(createdItem.stats, item.primaryStat, itemType);
     } catch (e) {
-      console.error(`Error building quality rating for ${createdItem.name}`, item, itemDef, e);
+      errorLog(
+        'd1-stores',
+        `Error building quality rating for ${createdItem.name}`,
+        item,
+        itemDef,
+        e
+      );
     }
   }
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -1,5 +1,6 @@
 import { t } from 'app/i18next-t';
 import { THE_FORBIDDEN_BUCKET } from 'app/search/d2-known-values';
+import { errorLog, warnLog } from 'app/utils/log';
 import {
   DestinyAmmunitionType,
   DestinyClass,
@@ -73,7 +74,7 @@ export function processItems(
         uninstancedItemObjectives
       );
     } catch (e) {
-      console.error('Error processing item', item, e);
+      errorLog('d2-stores', 'Error processing item', item, e);
       reportException('Processing Dim item', e);
     }
     if (createdItem !== null) {
@@ -164,7 +165,8 @@ export function makeItem(
   }
 
   if (itemDef.redacted) {
-    console.warn(
+    warnLog(
+      'd2-stores',
       'Missing Item Definition:\n\n',
       { item, itemDef, instanceDef },
       '\n\nThis item is not in the current manifest and will be added at a later time by Bungie.'
@@ -390,7 +392,7 @@ export function makeItem(
     createdItem.sockets = socketInfo.sockets;
     createdItem.missingSockets = socketInfo.missingSockets;
   } catch (e) {
-    console.error(`Error building sockets for ${createdItem.name}`, item, itemDef, e);
+    errorLog('d2-stores', `Error building sockets for ${createdItem.name}`, item, itemDef, e);
     reportException('Sockets', e, { itemHash: item.itemHash });
   }
 
@@ -398,7 +400,7 @@ export function makeItem(
     const stats = itemComponents?.stats?.data;
     createdItem.stats = buildStats(createdItem, stats || null, itemDef, defs);
   } catch (e) {
-    console.error(`Error building stats for ${createdItem.name}`, item, itemDef, e);
+    errorLog('d2-stores', `Error building stats for ${createdItem.name}`, item, itemDef, e);
     reportException('Stats', e, { itemHash: item.itemHash });
   }
 
@@ -408,7 +410,7 @@ export function makeItem(
       createdItem.talentGrid = buildTalentGrid(item, talentData, defs);
     }
   } catch (e) {
-    console.error(`Error building talent grid for ${createdItem.name}`, item, itemDef, e);
+    errorLog('d2-stores', `Error building talent grid for ${createdItem.name}`, item, itemDef, e);
     reportException('TalentGrid', e, { itemHash: item.itemHash });
   }
 
@@ -423,7 +425,7 @@ export function makeItem(
       );
     }
   } catch (e) {
-    console.error(`Error building objectives for ${createdItem.name}`, item, itemDef, e);
+    errorLog('d2-stores', `Error building objectives for ${createdItem.name}`, item, itemDef, e);
     reportException('Objectives', e, { itemHash: item.itemHash });
   }
 
@@ -507,14 +509,20 @@ export function makeItem(
   try {
     createdItem.masterworkInfo = buildMasterwork(createdItem, defs);
   } catch (e) {
-    console.error(`Error building masterwork info for ${createdItem.name}`, item, itemDef, e);
+    errorLog(
+      'd2-stores',
+      `Error building masterwork info for ${createdItem.name}`,
+      item,
+      itemDef,
+      e
+    );
     reportException('MasterworkInfo', e, { itemHash: item.itemHash });
   }
 
   try {
     buildPursuitInfo(createdItem, item, itemDef);
   } catch (e) {
-    console.error(`Error building Quest info for ${createdItem.name}`, item, itemDef, e);
+    errorLog('d2-stores', `Error building Quest info for ${createdItem.name}`, item, itemDef, e);
     reportException('Quest', e, { itemHash: item.itemHash });
   }
 

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -6,6 +6,7 @@ import { storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { RootState } from 'app/store/types';
 import { useSubscription } from 'app/utils/hooks';
+import { infoLog } from 'app/utils/log';
 import clsx from 'clsx';
 import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
@@ -102,7 +103,7 @@ function ItemPopupContainer({
         });
         // Log the item so it's easy to inspect item structure by clicking on an item
         if ($DIM_FLAVOR !== 'release') {
-          console.log(item);
+          infoLog('clicked item', item);
         }
       }
     })

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -1,6 +1,7 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { Loadout } from 'app/loadout/loadout-types';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
+import { errorLog } from 'app/utils/log';
 import React, { Dispatch } from 'react';
 import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
@@ -48,7 +49,7 @@ function GeneratedSet({
   };
 
   if (set.armor.some((items) => !items.length)) {
-    console.error('No valid sets!');
+    errorLog('loadout optimizer', 'No valid sets!');
     return null;
   }
 

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -1,5 +1,6 @@
 import { DimItem } from 'app/inventory/item-types';
 import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
+import { infoLog } from 'app/utils/log';
 import { releaseProxy, wrap } from 'comlink';
 import _ from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
@@ -105,7 +106,10 @@ export function useProcess(
         minimumPower
       )
       .then(({ sets, combos, combosWithoutCaps, statRanges }) => {
-        console.log(`useProcess: worker time ${performance.now() - workerStart}ms`);
+        infoLog(
+          'loadout optimizer',
+          `useProcess: worker time ${performance.now() - workerStart}ms`
+        );
         const hydratedSets = sets.map((set) => hydrateArmorSet(set, itemsById));
 
         setState({
@@ -119,7 +123,7 @@ export function useProcess(
           currentCleanup: null,
         });
 
-        console.log(`useProcess ${performance.now() - processStart}ms`);
+        infoLog('loadout optimizer', `useProcess ${performance.now() - processStart}ms`);
       });
     /* do not include things from state or worker in dependencies */
     /* eslint-disable react-hooks/exhaustive-deps */

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -1,6 +1,7 @@
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { armor2PlugCategoryHashesByName, TOTAL_STAT_HASH } from '../../search/d2-known-values';
+import { infoLog } from '../../utils/log';
 import { LockableBuckets, MinMax, MinMaxIgnored, statHashes, StatTypes } from '../types';
 import { statTier } from '../utils';
 import { canTakeGeneralAndSeasonalMods, generateModPermutations } from './processUtils';
@@ -152,7 +153,13 @@ export function process(
   }
 
   if (combos < combosWithoutCaps) {
-    console.log('Reduced armor combinations from', combosWithoutCaps, 'to', combos);
+    infoLog(
+      'loadout optimizer',
+      'Reduced armor combinations from',
+      combosWithoutCaps,
+      'to',
+      combos
+    );
   }
 
   if (combos === 0) {
@@ -302,7 +309,8 @@ export function process(
 
   const finalSets = setTracker.map((set) => set.statMixes.map((mix) => mix.armorSets)).flat(2);
 
-  console.log(
+  infoLog(
+    'loadout optimizer',
     'found',
     finalSets.length,
     'stat mixes after processing',

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -1,6 +1,7 @@
 import { t } from 'app/i18next-t';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
+import { infoLog } from 'app/utils/log';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
@@ -187,7 +188,6 @@ function fillLoadoutFromEquipped(
     (item) => item.equipped && itemCanBeInLoadout(item) && fromEquippedTypes.includes(item.type)
   );
 
-  console.log({ items, loadout, dimStore });
   for (const item of items) {
     if (
       !itemsByBucket[item.bucket.hash] ||
@@ -195,7 +195,7 @@ function fillLoadoutFromEquipped(
     ) {
       add(item, undefined, true);
     } else {
-      console.log('Skipping', item, { itemsByBucket, bucketId: item.bucket.hash });
+      infoLog('loadout', 'Skipping', item, { itemsByBucket, bucketId: item.bucket.hash });
     }
   }
 }

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -25,6 +25,7 @@ import { showNotification } from 'app/notifications/notifications';
 import { loadingTracker } from 'app/shell/loading-tracker';
 import { ThunkResult } from 'app/store/types';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
+import { errorLog, infoLog } from 'app/utils/log';
 import copy from 'fast-copy';
 import _ from 'lodash';
 import { savePreviousLoadout } from './actions';
@@ -62,7 +63,7 @@ export function applyLoadout(store: DimStore, loadout: Loadout, allowUndo = fals
     }
 
     if ($featureFlags.debugMoves) {
-      console.log('LoadoutService: Apply loadout', loadout.name, 'to', store.name);
+      infoLog('loadout', 'Apply loadout', loadout.name, 'to', store.name);
     }
 
     const loadoutPromise = queueAction(() => dispatch(doApplyLoadout(store, loadout, allowUndo)));
@@ -320,7 +321,7 @@ function applyLoadoutItems(
     } catch (e) {
       const level = e.level || 'error';
       if (level === 'error') {
-        console.error('Failed to apply loadout item', item?.name, e);
+        errorLog('loadout', 'Failed to apply loadout item', item?.name, e);
         scope.failed++;
       }
       scope.errors.push({
@@ -431,7 +432,8 @@ export function clearItemsOffCharacter(
 
           if (otherStoresWithSpace.length) {
             if ($featureFlags.debugMoves) {
-              console.log(
+              infoLog(
+                'loadout',
                 'clearItemsOffCharacter initiated move:',
                 item.amount,
                 item.name,
@@ -452,7 +454,8 @@ export function clearItemsOffCharacter(
           }
         }
         if ($featureFlags.debugMoves) {
-          console.log(
+          infoLog(
+            'loadout',
             'clearItemsOffCharacter initiated move:',
             item.amount,
             item.name,

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -8,6 +8,7 @@ import {
   spaceLeftForItem,
 } from 'app/inventory/stores-helpers';
 import { ThunkResult } from 'app/store/types';
+import { errorLog } from 'app/utils/log';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
@@ -157,7 +158,7 @@ export function pullFromPostmaster(store: DimStore): ThunkResult {
           succeeded++;
         } catch (e) {
           // TODO: collect errors
-          console.error(`Error pulling ${item.name} from postmaster`, e);
+          errorLog('postmaster', `Error pulling ${item.name} from postmaster`, e);
           if (e.code === 'no-space') {
             showNoSpaceError(e);
           } else {

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -2,6 +2,7 @@ import { settingsSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { loadingEnd, loadingStart } from 'app/shell/actions';
 import { ThunkResult } from 'app/store/types';
+import { errorLog, infoLog } from 'app/utils/log';
 import { dedupePromise } from 'app/utils/util';
 import { del, get, set } from 'idb-keyval';
 import { showNotification } from '../notifications/notifications';
@@ -56,7 +57,7 @@ function doGetManifest(): ThunkResult<object> {
       }
 
       const statusText = t('Manifest.Error', { error: message });
-      console.error('Manifest loading error', { error: e }, e);
+      errorLog('manifest', 'Manifest loading error', { error: e }, e);
       reportException('manifest load', e);
       throw new Error(statusText);
     } finally {
@@ -108,10 +109,10 @@ function loadManifestRemote(version: string, path: string): ThunkResult<object> 
 async function saveManifestToIndexedDB(typedArray: object, version: string) {
   try {
     await set(idbKey, typedArray);
-    console.log(`Sucessfully stored manifest file.`);
+    infoLog('manifest', `Sucessfully stored manifest file.`);
     localStorage.setItem(localStorageKey, version);
   } catch (e) {
-    console.error('Error saving manifest file', e);
+    errorLog('manifest', 'Error saving manifest file', e);
     showNotification({
       title: t('Help.NoStorage'),
       body: t('Help.NoStorageMessage'),

--- a/src/app/progress/WellRestedPerkIcon.tsx
+++ b/src/app/progress/WellRestedPerkIcon.tsx
@@ -27,7 +27,6 @@ export default function WellRestedPerkIcon({
   }
   const wellRestedPerk = defs.SandboxPerk.get(WELL_RESTED_PERK);
   if (!wellRestedPerk) {
-    console.error("Couldn't find Well Rested perk in manifest");
     return null;
   }
   const perkDisplay = wellRestedPerk.displayProperties;

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -1,6 +1,7 @@
 import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
+import { errorLog } from 'app/utils/log';
 import { createSelector } from 'reselect';
 import { getTag, ItemInfos } from '../inventory/dim-item-info';
 import { DimItem } from '../inventory/item-types';
@@ -137,7 +138,7 @@ function makeSearchFilterFactory(
             try {
               return filterDef.filter({ filterValue, ...filterContext });
             } catch (e) {
-              console.error('Invalid query term', filterName, filterValue, e);
+              errorLog('search', 'Invalid query term', filterName, filterValue, e);
               return () => true;
             }
           }

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import WishListSettings from 'app/settings/WishListSettings';
 import { dimHunterIcon, dimTitanIcon, dimWarlockIcon } from 'app/shell/icons/custom';
 import DimApiSettings from 'app/storage/DimApiSettings';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { errorLog } from 'app/utils/log';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import i18next from 'i18next';
 import exampleArmorImage from 'images/example-armor.jpg';
@@ -158,7 +159,7 @@ function SettingsPage({
 
   const onChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (e) => {
     if (e.target.name.length === 0) {
-      console.error(new Error('You need to have a name on the form input'));
+      errorLog('settings', new Error('You need to have a name on the form input'));
     }
 
     if (isInputElement(e.target) && e.target.type === 'checkbox') {

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -8,6 +8,7 @@ import { accountRoute } from 'app/routes';
 import { SearchFilterRef } from 'app/search/SearchBar';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { useSubscription } from 'app/utils/hooks';
+import { infoLog } from 'app/utils/log';
 import { getAllVendorDrops, isDroppingHigh } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
 import clsx from 'clsx';
 import logo from 'images/logo-type-right-light.svg';
@@ -91,9 +92,9 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
       installPromptEvent.prompt();
       installPromptEvent.userChoice.then((choiceResult) => {
         if (choiceResult.outcome === 'accepted') {
-          console.log('User installed DIM to desktop/home screen');
+          infoLog('install', 'User installed DIM to desktop/home screen');
         } else {
-          console.log('User dismissed the install prompt');
+          infoLog('install', 'User dismissed the install prompt');
         }
         installPrompt$.next(undefined);
       });

--- a/src/app/utils/log.ts
+++ b/src/app/utils/log.ts
@@ -16,7 +16,7 @@ export function infoLog(tag: string, ...args: any[]) {
  * Otherwise, we'll prevent warnLog from getting submitted via a lint rule.
  *
  * @param tag an informative label for categorizing this log
- * @example warn("Manifest", "The manifest loaded")
+ * @example warn("Manifest", "The manifest is out of date")
  */
 export function warnLog(tag: string, ...args: any[]) {
   console.warn(`[${tag}]`, ...args);
@@ -27,7 +27,7 @@ export function warnLog(tag: string, ...args: any[]) {
  * Otherwise, we'll prevent errorLog from getting submitted via a lint rule.
  *
  * @param tag an informative label for categorizing this log
- * @example error("Manifest", "The manifest loaded")
+ * @example error("Manifest", "The manifest failed to load")
  */
 export function errorLog(tag: string, ...args: any[]) {
   console.error(`[${tag}]`, ...args);

--- a/src/app/utils/log.ts
+++ b/src/app/utils/log.ts
@@ -1,0 +1,45 @@
+/* eslint-disable no-console */
+
+/**
+ * A wrapper around log. Use this when you mean to have logging in the shipped app.
+ * Otherwise, we'll prevent log from getting submitted via a lint rule.
+ *
+ * @param tag an informative label for categorizing this log
+ * @example infoLog("Manifest", "The manifest loaded")
+ */
+export function infoLog(tag: string, ...args: any[]) {
+  console.log(`[${tag}]`, ...args);
+}
+
+/**
+ * A wrapper around warnLog. Use this when you mean to have logging in the shipped app.
+ * Otherwise, we'll prevent warnLog from getting submitted via a lint rule.
+ *
+ * @param tag an informative label for categorizing this log
+ * @example warn("Manifest", "The manifest loaded")
+ */
+export function warnLog(tag: string, ...args: any[]) {
+  console.warn(`[${tag}]`, ...args);
+}
+
+/**
+ * A wrapper around errorLog. Use this when you mean to have logging in the shipped app.
+ * Otherwise, we'll prevent errorLog from getting submitted via a lint rule.
+ *
+ * @param tag an informative label for categorizing this log
+ * @example error("Manifest", "The manifest loaded")
+ */
+export function errorLog(tag: string, ...args: any[]) {
+  console.error(`[${tag}]`, ...args);
+}
+
+/**
+ * A wrapper around console.time. Use this when you mean to have timing in the shipped app.
+ * Otherwise, we'll prevent console.time from getting submitted via a lint rule.
+ *
+ * Unlike the real console.time, this returns a function that is used to end the timer.
+ */
+export function timer(tag: string) {
+  console.time(tag);
+  return () => console.timeEnd(tag);
+}

--- a/src/app/utils/log.ts
+++ b/src/app/utils/log.ts
@@ -7,8 +7,8 @@
  * @param tag an informative label for categorizing this log
  * @example infoLog("Manifest", "The manifest loaded")
  */
-export function infoLog(tag: string, ...args: any[]) {
-  console.log(`[${tag}]`, ...args);
+export function infoLog(tag: string, message: any, ...args: any[]) {
+  console.log(`[${tag}]`, message, ...args);
 }
 
 /**
@@ -18,8 +18,8 @@ export function infoLog(tag: string, ...args: any[]) {
  * @param tag an informative label for categorizing this log
  * @example warn("Manifest", "The manifest is out of date")
  */
-export function warnLog(tag: string, ...args: any[]) {
-  console.warn(`[${tag}]`, ...args);
+export function warnLog(tag: string, message: any, ...args: any[]) {
+  console.warn(`[${tag}]`, message, ...args);
 }
 
 /**
@@ -29,8 +29,8 @@ export function warnLog(tag: string, ...args: any[]) {
  * @param tag an informative label for categorizing this log
  * @example error("Manifest", "The manifest failed to load")
  */
-export function errorLog(tag: string, ...args: any[]) {
-  console.error(`[${tag}]`, ...args);
+export function errorLog(tag: string, message: any, ...args: any[]) {
+  console.error(`[${tag}]`, message, ...args);
 }
 
 /**

--- a/src/app/utils/useWhatChanged.ts
+++ b/src/app/utils/useWhatChanged.ts
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { infoLog } from './log';
 
 /**
  * A debugging hook that will print out what changed since the last render!
@@ -11,12 +12,12 @@ export function useWhatChanged<T extends object>(name: string, params: T) {
   const previousState = useRef<T>();
 
   if (!previousState.current) {
-    console.log(`[useWhatChanged] ${name} first render`);
+    infoLog('useWhatChanged', `${name} first render`);
   } else {
     for (const [key, val] of Object.entries(params)) {
       const previousVal = previousState.current[key];
       if (val !== previousVal) {
-        console.log(`[useWhatChanged] ${name} ${key}`, previousVal, val);
+        infoLog('useWhatChanged', `${name} ${key}`, previousVal, val);
       }
     }
   }

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -5,6 +5,7 @@ import { setSetting } from 'app/settings/actions';
 import { settingsReady } from 'app/settings/settings';
 import { isValidWishListUrlDomain, wishListAllowedPrefixes } from 'app/settings/WishListSettings';
 import { ThunkResult } from 'app/store/types';
+import { errorLog, infoLog } from 'app/utils/log';
 import { get } from 'idb-keyval';
 import _ from 'lodash';
 import { loadWishLists, touchWishLists } from './actions';
@@ -91,7 +92,7 @@ export function fetchWishList(newWishlistSource?: string): ThunkResult {
         title: t('WishListRoll.Header'),
         body: t('WishListRoll.ImportFailed'),
       });
-      console.error('Unable to load wish list', e);
+      errorLog('wishlist', 'Unable to load wish list', e);
       return;
     }
 
@@ -108,7 +109,7 @@ export function fetchWishList(newWishlistSource?: string): ThunkResult {
     ) {
       dispatch(transformAndStoreWishList(wishListAndInfo));
     } else {
-      console.log('Refreshed wishlist, but it matched the one we already have');
+      infoLog('wishlist', 'Refreshed wishlist, but it matched the one we already have');
       dispatch(touchWishLists());
     }
   };

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -1,4 +1,5 @@
 import { emptySet } from 'app/utils/empty';
+import { timer, warnLog } from 'app/utils/log';
 import { DimWishList, WishListAndInfo, WishListRoll } from './types';
 
 /**
@@ -21,6 +22,7 @@ const notesLabel = '//notes:';
  * a wish list text file.
  */
 export function toWishList(fileText: string): WishListAndInfo {
+  const stopTimer = timer('Parse wish list');
   try {
     const wishList: WishListAndInfo = {
       wishListRolls: [],
@@ -28,7 +30,6 @@ export function toWishList(fileText: string): WishListAndInfo {
       description: undefined,
     };
 
-    console.time('Parse wish list');
     let blockNotes: string | undefined = undefined;
     const seen = new Set<string>();
     let dups = 0;
@@ -65,11 +66,11 @@ export function toWishList(fileText: string): WishListAndInfo {
     }
 
     if (dups > 0) {
-      console.warn('Discarded', dups, 'duplicate rolls from wish list');
+      warnLog('wishlist', 'Discarded', dups, 'duplicate rolls from wish list');
     }
     return wishList;
   } finally {
-    console.timeEnd('Parse wish list');
+    stopTimer();
   }
 }
 

--- a/src/authReturn.ts
+++ b/src/authReturn.ts
@@ -1,3 +1,4 @@
+import { errorLog } from 'app/utils/log';
 import { getAccessTokenFromCode } from './app/bungie-api/oauth';
 import { setToken } from './app/bungie-api/oauth-tokens';
 import { reportException } from './app/utils/exceptions';
@@ -36,7 +37,7 @@ function handleAuthReturn() {
         );
         return;
       }
-      console.error("Couldn't get access token", error);
+      errorLog('bungie auth', "Couldn't get access token", error);
       reportException('authReturn', error);
       setError(error.message || error.data?.error_description || 'Unknown'); // eslint-disable-line @typescript-eslint/naming-convention
     });


### PR DESCRIPTION
Sometimes we forget and leave debugging console logs in our PRs. This fixes that by moving all the logging we intend to keep under some wrappers, so you can console.log all you want while developing, but then ESLint will yell at you if you try to check it in.