### PR TITLE
Validate search filter values

### DIFF
--- a/src/app/search/__snapshots__/search-utils.test.ts.snap
+++ b/src/app/search/__snapshots__/search-utils.test.ts.snap
@@ -79,7 +79,7 @@ Array [
 ]
 `;
 
-exports[`generateSuggestionsForFilter full suggestions for filter format 'range', keyword 'a' with suggestions undefined 1`] = `
+exports[`generateSuggestionsForFilter full suggestions for filter format 'range', keyword 'a' with suggestions [ 'b', 'c' ] 1`] = `
 Array [
   "a:",
   "a:<",
@@ -89,16 +89,13 @@ Array [
 ]
 `;
 
-exports[`generateSuggestionsForFilter full suggestions for filter format 'rangeoverload', keyword 'a' with suggestions [ 'b', 'c' ] 1`] = `
+exports[`generateSuggestionsForFilter full suggestions for filter format 'range', keyword 'a' with suggestions undefined 1`] = `
 Array [
   "a:",
   "a:<",
   "a:>",
   "a:<=",
   "a:>=",
-  "a:",
-  "a:b",
-  "a:c",
 ]
 `;
 

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -168,7 +168,7 @@ export function filterSortRecentSearches(query: string, recentSearches: Search[]
 const caretEndRegex = /([\s)]|$)/;
 
 // most times, insist on at least 3 typed characters, but for #, start suggesting immediately
-const lastWordRegex = /(\b[\w:"']{3,}|#\w*)$/;
+const lastWordRegex = /(\b[\w:"'&<=>+]{3,}|#\w*)$/;
 // matches a string that seems to end with a closing, not opening, quote
 const closingQuoteRegex = /\w["']$/;
 

--- a/src/app/search/search-config.ts
+++ b/src/app/search/search-config.ts
@@ -69,7 +69,11 @@ export function buildSearchConfig(
       }
       allApplicableFilters.push(filter);
       const filterKeywords = Array.isArray(filter.keywords) ? filter.keywords : [filter.keywords];
+
       for (const keyword of filterKeywords) {
+        if ($DIM_FLAVOR === 'test' && keyword in allFiltersByKeyword) {
+          throw new Error(`filter clash in '${keyword}'`);
+        }
         allFiltersByKeyword[keyword] = filter;
       }
     }

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -21,10 +21,15 @@ import { loadoutsSelector } from '../loadout-drawer/selectors';
 import { querySelector } from '../shell/selectors';
 import { wishListFunctionSelector } from '../wishlists/selectors';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
-import { FilterContext, ItemFilter } from './filter-types';
+import {
+  canonicalFilterFormats,
+  FilterContext,
+  FilterDefinition,
+  ItemFilter,
+} from './filter-types';
 import { parseQuery, QueryAST } from './query-parser';
 import { SearchConfig, searchConfigSelector } from './search-config';
-import { parseAndValidateQuery } from './search-utils';
+import { parseAndValidateQuery, rangeStringToComparator } from './search-utils';
 
 //
 // Selectors
@@ -139,23 +144,50 @@ function makeSearchFilterFactory(
           return (item) => !fn(item);
         }
         case 'filter': {
-          let filterName = ast.type;
+          const filterName = ast.type;
           const filterValue = ast.args;
 
           // "is:" filters are slightly special cased
           if (filterName === 'is') {
-            filterName = filterValue;
-          }
-
-          const filterDef = filters[filterName];
-          if (filterDef) {
-            // Each filter knows how to generate a standalone item filter function
-            try {
-              return filterDef.filter({ filterValue, ...filterContext });
-            } catch (e) {
-              // TODO: mark invalid - fill out what didn't make sense and where it was in the string
-              errorLog('search', 'Invalid query term', filterName, filterValue, e);
-              return () => true;
+            const filterDef = filters[filterValue];
+            if (filterDef && canonicalFilterFormats(filterDef.format).some((f) => f === 'simple')) {
+              try {
+                return filterDef.filter({ keyword: filterName, filterValue, ...filterContext });
+              } catch (e) {
+                // An `is` filter really shouldn't throw an error on filter construction...
+                errorLog(
+                  'search',
+                  'internal error: simple is filter threw exception?',
+                  filterName,
+                  filterValue,
+                  e
+                );
+                return () => true;
+              }
+            }
+          } else {
+            const filterDef = filters[filterName];
+            if (filterDef) {
+              const matchedFilter = matchFilter(filterDef, filterName, filterValue);
+              if (matchedFilter) {
+                try {
+                  return matchedFilter(filterContext);
+                } catch (e) {
+                  // This shouldn't happen because it means validation wouldn't catch it, but
+                  // not the end of the world...
+                  errorLog(
+                    'search',
+                    'internal error: filter construction threw exception',
+                    filterName,
+                    filterValue,
+                    e
+                  );
+                  return () => true;
+                }
+              } else {
+                // TODO: mark invalid - fill out what didn't make sense and where it was in the string
+                return () => true;
+              }
             }
           }
 
@@ -169,4 +201,67 @@ function makeSearchFilterFactory(
 
     return transformAST(parsedQuery);
   };
+}
+
+/** Matches a non-`is` filter syntax and returns a way to actually create the matched filter function. */
+export function matchFilter(
+  filterDef: FilterDefinition,
+  keyword: string,
+  filterValue: string
+): ((args: FilterContext) => ItemFilter) | undefined {
+  for (const format of canonicalFilterFormats(filterDef.format)) {
+    switch (format) {
+      case 'simple': {
+        break;
+      }
+      case 'query': {
+        if (filterDef.suggestions!.includes(filterValue)) {
+          return (filterContext) =>
+            filterDef.filter({
+              keyword,
+              filterValue,
+              ...filterContext,
+            });
+        } else {
+          break;
+        }
+      }
+      case 'freeform': {
+        return (filterContext) => filterDef.filter({ keyword, filterValue, ...filterContext });
+      }
+      case 'range': {
+        try {
+          const compare = rangeStringToComparator(filterValue, filterDef.overload);
+          return (filterContext) =>
+            filterDef.filter({
+              keyword,
+              filterValue: '',
+              compare,
+              ...filterContext,
+            });
+        } catch {
+          break;
+        }
+      }
+      case 'stat': {
+        const [stat, rangeString] = filterValue.split(':', 2);
+        try {
+          const compare = rangeStringToComparator(rangeString, filterDef.overload);
+          if (!filterDef.validateStat || filterDef.validateStat(stat)) {
+            return (filterContext) =>
+              filterDef.filter({
+                keyword,
+                filterValue: stat,
+                compare,
+                ...filterContext,
+              });
+          }
+        } catch {
+          break;
+        }
+      }
+      case 'custom':
+        break;
+    }
+  }
 }

--- a/src/app/search/search-filters/d1-filters.tsx
+++ b/src/app/search/search-filters/d1-filters.tsx
@@ -9,7 +9,6 @@ import {
   vendorHashes,
 } from '../d1-known-values';
 import { FilterDefinition } from '../filter-types';
-import { rangeStringToComparator } from './range-numeric';
 
 // these just check an attribute found on DimItem
 const d1Filters: FilterDefinition[] = [
@@ -140,15 +139,14 @@ const d1Filters: FilterDefinition[] = [
     description: [tl('Filter.Quality'), { percentage: 'percentage', quality: 'quality' }],
     format: 'range',
     destinyVersion: 1,
-    filter: ({ filterValue }) => {
-      const compare = rangeStringToComparator(filterValue);
-      return (item: D1Item) => {
+    filter:
+      ({ compare }) =>
+      (item: D1Item) => {
         if (!item.quality) {
           return false;
         }
-        return compare(item.quality.min);
-      };
-    },
+        return compare!(item.quality.min);
+      },
   },
   {
     keywords: [

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -10,7 +10,6 @@ import _ from 'lodash';
 import { chainComparator, compareBy, reverseComparator } from '../../utils/comparators';
 import { armorStats, DEFAULT_SHADER } from '../d2-known-values';
 import { FilterDefinition } from '../filter-types';
-import { rangeStringToComparator } from './range-numeric';
 
 const notableTags = ['favorite', 'keep'];
 
@@ -159,12 +158,11 @@ const dupeFilters: FilterDefinition[] = [
     keywords: 'count',
     description: tl('Filter.DupeCount'),
     format: 'range',
-    filter: ({ allItems, filterValue }) => {
-      const compare = rangeStringToComparator(filterValue);
+    filter: ({ allItems, compare }) => {
       const duplicates = computeDupes(allItems);
       return (item) => {
         const dupeId = makeDupeID(item);
-        return compare(duplicates[dupeId]?.length ?? 0);
+        return compare!(duplicates[dupeId]?.length ?? 0);
       };
     },
   },

--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -14,14 +14,14 @@ const loadoutFilters: FilterDefinition[] = [
         .map((l) => 'inloadout:' + quoteFilterString(l.name.toLowerCase())),
 
     description: tl('Filter.InLoadout'),
-    filter: ({ filterValue, loadouts }) => {
+    filter: ({ keyword, filterValue, loadouts }) => {
       // the default search:
       // is:inloadout
       let selectedLoadouts = loadouts;
 
       // a search like
       // inloadout:"loadout name here"
-      if (filterValue !== 'inloadout') {
+      if (keyword !== 'is') {
         selectedLoadouts = loadouts.filter((l) => l.name.toLowerCase() === filterValue);
       }
 

--- a/src/app/search/search-filters/range-numeric.test.ts
+++ b/src/app/search/search-filters/range-numeric.test.ts
@@ -1,4 +1,4 @@
-import { rangeStringToComparator } from './range-numeric';
+import { rangeStringToComparator } from '../search-utils';
 
 describe('rangeStringToComparator', () => {
   const cases: [input: string, reference: number, result: boolean][] = [

--- a/src/app/search/search-filters/range-overload.tsx
+++ b/src/app/search/search-filters/range-overload.tsx
@@ -6,19 +6,12 @@ import seasonTags from 'data/d2/season-tags.json';
 import { energyCapacityTypeNames, energyNamesByEnum } from '../d2-known-values';
 import { FilterDefinition } from '../filter-types';
 import { allStatNames, statHashByName } from '../search-filter-values';
-import { rangeStringToComparator } from './range-numeric';
-
-/** matches a filterValue that's probably a math check */
-const mathCheck = /^[\d<>=]/;
 
 const seasonTagToNumber = {
   ...seasonTags,
   next: D2CalculatedSeason + 1,
   current: D2CalculatedSeason,
 };
-
-// prioritize newer seasons. nobody is looking for "redwar" at this point
-const seasonTagNames = Object.keys(seasonTagToNumber).reverse();
 
 // shortcuts for power numbers
 const powerLevelByKeyword = {
@@ -27,9 +20,6 @@ const powerLevelByKeyword = {
   powerfulcap: D2SeasonInfo[D2CalculatedSeason].powerfulCap,
   pinnaclecap: D2SeasonInfo[D2CalculatedSeason].pinnacleCap,
 };
-const powerLevelKeywords = Object.keys(powerLevelByKeyword);
-// TO DATE, things cannot cap at anything but pinnacle limits
-const powerCapKeywords = ['pinnaclecap'];
 
 // overloadedRangeFilters: stuff that may test a range, but also accepts a word
 
@@ -43,16 +33,14 @@ const overloadedRangeFilters: FilterDefinition[] = [
     format: ['simple', 'query', 'range'],
     destinyVersion: 2,
     suggestions: allStatNames,
-    filter: ({ filterValue }) => {
+    filter: ({ keyword, filterValue, compare }) => {
       // the "is:masterwork" case
-      if (filterValue === 'masterwork') {
+      if (keyword === 'is') {
         return (item) => item.masterwork;
       }
       // "masterwork:<5" case
-      if (mathCheck.test(filterValue)) {
-        const numberComparisonFunction = rangeStringToComparator(filterValue);
-        return (item) =>
-          Boolean(item.masterworkInfo?.tier && numberComparisonFunction(item.masterworkInfo.tier));
+      if (compare) {
+        return (item) => Boolean(item.masterworkInfo?.tier && compare(item.masterworkInfo.tier));
       }
       // "masterwork:range" case
       const searchedMasterworkStatHash = statHashByName[filterValue];
@@ -69,11 +57,9 @@ const overloadedRangeFilters: FilterDefinition[] = [
     format: ['range', 'query'],
     destinyVersion: 2,
     suggestions: energyCapacityTypeNames,
-    filter: ({ filterValue }) => {
-      if (mathCheck.test(filterValue)) {
-        const numberComparisonFunction = rangeStringToComparator(filterValue);
-        return (item: DimItem) =>
-          item.energy && numberComparisonFunction(item.energy.energyCapacity);
+    filter: ({ filterValue, compare }) => {
+      if (compare) {
+        return (item: DimItem) => item.energy && compare(item.energy.energyCapacity);
       }
       return (item: DimItem) =>
         item.energy && filterValue === energyNamesByEnum[item.energy.energyType];
@@ -82,63 +68,38 @@ const overloadedRangeFilters: FilterDefinition[] = [
   {
     keywords: 'season',
     description: tl('Filter.Season'),
-    format: 'rangeoverload',
+    format: 'range',
     destinyVersion: 2,
-    suggestions: seasonTagNames,
-    filter: ({ filterValue }) => {
-      filterValue = replaceSeasonTagWithNumber(filterValue);
-      const compareTo = rangeStringToComparator(filterValue);
-      return (item: DimItem) => compareTo(getSeason(item));
-    },
+    overload: Object.fromEntries(Object.entries(seasonTagToNumber).reverse()),
+    filter:
+      ({ compare }) =>
+      (item: DimItem) =>
+        compare!(getSeason(item)),
   },
   {
     keywords: ['light', 'power'],
     /* t('Filter.PowerKeywords') */
     description: tl('Filter.PowerLevel'),
-    format: 'rangeoverload',
-    suggestions: powerLevelKeywords,
-    filter: ({ filterValue }) => {
-      filterValue = replacePowerLevelKeyword(filterValue);
-      const compareTo = rangeStringToComparator(filterValue);
-      return (item) => Boolean(item.power && compareTo(item.power));
-    },
+    format: 'range',
+    overload: powerLevelByKeyword,
+    filter:
+      ({ compare }) =>
+      (item) =>
+        Boolean(item.power && compare!(item.power)),
   },
   {
     keywords: 'powerlimit',
     /* t('Filter.PowerKeywords') */
     description: tl('Filter.PowerLimit'),
-    format: 'rangeoverload',
-    suggestions: powerCapKeywords,
+    format: 'range',
+    overload: powerLevelByKeyword,
     destinyVersion: 2,
-    filter: ({ filterValue }) => {
-      filterValue = replacePowerLevelKeyword(filterValue);
-      const compareTo = rangeStringToComparator(filterValue);
-      return (item) =>
+    filter:
+      ({ compare }) =>
+      (item) =>
         // anything with no powerCap has no known limit, so treat it like it's 99999999
-        compareTo(item.powerCap ?? 99999999);
-    },
+        compare!(item.powerCap ?? 99999999),
   },
 ];
 
 export default overloadedRangeFilters;
-
-/**
- * replaces a word with a corresponding season
- *
- * i.e. turns `<=forge` into `<=5`
- *
- * use only on simple filter values where there's not other letters
- */
-function replaceSeasonTagWithNumber(s: string) {
-  return s.replace(/[a-z]+$/i, (tag) => seasonTagToNumber[tag]);
-}
-
-const powerKeywordMatcher = new RegExp(powerLevelKeywords.join('|'));
-/**
- * replaces a word with a corresponding power level
- *
- * use only on simple filter values where there's not other letters
- */
-function replacePowerLevelKeyword(s: string) {
-  return s.replace(powerKeywordMatcher, (tag) => powerLevelByKeyword[tag]);
-}

--- a/src/app/search/search-utils.test.ts
+++ b/src/app/search/search-utils.test.ts
@@ -13,7 +13,7 @@ describe('generateSuggestionsForFilter', () => {
     ['query', 'a', ['b', 'c']],
     ['stat', 'a', ['b', 'c']],
     ['range', 'a', undefined],
-    ['rangeoverload', 'a', ['b', 'c']],
+    ['range', 'a', ['b', 'c']],
     ['freeform', 'a', ['b', 'c']],
     [undefined, ['a'], undefined],
     ['stat', 'stat', allStatNames],

--- a/src/app/search/search-utils.ts
+++ b/src/app/search/search-utils.ts
@@ -1,5 +1,50 @@
+import { canonicalFilterFormats } from './filter-types';
 import { parseQuery, QueryAST } from './query-parser';
 import { SearchConfig } from './search-config';
+import { matchFilter } from './search-filter';
+
+const rangeStringRegex = /^([<=>]{0,2})(\d+(?:\.\d+)?)$/;
+const overloadedRangeStringRegex = /^([<=>]{0,2})(\w+)$/;
+
+export function rangeStringToComparator(
+  rangeString?: string,
+  overloads?: { [key: string]: number }
+) {
+  if (!rangeString) {
+    throw new Error('Missing range comparison');
+  }
+
+  const [operator, comparisonValue] = extractOpAndValue(rangeString, overloads);
+
+  switch (operator) {
+    case '=':
+    case '':
+      return (compare: number) => compare === comparisonValue;
+    case '<':
+      return (compare: number) => compare < comparisonValue;
+    case '<=':
+      return (compare: number) => compare <= comparisonValue;
+    case '>':
+      return (compare: number) => compare > comparisonValue;
+    case '>=':
+      return (compare: number) => compare >= comparisonValue;
+  }
+  throw new Error('Unknown range operator ' + operator);
+}
+
+function extractOpAndValue(rangeString: string, overloads?: { [key: string]: number }) {
+  const matchedOverloadString = rangeString.match(overloadedRangeStringRegex);
+  if (matchedOverloadString && overloads && matchedOverloadString[2] in overloads) {
+    return [matchedOverloadString[1], overloads[matchedOverloadString[2]]] as const;
+  }
+
+  const matchedRangeString = rangeString.match(rangeStringRegex);
+  if (matchedRangeString) {
+    return [matchedRangeString[1], parseFloat(matchedRangeString[2])] as const;
+  }
+
+  throw new Error("Doesn't match our range comparison syntax, or invalid overload");
+}
 
 export function parseAndValidateQuery(query: string, searchConfig: SearchConfig) {
   let valid = true;
@@ -23,16 +68,16 @@ export function validateQuery(query: QueryAST, searchConfig: SearchConfig): bool
   }
   switch (query.op) {
     case 'filter': {
-      let filterName = query.type;
+      const filterName = query.type;
       const filterValue = query.args;
 
-      // "is:" filters are slightly special cased
       if (filterName === 'is') {
-        filterName = filterValue;
+        const filterDef = searchConfig.filters[filterValue];
+        return filterDef && canonicalFilterFormats(filterDef.format).some((f) => f === 'simple');
+      } else {
+        const filterDef = searchConfig.filters[filterName];
+        return Boolean(filterDef && matchFilter(filterDef, filterName, filterValue));
       }
-
-      // TODO: validate that filterValue is correct
-      return Boolean(searchConfig.filters[filterName]);
     }
     case 'not':
       return validateQuery(query.operand, searchConfig);

--- a/src/app/search/suggestions-generation.ts
+++ b/src/app/search/suggestions-generation.ts
@@ -46,13 +46,12 @@ function makeSuggestionsContext(
   };
 }
 
-const operators = ['<', '>', '<=', '>=']; // TODO: add "none"? remove >=, <=?
+const operators = ['<', '>', '<=', '>=']; // TODO: remove >=, <=?
 
 /**
- * Generates all the possible suggested keywords for the given filter
- *
- * Accepts partial filters with as little as just a "keywords" property,
- * if you want to generate some keywords without a full valid filter
+ * Generates all the possible suggested keywords for the given filter,
+ * followed by the operators that should be grouped in a single help
+ * line.
  */
 export function generateSuggestionsForFilter(
   filterDefinition: Pick<FilterDefinition, 'keywords' | 'suggestions' | 'format' | 'deprecated'>
@@ -68,8 +67,16 @@ export function generateSuggestionsForFilter(
   );
 }
 
+/**
+ * Generates all the possible suggested keywords for the given filter,
+ * followed by the operators that should be grouped in a single help
+ * line.
+ */
 export function generateGroupedSuggestionsForFilter(
-  filterDefinition: Pick<FilterDefinition, 'keywords' | 'suggestions' | 'format' | 'deprecated'>,
+  filterDefinition: Pick<
+    FilterDefinition,
+    'keywords' | 'suggestions' | 'format' | 'deprecated' | 'overload'
+  >,
   forHelp?: boolean
 ): { keyword: string; ops?: string[] }[] {
   if (filterDefinition.deprecated) {
@@ -121,10 +128,11 @@ export function generateGroupedSuggestionsForFilter(
         break;
       case 'range':
         allSuggestions.push(...expandOps([thisFilterKeywords], operators));
-        break;
-      case 'rangeoverload':
-        allSuggestions.push(...expandOps([thisFilterKeywords], operators));
-        allSuggestions.push(...expandFlat([thisFilterKeywords, filterSuggestions]));
+        if (filterDefinition.overload) {
+          allSuggestions.push(
+            ...expandFlat([thisFilterKeywords, Object.keys(filterDefinition.overload)])
+          );
+        }
         break;
       case 'stat':
         // stat lists aren't exhaustive


### PR DESCRIPTION
Filters currently "accept" a lot of invalid syntax and internally throw an error on filter construction, which is logged to the console but not shown to the user anywhere. In an earlier PR, we categorized our filters more cleanly, which allows validation. This also prevents using `is:` syntax for filters that don't support it and query syntax for `is:` filters.

Practically, this means that the search bar text will now turn grey if the syntax couldn't be matched to one of the filter definition's formats, and the filter function construction will be skipped in favor of a noop.

This makes some previously valid syntax invalid. Two cases I know of (there might be more. this really needs more testing):

* `ghost:energy`: These are meant to be `is:` filters, but because they're keywords of the same filter definition, it's interpreted as `is:energy`. Doesn't seem to be too useful, but maybe people rely on `ghost:ghost` or something?
* `season:<1redwar`: Really just an amusing quirk in overloaded range filters that I fixed, this is `season:<11`.