### PR TITLE
Suppress sockets entirely when missing

### DIFF
--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -41,8 +41,6 @@ export function buildSockets(
   itemDef: DestinyInventoryItemDefinition
 ) {
   let sockets: DimSockets | null = null;
-  let missingSockets = false;
-
   const socketData =
     (item.itemInstanceId && itemComponents?.sockets?.data?.[item.itemInstanceId]?.sockets) ||
     undefined;
@@ -69,12 +67,12 @@ export function buildSockets(
   if (!sockets && itemDef.sockets) {
     // If this really *should* have live sockets, but didn't...
     if (item.itemInstanceId && socketData && !socketData[item.itemInstanceId]) {
-      missingSockets = true;
+      return { sockets: null, missingSockets: true };
     }
     sockets = buildDefinedSockets(defs, itemDef);
   }
 
-  return { sockets, missingSockets };
+  return { sockets, missingSockets: false };
 }
 
 /**

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -41,9 +41,9 @@
   box-sizing: border-box;
 
   &.warning {
-    background-color: $red !important;
+    background: scale-color($red, $lightness: -90%);
+    border-top: 4px solid $red;
     padding: 8px;
-    border: 2px solid rgba(255, 255, 255, 0.5);
     a {
       color: white;
       font-size: 12px;

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -21,6 +21,7 @@ type Props = ProvidedProps;
 
 export default function ItemSockets(props: Props) {
   const item = props.item;
+
   if (item.destinyVersion === 2 && item.bucket.inWeapons) {
     return <ItemSocketsWeapons {...props} />;
   }


### PR DESCRIPTION
This may help with the inevitable confusion whenever maintenance takes sockets offline, as well as potentially helping with the wishlist misfires we saw when we tried to load without sockets initially.