### PR TITLE
Bug: disabled mods effecting stats

### DIFF
--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -339,7 +339,7 @@ function enhanceStatsWithPlugs(
 
   // Add the chosen plugs' investment stats to the item's base investment stats
   for (const socket of createdItem.sockets.allSockets) {
-    if (socket.plugged?.plugDef.investmentStats) {
+    if (socket.plugged?.enabled && socket.plugged.plugDef.investmentStats) {
       for (const perkStat of socket.plugged.plugDef.investmentStats) {
         const statHash = perkStat.statTypeHash;
         const itemStat = statsByHash[statHash];


### PR DESCRIPTION
Ensure that plugs are enabled if we calculate their stats.

This should fix the issue as the enabled parameter controls whether the mod is displayed as disabled in the ui. I don't have anything I can test with so I will crowdsource that once this is in.

Fixes #6459 