### PR TITLE
Remove live stats calculation and stop requesting the component

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -85,7 +85,6 @@ export function getStores(
     // TODO: consider loading less item data, and then loading item details on click? Makes searches hard though.
     DestinyComponentType.ItemInstances,
     DestinyComponentType.ItemObjectives,
-    DestinyComponentType.ItemStats,
     DestinyComponentType.ItemSockets,
     DestinyComponentType.ItemTalentGrids,
     DestinyComponentType.ItemCommonData,
@@ -195,7 +194,6 @@ export async function getVendor(
       DestinyComponentType.VendorSales,
       DestinyComponentType.ItemInstances,
       DestinyComponentType.ItemObjectives,
-      DestinyComponentType.ItemStats,
       DestinyComponentType.ItemSockets,
       DestinyComponentType.ItemTalentGrids,
       DestinyComponentType.ItemCommonData,
@@ -223,7 +221,6 @@ export async function getVendors(
       DestinyComponentType.VendorSales,
       DestinyComponentType.ItemInstances,
       DestinyComponentType.ItemObjectives,
-      DestinyComponentType.ItemStats,
       DestinyComponentType.ItemSockets,
       DestinyComponentType.ItemTalentGrids,
       DestinyComponentType.ItemCommonData,

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -475,8 +475,7 @@ export function makeItem(
   }
 
   try {
-    const liveStats = itemComponents?.stats?.data?.[createdItem.id];
-    createdItem.stats = buildStats(createdItem, liveStats, itemDef, defs);
+    createdItem.stats = buildStats(createdItem, itemDef, defs);
   } catch (e) {
     errorLog('d2-stores', `Error building stats for ${createdItem.name}`, item, itemDef, e);
     reportException('Stats', e, { itemHash: item.itemHash });


### PR DESCRIPTION
Inspired by @nev-r's comment in Discord (and their great work building stats from sockets), this removes the live stats code entirely and stops even requesting the component. The only things that code was triggering for was Ghost Shells. That takes the profile response from 2.7MB (292KB compressed) to 2.5MB (272KB compressed). Not as big a win as you'd hope given that loading sockets is itself the biggest load on the B.net servers, but still a win.