### PR TITLE
Horizontal mods for mobile

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Masterwork picker now only shows higher tiers of the current masterwork and full masterworks compatible with the weapon type.
+* Mods in the Loadout Optimizer and Show Mod Assignment screens are displayed in a row on mobile, to better use screen space.
 
 ## 7.3.0 <span class="changelog-date">(2022-01-30)</span>
 

--- a/src/app/loadout/loadout-ui/Sockets.m.scss
+++ b/src/app/loadout/loadout-ui/Sockets.m.scss
@@ -2,12 +2,23 @@
 
 .lockedItems {
   display: grid;
+  grid-template-columns: repeat(2, auto);
   gap: 2px;
+  @include phone-portrait {
+    grid-template-columns: repeat(5, auto);
+  }
+  --item-icon-size: var(--item-size);
+  @include phone-portrait {
+    --item-icon-size: calc(((var(--item-size) + ((var(--item-size) / 5) + 4px)) / 1.4) - 1px);
+  }
+  :global(.item) {
+    --item-size: var(--item-icon-size);
+  }
 }
 
 .small {
   --item-icon-size: calc(((var(--item-size) + ((var(--item-size) / 5) + 4px)) / 2) - 1px);
-  :global(.item) {
-    --item-size: var(--item-icon-size);
+  @include phone-portrait {
+    --item-icon-size: calc(((var(--item-size) + ((var(--item-size) / 5) + 4px)) / 1.4) - 1px);
   }
 }

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -83,7 +83,6 @@ function Sockets({ item, lockedMods, size, onSocketClick }: Props) {
       {modsAndWhitelist.map(({ plugDef, whitelist }, index) => (
         <Mod
           key={index}
-          gridColumn={(index % 2) + 1}
           plugDef={plugDef}
           onClick={onSocketClick ? () => onSocketClick(plugDef, whitelist) : undefined}
         />

--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss
@@ -1,11 +1,6 @@
 @import '../../variables';
 
 .plug {
-  > img,
-  > * > img {
-    height: var(--item-size);
-    width: var(--item-size);
-  }
   > * {
     margin-right: 8px;
   }


### PR DESCRIPTION
Let me know what you think - this puts the mods in a line on mobile in order to maybe pack more on screen. It's cooler in a square but IDK.

<img width="299" alt="Screen Shot 2022-02-01 at 11 15 25 PM" src="https://user-images.githubusercontent.com/313208/152110709-acc27395-c6f4-45d5-ab90-1372ae35740b.png">
<img width="301" alt="Screen Shot 2022-02-01 at 11 17 51 PM" src="https://user-images.githubusercontent.com/313208/152110714-66234b93-4628-429d-b436-6dfb8f5380c8.png">

Old style:
<img width="300" alt="Screen Shot 2022-02-01 at 11 21 06 PM" src="https://user-images.githubusercontent.com/313208/152110845-5d1dfc5d-d046-474d-a848-1e22b74050b3.png">
<img width="298" alt="Screen Shot 2022-02-01 at 11 21 30 PM" src="https://user-images.githubusercontent.com/313208/152110847-5b663a00-14b2-432c-a778-0fd8b5b89680.png">

