### PR TITLE
Organizer: Filter by Special Mod Slots

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Armor in the Organizer no longer displays the now-standard Combat Mod Slot
+
 ## 6.77.0 <span class="changelog-date">(2021-08-08)</span>
 
 * Timelost weapons now include their additional Level 10 Masterwork stats.

--- a/src/app/dim-ui/SpecialtyModSlotIcon.tsx
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.tsx
@@ -16,11 +16,11 @@ export function SpecialtyModSlotIcon({
   item,
   className,
   lowRes,
-  onlyInteresting,
-}: ModSlotIconProps & { onlyInteresting?: boolean }) {
+  excludeStandardD2ModSockets,
+}: ModSlotIconProps & { excludeStandardD2ModSockets?: boolean }) {
   const defs = useD2Definitions()!;
   const modMetadatas = (
-    onlyInteresting ? getInterestingSocketMetadatas : getSpecialtySocketMetadatas
+    excludeStandardD2ModSockets ? getInterestingSocketMetadatas : getSpecialtySocketMetadatas
   )(item);
 
   if (!modMetadatas) {

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -294,7 +294,12 @@ const itemFactors: Record<string, Factor> = {
     id: 'specialtySocket',
     runIf: getInterestingSocketMetadatas,
     render: (item) => (
-      <SpecialtyModSlotIcon className={styles.inlineIcon} item={item} lowRes onlyInteresting />
+      <SpecialtyModSlotIcon
+        className={styles.inlineIcon}
+        item={item}
+        lowRes
+        excludeStandardD2ModSockets
+      />
     ),
     filter: modslotFilter.fromItem!,
   },

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -353,8 +353,8 @@ export function getColumns(
         filter: (value: string) =>
           value !== undefined
             ? value
-                ?.split(',')
-                ?.map((m) => `modslot:${m}`)
+                .split(',')
+                .map((m) => `modslot:${m}`)
                 .join(' ')
             : ``,
       },

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -37,11 +37,11 @@ import {
 import { RootState } from 'app/store/types';
 import { compareBy } from 'app/utils/comparators';
 import {
+  getInterestingSocketMetadatas,
   getItemDamageShortName,
   getItemKillTrackerInfo,
   getItemYear,
   getMasterworkStatNames,
-  getSpecialtySocketMetadatas,
   isD1Item,
   isSunset,
 } from 'app/utils/item-utils';
@@ -339,15 +339,18 @@ export function getColumns(
         header: t('Organizer.Columns.ModSlot'),
         // TODO: only show if there are mod slots
         value: (item) =>
-          getSpecialtySocketMetadatas(item)
+          getInterestingSocketMetadatas(item)
             ?.map((m) => m.slotTag)
             .join(','),
         cell: (value, item) =>
-          value && <SpecialtyModSlotIcon className={styles.modslotIcon} item={item} />,
-        filter: (_val, item) => {
-          const modSlotMetadata = getSpecialtySocketMetadatas(item);
-          return `modslot:${modSlotMetadata?.[0].slotTag || 'none'}`;
-        },
+          value && (
+            <SpecialtyModSlotIcon
+              className={styles.modslotIcon}
+              item={item}
+              excludeStandardD2ModSockets
+            />
+          ),
+        filter: (value) => (value !== undefined ? `modslot:${value}` : ``),
       },
     destinyVersion === 1 && {
       id: 'percentComplete',

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -350,7 +350,13 @@ export function getColumns(
               excludeStandardD2ModSockets
             />
           ),
-        filter: (value) => (value !== undefined ? `modslot:${value}` : ``),
+        filter: (value: string) =>
+          value !== undefined
+            ? value
+                ?.split(',')
+                ?.map((m) => `modslot:${m}`)
+                .join(' ')
+            : ``,
       },
     destinyVersion === 1 && {
       id: 'percentComplete',


### PR DESCRIPTION
Written to address #6889, I have removed the now-standard Combat Mod Slot from display in the Organizer, which also fixes attempting to shift-click to sort by a more specialized slot.

User-facing changes:
- When viewing the Organizer Armor table, the Mod Slot column no longer shows the now-standard combat style mod slot
   - Accomplished by having the Organizer Mod Slot column use 'getInterestingSocketMetadatas' in place of 'getSpecialtySocketMetadatas'
   - This also addresses shift-clicking to sort by these mod slots - the filter will be applied if special mod slots are present (raid or nightmare), and no filter appears if they are not
 
 Preview of visual changes to the Mod Slot column, demoed on my local machine:
![image](https://user-images.githubusercontent.com/77800119/128800986-bc0913c4-e4f0-41af-971e-b9a5df9ff60f.png)

Other code changes:
- Renamed `SpecialtyModSlotIcon` boolean prop `onlyInteresting` to `excludeStandardD2ModSockets`, aiming for more clarity of purpose
- Edit: As suggested by nev-r, refactored the mod slot column to filter by all mod slots present on an armor piece