### PR TITLE
Add indicator for broken loadouts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Elemental Capacitor stats are no longer added to weapons with the perk enabled.
 * In the Loadout Optimizer, searching items now works in conjunction with locking exotics and items.
 * Added `is:currentclass` filter, which selects items currently equippable on the logged in guardian.
+* Added a warning indicator to previously created loadouts that are now missing items.
 
 ## 6.80.0 <span class="changelog-date">(2021-08-29)</span>
 

--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -2,6 +2,7 @@ import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
 import ModPicker from 'app/loadout/mod-picker/ModPicker';
 import { useDefinitions } from 'app/manifest/selectors';
+import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { useEventBusListener } from 'app/utils/hooks';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
@@ -576,7 +577,10 @@ function LoadoutDrawer({
           >
             {warnitems.length > 0 && (
               <div className="loadout-contents">
-                <p>{t('Loadouts.VendorsCannotEquip')}</p>
+                <p>
+                  <AppIcon className="warning-icon" icon={faExclamationTriangle} />
+                  {t('Loadouts.VendorsCannotEquip')}
+                </p>
                 <div className="loadout-warn-items">
                   {warnitems.map((item) => (
                     <div key={item.id} className="loadout-item">

--- a/src/app/loadout-drawer/LoadoutPopup.tsx
+++ b/src/app/loadout-drawer/LoadoutPopup.tsx
@@ -23,6 +23,7 @@ import {
   banIcon,
   editIcon,
   engramIcon,
+  faExclamationTriangle,
   faRandom,
   levellingIcon,
   searchIcon,
@@ -40,7 +41,12 @@ import {
 import { applyLoadout } from './loadout-apply';
 import './loadout-popup.scss';
 import { Loadout } from './loadout-types';
-import { convertToLoadoutItem, extractArmorModHashes, newLoadout } from './loadout-utils';
+import {
+  convertToLoadoutItem,
+  extractArmorModHashes,
+  isMissingItems,
+  newLoadout,
+} from './loadout-utils';
 import { fromEquippedTypes } from './LoadoutDrawerContents';
 import {
   makeRoomForPostmaster,
@@ -350,6 +356,9 @@ function LoadoutPopup({
         {loadouts.map((loadout) => (
           <li key={loadout.id} className="loadout-set">
             <span title={loadout.name} onClick={(e) => onApplyLoadout(loadout, e)}>
+              {isMissingItems(allItems, loadout) && (
+                <AppIcon className="warning-icon" icon={faExclamationTriangle} />
+              )}
               <ClassIcon className="loadout-type-icon" classType={loadout.classType} />
               {loadout.name}
             </span>

--- a/src/app/loadout-drawer/loadout-drawer.scss
+++ b/src/app/loadout-drawer/loadout-drawer.scss
@@ -127,6 +127,10 @@
   }
 }
 
+.warning-icon {
+  color: yellow;
+}
+
 .loadout-warn-items {
   display: flex;
   flex-direction: row;

--- a/src/app/loadout-drawer/loadout-popup.scss
+++ b/src/app/loadout-drawer/loadout-popup.scss
@@ -22,6 +22,10 @@
     color: #666;
   }
 
+  .warning-icon {
+    color: yellow;
+  }
+
   &:last-of-type {
     border: 0;
   }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -205,6 +205,28 @@ export function extractArmorModHashes(item: DimItem) {
   );
 }
 
+function findItem(allItems: DimItem[], loadoutItem: LoadoutItem): DimItem | undefined {
+  for (const item of allItems) {
+    if (
+      (loadoutItem.id && loadoutItem.id !== '0' && loadoutItem.id === item.id) ||
+      ((!loadoutItem.id || loadoutItem.id === '0') && loadoutItem.hash === item.hash)
+    ) {
+      return item;
+    }
+  }
+  return undefined;
+}
+
+export function isMissingItems(allItems: DimItem[], loadout: Loadout): boolean {
+  for (const loadoutItem of loadout.items) {
+    const item = findItem(allItems, loadoutItem);
+    if (!item) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Turn the loadout's items into real DIM items. Any that don't exist in inventory anymore
  * are returned as warnitems.
@@ -218,22 +240,10 @@ export function getItemsFromLoadoutItems(
     return [emptyArray(), emptyArray()];
   }
 
-  const findItem = (loadoutItem: LoadoutItem) => {
-    for (const item of allItems) {
-      if (
-        (loadoutItem.id && loadoutItem.id !== '0' && loadoutItem.id === item.id) ||
-        ((!loadoutItem.id || loadoutItem.id === '0') && loadoutItem.hash === item.hash)
-      ) {
-        return item;
-      }
-    }
-    return undefined;
-  };
-
   const items: DimItem[] = [];
   const warnitems: DimItem[] = [];
   for (const loadoutItem of loadoutItems) {
-    const item = findItem(loadoutItem);
+    const item = findItem(allItems, loadoutItem);
     if (item) {
       items.push(item);
     } else {


### PR DESCRIPTION
These loadouts are referencing items that no longer exist. Editing the loadout prompts the user to remove them or pick a replacement already, this makes it a bit more obvious which loadouts need to be fixed.

![grafik](https://user-images.githubusercontent.com/14299449/132109295-02e1df99-fa72-4da6-96b8-14aa10f82982.png)
