### PR TITLE
Only reload when DIM is in the background

### DIFF
--- a/src/app/dim-ui/ActivityTracker.tsx
+++ b/src/app/dim-ui/ActivityTracker.tsx
@@ -182,7 +182,7 @@ function useVisibilityRefresh() {
   useEffect(
     () =>
       dimNeedsUpdate$.subscribe((needsUpdate) => {
-        if (needsUpdate && !hasSearchQuery) {
+        if (needsUpdate && !hasSearchQuery && document.hidden) {
           // Sneaky updates - if DIM is hidden and needs an update, do the update.
           reloadDIM();
         }


### PR DESCRIPTION
I had forgotten the condition that DIM should only update if the page is not visible.