### PR TITLE
Remove warning for pre-Beyond-Light triumphs

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -784,8 +784,6 @@
     "Bounties": "Bounties",
     "CrucibleRank": "Ranks",
     "Items": "Quest Items",
-    "LegacyRecord": "This Triumph will no longer be available to complete after Beyond Light is released.",
-    "LegacyTriumphs": "Legacy Triumphs",
     "Milestones": "Milestones & Challenges",
     "PercentPrestige": "{{pct}}% to reset",
     "Progress": "Progress",

--- a/src/app/records/PresentationNode.scss
+++ b/src/app/records/PresentationNode.scss
@@ -21,7 +21,6 @@
     }
 
     #triumphs &,
-    #legacyTriumphs &,
     #collections & {
       /* styling for completed triumph categories */
       > .title.completed {

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -114,16 +114,6 @@
   }
 }
 
-.legacyRecord {
-  cursor: help;
-  position: absolute;
-  display: block;
-  width: calc((var(--item-size) + 1px) / 2) !important;
-  height: calc((var(--item-size) + 1px) / 2) !important;
-  top: 0;
-  left: 0;
-}
-
 .trackedIcon {
   position: absolute;
   display: block;

--- a/src/app/records/Record.m.scss.d.ts
+++ b/src/app/records/Record.m.scss.d.ts
@@ -10,7 +10,6 @@ interface CssExports {
   'intervalContainer': string;
   'intervalRedeemed': string;
   'intervalUnlocked': string;
-  'legacyRecord': string;
   'multistep': string;
   'objectives': string;
   'obscured': string;

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -1,6 +1,5 @@
 import { trackTriumph } from 'app/dim-api/basic-actions';
 import { trackedTriumphsSelector } from 'app/dim-api/selectors';
-import PressTip from 'app/dim-ui/PressTip';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { t } from 'app/i18next-t';
 import { useD2Definitions } from 'app/manifest/selectors';
@@ -17,9 +16,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import catalystIcons from 'data/d2/catalyst-triumph-icons.json';
-import legacyTriumphHashes from 'data/d2/legacy-triumphs.json';
 import dimTrackedIcon from 'images/dimTrackedIcon.svg';
-import pursuitExpired from 'images/pursuitExpired.svg';
 import trackedIcon from 'images/trackedIcon.svg';
 import _ from 'lodash';
 import React from 'react';
@@ -170,8 +167,6 @@ export default function Record({
     dispatch(trackTriumph({ recordHash, tracked: !trackedInDim }));
   };
 
-  const legacy = legacyTriumphHashes.includes(recordHash);
-
   return (
     <div
       className={clsx(styles.triumphRecord, {
@@ -219,11 +214,6 @@ export default function Record({
         )}
       </div>
       {intervalProgressBar}
-      {legacy && (
-        <PressTip tooltip={t('Progress.LegacyRecord')} className={styles.legacyRecord}>
-          <img src={pursuitExpired} />
-        </PressTip>
-      )}
     </div>
   );
 }

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -714,7 +714,6 @@
     "Bounties": "Bounties",
     "CrucibleRank": "Ranks",
     "Items": "Quest Items",
-    "LegacyRecord": "This Triumph will no longer be available to complete after Beyond Light is released.",
     "Milestones": "Milestones & Challenges",
     "NoTrackedTriumph": "You have no tracked triumphs. Track one in the game, or as many as you like in DIM.",
     "PercentPrestige": "{{pct}}% to reset",


### PR DESCRIPTION
This is broken from a bad transfer, and it isn't needed anymore anyway.