### PR TITLE
Remove baseStat logic to fix display / sort discrepancy

### DIFF
--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -28,7 +28,6 @@ export default function CompareStat({
   const itemStat = stat.getStat(item);
   const adjustedStatValue = itemStat ? adjustedItemStats?.[itemStat.statHash] : undefined;
 
-  compareBaseStats = Boolean(compareBaseStats && item.bucket.inArmor);
   return (
     <div
       className={clsx({ highlight: stat.id === highlight })}


### PR DESCRIPTION
Fixes #6384 

Since there is no 'armor only' restriction on the show base stats checkbox the user is able to use this on weapons.

When the user decides to sort his weapons based on a stat, the sorting process correctly sorts the weapons based on the base stat, but the CompareStat element decides that it needs to show the actual statistic, causing the sorting to look wrong.

If we want to restrict the sorting to only Armor then we can add this logic to the Compare component, and send it down to the Item/Stat display.