### PR TITLE
Use LoadoutView in compare drawer.

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -499,15 +499,13 @@ function LoadoutBuilder({
           ReactDOM.createPortal(
             <CompareDrawer
               set={compareSet}
+              selectedStore={selectedStore}
               loadouts={loadouts}
               initialLoadoutId={preloadedLoadout?.id}
               lockedMods={lockedMods}
               subclass={subclass}
               classType={classType}
-              statOrder={statOrder}
-              enabledStats={enabledStats}
               upgradeSpendTier={upgradeSpendTier}
-              lockItemEnergyType={lockItemEnergyType}
               params={params}
               notes={notes}
               onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -502,10 +502,8 @@ function LoadoutBuilder({
               selectedStore={selectedStore}
               loadouts={loadouts}
               initialLoadoutId={preloadedLoadout?.id}
-              lockedMods={lockedMods}
               subclass={subclass}
               classType={classType}
-              upgradeSpendTier={upgradeSpendTier}
               params={params}
               notes={notes}
               onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.m.scss
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.m.scss
@@ -35,51 +35,6 @@
   margin-bottom: 4px;
 }
 
-.set {
-  display: flex;
-  flex-flow: row nowrap;
-  padding: 0;
-
-  @include phone-portrait {
-    flex-direction: column;
-  }
-}
-
-.item {
-  display: grid;
-  grid-template-areas:
-    'item sockets'
-    'button sockets';
-  gap: 6px;
-  width: min-content;
-  align-items: start;
-  justify-content: start;
-  margin: 7px 0 14px 0;
-
-  @include phone-portrait {
-    grid-template-columns: min-content min-content 1fr;
-    grid-template-areas: 'item sockets button';
-    width: 100%;
-  }
-
-  > *:first-child {
-    grid-area: item;
-  }
-
-  > :last-child {
-    margin-right: 0;
-  }
-}
-
-.unassigned {
-  margin-bottom: 8px;
-}
-
-.unassignedMods {
-  display: flex;
-  flex-direction: row;
-}
-
 .noLoadouts {
   margin: 16px;
   font-size: 14px;

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.m.scss.d.ts
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.m.scss.d.ts
@@ -4,14 +4,10 @@ interface CssExports {
   'content': string;
   'fillRow': string;
   'header': string;
-  'item': string;
   'loadoutName': string;
   'noLoadouts': string;
-  'set': string;
   'setHeader': string;
   'setTitle': string;
-  'unassigned': string;
-  'unassignedMods': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -32,10 +32,12 @@ export default function LoadoutView({
   loadout,
   store,
   actionButtons,
+  hideOptimizeArmor,
 }: {
   loadout: Loadout;
   store: DimStore;
   actionButtons: ReactNode[];
+  hideOptimizeArmor?: boolean;
 }) {
   const defs = useD2Definitions()!;
   const buckets = useSelector(bucketsSelector)!;
@@ -95,6 +97,7 @@ export default function LoadoutView({
                 savedMods={savedMods}
                 equippedItemIds={equippedItemIds}
                 loadout={loadout}
+                hideOptimizeArmor={hideOptimizeArmor}
               />
             ))}
             {savedMods.length > 0 ? (

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -32,6 +32,7 @@ export default function LoadoutItemCategorySection({
   savedMods,
   equippedItemIds,
   loadout,
+  hideOptimizeArmor,
 }: {
   category: string;
   subclass?: DimLoadoutItem;
@@ -39,6 +40,7 @@ export default function LoadoutItemCategorySection({
   savedMods: PluggableInventoryItemDefinition[];
   equippedItemIds: Set<string>;
   loadout: Loadout;
+  hideOptimizeArmor?: boolean;
 }) {
   const defs = useD2Definitions()!;
   const buckets = useSelector(bucketsSelector)!;
@@ -81,7 +83,7 @@ export default function LoadoutItemCategorySection({
             </div>
           )}
           {loadout.parameters && <LoadoutParametersDisplay params={loadout.parameters} />}
-          <OptimizerButton loadout={loadout} />
+          {!hideOptimizeArmor && <OptimizerButton loadout={loadout} />}
         </>
       )}
     </div>


### PR DESCRIPTION
This uses the same view from the loadout page in the compare drawer.

Things to note
- We aren't showing the overall tier. I think that maybe we should add that to the `LoadoutView` rather then tacking it on somewhere here.
- We are replacing the items in the loadout with the items from LO, this means the user will see all their other stuff in both loadouts shown here (see second pic)

### PR's
- https://github.com/DestinyItemManager/DIM/pull/7566
- https://github.com/DestinyItemManager/DIM/pull/7568 **(this one)**

<img width="1210" alt="Screen Shot 2021-12-27 at 11 13 15 pm" src="https://user-images.githubusercontent.com/7344652/147471015-d7c73727-27d3-4d87-99e7-7b49bcbbbd67.png">

<img width="1170" alt="Screen Shot 2021-12-27 at 11 20 05 pm" src="https://user-images.githubusercontent.com/7344652/147471294-ff359fc0-15b7-451e-b838-d393b9b7e5ba.png">
