### PR TITLE
Active mode bugfix for saved search and cursor for dropodown

### DIFF
--- a/src/app/active-mode/Views/RecentItems.tsx
+++ b/src/app/active-mode/Views/RecentItems.tsx
@@ -43,7 +43,7 @@ export default function RecentItems() {
       {options.length > 0 && (
         <div className={styles.options}>
           <Dropdown options={options}>{t('ActiveMode.ChangeFilter')}</Dropdown>
-          <ItemActionsDropdown filteredItems={items} searchActive={Boolean(query.length)} />
+          <ItemActionsDropdown filteredItems={items} searchActive={Boolean(query?.length)} />
           <div className={styles.applySearch} onClick={() => dispatch(setSearchQuery(query))}>
             <AppIcon icon={searchIcon} />
           </div>

--- a/src/app/item-popup/ItemTagSelector.m.scss
+++ b/src/app/item-popup/ItemTagSelector.m.scss
@@ -1,4 +1,5 @@
 .itemTagSelector {
+  cursor: default;
   button {
     min-width: 10em;
     width: 100%;


### PR DESCRIPTION
If you had no saved searches and save one, it would save it but it would thrown an error, this fixes it. Also I noticed that the dropdown in the sidecar for tags shows the text cursor when you hover the text, just going to always default it to the normal cursor.