### PR TITLE
Fix for missing i18n String for "Recency Sort"

### DIFF
--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -641,6 +641,7 @@
       "Perks": "Perks",
       "PerksMods": "Perks, Mods & Shaders",
       "Quality": "Quality %",
+      "Recency": "Recency",
       "Season": "Season",
       "Source": "Source",
       "StatQuality": "Stat Quality",


### PR DESCRIPTION
Missed dim.json changes in original PR

Related https://github.com/DestinyItemManager/DIM/pull/6840