### PR TITLE
allow pull from postmaster even if notransfer is set

### DIFF
--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -112,8 +112,9 @@ export function moveItemTo(
   return async (dispatch, getState) => {
     hideItemPopup();
     if (
-      (!item.location.inPostmaster && item.notransfer && item.owner !== store.id) ||
-      (item.location.inPostmaster && !item.canPullFromPostmaster)
+      item.location.inPostmaster
+        ? !item.canPullFromPostmaster
+        : item.notransfer && item.owner !== store.id
     ) {
       throw new Error(t('Help.CannotMove'));
     }

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -112,7 +112,7 @@ export function moveItemTo(
   return async (dispatch, getState) => {
     hideItemPopup();
     if (
-      (item.notransfer && item.owner !== store.id) ||
+      (!item.location.inPostmaster && item.notransfer && item.owner !== store.id) ||
       (item.location.inPostmaster && !item.canPullFromPostmaster)
     ) {
       throw new Error(t('Help.CannotMove'));


### PR DESCRIPTION
"notransfer" (mainly used to prevent things from going to vault)
should not prevent attempts to pull an item from postmaster (canPullFromPostmaster's express purpose)

pictured: me pulling a notransfer item from postmaster successfully, into character's consumables
![image](https://user-images.githubusercontent.com/68782081/96988236-ec025780-14d8-11eb-88bc-2bc2d6447d78.png)
