### PR TITLE
Disable issue banner

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -378,7 +378,7 @@ module.exports = (env) => {
         // Enable vendorengrams.xyz integration
         '$featureFlags.vendorEngrams': JSON.stringify(false),
         // Show a banner for supporting a charitable cause
-        '$featureFlags.issueBanner': JSON.stringify(true),
+        '$featureFlags.issueBanner': JSON.stringify(false),
         // Show the triage tab in the item popup
         '$featureFlags.triage': JSON.stringify(env.dev),
         // Drag and drop mobile inspect


### PR DESCRIPTION
This will make it so that we don't include this code (and the several half-megabyte images it includes) in our bundle that precaches for every user. It'll also help prevent the issue we saw where the next time we want to run a campaign, turning it on shows whatever the last campaign was.