### PR TITLE
Refactor loadout builder to preserve LO params

### DIFF
--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -19,11 +19,7 @@ import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { useReducer } from 'react';
 import { isLoadoutBuilderItem } from '../loadout/item-utils';
-import {
-  lockedModsFromLoadoutParameters,
-  statFiltersFromLoadoutParamaters,
-  statOrderFromLoadoutParameters,
-} from './loadout-params';
+import { statFiltersFromLoadoutParamaters, statOrderFromLoadoutParameters } from './loadout-params';
 import {
   ArmorSet,
   ArmorStatHashes,
@@ -34,16 +30,14 @@ import {
 } from './types';
 
 export interface LoadoutBuilderState {
+  loadoutParameters: LoadoutParameters;
+  // TODO: also fold statOrder, statFilters into loadoutParameters
   statOrder: ArmorStatHashes[]; // stat hashes, including disabled stats
-  upgradeSpendTier: UpgradeSpendTier;
-  lockItemEnergyType: boolean;
+  statFilters: Readonly<StatFilters>;
   pinnedItems: PinnedItems;
   excludedItems: ExcludedItems;
-  lockedMods: PluggableInventoryItemDefinition[];
-  lockedExoticHash?: number;
   selectedStoreId?: string;
   subclass?: DimLoadoutItem;
-  statFilters: Readonly<StatFilters>;
   modPicker: {
     open: boolean;
     plugCategoryHashWhitelist?: number[];
@@ -161,24 +155,18 @@ const lbStateInit = ({
 
   const statOrder = statOrderFromLoadoutParameters(loadoutParams);
   const statFilters = statFiltersFromLoadoutParamaters(loadoutParams);
-  const lockedMods = lockedModsFromLoadoutParameters(loadoutParams, defs);
-  const lockItemEnergyType = Boolean(loadoutParams?.lockItemEnergyType);
   // We need to handle the deprecated case
-  const upgradeSpendTier =
+  loadoutParams.upgradeSpendTier =
     loadoutParams.upgradeSpendTier === UpgradeSpendTier.AscendantShardsLockEnergyType
       ? UpgradeSpendTier.Nothing
       : loadoutParams.upgradeSpendTier!;
-  const lockedExoticHash = loadoutParams.exoticArmorHash;
 
   return {
-    lockItemEnergyType,
-    upgradeSpendTier,
+    loadoutParameters: loadoutParams,
     statOrder,
     pinnedItems,
     excludedItems: emptyObject(),
     statFilters,
-    lockedMods,
-    lockedExoticHash,
     subclass,
     selectedStoreId,
     modPicker: {
@@ -193,9 +181,9 @@ export type LoadoutBuilderAction =
   | { type: 'sortOrderChanged'; sortOrder: LoadoutBuilderState['statOrder'] }
   | {
       type: 'lockItemEnergyTypeChanged';
-      lockItemEnergyType: LoadoutBuilderState['lockItemEnergyType'];
+      lockItemEnergyType: boolean;
     }
-  | { type: 'upgradeSpendTierChanged'; upgradeSpendTier: LoadoutBuilderState['upgradeSpendTier'] }
+  | { type: 'upgradeSpendTierChanged'; upgradeSpendTier: UpgradeSpendTier }
   | { type: 'pinItem'; item: DimItem }
   | { type: 'setPinnedItems'; items: DimItem[] }
   | { type: 'unpinItem'; item: DimItem }
@@ -219,235 +207,275 @@ export type LoadoutBuilderAction =
   | { type: 'closeCompareDrawer' };
 
 // TODO: Move more logic inside the reducer
-function lbStateReducer(
-  state: LoadoutBuilderState,
-  action: LoadoutBuilderAction
-): LoadoutBuilderState {
-  switch (action.type) {
-    case 'changeCharacter':
-      return {
-        ...state,
-        selectedStoreId: action.storeId,
-        pinnedItems: {},
-        excludedItems: {},
-        lockedExoticHash: undefined,
-      };
-    case 'statFiltersChanged':
-      return { ...state, statFilters: action.statFilters };
-    case 'pinItem': {
-      const { item } = action;
-      const bucketHash = item.bucket.hash;
-      return {
-        ...state,
-        // Remove any previously locked item in that bucket and add this one
-        pinnedItems: {
-          ...state.pinnedItems,
-          [bucketHash]: item,
-        },
-        // Locking an item clears excluded items in this bucket
-        excludedItems: {
-          ...state.excludedItems,
-          [bucketHash]: undefined,
-        },
-      };
-    }
-    case 'setPinnedItems': {
-      const { items } = action;
-      return {
-        ...state,
-        pinnedItems: _.keyBy(items, (i) => i.bucket.hash),
-        excludedItems: {},
-      };
-    }
-    case 'unpinItem': {
-      const { item } = action;
-      const bucketHash = item.bucket.hash;
-      return {
-        ...state,
-        pinnedItems: {
-          ...state.pinnedItems,
-          [bucketHash]: undefined,
-        },
-      };
-    }
-    case 'excludeItem': {
-      const { item } = action;
-      const bucketHash = item.bucket.hash;
-      if (state.excludedItems[bucketHash]?.some((i) => i.id === item.id)) {
-        return state; // item's already there
+function lbStateReducer(defs: D2ManifestDefinitions) {
+  return (state: LoadoutBuilderState, action: LoadoutBuilderAction): LoadoutBuilderState => {
+    switch (action.type) {
+      case 'changeCharacter':
+        return {
+          ...state,
+          selectedStoreId: action.storeId,
+          pinnedItems: {},
+          excludedItems: {},
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            exoticArmorHash: undefined,
+          },
+        };
+      case 'statFiltersChanged':
+        return { ...state, statFilters: action.statFilters };
+      case 'pinItem': {
+        const { item } = action;
+        const bucketHash = item.bucket.hash;
+        return {
+          ...state,
+          // Remove any previously locked item in that bucket and add this one
+          pinnedItems: {
+            ...state.pinnedItems,
+            [bucketHash]: item,
+          },
+          // Locking an item clears excluded items in this bucket
+          excludedItems: {
+            ...state.excludedItems,
+            [bucketHash]: undefined,
+          },
+        };
       }
-      const existingExcluded = state.excludedItems[bucketHash] ?? [];
-      return {
-        ...state,
-        excludedItems: {
-          ...state.excludedItems,
-          [bucketHash]: [...existingExcluded, item],
-        },
-      };
-    }
-    case 'unexcludeItem': {
-      const { item } = action;
-      const bucketHash = item.bucket.hash;
-      const newExcluded = (state.excludedItems[bucketHash] ?? []).filter((i) => i.id !== item.id);
-      return {
-        ...state,
-        excludedItems: {
-          ...state.excludedItems,
-          [bucketHash]: newExcluded.length > 0 ? newExcluded : undefined,
-        },
-      };
-    }
-    case 'lockedModsChanged': {
-      return {
-        ...state,
-        lockedMods: action.lockedMods,
-      };
-    }
-    case 'sortOrderChanged': {
-      return {
-        ...state,
-        statOrder: action.sortOrder,
-      };
-    }
-    case 'lockItemEnergyTypeChanged': {
-      return {
-        ...state,
-        lockItemEnergyType: action.lockItemEnergyType,
-      };
-    }
-    case 'upgradeSpendTierChanged': {
-      return {
-        ...state,
-        upgradeSpendTier: action.upgradeSpendTier,
-      };
-    }
-    case 'addGeneralMods': {
-      let currentGeneralModsCount = state.lockedMods.filter(
-        (mod) => mod.plug.plugCategoryHash === armor2PlugCategoryHashesByName.general
-      ).length;
-
-      const newMods = [...state.lockedMods];
-      const failures: string[] = [];
-
-      for (const mod of action.mods) {
-        if (currentGeneralModsCount < 5) {
-          newMods.push(mod);
-          currentGeneralModsCount++;
-        } else {
-          failures.push(mod.displayProperties.name);
+      case 'setPinnedItems': {
+        const { items } = action;
+        return {
+          ...state,
+          pinnedItems: _.keyBy(items, (i) => i.bucket.hash),
+          excludedItems: {},
+        };
+      }
+      case 'unpinItem': {
+        const { item } = action;
+        const bucketHash = item.bucket.hash;
+        return {
+          ...state,
+          pinnedItems: {
+            ...state.pinnedItems,
+            [bucketHash]: undefined,
+          },
+        };
+      }
+      case 'excludeItem': {
+        const { item } = action;
+        const bucketHash = item.bucket.hash;
+        if (state.excludedItems[bucketHash]?.some((i) => i.id === item.id)) {
+          return state; // item's already there
         }
+        const existingExcluded = state.excludedItems[bucketHash] ?? [];
+        return {
+          ...state,
+          excludedItems: {
+            ...state.excludedItems,
+            [bucketHash]: [...existingExcluded, item],
+          },
+        };
       }
-
-      if (failures.length) {
-        showNotification({
-          title: t('LoadoutBuilder.UnableToAddAllMods'),
-          body: t('LoadoutBuilder.UnableToAddAllModsBody', { mods: failures.join(', ') }),
-          type: 'warning',
-        });
+      case 'unexcludeItem': {
+        const { item } = action;
+        const bucketHash = item.bucket.hash;
+        const newExcluded = (state.excludedItems[bucketHash] ?? []).filter((i) => i.id !== item.id);
+        return {
+          ...state,
+          excludedItems: {
+            ...state.excludedItems,
+            [bucketHash]: newExcluded.length > 0 ? newExcluded : undefined,
+          },
+        };
       }
-
-      return {
-        ...state,
-        lockedMods: newMods,
-      };
-    }
-    case 'removeLockedMod': {
-      const indexToRemove = state.lockedMods.findIndex((mod) => mod.hash === action.mod.hash);
-      const newMods = [...state.lockedMods];
-      newMods.splice(indexToRemove, 1);
-
-      return {
-        ...state,
-        lockedMods: newMods,
-      };
-    }
-    case 'updateSubclass': {
-      const { item } = action;
-      const abilitySockets = getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.Abilities);
-      const defaultAbilityOverrides: SocketOverrides = {};
-      for (const socket of abilitySockets) {
-        defaultAbilityOverrides[socket.socketIndex] = socket.socketDefinition.singleInitialItemHash;
+      case 'lockedModsChanged': {
+        return {
+          ...state,
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            mods: action.lockedMods.map((m) => m.hash),
+          },
+        };
       }
-      return { ...state, subclass: { ...item, socketOverrides: defaultAbilityOverrides } };
-    }
-    case 'removeSubclass': {
-      return { ...state, subclass: undefined };
-    }
-    case 'updateSubclassSocketOverrides': {
-      if (!state.subclass) {
-        return state;
+      case 'sortOrderChanged': {
+        return {
+          ...state,
+          statOrder: action.sortOrder,
+        };
       }
-
-      const { socketOverrides } = action;
-      return { ...state, subclass: { ...state.subclass, socketOverrides } };
-    }
-    case 'removeSingleSubclassSocketOverride': {
-      if (!state.subclass) {
-        return state;
+      case 'lockItemEnergyTypeChanged': {
+        return {
+          ...state,
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            lockItemEnergyType: action.lockItemEnergyType,
+          },
+        };
       }
+      case 'upgradeSpendTierChanged': {
+        return {
+          ...state,
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            upgradeSpendTier: action.upgradeSpendTier,
+          },
+        };
+      }
+      case 'addGeneralMods': {
+        const newMods = [...(state.loadoutParameters.mods ?? [])];
+        let currentGeneralModsCount =
+          newMods.filter(
+            (mod) =>
+              defs.InventoryItem.get(mod)?.plug?.plugCategoryHash ===
+              armor2PlugCategoryHashesByName.general
+          ).length ?? 0;
 
-      const { plug } = action;
-      const abilitySockets = getSocketsByCategoryHash(
-        state.subclass.sockets,
-        SocketCategoryHashes.Abilities
-      );
-      const newSocketOverrides = { ...state.subclass?.socketOverrides };
-      let socketIndexToRemove: number | undefined;
+        const failures: string[] = [];
 
-      // Find the socket index to remove the plug from.
-      for (const socketIndexString of Object.keys(newSocketOverrides)) {
-        const socketIndex = parseInt(socketIndexString, 10);
-        const overridePlugHash = newSocketOverrides[socketIndex];
-        if (overridePlugHash === plug.hash) {
-          socketIndexToRemove = socketIndex;
-          break;
+        for (const mod of action.mods) {
+          if (currentGeneralModsCount < 5) {
+            newMods.push(mod.hash);
+            currentGeneralModsCount++;
+          } else {
+            failures.push(mod.displayProperties.name);
+          }
         }
-      }
 
-      // If we are removing from an ability socket, find the socket so we can
-      // show the default plug instead
-      const abilitySocketRemovingFrom = abilitySockets.find(
-        (socket) => socket.socketIndex === socketIndexToRemove
-      );
+        if (failures.length) {
+          showNotification({
+            title: t('LoadoutBuilder.UnableToAddAllMods'),
+            body: t('LoadoutBuilder.UnableToAddAllModsBody', { mods: failures.join(', ') }),
+            type: 'warning',
+          });
+        }
 
-      if (socketIndexToRemove !== undefined && abilitySocketRemovingFrom) {
-        // If this is an ability socket, replace with the default plug hash
-        newSocketOverrides[socketIndexToRemove] =
-          abilitySocketRemovingFrom.socketDefinition.singleInitialItemHash;
-      } else if (socketIndexToRemove) {
-        // If its not an ability we just remove it from the overrides
-        delete newSocketOverrides[socketIndexToRemove];
+        return {
+          ...state,
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            mods: newMods,
+          },
+        };
       }
-      return {
-        ...state,
-        subclass: {
-          ...state.subclass,
-          socketOverrides: Object.keys(newSocketOverrides).length ? newSocketOverrides : undefined,
-        },
-      };
+      case 'removeLockedMod': {
+        const newMods = [...(state.loadoutParameters.mods ?? [])];
+        const indexToRemove = newMods.findIndex((mod) => mod === action.mod.hash);
+        if (indexToRemove >= 0) {
+          newMods.splice(indexToRemove, 1);
+        }
+
+        return {
+          ...state,
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            mods: newMods,
+          },
+        };
+      }
+      case 'updateSubclass': {
+        const { item } = action;
+        const abilitySockets = getSocketsByCategoryHash(
+          item.sockets,
+          SocketCategoryHashes.Abilities
+        );
+        const defaultAbilityOverrides: SocketOverrides = {};
+        for (const socket of abilitySockets) {
+          defaultAbilityOverrides[socket.socketIndex] =
+            socket.socketDefinition.singleInitialItemHash;
+        }
+        return { ...state, subclass: { ...item, socketOverrides: defaultAbilityOverrides } };
+      }
+      case 'removeSubclass': {
+        return { ...state, subclass: undefined };
+      }
+      case 'updateSubclassSocketOverrides': {
+        if (!state.subclass) {
+          return state;
+        }
+
+        const { socketOverrides } = action;
+        return { ...state, subclass: { ...state.subclass, socketOverrides } };
+      }
+      case 'removeSingleSubclassSocketOverride': {
+        if (!state.subclass) {
+          return state;
+        }
+
+        const { plug } = action;
+        const abilitySockets = getSocketsByCategoryHash(
+          state.subclass.sockets,
+          SocketCategoryHashes.Abilities
+        );
+        const newSocketOverrides = { ...state.subclass?.socketOverrides };
+        let socketIndexToRemove: number | undefined;
+
+        // Find the socket index to remove the plug from.
+        for (const socketIndexString of Object.keys(newSocketOverrides)) {
+          const socketIndex = parseInt(socketIndexString, 10);
+          const overridePlugHash = newSocketOverrides[socketIndex];
+          if (overridePlugHash === plug.hash) {
+            socketIndexToRemove = socketIndex;
+            break;
+          }
+        }
+
+        // If we are removing from an ability socket, find the socket so we can
+        // show the default plug instead
+        const abilitySocketRemovingFrom = abilitySockets.find(
+          (socket) => socket.socketIndex === socketIndexToRemove
+        );
+
+        if (socketIndexToRemove !== undefined && abilitySocketRemovingFrom) {
+          // If this is an ability socket, replace with the default plug hash
+          newSocketOverrides[socketIndexToRemove] =
+            abilitySocketRemovingFrom.socketDefinition.singleInitialItemHash;
+        } else if (socketIndexToRemove) {
+          // If its not an ability we just remove it from the overrides
+          delete newSocketOverrides[socketIndexToRemove];
+        }
+        return {
+          ...state,
+          subclass: {
+            ...state.subclass,
+            socketOverrides: Object.keys(newSocketOverrides).length
+              ? newSocketOverrides
+              : undefined,
+          },
+        };
+      }
+      case 'lockExotic': {
+        const { lockedExoticHash } = action;
+        return {
+          ...state,
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            exoticArmorHash: lockedExoticHash,
+          },
+        };
+      }
+      case 'removeLockedExotic': {
+        return {
+          ...state,
+          loadoutParameters: {
+            ...state.loadoutParameters,
+            exoticArmorHash: undefined,
+          },
+        };
+      }
+      case 'openModPicker':
+        return {
+          ...state,
+          modPicker: {
+            open: true,
+            plugCategoryHashWhitelist: action.plugCategoryHashWhitelist,
+          },
+        };
+      case 'closeModPicker':
+        return { ...state, modPicker: { open: false } };
+      case 'openCompareDrawer':
+        return { ...state, compareSet: action.set };
+      case 'closeCompareDrawer':
+        return { ...state, compareSet: undefined };
     }
-    case 'lockExotic': {
-      const { lockedExoticHash } = action;
-      return { ...state, lockedExoticHash };
-    }
-    case 'removeLockedExotic': {
-      return { ...state, lockedExoticHash: undefined };
-    }
-    case 'openModPicker':
-      return {
-        ...state,
-        modPicker: {
-          open: true,
-          plugCategoryHashWhitelist: action.plugCategoryHashWhitelist,
-        },
-      };
-    case 'closeModPicker':
-      return { ...state, modPicker: { open: false } };
-    case 'openCompareDrawer':
-      return { ...state, compareSet: action.set };
-    case 'closeCompareDrawer':
-      return { ...state, compareSet: undefined };
-  }
+  };
 }
 
 export function useLbState(
@@ -458,7 +486,7 @@ export function useLbState(
   defs: D2ManifestDefinitions
 ) {
   return useReducer(
-    lbStateReducer,
+    lbStateReducer(defs),
     { stores, preloadedLoadout, initialLoadoutParameters, defs, classType },
     lbStateInit
   );

--- a/src/app/loadout-builder/loadout-params.ts
+++ b/src/app/loadout-builder/loadout-params.ts
@@ -4,7 +4,6 @@ import {
   defaultLoadoutParameters,
   LoadoutParameters,
   StatConstraint,
-  UpgradeSpendTier,
 } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
@@ -15,15 +14,13 @@ import _ from 'lodash';
 import { ArmorStatHashes, MinMaxIgnored, StatFilters } from './types';
 
 export function buildLoadoutParams(
-  upgradeSpendTier: UpgradeSpendTier,
-  lockItemEnergyType: boolean,
-  lockedMods: PluggableInventoryItemDefinition[],
+  loadoutParameters: LoadoutParameters,
   searchQuery: string,
   statFilters: Readonly<{ [statType in ArmorStatHashes]: MinMaxIgnored }>,
-  statOrder: number[],
-  exoticArmorHash?: number
+  statOrder: number[]
 ): LoadoutParameters {
   const params: LoadoutParameters = {
+    ...loadoutParameters,
     statConstraints: _.compact(
       statOrder.map((statHash) => {
         const minMax = statFilters[statHash];
@@ -42,18 +39,12 @@ export function buildLoadoutParams(
         return stat;
       })
     ),
-    lockItemEnergyType,
-    upgradeSpendTier,
   };
 
-  if (lockedMods) {
-    params.mods = lockedMods.map((mod) => mod.hash);
-  }
   if (searchQuery) {
     params.query = searchQuery;
-  }
-  if (exoticArmorHash) {
-    params.exoticArmorHash = exoticArmorHash;
+  } else {
+    delete params.query;
   }
 
   return params;


### PR DESCRIPTION
The idea behind LO params is that they represent the share-able parts of a loadout, and that means it has to make it through our tools unmolested. Unfortunately LO still disassembled and reassembled the params. This is the next step towards not doing that anymore, and should result in new additions to LoadoutParameters getting preserved without any extra work. This makes loading shared build links with Fashion work.