### PR TITLE
Show badge on app icon for postmaster items

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -772,6 +772,8 @@
     "Title": "Search History"
   },
   "Settings": {
+    "BadgePostmaster": "Show the number of postmaster items for the current character on app icon",
+    "BadgePostmasterExplanation": "For this to work you must install DIM as an app and your OS must support displaying badges",
     "CharacterOrder": "Sort characters by",
     "CharacterOrderFixed": "Character age (buggy on PC)",
     "CharacterOrderRecent": "Most recent character",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Legendary Marks and Silver once again appear in the D1 inventory view.
 * Tap/hover the Artifact power level in the header, to check XP progress towards the next level.
+* When you install DIM on your desktop or home screen, it will now be badged with the number of postmaster items on the current character. You can disable this from Settings. This won't work on iOS.
 
 ## 6.75.0 <span class="changelog-date">(2021-07-25)</span>
 

--- a/src/app/loadout-drawer/postmaster.ts
+++ b/src/app/loadout-drawer/postmaster.ts
@@ -119,7 +119,6 @@ export function postmasterSpaceUsed(store: DimStore) {
   return POSTMASTER_SIZE - postmasterSpaceLeft(store);
 }
 
-// to-do: either typing is wrong and this can return undefined, or this doesn't need &&s and ?.s
 export function totalPostmasterItems(store: DimStore) {
   return findItemsByBucket(store, BucketHashes.LostItems).length;
 }

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -139,6 +139,13 @@ function SettingsPage({ settings, storesLoaded, stores, currentAccount, dispatch
     }
   };
 
+  const onBadgePostmasterChanged = (checked: boolean, name: keyof Settings) => {
+    if (!checked && 'setAppBadge' in navigator) {
+      navigator.clearAppBadge();
+    }
+    onCheckChange(checked, name);
+  };
+
   const changeLanguage = (e: React.ChangeEvent<HTMLSelectElement>) => {
     languageChanged = true;
     const language = e.target.value;
@@ -420,6 +427,15 @@ function SettingsPage({ settings, storesLoaded, stores, currentAccount, dispatch
                 onChange={onChange}
               />
             )}
+            <div className="setting">
+              <Checkbox
+                label={t('Settings.BadgePostmaster')}
+                name="badgePostmaster"
+                value={settings.badgePostmaster}
+                onChange={onBadgePostmasterChanged}
+              />
+              <div className="fineprint">{t('Settings.BadgePostmasterExplanation')}</div>
+            </div>
           </section>
 
           {$featureFlags.wishLists && <WishListSettings />}

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -8,6 +8,8 @@ import { defaultLanguage } from 'app/i18n';
 export interface Settings extends DimApiSettings {
   activeMode: boolean;
   loLockItemEnergyType: boolean;
+  /** Badge the app icon with the number of postmaster items on the current character */
+  badgePostmaster: boolean;
 }
 
 export const initialSettingsState: Settings = {
@@ -20,4 +22,5 @@ export const initialSettingsState: Settings = {
   loUpgradeSpendTier: UpgradeSpendTier.Nothing,
   loLockItemEnergyType: false,
   singleCharacter: false,
+  badgePostmaster: true,
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -66,6 +66,9 @@ interface Window {
 interface Navigator {
   /** iOS-only: True if the app is running in installed mode */
   standalone?: boolean;
+
+  setAppBadge(num?: number);
+  clearAppBadge();
 }
 
 /**

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -723,6 +723,8 @@
     "UsageCount": "# Used"
   },
   "Settings": {
+    "BadgePostmaster": "Show the number of postmaster items for the current character on app icon",
+    "BadgePostmasterExplanation": "For this to work you must install DIM as an app and your OS must support displaying badges",
     "CharacterOrder": "Sort characters by",
     "CharacterOrderFixed": "Character age (buggy on PC)",
     "CharacterOrderRecent": "Most recent character",


### PR DESCRIPTION
This is a bit of an experiment - I might revert it, but I can't really test it until it's shipped to beta. This uses the navigator badging API to display a "badge" (like the unread emails count on the mail app) on DIM's installed app icon in your dock/homescreen. I don't really know where it will work and where it won't!

I also included a setting because I know badges drive some people crazy.