### PR TITLE
Hide the support and shop buttons on the iOS app

### DIFF
--- a/src/app/shell/About.tsx
+++ b/src/app/shell/About.tsx
@@ -37,7 +37,12 @@ const discordLink = 'https://discord.gg/UK2GWC7';
 const wikiLink = 'https://destinyitemmanager.fandom.com/wiki/Destiny_Item_Manager_Wiki';
 
 export default function About() {
+  const iOSApp = document.cookie.includes('app-platform=iOS App Store;');
+
   useEffect(() => {
+    if (iOSApp) {
+      return;
+    }
     const script = document.createElement('script');
 
     script.src = 'https://opencollective.com/dim/banner.js?style={"h2":{"color":"white"}}';
@@ -48,7 +53,7 @@ export default function About() {
     return () => {
       delete window.OC;
     };
-  }, []);
+  }, [iOSApp]);
 
   const token = getToken();
   return (
@@ -87,30 +92,34 @@ export default function About() {
         )}
       </ul>
       <div className={styles.social}>
-        <div>
-          <h2>
-            <ExternalLink href={openCollectiveLinkDirect}>
-              <AppIcon icon={heartIcon} /> {t('Views.Support.Support')}
-            </ExternalLink>
-          </h2>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: t('Views.Support.OpenCollective', { link: openCollectiveLink }),
-            }}
-          />
-        </div>
-        <div>
-          <h2>
-            <ExternalLink href={storeLinkDirect}>
-              <AppIcon icon={faTshirt} /> {t('Header.Shop')}
-            </ExternalLink>
-          </h2>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: t('Views.Support.Store', { link: storeLink }),
-            }}
-          />
-        </div>
+        {!iOSApp && (
+          <div>
+            <h2>
+              <ExternalLink href={openCollectiveLinkDirect}>
+                <AppIcon icon={heartIcon} /> {t('Views.Support.Support')}
+              </ExternalLink>
+            </h2>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: t('Views.Support.OpenCollective', { link: openCollectiveLink }),
+              }}
+            />
+          </div>
+        )}
+        {!iOSApp && (
+          <div>
+            <h2>
+              <ExternalLink href={storeLinkDirect}>
+                <AppIcon icon={faTshirt} /> {t('Header.Shop')}
+              </ExternalLink>
+            </h2>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: t('Views.Support.Store', { link: storeLink }),
+              }}
+            />
+          </div>
+        )}
         <div>
           <h2>
             <ExternalLink href={twitterLink}>
@@ -207,17 +216,21 @@ export default function About() {
         <dd>{t('Views.About.FAQAccessAnswer')}</dd>
       </dl>
 
-      <h1>{t('Views.Support.Support')}</h1>
-      <p>{t('Views.Support.FreeToDownload')}</p>
-      <p>
-        <span
-          dangerouslySetInnerHTML={{
-            __html: t('Views.Support.OpenCollective', { link: openCollectiveLink }),
-          }}
-        />{' '}
-        {t('Views.Support.BackersDetail')}
-      </p>
-      <div id="opencollective" />
+      {!iOSApp && (
+        <>
+          <h1>{t('Views.Support.Support')}</h1>
+          <p>{t('Views.Support.FreeToDownload')}</p>
+          <p>
+            <span
+              dangerouslySetInnerHTML={{
+                __html: t('Views.Support.OpenCollective', { link: openCollectiveLink }),
+              }}
+            />{' '}
+            {t('Views.Support.BackersDetail')}
+          </p>
+          <div id="opencollective" />
+        </>
+      )}
     </StaticPage>
   );
 }

--- a/src/app/shell/About.tsx
+++ b/src/app/shell/About.tsx
@@ -40,12 +40,10 @@ export default function About() {
   const iOSApp = document.cookie.includes('app-platform=iOS App Store;');
 
   useEffect(() => {
-    if (iOSApp) {
-      return;
-    }
     const script = document.createElement('script');
 
-    script.src = 'https://opencollective.com/dim/banner.js?style={"h2":{"color":"white"}}';
+    script.src =
+      'https://opencollective.com/dim/banner.js?style={"a":{"display":"none"}, "h2":{"color":"white"}}';
     script.async = true;
 
     document.getElementById('opencollective')!.appendChild(script);
@@ -226,11 +224,11 @@ export default function About() {
                 __html: t('Views.Support.OpenCollective', { link: openCollectiveLink }),
               }}
             />{' '}
-            {t('Views.Support.BackersDetail')}
           </p>
-          <div id="opencollective" />
+          {t('Views.Support.BackersDetail')}
         </>
       )}
+      <div id="opencollective" />
     </StaticPage>
   );
 }


### PR DESCRIPTION
We set a cookie in the app shell, so we can just look for that to see if we should hide the links to donate/purchase outside of Apples ecosystem.

> We noticed that your app allows users to contribute donations to the development of your app with a mechanism other than the in-app purchase API, which is not appropriate for the App Store.

> To resolve this issue, please revise your app to use the in-app purchase API to pay for this type of transaction. Please note that even though tipping another individual is optional, the tip is connected to or associated with the receipt of digital content or services in your app and must be purchased through in-app purchase in accordance with guideline 3.1.1 of the App Store Review Guidelines.

![attachment Screenshot+2021-12-30+at+08 52 30](https://user-images.githubusercontent.com/424158/147788877-005792fe-a7d4-49ef-9720-cf9fec850f1d.jpeg)


The open collective container at the bottom also has a link to open collective. I updated the URL to set a style to just hide it from view so we can still show the existing backers/supporters, should be fine for getting us past the review process. They didn't explicitly circle the Shop section, but I just hid it in anticipation. 

| | |
|----|----|
|non-app store|<img width="1279" alt="Screen Shot 2021-12-30 at 1 18 24 PM" src="https://user-images.githubusercontent.com/424158/147788633-f5e087e1-5cea-4818-894f-ff79f34cce1f.png">|
|app store|<img width="1279" alt="Screen Shot 2021-12-30 at 1 30 40 PM" src="https://user-images.githubusercontent.com/424158/147789332-e5768806-bef2-4f09-99a4-8abc88fbcd79.png">|