### PR TITLE
Apply the default ornament

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -5,8 +5,7 @@
     "Error": "Error changing mods or perks",
     "ErrorMessage": "We couldn't equip {{plug}} into {{item}}.\n\n{{error}}",
     "FailedToken": "Couldn't get permission to change item",
-    "NotSupported": "We cannot change this type of mod or perk",
-    "SelfInsertion": "You cannot plug an item into itself!"
+    "NotSupported": "We cannot change this type of mod or perk"
   },
   "Accounts": {
     "Blizzard": "PC",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -4,8 +4,7 @@
     "ConfirmTitle": "Confirm Action",
     "Error": "Error changing mods or perks",
     "ErrorMessage": "We couldn't equip {{plug}} into {{item}}.\n\n{{error}}",
-    "FailedToken": "Couldn't get permission to change item",
-    "SelfInsertion": "You cannot plug an item into itself!"
+    "FailedToken": "Couldn't get permission to change item"
   },
   "Accounts": {
     "ErrorLoadInventory": "Unable to load your Destiny {{version}} characters and inventory",
@@ -1042,7 +1041,6 @@
     "VoltronDescription": "voltron is an auto-updated collection of PvE and PvP wish list rolls from Mercules904 and pandapaxxy. We ship with this by default.",
     "WishListNotes": "Wish List Notes: {{notes}}"
   },
-  "You cannot plug an item into itself!": "",
   "no-space": "",
   "wrong-level": ""
 }


### PR DESCRIPTION
... if the user selects a universal ornament that matches the item it's being applied to. I'll keep the special case higher up in the loadout-apply function, because that helps with progress reporting and skipping unnecessary loadout work.