### PR TITLE
added titles for compare buttons for clarity

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added a "pull" button (down-arrow) to each item in the Compare tool that will pull the item to your current character.
 * Collapsed the Tag menu into an icon in Compare to allow more items to fit on screen.
 * Shortened the names of stats in Compare to allow more items to fit on screen.
+* Added hover titles to the new compare buttons for more clarity.
 
 ## 6.81.0 <span class="changelog-date">(2021-09-05)</span>
 

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -59,7 +59,7 @@ export default function CompareItem({
     () => (
       <div ref={headerRef}>
         <div className={styles.header}>
-          <ActionButton onClick={pullItem}>
+          <ActionButton title={t('Hotkey.Pull')} onClick={pullItem}>
             <AppIcon icon={faArrowCircleDown} />
           </ActionButton>
           <LockActionButton item={item} />

--- a/src/app/item-actions/ActionButtons.tsx
+++ b/src/app/item-actions/ActionButtons.tsx
@@ -78,6 +78,7 @@ export function TagActionButton({
 
   return (
     <div
+      title={t('Tags.TagItem')}
       className={clsx(styles.entry, {
         [styles.tagSelectorLabelHidden]: !label,
       })}


### PR DESCRIPTION
this adds titles to the pull and tag buttons in the new compare view. it won't help mobile much but will help desktop users with these. 