### PR TITLE
Updating sidecar to allow favouriting of finishers - Issue #7348

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -693,6 +693,12 @@
     "Equip": "Equip",
     "EquipWithName": "Equip to {{character}}",
     "Expand": "Expand item details",
+    "FavoriteUnFavorite": {
+      "Favorite": "Favorite {{itemType}}",
+      "Unfavorite": "Unfavorite {{itemType}}",
+      "Favorited": "Favorited",
+      "Unfavorited": "Unfavorited"
+    },
     "Infuse": "Infuse",
     "ItemDetailSheet": "Open item details",
     "LockUnlock": {

--- a/cspell-dim-dict.txt
+++ b/cspell-dim-dict.txt
@@ -136,6 +136,7 @@ unassended
 unequip
 unequippable
 unexclude
+unfavorited
 UniFFFD
 uninstanced
 unly

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Fixed issue where selecting mods from the Mod Picker, opened from an item socket, would clear other mod selections.
+* Added the ability to favorite finishers
 
 ## 6.95.0 <span class="changelog-date">(2021-12-12)</span>
 

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -101,7 +101,10 @@ export default function InventoryItem({
         {(tag || item.locked || notes) && (
           <div className={styles.icons}>
             {item.locked && (
-              <AppIcon className={styles.icon} icon={item.lockable ? lockIcon : starIcon} />
+              <AppIcon
+                className={styles.icon}
+                icon={item.type !== 'Finishers' ? lockIcon : starIcon}
+              />
             )}
             {tag && <TagIcon className={styles.icon} tag={tag} />}
             {notes && <AppIcon className={styles.icon} icon={stickyNoteIcon} />}

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -425,7 +425,7 @@ export function makeItem(
     element,
     energy: instanceDef?.energy ?? null,
     powerCap,
-    lockable: item.lockable,
+    lockable: itemType !== 'Finishers' ? item.lockable : true,
     trackable: Boolean(item.itemInstanceId && itemDef.objectives?.questlineItemHash),
     tracked: Boolean(item.state & ItemState.Tracked),
     locked: Boolean(item.state & ItemState.Locked),

--- a/src/app/item-actions/ActionButtons.tsx
+++ b/src/app/item-actions/ActionButtons.tsx
@@ -54,7 +54,11 @@ export function LockActionButton({ item, label }: ActionButtonProps) {
   const title =
     type === 'lock'
       ? item.locked
-        ? t('MovePopup.LockUnlock.Locked')
+        ? item.type === 'Finishers'
+          ? t('MovePopup.FavoriteUnFavorite.Favorited')
+          : t('MovePopup.LockUnlock.Locked')
+        : item.type === 'Finishers'
+        ? t('MovePopup.FavoriteUnFavorite.Unfavorited')
         : t('MovePopup.LockUnlock.Unlocked')
       : item.tracked
       ? t('MovePopup.TrackUntrack.Tracked')

--- a/src/app/item-actions/LockButton.tsx
+++ b/src/app/item-actions/LockButton.tsx
@@ -7,7 +7,15 @@ import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import { DimItem } from '../inventory/item-types';
-import { AppIcon, lockIcon, trackedIcon, unlockedIcon, unTrackedIcon } from '../shell/icons';
+import {
+  AppIcon,
+  lockIcon,
+  starIcon,
+  starOutlineIcon,
+  trackedIcon,
+  unlockedIcon,
+  unTrackedIcon,
+} from '../shell/icons';
 import ActionButton from './ActionButton';
 import styles from './LockButton.m.scss';
 
@@ -54,7 +62,11 @@ export default function LockButton({ type, item, children }: Props) {
   const icon =
     type === 'lock'
       ? item.locked
-        ? lockIcon
+        ? item.type === 'Finishers'
+          ? starIcon
+          : lockIcon
+        : item.type === 'Finishers'
+        ? starOutlineIcon
         : unlockedIcon
       : item.tracked
       ? trackedIcon
@@ -80,7 +92,11 @@ export function lockButtonTitle(item: DimItem, type: 'lock' | 'track') {
   return (
     (type === 'lock'
       ? !item.locked
-        ? t('MovePopup.LockUnlock.Lock', data)
+        ? item.type === 'Finishers'
+          ? t('MovePopup.FavoriteUnFavorite.Favorite', data)
+          : t('MovePopup.LockUnlock.Lock', data)
+        : item.type === 'Finishers'
+        ? t('MovePopup.FavoriteUnFavorite.Unfavorite', data)
         : t('MovePopup.LockUnlock.Unlock', data)
       : !item.tracked
       ? t('MovePopup.TrackUntrack.Track', data)

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -623,6 +623,12 @@
     "Consolidate": "Consolidate",
     "DistributeEvenly": "Distribute Evenly",
     "Equip": "Equip",
+    "FavoriteUnFavorite": {
+      "Favorite": "Favorite {{itemType}}",
+      "Favorited": "Favorited",
+      "Unfavorite": "Unfavorite {{itemType}}",
+      "Unfavorited": "Unfavorited"
+    },
     "Infuse": "Infuse",
     "LockUnlock": {
       "Lock": "Lock {{itemType}}",


### PR DESCRIPTION
**Changes:**
- Updated title & icons if finisher
- manually set Finishers to "lockable"
- Update Inventory Item to display star if finisher & locked

**Notes:**
Would be ideal if finishers came back as "lockable" from the API, doesn't feel right to manually set it. Also, I feel the ActionButtons / LockButton are a little heavy on the conditionals with checks for lockable, lockable / finisher & taggable. Might be worth Lockbutton out into TagButton / LockButton or similar.

Oh and strange tidbit, you can favourite the collection itself. I guess it's technically a finisher.


**Preview**
![DIMFav](https://user-images.githubusercontent.com/6667803/146020574-b207b0cc-5c55-424f-831c-074f20bb4151.gif)
