### PR TITLE
Clean up feature flags, remove mobile inspect and active mode

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -403,8 +403,6 @@ module.exports = (env) => {
         '$featureFlags.mobileInspect': JSON.stringify(env.release),
         // Enable alternative inventory mode
         '$featureFlags.altInventoryMode': JSON.stringify(false),
-        // Enable search results
-        '$featureFlags.searchResults': JSON.stringify(true),
         // Alternate perks display on item popup
         '$featureFlags.newPerks': JSON.stringify(!env.release),
         // Advanced Write Actions (inserting mods)

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -402,7 +402,7 @@ module.exports = (env) => {
         // Drag and drop mobile inspect
         '$featureFlags.mobileInspect': JSON.stringify(env.release),
         // Enable alternative inventory mode
-        '$featureFlags.altInventoryMode': JSON.stringify(!env.release),
+        '$featureFlags.altInventoryMode': JSON.stringify(false),
         // Enable search results
         '$featureFlags.searchResults': JSON.stringify(true),
         // Alternate perks display on item popup

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -413,8 +413,6 @@ module.exports = (env) => {
         '$featureFlags.abilityCooldowns': JSON.stringify(true),
         // Install prompt banners for mobile
         '$featureFlags.installBanner': JSON.stringify(true),
-        // Header banner when postmaster is full
-        '$featureFlags.postmasterBanner': JSON.stringify(true),
       }),
 
       new LodashModuleReplacementPlugin({

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -409,8 +409,6 @@ module.exports = (env) => {
         '$featureFlags.newPerks': JSON.stringify(!env.release),
         // Advanced Write Actions (inserting mods)
         '$featureFlags.awa': JSON.stringify(process.env.USER === 'brh'), // Only Ben has the keys...
-        // Incorporate mods directly into loadouts
-        '$featureFlags.loadoutMods': JSON.stringify(true),
         // Ability cooldowns in stats tooltips
         '$featureFlags.abilityCooldowns': JSON.stringify(true),
         // Install prompt banners for mobile

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -411,8 +411,6 @@ module.exports = (env) => {
         '$featureFlags.awa': JSON.stringify(process.env.USER === 'brh'), // Only Ben has the keys...
         // Ability cooldowns in stats tooltips
         '$featureFlags.abilityCooldowns': JSON.stringify(true),
-        // Install prompt banners for mobile
-        '$featureFlags.installBanner': JSON.stringify(true),
       }),
 
       new LodashModuleReplacementPlugin({

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -400,7 +400,7 @@ module.exports = (env) => {
         // Show the triage tab in the item popup
         '$featureFlags.triage': JSON.stringify(env.dev),
         // Drag and drop mobile inspect
-        '$featureFlags.mobileInspect': JSON.stringify(true),
+        '$featureFlags.mobileInspect': JSON.stringify(env.release),
         // Enable alternative inventory mode
         '$featureFlags.altInventoryMode': JSON.stringify(!env.release),
         // Enable search results

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -393,8 +393,6 @@ module.exports = (env) => {
         '$featureFlags.debugSW': JSON.stringify(!env.release),
         // Send exception reports to Sentry.io on beta/prod only
         '$featureFlags.sentry': JSON.stringify(!env.dev),
-        // Respect the "do not track" header
-        '$featureFlags.respectDNT': JSON.stringify(!env.release),
         // Community-curated wish lists
         '$featureFlags.wishLists': JSON.stringify(true),
         // Show a banner for supporting a charitable cause

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### Beta Only
 
-* Removed the press-and-hold mobile item menu, which saw very limited use.
 * Removed the press-and-hold mobile item menu, which saw very limited use. This will also be removed in the release version after some time.
 * Removed the "Active Mode" experiment - its ideas will come back in the future in other forms, but for now it doesn't offer enough above the Progress page (which can be opened in another tab/window next to Inventory if you want to see both).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@
 * Armor in Collections now shows what mod slots it has.
 * Fixed vendor items showing some incorrect wishlist matches.
 
+### Beta Only
+
+* Removed the press-and-hold mobile item menu, which saw very limited use.
+* Removed the press-and-hold mobile item menu, which saw very limited use. This will also be removed in the release version after some time.
+* Removed the "Active Mode" experiment - its ideas will come back in the future in other forms, but for now it doesn't offer enough above the Progress page (which can be opened in another tab/window next to Inventory if you want to see both).
+
 ## 6.82.0 <span class="changelog-date">(2021-09-12)</span>
 
 * Loadout Optimizer remembers stats you've Ignored between sessions.

--- a/src/app/google.js
+++ b/src/app/google.js
@@ -1,33 +1,25 @@
 import { getToken } from 'app/bungie-api/oauth-tokens';
 
-// Respect "do not track"
-// https://www.paulfurley.com/google-analytics-do-not-track/
-const dnt = navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
-if (!$featureFlags.respectDNT || (dnt != '1' && dnt != 'yes')) {
-  (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r;
-    (i[r] =
-      i[r] ||
-      function () {
-        (i[r].q = i[r].q || []).push(arguments);
-      }),
-      (i[r].l = 1 * new Date());
-    (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m);
-  })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+(function (i, s, o, g, r, a, m) {
+  i['GoogleAnalyticsObject'] = r;
+  (i[r] =
+    i[r] ||
+    function () {
+      (i[r].q = i[r].q || []).push(arguments);
+    }),
+    (i[r].l = 1 * new Date());
+  (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+  a.async = 1;
+  a.src = g;
+  m.parentNode.insertBefore(a, m);
+})(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-  ga('create', $DIM_FLAVOR === 'release' ? 'UA-60316581-1' : 'UA-60316581-5', 'auto');
-  ga('set', 'anonymizeIp', true);
-  ga('set', 'dimension1', $DIM_VERSION);
-  ga('set', 'dimension2', $DIM_FLAVOR);
+ga('create', $DIM_FLAVOR === 'release' ? 'UA-60316581-1' : 'UA-60316581-5', 'auto');
+ga('set', 'anonymizeIp', true);
+ga('set', 'dimension1', $DIM_VERSION);
+ga('set', 'dimension2', $DIM_FLAVOR);
 
-  const token = getToken();
-  if (token && token.bungieMembershipId) {
-    ga('set', 'userId', token.bungieMembershipId);
-  }
-} else {
-  // Fake "ga" function so code that depends on it still works
-  window.ga = window.ga || function () {};
+const token = getToken();
+if (token && token.bungieMembershipId) {
+  ga('set', 'userId', token.bungieMembershipId);
 }

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -154,13 +154,11 @@ export default function LoadoutDrawerContents(
           />
         ))}
       </div>
-      {$featureFlags.loadoutMods && (
-        <SavedMods
-          savedMods={savedMods}
-          onOpenModPicker={onOpenModPicker}
-          removeModByHash={removeModByHash}
-        />
-      )}
+      <SavedMods
+        savedMods={savedMods}
+        onOpenModPicker={onOpenModPicker}
+        removeModByHash={removeModByHash}
+      />
     </>
   );
 }

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -66,7 +66,7 @@ function MainSearchBarActions({
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}
         >
-          {$featureFlags.searchResults && showSearchResults ? (
+          {showSearchResults ? (
             <button
               type="button"
               className={styles.resultButton}
@@ -86,8 +86,7 @@ function MainSearchBarActions({
         </motion.div>
       )}
 
-      {$featureFlags.searchResults &&
-        showSearchResults &&
+      {showSearchResults &&
         searchResultsOpen &&
         ReactDOM.createPortal(
           <SearchResults

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -348,7 +348,7 @@ export default function Header() {
       {$featureFlags.installBanner && isPhonePortrait && installable && (
         <AppInstallBanner onClick={installDim} />
       )}
-      {$featureFlags.postmasterBanner && <PostmasterWarningBanner />}
+      <PostmasterWarningBanner />
       {promptIosPwa &&
         ReactDOM.createPortal(
           <Sheet header={<h1>{t('Header.InstallDIM')}</h1>} onClose={() => setPromptIosPwa(false)}>

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -345,9 +345,7 @@ export default function Header() {
           <SearchFilter onClear={hideSearch} ref={searchFilter} />
         </span>
       )}
-      {$featureFlags.installBanner && isPhonePortrait && installable && (
-        <AppInstallBanner onClick={installDim} />
-      )}
+      {isPhonePortrait && installable && <AppInstallBanner onClick={installDim} />}
       <PostmasterWarningBanner />
       {promptIosPwa &&
         ReactDOM.createPortal(

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -40,8 +40,6 @@ declare const $featureFlags: {
   awa: boolean;
   /** Whether ability cooldowns are shown in stats tooltips */
   abilityCooldowns: boolean;
-  /** Install prompt banners for mobile */
-  installBanner: boolean;
 };
 
 declare function ga(...params: string[]);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -42,8 +42,6 @@ declare const $featureFlags: {
   abilityCooldowns: boolean;
   /** Install prompt banners for mobile */
   installBanner: boolean;
-  /** Header banner when postmaster is full */
-  postmasterBanner: boolean;
 };
 
 declare function ga(...params: string[]);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -18,8 +18,6 @@ declare const $featureFlags: {
   sentry: boolean;
   /** D2 Vendors */
   vendors: boolean;
-  /** Respect the "do not track" header. */
-  respectDNT: boolean;
   /** Community-curated wish lists */
   wishLists: boolean;
   /** Show a banner for supporting a charitable cause */

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -38,8 +38,6 @@ declare const $featureFlags: {
   newPerks: boolean;
   /** Advanced Write Actions (inserting mods) */
   awa: boolean;
-  /** Incorporate mods directly into loadouts */
-  loadoutMods: boolean;
   /** Whether ability cooldowns are shown in stats tooltips */
   abilityCooldowns: boolean;
   /** Install prompt banners for mobile */

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -24,8 +24,6 @@ declare const $featureFlags: {
   mobileInspect: boolean;
   /** Enable alt inv mode */
   altInventoryMode: boolean;
-  /** Enable search results */
-  searchResults: boolean;
   /** Alternate perks display on item popup */
   newPerks: boolean;
   /** Advanced Write Actions (inserting mods) */

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -10,26 +10,18 @@ declare const $BROWSERS: string[];
 declare const $featureFlags: {
   /** Print debug info to console about item moves */
   debugMoves: boolean;
-  /** Enable color-blind a11y */
-  colorA11y: boolean;
   /** Debug Service Worker */
   debugSW: boolean;
   /** Send exception reports to Sentry.io */
   sentry: boolean;
-  /** D2 Vendors */
-  vendors: boolean;
   /** Community-curated wish lists */
   wishLists: boolean;
   /** Show a banner for supporting a charitable cause */
   issueBanner: boolean;
-  /** Show confetti */
-  confetti: boolean;
   /** Show the triage tab in the item popup */
   triage: boolean;
   /** Enable new mobile inspect view when dragging an item */
   mobileInspect: boolean;
-  /** Enable move amounts */
-  moveAmounts: boolean;
   /** Enable alt inv mode */
   altInventoryMode: boolean;
   /** Enable search results */


### PR DESCRIPTION
I'll leave this open for a bit to gather comments. Mostly this is a cleanup of old flags, but there are two that I expect to hear some wailing and gnashing of teeth on - the removal of the mobile inspect menu and the removal of Active Mode. 

Mobile Inspect was super cool but I don't think actually got a lot of use vs. people going through the item popup.

Active Mode has sort of confusing value for me vs. the Progress page, and as far as I could see there was no plan to get it into a state where it could appear in the release version. I'd like to revisit some of its ideas (e.g. a bounty tracker sidebar) in a different form.