### PR TITLE
Big buttons / menus on mobile

### DIFF
--- a/src/app/dim-ui/CharacterSelect.m.scss
+++ b/src/app/dim-ui/CharacterSelect.m.scss
@@ -40,7 +40,7 @@
   @include phone-portrait {
     max-width: 260px;
   }
-  margin: 16px auto;
+  margin: 8px auto;
   overflow: visible !important;
   position: relative;
 }

--- a/src/app/dim-ui/Dropdown.m.scss
+++ b/src/app/dim-ui/Dropdown.m.scss
@@ -20,7 +20,7 @@
   min-width: 10em;
   padding: 6px 9px;
   @include phone-portrait {
-    padding: 8px 10px;
+    padding: 10px 10px;
     width: 100vw;
   }
 

--- a/src/app/dim-ui/Select.m.scss
+++ b/src/app/dim-ui/Select.m.scss
@@ -25,7 +25,7 @@
   min-width: 10em;
   padding: 6px 9px;
   @include phone-portrait {
-    padding: 8px 10px;
+    padding: 10px 10px;
   }
 
   :global(.app-icon) {

--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -47,13 +47,6 @@ $control-color: rgba(255, 255, 255, 0.5);
     padding-bottom: calc(8px + constant(safe-area-inset-bottom));
     padding-bottom: calc(8px + env(safe-area-inset-bottom));
     flex-shrink: 0;
-
-    // Add space for iOS' touch dead zone
-    @media not all and (display-mode: standalone) {
-      .ios & {
-        margin-bottom: 44px;
-      }
-    }
   }
 
   .sheet-container {

--- a/src/app/inventory/PhoneStores.tsx
+++ b/src/app/inventory/PhoneStores.tsx
@@ -30,7 +30,7 @@ export default function PhoneStores({ stores, buckets, singleCharacter }: Props)
 
   const [{ selectedStoreId, direction }, setSelectedStoreId] = useState({
     selectedStoreId: currentStore?.id,
-    direction: 1,
+    direction: 0,
   });
   const [selectedCategoryId, setSelectedCategoryId] = useState<string>('Weapons');
   const detachedLoadoutMenu = useRef<HTMLDivElement>(null);

--- a/src/app/loadout-builder/filter/FilterBuilds.m.scss
+++ b/src/app/loadout-builder/filter/FilterBuilds.m.scss
@@ -1,3 +1,5 @@
+@import '../../variables.scss';
+
 .filters {
   margin: 8px 0;
 }
@@ -13,6 +15,9 @@
 
   > * {
     margin: 4px 0;
+    @include phone-portrait {
+      margin: 8px 0;
+    }
     &:first-child {
       margin-left: 8px;
     }

--- a/src/app/loadout/loadout-drawer.scss
+++ b/src/app/loadout/loadout-drawer.scss
@@ -19,6 +19,8 @@
 }
 
 .loadout-drawer-header {
+  width: 100%;
+
   .stat-bars.destiny2 {
     cursor: default;
     max-width: 280px;
@@ -70,6 +72,10 @@
 }
 
 .loadout-options {
+  @include phone-portrait {
+    font-size: 14px;
+  }
+
   form {
     display: flex;
     flex-direction: row;
@@ -88,6 +94,11 @@
     border-bottom: 1px solid #555;
     color: white;
     width: 100%;
+
+    @include phone-portrait {
+      font-size: 14px;
+      height: 32px;
+    }
 
     &:hover,
     &:focus {

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -13,6 +13,11 @@
   overflow: hidden;
   background-color: black;
 
+  @include phone-portrait {
+    font-size: 14px;
+    padding: 6px;
+  }
+
   .loadout-type-icon {
     color: #666;
   }
@@ -41,6 +46,10 @@
       width: 12px;
       margin-right: 5px;
       text-align: center;
+      @include phone-portrait {
+        width: 14px;
+        margin-right: 8px;
+      }
     }
   }
 
@@ -103,6 +112,7 @@
   @include visible-scrollbars;
 
   @include phone-portrait {
+    // TODO: use visual viewport API / dropdown class
     max-height: 60vh;
   }
 
@@ -124,5 +134,14 @@
     left: 50%;
     transform: translateX(-50%);
     padding: 0 5px;
+
+    @include phone-portrait {
+      width: 100vw;
+      max-width: none;
+      padding: 0;
+      max-height: calc(100vh - #{54px + $header-height});
+      max-height: calc(100vh - #{54px + $header-height} - constant(safe-area-inset-top));
+      max-height: calc(100vh - #{54px + $header-height} - env(safe-area-inset-top));
+    }
   }
 }

--- a/src/app/loadout/loadout-popup.scss
+++ b/src/app/loadout/loadout-popup.scss
@@ -62,9 +62,15 @@
     background-color: #222;
     display: flex;
     align-items: center;
+    @include phone-portrait {
+      margin: 4px 4px 4px 2px;
+    }
     .app-icon,
     .fa {
       font-size: 13px;
+      @include phone-portrait {
+        font-size: 15px;
+      }
     }
     &:hover {
       background-color: $blue;

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -302,6 +302,13 @@ select {
   font-family: 'Open Sans', sans-serif;
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   border: 1px solid transparent;
+
+  @include phone-portrait {
+    font-size: 14px;
+    padding: 6px 32px 6px 16px;
+    height: 35px;
+  }
+
   &:hover,
   &:active {
     background-color: $orange;
@@ -338,6 +345,12 @@ select {
   border: 1px solid transparent;
   transition: all 150ms ease-out;
   box-sizing: border-box;
+
+  @include phone-portrait {
+    font-size: 14px;
+    padding: 8px 16px;
+  }
+
   &:hover,
   &:active,
   &.selected {


### PR DESCRIPTION
This makes a bunch of tweaks for mobile usability - generally just bigger tap targets for buttons and menus. The character menu is now full screen. I could actually be convinced that we should change the base font size in DIM to 14px all over, but this is a bit more targeted.

<img width="312" alt="Screen Shot 2021-04-17 at 3 20 17 PM" src="https://user-images.githubusercontent.com/313208/115128198-eb7ee100-9f90-11eb-8a6c-1e3008856131.png">
<img width="310" alt="Screen Shot 2021-04-17 at 3 20 26 PM" src="https://user-images.githubusercontent.com/313208/115128199-ede13b00-9f90-11eb-8c26-0b8d45296c63.png">
<img width="310" alt="Screen Shot 2021-04-17 at 3 20 37 PM" src="https://user-images.githubusercontent.com/313208/115128200-ef126800-9f90-11eb-9c3a-4270e2d9e43a.png">
