### PR TITLE
Give the icon + select a higher z-index for hoz scroll

### DIFF
--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -117,7 +117,7 @@ $toolbarHeight: 41px - 16px + 8px;
   &.header {
     top: $header-height + $toolbarHeight;
   }
-  z-index: 1;
+  z-index: $header-cells;
 }
 
 .rating {
@@ -163,7 +163,7 @@ $toolbarHeight: 41px - 16px + 8px;
     top: $header-height + $toolbarHeight;
     padding-top: 0;
   }
-  z-index: 1;
+  z-index: $header-cells;
   --icon-item-size: calc(var(--item-size) * 0.75);
   > :global(.item) {
     --item-size: var(--icon-item-size) !important;

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -496,7 +496,7 @@ function ItemTable({
             }
             onChange={selectAllItems}
           />
-          {selectedItemIds.length}
+          {selectedItemIds.length || null}
         </div>
       </div>
       {filteredColumns.map((column: ColumnDefinition) => (


### PR DESCRIPTION
Quick fix for using the organizer on a phone. Makes it so that the select box and the icon have a higher z-index so you know what row you're on.

Also hide the `0` text if no searches are active, may otherwise be misleading what the zero in the header means?

<img width="737" alt="Screen Shot 2020-10-12 at 6 34 26 PM" src="https://user-images.githubusercontent.com/424158/95805161-98fafa00-0cb9-11eb-92d1-e8345a643699.png">
