### PR TITLE
Replace DimLoadoutItem with ResolvedLoadoutItem

### DIFF
--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -209,7 +209,7 @@ export default function LoadoutDrawer() {
                   {t('Loadouts.VendorsCannotEquip')}
                 </p>
                 <div className="loadout-warn-items">
-                  {warnitems.map((item) => (
+                  {warnitems.map(({ item }) => (
                     <div key={item.id} className="loadout-item" onClick={() => fixWarnItem(item)}>
                       <ClosableContainer onClose={(e) => onRemoveItem(item, e)}>
                         <ItemIcon item={item} />

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
@@ -1,11 +1,12 @@
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
-import { LoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { itemSortOrderSelector } from 'app/settings/item-sort';
 import { sortItems } from 'app/shell/filters';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
+import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { AddButton } from './Buttons';
@@ -14,30 +15,25 @@ import LoadoutDrawerItem from './LoadoutDrawerItem';
 
 export default function LoadoutDrawerBucket({
   bucket,
-  loadoutItems,
   items,
   pickLoadoutItem,
   equip,
   remove,
 }: {
   bucket: InventoryBucket;
-  loadoutItems: LoadoutItem[];
-  items: DimItem[];
+  items: ResolvedLoadoutItem[];
   pickLoadoutItem(bucket: InventoryBucket): void;
   equip(item: DimItem, e: React.MouseEvent): void;
   remove(item: DimItem, e: React.MouseEvent): void;
 }) {
   const itemSortOrder = useSelector(itemSortOrderSelector);
+  const [equippedUnsorted, unequippedUnsorted] = _.partition(items, (li) => li.loadoutItem.equip);
   const equippedItems = sortItems(
-    items.filter((i) =>
-      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && li.equip)
-    ),
+    equippedUnsorted.map((li) => li.item),
     itemSortOrder
   );
   const unequippedItems = sortItems(
-    items.filter((i) =>
-      loadoutItems.some((li) => li.id === i.id && li.hash === i.hash && !li.equip)
-    ),
+    unequippedUnsorted.map((li) => li.item),
     itemSortOrder
   );
   // Only allow one emblem

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -4,13 +4,13 @@ import {
   LockArmorEnergyType,
 } from '@destinyitemmanager/dim-api-types';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DimStore } from 'app/inventory/store-types';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
-import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { fitMostMods } from 'app/loadout/mod-assignment-utils';
 import { errorLog } from 'app/utils/log';
 import _ from 'lodash';
 import React, { Dispatch, useMemo } from 'react';
-import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { ArmorSet, ArmorStatHashes, MIN_LO_ITEM_ENERGY, PinnedItems } from '../types';
 import { getPower } from '../utils';
@@ -21,7 +21,7 @@ import SetStats from './SetStats';
 
 interface Props {
   set: ArmorSet;
-  subclass: DimLoadoutItem | undefined;
+  subclass: ResolvedLoadoutItem | undefined;
   notes?: string;
   selectedStore: DimStore;
   lockedMods: PluggableInventoryItemDefinition[];

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -1,14 +1,14 @@
 import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { t } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DimStore } from 'app/inventory/store-types';
 import { applyLoadout } from 'app/loadout-drawer/loadout-apply';
-import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { convertToLoadoutItem, newLoadout } from 'app/loadout-drawer/loadout-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React, { Dispatch } from 'react';
 import { useDispatch } from 'react-redux';
-import { DimStore } from '../../inventory/store-types';
-import { convertToLoadoutItem, newLoadout } from '../../loadout-drawer/loadout-utils';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { ArmorSet } from '../types';
 import { statTier } from '../utils';
@@ -30,7 +30,7 @@ export default function GeneratedSetButtons({
 }: {
   store: DimStore;
   set: ArmorSet;
-  subclass: DimLoadoutItem | undefined;
+  subclass: ResolvedLoadoutItem | undefined;
   notes?: string;
   params: LoadoutParameters;
   canCompareLoadouts: boolean;
@@ -100,7 +100,7 @@ export default function GeneratedSetButtons({
 function createLoadout(
   classType: DestinyClass,
   set: ArmorSet,
-  subclass: DimLoadoutItem | undefined,
+  subclass: ResolvedLoadoutItem | undefined,
   params: LoadoutParameters,
   notes?: string
 ): Loadout {
@@ -110,7 +110,7 @@ function createLoadout(
   const items = set.armor.map((items) => convertToLoadoutItem(items[0], true));
 
   if (subclass) {
-    items.push(convertToLoadoutItem(subclass, true));
+    items.push(subclass.loadoutItem);
   }
 
   const loadout = newLoadout(t('Loadouts.Generated', data), items, classType);

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -5,7 +5,8 @@ import {
 } from '@destinyitemmanager/dim-api-types';
 import { t } from 'app/i18next-t';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
+import { DimStore } from 'app/inventory/store-types';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import raidModPlugCategoryHashes from 'data/d2/raid-mod-plug-category-hashes.json';
 import _ from 'lodash';
 import React, {
@@ -18,7 +19,6 @@ import React, {
   useState,
 } from 'react';
 import { List, WindowScroller } from 'react-virtualized';
-import { DimStore } from '../../inventory/store-types';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { ArmorSet, PinnedItems } from '../types';
 import GeneratedSet from './GeneratedSet';
@@ -71,7 +71,7 @@ function getMeasureSet(sets: readonly ArmorSet[]) {
 interface Props {
   selectedStore: DimStore;
   sets: readonly ArmorSet[];
-  subclass: DimLoadoutItem | undefined;
+  subclass: ResolvedLoadoutItem | undefined;
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
   statOrder: number[];

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -9,11 +9,12 @@ import { t } from 'app/i18next-t';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
-import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import {
   createSubclassDefaultSocketOverrides,
   findItemForLoadout,
 } from 'app/loadout-drawer/loadout-utils';
+import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
@@ -22,7 +23,6 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { useReducer } from 'react';
-import { isLoadoutBuilderItem } from '../loadout/item-utils';
 import { statFiltersFromLoadoutParamaters, statOrderFromLoadoutParameters } from './loadout-params';
 import {
   ArmorSet,
@@ -41,7 +41,7 @@ export interface LoadoutBuilderState {
   pinnedItems: PinnedItems;
   excludedItems: ExcludedItems;
   selectedStoreId?: string;
-  subclass?: DimLoadoutItem;
+  subclass?: ResolvedLoadoutItem;
   modPicker: {
     open: boolean;
     plugCategoryHashWhitelist?: number[];
@@ -87,7 +87,7 @@ const lbStateInit = ({
   let selectedStoreId = (matchingClass ?? getCurrentStore(stores)!).id;
 
   let loadoutParams = initialLoadoutParameters;
-  let subclass: DimLoadoutItem | undefined;
+  let subclass: ResolvedLoadoutItem | undefined;
 
   if (stores.length && preloadedLoadout) {
     let loadoutStore = getCurrentStore(stores);
@@ -117,14 +117,17 @@ const lbStateInit = ({
           const item = findItemForLoadout(defs, allItems, selectedStoreId, loadoutItem);
           if (item && isLoadoutBuilderItem(item)) {
             pinnedItems[item.bucket.hash] = item;
-          } else if (item && item.bucket.hash === BucketHashes.Subclass && item.sockets) {
+          } else if (item?.bucket.hash === BucketHashes.Subclass && item.sockets) {
             // In LO we populate the default ability plugs because in game you cannot unselect all abilities.
             const socketOverridesForLO = {
               ...createSubclassDefaultSocketOverrides(item),
               ...loadoutItem.socketOverrides,
             };
 
-            subclass = { ...item, socketOverrides: socketOverridesForLO };
+            subclass = {
+              item,
+              loadoutItem: { ...loadoutItem, socketOverrides: socketOverridesForLO },
+            };
           }
         }
       }
@@ -367,7 +370,16 @@ function lbStateReducer(defs: D2ManifestDefinitions) {
 
         return {
           ...state,
-          subclass: { ...item, socketOverrides: createSubclassDefaultSocketOverrides(item) },
+          subclass: {
+            item,
+            loadoutItem: {
+              id: item.id,
+              hash: item.hash,
+              equip: true,
+              amount: 1,
+              socketOverrides: createSubclassDefaultSocketOverrides(item),
+            },
+          },
         };
       }
       case 'removeSubclass': {
@@ -379,7 +391,13 @@ function lbStateReducer(defs: D2ManifestDefinitions) {
         }
 
         const { socketOverrides } = action;
-        return { ...state, subclass: { ...state.subclass, socketOverrides } };
+        return {
+          ...state,
+          subclass: {
+            ...state.subclass,
+            loadoutItem: { ...state.subclass.loadoutItem, socketOverrides },
+          },
+        };
       }
       case 'removeSingleSubclassSocketOverride': {
         if (!state.subclass) {
@@ -387,12 +405,12 @@ function lbStateReducer(defs: D2ManifestDefinitions) {
         }
 
         const { plug } = action;
-        const abilityAndSuperSockets = getSocketsByCategoryHashes(state.subclass.sockets, [
+        const abilityAndSuperSockets = getSocketsByCategoryHashes(state.subclass.item.sockets, [
           SocketCategoryHashes.Abilities_Abilities_DarkSubclass,
           SocketCategoryHashes.Abilities_Abilities_LightSubclass,
           SocketCategoryHashes.Super,
         ]);
-        const newSocketOverrides = { ...state.subclass?.socketOverrides };
+        const newSocketOverrides = { ...state.subclass?.loadoutItem.socketOverrides };
         let socketIndexToRemove: number | undefined;
 
         // Find the socket index to remove the plug from.
@@ -423,9 +441,12 @@ function lbStateReducer(defs: D2ManifestDefinitions) {
           ...state,
           subclass: {
             ...state.subclass,
-            socketOverrides: Object.keys(newSocketOverrides).length
-              ? newSocketOverrides
-              : undefined,
+            loadoutItem: {
+              ...state.subclass.loadoutItem,
+              socketOverrides: Object.keys(newSocketOverrides).length
+                ? newSocketOverrides
+                : undefined,
+            },
           },
         };
       }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -4,7 +4,7 @@ import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-ty
 import { DimStore } from 'app/inventory/store-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { keyByStatHash } from 'app/inventory/store/stats';
-import { DimLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { calculateAssumedItemEnergy, isArmorEnergyLocked } from 'app/loadout/armor-upgrade-utils';
 import { activityModPlugCategoryHashes, bucketHashToPlugCategoryHash } from 'app/loadout/mod-utils';
 import {
@@ -65,7 +65,7 @@ export function useProcess({
   selectedStore: DimStore;
   filteredItems: ItemsByBucket;
   lockedMods: PluggableInventoryItemDefinition[];
-  subclass: DimLoadoutItem | undefined;
+  subclass: ResolvedLoadoutItem | undefined;
   assumeArmorMasterwork: AssumeArmorMasterwork | undefined;
   lockArmorEnergyType: LockArmorEnergyType | undefined;
   statOrder: number[];
@@ -169,8 +169,8 @@ export function useProcess({
       mods.map(mapArmor2ModToProcessMod)
     );
 
-    const subclassPlugs = subclass?.socketOverrides
-      ? Object.values(subclass.socketOverrides)
+    const subclassPlugs = subclass?.loadoutItem.socketOverrides
+      ? Object.values(subclass.loadoutItem.socketOverrides)
           .map((hash) => defs.InventoryItem.get(hash))
           .filter(isPluggableItem)
       : emptyArray<PluggableInventoryItemDefinition>();
@@ -222,7 +222,7 @@ export function useProcess({
     statOrder,
     anyExotic,
     disabledDueToMaintenance,
-    subclass?.socketOverrides,
+    subclass?.loadoutItem.socketOverrides,
     assumeArmorMasterwork,
     lockArmorEnergyType,
   ]);

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -17,7 +17,6 @@ import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import produce from 'immer';
-import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
@@ -145,7 +144,6 @@ export default function LoadoutDrawer2() {
     () => getItemsFromLoadoutItems(loadoutItems, defs, store?.id, buckets, allItems),
     [loadoutItems, defs, store?.id, buckets, allItems]
   );
-  const itemsByBucket = _.groupBy(items, (i) => i.bucket.hash);
 
   const onAddItem = useCallback(
     (item: DimItem, equip?: boolean) =>
@@ -345,7 +343,12 @@ export default function LoadoutDrawer2() {
             type="button"
             className="dim-button"
             onClick={() =>
-              fillLoadoutFromEquipped(loadout, itemsByBucket, store, handleUpdateLoadout)
+              fillLoadoutFromEquipped(
+                loadout,
+                items.map((li) => li.item),
+                store,
+                handleUpdateLoadout
+              )
             }
           >
             <AppIcon icon={addIcon} /> {t('Loadouts.FillFromEquipped')}

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -8,7 +8,7 @@ import { emptyArray } from 'app/utils/empty';
 import { warnLog } from 'app/utils/log';
 import { plugFitsIntoSocket } from 'app/utils/socket-utils';
 import { DimItem } from '../inventory/item-types';
-import { DimLoadoutItem, LoadoutItem } from './loadout-types';
+import { LoadoutItem, ResolvedLoadoutItem } from './loadout-types';
 import { findItemForLoadout } from './loadout-utils';
 
 /**
@@ -24,13 +24,13 @@ export function getItemsFromLoadoutItems(
   modsByBucket?: {
     [bucketHash: number]: number[] | undefined;
   }
-): [items: DimLoadoutItem[], warnitems: DimLoadoutItem[]] {
+): [items: ResolvedLoadoutItem[], warnitems: ResolvedLoadoutItem[]] {
   if (!loadoutItems) {
     return [emptyArray(), emptyArray()];
   }
 
-  const items: DimLoadoutItem[] = [];
-  const warnitems: DimLoadoutItem[] = [];
+  const items: ResolvedLoadoutItem[] = [];
+  const warnitems: ResolvedLoadoutItem[] = [];
   for (const loadoutItem of loadoutItems) {
     // TODO: filter down to the class type of the loadout
     const item = findItemForLoadout(defs, allItems, storeId, loadoutItem);
@@ -51,16 +51,20 @@ export function getItemsFromLoadoutItems(
       // Apply socket overrides so the item appears as it should be configured in the loadout
       const overriddenItem = defs.isDestiny2() ? applySocketOverrides(defs, item, overrides) : item;
 
-      items.push({ ...overriddenItem, socketOverrides: overrides });
+      items.push({
+        item: overriddenItem,
+        // TODO: Should we keep the original socket overrides here, somewhere? There's a difference between "effective socket overrides" and "socket overrides to save"
+        loadoutItem:
+          overrides === loadoutItem.socketOverrides
+            ? loadoutItem
+            : { ...loadoutItem, socketOverrides: overrides },
+      });
     } else {
-      const fakeItem: DimLoadoutItem | null = defs.isDestiny2()
+      const fakeItem: DimItem | null = defs.isDestiny2()
         ? makeFakeItem(defs, buckets, undefined, loadoutItem.hash)
         : makeFakeD1Item(defs, buckets, loadoutItem.hash);
       if (fakeItem) {
-        fakeItem.equipped = loadoutItem.equip;
-        fakeItem.socketOverrides = loadoutItem.socketOverrides;
-        fakeItem.id = loadoutItem.id;
-        warnitems.push(fakeItem);
+        warnitems.push({ item: fakeItem, loadoutItem });
       } else {
         warnLog('loadout', "Couldn't create fake warn item for", loadoutItem);
       }

--- a/src/app/loadout-drawer/loadout-types.ts
+++ b/src/app/loadout-drawer/loadout-types.ts
@@ -21,15 +21,29 @@ export type Loadout = Omit<DimApiLoadout, 'equipped' | 'unequipped'> & {
 };
 
 /**
- * This merges data from DimItem and LoadoutItem so we don't need to pass both objects around as
- * a pair.
+ * Once we resolve a loadout item specifier to an actual item in inventory, we
+ * can pass them around together. This represents the pair of the loadout item
+ * specifier and the item in inventory (or fake placeholder item) that goes
+ * along with it.
  */
-export interface DimLoadoutItem extends DimItem {
+export interface ResolvedLoadoutItem {
   /**
-   * A map of socketIndex's to item hashes for plugs that override the current items plugs in
-   * the loadout.
+   * The actual item in inventory, wherever it is. This item will have any
+   * socketOverrides and fashion from the loadoutItem applied to it.
+   *
+   * Note: Don't use the `equipped` property of this item - use `loadoutItem.equip` instead!
    */
-  socketOverrides?: { [socketIndex: number]: number };
+  readonly item: DimItem;
+  /**
+   * The original loadout item specifier which says what we want to do with
+   * this item in the loadout. Note that this loadoutItem may not have the same
+   * id or even hash as the resolved item!
+   */
+  // TODO: remove this in favor of just equip/socketOverrides/amount?
+  readonly loadoutItem: LoadoutItem;
+
+  /** This item wasn't found in inventory. This means `item` is a fake placeholder. */
+  readonly missing?: boolean;
 }
 
 /** represents a single mod, and where to place it (on a non-specific item) */

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -6,7 +6,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
-import { DimLoadoutItem, Loadout, LoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { Loadout, LoadoutItem, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
@@ -33,7 +33,11 @@ export function getItemsAndSubclassFromLoadout(
   modsByBucket?: {
     [bucketHash: number]: number[] | undefined;
   }
-): [items: DimLoadoutItem[], subclass: DimLoadoutItem | undefined, warnitems: DimLoadoutItem[]] {
+): [
+  items: ResolvedLoadoutItem[],
+  subclass: ResolvedLoadoutItem | undefined,
+  warnitems: ResolvedLoadoutItem[]
+] {
   let [items, warnitems] = getItemsFromLoadoutItems(
     loadoutItems,
     defs,
@@ -44,12 +48,12 @@ export function getItemsAndSubclassFromLoadout(
   );
   const subclass = items
     .concat(warnitems)
-    .find((item) => item.bucket.hash === BucketHashes.Subclass);
+    .find((li) => li.item.bucket.hash === BucketHashes.Subclass);
 
-  items = items.filter((i) => itemCanBeEquippedBy(i, store, true));
+  items = items.filter((li) => itemCanBeEquippedBy(li.item, store, true));
   if (subclass) {
-    items = items.filter((i) => i.hash !== subclass.hash);
-    warnitems = warnitems.filter((i) => i.hash !== subclass.hash);
+    items = items.filter((li) => li.item.hash !== subclass.item.hash);
+    warnitems = warnitems.filter((li) => li.item.hash !== subclass.item.hash);
   }
 
   return [items, subclass, warnitems];
@@ -94,18 +98,8 @@ export default function LoadoutView({
 
   const savedMods = useMemo(() => getModsFromLoadout(defs, loadout), [defs, loadout]);
 
-  const equippedItemIds = new Set(loadout.items.filter((i) => i.equip).map((i) => i.id));
-
-  const categories = _.groupBy(items.concat(warnitems), (i) => i.bucket.sort);
-
-  const isEquipped = (i: DimItem) =>
-    Boolean(i.owner !== 'unknown' && i.power && equippedItemIds.has(i.id));
-  const showPower =
-    count(categories.Weapons ?? [], isEquipped) === 3 &&
-    count(categories.Armor ?? [], isEquipped) === 5;
-  const power = showPower
-    ? Math.floor(getLight(store, [...categories.Weapons, ...categories.Armor]))
-    : 0;
+  const categories = _.groupBy(items.concat(warnitems), (li) => li.item.bucket.sort);
+  const power = loadoutPower(store, categories);
 
   return (
     <div className={styles.loadout} id={loadout.id}>
@@ -140,7 +134,6 @@ export default function LoadoutView({
                 items={categories[category]}
                 savedMods={savedMods}
                 modsByBucket={modsByBucket}
-                equippedItemIds={equippedItemIds}
                 loadout={loadout}
                 hideOptimizeArmor={hideOptimizeArmor}
               />
@@ -156,4 +149,22 @@ export default function LoadoutView({
       </div>
     </div>
   );
+}
+
+export function loadoutPower(store: DimStore, categories: _.Dictionary<ResolvedLoadoutItem[]>) {
+  const isEquipped = (li: ResolvedLoadoutItem) =>
+    Boolean(!li.missing && li.item.power && li.loadoutItem.equip);
+  const showPower =
+    count(categories.Weapons ?? [], isEquipped) === 3 &&
+    count(categories.Armor ?? [], isEquipped) === 5;
+  const power = showPower
+    ? Math.floor(
+        getLight(
+          store,
+          [...categories.Weapons, ...categories.Armor].map((li) => li.item)
+        )
+      )
+    : 0;
+
+  return power;
 }

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -3,7 +3,7 @@ import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
-import { DimLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
 import clsx from 'clsx';
 import React, { useMemo } from 'react';
@@ -22,7 +22,7 @@ export default function LoadoutEditSubclass({
   onPick,
 }: {
   defs: D2ManifestDefinitions;
-  subclass?: DimLoadoutItem;
+  subclass?: ResolvedLoadoutItem;
   power: number;
   onRemove(): void;
   onPick(): void;
@@ -38,17 +38,17 @@ export default function LoadoutEditSubclass({
             onClose={onRemove}
             showCloseIconOnHover
             className={clsx({
-              [styles.missingItem]: subclass?.owner === 'unknown',
+              [styles.missingItem]: subclass?.missing,
             })}
           >
-            <ItemPopupTrigger item={subclass}>
+            <ItemPopupTrigger item={subclass.item}>
               {(ref, onClick) => (
                 <ConnectedInventoryItem
                   innerRef={ref}
                   // Disable the popup when plugs are available as we are showing
                   // plugs in the loadout and they may be different to the popup
                   onClick={plugs.length ? undefined : onClick}
-                  item={subclass}
+                  item={subclass.item}
                   ignoreSelectedPerks
                 />
               )}

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -4,7 +4,7 @@ import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import { DimLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
 import { getSocketsByIndexes } from 'app/utils/socket-utils';
 import clsx from 'clsx';
@@ -17,19 +17,19 @@ import PlugDef from './PlugDef';
 
 export function getSubclassPlugs(
   defs: D2ManifestDefinitions,
-  subclass: DimLoadoutItem | undefined
+  subclass: ResolvedLoadoutItem | undefined
 ) {
   const plugs: PluggableInventoryItemDefinition[] = [];
 
-  if (subclass?.sockets?.categories) {
-    for (const category of subclass.sockets.categories) {
+  if (subclass?.item.sockets?.categories) {
+    for (const category of subclass.item.sockets.categories) {
       const showInitial =
         category.category.hash !== SocketCategoryHashes.Aspects &&
         category.category.hash !== SocketCategoryHashes.Fragments;
-      const sockets = getSocketsByIndexes(subclass.sockets, category.socketIndexes);
+      const sockets = getSocketsByIndexes(subclass.item.sockets, category.socketIndexes);
 
       for (const socket of sockets) {
-        const override = subclass.socketOverrides?.[socket.socketIndex];
+        const override = subclass.loadoutItem.socketOverrides?.[socket.socketIndex];
         // Void grenades do not have a singleInitialItemHash
         const initial =
           socket.socketDefinition.singleInitialItemHash || socket.plugSet!.plugs[0].plugDef.hash;
@@ -52,7 +52,7 @@ export default function LoadoutSubclassSection({
   power,
 }: {
   defs: D2ManifestDefinitions;
-  subclass?: DimLoadoutItem;
+  subclass?: ResolvedLoadoutItem;
   power: number;
 }) {
   const getModRenderKey = createGetModRenderKey();
@@ -62,18 +62,18 @@ export default function LoadoutSubclassSection({
     <div className={styles.subclassContainer}>
       <div
         className={clsx(styles.subclass, {
-          [styles.missingItem]: subclass?.owner === 'unknown',
+          [styles.missingItem]: subclass?.missing,
         })}
       >
         {subclass ? (
-          <ItemPopupTrigger item={subclass}>
+          <ItemPopupTrigger item={subclass.item}>
             {(ref, onClick) => (
               <ConnectedInventoryItem
                 innerRef={ref}
                 // Disable the popup when plugs are available as we are showing
                 // plugs in the loadout and they may be different to the popup
                 onClick={plugs.length ? undefined : onClick}
-                item={subclass}
+                item={subclass.item}
                 ignoreSelectedPerks
               />
             )}

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -7,7 +7,7 @@ import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getLoadoutStats } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
@@ -32,7 +32,7 @@ function Header({
 }: {
   defs: D2ManifestDefinitions;
   loadout: Loadout;
-  subclass: DimLoadoutItem | undefined;
+  subclass: ResolvedLoadoutItem | undefined;
   armor: DimItem[];
   mods: PluggableInventoryItemDefinition[];
 }) {
@@ -67,6 +67,7 @@ export default function ModAssignmentDrawer({
   const defs = useD2Definitions()!;
   const { armor, subclass } = useEquippedLoadoutArmorAndSubclass(loadout, storeId);
   const getModRenderKey = createGetModRenderKey();
+  const armorItems = useMemo(() => armor.map((li) => li.item), [armor]);
 
   const [itemModAssignments, unassignedMods, mods] = useMemo(() => {
     let mods: PluggableInventoryItemDefinition[] = [];
@@ -76,7 +77,7 @@ export default function ModAssignmentDrawer({
         .filter(isPluggableItem);
     }
     const { itemModAssignments, unassignedMods } = fitMostMods({
-      items: armor,
+      items: armorItems,
       plannedMods: mods,
       assumeArmorMasterwork: undefined,
       lockArmorEnergyType: LockArmorEnergyType.All,
@@ -84,7 +85,7 @@ export default function ModAssignmentDrawer({
     });
 
     return [itemModAssignments, unassignedMods, mods];
-  }, [defs, armor, loadout.parameters?.mods]);
+  }, [defs, loadout.parameters?.mods, armorItems]);
 
   const onSocketClick = useCallback(
     (plugDef: PluggableInventoryItemDefinition, plugCategoryHashWhitelist: number[]) => {
@@ -116,7 +117,7 @@ export default function ModAssignmentDrawer({
             defs={defs}
             loadout={loadout}
             subclass={subclass}
-            armor={armor}
+            armor={armorItems}
             mods={flatAssigned}
           />
         }
@@ -125,7 +126,7 @@ export default function ModAssignmentDrawer({
       >
         <div className={styles.container}>
           <div className={styles.assigned}>
-            {armor.map((item) => {
+            {armorItems.map((item) => {
               const energyUsed = _.sumBy(
                 itemModAssignments[item.id],
                 (m) => m.plug.energyCost?.energyCost || 0

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -2,7 +2,7 @@ import { allItemsSelector, bucketsSelector, sortedStoresSelector } from 'app/inv
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { LockableBucketHashes } from 'app/loadout-builder/types';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
-import { DimLoadoutItem, Loadout } from 'app/loadout-drawer/loadout-types';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { manifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -22,9 +22,11 @@ import { shallowEqual, useSelector } from 'react-redux';
 export function useEquippedLoadoutArmorAndSubclass(
   loadout: Loadout,
   storeId: string | undefined
-): { armor: DimLoadoutItem[]; subclass: DimLoadoutItem | undefined } {
+): { armor: ResolvedLoadoutItem[]; subclass: ResolvedLoadoutItem | undefined } {
   const loadoutItemSelector = useCallback(
-    (state: RootState): { armor: DimLoadoutItem[]; subclass: DimLoadoutItem | undefined } => {
+    (
+      state: RootState
+    ): { armor: ResolvedLoadoutItem[]; subclass: ResolvedLoadoutItem | undefined } => {
       const stores = sortedStoresSelector(state);
       const currentStore = getCurrentStore(stores)!;
       const storeToHydrateFrom = storeId
@@ -50,8 +52,8 @@ export function useEquippedLoadoutArmorAndSubclass(
       );
 
       const loadoutItemsByBucket = _.keyBy(
-        loadoutItems.filter((i) => i.classType === classType),
-        (i) => i.bucket.hash
+        loadoutItems.filter((i) => i.item.classType === classType),
+        (i) => i.item.bucket.hash
       );
 
       const subclass = loadoutItemsByBucket[BucketHashes.Subclass];


### PR DESCRIPTION
ResolvedLoadoutItem explicitly pairs together the resolved DimItem and the original LoadoutItem, along with a flag indicating whether the item was missing. This makes a lot of logic easier!