### PR TITLE
LO Energy Choice styling

### DIFF
--- a/src/app/loadout-builder/filter/EnergyOptions.m.scss
+++ b/src/app/loadout-builder/filter/EnergyOptions.m.scss
@@ -18,10 +18,22 @@
 }
 
 .button {
+  composes: dim-button from global;
   cursor: pointer;
   flex-grow: 1;
 }
 
 .selected {
   cursor: default;
+  position: relative;
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    background-color: $orange;
+    height: 2px;
+    bottom: -1px;
+    left: -1px;
+    right: -1px;
+  }
 }

--- a/src/app/loadout-builder/filter/EnergyOptions.tsx
+++ b/src/app/loadout-builder/filter/EnergyOptions.tsx
@@ -13,9 +13,11 @@ interface Option {
 
 const RadioSetting = React.memo(function RadioSetting({
   label,
+  name,
   options,
 }: {
   label: string;
+  name: string;
   options: Option[];
 }) {
   return (
@@ -23,24 +25,29 @@ const RadioSetting = React.memo(function RadioSetting({
       <div className={styles.title}>{label}</div>
       <div className={styles.buttons}>
         {options.map(({ label, selected, onClick }) => (
-          <RadioButton key={label} label={label} selected={selected} onClick={onClick} />
+          <RadioButton
+            key={label}
+            label={label}
+            selected={selected}
+            onClick={onClick}
+            name={name}
+          />
         ))}
       </div>
     </div>
   );
 });
 
-function RadioButton({ label, selected, onClick }: Option) {
+function RadioButton({ label, name, selected, onClick }: Option & { name: string }) {
   return (
-    <button
-      type="button"
+    <label
       className={clsx(styles.button, {
         [styles.selected]: selected,
       })}
-      onClick={onClick}
     >
+      <input type="radio" name={name} checked={selected} onClick={onClick} />
       {label}
-    </button>
+    </label>
   );
 }
 
@@ -139,8 +146,13 @@ export default function EnergyOptions({
 
   return (
     <div className={styles.energyOptions}>
-      <RadioSetting label={t('LoadoutBuilder.LockElement')} options={lockEnergyOptions} />
       <RadioSetting
+        name="lockElement"
+        label={t('LoadoutBuilder.LockElement')}
+        options={lockEnergyOptions}
+      />
+      <RadioSetting
+        name="assumeMasterwork"
         label={t('LoadoutBuilder.AssumeMasterwork')}
         options={assumeMasterworkOptions}
       />

--- a/src/app/loadout-builder/filter/EnergyOptions.tsx
+++ b/src/app/loadout-builder/filter/EnergyOptions.tsx
@@ -34,8 +34,7 @@ function RadioButton({ label, selected, onClick }: Option) {
   return (
     <button
       type="button"
-      className={clsx('dim-button', styles.button, {
-        selected,
+      className={clsx(styles.button, {
         [styles.selected]: selected,
       })}
       onClick={onClick}

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -278,6 +278,7 @@ select {
   border: 1px solid transparent;
   transition: all 150ms ease-out;
   box-sizing: border-box;
+  text-align: center;
 
   @include phone-portrait {
     font-size: 14px;


### PR DESCRIPTION
<img width="238" alt="Screen Shot 2022-01-24 at 4 04 43 PM" src="https://user-images.githubusercontent.com/313208/150886379-9a91f170-c75c-4a94-8c1f-9bcb2b127f40.png">

Trying to make these a little less bright, and call back to the "tabs" in our main navigation. Also using radio buttons for accessibility.