### PR TITLE
Fix transmog ornament chooser to grey out locked options

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -915,6 +915,10 @@
     "SelectWishlistPerks": "Preview Wishlist Perks",
     "InsertModButton": "Insert Mod",
     "SelectModButton": "Select Mod",
+    "InsertShaderButton": "Apply Shader",
+    "SelectShaderButton": "Select Shader",
+    "InsertOrnamentButton": "Apply Ornament",
+    "SelectOrnamentButton": "Select Ornament",
     "ListStyle": "Display perks as a list",
     "GridStyle": "Display perks as a grid"
   },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improved the time taken to apply a loadout with mods.
 * Stasis subclass can also be applied in the Loadouts page.
 * Fixed showing the amount of Dawning Spirit in the holiday oven popup.
+* Transmog Ornaments menu now correctly shows whether ornament has been unlocked or not.
 
 ## 6.95.1 <span class="changelog-date">(2021-12-14)</span>
 

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -50,7 +50,7 @@ function mapStateToProps() {
       const unlockedPlugs = new Set<number>();
       const plugSetItems = itemsForCharacterOrProfilePlugSet(profileResponse, plugSetHash, owner);
       for (const plugSetItem of plugSetItems) {
-        if (plugSetItem.enabled) {
+        if (plugSetItem.canInsert) {
           unlockedPlugs.add(plugSetItem.plugItemHash);
         }
       }

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -11,6 +11,7 @@ import {
 import { interpolateStatValue } from 'app/inventory/store/stats';
 import { destiny2CoreSettingsSelector, useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
+import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { refreshIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
@@ -112,6 +113,20 @@ export default function SocketDetailsSelectedPlug({
   const canDoAWA =
     itemIsInstanced(item) && canInsertPlug(socket, plug.hash, destiny2CoreSettings, defs);
 
+  const initialPlugHash = socket.socketDefinition.singleInitialItemHash;
+  let insertName;
+  if (initialPlugHash) {
+    if (initialPlugHash === DEFAULT_SHADER) {
+      insertName = canDoAWA ? t('Sockets.InsertShaderButton') : t('Sockets.SelectShaderButton');
+    } else if (DEFAULT_ORNAMENTS.includes(initialPlugHash)) {
+      insertName = canDoAWA ? t('Sockets.InsertOrnamentButton') : t('Sockets.SelectOrnamentButton');
+    } else {
+      insertName = canDoAWA ? t('Sockets.InsertModButton') : t('Sockets.SelectModButton');
+    }
+  } else {
+    insertName = canDoAWA ? t('Sockets.InsertModButton') : t('Sockets.SelectModButton');
+  }
+
   const [insertInProgress, setInsertInProgress] = useState(false);
   const onInsertPlug = async () => {
     if (canDoAWA) {
@@ -193,9 +208,7 @@ export default function SocketDetailsSelectedPlug({
             </motion.span>
           )}
           <motion.span layout>
-            <motion.span layout>
-              {canDoAWA ? t('Sockets.InsertModButton') : t('Sockets.SelectModButton')}
-            </motion.span>
+            <motion.span layout>{insertName}</motion.span>
             <motion.span layout>{costs}</motion.span>
           </motion.span>
         </motion.button>

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -839,8 +839,12 @@
     "ApplyPerks": "Apply Perks",
     "GridStyle": "Display perks as a grid",
     "InsertModButton": "Insert Mod",
+    "InsertOrnamentButton": "Apply Ornament",
+    "InsertShaderButton": "Apply Shader",
     "ListStyle": "Display perks as a list",
     "SelectModButton": "Select Mod",
+    "SelectOrnamentButton": "Select Ornament",
+    "SelectShaderButton": "Select Shader",
     "SelectWishlistPerks": "Preview Wishlist Perks"
   },
   "Stats": {


### PR DESCRIPTION
Fixes #7488. Universal ornaments appear to be the only plugs where `enabled` and `canInsert` disagree.

Drive by fix for the "Insert Mod" text appearing for shaders and ornaments.