### PR TITLE
Vendor fixes

### DIFF
--- a/src/app/item-popup/ItemPerksList.m.scss
+++ b/src/app/item-popup/ItemPerksList.m.scss
@@ -3,7 +3,7 @@
 .sockets {
   display: flex;
   flex-direction: column;
-  margin: -12px -10px 0 -10px;
+  margin: -12px -10px -12px -10px;
 }
 
 .socket {

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -49,10 +49,6 @@
       font-size: 12px;
     }
   }
-
-  &:last-child {
-    margin-bottom: 0;
-  }
 }
 
 .item-description {

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -16,18 +16,16 @@ export const enum ItemPopupTab {
 /** The main portion of the item popup, with pages of info (Actions, Details, Reviews) */
 export default function ItemPopupBody({
   item,
-  failureStrings,
   extraInfo,
   tab,
   onTabChanged,
 }: {
   item: DimItem;
-  failureStrings?: string[];
   extraInfo?: ItemPopupExtraInfo;
   tab: ItemPopupTab;
   onTabChanged(tab: ItemPopupTab): void;
 }) {
-  failureStrings = Array.from(failureStrings || []);
+  const failureStrings = Array.from(extraInfo?.failureStrings || []);
   if (!item.canPullFromPostmaster && item.location.inPostmaster) {
     failureStrings.push(t('MovePopup.CantPullFromPostmaster'));
   }

--- a/src/app/vendors/VendorItem.m.scss
+++ b/src/app/vendors/VendorItem.m.scss
@@ -32,25 +32,6 @@
   background: #44bd32;
 }
 
-.attachedIcon {
-  width: calc(var(--item-size) / 3.5) !important;
-  height: calc(var(--item-size) / 3.5) !important;
-  border-radius: 50%;
-  padding: 1px;
-  box-sizing: border-box;
-  z-index: 3;
-  position: absolute;
-  top: $item-border-width + 2px;
-  right: $item-border-width + 2px;
-  pointer-events: none;
-  background: #bb42cd;
-  filter: invert(1);
-}
-.attachedWeaponIcon {
-  composes: attachedIcon;
-  transform: rotate(-45deg);
-}
-
 .vendorItem {
   display: flex;
   flex-direction: column;

--- a/src/app/vendors/VendorItem.m.scss
+++ b/src/app/vendors/VendorItem.m.scss
@@ -58,6 +58,10 @@
   position: relative;
   margin-right: var(--item-margin);
   cursor: pointer;
+
+  :global(.item-img) {
+    object-fit: cover;
+  }
 }
 
 .unavailable {

--- a/src/app/vendors/VendorItem.m.scss.d.ts
+++ b/src/app/vendors/VendorItem.m.scss.d.ts
@@ -2,8 +2,6 @@
 // Please do not change this file!
 interface CssExports {
   'acquiredIcon': string;
-  'attachedIcon': string;
-  'attachedWeaponIcon': string;
   'cost': string;
   'currency': string;
   'notEnough': string;

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -3,8 +3,6 @@ import { ItemPopupExtraInfo } from 'app/item-popup/item-popup';
 import { DestinyCollectibleState } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
-import helmetIcon from 'destiny-icons/armor_types/helmet.svg';
-import handCannonIcon from 'destiny-icons/weapons/hand_cannon.svg';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
@@ -91,21 +89,17 @@ export function VendorItemDisplay({
   extraData?: ItemPopupExtraInfo;
   children?: React.ReactNode;
 }) {
-  const acquiredIcon = item.itemCategoryHashes.includes(ItemCategoryHashes.ArmorMods) ? (
-    <img src={helmetIcon} className={styles.attachedIcon} />
-  ) : item.itemCategoryHashes.includes(ItemCategoryHashes.WeaponMods) ? (
-    <img src={handCannonIcon} className={styles.attachedWeaponIcon} />
-  ) : (
-    <AppIcon className={styles.acquiredIcon} icon={faCheck} />
-  );
-
   return (
     <div
       className={clsx(styles.vendorItem, {
         [styles.unavailable]: unavailable,
       })}
     >
-      {owned ? <AppIcon className={styles.ownedIcon} icon={faCheck} /> : acquired && acquiredIcon}
+      {owned ? (
+        <AppIcon className={styles.ownedIcon} icon={faCheck} />
+      ) : (
+        acquired && <AppIcon className={styles.acquiredIcon} icon={faCheck} />
+      )}
       <ItemPopupTrigger item={item} extraData={extraData}>
         {(ref, onClick) => (
           <ConnectedInventoryItem item={item} allowFilter={true} innerRef={ref} onClick={onClick} />

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -51,10 +51,16 @@ export default function VendorItemComponent({
     item.item.collectibleState !== undefined &&
     !(item.item.collectibleState & DestinyCollectibleState.NotAcquired);
 
+  const unavailable =
+    !item.canPurchase ||
+    !item.canBeSold ||
+    (owned &&
+      item.item?.itemCategoryHashes.includes(ItemCategoryHashes.Bounties) &&
+      !item.item.itemCategoryHashes.includes(ItemCategoryHashes.RepeatableBounties));
   return (
     <VendorItemDisplay
       item={item.item}
-      unavailable={!item.canPurchase || !item.canBeSold}
+      unavailable={unavailable}
       owned={owned}
       acquired={acquired}
       extraData={{ failureStrings: item.failureStrings, owned, acquired }}


### PR DESCRIPTION
1. Fix some bottom margins in the popups that I'd screwed up while introducing list-style perks
2. Fix showing failure reasons for vendor items, those had gotten broken some really long time ago
3. Show owned nonrepeatable bounties as greyed out. For whatever reason the vendors API still thinks you can buy them, but you can't.
4. Fix the owned icon for armor/weapon mods to match the checkmark shown on other items (bottom right corner).