### PR TITLE
Don't automatically show dupes in Compare

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -425,13 +425,7 @@ class Compare extends React.Component<Props, State> {
       sortBetterFirst: prevState.sortedHash === sortedHash ? !prevState.sortBetterFirst : true,
     }));
   };
-  private add = ({
-    additionalItems,
-    showSomeDupes,
-  }: {
-    additionalItems: DimItem[];
-    showSomeDupes: boolean;
-  }) => {
+  private add = ({ additionalItems }: { additionalItems: DimItem[] }) => {
     // use the first item and assume all others are of the same 'type'
     const exampleItem = additionalItems[0];
     if (!exampleItem.comparable) {
@@ -470,19 +464,7 @@ class Compare extends React.Component<Props, State> {
         ? this.findSimilarWeapons(additionalItems)
         : [];
 
-      // if this was spawned from an item, and not from a search,
-      // DIM tries to be helpful by including a starter comparison of dupes
-      if (additionalItems.length === 1 && showSomeDupes) {
-        const comparisonItems = comparisonSets[0]?.items ?? additionalItems;
-        this.setState({
-          comparisonSets,
-          comparisonItems,
-        });
-      }
-      // otherwise, compare only the items we were asked to compare
-      else {
-        this.setState({ comparisonSets, comparisonItems: [...additionalItems] });
-      }
+      this.setState({ comparisonSets, comparisonItems: [...additionalItems] });
     }
   };
 

--- a/src/app/compare/compare.service.ts
+++ b/src/app/compare/compare.service.ts
@@ -5,9 +5,8 @@ export const CompareService = {
   dialogOpen: false,
   compareItems$: new Subject<{
     additionalItems: DimItem[];
-    showSomeDupes: boolean;
   }>(),
-  addItemsToCompare(additionalItems: DimItem[], showSomeDupes = false) {
-    this.compareItems$.next({ additionalItems, showSomeDupes });
+  addItemsToCompare(additionalItems: DimItem[]) {
+    this.compareItems$.next({ additionalItems });
   },
 };

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -117,7 +117,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
 
   const openCompare = () => {
     hideItemPopup();
-    CompareService.addItemsToCompare([item], true);
+    CompareService.addItemsToCompare([item]);
   };
 
   const addToLoadout = (e) => {

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -35,7 +35,7 @@ export default function ItemPopupHeader({
   const hasLeftIcon = item.trackable || item.lockable || item.element;
   const openCompare = () => {
     hideItemPopup();
-    CompareService.addItemsToCompare([item], true);
+    CompareService.addItemsToCompare([item]);
   };
 
   const hasDetails = Boolean(


### PR DESCRIPTION
This'll probably make people mad, but sometimes I want to compare only a couple items, and pre-filling with all dupes makes it hard to narrow back down to the ones I want. See #5834 for more discussion.

The alternative would, I guess, be to add a "just the original item" button to the header?