### PR TITLE
Rename loadout item "equipped" to "equip" in order to separate it from DimItem

### DIFF
--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -344,7 +344,7 @@ async function transferItems(
         id: '0',
         hash: 937555249,
         amount: 2,
-        equipped: false,
+        equip: false,
       });
     } else if (target.bucket.sort === 'Weapons') {
       // Weapon Parts
@@ -352,7 +352,7 @@ async function transferItems(
         id: '0',
         hash: 1898539128,
         amount: 10,
-        equipped: false,
+        equip: false,
       });
     } else {
       // Armor Materials
@@ -360,7 +360,7 @@ async function transferItems(
         id: '0',
         hash: 1542293174,
         amount: 10,
-        equipped: false,
+        equip: false,
       });
     }
     if (source.isExotic) {
@@ -369,7 +369,7 @@ async function transferItems(
         id: '0',
         hash: 452597397,
         amount: 1,
-        equipped: false,
+        equip: false,
       });
     }
   }

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -109,7 +109,7 @@ export default function CompareDrawer({
 
   // This probably isn't needed but I am being cautious as it iterates over the stores.
   const { loadoutItems, loadoutSubclass } = useMemo(() => {
-    const equippedItems = selectedLoadout?.items.filter((item) => item.equipped);
+    const equippedItems = selectedLoadout?.items.filter((item) => item.equip);
     const [items] = getItemsFromLoadoutItems(
       equippedItems,
       defs,

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -72,7 +72,7 @@ function GeneratedSet({
   let displayedItems: DimItem[] = set.armor.map((items) => items[0]);
 
   for (const loadout of loadouts) {
-    const equippedLoadoutItems = loadout.items.filter((item) => item.equipped);
+    const equippedLoadoutItems = loadout.items.filter((item) => item.equip);
     const allSetItems = set.armor.flat();
     const intersection = _.intersectionBy(allSetItems, equippedLoadoutItems, (item) => item.id);
     if (intersection.length === set.armor.length) {

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -112,7 +112,7 @@ const lbStateInit = ({
       selectedStoreId = loadoutStore.id;
       // TODO: instead of locking items, show the loadout fixed at the top to compare against and leave all items free
       for (const loadoutItem of preloadedLoadout.items) {
-        if (loadoutItem.equipped) {
+        if (loadoutItem.equip) {
           const allItems = stores.flatMap((s) => s.items);
           const item = findItemForLoadout(defs, allItems, selectedStoreId, loadoutItem);
           if (item && isLoadoutBuilderItem(item)) {
@@ -136,7 +136,7 @@ const lbStateInit = ({
 
       if (!loadoutParams.exoticArmorHash) {
         const equippedExotic = preloadedLoadout.items
-          .filter((li) => li.equipped)
+          .filter((li) => li.equip)
           .map((li) => defs.InventoryItem.get(li.hash))
           .find(
             (i) =>

--- a/src/app/loadout-drawer/LoadoutDrawerBucket.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerBucket.tsx
@@ -30,13 +30,13 @@ export default function LoadoutDrawerBucket({
   const itemSortOrder = useSelector(itemSortOrderSelector);
   const equippedItems = sortItems(
     items.filter((i) =>
-      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && li.equipped)
+      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && li.equip)
     ),
     itemSortOrder
   );
   const unequippedItems = sortItems(
     items.filter((i) =>
-      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && !li.equipped)
+      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && !li.equip)
     ),
     itemSortOrder
   );

--- a/src/app/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContents.tsx
@@ -189,7 +189,7 @@ function fillLoadoutFromEquipped(
       (bucketItem) =>
         loadout.items.find(
           (loadoutItem) => bucketItem.hash === loadoutItem.hash && bucketItem.id === loadoutItem.id
-        )?.equipped
+        )?.equip
     );
 
   const newLoadout = produce(loadout, (draftLoadout) => {
@@ -198,7 +198,7 @@ function fillLoadoutFromEquipped(
         const loadoutItem: LoadoutItem = {
           id: item.id,
           hash: item.hash,
-          equipped: true,
+          equip: true,
           amount: 1,
         };
         draftLoadout.items.push(loadoutItem);

--- a/src/app/loadout-drawer/LoadoutPopup.tsx
+++ b/src/app/loadout-drawer/LoadoutPopup.tsx
@@ -379,6 +379,6 @@ export default connect<StoreProps, {}, ProvidedProps>(mapStateToProps)(LoadoutPo
 function filterLoadoutToEquipped(loadout: Loadout) {
   return {
     ...loadout,
-    items: loadout.items.filter((i) => i.equipped),
+    items: loadout.items.filter((i) => i.equip),
   };
 }

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -241,7 +241,7 @@ function doApplyLoadout(
             const item = getLoadoutItem(loadoutItem)!;
             state.itemStates[item.index] = {
               item,
-              equip: loadoutItem.equipped,
+              equip: loadoutItem.equip,
               state: LoadoutItemState.Pending,
             };
           }
@@ -288,7 +288,7 @@ function doApplyLoadout(
               item.location.inPostmaster ||
               // Needs to be equipped. Stuff not marked "equip" doesn't
               // necessarily mean to de-equip it.
-              (loadoutItem.equipped && !item.equipped) ||
+              (loadoutItem.equip && !item.equipped) ||
               // We always try to move consumable stacks because their logic is complicated
               (loadoutItem.amount && loadoutItem.amount > 1));
 
@@ -309,16 +309,16 @@ function doApplyLoadout(
       // The vault can't equip items, so set equipped to false
       if (store.isVault) {
         for (const loadoutItem of loadoutItemsToMove) {
-          loadoutItem.equipped = false;
+          loadoutItem.equip = false;
         }
       }
 
-      let itemsToEquip = loadoutItemsToMove.filter((i) => i.equipped);
+      let itemsToEquip = loadoutItemsToMove.filter((i) => i.equip);
       // If we need to equip many items at once, we'll use a single bulk-equip later
       if (itemsToEquip.length > 1) {
         // TODO: just set a bulkEquip flag
         itemsToEquip.forEach((i) => {
-          i.equipped = false;
+          i.equip = false;
         });
       }
 
@@ -645,7 +645,7 @@ function applyLoadoutItem(
       // Normal items get a straightforward move
       await dispatch(
         executeMoveItem(item, store, {
-          equip: loadoutItem.equipped,
+          equip: loadoutItem.equip,
           amount: item.amount,
           excludes,
           cancelToken,
@@ -918,7 +918,7 @@ function applyLoadoutMods(
     // item in the loadout, use the current equipped item (whatever it is)
     // instead.
     const currentEquippedArmor = store.items.filter((i) => i.bucket.inArmor && i.equipped);
-    const equippedLoadoutItems = loadoutItems.filter((item) => item.equipped);
+    const equippedLoadoutItems = loadoutItems.filter((item) => item.equip);
     const loadoutDimItems: DimItem[] = [];
     for (const loadoutItem of loadoutItems) {
       const item = getLoadoutItem(loadoutItem);

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -251,7 +251,7 @@ export function stateReducer(state: State, action: Action): State {
       id: item.id,
       hash: item.hash,
       amount: 1,
-      equipped: false,
+      equip: false,
     };
 
     // TODO: maybe we should just switch back to storing loadout items in memory by bucket
@@ -267,11 +267,11 @@ export function stateReducer(state: State, action: Action): State {
 
       if (!dupe) {
         if (typeInventory.length < maxSlots) {
-          loadoutItem.equipped =
+          loadoutItem.equip =
             equip !== undefined ? equip : item.equipment && typeInventory.length === 0;
-          if (loadoutItem.equipped) {
+          if (loadoutItem.equip) {
             for (const otherItem of typeInventory) {
-              findItem(otherItem).equipped = false;
+              findItem(otherItem).equip = false;
             }
           }
 
@@ -283,7 +283,7 @@ export function stateReducer(state: State, action: Action): State {
             if (conflictingItem) {
               draftLoadout.items = draftLoadout.items.filter((i) => i.id !== conflictingItem.id);
             }
-            loadoutItem.equipped = true;
+            loadoutItem.equip = true;
           }
 
           if (socketOverrides) {
@@ -295,7 +295,7 @@ export function stateReducer(state: State, action: Action): State {
           // If adding a new armor item, remove any fashion mods (shader/ornament) that couldn't be slotted
           if (
             item.bucket.inArmor &&
-            loadoutItem.equipped &&
+            loadoutItem.equip &&
             draftLoadout.parameters?.modsByBucket?.[item.bucket.hash]?.length
           ) {
             const cosmeticSockets = getSocketsByCategoryHash(
@@ -341,7 +341,7 @@ export function stateReducer(state: State, action: Action): State {
         );
       }
 
-      if (loadoutItem.equipped) {
+      if (loadoutItem.equip) {
         const typeInventory = items.filter((i) => i.bucket.hash === item.bucket.hash);
         const nextInLine =
           typeInventory.length > 0 &&
@@ -349,7 +349,7 @@ export function stateReducer(state: State, action: Action): State {
             (i) => i.id === typeInventory[0].id && i.hash === typeInventory[0].hash
           );
         if (nextInLine) {
-          nextInLine.equipped = true;
+          nextInLine.equip = true;
         }
       }
     });
@@ -370,9 +370,9 @@ export function stateReducer(state: State, action: Action): State {
 
       const loadoutItem = findItem(item);
       if (item.equipment) {
-        if (loadoutItem.equipped) {
+        if (loadoutItem.equip) {
           // It's equipped, mark it unequipped
-          loadoutItem.equipped = false;
+          loadoutItem.equip = false;
         } else {
           // It's unequipped - mark all the other items and conflicting exotics unequipped, then mark this equipped
           items
@@ -385,10 +385,10 @@ export function stateReducer(state: State, action: Action): State {
             )
             .map(findItem)
             .forEach((i) => {
-              i.equipped = false;
+              i.equip = false;
             });
 
-          loadoutItem.equipped = true;
+          loadoutItem.equip = true;
         }
       }
     });

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -37,7 +37,7 @@ export function getItemsFromLoadoutItems(
     if (item) {
       // If there are any mods for this item's bucket, and the item is equipped, add them to socket overrides
       const modsForBucket =
-        loadoutItem.equipped && modsByBucket ? modsByBucket[item.bucket.hash] ?? [] : [];
+        loadoutItem.equip && modsByBucket ? modsByBucket[item.bucket.hash] ?? [] : [];
 
       let overrides = loadoutItem.socketOverrides;
 
@@ -57,7 +57,7 @@ export function getItemsFromLoadoutItems(
         ? makeFakeItem(defs, buckets, undefined, loadoutItem.hash)
         : makeFakeD1Item(defs, buckets, loadoutItem.hash);
       if (fakeItem) {
-        fakeItem.equipped = loadoutItem.equipped;
+        fakeItem.equipped = loadoutItem.equip;
         fakeItem.socketOverrides = loadoutItem.socketOverrides;
         fakeItem.id = loadoutItem.id;
         warnitems.push(fakeItem);

--- a/src/app/loadout-drawer/loadout-type-converters.ts
+++ b/src/app/loadout-drawer/loadout-type-converters.ts
@@ -13,8 +13,8 @@ import { Loadout as DimLoadout, LoadoutItem as DimLoadoutItem } from './loadout-
  */
 export function convertDimLoadoutToApiLoadout(dimLoadout: DimLoadout): Loadout {
   const { items, name, clearSpace, parameters, ...rest } = dimLoadout;
-  const equipped = items.filter((i) => i.equipped).map(convertDimLoadoutItemToLoadoutItem);
-  const unequipped = items.filter((i) => !i.equipped).map(convertDimLoadoutItemToLoadoutItem);
+  const equipped = items.filter((i) => i.equip).map(convertDimLoadoutItemToLoadoutItem);
+  const unequipped = items.filter((i) => !i.equip).map(convertDimLoadoutItemToLoadoutItem);
 
   const loadout: Loadout = {
     ...rest,
@@ -126,6 +126,6 @@ function convertDimApiLoadoutItemToLoadoutItem(
     hash: item.hash,
     amount: item.amount || 1,
     socketOverrides: item.socketOverrides,
-    equipped,
+    equip: equipped,
   };
 }

--- a/src/app/loadout-drawer/loadout-types.ts
+++ b/src/app/loadout-drawer/loadout-types.ts
@@ -5,7 +5,8 @@ export interface LoadoutItem {
   id: string;
   hash: number;
   amount: number;
-  equipped: boolean;
+  /** Whether or not the item should be equipped when the loadout is applied. */
+  equip: boolean;
   /**
    * A map of socketIndex's to item hashes for plugs that override the current items plugs in
    * the loadout.

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -347,13 +347,16 @@ export function backupLoadout(store: DimStore, name: string): Loadout {
 /**
  * Converts DimItem or other LoadoutItem-like objects to real loadout items.
  */
-export function convertToLoadoutItem(item: LoadoutItem, equipped: boolean) {
+export function convertToLoadoutItem(
+  item: Pick<LoadoutItem, 'id' | 'hash' | 'amount' | 'socketOverrides'>,
+  equip: boolean
+) {
   return {
     id: item.id,
     hash: item.hash,
     amount: item.amount,
     socketOverrides: item.socketOverrides,
-    equipped,
+    equip,
   };
 }
 

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -94,7 +94,7 @@ export default function LoadoutView({
 
   const savedMods = useMemo(() => getModsFromLoadout(defs, loadout), [defs, loadout]);
 
-  const equippedItemIds = new Set(loadout.items.filter((i) => i.equipped).map((i) => i.id));
+  const equippedItemIds = new Set(loadout.items.filter((i) => i.equip).map((i) => i.id));
 
   const categories = _.groupBy(items.concat(warnitems), (i) => i.bucket.sort);
 

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -58,7 +58,7 @@ export default function FashionDrawer({
   const [pickPlug, setPickPlug] = useState<PickPlugState>();
   const allItems = useSelector(allItemsSelector);
 
-  const equippedIds = new Set([...loadout.items.filter((i) => i.equipped).map((i) => i.id)]);
+  const equippedIds = new Set([...loadout.items.filter((i) => i.equip).map((i) => i.id)]);
   const armor = items.filter(
     (i) => equippedIds.has(i.id) && LockableBucketHashes.includes(i.bucket.hash)
   );

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -78,7 +78,7 @@ export default function LoadoutEdit({
 
   // TODO: This is basically wrong, because the DIM items may have different IDs than the loadout item. We need to
   // process the loadout items into pairs of [LoadoutItem, DimItem] instead.
-  const equippedItemIds = new Set(loadout.items.filter((i) => i.equipped).map((i) => i.id));
+  const equippedItemIds = new Set(loadout.items.filter((i) => i.equip).map((i) => i.id));
 
   const categories = _.groupBy(items.concat(warnitems), (i) => i.bucket.sort);
 
@@ -314,7 +314,7 @@ function setLoadoutSubclassFromEquipped(
   const newLoadoutItem: LoadoutItem = {
     id: newSubclass.id,
     hash: newSubclass.hash,
-    equipped: true,
+    equip: true,
     amount: 1,
     socketOverrides: createSocketOverridesFromEquipped(newSubclass),
   };
@@ -356,7 +356,7 @@ export function fillLoadoutFromEquipped(
       (bucketItem) =>
         loadout.items.find(
           (loadoutItem) => bucketItem.hash === loadoutItem.hash && bucketItem.id === loadoutItem.id
-        )?.equipped
+        )?.equip
     );
 
   const newLoadout = produce(loadout, (draftLoadout) => {
@@ -366,7 +366,7 @@ export function fillLoadoutFromEquipped(
         const loadoutItem: LoadoutItem = {
           id: item.id,
           hash: item.hash,
-          equipped: true,
+          equip: true,
           amount: 1,
         };
         if (item.bucket.hash === BucketHashes.Subclass) {

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -41,7 +41,7 @@ export function useEquippedLoadoutArmorAndSubclass(
       const modsByBucket = loadout.parameters?.modsByBucket;
 
       const [loadoutItems] = getItemsFromLoadoutItems(
-        loadout.items.filter((i) => i.equipped),
+        loadout.items.filter((i) => i.equip),
         defs,
         storeId,
         buckets,


### PR DESCRIPTION
Pulling apart some of my other refactoring into individual PRs. Renaming this property prevents the two concepts of "equip" and "equipped" from overlapping.