### PR TITLE
Change behaviour of not exotic armour upgrade

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * If a loadout has items for multiple character classes in it, applying it to a character behaves as if only the items that can be equipped on that character are in the loadout.
+* Fixed an issue where the Loadout Optimizer would allow masterworked items to have their energy changed when using the Ascendant Shard (not exotic) armor upgrade option.
 * Fixed an issue where clicking a mod icon in the Loadout Optimizer would select more than one of the mod.
 
 ## 6.89.0 <span class="changelog-date">(2021-10-31)</span>

--- a/src/app/loadout/armor-upgrade-utils.test.ts
+++ b/src/app/loadout/armor-upgrade-utils.test.ts
@@ -46,7 +46,7 @@ describe('Spend tier tests', () => {
   test.each([
     ['AscendantShards', true],
     ['AscendantShardsNotMasterworked', false],
-    ['AscendantShardsNotExotic', true],
+    ['AscendantShardsNotExotic', false],
     ['EnhancementPrisms', false],
     ['LegendaryShards', false],
     ['Nothing', false],

--- a/src/app/loadout/armor-upgrade-utils.ts
+++ b/src/app/loadout/armor-upgrade-utils.ts
@@ -25,6 +25,10 @@ function getEnergySpendTierBoundaryHash(item: DimItem, tier: UpgradeSpendTier) {
       break;
     case UpgradeSpendTier.AscendantShardsNotExotic: {
       if (!item.isExotic) {
+        // already masterworked items will have full energy by default, by dropping the boundary
+        // we will stop energy swaps
+        boundaryHash =
+          item.energy?.energyCapacity === 10 ? UpgradeMaterialHashes.ascendantShard : 'none';
         break;
       }
       // for exotics we allow energy upgrades/swaps using enhancement prisms.


### PR DESCRIPTION
So by the looks of it the code did one thing but the description said another. I think the description is better as someone that doesn't want to spend masterwork materials on exotics is unlikely to want to change existing masterwork armour's element types.

This PR stops energy swaps happening on masterworked armour when the Ascendant shard (not exotic) option is selected.

I am going to set something up we can all have a look at that has 3 energy sliders with 3 lock element toggles. The code will be way simpler and I think it will be less confusing for users.

https://www.reddit.com/r/DestinyItemManager/comments/qmfn1p/loadout_optimizer_swaps_elements_where_it_should/