### PR TITLE
Better title for replaced items in RichDestinyText

### DIFF
--- a/src/app/dim-ui/RichDestinyText.tsx
+++ b/src/app/dim-ui/RichDestinyText.tsx
@@ -155,7 +155,12 @@ function replaceWithIcon(textSegment: string, index: number) {
   );
   return (
     (replacement && (
-      <img src={replacement.icon} className={styles.inlineSvg} title={textSegment} key={index} />
+      <img
+        src={replacement.icon}
+        className={styles.inlineSvg}
+        title={replacement.substring}
+        key={index}
+      />
     )) || <span key={textSegment}>{textSegment}</span>
   );
 }


### PR DESCRIPTION
Fixes #6760

<img width="396" alt="Screen Shot 2021-06-01 at 9 48 06 PM" src="https://user-images.githubusercontent.com/313208/120425174-96b9de80-c322-11eb-949c-19c78c37afb9.png">
