### PR TITLE
Hide active mode in phone portrait

### DIFF
--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -59,8 +59,8 @@ function Inventory({ storesLoaded, account, activeMode, isPhonePortrait }: Props
 
   return (
     <ErrorBoundary name="Inventory">
-      {$featureFlags.altInventoryMode && <InventoryToggle mode={activeMode} />}
-      {activeMode ? <ActiveMode account={account} /> : <Stores />}
+      {$featureFlags.altInventoryMode && !isPhonePortrait && <InventoryToggle mode={activeMode} />}
+      {activeMode && !isPhonePortrait ? <ActiveMode account={account} /> : <Stores />}
       {$featureFlags.moveAmounts && <StackableDragHelp />}
       <DragPerformanceFix />
       {account.destinyVersion === 2 && <GearPower />}


### PR DESCRIPTION
It seems like active mode isn't yet set up to work well for phone-portrait, but it still shows the button (which covers up some info) and can be toggled into. This disables it entirely in phone-portrait mode.