### PR TITLE
Try reverse socket order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+### Beta Only
+
+* We continue to experiment with the order of the list-style perk display on weapons - the most important perks tend to be on the rightmost column of the grid, so now we list the perks in right-to-left order from the original grid.
+
 ## 6.43.2 <span className="changelog-date">(2020-12-13)</span>
 
 ## 6.43.1 <span className="changelog-date">(2020-12-13)</span>

--- a/src/app/item-popup/ItemPerksList.tsx
+++ b/src/app/item-popup/ItemPerksList.tsx
@@ -5,7 +5,6 @@ import AppIcon from 'app/shell/icons/AppIcon';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { isKillTrackerSocket } from 'app/utils/item-utils';
 import clsx from 'clsx';
-import _ from 'lodash';
 import { default as React, useState } from 'react';
 import { connect } from 'react-redux';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
@@ -15,9 +14,6 @@ import { InventoryWishListRoll } from '../wishlists/wishlists';
 import styles from './ItemPerksList.m.scss';
 import './ItemSockets.scss';
 import PlugTooltip from './PlugTooltip';
-
-// Reorder sockets to put frames and intrinsics first, since they're most interesting
-const plugCategoryIdentifierOrder = ['frames', 'intrinsics'];
 
 interface ProvidedProps {
   item: DimItem;
@@ -59,12 +55,7 @@ function ItemPerksList({ defs, item, perks, inventoryWishListRoll }: Props) {
     return null;
   }
 
-  const sockets = _.sortBy(
-    perks.sockets,
-    (s) =>
-      s.plugged &&
-      -plugCategoryIdentifierOrder.indexOf(s.plugged.plugDef.plug.plugCategoryIdentifier)
-  );
+  const sockets = [...perks.sockets].reverse();
 
   return (
     <div className={styles.sockets}>


### PR DESCRIPTION
Instead of transposing frame/intrinsics to the front, just reverse the sockets. This still leaves the most important stuff on top, but it's in right-to-left order from the original grid instead of 3,4,1,2.