### PR TITLE
Remove shift key handling from loadouts

### DIFF
--- a/src/app/item-actions/ActionButtons.tsx
+++ b/src/app/item-actions/ActionButtons.tsx
@@ -176,9 +176,9 @@ export function LoadoutActionButton({
     return null;
   }
 
-  const addToLoadout = (e: React.MouseEvent) => {
+  const addToLoadout = () => {
     hideItemPopup();
-    addItemToLoadout(item, e);
+    addItemToLoadout(item);
   };
 
   return (

--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -68,11 +68,10 @@ export default function LoadoutDrawer() {
   );
 
   const onAddItem = useCallback(
-    ({ item, e, equip }: { item: DimItem; e?: MouseEvent | React.MouseEvent; equip?: boolean }) =>
+    (item: DimItem, equip?: boolean) =>
       stateDispatch({
         type: 'addItem',
         item,
-        shift: Boolean(e?.shiftKey),
         items,
         equip,
         stores,
@@ -82,7 +81,7 @@ export default function LoadoutDrawer() {
 
   const onRemoveItem = (item: DimItem, e?: React.MouseEvent) => {
     e?.stopPropagation();
-    stateDispatch({ type: 'removeItem', item, shift: Boolean(e?.shiftKey), items });
+    stateDispatch({ type: 'removeItem', item, items });
   };
 
   const onEquipItem = (item: DimItem) => stateDispatch({ type: 'equipItem', item, items });
@@ -90,10 +89,7 @@ export default function LoadoutDrawer() {
   /**
    * If an item comes in on the addItem$ rx observable, add it.
    */
-  useEventBusListener(
-    addItem$,
-    useCallback(({ item, clickEvent }) => onAddItem({ item, e: clickEvent }), [onAddItem])
-  );
+  useEventBusListener(addItem$, onAddItem);
 
   const close = () => {
     stateDispatch({ type: 'reset' });
@@ -125,7 +121,7 @@ export default function LoadoutDrawer() {
         ignoreSelectedPerks: true,
       });
 
-      onAddItem({ item });
+      onAddItem(item);
       onRemoveItem(warnItem);
     } catch (e) {
     } finally {
@@ -166,8 +162,6 @@ export default function LoadoutDrawer() {
     onSaveLoadout(e, newLoadout);
   };
 
-  const onDroppedItem = useCallback((item) => onAddItem({ item }), [onAddItem]);
-
   if (!loadout) {
     return null;
   }
@@ -207,7 +201,7 @@ export default function LoadoutDrawer() {
     <Sheet onClose={close} header={header} disabled={showingItemPicker}>
       <div className="loadout-drawer loadout-create">
         <div className="loadout-content">
-          <LoadoutDrawerDropTarget onDroppedItem={onDroppedItem} classType={loadout.classType}>
+          <LoadoutDrawerDropTarget onDroppedItem={onAddItem} classType={loadout.classType}>
             {warnitems.length > 0 && (
               <div className="loadout-contents">
                 <p>

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -148,11 +148,10 @@ export default function LoadoutDrawer2() {
   const itemsByBucket = _.groupBy(items, (i) => i.bucket.hash);
 
   const onAddItem = useCallback(
-    (item: DimItem, e?: MouseEvent | React.MouseEvent, equip?: boolean) =>
+    (item: DimItem, equip?: boolean) =>
       stateDispatch({
         type: 'addItem',
         item,
-        shift: Boolean(e?.shiftKey),
         items,
         equip,
         stores,
@@ -163,10 +162,7 @@ export default function LoadoutDrawer2() {
   /**
    * If an item comes in on the addItem$ observable, add it.
    */
-  useEventBusListener(
-    addItem$,
-    useCallback(({ item, clickEvent }) => onAddItem(item, clickEvent), [onAddItem])
-  );
+  useEventBusListener(addItem$, onAddItem);
 
   const close = () => {
     stateDispatch({ type: 'reset' });
@@ -226,8 +222,7 @@ export default function LoadoutDrawer2() {
   const handleNameChanged = (name: string) =>
     stateDispatch({ type: 'update', loadout: { ...loadout, name } });
 
-  const handleRemoveItem = (item: DimItem, e?: React.MouseEvent) =>
-    stateDispatch({ type: 'removeItem', item, shift: Boolean(e?.shiftKey), items });
+  const handleRemoveItem = (item: DimItem) => stateDispatch({ type: 'removeItem', item, items });
 
   /** Prompt the user to select a replacement for a missing item. */
   const fixWarnItem = async (warnItem: DimItem) => {
@@ -283,12 +278,7 @@ export default function LoadoutDrawer2() {
     bucket: InventoryBucket;
     equip: boolean;
   }) => {
-    pickLoadoutItem(
-      loadout,
-      bucket,
-      ({ item }) => onAddItem(item, undefined, equip),
-      setShowingItemPicker
-    );
+    pickLoadoutItem(loadout, bucket, (item) => onAddItem(item, equip), setShowingItemPicker);
   };
   const handleClickSubclass = (subclass: DimItem | undefined) =>
     pickLoadoutSubclass(
@@ -363,11 +353,7 @@ export default function LoadoutDrawer2() {
           <button
             type="button"
             className="dim-button"
-            onClick={() =>
-              fillLoadoutFromUnequipped(loadout, store, ({ item }) =>
-                onAddItem(item, undefined, false)
-              )
-            }
+            onClick={() => fillLoadoutFromUnequipped(loadout, store, onAddItem)}
           >
             <AppIcon icon={addIcon} /> {t('Loadouts.FillFromInventory')}
           </button>
@@ -422,7 +408,7 @@ function filterLoadoutToAllowedItems(
 async function pickLoadoutItem(
   loadout: Loadout,
   bucket: InventoryBucket,
-  add: (params: { item: DimItem }) => void,
+  add: (item: DimItem) => void,
   onShowItemPicker: (shown: boolean) => void
 ) {
   const loadoutClassType = loadout?.classType;
@@ -448,7 +434,7 @@ async function pickLoadoutItem(
       ignoreSelectedPerks: true,
     });
 
-    add({ item });
+    add(item);
   } catch (e) {
   } finally {
     onShowItemPicker(false);

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -1,6 +1,5 @@
 import { t } from 'app/i18next-t';
 import { storesSelector } from 'app/inventory/selectors';
-import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
@@ -60,7 +59,7 @@ export default function LoadoutDrawerContents({
   items: DimItem[];
   equip(item: DimItem, e: React.MouseEvent): void;
   remove(item: DimItem, e: React.MouseEvent): void;
-  add(params: { item: DimItem; equip?: boolean; socketOverrides?: SocketOverrides }): void;
+  add(item: DimItem, equip?: boolean): void;
   onUpdateLoadout(loadout: Loadout): void;
   onShowItemPicker(shown: boolean): void;
 }) {
@@ -137,7 +136,7 @@ export default function LoadoutDrawerContents({
 async function pickLoadoutItem(
   loadout: Loadout,
   bucket: InventoryBucket,
-  add: (params: { item: DimItem }) => void,
+  add: (item: DimItem) => void,
   onShowItemPicker: (shown: boolean) => void
 ) {
   const loadoutClassType = loadout?.classType;
@@ -163,7 +162,7 @@ async function pickLoadoutItem(
       ignoreSelectedPerks: true,
     });
 
-    add({ item });
+    add(item);
   } catch (e) {
   } finally {
     onShowItemPicker(false);
@@ -215,7 +214,7 @@ function fillLoadoutFromEquipped(
 async function fillLoadoutFromUnequipped(
   loadout: Loadout,
   dimStore: DimStore,
-  add: (params: { item: DimItem; equip?: boolean }) => void,
+  add: (item: DimItem, equip?: boolean) => void,
   category?: string
 ) {
   if (!loadout) {
@@ -226,7 +225,7 @@ async function fillLoadoutFromUnequipped(
 
   // TODO: this isn't right - `items` isn't being updated after each add
   for (const item of items) {
-    add({ item, equip: false });
+    add(item, false);
   }
 }
 

--- a/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
@@ -35,7 +35,7 @@ export default function LoadoutDrawerDropTarget({
   children?: React.ReactNode;
   className?: string;
   classType: DestinyClass;
-  onDroppedItem(item: DimItem, e?: React.MouseEvent, equip?: boolean): void;
+  onDroppedItem(item: DimItem, equip?: boolean): void;
 }) {
   const bucketTypes = useSelector(bucketTypesSelector);
 
@@ -44,7 +44,7 @@ export default function LoadoutDrawerDropTarget({
       accept: bucketTypes,
       drop: (item: DimItem, monitor: DropTargetMonitor<DimItem, { equipped: boolean }>) => {
         const result = monitor.getDropResult();
-        onDroppedItem(item, undefined, result?.equipped);
+        onDroppedItem(item, result?.equipped);
       },
       canDrop: (i) =>
         itemCanBeInLoadout(i) &&

--- a/src/app/loadout-drawer/loadout-events.ts
+++ b/src/app/loadout-drawer/loadout-events.ts
@@ -8,10 +8,7 @@ export const editLoadout$ = new EventBus<{
   isNew?: boolean;
   storeId: string;
 }>();
-export const addItem$ = new EventBus<{
-  item: DimItem;
-  clickEvent: MouseEvent | React.MouseEvent;
-}>();
+export const addItem$ = new EventBus<DimItem>();
 
 /**
  * Start editing a loadout.
@@ -32,9 +29,6 @@ export function editLoadout(
 /**
  * Add an item to the loadout we're currently editing. This is driven by clicks in Inventory.
  */
-export function addItemToLoadout(item: DimItem, $event: MouseEvent | React.MouseEvent) {
-  addItem$.next({
-    item,
-    clickEvent: $event,
-  });
+export function addItemToLoadout(item: DimItem) {
+  addItem$.next(item);
 }

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -101,7 +101,7 @@ export default function LoadoutEdit({
     // TODO: do these all in one action
     for (const item of items.concat(warnitems)) {
       if (item.bucket.sort === category && item.bucket.hash !== BucketHashes.Subclass) {
-        stateDispatch({ type: 'removeItem', item, items, shift: false });
+        stateDispatch({ type: 'removeItem', item, items });
       }
     }
   };
@@ -109,17 +109,15 @@ export default function LoadoutEdit({
   const handleClearSubclass = () => {
     // TODO: do these all in one action
     if (subclass) {
-      stateDispatch({ type: 'removeItem', item: subclass, items, shift: false });
+      stateDispatch({ type: 'removeItem', item: subclass, items });
     }
   };
 
-  const updateLoadout = (loadout: Loadout) => {
-    stateDispatch({ type: 'update', loadout });
-  };
+  const updateLoadout = (loadout: Loadout) => stateDispatch({ type: 'update', loadout });
 
   const onAddItem = useCallback(
-    ({ item, equip }: { item: DimItem; equip?: boolean }) =>
-      stateDispatch({ type: 'addItem', item, stores, shift: false, items, equip }),
+    (item: DimItem, equip?: boolean) =>
+      stateDispatch({ type: 'addItem', item, stores, items, equip }),
     [items, stores, stateDispatch]
   );
 
@@ -414,7 +412,7 @@ export function fillLoadoutFromEquipped(
 export async function fillLoadoutFromUnequipped(
   loadout: Loadout,
   dimStore: DimStore,
-  add: (params: { item: DimItem; equip?: boolean }) => void,
+  add: (item: DimItem, equip?: boolean) => void,
   category?: string
 ) {
   if (!loadout) {
@@ -425,7 +423,7 @@ export async function fillLoadoutFromUnequipped(
 
   // TODO: this isn't right - `items` isn't being updated after each add
   for (const item of items) {
-    add({ item, equip: false });
+    add(item, false);
   }
 }
 


### PR DESCRIPTION
This was around since the D1 days to more easily add big stacks of consumables, but it just complicates things. Easier to remove it.