### PR TITLE
Error handling, Sentry tracing

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -78,3 +78,8 @@ jobs:
           # Use the dim-release-bot token rather than the default
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           PATCH: ${{ github.event.inputs.patch }}
+
+      - name: Publish Sentry release
+        run: ./build/sentry-release-prod.sh
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/build/sentry-release-prod.sh
+++ b/build/sentry-release-prod.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eux
+
+set -o pipefail
+
+# Create a new release in Sentry for this version
+VERSION=$(node -p -e "require('./package.json').version")
+npx sentry-cli releases new "$VERSION" --finalize
+npx sentry-cli releases set-commits "$VERSION" --auto

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -383,8 +383,8 @@ module.exports = (env) => {
         '$featureFlags.debugMoves': JSON.stringify(!env.release),
         // Debug Service Worker
         '$featureFlags.debugSW': JSON.stringify(!env.release),
-        // Send exception reports to Sentry.io on beta only
-        '$featureFlags.sentry': JSON.stringify(env.beta),
+        // Send exception reports to Sentry.io on beta/prod only
+        '$featureFlags.sentry': JSON.stringify(!env.dev),
         // Respect the "do not track" header
         '$featureFlags.respectDNT': JSON.stringify(!env.release),
         // Community-curated wish lists

--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -6,7 +6,7 @@ module.exports = {
     removeUnusedKeys: true,
     sort: true,
     func: {
-      list: ['t', 'i18next.t', 'tl'],
+      list: ['t', 'i18next.t', 'tl', 'DimError'],
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
     },
     lngs: ['en'],

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@popperjs/core": "^2.2.1",
     "@sentry/browser": "^5.0.3",
+    "@sentry/react": "^6.0.1",
     "body-scroll-lock": "^3.1.5",
     "bungie-api-ts": "^4.5.0",
     "caniuse-lite": ">=1.0.30000843",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "@popperjs/core": "^2.2.1",
     "@sentry/browser": "^5.0.3",
     "@sentry/react": "^6.0.1",
+    "@sentry/tracing": "^6.0.1",
     "body-scroll-lock": "^3.1.5",
     "bungie-api-ts": "^4.5.0",
     "caniuse-lite": ">=1.0.30000843",

--- a/src/app/accounts/actions.ts
+++ b/src/app/accounts/actions.ts
@@ -1,4 +1,3 @@
-import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { createAction } from 'typesafe-actions';
 import { DestinyAccount } from './destiny-account';
 
@@ -9,7 +8,7 @@ export const setCurrentAccount = createAction('accounts/SET_CURRENT_ACCOUNT')<
 
 export const loadFromIDB = createAction('accounts/LOAD_FROM_IDB')<DestinyAccount[]>();
 
-export const error = createAction('accounts/ERROR')<DimError>();
+export const error = createAction('accounts/ERROR')<Error>();
 
 export const loggedOut = createAction('accounts/LOG_OUT', (reauth?: boolean) => ({
   reauth: reauth || false,

--- a/src/app/accounts/reducer.ts
+++ b/src/app/accounts/reducer.ts
@@ -1,5 +1,4 @@
 import { API_KEY as BUNGIE_API_KEY } from 'app/bungie-api/bungie-api-utils';
-import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { hasValidAuthTokens } from 'app/bungie-api/oauth-tokens';
 import { API_KEY as DIM_API_KEY } from 'app/dim-api/dim-api-helper';
 import { deepEqual } from 'fast-equals';
@@ -15,7 +14,7 @@ export interface AccountsState {
   readonly loaded: boolean;
   readonly loadedFromIDB: boolean;
 
-  readonly accountsError?: DimError;
+  readonly accountsError?: Error;
 
   /** Do we need the user to log in? */
   readonly needsLogin: boolean;

--- a/src/app/bungie-api/destiny1-api.ts
+++ b/src/app/bungie-api/destiny1-api.ts
@@ -1,16 +1,13 @@
 import { t } from 'app/i18next-t';
+import { DimError } from 'app/utils/dim-error';
 import { errorLog } from 'app/utils/log';
-import { DestinyManifest, PlatformErrorCodes, ServerResponse } from 'bungie-api-ts/destiny2';
+import { DestinyManifest, ServerResponse } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { DestinyAccount } from '../accounts/destiny-account';
 import { D1Item, DimItem } from '../inventory/item-types';
 import { D1Store } from '../inventory/store-types';
 import { bungieApiQuery, bungieApiUpdate } from './bungie-api-utils';
-import {
-  authenticatedHttpClient,
-  dimError,
-  handleUniquenessViolation,
-} from './bungie-service-helper';
+import { authenticatedHttpClient, handleUniquenessViolation } from './bungie-service-helper';
 
 /**
  * APIs for interacting with Destiny 1 game data.
@@ -30,11 +27,11 @@ export async function getCharacters(platform: DestinyAccount) {
     )
   );
   if (!response || Object.keys(response.Response).length === 0) {
-    throw dimError(
+    throw new DimError(
+      'BungieService.NoAccountForPlatform',
       t('BungieService.NoAccountForPlatform', {
         platform: platform.platformLabel,
-      }),
-      PlatformErrorCodes.DestinyAccountNotFound
+      })
     );
   }
   return _.map(response.Response.data.characters, (c) => {

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -1,6 +1,6 @@
 import { ThunkResult } from 'app/store/types';
 import { reportException } from 'app/utils/exceptions';
-import { ManifestDefinitions } from '../destiny2/definitions';
+import { HashLookupFailure, ManifestDefinitions } from '../destiny2/definitions';
 import { setD1Manifest } from '../manifest/actions';
 import { getManifest } from '../manifest/d1-manifest-service';
 
@@ -86,15 +86,11 @@ export function getDefinitions(): ThunkResult<D1ManifestDefinitions> {
           if (!dbEntry) {
             const requestingEntryInfo =
               typeof requestor === 'object' ? requestor.hash : String(requestor);
-            reportException(
-              `hashLookupFailureD1`,
-              new Error(`hashLookupFailureD1: ${table}[${id}]`),
-              {
-                requestingEntryInfo,
-                failedHash: id,
-                failedComponent: table,
-              }
-            );
+            reportException(`hashLookupFailureD1`, new HashLookupFailure(table, id), {
+              requestingEntryInfo,
+              failedHash: id,
+              failedComponent: table,
+            });
           }
           return dbEntry;
         },

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -87,7 +87,7 @@ export function getDefinitions(): ThunkResult<D1ManifestDefinitions> {
             const requestingEntryInfo =
               typeof requestor === 'object' ? requestor.hash : String(requestor);
             reportException(
-              `hashLookupFailureD1: ${table}[${id}]`,
+              `hashLookupFailureD1`,
               new Error(`hashLookupFailureD1: ${table}[${id}]`),
               {
                 requestingEntryInfo,

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -41,7 +41,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { setD2Manifest } from '../manifest/actions';
 import { getManifest } from '../manifest/manifest-service-json';
-import { ManifestDefinitions } from './definitions';
+import { HashLookupFailure, ManifestDefinitions } from './definitions';
 
 const lazyTables = [
   'InventoryItem',
@@ -170,7 +170,7 @@ export function getDefinitions(): ThunkResult<D2ManifestDefinitions> {
           if (!dbEntry && tableShort !== 'Record' && tableShort !== 'ItemCategory') {
             const requestingEntryInfo =
               typeof requestor === 'object' ? requestor.hash : String(requestor);
-            reportException(`hashLookupFailure`, new Error(`hashLookupFailure: ${table}[${id}]`), {
+            reportException(`hashLookupFailure`, new HashLookupFailure(table, id), {
               requestingEntryInfo,
               failedHash: id,
               failedComponent: table,

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -167,18 +167,14 @@ export function getDefinitions(): ThunkResult<D2ManifestDefinitions> {
             throw new Error(`Table ${table} does not exist in the manifest`);
           }
           const dbEntry = dbTable[id];
-          if (!dbEntry && tableShort !== 'Record') {
+          if (!dbEntry && tableShort !== 'Record' && tableShort !== 'ItemCategory') {
             const requestingEntryInfo =
               typeof requestor === 'object' ? requestor.hash : String(requestor);
-            reportException(
-              `hashLookupFailure: ${table}[${id}]`,
-              new Error(`hashLookupFailure: ${table}[${id}]`),
-              {
-                requestingEntryInfo,
-                failedHash: id,
-                failedComponent: table,
-              }
-            );
+            reportException(`hashLookupFailure`, new Error(`hashLookupFailure: ${table}[${id}]`), {
+              requestingEntryInfo,
+              failedHash: id,
+              failedComponent: table,
+            });
           }
           return dbEntry;
         },

--- a/src/app/destiny2/definitions.ts
+++ b/src/app/destiny2/definitions.ts
@@ -6,3 +6,16 @@ export interface ManifestDefinitions {
   /** Check if these defs are from D2. Inside an if statement, these defs will be narrowed to type D2ManifestDefinitions. */
   isDestiny2(): this is D2ManifestDefinitions;
 }
+
+export class HashLookupFailure extends Error {
+  table: string;
+  id: number;
+
+  /** Pass in just a message key to set the message to the localized version of that key, or override with the second parameter. */
+  constructor(table: string, id: number) {
+    super(`hashLookupFailure: ${table}[${id}]`);
+    this.table = table;
+    this.id = id;
+    this.name = 'HashLookupFailure';
+  }
+}

--- a/src/app/destiny2/definitions.ts
+++ b/src/app/destiny2/definitions.ts
@@ -11,7 +11,6 @@ export class HashLookupFailure extends Error {
   table: string;
   id: number;
 
-  /** Pass in just a message key to set the message to the localized version of that key, or override with the second parameter. */
   constructor(table: string, id: number) {
     super(`hashLookupFailure: ${table}[${id}]`);
     this.table = table;

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -1,5 +1,4 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
-import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { ThunkResult } from 'app/store/types';
 import {
@@ -44,7 +43,7 @@ export const charactersUpdated = createAction('inventory/CHARACTERS')<CharacterI
 /**
  * Reflect the old stores service data into the Redux store as a migration aid.
  */
-export const error = createAction('inventory/ERROR')<DimError>();
+export const error = createAction('inventory/ERROR')<Error>();
 
 /**
  * An item has moved (or equipped/dequipped)

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -4,6 +4,7 @@ import { currentAccountSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import { maxLightItemSet } from 'app/loadout/auto-loadouts';
 import { ThunkResult } from 'app/store/types';
+import { DimError } from 'app/utils/dim-error';
 import { errorLog, timer } from 'app/utils/log';
 import {
   DestinyCharacterComponent,
@@ -186,7 +187,7 @@ function loadStoresData(
             'd2-stores',
             'Vault or character inventory was missing - bailing in order to avoid corruption'
           );
-          throw new Error(t('BungieService.MissingInventory'));
+          throw new DimError('BungieService.MissingInventory');
         }
 
         const lastPlayedDate = findLastPlayedDate(profileInfo);

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -2,6 +2,7 @@ import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import { RootState, ThunkResult } from 'app/store/types';
+import { DimError } from 'app/utils/dim-error';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog, warnLog } from 'app/utils/log';
 import { count } from 'app/utils/util';
@@ -10,7 +11,6 @@ import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import _ from 'lodash';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { DimError } from '../bungie-api/bungie-service-helper';
 import {
   equip as d1equip,
   equipItems as d1EquipItems,
@@ -498,11 +498,10 @@ function chooseMoveAsideItem(
 
   // if there are no candidates at all, fail
   if (moveAsideCandidates.length === 0) {
-    const e: DimError = new Error(
+    throw new DimError(
+      'no-space',
       t('ItemService.NotEnoughRoom', { store: target.name, itemname: item.name })
     );
-    e.code = 'no-space';
-    throw e;
   }
 
   // Find any stackable that could be combined with another stack
@@ -618,11 +617,10 @@ function chooseMoveAsideItem(
   }
 
   if (!moveAsideCandidate) {
-    const e: DimError = new Error(
+    throw new DimError(
+      'no-space',
       t('ItemService.NotEnoughRoom', { store: target.name, itemname: item.name })
     );
-    e.code = 'no-space';
-    throw e;
   }
 
   return moveAsideCandidate;
@@ -672,9 +670,7 @@ function canMoveToStore(
 
     // You can't move more than the max stack of a unique stack item.
     if (item.uniqueStack && amountOfItem(store, item) + amount > item.maxStackSize) {
-      const error: DimError = new Error(t('ItemService.StackFull', { name: item.name }));
-      error.code = 'no-space';
-      throw error;
+      throw new DimError('no-space', t('ItemService.StackFull', { name: item.name }));
     }
 
     const stores = storesSelector(getState());
@@ -738,7 +734,8 @@ function canMoveToStore(
             : ''
           : moveAsideItem.type;
 
-        const error: DimError = new Error(
+        throw new DimError(
+          'no-space',
           moveAsideTarget.isVault
             ? t('ItemService.BucketFull.Vault', {
                 itemtype,
@@ -750,8 +747,6 @@ function canMoveToStore(
                 context: moveAsideTarget.genderName,
               })
         );
-        error.code = 'no-space';
-        throw error;
       } else {
         // Make one move and start over!
         try {
@@ -797,9 +792,7 @@ function canEquip(item: DimItem, store: DimStore): void {
             level: item.equipRequiredLevel,
           });
 
-    const error: DimError = new Error(message);
-    error.code = 'wrong-level';
-    throw error;
+    throw new DimError('wrong-level', message);
   }
 }
 

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -1,8 +1,8 @@
-import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { t } from 'app/i18next-t';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { hideItemPopup } from 'app/item-popup/item-popup';
 import { ThunkResult } from 'app/store/types';
+import { DimError } from 'app/utils/dim-error';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog } from 'app/utils/log';
 import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
@@ -144,9 +144,7 @@ export function moveItemTo(
         try {
           moveAmount = await showMoveAmountPopup(item, store, maximum);
         } catch (e) {
-          const error: DimError = new Error('move-canceled');
-          error.code = 'move-canceled';
-          throw error;
+          throw new DimError('move-canceled', 'Move canceled'); // not shown to user
         }
       }
 

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -1,4 +1,3 @@
-import { DimError } from 'app/bungie-api/bungie-service-helper';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { warnLog } from 'app/utils/log';
 import {
@@ -38,7 +37,7 @@ export interface InventoryState {
 
   readonly profileResponse?: DestinyProfileResponse;
 
-  readonly profileError?: DimError;
+  readonly profileError?: Error;
 
   /**
    * The inventoryItemIds of all items that are "new".

--- a/src/app/register-service-worker.ts
+++ b/src/app/register-service-worker.ts
@@ -141,7 +141,6 @@ async function getServerVersion() {
     if (!data.version) {
       throw new Error('No version property');
     }
-    infoLog('SW', 'Got server version', data);
     return data.version as string;
   } else {
     throw response;

--- a/src/app/shell/DefaultAccount.tsx
+++ b/src/app/shell/DefaultAccount.tsx
@@ -1,7 +1,6 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { getPlatforms } from 'app/accounts/platforms';
 import { accountsLoadedSelector, currentAccountSelector } from 'app/accounts/selectors';
-import { DimError } from 'app/bungie-api/bungie-service-helper';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { accountRoute } from 'app/routes';
@@ -14,7 +13,7 @@ import ErrorPanel from './ErrorPanel';
 interface StoreProps {
   activeAccount?: DestinyAccount;
   accountsLoaded: boolean;
-  accountsError?: DimError;
+  accountsError?: Error;
 }
 
 function mapStateToProps(state: RootState): StoreProps {

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -2,7 +2,6 @@ import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { getPlatforms, setActivePlatform } from 'app/accounts/platforms';
 import { accountsLoadedSelector, accountsSelector } from 'app/accounts/selectors';
-import { DimError } from 'app/bungie-api/bungie-service-helper';
 import Compare from 'app/compare/Compare';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import Farming from 'app/farming/Farming';
@@ -69,7 +68,7 @@ interface ProvidedProps {
 interface StoreProps {
   accountsLoaded: boolean;
   account?: DestinyAccount;
-  profileError?: DimError;
+  profileError?: Error;
 }
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {

--- a/src/app/utils/dim-error.ts
+++ b/src/app/utils/dim-error.ts
@@ -1,0 +1,39 @@
+import { t } from 'app/i18next-t';
+import { PlatformErrorCodes } from 'bungie-api-ts/user';
+
+/**
+ * An internal error that captures more error info for reporting.
+ *
+ * The message is typically a localized error message.
+ */
+export class DimError extends Error {
+  // A non-localized string to help identify/categorize errors for DIM developers. Usually the localization key of the message.
+  code?: string;
+  // The error that caused this error, if there is one
+  error?: Error;
+
+  /** Pass in just a message key to set the message to the localized version of that key, or override with the second parameter. */
+  constructor(messageKey: string, message?: string) {
+    super(message || t(messageKey));
+    this.code = messageKey;
+    this.name = 'DimError';
+  }
+
+  public withError(error: Error): DimError {
+    this.error = error;
+    return this;
+  }
+
+  // TODO: more factories, string formatting
+  // TODO: handle specially in exceptions.ts
+  // TODO: print an error in logs when sentry is off
+  // TODO: show sentry report dialog if there's an option in this class
+  //
+}
+
+/** Generate an error with a bit more info */
+export function dimError(message: string, errorCode: PlatformErrorCodes): DimError {
+  const error: DimError = new Error(message);
+  error.code = errorCode;
+  return error;
+}

--- a/src/app/utils/dim-error.ts
+++ b/src/app/utils/dim-error.ts
@@ -1,5 +1,4 @@
 import { t } from 'app/i18next-t';
-import { PlatformErrorCodes } from 'bungie-api-ts/user';
 
 /**
  * An internal error that captures more error info for reporting.
@@ -24,16 +23,7 @@ export class DimError extends Error {
     return this;
   }
 
-  // TODO: more factories, string formatting
   // TODO: handle specially in exceptions.ts
-  // TODO: print an error in logs when sentry is off
   // TODO: show sentry report dialog if there's an option in this class
-  //
-}
-
-/** Generate an error with a bit more info */
-export function dimError(message: string, errorCode: PlatformErrorCodes): DimError {
-  const error: DimError = new Error(message);
-  error.code = errorCode;
-  return error;
+  // TODO: optional help link
 }

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -58,7 +58,7 @@ if ($featureFlags.sentry) {
           ...context,
           // We could use the React-Router integration but it's annoying
           name: location.pathname
-            .replace(/\/\d+d(1|2)\//g, '/profileMembershipId/d\1/')
+            .replace(/\/\d+\/d(1|2)\//g, '/profileMembershipId/d$1/')
             .replace(/\/vendors\/\d+/g, '/vendors/vendorId'),
         }),
       }),

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -1,57 +1,100 @@
-import _ from 'lodash';
+import type { BrowserOptions, Scope } from '@sentry/browser';
+import { BungieError } from 'app/bungie-api/http-client';
+import { getToken } from 'app/bungie-api/oauth-tokens';
+import { defaultLanguage } from 'app/i18n';
+import { PlatformErrorCodes } from 'bungie-api-ts/user';
+import { DimError } from './dim-error';
+import { errorLog } from './log';
+
+// TODO: rename this file "sentry"
 
 /** Sentry.io exception reporting */
-export let reportException: (name: string, e: Error, errorInfo?: {}) => void = _.noop;
+export let reportException = (name: string, e: Error, errorInfo?: {}) => {
+  errorLog(
+    'exception',
+    name,
+    e,
+    errorInfo,
+    e instanceof DimError && e.code,
+    e instanceof DimError && e.error
+  );
+};
+
+// DIM error codes to ignore and not report. This works regardless of language.
+const ignoreDimErrors: (string | PlatformErrorCodes)[] = [
+  'BungieService.SlowResponse',
+  'BungieService.Difficulties',
+  'BungieService.Throttled',
+  'BungieService.Maintenance',
+  'BungieService.NotConnected',
+  'BungieService.NotConnectedOrBlocked',
+  PlatformErrorCodes.DestinyCannotPerformActionAtThisLocation,
+];
 
 if ($featureFlags.sentry) {
   // The require instead of import helps us trim this from the production bundle
   const Sentry = require('@sentry/browser');
-  Sentry.init({
+
+  const options: BrowserOptions = {
     dsn: 'https://1367619d45da481b8148dd345c1a1330@sentry.io/279673',
     release: $DIM_VERSION,
     environment: $DIM_FLAVOR,
     ignoreErrors: [
-      'QuotaExceededError',
-      'Time out during communication with the game servers.',
-      'Bungie.net servers are down for maintenance.',
-      "This action is forbidden at your character's current location.",
-      "An unexpected error has occurred on Bungie's servers",
-      /Destiny tracker service call failed\./,
-      'Appel au service de Destiny tracker échoué.',
-      /You may not be connected to the internet/,
-      'Software caused connection abort',
-      'Refresh token invalid, clearing auth tokens & going to login',
-      'cannot be equipped because the exotic',
-      'No auth token exists, redirect to login',
-      'Circuit breaker open',
+      /QuotaExceededError/,
       'HTTP 503 returned',
       'Waiting due to HTTP 503',
-      'Bungie.net was too slow to respond.',
-      'Bungie.net is currently experiencing difficulties.',
+      /FatalTokenError/,
       /Failed to fetch/,
       /AbortError/,
       /Non-Error promise rejection/,
     ],
-    ignoreUrls: [
-      // Chrome extensions
-      /extensions\//i,
-      /^chrome:\/\//i,
-      /^moz-extension:\/\//i,
-    ],
-    attachStackTrace: true,
+    sampleRate: $DIM_VERSION === 'beta' ? 0.5 : 0.01, // Sample Beta at 50%, Prod at 1%
+    attachStacktrace: true,
     beforeSend: function (event, hint) {
-      if (hint.originalException?.errorCode) {
-        event.fingerprint = ['{{ default }}', String(hint.originalException.errorCode)];
+      const e = hint?.originalException;
+      const underlyingError = e instanceof DimError ? e.error : undefined;
+
+      const code =
+        underlyingError instanceof BungieError
+          ? underlyingError.code
+          : e instanceof DimError
+          ? e.code
+          : undefined;
+      if (code && ignoreDimErrors.includes(code)) {
+        return null; // drop report
       }
+
+      if (e instanceof DimError) {
+        // Replace the (localized) message with our code
+        event.message = e.code;
+
+        // TODO: it might be neat to be able to pass attachments here too - such as the entire profile response!
+      }
+
+      // TODO: we can edit the fingerprint here to make things map to the same error, or map to different errors!
+
       return event;
     },
-  });
+  };
+
+  Sentry.init(options);
+
+  // Set user ID (membership ID) to help debug and to better count affected users
+  const token = getToken();
+  if (token?.bungieMembershipId) {
+    Sentry.setUser({ id: token.bungieMembershipId });
+  }
+  // Capture locale
+  Sentry.setTag('lang', defaultLanguage());
 
   reportException = (name: string, e: Error, errorInfo?: {}) => {
     // TODO: we can also do this in some situations to gather more feedback from users
     // Sentry.showReportDialog();
-    Sentry.withScope((scope) => {
+    Sentry.withScope((scope: Scope) => {
       scope.setTag('context', name);
+      if (e instanceof DimError) {
+        scope.setExtras({ underlyingError: e.error });
+      }
       if (errorInfo) {
         scope.setExtras(errorInfo);
       }

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -34,7 +34,7 @@ const ignoreDimErrors: (string | PlatformErrorCodes)[] = [
 
 if ($featureFlags.sentry) {
   // The require instead of import helps us trim this from the production bundle
-  const Sentry = require('@sentry/browser');
+  const Sentry = require('@sentry/react');
 
   const options: BrowserOptions = {
     dsn: 'https://1367619d45da481b8148dd345c1a1330@sentry.io/279673',
@@ -78,6 +78,9 @@ if ($featureFlags.sentry) {
       return event;
     },
   };
+
+  // TODO: There's a redux integration but I'm worried it'd be too much trouble to trim out all the stuff we wouldn't want to report (by default it sends the whole action & state.
+  // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/redux/
 
   Sentry.init(options);
 

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -58,7 +58,7 @@ if ($featureFlags.sentry) {
           ...context,
           // We could use the React-Router integration but it's annoying
           name: location.pathname
-            .replace(/\\d+\d(1|2)\//g, '/profileMembershipId/d\1/')
+            .replace(/\/\d+d(1|2)\//g, '/profileMembershipId/d\1/')
             .replace(/\/vendors\/\d+/g, '/vendors/vendorId'),
         }),
       }),

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -1,6 +1,7 @@
 import type { BrowserOptions, Scope } from '@sentry/browser';
 import { BungieError } from 'app/bungie-api/http-client';
 import { getToken } from 'app/bungie-api/oauth-tokens';
+import { HashLookupFailure } from 'app/destiny2/definitions';
 import { defaultLanguage } from 'app/i18n';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { DimError } from './dim-error';
@@ -63,15 +64,16 @@ if ($featureFlags.sentry) {
       if (code && ignoreDimErrors.includes(code)) {
         return null; // drop report
       }
-
+      if (e instanceof HashLookupFailure) {
+        // Add the ID to the fingerprint so we don't collapse different errors
+        event.fingerprint = ['{{ default }}', String(e.table), String(e.id)];
+      }
       if (e instanceof DimError) {
         // Replace the (localized) message with our code
         event.message = e.code;
 
         // TODO: it might be neat to be able to pass attachments here too - such as the entire profile response!
       }
-
-      // TODO: we can edit the fingerprint here to make things map to the same error, or map to different errors!
 
       return event;
     },

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -51,6 +51,19 @@ if ($featureFlags.sentry) {
     ],
     sampleRate: $DIM_VERSION === 'beta' ? 0.5 : 0.01, // Sample Beta at 50%, Prod at 1%
     attachStacktrace: true,
+    integrations: [
+      new Sentry.Integrations.BrowserTracing({
+        tracingOrigins: ['localhost', 'api.destinyitemmanager.com', 'www.bungie.net', /^\//],
+        beforeNavigate: (context) => ({
+          ...context,
+          // We could use the React-Router integration but it's annoying
+          name: location.pathname
+            .replace(/\\d+\d(1|2)\//g, '/profileMembershipId/d\1/')
+            .replace(/\/vendors\/\d+/g, '/vendors/vendorId'),
+        }),
+      }),
+    ],
+    tracesSampleRate: 0.01, // Performance traces at 1%
     beforeSend: function (event, hint) {
       const e = hint?.originalException;
       const underlyingError = e instanceof DimError ? e.error : undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,6 +1425,17 @@
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
+"@sentry/tracing@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.0.1.tgz#82001ce3369e05fe161e57dfb3cb3784fbe3f23b"
+  integrity sha512-p4laeCu7isrvXiCgM/ix4GU5lckoL2Mw2OI3l93lRYL7fKU8XJs+/2Cybs0J+QY1HP5OTrNIF+VpnJZbpM6MQg==
+  dependencies:
+    "@sentry/hub" "6.0.1"
+    "@sentry/minimal" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
 "@sentry/types@5.29.2":
   version "5.29.2"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.29.2.tgz#ac87383df1222c2d9b9f8f9ed7a6b86ea41a098a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,6 +1324,16 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@sentry/browser@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.0.1.tgz#5d0b8e3bc893c1c7e55a9238e23ed47adf264fa2"
+  integrity sha512-iP8Bqxj4Ye8CXA4ja77buPZfXsKiZYUgHFzBQxVMihTHA8ZZLgBMPLQI6uFfHuJJW+1/yLzOf8BhvF2zknAebg==
+  dependencies:
+    "@sentry/core" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
 "@sentry/browser@^5.0.3":
   version "5.29.2"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.29.2.tgz#51adb4005511b1a4a70e4571880fc6653d651f91"
@@ -1356,6 +1366,17 @@
     "@sentry/utils" "5.29.2"
     tslib "^1.9.3"
 
+"@sentry/core@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.0.1.tgz#4024b2b04e5ce78ce35d7795a283fbd235f37757"
+  integrity sha512-EoxgodyClasI8PA4GyU8Cp88W3R5ebpiLsE7fCcBcOU0DOBRkO8GAZ5IzfCDtYDJ50c9npivum5Oyj2wf8CXYw==
+  dependencies:
+    "@sentry/hub" "6.0.1"
+    "@sentry/minimal" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
 "@sentry/hub@5.29.2":
   version "5.29.2"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.29.2.tgz#208f10fe6674695575ad74182a1151f71d6df00a"
@@ -1363,6 +1384,15 @@
   dependencies:
     "@sentry/types" "5.29.2"
     "@sentry/utils" "5.29.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.0.1.tgz#6a338522f62d6d6282822e16da4385a5a854f0a8"
+  integrity sha512-pGckNdhKcr7qYVXgSgA/QVGArATcmQu54YFAR5xTnkWVHpAwNmh0fc4CJCc4JBwS/LXSU1Y0nYiLQduVfnv8Cg==
+  dependencies:
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
     tslib "^1.9.3"
 
 "@sentry/minimal@5.29.2":
@@ -1374,10 +1404,36 @@
     "@sentry/types" "5.29.2"
     tslib "^1.9.3"
 
+"@sentry/minimal@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.0.1.tgz#f970a59b024d08e61e00d518081eb4b7591f3d77"
+  integrity sha512-TQ/M5A+OsxtQJ8dzHwrclxKXpJNdQeM1PUoYhff4BvsOXJScvZb7+Yn0OUEQXEc9pSMNt62tnQy4ct80iAMTHw==
+  dependencies:
+    "@sentry/hub" "6.0.1"
+    "@sentry/types" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/react@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.0.1.tgz#5b7f0284fee35b639cb4538096ee57bf3593792f"
+  integrity sha512-loI9AnKp32yLRBGVZh5eVpAkpkGnCQ4rx+8GN+BICLwqsQTAJUyPLuyDarEqlH4sHOGJCwYf5s5Iu4uqpAP4vg==
+  dependencies:
+    "@sentry/browser" "6.0.1"
+    "@sentry/minimal" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
 "@sentry/types@5.29.2":
   version "5.29.2"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.29.2.tgz#ac87383df1222c2d9b9f8f9ed7a6b86ea41a098a"
   integrity sha512-dM9wgt8wy4WRty75QkqQgrw9FV9F+BOMfmc0iaX13Qos7i6Qs2Q0dxtJ83SoR4YGtW8URaHzlDtWlGs5egBiMA==
+
+"@sentry/types@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.0.1.tgz#4d1a281a4a79541b607361523e08058c6676409e"
+  integrity sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg==
 
 "@sentry/utils@5.29.2":
   version "5.29.2"
@@ -1385,6 +1441,14 @@
   integrity sha512-nEwQIDjtFkeE4k6yIk4Ka5XjGRklNLThWLs2xfXlL7uwrYOH2B9UBBOOIRUraBm/g/Xrra3xsam/kRxuiwtXZQ==
   dependencies:
     "@sentry/types" "5.29.2"
+    tslib "^1.9.3"
+
+"@sentry/utils@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.0.1.tgz#061ef604df519e1488960484e9bf0cbcb8d8c9a4"
+  integrity sha512-bjGuBYnG6fulZ8mLhPGBxttNu96DCN6d7Glw2sfLf4aurn1kjJ/58hP2c8dH0OqWO5e+rGYTsZ5Dr5kqVKNGTg==
+  dependencies:
+    "@sentry/types" "6.0.1"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":


### PR DESCRIPTION
This revamps our error handling a bit by making a real `DimError` class that holds more info and also carries a non-localized but identifiable code we can use to help normalize errors in Sentry. The new integration also uploads the full original Bungie API error when we report a DimError.

I also enabled Sentry's new performance tracing which should be interesting (we can add more instrumentation ourselves later) and I'm adding Sentry reporting sampled at 1% for Prod.