### PR TITLE
Fix version update logic

### DIFF
--- a/build/purge-cloudflare.sh
+++ b/build/purge-cloudflare.sh
@@ -9,4 +9,4 @@ curl -X POST "https://api.cloudflare.com/client/v4/zones/2c34c69276ed0f6eb2b9e15
     -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
     -H "X-Auth-Key: $CLOUDFLARE_KEY" \
     -H "Content-Type: application/json" \
-    --data '{"files":["https://'"$APP_DOMAIN"', "https://'"$APP_DOMAIN"'/index.html", "https://'"$APP_DOMAIN"'/version.json", "https://'"$APP_DOMAIN"'/service-worker.js", "https://'"$APP_DOMAIN"'/return.html", "https://'"$APP_DOMAIN"'/.well-known/assetlinks.json", "https://'"$APP_DOMAIN"'/manifest-webapp-6-2018.json", "https://'"$APP_DOMAIN"'/manifest-webapp-6-2018-ios.json"]}'
+    --data '{"files":["https://'"$APP_DOMAIN"'", "https://'"$APP_DOMAIN"'/index.html", "https://'"$APP_DOMAIN"'/version.json", "https://'"$APP_DOMAIN"'/service-worker.js", "https://'"$APP_DOMAIN"'/return.html", "https://'"$APP_DOMAIN"'/.well-known/assetlinks.json", "https://'"$APP_DOMAIN"'/manifest-webapp-6-2018.json", "https://'"$APP_DOMAIN"'/manifest-webapp-6-2018-ios.json"]}'

--- a/src/app/register-service-worker.test.ts
+++ b/src/app/register-service-worker.test.ts
@@ -1,0 +1,15 @@
+import { isNewVersion } from './register-service-worker';
+
+describe('isNewVersion', () => {
+  it('should recognize two identical versions', async () => {
+    expect(isNewVersion('6.44.0.1000100', '6.44.0.1000100')).toBe(false);
+  });
+
+  it('should newer versions', async () => {
+    expect(isNewVersion('6.45.0.1000100', '6.44.0.1000100')).toBe(true);
+  });
+
+  it('should ignore older versions', async () => {
+    expect(isNewVersion('6.40.0.1000100', '6.44.0.1000100')).toBe(false);
+  });
+});


### PR DESCRIPTION
This fixes a couple problems:

1. The cloudflare purge script was failing because of a missing quote, leading to `version.json` being out of date.
2. Our update logic would then check for an update, and even if that failed, it would signal there was an update. I've changed it to not signal an update unless it actually finds one.