### PR TITLE
Remove confetti work around for click events

### DIFF
--- a/src/app/inventory/ItemPopupTrigger.tsx
+++ b/src/app/inventory/ItemPopupTrigger.tsx
@@ -1,6 +1,5 @@
-import { settingsSelector } from 'app/dim-api/selectors';
 import React, { useCallback, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { CompareService } from '../compare/compare.service';
 import { ItemPopupExtraInfo, showItemPopup } from '../item-popup/item-popup';
 import { clearNewItem } from './actions';
@@ -17,27 +16,19 @@ interface Props {
  */
 export default function ItemPopupTrigger({ item, extraData, children }: Props): JSX.Element {
   const ref = useRef<HTMLDivElement>(null);
-  const disableConfetti = useSelector(settingsSelector).disableConfetti;
   const dispatch = useDispatch();
 
-  const clicked = useCallback(
-    (e: React.MouseEvent) => {
-      if (disableConfetti) {
-        e.stopPropagation();
-      }
+  const clicked = useCallback(() => {
+    dispatch(clearNewItem(item.id));
 
-      dispatch(clearNewItem(item.id));
-
-      // TODO: a dispatcher based on store state?
-      if (CompareService.dialogOpen) {
-        CompareService.addItemsToCompare([item]);
-      } else {
-        showItemPopup(item, ref.current!, extraData);
-        return false;
-      }
-    },
-    [dispatch, extraData, item, disableConfetti]
-  );
+    // TODO: a dispatcher based on store state?
+    if (CompareService.dialogOpen) {
+      CompareService.addItemsToCompare([item]);
+    } else {
+      showItemPopup(item, ref.current!, extraData);
+      return false;
+    }
+  }, [dispatch, extraData, item]);
 
   return children(ref, clicked) as JSX.Element;
 }


### PR DESCRIPTION
We can fully remove the confetti whenever, but I wanted to at least pull out this bit since it's not needed. This previously made it so that clicking an item would still trigger the confetti click