### PR TITLE
DimItem vendor data

### DIFF
--- a/src/app/active-mode/Views/activity-util.ts
+++ b/src/app/active-mode/Views/activity-util.ts
@@ -9,7 +9,7 @@ import { refresh } from 'app/shell/refresh';
 import { RootState } from 'app/store/types';
 import { toVendor } from 'app/vendors/d2-vendors';
 import { vendorsByCharacterSelector } from 'app/vendors/selectors';
-import { VendorItem } from 'app/vendors/vendor-item';
+import type { VendorItem } from 'app/vendors/vendor-item';
 import { DestinyCharacterActivitiesComponent } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import pursuitsInfo from 'data/d2/pursuits.json';
@@ -98,6 +98,7 @@ export const purchasableBountiesSelector = (store: DimStore) =>
           buckets,
           vendor,
           account,
+          store.id,
           itemComponents[vendorHash],
           sales.data?.[vendorHash]?.saleItems,
           {}

--- a/src/app/active-mode/Views/current-activity/VendorBounties.tsx
+++ b/src/app/active-mode/Views/current-activity/VendorBounties.tsx
@@ -11,7 +11,7 @@ import { DimStore } from 'app/inventory/store-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { PursuitsGroup } from 'app/progress/Pursuits';
 import { RootState } from 'app/store/types';
-import { VendorItem } from 'app/vendors/vendor-item';
+import type { VendorItem } from 'app/vendors/vendor-item';
 import { DestinyCharacterActivitiesComponent } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import { connect } from 'react-redux';

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
@@ -19,7 +19,8 @@ export default function LoadoutBuilderItem({ item, shiftClickCallback }: Props) 
       shiftClickCallback(item);
     });
 
