### PR TITLE
Switch well-rested perk hash

### DIFF
--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -239,7 +239,7 @@ export const VENDOR_GROUPS = {
 };
 
 /** used to snag the icon for display */
-export const WELL_RESTED_PERK = 2319209868;
+export const WELL_RESTED_PERK = 2352765282;
 
 /** an "All" trait we want to filter out of trait lists */
 export const ALL_TRAIT = 1434215347;


### PR DESCRIPTION
Causes it to show the right text (first 5 levels), not sure if the actual XP logic needs to be tweaked though.