### PR TITLE
Fix cases where compare drawer would refuse to add items to comparison

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * The shader picker now filters invalid shaders more consistently and won't call shaders "mods".
 * Fixed Records page sometimes duplicating Triumphs or Seals section while missing Collections.
 * When provided multiple wish lists, Settings page now shows info about all loaded wish lists, not just the first one.
+* Compare Drawer should no longer refuse valid requests to add an item to comparison.
 
 ## 6.99.1 <span class="changelog-date">(2022-01-10)</span>
 

--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -13,7 +13,9 @@ export interface CompareSession {
    */
   readonly itemCategoryHashes: number[];
   /**
-   * The query further filters the items to be shown.
+   * The query further filters the items to be shown. Since this query is modified
+   * when adding or removing items, external queries must be parenthesized first
+   * to avoid modifications binding to single filters within the original query.
    */
   readonly query: string;
 
@@ -68,7 +70,7 @@ export const compare: Reducer<CompareState, CompareAction> = (
         ...state,
         session: {
           ...state.session,
-          query: action.payload,
+          query: `(${action.payload})`,
         },
       };
     }
@@ -99,7 +101,7 @@ function addCompareItem(state: CompareState, item: DimItem): CompareState {
       return state;
     }
 
-    const itemQuery = `or id:${item.id}`;
+    const itemQuery = `id:${item.id} or`;
     const query = state.session?.query || '';
 
     // Don't just keep adding them
@@ -108,10 +110,12 @@ function addCompareItem(state: CompareState, item: DimItem): CompareState {
     }
     const removeQuery = `-id:${item.id}`;
 
+    // Add `or` item filter to the left to avoid mixing it with
+    // `implicit_and` filters from item removal (see `removeCompareItem`).
     const newQuery = (
       query.includes(removeQuery)
         ? query.replace(removeQuery, '')
-        : `${query} ${itemQuery}`.replace(/\s+/, ' ')
+        : `${itemQuery} ${query}`.replace(/\s+/, ' ')
     ).trim();
 
     return {
@@ -134,7 +138,7 @@ function addCompareItem(state: CompareState, item: DimItem): CompareState {
     return {
       ...state,
       session: {
-        query: itemNameQuery,
+        query: `(${itemNameQuery})`,
         itemCategoryHashes,
         initialItemId: item.id,
         vendorCharacterId,
@@ -148,7 +152,9 @@ function removeCompareItem(state: CompareState, item: DimItem): CompareState {
     throw new Error("Programmer error: Can't remove item with no session");
   }
 
-  const addedQuery = `or id:${item.id}`;
+  // Add `-id` filter to the right to avoid mixing it with
+  // `or` filters from item addition (see `addCompareItem`).
+  const addedQuery = `id:${item.id} or`;
   const newQuery = (
     state.session.query.includes(addedQuery)
       ? state.session.query.replace(addedQuery, '')


### PR DESCRIPTION
In addition to the bug report in #7745, this also fixes an issue where query modifications would bind to sub-filters from the original query, e.g. on beta it's impossible to add exotic warlock gauntlets to a compare session created from the following query: `is:legendary is:gauntlets is:warlock`, because clicking an exotic results in this query: `is:legendary is:gauntlets (is:warlock or id:12345)`.

Fixes #7745.