### PR TITLE
WIP: Group milestones by reward

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 6.91.0 <span class="changelog-date">(2021-11-10)</span>
+
+* Progress page sections can now be filtered by reward type
+
 ## 6.90.1 <span class="changelog-date">(2021-11-08)</span>
 
 * Mod costs now show in Firefox.

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -6,12 +6,10 @@ import { DestinyMilestone, DestinyProfileResponse } from 'bungie-api-ts/destiny2
 import _ from 'lodash';
 import React from 'react';
 import { milestoneToItems } from './milestone-items';
-import Pursuit from './Pursuit';
-import { sortPursuits } from './Pursuits';
+import { PursuitsGroup, sortPursuits } from './Pursuits';
 import SeasonalRank from './SeasonalRank';
 import { getCharacterProgressions } from './selectors';
 import WellRestedPerkIcon from './WellRestedPerkIcon';
-
 /**
  * The list of Milestones for a character. Milestones are different from pursuits and
  * represent challenges, story prompts, and other stuff you can do not represented by Pursuits.
@@ -42,27 +40,27 @@ export default function Milestones({
   ).flatMap((milestone) => milestoneToItems(milestone, defs, buckets, store));
 
   return (
-    <div className="progress-for-character">
-      {characterProgressions && (
-        <SeasonalRank
-          store={store}
-          characterProgressions={characterProgressions}
-          season={season}
-          seasonPass={seasonPass}
-          profileInfo={profileInfo}
-        />
-      )}
-      {characterProgressions && (
-        <WellRestedPerkIcon
-          progressions={characterProgressions}
-          season={season}
-          seasonPass={seasonPass}
-        />
-      )}
-      {milestoneItems.sort(sortPursuits).map((item) => (
-        <Pursuit key={item.hash} item={item} />
-      ))}
-    </div>
+    <>
+      <div className="progress-for-character">
+        {characterProgressions && (
+          <SeasonalRank
+            store={store}
+            characterProgressions={characterProgressions}
+            season={season}
+            seasonPass={seasonPass}
+            profileInfo={profileInfo}
+          />
+        )}
+        {characterProgressions && (
+          <WellRestedPerkIcon
+            progressions={characterProgressions}
+            season={season}
+            seasonPass={seasonPass}
+          />
+        )}
+      </div>
+      <PursuitsGroup store={store} pursuits={milestoneItems.sort(sortPursuits)} />
+    </>
   );
 }
 


### PR DESCRIPTION
Fixes #7221

A side effect of the addition is that now all sections can be filtered by reward type, although it can easily be remedied by using `skipTypes`.

Also, "Seasonal Rank" is now outside of the main grouping, which can also be fixed with some refactoring. But since this is my first ever open-source contribution, I want to keep the changes to a minimum.

<img width="1542" alt="Screen Shot 2021-11-10 at 5 05 27 PM" src="https://user-images.githubusercontent.com/16901849/141213182-e5bf5f4f-2dc6-45e1-9546-5bd5dd92d7d9.png">

