### PR TITLE
Remove stat range restrictions from TierSelect

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Progress win streak will now correctly display when a user hits a 5 win streak.
 * Fixed broken description for some new triumphs.
 * Loadout Optimizer's exotic picker now consistently orders slots.
+* Loadout Optimizer's stat filters no longer attempt to automatically limit to possible ranges.
 * Added numerical faction ranks alongside rank names on the Progress page.
 * Fixed the order of items in vendors and seasonal vendor upgrade grids.
 * Seasonal artifact display now matches the games display.

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -294,7 +294,6 @@ function LoadoutBuilder({
     <div className={styles.menuContent}>
       <TierSelect
         stats={statFilters}
-        statRanges={result?.statRanges}
         order={statOrder}
         onStatFiltersChanged={(statFilters) =>
           lbDispatch({ type: 'statFiltersChanged', statFilters })

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -4,11 +4,10 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, dragHandleIcon } from 'app/shell/icons';
 import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
-import { ArmorStatHashes, StatFilters, StatRanges } from '../types';
+import { ArmorStatHashes, MinMaxIgnored, StatFilters } from '../types';
 import styles from './TierSelect.m.scss';
 
 const IGNORE = 'ignore';
@@ -16,27 +15,16 @@ const INCLUDE = 'include';
 
 const MinMaxSelect = React.memo(MinMaxSelectInner);
 
-const defaultStatRanges: Readonly<StatRanges> = {
-  [StatHashes.Mobility]: { min: 0, max: 10 },
-  [StatHashes.Resilience]: { min: 0, max: 10 },
-  [StatHashes.Recovery]: { min: 0, max: 10 },
-  [StatHashes.Discipline]: { min: 0, max: 10 },
-  [StatHashes.Intellect]: { min: 0, max: 10 },
-  [StatHashes.Strength]: { min: 0, max: 10 },
-};
-
 /**
  * A selector that allows for choosing minimum and maximum stat ranges, plus reordering the stat priority.
  */
 export default function TierSelect({
   stats,
-  statRanges = defaultStatRanges,
   order,
   onStatOrderChanged,
   onStatFiltersChanged,
 }: {
   stats: StatFilters;
-  statRanges?: Readonly<StatRanges>;
   order: number[]; // stat hashes in user order
   onStatOrderChanged(order: ArmorStatHashes[]): void;
   onStatFiltersChanged(stats: StatFilters): void;
@@ -91,19 +79,19 @@ export default function TierSelect({
               >
                 <MinMaxSelect
                   statHash={statHash}
-                  stats={stats}
+                  stat={stats[statHash]}
                   type="Min"
-                  min={statRanges[statHash].min}
-                  max={statRanges[statHash].max}
+                  min={0}
+                  max={10}
                   ignored={stats[statHash].ignored}
                   handleTierChange={handleTierChange}
                 />
                 <MinMaxSelect
                   statHash={statHash}
-                  stats={stats}
+                  stat={stats[statHash]}
                   type="Max"
-                  min={statRanges[statHash].min}
-                  max={statRanges[statHash].max}
+                  min={0}
+                  max={10}
                   ignored={stats[statHash].ignored}
                   handleTierChange={handleTierChange}
                 />
@@ -157,7 +145,7 @@ function MinMaxSelectInner({
   min,
   max,
   ignored,
-  stats,
+  stat,
   handleTierChange,
 }: {
   statHash: number;
@@ -165,7 +153,7 @@ function MinMaxSelectInner({
   min: number;
   max: number;
   ignored: boolean;
-  stats: StatFilters;
+  stat: MinMaxIgnored;
   handleTierChange(
     statHash: number,
     changed: {
@@ -175,7 +163,7 @@ function MinMaxSelectInner({
     }
   ): void;
 }) {
-  const statSetting = stats[statHash];
+  const statSetting = stat;
 
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     let update: {


### PR DESCRIPTION
Fixes #7044. This is a change I was going to do anyway to try and de-mystify LO but I'm speeding it up since saving stat ranges seems to render LO unusable at times and I don't have time to figure out how to unbreak it more subtly.