### PR TITLE
Feat: Created Ammo Type Setting #6562

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -788,6 +788,7 @@
     "SingleCharacter": "Only show current character",
     "SingleCharacterExplanation": "DIM will hide all but the most recently played character. Those characters' inventories will appear as if they were in the vault.",
     "SizeItem": "Item size",
+    "SortByAmmoType": "Ammo Type",
     "SortByAmount": "Stack Size",
     "SortByClassType": "Required Class",
     "SortByPrimary": "Power level",

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -186,6 +186,7 @@ function SettingsPage({
     amount: t('Settings.SortByAmount'),
     rating: t('Settings.SortByRating'),
     classType: t('Settings.SortByClassType'),
+    ammoType: t('Settings.SortByAmmoType'),
     name: t('Settings.SortName'),
     tag: t('Settings.SortByTag', { taglist: tagListString }),
     season: t('Settings.SortBySeason'),

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -126,6 +126,7 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
     })
   ),
   classType: compareBy((item: DimItem) => item.classType),
+  ammoType: compareBy((item: DimItem) => item.ammoType),
   name: compareBy((item: DimItem) => item.name),
   amount: reverseComparator(compareBy((item: DimItem) => item.amount)),
   tag: compareBy((item: DimItem) => {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -753,6 +753,7 @@
     "SingleCharacter": "Only show current character",
     "SingleCharacterExplanation": "DIM will hide all but the most recently played character. Those characters' inventories will appear as if they were in the vault.",
     "SizeItem": "Item size",
+    "SortByAmmoType": "Ammo Type",
     "SortByAmount": "Stack Size",
     "SortByClassType": "Required Class",
     "SortByPrimary": "Power level",


### PR DESCRIPTION
So I've done the basic function for the ammo types for the weapon and it worked perfectly. What I did it within the settings was as followed:

Sort Items By:

1. Ammo Type
2. [Weapon] Type
3. Name

We will need to create a set of issues for localisation for the Ammo Type.