### PR TITLE
show loadout notes in hover text if notes exist.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix emblems and subclasses not applying from loadouts.
 * Fix an issue where energy swaps in the Optimizer where not displaying the correct resulting energy.
 * Removed the "Max Power" loadout from the loadouts page. You can still apply it from the loadout menu on the inventory screen.
+* If loadouts have notes, those notes are now displayed in the hover text on the loadout dropdown
 
 ## 6.94.0 <span class="changelog-date">(2021-12-05)</span>
 

--- a/src/app/loadout-drawer/LoadoutPopup.tsx
+++ b/src/app/loadout-drawer/LoadoutPopup.tsx
@@ -364,7 +364,10 @@ function LoadoutPopup({
 
         {loadouts.map((loadout) => (
           <li key={loadout.id} className={styles.menuItem}>
-            <span title={loadout.name} onClick={() => applySavedLoadout(loadout)}>
+            <span
+              title={loadout.notes ? loadout.notes : loadout.name}
+              onClick={() => applySavedLoadout(loadout)}
+            >
               {isMissingItems(allItems, loadout) && (
                 <AppIcon
                   className={styles.warningIcon}


### PR DESCRIPTION
implements #7435 
![image](https://user-images.githubusercontent.com/29002828/145650696-325ce918-ca5e-478a-9507-34c0aab01119.png)

