### PR TITLE
Fix energy swap display.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Items in the postmaster are now included in search transfers.
 * Added 'source:30th' for items coming from the Bungie 30th Anniversary.
 * Fix emblems and subclasses not applying from loadouts.
+* Fix an issue where energy swaps in the Optimizer where not displaying the correct resulting energy.
 
 ## 6.94.0 <span class="changelog-date">(2021-12-05)</span>
 

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -31,7 +31,7 @@ function EnergySwap({
 
   const modCost = _.sumBy(assignedMods, (mod) => mod.plug.energyCost?.energyCost || 0);
   const modEnergyHashNotAny = assignedMods?.find(
-    (mod) => mod.plug.energyCost?.energyType !== DestinyEnergyType.Any
+    (mod) => mod.plug.energyCost && mod.plug.energyCost.energyType !== DestinyEnergyType.Any
   )?.plug.energyCost?.energyTypeHash;
   const modEnergy = (modEnergyHashNotAny && defs.EnergyType.get(modEnergyHashNotAny)) || null;
 

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -31,7 +31,10 @@ function EnergySwap({
 
   const modCost = _.sumBy(assignedMods, (mod) => mod.plug.energyCost?.energyCost || 0);
   const modEnergyHashNotAny = assignedMods?.find(
-    (mod) => mod.plug.energyCost && mod.plug.energyCost.energyType !== DestinyEnergyType.Any
+    (mod) =>
+      mod.plug.energyCost &&
+      mod.plug.energyCost.energyCost > 0 &&
+      mod.plug.energyCost.energyType !== DestinyEnergyType.Any
   )?.plug.energyCost?.energyTypeHash;
   const modEnergy = (modEnergyHashNotAny && defs.EnergyType.get(modEnergyHashNotAny)) || null;
 


### PR DESCRIPTION
This fixes the energy swap display issue.

The reason this happened is that we are now returning the initial sockets from the assignment algorithm for the mod swap API. This was an issue here as those plugs have no energy cost. This will be something to keep in mind for future changes.

<img width="1202" alt="Screen Shot 2021-12-09 at 10 14 10 pm" src="https://user-images.githubusercontent.com/7344652/145386708-1d464391-5e63-49b0-b243-ed30f84768ac.png">

Fixes #7407 