### PR TITLE
Don't clear fashion mods if none are requested

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Applying a loadout *without* fashion will no longer remove shaders and ornaments from your armor.
+
 ## 6.99.1 <span class="changelog-date">(2022-01-10)</span>
 
 * The Loadouts page is a bit cleaner and more compact in the mobile view.

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -952,7 +952,6 @@ function applyLoadoutMods(
     }
 
     // TODO: prefer equipping to armor that *is* part of the loadout
-    // TODO: compute assignments should consider which mods are already on the item!
     const { itemModAssignments, unassignedMods } = fitMostMods(armor, mods, defs);
 
     for (const mod of unassignedMods) {

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -333,10 +333,13 @@ export function pickPlugPositions(
   if (!item.sockets) {
     return assignments;
   }
-  const existingModSockets = [
-    ...getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorMods),
-    ...getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics),
-  ].sort(
+  const armorModSockets = getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorMods);
+  const fashionModSockets = getSocketsByCategoryHash(
+    item.sockets,
+    SocketCategoryHashes.ArmorCosmetics
+  );
+
+  const existingModSockets = [...armorModSockets, ...fashionModSockets].sort(
     // We are sorting so that we can assign mods to the socket with the least number of possible options
     // first. This helps with artificer mods as the socket is a subset of the other mod sockets on the item
     compareBy((socket) => (socket.plugSet ? socket.plugSet.plugs.length : 999))
@@ -376,11 +379,10 @@ export function pickPlugPositions(
     existingModSockets.splice(destinationSocketIndex, 1);
   }
 
-  // For each remaining socket that won't have mods assigned,
-  // return it to its default (usually "Empty Mod Socket")
-
-  // so we fall back to the first item in its reusable PlugSet
-  for (const socket of existingModSockets) {
+  // For each remaining armor mod socket that won't have mods assigned,
+  // allow it to be returned to its default (usually "Empty Mod Socket").
+  // We only do this for armor mods - fashion mods shouldn't ever be reset.
+  for (const socket of armorModSockets) {
     const defaultModHash = getDefaultPlugHash(socket, defs);
     const mod =
       defaultModHash &&


### PR DESCRIPTION
Fixes #7708, I think. The repro should be easy given the bug but I haven't gotten it to happen yet.

I didn't fully understand what `pickPlugPositions` was doing, so when I added the fashion sockets to it, it nominated those as options to be removed. Then `createPluggingStrategy` would choose them to be removed because it would include zero-gain `optionalRegains`, and it'd try applying them to try and "add up" gains to allow a mod to be slotted. For example, if we needed to free up 3 energy from a mod, and the `optionalGains` were `[0, 0, -1, -2]` (where the 0s are the shader/ornament), it would reset the shader and ornament, then the two mods it actually needed.

While I was in there I realized it's probably easier to patch in the fashion mods after `pickPlugPositions` rather than after `fitMostMods`.

**I haven't tested this** because I'm going to bed, but I think it should work :-D
