### PR TITLE
Fix assume armor masterwork and lock armor energy between loadouts and optimizer.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Assume armor masterwork and lock armor energy options will now be saved correctly when saving a loadout from the Loadout Optimizer and loaded correctly when Optimizing Armor.
+
 ## 7.8.0 <span class="changelog-date">(2022-03-06)</span>
 
 ### Changes

--- a/src/app/loadout-builder/filter/EnergyOptions.tsx
+++ b/src/app/loadout-builder/filter/EnergyOptions.tsx
@@ -70,12 +70,12 @@ export default function EnergyOptions({
       {
         label: t('LoadoutBuilder.None'),
         tooltip: t('LoadoutBuilder.LockElementOptions.None'),
-        selected: !lockArmorEnergyType,
+        selected: !lockArmorEnergyType || lockArmorEnergyType === LockArmorEnergyType.None,
         onChange: () => {
-          if (lockArmorEnergyType) {
+          if (lockArmorEnergyType && lockArmorEnergyType !== LockArmorEnergyType.None) {
             lbDispatch({
               type: 'lockArmorEnergyTypeChanged',
-              lockArmorEnergyType: undefined,
+              lockArmorEnergyType: LockArmorEnergyType.None,
             });
           }
         },
@@ -115,12 +115,12 @@ export default function EnergyOptions({
       {
         label: t('LoadoutBuilder.None'),
         tooltip: t('LoadoutBuilder.AssumeMasterworkOptions.None'),
-        selected: !assumeArmorMasterwork,
+        selected: !assumeArmorMasterwork || assumeArmorMasterwork === AssumeArmorMasterwork.None,
         onChange: () => {
-          if (assumeArmorMasterwork) {
+          if (assumeArmorMasterwork && assumeArmorMasterwork !== AssumeArmorMasterwork.None) {
             lbDispatch({
               type: 'assumeArmorMasterworkChanged',
-              assumeArmorMasterwork: undefined,
+              assumeArmorMasterwork: AssumeArmorMasterwork.None,
             });
           }
         },

--- a/src/app/loadout-drawer/loadout-type-converters.ts
+++ b/src/app/loadout-drawer/loadout-type-converters.ts
@@ -47,15 +47,20 @@ function convertDimLoadoutItemToLoadoutItem(item: DimLoadoutItem): LoadoutItem {
   return result;
 }
 
-function migrateUpgradeSpendTierAndLockItemEnergy(parameters: DimLoadout['parameters']): {
-  assumeArmorMasterwork: AssumeArmorMasterwork;
-  lockArmorEnergyType: LockArmorEnergyType;
-} {
+function migrateUpgradeSpendTierAndLockItemEnergy(
+  parameters: DimLoadout['parameters']
+): DimLoadout['parameters'] {
   const migrated = { ...parameters };
-  const { upgradeSpendTier, lockItemEnergyType } = migrated;
+  const { upgradeSpendTier, lockItemEnergyType, assumeArmorMasterwork, lockArmorEnergyType } =
+    migrated;
 
   delete migrated.upgradeSpendTier;
   delete migrated.lockItemEnergyType;
+  delete migrated.assumeMasterworked;
+
+  if (assumeArmorMasterwork || lockArmorEnergyType) {
+    return migrated;
+  }
 
   switch (upgradeSpendTier) {
     case UpgradeSpendTier.AscendantShards:


### PR DESCRIPTION
This should fix an issue where the assume armor masterwork and lock armor energy options are not saved correctly and can be broken in migration.

In relation to this I have also update the default loadout params [here](https://github.com/DestinyItemManager/dim-api/pull/97), I don't believe we need the API for this to work.