### PR TITLE
Slow the farming mode refresh down a little bit

### DIFF
--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -49,7 +49,7 @@ const makeRoomTypes = [
   3865314626, // Material
 ];
 
-const FARMING_REFRESH_RATE = 10_000; // Bungie.net caches results for 30 seconds - this may be too fast
+const FARMING_REFRESH_RATE = 30_000; // Bungie.net caches results for 30 seconds - this may be too fast
 
 let intervalId = 0;
 


### PR DESCRIPTION
10 seconds seems a bit too quick, slowing to every 30 seconds. we can bump it back up when we start to implement partial data refreshes. 

I think it's been this for a while, but it may be getting a little bit more use w. the more prominent button in active mode, some users have been reporting api slowness messages from bnet. hopefully this relieves some pressure?