### PR TITLE
Add show mod placements button to loadouts page.

### DIFF
--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -188,8 +188,11 @@
 }
 
 .mods {
-  --item-icon-size: calc(0.8 * var(--item-size));
   flex: 1;
+}
+
+.modsGrid {
+  --item-icon-size: calc(0.8 * var(--item-size));
   min-width: calc(5 * var(--item-icon-size) + 4 * var(--item-margin));
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--item-icon-size));
@@ -201,8 +204,12 @@
   }
 }
 
+.showModPlacementButton {
+  margin-top: 8px;
+}
+
 .subclassMods {
-  composes: mods;
+  composes: modsGrid;
   min-width: calc(3 * var(--item-icon-size) + 2 * var(--item-margin));
 }
 

--- a/src/app/loadout/Loadouts.m.scss.d.ts
+++ b/src/app/loadout/Loadouts.m.scss.d.ts
@@ -26,10 +26,12 @@ interface CssExports {
   'menuButtons': string;
   'missingItems': string;
   'mods': string;
+  'modsGrid': string;
   'modsPlaceholder': string;
   'page': string;
   'placeholder': string;
   'power': string;
+  'showModPlacementButton': string;
   'subclass': string;
   'subclassContainer': string;
   'subclassMods': string;

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -56,10 +56,12 @@ import clsx from 'clsx';
 import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { useMemo, useState } from 'react';
+import ReactDOM from 'react-dom';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import PlugDef from './loadout-ui/PlugDef';
 import styles from './Loadouts.m.scss';
+import ModAssignmentDrawer from './mod-assignment-drawer/ModAssignmentDrawer';
 import { createGetModRenderKey } from './mod-utils';
 
 const categoryStyles = {
@@ -212,6 +214,7 @@ function LoadoutRow({
   const defs = useD2Definitions()!;
   const allItems = useSelector(allItemsSelector);
   const getModRenderKey = createGetModRenderKey();
+  const [showModAssignmentDrawer, setShowModAssignmentDrawer] = useState(false);
 
   // Turn loadout items into real DimItems, filtering out unequippable items
   const [items, subclass, warnitems] = useMemo(() => {
@@ -287,6 +290,14 @@ function LoadoutRow({
           <button type="button" className="dim-button" onClick={handleEdit}>
             {saved ? t('Loadouts.EditBrief') : t('Loadouts.SaveLoadout')}
           </button>
+          <button
+            className="dim-button"
+            type="button"
+            title="Assign Mods"
+            onClick={() => setShowModAssignmentDrawer(true)}
+          >
+            {t('Loadouts.ShowModPlacement')}
+          </button>
           {canShare && (
             <button type="button" className="dim-button" onClick={shareBuild}>
               {t('LoadoutBuilder.ShareBuild')}
@@ -329,6 +340,14 @@ function LoadoutRow({
           </>
         )}
       </div>
+      {showModAssignmentDrawer &&
+        ReactDOM.createPortal(
+          <ModAssignmentDrawer
+            loadout={loadout}
+            onClose={() => setShowModAssignmentDrawer(false)}
+          />,
+          document.body
+        )}
     </div>
   );
 }

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -290,14 +290,6 @@ function LoadoutRow({
           <button type="button" className="dim-button" onClick={handleEdit}>
             {saved ? t('Loadouts.EditBrief') : t('Loadouts.SaveLoadout')}
           </button>
-          <button
-            className="dim-button"
-            type="button"
-            title="Assign Mods"
-            onClick={() => setShowModAssignmentDrawer(true)}
-          >
-            {t('Loadouts.ShowModPlacement')}
-          </button>
           {canShare && (
             <button type="button" className="dim-button" onClick={shareBuild}>
               {t('LoadoutBuilder.ShareBuild')}
@@ -328,11 +320,21 @@ function LoadoutRow({
             ))}
             {savedMods.length > 0 ? (
               <div className={styles.mods}>
-                {savedMods.map((mod) => (
-                  <div key={getModRenderKey(mod)}>
-                    <PlugDef plug={mod} />
-                  </div>
-                ))}
+                <div className={styles.modsGrid}>
+                  {savedMods.map((mod) => (
+                    <div key={getModRenderKey(mod)}>
+                      <PlugDef plug={mod} />
+                    </div>
+                  ))}
+                </div>
+                <button
+                  className={clsx('dim-button', styles.showModPlacementButton)}
+                  type="button"
+                  title="Show mod placement"
+                  onClick={() => setShowModAssignmentDrawer(true)}
+                >
+                  {t('Loadouts.ShowModPlacement')}
+                </button>
               </div>
             ) : (
               <div className={styles.modsPlaceholder}>{t('Loadouts.Mods')}</div>

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -11,7 +11,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import React, { RefObject, useMemo, useState } from 'react';
+import React, { RefObject, useCallback, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import Mod from '../loadout-ui/Mod';
 import Sockets from '../loadout-ui/Sockets';
@@ -69,7 +69,7 @@ export default function ModAssignmentDrawer({
   minHeight?: number;
   /** A ref passed down to the sheets container. */
   sheetRef?: RefObject<HTMLDivElement>;
-  onUpdateMods(newMods: PluggableInventoryItemDefinition[]): void;
+  onUpdateMods?(newMods: PluggableInventoryItemDefinition[]): void;
   onClose(): void;
 }) {
   const [plugCategoryHashWhitelist, setPlugCategoryHashWhitelist] = useState<number[]>();
@@ -90,18 +90,18 @@ export default function ModAssignmentDrawer({
     return [compactModAssignments(itemModAssignments), unassignedMods, mods];
   }, [defs, armor, loadout.parameters?.mods]);
 
-  const onSocketClick = (
-    plugDef: PluggableInventoryItemDefinition,
-    plugCategoryHashWhitelist: number[]
-  ) => {
-    const { plugCategoryHash } = plugDef.plug;
+  const onSocketClick = useCallback(
+    (plugDef: PluggableInventoryItemDefinition, plugCategoryHashWhitelist: number[]) => {
+      const { plugCategoryHash } = plugDef.plug;
 
-    if (plugCategoryHash === PlugCategoryHashes.Intrinsics) {
-      // Do nothing, it's an exotic plug
-    } else {
-      setPlugCategoryHashWhitelist(plugCategoryHashWhitelist);
-    }
-  };
+      if (plugCategoryHash === PlugCategoryHashes.Intrinsics) {
+        // Do nothing, it's an exotic plug
+      } else {
+        setPlugCategoryHashWhitelist(plugCategoryHashWhitelist);
+      }
+    },
+    []
+  );
 
   const flatAssigned = _.compact(Object.values(itemModAssignments).flat());
 
@@ -128,20 +128,25 @@ export default function ModAssignmentDrawer({
                 <Sockets
                   item={item}
                   lockedMods={itemModAssignments[item.id]}
-                  onSocketClick={onSocketClick}
+                  onSocketClick={onUpdateMods ? onSocketClick : undefined}
                 />
               </div>
             ))}
           </div>
-          <h3>{t('Loadouts.UnassignedMods')}</h3>
-          <div className={styles.unassigned}>
-            {unassignedMods.map((mod) => (
-              <Mod key={getModRenderKey(mod)} plugDef={mod} />
-            ))}
-          </div>
+          {unassignedMods.length > 0 && (
+            <>
+              <h3>{t('Loadouts.UnassignedMods')}</h3>
+              <div className={styles.unassigned}>
+                {unassignedMods.map((mod) => (
+                  <Mod key={getModRenderKey(mod)} plugDef={mod} />
+                ))}
+              </div>
+            </>
+          )}
         </div>
       </Sheet>
-      {plugCategoryHashWhitelist &&
+      {onUpdateMods &&
+        plugCategoryHashWhitelist &&
         ReactDOM.createPortal(
           <ModPicker
             classType={loadout.classType}


### PR DESCRIPTION
This adds a limited version of the show mods placement drawer to the loadouts page. It won't let you edit the mod assignments but it will let you see them. I think we should wait for editing until the whole loadout can be edited.

<img width="1512" alt="Screen Shot 2021-12-09 at 11 09 00 pm" src="https://user-images.githubusercontent.com/7344652/145394095-336c3aaf-607a-4f48-9793-77c53d1070b9.png">

Closes #7414 