### PR TITLE
Add tracing spans to bungie API calls, item moves, store loads

### DIFF
--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -1,3 +1,4 @@
+import { withProfiler } from '@sentry/react';
 import { MouseTransition, TouchTransition } from 'dnd-multi-backend';
 import React from 'react';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -8,6 +9,9 @@ import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 import store from './store/store';
+
+// Wrap App with Sentry profiling
+const WrappedApp = $featureFlags.sentry ? withProfiler(App) : App;
 
 function Root() {
   const options = {
@@ -20,7 +24,7 @@ function Root() {
     <Router>
       <Provider store={store}>
         <DndProvider options={options}>
-          <App />
+          <WrappedApp />
         </DndProvider>
       </Provider>
     </Router>

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -164,7 +164,7 @@ async function handleRefreshTokenError(response: Error | Response): Promise<Toke
       if (data?.error === 'server_error') {
         if (data.error_description === 'SystemDisabled') {
           throw new Error(t('BungieService.Maintenance'));
-        } else {
+        } else if (data.error_description !== 'AuthorizationRecordExpired') {
           throw new Error(
             `Unknown error getting response token: ${data.error}, ${data.error_description}`
           );

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -17,6 +17,7 @@ import {
   createHttpClient,
   HttpStatusError,
   responsivelyThrottleHttpClient,
+  sentryTraceHttpClient,
 } from './http-client';
 import { rateLimitedFetch } from './rate-limiter';
 
@@ -69,10 +70,12 @@ export const authenticatedHttpClient = dimErrorHandledHttpClient(
 /** used to get manifest and global alerts*/
 export const unauthenticatedHttpClient = dimErrorHandledHttpClient(
   responsivelyThrottleHttpClient(
-    createHttpClient(
-      createFetchWithNonStoppingTimeout(fetch, TIMEOUT, notifyTimeout),
-      API_KEY,
-      false
+    sentryTraceHttpClient(
+      createHttpClient(
+        createFetchWithNonStoppingTimeout(fetch, TIMEOUT, notifyTimeout),
+        API_KEY,
+        false
+      )
     ),
     logThrottle
   )

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -107,23 +107,23 @@ export function handleErrors(error: Error) {
 
   if (error instanceof SyntaxError) {
     errorLog('bungie api', 'Error parsing Bungie.net response', error);
-    throw new Error(t('BungieService.Difficulties'));
+    throw new DimError('BungieService.Difficulties').withError(error);
   }
 
   if (error instanceof TypeError) {
-    throw new Error(
-      navigator.onLine ? t('BungieService.NotConnectedOrBlocked') : t('BungieService.NotConnected')
-    );
+    throw (navigator.onLine
+      ? new DimError('BungieService.NotConnectedOrBlocked')
+      : new DimError('BungieService.NotConnected')
+    ).withError(error);
   }
 
   if (error instanceof HttpStatusError) {
     // "I don't think they exist" --Westley, The Princess Bride (1987)
     if (error.status === -1) {
-      throw new Error(
-        navigator.onLine
-          ? t('BungieService.NotConnectedOrBlocked')
-          : t('BungieService.NotConnected')
-      );
+      throw (navigator.onLine
+        ? new DimError('BungieService.NotConnectedOrBlocked')
+        : new DimError('BungieService.NotConnected')
+      ).withError(error);
     }
 
     // Token expired and other auth maladies
@@ -214,7 +214,7 @@ export function handleErrors(error: Error) {
 
   // Any other error
   errorLog('bungie api', 'No response data:', error);
-  throw new DimError(t('BungieService.Difficulties')).withError(error);
+  throw new DimError('BungieService.Difficulties').withError(error);
 }
 
 // Handle "DestinyUniquenessViolation" (1648)

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -1,4 +1,5 @@
 import { t } from 'app/i18next-t';
+import { DimError } from 'app/utils/dim-error';
 import { errorLog } from 'app/utils/log';
 import {
   AwaAuthorizationResult,
@@ -148,7 +149,8 @@ async function getProfile(
   });
   // TODO: what does it actually look like to not have an account?
   if (Object.keys(response.Response).length === 0) {
-    throw new Error(
+    throw new DimError(
+      'BungieService.NoAccountForPlatform',
       t('BungieService.NoAccountForPlatform', {
         platform: platform.platformLabel,
       })

--- a/src/app/bungie-api/http-client.ts
+++ b/src/app/bungie-api/http-client.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/browser';
 import { delay } from 'app/utils/util';
 import { PlatformErrorCodes, ServerResponse } from 'bungie-api-ts/destiny2';
 import { HttpClient, HttpClientConfig } from 'bungie-api-ts/http';
@@ -207,6 +208,52 @@ export function responsivelyThrottleHttpClient(
         }
       }
       throw e;
+    }
+  };
+}
+
+/**
+ * accepts an HttpClient and returns it with sentry performance tracking
+ *
+ * @param httpClient use this client to make the API request
+ */
+export function sentryTraceHttpClient(httpClient: HttpClient): HttpClient {
+  return async (config: HttpClientConfig) => {
+    if (!$featureFlags.sentry) {
+      return httpClient(config);
+    }
+
+    const activeTransaction = getCurrentHub()?.getScope()?.getTransaction();
+    if (!activeTransaction) {
+      return httpClient(config);
+    }
+
+    const span = activeTransaction.startChild({
+      data: {
+        ...config,
+        type: 'fetch',
+      },
+      description: `${config.method} ${config.url}`,
+      op: 'http',
+    });
+
+    try {
+      const result = await httpClient(config);
+      if (result) {
+        // TODO (kmclb) remove this once types PR goes through
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        span.setHttpStatus(200);
+      }
+      return result;
+    } catch (e) {
+      if (e instanceof HttpStatusError) {
+        span.setHttpStatus(e.status);
+      } else {
+        span.setHttpStatus(200);
+      }
+      throw e;
+    } finally {
+      span.finish();
     }
   };
 }

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub, startTransaction } from '@sentry/browser';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { getPlatforms } from 'app/accounts/platforms';
 import { currentAccountSelector } from 'app/accounts/selectors';
@@ -160,6 +161,10 @@ function loadStoresData(
 ): ThunkResult<DimStore[] | undefined> {
   return async (dispatch, getState) => {
     const promise = (async () => {
+      const transaction = startTransaction({ name: 'loadStoresD2' });
+      // set the transaction on the scope so it picks up any errors
+      getCurrentHub()?.configureScope((scope) => scope.setSpan(transaction));
+
       resetItemIndexGenerator();
 
       // TODO: if we've already loaded profile recently, don't load it again
@@ -255,6 +260,8 @@ function loadStoresData(
         // around that with some rxjs operators, but it's easier to
         // just make this never fail.
         return undefined;
+      } finally {
+        transaction.finish();
       }
     })();
     loadingTracker.addPromise(promise);

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -231,7 +231,10 @@ export function equipItems(store: DimStore, items: DimItem[]): ThunkResult<DimIt
             const similarItem = getSimilarItem(getStores(), otherExotic);
             if (!similarItem) {
               return Promise.reject(
-                new Error(t('ItemService.Deequip', { itemname: otherExotic.name }))
+                new DimError(
+                  'ItemService.Deequip',
+                  t('ItemService.Deequip', { itemname: otherExotic.name })
+                )
               );
             }
             const target = getStore(getStores(), similarItem.owner)!;
@@ -284,7 +287,7 @@ function dequipItem(item: DimItem, excludeExotic = false): ThunkResult<DimItem> 
     const stores = storesSelector(getState());
     const similarItem = getSimilarItem(stores, item, [], excludeExotic);
     if (!similarItem) {
-      throw new Error(t('ItemService.Deequip', { itemname: item.name }));
+      throw new DimError('ItemService.Deequip', t('ItemService.Deequip', { itemname: item.name }));
     }
 
     const ownerStore = getStore(stores, item.owner)!;
@@ -788,7 +791,7 @@ function canEquip(item: DimItem, store: DimStore): void {
   if (itemCanBeEquippedBy(item, store)) {
     return;
   } else if (item.classified) {
-    throw new Error(t('ItemService.Classified'));
+    throw new DimError('ItemService.Classified');
   } else {
     const message =
       item.classType === DestinyClass.Unknown

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -121,7 +121,7 @@ export function moveItemTo(
         ? !item.canPullFromPostmaster
         : item.notransfer && item.owner !== store.id
     ) {
-      throw new Error(t('Help.CannotMove'));
+      throw new DimError('Help.CannotMove');
     }
 
     if (item.owner === store.id && !item.location.inPostmaster) {

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub, startTransaction } from '@sentry/browser';
 import { t } from 'app/i18next-t';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { hideItemPopup } from 'app/item-popup/item-popup';
@@ -110,6 +111,10 @@ export function moveItemTo(
   chooseAmount = false
 ): ThunkResult<DimItem> {
   return async (dispatch, getState) => {
+    const transaction = startTransaction({ name: 'moveItemTo' });
+    // set the transaction on the scope so it picks up any errors
+    getCurrentHub()?.configureScope((scope) => scope.setSpan(transaction));
+
     hideItemPopup();
     if (
       item.location.inPostmaster
@@ -191,6 +196,8 @@ export function moveItemTo(
       } else {
         reportException('moveItem', e);
       }
+    } finally {
+      transaction.finish();
     }
 
     return item;

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -79,9 +79,10 @@ export function applyLoadout(store: DimStore, loadout: Loadout, allowUndo = fals
         loadoutPromise.then((scope) => {
           if (scope.failed > 0) {
             if (scope.failed === scope.total) {
-              throw new Error(t('Loadouts.AppliedError'));
+              throw new DimError('Loadouts.AppliedError');
             } else {
-              throw new Error(
+              throw new DimError(
+                'Loadouts.AppliedWarn',
                 t('Loadouts.AppliedWarn', { failed: scope.failed, total: scope.total })
               );
             }

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -58,7 +58,8 @@ if ($featureFlags.sentry) {
           // We could use the React-Router integration but it's annoying
           name: location.pathname
             .replace(/\/\d+\/d(1|2)\//g, '/profileMembershipId/d$1/')
-            .replace(/\/vendors\/\d+/g, '/vendors/vendorId'),
+            .replace(/\/vendors\/\d+/g, '/vendors/vendorId')
+            .replace(/index\.html/, ''),
         }),
       }),
     ],
@@ -119,6 +120,10 @@ if ($featureFlags.sentry) {
       setTag('context', name);
       if (e instanceof DimError) {
         scope.setExtras({ cause: e.cause });
+        scope.setTag('code', e.code);
+        if (e.cause instanceof BungieError) {
+          scope.setTag('bungieErrorCode', e.code);
+        }
       }
       if (errorInfo) {
         scope.setExtras(errorInfo);

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -57,7 +57,7 @@ if ($featureFlags.sentry) {
           ...context,
           // We could use the React-Router integration but it's annoying
           name: location.pathname
-            .replace(/\/\d+\/d(1|2)\//g, '/profileMembershipId/d$1/')
+            .replace(/\/\d+\/d(1|2)/g, '/profileMembershipId/d$1')
             .replace(/\/vendors\/\d+/g, '/vendors/vendorId')
             .replace(/index\.html/, ''),
         }),
@@ -110,6 +110,7 @@ if ($featureFlags.sentry) {
   if (token?.bungieMembershipId) {
     setUser({ id: token.bungieMembershipId });
   }
+
   // Capture locale
   setTag('lang', defaultLanguage());
 


### PR DESCRIPTION
This adds Bungie.net API calls to our performance tracing data, and marks out store refreshes and item moves as "transactions" that get captured. This should let us answer questions about how many API calls are required to move items and how long they take.