### PR TITLE
Organizer: fix recoil base stat display

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -22,7 +22,7 @@ import TagIcon from 'app/inventory/TagIcon';
 import { ItemStatValue } from 'app/item-popup/ItemStat';
 import NotesArea from 'app/item-popup/NotesArea';
 import { DimPlugTooltip } from 'app/item-popup/PlugTooltip';
-import { recoilValue } from 'app/item-popup/RecoilStat';
+import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { CUSTOM_TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 import { statHashByName } from 'app/search/search-filter-values';
@@ -172,16 +172,28 @@ export function getColumns(
     destinyVersion === 2
       ? statColumns.map((column) => ({
           ...column,
-          id: `base_${column.statHash}`,
+          id: `base${column.statHash}`,
           columnGroup: baseStatsGroup,
-          value: (item: DimItem) => {
+          value: (item: DimItem): number => {
             const stat = item.stats?.find((s) => s.statHash === column.statHash);
             if (stat?.statHash === StatHashes.RecoilDirection) {
               return recoilValue(stat.base);
             }
             return stat?.base || 0;
           },
-          cell: (value) => <div className={styles.statValue}>{value}</div>,
+          cell: (_val, item: DimItem) => {
+            const stat = item.stats?.find((s) => s.statHash === column.statHash);
+            if (!stat) {
+              return null;
+            }
+            const value = stat.base;
+            return (
+              <div className={clsx(styles.statValue)}>
+                {value}
+                {column.statHash === StatHashes.RecoilDirection && <RecoilStat value={value} />}
+              </div>
+            );
+          },
           filter: (value) => `basestat:${_.invert(statHashByName)[column.statHash]}:>=${value}`,
         }))
       : [];

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -247,7 +247,9 @@ $content-cells: 5;
   }
 }
 
-.stat-2715839340 {
+// Recoil circle
+.stat-2715839340,
+.base-2715839340 {
   svg {
     circle {
       fill: black;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'archetype': string;
+  'base2715839340': string;
   'customstat': string;
   'dmg': string;
   'energy': string;


### PR DESCRIPTION
When the "base stats" columns are enabled in the Organizer's weapons views there's a very badly formatted recoil value: 
![grafik](https://user-images.githubusercontent.com/14299449/153094238-25555995-f28f-40e5-85b4-bf5c7e4d5e99.png)

This fixes the way they're displayed 
![grafik](https://user-images.githubusercontent.com/14299449/153095055-04c57a93-3d86-4e96-ba21-1705cc606f45.png)
