### PR TITLE
Update compare-buttons.tsx

### DIFF
--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -156,12 +156,14 @@ export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
         <WeaponTypeIcon key="type" item={exampleItem} className={styles.svgIcon} />,
       ],
       query:
+        '(' + 
         bucketToSearch[exampleItem.bucket.hash] +
         ' ' +
         (exampleItem.destinyVersion === 2 && intrinsic
           ? // TODO: add a search by perk hash? It'd be slightly different than searching by name
             `perkname:"${intrinsic.displayProperties.name}"`
-          : `stat:rpm:${getRpm(exampleItem)}`),
+          : `stat:rpm:${getRpm(exampleItem)}`)
+        ')',
     },
 
     // above, but also same (kinetic/energy/heavy) slot

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -162,7 +162,7 @@ export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
         (exampleItem.destinyVersion === 2 && intrinsic
           ? // TODO: add a search by perk hash? It'd be slightly different than searching by name
             `perkname:"${intrinsic.displayProperties.name}"`
-          : `stat:rpm:${getRpm(exampleItem)}`)
+          : `stat:rpm:${getRpm(exampleItem)}`) +
         ')',
     },
 


### PR DESCRIPTION
Update intrinsic query to group bucket and perkname in parentheses so that `or id:nnn` works correctly.