### PR TITLE
Fix mods descriptions in loadout optimizer

### DIFF
--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -62,7 +62,11 @@ export function SelectableArmor2Mod({
         <SocketDetailsMod className={styles.iconContainer} itemDef={mod.modDef} defs={defs} />
         <div className={styles.perkInfo}>
           <div className={styles.perkTitle}>{mod.modDef.displayProperties.name}</div>
-          <div className={styles.perkDescription}>{mod.modDef.displayProperties.description}</div>
+          {mod.modDef.perks.map((perk) => (
+            <div key={perk.perkHash}>
+              {defs.SandboxPerk.get(perk.perkHash).displayProperties.description}
+            </div>
+          ))}
           {mod.modDef.investmentStats
             .filter((stat) => armorStatHashes.includes(stat.statTypeHash))
             .map((stat) => (


### PR DESCRIPTION
Issue #6053
This actually affected *all* mods, not just rasputin ones. Most mods had no description whatsoever.

Before the change:
![image](https://user-images.githubusercontent.com/15267770/97048194-b5811700-1582-11eb-9be0-440fc4205c71.png)

After:
![image](https://user-images.githubusercontent.com/15267770/97048315-e5301f00-1582-11eb-9855-6c6ea5f54b3d.png)
