### PR TITLE
Slight tweak to organizer toolbar styling

### DIFF
--- a/src/app/organizer/ItemActions.m.scss
+++ b/src/app/organizer/ItemActions.m.scss
@@ -7,9 +7,15 @@
   display: inline-block;
 }
 
-.tip,
-.label {
+.tip {
   @media (max-width: 1270px) {
+    display: none;
+  }
+}
+
+.label {
+  padding-left: 3px;
+  @media (max-width: 900px) {
     display: none;
   }
 }

--- a/src/app/organizer/ItemActions.m.scss
+++ b/src/app/organizer/ItemActions.m.scss
@@ -7,7 +7,8 @@
   display: inline-block;
 }
 
-.tip {
+.tip,
+.label {
   @media (max-width: 1270px) {
     display: none;
   }

--- a/src/app/organizer/ItemActions.m.scss.d.ts
+++ b/src/app/organizer/ItemActions.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'actionButton': string;
   'itemActions': string;
+  'label': string;
   'tip': string;
 }
 export const cssExports: CssExports;

--- a/src/app/organizer/ItemActions.tsx
+++ b/src/app/organizer/ItemActions.tsx
@@ -67,7 +67,8 @@ function ItemActions({
         name="lock"
         onClick={() => onLock(true)}
       >
-        <AppIcon icon={lockIcon} /> <span className={styles.label}>{t('Organizer.Lock')}</span>
+        <AppIcon icon={lockIcon} />
+        <span className={styles.label}>{t('Organizer.Lock')}</span>
       </button>
       <button
         type="button"
@@ -76,14 +77,16 @@ function ItemActions({
         name="unlock"
         onClick={() => onLock(false)}
       >
-        <AppIcon icon={unlockedIcon} />{' '}
+        <AppIcon icon={unlockedIcon} />
         <span className={styles.label}>{t('Organizer.Unlock')}</span>
       </button>
       <Dropdown disabled={!itemsAreSelected} options={tagItems} className={styles.actionButton}>
-        <AppIcon icon={tagIcon} /> <span className={styles.label}>{t('Organizer.BulkTag')}</span>
+        <AppIcon icon={tagIcon} />
+        <span className={styles.label}>{t('Organizer.BulkTag')}</span>
       </Dropdown>
       <Dropdown disabled={!itemsAreSelected} options={moveItems} className={styles.actionButton}>
-        <AppIcon icon={moveIcon} /> <span className={styles.label}>{t('Organizer.BulkMove')}</span>
+        <AppIcon icon={moveIcon} />
+        <span className={styles.label}>{t('Organizer.BulkMove')}</span>
       </Dropdown>
       <button
         type="button"
@@ -92,7 +95,7 @@ function ItemActions({
         name="note"
         onClick={noted}
       >
-        <AppIcon icon={stickyNoteIcon} />{' '}
+        <AppIcon icon={stickyNoteIcon} />
         <span className={styles.label}>{t('Organizer.Note')}</span>
       </button>
       <span className={styles.tip}> {t('Organizer.ShiftTip')}</span>

--- a/src/app/organizer/ItemActions.tsx
+++ b/src/app/organizer/ItemActions.tsx
@@ -67,7 +67,7 @@ function ItemActions({
         name="lock"
         onClick={() => onLock(true)}
       >
-        <AppIcon icon={lockIcon} /> {t('Organizer.Lock')}
+        <AppIcon icon={lockIcon} /> <span className={styles.label}>{t('Organizer.Lock')}</span>
       </button>
       <button
         type="button"
@@ -76,13 +76,14 @@ function ItemActions({
         name="unlock"
         onClick={() => onLock(false)}
       >
-        <AppIcon icon={unlockedIcon} /> {t('Organizer.Unlock')}
+        <AppIcon icon={unlockedIcon} />{' '}
+        <span className={styles.label}>{t('Organizer.Unlock')}</span>
       </button>
       <Dropdown disabled={!itemsAreSelected} options={tagItems} className={styles.actionButton}>
-        <AppIcon icon={tagIcon} /> {t('Organizer.BulkTag')}
+        <AppIcon icon={tagIcon} /> <span className={styles.label}>{t('Organizer.BulkTag')}</span>
       </Dropdown>
       <Dropdown disabled={!itemsAreSelected} options={moveItems} className={styles.actionButton}>
-        <AppIcon icon={moveIcon} /> {t('Organizer.BulkMove')}
+        <AppIcon icon={moveIcon} /> <span className={styles.label}>{t('Organizer.BulkMove')}</span>
       </Dropdown>
       <button
         type="button"
@@ -91,7 +92,8 @@ function ItemActions({
         name="note"
         onClick={noted}
       >
-        <AppIcon icon={stickyNoteIcon} /> {t('Organizer.Note')}
+        <AppIcon icon={stickyNoteIcon} />{' '}
+        <span className={styles.label}>{t('Organizer.Note')}</span>
       </button>
       <span className={styles.tip}> {t('Organizer.ShiftTip')}</span>
     </div>

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -23,6 +23,7 @@ $content-cells: 5;
   }
 }
 
+$toolbarHeightWithPadding: 45px + 8px;
 .toolbar {
   grid-column: 1 / -1;
   position: sticky;
@@ -30,7 +31,7 @@ $content-cells: 5;
 
   top: $header-height;
   padding: 8px 8px !important;
-  height: 41px - 16px;
+  height: $toolbarHeightWithPadding - 8px;
 
   border-bottom: none !important;
   > div {
@@ -39,11 +40,11 @@ $content-cells: 5;
     align-items: center;
     position: sticky;
     left: 4px;
+    height: 100%;
     width: 98vw;
     @include horizontal-space-children(4px);
   }
 }
-$toolbarHeight: 41px - 16px + 8px;
 
 .guideLink {
   margin-right: 8px !important;
@@ -64,7 +65,7 @@ $toolbarHeight: 41px - 16px + 8px;
   position: sticky;
   z-index: $header-cells;
 
-  top: $header-height + $toolbarHeight;
+  top: $header-height + $toolbarHeightWithPadding;
   white-space: nowrap;
   padding-top: 4px !important;
 
@@ -109,9 +110,9 @@ $toolbarHeight: 41px - 16px + 8px;
   min-width: 20px;
   left: 0;
   position: sticky;
-  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeight});
+  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeightWithPadding});
   &.header {
-    top: $header-height + $toolbarHeight;
+    top: $header-height + $toolbarHeightWithPadding;
   }
   z-index: $header-cells;
 }
@@ -154,9 +155,9 @@ $toolbarHeight: 41px - 16px + 8px;
   min-width: calc(var(--item-size) * 0.75);
   left: 30px;
   position: sticky;
-  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeight});
+  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeightWithPadding});
   &.header {
-    top: $header-height + $toolbarHeight;
+    top: $header-height + $toolbarHeightWithPadding;
     padding-top: 0;
   }
   z-index: $header-cells;

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -23,7 +23,6 @@ $content-cells: 5;
   }
 }
 
-$toolbarHeightWithPadding: 45px + 8px;
 .toolbar {
   grid-column: 1 / -1;
   position: sticky;
@@ -31,7 +30,7 @@ $toolbarHeightWithPadding: 45px + 8px;
 
   top: $header-height;
   padding: 8px 8px !important;
-  height: $toolbarHeightWithPadding - 8px;
+  height: 41px - 16px;
 
   border-bottom: none !important;
   > div {
@@ -40,11 +39,11 @@ $toolbarHeightWithPadding: 45px + 8px;
     align-items: center;
     position: sticky;
     left: 4px;
-    height: 100%;
     width: 98vw;
     @include horizontal-space-children(4px);
   }
 }
+$toolbarHeight: 41px - 16px + 8px;
 
 .guideLink {
   margin-right: 8px !important;
@@ -65,7 +64,7 @@ $toolbarHeightWithPadding: 45px + 8px;
   position: sticky;
   z-index: $header-cells;
 
-  top: $header-height + $toolbarHeightWithPadding;
+  top: $header-height + $toolbarHeight;
   white-space: nowrap;
   padding-top: 4px !important;
 
@@ -110,9 +109,9 @@ $toolbarHeightWithPadding: 45px + 8px;
   min-width: 20px;
   left: 0;
   position: sticky;
-  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeightWithPadding});
+  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeight});
   &.header {
-    top: $header-height + $toolbarHeightWithPadding;
+    top: $header-height + $toolbarHeight;
   }
   z-index: $header-cells;
 }
@@ -155,9 +154,9 @@ $toolbarHeightWithPadding: 45px + 8px;
   min-width: calc(var(--item-size) * 0.75);
   left: 30px;
   position: sticky;
-  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeightWithPadding});
+  top: calc(#{$header-height} + var(--table-header-height) + #{$toolbarHeight});
   &.header {
-    top: $header-height + $toolbarHeightWithPadding;
+    top: $header-height + $toolbarHeight;
     padding-top: 0;
   }
   z-index: $header-cells;


### PR DESCRIPTION
~Just slightly increased the height so that the buttons can wrap on narrower devices without overlapping the table header~

removed text labels for smaller viewports

This resolves #5574