### PR TITLE
initial craftables setup for presentation nodes

### DIFF
--- a/src/app/item-popup/item-popup.ts
+++ b/src/app/item-popup/item-popup.ts
@@ -17,6 +17,9 @@ export interface ItemPopupExtraInfo {
   owned?: boolean;
   acquired?: boolean;
   mod?: boolean;
+  // markers for craftable items
+  allPlugsReqsAreMet?: boolean;
+  craftingReqsAreMet?: boolean;
 }
 
 export function showItemPopup(

--- a/src/app/records/Craftable.tsx
+++ b/src/app/records/Craftable.tsx
@@ -1,0 +1,19 @@
+import { VendorItemDisplay } from 'app/vendors/VendorItemComponent';
+import React from 'react';
+import { DimCraftable } from './presentation-nodes';
+
+interface Props {
+  craftable: DimCraftable;
+}
+
+export default function Craftable({ craftable }: Props) {
+  const { item, allPlugsReqsAreMet, craftingReqsAreMet } = craftable;
+
+  return (
+    <VendorItemDisplay
+      item={item}
+      unavailable={!allPlugsReqsAreMet}
+      extraData={{ allPlugsReqsAreMet, craftingReqsAreMet }}
+    />
+  );
+}

--- a/src/app/records/PresentationNodeLeaf.tsx
+++ b/src/app/records/PresentationNodeLeaf.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Collectible from './Collectible';
+import Craftable from './Craftable';
 import Metrics from './Metrics';
 import { DimPresentationNodeLeaf } from './presentation-nodes';
 import Record from './Record';
@@ -33,6 +34,7 @@ export default function PresentationNodeLeaf({
           ))}
         </div>
       )}
+
       {node.records && node.records.length > 0 && (
         <div className="records">
           {node.records.map((record) => {
@@ -51,7 +53,16 @@ export default function PresentationNodeLeaf({
           })}
         </div>
       )}
+
       {node.metrics && node.metrics.length > 0 && <Metrics metrics={node.metrics} />}
+
+      {node.craftables && node.craftables.length > 0 && (
+        <div className="collectibles">
+          {node.craftables.map((craftable) => (
+            <Craftable key={craftable.item.hash} craftable={craftable} />
+          ))}
+        </div>
+      )}
     </>
   );
 }

--- a/src/app/records/PresentationNodeSearchResults.tsx
+++ b/src/app/records/PresentationNodeSearchResults.tsx
@@ -34,6 +34,7 @@ export default function PresentationNodeSearchResults({
             {!sr.collectibles &&
               !sr.records &&
               !sr.metrics &&
+              !sr.craftables &&
               (() => {
                 const node = sr.path[sr.path.length - 1];
                 return node.childPresentationNodes ? (

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -82,6 +82,7 @@ export function VendorItemDisplay({
   extraData,
   children,
 }: {
+  /** i.e. greyed out */
   unavailable?: boolean;
   owned?: boolean;
   acquired?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,9 +3206,9 @@ builtin-modules@^3.1.0:
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
 bungie-api-ts@^4.12.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-4.14.0.tgz#b592d78fee7f733ac70f7278dcffff9e0d0b5d84"
-  integrity sha512-Js5bts7XUW5/CSi7hnUBI0Y2m4v20J5oYgxXcIedpSRAOBxBTGgT5W+XsPHrTNIlYtwX56C1nHPs6+s3f+Ka4w==
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-4.15.0.tgz#50e4f70bf503b75b2554768cf2438ab185751b69"
+  integrity sha512-QMFCr4Smfit5Do4FZ+Cl5QsvS0CVbSJJ5vLBB0CtkiY+zSTnzkAzeUMmNEVBmF5uBcGGcTxWja/434huMMBVNA==
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
sets up craftables just like other children nodes. there's not a ton to say about this, it's similar boilerplate.

the node tree terminates in fake items, similar to collections for now, and threads through the "met requirements" metadata into the vendoritem. we may need an armory-like sheet, or an item popup variation, to properly express what plugsets are earned or whatever.

as far as i can tell from typings, the only thing the new profile component tells us is whether "requirements are met", at both the item and plugset levels.
we need to know a little more about the game to know if these are useful indicators. this might just mean currency or might mean earnedness.

this starts to address #7916 but that should be converted to a followup checklist once we have a little experience with item crafting