### PR TITLE
Set a width for the character header

### DIFF
--- a/src/app/dim-ui/CharacterSelect.tsx
+++ b/src/app/dim-ui/CharacterSelect.tsx
@@ -179,6 +179,7 @@ function SwipableCharacterSelect({
         {stores.map((store) => (
           <div
             key={store.id}
+            style={{ width: `${100 / stores.length}%` }}
             className={clsx(styles.tile, {
               [styles.unselected]: store.id !== selectedStore.id,
             })}


### PR DESCRIPTION
Setting a width relative to the number of columns on a track. This fixes #6327

Would like to make it so that the character headers are always proportional/uncropped, but this should at least fix the issue for now.

<img width="320" alt="Screen Shot 2020-12-16 at 6 23 24 PM" src="https://user-images.githubusercontent.com/424158/102435784-0bdf6480-3fcc-11eb-8bf3-17f237de7aec.png">
