### PR TITLE
Load Xur's location

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -38,12 +38,14 @@ module.exports = function csp(env) {
       //'https://reviews-api.destinytracker.net',
       //'https://api.tracker.gg',
       // VendorEngrams
-      'https://api.vendorengrams.xyz',
+      //'https://api.vendorengrams.xyz',
       // Wishlists
       'https://raw.githubusercontent.com',
       'https://gist.githubusercontent.com',
       // DIM Sync
       'https://api.destinyitemmanager.com',
+      // Xur location
+      'paracausal.science',
     ],
     imgSrc: [
       SELF,

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
+    "@d2api/d2api-types": "^1.0.2",
     "@destinyitemmanager/dim-api-types": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.12.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.27",

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -236,6 +236,7 @@ export const VENDORS = {
   /** rahool. we override how his vendor FakeItems are displayed */
   RAHOOL: 2255782930,
   VAULT: 1037843411,
+  XUR: 2190858386,
 };
 
 /** used to snag the icon for display */

--- a/src/app/vendors/Vendor.m.scss
+++ b/src/app/vendors/Vendor.m.scss
@@ -4,7 +4,7 @@
   width: 30px;
   height: 30px;
   vertical-align: middle;
-  margin: 5px 22px 5px 0;
+  margin: 5px 8px 5px 0;
 }
 
 .location {

--- a/src/app/vendors/Vendor.tsx
+++ b/src/app/vendors/Vendor.tsx
@@ -1,9 +1,13 @@
+import { XurLocation } from '@d2api/d2api-types';
 import { t } from 'app/i18next-t';
+import { VENDORS } from 'app/search/d2-known-values';
+import { RootState } from 'app/store/types';
 import { VendorDrop } from 'app/vendorEngramsXyzApi/vendorDrops';
 import { isDroppingHigh } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import vendorEngramSvg from '../../images/engram.svg';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import BungieImage from '../dim-ui/BungieImage';
@@ -35,11 +39,17 @@ export default function Vendor({
   vendorDrops?: VendorDrop[];
   characterId: string;
 }) {
-  const placeString = _.uniq(
-    [vendor.destination?.displayProperties.name, vendor.place?.displayProperties.name].filter(
-      (n) => n?.length
-    )
-  ).join(', ');
+  const xurLocation = useSelector((state: RootState) =>
+    vendor.def.hash === VENDORS.XUR ? state.vendors.xurLocation : undefined
+  );
+
+  const placeString = xurLocation
+    ? extractXurLocationString(defs, xurLocation)
+    : _.uniq(
+        [vendor.destination?.displayProperties.name, vendor.place?.displayProperties.name].filter(
+          (n) => n?.length
+        )
+      ).join(', ');
 
   const vendorEngramDrops =
     $featureFlags.vendorEngrams && vendorDrops
@@ -100,4 +110,18 @@ export default function Vendor({
       </CollapsibleTitle>
     </div>
   );
+}
+
+function extractXurLocationString(defs: D2ManifestDefinitions, xurLocation: XurLocation) {
+  const placeDef = defs.Place.get(xurLocation.placeHash);
+  if (!placeDef) {
+    return null;
+  }
+  const destinationDef = defs.Destination.get(xurLocation.destinationHash);
+  if (!destinationDef) {
+    return null;
+  }
+  const bubbleDef = destinationDef.bubbles[xurLocation.bubbleIndex];
+
+  return `${bubbleDef.displayProperties.name}, ${destinationDef.displayProperties.name}, ${placeDef.displayProperties.name}`;
 }

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -1,5 +1,6 @@
 import { XurLocation } from '@d2api/d2api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
+import { VENDORS } from 'app/search/d2-known-values';
 import { ThunkResult } from 'app/store/types';
 import { errorLog } from 'app/utils/log';
 import { getAllVendorDrops } from 'app/vendorEngramsXyzApi/vendorEngramsXyzService';
@@ -38,11 +39,19 @@ export function loadAllVendors(
       dispatch(getAllVendorDrops());
     }
 
-    dispatch(loadXurLocation());
-
     try {
       const vendorsResponse = await getVendorsApi(account, characterId);
       dispatch(loadedAll({ vendorsResponse, characterId }));
+
+      // If xur is a vendor, load their location
+      if (
+        vendorsResponse.vendors.data &&
+        Object.values(vendorsResponse.vendors.data).some((v) => v.vendorHash === VENDORS.XUR)
+      ) {
+        dispatch(loadXurLocation());
+      } else if (getState().vendors.xurLocation) {
+        dispatch(loadedXur(undefined)); // clear out xur
+      }
     } catch (error) {
       dispatch(loadedError({ characterId, error }));
     }

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -1,4 +1,4 @@
-import { XurLocation } from '@d2api/d2api-types';
+import { XurLocation, XurLocationResponse } from '@d2api/d2api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { VENDORS } from 'app/search/d2-known-values';
 import { ThunkResult } from 'app/store/types';
@@ -69,7 +69,7 @@ function loadXurLocation(): ThunkResult {
   };
 }
 
-async function xurLocationFetch(): Promise<XurLocation> {
+async function xurLocationFetch(): Promise<XurLocationResponse> {
   const request = new Request('https://paracausal.science/xur/current.json', {
     method: 'GET',
     headers: {

--- a/src/app/vendors/reducer.ts
+++ b/src/app/vendors/reducer.ts
@@ -1,3 +1,4 @@
+import { XurLocation } from '@d2api/d2api-types';
 import { DestinyVendorsResponse } from 'bungie-api-ts/destiny2';
 import { Reducer } from 'redux';
 import { ActionType, getType } from 'typesafe-actions';
@@ -15,6 +16,8 @@ export interface VendorsState {
       error?: Error;
     };
   };
+
+  xurLocation?: XurLocation;
 }
 
 export type VendorsAction = ActionType<typeof actions>;
@@ -54,6 +57,13 @@ export const vendors: Reducer<VendorsState, VendorsAction | AccountsAction> = (
             error,
           },
         },
+      };
+    }
+
+    case getType(actions.loadedXur): {
+      return {
+        ...state,
+        xurLocation: action.payload,
       };
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,6 +985,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@d2api/d2api-types@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@d2api/d2api-types/-/d2api-types-1.0.2.tgz#ea90395bfdcd8cb233361573ba1f554b8d398e5d"
+  integrity sha512-DR/vjANiI4UYf6Cy8hz+Xb0s5hE6c2I6OXsjx5DRBSJSETDevGxQk2LZjSt5b/yJcfvoaBoJowN3oEP4tlmXnw==
+
 "@destinyitemmanager/dim-api-types@^1.0.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@destinyitemmanager/dim-api-types/-/dim-api-types-1.7.1.tgz#5d5cecaa042b48f3d59e81a8812229b467cf3d66"


### PR DESCRIPTION
This uses @nev-r's cool Xur API to load Xur's location and display it on the vendor page:

<img width="378" alt="Screen Shot 2020-11-14 at 10 19 18 PM" src="https://user-images.githubusercontent.com/313208/99178483-5ff2e280-26c8-11eb-9357-d8001bd98a06.png">
