### PR TITLE
Include Zoom stat in weapons CSV

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Weapons CSV download now includes a Zoom stat column.
+
 ## 7.1.0 <span class="changelog-date">(2022-01-16)</span>
 
 * Applying a loadout *without* fashion will no longer remove shaders and ornaments from your armor.

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -444,6 +444,7 @@ function downloadWeapons(
       aa: 0,
       impact: 0,
       range: 0,
+      zoom: 0,
       stability: 0,
       rof: 0,
       reload: 0,
@@ -472,6 +473,9 @@ function downloadWeapons(
               break;
             case StatHashes.Range:
               stats.range = stat.value;
+              break;
+            case StatHashes.Zoom:
+              stats.zoom = stat.value;
               break;
             case StatHashes.Stability:
               stats.stability = stat.value;
@@ -513,6 +517,7 @@ function downloadWeapons(
     row.AA = stats.aa;
     row.Impact = stats.impact;
     row.Range = stats.range;
+    row.Zoom = stats.zoom;
     row['Blast Radius'] = stats.blastRadius;
     row.Velocity = stats.velocity;
     row.Stability = stats.stability;


### PR DESCRIPTION
As requested in https://www.reddit.com/r/DestinyItemManager/comments/s6awz4/include_zoom_in_weaponscsv/

This stat is exposed in the item popup and as an Organizer column already, so it only makes sense to included it in the CSV.