### PR TITLE
LO: Clear subclass when switching characters

### DIFF
--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -231,6 +231,7 @@ function lbStateReducer(
         pinnedItems: {},
         excludedItems: {},
         lockedExoticHash: undefined,
+        subclass: undefined,
       };
     case 'statFiltersChanged':
       return { ...state, statFilters: action.statFilters };


### PR DESCRIPTION
Choosing a Stasis subclass for my Warlock, then switching to Titan allows LO to build and save a Titan loadout with Shadebinder, which should not be allowed.