### PR TITLE
Set a maximum length for loadout notes

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -242,6 +242,7 @@ export default function LoadoutDrawer() {
           onChange={handleNotesChanged}
           value={loadout.notes}
           placeholder={t('Loadouts.NotesPlaceholder')}
+          maxLength={2048}
         />
       )}
       <GeneratedLoadoutStats items={items} loadout={loadout} savedMods={savedMods} />


### PR DESCRIPTION
This sets an arbitrary but pretty generous cap on loadout notes in the UI. I'll be updating the API to reject loadouts with longer notes than these.