### PR TITLE
Show info in the item popup for things that expire at the end of a season

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -627,7 +627,8 @@
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
-      "Type": "{{classType}} {{typeName}}"
+      "Type": "{{classType}} {{typeName}}",
+      "QuestProgress": "Step {{questStepNum}} of {{questStepsTotal}}"
     },
     "Take": "Take",
     "ToggleSidecar": "Expand or collapse item actions",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added Seasonal Challenges to the Records page. You can track as many of these as you want in DIM and the tracked ones will show up in the Progress page.
 * Quests that expire after a certain season now show that info in the item popup.
 * Quests show which step number on the questline they are.
+* Triumphs that provide rewards for completing a part of the triumph now show that reward.
 
 ## 6.51.1 <span class="changelog-date">(2021-02-10)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Confirm before pulling all items from Postmaster.
 * Added Seasonal Challenges to the Records page. You can track as many of these as you want in DIM and the tracked ones will show up in the Progress page.
 * Quests that expire after a certain season now show that info in the item popup.
+* Quests show which step number on the questline they are.
 
 ## 6.51.1 <span class="changelog-date">(2021-02-10)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
   * `sunsetsin:next` will show the same items: items whose power limit won't reach next season's limit on all items.
 * Confirm before pulling all items from Postmaster.
 * Added Seasonal Challenges to the Records page. You can track as many of these as you want in DIM and the tracked ones will show up in the Progress page.
+* Quests that expire after a certain season now show that info in the item popup.
 
 ## 6.51.1 <span class="changelog-date">(2021-02-10)</span>
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -13,6 +13,7 @@ import {
   DestinyItemQualityBlockDefinition,
   DestinyItemQuantity,
   DestinyItemSocketEntryDefinition,
+  DestinyItemTooltipNotification,
   DestinyObjectiveProgress,
   DestinySandboxPerkDefinition,
   DestinySocketCategoryDefinition,
@@ -196,6 +197,8 @@ export interface DimItem {
   breakerType: DestinyBreakerTypeDefinition | null;
   /** The state of this item in the user's D2 Collection */
   collectibleState?: DestinyCollectibleState;
+  /** Extra tooltips to show in the item popup */
+  tooltipNotifications?: DestinyItemTooltipNotification[];
 }
 
 /**

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -417,4 +417,6 @@ export interface DimPursuit {
   expiredInActivityMessage?: string;
   /** Modifiers active in this quest */
   modifierHashes: number[];
+  questStepNum?: number;
+  questStepsTotal?: number;
 }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -653,4 +653,15 @@ function buildPursuitInfo(
       rewards,
     };
   }
+  if (
+    createdItem.pursuit &&
+    createdItem.bucket.hash === BucketHashes.Quests &&
+    itemDef.setData?.itemList
+  ) {
+    createdItem.pursuit = {
+      ...createdItem.pursuit,
+      questStepNum: itemDef.setData.itemList.findIndex((i) => i.itemHash === itemDef.hash) + 1,
+      questStepsTotal: itemDef.setData.itemList.length,
+    };
+  }
 }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -606,7 +606,7 @@ export function makeItem(
   // Some items have multiple tooltips, but the item.tooltipNotificationIndexes property that
   // should tell us which to show is missing: https://github.com/Bungie-net/api/issues/1419
   if (
-    itemDef.tooltipNotifications.length === 1 &&
+    itemDef.tooltipNotifications?.length === 1 &&
     itemDef.tooltipNotifications[0].displayString.length
   ) {
     createdItem.tooltipNotifications = itemDef.tooltipNotifications

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -597,12 +597,29 @@ export function makeItem(
     reportException('Quest', e, { itemHash: item.itemHash });
   }
 
-  // TODO: Phase out "base power"
   if (createdItem.primStat) {
     createdItem.basePower = createdItem.primStat.value;
   }
 
   createdItem.index = createItemIndex(createdItem);
+
+  // Some items have multiple tooltips, but the item.tooltipNotificationIndexes property that
+  // should tell us which to show is missing: https://github.com/Bungie-net/api/issues/1419
+  if (
+    itemDef.tooltipNotifications.length === 1 &&
+    itemDef.tooltipNotifications[0].displayString.length
+  ) {
+    createdItem.tooltipNotifications = itemDef.tooltipNotifications
+      .filter((t) =>
+        // displayString is never actually set in the definitions, so we hijack it to set our own. If this contains
+        // numbers it's probably a seasonal expiration notice. All the other tooltips are kind of junk right now.
+        /\d+/.test(t.displayString)
+      )
+      .map((t) => ({
+        displayString: t.displayString,
+        displayStyle: 'seasonal-expiration',
+      }));
+  }
 
   return createdItem;
 }

--- a/src/app/item-popup/ItemDescription.m.scss
+++ b/src/app/item-popup/ItemDescription.m.scss
@@ -16,6 +16,11 @@
 
 .officialDescription {
   composes: description;
+  overflow: auto;
+}
+
+.flavorText {
+  composes: description;
   font-style: italic;
   overflow: auto;
 }

--- a/src/app/item-popup/ItemDescription.m.scss.d.ts
+++ b/src/app/item-popup/ItemDescription.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'description': string;
   'descriptionTools': string;
+  'flavorText': string;
   'loreLink': string;
   'officialDescription': string;
   'wishListLabel': string;

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -49,7 +49,7 @@ export default function ItemDescription({ item, defs }: Props) {
             </div>
           )}
           {Boolean(item.displaySource?.length) && (
-            <div className={styles.officialDescription}>{item.displaySource}</div>
+            <div className={styles.flavorText}>{item.displaySource}</div>
           )}
         </>
       )}

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -10,6 +10,7 @@ import Objective from 'app/progress/Objective';
 import { Reward } from 'app/progress/Reward';
 import { RootState } from 'app/store/types';
 import { getItemKillTrackerInfo } from 'app/utils/item-utils';
