### PR TITLE
fix currency wrapping

### DIFF
--- a/src/app/store-stats/AccountCurrencies.tsx
+++ b/src/app/store-stats/AccountCurrencies.tsx
@@ -20,27 +20,32 @@ const synthCurrencies = [
 /** The account currencies (glimmer, shards, etc.) */
 export default React.memo(function AccountCurrency() {
   const currencies = useSelector(currenciesSelector);
+  const { other, synth } = _.groupBy(currencies, (c) =>
+    synthCurrencies.includes(c.itemHash) ? 'synth' : 'other'
+  );
   return (
     <>
-      {_.sortBy(currencies, (c) => (synthCurrencies.includes(c.itemHash) ? 1 : -1)).map(
-        (currency) => (
-          <React.Fragment key={currency.itemHash}>
-            <BungieImage
-              className={styles.currency}
-              src={currency.displayProperties.icon}
-              title={currency.displayProperties.name}
-            />
-            <div className={styles.currency} title={currency.displayProperties.name}>
-              {currency.quantity.toLocaleString()}
-            </div>
-          </React.Fragment>
-        )
-      )}
-      {_.times(4 - (currencies.length % 4), (i) => (
-        <React.Fragment key={i}>
-          <div />
-          <div />
-        </React.Fragment>
+      {[other, synth].map((currencyGroup) => (
+        <>
+          {currencyGroup.map((currency) => (
+            <React.Fragment key={currency.itemHash}>
+              <BungieImage
+                className={styles.currency}
+                src={currency.displayProperties.icon}
+                title={currency.displayProperties.name}
+              />
+              <div className={styles.currency} title={currency.displayProperties.name}>
+                {currency.quantity.toLocaleString()}
+              </div>
+            </React.Fragment>
+          ))}
+          {_.times((4 - currencyGroup.length) % 4, (i) => (
+            <React.Fragment key={i}>
+              <div />
+              <div />
+            </React.Fragment>
+          ))}
+        </>
       ))}
     </>
   );


### PR DESCRIPTION
when silver isn't showing up, synth mats wrap awkwardly across two lines. this forces separate lines

before:
![image](https://user-images.githubusercontent.com/68782081/118386763-aae5a800-b5ce-11eb-868a-aaff0ec6d3db.png)

after:
![image](https://user-images.githubusercontent.com/68782081/118386768-b042f280-b5ce-11eb-9ee9-2ab0a04a337d.png)

before and after with silver:
![image](https://user-images.githubusercontent.com/68782081/118386791-c0f36880-b5ce-11eb-9778-f84283cc1b26.png)
