### PR TITLE
fix craftables node generation

### DIFF
--- a/src/app/item-popup/item-popup.ts
+++ b/src/app/item-popup/item-popup.ts
@@ -19,8 +19,10 @@ export interface ItemPopupExtraInfo {
   acquired?: boolean;
   mod?: boolean;
   socketOverrides?: SocketOverrides;
-  allPlugsReqsAreMet?: boolean;
-  craftingReqsAreMet?: boolean;
+  // whether you can make this item at all
+  canCraftThis?: boolean;
+  // if you completely leveled up the item, it can be crafted with any of its perks. impressive.
+  canCraftAllPlugs?: boolean;
 }
 
 export function showItemPopup(

--- a/src/app/records/Craftable.tsx
+++ b/src/app/records/Craftable.tsx
@@ -7,13 +7,13 @@ interface Props {
 }
 
 export default function Craftable({ craftable }: Props) {
-  const { item, allPlugsReqsAreMet, craftingReqsAreMet } = craftable;
+  const { item, canCraftAllPlugs, canCraftThis } = craftable;
 
   return (
     <VendorItemDisplay
       item={item}
-      unavailable={!allPlugsReqsAreMet}
-      extraData={{ allPlugsReqsAreMet, craftingReqsAreMet }}
+      unavailable={!canCraftThis}
+      extraData={{ canCraftAllPlugs, canCraftThis }}
     />
   );
 }

--- a/src/app/records/PresentationNodeRoot.tsx
+++ b/src/app/records/PresentationNodeRoot.tsx
@@ -61,6 +61,7 @@ export default function PresentationNodeRoot({
     () => toPresentationNodeTree(defs, buckets, profileResponse, presentationNodeHash),
     [defs, buckets, profileResponse, presentationNodeHash]
   );
+  // console.log(nodeTree);
 
   if (!nodeTree) {
     return null;

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -147,6 +147,7 @@ export default function Records({ account }: Props) {
         {nodeHashes
           .map((h) => defs.PresentationNode.get(h))
           .map((nodeDef) => (
+            // console.log(nodeDef)
             <section key={nodeDef.hash} id={`p_${nodeDef.hash}`}>
               <CollapsibleTitle
                 title={overrideTitles[nodeDef.hash] || nodeDef.displayProperties.name}

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -7,6 +7,7 @@ import { count } from 'app/utils/util';
 import {
   DestinyCollectibleDefinition,
   DestinyCollectibleState,
+  DestinyCraftableComponent,
   DestinyDisplayPropertiesDefinition,
   DestinyMetricComponent,
   DestinyMetricDefinition,
@@ -57,8 +58,8 @@ export interface DimCollectible {
 export interface DimCraftable {
   // to-do: determine what interesting information we can share about a craftable
   item: DimItem;
-  craftingReqsAreMet: boolean;
-  allPlugsReqsAreMet: boolean;
+  canCraftThis: boolean;
+  canCraftAllPlugs: boolean;
 }
 
 export interface DimPresentationNodeSearchResult extends DimPresentationNodeLeaf {
@@ -117,15 +118,14 @@ export function toPresentationNodeTree(
     );
     const visible = craftables.length;
 
-    const acquired = count(craftables, (c) =>
-      Boolean(c.allPlugsReqsAreMet && c.craftingReqsAreMet)
-    );
+    const acquired = count(craftables, (c) => c.canCraftThis);
 
     // add an entry for self and return
     return {
       nodeDef: presentationNodeDef,
       visible,
       acquired,
+      craftables,
     };
   } else if (presentationNodeDef.children.metrics?.length) {
     const metrics = toMetrics(defs, profileResponse, presentationNodeDef.children.metrics);
@@ -373,12 +373,12 @@ export function toCraftable(
     return;
   }
 
-  const craftingReqsAreMet = info.failedRequirementIndexes.length === 0;
-  const allPlugsReqsAreMet = info.sockets.every((s) =>
+  const canCraftThis = info.failedRequirementIndexes.length === 0;
+  const canCraftAllPlugs = info.sockets.every((s) =>
     s.plugs.every((p) => p.failedRequirementIndexes.length === 0)
   );
 
-  return { item, craftingReqsAreMet, allPlugsReqsAreMet };
+  return { item, canCraftThis, canCraftAllPlugs };
 }
 
 function toMetrics(
@@ -421,9 +421,12 @@ function getCraftableInfo(itemHash: number, profileResponse: DestinyProfileRespo
   if (!profileResponse.characterCraftables?.data) {
     return;
   }
-  const id = Object.keys(profileResponse.characterCraftables.data)[0];
+  const allCharCraftables: (DestinyCraftableComponent | undefined)[] = Object.values(
+    profileResponse.characterCraftables.data
+  ).map((d) => d.craftables[itemHash]);
 
-  return profileResponse.characterCraftables.data[id].craftables[itemHash];
+  // try to find a character on whom this item is visible
+  return allCharCraftables.find((c) => c?.visible === true) ?? allCharCraftables[0];
 }
 
 export function getCollectibleState(


### PR DESCRIPTION
this gets craftables root node to actually display information......

still threads through some info to VendorItem that is not used in its popup yet.

item popup for these craftable weapons is still a mess with too many perk sockets, but we need to, or at least can, code some custom version of the Armory view for them

![image](https://user-images.githubusercontent.com/68782081/155441923-d3b448f7-642c-4648-b94f-096ed5411d91.png)
