### PR TITLE
Exclude other slot exotics in optimizer

### DIFF
--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -58,7 +58,10 @@ export function filterItems(
     if (filteredItems[bucket]) {
       filteredItems[bucket] = filteredItems[bucket].filter(
         (item) =>
-          (bucket !== lockedExotic?.bucketHash || item.hash === lockedExotic.def.hash) &&
+          (!lockedExotic ||
+            (bucket === lockedExotic.bucketHash ?
+              item.hash === lockedExotic.def.hash :
+              item.equippingLabel !== lockedExotic.def.equippingBlock!.uniqueLabel)) &&
           // handle locked items and mods cases
           (!locked || locked.every((lockedItem) => matchLockedItem(item, lockedItem))) &&
           (!lockedModsByPlugCategoryHash ||

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -203,19 +203,28 @@ export function process(
   for (const helm of helms) {
     for (const gaunt of gaunts) {
       // For each additional piece, skip the whole branch if we've managed to get 2 exotics
-      if (helm.equippingLabel && gaunt.equippingLabel) {
+      if (
+        gaunt.equippingLabel &&
+        gaunt.equippingLabel === helm.equippingLabel
+      ) {
         numDoubleExotic += chests.length * legs.length * classItems.length;
         continue;
       }
       for (const chest of chests) {
-        if (chest.equippingLabel && (helm.equippingLabel || gaunt.equippingLabel)) {
+        if (
+          chest.equippingLabel &&
+          (chest.equippingLabel === gaunt.equippingLabel ||
+            chest.equippingLabel === helm.equippingLabel)
+        ) {
           numDoubleExotic += legs.length * classItems.length;
           continue;
         }
         for (const leg of legs) {
           if (
             leg.equippingLabel &&
-            (chest.equippingLabel || helm.equippingLabel || gaunt.equippingLabel)
+            (leg.equippingLabel === chest.equippingLabel ||
+              leg.equippingLabel === gaunt.equippingLabel ||
+              leg.equippingLabel === helm.equippingLabel)
           ) {
             numDoubleExotic += classItems.length;
             continue;


### PR DESCRIPTION
If an exotic is locked in a slot we can exclude all the exotics in the other slots.