### PR TITLE
dynamic replacer hook

### DIFF
--- a/src/app/dim-ui/RichDestinyText.tsx
+++ b/src/app/dim-ui/RichDestinyText.tsx
@@ -26,15 +26,9 @@ export default function RichDestinyText({
   text?: string;
   ownerId?: string;
 }): React.ReactElement {
-  const dynamicStrings = useSelector(dynamicStringsSelector);
-
+  const replacer = useDynamicStringReplacer(ownerId);
   // perform dynamic string replacement
-  text = (text ?? '').replace(dynamicTextFinder, (segment) => {
-    const hash = segment.match(/\d+/)![0];
-    const dynamicValue =
-      dynamicStrings?.byCharacter[ownerId]?.[hash] ?? dynamicStrings?.allProfile[hash];
-    return dynamicValue?.toString() ?? segment;
-  });
+  text = replacer(text);
 
   // split into segments, filter out empty, try replacing each piece with an icon if one matches
   const richTextSegments = text
@@ -55,4 +49,17 @@ function replaceWithIcon(textSegment: string, index: number) {
       {replacementInfo?.unicode ?? textSegment}
     </span>
   );
+}
+
+export function useDynamicStringReplacer(ownerId = '') {
+  const dynamicStrings = useSelector(dynamicStringsSelector);
+
+  return function (text = '') {
+    return text.replace(dynamicTextFinder, (segment) => {
+      const hash = segment.match(/\d+/)![0];
+      const dynamicValue =
+        dynamicStrings?.byCharacter[ownerId]?.[hash] ?? dynamicStrings?.allProfile[hash];
+      return dynamicValue?.toString() ?? segment;
+    });
+  };
 }

--- a/src/app/progress/CrucibleRank.tsx
+++ b/src/app/progress/CrucibleRank.tsx
@@ -1,3 +1,4 @@
+import { useDynamicStringReplacer } from 'app/dim-ui/RichDestinyText';
 import { t } from 'app/i18next-t';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DestinyProgression } from 'bungie-api-ts/destiny2';
@@ -18,6 +19,7 @@ interface CrucibleRankProps {
  */
 export function CrucibleRank({ progress, streak }: CrucibleRankProps) {
   const defs = useD2Definitions()!;
+  const replacer = useDynamicStringReplacer();
   const progressionDef = defs.Progression.get(progress.progressionHash);
 
   const step = progressionDef.steps[Math.min(progress.level, progressionDef.steps.length - 1)];
@@ -32,7 +34,7 @@ export function CrucibleRank({ progress, streak }: CrucibleRankProps) {
   return (
     <div
       className={clsx(factionClass, styles.activityRank)}
-      title={progressionDef.displayProperties.description}
+      title={replacer(progressionDef.displayProperties.description)}
     >
       <div>
         <CrucibleRankIcon progress={progress} />


### PR DESCRIPTION
~~Xur's~~ Bob Barker's faction progression description needed dynamic api text
~~looks like something's also up with bountydescs, but that's weird in beta too, i'l address it next.~~ i was getting a weird thing because of secondary launch profile load

before:
![image](https://user-images.githubusercontent.com/68782081/145644860-559ee285-566c-468f-9562-adf94447b51e.png)

after:
![image](https://user-images.githubusercontent.com/68782081/145644811-f661146e-57c5-467f-a830-0236718e3286.png)

fixes #7444 