### PR TITLE
Store header on Android UI issue with positioning when tray open

### DIFF
--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -311,8 +311,6 @@ function useLockSheetContents(sheetContents: React.MutableRefObject<HTMLDivEleme
       if (sheetContents.current) {
         sheetContents.current.addEventListener('touchstart', blockEvents);
         if (mobile) {
-          document.body.classList.add('body-scroll-lock');
-          enableBodyScroll(sheetContents.current);
           disableBodyScroll(sheetContents.current);
         }
       }
@@ -323,9 +321,6 @@ function useLockSheetContents(sheetContents: React.MutableRefObject<HTMLDivEleme
   useLayoutEffect(
     () => () => {
       if (sheetContents.current) {
-        setTimeout(() => {
-          document.body.classList.remove('body-scroll-lock');
-        }, 0);
         sheetContents.current.removeEventListener('touchstart', blockEvents);
         if (mobile) {
           enableBodyScroll(sheetContents.current);

--- a/src/app/inventory/HeaderShadowDiv.m.scss
+++ b/src/app/inventory/HeaderShadowDiv.m.scss
@@ -4,7 +4,7 @@
   height: 1px;
   box-shadow: 0 1px 4px 0 black;
   width: 100%;
-  position: sticky;
+  position: fixed;
   left: 0;
   top: calc(var(--store-header-height) + var(--header-height) - 1px);
   z-index: 9;

--- a/src/app/inventory/Stores.scss
+++ b/src/app/inventory/Stores.scss
@@ -7,6 +7,7 @@
 .inventory-content {
   margin: 0 auto;
   width: 100%;
+  margin-top: var(--store-header-height);
 
   .title {
     top: 124px;
@@ -26,10 +27,6 @@
     min-width: auto;
     // Give room for the category selector strip (height 53px)
     padding-bottom: calc(#{53px + 10px} + env(safe-area-inset-bottom));
-  }
-
-  .body-scroll-lock & {
-    margin-top: var(--store-header-height);
   }
 }
 
@@ -213,12 +210,6 @@
 
   &:focus {
     outline: none;
-  }
-  @supports (position: sticky) {
-    position: sticky;
-  }
-  .body-scroll-lock & {
-    position: fixed;
   }
   &.sticky {
     box-shadow: 0 1px 4px 0 black;


### PR DESCRIPTION
Seems to only have been an issue on Android. Quickly tested using an emulator for safari and it looks the same.

| | before|after|
|----|----|----|
| Item detail open, shadow in wrong spot (shown even though we're scrolled to top. If you're scrolled down the page, the shadow isn't shown at all.) When the tray goes away, shadow is correctly shown. With the fix the shadows just always in the right spot.  |![Screenshot_20211229-133912](https://user-images.githubusercontent.com/424158/147705417-fcbc2478-1593-4c28-afaf-7f9fa7c4e9b7.png)|![Screenshot_20211229-133941](https://user-images.githubusercontent.com/424158/147705480-0d49b576-43c6-4573-a4e6-78d9b0d985b5.png)|
| Compare open, weird top padding | ![Screenshot_20211229-133900](https://user-images.githubusercontent.com/424158/147705461-64c0bf47-c619-47c1-a0a0-4d7e4302d0e6.png)|![Screenshot_20211229-133944](https://user-images.githubusercontent.com/424158/147705483-04bb2bbc-f620-4e1a-8a89-503811ddb64b.png)|
