### PR TITLE
Remove enable parameter from CloseableContainer.

### DIFF
--- a/src/app/dim-ui/ClosableContainer.tsx
+++ b/src/app/dim-ui/ClosableContainer.tsx
@@ -4,19 +4,19 @@ import styles from './ClosableContainer.m.scss';
 
 /**
  * A generic wrapper that adds a "close" button in the top right corner.
+ * If the onClose function isn't passed in the close button won't appear
+ * allowing dynamic enable/disable functionality.
  */
 export default function ClosableContainer({
   children,
   className,
-  enabled = true,
   showCloseIconOnHover = false,
   onClose,
 }: {
   children: React.ReactNode;
   className?: string;
-  enabled?: boolean;
   showCloseIconOnHover?: boolean;
-  onClose(e: React.MouseEvent): void;
+  onClose?(e: React.MouseEvent): void;
 }) {
   return (
     <div
@@ -25,7 +25,7 @@ export default function ClosableContainer({
       })}
     >
       {children}
-      {enabled && (
+      {Boolean(onClose) && (
         <div className={clsx(styles.close)} onClick={onClose} role="button" tabIndex={0} />
       )}
     </div>

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -7,7 +7,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { armorStats } from 'app/search/d2-known-values';
 import clsx from 'clsx';
 import _ from 'lodash';
-import React from 'react';
+import React, { useMemo } from 'react';
 import styles from './SelectablePlug.m.scss';
 
 export default function SelectablePlug({
@@ -24,12 +24,19 @@ export default function SelectablePlug({
   onPlugRemoved(plug: PluggableInventoryItemDefinition): void;
 }) {
   const defs = useD2Definitions()!;
-  const handleClick = () => {
-    selectable && onPlugSelected(plug);
-  };
+
+  const { handleClick, onClose } = useMemo(() => {
+    const handleClick = () => {
+      selectable && onPlugSelected(plug);
+    };
+
+    const onClose = selected ? () => onPlugRemoved(plug) : undefined;
+
+    return { handleClick, onClose };
+  }, [onPlugRemoved, onPlugSelected, plug, selectable, selected]);
 
   return (
-    <ClosableContainer enabled={selected} onClose={() => onPlugRemoved(plug)}>
+    <ClosableContainer onClose={onClose}>
       <div
         className={clsx(styles.plug, {
           [styles.lockedPerk]: selected,

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -7,7 +7,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { armorStats } from 'app/search/d2-known-values';
 import clsx from 'clsx';
 import _ from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useCallback } from 'react';
 import styles from './SelectablePlug.m.scss';
 
 export default function SelectablePlug({
@@ -25,18 +25,16 @@ export default function SelectablePlug({
 }) {
   const defs = useD2Definitions()!;
 
-  const { handleClick, onClose } = useMemo(() => {
-    const handleClick = () => {
-      selectable && onPlugSelected(plug);
-    };
+  const handleClick = useCallback(() => {
+    selectable && onPlugSelected(plug);
+  }, [onPlugSelected, plug, selectable]);
 
-    const onClose = selected ? () => onPlugRemoved(plug) : undefined;
-
-    return { handleClick, onClose };
-  }, [onPlugRemoved, onPlugSelected, plug, selectable, selected]);
+  const onClose = useCallback(() => {
+    () => onPlugRemoved(plug);
+  }, [onPlugRemoved, plug]);
 
   return (
-    <ClosableContainer onClose={onClose}>
+    <ClosableContainer onClose={selected ? onClose : undefined}>
       <div
         className={clsx(styles.plug, {
           [styles.lockedPerk]: selected,


### PR DESCRIPTION
I have removed the `enable` prop and have made the `onClose` prop optional. That way we can just enable/disable the button by passing in the handler or not. It is useful when we are using the `CloseableContainer` to act as a `remove` button for mods. I am tempted to create a new component for these use cases but I believe I only have two cases for it now, the `SelectablePlug` component in the `PlugDrawer` and in the new subclass drawer in loadouts. If more pop up I might split it out to keep things to a single intent.