### PR TITLE
Hotkeys

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -291,7 +291,7 @@
     "Inventory": "Inventory",
     "IosPwaPrompt": "In Mobile Safari, click the share icon (middle button on the bottom) and select \"Add to Home Screen\".",
     "Menu": "Menu",
-    "Refresh": "Refresh Destiny Data",
+    "Refresh": "Refresh Destiny Data [R]",
     "ReloadApp": "Reload App",
     "ReportBug": "Report a Bug",
     "SaveSearch": "Save Search",

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -40,7 +40,7 @@ export default function CompareItem({
           {item.lockable && <LockButton item={item} type="lock" />}
           {item.trackable && <LockButton item={item} type="track" />}
         </div>
-        <ItemTagSelector item={item} className="tagSelector" />
+        <ItemTagSelector item={item} className="tagSelector" hideKeys={true} />
         <div className="close" onClick={() => remove(item)} />
       </div>
       <div className="item-name" onClick={() => itemClick(item)}>

--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -58,7 +58,6 @@
 
 .compare-item {
   border-left: 1px solid rgba(245, 245, 245, 0.25);
-  max-width: 165px;
 
   .comp-lock-icon .app-icon {
     font-size: 12px;
@@ -111,7 +110,7 @@
     }
   }
   .spacer {
-    height: 44px;
+    height: 46px;
   }
 
   span > .app-icon,

--- a/src/app/dim-ui/KeyHelp.m.scss
+++ b/src/app/dim-ui/KeyHelp.m.scss
@@ -9,6 +9,8 @@
   color: #ddd;
   border: 1px solid #ddd;
   white-space: nowrap;
+  text-align: center;
+  min-width: 1em;
 
   @include phone-portrait {
     display: none;

--- a/src/app/dim-ui/KeyHelp.m.scss
+++ b/src/app/dim-ui/KeyHelp.m.scss
@@ -8,6 +8,7 @@
   font-size: 10px;
   color: #ddd;
   border: 1px solid #ddd;
+  white-space: nowrap;
 
   @include phone-portrait {
     display: none;

--- a/src/app/hotkeys/HotkeysCheatSheet.scss
+++ b/src/app/hotkeys/HotkeysCheatSheet.scss
@@ -11,9 +11,9 @@
   height: 100%;
   top: 0;
   left: 0;
-  color: #333;
+  color: white;
   font-size: 1em;
-  background-color: rgba(255, 255, 255, 0.9);
+  background-color: rgba(0, 0, 0, 0.9);
   z-index: 100;
   @supports (backdrop-filter: blur(5px)) {
     backdrop-filter: blur(5px);
@@ -38,7 +38,7 @@
   grid-template-columns: repeat(auto-fill, 75px minmax(200px, 1fr));
   margin: 0 auto;
   max-width: 800px;
-  color: #333;
+  color: white;
 }
 
 .cfp-hotkeys-keys {
@@ -47,16 +47,8 @@
 }
 
 .cfp-hotkeys-key {
-  display: inline-block;
-  color: #fff;
-  background-color: #333;
-  border: 1px solid #333;
-  border-radius: 5px;
-  text-align: center;
-  margin-right: 5px;
-  box-shadow: inset 0 1px 0 #666, 0 1px 0 #bbb;
-  padding: 5px 9px;
-  font-size: 1em;
+  font-size: 1em !important;
+  padding: 4px 6px !important;
 }
 
 .cfp-hotkeys-text {

--- a/src/app/hotkeys/HotkeysCheatSheet.tsx
+++ b/src/app/hotkeys/HotkeysCheatSheet.tsx
@@ -1,3 +1,4 @@
+import KeyHelp from 'app/dim-ui/KeyHelp';
 import { t } from 'app/i18next-t';
 import _ from 'lodash';
 import React, { useState } from 'react';
@@ -40,7 +41,7 @@ export default function HotkeysCheatSheet() {
               description.length > 0 && (
                 <React.Fragment key={combo}>
                   <div className="cfp-hotkeys-keys">
-                    <span className="cfp-hotkeys-key">{combo}</span>
+                    <KeyHelp combo={combo} className="cfp-hotkeys-key" />
                   </div>
                   <div className="cfp-hotkeys-text">{description}</div>
                 </React.Fragment>

--- a/src/app/item-popup/ItemTagSelector.tsx
+++ b/src/app/item-popup/ItemTagSelector.tsx
@@ -17,6 +17,7 @@ import styles from './ItemTagSelector.m.scss';
 interface ProvidedProps {
   item: DimItem;
   className?: string;
+  hideKeys?: boolean;
 }
 
 interface StoreProps {
@@ -29,7 +30,7 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
 
 type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 
-function ItemTagSelector({ item, className, tag, dispatch }: Props) {
+function ItemTagSelector({ item, className, tag, hideKeys, dispatch }: Props) {
   const onChange = (tag?: TagValue) => {
     dispatch(
       itemIsInstanced(item)
@@ -58,7 +59,7 @@ function ItemTagSelector({ item, className, tag, dispatch }: Props) {
     (t) => t.sortOrder
   ).map((tagOption) => ({
     key: tagOption.type || 'none',
-    content: <TagOption tagOption={tagOption} />,
+    content: <TagOption tagOption={tagOption} hideKeys={hideKeys} />,
     value: tagOption.type,
   }));
 
@@ -75,12 +76,14 @@ function ItemTagSelector({ item, className, tag, dispatch }: Props) {
 
 export default connect<StoreProps>(mapStateToProps)(ItemTagSelector);
 
-function TagOption({ tagOption }: { tagOption: TagInfo }) {
+function TagOption({ tagOption, hideKeys }: { tagOption: TagInfo; hideKeys?: boolean }) {
   return (
     <div className={styles.item}>
       {tagOption.icon ? <AppIcon icon={tagOption.icon} /> : <div className={styles.null} />}
       <span>{t(tagOption.label)}</span>
-      {tagOption.hotkey && <KeyHelp combo={tagOption.hotkey} className={styles.keyHelp} />}
+      {!hideKeys && tagOption.hotkey && (
+        <KeyHelp combo={tagOption.hotkey} className={styles.keyHelp} />
+      )}
     </div>
   );
 }

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -294,7 +294,7 @@
     "Inventory": "Inventory",
     "IosPwaPrompt": "In Mobile Safari, click the share icon (middle button on the bottom) and select \"Add to Home Screen\".",
     "Menu": "Menu",
-    "Refresh": "Refresh Destiny Data",
+    "Refresh": "Refresh Destiny Data [R]",
     "ReloadApp": "Reload App",
     "ReportBug": "Report a Bug",
     "SaveSearch": "Save Search",


### PR DESCRIPTION
1. Strip hotkeys from the tagging dropdown in contexts where the hotkeys don't work.
2. Add a bit of hotkey info to the Refresh tooltip
3. Restyle keyboard help to avoid "flashbang" effect and connect better with KeyHelp styles.

![image](https://user-images.githubusercontent.com/313208/95815333-43324c00-0cd1-11eb-9b75-a60570e34c43.png)
