### PR TITLE
Make fake D1 items for loadout warnItems

### DIFF
--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -61,7 +61,7 @@ export interface D1ItemComponent {
   stackSize: number;
   qualityLevel: number;
   stats: D1Stat[];
-  primaryStat: D1Stat;
+  primaryStat?: D1Stat;
   canEquip: boolean;
   equipRequiredLevel: number;
   unlockFlagHashRequiredToEquip: number;
@@ -70,7 +70,7 @@ export interface D1ItemComponent {
   damageTypeHash: number;
   damageTypeNodeIndex: number;
   damageTypeStepIndex: number;
-  progression: {
+  progression?: {
     dailyProgress: number;
     weeklyProgress: number;
     currentProgress: number;

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -13,11 +13,16 @@ import { getItemYear } from 'app/utils/item-utils';
 import { errorLog, warnLog } from 'app/utils/log';
 import {
   BucketCategory,
+  DamageType,
   DestinyAmmunitionType,
   DestinyClass,
   DestinyDamageTypeDefinition,
   DestinyDisplayPropertiesDefinition,
   DestinyStatCategory,
+  ItemBindStatus,
+  ItemLocation,
+  ItemState,
+  TransferStatuses,
 } from 'bungie-api-ts/destiny2';
 import missingSources from 'data/d1/missing_sources.json';
 import { BucketHashes, ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
@@ -27,7 +32,7 @@ import { D1ManifestDefinitions, DefinitionTable } from '../../destiny1/d1-defini
 import { reportException } from '../../utils/exceptions';
 import { InventoryBuckets } from '../inventory-buckets';
 import { D1GridNode, D1Item, D1Stat, D1TalentGrid } from '../item-types';
-import { D1Store } from '../store-types';
+import { D1Store, DimStore } from '../store-types';
 import { getQualityRating } from './armor-quality';
 import { getBonus } from './character-utils';
 import { createItemIndex } from './item-index';
@@ -106,6 +111,50 @@ const toD2DamageType = _.memoize(
     }
 );
 
+export function makeFakeItem(
+  defs: D1ManifestDefinitions,
+  buckets: InventoryBuckets,
+  itemHash: number,
+  itemInstanceId = '0'
+) {
+  return makeItem(
+    defs,
+    buckets,
+    {
+      itemHash,
+      itemInstanceId,
+      bindStatus: ItemBindStatus.NotBound,
+      location: ItemLocation.Vendor,
+      transferStatus: TransferStatuses.NotTransferrable,
+      lockable: false,
+      state: ItemState.None,
+      isEquipped: false,
+      itemLevel: 0,
+      stackSize: 1,
+      qualityLevel: 0,
+      canEquip: false,
+      equipRequiredLevel: 0,
+      unlockFlagHashRequiredToEquip: 0,
+      stats: [],
+      cannotEquipReason: 0,
+      damageType: DamageType.None,
+      damageTypeHash: 0,
+      damageTypeNodeIndex: 0,
+      damageTypeStepIndex: 0,
+      talentGridHash: 0,
+      nodes: [],
+      useCustomDyes: false,
+      isEquipment: false,
+      isGridComplete: false,
+      perks: [],
+      locked: false,
+      objectives: [],
+      bucket: 0,
+    },
+    undefined
+  );
+}
+
 /**
  * Process a single raw item into a DIM item.
  * @param defs the manifest definitions
@@ -119,7 +168,7 @@ function makeItem(
   defs: D1ManifestDefinitions,
   buckets: InventoryBuckets,
   item: D1ItemComponent,
-  owner: D1Store
+  owner: DimStore | undefined
 ) {
   const itemDef = defs.InventoryItem.get(item.itemHash);
   // Missing definition?
@@ -220,7 +269,7 @@ function makeItem(
   }
 
   const createdItem: D1Item = {
-    owner: owner.id,
+    owner: owner?.id || 'unknown',
     // figure out what year this item is probably from
     destinyVersion: 1,
     // The bucket the item is currently in

--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -109,8 +109,10 @@ export default function LoadoutDrawer() {
     stateDispatch({ type: 'applySocketOverrides', item, socketOverrides });
   }, []);
 
-  const onRemoveItem = (item: DimItem, e?: React.MouseEvent) =>
+  const onRemoveItem = (item: DimItem, e?: React.MouseEvent) => {
+    e?.stopPropagation();
     stateDispatch({ type: 'removeItem', item, shift: Boolean(e?.shiftKey), items });
+  };
 
   const onEquipItem = (item: DimItem) => stateDispatch({ type: 'equipItem', item, items });
 
@@ -262,7 +264,7 @@ export default function LoadoutDrawer() {
                       className="loadout-item"
                       onClick={() => fixWarnItem(item)}
                     >
-                      <ClosableContainer onClose={() => onRemoveItem(item)}>
+                      <ClosableContainer onClose={(e) => onRemoveItem(item, e)}>
                         <ItemIcon item={item} />
                       </ClosableContainer>
                     </div>


### PR DESCRIPTION
Fixes #8018, by making fully featured fake items and skipping over the ones we can't construct.