### PR TITLE
Fix loadout optimizer stat tier 10 handling

### DIFF
--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -302,17 +302,12 @@ export function process(
             };
 
             // Calculate the "tiers string" here, since most sets don't make it this far
-            // A string version of the tier-level of each stat, separated by commas
-            // This is an awkward implementation to save garbage allocations.
+            // A string version of the tier-level of each stat, must be lexically comparable
             let tiers = '';
-            let index = 0;
             for (const statKey of orderedConsideredStats) {
               const tier = statTier(stats[statKey]);
-              tiers += tier;
-              if (index < statOrder.length - 1) {
-                tiers += ',';
-              }
-              index++;
+              // Make each stat exactly one code unit so the string compares correctly
+              tiers += tier.toString(11);
             }
 
             numInserted++;


### PR DESCRIPTION
The optimizer set tracker needs lexically comparable stat tier
strings to correctly sort the sets. Previously sets with any stats
at tier 10 would be incorrectly sorted to near the bottom and often
thrown away because "10" has 2 characters and compares smaller than
any stats 2-9 (while also misaligning the rest of the string).
Changed stats string to be exactly 1 character per stat and removed
unnecessary commas to fix this.