### PR TITLE
Organizer tuning

### DIFF
--- a/src/app/item-popup/ItemStat.m.scss
+++ b/src/app/item-popup/ItemStat.m.scss
@@ -11,6 +11,11 @@
   grid-column: 2;
   text-align: right !important;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  > svg {
+    vertical-align: middle;
+    margin-left: 4px;
+  }
 }
 
 .icon {

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -210,6 +210,7 @@ export function ItemStatValue({ stat, item }: { stat: DimStat; item?: DimItem })
     <div className={clsx(styles.value, optionalClasses)}>
       {stat.value}
       {statsMs.includes(stat.statHash) && t('Stats.Milliseconds')}
+      {stat.statHash === StatHashes.RecoilDirection && <RecoilStat value={stat.value} />}
     </div>
   );
 }

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -124,7 +124,7 @@ export function getColumns(
           return undefined;
         }
         return {
-          id: `stat_${statHash}`,
+          id: `stat${statHash}`,
           header: statInfo.displayProperties.hasIcon ? (
             <span title={statInfo.displayProperties.name}>
               <BungieImage src={statInfo.displayProperties.icon} />

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -23,7 +23,6 @@ $content-cells: 5;
     :global(.gradientBackground) & {
       background-color: #27263a;
     }
-    border-bottom: 1px solid #3c3c3e;
   }
 }
 
@@ -200,9 +199,6 @@ $toolbarHeight: 41px - 16px + 8px;
 }
 .traits {
   visibility: visible;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
   .modPerks {
     flex: 0;
     min-width: 160px;

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -167,6 +167,7 @@ $toolbarHeight: 41px - 16px + 8px;
   --icon-item-size: calc(var(--item-size) * 0.75);
   > :global(.item) {
     --item-size: var(--icon-item-size) !important;
+    height: var(--item-size);
   }
 }
 
@@ -251,6 +252,14 @@ $toolbarHeight: 41px - 16px + 8px;
     margin-right: 4px;
     height: 16px;
     width: 16px;
+  }
+}
+
+.stat_2715839340 {
+  svg {
+    circle {
+      fill: black;
+    }
   }
 }
 

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -35,6 +35,7 @@ interface CssExports {
   'selection': string;
   'shiftHeld': string;
   'sorter': string;
+  'stat2715839340': string;
   'table': string;
   'tag': string;
   'toolbar': string;

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -34,6 +34,7 @@ import clsx from 'clsx';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
 import Dropzone, { DropzoneOptions } from 'react-dropzone';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -333,6 +334,17 @@ function ItemTable({
     .map((c) => c.gridWidth ?? 'min-content')
     .join(' ')}`;
 
+  const numColumns = filteredColumns.length + 1;
+
+  const rowStyle = [...Array(numColumns).keys()]
+    .map(
+      (_, n) =>
+        `[role="cell"]:nth-of-type(${numColumns * 2}n+${
+          n + 2
+        }){background-color:#1a1a1d !important;}`
+    )
+    .join('\n');
+
   /**
    * Toggle sorting of columns. If shift is held, adds this column to the sort.
    */
@@ -481,6 +493,7 @@ function ItemTable({
             forClass={classIfAny}
           />
         </div>
+        {ReactDOM.createPortal(<style>{rowStyle}</style>, document.head)}
       </div>
       <div className={clsx(styles.selection, styles.header)} role="columnheader" aria-sort="none">
         <div>


### PR DESCRIPTION
Adds alternating row colors courtesy of @nev-r's earlier exploration, and brings in the recoil direction indicator.

<img width="1439" alt="Screen Shot 2020-10-23 at 10 27 57 PM" src="https://user-images.githubusercontent.com/313208/97068720-14449180-157f-11eb-9183-bd24db55ee1a.png">
<img width="424" alt="Screen Shot 2020-10-23 at 10 28 00 PM" src="https://user-images.githubusercontent.com/313208/97068723-17d81880-157f-11eb-99b4-92c269c5d1bf.png">
