### PR TITLE
truncate long stat names in LO sidebar

### DIFF
--- a/src/app/loadout-builder/filter/TierSelect.m.scss
+++ b/src/app/loadout-builder/filter/TierSelect.m.scss
@@ -67,11 +67,21 @@
     grid-area: name;
     height: 100%;
     display: flex;
+    overflow: hidden;
+
     > span {
       display: flex;
       flex-direction: row;
       align-items: center;
       white-space: nowrap;
+    }
+  }
+
+  .statDisplayInfo {
+    overflow: hidden;
+    .statName {
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 

--- a/src/app/loadout-builder/filter/TierSelect.m.scss.d.ts
+++ b/src/app/loadout-builder/filter/TierSelect.m.scss.d.ts
@@ -8,6 +8,8 @@ interface CssExports {
   'minimum': string;
   'range': string;
   'row': string;
+  'statDisplayInfo': string;
+  'statName': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -72,12 +72,22 @@ export default function TierSelect({
                 index={index}
                 className={styles.row}
                 name={
-                  <span className={clsx({ [styles.ignored]: stats[statHash].ignored })}>
+                  <span
+                    className={clsx(
+                      { [styles.ignored]: stats[statHash].ignored },
+                      styles.statDisplayInfo
+                    )}
+                  >
                     <BungieImage
                       className={styles.iconStat}
                       src={statDefs[statHash].displayProperties.icon}
                     />
-                    {statDefs[statHash].displayProperties.name}
+                    <span
+                      className={styles.statName}
+                      title={statDefs[statHash].displayProperties.name}
+                    >
+                      {statDefs[statHash].displayProperties.name}
+                    </span>
                   </span>
                 }
               >


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/68782081/153739300-58f02874-72b7-48bb-8a9a-965a48cb03f7.png)

after:
![image](https://user-images.githubusercontent.com/68782081/153739286-0a7d4161-b708-4fe8-a062-900a47531cb5.png)
 