### PR TITLE
Fix mod type tags

### DIFF
--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -14,7 +14,7 @@ import { escapeRegExp } from 'app/search/search-filters/freeform';
 import { SearchFilterRef } from 'app/search/SearchBar';
 import { RootState } from 'app/store/types';
 import { chainComparator, compareBy } from 'app/utils/comparators';
-import { getSpecialtySocketMetadataByPlugCategoryHash, isArmor2Mod } from 'app/utils/item-utils';
+import { getModTypeTagByPlugCategoryHash, isArmor2Mod } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import copy from 'fast-copy';
 import _ from 'lodash';
@@ -127,12 +127,10 @@ function mapStateToProps() {
             isArmor2Mod(def) &&
             def.plug.insertionMaterialRequirementHash !== 0
           ) {
-            const metadata = getSpecialtySocketMetadataByPlugCategoryHash(
-              def.plug.plugCategoryHash
-            );
+            const modTypeTag = getModTypeTagByPlugCategoryHash(def.plug.plugCategoryHash);
             const category =
               (isModPickerCategory(def.plug.plugCategoryHash) && def.plug.plugCategoryHash) ||
-              (metadata && ModPickerCategories.seasonal) ||
+              (modTypeTag && ModPickerCategories.seasonal) ||
               undefined;
 
             if (category) {

--- a/src/app/loadout-builder/generated-sets/Sockets.tsx
+++ b/src/app/loadout-builder/generated-sets/Sockets.tsx
@@ -1,7 +1,7 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import { getSpecialtySocketMetadataByPlugCategoryHash } from 'app/utils/item-utils';
+import { getModTypeTagByPlugCategoryHash } from 'app/utils/item-utils';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
@@ -71,10 +71,10 @@ function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
       isPluggableItem(toSave) &&
       !undesireablePlugs.includes(toSave.plug.plugCategoryHash)
     ) {
-      const metadata = getSpecialtySocketMetadataByPlugCategoryHash(toSave.plug.plugCategoryHash);
+      const modTypeTag = getModTypeTagByPlugCategoryHash(toSave.plug.plugCategoryHash);
       const category =
         (isModPickerCategory(toSave.plug.plugCategoryHash) && toSave.plug.plugCategoryHash) ||
-        (metadata && ModPickerCategories.seasonal) ||
+        (modTypeTag && ModPickerCategories.seasonal) ||
         undefined;
 
       modsAndPerks.push({ plugDef: toSave, category, season: undefined });

--- a/src/app/loadout-builder/processWorker/mappers.ts
+++ b/src/app/loadout-builder/processWorker/mappers.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { DimItem, DimSocket, DimSockets } from '../../inventory/item-types';
 import {
-  getSpecialtySocketMetadataByPlugCategoryHash,
+  getModTypeTagByPlugCategoryHash,
   getSpecialtySocketMetadatas,
 } from '../../utils/item-utils';
 import {
@@ -38,11 +38,11 @@ export function mapArmor2ModToProcessMod(mod: LockedArmor2Mod): ProcessMod {
   };
 
   if (mod.category === 'seasonal') {
-    const metadata = getSpecialtySocketMetadataByPlugCategoryHash(mod.modDef.plug.plugCategoryHash);
+    const modTypeTag = getModTypeTagByPlugCategoryHash(mod.modDef.plug.plugCategoryHash);
     return {
       ...processMod,
       season: undefined,
-      tag: metadata?.slotTag,
+      tag: modTypeTag,
     };
   }
 

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -17,7 +17,10 @@ import {
   TOTAL_STAT_HASH,
 } from 'app/search/d2-known-values';
 import { damageNamesByEnum } from 'app/search/search-filter-values';
-import modSocketMetadata, { ModSocketMetadata } from 'app/search/specialty-modslots';
+import modSocketMetadata, {
+  ModSocketMetadata,
+  modTypeTagByPlugCategoryHash,
+} from 'app/search/specialty-modslots';
 import { DestinyClass, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import powerCapToSeason from 'data/d2/lightcap-to-season.json';
 import _ from 'lodash';
@@ -38,10 +41,6 @@ export const getItemDamageShortName = (item: DimItem): string | undefined =>
 // process its data here and export it to thing that needs it
 
 const modMetadataBySocketTypeHash = objectifyArray(modSocketMetadata, 'socketTypeHashes');
-const modMetadataByPlugCategoryHash = objectifyArray(
-  modSocketMetadata,
-  'compatiblePlugCategoryHashes'
-);
 
 export const modMetadataByTag = objectifyArray(modSocketMetadata, 'tag');
 
@@ -78,13 +77,10 @@ export const getSpecialtySocketMetadatas = (item: DimItem): ModSocketMetadata[] 
     .filter(Boolean);
 
 /**
- * returns ModMetadata if the plugCategoryHash (from a mod definition's .plug) is known
- *
- * if you use this you can only trust the returned season, tag, and emptyModSocketHash
+ * returns mod type tag if the plugCategoryHash (from a mod definition's .plug) is known
  */
-export const getSpecialtySocketMetadataByPlugCategoryHash = (
-  plugCategoryHash: number
-): ModSocketMetadata | undefined => modMetadataByPlugCategoryHash[plugCategoryHash];
+export const getModTypeTagByPlugCategoryHash = (plugCategoryHash: number): string | undefined =>
+  modTypeTagByPlugCategoryHash[plugCategoryHash];
 
 /**
  * this always returns a string for easy printing purposes


### PR DESCRIPTION
Fixes #6195 

getSpecialtySocketMetadataByPlugCategoryHash was always returning slotTag `reveriedawn` due to an issue in https://github.com/DestinyItemManager/DIM/pull/6141. When building the map of `compatiblePlugCategoryHashes`, duplicate keys were being overwritten, thus `reveriedawn` was overwriting all `legacy`. Furthermore, I found that armor `compatibleModSeasons` contained values like `chargedwithlight` instead of `legacy` or `combatstyle`.

This change uses modTypeTag instead of slotTag, which properly matches against armor's `compatibleModSeasons`.