### PR TITLE
Add D1 types

### DIFF
--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -90,7 +90,7 @@ export function getBuckets(defs: D1ManifestDefinitions) {
       this.byType[this.unknown.type] = this.unknown;
     },
   };
-  _.forIn(defs.InventoryBucket, (def: any) => {
+  _.forIn(defs.InventoryBucket, (def) => {
     if (def.enabled) {
       const type = bucketToType[def.hash];
       let sort: D1BucketCategory | undefined;

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -4,19 +4,28 @@ import { HashLookupFailure, ManifestDefinitions } from '../destiny2/definitions'
 import { setD1Manifest } from '../manifest/actions';
 import { getManifest } from '../manifest/d1-manifest-service';
 import {
+  D1ActivityDefinition,
+  D1ActivityTypeDefinition,
   D1ClassDefinition,
   D1DamageTypeDefinition,
+  D1FactionDefinition,
+  D1InventoryBucketDefinition,
   D1InventoryItemDefinition,
+  D1ItemCategoryDefinition,
   D1ObjectiveDefinition,
   D1ProgressionDefinition,
+  D1RaceDefinition,
+  D1RecordBookDefinition,
+  D1RecordDefinition,
   D1StatDefinition,
   D1TalentGridDefinition,
+  D1VendorCategoryDefinition,
+  D1VendorDefinition,
 } from './d1-manifest-types';
 
 const lazyTables = [
   'InventoryItem',
   'Objective',
-  'SandboxPerk',
   'Stat',
   'TalentGrid',
   'Progression',
@@ -24,8 +33,6 @@ const lazyTables = [
   'ItemCategory',
   'VendorCategory',
   'RecordBook',
-  'ActivityCategory',
-  'ScriptedSkull',
   'Activity',
   'ActivityType',
   'DamageType',
@@ -41,25 +48,22 @@ export interface DefinitionTable<T> {
 export interface D1ManifestDefinitions extends ManifestDefinitions {
   InventoryItem: DefinitionTable<D1InventoryItemDefinition>;
   Objective: DefinitionTable<D1ObjectiveDefinition>;
-  SandboxPerk: DefinitionTable<any>;
   Stat: DefinitionTable<D1StatDefinition>;
   TalentGrid: DefinitionTable<D1TalentGridDefinition>;
   Progression: DefinitionTable<D1ProgressionDefinition>;
-  Record: DefinitionTable<any>;
-  ItemCategory: DefinitionTable<any>;
-  VendorCategory: DefinitionTable<any>;
-  RecordBook: DefinitionTable<any>;
-  ActivityCategory: DefinitionTable<any>;
-  ScriptedSkull: DefinitionTable<any>;
-  Activity: DefinitionTable<any>;
-  ActivityType: DefinitionTable<any>;
+  Record: DefinitionTable<D1RecordDefinition>;
+  ItemCategory: DefinitionTable<D1ItemCategoryDefinition>;
+  VendorCategory: DefinitionTable<D1VendorCategoryDefinition>;
+  RecordBook: DefinitionTable<D1RecordBookDefinition>;
+  Activity: DefinitionTable<D1ActivityDefinition>;
+  ActivityType: DefinitionTable<D1ActivityTypeDefinition>;
   DamageType: DefinitionTable<D1DamageTypeDefinition>;
 
-  InventoryBucket: { [hash: number]: any };
+  InventoryBucket: { [hash: number]: D1InventoryBucketDefinition };
   Class: { [hash: number]: D1ClassDefinition };
-  Race: { [hash: number]: any };
-  Faction: { [hash: number]: any };
-  Vendor: { [hash: number]: any };
+  Race: { [hash: number]: D1RaceDefinition };
+  Faction: { [hash: number]: D1FactionDefinition };
+  Vendor: { [hash: number]: D1VendorDefinition };
 }
 
 /**

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -3,6 +3,15 @@ import { reportException } from 'app/utils/exceptions';
 import { HashLookupFailure, ManifestDefinitions } from '../destiny2/definitions';
 import { setD1Manifest } from '../manifest/actions';
 import { getManifest } from '../manifest/d1-manifest-service';
+import {
+  D1ClassDefinition,
+  D1DamageTypeDefinition,
+  D1InventoryItemDefinition,
+  D1ObjectiveDefinition,
+  D1ProgressionDefinition,
+  D1StatDefinition,
+  D1TalentGridDefinition,
+} from './d1-manifest-types';
 
 const lazyTables = [
   'InventoryItem',
@@ -30,12 +39,12 @@ export interface DefinitionTable<T> {
 
 // D1 types don't exist yet
 export interface D1ManifestDefinitions extends ManifestDefinitions {
-  InventoryItem: DefinitionTable<any>;
-  Objective: DefinitionTable<any>;
+  InventoryItem: DefinitionTable<D1InventoryItemDefinition>;
+  Objective: DefinitionTable<D1ObjectiveDefinition>;
   SandboxPerk: DefinitionTable<any>;
-  Stat: DefinitionTable<any>;
-  TalentGrid: DefinitionTable<any>;
-  Progression: DefinitionTable<any>;
+  Stat: DefinitionTable<D1StatDefinition>;
+  TalentGrid: DefinitionTable<D1TalentGridDefinition>;
+  Progression: DefinitionTable<D1ProgressionDefinition>;
   Record: DefinitionTable<any>;
   ItemCategory: DefinitionTable<any>;
   VendorCategory: DefinitionTable<any>;
@@ -44,10 +53,10 @@ export interface D1ManifestDefinitions extends ManifestDefinitions {
   ScriptedSkull: DefinitionTable<any>;
   Activity: DefinitionTable<any>;
   ActivityType: DefinitionTable<any>;
-  DamageType: DefinitionTable<any>;
+  DamageType: DefinitionTable<D1DamageTypeDefinition>;
 
   InventoryBucket: { [hash: number]: any };
-  Class: { [hash: number]: any };
+  Class: { [hash: number]: D1ClassDefinition };
   Race: { [hash: number]: any };
   Faction: { [hash: number]: any };
   Vendor: { [hash: number]: any };

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -3,11 +3,12 @@ import {
   DamageType,
   DestinyClass,
   DestinyInventoryItemStatDefinition,
+  DestinyItemQuantity,
   DestinyItemSubType,
   DestinyItemType,
-  DestinyObjectiveProgress,
   DestinyProgressionScope,
   DestinyProgressionStepDefinition,
+  DestinyRace,
   DestinyStat,
   DestinyStatAggregationType,
   DestinyTalentNodeState,
@@ -31,7 +32,7 @@ export interface D1TalentNode {
 export interface D1Perk {
   iconPath: string;
   perkHash: number;
-  isActive: false;
+  isActive: boolean;
 }
 
 export interface D1ItemSourceDefinition {
@@ -88,7 +89,7 @@ export interface D1ItemComponent {
   transferStatus: TransferStatuses;
   locked: boolean;
   lockable: boolean;
-  objectives: DestinyObjectiveProgress[];
+  objectives: D1ObjectiveProgress[];
   state: ItemState;
   bucket: number;
 }
@@ -173,19 +174,19 @@ interface D1TalentGridNodeStepDefinition {
   activationRequirement: {
     gridLevel: number;
     materialRequirementHashes: [];
-    exclusiveSetRequiredHash: 0;
+    exclusiveSetRequiredHash: number;
   };
-  canActivateNextStep: false;
+  canActivateNextStep: boolean;
   nextStepIndex: number;
-  isNextStepRandom: true;
+  isNextStepRandom: boolean;
   perkHashes: [];
   startProgressionBarAtProgress: number;
   statHashes: number[];
-  affectsQuality: false;
+  affectsQuality: boolean;
   stepGroups: DestinyTalentNodeStepGroups;
   trueStepIndex: number;
   truePropertyIndex: number;
-  affectsLevel: false;
+  affectsLevel: boolean;
 }
 
 interface D1TalentGridNodeDefinition {
@@ -286,5 +287,386 @@ export interface D1ObjectiveDefinition {
   hash: number;
   index: number;
   contentIdentifier: string;
+  redacted: boolean;
+}
+
+export interface D1ObjectiveProgress {
+  objectiveHash: number;
+  destinationHash: number;
+  activityHash: number;
+  progress: number;
+  hasProgress: boolean;
+  isComplete: boolean;
+  displayValue: number;
+}
+
+export interface D1RecordComponent {
+  recordHash: number;
+  objectives: D1ObjectiveProgress[];
+  status: number;
+  scramble: boolean;
+}
+
+export interface D1RecordDefinition {
+  displayName: string;
+  description: string;
+  recordValueUIStyle: string;
+  icon: string;
+  style: number;
+  rewards: never[];
+  actualRewards: never[];
+  objectives: { objectiveHash: number }[];
+  hash: number;
+  index: number;
+  contentIdentifier: string;
+  redacted: boolean;
+}
+
+export interface D1Progression {
+  dailyProgress: number;
+  weeklyProgress: number;
+  currentProgress: number;
+  level: number;
+  step: number;
+  progressToNextLevel: number;
+  nextLevelAt: number;
+  progressionHash: number;
+  name: string;
+  scope: number;
+  repeatLastStep: boolean;
+  steps: {
+    progressTotal: number;
+    rewardItems: DestinyItemQuantity[];
+  }[];
+  visible: boolean;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1RecordBook {
+  bookHash: number;
+  records: { [recordHash: number]: D1RecordComponent };
+  progression: D1Progression;
+  completedCount: number;
+  redeemedCount: number;
+  spotlights: never[];
+  startDate: string;
+  expirationDate: string;
+  progress: D1Progression;
+  percentComplete: number;
+}
+
+export interface D1RecordBookPageDefinition {
+  displayName: string;
+  displayDescription: string;
+  displayStyle: number;
+  records: {
+    recordHash: number;
+    spotlight: boolean;
+    scrambled: boolean;
+  }[];
+  rewards: {
+    visible: boolean;
+    itemHash: number;
+    requirementUnlockExpressions: string[];
+    requirementProgressionLevel: number;
+    claimedUnlockHash: number;
+    canReclaim: boolean;
+    quantity: number;
+  }[];
+}
+
+export interface D1RecordBookDefinition {
+  bookAvailableUnlockExpression: {
+    steps: {
+      stepOperator: number;
+      flagHash: number;
+      valueHash: number;
+      value: number;
+    }[];
+  };
+  activeRanges: {
+    start: string;
+    end: string;
+  }[];
+  pages: D1RecordBookPageDefinition[];
+  displayName: string;
+  displayDescription: string;
+  icon: string;
+  unavailableReason: string;
+  progressionHash: number;
+  recordCount: number;
+  bannerImage: string;
+  itemHash: number;
+  hash: number;
+  index: number;
+  contentIdentifier: string;
+  redacted: boolean;
+}
+
+export interface D1ItemCategoryDefinition {
+  itemCategoryHash: number;
+  identifier: string;
+  visible: boolean;
+  title: string;
+  shortTitle: string;
+  description: string;
+  grantDestinyItemType: DestinyItemType;
+  grantDestinySubType: DestinyItemSubType;
+  grantDestinyClass: DestinyClass;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1VendorCategoryDefinition {
+  categoryHash: number;
+  order: number;
+  categoryName: string;
+  mobileBannerPath: string;
+  identifier: string;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1ActivityTier {
+  activityHash: number;
+  tierDisplayName: string;
+  completion: {
+    complete: boolean;
+    success: boolean;
+  };
+  steps: {
+    complete: boolean;
+  }[];
+  skullCategories: D1SkullCategory[];
+  rewards: {
+    rewardItems: DestinyItemQuantity[];
+  }[];
+  activityData: {
+    activityHash: number;
+    isNew: boolean;
+    canLead: boolean;
+    canJoin: boolean;
+    isCompleted: boolean;
+    isVisible: boolean;
+    displayLevel: number;
+    recommendedLight: number;
+    difficultyTier: number;
+  };
+}
+
+export interface D1SkullCategory {
+  title: string;
+  skulls: {
+    displayName: string;
+    description: string;
+    icon: string;
+  }[];
+}
+
+export interface D1ActivityComponent {
+  identifier: string;
+  status: {
+    expirationDate: string;
+    startDate: string;
+    expirationKnown: boolean;
+    active: boolean;
+  };
+  display: {
+    categoryHash: number;
+    icon: string;
+    image: string;
+    advisorTypeCategory: string;
+    activityHash: number;
+    destinationHash: number;
+    placeHash: number;
+    about: string;
+    status: string;
+    tips: string[];
+    recruitmentIds: string[];
+  };
+  activityTiers: D1ActivityTier[];
+  extended?: {
+    highestWinRank: number;
+    objectives: D1ObjectiveProgress[];
+    skullCategories: D1SkullCategory[];
+  };
+}
+
+export interface D1ActivityDefinition {
+  activityHash: number;
+  activityName: string;
+  activityDescription: string;
+  icon: string;
+  releaseIcon: string;
+  releaseTime: number;
+  activityLevel: number;
+  completionFlagHash: number;
+  activityPower: number;
+  minParty: number;
+  maxParty: number;
+  maxPlayers: number;
+  destinationHash: number;
+  placeHash: number;
+  activityTypeHash: number;
+  tier: number;
+  pgcrImage: string;
+  rewards: DestinyItemQuantity[];
+  skulls: { displayName: string; description: string }[];
+  isPlaylist: boolean;
+  isMatchmade: boolean;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1ActivityTypeDefinition {
+  activityTypeHash: number;
+  identifier: string;
+  activityTypeName: string;
+  icon: string;
+  activeBackgroundVirtualPath: string;
+  completedBackgroundVirtualPath: string;
+  hiddenOverrideVirtualPath: string;
+  tooltipBackgroundVirtualPath: string;
+  enlargedActiveBackgroundVirtualPath: string;
+  enlargedCompletedBackgroundVirtualPath: string;
+  enlargedHiddenOverrideVirtualPath: string;
+  enlargedTooltipBackgroundVirtualPath: string;
+  order: number;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1InventoryBucketDefinition {
+  bucketHash: number;
+  bucketName: string;
+  bucketDescription: string;
+  scope: number;
+  category: number;
+  bucketOrder: number;
+  bucketIdentifier: string;
+  itemCount: number;
+  location: number;
+  hasTransferDestination: boolean;
+  enabled: boolean;
+  fifo: boolean;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1RaceDefinition {
+  raceHash: number;
+  raceType: DestinyRace;
+  raceName: string;
+  raceNameMale: string;
+  raceNameFemale: string;
+  raceDescription: string;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1FactionDefinition {
+  factionHash: number;
+  factionName: string;
+  factionDescription: string;
+  factionIcon: string;
+  progressionHash: number;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1VendorDefinition {
+  summary: {
+    vendorHash: number;
+    vendorName: string;
+    vendorDescription: string;
+    vendorIcon: string;
+    vendorOrder: number;
+    factionName: string;
+    factionIcon: string;
+    factionHash: number;
+    factionDescription: string;
+    resetIntervalMinutes: number;
+    resetOffsetMinutes: number;
+    vendorIdentifier: string;
+    positionX: number;
+    positionY: number;
+    transitionNodeIdentifier: string;
+    visible: boolean;
+    progressionHash: number;
+    sellString: string;
+    buyString: string;
+    vendorPortrait: string;
+    vendorBanner: string;
+    unlockFlagHashes: number[];
+    enabledUnlockFlagHashes: number[];
+    mapSectionIdentifier: string;
+    mapSectionName: string;
+    mapSectionOrder: number;
+    showOnMap: boolean;
+    eventHash: number;
+    vendorCategoryHash: number;
+    vendorCategoryHashes: number[];
+    vendorSubcategoryHash: number;
+    inhibitBuying: boolean;
+  };
+  acceptedItems: never[];
+  categories: {
+    categoryHash: number;
+    categoryIndex: number;
+    displayTitle: string;
+    overlayCurrencyItemHash: number;
+    quantityAvailable: number;
+    showUnavailableItems: boolean;
+    hideIfNoCurrency: boolean;
+    buyStringOverride: string;
+    overlayTitle: string;
+    overlayDescription: string;
+    overlayChoice: string;
+    overlayIcon: string;
+    hasOverlay: boolean;
+    hideFromRegularPurchase: boolean;
+  }[];
+  failureStrings: string[];
+  sales: {
+    priceOverride: boolean;
+    itemHash: number;
+    bucketHash: number;
+    categoryHash: number;
+    categoryIndex: number;
+    quantityPurchased: number;
+    licenseUnlockHash: number;
+    currencies: [
+      {
+        itemHash: number;
+        quantity: number;
+      }
+    ];
+    price: number;
+    currencyHash: number;
+    hasCurrency: boolean;
+    failureIndexes: number[];
+    refundPolicy: number;
+    refundLimit: number;
+    seedOverride: number;
+    weight: number;
+    requiredLevel: number;
+    creationLevel: number;
+    saleItemIndex: number;
+    originalCategoryIndex: number;
+    minimumLevel: number;
+    maximumLevel: number;
+  }[];
+  unlockValueHash: number;
+  hash: number;
+  index: number;
   redacted: boolean;
 }

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -1,0 +1,290 @@
+import {
+  BungieMembershipType,
+  DamageType,
+  DestinyClass,
+  DestinyInventoryItemStatDefinition,
+  DestinyItemSubType,
+  DestinyItemType,
+  DestinyObjectiveProgress,
+  DestinyProgressionScope,
+  DestinyProgressionStepDefinition,
+  DestinyStat,
+  DestinyStatAggregationType,
+  DestinyTalentNodeState,
+  DestinyTalentNodeStepGroups,
+  DestinyUnlockValueUIStyle,
+  ItemBindStatus,
+  ItemState,
+  SpecialItemType,
+  TierType,
+  TransferStatuses,
+} from 'bungie-api-ts/destiny2';
+
+export interface D1TalentNode {
+  isActivated: boolean;
+  stepIndex: number;
+  state: DestinyTalentNodeState;
+  hidden: boolean;
+  nodeHash: number;
+}
+
+export interface D1Perk {
+  iconPath: string;
+  perkHash: number;
+  isActive: false;
+}
+
+export interface D1ItemSourceDefinition {
+  expansionIndex: number;
+  level: number;
+  minQuality: number;
+  maxQuality: number;
+  minLevelRequired: number;
+  maxLevelRequired: number;
+  exclusivity: number;
+  computedStats: { [statHash: number]: D1Stat };
+  sourceHashes: number[];
+}
+
+export interface D1Stat extends DestinyStat {
+  maximumValue: number;
+}
+
+export interface D1ItemComponent {
+  itemHash: number;
+  bindStatus: ItemBindStatus;
+  isEquipped: boolean;
+  itemInstanceId: string;
+  itemLevel: number;
+  stackSize: number;
+  qualityLevel: number;
+  stats: D1Stat[];
+  primaryStat: D1Stat;
+  canEquip: boolean;
+  equipRequiredLevel: number;
+  unlockFlagHashRequiredToEquip: number;
+  cannotEquipReason: number;
+  damageType: DamageType;
+  damageTypeHash: number;
+  damageTypeNodeIndex: number;
+  damageTypeStepIndex: number;
+  progression: {
+    dailyProgress: number;
+    weeklyProgress: number;
+    currentProgress: number;
+    level: number;
+    step: number;
+    progressToNextLevel: number;
+    nextLevelAt: number;
+    progressionHash: number;
+  };
+  talentGridHash: number;
+  nodes: D1TalentNode[];
+  useCustomDyes: boolean;
+  isEquipment: boolean;
+  isGridComplete: boolean;
+  perks: D1Perk[];
+  location: number;
+  transferStatus: TransferStatuses;
+  locked: boolean;
+  lockable: boolean;
+  objectives: DestinyObjectiveProgress[];
+  state: ItemState;
+  bucket: number;
+}
+
+export interface D1InventoryItemDefinition {
+  itemHash: number;
+  itemName: string;
+  itemDescription: string;
+  icon: string;
+  hasIcon: boolean;
+  secondaryIcon: string;
+  actionName: string;
+  hasAction: boolean;
+  deleteOnAction: boolean;
+  tierTypeName: string;
+  tierType: TierType;
+  itemTypeName: string;
+  bucketTypeHash: number;
+  primaryBaseStatHash: number;
+  stats: {
+    [key: number]: DestinyInventoryItemStatDefinition;
+  };
+  perkHashes: number[];
+  specialItemType: SpecialItemType;
+  talentGridHash: number;
+  hasGeometry: boolean;
+  statGroupHash: number;
+  itemLevels: number[];
+  qualityLevel: number;
+  equippable: boolean;
+  instanced: boolean;
+  rewardItemHash: number;
+  values: {};
+  itemType: DestinyItemType;
+  itemSubType: DestinyItemSubType;
+  classType: DestinyClass;
+  sources: D1ItemSourceDefinition[];
+  itemCategoryHashes: number[];
+  sourceHashes: number[];
+  nonTransferrable: boolean;
+  exclusive: BungieMembershipType;
+  maxStackSize: number;
+  itemIndex: number;
+  setItemHashes: number[];
+  tooltipStyle: string;
+  questlineItemHash: number;
+  needsFullCompletion: boolean;
+  objectiveHashes: number[];
+  allowActions: boolean;
+  questTrackingUnlockValueHash: number;
+  bountyResetUnlockHash: number;
+  uniquenessHash: number;
+  showActiveNodesInTooltip: boolean;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1DamageTypeDefinition {
+  damageTypeHash: number;
+  identifier: string;
+  damageTypeName: string;
+  description: string;
+  iconPath: string;
+  transparentIconPath: string;
+  showIcon: boolean;
+  enumValue: number;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+interface D1TalentGridNodeStepDefinition {
+  stepIndex: number;
+  nodeStepHash: number;
+  nodeStepName?: string;
+  nodeStepDescription?: string;
+  interactionDescription?: string;
+  icon: string;
+  damageType: number;
+  damageTypeHash: number;
+  activationRequirement: {
+    gridLevel: number;
+    materialRequirementHashes: [];
+    exclusiveSetRequiredHash: 0;
+  };
+  canActivateNextStep: false;
+  nextStepIndex: number;
+  isNextStepRandom: true;
+  perkHashes: [];
+  startProgressionBarAtProgress: number;
+  statHashes: number[];
+  affectsQuality: false;
+  stepGroups: DestinyTalentNodeStepGroups;
+  trueStepIndex: number;
+  truePropertyIndex: number;
+  affectsLevel: false;
+}
+
+interface D1TalentGridNodeDefinition {
+  nodeIndex: number;
+  nodeHash: number;
+  row: number;
+  column: number;
+  prerequisiteNodeIndexes: number[];
+  binaryPairNodeIndex: number;
+  autoUnlocks: boolean;
+  lastStepRepeats: boolean;
+  isRandom: boolean;
+  randomActivationRequirement: {
+    gridLevel: number;
+    materialRequirementHashes: number[];
+    exclusiveSetRequiredHash: number;
+  };
+  isRandomRepurchasable: boolean;
+  steps: D1TalentGridNodeStepDefinition[];
+  exlusiveWithNodes: number[];
+  randomStartProgressionBarAtProgression: number;
+  originalNodeHash: number;
+  talentNodeTypes: number;
+  exclusiveSetHash: number;
+  isRealStepSelectionRandom: boolean;
+}
+
+export interface D1TalentGridDefinition {
+  gridHash: number;
+  maxGridLevel: number;
+  gridLevelPerColumn: number;
+  progressionHash: number;
+  nodes: D1TalentGridNodeDefinition[];
+  calcMaxGridLevel: number;
+  calcProgressToMaxLevel: number;
+  exclusiveSets: {
+    nodeIndexes: number[];
+  }[];
+  independentNodeIndexes: number[];
+  maximumRandomMaterialRequirements: number;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1ClassDefinition {
+  classHash: number;
+  classType: DestinyClass;
+  className: string;
+  classNameMale: string;
+  classNameFemale: string;
+  classIdentifier: string;
+  mentorVendorIdentifier: string;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1StatDefinition {
+  statHash: number;
+  statName: string;
+  statDescription: string;
+  icon: string;
+  statIdentifier: string;
+  aggregationType: DestinyStatAggregationType;
+  hasComputedBlock: boolean;
+  interpolate: boolean;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1ProgressionDefinition {
+  progressionHash: number;
+  name: string;
+  scope: DestinyProgressionScope;
+  repeatLastStep: boolean;
+  icon: string;
+  steps: DestinyProgressionStepDefinition[];
+  visible: boolean;
+  hash: number;
+  index: number;
+  redacted: boolean;
+}
+
+export interface D1ObjectiveDefinition {
+  objectiveHash: number;
+  unlockValueHash: number;
+  completionValue: number;
+  vendorHash: number;
+  vendorCategoryHash: number;
+  displayDescription: string;
+  locationHash: number;
+  allowNegativeValue: boolean;
+  allowValueChangeWhenCompleted: boolean;
+  isCountingDownward: boolean;
+  valueStyle: DestinyUnlockValueUIStyle;
+  hash: number;
+  index: number;
+  contentIdentifier: string;
+  redacted: boolean;
+}

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -2,6 +2,7 @@ import {
   BungieMembershipType,
   DamageType,
   DestinyClass,
+  DestinyGender,
   DestinyInventoryItemStatDefinition,
   DestinyItemQuantity,
   DestinyItemSubType,
@@ -669,4 +670,69 @@ export interface D1VendorDefinition {
   hash: number;
   index: number;
   redacted: boolean;
+}
+
+export interface D1CharacterResponse {
+  character: {
+    base: {
+      backgroundPath: string;
+      baseCharacterLevel: number;
+      characterBase: {
+        membershipId: string;
+        membershipType: BungieMembershipType;
+        classType: DestinyClass;
+        characterId: string;
+        dateLastPlayed: string;
+        minutesPlayedThisSession: string;
+        minutesPlayedTotal: string;
+        powerLevel: number;
+        raceHash: number;
+        genderHash: number;
+        genderType: DestinyGender;
+        classHash: number;
+        currentActivityHash: number;
+        lastCompletedStoryHash: number;
+        stats: {
+          [statLabel: string]: D1Stat;
+        };
+        grimoireScore: number;
+        peerView: { equipment: { itemHash: number }[] };
+      };
+      characterLevel: number;
+      emblemHash: number;
+      emblemPath: string;
+      isPrestigeLevel: false;
+      levelProgression: {
+        dailyProgress: number;
+        weeklyProgress: number;
+        currentProgress: number;
+        level: number;
+        step: number;
+      };
+      percentToNextLevel: number;
+      inventory: {
+        buckets: {
+          Currency: { items: D1ItemComponent[]; bucketHash: number }[];
+          Invisible: { items: D1ItemComponent[]; bucketHash: number }[];
+          Item: { items: D1ItemComponent[]; bucketHash: number }[];
+        };
+        currencies: { itemHash: number; value: number }[];
+      };
+    };
+    progression: { progressions: never[] };
+    advisors: any;
+  };
+  id: string;
+  data: {
+    buckets: { [key: string]: { items: D1ItemComponent[]; bucketHash: number }[] };
+    currencies: { itemHash: number; value: number }[];
+  };
+}
+
+export interface D1VaultResponse {
+  id: 'vault';
+  data: {
+    buckets: { items: D1ItemComponent[]; bucketHash: number }[];
+    currencies: { itemHash: number; value: number }[];
+  };
 }

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -9,6 +9,7 @@ import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { errorLog } from 'app/utils/log';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import { produce } from 'immer';
 import _ from 'lodash';
 import React from 'react';
@@ -211,7 +212,15 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
 
     const i18nItemNames: { [key: string]: string } = _.zipObject(
       ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem', 'Artifact', 'Ghost'],
-      [45, 46, 47, 48, 49, 38, 39].map((key) => defs.ItemCategory.get(key).title)
+      [
+        ItemCategoryHashes.Helmets,
+        ItemCategoryHashes.Arms,
+        ItemCategoryHashes.Chest,
+        ItemCategoryHashes.Legs,
+        ItemCategoryHashes.ClassItems,
+        38,
+        ItemCategoryHashes.Ghost,
+      ].map((key) => defs.ItemCategory.get(key).title)
     );
 
     // Armor of each type on a particular character

--- a/src/app/destiny1/record-books/RecordBooks.tsx
+++ b/src/app/destiny1/record-books/RecordBooks.tsx
@@ -16,6 +16,7 @@ import { D1Store } from '../../inventory/store-types';
 import Objective from '../../progress/Objective';
 import { count } from '../../utils/util';
 import { D1ManifestDefinitions } from '../d1-definitions';
+import { D1RecordBook, D1RecordComponent } from '../d1-manifest-types';
 import './record-books.scss';
 
 interface Props {
@@ -23,7 +24,7 @@ interface Props {
 }
 
 interface RecordBook {
-  hash: string;
+  hash: number;
   name: string;
   recordCount: number;
   completedCount: number;
@@ -71,7 +72,10 @@ export default function RecordBooks({ account }: Props) {
   // extra info in Trials cards in Store service, and it's more
   // efficient to just fish the info out of there.
 
-  const processRecordBook = (defs: D1ManifestDefinitions, rawRecordBook: any): RecordBook => {
+  const processRecordBook = (
+    defs: D1ManifestDefinitions,
+    rawRecordBook: D1RecordBook
+  ): RecordBook => {
     // TODO: rewards are in "spotlights"
     // TODO: rank
 
@@ -90,9 +94,8 @@ export default function RecordBooks({ account }: Props) {
       percentComplete: undefined as number | undefined,
     };
 
-    const processRecord = (defs: D1ManifestDefinitions, record: any) => {
+    const processRecord = (defs: D1ManifestDefinitions, record: D1RecordComponent) => {
       const recordDef = defs.Record.get(record.recordHash);
-
       return {
         hash: record.recordHash,
         icon: recordDef.icon,

--- a/src/app/destiny1/vendors/vendor.service.ts
+++ b/src/app/destiny1/vendors/vendor.service.ts
@@ -404,7 +404,7 @@ async function processVendor(
 
   const items = processItems(
     { id: null } as any,
-    saleItems.map((i) => i.item),
+    saleItems.map((i) => i.item) as any[],
     defs,
     buckets
   );

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -1,9 +1,14 @@
 import { handleAuthErrors } from 'app/accounts/actions';
 import { getPlatforms } from 'app/accounts/platforms';
 import { currentAccountSelector } from 'app/accounts/selectors';
-import { D1ItemComponent } from 'app/destiny1/d1-manifest-types';
+import {
+  D1CharacterResponse,
+  D1ItemComponent,
+  D1VaultResponse,
+} from 'app/destiny1/d1-manifest-types';
 import { ThunkResult } from 'app/store/types';
 import { errorLog, infoLog } from 'app/utils/log';
+import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { getStores } from '../bungie-api/destiny1-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
@@ -91,23 +96,21 @@ export function loadStores(): ThunkResult<D1Store[] | undefined> {
   };
 }
 
-function processCurrencies(rawStores: any[], defs: D1ManifestDefinitions) {
+function processCurrencies(rawStores: D1CharacterResponse[], defs: D1ManifestDefinitions) {
   try {
-    return rawStores[0].character.base.inventory.currencies.map(
-      (c: { itemHash: number; value: any }) => {
-        const itemDef = defs.InventoryItem.get(c.itemHash);
-        return {
-          itemHash: c.itemHash,
-          quantity: c.value,
-          displayProperties: {
-            name: itemDef.itemName,
-            description: itemDef.itemDescription,
-            icon: itemDef.icon,
-            hasIcon: Boolean(itemDef.icon),
-          },
-        };
-      }
-    );
+    return rawStores[0].character.base.inventory.currencies.map((c) => {
+      const itemDef = defs.InventoryItem.get(c.itemHash);
+      return {
+        itemHash: c.itemHash,
+        quantity: c.value,
+        displayProperties: {
+          name: itemDef.itemName,
+          description: itemDef.itemDescription,
+          icon: itemDef.icon,
+          hasIcon: Boolean(itemDef.icon),
+        } as DestinyDisplayPropertiesDefinition,
+      };
+    });
   } catch (e) {
     infoLog('d1-stores', 'error processing currencies', e);
   }
@@ -118,15 +121,7 @@ function processCurrencies(rawStores: any[], defs: D1ManifestDefinitions) {
  * Process a single store from its raw form to a DIM store, with all the items.
  */
 function processStore(
-  raw: {
-    id: string;
-    data: { buckets: any };
-    character: {
-      base: any;
-      progression: { progressions: never[] };
-      advisors: any;
-    };
-  },
+  raw: D1CharacterResponse | D1VaultResponse,
   defs: D1ManifestDefinitions,
   buckets: InventoryBuckets,
   lastPlayedDate: Date
@@ -138,11 +133,11 @@ function processStore(
   let store: D1Store;
   let rawItems: D1ItemComponent[];
   if (raw.id === 'vault') {
-    const result = makeVault(raw);
+    const result = makeVault(raw as D1VaultResponse);
     store = result.store;
     rawItems = result.items;
   } else {
-    const result = makeCharacter(raw, defs, lastPlayedDate);
+    const result = makeCharacter(raw as D1CharacterResponse, defs, lastPlayedDate);
     store = result.store;
     rawItems = result.items;
   }

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -1,6 +1,7 @@
 import { handleAuthErrors } from 'app/accounts/actions';
 import { getPlatforms } from 'app/accounts/platforms';
 import { currentAccountSelector } from 'app/accounts/selectors';
+import { D1ItemComponent } from 'app/destiny1/d1-manifest-types';
 import { ThunkResult } from 'app/store/types';
 import { errorLog, infoLog } from 'app/utils/log';
 import _ from 'lodash';
@@ -135,7 +136,7 @@ function processStore(
   }
 
   let store: D1Store;
-  let rawItems: any[];
+  let rawItems: D1ItemComponent[];
   if (raw.id === 'vault') {
     const result = makeVault(raw);
     store = result.store;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -168,6 +168,7 @@ export interface DimItem {
    */
   primaryStat:
     | (DestinyStat & {
+        // TODO: get rid of this
         stat: DestinyStatDefinition;
       })
     | null;

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -1,9 +1,13 @@
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import {
+  D1ActivityComponent,
+  D1FactionDefinition,
+  D1RecordBook,
+} from 'app/destiny1/d1-manifest-types';
+import {
   DestinyClass,
   DestinyColor,
   DestinyDisplayPropertiesDefinition,
-  DestinyFactionDefinition,
   DestinyProgression,
 } from 'bungie-api-ts/destiny2';
 import React from 'react';
@@ -112,10 +116,7 @@ export interface DimCharacterStat {
 
 export interface D1Progression extends DestinyProgression {
   /** The faction definition associated with this progress. */
-  faction: DestinyFactionDefinition & {
-    factionName: string;
-    factionIcon: string;
-  };
+  faction: D1FactionDefinition;
   order: number;
 }
 
@@ -127,7 +128,7 @@ export interface D1Store extends DimStore<D1Item> {
 
   // TODO: shape?
   advisors: {
-    recordBooks?: any;
-    activities?: any;
+    recordBooks?: D1RecordBook[];
+    activities?: { [activityId: string]: D1ActivityComponent };
   };
 }

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -1,4 +1,5 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
+import { D1CharacterResponse } from 'app/destiny1/d1-manifest-types';
 import { warnLog } from 'app/utils/log';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { StatHashes } from 'data/d2/generated-enums';
@@ -107,10 +108,7 @@ const stats = [
  */
 export function getCharacterStatsData(
   defs: D1ManifestDefinitions,
-  data: {
-    stats: { [x: string]: { statHash: number; value: number } | undefined };
-    peerView: { equipment: { itemHash: number }[] };
-  }
+  data: D1CharacterResponse['character']['base']['characterBase']
 ) {
   const ret: { [statHash: string]: DimCharacterStat } = {};
   stats.forEach((statId) => {

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -66,7 +66,7 @@ export function processItems(
       // dummies and invisible items are not a big deal
       const bucketDef = defs.InventoryBucket[item.bucket];
       // if it's a named, non-invisible bucket, it may be a problem that the item wasn't generated
-      if (bucketDef.category !== BucketCategory.Invisible && bucketDef.displayProperties.name) {
+      if (bucketDef.category !== BucketCategory.Invisible && bucketDef.bucketName) {
         owner.hadErrors = true;
       }
     }
@@ -364,7 +364,16 @@ function makeItem(
     errorLog('d1-stores', `Error building stats for ${createdItem.name}`, item, itemDef, e);
   }
 
-  createdItem.objectives = item.objectives?.length > 0 ? item.objectives : null;
+  createdItem.objectives =
+    item.objectives?.length > 0
+      ? item.objectives.map((o) => ({
+          objectiveHash: o.objectiveHash,
+          complete: o.isComplete,
+          progress: o.progress,
+          completionValue: defs.Objective.get(o.objectiveHash).completionValue,
+          visible: true,
+        }))
+      : null;
 
   if (createdItem.talentGrid && createdItem.infusable) {
     try {

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -1,3 +1,11 @@
+import {
+  D1DamageTypeDefinition,
+  D1InventoryItemDefinition,
+  D1ItemComponent,
+  D1ProgressionDefinition,
+  D1StatDefinition,
+  D1TalentGridDefinition,
+} from 'app/destiny1/d1-manifest-types';
 import { t } from 'app/i18next-t';
 import { D1BucketHashes, D1_StatHashes } from 'app/search/d1-known-values';
 import { lightStats } from 'app/search/search-filter-values';
@@ -9,9 +17,10 @@ import {
   DestinyClass,
   DestinyDamageTypeDefinition,
   DestinyDisplayPropertiesDefinition,
+  DestinyStatCategory,
 } from 'bungie-api-ts/destiny2';
 import missingSources from 'data/d1/missing_sources.json';
-import { BucketHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { vaultTypes } from '../../destiny1/d1-buckets';
 import { D1ManifestDefinitions, DefinitionTable } from '../../destiny1/d1-definitions';
@@ -34,7 +43,7 @@ const tiers = ['Unknown', 'Unknown', 'Common', 'Uncommon', 'Rare', 'Legendary', 
  */
 export function processItems(
   owner: D1Store,
-  items: any[],
+  items: D1ItemComponent[],
   defs: D1ManifestDefinitions,
   buckets: InventoryBuckets
 ): D1Item[] {
@@ -55,7 +64,7 @@ export function processItems(
       // an exception occurred while creating the item, or it has a definition but lacks a name
       // not all of these should cause the store to consider itself hadErrors.
       // dummies and invisible items are not a big deal
-      const bucketDef = defs.InventoryBucket[item.bucketHash];
+      const bucketDef = defs.InventoryBucket[item.bucket];
       // if it's a named, non-invisible bucket, it may be a problem that the item wasn't generated
       if (bucketDef.category !== BucketCategory.Invisible && bucketDef.displayProperties.name) {
         owner.hadErrors = true;
@@ -78,36 +87,7 @@ const getClassTypeNameLocalized = _.memoize((type: DestinyClass, defs: D1Manifes
  * Convert a D1DamageType to the D2 definition, so we don't have to maintain both codepaths
  */
 const toD2DamageType = _.memoize(
-  (damageType: {
-    damageTypeHash: number;
-    identifier: string;
-    damageTypeName: string;
-    description: string;
-    iconPath: string;
-    transparentIconPath: string;
-    showIcon: boolean;
-    enumValue: number;
-    hash: number;
-    index: number;
-    redacted: boolean;
-  }): DestinyDamageTypeDefinition =>
-    /*    a d1 damagetype def looks like this:
-    {
-      "damageTypeHash": 2303181850,
-      "identifier": "DAMAGE_TYPE_ARC",
-      "damageTypeName": "Arc",
-      "description": "This weapon causes Arc damage.",
-      "iconPath": "/img/destiny_content/damage_types/arc.png",
-      "transparentIconPath": "img/destiny_content/damage_types/arc_trans.png",
-      "showIcon": true,
-      "enumValue": 2,
-      "hash": 2303181850,
-      "index": 0,
-      "redacted": false
-    }
-  i like the icons a lot
-*/
-
+  (damageType: D1DamageTypeDefinition | undefined): DestinyDamageTypeDefinition | undefined =>
     damageType && {
       displayProperties: {
         name: damageType.damageTypeName,
@@ -138,21 +118,17 @@ const toD2DamageType = _.memoize(
 function makeItem(
   defs: D1ManifestDefinitions,
   buckets: InventoryBuckets,
-  item: any,
+  item: D1ItemComponent,
   owner: D1Store
 ) {
-  let itemDef = defs.InventoryItem.get(item.itemHash);
+  const itemDef = defs.InventoryItem.get(item.itemHash);
   // Missing definition?
   if (!itemDef) {
-    // maybe it is redacted...
-    itemDef = {
-      itemName: 'Missing Item',
-      redacted: true,
-    };
+    return null;
   }
 
-  if (!itemDef.icon && !itemDef.action) {
-    itemDef.classified = true;
+  if (!itemDef.icon) {
+    itemDef.redacted = true;
     itemDef.classType = 3;
   }
 
@@ -212,9 +188,7 @@ function makeItem(
   // vault as a character. So put them in the bucket they would
   // have been in if they'd been on a character.
   if (currentBucket.hash in vaultTypes) {
-    // TODO: Remove this if Bungie ever returns bucket.id for classified
-    // items in the vault.
-    if (itemDef.classified && itemDef.itemTypeName === 'Unknown') {
+    if (itemDef.redacted && itemDef.itemTypeName === 'Unknown') {
       switch (currentBucket.hash) {
         case 4046403665:
           currentBucket = buckets.byType.Heavy;
@@ -267,7 +241,7 @@ function makeItem(
       currentBucket.inPostmaster ||
         itemDef.nonTransferrable ||
         !itemDef.allowActions ||
-        itemDef.classified
+        itemDef.redacted
     ),
     id: item.itemInstanceId,
     equipped: item.isEquipped,
@@ -276,7 +250,7 @@ function makeItem(
       item.isEquipment && tiers[itemDef.tierType] === 'Exotic' ? normalBucket.sort : undefined,
     complete: item.isGridComplete,
     amount: item.stackSize || 1,
-    primaryStat: item.primaryStat || null,
+    primaryStat: null,
     typeName: itemDef.itemTypeName,
     isEngram: (itemDef.itemCategoryHashes || []).includes(34),
     // "perks" are the two or so talent grid items that are "featured" for an
@@ -302,7 +276,7 @@ function makeItem(
     ),
     tracked: item.state === 2,
     locked: item.locked,
-    classified: Boolean(itemDef.classified),
+    classified: Boolean(itemDef.redacted),
     // These get filled in later or aren't relevant to D1 items
     percentComplete: 0,
     talentGrid: null,
@@ -338,20 +312,27 @@ function makeItem(
   createdItem.comparable = Boolean(createdItem.equipment && createdItem.lockable);
 
   // Moving rare masks destroys them
-  if (createdItem.itemCategoryHashes.includes(55) && createdItem.tier !== 'Legendary') {
+  if (
+    createdItem.itemCategoryHashes.includes(ItemCategoryHashes.Mask) &&
+    createdItem.tier !== 'Legendary'
+  ) {
     createdItem.notransfer = true;
   }
 
-  if (createdItem.primaryStat) {
-    const statDef = defs.Stat.get(createdItem.primaryStat.statHash);
-    createdItem.primaryStat.stat = {
-      ...statDef,
-      // D2 is much better about display info
-      displayProperties: {
-        name: statDef.statName,
-        description: statDef.statDescription,
-        icon: statDef.icon,
-        hasIcon: Boolean(statDef.icon),
+  if (item.primaryStat) {
+    const statDef = defs.Stat.get(item.primaryStat.statHash);
+    createdItem.primaryStat = {
+      ...item.primaryStat,
+      stat: {
+        ...statDef,
+        statCategory: DestinyStatCategory.Primary,
+        // D2 is much better about display info
+        displayProperties: {
+          name: statDef.statName,
+          description: statDef.statDescription,
+          icon: statDef.icon,
+          hasIcon: Boolean(statDef.icon),
+        } as DestinyDisplayPropertiesDefinition,
       },
     };
 
@@ -370,7 +351,7 @@ function makeItem(
 
   // An item can be used as infusion fuel if it is equipment, and has a primary stat that isn't Speed
   createdItem.infusionFuel = Boolean(
-    createdItem.equipment && createdItem.primaryStat?.statHash !== 1501155019
+    createdItem.equipment && createdItem.primaryStat?.statHash !== StatHashes.Speed
   );
 
   try {
@@ -453,14 +434,9 @@ function getAmmoType(itemType: string) {
 }
 
 function buildTalentGrid(
-  item: {
-    talentGridHash: number;
-    progression: { progressionHash: number; currentProgress: any; level: number };
-    nodes: string | any[];
-    primaryStat: any;
-  },
-  talentDefs: DefinitionTable<any>,
-  progressDefs: DefinitionTable<any>
+  item: D1ItemComponent,
+  talentDefs: DefinitionTable<D1TalentGridDefinition>,
+  progressDefs: DefinitionTable<D1ProgressionDefinition>
 ): D1TalentGrid | null {
   const talentGridDef = item.talentGridHash && talentDefs.get(item.talentGridHash);
   if (
@@ -494,12 +470,7 @@ function buildTalentGrid(
 
   const possibleNodes = talentGridDef.nodes;
 
-  // var featuredPerkNames = item.perks.map(function(perk) {
-  //   var perkDef = perkDefs.get(perk.perkHash);
-  //   return perkDef ? perkDef.displayName : 'Unknown';
-  // });
-
-  let gridNodes = (item.nodes as any[]).map((node): D1GridNode | undefined => {
+  let gridNodes = item.nodes.map((node): D1GridNode | undefined => {
     const talentNodeGroup = possibleNodes[node.nodeHash];
     const talentNodeSelected = talentNodeGroup.steps[node.stepIndex];
 
@@ -539,7 +510,7 @@ function buildTalentGrid(
     // Build a perk string for the DTR link. See https://github.com/DestinyItemManager/DIM/issues/934
     let dtrHash: string | null = null;
     if (node.isActivated || talentNodeGroup.isRandom) {
-      dtrHash = (node.nodeHash as number).toString(16);
+      dtrHash = node.nodeHash.toString(16);
       if (dtrHash.length > 1) {
         dtrHash += '.';
       }
@@ -563,7 +534,7 @@ function buildTalentGrid(
       name: nodeName,
       ornament: ornamentComplete,
       hash: talentNodeSelected.nodeStepHash,
-      description: talentNodeSelected.nodeStepDescription,
+      description: talentNodeSelected.nodeStepDescription ?? '',
       icon: talentNodeSelected.icon,
       // XP put into this node
       xp,
@@ -632,7 +603,7 @@ function buildTalentGrid(
       node.column -= minColumn;
     });
   }
-  const maxColumn = _.maxBy(gridNodes, (n: any) => n.column)!.column;
+  const maxColumn = _.maxBy(gridNodes, (n) => n.column)!.column;
 
   return {
     nodes: _.sortBy(gridNodes, (node) => node.column + 0.1 * node.row),
@@ -644,14 +615,14 @@ function buildTalentGrid(
     infusable: gridNodes.some((n) => n.hash === 1270552711),
     complete:
       totalXPRequired <= totalXP &&
-      _.every(gridNodes, (n: any) => n.unlocked || (n.xpRequired === 0 && n.column === maxColumn)),
+      _.every(gridNodes, (n) => n.unlocked || (n.xpRequired === 0 && n.column === maxColumn)),
   };
 }
 
 function buildStats(
-  item: any,
-  itemDef: { stats: any },
-  statDefs: DefinitionTable<any>,
+  item: D1ItemComponent,
+  itemDef: D1InventoryItemDefinition | D1ItemComponent,
+  statDefs: DefinitionTable<D1StatDefinition>,
   grid: D1TalentGrid | null,
   type: string
 ): D1Stat[] | null {
@@ -672,7 +643,7 @@ function buildStats(
 
   return _.sortBy(
     _.compact(
-      _.map(itemDef.stats, (stat: any) => {
+      _.map(itemDef.stats, (stat) => {
         const def = statDefs.get(stat.statHash);
         if (!def) {
           return undefined;
@@ -684,7 +655,7 @@ function buildStats(
         const secondarySort = ['STAT_AIM_ASSISTANCE', 'STAT_EQUIP_SPEED'];
         let secondaryIndex = -1;
 
-        let sort = _.findIndex(item.stats, (s: any) => s.statHash === stat.statHash);
+        let sort = _.findIndex(item.stats, (s) => s.statHash === stat.statHash);
         let itemStat;
         if (sort < 0) {
           secondaryIndex = secondarySort.indexOf(identifier);
@@ -710,8 +681,10 @@ function buildStats(
         let base = val;
         let bonus = 0;
 
+        const primaryStatDef = item.primaryStat && statDefs.get(item.primaryStat.statHash);
+
         if (
-          item.primaryStat?.stat.statIdentifier === 'STAT_DEFENSE' &&
+          primaryStatDef?.statIdentifier === 'STAT_DEFENSE' &&
           ((identifier === 'STAT_INTELLECT' &&
             armorNodes.find((n) => n.hash === 1034209669 /* Increase Intellect */)) ||
             (identifier === 'STAT_DISCIPLINE' &&
@@ -745,7 +718,7 @@ function buildStats(
           maximumValue,
           bar: identifier !== 'STAT_MAGAZINE_SIZE' && identifier !== 'STAT_ATTACK_ENERGY', // energy == magazine for swords
           smallerIsBetter: [447667954, 2961396640].includes(stat.statHash),
-          additive: item.primaryStat.stat.statIdentifier === 'STAT_DEFENSE',
+          additive: primaryStatDef?.statIdentifier === 'STAT_DEFENSE',
           isConditionallyActive: false,
         };
       })

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -1,4 +1,8 @@
-import { D1ItemComponent } from 'app/destiny1/d1-manifest-types';
+import {
+  D1CharacterResponse,
+  D1ItemComponent,
+  D1VaultResponse,
+} from 'app/destiny1/d1-manifest-types';
 import { t } from 'app/i18next-t';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import vaultBackground from 'images/vault-background.svg';
@@ -25,11 +29,7 @@ const progressionMeta = {
 };
 
 export function makeCharacter(
-  raw: {
-    character: { base: any; progression: { progressions: never[] }; advisors: any };
-    id: any;
-    data: { buckets: any };
-  },
+  raw: D1CharacterResponse,
   defs: D1ManifestDefinitions,
   mostRecentLastPlayed: Date
 ): {
@@ -101,22 +101,24 @@ export function makeCharacter(
     hadErrors: false,
   };
 
-  let items: any[] = [];
-
-  const bucketize = (pail: any) => {
-    _.forIn(pail.items, (item: any) => {
-      item.bucket = pail.bucketHash;
-    });
-
-    items = items.concat(pail.items);
-  };
-
-  _.forIn(raw.data.buckets, (bucket: any) => {
-    _.forIn(bucket, bucketize);
-  });
+  let items: D1ItemComponent[] = [];
+  for (const buckets of Object.values(raw.data.buckets)) {
+    for (const bucket of buckets) {
+      for (const item of bucket.items) {
+        item.bucket = bucket.bucketHash;
+      }
+      items = items.concat(bucket.items);
+    }
+  }
 
   if (_.has(character.inventory.buckets, 'Invisible')) {
-    _.forIn(character.inventory.buckets.Invisible, bucketize);
+    const buckets = character.inventory.buckets.Invisible;
+    for (const bucket of buckets) {
+      for (const item of bucket.items) {
+        item.bucket = bucket.bucketHash;
+      }
+      items = items.concat(bucket.items);
+    }
   }
 
   return {
@@ -125,7 +127,7 @@ export function makeCharacter(
   };
 }
 
-export function makeVault(raw: { data: { buckets: any } }): {
+export function makeVault(raw: D1VaultResponse): {
   store: D1Store;
   items: D1ItemComponent[];
 } {
@@ -154,15 +156,14 @@ export function makeVault(raw: { data: { buckets: any } }): {
     hadErrors: false,
   };
 
-  let items: any[] = [];
+  let items: D1ItemComponent[] = [];
 
-  _.forIn(raw.data.buckets, (bucket: any) => {
-    _.forIn(bucket.items, (item: any) => {
+  for (const bucket of raw.data.buckets) {
+    for (const item of bucket.items) {
       item.bucket = bucket.bucketHash;
-    });
-
+    }
     items = items.concat(bucket.items);
-  });
+  }
 
   return {
     store,

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -1,3 +1,4 @@
+import { D1ItemComponent } from 'app/destiny1/d1-manifest-types';
 import { t } from 'app/i18next-t';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import vaultBackground from 'images/vault-background.svg';
@@ -33,10 +34,11 @@ export function makeCharacter(
   mostRecentLastPlayed: Date
 ): {
   store: D1Store;
-  items: any[];
+  items: D1ItemComponent[];
 } {
   const character = raw.character.base;
   const race = defs.Race[character.characterBase.raceHash];
+  const klass = defs.Class[character.characterBase.classHash];
   let genderRace = '';
   let className = '';
   let raceName = '';
@@ -47,13 +49,13 @@ export function makeCharacter(
     genderName = 'male';
     genderRace = race.raceNameMale;
     raceName = race.raceNameMale;
-    className = defs.Class[character.characterBase.classHash].classNameMale;
+    className = klass.classNameMale;
   } else {
     gender = 'female';
     genderName = 'female';
     genderRace = race.raceNameFemale;
     raceName = race.raceNameFemale;
-    className = defs.Class[character.characterBase.classHash].classNameFemale;
+    className = klass.classNameFemale;
   }
 
   const lastPlayed = new Date(character.characterBase.dateLastPlayed);
@@ -125,7 +127,7 @@ export function makeCharacter(
 
 export function makeVault(raw: { data: { buckets: any } }): {
   store: D1Store;
-  items: any[];
+  items: D1ItemComponent[];
 } {
   const store: D1Store = {
     destinyVersion: 1,

--- a/src/app/inventory/store/objectives.ts
+++ b/src/app/inventory/store/objectives.ts
@@ -1,3 +1,4 @@
+import { D1ObjectiveDefinition } from 'app/destiny1/d1-manifest-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import {
   DestinyInventoryItemDefinition,
@@ -53,13 +54,15 @@ export function buildObjectives(
 }
 
 export function isBooleanObjective(
-  objectiveDef: DestinyObjectiveDefinition,
+  objectiveDef: DestinyObjectiveDefinition | D1ObjectiveDefinition,
   completionValue: number
 ) {
   return (
     objectiveDef.valueStyle === DestinyUnlockValueUIStyle.Checkbox ||
     (completionValue === 1 &&
-      (!objectiveDef.allowOvercompletion || !objectiveDef.showValueOnComplete))
+      (!('allowOvercompletion' in objectiveDef) ||
+        !objectiveDef.allowOvercompletion ||
+        !objectiveDef.showValueOnComplete))
   );
 }
 

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -57,8 +57,9 @@ export function getItemsFromLoadoutItems(
           (defs.isDestiny2() && makeFakeItem(defs, buckets, undefined, loadoutItem.hash)) ||
           ({
             ...loadoutItem,
-            icon: itemDef.displayProperties?.icon || itemDef.icon,
-            name: itemDef.displayProperties?.name || itemDef.itemName,
+            icon: 'displayProperties' in itemDef ? itemDef.displayProperties?.icon : itemDef.icon,
+            name:
+              'displayProperties' in itemDef ? itemDef.displayProperties?.name : itemDef.itemName,
           } as DimLoadoutItem);
         fakeItem.equipped = loadoutItem.equipped;
         fakeItem.socketOverrides = loadoutItem.socketOverrides;

--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -365,6 +365,8 @@ export default function ItemTypeSelector({
                 if (armorTopLevelCatHashes.some((h) => categoryHashList.includes(h))) {
                   categoryHashList.push(ItemCategoryHashes.Armor);
                 }
+
+                const itemCategory = defs.ItemCategory.get(Math.abs(subCategory.itemCategoryHash));
                 return (
                   <label
                     key={subCategory.itemCategoryHash}
@@ -383,9 +385,9 @@ export default function ItemTypeSelector({
                     {itemCategoryIcons[subCategory.itemCategoryHash] && (
                       <img src={itemCategoryIcons[subCategory.itemCategoryHash]} />
                     )}
-                    {defs.ItemCategory.get(Math.abs(subCategory.itemCategoryHash)).displayProperties
-                      ?.name ||
-                      defs.ItemCategory.get(Math.abs(subCategory.itemCategoryHash)).title}{' '}
+                    {'displayProperties' in itemCategory
+                      ? itemCategory.displayProperties.name
+                      : itemCategory.title}{' '}
                     <span className={styles.buttonItemCount}>
                       (
                       {

--- a/src/app/progress/LoadoutRequirementModifier.tsx
+++ b/src/app/progress/LoadoutRequirementModifier.tsx
@@ -3,6 +3,7 @@ import PressTip from 'app/dim-ui/PressTip';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { ARMSMASTER_ACTIVITY_MODIFIER } from 'app/search/d2-known-values';
 import { DestinyItemSubType, DestinyMilestoneChallengeActivity } from 'bungie-api-ts/destiny2';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
 import './ActivityModifier.scss';
 
@@ -24,25 +25,25 @@ const itemSubTypeToItemCategoryHash: { [key in DestinyItemSubType]: number } = {
   [DestinyItemSubType.ClassArmor]: 17,
   [DestinyItemSubType.DummyRepeatableBounty]: 17,
   // END useless types
-  [DestinyItemSubType.AutoRifle]: 5,
-  [DestinyItemSubType.Shotgun]: 11,
-  [DestinyItemSubType.Machinegun]: 12,
-  [DestinyItemSubType.HandCannon]: 6,
-  [DestinyItemSubType.RocketLauncher]: 13,
-  [DestinyItemSubType.FusionRifle]: 9,
-  [DestinyItemSubType.SniperRifle]: 10,
-  [DestinyItemSubType.PulseRifle]: 7,
-  [DestinyItemSubType.ScoutRifle]: 8,
-  [DestinyItemSubType.Sidearm]: 14,
-  [DestinyItemSubType.Sword]: 54,
-  [DestinyItemSubType.Mask]: 0,
-  [DestinyItemSubType.Shader]: 0,
-  [DestinyItemSubType.Ornament]: 0,
-  [DestinyItemSubType.FusionRifleLine]: 1504945536,
-  [DestinyItemSubType.GrenadeLauncher]: 153950757,
-  [DestinyItemSubType.SubmachineGun]: 3954685534,
-  [DestinyItemSubType.TraceRifle]: 2489664120,
-  [DestinyItemSubType.Bow]: 3317538576,
+  [DestinyItemSubType.AutoRifle]: ItemCategoryHashes.AutoRifle,
+  [DestinyItemSubType.Shotgun]: ItemCategoryHashes.Shotgun,
+  [DestinyItemSubType.Machinegun]: ItemCategoryHashes.MachineGun,
+  [DestinyItemSubType.HandCannon]: ItemCategoryHashes.HandCannon,
+  [DestinyItemSubType.RocketLauncher]: ItemCategoryHashes.RocketLauncher,
+  [DestinyItemSubType.FusionRifle]: ItemCategoryHashes.FusionRifle,
+  [DestinyItemSubType.SniperRifle]: ItemCategoryHashes.SniperRifle,
+  [DestinyItemSubType.PulseRifle]: ItemCategoryHashes.PulseRifle,
+  [DestinyItemSubType.ScoutRifle]: ItemCategoryHashes.ScoutRifle,
+  [DestinyItemSubType.Sidearm]: ItemCategoryHashes.Sidearm,
+  [DestinyItemSubType.Sword]: ItemCategoryHashes.Sword,
+  [DestinyItemSubType.Mask]: ItemCategoryHashes.Mask,
+  [DestinyItemSubType.Shader]: ItemCategoryHashes.Shaders,
+  [DestinyItemSubType.Ornament]: ItemCategoryHashes.Mods_Ornament,
+  [DestinyItemSubType.FusionRifleLine]: ItemCategoryHashes.LinearFusionRifles,
+  [DestinyItemSubType.GrenadeLauncher]: ItemCategoryHashes.GrenadeLaunchers,
+  [DestinyItemSubType.SubmachineGun]: ItemCategoryHashes.SubmachineGuns,
+  [DestinyItemSubType.TraceRifle]: ItemCategoryHashes.TraceRifles,
+  [DestinyItemSubType.Bow]: ItemCategoryHashes.Bows,
   // TODO: Fill this in when the manifest gets released
   [DestinyItemSubType.Glaive]: 0,
 };

--- a/src/app/progress/Objective.tsx
+++ b/src/app/progress/Objective.tsx
@@ -1,4 +1,4 @@
-import { D1ObjectiveDefinition } from 'app/destiny1/d1-manifest-types';
+import { D1ObjectiveDefinition, D1ObjectiveProgress } from 'app/destiny1/d1-manifest-types';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { t } from 'app/i18next-t';
 import {
@@ -24,7 +24,7 @@ export default function Objective({
   suppressObjectiveDescription,
   isTrialsPassage,
 }: {
-  objective: DestinyObjectiveProgress;
+  objective: DestinyObjectiveProgress | D1ObjectiveProgress;
   suppressObjectiveDescription?: boolean;
   isTrialsPassage?: boolean;
 }) {
@@ -43,11 +43,9 @@ export default function Objective({
 
   // These two are to support D1 objectives
   const completionValue =
-    objective.completionValue !== undefined
-      ? objective.completionValue
-      : objectiveDef.completionValue;
+    'completionValue' in objective ? objective.completionValue : objectiveDef.completionValue;
 
-  const complete = objective.complete || (objective as any).isComplete;
+  const complete = 'complete' in objective ? objective.complete : objective.isComplete;
 
   const progressDescription =
     // D1 display description
@@ -74,7 +72,7 @@ export default function Objective({
   const isBoolean = isBooleanObjective(objectiveDef, completionValue);
   const showAsCounter = isTrialsPassage && isRoundsWonObjective(objective.objectiveHash);
   const passageFlawed =
-    isTrialsPassage && isFlawlessObjective(objective.objectiveHash) && !objective.complete;
+    isTrialsPassage && isFlawlessObjective(objective.objectiveHash) && !complete;
 
   const classes = clsx('objective-row', {
     'objective-complete': complete && !showAsCounter,

--- a/src/app/progress/ObjectiveDescription.tsx
+++ b/src/app/progress/ObjectiveDescription.tsx
@@ -1,3 +1,4 @@
+import { D1ObjectiveDefinition } from 'app/destiny1/d1-manifest-types';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { DestinyObjectiveDefinition } from 'bungie-api-ts/destiny2';
 import React from 'react';
@@ -8,13 +9,16 @@ export default function ObjectiveDescription({
   objectiveDef,
 }: {
   progressDescription: string;
-  objectiveDef?: DestinyObjectiveDefinition;
+  objectiveDef?: DestinyObjectiveDefinition | D1ObjectiveDefinition;
 }) {
+  const icon =
+    objectiveDef && 'displayProperties' in objectiveDef && objectiveDef.displayProperties.hasIcon
+      ? objectiveDef.displayProperties.icon
+      : undefined;
+
   return (
     <div className="objective-description">
-      {objectiveDef?.displayProperties.hasIcon && (
-        <BungieImage src={objectiveDef.displayProperties.icon} />
-      )}
+      {icon && <BungieImage src={icon} />}
       <RichDestinyText text={progressDescription} />
     </div>
   );


### PR DESCRIPTION
Why do this? Why do this *now*? I dunno, just felt like doing it. But now we have reasonable types for most of the D1 code, which can help with catching bugs and writing components that are meant to handle both.