### PR TITLE
Hardcode universal ornament plugsets to use canInsert instead of enabled to determine unlocked.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Vendors page now correctly recognizes owned bounties per character and is more accurate about mods ownership.
 * Fixed an issue that could make moving searches containing stacks of items to fail.
 * Fixes for display on iPhones with rounded corners and a notch.
+* Transmog Ornaments menu now correctly shows whether ornament has been unlocked or not.
 
 ## 6.97.3 <span class="changelog-date">(2021-12-30)</span>
 

--- a/src/app/records/plugset-helpers.ts
+++ b/src/app/records/plugset-helpers.ts
@@ -1,4 +1,5 @@
 import { DimPlugSet } from 'app/inventory/item-types';
+import { universalOrnamentPlugSetHashes } from 'app/search/d2-known-values';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 
 /**
@@ -25,10 +26,11 @@ export function unlockedItemsForCharacterOrProfilePlugSet(
 ): Set<number> {
   const unlockedPlugs = new Set<number>();
   const plugSetItems = itemsForCharacterOrProfilePlugSet(profileResponse, plugSetHash, characterId);
+  const useCanInsert = universalOrnamentPlugSetHashes.includes(plugSetHash);
   // TODO: would be great to precalculate/memoize this by character ID and profileResponse
   for (const plugSetItem of plugSetItems) {
     // TODO: https://github.com/DestinyItemManager/DIM/issues/7561
-    if (plugSetItem.enabled) {
+    if (useCanInsert ? plugSetItem.canInsert : plugSetItem.enabled) {
       unlockedPlugs.add(plugSetItem.plugItemHash);
     }
   }

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -83,6 +83,11 @@ export const killTrackerObjectivesByHash: Record<number, 'pvp' | 'pve' | undefin
 };
 export const killTrackerSocketTypeHash = 1282012138;
 
+export const universalOrnamentPlugSetHashes: number[] = [
+  26360131, 71785814, 709078552, 1133647128, 1323117612, 1742798175, 2093871133, 2203626505,
+  2425516788, 2568801218, 2733810650, 3024995628, 3479876793, 4014441445, 4178224051,
+];
+
 //
 // STATS KNOWN VALUES
 //


### PR DESCRIPTION
This isn't a terribly rigorous fix, but in practice I think it clears up unlockability where we need it most.

Fixes #7561