### PR TITLE
fix aeon perk detection/ignore unnamed exotic sockets

### DIFF
--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -121,10 +121,13 @@ export function getArmorExoticPerkSocket(item: DimItem): DimSocket | undefined {
       (c) => c.category.hash === SocketCategoryHashes.ArmorPerks_LargePerk
     );
     if (largePerkCategory) {
-      return getSocketByIndex(
+      const largePerkSocket = getSocketByIndex(
         item.sockets,
-        largePerkCategory.socketIndexes[largePerkCategory.socketIndexes.length - 1]
+        _.nth(largePerkCategory.socketIndexes, -1)!
       );
+      if (largePerkSocket?.plugged?.plugDef.displayProperties.name) {
+        return largePerkSocket;
+      }
     }
     return getSocketsByPlugCategoryIdentifier(item.sockets, 'enhancements.exotic');
   }


### PR DESCRIPTION
this fixes the fact that aeon perks aren't being searched for, in favor of assuming a stat plug is the exotic perk. i think this needs to be redone not to rely on socket category, and instead rely on attributes of the plugged item def