### PR TITLE
Limit currencies to a handpicked list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Solstice of Heroes pursuit list now shows the full description of the objectives, not just the checkboxes.
+* Armor synthesis materials are no longer shown in the currencies block under the vault.
 
 ## 6.72.1 <span class="changelog-date">(2021-07-06)</span>
 

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -49,8 +49,18 @@ export const currentStoreSelector = (state: RootState) => getCurrentStore(stores
 /** The vault */
 export const vaultSelector = (state: RootState) => getVault(storesSelector(state));
 
+const visibleCurrencies = [
+  3159615086, // Glimmer
+  1022552290, // Legendary Shards
+  2817410917, // Bright Dust
+  3147280338, // Silver
+];
+
 /** Account wide currencies */
-export const currenciesSelector = (state: RootState) => state.inventory.currencies;
+export const currenciesSelector = createSelector(
+  (state: RootState) => state.inventory.currencies,
+  (currencies) => currencies.filter((c) => visibleCurrencies.includes(c.itemHash))
+);
 
 /** materials/currencies that aren't top level stuff */
 export const materialsSelector = (state: RootState) =>

--- a/src/app/store-stats/AccountCurrencies.tsx
+++ b/src/app/store-stats/AccountCurrencies.tsx
@@ -5,50 +5,33 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import styles from './AccountCurrencies.m.scss';
 
-// TO-DO: top level currency display should really be a handpicked list, not
-// a naive echo of whatever the API decides is a currency
-const synthCurrencies = [
-  1583786617, // InventoryItem "Synthweave Template"
-  3107195131, // InventoryItem "Sleek Synthcord"
-  3552107018, // InventoryItem "Plush Synthcord"
-  3855200273, // InventoryItem "Rigid Synthcord"
-  3905974032, // InventoryItem "Synthstrand"
-  1498161294, // InventoryItem "Synthweave Bolt"
-  4019412287, // InventoryItem "Synthweave Strap"
-  4238733045, // InventoryItem "Synthweave Plate"
-];
-
 /** The account currencies (glimmer, shards, etc.) */
 export default React.memo(function AccountCurrency() {
   const currencies = useSelector(currenciesSelector);
-  const [synth, other] = _.partition(currencies, (c) => synthCurrencies.includes(c.itemHash));
   return (
     <>
-      {[other, synth].map(
-        (currencyGroup, ci) =>
-          currencyGroup.length > 0 && (
-            <React.Fragment key={currencyGroup.map((c) => c.itemHash).join()}>
-              {currencyGroup.map((currency) => (
-                <React.Fragment key={currency.itemHash}>
-                  <BungieImage
-                    className={styles.currency}
-                    src={currency.displayProperties.icon}
-                    title={currency.displayProperties.name}
-                  />
-                  <div className={styles.currency} title={currency.displayProperties.name}>
-                    {currency.quantity.toLocaleString()}
-                  </div>
-                </React.Fragment>
-              ))}
-              {/* add 0-3 blank slots to keep each currencyGroup rounded to a multiple of 4 (for css grid) */}
-              {_.times((4 - (currencyGroup.length % 4)) % 4, (i) => (
-                <React.Fragment key={`${ci}-${i}`}>
-                  <div />
-                  <div />
-                </React.Fragment>
-              ))}
+      {currencies.length > 0 && (
+        <React.Fragment key={currencies.map((c) => c.itemHash).join()}>
+          {currencies.map((currency) => (
+            <React.Fragment key={currency.itemHash}>
+              <BungieImage
+                className={styles.currency}
+                src={currency.displayProperties.icon}
+                title={currency.displayProperties.name}
+              />
+              <div className={styles.currency} title={currency.displayProperties.name}>
+                {currency.quantity.toLocaleString()}
+              </div>
             </React.Fragment>
-          )
+          ))}
+          {/* add 0-3 blank slots to keep each currencyGroup rounded to a multiple of 4 (for css grid) */}
+          {_.times((4 - (currencies.length % 4)) % 4, (i) => (
+            <React.Fragment key={i}>
+              <div />
+              <div />
+            </React.Fragment>
+          ))}
+        </React.Fragment>
       )}
     </>
   );


### PR DESCRIPTION
I don't think we need to show the synthesis materials all the time. This makes the header return to a nice, consistent size.