### PR TITLE
explicitly set environment variable for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "test": "jest --verbose",
+    "test": "cross-env NODE_ENV=test jest --verbose",
     "lint": "jsonsort src/locale && eslint --fix src --ext .js,.ts,.tsx && stylelint --fix \"src/**/*.scss\"",
     "lint-check": "eslint src --ext .js,.ts,.tsx --cache --cache-location .eslintcache",
     "bundle": "webpack --config ./config/webpack.js",


### PR DESCRIPTION
this fixes jest in windows/gitbash

however jest is internally setting environment to test, is not persisting to the babel config js

see if this works on on mac please? i would like my tests to work