### PR TITLE
LO tweaks

### DIFF
--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -183,7 +183,7 @@ function useWorkerAndCleanup(
     statFilters,
   ]);
 
-  // cleanup the worker on unmount
+  // cleanup the worker on unmount or if the worker gets recreated
   useEffect(() => cleanup, [worker, cleanup]);
 
   return { worker, cleanup };

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -44,6 +44,7 @@ interface ProcessState {
 /**
  * Hook to process all the stat groups for LO in a web worker.
  */
+// TODO: introduce params object
 export function useProcess(
   selectedStoreId: string | undefined,
   filteredItems: ItemsByBucket,
@@ -53,13 +54,14 @@ export function useProcess(
   statOrder: StatTypes[],
   statFilters: { [statType in StatTypes]: MinMaxIgnored }
 ) {
-  const [{ result, resultStoreId, processing, currentCleanup }, setState] = useState({
+  const [{ result, resultStoreId, processing, currentCleanup }, setState] = useState<ProcessState>({
     processing: false,
     resultStoreId: selectedStoreId,
     result: null,
     currentCleanup: null,
-  } as ProcessState);
+  });
 
+  // TODO: just create a fresh worker every time
   const { worker, cleanup } = useWorkerAndCleanup(
     filteredItems,
     lockedItems,
@@ -151,9 +153,6 @@ export function useProcess(
           },
           currentCleanup: null,
         }));
-
-        // Destroy the worker since we're done with it
-        cleanup();
 
         infoLog('loadout optimizer', `useProcess ${performance.now() - processStart}ms`);
       });

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -121,6 +121,8 @@ export function useProcess(
       (mods) => mods?.map((mod) => mapArmor2ModToProcessMod(mod)) || []
     );
 
+    // TODO: could potentially partition the problem (split the largest item category maybe) to spread across more cores
+    // TODO: does it hurt to recreate the worker each time?
     const workerStart = performance.now();
     worker
       .process(

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -76,7 +76,7 @@ export function useProcess(
     );
 
     const processItems: ProcessItemsByBucket = {};
-    const itemsById: { [id: string]: DimItem[] } = {};
+    const itemsById = new Map<string, DimItem[]>();
 
     for (const [key, items] of Object.entries(filteredItems)) {
       processItems[key] = [];
@@ -96,7 +96,7 @@ export function useProcess(
           processItems[key].push(
             mapDimItemToProcessItem(item, lockedModMap[bucketsToCategories[item.bucket.hash]])
           );
-          itemsById[item.id] = group;
+          itemsById.set(item.id, group);
         }
       }
     }

--- a/src/app/loadout-builder/hooks/useProcess.ts
+++ b/src/app/loadout-builder/hooks/useProcess.ts
@@ -152,6 +152,9 @@ export function useProcess(
           currentCleanup: null,
         }));
 
+        // Destroy the worker since we're done with it
+        cleanup();
+
         infoLog('loadout optimizer', `useProcess ${performance.now() - processStart}ms`);
       });
     /* do not include things from state or worker in dependencies */

