### PR TITLE
Fix interpretation of insertPlugFreeProtectedPlugItemHashes

### DIFF
--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -59,8 +59,9 @@ function canInsertForFree(
 ) {
   const { insertPlugFreeProtectedPlugItemHashes, insertPlugFreeBlockedSocketTypeHashes } =
     destiny2CoreSettings;
+  const pluggedDef = (socket.actuallyPlugged || socket.plugged)?.plugDef;
   if (
-    (insertPlugFreeProtectedPlugItemHashes || []).includes(plugItemHash) ||
+    (pluggedDef && (insertPlugFreeProtectedPlugItemHashes || []).includes(pluggedDef.hash)) ||
     (insertPlugFreeBlockedSocketTypeHashes || []).includes(socket.socketDefinition.socketTypeHash)
   ) {
     return false;
@@ -78,7 +79,7 @@ function canInsertForFree(
     // And have no cost to insert
     !hasInsertionCost(defs, plug) &&
     // And the current plug didn't cost anything (can't replace a non-free mod with a free one)
-    (!socket.plugged || !hasInsertionCost(defs, socket.plugged.plugDef));
+    (!pluggedDef || !hasInsertionCost(defs, pluggedDef));
 
   return free;
 }

--- a/src/app/inventory/store/override-sockets.ts
+++ b/src/app/inventory/store/override-sockets.ts
@@ -38,20 +38,24 @@ export function applySocketOverrides(
     let plugOptions: DimPlug[] = s.plugOptions.map((p) => ({ ...p, stats: null }));
 
     if (override && s.plugged?.plugDef.hash !== override) {
-      let newPlug = plugOptions.find((p) => p.plugDef.hash === override);
-      if (!newPlug && !s.isPerk) {
+      let newPlug, actuallyPlugged;
+
+      if (s.isPerk) {
+        newPlug = plugOptions.find((p) => p.plugDef.hash === override);
+        actuallyPlugged = plugOptions.find((p) => p.plugDef.hash === s.plugged?.plugDef.hash);
+      } else {
         // This is likely a mod selection!
         const createdPlug = buildDefinedPlug(defs, override);
         if (createdPlug) {
           newPlug = createdPlug;
+          // Mod sockets' plugOptions only ever
+          // contain the currently plugged item
+          actuallyPlugged = plugOptions.find((p) => p.plugDef.hash === s.plugged?.plugDef.hash);
           plugOptions = [newPlug];
         }
       }
 
       if (newPlug) {
-        // Back up the real plug here
-        const actuallyPlugged = plugOptions.find((p) => p.plugDef.hash === s.plugged?.plugDef.hash);
-
         return {
           ...s,
           actuallyPlugged,


### PR DESCRIPTION
`insertPlugFreeProtectedPlugItemHashes` refers to the thing potentially being replaced, not the thing potentially being plugged, e.g. we should refuse to overwrite a plugged Riven's Curse mod, not to insert such a mod.

`canInsertForFree` needs to take `actuallyPlugged` into account, otherwise this restriction could be bypassed by previewing a reusable, non-protected mod first.