### PR TITLE
some artifact vendor display fixes

### DIFF
--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -21,6 +21,10 @@ const itemSort = chainComparator<VendorItem>(
   compareBy((item) => item.item?.name)
 );
 
+// ignore what i think is the loot pool preview on some tower vendors?
+// ignore the "reset artifact" button on artifact "vendor"
+const ignoreCategories = ['category_preview', 'category_reset'];
+
 /**
  * Display the items for a single vendor, organized by category.
  */
@@ -119,7 +123,7 @@ export default function VendorItems({
           itemsByCategory,
           (items, categoryIndex) =>
             vendor.def.displayCategories[categoryIndex] &&
-            vendor.def.displayCategories[categoryIndex].identifier !== 'category_preview' && (
+            !ignoreCategories.includes(vendor.def.displayCategories[categoryIndex].identifier) && (
               <div className={styles.vendorRow} key={categoryIndex}>
                 <h3 className={styles.categoryTitle}>
                   {vendor.def.displayCategories[categoryIndex]?.displayProperties.name || 'Unknown'}


### PR DESCRIPTION
addresses #6838 in part, but not everything i want yet..

the manifest is a mess as usual. artifact vendor's had the wrong display props since artifacts were invented. DestinyArtifactDefinition must have updated at some point but it now frozen at Beyond Light's artifact. all the InventoryItems are left over still, but they link only to the same repeatedly overwritten hash..

this cheats to give the vendor preview page better display properties by searching all items, to find an artifact with the current season's hash. from what i can tell that is set correctly on all of them. this also hides the Reset Artifact button (by skipping its vendor item category)