### PR TITLE
Fix "apply previous loadout" pulling from postmaster

### DIFF
--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -161,13 +161,9 @@ export function optimalLoadout(
   );
 }
 /** Create a loadout from all of this character's items that can be in loadouts */
-export function loadoutFromAllItems(
-  store: DimStore,
-  name: string,
-  onlyEquipped?: boolean
-): Loadout {
+export function loadoutFromAllItems(store: DimStore, name: string): Loadout {
   const allItems = store.items.filter(
-    (item) => (!onlyEquipped || item.equipped) && itemCanBeInLoadout(item)
+    (item) => itemCanBeInLoadout(item) && !item.location.inPostmaster
   );
   return newLoadout(
     name,


### PR DESCRIPTION
The function that created a loadout of all your items, to be used by the "Before [LoadoutName]" button, was accidentally including items that were in the postmaster, meaning when you applied that loadout those items would get pulled.