### PR TITLE
Make farming mode pull equipment from postmaster

### DIFF
--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -11,6 +11,7 @@ import {
   getVault,
   isD1Store,
 } from 'app/inventory/stores-helpers';
+import { pullablePostmasterEquipment, pullEquipmentFromPostmaster } from 'app/loadout/postmaster';
 import { refresh } from 'app/shell/refresh';
 import { ThunkResult } from 'app/store/types';
 import { infoLog } from 'app/utils/log';
@@ -85,6 +86,13 @@ export function startFarming(storeId: string): ThunkResult {
           dispatch(farmD1(farmingStore));
         } else {
           // In D2 we just make room
+          const itemsToBePulledFromPostmaster = pullablePostmasterEquipment(
+            farmingStore,
+            storesSelector(getState())
+          );
+          if (itemsToBePulledFromPostmaster.length > 0) {
+            dispatch(pullEquipmentFromPostmaster(farmingStore));
+          }
           dispatch(makeRoomForItems(farmingStore));
         }
       }


### PR DESCRIPTION
Farming mode will now pull equipment from the postmaster, as sometimes when you are farming, you miss things on the ground, this will prevent your postmaster from filling up during farming mode. I only chose equipment, so if you are saving currency in your postmaster, it won't get pulled.
I made an issue asking about this feature earlier, and thought I would take a shot at it.

#5992