### PR TITLE
Remove plug stats from selectable plug.

### DIFF
--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss
@@ -47,23 +47,6 @@
   border-color: $orange;
 }
 
-.plugStats {
-  display: grid;
-  grid-template: auto / auto 1fr;
-  grid-column-gap: 4px;
-  margin-top: 4px;
-  > div {
-    &:nth-child(2n + 1) {
-      font-weight: bold;
-      justify-self: end;
-    }
-  }
-  img {
-    vertical-align: bottom;
-    margin-right: 2px;
-  }
-}
-
 .iconContainer {
   height: fit-content;
 }

--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss.d.ts
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss.d.ts
@@ -5,7 +5,6 @@ interface CssExports {
   'lockedPerk': string;
   'plug': string;
   'plugInfo': string;
-  'plugStats': string;
   'plugTitle': string;
   'requirement': string;
   'unselectable': string;

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -2,9 +2,7 @@ import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
-import { StatValue } from 'app/item-popup/PlugTooltip';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { armorStats } from 'app/search/d2-known-values';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React, { useCallback } from 'react';
@@ -62,13 +60,6 @@ export default function SelectablePlug({
               )}
             </div>
           ))}
-          {plug.investmentStats
-            .filter((stat) => armorStats.includes(stat.statTypeHash))
-            .map((stat) => (
-              <div className={styles.plugStats} key={stat.statTypeHash}>
-                <StatValue value={stat.value} statHash={stat.statTypeHash} />
-              </div>
-            ))}
         </div>
       </div>
     </ClosableContainer>


### PR DESCRIPTION
We currently have a double up of plug stats in the mod picker. This removes the one we create in favour of the bungie one. Our one is nicer but this comes for free.

### Current behaviour

<img width="305" alt="Screen Shot 2021-11-14 at 10 38 17 pm" src="https://user-images.githubusercontent.com/7344652/141679273-f9fc7f34-3a05-40eb-9861-767f371ee951.png">

<img width="928" alt="Screen Shot 2021-11-14 at 10 37 59 pm" src="https://user-images.githubusercontent.com/7344652/141679282-a4046213-1306-4615-9868-ead3e10e641f.png">
