### PR TITLE
Remove the LockedMod and LockedMods types from optimiser.

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -40,7 +40,6 @@ import { useProcess } from './process/useProcess';
 import {
   generalSocketReusablePlugSetHash,
   ItemsByBucket,
-  PluggableItemsByPlugCategoryHash,
   statHashes,
   statHashToType,
   statKeys,
@@ -239,7 +238,7 @@ function LoadoutBuilder({
           return stat;
         })
       ),
-      mods: Object.values(lockedMods).flatMap((mods) => mods?.map((m) => m.modDef.hash) || []),
+      mods: lockedMods.map((mod) => mod.hash),
       query: searchQuery,
       assumeMasterworked: assumeMasterwork,
     }),
@@ -339,9 +338,9 @@ function LoadoutBuilder({
           ReactDOM.createPortal(
             <ModPicker
               classType={selectedStore.classType}
-              lockedMods={_.mapValues(lockedMods, (mods) => mods?.map((mod) => mod.modDef))}
+              lockedMods={lockedMods}
               initialQuery={modPicker.initialQuery}
-              onAccept={(newLockedMods: PluggableItemsByPlugCategoryHash) =>
+              onAccept={(newLockedMods: PluggableInventoryItemDefinition[]) =>
                 lbDispatch({
                   type: 'lockedModsChanged',
                   lockedMods: newLockedMods,

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -14,6 +14,7 @@ import React, { Dispatch } from 'react';
 import { connect } from 'react-redux';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import LoadoutBucketDropTarget from '../LoadoutBucketDropTarget';
+import { getModRenderKey } from '../mod-utils';
 import {
   LockableBuckets,
   LockedExclude,
@@ -172,15 +173,15 @@ function LockArmorAndPerks({
   const bucketTypes = buckets.byCategory.Armor.map((b) => b.type!);
 
   const anyLocked = Object.values(lockedMap).some((lockedItems) => Boolean(lockedItems?.length));
-
+  const modCounts = {};
   return (
     <div>
       <div className={styles.area}>
         {Boolean(lockedMods.length) && (
           <div className={styles.itemGrid}>
-            {lockedMods.map((mod, index) => (
+            {lockedMods.map((mod) => (
               <LockedModIcon
-                key={index}
+                key={getModRenderKey(mod, modCounts)}
                 mod={mod}
                 defs={defs}
                 onModClicked={() => onModClicked(mod)}

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -2,7 +2,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
-import { DimItem } from 'app/inventory/item-types';
+import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { showItemPicker } from 'app/item-picker/item-picker';
@@ -15,14 +15,11 @@ import { connect } from 'react-redux';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import LoadoutBucketDropTarget from '../LoadoutBucketDropTarget';
 import {
-  knownModPlugCategoryHashes,
   LockableBuckets,
   LockedExclude,
   LockedItemCase,
   LockedItemType,
   LockedMap,
-  LockedMod,
-  LockedMods,
   LockedPerk,
 } from '../types';
 import { addLockedItem, isLoadoutBuilderItem, removeLockedItem } from '../utils';
@@ -33,7 +30,7 @@ import LockedModIcon from './LockedModIcon';
 interface ProvidedProps {
   selectedStore: DimStore;
   lockedMap: LockedMap;
-  lockedMods: LockedMods;
+  lockedMods: PluggableInventoryItemDefinition[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }
 
@@ -141,9 +138,9 @@ function LockArmorAndPerks({
     }
   };
 
-  const onModClicked = (mod: LockedMod) => {
+  const onModClicked = (mod: PluggableInventoryItemDefinition) => {
     lbDispatch({
-      type: 'removeLockedArmor2Mod',
+      type: 'removeLockedMod',
       mod,
     });
   };
@@ -171,16 +168,6 @@ function LockArmorAndPerks({
     _.sortBy(items, (i: LockedItemCase) => order.indexOf(i.bucket.hash))
   );
 
-  let flatLockedMods: LockedMod[] = knownModPlugCategoryHashes.flatMap(
-    (plugCategoryHash) => lockedMods[plugCategoryHash] || []
-  );
-
-  for (const [plugCategoryHashAsString, mods] of Object.entries(lockedMods)) {
-    if (mods && !knownModPlugCategoryHashes.includes(Number(plugCategoryHashAsString))) {
-      flatLockedMods = flatLockedMods.concat(mods);
-    }
-  }
-
   const storeIds = stores.filter((s) => !s.isVault).map((s) => s.id);
   const bucketTypes = buckets.byCategory.Armor.map((b) => b.type!);
 
@@ -189,14 +176,14 @@ function LockArmorAndPerks({
   return (
     <div>
       <div className={styles.area}>
-        {Boolean(flatLockedMods.length) && (
+        {Boolean(lockedMods.length) && (
           <div className={styles.itemGrid}>
-            {flatLockedMods.map((item) => (
+            {lockedMods.map((mod, index) => (
               <LockedModIcon
-                key={item.key}
-                mod={item.modDef}
+                key={index}
+                mod={mod}
                 defs={defs}
-                onModClicked={() => onModClicked(item)}
+                onModClicked={() => onModClicked(mod)}
               />
             ))}
           </div>

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -239,15 +239,17 @@ function ModPicker({
   const autoFocus =
     !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
 
-  const footer = ({ onClose }) => (
-    <ModPickerFooter
-      defs={defs}
-      lockedModsInternal={lockedModsInternal}
-      isPhonePortrait={isPhonePortrait}
-      onSubmit={(e) => onSubmit(e, onClose)}
-      onModSelected={onModRemoved}
-    />
-  );
+  const footer = lockedMods.length
+    ? ({ onClose }) => (
+        <ModPickerFooter
+          defs={defs}
+          lockedModsInternal={lockedModsInternal}
+          isPhonePortrait={isPhonePortrait}
+          onSubmit={(e) => onSubmit(e, onClose)}
+          onModSelected={onModRemoved}
+        />
+      )
+    : undefined;
 
   return (
     <Sheet

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -239,7 +239,7 @@ function ModPicker({
   const autoFocus =
     !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
 
-  const footer = lockedMods.length
+  const footer = lockedModsInternal.length
     ? ({ onClose }) => (
         <ModPickerFooter
           defs={defs}

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -161,7 +161,7 @@ function ModPicker({
   onClose,
 }: Props) {
   const [query, setQuery] = useState(initialQuery || '');
-  const [lockedModsInternal, setLockedModsInternal] = useState([...lockedMods]);
+  const [lockedModsInternal, setLockedModsInternal] = useState(() => [...lockedMods]);
   const filterInput = useRef<SearchFilterRef | null>(null);
 
   useEffect(() => {

--- a/src/app/loadout-builder/filter/ModPickerFooter.tsx
+++ b/src/app/loadout-builder/filter/ModPickerFooter.tsx
@@ -8,11 +8,8 @@ import styles from './ModPickerFooter.m.scss';
 
 interface Props {
   defs: D2ManifestDefinitions;
-  groupOrder: number[];
   isPhonePortrait: boolean;
-  locked: {
-    [plugCategoryHash: number]: PluggableInventoryItemDefinition[] | undefined;
-  };
+  lockedModsInternal: PluggableInventoryItemDefinition[];
   onSubmit(event: React.FormEvent | KeyboardEvent): void;
   onModSelected(item: PluggableInventoryItemDefinition): void;
 }
@@ -20,8 +17,7 @@ interface Props {
 function ModPickerFooter({
   defs,
   isPhonePortrait,
-  groupOrder,
-  locked,
+  lockedModsInternal,
   onSubmit,
   onModSelected,
 }: Props) {
@@ -39,27 +35,20 @@ function ModPickerFooter({
         </button>
       </div>
       <div className={styles.selectedMods}>
-        {groupOrder.map(
-          (pch) =>
-            pch in locked && (
-              <React.Fragment key={pch}>
-                {locked[pch]?.map((mod) => {
-                  if (!modCounts[mod.hash]) {
-                    modCounts[mod.hash] = 0;
-                  }
+        {lockedModsInternal.map((mod) => {
+          if (!modCounts[mod.hash]) {
+            modCounts[mod.hash] = 0;
+          }
 
-                  return (
-                    <LockedModIcon
-                      key={`${mod.hash}-${++modCounts[mod.hash]}`}
-                      mod={mod}
-                      defs={defs}
-                      onModClicked={() => onModSelected(mod)}
-                    />
-                  );
-                })}
-              </React.Fragment>
-            )
-        )}
+          return (
+            <LockedModIcon
+              key={`${mod.hash}-${++modCounts[mod.hash]}`}
+              mod={mod}
+              defs={defs}
+              onModClicked={() => onModSelected(mod)}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/loadout-builder/filter/ModPickerFooter.tsx
+++ b/src/app/loadout-builder/filter/ModPickerFooter.tsx
@@ -3,6 +3,7 @@ import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import React from 'react';
+import { getModRenderKey } from '../mod-utils';
 import LockedModIcon from './LockedModIcon';
 import styles from './ModPickerFooter.m.scss';
 
@@ -35,20 +36,14 @@ function ModPickerFooter({
         </button>
       </div>
       <div className={styles.selectedMods}>
-        {lockedModsInternal.map((mod) => {
-          if (!modCounts[mod.hash]) {
-            modCounts[mod.hash] = 0;
-          }
-
-          return (
-            <LockedModIcon
-              key={`${mod.hash}-${++modCounts[mod.hash]}`}
-              mod={mod}
-              defs={defs}
-              onModClicked={() => onModSelected(mod)}
-            />
-          );
-        })}
+        {lockedModsInternal.map((mod) => (
+          <LockedModIcon
+            key={getModRenderKey(mod, modCounts)}
+            mod={mod}
+            defs={defs}
+            onModClicked={() => onModSelected(mod)}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -23,7 +23,7 @@ const MAX_SLOT_INDEPENDENT_MODS = 5;
 export default function PickerSectionMods({
   defs,
   mods,
-  lockedMods,
+  lockedModsInternal,
   onModSelected,
   onModRemoved,
 }: {
@@ -31,7 +31,7 @@ export default function PickerSectionMods({
   /** A array of mods where plug.plugCategoryHash's are equal. */
   mods: readonly PluggableInventoryItemDefinition[];
   /** The current set of selected mods. Needed to figure out selection limits for some plugCategoryHashes. */
-  lockedMods: PluggableInventoryItemDefinition[];
+  lockedModsInternal: PluggableInventoryItemDefinition[];
   onModSelected(mod: PluggableInventoryItemDefinition);
   onModRemoved(mod: PluggableInventoryItemDefinition);
 }) {
@@ -47,15 +47,15 @@ export default function PickerSectionMods({
   let associatedLockedMods: PluggableInventoryItemDefinition[] = [];
 
   if (isSlotSpecificCategory || plugCategoryHash === armor2PlugCategoryHashesByName.general) {
-    associatedLockedMods = lockedMods.filter(
+    associatedLockedMods = lockedModsInternal.filter(
       (mod) => mod.plug.plugCategoryHash === plugCategoryHash
     );
   } else if (raidPlugCategoryHashes.includes(plugCategoryHash)) {
-    associatedLockedMods = lockedMods.filter((mod) =>
+    associatedLockedMods = lockedModsInternal.filter((mod) =>
       raidPlugCategoryHashes.includes(mod.plug.plugCategoryHash)
     );
   } else {
-    associatedLockedMods = lockedMods.filter(
+    associatedLockedMods = lockedModsInternal.filter(
       (mod) => !knownModPlugCategoryHashes.includes(mod.plug.plugCategoryHash)
     );
   }

--- a/src/app/loadout-builder/filter/PickerSectionMods.tsx
+++ b/src/app/loadout-builder/filter/PickerSectionMods.tsx
@@ -9,7 +9,6 @@ import _ from 'lodash';
 import React from 'react';
 import {
   knownModPlugCategoryHashes,
-  PluggableItemsByPlugCategoryHash,
   raidPlugCategoryHashes,
   slotSpecificPlugCategoryHashes,
 } from '../types';
@@ -24,7 +23,7 @@ const MAX_SLOT_INDEPENDENT_MODS = 5;
 export default function PickerSectionMods({
   defs,
   mods,
-  locked,
+  lockedMods,
   onModSelected,
   onModRemoved,
 }: {
@@ -32,7 +31,7 @@ export default function PickerSectionMods({
   /** A array of mods where plug.plugCategoryHash's are equal. */
   mods: readonly PluggableInventoryItemDefinition[];
   /** The current set of selected mods. Needed to figure out selection limits for some plugCategoryHashes. */
-  locked: PluggableItemsByPlugCategoryHash;
+  lockedMods: PluggableInventoryItemDefinition[];
   onModSelected(mod: PluggableInventoryItemDefinition);
   onModRemoved(mod: PluggableInventoryItemDefinition);
 }) {
@@ -48,17 +47,16 @@ export default function PickerSectionMods({
   let associatedLockedMods: PluggableInventoryItemDefinition[] = [];
 
   if (isSlotSpecificCategory || plugCategoryHash === armor2PlugCategoryHashesByName.general) {
-    associatedLockedMods = locked[plugCategoryHash] || [];
+    associatedLockedMods = lockedMods.filter(
+      (mod) => mod.plug.plugCategoryHash === plugCategoryHash
+    );
   } else if (raidPlugCategoryHashes.includes(plugCategoryHash)) {
-    associatedLockedMods = raidPlugCategoryHashes.flatMap((hash) => locked[hash] || []);
+    associatedLockedMods = lockedMods.filter((mod) =>
+      raidPlugCategoryHashes.includes(mod.plug.plugCategoryHash)
+    );
   } else {
-    associatedLockedMods = Object.entries(
-      locked
-    ).flatMap(([lockedPlugCategoryHash, lockedModsByPlugCatHash]) =>
-      lockedModsByPlugCatHash &&
-      !knownModPlugCategoryHashes.includes(Number(lockedPlugCategoryHash))
-        ? lockedModsByPlugCatHash
-        : []
+    associatedLockedMods = lockedMods.filter(
+      (mod) => !knownModPlugCategoryHashes.includes(mod.plug.plugCategoryHash)
     );
   }
 

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -2,7 +2,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import Sheet from 'app/dim-ui/Sheet';
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
-import { DimItem } from 'app/inventory/item-types';
+import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { allItemsSelector, currentStoreSelector } from 'app/inventory/selectors';
 import { updateLoadout } from 'app/loadout/actions';
 import { Loadout, LoadoutItem } from 'app/loadout/loadout-types';
@@ -16,14 +16,7 @@ import { connect } from 'react-redux';
 import { getItemsFromLoadoutItems } from '../../loadout/loadout-utils';
 import { assignModsToArmorSet } from '../mod-utils';
 import { getTotalModStatChanges } from '../process/mappers';
-import {
-  ArmorSet,
-  LockableBucketHashes,
-  LockedMods,
-  statHashes,
-  statKeys,
-  StatTypes,
-} from '../types';
+import { ArmorSet, LockableBucketHashes, statHashes, statKeys, StatTypes } from '../types';
 import { getPower } from '../utils';
 import styles from './CompareDrawer.m.scss';
 import Mod from './Mod';
@@ -48,7 +41,7 @@ function getItemStats(item: DimItem, assumeMasterwork: boolean | null) {
 interface ProvidedProps {
   set: ArmorSet;
   loadouts: Loadout[];
-  lockedMods: LockedMods;
+  lockedMods: PluggableInventoryItemDefinition[];
   defs: D2ManifestDefinitions;
   classType: DestinyClass;
   statOrder: StatTypes[];
@@ -258,8 +251,8 @@ function CompareDrawer({
                 </div>
               )}
               <div className={styles.unassignedMods}>
-                {loadoutUnassignedMods.map((unassigned) => (
-                  <Mod key={unassigned.key} plugDef={unassigned.modDef} defs={defs} large={true} />
+                {loadoutUnassignedMods.map((unassigned, index) => (
+                  <Mod key={index} plugDef={unassigned} defs={defs} large={true} />
                 ))}
               </div>
             </>

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -14,7 +14,7 @@ import _ from 'lodash';
 import React, { useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { getItemsFromLoadoutItems } from '../../loadout/loadout-utils';
-import { assignModsToArmorSet } from '../mod-utils';
+import { assignModsToArmorSet, getModRenderKey } from '../mod-utils';
 import { getTotalModStatChanges } from '../process/mappers';
 import { ArmorSet, LockableBucketHashes, statHashes, statKeys, StatTypes } from '../types';
 import { getPower } from '../utils';
@@ -174,6 +174,8 @@ function CompareDrawer({
     );
   }
 
+  const modCounts = {};
+
   return (
     <Sheet onClose={onClose} header={header}>
       <div className={styles.content}>
@@ -251,8 +253,13 @@ function CompareDrawer({
                 </div>
               )}
               <div className={styles.unassignedMods}>
-                {loadoutUnassignedMods.map((unassigned, index) => (
-                  <Mod key={index} plugDef={unassigned} defs={defs} large={true} />
+                {loadoutUnassignedMods.map((unassigned) => (
+                  <Mod
+                    key={getModRenderKey(unassigned, modCounts)}
+                    plugDef={unassigned}
+                    defs={defs}
+                    large={true}
+                  />
                 ))}
               </div>
             </>

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -8,7 +8,7 @@ import React, { Dispatch } from 'react';
 import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { assignModsToArmorSet } from '../mod-utils';
-import { ArmorSet, LockedMap, LockedMods, StatTypes } from '../types';
+import { ArmorSet, LockedMap, StatTypes } from '../types';
 import { getPower } from '../utils';
 import styles from './GeneratedSet.m.scss';
 import GeneratedSetButtons from './GeneratedSetButtons';
@@ -24,7 +24,7 @@ interface Props {
   defs: D2ManifestDefinitions;
   forwardedRef?: React.Ref<HTMLDivElement>;
   enabledStats: Set<StatTypes>;
-  lockedMods: LockedMods;
+  lockedMods: PluggableInventoryItemDefinition[];
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
   params: LoadoutParameters;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -9,7 +9,7 @@ import { DimItem, PluggableInventoryItemDefinition } from '../../inventory/item-
 import { matchLockedItem } from '../item-filter';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import LoadoutBuilderItem from '../LoadoutBuilderItem';
-import { LockedItemType, LockedMod } from '../types';
+import { LockedItemType } from '../types';
 import styles from './GeneratedSetItem.m.scss';
 import Sockets from './Sockets';
 
@@ -29,7 +29,7 @@ export default function GeneratedSetItem({
   locked?: readonly LockedItemType[];
   defs: D2ManifestDefinitions;
   itemOptions: DimItem[];
-  lockedMods: LockedMod[];
+  lockedMods: PluggableInventoryItemDefinition[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
   const addLockedItem = (item: LockedItemType) => lbDispatch({ type: 'addItemToLockedMap', item });

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -16,7 +16,7 @@ import { List, WindowScroller } from 'react-virtualized';
 import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { someModHasEnergyRequirement } from '../mod-utils';
-import { ArmorSet, LockedMap, LockedMods, StatTypes } from '../types';
+import { ArmorSet, LockedMap, StatTypes } from '../types';
 import GeneratedSet from './GeneratedSet';
 import styles from './GeneratedSets.m.scss';
 
@@ -80,7 +80,7 @@ interface Props {
   statOrder: StatTypes[];
   defs: D2ManifestDefinitions;
   enabledStats: Set<StatTypes>;
-  lockedMods: LockedMods;
+  lockedMods: PluggableInventoryItemDefinition[];
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
   params: LoadoutParameters;
@@ -156,10 +156,16 @@ export default function GeneratedSets({
 
   let groupingDescription;
 
-  const generalMods = lockedMods[armor2PlugCategoryHashesByName.general] || [];
-  const raidCombatAndLegacyMods = Object.entries(lockedMods).flatMap(([plugCategoryHash, mods]) =>
-    !armor2PlugCategoryHashes.includes(Number(plugCategoryHash)) && mods ? mods : []
-  );
+  const generalMods: PluggableInventoryItemDefinition[] = [];
+  const raidCombatAndLegacyMods: PluggableInventoryItemDefinition[] = [];
+
+  for (const mod of lockedMods) {
+    if (mod.plug.plugCategoryHash === armor2PlugCategoryHashesByName.general) {
+      generalMods.push(mod);
+    } else if (!armor2PlugCategoryHashes.includes(mod.plug.plugCategoryHash)) {
+      raidCombatAndLegacyMods.push(mod);
+    }
+  }
 
   if (someModHasEnergyRequirement(raidCombatAndLegacyMods)) {
     groupingDescription = t('LoadoutBuilder.ItemsGroupedByStatsEnergyModSlot');

--- a/src/app/loadout-builder/generated-sets/Sockets.tsx
+++ b/src/app/loadout-builder/generated-sets/Sockets.tsx
@@ -4,7 +4,6 @@ import { isPluggableItem } from 'app/inventory/store/sockets';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
-import { LockedMod } from '../types';
 import Mod from './Mod';
 import styles from './Sockets.m.scss';
 
@@ -19,7 +18,7 @@ const undesireablePlugs = [
 
 interface Props {
   item: DimItem;
-  lockedMods?: LockedMod[];
+  lockedMods?: PluggableInventoryItemDefinition[];
   defs: D2ManifestDefinitions;
   onSocketClick?(plugDef: PluggableInventoryItemDefinition, whitelist: number[]): void;
 }
@@ -37,7 +36,7 @@ function Sockets({ item, lockedMods, defs, onSocketClick }: Props) {
     let toSave: DestinyInventoryItemDefinition | undefined;
 
     for (let modIndex = 0; modIndex < modsToUse.length; modIndex++) {
-      const mod = modsToUse[modIndex].modDef;
+      const mod = modsToUse[modIndex];
       if (
         socketType.plugWhitelist.some((plug) => plug.categoryHash === mod.plug.plugCategoryHash)
       ) {

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -177,10 +177,9 @@ function lbStateReducer(
       };
     }
     case 'removeLockedMod': {
-      const indexToRemove = state.lockedMods.findIndex(
-        (mod) => mod.plug.plugCategoryHash === action.mod.plug.plugCategoryHash
-      );
-      const newMods = [...state.lockedMods].splice(indexToRemove, 1);
+      const indexToRemove = state.lockedMods.findIndex((mod) => mod.hash === action.mod.hash);
+      const newMods = [...state.lockedMods];
+      newMods.splice(indexToRemove, 1);
 
       return {
         ...state,

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -140,8 +140,20 @@ export function someModHasEnergyRequirement(mods: PluggableInventoryItemDefiniti
   );
 }
 
-/** Sorts PluggableInventoryItemDefinition's by energyType else energyCost else name. */
+/**
+ * Sorts PluggableInventoryItemDefinition's by the following list of comparators.
+ * 1. The known plug category hashes, see ./types#knownModPlugCategoryHashes for ordering
+ * 2. itemTypeDisplayName, so that legacy and combat mods are ordered alphabetically by their category name
+ * 3. energyType, so mods in each category go Any, Arc, Solar, Void
+ * 4. by energy cost, so cheaper mods come before more expensive mods
+ * 5. by mod name, so mods in the same category with the same energy type and cost are alphabetical
+ */
 export const sortMods = chainComparator<PluggableInventoryItemDefinition>(
+  compareBy((mod) => {
+    const knownIndex = knownModPlugCategoryHashes.indexOf(mod.plug.plugCategoryHash);
+    return knownIndex === -1 ? knownModPlugCategoryHashes.length : knownIndex;
+  }),
+  compareBy((mod) => mod.itemTypeDisplayName),
   compareBy((mod) => mod.plug.energyCost?.energyType),
   compareBy((mod) => mod.plug.energyCost?.energyCost),
   compareBy((mod) => mod.displayProperties.name)

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -13,8 +13,6 @@ import {
   bucketsToCategories,
   knownModPlugCategoryHashes,
   LockableBucketHashes,
-  LockedMod,
-  LockedMods,
   raidPlugCategoryHashes,
 } from './types';
 
@@ -23,11 +21,11 @@ import {
  *   1. The armour piece is Armour 2.0
  *   2. The mod matches the Armour energy OR the mod has the any Energy type
  */
-export const doEnergiesMatch = (mod: LockedMod, item: DimItem) =>
+export const doEnergiesMatch = (mod: PluggableInventoryItemDefinition, item: DimItem) =>
   item.energy &&
-  (!mod.modDef.plug.energyCost ||
-    mod.modDef.plug.energyCost.energyType === DestinyEnergyType.Any ||
-    mod.modDef.plug.energyCost.energyType === item.energy?.energyType);
+  (!mod.plug.energyCost ||
+    mod.plug.energyCost.energyType === DestinyEnergyType.Any ||
+    mod.plug.energyCost.energyType === item.energy?.energyType);
 
 /**
  * If the energies match, this will assign the mods to the item in assignments.
@@ -37,10 +35,10 @@ export const doEnergiesMatch = (mod: LockedMod, item: DimItem) =>
 function assignModsForSlot(
   item: DimItem,
   assignments: Record<string, number[]>,
-  mods?: LockedMod[]
+  mods?: PluggableInventoryItemDefinition[]
 ): void {
   if (mods?.length && mods.every((mod) => doEnergiesMatch(mod, item))) {
-    assignments[item.id] = [...assignments[item.id], ...mods.map((mod) => mod.modDef.hash)];
+    assignments[item.id] = [...assignments[item.id], ...mods.map((mod) => mod.hash)];
   }
 }
 
@@ -51,24 +49,21 @@ function assignModsForSlot(
  */
 function assignSlotIndependantMods(
   setToMatch: ProcessItem[],
-  lockedMods: LockedMods,
+  lockedMods: PluggableInventoryItemDefinition[],
   assignments: Record<string, number[]>
 ): void {
-  let generalMods: LockedMod[] = [];
-  let otherMods: LockedMod[] = [];
-  let raidMods: LockedMod[] = [];
+  const generalMods: PluggableInventoryItemDefinition[] = [];
+  const otherMods: PluggableInventoryItemDefinition[] = [];
+  const raidMods: PluggableInventoryItemDefinition[] = [];
 
-  for (const [plugCategoryHashString, mods] of Object.entries(lockedMods)) {
-    const plugCategoryHash = Number(plugCategoryHashString);
-
-    if (!mods) {
-      continue;
-    } else if (plugCategoryHash === armor2PlugCategoryHashesByName.general) {
-      generalMods = mods;
+  for (const mod of lockedMods) {
+    const { plugCategoryHash } = mod.plug;
+    if (plugCategoryHash === armor2PlugCategoryHashesByName.general) {
+      generalMods.push(mod);
     } else if (raidPlugCategoryHashes.includes(plugCategoryHash)) {
-      raidMods = raidMods.concat(mods);
+      raidMods.push(mod);
     } else if (!knownModPlugCategoryHashes.includes(plugCategoryHash)) {
-      otherMods = otherMods.concat(mods);
+      otherMods.push(mod);
     }
   }
 
@@ -96,8 +91,8 @@ function assignSlotIndependantMods(
 
 export function assignModsToArmorSet(
   setToMatch: readonly DimItem[],
-  lockedMods: LockedMods
-): [Record<string, LockedMod[]>, LockedMod[]] {
+  lockedMods: PluggableInventoryItemDefinition[]
+): [Record<string, PluggableInventoryItemDefinition[]>, PluggableInventoryItemDefinition[]] {
   const assignments: Record<string, number[]> = {};
 
   for (const item of setToMatch) {
@@ -105,12 +100,13 @@ export function assignModsToArmorSet(
   }
 
   const processItems: ProcessItem[] = [];
+  const lockedModMap = _.groupBy(lockedMods, (mod) => mod.plug.plugCategoryHash);
 
   for (const hash of LockableBucketHashes) {
     const item = setToMatch.find((i) => i.bucket.hash === hash);
 
     if (item) {
-      const lockedModsByPlugCategoryHash = lockedMods[bucketsToCategories[hash]];
+      const lockedModsByPlugCategoryHash = lockedModMap[bucketsToCategories[hash]];
       assignModsForSlot(item, assignments, lockedModsByPlugCategoryHash);
       processItems.push(mapDimItemToProcessItem(item, lockedModsByPlugCategoryHash));
     }
@@ -118,21 +114,18 @@ export function assignModsToArmorSet(
 
   assignSlotIndependantMods(processItems, lockedMods, assignments);
 
-  const modsByHash = _.groupBy(
-    Object.values(lockedMods)
-      .flat()
-      .filter((x: LockedMod | undefined): x is LockedMod => Boolean(x)),
-    (mod) => mod.modDef.hash
-  );
+  const modsByHash = _.groupBy(lockedMods, (mod) => mod.hash);
+
+  // In this we map modHashes to their mod using modsByHash. Note that we pop the mod from the
+  // array in modByHash, this will leave us with any unassigned mods left in modsByHash
   const assignedMods = _.mapValues(assignments, (modHashes) =>
-    modHashes.map((modHash) => modsByHash[modHash].pop()).filter((x): x is LockedMod => Boolean(x))
+    modHashes
+      .map((modHash) => modsByHash[modHash].pop())
+      // This shouldn't happen but lets throw in a filter for saftey and type happyness
+      .filter((x): x is PluggableInventoryItemDefinition => Boolean(x))
   );
-  const assigned = Object.values(assignedMods).flat();
-  const unassignedMods = Object.values(lockedMods)
-    .flat()
-    .filter((unassign): unassign is LockedMod =>
-      Boolean(unassign && !assigned.some((assign) => assign.key === unassign.key))
-    );
+
+  const unassignedMods = Object.values(modsByHash).flat();
 
   return [assignedMods, unassignedMods];
 }
@@ -141,10 +134,9 @@ export function assignModsToArmorSet(
  * Checks to see if some mod in a collection of LockedMod or LockedMod,
  * has an elemental (non-Any) energy requirement
  */
-export function someModHasEnergyRequirement(mods: LockedMod[]) {
+export function someModHasEnergyRequirement(mods: PluggableInventoryItemDefinition[]) {
   return mods.some(
-    (mod) =>
-      !mod.modDef.plug.energyCost || mod.modDef.plug.energyCost.energyType !== DestinyEnergyType.Any
+    (mod) => !mod.plug.energyCost || mod.plug.energyCost.energyType !== DestinyEnergyType.Any
   );
 }
 

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -173,3 +173,21 @@ export const sortModGroups = chainComparator(
   }),
   compareBy((mods: PluggableInventoryItemDefinition[]) => mods[0].itemTypeDisplayName)
 );
+
+/**
+ * Generates a unique key for a mod when rendering. As mods can appear multiple times as
+ * siblings we need to count them and append a number to its hash to make it unique.
+ *
+ * Note that counts is mutated and a new object should be passed in with each render.
+ */
+export const getModRenderKey = (
+  mod: PluggableInventoryItemDefinition,
+  /** A supplied object to store the counts in. This is mutated. */
+  counts: Record<number, number>
+) => {
+  if (!counts[mod.hash]) {
+    counts[mod.hash] = 0;
+  }
+
+  return `${mod.hash}-${counts[mod.hash]++}`;
+};

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -53,17 +53,6 @@ export type LockedMap = Readonly<{
   [bucketHash: number]: readonly LockedItemType[] | undefined;
 }>;
 
-export interface LockedMod {
-  /** Essentially an identifier for each mod, as a single mod definition can be selected multiple times.*/
-  key: number;
-  modDef: PluggableInventoryItemDefinition;
-}
-
-/** An object of plugCategoryHashes to arrays of locked mods with said plugCategoryHash. */
-export type LockedMods = {
-  [plugCategoryHash: number]: LockedMod[] | undefined;
-};
-
 /**
  * An individual "stat mix" of loadouts where each slot has a list of items with the same stat options.
  */

--- a/src/app/loadout/LoadoutDrawer.tsx
+++ b/src/app/loadout/LoadoutDrawer.tsx
@@ -1,7 +1,6 @@
 import { destinyVersionSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import ModPicker from 'app/loadout-builder/filter/ModPicker';
-import { PluggableItemsByPlugCategoryHash } from 'app/loadout-builder/types';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { useEventBusListener } from 'app/utils/hooks';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
@@ -21,7 +20,7 @@ import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import Sheet from '../dim-ui/Sheet';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import InventoryItem from '../inventory/InventoryItem';
-import { DimItem } from '../inventory/item-types';
+import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import { allItemsSelector, bucketsSelector, storesSelector } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
 import { showItemPicker } from '../item-picker/item-picker';
@@ -510,19 +509,12 @@ function LoadoutDrawer({
   const savedMods = getModsFromLoadout(defs, loadout);
 
   /** Updates the loadout replacing it's current mods with all the mods in newMods. */
-  const onUpdateMods = (newMods: PluggableItemsByPlugCategoryHash) => {
+  const onUpdateMods = (newMods: PluggableInventoryItemDefinition[]) => {
     const newLoadout = { ...loadout };
-    const mods: number[] = [];
-
-    for (const mod of Object.values(newMods).flat()) {
-      if (mod) {
-        mods.push(mod.hash);
-      }
-    }
 
     newLoadout.parameters = {
       ...newLoadout.parameters,
-      mods,
+      mods: newMods.map((mod) => mod.hash),
     };
     stateDispatch({ type: 'update', loadout: newLoadout });
   };

--- a/src/app/loadout/LoadoutDrawerContents.tsx
+++ b/src/app/loadout/LoadoutDrawerContents.tsx
@@ -2,14 +2,13 @@ import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
-import { PluggableItemsByPlugCategoryHash } from 'app/loadout-builder/types';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { infoLog } from 'app/utils/log';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
 import { InventoryBucket, InventoryBuckets } from '../inventory/inventory-buckets';
-import { DimItem } from '../inventory/item-types';
+import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import { DimStore } from '../inventory/store-types';
 import { showItemPicker } from '../item-picker/item-picker';
 import { addIcon, AppIcon } from '../shell/icons';
@@ -81,7 +80,7 @@ export default function LoadoutDrawerContents(
     removeModByHash,
   }: {
     loadout: Loadout;
-    savedMods: PluggableItemsByPlugCategoryHash;
+    savedMods: PluggableInventoryItemDefinition[];
     buckets: InventoryBuckets;
     defs: D1ManifestDefinitions | D2ManifestDefinitions;
     stores: DimStore[];

--- a/src/app/loadout/SavedMods.tsx
+++ b/src/app/loadout/SavedMods.tsx
@@ -1,17 +1,18 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
+import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { sortModGroups } from 'app/loadout-builder/mod-utils';
-import { PluggableItemsByPlugCategoryHash } from 'app/loadout-builder/types';
 import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
+import _ from 'lodash';
 import React, { useMemo } from 'react';
 import SavedModCategory from './SavedModCategory';
 import styles from './SavedMods.m.scss';
 
 interface Props {
   defs: D1ManifestDefinitions | D2ManifestDefinitions;
-  /** The loadouts saved mods in an object to mod arrays indexed by plugCategoryHash. */
-  savedMods: PluggableItemsByPlugCategoryHash;
+  /** The loadouts saved mods hydrated. */
+  savedMods: PluggableInventoryItemDefinition[];
   /** Opens the mod picker sheet with a supplied query to filter the mods. */
   onOpenModPicker(query?: string): void;
   /** Removes a mod from the loadout via the mods item hash. */
@@ -28,7 +29,9 @@ function SavedMods({ defs, savedMods, onOpenModPicker, removeModByHash }: Props)
       return [];
     }
 
-    return Object.values(savedMods).sort(sortModGroups);
+    const indexedMods = _.groupBy(savedMods, (mod) => mod.plug.plugCategoryHash);
+
+    return Object.values(indexedMods).sort(sortModGroups);
   }, [savedMods, defs]);
 
   if (!defs.isDestiny2() || !Object.keys(savedMods).length) {

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -4,7 +4,6 @@ import { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { DimCharacterStat, DimStore } from 'app/inventory/store-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { sortMods } from 'app/loadout-builder/mod-utils';
-import { PluggableItemsByPlugCategoryHash } from 'app/loadout-builder/types';
 import { armorStats } from 'app/search/d2-known-values';
 import { emptyArray } from 'app/utils/empty';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
@@ -251,7 +250,7 @@ export function loadoutFromEquipped(store: DimStore): Loadout {
 export function getModsFromLoadout(
   defs: D1ManifestDefinitions | D2ManifestDefinitions,
   loadout: Loadout
-): PluggableItemsByPlugCategoryHash {
+) {
   const mods: PluggableInventoryItemDefinition[] = [];
 
   if (defs.isDestiny2() && loadout.parameters?.mods) {
@@ -263,7 +262,5 @@ export function getModsFromLoadout(
     }
   }
 
-  const sortedMods = mods.sort(sortMods);
-
-  return _.groupBy(sortedMods, (mod) => mod.plug.plugCategoryHash);
+  return mods.sort(sortMods);
 }


### PR DESCRIPTION
The majority of this is just removing the types and fixing the code as needed. 

The mod state in the optimiser is now an array of PluggableInventoryItemDefs rather than the map of plug category hashes to arrays.