### PR TITLE
add stat averaging to stat/basestat filter

### DIFF
--- a/src/app/search/search-filters/range-numeric.tsx
+++ b/src/app/search/search-filters/range-numeric.tsx
@@ -3,7 +3,7 @@ import { getItemKillTrackerInfo, getItemYear } from 'app/utils/item-utils';
 import { FilterDefinition } from '../filter-types';
 import { generateSuggestionsForFilter } from '../suggestions-generation';
 
-const rangeStringRegex = /^([<=>]{0,2})(\d+)$/;
+const rangeStringRegex = /^([<=>]{0,2})(\d+(?:\.\d+)?)$/;
 
 export function rangeStringToComparator(rangeString?: string) {
   if (!rangeString) {


### PR DESCRIPTION
pull request #6666 baby

enables a syntax like
```
basestat:intellect&mobility:>=15
```


arguably this serves the same purpose as the addition operator,
but doesn't require an awareness of how many stats you're combining.

if 15 or 20 is "an impressive number to see in a single stat",
average can more clearly express "i want my combined mobility and intellect stats to be impressive"
without needing to say "and that's 2 stats, so 30. or 40"

also i just wanted to lay the thinking groundwork for the conversion of Custom Stat to an average or weighted average, instead of a total
for the same above reason and for purposes of cross-class consistency and comparability