### PR TITLE
Scale perks/mods with the item size variable

### DIFF
--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -130,8 +130,8 @@
 
   img {
     -webkit-touch-callout: none;
-    width: 32px;
-    height: 32px;
+    width: calc(32 / 50 * var(--item-size));
+    height: calc(32 / 50 * var(--item-size));
     display: block;
   }
 }
@@ -140,15 +140,16 @@
   border: 1px solid #888;
   border-radius: 50%;
   background-color: #4887ba;
-  padding: 1px;
+  padding: calc(2 / 50 * var(--item-size));
   margin-bottom: 6px;
   &:last-child {
     margin-bottom: 0;
   }
 
   img {
-    width: 26px;
-    height: 26px;
+    border: none;
+    width: calc(24 / 50 * var(--item-size));
+    height: calc(24 / 50 * var(--item-size));
   }
 
   @include phone-portrait {

--- a/src/app/item-popup/ItemSocketsWeapons.m.scss
+++ b/src/app/item-popup/ItemSocketsWeapons.m.scss
@@ -27,20 +27,20 @@
   }
 
   :global(.socket-container) img {
-    width: 26px;
-    height: 26px;
+    width: calc(26 / 50 * var(--item-size));
+    height: calc(26 / 50 * var(--item-size));
   }
 
   :global(.item-socket-category-Consumable) img {
-    width: 32px;
-    height: 32px;
+    width: calc(32 / 50 * var(--item-size));
+    height: calc(32 / 50 * var(--item-size));
   }
 }
 
 .archetypeMod {
   img {
-    width: 26px;
-    height: 26px;
+    width: calc(26 / 50 * var(--item-size));
+    height: calc(26 / 50 * var(--item-size));
     transform: scale(1.4);
     margin-right: 6px;
     margin-left: 2px;


### PR DESCRIPTION
This returns to scaling perks / mods with the item size variable. I still really want to clean up these styles more...

This should fix #6102.

Before (item size 66px):
<img width="492" alt="Screen Shot 2020-11-07 at 11 20 53 PM" src="https://user-images.githubusercontent.com/313208/98459503-442f8f80-2150-11eb-859a-2fb9ff573409.png">

After (item size 66px):
<img width="493" alt="Screen Shot 2020-11-07 at 11 19 54 PM" src="https://user-images.githubusercontent.com/313208/98459502-41349f00-2150-11eb-8e06-3245eab72b8e.png">
