### PR TITLE
Fix missing socket overrides in loadout page display.

### DIFF
--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
-import { Loadout } from 'app/loadout-drawer/loadout-types';
+import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
 import { getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
@@ -48,14 +48,19 @@ export default function LoadoutView({
   // Turn loadout items into real DimItems, filtering out unequippable items
   const [items, subclass, warnitems] = useMemo(() => {
     const [items, warnitems] = getItemsFromLoadoutItems(loadout.items, defs, buckets, allItems);
-    const subclass = store.items.find(
-      (item) =>
-        item.bucket.hash === BucketHashes.Subclass &&
-        items.some((loadoutItem) => item.hash === loadoutItem.hash)
-    );
+    let subclass: DimLoadoutItem | undefined;
+    for (const storeItem of items) {
+      if (storeItem.bucket.hash === BucketHashes.Subclass) {
+        const loadoutItem = items.find((loadoutItem) => loadoutItem.hash === storeItem.hash);
+        if (loadoutItem) {
+          subclass = { ...storeItem, socketOverrides: loadoutItem.socketOverrides };
+          break;
+        }
+      }
+    }
     let equippableItems = items.filter((i) => itemCanBeEquippedBy(i, store, true));
     if (subclass) {
-      equippableItems = equippableItems.filter((i) => i.hash !== subclass.hash);
+      equippableItems = equippableItems.filter((i) => i.hash !== subclass!.hash);
     }
     return [equippableItems, subclass, warnitems];
   }, [loadout.items, defs, buckets, allItems, store]);


### PR DESCRIPTION
This fixes a bug I introduced in #7585. 

At the moment subclass handling is really awkward because we need to get the correct item for the store in context and then populate the socket overrides. We either need to change the way we save subclasses in loadouts or provide some helper functions to deal with it.