### PR TITLE
Line breaks for Loadout Notes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update some error messages for when equipping items fails.
 * Radiant Light and Powerful Friends will now be accounted for when showing mod placements and applying mods to a loadout. If possible they will be assigned to an item so that their conditional perks are active.
 * Selecting toggleable subclass abilities like jumps and grenades now works more smoothly.
+* Loadout notes now retain whitespace formatting.
 
 ## 6.96.0 <span class="changelog-date">(2021-12-19)</span>
 

--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -222,6 +222,7 @@
 
 .loadoutNotes {
   margin: 4px 0;
+  white-space: pre-wrap;
 }
 
 .loParams {


### PR DESCRIPTION
adding white-space styling to `.loadoutNotes` to preserve whitespace formatting

fixes #7525 