### PR TITLE
Cancel moves

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -123,7 +123,7 @@
       "Tooltip": "If checked, DIM will move weapons and armor around to make space in the vault for engrams."
     },
     "MoveTokens": "Send reputation items to the vault",
-    "OutOfRoom": "You're out of space to move items off of {{character}}. Time to decrypt some engrams and clear out the trash!",
+    "OutOfRoom": "You're out of space to move items off of {{character}}. Time to clear out the trash!",
     "OutOfRoomTitle": "Out of Room",
     "Stop": "Stop"
   },
@@ -550,8 +550,10 @@
     "PullFromPostmasterNotification_female_plural": "Pulling {{count}} Postmaster items to {{store}}.",
     "PullFromPostmasterNotification_male_plural": "Pulling {{count}} Postmaster items to {{store}}.",
     "PullFromPostmasterError": "Unable to pull from Postmaster: {{error}}.",
+    "PullFromPostmasterGeneralError": "Unable to pull all items from Postmaster.",
     "PullFromPostmasterPopupTitle": "Pull from Postmaster",
     "PullMakeSpace": "Space",
+    "NoSpace": "You're out of space in the vault and any other characters.",
     "Random": "Random",
     "Randomize": "Randomize",
     "RandomizePrompt": "Randomize your equipped class, weapons, armor and ghost?",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+* Pulling from postmaster, applying loadouts, moving searches, moving individual items, and more are now cancel-able. Click the "cancel" button in the notification to prevent any further actions.
