### PR TITLE
Use margin for positioning sidecar, which fixes tagging menu

### DIFF
--- a/src/app/dim-ui/Select.m.scss
+++ b/src/app/dim-ui/Select.m.scss
@@ -13,6 +13,7 @@
   color: white;
   font-size: 12px;
   z-index: 100;
+  position: absolute;
   &.open {
     outline: 2px solid change-color($orange, $alpha: 0.4) !important;
     margin: 2px;

--- a/src/app/item-popup/DesktopItemActions.tsx
+++ b/src/app/item-popup/DesktopItemActions.tsx
@@ -72,7 +72,10 @@ export default function DesktopItemActions({ item }: { item: DimItem }) {
 
         const top = _.clamp(offset - containerHeight / 2, 0, parent.clientHeight - containerHeight);
 
-        containerRef.current.style.transform = `translateY(${Math.round(top)}px)`;
+        // Originally this used translateY, but that caused menus to not work on Safari.
+        containerRef.current.style.marginTop = `${Math.round(top)}px`;
+
+        // TODO: also don't push it off screen
       }
     };
 


### PR DESCRIPTION
Fixes https://github.com/DestinyItemManager/DIM/issues/6091. For whatever reason, having nested transforms totally confused the positioning on Safari.