### PR TITLE
Add mods with +Equipped, and save subclass stuff with "Create From Equipped"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 * If loadouts have notes, those notes are now displayed in the hover text on the loadout dropdown
 * Hitting +Equipped in the loadout editor will add current mods.
 * Creating a new loadout from equipped items will also save your subclass configuration.
+* Creating a new loadout from equipped or hitting +Equipped in the loadout editor will now also include your current emblem, ship, and sparrow.
 
 ## 6.94.0 <span class="changelog-date">(2021-12-05)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Fix an issue where energy swaps in the Optimizer where not displaying the correct resulting energy.
 * Removed the "Max Power" loadout from the loadouts page. You can still apply it from the loadout menu on the inventory screen.
 * If loadouts have notes, those notes are now displayed in the hover text on the loadout dropdown
+* Hitting +Equipped in the loadout editor will add current mods.
+* Creating a new loadout from equipped items will also save your subclass configuration.
 
 ## 6.94.0 <span class="changelog-date">(2021-12-05)</span>
 

--- a/src/app/inventory/store/override-sockets.ts
+++ b/src/app/inventory/store/override-sockets.ts
@@ -162,3 +162,21 @@ export function useSocketOverridesForItems(
 
   return [socketOverrides, onPlugClicked, resetSocketOverrides];
 }
+
+/**
+ * Create a socket overrides structure from the item's currently plugged sockets.
+ */
+export function createSocketOverridesFromEquipped(item: DimItem) {
+  const socketOverrides: SocketOverrides = {};
+  for (const socket of item.sockets?.allSockets || []) {
+    // If the socket is plugged and we plug isn't the initial plug we apply the overrides
+    // to the loadout.
+    if (
+      socket.plugged &&
+      socket.plugged.plugDef.hash !== socket.socketDefinition.singleInitialItemHash
+    ) {
+      socketOverrides[socket.socketIndex] = socket.plugged.plugDef.hash;
+    }
+  }
+  return socketOverrides;
+}

