### PR TITLE
Handle scrollbars in page menus better

### DIFF
--- a/src/app/dim-ui/PageWithMenu.m.scss
+++ b/src/app/dim-ui/PageWithMenu.m.scss
@@ -47,18 +47,22 @@
   margin-top: 8px;
   position: sticky;
   top: calc(var(--header-height) + 8px);
-  width: 230px + 17px + 8px; // Windows scrollbars are 17px, then padding
+  width: 230px + 8px;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: none;
   -webkit-overflow-scrolling: touch;
   max-height: calc(var(--viewport-height) - var(--header-height) - 8px);
 
-  // This div what the actual content lives in. The outer menu is 17px larger to create a "gutter" for scrollbars to show up in.
-  // It'd be cooler if https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter existed.
   > div {
     width: 230px;
     padding: 4px;
+  }
+
+  // Add in some width when a scrollbar is present!
+  // It'd be cooler if https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter existed.
+  &.menuScrollbars {
+    width: 230px + 17px + 8px; // Windows scrollbars are 17px, then padding
   }
 
   @include phone-portrait {
@@ -67,6 +71,10 @@
     padding: 0;
     width: 100%;
     max-height: none;
+    > div {
+      width: 100%;
+      padding: 0;
+    }
   }
 
   ul {

--- a/src/app/dim-ui/PageWithMenu.m.scss
+++ b/src/app/dim-ui/PageWithMenu.m.scss
@@ -44,16 +44,22 @@
   font-size: 14px;
   flex-shrink: 0;
   margin-right: 12px;
-  padding: 4px;
   margin-top: 8px;
   position: sticky;
   top: calc(var(--header-height) + 8px);
-  width: 230px;
+  width: 230px + 17px + 8px; // Windows scrollbars are 17px, then padding
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: none;
   -webkit-overflow-scrolling: touch;
   max-height: calc(var(--viewport-height) - var(--header-height) - 8px);
+
+  // This div what the actual content lives in. The outer menu is 17px larger to create a "gutter" for scrollbars to show up in.
+  // It'd be cooler if https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter existed.
+  > div {
+    width: 230px;
+    padding: 4px;
+  }
 
   @include phone-portrait {
     position: static;

--- a/src/app/dim-ui/PageWithMenu.m.scss.d.ts
+++ b/src/app/dim-ui/PageWithMenu.m.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'menu': string;
   'menuButton': string;
   'menuHeader': string;
+  'menuScrollbars': string;
   'page': string;
 }
 export const cssExports: CssExports;

--- a/src/app/dim-ui/PageWithMenu.tsx
+++ b/src/app/dim-ui/PageWithMenu.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './PageWithMenu.m.scss';
 import { scrollToHref } from './scroll';
 
@@ -7,21 +7,47 @@ function PageWithMenu({ children, className }: { children: React.ReactNode; clas
   return <div className={clsx(className, styles.page)}>{children}</div>;
 }
 
-PageWithMenu.Menu = function ({
+/** Detect the presence of scrollbars that take up space. This may only work in this particular case! */
+function useHasScrollbars(ref: React.RefObject<HTMLDivElement>) {
+  const [hasScrollbars, setHasScrollbars] = useState(false);
+
+  const updateResize = useCallback(() => {
+    if (ref.current) {
+      setHasScrollbars(ref.current.clientWidth < ref.current.offsetWidth);
+    }
+  }, [ref]);
+
+  useEffect(() => {
+    updateResize();
+  });
+
+  useEffect(() => {
+    window.addEventListener('resize', updateResize);
+    return () => window.removeEventListener('resize', updateResize);
+  });
+  return hasScrollbars;
+}
+
+PageWithMenu.Menu = function Menu({
   children,
   className,
 }: {
   children: React.ReactNode;
   className?: string;
 }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const hasScrollbars = useHasScrollbars(ref);
   return (
-    <div className={clsx(className, styles.menu)}>
+    <div
+      ref={ref}
+      className={clsx(className, styles.menu, { [styles.menuScrollbars]: hasScrollbars })}
+    >
       <div>{children}</div>
     </div>
   );
 };
 
-PageWithMenu.Contents = function ({
+PageWithMenu.Contents = function Contents({
   children,
   className,
 }: {
@@ -31,7 +57,7 @@ PageWithMenu.Contents = function ({
   return <div className={clsx(className, styles.contents)}>{children}</div>;
 };
 
-PageWithMenu.MenuHeader = function ({
+PageWithMenu.MenuHeader = function MenuHeader({
   children,
   className,
 }: {
@@ -41,7 +67,7 @@ PageWithMenu.MenuHeader = function ({
   return <div className={clsx(className, styles.menuHeader)}>{children}</div>;
 };
 
-PageWithMenu.MenuButton = function ({
+PageWithMenu.MenuButton = function MenuButton({
   children,
   className,
   anchor,

--- a/src/app/dim-ui/PageWithMenu.tsx
+++ b/src/app/dim-ui/PageWithMenu.tsx
@@ -14,7 +14,11 @@ PageWithMenu.Menu = function ({
   children: React.ReactNode;
   className?: string;
 }) {
-  return <div className={clsx(className, styles.menu)}>{children}</div>;
+  return (
+    <div className={clsx(className, styles.menu)}>
+      <div>{children}</div>
+    </div>
+  );
 };
 
 PageWithMenu.Contents = function ({


### PR DESCRIPTION
Fixes #7423. This probably needs some testing on Windows, but basically it builds in a space for the scrollbar to go so that when it's present, the content doesn't get squished. As a result, things like the LO mods list properly shows 4 mods per row instead of 3.