### PR TITLE
Fix LO single set in optimizer.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fix issue in Loadout Optimizer where only one set would show when using Safari or iOS apps.
+
 ## 6.91.0 <span class="changelog-date">(2021-11-14)</span>
 
 * The link to D2Gunsmith from the Armory view is now shown on mobile.


### PR DESCRIPTION
It seems safari and chrome have different event loop cycles in some way. Either react state updates, effect hooks, or setTimeout's are fired at a different point.

This fixes the issue by removing the callback ref and updating the state for the set height in a useEffect hook. By running it after the hook intended to clear the height and recalculate we can ensure that we don't clear the height unintentionally. 

This code hasn't changed in around eight months so something must have changed with safari in the recent updates.

## Behaviour after fix

![Screen Shot 2021-11-15 at 9 37 05 pm](https://user-images.githubusercontent.com/7344652/141769211-78988a05-69c8-4e05-b808-6d3d3ed544d3.png)


