### PR TITLE
Don't freeze initial height in socket drawer

### DIFF
--- a/src/app/item-popup/SocketDetails.m.scss
+++ b/src/app/item-popup/SocketDetails.m.scss
@@ -22,11 +22,6 @@
       line-height: 0;
     }
   }
-
-  // Cap the height for exceedingly large plug lists (shaders...)
-  :global(.sheet-container) {
-    max-height: 840px;
-  }
 }
 
 .clickableMod {

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -308,7 +308,6 @@ function SocketDetails({
       header={header}
       footer={footer}
       sheetClassName={styles.socketDetailsSheet}
-      freezeInitialHeight={true}
     >
       <div className={clsx('sub-bucket', styles.modList)}>
         {mods.map((mod) => (


### PR DESCRIPTION
The masterwork picker isn't behaving nicely on mobile:

* `freezeInitialHeight`, when the footer changes height due to materials in the apply button, does the opposite and instead increases or decreases the height of the sheet according to the height changes of the footer.
* `max-height` ends up overriding CSS preventing the sheet from becoming higher than the screen supports instead of purely capping it.