### PR TITLE
Loadout optimizer: Order exotic slots in exotic picker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Selecting "Add Unequipped" in the loadout editor no longer tries to equip all your unequipped items.
 * Progress win streak will now correctly display when a user hits a 5 win streak.
 * Fixed broken description for some new triumphs.
+* Loadout Optimizer's exotic picker now consistently orders slots.
 
 ## 6.81.0 <span class="changelog-date">(2021-09-05)</span>
 

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -16,6 +16,7 @@ import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { LockableBucketHashes } from '../types';
 import styles from './ExoticPicker.m.scss';
 import ExoticTile, { LockedExoticWithPlugs } from './ExoticTile';
 
@@ -38,7 +39,10 @@ function findLockableExotics(
   const exotics = allItems.filter(
     (item) => item.isExotic && item.classType === classType && isLoadoutBuilderItem(item)
   );
-  const uniqueExotics = _.uniqBy(exotics, (item) => item.hash);
+  const orderedExotics = _.sortBy(exotics, (item) =>
+    LockableBucketHashes.indexOf(item.bucket.hash)
+  );
+  const uniqueExotics = _.uniqBy(orderedExotics, (item) => item.hash);
 
   // Add in armor 1 exotics that don't have an armor 2 version
   const exoticArmorWithoutEnergy = allItems.filter(

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -21,7 +21,7 @@ import { isLoadoutBuilderItem } from '../../loadout/item-utils';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import LoadoutBucketDropTarget from '../LoadoutBucketDropTarget';
 import {
-  LockableBuckets,
+  LockableBucketHashes,
   LockedExclude,
   LockedItemCase,
   LockedItemType,
@@ -107,7 +107,6 @@ function LockArmorAndPerks({
     async (e: React.MouseEvent) => {
       e.preventDefault();
 
-      const order = Object.values(LockableBuckets);
       try {
         const { item } = await showItemPicker({
           filterItems: (item: DimItem) =>
@@ -116,7 +115,7 @@ function LockArmorAndPerks({
                 itemCanBeEquippedBy(item, selectedStore, true) &&
                 (!filter || filter(item))
             ),
-          sortBy: (item) => order.indexOf(item.bucket.hash),
+          sortBy: (item) => LockableBucketHashes.indexOf(item.bucket.hash),
         });
 
         updateFunc(item);
@@ -172,9 +171,8 @@ function LockArmorAndPerks({
     (item) => item.type
   );
 
-  const order = Object.values(LockableBuckets);
   flatLockedMap = _.mapValues(flatLockedMap, (items) =>
-    _.sortBy(items, (i: LockedItemCase) => order.indexOf(i.bucket.hash))
+    _.sortBy(items, (i: LockedItemCase) => LockableBucketHashes.indexOf(i.bucket.hash))
   );
 
   const storeIds = stores.filter((s) => !s.isVault).map((s) => s.id);

--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -7,7 +7,7 @@ import { doEnergiesMatch } from './mod-utils';
 import {
   bucketsToCategories,
   ItemsByBucket,
-  LockableBuckets,
+  LockableBucketHashes,
   LockedItemType,
   LockedMap,
 } from './types';
@@ -32,7 +32,7 @@ export function filterItems(
 
   const lockedModMap = _.groupBy(lockedMods, (mod) => mod.plug.plugCategoryHash);
 
-  Object.values(LockableBuckets).forEach((bucket) => {
+  LockableBucketHashes.forEach((bucket) => {
     const locked = lockedMap[bucket];
     const lockedModsByPlugCategoryHash = lockedModMap[bucketsToCategories[bucket]];
 


### PR DESCRIPTION
Without this, the exotic picker displays gauntlets last on my Hunter and Titan. I presume this is different between players and may change.

This uses the same sorting approach as other places in the loadout optimizer (such as the armor lock popup), which I updated to use `LockableBucketHashes` consistently.