### PR TITLE
Skip conditionally active stats

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Postmaster items can be dragged over any items on your character to transfer them - they don't need to be dragged to the matching item type.
+* Stop showing extra +3 stats on masterwork weapons. The fix for this means that Adept weapons may not show that bonus when they are released.
 
 ## 6.39.1 <span className="changelog-date">(2020-11-16)</span>
 

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -68,6 +68,9 @@ function buildMasterworkInfo(
   const stats: DimMasterwork['stats'] = [];
 
   for (const stat of investmentStats) {
+    if (stat.isConditionallyActive) {
+      continue;
+    }
     if (!createdItem.element && createdItem.bucket?.sort === 'Armor') {
       createdItem.element =
         Object.values(defs.DamageType).find(

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -317,7 +317,13 @@ function enhanceStatsWithPlugs(
       for (const perkStat of socket.plugged.plugDef.investmentStats) {
         const statHash = perkStat.statTypeHash;
         const itemStat = statsByHash[statHash];
-        const value = perkStat.value || 0;
+        // TODO: we should check the final computed stat against the result including and not including
+        // conditinally active stats, and only include them if it lines up. There's not a way to figure
+        // out if the conditions are met otherwise.
+        if (perkStat.isConditionallyActive) {
+          continue;
+        }
+        const value = perkStat.value;
         if (itemStat) {
           itemStat.investmentValue += value;
         } else if (shouldShowStat(itemDef, statHash, statDisplays)) {
@@ -375,7 +381,13 @@ function buildPlugStats(
   } = {};
 
   for (const perkStat of plug.plugDef.investmentStats) {
-    let value = perkStat.value || 0;
+    // TODO: we should check the final computed stat against the result including and not including
+    // conditinally active stats, and only include them if it lines up. There's not a way to figure
+    // out if the conditions are met otherwise.
+    if (perkStat.isConditionallyActive) {
+      continue;
+    }
+    let value = perkStat.value;
     const itemStat = statsByHash[perkStat.statTypeHash];
     const statDisplay = statDisplays[perkStat.statTypeHash];
     if (itemStat && statDisplay) {

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -69,14 +69,20 @@ export default function SocketDetailsSelectedPlug({
 
       const currentModValue = currentPlug?.stats?.[stat.statTypeHash] || 0;
 
-      const updatedInvestmentValue = itemStat.investmentValue + stat.value - currentModValue;
-      let itemStatValue = updatedInvestmentValue;
+      // TODO: we should check the final computed stat against the result including and not including
+      // conditinally active stats, and only include them if it lines up. There's not a way to figure
+      // out if the conditions are met otherwise.
+      if (stat.isConditionallyActive) {
+        return null;
+      }
       let modValue = stat.value;
+      const updatedInvestmentValue = itemStat.investmentValue + modValue - currentModValue;
+      let itemStatValue = updatedInvestmentValue;
 
       if (statDisplay) {
         itemStatValue = interpolateStatValue(updatedInvestmentValue, statDisplay);
         modValue =
-          itemStatValue - interpolateStatValue(updatedInvestmentValue - stat.value, statDisplay);
+          itemStatValue - interpolateStatValue(updatedInvestmentValue - modValue, statDisplay);
       }
 
       return {


### PR DESCRIPTION
Stop showing extra +3 stats on masterwork weapons. The fix for this means that Adept weapons may not show that bonus when they are released, since we're just skipping these stats entirely.

A better fix would involve comparing the "live" stats with the calculated stats and using that to figure out if any of the conditional stats were available.