### PR TITLE
Pipe split multi wishlist URLs

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -967,7 +967,7 @@
     "Clear": "Clear Wish List",
     "ChoosyVoltron": "choosy_voltron",
     "ChoosyVoltronDescription": "choosy_voltron is an auto-updated collection of PvE and PvP wish list rolls from Mercules904 and pandapaxxy, along with some trash list rolls.",
-    "ExternalSource": "Optionally, supply the URL for a wish list",
+    "ExternalSource": "Optionally, supply the URL(s) for a wish list (pipe | seperated)",
     "Header": "Wish List",
     "Import": "Load Wish List Rolls",
     "ImportFailed": "No wish list information found.",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -967,7 +967,7 @@
     "Clear": "Clear Wish List",
     "ChoosyVoltron": "choosy_voltron",
     "ChoosyVoltronDescription": "choosy_voltron is an auto-updated collection of PvE and PvP wish list rolls from Mercules904 and pandapaxxy, along with some trash list rolls.",
-    "ExternalSource": "Optionally, supply the URL(s) for a wish list (pipe | seperated)",
+    "ExternalSource": "Optionally, supply the URL(s) for a wish list (pipe | separated)",
     "Header": "Wish List",
     "Import": "Load Wish List Rolls",
     "ImportFailed": "No wish list information found.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -937,7 +937,7 @@
     "ChoosyVoltron": "choosy_voltron",
     "ChoosyVoltronDescription": "choosy_voltron is an auto-updated collection of PvE and PvP wish list rolls from Mercules904 and pandapaxxy, along with some trash list rolls.",
     "Clear": "Clear Wish List",
-    "ExternalSource": "Optionally, supply the URL(s) for a wish list (pipe | seperated)",
+    "ExternalSource": "Optionally, supply the URL(s) for a wish list (pipe | separated)",
     "Header": "Wish List",
     "Import": "Load Wish List Rolls",
     "ImportError": "Error loading wish list: {{error}}",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -937,7 +937,7 @@
     "ChoosyVoltron": "choosy_voltron",
     "ChoosyVoltronDescription": "choosy_voltron is an auto-updated collection of PvE and PvP wish list rolls from Mercules904 and pandapaxxy, along with some trash list rolls.",
     "Clear": "Clear Wish List",
-    "ExternalSource": "Optionally, supply the URL for a wish list",
+    "ExternalSource": "Optionally, supply the URL(s) for a wish list (pipe | seperated)",
     "Header": "Wish List",
     "Import": "Load Wish List Rolls",
     "ImportError": "Error loading wish list: {{error}}",


### PR DESCRIPTION
Handy if you just care about a subset of wishlists. Or maybe you like to use voltron.txt as a base and want to add a handful of items, but don't want to constantly rebuild your list if voltron is updated.

Uses pipe to split url (that's what d2checklist uses?)

For example, pasting the following (new lines + spaces are trimmed) will just give you PvP rolls by PandaPaxxy.

```
https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/PandaPaxxy/panda_black_armory_pvp_picks.txt|
https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/PandaPaxxy/panda_forsaken_pvp_rolls.txt|
https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/PandaPaxxy/panda_missing_black_armory_pvp.txt|
https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/PandaPaxxy/panda_penumbra_pvp.txt|
https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/PandaPaxxy/panda_salvation_pvp.txt|
https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/PandaPaxxy/panda_season_drifter_pvp.txt|
https://raw.githubusercontent.com/48klocs/dim-wish-list-sources/master/PandaPaxxy/panda_shadowkeep_pvp.txt
```

This resolves #4917