### PR TITLE
Trim loadout name while saving

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -1146,7 +1146,7 @@ function convertDimLoadoutToApiLoadout(dimLoadout: DimLoadout): Loadout {
   return {
     id: dimLoadout.id,
     classType: dimLoadout.classType,
-    name: dimLoadout.name,
+    name: dimLoadout.name.trim(),
     clearSpace: dimLoadout.clearSpace || false,
     equipped,
     unequipped,


### PR DESCRIPTION
Loadout names were never meant to allow leading or trailing whitespace. Believe it or not, in the Discord discussion where this was pointed out, someone mentioned that they add whitespace intentionally to affect loadout order, which will break after this. I'm OK with that.