### PR TITLE
Avoid react error in Records when profile response doesn't have seals or triumphs hash

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Applying a loadout *without* fashion will no longer remove shaders and ornaments from your armor.
 * The shader picker now filters invalid shaders more consistently and won't call shaders "mods".
+* Fixed Records page sometimes duplicating Triumphs or Seals section while missing Collections.
 
 ## 6.99.1 <span class="changelog-date">(2022-01-10)</span>
 

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -88,11 +88,10 @@ export default function Records({ account }: Props) {
     ? Object.keys(destiny2CoreSettings)
         .filter((k) => k.includes('RootNode'))
         .map((k) => destiny2CoreSettings[k] as number)
-        .filter((n) => !profileHashes.includes(n))
     : [];
 
   // We put the hashes we know about from profile first
-  const nodeHashes = [...profileHashes, ...otherHashes];
+  const nodeHashes = _.uniq([...profileHashes, ...otherHashes]);
 
   const menuItems = [
     { id: 'trackedTriumphs', title: t('Progress.TrackedTriumphs') },


### PR DESCRIPTION
Not sure when exactly that happens, but if we fail to discover the seals or records hash from the profile response, the core settings have several keys that include `RootNode` in their names mapping to the same presentation node hashes, which causes an error because those weren't being deduplicated amongst themselves. 

Fixes #7490.