### PR TITLE
Fix universal ornament unlock detection in ornament picker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue that could make moving searches containing stacks of items to fail.
 * Added Spoils of Conquest to the currencies hover menu.
 * Fixed an issue where the Loadout Optimizer would let you pin items from other classes.
+* Fixed an issue where the universal ornament picker would show too many ornaments as unlocked.
 
 ## 6.98.0 <span class="changelog-date">(2022-01-02)</span>
 

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -7,6 +7,7 @@ import { allItemsSelector, profileResponseSelector } from 'app/inventory/selecto
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { d2ManifestSelector, useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
+import { armorBuckets } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptySet } from 'app/utils/empty';
@@ -77,7 +78,17 @@ function mapStateToProps() {
       const plugAllowList = new Set(socketType.plugWhitelist.map((e) => e.categoryHash));
       for (const item of allItems) {
         const itemDef = defs!.InventoryItem.get(item.hash);
-        if (itemDef.plug && plugAllowList.has(itemDef.plug.plugCategoryHash)) {
+        if (
+          itemDef.plug &&
+          plugAllowList.has(itemDef.plug.plugCategoryHash) &&
+          // Filter out items that reside in armor buckets (e.g. regular
+          // instanced armor whose inventory item def double-functions
+          // as a universal ornament plug). This might not be the proper
+          // way to do this. Maybe check API responses after Companion App
+          // gets universal ornaments right?
+          (!itemDef.inventory ||
+            !Object.values(armorBuckets).includes(itemDef.inventory?.bucketTypeHash))
+        ) {
           modHashes.add(item.hash);
         }
       }

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -7,7 +7,6 @@ import { allItemsSelector, profileResponseSelector } from 'app/inventory/selecto
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { d2ManifestSelector, useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
-import { armorBuckets } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptySet } from 'app/utils/empty';
@@ -18,6 +17,7 @@ import {
   SocketPlugSources,
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
+import { BucketHashes } from 'data/d2/generated-enums';
 import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -81,13 +81,7 @@ function mapStateToProps() {
         if (
           itemDef.plug &&
           plugAllowList.has(itemDef.plug.plugCategoryHash) &&
-          // Filter out items that reside in armor buckets (e.g. regular
-          // instanced armor whose inventory item def double-functions
-          // as a universal ornament plug). This might not be the proper
-          // way to do this. Maybe check API responses after Companion App
-          // gets universal ornaments right?
-          (!itemDef.inventory ||
-            !Object.values(armorBuckets).includes(itemDef.inventory?.bucketTypeHash))
+          item.location.hash === BucketHashes.Modifications
         ) {
           modHashes.add(item.hash);
         }


### PR DESCRIPTION
For some reason, the universal ornament sockets are `InventorySourced`, so the universal ornaments picker looked at characters' inventories and vaults and would consider any copies of the armor as unlocked due to inventory presence. I'm not convinced this is the entirely right fix, but at least we're getting it more correct than the companion app.