### PR TITLE
Hide kill tracker socket

### DIFF
--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -1,6 +1,7 @@
 import { LockedItemType } from 'app/loadout-builder/types';
 import { CHALICE_OF_OPULENCE, synthesizerHashes } from 'app/search/d2-known-values';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { isKillTrackerSocket } from 'app/utils/item-utils';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React, { useState } from 'react';
@@ -113,21 +114,24 @@ function ItemSockets({
             </div>
           )}
           <div className="item-sockets">
-            {category.sockets.map((socketInfo) => (
-              <Socket
-                key={socketInfo.socketIndex}
-                defs={defs}
-                item={item}
-                isPhonePortrait={isPhonePortrait}
-                socket={socketInfo}
-                wishListsEnabled={wishListsEnabled}
-                inventoryWishListRoll={inventoryWishListRoll}
-                classesByHash={classesByHash}
-                onClick={handleSocketClick}
-                onShiftClick={onShiftClick}
-                adjustedPlug={adjustedItemPlugs?.[socketInfo.socketIndex]}
-              />
-            ))}
+            {category.sockets.map(
+              (socketInfo) =>
+                !isKillTrackerSocket(socketInfo) && (
+                  <Socket
+                    key={socketInfo.socketIndex}
+                    defs={defs}
+                    item={item}
+                    isPhonePortrait={isPhonePortrait}
+                    socket={socketInfo}
+                    wishListsEnabled={wishListsEnabled}
+                    inventoryWishListRoll={inventoryWishListRoll}
+                    classesByHash={classesByHash}
+                    onClick={handleSocketClick}
+                    onShiftClick={onShiftClick}
+                    adjustedPlug={adjustedItemPlugs?.[socketInfo.socketIndex]}
+                  />
+                )
+            )}
           </div>
         </div>
       ))}

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -198,12 +198,13 @@ export function itemCanBeInLoadout(item: DimItem): boolean {
 /** verifies an item has kill tracker mod slot, which is returned */
 const getKillTrackerSocket = (item: DimItem): DimSocket | undefined => {
   if (item.bucket.inWeapons) {
-    return item.sockets?.allSockets.find(
-      (socket) =>
-        (socket.plugged?.plugObjectives[0]?.objectiveHash ?? 0) in killTrackerObjectivesByHash
-    );
+    return item.sockets?.allSockets.find(isKillTrackerSocket);
   }
 };
+
+export function isKillTrackerSocket(socket: DimSocket) {
+  return (socket.plugged?.plugObjectives[0]?.objectiveHash ?? 0) in killTrackerObjectivesByHash;
+}
 
 export type KillTracker = {
   type: 'pve' | 'pvp';


### PR DESCRIPTION
I'm sure this will confuse someone but I get annoyed seeing the masterwork kill tracker socket in the socket grid.