### PR TITLE
Optimiser cleanup

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -14,7 +14,6 @@ import { searchFilterSelector } from 'app/search/search-filter';
 import { AppIcon, refreshIcon } from 'app/shell/icons';
 import { querySelector } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { AnimatePresence, motion } from 'framer-motion';
 import _ from 'lodash';
 import React, { useMemo } from 'react';
@@ -74,17 +73,17 @@ function mapStateToProps() {
         if (!item || !isLoadoutBuilderItem(item)) {
           continue;
         }
-        for (const classType of item.classType === DestinyClass.Unknown
-          ? [DestinyClass.Hunter, DestinyClass.Titan, DestinyClass.Warlock]
-          : [item.classType]) {
-          if (!items[classType]) {
-            items[classType] = {};
-          }
-          if (!items[classType][item.bucket.hash]) {
-            items[classType][item.bucket.hash] = [];
-          }
-          items[classType][item.bucket.hash].push(item);
+        const { classType, bucket } = item;
+
+        if (!items[classType]) {
+          items[classType] = {};
         }
+
+        if (!items[classType][bucket.hash]) {
+          items[classType][bucket.hash] = [];
+        }
+
+        items[classType][bucket.hash].push(item);
       }
 
       return items;

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -84,16 +84,13 @@ function mapStateToProps() {
         if (!plugSets[item.bucket.hash]) {
           plugSets[item.bucket.hash] = new Set<number>();
         }
-        // build the filtered unique perks item picker
+        // build the filtered unique mods
         item.sockets.allSockets
           .filter((s) => !s.isPerk)
           .forEach((socket) => {
             if (socket.socketDefinition.reusablePlugSetHash) {
               plugSets[item.bucket.hash].add(socket.socketDefinition.reusablePlugSetHash);
-            } else if (socket.socketDefinition.randomizedPlugSetHash) {
-              plugSets[item.bucket.hash].add(socket.socketDefinition.randomizedPlugSetHash);
             }
-            // TODO: potentially also add inventory-based mods
           });
       }
 
@@ -244,10 +241,7 @@ function ModPicker({
   const groupHeaderOrder = [...knownModPlugCategoryHashes];
 
   for (const mod of queryFilteredMods) {
-    const title =
-      language === 'en'
-        ? mod.modDef.itemTypeDisplayName.replaceAll(/armor/gi, '').replaceAll(/mod/gi, '').trim()
-        : mod.modDef.itemTypeDisplayName;
+    const title = mod.modDef.itemTypeDisplayName;
 
     if (!groupedModsByItemTypeDisplayName[title]) {
       groupedModsByItemTypeDisplayName[title] = {


### PR DESCRIPTION
Cleaned up a few random things in the optimiser
1. When building the item map in LoadoutBuilder remove the bit meant for ghosts
2. Remove the randomized socket lookup in the mod picker
3. Stop stripping words out of mod category headings in the mod picker as languages other than english exist.