### PR TITLE
Remove count of selected items in organizer

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -744,7 +744,7 @@
     "CharacterOrderReversed": "Most recent character (reversed)",
     "ColumnSize": "{{num}} items",
     "ColumnSizeAuto": "Auto",
-    "CsvImport": "Import tags/notes from CSV",
+    "CsvImport": "Import CSV",
     "CustomStatDesc": "Choose armor stats to make a custom total stat that will show on the item popup, Organizer, and Compare. Search with stat:custom:>=30.",
     "Data": "Spreadsheets",
     "DefaultItemSizeNote": "An item size of 50px will look the sharpest, without blurring the item picture or text.",

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -263,8 +263,9 @@ function ItemTable({
     [dispatch, columns, enabledColumns, itemType]
   );
 
+  const selectedItems = items.filter((i) => selectedItemIds.includes(i.id));
+
   const onLock = loadingTracker.trackPromise(async (lock: boolean) => {
-    const selectedItems = items.filter((i) => selectedItemIds.includes(i.id));
     dispatch(bulkLockItems(selectedItems, lock));
   });
 
@@ -272,8 +273,7 @@ function ItemTable({
     if (!note) {
       note = undefined;
     }
-    if (selectedItemIds.length) {
-      const selectedItems = items.filter((i) => selectedItemIds.includes(i.id));
+    if (selectedItems.length) {
       for (const item of selectedItems) {
         dispatch(setItemNote({ itemId: item.id, note }));
       }
@@ -312,8 +312,7 @@ function ItemTable({
   );
 
   const onMoveSelectedItems = (store: DimStore) => {
-    if (selectedItemIds.length) {
-      const selectedItems = items.filter((i) => selectedItemIds.includes(i.id));
+    if (selectedItems.length) {
       const loadout = newLoadout(
         t('Organizer.BulkMoveLoadoutName'),
         selectedItems.map((i) => convertToLoadoutItem(i, false))
@@ -380,7 +379,7 @@ function ItemTable({
    * Select all items, or if any are selected, clear the selection.
    */
   const selectAllItems: React.ChangeEventHandler<HTMLInputElement> = () => {
-    if (selectedItemIds.length === 0) {
+    if (selectedItems.length === 0) {
       setSelectedItemIds(rows.map((r) => r.item.id));
     } else {
       setSelectedItemIds([]);
@@ -467,7 +466,7 @@ function ItemTable({
       <div className={styles.toolbar}>
         <div>
           <ItemActions
-            itemsAreSelected={Boolean(selectedItemIds.length)}
+            itemsAreSelected={Boolean(selectedItems.length)}
             onLock={onLock}
             onNote={onNote}
             stores={stores}
@@ -501,15 +500,13 @@ function ItemTable({
             name="selectAll"
             title={t('Organizer.SelectAll')}
             type="checkbox"
-            checked={selectedItemIds.length === rows.length}
+            checked={selectedItems.length === rows.length}
             ref={(el) =>
               el &&
-              (el.indeterminate =
-                selectedItemIds.length !== rows.length && selectedItemIds.length > 0)
+              (el.indeterminate = selectedItems.length !== rows.length && selectedItems.length > 0)
             }
             onChange={selectAllItems}
           />
-          {selectedItemIds.length || null}
         </div>
       </div>
       {filteredColumns.map((column: ColumnDefinition) => (

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -741,7 +741,7 @@
     "CharacterOrderReversed": "Most recent character (reversed)",
     "ColumnSize": "{{num}} items",
     "ColumnSizeAuto": "Auto",
-    "CsvImport": "Import tags/notes from CSV",
+    "CsvImport": "Import CSV",
     "CustomStatDesc": "Choose armor stats to make a custom total stat that will show on the item popup, Organizer, and Compare. Search with stat:custom:>=30.",
     "Data": "Spreadsheets",
     "DefaultItemSizeNote": "An item size of 50px will look the sharpest, without blurring the item picture or text.",


### PR DESCRIPTION
And handle the selection a bit better by filtering to visible items.

This fixes https://github.com/DestinyItemManager/DIM/issues/6132. I played around with other places to put this number, but nothing fit and I really don't think this is interesting info to show. I understand that one person was using this to carefully move items in and out of their inventory, but I don't think that's a use case we intend to support from organizer.