### PR TITLE
Compare: Fix comparing ghosts/ships, don't allow comparing emblems/artifacts

### DIFF
--- a/src/app/compare/CompareSuggestions.tsx
+++ b/src/app/compare/CompareSuggestions.tsx
@@ -1,10 +1,9 @@
 import { DimItem } from 'app/inventory/item-types';
 import { filterFactorySelector } from 'app/search/search-filter';
 import { RootState } from 'app/store/types';
-import { emptyArray } from 'app/utils/empty';
 import React, { memo } from 'react';
 import { useSelector } from 'react-redux';
-import { CompareButton, findSimilarArmors, findSimilarWeapons } from './compare-buttons';
+import { defaultComparisons, findSimilarArmors, findSimilarWeapons } from './compare-buttons';
 
 /**
  * Display a row of buttons that suggest alternate queries based on an example item.
@@ -26,7 +25,7 @@ export default memo(function CompareSuggestions({
     ? findSimilarArmors(defs, exampleItem)
     : exampleItem.bucket.inWeapons
     ? findSimilarWeapons(exampleItem)
-    : emptyArray<CompareButton>();
+    : defaultComparisons(exampleItem);
 
   // Fill in the items that match each query
   const compareButtonsWithItems = compareButtons.map((button) => ({

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -157,3 +157,25 @@ export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
   comparisonSets = comparisonSets.reverse();
   return comparisonSets;
 }
+/**
+ * Generate possible comparisons for non-armor/weapon, given a reference item
+ */
+export function defaultComparisons(exampleItem: DimItem): CompareButton[] {
+  let comparisonSets: CompareButton[] = _.compact([
+    // same item type
+    {
+      // TODO: replace typeName with a lookup of itemCategoryHash
+      buttonLabel: exampleItem.typeName,
+      query: '', // since we already filter by itemCategoryHash, an empty query gives you all items matching that category
+    },
+
+    // exact same item, judging by name. might span multiple expansions.
+    {
+      buttonLabel: exampleItem.name,
+      query: `name:"${exampleItem.name}"`,
+    },
+  ]);
+
+  comparisonSets = comparisonSets.reverse();
+  return comparisonSets;
+}

--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -121,15 +121,9 @@ function addCompareItem(state: CompareState, item: DimItem): CompareState {
 
     const itemNameQuery = item.bucket.inWeapons
       ? `name:"${item.name.replace(new RegExp(t('Filter.Adept'), 'gi'), '').trim()}"`
-      : item.bucket.inArmor
-      ? // TODO: bring back the much more complicated armor dupes logic?
-        item.element
-        ? `(name:"${item.name}" is:${getItemDamageShortName(item)})`
-        : `name:"${item.name}"`
-      : undefined;
-    if (!itemNameQuery) {
-      throw new Error('Programmer error: Compare only supports weapons and armor');
-    }
+      : item.element
+      ? `(name:"${item.name}" is:${getItemDamageShortName(item)})`
+      : `name:"${item.name}"`;
 
     return {
       ...state,
@@ -195,14 +189,20 @@ function getItemCategoryHashesFromExampleItem(item: DimItem) {
   for (const node of itemSelectionTree.subCategories!) {
     if (item.itemCategoryHashes.includes(node.itemCategoryHash)) {
       hashes.push(node.itemCategoryHash);
-      for (const subNode of node.subCategories!) {
-        if (item.itemCategoryHashes.includes(subNode.itemCategoryHash)) {
-          hashes.push(subNode.itemCategoryHash);
-          break;
+      if (node.subCategories) {
+        for (const subNode of node.subCategories) {
+          if (item.itemCategoryHashes.includes(subNode.itemCategoryHash)) {
+            hashes.push(subNode.itemCategoryHash);
+            break;
+          }
         }
       }
       break;
     }
+  }
+
+  if (hashes.length === 0) {
+    hashes.push(item.itemCategoryHashes[0]);
   }
 
   return hashes;

--- a/src/app/compare/selectors.ts
+++ b/src/app/compare/selectors.ts
@@ -4,6 +4,7 @@ import { allItemsSelector } from 'app/inventory/selectors';
 import { filterFactorySelector } from 'app/search/search-filter';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import { createSelector } from 'reselect';
 
 /**
@@ -45,6 +46,12 @@ export const compareItemsSelector = createSelector(
   }
 );
 
+const organizerTypes = [
+  ItemCategoryHashes.Armor,
+  ItemCategoryHashes.Weapon,
+  ItemCategoryHashes.Ghost,
+];
+
 /**
  * Returns a link to the organizer for the current compare search.
  */
@@ -52,7 +59,7 @@ export const compareOrganizerLinkSelector = createSelector(
   currentAccountSelector,
   compareSessionSelector,
   (account, session) => {
-    if (!session || !account) {
+    if (!session || !account || organizerTypes.includes(session.itemCategoryHashes[0])) {
       return undefined;
     }
     return `/${account.membershipId}/d${

--- a/src/app/compare/selectors.ts
+++ b/src/app/compare/selectors.ts
@@ -59,7 +59,7 @@ export const compareOrganizerLinkSelector = createSelector(
   currentAccountSelector,
   compareSessionSelector,
   (account, session) => {
-    if (!session || !account || organizerTypes.includes(session.itemCategoryHashes[0])) {
+    if (!session || !account || !organizerTypes.includes(session.itemCategoryHashes[0])) {
       return undefined;
     }
     return `/${account.membershipId}/d${

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -376,7 +376,8 @@ export function makeItem(
     canPullFromPostmaster: !itemDef.doesPostmasterPullHaveSideEffects,
     id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
     equipped: Boolean(instanceDef?.isEquipped),
-    equipment: Boolean(itemDef.equippingBlock), // TODO: this has a ton of good info for the item move logic
+    equipment:
+      Boolean(itemDef.equippingBlock) && normalBucket.hash !== BucketHashes.SeasonalArtifact, // TODO: this has a ton of good info for the item move logic
     equippingLabel: itemDef.equippingBlock?.uniqueLabel,
     complete: false,
     amount: item.quantity || 1,
@@ -444,7 +445,11 @@ export function makeItem(
       // Shaders
       createdItem.bucket.hash === BucketHashes.Shaders_Equippable
   );
-  createdItem.comparable = Boolean(createdItem.equipment && createdItem.lockable);
+  createdItem.comparable = Boolean(
+    createdItem.equipment &&
+      createdItem.lockable &&
+      createdItem.bucket.hash !== BucketHashes.Emblems
+  );
 
   if (createdItem.primStat) {
     const statDef = defs.Stat.get(createdItem.primStat.statHash);

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -55,6 +55,9 @@
 
 .seasonal-expiration {
   color: rgb(218, 149, 45);
+  .app-icon {
+    margin-right: 4px;
+  }
 }
 
 .item-description {


### PR DESCRIPTION
A handful of related Compare fixes:

1. Comparing Ghosts and Ships works again. Didn't realize they were comparable...
2. You can't compare Emblems anymore, or Seasonal Artifacts.
3. Seasonal Artifacts are no longer considered equippable, no matter what the game thinks.