### PR TITLE
Loadout fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Loadouts can now have notes.
 * Share loadout build settings (mods, notes, loadout optimizer settings) from the Loadouts page.
 * Loadouts can now save stasis subclass abilities, aspects, and fragments.
+* We made several bugfixes to how loadouts are applied that should fix some issues where not all items got equipped or failures were shown when nothing failed.
 * The "Create Loadout" button on the Loadouts page defaults the loadout to match the class of the selected character.
 * The menu for pinning or excluding an item in Loadout Optimizer now only shows items that match the overall search filter.
 * Stat searches support keywords like "highest" and "secondhighest" in stat total/mean expressions. e.g. basestat:highest&secondhighest:>=17.5

--- a/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
@@ -92,7 +92,7 @@ export default function LoadoutDrawerOptions({
 
   const saveDisabled =
     !loadout.name.length ||
-    !loadout.items.length ||
+    (!loadout.items.length && !loadout.parameters?.mods?.length) ||
     // There's an existing loadout with the same name & class and it's not the loadout we are currently editing
     Boolean(clashingLoadout && clashingLoadout.id !== loadout.id);
 

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -168,7 +168,7 @@ function doApplyLoadout(
           (loadoutItem.equipped && !item.equipped) ||
           // We always try to move consumable stacks because their logic is complicated
           (loadoutItem.amount && loadoutItem.amount > 1));
-      return notAlreadyThere;
+      return notAlreadyThere && !item.notransfer;
     });
 
     // vault can't equip

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -211,7 +211,9 @@ function doApplyLoadout(
         _.groupBy(realItemsToDequip, (i) => i.owner),
         (dequipItems, owner) => {
           const itemsToEquip = _.compact(
-            dequipItems.map((i) => getSimilarItem(getStores(), i, excludes))
+            dequipItems.map((i) =>
+              getSimilarItem(getStores(), i, { exclusions: excludes, excludeExotic: i.isExotic })
+            )
           );
           return dispatch(equipItems(getStore(getStores(), owner)!, itemsToEquip));
         }

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -133,7 +133,9 @@ function doApplyLoadout(
 ): ThunkResult<Scope> {
   return async (dispatch, getState) => {
     dispatch(interruptFarming());
+    // The store and its items may change as we move things - make sure we're always looking at the latest version
     const getStores = () => storesSelector(getState());
+    const getTargetStore = () => getStore(getStores(), store.id)!;
     if (allowUndo && !store.isVault) {
       dispatch(
         savePreviousLoadout({
@@ -217,10 +219,11 @@ function doApplyLoadout(
       await Promise.all(dequips);
     }
 
-    await dispatch(applyLoadoutItems(store, loadoutItemsToMove, excludes, cancelToken, scope));
+    await dispatch(applyLoadoutItems(store.id, loadoutItemsToMove, excludes, cancelToken, scope));
 
     let equippedItems: LoadoutItem[];
     if (itemsToEquip.length > 1) {
+      const store = getTargetStore();
       // Use the bulk equipAll API to equip all at once.
       itemsToEquip = itemsToEquip.filter((i) => scope.successfulItems.find((si) => si.id === i.id));
       const realItemsToEquip = _.compact(
@@ -232,6 +235,7 @@ function doApplyLoadout(
     }
 
     if (equippedItems.length < itemsToEquip.length) {
+      const store = getTargetStore();
       const failedItems = _.compact(
         itemsToEquip
           .filter((i) => !equippedItems.find((it) => it.id === i.id))
@@ -258,7 +262,7 @@ function doApplyLoadout(
     if (loadout.clearSpace && !store.isVault) {
       await dispatch(
         clearSpaceAfterLoadout(
-          getStore(getStores(), store.id)!,
+          getTargetStore(),
           applicableLoadoutItems.map((i) => getLoadoutItem(i, store, getStores())!),
           cancelToken
         )
@@ -272,7 +276,7 @@ function doApplyLoadout(
 
 // Move one loadout item at a time. Called recursively to move items!
 function applyLoadoutItems(
-  store: DimStore,
+  storeId: string,
   items: LoadoutItem[],
   excludes: { id: string; hash: number }[],
   cancelToken: CancelToken,
@@ -293,10 +297,12 @@ function applyLoadoutItems(
       return;
     }
 
-    const getStores = () => storesSelector(getState());
+    // The store and its items may change as we move things - make sure we're always looking at the latest version
+    const stores = storesSelector(getState());
+    const store = getStore(stores, storeId)!;
 
     const pseudoItem = items.shift()!;
-    const item = getLoadoutItem(pseudoItem, store, getStores());
+    const item = getLoadoutItem(pseudoItem, store, stores);
 
     try {
       if (item) {
@@ -309,7 +315,7 @@ function applyLoadoutItems(
           const amountAlreadyHave = amountOfItem(store, pseudoItem);
           let amountNeeded = pseudoItem.amount - amountAlreadyHave;
           if (amountNeeded > 0) {
-            const otherStores = getStores().filter((otherStore) => store.id !== otherStore.id);
+            const otherStores = stores.filter((otherStore) => store.id !== otherStore.id);
             const storesByAmount = _.sortBy(
               otherStores.map((store) => ({
                 store,
@@ -381,7 +387,7 @@ function applyLoadoutItems(
     }
 
     // Keep going
-    return dispatch(applyLoadoutItems(store, items, excludes, cancelToken, scope));
+    return dispatch(applyLoadoutItems(storeId, items, excludes, cancelToken, scope));
   };
 }
 

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -18,6 +18,7 @@ import { SelectedArmorUpgrade } from 'app/loadout-builder/filter/ArmorUpgradePic
 import ExoticArmorChoice from 'app/loadout-builder/filter/ExoticArmorChoice';
 import { deleteLoadout } from 'app/loadout-drawer/actions';
 import { maxLightLoadout } from 'app/loadout-drawer/auto-loadouts';
+import { applyLoadout } from 'app/loadout-drawer/loadout-apply';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import {
@@ -251,6 +252,11 @@ function LoadoutRow({
     });
   };
 
+  const handleApply = () =>
+    dispatch(applyLoadout(store, loadout, { allowUndo: true, onlyMatchingClass: true }));
+
+  const handleEdit = () => editLoadout(loadout, { isNew: !saved });
+
   return (
     <div className={styles.loadout} id={loadout.id}>
       <div className={styles.title}>
@@ -265,18 +271,10 @@ function LoadoutRow({
           )}
         </h2>
         <div className={styles.actions}>
-          <button
-            type="button"
-            className="dim-button"
-            onClick={() => editLoadout(loadout, { isNew: !saved })}
-          >
+          <button type="button" className="dim-button" onClick={handleApply}>
             {t('Loadouts.Apply')}
           </button>
-          <button
-            type="button"
-            className="dim-button"
-            onClick={() => editLoadout(loadout, { isNew: !saved })}
-          >
+          <button type="button" className="dim-button" onClick={handleEdit}>
             {saved ? t('Loadouts.EditBrief') : t('Loadouts.SaveLoadout')}
           </button>
           {canShare && (

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -293,7 +293,7 @@ function LoadoutRow({
       </div>
       {loadout.notes && <div className={styles.loadoutNotes}>{loadout.notes}</div>}
       <div className={styles.contents}>
-        {(items.length > 0 || subClass) && (
+        {(items.length > 0 || subClass || savedMods.length > 0) && (
           <>
             <div className={styles.subClass}>
               {subClass ? (


### PR DESCRIPTION
A bunch of general loadout / item move fixes. These fix a lot of problems that I've seen people report, plus some that are theoretical but would be hard to pin down. These include:

1. Loadouts saying they failed to move a subclass to the vault (you can't do that)
2. Loadouts failing to equip the exotic you want and instead equipping a different exotic.
3. Loadouts generally failing to move things or moving too many things because they were operating on outdated intermediate views of inventory.
4. Allow loadouts to be created that only include mods.