### PR TITLE
Popup header tweaks

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -622,8 +622,8 @@
     "Store": "Store",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Take",
     "ToggleSidecar": "Expand or collapse item actions",
@@ -801,7 +801,7 @@
     "CustomDesc": "Custom total of selected base stats, ignoring mods or masterworks. Visit Settings to configure which stats are included.",
     "Discipline": "Discipline",
     "Effect": "Effect",
-    "FinalSeason": "(S{finalSeason})",
+    "FinalSeason": "(S{{finalSeason}})",
     "Intellect": "Intellect",
     "MaxBasePower": "Max Power",
     "MaxGearPower": "Maximum Power of equippable gear",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -622,8 +622,7 @@
     "Store": "Store",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
-      "GearWithMax": "{{light}} ({{maxLight}} max) {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Take",

--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -25,7 +25,7 @@
 .subtitle {
   display: flex;
   justify-content: space-between;
-  margin-top: 4px;
+  margin-top: 6px;
 }
 
 .type,
@@ -45,23 +45,24 @@
 }
 
 .breakerIcon {
-  margin: 0 5px;
-  width: 16px;
-  height: 16px;
+  margin: 1px 5px 0;
+  width: 15px;
+  height: 15px;
 }
 
 .ammoIcon {
-  margin: 0 5px 2px 7px;
-  height: 15px;
-  width: 20px;
+  margin: 0 5px 1px 7px;
+  height: 14px;
+  width: 19px;
   background-color: rgba(0, 0, 0, 0.3);
   border-radius: 5px;
   align-self: flex-end;
 }
 
 .elementIcon {
-  height: 17px;
-  width: 17px;
+  margin-top: 1px;
+  height: 16px;
+  width: 16px;
 }
 
 .itemType {
@@ -70,7 +71,7 @@
 }
 
 .power {
-  margin: 0 5px;
+  margin: 0 4px;
 }
 
 .powerCap {

--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -1,10 +1,9 @@
 @import '../variables.scss';
 
 .header {
-  font-family: Helvetica;
-  font-size: 16px;
-  line-height: 18px;
-  letter-spacing: -0.01em;
+  font-size: 15px;
+  line-height: 17px;
+  letter-spacing: -0.02em;
   padding: 10px;
 
   color: #eee;
@@ -15,18 +14,12 @@
 
 .title {
   @include destiny-header;
-  font-size: 25px;
-  line-height: 29px;
-  letter-spacing: -0.02em;
+  font-size: 21px;
+  line-height: 24px;
 
   a {
     text-decoration: none;
   }
-}
-
-.longTitle {
-  font-size: 18px;
-  line-height: 22px;
 }
 
 .subtitle {
@@ -83,6 +76,7 @@
 .powerCap {
   color: #efe59d;
   font-size: 12px;
+  line-height: 16px;
 }
 
 .primary {

--- a/src/app/item-popup/ItemPopupHeader.m.scss.d.ts
+++ b/src/app/item-popup/ItemPopupHeader.m.scss.d.ts
@@ -10,7 +10,6 @@ interface CssExports {
   'header': string;
   'itemType': string;
   'legendary': string;
-  'longTitle': string;
   'masterwork': string;
   'power': string;
   'powerCap': string;

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -32,7 +32,7 @@ export default function ItemPopupHeader({ item }: { item: DimItem }) {
         [styles.pursuit]: item.pursuit,
       })}
     >
-      <div className={clsx(styles.title, { [styles.longTitle]: item.name.length >= 19 })}>
+      <div className={styles.title}>
         <ExternalLink href={destinyDBLink(item, language)}>{item.name}</ExternalLink>
       </div>
 
@@ -56,7 +56,7 @@ export default function ItemPopupHeader({ item }: { item: DimItem }) {
           <div className={styles.power}>{item.primStat?.value}</div>
           {item.powerCap && (
             <div className={styles.powerCap}>
-              / {item.powerCap}{' '}
+              | {item.powerCap}{' '}
               {t('Stats.FinalSeason', {
                 finalSeason: getItemPowerCapFinalSeason(item),
               })}
@@ -87,17 +87,21 @@ function AmmoIcon({ type }: { type: DestinyAmmunitionType }) {
 
 function ItemTypeName({ item }: { item: DimItem }) {
   const classType =
-    item.classType !== DestinyClass.Unknown &&
-    // These already include the class name
-    item.type !== 'ClassItem' &&
-    item.type !== 'Artifact' &&
-    item.type !== 'Class' &&
-    !item.classified &&
-    item.classTypeNameLocalized[0].toUpperCase() + item.classTypeNameLocalized.slice(1);
+    (item.classType !== DestinyClass.Unknown &&
+      // These already include the class name
+      item.type !== 'ClassItem' &&
+      item.type !== 'Artifact' &&
+      item.type !== 'Class' &&
+      !item.classified &&
+      item.classTypeNameLocalized[0].toUpperCase() + item.classTypeNameLocalized.slice(1)) ||
+    '';
 
   return (
     <div className={styles.itemType}>
-      {classType} {item.typeName}
+      {t('MovePopup.Subtitle.Type', {
+        classType,
+        typeName: item.typeName,
+      })}
     </div>
   );
 }

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -94,7 +94,7 @@ function ItemTypeName({ item }: { item: DimItem }) {
       item.type !== 'Class' &&
       !item.classified &&
       item.classTypeNameLocalized[0].toUpperCase() + item.classTypeNameLocalized.slice(1)) ||
-    '';
+    ' ';
 
   return (
     <div className={styles.itemType}>

--- a/src/app/mobile-inspect/ItemSubHeader.tsx
+++ b/src/app/mobile-inspect/ItemSubHeader.tsx
@@ -27,7 +27,7 @@ export function ItemSubHeader({ item }: { item: DimItem }) {
     <>
       {light
         ? t('MovePopup.Subtitle.Gear', subtitleData)
-        : t('MovePopup.Subtitle.Consumable', subtitleData)}
+        : t('MovePopup.Subtitle.Type', subtitleData)}
     </>
   );
 }

--- a/src/app/mobile-inspect/MobileInspect.tsx
+++ b/src/app/mobile-inspect/MobileInspect.tsx
@@ -2,7 +2,7 @@ import BungieImage from 'app/dim-ui/BungieImage';
 import { DimItem } from 'app/inventory/item-types';
 import ItemActions from 'app/item-popup/ItemActions';
 import ItemSockets from 'app/item-popup/ItemSockets';
-import { ItemSubHeader } from 'app/item-popup/ItemSubHeader';
+import { ItemSubHeader } from 'app/mobile-inspect/ItemSubHeader';
 import { useSubscription } from 'app/utils/hooks';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';

--- a/src/locale/de/dim.json
+++ b/src/locale/de/dim.json
@@ -606,8 +606,8 @@
     "Store": "Lagern",
     "StoreWithName": "Lagern auf {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Nehmen",
     "ToggleSidecar": "Gegenstand-Aktionen erweitern oder einklappen",

--- a/src/locale/de/dim.json
+++ b/src/locale/de/dim.json
@@ -606,7 +606,7 @@
     "Store": "Lagern",
     "StoreWithName": "Lagern auf {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Nehmen",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -606,7 +606,7 @@
     "Store": "Store",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Take",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -595,7 +595,6 @@
     "OverviewTab": "Overview",
     "Owned": "This item is in your inventory.",
     "OwnedMod": "This mod is in your modifications inventory.",
-    "PowerCap": "",
     "PullItem": "Pull from {{bucket}} to {{store}}",
     "PullPostmaster": "Pull from Postmaster",
     "ReadLore": "Read lore on Ishtar Collective",
@@ -606,8 +605,8 @@
     "Store": "Store",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Take",
     "ToggleSidecar": "Expand or collapse item actions",
@@ -778,7 +777,7 @@
     "Discipline": "Discipline",
     "DodgeCooldown": "Dodge Cooldown",
     "Effect": "Effect",
-    "FinalSeason": "(S{{finalSeason}})",
+    "FinalSeason": "(S{finalSeason})",
     "GrenadeCooldown": "Grenade Cooldown",
     "Intellect": "Intellect",
     "MaxGearPower": "Maximum Power of equippable gear",

--- a/src/locale/es-mx/dim.json
+++ b/src/locale/es-mx/dim.json
@@ -606,8 +606,8 @@
     "Store": "Guardar",
     "StoreWithName": "Almacenar en {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{classType}} {{typeName}} con {{light}} de {{statName}}"
+      "Gear": "{{classType}} {{typeName}} con {{light}} de {{statName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Toma",
     "ToggleSidecar": "Expandir o colapsar acciones de objeto",

--- a/src/locale/es-mx/dim.json
+++ b/src/locale/es-mx/dim.json
@@ -606,7 +606,7 @@
     "Store": "Guardar",
     "StoreWithName": "Almacenar en {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{classType}} {{typeName}} con {{light}} de {{statName}}"
     },
     "Take": "Toma",

--- a/src/locale/es/dim.json
+++ b/src/locale/es/dim.json
@@ -606,7 +606,7 @@
     "Store": "Almacenar",
     "StoreWithName": "Almacenar en {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{classType}} {{typeName}} con {{light}} de {{statName}}"
     },
     "Take": "Tomar",

--- a/src/locale/es/dim.json
+++ b/src/locale/es/dim.json
@@ -606,8 +606,8 @@
     "Store": "Almacenar",
     "StoreWithName": "Almacenar en {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{classType}} {{typeName}} con {{light}} de {{statName}}"
+      "Gear": "{{classType}} {{typeName}} con {{light}} de {{statName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Tomar",
     "ToggleSidecar": "Expandir o colapsar acciones de objeto",

--- a/src/locale/fr/dim.json
+++ b/src/locale/fr/dim.json
@@ -606,7 +606,7 @@
     "Store": "Dépôt",
     "StoreWithName": "Déposer sur {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Réunir",

--- a/src/locale/fr/dim.json
+++ b/src/locale/fr/dim.json
@@ -606,8 +606,8 @@
     "Store": "Dépôt",
     "StoreWithName": "Déposer sur {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Réunir",
     "ToggleSidecar": "Développer ou réduire les actions d'objet",

--- a/src/locale/it/dim.json
+++ b/src/locale/it/dim.json
@@ -606,7 +606,7 @@
     "Store": "Sposta",
     "StoreWithName": "Sposta su {{character}}",
     "Subtitle": {
-      "Consumable": "{{typeName}} {{classType}}",
+      "Type": "{{typeName}} {{classType}}",
       "Gear": "{{light}} {{statName}} {{typeName}} {{classType}}"
     },
     "Take": "Prendi",

--- a/src/locale/it/dim.json
+++ b/src/locale/it/dim.json
@@ -606,8 +606,8 @@
     "Store": "Sposta",
     "StoreWithName": "Sposta su {{character}}",
     "Subtitle": {
-      "Type": "{{typeName}} {{classType}}",
-      "Gear": "{{light}} {{statName}} {{typeName}} {{classType}}"
+      "Gear": "{{light}} {{statName}} {{typeName}} {{classType}}",
+      "Type": "{{typeName}} {{classType}}"
     },
     "Take": "Prendi",
     "ToggleSidecar": "Espandi o comprimi le azioni per l'oggetto",

--- a/src/locale/ja/dim.json
+++ b/src/locale/ja/dim.json
@@ -606,8 +606,8 @@
     "Store": "保存",
     "StoreWithName": "{{character}} が装備しています",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "取る",
     "ToggleSidecar": "アイテムアクションを展開または折りたたむ",

--- a/src/locale/ja/dim.json
+++ b/src/locale/ja/dim.json
@@ -606,7 +606,7 @@
     "Store": "保存",
     "StoreWithName": "{{character}} が装備しています",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "取る",

--- a/src/locale/ko/dim.json
+++ b/src/locale/ko/dim.json
@@ -606,7 +606,7 @@
     "Store": "보관",
     "StoreWithName": "{{character}}에게 보관",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "모으기",

--- a/src/locale/ko/dim.json
+++ b/src/locale/ko/dim.json
@@ -606,8 +606,8 @@
     "Store": "보관",
     "StoreWithName": "{{character}}에게 보관",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "모으기",
     "ToggleSidecar": "아이템 액션 확장 또는 축소",

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -606,7 +606,7 @@
     "Store": "Umieść",
     "StoreWithName": "Umieść na {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}}{{typeName}}",
+      "Type": "{{classType}}{{typeName}}",
       "Gear": "{{light}}{{statName}}{{classType}}{{typeName}}"
     },
     "Take": "Weź",

--- a/src/locale/pl/dim.json
+++ b/src/locale/pl/dim.json
@@ -606,8 +606,8 @@
     "Store": "Umieść",
     "StoreWithName": "Umieść na {{character}}",
     "Subtitle": {
-      "Type": "{{classType}}{{typeName}}",
-      "Gear": "{{light}}{{statName}}{{classType}}{{typeName}}"
+      "Gear": "{{light}}{{statName}}{{classType}}{{typeName}}",
+      "Type": "{{classType}}{{typeName}}"
     },
     "Take": "Weź",
     "ToggleSidecar": "Rozwiń lub zwiń akcje przedmiotu",

--- a/src/locale/pt-br/dim.json
+++ b/src/locale/pt-br/dim.json
@@ -606,8 +606,8 @@
     "Store": "Armazenar",
     "StoreWithName": "Armazenar em {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Tomar",
     "ToggleSidecar": "Expandir ou recolher ações do item",

--- a/src/locale/pt-br/dim.json
+++ b/src/locale/pt-br/dim.json
@@ -606,7 +606,7 @@
     "Store": "Armazenar",
     "StoreWithName": "Armazenar em {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Tomar",

--- a/src/locale/ru/dim.json
+++ b/src/locale/ru/dim.json
@@ -606,7 +606,7 @@
     "Store": "Передать",
     "StoreWithName": "Передать {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "Взять",

--- a/src/locale/ru/dim.json
+++ b/src/locale/ru/dim.json
@@ -606,8 +606,8 @@
     "Store": "Передать",
     "StoreWithName": "Передать {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "Взять",
     "ToggleSidecar": "Скрыть/Показать действия",

--- a/src/locale/zh-chs/dim.json
+++ b/src/locale/zh-chs/dim.json
@@ -606,8 +606,8 @@
     "Store": "寄存",
     "StoreWithName": "存储到 {{character}}",
     "Subtitle": {
-      "Type": "{{classType}} {{typeName}}",
-      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
+      "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}"
     },
     "Take": "收集",
     "ToggleSidecar": "展开或折叠物品操作",

--- a/src/locale/zh-chs/dim.json
+++ b/src/locale/zh-chs/dim.json
@@ -606,7 +606,7 @@
     "Store": "寄存",
     "StoreWithName": "存储到 {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}} {{typeName}}",
+      "Type": "{{classType}} {{typeName}}",
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}"
     },
     "Take": "收集",

--- a/src/locale/zh-cht/dim.json
+++ b/src/locale/zh-cht/dim.json
@@ -606,7 +606,7 @@
     "Store": "Store",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
-      "Consumable": "{{classType}}{{typeName}}",
+      "Type": "{{classType}}{{typeName}}",
       "Gear": "{{light}}{{statName}}{{classType}}{{typeName}}"
     },
     "Take": "收集",

