### PR TITLE
Make the farming mode display on mobile smaller

### DIFF
--- a/src/app/active-mode/InventoryModeToggle.m.scss
+++ b/src/app/active-mode/InventoryModeToggle.m.scss
@@ -18,8 +18,7 @@
   }
 
   @include phone-portrait {
-    bottom: 58px;
-    top: inherit;
+    top: 110px;
     right: 7px;
   }
 }

--- a/src/app/farming/farming.scss
+++ b/src/app/farming/farming.scss
@@ -57,4 +57,19 @@
     transform: translateY(250px) translateX(-50%);
     transition: transform 200ms $easeInCubic;
   }
+
+  @include phone-portrait {
+    width: auto;
+    right: 0px;
+    bottom: 50px;
+    left: inherit;
+    transform: none;
+
+    button {
+      margin: 0;
+    }
+    p {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
Currently the farming mode box overlaps the category strip. We could place it above the strip, but then we'd need to apply enough extra bottom padding to the page to still be able to see all of your items. Instead (for now, at least) we can just make the button show up in the bottom right.

|before|after|
|---|---|
|<img width="206" alt="Screen Shot 2020-10-10 at 8 10 42 PM" src="https://user-images.githubusercontent.com/424158/95669337-b6eb2200-0b34-11eb-9321-169636d8c2cb.png">|<img width="205" alt="Screen Shot 2020-10-10 at 8 06 42 PM" src="https://user-images.githubusercontent.com/424158/95669329-9cb14400-0b34-11eb-9365-5a38df593fb2.png">|