### PR TITLE
Hide show mod placements button on equipped loadout.

### DIFF
--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -33,11 +33,13 @@ export default function LoadoutView({
   store,
   actionButtons,
   hideOptimizeArmor,
+  hideShowModPlacements,
 }: {
   loadout: Loadout;
   store: DimStore;
   actionButtons: ReactNode[];
   hideOptimizeArmor?: boolean;
+  hideShowModPlacements?: boolean;
 }) {
   const defs = useD2Definitions()!;
   const buckets = useSelector(bucketsSelector)!;
@@ -111,14 +113,16 @@ export default function LoadoutView({
                     <PlugDef key={getModRenderKey(mod)} plug={mod} />
                   ))}
                 </div>
-                <button
-                  className={clsx('dim-button', styles.showModPlacementButton)}
-                  type="button"
-                  title="Show mod placement"
-                  onClick={() => setShowModAssignmentDrawer(true)}
-                >
-                  {t('Loadouts.ShowModPlacement')}
-                </button>
+                {!hideShowModPlacements && (
+                  <button
+                    className={clsx('dim-button', styles.showModPlacementButton)}
+                    type="button"
+                    title="Show mod placement"
+                    onClick={() => setShowModAssignmentDrawer(true)}
+                  >
+                    {t('Loadouts.ShowModPlacement')}
+                  </button>
+                )}
               </div>
             ) : (
               <div className={styles.modsPlaceholder}>{t('Loadouts.Mods')}</div>

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -237,5 +237,12 @@ function LoadoutRow({
     return actionButtons;
   }, [dispatch, equippable, loadout, saved, store]);
 
-  return <LoadoutView loadout={loadout} store={store} actionButtons={actionButtons} />;
+  return (
+    <LoadoutView
+      loadout={loadout}
+      store={store}
+      actionButtons={actionButtons}
+      hideShowModPlacements={!equippable}
+    />
+  );
 }


### PR DESCRIPTION
This hides the "Show mod placements" button for the equipped loadout.

I raised this because I think it makes sense to disable it on non-equippable loadouts. In saying that it should actually show the in game placements due to my recent change to favour current mod positions.

<img width="1257" alt="Screen Shot 2022-01-02 at 8 11 03 am" src="https://user-images.githubusercontent.com/7344652/147860253-7636bafb-c93c-405b-b8cd-bf5cc61eeaf7.png">

Closes #7618 
