### PR TITLE
Throttle loadout updates

### DIFF
--- a/src/app/inventory/MoveNotifications.tsx
+++ b/src/app/inventory/MoveNotifications.tsx
@@ -18,11 +18,11 @@ import {
   refreshIcon,
 } from 'app/shell/icons';
 import { DimError } from 'app/utils/dim-error';
+import { useThrottledSubscription } from 'app/utils/hooks';
 import { Observable } from 'app/utils/observable';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
-import { useSubscription } from 'use-subscription';
 import ConnectedInventoryItem from './ConnectedInventoryItem';
 import { DimItem, PluggableInventoryItemDefinition } from './item-types';
 import ItemIcon from './ItemIcon';
@@ -97,7 +97,7 @@ function ApplyLoadoutProgressBody({
 }) {
   // TODO: throttle subscription?
   const { phase, equipNotPossible, itemStates, socketOverrideStates, modStates } =
-    useSubscription(stateObservable);
+    useThrottledSubscription(stateObservable, 100);
   const defs = useD2Definitions()!;
 
   const progressIcon =


### PR DESCRIPTION
It reduces updates a bit, and doesn't seem to affect responsiveness of the notification.