### PR TITLE
Fix perf issues with loadout apply

### DIFF
--- a/src/app/bungie-api/rate-limit-config.ts
+++ b/src/app/bungie-api/rate-limit-config.ts
@@ -34,7 +34,7 @@ export default function setupRateLimiter() {
     new RateLimiterQueue(
       /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/InsertSocketPlugFree/,
       2,
-      2100
+      1100
     )
   );
 }

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -539,7 +539,7 @@ function buildCachedDefinedPlug(defs: D2ManifestDefinitions, plugHash: number): 
     // We also run DimItems through immer in the store, which means these get frozen. This essentially
     // unfreezes it in that situation. It only seems to be an issue for fake items in loadouts.
     // TODO (ryan) lets fine a way around this
-    return cachedValue ? { ...cachedValue } : cachedValue;
+    return cachedValue ? { ...cachedValue } : null;
   }
 
   const plug = buildDefinedPlug(defs, plugHash);

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -547,5 +547,5 @@ function buildCachedDefinedPlug(defs: D2ManifestDefinitions, plugHash: number): 
 
   // We mutate cannotCurrentlyRoll and attach stats in this module so we need to spread the object
   // TODO (ryan) lets fine a way around this
-  return plug ? { ...plug } : plug;
+  return plug ? { ...plug } : null;
 }

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -535,10 +535,17 @@ function buildCachedDefinedPlug(defs: D2ManifestDefinitions, plugHash: number): 
   const cachedValue = definedPlugCache[plugHash];
   // The result of buildDefinedPlug can be null, we still consider that a cached value.
   if (cachedValue !== undefined) {
+    // We mutate cannotCurrentlyRoll and attach stats in this module so we need to spread the object
+    // We also run DimItems through immer in the store, which means these get frozen. This essentially
+    // unfreezes it in that situation. It only seems to be an issue for fake items in loadouts.
+    // TODO (ryan) lets fine a way around this
     return cachedValue ? { ...cachedValue } : cachedValue;
   }
 
   const plug = buildDefinedPlug(defs, plugHash);
   definedPlugCache[plugHash] = plug;
+
+  // We mutate cannotCurrentlyRoll and attach stats in this module so we need to spread the object
+  // TODO (ryan) lets fine a way around this
   return plug ? { ...plug } : plug;
 }

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -535,10 +535,10 @@ function buildCachedDefinedPlug(defs: D2ManifestDefinitions, plugHash: number): 
   const cachedValue = definedPlugCache[plugHash];
   // The result of buildDefinedPlug can be null, we still consider that a cached value.
   if (cachedValue !== undefined) {
-    return cachedValue;
+    return cachedValue ? { ...cachedValue } : cachedValue;
   }
 
   const plug = buildDefinedPlug(defs, plugHash);
   definedPlugCache[plugHash] = plug;
-  return plug;
+  return plug ? { ...plug } : plug;
 }

--- a/src/app/loadout-drawer/loadout-apply-state.ts
+++ b/src/app/loadout-drawer/loadout-apply-state.ts
@@ -2,10 +2,6 @@
 
 import { DimItem } from 'app/inventory/item-types';
 import { Observable } from 'app/utils/observable';
