### PR TITLE
Commas in donation amounts

### DIFF
--- a/src/app/banner/IssueBanner.tsx
+++ b/src/app/banner/IssueBanner.tsx
@@ -117,10 +117,10 @@ export default function IssueBanner() {
                       width: `${Math.min((state.donations / state.goal) * 100, 100)}%`,
                     }}
                   >
-                    <em>${state.donations}</em>
+                    <em>${state.donations.toLocaleString()}</em>
                   </div>
                 </div>
-                <div className={styles.goal}>${state.goal}</div>
+                <div className={styles.goal}>${state.goal.toLocaleString()}</div>
               </div>
               <div className={styles.buttongroup}>
                 <button className="dim-button" type="button">


### PR DESCRIPTION
It was bugging me that we didn't have commas for the thousands of dollars we've raised for charity:
![image](https://user-images.githubusercontent.com/313208/101232708-19a9f700-3668-11eb-815b-0c6d95ea8975.png)
