### PR TITLE
Loadout Optimizer - compare with currently equipped gear

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -6,6 +6,7 @@ import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { Loadout } from 'app/loadout/loadout-types';
+import { loadoutFromEquipped } from 'app/loadout/loadout-utils';
 import LoadoutDrawer from 'app/loadout/LoadoutDrawer';
 import { loadoutsSelector } from 'app/loadout/selectors';
 import { ItemFilter } from 'app/search/filter-types';
@@ -146,6 +147,9 @@ function LoadoutBuilder({
   );
 
   const characterItems: ItemsByBucket | undefined = selectedStore && items[selectedStore.classType];
+
+  const equippedLoadout: Loadout | undefined = selectedStore && loadoutFromEquipped(selectedStore);
+  loadouts = equippedLoadout ? [...loadouts, equippedLoadout] : loadouts;
 
   const filteredItems = useMemo(
     () =>

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -234,3 +234,18 @@ export function getItemsFromLoadoutItems(
 
   return [items, warnitems];
 }
+
+/**
+ * Returns a Loadout object containing currently equipped items
+ */
+export function loadoutFromEquipped(store: DimStore): Loadout {
+  const items = store.items.filter((item) => item.equipped && itemCanBeInLoadout(item));
+
+  const loadout = newLoadout(
+    'Currently Equipped',
+    items.map((i) => convertToLoadoutItem(i, true))
+  );
+  loadout.classType = store.classType;
+
+  return loadout;
+}


### PR DESCRIPTION
PR for issue #5971.
Can now compare generated sets with a loadout made of currently equipped items even with no prior saved loadouts.
![image](https://user-images.githubusercontent.com/15267770/95656232-91025500-0b15-11eb-926b-fe1829aa9a37.png)
