### PR TITLE
Provide a sheet context so press tips dont move around on scroll.

### DIFF
--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -1,7 +1,8 @@
 import _ from 'lodash';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import styles from './PressTip.m.scss';
+import { SheetContext } from './Sheet';
 import { usePopper } from './usePopper';
 
 interface Props {
@@ -46,6 +47,7 @@ function Control({
   ...rest
 }: ControlProps) {
   const tooltipContents = useRef<HTMLDivElement>(null);
+  const sheetContext = useContext(SheetContext);
 
   usePopper({
     contents: tooltipContents,
@@ -73,7 +75,7 @@ function Control({
             <div className={styles.content}>{_.isFunction(tooltip) ? tooltip() : tooltip}</div>
             <div className={styles.arrow} />
           </div>,
-          document.body
+          sheetContext?.current || document.body
         )}
     </Component>
   );


### PR DESCRIPTION
This provides a sheet context for the press tip so that scolling the page behind doesn't move the tool tip. Not sure what other components we would want this in but this is a start.

https://user-images.githubusercontent.com/7344652/144229556-0203007c-47b7-47ce-9b64-bba6b53017de.mp4

