### PR TITLE
Revert "Include postmaster items in search transfers"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Fix issue where Optimizer throws an error when selecting a raid or combat mod.
 * Fix a bug that prevented applying shaders or ornaments from the item popup.
 * Fix an error that can occur when loading a shared build link.
-* Items in the postmaster are now included in search transfers.
 * Added 'source:30th' for items coming from the Bungie 30th Anniversary.
 * Fix emblems and subclasses not applying from loadouts.
 

--- a/src/app/loadout-drawer/auto-loadouts.ts
+++ b/src/app/loadout-drawer/auto-loadouts.ts
@@ -186,7 +186,8 @@ export function gatherEngramsLoadout(
  * Move a list of items to a store
  */
 export function itemMoveLoadout(items: DimItem[], store: DimStore): Loadout {
-  items = items.filter((i) => !i.notransfer);
+  // Don't move things from the postmaster or that can't move
+  items = items.filter((i) => !i.location.inPostmaster && !i.notransfer);
   items = addUpStackables(items);
 
   const itemsByType = _.mapValues(


### PR DESCRIPTION
This reverts commit d71d3ef1ad56afc35f52b1a782e0d598b55fb9e9. #7400 said this "no longer happens" but it never happened, and people are sensitive about the postmaster.