### PR TITLE
stop suppressing nameless quest step items

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -229,7 +229,7 @@ export function makeItem(
     );
   }
 
-  if (!itemDef || !itemDef.displayProperties.name) {
+  if (!itemDef || !(itemDef.displayProperties.name || itemDef.setData?.questLineName)) {
     return null;
   }
 


### PR DESCRIPTION
later in makeItem, their name gets replaced with their quest line name anyway

this fixes missing guardian games quests and quest items and some recent multi-stage catalysts