### PR TITLE
Nicer loadouts on mobile

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* The Loadouts page is a bit cleaner and more compact in the mobile view.
+
 ## 6.99.0 <span class="changelog-date">(2022-01-09)</span>
 
 * You can now add Fashion (shaders and ornaments) to loadouts. Creating a loadout from equipped automatically adds in the current shaders and ornaments, and you can edit them manually from the Loadouts editor.

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -94,7 +94,19 @@ $issue-banner-height: 101px;
   }
 }
 
-// Show visible scrollbars when scrollable, even if the OS (e.g. macOS) prefers hidden scrollbars
+// Emulate the gap property for flexbox. Not all browsers support it (notably
+// iOS Safari < 14.5 and Chrome < 84). Use this instead of
+// horizontal/vertical-space-children only if you'll have wrapping content.
+@mixin flex-gap($gapRow, $gapColumn: $gapRow, $marginBottom: 0, $marginRight: 0) {
+  margin-bottom: -1 * $gapRow + $marginBottom;
+  margin-right: -1 * $gapColumn + $marginRight;
+  > * {
+    margin-bottom: $gapRow;
+    margin-right: $gapColumn;
+  }
+}
+
+// Show visible scrollbars when scrollable, even if the OS (e.g. macOS) prefers hidden scrollbars.
 @mixin visible-scrollbars {
   &::-webkit-scrollbar-track {
     background: #555;

--- a/src/app/inventory/ItemPowerSet.m.scss
+++ b/src/app/inventory/ItemPowerSet.m.scss
@@ -3,7 +3,7 @@
   margin: auto;
   width: fit-content;
   grid-template-columns: max-content max-content max-content max-content;
-  grid-gap: 1px 6px;
+  gap: 1px 6px;
   align-items: center;
 
   img {

--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -68,7 +68,7 @@
 .plug-stats {
   display: grid;
   grid-template: auto / auto 1fr;
-  grid-column-gap: 4px;
+  column-gap: 4px;
   margin-top: 4px;
   > div {
     &:nth-child(2n + 1) {

--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -3,7 +3,7 @@
 .loadout {
   composes: flexColumn from '../dim-ui/common.m.scss';
   margin-bottom: 10px;
-  padding: 20px;
+  padding: 15px;
   background: rgba(0, 0, 0, 0.25);
 }
 
@@ -26,7 +26,7 @@
 .actions {
   composes: flexRow from '../dim-ui/common.m.scss';
   flex-flow: row wrap;
-  @include horizontal-space-children(4px);
+  @include flex-gap(4px);
   @include phone-portrait {
     margin-top: 16px;
     margin-bottom: 16px;
@@ -41,6 +41,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  @include phone-portrait {
+    display: none;
+  }
 }
 
 .missingItems {
@@ -56,10 +59,13 @@
 }
 
 .contents {
-  composes: flexRow from '../dim-ui/common.m.scss';
-  gap: calc(4 * var(--item-margin));
-  flex-wrap: wrap;
+  display: flex;
+  flex-flow: row wrap;
   margin-top: 10px;
+  @include flex-gap(24px);
+  @include phone-portrait {
+    @include flex-gap(12px);
+  }
 }
 
 .classIcon {

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -12,6 +12,7 @@ import { getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
+import { useIsPhonePortrait } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import clsx from 'clsx';
@@ -52,6 +53,7 @@ export default function LoadoutView({
   const allItems = useSelector(allItemsSelector);
   const getModRenderKey = createGetModRenderKey();
   const [showModAssignmentDrawer, setShowModAssignmentDrawer] = useState(false);
+  const isPhonePortrait = useIsPhonePortrait();
 
   // Turn loadout items into real DimItems, filtering out unequippable items
   const [items, subclass, warnitems] = useMemo(() => {
@@ -107,9 +109,9 @@ export default function LoadoutView({
       <div className={styles.contents}>
         {(items.length > 0 || subclass || savedMods.length > 0 || !_.isEmpty(modsByBucket)) && (
           <>
-            <div>
+            {(!isPhonePortrait || subclass) && (
               <LoadoutSubclassSection defs={defs} subclass={subclass} power={power} />
-            </div>
+            )}
             {['Weapons', 'Armor', 'General'].map((category) => (
               <LoadoutItemCategorySection
                 key={category}
@@ -152,7 +154,7 @@ export default function LoadoutView({
                 )}
               </div>
             ) : (
-              <div className={styles.modsPlaceholder}>{t('Loadouts.Mods')}</div>
+              !isPhonePortrait && <div className={styles.modsPlaceholder}>{t('Loadouts.Mods')}</div>
             )}
           </>
         )}

--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -2,10 +2,6 @@
 
 .page {
   margin-top: 10px;
-  @include phone-portrait {
-    padding-left: 10px;
-    padding-right: 10px;
-  }
 }
 
 .menu {

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -18,7 +18,7 @@ import { showNotification } from 'app/notifications/notifications';
 import { startWordRegexp } from 'app/search/search-filters/freeform';
 import { useSetting } from 'app/settings/hooks';
 import { LoadoutSort } from 'app/settings/initial-settings';
-import { addIcon, AppIcon, faCalculator } from 'app/shell/icons';
+import { addIcon, AppIcon, deleteIcon, faCalculator } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { copyString } from 'app/utils/util';
@@ -228,7 +228,7 @@ function LoadoutRow({
           className="dim-button"
           onClick={() => handleDeleteClick(loadout)}
         >
-          {t('Loadouts.Delete')}
+          <AppIcon icon={deleteIcon} title={t('Loadouts.Delete')} />
         </button>
       );
     }

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -9,6 +9,7 @@ import { getLoadoutStats } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { AppIcon, faCalculator } from 'app/shell/icons';
+import { useIsPhonePortrait } from 'app/shell/selectors';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
 import { emptyArray } from 'app/utils/empty';
 import clsx from 'clsx';
@@ -52,6 +53,7 @@ export default function LoadoutItemCategorySection({
   const defs = useD2Definitions()!;
   const buckets = useSelector(bucketsSelector)!;
   const itemsByBucket = _.groupBy(items, (i) => i.bucket.hash);
+  const isPhonePortrait = useIsPhonePortrait();
   const bucketOrder =
     category === 'Weapons' || category === 'Armor'
       ? buckets.byCategory[category]
@@ -64,6 +66,10 @@ export default function LoadoutItemCategorySection({
 
   const isArmor = category === 'Armor';
   const hasFashion = isArmor && !_.isEmpty(modsByBucket);
+
+  if (isPhonePortrait && !items && !hasFashion) {
+    return null;
+  }
 
   return (
     <div key={category} className={clsx(styles.itemCategory, categoryStyles[category])}>

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.m.scss
@@ -3,7 +3,6 @@
 .subclassContainer {
   --item-icon-size: calc(0.8 * var(--item-size));
   composes: flexRow from '../../dim-ui/common.m.scss';
-  width: calc(var(--item-icon-size) + 3 * var(--item-icon-size) + 2 * var(--item-margin));
 }
 
 .subclass {
@@ -30,7 +29,8 @@
 
 .subclassMods {
   --item-icon-size: calc(0.8 * var(--item-size));
-  min-width: calc(3 * var(--item-icon-size) + 2 * var(--item-margin));
+  width: calc(3 * var(--item-icon-size) + 2 * var(--item-margin));
+  margin-right: calc(-1 * var(--item-margin) + #{$item-border-width});
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--item-icon-size));
   gap: 4px;
@@ -43,5 +43,5 @@
 
 .modsPlaceholder {
   composes: placeholder from '../LoadoutView.m.scss';
-  flex: 1;
+  width: calc(3 * var(--item-icon-size) + var(--item-margin) + #{$item-border-width}) !important;
 }

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.m.scss
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.m.scss
@@ -36,8 +36,7 @@
 }
 
 .unassigned {
-  display: flex;
-  flex-direction: row;
+  composes: sub-bucket from global;
 }
 
 .headerInfo {

--- a/src/app/store-stats/MaterialCounts.m.scss
+++ b/src/app/store-stats/MaterialCounts.m.scss
@@ -3,7 +3,7 @@
   margin: auto;
   width: fit-content;
   grid-template-columns: max-content max-content max-content;
-  grid-gap: 2px 6px;
+  gap: 2px 6px;
   align-items: center;
 
   img {


### PR DESCRIPTION
While this makes it a bit harder to discover the capabilities of loadouts on mobile, it does make them a lot nicer to scroll through. There's no column alignment to preserve like we have in the full desktop layout:

<img width="195" alt="Screen Shot 2022-01-09 at 5 57 24 PM" src="https://user-images.githubusercontent.com/313208/148710492-e25251fd-8958-4379-9259-31f8ecfc5eff.png">
