### PR TITLE
Fix LO layout error from #7765

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -123,7 +123,8 @@ export default memo(function GeneratedSets({
         rowWidth: measureSetRef.current.clientWidth,
       });
     }
-  }, [rowHeight]);
+    // Include sets to recover after no sets were found and rowHeight stayed 0
+  }, [rowHeight, sets]);
 
   useEffect(() => {
     const handleWindowResize = _.throttle(() => setRowSize({ rowHeight: 0, rowWidth: 0 }), 300, {


### PR DESCRIPTION
In #7765 I removed a dependency from `useLayoutEffect` while playing around with various attempts to fix the issue and didn't see a need to put it back in, but forgot about the case when going from "no sets found" to "sets found". Without this LO gets stuck only showing one set if LO found 0 sets at some point.