### PR TITLE
Assume browser support if iOS PWA/APP

### DIFF
--- a/src/browsercheck.js
+++ b/src/browsercheck.js
@@ -54,6 +54,11 @@ export function isSupported(browsersSupported, userAgent) {
     return false;
   }
 
+  if (navigator.standalone) {
+    // Assume support if we're installed as an iOS PWA.
+    return true;
+  }
+
   var agent = parser(userAgent);
 
   // Build a map from browser version to minimum supported version


### PR DESCRIPTION
Thinking we can assume the browser supports DIM if it can be installed as a PWA, it just may not get caught by the UA parser/detection (especially because on the iOS app we modify the UA string to bypass a google login issue.)

https://github.com/DestinyItemManager/iOS/blob/8e23de687ad3f4ddd24a8c6f2bebd8a3a974fd97/DIM/WebView.swift#L27

This way users that install an app/pwa on iOS don't get the "this browser is not supported" message.