### PR TITLE
remove warning and adjust "already there" mods logic

### DIFF
--- a/src/app/loadout-drawer/SavedMods.m.scss
+++ b/src/app/loadout-drawer/SavedMods.m.scss
@@ -8,16 +8,6 @@
   text-transform: uppercase;
 }
 
-.disclaimer {
-  font-style: italic;
-  padding-top: 8px;
-}
-
-.warningIcon {
-  color: yellow;
-  margin-right: 4px;
-}
-
 .categories {
   display: flex;
   flex-flow: row wrap;

--- a/src/app/loadout-drawer/SavedMods.m.scss.d.ts
+++ b/src/app/loadout-drawer/SavedMods.m.scss.d.ts
@@ -3,9 +3,7 @@
 interface CssExports {
   'categories': string;
   'container': string;
-  'disclaimer': string;
   'title': string;
-  'warningIcon': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/loadout-drawer/SavedMods.tsx
+++ b/src/app/loadout-drawer/SavedMods.tsx
@@ -1,7 +1,6 @@
 import { t } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { sortModGroups } from 'app/loadout/mod-utils';
-import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
 import _ from 'lodash';
 import React, { useMemo } from 'react';
 import SavedModCategory from './SavedModCategory';
@@ -46,10 +45,6 @@ function SavedMods({ savedMods, onOpenModPicker, removeModByHash }: Props) {
             />
           ) : null
         )}
-      </div>
-      <div className={styles.disclaimer}>
-        <AppIcon className={styles.warningIcon} icon={faExclamationTriangle} />
-        {t('Loadouts.ModsInfo')}
       </div>
     </div>
   );

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -633,19 +633,31 @@ function applyLoadoutMods(
     const mods = modHashes.map((h) => defs.InventoryItem.get(h)).filter(isPluggableItem);
 
     // What mods are already on the equipped armor set?
-    const existingMods = new Set<number>();
+    const existingMods: number[] = [];
     for (const item of armor) {
       if (item.sockets) {
         for (const socket of item.sockets.allSockets) {
           if (socket.plugged) {
-            existingMods.add(socket.plugged.plugDef.hash);
+            existingMods.push(socket.plugged.plugDef.hash);
           }
         }
       }
     }
 
     // Early exit - if all the mods are already there, nothing to do
-    if (modHashes.every((h) => existingMods.has(h))) {
+    if (
+      modHashes.every((h) => {
+        const foundAt = existingMods.indexOf(h);
+        if (foundAt === -1) {
+          // a mod was missing
+          return false;
+        } else {
+          // the mod was found, but we have consumed this copy of it
+          delete existingMods[foundAt];
+          return true;
+        }
+      })
+    ) {
       infoLog('loadout mods', 'all mods are already there, skipping');
       return modHashes;
     }


### PR DESCRIPTION
2 quick fixes 

removes this warning
![image](https://user-images.githubusercontent.com/68782081/144794276-b8a62885-a697-4b20-a69c-cfdb06f07120.png)

accounts for a loadout with multiple copies of the same mod. a single existing mod X shouldn't satisfy a loadout containing two of X. does this make sense?