### PR TITLE
Disable Sentry reporting on older versions of the app

### DIFF
--- a/src/app/register-service-worker.ts
+++ b/src/app/register-service-worker.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/browser';
 import { BehaviorSubject, combineLatest, empty, from, of, timer } from 'rxjs';
 import { catchError, distinctUntilChanged, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { reportException } from './utils/exceptions';
@@ -116,6 +117,15 @@ export default function registerServiceWorker() {
             .then(() => {
               if (registration.waiting) {
                 infoLog('SW', 'New content is available; please refresh. (from update)');
+
+                if ($featureFlags.sentry) {
+                  // Disable Sentry error logging if this user is on an older version
+                  const sentryOptions = getCurrentHub()?.getClient()?.getOptions();
+                  if (sentryOptions) {
+                    sentryOptions.enabled = false;
+                  }
+                }
+
                 return true;
               } else {
                 infoLog('SW', 'Updated, but theres not a new worker waiting');


### PR DESCRIPTION
This is kind of a weird idea - whenever we detect that we're on an older version of the app (from the `version.json` check), this disables Sentry reporting. That way we should automatically stop getting reports from old versions whenever we release a new one. I *think* that should reduce the noise in Sentry.