### PR TITLE
Fix Use Equipped fashion not updating existing loadouts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Crafted weapons' levels and level progress are now shown on the item popup.
 * Added `is:crafted` and `is:deepsight` filters.
 * Crafting materials are now included in the currency counter. Tap and hold, or hover, the consumables count in the vault header to check them.
+* Fixed a bug where "Use Equipped" would not update fashion in existing loadout.
 
 ## 7.6.0 <span class="changelog-date">(2022-02-21)</span>
 

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -168,7 +168,10 @@ export default function FashionDrawer({
         const cosmeticSockets = item.sockets
           ? getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics)
           : [];
-        return [bucketHash, _.compact(cosmeticSockets.map((s) => s.plugged?.plugDef.hash))];
+        return [
+          bucketHash,
+          _.compact(cosmeticSockets.map((s) => (s.actuallyPlugged || s.plugged)?.plugDef.hash)),
+        ];
       })
     );
 


### PR DESCRIPTION
It's still weird that the fashion drawer won't show what "Use Equipped" fashion will actually do, but that's already the case when the loadout has no items.