### PR TITLE
Safari desktop fix broke mobile tagging

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fix the item tagging popup not working on mobile by un-fixing the Safari desktop item popup.
+
 ## 6.37.1 <span className="changelog-date">(2020-11-02)</span>
 
 * Fixed not being able to scroll on mobile.

--- a/src/app/item-popup/ItemTagSelector.m.scss
+++ b/src/app/item-popup/ItemTagSelector.m.scss
@@ -1,5 +1,4 @@
 .itemTagSelector {
-  position: relative;
   button {
     min-width: 10em;
   }


### PR DESCRIPTION
Fixes #6103. `position:relative` is causing the popup to clip to its container. Gonna have to figure out something else to fix Safari's bad positioning calculation.