### PR TITLE
Hide action button if owner is unknown

### DIFF
--- a/src/app/item-actions/ActionButtons.tsx
+++ b/src/app/item-actions/ActionButtons.tsx
@@ -141,7 +141,7 @@ export function DistributeActionButton({ item, label }: ActionButtonProps) {
 }
 
 export function InfuseActionButton({ item, label }: ActionButtonProps) {
-  if (!item.infusionFuel) {
+  if (!item.infusionFuel || item.owner === 'unknown') {
     return null;
   }
 
@@ -159,7 +159,7 @@ export function InfuseActionButton({ item, label }: ActionButtonProps) {
 }
 
 export function LoadoutActionButton({ item, label }: ActionButtonProps) {
-  if (!itemCanBeInLoadout(item)) {
+  if (!itemCanBeInLoadout(item) || item.owner === 'unknown') {
     return null;
   }
   const addToLoadout = (e) => {


### PR DESCRIPTION
it seems that vendor and collection items had the infuse and add to loadout buttons because nothing was stopping them. added a check to make sure there is an owner 