### PR TITLE
Perks tweaks

### DIFF
--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -114,7 +114,7 @@
   .socket-container & {
     position: absolute;
     top: -6px;
-    right: -6px;
+    right: -8px;
     filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.9));
   }
 }
@@ -124,25 +124,30 @@
   display: inline-block;
 
   .item-socket-category-Consumable & {
-    border: 1px solid #999999;
+    border: 1px solid #888;
   }
 
   img {
     -webkit-touch-callout: none;
-    width: calc(0.64 * var(--item-size));
-    height: calc(0.64 * var(--item-size));
+    width: 32px;
+    height: 32px;
     display: block;
   }
 }
 
 .item-socket-category-Reusable .socket-container.notIntrinsic {
-  border: 1px solid #999999;
+  border: 1px solid #888;
   border-radius: 50%;
   background-color: #4887ba;
-  transform: scale(0.9);
+  padding: 1px;
+  margin-bottom: 6px;
+  &:last-child {
+    margin-bottom: 0;
+  }
 
   img {
-    transform: scale(0.85);
+    width: 26px;
+    height: 26px;
   }
 
   &.notChosen {


### PR DESCRIPTION
This makes some minor tweaks to perks display, largely to line up better with the in-game display.

1. They no longer scale with the item size slider, and are instead a fixed size. This tends to make them very slightly smaller, but they also display much sharper.
3. The sizing of the icon within the circle is a bit closer to in-game.
4. The border of the circle is a bit darker.
2. The wishlist thumb is moved a bit to the right.

Mods haven't been changed.

Before:
<img width="335" alt="Screen Shot 2020-10-25 at 8 48 38 PM" src="https://user-images.githubusercontent.com/313208/97132323-c311da80-1703-11eb-9fc1-fd4cdcf172ab.png">

After:
<img width="341" alt="Screen Shot 2020-10-25 at 8 48 32 PM" src="https://user-images.githubusercontent.com/313208/97132320-c1e0ad80-1703-11eb-9ca1-ba2da44c4dc6.png">

