### PR TITLE
LO: Unpin item in bucket of newly excluded item

### DIFF
--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -262,6 +262,11 @@ function lbStateReducer(defs: D2ManifestDefinitions) {
         const existingExcluded = state.excludedItems[bucketHash] ?? [];
         return {
           ...state,
+          // Also unpin items in this bucket
+          pinnedItems: {
+            ...state.pinnedItems,
+            [bucketHash]: undefined,
+          },
           excludedItems: {
             ...state.excludedItems,
             [bucketHash]: [...existingExcluded, item],


### PR DESCRIPTION
Similar to how pinning an item drops exclusions from that bucket, excluding an item now drops the pin from that bucket. Seems only reasonable because if you exclude a pinned item (e.g. via drag and drop) you get no results at all, and excluding any other item in that bucket has no effect if the pin isn't dropped.