### PR TITLE
Sidecar tweaks

### DIFF
--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -137,4 +137,8 @@
     width: 16px;
     font-size: 16px;
   }
+
+  [data-popper-placement^='left'] & {
+    transform: scaleX(-1);
+  }
 }

--- a/src/app/item-popup/ItemTagSelector.m.scss
+++ b/src/app/item-popup/ItemTagSelector.m.scss
@@ -1,3 +1,9 @@
+.itemTagSelector {
+  button {
+    min-width: 10em;
+  }
+}
+
 .item {
   flex: 1;
   display: flex;
@@ -5,6 +11,7 @@
   align-items: center;
   > *:nth-child(2) {
     flex: 1;
+    text-align: left;
   }
 }
 
@@ -34,6 +41,7 @@
   button {
     padding: 0;
     background: none;
+    min-width: auto;
   }
   button .item > *:nth-child(2) {
     display: none;

--- a/src/app/item-popup/ItemTagSelector.m.scss.d.ts
+++ b/src/app/item-popup/ItemTagSelector.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'item': string;
+  'itemTagSelector': string;
   'keyHelp': string;
   'minimized': string;
   'null': string;

--- a/src/app/item-popup/ItemTagSelector.tsx
+++ b/src/app/item-popup/ItemTagSelector.tsx
@@ -70,7 +70,9 @@ function ItemTagSelector({ item, className, tag, hideKeys, hideButtonLabel, disp
       value={tag}
       onChange={onChange}
       hideSelected={true}
-      className={clsx(className, 'item-tag-selector', { [styles.minimized]: hideButtonLabel })}
+      className={clsx(className, styles.itemTagSelector, 'item-tag-selector', {
+        [styles.minimized]: hideButtonLabel,
+      })}
     />
   );
 }

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -33,8 +33,8 @@ const faCaretDown = 'fas fa-caret-down';
 const faPencilAlt = 'fas fa-pencil-alt';
 const faPlus = 'fas fa-plus';
 const faCaretRight = 'fas fa-caret-right';
-const faExpandAlt = 'fas fa-expand-alt';
-const faCompressAlt = 'fas fa-compress-alt';
+const faAngleDoubleLeft = 'fas fa-angle-double-left';
+const faAngleDoubleRight = 'fas fa-angle-double-right';
 const faPlusCircle = 'fas fa-plus-circle';
 const faPlusSquare = 'fas fa-plus-square';
 const faQuestionCircle = 'far fa-question-circle';
@@ -133,8 +133,8 @@ export {
   faThumbtack as pinIcon,
   faPlusSquare,
   faCaretRight as expandIcon,
-  faExpandAlt as maximizeIcon,
-  faCompressAlt as minimizeIcon,
+  faAngleDoubleLeft as maximizeIcon,
+  faAngleDoubleRight as minimizeIcon,
   faPlusCircle as addIcon,
   faQuestionCircle as helpIcon,
   faSave as saveIcon,


### PR DESCRIPTION
Switch the expand/collapse to be a double-arrow, with provisions for flipping it when the sidecar is on the right. Also, fix a minimum width for the tagging dropdown, which makes the sidecar overall a bit wider but prevents it from resizing when you tag - not sure if that's the right tradeoff.

<img width="558" alt="Screen Shot 2020-10-18 at 2 46 36 PM" src="https://user-images.githubusercontent.com/313208/96386565-c0861280-1150-11eb-8583-df17afb9a485.png">
