### PR TITLE
remove layoutEffect to align DesktopItemActions with top of ItemDialog

### DIFF
--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -14,8 +14,7 @@ import { RootState } from 'app/store/types';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
-import _ from 'lodash';
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import arrowsIn from '../../images/arrows-in.png';
 import arrowsOut from '../../images/arrows-out.png';
@@ -95,31 +94,6 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
   });
 
   const containerRef = useRef<HTMLDivElement>(null);
-  useLayoutEffect(() => {
-    const reposition = () => {
-      if (containerRef.current) {
-        let parent = containerRef.current.parentElement;
-        while (parent && !parent.classList.contains('item-popup')) {
-          parent = parent.parentElement;
-        }
-        const arrow = parent?.querySelector('.arrow') as HTMLDivElement;
-        if (!arrow || !parent) {
-          return;
-        }
-        const arrowRect = arrow.getBoundingClientRect();
-        const parentRect = parent.getBoundingClientRect();
-        const containerHeight = containerRef.current.clientHeight;
-        const offset = arrowRect.top - parentRect.top + 2.5;
-
-        const top = _.clamp(offset - containerHeight / 2, 0, parent.clientHeight - containerHeight);
-
-        containerRef.current.style.transform = `translateY(${Math.round(top)}px)`;
-      }
-    };
-
-    reposition();
-    setTimeout(reposition, 10);
-  });
 
   const onAmountChanged = setAmount;
 


### PR DESCRIPTION
https://github.com/DestinyItemManager/DIM/issues/6229#issue-751760945

Jumping UI elements can make interactions wonky, so my suggestion is to align the (awesome) DesktopItemActions flyout with the top of the item dialog itself.
This way the element doesnt "jump" around so much and its easier to interact with it.

i know you @bhollis didn't add this layoutEffect for no good reason, so please let me know if this is just my taste.

![dim-update](https://user-images.githubusercontent.com/8297816/100381565-83e3eb80-3019-11eb-92fd-31e739671bc4.gif)
