### PR TITLE
Refactor SetTracker into its own class

### DIFF
--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -242,6 +242,12 @@ export function process(
               // itemStats are already in the user's chosen stat order
               for (const statType of statOrder) {
                 stats[statType] = stats[statType] + itemStats[index];
+                // Stats can't exceed 100 even with mods. At least, today they
+                // can't - we *could* pass the max value in from the stat def.
+                // Math.min is slow.
+                if (stats[statType] > 100) {
+                  stats[statType] = 100;
+                }
                 index++;
               }
             }
@@ -249,12 +255,6 @@ export function process(
             let totalTier = 0;
             let statRangeExceeded = false;
             for (const statKey of orderedConsideredStats) {
-              // Stats can't exceed 100 even with mods. At least, today they
-              // can't - we *could* pass the max value in from the stat def.
-              // Math.min is slow.
-              if (stats[statKey] > 100) {
-                stats[statKey] = 100;
-              }
               const tier = statTier(stats[statKey]);
 
               // Update our global min/max for this stat

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -246,8 +246,6 @@ export function process(
               }
             }
 
-            // A string version of the tier-level of each stat, separated by commas
-            // This is an awkward implementation to save garbage allocations.
             let totalTier = 0;
             let statRangeExceeded = false;
             for (const statKey of orderedConsideredStats) {
@@ -305,6 +303,8 @@ export function process(
             };
 
             // Calculate the "tiers string" here, since most sets don't make it this far
+            // A string version of the tier-level of each stat, separated by commas
+            // This is an awkward implementation to save garbage allocations.
             let tiers = '';
             let index = 0;
             for (const statKey of orderedConsideredStats) {
@@ -340,14 +340,15 @@ export function process(
     'ms - ',
     (combos * 1000) / totalTime,
     'combos/s',
+    // Split into two objects so console.log will show them all expanded
     {
       numCantSlotMods,
       numSkippedLowTier,
       numStatRangeExceeded,
-      numInserted,
-      numRejectedAfterInsert,
     },
     {
+      numInserted,
+      numRejectedAfterInsert,
       numDoubleExotic,
     }
   );

--- a/src/app/loadout-builder/processWorker/process.ts
+++ b/src/app/loadout-builder/processWorker/process.ts
@@ -248,9 +248,7 @@ export function process(
 
             // A string version of the tier-level of each stat, separated by commas
             // This is an awkward implementation to save garbage allocations.
-            let tiers = '';
             let totalTier = 0;
-            let index = 0;
             let statRangeExceeded = false;
             for (const statKey of orderedConsideredStats) {
               // Stats can't exceed 100 even with mods. At least, today they
@@ -273,12 +271,7 @@ export function process(
                 statRangeExceeded = true;
                 break;
               }
-              tiers += tier;
               totalTier += tier;
-              if (index < statOrder.length - 1) {
-                tiers += ',';
-              }
-              index++;
             }
 
             if (statRangeExceeded) {
@@ -310,6 +303,18 @@ export function process(
               armor,
               stats,
             };
+
+            // Calculate the "tiers string" here, since most sets don't make it this far
+            let tiers = '';
+            let index = 0;
+            for (const statKey of orderedConsideredStats) {
+              const tier = statTier(stats[statKey]);
+              tiers += tier;
+              if (index < statOrder.length - 1) {
+                tiers += ',';
+              }
+              index++;
+            }
 
             numInserted++;
             if (!setTracker.insert(totalTier, tiers, newArmorSet)) {

--- a/src/app/loadout-builder/processWorker/set-tracker.ts
+++ b/src/app/loadout-builder/processWorker/set-tracker.ts
@@ -1,0 +1,100 @@
+import { IntermediateProcessArmorSet } from 'types';
+import { getPower } from '../utils';
+
+/**
+ * A list of stat mixes by total tier. We can keep this list up to date
+ * as we process new sets with an insertion sort algorithm.
+ */
+export type SetTracker = {
+  tier: number;
+  statMixes: { statMix: string; armorSets: IntermediateProcessArmorSet[] }[];
+}[];
+
+/**
+ * Use an insertion sort algorithm to keep an ordered list of sets first by total tier, then by stat mix within a tier.
+ * This takes advantage of the fact that strings are lexically comparable, but maybe it does that badly...
+ */
+// TODO: replace with trie?
+export function insertIntoSetTracker(
+  tier: number,
+  statMix: string,
+  armorSet: IntermediateProcessArmorSet,
+  setTracker: SetTracker
+): void {
+  if (setTracker.length === 0) {
+    setTracker.push({ tier, statMixes: [{ statMix, armorSets: [armorSet] }] });
+    return;
+  }
+
+  for (let tierIndex = 0; tierIndex < setTracker.length; tierIndex++) {
+    const currentTier = setTracker[tierIndex];
+
+    if (tier > currentTier.tier) {
+      setTracker.splice(tierIndex, 0, { tier, statMixes: [{ statMix, armorSets: [armorSet] }] });
+      return;
+    }
+
+    if (tier === currentTier.tier) {
+      const currentStatMixes = currentTier.statMixes;
+
+      for (let statMixIndex = 0; statMixIndex < currentStatMixes.length; statMixIndex++) {
+        const currentStatMix = currentStatMixes[statMixIndex];
+
+        if (statMix > currentStatMix.statMix) {
+          currentStatMixes.splice(statMixIndex, 0, { statMix, armorSets: [armorSet] });
+          return;
+        }
+
+        if (currentStatMix.statMix === statMix) {
+          for (
+            let armorSetIndex = 0;
+            armorSetIndex < currentStatMix.armorSets.length;
+            armorSetIndex++
+          ) {
+            if (
+              getPower(armorSet.armor) > getPower(currentStatMix.armorSets[armorSetIndex].armor)
+            ) {
+              currentStatMix.armorSets.splice(armorSetIndex, 0, armorSet);
+            } else {
+              currentStatMix.armorSets.push(armorSet);
+            }
+            return;
+          }
+        }
+
+        if (statMixIndex === currentStatMixes.length - 1) {
+          currentStatMixes.push({ statMix, armorSets: [armorSet] });
+          return;
+        }
+      }
+    }
+
+    if (tierIndex === setTracker.length - 1) {
+      setTracker.push({ tier, statMixes: [{ statMix, armorSets: [armorSet] }] });
+      return;
+    }
+  }
+}
+
+/**
+ * Returns the lowest known tier
+ */
+export function trimWorstSet(setTracker: SetTracker) {
+  const lowestTierSet = setTracker[setTracker.length - 1];
+  const worstMix = lowestTierSet.statMixes[lowestTierSet.statMixes.length - 1];
+
+  worstMix.armorSets.pop();
+
+  if (worstMix.armorSets.length === 0) {
+    lowestTierSet.statMixes.pop();
+
+    if (lowestTierSet.statMixes.length === 0) {
+      setTracker.pop();
+    }
+  }
+  return setTracker[setTracker.length - 1].tier;
+}
+
+export function getAllSets(setTracker: SetTracker) {
+  return setTracker.map((set) => set.statMixes.map((mix) => mix.armorSets)).flat(2);
+}

--- a/src/app/loadout-builder/processWorker/set-tracker.ts
+++ b/src/app/loadout-builder/processWorker/set-tracker.ts
@@ -3,7 +3,12 @@ import { IntermediateProcessArmorSet } from './types';
 
 interface TierSet {
   tier: number;
-  statMixes: { statMix: string; armorSets: IntermediateProcessArmorSet[] }[];
+  // Stat mixes ordered by decreasing lexical order of the statMix string
+  statMixes: {
+    statMix: string;
+    // Armor sets ordered by decreasing power
+    armorSets: IntermediateProcessArmorSet[];
+  }[];
 }
 
 /**
@@ -11,10 +16,10 @@ interface TierSet {
  * as we process new sets with an insertion sort algorithm.
  */
 export class SetTracker {
+  // Tiers ordered by decreasing tier
   tiers: TierSet[] = [];
   totalSets = 0;
-  lowestTier = 100;
-  capacity: number;
+  readonly capacity: number;
 
   constructor(capacity: number) {
     this.capacity = capacity;
@@ -24,87 +29,79 @@ export class SetTracker {
    * A short-circuit helper to check if inserting a set at this total tier could possibly be accepted.
    */
   couldInsert(totalTier: number) {
-    return totalTier >= this.lowestTier || this.totalSets < this.capacity;
+    const lowestKnownTier = this.tiers.length ? this.tiers[this.tiers.length - 1].tier : 0;
+    return totalTier >= lowestKnownTier || this.totalSets < this.capacity;
   }
 
   /**
    * Insert this set into the tracker. If the tracker is at capacity this set or another one may be dropped.
    */
   insert(tier: number, statMix: string, armorSet: IntermediateProcessArmorSet) {
-    if (tier < this.lowestTier) {
-      this.lowestTier = tier;
-    }
     if (this.tiers.length === 0) {
       this.tiers.push({ tier, statMixes: [{ statMix, armorSets: [armorSet] }] });
-      this.totalSets++;
-      return;
-    }
+    } else {
+      outer: for (let tierIndex = 0; tierIndex < this.tiers.length; tierIndex++) {
+        const currentTier = this.tiers[tierIndex];
 
-    let inserted = false;
-    // TODO: reverse order!
-    outer: for (let tierIndex = 0; tierIndex < this.tiers.length; tierIndex++) {
-      const currentTier = this.tiers[tierIndex];
+        if (tier > currentTier.tier) {
+          this.tiers.splice(tierIndex, 0, {
+            tier,
+            statMixes: [{ statMix, armorSets: [armorSet] }],
+          });
+          break outer;
+        }
 
-      if (tier > currentTier.tier) {
-        this.tiers.splice(tierIndex, 0, { tier, statMixes: [{ statMix, armorSets: [armorSet] }] });
-        this.totalSets++;
-        inserted = true;
-        break outer;
-      }
+        if (tier === currentTier.tier) {
+          const currentStatMixes = currentTier.statMixes;
 
-      if (tier === currentTier.tier) {
-        const currentStatMixes = currentTier.statMixes;
+          for (let statMixIndex = 0; statMixIndex < currentStatMixes.length; statMixIndex++) {
+            const currentStatMix = currentStatMixes[statMixIndex];
 
-        for (let statMixIndex = 0; statMixIndex < currentStatMixes.length; statMixIndex++) {
-          const currentStatMix = currentStatMixes[statMixIndex];
+            if (statMix > currentStatMix.statMix) {
+              currentStatMixes.splice(statMixIndex, 0, { statMix, armorSets: [armorSet] });
+              break outer;
+            }
 
-          if (statMix > currentStatMix.statMix) {
-            currentStatMixes.splice(statMixIndex, 0, { statMix, armorSets: [armorSet] });
-            this.totalSets++;
-            inserted = true;
-            break outer;
-          }
-
-          if (currentStatMix.statMix === statMix) {
-            for (
-              let armorSetIndex = 0;
-              armorSetIndex < currentStatMix.armorSets.length;
-              armorSetIndex++
-            ) {
-              if (
-                getPower(armorSet.armor) > getPower(currentStatMix.armorSets[armorSetIndex].armor)
+            if (currentStatMix.statMix === statMix) {
+              const armorSetPower = getPower(armorSet.armor);
+              for (
+                let armorSetIndex = 0;
+                armorSetIndex < currentStatMix.armorSets.length;
+                armorSetIndex++
               ) {
-                currentStatMix.armorSets.splice(armorSetIndex, 0, armorSet);
-              } else {
-                currentStatMix.armorSets.push(armorSet);
+                if (armorSetPower > getPower(currentStatMix.armorSets[armorSetIndex].armor)) {
+                  currentStatMix.armorSets.splice(armorSetIndex, 0, armorSet);
+                  break outer;
+                }
+                if (armorSetIndex === currentStatMix.armorSets.length - 1) {
+                  currentStatMix.armorSets.push(armorSet);
+                  break outer;
+                }
               }
-              this.totalSets++;
-              inserted = true;
+            }
+
+            // This is the worst mix for this tier we've seen, but it could still be better than something at a lower tier
+            if (statMixIndex === currentStatMixes.length - 1) {
+              currentStatMixes.push({ statMix, armorSets: [armorSet] });
               break outer;
             }
           }
+        }
 
-          if (statMixIndex === currentStatMixes.length - 1) {
-            currentStatMixes.push({ statMix, armorSets: [armorSet] });
-            this.totalSets++;
-            inserted = true;
+        // This is lower tier than our previous lowest tier
+        if (tierIndex === this.tiers.length - 1) {
+          if (this.totalSets < this.capacity) {
+            this.tiers.push({ tier, statMixes: [{ statMix, armorSets: [armorSet] }] });
             break outer;
+          } else {
+            // Don't bother inserting it at all
+            return false;
           }
         }
       }
-
-      // This is larger than the largest tier we know about, insert it
-      if (tierIndex === this.tiers.length - 1) {
-        this.tiers.push({ tier, statMixes: [{ statMix, armorSets: [armorSet] }] });
-        this.totalSets++;
-        inserted = true;
-        break outer;
-      }
     }
 
-    if (!inserted) {
-      throw new Error('failed to insert');
-    }
+    this.totalSets++;
 
     return this.trimWorstSet();
   }
@@ -126,7 +123,6 @@ export class SetTracker {
         this.tiers.pop();
       }
     }
-    this.lowestTier = this.tiers[this.tiers.length - 1].tier;
     this.totalSets--;
     return false;
   }


### PR DESCRIPTION
This makes `SetTracker` a class and moves its methods into another file. I also made some optimizations and fixes:

1. Print some info about all the reasons we skip things during the processing. Due to this I was able to figure out that 99.5% of sets are rejected due to being below the minimum tier.
2. Given the above observation, defer calculating the "tier string" until after that check. While it's more work re-calculating the tier per stat when it happens, it's only running for 0.5% of sets.
3. Fixed the stat tracker insertion algorithm which wasn't correctly ordering armor sets by power, meaning we could drop something other than the top-power set upon reaching capacity.