### PR TITLE
Fix for badge icons in records

### DIFF
--- a/src/app/collections/PresentationNode.tsx
+++ b/src/app/collections/PresentationNode.tsx
@@ -124,14 +124,7 @@ function PresentationNode({
 
   const title = (
     <span className="node-name">
-      {nodeDef.displayProperties.icon && (
-        <BungieImage
-          src={
-            nodeDef.displayProperties.iconSequences?.[0]?.frames?.[1] ??
-            nodeDef.displayProperties.icon
-          }
-        />
-      )}{' '}
+      {nodeDef.displayProperties.icon && <BungieImage src={nodeDef.displayProperties.icon} />}{' '}
       {overrideName || nodeDef.displayProperties.name}
     </span>
   );


### PR DESCRIPTION
All the other icons seem to be fine from what I can see with this change. Not entirely sure what the at icon I deleted was used for.

Before
![image](https://user-images.githubusercontent.com/7344652/98744369-b41a7000-2405-11eb-8885-0d8024a0b462.png)

After
![image](https://user-images.githubusercontent.com/7344652/98744398-bed50500-2405-11eb-9083-b53e81f08004.png)
