### PR TITLE
Allowed energy affinity swaps from upgrade spend tier.

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -191,8 +191,9 @@ function LoadoutBuilder({
   loadouts = equippedLoadout ? [...loadouts, equippedLoadout] : loadouts;
 
   const filteredItems = useMemo(
-    () => filterItems(characterItems, lockedMap, lockedMods, lockedExotic, filter),
-    [characterItems, lockedMap, lockedMods, lockedExotic, filter]
+    () =>
+      filterItems(characterItems, lockedMap, lockedMods, lockedExotic, upgradeSpendTier, filter),
+    [characterItems, lockedMap, lockedMods, lockedExotic, upgradeSpendTier, filter]
   );
 
   const availableExotics = useMemo(() => {

--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -9,6 +9,7 @@ import {
   LockableBuckets,
   LockedItemType,
   LockedMap,
+  UpgradeSpendTier,
 } from './types';
 
 /**
@@ -19,6 +20,7 @@ export function filterItems(
   lockedMap: LockedMap,
   lockedMods: PluggableInventoryItemDefinition[],
   lockedExotic: LoadoutBuilderState['lockedExotic'],
+  upgradeSpendTier: UpgradeSpendTier,
   filter: ItemFilter
 ): ItemsByBucket {
   const filteredItems: { [bucket: number]: readonly DimItem[] } = {};
@@ -59,13 +61,15 @@ export function filterItems(
       filteredItems[bucket] = filteredItems[bucket].filter(
         (item) =>
           (!lockedExotic ||
-            (bucket === lockedExotic.bucketHash ?
-              item.hash === lockedExotic.def.hash :
-              item.equippingLabel !== lockedExotic.def.equippingBlock!.uniqueLabel)) &&
+            (bucket === lockedExotic.bucketHash
+              ? item.hash === lockedExotic.def.hash
+              : item.equippingLabel !== lockedExotic.def.equippingBlock!.uniqueLabel)) &&
           // handle locked items and mods cases
           (!locked || locked.every((lockedItem) => matchLockedItem(item, lockedItem))) &&
           (!lockedModsByPlugCategoryHash ||
-            lockedModsByPlugCategoryHash.every((mod) => doEnergiesMatch(mod, item)))
+            lockedModsByPlugCategoryHash.every((mod) =>
+              doEnergiesMatch(mod, item, upgradeSpendTier)
+            ))
       );
     }
   });

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -106,6 +106,11 @@ function getEnergyCounts(modsOrItems: (ProcessMod | null | ProcessItemSubset)[])
       case DestinyEnergyType.Void:
         voidCount += 1;
         break;
+      case DestinyEnergyType.Any:
+        arcCount += 1;
+        solarCount += 1;
+        voidCount += 1;
+        break;
       default:
         break;
     }
@@ -175,7 +180,9 @@ export function canTakeSlotIndependantMods(
       const otherEnergyIsValid =
         item.energy &&
         item.energy.val + otherEnergy.val <= item.energy.capacity &&
-        (item.energy.type === otherEnergy.type || otherEnergy.type === DestinyEnergyType.Any);
+        (item.energy.type === otherEnergy.type ||
+          otherEnergy.type === DestinyEnergyType.Any ||
+          item.energy.type === DestinyEnergyType.Any);
 
       // The other mods wont fit in the item set so move on to the next set of mods
       if (!(otherEnergyIsValid && item.compatibleModSeasons?.includes(tag))) {
@@ -199,7 +206,9 @@ export function canTakeSlotIndependantMods(
         const generalEnergyIsValid =
           item.energy &&
           item.energy.val + generalEnergy.val + otherEnergy.val <= item.energy.capacity &&
-          (item.energy.type === generalEnergy.type || generalEnergy.type === DestinyEnergyType.Any);
+          (item.energy.type === generalEnergy.type ||
+            generalEnergy.type === DestinyEnergyType.Any ||
+            item.energy.type === DestinyEnergyType.Any);
 
         // The general mods wont fit in the item set so move on to the next set of mods
         if (!generalEnergyIsValid) {
@@ -226,7 +235,9 @@ export function canTakeSlotIndependantMods(
             item.energy &&
             item.energy.val + generalEnergy.val + otherEnergy.val + raidEnergy.val <=
               item.energy.capacity &&
-            (item.energy.type === raidEnergy.type || raidEnergy.type === DestinyEnergyType.Any);
+            (item.energy.type === raidEnergy.type ||
+              raidEnergy.type === DestinyEnergyType.Any ||
+              item.energy.type === DestinyEnergyType.Any);
 
           // Due to raid mods overlapping with legacy mods for last wish we need to ensure
           // that if an item has a legacy mod socket then another mod is not already intended

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -15,7 +15,7 @@ import {
 } from '../../utils/item-utils';
 import { ProcessArmorSet, ProcessItem, ProcessMod } from '../process-worker/types';
 import { ArmorSet, statHashToType, StatTypes, UpgradeSpendTier } from '../types';
-import { upgradeSpendTierToMaxEnergy } from '../utils';
+import { canSwapEnergyFromUpgradeSpendTier, upgradeSpendTierToMaxEnergy } from '../utils';
 
 export function mapArmor2ModToProcessMod(mod: PluggableInventoryItemDefinition): ProcessMod {
   const processMod: ProcessMod = {
@@ -140,7 +140,9 @@ export function mapDimItemToProcessItem(
     baseStats: baseStatMap,
     energy: energy
       ? {
-          type: energy.energyType,
+          type: canSwapEnergyFromUpgradeSpendTier(upgradeSpendTier, dimItem)
+            ? DestinyEnergyType.Any
+            : energy.energyType,
           capacity: upgradeSpendTierToMaxEnergy(upgradeSpendTier, dimItem),
           val: modsCost,
         }

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -75,9 +75,7 @@ export function getPower(items: DimItem[] | ProcessItem[]) {
   return Math.floor(power / numPoweredItems);
 }
 
-/** Gets the max energy allowed from the passed in UpgradeSpendTier */
-export function upgradeSpendTierToMaxEnergy(tier: UpgradeSpendTier, item: DimItem) {
-  const available = item.energy?.energyCapacity;
+function getMaxEnergyFromUpgradeSpendTier(tier: UpgradeSpendTier, item: DimItem) {
   const isExotic = Boolean(item.equippingLabel);
   if (available === undefined) {
     return 0;
@@ -85,15 +83,25 @@ export function upgradeSpendTierToMaxEnergy(tier: UpgradeSpendTier, item: DimIte
 
   switch (tier) {
     case UpgradeSpendTier.LegendaryShards:
-      return Math.max(7, available);
+      return 7;
     case UpgradeSpendTier.EnhancementPrisms:
-      return Math.max(isExotic ? 8 : 9, available);
+      return isExotic ? 8 : 9;
     case UpgradeSpendTier.AscendantShardsNotExotic:
-      return Math.max(isExotic ? 8 : 10, available);
+      return isExotic ? 8 : 10;
     case UpgradeSpendTier.AscendantShards:
       return 10;
     case UpgradeSpendTier.Nothing:
     default:
-      return available;
+      return 0;
   }
+}
+
+/** Gets the max energy allowed from the passed in UpgradeSpendTier */
+export function upgradeSpendTierToMaxEnergy(tier: UpgradeSpendTier, item: DimItem) {
+  return Math.max(item.energy?.energyCapacity || 0, getMaxEnergyFromUpgradeSpendTier(tier, item));
+}
+
+/** Figures out whether you can swap energies in the allowed spend tier. */
+export function canSwapEnergyFromUpgradeSpendTier(tier: UpgradeSpendTier, item: DimItem) {
+  return getMaxEnergyFromUpgradeSpendTier(tier, item) <= item.energy?.energyCapacity || 0;
 }

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -77,9 +77,6 @@ export function getPower(items: DimItem[] | ProcessItem[]) {
 
 function getMaxEnergyFromUpgradeSpendTier(tier: UpgradeSpendTier, item: DimItem) {
   const isExotic = Boolean(item.equippingLabel);
-  if (available === undefined) {
-    return 0;
-  }
 
   switch (tier) {
     case UpgradeSpendTier.LegendaryShards:
@@ -103,5 +100,5 @@ export function upgradeSpendTierToMaxEnergy(tier: UpgradeSpendTier, item: DimIte
 
 /** Figures out whether you can swap energies in the allowed spend tier. */
 export function canSwapEnergyFromUpgradeSpendTier(tier: UpgradeSpendTier, item: DimItem) {
-  return getMaxEnergyFromUpgradeSpendTier(tier, item) <= item.energy?.energyCapacity || 0;
+  return (item.energy?.energyCapacity || 0) <= getMaxEnergyFromUpgradeSpendTier(tier, item);
 }


### PR DESCRIPTION
Kept this as a seperate PR to making reviewing easier and because I expect there will be discussion on whether we want to either seperate these concerns into seperate selects or add more items to the single select. 

The way I see it people may be willing to upgrade armour all the way to masterworked, but they won't want to change already masterworked armour (I personally fall into this category).

This just allows energy type changes based on the upgrade spend tier selected. So if an items energy capacity is less than or equal to the energy identified by the material spend, we will allow energy swaps. It's pretty easy to add to depending on what we decide.