### PR TITLE
Swap i18next-xhr-backend for i18next-http-backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "fast-equals": "^2.0.0",
     "framer-motion": "^3.1.1",
     "i18next": "^19.0.0",
-    "i18next-xhr-backend": "^3.0.0",
+    "i18next-http-backend": "^1.0.21",
     "idb-keyval": "^3.1.0",
     "immer": "^6.0.9",
     "lodash": "^4.17.8",

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import XHR from 'i18next-xhr-backend';
+import HttpApi from 'i18next-http-backend';
 import de from '../locale/de/dim.json';
 import en from '../locale/dim.json';
 import esMX from '../locale/es-mx/dim.json';
@@ -44,8 +44,7 @@ export function defaultLanguage(): string {
 export function initi18n(): Promise<unknown> {
   return new Promise((resolve, reject) => {
     // See https://github.com/i18next/i18next
-    i18next.use(XHR);
-    i18next.init(
+    i18next.use(HttpApi).init(
       {
         initImmediate: true,
         debug: $DIM_FLAVOR === 'dev',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5857,6 +5857,13 @@ husky@^4.0.6:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
+i18next-http-backend@^1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/i18next-http-backend/-/i18next-http-backend-1.0.21.tgz#cee901b3527dad5165fa91de973b6aa6404c1c37"
+  integrity sha512-UDeHoV2B+31Gr++0KFAVjM5l+SEwePpF6sfDyaDq5ennM9QNJ78PBEMPStwkreEm4h5C8sT7M1JdNQrLcU1Wdg==
+  dependencies:
+    node-fetch "2.6.1"
+
 i18next-scanner@delphiactual/i18next-scanner:
   version "2.11.0"
   resolved "https://codeload.github.com/delphiactual/i18next-scanner/tar.gz/670814e7fc6e730042d51f3b76d5f4ccb0cb3054"
@@ -5881,13 +5888,6 @@ i18next-scanner@delphiactual/i18next-scanner:
     through2 "^3.0.1"
     vinyl "^2.2.0"
     vinyl-fs "^3.0.1"
-
-i18next-xhr-backend@^3.0.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz#769124441461b085291f539d91864e3691199178"
-  integrity sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
 
 i18next@*, i18next@^19.0.0:
   version "19.8.4"


### PR DESCRIPTION
It seems the xhr-backend has been deprecated and the http-backend is supposed to be a drop-in replacement. 

https://github.com/i18next/i18next-xhr-backend
https://github.com/i18next/i18next-http-backend

https://github.com/i18next/i18next-xhr-backend/issues/348#issuecomment-663060275