### PR TITLE
Improve styling for error panel

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -91,21 +91,15 @@ $header-height: 44px;
 
 // Apply spacing between children
 @mixin vertical-space-children($space) {
-  > * {
-    margin-bottom: $space;
-    &:last-child {
-      margin-bottom: 0;
-    }
+  > *:nth-last-child(n + 2) {
+    margin-top: $space;
   }
 }
 
 // Apply spacing between children
 @mixin horizontal-space-children($space) {
-  > * {
+  > *:nth-last-child(n + 2) {
     margin-right: $space;
-    &:last-child {
-      margin-right: 0;
-    }
   }
 }
 

--- a/src/app/shell/ErrorPanel.m.scss
+++ b/src/app/shell/ErrorPanel.m.scss
@@ -5,6 +5,7 @@
   padding: 0.85em;
   background: scale-color($red, $lightness: -90%);
   border-top: 4px solid $red;
+
   h2 {
     margin: 0 0 8px 0 !important;
     letter-spacing: normal !important;
@@ -18,9 +19,9 @@
 
 .twitterLinks {
   composes: flexRow from '../dim-ui/common.m.scss';
-  > * {
-    margin-right: 8px;
-  }
+  flex-wrap: wrap;
+  @include horizontal-space-children(8px);
+  gap: 8px 0;
 
   :global(.fa-twitter) {
     font-size: 1.5em;
@@ -44,7 +45,8 @@
     flex-direction: column;
   }
 
-  > div {
+  > div > div {
     height: 400px;
+    outline: 4px solid rgba(255, 255, 255, 0.3);
   }
 }


### PR DESCRIPTION
Before:
<img width="217" alt="Screen Shot 2020-11-09 at 9 28 29 PM" src="https://user-images.githubusercontent.com/313208/98631600-a0222180-22d2-11eb-9073-fc29ee2976e7.png">

After:
<img width="217" alt="Screen Shot 2020-11-09 at 9 23 21 PM" src="https://user-images.githubusercontent.com/313208/98631392-2e49d800-22d2-11eb-92b5-5a83378cbb47.png">
