### PR TITLE
Skip show/hide animations for sheets with prefers reduced motion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Masterwork picker now only shows higher tiers of the current masterwork and full masterworks compatible with the weapon type.
 * Sharing a build from the Loadouts page or Loadout Optimizer now uses our dim.gg links which are easier to share and show a preview.
+* If you prefer reduced motion (in your operating system preferences), sheets like the compare and loadout dialogs now appear and disappear instantly.
 
 ## 7.3.0 <span class="changelog-date">(2022-01-30)</span>
 


### PR DESCRIPTION
Show/hide are instant. Drag-dismissing (throwing the sheet or pulling and releasing) still animates it away.

This is a way to handle #7458 even though it's not as satisfying as fixing the perf issue.
Fixes #7471 for sheets. 