+import clsx from 'clsx';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import helmetIcon from 'destiny-icons/armor_types/helmet.svg';
 import modificationIcon from 'destiny-icons/general/modifications.svg';
@@ -19,7 +20,7 @@ import { connect, useSelector } from 'react-redux';
 import { Link, useParams } from 'react-router-dom';
 import BungieImage from '../dim-ui/BungieImage';
 import { DimItem } from '../inventory/item-types';
-import { AppIcon, faCheck } from '../shell/icons';
+import { AppIcon, faCheck, faClock } from '../shell/icons';
 import EmblemPreview from './EmblemPreview';
 import EnergyMeter from './EnergyMeter';
 import { ItemPopupExtraInfo } from './item-popup';
@@ -75,8 +76,6 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
       )}
 
       <ItemDescription item={item} defs={defs} />
-
-      <ItemExpiration item={item} />
 
       {!item.stats && Boolean(item.collectibleHash) && isD2Manifest(defs) && (
         <div className="item-details">
@@ -203,6 +202,20 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
           </div>
         )
       )}
+
+      <ItemExpiration item={item} />
+
+      {item.tooltipNotifications?.map((tip) => (
+        <div
+          key={tip.displayString}
+          className={clsx('quest-expiration item-details', {
+            'seasonal-expiration': tip.displayStyle === 'seasonal-expiration',
+          })}
+        >
+          {tip.displayStyle === 'seasonal-expiration' && <AppIcon icon={faClock} />}
+          {tip.displayString}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/app/item-popup/ItemExpiration.tsx
+++ b/src/app/item-popup/ItemExpiration.tsx
@@ -30,7 +30,7 @@ export default function ItemExpiration({ item, compact }: { item: DimItem; compa
         )
       ) : (
         <>
-          <AppIcon icon={faClock} /> {!compact && t('Progress.QuestExpires')}{' '}
+          <AppIcon icon={faClock} /> {!compact && t('Progress.QuestExpires')}
           <Countdown endTime={new Date(item.pursuit.expirationDate)} compact={compact} />
         </>
       )}

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -51,6 +51,10 @@
   }
 }
 
+.seasonal-expiration {
+  color: rgb(218, 149, 45);
+}
+
 .item-description {
   margin: 5px 10px;
   white-space: pre-wrap;

--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -110,20 +110,20 @@
   }
 }
 
-.pursuit {
-  background-color: #555;
-  color: #eee;
-  a {
-    color: #eee;
-  }
-}
-
 .uncommon {
   background-color: $uncommon;
 }
 
 .rare {
   background-color: $rare;
+}
+
+.pursuit {
+  background-color: #333;
+  color: #eee;
+  a {
+    color: #eee;
+  }
 }
 
 .legendary {

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -62,6 +62,14 @@ export default function ItemPopupHeader({ item }: { item: DimItem }) {
               })}
             </div>
           )}
