### PR TITLE
Better handle Recoil stat in Compare/Organizer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * The "Perks, Mods & Shaders" column in Organizer no longer shows the Kill Tracker socket.
+* The Recoil Direction stat now sorts and highlights differently in both Compare and Organizer - the best recoil is now straight up, and recoil that goes side to side is worse.
 
 ## 6.84.0 <span class="changelog-date">(2021-09-26)</span>
 

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -65,7 +65,7 @@ function mapStateToProps(state: RootState): StoreProps {
 }
 
 export interface StatInfo {
-  id: string | number;
+  id: number | 'EnergyCapacity';
   displayProperties: DestinyDisplayPropertiesDefinition;
   min: number;
   max: number;
@@ -548,7 +548,7 @@ function getAllStats(
             min: Number.MAX_SAFE_INTEGER,
             max: 0,
             enabled: false,
-            lowerBetter: false,
+            lowerBetter: stat.smallerIsBetter,
             getStat(item: DimItem) {
               const itemStat = item.stats
                 ? item.stats.find((s) => s.statHash === stat.statHash)
@@ -590,7 +590,6 @@ function getAllStats(
             : adjustedStatValue ?? itemStat.value) || 0
         );
         stat.enabled = stat.min !== stat.max;
-        stat.lowerBetter = isDimStat(itemStat) ? itemStat.smallerIsBetter : false;
       }
     }
   }
@@ -598,12 +597,8 @@ function getAllStats(
   return stats;
 }
 
-function isDimStat(stat: DimStat | unknown): stat is DimStat {
-  return Object.prototype.hasOwnProperty.call(stat as DimStat, 'smallerIsBetter');
-}
-
 function makeFakeStat(
-  id: string | number,
+  id: StatInfo['id'],
   displayProperties: DestinyDisplayPropertiesDefinition | string,
   getStat: StatGetter,
   lowerBetter = false

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -2,6 +2,7 @@ import { settingsSelector } from 'app/dim-api/selectors';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
 import { locateItem } from 'app/inventory/locate-item';
+import { recoilValue } from 'app/item-popup/RecoilStat';
 import { statLabels } from 'app/organizer/Columns';
 import { setSettingAction } from 'app/settings/actions';
 import Checkbox from 'app/settings/Checkbox';
@@ -15,6 +16,7 @@ import { emptyArray } from 'app/utils/empty';
 import { getSocketByIndex } from 'app/utils/socket-utils';
 import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
+import { StatHashes } from 'data/d2/generated-enums';
 import produce from 'immer';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -335,6 +337,9 @@ function sortCompareItemsComparator(
           return -1;
         }
         const statValue = compareBaseStats ? stat.base ?? stat.value : stat.value;
+        if (stat.statHash === StatHashes.RecoilDirection) {
+          return recoilValue(stat.value);
+        }
         return shouldReverse ? -statValue : statValue;
       }),
       compareBy((i) => i.index),

--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -6,3 +6,7 @@
 .range {
   font-size: 0.9em;
 }
+
+.stat {
+  margin-right: calc(var(--item-size) + 16px);
+}

--- a/src/app/compare/CompareStat.m.scss.d.ts
+++ b/src/app/compare/CompareStat.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'range': string;
   'recoil': string;
+  'stat': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -5,7 +5,6 @@ import { StatHashes } from 'data/d2/generated-enums';
 import React from 'react';
 import { D1Stat, DimItem } from '../inventory/item-types';
 import { getColor } from '../shell/filters';
-import { AppIcon, starIcon } from '../shell/icons';
 import { MinimalStat, StatInfo } from './Compare';
 import styles from './CompareStat.m.scss';
 import { DimAdjustedItemStat } from './types';
