### PR TITLE
tune up equipment info for classified items

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -444,7 +444,11 @@ export function makeItem(
     id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
     equipped: Boolean(instanceDef?.isEquipped),
     // TODO: equippingBlock has a ton of good info for the item move logic
-    equipment: Boolean(itemDef.equippingBlock) && !uniqueEquipBuckets.includes(normalBucket.hash),
+    equipment:
+      (itemDef.equippingBlock ||
+        // redacted items seem to have a correct boolean but no detailed equipping block info
+        (itemDef.redacted && itemDef.equippable)) &&
+      !uniqueEquipBuckets.includes(normalBucket.hash),
     equippingLabel: itemDef.equippingBlock?.uniqueLabel,
     complete: false,
     amount: item.quantity || 1,

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -149,14 +149,7 @@ export function itemCanBeEquippedBy(
   }
 
   return (
-    item.equipment &&
-    // For the right class
-    (item.classType === DestinyClass.Unknown || item.classType === store.classType) &&
-    // nothing we are too low-level to equip
-    item.equipRequiredLevel <= store.level &&
-    // can be moved or is already here
-    (!item.notransfer || item.owner === store.id) &&
-    (allowPostmaster || !item.location.inPostmaster) &&
+    itemCanBeEquippedByStoreId(item, store.id, store.classType, allowPostmaster) &&
     (isD1Item(item) ? factionItemAligns(store, item) : true)
   );
 }
@@ -165,15 +158,22 @@ export function itemCanBeEquippedBy(
 export function itemCanBeEquippedByStoreId(
   item: DimItem,
   storeId: string,
-  storeClassType: DestinyClass
+  storeClassType: DestinyClass,
+  allowPostmaster = false
 ): boolean {
-  return (
+  return Boolean(
     item.equipment &&
-    // For the right class
-    (item.classType === DestinyClass.Unknown || item.classType === storeClassType) &&
-    // can be moved or is already here
-    (!item.notransfer || item.owner === storeId) &&
-    !item.location.inPostmaster
+      (item.classified
+        ? // we can't trust the classType of redacted items! they're all marked titan.
+          // let's assume classified weapons are all-class
+          item.bucket.inWeapons ||
+          // if it's equipped by this store, it's obviously equippable to this store!
+          (item.owner === storeId && item.equipped)
+        : // For the right class
+          item.classType === DestinyClass.Unknown || item.classType === storeClassType) &&
+      // can be moved or is already here
+      (!item.notransfer || item.owner === storeId) &&
+      (allowPostmaster || !item.location.inPostmaster)
   );
 }
 


### PR DESCRIPTION
this does some slightly different equipment logic for classified items.
it allows a usually-more-accurate Max PL calculation while classified items are in play.
it does not yet allow you to equip classified items, but i would like to in the future.

![image](https://user-images.githubusercontent.com/68782081/156989898-704e2044-d204-4114-8686-00ce3664fd75.png)