+* Bulk tagging in the Organizer no longer shows an "undo" popup. We expect you know what you're doing there!
+
 ## 6.52.0 <span class="changelog-date">(2021-02-14)</span>
 
 * Search filters that operate on power levels now accept the keywords "pinnaclecap", "powerfulcap", "softcap", and "powerfloor" to refer to the current season's power limits. e.g "power:>=softcap"

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -779,6 +779,9 @@ function setTag(
 
   if (tag) {
     if (existingTag) {
+      if (existingTag.tag === tag) {
+        return; // nothing to do
+      }
       existingTag.tag = tag;
     } else {
       tags[itemId] = {
@@ -787,9 +790,13 @@ function setTag(
       };
     }
   } else {
-    delete existingTag?.tag;
-    if (!existingTag?.tag && !existingTag?.notes) {
-      delete tags[itemId];
+    if (existingTag?.tag) {
+      delete existingTag.tag;
+      if (!existingTag.notes) {
+        delete tags[itemId];
+      }
+    } else {
+      return; // nothing to do
     }
   }
 

--- a/src/app/inventory/MoveNotifications.tsx
+++ b/src/app/inventory/MoveNotifications.tsx
@@ -18,11 +18,12 @@ const lingerMs = 2000;
 export function moveItemNotification(
   item: DimItem,
   target: DimStore,
-  movePromise: Promise<any>
+  movePromise: Promise<any>,
+  cancel: () => void
 ): NotifyInput {
   return {
     promise: movePromise,
-    duration: lingerMs,
+    duration: 0,
     title: item.name,
     icon: <ConnectedInventoryItem item={item} />,
     trailer: <MoveItemNotificationIcon completion={movePromise} />,
@@ -31,6 +32,7 @@ export function moveItemNotification(
       target: target.name,
       context: target.genderName,
     }),
+    onCancel: cancel,
   };
 }
 
@@ -40,11 +42,14 @@ export function moveItemNotification(
 export function loadoutNotification(
   loadout: Loadout,
   store: DimStore,
-  loadoutPromise: Promise<any>
+  loadoutPromise: Promise<any>,
+  cancel: () => void
 ): NotifyInput {
   const count = loadout.items.length;
 
   // TODO: pass in a state updater that can communicate application state
+
+  // TODO: body! show all items, check 'em off
 
   return {
     promise: loadoutPromise,
@@ -56,6 +61,7 @@ export function loadoutNotification(
       store: store.name,
       context: store.genderName,
     }),
+    onCancel: cancel,
   };
 }
 
@@ -65,7 +71,8 @@ export function loadoutNotification(
 export function postmasterNotification(
   count: number,
   store: DimStore,
-  promise: Promise<any>
+  promise: Promise<any>,
+  cancel: () => void
 ): NotifyInput {
   // TODO: pass in a state updater that can communicate application state
 
@@ -79,6 +86,7 @@ export function postmasterNotification(
       store: store.name,
       context: store.genderName,
     }),
+    onCancel: cancel,
   };
 }
 

--- a/src/app/inventory/bulk-actions.tsx
+++ b/src/app/inventory/bulk-actions.tsx
@@ -14,7 +14,11 @@ import { itemHashTagsSelector, itemInfosSelector } from './selectors';
 /**
  * Bulk tag items, with an undo button in a notification.
  */
-export function bulkTagItems(itemsToBeTagged: DimItem[], selectedTag: TagValue): ThunkResult {
+export function bulkTagItems(
+  itemsToBeTagged: DimItem[],
+  selectedTag: TagValue,
+  notification = true
+): ThunkResult {
   return async (dispatch, getState) => {
     const appliedTagInfo = tagConfig[selectedTag];
     const itemInfos = itemInfosSelector(getState());
@@ -49,54 +53,56 @@ export function bulkTagItems(itemsToBeTagged: DimItem[], selectedTag: TagValue):
       }
     }
 
-    showNotification({
-      type: 'success',
-      duration: 30000,
-      title: t('Header.BulkTag'),
-      body: (
-        <>
-          {selectedTag === 'clear'
-            ? t('Filter.BulkClear', {
-                count: itemsToBeTagged.length,
-              })
-            : t('Filter.BulkTag', {
-                count: itemsToBeTagged.length,
-                tag: t(appliedTagInfo.label),
-              })}
-          <NotificationButton
-            onClick={async () => {
-              if (instanced.length) {
-                dispatch(
-                  setItemTagsBulk(
-                    instanced.map((item) => ({
-                      itemId: item.id,
-                      tag: previousState.get(item),
-                    }))
-                  )
-                );
-              }
-              if (nonInstanced.length) {
-                for (const item of nonInstanced) {
+    if (notification) {
+      showNotification({
+        type: 'success',
+        duration: 30000,
+        title: t('Header.BulkTag'),
+        body: (
+          <>
+            {selectedTag === 'clear'
+              ? t('Filter.BulkClear', {
+                  count: itemsToBeTagged.length,
+                })
+              : t('Filter.BulkTag', {
+                  count: itemsToBeTagged.length,
+                  tag: t(appliedTagInfo.label),
+                })}
+            <NotificationButton
+              onClick={async () => {
+                if (instanced.length) {
                   dispatch(
-                    setItemHashTag({
-                      itemHash: item.hash,
-                      tag: previousState.get(item),
-                    })
+                    setItemTagsBulk(
+                      instanced.map((item) => ({
+                        itemId: item.id,
+                        tag: previousState.get(item),
+                      }))
+                    )
                   );
                 }
-              }
-              showNotification({
-                type: 'success',
-                title: t('Header.BulkTag'),
-                body: t('Filter.BulkRevert', { count: itemsToBeTagged.length }),
-              });
-            }}
-          >
-            <AppIcon icon={undoIcon} /> {t('Filter.Undo')}
-          </NotificationButton>
-        </>
-      ),
-    });
+                if (nonInstanced.length) {
+                  for (const item of nonInstanced) {
+                    dispatch(
+                      setItemHashTag({
+                        itemHash: item.hash,
+                        tag: previousState.get(item),
+                      })
+                    );
+                  }
+                }
+                showNotification({
+                  type: 'success',
+                  title: t('Header.BulkTag'),
+                  body: t('Filter.BulkRevert', { count: itemsToBeTagged.length }),
+                });
+              }}
+            >
+              <AppIcon icon={undoIcon} /> {t('Filter.Undo')}
+            </NotificationButton>
+          </>
+        ),
+      });
+    }
   };
 }
 

--- a/src/app/loadout/loadout-apply.ts
+++ b/src/app/loadout/loadout-apply.ts
@@ -24,6 +24,7 @@ import { showNotification } from 'app/notifications/notifications';
 import { loadingTracker } from 'app/shell/loading-tracker';
 import { ThunkResult } from 'app/store/types';
 import { queueAction } from 'app/utils/action-queue';
+import { CanceledError, CancelToken, withCancel } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog } from 'app/utils/log';
@@ -67,7 +68,11 @@ export function applyLoadout(store: DimStore, loadout: Loadout, allowUndo = fals
       infoLog('loadout', 'Apply loadout', loadout.name, 'to', store.name);
     }
 
