### PR TITLE
fix a type error in organizer column sorting

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -540,7 +540,7 @@ export function getColumns(
       hasWishList && {
         id: 'wishListNote',
         header: t('Organizer.Columns.WishListNotes'),
-        value: (item) => wishList(item)?.notes,
+        value: (item) => wishList(item)?.notes?.trim() ?? '',
         gridWidth: 'minmax(200px, 1fr)',
         filter: (value) => `wishlistnotes:"${value}"`,
       },

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -607,7 +607,7 @@ function sortRows(
       if (column) {
         const compare = column.sort
           ? (row1: Row, row2: Row) => column.sort!(row1.values[column.id], row2.values[column.id])
-          : compareBy((row: Row) => row.values[column.id] || 0);
+          : compareBy((row: Row) => row.values[column.id] ?? 0);
         return sorter.sort === SortDirection.ASC ? compare : reverseComparator(compare);
       }
       return compareBy(() => 0);


### PR DESCRIPTION
empty string or undefined was getting `||`'d into `0`
and bad news,
![image](https://user-images.githubusercontent.com/68782081/136645360-9e3e875f-a6bf-4696-b5e5-923c7aa25503.png)

also some wishlist notes seem to start with spaces....

fixes #7137 