### PR TITLE
simplify string copying

### DIFF
--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -88,13 +88,7 @@ export function delay(ms: number) {
 
 /** Copy a string to the clipboard */
 export function copyString(str: string) {
-  function listener(e: ClipboardEvent) {
-    e.clipboardData?.setData('text/plain', str);
-    e.preventDefault();
-  }
-  document.addEventListener('copy', listener);
-  document.execCommand('copy');
-  document.removeEventListener('copy', listener);
+  navigator.clipboard.writeText(str);
 }
 
 /** Download a string as a file */


### PR DESCRIPTION
`clipboard.writeText` is supported by all major stuff for 2 years, except for iOS where it's been supported 1.5.
conveniently, our current way doesn't work anyway on iOS. so things can only improve from here.