### PR TITLE
gradient fix for enhanced perks

### DIFF
--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -174,7 +174,7 @@ function PerkCircle({
     <svg viewBox="0 0 100 100" width="100" height="100" className={clsx(className, 'perk-circle')}>
       <defs>
         <linearGradient id="mw" x1="0" x2="0" y1="0" y2="1">
-          <stop stopColor="#eade8b" offset="20%" stopOpacity="0" />
+          <stop stopColor="#eade8b" offset="50%" stopOpacity="0" />
           <stop stopColor="#eade8b" offset="100%" stopOpacity="1" />
         </linearGradient>
       </defs>

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -174,8 +174,8 @@ function PerkCircle({
     <svg viewBox="0 0 100 100" width="100" height="100" className={clsx(className, 'perk-circle')}>
       <defs>
         <linearGradient id="mw" x1="0" x2="0" y1="0" y2="1">
-          <stop stopColor="transparent" offset="20%" />
-          <stop stopColor="#eade8b" offset="100%" />
+          <stop stopColor="#eade8b" offset="20%" stopOpacity="0" />
+          <stop stopColor="#eade8b" offset="100%" stopOpacity="1" />
         </linearGradient>
       </defs>
       <mask id="mask">


### PR DESCRIPTION
SVG gradients like to be black by default so I swapped the gradient to be pure yellow and added stop-opacity instead to get a clean gradient. 

before > after 
![image](https://user-images.githubusercontent.com/29002828/157114290-9accc079-7abc-4662-a6bc-767e45e19c89.png)

we could perhaps now stand to drop the gradient down a bit too like so. Let me know your thoughts on that.
![image](https://user-images.githubusercontent.com/29002828/157114840-3d3bdcc8-4529-4cbf-9fb2-92fad5012236.png)

