### PR TITLE
Useragent based workaround for ios app PWA

### DIFF
--- a/src/app/login/Login.tsx
+++ b/src/app/login/Login.tsx
@@ -20,7 +20,9 @@ export default function Login() {
   const clientId = oauthClientId();
 
   const isStandalone =
-    window.navigator.standalone === true || window.matchMedia('(display-mode: standalone)').matches;
+    window.navigator.standalone === true ||
+    window.matchMedia('(display-mode: standalone)').matches ||
+    /.* STANDALONE$/.test(navigator.userAgent);
   // iOS versions before 12.2 don't support logging in via standalone mode.
   const isOldiOS =
     /iPad|iPhone|iPod/.test(navigator.userAgent) &&

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -105,7 +105,9 @@ export default function Header() {
 
   // Is this running as an installed app?
   const isStandalone =
-    window.navigator.standalone === true || window.matchMedia('(display-mode: standalone)').matches;
+    window.navigator.standalone === true ||
+    window.matchMedia('(display-mode: standalone)').matches ||
+    /.* STANDALONE$/.test(navigator.userAgent);
 
   const iosPwaAvailable =
     /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream && !isStandalone;


### PR DESCRIPTION
window.navigator.standalone isn't returning true for the webview in the ios app. work around by checking the UA

https://github.com/DestinyItemManager/iOS/blob/0f87fdd9fd2b925c1c6093276e2442a2c9a34e23/DIM/WebView.swift#L33