--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -198,34 +198,16 @@ export default function LoadoutDrawer() {
   const savedMods = getModsFromLoadout(defs, loadout);
 
   /** Updates the loadout replacing it's current mods with all the mods in newMods. */
-  const onUpdateMods = (newMods: PluggableInventoryItemDefinition[]) => {
-    const newLoadout = { ...loadout };
-
-    newLoadout.parameters = {
-      ...newLoadout.parameters,
-      mods: newMods.map((mod) => mod.hash),
-    };
-    stateDispatch({ type: 'update', loadout: newLoadout });
-  };
+  const onUpdateModHashes = (mods: number[]) => stateDispatch({ type: 'updateMods', mods });
+  const onUpdateMods = (newMods: PluggableInventoryItemDefinition[]) =>
+    onUpdateModHashes(newMods.map((mod) => mod.hash));
 
   /** Removes a single mod from the loadout with the supplied itemHash. */
-  const removeModByHash = (itemHash: number) => {
-    const newLoadout = { ...loadout };
-    const newMods = newLoadout.parameters?.mods?.length ? [...newLoadout.parameters.mods] : [];
-    const index = newMods.indexOf(itemHash);
-    if (index !== -1) {
-      newMods.splice(index, 1);
-      newLoadout.parameters = {
-        ...newLoadout.parameters,
-        mods: newMods,
-      };
-      stateDispatch({ type: 'update', loadout: newLoadout });
-    }
-  };
+  const removeModByHash = (itemHash: number) =>
+    stateDispatch({ type: 'removeMod', hash: itemHash });
 
-  const handleNotesChanged: React.ChangeEventHandler<HTMLTextAreaElement> = (e) => {
+  const handleNotesChanged: React.ChangeEventHandler<HTMLTextAreaElement> = (e) =>
     stateDispatch({ type: 'update', loadout: { ...loadout, notes: e.target.value } });
-  };
 
   const header = (
     <div className="loadout-drawer-header">
@@ -285,6 +267,7 @@ export default function LoadoutDrawer() {
                 equip={onEquipItem}
                 remove={onRemoveItem}
                 add={onAddItem}
+                onUpdateMods={onUpdateModHashes}
                 onOpenModPicker={(query?: string) =>
                   stateDispatch({ type: 'openModPicker', query })
                 }

--- a/src/app/loadout-drawer/LoadoutDrawerBucket.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerBucket.tsx
@@ -1,4 +1,5 @@
 import { itemSortOrderSelector } from 'app/settings/item-sort';
+import { BucketHashes } from 'data/d2/generated-enums';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { InventoryBucket } from '../inventory/inventory-buckets';
@@ -42,6 +43,8 @@ export default function LoadoutDrawerBucket({
     ),
     itemSortOrder
   );
+  // Only allow one emblem
+  const capacity = bucket.hash === BucketHashes.Emblems ? 1 : bucket.capacity;
 
   return (
     <div className="loadout-bucket">
@@ -68,7 +71,7 @@ export default function LoadoutDrawerBucket({
                 {unequippedItems.map((item) => (
                   <LoadoutDrawerItem key={item.index} item={item} equip={equip} remove={remove} />
                 ))}
-                {equippedItems.length > 0 && unequippedItems.length < bucket.capacity - 1 && (
+                {equippedItems.length > 0 && unequippedItems.length < capacity - 1 && (
                   <AddButton onClick={() => pickLoadoutItem(bucket)} />
                 )}
               </div>

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -49,8 +49,7 @@ const loadoutTypes: DimBucketType[] = [
   'Horn',
 ];
 
-// We don't want to prepopulate the loadout with a bunch of cosmetic junk
-// like emblems and ships and horns.
+// We don't want to prepopulate the loadout with D1 cosmetics
 export const fromEquippedTypes: DimBucketType[] = [
   'Class',
   'KineticSlot',
@@ -66,6 +65,9 @@ export const fromEquippedTypes: DimBucketType[] = [
   'ClassItem',
   'Artifact',
   'Ghost',
+  'Ships',
+  'Vehicle',
+  'Emblems',
 ];
 
 export default function LoadoutDrawerContents(

--- a/src/app/loadout-drawer/LoadoutPopup.tsx
+++ b/src/app/loadout-drawer/LoadoutPopup.tsx
@@ -15,7 +15,6 @@ import MaxlightButton from 'app/loadout-drawer/MaxlightButton';
 import { ItemFilter } from 'app/search/filter-types';
 import { LoadoutSort } from 'app/settings/initial-settings';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
@@ -49,13 +48,7 @@ import {
 } from './auto-loadouts';
 import { applyLoadout } from './loadout-apply';
 import { Loadout } from './loadout-types';
-import {
-  convertToLoadoutItem,
-  extractArmorModHashes,
-  isMissingItems,
-  newLoadout,
-} from './loadout-utils';
-import { fromEquippedTypes } from './LoadoutDrawerContents';
+import { isMissingItems, newLoadout, newLoadoutFromEquipped } from './loadout-utils';
 import styles from './LoadoutPopup.m.scss';
 import {
   makeRoomForPostmaster,
@@ -75,7 +68,6 @@ interface StoreProps {
   previousLoadout?: Loadout;
   loadouts: Loadout[];
   query: string;
-  classTypeId: DestinyClass;
   stores: DimStore[];
   hasClassified: boolean;
   buckets: InventoryBuckets;
@@ -106,22 +98,17 @@ function mapStateToProps() {
       )
   );
 
-  return (state: RootState, ownProps: ProvidedProps): StoreProps => {
-    const { dimStore } = ownProps;
-
-    return {
-      previousLoadout: previousLoadoutSelector(state, ownProps.dimStore.id),
-      loadouts: loadoutsForPlatform(state, ownProps),
-      query: querySelector(state),
-      searchFilter: searchFilterSelector(state),
-      classTypeId: dimStore.classType,
-      stores: storesSelector(state),
-      buckets: bucketsSelector(state)!,
-      hasClassified: hasClassifiedSelector(state),
-      allItems: allItemsSelector(state),
-      filteredItems: filteredItemsSelector(state),
-    };
-  };
+  return (state: RootState, ownProps: ProvidedProps): StoreProps => ({
+    previousLoadout: previousLoadoutSelector(state, ownProps.dimStore.id),
+    loadouts: loadoutsForPlatform(state, ownProps),
+    query: querySelector(state),
+    searchFilter: searchFilterSelector(state),
+    stores: storesSelector(state),
+    buckets: bucketsSelector(state)!,
+    hasClassified: hasClassifiedSelector(state),
+    allItems: allItemsSelector(state),
+    filteredItems: filteredItemsSelector(state),
+  });
 }
 
 function LoadoutPopup({
@@ -133,7 +120,6 @@ function LoadoutPopup({
   query,
   onClick,
   hasClassified,
-  classTypeId,
   searchFilter,
   buckets,
   allItems,
@@ -148,20 +134,10 @@ function LoadoutPopup({
 
   const makeNewLoadout = () => editLoadout(newLoadout('', []), { isNew: true });
 
-  const newLoadoutFromEquipped = () => {
-    const items = dimStore.items.filter(
-      (item) => item.equipped && itemCanBeInLoadout(item) && fromEquippedTypes.includes(item.type)
-    );
-    const loadout = newLoadout(
-      '',
-      items.map((i) => convertToLoadoutItem(i, true)),
-      items.flatMap((i) => extractArmorModHashes(i))
-    );
-    loadout.classType = classTypeId;
+  const handleNewLoadoutFromEquipped = () => {
+    const loadout = newLoadoutFromEquipped('', dimStore);
     editLoadout(loadout, { isNew: true });
   };
-
-  // TODO: move all these fancy loadouts to a new service
 
   const applySavedLoadout = (loadout: Loadout, { filterToEquipped = false } = {}) => {
     if (filterToEquipped) {
@@ -241,7 +217,7 @@ function LoadoutPopup({
             <span>{t('Loadouts.Create')}</span>
           </span>
           {!dimStore.isVault && (
-            <span onClick={newLoadoutFromEquipped}>{t('Loadouts.FromEquipped')}</span>
+            <span onClick={handleNewLoadoutFromEquipped}>{t('Loadouts.FromEquipped')}</span>
           )}
         </li>
 

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -41,7 +41,7 @@ import { getSocketByIndex } from 'app/utils/socket-utils';
 import _ from 'lodash';
 import { savePreviousLoadout } from './actions';
 import { Assignment, Loadout, LoadoutItem } from './loadout-types';
-import { loadoutFromAllItems } from './loadout-utils';
+import { backupLoadout } from './loadout-utils';
 
 const outOfSpaceWarning = _.throttle((store) => {
   showNotification({
@@ -164,7 +164,7 @@ function doApplyLoadout(
         savePreviousLoadout({
           storeId: store.id,
           loadoutId: loadout.id,
-          previousLoadout: loadoutFromAllItems(store, t('Loadouts.Before', { name: loadout.name })),
+          previousLoadout: backupLoadout(store, t('Loadouts.Before', { name: loadout.name })),
         })
       );
     }

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -205,7 +205,6 @@ function addItem(
           loadoutItem.equipped = true;
         }
 
-        console.log('add', loadoutItem);
         draftLoadout.items.push(loadoutItem);
       } else {
         showNotification({

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -38,6 +38,8 @@ export type Action =
   | { type: 'removeItem'; item: DimItem; shift: boolean; items: DimItem[] }
   /** Make an item that's already in the loadout equipped */
   | { type: 'equipItem'; item: DimItem; items: DimItem[] }
+  | { type: 'updateMods'; mods: number[] }
+  | { type: 'removeMod'; hash: number }
   | { type: 'openModPicker'; query?: string }
   | { type: 'closeModPicker' };
 
@@ -109,6 +111,42 @@ export function stateReducer(state: State, action: Action): State {
         : state;
     }
 
+    case 'updateMods': {
+      const { loadout } = state;
+      const { mods } = action;
+      return loadout
+        ? {
+            ...state,
+            loadout: {
+              ...loadout,
+              parameters: {
+                ...loadout.parameters,
+                mods,
+              },
+            },
+          }
+        : state;
+    }
+
+    case 'removeMod': {
+      const { loadout } = state;
+      const { hash } = action;
+      if (loadout) {
+        const newLoadout = { ...loadout };
+        const newMods = newLoadout.parameters?.mods?.length ? [...newLoadout.parameters.mods] : [];
+        const index = newMods.indexOf(hash);
+        if (index !== -1) {
+          newMods.splice(index, 1);
+          newLoadout.parameters = {
+            ...newLoadout.parameters,
+            mods: newMods,
+          };
+          return { ...state, loadout: newLoadout };
+        }
+      }
+      return state;
+    }
+
     case 'openModPicker': {
       const { query } = action;
       return { ...state, modPicker: { show: true, query } };
@@ -167,6 +205,7 @@ function addItem(
           loadoutItem.equipped = true;
         }
 
+        console.log('add', loadoutItem);
         draftLoadout.items.push(loadoutItem);
       } else {
         showNotification({

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -3,19 +3,21 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
 import { DimCharacterStat, DimStore } from 'app/inventory/store-types';
+import { createSocketOverridesFromEquipped } from 'app/inventory/store/override-sockets';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
 import { isInsertableArmor2Mod, sortMods } from 'app/loadout/mod-utils';
 import { armorStats } from 'app/search/d2-known-values';
 import { emptyArray } from 'app/utils/empty';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
-import { isUsedArmorModSocket } from 'app/utils/socket-utils';
 import { DestinyClass, DestinyStatDefinition } from 'bungie-api-ts/destiny2';
+import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { D2Categories } from '../destiny2/d2-bucket-categories';
 import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import { DimLoadoutItem, Loadout, LoadoutItem } from './loadout-types';
+import { fromEquippedTypes } from './LoadoutDrawerContents';
 
 const excludeGearSlots = ['Class', 'SeasonalArtifacts'];
 // order to display a list of all 8 gear slots
@@ -27,19 +29,41 @@ const gearSlotOrder: DimItem['type'][] = [
 /**
  * Creates a new loadout, with all of the items equipped and the items inserted mods saved.
  */
-export function newLoadout(name: string, items: LoadoutItem[], modsHashes?: number[]): Loadout {
+export function newLoadout(name: string, items: LoadoutItem[]): Loadout {
   return {
     id: uuidv4(),
     classType: DestinyClass.Unknown,
     name,
     items,
-    parameters: modsHashes?.length
-      ? {
-          mods: modsHashes,
-        }
-      : undefined,
     clearSpace: false,
   };
+}
+
+/**
+ * Create a new loadout that includes all the equipped items and mods on the character.
+ */
+export function newLoadoutFromEquipped(name: string, dimStore: DimStore) {
+  const items = dimStore.items.filter(
+    (item) => item.equipped && itemCanBeInLoadout(item) && fromEquippedTypes.includes(item.type)
+  );
+  const loadout = newLoadout(
+    name,
+    items.map((i) => {
+      const item = convertToLoadoutItem(i, true);
+      if (i.bucket.hash === BucketHashes.Subclass) {
+        item.socketOverrides = createSocketOverridesFromEquipped(i);
+      }
+      return item;
+    })
+  );
+  const mods = items.flatMap((i) => extractArmorModHashes(i));
+  if (mods.length) {
+    loadout.parameters = {
+      mods,
+    };
+  }
+  loadout.classType = dimStore.classType;
+  return loadout;
 }
 
 /*
@@ -168,25 +192,27 @@ export function optimalLoadout(
     equippable.map((i) => convertToLoadoutItem(i, true))
   );
 }
-/** Create a loadout from all of this character's items that can be in loadouts */
-export function loadoutFromAllItems(store: DimStore, name: string): Loadout {
+/**
+ * Create a loadout from all of this character's items that can be in loadouts,
+ * as a backup.
+ */
+export function backupLoadout(store: DimStore, name: string): Loadout {
   const allItems = store.items.filter(
     (item) => itemCanBeInLoadout(item) && !item.location.inPostmaster
   );
   const loadout = newLoadout(
     name,
-    allItems.map((i) => convertToLoadoutItem(i, i.equipped))
+    allItems.map((i) => {
+      const item = convertToLoadoutItem(i, i.equipped);
+      if (i.bucket.hash === BucketHashes.Subclass) {
+        item.socketOverrides = createSocketOverridesFromEquipped(i);
+      }
+      return item;
+    })
   );
   // Save mods too, so we put them back if you undo
   loadout.parameters = {
-    mods: allItems
-      .filter((i) => i.equipped)
-      .flatMap((i) =>
-        _.compact(
-          i.sockets?.allSockets.filter(isUsedArmorModSocket).map((s) => s.plugged?.plugDef.hash) ??
-            []
-        )
-      ),
+    mods: allItems.filter((i) => i.equipped).flatMap(extractArmorModHashes),
   };
   return loadout;
 }
@@ -278,6 +304,7 @@ export function getItemsFromLoadoutItems(
 
 /**
  * Returns a Loadout object containing currently equipped items
+ * @deprecated
  */
 export function loadoutFromEquipped(store: DimStore): Loadout {
   const items = store.items.filter((item) => item.equipped && itemCanBeInLoadout(item));

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -22,15 +22,13 @@ import { applyLoadout } from 'app/loadout-drawer/loadout-apply';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
 import {
-  convertToLoadoutItem,
-  extractArmorModHashes,
   getArmorStats,
   getItemsFromLoadoutItems,
   getLight,
   getModsFromLoadout,
   newLoadout,
+  newLoadoutFromEquipped,
 } from 'app/loadout-drawer/loadout-utils';
-import { fromEquippedTypes } from 'app/loadout-drawer/LoadoutDrawerContents';
 import { loadoutsSelector } from 'app/loadout-drawer/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
@@ -47,7 +45,7 @@ import {
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { getSocketsByIndexes } from 'app/utils/socket-utils';
 import { copyString } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -106,18 +104,10 @@ function Loadouts() {
     [allLoadouts, classType, loadoutSort]
   );
 
-  const currentLoadout = useMemo(() => {
-    const items = selectedStore.items.filter(
-      (item) => item.equipped && itemCanBeInLoadout(item) && fromEquippedTypes.includes(item.type)
-    );
-    const loadout = newLoadout(
-      t('Loadouts.FromEquipped'),
-      items.map((i) => convertToLoadoutItem(i, true)),
-      items.flatMap((i) => extractArmorModHashes(i))
-    );
-    loadout.classType = selectedStore.classType;
-    return loadout;
-  }, [selectedStore]);
+  const currentLoadout = useMemo(
+    () => newLoadoutFromEquipped(t('Loadouts.FromEquipped'), selectedStore),
+    [selectedStore]
+  );
 
   const loadouts = _.compact([currentLoadout, ...savedLoadouts]);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/313208/145661507-8599ef9a-433a-4adc-a224-187599fe241b.png)

This normalizes the behavior (mostly) between "Create from Equipped" and the "+Equipped" button - both now include mods and subclass configs.

I also tweaked the list of buckets to include emblem, ship, and sparrow - folks can remove them if they don't like them.

Fixes #7438