### PR TITLE
Wraparound stores on mobile

### DIFF
--- a/src/app/inventory/PhoneStores.tsx
+++ b/src/app/inventory/PhoneStores.tsx
@@ -2,6 +2,7 @@ import { scrollToPosition } from 'app/dim-ui/scroll';
 import { t } from 'app/i18next-t';
 import HeaderShadowDiv from 'app/inventory/HeaderShadowDiv';
 import StoreStats from 'app/store-stats/StoreStats';
+import { wrap } from 'app/utils/util';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
 import Hammer from 'react-hammerjs';
@@ -42,10 +43,10 @@ export default function PhoneStores({ stores, buckets }: Props) {
       ? stores.findIndex((s) => s.id === selectedStoreId)
       : stores.findIndex((s) => s.current);
 
-    if (e.direction === 2 && selectedStoreIndex < stores.length - 1) {
-      setSelectedStoreId(stores[selectedStoreIndex + 1].id);
-    } else if (e.direction === 4 && selectedStoreIndex > 0) {
-      setSelectedStoreId(stores[selectedStoreIndex - 1].id);
+    if (e.direction === 2) {
+      setSelectedStoreId(stores[wrap(selectedStoreIndex + 1, stores.length)].id);
+    } else if (e.direction === 4) {
+      setSelectedStoreId(stores[wrap(selectedStoreIndex - 1, stores.length)].id);
     }
   };
 

--- a/src/app/inventory/PhoneStoresHeader.tsx
+++ b/src/app/inventory/PhoneStoresHeader.tsx
@@ -1,4 +1,5 @@
 import { hideItemPopup } from 'app/item-popup/item-popup';
+import { wrap } from 'app/utils/util';
 import { animate, motion, PanInfo, Spring, useMotionValue, useTransform } from 'framer-motion';
 import React, { useEffect, useRef } from 'react';
 import StoreHeading from '../character-tile/StoreHeading';
@@ -12,16 +13,6 @@ const spring: Spring = {
   mass: 1,
   restSpeed: 0.01,
   restDelta: 0.01,
-};
-
-const wrap = (index: number, length: number) => {
-  while (index < 0) {
-    index += length;
-  }
-  while (index >= length) {
-    index -= length;
-  }
-  return index;
 };
 
 /**
@@ -44,21 +35,18 @@ export default function PhoneStoresHeader({
     hideItemPopup();
   };
 
-  // TODO: carousel
   // TODO: wrap StoreHeading in a div?
   // TODO: optional external motion control
 
   const index = stores.indexOf(selectedStore);
   const lastIndex = useRef(index);
 
-  // stores = stores.map((_, i) => stores[wrap(i - index - 1, stores.length)]);
-
   const trackRef = useRef<HTMLDivElement>(null);
 
   // The track is divided into "segments", with one item per segment
   const numSegments = stores.length;
   // This is a floating-point, animated representation of the position within the segments, relative to the current store
-  const offset = useMotionValue(2);
+  const offset = useMotionValue(0);
   // Keep track of the starting point when we begin a gesture
   const startOffset = useRef<number>(0);
 
@@ -109,11 +97,6 @@ export default function PhoneStoresHeader({
     if (newIndex !== 0) {
       onIndexChanged(newIndex);
     } else {
-      /*
-    const velocity = offset.getVelocity();
-    offset.set(offset.get() - newIndex);
-    animate(offset, 0, { ...spring, velocity });
-    */
       animate(offset, 0, spring);
     }
   };
