### PR TITLE
Update manual move timestamps earlier

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Loadout drawer, Compare, Farming, and Infusion now work on every page that shows an item from your inventory.
 * Deleting a loadout from the loadout drawer now closes the loadout drawer.
 * When Bungie.net is not returning live perk information, we won't show the default perks anymore.
+* Farming mode will no longer immediately kick out items you manually move onto your character.
 
 ### Beta Only
 

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -164,6 +164,10 @@ export function moveItemTo(
         );
       }
 
+      // We mark this *first*, because otherwise things observing state (like farming) may not see this
+      // in time.
+      updateManualMoveTimestamp(item);
+
       const movePromise = queueAction(() =>
         loadingTracker.addPromise(dispatch(moveTo(item, store, equip, moveAmount)))
       );
@@ -176,8 +180,6 @@ export function moveItemTo(
         // Refresh light levels and such
         dispatch(updateCharacters());
       }
-
-      updateManualMoveTimestamp(item);
     } catch (e) {
       errorLog('move', 'error moving item', item.name, 'to', store.name, e);
       // Some errors aren't worth reporting

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -269,6 +269,10 @@ function applyLoadoutItems(
 
     try {
       if (item) {
+        // We mark this *first*, because otherwise things observing state (like farming) may not see this
+        // in time.
+        updateManualMoveTimestamp(item);
+
         if (item.maxStackSize > 1) {
           // handle consumables!
           const amountAlreadyHave = amountOfItem(store, pseudoItem);
@@ -312,11 +316,8 @@ function applyLoadoutItems(
           // Pass in the list of items that shouldn't be moved away
           await dispatch(moveItemTo(item, store, pseudoItem.equipped, item.amount, loadoutItemIds));
         }
-      }
 
-      if (item) {
         scope.successfulItems.push(item);
-        updateManualMoveTimestamp(item);
       }
     } catch (e) {
       const level = e.level || 'error';


### PR DESCRIPTION
This fixes #6109, where farming mode would kick out anything you moved back in manually.