### PR TITLE
Show wish list info and clear button for file-loaded wishlists too

### DIFF
--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -171,7 +171,7 @@ export default function WishListSettings() {
         )}
       </div>
 
-      {wishListSource && (
+      {numWishListRolls > 0 && (
         <div className="setting">
           <div className="horizontal">
             <label>


### PR DESCRIPTION
Loading a wish list from a local file works, but causes no visible change in the wish list info below (other than apparently clearing any URL-loaded wish list). This caused some confusion when someone was using wish list file ("doesn't load anything").