### PR TITLE
Another try at loading a subset of components for init load

### DIFF
--- a/src/app/inventory/Inventory.tsx
+++ b/src/app/inventory/Inventory.tsx
@@ -6,6 +6,7 @@ import Stores from 'app/inventory/Stores';
 import MobileInspect from 'app/mobile-inspect/MobileInspect';
 import { isPhonePortraitSelector } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
+import { DestinyComponentType } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { connect } from 'react-redux';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -33,7 +34,6 @@ function mapStateToProps(state: RootState): StoreProps {
   };
 }
 
-/*
 const components = [
   DestinyComponentType.ProfileInventories,
   DestinyComponentType.ProfileCurrencies,
@@ -41,12 +41,14 @@ const components = [
   DestinyComponentType.CharacterInventories,
   DestinyComponentType.CharacterEquipment,
   DestinyComponentType.ItemInstances,
-  DestinyComponentType.ItemSockets, // TODO: remove ItemSockets - currently needed for wishlist perks
+  // Without ItemSockets and ItemReusablePlugs there will be a delay before the thumbs ups.
+  // One solution could ebe to cache the wishlist info between loads.
+  DestinyComponentType.ItemSockets,
+  DestinyComponentType.ItemReusablePlugs,
 ];
-*/
 
 function Inventory({ storesLoaded, account, isPhonePortrait }: Props) {
-  useLoadStores(account, storesLoaded);
+  useLoadStores(account, storesLoaded, components);
 
   if (!storesLoaded) {
     return <ShowPageLoading message={t('Loading.Profile')} />;


### PR DESCRIPTION
It turns out the reason we were seeing some odd results for wishlist items with the selective component loading was because I didn't not realize that `DestinyComponentType.ItemSockets` returns just the active/plugged sockets. 

Our fallback in the code is if you don't have the rest of the sockets for an item instance (`DestinyComponentType.ItemReusablePlugs`) we fall back to the curated roll perks, and combine them with the plugged sockets. 

The logic for that fallback if reusable plugs aren't fetched from the API is here: https://github.com/DestinyItemManager/DIM/blob/1ea0760e9a259ea17f52c9c7b57ce9f6d75368b2/src/app/inventory/store/sockets.ts#L431-L438

In our case the reusablePlugs were undefined, so we were pulling out the other options and adding them to the plugOptions with `addPlugOption` and getting wishlist rolls that matched the plugged perks combined with the curated rolls for the item.

A few options are:
 1. Load socket info on first load (so that the thumbs up immediately show up)
 2. Load socket info on all subsequent loads (thumbs up icons have a slight delay before showing, but page load is faster)
 3. Load socket info on subsequent loads, but have the wishlist information cached locally so that the thumbs up are already there