### PR TITLE
Item name suggestions

### DIFF
--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -1,6 +1,7 @@
 import { tl } from 'app/i18next-t';
 import { Loadout } from 'app/loadout/loadout-types';
 import { FilterDefinition } from '../filter-types';
+import { isQuotable, quoteFilterString } from './freeform';
 
 const loadoutFilters: FilterDefinition[] = [
   {
@@ -9,15 +10,8 @@ const loadoutFilters: FilterDefinition[] = [
     // excluding a "format" property causes autogeneration of the simple "is" and "not" stems
     suggestionsGenerator: ({ loadouts }) =>
       loadouts
-        // we can't properly quote loadout names if they contain both ' and ", so..
-        // we filter them out. small caveat there for the future "WHY DOESNT THIS WORK" user
-        ?.filter((l) => !(l.name.includes(`'`) && l.name.includes(`"`)))
-        .map((l) => {
-          const loadoutName = l.name.toLowerCase();
-          return loadoutName.includes(`"`)
-            ? `inloadout:'${loadoutName}'`
-            : `inloadout:"${loadoutName}"`;
-        }),
+        ?.filter((l) => isQuotable(l.name))
+        .map((l) => quoteFilterString(l.name.toLowerCase())),
 
     description: tl('Filter.InLoadout'),
     filter: ({ filterValue, loadouts }) => {


### PR DESCRIPTION
adds item name suggestions, including non-sunset equippables, and the user's own items
![image](https://user-images.githubusercontent.com/68782081/112790089-63ea2600-9013-11eb-9d14-776387d7b6aa.png)

when suggesting, favors owned items & perks ahead of those from the manifest
somewhat standardizes the code for the three new text-based searches

to-do: probably narrow manifest filter more than just by `.equippable`