### PR TITLE
fix event search for non-matching overlays

### DIFF
--- a/src/app/inventory/store/season.ts
+++ b/src/app/inventory/store/season.ts
@@ -1,4 +1,6 @@
+import { D2SourcesToEvent } from 'data/d2/d2-event-info';
 import { D2CalculatedSeason } from 'data/d2/d2-season-info';
+import D2Events from 'data/d2/events.json';
 import D2SeasonBackup from 'data/d2/seasons_backup.json';
 import D2EventFromOverlay from 'data/d2/watermark-to-event.json';
 import D2SeasonFromOverlay from 'data/d2/watermark-to-season.json';
@@ -23,7 +25,9 @@ export function getSeason(item: DimItem): number {
 export function getEvent(item: DimItem) {
   // hiddenOverlay has precedence for event
   const overlay = item.hiddenOverlay || item.iconOverlay;
-  if (overlay) {
-    return Number(D2EventFromOverlay[overlay]);
-  }
+  const nonOverlay = item.source
+    ? D2SourcesToEvent[item.source] || D2Events[item.hash]
+    : D2Events[item.hash];
+
+  return overlay ? Number(D2EventFromOverlay[overlay]) || nonOverlay : nonOverlay;
 }


### PR DESCRIPTION
Allows for matching items like https://data.destinysets.com/i/InventoryItem:1030895163 which do not use the seasonal icon overlay