### PR TITLE
Add Kinetic Fusion and Energy Linear categories to Organizer to account for Bastion and Lorentz

### DIFF
--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -127,7 +127,7 @@ const d2SelectionTree: ItemCategoryTreeNode = {
         {
           id: 'fusionrifle',
           itemCategoryHash: ItemCategoryHashes.FusionRifle,
-          subCategories: [energy, power],
+          subCategories: [kinetic, energy, power],
           terminal: true,
         },
         {
@@ -178,7 +178,7 @@ const d2SelectionTree: ItemCategoryTreeNode = {
         {
           id: 'linearfusionrifle',
           itemCategoryHash: ItemCategoryHashes.LinearFusionRifles,
-          subCategories: [kinetic, power],
+          subCategories: [kinetic, energy, power],
           terminal: true,
         },
       ],


### PR DESCRIPTION
As reported on Discord.

We have heavy bow, heavy fusion, and kinetic linear buttons for Leviathan's Breath, 1000 Voices, and Arbalest, respectively. Seems only consistent to account for Bastion and Lorentz as well.