### PR TITLE
Relative CI upkeep

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -56,11 +56,13 @@ jobs:
           WEB_OAUTH_CLIENT_SECRET: ${{ secrets.WEB_OAUTH_CLIENT_SECRET }}
           DIM_API_KEY: ${{ secrets.DIM_API_KEY }}
 
-      # Upload webpack-stats.json to use on relative-ci.yaml workflow
-      - name: Upload webpack stats artifact
-        uses: relative-ci/agent-upload-artifact-action@v1
+      # Send webpack stats and build information to RelativeCI
+      - name: Send webpack stats to RelativeCI
+        uses: relative-ci/agent-action@v2
         with:
           webpackStatsFile: ./webpack-stats.json
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Syntax
         run: yarn syntax

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -76,12 +76,6 @@ jobs:
           # Use the dim-release-bot token rather than the default
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      # Upload webpack-stats.json to use on relative-ci.yaml workflow
-      - name: Upload webpack stats artifact
-        uses: relative-ci/agent-upload-artifact-action@v1
-        with:
-          webpackStatsFile: ./webpack-stats.json
-
       - name: Purge CloudFlare cache
         run: ./build/purge-cloudflare.sh
         env:

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -2,7 +2,7 @@ name: RelativeCI
 
 on:
   workflow_run:
-    workflows: ["PR Build", "Deploy Beta", "Deploy Prod"]
+    workflows: ["PR Build"]
     types:
       - completed
 


### PR DESCRIPTION
Do not upload to RelativeCI on prod, bc Deploy Beta is going to run after it automatically, and it will upload directly to RelativeCI without using the workflow run yml, which will only be used on PRs to support forked PRs