### PR TITLE
Reduce the width of the item details sheet

### DIFF
--- a/src/app/item-popup/ItemPopupContainer.m.scss
+++ b/src/app/item-popup/ItemPopupContainer.m.scss
@@ -113,7 +113,7 @@
 }
 
 .desktopPopupBody {
-  width: 375px;
+  width: 320px;
   display: block;
   pointer-events: auto;
 }


### PR DESCRIPTION
Item details was only as wide as it was because of the move locations at the bottom. I know we're going to be adjusting all of this soon, but I wanted to get this change in so that the overall width of the popup is more narrow to handle the added width from the sidebar.

There now should be a few (at least one, maybe two) less cases where the popup flips to the left instead of the right (is one comment I've seen regarding the sidecar-especially so when it's expanded.)

|before | after|
|---|---|
|<img width="481" alt="Screen Shot 2020-10-22 at 7 27 55 PM" src="https://user-images.githubusercontent.com/424158/96949583-0fa7ac80-149d-11eb-84b2-1d63eb58326d.png">|<img width="444" alt="Screen Shot 2020-10-22 at 7 27 08 PM" src="https://user-images.githubusercontent.com/424158/96949588-120a0680-149d-11eb-87e0-71c7b5f04fde.png">|
