### PR TITLE
Fix empty modslots becoming required

### DIFF
--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -845,23 +845,23 @@ function applySocketOverrides(
             if (modHash) {
               const mod = defs.InventoryItem.get(modHash) as PluggableInventoryItemDefinition;
               // We explicitly set sockets that aren't in socketOverrides to the default plug for subclasses
-              modsForItem.push({ socketIndex, mod, required: true });
+              modsForItem.push({ socketIndex, mod, requested: true });
             }
           }
         }
 
-        const handleSuccess = ({ socketIndex, required }: Assignment) => {
-          required &&
+        const handleSuccess = ({ socketIndex, requested }: Assignment) => {
+          requested &&
             setLoadoutState(
               setSocketOverrideResult(dimItem, socketIndex, LoadoutSocketOverrideState.Applied)
             );
         };
         const handleFailure = (
-          { socketIndex, required }: Assignment,
+          { socketIndex, requested }: Assignment,
           error?: Error,
           equipNotPossible?: boolean
         ) =>
-          required
+          requested
             ? setLoadoutState(
                 setSocketOverrideResult(
                   dimItem,
@@ -958,15 +958,15 @@ function applyLoadoutMods(
 
     const applyModsPromises: Promise<void>[] = [];
 
-    const handleSuccess = ({ mod, required }: Assignment) =>
-      required &&
+    const handleSuccess = ({ mod, requested }: Assignment) =>
+      requested &&
       setLoadoutState(setModResult({ modHash: mod.hash, state: LoadoutModState.Applied }));
     const handleFailure = (
-      { mod, required }: Assignment,
+      { mod, requested }: Assignment,
       error?: Error,
       equipNotPossible?: boolean
     ) =>
-      required
+      requested
         ? setLoadoutState(
             setModResult(
               { modHash: mod.hash, state: LoadoutModState.Failed, error },

--- a/src/app/loadout-drawer/loadout-types.ts
+++ b/src/app/loadout-drawer/loadout-types.ts
@@ -37,12 +37,8 @@ export interface Assignment {
   mod: PluggableInventoryItemDefinition;
   /** which socket to plug it into */
   socketIndex: number;
-  /**
-   * If required, this assignment must be completed. The user wants this mod plugged, even if it's the default plug.
-   * If not, this is an optional action which clears out other mod slots.
-   * This also controls whether we show the status of this assignment in the loadout progress notification.
-   */
-  required: boolean;
+  /** Was this assignment requested by the user (and should thus be reported in the progress popup)? */
+  requested: boolean;
 }
 
 /**
@@ -53,4 +49,9 @@ export interface Assignment {
 export interface PluggingAction extends Assignment {
   /** This will be negative if we are recovering used energy back by swapping in a cheaper mod */
   energySpend: number;
+  /**
+   * If required, this assignment must be completed.
+   * If not, this is an optional action which clears out other mod slots.
+   */
+  required: boolean;
 }

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -364,7 +364,7 @@ export function pickPlugPositions(
     assignments.push({
       socketIndex: destinationSocket.socketIndex,
       mod: modToInsert,
-      required: true,
+      requested: true,
     });
 
     // remove this existing socket from consideration
@@ -386,8 +386,8 @@ export function pickPlugPositions(
       assignments.push({
         socketIndex,
         mod,
-        // If the user wants to clear out all items, this is required. Otherwise it's optional.
-        required: clearUnassignedSocketsPerItem,
+        // If the user wants to clear out all items, this is requested. Otherwise it's optional.
+        requested: clearUnassignedSocketsPerItem,
       });
     }
   }
@@ -432,6 +432,7 @@ export function createPluggingStrategy(
     const pluggingAction = {
       ...assignment,
       energySpend,
+      required: assignment.requested,
     };
 
     if (pluggingAction.energySpend > 0) {


### PR DESCRIPTION
https://github.com/DestinyItemManager/DIM/pull/7623 had a bug that could result in empty mod slots popping into the loadout progress notification. I hadn't noticed that sometimes required gets set to true on things that aren't requested. So now I track them separately.