### PR TITLE
Handle subclasses properly in loadouts and socket overrides application

### DIFF
--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -49,6 +49,7 @@ function ItemPicker({
   filters,
   itemSortOrder,
   sortBy,
+  uniqueBy,
   ignoreSelectedPerks,
   onItemSelected,
   onCancel,
@@ -81,8 +82,11 @@ function ItemPicker({
     if (sortBy) {
       items = _.sortBy(items, sortBy);
     }
+    if (uniqueBy) {
+      items = _.uniqBy(items, uniqueBy);
+    }
     return items;
-  }, [allItems, filter, itemSortOrder, sortBy]);
+  }, [allItems, filter, itemSortOrder, sortBy, uniqueBy]);
 
   return (
     <Sheet

--- a/src/app/item-picker/item-picker.ts
+++ b/src/app/item-picker/item-picker.ts
@@ -10,6 +10,7 @@ export interface ItemPickerOptions {
   filterItems?(item: DimItem): boolean;
   /** An extra sort function that items will be sorted by (beyond the default sort chosen by the user)  */
   sortBy?(item: DimItem): unknown;
+  uniqueBy?(item: DimItem): unknown;
 }
 
 interface ItemSelectResult {

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -48,8 +48,12 @@ export default function LoadoutView({
   // Turn loadout items into real DimItems, filtering out unequippable items
   const [items, subclass, warnitems] = useMemo(() => {
     const [items, warnitems] = getItemsFromLoadoutItems(loadout.items, defs, buckets, allItems);
+    const subclass = store.items.find(
+      (item) =>
+        item.bucket.hash === BucketHashes.Subclass &&
+        items.some((loadoutItem) => item.hash === loadoutItem.hash)
+    );
     let equippableItems = items.filter((i) => itemCanBeEquippedBy(i, store, true));
-    const subclass = equippableItems.find((i) => i.bucket.hash === BucketHashes.Subclass);
     if (subclass) {
       equippableItems = equippableItems.filter((i) => i !== subclass);
     }

--- a/src/app/loadout/item-utils.ts
+++ b/src/app/loadout/item-utils.ts
@@ -22,6 +22,9 @@ export async function pickSubclass(filterItems: (item: DimItem) => boolean) {
       filterItems: (item: DimItem) => item.bucket.type === 'Class' && filterItems(item),
       // We can only sort so that the classes are grouped and stasis comes first
       sortBy: (item) => `${item.classType}-${item.energy?.energyType}`,
+      // We only want to show a single instance of a given subclass, we reconcile them by their hash from
+      // the appropriate store at render time
+      uniqueBy: (item) => item.hash,
       prompt: t('Loadouts.ChooseItem', { name: t('Bucket.Class') }),
 
       // don't show information related to selected perks so we don't give the impression


### PR DESCRIPTION
This should hopefully fix the subclass issues for people who have multiple characters of the same class type.

I won't add to the changelog until I verify it with our user having the issues.

Might solve #7524 