### PR TITLE
Work around safari/popper bug for dropdowns in search header

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Display the energy swap or upgrade details for items in the Optimiser.
 * Optimiser is now better at matching a set to an existing loadout.
+* Fixed the search actions (three dots) menu not appearing in Safari.
 
 ## 6.74.0 <span class="changelog-date">(2021-07-18)</span>
 

--- a/src/app/dim-ui/Dropdown.m.scss
+++ b/src/app/dim-ui/Dropdown.m.scss
@@ -19,6 +19,7 @@
   align-items: center;
   min-width: 10em;
   padding: 6px 9px;
+  white-space: nowrap;
   @include phone-portrait {
     padding: 10px 16px;
     font-size: 14px;

--- a/src/app/dim-ui/Dropdown.tsx
+++ b/src/app/dim-ui/Dropdown.tsx
@@ -28,6 +28,7 @@ interface Props {
   disabled?: boolean;
   options: Option[];
   offset?: number;
+  fixed?: boolean;
 }
 
 function isDropdownOption(option: Option): option is DropdownOption {
@@ -49,6 +50,7 @@ export default function Dropdown({
   disabled,
   options: items,
   offset,
+  fixed,
 }: Props) {
   const { isOpen, getToggleButtonProps, getMenuProps, highlightedIndex, getItemProps } = useSelect({
     items,
@@ -63,6 +65,7 @@ export default function Dropdown({
     reference: buttonRef,
     placement: 'bottom-start',
     offset,
+    fixed,
   });
 
   return (

--- a/src/app/dim-ui/usePopper.ts
+++ b/src/app/dim-ui/usePopper.ts
@@ -32,7 +32,8 @@ const popperOptions = (
   placement: Options['placement'] = 'auto',
   arrowClassName?: string,
   boundarySelector?: string,
-  offset = arrowClassName ? 5 : 0
+  offset = arrowClassName ? 5 : 0,
+  fixed = false
 ): Partial<Options> => {
   const headerHeight = parseInt(
     document.querySelector('html')!.style.getPropertyValue('--header-height')!,
@@ -47,6 +48,7 @@ const popperOptions = (
   };
   const hasArrow = Boolean(arrowClassName);
   return {
+    strategy: fixed ? 'fixed' : 'absolute',
     placement,
     modifiers: _.compact([
       {
@@ -88,6 +90,7 @@ export function usePopper({
   boundarySelector,
   placement,
   offset,
+  fixed,
 }: {
   /** A ref to the rendered contents of a popper-positioned item */
   contents: React.RefObject<HTMLElement>;
@@ -101,6 +104,8 @@ export function usePopper({
   placement?: Placement;
   /** Offset of how far from the element to shift the popper. */
   offset?: number;
+  /** Is this placed on a fixed item? Workaround for https://github.com/popperjs/popper-core/issues/1156. TODO: make a "positioning context" context value for this */
+  fixed?: boolean;
 }) {
   const popper = useRef<Instance | undefined>();
 
@@ -120,7 +125,7 @@ export function usePopper({
       if (popper.current) {
         popper.current.update();
       } else {
-        const options = popperOptions(placement, arrowClassName, boundarySelector, offset);
+        const options = popperOptions(placement, arrowClassName, boundarySelector, offset, fixed);
         popper.current = createPopper(reference.current, contents.current, options);
         popper.current.update();
         setTimeout(() => popper.current?.update(), 0); // helps fix arrow position

--- a/src/app/item-actions/ItemActionsDropdown.tsx
+++ b/src/app/item-actions/ItemActionsDropdown.tsx
@@ -29,6 +29,7 @@ interface ProvidedProps {
   searchQuery: string;
   filteredItems: DimItem[];
   searchActive: boolean;
+  fixed?: boolean;
 }
 
 interface StoreProps {
@@ -54,6 +55,7 @@ function ItemActionsDropdown({
   isPhonePortrait,
   filteredItems,
   searchQuery,
+  fixed,
   dispatch,
 }: Props) {
   let isComparable = false;
@@ -179,6 +181,7 @@ function ItemActionsDropdown({
       kebab={true}
       className={styles.dropdownButton}
       offset={isPhonePortrait ? 10 : 3}
+      fixed={fixed}
     />
   );
 }

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -96,6 +96,7 @@ function MainSearchBarActions({
             filteredItems={filteredItems}
             searchActive={showSearchCount}
             searchQuery={searchQuery}
+            fixed={true}
           />
         </motion.div>
       )}


### PR DESCRIPTION
This fixes an issue where the dropdown for search actions no longer appeared on Safari. This is caused by the CSS transform applied by framer-motion to the dropdown button's containing div, which through some combo of browser bugs and maybe Popper trying to work around browser bugs meant the transform of the dropdown was calculated improperly.

Really wish the web just had a native way to position items relative to other items.