### PR TITLE
Fix for issue where a perk wasn't selectable for a user

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -318,7 +318,6 @@ function LoadoutBuilder({
           ReactDOM.createPortal(
             <PerkPicker
               classType={selectedStore.classType}
-              items={filteredItems}
               lockedMap={lockedMap}
               initialQuery={perkPicker.initialQuery}
               onClose={() => lbDispatch({ type: 'closePerkPicker' })}

--- a/src/app/loadout-builder/filter/PerkPicker.tsx
+++ b/src/app/loadout-builder/filter/PerkPicker.tsx
@@ -20,7 +20,7 @@ import Sheet from '../../dim-ui/Sheet';
 import '../../item-picker/ItemPicker.scss';
 import ArmorBucketIcon from '../ArmorBucketIcon';
 import { LoadoutBuilderAction } from '../loadoutBuilderReducer';
-import { ItemsByBucket, LockableBuckets, LockedItemType, LockedMap } from '../types';
+import { LockableBuckets, LockedItemType, LockedMap, LockedPerk } from '../types';
 import {
   addLockedItem,
   filterPlugs,
@@ -32,7 +32,6 @@ import styles from './PerkPicker.m.scss';
 import PickerSectionPerks from './PickerSectionPerks';
 
 interface ProvidedProps {
-  items: ItemsByBucket;
   lockedMap: LockedMap;
   classType: DestinyClass;
   initialQuery?: string;
@@ -108,7 +107,6 @@ function PerkPicker({
   lockedMap,
   perks,
   buckets,
-  items,
   language,
   isPhonePortrait,
   initialQuery,
@@ -223,6 +221,20 @@ function PerkPicker({
       )
     : undefined;
 
+  let lockedExoticPerk: LockedPerk | undefined;
+
+  for (const lockedBucket of Object.values(lockedMap)) {
+    for (const locked of lockedBucket || []) {
+      if (locked.type === 'perk') {
+        lockedExoticPerk = locked;
+        break;
+      }
+    }
+    if (lockedExoticPerk) {
+      break;
+    }
+  }
+
   return (
     <Sheet
       onClose={onClose}
@@ -261,8 +273,7 @@ function PerkPicker({
               defs={defs}
               bucket={buckets.byHash[bucketId]}
               perks={queryFilteredPerks[bucketId]}
-              locked={selectedPerks[bucketId] || []}
-              items={items[bucketId]}
+              lockedPerk={lockedExoticPerk}
               onPerkSelected={(perk) => onPerkSelected(perk, buckets.byHash[bucketId])}
             />
           )

--- a/src/app/loadout-builder/filter/PickerSectionPerks.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionPerks.tsx
@@ -1,9 +1,8 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
-import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import React from 'react';
-import { LockedItemType } from '../types';
-import { getFilteredPerksAndPlugSets } from '../utils';
+import { LockedItemType, LockedPerk } from '../types';
 import styles from './PickerSection.m.scss';
 import { SelectablePerk } from './SelectableBungieImage';
 
@@ -14,19 +13,15 @@ export default function PickerSectionPerks({
   bucket,
   defs,
   perks,
-  locked,
-  items,
+  lockedPerk,
   onPerkSelected,
 }: {
   bucket: InventoryBucket;
   defs: D2ManifestDefinitions;
   perks: readonly PluggableInventoryItemDefinition[];
-  locked: readonly LockedItemType[];
-  items: readonly DimItem[];
+  lockedPerk?: LockedPerk;
   onPerkSelected(perk: LockedItemType);
 }) {
-  const filterInfo = getFilteredPerksAndPlugSets(locked, items);
-
   return (
     <div className={styles.bucket}>
       <div className={styles.header}>{bucket.name}</div>
@@ -36,8 +31,8 @@ export default function PickerSectionPerks({
             key={perk.hash}
             defs={defs}
             bucket={bucket}
-            selected={Boolean(locked?.some((p) => p.type === 'perk' && p.perk.hash === perk.hash))}
-            selectable={Boolean(!filterInfo.filteredPerks || filterInfo.filteredPerks.has(perk))}
+            selected={Boolean(lockedPerk && perk.hash === lockedPerk.perk.hash)}
+            selectable={Boolean(!lockedPerk || perk.hash === lockedPerk.perk.hash)}
             perk={perk}
             onLockedPerk={onPerkSelected}
           />

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -1,9 +1,5 @@
 import { DimItem, DimSocket } from 'app/inventory/item-types';
-import {
-  DestinyEnergyType,
-  DestinyInventoryItemDefinition,
-  TierType,
-} from 'bungie-api-ts/destiny2';
+import { DestinyEnergyType, TierType } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { LockedItemType, LockedMod, statValues } from './types';
@@ -70,73 +66,6 @@ export function lockedItemsEqual(first: LockedItemType, second: LockedItemType) 
     case 'perk':
       return second.type === 'perk' && first.perk.hash === second.perk.hash;
   }
-}
-
-/**
- * filteredPerks:
- * The input perks, filtered down to perks on items that also include the other selected perks in that bucket.
- * For example, if you'd selected "heavy ammo finder" for class items it would only include perks that are on
- * class items that also had "heavy ammo finder".
- *
- * filteredPlugSetHashes:
- * Plug set hashes that contain the mods that can slot into items that can also slot the other selected mods in that bucket.
- * For example, if you'd selected "scout rifle loader" for gauntlets it would only include mods that can slot on
- * gauntlets that can also slot "scout rifle loader".
- */
-export function getFilteredPerksAndPlugSets(
-  locked: readonly LockedItemType[] | undefined,
-  items: readonly DimItem[]
-) {
-  const filteredPlugSetHashes = new Set<number>();
-  const filteredPerks = new Set<DestinyInventoryItemDefinition>();
-
-  if (!locked) {
-    return {};
-  }
-
-  for (const item of items) {
-    // flat list of plugs per item
-    const itemPlugs: DestinyInventoryItemDefinition[] = [];
-    // flat list of plugSetHashes per item
-    const itemPlugSets: number[] = [];
-
-    if (item.sockets) {
-      for (const socket of item.sockets.allSockets) {
-        // Populate mods
-        if (!socket.isPerk) {
-          if (socket.socketDefinition.reusablePlugSetHash) {
-            itemPlugSets.push(socket.socketDefinition.reusablePlugSetHash);
-          } else if (socket.socketDefinition.randomizedPlugSetHash) {
-            itemPlugSets.push(socket.socketDefinition.randomizedPlugSetHash);
-          }
-        }
-
-        // Populate plugs
-        if (filterPlugs(socket)) {
-          socket.plugOptions.forEach((option) => {
-            itemPlugs.push(option.plugDef);
-          });
-        }
-      }
-    }
-
-    // for each item, look to see if all perks match locked
-    const matches = locked.every(
-      (locked) => locked.type !== 'perk' || itemPlugs.some((plug) => plug.hash === locked.perk.hash)
-    );
-
-    // It matches all perks and plugs
-    if (matches) {
-      for (const plugSetHash of itemPlugSets) {
-        filteredPlugSetHashes.add(plugSetHash);
-      }
-      for (const itemPlug of itemPlugs) {
-        filteredPerks.add(itemPlug);
-      }
-    }
-  }
-
-  return { filteredPlugSetHashes, filteredPerks };
 }
 
 /** Whether this item is eligible for being in loadout builder. Now only armour 2.0 and only items that have all the stats. */


### PR DESCRIPTION
Changed the logic in the perk picker so a perk is only unselectable if another perk is selected.

I checked that perks from exotics which are not owned are not showing up and that is working correctly.

Fixes #6584 