### PR TITLE
Implement InsertSocketPlugFree

### DIFF
--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -74,18 +74,21 @@ async function responseIndicatesBadToken(response: Response) {
   if (response.status === 401) {
     return true;
   }
-  const data = await response.clone().json();
-  return (
-    data &&
-    (data.ErrorCode === PlatformErrorCodes.AccessTokenHasExpired ||
-      data.ErrorCode === PlatformErrorCodes.WebAuthRequired ||
-      // (also means the access token has expired)
-      data.ErrorCode === PlatformErrorCodes.WebAuthModuleAsyncFailed ||
-      data.ErrorCode === PlatformErrorCodes.AuthorizationRecordRevoked ||
-      data.ErrorCode === PlatformErrorCodes.AuthorizationRecordExpired ||
-      data.ErrorCode === PlatformErrorCodes.AuthorizationCodeStale ||
-      data.ErrorCode === PlatformErrorCodes.AuthorizationCodeInvalid)
-  );
+  try {
+    const data = await response.clone().json();
+    return (
+      data &&
+      (data.ErrorCode === PlatformErrorCodes.AccessTokenHasExpired ||
+        data.ErrorCode === PlatformErrorCodes.WebAuthRequired ||
+        // (also means the access token has expired)
+        data.ErrorCode === PlatformErrorCodes.WebAuthModuleAsyncFailed ||
+        data.ErrorCode === PlatformErrorCodes.AuthorizationRecordRevoked ||
+        data.ErrorCode === PlatformErrorCodes.AuthorizationRecordExpired ||
+        data.ErrorCode === PlatformErrorCodes.AuthorizationCodeStale ||
+        data.ErrorCode === PlatformErrorCodes.AuthorizationCodeInvalid)
+    );
+  } catch {}
+  return false;
 }
 
 export async function getActiveToken(): Promise<Tokens> {

--- a/src/app/bungie-api/http-client.ts
+++ b/src/app/bungie-api/http-client.ts
@@ -49,7 +49,7 @@ function throwHttpError(response: Response) {
  * but throws JS errors for "successful" fetches with Bungie error information
  */
 function throwBungieError<T>(
-  serverResponse: ServerResponse<T> & { error?: string; error_description?: string },
+  serverResponse: (ServerResponse<T> & { error?: string; error_description?: string }) | undefined,
   request: Request
 ) {
   // There's an alternate error response that can be returned during maintenance
@@ -65,7 +65,7 @@ function throwBungieError<T>(
     );
   }
 
-  if (serverResponse.ErrorCode !== PlatformErrorCodes.Success) {
+  if (serverResponse && serverResponse.ErrorCode !== PlatformErrorCodes.Success) {
     throw new BungieError(serverResponse, request);
   }
 
@@ -158,7 +158,10 @@ export function createHttpClient(
       credentials: withCredentials ? 'include' : 'omit',
     });
     const response = await fetchFunction(fetchOptions);
-    const data: ServerResponse<unknown> = await response.json();
+    let data: ServerResponse<unknown> | undefined;
+    try {
+      data = await response.json();
+    } catch {}
     // try throwing bungie errors, which have more information, first
     throwBungieError(data, fetchOptions);
     // then throw errors on generic http error codes

--- a/src/app/bungie-api/http-client.ts
+++ b/src/app/bungie-api/http-client.ts
@@ -159,13 +159,19 @@ export function createHttpClient(
     });
     const response = await fetchFunction(fetchOptions);
     let data: ServerResponse<unknown> | undefined;
+    let parseError: Error | undefined;
     try {
       data = await response.json();
-    } catch {}
+    } catch (e) {
+      parseError = e;
+    }
     // try throwing bungie errors, which have more information, first
     throwBungieError(data, fetchOptions);
     // then throw errors on generic http error codes
     throwHttpError(response);
+    if (parseError) {
+      throw parseError;
+    }
     return data;
   };
 }

--- a/src/app/bungie-api/rate-limit-config.ts
+++ b/src/app/bungie-api/rate-limit-config.ts
@@ -30,4 +30,11 @@ export default function setupRateLimiter() {
   RateLimiterConfig.addLimiter(
     new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100)
   );
