### PR TITLE
Don't show internal error when clicking on sub-vendor without items

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1077,6 +1077,7 @@
     "Collections": "Collections",
     "Engram": "Reward Engram",
     "FilterToUnacquired": "Only show uncollected items",
+    "NoItems": "This Vendor is currently not offering any items.",
     "Vendors": "Vendors",
     "Year2Mods": "Year 2 Mods"
   },

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -77,6 +77,11 @@ export default function VendorItems({
   characterId: string;
 }) {
   const defs = useD2Definitions()!;
+
+  if (!vendor.items.length) {
+    return <div className={styles.vendorContents}>{t('Vendors.NoItems')}</div>;
+  }
+
   const itemsByCategory = _.groupBy(vendor.items, (item: VendorItem) => item.displayCategoryIndex);
 
   const faction = vendor.def.factionHash ? defs.Faction[vendor.def.factionHash] : undefined;

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -57,19 +57,21 @@ export function toVendorGroups(
         def: groupDef,
         vendors: _.sortBy(
           _.compact(
-            group.vendorHashes.map((vendorHash) =>
-              toVendor(
-                vendorHash,
-                defs,
-                buckets,
-                vendorsResponse.vendors.data?.[vendorHash],
-                account,
-                characterId,
-                vendorsResponse.itemComponents[vendorHash],
-                vendorsResponse.sales.data?.[vendorHash]?.saleItems,
-                mergedCollectibles
+            group.vendorHashes
+              .map((vendorHash) =>
+                toVendor(
+                  vendorHash,
+                  defs,
+                  buckets,
+                  vendorsResponse.vendors.data?.[vendorHash],
+                  account,
+                  characterId,
+                  vendorsResponse.itemComponents[vendorHash],
+                  vendorsResponse.sales.data?.[vendorHash]?.saleItems,
+                  mergedCollectibles
+                )
               )
-            )
+              .filter((vendor) => vendor?.items.length)
           ),
           (v) => {
             const index = vendorOrder.indexOf(v.def.hash);
@@ -113,9 +115,6 @@ export function toVendor(
     sales,
     mergedCollectibles
   );
-  if (!vendorItems.length) {
-    return undefined;
-  }
 
   const destinationDef = vendor?.vendorLocationIndex
     ? defs.Destination.get(vendorDef.locations[vendor.vendorLocationIndex].destinationHash)

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -987,6 +987,7 @@
     "Collections": "Collections",
     "Engram": "Reward Engram",
     "FilterToUnacquired": "Only show uncollected items",
+    "NoItems": "This Vendor is currently not offering any items.",
     "Vendors": "Vendors"
   },
   "Views": {


### PR DESCRIPTION
Vendors without items aren't shown on the Vendors page, but clicking on a sub-vendor that isn't offering any items (like the "Campaigns" button in the Quest Archive, because I've completed all campaign quests) would show a scary red error message about a vendor with that hash not being found.

I briefly considered dimming out such vendor buttons but checking 20 additional vendors in the vendors page didn't seem worth it considering this only happens to a handful of predictable vendors.