### PR TITLE
Skip tagCleanup if any items had errors in processing

### DIFF
--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -129,6 +129,7 @@ function processStore(
 
   return processItems(store, rawItems, defs, buckets).then((items) => {
     store.items = items;
+    store.hadErrors = rawItems.length !== items.length;
     return store;
   });
 }

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -322,6 +322,7 @@ function processCharacter(
     uninstancedItemObjectives
   );
   store.items = processedItems;
+  store.hadErrors = items.length !== processedItems.length;
   return store;
 }
 
@@ -358,6 +359,7 @@ function processVault(
     mergedCollectibles
   );
   store.items = processedItems;
+  store.hadErrors = items.length !== processedItems.length;
   return store;
 }
 

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -119,7 +119,7 @@ export const itemTagSelectorList: TagInfo[] = [
  */
 export function cleanInfos(stores: DimStore[]): ThunkResult {
   return async (dispatch, getState) => {
-    if (!stores.length || stores.some((s) => s.items.length === 0)) {
+    if (!stores.length || stores.some((s) => s.items.length === 0 || s.hadErrors)) {
       // don't accidentally wipe out notes
       return;
     }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -71,6 +71,8 @@ export interface DimStore<Item = DimItem> {
     maxTotalPower?: DimCharacterStat;
     [hash: number]: DimCharacterStat;
   };
+  /** Did any of the items in the last inventory build fail? */
+  hadErrors: boolean;
 }
 
 /** Account-wide currency counts, e.g. glimmer */

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -92,6 +92,7 @@ export function makeCharacter(
     advisors: raw.character.advisors,
     isVault: false,
     items: [],
+    hadErrors: false,
   };
 
   let items: any[] = [];
@@ -149,6 +150,7 @@ export function makeVault(
     race: '',
     genderRace: '',
     stats: [],
+    hadErrors: false,
   };
 
   let items: any[] = [];

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -57,6 +57,7 @@ export function makeCharacter(
     isVault: false,
     color: character.emblemColor,
     items: [],
+    hadErrors: false,
   };
 }
 
@@ -82,6 +83,7 @@ export function makeVault(): DimStore {
     race: '',
     genderRace: '',
     stats: [],
+    hadErrors: false,
   };
 }
 


### PR DESCRIPTION
This protects against any case where we have trouble processing items, and as a result we skip them AND clear out their tags/notes because we think they don't exist anymore.