### PR TITLE
Fix webpack.js for static/ content hashes

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -27,7 +27,7 @@ const Visualizer = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const NotifyPlugin = require('notify-webpack-plugin');
 
-const ASSET_NAME_PATTERN = 'static/[name]-[md5:contenthash:6].[ext]';
+const ASSET_NAME_PATTERN = 'static/[name]-[contenthash:6].[ext]';
 
 const packageJson = require('../package.json');
 


### PR DESCRIPTION
Past webpack.js config did not generate content hashes properly for static/ paths, instead leaving an "[md5:contenthash:6]" string literal included in the filename.

Fixes #7121 