### PR TITLE
add reversible item sorting

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -968,6 +968,7 @@
     "Ratings": "Ratings",
     "ReloadDIM": "Reload DIM to finish switching language",
     "ResetToDefault": "Reset",
+    "ReverseSort": "Toggle forward/reverse sort",
     "SetSort": "Sort items by:",
     "Settings": "Settings",
     "ShowNewItems": "Show a red dot on new items",

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -14,7 +14,7 @@ import { shallowEqual } from 'fast-equals';
 import _ from 'lodash';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
-import { itemSortSettingsSelector } from '../settings/item-sort';
+import { ItemSortSettings, itemSortSettingsSelector } from '../settings/item-sort';
 import { addIcon, AppIcon } from '../shell/icons';
 import { InventoryBucket } from './inventory-buckets';
 import { DimItem } from './item-types';
@@ -42,10 +42,7 @@ interface StoreProps {
   storeClassType: DestinyClass;
   isVault: boolean;
   items: DimItem[];
-  itemSortSettings: {
-    sortOrder: string[];
-    sortReversals: string[];
-  };
+  itemSortSettings: ItemSortSettings;
   storeClassList: DestinyClass[];
   characterOrder: string;
 }

--- a/src/app/inventory/StoreBucket.tsx
+++ b/src/app/inventory/StoreBucket.tsx
@@ -14,7 +14,7 @@ import { shallowEqual } from 'fast-equals';
 import _ from 'lodash';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
-import { itemSortOrderSelector } from '../settings/item-sort';
+import { itemSortSettingsSelector } from '../settings/item-sort';
 import { addIcon, AppIcon } from '../shell/icons';
 import { InventoryBucket } from './inventory-buckets';
 import { DimItem } from './item-types';
@@ -42,7 +42,10 @@ interface StoreProps {
   storeClassType: DestinyClass;
   isVault: boolean;
   items: DimItem[];
-  itemSortOrder: string[];
+  itemSortSettings: {
+    sortOrder: string[];
+    sortReversals: string[];
+  };
   storeClassList: DestinyClass[];
   characterOrder: string;
 }
