### PR TITLE
eslint cache-strategy content

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,9 +37,7 @@ jobs:
         run: yarn test
 
       - name: Lint check
-        run: |
-          find . -type d -name "node_modules" -prune -o -type f -iregex '.*.ts\|.*.js\|.*.tsx\|.*.jsx' -exec ./build/set-mtime-to-md5.sh {} \;
-          yarn lintcached:eslint
+        run: yarn lintcached:eslint
 
       # We set the default packtracker ENV vars
       - name: Build beta

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -29,15 +29,11 @@ jobs:
             ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('.eslintrc') }}
             ${{ runner.os }}-${{ env.cache-name }}-
 
-      # TODO: Gnu parallel for test/check
       - name: Install
         run: yarn install --frozen-lockfile --prefer-offline
 
-      - name: Test
-        run: yarn test
-
-      - name: Lint check
-        run: yarn lintcached:eslint
+      - name: Test & Lint
+        run: yarn test-and-lint
 
       # We set the default packtracker ENV vars
       - name: Build beta

--- a/build/set-mtime-to-md5.sh
+++ b/build/set-mtime-to-md5.sh
@@ -1,3 +1,0 @@
-file=$1
-md5=$(date -d \@$((0x$(md5sum $file | cut -b 1-7))))
-touch $file -d $md5 -c

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "dead-code": "ts-prune -s '*.test.ts?' | grep -v cssExports | grep -v 'used in module'",
     "bcu": "run-s bcu:*",
     "bcu:build": "node src/build-browsercheck-utils.js",
-    "bcu:pretty": "prettier --write src/browsercheck-utils.js"
+    "bcu:pretty": "prettier --write src/browsercheck-utils.js",
+    "test-and-lint": "run-p test lintcached"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:prettier": "prettier src/**/*.{js,ts,tsx,scss,html} --check",
     "lint:stylelint": "stylelint src/**/*.scss",
     "lintcached": "run-p lintcached:*",
-    "lintcached:eslint": "yarn lint:eslint --cache --cache-location .eslintcache",
+    "lintcached:eslint": "yarn lint:eslint --cache --cache-location .eslintcache --cache-strategy content",
     "fix": "run-s fix:*",
     "fix:eslint": "yarn lint:eslint --fix",
     "fix:json": "jsonsort src/locale",


### PR DESCRIPTION
use eslint cache-strategy content instead of mtime hack

Running Lint and Test in parallel saves ~20s