### PR TITLE
Hide cost overlay for Stasis fragments

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -6,7 +6,7 @@ import {
   DestinyInventoryItemDefinition,
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
 import { DimItem } from './item-types';
 import styles from './ItemIcon.m.scss';
@@ -143,7 +143,8 @@ export function getModCostInfo(
     mod = defs.InventoryItem.get(mod);
   }
 
-  if (mod?.plug) {
+  // hide cost for Stasis fragments as these are currently always set to 1
+  if (mod?.plug && mod.plug.plugCategoryHash !== PlugCategoryHashes.SharedStasisTrinkets) {
     modCostInfo.energyCost = mod.plug.energyCost?.energyCost;
 
     if (mod.plug.energyCost?.energyTypeHash) {
@@ -155,5 +156,6 @@ export function getModCostInfo(
       )?.displayProperties.icon;
     }
   }
+
   return modCostInfo;
 }


### PR DESCRIPTION
This PR closes #7361.

![dim-hide-stasis-fragment-cost](https://user-images.githubusercontent.com/17512262/145986314-fcefac58-336d-4f74-979f-5d95485cbe24.png)

We'll probably need to revisit this after each Light subclass 3.0 rework as this is testing for the Stasis fragment plug category hash (`PlugCategoryHashes.SharedStasisTrinkets`).