### PR TITLE
Fix for loadouts that have armour 1.0 items and mods.

### DIFF
--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -731,8 +731,8 @@ function applyLoadoutMods(
     const store = getStore(stores, storeId)!;
 
     // TODO: find cases where the loadout specified armor for a slot to be equipped and it's not equipped, bail if so
+    // Don't filter out items without energy here, the mod assignment algorithm expects 5 items.
     const armor = store.items.filter((i) => i.bucket.inArmor && i.equipped);
-    //const loadoutArmor = loadout.items.filter((i) => i.equipped)
 
     const mods = modHashes.map((h) => defs.InventoryItem.get(h)).filter(isPluggableItem);
 

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -12,6 +12,7 @@ import {
   modTypeTagByPlugCategoryHash,
 } from 'app/search/specialty-modslots';
 import { compareBy } from 'app/utils/comparators';
+import { emptyArray } from 'app/utils/empty';
 import { getModTypeTagByPlugCategoryHash, getSpecialtySocketMetadatas } from 'app/utils/item-utils';
 import { warnLog } from 'app/utils/log';
 import { getSocketByIndex, getSocketsByIndexes } from 'app/utils/socket-utils';
@@ -439,6 +440,10 @@ export function createPluggingStrategy(
   // stuff we MAY apply, if we need more energy freed up
   const optionalRegains: PluggingAction[] = [];
 
+  if (!item.energy) {
+    return emptyArray();
+  }
+
   for (const assignment of assignments) {
     const destinationSocket = getSocketByIndex(item.sockets!, assignment.socketIndex)!;
     const existingModCost = destinationSocket.plugged?.plugDef.plug.energyCost?.energyCost || 0;
@@ -467,8 +472,8 @@ export function createPluggingStrategy(
 
   const operationSet: PluggingAction[] = [];
 
-  const itemTotalEnergy = item.energy!.energyCapacity;
-  let itemCurrentUsedEnergy = item.energy!.energyUsed;
+  const itemTotalEnergy = item.energy.energyCapacity;
+  let itemCurrentUsedEnergy = item.energy.energyUsed;
 
   // apply all required regains first
   for (const regainOperation of requiredRegains) {


### PR DESCRIPTION
This fixes the error thrown when you apply mods to a loadout that has an equipped armour item that isn't armour 2.0. In my case I used something from vanilla d2 so I think it should be good.

Fixes #7512 