-    const loadoutPromise = queueAction(() => dispatch(doApplyLoadout(store, loadout, allowUndo)));
+    const [cancelToken, cancel] = withCancel();
+
+    const loadoutPromise = queueAction(() =>
+      dispatch(doApplyLoadout(store, loadout, cancelToken, allowUndo))
+    );
     loadingTracker.addPromise(loadoutPromise);
 
     showNotification(
@@ -87,7 +92,8 @@ export function applyLoadout(store: DimStore, loadout: Loadout, allowUndo = fals
               );
             }
           }
-        })
+        }),
+        cancel
       )
     );
 
@@ -95,7 +101,12 @@ export function applyLoadout(store: DimStore, loadout: Loadout, allowUndo = fals
   };
 }
 
-function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = false): ThunkResult<Scope> {
+function doApplyLoadout(
+  store: DimStore,
+  loadout: Loadout,
+  cancelToken: CancelToken,
+  allowUndo = false
+): ThunkResult<Scope> {
   return async (dispatch, getState) => {
     dispatch(interruptFarming());
     const getStores = () => storesSelector(getState());
@@ -192,7 +203,7 @@ function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = false): T
       await Promise.all(dequips);
     }
 
-    await dispatch(applyLoadoutItems(store, items, loadoutItemIds, scope));
+    await dispatch(applyLoadoutItems(store, items, loadoutItemIds, cancelToken, scope));
 
     let equippedItems: LoadoutItem[];
     if (itemsToEquip.length > 1) {
@@ -234,7 +245,9 @@ function doApplyLoadout(store: DimStore, loadout: Loadout, allowUndo = false): T
           .flat()
           .map((i) => getLoadoutItem(i, store, getStores()))
       );
-      await dispatch(clearSpaceAfterLoadout(getStore(getStores(), store.id)!, allItems));
+      await dispatch(
+        clearSpaceAfterLoadout(getStore(getStores(), store.id)!, allItems, cancelToken)
+      );
     }
 
     dispatch(resumeFarming());
@@ -247,6 +260,7 @@ function applyLoadoutItems(
   store: DimStore,
   items: LoadoutItem[],
   loadoutItemIds: { id: string; hash: number }[],
+  cancelToken: CancelToken,
   scope: {
     failed: number;
     total: number;
@@ -312,20 +326,33 @@ function applyLoadoutItems(
               totalAmount += amountToMove;
 
               await dispatch(
-                executeMoveItem(sourceItem, store, false, amountToMove, loadoutItemIds)
+                executeMoveItem(sourceItem, store, {
+                  equip: false,
+                  amount: amountToMove,
+                  excludes: loadoutItemIds,
+                  cancelToken,
+                })
               );
             }
           }
         } else {
           // Pass in the list of items that shouldn't be moved away
           await dispatch(
-            executeMoveItem(item, store, pseudoItem.equipped, item.amount, loadoutItemIds)
+            executeMoveItem(item, store, {
+              equip: pseudoItem.equipped,
+              amount: item.amount,
+              excludes: loadoutItemIds,
+              cancelToken,
+            })
           );
         }
 
         scope.successfulItems.push(item);
       }
     } catch (e) {
+      if (e instanceof CanceledError) {
+        throw e;
+      }
       const level = e.level || 'error';
       if (level === 'error') {
         errorLog('loadout', 'Failed to apply loadout item', item?.name, e);
@@ -339,7 +366,7 @@ function applyLoadoutItems(
     }
 
     // Keep going
-    return dispatch(applyLoadoutItems(store, items, loadoutItemIds, scope));
+    return dispatch(applyLoadoutItems(store, items, loadoutItemIds, cancelToken, scope));
   };
 }
 
@@ -365,7 +392,7 @@ function getLoadoutItem(
   return item;
 }
 
