### PR TITLE
More saturated gradient options

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -6,10 +6,9 @@ $blue: #68a0b7;
 $red: #ff3232; // For warnings/errors
 $gradient: radial-gradient(
   circle at 50% 70px,
-  hsl(240, 30%, 35%) 0%,
-  hsl(240, 30%, 20%) 100%
+  hsl(240, 20%, 28%) 0%,
+  hsl(240, 27%, 12%) 100%
 ); //new background gradient
-// $gradient: radial-gradient(circle at 50% 70px, #353567 0%, #161626 100%); //new background gradient
 
 // Elemental damage types
 $arc: #85c5ec;

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -6,8 +6,8 @@ $blue: #68a0b7;
 $red: #ff3232; // For warnings/errors
 $gradient: radial-gradient(
   circle at 50% 70px,
-  hsl(240, 37%, 31%) 0%,
-  hsl(240, 37%, 18%) 100%
+  hsl(240, 30%, 35%) 0%,
+  hsl(240, 30%, 20%) 100%
 ); //new background gradient
 // $gradient: radial-gradient(circle at 50% 70px, #353567 0%, #161626 100%); //new background gradient
 

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -4,7 +4,12 @@
 $orange: #e8a534;
 $blue: #68a0b7;
 $red: #ff3232; // For warnings/errors
-$gradient: radial-gradient(circle at 50% 70px, #454568 0%, #161626 100%); //new background gradient
+$gradient: radial-gradient(
+  circle at 50% 70px,
+  hsl(240, 37%, 31%) 0%,
+  hsl(240, 37%, 18%) 100%
+); //new background gradient
+// $gradient: radial-gradient(circle at 50% 70px, #353567 0%, #161626 100%); //new background gradient
 
 // Elemental damage types
 $arc: #85c5ec;


### PR DESCRIPTION
Playing with the gradient a bit. This reduces the overall change in lightness, while also saturating the background color more.

Original:
<img width="1440" alt="Screen Shot 2020-11-07 at 10 40 56 PM" src="https://user-images.githubusercontent.com/313208/98458933-7b9b3d80-214a-11eb-98fd-0f6ddf97c1d8.png">

Option 4 - the original gradient, but with a less bright center:

<img width="1436" alt="Screen Shot 2020-11-08 at 1 47 13 PM" src="https://user-images.githubusercontent.com/313208/98485133-f014c180-21c8-11eb-863b-c16654debea6.png">

Option 1:

<img width="1440" alt="Screen Shot 2020-11-07 at 10 41 04 PM" src="https://user-images.githubusercontent.com/313208/98458934-81911e80-214a-11eb-9dc9-60ba1cc2a7ed.png">

Option 2 (a bit lighter, a bit less saturated):

<img width="1440" alt="Screen Shot 2020-11-07 at 10 45 41 PM" src="https://user-images.githubusercontent.com/313208/98458992-00865700-214b-11eb-9e63-61cce54d5ccf.png">

Not-really-an-option 3 (vary hue/saturation instead of lightness, looks dreadful):

<img width="1440" alt="Screen Shot 2020-11-07 at 10 49 00 PM" src="https://user-images.githubusercontent.com/313208/98459032-7b4f7200-214b-11eb-9eb6-219d1e69feee.png">
