### PR TITLE
highlight available, but unselected, plugs, in armory wishlist

### DIFF
--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -16,7 +16,15 @@ import styles from './AllWishlistRolls.m.scss';
  * (with some overrides to set some as "plugged", when spawned from a real item).
  * This would render much weirder if it were fed an owned inventory item.
  */
-export default function AllWishlistRolls({ item }: { item: DimItem }) {
+export default function AllWishlistRolls({
+  item,
+  realAvailablePlugHashes,
+}: {
+  item: DimItem;
+  // non-plugged, but available, plugs, from the real item this was spawned from.
+  // used to mark sockets as available
+  realAvailablePlugHashes?: number[];
+}) {
   const wishlistRolls = useSelector(wishListRollsForItemHashSelector(item.hash));
   const [goodRolls, badRolls] = _.partition(wishlistRolls, (r) => !r.isUndesirable);
 
@@ -25,20 +33,38 @@ export default function AllWishlistRolls({ item }: { item: DimItem }) {
       {goodRolls.length > 0 && (
         <>
           <h2>{t('Armory.WishlistedRolls', { count: goodRolls.length })}</h2>
-          <WishlistRolls item={item} wishlistRolls={goodRolls} />
+          <WishlistRolls
+            item={item}
+            wishlistRolls={goodRolls}
+            realAvailablePlugHashes={realAvailablePlugHashes}
+          />
         </>
       )}
       {badRolls.length > 0 && (
         <>
           <h2>{t('Armory.TrashlistedRolls', { count: badRolls.length })}</h2>
-          <WishlistRolls item={item} wishlistRolls={badRolls} />
+          <WishlistRolls
+            item={item}
+            wishlistRolls={badRolls}
+            realAvailablePlugHashes={realAvailablePlugHashes}
+          />
         </>
       )}
     </>
   );
 }
 
-function WishlistRolls({ wishlistRolls, item }: { wishlistRolls: WishListRoll[]; item: DimItem }) {
+function WishlistRolls({
+  wishlistRolls,
+  item,
+  realAvailablePlugHashes,
+}: {
+  wishlistRolls: WishListRoll[];
+  item: DimItem;
+  // non-plugged, but available, plugs, from the real item this was spawned from.
+  // used to mark sockets as available
+  realAvailablePlugHashes?: number[];
+}) {
   const groupedWishlistRolls = _.groupBy(wishlistRolls, (r) => r.notes || t('Armory.NoNotes'));
 
   // TODO: group by making a tree of least cardinality -> most?
@@ -65,6 +91,7 @@ function WishlistRolls({ wishlistRolls, item }: { wishlistRolls: WishListRoll[];
                         item={item}
                         socketInfo={socket}
                         hasMenu={false}
+                        notSelected={realAvailablePlugHashes?.includes(plug.plugDef.hash)}
                       />
                     )
                   );

--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -21,8 +21,10 @@ export default function AllWishlistRolls({
   realAvailablePlugHashes,
 }: {
   item: DimItem;
-  // non-plugged, but available, plugs, from the real item this was spawned from.
-  // used to mark sockets as available
+  /**
+   * non-plugged, but available, plugs, from the real item this was spawned from.
+   * used to mark sockets as available
+   */
   realAvailablePlugHashes?: number[];
 }) {
   const wishlistRolls = useSelector(wishListRollsForItemHashSelector(item.hash));
@@ -61,8 +63,10 @@ function WishlistRolls({
 }: {
   wishlistRolls: WishListRoll[];
   item: DimItem;
-  // non-plugged, but available, plugs, from the real item this was spawned from.
-  // used to mark sockets as available
+  /**
+   * non-plugged, but available, plugs, from the real item this was spawned from.
+   * used to mark sockets as available
+   */
   realAvailablePlugHashes?: number[];
 }) {
   const groupedWishlistRolls = _.groupBy(wishlistRolls, (r) => r.notes || t('Armory.NoNotes'));

--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -37,11 +37,15 @@ import Links from './Links';
 
 export default function Armory({
   itemHash,
-  sockets,
+  realItemSockets,
+  realAvailablePlugHashes,
 }: {
   itemHash: number;
   // this is used to pass a real DimItem's current "plugged" plugs, into the fake DimItem that Armory creates
-  sockets?: SocketOverrides;
+  realItemSockets?: SocketOverrides;
+  // non-plugged, but available, plugs, from the real item this was spawned from.
+  // used to mark sockets as available
+  realAvailablePlugHashes?: number[];
 }) {
   const dispatch = useThunkDispatch();
   const defs = useD2Definitions()!;
@@ -65,7 +69,7 @@ export default function Armory({
   // We apply socket overrides *twice* - once to set the original sockets, then to apply the user's chosen overrides
   const item = applySocketOverrides(
     defs,
-    applySocketOverrides(defs, itemWithoutSockets, sockets),
+    applySocketOverrides(defs, itemWithoutSockets, realItemSockets),
     socketOverrides
   );
 
@@ -236,7 +240,7 @@ export default function Armory({
           <ItemGrid items={storeItems} noLink />
         </>
       )}
-      <AllWishlistRolls item={item} />
+      <AllWishlistRolls item={item} realAvailablePlugHashes={realAvailablePlugHashes} />
     </div>
   );
 }

--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -41,10 +41,12 @@ export default function Armory({
   realAvailablePlugHashes,
 }: {
   itemHash: number;
-  // this is used to pass a real DimItem's current "plugged" plugs, into the fake DimItem that Armory creates
+  /** this is used to pass a real DimItem's current "plugged" plugs, into the fake DimItem that Armory creates */
   realItemSockets?: SocketOverrides;
-  // non-plugged, but available, plugs, from the real item this was spawned from.
-  // used to mark sockets as available
+  /**
+   * non-plugged, but available, plugs, from the real item this was spawned from.
+   * used to mark sockets as available
+   */
   realAvailablePlugHashes?: number[];
 }) {
   const dispatch = useThunkDispatch();

--- a/src/app/armory/ArmoryPage.tsx
+++ b/src/app/armory/ArmoryPage.tsx
@@ -27,7 +27,7 @@ export default function ArmoryPage({ account }: { account: DestinyAccount }) {
 
   return (
     <div className="dim-page">
-      <Armory key={itemHash} itemHash={itemHash} sockets={sockets} />
+      <Armory key={itemHash} itemHash={itemHash} realItemSockets={sockets} />
     </div>
   );
 }

--- a/src/app/armory/ArmorySheet.tsx
+++ b/src/app/armory/ArmorySheet.tsx
@@ -6,7 +6,7 @@ import Armory from './Armory';
 import styles from './ArmorySheet.m.scss';
 
 export default function ArmorySheet({ item, onClose }: { item: DimItem; onClose(): void }) {
-  const sockets = useMemo(
+  const realItemSockets = useMemo(
     () =>
       item.sockets
         ? Object.fromEntries(
@@ -17,11 +17,19 @@ export default function ArmorySheet({ item, onClose }: { item: DimItem; onClose(
         : {},
     [item.sockets]
   );
+  const realAvailablePlugHashes = useMemo(
+    () => item.sockets?.allSockets.flatMap((s) => s.plugOptions.map((p) => p.plugDef.hash)) ?? [],
+    [item.sockets]
+  );
 
   return (
     <Sheet onClose={onClose} sheetClassName={styles.sheet}>
       <ClickOutsideRoot>
-        <Armory itemHash={item.hash} sockets={sockets} />
+        <Armory
+          itemHash={item.hash}
+          realItemSockets={realItemSockets}
+          realAvailablePlugHashes={realAvailablePlugHashes}
+        />
       </ClickOutsideRoot>
     </Sheet>
   );


### PR DESCRIPTION
before -> after
![image](https://user-images.githubusercontent.com/68782081/157636470-21c92211-5b29-4a26-9ff1-42d7480a4152.png)![image](https://user-images.githubusercontent.com/68782081/157636485-9fb8adbb-30a9-4d92-8ec4-c9124d42f425.png)

the method of doing this feels pretty tortured... but armor is based on a fake DimItem and there's no available DimItem.sockets sidechannel to express this kind of info..