### PR TITLE
Add a tip for how to scroll Compare on iOS

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -75,7 +75,8 @@
     "Error": {
       "Unmatched": "This item doesn't match the type of items being compared."
     },
-    "Splits": "Compare similar splits ({{quantity}})"
+    "Splits": "Compare similar splits ({{quantity}})",
+    "SwipeAdvice": "Use two fingers to scroll"
   },
   "Cooldown": {
     "Grenade": "Grenade cooldown: {{cooldown}}",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Seasonal artifact display now matches the games display.
 * Ritual rank progress for vendors now matches the ritual rank circle shape.
 * Fixed vendor ranks being off by 1.
+* Accounts list shows your Bungie Name.
+* Add a tip for how to scroll Compare on iOS.
 
 ## 6.81.0 <span class="changelog-date">(2021-09-05)</span>
 

--- a/src/app/compare/Compare.m.scss
+++ b/src/app/compare/Compare.m.scss
@@ -73,3 +73,10 @@
     height: auto;
   }
 }
+
+.swipeAdvice {
+  width: min-content;
+  white-space: normal;
+  color: #999;
+  padding: 8px 0;
+}

--- a/src/app/compare/Compare.m.scss.d.ts
+++ b/src/app/compare/Compare.m.scss.d.ts
@@ -9,6 +9,7 @@ interface CssExports {
   'sorted': string;
   'spacer': string;
   'statLabel': string;
+  'swipeAdvice': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -7,7 +7,9 @@ import { setSettingAction } from 'app/settings/actions';
 import Checkbox from 'app/settings/Checkbox';
 import { Settings } from 'app/settings/initial-settings';
 import { AppIcon, faAngleLeft, faAngleRight, faList } from 'app/shell/icons';
+import { isPhonePortraitSelector } from 'app/shell/selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { isiOSBrowser } from 'app/utils/browsers';
 import { emptyArray } from 'app/utils/empty';
 import { getSocketByIndex } from 'app/utils/socket-utils';
 import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
@@ -43,6 +45,7 @@ interface StoreProps {
   session?: CompareSession;
   compareBaseStats: boolean;
   organizerLink?: string;
+  isPhonePortrait: boolean;
 }
 
 type Props = StoreProps & ThunkDispatchProp;
@@ -54,6 +57,7 @@ function mapStateToProps(state: RootState): StoreProps {
     compareItems: compareItemsSelector(state),
     session: compareSessionSelector(state),
     organizerLink: compareOrganizerLinkSelector(state),
+    isPhonePortrait: isPhonePortraitSelector(state),
   };
 }
 
@@ -79,6 +83,7 @@ function Compare({
   compareItems,
   session,
   organizerLink,
+  isPhonePortrait,
   dispatch,
 }: Props) {
   /** The stat row to highlight */
@@ -268,6 +273,9 @@ function Compare({
                 )}
               </div>
             ))}
+            {isPhonePortrait && isiOSBrowser() && (
+              <div className={styles.swipeAdvice}>{t('Compare.SwipeAdvice')}</div>
+            )}
           </div>
           <div className={styles.items}>
             {sortedComparisonItems.map((item) => (

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -10,6 +10,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { startWordRegexp } from 'app/search/search-filters/freeform';
 import { AppIcon, searchIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { isiOSBrowser } from 'app/utils/browsers';
 import { compareBy } from 'app/utils/comparators';
 import { DestinyClass, TierType } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
@@ -160,8 +161,7 @@ export default function ExoticPicker({ lockedExoticHash, classType, onSelected, 
     [language, query, lockableExotics]
   );
 
-  const autoFocus =
-    !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
+  const autoFocus = !isPhonePortrait && !isiOSBrowser();
 
   return (
     <Sheet

--- a/src/app/loadout/mod-picker/ModPicker.tsx
+++ b/src/app/loadout/mod-picker/ModPicker.tsx
@@ -11,6 +11,7 @@ import { SearchFilterRef } from 'app/search/SearchBar';
 import { AppIcon, searchIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
+import { isiOSBrowser } from 'app/utils/browsers';
 import { DestinyClass, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -210,8 +211,7 @@ function ModPicker({ mods, language, lockedMods, initialQuery, onAccept, onClose
     _.groupBy(queryFilteredMods, (mod) => mod.plug.plugCategoryHash)
   ).sort(sortModGroups);
 
-  const autoFocus =
-    !isPhonePortrait && !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
+  const autoFocus = !isPhonePortrait && !isiOSBrowser();
 
   const footer = lockedModsInternal.length
     ? ({ onClose }: { onClose(): void }) => (

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -9,6 +9,7 @@ import { t } from 'app/i18next-t';
 import { toggleSearchResults } from 'app/shell/actions';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
+import { isiOSBrowser } from 'app/utils/browsers';
 import clsx from 'clsx';
 import { useCombobox, UseComboboxState, UseComboboxStateChangeOptions } from 'downshift';
 import { AnimatePresence, AnimateSharedLayout, motion } from 'framer-motion';
@@ -200,10 +201,7 @@ function SearchBar(
   const isPhonePortrait = useIsPhonePortrait();
 
   // On iOS at least, focusing the keyboard pushes the content off the screen
-  const autoFocus =
-    !mainSearchBar &&
-    !isPhonePortrait &&
-    !(/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
+  const autoFocus = !mainSearchBar && !isPhonePortrait && !isiOSBrowser();
 
   const [liveQuery, setLiveQuery] = useState('');
   const [filterHelpOpen, setFilterHelpOpen] = useState(false);

--- a/src/app/utils/browsers.ts
+++ b/src/app/utils/browsers.ts
@@ -1,0 +1,11 @@
+// Utilities for browser detection. In general we avoid browser detection in
+// favor of feature detection but sometimes you just gotta.
+
+const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+/**
+ * Is this an iOS mobile browser (which all use Safari under the covers)?
+ */
+export function isiOSBrowser() {
+  return iOS;
+}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -85,7 +85,8 @@
     "Error": {
       "Unmatched": "This item doesn't match the type of items being compared."
     },
-    "InitialItem": "This is the item the Compare tool was launched from"
+    "InitialItem": "This is the item the Compare tool was launched from",
+    "SwipeAdvice": "Use two fingers to scroll"
   },
   "Cooldown": {
     "Grenade": "Grenade cooldown: {{cooldown}}",
@@ -452,7 +453,6 @@
     "OptimizerExplanationUpgrades": "Select which Armor Upgrades Loadout Optimizer can spend materials on. It may suggest masterworks to increase stats, or energy upgrades and element swaps to fit your requested mods.",
     "OptimizerSet": "Optimizer Set",
     "ProcessingSets": "Processing sets for\n{{character}}",
-    "ResetLocked": "Reset pinned items",
     "SaveAs": "Save as",
     "SelectArmorUpgrade": "Select Armor Upgrades",
     "SelectAssumedArmorUpgrade": "Select Assumed Armor Upgrades",


### PR DESCRIPTION
Not the prettiest, but it puts the information out there.

<img width="256" alt="Screen Shot 2021-09-11 at 12 37 34 PM" src="https://user-images.githubusercontent.com/313208/132959541-ed1ef706-55cf-4b5a-b055-05075a69b7fd.png">
