### PR TITLE
Revert "simple search" and change canonicalization

### DIFF
--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -3937,9 +3937,19 @@ Array [
 
 exports[`parse |cluster tracking|: ast 1`] = `
 Object {
-  "args": "cluster tracking",
-  "op": "filter",
-  "type": "keyword",
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "cluster",
+      "op": "filter",
+      "type": "keyword",
+    },
+    Object {
+      "args": "tracking",
+      "op": "filter",
+      "type": "keyword",
+    },
+  ],
 }
 `;
 
@@ -3948,16 +3958,34 @@ Array [
   Array [
     "filter",
     "keyword",
-    "cluster tracking",
+    "cluster",
+  ],
+  Array [
+    "implicit_and",
+  ],
+  Array [
+    "filter",
+    "keyword",
+    "tracking",
   ],
 ]
 `;
 
 exports[`parse |gnawing hunger|: ast 1`] = `
 Object {
-  "args": "gnawing hunger",
-  "op": "filter",
-  "type": "keyword",
+  "op": "and",
+  "operands": Array [
+    Object {
+      "args": "gnawing",
+      "op": "filter",
+      "type": "keyword",
+    },
+    Object {
+      "args": "hunger",
+      "op": "filter",
+      "type": "keyword",
+    },
+  ],
 }
 `;
 
@@ -3966,7 +3994,15 @@ Array [
   Array [
     "filter",
     "keyword",
-    "gnawing hunger",
+    "gnawing",
+  ],
+  Array [
+    "implicit_and",
+  ],
+  Array [
+    "filter",
+    "keyword",
+    "hunger",
   ],
 ]
 `;
@@ -4798,26 +4834,35 @@ Array [
 
 exports[`parse |not forgotten|: ast 1`] = `
 Object {
-  "args": "not forgotten",
-  "op": "filter",
-  "type": "keyword",
+  "op": "not",
+  "operand": Object {
+    "args": "forgotten",
+    "op": "filter",
+    "type": "keyword",
+  },
 }
 `;
 
 exports[`parse |not forgotten|: ast 2`] = `
 Object {
-  "args": "not forgotten",
-  "op": "filter",
-  "type": "keyword",
+  "op": "not",
+  "operand": Object {
+    "args": "forgotten",
+    "op": "filter",
+    "type": "keyword",
+  },
 }
 `;
 
 exports[`parse |not forgotten|: lexer 1`] = `
 Array [
   Array [
+    "not",
+  ],
+  Array [
     "filter",
     "keyword",
-    "not forgotten",
+    "forgotten",
   ],
 ]
 `;
@@ -4825,9 +4870,12 @@ Array [
 exports[`parse |not forgotten|: lexer 2`] = `
 Array [
   Array [
+    "not",
+  ],
+  Array [
     "filter",
     "keyword",
-    "not forgotten",
+    "forgotten",
   ],
 ]
 `;
@@ -4951,7 +4999,7 @@ Array [
 
 exports[`parse |‘grenade launcher reserves’|: ast 1`] = `
 Object {
-  "args": "'grenade launcher reserves'",
+  "args": "grenade launcher reserves",
   "op": "filter",
   "type": "keyword",
 }
@@ -4962,7 +5010,7 @@ Array [
   Array [
     "filter",
     "keyword",
-    "'grenade launcher reserves'",
+    "grenade launcher reserves",
   ],
 ]
 `;

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -63,8 +63,8 @@ const equivalentSearches = [
     'is:blue is:weapon or is:armor not:maxpower',
     'is:blue and (is:weapon or is:armor) and -is:maxpower',
   ],
-  ['not forgotten', '"not forgotten"'],
-  ['cluster tracking', '"cluster tracking"'],
+  ['not forgotten', '-"forgotten"'],
+  ['cluster tracking', '"cluster" and "tracking"'],
   [
     'is:weapon and is:sniperrifle or not is:armor and modslot:arrival',
     '(is:weapon and is:sniperrifle) or (-is:armor and modslot:arrival)',
@@ -90,14 +90,14 @@ const canonicalize = [
   ['is:blue is:haspower not:maxpower', 'is:blue is:haspower -is:maxpower'],
   [
     'is:weapon and is:sniperrifle or not is:armor and modslot:arrival',
-    '(-is:armor modslot:arrival) or (is:sniperrifle is:weapon)',
+    '(is:weapon is:sniperrifle) or (-is:armor modslot:arrival)',
   ],
   [
     'is:rocketlauncher perk:"cluster" or perk:\'tracking module\'',
-    'is:rocketlauncher (perk:"tracking module" or perk:cluster)',
+    'is:rocketlauncher (perk:cluster or perk:"tracking module")',
   ],
-  ['( power:>1000 and -modslot:arrival ) ', '-modslot:arrival power:>1000'],
-  ['food fight', '"food fight"'],
+  ['( power:>1000 and -modslot:arrival ) ', 'power:>1000 -modslot:arrival'],
+  ['food fight', 'food and fight'],
 ];
 
 test.each(cases)('parse |%s|', (query) => {


### PR DESCRIPTION
A few changes here:

1. Revert the simple literal search
2. Don't ever save no-op searches
3. Allow saving searches that we'd excluded from saving in history
4. Change canonicalization rules to no longer sort branches
5. Change canonicalization rules to insert an "and" between bare literals