### PR TITLE
add DimItem.vendor property / introduce makeItem overrides

### DIFF
--- a/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
@@ -19,7 +19,8 @@ export default function LoadoutBuilderItem({ item, shiftClickCallback }: Props) 
       shiftClickCallback(item);
     });
 
-  if (item.isVendorItem) {
+  // no owner means this is a vendor item
+  if (!item.owner) {
     return (
       <div className="loadout-builder-item">
         <DraggableInventoryItem item={item}>

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -193,7 +193,7 @@ export function getSetBucketsStep(
                         };
                       }
 
-                      set.includesVendorItems = pieces.some((armor) => armor.item.isVendorItem);
+                      set.includesVendorItems = pieces.some((armor) => !armor.item.owner);
                     }
 
                     processedCount++;

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -193,6 +193,7 @@ export function getSetBucketsStep(
                         };
                       }
 
+                      // no owner means this is a vendor item
                       set.includesVendorItems = pieces.some((armor) => !armor.item.owner);
                     }
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -59,8 +59,8 @@ export interface DimItem {
   tier: Tier;
   /** Is this an Exotic item? */
   isExotic: boolean;
-  /** Did this come from a vendor instead of character inventory? */
-  isVendorItem: boolean;
+  /** If this came from a vendor (instead of character inventory), this houses enough information to re-identify the item. */
+  vendor?: { vendorHash: number; saleIndex: number };
   /** Localized name of the item. */
   name: string;
   /** Localized description of the item. */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -246,7 +246,6 @@ function makeItem(
     itemCategoryHashes: itemDef.itemCategoryHashes || [],
     tier: tiers[itemDef.tierType] || 'Common',
     isExotic: tiers[itemDef.tierType] === 'Exotic',
-    isVendorItem: !owner || owner.id === null,
     name: itemDef.itemName,
     description: itemDef.itemDescription || '', // Added description for Bounties for now JFLAY2015
     icon: itemDef.icon,

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -239,7 +239,6 @@ function makeFakePursuitItem(
     itemCategoryHashes: [], // see defs.ItemCategory
     tier: 'Rare',
     isExotic: false,
-    isVendorItem: false,
     name: displayProperties.name,
     description: displayProperties.description,
     icon: displayProperties.icon || '/img/misc/missing_icon_d2.png',

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -130,15 +130,31 @@ export class VendorItem {
       this.previewVendorHash = inventoryItem.preview.previewVendorHash;
     }
 
+    // Fix for ada-1 bounties ... https://github.com/Bungie-net/api/issues/1522
+    // changes their sort to match the game
+    if (itemHash === 3675595381 || itemHash === 171866827) {
+      this.key = itemHash === 3675595381 ? 1 : 4;
+    }
+
+    // override the DimItem.id for vendor items, so they are each unique enough to identify
+    // (otherwise they'd get their vendor index as an id, which is only unique per-vendor)
+    const overrides: Partial<DimItem> = { id: `${vendorHash}-${this.key.toString()}` };
+
+    // if this is sold by a vendor, add vendor information
+    if (saleItem) {
+      overrides.vendor = { vendorHash, saleIndex: saleItem.vendorItemIndex };
+    }
+
     this.item = makeFakeItem(
       defs,
       buckets,
       itemComponents,
       itemHash,
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
-      saleItem ? saleItem.vendorItemIndex.toString() : itemHash.toString(),
+      this.key.toString(),
       vendorItemDef ? vendorItemDef.quantity : 1,
-      mergedCollectibles
+      mergedCollectibles,
+      overrides
     );
 
     if (this.item) {

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -29,11 +29,6 @@ export const wishListFunctionSelector = createSelector(
     // Cache of inventory item id to roll. For this to work, make sure vendor/collections rolls have unique ids.
     const cache = new Map<string, InventoryWishListRoll | undefined>();
     return (item: DimItem) => {
-      // don't cache vendor items because they don't have a safe cache key (yet)
-      if (item.isVendorItem) {
-        return getInventoryWishListRoll(item, wishlists);
-      }
-
       if (cache.has(item.id)) {
         return cache.get(item.id);
       }


### PR DESCRIPTION
- swap out the `isVendorItem` bool for `.vendor` data, allowing a DimItem to be better aware of its source.
enables comparison of vendor items later (might also require passing in the character id)
- enable an `overrides` param for makeItem, so item factory itself can house fewer odd exceptions, and instead, more specific features can pass in necessary changes