### PR TITLE
Workaround for bungie API incorrectly saying users haven't unlocked stasis aspects.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-* Fixed issue for some users where stasis aspects were not being shown when selecting stasis subclass options. This is a workaround for a bungie API issue and will allow users that have not unlocked aspects to try and equip them, resulting in failures with applying loadouts if the aspects are not unlocked.
+* Fixed issue for some users where stasis aspects were not being shown when selecting stasis subclass options. This is a workaround for a Bungie API issue and will allow users that have not unlocked aspects to try and equip them, resulting in failures with applying loadouts if the aspects are not unlocked.
 
 ## 6.97.2 <span class="changelog-date">(2021-12-30)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed issue for some users where stasis aspects were not being shown when selecting stasis subclass options. This is a workaround for a bungie API issue and will allow users that have not unlocked aspects to try and equip them, resulting in failures with applying loadouts if the aspects are not unlocked.
+
 ## 6.97.2 <span class="changelog-date">(2021-12-30)</span>
 
 * Improved the press-to-view tooltips on mobile. It should now be much easier to select perks on mobile.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
-* Fixed issue for some users where stasis aspects were not being shown when selecting stasis subclass options. This is a workaround for a Bungie API issue and will allow users that have not unlocked aspects to try and equip them, resulting in failures with applying loadouts if the aspects are not unlocked.
+* Fixed an issue for some users where Stasis Aspects were not shown when selecting Stasis subclass options.
+  * This works around a Bungie API issue, and will allow users to select and try equipping Stasis Aspects they have not unlocked, which may result in failures applying loadouts, if the aspects are not unlocked.
 
 ## 6.97.2 <span class="changelog-date">(2021-12-30)</span>
 

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -243,7 +243,9 @@ function filterUnlockedPlugsForForProfileAndAllCharacters(
       .flatMap((d) => d.plugs[dimPlugSet.hash])
   );
 
+  // Some users are seeing canInsert be false even when they have unlocked all aspects.
+  // https://github.com/Bungie-net/api/issues/1572
   return dimPlugSet.plugs.filter((plug) =>
-    availablePlugs.some((p) => p.plugItemHash === plug.plugDef.hash && p.canInsert)
+    availablePlugs.some((p) => p.plugItemHash === plug.plugDef.hash)
   );
 }


### PR DESCRIPTION
It appears some users are seeing that they have not unlocked any warlock aspects but claim they have unlocked them all. 

This change will show all aspects to all users, it will just result in loadout apply failures if a user tries to equip an aspect they haven't unlocked. I think this is the lesser of two evils.

Bungie API issue for reference, https://github.com/Bungie-net/api/issues/1572