--- a/src/app/loadout-builder/processWorker/mappers.ts
+++ b/src/app/loadout-builder/processWorker/mappers.ts
@@ -91,12 +91,10 @@ function mapDimSocketsToProcessSockets(dimSockets: DimSockets): ProcessSockets {
 export function mapDimItemToProcessItem(dimItem: DimItem, modsForSlot?: LockedMod[]): ProcessItem {
   const { bucket, id, type, name, equippingLabel, basePower, stats } = dimItem;
 
-  const statMap: { [statHash: number]: number } = {};
   const baseStatMap: { [statHash: number]: number } = {};
 
   if (stats) {
-    for (const { statHash, value, base } of stats) {
-      statMap[statHash] = value;
+    for (const { statHash, base } of stats) {
       baseStatMap[statHash] = base;
     }
   }
@@ -113,7 +111,6 @@ export function mapDimItemToProcessItem(dimItem: DimItem, modsForSlot?: LockedMo
     name,
     equippingLabel,
     basePower,
-    stats: statMap,
     baseStats: baseStatMap,
     sockets: dimItem.sockets && mapDimSocketsToProcessSockets(dimItem.sockets),
     energy:

--- a/src/app/loadout-builder/processWorker/mappers.ts
+++ b/src/app/loadout-builder/processWorker/mappers.ts
@@ -130,12 +130,12 @@ export function mapDimItemToProcessItem(dimItem: DimItem, modsForSlot?: LockedMo
 
 export function hydrateArmorSet(
   processed: ProcessArmorSet,
-  itemsById: { [id: string]: DimItem[] }
+  itemsById: Map<string, DimItem[]>
 ): ArmorSet {
   const armor: DimItem[][] = [];
 
   for (const itemId of processed.armor) {
-    armor.push(itemsById[itemId]);
+    armor.push(itemsById.get(itemId)!);
   }
 
   return {

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -22,13 +22,23 @@ import {
   ProcessMod,
 } from './types';
 
+/** Caps the maximum number of total armor sets that'll be returned */
 const RETURNED_ARMOR_SETS = 200;
 
+/**
+ * A list of stat mixes by total tier. We can keep this list up to date
+ * as we process new sets with an insertion sort algorithm.
+ */
 type SetTracker = {
   tier: number;
   statMixes: { statMix: string; armorSets: IntermediateProcessArmorSet[] }[];
 }[];
 
+/**
+ * Use an insertion sort algorithm to keep an ordered list of sets first by total tier, then by stat mix within a tier.
+ * This takes advantage of the fact that strings are lexically comparable, but maybe it does that badly...
+ */
+// TODO: replace with trie?
 function insertIntoSetTracker(
   tier: number,
   statMix: string,
@@ -97,10 +107,16 @@ function insertIntoSetTracker(
  */
 export function process(
   filteredItems: ProcessItemsByBucket,
+  /** No idea what this is */
+  /** Selected mods' total contribution to each stat */
+  // TODO: use stat hash, or order
   modStatTotals: { [stat in StatTypes]: number },
+  /** Mods to add onto the sets */
   lockedModMap: LockedProcessMods,
   assumeMasterwork: boolean,
+  // TODO: replace with stat hashes
   statOrder: StatTypes[],
+  // TODO: maps, eradicate stat types
   statFilters: { [stat in StatTypes]: MinMaxIgnored }
 ): {
   sets: ProcessArmorSet[];
@@ -110,9 +126,12 @@ export function process(
 } {
   const pstart = performance.now();
 
-  const orderedStatValues = statOrder.map((statType) => statHashes[statType]);
+  const orderedStatHashes = statOrder.map((statType) => statHashes[statType]);
+  // Stat types excluding ignored stats
   const orderedConsideredStats = statOrder.filter((statType) => !statFilters[statType].ignored);
 
+  // This stores the computed min and max value for each stat as we process all sets, so we
+  // can display it on the stat filter dropdowns
   const statRanges: { [stat in StatTypes]: MinMax } = {
     Mobility: statFilters.Mobility.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
     Resilience: statFilters.Resilience.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
@@ -122,6 +141,10 @@ export function process(
     Strength: statFilters.Strength.ignored ? { min: 0, max: 10 } : { min: 10, max: 0 },
   };
 
+  // Sort gear by total stat (descending) so we consider the best gear first
+  // TODO: make these a list/map
+  // TODO: we should precompute the stats first, and then sort on total, so we can incoporate the masterworkiness
+  // TODO: sort by total taking into account ignored stats!
   const helms = _.sortBy(
     filteredItems[LockableBuckets.helmet] || [],
     (i) => -i.baseStats[TOTAL_STAT_HASH]
@@ -138,6 +161,10 @@ export function process(
     filteredItems[LockableBuckets.leg] || [],
     (i) => -i.baseStats[TOTAL_STAT_HASH]
   );
+  // TODO: we used to do these in chunks, where items w/ same stats were considered together. For class items that
+  // might still be useful. In practice there are only 1/2 class items you need to care about - all of them that are
+  // masterworked and all of them that aren't.
+  // TODO: test this hypothesis by counting by unique stat?
   const classItems = _.sortBy(
     filteredItems[LockableBuckets.classitem] || [],
     (i) => -i.baseStats[TOTAL_STAT_HASH]
@@ -146,6 +173,7 @@ export function process(
   // We won't search through more than this number of stat combos - it can cause us to run out of memory.
   const combosLimit = 2_000_000;
 
+  // The maximum possible combos we could have
   const combosWithoutCaps =
     helms.length * gaunts.length * chests.length * legs.length * classItems.length;
 
@@ -153,6 +181,7 @@ export function process(
 
   // If we're over the limit, start trimming down the armor lists starting with the longest.
   // Since we're already sorted by total stats descending this should toss the worst items.
+  // TODO: this should also be post adjusted stats
   while (combos > combosLimit) {
     const lowestTotalStat = _.minBy(
       [helms, gaunts, chests, legs],
@@ -181,12 +210,17 @@ export function process(
   let lowestTier = 100;
   let setCount = 0;
 
+  // TODO: Map?
+  // TODO: this could be a map from item object to stat!
   const statsCache: Record<string, number[]> = {};
 
+  // Precompute the stats of each item in the order the user asked for
   for (const item of [...helms, ...gaunts, ...chests, ...legs, ...classItems]) {
-    statsCache[item.id] = getStatValuesWithMWProcess(item, assumeMasterwork, orderedStatValues);
+    statsCache[item.id] = getStatValuesWithMWProcess(item, assumeMasterwork, orderedStatHashes);
   }
 
+  // TODO: not sure what this is all about
+  // TODO: preprocess all this stuff? It doesn't change as often...
   let generalMods: ProcessMod[] = [];
   let otherMods: ProcessMod[] = [];
   let raidMods: ProcessMod[] = [];
@@ -204,7 +238,6 @@ export function process(
 
   const generalModsPermutations = generateModPermutations(generalMods);
   const otherModPermutations = generateModPermutations(otherMods);
-
   const raidModPermutations = generateModPermutations(raidMods);
 
   for (const helm of helms) {
@@ -212,109 +245,128 @@ export function process(
       for (const chest of chests) {
         for (const leg of legs) {
           for (const classItem of classItems) {
+            const numExotics =
+              (helm.equippingLabel ? 1 : 0) +
+              (gaunt.equippingLabel ? 1 : 0) +
+              (chest.equippingLabel ? 1 : 0) +
+              (leg.equippingLabel ? 1 : 0) +
+              (classItem.equippingLabel ? 1 : 0);
+            if (numExotics > 1) {
+              continue;
+            }
+
             const armor = [helm, gaunt, chest, leg, classItem];
 
-            // Make sure there is at most one exotic
-            if (_.sumBy(armor, (item) => (item.equippingLabel ? 1 : 0)) <= 1) {
-              const statChoices = [
-                statsCache[helm.id],
-                statsCache[gaunt.id],
-                statsCache[chest.id],
-                statsCache[leg.id],
-                statsCache[classItem.id],
-              ];
+            const statChoices = [
+              statsCache[helm.id],
+              statsCache[gaunt.id],
+              statsCache[chest.id],
+              statsCache[leg.id],
+              statsCache[classItem.id],
+            ];
 
-              const stats: any = {};
-              for (const stat of statChoices) {
-                let index = 0;
-                for (const key of statOrder) {
-                  stats[key] = Math.min((stats[key] || 0) + stat[index], 100);
-                  index++;
-                }
-              }
-
-              // A string version of the tier-level of each stat, separated by commas
-              // This is an awkward implementation to save garbage allocations.
-              let tiers = '';
-              let totalTier = 0;
-              let index = 1;
-              let statRangeExceeded = false;
-              for (const statKey of orderedConsideredStats) {
-                stats[statKey] += modStatTotals[statKey];
-                const tier = statTier(stats[statKey]);
-
-                if (tier > statRanges[statKey].max) {
-                  statRanges[statKey].max = tier;
-                }
-
-                if (tier < statRanges[statKey].min) {
-                  statRanges[statKey].min = tier;
-                }
-
-                if (tier > statFilters[statKey].max || tier < statFilters[statKey].min) {
-                  statRangeExceeded = true;
-                  break;
-                }
-                tiers += tier;
-                totalTier += tier;
-                if (index < statOrder.length) {
-                  tiers += ',';
-                }
+            // TODO: why not just another ordered list?
+            // TODO: reuse this object?
+            const stats: { [statType in StatTypes]: number } = {
+              Mobility: 0,
+              Resilience: 0,
+              Recovery: 0,
+              Discipline: 0,
+              Intellect: 0,
+              Strength: 0,
+            };
+            for (const itemStats of statChoices) {
+              let index = 0;
+              // itemStats are already in the user's chosen stat order
+              for (const statType of statOrder) {
+                stats[statType] = stats[statType] + itemStats[index];
                 index++;
               }
+            }
 
-              if (statRangeExceeded) {
+            // A string version of the tier-level of each stat, separated by commas
+            // This is an awkward implementation to save garbage allocations.
+            let tiers = '';
+            let totalTier = 0;
+            let index = 0;
+            let statRangeExceeded = false;
+            for (const statKey of orderedConsideredStats) {
+              // Stats can't exceed 100 even with mods. At least, today they
+              // can't - we *could* pass the max value in from the stat def.
+              stats[statKey] = Math.min(stats[statKey] + modStatTotals[statKey], 100);
+              const tier = statTier(stats[statKey]);
+
+              // Update our global min/max for this stat
+              if (tier > statRanges[statKey].max) {
+                statRanges[statKey].max = tier;
+              }
+              if (tier < statRanges[statKey].min) {
+                statRanges[statKey].min = tier;
+              }
+
+              if (tier > statFilters[statKey].max || tier < statFilters[statKey].min) {
+                statRangeExceeded = true;
+                break;
+              }
+              tiers += tier;
+              totalTier += tier;
+              if (index < statOrder.length - 1) {
+                tiers += ',';
+              }
+              index++;
+            }
+
+            if (statRangeExceeded) {
+              continue;
+            }
+
+            // While we have less than RETURNED_ARMOR_SETS sets keep adding and keep track of the lowest total tier.
+            if (totalTier < lowestTier) {
+              if (setCount <= RETURNED_ARMOR_SETS) {
+                lowestTier = totalTier;
+              } else {
                 continue;
               }
+            }
 
-              // While we have less than RETURNED_ARMOR_SETS sets keep adding and keep track of the lowest total tier.
-              if (totalTier < lowestTier) {
-                if (setCount <= RETURNED_ARMOR_SETS) {
-                  lowestTier = totalTier;
-                } else {
-                  continue;
-                }
-              }
+            // TODO: Perhaps do this as a post-filter
+            // For armour 2 mods we ignore slot specific mods as we prefilter items based on energy requirements
+            if (
+              (otherMods.length || raidMods.length || generalMods.length) &&
+              !canTakeSlotIndependantMods(
+                generalModsPermutations,
+                otherModPermutations,
+                raidModPermutations,
+                armor
+              )
+            ) {
+              continue;
+            }
 
-              // For armour 2 mods we ignore slot specific mods as we prefilter items based on energy requirements
-              if (
-                (otherMods.length || raidMods.length || generalMods.length) &&
-                !canTakeSlotIndependantMods(
-                  generalModsPermutations,
-                  otherModPermutations,
-                  raidModPermutations,
-                  armor
-                )
-              ) {
-                continue;
-              }
+            const newArmorSet: IntermediateProcessArmorSet = {
+              armor,
+              stats,
+            };
 
-              const newArmorSet: IntermediateProcessArmorSet = {
-                armor,
-                stats: stats as {
-                  [statType in StatTypes]: number;
-                },
-                statChoices,
-              };
+            insertIntoSetTracker(totalTier, tiers, newArmorSet, setTracker);
 
-              insertIntoSetTracker(totalTier, tiers, newArmorSet, setTracker);
+            setCount++;
 
-              setCount++;
+            // If we've gone over our max sets to return, drop the worst set
+            // TODO: Could this remove good sets?
+            if (setCount > RETURNED_ARMOR_SETS) {
+              const lowestTierSet = setTracker[setTracker.length - 1];
+              const worstMix = lowestTierSet.statMixes[lowestTierSet.statMixes.length - 1];
 
-              if (setCount > RETURNED_ARMOR_SETS) {
-                const lowestTierSet = setTracker[setTracker.length - 1];
-                const worstMix = lowestTierSet.statMixes[lowestTierSet.statMixes.length - 1];
+              worstMix.armorSets.pop();
+              setCount--;
 
-                worstMix.armorSets.pop();
-                setCount--;
+              if (worstMix.armorSets.length === 0) {
+                lowestTierSet.statMixes.pop();
 
-                if (worstMix.armorSets.length === 0) {
-                  lowestTierSet.statMixes.pop();
-
-                  if (lowestTierSet.statMixes.length === 0) {
-                    setTracker.pop();
-                    lowestTier = setTracker[setTracker.length - 1].tier;
-                  }
+                if (lowestTierSet.statMixes.length === 0) {
+                  setTracker.pop();
+                  lowestTier = setTracker[setTracker.length - 1].tier;
                 }
               }
             }
@@ -352,37 +404,35 @@ function getStatValuesWithMWProcess(
 
   // Checking energy tells us if it is Armour 2.0 (it can have value 0)
   if (item.sockets && item.energy) {
-    let masterworkSocketHashes: number[] = [];
-    // only get masterwork sockets if we aren't manually adding the values
-    if (!assumeMasterwork) {
+    if (assumeMasterwork || item.energy) {
+      // TODO: technically we could derive this from the available mods instead ("slot" them all)
+      // Alternately we could make a lot more assumptions and just say if the energy capacity is 10, add 2 to every stat
+      for (const statHash of orderedStatValues) {
+        baseStats[statHash] += 2;
+      }
+    } else {
+      // Armor masterworking is just filling up the energy meter
       const masterworkSocketCategory = item.sockets.categories.find(
         (category) => category.categoryStyle === DestinySocketCategoryStyle.EnergyMeter
       );
 
-      if (masterworkSocketCategory) {
-        masterworkSocketHashes = masterworkSocketCategory.sockets
+      const masterworkSocketHashes =
+        masterworkSocketCategory?.sockets
           .map((socket) => socket.plug?.plugItemHash ?? NaN)
-          .filter((val) => !isNaN(val));
-      }
-    }
+          .filter((val) => !isNaN(val)) ?? [];
 
-    if (masterworkSocketHashes.length) {
-      for (const socket of item.sockets.sockets) {
-        const plugHash = socket.plug?.plugItemHash ?? NaN;
+      if (masterworkSocketHashes.length) {
+        for (const socket of item.sockets.sockets) {
+          const plugHash = socket.plug?.plugItemHash ?? NaN;
 
-        if (socket.plug?.stats && masterworkSocketHashes.includes(plugHash)) {
-          for (const statHash of orderedStatValues) {
-            if (socket.plug.stats[statHash]) {
-              baseStats[statHash] += socket.plug.stats[statHash];
+          if (socket.plug?.stats && masterworkSocketHashes.includes(plugHash)) {
+            for (const statHash of orderedStatValues) {
+              if (socket.plug.stats[statHash]) {
+                baseStats[statHash] += socket.plug.stats[statHash];
+              }
             }
           }
         }
-      }
-    }
-
-    if (assumeMasterwork) {
-      for (const statHash of orderedStatValues) {
-        baseStats[statHash] += 2;
       }
     }
   }

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -203,7 +203,6 @@ export function process(
   // might still be useful. In practice there are only 1/2 class items you need to care about - all of them that are
   // masterworked and all of them that aren't. I think we may want to go back to grouping like items but we'll need to
   // incorporate modslots and energy maybe.
-  // TODO: test this hypothesis by counting by unique stat?
   const classItems = (filteredItems[LockableBuckets.classitem] || []).sort(itemComparator);
 
   // We won't search through more than this number of stat combos because it takes too long.
@@ -219,13 +218,7 @@ export function process(
   // If we're over the limit, start trimming down the armor lists starting with the worst among them.
   // Since we're already sorted by total stats descending this should toss the worst items.
   while (combos > combosLimit) {
-    const sortedTypes = [
-      helms,
-      gaunts,
-      chests,
-      legs,
-      // TODO: No class items?
-    ]
+    const sortedTypes = [helms, gaunts, chests, legs]
       // Don't ever remove the last item in a category
       .filter((items) => items.length > 1)
       // Sort by our same statOrder-aware comparator, but only compare the worst-ranked item in each category
@@ -257,8 +250,6 @@ export function process(
   let lowestTier = 100;
   let setCount = 0;
 
-  // TODO: not sure what this is all about
-  // TODO: preprocess all this stuff? It doesn't change as often...
   let generalMods: ProcessMod[] = [];
   let otherMods: ProcessMod[] = [];
   let raidMods: ProcessMod[] = [];
@@ -369,7 +360,6 @@ export function process(
               }
             }
 
-            // TODO: Perhaps do this as a post-filter
             // For armour 2 mods we ignore slot specific mods as we prefilter items based on energy requirements
             if (
               hasMods &&
@@ -393,7 +383,6 @@ export function process(
             setCount++;
 
             // If we've gone over our max sets to return, drop the worst set
-            // TODO: Could this remove good sets?
             if (setCount > RETURNED_ARMOR_SETS) {
               const lowestTierSet = setTracker[setTracker.length - 1];
               const worstMix = lowestTierSet.statMixes[lowestTierSet.statMixes.length - 1];

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -233,7 +233,7 @@ export function process(
         itemComparator(a[a.length - 1], b[b.length - 1])
       );
     // Pop the last item off the worst-sorted list
-    [sortedTypes[sortedTypes.length - 1]].pop();
+    sortedTypes[sortedTypes.length - 1].pop();
     // TODO: A smarter version of this would avoid trimming out items that match mod slots we need, somehow
     combos = helms.length * gaunts.length * chests.length * legs.length * classItems.length;
   }

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -134,7 +134,6 @@ function compareByStatOrder(
  */
 export function process(
   filteredItems: ProcessItemsByBucket,
-  /** No idea what this is */
   /** Selected mods' total contribution to each stat */
   // TODO: use stat hash, or order
   modStatTotals: { [stat in StatTypes]: number },

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -116,7 +116,7 @@ export function process(
   assumeMasterwork: boolean,
   // TODO: replace with stat hashes
   statOrder: StatTypes[],
-  // TODO: maps, eradicate stat types
+  // TODO: maps, eradicate StatTypes
   statFilters: { [stat in StatTypes]: MinMaxIgnored }
 ): {
   sets: ProcessArmorSet[];
@@ -125,6 +125,8 @@ export function process(
   statRanges?: { [stat in StatTypes]: MinMax };
 } {
   const pstart = performance.now();
+
+  // TODO: potentially could filter out items that provide more than the maximum of a stat all on their own?
 
   const orderedStatHashes = statOrder.map((statType) => statHashes[statType]);
   // Stat types excluding ignored stats
@@ -163,14 +165,16 @@ export function process(
   );
   // TODO: we used to do these in chunks, where items w/ same stats were considered together. For class items that
   // might still be useful. In practice there are only 1/2 class items you need to care about - all of them that are
-  // masterworked and all of them that aren't.
+  // masterworked and all of them that aren't. I think we may want to go back to grouping like items but we'll need to
+  // incorporate modslots and energy maybe.
   // TODO: test this hypothesis by counting by unique stat?
   const classItems = _.sortBy(
     filteredItems[LockableBuckets.classitem] || [],
     (i) => -i.baseStats[TOTAL_STAT_HASH]
   );
 
-  // We won't search through more than this number of stat combos - it can cause us to run out of memory.
+  // We won't search through more than this number of stat combos because it takes too long.
+  // On my machine (bhollis) it takes ~1s per 500,000 combos
   const combosLimit = 2_000_000;
 
   // The maximum possible combos we could have

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -268,13 +268,14 @@ export function process(
             const armor = [helm, gaunt, chest, leg, classItem];
 
             // TODO: why not just another ordered list?
+            // Start with the contribution of mods. Spread operator is slow.
             const stats: { [statType in StatTypes]: number } = {
-              Mobility: 0,
-              Resilience: 0,
-              Recovery: 0,
-              Discipline: 0,
-              Intellect: 0,
-              Strength: 0,
+              Mobility: modStatTotals.Mobility,
+              Resilience: modStatTotals.Resilience,
+              Recovery: modStatTotals.Recovery,
+              Discipline: modStatTotals.Discipline,
+              Intellect: modStatTotals.Intellect,
+              Strength: modStatTotals.Strength,
             };
             for (const item of armor) {
               const itemStats = statsCache.get(item)!;
@@ -295,7 +296,10 @@ export function process(
             for (const statKey of orderedConsideredStats) {
               // Stats can't exceed 100 even with mods. At least, today they
               // can't - we *could* pass the max value in from the stat def.
-              stats[statKey] = Math.min(stats[statKey] + modStatTotals[statKey], 100);
+              // Math.min is slow.
+              if (stats[statKey] > 100) {
+                stats[statKey] = 100;
+              }
               const tier = statTier(stats[statKey]);
 
               // Update our global min/max for this stat

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -212,11 +212,11 @@ export function process(
 
   // TODO: Map?
   // TODO: this could be a map from item object to stat!
-  const statsCache: Record<string, number[]> = {};
+  const statsCache: Map<ProcessItem, number[]> = new Map();
 
   // Precompute the stats of each item in the order the user asked for
   for (const item of [...helms, ...gaunts, ...chests, ...legs, ...classItems]) {
-    statsCache[item.id] = getStatValuesWithMWProcess(item, assumeMasterwork, orderedStatHashes);
+    statsCache.set(item, getStatValuesWithMWProcess(item, assumeMasterwork, orderedStatHashes));
   }
 
   // TODO: not sure what this is all about
@@ -257,16 +257,7 @@ export function process(
 
             const armor = [helm, gaunt, chest, leg, classItem];
 
-            const statChoices = [
-              statsCache[helm.id],
-              statsCache[gaunt.id],
-              statsCache[chest.id],
-              statsCache[leg.id],
-              statsCache[classItem.id],
-            ];
-
             // TODO: why not just another ordered list?
-            // TODO: reuse this object?
             const stats: { [statType in StatTypes]: number } = {
               Mobility: 0,
               Resilience: 0,
@@ -275,7 +266,8 @@ export function process(
               Intellect: 0,
               Strength: 0,
             };
-            for (const itemStats of statChoices) {
+            for (const item of armor) {
+              const itemStats = statsCache.get(item)!;
               let index = 0;
               // itemStats are already in the user's chosen stat order
               for (const statType of statOrder) {

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -48,6 +48,8 @@ function stringifyModPermutation(perm: (ProcessMod | null)[]) {
  * This is heaps algorithm implemented for generating mod permutations.
  * https://en.wikipedia.org/wiki/Heap%27s_algorithm
  *
+ * But why?
+ *
  * Note that we ensure the array length is always 5 so mods are aligned
  * with the 5 items.
  */

--- a/src/app/loadout-builder/processWorker/processUtils.ts
+++ b/src/app/loadout-builder/processWorker/processUtils.ts
@@ -48,8 +48,6 @@ function stringifyModPermutation(perm: (ProcessMod | null)[]) {
  * This is heaps algorithm implemented for generating mod permutations.
  * https://en.wikipedia.org/wiki/Heap%27s_algorithm
  *
- * But why?
- *
  * Note that we ensure the array length is always 5 so mods are aligned
  * with the 5 items.
  */

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -28,7 +28,9 @@ export interface ProcessItem {
   id: string;
   type: string;
   name: string;
+  // TODO: replace with isExotic?
   equippingLabel?: string;
+  // TODO: only used to calculate masterwork-stats. Maybe pass in bonus or adjusted stats ahead of time
   sockets: ProcessSockets | null;
   energy: {
     type: DestinyEnergyType;
@@ -37,6 +39,7 @@ export interface ProcessItem {
     val: number;
   } | null;
   basePower: number;
+  // TODO: unused
   stats: { [statHash: number]: number };
   baseStats: { [statHash: number]: number };
   compatibleModSeasons?: string[];
@@ -52,8 +55,6 @@ export interface ProcessArmorSet {
   readonly stats: Readonly<{ [statType in StatTypes]: number }>;
   /** For each armor type (see LockableBuckets), this is the list of items that could interchangeably be put into this loadout. */
   readonly armor: readonly string[];
-  /** The chosen stats for each armor type, as a list in the order Mobility/Resiliency/Recovery. */
-  readonly statChoices: readonly number[][];
 }
 
 export interface IntermediateProcessArmorSet {
@@ -61,8 +62,6 @@ export interface IntermediateProcessArmorSet {
   stats: { [statType in StatTypes]: number };
   /** The first (highest-power) valid set from this stat mix. */
   armor: ProcessItem[];
-  /** The chosen stats for each armor type, as a list in the order Mobility/Resiliency/Recovery. */
-  statChoices: number[][];
 }
 
 interface ProcessStat {

--- a/src/app/loadout-builder/processWorker/types.ts
+++ b/src/app/loadout-builder/processWorker/types.ts
@@ -28,7 +28,6 @@ export interface ProcessItem {
   id: string;
   type: string;
   name: string;
-  // TODO: replace with isExotic?
   equippingLabel?: string;
   // TODO: only used to calculate masterwork-stats. Maybe pass in bonus or adjusted stats ahead of time
   sockets: ProcessSockets | null;
@@ -39,8 +38,6 @@ export interface ProcessItem {
     val: number;
   } | null;
   basePower: number;
-  // TODO: unused
-  stats: { [statHash: number]: number };
   baseStats: { [statHash: number]: number };
   compatibleModSeasons?: string[];
   hasLegacyModSocket: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,14 +1370,14 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sentry/browser@6.2.2", "@sentry/browser@^6.1.0":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.2.2.tgz#4df4ad7026b269d85b63b79a75387ce5370bc705"
-  integrity sha512-K5UGyEePtVPZIFMoiRafhd4Ov0M1kdozVsVKIPZrOpJyjQdPNX+fYDNL/h0nVmgOlE2S/uu4fl4mEfe/6aLShw==
+"@sentry/browser@6.2.3", "@sentry/browser@^6.1.0":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.2.3.tgz#b622b3fb62340574e395b6ae12ffbb9d25d98bd4"
+  integrity sha512-QUqrZdAosY2MPAUfJYpyCT+dA6v7A2h8imO8R3Lbi0hRSPr+L7zjqHgFs3CTHJLmLV74cxHt6rVVUPSksYNQDQ==
   dependencies:
-    "@sentry/core" "6.2.2"
-    "@sentry/types" "6.2.2"
-    "@sentry/utils" "6.2.2"
+    "@sentry/core" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.30.4":
@@ -1391,69 +1391,69 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.2.tgz#ec86b5769f8855f43cb58e839f81f87074ec9a3f"
-  integrity sha512-qqWbvvXtymfXh7N5eEvk97MCnMURuyFIgqWdVD4MQM6yIfDCy36CyGfuQ3ViHTLZGdIfEOhLL9/f4kzf1RzqBA==
+"@sentry/core@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.3.tgz#ed5d21fd8b18ddc289d04c669393a437fb09639f"
+  integrity sha512-GpfHoSJiXchVXgyaMWVtIPVw2t97KkD1OJ4JdL3/TeH3auX5XvsN5iHTk+x/Er8t13IpOnvidH1xWdV1dnax2w==
   dependencies:
-    "@sentry/hub" "6.2.2"
-    "@sentry/minimal" "6.2.2"
-    "@sentry/types" "6.2.2"
-    "@sentry/utils" "6.2.2"
+    "@sentry/hub" "6.2.3"
+    "@sentry/minimal" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     tslib "^1.9.3"
 
-"@sentry/hub@6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.2.tgz#f451d8d3ad207e81556b4846d810226693e0444e"
-  integrity sha512-VR6uQGRYt6RP633FHShlSLj0LUKGVrlTeSlwCoooWM5FR9lmi6akAaweuxpG78/kZvXrAWpjX6/nuYwHKGwzGA==
+"@sentry/hub@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.3.tgz#07fba07627b7523f69f8b862f00cd197e5e4e5bd"
+  integrity sha512-D5Horfo2l0p52S7KPvy7qwWNMrE4IsCN8ODbfcCsfJu7hEXJmItbkbohIVSqO5neukhn5nu+x8kyCe9Q5u1Q6g==
   dependencies:
-    "@sentry/types" "6.2.2"
-    "@sentry/utils" "6.2.2"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.2.tgz#01f41e0a6a6a2becfc99f6bb6f9c4bddf54f8dae"
-  integrity sha512-l0IgoGQgg1lTd4qDU8bQn25sbZBg8PwIHfuTLbGMlRr1flDXHOM1UXajWK/UKbAPelnU7M2JBSVzgl7PwjprzA==
+"@sentry/minimal@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.3.tgz#462ce7739fa85fd7d6dd13d56d20f17ff91e46d0"
+  integrity sha512-Gpn9x4NQAG7E94EK1+hAz9GUcYrffTuqJ/XgqvHYk0jsHZ6RfsXYrmBac0ZwUxOivMf2t0n5opK0v5rhMDfF2w==
   dependencies:
-    "@sentry/hub" "6.2.2"
-    "@sentry/types" "6.2.2"
+    "@sentry/hub" "6.2.3"
+    "@sentry/types" "6.2.3"
     tslib "^1.9.3"
 
 "@sentry/react@^6.0.1":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.2.2.tgz#6a93fa1013b2b9e37a8c0bc16cf0cbf4353de4c6"
-  integrity sha512-yDuxPOD4j2WE5nX1p48GIqXwrrmwkjryFjtYvLgzGJkiGWLmGTrxrSqtUKrbqahJpKt3mi24Nkg0cMlsFB178g==
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.2.3.tgz#66e8a2073acd74677e4daf850e165273eb8eea7a"
+  integrity sha512-T2mBD9ZFxzLQ3Kc5cey7A5fBA+qN67NdmRw9W1Grk6cEoJIrQYg3LnFbM5YnBBK86ciXQlgz7ZsF7rbjRcmWMQ==
   dependencies:
-    "@sentry/browser" "6.2.2"
-    "@sentry/minimal" "6.2.2"
-    "@sentry/types" "6.2.2"
-    "@sentry/utils" "6.2.2"
+    "@sentry/browser" "6.2.3"
+    "@sentry/minimal" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
 "@sentry/tracing@^6.0.1":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.2.tgz#77097fb1dad7e8ad6ccd93c57b1ef5fa85219099"
-  integrity sha512-mAkPoqtofNfka/u9rOVVDQPaEoTmr0AQh654g9ZqsaqsOJLKjB4FDLVNubWs90fjeKqHiYkI3ZHPak2TzHBPkw==
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.3.tgz#fefa55b1f2265973a747b30da14a54b779b5090e"
+  integrity sha512-OnQZKp7qVera+Z4ly6hgybGgyf10p2VDXqwueXkMVeLD+PwlPG8a8NMpKkZ+QxwRbQbSFhRLQaib3NX34tusBQ==
   dependencies:
-    "@sentry/hub" "6.2.2"
-    "@sentry/minimal" "6.2.2"
-    "@sentry/types" "6.2.2"
-    "@sentry/utils" "6.2.2"
+    "@sentry/hub" "6.2.3"
+    "@sentry/minimal" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     tslib "^1.9.3"
 
-"@sentry/types@6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.2.tgz#9fc7795156680d3da5fc6ecc66702d8f7917f2b1"
-  integrity sha512-Y/1sRtw3a5JU4YdNBig8lLSVJ1UdYtuge+QP1CVLcLSAbq07Ok1bvF+Z+BlNcnHqle2Fl8aKuryG5Yu86enOyQ==
+"@sentry/types@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.3.tgz#0c06a475a51d28c73a69b05f0d43db05310ec241"
+  integrity sha512-BpA+9FherWgYlkMD/82bGFh/gAqZNlZX5UE8vWLKyyzNyOEEz3v9ScxE8dOSWE4v5iXJR1O3jjxaTcRQxPVgCA==
 
-"@sentry/utils@6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.2.2.tgz#69f7151db74e65a010cec062cc9ab3e30bf2c80a"
-  integrity sha512-qaee6X6VDNZ8HeO83/veaKw0KuhDE7j1R+Yryme3PywFzsoTzutDrEQjb7gvcHAhBaAYX8IHUBHgxcFI9BxI+w==
+"@sentry/utils@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.2.3.tgz#c96539571a67fb2eed56897133649f35309e3f74"
+  integrity sha512-YnkJm97wSvck39eRpqWjIuuwbvzPilvAcMqhbUy9yK/UBQMDGUzAKCOKH40udw1DwMUCWjJ71mOCDgUorE4Fog==
   dependencies:
-    "@sentry/types" "6.2.2"
+    "@sentry/types" "6.2.3"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":
@@ -1543,9 +1543,9 @@
   integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
-  version "7.1.13"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.13.tgz#bc6eea53975fdf163aff66c086522c6f293ae4cf"
-  integrity sha512-CC6amBNND16pTk4K3ZqKIaba6VGKAQs3gMjEY17FVd56oI/ZWt9OhS6riYiWv9s8ENbYUi7p8lgqb0QHQvUKQQ==
+  version "7.1.14"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
+  integrity sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -2194,6 +2194,11 @@ acorn-numeric-separator@^0.3.0:
   resolved "https://registry.yarnpkg.com/acorn-numeric-separator/-/acorn-numeric-separator-0.3.6.tgz#af7f0abaf8e74bd9ca1117602954d0a3b75804f3"
   integrity sha512-jUr5esgChu4k7VzesH/Nww3EysuyGJJcTEEiXqILUFKpO96PNyEXmK21M6nE0TSqGA1PeEg1MzgqJaoFsn9JMw==
 
+acorn-optional-chaining@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/acorn-optional-chaining/-/acorn-optional-chaining-0.0.3.tgz#b620a81ee3121d554c03a90f8c34f2dbe6ab90b6"
+  integrity sha512-kvXKOWyxajchq93OdXhCLB+v8/lbmwO9vstTxSJv1Ww1E6RRnQpycA0cKr+ja7gaeGcV9lC+bLm4aZPrZ04ytA==
+
 acorn-private-class-elements@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/acorn-private-class-elements/-/acorn-private-class-elements-0.2.7.tgz#b14902c705bcff267adede1c9f61c1a317ef95d2"
@@ -2286,9 +2291,9 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     uri-js "^4.2.2"
 
 ajv@^7.0.2:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.1.tgz#a5ac226171912447683524fa2f1248fcf8bac83d"
-  integrity sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.3.tgz#ca78d1cf458d7d36d1c3fa0794dd143406db5772"
+  integrity sha512-idv5WZvKVXDqKralOImQgPM9v6WOdLNa0IY3B3doOjw/YxRGT8I+allIJ6kd7Uaj+SF1xZUSU+nPM5aDNBVtnw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -3096,9 +3101,9 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@>=1.0.30000843, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001196:
-  version "1.0.30001202"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz#4cb3bd5e8a808e8cd89e4e66c549989bc8137201"
-  integrity sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==
+  version "1.0.30001203"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz#a7a34df21a387d9deffcd56c000b8cf5ab540580"
+  integrity sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3605,9 +3610,9 @@ cross-env@^7.0.0:
     cross-spawn "^7.0.1"
 
 cross-fetch@^3.0.6:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.1.tgz#a7ed5a9201d46223d805c5e9ecdc23ea600219eb"
-  integrity sha512-eIF+IHQpRzoGd/0zPrwQmHwDC90mdvjk+hcbYhKoaRrEk4GEIDqdjs/MljmdPPoHTQudbmWS+f0hZsEpFaEvWw==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.2.tgz#ee0c2f18844c4fde36150c2a4ddc068d20c1bc41"
+  integrity sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==
   dependencies:
     node-fetch "2.6.1"
 
@@ -4165,9 +4170,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.649:
-  version "1.3.692"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.692.tgz#4d00479055a7282cdd1b19caec09ed7779529640"
-  integrity sha512-Ix+zDUAXWZuUzqKdhkgN5dP7ZM+IwMG4yAGFGDLpGJP/3vNEEwuHG1LIhtXUfW0FFV0j38t5PUv2n/3MFSRviQ==
+  version "1.3.693"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.693.tgz#5089c506a925c31f93fcb173a003a22e341115dd"
+  integrity sha512-vUdsE8yyeu30RecppQtI+XTz2++LWLVEIYmzeCaCRLSdtKZ2eXqdJcrs85KwLiPOPVc6PELgWyXBsfqIvzGZag==
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -5904,6 +5909,7 @@ i18next-scanner@delphiactual/i18next-scanner:
     acorn "^6.0.0"
     acorn-dynamic-import "^4.0.0"
     acorn-jsx "^5.2.0"
+    acorn-optional-chaining "^0.0.3"
     acorn-stage3 "^2.0.0"
     acorn-walk "^6.0.0"
     chalk "^2.4.1"
@@ -5912,7 +5918,7 @@ i18next-scanner@delphiactual/i18next-scanner:
     deepmerge "^4.0.0"
     ensure-array "^1.0.0"
     eol "^0.9.1"
-    esprima "^4.0.1"
+    esprima "^4.0.0"
     gulp-sort "^2.0.0"
     i18next "*"
     lodash "^4.0.0"
@@ -9795,9 +9801,9 @@ rollup-plugin-terser@^7.0.0:
     terser "^5.0.0"
 
 rollup@^2.25.0:
-  version "2.41.5"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.5.tgz#e79cef8cc5c121612528f590319639b1f32da2d7"
-  integrity sha512-uG+WNNxhOYyeuO7oRt98GA2CNVRgQ67zca75UQVMPzMrLG9FUKzTCgvYVWhtB18TNbV7Uqxo97h+wErAnpFNJw==
+  version "2.42.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.42.1.tgz#6d675b7971e3bee510935326a0f7e556bb7d43de"
+  integrity sha512-/y7M2ULg06JOXmMpPzhTeQroJSchy8lX8q6qrjqil0jmLz6ejCWbQzVnWTsdmMQRhfU0QcwtiW8iZlmrGXWV4g==
   optionalDependencies:
     fsevents "~2.3.1"
 
@@ -11745,9 +11751,9 @@ webpack-sources@^2.1.1:
     source-map "^0.6.1"
 
 webpack@^5.1.3:
-  version "5.26.3"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.26.3.tgz#bafd439abac08fbb82657ec855d038743b725ab8"
-  integrity sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.27.0.tgz#387458f83142253f2759e22415dc1359746e6940"
+  integrity sha512-So7grHu//UyJ+80VrNHjWwW6WSZkfWWD6a7NV/88r8G92PO6TYOGzbtTiZBwbPVkx6LVP8OYvHD+IxuJ2KBz4g==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.46"


### PR DESCRIPTION
Refamiliarizing myself with Loadout Optimizer's code, and making some slight performance and (maybe) correctness tweaks:

* On my machine these changes take the default options (no stat filters, no mods) from 500,000 combos/s to 600,000 combos/s.
* Stats are capped at 100 *after* mods, not *before* mods.
* Items are sorted by "loadout optimizer priority" (total of non-ignored stats, then chosen stats in order) rather than just by total stat, which should improve some edge cases when trimming items from consideration.
* Masterworking and the "assume masterwork" flag are taking into account when sorting items.
* The worker is no longer left around after running.
* We can no longer accidentally remove the only item of a type when trimming combos (seems unlikely but it was possible).