### PR TITLE
Show wishlist for non-inventory items

### DIFF
--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -3,7 +3,7 @@ import { RootState } from 'app/store/types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { searchFilterSelector } from '../search/search-filter';
-import { inventoryWishListsSelector } from '../wishlists/selectors';
+import { wishListSelector } from '../wishlists/selectors';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import { getNotes, getTag, TagValue } from './dim-item-info';
 import InventoryItem from './InventoryItem';
@@ -37,13 +37,12 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   const settings = settingsSelector(state);
   const itemInfos = itemInfosSelector(state);
   const itemHashTags = itemHashTagsSelector(state);
-  const wishlistRolls = inventoryWishListsSelector(state);
 
   return {
     isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,
     tag: getTag(item, itemInfos, itemHashTags),
     notes: getNotes(item, itemInfos, itemHashTags) ? true : false,
-    wishlistRoll: wishlistRolls[item.id],
+    wishlistRoll: wishListSelector(item)(state),
     searchHidden: props.allowFilter && !searchFilterSelector(state)(item),
   };
 }

--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -3,7 +3,7 @@ import ExternalLink from 'app/dim-ui/ExternalLink';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import { inventoryWishListsSelector } from 'app/wishlists/selectors';
+import { wishListSelector } from 'app/wishlists/selectors';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import ishtarLogo from '../../images/ishtar-collective.svg';
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export default function ItemDescription({ item }: Props) {
-  const wishlistItem = useSelector(inventoryWishListsSelector)[item.id];
+  const wishlistItem = useSelector(wishListSelector(item));
 
   // suppressing some unnecessary information for weapons and armor,
   // to make room for all that other delicious info

--- a/src/app/item-popup/ItemPerksList.tsx
+++ b/src/app/item-popup/ItemPerksList.tsx
@@ -6,12 +6,12 @@ import AppIcon from 'app/shell/icons/AppIcon';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { isKillTrackerSocket } from 'app/utils/item-utils';
 import { getSocketsByIndexes } from 'app/utils/socket-utils';
+import { wishListSelector } from 'app/wishlists/selectors';
 import clsx from 'clsx';
 import { default as React, useState } from 'react';
 import { connect } from 'react-redux';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { DimItem, DimPlug, DimSocket, DimSocketCategory } from '../inventory/item-types';
-import { inventoryWishListsSelector } from '../wishlists/selectors';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import styles from './ItemPerksList.m.scss';
 import './ItemSockets.scss';
@@ -29,7 +29,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps {
   return {
-    wishlistRoll: inventoryWishListsSelector(state)[item.id],
+    wishlistRoll: wishListSelector(item)(state),
     defs: d2ManifestSelector(state),
   };
 }

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { DimAdjustedItemPlug } from '../compare/types';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { DimItem, DimPlug, DimSocket } from '../inventory/item-types';
-import { inventoryWishListsSelector } from '../wishlists/selectors';
+import { wishListSelector } from '../wishlists/selectors';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import ArchetypeSocket, { ArchetypeRow } from './ArchetypeSocket';
 import './ItemSockets.scss';
@@ -34,7 +34,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps {
   return {
-    wishlistRoll: inventoryWishListsSelector(state)[item.id],
+    wishlistRoll: wishListSelector(item)(state),
     defs: d2ManifestSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
   };

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -18,7 +18,7 @@ import { connect } from 'react-redux';
 import { DimAdjustedItemPlug } from '../compare/types';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { DimItem, DimPlug, DimSocket } from '../inventory/item-types';
-import { inventoryWishListsSelector } from '../wishlists/selectors';
+import { wishListSelector } from '../wishlists/selectors';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import ArchetypeSocket, { ArchetypeRow } from './ArchetypeSocket';
 import ItemPerksList from './ItemPerksList';
@@ -43,7 +43,7 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState, { item }: ProvidedProps): StoreProps {
   return {
-    wishlistRoll: inventoryWishListsSelector(state)[item.id],
+    wishlistRoll: wishListSelector(item)(state),
     defs: d2ManifestSelector(state),
     isPhonePortrait: state.shell.isPhonePortrait,
   };

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -83,16 +83,13 @@ export function getColumns(
   },
   classType: DestinyClass,
   itemInfos: ItemInfos,
-  wishList: {
-    [key: string]: InventoryWishListRoll;
-  },
+  wishList: (item: DimItem) => InventoryWishListRoll | undefined,
+  hasWishList: boolean,
   customTotalStat: number[],
   loadouts: Loadout[],
   newItems: Set<string>,
   destinyVersion: DestinyVersion
 ): ColumnDefinition[] {
-  const hasWishList = !_.isEmpty(wishList);
-
   const statsGroup: ColumnGroup = {
     id: 'stats',
     header: t('Organizer.Columns.Stats'),
@@ -279,12 +276,11 @@ export function getColumns(
       filter: (value) => (value ? 'is:new' : 'not:new'),
     },
     destinyVersion === 2 &&
-      isWeapon &&
-      hasWishList && {
+      isWeapon && {
         id: 'wishList',
         header: t('Organizer.Columns.WishList'),
         value: (item) => {
-          const roll = wishList?.[item.id];
+          const roll = wishList(item);
           return roll ? (roll.isUndesirable ? false : true) : undefined;
         },
         cell: (value) =>
@@ -502,7 +498,7 @@ export function getColumns(
       hasWishList && {
         id: 'wishListNote',
         header: t('Organizer.Columns.WishListNotes'),
-        value: (item) => wishList?.[item.id]?.notes,
+        value: (item) => wishList(item)?.notes,
         gridWidth: 'minmax(200px, 1fr)',
         filter: (value) => `wishlistnotes:"${value}"`,
       },

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -26,7 +26,7 @@ import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptyArray, emptyObject } from 'app/utils/empty';
 import { useSetCSSVarToHeight, useShiftHeld } from 'app/utils/hooks';
-import { inventoryWishListsSelector } from 'app/wishlists/selectors';
+import { hasWishListSelector, wishListFunctionSelector } from 'app/wishlists/selectors';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -70,9 +70,8 @@ interface StoreProps {
   stores: DimStore[];
   items: DimItem[];
   itemInfos: ItemInfos;
-  wishList: {
-    [key: string]: InventoryWishListRoll;
-  };
+  wishList: (item: DimItem) => InventoryWishListRoll | undefined;
+  hasWishList: boolean;
   isPhonePortrait: boolean;
   enabledColumns: string[];
   customTotalStatsByClass: StatHashListsKeyedByDestinyClass;
@@ -108,7 +107,8 @@ function mapStateToProps() {
       items,
       stores: storesSelector(state),
       itemInfos: itemInfosSelector(state),
-      wishList: inventoryWishListsSelector(state),
+      wishList: wishListFunctionSelector(state),
+      hasWishList: hasWishListSelector(state),
       isPhonePortrait: state.shell.isPhonePortrait,
       enabledColumns: settingsSelector(state)[columnSetting(itemType)],
       customTotalStatsByClass: settingsSelector(state).customTotalStatsByClass,
@@ -128,6 +128,7 @@ function ItemTable({
   categories,
   itemInfos,
   wishList,
+  hasWishList,
   stores,
   enabledColumns,
   customTotalStatsByClass,
@@ -193,6 +194,7 @@ function ItemTable({
         classIfAny,
         itemInfos,
         wishList,
+        hasWishList,
         customStatTotal,
         loadouts,
         newItems,
@@ -200,6 +202,7 @@ function ItemTable({
       ),
     [
       wishList,
+      hasWishList,
       statHashes,
       itemType,
       itemInfos,

--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -24,7 +24,7 @@ export interface FilterContext {
   allItems: DimItem[];
   currentStore: DimStore;
   loadouts: Loadout[];
-  inventoryWishListRolls: { [key: string]: InventoryWishListRoll };
+  wishListFunction: (item: DimItem) => InventoryWishListRoll | undefined;
   newItems: Set<string>;
   itemInfos: ItemInfos;
   itemHashTags: {

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -16,7 +16,7 @@ import { DimStore } from '../inventory/store-types';
 import { Loadout } from '../loadout-drawer/loadout-types';
 import { loadoutsSelector } from '../loadout-drawer/selectors';
 import { querySelector } from '../shell/selectors';
-import { inventoryWishListsSelector } from '../wishlists/selectors';
+import { wishListFunctionSelector } from '../wishlists/selectors';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import { FilterContext, ItemFilter } from './filter-types';
 import { parseQuery, QueryAST } from './query-parser';
@@ -37,7 +37,7 @@ export const filterFactorySelector = createSelector(
   allItemsSelector,
   currentStoreSelector,
   loadoutsSelector,
-  inventoryWishListsSelector,
+  wishListFunctionSelector,
   (state: RootState) => state.inventory.newItems,
   itemInfosSelector,
   itemHashTagsSelector,
@@ -65,7 +65,7 @@ function makeSearchFilterFactory(
   allItems: DimItem[],
   currentStore: DimStore,
   loadouts: Loadout[],
-  inventoryWishListRolls: { [key: string]: InventoryWishListRoll },
+  wishListFunction: (item: DimItem) => InventoryWishListRoll | undefined,
   newItems: Set<string>,
   itemInfos: ItemInfos,
   itemHashTags: {
@@ -78,7 +78,7 @@ function makeSearchFilterFactory(
     allItems,
     currentStore,
     loadouts,
-    inventoryWishListRolls,
+    wishListFunction,
     newItems,
     itemInfos,
     itemHashTags,

--- a/src/app/search/search-filters/wishlist.tsx
+++ b/src/app/search/search-filters/wishlist.tsx
@@ -6,22 +6,25 @@ import { checkIfIsDupe, computeDupes, makeDupeID } from './dupes';
 
 const checkIfIsWishlist = (
   item: DimItem,
-  inventoryWishListRolls: {
-    [key: string]: InventoryWishListRoll;
-  }
-) => inventoryWishListRolls[item.id] && !inventoryWishListRolls[item.id].isUndesirable;
+  wishListFunction: (item: DimItem) => InventoryWishListRoll | undefined
+) => {
+  const roll = wishListFunction(item);
+  return roll && !roll.isUndesirable;
+};
 
 const wishlistFilters: FilterDefinition[] = [
   {
     keywords: 'wishlist',
     description: tl('Filter.Wishlist'),
-    filter: ({ inventoryWishListRolls }) => (item) =>
-      checkIfIsWishlist(item, inventoryWishListRolls),
+    filter:
+      ({ wishListFunction }) =>
+      (item) =>
+        checkIfIsWishlist(item, wishListFunction),
   },
   {
     keywords: 'wishlistdupe',
     description: tl('Filter.WishlistDupe'),
-    filter: ({ inventoryWishListRolls, allItems }) => {
+    filter: ({ wishListFunction, allItems }) => {
       const duplicates = computeDupes(allItems);
       return (item) => {
         const dupeId = makeDupeID(item);
@@ -29,7 +32,7 @@ const wishlistFilters: FilterDefinition[] = [
           return false;
         }
         const itemDupes = duplicates?.[dupeId];
-        return itemDupes?.some((d) => checkIfIsWishlist(d, inventoryWishListRolls));
+        return itemDupes?.some((d) => checkIfIsWishlist(d, wishListFunction));
       };
     },
   },
@@ -37,14 +40,18 @@ const wishlistFilters: FilterDefinition[] = [
     keywords: 'wishlistnotes',
     description: tl('Filter.WishlistNotes'),
     format: 'freeform',
-    filter: ({ inventoryWishListRolls, filterValue }) => (item) =>
-      inventoryWishListRolls[item.id]?.notes?.toLocaleLowerCase().includes(filterValue),
+    filter:
+      ({ wishListFunction, filterValue }) =>
+      (item) =>
+        wishListFunction(item)?.notes?.toLocaleLowerCase().includes(filterValue),
   },
   {
     keywords: 'trashlist',
     description: tl('Filter.Trashlist'),
-    filter: ({ inventoryWishListRolls }) => (item) =>
-      inventoryWishListRolls[item.id]?.isUndesirable,
+    filter:
+      ({ wishListFunction }) =>
+      (item) =>
+        wishListFunction(item)?.isUndesirable,
   },
 ];
 

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -135,6 +135,7 @@ export class VendorItem {
       buckets,
       itemComponents,
       itemHash,
+      // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
       saleItem ? saleItem.vendorItemIndex.toString() : itemHash.toString(),
       vendorItemDef ? vendorItemDef.quantity : 1,
       mergedCollectibles

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -1,6 +1,5 @@
 import { DimItem } from 'app/inventory/item-types';
 import { RootState } from 'app/store/types';
-import { weakMemoize } from 'app/utils/util';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { getInventoryWishListRoll, InventoryWishListRoll } from './wishlists';
@@ -22,9 +21,18 @@ export const hasWishListSelector = createSelector(
 /** Returns a memoized function to look up wishlist by item, which is reset when the wishlist changes. Prefer wishListSelector */
 export const wishListFunctionSelector = createSelector(wishListsByHashSelector, (wishlists): ((
   item: DimItem
-) => InventoryWishListRoll | undefined) =>
-  weakMemoize((item: DimItem) => getInventoryWishListRoll(item, wishlists))
-);
+) => InventoryWishListRoll | undefined) => {
+  // Cache of inventory item id to roll. For this to work, make sure vendor/collections rolls have unique ids.
+  const cache = new Map<string, InventoryWishListRoll | undefined>();
+  return (item: DimItem) => {
+    if (cache.has(item.id)) {
+      return cache.get(item.id);
+    }
+    const roll = getInventoryWishListRoll(item, wishlists);
+    cache.set(item.id, roll);
+    return roll;
+  };
+});
 
 /**
  * A reverse-curried selector that is easier to use in useSelector. This will re-render the component only when

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -1,20 +1,38 @@
-import { allItemsSelector } from 'app/inventory/selectors';
+import { DimItem } from 'app/inventory/item-types';
 import { RootState } from 'app/store/types';
+import { weakMemoize } from 'app/utils/util';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import { getInventoryWishListRolls } from './wishlists';
+import { getInventoryWishListRoll, InventoryWishListRoll } from './wishlists';
 
 export const wishListsSelector = (state: RootState) => state.wishLists;
 
 export const wishListsLastFetchedSelector = (state: RootState) =>
   wishListsSelector(state).lastFetched;
 
-const wishListsByHashSelector = createSelector(wishListsSelector, (wls) =>
+export const wishListsByHashSelector = createSelector(wishListsSelector, (wls) =>
   _.groupBy(wls.wishListAndInfo.wishListRolls?.filter(Boolean), (r) => r.itemHash)
 );
 
-export const inventoryWishListsSelector = createSelector(
-  allItemsSelector,
+export const hasWishListSelector = createSelector(
   wishListsByHashSelector,
-  getInventoryWishListRolls
+  (wishlists) => !_.isEmpty(wishlists)
 );
+
+/** Returns a memoized function to look up wishlist by item, which is reset when the wishlist changes. Prefer wishListSelector */
+export const wishListFunctionSelector = createSelector(wishListsByHashSelector, (wishlists): ((
+  item: DimItem
+) => InventoryWishListRoll | undefined) =>
+  weakMemoize((item: DimItem) => getInventoryWishListRoll(item, wishlists))
+);
+
+/**
+ * A reverse-curried selector that is easier to use in useSelector. This will re-render the component only when
+ * this item's wishlist state changes.
+ *
+ * @example
+ *
+ * useSelector(wishListSelector(item))
+ */
+export const wishListSelector = (item: DimItem) => (state: RootState) =>
+  wishListFunctionSelector(state)(item);


### PR DESCRIPTION
This enables wish lists to work on any DimItem rather than just ones that are in the player's inventory (notably, vendor items work). Instead of pre-constructing a map from item instance ID to wishlist roll, we use a cached function that lazily computes the rolls for an item.

Fixes #6797