### PR TITLE
fix crash on subclass item popup

### DIFF
--- a/src/app/item-popup/EnergyMeter.tsx
+++ b/src/app/item-popup/EnergyMeter.tsx
@@ -24,6 +24,12 @@ export const energyStyles = {
   [DestinyEnergyType.Void]: styles.void,
 };
 
+const swappableEnergyTypes = [
+  DestinyEnergyType.Arc,
+  DestinyEnergyType.Thermal,
+  DestinyEnergyType.Void,
+];
+
 export default function EnergyMeter({
   defs,
   item,
@@ -117,11 +123,7 @@ export default function EnergyMeter({
 
   const energyTypes = Object.values(defs.EnergyType.getAll());
 
-  const energyOptions: Option<DestinyEnergyType>[] = [
-    DestinyEnergyType.Arc,
-    DestinyEnergyType.Thermal,
-    DestinyEnergyType.Void,
-  ].map((e) => {
+  const energyOptions: Option<DestinyEnergyType>[] = swappableEnergyTypes.map((e) => {
     const energyDef = energyTypes.find((ed) => ed.enumValue === e)!;
     return {
       key: e.toString(),
@@ -146,15 +148,17 @@ export default function EnergyMeter({
           </div>
         </div>
         <div className={clsx(styles.inner, energyStyles[previewEnergyType])}>
-          <Select<DestinyEnergyType>
-            options={energyOptions}
-            value={previewEnergyType}
-            onChange={onEnergyTypeChange}
-            hideSelected={true}
-            className={styles.elementSelect}
-          >
-            <ElementIcon className={styles.icon} element={energyTypeDef} />
-          </Select>
+          {swappableEnergyTypes.includes(item.energy.energyType) && (
+            <Select<DestinyEnergyType>
+              options={energyOptions}
+              value={previewEnergyType}
+              onChange={onEnergyTypeChange}
+              hideSelected={true}
+              className={styles.elementSelect}
+            >
+              <ElementIcon className={styles.icon} element={energyTypeDef} />
+            </Select>
+          )}
           {meterIncrements.map((incrementStyle, i) => (
             <div
               key={i}
@@ -213,7 +217,7 @@ function EnergyUpgradePreview({
   previewCapacity: number;
   previewEnergyType: DestinyEnergyType;
 }) {
-  if (!item.energy) {
+  if (!item.energy || !swappableEnergyTypes.includes(item.energy.energyType)) {
     return null;
   }
 


### PR DESCRIPTION
ok, 1 problem:
- stasis subclasses have energy capacity, but they are a capacity type (Subclass) that the hardcoded Select element did not take into account. Select throws when the current value is something other than what it's been told to offer

this is fixed in this PR, by not rendering the energy selector when we're not on an arc/void/solar item

3 other problems not fixed here:
- ghost energy is not returned by the API right now. i think this head that problem off but we'll see
- subclass shouldn't offer to upgrade energy at all. it's not upgradeable except by slotting special sockets
- DestinyEnergyType enum wasn't updated with Beyond Light's new energy types see https://github.com/Bungie-net/api/issues/1328