### PR TITLE
Tighten up search dispatch

### DIFF
--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -254,9 +254,12 @@ function SearchBar(
     initialIsOpen: isPhonePortrait && mainSearchBar,
     defaultHighlightedIndex: liveQuery ? 0 : -1,
     itemToString: (i) => i?.query || '',
-    onInputValueChange: ({ inputValue }) => {
+    onInputValueChange: ({ inputValue, type }) => {
       setLiveQuery(inputValue || '');
       debouncedUpdateQuery(inputValue || '');
+      if (type !== useCombobox.stateChangeTypes.InputChange) {
+        debouncedUpdateQuery.flush();
+      }
     },
   });
 
@@ -293,10 +296,9 @@ function SearchBar(
   };
 
   const clearFilter = useCallback(() => {
-    debouncedUpdateQuery('');
     reset();
     onClear?.();
-  }, [onClear, reset, debouncedUpdateQuery]);
+  }, [onClear, reset]);
 
   // Reset live query when search version changes
   useEffect(() => {


### PR DESCRIPTION
I noticed that we were delaying applying searches a lot because of the debouncer (which is still needed for typing until React Concurrent launches...) plus sometimes we were updating the query twice, like when you clear the search. This tightens things up and dispatches actions much more quickly for things like selecting from the search dropdown and clearing the search.