### PR TITLE
Add legendary itemCategory button to weapons compare sheet

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * You can now change the Aeon sect mod through the item popup.
 * You can now edit your equipped Emotes from DIM. You can't add them to loadouts... yet.
 * There's a good chance craftable items will display correctly in DIM. No promises though.
+* Weapon compare sheet now includes a button to compare with other legendary weapons of the same category, excluding exotics.
 
 ## 7.5.1 <span class="changelog-date">(2022-02-14)</span>
 

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -156,6 +156,16 @@ export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
       query: '', // since we already filter by itemCategoryHash, an empty query gives you all items matching that category
     },
 
+    // above but also has to be legendary
+    exampleItem.destinyVersion === 2 &&
+      exampleItem.tier === 'Legendary' && {
+        buttonLabel: [
+          <BungieImage key="rarity" src={rarityIcons.Legendary} />,
+          <WeaponTypeIcon key="type" item={exampleItem} className={styles.svgIcon} />,
+        ],
+        query: 'is:legendary',
+      },
+
     // above, but also matching intrinsic (rpm+impact..... ish)
     {
       buttonLabel: [


### PR DESCRIPTION
This was asked for on the Discord and I personally would have found it quite useful when clearing my vault for WQ. Essentially mirrors the armor button.