### PR TITLE
Fashion followups, part 1

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -160,14 +160,18 @@
   },
   "FashionDrawer": {
     "Title": "Choose shaders and ornaments",
-    "Accept": "Use this fashion",
-    "Reset": "Reset all",
+    "Accept": "Save this fashion",
+    "Reset": "Clear fashion",
     "Sync": "Sync",
-    "UseEquipped": "Use Equipped",
+    "UseEquipped": "Use equipped fashion",
     "SyncShaders": "Sync Shaders",
+    "SyncShadersTitle": "Use the same shader on all items",
     "SyncOrnaments": "Sync Ornaments",
+    "SyncOrnamentsTitle": "Use ornaments from the same set on all items, if they're unlocked",
     "ClearShaders": "Clear Shaders",
-    "ClearOrnaments": "Clear Ornaments"
+    "ClearShadersTitle": "Reset all shaders to \"no preference\"",
+    "ClearOrnaments": "Clear Ornaments",
+    "ClearOrnamentsTitle": "Reset all ornaments to \"no preference\""
   },
   "FileUpload": {
     "Instructions": "Click or drag files"

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -160,7 +160,7 @@
   },
   "FashionDrawer": {
     "Title": "Choose shaders and ornaments",
-    "Accept": "Save this fashion",
+    "Accept": "Save fashion",
     "Reset": "Clear fashion",
     "Sync": "Sync",
     "UseEquipped": "Use equipped fashion",

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -171,9 +171,11 @@ export default function LoadoutDrawerContents({
         <a onClick={() => onOpenModPicker()} className="dim-button loadout-add">
           <AppIcon icon={addIcon} /> {t('Loadouts.ArmorMods')}
         </a>
-        <a onClick={() => onOpenFashionDrawer()} className="dim-button loadout-add">
-          <AppIcon icon={faTshirt} /> {t('Loadouts.Fashion')}
-        </a>
+        {loadout.classType !== DestinyClass.Unknown && (
+          <a onClick={() => onOpenFashionDrawer()} className="dim-button loadout-add">
+            <AppIcon icon={faTshirt} /> {t('Loadouts.Fashion')}
+          </a>
+        )}
       </div>
       <div className="loadout-added-items">
         {typesWithItems.map((bucket) =>

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -26,7 +26,6 @@ import { LockableBucketHashes } from 'app/loadout-builder/types';
 import {
   createPluggingStrategy,
   fitMostMods,
-  isAssigningToDefault,
   pickPlugPositions,
 } from 'app/loadout/mod-assignment-utils';
 import { getDefaultPlugHash } from 'app/loadout/mod-utils';
@@ -881,7 +880,7 @@ function applySocketOverrides(
               }));
 
         await dispatch(
-          equipModsToItem(dimItem.id, modsForItem, handleSuccess, handleFailure, cancelToken, true)
+          equipModsToItem(dimItem.id, modsForItem, handleSuccess, handleFailure, cancelToken)
         );
       }
     }
@@ -1095,8 +1094,7 @@ function equipModsToItem(
   onSuccess: (assignment: Assignment) => void,
   /** Callback for state reporting while applying. Mods are applied in parallel so we want to report ASAP. */
   onFailure: (assignment: Assignment, error?: Error, equipNotPossible?: boolean) => void,
-  cancelToken: CancelToken,
-  includeAssignToDefault = false
+  cancelToken: CancelToken
 ): ThunkResult {
   return async (dispatch, getState) => {
     const defs = d2ManifestSelector(getState())!;
@@ -1133,10 +1131,7 @@ function equipModsToItem(
 
       // If the plug is already inserted we can skip this
       if (socket.plugged?.plugDef.hash === mod.hash) {
-        // Don't count removing mods as applying a mod successfully
-        if (includeAssignToDefault || !isAssigningToDefault(item, assignment, defs)) {
-          onSuccess(assignment);
-        }
+        onSuccess(assignment);
         continue;
       }
       if (canInsertPlug(socket, mod.hash, destiny2CoreSettings, defs)) {

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -185,6 +185,20 @@ export default function FashionDrawer({
     const ornaments = Object.values(modsByBucket)
       .flat()
       .filter((h) => !isShader(h));
+
+    // Make it easy to spread default ornament
+    if (ornaments.every((h) => DEFAULT_ORNAMENTS.includes(h))) {
+      setModsByBucket((modsByBucket) =>
+        Object.fromEntries(
+          LockableBucketHashes.map((bucketHash) => [
+            bucketHash,
+            [...(modsByBucket[bucketHash] ?? []).filter((h) => isShader(h)), ornaments[0]],
+          ])
+        )
+      );
+      return;
+    }
+
     const groupedOrnaments = _.groupBy(ornaments, (h) => {
       const collectibleHash =
         defs.InventoryItem.get(h)?.collectibleHash ??
@@ -202,8 +216,9 @@ export default function FashionDrawer({
       return;
     }
 
+    const mostCommon = parseInt(mostCommonOrnamentSet[0], 10);
     const set = _.compact(
-      defs.PresentationNode.get(parseInt(mostCommonOrnamentSet[0], 10)).children.collectibles.map(
+      defs.PresentationNode.get(mostCommon).children.collectibles.map(
         (c) =>
           defs.Collectible.get(c.collectibleHash).itemHash ??
           manuallyFindItemForCollectible(defs, c.collectibleHash)?.hash

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -150,12 +150,23 @@ export default function FashionDrawer({
   };
 
   const handleUseEquipped = () => {
-    const newModsByBucket = _.mapValues(exampleItemsByBucketHash, (item) => {
-      const cosmeticSockets = item.sockets
-        ? getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics)
-        : [];
-      return _.compact(cosmeticSockets.map((s) => s.plugged?.plugDef.hash));
-    });
+    const newModsByBucket = Object.fromEntries(
+      LockableBucketHashes.map((bucketHash) => {
+        // Either the item that's in the loadout, or whatever's equipped
+        const item =
+          armorItemsByBucketHash[bucketHash] ??
+          allItems.find(
+            (i) =>
+              i.bucket.hash === bucketHash &&
+              i.equipped &&
+              (storeId ? i.owner === storeId : i.classType === classType)
+          );
+        const cosmeticSockets = item.sockets
+          ? getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics)
+          : [];
+        return [bucketHash, _.compact(cosmeticSockets.map((s) => s.plugged?.plugDef.hash))];
+      })
+    );
 
     setModsByBucket(newModsByBucket);
   };
@@ -281,12 +292,7 @@ export default function FashionDrawer({
   const leftButtons = (
     <>
       <div>
-        <button
-          type="button"
-          className="dim-button"
-          onClick={handleUseEquipped}
-          disabled={_.isEmpty(armorItemsByBucketHash)}
-        >
+        <button type="button" className="dim-button" onClick={handleUseEquipped}>
           {t('FashionDrawer.UseEquipped')}
         </button>
       </div>

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -252,6 +252,7 @@ export default function FashionDrawer({
           className="dim-button"
           onClick={handleSyncShader}
           disabled={shaders.length === 0}
+          title={t('FashionDrawer.SyncShadersTitle')}
         >
           {isPhonePortrait ? t('FashionDrawer.SyncShaders') : t('FashionDrawer.Sync')}{' '}
           <AppIcon icon={rightArrowIcon} />
@@ -263,6 +264,7 @@ export default function FashionDrawer({
           className="dim-button"
           onClick={handleSyncOrnament}
           disabled={ornaments.length === 0}
+          title={t('FashionDrawer.SyncOrnamentsTitle')}
         >
           {isPhonePortrait ? t('FashionDrawer.SyncOrnaments') : t('FashionDrawer.Sync')}{' '}
           <AppIcon icon={rightArrowIcon} />

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -182,7 +182,7 @@ function FashionMods({ modsForBucket }: { modsForBucket: number[] }) {
   const ornamentItem = ornament ? defs.InventoryItem.get(ornament) : undefined;
 
   const defaultShader = defs.InventoryItem.get(DEFAULT_SHADER);
-  const defaultOrnament = defs.InventoryItem.get(DEFAULT_ORNAMENTS[0]);
+  const defaultOrnament = defs.InventoryItem.get(DEFAULT_ORNAMENTS[2]);
 
   const canSlotShader =
     shader !== undefined && (shader === DEFAULT_SHADER || unlockedPlugSetItems.has(shader));

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -152,7 +152,7 @@
     "Vault": "It will move items to the vault to make room."
   },
   "FashionDrawer": {
-    "Accept": "Save this fashion",
+    "Accept": "Save fashion",
     "ClearOrnaments": "Clear Ornaments",
     "ClearOrnamentsTitle": "Reset all ornaments to \"no preference\"",
     "ClearShaders": "Clear Shaders",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -152,15 +152,19 @@
     "Vault": "It will move items to the vault to make room."
   },
   "FashionDrawer": {
-    "Accept": "Use this fashion",
+    "Accept": "Save this fashion",
     "ClearOrnaments": "Clear Ornaments",
+    "ClearOrnamentsTitle": "Reset all ornaments to \"no preference\"",
     "ClearShaders": "Clear Shaders",
-    "Reset": "Reset all",
+    "ClearShadersTitle": "Reset all shaders to \"no preference\"",
+    "Reset": "Clear fashion",
     "Sync": "Sync",
     "SyncOrnaments": "Sync Ornaments",
+    "SyncOrnamentsTitle": "Use ornaments from the same set on all items, if they're unlocked",
     "SyncShaders": "Sync Shaders",
+    "SyncShadersTitle": "Use the same shader on all items",
     "Title": "Choose shaders and ornaments",
-    "UseEquipped": "Use Equipped"
+    "UseEquipped": "Use equipped fashion"
   },
   "FileUpload": {
     "Instructions": "Click or drag files"


### PR DESCRIPTION
* Reword some buttons
* Add help text to buttons
* Change "Use equipped fashion" to pull from your actually-equipped items if there is not an equipped loadout item in the slot
* Sync ornament now works with the default plug, but only if it's the only one. e.g., you can select "default plug" for one item and hit Sync and they'll all be default, but if you happen to have 2 default plugs and some other ornaments it won't sync "default plug" to all of them then.
* Fix the reporting in loadout-apply for applying the default plug. Either this got messed up in a merge or I had forgotten it in my previous change to fix this.