### PR TITLE
provide fallback path for vendor icons

### DIFF
--- a/src/app/vendors/Vendor.tsx
+++ b/src/app/vendors/Vendor.tsx
@@ -59,7 +59,13 @@ export default function Vendor({
         title={
           <>
             <span className={styles.vendorIconWrapper}>
-              <BungieImage src={vendor.def.displayProperties.icon} className={styles.icon} />
+              <BungieImage
+                src={
+                  vendor.def.displayProperties.icon ||
+                  vendor.def.displayProperties.smallTransparentIcon
+                }
+                className={styles.icon}
+              />
               {$featureFlags.vendorEngrams && vendorEngramDrops.length > 0 && (
                 <a target="_blank" rel="noopener noreferrer" href="https://vendorengrams.xyz/">
                   <img

--- a/src/app/vendors/VendorsMenu.tsx
+++ b/src/app/vendors/VendorsMenu.tsx
@@ -37,7 +37,12 @@ export default function VendorsMenu({
                     title={t('VendorEngramsXyz.DroppingHigh')}
                   />
                 )}
-                <BungieImage src={vendor.def.displayProperties.icon} />
+                <BungieImage
+                  src={
+                    vendor.def.displayProperties.icon ||
+                    vendor.def.displayProperties.smallTransparentIcon
+                  }
+                />
                 <span>{vendor.def.displayProperties.name}</span>
               </PageWithMenu.MenuButton>
             );


### PR DESCRIPTION
variks the loyal doesn't have an `icon`, so try another place for vendor image