### PR TITLE
Stop reporting hash lookup failures to Sentry

### DIFF
--- a/src/app/utils/log.ts
+++ b/src/app/utils/log.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
 /**
- * A wrapper around log. Use this when you mean to have logging in the shipped app.
- * Otherwise, we'll prevent log from getting submitted via a lint rule.
+ * A wrapper around console.log. Use this when you mean to have logging in the shipped app.
+ * Otherwise, we'll prevent console.log from getting submitted via a lint rule.
  *
  * @param tag an informative label for categorizing this log
  * @example infoLog("Manifest", "The manifest loaded")
@@ -12,22 +12,36 @@ export function infoLog(tag: string, message: unknown, ...args: unknown[]) {
 }
 
 /**
- * A wrapper around warnLog. Use this when you mean to have logging in the shipped app.
- * Otherwise, we'll prevent warnLog from getting submitted via a lint rule.
+ * A wrapper around console.warn. Use this when you mean to have logging in the shipped app.
+ * Otherwise, we'll prevent console.warn from getting submitted via a lint rule.
  *
  * @param tag an informative label for categorizing this log
- * @example warn("Manifest", "The manifest is out of date")
+ * @example warnLog("Manifest", "The manifest is out of date")
  */
 export function warnLog(tag: string, message: unknown, ...args: unknown[]) {
   console.warn(`[${tag}]`, message, ...args);
 }
 
 /**
- * A wrapper around errorLog. Use this when you mean to have logging in the shipped app.
- * Otherwise, we'll prevent errorLog from getting submitted via a lint rule.
+ * A wrapper around console.warn that doesn't show the stack trace until you
+ * expand it. Use this when you mean to have logging in the shipped app.
+ * Otherwise, we'll prevent console.warn from getting submitted via a lint rule.
  *
  * @param tag an informative label for categorizing this log
- * @example error("Manifest", "The manifest failed to load")
+ * @example warnLogCollapsedStack("Manifest", "The manifest is out of date")
+ */
+export function warnLogCollapsedStack(tag: string, message: unknown, ...args: unknown[]) {
+  console.groupCollapsed(`[${tag}]`, message);
+  console.warn(`[${tag}]`, message, ...args);
+  console.groupEnd();
+}
+
+/**
+ * A wrapper around console.error. Use this when you mean to have logging in the shipped app.
+ * Otherwise, we'll prevent console.error from getting submitted via a lint rule.
+ *
+ * @param tag an informative label for categorizing this log
+ * @example errorLog("Manifest", "The manifest failed to load")
  */
 export function errorLog(tag: string, message: unknown, ...args: unknown[]) {
   console.error(`[${tag}]`, message, ...args);


### PR DESCRIPTION
Fixes #7727. Hash lookup failures are really common these days with loadouts that contain old mods. I kept the console logging but collapsed the stack traces so they aren't so distracting.