### PR TITLE
Track all titles and descriptions when provided multiple wish lists

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1154,6 +1154,7 @@
     "Num": "{{num, number}} rolls in your wish list",
     "PreMadeFiles": "Use A Pre-Made Wish List",
     "UpdateExternalSource": "Update Wish List Source",
+    "Untitled": "Untitled Wish List",
     "Voltron": "voltron (default)",
     "VoltronDescription": "voltron is an auto-updated collection of PvE and PvP wish list rolls from Mercules904 and pandapaxxy. We ship with this by default.",
     "WishListNotes": "Wish List Notes: {{notes}}"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Applying a loadout *without* fashion will no longer remove shaders and ornaments from your armor.
 * The shader picker now filters invalid shaders more consistently and won't call shaders "mods".
 * Fixed Records page sometimes duplicating Triumphs or Seals section while missing Collections.
+* When provided multiple wish lists, Settings page now shows info about all loaded wish lists, not just the first one.
 
 ## 6.99.1 <span class="changelog-date">(2022-01-10)</span>
 

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -34,7 +34,6 @@ export default function WishListSettings() {
   const choosyVoltronNotSelected = wishListSource !== choosyVoltronLocation;
   const wishListLastUpdated = useSelector(wishListsLastFetchedSelector);
   const wishList = useSelector(wishListsSelector).wishListAndInfo;
-  const { title, description } = wishList;
   const numWishListRolls = wishList.wishListRolls.length;
   const [liveWishListSource, setLiveWishListSource] = useState(wishListSource);
   useEffect(() => {
@@ -184,16 +183,15 @@ export default function WishListSettings() {
               {t('WishListRoll.Clear')}
             </button>
           </div>
-          {(title || description) && (
-            <div className="fineprint">
-              {title && (
-                <div>
-                  <b>{title}</b>
-                </div>
-              )}
+          {wishList.infos.map(({ title, description, numRolls }, idx) => (
+            <div className="fineprint" key={idx}>
+              <div>
+                <b>{title || t('WishListRoll.Untitled')}</b>{' '}
+                {wishList.infos.length > 1 && <i>({numRolls})</i>}
+              </div>
               <div>{description}</div>
             </div>
-          )}
+          ))}
         </div>
       )}
     </section>

--- a/src/app/wishlists/reducer.ts
+++ b/src/app/wishlists/reducer.ts
@@ -13,7 +13,7 @@ export type WishListAction = ActionType<typeof actions>;
 
 const initialState: WishListsState = {
   loaded: false,
-  wishListAndInfo: { title: undefined, description: undefined, wishListRolls: [] },
+  wishListAndInfo: { infos: [], wishListRolls: [] },
   lastFetched: undefined,
 };
 
@@ -33,8 +33,7 @@ export const wishLists: Reducer<WishListsState, WishListAction> = (
       return {
         ...state,
         wishListAndInfo: {
-          title: undefined,
-          description: undefined,
+          infos: [],
           wishListRolls: [],
           source: '',
         },

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -42,8 +42,14 @@ export interface WishListRoll {
 
 export interface WishListAndInfo {
   wishListRolls: WishListRoll[];
+  /** The URL(s) we fetched the wish list(s) from */
+  source?: string;
+  infos: WishListInfo[];
+}
+
+export interface WishListInfo {
   title?: string;
   description?: string;
-  /** The URL we fetched the wish list from */
-  source?: string;
+  /** The number of rolls from this wish list that actually made it in. */
+  numRolls: number;
 }

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -103,7 +103,7 @@ export function fetchWishList(newWishlistSource?: string): ThunkResult {
       return;
     }
 
-    const wishListAndInfo = toWishList(wishListTexts.join('\n'));
+    const wishListAndInfo = toWishList(...wishListTexts);
     wishListAndInfo.source = wishlistToFetch;
 
     const existingWishLists = wishListsSelector(getState());

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -1057,6 +1057,7 @@
     "LastUpdated": "Last updated: {{lastUpdatedDate}} at {{lastUpdatedTime}}",
     "Num": "{{num, number}} rolls in your wish list",
     "PreMadeFiles": "Use A Pre-Made Wish List",
+    "Untitled": "Untitled Wish List",
     "UpdateExternalSource": "Update Wish List Source",
     "Voltron": "voltron (default)",
     "VoltronDescription": "voltron is an auto-updated collection of PvE and PvP wish list rolls from Mercules904 and pandapaxxy. We ship with this by default.",


### PR DESCRIPTION
There was some confusion in Discord about whether multiple pipe-separated wish lists were loaded correctly because only the first title and description were shown in settings. No other functional changes intended.