### PR TITLE
SetStats: show stat Tiers above T10 or below T0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Loadout notes now retain whitespace formatting.
 * Added new filter "is:stackfull" to show items that are at max stack size.
 * When re-Optimizing a loadout, the Loadout Optimizer's Compare button will now initially select the original loadout from the loadout page.
+* Armor set stats in Loadout Optimizer or Loadout Details will now show stat tiers exceeding T10 or going below T0.
 
 ### Beta Only
 

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -8,7 +8,7 @@ import { DestinyClass, DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React from 'react';
 import { ArmorStatHashes, ArmorStats } from '../types';
-import { statTierWithHalf } from '../utils';
+import { remEuclid, statTierWithHalf } from '../utils';
 import styles from './SetStats.m.scss';
 import { calculateTotalTier, sumEnabledStats } from './utils';
 
@@ -117,7 +117,7 @@ function Stat({
     >
       <span
         className={clsx({
-          [styles.halfTierValue]: isActive && value % 10 >= 5,
+          [styles.halfTierValue]: isActive && remEuclid(value, 10) >= 5,
         })}
       >
         <b>

--- a/src/app/loadout-builder/utils.test.ts
+++ b/src/app/loadout-builder/utils.test.ts
@@ -3,6 +3,7 @@ import { statTierWithHalf } from './utils';
 describe('statTierWithHalf', () => {
   test('checks proper visual tier formatting', () => {
     expect(statTierWithHalf(-13)).toBe('-1.5');
+    expect(statTierWithHalf(-10)).toBe('-1');
     expect(statTierWithHalf(-7)).toBe('-1');
     expect(statTierWithHalf(-3)).toBe('-0.5');
     expect(statTierWithHalf(0)).toBe('0');

--- a/src/app/loadout-builder/utils.test.ts
+++ b/src/app/loadout-builder/utils.test.ts
@@ -1,0 +1,15 @@
+import { statTierWithHalf } from './utils';
+
+describe('statTierWithHalf', () => {
+  test('checks proper visual tier formatting', () => {
+    expect(statTierWithHalf(-13)).toBe('-1.5');
+    expect(statTierWithHalf(-7)).toBe('-1');
+    expect(statTierWithHalf(-3)).toBe('-0.5');
+    expect(statTierWithHalf(0)).toBe('0');
+    expect(statTierWithHalf(7)).toBe('0.5');
+    expect(statTierWithHalf(100)).toBe('10');
+    expect(statTierWithHalf(103)).toBe('10');
+    expect(statTierWithHalf(107)).toBe('10.5');
+    expect(statTierWithHalf(127)).toBe('12.5');
+  });
+});

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -21,6 +21,14 @@ export function statTierWithHalf(stat: number) {
   }`;
 }
 
+/**
+ * Calculates the remainder of euclidean division `dividend / divisor`,
+ * i.e. returns `rem` such that `dividend = divisor * n + rem` and
+ * `0 <= rem < |divisor|`.
+ * Remainder is always non-negative, behavior differs from `%` for
+ * negative dividends. Find comparisons at
+ * https://en.wikipedia.org/wiki/Modulo_operation#Variants_of_the_definition
+ */
 export function remEuclid(dividend: number, divisor: number) {
   return ((dividend % divisor) + divisor) % divisor;
 }

--- a/src/app/loadout-builder/utils.ts
+++ b/src/app/loadout-builder/utils.ts
@@ -2,17 +2,27 @@ import { DimItem } from 'app/inventory/item-types';
 import _ from 'lodash';
 import { ProcessItem } from './process-worker/types';
 
-/** Gets the stat tier from a stat value. */
+/** Gets the effective stat tier from a stat value, clamping between 0-10 */
 export function statTier(stat: number) {
   return _.clamp(Math.floor(stat / 10), 0, 10);
 }
 
 /**
- * Gets the stat tier plus a .5 if stat % 10 >= 5.
+ * Gets the stat tier plus a .5, without clamping even when exceeding T10 or going below T0.
  * To be used for display purposed only.
  */
 export function statTierWithHalf(stat: number) {
-  return `${_.clamp(Math.floor(stat / 10), 0, 10)}${stat % 10 >= 5 ? '.5' : ''}`;
+  const base_tier = Math.floor(stat / 10);
+  // ensure (-3 mod 10) results in a remainder of 7 and a stat of -0.5
+  const point_five = remEuclid(stat, 10) >= 5;
+  const sign = base_tier < 0 ? '-' : '';
+  return `${sign}${base_tier < 0 && point_five ? Math.abs(base_tier + 1) : Math.abs(base_tier)}${
+    point_five ? '.5' : ''
+  }`;
+}
+
+export function remEuclid(dividend: number, divisor: number) {
+  return ((dividend % divisor) + divisor) % divisor;
 }
 
 /**


### PR DESCRIPTION
Not only is it inconsistent that the UI caps stats at 10 but adds a .5, but LO showed me a 119 recovery set as T10.5 recovery, which is even more wrong.