### PR TITLE
archive tag dimming on inventory page only

### DIFF
--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -34,18 +34,20 @@ interface StoreProps {
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
   const { item, searchFilterIsEmpty } = props;
-
   const settings = settingsSelector(state);
   const itemInfos = itemInfosSelector(state);
   const itemHashTags = itemHashTagsSelector(state);
   const tag = getTag(item, itemInfos, itemHashTags);
+
   return {
     isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,
     tag,
     notes: getNotes(item, itemInfos, itemHashTags) ? true : false,
     wishlistRoll: wishListSelector(item)(state),
     searchHidden:
+      // dim this item if there's no search filter and it's archived
       (searchFilterIsEmpty && tag === 'archive') ||
+      // or if there is filtering and it doesn't meet the condition
       (props.allowFilter && !searchFilterSelector(state)(item)),
   };
 }

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -20,6 +20,7 @@ interface ProvidedProps {
   onClick?(e: React.MouseEvent): void;
   onShiftClick?(e: React.MouseEvent): void;
   onDoubleClick?(e: React.MouseEvent): void;
+  searchFilterIsEmpty?: boolean;
 }
 
 // Props from Redux via mapStateToProps
@@ -32,18 +33,20 @@ interface StoreProps {
 }
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
-  const { item } = props;
+  const { item, searchFilterIsEmpty } = props;
 
   const settings = settingsSelector(state);
   const itemInfos = itemInfosSelector(state);
   const itemHashTags = itemHashTagsSelector(state);
-
+  const tag = getTag(item, itemInfos, itemHashTags);
   return {
     isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,
-    tag: getTag(item, itemInfos, itemHashTags),
+    tag,
     notes: getNotes(item, itemInfos, itemHashTags) ? true : false,
     wishlistRoll: wishListSelector(item)(state),
-    searchHidden: props.allowFilter && !searchFilterSelector(state)(item),
+    searchHidden:
+      (searchFilterIsEmpty && tag === 'archive') ||
+      (props.allowFilter && !searchFilterSelector(state)(item)),
   };
 }
 

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -1,5 +1,6 @@
 import { settingsSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
+import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { searchFilterSelector } from '../search/search-filter';
@@ -20,7 +21,7 @@ interface ProvidedProps {
   onClick?(e: React.MouseEvent): void;
   onShiftClick?(e: React.MouseEvent): void;
   onDoubleClick?(e: React.MouseEvent): void;
-  searchFilterIsEmpty?: boolean;
+  dimArchived?: boolean;
 }
 
 // Props from Redux via mapStateToProps
@@ -33,11 +34,13 @@ interface StoreProps {
 }
 
 function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
-  const { item, searchFilterIsEmpty } = props;
+  const { item, dimArchived } = props;
   const settings = settingsSelector(state);
   const itemInfos = itemInfosSelector(state);
   const itemHashTags = itemHashTagsSelector(state);
   const tag = getTag(item, itemInfos, itemHashTags);
+  const currentFilter = searchFilterSelector(state);
+  const defaultFilterActive = currentFilter === _.stubTrue;
 
   return {
     isNew: settings.showNewItems ? state.inventory.newItems.has(item.id) : false,
@@ -46,9 +49,9 @@ function mapStateToProps(state: RootState, props: ProvidedProps): StoreProps {
     wishlistRoll: wishListSelector(item)(state),
     searchHidden:
       // dim this item if there's no search filter and it's archived
-      (searchFilterIsEmpty && tag === 'archive') ||
+      (dimArchived && defaultFilterActive && tag === 'archive') ||
       // or if there is filtering and it doesn't meet the condition
-      (props.allowFilter && !searchFilterSelector(state)(item)),
+      (props.allowFilter && !currentFilter(item)),
   };
 }
 

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -1,9 +1,6 @@
 import { Inspect } from 'app/mobile-inspect/MobileInspect';
-import { searchFilterSelector } from 'app/search/search-filter';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import _ from 'lodash';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import ConnectedInventoryItem from './ConnectedInventoryItem';
 import DraggableInventoryItem from './DraggableInventoryItem';
 import { DimItem } from './item-types';
@@ -20,7 +17,6 @@ interface Props {
  */
 export default function StoreInventoryItem({ item, isPhonePortrait }: Props) {
   const dispatch = useThunkDispatch();
-  const currentFilter = useSelector(searchFilterSelector);
   const doubleClicked = (e: React.MouseEvent) => {
     dispatch(moveItemToCurrentStore(item, e));
   };
@@ -40,8 +36,8 @@ export default function StoreInventoryItem({ item, isPhonePortrait }: Props) {
             onClick={onClick}
             onDoubleClick={doubleClicked}
             // for only StoreInventoryItems (the main inventory page)
-            // we inject a special marker for use in dimming archived items
-            searchFilterIsEmpty={currentFilter === _.stubTrue}
+            // we mark these to be dimmed if archived
+            dimArchived
           />
         )}
       </ItemPopupTrigger>

--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -1,6 +1,9 @@
 import { Inspect } from 'app/mobile-inspect/MobileInspect';
+import { searchFilterSelector } from 'app/search/search-filter';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import _ from 'lodash';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import ConnectedInventoryItem from './ConnectedInventoryItem';
 import DraggableInventoryItem from './DraggableInventoryItem';
 import { DimItem } from './item-types';
@@ -17,7 +20,7 @@ interface Props {
  */
 export default function StoreInventoryItem({ item, isPhonePortrait }: Props) {
   const dispatch = useThunkDispatch();
-
+  const currentFilter = useSelector(searchFilterSelector);
   const doubleClicked = (e: React.MouseEvent) => {
     dispatch(moveItemToCurrentStore(item, e));
   };
@@ -36,6 +39,9 @@ export default function StoreInventoryItem({ item, isPhonePortrait }: Props) {
             innerRef={ref}
             onClick={onClick}
             onDoubleClick={doubleClicked}
+            // for only StoreInventoryItems (the main inventory page)
+            // we inject a special marker for use in dimming archived items
+            searchFilterIsEmpty={currentFilter === _.stubTrue}
           />
         )}
       </ItemPopupTrigger>

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -2,8 +2,9 @@ import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
 import { errorLog } from 'app/utils/log';
+import _ from 'lodash';
 import { createSelector } from 'reselect';
-import { getTag, ItemInfos } from '../inventory/dim-item-info';
+import { ItemInfos } from '../inventory/dim-item-info';
 import { DimItem } from '../inventory/item-types';
 import {
   allItemsSelector,
@@ -89,7 +90,7 @@ function makeSearchFilterFactory(
     query = query.trim().toLowerCase();
     if (!query.length) {
       // By default, show anything that doesn't have the archive tag
-      return (item: DimItem) => getTag(item, itemInfos, itemHashTags) !== 'archive';
+      return _.stubTrue;
     }
 
     const parsedQuery = parseQuery(query);


### PR DESCRIPTION
instead of using `-is:archive` as the default filter, this makes the default filter stubTrue,
and attaches an extra check only to main inventory page items to dim them.
this fixes an annoying behavior where archived items aren't included in LO calcs, are very hard to discover on organizer, etc.