### PR TITLE
fix armory link spacing

### DIFF
--- a/src/app/armory/Links.tsx
+++ b/src/app/armory/Links.tsx
@@ -44,7 +44,8 @@ export default function Links({ item }: { item: DimItem }) {
           !(isPhonePortrait && hideOnPhone) && (
             <li key={name}>
               <ExternalLink href={link(item, language)}>
-                <img src={icon} height={16} width={16} /> {name}
+                <img src={icon} height={16} width={16} />
+                {name}
               </ExternalLink>
             </li>
           )


### PR DESCRIPTION
In regards to: https://github.com/DestinyItemManager/DIM/pull/7055#discussion_r708841905

Before: 
![image](https://user-images.githubusercontent.com/4798491/133456886-3b07e18e-e286-4806-ad92-b399f28c54ec.png)

After:
![image](https://user-images.githubusercontent.com/4798491/133456688-eb406953-1852-49f3-87e4-ab625962283e.png)

to be consistent with `loreLink`