### PR TITLE
Loadout stats

### DIFF
--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -25,6 +25,7 @@
 
 .actions {
   composes: flexRow from '../dim-ui/common.m.scss';
+  flex-flow: row wrap;
   @include horizontal-space-children(4px);
   @include phone-portrait {
     margin-top: 16px;

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -51,6 +51,8 @@ export default function LoadoutItemCategorySection({
       : _.sortBy(Object.keys(itemsByBucket), (bucketType) =>
           buckets.byCategory[category].findIndex((b) => b.type === bucketType)
         );
+  const equippedItems =
+    items?.filter((i) => equippedItemIds.has(i.id) && i.owner !== 'unknown') ?? [];
 
   return (
     <div key={category} className={clsx(styles.itemCategory, categoryStyles[category])}>
@@ -74,10 +76,10 @@ export default function LoadoutItemCategorySection({
       )}
       {category === 'Armor' && items && (
         <>
-          {items.length === 5 && (
+          {equippedItems.length === 5 && (
             <div className="stat-bars destiny2">
               <LoadoutStats
-                stats={getLoadoutStats(defs, loadout.classType, subclass, items, savedMods)}
+                stats={getLoadoutStats(defs, loadout.classType, subclass, equippedItems, savedMods)}
                 characterClass={loadout.classType}
               />
             </div>

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -44,12 +44,13 @@ export default function LoadoutItemCategorySection({
 }) {
   const defs = useD2Definitions()!;
   const buckets = useSelector(bucketsSelector)!;
-  const itemsByBucket = _.groupBy(items, (i) => i.bucket.type);
+  const itemsByBucket = _.groupBy(items, (i) => i.bucket.hash);
   const bucketOrder =
     category === 'Weapons' || category === 'Armor'
-      ? buckets.byCategory[category].map((b) => b.type!)
-      : _.sortBy(Object.keys(itemsByBucket), (bucketType) =>
-          buckets.byCategory[category].findIndex((b) => b.type === bucketType)
+      ? buckets.byCategory[category]
+      : _.sortBy(
+          Object.keys(itemsByBucket).map((bucketHash) => buckets.byHash[parseInt(bucketHash, 10)]),
+          (bucket) => buckets.byCategory[category].findIndex((b) => b.hash === bucket.hash)
         );
   const equippedItems =
     items?.filter((i) => equippedItemIds.has(i.id) && i.owner !== 'unknown') ?? [];
@@ -58,10 +59,10 @@ export default function LoadoutItemCategorySection({
     <div key={category} className={clsx(styles.itemCategory, categoryStyles[category])}>
       {items ? (
         <div className={styles.itemsInCategory}>
-          {bucketOrder.map((bucketType) => (
+          {bucketOrder.map((bucket) => (
             <ItemBucket
-              key={bucketType}
-              items={itemsByBucket[bucketType]}
+              key={bucket.hash}
+              items={itemsByBucket[bucket.hash]}
               equippedItemIds={equippedItemIds}
             />
           ))}


### PR DESCRIPTION
This is broken out from the Fashion Loadouts PR, in order to make that more manageable.

This fixes a bug where loadout stats were only shown if there were exactly 5 armor items in the loadout - whether or not they were equipped! More or less, no stats. Now it always shows stats if there are 5 equipped armor items.

I also fixed the buttons not wrapping on mobile.