### PR TITLE
Force uninstanced items to never have a wishlist roll

### DIFF
--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -29,6 +29,9 @@ export const wishListFunctionSelector = createSelector(
     // Cache of inventory item id to roll. For this to work, make sure vendor/collections rolls have unique ids.
     const cache = new Map<string, InventoryWishListRoll | undefined>();
     return (item: DimItem) => {
+      if (item.id === '0') {
+        return undefined;
+      }
       if (cache.has(item.id)) {
         return cache.get(item.id);
       }

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -140,7 +140,8 @@ export function getInventoryWishListRoll(
     !wishListRolls ||
     !item ||
     item.destinyVersion === 1 ||
-    !item.sockets
+    !item.sockets ||
+    item.id === '0'
   ) {
     return undefined;
   }


### PR DESCRIPTION
This makes sure we never apply wishlist rolls to consumables and other uninstanced items, while still showing wishlist thumbs for vendor items.