### PR TITLE
Bug: No mods when loadout class not selected.

### DIFF
--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -76,7 +76,7 @@ function mapStateToProps() {
       classType?: DestinyClass
     ): PluggableInventoryItemDefinition[] => {
       const plugSets: { [bucketHash: number]: Set<number> } = {};
-      if (!profileResponse || classType === undefined) {
+      if (!profileResponse) {
         return [];
       }
 
@@ -85,8 +85,11 @@ function mapStateToProps() {
         if (
           !item ||
           !item.sockets ||
+          // Makes sure its an armour 2.0 item
           !isLoadoutBuilderItem(item) ||
-          !(item.classType === DestinyClass.Unknown || item.classType === classType)
+          // If classType is passed in only use items from said class otherwise use
+          // items from all characters. Usefull if in loadouts and only mods and guns.
+          !(classType === DestinyClass.Unknown || item.classType === classType)
         ) {
           continue;
         }

--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -76,7 +76,7 @@ function mapStateToProps() {
       classType?: DestinyClass
     ): PluggableInventoryItemDefinition[] => {
       const plugSets: { [bucketHash: number]: Set<number> } = {};
-      if (!profileResponse) {
+      if (!profileResponse || classType === undefined) {
         return [];
       }
 


### PR DESCRIPTION
Ensure mods are shown when no loadout class is selected. This will only really be utilised in the loadout drawer as the optimiser always has a chosen class.

Fixes #6674 