### PR TITLE
Sidecar style tweaks

### DIFF
--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 8px;
+  padding: 4px 8px;
 
   > img,
   > :global(.app-icon),
@@ -41,7 +41,7 @@
 
 .itemTagSelector {
   composes: entry;
-  padding: 8px;
+  padding: 4px 8px;
 
   :global(.app-icon) {
     margin-top: 1px;

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -16,11 +16,10 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 4px 8px;
+  padding: 6px 8px;
 
   > img,
-  > :global(.app-icon),
-  > .null {
+  > :global(.app-icon) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -41,7 +40,7 @@
 
 .itemTagSelector {
   composes: entry;
-  padding: 4px 8px;
+  padding: 6px 8px;
 
   :global(.app-icon) {
     margin-top: 1px;
@@ -50,32 +49,19 @@
 
   .collapsed & {
     padding: 0;
-    :global(.app-icon) {
-      margin-right: 8px;
-      font-size: 16px;
-      height: 24px;
-      width: 24px;
-    }
     button {
-      padding: 12px;
-      :global(.app-icon) {
-        margin-right: 0px;
+      border-radius: 0;
+      padding: 6px 8px;
+      > div > :global(.app-icon) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px;
+        margin: 0;
+        height: 24px;
+        width: 24px;
       }
     }
-  }
-}
-
-.null {
-  display: flex !important;
-  align-items: center;
-  justify-content: center;
-  &::before {
-    content: '';
-    display: block;
-    height: 6px;
-    width: 6px;
-    border-radius: 3px;
-    background-color: white;
   }
 }
 
@@ -123,7 +109,7 @@
   flex-direction: column;
   align-items: inherit;
   justify-self: flex-end;
-  padding: 4px 8px 0 8px;
+  padding: 6px 8px 0 8px;
   &:last-child {
     padding-bottom: 8px;
   }

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -16,19 +16,17 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 16px 12px;
+  padding: 8px;
 
-  @media (pointer: fine) {
-    padding: 12px;
-  }
-
-  img,
-  :global(.app-icon),
-  .null {
-    display: block;
+  > img,
+  > :global(.app-icon),
+  > .null {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     margin-right: 8px;
-    height: 16px;
-    width: 16px;
+    height: 24px;
+    width: 24px;
     font-size: 16px;
     text-align: center;
 
@@ -43,17 +41,20 @@
 
 .itemTagSelector {
   composes: entry;
-  padding-top: 12px;
-  padding-bottom: 6px;
+  padding: 8px;
 
   :global(.app-icon) {
     margin-top: 1px;
+    margin-right: 8px;
   }
 
   .collapsed & {
     padding: 0;
     :global(.app-icon) {
       margin-right: 8px;
+      font-size: 16px;
+      height: 24px;
+      width: 24px;
     }
     button {
       padding: 12px;
@@ -122,14 +123,17 @@
   flex-direction: column;
   align-items: inherit;
   justify-self: flex-end;
-  padding: 6px 12px 3px;
+  padding: 4px 8px 0 8px;
+  &:last-child {
+    padding-bottom: 8px;
+  }
 }
 
 .moveLocationIcons {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: 6px 0;
+  margin: 4px 0 0 0;
 }
 
 .move,

--- a/src/app/item-popup/DesktopItemActions.m.scss.d.ts
+++ b/src/app/item-popup/DesktopItemActions.m.scss.d.ts
@@ -13,7 +13,6 @@ interface CssExports {
   'move': string;
   'moveLocationIcons': string;
   'moveLocations': string;
-  'null': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/item-popup/ItemTagSelector.m.scss
+++ b/src/app/item-popup/ItemTagSelector.m.scss
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  white-space: nowrap;
   > *:nth-child(2) {
     flex: 1;
     text-align: left;
@@ -44,9 +45,9 @@
     min-width: auto;
   }
   button .item > *:nth-child(2) {
-    display: none;
+    display: none !important;
   }
   button > *:nth-child(2) {
-    display: none;
+    display: none !important;
   }
 }


### PR DESCRIPTION
This tweaks the sidecar a bit to have bigger square image icons, and normalizes some other padding. I also removed the `pointer: fine` tweaks - I had taken user feedback literally as "I want bigger touch targets" when users were actually asking for bigger icons.

Before:
<img width="557" alt="Screen Shot 2020-10-25 at 5 32 01 PM" src="https://user-images.githubusercontent.com/313208/97123312-85ec1f00-16e8-11eb-91c0-431b58f71b03.png">

After:
<img width="567" alt="Screen Shot 2020-10-25 at 5 31 49 PM" src="https://user-images.githubusercontent.com/313208/97123308-82f12e80-16e8-11eb-9f63-78d7a47df619.png">
