### PR TITLE
Fix for crafting socket being displayed in the armory

### DIFF
--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -65,9 +65,10 @@ export default function ItemSocketsWeapons({ item, minimal, grid, onPlugClicked 
       getSocketByIndex(item.sockets!, c.socketIndexes[0])?.isPerk
   );
 
-  const excludedSocketCategoryHashes = item.crafted
-    ? [craftedSocketCategoryHash]
-    : [mementoSocketCategoryHash];
+  const excludedSocketCategoryHashes = [
+    craftedSocketCategoryHash,
+    !item.crafted && mementoSocketCategoryHash,
+  ];
 
   // Iterate in reverse category order so cosmetic mods are at the front
   const mods = [...item.sockets.categories]


### PR DESCRIPTION
This fixes a regression introduced by #8067 whereby the crafting socket started showing in the Armory page.
![dim-armory-crafting-socket](https://user-images.githubusercontent.com/17512262/157426378-d22eacfe-f7e1-427f-a4db-e54e6e83b0f2.png)
