### PR TITLE
Add search to SocketDetails

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -946,6 +946,7 @@
   },
   "Sockets": {
     "ApplyPerks": "Apply Perks",
+    "Search": "Search names or descriptions",
     "SelectWishlistPerks": "Preview Wishlist Perks",
     "Insert": {
       "Mod": "Insert Mod",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Weapons CSV download now includes a Zoom stat column.
+* Shaders, ornaments, and mods can now be searched in their choosers.
 
 ## 7.1.0 <span class="changelog-date">(2022-01-16)</span>
 

--- a/src/app/item-popup/SocketDetails.m.scss
+++ b/src/app/item-popup/SocketDetails.m.scss
@@ -15,6 +15,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    min-height: 24px;
     > * {
       margin-right: 8px;
       line-height: 0;

--- a/src/app/item-popup/SocketDetails.m.scss
+++ b/src/app/item-popup/SocketDetails.m.scss
@@ -7,7 +7,8 @@
 }
 
 .socketDetailsSheet {
-  max-width: 800px;
+  // This fits 14 plugs + scroll bar
+  max-width: 820px;
   margin: 0 auto;
   z-index: 14; // higher than item popup
 
@@ -20,6 +21,11 @@
       margin-right: 8px;
       line-height: 0;
     }
+  }
+
+  // Cap the height for exceedingly large plug lists (shaders...)
+  :global(.sheet-container) {
+    max-height: 840px;
   }
 }
 

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -277,7 +277,7 @@ function SocketDetails({
       <div className="item-picker-search">
         <SearchInput
           query={query}
-          setQuery={setQuery}
+          onQueryChanged={setQuery}
           placeholder={t('Sockets.Search')}
           autoFocus
         />
@@ -308,6 +308,7 @@ function SocketDetails({
       header={header}
       footer={footer}
       sheetClassName={styles.socketDetailsSheet}
+      freezeInitialHeight={true}
     >
       <div className={clsx('sub-bucket', styles.modList)}>
         {mods.map((mod) => (

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -1,6 +1,8 @@
+import { languageSelector } from 'app/dim-api/selectors';
 import BungieImage from 'app/dim-ui/BungieImage';
 import ElementIcon from 'app/dim-ui/ElementIcon';
 import Sheet from 'app/dim-ui/Sheet';
+import { t } from 'app/i18next-t';
 import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { allItemsSelector, profileResponseSelector } from 'app/inventory/selectors';
@@ -8,6 +10,8 @@ import { isPluggableItem } from 'app/inventory/store/sockets';
 import { d2ManifestSelector, useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import { collectionsVisibleShadersSelector } from 'app/records/selectors';
+import { createPlugSearchPredicate } from 'app/search/plug-search';
+import { SearchInput } from 'app/search/SearchInput';
 import { RootState } from 'app/store/types';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptySet } from 'app/utils/empty';
@@ -19,8 +23,8 @@ import {
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
-import React, { useEffect, useRef, useState } from 'react';
-import { connect } from 'react-redux';
+import React, { useState } from 'react';
+import { connect, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import '../inventory/StoreBucket.scss';
 import styles from './SocketDetails.m.scss';
@@ -171,6 +175,8 @@ function SocketDetails({
   const [selectedPlug, setSelectedPlug] = useState<PluggableInventoryItemDefinition | null>(
     initialPlug || null
   );
+  const [query, setQuery] = useState('');
+  const language = useSelector(languageSelector);
 
   const socketType = defs.SocketType.get(socket.socketDefinition.socketTypeHash);
   const socketCategory = defs.SocketCategory.get(socketType.socketCategoryHash);
@@ -218,15 +224,21 @@ function SocketDetails({
   const unlocked = (i: PluggableInventoryItemDefinition) =>
     i.hash === initialPlugHash || unlockedPlugs.has(i.hash) || otherUnlockedPlugs.has(i.hash);
 
+  const searchFilter = createPlugSearchPredicate(query, language, defs);
+
   let mods = Array.from(modHashes, (h) => defs.InventoryItem.get(h))
+    .filter(isPluggableItem)
     .filter(
       (i) =>
-        !i.plug ||
         !i.plug.energyCost ||
         (energyType && i.plug.energyCost.energyTypeHash === energyType.hash) ||
         i.plug.energyCost.energyType === DestinyEnergyType.Any
-    )
-    .filter(isPluggableItem)
+    );
+
+  const requiresEnergy = mods.some((i) => i.plug.energyCost?.energyCost);
+
+  mods = mods
+    .filter(searchFilter)
     .filter((i) => unlocked(i) || !shownLockedPlugs || shownLockedPlugs.has(i.hash))
     .sort(
       chainComparator(
@@ -243,33 +255,35 @@ function SocketDetails({
     mods.unshift(initialPlug);
   }
 
-  const requiresEnergy = mods.some((i) => i.plug?.energyCost?.energyCost);
   const initialItem =
     socket.socketDefinition.singleInitialItemHash > 0 &&
     defs.InventoryItem.get(socket.socketDefinition.singleInitialItemHash);
-  const header = (
-    <h1>
-      {initialItem && (
-        <BungieImage
-          className={styles.categoryIcon}
-          src={initialItem.displayProperties.icon}
-          alt=""
-        />
-      )}
-      {requiresEnergy && energyType && (
-        <ElementIcon className={styles.energyElement} element={energyType} />
-      )}
-      <div>{socketCategory.displayProperties.name}</div>
-    </h1>
-  );
 
-  const modListRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (modListRef.current) {
-      const firstElement = modListRef.current.querySelector("[tabIndex='0']")!;
-      (firstElement as HTMLInputElement)?.focus();
-    }
-  }, []);
+  const header = (
+    <div>
+      <h1>
+        {initialItem && (
+          <BungieImage
+            className={styles.categoryIcon}
+            src={initialItem.displayProperties.icon}
+            alt=""
+          />
+        )}
+        {requiresEnergy && energyType && (
+          <ElementIcon className={styles.energyElement} element={energyType} />
+        )}
+        <div>{socketCategory.displayProperties.name}</div>
+      </h1>
+      <div className="item-picker-search">
+        <SearchInput
+          query={query}
+          setQuery={setQuery}
+          placeholder={t('Sockets.Search')}
+          autoFocus
+        />
+      </div>
+    </div>
+  );
 
   const footer =
     selectedPlug &&
@@ -295,7 +309,7 @@ function SocketDetails({
       footer={footer}
       sheetClassName={styles.socketDetailsSheet}
     >
-      <div ref={modListRef} className={clsx('sub-bucket', styles.modList)}>
+      <div className={clsx('sub-bucket', styles.modList)}>
         {mods.map((mod) => (
           <SocketDetailsMod
             key={mod.hash}

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -7,9 +7,7 @@ import { allItemsSelector } from 'app/inventory/selectors';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { startWordRegexp } from 'app/search/search-filters/freeform';
-import { AppIcon, searchIcon } from 'app/shell/icons';
-import { useIsPhonePortrait } from 'app/shell/selectors';
-import { isiOSBrowser } from 'app/utils/browsers';
+import { SearchInput } from 'app/search/SearchInput';
 import { compareBy } from 'app/utils/comparators';
 import { DestinyClass, TierType } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
@@ -138,7 +136,6 @@ function filterAndGroupExotics(
 /** A drawer to select an exotic for your build. */
 export default function ExoticPicker({ lockedExoticHash, classType, onSelected, onClose }: Props) {
   const defs = useD2Definitions()!;
-  const isPhonePortrait = useIsPhonePortrait();
   const language = useSelector(languageSelector);
   const [query, setQuery] = useState('');
 
@@ -154,29 +151,18 @@ export default function ExoticPicker({ lockedExoticHash, classType, onSelected, 
     [language, query, lockableExotics]
   );
 
-  const autoFocus = !isPhonePortrait && !isiOSBrowser();
-
   return (
     <Sheet
       header={
         <div>
           <h1>{t('LB.ChooseAnExotic')}</h1>
           <div className="item-picker-search">
-            <div className="search-filter" role="search">
-              <AppIcon icon={searchIcon} className="search-bar-icon" />
-              <input
-                className="filter-input"
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-                autoFocus={autoFocus}
-                placeholder={t('LB.SearchAnExotic')}
-                type="text"
-                name="filter"
-                value={query}
-                onChange={(e) => setQuery(e.currentTarget.value)}
-              />
-            </div>
+            <SearchInput
+              query={query}
+              setQuery={setQuery}
+              placeholder={t('LB.SearchAnExotic')}
+              autoFocus
+            />
           </div>
         </div>
       }

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -159,7 +159,7 @@ export default function ExoticPicker({ lockedExoticHash, classType, onSelected, 
           <div className="item-picker-search">
             <SearchInput
               query={query}
-              setQuery={setQuery}
+              onQueryChanged={setQuery}
               placeholder={t('LB.SearchAnExotic')}
               autoFocus
             />

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -1,7 +1,7 @@
 import { languageSelector } from 'app/dim-api/selectors';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { startWordRegexp } from 'app/search/search-filters/freeform';
+import { createPlugSearchPredicate } from 'app/search/plug-search';
 import { SearchInput } from 'app/search/SearchInput';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { Comparator, compareBy } from 'app/utils/comparators';
@@ -147,26 +147,13 @@ export default function PlugDrawer({
       return plugSets;
     }
 
-    const regexp = startWordRegexp(query, language);
-    const searchFilter = (plug: PluggableInventoryItemDefinition) =>
-      regexp.test(plug.displayProperties.name) ||
-      regexp.test(plug.displayProperties.description) ||
-      regexp.test(plug.itemTypeDisplayName) ||
-      plug.perks.some((perk) => {
-        const perkDef = defs.SandboxPerk.get(perk.perkHash);
-        return (
-          perkDef &&
-          (regexp.test(perkDef.displayProperties.name) ||
-            regexp.test(perkDef.displayProperties.description) ||
-            regexp.test(perk.requirementDisplayString))
-        );
-      });
+    const searchFilter = createPlugSearchPredicate(query, language, defs);
 
     return plugSets.map((plugSet) => ({
       ...plugSet,
       plugs: plugSet.plugs.filter(searchFilter),
     }));
-  }, [query, plugSets, defs.SandboxPerk, language]);
+  }, [query, plugSets, defs, language]);
 
   if (sortPlugGroups) {
     queryFilteredPlugSets.sort(sortPlugGroups);

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -192,7 +192,12 @@ export default function PlugDrawer({
     <div>
       <h1>{title}</h1>
       <div className="item-picker-search">
-        <SearchInput query={query} setQuery={setQuery} placeholder={searchPlaceholder} autoFocus />
+        <SearchInput
+          query={query}
+          onQueryChanged={setQuery}
+          placeholder={searchPlaceholder}
+          autoFocus
+        />
       </div>
     </div>
   );

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -2,14 +2,13 @@ import { languageSelector } from 'app/dim-api/selectors';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { startWordRegexp } from 'app/search/search-filters/freeform';
-import { AppIcon, searchIcon } from 'app/shell/icons';
+import { SearchInput } from 'app/search/SearchInput';
 import { useIsPhonePortrait } from 'app/shell/selectors';
-import { isiOSBrowser } from 'app/utils/browsers';
 import { Comparator, compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { produce } from 'immer';
 import _ from 'lodash';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Sheet from '../../dim-ui/Sheet';
 import '../../item-picker/ItemPicker.scss';
@@ -80,14 +79,7 @@ export default function PlugDrawer({
   const [selected, setSelected] = useState(() =>
     assignPlugsToPlugSets(plugSets, initiallySelected)
   );
-  const filterInput = useRef<HTMLInputElement>(null);
   const isPhonePortrait = useIsPhonePortrait();
-
-  useEffect(() => {
-    if (!isPhonePortrait && filterInput.current) {
-      filterInput.current.focus();
-    }
-  }, [isPhonePortrait, filterInput]);
 
   const handlePlugSelected = useCallback(
     (
@@ -180,8 +172,6 @@ export default function PlugDrawer({
     queryFilteredPlugSets.sort(sortPlugGroups);
   }
 
-  const autoFocus = !isPhonePortrait && !isiOSBrowser();
-
   // Flatten out the plugs and sort so the footer has a predictable order
   const flatSelectedPlugs = _.compact(Object.values(selected).flat());
   if (sortPlugs) {
@@ -215,22 +205,7 @@ export default function PlugDrawer({
     <div>
       <h1>{title}</h1>
       <div className="item-picker-search">
-        <div className="search-filter" role="search">
-          <AppIcon icon={searchIcon} className="search-bar-icon" />
-          <input
-            ref={filterInput}
-            className="filter-input"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            autoFocus={autoFocus}
-            placeholder={searchPlaceholder}
-            type="text"
-            name="filter"
-            value={query}
-            onChange={(e) => setQuery(e.currentTarget.value)}
-          />
-        </div>
+        <SearchInput query={query} setQuery={setQuery} placeholder={searchPlaceholder} autoFocus />
       </div>
     </div>
   );

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { FilterDefinition } from './filter-types';
 import styles from './FilterHelp.m.scss';
 import { searchConfigSelector } from './search-config';
+import { SearchInput } from './SearchInput';
 import { generateSuggestionsForFilter } from './suggestions-generation';
 
 function keywordsString(keywords: string | string[]) {
@@ -19,9 +20,6 @@ function keywordsString(keywords: string | string[]) {
 export default function FilterHelp() {
   const searchConfig = useSelector(searchConfigSelector);
   const [search, setSearch] = useState('');
-
-  const onSearchChange = (event: React.ChangeEvent<HTMLInputElement>) =>
-    setSearch(event.target.value);
 
   const searchLower = search.toLowerCase();
   const filters = search
@@ -51,18 +49,8 @@ export default function FilterHelp() {
           {t('Filter.Negate', { notexample: '-is:tagged', notexample2: 'not is:tagged' })}{' '}
           <a href="/search-history">{t('SearchHistory.Link')}</a>
         </p>
-        <div className={clsx(styles.search, 'search-filter')} role="search">
-          <input
-            className="filter-input"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            placeholder={t('Filter.SearchPrompt')}
-            type="text"
-            name="filter"
-            value={search}
-            onChange={onSearchChange}
-          />
+        <div className={clsx(styles.search)}>
+          <SearchInput query={search} setQuery={setSearch} placeholder={t('Filter.SearchPrompt')} />
         </div>
         <table>
           <thead>

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -50,7 +50,11 @@ export default function FilterHelp() {
           <a href="/search-history">{t('SearchHistory.Link')}</a>
         </p>
         <div className={clsx(styles.search)}>
-          <SearchInput query={search} setQuery={setSearch} placeholder={t('Filter.SearchPrompt')} />
+          <SearchInput
+            query={search}
+            onQueryChanged={setSearch}
+            placeholder={t('Filter.SearchPrompt')}
+          />
         </div>
         <table>
           <thead>

--- a/src/app/search/SearchInput.tsx
+++ b/src/app/search/SearchInput.tsx
@@ -5,15 +5,15 @@ import { isiOSBrowser } from 'app/utils/browsers';
 import React, { useEffect, useRef } from 'react';
 
 /**
- * A styled text input without fancy features like autocompletion or debouncing.
+ * A styled text input without fancy features like autocompletion or de-bouncing.
  */
 export function SearchInput({
-  setQuery,
+  onQueryChanged,
   placeholder,
   autoFocus,
   query,
 }: {
-  setQuery: (newValue: string) => void;
+  onQueryChanged: (newValue: string) => void;
   placeholder?: string;
   autoFocus?: boolean;
   query?: string;
@@ -43,7 +43,7 @@ export function SearchInput({
         type="text"
         name="filter"
         value={query}
-        onChange={(e) => setQuery(e.currentTarget.value)}
+        onChange={(e) => onQueryChanged(e.currentTarget.value)}
       />
     </div>
   );

--- a/src/app/search/SearchInput.tsx
+++ b/src/app/search/SearchInput.tsx
@@ -1,0 +1,50 @@
+import { searchIcon } from 'app/shell/icons';
+import AppIcon from 'app/shell/icons/AppIcon';
+import { useIsPhonePortrait } from 'app/shell/selectors';
+import { isiOSBrowser } from 'app/utils/browsers';
+import React, { useEffect, useRef } from 'react';
+
+/**
+ * A styled text input without fancy features like autocompletion or debouncing.
+ */
+export function SearchInput({
+  setQuery,
+  placeholder,
+  autoFocus,
+  query,
+}: {
+  setQuery: (newValue: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+  query?: string;
+}) {
+  const isPhonePortrait = useIsPhonePortrait();
+  // On iOS at least, focusing the keyboard pushes the content off the screen
+  const nativeAutoFocus = !isPhonePortrait && !isiOSBrowser();
+
+  const filterInput = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (autoFocus && !nativeAutoFocus && filterInput.current) {
+      filterInput.current.focus();
+    }
+  }, [autoFocus, nativeAutoFocus, filterInput]);
+
+  return (
+    <div className="search-filter" role="search">
+      <AppIcon icon={searchIcon} className="search-bar-icon" />
+      <input
+        ref={filterInput}
+        className="filter-input"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        autoFocus={autoFocus && nativeAutoFocus}
+        placeholder={placeholder}
+        type="text"
+        name="filter"
+        value={query}
+        onChange={(e) => setQuery(e.currentTarget.value)}
+      />
+    </div>
+  );
+}

--- a/src/app/search/plug-search.ts
+++ b/src/app/search/plug-search.ts
@@ -1,0 +1,28 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { startWordRegexp } from './search-filters/freeform';
+
+export function createPlugSearchPredicate(
+  query: string,
+  language: string,
+  defs: D2ManifestDefinitions
+) {
+  if (!query.length) {
+    return (_plug: PluggableInventoryItemDefinition) => true;
+  }
+
+  const regexp = startWordRegexp(query, language);
+  return (plug: PluggableInventoryItemDefinition) =>
+    regexp.test(plug.displayProperties.name) ||
+    regexp.test(plug.displayProperties.description) ||
+    regexp.test(plug.itemTypeDisplayName) ||
+    plug.perks.some((perk) => {
+      const perkDef = defs.SandboxPerk.get(perk.perkHash);
+      return (
+        perkDef &&
+        (regexp.test(perkDef.displayProperties.name) ||
+          regexp.test(perkDef.displayProperties.description) ||
+          regexp.test(perk.requirementDisplayString))
+      );
+    });
+}

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -880,6 +880,7 @@
       "Transmat": "Apply Transmat Effect"
     },
     "ListStyle": "Display perks as a list",
+    "Search": "Search names or descriptions",
     "Select": {
       "Ability": "Preview Ability",
       "Aspect": "Preview Aspect",


### PR DESCRIPTION
Shaders, ornaments, and all other plugs can now be searched in the individual socket drawer in the same way that they can be searched in the Loadout mods/subclass config drawer.

Because such a search input field is used in other places too, I moved some code to a common component. This affects filters help, the LO exotic picker, and the Loadout mods drawer. There shouldn't be any functional changes there, except the filters help now has a search icon.

Closes #7468.