### PR TITLE
Change rate limit for socketing free mods.

### DIFF
--- a/src/app/bungie-api/rate-limit-config.ts
+++ b/src/app/bungie-api/rate-limit-config.ts
@@ -34,7 +34,7 @@ export default function setupRateLimiter() {
     new RateLimiterQueue(
       /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/InsertSocketPlugFree/,
       2,
-      1100
+      2100
     )
   );
 }


### PR DESCRIPTION
Looking into some of the issues we were having regarding performance on beta. It appears our rate limit config is wrong, from memory it should be 2 items per 2s