### PR TITLE
Ignore element affinity when choosing compare dupes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * You can now select Stasis subclasses in the Loadout Optimizer and use the stat effects from fragments.
 * When determining mod assignments, DIM will now consider in game mod placement and attempt to use the same position if possible.
 * Tracked Triumphs are now grouped together with similar records.
+* Starting the Compare view from a single armor piece now includes other elements in initial comparison.
 
 ## 6.97.1 <span class="changelog-date">(2021-12-26)</span>
 

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -130,16 +130,23 @@ const getRpm = (i: DimItem) => {
 };
 
 /**
+ * Strips the (Timelost) or (Adept) suffixes for the user's language
+ * in order to include adept items in non-adept comparisons and vice versa.
+ */
+export const stripAdept = (name: string) =>
+  name
+    .replace(new RegExp(t('Filter.Adept'), 'gi'), '')
+    .trim()
+    .replace(new RegExp(t('Filter.Timelost'), 'gi'), '')
+    .trim();
+
+/**
  * Generate possible comparisons for weapons, given a reference item.
  */
 export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
   const intrinsic = getWeaponArchetype(exampleItem);
   const intrinsicName = intrinsic?.displayProperties.name || t('Compare.Archetype');
-  const adeptStripped = exampleItem.name
-    .replace(new RegExp(t('Filter.Adept'), 'gi'), '')
-    .trim()
-    .replace(new RegExp(t('Filter.Timelost'), 'gi'), '')
-    .trim();
+  const adeptStripped = stripAdept(exampleItem.name);
 
   let comparisonSets: CompareButton[] = _.compact([
     // same weapon type

--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -2,9 +2,9 @@ import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { showNotification } from 'app/notifications/notifications';
 import { getSelectionTree } from 'app/organizer/ItemTypeSelector';
-import { getItemDamageShortName } from 'app/utils/item-utils';
 import { ActionType, getType, Reducer } from 'typesafe-actions';
 import * as actions from './actions';
+import { stripAdept } from './compare-buttons';
 
 export interface CompareSession {
   /**
@@ -121,9 +121,7 @@ function addCompareItem(state: CompareState, item: DimItem): CompareState {
     const itemCategoryHashes = getItemCategoryHashesFromExampleItem(item);
 
     const itemNameQuery = item.bucket.inWeapons
-      ? `name:"${item.name.replace(new RegExp(t('Filter.Adept'), 'gi'), '').trim()}"`
-      : item.element
-      ? `(name:"${item.name}" is:${getItemDamageShortName(item)})`
+      ? `name:"${stripAdept(item.name)}"`
       : `name:"${item.name}"`;
 
     return {


### PR DESCRIPTION
Also a fix for incomplete adept suffix removal that I couldn't test because I don't currently own any non-timelost versions of VoG guns.

Fixes #7204.