### PR TITLE
Ensure organizer icons in the selected category retain their inverted color after moving mouse out

### DIFF
--- a/src/app/organizer/ItemTypeSelector.m.scss
+++ b/src/app/organizer/ItemTypeSelector.m.scss
@@ -17,14 +17,6 @@
   align-items: flex-start;
 }
 
-.checked {
-  background-color: $orange !important;
-  color: black !important;
-  > img {
-    filter: none !important;
-  }
-}
-
 .button {
   composes: dim-button from global;
   margin: 2px;
@@ -33,7 +25,8 @@
     margin-left: 0 !important;
   }
   &:hover,
-  &:active {
+  &:active,
+  &.checked {
     background-color: $orange;
     color: black;
     > img {


### PR DESCRIPTION
Fixes #7818.