### PR TITLE
Show Deep Stone Crypt Mods in ModPicker

### DIFF
--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -88,7 +88,7 @@ const modSocketMetadata: ModSocketMetadata[] = [
     slotTag: 'deepstonecrypt',
     compatibleModTags: ['deepstonecrypt'],
     socketTypeHashes: [1269555732],
-    compatiblePlugCategoryHashes: [1486918022],
+    compatiblePlugCategoryHashes: [1703496685],
     emptyModSocketHashes: [4055462131],
     emptyModSocketHash: 4055462131,
   },


### PR DESCRIPTION
The wrong category hash was being used. Correcting it causes the category to show in the ModPicker panel.

Fixes #6398

<img width="1078" alt="dscmodsinloadoutopt" src="https://user-images.githubusercontent.com/8553320/103478353-efd51480-4d7a-11eb-90c3-110c776a62ce.png">