### PR TITLE
Fixing an issue where the Progress win streak count is not displaying correctly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Shortened the names of stats in Compare to allow more items to fit on screen.
 * Added hover titles to the new compare buttons for more clarity.
 * Selecting "Add Unequipped" in the loadout editor no longer tries to equip all your unequipped items.
+* Progress win streak will now correctly display when a user hits a 5 win streak.
 
 ## 6.81.0 <span class="changelog-date">(2021-09-05)</span>
 

--- a/src/app/progress/CrucibleRank.tsx
+++ b/src/app/progress/CrucibleRank.tsx
@@ -24,7 +24,7 @@ export function CrucibleRank({ progress, streak }: CrucibleRankProps) {
 
   const rankTotal = _.sumBy(progressionDef.steps, (cur) => cur.progressTotal);
 
-  const streakCheckboxes = streak && Array(5).fill(true).fill(false, streak.stepIndex);
+  const streakCheckboxes = streak && Array(5).fill(true).fill(false, streak.currentProgress);
 
   // language-agnostic css class name to identify which rank type we are in
   const factionClass = `faction-${progress.progressionHash}`;


### PR DESCRIPTION
Currently, if a user is on a 5 win streak, this is displayed as a 4 win streak.
I edited the Progress streak to point to the currentProgress property, which accurately displays the current win streak.