### PR TITLE
Archetype bar tweaks

### DIFF
--- a/src/app/compare/compare.scss
+++ b/src/app/compare/compare.scss
@@ -124,10 +124,14 @@
     display: none;
   }
 
+  .sockets > * {
+    margin-bottom: 8px;
+  }
+
   .socket-container {
     img {
-      width: calc(0.5 * var(--item-size));
-      height: calc(0.5 * var(--item-size));
+      width: 26px;
+      height: 26px;
     }
   }
 

--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -121,7 +121,8 @@
 
 .socket-container {
   position: relative;
-  display: inline-block;
+  display: flex;
+  flex-direction: row;
 
   .item-socket-category-Consumable & {
     border: 1px solid #888;

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -1,7 +1,10 @@
 import { LockedItemType } from 'app/loadout-builder/types';
-import { CHALICE_OF_OPULENCE, synthesizerHashes } from 'app/search/d2-known-values';
+import {
+  CHALICE_OF_OPULENCE,
+  killTrackerSocketTypeHash,
+  synthesizerHashes,
+} from 'app/search/d2-known-values';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
-import { isKillTrackerSocket } from 'app/utils/item-utils';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React, { useState } from 'react';
@@ -116,7 +119,7 @@ function ItemSocketsGeneral({
           <div className="item-sockets">
             {category.sockets.map(
               (socketInfo) =>
-                !isKillTrackerSocket(socketInfo) && (
+                socketInfo.socketDefinition.socketTypeHash !== killTrackerSocketTypeHash && (
                   <Socket
                     key={socketInfo.socketIndex}
                     defs={defs}

--- a/src/app/item-popup/ItemSocketsWeapons.m.scss
+++ b/src/app/item-popup/ItemSocketsWeapons.m.scss
@@ -1,5 +1,10 @@
 @import '../variables.scss';
 
+.weaponSockets {
+  flex-direction: column;
+  flex-wrap: nowrap;
+}
+
 .row {
   composes: flexRow from '../dim-ui/common.m.scss';
   align-items: center;
@@ -19,8 +24,13 @@
 
 .archetype {
   background-color: #333;
-  margin: 0 -10px 10px -10px;
+  margin: 0 -10px 12px -10px;
   width: 100%;
+  border-bottom: none;
+
+  .minimal & {
+    background-color: transparent;
+  }
 
   :global(.socket-container) img {
     width: 26px;
@@ -36,6 +46,12 @@
     transform: scale(1.4);
     margin-right: 6px;
     margin-left: 2px;
+
+    .minimal & {
+      width: 16px !important;
+      height: 16px !important;
+      transform: scale(1.4);
+    }
   }
 }
 

--- a/src/app/item-popup/ItemSocketsWeapons.m.scss.d.ts
+++ b/src/app/item-popup/ItemSocketsWeapons.m.scss.d.ts
@@ -3,9 +3,11 @@
 interface CssExports {
   'archetype': string;
   'archetypeMod': string;
+  'minimal': string;
   'perks': string;
   'row': string;
   'stats': string;
+  'weaponSockets': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -1,8 +1,8 @@
 import { t } from 'app/i18next-t';
 import { statsMs } from 'app/inventory/store/stats';
 import { LockedItemType } from 'app/loadout-builder/types';
+import { killTrackerSocketTypeHash } from 'app/search/d2-known-values';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
-import { isKillTrackerSocket } from 'app/utils/item-utils';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { ItemCategoryHashes, SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
@@ -22,6 +22,8 @@ import SocketDetails from './SocketDetails';
 
 interface ProvidedProps {
   item: DimItem;
+  /** minimal style used for loadout generator and compare */
+  minimal?: boolean;
   updateSocketComparePlug?(value: { item: DimItem; socket: DimSocket; plug: DimPlug }): void;
   adjustedItemPlugs?: DimAdjustedItemPlug;
   /** Extra CSS classes to apply to perks based on their hash */
@@ -50,6 +52,7 @@ type Props = ProvidedProps & StoreProps & ThunkDispatchProp;
 function ItemSocketsWeapons({
   defs,
   item,
+  minimal,
   wishListsEnabled,
   inventoryWishListRoll,
   classesByHash,
@@ -105,7 +108,11 @@ function ItemSocketsWeapons({
   };
 
   return (
-    <div className={clsx('item-details', 'sockets')}>
+    <div
+      className={clsx('item-details', 'sockets', styles.weaponSockets, {
+        [styles.minimal]: minimal,
+      })}
+    >
       <div className={clsx(styles.row, styles.archetype)}>
         {archetype?.plugged && (
           <div className={styles.archetypeMod}>
@@ -124,7 +131,7 @@ function ItemSocketsWeapons({
             />
             <div>
               <div>{archetype.plugged.plugDef.displayProperties.name}</div>
-              {keyStats && keyStats.length > 0 && (
+              {!minimal && keyStats && keyStats.length > 0 && (
                 <div className={styles.stats}>
                   {keyStats
                     ?.map(
@@ -139,23 +146,25 @@ function ItemSocketsWeapons({
             </div>
           </div>
         )}
-        <div className="item-socket-category-Consumable socket-container">
-          {mods.map((socketInfo) => (
-            <Socket
-              key={socketInfo.socketIndex}
-              defs={defs}
-              item={item}
-              isPhonePortrait={isPhonePortrait}
-              socket={socketInfo}
-              wishListsEnabled={wishListsEnabled}
-              inventoryWishListRoll={inventoryWishListRoll}
-              classesByHash={classesByHash}
-              onClick={handleSocketClick}
-              onShiftClick={onShiftClick}
-              adjustedPlug={adjustedItemPlugs?.[socketInfo.socketIndex]}
-            />
-          ))}
-        </div>
+        {!minimal && mods.length > 0 && (
+          <div className="item-socket-category-Consumable socket-container">
+            {mods.map((socketInfo) => (
+              <Socket
+                key={socketInfo.socketIndex}
+                defs={defs}
+                item={item}
+                isPhonePortrait={isPhonePortrait}
+                socket={socketInfo}
+                wishListsEnabled={wishListsEnabled}
+                inventoryWishListRoll={inventoryWishListRoll}
+                classesByHash={classesByHash}
+                onClick={handleSocketClick}
+                onShiftClick={onShiftClick}
+                adjustedPlug={adjustedItemPlugs?.[socketInfo.socketIndex]}
+              />
+            ))}
+          </div>
+        )}
       </div>
       {perks && (
         <div
@@ -168,7 +177,7 @@ function ItemSocketsWeapons({
           <div className="item-sockets">
             {perks.sockets.map(
               (socketInfo) =>
-                !isKillTrackerSocket(socketInfo) && (
+                socketInfo.socketDefinition.socketTypeHash !== killTrackerSocketTypeHash && (
                   <Socket
                     key={socketInfo.socketIndex}
                     defs={defs}
@@ -185,6 +194,25 @@ function ItemSocketsWeapons({
                 )
             )}
           </div>
+        </div>
+      )}
+      {minimal && mods.length > 0 && (
+        <div className="item-socket-category-Consumable socket-container">
+          {mods.map((socketInfo) => (
+            <Socket
+              key={socketInfo.socketIndex}
+              defs={defs}
+              item={item}
+              isPhonePortrait={isPhonePortrait}
+              socket={socketInfo}
+              wishListsEnabled={wishListsEnabled}
+              inventoryWishListRoll={inventoryWishListRoll}
+              classesByHash={classesByHash}
+              onClick={handleSocketClick}
+              onShiftClick={onShiftClick}
+              adjustedPlug={adjustedItemPlugs?.[socketInfo.socketIndex]}
+            />
+          ))}
         </div>
       )}
       {socketInMenu &&

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -82,6 +82,7 @@ export const killTrackerObjectivesByHash: Record<number, 'pvp' | 'pve' | undefin
   73837075: 'pve', // Objective "Enemies Defeated" found inside InventoryItem[905869860] "Kill Tracker"
   90275515: 'pve', // Objective "Enemies Defeated" found inside InventoryItem[2240097604] "Kill Tracker"
   2579044636: 'pve', // Objective "Enemies Defeated" found inside InventoryItem[2302094943] "Kill Tracker"
+  2285418970: undefined, //
 };
 export const killTrackerSocketTypeHash = 1282012138;
 

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -202,6 +202,7 @@ const getKillTrackerSocket = (item: DimItem): DimSocket | undefined => {
   }
 };
 
+/** Is this both a kill tracker socket, and the kill tracker is enabled? */
 export function isKillTrackerSocket(socket: DimSocket) {
   return (socket.plugged?.plugObjectives[0]?.objectiveHash ?? 0) in killTrackerObjectivesByHash;
 }


### PR DESCRIPTION
This cleans up the new weapon perks layout for the compare screen, and eliminates the kill tracker column even for items where the kill tracker is off.

<img width="668" alt="Screen Shot 2020-10-29 at 5 33 23 PM" src="https://user-images.githubusercontent.com/313208/97646434-e642cf80-1a0c-11eb-9dd1-966d7c6b5eea.png">
