### PR TITLE
abolish gender in d2

### DIFF
--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -54,7 +54,7 @@ export default function CharacterTile({ store }: { store: DimStore }) {
             isPhonePortrait && <VaultCapacity />
           ) : (
             <>
-              <div className="race-gender">{store.genderRace}</div>
+              <div className="race-gender">{store.race}</div>
               {store.destinyVersion === 1 && store.level < 40 && (
                 <div className="level">{store.level}</div>
               )}

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -31,6 +31,8 @@ export interface DimStore<Item = DimItem> {
   className: string;
   /** Localized gender. */
   gender: string;
+  /** Localized race. */
+  race: string;
   /** Localized gender and race together. */
   genderRace: string;
   /** String gender name: 'male' | 'female' | '', used exclusively for i18n when translating to gendered languages */

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -35,17 +35,20 @@ export function makeCharacter(
   const race = defs.Race[character.characterBase.raceHash];
   let genderRace = '';
   let className = '';
+  let raceName = '';
   let gender: DimStore['gender'] = '';
   let genderName: DimStore['genderName'] = '';
   if (character.characterBase.genderType === 0) {
     gender = 'male';
     genderName = 'male';
     genderRace = race.raceNameMale;
+    raceName = race.raceNameMale;
     className = defs.Class[character.characterBase.classHash].classNameMale;
   } else {
     gender = 'female';
     genderName = 'female';
     genderRace = race.raceNameFemale;
+    raceName = race.raceNameFemale;
     className = defs.Class[character.characterBase.classHash].classNameFemale;
   }
 
@@ -81,6 +84,7 @@ export function makeCharacter(
     classType: character.characterBase.classType,
     className,
     gender,
+    race: raceName,
     genderRace,
     genderName,
     percentToNextLevel: character.percentToNextLevel / 100,
@@ -142,6 +146,7 @@ export function makeVault(
     percentToNextLevel: 0,
     powerLevel: 0,
     gender: '',
+    race: '',
     genderRace: '',
     stats: [],
   };

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -24,6 +24,7 @@ export function makeCharacter(
   mostRecentLastPlayed: Date
 ): DimStore {
   const race = defs.Race[character.raceHash];
+  const raceLocalizedName = race.displayProperties.name;
   const gender = defs.Gender[character.genderHash];
   const classy = defs.Class[character.classHash];
   const genderRace = race.genderedRaceNamesByGenderHash[gender.hash];
@@ -36,7 +37,7 @@ export function makeCharacter(
     id: character.characterId,
     icon: bungieNetPath(character.emblemPath),
     name: t('ItemService.StoreName', {
-      genderRace,
+      genderRace: raceLocalizedName,
       className,
     }),
     current: mostRecentLastPlayed.getTime() === lastPlayed.getTime(),
@@ -50,6 +51,7 @@ export function makeCharacter(
     classType: classy.classType,
     className,
     gender: genderLocalizedName,
+    race: raceLocalizedName,
     genderRace,
     genderName: genderTypeToEnglish[gender.genderType] ?? '',
     isVault: false,
@@ -77,6 +79,7 @@ export function makeVault(): DimStore {
     percentToNextLevel: 0,
     powerLevel: 0,
     gender: '',
+    race: '',
     genderRace: '',
     stats: [],
   };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68782081/98582059-48a29800-2277-11eb-9dde-c728c955f67c.png)

in BL, 'male' and 'female' are being replaced by 'masculine' and 'feminine' and either
- the API strings no longer match up
- that's weird and a mouthful to stick in a character banner

also its 2020 we dont need gender

i sort of soft removed this because there's several identity strings hanging basically unused off DimStore right now, they arent hurting anything and who knows what we might need. but this puts us in a good place for BL.