### PR TITLE
Only prevent text selection on mobile

### DIFF
--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -167,7 +167,9 @@ html,
 body {
   // Disable pull to refresh in Android
   overscroll-behavior: none;
-  user-select: none;
+  @include phone-portrait {
+    user-select: none;
+  }
 }
 
 body {


### PR DESCRIPTION
Adding user-select: none was only an experience improvement on mobile.