### PR TITLE
Visual bug in collections where elements were overlapping.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Fixed an issue where the progress bar for exotic weapons were clipping into other page elements. 
 
 ## 6.98.0 <span class="changelog-date">(2022-01-02)</span>
 

--- a/src/app/records/PresentationNode.scss
+++ b/src/app/records/PresentationNode.scss
@@ -128,7 +128,7 @@
 .collectibles {
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--item-size));
-  grid-template-rows: repeat(auto-fill, var(--item-size));
+  grid-template-rows: min-content;
   gap: 4px;
   margin: 6px 10px 8px;
   /* margin exception because plugset doesn't have an always-expanded parent */


### PR DESCRIPTION
Fixed collections bug where progress bars overflowed into other page elements.

![image](https://user-images.githubusercontent.com/10742576/147965109-6a5f5755-fc15-46c8-a0fc-bed431eb73f9.png)

fixes #7622 