### PR TITLE
Hide Masterwork socket on shaped weapons and Memento socket on non-shaped weapons

### DIFF
--- a/src/app/inventory/store/crafted.ts
+++ b/src/app/inventory/store/crafted.ts
@@ -6,6 +6,9 @@ import { DimCrafted, DimItem, DimSocket } from '../item-types';
 /** the socket category containing the single socket with weapon crafting objectives */
 export const craftedSocketCategoryHash = 3583996951;
 
+/** the socket category containing the Mementos */
+export const mementoSocketCategoryHash = 3201856887;
+
 export function buildCraftedInfo(item: DimItem, defs: D2ManifestDefinitions): DimCrafted | null {
   const craftedSocket = getCraftedSocket(item);
   if (!craftedSocket) {

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -1,5 +1,5 @@
 import { t } from 'app/i18next-t';
-import { craftedSocketCategoryHash } from 'app/inventory/store/crafted';
+import { craftedSocketCategoryHash, mementoSocketCategoryHash } from 'app/inventory/store/crafted';
 import { statsMs } from 'app/inventory/store/stats';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useSetting } from 'app/settings/hooks';
@@ -64,21 +64,21 @@ export default function ItemSocketsWeapons({ item, minimal, grid, onPlugClicked 
       c.socketIndexes.length &&
       getSocketByIndex(item.sockets!, c.socketIndexes[0])?.isPerk
   );
+
+  const excludedSocketCategoryHashes = item.crafted
+    ? [craftedSocketCategoryHash]
+    : [mementoSocketCategoryHash];
+
   // Iterate in reverse category order so cosmetic mods are at the front
   const mods = [...item.sockets.categories]
-    .filter((c) => c.category.hash !== craftedSocketCategoryHash)
+    .filter((c) => !excludedSocketCategoryHashes.includes(c.category.hash))
     .reverse()
     .flatMap((c) =>
       getSocketsByIndexes(item.sockets!, c.socketIndexes).filter(
         (s) => !s.isPerk && s !== archetypeSocket
       )
     )
-    .filter(
-      (socket) =>
-        // Hack: dummy deepsight plugs with no name can be ignored
-        socket.plugged?.plugDef.displayProperties.name ||
-        socket.socketDefinition.socketTypeHash !== 1085237186
-    );
+    .filter((socket) => socket.plugged?.plugDef.displayProperties.name);
 
   const keyStats =
     item.stats &&


### PR DESCRIPTION
This reduces some clutter on the archetype bar. Shaped weapons can't be masterworked and Mementos can only be inserted on shaped weapons.

![dim-hide-masterwork-memento-sockets](https://user-images.githubusercontent.com/17512262/156866697-2edaeedf-2401-429d-81a6-27f1f2f55a30.png)
