### PR TITLE
Compare colors

### DIFF
--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -5,7 +5,7 @@ import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
 import { StatHashes } from 'data/d2/generated-enums';
 import React from 'react';
 import { D1Stat, DimItem } from '../inventory/item-types';
-import { getColor } from '../shell/filters';
+import { getColorRamp } from '../shell/filters';
 import { MinimalStat, StatInfo } from './Compare';
 import styles from './CompareStat.m.scss';
 
@@ -22,7 +22,7 @@ export default function CompareStat({
 }) {
   const itemStat = stat.getStat(item);
 
-  const color = getColor(statRange(itemStat, stat, compareBaseStats), 'color');
+  const color = getColorRamp(statRange(itemStat, stat, compareBaseStats), 'color');
 
   const statValue = itemStat
     ? (compareBaseStats ? itemStat.base : itemStat.value) ?? itemStat.value

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -238,3 +238,21 @@ export function getColor(value: number, property = 'background-color') {
     [property]: `hsla(${color},65%,50%, 1)`,
   };
 }
+
+/**
+ * A filter that will heatmap-color a background according to a percentage.
+ */
+export function getColorRamp(value: number, property = 'background-color') {
+  let color = 0;
+  if (value < 0) {
+    return { [property]: 'white' };
+  }
+  if (value <= 99) {
+    color = 120 * (value / 100);
+  } else if (value >= 100) {
+    color = 190;
+  }
+  return {
+    [property]: `hsla(${Math.round(color)},65%,50%, 1)`,
+  };
+}

--- a/src/app/shell/filters.ts
+++ b/src/app/shell/filters.ts
@@ -247,12 +247,14 @@ export function getColorRamp(value: number, property = 'background-color') {
   if (value < 0) {
     return { [property]: 'white' };
   }
-  if (value <= 99) {
-    color = 120 * (value / 100);
+  if (value <= 50) {
+    color = 0;
+  } else if (value <= 99) {
+    color = 120 * ((value - 50) / 50);
   } else if (value >= 100) {
     color = 190;
   }
   return {
-    [property]: `hsla(${Math.round(color)},65%,50%, 1)`,
+    [property]: `hsla(${Math.round(color)},85%,50%, 1)`,
   };
 }


### PR DESCRIPTION
<img width="1221" alt="Screen Shot 2021-11-13 at 5 13 29 PM" src="https://user-images.githubusercontent.com/313208/141663808-315d2703-53d5-41e0-a500-da88041ac6ce.png">

This is starting to play around with different stat colors. The colors are a bit more saturated and shift from red towards green starting at the 50th percentile.

Fixes #7202 