### PR TITLE
only send stats to relative-ci on relative-ci labeled PRs

### DIFF
--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -7,10 +7,24 @@ on:
       - completed
 
 jobs:
-  build:
+  haslabel:
     runs-on: ubuntu-latest
+    outputs:
+      relative-ci: ${{ steps.haslabel.outputs.labeled-relative-ci }}
+    steps:
+      - name: Labeled to relative-ci
+        id: haslabel
+        uses: DanielTamkin/HasLabel@v1.0.4
+        with:
+          contains: 'relative-ci'
+
+  relative-ci:
+    runs-on: ubuntu-latest
+    needs: haslabel
+    if: needs.haslabel.outputs.relative-ci
     steps:
       - name: Send webpack stats to RelativeCI
+        if: steps.haslabel.outputs.labeled-relative-ci
         uses: relative-ci/agent-action@v2
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}


### PR DESCRIPTION
Only send webpack stats to relative ci on PRs labeled relative ci

Please do not apply this label prematurely.