### PR TITLE
allow DIM to launch separately

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -311,6 +311,7 @@
     "FilterMatchCount_plural": "{{count}} items",
     "Filters": "Filters",
     "FilterHelpMenuItem": "Filters Help...",
+    "LaunchDIMAlone": "Separate Window",
     "InstallDIM": "Install as an App",
     "InstallDIMBanner": "Install DIM as an app on your home screen",
     "Inventory": "Inventory",

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -202,6 +202,11 @@ $header-height: 44px;
       color: white;
       transition: none;
     }
+
+    .launchSeparateIcon {
+      font-size: 1em;
+      color: #888;
+    }
   }
 }
 .dropdownEnter {

--- a/src/app/shell/Header.m.scss.d.ts
+++ b/src/app/shell/Header.m.scss.d.ts
@@ -13,6 +13,7 @@ interface CssExports {
   'header': string;
   'headerLinks': string;
   'headerRight': string;
+  'launchSeparateIcon': string;
   'logo': string;
   'logoLink': string;
   'menu': string;

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -116,12 +116,11 @@ export default function Header() {
     // as an alternative to installing,
     !isStandalone &&
     !installable &&
-    // offer desktop users the choice to relaunch in a no-tabs, less-UI window
-    window.name !== 'dim-solo-window' &&
+    // offer desktop users
     !isPhonePortrait;
-
+  // the choice to relaunch in a no-tabs, less-UI window
   const reLaunchDim = () => {
-    window.open(window.location.href, 'dim-solo-window', 'resizable,scrollbars,status');
+    window.open(window.location.href, '_blank', 'resizable,scrollbars,status');
   };
 
   // Search filter

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -29,7 +29,7 @@ import { installPrompt$ } from './app-install';
 import AppInstallBanner from './AppInstallBanner';
 import styles from './Header.m.scss';
 //import './header.scss';
-import { AppIcon, menuIcon, searchIcon, settingsIcon } from './icons';
+import { AppIcon, faExternalLinkAlt, menuIcon, searchIcon, settingsIcon } from './icons';
 import MenuBadge from './MenuBadge';
 import PostmasterWarningBanner from './PostmasterWarningBanner';
 import RefreshButton from './RefreshButton';
@@ -111,6 +111,18 @@ export default function Header() {
     /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream && !isStandalone;
 
   const installable = installPromptEvent || iosPwaAvailable;
+
+  const offerRelaunch =
+    // as an alternative to installing,
+    !isStandalone &&
+    !installable &&
+    // offer desktop users the choice to relaunch in a no-tabs, less-UI window
+    window.name !== 'dim-solo-window' &&
+    !isPhonePortrait;
+
+  const reLaunchDim = () => {
+    window.open(window.location.href, 'dim-solo-window', 'resizable,scrollbars,status');
+  };
 
   // Search filter
   const searchFilter = useRef<SearchFilterRef>(null);
@@ -307,11 +319,16 @@ export default function Header() {
                 >
                   {t('General.UserGuideLink')}
                 </ExternalLink>
-                {installable && (
+                {installable ? (
                   <a className={styles.menuItem} onClick={installDim}>
                     {t('Header.InstallDIM')}
                   </a>
-                )}
+                ) : offerRelaunch ? (
+                  <a className={styles.menuItem} onClick={reLaunchDim}>
+                    {t('Header.LaunchDIMAlone')}{' '}
+                    <AppIcon icon={faExternalLinkAlt} className={styles.launchSeparateIcon} />
+                  </a>
+                ) : null}
                 {dimLinks}
                 <MenuAccounts closeDropdown={hideDropdown} />
               </ClickOutside>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -290,6 +290,7 @@
     "Inventory": "Inventory",
     "IosPwaPrompt": "In Safari, click the share icon (middle button on the bottom) and select \"Add to Home Screen\".",
     "KeyboardShortcuts": "Keyboard Shortcuts",
+    "LaunchDIMAlone": "Separate Window",
     "Menu": "Menu",
     "Refresh": "Refresh Destiny Data [R]",
     "ReloadApp": "Reload App",


### PR DESCRIPTION
in the absence of installability, offer users the option to launch DIM in a window with a bit less chrome, and where it can't get buried among other tabs or have its tab focus stolen.

it's dissatisfying but there's no way to close the source window programatically.. browsers are pretty against that behavior. and i found that transforming the old tab into a "you can now close this" is confusing and not any more satisfying really. think people just need to close it themselves.

definitely want opinions about verbiage. "Separate Window" has some noun/verb ambiguity, "Launch in a Separate Window" feels awfully wordy, "[Launch/Relaunch] [Externally/in an External Window]" are a struggle, i just don't know. maybe there's an obvious other choice.

![image](https://user-images.githubusercontent.com/68782081/146668070-fc8030cb-ad54-4f12-b71c-f2d7284a54c2.png)

