### PR TITLE
Organizer : New column to support sorting gear in Organizer by acquisition recency.

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -714,7 +714,8 @@
       "Notes": "Notes",
       "WishListNotes": "Wish List Notes",
       "Ghost": "Ghost Tag",
-      "New": "New"
+      "New": "New",
+      "Recency": "Recency"
     },
     "Stats": {
       "RPM": "RPM",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Added "Recency" Column & Sorting to Loadout Organizer, this allows viewing gear sorted by acquisition date.
 
 ## 6.68.0 <span class="changelog-date">(2021-06-06)</span>
 

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -88,8 +88,7 @@ export function getColumns(
   customTotalStat: number[],
   loadouts: Loadout[],
   newItems: Set<string>,
-  destinyVersion: DestinyVersion,
-  recencyIndicies: Map<string, number>
+  destinyVersion: DestinyVersion
 ): ColumnDefinition[] {
   const statsGroup: ColumnGroup = {
     id: 'stats',
@@ -279,7 +278,8 @@ export function getColumns(
     {
       id: 'recency',
       header: t('Organizer.Columns.Recency'),
-      value: (item) => recencyIndicies.get(item.id),
+      value: (item) => item.id,
+      cell: () => '',
     },
     destinyVersion === 2 &&
       isWeapon && {

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -88,7 +88,8 @@ export function getColumns(
   customTotalStat: number[],
   loadouts: Loadout[],
   newItems: Set<string>,
-  destinyVersion: DestinyVersion
+  destinyVersion: DestinyVersion,
+  recencyIndicies: Map<string, number>
 ): ColumnDefinition[] {
   const statsGroup: ColumnGroup = {
     id: 'stats',
@@ -274,6 +275,11 @@ export function getColumns(
       cell: (value) => (value ? <NewItemIndicator /> : undefined),
       defaultSort: SortDirection.DESC,
       filter: (value) => (value ? 'is:new' : 'not:new'),
+    },
+    {
+      id: 'recency',
+      header: t('Organizer.Columns.Recency'),
+      value: (item) => recencyIndicies.get(item.id),
     },
     destinyVersion === 2 &&
       isWeapon && {

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -179,6 +179,16 @@ function ItemTable({
     [terminal, items]
   );
 
+  const recencyIndicies: Map<string, number> = useMemo(
+    () =>
+      new Map<string, number>(
+        items
+          .sort(compareBy((item: DimItem) => BigInt(item.id)))
+          .map((item: DimItem, index) => [item.id, index + 1] as [string, number])
+      ),
+    [items]
+  );
+
   const firstCategory = categories[1];
   const isWeapon = Boolean(firstCategory?.itemCategoryHash === ItemCategoryHashes.Weapon);
   const isGhost = Boolean(firstCategory?.itemCategoryHash === ItemCategoryHashes.Ghost);
@@ -198,7 +208,8 @@ function ItemTable({
         customStatTotal,
         loadouts,
         newItems,
-        destinyVersion
+        destinyVersion,
+        recencyIndicies
       ),
     [
       wishList,
@@ -211,6 +222,7 @@ function ItemTable({
       loadouts,
       newItems,
       destinyVersion,
+      recencyIndicies,
     ]
   );
 

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -179,16 +179,6 @@ function ItemTable({
     [terminal, items]
   );
 
-  const recencyIndicies: Map<string, number> = useMemo(
-    () =>
-      new Map<string, number>(
-        items
-          .sort(compareBy((item: DimItem) => BigInt(item.id)))
-          .map((item: DimItem, index) => [item.id, index + 1] as [string, number])
-      ),
-    [items]
-  );
-
   const firstCategory = categories[1];
   const isWeapon = Boolean(firstCategory?.itemCategoryHash === ItemCategoryHashes.Weapon);
   const isGhost = Boolean(firstCategory?.itemCategoryHash === ItemCategoryHashes.Ghost);
@@ -208,8 +198,7 @@ function ItemTable({
         customStatTotal,
         loadouts,
         newItems,
-        destinyVersion,
-        recencyIndicies
+        destinyVersion
       ),
     [
       wishList,
@@ -222,7 +211,6 @@ function ItemTable({
       loadouts,
       newItems,
       destinyVersion,
-      recencyIndicies,
     ]
   );
 


### PR DESCRIPTION
Addresses Issue #6722

 - Added additional column to support sorting by gear acquisition recency.
 - Added logic to calculate "Recency Index", this value determines acquisition recency relative to other gear. Smaller the recency index, the older the item.
 - Updated i18n with "Recency" addition.
 - Updated Changelog

It's worth noting I made some assumptions in this implementation. Initially I was going to implement a blank column, but I felt this was difficult to understand, so I took the liberty of implementing a "recency index". This index will give a representation of acquisition recency relative to other items in the list. 

I'm thinking this implementation can be improved if we ever get the ability to more determine a firm date, via the API or some other means.

I'm also thinking a "Recency Index" may be useful outside of the organizer. I was thinking it could be calculated when retrieving gear and stored as a property on DIMItems. This would allow display / filtering / sorting outside of the organizer. 

Demo:
![DIMRecencySort](https://user-images.githubusercontent.com/6667803/121780164-0e93ce80-cb97-11eb-82b3-b3ecdb82915c.gif)
