### PR TITLE
Fix 5715 filterhelper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Mod costs display correctly on Firefox.
 * Fixed the `is:powerfulreward` search to recognize new powerful/pinnacle engrams.
 * When items are classified (like the new Raid gear was for a bit), any notes added to the item will show on the tile so you can keep track of them.
+* Fixed filter helper only opening the first time it is selected in the search bar
 
 ### Beta Only
 

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -248,7 +248,7 @@ function SearchBar(
     setInputValue,
     reset,
     openMenu,
-  } = useCombobox<SearchItem | null>({
+  } = useCombobox<SearchItem>({
     items,
     stateReducer,
     initialIsOpen: isPhonePortrait && mainSearchBar,

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -248,26 +248,40 @@ function SearchBar(
     setInputValue,
     reset,
     openMenu,
-    closeMenu,
-  } = useCombobox<SearchItem>({
+  } = useCombobox<SearchItem | null>({
     items,
+    stateReducer,
     initialIsOpen: isPhonePortrait && mainSearchBar,
     defaultHighlightedIndex: liveQuery ? 0 : -1,
     itemToString: (i) => i?.query || '',
-    onSelectedItemChange: ({ selectedItem }) => {
-      if (selectedItem) {
-        // Handle selecting the special "help" item
-        if (selectedItem.type === SearchItemType.Help) {
-          setFilterHelpOpen(true);
-          closeMenu();
-        }
-      }
-    },
     onInputValueChange: ({ inputValue }) => {
       setLiveQuery(inputValue || '');
       debouncedUpdateQuery(inputValue || '');
     },
   });
+
+  // special click handling for filter helper
+  function stateReducer(state, actionAndChanges) {
+    const { type, changes } = actionAndChanges;
+    switch (type) {
+      case useCombobox.stateChangeTypes.ItemClick:
+        //exit early if non FilterHelper item was selected
+        if (!changes.selectedItem || changes.selectedItem.type !== SearchItemType.Help) {
+          return changes;
+        }
+
+        // helper click, open FilterHelper and modify state
+        setFilterHelpOpen(true);
+        return {
+          ...changes,
+          selectedItem: state.selectedItem, // keep the last selected item (i.e. the edit field stays unchanged)
+          closeMenu: true, // close the menu
+        };
+
+      default:
+        return changes; // no handling for other types
+    }
+  }
 
   const onFocus = () => {
     if (!liveQuery && !isOpen && !autoFocus) {


### PR DESCRIPTION
fixes #5715 

replaced the event handler based approach with a state reducer to reliably detect clicks on the FilterHelper whilst also keeping the currently edited search string in the input.

@bhollis please have a look. I have only limited experience with React and TS and none with Downshift. Puzzled this together mostly with google and the downshift reference docs. Remarks on codestyle etc. (if any) are appreciated. 