### PR TITLE
Fixed issue where more than one mod can be selected for a single click.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed an issue where clicking a mod icon in the Loadout Optimizer would select more than one of the mod.
+
 ## 6.89.0 <span class="changelog-date">(2021-10-31)</span>
 
 ## 6.88.1 <span class="changelog-date">(2021-10-28)</span>

--- a/src/app/dim-ui/ClosableContainer.m.scss
+++ b/src/app/dim-ui/ClosableContainer.m.scss
@@ -18,6 +18,9 @@
   &:hover {
     background-color: $orange;
   }
+  &:focus {
+    outline: 1px solid $blue;
+  }
 }
 
 .showCloseOnHover {

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -17,7 +17,7 @@ import {
   SocketPlugSources,
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { MouseEvent, useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import '../inventory/StoreBucket.scss';
@@ -115,7 +115,12 @@ export const SocketDetailsMod = React.memo(
     className?: string;
     onClick?(mod: PluggableInventoryItemDefinition): void;
   }) => {
-    const onClickFn = onClick && (() => onClick(itemDef));
+    const onClickFn =
+      onClick &&
+      ((e: MouseEvent) => {
+        e.stopPropagation();
+        onClick(itemDef);
+      });
 
     return (
       <div
@@ -123,7 +128,6 @@ export const SocketDetailsMod = React.memo(
         className={clsx('item', className)}
         title={itemDef.displayProperties.name}
         onClick={onClickFn}
-        onFocus={onClickFn}
         tabIndex={0}
       >
         <DefItemIcon itemDef={itemDef} />

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -17,7 +17,7 @@ import {
   SocketPlugSources,
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import React, { MouseEvent, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import '../inventory/StoreBucket.scss';
@@ -115,12 +115,7 @@ export const SocketDetailsMod = React.memo(
     className?: string;
     onClick?(mod: PluggableInventoryItemDefinition): void;
   }) => {
-    const onClickFn =
-      onClick &&
-      ((e: MouseEvent) => {
-        e.stopPropagation();
-        onClick(itemDef);
-      });
+    const onClickFn = onClick && (() => onClick(itemDef));
 
     return (
       <div

--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss
@@ -21,6 +21,9 @@
   &:hover {
     background-color: rgba(255, 255, 255, 0.1);
   }
+  &:focus {
+    outline: 1px solid $blue;
+  }
 }
 
 .plugInfo {

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -42,7 +42,7 @@ export default function SelectablePlug({
         <SocketDetailsMod
           className={styles.iconContainer}
           itemDef={plug}
-          onClick={() => onPlugSelected(plug)}
+          onClick={onPlugSelected}
         />
         <div className={styles.plugInfo}>
           <div className={styles.plugTitle}>{plug.displayProperties.name}</div>

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -1,8 +1,8 @@
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { StatValue } from 'app/item-popup/PlugTooltip';
-import { SocketDetailsMod } from 'app/item-popup/SocketDetails';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { armorStats } from 'app/search/d2-known-values';
 import clsx from 'clsx';
@@ -39,11 +39,9 @@ export default function SelectablePlug({
         role="button"
         tabIndex={0}
       >
-        <SocketDetailsMod
-          className={styles.iconContainer}
-          itemDef={plug}
-          onClick={onPlugSelected}
-        />
+        <div className={clsx('item', styles.iconContainer)} title={plug.displayProperties.name}>
+          <DefItemIcon itemDef={plug} />
+        </div>
         <div className={styles.plugInfo}>
           <div className={styles.plugTitle}>{plug.displayProperties.name}</div>
           {_.uniqBy(


### PR DESCRIPTION
Only happens when you click on the actual image. Also happens if you try and tab around. I added blue outlines for the tabbed element as you had no idea where you were while tabbing before.

<img width="906" alt="Screen Shot 2021-11-02 at 10 57 16 pm" src="https://user-images.githubusercontent.com/7344652/139841892-c3b4a36b-dd11-4978-9efd-131b37379158.png">

Fixes #7200 