### PR TITLE
Tweak header and sidecar

### DIFF
--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background-color: #0d0d16;
+  background-color: black;
 }
 
 .collapsed .hideWhenCollapsed {

--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -26,42 +26,41 @@
 .subtitle {
   display: flex;
   justify-content: space-between;
-  margin-top: 6px;
+  margin-top: 4px;
 }
 
 .type,
 .details {
   display: flex;
   align-self: flex-end;
+  align-items: center;
 }
 
 .type {
   flex: 1;
 }
 
-.breakerIcon,
-.elementIcon,
-.ammoIcon {
-  filter: drop-shadow(0px 0px 1px #222) drop-shadow(0px 0px 0px #222);
+.rare,
+.common,
+.exotic {
+  .elementIcon {
+    filter: drop-shadow(0px 0px 1px #222) drop-shadow(0px 0px 0px #222);
+  }
 }
 
 .breakerIcon {
-  margin: 1px 5px 0;
+  margin: 0 4px;
   width: 15px;
   height: 15px;
 }
 
 .ammoIcon {
-  margin: 0 5px 1px 7px;
+  margin: 0 2px 0 6px;
   height: 14px;
   width: 19px;
-  background-color: rgba(0, 0, 0, 0.3);
-  border-radius: 5px;
-  align-self: flex-end;
 }
 
 .elementIcon {
-  margin-top: 1px;
   height: 16px;
   width: 16px;
 }
@@ -72,13 +71,14 @@
 }
 
 .power {
-  margin: 0 4px;
+  margin: 0 4px 0 2px;
 }
 
 .powerCap {
   color: #efe59d;
   font-size: 12px;
   line-height: 16px;
+  align-self: flex-start;
 }
 
 .primary {


### PR DESCRIPTION
Make the sidecar pure black, to further separate it from the popup.

On the header, tightened up spacing a bit, and removed the fuzzy backgrounds on some stuff where it wasn't needed - the legendary background has enough contrast for both elements and ammo. What do you think?

| Before | After |
|--------|-------|
|<img width="325" alt="Screen Shot 2020-12-18 at 9 44 56 PM" src="https://user-images.githubusercontent.com/313208/102681929-48e95980-417a-11eb-9a0e-b207763a5121.png">|<img width="323" alt="Screen Shot 2020-12-18 at 9 43 56 PM" src="https://user-images.githubusercontent.com/313208/102681927-47b82c80-417a-11eb-9910-17592bae8f99.png">|
|<img width="323" alt="Screen Shot 2020-12-18 at 9 48 35 PM" src="https://user-images.githubusercontent.com/313208/102682000-d2009080-417a-11eb-9102-422b5f401c1c.png">|<img width="321" alt="Screen Shot 2020-12-18 at 9 48 46 PM" src="https://user-images.githubusercontent.com/313208/102682001-d2992700-417a-11eb-9171-a8ca4ac0da4b.png">|
|<img width="324" alt="Screen Shot 2020-12-18 at 9 47 32 PM" src="https://user-images.githubusercontent.com/313208/102681985-a67da600-417a-11eb-9862-f5864d2f2243.png">|<img width="323" alt="Screen Shot 2020-12-18 at 9 47 41 PM" src="https://user-images.githubusercontent.com/313208/102681986-a8476980-417a-11eb-8e9a-7899eca986dd.png">|





