### PR TITLE
Restrict "is:armor2.0" to armor, and remove is:hascapacity

### DIFF
--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -322,7 +322,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
       row['% Leveled'] = (item.percentComplete * 100).toFixed(0);
     }
     if (item.destinyVersion === 2) {
-      row['Armor2.0'] = Boolean(item.energy);
+      row['Armor2.0'] = Boolean(item.energy) && item.bucket.inArmor;
     }
     row.Locked = item.locked;
     row.Equipped = item.equipped;

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -97,7 +97,6 @@ Array [
   "season",
   "sunsetsafter",
   "sunsetsin",
-  "hascapacity",
   "armor2.0",
   "weapon",
   "armor",

--- a/src/app/search/search-filters/simple.tsx
+++ b/src/app/search/search-filters/simple.tsx
@@ -7,10 +7,10 @@ import { FilterDefinition } from '../filter-types';
 // simple checks against check an attribute found on DimItem
 const simpleFilters: FilterDefinition[] = [
   {
-    keywords: ['hascapacity', 'armor2.0'],
+    keywords: ['armor2.0'],
     description: tl('Filter.Energy'),
     destinyVersion: 2,
-    filter: () => (item: DimItem) => Boolean(item.energy),
+    filter: () => (item: DimItem) => Boolean(item.energy) && item.bucket.inArmor,
   },
   {
     keywords: 'weapon',


### PR DESCRIPTION
Fixes #6349

This makes the armor2.0 search only match armor, and further removes the `is:hascapacity` alias because I'm not sure anyone has ever used it.