### PR TITLE
Add energy capacity to armor badges

### DIFF
--- a/src/app/dim-ui/ElementIcon.m.scss
+++ b/src/app/dim-ui/ElementIcon.m.scss
@@ -1,10 +1,10 @@
 .element {
-  width: calc(var(--item-size) / 6);
-  height: calc(var(--item-size) / 6);
+  width: calc((8 / 50) * var(--item-size));
+  height: calc((8 / 50) * var(--item-size));
   margin-right: 1px;
 
   :global(.destiny1) & {
-    width: calc(var(--item-size) / 5);
-    height: calc(var(--item-size) / 5);
+    width: calc((10 / 50) * var(--item-size));
+    height: calc((10 / 50) * var(--item-size));
   }
 }

--- a/src/app/inventory/BadgeInfo.m.scss
+++ b/src/app/inventory/BadgeInfo.m.scss
@@ -25,7 +25,7 @@
 
 .quality {
   display: none;
-  flex: 1;
+  margin-right: auto;
 
   :global(.itemQuality) & {
     display: block;
@@ -51,31 +51,38 @@
   background-color: #eade8b;
 }
 
-.energy-capacity {
+.energyCapacity {
+  display: flex;
+  margin-right: auto;
+  justify-self: flex-start;
+  align-items: center;
   font-weight: bold;
-  font-size: calc((var(--item-size) / 6));
-  padding: 0px 2px;
-  border-radius: 2px;
-  color: #dddddd;
-  line-height: 1;
-  margin-right: 2px;
+  font-size: calc((9 / 50) * var(--item-size)); // 9px at default 50px item size
+  padding-right: 2px;
 }
+
 /* these are my calculations for colors that would look ok as text badges . not in use this moment.*/
 .solar {
-  background-color: #f0631e;
+  color: #f0631e;
 }
 .arc {
   /* real arc: #79bbe8 rgb(121, 187, 232) - badgeinfo arc icon: #2b81bb rgb(43, 129, 187)*/
   /* #529ed1 rgb(82, 158, 209) */
-  background-color: #529ed1;
+  color: #529ed1;
 }
 .void {
   /* real void: #a371c2 rgb(163, 113, 194) - badgeinfo void icon: #804cce rgb(128, 76, 206) */
   /* #915ec8 rgb(145, 94, 200) */
-  background-color: #915ec8;
+  color: #915ec8;
 }
 
 .lightBackgroundElement {
   filter: brightness(75%) saturate(200%);
   background-color: transparent !important;
+}
+
+.energyCapacityIcon {
+  composes: lightBackgroundElement;
+  margin-right: 0;
+  margin-left: 1px;
 }

--- a/src/app/inventory/BadgeInfo.m.scss
+++ b/src/app/inventory/BadgeInfo.m.scss
@@ -18,20 +18,14 @@
   overflow: hidden;
 }
 
-.primaryStat {
-  flex: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-}
-
 .wishlistRoll {
   display: flex;
+  flex: 1;
 }
 
 .quality {
   display: none;
+  flex: 1;
 
   :global(.itemQuality) & {
     display: block;

--- a/src/app/inventory/BadgeInfo.m.scss.d.ts
+++ b/src/app/inventory/BadgeInfo.m.scss.d.ts
@@ -8,7 +8,6 @@ interface CssExports {
   'fullstack': string;
   'lightBackgroundElement': string;
   'masterwork': string;
-  'primaryStat': string;
   'quality': string;
   'solar': string;
   'void': string;

--- a/src/app/inventory/BadgeInfo.m.scss.d.ts
+++ b/src/app/inventory/BadgeInfo.m.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'badge': string;
   'capped': string;
   'energyCapacity': string;
+  'energyCapacityIcon': string;
   'fullstack': string;
   'lightBackgroundElement': string;
   'masterwork': string;

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -95,7 +95,6 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
           <RatingIcon uiWishListRoll={uiWishListRoll} />
         </div>
       )}
-      <div className={styles.primaryStat}>
         {/*
         // this is where the item's total energy capacity would go if we could just add things willy nilly to the badge bar
         item.energy && (<span className={clsx(energyTypeStyles[item.energy.energyType], styles.energyCapacity)}>
@@ -106,7 +105,6 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
             <ElementIcon element={item.element} className={styles.lightBackgroundElement} />
           )}
         <span>{badgeContent}</span>
-      </div>
     </div>
   );
 }

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -2,7 +2,7 @@ import { t } from 'app/i18next-t';
 import { isD1Item } from 'app/utils/item-utils';
 import { weakMemoize } from 'app/utils/util';
 import { UiWishListRoll } from 'app/wishlists/wishlists';
-import { DamageType } from 'bungie-api-ts/destiny2';
+import { DamageType, DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import ghostPerks from 'data/d2/ghost-perks.json';
@@ -13,6 +13,13 @@ import { getColor } from '../shell/filters';
 import styles from './BadgeInfo.m.scss';
 import { DimItem } from './item-types';
 import RatingIcon from './RatingIcon';
+
+const energyTypeStyles: Record<DestinyEnergyType, string> = {
+  [DestinyEnergyType.Arc]: styles.arc,
+  [DestinyEnergyType.Thermal]: styles.solar,
+  [DestinyEnergyType.Void]: styles.void,
+  [DestinyEnergyType.Any]: '',
+};
 
 interface Props {
   item: DimItem;
@@ -95,16 +102,18 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
           <RatingIcon uiWishListRoll={uiWishListRoll} />
         </div>
       )}
-        {/*
-        // this is where the item's total energy capacity would go if we could just add things willy nilly to the badge bar
-        item.energy && (<span className={clsx(energyTypeStyles[item.energy.energyType], styles.energyCapacity)}>
-        {item.energy.energyCapacity}</span>)
-        */}
-        {item.element &&
-          !(item.bucket.inWeapons && item.element.enumValue === DamageType.Kinetic) && (
-            <ElementIcon element={item.element} className={styles.lightBackgroundElement} />
-          )}
-        <span>{badgeContent}</span>
+      {item.energy ? (
+        <span className={clsx(energyTypeStyles[item.energy.energyType], styles.energyCapacity)}>
+          {item.energy.energyCapacity}
+          <ElementIcon element={item.element} className={styles.energyCapacityIcon} />
+        </span>
+      ) : (
+        item.element &&
+        !(item.bucket.inWeapons && item.element.enumValue === DamageType.Kinetic) && (
+          <ElementIcon element={item.element} className={styles.lightBackgroundElement} />
+        )
+      )}
+      <span>{badgeContent}</span>
     </div>
   );
 }

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -117,7 +117,7 @@
 .moveLocationIcons {
   display: flex;
   flex-direction: row;
-  justify-content: start;
+  justify-content: flex-start;
   margin: 4px 0 0 0;
 }
 


### PR DESCRIPTION
This continues work @nev-r started. I decided not to put the "pill" behind the number as I wanted to keep the element icon with the number.

This also cleans up the badge DOM a bit, simplifying it for the common case.

<img width="238" alt="Screen Shot 2020-11-14 at 1 49 47 PM" src="https://user-images.githubusercontent.com/313208/99157764-b4726f80-2680-11eb-8f7a-fabab3195c1c.png">
