### PR TITLE
Replace many usages of "primStat" with "power", renames

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
   "eslint.packageManager": "yarn",
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "search.exclude": {
-    "**/data/d1/manifests": true
+    "**/data/d1/manifests": true,
+    "src/testing/data": true
   },
   "jest.jestCommandLine": "yarn test",
   "[javascript]": {

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -348,12 +348,12 @@ function getAllStats(comparisonItems: DimItem[], compareBaseStats: boolean): Sta
   compareBaseStats = Boolean(compareBaseStats && firstComparison.bucket.inArmor);
   const stats: StatInfo[] = [];
 
-  if (firstComparison.primStat) {
+  if (firstComparison.primaryStat) {
     stats.push(
       makeFakeStat(
-        firstComparison.primStat.statHash,
-        firstComparison.primStat.stat.displayProperties,
-        (item: DimItem) => item.primStat || undefined
+        firstComparison.primaryStat.statHash,
+        firstComparison.primaryStat.stat.displayProperties,
+        (item: DimItem) => item.primaryStat || undefined
       )
     );
   }

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -5,6 +5,7 @@ import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { d1ManifestSelector } from 'app/manifest/selectors';
+import { D1_StatHashes } from 'app/search/d1-known-values';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { errorLog } from 'app/utils/log';
@@ -268,7 +269,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
               </label>
               <div className="loadout-builder-section">
                 {_.sortBy(
-                  bucket[type].filter((i) => i.primStat && i.primStat.value >= 280),
+                  bucket[type].filter((i) => i.power >= 280),
                   (i) => (i.quality ? -i.quality.min : 0)
                 ).map((item) => (
                   <div key={item.index} className="item-container">
@@ -534,8 +535,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
     function filterItems(items: readonly D1Item[]) {
       return items.filter(
         (item) =>
-          item.primStat &&
-          item.primStat.statHash === 3897883278 && // has defense hash
+          item.primStat?.statHash === D1_StatHashes.Defense &&
           item.talentGrid &&
           item.talentGrid.nodes &&
           item.stats

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -535,7 +535,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
     function filterItems(items: readonly D1Item[]) {
       return items.filter(
         (item) =>
-          item.primStat?.statHash === D1_StatHashes.Defense &&
+          item.primaryStat?.statHash === D1_StatHashes.Defense &&
           item.talentGrid &&
           item.talentGrid.nodes &&
           item.stats

--- a/src/app/destiny1/loadout-builder/utils.ts
+++ b/src/app/destiny1/loadout-builder/utils.ts
@@ -281,7 +281,7 @@ export function loadVendorsBucket(
         .filter(
           (i) =>
             i.item.stats &&
-            i.item.primStat?.statHash === D1_StatHashes.Defense &&
+            i.item.primaryStat?.statHash === D1_StatHashes.Defense &&
             itemCanBeEquippedBy(i.item, currentStore)
         )
         .map((i) => i.item)
@@ -296,7 +296,7 @@ export function loadBucket(currentStore: DimStore, stores: D1Store[]): ItemBucke
         store.items.filter(
           (i) =>
             i.stats &&
-            i.primStat?.statHash === D1_StatHashes.Defense &&
+            i.primaryStat?.statHash === D1_StatHashes.Defense &&
             itemCanBeEquippedBy(i, currentStore)
         )
       )

--- a/src/app/destiny1/loadout-builder/utils.ts
+++ b/src/app/destiny1/loadout-builder/utils.ts
@@ -1,3 +1,4 @@
+import { D1_StatHashes } from 'app/search/d1-known-values';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import _ from 'lodash';
 import { D1Item } from '../../inventory/item-types';
@@ -280,7 +281,7 @@ export function loadVendorsBucket(
         .filter(
           (i) =>
             i.item.stats &&
-            i.item.primStat?.statHash === 3897883278 &&
+            i.item.primStat?.statHash === D1_StatHashes.Defense &&
             itemCanBeEquippedBy(i.item, currentStore)
         )
         .map((i) => i.item)
@@ -294,7 +295,9 @@ export function loadBucket(currentStore: DimStore, stores: D1Store[]): ItemBucke
       getBuckets(
         store.items.filter(
           (i) =>
-            i.stats && i.primStat?.statHash === 3897883278 && itemCanBeEquippedBy(i, currentStore)
+            i.stats &&
+            i.primStat?.statHash === D1_StatHashes.Defense &&
+            itemCanBeEquippedBy(i, currentStore)
         )
       )
     )

--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -11,12 +11,14 @@ import {
   getVault,
   isD1Store,
 } from 'app/inventory/stores-helpers';
+import { supplies } from 'app/search/d1-known-values';
 import { refresh } from 'app/shell/refresh';
 import { ThunkResult } from 'app/store/types';
 import { CancelToken, withCancel } from 'app/utils/cancel';
 import { infoLog } from 'app/utils/log';
 import { observeStore } from 'app/utils/redux-utils';
 import { BucketCategory } from 'bungie-api-ts/destiny2';
+import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { InventoryBucket } from '../inventory/inventory-buckets';
 import { MoveReservations, sortMoveAsideCandidatesForStore } from '../inventory/item-move-service';
@@ -26,28 +28,20 @@ import { clearItemsOffCharacter } from '../loadout-drawer/loadout-apply';
 import * as actions from './basic-actions';
 import { farmingInterruptedSelector, farmingStoreSelector } from './selectors';
 
-// D1 Glimmer items
-const glimmerHashes = new Set([
-  269776572, // -house-banners
-  3632619276, // -silken-codex
-  2904517731, // -axiomatic-beads
-  1932910919, // -network-keys
-]);
-
 // These are things you may pick up frequently out in the wild
 const makeRoomTypes = [
-  1498876634, // Primary
-  2465295065, // Special
-  953998645, // Heavy
-  3448274439, // Helmet
-  3551918588, // Gauntlets
-  14239492, // Chest
-  20886954, // Legs
-  1585787867, // ClassItem
+  BucketHashes.KineticWeapons, // Primary
+  BucketHashes.EnergyWeapons, // Special
+  BucketHashes.PowerWeapons, // Heavy
+  BucketHashes.Helmet,
+  BucketHashes.Gauntlets,
+  BucketHashes.ChestArmor,
+  BucketHashes.LegArmor,
+  BucketHashes.ClassArmor,
   434908299, // Artifact
-  4023194814, // Ghost
-  1469714392, // Consumable
-  3865314626, // Material
+  BucketHashes.Ghost,
+  BucketHashes.Consumables,
+  BucketHashes.Materials,
 ];
 
 const FARMING_REFRESH_RATE = 30_000; // Bungie.net caches results for 30 seconds - this may be too fast
@@ -137,7 +131,7 @@ function farmItems(store: D1Store, cancelToken: CancelToken): ThunkResult {
   const toMove = store.items.filter(
     (i) =>
       !i.notransfer &&
-      (i.isEngram || (i.equipment && i.tier === 'Uncommon') || glimmerHashes.has(i.hash))
+      (i.isEngram || (i.equipment && i.tier === 'Uncommon') || supplies.includes(i.hash))
   );
 
   if (toMove.length === 0) {

--- a/src/app/gear-power/GearPower.m.scss
+++ b/src/app/gear-power/GearPower.m.scss
@@ -52,7 +52,7 @@
         display: flex;
         flex-direction: column;
 
-        .primStat {
+        .power {
           font-size: 16px;
           line-height: 1;
         }

--- a/src/app/gear-power/GearPower.m.scss.d.ts
+++ b/src/app/gear-power/GearPower.m.scss.d.ts
@@ -21,7 +21,6 @@ interface CssExports {
   'neutral': string;
   'positive': string;
   'power': string;
-  'primStat': string;
   'statMeta': string;
 }
 export const cssExports: CssExports;

--- a/src/app/gear-power/GearPower.tsx
+++ b/src/app/gear-power/GearPower.tsx
@@ -70,7 +70,7 @@ export default function GearPower() {
                   <BungieImage src={i.icon} className={styles.itemImage} />
                 </div>
                 <div className={styles.gearItemInfo}>
-                  <div className={styles.primStat}>{i.power}</div>
+                  <div className={styles.power}>{i.power}</div>
                   <div className={styles.statMeta}>
                     <BucketIcon className={styles.bucketImage} item={i} />
                     <div className={diffClass}>

--- a/src/app/gear-power/GearPower.tsx
+++ b/src/app/gear-power/GearPower.tsx
@@ -60,7 +60,7 @@ export default function GearPower() {
       <div className={styles.gearPowerSheetContent}>
         <div className={styles.gearGrid}>
           {unrestricted.map((i) => {
-            const powerDiff = (powerFloor - (i.primStat?.value ?? 0)) * -1;
+            const powerDiff = (powerFloor - i.power) * -1;
             const diffSymbol = powerDiff >= 0 ? '+' : '';
             const diffClass =
               powerDiff > 0 ? styles.positive : powerDiff < 0 ? styles.negative : styles.neutral;
@@ -70,7 +70,7 @@ export default function GearPower() {
                   <BungieImage src={i.icon} className={styles.itemImage} />
                 </div>
                 <div className={styles.gearItemInfo}>
-                  <div className={styles.primStat}>{i.primStat?.value}</div>
+                  <div className={styles.primStat}>{i.power}</div>
                   <div className={styles.statMeta}>
                     <BucketIcon className={styles.bucketImage} item={i} />
                     <div className={diffClass}>

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -27,7 +27,7 @@ import { showInfuse$ } from './infuse';
 import './InfusionFinder.scss';
 
 const itemComparator = chainComparator(
-  reverseComparator(compareBy((item: DimItem) => item.primStat?.value ?? 0)),
+  reverseComparator(compareBy((item: DimItem) => item.power)),
   compareBy((item: DimItem) =>
     isD1Item(item) && item.talentGrid
       ? (item.talentGrid.totalXP / item.talentGrid.totalXPRequired) * 0.5
@@ -217,12 +217,13 @@ function InfusionFinder({
   const effectiveSource = source || dupes[0] || items[0];
 
   let result: DimItem | undefined;
-  if (effectiveSource?.primStat && effectiveTarget?.primStat) {
-    const infused = effectiveSource.primStat?.value || 0;
+  if (effectiveSource?.power && effectiveTarget?.power) {
+    const infused = effectiveSource.power;
     result = {
       ...effectiveTarget,
+      power: infused,
       primStat: {
-        ...effectiveTarget.primStat,
+        ...effectiveTarget.primStat!,
         value: infused,
       },
     };
@@ -322,7 +323,7 @@ function isInfusable(target: DimItem, source: DimItem) {
   }
 
   if (source.destinyVersion === 1 && target.destinyVersion === 1) {
-    return source.type === target.type && target.primStat!.value < source.primStat!.value;
+    return source.type === target.type && target.power < source.power;
   }
 
   return (

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -222,8 +222,8 @@ function InfusionFinder({
     result = {
       ...effectiveTarget,
       power: infused,
-      primStat: {
-        ...effectiveTarget.primStat!,
+      primaryStat: {
+        ...effectiveTarget.primaryStat!,
         value: infused,
       },
     };

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -331,7 +331,7 @@ function isInfusable(target: DimItem, source: DimItem) {
     target.infusionQuality.infusionCategoryHashes.some((h) =>
       source.infusionQuality!.infusionCategoryHashes.includes(h)
     ) &&
-    target.basePower < source.basePower
+    target.power < source.power
   );
 }
 

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -30,7 +30,7 @@ interface Props {
 
 export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   const savedNotes = useSelector(itemNoteSelector(item));
-  const isBounty = Boolean(!item.primStat && item.objectives);
+  const isBounty = Boolean(!item.primaryStat && item.objectives);
   const isStackable = Boolean(item.maxStackSize > 1);
   const isGeneric = !isBounty && !isStackable;
   const wishlistRollIcon = toUiWishListRoll(wishlistRoll);
@@ -39,7 +39,7 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
     (item.isEngram && item.location.hash === BucketHashes.Engrams) ||
       (isBounty && (item.complete || item.hidePercentage)) ||
       (isStackable && item.amount === 1) ||
-      (isGeneric && !item.primStat?.value && !item.classified)
+      (isGeneric && !item.primaryStat?.value && !item.classified)
   );
 
   if (hideBadge) {
@@ -49,7 +49,7 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   const badgeContent =
     (isBounty && `${Math.floor(100 * item.percentComplete)}%`) ||
     (isStackable && item.amount.toString()) ||
-    (isGeneric && item.primStat?.value.toString()) ||
+    (isGeneric && item.primaryStat?.value.toString()) ||
     (item.classified && (savedNotes ?? '???'));
 
   const fixContrast =

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -73,8 +73,7 @@ export default function InventoryItem({
     [styles.subclassPathBottom]: subclassPath?.position === 'bottom',
   });
   // Subtitle for engram powerlevel vs regular item type
-  const subtitle =
-    item.destinyVersion === 2 && item.isEngram ? item.primStat?.value : item.typeName;
+  const subtitle = item.destinyVersion === 2 && item.isEngram ? item.power : item.typeName;
   // Memoize the contents of the item - most of the time if this is re-rendering it's for a search, or a new item
   const contents = useMemo(() => {
     // Subclasses have limited, but customized, display. They can't be new, or tagged, or locked, etc.

--- a/src/app/inventory/ItemPowerSet.tsx
+++ b/src/app/inventory/ItemPowerSet.tsx
@@ -10,7 +10,7 @@ export function ItemPowerSet(items: DimItem[], powerFloor: number) {
       {items.map((i, j) => {
         const sortChanged = Boolean(j) && lastSort !== i.bucket.sort;
         lastSort = i.bucket.sort;
-        const powerDiff = (powerFloor - (i.primStat?.value ?? 0)) * -1;
+        const powerDiff = (powerFloor - i.power) * -1;
         const diffSymbol = powerDiff > 0 ? '+' : '';
         return (
           <React.Fragment key={i.id}>
@@ -21,7 +21,7 @@ export function ItemPowerSet(items: DimItem[], powerFloor: number) {
             )}
             <span className={styles.bucketName}>{i.bucket.name}</span>
             <BucketIcon className={styles.invert} item={i} />
-            <span>{i.primStat?.value}</span>
+            <span>{i.power}</span>
             <span className={styles.powerDiff}>{powerDiff ? `${diffSymbol}${powerDiff}` : ''}</span>
           </React.Fragment>
         );

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -198,8 +198,8 @@ function searchForSimilarItem(
     if (item.isExotic && i.isExotic) {
       value += 5;
     }
-    if (i.primStat) {
-      value += i.primStat.value / 1000;
+    if (i.primaryStat) {
+      value += i.primaryStat.value / 1000;
     }
     return value;
   }).reverse();
@@ -1037,7 +1037,8 @@ export function sortMoveAsideCandidatesForStore(
       compareBy((i) => (fromStore.isVault ? tierValue[i.tier] : -tierValue[i.tier])),
       // Prefer keeping higher-stat items on characters
       compareBy(
-        (i) => (i.primStat && (fromStore.isVault ? i.primStat.value : -i.primStat.value)) || 0
+        (i) =>
+          (i.primaryStat && (fromStore.isVault ? i.primaryStat.value : -i.primaryStat.value)) || 0
       )
     )
   );

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -171,7 +171,7 @@ export interface DimItem {
         stat: DestinyStatDefinition;
       })
     | null;
-  /** The power level of the item. This is a synonym for (primaryStat?.value ?? 0) but only for items that actually have power. */
+  /** The power level of the item. This is a synonym for (primaryStat?.value ?? 0) for items with power, and 0 otherwise. */
   power: number;
   /** Is this a masterwork? (D2 only) */
   masterwork: boolean;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -164,15 +164,14 @@ export interface DimItem {
   /** How many items does this represent? Only greater than one if maxStackSize is greater than one. */
   amount: number;
   /**
-   * The primary stat (Attack, Defense, Speed) of the item.
-   * @deprecated use power instead
+   * The primary stat (Attack, Defense, Speed) of the item. Useful for display and for some weirder stat types. Prefer using "power" if what you want is power.
    */
-  primStat:
+  primaryStat:
     | (DestinyStat & {
         stat: DestinyStatDefinition;
       })
     | null;
-  /** The "base power" without any power-enhancing mods. This is a synonym for (primStat?.value || 0) but only for items that actually have power. */
+  /** The power level of the item. This is a synonym for (primaryStat?.value ?? 0) but only for items that actually have power. */
   power: number;
   /** Is this a masterwork? (D2 only) */
   masterwork: boolean;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -172,7 +172,7 @@ export interface DimItem {
         stat: DestinyStatDefinition;
       })
     | null;
-  /** The "base power" without any power-enhancing mods. This is a synonym for (primStat?.value || 0). */
+  /** The "base power" without any power-enhancing mods. This is a synonym for (primStat?.value || 0) but only for items that actually have power. */
   power: number;
   /** Is this a masterwork? (D2 only) */
   masterwork: boolean;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -47,7 +47,7 @@ export interface DimItem {
   classified: boolean;
   /** The version of Destiny this comes from. */
   destinyVersion: DestinyVersion;
-  /** This is the type of the item (see InventoryBuckets) regardless of location. This string is a DIM concept with no direct correlation to the API types. It should generally be avoided in favor of using bucket hash.  */
+  /** This is the type of the item (see InventoryBuckets) regardless of location. This string is a DIM concept with no direct correlation to the API types. It should generally be avoided in favor of using bucket hash. */
   type: NonNullable<InventoryBucket['type']>;
   /** Localized name of this item's type. */
   typeName: string;
@@ -163,14 +163,17 @@ export interface DimItem {
   complete: boolean;
   /** How many items does this represent? Only greater than one if maxStackSize is greater than one. */
   amount: number;
-  /** The primary stat (Attack, Defense, Speed) of the item. */
+  /**
+   * The primary stat (Attack, Defense, Speed) of the item.
+   * @deprecated use power instead
+   */
   primStat:
     | (DestinyStat & {
         stat: DestinyStatDefinition;
       })
     | null;
-  /** The "base power" without any power-enhancing mods. This is only defined for D2 and is a synonym for (primStat?.value || 0). */
-  basePower: number;
+  /** The "base power" without any power-enhancing mods. This is a synonym for (primStat?.value || 0). */
+  power: number;
   /** Is this a masterwork? (D2 only) */
   masterwork: boolean;
   /** What percent complete is this item (considers XP and objectives). */

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -71,19 +71,19 @@ export function downloadCsvFiles(
   });
   const items: DimItem[] = [];
   allItems.forEach((item) => {
-    if (!item.primStat && type !== 'Ghost') {
+    if (!item.primaryStat && type !== 'Ghost') {
       return;
     }
 
     if (type === 'Weapons') {
       if (
-        item.primStat?.statHash === D1_StatHashes.Attack ||
-        item.primStat?.statHash === StatHashes.Attack
+        item.primaryStat?.statHash === D1_StatHashes.Attack ||
+        item.primaryStat?.statHash === StatHashes.Attack
       ) {
         items.push(item);
       }
     } else if (type === 'Armor') {
-      if (item.primStat?.statHash === StatHashes.Defense) {
+      if (item.primaryStat?.statHash === StatHashes.Defense) {
         items.push(item);
       }
     } else if (type === 'Ghost' && item.bucket.hash === BucketHashes.Ghost) {

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -12,7 +12,7 @@ import {
 import { download } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { D2EventInfo } from 'data/d2/d2-event-info';
-import { StatHashes } from 'data/d2/generated-enums';
+import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import D2MissingSources from 'data/d2/missing-source-info';
 import D2Sources from 'data/d2/source-info';
 import _ from 'lodash';
@@ -86,7 +86,7 @@ export function downloadCsvFiles(
       if (item.primStat?.statHash === StatHashes.Defense) {
         items.push(item);
       }
-    } else if (type === 'Ghost' && item.bucket.hash === 4023194814) {
+    } else if (type === 'Ghost' && item.bucket.hash === BucketHashes.Ghost) {
       items.push(item);
     }
   });
@@ -306,7 +306,7 @@ function downloadArmor(items: DimItem[], nameMap: { [key: string]: string }, ite
       Type: item.typeName,
       Source: source(item),
       Equippable: equippable(item),
-      [item.destinyVersion === 1 ? 'Light' : 'Power']: item.primStat?.value,
+      [item.destinyVersion === 1 ? 'Light' : 'Power']: item.power,
     };
     if (item.destinyVersion === 2) {
       row['Power Limit'] = item.powerCap;
@@ -415,7 +415,7 @@ function downloadWeapons(
       Source: source(item),
       Category: item.bucket.type,
       Element: item.element?.displayProperties.name,
-      [item.destinyVersion === 1 ? 'Light' : 'Power']: item.primStat?.value,
+      [item.destinyVersion === 1 ? 'Light' : 'Power']: item.power,
     };
     if (item.destinyVersion === 2) {
       row['Power Limit'] = item.powerCap;

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -300,7 +300,7 @@ function makeItem(
     hidePercentage: false,
     taggable: false,
     comparable: false,
-    basePower: 0,
+    power: item.primaryStat?.value ?? 0,
     index: '',
     infusable: false,
     infusionFuel: false,

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -1,4 +1,6 @@
 import { t } from 'app/i18next-t';
+import { D1_StatHashes } from 'app/search/d1-known-values';
+import { lightStats } from 'app/search/search-filter-values';
 import { getItemYear } from 'app/utils/item-utils';
 import { errorLog, warnLog } from 'app/utils/log';
 import {
@@ -163,13 +165,10 @@ function makeItem(
     return null;
   }
 
+  const numStats = _.size(itemDef.stats);
+
   // fix itemDef for defense items with missing nodes
-  if (
-    item.primaryStat &&
-    item.primaryStat.statHash === 3897883278 &&
-    _.size(itemDef.stats) > 0 &&
-    _.size(itemDef.stats) !== 5
-  ) {
+  if (item.primaryStat?.statHash === D1_StatHashes.Defense && numStats > 0 && numStats !== 5) {
     const defaultMinMax = _.find(itemDef.stats, (stat) =>
       [144602215, 1735777505, 4244567218].includes(stat.statHash)
     );
@@ -337,6 +336,10 @@ function makeItem(
         hasIcon: Boolean(statDef.icon),
       },
     };
+
+    if (lightStats.includes(createdItem.primStat.statHash)) {
+      createdItem.power = createdItem.primStat.value;
+    }
   }
 
   try {
@@ -640,7 +643,7 @@ function buildStats(
 
   let armorNodes: D1GridNode[] = [];
   let activeArmorNode: D1GridNode | { hash: number };
-  if (grid?.nodes && item.primaryStat?.statHash === 3897883278) {
+  if (grid?.nodes && item.primaryStat?.statHash === D1_StatHashes.Defense) {
     armorNodes = grid.nodes.filter(
       (node) => [1034209669, 1263323987, 193091484].includes(node.hash) // ['Increase Intellect', 'Increase Discipline', 'Increase Strength']
     );

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -262,7 +262,7 @@ function makeItem(
       item.isEquipment && tiers[itemDef.tierType] === 'Exotic' ? normalBucket.sort : undefined,
     complete: item.isGridComplete,
     amount: item.stackSize || 1,
-    primStat: item.primaryStat || null,
+    primaryStat: item.primaryStat || null,
     typeName: itemDef.itemTypeName,
     isEngram: (itemDef.itemCategoryHashes || []).includes(34),
     // "perks" are the two or so talent grid items that are "featured" for an
@@ -324,9 +324,9 @@ function makeItem(
     createdItem.notransfer = true;
   }
 
-  if (createdItem.primStat) {
-    const statDef = defs.Stat.get(createdItem.primStat.statHash);
-    createdItem.primStat.stat = {
+  if (createdItem.primaryStat) {
+    const statDef = defs.Stat.get(createdItem.primaryStat.statHash);
+    createdItem.primaryStat.stat = {
       ...statDef,
       // D2 is much better about display info
       displayProperties: {
@@ -337,8 +337,8 @@ function makeItem(
       },
     };
 
-    if (lightStats.includes(createdItem.primStat.statHash)) {
-      createdItem.power = createdItem.primStat.value;
+    if (lightStats.includes(createdItem.primaryStat.statHash)) {
+      createdItem.power = createdItem.primaryStat.value;
     }
   }
 
@@ -352,7 +352,7 @@ function makeItem(
 
   // An item can be used as infusion fuel if it is equipment, and has a primary stat that isn't Speed
   createdItem.infusionFuel = Boolean(
-    createdItem.equipment && createdItem.primStat?.statHash !== 1501155019
+    createdItem.equipment && createdItem.primaryStat?.statHash !== 1501155019
   );
 
   try {

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -291,7 +291,7 @@ export function makeItem(
 
   // https://github.com/Bungie-net/api/issues/134, class items had a primary stat
 
-  const primaryStat: DimItem['primStat'] =
+  const primaryStat: DimItem['primaryStat'] =
     !instanceDef?.primaryStat || itemDef.stats?.disablePrimaryStatDisplay || itemType === 'Class'
       ? null
       : {
@@ -404,7 +404,7 @@ export function makeItem(
     equippingLabel: itemDef.equippingBlock?.uniqueLabel,
     complete: false,
     amount: item.quantity || 1,
-    primStat: primaryStat,
+    primaryStat: primaryStat,
     typeName,
     equipRequiredLevel: instanceDef?.equipRequiredLevel ?? 0,
     maxStackSize: Math.max(itemDef.inventory!.maxStackSize, 1),
@@ -472,9 +472,9 @@ export function makeItem(
       createdItem.bucket.hash !== BucketHashes.Emblems
   );
 
-  if (createdItem.primStat) {
-    const statDef = defs.Stat.get(createdItem.primStat.statHash);
-    createdItem.primStat.stat = statDef;
+  if (createdItem.primaryStat) {
+    const statDef = defs.Stat.get(createdItem.primaryStat.statHash);
+    createdItem.primaryStat.stat = statDef;
   }
 
   if (extendedICH[createdItem.hash]) {
@@ -620,8 +620,8 @@ export function makeItem(
     reportException('Quest', e, { itemHash: item.itemHash });
   }
 
-  if (createdItem.primStat && lightStats.includes(createdItem.primStat.statHash)) {
-    createdItem.power = createdItem.primStat.value;
+  if (createdItem.primaryStat && lightStats.includes(createdItem.primaryStat.statHash)) {
+    createdItem.power = createdItem.primaryStat.value;
   }
 
   createdItem.index = createItemIndex(createdItem);

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -448,7 +448,7 @@ export function makeItem(
     pursuit: null,
     taggable: false,
     comparable: false,
-    basePower: 0,
+    power: 0,
     index: '',
     infusable: false,
     infusionFuel: false,
@@ -620,7 +620,7 @@ export function makeItem(
   }
 
   if (createdItem.primStat) {
-    createdItem.basePower = createdItem.primStat.value;
+    createdItem.power = createdItem.primStat.value;
   }
 
   createdItem.index = createItemIndex(createdItem);

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -1,5 +1,6 @@
 import { t } from 'app/i18next-t';
 import { THE_FORBIDDEN_BUCKET } from 'app/search/d2-known-values';
+import { lightStats } from 'app/search/search-filter-values';
 import { errorLog, warnLog } from 'app/utils/log';
 import {
   BucketCategory,
@@ -619,7 +620,7 @@ export function makeItem(
     reportException('Quest', e, { itemHash: item.itemHash });
   }
 
-  if (createdItem.primStat) {
+  if (createdItem.primStat && lightStats.includes(createdItem.primStat.statHash)) {
     createdItem.power = createdItem.primStat.value;
   }
 

--- a/src/app/inventory/stores-helpers.ts
+++ b/src/app/inventory/stores-helpers.ts
@@ -77,7 +77,7 @@ export function getItemAcrossStores<Item extends DimItem, Store extends DimStore
 /** Get the bonus power from the Seasonal Artifact */
 export function getArtifactBonus(store: DimStore) {
   const artifact = findItemsByBucket(store, BucketHashes.SeasonalArtifact).find((i) => i.equipped);
-  return artifact?.primStat?.value || 0;
+  return artifact?.primaryStat?.value || 0;
 }
 
 /**

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -62,7 +62,7 @@ export default function ItemPopupHeader({
             !(item.bucket.inWeapons && item.element.enumValue === DamageType.Kinetic) && (
               <ElementIcon element={item.element} className={styles.elementIcon} />
             )}
-          <div className={styles.power}>{item.primStat?.value}</div>
+          <div className={styles.power}>{item.primaryStat?.value}</div>
           {item.powerCap && <div className={styles.powerCap}>| {item.powerCap} </div>}
           {item.pursuit?.questStepNum && (
             <div className={styles.itemType}>

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -112,7 +112,7 @@ export default function CompareDrawer({
     return null;
   }
 
-  const loadoutMaxPower = _.sumBy(loadoutItems, (i) => i.basePower) / loadoutItems.length;
+  const loadoutMaxPower = _.sumBy(loadoutItems, (i) => i.power) / loadoutItems.length;
   const loadoutStats = armorStats.reduce((memo, statHash) => {
     memo[statHash] = 0;
     return memo;

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -18,7 +18,7 @@ export interface ProcessItem {
      */
     val: number;
   };
-  basePower: number;
+  power: number;
   baseStats: { [statHash: number]: number };
   compatibleModSeasons?: string[];
 }

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -119,7 +119,7 @@ export function mapDimItemToProcessItem(
   lockItemEnergyType: boolean,
   modsForSlot?: PluggableInventoryItemDefinition[]
 ): ProcessItem {
-  const { bucket, id, hash, type, name, equippingLabel, basePower, stats, energy } = dimItem;
+  const { bucket, id, hash, type, name, equippingLabel, power, stats, energy } = dimItem;
 
   const baseStatMap: { [statHash: number]: number } = {};
 
@@ -153,7 +153,7 @@ export function mapDimItemToProcessItem(
     type,
     name,
     equippingLabel,
-    basePower,
+    power,
     baseStats: baseStatMap,
     energy: energy
       ? {

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -22,8 +22,8 @@ export function getPower(items: DimItem[] | ProcessItem[]) {
   let power = 0;
   let numPoweredItems = 0;
   for (const item of items) {
-    if (item.basePower) {
-      power += item.basePower;
+    if (item.power) {
+      power += item.power;
       numPoweredItems++;
     }
   }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -46,7 +46,7 @@ export function newLoadout(name: string, items: LoadoutItem[], modsHashes?: numb
 export function getLight(store: DimStore, items: DimItem[]): number {
   // https://www.reddit.com/r/DestinyTheGame/comments/6yg4tw/how_overall_power_level_is_calculated/
   if (store.destinyVersion === 2) {
-    const exactLight = _.sumBy(items, (i) => i.primStat?.value ?? 0) / items.length;
+    const exactLight = _.sumBy(items, (i) => i.power) / items.length;
     return Math.floor(exactLight * 1000) / 1000;
   } else {
     const itemWeight = {
@@ -65,8 +65,7 @@ export function getLight(store: DimStore, items: DimItem[]): number {
       items.reduce(
         (memo, item) =>
           memo +
-          (item.primStat?.value ?? 0) *
-            (itemWeight[item.type === 'ClassItem' ? 'General' : item.bucket.sort!] || 1),
+          item.power * (itemWeight[item.type === 'ClassItem' ? 'General' : item.bucket.sort!] || 1),
         0
       ) / itemWeightDenominator;
 

--- a/src/app/loadout-drawer/postmaster.ts
+++ b/src/app/loadout-drawer/postmaster.ts
@@ -51,9 +51,7 @@ export function makeRoomForPostmaster(store: DimStore, buckets: InventoryBuckets
                 Unknown: 6,
               }[i.tier];
               // And low-stat
-              if (i.primStat) {
-                value += i.primStat.value / 1000;
-              }
+              value += i.power / 1000;
               return value;
             }
           );

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -243,7 +243,7 @@ export function getColumns(
     !isGhost && {
       id: 'power',
       header: <AppIcon icon={powerIndicatorIcon} />,
-      value: (item) => item.primStat?.value,
+      value: (item) => item.power,
       defaultSort: SortDirection.DESC,
       filter: (value) => `power:>=${value}`,
     },

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -249,7 +249,7 @@ function makeFakePursuitItem(
     equipment: false, // TODO: this has a ton of good info for the item move logic
     complete: false,
     amount: 1,
-    primStat: null,
+    primaryStat: null,
     typeName,
     equipRequiredLevel: 0,
     maxStackSize: 1,

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -274,7 +274,7 @@ function makeFakePursuitItem(
     pursuit: null,
     taggable: false,
     comparable: false,
-    basePower: 0,
+    power: 0,
     index: hash.toString(),
     infusable: false,
     infusionFuel: false,

--- a/src/app/search/d1-known-values.ts
+++ b/src/app/search/d1-known-values.ts
@@ -7,8 +7,8 @@
 //
 
 export const enum D1_StatHashes {
-  Defense = 3897883278,
-  Attack = 368428387,
+  Defense = 3897883278, // Same as in D2
+  Attack = 368428387, // Not the same as in D2
 }
 
 /** hashes representing D1 PL stats */

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -75,7 +75,7 @@ export const TOTAL_STAT_HASH = -1000;
 export const CUSTOM_TOTAL_STAT_HASH = -1100;
 
 /** hashes representing D2 PL stats */
-export const D2LightStats = [StatHashes.Attack, StatHashes.Defense];
+export const D2LightStats = [StatHashes.Attack, StatHashes.Defense, StatHashes.Power];
 
 /** these stats canonically exist on D2 armor */
 export const D2ArmorStatHashByName = {

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -151,7 +151,7 @@ const dupeFilters: FilterDefinition[] = [
           return false;
         }
 
-        return duplicates[item.hash.toString()]?.some((i) => i.basePower < item.basePower);
+        return duplicates[item.hash.toString()]?.some((i) => i.power < item.power);
       };
     },
   },
@@ -218,7 +218,7 @@ function computeStatDupeLower(
   const dupes = new Set<string>();
 
   for (const item of armor) {
-    if (item.stats && item.basePower && item.bucket.hash !== BucketHashes.ClassArmor) {
+    if (item.stats && item.power && item.bucket.hash !== BucketHashes.ClassArmor) {
       const statsToConsider = customStats[item.classType] ?? armorStats;
       statsCache.set(
         item,

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -40,7 +40,7 @@ const sortDupes = (
   const dupeComparator = reverseComparator(
     chainComparator<DimItem>(
       // primary stat
-      compareBy((item) => item.primStat?.value),
+      compareBy((item) => item.power),
       compareBy((item) => item.masterwork),
       compareBy((item) => item.locked),
       compareBy((item) => {

--- a/src/app/search/search-filters/known-values.tsx
+++ b/src/app/search/search-filters/known-values.tsx
@@ -15,7 +15,7 @@ import {
   powerfulSources,
 } from '../d2-known-values';
 import { FilterDefinition } from '../filter-types';
-import { cosmeticTypes, damageTypeNames, lightStats } from '../search-filter-values';
+import { cosmeticTypes, damageTypeNames } from '../search-filter-values';
 
 // filters relying on curated known values (class names, rarities, elements)
 
@@ -139,7 +139,7 @@ const knownValuesFilters: FilterDefinition[] = [
   {
     keywords: ['light', 'haslight', 'haspower'],
     description: tl('Filter.ContributePower'),
-    filter: () => (item) => item.primStat && lightStats.includes(item.primStat.statHash),
+    filter: () => (item) => item.power > 0,
   },
   {
     keywords: 'breaker',

--- a/src/app/search/search-filters/range-overload.tsx
+++ b/src/app/search/search-filters/range-overload.tsx
@@ -104,7 +104,7 @@ const overloadedRangeFilters: FilterDefinition[] = [
     filter: ({ filterValue }) => {
       filterValue = replacePowerLevelKeyword(filterValue);
       const compareTo = rangeStringToComparator(filterValue);
-      return (item) => item.primStat && compareTo(item.primStat.value);
+      return (item) => Boolean(item.power && compareTo(item.power));
     },
   },
   {

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -8,7 +8,6 @@ import {
   allStatNames,
   armorAnyStatHashes,
   armorStatHashes,
-  lightStats,
   searchableArmorStatNames,
   statHashByName,
 } from '../search-filter-values';
@@ -90,10 +89,7 @@ const statFilters: FilterDefinition[] = [
         Boolean(
           // items can be 0pl but king of their own little kingdom,
           // like halloween masks, so let's exclude 0pl
-          item.basePower &&
-            maxPowerPerBucket[maxPowerKey(item)] <= item.basePower &&
-            // is:haspower condition. excludes sparrows
-            lightStats.includes(item.primStat!.statHash)
+          item.power && maxPowerPerBucket[maxPowerKey(item)] <= item.power
         );
     },
   },
@@ -257,6 +253,6 @@ function maxPowerKey(item: DimItem) {
 function calculateMaxPowerPerBucket(allItems: DimItem[]) {
   return _.mapValues(
     _.groupBy(allItems, (i) => maxPowerKey(i)),
-    (items) => _.maxBy(items, (i) => i.basePower)?.basePower ?? 0
+    (items) => _.maxBy(items, (i) => i.power)?.power ?? 0
   );
 }

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -68,7 +68,7 @@ const fakeWeapon = {
     type: 'energy',
   },
   visible: true,
-  primStat: {
+  primaryStat: {
     value: 300,
   },
   itemCategoryHashes: [],

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -112,7 +112,7 @@ export const acquisitionRecencyComparator = reverseComparator(
 const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
   typeName: compareBy((item: DimItem) => item.typeName),
   rarity: compareBy(rarity),
-  primStat: reverseComparator(compareBy((item: DimItem) => item.primStat?.value ?? 0)),
+  primStat: reverseComparator(compareBy((item: DimItem) => item.primaryStat?.value ?? 0)),
   basePower: reverseComparator(compareBy((item: DimItem) => item.power)),
   // This only sorts by D1 item quality
   rating: reverseComparator(

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -113,7 +113,7 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
   typeName: compareBy((item: DimItem) => item.typeName),
   rarity: compareBy(rarity),
   primStat: reverseComparator(compareBy((item: DimItem) => item.primStat?.value ?? 0)),
-  basePower: reverseComparator(compareBy((item: DimItem) => item.power || item.primStat?.value)),
+  basePower: reverseComparator(compareBy((item: DimItem) => item.power)),
   // This only sorts by D1 item quality
   rating: reverseComparator(
     compareBy((item: DimItem & { quality: { min: number } }) => {

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -113,9 +113,7 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
   typeName: compareBy((item: DimItem) => item.typeName),
   rarity: compareBy(rarity),
   primStat: reverseComparator(compareBy((item: DimItem) => item.primStat?.value ?? 0)),
-  basePower: reverseComparator(
-    compareBy((item: DimItem) => item.basePower || item.primStat?.value)
-  ),
+  basePower: reverseComparator(compareBy((item: DimItem) => item.power || item.primStat?.value)),
   // This only sorts by D1 item quality
   rating: reverseComparator(
     compareBy((item: DimItem & { quality: { min: number } }) => {

--- a/src/app/utils/comparators.ts
+++ b/src/app/utils/comparators.ts
@@ -4,8 +4,8 @@ export type Comparator<T> = (a: T, b: T) => -1 | 0 | 1;
  * Generate a comparator from a mapping function.
  *
  * @example
- * // Returns a comparator that compares items by primary stat
- * compareBy((item) => item.primStat.value)
+ * // Returns a comparator that compares items by power
+ * compareBy((item) => item.power)
  */
 export function compareBy<T>(fn: (arg: T) => number | string | undefined | boolean): Comparator<T> {
   return (a, b) => {


### PR DESCRIPTION
This is just something that's bugged me about the code for a while that I wanted to fix. Most of the time you want to look at an item's power and you don't want to deal with the weirdness of accessing `primStat`. Plus it was an annoying abbreviation.