### PR TITLE
Mod picker grouping fix

### DIFF
--- a/src/app/loadout-drawer/SavedMods.tsx
+++ b/src/app/loadout-drawer/SavedMods.tsx
@@ -1,7 +1,6 @@
 import { t } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { sortModGroups } from 'app/loadout/mod-utils';
-import _ from 'lodash';
+import { groupModsByModType, sortModGroups } from 'app/loadout/mod-utils';
 import React, { useMemo } from 'react';
 import SavedModCategory from './SavedModCategory';
 import styles from './SavedMods.m.scss';
@@ -21,7 +20,7 @@ interface Props {
 function SavedMods({ savedMods, onOpenModPicker, removeModByHash }: Props) {
   // Turn savedMods into an array of mod groups where each group is
   const groupedMods = useMemo(() => {
-    const indexedMods = _.groupBy(savedMods, (mod) => mod.plug.plugCategoryHash);
+    const indexedMods = groupModsByModType(savedMods);
     return Object.values(indexedMods).sort(sortModGroups);
   }, [savedMods]);
 

--- a/src/app/loadout-drawer/subclass-drawer/SubclassPlugDrawer.tsx
+++ b/src/app/loadout-drawer/subclass-drawer/SubclassPlugDrawer.tsx
@@ -5,7 +5,8 @@ import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/invent
 import { profileResponseSelector } from 'app/inventory/selectors';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import PlugDrawer, { PlugsWithMaxSelectable } from 'app/loadout/plug-drawer/PlugDrawer';
+import PlugDrawer from 'app/loadout/plug-drawer/PlugDrawer';
+import { PlugsWithMaxSelectable } from 'app/loadout/plug-drawer/PlugSection';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { itemsForPlugSetEverywhere } from 'app/records/plugset-helpers';
 import { compareBy } from 'app/utils/comparators';

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -9,6 +9,7 @@ import {
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { itemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import {
+  armor2PlugCategoryHashes,
   armor2PlugCategoryHashesByName,
   MAX_ARMOR_ENERGY_CAPACITY,
 } from 'app/search/d2-known-values';
@@ -24,7 +25,8 @@ import { createSelector } from 'reselect';
 import { isLoadoutBuilderItem } from './item-utils';
 import { knownModPlugCategoryHashes, slotSpecificPlugCategoryHashes } from './known-values';
 import { isInsertableArmor2Mod, sortModGroups, sortMods } from './mod-utils';
-import PlugDrawer, { PlugsWithMaxSelectable } from './plug-drawer/PlugDrawer';
+import PlugDrawer from './plug-drawer/PlugDrawer';
+import { PlugsWithMaxSelectable } from './plug-drawer/PlugSection';
 
 /** Raid, combat and legacy mods can have up to 5 selected. */
 const MAX_SLOT_INDEPENDENT_MODS = 5;
@@ -83,6 +85,8 @@ function mapStateToProps() {
       plugCategoryHashWhitelist,
       currentStore
     ): PlugsWithMaxSelectable[] => {
+      const artificeString = defs?.InventoryItem.get(3727270518).displayProperties.name;
+
       const plugsWithMaxSelectableSets: { [plugSetHash: number]: PlugsWithMaxSelectable } = {};
       if (!profileResponse || !defs) {
         return [];
@@ -92,10 +96,11 @@ function mapStateToProps() {
         if (
           !item ||
           !item.sockets ||
-          // Makes sure its an armour 2.0 item
+          // Makes sure it's an armour 2.0 item
           !isLoadoutBuilderItem(item) ||
-          // If classType is passed in only use items from said class otherwise use
-          // items from all characters. Usefull if in loadouts and only mods and guns.
+          // If classType is passed in, only use items from said class,
+          // otherwise use items from all characters.
+          // Useful if in loadouts and only mods and guns
           !(classType === DestinyClass.Unknown || item.classType === classType)
         ) {
           continue;
@@ -108,7 +113,7 @@ function mapStateToProps() {
           SocketCategoryHashes.ArmorMods
         ).filter((socket) => socket.socketDefinition.reusablePlugSetHash && socket.plugged);
 
-        // Group the sockets by their reusablePlugSetHash, this lets us get a count of availabe mods for
+        // Group the sockets by their reusablePlugSetHash, this lets us get a count of available mods for
         // each socket in the case of bucket specific mods/sockets
         const socketsGroupedByPlugSetHash = _.groupBy(
           modSockets,
@@ -154,6 +159,12 @@ function mapStateToProps() {
               maxSelectable,
               plugs,
             };
+            if (
+              maxSelectable === 1 &&
+              armor2PlugCategoryHashes.includes(plugs[0].plug.plugCategoryHash)
+            ) {
+              plugsWithMaxSelectableSets[plugSetHash].headerSuffix = artificeString;
+            }
           } else if (
             plugs.length &&
             plugsWithMaxSelectableSets[plugSetHash].maxSelectable < sockets.length
@@ -211,7 +222,7 @@ function ModPicker({
         : 0;
 
       if (isSlotSpecificCategory) {
-        // Traction has no energy type so its basically Any energy and 0 cost
+        // Traction has no energy type so it's basically Any energy and 0 cost
         const modCost = mod.plug.energyCost?.energyCost || 0;
         const modEnergyType = mod.plug.energyCost?.energyType || DestinyEnergyType.Any;
 

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -8,6 +8,7 @@ import { isArmor2Mod } from 'app/utils/item-utils';
 import { DestinyEnergyType, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import raidModPlugCategoryHashes from 'data/d2/raid-mod-plug-category-hashes.json';
+import _ from 'lodash';
 import { canSwapEnergyFromUpgradeSpendTier } from './armor-upgrade-utils';
 import { knownModPlugCategoryHashes } from './known-values';
 
@@ -146,4 +147,22 @@ export function getDefaultPlugHash(socket: DimSocket, defs?: D2ManifestDefinitio
       ? defs?.PlugSet.get(reusablePlugSetHash).reusablePlugItems[0].plugItemHash
       : undefined;
   }
+}
+
+/**
+ * group a whole variety of mod definitions into related mod-type groups
+ */
+export function groupModsByModType(plugs: PluggableInventoryItemDefinition[]) {
+  // allow a plug category hash to be "locked" to
+  // the first itemTypeDisplayName that shows up using it.
+  // this prevents "Class Item Mod" and "Class Item Armor Mod"
+  // from forming two different categories
+  const nameByPCH: NodeJS.Dict<string> = {};
+
+  return _.groupBy(
+    plugs,
+    (plugDef) =>
+      (nameByPCH[plugDef.plug.plugCategoryHash] ??=
+        plugDef.itemTypeDisplayName || plugDef.itemTypeAndTierDisplayName)
+  );
 }

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -12,22 +12,11 @@ import React, { RefObject, useCallback, useEffect, useMemo, useRef, useState } f
 import Sheet from '../../dim-ui/Sheet';
 import '../../item-picker/ItemPicker.scss';
 import Footer from './Footer';
-import PlugSection from './PlugSection';
-
-export interface PlugsWithMaxSelectable {
-  plugSetHash: number;
-  plugs: PluggableInventoryItemDefinition[];
-  maxSelectable: number;
-}
+import PlugSection, { PlugsWithMaxSelectable } from './PlugSection';
 
 interface Props {
-  /**
-   * A list of plug items that come from a PlugSet, along with the maximum number of these plugs that can be chosen.
-   */
   plugsWithMaxSelectableSets: PlugsWithMaxSelectable[];
-  /**
-   * An array of mods that are already locked.
-   */
+  /** An array of mods that are already locked. */
   initiallySelected: PluggableInventoryItemDefinition[];
   /** A list of stat hashes that if present will be displayed for each plug. */
   displayedStatHashes?: number[];
@@ -177,10 +166,11 @@ export default function PlugDrawer({
         );
       });
 
-    for (const { plugs, maxSelectable, plugSetHash } of plugsWithMaxSelectableSets) {
+    for (const { plugs, maxSelectable, plugSetHash, headerSuffix } of plugsWithMaxSelectableSets) {
       rtn.push({
         plugSetHash,
         maxSelectable,
+        headerSuffix,
         plugs: query.length ? plugs.filter(searchFilter) : plugs,
       });
     }

--- a/src/app/loadout/plug-drawer/PlugSection.tsx
+++ b/src/app/loadout/plug-drawer/PlugSection.tsx
@@ -1,14 +1,20 @@
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { Comparator } from 'app/utils/comparators';
-import _ from 'lodash';
 import React, { useCallback } from 'react';
+import { groupModsByModType } from '../mod-utils';
 import styles from './PlugSection.m.scss';
 import SelectablePlug from './SelectablePlug';
 
+/**
+ * a list of plugs, plus some metadata about:
+ * - the maximum we should let the user choose at once
+ * - the plugset whence these plugs originate
+ */
 export interface PlugsWithMaxSelectable {
-  plugSetHash: number;
   plugs: PluggableInventoryItemDefinition[];
+  plugSetHash: number;
   maxSelectable: number;
+  headerSuffix?: string;
 }
 
 export default function PlugSection({
@@ -29,7 +35,7 @@ export default function PlugSection({
   handlePlugRemoved(plugSetHash: number, mod: PluggableInventoryItemDefinition): void;
   sortPlugs?: Comparator<PluggableInventoryItemDefinition>;
 }) {
-  const { plugs, maxSelectable, plugSetHash } = plugsWithMaxSelectable;
+  const { plugs, maxSelectable, plugSetHash, headerSuffix } = plugsWithMaxSelectable;
 
   const handlePlugSelectedInternal = useCallback(
     (plug: PluggableInventoryItemDefinition) => handlePlugSelected(plugSetHash, plug),
@@ -49,28 +55,19 @@ export default function PlugSection({
     plugs.sort(sortPlugs);
   }
 
-  // allow a plug category hash to be "locked" to
-  // the first itemTypeDisplayName that shows up using it.
-  // this prevents "Class Item Mod" and "Class Item Armor Mod"
-  // from forming two different categories
-  const nameByPCH: NodeJS.Dict<string> = {};
-
   // Here we split the section into further pieces so that each plug category has has its own title
   // This is important for combat mods, which would otherwise be grouped into one massive category
-  const plugsGroupedByPlugCategoryHash = _.groupBy(
-    plugs,
-    (plugDef) =>
-      (nameByPCH[plugDef.plug.plugCategoryHash] ??=
-        plugDef.itemTypeDisplayName || plugDef.itemTypeAndTierDisplayName)
-  );
+  const plugsGroupedByModType = groupModsByModType(plugs);
 
+  let header = plugs[0].itemTypeDisplayName || plugs[0].itemTypeAndTierDisplayName;
+  if (headerSuffix) {
+    header += ` (${headerSuffix})`;
+  }
   return (
     <>
-      {Object.entries(plugsGroupedByPlugCategoryHash).map(([pch, plugs]) => (
+      {Object.entries(plugsGroupedByModType).map(([pch, plugs]) => (
         <div key={pch} className={styles.bucket}>
-          <div className={styles.header}>
-            {plugs[0].itemTypeDisplayName || plugs[0].itemTypeAndTierDisplayName}
-          </div>
+          <div className={styles.header}>{header}</div>
           <div className={styles.items}>
             {plugs.map((plug) => (
               <SelectablePlug

--- a/src/app/loadout/plug-drawer/PlugSection.tsx
+++ b/src/app/loadout/plug-drawer/PlugSection.tsx
@@ -49,11 +49,19 @@ export default function PlugSection({
     plugs.sort(sortPlugs);
   }
 
+  // allow a plug category hash to be "locked" to
+  // the first itemTypeDisplayName that shows up using it.
+  // this prevents "Class Item Mod" and "Class Item Armor Mod"
+  // from forming two different categories
+  const nameByPCH: NodeJS.Dict<string> = {};
+
   // Here we split the section into further pieces so that each plug category has has its own title
   // This is important for combat mods, which would otherwise be grouped into one massive category
   const plugsGroupedByPlugCategoryHash = _.groupBy(
     plugs,
-    (plugDef) => plugDef.plug.plugCategoryHash
+    (plugDef) =>
+      (nameByPCH[plugDef.plug.plugCategoryHash] ??=
+        plugDef.itemTypeDisplayName || plugDef.itemTypeAndTierDisplayName)
   );
 
   return (


### PR DESCRIPTION
causes Charged With Light mods to become 1 category instead of 2, marks artifice armor plug selectable categories as such. all changes previewable in mod picker