@@ -98,7 +101,7 @@ function mapStateToProps() {
       storeClassType: store.classType,
       isVault: store.isVault,
       items: internItems(items),
-      itemSortOrder: itemSortOrderSelector(state),
+      itemSortSettings: itemSortSettingsSelector(state),
       // We only need this property when this is a vault armor bucket
       storeClassList:
         store.isVault && bucket.inArmor
@@ -116,7 +119,7 @@ type Props = ProvidedProps & StoreProps;
  */
 function StoreBucket({
   items,
-  itemSortOrder,
+  itemSortSettings,
   bucket,
   storeId,
   destinyVersion,
@@ -152,7 +155,7 @@ function StoreBucket({
         {classTypeOrder.map((classType) => (
           <React.Fragment key={classType}>
             <ClassIcon classType={classType} className="armor-class-icon" />
-            {sortItems(itemsByClass[classType], itemSortOrder).map((item) => (
+            {sortItems(itemsByClass[classType], itemSortSettings).map((item) => (
               <StoreInventoryItem key={item.index} item={item} />
             ))}
           </React.Fragment>
@@ -163,10 +166,10 @@ function StoreBucket({
 
   const equippedItem = isVault ? undefined : items.find((i) => i.equipped);
   const unequippedItems = isVault
-    ? sortItems(items, itemSortOrder)
+    ? sortItems(items, itemSortSettings)
     : sortItems(
         items.filter((i) => !i.equipped),
-        itemSortOrder
+        itemSortSettings
       );
 
   return (

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -14,7 +14,7 @@ import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem } from '../inventory/item-types';
 import { allItemsSelector } from '../inventory/selectors';
 import { filterFactorySelector } from '../search/search-filter';
-import { itemSortOrderSelector } from '../settings/item-sort';
+import { itemSortSettingsSelector } from '../settings/item-sort';
 import { ItemPickerState } from './item-picker';
 import './ItemPicker.scss';
 
@@ -24,7 +24,10 @@ type ProvidedProps = ItemPickerState & {
 
 interface StoreProps {
   allItems: DimItem[];
-  itemSortOrder: string[];
+  itemSortSettings: {
+    sortOrder: string[];
+    sortReversals: string[];
+  };
   filters(query: string): ItemFilter;
 }
 
@@ -38,7 +41,7 @@ function mapStateToProps(): MapStateToProps<StoreProps, ProvidedProps> {
   return (state, ownProps) => ({
     allItems: filteredItemsSelector(state, ownProps),
     filters: filterFactorySelector(state),
-    itemSortOrder: itemSortOrderSelector(state),
+    itemSortSettings: itemSortSettingsSelector(state),
   });
 }
 
@@ -48,7 +51,7 @@ function ItemPicker({
   allItems,
   prompt,
   filters,
-  itemSortOrder,
+  itemSortSettings,
   sortBy,
   uniqueBy,
   ignoreSelectedPerks,
@@ -79,7 +82,7 @@ function ItemPicker({
 
   const filter = useMemo(() => filters(query), [filters, query]);
   const items = useMemo(() => {
-    let items = sortItems(allItems.filter(filter), itemSortOrder);
+    let items = sortItems(allItems.filter(filter), itemSortSettings);
     if (sortBy) {
       items = _.sortBy(items, sortBy);
     }
@@ -87,7 +90,7 @@ function ItemPicker({
       items = _.uniqBy(items, uniqueBy);
     }
     return items;
-  }, [allItems, filter, itemSortOrder, sortBy, uniqueBy]);
+  }, [allItems, filter, itemSortSettings, sortBy, uniqueBy]);
 
   // TODO: have compact and "list" views
   // TODO: long press for item popup

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -14,7 +14,7 @@ import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem } from '../inventory/item-types';
 import { allItemsSelector } from '../inventory/selectors';
 import { filterFactorySelector } from '../search/search-filter';
-import { itemSortSettingsSelector } from '../settings/item-sort';
+import { ItemSortSettings, itemSortSettingsSelector } from '../settings/item-sort';
 import { ItemPickerState } from './item-picker';
 import './ItemPicker.scss';
 
@@ -24,10 +24,7 @@ type ProvidedProps = ItemPickerState & {
 
 interface StoreProps {
   allItems: DimItem[];
-  itemSortSettings: {
-    sortOrder: string[];
-    sortReversals: string[];
-  };
+  itemSortSettings: ItemSortSettings;
   filters(query: string): ItemFilter;
 }
 

--- a/src/app/search/SearchResults.tsx
+++ b/src/app/search/SearchResults.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import Sheet from '../dim-ui/Sheet';
 import { DimItem } from '../inventory/item-types';
-import { itemSortOrderSelector } from '../settings/item-sort';
+import { itemSortSettingsSelector } from '../settings/item-sort';
 import styles from './SearchResults.m.scss';
 
 /**
@@ -17,7 +17,7 @@ import styles from './SearchResults.m.scss';
  * on mobile, and as a sheet when you hit "enter" on desktop.
  */
 export default function SearchResults({ items, onClose }: { items: DimItem[]; onClose(): void }) {
-  const itemSortOrder = useSelector(itemSortOrderSelector);
+  const itemSortSettings = useSelector(itemSortSettingsSelector);
 
   const header = (
     <div>
@@ -36,7 +36,7 @@ export default function SearchResults({ items, onClose }: { items: DimItem[]; on
     >
       <ClickOutsideRoot>
         <div className={clsx('sub-bucket', styles.contents)}>
-          {sortItems(items, itemSortOrder).map((item) => (
+          {sortItems(items, itemSortSettings).map((item) => (
             <DraggableInventoryItem key={item.index} item={item}>
               <ItemPopupTrigger item={item} key={item.index}>
                 {(ref, onClick) => (

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -29,7 +29,7 @@ import CharacterOrderEditor from './CharacterOrderEditor';
 import Checkbox from './Checkbox';
 import { useSetSetting } from './hooks';
 import { LoadoutSort, Settings } from './initial-settings';
-import { itemSortOrder } from './item-sort';
+import { itemSortSettings } from './item-sort';
 import Select, { mapToOptions } from './Select';
 import './settings.scss';
 import SortOrderEditor, { SortProperty } from './SortOrderEditor';
@@ -151,6 +151,10 @@ export default function SettingsPage() {
       'itemSortOrderCustom',
       sortOrder.filter((o) => o.enabled).map((o) => o.id)
     );
+    setSetting(
+      'itemSortReversals',
+      sortOrder.filter((o) => o.reversed).map((o) => o.id)
+    );
   };
 
   const characterSortOrderChanged = (order: string[]) => {
@@ -192,7 +196,7 @@ export default function SettingsPage() {
   }));
   vaultColOptions.unshift({ value: 999, name: t('Settings.ColumnSizeAuto') });
 
-  const sortOrder = itemSortOrder(settings);
+  const sortSettings = itemSortSettings(settings);
 
   const itemSortCustom = _.sortBy(
     _.map(
@@ -200,11 +204,12 @@ export default function SettingsPage() {
       (displayName, id): SortProperty => ({
         id,
         displayName,
-        enabled: sortOrder.includes(id),
+        enabled: sortSettings.sortOrder.includes(id),
+        reversed: sortSettings.sortReversals.includes(id),
       })
     ),
     (o) => {
-      const index = sortOrder.indexOf(o.id);
+      const index = sortSettings.sortOrder.indexOf(o.id);
       return index >= 0 ? index : 999;
     }
   );

--- a/src/app/settings/SortOrderEditor.scss
+++ b/src/app/settings/SortOrderEditor.scss
@@ -1,3 +1,5 @@
+@import '../variables';
+
 .sort-order-editor {
   padding: 4px 0 0 0;
 }
@@ -35,5 +37,12 @@
   .name {
     flex: 1;
     margin: 0 6px;
+  }
+
+  .sort-forward {
+    color: $orange;
+  }
+  .sort-reverse {
+    color: $blue;
   }
 }

--- a/src/app/settings/SortOrderEditor.tsx
+++ b/src/app/settings/SortOrderEditor.tsx
@@ -1,3 +1,4 @@
+import { t } from 'app/i18next-t';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React from 'react';
@@ -6,6 +7,8 @@ import {
   AppIcon,
   dragHandleIcon,
   enabledIcon,
+  maximizeIcon,
+  minimizeIcon,
   moveDownIcon,
   moveUpIcon,
   unselectedCheckIcon,
@@ -16,7 +19,7 @@ export interface SortProperty {
   readonly id: string;
   readonly displayName: string;
   readonly enabled: boolean;
-  // TODO, should we support up/down?
+  readonly reversed: boolean;
 }
 
 const SortEditorItemList = React.memo(({ order }: { order: SortProperty[] }) => (
@@ -61,9 +64,9 @@ export default function SortOrderEditor({
     moveItem(result.source.index, result.destination.index, true);
   };
 
-  const toggleItem = (index: number) => {
+  const toggleItem = (index: number, prop: 'enabled' | 'reversed') => {
     const orderArr = Array.from(order);
-    orderArr[index] = { ...orderArr[index], enabled: !orderArr[index].enabled };
+    orderArr[index] = { ...orderArr[index], [prop]: !orderArr[index][prop] };
     onSortOrderChanged(orderArr);
   };
 
@@ -82,7 +85,11 @@ export default function SortOrderEditor({
     } else if (target.classList.contains('sort-toggle')) {
       e.preventDefault();
       const index = getIndex();
-      toggleItem(index);
+      toggleItem(index, 'enabled');
+    } else if (target.classList.contains('direction-toggle')) {
+      e.preventDefault();
+      const index = getIndex();
+      toggleItem(index, 'reversed');
     }
   };
 
@@ -143,6 +150,14 @@ function SortEditorItem(props: { index: number; item: SortProperty }) {
           </span>
           <span className="sort-button sort-toggle">
             <AppIcon icon={item.enabled ? enabledIcon : unselectedCheckIcon} />
+          </span>
+          <span title={t('Settings.ReverseSort')} className="sort-button direction-toggle">
+            <AppIcon
+              icon={item.reversed ? maximizeIcon : minimizeIcon}
+              className={
+                item.enabled ? (item.reversed ? 'sort-reverse' : 'sort-forward') : undefined
+              }
+            />
           </span>
         </div>
       )}

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -19,6 +19,8 @@ export interface Settings extends DimApiSettings {
   itemFeedExpanded: boolean;
   /** Pull from postmaster is an irreversible action and some people don't want to accidentally hit it. */
   hidePullFromPostmaster: boolean;
+  /** supplements itemSortOrderCustom by allowing each sort to be reversed */
+  itemSortReversals: string[];
 }
 
 export const initialSettingsState: Settings = {
@@ -30,4 +32,5 @@ export const initialSettingsState: Settings = {
   itemFeedHideTagged: true,
   itemFeedExpanded: false,
   hidePullFromPostmaster: false,
+  itemSortReversals: [],
 };

--- a/src/app/settings/item-sort.ts
+++ b/src/app/settings/item-sort.ts
@@ -2,7 +2,12 @@ import { settingsSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
 import { Settings } from './initial-settings';
 
-export const itemSortSettings = (settings: Settings) => ({
+export type ItemSortSettings = {
+  sortOrder: Settings['itemSortOrderCustom'];
+  sortReversals: Settings['itemSortReversals'];
+};
+
+export const itemSortSettings: (settings: Settings) => ItemSortSettings = (settings: Settings) => ({
   sortOrder: settings.itemSortOrderCustom || ['primStat', 'name'],
   sortReversals: settings.itemSortReversals || [],
 });

--- a/src/app/settings/item-sort.ts
+++ b/src/app/settings/item-sort.ts
@@ -2,7 +2,10 @@ import { settingsSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
 import { Settings } from './initial-settings';
 
-export const itemSortOrder = (settings: Settings): string[] =>
-  settings.itemSortOrderCustom || ['primStat', 'name'];
+export const itemSortSettings = (settings: Settings) => ({
+  sortOrder: settings.itemSortOrderCustom || ['primStat', 'name'],
+  sortReversals: settings.itemSortReversals || [],
+});
 
-export const itemSortOrderSelector = (state: RootState) => itemSortOrder(settingsSelector(state));
+export const itemSortSettingsSelector = (state: RootState) =>
+  itemSortSettings(settingsSelector(state));

--- a/src/app/shell/item-comparators.ts
+++ b/src/app/shell/item-comparators.ts
@@ -3,6 +3,7 @@ import { itemHashTagsSelector, itemInfosSelector } from 'app/inventory/selectors
 import { getSeason } from 'app/inventory/store/season';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { D2ItemTiers } from 'app/search/d2-known-values';
+import { ItemSortSettings } from 'app/settings/item-sort';
 import { isSunset } from 'app/utils/item-utils';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -134,13 +135,7 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
 /**
  * Sort items according to the user's preferences (via the sort parameter).
  */
-export function sortItems(
-  items: DimItem[],
-  itemSortSettings: {
-    sortOrder: string[];
-    sortReversals: string[];
-  }
-) {
+export function sortItems(items: DimItem[], itemSortSettings: ItemSortSettings) {
   if (!items.length) {
     return items;
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -874,6 +874,7 @@
     "PerkList": "List",
     "ReloadDIM": "Reload DIM to finish switching language",
     "ResetToDefault": "Reset",
+    "ReverseSort": "Toggle forward/reverse sort",
     "SetSort": "Sort items by:",
     "Settings": "Settings",
     "ShowNewItems": "Show a red dot on new items",


### PR DESCRIPTION
adds a forward/backward toggle for inventory sort
![image](https://user-images.githubusercontent.com/68782081/158546505-dd1576a0-d8da-49b3-96b7-e5b9a8ff6e94.png)

wanted to keep settings structure simple, so i paired the two settings keys with a selector and they're each just an array of strings. very clean, and easy to provide defaults for.