### PR TITLE
Show a star icon for favorited finishers rather than a lock icon

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Show a star icon for finishers rather than a lock icon.
 
 ## 6.46.0 <span className="changelog-date">(2021-01-03)</span>
 

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React, { useMemo } from 'react';
 import BungieImage from '../dim-ui/BungieImage';
 import { percent } from '../shell/filters';
-import { AppIcon, lockIcon, stickyNoteIcon } from '../shell/icons';
+import { AppIcon, lockIcon, starIcon, stickyNoteIcon } from '../shell/icons';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import BadgeInfo from './BadgeInfo';
 import { TagValue } from './dim-item-info';
@@ -99,7 +99,9 @@ export default function InventoryItem({
         <BadgeInfo item={item} isCapped={isCapped} wishlistRoll={wishlistRoll} />
         {(tag || item.locked || notes) && (
           <div className={styles.icons}>
-            {item.locked && <AppIcon className={styles.icon} icon={lockIcon} />}
+            {item.locked && (
+              <AppIcon className={styles.icon} icon={item.lockable ? lockIcon : starIcon} />
+            )}
             {tag && <TagIcon className={styles.icon} tag={tag} />}
             {notes && <AppIcon className={styles.icon} icon={stickyNoteIcon} />}
           </div>


### PR DESCRIPTION
This is a UX tweak/fix for #6095. Finishers use the same [`ItemState`](https://bungie-net.github.io/multi/schema_Destiny-ItemState.html#schema_Destiny-ItemState) field as locked items (where `Locked` means "favorited") but their `lockable` value is set to `false`.

Example screencap of a favorited finisher using this change:

![image](https://user-images.githubusercontent.com/650810/103618492-e8317f00-4ee4-11eb-9b3a-43bb66c98e3e.png)
