### PR TITLE
Properly dedupe the token refresh call

### DIFF
--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -4,16 +4,7 @@ import store from 'app/store/store';
 import { infoLog, warnLog } from 'app/utils/log';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { getAccessTokenFromRefreshToken } from './oauth';
-import {
-  getToken,
-  hasTokenExpired,
-  removeAccessToken,
-  removeToken,
-  setToken,
-  Tokens,
-} from './oauth-tokens';
-
-let cache: Promise<Tokens> | null = null;
+import { getToken, hasTokenExpired, removeAccessToken, removeToken, Tokens } from './oauth-tokens';
 
 /**
  * A wrapper around "fetch" that implements Bungie's OAuth scheme. This either
@@ -100,7 +91,7 @@ export class FatalTokenError extends Error {
 }
 
 export async function getActiveToken(): Promise<Tokens> {
-  let token = getToken();
+  const token = getToken();
   if (!token) {
     removeToken();
     goToLoginPage();
@@ -121,14 +112,9 @@ export async function getActiveToken(): Promise<Tokens> {
   }
 
   try {
-    token = await (cache || getAccessTokenFromRefreshToken(token.refreshToken!));
-    setToken(token);
-    infoLog('bungie auth', 'Successfully updated auth token from refresh token.');
-    return token;
+    return await getAccessTokenFromRefreshToken(token.refreshToken!);
   } catch (e) {
     return await handleRefreshTokenError(e);
-  } finally {
-    cache = null;
   }
 }
 


### PR DESCRIPTION
I noticed a case where we were refreshing the access token twice, in parallel. Looks like I'd broken the deduping long ago in some reorganization.