### PR TITLE
More efficient canDrag

### DIFF
--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -13,7 +13,12 @@ interface Props {
 let dragTimeout: number | null = null;
 
 export default function DraggableInventoryItem({ children, item }: Props) {
-  const [{ canDrag }, dragRef] = useDrag<DimItem, unknown, { canDrag: boolean }>(
+  const canDrag =
+    (!item.location.inPostmaster || item.destinyVersion === 2) && item.notransfer
+      ? item.equipment
+      : item.equipment || item.bucket.hasTransferDestination;
+
+  const [_collect, dragRef] = useDrag<DimItem>(
     () => ({
       type: item.location.inPostmaster
         ? 'postmaster'
@@ -37,14 +42,11 @@ export default function DraggableInventoryItem({ children, item }: Props) {
         document.body.classList.remove('drag-perf-show');
         isDragging$.next(false);
       },
-      canDrag: () =>
-        (!item.location.inPostmaster || item.destinyVersion === 2) && item.notransfer
-          ? item.equipment
-          : item.equipment || item.bucket.hasTransferDestination,
-      collect: (monitor) => ({ canDrag: monitor.canDrag() }),
+      canDrag,
     }),
     [item]
   );
+
   return (
     <div
       ref={dragRef}


### PR DESCRIPTION
@nev-r you were right in the first place - using the `collect` property causes a bunch of re-renders... like, all of the items re-render when a drag starts. No need for that when canDrag is immutable!