### PR TITLE
Darken background behind code on the change log

### DIFF
--- a/src/app/whats-new/ChangeLog.scss
+++ b/src/app/whats-new/ChangeLog.scss
@@ -5,3 +5,9 @@
   color: #ccc;
   margin-left: 8px;
 }
+
+code {
+  background-color: #00000060;
+  padding: 0 3px;
+  border-radius: 2px;
+}


### PR DESCRIPTION
I think it makes search filters a bit more readable in the change log:
![dim-changelog-code](https://user-images.githubusercontent.com/17512262/156864095-fbdc83d0-df4c-483d-a855-b284dec24d8b.PNG)
