### PR TITLE
Allow click through loading screen

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -49,7 +49,7 @@
     "ItemUniquenessExplanation_female": "You tried to move the '{{name}}' {{type}} to your {{character}} but that destination already has that item and is only allowed one.",
     "ItemUniquenessExplanation_male": "You tried to move the '{{name}}' {{type}} to your {{character}} but that destination already has that item and is only allowed one.",
     "Maintenance": "Bungie.net servers are down for maintenance.",
-    "MissingInventory": "Bungie.net did not return your inventory, possibly because your privacy settings prevent it.",
+    "MissingInventory": "Bungie.net did not return your inventory, possibly because your privacy settings prevent it. Try logging out and logging back in.",
     "NetworkError": "Network error - {{status}} {{statusText}}",
     "NoAccount": "No Destiny account was found. Do you have the right platform selected?",
     "NoAccountForPlatform": "Failed to find a Destiny account for you on {{platform}}.",

--- a/src/app/dim-ui/Loading.scss
+++ b/src/app/dim-ui/Loading.scss
@@ -13,6 +13,7 @@
   bottom: 0;
   overflow: hidden;
   z-index: 100;
+  pointer-events: none;
 }
 
 $square-size: 40px;

--- a/src/app/dim-ui/PageLoading.m.scss
+++ b/src/app/dim-ui/PageLoading.m.scss
@@ -1,5 +1,6 @@
 .pageLoading {
   position: relative;
+  pointer-events: none;
 }
 
 .pageLoadingEnter {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -63,7 +63,7 @@
     "ItemUniquenessExplanation_female": "You tried to move the '{{name}}' {{type}} to your {{character}} but that destination already has that item and is only allowed one.",
     "ItemUniquenessExplanation_male": "You tried to move the '{{name}}' {{type}} to your {{character}} but that destination already has that item and is only allowed one.",
     "Maintenance": "Bungie.net servers are down for maintenance.",
-    "MissingInventory": "Bungie.net did not return your inventory, possibly because your privacy settings prevent it.",
+    "MissingInventory": "Bungie.net did not return your inventory, possibly because your privacy settings prevent it. Try logging out and logging back in.",
     "NetworkError": "Network error - {{status}} {{statusText}}",
     "NoAccount": "No Destiny account was found. Do you have the right platform selected?",
     "NoAccountForPlatform": "Failed to find a Destiny account for you on {{platform}}.",


### PR DESCRIPTION
There's a bug where the loading screen doesn't disappear during some failures. I'm not sure why, but a dumb fix for now is to make the loading stuff transparent to clicks, so that people can still click the troubleshooting links.