+          {item.pursuit?.questStepNum && (
+            <div className={styles.itemType}>
+              {t('MovePopup.Subtitle.QuestProgress', {
+                questStepNum: item.pursuit.questStepNum,
+                questStepsTotal: item.pursuit.questStepsTotal,
+              })}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -115,6 +115,10 @@
 }
 
 .quest-expiration {
+  .app-icon {
+    margin-right: 4px;
+  }
+
   &.expires-soon {
     color: #c74141;
   }

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -6,6 +6,7 @@ import { Reward } from 'app/progress/Reward';
 import { percent } from 'app/shell/filters';
 import { RootState } from 'app/store/types';
 import {
+  DestinyItemQuantity,
   DestinyObjectiveProgress,
   DestinyRecordComponent,
   DestinyRecordDefinition,
@@ -42,6 +43,7 @@ interface RecordInterval {
   score: number;
   percentCompleted: number;
   isRedeemed: boolean;
+  rewards: DestinyItemQuantity[];
 }
 
 const overrideIcons = Object.keys(catalystIcons).map(Number);
@@ -144,6 +146,10 @@ export default function Record({
             .objective,
         ]
       : recordComponent.objectives;
+  const rewards =
+    intervals.length > 0
+      ? intervals[Math.min(recordComponent.intervalsRedeemedCount, intervals.length - 1)].rewards
+      : recordDef.rewardItems;
   const showObjectives =
     !obscured &&
     objectives &&
@@ -196,12 +202,10 @@ export default function Record({
             <ExternalLink href={loreLink}>{t('MovePopup.ReadLore')}</ExternalLink>
           </div>
         )}
-        {recordDef.rewardItems?.length > 0 &&
+        {rewards &&
           !acquired &&
           !obscured &&
-          recordDef.rewardItems.map((reward) => (
-            <Reward key={reward.itemHash} reward={reward} defs={defs} />
-          ))}
+          rewards.map((reward) => <Reward key={reward.itemHash} reward={reward} defs={defs} />)}
         {trackedInGame && <img className={styles.trackedIcon} src={trackedIcon} />}
         {(!acquired || trackedInDim) && (
           <div role="button" onClick={toggleTracked} className={styles.dimTrackedIcon}>
@@ -225,6 +229,7 @@ function getIntervals(
 ): RecordInterval[] {
   const intervalDefinitions = definition?.intervalInfo?.intervalObjectives || [];
   const intervalObjectives = record?.intervalObjectives || [];
+  const intervalRewards = definition?.intervalInfo?.intervalRewards || [];
   if (intervalDefinitions.length !== intervalObjectives.length) {
     return [];
   }
@@ -235,6 +240,7 @@ function getIntervals(
   for (let i = 0; i < intervalDefinitions.length; i++) {
     const def = intervalDefinitions[i];
     const data = intervalObjectives[i];
+    const rewards = intervalRewards[i].intervalRewardItems;
 
     intervals.push({
       objective: data,
@@ -249,6 +255,7 @@ function getIntervals(
             )
         : 0,
       isRedeemed: record.intervalsRedeemedCount >= i + 1,
+      rewards,
     });
 
     isPrevIntervalComplete = data.complete;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -599,6 +599,7 @@
     "StoreWithName": "Store on {{character}}",
     "Subtitle": {
       "Gear": "{{light}} {{statName}} {{classType}} {{typeName}}",
+      "QuestProgress": "Step {{questStepNum}} of {{questStepsTotal}}",
       "Type": "{{classType}} {{typeName}}"
     },
     "ToggleSidecar": "Expand or collapse item actions",


### PR DESCRIPTION
<img width="390" alt="Screen Shot 2021-02-13 at 3 41 04 PM" src="https://user-images.githubusercontent.com/313208/107864542-1e321f00-6e12-11eb-8d50-159cc08056ae.png">

The data is dirty, so I had to mess with it a bit, but I think this'll mostly work.

While I was at it, I decided to also show quest step:

<img width="353" alt="Screen Shot 2021-02-13 at 4 05 09 PM" src="https://user-images.githubusercontent.com/313208/107864829-2a6bab80-6e15-11eb-89d2-564d738ca7dd.png">
