### PR TITLE
Better loadout mods on mobile

### DIFF
--- a/src/app/loadout/SavedMods.m.scss
+++ b/src/app/loadout/SavedMods.m.scss
@@ -21,6 +21,7 @@
 .categories {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .category {
@@ -46,6 +47,7 @@
   align-items: center;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   width: fit-content;
 
   > * {


### PR DESCRIPTION
Let the loadout mods wrap on mobile so you dont need to scroll. 

I could be persuaded to make the flex become a column instead but this way saves some room even if it looks a little messy.

![image](https://user-images.githubusercontent.com/7344652/116059844-a3fd0100-a6c4-11eb-8b9f-a8709c740fb3.png)