-  if (item.isVendorItem) {
+  // no owner means this is a vendor item
+  if (!item.owner) {
     return (
       <div className="loadout-builder-item">
         <DraggableInventoryItem item={item}>

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -193,7 +193,8 @@ export function getSetBucketsStep(
                         };
                       }
 
-                      set.includesVendorItems = pieces.some((armor) => armor.item.isVendorItem);
+                      // no owner means this is a vendor item
+                      set.includesVendorItems = pieces.some((armor) => !armor.item.owner);
                     }
 
                     processedCount++;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -59,8 +59,8 @@ export interface DimItem {
   tier: Tier;
   /** Is this an Exotic item? */
   isExotic: boolean;
-  /** Did this come from a vendor instead of character inventory? */
-  isVendorItem: boolean;
+  /** If this came from a vendor (instead of character inventory), this houses enough information to re-identify the item. */
+  vendor?: { vendorHash: number; saleIndex: number; characterId: string };
   /** Localized name of the item. */
   name: string;
   /** Localized description of the item. */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -246,7 +246,6 @@ function makeItem(
     itemCategoryHashes: itemDef.itemCategoryHashes || [],
     tier: tiers[itemDef.tierType] || 'Common',
     isExotic: tiers[itemDef.tierType] === 'Exotic',
-    isVendorItem: !owner || owner.id === null,
     name: itemDef.itemName,
     description: itemDef.itemDescription || '', // Added description for Bounties for now JFLAY2015
     icon: itemDef.icon,

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -7,6 +7,7 @@ import {
   DestinyAmmunitionType,
   DestinyClass,
   DestinyCollectibleComponent,
+  DestinyCollectibleState,
   DestinyInventoryItemDefinition,
   DestinyItemComponent,
   DestinyItemComponentSetOfint64,
@@ -206,7 +207,9 @@ export function makeItemSingle(
  * @param previousItems a set of item IDs representing the previous store's items
  * @param newItems a set of item IDs representing the previous list of new items
  * @param item "raw" item from the Destiny API
- * @param owner the ID of the owning store.
+ * @param owner the ID of the owning store
+ * @param mergedCollectibles collectible information so each DimItem is self-aware of whether it's already owned
+ * @param uninstancedItemObjectives the owning character's dictionary of uninstanced objectives
  */
 // TODO: extract individual item components first!
 export function makeItem(
@@ -329,9 +332,17 @@ export function makeItem(
     itemDef.iconWatermarkShelved ||
     undefined;
 
-  const collectible =
-    itemDef.collectibleHash && mergedCollectibles && mergedCollectibles[itemDef.collectibleHash];
+  // collection stuff: establish a collectedness state, and hashes leading to the collectible and source
+  const { collectibleHash } = itemDef;
+  let collectibleState: DestinyCollectibleState | undefined;
+  if (collectibleHash) {
+    collectibleState = mergedCollectibles?.[collectibleHash]?.state;
+  }
+  const source = collectibleHash
+    ? defs.Collectible.get(collectibleHash, itemDef.hash)?.sourceHash
+    : undefined;
 
+  // items' appearance can be overridden at bungie's request
   let overrideStyleItem = item.overrideStyleItemHash
     ? defs.InventoryItem.get(item.overrideStyleItemHash)
     : null;
@@ -371,7 +382,6 @@ export function makeItem(
     itemCategoryHashes: itemDef.itemCategoryHashes || [], // see defs.ItemCategory
     tier: tiers[itemDef.inventory!.tierType] || 'Common',
     isExotic: tiers[itemDef.inventory!.tierType] === 'Exotic',
-    isVendorItem: !owner || owner.id === null,
     name,
     description: displayProperties.description,
     icon:
@@ -385,12 +395,7 @@ export function makeItem(
       itemDef.nonTransferrable || item.transferStatus === TransferStatuses.NotTransferrable
     ),
     canPullFromPostmaster: !itemDef.doesPostmasterPullHaveSideEffects,
-    id:
-      item.itemHash === 3675595381 // Fix for ada-1 bounties ... https://github.com/Bungie-net/api/issues/1522
-        ? '1'
-        : item.itemHash === 171866827
-        ? '4'
-        : item.itemInstanceId || '0', // zero for non-instanced is legacy hack
+    id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
     equipped: Boolean(instanceDef?.isEquipped),
     equipment:
       Boolean(itemDef.equippingBlock) && normalBucket.hash !== BucketHashes.SeasonalArtifact, // TODO: this has a ton of good info for the item move logic
@@ -417,11 +422,9 @@ export function makeItem(
     loreHash: itemDef.loreHash,
     previewVendor: itemDef.preview?.previewVendorHash,
     ammoType: itemDef.equippingBlock ? itemDef.equippingBlock.ammoType : DestinyAmmunitionType.None,
-    source: itemDef.collectibleHash
-      ? defs.Collectible.get(itemDef.collectibleHash, itemDef.hash)?.sourceHash
-      : undefined,
-    collectibleState: collectible ? collectible.state : undefined,
-    collectibleHash: itemDef.collectibleHash,
+    source,
+    collectibleState,
+    collectibleHash,
     missingSockets: false,
     displaySource: itemDef.displaySource,
     plug: itemDef.plug && {

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -239,7 +239,6 @@ function makeFakePursuitItem(
     itemCategoryHashes: [], // see defs.ItemCategory
     tier: 'Rare',
     isExotic: false,
-    isVendorItem: false,
     name: displayProperties.name,
     description: displayProperties.description,
     icon: displayProperties.icon || '/img/misc/missing_icon_d2.png',

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -154,6 +154,7 @@ function SingleVendor({
     buckets,
     vendor,
     account,
+    characterId,
     vendorResponse?.itemComponents[vendorHash],
     vendorResponse?.sales.data?.[vendorHash]?.saleItems,
     mergedCollectibles

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -48,6 +48,7 @@ export function toVendorGroups(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
   account: DestinyAccount,
+  characterId: string,
   mergedCollectibles?: {
     [hash: number]: DestinyCollectibleComponent;
   }
@@ -70,6 +71,7 @@ export function toVendorGroups(
                 buckets,
                 vendorsResponse.vendors.data?.[vendorHash],
                 account,
+                characterId,
                 vendorsResponse.itemComponents[vendorHash],
                 vendorsResponse.sales.data?.[vendorHash]?.saleItems,
                 mergedCollectibles
@@ -93,6 +95,7 @@ export function toVendor(
   buckets: InventoryBuckets,
   vendor: DestinyVendorComponent | undefined,
   account: DestinyAccount,
+  characterId: string,
   itemComponents?: DestinyItemComponentSetOfint32,
   sales?: {
     [key: string]: DestinyVendorSaleItemComponent;
@@ -112,6 +115,7 @@ export function toVendor(
     defs,
     buckets,
     vendorDef,
+    characterId,
     itemComponents,
     sales,
     mergedCollectibles
@@ -152,6 +156,7 @@ export function getVendorItems(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
   vendorDef: DestinyVendorDefinition,
+  characterId: string,
   itemComponents?: DestinyItemComponentSetOfint32,
   sales?: {
     [key: string]: DestinyVendorSaleItemComponent;
@@ -168,6 +173,7 @@ export function getVendorItems(
         buckets,
         vendorDef,
         component,
+        characterId,
         itemComponents,
         mergedCollectibles
       )

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -41,8 +41,15 @@ export const vendorGroupsForCharacterSelector = createSelector(
     const vendorData = selectedStoreId ? vendors[selectedStoreId] : undefined;
     const vendorsResponse = vendorData?.vendorsResponse;
 
-    return vendorsResponse && defs && buckets && currentAccount
-      ? toVendorGroups(vendorsResponse, defs, buckets, currentAccount, mergedCollectibles)
+    return vendorsResponse && defs && buckets && currentAccount && selectedStoreId
+      ? toVendorGroups(
+          vendorsResponse,
+          defs,
+          buckets,
+          currentAccount,
+          selectedStoreId,
+          mergedCollectibles
+        )
       : emptyArray<D2VendorGroup>();
   }
 );

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -130,19 +130,34 @@ export class VendorItem {
       this.previewVendorHash = inventoryItem.preview.previewVendorHash;
     }
 
+    // Fix for ada-1 bounties ... https://github.com/Bungie-net/api/issues/1522
+    // changes their sort to match the game
+    if (itemHash === 3675595381 || itemHash === 171866827) {
+      this.key = itemHash === 3675595381 ? 1 : 4;
+    }
+
     this.item = makeFakeItem(
       defs,
       buckets,
       itemComponents,
       itemHash,
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
-      saleItem ? saleItem.vendorItemIndex.toString() : itemHash.toString(),
+      this.key.toString(),
       vendorItemDef ? vendorItemDef.quantity : 1,
       mergedCollectibles
     );
 
     if (this.item) {
       this.item.hidePercentage = true;
+
+      // override the DimItem.id for vendor items, so they are each unique enough to identify
+      // (otherwise they'd get their vendor index as an id, which is only unique per-vendor)
+      this.item.id = `${vendorHash}-${this.key}`;
+
+      // if this is sold by a vendor, add vendor information
+      if (saleItem) {
+        this.item.vendor = { vendorHash, saleIndex: saleItem.vendorItemIndex, characterId: '' };
+      }
     }
 
     // only apply for 2255782930, master rahool

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -29,11 +29,6 @@ export const wishListFunctionSelector = createSelector(
     // Cache of inventory item id to roll. For this to work, make sure vendor/collections rolls have unique ids.
     const cache = new Map<string, InventoryWishListRoll | undefined>();
     return (item: DimItem) => {
-      // don't cache vendor items because they don't have a safe cache key (yet)
-      if (item.isVendorItem) {
-        return getInventoryWishListRoll(item, wishlists);
-      }
-
       if (cache.has(item.id)) {
         return cache.get(item.id);
       }


### PR DESCRIPTION
- swap out the `isVendorItem` bool for `.vendor` data, allowing a DimItem to be better aware of its source.
this will enable comparison of vendor items later
- gives vendor items more unique IDs so that they can be picked out by ID easier, including for wishlists
- moves ada bounty fix into vendoritem maker where i think it belongs
- document my findings about vendoritems as i go