### PR TITLE
Fix mods wrapping in plug drawer selections.

### DIFF
--- a/src/app/loadout/plug-drawer/Footer.m.scss
+++ b/src/app/loadout/plug-drawer/Footer.m.scss
@@ -6,9 +6,10 @@
 }
 
 .selectedMods {
-  composes: flexWrap from '../../dim-ui/common.m.scss';
+  composes: flexRow from '../../dim-ui/common.m.scss';
   flex: 1;
   align-items: center;
+  overflow: auto;
   height: var(--item-size);
 
   > * {


### PR DESCRIPTION
This changes overflowing mods from wrapping to being scrollable.

## Before

<img width="904" alt="Screen Shot 2021-11-06 at 12 01 52 am" src="https://user-images.githubusercontent.com/7344652/140514677-08f071ea-8a26-4796-98c8-fb8006fc08c8.png">

## After

<img width="906" alt="Screen Shot 2021-11-06 at 12 03 37 am" src="https://user-images.githubusercontent.com/7344652/140514701-3ea00550-8d1c-4712-9247-ee6deb92eef0.png">
