### PR TITLE
Data driven mods in optimiser

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -35,14 +35,7 @@ import { useProcess } from './hooks/useProcess';
 import styles from './LoadoutBuilder.m.scss';
 import { LoadoutBuilderState, useLbState } from './loadoutBuilderReducer';
 import { filterItems } from './preProcessFilter';
-import {
-  ItemsByBucket,
-  LockedArmor2Mod,
-  statHashes,
-  statHashToType,
-  statKeys,
-  StatTypes,
-} from './types';
+import { ItemsByBucket, statHashes, statHashToType, statKeys, StatTypes } from './types';
 import { isLoadoutBuilderItem } from './utils';
 
 interface ProvidedProps {
@@ -210,10 +203,9 @@ function LoadoutBuilder({
           return stat;
         })
       ),
-      mods: Object.values(lockedArmor2Mods)
-        .flat()
-        .filter((x: LockedArmor2Mod | undefined): x is LockedArmor2Mod => Boolean(x))
-        .map((m) => m.modDef.hash),
+      mods: Object.values(lockedArmor2Mods).flatMap(
+        (mods) => mods?.map((m) => m.modDef.hash) || []
+      ),
       query: searchQuery,
       assumeMasterworked: assumeMasterwork,
     }),

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -35,7 +35,14 @@ import { useProcess } from './hooks/useProcess';
 import styles from './LoadoutBuilder.m.scss';
 import { LoadoutBuilderState, useLbState } from './loadoutBuilderReducer';
 import { filterItems } from './preProcessFilter';
