### PR TITLE
Fix perk search for languages with accents

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 * The Loadouts page can be filtered from the search bar in the header.
 * When re-Optimizing a loadout, the Loadout Optimizer's Compare button will now initially select the original loadout from the loadout page.
 * Armor set stats in Loadout Optimizer or Loadout Details will now show stat tiers exceeding T10 or going below T0.
+* Searching by perk now works on languages that use accented characters.
 
 ### Beta Only
 

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -4,6 +4,7 @@ import { ArmorSlotIcon, WeaponSlotIcon, WeaponTypeIcon } from 'app/dim-ui/ItemCa
 import { SpecialtyModSlotIcon } from 'app/dim-ui/SpecialtyModSlotIcon';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
+import { quoteFilterString } from 'app/search/search-filters/freeform';
 import { getInterestingSocketMetadatas, getItemDamageShortName } from 'app/utils/item-utils';
 import { getWeaponArchetype } from 'app/utils/socket-utils';
 import rarityIcons from 'data/d2/engram-rarity-icons.json';
@@ -161,7 +162,7 @@ export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
         ' ' +
         (exampleItem.destinyVersion === 2 && intrinsic
           ? // TODO: add a search by perk hash? It'd be slightly different than searching by name
-            `perkname:"${intrinsic.displayProperties.name}"`
+            `perkname:${quoteFilterString(intrinsic.displayProperties.name)}`
           : `stat:rpm:${getRpm(exampleItem)}`) +
         ')',
     },

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -26,6 +26,7 @@ import { recoilValue } from 'app/item-popup/RecoilStat';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { CUSTOM_TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 import { statHashByName } from 'app/search/search-filter-values';
+import { quoteFilterString } from 'app/search/search-filters/freeform';
 import { getColor, percent } from 'app/shell/filters';
 import {
   AppIcon,
@@ -238,7 +239,7 @@ export function getColumns(
       id: 'name',
       header: t('Organizer.Columns.Name'),
       value: (i) => i.name,
-      filter: (name) => `name:"${name}"`,
+      filter: (name: string) => `name:${quoteFilterString(name)}`,
     },
     !isGhost && {
       id: 'power',
@@ -409,7 +410,7 @@ export function getColumns(
             )
           );
         },
-        filter: (value) => `perkname:"${value}"`,
+        filter: (value: string) => `perkname:${quoteFilterString(value)}`,
       },
     (destinyVersion === 2 || isWeapon) && {
       id: 'breaker',
@@ -437,7 +438,8 @@ export function getColumns(
         ),
       noSort: true,
       gridWidth: 'minmax(324px,max-content)',
-      filter: (value) => (value !== 0 ? `perkname:"${value}"` : undefined),
+      filter: (value) =>
+        typeof value === 'string' ? `perkname:${quoteFilterString(value)}` : undefined,
     },
     destinyVersion === 2 &&
       isWeapon && {
@@ -449,7 +451,8 @@ export function getColumns(
         ),
         noSort: true,
         gridWidth: 'minmax(180px,max-content)',
-        filter: (value) => (value !== 0 ? `perkname:"${value}"` : undefined),
+        filter: (value) =>
+          typeof value === 'string' ? `perkname:${quoteFilterString(value)}` : undefined,
       },
     ...statColumns,
     ...baseStatColumns,
@@ -533,7 +536,7 @@ export function getColumns(
       value: (item) => getNotes(item, itemInfos),
       cell: (_val, item) => <NotesArea item={item} minimal={true} />,
       gridWidth: 'minmax(200px, 1fr)',
-      filter: (value) => `notes:"${value}"`,
+      filter: (value: string) => `notes:${quoteFilterString(value)}`,
     },
     isWeapon &&
       hasWishList && {
@@ -541,7 +544,7 @@ export function getColumns(
         header: t('Organizer.Columns.WishListNotes'),
         value: (item) => wishList(item)?.notes?.trim() ?? '',
         gridWidth: 'minmax(200px, 1fr)',
-        filter: (value) => `wishlistnotes:"${value}"`,
+        filter: (value: string) => `wishlistnotes:${quoteFilterString(value)}`,
       },
   ]);
 

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -119,7 +119,7 @@ const freeformFilters: FilterDefinition[] = [
     description: tl('Filter.Perk'),
     format: 'freeform',
     filter: ({ filterValue, language }) => {
-      const startWord = startWordRegexp(filterValue, language);
+      const startWord = startWordRegexp(plainString(filterValue, language), language);
       return (item) => {
         // TODO: this definitely does too many array allocations to be performant
         const strings = [
@@ -151,7 +151,7 @@ const freeformFilters: FilterDefinition[] = [
       }
     },
     filter: ({ filterValue, language }) => {
-      const startWord = startWordRegexp(filterValue, language);
+      const startWord = startWordRegexp(plainString(filterValue, language), language);
       return (item) => {
         // TODO: this may do too many array allocations to be performant.
         const strings = [


### PR DESCRIPTION
`perkname:` search is apparently so unpopular that nobody had bothered mentioning that it didn't work at all for languages such as Portuguese that have a lot of accented letters. This fixes that.

Tested on the search `perkname:"armação leve"`

This also fixes quoting searches wherever searches need to be quoted.