### PR TITLE
statbar segment details in tooltips

### DIFF
--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -11,6 +11,7 @@ interface Props {
   /** By default everything gets wrapped in a div, but you can choose a different element type here. */
   elementType?: React.ElementType;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 type ControlProps = Props &
@@ -54,7 +55,12 @@ function Control({
   });
 
   if (!tooltip) {
-    return <Component>{children}</Component>;
+    const { className, style } = rest;
+    return (
+      <Component className={className} style={style}>
+        {children}
+      </Component>
+    );
   }
 
   // TODO: if we reuse a stable tooltip container instance we could animate between them

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -1,6 +1,7 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import { StatTotalToggle } from 'app/dim-ui/CustomStatTotal';
 import ExternalLink from 'app/dim-ui/ExternalLink';
+import PressTip from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { D1Item, D1Stat, DimItem, DimSocket, DimStat } from 'app/inventory/item-types';
 import { statsMs } from 'app/inventory/store/stats';
@@ -139,20 +140,17 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
 
 function StatBar({ segments, stat }: { segments: [number, string?, string?][]; stat: DimStat }) {
   return (
-    <div
-      className={styles.statBar}
-      aria-label={stat.displayProperties.name}
-      title={stat.displayProperties.description}
-      aria-hidden="true"
-    >
+    <div className={styles.statBar} aria-label={stat.displayProperties.name} aria-hidden="true">
       <div className={styles.barContainer}>
         {segments.map(([val, className, description], index) => (
-          <div
+          <PressTip
             key={index}
-            title={description}
+            tooltip={[description, val].filter(Boolean).join(': ') || undefined}
             className={clsx(styles.barInner, className)}
             style={{ width: percent(val / stat.maximumValue) }}
-          />
+          >
+            <React.Fragment />
+          </PressTip>
         ))}
       </div>
     </div>


### PR DESCRIPTION
converts statbar segments to presstips so that you can see their associated value and, for mods, mod name

![image](https://user-images.githubusercontent.com/68782081/115951407-73835000-a495-11eb-9d8e-b57d5636381b.png)