### PR TITLE
Default to similar loadout as comparison base in Loadout Optimizer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Default to similar loadout as comparison base in Loadout Optimizer.
+
 ## 6.70.0 <span class="changelog-date">(2021-06-23)</span>
 
 * Fixed an issue where unwanted energy swaps were happening in the Optimizer.

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -75,6 +75,17 @@ function mapStateToProps() {
   });
 }
 
+function chooseSimilarLoadout(
+  setItems: DimItem[],
+  useableLoadouts: Loadout[]
+): Loadout | undefined {
+  const exotic = setItems.find((i) => i.equippingLabel);
+  return (
+    (exotic && useableLoadouts.find((l) => l.items.some((i) => i.hash === exotic.hash))) ||
+    (useableLoadouts.length ? useableLoadouts[0] : undefined)
+  );
+}
+
 function CompareDrawer({
   characterClass,
   loadouts,
@@ -91,11 +102,11 @@ function CompareDrawer({
   const defs = useD2Definitions()!;
   const useableLoadouts = loadouts.filter((l) => l.classType === classType);
 
-  const [selectedLoadout, setSelectedLoadout] = useState<Loadout | undefined>(
-    useableLoadouts.length ? useableLoadouts[0] : undefined
-  );
-
   const setItems = set.armor.map((items) => items[0]);
+
+  const [selectedLoadout, setSelectedLoadout] = useState<Loadout | undefined>(
+    chooseSimilarLoadout(setItems, useableLoadouts)
+  );
 
   // This probably isn't needed but I am being cautious as it iterates over the stores.
   const loadoutItems = useMemo(() => {


### PR DESCRIPTION
This makes it so that when I optimize, say, an Ophidian Aspect loadout and press the "Compare Loadout" button, the comparison drawer will try to find an existing loadout with Ophidian Aspect and compare against that instead of using an arbitrary loadout as comparison base.