### PR TITLE
use sortedStoresSelector for move locs in sidecar

### DIFF
--- a/src/app/item-actions/ItemActionsDropdown.tsx
+++ b/src/app/item-actions/ItemActionsDropdown.tsx
@@ -2,10 +2,11 @@ import Dropdown, { Option } from 'app/dim-ui/Dropdown';
 import { t } from 'app/i18next-t';
 import { setItemNote } from 'app/inventory/actions';
 import { bulkLockItems, bulkTagItems } from 'app/inventory/bulk-actions';
-import { sortedStoresSelector } from 'app/inventory/selectors';
+import { storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { itemMoveLoadout } from 'app/loadout/auto-loadouts';
 import { applyLoadout } from 'app/loadout/loadout-apply';
+import { characterSortImportanceSelector } from 'app/settings/character-sort';
 import { isPhonePortraitSelector } from 'app/shell/selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import React from 'react';
@@ -38,7 +39,7 @@ type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 
 function mapStateToProps(state: RootState): StoreProps {
   return {
-    stores: sortedStoresSelector(state),
+    stores: characterSortImportanceSelector(state)(storesSelector(state)),
     isPhonePortrait: isPhonePortraitSelector(state),
   };
 }

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -3,10 +3,10 @@ import { CompareService } from 'app/compare/compare.service';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
+import { sortedStoresSelector } from 'app/inventory/selectors';
 import { amountOfItem, getCurrentStore, getStore, getVault } from 'app/inventory/stores-helpers';
 import { addItemToLoadout } from 'app/loadout/LoadoutDrawer';
 import { setSetting } from 'app/settings/actions';
-import { characterSortImportanceSelector } from 'app/settings/character-sort';
 import { addIcon, AppIcon, compareIcon, maximizeIcon, minimizeIcon } from 'app/shell/icons';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
@@ -21,7 +21,6 @@ import d2Infuse from '../../images/d2infuse.png';
 import { showInfuse } from '../infuse/infuse';
 import { DimItem } from '../inventory/item-types';
 import { consolidate, distribute, moveItemTo } from '../inventory/move-item';
-import { storesSelector } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
 import styles from './DesktopItemActions.m.scss';
 import { hideItemPopup } from './item-popup';
@@ -30,11 +29,9 @@ import ItemTagSelector from './ItemTagSelector';
 import LockButton from './LockButton';
 
 const sidecarCollapsedSelector = (state: RootState) => settingsSelector(state).sidecarCollapsed;
-const importanceSortedStoresSelector = (state: RootState) =>
-  characterSortImportanceSelector(state)(storesSelector(state));
 
 export default function DesktopItemActions({ item }: { item: DimItem }) {
-  const stores = useSelector(importanceSortedStoresSelector);
+  const stores = useSelector(sortedStoresSelector);
   const vault = getVault(stores);
   const sidecarCollapsed = useSelector(sidecarCollapsedSelector);
   const [amount, setAmount] = useState(item.amount);

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -1,7 +1,6 @@
 import { t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
-import { allItemsSelector, bucketsSelector, sortedStoresSelector } from 'app/inventory/selectors';
-import { DimStore } from 'app/inventory/store-types';
+import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import ItemActionsDropdown from 'app/item-actions/ItemActionsDropdown';
 import { isPhonePortraitSelector, querySelector } from 'app/shell/selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
@@ -20,7 +19,6 @@ import SearchResults from './SearchResults';
 interface StoreProps {
   searchQuery: string;
   allItems: DimItem[];
-  stores: DimStore[];
   buckets?: InventoryBuckets;
   searchFilter: ItemFilter;
   isPhonePortrait: boolean;
@@ -31,7 +29,6 @@ type Props = StoreProps & ThunkDispatchProp;
 function mapStateToProps(state: RootState): StoreProps {
   return {
     searchQuery: querySelector(state),
-    stores: sortedStoresSelector(state),
     searchFilter: searchFilterSelector(state),
     allItems: allItemsSelector(state),
     buckets: bucketsSelector(state),

--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -41,6 +41,34 @@ export const characterSortSelector = createSelector(
   }
 );
 
+/**
+ * This sorts stores by "importance" rather than how they display as columns. This is for
+ * dropdowns and such where "mostRecentReverse" still implies that the most recent character
+ * is most important.
+ */
+export const characterSortImportanceSelector = createSelector(
+  characterOrderSelector,
+  customCharacterSortSelector,
+  (order, customCharacterSort) => {
+    switch (order) {
+      case 'mostRecent':
+      case 'mostRecentReverse':
+        return (stores: DimStore[]) => _.sortBy(stores, (store) => store.lastPlayed).reverse();
+
+      case 'custom': {
+        const customSortOrder = customCharacterSort;
+        return (stores: DimStore[]) =>
+          _.sortBy(stores, (s) => (s.isVault ? 999 : customSortOrder.indexOf(s.id)));
+      }
+
+      default:
+      case 'fixed': // "Age"
+        // https://github.com/Bungie-net/api/issues/614
+        return (stores: DimStore[]) => _.sortBy(stores, (s) => s.id);
+    }
+  }
+);
+
 export const characterComponentSortSelector = createSelector(
   characterOrderSelector,
   customCharacterSortSelector,

--- a/src/app/settings/character-sort.ts
+++ b/src/app/settings/character-sort.ts
@@ -41,34 +41,6 @@ export const characterSortSelector = createSelector(
   }
 );
 
-/**
- * This sorts stores by "importance" rather than how they display as columns. This is for
- * dropdowns and such where "mostRecentReverse" still implies that the most recent character
- * is most important.
- */
-export const characterSortImportanceSelector = createSelector(
-  characterOrderSelector,
-  customCharacterSortSelector,
-  (order, customCharacterSort) => {
-    switch (order) {
-      case 'mostRecent':
-      case 'mostRecentReverse':
-        return (stores: DimStore[]) => _.sortBy(stores, (store) => store.lastPlayed).reverse();
-
-      case 'custom': {
-        const customSortOrder = customCharacterSort;
-        return (stores: DimStore[]) =>
-          _.sortBy(stores, (s) => (s.isVault ? 999 : customSortOrder.indexOf(s.id)));
-      }
-
-      default:
-      case 'fixed': // "Age"
-        // https://github.com/Bungie-net/api/issues/614
-        return (stores: DimStore[]) => _.sortBy(stores, (s) => s.id);
-    }
-  }
-);
-
 export const characterComponentSortSelector = createSelector(
   characterOrderSelector,
   customCharacterSortSelector,


### PR DESCRIPTION
use same order for headers + move locs

actually coming to think of it -- do we still want to keep `characterSortImportanceSelector` around for the search dropdown ordering?