### PR TITLE
Improvements to `inloadout` filter

### DIFF
--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -11,7 +11,7 @@ const loadoutFilters: FilterDefinition[] = [
     suggestionsGenerator: ({ loadouts }) =>
       loadouts
         ?.filter((l) => isQuotable(l.name))
-        .map((l) => quoteFilterString(l.name.toLowerCase())),
+        .map((l) => 'inloadout:' + quoteFilterString(l.name.toLowerCase())),
 
     description: tl('Filter.InLoadout'),
     filter: ({ filterValue, loadouts }) => {

--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -22,8 +22,7 @@ const loadoutFilters: FilterDefinition[] = [
       // a search like
       // inloadout:"loadout name here"
       if (filterValue !== 'inloadout') {
-        const foundLoadout = loadouts.find((l) => l.name === filterValue);
-        selectedLoadouts = foundLoadout ? [foundLoadout] : [];
+        selectedLoadouts = loadouts.filter((l) => l.name.toLowerCase() === filterValue);
       }
 
       const loadoutItemIds = collectItemsInLoadouts(selectedLoadouts);


### PR DESCRIPTION
* Finds loadouts that aren't fully lowercase (doesn't seem to be too uncommon -- the changelog uses `inloadout:"My PVP Equipment"` as an example).
* Allows matching multiple loadouts. I have three "Aeon" loadouts, one for each character, and this would previously match one arbitrary character and ignore the other two.
* Provides the relevant suggestions when typing a loadout name; this would previously only suggest the loadout name as a plaintext search suggestion.