### PR TITLE
Fixed issue where locked mods were not being applied to the compared loadout in optimiser.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Default to similar loadout as comparison base in Loadout Optimizer.
 * Armor upgrades in the Optimizer have full descriptions of their functionality. Added Ascendant Shard 'Not Masterworked' and 'Lock Energy Type' options.
 * In the Exotic Selector, the currently selected exotic is now highlighted.
+* Fixed issue with locked mod stats not being applied to a compared loadouts in the Optimizer.
 
 ## 6.70.0 <span class="changelog-date">(2021-06-23)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## Next
 
+* Fixed issue with locked mod stats not being applied to a compared loadouts in the Optimizer.
+
 ## 6.71.0 <span class="changelog-date">(2021-06-27)</span>
 
 * Armor 1 exotics are visible in the exotic picker, albeit unselectable.
 * Default to similar loadout as comparison base in Loadout Optimizer.
 * Armor upgrades in the Optimizer have full descriptions of their functionality. Added Ascendant Shard 'Not Masterworked' and 'Lock Energy Type' options.
 * In the Exotic Selector, the currently selected exotic is now highlighted.
-* Fixed issue with locked mod stats not being applied to a compared loadouts in the Optimizer.
 
 ## 6.70.0 <span class="changelog-date">(2021-06-23)</span>
 

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -129,7 +129,7 @@ function CompareDrawer({
     }
   }
 
-  const lockedModStats = getTotalModStatChanges(lockedMods);
+  const lockedModStats = getTotalModStatChanges(lockedMods, characterClass);
 
   for (const statType of statKeys) {
     loadoutStats[statType] += lockedModStats[statType];

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -84,7 +84,7 @@ function isModStatActive(
  */
 export function getTotalModStatChanges(
   lockedMods: PluggableInventoryItemDefinition[],
-  characterClass?: DestinyClass
+  characterClass: DestinyClass | undefined
 ) {
   const totals: { [stat in StatTypes]: number } = {
     Mobility: 0,


### PR DESCRIPTION
<img width="871" alt="Screen Shot 2021-06-27 at 9 24 20 pm" src="https://user-images.githubusercontent.com/7344652/123542755-b364fd00-d78e-11eb-960a-aa74c14f0a6e.png">


Fixes #6871 