### PR TITLE
add flavor text for solstice Pursuits

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Solstice of Heroes pursuit list now shows the full description of the objectives, not just the checkboxes.
+
 ## 6.72.1 <span class="changelog-date">(2021-07-06)</span>
 
 * Solstice of Heroes is back and so is the **Solstice of Heroes** section of the **Progress** tab. Check it out and view your progress toward upgrading armor.

--- a/src/app/progress/SolsticeOfHeroes.tsx
+++ b/src/app/progress/SolsticeOfHeroes.tsx
@@ -4,6 +4,7 @@ import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { getEvent, getSeason } from 'app/inventory/store/season';
+import { useD2Definitions } from 'app/manifest/selectors';
 import { D2EventEnum } from 'data/d2/d2-event-info';
 import _ from 'lodash';
 import React from 'react';
@@ -15,6 +16,7 @@ import './SolsticeOfHeroes.scss';
  * List out all the Pursuits for the character, grouped out in a useful way.
  */
 export default function SolsticeOfHeroes({ armor, title }: { title: string; armor: DimItem[] }) {
+  const defs = useD2Definitions()!;
   if (!armor.length) {
     return null;
   }
@@ -25,14 +27,17 @@ export default function SolsticeOfHeroes({ armor, title }: { title: string; armo
         <div className="progress-row">
           <ErrorBoundary name="Solstice">
             <div className="progress-for-character">
-              {armor.map((item) => (
-                <div key={item.id} className="solsticeProgressBox">
-                  <Pursuit item={item} key={item.index} />
-                  {item.objectives?.map((objective) => (
-                    <Objective objective={objective} key={objective.objectiveHash} />
-                  ))}
-                </div>
-              ))}
+              {armor.map((item) => {
+                const description = defs.InventoryItem.get(item.hash).flavorText;
+                return (
+                  <div key={item.id} className="solsticeProgressBox">
+                    <Pursuit item={{ ...item, description }} key={item.index} />
+                    {item.objectives?.map((objective) => (
+                      <Objective objective={objective} key={objective.objectiveHash} />
+                    ))}
+                  </div>
+                );
+              })}
             </div>
           </ErrorBoundary>
         </div>


### PR DESCRIPTION
minorly adjust the DimItem of solstice Pursuits, because unfortunately the flavorText is more descriptive and helpful than the Objective blurbs.
it's a little wordy but imo, useful. shimming in the replacement property is *slightly* weird but i am trying to keep changes isolated inside solstice components

before:
![image](https://user-images.githubusercontent.com/68782081/124736036-79e96b80-decb-11eb-93b9-f6d865740857.png)

after:
![image](https://user-images.githubusercontent.com/68782081/124736092-879ef100-decb-11eb-9c08-032b80f6b043.png)
