### PR TITLE
Prevent Chrome from using auto-dark-mode

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -30,6 +30,7 @@
     <link rel="manifest" href="/manifest-webapp-6-2018.json" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444" />
     <meta name="theme-color" content="black" />
+    <meta name="color-scheme" content="only light" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
Chrome is trying to automatically ruin people's websites:
https://developer.chrome.com/blog/auto-dark-theme/

This opts out of that