+  RateLimiterConfig.addLimiter(
+    new RateLimiterQueue(
+      /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/InsertSocketPlugFree/,
+      2,
+      1100
+    )
+  );
 }

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -1,4 +1,5 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
+import { HttpStatusError } from 'app/bungie-api/http-client';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { d2ManifestSelector } from 'app/manifest/selectors';
@@ -69,8 +70,6 @@ function canInsertForFree(
 
 /**
  * Modify an item to insert a new plug into one of its socket.
- *
- * @param free true if this plug has no cost to insert, and the plug
  */
 export function insertPlug(item: DimItem, socket: DimSocket, plugItemHash: number): ThunkResult {
   return async (dispatch, getState) => {
@@ -95,7 +94,7 @@ export function insertPlug(item: DimItem, socket: DimSocket, plugItemHash: numbe
       await dispatch(refreshItemAfterAWA(item, response.Response));
     } catch (e) {
       errorLog('AWA', "Couldn't insert plug", item, e);
-      if (e instanceof DimError && e.code === 'BungieService.Difficulties') {
+      if (e instanceof DimError && e.cause instanceof HttpStatusError && e.cause.status === 404) {
         showNotification({
           type: 'error',
           title: 'Not Yet!',

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -63,7 +63,9 @@ function canInsertForFree(
         socket.socketDefinition.randomizedPlugSetHash
     ) &&
     // And have no cost to insert
-    !plug.plug?.insertionMaterialRequirementHash;
+    !plug.plug?.insertionMaterialRequirementHash &&
+    // And the current plug didn't cost anything (can't replace a non-free mod with a free one)
+    (!socket.plugged || !socket.plugged.plugDef.plug.insertionMaterialRequirementHash);
 
   return free;
 }

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -1,9 +1,11 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { ThunkResult } from 'app/store/types';
 import { DimError } from 'app/utils/dim-error';
 import { errorLog } from 'app/utils/log';
+import { Destiny2CoreSettings } from 'bungie-api-ts/core';
 import {
   AwaAuthorizationResult,
   AwaType,
@@ -11,6 +13,7 @@ import {
   DestinyItemChangeResponse,
   DestinySocketArrayType,
   insertSocketPlug,
+  insertSocketPlugFree,
 } from 'bungie-api-ts/destiny2';
 import { get, set } from 'idb-keyval';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -25,37 +28,128 @@ let awaCache: {
   [key: number]: AwaAuthorizationResult & { used: number };
 };
 
+export function canInsertPlug(
+  socket: DimSocket,
+  plugItemHash: number,
+  destiny2CoreSettings: Destiny2CoreSettings,
+  defs: D2ManifestDefinitions
+) {
+  return $featureFlags.awa || canInsertForFree(socket, plugItemHash, destiny2CoreSettings, defs);
+}
+
+function canInsertForFree(
+  socket: DimSocket,
+  plugItemHash: number,
+  destiny2CoreSettings: Destiny2CoreSettings,
+  defs: D2ManifestDefinitions
+) {
+  const { insertPlugFreeProtectedPlugItemHashes, insertPlugFreeBlockedSocketTypeHashes } =
+    destiny2CoreSettings;
+  if (
+    (insertPlugFreeProtectedPlugItemHashes || []).includes(plugItemHash) ||
+    (insertPlugFreeBlockedSocketTypeHashes || []).includes(socket.socketDefinition.socketTypeHash)
+  ) {
+    return false;
+  }
+
+  const plug = defs.InventoryItem.get(plugItemHash);
+
+  const free =
+    // Must be reusable or randomized type
+    Boolean(
+      socket.socketDefinition.reusablePlugItems.length > 0 ||
+        socket.socketDefinition.reusablePlugSetHash ||
+        socket.socketDefinition.randomizedPlugSetHash
+    ) &&
+    // And have no cost to insert
+    !plug.plug?.insertionMaterialRequirementHash;
+
+  return free;
+}
+
+/**
+ * Modify an item to insert a new plug into one of its socket.
+ *
+ * @param free true if this plug has no cost to insert, and the plug
+ */
 export function insertPlug(item: DimItem, socket: DimSocket, plugItemHash: number): ThunkResult {
   return async (dispatch, getState) => {
     const account = currentAccountSelector(getState())!;
 
+    const free = canInsertForFree(
+      socket,
+      plugItemHash,
+      getState().manifest.destiny2CoreSettings!,
+      d2ManifestSelector(getState())!
+    );
+
     // The API requires either the ID of the character that owns the item, or
     // the current character ID if the item is in the vault.
     const storeId = item.owner === 'vault' ? currentStoreSelector(getState())!.id : item.owner;
-    try {
-      const actionToken = await getAwaToken(account, AwaType.InsertPlugs, storeId, item);
-      // TODO: if the plug costs resources to insert, add a confirmation. This'd
-      // be a great place for a dialog component?
 
-      const response = await insertSocketPlug(authenticatedHttpClient, {
-        actionToken,
-        itemInstanceId: item.id,
-        plug: {
-          socketIndex: socket.socketIndex,
-          socketArrayType: DestinySocketArrayType.Default,
-          plugItemHash,
-        },
-        characterId: storeId,
-        membershipType: account.originalPlatformType,
-      });
+    try {
+      const insertFn = free ? awaInsertSocketPlugFree : awaInsertSocketPlug;
+      const response = await insertFn(account, storeId, item, socket, plugItemHash);
 
       // Update items that changed
       await dispatch(refreshItemAfterAWA(item, response.Response));
     } catch (e) {
       errorLog('AWA', "Couldn't insert plug", item, e);
-      showNotification({ type: 'error', title: t('AWA.Error'), body: e.message });
+      if (e instanceof DimError && e.code === 'BungieService.Difficulties') {
+        showNotification({
+          type: 'error',
+          title: 'Not Yet!',
+          body: "Changing perks and mods won't be available until the launch of the Bungie 30th Anniversary patch on December 7th.",
+        });
+      } else {
+        showNotification({ type: 'error', title: t('AWA.Error'), body: e.message });
+      }
     }
   };
+}
+
+async function awaInsertSocketPlugFree(
+  account: DestinyAccount,
+  storeId: string,
+  item: DimItem,
+  socket: DimSocket,
+  plugItemHash: number
+) {
+  return insertSocketPlugFree(authenticatedHttpClient, {
+    itemId: item.id,
+    plug: {
+      socketIndex: socket.socketIndex,
+      socketArrayType: DestinySocketArrayType.Default,
+      plugItemHash,
+    },
+    characterId: storeId,
+    membershipType: account.originalPlatformType,
+  });
+}
+
+async function awaInsertSocketPlug(
+  account: DestinyAccount,
+  storeId: string,
+  item: DimItem,
+  socket: DimSocket,
+  plugItemHash: number
+) {
+  const actionToken = await getAwaToken(account, AwaType.InsertPlugs, storeId, item);
+
+  // TODO: if the plug costs resources to insert, add a confirmation. This'd
+  // be a great place for a dialog component?
+
+  return insertSocketPlug(authenticatedHttpClient, {
+    actionToken,
+    itemInstanceId: item.id,
+    plug: {
+      socketIndex: socket.socketIndex,
+      socketArrayType: DestinySocketArrayType.Default,
+      plugItemHash,
+    },
+    characterId: storeId,
+    membershipType: account.originalPlatformType,
+  });
 }
 
 /**

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -110,7 +110,6 @@ export default function ItemDetails({
 
       <ApplyPerkSelection
         item={item}
-        socketOverrides={socketOverrides}
         setSocketOverride={onPlugClicked}
         onApplied={resetSocketOverrides}
       />

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -1,6 +1,6 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
-import { insertPlug } from 'app/inventory/advanced-write-actions';
+import { canInsertPlug, insertPlug } from 'app/inventory/advanced-write-actions';
 import {
   DimItem,
   DimPlug,
@@ -9,7 +9,7 @@ import {
   PluggableInventoryItemDefinition,
 } from 'app/inventory/item-types';
 import { interpolateStatValue } from 'app/inventory/store/stats';
-import { useD2Definitions } from 'app/manifest/selectors';
+import { destiny2CoreSettingsSelector, useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
 import { refreshIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
@@ -23,6 +23,7 @@ import { StatHashes } from 'data/d2/generated-enums';
 import { motion } from 'framer-motion';
 import _ from 'lodash';
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import ItemStats from './ItemStats';
 import { StatValue } from './PlugTooltip';
 import { SocketDetailsMod } from './SocketDetails';
@@ -55,6 +56,7 @@ export default function SocketDetailsSelectedPlug({
 }) {
   const dispatch = useThunkDispatch();
   const defs = useD2Definitions()!;
+  const destiny2CoreSettings = useSelector(destiny2CoreSettingsSelector)!;
   const selectedPlugPerk =
     Boolean(plug.perks?.length) && defs.SandboxPerk.get(plug.perks[0].perkHash);
 
@@ -107,7 +109,8 @@ export default function SocketDetailsSelectedPlug({
   );
 
   // Can we actually insert this mod instead of just previewing it?
-  const canDoAWA = itemIsInstanced(item) && $featureFlags.awa;
+  const canDoAWA =
+    itemIsInstanced(item) && canInsertPlug(socket, plug.hash, destiny2CoreSettings, defs);
 
   const [insertInProgress, setInsertInProgress] = useState(false);
   const onInsertPlug = async () => {
@@ -148,7 +151,6 @@ export default function SocketDetailsSelectedPlug({
     <div className={styles.selectedPlug}>
       <div className={styles.modIcon}>
         <SocketDetailsMod itemDef={plug} />
-        {!$featureFlags.awa && costs}
       </div>
       <div className={styles.modDescription}>
         <h3>


### PR DESCRIPTION
This leaves the awa feature flag around and automatically limits actions depending on whether the action is free or you have the full AWA scope, just in case they ever want to give that out.

The practical effect of this is that when the manifest updates to make things free, this should automatically pick up the capability. Obviously we can't test it until Tuesday. Perks are already free so it goes ahead and tries it - I've put a cheeky little error message up that should go away after the deployment (I didn't bother making it translate-able but I will if folks think that's worthwhile).