### PR TITLE
Record default Stasis abilities when creating loadout from equipped

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
-* Fixed an issue where the progress bar for exotic weapons were clipping into other page elements. 
+* Fixed an issue where the progress bar for exotic weapons were clipping into other page elements.
+* Creating a loadout from current equipment with a Stasis subclass now always includes all subclass abilities.
 
 ## 6.98.0 <span class="changelog-date">(2022-01-02)</span>
 

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -21,7 +21,11 @@ import { DimStore } from '../inventory/store-types';
 import { showItemPicker } from '../item-picker/item-picker';
 import { addIcon, AppIcon } from '../shell/icons';
 import { Loadout, LoadoutItem } from './loadout-types';
-import { extractArmorModHashes, fromEquippedTypes } from './loadout-utils';
+import {
+  createSocketOverridesFromEquipped,
+  extractArmorModHashes,
+  fromEquippedTypes,
+} from './loadout-utils';
 import LoadoutDrawerBucket from './LoadoutDrawerBucket';
 import SavedMods from './SavedMods';
 import { Subclass } from './subclass-drawer/Subclass';
@@ -264,24 +268,6 @@ async function pickLoadoutSubclass(
     add(item);
   }
   onShowItemPicker(false);
-}
-
-function createSocketOverridesFromEquipped(item: DimItem) {
-  const socketOverrides: SocketOverrides = {};
-  for (const socket of item.sockets?.allSockets || []) {
-    // If the socket is plugged and we plug isn't the initial plug we apply the overrides
-    // to the loadout.
-    if (
-      socket.plugged &&
-      socket.plugged.plugDef.hash !== socket.socketDefinition.singleInitialItemHash
-    ) {
-      socketOverrides[socket.socketIndex] = socket.plugged.plugDef.hash;
-    }
-  }
-  if (Object.keys(socketOverrides).length) {
-    return socketOverrides;
-  }
-  return undefined;
 }
 
 function fillLoadoutFromEquipped(


### PR DESCRIPTION
Right now, creating a loadout from equipped fails to record (for example) Healing Rift or Glacier Nade in the socket overrides of its subclass because it's the "default" in the Stasis Subclass. This is both wrong and causes weird errors in the loadout application popup later.