### PR TITLE
Disable immer auto-freeze to fix that issue trying to update frozen stats

### DIFF
--- a/src/app/loadout-drawer/loadout-apply-state.ts
+++ b/src/app/loadout-drawer/loadout-apply-state.ts
@@ -2,7 +2,10 @@
 
 import { DimItem } from 'app/inventory/item-types';
 import { Observable } from 'app/utils/observable';
-import produce from 'immer';
+import produce, { setAutoFreeze } from 'immer';
+
+// Immer's auto-freeze can get us in trouble because we do sometimes modify the produced item.
+setAutoFreeze(false);
 
 /**
  * What part of the loadout application process are we currently in?


### PR DESCRIPTION
I think what's happening is that we're modifying items w/ Immer, which deep-freezes them, but then our stats code expects to be able to go update them again while calculating plug stats. Rather than trying to fix this, we can just disable the auto-freeze.