### PR TITLE
is:statslower

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -228,6 +228,7 @@
     "SeasonalDupe": "Shows duplicate items, not counting reissues from a different season as the same item.",
     "StackLevel": "Shows items based on the quantity of items in its stack.",
     "Stackable": "Shows items that can stack (ammo synths, strange coin, etc)",
+    "StatLower": "Shows armor where their stats are strictly lower than another of the same type of armor.",
     "Stats": "Shows items based on a specific stat value. Supports stat addition by connecting multiple stat names with the + symbol.",
     "StatsBase": "Filters armor based on its base stat value, not including attached mods or masterworking. Supports stat addition by connecting multiple stat names with the + symbol.",
     "StatsLoadout": "Finds a set of items to equip for the maximum total value of a specific stat.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Loadout Optimizer no longer saves stat min/max settings as the default for the next time you use it. Opening an existing loadout in the Optimizer will still reload the min/max settings for that loadout.
 * We won't automatically refresh your inventory when you're on the Loadout Optimizer screen anymore - click the refresh button or hit R to recalculate sets with your latest items.
 * The "Perks, Mods & Shaders" column in Organizer no longer shows the Kill Tracker socket.
+* Added a "is:statlower" search that shows armor that has strictly worse stats than another piece of armor of the same type. This does not take into account special mod slots, element, or masterworked-ness.
 
 ## 6.84.0 <span class="changelog-date">(2021-09-26)</span>
 

--- a/src/app/loadout-builder/process-worker/__snapshots__/stats-set.test.ts.snap
+++ b/src/app/loadout-builder/process-worker/__snapshots__/stats-set.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`insertAll 1: internal 1`] = `
+StatsSet {
+  "statNodes": Array [
+    Object {
+      "next": Array [
+        Object {
+          "next": Array [
+            Object {
+              "items": Array [
+                "a",
+              ],
+              "next": Array [],
+              "value": 3,
+            },
+          ],
+          "value": 2,
+        },
+        Object {
+          "next": Array [
+            Object {
+              "items": Array [
+                "b",
+              ],
+              "next": Array [],
+              "value": 2,
+            },
+            Object {
+              "items": Array [
+                "c",
+              ],
+              "next": Array [],
+              "value": 1,
+            },
+          ],
+          "value": 1,
+        },
+      ],
+      "value": 1,
+    },
+  ],
+}
+`;

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -9,6 +9,7 @@ import { ArmorStatHashes, ArmorStats, LockableBuckets, StatFilters, StatRanges }
 import { statTier } from '../utils';
 import { canTakeSlotIndependantMods, sortProcessModsOrItems } from './process-utils';
 import { SetTracker } from './set-tracker';
+import { StatsSet } from './stats-set';
 import {
   IntermediateProcessArmorSet,
   LockedProcessMods,
@@ -104,15 +105,36 @@ export function process(
   // Sort gear by the chosen stats so we consider the likely-best gear first
   const itemComparator = compareByStatOrder(orderedConsideredStatHashes, statOrder, statsCache);
   // TODO: make these a list/map
-  const helms = (filteredItems[LockableBuckets.helmet] || []).sort(itemComparator);
-  const gaunts = (filteredItems[LockableBuckets.gauntlets] || []).sort(itemComparator);
-  const chests = (filteredItems[LockableBuckets.chest] || []).sort(itemComparator);
-  const legs = (filteredItems[LockableBuckets.leg] || []).sort(itemComparator);
+  const helms = filterSubsetStatItems(filteredItems[LockableBuckets.helmet] || [], statsCache).sort(
+    itemComparator
+  );
+  console.log('helms', (filteredItems[LockableBuckets.helmet] || []).length, helms.length);
+  const gaunts = filterSubsetStatItems(
+    filteredItems[LockableBuckets.gauntlets] || [],
+    statsCache
+  ).sort(itemComparator);
+  console.log('gaunts', (filteredItems[LockableBuckets.gauntlets] || []).length, gaunts.length);
+  const chests = filterSubsetStatItems(filteredItems[LockableBuckets.chest] || [], statsCache).sort(
+    itemComparator
+  );
+  console.log('chests', (filteredItems[LockableBuckets.chest] || []).length, chests.length);
+  const legs = filterSubsetStatItems(filteredItems[LockableBuckets.leg] || [], statsCache).sort(
+    itemComparator
+  );
+  console.log('legs', (filteredItems[LockableBuckets.leg] || []).length, legs.length);
   // TODO: we used to do these in chunks, where items w/ same stats were considered together. For class items that
   // might still be useful. In practice there are only 1/2 class items you need to care about - all of them that are
   // masterworked and all of them that aren't. I think we may want to go back to grouping like items but we'll need to
   // incorporate modslots and energy maybe.
-  const classItems = (filteredItems[LockableBuckets.classitem] || []).sort(itemComparator);
+  const classItems = filterSubsetStatItems(
+    filteredItems[LockableBuckets.classitem] || [],
+    statsCache
+  ).sort(itemComparator);
+  console.log(
+    'classItems',
+    (filteredItems[LockableBuckets.classitem] || []).length,
+    classItems.length
+  );
 
   // We won't search through more than this number of stat combos because it takes too long.
   // On my machine (bhollis) it takes ~1s per 270,000 combos
@@ -397,4 +419,36 @@ function flattenSets(sets: IntermediateProcessArmorSet[]): ProcessArmorSet[] {
     ...set,
     armor: set.armor.map((item) => item.id),
   }));
