### PR TITLE
Better sheet sizing logic for android keyboard/text input

### DIFF
--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -3,8 +3,7 @@
 $control-color: rgba(255, 255, 255, 0.5);
 
 .sheet {
-  // 100vh isn't really useful on Safari. We'll do this in code.
-  // max-height: calc(100vh - #{$header-height} - 88px);
+  max-height: calc(100vh - #{$header-height} - 88px);
   left: 0;
   right: 0;
   position: fixed;
@@ -60,8 +59,7 @@ $control-color: rgba(255, 255, 255, 0.5);
   .sheet-container {
     display: flex;
     flex-direction: column;
-    // 100vh isn't really useful on Safari. We'll do this in code.
-    // max-height: calc(100vh - #{$header-height} - 88px);
+    max-height: calc(100vh - #{$header-height} - 88px);
     position: relative;
   }
 

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -1,7 +1,7 @@
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import clsx from 'clsx';
 import _ from 'lodash';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { animated, config, useSpring } from 'react-spring';
 import { useDrag } from 'react-use-gesture';
 import { AppIcon, disabledIcon } from '../shell/icons';
@@ -52,10 +52,6 @@ export default function Sheet({
   const dragging = useRef(false);
   const [frozenHeight, setFrozenHeight] = useState<number | undefined>(undefined);
 
-  const windowHeight = window.innerHeight;
-  const headerHeight = useMemo(() => document.getElementById('header')!.clientHeight, []);
-  const maxHeight = windowHeight - headerHeight - 16 - 44;
-
   const sheetContents = useRef<HTMLDivElement | null>(null);
   const sheetContentsRefFn = useLockSheetContents(sheetContents);
 
@@ -84,7 +80,7 @@ export default function Sheet({
   /** This spring is controlled via setSpring, which doesn't trigger re-render. */
   const [springProps, setSpring] = useSpring(() => ({
     // Initially transition from offscreen to on
-    from: { transform: `translateY(${windowHeight}px)` },
+    from: { transform: `translateY(100vh)` },
     to: { transform: `translateY(0px)` },
     config: spring,
     onRest,
@@ -153,7 +149,7 @@ export default function Sheet({
   return (
     <animated.div
       {...bindDrag()}
-      style={{ ...springProps, maxHeight, touchAction: 'none' }}
+      style={{ ...springProps, touchAction: 'none' }}
       className={clsx('sheet', sheetClassName)}
       ref={sheet}
       role="dialog"
@@ -169,7 +165,6 @@ export default function Sheet({
 
       <div
         className="sheet-container"
-        style={{ maxHeight }}
         onMouseDown={dragHandleDown}
         onMouseUp={dragHandleUp}
         onTouchStart={dragHandleDown}


### PR DESCRIPTION
This should hopefully fix a long standing issue where inputting anything into a textbox on android needed to be done off screen. This was because the max-height for a sheet was set when the component is rendered, and when a keyboard pops up the max-height isn't updated. Instead of adding a resize listener, I just updated the styling to be responsive

I noticed there was a comment about vh support in safari, but it looks like it may have been around for a while- and it seems we're using vh units elsewhere in the app? Were we running into issues with that?

https://caniuse.com/?search=vh

This resolves #3596 

|before (text field off screen)|after|
|---|---|
|<img width="513" alt="Screen Shot 2020-12-17 at 11 59 38 AM" src="https://user-images.githubusercontent.com/424158/102537103-5fe75900-405f-11eb-8994-4a16fd3fc1a5.png">|<img width="513" alt="Screen Shot 2020-12-17 at 11 57 55 AM" src="https://user-images.githubusercontent.com/424158/102537010-3e866d00-405f-11eb-8daf-a7cd6edfa052.png">|