### PR TITLE
Remove "loadoutDialogOpen"

### DIFF
--- a/src/app/inventory/StoreInventoryItem.tsx
+++ b/src/app/inventory/StoreInventoryItem.tsx
@@ -1,5 +1,5 @@
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import React from 'react';
+import React, { useCallback } from 'react';
 import ConnectedInventoryItem from './ConnectedInventoryItem';
 import DraggableInventoryItem from './DraggableInventoryItem';
 import { DimItem } from './item-types';
@@ -15,9 +15,10 @@ interface Props {
  */
 export default function StoreInventoryItem({ item }: Props) {
   const dispatch = useThunkDispatch();
-  const doubleClicked = (e: React.MouseEvent) => {
-    dispatch(moveItemToCurrentStore(item, e));
-  };
+  const doubleClicked = useCallback(
+    (e: React.MouseEvent) => dispatch(moveItemToCurrentStore(item, e)),
+    [dispatch, item]
+  );
 
   return (
     <DraggableInventoryItem item={item}>

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -1,9 +1,7 @@
 import { getCurrentHub, startTransaction } from '@sentry/browser';
-import { compareOpenSelector } from 'app/compare/selectors';
 import { t } from 'app/i18next-t';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { hideItemPopup } from 'app/item-popup/item-popup';
-import { loadoutDialogOpen } from 'app/loadout-drawer/LoadoutDrawer';
 import { ThunkResult } from 'app/store/types';
 import { CanceledError, withCancel } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
@@ -30,10 +28,6 @@ import { amountOfItem, getCurrentStore, getStore, getVault } from './stores-help
  */
 export function moveItemToCurrentStore(item: DimItem, e?: React.MouseEvent): ThunkResult<DimItem> {
   return async (dispatch, getState) => {
-    if (loadoutDialogOpen || compareOpenSelector(getState())) {
-      return item;
-    }
-
     e?.stopPropagation();
 
     const active = getCurrentStore(storesSelector(getState()))!;

--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -32,11 +32,8 @@ import LoadoutDrawerContents from './LoadoutDrawerContents';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import LoadoutDrawerOptions from './LoadoutDrawerOptions';
 
-// TODO: Consider moving editLoadout/addItemToLoadout/loadoutDialogOpen into Redux (actions + state)
+// TODO: Consider moving editLoadout/addItemToLoadout into Redux (actions + state)
 // TODO: break out a container from the actual loadout drawer so we can lazy load the drawer
-
-/** Is the loadout drawer currently open? */
-export let loadoutDialogOpen = false;
 
 /**
  * The Loadout editor that shows up as a sheet on the Inventory screen. You can build and edit
@@ -60,9 +57,6 @@ export default function LoadoutDrawer() {
       },
       showFashionDrawer: false,
     });
-
-  // Sync this global variable with our actual state. TODO: move to redux
-  loadoutDialogOpen = Boolean(loadout);
 
   // The loadout to edit comes in from the editLoadout$ observable
   useEventBusListener(

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -36,11 +36,8 @@ import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import LoadoutDrawerFooter from './LoadoutDrawerFooter';
 import LoadoutDrawerHeader from './LoadoutDrawerHeader';
 
-// TODO: Consider moving editLoadout/addItemToLoadout/loadoutDialogOpen into Redux (actions + state)
+// TODO: Consider moving editLoadout/addItemToLoadout into Redux (actions + state)
 // TODO: break out a container from the actual loadout drawer so we can lazy load the drawer
-
-/** Is the loadout drawer currently open? */
-export let loadoutDialogOpen = false;
 
 /**
  * The Loadout editor that shows up as a sheet on the Inventory screen. You can build and edit
@@ -64,10 +61,6 @@ export default function LoadoutDrawer2() {
     },
     showFashionDrawer: false,
   });
-
-  // TODO: move to a container?
-  // Sync this global variable with our actual state. TODO: move to redux
-  loadoutDialogOpen = Boolean(loadout);
 
   // The loadout to edit comes in from the editLoadout$ observable
   useEventBusListener(


### PR DESCRIPTION
This makes double-clicking an item in inventory always equip it, instead of not equipping if the loadout drawer or compare is open. Seems like that's reasonable?