+}
+function filterSubsetStatItems(items: ProcessItem[], statsCache: Map<ProcessItem, number[]>) {
+  // 1. Group by element and modslot(s). This could be optimized to make larger
+  //    groups by looking at the inputs (e.g. if no mods, don't bother with
+  //    element/modslot, if no raid mods don't break those out, if only solar
+  //    mods break out solar vs other instead of each element). The idea is that
+  //    we are going to remove items which have strictly worse stats than some
+  //    other item, but you wouldn't want to say "we don't need this solar helm
+  //    because there's a strictly better arc helm".
+
+  const groups = [items]; //Object.values(
+  //_.groupBy(items, (i) => `${i.energy?.type};${(i.compatibleModSeasons || []).join(',')}`)
+  //);
+
+  const rejectedItems = new Set<ProcessItem>();
+  for (const group of groups) {
+    const tracker = new StatsSet<ProcessItem>();
+    for (const item of group) {
+      tracker.insert(statsCache.get(item)!, item);
+    }
+
+    // Now go back through and see if any are subsets of other items
+    for (const item of group) {
+      // TODO: what about when two items have the same stats? We'd need to do some extra work.
+      if (tracker.doBetterStatsExist(statsCache.get(item)!)) {
+        console.log('Dropping ', item.name, ' for subset stats');
+        rejectedItems.add(item);
+      }
+    }
+  }
+
+  return items.filter((i) => !rejectedItems.has(i));
 }

--- a/src/app/loadout-builder/process-worker/stats-set.test.ts
+++ b/src/app/loadout-builder/process-worker/stats-set.test.ts
@@ -1,0 +1,25 @@
+import { StatsSet } from './stats-set';
+
+const cases = [
+  [
+    [[1, 2, 3], 'a'],
+    [[1, 1, 2], 'b'],
+    [[1, 1, 1], 'c'],
+  ],
+];
+
+test('insertAll 1', () => {
+  const inputs: [number[], string][] = [
+    [[1, 2, 3], 'a'],
+    [[1, 1, 2], 'b'],
+    [[1, 1, 1], 'c'],
+  ];
+
+  const statsSet = new StatsSet<string>();
+
+  for (const [stats, item] of inputs) {
+    statsSet.insert(stats, item);
+  }
+
+  expect(statsSet).toMatchSnapshot('internal');
+});

--- a/src/app/loadout-builder/process-worker/stats-set.test.ts
+++ b/src/app/loadout-builder/process-worker/stats-set.test.ts
@@ -1,13 +1,5 @@
 import { StatsSet } from './stats-set';
 
