### PR TITLE
round viewport values

### DIFF
--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -49,11 +49,12 @@ export default function updateCSSVariables() {
   if (window.visualViewport) {
     const defineVH = () => {
       const viewport = window.visualViewport;
-      setCSSVariable('--viewport-height', `${viewport.height}px`);
+      const viewportHeight = Math.round(window.visualViewport.height);
+      setCSSVariable('--viewport-height', `${viewportHeight}px`);
       // The amount the bottom of the visual viewport is offset from the layout viewport
       setCSSVariable(
         '--viewport-bottom-offset',
-        `${window.innerHeight - (viewport.height + viewport.offsetTop)}px`
+        `${window.innerHeight - (viewportHeight + Math.round(viewport.offsetTop))}px`
       );
     };
     defineVH();


### PR DESCRIPTION
window.innerHeight is rounded to an integer and visualViewport supports decimals. at some zoom levels, this was resulting in a .5px gap between sheet and bottom of window, through which you could see a sliver of the tiles.