### PR TITLE
Hide badge for engrams

### DIFF
--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -31,6 +31,9 @@ export function hasBadge(item?: DimItem | null): boolean {
   if (!item) {
     return false;
   }
+  if (item.isEngram) {
+    return false;
+  }
   return (
     Boolean(item.primStat?.value) ||
     item.classified ||
@@ -49,7 +52,8 @@ export default function BadgeInfo({ item, isCapped, uiWishListRoll }: Props) {
   const isGeneric = !isBounty && !isStackable;
 
   const hideBadge = Boolean(
-    (isBounty && (item.complete || item.hidePercentage)) ||
+    item.isEngram ||
+      (isBounty && (item.complete || item.hidePercentage)) ||
       (isStackable && item.amount === 1) ||
       (isGeneric && !item.primStat?.value && !item.classified)
   );


### PR DESCRIPTION
<img width="449" alt="Screen Shot 2020-11-26 at 1 29 50 PM" src="https://user-images.githubusercontent.com/313208/100392495-947d6d00-2feb-11eb-99a3-0bf6f453ebc4.png">

This hides the polaroid badge for engrams - their power can still be seen in the item popup.