### PR TITLE
fix LO results default plug fetching

### DIFF
--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -784,7 +784,7 @@ function applyLoadoutMods(
         if (
           skipArmorsWithNoAssignments &&
           // if this assignmentSequence would return all sockets to their default
-          assignmentSequence.every((assignment) => isAssigningToDefault(item, assignment))
+          assignmentSequence.every((assignment) => isAssigningToDefault(item, assignment, defs))
         ) {
           infoLog(
             'loadout mods',
@@ -833,7 +833,7 @@ function equipModsToItem(
       // If the plug is already inserted we can skip this
       if (socket.plugged?.plugDef.hash === mod.hash) {
         // Don't count removing mods as applying a mod successfully
-        if (includeAssignToDefault || !isAssigningToDefault(item, { socketIndex, mod })) {
+        if (includeAssignToDefault || !isAssigningToDefault(item, { socketIndex, mod }, defs)) {
           successfulMods.push(mod.hash);
         }
         continue;
@@ -853,7 +853,7 @@ function equipModsToItem(
         try {
           await dispatch(insertPlug(item, socket, mod.hash));
           // Don't count removing mods as applying a mod successfully
-          if (includeAssignToDefault || !isAssigningToDefault(item, { socketIndex, mod })) {
+          if (includeAssignToDefault || !isAssigningToDefault(item, { socketIndex, mod }, defs)) {
             successfulMods.push(mod.hash);
           }
         } catch (e) {

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -5,6 +5,7 @@ import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
+import { getDefaultPlugHash } from '../mod-utils';
 import Mod from './Mod';
 import styles from './Sockets.m.scss';
 
@@ -56,8 +57,11 @@ function Sockets({ item, lockedMods, size, onSocketClick }: Props) {
       }
     }
 
-    if (!toSave && socket.socketDefinition.singleInitialItemHash) {
-      toSave = defs.InventoryItem.get(socket.socketDefinition.singleInitialItemHash);
+    if (!toSave) {
+      const plugHash = getDefaultPlugHash(socket, defs);
+      if (plugHash) {
+        toSave = defs.InventoryItem.get(plugHash);
+      }
     }
 
     if (

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -359,9 +359,8 @@ export function pickPlugPositions(
   // return it to its default (usually "Empty Mod Socket")
 
   // so we fall back to the first item in its reusable PlugSet
-  // so we fall back to the first item in its reusable PlugSet
   for (const socket of existingModSockets) {
-    const defaultModHash = getDefaultPlugHash(socket);
+    const defaultModHash = getDefaultPlugHash(socket, defs);
     const mod =
       defaultModHash &&
       (defs.InventoryItem.get(defaultModHash) as PluggableInventoryItemDefinition);
@@ -393,7 +392,7 @@ export function pickPlugPositions(
 export function createPluggingStrategy(
   item: DimItem,
   assignments: Assignment[],
-  defs?: D2ManifestDefinitions
+  defs: D2ManifestDefinitions
 ): PluggingAction[] {
   // stuff we need to apply, that frees up energy. we'll apply these first
   const requiredRegains: PluggingAction[] = [];
@@ -623,7 +622,7 @@ function energyTypesAreCompatible(first: DestinyEnergyType, second: DestinyEnerg
 export function isAssigningToDefault(
   item: DimItem,
   assignment: Assignment,
-  defs?: D2ManifestDefinitions
+  defs: D2ManifestDefinitions
 ) {
   const socket = item.sockets && getSocketByIndex(item.sockets, assignment.socketIndex);
   if (!socket) {

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -138,7 +138,7 @@ export function getItemEnergyType(
  * gets the InventoryItem hash corresponding to a socket's default contents
  * (what should be plugged in order to "revert/clear" it)
  */
-export function getDefaultPlugHash(socket: DimSocket, defs?: D2ManifestDefinitions) {
+export function getDefaultPlugHash(socket: DimSocket, defs: D2ManifestDefinitions) {
   if (socket.plugged) {
     const { singleInitialItemHash, reusablePlugSetHash } = socket.socketDefinition;
     return singleInitialItemHash


### PR DESCRIPTION
fixes socket display for artificer armor empty sockets

before:
![image](https://user-images.githubusercontent.com/68782081/146518706-21a50adc-c060-4753-973d-f747714b84ba.png)

after:
![image](https://user-images.githubusercontent.com/68782081/146518724-0c1e9e05-2d88-4793-90f5-79273e41602e.png)

*should* it include the intrinsic? yeah , i think so. it's a nice reminder of why that piece is different