### PR TITLE
use JS to take and lock confirmbutton measurements

### DIFF
--- a/src/app/dim-ui/ConfirmButton.m.scss
+++ b/src/app/dim-ui/ConfirmButton.m.scss
@@ -1,46 +1,42 @@
 .confirmButton {
-  white-space: nowrap;
   overflow: hidden;
   max-width: 100%;
 
+  // keep flexed things from trying to extend past the edges
   & div,
   & span {
-    text-overflow: ellipsis;
     max-width: 100%;
     overflow: hidden;
   }
 
+  // applies to both the children container and the "confirm" message container
   & > div {
+    // while transitioning out of confirm mode, linger the message, then sweep it away slowly
     transition: height 0.5s ease-in 0.5s;
     overflow: hidden;
+  }
 
-    &:nth-child(1) {
-      height: 16px;
-    }
-    &:nth-child(2) {
-      height: 0px;
-    }
+  // applies to just the "confirm" message container
+  & > div:nth-child(2) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   &.confirmMode {
-    color: white !important;
-    &[class~='danger'] {
-      &:hover {
-        background-color: #aa2222 !important;
-      }
+    // as elements transition into confirm mode, snap confirm message into place quickly
+    & > div {
+      transition: height 0.1s;
     }
+    color: white !important;
 
     &:hover {
       background-color: #af7d27 !important;
     }
 
-    & > div {
-      transition: height 0.1s;
-      &:nth-child(1) {
-        height: 0px;
-      }
-      &:nth-child(2) {
-        height: 16px;
+    &[class~='danger'] {
+      &:hover {
+        background-color: #aa2222 !important;
       }
     }
   }

--- a/src/app/dim-ui/ConfirmButton.tsx
+++ b/src/app/dim-ui/ConfirmButton.tsx
@@ -1,6 +1,6 @@
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './ConfirmButton.m.scss';
 
 /**
@@ -26,7 +26,18 @@ export function ConfirmButton({
   // controls whether the button is ready to submit the requested function
   // (available 100ms after "ask for confirmation" state)
   const [confirmReady, setConfirmReady] = useState(false);
-  const childrenContent = React.useRef<HTMLDivElement>(null);
+
+  const [contentHeight, setContentHeight] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  const containerRef = React.useRef<HTMLButtonElement>(null);
+  const childrenRef = React.useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setContentHeight(childrenRef.current?.offsetHeight || 0);
+    setContainerHeight(containerRef.current?.offsetHeight || 0);
+  }, []);
+
   const onClickAction =
     confirmMode && confirmReady
       ? () => {
@@ -45,19 +56,22 @@ export function ConfirmButton({
     <button
       key="save"
       type="button"
-      title={childrenContent.current?.innerText}
       className={clsx('dim-button', className, styles.confirmButton, {
         [styles.confirmMode]: confirmMode,
         danger,
       })}
+      ref={containerRef}
       onClick={onClickAction}
       onMouseLeave={() => {
         setConfirmMode(false);
         setConfirmReady(false);
       }}
+      style={{ height: containerHeight || 'auto' }}
     >
-      <div ref={childrenContent}>{children}</div>
-      <div>{t('General.Confirm')}</div>
+      <div style={{ height: confirmMode ? 0 : contentHeight || 'auto' }} ref={childrenRef}>
+        {children}
+      </div>
+      <div style={{ height: confirmMode ? contentHeight : 0 }}>{t('General.Confirm')}</div>
     </button>
   );
 }


### PR DESCRIPTION
this allows multi-line/arbitrary content inside confirm button. it takes initial measurements of the button then locks those while it switches between content/confirm

please try this out in fr/ru and see if multi-line postmaster button looks right? thanks