### PR TITLE
Fix Fashion Loadouts erroneously reporting some shaders as unavailable

### DIFF
--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -120,6 +120,7 @@ export default function LoadoutView({
                 key={category}
                 category={category}
                 subclass={subclass}
+                storeId={store.id}
                 items={categories[category]}
                 savedMods={savedMods}
                 modsByBucket={modsByBucket}

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -375,6 +375,7 @@ export default function FashionDrawer({
             item={armorItemsByBucketHash[bucketHash]}
             exampleItem={exampleItemsByBucketHash[bucketHash]}
             mods={modsByBucket[bucketHash]}
+            storeId={storeId}
             onPickPlug={setPickPlug}
             onRemovePlug={handleRemovePlug}
           />
@@ -409,6 +410,7 @@ function FashionItem({
   exampleItem,
   bucketHash,
   mods = [],
+  storeId,
   onPickPlug,
   onRemovePlug,
 }: {
@@ -416,6 +418,7 @@ function FashionItem({
   exampleItem?: DimItem;
   bucketHash: number;
   mods?: number[];
+  storeId?: string;
   onPickPlug(params: PickPlugState): void;
   onRemovePlug(bucketHash: number, modHash: number): void;
 }) {
@@ -460,6 +463,7 @@ function FashionItem({
         plug={shaderItem}
         exampleItem={exampleItem}
         defaultPlug={defaultShader}
+        storeId={storeId}
         onPickPlug={onPickPlug}
         onRemovePlug={onRemovePlug}
       />
@@ -469,6 +473,7 @@ function FashionItem({
         socket={ornamentSocket}
         plug={ornamentItem}
         exampleItem={exampleItem}
+        storeId={storeId}
         defaultPlug={defaultOrnament}
         onPickPlug={onPickPlug}
         onRemovePlug={onRemovePlug}
@@ -483,6 +488,7 @@ function FashionSocket({
   socket,
   plug,
   exampleItem,
+  storeId,
   defaultPlug,
   onPickPlug,
   onRemovePlug,
@@ -492,11 +498,14 @@ function FashionSocket({
   socket: DimSocket | undefined;
   plug: DestinyInventoryItemDefinition | undefined;
   exampleItem: DimItem;
+  storeId?: string;
   defaultPlug: DestinyInventoryItemDefinition;
   onPickPlug(params: PickPlugState): void;
   onRemovePlug(bucketHash: number, modHash: number): void;
 }) {
-  const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector);
+  const unlockedPlugSetItems = useSelector((state: RootState) =>
+    unlockedPlugSetItemsSelector(state, storeId)
+  );
   const handleOrnamentClick = socket && (() => onPickPlug({ item: exampleItem, socket }));
   const canSlotOrnament =
     plugHash !== undefined &&

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -502,7 +502,8 @@ function FashionSocket({
     plugHash !== undefined &&
     (plugHash === socket?.socketDefinition.singleInitialItemHash ||
       (unlockedPlugSetItems.has(plugHash) &&
-        socket?.plugSet?.plugs.some((p) => p.plugDef.hash === plugHash)));
+        socket?.plugSet?.plugs.some((p) => p.plugDef.hash === plugHash)) ||
+      socket?.reusablePlugItems?.some((p) => p.plugItemHash === plugHash && p.enabled));
 
   return (
     <ClosableContainer

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -157,8 +157,10 @@ export function socketContainsIntrinsicPlug(socket: DimSocket) {
 export function plugFitsIntoSocket(socket: DimSocket, plugHash: number) {
   return (
     socket.socketDefinition.singleInitialItemHash === plugHash ||
-    (socket.plugSet
-      ? socket.plugSet.plugs.some((dimPlug) => dimPlug.plugDef.hash === plugHash)
-      : socket.plugOptions.some((p) => p.plugDef.hash === plugHash))
+    socket.plugSet?.plugs.some((dimPlug) => dimPlug.plugDef.hash === plugHash) ||
+    // TODO(#7793): This should use reusablePlugItems on the socket def
+    // because the check should operate on static definitions. This is still
+    // incorrect for quite a few blue-quality items because DIM throws away the data.
+    socket.reusablePlugItems?.some((p) => p.plugItemHash === plugHash)
   );
 }


### PR DESCRIPTION
There was a bug report on Discord that Fashion Loadouts didn't show the Iron Banner shader "Wicked Overgrowth" as available, which is because Bungie returns it in the characterPlugSets, not the profilePlugSets. Passing along the storeId correctly shows it as unlocked.

Also *sort of* fixes #7720, I moved the hard part to a different issue.