### PR TITLE
properly render non-counter live emblem metrics

### DIFF
--- a/src/app/item-popup/EmblemPreview.tsx
+++ b/src/app/item-popup/EmblemPreview.tsx
@@ -36,7 +36,6 @@ export default function EmblemPreview({
         <div className={styles.value}>
           <ObjectiveValue objectiveDef={objectiveDef} progress={item.metricObjective.progress} />
         </div>
-        // <div className={styles.value}>{(item.metricObjective.progress || 0).toLocaleString()}</div>
       )}
       {item.secondaryIcon && <BungieImage src={item.secondaryIcon} width="237" height="48" />}
       {parentPresentationNode && metricDef && trait && (

--- a/src/app/item-popup/EmblemPreview.tsx
+++ b/src/app/item-popup/EmblemPreview.tsx
@@ -2,6 +2,7 @@ import MetricBanner from 'app/collections/MetricBanner';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { DimItem } from 'app/inventory/item-types';
+import { ObjectiveValue } from 'app/progress/Objective';
 import React from 'react';
 import styles from './EmblemPreview.m.scss';
 
@@ -18,6 +19,9 @@ export default function EmblemPreview({
   const trait =
     metricDef && defs.Trait.get(metricDef.traitHashes[metricDef.traitHashes.length - 1]);
 
+  const objectiveHash = item.metricObjective?.objectiveHash;
+  const objectiveDef = objectiveHash !== undefined && defs.Objective.get(objectiveHash);
+
   return (
     <div className={styles.container}>
       {item.metricObjective && item.metricHash !== undefined && (
@@ -28,8 +32,11 @@ export default function EmblemPreview({
           objectiveProgress={item.metricObjective}
         />
       )}
-      {item.metricObjective && (
-        <div className={styles.value}>{(item.metricObjective.progress || 0).toLocaleString()}</div>
+      {item.metricObjective?.progress !== undefined && objectiveDef && (
+        <div className={styles.value}>
+          <ObjectiveValue objectiveDef={objectiveDef} progress={item.metricObjective.progress} />
+        </div>
+        // <div className={styles.value}>{(item.metricObjective.progress || 0).toLocaleString()}</div>
       )}
       {item.secondaryIcon && <BungieImage src={item.secondaryIcon} width="237" height="48" />}
       {parentPresentationNode && metricDef && trait && (


### PR DESCRIPTION
item details on emblems were naively displaying a raw number, instead of rendering according to objective type

before
![image](https://user-images.githubusercontent.com/68782081/106245776-e1cfb380-61c1-11eb-8ec7-39389bdce994.png)

<hr/>

after
![image](https://user-images.githubusercontent.com/68782081/106245736-d1b7d400-61c1-11eb-8538-77023f5191c6.png)
