### PR TITLE
Further distinguish pointer handling for PressTip

### DIFF
--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -109,7 +109,8 @@ function Control({
 
 const isPointerEvents = 'onpointerdown' in window;
 const isTouch = 'ontouchstart' in window;
-const hoverDelay = isTouch ? 300 : 100;
+const hoverable = window.matchMedia('(hover: hover)').matches;
+const hoverDelay = hoverable ? 100 : 300;
 
 /**
  * A "press tip" is a tooltip that can be shown by pressing on an element, or via hover.
@@ -183,21 +184,31 @@ function PressTip(props: Props) {
   }, [hover]);
 
   const events = isPointerEvents
-    ? {
-        onPointerOver: hover,
-        onPointerDown: hover,
-        onPointerLeave: closeToolTip,
-        onPointerUp: closeToolTip,
-        onClick: absorbClick,
-      }
+    ? hoverable
+      ? // Mouse/hoverpen based devices with pointer events
+        {
+          onPointerOver: hover,
+          onPointerLeave: closeToolTip,
+          onPointerUp: closeToolTip,
+        }
+      : // Touch-based devices with pointer events
+        {
+          onPointerOver: hover,
+          onPointerDown: hover,
+          onPointerLeave: closeToolTip,
+          onPointerUp: closeToolTip,
+          onClick: absorbClick,
+        }
     : isTouch
-    ? {
+    ? // Touch-based devices without pointer events
+      {
         // onTouchStart is handled specially above
         onTouchEnd: closeToolTip,
         onTouchCancel: closeToolTip,
         onClick: absorbClick,
       }
-    : {
+    : // Mouse based devices without pointer events
+      {
         onMouseEnter: hover,
         onMouseUp: closeToolTip,
         onMouseLeave: closeToolTip,

--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -109,7 +109,7 @@ function Control({
 
 const isPointerEvents = 'onpointerdown' in window;
 const isTouch = 'ontouchstart' in window;
-const hoverable = window.matchMedia('(hover: hover)').matches;
+const hoverable = window.matchMedia?.('(hover: hover)').matches;
 const hoverDelay = hoverable ? 100 : 300;
 
 /**


### PR DESCRIPTION
With my previous change I used one set of events for both pointery and touchy devices, which led to a bit of an issue if you click (mouse down and up) in >100ms. This separates them out again based on whether the UA reports itself as being hover capable.

I've tested on Chrome, iOS simulator (iPhone) and iOS simulator (iPad with simulated attached touchpad) and they seem to work as intended. Note that this overall works a lot better on iPhone because press and hold no longer triggers a selection with these events.