### PR TITLE
set store.hadErrors only when important items fail

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -344,7 +344,6 @@ function processCharacter(
     uninstancedItemObjectives
   );
   store.items = processedItems;
-  store.hadErrors = items.length !== processedItems.length;
   return store;
 }
 
@@ -381,7 +380,7 @@ function processVault(
     mergedCollectibles
   );
   store.items = processedItems;
-  store.hadErrors = items.length !== processedItems.length;
+
   return store;
 }
 

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -172,5 +172,7 @@ export function getNotes(
 }
 
 /** given an item, returns a selector which monitors that item's notes */
-export const itemNoteSelector = (item: DimItem) => (state: RootState): string | undefined =>
-  getNotes(item, itemInfosSelector(state), itemHashTagsSelector(state));
+export const itemNoteSelector =
+  (item: DimItem) =>
+  (state: RootState): string | undefined =>
+    getNotes(item, itemInfosSelector(state), itemHashTagsSelector(state));


### PR DESCRIPTION
tags weren't getting pruned because stores are really frequently in hadError status