### PR TITLE
Allow popups to spill out of a sheet.

### DIFF
--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -16,7 +16,6 @@ $control-color: rgba(255, 255, 255, 0.5);
   color: #e0e0e0;
   box-shadow: 0 -1px 24px 0 #222;
   user-select: none;
-  overflow: hidden;
 
   .sheet-header {
     box-sizing: border-box;


### PR DESCRIPTION
This will allow plug popups to spill out the top of the sheet.

I will get back to my popper changes when I get a chance. @robojumper I am hoping this will actually fix your issues you were seeing.

<img width="1512" alt="Screen Shot 2022-01-20 at 11 05 45 pm" src="https://user-images.githubusercontent.com/7344652/150335949-6a7efdd9-1238-46c9-8d0c-93c3e122c6a8.png">