-import produce, { setAutoFreeze } from 'immer';
-
-// Immer's auto-freeze can get us in trouble because we do sometimes modify the produced item.
-setAutoFreeze(false);
 
 /**
  * What part of the loadout application process are we currently in?
@@ -157,18 +153,26 @@ export function setLoadoutApplyPhase(phase: LoadoutApplyPhase) {
 }
 
 export function setModResult(result: LoadoutModResult, equipNotPossible?: boolean) {
-  return produce<LoadoutApplyState>((state) => {
-    const mod = state.modStates.find(
+  return (state: LoadoutApplyState): LoadoutApplyState => {
+    const modIndex = state.modStates.findIndex(
       (m) => m.modHash === result.modHash && m.state === LoadoutModState.Pending
     );
-    if (mod) {
-      mod.state = result.state;
-      mod.error = result.error;
+    const updatedModStates = [...state.modStates];
+    if (modIndex !== -1) {
+      const updatedModState = { ...state.modStates[modIndex] };
+      updatedModState.state = result.state;
+      updatedModState.error = result.error;
+      updatedModStates[modIndex] = updatedModState;
     } else {
-      state.modStates.push(result);
+      updatedModStates.push(result);
     }
-    state.equipNotPossible ||= equipNotPossible || false;
-  });
+
+    return {
+      ...state,
+      equipNotPossible: state.equipNotPossible || equipNotPossible || false,
+      modStates: updatedModStates,
+    };
+  };
 }
 
 export function setSocketOverrideResult(
@@ -178,18 +182,73 @@ export function setSocketOverrideResult(
   error?: Error,
   equipNotPossible?: boolean
 ) {
-  return produce<LoadoutApplyState>((state) => {
-    const thisSocketResult = state.socketOverrideStates[item.index].results[socketIndex];
+  return (state: LoadoutApplyState): LoadoutApplyState => {
+    const socketOverridesForItem = { ...state.socketOverrideStates[item.index] };
+    const thisSocketResult = { ...socketOverridesForItem.results[socketIndex] };
 
     // don't insert a state or error for anything that wasn't given an initial tracking state
     if (!thisSocketResult) {
-      return;
+      return state;
     }
 
     thisSocketResult.state = socketState;
     thisSocketResult.error = error;
-    state.equipNotPossible ||= equipNotPossible || false;
+    socketOverridesForItem.results = {
+      ...socketOverridesForItem.results,
+      [socketIndex]: thisSocketResult,
+    };
+
+    return {
+      ...state,
+      equipNotPossible: state.equipNotPossible || equipNotPossible || false,
+      socketOverrideStates: { ...state.socketOverrideStates, [item.index]: socketOverridesForItem },
+    };
+  };
+}
+
+export function updateItemResult(
+  item: DimItem,
+  partialResult: Partial<LoadoutItemResult>,
+  equipNotPossible?: boolean
+) {
+  return (state: LoadoutApplyState): LoadoutApplyState => ({
+    ...state,
+    equipNotPossible: equipNotPossible || state.equipNotPossible,
+    itemStates: {
+      ...state.itemStates,
+      [item.index]: {
+        ...state.itemStates[item.index],
+        ...partialResult,
+      },
+    },
   });
+}
+
+export function updateResultForItems(
+  itemsWithResults: { item: DimItem; partialResult: Partial<LoadoutItemResult> }[],
+  equipNotPossible?: boolean
+) {
+  return (state: LoadoutApplyState): LoadoutApplyState => {
+    const updatedItemStates: { [itemIndex: number]: LoadoutItemResult } = {};
+
+    for (const { item, partialResult } of itemsWithResults) {
+      if (state.itemStates[item.index]) {
+        updatedItemStates[item.index] = {
+          ...state.itemStates[item.index],
+          ...partialResult,
+        };
+      }
+    }
+
+    return {
+      ...state,
+      equipNotPossible: equipNotPossible || state.equipNotPossible,
+      itemStates: {
+        ...state.itemStates,
+        ...updatedItemStates,
+      },
+    };
+  };
 }
 
 /**

--- a/src/app/loadout-drawer/loadout-apply-state.ts
+++ b/src/app/loadout-drawer/loadout-apply-state.ts
@@ -206,8 +206,9 @@ export function setSocketOverrideResult(
   };
 }
 
+/** Updates the item state for a single item for the given `DimItem.index`. */
 export function updateItemResult(
-  item: DimItem,
+  itemIndex: string,
   partialResult: Partial<LoadoutItemResult>,
   equipNotPossible?: boolean
 ) {
@@ -216,25 +217,31 @@ export function updateItemResult(
     equipNotPossible: equipNotPossible || state.equipNotPossible,
     itemStates: {
       ...state.itemStates,
-      [item.index]: {
-        ...state.itemStates[item.index],
+      [itemIndex]: {
+        ...state.itemStates[itemIndex],
         ...partialResult,
       },
     },
   });
 }
 
