### PR TITLE
Hydrate current armour when showing mod placement.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix a bug that prevented applying shaders or ornaments from the item popup.
 * Fix an error that can occur when loading a shared build link.
 * Items in the postmaster are now included in search transfers.
+* When displaying mod placement in loadouts, if an item is not present for a given armor slot in the loadout the characters current armor will be used.
 * Added 'source:30th' for items coming from the Bungie 30th Anniversary.
 * Fix emblems and subclasses not applying from loadouts.
 

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -1,8 +1,9 @@
-import { allItemsSelector } from 'app/inventory/selectors';
+import { DimItem } from 'app/inventory/item-types';
+import { allItemsSelector, sortedStoresSelector } from 'app/inventory/selectors';
+import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { armorBuckets } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
-import { compareBy } from 'app/utils/comparators';
 import { useCallback } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -15,11 +16,22 @@ const bucketOrder = [
 ];
 
 export function useEquippedLoadoutArmor(loadout: Loadout) {
+  const stores = useSelector(sortedStoresSelector);
+
   const loadoutItemSelector = useCallback(
     (state: RootState) => {
+      const currentStore = getCurrentStore(stores)!;
+      // TODO (ryan) how do we handle multiple chars with the same store? Does it matter?
+      const storeToHydrateFrom =
+        currentStore.classType === loadout.classType
+          ? currentStore
+          : stores.find((store) => store.classType === loadout.classType);
+      const currentItems = storeToHydrateFrom?.items.filter(
+        (item) => item.equipped && item.bucket.inArmor
+      );
       const equippedLoadoutItems = loadout.items.filter((item) => item.equipped);
       const allItems = allItemsSelector(state);
-      const loadoutDimItems = [];
+      const loadoutDimItems: DimItem[] = [];
 
       // TODO: if there's not an item in one of the slots, pick the current equipped!
       for (const item of allItems) {
@@ -31,9 +43,15 @@ export function useEquippedLoadoutArmor(loadout: Loadout) {
         }
       }
 
-      return loadoutDimItems.sort(compareBy((item) => bucketOrder.indexOf(item.bucket.hash)));
+      return bucketOrder
+        .map(
+          (bucketHash) =>
+            loadoutDimItems.find((item) => item.bucket.hash === bucketHash) ||
+            currentItems?.find((item) => item.bucket.hash === bucketHash)
+        )
+        .filter((item): item is DimItem => Boolean(item));
     },
-    [loadout]
+    [loadout, stores]
   );
 
   return useSelector(loadoutItemSelector, shallowEqual);

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -4,6 +4,7 @@ import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { armorBuckets } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
+import _ from 'lodash';
 import { useCallback } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -43,13 +44,13 @@ export function useEquippedLoadoutArmor(loadout: Loadout) {
         }
       }
 
-      return bucketOrder
-        .map(
+      return _.compact(
+        bucketOrder.map(
           (bucketHash) =>
             loadoutDimItems.find((item) => item.bucket.hash === bucketHash) ||
             currentItems?.find((item) => item.bucket.hash === bucketHash)
         )
-        .filter((item): item is DimItem => Boolean(item));
+      );
     },
     [loadout, stores]
   );


### PR DESCRIPTION
This will use the current armour for a character when showing mod placement if that bucket does not have an equipped item.

<img width="1289" alt="Screen Shot 2021-12-09 at 10 53 42 pm" src="https://user-images.githubusercontent.com/7344652/145392111-6b0e742e-c95c-4ba2-937b-8acca070ba18.png">

<img width="1210" alt="Screen Shot 2021-12-09 at 10 53 52 pm" src="https://user-images.githubusercontent.com/7344652/145392128-abe94931-ce5a-4449-af41-36ef0ccb7679.png">

Fixes #7415 