-import { ItemsByBucket, statHashes, statHashToType, statKeys, StatTypes } from './types';
+import {
+  ItemsByBucket,
+  LockedArmor2Mod,
+  statHashes,
+  statHashToType,
+  statKeys,
+  StatTypes,
+} from './types';
 import { isLoadoutBuilderItem } from './utils';
 
 interface ProvidedProps {
@@ -205,6 +212,7 @@ function LoadoutBuilder({
       ),
       mods: Object.values(lockedArmor2Mods)
         .flat()
+        .filter((x: LockedArmor2Mod | undefined): x is LockedArmor2Mod => Boolean(x))
         .map((m) => m.modDef.hash),
       query: searchQuery,
       assumeMasterworked: assumeMasterwork,

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -324,7 +324,6 @@ function LoadoutBuilder({
               classType={selectedStore.classType}
               lockedArmor2Mods={lockedArmor2Mods}
               initialQuery={modPicker.initialQuery}
-              filterLegacy={modPicker.filterLegacy}
               lbDispatch={lbDispatch}
               onClose={() => lbDispatch({ type: 'closeModPicker' })}
             />,

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -141,12 +141,13 @@ function LockArmorAndPerks({
     }
   };
 
-  const onArmor2ModClicked = (item: LockedArmor2Mod) => {
+  const onArmor2ModClicked = (mod: LockedArmor2Mod) => {
+    const plugCategoryHash = mod.modDef.plug.plugCategoryHash;
     lbDispatch({
       type: 'lockedArmor2ModsChanged',
       lockedArmor2Mods: {
         ...lockedArmor2Mods,
-        [item.category]: lockedArmor2Mods[item.category]?.filter((ex) => ex.key !== item.key),
+        [plugCategoryHash]: lockedArmor2Mods[plugCategoryHash]?.filter((ex) => ex.key !== mod.key),
       },
     });
   };

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 import LoadoutBucketDropTarget from '../locked-armor/LoadoutBucketDropTarget';
 import {
+  knownModPlugCategoryHashes,
   LockableBuckets,
   LockedArmor2Mod,
   LockedArmor2ModMap,
@@ -23,7 +24,6 @@ import {
   LockedItemType,
   LockedMap,
   LockedPerk,
-  ModPickerCategories,
 } from '../types';
 import { addLockedItem, isLoadoutBuilderItem, removeLockedItem } from '../utils';
 import styles from './LockArmorAndPerks.m.scss';
@@ -175,10 +175,15 @@ function LockArmorAndPerks({
     _.sortBy(items, (i: LockedItemCase) => order.indexOf(i.bucket.hash))
   );
 
-  const modOrder = Object.values(ModPickerCategories);
-  const flatLockedArmor2Mods: LockedArmor2Mod[] = modOrder
-    .flatMap((category) => lockedArmor2Mods[category])
-    .filter(Boolean);
+  let flatLockedArmor2Mods: LockedArmor2Mod[] = knownModPlugCategoryHashes.flatMap(
+    (plugCategoryHash) => lockedArmor2Mods[plugCategoryHash] || []
+  );
+
+  for (const [plugCategoryHashAsString, mods] of Object.entries(lockedArmor2Mods)) {
+    if (mods && !knownModPlugCategoryHashes.includes(Number(plugCategoryHashAsString))) {
+      flatLockedArmor2Mods = flatLockedArmor2Mods.concat(mods);
+    }
+  }
 
   const storeIds = stores.filter((s) => !s.isVault).map((s) => s.id);
   const bucketTypes = buckets.byCategory.Armor.map((b) => b.type!);

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -178,7 +178,7 @@ function ModPicker({
       const { plugCategoryHash } = mod.modDef.plug;
       setLockedArmor2ModsInternal((oldState) => {
         const firstIndex =
-          oldState[plugCategoryHash]?.findIndex((li) => li.modDef.hash === mod.modDef.hash) || -1;
+          oldState[plugCategoryHash]?.findIndex((li) => li.modDef.hash === mod.modDef.hash) ?? -1;
 
         if (firstIndex >= 0) {
           const newState = [...(oldState[plugCategoryHash] || [])];

--- a/src/app/loadout-builder/filter/ModPickerFooter.tsx
+++ b/src/app/loadout-builder/filter/ModPickerFooter.tsx
@@ -2,22 +2,27 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import React from 'react';
-import { LockedArmor2Mod, LockedArmor2ModMap, ModPickerCategory } from '../types';
+import { LockedArmor2Mod, LockedArmor2ModMap } from '../types';
 import LockedArmor2ModIcon from './LockedArmor2ModIcon';
 import styles from './ModPickerFooter.m.scss';
 
 interface Props {
   defs: D2ManifestDefinitions;
-  categoryOrder: { category: ModPickerCategory; translatedName: string }[];
+  groupOrder: { plugCategoryHashes: number[] }[];
   isPhonePortrait: boolean;
   lockedArmor2Mods: LockedArmor2ModMap;
   onSubmit(event: React.FormEvent | KeyboardEvent): void;
   onModSelected(item: LockedArmor2Mod): void;
 }
 
-function ModPickerFooter(props: Props) {
-  const { defs, isPhonePortrait, categoryOrder, lockedArmor2Mods, onSubmit, onModSelected } = props;
-
+function ModPickerFooter({
+  defs,
+  isPhonePortrait,
+  groupOrder,
+  lockedArmor2Mods,
+  onSubmit,
+  onModSelected,
+}: Props) {
   useHotkey('enter', t('LB.SelectMods'), onSubmit);
 
   return (
@@ -29,20 +34,22 @@ function ModPickerFooter(props: Props) {
         </button>
       </div>
       <div className={styles.selectedMods}>
-        {categoryOrder.map(
-          (category) =>
-            lockedArmor2Mods[category.category] && (
-              <React.Fragment key={category.category}>
-                {lockedArmor2Mods[category.category]?.map((lockedItem) => (
-                  <LockedArmor2ModIcon
-                    key={lockedItem.key}
-                    item={lockedItem}
-                    defs={defs}
-                    onModClicked={() => onModSelected(lockedItem)}
-                  />
-                ))}
-              </React.Fragment>
-            )
+        {groupOrder.map((group) =>
+          group.plugCategoryHashes.map(
+            (pch) =>
+              pch in lockedArmor2Mods && (
+                <React.Fragment key={pch}>
+                  {lockedArmor2Mods[pch]?.map((lockedItem) => (
+                    <LockedArmor2ModIcon
+                      key={lockedItem.key}
+                      item={lockedItem}
+                      defs={defs}
+                      onModClicked={() => onModSelected(lockedItem)}
+                    />
+                  ))}
+                </React.Fragment>
+              )
+          )
         )}
       </div>
     </div>

--- a/src/app/loadout-builder/filter/ModPickerHeader.tsx
+++ b/src/app/loadout-builder/filter/ModPickerHeader.tsx
@@ -1,19 +1,23 @@
 import { t } from 'app/i18next-t';
 import { AppIcon, searchIcon } from 'app/shell/icons';
 import React, { ChangeEvent } from 'react';
-import { ModPickerCategory } from '../types';
 import styles from './ModPickerHeader.m.scss';
 
 interface Props {
-  categoryOrder?: { category: ModPickerCategory; translatedName: string }[];
+  groupOrder: { plugCategoryHashes: number[]; title: string }[];
   isPhonePortrait: boolean;
   query: string;
   onSearchChange(event: ChangeEvent<HTMLInputElement>): void;
-  scrollToBucket(bucketOrSeasonal: number | string): void;
+  scrollToBucket(plugCategoryHashes: number[]): void;
 }
 
-function ModPickerHeader(props: Props) {
-  const { categoryOrder, isPhonePortrait, query, onSearchChange, scrollToBucket } = props;
+function ModPickerHeader({
+  groupOrder,
+  isPhonePortrait,
+  query,
+  onSearchChange,
+  scrollToBucket,
+}: Props) {
   // On iOS at least, focusing the keyboard pushes the content off the screen
   const autoFocus =
     !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
@@ -39,13 +43,13 @@ function ModPickerHeader(props: Props) {
         </div>
       </div>
       <div className={styles.tabs}>
-        {categoryOrder?.map((category) => (
+        {groupOrder?.map(({ plugCategoryHashes, title }) => (
           <div
-            key={category.category}
+            key={title}
             className={styles.tab}
-            onClick={() => scrollToBucket(category.category)}
+            onClick={() => scrollToBucket(plugCategoryHashes)}
           >
-            {category.translatedName}
+            {title}
           </div>
         ))}
       </div>

--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -4,7 +4,12 @@ import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
 import { SelectableArmor2Mod } from '../locked-armor/SelectableBungieImage';
-import { LockedArmor2Mod, ModPickerCategories, ModPickerCategory } from '../types';
+import {
+  knownModPlugCategoryHashes,
+  LockedArmor2Mod,
+  raidPlugCategoryHashes,
+  slotSpecificPlugCategoryHashes,
+} from '../types';
 import styles from './PickerSection.m.scss';
 
 /** Slot specific mods can have at most 2 mods. */
@@ -17,7 +22,7 @@ export default function PickerSectionMods({
   mods,
   locked,
   title,
-  category,
+  plugCategoryHashes,
   onModSelected,
   onModRemoved,
 }: {
@@ -25,7 +30,7 @@ export default function PickerSectionMods({
   mods: readonly LockedArmor2Mod[];
   locked: readonly LockedArmor2Mod[];
   title: string;
-  category: ModPickerCategory;
+  plugCategoryHashes: number[];
   onModSelected(mod: LockedArmor2Mod);
   onModRemoved(mod: LockedArmor2Mod);
 }) {
@@ -33,15 +38,15 @@ export default function PickerSectionMods({
     return null;
   }
   const lockedModCost = _.sumBy(locked, (l) => l.modDef.plug.energyCost?.energyCost || 0);
-  const isSlotSpecificCategory =
-    category === ModPickerCategories.helmet ||
-    category === ModPickerCategories.gauntlets ||
-    category === ModPickerCategories.chest ||
-    category === ModPickerCategories.leg ||
-    category === ModPickerCategories.classitem;
+  const isSlotSpecificCategory = Boolean(
+    _.intersection(slotSpecificPlugCategoryHashes, plugCategoryHashes).length
+  );
 
-  const splitByItemTypeDisplayName =
-    category === ModPickerCategories.other || category === ModPickerCategories.raid;
+  // Has a raid mod plug category hash or no known hashes, this case is combat and legacy.
+  const splitByItemTypeDisplayName = Boolean(
+    _.intersection(raidPlugCategoryHashes, plugCategoryHashes).length ||
+      !_.intersection(knownModPlugCategoryHashes, plugCategoryHashes).length
+  );
 
   /**
    * Figures out whether you should be able to select a mod. Different rules apply for slot specific
@@ -74,7 +79,7 @@ export default function PickerSectionMods({
     : { nogroup: mods };
 
   return (
-    <div className={styles.bucket} id={`mod-picker-section-${category}`}>
+    <div className={styles.bucket} id={`mod-picker-section-${plugCategoryHashes.join('-')}`}>
       <div className={styles.header}>{title}</div>
       {Object.entries(modGroups).map(([subTitle, mods]) => (
         <div key={subTitle}>

--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -56,9 +56,8 @@ export default function PickerSectionMods({
   } else if (_.intersection(raidPlugCategoryHashes, plugCategoryHashes).length) {
     associatedLockedMods = raidPlugCategoryHashes.flatMap((hash) => locked[hash] || []);
   } else {
-    associatedLockedMods = Object.entries(locked).flatMap(
-      ([plugCategoryHash, mods]) =>
-        (!knownModPlugCategoryHashes.includes(Number(plugCategoryHash)) && mods) || []
+    associatedLockedMods = Object.entries(locked).flatMap(([plugCategoryHash, mods]) =>
+      mods && !knownModPlugCategoryHashes.includes(Number(plugCategoryHash)) ? mods : []
     );
   }
 

--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -1,5 +1,8 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
+import {
+  armor2PlugCategoryHashesByName,
+  MAX_ARMOR_ENERGY_CAPACITY,
+} from 'app/search/d2-known-values';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
@@ -7,6 +10,7 @@ import { SelectableArmor2Mod } from '../locked-armor/SelectableBungieImage';
 import {
   knownModPlugCategoryHashes,
   LockedArmor2Mod,
+  LockedArmor2ModMap,
   raidPlugCategoryHashes,
   slotSpecificPlugCategoryHashes,
 } from '../types';
@@ -28,7 +32,7 @@ export default function PickerSectionMods({
 }: {
   defs: D2ManifestDefinitions;
   mods: readonly LockedArmor2Mod[];
-  locked: readonly LockedArmor2Mod[];
+  locked: LockedArmor2ModMap;
   title: string;
   plugCategoryHashes: number[];
   onModSelected(mod: LockedArmor2Mod);
@@ -37,16 +41,32 @@ export default function PickerSectionMods({
   if (!mods.length) {
     return null;
   }
-  const lockedModCost = _.sumBy(locked, (l) => l.modDef.plug.energyCost?.energyCost || 0);
+
   const isSlotSpecificCategory = Boolean(
     _.intersection(slotSpecificPlugCategoryHashes, plugCategoryHashes).length
   );
 
-  // Has a raid mod plug category hash or no known hashes, this case is combat and legacy.
-  const splitByItemTypeDisplayName = Boolean(
-    _.intersection(raidPlugCategoryHashes, plugCategoryHashes).length ||
-      !_.intersection(knownModPlugCategoryHashes, plugCategoryHashes).length
-  );
+  let associatedLockedMods: LockedArmor2Mod[] = [];
+
+  if (
+    isSlotSpecificCategory ||
+    plugCategoryHashes.includes(armor2PlugCategoryHashesByName.general)
+  ) {
+    associatedLockedMods = plugCategoryHashes.flatMap((hash) => locked[hash] || []);
+  } else if (_.intersection(raidPlugCategoryHashes, plugCategoryHashes).length) {
+    associatedLockedMods = raidPlugCategoryHashes.flatMap((hash) => locked[hash] || []);
+  } else {
+    associatedLockedMods = Object.entries(locked).flatMap(
+      ([plugCategoryHash, mods]) =>
+        (!knownModPlugCategoryHashes.includes(Number(plugCategoryHash)) && mods) || []
+    );
+  }
+
+  // We only care about this for slot specific mods and it is used in isModSelectable. It is calculated here
+  // so it is only done once per render.
+  const lockedModCost = isSlotSpecificCategory
+    ? _.sumBy(associatedLockedMods, (l) => l.modDef.plug.energyCost?.energyCost || 0)
+    : 0;
 
   /**
    * Figures out whether you should be able to select a mod. Different rules apply for slot specific
@@ -59,48 +79,41 @@ export default function PickerSectionMods({
       const modEnergyType = mod.modDef.plug.energyCost?.energyType || DestinyEnergyType.Any;
 
       return (
-        locked.length < MAX_SLOT_SPECIFIC_MODS &&
+        associatedLockedMods.length < MAX_SLOT_SPECIFIC_MODS &&
         lockedModCost + modCost <= MAX_ARMOR_ENERGY_CAPACITY &&
         (modEnergyType === DestinyEnergyType.Any || // Any energy works with everything
-          locked.some((l) => l.modDef.plug.energyCost?.energyType === modEnergyType) || // Matches some other enery
-          locked.every(
+          associatedLockedMods.some(
+            (l) => l.modDef.plug.energyCost?.energyType === modEnergyType
+          ) || // Matches some other enery
+          associatedLockedMods.every(
             (l) =>
               (l.modDef.plug.energyCost?.energyType || DestinyEnergyType.Any) ===
               DestinyEnergyType.Any
           )) // If every thing else is Any we are good
       );
     } else {
-      return locked.length < MAX_SLOT_INDEPENDENT_MODS;
+      return associatedLockedMods.length < MAX_SLOT_INDEPENDENT_MODS;
     }
   };
-
-  const modGroups = splitByItemTypeDisplayName
-    ? _.groupBy(mods, (mod) => mod.modDef.itemTypeDisplayName)
-    : { nogroup: mods };
 
   return (
     <div className={styles.bucket} id={`mod-picker-section-${plugCategoryHashes.join('-')}`}>
       <div className={styles.header}>{title}</div>
-      {Object.entries(modGroups).map(([subTitle, mods]) => (
-        <div key={subTitle}>
-          {subTitle !== 'nogroup' && <div className={styles.subheader}>{subTitle}</div>}
-          <div className={styles.items}>
-            {mods.map((item) => (
-              <SelectableArmor2Mod
-                key={item.modDef.hash}
-                defs={defs}
-                selected={Boolean(
-                  locked.some((lockedItem) => lockedItem.modDef.hash === item.modDef.hash)
-                )}
-                mod={item}
-                selectable={isModSelectable(item)}
-                onModSelected={onModSelected}
-                onModRemoved={onModRemoved}
-              />
-            ))}
-          </div>
-        </div>
-      ))}
+      <div className={styles.items}>
+        {mods.map((item) => (
+          <SelectableArmor2Mod
+            key={item.modDef.hash}
+            defs={defs}
+            selected={Boolean(
+              associatedLockedMods.some((lockedItem) => lockedItem.modDef.hash === item.modDef.hash)
+            )}
+            mod={item}
+            selectable={isModSelectable(item)}
+            onModSelected={onModSelected}
+            onModRemoved={onModRemoved}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -9,7 +9,7 @@ import { DimItem, PluggableInventoryItemDefinition } from '../../inventory/item-
 import LoadoutBuilderItem from '../LoadoutBuilderItem';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 import { matchLockedItem } from '../preProcessFilter';
-import { LockedArmor2Mod, LockedItemType, ModPickerCategory, StatTypes } from '../types';
+import { LockedArmor2Mod, LockedItemType, raidPlugCategoryHashes, StatTypes } from '../types';
 import { armor2ModPlugCategoriesTitles, generateMixesFromPerks } from '../utils';
 import styles from './GeneratedSetItem.m.scss';
 import Sockets from './Sockets';
@@ -82,18 +82,21 @@ export default function GeneratedSetItem({
     }
   }
 
-  const onSocketClick = (
-    plugDef: PluggableInventoryItemDefinition,
-    category?: ModPickerCategory
-  ) => {
-    if (category) {
+  const onSocketClick = (plugDef: PluggableInventoryItemDefinition) => {
+    const { plugCategoryHash } = plugDef.plug;
+    const initialQuery =
+      t(armor2ModPlugCategoriesTitles[plugCategoryHash]) ||
+      (raidPlugCategoryHashes.includes(plugCategoryHash) &&
+        t(armor2ModPlugCategoriesTitles.raid)) ||
+      t(armor2ModPlugCategoriesTitles.other);
+
+    if (initialQuery) {
       // TODO this will currently show legacy mods if you click a combat
-      const initialQuery = t(armor2ModPlugCategoriesTitles[category]);
       lbDispatch({
         type: 'openModPicker',
         initialQuery,
         filterLegacy:
-          category === 'other' &&
+          initialQuery === t(armor2ModPlugCategoriesTitles.other) &&
           combatCompatiblePlugCategoryHashes.includes(plugDef.plug.plugCategoryHash),
       });
     } else {

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -1,16 +1,16 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { showItemPicker } from 'app/item-picker/item-picker';
-import { combatCompatiblePlugCategoryHashes } from 'app/search/specialty-modslots';
 import { AppIcon, faRandom, lockIcon } from 'app/shell/icons';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React, { Dispatch, useMemo } from 'react';
 import { DimItem, PluggableInventoryItemDefinition } from '../../inventory/item-types';
 import LoadoutBuilderItem from '../LoadoutBuilderItem';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
 import { matchLockedItem } from '../preProcessFilter';
-import { LockedArmor2Mod, LockedItemType, raidPlugCategoryHashes, StatTypes } from '../types';
-import { armor2ModPlugCategoriesTitles, generateMixesFromPerks } from '../utils';
+import { LockedArmor2Mod, LockedItemType, StatTypes } from '../types';
+import { generateMixesFromPerks } from '../utils';
 import styles from './GeneratedSetItem.m.scss';
 import Sockets from './Sockets';
 
@@ -82,25 +82,21 @@ export default function GeneratedSetItem({
     }
   }
 
-  const onSocketClick = (plugDef: PluggableInventoryItemDefinition) => {
+  const onSocketClick = (
+    plugDef: PluggableInventoryItemDefinition,
+    plugCategoryHashWhitelist?: number[]
+  ) => {
     const { plugCategoryHash } = plugDef.plug;
-    const initialQuery =
-      t(armor2ModPlugCategoriesTitles[plugCategoryHash]) ||
-      (raidPlugCategoryHashes.includes(plugCategoryHash) &&
-        t(armor2ModPlugCategoriesTitles.raid)) ||
-      t(armor2ModPlugCategoriesTitles.other);
 
-    if (initialQuery) {
-      // TODO this will currently show legacy mods if you click a combat
+    if (plugCategoryHash === PlugCategoryHashes.Intrinsics) {
+      lbDispatch({ type: 'openPerkPicker', initialQuery: plugDef.displayProperties.name });
+    } else {
       lbDispatch({
         type: 'openModPicker',
-        initialQuery,
-        filterLegacy:
-          initialQuery === t(armor2ModPlugCategoriesTitles.other) &&
-          combatCompatiblePlugCategoryHashes.includes(plugDef.plug.plugCategoryHash),
+        initialQuery:
+          plugCategoryHashWhitelist &&
+          `plugCategoryHash:in:${JSON.stringify(plugCategoryHashWhitelist)}`,
       });
-    } else {
-      lbDispatch({ type: 'openPerkPicker', initialQuery: plugDef.displayProperties.name });
     }
   };
 

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -5,12 +5,14 @@ import { t } from 'app/i18next-t';
 import { Loadout } from 'app/loadout/loadout-types';
 import { newLoadout } from 'app/loadout/loadout-utils';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
+import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import _ from 'lodash';
 import React, { Dispatch, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { List, WindowScroller } from 'react-virtualized';
 import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
-import { ArmorSet, LockedArmor2ModMap, LockedMap, ModPickerCategories, StatTypes } from '../types';
+import { getOtherMods, getRaidMods } from '../mod-utils';
+import { ArmorSet, LockedArmor2ModMap, LockedMap, StatTypes } from '../types';
 import { someModHasEnergyRequirement } from '../utils';
 import GeneratedSet from './GeneratedSet';
 import styles from './GeneratedSets.m.scss';
@@ -105,15 +107,15 @@ export default function GeneratedSets({
 
   let groupingDescription;
 
-  if (
-    someModHasEnergyRequirement(lockedArmor2Mods[ModPickerCategories.other]) ||
-    (someModHasEnergyRequirement(lockedArmor2Mods[ModPickerCategories.general]) &&
-      lockedArmor2Mods[ModPickerCategories.other].length)
-  ) {
+  const generalMods = lockedArmor2Mods[armor2PlugCategoryHashesByName.general];
+  const otherMods = getOtherMods(lockedArmor2Mods);
+  const raidMods = getRaidMods(lockedArmor2Mods);
+
+  if (someModHasEnergyRequirement([...otherMods, ...raidMods])) {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStatsEnergyModSlot');
-  } else if (lockedArmor2Mods[ModPickerCategories.other].length) {
+  } else if (otherMods.length || raidMods.length) {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStatsModSlot');
-  } else if (someModHasEnergyRequirement(lockedArmor2Mods[ModPickerCategories.general])) {
+  } else if (generalMods && someModHasEnergyRequirement(generalMods)) {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStatsEnergy');
   } else {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStats');

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -5,13 +5,15 @@ import { t } from 'app/i18next-t';
 import { Loadout } from 'app/loadout/loadout-types';
 import { newLoadout } from 'app/loadout/loadout-utils';
 import { editLoadout } from 'app/loadout/LoadoutDrawer';
-import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
+import {
+  armor2PlugCategoryHashes,
+  armor2PlugCategoryHashesByName,
+} from 'app/search/d2-known-values';
 import _ from 'lodash';
 import React, { Dispatch, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { List, WindowScroller } from 'react-virtualized';
 import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
-import { getOtherMods, getRaidMods } from '../mod-utils';
 import { ArmorSet, LockedArmor2ModMap, LockedMap, StatTypes } from '../types';
 import { someModHasEnergyRequirement } from '../utils';
 import GeneratedSet from './GeneratedSet';
@@ -107,15 +109,18 @@ export default function GeneratedSets({
 
   let groupingDescription;
 
-  const generalMods = lockedArmor2Mods[armor2PlugCategoryHashesByName.general];
-  const otherMods = getOtherMods(lockedArmor2Mods);
-  const raidMods = getRaidMods(lockedArmor2Mods);
+  const generalMods = lockedArmor2Mods[armor2PlugCategoryHashesByName.general] || [];
+  const raidCombatAndLegacyMods = Object.entries(
+    lockedArmor2Mods
+  ).flatMap(([plugCategoryHash, mods]) =>
+    !armor2PlugCategoryHashes.includes(Number(plugCategoryHash)) && mods ? mods : []
+  );
 
-  if (someModHasEnergyRequirement([...otherMods, ...raidMods])) {
+  if (someModHasEnergyRequirement(raidCombatAndLegacyMods)) {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStatsEnergyModSlot');
-  } else if (otherMods.length || raidMods.length) {
+  } else if (raidCombatAndLegacyMods.length) {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStatsModSlot');
-  } else if (generalMods && someModHasEnergyRequirement(generalMods)) {
+  } else if (someModHasEnergyRequirement(generalMods)) {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStatsEnergy');
   } else {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStats');

--- a/src/app/loadout-builder/generated-sets/Sockets.tsx
+++ b/src/app/loadout-builder/generated-sets/Sockets.tsx
@@ -21,7 +21,7 @@ interface Props {
   item: DimItem;
   lockedMods?: LockedArmor2Mod[];
   defs: D2ManifestDefinitions;
-  onSocketClick?(plugDef: PluggableInventoryItemDefinition): void;
+  onSocketClick?(plugDef: PluggableInventoryItemDefinition, whitelist: number[]): void;
 }
 
 function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
@@ -29,7 +29,7 @@ function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
     return null;
   }
 
-  const modsAndPerks: PluggableInventoryItemDefinition[] = [];
+  const modsAndWhitelist: { plugDef: PluggableInventoryItemDefinition; whitelist: number[] }[] = [];
   const modsToUse = lockedMods ? [...lockedMods] : [];
 
   for (const socket of item.sockets?.allSockets || []) {
@@ -55,20 +55,23 @@ function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
       isPluggableItem(toSave) &&
       !undesireablePlugs.includes(toSave.plug.plugCategoryHash)
     ) {
-      modsAndPerks.push(toSave);
+      modsAndWhitelist.push({
+        plugDef: toSave,
+        whitelist: socketType.plugWhitelist.map((plug) => plug.categoryHash),
+      });
     }
   }
 
   return (
     <>
       <div className={styles.lockedItems}>
-        {modsAndPerks.map((plugDef, index) => (
+        {modsAndWhitelist.map(({ plugDef, whitelist }, index) => (
           <Mod
             key={index}
             gridColumn={(index % 2) + 1}
             plugDef={plugDef}
             defs={defs}
-            onClick={onSocketClick ? () => onSocketClick?.(plugDef) : undefined}
+            onClick={onSocketClick ? () => onSocketClick?.(plugDef, whitelist) : undefined}
           />
         ))}
       </div>

--- a/src/app/loadout-builder/generated-sets/Sockets.tsx
+++ b/src/app/loadout-builder/generated-sets/Sockets.tsx
@@ -4,8 +4,7 @@ import { isPluggableItem } from 'app/inventory/store/sockets';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
-import { LockedArmor2Mod, ModPickerCategory } from '../types';
-import { getModPickerCategoryFromPlugCategoryHash } from '../utils';
+import { LockedArmor2Mod } from '../types';
 import Mod from './Mod';
 import styles from './Sockets.m.scss';
 
@@ -18,16 +17,11 @@ const undesireablePlugs = [
   PlugCategoryHashes.V460PlugsArmorMasterworksStatResistance4,
 ];
 
-interface PlugAndCategory {
-  plugDef: PluggableInventoryItemDefinition;
-  category?: ModPickerCategory;
-}
-
 interface Props {
   item: DimItem;
   lockedMods?: LockedArmor2Mod[];
   defs: D2ManifestDefinitions;
-  onSocketClick?(plugDef: PluggableInventoryItemDefinition, category?: ModPickerCategory): void;
+  onSocketClick?(plugDef: PluggableInventoryItemDefinition): void;
 }
 
 function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
@@ -35,7 +29,7 @@ function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
     return null;
   }
 
-  const modsAndPerks: PlugAndCategory[] = [];
+  const modsAndPerks: PluggableInventoryItemDefinition[] = [];
   const modsToUse = lockedMods ? [...lockedMods] : [];
 
   for (const socket of item.sockets?.allSockets || []) {
@@ -61,23 +55,20 @@ function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
       isPluggableItem(toSave) &&
       !undesireablePlugs.includes(toSave.plug.plugCategoryHash)
     ) {
-      modsAndPerks.push({
-        plugDef: toSave,
-        category: getModPickerCategoryFromPlugCategoryHash(toSave.plug.plugCategoryHash),
-      });
+      modsAndPerks.push(toSave);
     }
   }
 
   return (
     <>
       <div className={styles.lockedItems}>
-        {modsAndPerks.map(({ plugDef, category }, index) => (
+        {modsAndPerks.map((plugDef, index) => (
           <Mod
             key={index}
             gridColumn={(index % 2) + 1}
             plugDef={plugDef}
             defs={defs}
-            onClick={onSocketClick ? () => onSocketClick?.(plugDef, category) : undefined}
+            onClick={onSocketClick ? () => onSocketClick?.(plugDef) : undefined}
           />
         ))}
       </div>

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -1,11 +1,13 @@
 import { DimItem } from 'app/inventory/item-types';
-import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
+import {
+  armor2PlugCategoryHashes,
+  armor2PlugCategoryHashesByName,
+} from 'app/search/d2-known-values';
 import { getSpecialtySocketMetadatas } from 'app/utils/item-utils';
 import { infoLog } from 'app/utils/log';
 import { releaseProxy, wrap } from 'comlink';
 import _ from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
-import { getOtherMods, getRaidMods } from '../mod-utils';
 import {
   getTotalModStatChanges,
   hydrateArmorSet,
@@ -17,6 +19,7 @@ import {
   ArmorSet,
   bucketsToCategories,
   ItemsByBucket,
+  LockedArmor2Mod,
   LockedArmor2ModMap,
   LockedMap,
   MinMax,
@@ -82,14 +85,30 @@ export function useProcess(
       currentCleanup: cleanup,
     });
 
+    const generalMods = lockedArmor2ModMap[armor2PlugCategoryHashesByName.general] || [];
+    const raidCombatAndLegacyMods = Object.entries(
+      lockedArmor2ModMap
+    ).flatMap(([plugCategoryHash, mods]) =>
+      !armor2PlugCategoryHashes.includes(Number(plugCategoryHash)) && mods ? mods : []
+    );
+
     const processItems: ProcessItemsByBucket = {};
     const itemsById: { [id: string]: DimItem[] } = {};
 
     for (const [key, items] of Object.entries(filteredItems)) {
       processItems[key] = [];
-      const groupedItems = groupItems(items, lockedArmor2ModMap, statOrder, assumeMasterwork);
+
+      const groupedItems = groupItems(
+        items,
+        statOrder,
+        assumeMasterwork,
+        generalMods,
+        raidCombatAndLegacyMods
+      );
+
       for (const group of Object.values(groupedItems)) {
         const item = group.length ? group[0] : null;
+
         if (item) {
           processItems[key].push(
             mapDimItemToProcessItem(item, lockedArmor2ModMap[bucketsToCategories[item.bucket.hash]])
@@ -206,9 +225,10 @@ function createWorker() {
  */
 function groupItems(
   items: readonly DimItem[],
-  lockedArmor2ModMap: LockedArmor2ModMap,
   statOrder: StatTypes[],
-  assumeMasterwork: boolean
+  assumeMasterwork: boolean,
+  generalMods: LockedArmor2Mod[],
+  raidCombatAndLegacyMods: LockedArmor2Mod[]
 ) {
   const groupingFn = (item: DimItem) => {
     const statValues: number[] = [];
@@ -222,13 +242,7 @@ function groupItems(
 
     let groupId = `${statValues}${assumeMasterwork || item.energy?.energyCapacity === 10}`;
 
-    const generalMods = lockedArmor2ModMap[armor2PlugCategoryHashesByName.general];
-    const otherMods = getOtherMods(lockedArmor2ModMap);
-    const raidMods = getRaidMods(lockedArmor2ModMap);
-
-    // TODO creating otherMods and doing these checks could be pulled out so it is only run once
-    // for all armour buckets.
-    if (otherMods.length || raidMods.length) {
+    if (raidCombatAndLegacyMods.length) {
       groupId += `${getSpecialtySocketMetadatas(item)
         ?.map((metadata) => metadata.slotTag)
         .join(',')}`;
@@ -236,9 +250,8 @@ function groupItems(
 
     // We don't need to worry about slot specific energy as items are already filtered for that.
     if (
-      someModHasEnergyRequirement(otherMods) ||
-      someModHasEnergyRequirement(raidMods) ||
-      (generalMods && someModHasEnergyRequirement(generalMods))
+      someModHasEnergyRequirement(raidCombatAndLegacyMods) ||
+      someModHasEnergyRequirement(generalMods)
     ) {
       groupId += `${item.energy?.energyType}`;
     }

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -89,7 +89,7 @@ export function useProcess(
     const raidCombatAndLegacyMods = Object.entries(
       lockedArmor2ModMap
     ).flatMap(([plugCategoryHash, mods]) =>
-      !armor2PlugCategoryHashes.includes(Number(plugCategoryHash)) && mods ? mods : []
+      mods && !armor2PlugCategoryHashes.includes(Number(plugCategoryHash)) ? mods : []
     );
 
     const processItems: ProcessItemsByBucket = {};

--- a/src/app/loadout-builder/loadoutBuilderReducer.ts
+++ b/src/app/loadout-builder/loadoutBuilderReducer.ts
@@ -8,7 +8,6 @@ import {
   LockedItemType,
   LockedMap,
   MinMaxIgnored,
-  ModPickerCategories,
   StatTypes,
 } from './types';
 import { addLockedItem, isLoadoutBuilderItem, removeLockedItem } from './utils';
@@ -70,16 +69,7 @@ const lbStateInit = ({
       Intellect: { min: 0, max: 10, ignored: false },
       Strength: { min: 0, max: 10, ignored: false },
     },
-    lockedArmor2Mods: {
-      [ModPickerCategories.general]: [],
-      [ModPickerCategories.helmet]: [],
-      [ModPickerCategories.gauntlets]: [],
-      [ModPickerCategories.chest]: [],
-      [ModPickerCategories.leg]: [],
-      [ModPickerCategories.classitem]: [],
-      [ModPickerCategories.other]: [],
-      [ModPickerCategories.raid]: [],
-    },
+    lockedArmor2Mods: {},
     minimumPower: 750,
     selectedStoreId: selectedStoreId,
     modPicker: {

--- a/src/app/loadout-builder/loadoutBuilderReducer.ts
+++ b/src/app/loadout-builder/loadoutBuilderReducer.ts
@@ -21,7 +21,6 @@ export interface LoadoutBuilderState {
   modPicker: {
     open: boolean;
     initialQuery?: string;
-    filterLegacy?: boolean;
   };
   perkPicker: {
     open: boolean;
@@ -89,7 +88,7 @@ export type LoadoutBuilderAction =
   | { type: 'addItemToLockedMap'; item: LockedItemType }
   | { type: 'removeItemFromLockedMap'; item: LockedItemType }
   | { type: 'lockedArmor2ModsChanged'; lockedArmor2Mods: LockedArmor2ModMap }
-  | { type: 'openModPicker'; initialQuery?: string; filterLegacy?: boolean }
+  | { type: 'openModPicker'; initialQuery?: string }
   | { type: 'closeModPicker' }
   | { type: 'openPerkPicker'; initialQuery?: string }
   | { type: 'closePerkPicker' }
@@ -153,7 +152,6 @@ function lbStateReducer(
         modPicker: {
           open: true,
           initialQuery: action.initialQuery,
-          filterLegacy: action.filterLegacy,
         },
       };
     case 'closeModPicker':

--- a/src/app/loadout-builder/processWorker/mappers.ts
+++ b/src/app/loadout-builder/processWorker/mappers.ts
@@ -4,14 +4,7 @@ import {
   getModTypeTagByPlugCategoryHash,
   getSpecialtySocketMetadatas,
 } from '../../utils/item-utils';
-import {
-  ArmorSet,
-  LockedArmor2Mod,
-  LockedArmor2ModMap,
-  ModPickerCategories,
-  statHashToType,
-  StatTypes,
-} from '../types';
+import { ArmorSet, LockedArmor2Mod, LockedArmor2ModMap, statHashToType, StatTypes } from '../types';
 import { ProcessArmorSet, ProcessItem, ProcessMod, ProcessSocket, ProcessSockets } from './types';
 
 function mapDimSocketToProcessSocket(dimSocket: DimSocket): ProcessSocket {
@@ -30,6 +23,7 @@ function mapDimSocketToProcessSocket(dimSocket: DimSocket): ProcessSocket {
 export function mapArmor2ModToProcessMod(mod: LockedArmor2Mod): ProcessMod {
   const processMod: ProcessMod = {
     hash: mod.modDef.hash,
+    plugCategoryHash: mod.modDef.plug.plugCategoryHash,
     energy: mod.modDef.plug.energyCost && {
       type: mod.modDef.plug.energyCost.energyType,
       val: mod.modDef.plug.energyCost.energyCost,
@@ -59,8 +53,8 @@ export function getTotalModStatChanges(lockedArmor2Mods: LockedArmor2ModMap) {
     Strength: 0,
   };
 
-  for (const category of Object.values(ModPickerCategories)) {
-    for (const mod of lockedArmor2Mods[category]) {
+  for (const mods of Object.values(lockedArmor2Mods)) {
+    for (const mod of mods || []) {
       for (const stat of mod.modDef.investmentStats) {
         const statType = statHashToType[stat.statTypeHash];
         if (statType) {
@@ -85,7 +79,7 @@ function mapDimSocketsToProcessSockets(dimSockets: DimSockets): ProcessSockets {
 
 export function mapDimItemToProcessItem(
   dimItem: DimItem,
-  modsForSlot: LockedArmor2Mod[]
+  modsForSlot?: LockedArmor2Mod[]
 ): ProcessItem {
   const { bucket, id, type, name, equippingLabel, basePower, stats } = dimItem;
 
@@ -100,8 +94,10 @@ export function mapDimItemToProcessItem(
   }
 
   const modMetadatas = getSpecialtySocketMetadatas(dimItem);
-  const costInitial =
-    dimItem.energy && _.sumBy(modsForSlot, (mod) => mod.modDef.plug.energyCost?.energyCost || 0);
+  const modsCost = modsForSlot
+    ? _.sumBy(modsForSlot, (mod) => mod.modDef.plug.energyCost?.energyCost || 0)
+    : 0;
+  const costInitial = dimItem.energy ? modsCost : null;
   return {
     bucketHash: bucket.hash,
     id,

--- a/src/app/loadout-builder/processWorker/mappers.ts
+++ b/src/app/loadout-builder/processWorker/mappers.ts
@@ -4,7 +4,15 @@ import {
   getModTypeTagByPlugCategoryHash,
   getSpecialtySocketMetadatas,
 } from '../../utils/item-utils';
-import { ArmorSet, LockedArmor2Mod, LockedArmor2ModMap, statHashToType, StatTypes } from '../types';
+import {
+  ArmorSet,
+  knownModPlugCategoryHashes,
+  LockedArmor2Mod,
+  LockedArmor2ModMap,
+  raidPlugCategoryHashes,
+  statHashToType,
+  StatTypes,
+} from '../types';
 import { ProcessArmorSet, ProcessItem, ProcessMod, ProcessSocket, ProcessSockets } from './types';
 
 function mapDimSocketToProcessSocket(dimSocket: DimSocket): ProcessSocket {
@@ -31,7 +39,10 @@ export function mapArmor2ModToProcessMod(mod: LockedArmor2Mod): ProcessMod {
     investmentStats: mod.modDef.investmentStats,
   };
 
-  if (mod.category === 'other' || mod.category === 'raid') {
+  if (
+    raidPlugCategoryHashes.includes(processMod.plugCategoryHash) ||
+    !knownModPlugCategoryHashes.includes(processMod.plugCategoryHash)
+  ) {
     processMod.tag = getModTypeTagByPlugCategoryHash(mod.modDef.plug.plugCategoryHash);
   }
 

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -12,7 +12,7 @@ import {
   StatTypes,
 } from '../types';
 import { statTier } from '../utils';
-import { canTakeAllMods, generateModPermutations } from './processUtils';
+import { canTakeSlotIndependantMods, generateModPermutations } from './processUtils';
 import {
   IntermediateProcessArmorSet,
   LockedArmor2ProcessMods,
@@ -284,7 +284,7 @@ export function process(
               // For armour 2 mods we ignore slot specific mods as we prefilter items based on energy requirements
               if (
                 (otherMods.length || raidMods.length || generalMods.length) &&
-                !canTakeAllMods(
+                !canTakeSlotIndependantMods(
                   generalModsPermutations,
                   otherModPermutations,
                   raidModPermutations,

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -2,7 +2,15 @@ import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { armor2PlugCategoryHashesByName, TOTAL_STAT_HASH } from '../../search/d2-known-values';
 import { infoLog } from '../../utils/log';
-import { LockableBuckets, MinMax, MinMaxIgnored, statHashes, StatTypes } from '../types';
+import {
+  knownModPlugCategoryHashes,
+  LockableBuckets,
+  MinMax,
+  MinMaxIgnored,
+  raidPlugCategoryHashes,
+  statHashes,
+  StatTypes,
+} from '../types';
 import { statTier } from '../utils';
 import { canTakeAllMods, generateModPermutations } from './processUtils';
 import {
@@ -11,6 +19,7 @@ import {
   ProcessArmorSet,
   ProcessItem,
   ProcessItemsByBucket,
+  ProcessMod,
 } from './types';
 
 const RETURNED_ARMOR_SETS = 200;
@@ -177,12 +186,25 @@ export function process(
     statsCache[item.id] = getStatMix(item, assumeMasterwork, orderedStatValues);
   }
 
-  const generalModsPermutations = generateModPermutations(
-    lockedArmor2ModMap[armor2PlugCategoryHashesByName.general]
-  );
-  const otherModPermutations = generateModPermutations(lockedArmor2ModMap.other);
+  let generalMods: ProcessMod[] = [];
+  let otherMods: ProcessMod[] = [];
+  let raidMods: ProcessMod[] = [];
 
-  const raidModPermutations = generateModPermutations(lockedArmor2ModMap.raid);
+  for (const [plugCategoryHash, mods] of Object.entries(lockedArmor2ModMap)) {
+    const pch = Number(plugCategoryHash);
+    if (pch === armor2PlugCategoryHashesByName.general) {
+      generalMods = generalMods.concat(mods);
+    } else if (raidPlugCategoryHashes.includes(pch)) {
+      raidMods = raidMods.concat(mods);
+    } else if (!knownModPlugCategoryHashes.includes(pch)) {
+      otherMods = otherMods.concat(mods);
+    }
+  }
+
+  const generalModsPermutations = generateModPermutations(generalMods);
+  const otherModPermutations = generateModPermutations(otherMods);
+
+  const raidModPermutations = generateModPermutations(raidMods);
 
   for (const helm of helms) {
     for (const gaunt of gaunts) {
@@ -261,9 +283,7 @@ export function process(
 
               // For armour 2 mods we ignore slot specific mods as we prefilter items based on energy requirements
               if (
-                (lockedArmor2ModMap.other.length ||
-                  lockedArmor2ModMap.raid.length ||
-                  lockedArmor2ModMap[armor2PlugCategoryHashesByName.general].length) &&
+                (otherMods.length || raidMods.length || generalMods.length) &&
                 !canTakeAllMods(
                   generalModsPermutations,
                   otherModPermutations,

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -120,7 +120,7 @@ function getEnergyCounts(modsOrItems: (ProcessMod | null | ProcessItemSubset)[])
  *
  * assignments is mutated by this function to store any mods assignments that were made.
  */
-export function canTakeAllMods(
+export function canTakeSlotIndependantMods(
   generalModPermutations: (ProcessMod | null)[][],
   otherModPermutations: (ProcessMod | null)[][],
   raidModPermutations: (ProcessMod | null)[][],

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -1,5 +1,5 @@
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
-import { ModPickerCategory, StatTypes } from '../types';
+import { StatTypes } from '../types';
 
 export interface ProcessPlug {
   stats: {
@@ -76,6 +76,7 @@ interface ProcessStat {
 
 export interface ProcessMod {
   hash: number;
+  plugCategoryHash: number;
   energy?: {
     type: DestinyEnergyType;
     /** The energy cost of the mod. */
@@ -87,5 +88,5 @@ export interface ProcessMod {
 }
 
 export type LockedArmor2ProcessMods = {
-  [T in ModPickerCategory]: ProcessMod[];
+  [plugCategoryHash: number]: ProcessMod[];
 };

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -1,5 +1,6 @@
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import {
+  armor2PlugCategoryHashes,
   armor2PlugCategoryHashesByName,
   armorBuckets,
   D2ArmorStatHashByName,
@@ -95,7 +96,7 @@ export interface LockedArmor2Mod {
 }
 
 export type LockedArmor2ModMap = {
-  [T in ModPickerCategory]: LockedArmor2Mod[];
+  [plugCategoryHash: number]: LockedArmor2Mod[] | undefined;
 };
 
 /**
@@ -136,6 +137,22 @@ export const bucketsToCategories = {
   [LockableBuckets.leg]: armor2PlugCategoryHashesByName.leg,
   [LockableBuckets.classitem]: armor2PlugCategoryHashesByName.classitem,
 };
+
+export const slotSpecificPlugCategoryHashes = [
+  armor2PlugCategoryHashesByName.helmet,
+  armor2PlugCategoryHashesByName.gauntlets,
+  armor2PlugCategoryHashesByName.chest,
+  armor2PlugCategoryHashesByName.leg,
+  armor2PlugCategoryHashesByName.classitem,
+];
+
+export const raidPlugCategoryHashes = [
+  PlugCategoryHashes.EnhancementsSeasonOutlaw, // last wish
+  PlugCategoryHashes.EnhancementsRaidGarden, // garden of salvation
+  PlugCategoryHashes.EnhancementsRaidDescent, // deep stone crypt
+];
+
+export const knownModPlugCategoryHashes = [...armor2PlugCategoryHashes, ...raidPlugCategoryHashes];
 
 // to-do: deduplicate this and use D2ArmorStatHashByName instead
 export const statHashes: { [type in StatTypes]: number } = {

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -92,7 +92,6 @@ export interface LockedArmor2Mod {
   /** Essentially an identifier for each mod, as a single mod definition can be selected multiple times.*/
   key?: number;
   modDef: PluggableInventoryItemDefinition;
-  category: ModPickerCategory;
 }
 
 export type LockedArmor2ModMap = {

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -64,30 +64,6 @@ export const raidPlugs = [
 
 export const raidSockets = [1444083081, 1764679361, 1269555732] as const;
 
-export const ModPickerCategories = {
-  ...armor2PlugCategoryHashesByName,
-  /** This encompases combat and legacy mods as they "share" a socket position on armour */
-  other: 'other',
-  raid: 'raid',
-} as const;
-export type ModPickerCategory = typeof ModPickerCategories[keyof typeof ModPickerCategories];
-
-/**
- * Checks whether the passed in value is a ModPickerCategory.
- */
-export function isModPickerCategory(value: unknown): value is ModPickerCategory {
-  return (
-    value === ModPickerCategories.general ||
-    value === ModPickerCategories.helmet ||
-    value === ModPickerCategories.gauntlets ||
-    value === ModPickerCategories.chest ||
-    value === ModPickerCategories.leg ||
-    value === ModPickerCategories.classitem ||
-    value === ModPickerCategories.other ||
-    value === ModPickerCategories.raid
-  );
-}
-
 export interface LockedArmor2Mod {
   /** Essentially an identifier for each mod, as a single mod definition can be selected multiple times.*/
   key?: number;

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -18,9 +18,6 @@ export type StatTypes =
   | 'Intellect'
   | 'Strength';
 
-// todo: and this?
-export type BurnTypes = 'arc' | 'solar' | 'void';
-
 export interface MinMax {
   min: number;
   max: number;
@@ -55,14 +52,6 @@ export type LockedItemType = LockedItemCase | LockedPerk | LockedExclude;
 export type LockedMap = Readonly<{
   [bucketHash: number]: readonly LockedItemType[] | undefined;
 }>;
-
-export const raidPlugs = [
-  PlugCategoryHashes.EnhancementsSeasonOutlaw,
-  PlugCategoryHashes.EnhancementsRaidGarden,
-  PlugCategoryHashes.EnhancementsRaidDescent,
-] as const;
-
-export const raidSockets = [1444083081, 1764679361, 1269555732] as const;
 
 export interface LockedArmor2Mod {
   /** Essentially an identifier for each mod, as a single mod definition can be selected multiple times.*/
@@ -121,6 +110,7 @@ export const slotSpecificPlugCategoryHashes = [
   armor2PlugCategoryHashesByName.classitem,
 ];
 
+// TODO generate this somehow so we dont need to maintain it
 export const raidPlugCategoryHashes = [
   PlugCategoryHashes.EnhancementsSeasonOutlaw, // last wish
   PlugCategoryHashes.EnhancementsRaidGarden, // garden of salvation

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -1,6 +1,4 @@
-import { tl } from 'app/i18next-t';
 import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
-import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import {
   DestinyEnergyType,
   DestinyInventoryItemDefinition,
@@ -284,26 +282,6 @@ function getOrderedStatValues(item: DimItem, statOrder: StatTypes[]) {
 }
 
 /**
- * Get the stats totals attributed to locked mods. Note that these are stats from mods in a single bucket, head, arms, ect.
- */
-export function getLockedModStats(
-  lockedArmor2Mods: readonly LockedArmor2Mod[]
-): { [statHash: number]: number } {
-  const lockedModStats: { [statHash: number]: number } = {};
-  if (lockedArmor2Mods) {
-    for (const lockedMod of lockedArmor2Mods) {
-      for (const stat of lockedMod.modDef.investmentStats) {
-        lockedModStats[stat.statTypeHash] ||= 0;
-        // TODO This is no longer accurate, see https://github.com/DestinyItemManager/DIM/wiki/DIM's-New-Stat-Calculations
-        lockedModStats[stat.statTypeHash] += stat.value;
-      }
-    }
-  }
-
-  return lockedModStats;
-}
-
-/**
  * Checks to see if some mod in a collection of LockedArmor2Mod or LockedMod,
  * has an elemental (non-Any) energy requirement
  */
@@ -313,14 +291,3 @@ export function someModHasEnergyRequirement(mods: LockedArmor2Mod[]) {
       !mod.modDef.plug.energyCost || mod.modDef.plug.energyCost.energyType !== DestinyEnergyType.Any
   );
 }
-
-export const armor2ModPlugCategoriesTitles = {
-  [armor2PlugCategoryHashesByName.general]: tl('LB.General'),
-  [armor2PlugCategoryHashesByName.helmet]: tl('LB.Helmet'),
-  [armor2PlugCategoryHashesByName.gauntlets]: tl('LB.Gauntlets'),
-  [armor2PlugCategoryHashesByName.chest]: tl('LB.Chest'),
-  [armor2PlugCategoryHashesByName.leg]: tl('LB.Legs'),
-  [armor2PlugCategoryHashesByName.classitem]: tl('LB.ClassItem'),
-  other: tl('LB.Other'),
-  raid: tl('LB.Raid'),
-} as const;

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -1,9 +1,6 @@
 import { tl } from 'app/i18next-t';
 import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
-import {
-  combatCompatiblePlugCategoryHashes,
-  legacyCompatiblePlugCategoryHashes,
-} from 'app/search/specialty-modslots';
+import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import {
   DestinyEnergyType,
   DestinyInventoryItemDefinition,
@@ -12,16 +9,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { BucketHashes, ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import {
-  isModPickerCategory,
-  LockedArmor2Mod,
-  LockedItemType,
-  ModPickerCategories,
-  ModPickerCategory,
-  raidPlugs,
-  StatTypes,
-  statValues,
-} from './types';
+import { LockedArmor2Mod, LockedItemType, StatTypes, statValues } from './types';
 
 /**
  * Plug item hashes that should be excluded from the list of selectable perks.
@@ -327,34 +315,12 @@ export function someModHasEnergyRequirement(mods: LockedArmor2Mod[]) {
 }
 
 export const armor2ModPlugCategoriesTitles = {
-  [ModPickerCategories.general]: tl('LB.General'),
-  [ModPickerCategories.helmet]: tl('LB.Helmet'),
-  [ModPickerCategories.gauntlets]: tl('LB.Gauntlets'),
-  [ModPickerCategories.chest]: tl('LB.Chest'),
-  [ModPickerCategories.leg]: tl('LB.Legs'),
-  [ModPickerCategories.classitem]: tl('LB.ClassItem'),
-  [ModPickerCategories.other]: tl('LB.Other'),
-  [ModPickerCategories.raid]: tl('LB.Raid'),
-};
-
-/** Returns the relevant mod picker category from the plug category hash.
- *
- * For raid mods, while they will fit into legacy sockets, they have their
- * own category so expect 'raid' rather than 'other'.
- *
- * Legacy and combat mod hashes will return 'other'.
- */
-export function getModPickerCategoryFromPlugCategoryHash(
-  plugCategoryHash: number
-): ModPickerCategory | undefined {
-  if (isModPickerCategory(plugCategoryHash)) {
-    return plugCategoryHash;
-  } else if (raidPlugs.includes(plugCategoryHash)) {
-    return ModPickerCategories.raid;
-  } else if (
-    legacyCompatiblePlugCategoryHashes.includes(plugCategoryHash) ||
-    combatCompatiblePlugCategoryHashes.includes(plugCategoryHash)
-  ) {
-    return ModPickerCategories.other;
-  }
-}
+  [armor2PlugCategoryHashesByName.general]: tl('LB.General'),
+  [armor2PlugCategoryHashesByName.helmet]: tl('LB.Helmet'),
+  [armor2PlugCategoryHashesByName.gauntlets]: tl('LB.Gauntlets'),
+  [armor2PlugCategoryHashesByName.chest]: tl('LB.Chest'),
+  [armor2PlugCategoryHashesByName.leg]: tl('LB.Legs'),
+  [armor2PlugCategoryHashesByName.classitem]: tl('LB.ClassItem'),
+  other: tl('LB.Other'),
+  raid: tl('LB.Raid'),
+} as const;

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -74,14 +74,7 @@ export const armor2PlugCategoryHashesByName = {
 } as const;
 
 /** The consistent armour 2 mod category hashes. This excludes raid, combat and legacy slots as they tend to change. */
-export const armor2PlugCategoryHashes: number[] = [
-  armor2PlugCategoryHashesByName.general,
-  armor2PlugCategoryHashesByName.helmet,
-  armor2PlugCategoryHashesByName.gauntlets,
-  armor2PlugCategoryHashesByName.chest,
-  armor2PlugCategoryHashesByName.leg,
-  armor2PlugCategoryHashesByName.classitem,
-];
+export const armor2PlugCategoryHashes: number[] = Object.values(armor2PlugCategoryHashesByName);
 
 export const killTrackerObjectivesByHash: Record<number, 'pvp' | 'pve' | undefined> = {
   74070459: 'pvp', // Objective "Crucible Opponents Defeated" found inside InventoryItem[38912240] "Crucible Tracker"

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -73,7 +73,7 @@ export const armor2PlugCategoryHashesByName = {
   classitem: PlugCategoryHashes.EnhancementsV2ClassItem,
 } as const;
 
-// Hardcoded to ensure ordering.
+/** The consistent armour 2 mod category hashes. This excludes raid, combat and legacy slots as they tend to change. */
 export const armor2PlugCategoryHashes: number[] = [
   armor2PlugCategoryHashesByName.general,
   armor2PlugCategoryHashesByName.helmet,

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -73,7 +73,15 @@ export const armor2PlugCategoryHashesByName = {
   classitem: PlugCategoryHashes.EnhancementsV2ClassItem,
 } as const;
 
-export const armor2PlugCategoryHashes: number[] = Object.values(armor2PlugCategoryHashesByName);
+// Hardcoded to ensure ordering.
+export const armor2PlugCategoryHashes: number[] = [
+  armor2PlugCategoryHashesByName.general,
+  armor2PlugCategoryHashesByName.helmet,
+  armor2PlugCategoryHashesByName.gauntlets,
+  armor2PlugCategoryHashesByName.chest,
+  armor2PlugCategoryHashesByName.leg,
+  armor2PlugCategoryHashesByName.classitem,
+];
 
 export const killTrackerObjectivesByHash: Record<number, 'pvp' | 'pve' | undefined> = {
   74070459: 'pvp', // Objective "Crucible Opponents Defeated" found inside InventoryItem[38912240] "Crucible Tracker"

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -347,10 +347,8 @@
   },
   "LB": {
     "AdvancedOptions": "Advanced Options",
-    "Chest": "Chest",
     "ChooseAMod": "Choose your mods",
     "ChooseAPerk": "Choose a perk",
-    "ClassItem": "Class Item",
     "ClearLocked": "Clear Locked",
     "ContainsVendorItems": "This loadout contains vendor items",
     "Current": "Current",
@@ -358,9 +356,6 @@
     "Exclude": "Excluded Items",
     "ExcludeHelp": "Shift + click an item (or drag and drop into this bucket) to build sets without specific gear.",
     "FilterSets": "Filter sets",
-    "Gauntlets": "Gauntlets",
-    "General": "General",
-    "Helmet": "Helmet",
     "Help": {
       "And": "Armor with all of these perks will be used (\"and\")",
       "ChangeNodes": "Change the Intellect, Discipline, or Strength nodes in game to what is displayed to create each loadout.",
@@ -382,7 +377,6 @@
     "HideAllConfigs": "Hide all configurations",
     "HideConfigs": "Hide configurations",
     "LB": "Loadout Optimizer",
-    "Legs": "Legs",
     "LightMode": {
       "HelpCurrent": "Calculates loadouts at current defense levels.",
       "HelpScaled": "Calculates loadouts as if all items were 350 defense.",
@@ -395,7 +389,6 @@
     "LockedHelp": "Drag and drop any item into its bucket to build set with that specific gear. Shift + click to exclude items.",
     "Missing2": "Missing rare, legendary, or exotic pieces to build a full set!",
     "ModLockButton": "Select mods",
-    "Other": "Other",
     "ProcessingMode": {
       "Fast": "Fast",
       "Full": "Full",
@@ -403,7 +396,6 @@
       "HelpFull": "Looks at more gear, but takes longer.",
       "ProcessingMode": "Processing mode"
     },
-    "Raid": "Raid",
     "Scaled": "Scaled",
     "SearchAMod": "Search a mod or description",
     "SelectMods": "Select Mods",


### PR DESCRIPTION
This is what I am thinking we can do to stop those issues we had when beyond light came out with mod picker breaking.

Basically remove the hard coded categories that were in there for mods and try and drive the whole thing off plugCategoryHashes. We still need to group them at points for the assignment algorithms and so we can restrict users to only selecting say 5 raid mods or 5 combat mods. 

I still have a bit to clean up but it's kinda large so I wouldn't mind getting some opinions on it before I polish it up more.