-function clearSpaceAfterLoadout(store: DimStore, items: DimItem[]) {
+function clearSpaceAfterLoadout(store: DimStore, items: DimItem[], cancelToken: CancelToken) {
   const itemsByType = _.groupBy(items, (i) => i.bucket.hash);
 
   const reservations: MoveReservations = {};
@@ -409,7 +436,7 @@ function clearSpaceAfterLoadout(store: DimStore, items: DimItem[]) {
       loadoutItems[0].bucket.capacity - numUnequippedLoadoutItems;
   });
 
-  return clearItemsOffCharacter(store, itemsToRemove, reservations);
+  return clearItemsOffCharacter(store, itemsToRemove, cancelToken, reservations);
 }
 
 /**
@@ -420,6 +447,7 @@ function clearSpaceAfterLoadout(store: DimStore, items: DimItem[]) {
 export function clearItemsOffCharacter(
   store: DimStore,
   items: DimItem[],
+  cancelToken: CancelToken,
   reservations: MoveReservations
 ): ThunkResult {
   return async (dispatch, getState) => {
@@ -452,14 +480,13 @@ export function clearItemsOffCharacter(
               );
             }
             await dispatch(
-              executeMoveItem(
-                item,
-                otherStoresWithSpace[0],
-                false,
-                item.amount,
-                items,
-                reservations
-              )
+              executeMoveItem(item, otherStoresWithSpace[0], {
+                equip: false,
+                amount: item.amount,
+                excludes: items,
+                reservations,
+                cancelToken,
+              })
             );
             continue;
           } else if (vaultSpaceLeft === 0) {
@@ -480,8 +507,19 @@ export function clearItemsOffCharacter(
             getStore(stores, item.owner)!.name
           );
         }
-        await dispatch(executeMoveItem(item, vault, false, item.amount, items, reservations));
+        await dispatch(
+          executeMoveItem(item, vault, {
+            equip: false,
+            amount: item.amount,
+            excludes: items,
+            reservations,
+            cancelToken,
+          })
+        );
       } catch (e) {
+        if (e instanceof CanceledError) {
+          throw e;
+        }
         if (e instanceof DimError && e.code === 'no-space') {
           outOfSpaceWarning(store);
         } else {

--- a/src/app/notifications/Notification.tsx
+++ b/src/app/notifications/Notification.tsx
@@ -6,6 +6,8 @@ import './Notification.scss';
 import NotificationButton from './NotificationButton';
 import { NotificationError, Notify } from './notifications';
 
+const showErrorDuration = 5000;
+
 interface Props extends MotionProps {
   notification: Notify;
   onClose(notification: Notify): void;
@@ -27,14 +29,14 @@ export default function Notification({ notification, onClose, ...animation }: Pr
       notification.promise
         .then(() => setSuccess(true))
         .catch((e) => (e instanceof CanceledError ? setSuccess(true) : setError(e)));
-    } else if (notification.duration) {
+    } else if (notification.duration || error) {
       timer.current = window.setTimeout(
         () => {
           if (!mouseover) {
             onClose(notification);
           }
         },
-        error ? 5000 : notification.duration
+        error ? showErrorDuration : notification.duration
       );
     } else {
       window.setTimeout(() => onClose(notification), 0);
@@ -81,7 +83,7 @@ export default function Notification({ notification, onClose, ...animation }: Pr
     : {
         type: 'tween',
         ease: 'linear',
-        duration: notification.duration / 1000 - 0.3,
+        duration: (error ? showErrorDuration : notification.duration) / 1000 - 0.3,
       };
 
   // A NotificationError can override a lot of properties

--- a/src/app/notifications/Notification.tsx
+++ b/src/app/notifications/Notification.tsx
@@ -1,8 +1,10 @@
+import { CanceledError } from 'app/utils/cancel';
 import clsx from 'clsx';
 import { motion, MotionProps, Transition } from 'framer-motion';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './Notification.scss';
-import { Notify } from './notifications';
+import NotificationButton from './NotificationButton';
+import { NotificationError, Notify } from './notifications';
 
 interface Props extends MotionProps {
   notification: Notify;
@@ -12,7 +14,7 @@ interface Props extends MotionProps {
 export default function Notification({ notification, onClose, ...animation }: Props) {
   const [mouseover, setMouseover] = useState(false);
   const [success, setSuccess] = useState<boolean | undefined>();
-  const [error, setError] = useState<Error | undefined>();
+  const [error, setError] = useState<NotificationError | undefined>();
 
   const timer = useRef(0);
 
@@ -22,7 +24,9 @@ export default function Notification({ notification, onClose, ...animation }: Pr
       timer.current = 0;
     }
     if (!error && !success && notification.promise) {
-      notification.promise.then(() => setSuccess(true)).catch(setError);
+      notification.promise
+        .then(() => setSuccess(true))
+        .catch((e) => (e instanceof CanceledError ? setSuccess(true) : setError(e)));
     } else if (notification.duration) {
       timer.current = window.setTimeout(
         () => {
@@ -80,6 +84,12 @@ export default function Notification({ notification, onClose, ...animation }: Pr
         duration: notification.duration / 1000 - 0.3,
       };
 
+  // A NotificationError can override a lot of properties
+  const title = error?.title || notification.title;
+  const body = error?.body || error?.message || notification.body;
+  const icon = error?.icon || notification.icon;
+  const trailer = error?.trailer || notification.trailer;
+
   return (
     <motion.div
       className="notification"
@@ -97,18 +107,15 @@ export default function Notification({ notification, onClose, ...animation }: Pr
         )}
       >
         <div className="notification-contents">
-          {notification.icon && <div className="notification-icon">{notification.icon}</div>}
+          {icon && <div className="notification-icon">{icon}</div>}
           <div className="notification-details">
-            <div className="notification-title">{notification.title}</div>
-            {error ? (
-              <div className="notification-body">{error.message}</div>
-            ) : (
-              notification.body && <div className="notification-body">{notification.body}</div>
+            <div className="notification-title">{title}</div>
+            {body && <div className="notification-body">{body}</div>}
+            {!error && notification.onCancel && (
+              <NotificationButton onClick={notification.onCancel}>Cancel</NotificationButton>
             )}
           </div>
-          {notification.trailer && (
-            <div className="notification-trailer">{notification.trailer}</div>
-          )}
+          {trailer && <div className="notification-trailer">{trailer}</div>}
         </div>
         {(success || error || !notification.promise) &&
           typeof notification.duration === 'number' && (

--- a/src/app/notifications/notifications.ts
+++ b/src/app/notifications/notifications.ts
@@ -7,14 +7,17 @@ export interface NotifyInput {
   title: string;
   body?: React.ReactNode;
   type?: NotificationType;
+  /** Some content to show to the left of the notification */
   icon?: React.ReactNode;
