### PR TITLE
Use correct store ID for new loadout drawer's mod picker

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -227,6 +227,7 @@ export default function LoadoutDrawer() {
       <h1>{isNew ? t('Loadouts.Create') : t('Loadouts.Edit')}</h1>
       <LoadoutDrawerOptions
         loadout={loadout}
+        storeId={storeId}
         showClass={showClass}
         isNew={isNew}
         onUpdateMods={onUpdateMods}

--- a/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
@@ -39,8 +39,8 @@ export default function LoadoutDrawerOptions({
   saveAsNew,
   deleteLoadout,
 }: {
-  loadout?: Readonly<Loadout>;
-  storeId?: string;
+  loadout: Readonly<Loadout> | undefined;
+  storeId: string | undefined;
   showClass: boolean;
   isNew: boolean;
   onUpdateMods(mods: PluggableInventoryItemDefinition[]): void;

--- a/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerOptions.tsx
@@ -30,6 +30,7 @@ const classTypeOptionsSelector = createSelector(storesSelector, (stores) => {
 
 export default function LoadoutDrawerOptions({
   loadout,
+  storeId,
   showClass,
   isNew,
   onUpdateMods,
@@ -39,6 +40,7 @@ export default function LoadoutDrawerOptions({
   deleteLoadout,
 }: {
   loadout?: Readonly<Loadout>;
+  storeId?: string;
   showClass: boolean;
   isNew: boolean;
   onUpdateMods(mods: PluggableInventoryItemDefinition[]): void;
@@ -214,6 +216,7 @@ export default function LoadoutDrawerOptions({
         ReactDOM.createPortal(
           <ModAssignmentDrawer
             loadout={loadout}
+            storeId={storeId}
             onUpdateMods={onUpdateMods}
             onClose={() => setShowModAssignmentDrawer(false)}
           />,

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -93,6 +93,7 @@ export default memo(function LoadoutMods({
         ReactDOM.createPortal(
           <ModAssignmentDrawer
             loadout={loadout}
+            storeId={storeId}
             onUpdateMods={onUpdateMods}
             onClose={() => setShowModAssignmentDrawer(false)}
           />,
@@ -103,6 +104,7 @@ export default memo(function LoadoutMods({
         ReactDOM.createPortal(
           <ModPicker
             classType={loadout.classType}
+            owner={storeId}
             lockedMods={savedMods}
             onAccept={onUpdateMods}
             onClose={() => setShowModPicker(false)}

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -53,10 +53,12 @@ function Header({
 
 export default function ModAssignmentDrawer({
   loadout,
+  storeId,
   onUpdateMods,
   onClose,
 }: {
   loadout: Loadout;
+  storeId: string | undefined;
   onUpdateMods?(newMods: PluggableInventoryItemDefinition[]): void;
   onClose(): void;
 }) {
@@ -182,6 +184,7 @@ export default function ModAssignmentDrawer({
         ReactDOM.createPortal(
           <ModPicker
             classType={loadout.classType}
+            owner={storeId}
             lockedMods={mods}
             plugCategoryHashWhitelist={plugCategoryHashWhitelist}
             onAccept={onUpdateMods}


### PR DESCRIPTION
This hopefully fixes a regression where artifact mods would go missing from the mods picker for no apparent reason when the unlock status differs between characters.