### PR TITLE
Make +Loadout work when the loadout drawer isn't open

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -625,6 +625,8 @@
     "CannotCustomizeSubclass": "Light subclasses cannot be configured",
     "ChooseItem": "Add {{name}}",
     "Classified": "Some of your items are classified, and cannot be included in the max power calculation.",
+    "ClassTypeMismatch": "A {{className}} item cannot be added to this loadout",
+    "ClassTypeMissing": "You do not have a {{className}} to create a loadout for",
     "ClearSection": "Remove all",
     "ClearLoadoutParameters": "Remove Loadout Optimizer settings",
     "ClearSpace": "Move other items away",

--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -17,7 +17,7 @@ import { v4 as uuidv4 } from 'uuid';
 import Sheet from '../dim-ui/Sheet';
 import InventoryItem from '../inventory/InventoryItem';
 import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
-import { allItemsSelector, bucketsSelector } from '../inventory/selectors';
+import { allItemsSelector, bucketsSelector, storesSelector } from '../inventory/selectors';
 import '../inventory/Stores.scss';
 import { showItemPicker } from '../item-picker/item-picker';
 import { deleteLoadout, updateLoadout } from './actions';
@@ -47,6 +47,7 @@ export default function LoadoutDrawer() {
   const defs = useDefinitions()!;
 
   const allItems = useSelector(allItemsSelector);
+  const stores = useSelector(storesSelector);
   const buckets = useSelector(bucketsSelector)!;
   const [showingItemPicker, setShowingItemPicker] = useState(false);
 
@@ -105,8 +106,9 @@ export default function LoadoutDrawer() {
         items,
         equip,
         socketOverrides,
+        stores,
       }),
-    [items]
+    [items, stores]
   );
 
   const onApplySocketOverrides = useCallback((item: DimItem, socketOverrides: SocketOverrides) => {

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -17,11 +17,9 @@ import { v4 as uuidv4 } from 'uuid';
 import Sheet from '../dim-ui/Sheet';
 import { DimItem } from '../inventory/item-types';
 import { allItemsSelector, bucketsSelector, storesSelector } from '../inventory/selectors';
-import '../inventory/Stores.scss';
 import LoadoutEdit from '../loadout/loadout-edit/LoadoutEdit';
 import { deleteLoadout, updateLoadout } from './actions';
 import { stateReducer } from './loadout-drawer-reducer';
-import './loadout-drawer.scss';
 import { addItem$, editLoadout$ } from './loadout-events';
 import { getItemsFromLoadoutItems } from './loadout-item-conversion';
 import { Loadout } from './loadout-types';
@@ -98,8 +96,15 @@ export default function LoadoutDrawer2() {
 
   const onAddItem = useCallback(
     (item: DimItem, e?: MouseEvent | React.MouseEvent, equip?: boolean) =>
-      stateDispatch({ type: 'addItem', item, shift: Boolean(e?.shiftKey), items, equip }),
-    [items]
+      stateDispatch({
+        type: 'addItem',
+        item,
+        shift: Boolean(e?.shiftKey),
+        items,
+        equip,
+        stores,
+      }),
+    [items, stores]
   );
 
   /**
@@ -283,7 +288,7 @@ export default function LoadoutDrawer2() {
         <div className={styles.inputGroup}>
           <button
             type="button"
-            className="dim-button loadout-add"
+            className="dim-button"
             onClick={() =>
               fillLoadoutFromEquipped(loadout, itemsByBucket, store, handleUpdateLoadout)
             }
@@ -292,7 +297,7 @@ export default function LoadoutDrawer2() {
           </button>
           <button
             type="button"
-            className="dim-button loadout-add"
+            className="dim-button"
             onClick={() =>
               fillLoadoutFromUnequipped(loadout, store, ({ item }) =>
                 onAddItem(item, undefined, false)

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -1,7 +1,7 @@
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
+import { allItemsSelector, bucketsSelector, storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { Action } from 'app/loadout-drawer/loadout-drawer-reducer';
@@ -54,6 +54,7 @@ export default function LoadoutEdit({
   onRemoveItem: (item: DimItem) => void;
 }) {
   const defs = useD2Definitions()!;
+  const stores = useSelector(storesSelector);
   const buckets = useSelector(bucketsSelector)!;
   const allItems = useSelector(allItemsSelector);
   const [plugDrawerOpen, setPlugDrawerOpen] = useState(false);
@@ -110,8 +111,8 @@ export default function LoadoutEdit({
 
   const onAddItem = useCallback(
     ({ item, equip }: { item: DimItem; equip?: boolean }) =>
-      stateDispatch({ type: 'addItem', item, shift: false, items, equip }),
-    [items, stateDispatch]
+      stateDispatch({ type: 'addItem', item, stores, shift: false, items, equip }),
+    [items, stores, stateDispatch]
   );
 
   const handleSyncModsFromEquipped = () => {

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -544,6 +544,8 @@
     "Before": "Before '{{name}}'",
     "CannotCustomizeSubclass": "Light subclasses cannot be configured",
     "ChooseItem": "Add {{name}}",
+    "ClassTypeMismatch": "A {{className}} item cannot be added to this loadout",
+    "ClassTypeMissing": "You do not have a {{className}} to create a loadout for",
     "Classified": "Some of your items are classified, and cannot be included in the max power calculation.",
     "ClearLoadoutParameters": "Remove Loadout Optimizer settings",
     "ClearSection": "Remove all",


### PR DESCRIPTION
It'll pick the class and store based on the character the item is on, or if the item is in the vault, a character of the same class or the current character if it's not a class-specific item.