### PR TITLE
case-insensitize notes area tag suggestions

### DIFF
--- a/src/app/inventory/note-hashtags.ts
+++ b/src/app/inventory/note-hashtags.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { ItemInfos } from './dim-item-info';
 
 /**
@@ -13,7 +14,7 @@ export function collectNotesHashtags(itemInfos: ItemInfos) {
       }
     }
   }
-  return [...hashTags];
+  return _.uniqBy([...hashTags], (t) => t.toLowerCase());
 }
 
 export function getHashtagsFromNote(note?: string | null) {

--- a/src/app/item-popup/NotesArea.tsx
+++ b/src/app/item-popup/NotesArea.tsx
@@ -134,20 +134,22 @@ function NotesEditor({
           {
             match: /#(\w*)$/,
             search: (term, callback) => {
+              const termLower = term.toLowerCase();
               // need to build this list from the element ref, because relying
               // on liveNotes state would reinstantiate Textcomplete every keystroke
               const existingTags = getHashtagsFromNote(textArea.current!.value);
               const possibleTags: string[] = [];
               for (const t of tags) {
+                const tagLower = t.toLowerCase();
                 // don't suggest duplicate tags
-                if (existingTags.includes(t)) {
+                if (existingTags.includes(tagLower)) {
                   continue;
                 }
                 // favor startswith
-                if (t.startsWith('#' + term)) {
+                if (tagLower.startsWith('#' + termLower)) {
                   possibleTags.unshift(t);
                   // over full text search
-                } else if (t.includes(term)) {
+                } else if (tagLower.includes(termLower)) {
                   possibleTags.push(t);
                 }
               }

--- a/src/app/item-popup/NotesArea.tsx
+++ b/src/app/item-popup/NotesArea.tsx
@@ -137,7 +137,9 @@ function NotesEditor({
               const termLower = term.toLowerCase();
               // need to build this list from the element ref, because relying
               // on liveNotes state would reinstantiate Textcomplete every keystroke
-              const existingTags = getHashtagsFromNote(textArea.current!.value);
+              const existingTags = getHashtagsFromNote(textArea.current!.value).map((t) =>
+                t.toLowerCase()
+              );
               const possibleTags: string[] = [];
               for (const t of tags) {
                 const tagLower = t.toLowerCase();


### PR DESCRIPTION
`#P` should suggest `#pvp` now, or vice versa. dupe tag prevention is also case insensitive now and suggested search tags won't treat different capitalizations as separate tags