### PR TITLE
Allow items in postmaster to be dragged to any bucket

### DIFF
--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -32,7 +32,11 @@ function dragType(props: ExternalProps): string {
   if ($featureFlags.mobileInspect && props.isPhonePortrait) {
     return mobileDragType;
   }
-  return item.notransfer ? `${item.owner}-${item.bucket.type}` : item.bucket.type!;
+  return item.location.inPostmaster
+    ? 'postmaster'
+    : item.notransfer
+    ? `${item.owner}-${item.bucket.type}`
+    : item.bucket.type!;
 }
 
 export interface DragObject {

--- a/src/app/inventory/StoreBucketDropTarget.tsx
+++ b/src/app/inventory/StoreBucketDropTarget.tsx
@@ -35,7 +35,9 @@ type Props = InternalProps & ExternalProps;
 
 // This determines what types can be dropped on this target
 function dragType(props: ExternalProps) {
-  return [props.bucket.type!, `${props.storeId}-${props.bucket.type!}`];
+  return props.bucket.inPostmaster
+    ? []
+    : [props.bucket.type!, `${props.storeId}-${props.bucket.type!}`, 'postmaster'];
 }
 
 // This determines the behavior of dropping on this target


### PR DESCRIPTION
This allows items that are in the postmaster to be dragged to any character. Before, things like armor just weren't happening, since you'd have to scroll down to the right bucket.