### PR TITLE
Vendor item compare

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -93,7 +93,8 @@
     "ButtonHelp": "Compare Items",
     "CompareBaseStats": "Show Base Stats",
     "InitialItem": "This is the item the Compare tool was launched from",
-    "IsVendorItem": "This item is in a vendor's inventory:",
+    "IsVendorItem": "This item is not owned. This is in a vendor's inventory and may be for sale.",
+    "SoldBy": "Sold by:",
     "Error": {
       "Unmatched": "This item doesn't match the type of items being compared."
     },

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -93,6 +93,7 @@
     "ButtonHelp": "Compare Items",
     "CompareBaseStats": "Show Base Stats",
     "InitialItem": "This is the item the Compare tool was launched from",
+    "IsVendorItem": "This item is in a vendor's inventory:",
     "Error": {
       "Unmatched": "This item doesn't match the type of items being compared."
     },

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -65,8 +65,8 @@ export default function Compare() {
   const dispatch = useThunkDispatch();
   const defs = useD2Definitions()!;
   const [compareBaseStats, setCompareBaseStats] = useSetting('compareBaseStats');
-  const rawCompareItems = useSelector(compareItemsSelector);
   const session = useSelector(compareSessionSelector);
+  const rawCompareItems = useSelector(compareItemsSelector(session?.vendorCharacterId));
   const organizerLink = useSelector(compareOrganizerLinkSelector);
   const isPhonePortrait = useIsPhonePortrait();
 

--- a/src/app/compare/CompareItem.m.scss
+++ b/src/app/compare/CompareItem.m.scss
@@ -5,6 +5,10 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  height: 32px;
+  > div {
+    min-width: 32px;
+  }
   // pull & lock buttons
   > div:nth-child(1),
   > div:nth-child(2) {

--- a/src/app/compare/CompareItem.m.scss
+++ b/src/app/compare/CompareItem.m.scss
@@ -29,13 +29,15 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  cursor: pointer;
   margin-top: 2px;
   margin-bottom: 2px;
   :global(.app-icon) {
     font-size: 8px;
     margin-right: 2px;
     vertical-align: initial;
+  }
+  &.isFindable {
+    cursor: pointer;
   }
 }
 

--- a/src/app/compare/CompareItem.m.scss.d.ts
+++ b/src/app/compare/CompareItem.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'close': string;
   'header': string;
   'initialItem': string;
+  'isFindable': string;
   'itemAside': string;
   'itemName': string;
 }

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -6,16 +6,19 @@ import { moveItemTo } from 'app/inventory/move-item';
 import { currentStoreSelector } from 'app/inventory/selectors';
 import ActionButton from 'app/item-actions/ActionButton';
 import { LockActionButton, TagActionButton } from 'app/item-actions/ActionButtons';
+import { useD2Definitions } from 'app/manifest/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useSetCSSVarToHeight } from 'app/utils/hooks';
 import clsx from 'clsx';
+import _ from 'lodash';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem, DimSocket } from '../inventory/item-types';
 import ItemSockets from '../item-popup/ItemSockets';
 import ItemTalentGrid from '../item-popup/ItemTalentGrid';
-import { AppIcon, faArrowCircleDown, searchIcon } from '../shell/icons';
+import { AppIcon, faArrowCircleDown, searchIcon, shoppingCart } from '../shell/icons';
 import { StatInfo } from './Compare';
 import styles from './CompareItem.m.scss';
 import CompareStat from './CompareStat';
@@ -48,23 +51,33 @@ export default function CompareItem({
     dispatch(moveItemTo(item, currentStore, false));
   }, [currentStore, dispatch, item]);
 
