### PR TITLE
Use only the item icon in Compare

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * The link to D2Gunsmith from the Armory view is now shown on mobile.
 * Currency counts won't get squished anymore
+* Simplified item tiles in the Compare view since a lot of the tile info was redundant.
 
 ## 6.90.1 <span class="changelog-date">(2021-11-08)</span>
 

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -1,6 +1,7 @@
 import PressTip from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { itemNoteSelector } from 'app/inventory/dim-item-info';
+import ItemIcon from 'app/inventory/ItemIcon';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { moveItemTo } from 'app/inventory/move-item';
 import { currentStoreSelector } from 'app/inventory/selectors';
@@ -11,7 +12,6 @@ import { useSetCSSVarToHeight } from 'app/utils/hooks';
 import clsx from 'clsx';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem, DimSocket } from '../inventory/item-types';
 import ItemSockets from '../item-popup/ItemSockets';
 import ItemTalentGrid from '../item-popup/ItemTalentGrid';
@@ -70,7 +70,7 @@ export default function CompareItem({
           {(ref, onClick) => (
             <div className={styles.itemAside} ref={ref} onClick={onClick}>
               <PressTip className={styles.itemAside} tooltip={itemNotes} allowClickThrough={true}>
-                <ConnectedInventoryItem item={item} />
+                <ItemIcon item={item} />
               </PressTip>
             </div>
           )}


### PR DESCRIPTION
The info in the tile is redundant, maybe this cleans things up?
<img width="956" alt="Screen Shot 2021-11-13 at 5 22 10 PM" src="https://user-images.githubusercontent.com/313208/141664135-148ea723-43d3-4c7c-a83d-d85c7c32e2a4.png">
