### PR TITLE
Exclude expired pursuits from Bounty Guide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Bounties and Quests sections on the Progress page now show a summary of bounties by their requirement - weapon, location, activity, and element. Click on a weapon type to pull a weapon matching that type.
+
 ## 6.40.0 <span className="changelog-date">(2020-11-22)</span>
 
 * Mod and mod slot info in Loadout Optimizer have been updated to handle the new mod slots better.

--- a/src/app/progress/BountyGuide.tsx
+++ b/src/app/progress/BountyGuide.tsx
@@ -76,7 +76,10 @@ export default function BountyGuide({
     KillType: {},
   };
   for (const i of bounties) {
-    if (!i.complete) {
+    const expired = i.pursuit?.expirationDate
+      ? i.pursuit.expirationDate.getTime() < Date.now()
+      : false;
+    if (!i.complete && !expired) {
       const info = pursuitsInfo[i.hash];
       if (info) {
         for (const key in info) {


### PR DESCRIPTION
I excluded complete but should have also excluded expired.