### PR TITLE
Fix kinetic slot icon in gear power tooltip and drawer

### DIFF
--- a/src/app/dim-ui/svgs/BucketIcon.tsx
+++ b/src/app/dim-ui/svgs/BucketIcon.tsx
@@ -1,3 +1,4 @@
+import type { DimBucketType } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import legs from 'destiny-icons/armor_types/boots.svg';
 import chest from 'destiny-icons/armor_types/chest.svg';
@@ -11,8 +12,8 @@ import dmgKinetic from 'destiny-icons/weapons/damage_kinetic.svg';
 import React from 'react';
 import BungieImage from '../BungieImage';
 
-const bucketIcons = {
-  Kinetic: dmgKinetic,
+const bucketIcons: { [key in DimBucketType]?: string } = {
+  KineticSlot: dmgKinetic,
   Energy: energyWeapon,
   Power: powerWeapon,
   Helmet: helmet,


### PR DESCRIPTION
Hovering over the gear power (and clicking it for the gear power drawer) shows a broken icon for the kinetic slot, which looks like it was missed in #7053 when renaming `Kinetic` to `KineticSlot`.

The mapped type should ensure future renames are caught here too.