### PR TITLE
use bucket icons for classified items

### DIFF
--- a/src/app/dim-ui/svgs/BucketIcon.tsx
+++ b/src/app/dim-ui/svgs/BucketIcon.tsx
@@ -1,4 +1,5 @@
 import { DimItem } from 'app/inventory/item-types';
+import { d2MissingIcon } from 'app/search/d2-known-values';
 import { BucketHashes } from 'data/d2/generated-enums';
 import legs from 'destiny-icons/armor_types/boots.svg';
 import chest from 'destiny-icons/armor_types/chest.svg';
@@ -12,7 +13,7 @@ import dmgKinetic from 'destiny-icons/weapons/damage_kinetic.svg';
 import React from 'react';
 import BungieImage from '../BungieImage';
 
-const bucketIcons = {
+export const bucketIcons = {
   [BucketHashes.KineticWeapons]: dmgKinetic,
   [BucketHashes.EnergyWeapons]: energyWeapon,
   [BucketHashes.PowerWeapons]: powerWeapon,
@@ -35,6 +36,6 @@ export default function BucketIcon(props: BucketIconProps) {
   return svg ? (
     <img src={svg} {...otherProps} />
   ) : (
-    <BungieImage src="/img/misc/missing_icon_d2.png" {...otherProps} />
+    <BungieImage src={d2MissingIcon} {...otherProps} />
   );
 }

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -136,3 +136,8 @@ $commonBg: #366f42;
   top: calc(var(--item-size) - ((var(--item-size) + 1px) / 2) - 1px);
   pointer-events: none;
 }
+
+.bucketIcon {
+  filter: invert(1);
+  border-color: #222;
+}

--- a/src/app/inventory/ItemIcon.m.scss.d.ts
+++ b/src/app/inventory/ItemIcon.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'backgroundOverlay': string;
   'basic': string;
   'borderless': string;
+  'bucketIcon': string;
   'common': string;
   'complete': string;
   'deepsight': string;

--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -1,6 +1,8 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage, { bungieBackgroundStyle, bungieNetPath } from 'app/dim-ui/BungieImage';
+import BucketIcon from 'app/dim-ui/svgs/BucketIcon';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { d2MissingIcon } from 'app/search/d2-known-values';
 import { errorLog } from 'app/utils/log';
 import {
   DestinyEnergyTypeDefinition,
@@ -35,17 +37,23 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
       (item.bucket.hash === BucketHashes.Subclass ||
         item.itemCategoryHashes.includes(ItemCategoryHashes.Packages))) ||
     item.isEngram;
+  const useClassifiedPlaceholder = item.icon === d2MissingIcon && item.classified;
   const itemImageStyles = clsx('item-img', className, {
     [styles.complete]: item.complete || isCapped,
     [styles.borderless]: borderless,
     [styles.masterwork]: item.masterwork,
     [styles.deepsight]: item.deepsightInfo,
+    [styles.bucketIcon]: useClassifiedPlaceholder,
     [itemTierStyles[item.tier]]: !borderless && !item.plug,
   });
 
   return (
     <>
-      <BungieImage src={item.icon} className={itemImageStyles} alt="" />
+      {useClassifiedPlaceholder ? (
+        <BucketIcon item={item} className={itemImageStyles} />
+      ) : (
+        <BungieImage src={item.icon} className={itemImageStyles} alt="" />
+      )}
       {item.iconOverlay && (
         <div className={styles.iconOverlay}>
           <BungieImage src={item.iconOverlay} />

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -1,7 +1,11 @@
 import { D2Categories } from 'app/destiny2/d2-bucket-categories';
 import { t } from 'app/i18next-t';
 import { isTrialsPassage, isWinsObjective } from 'app/inventory/store/objectives';
-import { THE_FORBIDDEN_BUCKET, uniqueEquipBuckets } from 'app/search/d2-known-values';
+import {
+  d2MissingIcon,
+  THE_FORBIDDEN_BUCKET,
+  uniqueEquipBuckets,
+} from 'app/search/d2-known-values';
 import { lightStats } from 'app/search/search-filter-values';
 import { errorLog, warnLog } from 'app/utils/log';
 import {
@@ -431,10 +435,7 @@ export function makeItem(
     isExotic: tiers[itemDef.inventory!.tierType] === 'Exotic',
     name,
     description: displayProperties.description,
-    icon:
-      overrideStyleItem?.displayProperties.icon ||
-      displayProperties.icon ||
-      '/img/misc/missing_icon_d2.png',
+    icon: overrideStyleItem?.displayProperties.icon || displayProperties.icon || d2MissingIcon,
     hiddenOverlay,
     iconOverlay,
     secondaryIcon: overrideStyleItem?.secondaryIcon || itemDef.secondaryIcon || itemDef.screenshot,

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -4,6 +4,7 @@ import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { DimRecord } from 'app/records/presentation-nodes';
+import { d2MissingIcon } from 'app/search/d2-known-values';
 import {
   DestinyAmmunitionType,
   DestinyClass,
@@ -242,7 +243,7 @@ function makeFakePursuitItem(
     isExotic: false,
     name: displayProperties.name,
     description: displayProperties.description,
-    icon: displayProperties.icon || '/img/misc/missing_icon_d2.png',
+    icon: displayProperties.icon || d2MissingIcon,
     notransfer: true,
     canPullFromPostmaster: false,
     id: '0', // zero for non-instanced is legacy hack

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -11,6 +11,8 @@ import {
 // this file has non-programatically decided information
 // hashes, names, & enums, hand-crafted and chosen by us
 
+export const d2MissingIcon = '/img/misc/missing_icon_d2.png';
+
 //
 // GAME MECHANICS KNOWN VALUES
 //


### PR DESCRIPTION
haha...

this helps mostly in postmaster, where DIM already knows an item's bucket, but the user can't infer it

![image](https://user-images.githubusercontent.com/68782081/157185667-ef0f3742-0489-469c-b681-feca1f1feb2a.png)
