### PR TITLE
Fix issue with deprecated upgrade spend tier.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Items in the Compare view no longer move around according to the character they're on.
+* Fixed an issue where the Loadout Optimizer would not load due to deprecated settings.
 
 ## 6.83.0 <span class="changelog-date">(2021-09-19)</span>
 

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -84,7 +84,11 @@ const lbStateInit = ({
   const statFilters = statFiltersFromLoadoutParamaters(loadoutParams);
   const lockedMods = lockedModsFromLoadoutParameters(loadoutParams, defs);
   const lockItemEnergyType = Boolean(loadoutParams?.lockItemEnergyType);
-  const upgradeSpendTier = loadoutParams.upgradeSpendTier!;
+  // We need to handle the deprecated case
+  const upgradeSpendTier =
+    loadoutParams.upgradeSpendTier === UpgradeSpendTier.AscendantShardsLockEnergyType
+      ? UpgradeSpendTier.Nothing
+      : loadoutParams.upgradeSpendTier!;
   const lockedExoticHash = loadoutParams.exoticArmorHash;
 
   return {


### PR DESCRIPTION
Users are running into the thrown error from the deprecated upgrade setting. I am going to remove the enum soonish but this is a fix for the meantime.