### PR TITLE
Build speedup

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -9,69 +9,83 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
-    - name: Install SSH key
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ secrets.SSH_KEY }}
-        name: dim.rsa # optional
-        known_hosts: ${{ secrets.REMOTE_HOST }}
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: dim.rsa # optional
+          known_hosts: ${{ secrets.REMOTE_HOST }}
 
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2 # So packtracker can get the previous commit
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # So packtracker can get the previous commit
 
-    - name: Cache node_modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node_modules
-      with:
-        path: $GITHUB_WORKSPACE/node_modules
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Cache eslint
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-eslint
-      with:
-        path: ~/.cache
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+      - name: Cache eslint
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-eslint
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Install
-      uses: bahmutov/npm-install@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-    - name: Test
-      run: yarn test
+      - name: Cache yarn
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-yarn
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Lint check
-      run: |
-        find . -type d -name "node_modules" -prune -o -type f -iregex '.*.ts\|.*.js\|.*.tsx\|.*.jsx' -exec ./build/set-mtime-to-md5.sh {} \;
-        yarn run lint-check
+      - name: Install
+        run: yarn install --frozen-lockfile --prefer-offline
 
-    - name: Build and deploy
-      run: ./build/ga_build.sh
-      env:
-        PT_PROJECT_TOKEN: ${{ secrets.PT_PROJECT_TOKEN }}
-        WEB_API_KEY: ${{ secrets.WEB_API_KEY }}
-        WEB_OAUTH_CLIENT_ID: ${{ secrets.WEB_OAUTH_CLIENT_ID }}
-        WEB_OAUTH_CLIENT_SECRET: ${{ secrets.WEB_OAUTH_CLIENT_SECRET }}
-        DIM_API_KEY: ${{ secrets.DIM_API_KEY }}
-        CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}
-        CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
-        REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
-        REMOTE_PATH: beta.destinyitemmanager.com
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      - name: Test
+        run: yarn test
+
+      - name: Lint check
+        run: |
+          find . -type d -name "node_modules" -prune -o -type f -iregex '.*.ts\|.*.js\|.*.tsx\|.*.jsx' -exec ./build/set-mtime-to-md5.sh {} \;
+          yarn run lint-check
+
+      - name: Build and deploy
+        run: ./build/ga_build.sh
+        env:
+          PT_PROJECT_TOKEN: ${{ secrets.PT_PROJECT_TOKEN }}
+          WEB_API_KEY: ${{ secrets.WEB_API_KEY }}
+          WEB_OAUTH_CLIENT_ID: ${{ secrets.WEB_OAUTH_CLIENT_ID }}
+          WEB_OAUTH_CLIENT_SECRET: ${{ secrets.WEB_OAUTH_CLIENT_SECRET }}
+          DIM_API_KEY: ${{ secrets.DIM_API_KEY }}
+          CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_PATH: beta.destinyitemmanager.com
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -35,7 +35,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
             ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -51,7 +50,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
             ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
 
       - name: Install
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -18,7 +18,7 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_KEY }}
-          name: dim.rsa # optional
+          name: dim.rsa
           known_hosts: ${{ secrets.REMOTE_HOST }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -37,18 +37,6 @@ jobs:
             ${{ runner.os }}-${{ env.cache-name }}-
             ${{ runner.os }}-
 
-      - name: Cache eslint
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-eslint
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -67,14 +55,6 @@ jobs:
 
       - name: Install
         run: yarn install --frozen-lockfile --prefer-offline
-
-      - name: Test
-        run: yarn test
-
-      - name: Lint check
-        run: |
-          find . -type d -name "node_modules" -prune -o -type f -iregex '.*.ts\|.*.js\|.*.tsx\|.*.jsx' -exec ./build/set-mtime-to-md5.sh {} \;
-          yarn run lint-check
 
       - name: Build and deploy
         run: ./build/ga_build.sh

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,7 +44,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
             ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -60,7 +59,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
             ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
 
       - name: Install
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,7 +25,7 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_KEY }}
-          name: dim.rsa # optional
+          name: dim.rsa
           known_hosts: ${{ secrets.REMOTE_HOST }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,66 +16,80 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
-    - name: Install SSH key
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ secrets.SSH_KEY }}
-        name: dim.rsa # optional
-        known_hosts: ${{ secrets.REMOTE_HOST }}
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          name: dim.rsa # optional
+          known_hosts: ${{ secrets.REMOTE_HOST }}
 
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2 # So packtracker can get the previous commit
-        # Use the dim-release-bot token rather than the default
-        token: ${{ secrets.GH_TOKEN }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # So packtracker can get the previous commit
+          # Use the dim-release-bot token rather than the default
+          token: ${{ secrets.GH_TOKEN }}
 
-    - name: Cache node_modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node_modules
-      with:
-        path: $GITHUB_WORKSPACE/node_modules
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Cache eslint
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-eslint
-      with:
-        path: ~/.cache
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+      - name: Cache eslint
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-eslint
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Install
-      uses: bahmutov/npm-install@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-    - name: Build and deploy
-      run: ./build/deploy-prod.sh
-      env:
-        PT_PROJECT_TOKEN: ${{ secrets.PT_PROJECT_TOKEN }}
-        WEB_API_KEY: ${{ secrets.PROD_API_KEY }}
-        WEB_OAUTH_CLIENT_ID: ${{ secrets.PROD_OAUTH_CLIENT_ID }}
-        WEB_OAUTH_CLIENT_SECRET: ${{ secrets.PROD_OAUTH_CLIENT_SECRET }}
-        DIM_API_KEY: ${{ secrets.PROD_DIM_API_KEY }}
-        CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}
-        CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
-        REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
-        REMOTE_PATH: app.destinyitemmanager.com
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # Use the dim-release-bot token rather than the default
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        PATCH: ${{ github.event.inputs.patch }}
+      - name: Cache yarn
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-yarn
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
+
+      - name: Install
+        run: yarn install --frozen-lockfile --prefer-offline
+
+      - name: Build and deploy
+        run: ./build/deploy-prod.sh
+        env:
+          PT_PROJECT_TOKEN: ${{ secrets.PT_PROJECT_TOKEN }}
+          WEB_API_KEY: ${{ secrets.PROD_API_KEY }}
+          WEB_OAUTH_CLIENT_ID: ${{ secrets.PROD_OAUTH_CLIENT_ID }}
+          WEB_OAUTH_CLIENT_SECRET: ${{ secrets.PROD_OAUTH_CLIENT_SECRET }}
+          DIM_API_KEY: ${{ secrets.PROD_DIM_API_KEY }}
+          CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_PATH: app.destinyitemmanager.com
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Use the dim-release-bot token rather than the default
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          PATCH: ${{ github.event.inputs.patch }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,18 +46,6 @@ jobs:
             ${{ runner.os }}-${{ env.cache-name }}-
             ${{ runner.os }}-
 
-      - name: Cache eslint
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-eslint
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-            ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,7 +26,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
             ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
 
       - name: Cache eslint
         uses: actions/cache@v2
@@ -38,7 +37,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
             ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -54,7 +52,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
             ${{ runner.os }}-${{ env.cache-name }}-
-            ${{ runner.os }}-
 
       - name: Install
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,53 +7,67 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 2 # So packtracker can get the previous commit
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # So packtracker can get the previous commit
 
-    - name: Cache node_modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node_modules
-      with:
-        path: $GITHUB_WORKSPACE/node_modules
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock')}}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Cache eslint
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-eslint
-      with:
-        path: ~/.cache
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+      - name: Cache eslint
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-eslint
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/eslint.json') }}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Install
-      uses: bahmutov/npm-install@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-    - name: Test
-      run: yarn test
+      - name: Cache yarn
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-yarn
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-
 
-    - name: Lint check
-      run: |
-        find . -type d -name "node_modules" -prune -o -type f -iregex '.*.ts\|.*.js\|.*.tsx\|.*.jsx' -exec ./build/set-mtime-to-md5.sh {} \;
-        yarn run lint-check
+      - name: Install
+        run: yarn install --frozen-lockfile --prefer-offline
 
-    - name: Build beta
-      run: yarn run build-beta
-      env:
-        PT_PROJECT_TOKEN: ${{ secrets.PT_PROJECT_TOKEN }}
+      - name: Test
+        run: yarn test
+
+      - name: Lint check
+        run: |
+          find . -type d -name "node_modules" -prune -o -type f -iregex '.*.ts\|.*.js\|.*.tsx\|.*.jsx' -exec ./build/set-mtime-to-md5.sh {} \;
+          yarn run lint-check
+
+      - name: Build beta
+        run: yarn run build-beta
+        env:
+          PT_PROJECT_TOKEN: ${{ secrets.PT_PROJECT_TOKEN }}


### PR DESCRIPTION
~~Split workflows into multiple jobs. They basically all have some form of install, test, lint, build/deploy.~~

~~The linting and testing jobs take a bit so running those in parallel will help some. Also with pr builds, test, lint, and build will all run in parallel.~~

I initially tried to split things into jobs but came to the realisation that we need to run through the whole checkout/cache/install process with each job (I don't know why I didn't realise it to begin with). We could potentially do something like this but we would need to share pretty large artefacts between jobs so I am not sure its really worth it.

Moved over to our own yarn cache as the npm-install action seemed to be clashing with our node_modules cache. Also tweaking some of the cache settings in an effort to clean things up and improve speed.