### PR TITLE
upgrade node base docker image to fermium (v14)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   webpack:
     container_name: dim-webpack
-    image: node:dubnium
+    image: node:fermium
     ports:
       - '8080:8080'
     working_dir: /usr/src/app


### PR DESCRIPTION
bungie-api-ts requires Node v13.2 or above.
Current docker-compose uses Node 10 as base
This change upgrades to node v14 and fixes #6226 