### PR TITLE
Tone down masterwork headers

### DIFF
--- a/src/app/item-popup/ItemPopupHeader.scss
+++ b/src/app/item-popup/ItemPopupHeader.scss
@@ -143,15 +143,18 @@ $icon-bg-shadow: rgba(0, 0, 0, 1);
   }
 
   &.masterwork {
-    background-image: url('../../images/masterworkHeader.png');
+    background-image: linear-gradient(0deg, #c4b03b 0%, #c4b03b 100%);
+    background-size: 4px 4px;
     background-repeat: repeat-x;
-    background-size: cover;
     background-position: top center;
     &.is-Exotic {
-      background-image: url('../../images/exoticMasterworkHeader.png');
-    }
-    &.is-Legendary .item-title {
-      text-shadow: 0 0 3px black;
+      background-size: 8px 8px;
+      background-image: linear-gradient(
+        180deg,
+        #ddce39 4px,
+        rgba(0, 0, 0, 0.1) 4px,
+        rgba(0, 0, 0, 0) 8px
+      );
     }
   }
 }


### PR DESCRIPTION
I got real tired of the overly patterned masterwork headers - this tones them down to something more minimal:

Before:
<img width="549" alt="Screen Shot 2020-10-12 at 11 10 11 PM" src="https://user-images.githubusercontent.com/313208/95822155-379a5180-0ce0-11eb-8ef4-0f1b7fc6438b.png">
<img width="539" alt="Screen Shot 2020-10-12 at 11 10 16 PM" src="https://user-images.githubusercontent.com/313208/95822156-3832e800-0ce0-11eb-944b-291a6ab2f7c8.png">

After:
<img width="514" alt="Screen Shot 2020-10-12 at 11 09 17 PM" src="https://user-images.githubusercontent.com/313208/95822145-3537f780-0ce0-11eb-959e-1329edd46a86.png">
<img width="503" alt="Screen Shot 2020-10-12 at 11 09 21 PM" src="https://user-images.githubusercontent.com/313208/95822151-3701bb00-0ce0-11eb-8a70-788adeea4160.png">
