### PR TITLE
Fallback to item def element type

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -288,6 +288,8 @@ export function makeItem(
   const element =
     (instanceDef?.damageTypeHash !== undefined &&
       defs.DamageType.get(instanceDef.damageTypeHash)) ||
+    (itemDef.defaultDamageTypeHash !== undefined &&
+      defs.DamageType.get(itemDef.defaultDamageTypeHash)) ||
     (instanceDef?.energy?.energyTypeHash !== undefined &&
       defs.EnergyType.get(instanceDef.energy.energyTypeHash)) ||
     null;


### PR DESCRIPTION
nev pointed out that collections items were missing their elemental damage. it looks like the item defs have that info. still use the instance one first (for items that can swap the element.)

speaking of collections items - what is the formula for the power level that items are pulled as? could try to estimate that instead of it being blank. Something less than your power level but not sure by how much.