### PR TITLE
Never show badge for subclass

### DIFF
--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -36,7 +36,8 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   const wishlistRollIcon = toUiWishListRoll(wishlistRoll);
 
   const hideBadge = Boolean(
-    (item.isEngram && item.location.hash === BucketHashes.Engrams) ||
+    item.location.hash === BucketHashes.Subclass ||
+      (item.isEngram && item.location.hash === BucketHashes.Engrams) ||
       (isBounty && (item.complete || item.hidePercentage)) ||
       (isStackable && item.amount === 1) ||
       (isGeneric && !item.primaryStat?.value && !item.classified)


### PR DESCRIPTION
This should prevent subclasses from sometimes showing a badge when sockets haven't fully loaded. It used to be that you had to progressively unlock subclasses which made this percentage useful but I don't think that's a mechanic in the game anymore.