### PR TITLE
more visual distinction for loadouts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Creating a new loadout from equipped items will also save your subclass configuration.
 * Creating a new loadout from equipped or hitting +Equipped in the loadout editor will now also include your current emblem, ship, and sparrow.
 * Vendor items no longer offer to apply perks.
+* Added more visual distinction between loadouts on the loadouts page.
 
 ## 6.94.0 <span class="changelog-date">(2021-12-05)</span>
 

--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -10,7 +10,9 @@
 
 .loadout {
   composes: flexColumn from '../dim-ui/common.m.scss';
-  margin-bottom: 48px;
+  margin-bottom: 10px;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.25);
 }
 
 .title {


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/29002828/145686777-3c143c44-df3c-4223-a514-50f516bfac39.png)


after
![image](https://user-images.githubusercontent.com/29002828/145686744-93473bc9-1d5e-4034-9d63-b32477bc7201.png)
