### PR TITLE
Put instructions inline for LO on mobile

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -338,6 +338,13 @@ function LoadoutBuilder({
 
   const menuContent = (
     <>
+      {isPhonePortrait && (
+        <div className={styles.guide}>
+          <ol>
+            <li>{t('LoadoutBuilder.OptimizerExplanationStats')}</li>
+          </ol>
+        </div>
+      )}
       <TierSelect
         stats={statFilters}
         statRangesFiltered={result?.statRangesFiltered}
@@ -347,7 +354,6 @@ function LoadoutBuilder({
         }
         onStatOrderChanged={(sortOrder) => lbDispatch({ type: 'sortOrderChanged', sortOrder })}
       />
-
       <LockArmorAndPerks
         selectedStore={selectedStore}
         pinnedItems={pinnedItems}
@@ -359,6 +365,14 @@ function LoadoutBuilder({
         searchFilter={searchFilter}
         lbDispatch={lbDispatch}
       />
+      {isPhonePortrait && (
+        <div className={styles.guide}>
+          <ol start={4}>
+            <li>{t('LoadoutBuilder.OptimizerExplanationSearch')}</li>
+          </ol>
+          <p>{t('LoadoutBuilder.OptimizerExplanationGuide')}</p>
+        </div>
+      )}
     </>
   );
 
@@ -435,15 +449,17 @@ function LoadoutBuilder({
             </div>
           )}
         </div>
-        <div className={styles.guide}>
-          <ol>
-            <li>{t('LoadoutBuilder.OptimizerExplanationStats')}</li>
-            <li>{t('LoadoutBuilder.OptimizerExplanationMods')}</li>
-            <li>{t('LoadoutBuilder.OptimizerExplanationUpgrades')}</li>
-            <li>{t('LoadoutBuilder.OptimizerExplanationSearch')}</li>
-          </ol>
-          <p>{t('LoadoutBuilder.OptimizerExplanationGuide')}</p>
-        </div>
+        {!isPhonePortrait && (
+          <div className={styles.guide}>
+            <ol>
+              <li>{t('LoadoutBuilder.OptimizerExplanationStats')}</li>
+              <li>{t('LoadoutBuilder.OptimizerExplanationMods')}</li>
+              <li>{t('LoadoutBuilder.OptimizerExplanationUpgrades')}</li>
+              <li>{t('LoadoutBuilder.OptimizerExplanationSearch')}</li>
+            </ol>
+            <p>{t('LoadoutBuilder.OptimizerExplanationGuide')}</p>
+          </div>
+        )}
         {notes && (
           <div className={styles.guide}>
             <p>

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.m.scss
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.m.scss
@@ -30,3 +30,8 @@
     }
   }
 }
+
+// TODO: dedupe this
+.guide {
+  composes: guide from '../LoadoutBuilder.m.scss';
+}

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.m.scss.d.ts
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'area': string;
   'buttons': string;
+  'guide': string;
   'itemGrid': string;
   'notItemGrid': string;
 }

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -8,6 +8,7 @@ import { getModRenderKey } from 'app/loadout/mod-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { ItemFilter } from 'app/search/filter-types';
 import { addIcon, AppIcon, faTimesCircle, pinIcon } from 'app/shell/icons';
+import { useIsPhonePortrait } from 'app/shell/selectors';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import _ from 'lodash';
 import React, { Dispatch, memo, useCallback, useState } from 'react';
@@ -51,6 +52,7 @@ export default memo(function LockArmorAndPerks({
   const [showExoticPicker, setShowExoticPicker] = useState(false);
   const [showArmorUpgradePicker, setShowArmorUpgradePicker] = useState(false);
   const defs = useD2Definitions()!;
+  const isPhonePortrait = useIsPhonePortrait();
 
   /**
    * Lock currently equipped items on a character
@@ -114,19 +116,25 @@ export default memo(function LockArmorAndPerks({
 
   return (
     <>
+      {isPhonePortrait && (
+        <div className={styles.guide}>
+          <ol start={2}>
+            <li>{t('LoadoutBuilder.OptimizerExplanationMods')}</li>
+          </ol>
+        </div>
+      )}
       <div className={styles.area}>
-        <SelectedArmorUpgrade
-          defs={defs}
-          upgradeSpendTier={upgradeSpendTier}
-          lockItemEnergyType={lockItemEnergyType}
-        />
+        {lockedExoticHash && (
+          <div className={styles.notItemGrid}>
+            <ExoticArmorChoice
+              lockedExoticHash={lockedExoticHash}
+              onClose={() => lbDispatch({ type: 'removeLockedExotic' })}
+            />
+          </div>
+        )}
         <div className={styles.buttons}>
-          <button
-            type="button"
-            className="dim-button"
-            onClick={() => setShowArmorUpgradePicker(true)}
-          >
-            {t('LoadoutBuilder.SelectArmorUpgrade')}
+          <button type="button" className="dim-button" onClick={() => setShowExoticPicker(true)}>
+            {t('LB.SelectExotic')}
           </button>
         </div>
       </div>
@@ -152,18 +160,26 @@ export default memo(function LockArmorAndPerks({
           </button>
         </div>
       </div>
+      {isPhonePortrait && (
+        <div className={styles.guide}>
+          <ol start={3}>
+            <li>{t('LoadoutBuilder.OptimizerExplanationUpgrades')}</li>
+          </ol>
+        </div>
+      )}
       <div className={styles.area}>
-        {lockedExoticHash && (
-          <div className={styles.notItemGrid}>
-            <ExoticArmorChoice
-              lockedExoticHash={lockedExoticHash}
-              onClose={() => lbDispatch({ type: 'removeLockedExotic' })}
-            />
-          </div>
-        )}
+        <SelectedArmorUpgrade
+          defs={defs}
+          upgradeSpendTier={upgradeSpendTier}
+          lockItemEnergyType={lockItemEnergyType}
+        />
         <div className={styles.buttons}>
-          <button type="button" className="dim-button" onClick={() => setShowExoticPicker(true)}>
-            {t('LB.SelectExotic')}
+          <button
+            type="button"
+            className="dim-button"
+            onClick={() => setShowArmorUpgradePicker(true)}
+          >
+            {t('LoadoutBuilder.SelectArmorUpgrade')}
           </button>
         </div>
       </div>


### PR DESCRIPTION
On mobile the LO is linear, so might as well put the instructions right there:
<img width="187" alt="Screen Shot 2021-12-04 at 12 14 13 PM" src="https://user-images.githubusercontent.com/313208/144723328-90cabfd7-baab-4be5-ad5d-a1e94529ff74.png">
