### PR TITLE
don't show draggy hand when something can't be dragged

### DIFF
--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -13,12 +13,7 @@ interface Props {
 let dragTimeout: number | null = null;
 
 export default function DraggableInventoryItem({ children, item }: Props) {
-  function canDrag() {
-    return (!item.location.inPostmaster || item.destinyVersion === 2) && item.notransfer
-      ? item.equipment
-      : item.equipment || item.bucket.hasTransferDestination;
-  }
-  const [_collected, dragRef] = useDrag<DimItem>(
+  const [{ canDrag }, dragRef] = useDrag<DimItem, unknown, { canDrag: boolean }>(
     () => ({
       type: item.location.inPostmaster
         ? 'postmaster'
@@ -42,14 +37,18 @@ export default function DraggableInventoryItem({ children, item }: Props) {
         document.body.classList.remove('drag-perf-show');
         isDragging$.next(false);
       },
-      canDrag,
+      canDrag: () =>
+        (!item.location.inPostmaster || item.destinyVersion === 2) && item.notransfer
+          ? item.equipment
+          : item.equipment || item.bucket.hasTransferDestination,
+      collect: (monitor) => ({ canDrag: monitor.canDrag() }),
     }),
     [item]
   );
   return (
     <div
       ref={dragRef}
-      className={clsx('item-drag-container', `item-type-${item.type}`, { 'cant-drag': !canDrag() })}
+      className={clsx('item-drag-container', `item-type-${item.type}`, { 'cant-drag': !canDrag })}
     >
       {children}
     </div>

--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -13,6 +13,11 @@ interface Props {
 let dragTimeout: number | null = null;
 
 export default function DraggableInventoryItem({ children, item }: Props) {
+  function canDrag() {
+    return (!item.location.inPostmaster || item.destinyVersion === 2) && item.notransfer
+      ? item.equipment
+      : item.equipment || item.bucket.hasTransferDestination;
+  }
   const [_collected, dragRef] = useDrag<DimItem>(
     () => ({
       type: item.location.inPostmaster
@@ -37,15 +42,15 @@ export default function DraggableInventoryItem({ children, item }: Props) {
         document.body.classList.remove('drag-perf-show');
         isDragging$.next(false);
       },
-      canDrag: () =>
-        (!item.location.inPostmaster || item.destinyVersion === 2) && item.notransfer
-          ? item.equipment
-          : item.equipment || item.bucket.hasTransferDestination,
+      canDrag,
     }),
     [item]
   );
   return (
-    <div ref={dragRef} className={clsx('item-drag-container', `item-type-${item.type}`)}>
+    <div
+      ref={dragRef}
+      className={clsx('item-drag-container', `item-type-${item.type}`, { 'cant-drag': !canDrag() })}
+    >
       {children}
     </div>
   );

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -20,9 +20,12 @@
 // The wrapper for draggable items. Global because it's referenced by other styles.
 :global(.item-drag-container) {
   contain: layout paint style;
-  cursor: grab;
   box-sizing: border-box;
   width: var(--item-size);
+  cursor: grab;
+  &:global(.cant-drag) {
+    cursor: pointer;
+  }
 
   &:hover {
     @include draggable-hover-border;


### PR DESCRIPTION
this is actually very nice hinting in practice. a nice quick check whether a consumable can be vaulted

fixes #7938 