### PR TITLE
Skip attempting to apply fashion mods that can't be assigned to their item

### DIFF
--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -15,7 +15,7 @@ import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { AppIcon, clearIcon, rightArrowIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
-import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import { getSocketsByCategoryHash, plugFitsIntoSocket } from 'app/utils/socket-utils';
 import {
   DestinyCollectibleDefinition,
   DestinyInventoryItemDefinition,
@@ -137,9 +137,7 @@ export default function FashionDrawer({
     setModsByBucket((modsByBucket) => {
       // Clear out existing selections for this socket.
       const existingMods = (modsByBucket[item.bucket.hash] ?? []).filter(
-        (mod) =>
-          mod !== socket.socketDefinition.singleInitialItemHash &&
-          !socket.plugSet?.plugs.some((p) => p.plugDef.hash === mod)
+        (mod) => !plugFitsIntoSocket(socket, mod)
       );
 
       return {

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -15,7 +15,11 @@ import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { getModTypeTagByPlugCategoryHash, getSpecialtySocketMetadatas } from 'app/utils/item-utils';
 import { warnLog } from 'app/utils/log';
-import { getSocketByIndex, getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import {
+  getSocketByIndex,
+  getSocketsByCategoryHash,
+  plugFitsIntoSocket,
+} from 'app/utils/socket-utils';
 import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -347,10 +351,8 @@ export function pickPlugPositions(
     // If it wasn't found already plugged, find the first socket with a matching PCH
     // TO-DO: this is naive and is going to be misleading for armor
     if (destinationSocketIndex === -1) {
-      destinationSocketIndex = existingModSockets.findIndex(
-        (socket) =>
-          socket.socketDefinition.singleInitialItemHash === modToInsert.hash ||
-          socket.plugSet?.plugs.some((dimPlug) => dimPlug.plugDef.hash === modToInsert.hash)
+      destinationSocketIndex = existingModSockets.findIndex((socket) =>
+        plugFitsIntoSocket(socket, modToInsert.hash)
       );
     }
 

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -148,3 +148,17 @@ export function getArmorExoticPerkSocket(item: DimItem): DimSocket | undefined {
 export function socketContainsIntrinsicPlug(socket: DimSocket) {
   return socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics;
 }
+
+/**
+ * Is this one of the plugs that could possibly fit into this socket? This does not
+ * check whether the plug is enabled or unlocked - only that it appears in the list of
+ * possible plugs.
+ */
+export function plugFitsIntoSocket(socket: DimSocket, plugHash: number) {
+  return (
+    socket.socketDefinition.singleInitialItemHash === plugHash ||
+    (socket.plugSet
+      ? socket.plugSet.plugs.some((dimPlug) => dimPlug.plugDef.hash === plugHash)
+      : socket.plugOptions.some((p) => p.plugDef.hash === plugHash))
+  );
+}


### PR DESCRIPTION
This partially fixes #7704 - it won't break the loadout anymore, and it won't block other actions from happening, though it does still report as a failure. To fully fix this I'll need to invent a new status for these conditions.