### PR TITLE
safety measures for Spoils of Conquest consumable

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -344,6 +344,7 @@
     "PostmasterAlmostFull": "Almost full! ({{number}}/{{postmasterSize}})",
     "PostmasterFull": "Full! ({{number}}/{{postmasterSize}})",
     "PreviewVendor": "Preview {{type}} contents",
+    "ShouldNotBeInVault": "This item may be at risk if it is left in the Vault. Please transfer it to a character.",
     "StackFull": "You already have a full stack of {{name}}",
     "StoreName": "{{genderRace}} {{className}}",
     "TooMuch": "Looks like you requested to move more of this item than exists in the source!"

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -33,6 +33,7 @@ import { createItemIndex } from './item-index';
 import { buildMasterwork } from './masterwork';
 import { buildObjectives } from './objectives';
 import { buildSockets } from './sockets';
+import { isSpoilsOnCharacter } from './spoils-of-conquest';
 import { buildStats } from './stats';
 import { buildTalentGrid } from './talent-grids';
 
@@ -365,7 +366,9 @@ export function makeItem(
     iconOverlay,
     secondaryIcon: overrideStyleItem?.secondaryIcon || itemDef.secondaryIcon,
     notransfer: Boolean(
-      itemDef.nonTransferrable || item.transferStatus === TransferStatuses.NotTransferrable
+      itemDef.nonTransferrable ||
+        item.transferStatus === TransferStatuses.NotTransferrable ||
+        isSpoilsOnCharacter(itemDef, owner, defs)
     ),
     canPullFromPostmaster: !itemDef.doesPostmasterPullHaveSideEffects,
     id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack

--- a/src/app/inventory/store/spoils-of-conquest.tsx
+++ b/src/app/inventory/store/spoils-of-conquest.tsx
@@ -1,0 +1,54 @@
+import type { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import BungieImage from 'app/dim-ui/BungieImage';
+import { t } from 'app/i18next-t';
+import type { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import _ from 'lodash';
+import React from 'react';
+import { showNotification } from '../../notifications/notifications';
+import type { DimItem } from '../item-types';
+import type { DimStore } from '../store-types';
+
+const warnSpoilsInVault = _.debounce(
+  (title: string, icon: JSX.Element) => {
+    showNotification({
+      type: 'warning',
+      icon,
+      title,
+      body: t('ItemService.ShouldNotBeInVault'),
+      duration: 10000,
+    });
+  },
+  30000,
+  {
+    leading: true,
+    trailing: false,
+  }
+);
+
+/**
+ * returns true if this is a Spoils of Conquest (3702027555) that's not in the vault
+ *
+ * if true, please do not transfer this item!! spoils can't safely be in the vault
+ */
+export function isSpoilsOnCharacter(
+  itemDef: DestinyInventoryItemDefinition,
+  owner: DimStore<DimItem> | undefined,
+  defs: D2ManifestDefinitions
+) {
+  if (itemDef.hash === 3702027555) {
+    if (owner?.isVault) {
+      const spoilsDef = defs.InventoryItem.get(3702027555);
+      warnSpoilsInVault(
+        spoilsDef.displayProperties.name,
+        <BungieImage
+          style={{ height: 48, width: 48, border: '1px solid #ccc' }}
+          src={spoilsDef.displayProperties.icon}
+        />
+      );
+    } else {
+      // it's spoils, but it's in the right place. return true to prevent transfers
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -341,6 +341,7 @@
     "PostmasterAlmostFull": "Almost full! ({{number}}/{{postmasterSize}})",
     "PostmasterFull": "Full! ({{number}}/{{postmasterSize}})",
     "PreviewVendor": "Preview {{type}} contents",
+    "ShouldNotBeInVault": "This item may be at risk if it is left in the Vault. Please transfer it to a character.",
     "StackFull": "You already have a full stack of {{name}}",
     "StoreName": "{{genderRace}} {{className}}"
   },


### PR DESCRIPTION
warns users if they are in the vault, and only allows transfers OUT of the vault.

![image](https://user-images.githubusercontent.com/68782081/101414720-7b9e7280-389b-11eb-8c0c-43b92dc4664e.png)

can't find anything actually tracking this (bungie.net known issues, twab, etc), but supposedly it's Known by D2 support