@@ -124,10 +107,8 @@ export default function PhoneStoresHeader({
     segments.push(stores[wrap(i, stores.length)]);
   }
 
-  // Transform the segment-relative offset back into pixels
-  const offsetPercent = useTransform(offset, (o) =>
-    trackRef.current ? (trackRef.current.clientWidth / segments.length) * -(o + 2) : 0
-  );
+  // Transform the segment-relative offset back into percents
+  const offsetPercent = useTransform(offset, (o) => (100 / segments.length) * -(o + 2) + '%');
 
   return (
     <div className={styles.frame}>

--- a/src/app/inventory/PhoneStoresHeader.tsx
+++ b/src/app/inventory/PhoneStoresHeader.tsx
@@ -1,7 +1,5 @@
 import { hideItemPopup } from 'app/item-popup/item-popup';
-import { infoLog } from 'app/utils/log';
 import { animate, motion, PanInfo, Spring, useMotionValue, useTransform } from 'framer-motion';
-import _ from 'lodash';
 import React, { useEffect, useRef } from 'react';
 import StoreHeading from '../character-tile/StoreHeading';
 import styles from './PhoneStoresHeader.m.scss';
@@ -14,6 +12,16 @@ const spring: Spring = {
   mass: 1,
   restSpeed: 0.01,
   restDelta: 0.01,
+};
+
+const wrap = (index: number, length: number) => {
+  while (index < 0) {
+    index += length;
+  }
+  while (index >= length) {
+    index -= length;
+  }
+  return index;
 };
 
 /**
@@ -31,7 +39,8 @@ export default function PhoneStoresHeader({
   setSelectedStoreId(id: string): void;
 }) {
   const onIndexChanged = (index: number) => {
-    setSelectedStoreId(stores[index].id);
+    const originalIndex = stores.indexOf(selectedStore);
+    setSelectedStoreId(stores[wrap(originalIndex + index, stores.length)].id);
     hideItemPopup();
   };
 
@@ -40,19 +49,32 @@ export default function PhoneStoresHeader({
   // TODO: optional external motion control
 
   const index = stores.indexOf(selectedStore);
+  const lastIndex = useRef(index);
+
+  // stores = stores.map((_, i) => stores[wrap(i - index - 1, stores.length)]);
 
   const trackRef = useRef<HTMLDivElement>(null);
 
   // The track is divided into "segments", with one item per segment
   const numSegments = stores.length;
-  // This is a floating-point, animated representation of the position within the segments!
-  const offset = useMotionValue(index);
+  // This is a floating-point, animated representation of the position within the segments, relative to the current store
+  const offset = useMotionValue(2);
   // Keep track of the starting point when we begin a gesture
   const startOffset = useRef<number>(0);
 
   useEffect(() => {
-    animate(offset, index, spring);
-  }, [index, offset]);
+    let diff = index - lastIndex.current;
+    if (lastIndex.current === 0 && diff > 1) {
+      diff = -1;
+    } else if (lastIndex.current === numSegments - 1 && diff < -1) {
+      diff = 1;
+    }
+
+    const velocity = offset.getVelocity();
+    offset.set(offset.get() - diff);
+    animate(offset, 0, { ...spring, velocity });
+    lastIndex.current = index;
+  }, [index, offset, numSegments]);
 
   // We want a bit more control than Framer Motion's drag gesture can give us, so fall
   // back to the pan gesture and implement our own elasticity, etc.
@@ -66,44 +88,45 @@ export default function PhoneStoresHeader({
     }
     const trackWidth = trackRef.current.clientWidth;
     // The offset as a proportion of segments
-    let newValue = startOffset.current + -info.offset.x / (trackWidth / numSegments);
+    const newValue = startOffset.current + -info.offset.x / (trackWidth / numSegments);
 
-    // Apply elasticity outside the extents
-    const elasticity = 0.5;
-    const minExtent = 0;
-    const maxExtent = numSegments - 1;
-    if (newValue < minExtent) {
-      newValue = elasticity * newValue;
-    } else if (newValue > maxExtent) {
-      newValue = elasticity * (newValue - maxExtent) + maxExtent;
-    }
     offset.set(newValue);
   };
 
   const onPanEnd = (_e, info: PanInfo) => {
     // Animate to one of the settled whole-number indexes
-    let newIndex = _.clamp(Math.round(offset.get()), 0, numSegments - 1);
+    let newIndex = Math.round(offset.get());
     const scale = trackRef.current!.clientWidth / numSegments;
 
-    if (index === newIndex) {
+    if (newIndex === 0) {
       const swipe = (info.velocity.x * info.offset.x) / (scale * scale);
-      infoLog('swipe', swipe);
       if (swipe > 0.05) {
         const direction = -Math.sign(info.velocity.x);
-        newIndex = _.clamp(newIndex + direction, 0, numSegments - 1);
+        newIndex = newIndex + direction;
       }
     }
 
-    animate(offset, newIndex, spring);
-
-    if (index !== newIndex) {
+    if (newIndex !== 0) {
       onIndexChanged(newIndex);
+    } else {
+      /*
+    const velocity = offset.getVelocity();
+    offset.set(offset.get() - newIndex);
+    animate(offset, 0, { ...spring, velocity });
+    */
+      animate(offset, 0, spring);
     }
   };
 
+  // Expand out from the selected index in each direction 2 items
+  const segments: DimStore[] = [];
+  for (let i = index - 2; i <= index + 2; i++) {
+    segments.push(stores[wrap(i, stores.length)]);
+  }
+
   // Transform the segment-relative offset back into pixels
   const offsetPercent = useTransform(offset, (o) =>
-    trackRef.current ? (trackRef.current.clientWidth / numSegments) * -o : 0
+    trackRef.current ? (trackRef.current.clientWidth / segments.length) * -(o + 2) : 0
   );
 
   return (
@@ -114,13 +137,13 @@ export default function PhoneStoresHeader({
         onPanStart={onPanStart}
         onPan={onPan}
         onPanEnd={onPanEnd}
-        style={{ width: `${100 * stores.length}%`, x: offsetPercent }}
+        style={{ width: `${100 * segments.length}%`, x: offsetPercent }}
       >
-        {stores.map((store) => (
+        {segments.map((store, index) => (
           <div
             className="store-cell"
-            key={store.id}
-            style={{ width: `${Math.floor(100 / stores.length)}%` }}
+            key={index}
+            style={{ width: `${Math.floor(100 / segments.length)}%` }}
           >
             <StoreHeading
               store={store}

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -111,3 +111,20 @@ export function download(data: string, filename: string, type: string) {
   a.click();
   setTimeout(() => document.body.removeChild(a));
 }
+
+/**
+ * Given an index into an array, which may exceed the bounds of the array in either direction,
+ * return a new index that "wraps around".
+ *
+ * Example:
+ * [0, 1][wrap(-1, 2)] === 1
+ */
+export const wrap = (index: number, length: number) => {
+  while (index < 0) {
+    index += length;
+  }
+  while (index >= length) {
+    index -= length;
+  }
+  return index;
+};


### PR DESCRIPTION
This is the product of sleep-deprived, guess-and-check hacking, so the code is kind of a mess. However, I think the final effect works pretty well. This sets up our header to be an infinite loop in either direction. You can swipe along one way or the other forever. I also updated the invisible swipe on the main inventory body to follow these rules (it'll be replaced with a real pager soon, I promise!)

I think @duckmanBR will be overjoyed that this brings back the vault "peeking" behavior on the way to just making it generally easier to get to your vault.

<img width="255" alt="Screen Shot 2020-10-23 at 12 24 46 AM" src="https://user-images.githubusercontent.com/313208/96968741-43e39300-14c6-11eb-8336-b47055e3f485.png">
