### PR TITLE
Conditional mods in optimiser fix.

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -156,7 +156,7 @@ function LoadoutBuilder({
   );
 
   const { result, processing } = useProcess(
-    selectedStoreId,
+    selectedStore,
     filteredItems,
     lockedMap,
     lockedArmor2Mods,

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -1,3 +1,11 @@
+import { modsWithConditionalStats } from 'app/search/d2-known-values';
+import { chargedWithLightPlugCategoryHashes } from 'app/search/specialty-modslots';
+import {
+  DestinyClass,
+  DestinyEnergyType,
+  DestinyItemInvestmentStatDefinition,
+} from 'bungie-api-ts/destiny2';
+import { StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { DimItem } from '../../inventory/item-types';
 import {
@@ -36,12 +44,51 @@ export function mapArmor2ModToProcessMod(mod: LockedMod): ProcessMod {
   return processMod;
 }
 
+function isModStatActive(
+  characterClass: DestinyClass,
+  plugHash: number,
+  stat: DestinyItemInvestmentStatDefinition,
+  lockedMods: LockedMod[]
+): boolean {
+  if (!stat.isConditionallyActive) {
+    return true;
+  } else if (
+    plugHash === modsWithConditionalStats.powerfulFriends ||
+    plugHash === modsWithConditionalStats.radiantLight
+  ) {
+    // Powerful Friends & Radiant Light
+    // True if another arc charged with light mod is found
+    // Note the this is not entirely correct as another arc mod slotted into the same item would
+    // also trigger it but we dont know that until we try to socket them. Basically it is too hard
+    // to figure that condition out so lets leave it as a known issue for now.
+    return Boolean(
+      lockedMods.find(
+        (mod) =>
+          mod.modDef.plug.energyCost?.energyType === DestinyEnergyType.Arc &&
+          chargedWithLightPlugCategoryHashes.includes(mod.modDef.plug.plugCategoryHash)
+      )
+    );
+  } else if (plugHash === modsWithConditionalStats.chargeHarvester) {
+    // Charge Harvester
+    return (
+      (characterClass === DestinyClass.Hunter && stat.statTypeHash === StatHashes.Mobility) ||
+      (characterClass === DestinyClass.Titan && stat.statTypeHash === StatHashes.Resilience) ||
+      (characterClass === DestinyClass.Warlock && stat.statTypeHash === StatHashes.Recovery)
+    );
+  } else {
+    return true;
+  }
+}
+
 /**
  * This sums up the total stat contributions across mods passed in. These are then applied
  * to the loadouts after all the items base values have been summed. This mimics how mods
  * effect stat values in game and allows us to do some preprocessing.
  */
-export function getTotalModStatChanges(lockedArmor2Mods: LockedModMap) {
+export function getTotalModStatChanges(
+  lockedArmor2Mods: LockedModMap,
+  characterClass?: DestinyClass
+) {
   const totals: { [stat in StatTypes]: number } = {
     Mobility: 0,
     Recovery: 0,
@@ -51,11 +98,20 @@ export function getTotalModStatChanges(lockedArmor2Mods: LockedModMap) {
     Strength: 0,
   };
 
+  // This should only happen on initialisation if the store is undefined.
+  if (!characterClass) {
+    return totals;
+  }
+
+  const flatMods = Object.values(lockedArmor2Mods)
+    .flat()
+    .filter((mod): mod is LockedMod => Boolean(mod));
+
   for (const mods of Object.values(lockedArmor2Mods)) {
     for (const mod of mods || []) {
       for (const stat of mod.modDef.investmentStats) {
         const statType = statHashToType[stat.statTypeHash];
-        if (statType) {
+        if (statType && isModStatActive(characterClass, mod.modDef.hash, stat, flatMods)) {
           totals[statType] += stat.value;
         }
       }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -1,4 +1,5 @@
 import { DimItem } from 'app/inventory/item-types';
+import { DimStore } from 'app/inventory/store-types';
 import {
   armor2PlugCategoryHashes,
   armor2PlugCategoryHashesByName,
@@ -45,7 +46,7 @@ interface ProcessState {
  */
 // TODO: introduce params object
 export function useProcess(
-  selectedStoreId: string | undefined,
+  selectedStore: DimStore<DimItem> | undefined,
   filteredItems: ItemsByBucket,
   lockedItems: LockedMap,
   lockedModMap: LockedModMap,
@@ -55,7 +56,7 @@ export function useProcess(
 ) {
   const [{ result, processing }, setState] = useState<ProcessState>({
     processing: false,
-    resultStoreId: selectedStoreId,
+    resultStoreId: selectedStore?.id,
     result: null,
   });
 
@@ -85,8 +86,8 @@ export function useProcess(
 
     setState((state) => ({
       processing: true,
-      resultStoreId: selectedStoreId,
-      result: selectedStoreId === state.resultStoreId ? state.result : null,
+      resultStoreId: selectedStore?.id,
+      result: selectedStore?.id === state.resultStoreId ? state.result : null,
       currentCleanup: cleanup,
     }));
 
@@ -133,7 +134,7 @@ export function useProcess(
     worker
       .process(
         processItems,
-        getTotalModStatChanges(lockedModMap),
+        getTotalModStatChanges(lockedModMap, selectedStore?.classType),
         lockedProcessMods,
         assumeMasterwork,
         statOrder,
@@ -171,7 +172,7 @@ export function useProcess(
     assumeMasterwork,
     statOrder,
     statFilters,
-    selectedStoreId,
+    selectedStore,
   ]);
 
   return { result, processing };

--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -57,6 +57,11 @@ export const modTypeTagByPlugCategoryHash = {
   [PlugCategoryHashes.EnhancementsSeasonV500]: 'combat',
 };
 
+export const chargedWithLightPlugCategoryHashes = [
+  PlugCategoryHashes.EnhancementsSeasonV470,
+  PlugCategoryHashes.EnhancementsSeasonV490,
+];
+
 const legacySocketTypeHashes = [
   1540673283, // an outlaw-looking one, that's on S11 LW/Reverie,
   // but in-game it has the same compatibility as any other legacy slot


### PR DESCRIPTION
Fix for conditional mods not being quite correct in the optimiser. Apparently I didn't handle it when I did the rest of the conditional mods.

Still not entirely correct. It's too hard to handle the condition of another arc mod being slotted into an item as that isn't figured out until we start trying to align mods with items and we calculate these stats well before any of that happens.

Fixes #6615 