+  const { pathname } = useLocation();
+  const isFindable = !item.vendor && pathname.endsWith('/inventory');
+
   const itemHeader = useMemo(
     () => (
       <div ref={headerRef}>
         <div className={styles.header}>
-          <ActionButton title={t('Hotkey.Pull')} onClick={pullItem}>
-            <AppIcon icon={faArrowCircleDown} />
-          </ActionButton>
+          {item.vendor ? (
+            <VendorItemWarning item={item} />
+          ) : (
+            <ActionButton title={t('Hotkey.Pull')} onClick={pullItem}>
+              <AppIcon icon={faArrowCircleDown} />
+            </ActionButton>
+          )}
           <LockActionButton item={item} />
           <TagActionButton item={item} label={false} hideKeys={true} />
           <div className={styles.close} onClick={() => remove(item)} role="button" tabIndex={0} />
         </div>
         <div
-          className={clsx(styles.itemName, { [styles.initialItem]: isInitialItem })}
-          title={isInitialItem ? t('Compare.InitialItem') : undefined}
+          className={clsx(styles.itemName, {
+            [styles.initialItem]: isInitialItem,
+            [styles.isFindable]: isFindable,
+          })}
           onClick={() => itemClick(item)}
         >
-          {item.name} <AppIcon icon={searchIcon} />
+          <span title={isInitialItem ? t('Compare.InitialItem') : undefined}>{item.name}</span>{' '}
+          {isFindable && <AppIcon icon={searchIcon} />}
         </div>
         <ItemPopupTrigger item={item} noCompare={true}>
           {(ref, onClick) => (
@@ -77,7 +90,7 @@ export default function CompareItem({
         </ItemPopupTrigger>
       </div>
     ),
-    [isInitialItem, item, itemClick, pullItem, remove, itemNotes]
+    [isInitialItem, item, itemClick, pullItem, remove, itemNotes, isFindable]
   );
 
   return (
@@ -99,4 +112,27 @@ export default function CompareItem({
       {item.sockets && <ItemSockets item={item} minimal={true} onPlugClicked={onPlugClicked} />}
     </div>
   );
+}
+
+function VendorItemWarning({ item }: { item: DimItem }) {
+  const defs = useD2Definitions()!;
+  return item.vendor ? (
+    <PressTip
+      elementType="span"
+      tooltip={() => {
+        const vendorName = defs.Vendor.get(item.vendor!.vendorHash).displayProperties.name;
+        return (
+          <>
+            {t('Compare.IsVendorItem')}
+            <br />
+            {vendorName}
+          </>
+        );
+      }}
+    >
+      <ActionButton onClick={_.noop} disabled title={t('Hotkey.Pull')}>
+        <AppIcon icon={shoppingCart} />
+      </ActionButton>
+    </PressTip>
+  ) : null;
 }

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -125,7 +125,7 @@ function VendorItemWarning({ item }: { item: DimItem }) {
           <>
             {t('Compare.IsVendorItem')}
             <br />
-            {vendorName}
+            {t('Compare.SoldBy')} {vendorName}
           </>
         );
       }}

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -65,8 +65,8 @@ export default function CompareItem({
               <AppIcon icon={faArrowCircleDown} />
             </ActionButton>
           )}
-          <LockActionButton item={item} />
-          <TagActionButton item={item} label={false} hideKeys={true} />
+          {item.lockable ? <LockActionButton item={item} /> : <div />}
+          {item.taggable ? <TagActionButton item={item} label={false} hideKeys={true} /> : <div />}
           <div className={styles.close} onClick={() => remove(item)} role="button" tabIndex={0} />
         </div>
         <div

--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -22,6 +22,11 @@ export interface CompareSession {
    */
   readonly initialItemId?: string;
 
+  /**
+   * The ID of the character (if any) whose vendor response we should intermingle with owned items
+   */
+  readonly vendorCharacterId?: string;
+
   // TODO: Query history to offer back/forward navigation within compare sessions?
 }
 
@@ -124,12 +129,15 @@ function addCompareItem(state: CompareState, item: DimItem): CompareState {
       ? `name:"${stripAdept(item.name)}"`
       : `name:"${item.name}"`;
 
+    const vendorCharacterId = item.vendor?.characterId;
+
     return {
       ...state,
       session: {
         query: itemNameQuery,
         itemCategoryHashes,
         initialItemId: item.id,
+        vendorCharacterId,
       },
     };
   }

--- a/src/app/compare/selectors.ts
+++ b/src/app/compare/selectors.ts
@@ -24,12 +24,16 @@ const compareVendorItemsSelector = createSelector(
   (state: RootState) => state,
   (state: RootState) => state.compare.session?.vendorCharacterId,
   vendorGroupsForCharacterSelector,
-  (state, vendorCharacterId) =>
-    _.compact(
+  (state, vendorCharacterId) => {
+    if (!vendorCharacterId) {
+      return emptyArray<DimItem>();
+    }
+    return _.compact(
       vendorGroupsForCharacterSelector(vendorCharacterId)(state).flatMap((vg) =>
         vg.vendors.flatMap((vs) => vs.items.map((vi) => vi.item))
       )
-    )
+    );
+  }
 );
 
 /**

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -48,6 +48,7 @@ const faSignInAlt = 'fas fa-sign-in-alt';
 const faSignOutAlt = 'fas fa-sign-out-alt';
 const faChevronDown = 'fas fa-chevron-down';
 const faChevronUp = 'fas fa-chevron-up';
+const faShoppingCart = 'fas fa-shopping-cart';
 const faStar = 'fas fa-star';
 const faStarHalfAlt = 'fas fa-star-half-alt';
 const faStarOutline = 'far fa-star';
@@ -123,6 +124,7 @@ export {
   faCheckCircleRegular as unselectedCheckIcon,
   faChevronCircleDown as openDropdownIcon,
   faChevronCircleUp,
+  faShoppingCart as shoppingCart,
   faCircleRegular as uncompletedIcon,
   faCog as settingsIcon,
   faCopy as copyIcon,

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -31,32 +31,36 @@ export const mergedCollectiblesSelector = createSelector(
 /**
  * returns a character's vendors and their sale items
  */
-export const vendorGroupsForCharacterSelector = currySelector(
-  createSelector(
-    d2ManifestSelector,
-    vendorsByCharacterSelector,
-    mergedCollectiblesSelector,
-    bucketsSelector,
-    currentAccountSelector,
-    // get character ID from props not state
-    (state: any, characterId: string | undefined) =>
-      characterId || getCurrentStore(sortedStoresSelector(state))?.id,
-    (defs, vendors, mergedCollectibles, buckets, currentAccount, selectedStoreId) => {
-      const vendorData = selectedStoreId ? vendors[selectedStoreId] : undefined;
-      const vendorsResponse = vendorData?.vendorsResponse;
+export const nonCurriedVendorGroupsForCharacterSelector = createSelector(
+  d2ManifestSelector,
+  vendorsByCharacterSelector,
+  mergedCollectiblesSelector,
+  bucketsSelector,
+  currentAccountSelector,
+  // get character ID from props not state
+  (state: any, characterId: string | undefined) =>
+    characterId || getCurrentStore(sortedStoresSelector(state))?.id,
+  (defs, vendors, mergedCollectibles, buckets, currentAccount, selectedStoreId) => {
+    const vendorData = selectedStoreId ? vendors[selectedStoreId] : undefined;
+    const vendorsResponse = vendorData?.vendorsResponse;
 
-      return vendorsResponse && defs && buckets && currentAccount && selectedStoreId
-        ? toVendorGroups(
-            vendorsResponse,
-            defs,
-            buckets,
-            currentAccount,
-            selectedStoreId,
-            mergedCollectibles
-          )
-        : emptyArray<D2VendorGroup>();
-    }
-  )
+    return vendorsResponse && defs && buckets && currentAccount && selectedStoreId
+      ? toVendorGroups(
+          vendorsResponse,
+          defs,
+          buckets,
+          currentAccount,
+          selectedStoreId,
+          mergedCollectibles
+        )
+      : emptyArray<D2VendorGroup>();
+  }
+);
+/**
+ * returns a character's vendors and their sale items
+ */
+export const vendorGroupsForCharacterSelector = currySelector(
+  nonCurriedVendorGroupsForCharacterSelector
 );
 
 export const ownedVendorItemsSelector = currySelector(

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -171,6 +171,9 @@ export class VendorItem {
       // if this is sold by a vendor, add vendor information
       if (saleItem && characterId) {
         this.item.vendor = { vendorHash, saleIndex: saleItem.vendorItemIndex, characterId };
+        if (this.item.equipment) {
+          this.item.comparable = true;
+        }
       }
     }
 

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -91,7 +91,8 @@
       "Unmatched": "This item doesn't match the type of items being compared."
     },
     "InitialItem": "This is the item the Compare tool was launched from",
-    "IsVendorItem": "This item is in a vendor's inventory:",
+    "IsVendorItem": "This item is not owned. This is in a vendor's inventory and may be for sale.",
+    "SoldBy": "Sold by:",
     "SwipeAdvice": "Use two fingers to scroll"
   },
   "Cooldown": {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -91,6 +91,7 @@
       "Unmatched": "This item doesn't match the type of items being compared."
     },
     "InitialItem": "This is the item the Compare tool was launched from",
+    "IsVendorItem": "This item is in a vendor's inventory:",
     "SwipeAdvice": "Use two fingers to scroll"
   },
   "Cooldown": {


### PR DESCRIPTION
turns out a bunch of the required prep work was split out and merged in september..

anyway, this flags vendor items as comparable,
and includes them in the compare items selector *(when launched from a vendor item)*
![image](https://user-images.githubusercontent.com/68782081/148792517-cafebad1-6ec2-4e24-9741-2b267cd65002.png)

and replaces their Pull button with a warning that they're vendor items
![image](https://user-images.githubusercontent.com/68782081/148794080-a020d5a4-041f-4be3-9a72-0bf84e95a9b2.png)
