### PR TITLE
Tweak mod picker sections

### DIFF
--- a/src/app/loadout-builder/filter/ModPickerFooter.tsx
+++ b/src/app/loadout-builder/filter/ModPickerFooter.tsx
@@ -8,9 +8,11 @@ import styles from './ModPickerFooter.m.scss';
 
 interface Props {
   defs: D2ManifestDefinitions;
-  groupOrder: { plugCategoryHashes: number[] }[];
+  groupOrder: number[];
   isPhonePortrait: boolean;
-  lockedMods: { [plugCategoryHash: number]: PluggableInventoryItemDefinition[] | undefined };
+  locked: {
+    [plugCategoryHash: number]: PluggableInventoryItemDefinition[] | undefined;
+  };
   onSubmit(event: React.FormEvent | KeyboardEvent): void;
   onModSelected(item: PluggableInventoryItemDefinition): void;
 }
@@ -19,7 +21,7 @@ function ModPickerFooter({
   defs,
   isPhonePortrait,
   groupOrder,
-  lockedMods,
+  locked,
   onSubmit,
   onModSelected,
 }: Props) {
@@ -37,28 +39,26 @@ function ModPickerFooter({
         </button>
       </div>
       <div className={styles.selectedMods}>
-        {groupOrder.map((group) =>
-          group.plugCategoryHashes.map(
-            (pch) =>
-              pch in lockedMods && (
-                <React.Fragment key={pch}>
-                  {lockedMods[pch]?.map((mod) => {
-                    if (!modCounts[mod.hash]) {
-                      modCounts[mod.hash] = 0;
-                    }
+        {groupOrder.map(
+          (pch) =>
+            pch in locked && (
+              <React.Fragment key={pch}>
+                {locked[pch]?.map((mod) => {
+                  if (!modCounts[mod.hash]) {
+                    modCounts[mod.hash] = 0;
+                  }
 
-                    return (
-                      <LockedModIcon
-                        key={`${mod.hash}-${++modCounts[mod.hash]}`}
-                        mod={mod}
-                        defs={defs}
-                        onModClicked={() => onModSelected(mod)}
-                      />
-                    );
-                  })}
-                </React.Fragment>
-              )
-          )
+                  return (
+                    <LockedModIcon
+                      key={`${mod.hash}-${++modCounts[mod.hash]}`}
+                      mod={mod}
+                      defs={defs}
+                      onModClicked={() => onModSelected(mod)}
+                    />
+                  );
+                })}
+              </React.Fragment>
+            )
         )}
       </div>
     </div>

--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -24,16 +24,12 @@ export default function PickerSectionMods({
   defs,
   mods,
   locked,
-  title,
-  plugCategoryHashes,
   onModSelected,
   onModRemoved,
 }: {
   defs: D2ManifestDefinitions;
   mods: readonly PluggableInventoryItemDefinition[];
   locked: { [plugCategoryHash: number]: PluggableInventoryItemDefinition[] | undefined };
-  title: string;
-  plugCategoryHashes: number[];
   onModSelected(mod: PluggableInventoryItemDefinition);
   onModRemoved(mod: PluggableInventoryItemDefinition);
 }) {
@@ -41,22 +37,25 @@ export default function PickerSectionMods({
     return null;
   }
 
-  const isSlotSpecificCategory = Boolean(
-    _.intersection(slotSpecificPlugCategoryHashes, plugCategoryHashes).length
-  );
+  const { plugCategoryHash } = mods[0].plug;
+  const title = mods[0].itemTypeDisplayName;
+
+  const isSlotSpecificCategory = slotSpecificPlugCategoryHashes.includes(plugCategoryHash);
 
   let associatedLockedMods: PluggableInventoryItemDefinition[] = [];
 
-  if (
-    isSlotSpecificCategory ||
-    plugCategoryHashes.includes(armor2PlugCategoryHashesByName.general)
-  ) {
-    associatedLockedMods = plugCategoryHashes.flatMap((hash) => locked[hash] || []);
-  } else if (_.intersection(raidPlugCategoryHashes, plugCategoryHashes).length) {
+  if (isSlotSpecificCategory || plugCategoryHash === armor2PlugCategoryHashesByName.general) {
+    associatedLockedMods = locked[plugCategoryHash] || [];
+  } else if (raidPlugCategoryHashes.includes(plugCategoryHash)) {
     associatedLockedMods = raidPlugCategoryHashes.flatMap((hash) => locked[hash] || []);
   } else {
-    associatedLockedMods = Object.entries(locked).flatMap(([plugCategoryHash, mods]) =>
-      mods && !knownModPlugCategoryHashes.includes(Number(plugCategoryHash)) ? mods : []
+    associatedLockedMods = Object.entries(
+      locked
+    ).flatMap(([lockedPlugCategoryHash, lockedModsByPlugCatHash]) =>
+      lockedModsByPlugCatHash &&
+      !knownModPlugCategoryHashes.includes(Number(lockedPlugCategoryHash))
+        ? lockedModsByPlugCatHash
+        : []
     );
   }
 


### PR DESCRIPTION
We were getting two class item sections as we were grouping by itemTypeDisplayName.

![image](https://user-images.githubusercontent.com/7344652/113380910-3a414e00-93c9-11eb-8974-5a3d7aa97d8d.png)

I have changed it to group by plugCategoryHash. This means we will get two Charged With Light sections but they are from different seasons and have different plugCategoryHashes. Since basically everything is driven off plugCategoryHash I feel like this change makes the grouping a little more natural.