### PR TITLE
properly type reducers

### DIFF
--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -35,7 +35,8 @@ function getItemStats(
   const baseStats = armorStats.reduce((memo, statHash) => {
     memo[statHash] = item.stats?.find((s) => s.statHash === statHash)?.base || 0;
     return memo;
-  }, {}) as ArmorStats;
+    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+  }, {} as ArmorStats);
 
   if (
     upgradeSpendTierToMaxEnergy(defs, upgradeSpendTier, item) === 10 ||
@@ -128,7 +129,8 @@ function CompareDrawer({
   const loadoutStats = armorStats.reduce((memo, statHash) => {
     memo[statHash] = 0;
     return memo;
-  }, {}) as ArmorStats;
+    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+  }, {} as ArmorStats);
 
   for (const item of loadoutItems) {
     const itemStats = getItemStats(defs, item, upgradeSpendTier);

--- a/src/app/loadout-builder/loadout-params.ts
+++ b/src/app/loadout-builder/loadout-params.ts
@@ -72,7 +72,8 @@ export function statFiltersFromLoadoutParamaters(params: LoadoutParameters): Sta
       ? { min: c.minTier ?? 0, max: c.maxTier ?? 10, ignored: false }
       : { min: 0, max: 10, ignored: true };
     return memo;
-  }, {}) as StatFilters;
+    // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+  }, {} as StatFilters);
 }
 
 export function lockedModsFromLoadoutParameters(

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -568,7 +568,7 @@ function ItemTable({
 function buildRows(items: DimItem[], filteredColumns: ColumnDefinition[]) {
   const unsortedRows: Row[] = items.map((item) => ({
     item,
-    values: filteredColumns.reduce((memo, col) => {
+    values: filteredColumns.reduce<Row['values']>((memo, col) => {
       memo[col.id] = col.value(item);
       return memo;
     }, {}),


### PR DESCRIPTION
the linting rule has an important case it's not appropriate for:
it gets in the way of purposely improperly typing initial values
(i.e. empty object as having keys you intend to fill in later)

it's better to defy it and `as` the initial value so that you have some type checking in the reducer
`as`ing it *after* reduction is way more of a bandaid