+export interface PartialItemResultUpdate {
+  itemIndex: string;
+  partialResult: Partial<LoadoutItemResult>;
+}
+
+/** Updates the item state for multiple items based of the `DimItem.index`. */
 export function updateResultForItems(
-  itemsWithResults: { item: DimItem; partialResult: Partial<LoadoutItemResult> }[],
+  itemsWithResults: PartialItemResultUpdate[],
   equipNotPossible?: boolean
 ) {
   return (state: LoadoutApplyState): LoadoutApplyState => {
     const updatedItemStates: { [itemIndex: number]: LoadoutItemResult } = {};
 
-    for (const { item, partialResult } of itemsWithResults) {
-      if (state.itemStates[item.index]) {
-        updatedItemStates[item.index] = {
-          ...state.itemStates[item.index],
+    for (const { itemIndex, partialResult } of itemsWithResults) {
+      if (state.itemStates[itemIndex]) {
+        updatedItemStates[itemIndex] = {
+          ...state.itemStates[itemIndex],
           ...partialResult,
         };
       }

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -44,14 +44,16 @@ import { getSocketByIndex, getSocketsByIndexes } from 'app/utils/socket-utils';
 import { count } from 'app/utils/util';
 import { DestinyClass, PlatformErrorCodes } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
-import produce from 'immer';
 import _ from 'lodash';
 import { savePreviousLoadout } from './actions';
 import {
   anyActionFailed,
   LoadoutApplyPhase,
+  LoadoutItemResult,
   LoadoutItemState,
+  LoadoutModResult,
   LoadoutModState,
+  LoadoutSocketOverrideResult,
   LoadoutSocketOverrideState,
   LoadoutStateGetter,
   LoadoutStateUpdater,
@@ -59,6 +61,8 @@ import {
   setLoadoutApplyPhase,
   setModResult,
   setSocketOverrideResult,
+  updateItemResult,
+  updateResultForItems,
 } from './loadout-apply-state';
 import { Assignment, Loadout, LoadoutItem } from './loadout-types';
 import { backupLoadout } from './loadout-utils';
@@ -202,39 +206,46 @@ function doApplyLoadout(
       );
 
       // Initialize items/mods/etc in the LoadoutApplyState, for the notification
-      setLoadoutState(
-        produce((state) => {
-          state.phase = LoadoutApplyPhase.Deequip;
-
-          // Fill out pending state for all items
-          for (const loadoutItem of applicableLoadoutItems) {
-            const item = getLoadoutItem(loadoutItem, store, getStores())!;
-            state.itemStates[item.index] = {
+      setLoadoutState((state) => {
+        // Fill out pending state for all items
+        const itemStates: { [itemIndex: number]: LoadoutItemResult } = {};
+        for (const loadoutItem of applicableLoadoutItems) {
+          // TODO create a getLoadoutItems, so we can batch get items rather then iterating the stores for each one.
+          const item = getLoadoutItem(loadoutItem, store, getStores())!;
+          itemStates[item.index] = {
+            item,
+            equip: loadoutItem.equipped,
+            state: LoadoutItemState.Pending,
+          };
+        }
+        // Fill out pending state for all socket overrides
+        const socketOverrideStates: { [itemIndex: number]: LoadoutSocketOverrideResult } = {};
+        for (const loadoutItem of itemsWithOverrides) {
+          const item = getLoadoutItem(loadoutItem, store, getStores())!;
+          if (item) {
+            socketOverrideStates[item.index] = {
               item,
-              equip: loadoutItem.equipped,
-              state: LoadoutItemState.Pending,
+              results: _.mapValues(loadoutItem.socketOverrides, (plugHash) => ({
+                plugHash,
+                state: LoadoutSocketOverrideState.Pending,
+              })),
             };
           }
-          // Fill out pending state for all socket overrides
-          for (const loadoutItem of itemsWithOverrides) {
-            const item = getLoadoutItem(loadoutItem, store, getStores())!;
-            if (item) {
-              state.socketOverrideStates[item.index] = {
-                item,
-                results: _.mapValues(loadoutItem.socketOverrides, (plugHash) => ({
-                  plugHash,
-                  state: LoadoutSocketOverrideState.Pending,
-                })),
-              };
-            }
-          }
-          // Fill out pending state for all mods
-          state.modStates = modsToApply.map((modHash) => ({
-            modHash,
-            state: LoadoutModState.Pending,
-          }));
-        })
-      );
+        }
+        // Fill out pending state for all mods
+        const modStates: LoadoutModResult[] = modsToApply.map((modHash) => ({
+          modHash,
+          state: LoadoutModState.Pending,
+        }));
+
+        return {
+          ...state,
+          phase: LoadoutApplyPhase.Deequip,
+          itemStates,
+          socketOverrideStates,
+          modStates,
+        };
+      });
 
       // Filter out items that don't need to move
       const loadoutItemsToMove: LoadoutItem[] = Array.from(
@@ -254,11 +265,7 @@ function doApplyLoadout(
               (loadoutItem.amount && loadoutItem.amount > 1));
 
           if (item && !requiresAction) {
-            setLoadoutState(
-              produce((state) => {
-                state.itemStates[item.index].state = LoadoutItemState.AlreadyThere;
-              })
-            );
+            setLoadoutState(updateItemResult(item, { state: LoadoutItemState.AlreadyThere }));
           }
 
           return requiresAction;
@@ -316,33 +323,44 @@ function doApplyLoadout(
               equipItems(getStore(getStores(), owner)!, itemsToEquip, cancelToken)
             );
             // Bulk equip can partially fail
-            setLoadoutState(
-              produce((state) => {
-                for (const item of dequipItems) {
-                  const errorCode = result[item.id];
-                  state.itemStates[item.index].state =
+            setLoadoutState((state) => {
+              const updatedItemStates = { ...state.itemStates };
+              for (const item of dequipItems) {
+                const errorCode = result[item.id];
+                updatedItemStates[item.index] = {
+                  ...updatedItemStates[item.index],
+                  state:
                     errorCode === PlatformErrorCodes.Success
                       ? LoadoutItemState.DequippedPendingMove
-                      : LoadoutItemState.FailedDequip;
-
-                  // TODO how to set the error code here?
-                  // state.itemStates[item.index].error = new DimError().withCause(BungieError(errorCode))
-                }
-              })
-            );
+                      : LoadoutItemState.FailedDequip,
+                };
+                // TODO how to set the error code here?
+                // state.itemStates[item.index].error = new DimError().withCause(BungieError(errorCode))
+              }
+              return {
+                ...state,
+                itemStates: updatedItemStates,
+              };
+            });
           } catch (e) {
             if (e instanceof CanceledError) {
               throw e;
             }
             errorLog('loadout dequip', 'Failed to dequip items from', owner, e);
-            setLoadoutState(
-              produce((state) => {
-                for (const item of dequipItems) {
-                  state.itemStates[item.index].state = LoadoutItemState.FailedDequip;
-                  state.itemStates[item.index].error = e;
-                }
-              })
-            );
+            setLoadoutState((state) => {
+              const updatedItemStates = { ...state.itemStates };
+              for (const item of dequipItems) {
+                updatedItemStates[item.index] = {
+                  ...updatedItemStates[item.index],
+                  state: LoadoutItemState.FailedDequip,
+                  error: e,
+                };
+              }
+              return {
+                ...state,
+                itemStates: updatedItemStates,
+              };
+            });
           }
         }
       );
@@ -361,13 +379,13 @@ function doApplyLoadout(
           const updatedItem = getItemAcrossStores(getStores(), loadoutItem);
           if (updatedItem) {
             setLoadoutState(
-              produce((state) => {
-                state.itemStates[updatedItem.index].state =
+              updateItemResult(updatedItem, {
+                state:
                   // If we're doing a bulk equip later, set to MovedPendingEquip
                   itemsToEquip.length > 1 &&
                   itemsToEquip.some((loadoutItem) => loadoutItem.id === updatedItem.id)
                     ? LoadoutItemState.MovedPendingEquip
-                    : LoadoutItemState.Succeeded;
+                    : LoadoutItemState.Succeeded,
               })
             );
           }
@@ -378,19 +396,24 @@ function doApplyLoadout(
           const updatedItem = getItemAcrossStores(getStores(), loadoutItem);
           if (updatedItem) {
             errorLog('loadout', 'Failed to apply loadout item', updatedItem.name, e);
+            const isOnCorrectStore = updatedItem.owner === store.id;
+            const itemState = isOnCorrectStore
+              ? LoadoutItemState.FailedEquip
+              : LoadoutItemState.FailedMove;
+            const equipNotPossible =
+              isOnCorrectStore &&
+              e instanceof DimError &&
+              checkequipNotPossible(e.bungieErrorCode());
+
             setLoadoutState(
-              produce((state) => {
-                // If it made it to the right store, the failure was in equipping, not moving
-                const isOnCorrectStore = updatedItem.owner === store.id;
-                state.itemStates[updatedItem.index].state = isOnCorrectStore
-                  ? LoadoutItemState.FailedEquip
-                  : LoadoutItemState.FailedMove;
-                state.itemStates[updatedItem.index].error = e;
-                state.equipNotPossible ||=
-                  isOnCorrectStore &&
-                  e instanceof DimError &&
-                  checkequipNotPossible(e.bungieErrorCode());
-              })
+              updateItemResult(
+                updatedItem,
+                {
+                  state: itemState,
+                  error: e,
+                },
+                equipNotPossible
+              )
             );
           }
         }
@@ -414,36 +437,40 @@ function doApplyLoadout(
         );
         try {
           const result = await dispatch(equipItems(store, realItemsToEquip, cancelToken));
+          const itemStateUpdates: { item: DimItem; partialResult: Partial<LoadoutItemResult> }[] =
+            [];
+          let equipNotPossible = false;
+
+          for (const item of realItemsToEquip) {
+            const errorCode = result[item.id];
+            const partialResult = {
+              state:
+                errorCode === PlatformErrorCodes.Success
+                  ? LoadoutItemState.Succeeded
+                  : LoadoutItemState.FailedEquip,
+            };
+            itemStateUpdates.push({ item, partialResult });
+
+            // TODO how to set the error code here?
+            // state.itemStates[item.index].error = new DimError().withCause(BungieError(errorCode))
+
+            equipNotPossible ||= checkequipNotPossible(errorCode);
+          }
+
           // Bulk equip can partially fail
-          setLoadoutState(
-            produce((state) => {
-              for (const item of realItemsToEquip) {
-                const errorCode = result[item.id];
-                state.itemStates[item.index].state =
-                  errorCode === PlatformErrorCodes.Success
-                    ? LoadoutItemState.Succeeded
-                    : LoadoutItemState.FailedEquip;
-
-                // TODO how to set the error code here?
-                // state.itemStates[item.index].error = new DimError().withCause(BungieError(errorCode))
-
-                state.equipNotPossible ||= checkequipNotPossible(errorCode);
-              }
-            })
-          );
+          setLoadoutState(updateResultForItems(itemStateUpdates, equipNotPossible));
         } catch (e) {
           if (e instanceof CanceledError) {
             throw e;
           }
           errorLog('loadout equip', 'Failed to equip items', e);
-          setLoadoutState(
-            produce((state) => {
-              for (const item of realItemsToEquip) {
-                state.itemStates[item.index].state = LoadoutItemState.FailedEquip;
-                state.itemStates[item.index].error = e;
-              }
-            })
-          );
+          const itemStateUpdates: { item: DimItem; partialResult: Partial<LoadoutItemResult> }[] =
+            [];
+          for (const item of realItemsToEquip) {
+            const partialResult = { state: LoadoutItemState.FailedEquip, error: e };
+            itemStateUpdates.push({ item, partialResult });
+          }
+          setLoadoutState(updateResultForItems(itemStateUpdates));
         }
       }
 

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -3,7 +3,6 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { makeFakeItem } from 'app/inventory/store/d2-item-factory';
 import { emptyArray } from 'app/utils/empty';
-import _ from 'lodash';
 import { DimItem } from '../inventory/item-types';
 import { DimLoadoutItem, LoadoutItem } from './loadout-types';
 import { findItem } from './loadout-utils';
@@ -27,8 +26,7 @@ export function getItemsFromLoadoutItems(
   for (const loadoutItem of loadoutItems) {
     const item = findItem(allItems, loadoutItem);
     if (item) {
-      const copiedDimItem = _.cloneDeep(item);
-      items.push({ ...copiedDimItem, socketOverrides: loadoutItem.socketOverrides });
+      items.push({ ...item, socketOverrides: loadoutItem.socketOverrides });
     } else {
       const itemDef = defs.InventoryItem.get(loadoutItem.hash);
       if (itemDef) {

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -3,6 +3,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { makeFakeItem } from 'app/inventory/store/d2-item-factory';
 import { emptyArray } from 'app/utils/empty';
+import _ from 'lodash';
 import { DimItem } from '../inventory/item-types';
 import { DimLoadoutItem, LoadoutItem } from './loadout-types';
 import { findItem } from './loadout-utils';
@@ -26,7 +27,8 @@ export function getItemsFromLoadoutItems(
   for (const loadoutItem of loadoutItems) {
     const item = findItem(allItems, loadoutItem);
     if (item) {
-      items.push({ ...item, socketOverrides: loadoutItem.socketOverrides });
+      const copiedDimItem = _.cloneDeep(item);
+      items.push({ ...copiedDimItem, socketOverrides: loadoutItem.socketOverrides });
     } else {
       const itemDef = defs.InventoryItem.get(loadoutItem.hash);
       if (itemDef) {


### PR DESCRIPTION
This strips immer out of the loadout apply state.

It seems as though immer is causing performance issues during loadout application. In the following screen shot you can see the blocking tasks and the produce method being the main culprit in each case.

<img width="2410" alt="perf" src="https://user-images.githubusercontent.com/7344652/147877058-6c696f55-b3b5-4915-af24-3ac2545d6c01.png">

I am no expert in immer but I believe what is happening is we are running `DimItem`s though immer, which creates proxies for the item, and also recursively freezes each item. When items then get updated after a move/awa action immer runs all its produce functionality again. I think this is just blowing out and bottle necking the event loop. 

I believe this is still happening in the apps main reducer and I have included a workaround for our cached plugs.

You can see this by simply capturing the performance details in chrome after hitting the apply button. The inability for mod items popups to work on hover is a give away it is happening and the easiest way to test that this fixes it.

