### PR TITLE
Fix perk list layout when missing origin perk

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix organizer stats header alignment
 * Added Vow of the Disciple raid mods to Loadout Optimizer and search filters.
+* Fixed some weird spacing in the item popup perk list when a gun could but doesn't have an origin perk.
 
 ## 7.8.3 <span class="changelog-date">(2022-03-15)</span>
 

--- a/src/app/item-popup/ItemPerksList.tsx
+++ b/src/app/item-popup/ItemPerksList.tsx
@@ -71,6 +71,10 @@ function PerkSocket({
   selectedPerk?: { socketIndex: number; perkHash: number };
   onPerkSelected(socketInfo: DimSocket, plug: DimPlug): void;
 }) {
+  if (!socket.plugOptions.length) {
+    return null;
+  }
+
   return (
     <div className={styles.socket}>
       {socket.plugOptions.map((plug) => (


### PR DESCRIPTION
E.g. the Palindrome def now has an origin perk socket but legacy rolls don't get them retroactively.

![grafik](https://user-images.githubusercontent.com/14299449/159082803-60df9ce4-ba75-4d1f-a88a-9b09d8a1f15d.png)
->
![grafik](https://user-images.githubusercontent.com/14299449/159082817-e7bac6c9-6b6c-4a58-bcb0-2081932c2659.png)
