### PR TITLE
Bug: stats not used for mods with titans in optimiser

### DIFF
--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -98,6 +98,11 @@ export function getTotalModStatChanges(
     Strength: 0,
   };
 
+  // This should only happen on initialisation if the store is undefined.
+  if (characterClass === undefined) {
+    return totals;
+  }
+
   const flatMods = Object.values(lockedArmor2Mods)
     .flat()
     .filter((mod): mod is LockedMod => Boolean(mod));

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -98,11 +98,6 @@ export function getTotalModStatChanges(
     Strength: 0,
   };
 
-  // This should only happen on initialisation if the store is undefined.
-  if (!characterClass) {
-    return totals;
-  }
-
   const flatMods = Object.values(lockedArmor2Mods)
     .flat()
     .filter((mod): mod is LockedMod => Boolean(mod));


### PR DESCRIPTION
Fix issue where we were hitting a falsey condition with mods for titan in the optimiser causing mods not to be counted