### PR TITLE
Fix autocompletion considering rangeoverload filters complete too early

### DIFF
--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -51,19 +51,7 @@ Array [
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `
-Array [
-  Object {
-    "helpText": undefined,
-    "highlightRange": Array [
-      8,
-      21,
-    ],
-    "query": "season:>season:outlaw",
-    "type": 3,
-  },
-]
-`;
+exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `Array []`;
 
 exports[`filterComplete autocomplete terms for |is:b| 1`] = `
 Array [

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -51,6 +51,20 @@ Array [
 ]
 `;
 
+exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `
+Array [
+  Object {
+    "helpText": undefined,
+    "highlightRange": Array [
+      8,
+      21,
+    ],
+    "query": "season:>season:outlaw",
+    "type": 3,
+  },
+]
+`;
+
 exports[`filterComplete autocomplete terms for |is:b| 1`] = `
 Array [
   "is:bow",

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -14,6 +14,7 @@ describe('autocompleteTermSuggestions', () => {
     ['is:haspower is:b', 16],
     ['(is:blue jun)', 11],
     ['is:bow is:void', 11],
+    ['season:>outl', 12],
   ];
 
   test.each(cases)(

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -168,7 +168,7 @@ export function filterSortRecentSearches(query: string, recentSearches: Search[]
 const caretEndRegex = /([\s)]|$)/;
 
 // most times, insist on at least 3 typed characters, but for #, start suggesting immediately
-const lastWordRegex = /(\b[\w:"']{3,}|#\w*)$/;
+const lastWordRegex = /(\b[\w:"'<=>]{3,}|#\w*)$/;
 // matches a string that seems to end with a closing, not opening, quote
 const closingQuoteRegex = /\w["']$/;
 


### PR DESCRIPTION
Would be cool to actually complete the term here but that'd have to happen in the autocompleter because I don't want to blow up filters help again.

Fixes #6482.