### PR TITLE
fix collections armor stats

### DIFF
--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -236,17 +236,20 @@ function buildDefinedSocket(
         const plugs: {
           [plugItemHash: number]: DestinyItemSocketEntryPlugItemRandomizedDefinition;
         } = {};
-        for (const reusablePlug of plugSet.reusablePlugItems) {
-          const existing = plugs[reusablePlug.plugItemHash];
-          if (!existing || (!existing.currentlyCanRoll && reusablePlug.currentlyCanRoll)) {
-            plugs[reusablePlug.plugItemHash] = reusablePlug;
+        for (const randomPlug of plugSet.reusablePlugItems) {
+          const existing = plugs[randomPlug.plugItemHash];
+          if (!existing || (!existing.currentlyCanRoll && randomPlug.currentlyCanRoll)) {
+            plugs[randomPlug.plugItemHash] = randomPlug;
           }
         }
 
-        for (const reusablePlug of Object.values(plugs)) {
-          const built = buildCachedDefinedPlug(defs, reusablePlug.plugItemHash);
-          if (built) {
-            reusablePlugs.push({ ...built, cannotCurrentlyRoll: !reusablePlug.currentlyCanRoll });
+        for (const randomPlug of Object.values(plugs)) {
+          const built = buildCachedDefinedPlug(defs, randomPlug.plugItemHash);
+          // we don't want "stat roll" plugs to count as reusablePlugs, but they're almost
+          // indistinguishable from exotic intrinsic armor perks, so we stop them here based
+          // on the fact that they have no name
+          if (built?.plugDef.displayProperties.name) {
+            reusablePlugs.push({ ...built, cannotCurrentlyRoll: !randomPlug.currentlyCanRoll });
           }
         }
       }


### PR DESCRIPTION
this stops random-roll stat sockets from counting all their possible rolled plugs as "reusable".
this in turn causes them to correctly plug in their default when built from definitions.
this in turn causes randomly rolled collections armor to have non-zero stats.

also corrected a confusing variable name