### PR TITLE
Drive the item popup trigger preventDefault

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -379,8 +379,6 @@ module.exports = (env) => {
         '$featureFlags.vendorEngrams': JSON.stringify(false),
         // Show a banner for supporting a charitable cause
         '$featureFlags.issueBanner': JSON.stringify(true),
-        // Show confetti
-        '$featureFlags.confetti': JSON.stringify(true),
         // Show the triage tab in the item popup
         '$featureFlags.triage': JSON.stringify(env.dev),
         // Drag and drop mobile inspect

--- a/src/app/banner/IssueBanner.tsx
+++ b/src/app/banner/IssueBanner.tsx
@@ -81,7 +81,7 @@ export default function IssueBanner() {
     return () => document.body.classList.remove('issue-banner-shown');
   }, [state.show]);
 
-  const met25kGoal = $featureFlags.confetti && state.donations >= 25000;
+  const met25kGoal = state.donations >= 25000;
 
   return (
     <>

--- a/src/app/inventory/ItemPopupTrigger.tsx
+++ b/src/app/inventory/ItemPopupTrigger.tsx
@@ -1,5 +1,6 @@
+import { settingsSelector } from 'app/dim-api/selectors';
 import React, { useCallback, useRef } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { CompareService } from '../compare/compare.service';
 import { ItemPopupExtraInfo, showItemPopup } from '../item-popup/item-popup';
 import { clearNewItem } from './actions';
@@ -16,11 +17,12 @@ interface Props {
  */
 export default function ItemPopupTrigger({ item, extraData, children }: Props): JSX.Element {
   const ref = useRef<HTMLDivElement>(null);
+  const disableConfetti = useSelector(settingsSelector).disableConfetti;
   const dispatch = useDispatch();
 
   const clicked = useCallback(
     (e: React.MouseEvent) => {
-      if (!$featureFlags.confetti) {
+      if (disableConfetti) {
         e.stopPropagation();
       }
 
@@ -34,7 +36,7 @@ export default function ItemPopupTrigger({ item, extraData, children }: Props): 
         return false;
       }
     },
-    [dispatch, extraData, item]
+    [dispatch, extraData, item, disableConfetti]
   );
 
   return children(ref, clicked) as JSX.Element;


### PR DESCRIPTION
if confetti mode is turned off, then allow clicking through to an item again to open the popup (instead of requiring a click to close) will rip this all out after the event concludes 