### PR TITLE
Hide store header on short screens

### DIFF
--- a/src/app/dim-ui/ScrollClassDiv.tsx
+++ b/src/app/dim-ui/ScrollClassDiv.tsx
@@ -2,10 +2,12 @@ import React, { useEffect, useRef } from 'react';
 
 export default React.memo(function ScrollClassDiv({
   scrollClass,
+  hideClass,
   children,
   ...divProps
 }: React.HTMLAttributes<HTMLDivElement> & {
   scrollClass: string;
+  hideClass?: string;
 }) {
   const rafTimer = useRef<number>(0);
   const ref = useRef<HTMLDivElement>(null);
@@ -17,6 +19,10 @@ export default React.memo(function ScrollClassDiv({
       );
       if (ref.current) {
         ref.current.classList.toggle(scrollClass, scrolled);
+
+        if (hideClass) {
+          ref.current.classList.toggle(hideClass, window.innerHeight < 500);
+        }
       }
     };
 
@@ -27,7 +33,7 @@ export default React.memo(function ScrollClassDiv({
 
     document.addEventListener('scroll', scrollHandler, false);
     return () => document.removeEventListener('scroll', scrollHandler);
-  }, [scrollClass]);
+  }, [scrollClass, hideClass]);
 
   return (
     <div ref={ref} {...divProps}>

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -230,6 +230,10 @@
   &.sticky {
     box-shadow: 0 1px 4px 0px black;
   }
+  &.hide {
+    position: inherit;
+    box-shadow: none;
+  }
   .phone-portrait & {
     padding-left: 0;
     overflow: hidden;

--- a/src/app/inventory/Stores.tsx
+++ b/src/app/inventory/Stores.tsx
@@ -168,7 +168,7 @@ function Stores(this: void, { stores, buckets, isPhonePortrait }: Props) {
       role="main"
       aria-label={t('Header.Inventory')}
     >
-      <ScrollClassDiv className="store-row store-header" scrollClass="sticky">
+      <ScrollClassDiv className="store-row store-header" scrollClass="sticky" hideClass="hide">
         {stores.map((store, index) => (
           <div
             className={clsx('store-cell', { vault: store.isVault })}


### PR DESCRIPTION
Just a thought & fine with abandoning it.

DIM on landscape phones can be tricky to use because the store header takes up a large part of it. Maybe we could instead show a very thin bar that partially shows the emblem background/character tile?  

Thought about making it show again if you start to swipe up again, but that can can be frustrating at times (DIM requires lots of up + down scrolling to find things.)


|before|after|
|---|---|
|<img width="734" alt="Screen Shot 2020-10-10 at 3 17 46 PM" src="https://user-images.githubusercontent.com/424158/95666155-e33e7880-0b0b-11eb-8203-fdd0283c8910.png">|<img width="734" alt="Screen Shot 2020-10-10 at 3 18 02 PM" src="https://user-images.githubusercontent.com/424158/95666148-d15cd580-0b0b-11eb-936d-bc1a00f2ebcc.png">
|<img width="730" alt="Screen Shot 2020-10-10 at 3 19 35 PM" src="https://user-images.githubusercontent.com/424158/95666175-0f59f980-0b0c-11eb-9dce-8bfafb1c9c58.png">|<img width="732" alt="Screen Shot 2020-10-10 at 3 19 26 PM" src="https://user-images.githubusercontent.com/424158/95666177-11bc5380-0b0c-11eb-946e-d50e93fb12dc.png">|
