### PR TITLE
Show screenshots for ornaments

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -368,7 +368,7 @@ export function makeItem(
       '/img/misc/missing_icon_d2.png',
     hiddenOverlay,
     iconOverlay,
-    secondaryIcon: overrideStyleItem?.secondaryIcon || itemDef.secondaryIcon,
+    secondaryIcon: overrideStyleItem?.secondaryIcon || itemDef.secondaryIcon || itemDef.screenshot,
     notransfer: Boolean(
       itemDef.nonTransferrable ||
         item.transferStatus === TransferStatuses.NotTransferrable ||

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -72,9 +72,9 @@ function ItemDetails({ item, extraInfo = {}, defs }: Props) {
         <BungieImage className="item-shader" src={item.icon} width="96" height="96" />
       )}
 
-      {item.type === 'Milestone' && item.secondaryIcon && (
-        <BungieImage src={item.secondaryIcon} width="100%" />
-      )}
+      {(item.type === 'Milestone' ||
+        item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Ornament)) &&
+        item.secondaryIcon && <BungieImage src={item.secondaryIcon} width="100%" />}
 
       <ItemDescription item={item} defs={defs} />
 


### PR DESCRIPTION
<img width="388" alt="Screen Shot 2021-05-17 at 11 32 08 PM" src="https://user-images.githubusercontent.com/313208/118602700-dc45ab80-b767-11eb-9c9d-83e9427af58f.png">

Not sure why I was sitting on this branch. It mostly affects Eververse, unless you happen to have the ornament in your mods inventory.