### PR TITLE
more loadout apply adjustments

### DIFF
--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -74,7 +74,7 @@ export default function ModAssignmentDrawer({
 }) {
   const [plugCategoryHashWhitelist, setPlugCategoryHashWhitelist] = useState<number[]>();
 
-  const defs = useD2Definitions();
+  const defs = useD2Definitions()!;
   const armor = useEquippedLoadoutArmor(loadout);
   const getModRenderKey = createGetModRenderKey();
 


### PR DESCRIPTION
#### loadout-apply.ts
- `skipArmorsWithNoAssignments = true` don't waste time wiping 4 armors clean if there's 1 mod in the loadout
- `loadout already applied` clarify what is being skipped
- `equipMods()` clarify that order matters. fix a console log to be accurate

#### mod-utils.ts 
- comments and renames for clarification

#### equipMods, getCheapestModAssignments, various other places
- stop worrying defs might not exist