### PR TITLE
Expand keyboard shortcuts

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -290,6 +290,7 @@
     "InstallDIM": "Install as an App",
     "Inventory": "Inventory",
     "IosPwaPrompt": "In Mobile Safari, click the share icon (middle button on the bottom) and select \"Add to Home Screen\".",
+    "KeyboardShortcuts": "Keyboard Shortcuts",
     "Menu": "Menu",
     "Refresh": "Refresh Destiny Data [R]",
     "ReloadApp": "Reload App",
@@ -312,14 +313,16 @@
     "ClearNewItems": "Clear new items",
     "ClearNewItemsTitle": "Keyboard shortcut: X",
     "Enter": "ENTER",
+    "LockUnlock": "Lock or unlock an item",
     "MarkItemAs": "Mark item as '{{tag}}'",
     "Menu": "Toggle menu",
+    "Pull": "Pull item to active character",
     "RefreshInventory": "Refresh inventory",
     "ShowHotkeys": "Show keyboard shortcuts",
     "StartSearch": "Start a search",
     "StartSearchClear": "Start a fresh search",
     "Tab": "TAB",
-    "ToggleDetails": "Toggle showing full item details"
+    "Vault": "Send item to vault"
   },
   "Infusion": {
     "Filter": "Filter items",
@@ -638,6 +641,7 @@
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Take",
+    "ToggleSidecar": "Expand or collapse item actions",
     "TrackUntrack": {
       "Track": "Track {{itemType}}",
       "Untrack": "Untrack {{itemType}}",

--- a/src/app/hotkeys/HotkeysCheatSheet.scss
+++ b/src/app/hotkeys/HotkeysCheatSheet.scss
@@ -14,7 +14,7 @@
   color: white;
   font-size: 1em;
   background-color: rgba(0, 0, 0, 0.9);
-  z-index: 100;
+  z-index: 2000;
   @supports (backdrop-filter: blur(5px)) {
     backdrop-filter: blur(5px);
   }

--- a/src/app/hotkeys/hotkeys.ts
+++ b/src/app/hotkeys/hotkeys.ts
@@ -124,11 +124,11 @@ function installHotkey(hotkey: Hotkey) {
     // if the callback is executed directly `hotkey.get('w').callback()`
     // there will be no event, so just execute the callback.
     if (event) {
-      const target = (event.target || event.srcElement!) as Element; // srcElement is IE only
-      const nodeName = target.nodeName.toUpperCase();
+      const target = (event.target || event.srcElement!) as Element | undefined; // srcElement is IE only
+      const nodeName = target?.nodeName.toUpperCase();
 
       // check if the input has a mousetrap class, and skip checking preventIn if so
-      if (target.classList.contains('mousetrap')) {
+      if (target?.classList.contains('mousetrap')) {
         shouldExecute = true;
       } else {
         // don't execute callback if the event was fired from inside an element listed in preventIn

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -1,8 +1,9 @@
 import { StoreIcons } from 'app/character-tile/StoreIcons';
 import { CompareService } from 'app/compare/compare.service';
 import { settingsSelector } from 'app/dim-api/selectors';
+import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
-import { amountOfItem, getStore } from 'app/inventory/stores-helpers';
+import { amountOfItem, getCurrentStore, getStore, getVault } from 'app/inventory/stores-helpers';
 import { addItemToLoadout } from 'app/loadout/LoadoutDrawer';
 import { setSetting } from 'app/settings/actions';
 import { addIcon, AppIcon, compareIcon, maximizeIcon, minimizeIcon } from 'app/shell/icons';
@@ -74,6 +75,16 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
   const onToggleSidecar = () => {
     dispatch(setSetting('sidecarCollapsed', !sidecarCollapsed));
   };
+
+  useHotkey('/', t('MovePopup.ToggleSidecar'), onToggleSidecar);
+  useHotkey('p', t('Hotkey.Pull'), () => {
+    const currentChar = getCurrentStore(stores)!;
+    onMoveItemTo(currentChar);
+  });
+  useHotkey('v', t('Hotkey.Vault'), () => {
+    const vault = getVault(stores)!;
+    onMoveItemTo(vault);
+  });
 
   const containerRef = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => {
@@ -147,6 +158,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
             className={styles.collapseButton}
             onClick={onToggleSidecar}
             role="button"
+            title={t('MovePopup.ToggleSidecar') + ' [/]'}
             tabIndex={-1}
           >
             <AppIcon icon={sidecarCollapsed ? maximizeIcon : minimizeIcon} />
@@ -184,6 +196,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                   className={styles.actionButton}
                   onClick={() => onMoveItemTo(store)}
                   role="button"
+                  title={t('MovePopup.Vault') + ' [V]'}
                   tabIndex={-1}
                 >
                   <StoreIcons store={store} /> {t('MovePopup.Vault')}
@@ -195,6 +208,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                     [styles.disabled]: !storeButtonEnabled(store, itemOwner, item),
                   })}
                   onClick={() => onMoveItemTo(store)}
+                  title={t('MovePopup.Store') + ' [P]'}
                   role="button"
                   tabIndex={-1}
                 >

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -46,7 +46,6 @@ export default function ItemPopupHeader({
 
   const light = item.primStat?.value.toString();
 
-  useHotkey('t', t('Hotkey.ToggleDetails'), onToggleExpanded);
   useHotkey('c', t('Compare.ButtonHelp'), openCompare);
 
   const finalSeason = getItemPowerCapFinalSeason(item);

--- a/src/app/item-popup/ItemTagHotkeys.tsx
+++ b/src/app/item-popup/ItemTagHotkeys.tsx
@@ -29,7 +29,21 @@ type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 function ItemTagHotkeys({ item, itemTag, dispatch }: Props) {
   let hotkeys: Hotkey[] = emptyArray<Hotkey>();
   if (item.taggable) {
-    hotkeys = [];
+    hotkeys = [
+      {
+        combo: 'shift+0',
+        description: t('Tags.ClearTag'),
+        callback: () =>
+          dispatch(
+            itemIsInstanced(item)
+              ? setItemTag({ itemId: item.id, tag: undefined })
+              : setItemHashTag({
+                  itemHash: item.hash,
+                  tag: undefined,
+                })
+          ),
+      },
+    ];
 
     itemTagList.forEach((tag) => {
       if (tag.hotkey) {

--- a/src/app/item-popup/ItemTagSelector.tsx
+++ b/src/app/item-popup/ItemTagSelector.tsx
@@ -52,7 +52,7 @@ function ItemTagSelector({ item, className, tag, hideKeys, hideButtonLabel, disp
         ? {
             label: tl('Tags.ClearTag'),
             icon: clearIcon,
-            hotkey: itemTagSelectorList.find((t) => t.type === tag)!.hotkey!,
+            hotkey: 'shift+0',
             sortOrder: -1,
           }
         : t

--- a/src/app/item-popup/LockButton.tsx
+++ b/src/app/item-popup/LockButton.tsx
@@ -1,3 +1,4 @@
+import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import { setItemLockState } from 'app/inventory/item-move-service';
 import { ThunkDispatchProp } from 'app/store/types';
@@ -40,6 +41,8 @@ export default function LockButton({ type, item, className, children }: Props) {
     }
   };
 
+  useHotkey('l', t('Hotkey.LockUnlock'), lockUnlock);
+
   const title = lockButtonTitle(item, type);
 
   const icon =
@@ -68,11 +71,13 @@ export default function LockButton({ type, item, className, children }: Props) {
 
 export function lockButtonTitle(item: DimItem, type: 'lock' | 'track') {
   const data = { itemType: item.typeName };
-  return type === 'lock'
-    ? !item.locked
-      ? t('MovePopup.LockUnlock.Lock', data)
-      : t('MovePopup.LockUnlock.Unlock', data)
-    : !item.tracked
-    ? t('MovePopup.TrackUntrack.Track', data)
-    : t('MovePopup.TrackUntrack.Untrack', data);
+  return (
+    (type === 'lock'
+      ? !item.locked
+        ? t('MovePopup.LockUnlock.Lock', data)
+        : t('MovePopup.LockUnlock.Unlock', data)
+      : !item.tracked
+      ? t('MovePopup.TrackUntrack.Track', data)
+      : t('MovePopup.TrackUntrack.Untrack', data)) + ' [L]'
+  );
 }

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -114,15 +114,43 @@ function Destiny({ accountsLoaded, account, dispatch, profileError }: Props) {
   // Define some hotkeys without implementation, so they show up in the help
   const hotkeys: Hotkey[] = [
     {
-      combo: 't',
-      description: t('Hotkey.ToggleDetails'),
+      combo: 'c',
+      description: t('Compare.ButtonHelp'),
       callback() {
-        // Empty - this gets redefined in dimMoveItemProperties
+        // Empty
       },
     },
     {
-      combo: 'c',
-      description: t('Compare.ButtonHelp'),
+      combo: 'l',
+      description: t('Hotkey.LockUnlock'),
+      callback() {
+        // Empty
+      },
+    },
+    {
+      combo: '/',
+      description: t('MovePopup.ToggleSidecar'),
+      callback() {
+        // Empty
+      },
+    },
+    {
+      combo: 'v',
+      description: t('Hotkey.Vault'),
+      callback() {
+        // Empty
+      },
+    },
+    {
+      combo: 'p',
+      description: t('Hotkey.Pull'),
+      callback() {
+        // Empty
+      },
+    },
+    {
+      combo: 'shift+0',
+      description: t('Tags.ClearTag'),
       callback() {
         // Empty
       },

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -13,6 +13,7 @@ import { getAllVendorDrops, isDroppingHigh } from 'app/vendorEngramsXyzApi/vendo
 import clsx from 'clsx';
 import logo from 'images/logo-type-right-light.svg';
 import _ from 'lodash';
+import Mousetrap from 'mousetrap';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
@@ -260,6 +261,13 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
   ];
   useHotkeys(hotkeys);
 
+  const showKeyboardHelp = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    Mousetrap.trigger('?');
+    setDropdownOpen(false);
+  };
+
   const iosPwaAvailable =
     /iPad|iPhone|iPod/.test(navigator.userAgent) &&
     !window.MSStream &&
@@ -298,6 +306,11 @@ function Header({ account, vendorEngramDropActive, isPhonePortrait, dispatch }: 
               <NavLink className="link menuItem" to="/settings">
                 {t('Settings.Settings')}
               </NavLink>
+              {!isPhonePortrait && (
+                <a className="link menuItem" onClick={showKeyboardHelp}>
+                  {t('Header.KeyboardShortcuts')}
+                </a>
+              )}
               <ExternalLink
                 className="link menuItem"
                 href="https://destinyitemmanager.fandom.com/wiki/Category:User_Guide"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -295,6 +295,7 @@
     "InstallDIM": "Install as an App",
     "Inventory": "Inventory",
     "IosPwaPrompt": "In Mobile Safari, click the share icon (middle button on the bottom) and select \"Add to Home Screen\".",
+    "KeyboardShortcuts": "Keyboard Shortcuts",
     "Menu": "Menu",
     "Refresh": "Refresh Destiny Data [R]",
     "ReloadApp": "Reload App",
@@ -318,14 +319,16 @@
     "ClearNewItems": "Clear new items",
     "ClearNewItemsTitle": "Keyboard shortcut: X",
     "Enter": "ENTER",
+    "LockUnlock": "Lock or unlock an item",
     "MarkItemAs": "Mark item as '{{tag}}'",
     "Menu": "Toggle menu",
+    "Pull": "Pull item to active character",
     "RefreshInventory": "Refresh inventory",
     "ShowHotkeys": "Show keyboard shortcuts",
     "StartSearch": "Start a search",
     "StartSearchClear": "Start a fresh search",
     "Tab": "TAB",
-    "ToggleDetails": "Toggle showing full item details"
+    "Vault": "Send item to vault"
   },
   "Infusion": {
     "Filter": "Filter items",
@@ -636,6 +639,7 @@
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Take",
+    "ToggleSidecar": "Expand or collapse item actions",
     "TrackUntrack": {
       "Track": "Track {{itemType}}",
       "Tracked": "Tracked",


### PR DESCRIPTION
This adds some new keyboard shortcuts for:

* `/` Expand/collapse the sidecar 
* `l` Lock/unlock item 
* `v` Vault item 
* `p` Pull item 
* `shift+0` Clear tag (reselecting the current tag still works too)

I also added a Keyboard Shortcuts entry to the hamburger menu (desktop only) to help discoverability (probably in vain...).

Fixes #5662

<img width="728" alt="Screen Shot 2020-10-22 at 10 39 20 PM" src="https://user-images.githubusercontent.com/313208/96960745-ffe99180-14b7-11eb-8384-43ad55730117.png">
