### PR TITLE
Change the sidecar keyboard shortcut to K

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Added stat tooltips to the Loadout Optimizer.
 * Fixed descriptions for mod effects in the Loadout Optimizer's mod picker.
 * Launching the Compare tool on an item no longer automatically selects all dupes to compare. Click the button with the item's name to see those. This was done to make it easier to compare specific items, while still keeping the ability to quickly see dupes.
-* New keyboard shortcuts for pull item (P), vault item (V), lock/unlock item (L), expand/collapse sidecar (/), and clear tag (Shift+0). Remember, you must click an item before being able to use shortcuts.
+* New keyboard shortcuts for pull item (P), vault item (V), lock/unlock item (L), expand/collapse sidecar (K), and clear tag (Shift+0). Remember, you must click an item before being able to use shortcuts.
 * Made the item popup a bit thinner.
 * Collapsing sections now animate open and closed.
 * When your character sort is set to "most recent (reverse)", your characters are still in recency order in the item actions sidecar.

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -77,7 +77,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
     dispatch(setSetting('sidecarCollapsed', !sidecarCollapsed));
   };
 
-  useHotkey('/', t('MovePopup.ToggleSidecar'), onToggleSidecar);
+  useHotkey('k', t('MovePopup.ToggleSidecar'), onToggleSidecar);
   useHotkey('p', t('Hotkey.Pull'), () => {
     const currentChar = getCurrentStore(stores)!;
     onMoveItemTo(currentChar);
@@ -162,7 +162,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
             className={styles.collapseButton}
             onClick={onToggleSidecar}
             role="button"
-            title={t('MovePopup.ToggleSidecar') + ' [/]'}
+            title={t('MovePopup.ToggleSidecar') + ' [K]'}
             tabIndex={-1}
           >
             <AppIcon icon={sidecarCollapsed ? maximizeIcon : minimizeIcon} />

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -128,7 +128,7 @@ function Destiny({ accountsLoaded, account, dispatch, profileError }: Props) {
       },
     },
     {
-      combo: '/',
+      combo: 'k',
       description: t('MovePopup.ToggleSidecar'),
       callback() {
         // Empty


### PR DESCRIPTION
Apparently Firefox has a "quick search" thing that's triggered off /. Why K? I dunno, it doesn't seem like it'd ever be used for anything else.