### PR TITLE
Autosuggest hash tags

### DIFF
--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -184,7 +184,7 @@ export function autocompleteTermSuggestions(
   caretIndex = (caretEndRegex.exec(query.slice(caretIndex))?.index || 0) + caretIndex;
 
   // Find the last word that looks like a search
-  const match = /\b([\w:"']{3,})$/i.exec(query.slice(0, caretIndex));
+  const match = /(\b[\w:"']{3,}|#\w*)$/i.exec(query.slice(0, caretIndex));
   if (match) {
     const term = match[1];
     const candidates = filterComplete(term);

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -43,6 +43,22 @@ const freeformFilters: FilterDefinition[] = [
     keywords: 'notes',
     description: tl('Filter.Notes'),
     format: 'freeform',
+    suggestionsGenerator: ({ itemInfos }) => {
+      if (!itemInfos) {
+        return;
+      }
+      // collect hash tags from item notes
+      const hashTags = new Set<string>();
+      for (const info of Object.values(itemInfos)) {
+        const matches = info.notes?.matchAll(/#\w+/g);
+        if (matches) {
+          for (const match of matches) {
+            hashTags.add(match[0]);
+          }
+        }
+      }
+      return [...hashTags];
+    },
     filter: ({ filterValue, itemInfos, itemHashTags, language }) => {
       filterValue = plainString(filterValue, language);
       return (item) => {


### PR DESCRIPTION
branched from #6623, the diff might be clearer once that's merged
detects "hash tags" in notes, and suggests searches for them when you type `#`
![6924gj](https://user-images.githubusercontent.com/68782081/112749769-6bf58780-8f79-11eb-84f1-e275e381ffe5.gif)

there's a lot more neat stuff to do with something like this, altering the notes icon, providing text suggest in the notes field, highlighting hash tags in the notes field. but here's an easy start since i have the contextual suggestion generator now