### PR TITLE
Support steam overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   },
   "homepage": "https://destinyitemmanager.com",
   "browserslist": [
-    "last 2 Chrome versions",
+    "Chrome >= 79",
     "last 2 ChromeAndroid versions",
     "last 2 FirefoxAndroid versions",
     "last 2 Firefox versions",
     "Firefox ESR",
     "last 2 Safari versions",
-    "iOS >= 11",
+    "iOS >= 12",
     "last 2 Edge versions",
     "last 2 Opera versions"
   ],

--- a/src/browsercheck.test.ts
+++ b/src/browsercheck.test.ts
@@ -59,6 +59,11 @@ test.each([
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36',
     false,
   ],
+  [
+    'Steam Overlay',
+    'Mozilla/5.0 (Windows; U; Windows NT 10.0; en-US; Valve Steam GameOverlay/1608507519; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36',
+    true,
+  ],
 ])('%s: User agent %s, supported: %s', (_, userAgent, shouldBeSupported) => {
   expect(isSupported(browsersSupported, userAgent)).toStrictEqual(shouldBeSupported);
 });


### PR DESCRIPTION
This updates our browser compatibility versions:

1. Pin to Chrome 79+ since that's the newest Steam overlay and lots of people use it even though it's not supported.
2. Bump iOS requirement to 12 - all devices which can install iOS 11 can install iOS 12, and iOS 11 is no longer supported by Apple.