### PR TITLE
Reduce dependency on string bucket type

### DIFF
--- a/src/app/destiny1/d1-bucket-categories.ts
+++ b/src/app/destiny1/d1-bucket-categories.ts
@@ -1,24 +1,32 @@
-import type { D1BucketCategory, DimBucketType } from 'app/inventory/inventory-buckets';
+import type { D1BucketCategory } from 'app/inventory/inventory-buckets';
+import { D1BucketHashes } from 'app/search/d1-known-values';
+import { BucketHashes } from 'data/d2/generated-enums';
 
 export const D1Categories: {
-  [key in D1BucketCategory]: DimBucketType[];
+  [key in D1BucketCategory]: (BucketHashes | D1BucketHashes)[];
 } = {
-  Postmaster: ['LostItems', 'SpecialOrders', 'Messages'],
-  Weapons: ['Primary', 'Special', 'Heavy'],
-  Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
-  General: [
-    'Class',
-    'Artifact',
-    'Ghost',
-    'Consumable',
-    'Material',
-    'Ornaments',
-    'Emblem',
-    'Shader',
-    'Emote',
-    'Ship',
-    'Vehicle',
-    'Horn',
+  Postmaster: [BucketHashes.LostItems, BucketHashes.SpecialOrders, BucketHashes.Messages],
+  Weapons: [BucketHashes.KineticWeapons, BucketHashes.EnergyWeapons, BucketHashes.PowerWeapons],
+  Armor: [
+    BucketHashes.Helmet,
+    BucketHashes.Gauntlets,
+    BucketHashes.ChestArmor,
+    BucketHashes.LegArmor,
+    BucketHashes.ClassArmor,
   ],
-  Progress: ['Bounties', 'Quests', 'Missions'],
+  General: [
+    BucketHashes.Subclass,
+    D1BucketHashes.Artifact,
+    BucketHashes.Ghost,
+    BucketHashes.Consumables,
+    BucketHashes.Materials,
+    BucketHashes.Modifications,
+    BucketHashes.Emblems,
+    D1BucketHashes.Shader,
+    BucketHashes.Emotes_Equippable,
+    BucketHashes.Ships,
+    BucketHashes.Vehicle,
+    D1BucketHashes.Horn,
+  ],
+  Progress: [D1BucketHashes.Bounties, D1BucketHashes.Quests, D1BucketHashes.Missions],
 };

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -72,7 +72,6 @@ _.forIn(D1Categories, (bucketHashes, category: D1BucketCategory) => {
 export function getBuckets(defs: D1ManifestDefinitions) {
   const buckets: InventoryBuckets = {
     byHash: {},
-    byType: {},
     byCategory: {},
     unknown: {
       description: 'Unknown items. DIM needs a manifest update.',
@@ -105,9 +104,6 @@ export function getBuckets(defs: D1ManifestDefinitions) {
         type,
         sort,
       };
-      if (bucket.type) {
-        buckets.byType[bucket.type] = bucket;
-      }
       if (sort) {
         // Add an easy helper property like "inPostmaster"
         bucket[`in${sort}`] = true;

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -62,10 +62,10 @@ const sortToVault = {
   General: 138197802,
 };
 
-const typeToSort: { [type: string]: D1BucketCategory } = {};
-_.forIn(D1Categories, (types, category: D1BucketCategory) => {
-  types.forEach((type) => {
-    typeToSort[type] = category;
+const bucketHashToSort: { [bucketHash: number]: D1BucketCategory } = {};
+_.forIn(D1Categories, (bucketHashes, category: D1BucketCategory) => {
+  bucketHashes.forEach((bucketHash) => {
+    bucketHashToSort[bucketHash] = category;
   });
 });
 
@@ -93,12 +93,7 @@ export function getBuckets(defs: D1ManifestDefinitions) {
   _.forIn(defs.InventoryBucket, (def: any) => {
     if (def.enabled) {
       const type = bucketToType[def.hash];
-      let sort: D1BucketCategory | undefined;
-      if (type) {
-        sort = typeToSort[type];
-      } else if (vaultTypes[def.hash]) {
-        sort = vaultTypes[def.hash];
-      }
+      const sort = bucketHashToSort[def.hash] ?? vaultTypes[def.hash];
       const bucket: InventoryBucket = {
         description: def.bucketDescription,
         name: def.bucketName,
@@ -107,7 +102,7 @@ export function getBuckets(defs: D1ManifestDefinitions) {
         capacity: def.itemCount,
         accountWide: false,
         category: BucketCategory.Item,
-        type: bucketToType[def.hash],
+        type,
         sort,
       };
       if (bucket.type) {
@@ -125,8 +120,10 @@ export function getBuckets(defs: D1ManifestDefinitions) {
       bucket.vaultBucket = buckets.byHash[sortToVault[bucket.sort]];
     }
   });
-  _.forIn(D1Categories, (types, category) => {
-    buckets.byCategory[category] = _.compact(types.map((type) => buckets.byType[type]));
+  _.forIn(D1Categories, (bucketHashes, category) => {
+    buckets.byCategory[category] = _.compact(
+      bucketHashes.map((bucketHash) => buckets.byHash[bucketHash])
+    );
   });
   return buckets;
 }

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
@@ -1,8 +1,8 @@
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
-import { bucketsSelector } from 'app/inventory/selectors';
+import { D1BucketHashes } from 'app/search/d1-known-values';
+import { BucketHashes } from 'data/d2/generated-enums';
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
 import BungieImage from '../../dim-ui/BungieImage';
 import { D1GridNode, DimItem } from '../../inventory/item-types';
 import { AppIcon, plusIcon } from '../../shell/icons';
@@ -22,6 +22,16 @@ interface Props {
   onItemLocked(item: DimItem): void;
 }
 
+const typeToHash: { [key in ArmorTypes]: BucketHashes | D1BucketHashes } = {
+  Helmet: BucketHashes.Helmet,
+  Gauntlets: BucketHashes.Gauntlets,
+  Chest: BucketHashes.ChestArmor,
+  Leg: BucketHashes.LegArmor,
+  ClassItem: BucketHashes.ClassArmor,
+  Ghost: BucketHashes.Ghost,
+  Artifact: D1BucketHashes.Artifact,
+};
+
 export default function LoadoutBuilderLockPerk({
   type,
   lockeditem,
@@ -33,7 +43,6 @@ export default function LoadoutBuilderLockPerk({
   onItemLocked,
 }: Props) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const buckets = useSelector(bucketsSelector)!;
 
   const closeDialog = () => setDialogOpen(false);
   const addPerkClicked = () => setDialogOpen(true);
@@ -48,7 +57,7 @@ export default function LoadoutBuilderLockPerk({
 
   return (
     <div className="locked-item">
-      <LoadoutBucketDropTarget bucketHash={buckets.byType[type].hash} onItemLocked={onItemLocked}>
+      <LoadoutBucketDropTarget bucketHash={typeToHash[type]} onItemLocked={onItemLocked}>
         {lockeditem === null ? (
           <div className="empty-item">
             <div className="perk-addition" onClick={addPerkClicked}>

--- a/src/app/destiny2/d2-bucket-categories.ts
+++ b/src/app/destiny2/d2-bucket-categories.ts
@@ -1,20 +1,33 @@
-import type { D2BucketCategory, DimBucketType } from 'app/inventory/inventory-buckets';
+import type { D2BucketCategory } from 'app/inventory/inventory-buckets';
+import { BucketHashes } from 'data/d2/generated-enums';
 
 export const D2Categories: {
-  [key in D2BucketCategory]: DimBucketType[];
+  [key in D2BucketCategory]: BucketHashes[];
 } = {
-  Postmaster: ['Engrams', 'LostItems', 'Messages', 'SpecialOrders'],
-  Weapons: ['KineticSlot', 'Energy', 'Power'],
-  Armor: ['Helmet', 'Gauntlets', 'Chest', 'Leg', 'ClassItem'],
-  General: [
-    'Class',
-    'Ghost',
-    'Emblems',
-    'Ships',
-    'Vehicle',
-    'Emotes',
-    'Finishers',
-    'SeasonalArtifacts',
+  Postmaster: [
+    BucketHashes.Engrams,
+    BucketHashes.LostItems,
+    BucketHashes.Messages,
+    BucketHashes.SpecialOrders,
   ],
-  Inventory: ['Consumables', 'Modifications'],
+  Weapons: [BucketHashes.KineticWeapons, BucketHashes.EnergyWeapons, BucketHashes.PowerWeapons],
+  Armor: [
+    BucketHashes.Helmet,
+    BucketHashes.Gauntlets,
+    BucketHashes.ChestArmor,
+    BucketHashes.LegArmor,
+    BucketHashes.ClassArmor,
+  ],
+  General: [
+    BucketHashes.Subclass,
+    BucketHashes.Ghost,
+    BucketHashes.Emblems,
+    BucketHashes.Ships,
+    BucketHashes.Vehicle,
+    BucketHashes.Emotes_Invisible,
+    BucketHashes.Finishers,
+    BucketHashes.SeasonalArtifact,
+    BucketHashes.ClanBanners,
+  ],
+  Inventory: [BucketHashes.Consumables, BucketHashes.Modifications],
 };

--- a/src/app/destiny2/d2-bucket-categories.ts
+++ b/src/app/destiny2/d2-bucket-categories.ts
@@ -27,7 +27,6 @@ export const D2Categories: {
     BucketHashes.Emotes_Invisible,
     BucketHashes.Finishers,
     BucketHashes.SeasonalArtifact,
-    BucketHashes.ClanBanners,
   ],
   Inventory: [BucketHashes.Consumables, BucketHashes.Modifications],
 };

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -68,7 +68,6 @@ _.forIn(D2Categories, (bucketHashes, category: D2BucketCategory) => {
 export function getBuckets(defs: D2ManifestDefinitions) {
   const buckets: InventoryBuckets = {
     byHash: {},
-    byType: {},
     byCategory: {},
     unknown: {
       description: 'Unknown items. DIM needs a manifest update.',
@@ -100,9 +99,6 @@ export function getBuckets(defs: D2ManifestDefinitions) {
       type,
       sort,
     };
-    if (bucket.type) {
-      buckets.byType[bucket.type] = bucket;
-    }
     // Add an easy helper property like "inPostmaster"
     if (bucket.sort) {
       bucket[`in${bucket.sort}`] = true;

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -45,6 +45,7 @@ const bucketToTypeRaw = {
   [BucketHashes.Quests]: 'Pursuits',
   [BucketHashes.SeasonalArtifact]: 'SeasonalArtifacts',
   [BucketHashes.Finishers]: 'Finishers',
+  [BucketHashes.ClanBanners]: 'ClanBanner',
 } as const;
 
 export type D2BucketTypes = typeof bucketToTypeRaw[keyof typeof bucketToTypeRaw];
@@ -53,14 +54,14 @@ export type D2BucketTypes = typeof bucketToTypeRaw[keyof typeof bucketToTypeRaw]
 export type D2AdditionalBucketTypes = 'Milestone' | 'Unknown';
 
 // A mapping from the bucket hash to DIM item types
-const bucketToType: {
+export const bucketToType: {
   [hash: number]: DimBucketType | undefined;
 } = bucketToTypeRaw;
 
-const typeToSort: { [type: string]: D2BucketCategory } = {};
-_.forIn(D2Categories, (types, category: D2BucketCategory) => {
-  types.forEach((type) => {
-    typeToSort[type] = category;
+const bucketHashToSort: { [bucketHash: number]: D2BucketCategory } = {};
+_.forIn(D2Categories, (bucketHashes, category: D2BucketCategory) => {
+  bucketHashes.forEach((bucketHash) => {
+    bucketHashToSort[bucketHash] = category;
   });
 });
 
@@ -87,10 +88,7 @@ export function getBuckets(defs: D2ManifestDefinitions) {
   };
   _.forIn(defs.InventoryBucket, (def: DestinyInventoryBucketDefinition) => {
     const type = bucketToType[def.hash];
-    let sort: D2BucketCategory | undefined;
-    if (type) {
-      sort = typeToSort[type];
-    }
+    const sort = bucketHashToSort[def.hash];
     const bucket: InventoryBucket = {
       description: def.displayProperties.description,
       name: def.displayProperties.name,
@@ -120,8 +118,10 @@ export function getBuckets(defs: D2ManifestDefinitions) {
       bucket.vaultBucket = buckets.byHash[vaultMappings[bucket.hash]];
     }
   });
-  _.forIn(D2Categories, (types, category) => {
-    buckets.byCategory[category] = _.compact(types.map((type) => buckets.byType[type]));
+  _.forIn(D2Categories, (bucketHashes, category) => {
+    buckets.byCategory[category] = _.compact(
+      bucketHashes.map((bucketHash) => buckets.byHash[bucketHash])
+    );
   });
   return buckets;
 }

--- a/src/app/inventory/inventory-buckets.ts
+++ b/src/app/inventory/inventory-buckets.ts
@@ -31,7 +31,6 @@ export type DimBucketType = D2BucketTypes | D2AdditionalBucketTypes | D1BucketTy
 
 export interface InventoryBuckets {
   byHash: { [hash: number]: InventoryBucket };
-  byType: { [type: string]: InventoryBucket };
   byCategory: { [category: string]: InventoryBucket[] };
   unknown: InventoryBucket; // TODO: get rid of this?
   setHasUnknown(): void;

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -40,11 +40,7 @@ export const bucketsSelector = createSelector(
 /** Bucket hashes for buckets that we actually show on the inventory page. */
 export const displayableBucketHashesSelector = createSelector(bucketsSelector, (buckets) =>
   buckets
-    ? new Set(
-        Object.keys(buckets.byCategory).flatMap((category) =>
-          buckets.byCategory[category].map((b) => b.hash)
-        )
-      )
+    ? new Set(Object.values(buckets.byCategory).flatMap((buckets) => buckets.map((b) => b.hash)))
     : emptySet<number>()
 );
 

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -416,7 +416,7 @@ function downloadWeapons(
       Tier: item.tier,
       Type: item.typeName,
       Source: source(item),
-      Category: item.bucket.type,
+      Category: item.type,
       Element: item.element?.displayProperties.name,
       [item.destinyVersion === 1 ? 'Light' : 'Power']: item.power,
     };

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -217,13 +217,13 @@ function makeItem(
     if (itemDef.classified && itemDef.itemTypeName === 'Unknown') {
       switch (currentBucket.hash) {
         case 4046403665:
-          currentBucket = buckets.byType.Heavy;
+          currentBucket = buckets.byHash[BucketHashes.PowerWeapons];
           break;
         case 3003523923:
-          currentBucket = buckets.byType.ClassItem;
+          currentBucket = buckets.byHash[BucketHashes.ClassArmor];
           break;
         case 138197802:
-          currentBucket = buckets.byType.Artifact;
+          currentBucket = buckets.byHash[D1BucketHashes.Artifact];
           break;
         default:
           break;

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -3,6 +3,7 @@ import { storesSelector } from 'app/inventory/selectors';
 import { SocketOverrides, SocketOverridesForItems } from 'app/inventory/store/override-sockets';
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { pickSubclass } from 'app/loadout/item-utils';
+import { D1BucketHashes } from 'app/search/d1-known-values';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { infoLog } from 'app/utils/log';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
@@ -12,11 +13,7 @@ import produce from 'immer';
 import _ from 'lodash';
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import type {
-  DimBucketType,
-  InventoryBucket,
-  InventoryBuckets,
-} from '../inventory/inventory-buckets';
+import type { InventoryBucket, InventoryBuckets } from '../inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import { DimStore } from '../inventory/store-types';
 import { showItemPicker } from '../item-picker/item-picker';
@@ -32,31 +29,26 @@ import LoadoutDrawerBucket from './LoadoutDrawerBucket';
 import SavedMods from './SavedMods';
 import { Subclass } from './subclass-drawer/Subclass';
 
-const loadoutTypes: DimBucketType[] = [
-  'Primary',
-  'Special',
-  'Heavy',
-  'KineticSlot',
-  'Energy',
-  'Power',
-  'Helmet',
-  'Gauntlets',
-  'Chest',
-  'Leg',
-  'ClassItem',
-  'Class',
-  'Artifact',
-  'Ghost',
-  'Consumable',
-  'Material',
-  'Emblem',
-  'Emblems',
-  'Shader',
-  'Emote',
-  'Ship',
-  'Ships',
-  'Vehicle',
-  'Horn',
+const loadoutTypes: (BucketHashes | D1BucketHashes)[] = [
+  BucketHashes.KineticWeapons,
+  BucketHashes.EnergyWeapons,
+  BucketHashes.PowerWeapons,
+  BucketHashes.Helmet,
+  BucketHashes.Gauntlets,
+  BucketHashes.ChestArmor,
+  BucketHashes.LegArmor,
+  BucketHashes.ClassArmor,
+  D1BucketHashes.Artifact,
+  BucketHashes.Ghost,
+  BucketHashes.Consumables,
+  BucketHashes.Materials,
+  BucketHashes.Emblems,
+  D1BucketHashes.Shader,
+  BucketHashes.Emotes_Invisible,
+  BucketHashes.Emotes_Equippable,
+  BucketHashes.Ships,
+  BucketHashes.Vehicle,
+  D1BucketHashes.Horn,
 ];
 
 export default function LoadoutDrawerContents({
@@ -109,13 +101,13 @@ export default function LoadoutDrawerContents({
     fillLoadoutFromUnequipped(loadout, dimStore, add);
   }
 
-  const availableTypes = _.compact(loadoutTypes.map((type) => buckets.byType[type]));
+  const availableTypes = _.compact(loadoutTypes.map((h) => buckets.byHash[h]));
 
   const [typesWithItems, typesWithoutItems] = _.partition(
     availableTypes,
-    (bucket) => bucket.hash && itemsByBucket[bucket.hash] && itemsByBucket[bucket.hash].length
+    (bucket) => bucket.hash && itemsByBucket[bucket.hash]?.length
   );
-  const subclassBucket = buckets.byType.Class;
+  const subclassBucket = buckets.byHash[BucketHashes.Subclass];
 
   const showFillFromEquipped = typesWithoutItems.some((b) => fromEquippedTypes.includes(b.hash));
 

--- a/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
@@ -17,7 +17,8 @@ export const bucketTypesSelector = createSelector(
     buckets
       ? [
           'postmaster',
-          ...Object.values(buckets.byType).flatMap((bucket) => [
+          // TODO: we don't really need every possible bucket right?
+          ...Object.values(buckets.byHash).flatMap((bucket) => [
             bucket.hash.toString(),
             ...stores.flatMap((store) => `${store.id}-${bucket.hash}`),
           ]),

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -42,13 +42,8 @@ export const fromEquippedTypes: (BucketHashes | D1BucketHashes)[] = [
   BucketHashes.Emblems,
 ];
 
-// TODO (ryan) why is this a thing? Weapons doesn't contain either of these
-const excludeGearSlots = ['Class', 'SeasonalArtifacts'];
 // order to display a list of all 8 gear slots
-const gearSlotOrder: DimItem['type'][] = [
-  ...D2Categories.Weapons.filter((t) => !excludeGearSlots.includes(t)),
-  ...D2Categories.Armor,
-];
+const gearSlotOrder: BucketHashes[] = [...D2Categories.Weapons, ...D2Categories.Armor];
 
 /**
  * Creates a new loadout, with all of the items equipped and the items inserted mods saved.
@@ -266,7 +261,7 @@ export function optimalItemSet(
 
   // Pick the best item
   let items = _.mapValues(itemsByType, (items) => _.maxBy(items, bestItemFn)!);
-  const unrestricted = _.sortBy(Object.values(items), (i) => gearSlotOrder.indexOf(i.type));
+  const unrestricted = _.sortBy(Object.values(items), (i) => gearSlotOrder.indexOf(i.bucket.hash));
 
   // Solve for the case where our optimizer decided to equip two exotics
   const getLabel = (i: DimItem) => i.equippingLabel;
@@ -308,7 +303,7 @@ export function optimalItemSet(
     }
   });
 
-  const equippable = _.sortBy(Object.values(items), (i) => gearSlotOrder.indexOf(i.type));
+  const equippable = _.sortBy(Object.values(items), (i) => gearSlotOrder.indexOf(i.bucket.hash));
 
   return { equippable, unrestricted };
 }

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -1,7 +1,7 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import ClassIcon from 'app/dim-ui/ClassIcon';
 import { t } from 'app/i18next-t';
-import { InventoryBuckets } from 'app/inventory/inventory-buckets';
+import { D2BucketCategory, InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
@@ -131,7 +131,7 @@ export default function LoadoutView({
             {(!isPhonePortrait || subclass) && (
               <LoadoutSubclassSection defs={defs} subclass={subclass} power={power} />
             )}
-            {['Weapons', 'Armor', 'General'].map((category) => (
+            {['Weapons', 'Armor', 'General'].map((category: D2BucketCategory) => (
               <LoadoutItemCategorySection
                 key={category}
                 category={category}

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -1,5 +1,5 @@
 import { t } from 'app/i18next-t';
-import { InventoryBucket } from 'app/inventory/inventory-buckets';
+import { D2BucketCategory, InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { allItemsSelector, bucketsSelector, storesSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
@@ -229,49 +229,53 @@ export default function LoadoutEdit({
           </LoadoutEditBucketDropTarget>
         </LoadoutEditSection>
       )}
-      {(anyClass ? ['Weapons', 'General'] : ['Weapons', 'Armor', 'General']).map((category) => (
-        <LoadoutEditSection
-          key={category}
-          title={t(`Bucket.${category}`, { contextList: 'buckets' })}
-          onClear={() => handleClearCategory(category)}
-          onFillFromEquipped={() =>
-            fillLoadoutFromEquipped(loadout, itemsByBucket, store, updateLoadout, category)
-          }
-          fillFromInventoryCount={getUnequippedItemsForLoadout(store, category).length}
-          onFillFromInventory={() => fillLoadoutFromUnequipped(loadout, store, onAddItem, category)}
-          onClearLoadoutParameters={
-            category === 'Armor' && hasVisibleLoadoutParameters(loadout.parameters)
-              ? handleClearLoadoutParameters
-              : undefined
-          }
-        >
-          <LoadoutEditBucketDropTarget category={category} classType={loadout.classType}>
-            <LoadoutEditBucket
-              category={category}
-              storeId={store.id}
-              items={categories[category]}
-              modsByBucket={modsByBucket}
-              equippedItemIds={equippedItemIds}
-              onClickPlaceholder={onClickPlaceholder}
-              onClickWarnItem={onClickWarnItem}
-              onRemoveItem={onRemoveItem}
-              onToggleEquipped={handleToggleEquipped}
-            >
-              {category === 'Armor' && (
-                <ArmorExtras
-                  loadout={loadout}
-                  storeId={store.id}
-                  subclass={subclass}
-                  items={categories[category]}
-                  savedMods={savedMods}
-                  equippedItemIds={equippedItemIds}
-                  onModsByBucketUpdated={onModsByBucketUpdated}
-                />
-              )}
-            </LoadoutEditBucket>
-          </LoadoutEditBucketDropTarget>
-        </LoadoutEditSection>
-      ))}
+      {(anyClass ? ['Weapons', 'General'] : ['Weapons', 'Armor', 'General']).map(
+        (category: D2BucketCategory) => (
+          <LoadoutEditSection
+            key={category}
+            title={t(`Bucket.${category}`, { contextList: 'buckets' })}
+            onClear={() => handleClearCategory(category)}
+            onFillFromEquipped={() =>
+              fillLoadoutFromEquipped(loadout, itemsByBucket, store, updateLoadout, category)
+            }
+            fillFromInventoryCount={getUnequippedItemsForLoadout(store, category).length}
+            onFillFromInventory={() =>
+              fillLoadoutFromUnequipped(loadout, store, onAddItem, category)
+            }
+            onClearLoadoutParameters={
+              category === 'Armor' && hasVisibleLoadoutParameters(loadout.parameters)
+                ? handleClearLoadoutParameters
+                : undefined
+            }
+          >
+            <LoadoutEditBucketDropTarget category={category} classType={loadout.classType}>
+              <LoadoutEditBucket
+                category={category}
+                storeId={store.id}
+                items={categories[category]}
+                modsByBucket={modsByBucket}
+                equippedItemIds={equippedItemIds}
+                onClickPlaceholder={onClickPlaceholder}
+                onClickWarnItem={onClickWarnItem}
+                onRemoveItem={onRemoveItem}
+                onToggleEquipped={handleToggleEquipped}
+              >
+                {category === 'Armor' && (
+                  <ArmorExtras
+                    loadout={loadout}
+                    storeId={store.id}
+                    subclass={subclass}
+                    items={categories[category]}
+                    savedMods={savedMods}
+                    equippedItemIds={equippedItemIds}
+                    onModsByBucketUpdated={onModsByBucketUpdated}
+                  />
+                )}
+              </LoadoutEditBucket>
+            </LoadoutEditBucketDropTarget>
+          </LoadoutEditSection>
+        )
+      )}
       <LoadoutEditSection
         title={t('Loadouts.Mods')}
         className={styles.mods}

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -2,7 +2,7 @@ import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
-import { InventoryBucket } from 'app/inventory/inventory-buckets';
+import { D2BucketCategory, InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { bucketsSelector } from 'app/inventory/selectors';
@@ -44,7 +44,7 @@ export default function LoadoutEditBucket({
   onToggleEquipped,
   children,
 }: {
-  category: string;
+  category: D2BucketCategory;
   storeId: string;
   items?: DimItem[];
   modsByBucket: {

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -1,6 +1,7 @@
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import DraggableInventoryItem from 'app/inventory/DraggableInventoryItem';
+import { D2BucketCategory } from 'app/inventory/inventory-buckets';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { bucketsSelector } from 'app/inventory/selectors';
@@ -38,7 +39,7 @@ export default function LoadoutItemCategorySection({
   loadout,
   hideOptimizeArmor,
 }: {
-  category: string;
+  category: D2BucketCategory;
   subclass?: DimLoadoutItem;
   storeId?: string;
   items?: DimLoadoutItem[];

--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -181,6 +181,13 @@ const d2SelectionTree: ItemCategoryTreeNode = {
           subCategories: [kinetic, energy, power],
           terminal: true,
         },
+        {
+          id: 'glaive',
+          // TODO: glaive item category hash
+          itemCategoryHash: 0,
+          subCategories: [kinetic, energy, power],
+          terminal: true,
+        },
       ],
     },
     {

--- a/src/app/progress/SolsticeOfHeroes.tsx
+++ b/src/app/progress/SolsticeOfHeroes.tsx
@@ -57,6 +57,6 @@ export function solsticeOfHeroesArmor(allItems: DimItem[], selectedStore: DimSto
         getEvent(item) === D2EventEnum.SOLSTICE_OF_HEROES &&
         getSeason(item) === 14
     ),
-    (i) => D2Categories.Armor.indexOf(i.type)
+    (i) => D2Categories.Armor.indexOf(i.bucket.hash)
   );
 }

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -18,7 +18,7 @@ import {
   DestinyObjectiveProgress,
   DestinyRecordState,
 } from 'bungie-api-ts/destiny2';
-import { ItemCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 
 export function milestoneToItems(
@@ -226,13 +226,14 @@ function makeFakePursuitItem(
   typeName: string,
   store: DimStore
 ): DimItem {
+  const bucket = buckets.byHash[BucketHashes.Quests];
   return {
     // figure out what year this item is probably from
     destinyVersion: 2,
     // The bucket the item is currently in
-    location: buckets.byType.Pursuits,
+    location: bucket,
     // The bucket the item normally resides in (even though it may be in the vault/postmaster)
-    bucket: buckets.byType.Pursuits,
+    bucket: bucket,
     hash,
     // This is the type of the item (see DimCategory/DimBuckets) regardless of location
     type: 'Milestone',

--- a/src/app/search/search-filters/known-values.tsx
+++ b/src/app/search/search-filters/known-values.tsx
@@ -1,4 +1,5 @@
 import { D2Categories } from 'app/destiny2/d2-bucket-categories';
+import { bucketToType } from 'app/destiny2/d2-buckets';
 import { tl } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { getEvent } from 'app/inventory/store/season';
@@ -68,7 +69,13 @@ export const classFilter: FilterDefinition = {
 export const itemTypeFilter: FilterDefinition = {
   keywords: Object.values(D2Categories) // stuff like Engrams, Kinetic, Gauntlets, Emblems, Finishers, Modifications
     .flat()
-    .map((v) => v.toLowerCase()),
+    .map((v) => {
+      const type = bucketToType[v];
+      if (!type && $DIM_FLAVOR === 'dev') {
+        throw new Error(`You forgot to map a string type name for bucket hash ${v}`);
+      }
+      return type!.toLowerCase();
+    }),
   description: tl('Filter.ArmorCategory'), // or 'Filter.WeaponClass'
   filter:
     ({ filterValue }) =>

--- a/src/app/store-stats/VaultCapacity.tsx
+++ b/src/app/store-stats/VaultCapacity.tsx
@@ -47,7 +47,7 @@ interface VaultCounts {
 function computeVaultCounts(activeStore: DimStore, vault: DimStore, buckets: InventoryBuckets) {
   const vaultCounts: VaultCounts = {};
 
-  for (const bucket of Object.values(buckets.byType)) {
+  for (const bucket of Object.values(buckets.byHash)) {
     // If this bucket can have items placed in the vault, count up how many of
     // that type are in the vault.
     if (bucket.vaultBucket) {


### PR DESCRIPTION
This removes `buckets.byType` and converts a lot of its previous usages over to bucket hash. It also switches bucket categories over to hashes instead of types.

I can't quite remember if there was more to do here...