### PR TITLE
Explicitly list possible filter syntaxes in filter definition

### DIFF
--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -78,16 +78,7 @@ function FilterExplanation({ filter }: { filter: FilterDefinition }) {
   const dispatch = useDispatch();
   const additionalSuggestions = filter.suggestionsGenerator?.({}) ?? [];
   const suggestions = Array.from(
-    new Set(
-      [...generateSuggestionsForFilter(filter), ...additionalSuggestions].filter(
-        (s) =>
-          !s.startsWith('not:') &&
-          (filter.format === 'freeform' ||
-            filter.format === 'range' ||
-            filter.format === 'rangeoverload' ||
-            !s.endsWith(':'))
-      )
-    )
+    new Set([...generateSuggestionsForFilter(filter, true), ...additionalSuggestions])
   );
   const localDesc = Array.isArray(filter.description)
     ? t(...filter.description)

--- a/src/app/search/__snapshots__/search-utils.test.ts.snap
+++ b/src/app/search/__snapshots__/search-utils.test.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generateSuggestionsForFilter full suggestions for filter format '[ 'range', 'query' ]', keyword 'energycapacity' with suggestions [
+  'any',    'arc',
+  'solar',  'void',
+  'ghost',  'subclass',
+  'stasis'
+] 1`] = `
+Array [
+  "energycapacity:",
+  "energycapacity:<",
+  "energycapacity:>",
+  "energycapacity:<=",
+  "energycapacity:>=",
+  "energycapacity:",
+  "energycapacity:any",
+  "energycapacity:arc",
+  "energycapacity:solar",
+  "energycapacity:void",
+  "energycapacity:ghost",
+  "energycapacity:subclass",
+  "energycapacity:stasis",
+]
+`;
+
 exports[`generateSuggestionsForFilter full suggestions for filter format 'freeform', keyword 'a' with suggestions [ 'b', 'c' ] 1`] = `
 Array [
   "a:",
@@ -56,7 +79,30 @@ Array [
 ]
 `;
 
-exports[`generateSuggestionsForFilter full suggestions for filter format 'range', keyword 'a' with suggestions [ 'b', 'c' ] 1`] = `
+exports[`generateSuggestionsForFilter full suggestions for filter format 'range', keyword 'a' with suggestions undefined 1`] = `
+Array [
+  "a:",
+  "a:<",
+  "a:>",
+  "a:<=",
+  "a:>=",
+]
+`;
+
+exports[`generateSuggestionsForFilter full suggestions for filter format 'rangeoverload', keyword 'a' with suggestions [ 'b', 'c' ] 1`] = `
+Array [
+  "a:",
+  "a:<",
+  "a:>",
+  "a:<=",
+  "a:>=",
+  "a:",
+  "a:b",
+  "a:c",
+]
+`;
+
+exports[`generateSuggestionsForFilter full suggestions for filter format 'stat', keyword 'a' with suggestions [ 'b', 'c' ] 1`] = `
 Array [
   "a:",
   "a:b:",
@@ -72,17 +118,7 @@ Array [
 ]
 `;
 
-exports[`generateSuggestionsForFilter full suggestions for filter format 'range', keyword 'a' with suggestions undefined 1`] = `
-Array [
-  "a:",
-  "a:<",
-  "a:>",
-  "a:<=",
-  "a:>=",
-]
-`;
-
-exports[`generateSuggestionsForFilter full suggestions for filter format 'range', keyword 'stat' with suggestions [
+exports[`generateSuggestionsForFilter full suggestions for filter format 'stat', keyword 'stat' with suggestions [
   'rpm',             'rof',
   'charge',          'impact',
   'handling',        'range',
@@ -262,42 +298,6 @@ Array [
   "stat:total:>=",
   "stat:custom:>=",
   "stat:any:>=",
-]
-`;
-
-exports[`generateSuggestionsForFilter full suggestions for filter format 'rangeoverload', keyword 'a' with suggestions [ 'b', 'c' ] 1`] = `
-Array [
-  "a:",
-  "a:<",
-  "a:>",
-  "a:<=",
-  "a:>=",
-  "a:",
-  "a:b",
-  "a:c",
-]
-`;
-
-exports[`generateSuggestionsForFilter full suggestions for filter format 'rangeoverload', keyword 'energycapacity' with suggestions [
-  'any',    'arc',
-  'solar',  'void',
-  'ghost',  'subclass',
-  'stasis'
-] 1`] = `
-Array [
-  "energycapacity:",
-  "energycapacity:<",
-  "energycapacity:>",
-  "energycapacity:<=",
-  "energycapacity:>=",
-  "energycapacity:",
-  "energycapacity:any",
-  "energycapacity:arc",
-  "energycapacity:solar",
-  "energycapacity:void",
-  "energycapacity:ghost",
-  "energycapacity:subclass",
-  "energycapacity:stasis",
 ]
 `;
 

--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -6,8 +6,8 @@ import { isQuotable, quoteFilterString } from './freeform';
 const loadoutFilters: FilterDefinition[] = [
   {
     keywords: 'inloadout',
+    format: ['simple', 'freeform'],
 
-    // excluding a "format" property causes autogeneration of the simple "is" and "not" stems
     suggestionsGenerator: ({ loadouts }) =>
       loadouts
         ?.filter((l) => isQuotable(l.name))

--- a/src/app/search/search-filters/range-numeric.tsx
+++ b/src/app/search/search-filters/range-numeric.tsx
@@ -1,7 +1,6 @@
 import { tl } from 'app/i18next-t';
 import { getItemKillTrackerInfo, getItemYear } from 'app/utils/item-utils';
 import { FilterDefinition } from '../filter-types';
-import { generateSuggestionsForFilter } from '../suggestions-generation';
 
 const rangeStringRegex = /^([<=>]{0,2})(\d+(?:\.\d+)?)$/;
 
@@ -64,11 +63,9 @@ const simpleRangeFilters: FilterDefinition[] = [
   {
     keywords: 'kills',
     description: tl('Filter.MasterworkKills'),
-    format: 'range',
+    format: ['range', 'stat'],
     destinyVersion: 2,
     suggestions: ['pve', 'pvp'],
-    suggestionsGenerator: () =>
-      generateSuggestionsForFilter({ keywords: 'kills', format: 'range' }),
     filter: ({ filterValue }) => {
       const parts = filterValue.split(':');
       const [count, ...[activityType, shouldntExist]] = [parts.pop(), ...parts];

--- a/src/app/search/search-filters/range-overload.tsx
+++ b/src/app/search/search-filters/range-overload.tsx
@@ -6,7 +6,6 @@ import seasonTags from 'data/d2/season-tags.json';
 import { energyCapacityTypeNames, energyNamesByEnum } from '../d2-known-values';
 import { FilterDefinition } from '../filter-types';
 import { allStatNames, statHashByName } from '../search-filter-values';
-import { generateSuggestionsForFilter } from '../suggestions-generation';
 import { rangeStringToComparator } from './range-numeric';
 
 /** matches a filterValue that's probably a math check */
@@ -37,16 +36,13 @@ const powerCapKeywords = ['pinnaclecap'];
 // this word might become a number like arrival ====> 11,
 // then be processed normally in a number check
 
-// or the word might be checked differently than the number, like
-// masterwork:handling is a completely different test from masterwork:>7
 const overloadedRangeFilters: FilterDefinition[] = [
   {
     keywords: 'masterwork',
     description: tl('Filter.Masterwork'),
-    format: 'rangeoverload',
+    format: ['simple', 'query', 'range'],
     destinyVersion: 2,
     suggestions: allStatNames,
-    suggestionsGenerator: () => generateSuggestionsForFilter({ keywords: 'masterwork' }),
     filter: ({ filterValue }) => {
       // the "is:masterwork" case
       if (filterValue === 'masterwork') {
@@ -70,7 +66,7 @@ const overloadedRangeFilters: FilterDefinition[] = [
   {
     keywords: 'energycapacity',
     description: tl('Filter.Energy'),
-    format: 'rangeoverload',
+    format: ['range', 'query'],
     destinyVersion: 2,
     suggestions: energyCapacityTypeNames,
     filter: ({ filterValue }) => {

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -19,7 +19,7 @@ const statFilters: FilterDefinition[] = [
     keywords: 'stat',
     // t('Filter.StatsExtras')
     description: tl('Filter.Stats'),
-    format: 'range',
+    format: 'stat',
     suggestions: allStatNames,
     filter: ({ filterValue }) => statFilterFromString(filterValue),
   },
@@ -27,7 +27,7 @@ const statFilters: FilterDefinition[] = [
     keywords: 'basestat',
     // t('Filter.StatsExtras')
     description: tl('Filter.StatsBase'),
-    format: 'range',
+    format: 'stat',
     suggestions: searchableArmorStatNames,
     filter: ({ filterValue }) => statFilterFromString(filterValue, true),
   },

--- a/src/app/search/search-utils.test.ts
+++ b/src/app/search/search-utils.test.ts
@@ -11,15 +11,15 @@ describe('generateSuggestionsForFilter', () => {
   ][] = [
     [undefined, ['a', 'b', 'c'], undefined],
     ['query', 'a', ['b', 'c']],
-    ['range', 'a', ['b', 'c']],
+    ['stat', 'a', ['b', 'c']],
     ['range', 'a', undefined],
     ['rangeoverload', 'a', ['b', 'c']],
     ['freeform', 'a', ['b', 'c']],
     [undefined, ['a'], undefined],
-    ['range', 'stat', allStatNames],
+    ['stat', 'stat', allStatNames],
     ['query', 'maxstatvalue', searchableArmorStatNames],
     ['query', 'maxstatvalue', searchableArmorStatNames],
-    ['rangeoverload', 'energycapacity', energyCapacityTypeNames],
+    [['range', 'query'], 'energycapacity', energyCapacityTypeNames],
   ];
 
   test.each(cases)(


### PR DESCRIPTION
Filters have to specify a filter format for suggestions and autocompletion to work, but some filters accept multiple formats and use the `suggestionsGenerator` to work around these issues. This is a first step towards deeper query validation, but slightly improves the filter help sheet in terms of ordering and completeness.

I don't know why the jest snapshot file has its contents reordered :/