@@ -28,23 +27,24 @@ export default function CompareStat({
 
   const color = getColor(statRange(itemStat, stat, compareBaseStats, adjustedStatValue), 'color');
 
+  const statValue = itemStat
+    ? (compareBaseStats ? itemStat.base : adjustedStatValue) ?? itemStat.value
+    : 0;
+
   return (
     <div onMouseOver={() => setHighlight?.(stat.id)} className={styles.stat} style={color}>
       <span>
-        {stat.id === 'Rating' && <AppIcon icon={starIcon} />}
         {stat.id === 'EnergyCapacity' && itemStat && item.energy && (
           <ElementIcon element={item.element} />
         )}
         {itemStat?.value !== undefined ? (
           itemStat.statHash === StatHashes.RecoilDirection ? (
             <span className={styles.recoil}>
-              <span>{adjustedItemStats?.[itemStat.statHash] ?? itemStat.value}</span>
-              <RecoilStat value={adjustedItemStats?.[itemStat.statHash] ?? itemStat.value} />
+              <span>{statValue}</span>
+              <RecoilStat value={statValue} />
             </span>
-          ) : compareBaseStats ? (
-            itemStat.base ?? itemStat.value
           ) : (
-            adjustedItemStats?.[itemStat.statHash] ?? itemStat.value
+            statValue
           )
         ) : (
           t('Stats.NotApplicable')

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -1,6 +1,6 @@
 import ElementIcon from 'app/dim-ui/ElementIcon';
 import { t } from 'app/i18next-t';
-import RecoilStat from 'app/item-popup/RecoilStat';
+import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
 import { StatHashes } from 'data/d2/generated-enums';
 import React from 'react';
 import { D1Stat, DimItem } from '../inventory/item-types';
@@ -26,11 +26,10 @@ export default function CompareStat({
   const itemStat = stat.getStat(item);
   const adjustedStatValue = itemStat ? adjustedItemStats?.[itemStat.statHash] : undefined;
 
+  const color = getColor(statRange(itemStat, stat, compareBaseStats, adjustedStatValue), 'color');
+
   return (
-    <div
-      onMouseOver={() => setHighlight?.(stat.id)}
-      style={getColor(statRange(itemStat, stat, compareBaseStats, adjustedStatValue), 'color')}
-    >
+    <div onMouseOver={() => setHighlight?.(stat.id)} className={styles.stat} style={color}>
       <span>
         {stat.id === 'Rating' && <AppIcon icon={starIcon} />}
         {stat.id === 'EnergyCapacity' && itemStat && item.energy && (
@@ -78,33 +77,15 @@ function statRange(
     return -1;
   }
 
+  const statValue = (compareBaseStats ? stat.base : adjustedStatValue ?? stat.value) ?? 0;
+
+  if (statInfo.id === StatHashes.RecoilDirection) {
+    return recoilValue(statValue);
+  }
+
   if (statInfo.lowerBetter) {
-    if (adjustedStatValue) {
-      return (
-        (100 *
-          (statInfo.max - (compareBaseStats ? stat.base ?? adjustedStatValue : statInfo.max))) /
-        (statInfo.max - statInfo.min)
-      );
-    }
-
-    return (
-      (100 *
-        (statInfo.max -
-          ((compareBaseStats ? stat.base ?? stat.value : stat.value) || statInfo.max))) /
-      (statInfo.max - statInfo.min)
-    );
+    return (100 * (statInfo.max - statValue)) / (statInfo.max - statInfo.min);
   }
 
-  if (adjustedStatValue) {
-    return (
-      (100 *
-        ((compareBaseStats ? stat.base ?? adjustedStatValue : adjustedStatValue) - statInfo.min)) /
-      (statInfo.max - statInfo.min)
-    );
-  }
-
-  return (
-    (100 * (((compareBaseStats ? stat.base ?? stat.value : stat.value) || 0) - statInfo.min)) /
-    (statInfo.max - statInfo.min)
-  );
+  return (100 * (statValue - statInfo.min)) / (statInfo.max - statInfo.min);
 }

--- a/src/app/item-popup/RecoilStat.tsx
+++ b/src/app/item-popup/RecoilStat.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 
-export default function RecoilStat({ value }: { value: number }) {
-  // A value from 100 to -100 where positive is right and negative is left
-  // See https://imgur.com/LKwWUNV
-  const direction = Math.sin((value + 5) * ((2 * Math.PI) / 20)) * (100 - value) * (Math.PI / 180);
+/**
+ * A value from 100 to -100 where positive is right and negative is left
+ * See https://imgur.com/LKwWUNV
+ */
+export function recoilDirection(value: number) {
+  return Math.sin((value + 5) * ((2 * Math.PI) / 20)) * (100 - value) * (Math.PI / 180);
+}
 
+/**
+ * A value from 0 to 100 describing how straight up and down the recoil is, for sorting
+ */
+export function recoilValue(value: number) {
+  const deviation = Math.abs(recoilDirection(value));
+  return 100 - deviation + value / 100000;
+}
+
+export default function RecoilStat({ value }: { value: number }) {
+  const direction = recoilDirection(value);
   const x = Math.sin(direction);
   const y = Math.cos(direction);
 

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -22,6 +22,7 @@ import TagIcon from 'app/inventory/TagIcon';
 import { ItemStatValue } from 'app/item-popup/ItemStat';
 import NotesArea from 'app/item-popup/NotesArea';
 import PlugTooltip from 'app/item-popup/PlugTooltip';
+import { recoilValue } from 'app/item-popup/RecoilStat';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { CUSTOM_TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 import { statHashByName } from 'app/search/search-filter-values';
@@ -140,7 +141,13 @@ export function getColumns(
           ),
           statHash,
           columnGroup: statsGroup,
-          value: (item: DimItem) => item.stats?.find((s) => s.statHash === statHash)?.value,
+          value: (item: DimItem) => {
+            const stat = item.stats?.find((s) => s.statHash === statHash);
+            if (stat?.statHash === StatHashes.RecoilDirection) {
+              return recoilValue(stat.value);
+            }
+            return stat?.value || 0;
+          },
           cell: (_val, item: DimItem) => {
             const stat = item.stats?.find((s) => s.statHash === statHash);
             if (!stat) {
@@ -166,7 +173,13 @@ export function getColumns(
           ...column,
           id: `base_${column.statHash}`,
           columnGroup: baseStatsGroup,
-          value: (item: DimItem) => item.stats?.find((s) => s.statHash === column.statHash)?.base,
+          value: (item: DimItem) => {
+            const stat = item.stats?.find((s) => s.statHash === column.statHash);
+            if (stat?.statHash === StatHashes.RecoilDirection) {
+              return recoilValue(stat.base);
+            }
+            return stat?.base || 0;
+          },
           cell: (value) => <div className={styles.statValue}>{value}</div>,
           filter: (value) => `basestat:${_.invert(statHashByName)[column.statHash]}:>=${value}`,
         }))


### PR DESCRIPTION
This changes the coloring and sorting for Recoil to operate off "how far from straight up is the recoil" rather than just the numeric value.