--- a/src/locale/zh-cht/dim.json
+++ b/src/locale/zh-cht/dim.json
@@ -606,8 +606,8 @@
     "Store": "Store",
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
-      "Type": "{{classType}}{{typeName}}",
-      "Gear": "{{light}}{{statName}}{{classType}}{{typeName}}"
+      "Gear": "{{light}}{{statName}}{{classType}}{{typeName}}",
+      "Type": "{{classType}}{{typeName}}"
     },
     "Take": "收集",
     "ToggleSidecar": "Expand or collapse item actions",


### PR DESCRIPTION
making things more proportional and fix i18n for the subtitle. Also reverted using helvetica for the entire header, and just for the item name.

|original|old|new|
|---|---|---|
|<img width="321" alt="Screen Shot 2020-12-12 at 10 30 59 AM" src="https://user-images.githubusercontent.com/424158/101992005-2c728c00-3c65-11eb-997a-8837d5769426.png">|<img width="320" alt="Screen Shot 2020-12-12 at 10 30 11 AM" src="https://user-images.githubusercontent.com/424158/101991980-0e0c9080-3c65-11eb-9739-d00dc8f8e60c.png">|<img width="321" alt="Screen Shot 2020-12-12 at 10 29 55 AM" src="https://user-images.githubusercontent.com/424158/101991982-11078100-3c65-11eb-9c05-c4b704fe3c4c.png">|

