### PR TITLE
Remove shaders from known inventory buckets

### DIFF
--- a/src/app/destiny2/d2-bucket-categories.ts
+++ b/src/app/destiny2/d2-bucket-categories.ts
@@ -12,5 +12,5 @@ export const D2Categories = {
     'SeasonalArtifacts',
     'ClanBanners',
   ],
-  Inventory: ['Consumables', 'Modifications', 'Shaders'],
+  Inventory: ['Consumables', 'Modifications'],
 };

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -104,7 +104,6 @@ Array [
   "seasonalartifacts",
   "seasonaldupe",
   "shaded",
-  "shaders",
   "ships",
   "shotgun",
   "sidearm",


### PR DESCRIPTION
Their bucket is gone, but it's still listed in categories.