### PR TITLE
Clickoutside again

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Clicking on the empty area below Organizer can now close item popups, where it didn't before.
+
 ## 6.56.1 <span class="changelog-date">(2021-03-14)</span>
 
 * Fix a bug where clicking inside the mod picker would dismiss the popup.
@@ -14,7 +16,6 @@
 * Invalid searches no longer save to search history.
 * Bright engrams show up correctly in the seasonal progress again.
 * Added an icon for Cabal Gold in objective text.
-* Clicking on the empty area below Organizer can now close item popups, where it didn't before.
 * You can sort items by ammo type.
 * There's a new button in the Loadout editor to add all unequipped items, similar to adding all equipped items.
 * The farming mode "stop" button no longer covers the category strip on mobile.

--- a/src/app/character-tile/StoreHeading.tsx
+++ b/src/app/character-tile/StoreHeading.tsx
@@ -1,7 +1,7 @@
 import { t } from 'app/i18next-t';
 import { isD1Store } from 'app/inventory/stores-helpers';
 import clsx from 'clsx';
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import ClickOutside from '../dim-ui/ClickOutside';
 import { DimStore } from '../inventory/store-types';
@@ -71,16 +71,20 @@ export default function StoreHeading({ store, selectedStore, loadoutMenuRef, onT
     setLoadoutMenuOpen((open) => !open);
   };
 
-  const clickOutsideLoadoutMenu = (e) => {
-    if (!e || !menuTrigger.current || !menuTrigger.current.contains(e.target)) {
+  const clickOutsideLoadoutMenu = useCallback(() => {
+    if (loadoutMenuOpen) {
       setLoadoutMenuOpen(false);
     }
-  };
+  }, [loadoutMenuOpen]);
 
   let loadoutMenu: React.ReactNode | undefined;
   if (loadoutMenuOpen) {
     const menuContents = (
-      <ClickOutside onClickOutside={clickOutsideLoadoutMenu} className="loadout-menu">
+      <ClickOutside
+        onClickOutside={clickOutsideLoadoutMenu}
+        extraRef={menuTrigger}
+        className="loadout-menu"
+      >
         <LoadoutPopup dimStore={store} onClick={clickOutsideLoadoutMenu} />
       </ClickOutside>
     );

--- a/src/app/dim-ui/ClickOutside.tsx
+++ b/src/app/dim-ui/ClickOutside.tsx
@@ -6,6 +6,8 @@ export const ClickOutsideContext = React.createContext(new EventBus<React.MouseE
 
 type Props = React.HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode;
+  /** An optional second ref that will be excluded from being considered "outside". This is good for preventing the triggering button from double-counting clicks. */
+  extraRef?: React.RefObject<HTMLElement>;
   onClickOutside(event: React.MouseEvent): void;
 };
 
@@ -17,7 +19,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
  * spawned through portals from the item popup.
  */
 export default React.forwardRef(function ClickOutside(
-  { onClickOutside, children, ...other }: Props,
+  { onClickOutside, children, extraRef, ...other }: Props,
   ref: React.RefObject<HTMLDivElement> | null
 ) {
   const localRef = useRef<HTMLDivElement>(null);
@@ -30,10 +32,12 @@ export default React.forwardRef(function ClickOutside(
   const handleClickOutside = useCallback(
     (event: React.MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
-        onClickOutside(event);
+        if (!extraRef?.current || !extraRef.current.contains(event.target as Node)) {
+          onClickOutside(event);
+        }
       }
     },
-    [onClickOutside, wrapperRef]
+    [onClickOutside, wrapperRef, extraRef]
   );
 
   useEventBusListener(mouseEvents, handleClickOutside);

--- a/src/app/dim-ui/ClickOutside.tsx
+++ b/src/app/dim-ui/ClickOutside.tsx
@@ -1,6 +1,6 @@
 import { useEventBusListener } from 'app/utils/hooks';
 import { EventBus } from 'app/utils/observable';
-import React, { useCallback, useContext, useRef } from 'react';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
 
 export const ClickOutsideContext = React.createContext(new EventBus<React.MouseEvent>());
 
@@ -8,7 +8,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode;
   /** An optional second ref that will be excluded from being considered "outside". This is good for preventing the triggering button from double-counting clicks. */
   extraRef?: React.RefObject<HTMLElement>;
-  onClickOutside(event: React.MouseEvent): void;
+  onClickOutside(event: React.MouseEvent | MouseEvent): void;
 };
 
 /**
@@ -19,7 +19,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
  * spawned through portals from the item popup.
  */
 export default React.forwardRef(function ClickOutside(
-  { onClickOutside, children, extraRef, ...other }: Props,
+  { onClickOutside, children, extraRef, onClick, ...other }: Props,
   ref: React.RefObject<HTMLDivElement> | null
 ) {
   const localRef = useRef<HTMLDivElement>(null);
@@ -41,6 +41,17 @@ export default React.forwardRef(function ClickOutside(
   );
 
   useEventBusListener(mouseEvents, handleClickOutside);
+
+  // Handle clicks directly on the body as always outside. This handles the case where the ClickoutsideRoot doesn't cover the whole screen.
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (e.target === document.body) {
+        onClickOutside(e);
+      }
+    };
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  });
 
   return (
     <div ref={wrapperRef} {...other}>

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -58,11 +58,9 @@ function Header({ account, isPhonePortrait, dispatch }: Props) {
     setDropdownOpen((dropdownOpen) => !dropdownOpen);
   }, []);
 
-  const hideDropdown = (event) => {
-    if (!dropdownToggler.current || !dropdownToggler.current.contains(event.target)) {
-      setDropdownOpen(false);
-    }
-  };
+  const hideDropdown = useCallback(() => {
+    setDropdownOpen(false);
+  }, []);
 
   // Mobile search bar
   const [showSearch, setShowSearch] = useState(false);
@@ -114,7 +112,7 @@ function Header({ account, isPhonePortrait, dispatch }: Props) {
     document.body.classList.toggle('search-open', showSearch);
   }, [showSearch]);
 
-  const nodeRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const bugReportLink = $DIM_FLAVOR !== 'release';
 
@@ -263,12 +261,13 @@ function Header({ account, isPhonePortrait, dispatch }: Props) {
       <TransitionGroup component={null}>
         {dropdownOpen && (
           <CSSTransition
-            nodeRef={nodeRef}
+            nodeRef={dropdownRef}
             classNames="dropdown"
             timeout={{ enter: 500, exit: 500 }}
           >
             <ClickOutside
-              ref={nodeRef}
+              ref={dropdownRef}
+              extraRef={dropdownToggler}
               key="dropdown"
               className="dropdown"
               onClickOutside={hideDropdown}


### PR DESCRIPTION
OK, one last try to fix this. Instead of the elegant solution I thought worked, this is an ugly solution that seems to actually work. Basically I'm just special casing clicks to `body` so that clicking on dead space will still close popups.

Fixes #5909 
