### PR TITLE
Add plug subtype to tooltips

### DIFF
--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -26,12 +26,16 @@
   h2,
   h3 {
     background-color: #444;
-    margin: 0 0 4px 0;
+  }
+  h2 {
     font-size: 14px;
+    margin: 0 0 4px 0;
     @include destiny-header;
   }
   h3 {
     font-size: 12px;
+    margin: -4px 0 4px 0;
+    opacity: 0.5;
   }
 
   hr {

--- a/src/app/item-popup/ItemPerksList.tsx
+++ b/src/app/item-popup/ItemPerksList.tsx
@@ -154,7 +154,12 @@ function PerkPlug({
       </div>
       {selectedPerk ? (
         <div className={styles.perkInfo}>
-          <DimPlugTooltip item={item} plug={plug} wishlistRoll={wishlistRoll} />
+          <DimPlugTooltip
+            item={item}
+            plug={plug}
+            wishlistRoll={wishlistRoll}
+            hidePlugSubtype={true}
+          />
         </div>
       ) : (
         selected &&

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -5,7 +5,7 @@ import { statAllowList } from 'app/inventory/store/stats';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { thumbsUpIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
-import { emptySpecialtySocketHashes, isPlugStatActive } from 'app/utils/item-utils';
+import { isPlugStatActive } from 'app/utils/item-utils';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import {
   DestinyInventoryItemDefinition,
@@ -117,7 +117,7 @@ export function PlugTooltip({
   return (
     <>
       <h2>{def.displayProperties.name}</h2>
-      {emptySpecialtySocketHashes.includes(def.hash) && <h3>{def.itemTypeDisplayName}</h3>}
+      {def.itemTypeDisplayName && <h3>{def.itemTypeDisplayName}</h3>}
 
       {def.displayProperties.description ? (
         <div>

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -23,10 +23,12 @@ export function DimPlugTooltip({
   item,
   plug,
   wishlistRoll,
+  hidePlugSubtype,
 }: {
   item: DimItem;
   plug: DimPlug;
   wishlistRoll?: InventoryWishListRoll;
+  hidePlugSubtype?: boolean;
 }) {
   // TODO: show insertion costs
 
@@ -68,6 +70,7 @@ export function DimPlugTooltip({
       enableFailReasons={plug.enableFailReasons}
       cannotCurrentlyRoll={plug.cannotCurrentlyRoll}
       wishListTip={wishListTip}
+      hidePlugSubtype={hidePlugSubtype}
     />
   );
 }
@@ -89,6 +92,7 @@ export function PlugTooltip({
   enableFailReasons,
   cannotCurrentlyRoll,
   wishListTip,
+  hidePlugSubtype,
 }: {
   def: DestinyInventoryItemDefinition;
   perks?: DestinySandboxPerkDefinition[];
@@ -97,6 +101,7 @@ export function PlugTooltip({
   enableFailReasons?: string;
   cannotCurrentlyRoll?: boolean;
   wishListTip?: string;
+  hidePlugSubtype?: boolean;
 }) {
   const defs = useD2Definitions();
   const sourceString =
@@ -117,7 +122,7 @@ export function PlugTooltip({
   return (
     <>
       <h2>{def.displayProperties.name}</h2>
-      {def.itemTypeDisplayName && <h3>{def.itemTypeDisplayName}</h3>}
+      {!hidePlugSubtype && def.itemTypeDisplayName && <h3>{def.itemTypeDisplayName}</h3>}
 
       {def.displayProperties.description ? (
         <div>

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -121,7 +121,7 @@ export const SocketDetailsMod = React.memo(
       <div
         role="button"
         className={clsx('item', className)}
-        title={itemDef.displayProperties.name}
+        title={`${itemDef.displayProperties.name}\n${itemDef.itemTypeDisplayName}`}
         onClick={onClickFn}
         tabIndex={0}
       >

--- a/src/app/loadout/loadout-ui/Mod.tsx
+++ b/src/app/loadout/loadout-ui/Mod.tsx
@@ -22,7 +22,7 @@ function Mod({ plugDef, gridColumn, large, onClick }: Props) {
         [styles.largeItem]: large,
       })}
       style={gridColumn ? { gridColumn } : undefined}
-      title={plugDef.displayProperties.name}
+      title={`${plugDef.displayProperties.name}\n${plugDef.itemTypeDisplayName}`}
       tabIndex={0}
       onClick={onClick}
     >


### PR DESCRIPTION
This PR closes #7473 .

![dim-item-subtype-tooltips](https://user-images.githubusercontent.com/17512262/147381134-e266771f-6c8e-47d7-99a3-72097ecab930.png)

Having to explicitly hide the subtype for the selected perk in the item popup is not ideal, but I think it feels too cluttered if we don't.