### PR TITLE
Filter hidden shaders in plug picker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue that could make moving searches containing stacks of items to fail.
 * Added Spoils of Conquest to the currencies hover menu.
 * Fixed an issue where the Loadout Optimizer would let you pin items from other classes.
+* Shader picker now hides unavailable, unobtainable shaders.
 
 ## 6.98.0 <span class="changelog-date">(2022-01-02)</span>
 

--- a/src/app/records/selectors.ts
+++ b/src/app/records/selectors.ts
@@ -17,19 +17,12 @@ export const collectionsVisibleShadersSelector = createSelector(
 
     const getVisibleCollectibles = (node: DestinyPresentationNodeDefinition): number[] => {
       const visibleCollectibles: number[] = node.children.collectibles
-        .map((c) => {
-          const collectibleDef = defs.Collectible.get(c.collectibleHash);
-          const state = getCollectibleState(collectibleDef, profileResponse);
-          if (
-            state === undefined ||
-            state & DestinyCollectibleState.Invisible ||
-            collectibleDef.redacted
-          ) {
-            return undefined;
-          }
-          return collectibleDef.itemHash;
+        .map((c) => defs.Collectible.get(c.collectibleHash))
+        .filter((c) => {
+          const state = getCollectibleState(c, profileResponse);
+          return state !== undefined && !(state & DestinyCollectibleState.Invisible) && !c.redacted;
         })
-        .filter((i: number | undefined): i is number => Boolean(i));
+        .map((c) => c.itemHash);
       const visibleChildCollectibles = node.children.presentationNodes.flatMap((childNode) =>
         getVisibleCollectibles(defs.PresentationNode.get(childNode.presentationNodeHash))
       );

--- a/src/app/records/selectors.ts
+++ b/src/app/records/selectors.ts
@@ -1,7 +1,6 @@
 import { profileResponseSelector } from 'app/inventory/selectors';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { SHADER_NODE } from 'app/search/d2-known-values';
-import { emptySet } from 'app/utils/empty';
 import { DestinyCollectibleState, DestinyPresentationNodeDefinition } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
@@ -13,22 +12,24 @@ export const collectionsVisibleShadersSelector = createSelector(
   profileResponseSelector,
   (defs, profileResponse) => {
     if (!defs || !profileResponse) {
-      return emptySet<number>();
+      return undefined;
     }
 
     const getVisibleCollectibles = (node: DestinyPresentationNodeDefinition): number[] => {
-      const visibleCollectibles: number[] = node.children.collectibles.flatMap((c) => {
-        const collectibleDef = defs.Collectible.get(c.collectibleHash);
-        const state = getCollectibleState(collectibleDef, profileResponse);
-        if (
-          state === undefined ||
-          state & DestinyCollectibleState.Invisible ||
-          collectibleDef.redacted
-        ) {
-          return [];
-        }
-        return [collectibleDef.itemHash];
-      });
+      const visibleCollectibles: number[] = node.children.collectibles
+        .map((c) => {
+          const collectibleDef = defs.Collectible.get(c.collectibleHash);
+          const state = getCollectibleState(collectibleDef, profileResponse);
+          if (
+            state === undefined ||
+            state & DestinyCollectibleState.Invisible ||
+            collectibleDef.redacted
+          ) {
+            return undefined;
+          }
+          return collectibleDef.itemHash;
+        })
+        .filter((i: number | undefined): i is number => Boolean(i));
       const visibleChildCollectibles = node.children.presentationNodes.flatMap((childNode) =>
         getVisibleCollectibles(defs.PresentationNode.get(childNode.presentationNodeHash))
       );

--- a/src/app/records/selectors.ts
+++ b/src/app/records/selectors.ts
@@ -1,0 +1,40 @@
+import { profileResponseSelector } from 'app/inventory/selectors';
+import { d2ManifestSelector } from 'app/manifest/selectors';
+import { SHADER_NODE } from 'app/search/d2-known-values';
+import { emptySet } from 'app/utils/empty';
+import { DestinyCollectibleState, DestinyPresentationNodeDefinition } from 'bungie-api-ts/destiny2';
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+import { getCollectibleState } from './presentation-nodes';
+
+// A set containing shaders that are displayed in collections for any character.
+export const collectionsVisibleShadersSelector = createSelector(
+  d2ManifestSelector,
+  profileResponseSelector,
+  (defs, profileResponse) => {
+    if (!defs || !profileResponse) {
+      return emptySet<number>();
+    }
+
+    const getVisibleCollectibles = (node: DestinyPresentationNodeDefinition): number[] => {
+      const visibleCollectibles: number[] = node.children.collectibles.flatMap((c) => {
+        const collectibleDef = defs.Collectible.get(c.collectibleHash);
+        const state = getCollectibleState(collectibleDef, profileResponse);
+        if (
+          state === undefined ||
+          state & DestinyCollectibleState.Invisible ||
+          collectibleDef.redacted
+        ) {
+          return [];
+        }
+        return [collectibleDef.itemHash];
+      });
+      const visibleChildCollectibles = node.children.presentationNodes.flatMap((childNode) =>
+        getVisibleCollectibles(defs.PresentationNode.get(childNode.presentationNodeHash))
+      );
+      return _.concat(visibleChildCollectibles, visibleCollectibles);
+    };
+
+    return new Set(getVisibleCollectibles(defs.PresentationNode.get(SHADER_NODE)));
+  }
+);

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -211,6 +211,7 @@ export const armorBuckets = {
 //
 
 export const RAID_NODE = 4025982223;
+export const SHADER_NODE = 1516796296;
 
 //
 // MISC KNOWN HASHES / ENUMS


### PR DESCRIPTION
Removes 63 unavailable shaders for my profile, including Y1 shaders I don't have that are hidden in collections, (Worn) shaders without a collections entry, and dud shaders that don't even have a name.

Fixes #7606.