### PR TITLE
Bugfix: ensure duplicate mod permutation isn't being added to Set

### DIFF
--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -66,6 +66,7 @@ export function generateModPermutations(mods: ProcessMod[]): (ProcessMod | null)
   let i = 0;
 
   const rtn = [Array.from(modsCopy)];
+  containsSet.add(stringifyModPermutation(modsCopy));
 
   while (i < 5) {
     if (cursorArray[i] < i) {


### PR DESCRIPTION
`generateModPermutations` currently creates a duplicate permutation as the initial array isn't added to `containsSet`