### PR TITLE
Fix energy swap display in LO

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -35,13 +35,17 @@ function EnergySwap({
   )?.plug.energyCost?.energyTypeHash;
   const modEnergy = (modEnergyHash && defs.EnergyType.get(modEnergyHash)) || null;
 
+  // The armor energy type and capacity needed for the mods
   const resultingEnergy = modEnergy ?? armorEnergy;
   let resultingEnergyCapacity = armorEnergyCapacity;
 
-  if (modEnergyHash === armorEnergy.hash) {
-    resultingEnergyCapacity = Math.max(armorEnergyCapacity, modCost);
-  } else if (modEnergy) {
+  // If there is a non Any mod energy type and its different to ther armor energy type
+  // we always use the mod cost as we are swapping energy types
+  if (modEnergyHash && modEnergyHash !== armorEnergy.hash) {
     resultingEnergyCapacity = modCost;
+  } else {
+    // Otherwise we just take the max of capacity and mod cost
+    resultingEnergyCapacity = Math.max(armorEnergyCapacity, modCost);
   }
 
   const noEnergyChange =

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -30,21 +30,21 @@ function EnergySwap({
   const armorEnergy = defs.EnergyType.get(item.energy!.energyTypeHash);
 
   const modCost = _.sumBy(assignedMods, (mod) => mod.plug.energyCost?.energyCost || 0);
-  const modEnergyHash = assignedMods?.find(
+  const modEnergyHashNotAny = assignedMods?.find(
     (mod) => mod.plug.energyCost?.energyType !== DestinyEnergyType.Any
   )?.plug.energyCost?.energyTypeHash;
-  const modEnergy = (modEnergyHash && defs.EnergyType.get(modEnergyHash)) || null;
+  const modEnergy = (modEnergyHashNotAny && defs.EnergyType.get(modEnergyHashNotAny)) || null;
 
   // The armor energy type and capacity needed for the mods
   const resultingEnergy = modEnergy ?? armorEnergy;
   let resultingEnergyCapacity = armorEnergyCapacity;
 
-  // If there is a non Any mod energy type and its different to ther armor energy type
-  // we always use the mod cost as we are swapping energy types
-  if (modEnergyHash && modEnergyHash !== armorEnergy.hash) {
+  // If there is a mod energy type and it's different to the armor energy type
+  // we always use the mod cost as we are swapping energy types on the armor
+  if (modEnergyHashNotAny && modEnergyHashNotAny !== armorEnergy.hash) {
     resultingEnergyCapacity = modCost;
   } else {
-    // Otherwise we just take the max of capacity and mod cost
+    // Otherwise we just take the max of armor capacity and mod cost
     resultingEnergyCapacity = Math.max(armorEnergyCapacity, modCost);
   }
 


### PR DESCRIPTION
Fixes an issue where energy increases are not displayed when only locking `Any` energy type mods (note the cloak).

<img width="805" alt="Screen Shot 2021-11-16 at 10 23 11 pm" src="https://user-images.githubusercontent.com/7344652/141976835-c60c847a-2781-4ec7-be7f-16b342b26b1c.png">


Fixes #7260 