### PR TITLE
Fix "c" hot key to trigger compare

### DIFF
--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -1,4 +1,5 @@
 import { StoreIcon } from 'app/character-tile/StoreIcon';
+import { CompareService } from 'app/compare/compare.service';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
@@ -73,6 +74,10 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
   useHotkey('v', t('Hotkey.Vault'), () => {
     const vault = getVault(stores)!;
     submitMoveTo(vault);
+  });
+  useHotkey('c', t('Compare.ButtonHelp'), () => {
+    hideItemPopup();
+    CompareService.addItemsToCompare([item], true);
   });
 
   const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
previously lived in the popup header, moved to desktop item actions

https://github.com/DestinyItemManager/DIM/pull/6311/files#diff-df7287c48a15a7d5bfc0563a2d0afd408d81f0c09fd153c04e13e7a068b55058L37

This resolves #6322