### PR TITLE
Loadout/add equipped: don't equip multiple items into same bucket

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
-* Removing subclass from loadout will now enable 'Add Equipped' button
+* Removing subclass from loadout will now enable "Add Equipped" button.
+* "Add Equipped" button will no longer cause multiple items in the same slot to be listed as equipped.
 * Widened and reorganized the Loadouts menu.
   * Pull from Postmaster (and its lesser known cousin, Make room for Postmaster) are removed in favor of the button next to your Postmaster items.
   * Randomize loadout is now at the end of the list of loadouts.

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -301,10 +301,18 @@ function fillLoadoutFromEquipped(
     (item) => item.equipped && itemCanBeInLoadout(item) && fromEquippedTypes.includes(item.type)
   );
 
+  const hasEquippedInBucket = (bucket: InventoryBucket) =>
+    itemsByBucket[bucket.hash]?.some(
+      (bucketItem) =>
+        loadout.items.find(
+          (loadoutItem) => bucketItem.hash === loadoutItem.hash && bucketItem.id === loadoutItem.id
+        )?.equipped
+    );
+
   const newLoadout = produce(loadout, (draftLoadout) => {
     const mods: number[] = [];
     for (const item of newEquippedItems) {
-      if (!itemsByBucket[item.bucket.hash]?.some((i) => i.equipped)) {
+      if (!hasEquippedInBucket(item.bucket)) {
         const loadoutItem: LoadoutItem = {
           id: item.id,
           hash: item.hash,


### PR DESCRIPTION
Fixes #7737.