### PR TITLE
Loadouts: Mods when creating from existing.

### DIFF
--- a/src/app/loadout-builder/filter/ModPicker.tsx
+++ b/src/app/loadout-builder/filter/ModPicker.tsx
@@ -8,14 +8,12 @@ import {
   bucketsSelector,
   profileResponseSelector,
 } from 'app/inventory/selectors';
-import { isPluggableItem } from 'app/inventory/store/sockets';
 import { plugIsInsertable } from 'app/item-popup/SocketDetails';
 import { itemsForPlugSet } from 'app/records/plugset-helpers';
 import { escapeRegExp } from 'app/search/search-filters/freeform';
 import { SearchFilterRef } from 'app/search/SearchBar';
 import { AppIcon, searchIcon } from 'app/shell/icons';
 import { RootState } from 'app/store/types';
-import { isArmor2Mod } from 'app/utils/item-utils';
 import { DestinyClass, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -23,7 +21,7 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import Sheet from '../../dim-ui/Sheet';
 import '../../item-picker/ItemPicker.scss';
-import { sortModGroups, sortMods } from '../mod-utils';
+import { isInsertableArmor2Mod, sortModGroups, sortMods } from '../mod-utils';
 import { isLoadoutBuilderItem } from '../utils';
 import ModPickerFooter from './ModPickerFooter';
 import PickerSectionMods from './PickerSectionMods';
@@ -122,15 +120,7 @@ function mapStateToProps() {
         for (const plug of unlockedPlugs) {
           const def = defs.InventoryItem.get(plug);
 
-          if (
-            isPluggableItem(def) &&
-            isArmor2Mod(def) &&
-            // Filters out mods that are deprecated.
-            (def.plug.insertionMaterialRequirementHash !== 0 || def.plug.energyCost?.energyCost) &&
-            // This string can be empty so let those cases through in the event a mod hasn't been given a itemTypeDisplayName.
-            // My investigation showed that only classified items had this being undefined.
-            def.itemTypeDisplayName !== undefined
-          ) {
+          if (isInsertableArmor2Mod(def)) {
             finalMods.push(def);
           }
         }

--- a/src/app/loadout-builder/mod-utils.ts
+++ b/src/app/loadout-builder/mod-utils.ts
@@ -1,6 +1,8 @@
+import { isPluggableItem } from 'app/inventory/store/sockets';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { chainComparator, compareBy } from 'app/utils/comparators';
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
+import { isArmor2Mod } from 'app/utils/item-utils';
+import { DestinyEnergyType, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import {
@@ -191,3 +193,20 @@ export const getModRenderKey = (
 
   return `${mod.hash}-${counts[mod.hash]++}`;
 };
+
+/** Figures out if a definition is an insertable armor 2.0 mod. To do so it does the following
+ * 1. Figures out if the def is pluggable (def.plug exists)
+ * 2. Checks to see if the plugCategoryHash is in one of our known plugCategoryHashes (relies on d2ai).
+ * 3. Checks to see if plug.insertionMaterialRequirementHash is non zero or plug.energyCost a thing. This rules out deprecated mods.
+ * 4. Makes sure that itemTypeDisplayName is a thing, this rules out classified items.
+ */
+export function isInsertableArmor2Mod(
+  def: DestinyInventoryItemDefinition
+): def is PluggableInventoryItemDefinition {
+  return Boolean(
+    isPluggableItem(def) &&
+      isArmor2Mod(def) &&
+      (def.plug.insertionMaterialRequirementHash !== 0 || def.plug.energyCost) &&
+      def.itemTypeDisplayName !== undefined
+  );
+}

--- a/src/app/loadout/LoadoutPopup.tsx
+++ b/src/app/loadout/LoadoutPopup.tsx
@@ -40,7 +40,7 @@ import {
 import { applyLoadout } from './loadout-apply';
 import './loadout-popup.scss';
 import { Loadout } from './loadout-types';
-import { convertToLoadoutItem, newLoadout } from './loadout-utils';
+import { convertToLoadoutItem, extractArmorModHashes, newLoadout } from './loadout-utils';
 import { fromEquippedTypes } from './LoadoutDrawerContents';
 import {
   makeRoomForPostmaster,
@@ -143,7 +143,8 @@ function LoadoutPopup({
     );
     const loadout = newLoadout(
       '',
-      items.map((i) => convertToLoadoutItem(i, true))
+      items.map((i) => convertToLoadoutItem(i, true)),
+      items.flatMap((i) => extractArmorModHashes(i))
     );
     loadout.classType = classTypeId;
     editLoadout(loadout, { isNew: true });

--- a/src/app/loadout/loadout-utils.ts
+++ b/src/app/loadout/loadout-utils.ts
@@ -3,7 +3,8 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { DimCharacterStat, DimStore } from 'app/inventory/store-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import { sortMods } from 'app/loadout-builder/mod-utils';
+import { isInsertableArmor2Mod, sortMods } from 'app/loadout-builder/mod-utils';
+import { isLoadoutBuilderItem } from 'app/loadout-builder/utils';
 import { armorStats } from 'app/search/d2-known-values';
 import { emptyArray } from 'app/utils/empty';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
@@ -22,9 +23,9 @@ const gearSlotOrder = [
 ];
 
 /**
- * Creates a new loadout, with all of the items equipped.
+ * Creates a new loadout, with all of the items equipped and the items inserted mods saved.
  */
-export function newLoadout(name: string, items: LoadoutItem[]): Loadout {
+export function newLoadout(name: string, items: LoadoutItem[], modsHashes?: number[]): Loadout {
   return {
     id: uuidv4(),
     classType: DestinyClass.Unknown,
@@ -32,6 +33,9 @@ export function newLoadout(name: string, items: LoadoutItem[]): Loadout {
     destinyVersion: 2,
     name,
     items,
+    parameters: {
+      mods: modsHashes?.length ? modsHashes : undefined,
+    },
   };
 }
 
@@ -183,6 +187,21 @@ export function convertToLoadoutItem(item: LoadoutItem, equipped: boolean) {
     amount: item.amount,
     equipped,
   };
+}
+
+/** Extracts the equipped armour 2.0 mod hashes from the item */
+export function extractArmorModHashes(item: DimItem) {
+  if (!isLoadoutBuilderItem(item) || !item.sockets) {
+    return [];
+  }
+  return _.compact(
+    item.sockets.allSockets.map(
+      (socket) =>
+        socket.plugged &&
+        isInsertableArmor2Mod(socket.plugged.plugDef) &&
+        socket.plugged.plugDef.hash
+    )
+  );
 }
 
 /**


### PR DESCRIPTION
When creating a loadout from existing items the currently equipped mods will be saved in loadout parameters.

Note that we will be saving them in the main app but users wont be able to see them as its a beta only thing.

Happy for this to go in after release.