### PR TITLE
Tweak archetype socket to show exotic class item perk

### DIFF
--- a/src/app/item-popup/ArchetypeSocket.m.scss
+++ b/src/app/item-popup/ArchetypeSocket.m.scss
@@ -12,9 +12,13 @@
     align-items: center;
   }
 
+  &.isWeapons {
+    align-items: center;
+  }
+
   :global(.socket-container) img {
-    width: calc(26 / 50 * var(--item-size));
-    height: calc(26 / 50 * var(--item-size));
+    width: calc(24 / 50 * var(--item-size));
+    height: calc(24 / 50 * var(--item-size));
   }
 
   :global(.item-socket-category-Consumable) img {
@@ -25,15 +29,18 @@
 
 .mod {
   margin-top: calc(4 / 50 * var(--item-size));
-  .minimal & {
+  margin-right: 2px;
+  .minimal &,
+  .isWeapons & {
     margin-top: 0;
+    margin-right: 0;
   }
 
   img {
-    width: calc(26 / 50 * var(--item-size));
-    height: calc(26 / 50 * var(--item-size));
+    width: calc(24 / 50 * var(--item-size));
+    height: calc(24 / 50 * var(--item-size));
     transform: scale(1.4);
-    margin-right: 6px;
+    margin-right: 7px;
     margin-left: 2px;
 
     .minimal & {

--- a/src/app/item-popup/ArchetypeSocket.m.scss.d.ts
+++ b/src/app/item-popup/ArchetypeSocket.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'info': string;
+  'isWeapons': string;
   'minimal': string;
   'mod': string;
   'name': string;

--- a/src/app/item-popup/ArchetypeSocket.tsx
+++ b/src/app/item-popup/ArchetypeSocket.tsx
@@ -48,12 +48,21 @@ export function ArchetypeRow({
   className,
   children,
   minimal,
+  isWeapons,
 }: {
   className?: string;
   children: React.ReactNode;
   minimal?: boolean;
+  isWeapons?: boolean;
 }) {
   return (
-    <div className={clsx(className, styles.row, { [styles.minimal]: minimal })}>{children}</div>
+    <div
+      className={clsx(className, styles.row, {
+        [styles.minimal]: minimal,
+        [styles.isWeapons]: isWeapons,
+      })}
+    >
+      {children}
+    </div>
   );
 }

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -3,7 +3,6 @@ import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { getArmorExoticPerkSocket, getSocketsByIndexes } from 'app/utils/socket-utils';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
@@ -77,8 +76,10 @@ function ItemSocketsGeneral({
       c.socketIndexes.length > 0 &&
       // hide if this is the energy slot. it's already displayed in ItemDetails
       c.category.categoryStyle !== DestinySocketCategoryStyle.EnergyMeter &&
+      // Hidden sockets for intrinsic armor stats
+      c.category.uiCategoryStyle !== 2251952357 &&
       // we handle exotic perk specially too
-      c.category.hash !== SocketCategoryHashes.ArmorPerks_LargePerk
+      (!exoticArmorPerkSocket || !c.socketIndexes.includes(exoticArmorPerkSocket?.socketIndex))
   );
   if (minimal) {
     // Only show the first of each style of category

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -110,7 +110,7 @@ function ItemSocketsWeapons({
   return (
     <div className={clsx('item-details', 'sockets', styles.weaponSockets)}>
       {(archetypeSocket?.plugged || (!minimal && mods.length > 0)) && (
-        <ArchetypeRow minimal={minimal}>
+        <ArchetypeRow minimal={minimal} isWeapons={true}>
           {archetypeSocket?.plugged && (
             <ArchetypeSocket
               archetypeSocket={archetypeSocket}

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -116,7 +116,7 @@ export const getWeaponArchetype = (item: DimItem): PluggableInventoryItemDefinit
   getWeaponArchetypeSocket(item)?.plugged?.plugDef;
 
 export function getArmorExoticPerkSocket(item: DimItem): DimSocket | undefined {
-  if (item.isExotic && item.bucket.inArmor && item.sockets) {
+  if (item.bucket.inArmor && item.sockets) {
     const largePerkCategory = item.sockets.categories.find(
       (c) => c.category.hash === SocketCategoryHashes.ArmorPerks_LargePerk
     );


### PR DESCRIPTION
I made sure this didn't make hidden perks show up.
Also fix CSS to center weapon perk, resize/padding.

<img width="470" alt="Screen Shot 2021-04-24 at 8 03 22 PM" src="https://user-images.githubusercontent.com/313208/115978999-18ef0000-a538-11eb-9353-2b69546e7e0b.png">
<img width="475" alt="Screen Shot 2021-04-24 at 8 03 29 PM" src="https://user-images.githubusercontent.com/313208/115979001-1c828700-a538-11eb-8784-725276f36573.png">
<img width="472" alt="Screen Shot 2021-04-24 at 8 03 35 PM" src="https://user-images.githubusercontent.com/313208/115979002-1d1b1d80-a538-11eb-9cfd-f9246823429f.png">

