### PR TITLE
Loadout Builder/Compare drawer: show ability cooldowns/stat tier effects for new set

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Items in the Compare view no longer move around according to the character they're on.
 * Fixed an issue where the Loadout Optimizer would not load due to deprecated settings.
+* Hovering over stat tiers in the Loadout Optimizer's compare drawer now shows stat tier effects for the new set too.
 
 ## 6.83.0 <span class="changelog-date">(2021-09-19)</span>
 

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -227,6 +227,7 @@ function CompareDrawer({
             statOrder={statOrder}
             enabledStats={enabledStats}
             className={styles.fillRow}
+            characterClass={characterClass}
           />
           <div className={clsx(styles.fillRow, styles.set)}>
             {setItems.map((item) => (


### PR DESCRIPTION
Just a fix for a minor papercut I encountered.