### PR TITLE
SocketDetails: Filter Y2 weapon masterworks down to a reasonably sized list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Widened and reorganized the Loadouts menu.
   * Pull from Postmaster (and its lesser known cousin, Make room for Postmaster) are removed in favor of the button next to your Postmaster items.
   * Randomize loadout is now at the end of the list of loadouts.
+* Masterwork picker now only shows higher tiers of the current masterwork and full masterworks compatible with the weapon type.
 
 ## 7.2.0 <span class="changelog-date">(2022-01-23)</span>
 

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -66,6 +66,8 @@ export const killTrackerObjectivesByHash: Record<number, 'pvp' | 'pve' | undefin
 };
 export const killTrackerSocketTypeHash = 1282012138;
 
+export const weaponMasterworkY2SocketTypeHash = 2218962841;
+
 export const universalOrnamentPlugSetHashes: number[] = [
   26360131, 71785814, 709078552, 1133647128, 1323117612, 1742798175, 2093871133, 2203626505,
   2425516788, 2568801218, 2733810650, 3024995628, 3479876793, 4014441445, 4178224051,


### PR DESCRIPTION
Fixes #7575. This takes care to show other valid full masterworks as well because it's genuinely useful in the armory and in compare.

![grafik](https://user-images.githubusercontent.com/14299449/151707270-043c9f67-46b9-4b8d-9f2d-a05b69ae7f18.png)
