### PR TITLE
more autocomplete tuning

### DIFF
--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -34,18 +34,18 @@ Array [
     "helpText": undefined,
     "highlightRange": Array [
       12,
-      19,
+      18,
     ],
-    "query": "is:haspower is:blue",
+    "query": "is:haspower is:bow",
     "type": 3,
   },
   Object {
     "helpText": undefined,
     "highlightRange": Array [
       12,
-      18,
+      19,
     ],
-    "query": "is:haspower is:bow",
+    "query": "is:haspower is:blue",
     "type": 3,
   },
 ]
@@ -53,8 +53,8 @@ Array [
 
 exports[`filterComplete autocomplete terms for |is:b| 1`] = `
 Array [
-  "is:blue",
   "is:bow",
+  "is:blue",
 ]
 `;
 


### PR DESCRIPTION
closes #6009 

re-enables some ordering rules that i disabled because they needed further work
re-tuned the "remaining term length" rule with more conditions, and made the "start of the term" also apply to the part of the term after the colon