### PR TITLE
Add Spoils of Conquest to materials display

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 * Fixed an issue where the progress bar for exotic weapons were clipping into other page elements. 
 * Fixed an issue that could make moving searches containing stacks of items to fail.
+* Added Spoils of Conquest to the currencies hover menu.
 
 ## 6.98.0 <span class="changelog-date">(2022-01-02)</span>
 

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -103,7 +103,8 @@ export const materialsSelector = (state: RootState) =>
   allItemsSelector(state).filter(
     (i) =>
       i.itemCategoryHashes.includes(ItemCategoryHashes.Materials) ||
-      i.itemCategoryHashes.includes(ItemCategoryHashes.ReputationTokens)
+      i.itemCategoryHashes.includes(ItemCategoryHashes.ReputationTokens) ||
+      i.hash === 3702027555 // Spoils of Conquest do not have item category hashes
   );
 
 /** The actual raw profile response from the Bungie.net profile API */

--- a/src/app/store-stats/MaterialCounts.tsx
+++ b/src/app/store-stats/MaterialCounts.tsx
@@ -10,7 +10,7 @@ import styles from './MaterialCounts.m.scss';
 
 const retiredMats = [31293053, 49145143, 1305274547, 2014411539];
 const showMats = spiderMats.filter((m) => !retiredMats.includes(m));
-const goodMats = [2979281381, 4257549984, 3853748946, 4257549985];
+const goodMats = [2979281381, 4257549984, 3853748946, 4257549985, 3702027555];
 const seasonal = [1425776985, 1776857076];
 
 export function MaterialCounts() {


### PR DESCRIPTION
This has bugged me in forever. You could argue about the position but somewhere near Ascendant Shards makes sense because raid exotics from the kiosk require both of those.