### PR TITLE
Fix floating season tag, remove max height

### DIFF
--- a/src/app/loadout-builder/filter/ExoticArmorChoice.m.scss
+++ b/src/app/loadout-builder/filter/ExoticArmorChoice.m.scss
@@ -2,6 +2,7 @@
   composes: flexRow from '../../dim-ui/common.m.scss';
   align-items: center;
   width: 100%;
+  position: relative;
 
   span {
     margin-left: 8px;


### PR DESCRIPTION
Removing the max height because people seem to dislike scrolling more than they like dragging items?