### PR TITLE
Fix some issues with assuming valid `LoadoutItem.id`s

### DIFF
--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -73,12 +73,7 @@ export default function LoadoutDrawerContents({
       getCurrentStore(stores)!;
 
   const doFillLoadoutFromEquipped = () =>
-    fillLoadoutFromEquipped(
-      loadout,
-      items.map((li) => li.item),
-      dimStore,
-      onUpdateLoadout
-    );
+    fillLoadoutFromEquipped(loadout, items, dimStore, onUpdateLoadout);
   const doFillLoadOutFromUnequipped = () => fillLoadoutFromUnequipped(loadout, dimStore, add);
 
   const availableTypes = _.compact(loadoutTypes.map((h) => buckets.byHash[h]));
@@ -145,6 +140,8 @@ async function pickLoadoutItem(
 ) {
   const loadoutClassType = loadout?.classType;
   function loadoutHasItem(item: DimItem) {
+    // TODO: Accessing id is not safe because we resolve emblems.
+    // Should we use the definitions here too?
     return loadout?.items.some((i) => i.id === item.id && i.hash === item.hash);
   }
 
@@ -175,14 +172,14 @@ async function pickLoadoutItem(
 
 function fillLoadoutFromEquipped(
   loadout: Loadout,
-  items: DimItem[],
+  items: ResolvedLoadoutItem[],
   dimStore: DimStore,
   onUpdateLoadout: (loadout: Loadout) => void
 ) {
   if (!loadout) {
     return;
   }
-  const itemsByBucket = _.groupBy(items, (i) => i.bucket.hash);
+  const itemsByBucket = _.groupBy(items, (i) => i.item.bucket.hash);
 
   const newEquippedItems = dimStore.items.filter(
     (item) =>
@@ -190,12 +187,7 @@ function fillLoadoutFromEquipped(
   );
 
   const hasEquippedInBucket = (bucket: InventoryBucket) =>
-    itemsByBucket[bucket.hash]?.some(
-      (bucketItem) =>
-        loadout.items.find(
-          (loadoutItem) => bucketItem.hash === loadoutItem.hash && bucketItem.id === loadoutItem.id
-        )?.equip
-    );
+    itemsByBucket[bucket.hash]?.some((bucketItem) => bucketItem.loadoutItem.equip);
 
   const newLoadout = produce(loadout, (draftLoadout) => {
     for (const item of newEquippedItems) {

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -83,6 +83,7 @@ export function ItemTriage({ item }: { item: DimItem }) {
   // we rely on factorCombosLabels and itemFactors having the same number of elements,
   // because they are check the same factors
   const factorCombosLabels = getItemFactorComboDisplays(item);
+  // Accessing id is safe: ItemTriage is only weapons and armor (see above)
   const inLoadouts = loadouts.filter((l) => l.items.some((i) => i.id === item.id));
 
   return (

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -53,7 +53,7 @@ function createLoadoutUsingLOItems(
   setItems: DimItem[],
   subclass: ResolvedLoadoutItem | undefined,
   loadout: Loadout | undefined,
-  loadoutItems: ResolvedLoadoutItem[],
+  loadoutArmor: ResolvedLoadoutItem[],
   loadoutSubclass: ResolvedLoadoutItem | undefined,
   params: LoadoutParameters,
   notes: string | undefined
@@ -67,10 +67,12 @@ function createLoadoutUsingLOItems(
       }
 
       for (const item of draftLoadout.items) {
-        const existingLoadoutItem = loadoutItems.find((i) => i.item.id === item.id);
+        // Accessing id is safe: Armor is always instanced
+        const existingLoadoutItem = loadoutArmor.find((i) => i.item.id === item.id);
         const hasBeenReplaced =
           (existingLoadoutItem &&
             setItems.some((i) => i.bucket.hash === existingLoadoutItem.item.bucket.hash)) ||
+          // TODO: This fails to overwrite a migrated or received subclass!
           (subclass && item.id === loadoutSubclass?.item.id);
         if (!hasBeenReplaced) {
           newItems.push(item);
@@ -109,7 +111,7 @@ export default function CompareDrawer({
   const allItems = useSelector(allItemsSelector);
 
   // This probably isn't needed but I am being cautious as it iterates over the stores.
-  const { loadoutItems, loadoutSubclass } = useMemo(() => {
+  const { loadoutItems: loadoutArmor, loadoutSubclass } = useMemo(() => {
     const equippedItems = selectedLoadout?.items.filter((item) => item.equip);
     const [items] = getItemsFromLoadoutItems(
       equippedItems,
@@ -136,7 +138,7 @@ export default function CompareDrawer({
     setItems,
     subclass,
     selectedLoadout,
-    loadoutItems,
+    loadoutArmor,
     loadoutSubclass,
     params,
     notes

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -74,6 +74,7 @@ function GeneratedSet({
   for (const loadout of loadouts) {
     const equippedLoadoutItems = loadout.items.filter((item) => item.equip);
     const allSetItems = set.armor.flat();
+    // Accessing id is safe: Armor is always instanced
     const intersection = _.intersectionBy(allSetItems, equippedLoadoutItems, (item) => item.id);
     if (intersection.length === set.armor.length) {
       existingLoadout = loadout;

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -30,7 +30,7 @@ import { stateReducer } from './loadout-drawer-reducer';
 import { addItem$ } from './loadout-events';
 import { getItemsFromLoadoutItems } from './loadout-item-conversion';
 import { Loadout, ResolvedLoadoutItem } from './loadout-types';
-import { createSubclassDefaultSocketOverrides } from './loadout-utils';
+import { createSubclassDefaultSocketOverrides, findSameLoadoutItemIndex } from './loadout-utils';
 import styles from './LoadoutDrawer2.m.scss';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import LoadoutDrawerFooter from './LoadoutDrawerFooter';
@@ -204,7 +204,7 @@ export default function LoadoutDrawer2({
     bucket: InventoryBucket;
     equip: boolean;
   }) => {
-    pickLoadoutItem(loadout, bucket, (item) => onAddItem(item, equip), setShowingItemPicker);
+    pickLoadoutItem(defs, loadout, bucket, (item) => onAddItem(item, equip), setShowingItemPicker);
   };
 
   const handleClickSubclass = () =>
@@ -265,14 +265,7 @@ export default function LoadoutDrawer2({
           <button
             type="button"
             className="dim-button"
-            onClick={() =>
-              fillLoadoutFromEquipped(
-                loadout,
-                items.map((li) => li.item),
-                store,
-                handleUpdateLoadout
-              )
-            }
+            onClick={() => fillLoadoutFromEquipped(loadout, items, store, handleUpdateLoadout)}
           >
             <AppIcon icon={addIcon} /> {t('Loadouts.FillFromEquipped')}
           </button>
@@ -332,15 +325,15 @@ function filterLoadoutToAllowedItems(
 }
 
 async function pickLoadoutItem(
+  defs: D1ManifestDefinitions | D2ManifestDefinitions,
   loadout: Loadout,
   bucket: InventoryBucket,
   add: (item: DimItem) => void,
   onShowItemPicker: (shown: boolean) => void
 ) {
   const loadoutClassType = loadout?.classType;
-  function loadoutHasItem(item: DimItem) {
-    return loadout?.items.some((i) => i.id === item.id && i.hash === item.hash);
-  }
+  const loadoutHasItem = (item: DimItem) =>
+    findSameLoadoutItemIndex(defs, loadout.items, item) !== -1;
 
   onShowItemPicker(true);
   try {

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -412,6 +412,7 @@ function doApplyLoadout(
                   state.itemStates[initialItem.index].state =
                     // If we're doing a bulk equip later, set to MovedPendingEquip
                     itemsToEquip.length > 1 &&
+                    // TODO: The actual item may have a different ID, so we erroneously consider those items equipped!
                     itemsToEquip.some((loadoutItem) => loadoutItem.id === updatedItem.id)
                       ? LoadoutItemState.MovedPendingEquip
                       : LoadoutItemState.Succeeded;
@@ -453,6 +454,7 @@ function doApplyLoadout(
           (s) => s.equip && s.state === LoadoutItemState.MovedPendingEquip
         );
         // Use the bulk equipAll API to equip all at once.
+        // TODO: The actual item may have a different ID, so we fail to find the item here!
         itemsToEquip = itemsToEquip.filter((i) =>
           successfulItems.some((si) => si.item.id === i.id)
         );
@@ -918,14 +920,10 @@ function applyLoadoutMods(
     // item in the loadout, use the current equipped item (whatever it is)
     // instead.
     const currentEquippedArmor = store.items.filter((i) => i.bucket.inArmor && i.equipped);
-    const equippedLoadoutItems = loadoutItems.filter((item) => item.equip);
     const loadoutDimItems: DimItem[] = [];
     for (const loadoutItem of loadoutItems) {
       const item = getLoadoutItem(loadoutItem);
-      if (
-        item?.bucket.inArmor &&
-        equippedLoadoutItems.some((loadoutItem) => loadoutItem.id === item.id)
-      ) {
+      if (item?.bucket.inArmor && loadoutItem.equip) {
         loadoutDimItems.push(item);
       }
     }

--- a/src/app/loadout-drawer/loadout-types.ts
+++ b/src/app/loadout-drawer/loadout-types.ts
@@ -2,7 +2,16 @@ import { Loadout as DimApiLoadout } from '@destinyitemmanager/dim-api-types';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 
 export interface LoadoutItem {
+  /**
+   * The item's id. There's no guarantee that the item this resolves to
+   * actually has that id (subclasses, emblems, ...) so avoid accessing
+   * it unless you know you're only looking at instanced items.
+   */
   id: string;
+  /**
+   * The item's hash. There's also no guarantee that the resolved item
+   * has this hash because we have migration from subclasses to their 3.0 form.
+   */
   hash: number;
   amount: number;
   /** Whether or not the item should be equipped when the loadout is applied. */

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -415,9 +415,9 @@ const matchByHash = [
 
 function getResolutionInfo(
   defs: D1ManifestDefinitions | D2ManifestDefinitions,
-  loadoutItem: LoadoutItem
+  loadoutItemHash: number
 ) {
-  const hash = oldToNewItems[loadoutItem.hash] ?? loadoutItem.hash;
+  const hash = oldToNewItems[loadoutItemHash] ?? loadoutItemHash;
 
   const def = defs.InventoryItem.get(hash) as
     | undefined
@@ -454,9 +454,9 @@ function getResolutionInfo(
 export function findSameLoadoutItemIndex(
   defs: D1ManifestDefinitions | D2ManifestDefinitions,
   loadoutItems: LoadoutItem[],
-  loadoutItem: LoadoutItem
+  loadoutItem: Pick<LoadoutItem, 'hash' | 'id'>
 ) {
-  const info = getResolutionInfo(defs, loadoutItem);
+  const info = getResolutionInfo(defs, loadoutItem.hash);
 
   return loadoutItems.findIndex((i) => {
     const newHash = oldToNewItems[i.hash] ?? i.hash;
@@ -473,7 +473,7 @@ export function findItemForLoadout(
   storeId: string | undefined,
   loadoutItem: LoadoutItem
 ): DimItem | undefined {
-  const info = getResolutionInfo(defs, loadoutItem);
+  const info = getResolutionInfo(defs, loadoutItem.hash);
 
   // TODO: so inefficient to look through all items over and over again - need an index by ID and hash
   if (info.instanced) {

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -401,14 +401,22 @@ const oldToNewItems = {
 };
 
 /**
- * Given a loadout item specification, find the corresponding inventory item we should use.
+ * Items that are technically instanced but should always
+ * be matched by hash.
  */
-export function findItemForLoadout(
+const matchByHash = [
+  BucketHashes.Subclass,
+  BucketHashes.Shaders,
+  BucketHashes.Emblems,
+  BucketHashes.Emotes_Invisible,
+  BucketHashes.Emotes_Equippable,
+  D1BucketHashes.Horn,
+];
+
+function getResolutionInfo(
   defs: D1ManifestDefinitions | D2ManifestDefinitions,
-  allItems: DimItem[],
-  storeId: string | undefined,
   loadoutItem: LoadoutItem
-): DimItem | undefined {
+) {
   const hash = oldToNewItems[loadoutItem.hash] ?? loadoutItem.hash;
 
   const def = defs.InventoryItem.get(hash) as
@@ -427,31 +435,56 @@ export function findItemForLoadout(
   // Instanced items match by ID, uninstanced match by hash. It'd actually be
   // nice to use "is random rolled or configurable" here instead but that's hard
   // to determine.
-  // TODO: this might be nice to add to DimItem
   const bucketHash = def.bucketTypeHash || def.inventory?.bucketTypeHash || 0;
   const instanced =
     (def.instanced || def.inventory?.isInstanceItem) &&
     // Subclasses and some other types are technically instanced but should be matched by hash
-    ![
-      BucketHashes.Subclass,
-      BucketHashes.Shaders,
-      BucketHashes.Emblems,
-      BucketHashes.Emotes_Invisible,
-      BucketHashes.Emotes_Equippable,
-      D1BucketHashes.Horn,
-    ].includes(bucketHash);
+    !matchByHash.includes(bucketHash);
+
+  return {
+    hash,
+    instanced,
+  };
+}
+
+/**
+ * Returns the index of the LoadoutItem in the list of loadoutItems that would
+ * resolve to the same item as loadoutItem, or -1 if not found.
+ */
+export function findSameLoadoutItemIndex(
+  defs: D1ManifestDefinitions | D2ManifestDefinitions,
+  loadoutItems: LoadoutItem[],
+  loadoutItem: LoadoutItem
+) {
+  const info = getResolutionInfo(defs, loadoutItem);
+
+  return loadoutItems.findIndex((i) => {
+    const newHash = oldToNewItems[i.hash] ?? i.hash;
+    return info.hash === newHash && (!info.instanced || loadoutItem.id === i.id);
+  });
+}
+
+/**
+ * Given a loadout item specification, find the corresponding inventory item we should use.
+ */
+export function findItemForLoadout(
+  defs: D1ManifestDefinitions | D2ManifestDefinitions,
+  allItems: DimItem[],
+  storeId: string | undefined,
+  loadoutItem: LoadoutItem
+): DimItem | undefined {
+  const info = getResolutionInfo(defs, loadoutItem);
 
   // TODO: so inefficient to look through all items over and over again - need an index by ID and hash
-  if (instanced) {
+  if (info.instanced) {
     return allItems.find((item) => item.id === loadoutItem.id);
   }
 
   // This is mostly for subclasses - it finds all matching items by hash and then picks the one that's on the desired character
-  const candidates = allItems.filter((item) => item.hash === hash);
-  return (
-    (storeId !== undefined ? candidates.find((item) => item.owner === storeId) : undefined) ??
-    candidates[0]
-  );
+  const candidates = allItems.filter((item) => item.hash === info.hash);
+  const onCurrent =
+    storeId !== undefined ? candidates.find((item) => item.owner === storeId) : undefined;
+  return onCurrent ?? (candidates[0]?.notransfer ? undefined : candidates[0]);
 }
 
 export function isMissingItems(

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -456,7 +456,7 @@ export function findSameLoadoutItemIndex(
   loadoutItems: LoadoutItem[],
   loadoutItem: Pick<LoadoutItem, 'hash' | 'id'>
 ) {
-  const info = getResolutionInfo(defs, loadoutItem.hash);
+  const info = getResolutionInfo(defs, loadoutItem.hash)!;
 
   return loadoutItems.findIndex((i) => {
     const newHash = oldToNewItems[i.hash] ?? i.hash;
@@ -474,6 +474,10 @@ export function findItemForLoadout(
   loadoutItem: LoadoutItem
 ): DimItem | undefined {
   const info = getResolutionInfo(defs, loadoutItem.hash);
+
+  if (!info) {
+    return;
+  }
 
   // TODO: so inefficient to look through all items over and over again - need an index by ID and hash
   if (info.instanced) {

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -207,13 +207,7 @@ export default function LoadoutEdit({
             title={t(`Bucket.${category}`, { contextList: 'buckets' })}
             onClear={() => handleClearCategory(category)}
             onFillFromEquipped={() =>
-              fillLoadoutFromEquipped(
-                loadout,
-                items.map((li) => li.item),
-                store,
-                updateLoadout,
-                category
-              )
+              fillLoadoutFromEquipped(loadout, items, store, updateLoadout, category)
             }
             fillFromInventoryCount={getUnequippedItemsForLoadout(store, category).length}
             onFillFromInventory={() =>
@@ -310,7 +304,7 @@ function setLoadoutSubclassFromEquipped(
 export function fillLoadoutFromEquipped(
   loadout: Loadout,
   // TODO: knock this out?
-  items: DimItem[],
+  items: ResolvedLoadoutItem[],
   dimStore: DimStore,
   onUpdateLoadout: (loadout: Loadout) => void,
   // This is a bit dangerous as it is only used from the new loadout edit drawer and
@@ -321,7 +315,7 @@ export function fillLoadoutFromEquipped(
     return;
   }
 
-  const itemsByBucket = _.groupBy(items, (li) => li.bucket.hash);
+  const itemsByBucket = _.groupBy(items, (li) => li.item.bucket.hash);
 
   const newEquippedItems = dimStore.items.filter(
     (item) =>
@@ -335,12 +329,7 @@ export function fillLoadoutFromEquipped(
   );
 
   const hasEquippedInBucket = (bucket: InventoryBucket) =>
-    itemsByBucket[bucket.hash]?.some(
-      (bucketItem) =>
-        loadout.items.find(
-          (loadoutItem) => bucketItem.hash === loadoutItem.hash && bucketItem.id === loadoutItem.id
-        )?.equip
-    );
+    itemsByBucket[bucket.hash]?.some((bucketItem) => bucketItem.loadoutItem.equip);
 
   const newLoadout = produce(loadout, (draftLoadout) => {
     const mods: number[] = [];

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -534,6 +534,7 @@ export function getColumns(
       header: t('Organizer.Columns.Loadouts'),
       value: () => 0,
       cell: (_val, item) => {
+        // Accessing id is safe: Organizer is only weapons and armor
         const inloadouts = loadouts.filter((l) => l.items.some((i) => i.id === item.id));
         return (
           inloadouts.length > 0 &&

--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -39,6 +39,8 @@ function collectItemsInLoadouts(loadouts: Loadout[]) {
   for (const loadout of loadouts) {
     for (const item of loadout.items) {
       if (item.id && item.id !== '0') {
+        // TODO: This very inconsistently matches subclasses and emblems
+        // because they have complicated resolution logic.
         loadoutItemIds.add(item.id);
       }
     }

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -217,6 +217,8 @@ function getStatValuesByHash(item: DimItem, byWhichValue: 'base' | 'value') {
 function findMaxStatLoadout(stores: DimStore[], allItems: DimItem[], statName: string) {
   const maxStatHash = statHashByName[statName];
   return stores.flatMap((store) =>
+    // Accessing id is safe: maxStatLoadout only includes items with a power level,
+    // i.e. only weapons and armor and those are instanced.
     maxStatLoadout(maxStatHash, allItems, store).items.map((i) => i.id)
   );
 }


### PR DESCRIPTION
I went through all IDE-reported reads of `LoadoutItem.id` and tried to either remove them or to justify them. This should fix a number of bugs, but in the process I also uncovered some more bugs, so this is WIP until I decide whether to address them here or later.