### PR TITLE
Show postmaster size when collapsed

### DIFF
--- a/src/app/inventory/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory/InventoryCollapsibleTitle.scss
@@ -25,10 +25,6 @@
     }
   }
 
-  &.collapsed {
-    background-color: rgba(0, 0, 0, 0.4);
-  }
-
   .collapse-handle {
     cursor: pointer;
     height: 100%;
@@ -54,4 +50,11 @@
     min-height: 34px;
     opacity: 0.8;
   }
+}
+
+.bucket-size {
+  margin-left: 4px;
+  text-transform: none;
+  font-size: 12px;
+  letter-spacing: 0;
 }

--- a/src/app/inventory/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory/InventoryCollapsibleTitle.tsx
@@ -98,7 +98,14 @@ function InventoryCollapsibleTitle({
               {index === 0 ? (
                 <span className="collapse-handle" onClick={toggle}>
                   <AppIcon className="collapse-icon" icon={collapsed ? expandIcon : collapseIcon} />{' '}
-                  <span>{showPostmasterFull ? text : title}</span>
+                  <span>
+                    {showPostmasterFull ? text : title}
+                    {checkPostmaster && collapsed && (
+                      <span className="bucket-size">
+                        ({postMasterSpaceUsed}/{POSTMASTER_SIZE})
+                      </span>
+                    )}
+                  </span>
                 </span>
               ) : (
                 showPostmasterFull && text


### PR DESCRIPTION
Today it's pretty dangerous to collapse your postmaster, because you don't know how full it is. This shows the capacity when collapsed instead:

<img width="469" alt="Screen Shot 2020-12-04 at 7 34 21 PM" src="https://user-images.githubusercontent.com/313208/101232736-570e8480-3668-11eb-9f1e-dec14007d5de.png">

I also cleaned up the darkened background on collapsed rows, which was a holdover from before the gradient background. Before this change it looks like this:

<img width="565" alt="Screen Shot 2020-12-04 at 7 39 48 PM" src="https://user-images.githubusercontent.com/313208/101232763-858c5f80-3668-11eb-82af-b7af60b53368.png">
