### PR TITLE
Fix loadouts showing subclass in the "general" category

### DIFF
--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -55,7 +55,7 @@ export default function LoadoutView({
     );
     let equippableItems = items.filter((i) => itemCanBeEquippedBy(i, store, true));
     if (subclass) {
-      equippableItems = equippableItems.filter((i) => i !== subclass);
+      equippableItems = equippableItems.filter((i) => i.hash !== subclass.hash);
     }
     return [equippableItems, subclass, warnitems];
   }, [loadout.items, defs, buckets, allItems, store]);


### PR DESCRIPTION
#7585 introduced a bug that caused subclass to show up in the "general" category on loadouts:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/313208/147838787-614ec282-81fb-4881-a607-fb90f31dde92.png">
