### PR TITLE
Loadout dates

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -189,6 +189,7 @@ export default function LoadoutDrawer() {
     const newLoadout = {
       ...loadout,
       id: uuidv4(), // Let it be a new ID
+      createdAt: Date.now(),
     };
     onSaveLoadout(e, newLoadout);
   };

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -196,6 +196,7 @@ export default function LoadoutDrawer2() {
       loadoutToSave = {
         ...loadout,
         id: uuidv4(), // Let it be a new ID
+        createdAt: Date.now(),
       };
     }
 

--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -21,6 +21,10 @@
     flex-direction: column;
     align-items: flex-start;
   }
+
+  :global(.app-icon) {
+    font-size: 12px;
+  }
 }
 
 .actions {

--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -66,3 +66,9 @@
   margin: 4px 0;
   white-space: pre-wrap;
 }
+
+.season {
+  height: 24px;
+  width: 24px;
+  vertical-align: bottom;
+}

--- a/src/app/loadout/LoadoutView.m.scss.d.ts
+++ b/src/app/loadout/LoadoutView.m.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'loadout': string;
   'loadoutNotes': string;
   'missingItems': string;
+  'season': string;
   'title': string;
 }
 export const cssExports: CssExports;

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -1,4 +1,5 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import BungieImage from 'app/dim-ui/BungieImage';
 import ClassIcon from 'app/dim-ui/ClassIcon';
 import { t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
@@ -9,7 +10,7 @@ import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conver
 import { DimLoadoutItem, Loadout, LoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
+import { AppIcon, faExclamationTriangle, faTshirt } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
@@ -119,6 +120,13 @@ export default function LoadoutView({
 
   // TODO: auto icons for fashion, weapon/armor/mods?
 
+  const createdAt = loadout.createdAt ? new Date(loadout.createdAt) : undefined;
+  const seasonNum = createdAt ? findSeason(createdAt)?.season : undefined;
+  const season = seasonNum
+    ? Object.values(defs.Season.getAll()).find((s) => s.seasonNumber === seasonNum)
+    : undefined;
+  const hasFashion = loadout.parameters?.modsByBucket;
+
   return (
     <div className={styles.loadout} id={loadout.id}>
       <div className={styles.title}>
@@ -126,6 +134,8 @@ export default function LoadoutView({
           {loadout.classType === DestinyClass.Unknown && (
             <ClassIcon className={styles.classIcon} classType={loadout.classType} />
           )}
+          {season && <BungieImage className={styles.season} src={season.displayProperties.icon} />}
+          {hasFashion && <AppIcon icon={faTshirt} />}
           {loadout.name}
           {warnitems.length > 0 && (
             <span className={styles.missingItems}>

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -15,6 +15,7 @@ import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { count } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { D2SeasonInfo } from 'data/d2/d2-season-info';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { ReactNode, useMemo } from 'react';
@@ -53,6 +54,15 @@ export function getItemsAndSubclassFromLoadout(
   }
 
   return [items, subclass, warnitems];
+}
+
+function findSeason(date: Date) {
+  for (const season of Object.values(D2SeasonInfo).reverse()) {
+    const seasonDate = new Date(`${season.releaseDate}T${season.resetTime}`);
+    if (seasonDate.getTime() < date.getTime()) {
+      return season;
+    }
+  }
 }
 
 /**
@@ -107,6 +117,8 @@ export default function LoadoutView({
     ? Math.floor(getLight(store, [...categories.Weapons, ...categories.Armor]))
     : 0;
 
+  // TODO: auto icons for fashion, weapon/armor/mods?
+
   return (
     <div className={styles.loadout} id={loadout.id}>
       <div className={styles.title}>
@@ -122,6 +134,13 @@ export default function LoadoutView({
             </span>
           )}
         </h2>
+        {loadout.createdAt !== undefined && loadout.lastUpdatedAt !== undefined && (
+          <div>
+            {findSeason(new Date(loadout.createdAt))?.seasonName}
+            {new Date(loadout.createdAt).toLocaleDateString()}{' '}
+            {new Date(loadout.lastUpdatedAt).toLocaleDateString()}
+          </div>
+        )}
         <div className={styles.actions}>{actionButtons}</div>
       </div>
       {loadout.notes && <div className={styles.loadoutNotes}>{loadout.notes}</div>}


### PR DESCRIPTION
This isn't fully formed but I wanted to get people's thoughts on the direction:

<img width="230" alt="Screen Shot 2022-03-02 at 4 50 16 PM" src="https://user-images.githubusercontent.com/313208/156455486-1444e002-0c75-41f6-b7a2-81a6c3db9c90.png">

I'm adding an automatic season icon based on when the loadout was created. I can also show the created and updated dates somewhere. I also played around with adding a t-shirt for loadouts with fashion but I'm not sure how I feel about it.