### PR TITLE
explicitly set compare cell height

### DIFF
--- a/src/app/compare/Compare.m.scss
+++ b/src/app/compare/Compare.m.scss
@@ -19,6 +19,7 @@
   padding-right: 8px;
   padding-left: 0;
   cursor: pointer;
+  height: 16px;
   img {
     height: 16px;
     width: 16px;

--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -8,5 +8,6 @@
 }
 
 .stat {
+  height: 16px;
   margin-right: calc(var(--item-size) + 16px);
 }


### PR DESCRIPTION
turns out the entire layout of compare, rests atop the flimsy and inconsistent foundation,
of the practical rendering height of the google open sans font at css 12px font-height

this pr takes the effective 16px resulting cell height, in the compare table, and makes it explicit. because relying on font quirks to create the layout for a table seems not ideal

test fine on mobile from what i can tell