### PR TITLE
Animate/scale up and down the checkbox toggle on click

### DIFF
--- a/src/app/banner/IssueBanner.m.scss
+++ b/src/app/banner/IssueBanner.m.scss
@@ -110,3 +110,14 @@
     background-color: #c00 !important;
   }
 }
+
+.wiggleElement {
+  animation: 0.25s linear 2 alternate pop;
+  z-index: 1;
+}
+
+@keyframes pop {
+  to {
+    transform: scale(1.25);
+  }
+}

--- a/src/app/banner/IssueBanner.m.scss.d.ts
+++ b/src/app/banner/IssueBanner.m.scss.d.ts
@@ -11,10 +11,12 @@ interface CssExports {
   'link': string;
   'maximized': string;
   'mercury': string;
+  'pop': string;
   'streaming': string;
   'thermo': string;
   'toaster': string;
   'track': string;
+  'wiggleElement': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/banner/IssueBanner.tsx
+++ b/src/app/banner/IssueBanner.tsx
@@ -33,6 +33,7 @@ function Link({
  */
 export default function IssueBanner() {
   const dispatch = useDispatch();
+  const [wiggle, setWiggle] = useState(false);
   const disableConfetti = useSelector(settingsSelector).disableConfetti;
   const [isMinimized, setIsMinimized] = useState(true);
   const [state, setState] = useState({
@@ -85,7 +86,7 @@ export default function IssueBanner() {
 
   return (
     <>
-      {!disableConfetti && met25kGoal && <ConfettiClick />}
+      {!disableConfetti && met25kGoal && <ConfettiClick isAnimating={setWiggle} />}
       <div
         className={clsx(styles.toaster, {
           [styles.maximized]: !isMinimized,
@@ -95,7 +96,11 @@ export default function IssueBanner() {
           state.show && (
             <>
               {met25kGoal && (
-                <label className={styles.confettiToggle}>
+                <label
+                  className={clsx(styles.confettiToggle, {
+                    [styles.wiggleElement]: wiggle,
+                  })}
+                >
                   <input
                     checked={disableConfetti}
                     type="checkbox"

--- a/src/app/shell/ConfettiClick.tsx
+++ b/src/app/shell/ConfettiClick.tsx
@@ -44,11 +44,19 @@ function drawShapes(ctx) {
   }
 }
 
-export default function ConfettiClick() {
+export default function ConfettiClick({
+  isAnimating,
+}: {
+  isAnimating: (animating: boolean) => void;
+}) {
   const {
     clicked,
     position: { x, y },
   } = useMouseClick();
+
+  useEffect(() => {
+    isAnimating(clicked);
+  }, [clicked, isAnimating]);
 
   return (
     <Confetti


### PR DESCRIPTION
suppose we're planning on probably removing the confetti soon anyway but this should help a little

I suppose for future events a better way would be do the special thing on the first load, and subsequent loads its turned off or something