### PR TITLE
break suggestion finder into 2 segments to account for text string searches

### DIFF
--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -231,6 +231,8 @@ function findFilter(term: string, searchConfig: SearchConfig) {
   return searchConfig.filters[filterName];
 }
 
+// these filters might include quotes, so we search for two text segments to ignore quotes & colon
+// i.e. `name:test` can find `name:"test item"`
 const freeformTerms = freeformFilters.flatMap((f) => f.keywords).map((s) => `${s}:`);
 
 /**


### PR DESCRIPTION
enable this:
![image](https://user-images.githubusercontent.com/68782081/113055763-d536ef80-915f-11eb-84ec-e54b768c90ad.png)
