### PR TITLE
Fix armor class icon vault separator sizing

### DIFF
--- a/src/app/inventory/StoreBucket.scss
+++ b/src/app/inventory/StoreBucket.scss
@@ -60,7 +60,7 @@
   }
 
   .armor-class-icon {
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     width: var(--item-size);
     height: calc((var(--item-size) + ((var(--item-size) / 5) + 4px) - 1px));
     font-size: calc(var(--item-size) * 0.71);


### PR DESCRIPTION
The FontAwesome upgrade in ddc6dac broke the sizing of the class icon vault separators because FontAwesome now sets `box-sizing` to `content-box` for all inline icons. This PR overrides that behaviour for the separators specifically.

![dim-fix-class-separator-sizing](https://user-images.githubusercontent.com/17512262/156172928-941a224f-1baa-4b90-8f40-f507445ae367.png)
