### PR TITLE
Loadout optimizer CSS fixes

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.m.scss
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss
@@ -43,8 +43,8 @@
   font-size: 1.2em;
   padding: 10px 10px;
   position: fixed;
-  top: $header-height;
   left: 50%;
+  @include below-header;
 
   white-space: nowrap;
   z-index: 10;

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'menuContent': string;
   'page': string;
   'processing': string;
+  'searchOpen': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
@@ -2,9 +2,7 @@
 
 .item {
   display: grid;
-  grid-template-areas:
-    'item sockets'
-    'container sockets';
+  grid-template-areas: 'item sockets';
   gap: 6px;
   width: min-content;
   align-items: start;
@@ -67,13 +65,13 @@
 .swapButton {
   composes: dim-button from global;
   justify-self: center;
+  margin-top: 6px;
   @include phone-portrait {
     padding: 8px 20px;
   }
 }
 
 .swapButtonContainer {
-  grid-area: container;
   display: grid;
   min-height: 24px;
   @include phone-portrait {

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -79,9 +79,8 @@ export default function GeneratedSetItem({
 
   return (
     <div className={styles.item}>
-      <LoadoutBuilderItem item={item} locked={locked} addLockedItem={addLockedItem} />
-
       <div className={styles.swapButtonContainer}>
+        <LoadoutBuilderItem item={item} locked={locked} addLockedItem={addLockedItem} />
         {itemOptions.length > 1 ? (
           <button
             type="button"


### PR DESCRIPTION
1. Fix the progress popup not showing up on iPhone (it needs special padding for rounded-corner iPhones)
2. Fix the swap button getting pushed down by 5th mod.

<img width="139" alt="Screen Shot 2021-03-20 at 3 00 10 PM" src="https://user-images.githubusercontent.com/313208/111886712-0576d500-898d-11eb-8bfa-7dcbc4336e22.png">
