### PR TITLE
Active mode pull from all ghost across all stores

### DIFF
--- a/src/app/active-mode/Views/CurrentActivity.tsx
+++ b/src/app/active-mode/Views/CurrentActivity.tsx
@@ -75,7 +75,7 @@ function CurrentActivity({ account, store, defs, buckets }: Props) {
         <div className={styles.currentLocation}>{activityName}</div>
         <div className={styles.activityItems}>
           <ActivityInformation defs={defs} store={store} activity={activity} />
-          <SuggestedGhosts activity={activity} />
+          <SuggestedGhosts store={store} activity={activity} />
           <VendorBounties
             account={account}
             store={store}

--- a/src/app/active-mode/Views/CurrentActivity.tsx
+++ b/src/app/active-mode/Views/CurrentActivity.tsx
@@ -75,7 +75,7 @@ function CurrentActivity({ account, store, defs, buckets }: Props) {
         <div className={styles.currentLocation}>{activityName}</div>
         <div className={styles.activityItems}>
           <ActivityInformation defs={defs} store={store} activity={activity} />
-          <SuggestedGhosts store={store} activity={activity} />
+          <SuggestedGhosts activity={activity} />
           <VendorBounties
             account={account}
             store={store}

--- a/src/app/active-mode/Views/current-activity/SuggestedGhost.tsx
+++ b/src/app/active-mode/Views/current-activity/SuggestedGhost.tsx
@@ -5,6 +5,7 @@ import {
 import { ghostBadgeContent } from 'app/inventory/BadgeInfo';
 import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector } from 'app/inventory/selectors';
+import { DimStore } from 'app/inventory/store-types';
 import StoreInventoryItem from 'app/inventory/StoreInventoryItem';
 import { DestinyActivityDefinition, DestinyActivityModeType } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -12,7 +13,13 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 /** Find the ghost based on your current activity */
-export default function SuggestedGhosts({ activity }: { activity: DestinyActivityDefinition }) {
+export default function SuggestedGhosts({
+  store,
+  activity,
+}: {
+  store: DimStore;
+  activity: DestinyActivityDefinition;
+}) {
   const allItems = useSelector(allItemsSelector);
 
   if (
@@ -42,6 +49,14 @@ export default function SuggestedGhosts({ activity }: { activity: DestinyActivit
       return ghostTypeToPlaceHash[planetName] === activity.placeHash;
     }
   });
+
+  const ghostHashes = possibleGhosts.map(({ index }) => index);
+
+  const alreadyEquipped = store.items.some(({ index }) => ghostHashes.includes(index));
+  if (alreadyEquipped) {
+    // Don't suggest ghosts if you already have the right one equipped
+    return null;
+  }
 
   return (
     <>

--- a/src/app/active-mode/Views/current-activity/SuggestedGhost.tsx
+++ b/src/app/active-mode/Views/current-activity/SuggestedGhost.tsx
@@ -4,20 +4,17 @@ import {
 } from 'app/active-mode/Views/current-activity/util';
 import { ghostBadgeContent } from 'app/inventory/BadgeInfo';
 import { DimItem } from 'app/inventory/item-types';
-import { DimStore } from 'app/inventory/store-types';
+import { allItemsSelector } from 'app/inventory/selectors';
 import StoreInventoryItem from 'app/inventory/StoreInventoryItem';
 import { DestinyActivityDefinition, DestinyActivityModeType } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 /** Find the ghost based on your current activity */
-export default function SuggestedGhosts({
-  store,
-  activity,
-}: {
-  store: DimStore;
-  activity: DestinyActivityDefinition;
-}) {
+export default function SuggestedGhosts({ activity }: { activity: DestinyActivityDefinition }) {
+  const allItems = useSelector(allItemsSelector);
+
   if (
     !activity.activityModeTypes.length ||
     activity.activityModeTypes.includes(DestinyActivityModeType.Social)
@@ -32,7 +29,7 @@ export default function SuggestedGhosts({
     DestinyActivityModeType.AllStrikes,
   ].some((modeType) => activity.activityModeTypes.includes(modeType));
 
-  const possibleGhosts: DimItem[] = store.items.filter((item) => {
+  const possibleGhosts: DimItem[] = allItems.filter((item) => {
     if (item.bucket.hash !== BucketHashes.Ghost) {
       return;
     }

--- a/src/app/active-mode/Views/current-activity/SuggestedGhost.tsx
+++ b/src/app/active-mode/Views/current-activity/SuggestedGhost.tsx
@@ -52,7 +52,9 @@ export default function SuggestedGhosts({
 
   const ghostHashes = possibleGhosts.map(({ index }) => index);
 
-  const alreadyEquipped = store.items.some(({ index }) => ghostHashes.includes(index));
+  const alreadyEquipped = store.items.some(
+    ({ index, equipped }) => equipped && ghostHashes.includes(index)
+  );
   if (alreadyEquipped) {
     // Don't suggest ghosts if you already have the right one equipped
     return null;


### PR DESCRIPTION
currently ghosts are pulled just from current store, should look across all stores.

worried about how many results to show, right now it will show all. might eventually want to somehow have some ranking, but this all goes out the window in BL... should be fine in the interm. 

This diff also updates it so that if you have a suggested ghost equipped, it won't show the suggestions for that activity.

 https://github.com/DestinyItemManager/DIM/issues/5976