### PR TITLE
minor fixes

### DIFF
--- a/src/app/item-popup/ItemDescription.tsx
+++ b/src/app/item-popup/ItemDescription.tsx
@@ -11,11 +11,7 @@ import ishtarLogo from '../../images/ishtar-collective.svg';
 import styles from './ItemDescription.m.scss';
 import NotesArea from './NotesArea';
 
-interface Props {
-  item: DimItem;
-}
-
-export default function ItemDescription({ item }: Props) {
+export default function ItemDescription({ item }: { item: DimItem }) {
   const wishlistItem = useSelector(wishListSelector(item));
 
   // suppressing some unnecessary information for weapons and armor,

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -355,20 +355,24 @@ export function getColumns(
         id: 'archetype',
         header: t('Organizer.Columns.Archetype'),
         value: (item) => getWeaponArchetype(item)?.displayProperties.name,
-        cell: (_val, item) => (
-          <div>
-            {_.compact([getWeaponArchetypeSocket(item)?.plugged]).map((p) => (
-              <PressTip key={p.plugDef.hash} tooltip={<PlugTooltip item={item} plug={p} />}>
+        cell: (_val, item) => {
+          const plugged = getWeaponArchetypeSocket(item)?.plugged;
+          return (
+            plugged && (
+              <PressTip
+                key={plugged.plugDef.hash}
+                tooltip={<PlugTooltip item={item} plug={plugged} />}
+              >
                 <div className={styles.modPerk}>
                   <div className={styles.miniPerkContainer}>
-                    <DefItemIcon itemDef={p.plugDef} borderless={true} />
+                    <DefItemIcon itemDef={plugged.plugDef} borderless={true} />
                   </div>{' '}
-                  {p.plugDef.displayProperties.name}
+                  {plugged.plugDef.displayProperties.name}
                 </div>
               </PressTip>
-            ))}
-          </div>
-        ),
+            )
+          );
+        },
         filter: (value) => `perkname:"${value}"`,
       },
     (destinyVersion === 2 || isWeapon) && {
@@ -475,13 +479,8 @@ export function getColumns(
       cell: (_val, item) => {
         const inloadouts = loadouts.filter((l) => l.items.some((i) => i.id === item.id));
         return (
-          inloadouts.length > 0 && (
-            <div>
-              {inloadouts.map((loadout) => (
-                <div key={loadout.id}>{loadout.name}</div>
-              ))}
-            </div>
-          )
+          inloadouts.length > 0 &&
+          inloadouts.map((loadout) => <div key={loadout.id}>{loadout.name}</div>)
         );
       },
       noSort: true,

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -263,9 +263,7 @@ $modslotSize: 30px;
 
 .loadouts {
   > div {
-    > div {
-      white-space: nowrap;
-    }
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
undo an unnecessary prop separation in itemdescription

remove some extraneous div wrappers in organizer column render methods
(valid output is anything that can be react child content, including arrays)