### PR TITLE
Turn on item list sockets in beta

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -393,7 +393,7 @@ module.exports = (env) => {
         // Enable search results
         '$featureFlags.searchResults': JSON.stringify(!env.release),
         // Alternate perks display on item popup
-        '$featureFlags.newPerks': JSON.stringify(env.dev),
+        '$featureFlags.newPerks': JSON.stringify(!env.release),
         // Advanced Write Actions (inserting mods)
         '$featureFlags.awa': JSON.stringify(process.env.USER === 'brh'), // Only Ben has the keys...
         // Incorporate mods directly into loadouts

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+### Beta Only
+
+* We're trying out a new display for weapon perks, which displays the name of the active perk and shows details on click, instead of on hover. This is partly to make perks easier to understand, but also to allow for more actions on perks in the future. Let us know what you think! Animations will be added later if this design catches on.
+
 ## 6.41.1 <span className="changelog-date">(2020-12-02)</span>
 
 ## 6.41.0 <span className="changelog-date">(2020-12-02)</span>

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -172,7 +172,7 @@ function ItemSocketsWeapons({
         </div>
       )}
       {perks &&
-        ($featureFlags.newPerks ? (
+        ($featureFlags.newPerks && !minimal ? (
           <ItemPerksList item={item} perks={perks} />
         ) : (
           <div


### PR DESCRIPTION
Enables the list style sockets in beta. I *disabled* them on the Compare screen - they either don't ever belong there, or need some variant to fit nicely in compare.