### PR TITLE
Fix crash on socket details for some masterworks

### DIFF
--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -151,7 +151,9 @@ function SocketDetails({ defs, item, socket, unlockedPlugs, inventoryPlugs, onCl
   }
 
   const initialPlugHash = socket.socketDefinition.singleInitialItemHash;
-  modHashes.add(initialPlugHash);
+  if (initialPlugHash) {
+    modHashes.add(initialPlugHash);
+  }
 
   if (
     socket.socketDefinition.plugSources & SocketPlugSources.ReusablePlugItems &&


### PR DESCRIPTION
Mentioned on Reddit - clicking the masterwork from the item popup on an IKELOS SMG would cause this crash as there is no initial plug hash.