### PR TITLE
LO: Compare uses the loadout selected in the loadout page.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Selecting toggleable subclass abilities like jumps and grenades now works more smoothly.
 * Loadout notes now retain whitespace formatting.
 * Added new filter "is:stackfull" to show items that are at max stack size.
+* The Loadout Optimizer will now initially select the loadout which was optimized from the loadout page.
 
 ### Beta Only
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Selecting toggleable subclass abilities like jumps and grenades now works more smoothly.
 * Loadout notes now retain whitespace formatting.
 * Added new filter "is:stackfull" to show items that are at max stack size.
-* The Loadout Optimizer will now initially select the loadout which was optimized from the loadout page.
+* When re-Optimizing a loadout, the Loadout Optimizer's Compare button will now initially select the original loadout from the loadout page.
 
 ### Beta Only
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -496,6 +496,7 @@ function LoadoutBuilder({
             <CompareDrawer
               set={compareSet}
               loadouts={loadouts}
+              initialLoadoutId={preloadedLoadout?.id}
               lockedMods={lockedMods}
               classType={classType}
               statOrder={statOrder}

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -54,6 +54,7 @@ function getItemStats(
 interface Props {
   set: ArmorSet;
   loadouts: Loadout[];
+  initialLoadoutId?: string;
   lockedMods: PluggableInventoryItemDefinition[];
   classType: DestinyClass;
   statOrder: number[];
@@ -65,10 +66,15 @@ interface Props {
   onClose(): void;
 }
 
-function chooseSimilarLoadout(
+function chooseInitialLoadout(
   setItems: DimItem[],
-  useableLoadouts: Loadout[]
+  useableLoadouts: Loadout[],
+  initialLoadoutId?: string
 ): Loadout | undefined {
+  const loadoutFromInitialId = useableLoadouts.find((lo) => lo.id === initialLoadoutId);
+  if (loadoutFromInitialId) {
+    return loadoutFromInitialId;
+  }
   const exotic = setItems.find((i) => i.isExotic);
   return (
     (exotic && useableLoadouts.find((l) => l.items.some((i) => i.hash === exotic.hash))) ||
@@ -78,6 +84,7 @@ function chooseSimilarLoadout(
 
 export default function CompareDrawer({
   loadouts,
+  initialLoadoutId,
   set,
   lockedMods,
   classType,
@@ -97,7 +104,7 @@ export default function CompareDrawer({
   const setItems = set.armor.map((items) => items[0]);
 
   const [selectedLoadout, setSelectedLoadout] = useState<Loadout | undefined>(
-    chooseSimilarLoadout(setItems, useableLoadouts)
+    chooseInitialLoadout(setItems, useableLoadouts, initialLoadoutId)
   );
 
   const allItems = useSelector(allItemsSelector);

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -103,7 +103,7 @@ export default function CompareDrawer({
 
   const setItems = set.armor.map((items) => items[0]);
 
-  const [selectedLoadout, setSelectedLoadout] = useState<Loadout | undefined>(
+  const [selectedLoadout, setSelectedLoadout] = useState<Loadout | undefined>(() =>
     chooseInitialLoadout(setItems, useableLoadouts, initialLoadoutId)
   );
 


### PR DESCRIPTION
If a loadout is opened in the optimiser, this will ensure it is the initially selected loadout in the compare drawer.