### PR TITLE
Fix raid mod descriptions.

### DIFF
--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss
@@ -54,3 +54,9 @@
   margin-top: 8px;
   font-style: italic;
 }
+
+.partialDescription {
+  &:not(:last-child) {
+    margin-bottom: 4px;
+  }
+}

--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss.d.ts
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'iconContainer': string;
   'lockedPerk': string;
+  'partialDescription': string;
   'plug': string;
   'plugInfo': string;
   'plugTitle': string;

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -51,24 +51,23 @@ export default function SelectablePlug({
         </div>
         <div className={styles.plugInfo}>
           <div className={styles.plugTitle}>{plug.displayProperties.name}</div>
-          {plug.displayProperties.description ? (
-            <div>
+          {_.uniqBy(
+            plug.perks,
+            (p) => defs.SandboxPerk.get(p.perkHash).displayProperties.description
+          ).map((perk) => (
+            <div className={styles.partialDescription} key={perk.perkHash}>
+              <RichDestinyText
+                text={defs.SandboxPerk.get(perk.perkHash).displayProperties.description}
+              />
+              {perk.requirementDisplayString && (
+                <div className={styles.requirement}>{perk.requirementDisplayString}</div>
+              )}
+            </div>
+          ))}
+          {plug.displayProperties.description && (
+            <div className={styles.partialDescription}>
               <RichDestinyText text={plug.displayProperties.description} />
             </div>
-          ) : (
-            _.uniqBy(
-              plug.perks,
-              (p) => defs.SandboxPerk.get(p.perkHash).displayProperties.description
-            ).map((perk) => (
-              <div key={perk.perkHash}>
-                <RichDestinyText
-                  text={defs.SandboxPerk.get(perk.perkHash).displayProperties.description}
-                />
-                {perk.requirementDisplayString && (
-                  <div className={styles.requirement}>{perk.requirementDisplayString}</div>
-                )}
-              </div>
-            ))
           )}
           {stats.length > 0 && (
             <div className="plug-stats">


### PR DESCRIPTION
Fixes #7381 

It's not perfect but it fixes the issue (note the double up of text in the GoS ones). We should probably collect all the descriptions and attempt to filter out ones that are identical or very similar based on edit distance.

<img width="1253" alt="Screen Shot 2021-12-07 at 1 17 10 am" src="https://user-images.githubusercontent.com/7344652/144862188-6fd34893-88a7-4215-9cd0-127c58e3d996.png">