+  /** Some content to show to the right of the notification */
   trailer?: React.ReactNode;
-  /** The notification will stay up while the promise is not complete, and for a duration afterwards. */
+  /** The notification will stay up while the promise is not complete, and for a duration afterwards. Throw NotificationError to customize the error screen. */
   promise?: Promise<any>;
   /** The notification will show for the given number of milliseconds. */
   duration?: number;
   /** Return false to not close the notification on click. */
   onClick?(event: React.MouseEvent): boolean | void;
+  onCancel?(): void;
 }
 
 export interface Notify {
@@ -28,6 +31,44 @@ export interface Notify {
   /** The notification will show for either the given number of milliseconds, or when the provided promise completes. */
   duration: number;
   onClick?(event: React.MouseEvent): boolean | void;
+  onCancel?(): void;
+}
+
+/**
+ * An error that allows setting the properties of the notification. Throw this from your promise
+ * to transform the notification into an error.
+ */
+export class NotificationError extends Error {
+  title?: string;
+  body?: React.ReactNode;
+  type?: NotificationType;
+  icon?: React.ReactNode;
+  trailer?: React.ReactNode;
+
+  constructor(
+    message: string,
+    {
+      title,
+      body,
+      type,
+      icon,
+      trailer,
+    }: {
+      title?: string;
+      body?: React.ReactNode;
+      type?: NotificationType;
+      icon?: React.ReactNode;
+      trailer?: React.ReactNode;
+    }
+  ) {
+    super(message);
+    this.name = 'NotificationError';
+    this.title = title;
+    this.body = body || message;
+    this.type = type || 'error';
+    this.icon = icon;
+    this.trailer = trailer;
+  }
 }
 
 export const notifications$ = new Subject<Notify>();

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -325,7 +325,7 @@ function ItemTable({
   const onTagSelectedItems = (tagInfo: TagInfo) => {
     if (tagInfo.type && selectedItemIds.length) {
       const selectedItems = items.filter((i) => selectedItemIds.includes(i.id));
-      dispatch(bulkTagItems(selectedItems, tagInfo.type));
+      dispatch(bulkTagItems(selectedItems, tagInfo.type, false));
     }
   };
 

--- a/src/app/utils/cancel.ts
+++ b/src/app/utils/cancel.ts
@@ -1,0 +1,50 @@
+/**
+ * A CancelToken should be passed to cancelable functions. Those functions should then check the state of the
+ * token and return early, or use checkCanceled to throw a CanceledError if the token has been canceled. Callers
+ * of cancelable functions should catch CanceledError.
+ */
+export interface CancelToken {
+  readonly canceled;
+  checkCanceled(): void;
+}
+
+/**
+ * Indicates that the function was canceled by a call to the cancellation token's cancel function.
+ */
+export class CanceledError extends Error {
+  constructor() {
+    super('canceled');
+    this.name = 'CanceledError';
+  }
+}
+
+/**
+ * Returns a cancel token and a cancellation function. The token can be passed to functions and checked
+ * to see whether it has been canceled. The function can be called to cancel the token.
+ */
+export function withCancel(): [CancelToken, () => void] {
+  const innerToken = {
+    canceled: false,
+  };
+  return [
+    {
+      get canceled() {
+        return innerToken.canceled;
+      },
+      checkCanceled() {
+        if (this.canceled) {
+          throw new CanceledError();
+        }
+      },
+    },
+    () => (innerToken.canceled = true),
+  ];
+}
+
+export const neverCanceled = {
+  get canceled() {
+    return false;
+  },
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  checkCanceled() {},
+};

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -135,7 +135,7 @@
       "MakeRoom": "Make room to pick up items by moving equipment",
       "Tooltip": "If checked, DIM will move weapons and armor around to make space in the vault for engrams."
     },
-    "OutOfRoom": "You're out of space to move items off of {{character}}. Time to decrypt some engrams and clear out the trash!",
+    "OutOfRoom": "You're out of space to move items off of {{character}}. Time to clear out the trash!",
     "OutOfRoomTitle": "Out of Room",
     "Stop": "Stop"
   },
@@ -208,7 +208,6 @@
     "Perk": "Shows items where one of their perks or mods has a partial match to the filter text in their name or description. Search for entire phrases using quotes.",
     "PerkName": "Shows items where one of their perks or mods has a partial match to the filter text in their name only. Search for entire phrases using quotes.",
     "Postmaster": "Items that are currently in the Postmaster.",
-    "PowerKeywords": "Use the hardcap or softcap keyword instead of a number to refer to the current season's power limits.",
     "PowerLevel": "Shows items based on their power level. $t(Filter.PowerKeywords)",
     "PowerLimit": "Shows items based on the maximum power level they can be infused to. $t(Filter.PowerKeywords)",
     "PowerfulReward": "Shows pursuits which produce a powerful reward.",
@@ -509,6 +508,7 @@
     "ModsInfo": "DIM cannot equip mods, it must be done in game.",
     "NoEngrams": "No non-exotic engrams are available to transfer.",
     "NoExotics": "No engrams are available to transfer.",
+    "NoSpace": "You're out of space in the vault and any other characters.",
     "NotificationMessage": "Sending loadout with 1 item to vault.",
     "NotificationMessage_female": "Equipping loadout with 1 item to {{store}}",
     "NotificationMessage_female_plural": "Equipping loadout with {{count}} items to {{store}}",
@@ -520,6 +520,7 @@
     "OpenInOptimizer": "Open in Loadout Optimizer",
     "PullFromPostmaster": "Collect Postmaster",
     "PullFromPostmasterError": "Unable to pull from Postmaster: {{error}}.",
+    "PullFromPostmasterGeneralError": "Unable to pull all items from Postmaster.",
     "PullFromPostmasterNotification": "Pulling 1 Postmaster item to {{store}}.",
     "PullFromPostmasterNotification_female": "Pulling 1 Postmaster item to {{store}}.",
     "PullFromPostmasterNotification_female_plural": "Pulling {{count}} Postmaster items to {{store}}.",


### PR DESCRIPTION
This adds a `withCancel` helper and winds it through all the item move code to make all item moves cancelable from the move notification popup. I then extended that to loadout moves (including search loadout), pull from postmaster, and anything else I could find. Canceling these operations prevents any further action but does not roll back any actions that have already been taken.

I also removed the bulk tag notification from the Organizer, since it seems superfluous.