### PR TITLE
Ask caches to always revalidate before using cached service worker / html

### DIFF
--- a/src/htaccess
+++ b/src/htaccess
@@ -971,7 +971,8 @@ AddEncoding br .br
 
 <FilesMatch "service-worker\.js(\.(gz|br))?">
     <IfModule mod_headers.c>
-        Header set Cache-Control "max-age=0, s-maxage=86400"
+        # no-cache = revalidate with the server before using
+        Header set Cache-Control "max-age=0, s-maxage=86400, must-revalidate"
         Header unset Expires
     </IfModule>
 </FilesMatch>
@@ -980,7 +981,7 @@ AddEncoding br .br
 
 <FilesMatch "\.html(\.(gz|br))?">
     <IfModule mod_headers.c>
-        Header set Cache-Control "max-age=0, s-maxage=86400"
+        Header set Cache-Control "max-age=0, s-maxage=86400, must-revalidate"
         Header unset Expires
     </IfModule>
 </FilesMatch>
@@ -989,7 +990,7 @@ AddEncoding br .br
 
 <FilesMatch "version\.json(\.(gz|br))?">
     <IfModule mod_headers.c>
-        Header set Cache-Control "max-age=900, s-maxage=86400"
+        Header set Cache-Control "max-age=900, s-maxage=86400, must-revalidate"
         Header unset Expires
     </IfModule>
 </FilesMatch>


### PR DESCRIPTION
Undoing a bit of https://github.com/DestinyItemManager/DIM/commit/97c84129527c1df09abd2b3111cf4075fddd7126 and https://github.com/DestinyItemManager/DIM/commit/f9717530efc7853d155672a1ba80aff24e5c9bdf in hopes of fixing the issue #6910 where updates sometimes don't show up for a while. Hopefully DreamHost doesn't melt down.