### PR TITLE
StatTooltip clamp values

### DIFF
--- a/src/app/store-stats/StatTooltip.tsx
+++ b/src/app/store-stats/StatTooltip.tsx
@@ -56,7 +56,7 @@ function getAbilityTranslation(statHash: number) {
 function StatTooltip({ stat, characterClass }: Props) {
   const abilityTranslation = getAbilityTranslation(stat.hash);
   const classAbilityTranslation = getClassAbilityCooldownTranslation(characterClass);
-  const tier = Math.floor(stat.value / 10);
+  const tier = Math.min(10, Math.max(0, Math.floor(stat.value / 10)));
   const statEffects = getStatEffects(stat.hash);
   const classAbilityEffects = getClassAbilityCooldowns(characterClass);
 


### PR DESCRIPTION
We should be clamping those stat values between 0 and 10 now that we are using arrays.