### PR TITLE
Move loadout drawer under a container component

### DIFF
--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -78,12 +78,13 @@ export default function LoadoutDrawer({
     []
   );
 
-  const onRemoveItem = (li: ResolvedLoadoutItem, e?: React.MouseEvent) => {
+  const onRemoveItem = (resolvedItem: ResolvedLoadoutItem, e?: React.MouseEvent) => {
     e?.stopPropagation();
-    stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
+    stateDispatch({ type: 'removeItem', resolvedItem });
   };
 
-  const onEquipItem = (item: DimItem) => stateDispatch({ type: 'equipItem', item, items });
+  const onEquipItem = (resolvedItem: ResolvedLoadoutItem) =>
+    stateDispatch({ type: 'equipItem', resolvedItem });
 
   /**
    * If an item comes in on the addItem$ observable, add it.

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -73,10 +73,9 @@ export default function LoadoutDrawer({
       stateDispatch({
         type: 'addItem',
         item,
-        items,
         equip,
       }),
-    [items]
+    []
   );
 
   const onRemoveItem = (item: DimItem, e?: React.MouseEvent) => {

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -10,7 +10,7 @@ import { deleteLoadout, updateLoadout } from 'app/loadout-drawer/actions';
 import { stateReducer } from 'app/loadout-drawer/loadout-drawer-reducer';
 import { addItem$ } from 'app/loadout-drawer/loadout-events';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
-import { Loadout } from 'app/loadout-drawer/loadout-types';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import LoadoutDrawerDropTarget from 'app/loadout-drawer/LoadoutDrawerDropTarget';
 import { useDefinitions } from 'app/manifest/selectors';
 import { AppIcon, faExclamationTriangle } from 'app/shell/icons';
@@ -78,9 +78,9 @@ export default function LoadoutDrawer({
     []
   );
 
-  const onRemoveItem = (item: DimItem, e?: React.MouseEvent) => {
+  const onRemoveItem = (li: ResolvedLoadoutItem, e?: React.MouseEvent) => {
     e?.stopPropagation();
-    stateDispatch({ type: 'removeItem', item, items });
+    stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
   };
 
   const onEquipItem = (item: DimItem) => stateDispatch({ type: 'equipItem', item, items });
@@ -95,8 +95,9 @@ export default function LoadoutDrawer({
   useEffect(onClose, [pathname, onClose]);
 
   /** Prompt the user to select a replacement for a missing item. */
-  const fixWarnItem = async (warnItem: DimItem) => {
+  const fixWarnItem = async (li: ResolvedLoadoutItem) => {
     const loadoutClassType = loadout?.classType;
+    const warnItem = li.item;
 
     setShowingItemPicker(true);
     try {
@@ -116,7 +117,7 @@ export default function LoadoutDrawer({
       });
 
       onAddItem(item);
-      onRemoveItem(warnItem);
+      onRemoveItem(li);
     } catch (e) {
     } finally {
       setShowingItemPicker(false);
@@ -203,10 +204,10 @@ export default function LoadoutDrawer({
                   {t('Loadouts.VendorsCannotEquip')}
                 </p>
                 <div className="loadout-warn-items">
-                  {warnitems.map(({ item }) => (
-                    <div key={item.id} className="loadout-item" onClick={() => fixWarnItem(item)}>
-                      <ClosableContainer onClose={(e) => onRemoveItem(item, e)}>
-                        <ItemIcon item={item} />
+                  {warnitems.map((li) => (
+                    <div key={li.item.id} className="loadout-item" onClick={() => fixWarnItem(li)}>
+                      <ClosableContainer onClose={(e) => onRemoveItem(li, e)}>
+                        <ItemIcon item={li.item} />
                       </ClosableContainer>
                     </div>
                   ))}

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
@@ -1,14 +1,11 @@
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
-import { itemSortOrderSelector } from 'app/settings/item-sort';
-import { sortItems } from 'app/shell/filters';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { AddButton } from './Buttons';
 import styles from './LoadoutDrawerBucket.m.scss';
 import LoadoutDrawerItem from './LoadoutDrawerItem';
@@ -24,20 +21,16 @@ export default function LoadoutDrawerBucket({
   items: ResolvedLoadoutItem[];
   pickLoadoutItem(bucket: InventoryBucket): void;
   equip(item: DimItem, e: React.MouseEvent): void;
-  remove(item: DimItem, e: React.MouseEvent): void;
+  remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
 }) {
-  const itemSortOrder = useSelector(itemSortOrderSelector);
-  const [equippedUnsorted, unequippedUnsorted] = _.partition(items, (li) => li.loadoutItem.equip);
-  const equippedItems = sortItems(
-    equippedUnsorted.map((li) => li.item),
-    itemSortOrder
-  );
-  const unequippedItems = sortItems(
-    unequippedUnsorted.map((li) => li.item),
-    itemSortOrder
-  );
+  const [equippedItems, unequippedItems] = _.partition(items, (li) => li.loadoutItem.equip);
+
   // Only allow one emblem
   const capacity = bucket.hash === BucketHashes.Emblems ? 1 : bucket.capacity;
+
+  const mapItem = (li: ResolvedLoadoutItem) => (
+    <LoadoutDrawerItem key={li.item.index} resolvedLoadoutItem={li} equip={equip} remove={remove} />
+  );
 
   return (
     <div className="loadout-bucket">
@@ -52,9 +45,7 @@ export default function LoadoutDrawerBucket({
             <div className="sub-bucket equipped">
               <div className="equipped-item">
                 {equippedItems.length > 0 ? (
-                  equippedItems.map((item) => (
-                    <LoadoutDrawerItem key={item.index} item={item} equip={equip} remove={remove} />
-                  ))
+                  equippedItems.map(mapItem)
                 ) : (
                   <AddButton
                     className={styles.equippedAddButton}
@@ -66,9 +57,7 @@ export default function LoadoutDrawerBucket({
             {(equippedItems.length > 0 || unequippedItems.length > 0) &&
               bucket.hash !== BucketHashes.Subclass && (
                 <div className="sub-bucket">
-                  {unequippedItems.map((item) => (
-                    <LoadoutDrawerItem key={item.index} item={item} equip={equip} remove={remove} />
-                  ))}
+                  {unequippedItems.map(mapItem)}
                   {equippedItems.length > 0 && unequippedItems.length < capacity - 1 && (
                     <AddButton onClick={() => pickLoadoutItem(bucket)} />
                   )}

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
@@ -1,5 +1,4 @@
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
-import { DimItem } from 'app/inventory/item-types';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import clsx from 'clsx';
@@ -20,7 +19,7 @@ export default function LoadoutDrawerBucket({
   bucket: InventoryBucket;
   items: ResolvedLoadoutItem[];
   pickLoadoutItem(bucket: InventoryBucket): void;
-  equip(item: DimItem, e: React.MouseEvent): void;
+  equip(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
   remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
 }) {
   const [equippedItems, unequippedItems] = _.partition(items, (li) => li.loadoutItem.equip);

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -58,7 +58,7 @@ export default function LoadoutDrawerContents({
   buckets: InventoryBuckets;
   items: ResolvedLoadoutItem[];
   equip(item: DimItem, e: React.MouseEvent): void;
-  remove(item: DimItem, e: React.MouseEvent): void;
+  remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
   add(item: DimItem, equip?: boolean): void;
   onUpdateLoadout(loadout: Loadout): void;
   onShowItemPicker(shown: boolean): void;

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -57,7 +57,7 @@ export default function LoadoutDrawerContents({
   loadout: Loadout;
   buckets: InventoryBuckets;
   items: ResolvedLoadoutItem[];
-  equip(item: DimItem, e: React.MouseEvent): void;
+  equip(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
   remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
   add(item: DimItem, equip?: boolean): void;
   onUpdateLoadout(loadout: Loadout): void;

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerItem.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerItem.tsx
@@ -1,7 +1,6 @@
 import ClassIcon from 'app/dim-ui/ClassIcon';
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
-import { DimItem } from 'app/inventory/item-types';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { BucketHashes } from 'data/d2/generated-enums';
 import React from 'react';
@@ -12,7 +11,7 @@ export default function LoadoutDrawerItem({
   remove,
 }: {
   resolvedLoadoutItem: ResolvedLoadoutItem;
-  equip(item: DimItem, e: React.MouseEvent): void;
+  equip(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
   remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
 }) {
   const onClose = (e: React.MouseEvent) => {
@@ -23,7 +22,7 @@ export default function LoadoutDrawerItem({
   const { item } = resolvedLoadoutItem;
 
   return (
-    <div onClick={(e) => equip(item, e)} className="loadout-item">
+    <div onClick={(e) => equip(resolvedLoadoutItem, e)} className="loadout-item">
       <ClosableContainer onClose={onClose} showCloseIconOnHover={true}>
         <ConnectedInventoryItem item={item} ignoreSelectedPerks={true} />
         {item.bucket.hash === BucketHashes.Subclass && (

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerItem.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerItem.tsx
@@ -2,22 +2,25 @@ import ClassIcon from 'app/dim-ui/ClassIcon';
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import { DimItem } from 'app/inventory/item-types';
+import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { BucketHashes } from 'data/d2/generated-enums';
 import React from 'react';
 
 export default function LoadoutDrawerItem({
-  item,
+  resolvedLoadoutItem,
   equip,
   remove,
 }: {
-  item: DimItem;
+  resolvedLoadoutItem: ResolvedLoadoutItem;
   equip(item: DimItem, e: React.MouseEvent): void;
-  remove(item: DimItem, e: React.MouseEvent): void;
+  remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
 }) {
   const onClose = (e: React.MouseEvent) => {
     e.stopPropagation();
-    remove(item, e);
+    remove(resolvedLoadoutItem, e);
   };
+
+  const { item } = resolvedLoadoutItem;
 
   return (
     <div onClick={(e) => equip(item, e)} className="loadout-item">

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -30,7 +30,7 @@ import { deleteLoadout, updateLoadout } from './actions';
 import { stateReducer } from './loadout-drawer-reducer';
 import { addItem$ } from './loadout-events';
 import { getItemsFromLoadoutItems } from './loadout-item-conversion';
-import { Loadout } from './loadout-types';
+import { Loadout, ResolvedLoadoutItem } from './loadout-types';
 import { createSubclassDefaultSocketOverrides } from './loadout-utils';
 import styles from './LoadoutDrawer2.m.scss';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
@@ -156,11 +156,13 @@ export default function LoadoutDrawer2({
   const handleNameChanged = (name: string) =>
     stateDispatch({ type: 'update', loadout: { ...loadout, name } });
 
-  const handleRemoveItem = (item: DimItem) => stateDispatch({ type: 'removeItem', item, items });
+  const handleRemoveItem = (li: ResolvedLoadoutItem) =>
+    stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
 
   /** Prompt the user to select a replacement for a missing item. */
-  const fixWarnItem = async (warnItem: DimItem) => {
+  const fixWarnItem = async (li: ResolvedLoadoutItem) => {
     const loadoutClassType = loadout?.classType;
+    const warnItem = li.item;
 
     setShowingItemPicker(true);
     try {
@@ -184,7 +186,7 @@ export default function LoadoutDrawer2({
       });
 
       onAddItem(item);
-      handleRemoveItem(warnItem);
+      handleRemoveItem(li);
     } catch (e) {
     } finally {
       setShowingItemPicker(false);
@@ -274,7 +276,6 @@ export default function LoadoutDrawer2({
           onClickPlaceholder={handleClickPlaceholder}
           onClickWarnItem={fixWarnItem}
           onClickSubclass={handleClickSubclass}
-          onRemoveItem={handleRemoveItem}
         />
         <div className={styles.inputGroup}>
           <button

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -93,10 +93,9 @@ export default function LoadoutDrawer2({
       stateDispatch({
         type: 'addItem',
         item,
-        items,
         equip,
       }),
-    [items]
+    []
   );
 
   /**

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -156,8 +156,8 @@ export default function LoadoutDrawer2({
   const handleNameChanged = (name: string) =>
     stateDispatch({ type: 'update', loadout: { ...loadout, name } });
 
-  const handleRemoveItem = (li: ResolvedLoadoutItem) =>
-    stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
+  const handleRemoveItem = (resolvedItem: ResolvedLoadoutItem) =>
+    stateDispatch({ type: 'removeItem', resolvedItem });
 
   /** Prompt the user to select a replacement for a missing item. */
   const fixWarnItem = async (li: ResolvedLoadoutItem) => {

--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 import { addItem$, editLoadout$ } from './loadout-events';
+import { generateMissingLoadoutItemId } from './loadout-item-conversion';
 import { convertDimApiLoadoutToLoadout } from './loadout-type-converters';
 import { Loadout } from './loadout-types';
 import { newLoadout } from './loadout-utils';
@@ -129,10 +130,8 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
               item.id === '0'
                 ? // We don't save consumables in D2 loadouts, but we may omit ids in shared loadouts
                   // (because they'll never match someone else's inventory). So
-                  // instead, pick a random ID. It's possible these will
-                  // conflict with something already in the user's inventory but
-                  // it's not likely.
-                  Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString()
+                  // instead, pick an ID.
+                  generateMissingLoadoutItemId()
                 : item.id,
           }));
 

--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -1,0 +1,177 @@
+import { DestinyAccount } from 'app/accounts/destiny-account';
+import LoadoutDrawer from 'app/destiny1/loadout-drawer/LoadoutDrawer';
+import { t } from 'app/i18next-t';
+import { DimItem } from 'app/inventory/item-types';
+import { storesSelector } from 'app/inventory/selectors';
+import { DimStore } from 'app/inventory/store-types';
+import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
+import { warnMissingClass } from 'app/loadout-builder/loadout-builder-reducer';
+import { useD2Definitions } from 'app/manifest/selectors';
+import { showNotification } from 'app/notifications/notifications';
+import { useEventBusListener } from 'app/utils/hooks';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router';
+import { v4 as uuidv4 } from 'uuid';
+import { addItem$, editLoadout$ } from './loadout-events';
+import { convertDimApiLoadoutToLoadout } from './loadout-type-converters';
+import { Loadout } from './loadout-types';
+import { newLoadout } from './loadout-utils';
+import LoadoutDrawer2 from './LoadoutDrawer2';
+
+/**
+ * A launcher for the LoadoutDrawer. This is used both so we can lazy-load the
+ * LoadoutDrawer, and so we can make sure defs are defined when the loadout
+ * drawer is rendered.
+ */
+export default function LoadoutDrawerContainer({ account }: { account: DestinyAccount }) {
+  const defs = useD2Definitions();
+  const navigate = useNavigate();
+  const { search: queryString, pathname } = useLocation();
+
+  // This state only holds the initial version of the loadout that launches the
+  // drawer - after that, the loadout drawer itself manages edits to the
+  // loadout.
+  // TODO: Alternately we could come up with the concept of a
+  // `useControlledReducer` that applied a reducer to mutate an object whose
+  // state is handled outside the component.
+  const [initialLoadout, setInitialLoadout] =
+    useState<{ loadout: Loadout; storeId?: string; showClass: boolean; isNew: boolean }>();
+
+  const handleDrawerClose = () => setInitialLoadout(undefined);
+
+  // The loadout to edit comes in from the editLoadout$ observable
+  useEventBusListener(
+    editLoadout$,
+    useCallback(({ loadout, storeId, showClass, isNew }) => {
+      setInitialLoadout({
+        loadout,
+        storeId: storeId === 'vault' ? undefined : storeId,
+        showClass: Boolean(showClass),
+        isNew: Boolean(isNew),
+      });
+    }, [])
+  );
+
+  const stores = useSelector(storesSelector);
+
+  const hasInitialLoadout = Boolean(initialLoadout);
+
+  // Only react to add item if there's not a loadout open (otherwise it'll be handled in the loadout drawer!)
+  useEventBusListener(
+    addItem$,
+    useCallback(
+      (item: DimItem) => {
+        if (!hasInitialLoadout) {
+          // If we don't have a loadout, this action was invoked via the "+ Loadout" button in item actions
+          let owner: DimStore =
+            item.owner === 'vault' ? getCurrentStore(stores)! : getStore(stores, item.owner)!;
+
+          if (item.classType !== DestinyClass.Unknown && item.classType !== owner.classType) {
+            const matchingStore = stores.find((s) => s.classType === item.classType);
+            if (!matchingStore) {
+              showNotification({
+                type: 'warning',
+                title: t('Loadouts.ClassTypeMissing', { className: item.classTypeNameLocalized }),
+              });
+              return;
+            }
+            owner = matchingStore;
+          }
+
+          const classType =
+            item.classType === DestinyClass.Unknown ? owner.classType : item.classType;
+          const draftLoadout = newLoadout('', [], classType);
+          draftLoadout.items.push({
+            id: item.id,
+            hash: item.hash,
+            equip: true,
+            amount: item.amount ?? 1,
+          });
+          setInitialLoadout({
+            loadout: draftLoadout,
+            storeId: owner.id,
+            isNew: true,
+            showClass: true,
+          });
+        }
+      },
+      [hasInitialLoadout, stores]
+    )
+  );
+
+  // Load in a full loadout specified in the URL
+  useEffect(() => {
+    if (!stores.length || !defs?.isDestiny2()) {
+      return;
+    }
+    const searchParams = new URLSearchParams(queryString);
+    const loadoutJSON = searchParams.get('loadout');
+    if (loadoutJSON) {
+      try {
+        const parsedLoadout = convertDimApiLoadoutToLoadout(JSON.parse(loadoutJSON));
+        if (parsedLoadout) {
+          const storeId =
+            parsedLoadout.classType === DestinyClass.Unknown
+              ? getCurrentStore(stores)?.id
+              : stores.find((s) => s.classType === parsedLoadout.classType)?.id;
+
+          if (!storeId) {
+            warnMissingClass(parsedLoadout.classType, defs);
+            return;
+          }
+
+          parsedLoadout.id = uuidv4();
+          parsedLoadout.items = parsedLoadout.items.map((item) => ({
+            ...item,
+            id:
+              item.id === '0'
+                ? // We don't save consumables in D2 loadouts, but we may omit ids in shared loadouts
+                  // (because they'll never match someone else's inventory). So
+                  // instead, pick a random ID. It's possible these will
+                  // conflict with something already in the user's inventory but
+                  // it's not likely.
+                  Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString()
+                : item.id,
+          }));
+
+          setInitialLoadout({
+            loadout: parsedLoadout,
+            storeId,
+            isNew: true,
+            showClass: false,
+          });
+        }
+      } catch (e) {
+        showNotification({
+          type: 'error',
+          title: t('Loadouts.BadLoadoutShare'),
+          body: t('Loadouts.BadLoadoutShareBody', { error: e.message }),
+        });
+      }
+      // Clear the loadout
+      navigate(pathname, { replace: true });
+    }
+  }, [defs, queryString, navigate, pathname, stores]);
+
+  if (initialLoadout) {
+    return account.destinyVersion === 2 ? (
+      <LoadoutDrawer2
+        initialLoadout={initialLoadout.loadout}
+        storeId={initialLoadout.storeId}
+        isNew={initialLoadout.isNew}
+        onClose={handleDrawerClose}
+      />
+    ) : (
+      <LoadoutDrawer
+        initialLoadout={initialLoadout.loadout}
+        storeId={initialLoadout.storeId}
+        isNew={initialLoadout.isNew}
+        showClass={initialLoadout.showClass}
+        onClose={handleDrawerClose}
+      />
+    );
+  }
+  return null;
+}

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -32,7 +32,11 @@ export type Action =
       equip?: boolean;
     }
   /** Applies socket overrides to the supplied item */
-  | { type: 'applySocketOverrides'; item: DimItem; socketOverrides: SocketOverrides }
+  | {
+      type: 'applySocketOverrides';
+      resolvedItem: ResolvedLoadoutItem;
+      socketOverrides: SocketOverrides;
+    }
   | { type: 'updateModsByBucket'; modsByBucket: LoadoutParameters['modsByBucket'] }
   /** Remove an item from the loadout */
   | { type: 'removeItem'; resolvedItem: ResolvedLoadoutItem }
@@ -91,9 +95,9 @@ export function stateReducer(defs: D2ManifestDefinitions | D1ManifestDefinitions
 
       case 'applySocketOverrides': {
         const { loadout } = state;
-        const { item, socketOverrides } = action;
+        const { resolvedItem, socketOverrides } = action;
         return loadout
-          ? { ...state, loadout: applySocketOverrides(loadout, item, socketOverrides) }
+          ? { ...state, loadout: applySocketOverrides(loadout, resolvedItem, socketOverrides) }
           : state;
       }
 
@@ -358,14 +362,14 @@ function equipItem(
 
 function applySocketOverrides(
   loadout: Readonly<Loadout>,
-  item: DimItem,
+  { loadoutItem: searchLoadoutItem }: ResolvedLoadoutItem,
   socketOverrides: SocketOverrides
 ) {
   return produce(loadout, (draftLoadout) => {
-    let loadoutItem = draftLoadout.items.find((li) => li.id === item.id);
+    let loadoutItem = draftLoadout.items.find((li) => li.id === searchLoadoutItem.id);
     // TODO: right now socketOverrides are only really used for subclasses, so we can match by hash
     if (!loadoutItem) {
-      loadoutItem = draftLoadout.items.find((li) => li.hash === item.hash);
+      loadoutItem = draftLoadout.items.find((li) => li.hash === searchLoadoutItem.hash);
     }
     if (loadoutItem) {
       loadoutItem.socketOverrides = socketOverrides;

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -1,9 +1,9 @@
 import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import { DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
-import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { showNotification } from 'app/notifications/notifications';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
@@ -12,31 +12,12 @@ import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import produce from 'immer';
 import _ from 'lodash';
 import { Loadout, LoadoutItem, ResolvedLoadoutItem } from './loadout-types';
-import { newLoadout } from './loadout-utils';
 
 export interface State {
-  loadout?: Readonly<Loadout>;
-  /**
-   * The store that provides context to how this loadout is being edited from.
-   * The store this edit session was launched from. This is to help pick which
-   * mods are enabled, which subclass items to show, etc.
-   */
-  storeId?: string;
-  showClass: boolean;
-  isNew: boolean;
+  loadout: Readonly<Loadout>;
 }
 
 export type Action =
-  /** Reset the tool (for when the sheet is closed) */
-  | { type: 'reset' }
-  /** Start editing a new or existing loadout */
-  | {
-      type: 'editLoadout';
-      loadout: Loadout;
-      storeId: string;
-      isNew: boolean;
-      showClass: boolean;
-    }
   /** Replace the current loadout with an updated one */
   | { type: 'update'; loadout: Loadout }
   /** Add an item to the loadout */
@@ -46,7 +27,6 @@ export type Action =
       items: ResolvedLoadoutItem[];
       equip?: boolean;
       socketOverrides?: SocketOverrides;
-      stores: DimStore[];
     }
   /** Applies socket overrides to the supplied item */
   | { type: 'applySocketOverrides'; item: DimItem; socketOverrides: SocketOverrides }
@@ -62,43 +42,24 @@ export type Action =
 /**
  * All state for this component is managed through this reducer and the Actions above.
  */
-export function stateReducer(state: State, action: Action): State {
-  switch (action.type) {
-    case 'reset':
-      return {
-        showClass: true,
-        isNew: false,
-        loadout: undefined,
-      };
+export function stateReducer(_defs: D2ManifestDefinitions | D1ManifestDefinitions) {
+  return (state: State, action: Action): State => {
+    switch (action.type) {
+      case 'update':
+        return {
+          ...state,
+          loadout: action.loadout,
+        };
 
-    case 'editLoadout': {
-      const { loadout, storeId, isNew, showClass } = action;
+      case 'addItem': {
+        const { loadout } = state;
+        const { item, items, equip, socketOverrides } = action;
 
-      return {
-        ...state,
-        loadout,
-        storeId: storeId === 'vault' ? undefined : storeId,
-        isNew,
-        showClass,
-      };
-    }
+        if (!itemCanBeInLoadout(item)) {
+          showNotification({ type: 'warning', title: t('Loadouts.OnlyItems') });
+          return state;
+        }
 
-    case 'update':
-      return {
-        ...state,
-        loadout: action.loadout,
-      };
-
-    case 'addItem': {
-      const { loadout } = state;
-      const { item, items, equip, socketOverrides, stores } = action;
-
-      if (!itemCanBeInLoadout(item)) {
-        showNotification({ type: 'warning', title: t('Loadouts.OnlyItems') });
-        return state;
-      }
-
-      if (loadout) {
         if (item.classType !== DestinyClass.Unknown && loadout.classType !== item.classType) {
           showNotification({
             type: 'warning',
@@ -111,219 +72,184 @@ export function stateReducer(state: State, action: Action): State {
           ...state,
           loadout: draftLoadout,
         };
+      }
+
+      case 'removeItem': {
+        const { loadout } = state;
+        const { item, items } = action;
+        return loadout ? { ...state, loadout: removeItem(loadout, item, items) } : state;
+      }
+
+      case 'equipItem': {
+        const { loadout } = state;
+        const { item, items } = action;
+        return loadout ? { ...state, loadout: equipItem(loadout, item, items) } : state;
+      }
+
+      case 'applySocketOverrides': {
+        const { loadout } = state;
+        const { item, socketOverrides } = action;
+        return loadout
+          ? { ...state, loadout: applySocketOverrides(loadout, item, socketOverrides) }
+          : state;
+      }
+
+      case 'updateModsByBucket': {
+        const { loadout } = state;
+        const { modsByBucket } = action;
+        return loadout
+          ? {
+              ...state,
+              loadout: {
+                ...loadout,
+                parameters: {
+                  ...loadout.parameters,
+                  modsByBucket: _.isEmpty(modsByBucket) ? undefined : modsByBucket,
+                },
+              },
+            }
+          : state;
+      }
+
+      case 'updateMods': {
+        const { loadout } = state;
+        const { mods } = action;
+        return loadout
+          ? {
+              ...state,
+              loadout: {
+                ...loadout,
+                parameters: {
+                  ...loadout.parameters,
+                  mods,
+                },
+              },
+            }
+          : state;
+      }
+
+      case 'changeClearMods': {
+        const { loadout } = state;
+        const { enabled } = action;
+        return loadout
+          ? {
+              ...state,
+              loadout: {
+                ...loadout,
+                parameters: {
+                  ...loadout.parameters,
+                  clearMods: enabled,
+                },
+              },
+            }
+          : state;
+      }
+
+      case 'removeMod': {
+        const { loadout } = state;
+        const { hash } = action;
+        if (loadout) {
+          const newLoadout = { ...loadout };
+          const newMods = newLoadout.parameters?.mods?.length
+            ? [...newLoadout.parameters.mods]
+            : [];
+          const index = newMods.indexOf(hash);
+          if (index !== -1) {
+            newMods.splice(index, 1);
+            newLoadout.parameters = {
+              ...newLoadout.parameters,
+              mods: newMods,
+            };
+            return { ...state, loadout: newLoadout };
+          }
+        }
+        return state;
+      }
+    }
+  };
+}
+
+/**
+ * Produce a new loadout that adds a new item to the given loadout.
+ */
+function addItem(
+  loadout: Readonly<Loadout>,
+  item: DimItem,
+  items: ResolvedLoadoutItem[],
+  equip?: boolean,
+  socketOverrides?: SocketOverrides
+): Loadout {
+  const loadoutItem: LoadoutItem = {
+    id: item.id,
+    hash: item.hash,
+    amount: 1,
+    equip: false,
+  };
+
+  // TODO: maybe we should just switch back to storing loadout items in memory by bucket
+
+  // Other items of the same type (as DimItem)
+  const typeInventory = items.filter((li) => li.item.bucket.hash === item.bucket.hash);
+  const dupe = loadout.items.find((i) => i.hash === item.hash && i.id === item.id);
+  const maxSlots = item.bucket.capacity;
+
+  return produce(loadout, (draftLoadout) => {
+    const findItem = ({ loadoutItem }: ResolvedLoadoutItem) =>
+      draftLoadout.items.find((i) => i.id === loadoutItem.id && i.hash === loadoutItem.hash)!;
+
+    if (!dupe) {
+      if (typeInventory.length < maxSlots) {
+        loadoutItem.equip =
+          equip !== undefined ? equip : item.equipment && typeInventory.length === 0;
+        if (loadoutItem.equip) {
+          for (const otherItem of typeInventory) {
+            findItem(otherItem).equip = false;
+          }
+        }
+
+        // Only allow one subclass to be present per class (to allow for making a loadout that specifies a subclass for each class)
+        if (item.bucket.hash === BucketHashes.Subclass) {
+          const conflictingItem = items.find(
+            (li) => li.item.bucket.hash === item.bucket.hash && li.item.classType === item.classType
+          );
+          if (conflictingItem) {
+            draftLoadout.items = draftLoadout.items.filter((i) => i.id !== conflictingItem.item.id);
+          }
+          loadoutItem.equip = true;
+        }
+
+        if (socketOverrides) {
+          loadoutItem.socketOverrides = socketOverrides;
+        }
+
+        draftLoadout.items.push(loadoutItem);
+
+        // If adding a new armor item, remove any fashion mods (shader/ornament) that couldn't be slotted
+        if (
+          item.bucket.inArmor &&
+          loadoutItem.equip &&
+          draftLoadout.parameters?.modsByBucket?.[item.bucket.hash]?.length
+        ) {
+          const cosmeticSockets = getSocketsByCategoryHash(
+            item.sockets,
+            SocketCategoryHashes.ArmorCosmetics
+          );
+          draftLoadout.parameters.modsByBucket[item.bucket.hash] =
+            draftLoadout.parameters.modsByBucket[item.bucket.hash].filter((plugHash) =>
+              cosmeticSockets.some((s) => s.plugSet?.plugs.some((p) => p.plugDef.hash === plugHash))
+            );
+        }
       } else {
-        // If we don't have a loadout, this action was invoked via the "+ Loadout" button in item actions
-        let owner: DimStore =
-          item.owner === 'vault' ? getCurrentStore(stores)! : getStore(stores, item.owner)!;
-
-        if (item.classType !== DestinyClass.Unknown && item.classType !== owner.classType) {
-          const matchingStore = stores.find((s) => s.classType === item.classType);
-          if (!matchingStore) {
-            showNotification({
-              type: 'warning',
-              title: t('Loadouts.ClassTypeMissing', { className: item.classTypeNameLocalized }),
-            });
-            return state;
-          }
-          owner = matchingStore;
-        }
-
-        const classType =
-          item.classType === DestinyClass.Unknown ? owner.classType : item.classType;
-        const draftLoadout = addItem(
-          newLoadout('', [], classType),
-          item,
-          items,
-          equip,
-          socketOverrides
-        );
-        return {
-          ...state,
-          loadout: draftLoadout,
-          storeId: owner.id,
-          isNew: true,
-        };
+        showNotification({
+          type: 'warning',
+          title: t('Loadouts.MaxSlots', { slots: maxSlots }),
+        });
       }
+    } else if (item.maxStackSize > 1) {
+      const increment = Math.min(dupe.amount + item.amount, item.maxStackSize) - dupe.amount;
+      dupe.amount += increment;
     }
-
-    case 'removeItem': {
-      const { loadout } = state;
-      const { item, items } = action;
-      return loadout ? { ...state, loadout: removeItem(loadout, item, items) } : state;
-    }
-
-    case 'equipItem': {
-      const { loadout } = state;
-      const { item, items } = action;
-      return loadout ? { ...state, loadout: equipItem(loadout, item, items) } : state;
-    }
-
-    case 'applySocketOverrides': {
-      const { loadout } = state;
-      const { item, socketOverrides } = action;
-      return loadout
-        ? { ...state, loadout: applySocketOverrides(loadout, item, socketOverrides) }
-        : state;
-    }
-
-    case 'updateModsByBucket': {
-      const { loadout } = state;
-      const { modsByBucket } = action;
-      return loadout
-        ? {
-            ...state,
-            loadout: {
-              ...loadout,
-              parameters: {
-                ...loadout.parameters,
-                modsByBucket: _.isEmpty(modsByBucket) ? undefined : modsByBucket,
-              },
-            },
-          }
-        : state;
-    }
-
-    case 'updateMods': {
-      const { loadout } = state;
-      const { mods } = action;
-      return loadout
-        ? {
-            ...state,
-            loadout: {
-              ...loadout,
-              parameters: {
-                ...loadout.parameters,
-                mods,
-              },
-            },
-          }
-        : state;
-    }
-
-    case 'changeClearMods': {
-      const { loadout } = state;
-      const { enabled } = action;
-      return loadout
-        ? {
-            ...state,
-            loadout: {
-              ...loadout,
-              parameters: {
-                ...loadout.parameters,
-                clearMods: enabled,
-              },
-            },
-          }
-        : state;
-    }
-
-    case 'removeMod': {
-      const { loadout } = state;
-      const { hash } = action;
-      if (loadout) {
-        const newLoadout = { ...loadout };
-        const newMods = newLoadout.parameters?.mods?.length ? [...newLoadout.parameters.mods] : [];
-        const index = newMods.indexOf(hash);
-        if (index !== -1) {
-          newMods.splice(index, 1);
-          newLoadout.parameters = {
-            ...newLoadout.parameters,
-            mods: newMods,
-          };
-          return { ...state, loadout: newLoadout };
-        }
-      }
-      return state;
-    }
-  }
-
-  /**
-   * Produce a new loadout that adds a new item to the given loadout.
-   */
-  function addItem(
-    loadout: Readonly<Loadout>,
-    item: DimItem,
-    items: ResolvedLoadoutItem[],
-    equip?: boolean,
-    socketOverrides?: SocketOverrides
-  ): Loadout {
-    const loadoutItem: LoadoutItem = {
-      id: item.id,
-      hash: item.hash,
-      amount: 1,
-      equip: false,
-    };
-
-    // TODO: maybe we should just switch back to storing loadout items in memory by bucket
-
-    // Other items of the same type (as DimItem)
-    const typeInventory = items.filter((li) => li.item.bucket.hash === item.bucket.hash);
-    const dupe = loadout.items.find((i) => i.hash === item.hash && i.id === item.id);
-    const maxSlots = item.bucket.capacity;
-
-    return produce(loadout, (draftLoadout) => {
-      const findItem = ({ loadoutItem }: ResolvedLoadoutItem) =>
-        draftLoadout.items.find((i) => i.id === loadoutItem.id && i.hash === loadoutItem.hash)!;
-
-      if (!dupe) {
-        if (typeInventory.length < maxSlots) {
-          loadoutItem.equip =
-            equip !== undefined ? equip : item.equipment && typeInventory.length === 0;
-          if (loadoutItem.equip) {
-            for (const otherItem of typeInventory) {
-              findItem(otherItem).equip = false;
-            }
-          }
-
-          // Only allow one subclass to be present per class (to allow for making a loadout that specifies a subclass for each class)
-          if (item.bucket.hash === BucketHashes.Subclass) {
-            const conflictingItem = items.find(
-              (li) =>
-                li.item.bucket.hash === item.bucket.hash && li.item.classType === item.classType
-            );
-            if (conflictingItem) {
-              draftLoadout.items = draftLoadout.items.filter(
-                (i) => i.id !== conflictingItem.item.id
-              );
-            }
-            loadoutItem.equip = true;
-          }
-
-          if (socketOverrides) {
-            loadoutItem.socketOverrides = socketOverrides;
-          }
-
-          draftLoadout.items.push(loadoutItem);
-
-          // If adding a new armor item, remove any fashion mods (shader/ornament) that couldn't be slotted
-          if (
-            item.bucket.inArmor &&
-            loadoutItem.equip &&
-            draftLoadout.parameters?.modsByBucket?.[item.bucket.hash]?.length
-          ) {
-            const cosmeticSockets = getSocketsByCategoryHash(
-              item.sockets,
-              SocketCategoryHashes.ArmorCosmetics
-            );
-            draftLoadout.parameters.modsByBucket[item.bucket.hash] =
-              draftLoadout.parameters.modsByBucket[item.bucket.hash].filter((plugHash) =>
-                cosmeticSockets.some((s) =>
-                  s.plugSet?.plugs.some((p) => p.plugDef.hash === plugHash)
-                )
-              );
-          }
-        } else {
-          showNotification({
-            type: 'warning',
-            title: t('Loadouts.MaxSlots', { slots: maxSlots }),
-          });
-        }
-      } else if (item.maxStackSize > 1) {
-        const increment = Math.min(dupe.amount + item.amount, item.maxStackSize) - dupe.amount;
-        dupe.amount += increment;
-      }
-    });
-  }
+  });
 }
 
 /**

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -30,6 +30,7 @@ export type Action =
        * equipped, undefined to accept a default based on what's already there
        */
       equip?: boolean;
+      socketOverrides?: SocketOverrides;
     }
   /** Applies socket overrides to the supplied item */
   | {
@@ -60,7 +61,7 @@ export function stateReducer(defs: D2ManifestDefinitions | D1ManifestDefinitions
 
       case 'addItem': {
         const { loadout } = state;
-        const { item, equip } = action;
+        const { item, equip, socketOverrides } = action;
 
         if (!itemCanBeInLoadout(item)) {
           showNotification({ type: 'warning', title: t('Loadouts.OnlyItems') });
@@ -74,7 +75,7 @@ export function stateReducer(defs: D2ManifestDefinitions | D1ManifestDefinitions
           });
           return state;
         }
-        const draftLoadout = addItem(defs, loadout, item, equip);
+        const draftLoadout = addItem(defs, loadout, item, equip, socketOverrides);
         return {
           ...state,
           loadout: draftLoadout,
@@ -183,7 +184,8 @@ function addItem(
   defs: D2ManifestDefinitions | D1ManifestDefinitions,
   loadout: Readonly<Loadout>,
   item: DimItem,
-  equip?: boolean
+  equip?: boolean,
+  socketOverrides?: SocketOverrides
 ): Loadout {
   const loadoutItem: LoadoutItem = {
     id: item.id,
@@ -191,6 +193,9 @@ function addItem(
     amount: 1,
     equip: false,
   };
+  if (socketOverrides) {
+    loadoutItem.socketOverrides = socketOverrides;
+  }
 
   // TODO: We really want to be operating against the resolved items, right? Should we re-resolve them here, or what?
   //       If we don't, we may not properly detect a dupe?

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -11,6 +11,11 @@ import { DimItem } from '../inventory/item-types';
 import { LoadoutItem, ResolvedLoadoutItem } from './loadout-types';
 import { findItemForLoadout } from './loadout-utils';
 
+let missingLoadoutItemId = 1;
+export function generateMissingLoadoutItemId() {
+  return `loadoutitem-${missingLoadoutItemId++}`;
+}
+
 /**
  * Turn the loadout's items into real DIM items. Any that don't exist in inventory anymore
  * are returned as warnitems.
@@ -64,7 +69,8 @@ export function getItemsFromLoadoutItems(
         ? makeFakeItem(defs, buckets, undefined, loadoutItem.hash)
         : makeFakeD1Item(defs, buckets, loadoutItem.hash);
       if (fakeItem) {
-        warnitems.push({ item: fakeItem, loadoutItem });
+        fakeItem.id = generateMissingLoadoutItemId();
+        warnitems.push({ item: fakeItem, loadoutItem, missing: true });
       } else {
         warnLog('loadout', "Couldn't create fake warn item for", loadoutItem);
       }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -42,6 +42,16 @@ export const fromEquippedTypes: (BucketHashes | D1BucketHashes)[] = [
   BucketHashes.Emblems,
 ];
 
+/**
+ * Buckets where the item should be treated as "singular" in a loadout - where
+ * it can only have a single item and that item must be equipped.
+ */
+export const singularBucketHashes = [
+  BucketHashes.Subclass,
+  BucketHashes.Emblems,
+  BucketHashes.Emotes_Invisible,
+];
+
 // order to display a list of all 8 gear slots
 const gearSlotOrder: BucketHashes[] = [...D2Categories.Weapons, ...D2Categories.Armor];
 

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -5,7 +5,7 @@ import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { Action } from 'app/loadout-drawer/loadout-drawer-reducer';
-import { Loadout, LoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { Loadout, LoadoutItem, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import {
   createSocketOverridesFromEquipped,
   extractArmorModHashes,
@@ -41,15 +41,13 @@ export default function LoadoutEdit({
   onClickSubclass,
   onClickPlaceholder,
   onClickWarnItem,
-  onRemoveItem,
 }: {
   loadout: Loadout;
   store: DimStore;
   stateDispatch: React.Dispatch<Action>;
   onClickSubclass: (subclass: DimItem | undefined) => void;
   onClickPlaceholder: (params: { bucket: InventoryBucket; equip: boolean }) => void;
-  onClickWarnItem: (item: DimItem) => void;
-  onRemoveItem: (item: DimItem) => void;
+  onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
 }) {
   const defs = useD2Definitions()!;
   const buckets = useSelector(bucketsSelector)!;
@@ -84,17 +82,15 @@ export default function LoadoutEdit({
     // TODO: do these all in one action
     for (const li of items.concat(warnitems)) {
       if (li.item.bucket.sort === category && li.item.bucket.hash !== BucketHashes.Subclass) {
-        stateDispatch({ type: 'removeItem', item: li.item, items });
+        stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
       }
     }
   };
 
-  const handleClearSubclass = () => {
-    // TODO: do these all in one action
-    if (subclass) {
-      stateDispatch({ type: 'removeItem', item: subclass.item, items });
-    }
-  };
+  const onRemoveItem = (li: ResolvedLoadoutItem) =>
+    stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
+
+  const handleClearSubclass = () => subclass && onRemoveItem(subclass);
 
   const updateLoadout = (loadout: Loadout) => stateDispatch({ type: 'update', loadout });
 
@@ -311,8 +307,10 @@ function setLoadoutSubclassFromEquipped(
   onUpdateLoadout(newLoadout);
 }
 
+// TODO: push into reducer
 export function fillLoadoutFromEquipped(
   loadout: Loadout,
+  // TODO: knock this out?
   items: DimItem[],
   dimStore: DimStore,
   onUpdateLoadout: (loadout: Loadout) => void,
@@ -395,6 +393,7 @@ export function fillLoadoutFromEquipped(
   onUpdateLoadout(newLoadout);
 }
 
+// TODO: push into reducer?
 export async function fillLoadoutFromUnequipped(
   loadout: Loadout,
   dimStore: DimStore,

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -82,13 +82,13 @@ export default function LoadoutEdit({
     // TODO: do these all in one action
     for (const li of items.concat(warnitems)) {
       if (li.item.bucket.sort === category && li.item.bucket.hash !== BucketHashes.Subclass) {
-        stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
+        stateDispatch({ type: 'removeItem', resolvedItem: li });
       }
     }
   };
 
-  const onRemoveItem = (li: ResolvedLoadoutItem) =>
-    stateDispatch({ type: 'removeItem', loadoutItem: li.loadoutItem });
+  const onRemoveItem = (resolvedItem: ResolvedLoadoutItem) =>
+    stateDispatch({ type: 'removeItem', resolvedItem });
 
   const handleClearSubclass = () => subclass && onRemoveItem(subclass);
 
@@ -123,8 +123,8 @@ export default function LoadoutEdit({
     [stateDispatch]
   );
 
-  const handleToggleEquipped = (item: DimItem) => {
-    stateDispatch({ type: 'equipItem', item, items });
+  const handleToggleEquipped = (resolvedItem: ResolvedLoadoutItem) => {
+    stateDispatch({ type: 'equipItem', resolvedItem });
   };
 
   const handleClearUnsetModsChanged = (enabled: boolean) => {

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -1,7 +1,7 @@
 import { t } from 'app/i18next-t';
 import { D2BucketCategory, InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { allItemsSelector, bucketsSelector, storesSelector } from 'app/inventory/selectors';
+import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { Action } from 'app/loadout-drawer/loadout-drawer-reducer';
@@ -52,7 +52,6 @@ export default function LoadoutEdit({
   onRemoveItem: (item: DimItem) => void;
 }) {
   const defs = useD2Definitions()!;
-  const stores = useSelector(storesSelector);
   const buckets = useSelector(bucketsSelector)!;
   const allItems = useSelector(allItemsSelector);
   const [plugDrawerOpen, setPlugDrawerOpen] = useState(false);
@@ -99,11 +98,8 @@ export default function LoadoutEdit({
 
   const updateLoadout = (loadout: Loadout) => stateDispatch({ type: 'update', loadout });
 
-  const onAddItem = useCallback(
-    (item: DimItem, equip?: boolean) =>
-      stateDispatch({ type: 'addItem', item, stores, items, equip }),
-    [items, stores, stateDispatch]
-  );
+  const onAddItem = (item: DimItem, equip?: boolean) =>
+    stateDispatch({ type: 'addItem', item, equip });
 
   const handleSyncModsFromEquipped = () => {
     const mods: number[] = [];
@@ -410,8 +406,6 @@ export async function fillLoadoutFromUnequipped(
   }
 
   const items = getUnequippedItemsForLoadout(dimStore, category);
-
-  // TODO: this isn't right - `items` isn't being updated after each add
   for (const item of items) {
     add(item, false);
   }

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -148,7 +148,6 @@ export default function LoadoutEdit({
 
   const anyClass = loadout.classType === DestinyClass.Unknown;
 
-  // TODO: i18n the category title
   // TODO: dedupe styles/code
   return (
     <div className={styles.contents}>

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -117,8 +117,8 @@ export default function LoadoutEdit({
   ) => stateDispatch({ type: 'updateModsByBucket', modsByBucket });
 
   const handleApplySocketOverrides = useCallback(
-    (item: DimItem, socketOverrides: SocketOverrides) => {
-      stateDispatch({ type: 'applySocketOverrides', item, socketOverrides });
+    (resolvedItem: ResolvedLoadoutItem, socketOverrides: SocketOverrides) => {
+      stateDispatch({ type: 'applySocketOverrides', resolvedItem, socketOverrides });
     },
     [stateDispatch]
   );
@@ -194,7 +194,7 @@ export default function LoadoutEdit({
                   subclass={subclass.item}
                   socketOverrides={subclass.loadoutItem.socketOverrides ?? {}}
                   onClose={() => setPlugDrawerOpen(false)}
-                  onAccept={(overrides) => handleApplySocketOverrides(subclass.item, overrides)}
+                  onAccept={(overrides) => handleApplySocketOverrides(subclass, overrides)}
                 />,
                 document.body
               )}

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -8,7 +8,7 @@ import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { bucketsSelector } from 'app/inventory/selectors';
 import { LockableBucketHashes } from 'app/loadout-builder/types';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
-import { getLoadoutStats } from 'app/loadout-drawer/loadout-utils';
+import { getLoadoutStats, singularBucketHashes } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { addIcon, AppIcon, faTshirt } from 'app/shell/icons';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
@@ -162,12 +162,11 @@ function ItemBucket({
   const handlePlaceholderClick = (equip: boolean) => onClickPlaceholder({ bucket, equip });
 
   // TODO: plumb through API from context??
-  // TODO: expose a menu item for adding more items?
-  // TODO: add-unequipped button?
   // T0DO: customize buttons in item popup?
   // TODO: draggable items?
 
-  const showAddUnequipped = equipped.length > 0 && unequipped.length < bucket.capacity - 1;
+  const maxSlots = singularBucketHashes.includes(bucket.hash) ? 1 : bucket.capacity;
+  const showAddUnequipped = equipped.length > 0 && unequipped.length < maxSlots - 1;
 
   const addUnequipped = showAddUnequipped && (
     <button

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -50,9 +50,9 @@ export default function LoadoutEditBucket({
     [bucketHash: number]: number[] | undefined;
   };
   onClickPlaceholder: (params: { bucket: InventoryBucket; equip: boolean }) => void;
-  onClickWarnItem: (item: DimItem) => void;
+  onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
   onToggleEquipped: (item: DimItem) => void;
-  onRemoveItem: (item: DimItem) => void;
+  onRemoveItem: (resolvedItem: ResolvedLoadoutItem) => void;
   children?: React.ReactNode;
 }) {
   const buckets = useSelector(bucketsSelector)!;
@@ -150,8 +150,8 @@ function ItemBucket({
   items: ResolvedLoadoutItem[];
   equippedContent?: React.ReactNode;
   onClickPlaceholder: (params: { bucket: InventoryBucket; equip: boolean }) => void;
-  onClickWarnItem: (item: DimItem) => void;
-  onRemoveItem: (item: DimItem) => void;
+  onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
+  onRemoveItem: (resolvedItem: ResolvedLoadoutItem) => void;
   onToggleEquipped: (item: DimItem) => void;
 }) {
   const bucketHash = bucket.hash;
@@ -188,27 +188,27 @@ function ItemBucket({
             className={clsx(styles.items, index === 0 ? styles.equipped : styles.unequipped)}
             key={index}
           >
-            {items.map(({ item, loadoutItem, missing }) => (
+            {items.map((li) => (
               <ClosableContainer
-                key={item.id}
-                onClose={() => onRemoveItem(item)}
+                key={li.item.id}
+                onClose={() => onRemoveItem(li)}
                 showCloseIconOnHover
               >
                 <ItemPopupTrigger
-                  item={item}
-                  extraData={{ socketOverrides: loadoutItem.socketOverrides }}
+                  item={li.item}
+                  extraData={{ socketOverrides: li.loadoutItem.socketOverrides }}
                 >
                   {(ref, onClick) => (
                     <div
                       className={clsx({
-                        [styles.missingItem]: missing,
+                        [styles.missingItem]: li.missing,
                       })}
                     >
                       <ConnectedInventoryItem
-                        item={item}
+                        item={li.item}
                         innerRef={ref}
-                        onClick={missing ? () => onClickWarnItem(item) : onClick}
-                        onDoubleClick={() => onToggleEquipped(item)}
+                        onClick={li.missing ? () => onClickWarnItem(li) : onClick}
+                        onDoubleClick={() => onToggleEquipped(li.item)}
                       />
                     </div>
                   )}

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -3,7 +3,7 @@ import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import { D2BucketCategory, InventoryBucket } from 'app/inventory/inventory-buckets';
-import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { bucketsSelector } from 'app/inventory/selectors';
 import { LockableBucketHashes } from 'app/loadout-builder/types';
@@ -51,7 +51,7 @@ export default function LoadoutEditBucket({
   };
   onClickPlaceholder: (params: { bucket: InventoryBucket; equip: boolean }) => void;
   onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
-  onToggleEquipped: (item: DimItem) => void;
+  onToggleEquipped: (resolvedItem: ResolvedLoadoutItem) => void;
   onRemoveItem: (resolvedItem: ResolvedLoadoutItem) => void;
   children?: React.ReactNode;
 }) {
@@ -152,7 +152,7 @@ function ItemBucket({
   onClickPlaceholder: (params: { bucket: InventoryBucket; equip: boolean }) => void;
   onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
   onRemoveItem: (resolvedItem: ResolvedLoadoutItem) => void;
-  onToggleEquipped: (item: DimItem) => void;
+  onToggleEquipped: (resolvedItem: ResolvedLoadoutItem) => void;
 }) {
   const bucketHash = bucket.hash;
   const [equipped, unequipped] = _.partition(items, (li) => li.loadoutItem.equip);
@@ -208,7 +208,7 @@ function ItemBucket({
                         item={li.item}
                         innerRef={ref}
                         onClick={li.missing ? () => onClickWarnItem(li) : onClick}
-                        onDoubleClick={() => onToggleEquipped(li.item)}
+                        onDoubleClick={() => onToggleEquipped(li)}
                       />
                     </div>
                   )}

--- a/src/app/loadout/loadout-edit/LoadoutEditBucketDropTarget.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucketDropTarget.tsx
@@ -1,6 +1,7 @@
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
+import { singularBucketHashes } from 'app/loadout-drawer/loadout-utils';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -53,7 +54,8 @@ export default function LoadoutEditBucketDropTarget({
       drop: () => ({ equipped }),
       canDrop: (i) =>
         itemCanBeInLoadout(i) &&
-        (i.classType === DestinyClass.Unknown || classType === i.classType),
+        (i.classType === DestinyClass.Unknown || classType === i.classType) &&
+        (equipped || !singularBucketHashes.includes(i.bucket.hash)),
       collect: (monitor) => ({
         isOver: monitor.isOver() && monitor.canDrop(),
         canDrop: monitor.canDrop(),
@@ -74,15 +76,17 @@ export default function LoadoutEditBucketDropTarget({
     <>
       {(canDropEquipped || canDropUnequipped) && (
         <div className={styles.options}>
-          <div
-            className={clsx({
-              [styles.over]: isOverEquipped,
-            })}
-            ref={equippedRef}
-          >
-            {t('Loadouts.Equipped')}
-          </div>
-          {!equippedOnly && (
+          {canDropEquipped && (
+            <div
+              className={clsx({
+                [styles.over]: isOverEquipped,
+              })}
+              ref={equippedRef}
+            >
+              {t('Loadouts.Equipped')}
+            </div>
+          )}
+          {!equippedOnly && canDropUnequipped && (
             <div
               className={clsx({
                 [styles.over]: isOverUnequipped,

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -3,7 +3,6 @@ import { getPlatforms, setActivePlatform } from 'app/accounts/platforms';
 import { accountsLoadedSelector, accountsSelector } from 'app/accounts/selectors';
 import ArmoryPage from 'app/armory/ArmoryPage';
 import Compare from 'app/compare/Compare';
-import LoadoutDrawer from 'app/destiny1/loadout-drawer/LoadoutDrawer';
 import { settingSelector } from 'app/dim-api/selectors';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import Farming from 'app/farming/Farming';
@@ -13,7 +12,7 @@ import InfusionFinder from 'app/infuse/InfusionFinder';
 import { storesSelector } from 'app/inventory/selectors';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import ItemFeedPage from 'app/item-feed/ItemFeedPage';
-import LoadoutDrawer2 from 'app/loadout-drawer/LoadoutDrawer2';
+import LoadoutDrawerContainer from 'app/loadout-drawer/LoadoutDrawerContainer';
 import { totalPostmasterItems } from 'app/loadout-drawer/postmaster';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { RootState } from 'app/store/types';
@@ -176,7 +175,6 @@ export default function Destiny() {
           <ErrorPanel
             title={t('Accounts.MissingTitle')}
             fallbackMessage={t('Accounts.MissingDescription')}
-            showTwitters={true}
           />
         </div>
       ) : (
@@ -256,7 +254,7 @@ export default function Destiny() {
           <Route path="*" element={<Navigate to="inventory" />} />
         </Routes>
       </div>
-      {account.destinyVersion === 2 ? <LoadoutDrawer2 /> : <LoadoutDrawer />}
+      <LoadoutDrawerContainer account={account} />
       <Compare />
       <Farming />
       <InfusionFinder />


### PR DESCRIPTION
This introduces a container component for the loadout drawer, such that the loadout drawer itself can always be guaranteed to have defs available. This allows for some nice improvements such as removing the dependency on resolved items state from all the reducer functions. It'll also allow us to code-split the loadout drawer, though that's not part of this change.