### PR TITLE
let new seasonal mods through filter, de-dupe perk display

### DIFF
--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -117,8 +117,8 @@ function mapStateToProps() {
           if (
             isPluggableItem(def) &&
             isArmor2Mod(def) &&
-            // Filters our mods that are deprecated.
-            def.plug.insertionMaterialRequirementHash !== 0 &&
+            // Filters out mods that are deprecated.
+            (def.plug.insertionMaterialRequirementHash !== 0 || def.plug.energyCost?.energyCost) &&
             // This string can be empty so let those cases through in the event a mod hasn't been given a itemTypeDisplayName.
             // My investigation showed that only classified items had this being undefined.
             def.itemTypeDisplayName !== undefined

--- a/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
+++ b/src/app/loadout-builder/locked-armor/SelectableBungieImage.tsx
@@ -7,6 +7,7 @@ import { StatValue } from 'app/item-popup/PlugTooltip';
 import { SocketDetailsMod } from 'app/item-popup/SocketDetails';
 import { armorStatHashes } from 'app/search/search-filter-values';
 import clsx from 'clsx';
+import _ from 'lodash';
 import React from 'react';
 import ClosableContainer from '../ClosableContainer';
 import { LockedArmor2Mod, LockedItemType } from '../types';
@@ -45,7 +46,10 @@ export function SelectableArmor2Mod({
         <SocketDetailsMod className={styles.iconContainer} itemDef={mod.modDef} defs={defs} />
         <div className={styles.perkInfo}>
           <div className={styles.perkTitle}>{mod.modDef.displayProperties.name}</div>
-          {mod.modDef.perks.map((perk) => (
+          {_.uniqBy(
+            mod.modDef.perks,
+            (p) => defs.SandboxPerk.get(p.perkHash).displayProperties.description
+          ).map((perk) => (
             <div key={perk.perkHash}>
               <RichDestinyText
                 text={defs.SandboxPerk.get(perk.perkHash).displayProperties.description}


### PR DESCRIPTION
## fix duplicate perk descriptions
before:
![image](https://user-images.githubusercontent.com/68782081/107588697-30655080-6bb9-11eb-9137-b6e6feaca8eb.png)
![image](https://user-images.githubusercontent.com/68782081/107588711-378c5e80-6bb9-11eb-8680-9a10cb49da23.png)

after:
![image](https://user-images.githubusercontent.com/68782081/107588722-407d3000-6bb9-11eb-88bb-9051a5101a1c.png)
![image](https://user-images.githubusercontent.com/68782081/107588733-44a94d80-6bb9-11eb-8fe8-6099f7ac48dd.png)

## fix season 13 mods not appearing
before:
![image](https://user-images.githubusercontent.com/68782081/107588757-54289680-6bb9-11eb-96d5-f2e4a3f6a027.png)

after:
![image](https://user-images.githubusercontent.com/68782081/107588765-5985e100-6bb9-11eb-99b4-8406157ff170.png)
