### PR TITLE
Show more routes for logged out users

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -120,80 +120,53 @@ function App({
         <PageLoading />
         <ErrorBoundary name="DIM Code">
           <Suspense fallback={<ShowPageLoading message={t('Loading.Code')} />}>
-            {/* In the force-login or force-developer cases, the app can only navigate to /login or /developer */}
-            {$DIM_FLAVOR === 'dev' && needsDeveloper ? (
-              <Switch>
-                <Route path="/developer" exact>
-                  <Developer />
-                </Route>
-                <Route>
+            <Switch>
+              <Route path="/about" component={About} exact />
+              <Route path="/privacy" component={Privacy} exact />
+              <Route path="/whats-new" component={WhatsNew} exact />
+              <Route path="/login" component={Login} exact />
+              <Route path="/settings" component={SettingsPage} exact />
+              {$DIM_FLAVOR === 'dev' && <Route path="/developer" component={Developer} exact />}
+              {needsLogin ? (
+                $DIM_FLAVOR === 'dev' && needsDeveloper ? (
                   <Redirect to={'/developer'} />
-                </Route>
-              </Switch>
-            ) : needsLogin ? (
-              <Switch>
-                <Route path="/login" exact>
-                  <Login />
-                </Route>
-                <Route>
+                ) : (
                   <Redirect to={reauth ? '/login?reauth=true' : '/login'} />
-                </Route>
-              </Switch>
-            ) : (
-              <Switch>
-                <Route path="/about" exact>
-                  <About />
-                </Route>
-                <Route path="/privacy" exact>
-                  <Privacy />
-                </Route>
-                <Route path="/whats-new" exact>
-                  <WhatsNew />
-                </Route>
-                <Route path="/login" exact>
-                  <Login />
-                </Route>
-                <Route path="/settings" exact>
-                  <SettingsPage />
-                </Route>
-                <Route path="/search-history" exact>
-                  <SearchHistory />
-                </Route>
-                <Route
-                  path="/:membershipId(\d+)/d:destinyVersion(1|2)"
-                  render={({ match }) => (
-                    <Destiny
-                      destinyVersion={parseInt(match.params.destinyVersion, 10) as DestinyVersion}
-                      platformMembershipId={match.params.membershipId}
-                    />
-                  )}
-                />
-                {$DIM_FLAVOR === 'dev' && (
-                  <Route path="/developer" exact>
-                    <Developer />
+                )
+              ) : (
+                <>
+                  <Route path="/search-history" component={SearchHistory} exact />
+                  <Route
+                    path="/:membershipId(\d+)/d:destinyVersion(1|2)"
+                    render={({ match }) => (
+                      <Destiny
+                        destinyVersion={parseInt(match.params.destinyVersion, 10) as DestinyVersion}
+                        platformMembershipId={match.params.membershipId}
+                      />
+                    )}
+                  />
+                  <Route
+                    path={[
+                      '/inventory',
+                      '/progress',
+                      '/records',
+                      '/optimizer',
+                      '/organizer',
+                      '/vendors/:vendorId',
+                      '/vendors',
+                      '/record-books',
+                      '/activities',
+                    ]}
+                    exact
+                  >
+                    <AccountRedirectRoute />
                   </Route>
-                )}
-                <Route
-                  path={[
-                    '/inventory',
-                    '/progress',
-                    '/records',
-                    '/optimizer',
-                    '/organizer',
-                    '/vendors/:vendorId',
-                    '/vendors',
-                    '/record-books',
-                    '/activities',
-                  ]}
-                  exact
-                >
-                  <AccountRedirectRoute />
-                </Route>
-                <Route>
-                  <DefaultAccount />
-                </Route>
-              </Switch>
-            )}
+                  <Route>
+                    <DefaultAccount />
+                  </Route>
+                </>
+              )}
+            </Switch>
           </Suspense>
         </ErrorBoundary>
         <NotificationsContainer />

--- a/src/app/developer/Developer.tsx
+++ b/src/app/developer/Developer.tsx
@@ -173,7 +173,7 @@ export default class Developer extends React.Component<{}, State> {
       localStorage.setItem('dimApiKey', dimApiKey);
       localStorage.removeItem('dimApiToken');
       localStorage.removeItem('authorization');
-      window.location.href = `${window.location.origin}/index.html`;
+      window.location.href = window.location.origin;
     } else {
       alert('You need to fill in the whole form');
     }

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -4,7 +4,6 @@ import { settingsSelector } from 'app/dim-api/selectors';
 import ClassIcon from 'app/dim-ui/ClassIcon';
 import { StatTotalToggle } from 'app/dim-ui/CustomStatTotal';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
-import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { clearAllNewItems } from 'app/inventory/actions';
 import { itemTagList } from 'app/inventory/dim-item-info';
@@ -20,10 +19,8 @@ import i18next from 'i18next';
 import exampleArmorImage from 'images/example-armor.jpg';
 import exampleWeaponImage from 'images/example-weapon.jpg';
 import _ from 'lodash';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { getPlatforms } from '../accounts/platforms';
-import { getDefinitions } from '../destiny2/d2-definitions';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import InventoryItem from '../inventory/InventoryItem';
 import { DimItem } from '../inventory/item-types';
@@ -130,11 +127,6 @@ function SettingsPage({
   currentAccount,
   dispatch,
 }: Props) {
-  useEffect(() => {
-    dispatch(getDefinitions());
-    dispatch(getPlatforms());
-  }, [dispatch]);
-
   useLoadStores(currentAccount, storesLoaded);
 
   const onChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement> = (e) => {
@@ -238,14 +230,12 @@ function SettingsPage({
     { id: 'spreadsheets', title: t('Settings.Data') },
   ]);
 
-  if (!storesLoaded) {
-    return <ShowPageLoading message={t('Loading.Profile')} />;
-  }
-
-  const uniqChars = _.uniqBy(
-    stores.filter((s) => !s.isVault),
-    (s) => s.classType
-  );
+  const uniqChars =
+    stores &&
+    _.uniqBy(
+      stores.filter((s) => !s.isVault),
+      (s) => s.classType
+    );
 
   return (
     <PageWithMenu>

--- a/src/manifest-webapp-6-2018.json
+++ b/src/manifest-webapp-6-2018.json
@@ -16,5 +16,5 @@
   "theme_color": "black",
   "background_color": "black",
   "display": "standalone",
-  "start_url": "/?utm_source=homescreen"
+  "start_url": "/index.html?utm_source=homescreen"
 }

--- a/src/manifest-webapp-6-2018.json
+++ b/src/manifest-webapp-6-2018.json
@@ -16,5 +16,5 @@
   "theme_color": "black",
   "background_color": "black",
   "display": "standalone",
-  "start_url": "/index.html?utm_source=homescreen"
+  "start_url": "/?utm_source=homescreen"
 }

--- a/src/return.html
+++ b/src/return.html
@@ -19,7 +19,7 @@
           or let us know what error you're seeing.
         </p>
 
-        <a href="/index.html">Go back to DIM and try again</a>
+        <a href="/">Go back to DIM and try again</a>
       </div>
     </div>
   </body>


### PR DESCRIPTION
Allow users to visit the: About, Privacy, Whats-new, Settings

Settings technically only needs you to be logged into be able to set a custom stat total for each of your unique character types. If you're logged out that section is just blank. I could be convinced to move settings back to logged-in only.

The benefit now is that we can link to the About, Privacy, and What's New pages without them requiring to be logged in.