### PR TITLE
Move Ada and Banshee up in the Vendors view

### DIFF
--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -34,14 +34,7 @@ export interface D2Vendor {
   currencies: DestinyInventoryItemDefinition[];
 }
 
-const vendorOrder = [
-  VENDORS.SPIDER,
-  VENDORS.EVERVERSE,
-  VENDORS.BENEDICT,
-  VENDORS.BANSHEE,
-  VENDORS.DRIFTER,
-  VENDORS.ADA_FORGE,
-];
+const vendorOrder = [VENDORS.SPIDER, VENDORS.ADA_TRANSMOG, VENDORS.BANSHEE, VENDORS.EVERVERSE];
 
 export function toVendorGroups(
   vendorsResponse: DestinyVendorsResponse,


### PR DESCRIPTION
The old order looks like from the Forsaken days. Today seasonal vendors have their own category, so this just keeps Spider at the top of the destination vendors (won't be needed soon) and moves Ada-1 and Banshee up in the Tower vendors because they update the most frequently (daily mods, weekly weapons/armor).