### PR TITLE
Cleanup socket overrides from equipped.

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -22,7 +22,11 @@ import { DimStore } from '../inventory/store-types';
 import { showItemPicker } from '../item-picker/item-picker';
 import { addIcon, AppIcon } from '../shell/icons';
 import { Loadout, LoadoutItem } from './loadout-types';
-import { extractArmorModHashes, fromEquippedTypes } from './loadout-utils';
+import {
+  createSocketOverridesFromEquipped,
+  extractArmorModHashes,
+  fromEquippedTypes,
+} from './loadout-utils';
 import LoadoutDrawerBucket from './LoadoutDrawerBucket';
 import SavedMods from './SavedMods';
 import { Subclass } from './subclass-drawer/Subclass';
@@ -274,19 +278,6 @@ async function pickLoadoutSubclass(
     add({ item, socketOverrides });
   }
   onShowItemPicker(false);
-}
-
-function createSocketOverridesFromEquipped(item: DimItem) {
-  const socketOverrides: SocketOverrides = {};
-  for (const socket of item.sockets?.allSockets || []) {
-    if (socket.plugged) {
-      socketOverrides[socket.socketIndex] = socket.plugged.plugDef.hash;
-    }
-  }
-  if (Object.keys(socketOverrides).length) {
-    return socketOverrides;
-  }
-  return undefined;
 }
 
 function fillLoadoutFromEquipped(


### PR DESCRIPTION
Just cleaning up some duplicated functions and added a better condition for the equipped plug hydration.

The PR to not force initial plugs for abilities is going to be seperate to this functionality.

Just merging this one but tagged you both for awareness.