### PR TITLE
Use simpler icons for vendors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 * There is now a helpful banner prompt to install the app on mobile.
 * When the postmaster is near full, a banner will warn you even if you're not on the inventory screen.
 * Artifact XP progress is now displayed for the correct season.
+* Changed the icons in the Vendors menu.
 
 ## 6.79.1 <span class="changelog-date">(2021-08-25)</span>
 

--- a/src/app/vendors/Vendor.tsx
+++ b/src/app/vendors/Vendor.tsx
@@ -61,8 +61,8 @@ export default function Vendor({
             <span className={styles.vendorIconWrapper}>
               <BungieImage
                 src={
-                  vendor.def.displayProperties.icon ||
-                  vendor.def.displayProperties.smallTransparentIcon
+                  vendor.def.displayProperties.smallTransparentIcon ||
+                  vendor.def.displayProperties.icon
                 }
                 className={styles.icon}
               />

--- a/src/app/vendors/VendorsMenu.tsx
+++ b/src/app/vendors/VendorsMenu.tsx
@@ -13,8 +13,8 @@ export default function VendorsMenu({ groups }: { groups: readonly D2VendorGroup
             <PageWithMenu.MenuButton anchor={vendor.def.hash.toString()} key={vendor.def.hash}>
               <BungieImage
                 src={
-                  vendor.def.displayProperties.icon ||
-                  vendor.def.displayProperties.smallTransparentIcon
+                  vendor.def.displayProperties.smallTransparentIcon ||
+                  vendor.def.displayProperties.icon
                 }
               />
               <span>{vendor.def.displayProperties.name}</span>


### PR DESCRIPTION
Less colorful icons:

<img width="249" alt="Screen Shot 2021-08-29 at 5 06 46 PM" src="https://user-images.githubusercontent.com/313208/131269676-879e1e2a-ac5c-4668-8847-a7d53681f85f.png">
