### PR TITLE
Artifact Contents: Show unlock status from perspective of character the page was opened from

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added Spoils of Conquest to the currencies hover menu.
 * Fixed an issue where the Loadout Optimizer would let you pin items from other classes.
 * Shader picker now hides unavailable, unobtainable shaders.
+* "Preview Artifact Contents" in artifact popup now shows unlocked mods from the perspective of the owning character, not the current character.
 
 ## 6.98.0 <span class="changelog-date">(2022-01-02)</span>
 

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -139,7 +139,11 @@ export default function ItemDetails({
 
       {item.previewVendor !== undefined && item.previewVendor !== 0 && (
         <div className="item-description">
-          <Link to={`../vendors/${item.previewVendor}`}>
+          <Link
+            to={`../vendors/${item.previewVendor}${
+              ownerStore && !ownerStore.isVault ? `?characterId=${ownerStore.id}` : ''
+            }`}
+          >
             {t('ItemService.PreviewVendor', { type: item.typeName })}
           </Link>
         </div>


### PR DESCRIPTION
Clicking on any character's artifact and clicking "Preview Artifact Contents" would show unlock checkmarks on the artifact mods, but those were always from the perspective of the currently active character, not the character the item popup was initiated from. This change allows viewing the different unlock statuses for different characters.