### PR TITLE
Make LO mod searching faster.

### DIFF
--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -236,7 +236,7 @@ export function canTakeSlotIndependentMods(
         }
 
         // To hit this point we need to have found a valid set of activity mods
-        // if none is found the continue's will skip this.
+        // if none is found the continues will skip this.
         return true;
       }
     }


### PR DESCRIPTION
This speeds up processing activity mods by about 1/3. Note you need one of each element for activity and combat to trigger slower speeds.

### Before

<img width="1194" alt="Screen Shot 2021-11-27 at 11 22 16 am" src="https://user-images.githubusercontent.com/7344652/143662378-fa242d39-1250-4cc6-866b-0c5868c19071.png">

### After

<img width="1044" alt="Screen Shot 2021-11-27 at 11 22 06 am" src="https://user-images.githubusercontent.com/7344652/143662384-6ab61314-67e0-46fc-892a-043ea2c00659.png">
