### PR TITLE
Reorder sockets to put key traits up top

### DIFF
--- a/src/app/item-popup/ItemPerksList.tsx
+++ b/src/app/item-popup/ItemPerksList.tsx
@@ -5,6 +5,7 @@ import AppIcon from 'app/shell/icons/AppIcon';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { isKillTrackerSocket } from 'app/utils/item-utils';
 import clsx from 'clsx';
+import _ from 'lodash';
 import { default as React, useState } from 'react';
 import { connect } from 'react-redux';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
@@ -14,6 +15,9 @@ import { InventoryWishListRoll } from '../wishlists/wishlists';
 import styles from './ItemPerksList.m.scss';
 import './ItemSockets.scss';
 import PlugTooltip from './PlugTooltip';
+
+// Reorder sockets to put frames and intrinsics first, since they're most interesting
+const plugCategoryIdentifierOrder = ['frames', 'intrinsics'];
 
 interface ProvidedProps {
   item: DimItem;
@@ -54,9 +58,17 @@ function ItemPerksList({ defs, item, perks, inventoryWishListRoll }: Props) {
   if (!perks.sockets || !defs) {
     return null;
   }
+
+  const sockets = _.sortBy(
+    perks.sockets,
+    (s) =>
+      s.plugged &&
+      -plugCategoryIdentifierOrder.indexOf(s.plugged.plugDef.plug.plugCategoryIdentifier)
+  );
+
   return (
     <div className={styles.sockets}>
-      {perks?.sockets.map(
+      {sockets.map(
         (socketInfo) =>
           !isKillTrackerSocket(socketInfo) && (
             <PerkSocket

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -49,6 +49,10 @@
       font-size: 12px;
     }
   }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .item-description {


### PR DESCRIPTION
I'm a bit wary of this, but it puts the "traits" sockets up top where they're easier to see. I'm not sure if people will be *looking* for them there...

<img width="370" alt="Screen Shot 2020-12-06 at 7 25 38 PM" src="https://user-images.githubusercontent.com/313208/101306118-eea2dd00-37f8-11eb-96d2-5519a80279ea.png">
