### PR TITLE
Include postmaster items in search transfers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Stasis subclass abilities, aspects, and fragments are now displayed in the loadouts page.
 * Fix issue where Optimizer throws an error when selecting a raid or combat mod.
 * Fix an error that can occur when loading a shared build link.
+* Items in the postmaster are now included in search transfers.
 
 ## 6.94.0 <span class="changelog-date">(2021-12-05)</span>
 

--- a/src/app/loadout-drawer/auto-loadouts.ts
+++ b/src/app/loadout-drawer/auto-loadouts.ts
@@ -186,7 +186,6 @@ export function gatherEngramsLoadout(
  * Move a list of items to a store
  */
 export function itemMoveLoadout(items: DimItem[], store: DimStore): Loadout {
-  // Don't move things from the postmaster or that can't move
   items = items.filter((i) => !i.notransfer);
   items = addUpStackables(items);
 

--- a/src/app/loadout-drawer/auto-loadouts.ts
+++ b/src/app/loadout-drawer/auto-loadouts.ts
@@ -187,7 +187,7 @@ export function gatherEngramsLoadout(
  */
 export function itemMoveLoadout(items: DimItem[], store: DimStore): Loadout {
   // Don't move things from the postmaster or that can't move
-  items = items.filter((i) => !i.location.inPostmaster && !i.notransfer);
+  items = items.filter((i) => !i.notransfer);
   items = addUpStackables(items);
 
   const itemsByType = _.mapValues(


### PR DESCRIPTION
Fixes #7400

As far as I can tell search transfers never included postmaster items - or at least not for a very long time. I'm not sure why it was that way, or what would break with this change.