### PR TITLE
comparison fixes

### DIFF
--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -1032,7 +1032,9 @@ export function sortMoveAsideCandidatesForStore(
       // Prefer moving lower-tier into the vault and higher tier out
       compareBy((i) => (fromStore.isVault ? tierValue[i.tier] : -tierValue[i.tier])),
       // Prefer keeping higher-stat items on characters
-      compareBy((i) => i.primStat && (fromStore.isVault ? i.primStat.value : -i.primStat.value))
+      compareBy(
+        (i) => (i.primStat && (fromStore.isVault ? i.primStat.value : -i.primStat.value)) || 0
+      )
     )
   );
 

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -590,7 +590,7 @@ function sortRows(
       if (column) {
         const compare = column.sort
           ? (row1: Row, row2: Row) => column.sort!(row1.values[column.id], row2.values[column.id])
-          : compareBy((row: Row) => row.values[column.id]);
+          : compareBy((row: Row) => row.values[column.id] || 0);
         return sorter.sort === SortDirection.ASC ? compare : reverseComparator(compare);
       }
       return compareBy(() => 0);

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -17,7 +17,7 @@ export const sortPursuits = chainComparator(
   compareBy(showPursuitAsExpired),
   compareBy((item) => !item.tracked),
   compareBy((item) => item.complete),
-  compareBy((item) => item.pursuit?.expirationDate || defaultExpirationDate),
+  compareBy((item) => (item.pursuit?.expirationDate || defaultExpirationDate).getTime()),
   compareBy((item) => item.typeName),
   compareBy((item) => item.icon),
   compareBy((item) => item.name)

--- a/src/app/progress/SeasonalChallenges.tsx
+++ b/src/app/progress/SeasonalChallenges.tsx
@@ -26,7 +26,7 @@ export const sortPursuits = chainComparator(
   compareBy(showPursuitAsExpired),
   compareBy((item) => !item.tracked),
   compareBy((item) => item.complete),
-  compareBy((item) => item.pursuit?.expirationDate || defaultExpirationDate),
+  compareBy((item) => (item.pursuit?.expirationDate || defaultExpirationDate).getTime()),
   compareBy((item) => item.typeName),
   compareBy((item) => item.icon),
   compareBy((item) => item.name)

--- a/src/app/utils/comparators.ts
+++ b/src/app/utils/comparators.ts
@@ -7,22 +7,23 @@ export type Comparator<T> = (a: T, b: T) => -1 | 0 | 1;
  * // Returns a comparator that compares items by primary stat
  * compareBy((item) => item.primStat.value)
  */
-export function compareBy<T, V>(fn: (arg: T) => V): Comparator<T> {
+export function compareBy<T>(
+  fn: (arg: T) => number | string | undefined | boolean | bigint
+): Comparator<T> {
   return (a, b) => {
     const aVal = fn(a);
     const bVal = fn(b);
     // Undefined is neither greater than or less than anything. This considers it less than everything.
-    return aVal === undefined
-      ? bVal === undefined
-        ? 0
-        : -1
+
+    return aVal === bVal
+      ? 0 // neither goes first
       : bVal === undefined
-      ? 1
-      : aVal < bVal
-      ? -1
+      ? 1 // b goes first
+      : aVal === undefined || aVal < bVal
+      ? -1 // a goes first
       : aVal > bVal
-      ? 1
-      : 0;
+      ? 1 // b goes first
+      : 0; // a fallback that would catch only invalid inputs
   };
 }
 

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -29,6 +29,8 @@ function itemSort(category: string) {
       compareBy((item) => item.item?.typeName),
       compareBy(vendorItemIndex)
     );
+  } else if (category === 'category_weapon') {
+    return chainComparator<VendorItem>(compareBy((item) => item.item?.itemCategoryHashes[0]));
   } else if (category.startsWith('category_tier')) {
     return undefined;
   } else {

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -14,27 +14,25 @@ import { VendorItem } from './vendor-item';
 import VendorItemComponent from './VendorItemComponent';
 import styles from './VendorItems.m.scss';
 
+function vendorItemIndex(item: VendorItem) {
+  return parseInt(item.item?.index ?? '', 10);
+}
+
 function itemSort(category: string) {
   if (category === 'category.rank_rewards_seasonal') {
     return chainComparator<VendorItem>(
       compareBy((item) => item.item?.tier),
-      compareBy((item) => parseInt(item.item?.id ?? '', 10))
+      compareBy(vendorItemIndex)
     );
   } else if (category === 'category_bounties') {
     return chainComparator<VendorItem>(
       compareBy((item) => item.item?.typeName),
-      compareBy((item) => parseInt(item.item?.id ?? '', 10)),
-      compareBy((item) => item.item?.itemCategoryHashes)
+      compareBy(vendorItemIndex)
     );
-  } else if (category === 'category_weapon') {
-    return chainComparator<VendorItem>(compareBy((item) => item.item?.itemCategoryHashes));
   } else if (category.startsWith('category_tier')) {
     return undefined;
   } else {
-    return chainComparator<VendorItem>(
-      compareBy((item) => parseInt(item.item?.id ?? '', 10)),
-      compareBy((item) => item.item?.itemCategoryHashes)
-    );
+    return chainComparator<VendorItem>(compareBy(vendorItemIndex));
   }
 }
 

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -15,7 +15,7 @@ import VendorItemComponent from './VendorItemComponent';
 import styles from './VendorItems.m.scss';
 
 function vendorItemIndex(item: VendorItem) {
-  return parseInt(item.item?.index ?? '', 10);
+  return item.key;
 }
 
 function itemSort(category: string) {


### PR DESCRIPTION
@bhollis re: comparators.ts
i found this logic to be a lot clearer than the nested ternaries, fewer lines, and equal number of logical tests unless it's fed a somehow completely incomparable value.
i typed it so that it can only accept values that actually work with `<` and `>` operators (and get accurate `===` readings, i.e. not `Date`)

@inexorableAce @delphiactual re: VendorItems.tsx 
- apologize for not catching this but you can't lessthan/greaterthan an array, so ICH needed to go, unless you wanted to change this to maybe get last ICH in the array and compare that?
- VendorItem.key is directly set from the item's index at that vendor, which is I think what you're trying to sort by. this skips using semi-related DimItem properties and having to parse a string. i can't see any difference in sorting on vendors screen, or the artifact. can you verify?