### PR TITLE
Add crafted item level to item popup, `is:crafted` filter

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -806,7 +806,7 @@
     },
     "TriageTab": "Triage",
     "Vault": "Vault",
-    "WeaponLevel": "Weapon Lv."
+    "WeaponLevel": "Weapon Level {{level}}"
   },
   "Notes": {
     "Error": "Error! Max 120 characters for notes.",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -217,6 +217,7 @@
     "HasOrnament": "Shows items that have an ornament applied.",
     "InLoadout": "Shows items that are included in any loadout.",
     "Infusable": "Shows items that can be infused.",
+    "IsCrafted": "Shows weapons that have been crafted.",
     "IsSunset": "Shows items that have been sunset and can no longer be infused to max power.",
     "ItemId": "Shows the item with the given inventory item ID. For advanced users.",
     "ItemHash": "Shows the items with the given inventory item hash. For advanced users.",
@@ -804,7 +805,8 @@
       "Untracked": "Untracked"
     },
     "TriageTab": "Triage",
-    "Vault": "Vault"
+    "Vault": "Vault",
+    "WeaponLevel": "Weapon Lv."
   },
   "Notes": {
     "Error": "Error! Max 120 characters for notes.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
 * Increased the strings we search through when filtering by mods/perks.
+* Crafted weapons' levels and level progress are now shown on the item popup.
+* Added an `is:crafted` filter.
 
 ## 7.6.0 <span class="changelog-date">(2022-02-21)</span>
 

--- a/src/app/dim-ui/WeaponCraftedInfo.tsx
+++ b/src/app/dim-ui/WeaponCraftedInfo.tsx
@@ -1,0 +1,32 @@
+import { t } from 'app/i18next-t';
+import { DimCrafted } from 'app/inventory/item-types';
+import { percent } from 'app/shell/filters';
+import React from 'react';
+
+/**
+ * A progress bar that shows weapon crafting info like the game does.
+ */
+export function WeaponCraftedInfo({
+  craftInfo,
+  className,
+}: {
+  craftInfo: DimCrafted;
+  className: string;
+}) {
+  const pct = percent(craftInfo.progress || 0);
+  const progressBarStyle = {
+    width: pct,
+  };
+
+  return (
+    <div className={className}>
+      <div className="objective-progress">
+        <div className="objective-progress-bar" style={progressBarStyle} />
+        <div className="objective-description">
+          {t('MovePopup.WeaponLevel')} {craftInfo.level}
+        </div>
+        <div className="objective-text">{pct}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dim-ui/WeaponCraftedInfo.tsx
+++ b/src/app/dim-ui/WeaponCraftedInfo.tsx
@@ -23,7 +23,7 @@ export function WeaponCraftedInfo({
       <div className="objective-progress">
         <div className="objective-progress-bar" style={progressBarStyle} />
         <div className="objective-description">
-          {t('MovePopup.WeaponLevel')} {craftInfo.level}
+          {t('MovePopup.WeaponLevel', { level: craftInfo.level })}
         </div>
         <div className="objective-text">{pct}</div>
       </div>

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -199,6 +199,8 @@ export interface DimItem {
   energy: DestinyItemInstanceEnergy | null;
   /** If this item is a masterwork, this will include information about its masterwork properties. */
   masterworkInfo: DimMasterwork | null;
+  /** If this item is crafted, this includes info about its crafting properties. */
+  craftedInfo: DimCrafted | null;
   /** an item's current breaker type, if it has one */
   breakerType: DestinyBreakerTypeDefinition | null;
   /** The state of this item in the user's D2 Collection */
@@ -237,6 +239,15 @@ export interface DimMasterwork {
     /** How much the stat is enhanced by this masterwork. */
     value?: number;
   }[];
+}
+
+export interface DimCrafted {
+  /** The level of this crafted weapon */
+  level?: number;
+  /** 0-1 progress to the next level */
+  progress?: number;
+  /** when this weapon was crafted, unix epoch timestamp */
+  dateCrafted?: number;
 }
 
 export interface DimStat {

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -246,7 +246,7 @@ export interface DimCrafted {
   level?: number;
   /** 0-1 progress to the next level */
   progress?: number;
-  /** when this weapon was crafted, unix epoch timestamp */
+  /** when this weapon was crafted, UTC epoch milliseconds timestamp */
   dateCrafted?: number;
 }
 

--- a/src/app/inventory/store/crafted.ts
+++ b/src/app/inventory/store/crafted.ts
@@ -43,7 +43,7 @@ function getCraftingInfo(defs: D2ManifestDefinitions, objectives: DestinyObjecti
             ? objective.progress / objective.completionValue
             : undefined;
       } else if (def.uiStyle === DestinyObjectiveUiStyle.CraftingWeaponTimestamp) {
-        dateCrafted = objective.progress;
+        dateCrafted = objective.progress ? objective.progress * 1000 : undefined;
       }
     }
   }

--- a/src/app/inventory/store/crafted.ts
+++ b/src/app/inventory/store/crafted.ts
@@ -1,0 +1,52 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { getFirstSocketByCategoryHash } from 'app/utils/socket-utils';
+import { DestinyObjectiveProgress, DestinyObjectiveUiStyle } from 'bungie-api-ts/destiny2';
+import { DimCrafted, DimItem, DimSocket } from '../item-types';
+
+/** the socket category containing the single socket with weapon crafting objectives */
+export const craftedSocketCategoryHash = 3583996951;
+
+export function buildCraftedInfo(item: DimItem, defs: D2ManifestDefinitions): DimCrafted | null {
+  const craftedSocket = getCraftedSocket(item);
+  if (!craftedSocket) {
+    return null;
+  }
+
+  const objectives = craftedSocket.plugged?.plugObjectives;
+  if (!objectives) {
+    return null;
+  }
+
+  return getCraftingInfo(defs, objectives);
+}
+
+/** find the item socket that could contain the "this weapon was crafted" plug with its objectives */
+function getCraftedSocket(item: DimItem): DimSocket | undefined {
+  if (item.bucket.inWeapons && item.sockets) {
+    return getFirstSocketByCategoryHash(item.sockets, craftedSocketCategoryHash);
+  }
+}
+
+function getCraftingInfo(defs: D2ManifestDefinitions, objectives: DestinyObjectiveProgress[]) {
+  let level;
+  let progress;
+  let dateCrafted;
+
+  for (const objective of objectives) {
+    const def = defs.Objective.get(objective.objectiveHash);
+    if (def) {
+      if (def.uiStyle === DestinyObjectiveUiStyle.CraftingWeaponLevel) {
+        level = objective.progress;
+      } else if (def.uiStyle === DestinyObjectiveUiStyle.CraftingWeaponLevelProgress) {
+        progress =
+          objective.progress !== undefined && objective.completionValue > 0
+            ? objective.progress / objective.completionValue
+            : undefined;
+      } else if (def.uiStyle === DestinyObjectiveUiStyle.CraftingWeaponTimestamp) {
+        dateCrafted = objective.progress;
+      }
+    }
+  }
+
+  return { level, progress, dateCrafted };
+}

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -320,6 +320,7 @@ function makeItem(
     infusionFuel: false,
     perks: null,
     masterworkInfo: null,
+    craftedInfo: null,
     infusionQuality: null,
     canPullFromPostmaster: false,
     uniqueStack: false,

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -35,6 +35,7 @@ import { InventoryBuckets } from '../inventory-buckets';
 import { DimItem, DimPerk } from '../item-types';
 import { DimStore } from '../store-types';
 import { getVault } from '../stores-helpers';
+import { buildCraftedInfo } from './crafted';
 import { createItemIndex } from './item-index';
 import { buildMasterwork } from './masterwork';
 import { buildObjectives } from './objectives';
@@ -475,6 +476,7 @@ export function makeItem(
     sockets: null,
     perks: null,
     masterworkInfo: null,
+    craftedInfo: null,
     infusionQuality: null,
     tooltipNotifications,
   };
@@ -640,6 +642,9 @@ export function makeItem(
     );
     reportException('MasterworkInfo', e, { itemHash: item.itemHash });
   }
+
+  // Crafted
+  createdItem.craftedInfo = buildCraftedInfo(createdItem, defs);
 
   try {
     buildPursuitInfo(createdItem, item, itemDef);

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -1,5 +1,6 @@
 import { DestinyTooltipText } from 'app/dim-ui/DestinyTooltipText';
 import { KillTrackerInfo } from 'app/dim-ui/KillTracker';
+import { WeaponCraftedInfo } from 'app/dim-ui/WeaponCraftedInfo';
 import { t } from 'app/i18next-t';
 import { storesSelector } from 'app/inventory/selectors';
 import { isTrialsPassage } from 'app/inventory/store/objectives';
@@ -52,6 +53,7 @@ export default function ItemDetails({
   const ownerStore = useSelector((state: RootState) => getStore(storesSelector(state), item.owner));
 
   const killTrackerInfo = getItemKillTrackerInfo(item);
+
   return (
     <div className="item-details-body">
       {item.itemCategoryHashes.includes(ItemCategoryHashes.Shaders) && (
@@ -82,6 +84,10 @@ export default function ItemDetails({
             availableMetricCategoryNodeHashes={item.availableMetricCategoryNodeHashes}
           />
         </div>
+      )}
+
+      {item.crafted && item.craftedInfo && defs.isDestiny2() && (
+        <WeaponCraftedInfo craftInfo={item.craftedInfo} className="crafted-progess" />
       )}
 
       {killTrackerInfo && defs.isDestiny2() && (

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -82,6 +82,19 @@
   }
 }
 
+.crafted-progess {
+  padding: 4px 10px 4px;
+  background: #333;
+
+  .objective-progress {
+    background: #222;
+  }
+
+  .objective-progress-bar {
+    background-color: $crafted-border-color;
+  }
+}
+
 .item-perks {
   margin: 5px 10px;
 }

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -1,4 +1,5 @@
 import { t } from 'app/i18next-t';
+import { craftedSocketCategoryHash } from 'app/inventory/store/crafted';
 import { statsMs } from 'app/inventory/store/stats';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useSetting } from 'app/settings/hooks';
@@ -65,11 +66,18 @@ export default function ItemSocketsWeapons({ item, minimal, grid, onPlugClicked 
   );
   // Iterate in reverse category order so cosmetic mods are at the front
   const mods = [...item.sockets.categories]
+    .filter((c) => c.category.hash !== craftedSocketCategoryHash)
     .reverse()
     .flatMap((c) =>
       getSocketsByIndexes(item.sockets!, c.socketIndexes).filter(
         (s) => !s.isPerk && s !== archetypeSocket
       )
+    )
+    .filter(
+      (socket) =>
+        // Hack: dummy deepsight plugs with no name can be ignored
+        socket.plugged?.plugDef.displayProperties.name ||
+        socket.socketDefinition.socketTypeHash !== 1085237186
     );
 
   const keyStats =

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -283,6 +283,7 @@ function makeFakePursuitItem(
     sockets: null,
     perks: null,
     masterworkInfo: null,
+    craftedInfo: null,
     infusionQuality: null,
     owner: store.id,
     uniqueStack: false,

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -15,6 +15,7 @@ Array [
   "common",
   "consumables",
   "cosmetic",
+  "crafted",
   "curated",
   "currentclass",
   "customstatlower",

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -88,6 +88,7 @@ Array [
   "seasonalartifacts",
   "seasonaldupe",
   "shaded",
+  "shaped",
   "ships",
   "shotgun",
   "sidearm",

--- a/src/app/search/search-filters/simple.tsx
+++ b/src/app/search/search-filters/simple.tsx
@@ -84,7 +84,7 @@ const simpleFilters: FilterDefinition[] = [
     filter: () => isSunset,
   },
   {
-    keywords: 'crafted',
+    keywords: ['crafted', 'shaped'],
     description: tl('Filter.IsCrafted'),
     filter: () => (item) => item.crafted,
   },

--- a/src/app/search/search-filters/simple.tsx
+++ b/src/app/search/search-filters/simple.tsx
@@ -83,6 +83,11 @@ const simpleFilters: FilterDefinition[] = [
     description: tl('Filter.IsSunset'),
     filter: () => isSunset,
   },
+  {
+    keywords: 'crafted',
+    description: tl('Filter.IsCrafted'),
+    filter: () => (item) => item.crafted,
+  },
 ];
 
 export default simpleFilters;

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -714,7 +714,7 @@
     },
     "TriageTab": "Triage",
     "Vault": "Vault",
-    "WeaponLevel": "Weapon Lv."
+    "WeaponLevel": "Weapon Level {{level}}"
   },
   "Notes": {
     "Error": "Error! Max 120 characters for notes.",

--- a/src/locale/dim.json
+++ b/src/locale/dim.json
@@ -213,6 +213,7 @@
     "InLoadout": "Shows items that are included in any loadout.",
     "Infusable": "Shows items that can be infused.",
     "InfusionFodder": "Shows items that could be infused into lower-power versions of the same item for only glimmer.",
+    "IsCrafted": "Shows weapons that have been crafted.",
     "IsSunset": "Shows items that have been sunset and can no longer be infused to max power.",
     "ItemHash": "Shows the items with the given inventory item hash. For advanced users.",
     "ItemId": "Shows the item with the given inventory item ID. For advanced users.",
@@ -712,7 +713,8 @@
       "Untracked": "Untracked"
     },
     "TriageTab": "Triage",
-    "Vault": "Vault"
+    "Vault": "Vault",
+    "WeaponLevel": "Weapon Lv."
   },
   "Notes": {
     "Error": "Error! Max 120 characters for notes.",


### PR DESCRIPTION
In game: 
![grafik](https://user-images.githubusercontent.com/14299449/155411455-120403aa-1c15-4182-9d07-017d068629d2.png)

DIM: 
![grafik](https://user-images.githubusercontent.com/14299449/155411407-cb1945bc-ebe6-4372-9aaf-41052e871ada.png)

Also gets rid of the deepsight sockets without a meaningful plug in the item popup; they're not empty for some reason even if the gun doesn't have a deepsight objective.