### PR TITLE
Add Vow of the Disciple raid mods to Loadout Optimizer and search filters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Fix organizer stats header alignment
+* Added Vow of the Disciple raid mods to Loadout Optimizer and search filters.
 
 ## 7.8.3 <span class="changelog-date">(2022-03-15)</span>
 

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -1,6 +1,7 @@
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { modTypeTagByPlugCategoryHash } from 'app/search/specialty-modslots';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
@@ -69,7 +70,10 @@ function Sockets({ item, lockedMods, size, onSocketClick }: Props) {
       toSave &&
       isPluggableItem(toSave) &&
       !undesirablePlugs.includes(toSave.plug.plugCategoryHash) &&
-      toSave.itemTypeDisplayName // account for plugs that look exotic-ish but are nothings
+      // account for plugs that look exotic-ish but are nothings
+      // but always include specialty mod slots, Vow mods don't have
+      // an itemTypeDisplayName https://github.com/Bungie-net/api/issues/1620
+      (toSave.itemTypeDisplayName || modTypeTagByPlugCategoryHash[toSave.plug.plugCategoryHash])
     ) {
       modsAndWhitelist.push({
         plugDef: toSave,

--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -55,6 +55,7 @@ export const modTypeTagByPlugCategoryHash = {
   [PlugCategoryHashes.EnhancementsSeasonV490]: 'chargedwithlight',
   [PlugCategoryHashes.EnhancementsRaidDescent]: 'deepstonecrypt',
   [PlugCategoryHashes.EnhancementsRaidV520]: 'vaultofglass',
+  [PlugCategoryHashes.EnhancementsRaidV600]: 'vowofthedisciple',
   [PlugCategoryHashes.EnhancementsSeasonV500]: 'combat',
 };
 
@@ -123,6 +124,14 @@ const modSocketMetadata: ModSocketMetadata[] = [
     compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsRaidV520],
     emptyModSocketHashes: [3738398030],
     emptyModSocketHash: 3738398030,
+  },
+  {
+    slotTag: 'vowofthedisciple',
+    compatibleModTags: ['vowofthedisciple'],
+    socketTypeHashes: [2381877427],
+    compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsRaidV600],
+    emptyModSocketHashes: [2447143568],
+    emptyModSocketHash: 2447143568,
   },
   {
     slotTag: 'combatstyle',


### PR DESCRIPTION
Due to https://github.com/Bungie-net/api/issues/1620 the plug drawer doesn't show a title for these, but typing "vow" in the search bar still finds the mods based on their descriptions. We could add our own "Vow of the Disciple Raid Mod" localization string or we could wait to see if there's any movement on the linked issue.