### PR TITLE
More robustly identify socket kind in order to name mod/ornament/shader in plug picker popup

### DIFF
--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -8,7 +8,6 @@ import { isPluggableItem } from 'app/inventory/store/sockets';
 import { d2ManifestSelector, useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import { collectionsVisibleShadersSelector } from 'app/records/selectors';
-import { DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptySet } from 'app/utils/empty';
@@ -19,7 +18,7 @@ import {
   SocketPlugSources,
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { BucketHashes } from 'data/d2/generated-enums';
+import { BucketHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -66,10 +65,12 @@ function mapStateToProps() {
    * plugs.
    */
   const shownLockedPlugsSelector = createSelector(
+    d2ManifestSelector,
     collectionsVisibleShadersSelector,
     (_state: RootState, { socket }: ProvidedProps) => socket.socketDefinition,
-    (visibleShaders, socketDef) => {
-      if (socketDef.singleInitialItemHash === DEFAULT_SHADER) {
+    (defs, visibleShaders, socketDef) => {
+      const socketType = defs?.SocketType.get(socketDef.socketTypeHash);
+      if (socketType?.plugWhitelist.some((p) => p.categoryHash === PlugCategoryHashes.Shader)) {
         return visibleShaders;
       }
       return undefined;

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -27,28 +27,11 @@ export const DEFAULT_SHADER = 4248210736; // InventoryItem "Default Shader"
 /** the default glow InventoryItem in every empty glow slot */
 export const DEFAULT_GLOW = 3807544519; // InventoryItem "Remove Armor Glow"
 
-/** the default empty ghost projection in ghost projection slots */
-export const DEFAULT_PROJECTION = 2426387438;
-
-/** the default transmat effect in ship transmat effect slots */
-export const DEFAULT_TRANSMAT = 1390587439;
-
 /** An array of default ornament hashes */
 export const DEFAULT_ORNAMENTS: number[] = [
   2931483505, // InventoryItem "Default Ornament"
   1959648454, // InventoryItem "Default Ornament"
   702981643, // InventoryItem "Default Ornament"
-];
-
-/** the default empty fragment for Subclasses 2.0 */
-export const DEFAULT_FRAGMENT = 3251563851;
-
-// TODO: Is there a way to recognize these without hardcoding every 2.0 subclass?
-/** the default empty aspects for Subclasses 2.0 */
-export const DEFAULT_ASPECTS: number[] = [
-  321296654, // Stasis Titan
-  3819991001, // Stasis Warlock
-  1715180370, // Stasis Hunter
 ];
 
 /** if a socket contains these, consider it empty */


### PR DESCRIPTION
The same assumption that lead to #7720 also leads to some missed socket identification in the popup, causing some amusement in Discord when a random piece of boots would call its shaders "mods".

With this PR, we should always call shaders "Shader" in the shader picker even when the collections entry of the item has a non-empty shader.