### PR TITLE
fix danger buttons & establish global line height

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
@@ -172,7 +172,7 @@ export default function LoadoutDrawerOptions({
         {loadout.notes === undefined && (
           <div className={styles.inputGroup}>
             <button
-              className="dim-button danger"
+              className="dim-button"
               onClick={addNotes}
               type="button"
               title={t('Loadouts.AddNotes')}

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -225,7 +225,7 @@ function LoadoutRow({
         <button
           key="save"
           type="button"
-          className="dim-button"
+          className="dim-button danger"
           onClick={() => handleDeleteClick(loadout)}
         >
           <AppIcon icon={deleteIcon} title={t('Loadouts.Delete')} />

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -178,6 +178,7 @@ body {
   color: white;
   font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
   font-size: 12px;
+  line-height: calc(16 / 12);
   // Disable drag and drop so we can use our polyfill
   -webkit-user-drag: none;
 }
@@ -232,12 +233,14 @@ select {
   padding: 2px 28px 2px 10px;
   height: 27px;
   font-size: 12px;
+  line-height: calc(16 / 12);
   color: white;
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   border: 1px solid transparent;
 
   @include phone-portrait {
     font-size: 14px;
+    line-height: calc(18 / 14);
     padding: 6px 32px 6px 16px;
     height: 35px;
   }
@@ -273,6 +276,7 @@ select {
   background-color: rgba(255, 255, 255, 0.2);
   color: white;
   font-size: 12px;
+  line-height: calc(16 / 12);
   font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   border: 1px solid transparent;
@@ -281,6 +285,7 @@ select {
 
   @include phone-portrait {
     font-size: 14px;
+    line-height: calc(18 / 14);
     padding: 8px 16px;
   }
   img {
@@ -320,7 +325,7 @@ select {
   }
   &.danger {
     &:hover {
-      background-color: $red;
+      background-color: $red !important;
     }
   }
   // Set focus styles


### PR DESCRIPTION
- danger buttons have never been styled right. hover orange was not adequately overridden
- DIM lacks an explicit line height, which browsers tend to vary by default
  - this establishes 16px as the LH for 12px text, and 18px as the LH for 14px text, but does it as a fraction so you can still set other text sizes without needing to override a fixed px LH
  - having a known LH means you can make, for instance, a div that's explicitly the height of a text line
  - these px values basically match effective/existing chrome LH, but as nice integer values