### PR TITLE
Get rid of StatTypes

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -44,7 +44,6 @@ import {
   generalSocketReusablePlugSetHash,
   ItemsByBucket,
   statHashes,
-  statHashToType,
   statKeys,
   StatTypes,
   statValues,
@@ -56,7 +55,7 @@ interface ProvidedProps {
 }
 
 interface StoreProps {
-  statOrder: StatTypes[];
+  statOrder: number[]; // stat hashes, including disabled stats
   upgradeSpendTier: UpgradeSpendTier;
   lockItemEnergyType: boolean;
   items: Readonly<{
@@ -133,11 +132,6 @@ function mapStateToProps() {
     }
   );
 
-  const statOrderSelector = createSelector(
-    (state: RootState) => settingsSelector(state).loStatSortOrder,
-    (loStatSortOrder: number[]) => loStatSortOrder.map((hash) => statHashToType[hash])
-  );
-
   /** A selector to pull out all half tier general mods so we can quick add them to sets. */
   const halfTierModsSelector = createSelector(
     (state: RootState) => settingsSelector(state).loStatSortOrder,
@@ -183,7 +177,7 @@ function mapStateToProps() {
   return (state: RootState): StoreProps => {
     const { loUpgradeSpendTier, loLockItemEnergyType } = settingsSelector(state);
     return {
-      statOrder: statOrderSelector(state),
+      statOrder: settingsSelector(state).loStatSortOrder,
       upgradeSpendTier: loUpgradeSpendTier,
       lockItemEnergyType: loLockItemEnergyType,
       items: itemsSelector(state),
@@ -264,7 +258,7 @@ function LoadoutBuilder({
     () => ({
       statConstraints: _.compact(
         _.sortBy(Object.entries(statFilters), ([statName]) =>
-          statOrder.indexOf(statName as StatTypes)
+          statOrder.indexOf(statHashes[statName as StatTypes])
         ).map(([statName, minMax]) => {
           if (minMax.ignored) {
             return undefined;

--- a/src/app/loadout-builder/filter/FilterBuilds.tsx
+++ b/src/app/loadout-builder/filter/FilterBuilds.tsx
@@ -16,17 +16,12 @@ export default function FilterBuilds({
 }: {
   statRanges?: { [statType in StatTypes]: MinMax };
   stats: { [statType in StatTypes]: MinMaxIgnored };
-  order: StatTypes[];
+  order: number[]; // stat hashes in user order
   onStatFiltersChanged(stats: { [statType in StatTypes]: MinMaxIgnored }): void;
 }) {
   const setSetting = useSetSetting();
 
-  const onStatOrderChanged = (sortOrder: StatTypes[]) => {
-    setSetting(
-      'loStatSortOrder',
-      sortOrder.map((type) => statHashes[type])
-    );
-  };
+  const onStatOrderChanged = (sortOrder: number[]) => setSetting('loStatSortOrder', sortOrder);
 
   const workingStatRanges =
     statRanges || _.mapValues(statHashes, () => ({ min: 0, max: 10, ignored: false }));

--- a/src/app/loadout-builder/filter/FilterBuilds.tsx
+++ b/src/app/loadout-builder/filter/FilterBuilds.tsx
@@ -1,7 +1,7 @@
 import { useSetSetting } from 'app/settings/hooks';
-import _ from 'lodash';
 import React from 'react';
-import { MinMax, MinMaxIgnored, statHashes, StatTypes } from '../types';
+import { defaultStatFilters } from '../loadout-builder-reducer';
+import { ArmorStatHashes, MinMax, MinMaxIgnored } from '../types';
 import styles from './FilterBuilds.m.scss';
 import TierSelect from './TierSelect';
 
@@ -14,17 +14,16 @@ export default function FilterBuilds({
   order,
   onStatFiltersChanged,
 }: {
-  statRanges?: { [statType in StatTypes]: MinMax };
-  stats: { [statType in StatTypes]: MinMaxIgnored };
+  statRanges?: { [statHash in ArmorStatHashes]: MinMax };
+  stats: { [statHash in ArmorStatHashes]: MinMaxIgnored };
   order: number[]; // stat hashes in user order
-  onStatFiltersChanged(stats: { [statType in StatTypes]: MinMaxIgnored }): void;
+  onStatFiltersChanged(stats: { [statHash in ArmorStatHashes]: MinMaxIgnored }): void;
 }) {
   const setSetting = useSetSetting();
 
   const onStatOrderChanged = (sortOrder: number[]) => setSetting('loStatSortOrder', sortOrder);
 
-  const workingStatRanges =
-    statRanges || _.mapValues(statHashes, () => ({ min: 0, max: 10, ignored: false }));
+  const workingStatRanges = statRanges || defaultStatFilters;
 
   return (
     <div>

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import _ from 'lodash';
 import React from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
-import { MinMax, MinMaxIgnored, statHashToType, StatTypes } from '../types';
+import { ArmorStatHashes, MinMax, MinMaxIgnored } from '../types';
 import styles from './TierSelect.m.scss';
 
 const IGNORE = 'ignore';
@@ -26,12 +26,12 @@ export default function TierSelect({
   onStatOrderChanged,
   onStatFiltersChanged,
 }: {
-  stats: { [statType in StatTypes]: MinMaxIgnored };
-  statRanges: { [statType in StatTypes]: MinMax };
+  stats: { [statHash in ArmorStatHashes]: MinMaxIgnored };
+  statRanges: { [statHash in ArmorStatHashes]: MinMax };
   rowClassName: string;
   order: number[]; // stat hashes in user order
   onStatOrderChanged(order: number[]): void;
-  onStatFiltersChanged(stats: { [statType in StatTypes]: MinMaxIgnored }): void;
+  onStatFiltersChanged(stats: { [statHash in ArmorStatHashes]: MinMaxIgnored }): void;
 }) {
   const defs = useD2Definitions()!;
   const handleTierChange = (
@@ -40,7 +40,7 @@ export default function TierSelect({
   ) => {
     const newTiers = {
       ...stats,
-      [statHashToType[statHash]]: { ...stats[statHashToType[statHash]], ...changed },
+      [statHash]: { ...stats[statHash], ...changed },
     };
 
     onStatFiltersChanged(newTiers);
@@ -72,7 +72,7 @@ export default function TierSelect({
                 index={index}
                 className={rowClassName}
                 name={
-                  <span className={stats[statHashToType[statHash]].ignored ? styles.ignored : ''}>
+                  <span className={stats[statHash].ignored ? styles.ignored : ''}>
                     <BungieImage
                       className={styles.iconStat}
                       src={statDefs[statHash].displayProperties.icon}
@@ -85,18 +85,18 @@ export default function TierSelect({
                   statHash={statHash}
                   stats={stats}
                   type="Min"
-                  min={statRanges[statHashToType[statHash]].min}
-                  max={statRanges[statHashToType[statHash]].max}
-                  ignored={stats[statHashToType[statHash]].ignored}
+                  min={statRanges[statHash].min}
+                  max={statRanges[statHash].max}
+                  ignored={stats[statHash].ignored}
                   handleTierChange={handleTierChange}
                 />
                 <MinMaxSelect
                   statHash={statHash}
                   stats={stats}
                   type="Max"
-                  min={statRanges[statHashToType[statHash]].min}
-                  max={statRanges[statHashToType[statHash]].max}
-                  ignored={stats[statHashToType[statHash]].ignored}
+                  min={statRanges[statHash].min}
+                  max={statRanges[statHash].max}
+                  ignored={stats[statHash].ignored}
                   handleTierChange={handleTierChange}
                 />
               </DraggableItem>
@@ -157,7 +157,7 @@ function MinMaxSelectInner({
   min: number;
   max: number;
   ignored: boolean;
-  stats: { [statType in StatTypes]: MinMaxIgnored };
+  stats: { [statHash in ArmorStatHashes]: MinMaxIgnored };
   handleTierChange(
     statHash: number,
     changed: {
@@ -167,7 +167,7 @@ function MinMaxSelectInner({
     }
   ): void;
 }) {
-  const statSetting = stats[statHashToType[statHash]];
+  const statSetting = stats[statHash];
 
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     let update: {

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -53,7 +53,7 @@ interface ProvidedProps {
   loadouts: Loadout[];
   lockedMods: PluggableInventoryItemDefinition[];
   classType: DestinyClass;
-  statOrder: StatTypes[];
+  statOrder: number[];
   enabledStats: Set<StatTypes>;
   upgradeSpendTier: UpgradeSpendTier;
   lockItemEnergyType: boolean;

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -9,6 +9,7 @@ import { updateLoadout } from 'app/loadout-drawer/actions';
 import { Loadout, LoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getModRenderKey } from 'app/loadout/mod-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { armorStats } from 'app/search/d2-known-values';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -19,7 +20,7 @@ import { connect } from 'react-redux';
 import { getItemsFromLoadoutItems } from '../../loadout-drawer/loadout-utils';
 import { assignModsToArmorSet } from '../mod-utils';
 import { getTotalModStatChanges } from '../process/mappers';
-import { ArmorSet, LockableBucketHashes, statHashes, statKeys, StatTypes } from '../types';
+import { ArmorSet, ArmorStatHashes, LockableBucketHashes } from '../types';
 import { getPower, upgradeSpendTierToMaxEnergy } from '../utils';
 import styles from './CompareDrawer.m.scss';
 import Mod from './Mod';
@@ -30,18 +31,18 @@ function getItemStats(
   defs: D2ManifestDefinitions,
   item: DimItem,
   upgradeSpendTier: UpgradeSpendTier
-) {
-  const baseStats = _.mapValues(
-    statHashes,
-    (value) => item.stats?.find((s) => s.statHash === value)?.base || 0
-  );
+): { [statHash in ArmorStatHashes]: number } {
+  const baseStats = armorStats.reduce((memo, statHash) => {
+    memo[statHash] = item.stats?.find((s) => s.statHash === statHash)?.base || 0;
+    return memo;
+  }, {}) as { [statHash in ArmorStatHashes]: number };
 
   if (
     upgradeSpendTierToMaxEnergy(defs, upgradeSpendTier, item) === 10 ||
     item.energy?.energyCapacity === 10
   ) {
-    for (const statType of statKeys) {
-      baseStats[statType] += 2;
+    for (const statHash of armorStats) {
+      baseStats[statHash] += 2;
     }
   }
 
@@ -54,7 +55,7 @@ interface ProvidedProps {
   lockedMods: PluggableInventoryItemDefinition[];
   classType: DestinyClass;
   statOrder: number[];
-  enabledStats: Set<StatTypes>;
+  enabledStats: Set<number>;
   upgradeSpendTier: UpgradeSpendTier;
   lockItemEnergyType: boolean;
   onClose(): void;
@@ -122,19 +123,22 @@ function CompareDrawer({
   }
 
   const loadoutMaxPower = _.sumBy(loadoutItems, (i) => i.basePower) / loadoutItems.length;
-  const loadoutStats = _.mapValues(statHashes, () => 0);
+  const loadoutStats = armorStats.reduce((memo, statHash) => {
+    memo[statHash] = 0;
+    return memo;
+  }, {}) as { [statHash in ArmorStatHashes]: number };
 
   for (const item of loadoutItems) {
     const itemStats = getItemStats(defs, item, upgradeSpendTier);
-    for (const statType of statKeys) {
-      loadoutStats[statType] += itemStats[statType];
+    for (const statHash of armorStats) {
+      loadoutStats[statHash] += itemStats[statHash];
     }
   }
 
   const lockedModStats = getTotalModStatChanges(lockedMods, characterClass);
 
-  for (const statType of statKeys) {
-    loadoutStats[statType] += lockedModStats[statType];
+  for (const statHash of armorStats) {
+    loadoutStats[statHash] += lockedModStats[statHash];
   }
 
   const [assignedMods] = assignModsToArmorSet(

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -9,7 +9,7 @@ import React, { Dispatch } from 'react';
 import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { assignModsToArmorSet } from '../mod-utils';
-import { ArmorSet, LockedMap, StatTypes } from '../types';
+import { ArmorSet, LockedMap } from '../types';
 import { getPower } from '../utils';
 import styles from './GeneratedSet.m.scss';
 import GeneratedSetButtons from './GeneratedSetButtons';
@@ -23,7 +23,7 @@ interface Props {
   style: React.CSSProperties;
   statOrder: number[];
   forwardedRef?: React.Ref<HTMLDivElement>;
-  enabledStats: Set<StatTypes>;
+  enabledStats: Set<number>;
   lockedMods: PluggableInventoryItemDefinition[];
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -21,7 +21,7 @@ interface Props {
   selectedStore?: DimStore;
   lockedMap: LockedMap;
   style: React.CSSProperties;
-  statOrder: StatTypes[];
+  statOrder: number[];
   forwardedRef?: React.Ref<HTMLDivElement>;
   enabledStats: Set<StatTypes>;
   lockedMods: PluggableInventoryItemDefinition[];

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -9,7 +9,7 @@ import { useDispatch } from 'react-redux';
 import { DimStore } from '../../inventory/store-types';
 import { convertToLoadoutItem, newLoadout } from '../../loadout-drawer/loadout-utils';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
-import { ArmorSet, statHashes } from '../types';
+import { ArmorSet } from '../types';
 import { statTier } from '../utils';
 import styles from './GeneratedSetButtons.m.scss';
 
@@ -46,9 +46,9 @@ export default function GeneratedSetButtons({
 
   const statsWithPlus5: number[] = [];
 
-  for (const [stat, value] of Object.entries(set.stats)) {
+  for (const [statHash, value] of Object.entries(set.stats)) {
     if (value % 10 > 4) {
-      statsWithPlus5.push(statHashes[stat]);
+      statsWithPlus5.push(parseInt(statHash, 10));
     }
   }
 

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -70,7 +70,7 @@ interface Props {
   combos: number;
   combosWithoutCaps: number;
   lockedMap: LockedMap;
-  statOrder: StatTypes[];
+  statOrder: number[];
   enabledStats: Set<StatTypes>;
   lockedMods: PluggableInventoryItemDefinition[];
   loadouts: Loadout[];

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -11,7 +11,7 @@ import React, { Dispatch, useCallback, useEffect, useMemo, useRef, useState } fr
 import { List, WindowScroller } from 'react-virtualized';
 import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
-import { ArmorSet, LockedMap, StatTypes } from '../types';
+import { ArmorSet, LockedMap } from '../types';
 import GeneratedSet from './GeneratedSet';
 import styles from './GeneratedSets.m.scss';
 
@@ -71,7 +71,7 @@ interface Props {
   combosWithoutCaps: number;
   lockedMap: LockedMap;
   statOrder: number[];
-  enabledStats: Set<StatTypes>;
+  enabledStats: Set<number>;
   lockedMods: PluggableInventoryItemDefinition[];
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -7,16 +7,16 @@ import StatTooltip from 'app/store-stats/StatTooltip';
 import { DestinyClass, DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React from 'react';
-import { statHashToType, StatTypes } from '../types';
+import { ArmorSet } from '../types';
 import { statTierWithHalf } from '../utils';
 import styles from './SetStats.m.scss';
 import { calculateTotalTier, sumEnabledStats } from './utils';
 
 interface Props {
-  stats: Readonly<{ [statType in StatTypes]: number }>;
+  stats: ArmorSet['stats'];
   maxPower: number;
   statOrder: number[];
-  enabledStats: Set<StatTypes>;
+  enabledStats: Set<number>;
   characterClass?: DestinyClass;
   className?: string;
   existingLoadoutName?: string;
@@ -80,7 +80,7 @@ function SetStats({
                 stat={{
                   hash: statHash,
                   name: statDefs[statHash].displayProperties.name,
-                  value: stats[statHashToType[statHash]],
+                  value: stats[statHash],
                   description: statDefs[statHash].displayProperties.description,
                 }}
                 characterClass={characterClass}
@@ -89,9 +89,9 @@ function SetStats({
             allowClickThrough={true}
           >
             <Stat
-              isActive={enabledStats.has(statHashToType[statHash])}
+              isActive={enabledStats.has(statHash)}
               stat={statDefs[statHash]}
-              value={stats[statHashToType[statHash]]}
+              value={stats[statHash]}
             />
           </PressTip>
         ))}

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -1,24 +1,24 @@
 import { chainComparator, Comparator, compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
-import { ArmorSet, statKeys, StatTypes } from '../types';
+import { ArmorSet, statHashToType, statKeys, StatTypes } from '../types';
 import { statTier } from '../utils';
 
-function getComparatorsForMatchedSetSorting(statOrder: StatTypes[], enabledStats: Set<StatTypes>) {
+function getComparatorsForMatchedSetSorting(statOrder: number[], enabledStats: Set<StatTypes>) {
   const comparators: Comparator<ArmorSet>[] = [];
 
   comparators.push(compareBy((s: ArmorSet) => -sumEnabledStats(s.stats, enabledStats)));
 
-  statOrder.forEach((statType) => {
-    if (enabledStats.has(statType)) {
-      comparators.push(compareBy((s: ArmorSet) => -statTier(s.stats[statType])));
+  for (const statHash of statOrder) {
+    if (enabledStats.has(statHashToType[statHash])) {
+      comparators.push(compareBy((s: ArmorSet) => -statTier(s.stats[statHashToType[statHash]])));
     }
-  });
+  }
 
   return comparators;
 }
 
 export function sortGeneratedSets(
-  statOrder: StatTypes[],
+  statOrder: number[],
   enabledStats: Set<StatTypes>,
   sets?: readonly ArmorSet[]
 ) {

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -1,16 +1,17 @@
+import { armorStats } from 'app/search/d2-known-values';
 import { chainComparator, Comparator, compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
-import { ArmorSet, statHashToType, statKeys, StatTypes } from '../types';
+import { ArmorSet } from '../types';
 import { statTier } from '../utils';
 
-function getComparatorsForMatchedSetSorting(statOrder: number[], enabledStats: Set<StatTypes>) {
+function getComparatorsForMatchedSetSorting(statOrder: number[], enabledStats: Set<number>) {
   const comparators: Comparator<ArmorSet>[] = [];
 
   comparators.push(compareBy((s: ArmorSet) => -sumEnabledStats(s.stats, enabledStats)));
 
   for (const statHash of statOrder) {
-    if (enabledStats.has(statHashToType[statHash])) {
-      comparators.push(compareBy((s: ArmorSet) => -statTier(s.stats[statHashToType[statHash]])));
+    if (enabledStats.has(statHash)) {
+      comparators.push(compareBy((s: ArmorSet) => -statTier(s.stats[statHash])));
     }
   }
 
@@ -19,7 +20,7 @@ function getComparatorsForMatchedSetSorting(statOrder: number[], enabledStats: S
 
 export function sortGeneratedSets(
   statOrder: number[],
-  enabledStats: Set<StatTypes>,
+  enabledStats: Set<number>,
   sets?: readonly ArmorSet[]
 ) {
   if (!sets) {
@@ -39,8 +40,8 @@ export function calculateTotalTier(stats: ArmorSet['stats']) {
   return _.sum(Object.values(stats).map(statTier));
 }
 
-export function sumEnabledStats(stats: ArmorSet['stats'], enabledStats: Set<StatTypes>) {
-  return _.sumBy(statKeys, (statType) =>
-    enabledStats.has(statType) ? statTier(stats[statType]) : 0
+export function sumEnabledStats(stats: ArmorSet['stats'], enabledStats: Set<number>) {
+  return _.sumBy(armorStats, (statHash) =>
+    enabledStats.has(statHash) ? statTier(stats[statHash]) : 0
   );
 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -5,15 +5,17 @@ import { getCurrentStore, getItemAcrossStores } from 'app/inventory/stores-helpe
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
+import { StatHashes } from 'data/d2/generated-enums';
+import _ from 'lodash';
 import { useReducer } from 'react';
 import { isLoadoutBuilderItem } from '../loadout/item-utils';
 import {
   ArmorSet,
+  ArmorStatHashes,
   LockedExotic,
   LockedItemType,
   LockedMap,
   MinMaxIgnored,
-  StatTypes,
 } from './types';
 import { addLockedItem, removeLockedItem } from './utils';
 
@@ -22,13 +24,23 @@ export interface LoadoutBuilderState {
   lockedMods: PluggableInventoryItemDefinition[];
   lockedExotic?: LockedExotic;
   selectedStoreId?: string;
-  statFilters: Readonly<{ [statType in StatTypes]: MinMaxIgnored }>;
+  statFilters: Readonly<{ [statHash in ArmorStatHashes]: MinMaxIgnored }>;
   modPicker: {
     open: boolean;
     initialQuery?: string;
   };
   compareSet?: ArmorSet;
 }
+
+export const defaultStatFilters = {
+  [StatHashes.Mobility]: { min: 0, max: 10, ignored: false },
+  [StatHashes.Resilience]: { min: 0, max: 10, ignored: false },
+  [StatHashes.Recovery]: { min: 0, max: 10, ignored: false },
+  [StatHashes.Discipline]: { min: 0, max: 10, ignored: false },
+  [StatHashes.Intellect]: { min: 0, max: 10, ignored: false },
+  [StatHashes.Strength]: { min: 0, max: 10, ignored: false },
+};
+Object.freeze(defaultStatFilters);
 
 const lbStateInit = ({
   stores,
@@ -61,14 +73,7 @@ const lbStateInit = ({
   }
   return {
     lockedMap,
-    statFilters: {
-      Mobility: { min: 0, max: 10, ignored: false },
-      Resilience: { min: 0, max: 10, ignored: false },
-      Recovery: { min: 0, max: 10, ignored: false },
-      Discipline: { min: 0, max: 10, ignored: false },
-      Intellect: { min: 0, max: 10, ignored: false },
-      Strength: { min: 0, max: 10, ignored: false },
-    },
+    statFilters: _.cloneDeep(defaultStatFilters),
     lockedMods: [],
     selectedStoreId: selectedStoreId,
     modPicker: {
@@ -108,14 +113,7 @@ function lbStateReducer(
         selectedStoreId: action.storeId,
         lockedMap: {},
         lockedExotic: undefined,
-        statFilters: {
-          Mobility: { min: 0, max: 10, ignored: false },
-          Resilience: { min: 0, max: 10, ignored: false },
-          Recovery: { min: 0, max: 10, ignored: false },
-          Discipline: { min: 0, max: 10, ignored: false },
-          Intellect: { min: 0, max: 10, ignored: false },
-          Strength: { min: 0, max: 10, ignored: false },
-        },
+        statFilters: _.cloneDeep(defaultStatFilters),
       };
     case 'statFiltersChanged':
       return { ...state, statFilters: action.statFilters };

--- a/src/app/loadout-builder/process-worker/tsconfig.json
+++ b/src/app/loadout-builder/process-worker/tsconfig.json
@@ -14,6 +14,10 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "allowJs": false,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "app/*": ["../../*"],
+      "data/*": ["../../../data/*"]
+    }
   }
 }

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -1,5 +1,5 @@
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
-import { StatTypes } from '../types';
+import { ArmorSet, ArmorStatHashes } from '../types';
 
 export interface ProcessItem {
   bucketHash: number;
@@ -29,14 +29,14 @@ export type ProcessItemsByBucket = Readonly<{
 
 export interface ProcessArmorSet {
   /** The overall stats for the loadout as a whole. */
-  readonly stats: Readonly<{ [statType in StatTypes]: number }>;
+  readonly stats: Readonly<{ [statHash in ArmorStatHashes]: number }>;
   /** For each armor type (see LockableBuckets), this is the list of items that could interchangeably be put into this loadout. */
   readonly armor: readonly string[];
 }
 
 export interface IntermediateProcessArmorSet {
   /** The overall stats for the loadout as a whole. */
-  stats: { [statType in StatTypes]: number };
+  stats: ArmorSet['stats'];
   /** The first (highest-power) valid set from this stat mix. */
   armor: ProcessItem[];
 }

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -17,7 +17,7 @@ import {
   getSpecialtySocketMetadatas,
 } from '../../utils/item-utils';
 import { ProcessArmorSet, ProcessItem, ProcessMod } from '../process-worker/types';
-import { ArmorSet, statHashToType, StatTypes } from '../types';
+import { ArmorSet } from '../types';
 import { canSwapEnergyFromUpgradeSpendTier, upgradeSpendTierToMaxEnergy } from '../utils';
 
 export function mapArmor2ModToProcessMod(mod: PluggableInventoryItemDefinition): ProcessMod {
@@ -86,13 +86,13 @@ export function getTotalModStatChanges(
   lockedMods: PluggableInventoryItemDefinition[],
   characterClass: DestinyClass | undefined
 ) {
-  const totals: { [stat in StatTypes]: number } = {
-    Mobility: 0,
-    Recovery: 0,
-    Resilience: 0,
-    Intellect: 0,
-    Discipline: 0,
-    Strength: 0,
+  const totals: ArmorSet['stats'] = {
+    [StatHashes.Mobility]: 0,
+    [StatHashes.Recovery]: 0,
+    [StatHashes.Resilience]: 0,
+    [StatHashes.Intellect]: 0,
+    [StatHashes.Discipline]: 0,
+    [StatHashes.Strength]: 0,
   };
 
   // This should only happen on initialisation if the store is undefined.
@@ -102,9 +102,11 @@ export function getTotalModStatChanges(
 
   for (const mod of lockedMods) {
     for (const stat of mod.investmentStats) {
-      const statType = statHashToType[stat.statTypeHash];
-      if (statType && isModStatActive(characterClass, mod.hash, stat, lockedMods)) {
-        totals[statType] += stat.value;
+      if (
+        stat.statTypeHash in totals &&
+        isModStatActive(characterClass, mod.hash, stat, lockedMods)
+      ) {
+        totals[stat.statTypeHash] += stat.value;
       }
     }
   }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -22,7 +22,6 @@ import {
   LockedMap,
   MinMax,
   MinMaxIgnored,
-  statHashes,
   StatTypes,
 } from '../types';
 import { upgradeSpendTierToMaxEnergy } from '../utils';
@@ -56,7 +55,7 @@ export function useProcess(
   lockedMods: PluggableInventoryItemDefinition[],
   upgradeSpendTier: UpgradeSpendTier,
   lockItemEnergyType: boolean,
-  statOrder: StatTypes[],
+  statOrder: number[],
   statFilters: { [statType in StatTypes]: MinMaxIgnored }
 ) {
   const [{ result, processing }, setState] = useState<ProcessState>({
@@ -220,7 +219,7 @@ const groupComparator = chainComparator(
 function groupItems(
   defs: D2ManifestDefinitions | undefined,
   items: readonly DimItem[],
-  statOrder: StatTypes[],
+  statOrder: number[],
   upgradeSpendTier: UpgradeSpendTier,
   generalMods: PluggableInventoryItemDefinition[],
   raidCombatAndLegacyMods: PluggableInventoryItemDefinition[]
@@ -230,8 +229,8 @@ function groupItems(
     const statsByHash = item.stats && keyByStatHash(item.stats);
     // Ensure ordering of stats
     if (statsByHash) {
-      for (const statType of statOrder) {
-        statValues.push(statsByHash[statHashes[statType]]!.base);
+      for (const statHash of statOrder) {
+        statValues.push(statsByHash[statHash]!.base);
       }
     }
 

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -17,12 +17,12 @@ import { someModHasEnergyRequirement } from '../mod-utils';
 import { ProcessItemsByBucket } from '../process-worker/types';
 import {
   ArmorSet,
+  ArmorStatHashes,
   bucketsToCategories,
   ItemsByBucket,
   LockedMap,
   MinMax,
   MinMaxIgnored,
-  StatTypes,
 } from '../types';
 import { upgradeSpendTierToMaxEnergy } from '../utils';
 import {
@@ -39,7 +39,7 @@ interface ProcessState {
     sets: ArmorSet[];
     combos: number;
     combosWithoutCaps: number;
-    statRanges?: { [stat in StatTypes]: MinMax };
+    statRanges?: { [statHash in ArmorStatHashes]: MinMax };
   } | null;
 }
 
@@ -56,7 +56,7 @@ export function useProcess(
   upgradeSpendTier: UpgradeSpendTier,
   lockItemEnergyType: boolean,
   statOrder: number[],
-  statFilters: { [statType in StatTypes]: MinMaxIgnored }
+  statFilters: { [statHash in ArmorStatHashes]: MinMaxIgnored }
 ) {
   const [{ result, processing }, setState] = useState<ProcessState>({
     processing: false,

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -1,22 +1,8 @@
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
-import {
-  armor2PlugCategoryHashesByName,
-  armorBuckets,
-  D2ArmorStatHashByName,
-} from 'app/search/d2-known-values';
+import { armor2PlugCategoryHashesByName, armorBuckets } from 'app/search/d2-known-values';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
-import { BucketHashes } from 'data/d2/generated-enums';
-import _ from 'lodash';
+import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
-
-// todo: get this from d2-known-values
-export type StatTypes =
-  | 'Mobility'
-  | 'Resilience'
-  | 'Recovery'
-  | 'Discipline'
-  | 'Intellect'
-  | 'Strength';
 
 export interface MinMax {
   min: number;
@@ -67,7 +53,7 @@ export type LockedMap = Readonly<{
  */
 export interface ArmorSet {
   /** The overall stats for the loadout as a whole. */
-  readonly stats: Readonly<{ [statType in StatTypes]: number }>;
+  readonly stats: Readonly<{ [statHash in ArmorStatHashes]: number }>;
   /** For each armor type (see LockableBuckets), this is the list of items that could interchangeably be put into this loadout. */
   readonly armor: readonly DimItem[][];
 }
@@ -97,21 +83,13 @@ export const bucketsToCategories = {
   [LockableBuckets.classitem]: armor2PlugCategoryHashesByName.classitem,
 };
 
-// to-do: deduplicate this and use D2ArmorStatHashByName instead
-export const statHashes: { [type in StatTypes]: number } = {
-  Mobility: D2ArmorStatHashByName.mobility,
-  Resilience: D2ArmorStatHashByName.resilience,
-  Recovery: D2ArmorStatHashByName.recovery,
-  Discipline: D2ArmorStatHashByName.discipline,
-  Intellect: D2ArmorStatHashByName.intellect,
-  Strength: D2ArmorStatHashByName.strength,
-};
-
-export const statValues = Object.values(statHashes);
-export const statKeys = Object.keys(statHashes) as StatTypes[];
-
-// Need to force the type as lodash converts the StatTypes type to string.
-export const statHashToType = _.invert(statHashes) as { [hash: number]: StatTypes };
+export type ArmorStatHashes =
+  | StatHashes.Mobility
+  | StatHashes.Resilience
+  | StatHashes.Recovery
+  | StatHashes.Discipline
+  | StatHashes.Intellect
+  | StatHashes.Strength;
 
 /**
  * The resuablePlugSetHash from armour 2.0's general socket.

--- a/src/app/loadout/item-utils.ts
+++ b/src/app/loadout/item-utils.ts
@@ -1,15 +1,13 @@
 import { DimItem } from 'app/inventory/item-types';
+import { armorStats } from 'app/search/d2-known-values';
 import { isSunset } from 'app/utils/item-utils';
-import { armorStatHashes } from './known-values';
 
 /** Checks if the item is non-sunset Armor 2.0 and whether it has stats present for all 6 armor stats. */
 export function isLoadoutBuilderItem(item: DimItem) {
   return (
     item.bucket.inArmor &&
     item.energy &&
-    armorStatHashes.every((statHash) =>
-      item.stats?.some((dimStat) => dimStat.statHash === statHash)
-    ) &&
+    armorStats.every((statHash) => item.stats?.some((dimStat) => dimStat.statHash === statHash)) &&
     !isSunset(item)
   );
 }

--- a/src/app/loadout/known-values.ts
+++ b/src/app/loadout/known-values.ts
@@ -1,18 +1,8 @@
 import {
   armor2PlugCategoryHashes,
   armor2PlugCategoryHashesByName,
-  D2ArmorStatHashByName,
 } from 'app/search/d2-known-values';
 import raidModPlugCategoryHashes from 'data/d2/raid-mod-plug-category-hashes.json';
-
-export const armorStatHashes = [
-  D2ArmorStatHashByName.intellect,
-  D2ArmorStatHashByName.discipline,
-  D2ArmorStatHashByName.strength,
-  D2ArmorStatHashByName.mobility,
-  D2ArmorStatHashByName.recovery,
-  D2ArmorStatHashByName.resilience,
-];
 
 export const slotSpecificPlugCategoryHashes = [
   armor2PlugCategoryHashesByName.helmet,

--- a/src/app/loadout/mod-picker/SelectableMod.tsx
+++ b/src/app/loadout/mod-picker/SelectableMod.tsx
@@ -4,7 +4,7 @@ import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { StatValue } from 'app/item-popup/PlugTooltip';
 import { SocketDetailsMod } from 'app/item-popup/SocketDetails';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { armorStatHashes } from 'app/search/search-filter-values';
+import { armorStats } from 'app/search/d2-known-values';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React from 'react';
@@ -56,7 +56,7 @@ function SelectableMod({
             </div>
           ))}
           {mod.investmentStats
-            .filter((stat) => armorStatHashes.includes(stat.statTypeHash))
+            .filter((stat) => armorStats.includes(stat.statTypeHash))
             .map((stat) => (
               <div className={styles.plugStats} key={stat.statTypeHash}>
                 <StatValue value={stat.value} statHash={stat.statTypeHash} />

--- a/src/app/search/search-filter-values.ts
+++ b/src/app/search/search-filter-values.ts
@@ -1,6 +1,7 @@
 import { DamageType } from 'bungie-api-ts/destiny2';
 import { D1LightStats } from './d1-known-values';
 import {
+  armorStats,
   CUSTOM_TOTAL_STAT_HASH,
   D2ArmorStatHashByName,
   D2LightStats,
@@ -43,7 +44,7 @@ export const dimArmorStatHashByName = {
 export const searchableArmorStatNames = [...Object.keys(dimArmorStatHashByName), 'any'];
 
 /** armor stat hashes to check for the "any" keyword */
-export const armorAnyStatHashes = Object.values(D2ArmorStatHashByName);
+export const armorAnyStatHashes = armorStats;
 
 /** stat hashes to calculate max values for */
 export const armorStatHashes = Object.values(dimArmorStatHashByName);


### PR DESCRIPTION
This purges Loadout Optimizer of the `StatTypes` stringy stat keys.