### PR TITLE
Fix mod selection from socket.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed issue where selecting mods from the Mod Picker, opened from an item socket, would clear other mod selections.
+
 ## 6.95.0 <span class="changelog-date">(2021-12-12)</span>
 
 * Fix image paths for D1 perks.

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -24,12 +24,12 @@ import { createSelector } from 'reselect';
 import { isLoadoutBuilderItem } from './item-utils';
 import { knownModPlugCategoryHashes, slotSpecificPlugCategoryHashes } from './known-values';
 import { isInsertableArmor2Mod, sortModGroups, sortMods } from './mod-utils';
-import PlugDrawer, { PlugSetWithMaxSelectable } from './plug-drawer/PlugDrawer';
+import PlugDrawer, { PlugsWithMaxSelectable } from './plug-drawer/PlugDrawer';
 
 /** Raid, combat and legacy mods can have up to 5 selected. */
 const MAX_SLOT_INDEPENDENT_MODS = 5;
 
-const sortModPickerPlugSets = (a: PlugSetWithMaxSelectable, b: PlugSetWithMaxSelectable) =>
+const sortModPickerPlugGroups = (a: PlugsWithMaxSelectable, b: PlugsWithMaxSelectable) =>
   sortModGroups(a.plugs, b.plugs);
 
 interface ProvidedProps {
@@ -59,7 +59,7 @@ interface ProvidedProps {
 
 interface StoreProps {
   language: string;
-  plugSetWithMaxSelectables: PlugSetWithMaxSelectable[];
+  plugsWithMaxSelectableSets: PlugsWithMaxSelectable[];
 }
 
 type Props = ProvidedProps & StoreProps;
@@ -82,8 +82,8 @@ function mapStateToProps() {
       owner,
       plugCategoryHashWhitelist,
       currentStore
-    ): PlugSetWithMaxSelectable[] => {
-      const plugsWithMaxSelectableSets: { [plugSetHash: number]: PlugSetWithMaxSelectable } = {};
+    ): PlugsWithMaxSelectable[] => {
+      const plugsWithMaxSelectableSets: { [plugSetHash: number]: PlugsWithMaxSelectable } = {};
       if (!profileResponse || !defs) {
         return [];
       }
@@ -167,7 +167,7 @@ function mapStateToProps() {
   );
   return (state: RootState, props: ProvidedProps): StoreProps => ({
     language: languageSelector(state),
-    plugSetWithMaxSelectables: unlockedPlugSetsSelector(state, props),
+    plugsWithMaxSelectableSets: unlockedPlugSetsSelector(state, props),
   });
 }
 
@@ -175,7 +175,7 @@ function mapStateToProps() {
  * A sheet to pick mods that are required in the final loadout sets.
  */
 function ModPicker({
-  plugSetWithMaxSelectables,
+  plugsWithMaxSelectableSets,
   language,
   lockedMods,
   initialQuery,
@@ -234,11 +234,11 @@ function ModPicker({
   const [visibleSelectedMods, hiddenSelectedMods] = useMemo(
     () =>
       _.partition(lockedMods, (mod) =>
-        plugSetWithMaxSelectables.some((plugSet) =>
+        plugsWithMaxSelectableSets.some((plugSet) =>
           plugSet.plugs.some((plug) => plug.hash === mod.hash)
         )
       ),
-    [lockedMods, plugSetWithMaxSelectables]
+    [lockedMods, plugsWithMaxSelectableSets]
   );
 
   const onAcceptWithHiddenSelectedMods = useCallback(
@@ -255,11 +255,11 @@ function ModPicker({
       acceptButtonText={t('LB.SelectMods')}
       language={language}
       initialQuery={initialQuery}
-      plugSetWithMaxSelectables={plugSetWithMaxSelectables}
+      plugsWithMaxSelectableSets={plugsWithMaxSelectableSets}
       initiallySelected={visibleSelectedMods}
       minHeight={minHeight}
       isPlugSelectable={isModSelectable}
-      sortPlugSets={sortModPickerPlugSets}
+      sortPlugGroups={sortModPickerPlugGroups}
       sortPlugs={sortMods}
       onAccept={onAcceptWithHiddenSelectedMods}
       onClose={onClose}

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -25,11 +25,15 @@ export interface PlugsWithMaxSelectable {
 
 interface Props {
   /**
-   * A list of plug items that come from a PlugSet, along with the maximum number of these plugs that can be chosen.
+   * A list of plug items that come from a PlugSet, along with the maximum number of these plugs
+   * that can be chosen.
    */
   plugsWithMaxSelectableSets: PlugsWithMaxSelectable[];
   /**
    * An array of mods that are already locked.
+   *
+   * These must be a subset of the plugs in plugsWithMaxSelectableSets otherwise unknown plugs
+   * will be discarded on accept.
    */
   initiallySelected: PluggableInventoryItemDefinition[];
   /** A list of stat hashes that if present will be displayed for each plug. */
@@ -267,7 +271,7 @@ type InternalSelectedState = {
  * This creates the internally used state for the selected plugs.
  *
  * We need to associate each selected plug with a plugSetHash to correctly handle artificer
- * socket plugs. The plugsets that they can take are a subset of the bucket specific sockets
+ * sockets. The plugsets that they can take are a subset of the bucket specific sockets
  * plugsets on an item, specifically they are just the artifact mods.
  *
  * To do this we create a map from plugSet to a list of plugs selected. This ensure that when

--- a/src/app/loadout/plug-drawer/PlugSection.tsx
+++ b/src/app/loadout/plug-drawer/PlugSection.tsx
@@ -11,8 +11,11 @@ import SelectablePlug from './SelectablePlug';
  * - the plugset whence these plugs originate
  */
 export interface PlugsWithMaxSelectable {
-  plugs: PluggableInventoryItemDefinition[];
+  /** The hash that links to the PlugSet definition. */
   plugSetHash: number;
+  /** A list of plugs from this plugset. */
+  plugs: PluggableInventoryItemDefinition[];
+  /** The maximum number of plugs a user can select from this plug set. */
   maxSelectable: number;
   headerSuffix?: string;
 }


### PR DESCRIPTION
Fixed issue where selecting mods from the Mod Picker, opened from an item socket, would clear other mod selections.

It is correct that this bug came from the work to handle artificer mods but I think the root cause is better attributed to the mod picker not intelligently sending in selected mods that are actually visible in the mod picker.

This fixes that by only sending in mods that are actually visible, and when the user accepts the selection we append all the selected mods that were not visible to the result.

Fixes #7470 