### PR TITLE
Fix breaker icon size in Armory header

### DIFF
--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -107,7 +107,9 @@ export default function Armory({
         <div className={styles.headerContent}>
           <div className={styles.subtitle}>
             <ElementIcon element={item.element} className={styles.element} />
-            {item.breakerType && <BungieImage src={item.breakerType.displayProperties.icon} />}
+            {item.breakerType && (
+              <BungieImage src={item.breakerType.displayProperties.icon} height={15} />
+            )}
             {item.destinyVersion === 2 && item.ammoType > 0 && <AmmoIcon type={item.ammoType} />}
             <ItemTypeName item={item} />
             {item.pursuit?.questStepNum && (


### PR DESCRIPTION
This PR closes #7366.

![dim-armory-breaker-icon-fix](https://user-images.githubusercontent.com/17512262/145786451-b458b831-6099-4e73-ace6-efcffb5ba47e.png)

The breaker icon's height has been hardcoded to 15px to match the season icon in the header. This is also the same height used for the breaker icon in the item popup.
