### PR TITLE
Make clicking on compare or search results close the item popup again

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed an issue where the universal ornament picker would show too many ornaments as unlocked.
 * Shader picker now hides unavailable, unobtainable shaders.
 * "Preview Artifact Contents" in artifact popup now shows unlocked mods from the perspective of the owning character, not the current character.
+* You can once again click within the Compare sheet to close an item popup.
 
 ## 6.98.0 <span class="changelog-date">(2022-01-02)</span>
 

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -231,7 +231,7 @@ export default function Compare() {
   );
 
   return (
-    <Sheet onClose={cancel} header={header}>
+    <Sheet onClose={cancel} header={header} allowClickThrough>
       <div className="loadout-drawer compare">
         <div
           className={styles.bucket}

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -45,7 +45,7 @@ interface Props {
    * Disable the sheet (no clicking, dragging, or close-on-esc). The sheet will
    * automatically disable itself if another sheet is shown as a child, so no
    * need to set this explicitly most of the time - pretty much just if you need
-   * to communciate that some "global" sheet like the item picker is up.
+   * to communicate that some "global" sheet like the item picker is up.
    */
   disabled?: boolean;
   /** Override the z-index of the sheet. Useful when stacking sheets on top of other sheets or on top of the item popup. */
@@ -54,6 +54,13 @@ interface Props {
   sheetClassName?: string;
   /** If set, the sheet will always be whatever height it was when first rendered, even if the contents change size. */
   freezeInitialHeight?: boolean;
+  /**
+   * Allow clicks to escape this sheet. This allows for things like the popups
+   * in the Compare sheet being closed by clicking in the Compare sheet. By
+   * default we block clicks so that clicks in sheets spawned from within an
+   * item popup don't close the popup they were spawned from!
+   */
+  allowClickThrough?: boolean;
   onClose(): void;
 }
 
@@ -101,6 +108,7 @@ export default function Sheet({
   disabled: forceDisabled,
   zIndex,
   freezeInitialHeight,
+  allowClickThrough,
   onClose,
 }: Props) {
   // This component basically doesn't render - it works entirely through setSpring and useDrag.
@@ -223,7 +231,7 @@ export default function Sheet({
           onKeyDown={stopPropagation}
           onKeyUp={stopPropagation}
           onKeyPress={stopPropagation}
-          onClick={stopPropagation}
+          onClick={allowClickThrough ? undefined : stopPropagation}
         >
           <a
             href="#"

--- a/src/app/search/SearchResults.tsx
+++ b/src/app/search/SearchResults.tsx
@@ -32,6 +32,7 @@ export default function SearchResults({ items, onClose }: { items: DimItem[]; on
       onClose={onClose}
       header={header}
       sheetClassName={clsx('item-picker', styles.searchResults)}
+      allowClickThrough={true}
     >
       <ClickOutsideRoot>
         <div className={clsx('sub-bucket', styles.contents)}>


### PR DESCRIPTION
Fixes #7657 by basically reverting my ill-informed revert of allowClickthrough. I tried some other, more clever ways of plumbing this, but they all failed in one way or another.