-const cases = [
-  [
-    [[1, 2, 3], 'a'],
-    [[1, 1, 2], 'b'],
-    [[1, 1, 1], 'c'],
-  ],
-];
-
 test('insertAll 1', () => {
   const inputs: [number[], string][] = [
     [[1, 2, 3], 'a'],
@@ -21,5 +13,13 @@ test('insertAll 1', () => {
     statsSet.insert(stats, item);
   }
 
-  expect(statsSet).toMatchSnapshot('internal');
+  //expect(statsSet).toMatchSnapshot('internal');
+
+  expect(statsSet.doBetterStatsExist([1, 2, 3])).toBe(false);
+  expect(statsSet.doBetterStatsExist([1, 1, 2])).toBe(true);
+  expect(statsSet.doBetterStatsExist([1, 1, 3])).toBe(true);
+  expect(statsSet.doBetterStatsExist([1, 2, 2])).toBe(true);
+  expect(statsSet.doBetterStatsExist([2, 1, 1])).toBe(false);
+  expect(statsSet.doBetterStatsExist([1, 4, 0])).toBe(false);
+  expect(statsSet.doBetterStatsExist([0, 0, 0])).toBe(true);
 });

--- a/src/app/loadout-builder/process-worker/stats-set.ts
+++ b/src/app/loadout-builder/process-worker/stats-set.ts
@@ -1,0 +1,118 @@
+/**
+ * The internal structure of StatsSet is a trie (https://en.wikipedia.org/wiki/Trie) where
+ * each level represents a consecutive stat in a stat array.
+ */
+interface StatNode<T> {
+  /** The value of the stat */
+  value: number;
+  /** The next set of stats. This array is ordered by the stat nodes' value, in decreasing order. */
+  next: StatNode<T>[];
+  /** The terminal node holds the actual inserted items */
+  items?: T[];
+}
+
+/**
+ * A StatsSet can be populated with a bunch of stats, and can then answer questions such as:
+ * 1. Have we seen stats that are strictly better than the input stats?
+ * 2. ???
+ *
+ * In general "stats" are just an ordered array of numbers, and can represent anything - item stats, set tiers, etc.
+ */
+export class StatsSet<T> {
+  statNodes: StatNode<T>[] = [];
+
+  /**
+   * Insert a new line of stats and an associated value into the set. Input
+   * stats must always be in the same order and have the same length.
+   */
+  insert(stats: number[], item: T) {
+    let currentNodes = this.statNodes;
+    // TODO: binary search (later). Right now it's just insertion sort
+    // TODO: find (returns index + found)
+    for (let statIndex = 0; statIndex < stats.length; statIndex++) {
+      const stat = stats[statIndex];
+      let insertionIndex = 0;
+      if (currentNodes.length === 0) {
+        currentNodes.push({
+          value: stat,
+          next: [],
+        });
+        insertionIndex = 0;
+      } else {
+        for (let nodeIndex = 0; nodeIndex < currentNodes.length; nodeIndex++) {
+          const node = currentNodes[nodeIndex];
+          if (stat > node.value) {
+            currentNodes.splice(nodeIndex, 0, {
+              value: stat,
+              next: [],
+            });
+            insertionIndex = nodeIndex;
+            break;
+          } else if (stat === node.value) {
+            insertionIndex = nodeIndex;
+            break;
+          } else if (nodeIndex === currentNodes.length - 1) {
+            currentNodes.push({
+              value: stat,
+              next: [],
+            });
+            insertionIndex = nodeIndex + 1;
+            break;
+          }
+        }
+      }
+
+      if (statIndex === stats.length - 1) {
+        (currentNodes[insertionIndex].items ||= []).push(item);
+      }
+
+      currentNodes = currentNodes[insertionIndex].next;
+    }
+  }
+
+  /**
+   * Given all the stats this set knows about, are there any stats which are better than
+   * this one? For this to be true at least one stat array that was inserted must have each
+   * stat be better or equal to the input, without being equal to the input stats. For example,
+   * if the stat set contains:
+   *
+   * {
+   *   [1, 2, 3],
+   *   [1, 1, 2],
+   *   [1, 1, 1]
+   * }
+   *
+   * Then:
+   *
+   * doBetterStatsExist([1, 2, 3]) === false
+   * doBetterStatsExist([1, 2, 2]) === true
+   * doBetterStatsExist([2, 1, 1]) === false
+   *
+   * See tests for more examples.
+   */
+  doBetterStatsExist(stats: number[]) {}
+
+  /**
+   * Get all saved stats sets which are lower than the input example. This won't return
+   * something with the exact same stats as the input, but if any stat is lower than the
+   * input and all other stats are lower or equal, it will be returned.
+   */
+  // TODO: should be removeByLowerStats? Combine with an insert?
+  getByLowerStats(stats: number[]) {}
+}
+
+function findNode<T>(nodes: StatNode<T>[], val: number): [index: number, found: boolean] {
+  if (nodes.length === 0) {
+    return [0, false];
+  } else {
+    for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
+      const node = nodes[nodeIndex];
+      if (val > node.value) {
+        return [nodeIndex, false];
+      } else if (val === node.value) {
+        return [nodeIndex, true];
+      }
+    }
+    return [nodes.length, false];
+  }
+}


### PR DESCRIPTION
I've had this on a branch forever - I don't think it's that useful but people ask for it all the time. It adds a new search for armor items which are strictly worse, from a stats perspective, than some other item. In my inventory that's 2 legendaries and 4 blues I hadn't gotten around to deleting. I had built this stat-set-tracking trie data structure in hopes of using it for Loadout Optimizer but it wasn't that useful there.

I think this actually works, but it's been a long time and I don't necessarily understand the code anymore...