### PR TITLE
Stop showing mod placements in LO while processing.

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -398,7 +398,7 @@ function LoadoutBuilder({
         {filteredSets && (
           <GeneratedSets
             sets={filteredSets}
-            lockedMods={lockedMods}
+            lockedMods={processing ? [] : lockedMods}
             pinnedItems={pinnedItems}
             selectedStore={selectedStore}
             lbDispatch={lbDispatch}


### PR DESCRIPTION
This stops us showing mod placements while LO is processing items. I see this having two benefits
1. We aren't showing a weird intermediate state where only some mods are applied
2. The mod placement algorithm can be fairly intensive, so this just means it only gets run if necessary.