### PR TITLE
Fixes an issue with raid mods and selection limits

### DIFF
--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -34,8 +34,10 @@ export default function PickerSectionMods({
     return null;
   }
   const lockedModCost = _.sumBy(locked, (l) => l.modDef.plug.energyCost?.energyCost || 0);
-  const isNotGeneralOrOther =
-    category !== ModPickerCategories.general && category !== ModPickerCategories.other;
+  const isNotGeneralOrOtherOrRaid =
+    category !== ModPickerCategories.general &&
+    category !== ModPickerCategories.other &&
+    category !== ModPickerCategories.raid;
   const allLockedAreAnyEnergy = locked?.every(
     (locked) =>
       !locked.modDef.plug.energyCost ||
@@ -47,7 +49,7 @@ export default function PickerSectionMods({
     if (
       locked &&
       (locked.length >= maximumSelectable ||
-        (isNotGeneralOrOther && lockedModCost + itemEnergyCost > MAX_ARMOR_ENERGY_CAPACITY))
+        (isNotGeneralOrOtherOrRaid && lockedModCost + itemEnergyCost > MAX_ARMOR_ENERGY_CAPACITY))
     ) {
       return true;
     }


### PR DESCRIPTION
Raid mods need to be treated like general or other mods where up to 5 can be picked instead of treating them like they are all going into the same gear piece. Fixes #6404

Same fix approach as #6403 