### PR TITLE
Fixed display of energy changes.

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -114,7 +114,8 @@ function GeneratedSet({
               itemOptions={set.armor[i]}
               locked={lockedMap[item.bucket.hash]}
               lbDispatch={lbDispatch}
-              lockedMods={assignedMods[item.id]}
+              assignedMods={assignedMods[item.id]}
+              showEnergyChanges={Boolean(lockedMods.length)}
             />
           ))}
         </div>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
@@ -103,3 +103,7 @@
     min-height: 32px;
   }
 }
+
+.energyHidden {
+  visibility: hidden;
+}

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss.d.ts
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'arrow': string;
+  'energyHidden': string;
   'energyIcon': string;
   'energySwapContainer': string;
   'energyValue': string;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -45,11 +45,11 @@ function EnergySwap({
     resultingEnergyCapacity = modCost;
   }
 
-  const showChange =
-    resultingEnergyCapacity !== armorEnergyCapacity || resultingEnergy !== armorEnergy;
+  const noEnergyChange =
+    resultingEnergyCapacity === armorEnergyCapacity && resultingEnergy === armorEnergy;
 
   return (
-    <div className={clsx(styles.energySwapContainer, { [styles.energyHidden]: !showChange })}>
+    <div className={clsx(styles.energySwapContainer, { [styles.energyHidden]: noEnergyChange })}>
       <div className={styles.energyValue}>
         <div className={clsx({ [styles.masterworked]: armorEnergyCapacity === 10 })}>
           {armorEnergyCapacity}

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -20,42 +20,50 @@ import Sockets from './Sockets';
  */
 function EnergySwap({
   item,
-  lockedMods,
+  assignedMods,
 }: {
   item: DimItem;
-  lockedMods: PluggableInventoryItemDefinition[];
+  assignedMods?: PluggableInventoryItemDefinition[];
 }) {
   const defs = useD2Definitions()!;
-  const modCost = _.sumBy(lockedMods, (mod) => mod.plug.energyCost?.energyCost || 0);
-  const itemEnergyCapacity = item.energy?.energyCapacity || 0;
+
+  const armorEnergyCapacity = item.energy?.energyCapacity || 0;
   const armorEnergy = defs.EnergyType.get(item.energy!.energyTypeHash);
-  const modEnergyHash = lockedMods.find(
+
+  const modCost = _.sumBy(assignedMods, (mod) => mod.plug.energyCost?.energyCost || 0);
+  const modEnergyHash = assignedMods?.find(
     (mod) => mod.plug.energyCost?.energyType !== DestinyEnergyType.Any
   )?.plug.energyCost?.energyTypeHash;
   const modEnergy = (modEnergyHash && defs.EnergyType.get(modEnergyHash)) || null;
-  const resultingEnergyCapacity =
-    modEnergy && armorEnergy.hash === modEnergy.hash
-      ? Math.max(itemEnergyCapacity, modCost)
-      : modCost;
+
+  const resultingEnergy = modEnergy ? modEnergy : armorEnergy;
+  let resultingEnergyCapacity = armorEnergyCapacity;
+
+  if (modEnergyHash === armorEnergy.hash) {
+    resultingEnergyCapacity = Math.max(armorEnergyCapacity, modCost);
+  } else if (modEnergy) {
+    resultingEnergyCapacity = modCost;
+  }
+
+  const showChange =
+    resultingEnergyCapacity !== armorEnergyCapacity || resultingEnergy !== armorEnergy;
 
   return (
-    modEnergy && (
-      <div className={styles.energySwapContainer}>
-        <div className={styles.energyValue}>
-          <div className={clsx({ [styles.masterworked]: itemEnergyCapacity === 10 })}>
-            {itemEnergyCapacity}
-          </div>
-          <BungieImage className={styles.energyIcon} src={armorEnergy.displayProperties.icon} />
+    <div className={clsx(styles.energySwapContainer, { [styles.energyHidden]: !showChange })}>
+      <div className={styles.energyValue}>
+        <div className={clsx({ [styles.masterworked]: armorEnergyCapacity === 10 })}>
+          {armorEnergyCapacity}
         </div>
-        <div className={styles.arrow}>{'➜'}</div>
-        <div className={styles.energyValue}>
-          <div className={clsx({ [styles.masterworked]: resultingEnergyCapacity === 10 })}>
-            {resultingEnergyCapacity}
-          </div>
-          <BungieImage className={styles.energyIcon} src={modEnergy.displayProperties.icon} />
-        </div>
+        <BungieImage className={styles.energyIcon} src={armorEnergy.displayProperties.icon} />
       </div>
-    )
+      <div className={styles.arrow}>{'➜'}</div>
+      <div className={styles.energyValue}>
+        <div className={clsx({ [styles.masterworked]: resultingEnergyCapacity === 10 })}>
+          {resultingEnergyCapacity}
+        </div>
+        <BungieImage className={styles.energyIcon} src={resultingEnergy.displayProperties.icon} />
+      </div>
+    </div>
   );
 }
 
@@ -67,13 +75,15 @@ export default function GeneratedSetItem({
   item,
   locked,
   itemOptions,
-  lockedMods,
+  assignedMods,
+  showEnergyChanges,
   lbDispatch,
 }: {
   item: DimItem;
   locked?: readonly LockedItemType[];
   itemOptions: DimItem[];
-  lockedMods?: PluggableInventoryItemDefinition[];
+  assignedMods?: PluggableInventoryItemDefinition[];
+  showEnergyChanges: boolean;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
   const addLockedItem = (item: LockedItemType) => lbDispatch({ type: 'addItemToLockedMap', item });
@@ -113,7 +123,7 @@ export default function GeneratedSetItem({
 
   return (
     <div>
-      {lockedMods && lockedMods.length > 0 && <EnergySwap item={item} lockedMods={lockedMods} />}
+      {showEnergyChanges && <EnergySwap item={item} assignedMods={assignedMods} />}
       <div className={styles.item}>
         <div className={styles.swapButtonContainer}>
           <LoadoutBuilderItem item={item} locked={locked} addLockedItem={addLockedItem} />
@@ -140,7 +150,7 @@ export default function GeneratedSetItem({
           )}
         </div>
         <div className={styles.lockedSockets}>
-          <Sockets item={item} lockedMods={lockedMods} onSocketClick={onSocketClick} />
+          <Sockets item={item} lockedMods={assignedMods} onSocketClick={onSocketClick} />
         </div>
       </div>
     </div>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -36,7 +36,7 @@ function EnergySwap({
   )?.plug.energyCost?.energyTypeHash;
   const modEnergy = (modEnergyHash && defs.EnergyType.get(modEnergyHash)) || null;
 
-  const resultingEnergy = modEnergy ? modEnergy : armorEnergy;
+  const resultingEnergy = modEnergy ?? armorEnergy;
   let resultingEnergyCapacity = armorEnergyCapacity;
 
   if (modEnergyHash === armorEnergy.hash) {


### PR DESCRIPTION
This fixes the janky display of energy swaps when adding mods.

Fixes #6993 

<img width="1440" alt="Screen Shot 2021-09-05 at 11 14 14 am" src="https://user-images.githubusercontent.com/7344652/132111787-4078b27c-4b7e-4377-b850-c31e505e8e41.png">

<img width="1440" alt="Screen Shot 2021-09-05 at 11 19 01 am" src="https://user-images.githubusercontent.com/7344652/132111822-95d292d0-9932-43bb-be19-5618cff80119.png">

<img width="1440" alt="Screen Shot 2021-09-05 at 11 17 32 am" src="https://user-images.githubusercontent.com/7344652/132111807-0bd75d2e-f0f7-4968-91ad-6540b71db5c2.png">
