### PR TITLE
introduce a no-class DimItem.classType

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -96,8 +96,11 @@ export interface DimItem {
   maxStackSize: number;
   /** Is this stack unique (one per account, sometimes two if you can move to vault)? */
   uniqueStack: boolean;
-  /** The class this item is restricted to. Unknown means it can be used by any class. */
-  classType: DestinyClass;
+  /**
+   * The class this item is restricted to. DestinyClass.Unknown means it can be used by any class.
+   * -1 is for classified armor, which, until proven otherwise, can't be equipped by any class.
+   * */
+  classType: DestinyClass | -1;
   /** The localized name of the class this item is restricted to. */
   classTypeNameLocalized: string;
   /** Whether this item can be locked. */

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -419,6 +419,18 @@ export function makeItem(
     }
   }
 
+  // we cannot trust the claimed class of redacted items. they all say Titan
+  const classType = itemDef.redacted
+    ? normalBucket.inArmor
+      ? instanceDef?.isEquipped && owner
+        ? // equipped armor gets marked as that character's class
+          owner.classType
+        : // unequipped armor gets marked "no class"
+          -1
+      : // other items are marked "any class"
+        DestinyClass.Unknown
+    : itemDef.classType;
+
   const createdItem: DimItem = {
     owner: owner?.id || 'unknown',
     // figure out what year this item is probably from
@@ -459,7 +471,7 @@ export function makeItem(
     equipRequiredLevel: instanceDef?.equipRequiredLevel ?? 0,
     maxStackSize: Math.max(itemDef.inventory!.maxStackSize, 1),
     uniqueStack: Boolean(itemDef.inventory!.stackUniqueLabel?.length),
-    classType: itemDef.classType, // 0: titan, 1: hunter, 2: warlock, 3: any
+    classType,
     classTypeNameLocalized: getClassTypeNameLocalized(itemDef.classType, defs),
     element,
     energy: instanceDef?.energy ?? null,

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -206,7 +206,8 @@ function computeStatDupeLower(
   allItems: DimItem[],
   customStats: Settings['customTotalStatsByClass'] = {}
 ) {
-  const armor = allItems.filter((i) => i.bucket.inArmor);
+  // disregard no-class armor
+  const armor = allItems.filter((i) => i.bucket.inArmor && i.classType !== -1);
 
   // Group by class and armor type. Also, compare exotics with each other, not the general pool.
   const grouped = Object.values(

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -288,7 +288,11 @@ function maxPowerKey(item: DimItem) {
 
 function calculateMaxPowerPerBucket(allItems: DimItem[]) {
   return _.mapValues(
-    _.groupBy(allItems, (i) => maxPowerKey(i)),
+    _.groupBy(
+      // disregard no-class armor
+      allItems.filter((i) => i.classType !== -1),
+      (i) => maxPowerKey(i)
+    ),
     (items) => _.maxBy(items, (i) => i.power)?.power ?? 0
   );
 }


### PR DESCRIPTION
fixes #8099

why is this safe?
because i reviewed all use of DimItem.classType and it's all using strict equalities and known values. only needed to fix cases where it was being used to key or build keys