### PR TITLE
Special-case simple searches

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Deleting multiple searches from your search history works now - before there was a bug where only the first delete would succeed.
 * On the Search History page accessible from Settings, you can now clear all non-saved searches with a single button.
 * Deprecated search filters no longer show up in Filter Help.
+* Searches that don't use any special filters now search for the entire string in item names and descriptions and perk names and descriptions. e.g. `gnawing hunger` now searches for the full string "gnawing hunger" as opposed to being equivalent to `"gnawing" and "hunger"`.
 
 ## 6.55.0 <span class="changelog-date">(2021-03-07)</span>
 

--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -3937,19 +3937,9 @@ Array [
 
 exports[`parse |cluster tracking|: ast 1`] = `
 Object {
-  "op": "and",
-  "operands": Array [
-    Object {
-      "args": "cluster",
-      "op": "filter",
-      "type": "keyword",
-    },
-    Object {
-      "args": "tracking",
-      "op": "filter",
-      "type": "keyword",
-    },
-  ],
+  "args": "cluster tracking",
+  "op": "filter",
+  "type": "keyword",
 }
 `;
 
@@ -3958,15 +3948,25 @@ Array [
   Array [
     "filter",
     "keyword",
-    "cluster",
+    "cluster tracking",
   ],
-  Array [
-    "implicit_and",
-  ],
+]
+`;
+
+exports[`parse |gnawing hunger|: ast 1`] = `
+Object {
+  "args": "gnawing hunger",
+  "op": "filter",
+  "type": "keyword",
+}
+`;
+
+exports[`parse |gnawing hunger|: lexer 1`] = `
+Array [
   Array [
     "filter",
     "keyword",
-    "tracking",
+    "gnawing hunger",
   ],
 ]
 `;
@@ -4709,6 +4709,60 @@ Array [
 ]
 `;
 
+exports[`parse |not "forgotten"|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "args": "forgotten",
+    "op": "filter",
+    "type": "keyword",
+  },
+}
+`;
+
+exports[`parse |not "forgotten"|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "filter",
+    "keyword",
+    "forgotten",
+  ],
+]
+`;
+
+exports[`parse |not (forgotten)|: ast 1`] = `
+Object {
+  "op": "not",
+  "operand": Object {
+    "args": "forgotten",
+    "op": "filter",
+    "type": "keyword",
+  },
+}
+`;
+
+exports[`parse |not (forgotten)|: lexer 1`] = `
+Array [
+  Array [
+    "not",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "filter",
+    "keyword",
+    "forgotten",
+  ],
+  Array [
+    ")",
+  ],
+]
+`;
+
 exports[`parse |not -not:maxpower|: ast 1`] = `
 Object {
   "op": "not",
@@ -4744,24 +4798,36 @@ Array [
 
 exports[`parse |not forgotten|: ast 1`] = `
 Object {
-  "op": "not",
-  "operand": Object {
-    "args": "forgotten",
-    "op": "filter",
-    "type": "keyword",
-  },
+  "args": "not forgotten",
+  "op": "filter",
+  "type": "keyword",
+}
+`;
+
+exports[`parse |not forgotten|: ast 2`] = `
+Object {
+  "args": "not forgotten",
+  "op": "filter",
+  "type": "keyword",
 }
 `;
 
 exports[`parse |not forgotten|: lexer 1`] = `
 Array [
   Array [
-    "not",
+    "filter",
+    "keyword",
+    "not forgotten",
   ],
+]
+`;
+
+exports[`parse |not forgotten|: lexer 2`] = `
+Array [
   Array [
     "filter",
     "keyword",
-    "forgotten",
+    "not forgotten",
   ],
 ]
 `;
@@ -4885,7 +4951,7 @@ Array [
 
 exports[`parse |‘grenade launcher reserves’|: ast 1`] = `
 Object {
-  "args": "grenade launcher reserves",
+  "args": "'grenade launcher reserves'",
   "op": "filter",
   "type": "keyword",
 }
@@ -4896,7 +4962,7 @@ Array [
   Array [
     "filter",
     "keyword",
-    "grenade launcher reserves",
+    "'grenade launcher reserves'",
   ],
 ]
 `;

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -50,6 +50,11 @@ const cases = [
   [
     '  (\n    (\n    (is:weapon -is:maxpower powerlimit:1060 or tag:junk or is:blue)\n    or\n    (\n    (is:armor -is:exotic -is:classitem)\n  \n    -(is:titan (basestat:recovery:>=18 or basestat:total:>=63))\n    -(is:hunter ((basestat:recovery:>=13 basestat:mobility:>=18) or basestat:recovery:>15 or basestat:total:>=63))\n    -(is:warlock ((basestat:recovery:>=18 discipline:>=17) or basestat:total:>=63))\n  \n    -(\n    ((basestat:mobility:>=18 basestat:resilience:>=13) or\n    (basestat:mobility:>=18 basestat:recovery:>=13) or\n    (basestat:mobility:>=18 basestat:discipline:>=13) or\n    (basestat:mobility:>=18 basestat:intellect:>=13) or\n    (basestat:mobility:>=18 basestat:strength:>=13) or\n    (basestat:resilience:>=18 basestat:mobility:>=13) or\n    (basestat:resilience:>=18 basestat:recovery:>=13) or\n    (basestat:resilience:>=18 basestat:discipline:>=13) or\n    (basestat:resilience:>=18 basestat:intellect:>=13) or\n    (basestat:resilience:>=18 basestat:strength:>=13) or\n    (basestat:recovery:>=18 basestat:mobility:>=13) or\n    (basestat:recovery:>=18 basestat:resilience:>=13) or\n    (basestat:recovery:>=18 basestat:discipline:>=13) or\n    (basestat:recovery:>=18 basestat:intellect:>=13) or\n    (basestat:recovery:>=18 basestat:strength:>=13) or\n    (basestat:discipline:>=18 basestat:mobility:>=13) or\n    (basestat:discipline:>=18 basestat:resilience:>=13) or\n    (basestat:discipline:>=18 basestat:recovery:>=13) or\n    (basestat:discipline:>=18 basestat:intellect:>=13) or\n    (basestat:discipline:>=18 basestat:strength:>=13) or\n    (basestat:intellect:>=18 basestat:mobility:>=13) or\n    (basestat:intellect:>=18 basestat:resilience:>=13) or\n    (basestat:intellect:>=18 basestat:recovery:>=13) or\n    (basestat:intellect:>=18 basestat:discipline:>=13) or\n    (basestat:intellect:>=18 basestat:strength:>=13) or\n    (basestat:strength:>=18 basestat:mobility:>=13) or\n    (basestat:strength:>=18 basestat:resilience:>=13) or\n    (basestat:strength:>=18 basestat:recovery:>=13) or\n    (basestat:strength:>=18 basestat:discipline:>=13) or\n    (basestat:strength:>=18 basestat:intellect:>=13))\n    )\n  \n    -(\n    ((basestat:mobility:>=13 basestat:resilience:>=13 basestat:recovery:>=13) or\n    (basestat:mobility:>=13 basestat:resilience:>=13 basestat:discipline:>=13) or\n    (basestat:mobility:>=13 basestat:resilience:>=13 basestat:intellect:>=13) or\n    (basestat:mobility:>=13 basestat:resilience:>=13 basestat:strength:>=13) or\n    (basestat:mobility:>=13 basestat:recovery:>=13 basestat:discipline:>=13) or\n    (basestat:mobility:>=13 basestat:recovery:>=13 basestat:intellect:>=13) or\n    (basestat:mobility:>=13 basestat:recovery:>=13 basestat:strength:>=13) or\n    (basestat:mobility:>=13 basestat:discipline:>=13 basestat:intellect:>=13) or\n    (basestat:mobility:>=13 basestat:discipline:>=13 basestat:strength:>=13) or\n    (basestat:mobility:>=13 basestat:intellect:>=13 basestat:strength:>=13) or\n    (basestat:resilience:>=13 basestat:recovery:>=13 basestat:discipline:>=13) or\n    (basestat:resilience:>=13 basestat:recovery:>=13 basestat:intellect:>=13) or\n    (basestat:resilience:>=13 basestat:recovery:>=13 basestat:strength:>=13) or\n    (basestat:resilience:>=13 basestat:discipline:>=13 basestat:intellect:>=13) or\n    (basestat:resilience:>=13 basestat:discipline:>=13 basestat:strength:>=13) or\n    (basestat:resilience:>=13 basestat:intellect:>=13 basestat:strength:>=13) or\n    (basestat:recovery:>=13 basestat:discipline:>=13 basestat:intellect:>=13) or\n    (basestat:recovery:>=13 basestat:discipline:>=13 basestat:strength:>=13) or\n    (basestat:recovery:>=13 basestat:intellect:>=13 basestat:strength:>=13) or\n    (basestat:discipline:>=13 basestat:intellect:>=13 basestat:strength:>=13))\n    )\n  \n    -(basestat:mobility:>=8 basestat:resilience:>=8 basestat:recovery:>=8 basestat:discipline:>=8 basestat:intellect:>=8 basestat:strength:>=8)\n    )\n  \n    or\n    (is:classitem ((is:dupelower -is:modded) or (is:sunset))) \n    or\n    (is:armor -powerlimit:>1060) \n    or\n    (is:armor is:blue)\n    )\n    -tag:keep -tag:archive -tag:favorite -tag:infuse -is:maxpower -power:>=1260 -is:inloadout -is:masterwork\n    )',
   ],
+  // Plaintext special case
+  ['not forgotten'],
+  ['not (forgotten)'],
+  ['not "forgotten"'],
+  ['gnawing hunger'],
 ];
 
 // Each of these asserts that the first query is the same as the second query once parsed
@@ -58,8 +63,8 @@ const equivalentSearches = [
     'is:blue is:weapon or is:armor not:maxpower',
     'is:blue and (is:weapon or is:armor) and -is:maxpower',
   ],
-  ['not forgotten', "-'forgotten'"],
-  ['cluster tracking', '"cluster" and "tracking"'],
+  ['not forgotten', '"not forgotten"'],
+  ['cluster tracking', '"cluster tracking"'],
   [
     'is:weapon and is:sniperrifle or not is:armor and modslot:arrival',
     '(is:weapon and is:sniperrifle) or (-is:armor and modslot:arrival)',
@@ -92,7 +97,7 @@ const canonicalize = [
     'is:rocketlauncher (perk:"tracking module" or perk:cluster)',
   ],
   ['( power:>1000 and -modslot:arrival ) ', '-modslot:arrival power:>1000'],
-  ['food fight', 'fight food'],
+  ['food fight', '"food fight"'],
 ];
 
 test.each(cases)('parse |%s|', (query) => {

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -273,6 +273,11 @@ const bareWords = /[^\s)]+/y;
 // Whitespace that doesn't match anything else is an implicit `and`
 const whitespace = /\s+/y;
 
+// A search matching this regex is treated as a single quoted string, to handle the common case of
+// someone typing "gnawing hunger" or "kill clip". This also means "not forgotten" is different from
+// "not (forgotten)" or "not "forgotten"".
+const isPlainSearch = /^[^":()<=>-]+$/;
+
 /**
  * The lexer yields a series of tokens representing the linear structure of the search query.
  * This throws an exception if it finds an invalid input.
@@ -286,6 +291,11 @@ export function* lexer(query: string): Generator<Token> {
   // http://blog.tatedavies.com/2012/08/28/replace-microsoft-chars-in-javascript/
   query = query.replace(/[\u2018|\u2019|\u201A]/g, "'");
   query = query.replace(/[\u201C|\u201D|\u201E]/g, '"');
+
+  // First test for the simple case of plaintext search
+  if (isPlainSearch.test(query)) {
+    return yield ['filter', 'keyword', query];
+  }
 
   let match: string | undefined;
   let i = 0;


### PR DESCRIPTION
This introduces a special case for "simple searches" where somebody just types in the name of something they want, without bothering with the full search syntax. This solves the `not forgotten` search problem and should match expectations better judging from many of the searches I see in our search history table. 

This will also prevent us from saving these searches to search history under the rule that single-node simple filters aren't saved, though I could be convinced that they *should* be saved if you spend a lot of your time searching for `gnawing hunger`.

There is one casualty which is single-quoted strings - they work normally within a complex expression, but the search `'gnawing hunger'` will now be equivalent to `"'gnawing hunger'"` wheras before it would've correctly been equivalent to `"gnawing hunger"`