### PR TITLE
Fix bulk-transferring ships

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Collect Postmaster now requires an additional click to confirm.
+* Transferring ships via search query should now reliably transfer all selected items.
 
 ## 7.4.0 <span class="changelog-date">(2022-02-06)</span>
 

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -655,7 +655,6 @@ function getLoadoutItem(
       BucketHashes.Emblems,
       BucketHashes.Emotes_Invisible,
       BucketHashes.Emotes_Equippable,
-      BucketHashes.Ships,
       D1BucketHashes.Horn,
     ].includes(item.bucket.hash)
   ) {


### PR DESCRIPTION
As reported on Discord. With `Ships` in this list, DIM would reliably select the wrong ship in `getLoadoutItem` and only transfer one copy of each ship, and also unequip other instances of transferred ship hashes from other characters even when those weren't selected for transfer.

I'm not sure why ships are in here (D1 reasons? please shout if this breaks D1 DIM?) but it seems definitely incorrect for D2. `Shaders` also seems suspicious but that bucket isn't in use anymore.