### PR TITLE
Fix LO mods picker requiring two confirmations

### DIFF
--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -210,7 +210,10 @@ function ModPicker({ plugSets, lockedMods, initialQuery, onAccept, onClose }: Pr
   // Ensure the plug drawer is reset when selecting a different
   // set of plugSets so that it shows the correct mods and chooses
   // a correct height for the sheet.
-  const plugSetsKey = plugSets.map((p) => p.plugSetHash).toString();
+  const plugSetsKey = plugSets
+    .map((p) => p.plugSetHash)
+    .sort()
+    .toString();
 
   return (
     <PlugDrawer

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -144,7 +144,7 @@ export default function PlugDrawer({
   /** Filter the plugs from each plugSet based on the query. This can leave plugSets with zero plugs */
   const queryFilteredPlugSets = useMemo(() => {
     if (!query.length) {
-      return plugSets;
+      return Array.from(plugSets);
     }
 
     const searchFilter = createPlugSearchPredicate(query, language, defs);


### PR DESCRIPTION
`PlugDrawer` would modify an array in its props in place when sorting plug sets, so the first confirmation would create a different key, which seems like a bad idea (`PlugDrawer`'s call to sort is idempotent, so subsequent confirmations would come through). Still, sorting explicitly in `ModPicker` seems like a good defensive idea.