### PR TITLE
Better updates for DimPlug's.

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -352,33 +352,33 @@ export interface PluggableInventoryItemDefinition extends DestinyInventoryItemDe
  */
 export interface DimPlug {
   /** The InventoryItem definition associated with this plug. */
-  plugDef: PluggableInventoryItemDefinition;
+  readonly plugDef: PluggableInventoryItemDefinition;
   /** Perks associated with the use of this plug. TODO: load on demand? */
-  perks: DestinySandboxPerkDefinition[];
+  readonly perks: DestinySandboxPerkDefinition[];
   /** Objectives associated with this plug, usually used to unlock it. */
-  plugObjectives: DestinyObjectiveProgress[];
+  readonly plugObjectives: DestinyObjectiveProgress[];
   /** Is the plug enabled? For example, some perks only activate on certain planets. */
-  enabled: boolean;
+  readonly enabled: boolean;
   /** If not enabled, this is the localized reasons why, as a single string. */
-  enableFailReasons: string;
+  readonly enableFailReasons: string;
   /** Stats this plug modifies. If present, it's a map from the stat hash to the amount the stat is modified. */
-  stats: {
+  readonly stats: {
     [statHash: number]: number;
   } | null;
   /** This plug is one of the random roll options but the current version of this item cannot roll this perk. */
-  cannotCurrentlyRoll?: boolean;
+  readonly cannotCurrentlyRoll?: boolean;
 }
 
 export interface DimPlugSet {
   /** The hash that links to a DestinyPlugSetDefinition. */
-  hash: number;
+  readonly hash: number;
   /**
    * A list of built DimPlugs that are found in the plugSet.
    * This plugs included encompass everything that can be plugged into the socket whether it
    * is available to the character or not. You should filter this list down based on the plugs
    * available to the profile/character.
    */
-  plugs: DimPlug[];
+  readonly plugs: DimPlug[];
 }
 
 export interface DimSocket {

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -224,8 +224,7 @@ function buildDefinedSocket(
         for (const reusablePlug of plugSet.reusablePlugItems) {
           const built = buildCachedDefinedPlug(defs, reusablePlug.plugItemHash);
           if (built) {
-            built.cannotCurrentlyRoll = !reusablePlug.currentlyCanRoll;
-            reusablePlugs.push(built);
+            reusablePlugs.push({ ...built, cannotCurrentlyRoll: !reusablePlug.currentlyCanRoll });
           }
         }
       }
@@ -247,8 +246,7 @@ function buildDefinedSocket(
         for (const reusablePlug of Object.values(plugs)) {
           const built = buildCachedDefinedPlug(defs, reusablePlug.plugItemHash);
           if (built) {
-            built.cannotCurrentlyRoll = !reusablePlug.currentlyCanRoll;
-            reusablePlugs.push(built);
+            reusablePlugs.push({ ...built, cannotCurrentlyRoll: !reusablePlug.currentlyCanRoll });
           }
         }
       }
@@ -535,17 +533,11 @@ function buildCachedDefinedPlug(defs: D2ManifestDefinitions, plugHash: number): 
   const cachedValue = definedPlugCache[plugHash];
   // The result of buildDefinedPlug can be null, we still consider that a cached value.
   if (cachedValue !== undefined) {
-    // We mutate cannotCurrentlyRoll and attach stats in this module so we need to spread the object
-    // We also run DimItems through immer in the store, which means these get frozen. This essentially
-    // unfreezes it in that situation. It only seems to be an issue for fake items in loadouts.
-    // TODO (ryan) lets fine a way around this
-    return cachedValue ? { ...cachedValue } : null;
+    return cachedValue;
   }
 
   const plug = buildDefinedPlug(defs, plugHash);
   definedPlugCache[plugHash] = plug;
 
-  // We mutate cannotCurrentlyRoll and attach stats in this module so we need to spread the object
-  // TODO (ryan) lets fine a way around this
-  return plug ? { ...plug } : null;
+  return plug;
 }

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -410,9 +410,10 @@ function attachPlugStats(
       activePlugStats[plugInvestmentStat.statTypeHash] = plugStatValue;
     }
 
-    activePlug.stats = activePlugStats;
+    socket.plugged = { ...activePlug, stats: activePlugStats };
   }
 
+  const plugOptionsWithStats: DimPlug[] = [];
   for (const plug of socket.plugOptions) {
     // We already did this plug above and activePlug should be a reference to plug.
     if (plug === activePlug) {
@@ -457,8 +458,10 @@ function attachPlugStats(
       inactivePlugStats[plugInvestmentStat.statTypeHash] = plugStatValue;
     }
 
-    plug.stats = inactivePlugStats;
+    plugOptionsWithStats.push({ ...plug, stats: inactivePlugStats });
   }
+
+  socket.plugOptions = plugOptionsWithStats;
 }
 
 function totalStat(stats: DimStat[]): DimStat {


### PR DESCRIPTION
I think this is a better version of locking down DimPlug's after they have been created. Each plug gets tailored if they are attached to an instanced item. This makes plugs immutable and creates shallow clones when we need to update any property.

I think the really interested thing here is we didn't see issues with incorrect stats on plugs around the app. The cached code has been live for a number of weeks. Maybe we don't actually need to build these values from instanced items like we do?