### PR TITLE
use fancy assignment operators

### DIFF
--- a/src/app/destiny1/vendors/vendor.service.ts
+++ b/src/app/destiny1/vendors/vendor.service.ts
@@ -194,7 +194,7 @@ function mergeCategory(mergedCategory, otherCategory) {
   otherCategory.saleItems.forEach((saleItem) => {
     const existingSaleItem = mergedCategory.saleItems.find((i) => i.index === saleItem.index);
     if (existingSaleItem) {
-      existingSaleItem.unlocked = existingSaleItem.unlocked || saleItem.unlocked;
+      existingSaleItem.unlocked ||= saleItem.unlocked;
       if (saleItem.unlocked) {
         existingSaleItem.unlockedByCharacter.push(saleItem.unlockedByCharacter[0]);
       }

--- a/src/app/inventory/HeaderShadowDiv.m.scss.d.ts
+++ b/src/app/inventory/HeaderShadowDiv.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'cover': string;
+  'searchOpen': string;
   'shadow': string;
 }
 export const cssExports: CssExports;

--- a/src/app/inventory/HeaderShadowDiv.m.scss.d.ts
+++ b/src/app/inventory/HeaderShadowDiv.m.scss.d.ts
@@ -2,7 +2,6 @@
 // Please do not change this file!
 interface CssExports {
   'cover': string;
-  'searchOpen': string;
   'shadow': string;
 }
 export const cssExports: CssExports;

--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -87,8 +87,7 @@ export function DefItemIcon({
   borderless?: boolean;
 }) {
   const itemCategoryHashes = itemDef.itemCategoryHashes || [];
-  borderless =
-    borderless ||
+  borderless ||=
     itemCategoryHashes.includes(ItemCategoryHashes.Packages) ||
     itemCategoryHashes.includes(ItemCategoryHashes.Engrams);
   const itemImageStyles = clsx(

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -705,7 +705,7 @@ function canMoveToStore(
         spaceLeft(s, i) {
           let left = spaceLeftWithReservations(s, i);
           if (i.type === this.originalItemType && storeReservations[s.id]) {
-            left = left - storeReservations[s.id];
+            left -= storeReservations[s.id];
           }
           return Math.max(0, left);
         },

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -225,7 +225,7 @@ function makeItem(
   const element =
     (item.damageTypeHash && toD2DamageType(defs.DamageType.get(item.damageTypeHash))) || null;
 
-  itemDef.sourceHashes = itemDef.sourceHashes || [];
+  itemDef.sourceHashes ||= [];
 
   const missingSource = missingSources[itemDef.hash] || [];
   if (missingSource.length) {

--- a/src/app/inventory/store/item-index.ts
+++ b/src/app/inventory/store/item-index.ts
@@ -11,7 +11,8 @@ export function createItemIndex(item: DimItem): string {
   // Try to make a unique, but stable ID. This isn't always possible, such as in the case of consumables.
   let index = item.id;
   if (item.id === '0') {
-    _idTracker[index] = (_idTracker[index] || 0) + 1;
+    _idTracker[index] ||= 0;
+    _idTracker[index]++;
     index = `${index}-t${_idTracker[index]}`;
   }
 

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -10,11 +10,11 @@ export default function ItemStats({
   item,
   className,
 }: {
-  stats?: DimStat[];
+  stats?: DimStat[] | null;
   item?: DimItem;
   className?: string;
 }) {
-  stats = stats || item?.stats || undefined;
+  stats ||= item?.stats;
 
   if (!stats || !stats.length) {
     return null;

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -270,7 +270,7 @@ function collectRelevantItemFactors(exampleItem: DimItem, allItems: DimItem[]) {
     .forEach((item: DimItem) => {
       factorCombos[exampleItem.bucket.sort as factorComboCategory].forEach((factorCombo) => {
         const combination = applyFactorCombo(item, factorCombo);
-        combinationCounts[combination] ??= 0 + 1;
+        combinationCounts[combination] ??= 0;
         combinationCounts[combination]++;
       });
     });

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -270,7 +270,8 @@ function collectRelevantItemFactors(exampleItem: DimItem, allItems: DimItem[]) {
     .forEach((item: DimItem) => {
       factorCombos[exampleItem.bucket.sort as factorComboCategory].forEach((factorCombo) => {
         const combination = applyFactorCombo(item, factorCombo);
-        combinationCounts[combination] = (combinationCounts[combination] ?? 0) + 1;
+        combinationCounts[combination] ??= 0 + 1;
+        combinationCounts[combination]++;
       });
     });
   return combinationCounts;

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -298,7 +298,7 @@ export function getLockedModStats(
   if (lockedArmor2Mods) {
     for (const lockedMod of lockedArmor2Mods) {
       for (const stat of lockedMod.modDef.investmentStats) {
-        lockedModStats[stat.statTypeHash] = lockedModStats[stat.statTypeHash] || 0;
+        lockedModStats[stat.statTypeHash] ||= 0;
         // TODO This is no longer accurate, see https://github.com/DestinyItemManager/DIM/wiki/DIM's-New-Stat-Calculations
         lockedModStats[stat.statTypeHash] += stat.value;
       }

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -233,7 +233,7 @@ function addItem(
       }
     } else if (item.maxStackSize > 1) {
       const increment = Math.min(dupe.amount + item.amount, item.maxStackSize) - dupe.amount;
-      dupe.amount = dupe.amount + increment;
+      dupe.amount += increment;
       // TODO: handle stack splits
     }
 
@@ -263,7 +263,8 @@ function removeItem(
     }
 
     const decrement = shift ? 5 : 1;
-    loadoutItem.amount = (loadoutItem.amount || 1) - decrement;
+    loadoutItem.amount ||= 1;
+    loadoutItem.amount -= decrement;
     if (loadoutItem.amount <= 0) {
       draftLoadout.items = draftLoadout.items.filter(
         (i) => !(i.hash === item.hash && i.id === item.id)

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -213,9 +213,9 @@ function loadManifestRemote(
               if (response.ok) {
                 break;
               }
-              error = error ?? response;
+              error ??= response;
             } catch (e) {
-              error = error ?? e;
+              error ??= e;
             }
           }
           const body = await (response?.ok ? response.json() : Promise.reject(error));

--- a/src/app/progress/Objective.tsx
+++ b/src/app/progress/Objective.tsx
@@ -153,20 +153,20 @@ function duration(d: number) {
   let ret = '';
   const days = d % (60 * 60 * 24);
   if (days > 0) {
-    d = d - days * 60 * 60 * 24;
+    d -= days * 60 * 60 * 24;
     ret += `${days}:`;
   }
   const hours = d % (60 * 60);
   if (days > 0 || hours > 0) {
-    d = d - hours * 60 * 60;
+    d -= hours * 60 * 60;
     ret += `${hours}:`;
   }
   const minutes = d % 60;
   if (days > 0 || hours > 0 || minutes > 0) {
-    d = d - minutes * 60;
+    d -= minutes * 60;
     ret += `${minutes}:`;
   }
-  const seconds = d;
-  ret += `${seconds}`;
+  // at this point, d is the remaining seconds
+  ret += `${d}`;
   return ret;
 }


### PR DESCRIPTION
![htdky5jstrhaerg](https://user-images.githubusercontent.com/68782081/96399439-31deb900-1183-11eb-9e89-816d5d89fe3e.jpg)

with these changes, looks like DIM survives eslint `operator-assignment:always`  unscathed. opinions on enabling it?