### PR TITLE
Fix logic for canBePulledFromPostmaster

### DIFF
--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -6,6 +6,7 @@ import { t } from 'app/i18next-t';
 import { sortedStoresSelector } from 'app/inventory/selectors';
 import { amountOfItem, getCurrentStore, getStore, getVault } from 'app/inventory/stores-helpers';
 import { addItemToLoadout } from 'app/loadout/LoadoutDrawer';
+import { canBePulledFromPostmaster } from 'app/loadout/postmaster';
 import { setSetting } from 'app/settings/actions';
 import { addIcon, AppIcon, compareIcon, maximizeIcon, minimizeIcon } from 'app/shell/icons';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
@@ -238,13 +239,15 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
                 <StoreIcon store={vault} /> {t('MovePopup.Vault')}
               </ActionButton>
             )}
-          {item.location.type === 'LostItems' && item.canPullFromPostmaster ? (
-            <PullButtons
-              item={item}
-              itemOwner={itemOwner}
-              submitMoveTo={submitMoveTo}
-              vault={vault}
-            />
+          {item.location.type === 'LostItems' ? (
+            canBePulledFromPostmaster(item, itemOwner, stores) && (
+              <PullButtons
+                item={item}
+                itemOwner={itemOwner}
+                submitMoveTo={submitMoveTo}
+                vault={vault}
+              />
+            )
           ) : (
             <>
               <MoveLocations

--- a/src/app/item-popup/ItemActions.tsx
+++ b/src/app/item-popup/ItemActions.tsx
@@ -92,6 +92,7 @@ export default function ItemActions({
             itemOwnerStore={store}
             vertical={Boolean(mobileInspect)}
             moveItemTo={onMoveItemTo}
+            stores={stores}
           />
         ))}
 

--- a/src/app/loadout/postmaster.ts
+++ b/src/app/loadout/postmaster.ts
@@ -79,12 +79,19 @@ export function makeRoomForPostmaster(store: DimStore, buckets: InventoryBuckets
 
 // D2 only
 export function pullablePostmasterItems(store: DimStore, stores: DimStore[]) {
-  return (findItemsByBucket(store, BucketHashes.LostItems) || []).filter(
-    (i) =>
-      // Can be pulled
-      i.canPullFromPostmaster &&
-      // Either has space, or is going to a bucket we can make room in
-      (i.bucket.vaultBucket || spaceLeftForItem(store, i, stores) > 0)
+  return (findItemsByBucket(store, BucketHashes.LostItems) || []).filter((i) =>
+    canBePulledFromPostmaster(i, store, stores)
+  );
+}
+
+/**
+ * Can the given item be pulled from postmaster into a store?
+ */
+export function canBePulledFromPostmaster(i: DimItem, store: DimStore, stores: DimStore[]) {
+  return (
+    i.canPullFromPostmaster && // Can be pulled
+    // Either has space, or is going to a bucket we can make room in
+    ((i.bucket.vaultBucket && !i.notransfer) || spaceLeftForItem(store, i, stores) > 0)
   );
 }
 


### PR DESCRIPTION
I can verify this fixes #6137 - I don't have a "pull from postmaster" button for my upgrade modules, nor do I see buttons to do so in the sidecar actions or mobile actions. However, I don't have anything else in postmaster so this probably needs more testing.