### PR TITLE
More AWA machinery

### DIFF
--- a/src/app/active-mode/RestStoresBucket.tsx
+++ b/src/app/active-mode/RestStoresBucket.tsx
@@ -2,10 +2,11 @@ import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimStore } from 'app/inventory/store-types';
 import StoreBucketDropTarget from 'app/inventory/StoreBucketDropTarget';
 import StoreInventoryItem from 'app/inventory/StoreInventoryItem';
-import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { RootState } from 'app/store/types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import React, { useMemo } from 'react';
-import { connect, MapStateToProps, useDispatch } from 'react-redux';
+import { connect, MapStateToProps } from 'react-redux';
 import { createSelector } from 'reselect';
 import { DimItem } from '../inventory/item-types';
 import { allItemsSelector } from '../inventory/selectors';
@@ -45,7 +46,7 @@ type Props = ProvidedProps & StoreProps;
 
 /** a `StoreBucket` for items not on the currently selected store */
 function RestStoresBucket({ restItems, bucket, itemSortOrder }: Props) {
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
   const items = useMemo(() => sortItems(restItems, itemSortOrder), [restItems, itemSortOrder]);
 
   if (!bucket.hasTransferDestination) {

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -5,7 +5,7 @@ import { applyLoadout } from 'app/loadout/loadout-apply';
 import { LoadoutItem } from 'app/loadout/loadout-types';
 import { ItemFilter } from 'app/search/filter-types';
 import SearchBar from 'app/search/SearchBar';
-import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { DimThunkDispatch, RootState, ThunkDispatchProp } from 'app/store/types';
 import { useSubscription } from 'app/utils/hooks';
 import { isD1Item } from 'app/utils/item-utils';
 import clsx from 'clsx';
@@ -352,7 +352,7 @@ function isInfusable(target: DimItem, source: DimItem) {
 }
 
 async function transferItems(
-  dispatch: ThunkDispatchProp['dispatch'],
+  dispatch: DimThunkDispatch,
   currentStore: DimStore,
   onClose: () => void,
   source: DimItem,

--- a/src/app/inventory/PullFromPostmaster.tsx
+++ b/src/app/inventory/PullFromPostmaster.tsx
@@ -1,7 +1,8 @@
 import { t } from 'app/i18next-t';
-import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { RootState } from 'app/store/types';
 import React, { useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { pullablePostmasterItems, pullFromPostmaster } from '../loadout/postmaster';
 import { AppIcon, refreshIcon, sendIcon } from '../shell/icons';
 import { queueAction } from '../utils/action-queue';
@@ -10,7 +11,7 @@ import { DimStore } from './store-types';
 
 export function PullFromPostmaster({ store }: { store: DimStore }) {
   const [working, setWorking] = useState(false);
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
   const numPullablePostmasterItems = useSelector(
     (state: RootState) => pullablePostmasterItems(store, storesSelector(state)).length
   );

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -3,7 +3,8 @@ import ClassIcon from 'app/dim-ui/ClassIcon';
 import { t } from 'app/i18next-t';
 import { characterOrderSelector } from 'app/settings/character-sort';
 import { isPhonePortraitSelector } from 'app/shell/selectors';
-import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -12,7 +13,7 @@ import emptyEngram from 'destiny-icons/general/empty-engram.svg';
 import { shallowEqual } from 'fast-equals';
 import _ from 'lodash';
 import React, { useCallback } from 'react';
-import { connect, useDispatch } from 'react-redux';
+import { connect } from 'react-redux';
 import { itemSortOrderSelector } from '../settings/item-sort';
 import { sortItems } from '../shell/filters';
 import { addIcon, AppIcon } from '../shell/icons';
@@ -109,7 +110,7 @@ function StoreBucket({
   characterOrder,
   isPhonePortrait,
 }: Props) {
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
 
   const pickEquipItem = useCallback(() => {
     dispatch(pullItem(storeId, bucket));

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -1,8 +1,7 @@
 import { loadoutDialogOpen } from 'app/loadout/LoadoutDrawer';
 import { Inspect } from 'app/mobile-inspect/MobileInspect';
-import { ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import { CompareService } from '../compare/compare.service';
 import ConnectedInventoryItem from './ConnectedInventoryItem';
 import DraggableInventoryItem from './DraggableInventoryItem';
@@ -19,7 +18,7 @@ interface Props {
  * The "full" inventory item, which can be dragged around and which pops up a move popup when clicked.
  */
 export default function StoreInventoryItem({ item, isPhonePortrait }: Props) {
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
 
   const doubleClicked = (e: React.MouseEvent) => {
     if (!loadoutDialogOpen && !CompareService.dialogOpen) {

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -1,10 +1,16 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { DimError } from 'app/bungie-api/bungie-service-helper';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { ThunkResult } from 'app/store/types';
-import { DestinyColor, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
+import {
+  DestinyColor,
+  DestinyItemChangeResponse,
+  DestinyProfileResponse,
+} from 'bungie-api-ts/destiny2';
 import { get } from 'idb-keyval';
 import { createAction } from 'typesafe-actions';
 import { TagValue } from './dim-item-info';
+import { InventoryBuckets } from './inventory-buckets';
 import { DimItem } from './item-types';
 import { AccountCurrency, DimCharacterStat, DimStore } from './store-types';
 
@@ -49,6 +55,16 @@ export const itemMoved = createAction('inventory/MOVE_ITEM')<{
   target: DimStore;
   equip: boolean;
   amount: number;
+}>();
+
+/**
+ * An item was mutated by Advanced Write Actions (perks changed, sockets inserted, etc.).
+ * We need to update the inventory with the updated item and any removed/added items.
+ */
+export const awaItemChanged = createAction('inventory/AWA_CHANGE')<{
+  changes: DestinyItemChangeResponse;
+  defs: D2ManifestDefinitions;
+  buckets: InventoryBuckets;
 }>();
 
 /*

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -137,7 +137,7 @@ export interface DimItem {
   /** Extra pursuit info, if this item is a quest or bounty. */
   pursuit: DimPursuit | null;
 
-  // "Mutable" data - this may be changed by moving the item around, lock/unlock, etc. Any place DIM updates its view of the world without a profile refresh.
+  // "Mutable" data - this may be changed by moving the item around, lock/unlock, etc. Any place DIM updates its view of the world without a profile refresh. This info is always reset to server truth on a refresh.
 
   /** The ID of the store that currently contains this item. */
   owner: string;

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -2,6 +2,7 @@ import { t } from 'app/i18next-t';
 import { THE_FORBIDDEN_BUCKET } from 'app/search/d2-known-values';
 import { errorLog, warnLog } from 'app/utils/log';
 import {
+  ComponentPrivacySetting,
   DestinyAmmunitionType,
   DestinyClass,
   DestinyCollectibleComponent,
@@ -9,11 +10,14 @@ import {
   DestinyItemComponent,
   DestinyItemComponentSetOfint64,
   DestinyItemInstanceComponent,
+  DestinyItemResponse,
   DestinyItemType,
   DestinyObjectiveProgress,
+  DictionaryComponentResponse,
   ItemBindStatus,
   ItemLocation,
   ItemState,
+  SingleComponentResponse,
   TransferStatuses,
 } from 'bungie-api-ts/destiny2';
 import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
@@ -24,6 +28,7 @@ import { reportException } from '../../utils/exceptions';
 import { InventoryBuckets } from '../inventory-buckets';
 import { DimItem, DimPerk } from '../item-types';
 import { DimStore } from '../store-types';
+import { getVault } from '../stores-helpers';
 import { createItemIndex } from './item-index';
 import { buildMasterwork } from './masterwork';
 import { buildObjectives } from './objectives';
@@ -131,6 +136,55 @@ export function makeFakeItem(
 }
 
 /**
+ * Create a single item from a DestinyItemResponse, either from getItemDetails or an AWA result.
+ * We can use this item to refresh a single item in the store from this response.
+ */
+export function makeItemSingle(
+  defs: D2ManifestDefinitions,
+  buckets: InventoryBuckets,
+  item: DestinyItemResponse,
+  stores: DimStore[],
+  mergedCollectibles?: {
+    [hash: number]: DestinyCollectibleComponent;
+  }
+): DimItem | null {
+  if (!item.item.data) {
+    return null;
+  }
+
+  const owner = item.characterId ? stores.find((s) => s.id === item.characterId) : getVault(stores);
+
+  const itemId = item.item.data.itemInstanceId;
+
+  // Convert a single component response into a dictionary component response
+  const empty = { privacy: ComponentPrivacySetting.Public, data: {} };
+  const m: <V>(v: SingleComponentResponse<V>) => DictionaryComponentResponse<V> = itemId
+    ? (v) => ({ privacy: v.privacy, data: v.data ? { [itemId]: v.data } : {} })
+    : () => empty;
+
+  // Make it look like a full response
+  return makeItem(
+    defs,
+    buckets,
+    {
+      instances: m(item.instance),
+      perks: m(item.perks),
+      renderData: m(item.renderData),
+      stats: m(item.stats),
+      sockets: m(item.sockets),
+      reusablePlugs: m(item.reusablePlugs),
+      plugObjectives: m(item.plugObjectives),
+      talentGrids: m(item.talentGrid),
+      plugStates: empty,
+      objectives: m(item.objectives),
+    },
+    item.item.data,
+    owner,
+    mergedCollectibles
+  );
+}
+
+/**
  * Process a single raw item into a DIM item.
  * @param defs the manifest definitions
  * @param buckets the bucket definitions
@@ -139,7 +193,7 @@ export function makeFakeItem(
  * @param item "raw" item from the Destiny API
  * @param owner the ID of the owning store.
  */
-// TODO: extract item components first!
+// TODO: extract individual item components first!
 export function makeItem(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -8,13 +8,14 @@ import { amountOfItem, getCurrentStore, getStore, getVault } from 'app/inventory
 import { addItemToLoadout } from 'app/loadout/LoadoutDrawer';
 import { setSetting } from 'app/settings/actions';
 import { addIcon, AppIcon, compareIcon, maximizeIcon, minimizeIcon } from 'app/shell/icons';
-import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { RootState } from 'app/store/types';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import arrowsIn from '../../images/arrows-in.png';
 import arrowsOut from '../../images/arrows-out.png';
 import d2Infuse from '../../images/d2infuse.png';
@@ -41,7 +42,7 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
   // barring a user selection, default to moving the whole stack of this item
   const [amount, setAmount] = useState(item.amount);
   const itemOwner = getStore(stores, item.owner);
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
 
   // If the item can't be transferred (or is unique) don't show the move amount slider
   const maximum = useMemo(

--- a/src/app/item-popup/EnergyMeter.tsx
+++ b/src/app/item-popup/EnergyMeter.tsx
@@ -6,7 +6,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { energyUpgrade, sumModCosts } from 'app/inventory/store/energy';
 import { showNotification } from 'app/notifications/notifications';
 import { AppIcon, disabledIcon, enabledIcon } from 'app/shell/icons';
-import { ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import Cost from 'app/vendors/Cost';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -14,7 +14,6 @@ import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import { AnimatePresence, motion } from 'framer-motion';
 import _ from 'lodash';
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import styles from './EnergyMeter.m.scss';
 
@@ -36,7 +35,7 @@ export default function EnergyMeter({
   const [hoverEnergyCapacity, setHoverEnergyCapacity] = useState(0);
   const [previewCapacity, setPreviewCapacity] = useState<number>(energyCapacity);
   const [previewEnergyType, setPreviewEnergyType] = useState<DestinyEnergyType>(energyType);
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
 
   if (!item.energy) {
     return null;

--- a/src/app/item-popup/ItemActions.tsx
+++ b/src/app/item-popup/ItemActions.tsx
@@ -1,10 +1,10 @@
 import { t } from 'app/i18next-t';
 import { amountOfItem, getStore } from 'app/inventory/stores-helpers';
 import { showItemPopup } from 'app/item-popup/item-popup';
-import { ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
 import React, { useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { showInfuse } from '../infuse/infuse';
 import { DimItem } from '../inventory/item-types';
 import { consolidate, distribute, moveItemTo } from '../inventory/move-item';
@@ -26,7 +26,7 @@ export default function ItemActions({
   const [amount, setAmount] = useState(item.amount);
   const stores = useSelector(sortedStoresSelector);
   const store = getStore(stores, item.owner);
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
 
   // If the item can't be transferred (or is unique) don't show the move amount slider
   const maximum = useMemo(

--- a/src/app/item-popup/LockButton.tsx
+++ b/src/app/item-popup/LockButton.tsx
@@ -1,10 +1,9 @@
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import { setItemLockState } from 'app/inventory/item-move-service';
-import { ThunkDispatchProp } from 'app/store/types';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { DimItem } from '../inventory/item-types';
 import { AppIcon, lockIcon, trackedIcon, unlockedIcon, unTrackedIcon } from '../shell/icons';
 import styles from './LockButton.m.scss';
@@ -18,7 +17,7 @@ interface Props {
 
 export default function LockButton({ type, item, className, children }: Props) {
   const [locking, setLocking] = useState(false);
-  const dispatch = useDispatch<ThunkDispatchProp['dispatch']>();
+  const dispatch = useThunkDispatch();
 
   const lockUnlock = async () => {
     if (locking) {

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -253,6 +253,7 @@ function SocketDetails({
       plug={selectedPlug}
       defs={defs}
       item={item}
+      socket={socket}
       currentPlug={socket.plugged}
     />
   );

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -1,4 +1,3 @@
-import { getActivePlatform } from 'app/accounts/get-active-platform';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { insertPlug } from 'app/inventory/advanced-write-actions';
@@ -10,6 +9,7 @@ import {
   PluggableInventoryItemDefinition,
 } from 'app/inventory/item-types';
 import { interpolateStatValue } from 'app/inventory/store/stats';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { emptySpecialtySocketHashes } from 'app/utils/item-utils';
 import { StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -39,6 +39,8 @@ export default function SocketDetailsSelectedPlug({
   item: DimItem;
   currentPlug: DimPlug | null;
 }) {
+  const dispatch = useThunkDispatch();
+
   const selectedPlugPerk =
     Boolean(plug.perks?.length) && defs.SandboxPerk.get(plug.perks[0].perkHash);
 
@@ -88,10 +90,8 @@ export default function SocketDetailsSelectedPlug({
   );
 
   const onInsertPlug = async () => {
-    const response = await insertPlug(getActivePlatform()!, item, socket, plug.hash);
-    if (response.item) {
-      // Update the item!
-    }
+    await dispatch(insertPlug(item, socket, plug.hash));
+    // Handle errors?
 
     // close the menu?
   };
@@ -117,7 +117,7 @@ export default function SocketDetailsSelectedPlug({
     <div className={styles.selectedPlug}>
       <div className={styles.modIcon}>
         <SocketDetailsMod itemDef={plug} defs={defs} />
-        {!$featureFlags.advancedWriteActions && costs}
+        {!$featureFlags.awa && costs}
       </div>
       <div className={styles.modDescription}>
         <h3>
@@ -141,7 +141,7 @@ export default function SocketDetailsSelectedPlug({
         ))}
       </div>
       <ItemStats stats={stats.map((s) => s.dimStat)} className={styles.itemStats} />
-      {$featureFlags.advancedWriteActions && (
+      {$featureFlags.awa && (
         <button type="button" onClick={onInsertPlug}>
           Insert Mod
           {costs}

--- a/src/app/store/thunk-dispatch.ts
+++ b/src/app/store/thunk-dispatch.ts
@@ -1,0 +1,7 @@
+import { useDispatch } from 'react-redux';
+import { DimThunkDispatch } from './types';
+/**
+ * A hook to access the redux `dispatch` function, compatible with hooks. This returns a `dispatch` that's typed
+ * correctly for thunk actions.
+ */
+export const useThunkDispatch = () => useDispatch<DimThunkDispatch>();

--- a/src/app/store/types.ts
+++ b/src/app/store/types.ts
@@ -27,6 +27,7 @@ export interface RootState {
 }
 
 export type ThunkResult<R = void> = ThunkAction<Promise<R>, RootState, undefined, AnyAction>;
+export type DimThunkDispatch = ThunkDispatch<RootState, undefined, AnyAction>;
 export type ThunkDispatchProp = {
-  dispatch: ThunkDispatch<RootState, undefined, AnyAction>;
+  dispatch: DimThunkDispatch;
 };


### PR DESCRIPTION
This improves our underlying support for AWA. It introduces a new action that allows us to update inventory based on the result of an AWA action, both updating the item that was changed and incrementing/decrementing currencies and materials. This also gives us the building blocks to be able to refresh a single item from the API.

As a proof of concept, this also hooks up an awful looking button to the socket details sheet, to allow slotting mods/shaders/etc.