### PR TITLE
Clean up LoadoutDrawer reducer

### DIFF
--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -164,7 +164,7 @@ export default function LoadoutDrawer({
   };
 
   const handleNotesChanged: React.ChangeEventHandler<HTMLTextAreaElement> = (e) =>
-    stateDispatch({ type: 'update', loadout: { ...loadout, notes: e.target.value } });
+    stateDispatch({ type: 'setNotes', notes: e.target.value });
 
   const header = ({ onClose }: { onClose(): void }) => (
     <div className="loadout-drawer-header">
@@ -173,7 +173,7 @@ export default function LoadoutDrawer({
         loadout={loadout}
         showClass={showClass}
         isNew={isNew}
-        updateLoadout={(loadout) => stateDispatch({ type: 'update', loadout })}
+        stateDispatch={stateDispatch}
         saveLoadout={(e) => (isNew ? saveAsNew(e, onClose) : onSaveLoadout(e, loadout, onClose))}
         saveAsNew={(e) => saveAsNew(e, onClose)}
         deleteLoadout={onDeleteLoadout}
@@ -220,7 +220,7 @@ export default function LoadoutDrawer({
                 equip={onEquipItem}
                 remove={onRemoveItem}
                 add={onAddItem}
-                onUpdateLoadout={(loadout) => stateDispatch({ type: 'update', loadout })}
+                stateDispatch={stateDispatch}
                 onShowItemPicker={setShowingItemPicker}
               />
             </div>

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.tsx
@@ -2,6 +2,7 @@ import { ConfirmButton } from 'app/dim-ui/ConfirmButton';
 import { t } from 'app/i18next-t';
 import { storesSelector } from 'app/inventory/selectors';
 import { getClass } from 'app/inventory/store/character-utils';
+import { Action } from 'app/loadout-drawer/loadout-drawer-reducer';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { loadoutsSelector } from 'app/loadout-drawer/selectors';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
@@ -28,7 +29,7 @@ export default function LoadoutDrawerOptions({
   loadout,
   showClass,
   isNew,
-  updateLoadout,
+  stateDispatch,
   saveLoadout,
   saveAsNew,
   deleteLoadout,
@@ -36,7 +37,7 @@ export default function LoadoutDrawerOptions({
   loadout: Readonly<Loadout> | undefined;
   showClass: boolean;
   isNew: boolean;
-  updateLoadout(loadout: Loadout): void;
+  stateDispatch: React.Dispatch<Action>;
   saveLoadout(e: React.FormEvent): void;
   saveAsNew(e: React.MouseEvent): void;
   deleteLoadout(): void;
@@ -59,26 +60,16 @@ export default function LoadoutDrawerOptions({
         loadout.classType === DestinyClass.Unknown)
   );
 
-  const setName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    updateLoadout({
-      ...loadout,
-      name: e.target.value,
-    });
-  };
+  const setName = (e: React.ChangeEvent<HTMLInputElement>) =>
+    stateDispatch({ type: 'setName', name: e.target.value });
 
-  const setClassType = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    updateLoadout({
-      ...loadout,
-      classType: parseInt(e.target.value, 10),
-    });
-  };
+  const setClassType = (e: React.ChangeEvent<HTMLSelectElement>) =>
+    stateDispatch({ type: 'setClassType', classType: parseInt(e.target.value, 10) });
 
-  const setClearSpace = (e: React.ChangeEvent<HTMLInputElement>) => {
-    updateLoadout({
-      ...loadout,
-      clearSpace: e.target.checked,
-    });
-  };
+  const setClearSpace = (e: React.ChangeEvent<HTMLInputElement>) =>
+    stateDispatch({ type: 'setClearSpace', clearSpace: e.target.checked });
+
+  const addNotes = () => stateDispatch({ type: 'setNotes', notes: '' });
 
   // TODO: make the link to loadout optimizer bring the currently equipped items along in route state
 
@@ -94,13 +85,6 @@ export default function LoadoutDrawerOptions({
     saveDisabled ||
     // There's an existing loadout with the same name & class
     Boolean(clashingLoadout);
-
-  const addNotes = () => {
-    updateLoadout({
-      ...loadout,
-      notes: '',
-    });
-  };
 
   return (
     <div className={styles.loadoutOptions}>

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -15,20 +15,16 @@ import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import produce from 'immer';
-import React, { useCallback, useMemo, useReducer, useState } from 'react';
+import React, { useCallback, useReducer, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { v4 as uuidv4 } from 'uuid';
 import Sheet from '../dim-ui/Sheet';
 import { DimItem } from '../inventory/item-types';
-import { allItemsSelector, bucketsSelector, storesSelector } from '../inventory/selectors';
-import LoadoutEdit, {
-  fillLoadoutFromEquipped,
-  fillLoadoutFromUnequipped,
-} from '../loadout/loadout-edit/LoadoutEdit';
+import { storesSelector } from '../inventory/selectors';
+import LoadoutEdit from '../loadout/loadout-edit/LoadoutEdit';
 import { deleteLoadout, updateLoadout } from './actions';
 import { stateReducer } from './loadout-drawer-reducer';
 import { addItem$ } from './loadout-events';
-import { getItemsFromLoadoutItems } from './loadout-item-conversion';
 import { Loadout, ResolvedLoadoutItem } from './loadout-types';
 import { createSubclassDefaultSocketOverrides } from './loadout-utils';
 import styles from './LoadoutDrawer2.m.scss';
@@ -64,8 +60,6 @@ export default function LoadoutDrawer2({
   const dispatch = useThunkDispatch();
   const defs = useDefinitions()!;
   const stores = useSelector(storesSelector);
-  const allItems = useSelector(allItemsSelector);
-  const buckets = useSelector(bucketsSelector)!;
   const [showingItemPicker, setShowingItemPicker] = useState(false);
 
   // All state and the state of the loadout is managed through this reducer
@@ -73,17 +67,9 @@ export default function LoadoutDrawer2({
     loadout: initialLoadout,
   });
 
-  const loadoutItems = loadout?.items;
-
   const store = storeId
     ? getStore(stores, storeId)
     : stores.find((s) => !s.isVault && s.classType === loadout?.classType);
-
-  // Turn loadout items into real DimItems
-  const [items] = useMemo(
-    () => getItemsFromLoadoutItems(loadoutItems, defs, store?.id, buckets, allItems),
-    [loadoutItems, defs, store?.id, buckets, allItems]
-  );
 
   const onAddItem = useCallback(
     (item: DimItem, equip?: boolean, socketOverrides?: SocketOverrides) =>
@@ -139,15 +125,14 @@ export default function LoadoutDrawer2({
   };
 
   const handleNotesChanged: React.ChangeEventHandler<HTMLTextAreaElement> = (e) =>
-    stateDispatch({ type: 'update', loadout: { ...loadout, notes: e.target.value } });
-
-  const handleUpdateLoadout = (loadout: Loadout) => stateDispatch({ type: 'update', loadout });
-
-  const handleNameChanged = (name: string) =>
-    stateDispatch({ type: 'update', loadout: { ...loadout, name } });
-
+    stateDispatch({ type: 'setNotes', notes: e.target.value });
+  const handleNameChanged = (name: string) => stateDispatch({ type: 'setName', name });
   const handleRemoveItem = (resolvedItem: ResolvedLoadoutItem) =>
     stateDispatch({ type: 'removeItem', resolvedItem });
+  const handleFillLoadoutFromEquipped = () =>
+    stateDispatch({ type: 'fillLoadoutFromEquipped', store });
+  const handleFillLoadoutFromUnequipped = () =>
+    stateDispatch({ type: 'fillLoadoutFromUnequipped', store });
 
   /** Prompt the user to select a replacement for a missing item. */
   const fixWarnItem = async (li: ResolvedLoadoutItem) => {
@@ -183,19 +168,14 @@ export default function LoadoutDrawer2({
     }
   };
 
-  const setClearSpace = (clearSpace: boolean) => {
-    handleUpdateLoadout({
-      ...loadout,
-      clearSpace,
-    });
-  };
+  const setClearSpace = (clearSpace: boolean) =>
+    stateDispatch({ type: 'setClearSpace', clearSpace });
 
-  const toggleAnyClass = (checked: boolean) => {
-    handleUpdateLoadout({
-      ...loadout,
+  const toggleAnyClass = (checked: boolean) =>
+    stateDispatch({
+      type: 'setClassType',
       classType: checked ? DestinyClass.Unknown : store.classType,
     });
-  };
 
   const handleClickPlaceholder = ({
     bucket,
@@ -262,25 +242,10 @@ export default function LoadoutDrawer2({
           onClickSubclass={handleClickSubclass}
         />
         <div className={styles.inputGroup}>
-          <button
-            type="button"
-            className="dim-button"
-            onClick={() =>
-              fillLoadoutFromEquipped(
-                loadout,
-                items.map((li) => li.item),
-                store,
-                handleUpdateLoadout
-              )
-            }
-          >
+          <button type="button" className="dim-button" onClick={handleFillLoadoutFromEquipped}>
             <AppIcon icon={addIcon} /> {t('Loadouts.FillFromEquipped')}
           </button>
-          <button
-            type="button"
-            className="dim-button"
-            onClick={() => fillLoadoutFromUnequipped(loadout, store, onAddItem)}
-          >
+          <button type="button" className="dim-button" onClick={handleFillLoadoutFromUnequipped}>
             <AppIcon icon={addIcon} /> {t('Loadouts.FillFromInventory')}
           </button>
           <CheckButton

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -1,26 +1,59 @@
 import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { D1Categories } from 'app/destiny1/d1-bucket-categories';
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
+import { D2Categories } from 'app/destiny2/d2-bucket-categories';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
+import { DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { showNotification } from 'app/notifications/notifications';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyClass, TierType } from 'bungie-api-ts/destiny2';
-import { SocketCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import produce from 'immer';
 import _ from 'lodash';
 import { Loadout, LoadoutItem, ResolvedLoadoutItem } from './loadout-types';
-import { singularBucketHashes } from './loadout-utils';
+import {
+  createSocketOverridesFromEquipped,
+  extractArmorModHashes,
+  fromEquippedTypes,
+  getUnequippedItemsForLoadout,
+  singularBucketHashes,
+} from './loadout-utils';
+
+// TODO: should this really be a reducer, or just a series of functions that produce a new loadout coupled w/ a setLoadout function? General loadout manipulation library would be useful...
+// Each function should return a (loadout: Loadout) => Loadout
+
+/*
+ * This module contains functions for mutating loadouts. Each exported function
+ * should return a LoadoutUpdateFunction so it can be used directly in useState
+ * setters.
+ */
+
+/**
+ * A function that takes a loadout and returns a modified loadout. The modified
+ * loadout must be a new instance (immutable updates). These functions can be
+ * used in reducers or passed directly to a `setLoadout` function.
+ *
+ * Example:
+ *
+ * function addItem(defs, item): LoadoutUpdateFunction {
+ *   return (loadout) => {
+ *     ...
+ *   }
+ * }
+ *
+ * setLoadout(addItem(defs, item))
+ */
+export type LoadoutUpdateFunction = (loadout: Loadout) => Loadout;
 
 export interface State {
   loadout: Readonly<Loadout>;
 }
 
 export type Action =
-  /** Replace the current loadout with an updated one */
-  | { type: 'update'; loadout: Loadout }
   /** Add an item to the loadout */
   | {
       type: 'addItem';
@@ -32,6 +65,7 @@ export type Action =
       equip?: boolean;
       socketOverrides?: SocketOverrides;
     }
+  // | { type: 'replaceItem' } // add+remove? remove+add? doesn't need to respect type limits?
   /** Applies socket overrides to the supplied item */
   | {
       type: 'applySocketOverrides';
@@ -45,20 +79,31 @@ export type Action =
   | { type: 'equipItem'; resolvedItem: ResolvedLoadoutItem }
   | { type: 'updateMods'; mods: number[] }
   | { type: 'changeClearMods'; enabled: boolean }
-  | { type: 'removeMod'; hash: number };
+  | { type: 'removeMod'; hash: number }
+  | { type: 'clearLoadoutParameters' }
+  | { type: 'clearMods' }
+  | { type: 'setLoadoutSubclassFromEquipped'; store: DimStore }
+  | { type: 'fillLoadoutFromEquipped'; store: DimStore; category?: string }
+  | { type: 'fillLoadoutFromUnequipped'; store: DimStore; category?: string }
+  | { type: 'setNotes'; notes: string | undefined }
+  | { type: 'setName'; name: string }
+  | { type: 'setClassType'; classType: DestinyClass }
+  | { type: 'setClearSpace'; clearSpace: boolean }
+  | { type: 'clearCategory'; category: string }
+  | { type: 'clearSubclass' }
+  | { type: 'syncModsFromEquipped'; store: DimStore };
 
 /**
  * All state for this component is managed through this reducer and the Actions above.
  */
 export function stateReducer(defs: D2ManifestDefinitions | D1ManifestDefinitions) {
   return (state: State, action: Action): State => {
-    switch (action.type) {
-      case 'update':
-        return {
-          ...state,
-          loadout: action.loadout,
-        };
+    const setLoadout = (updater: LoadoutUpdateFunction) => ({
+      ...state,
+      loadout: updater(state.loadout),
+    });
 
+    switch (action.type) {
       case 'addItem': {
         const { loadout } = state;
         const { item, equip, socketOverrides } = action;
@@ -75,104 +120,73 @@ export function stateReducer(defs: D2ManifestDefinitions | D1ManifestDefinitions
           });
           return state;
         }
-        const draftLoadout = addItem(defs, loadout, item, equip, socketOverrides);
-        return {
-          ...state,
-          loadout: draftLoadout,
-        };
+        return setLoadout(addItem(defs, item, equip, socketOverrides));
       }
 
-      case 'removeItem': {
-        const { loadout } = state;
-        const { resolvedItem } = action;
-        return loadout ? { ...state, loadout: removeItem(defs, loadout, resolvedItem) } : state;
-      }
+      case 'removeItem':
+        return setLoadout(removeItem(defs, action.resolvedItem));
 
-      case 'equipItem': {
-        const { loadout } = state;
-        const { resolvedItem } = action;
-        return loadout ? { ...state, loadout: equipItem(defs, loadout, resolvedItem) } : state;
-      }
+      case 'equipItem':
+        return setLoadout(equipItem(defs, action.resolvedItem));
 
-      case 'applySocketOverrides': {
-        const { loadout } = state;
-        const { resolvedItem, socketOverrides } = action;
-        return loadout
-          ? { ...state, loadout: applySocketOverrides(loadout, resolvedItem, socketOverrides) }
-          : state;
-      }
+      case 'applySocketOverrides':
+        return setLoadout(applySocketOverrides(action.resolvedItem, action.socketOverrides));
 
-      case 'updateModsByBucket': {
-        const { loadout } = state;
-        const { modsByBucket } = action;
-        return loadout
-          ? {
-              ...state,
-              loadout: {
-                ...loadout,
-                parameters: {
-                  ...loadout.parameters,
-                  modsByBucket: _.isEmpty(modsByBucket) ? undefined : modsByBucket,
-                },
-              },
-            }
-          : state;
-      }
+      case 'updateModsByBucket':
+        return setLoadout(updateModsByBucket(action.modsByBucket));
 
-      case 'updateMods': {
-        const { loadout } = state;
-        const { mods } = action;
-        return loadout
-          ? {
-              ...state,
-              loadout: {
-                ...loadout,
-                parameters: {
-                  ...loadout.parameters,
-                  mods,
-                },
-              },
-            }
-          : state;
-      }
+      case 'updateMods':
+        return setLoadout(updateMods(action.mods));
 
-      case 'changeClearMods': {
-        const { loadout } = state;
-        const { enabled } = action;
-        return loadout
-          ? {
-              ...state,
-              loadout: {
-                ...loadout,
-                parameters: {
-                  ...loadout.parameters,
-                  clearMods: enabled,
-                },
-              },
-            }
-          : state;
-      }
+      case 'changeClearMods':
+        return setLoadout(changeClearMods(action.enabled));
 
-      case 'removeMod': {
-        const { loadout } = state;
-        const { hash } = action;
-        if (loadout) {
-          const newLoadout = { ...loadout };
-          const newMods = newLoadout.parameters?.mods?.length
-            ? [...newLoadout.parameters.mods]
-            : [];
-          const index = newMods.indexOf(hash);
-          if (index !== -1) {
-            newMods.splice(index, 1);
-            newLoadout.parameters = {
-              ...newLoadout.parameters,
-              mods: newMods,
-            };
-            return { ...state, loadout: newLoadout };
-          }
+      case 'removeMod':
+        return setLoadout(removeMod(action.hash));
+
+      case 'clearLoadoutParameters':
+        return setLoadout(clearLoadoutParameters());
+
+      case 'setLoadoutSubclassFromEquipped': {
+        if (!defs.isDestiny2()) {
+          return state;
         }
-        return state;
+        return setLoadout(setLoadoutSubclassFromEquipped(defs, action.store));
       }
+
+      case 'fillLoadoutFromEquipped':
+        return setLoadout(fillLoadoutFromEquipped(defs, action.store, action.category));
+
+      case 'fillLoadoutFromUnequipped':
+        return setLoadout(fillLoadoutFromUnequipped(defs, action.store, action.category));
+
+      case 'setNotes':
+        return setLoadout(setNotes(action.notes));
+
+      case 'setClassType':
+        return setLoadout(setClassType(action.classType));
+
+      case 'setClearSpace':
+        return setLoadout(setClearSpace(action.clearSpace));
+
+      case 'setName':
+        return setLoadout(setName(action.name));
+
+      case 'clearSubclass': {
+        if (!defs.isDestiny2()) {
+          return state;
+        }
+        return setLoadout(clearSubclass(defs));
+      }
+
+      case 'syncModsFromEquipped':
+        return setLoadout(syncModsFromEquipped(action.store));
+
+      case 'clearCategory':
+        return setLoadout(clearBucketCategory(defs, action.category));
+
+      case 'clearMods':
+        return setLoadout(clearMods());
     }
   };
 }
@@ -180,13 +194,12 @@ export function stateReducer(defs: D2ManifestDefinitions | D1ManifestDefinitions
 /**
  * Produce a new loadout that adds a new item to the given loadout.
  */
-function addItem(
+export function addItem(
   defs: D2ManifestDefinitions | D1ManifestDefinitions,
-  loadout: Readonly<Loadout>,
   item: DimItem,
   equip?: boolean,
   socketOverrides?: SocketOverrides
-): Loadout {
+): LoadoutUpdateFunction {
   const loadoutItem: LoadoutItem = {
     id: item.id,
     hash: item.hash,
@@ -204,9 +217,9 @@ function addItem(
   const singular = singularBucketHashes.includes(item.bucket.hash);
   const maxSlots = singular ? 1 : item.bucket.capacity;
 
-  return produce(loadout, (draftLoadout) => {
+  return produce((draftLoadout) => {
     // If this item is already in the loadout, find it via its id/hash.
-    const dupe = loadout.items.find((i) => i.hash === item.hash && i.id === item.id);
+    const dupe = draftLoadout.items.find((i) => i.hash === item.hash && i.id === item.id);
     if (dupe) {
       if (item.maxStackSize > 1) {
         // The item is already here but we'd like to add more of it (only D1 loadouts hold stackables)
@@ -267,12 +280,11 @@ function addItem(
 /**
  * Produce a new Loadout with the given item removed from the original loadout.
  */
-function removeItem(
+export function removeItem(
   defs: D1ManifestDefinitions | D2ManifestDefinitions,
-  loadout: Readonly<Loadout>,
   { item, loadoutItem: searchLoadoutItem }: ResolvedLoadoutItem
-): Loadout {
-  return produce(loadout, (draftLoadout) => {
+): LoadoutUpdateFunction {
+  return produce((draftLoadout) => {
     // We can't just look it up by identity since Immer wraps objects in a proxy
     // TODO: it might be nice if we just assigned a unique ID to every loadout item just for in-memory ops like deleting
     const loadoutItemIndex = draftLoadout.items.findIndex(
@@ -307,12 +319,11 @@ function removeItem(
 /**
  * Produce a new loadout with the given item switched to being equipped (or unequipped if it's already equipped).
  */
-function equipItem(
+export function equipItem(
   defs: D1ManifestDefinitions | D2ManifestDefinitions,
-  loadout: Readonly<Loadout>,
   { item, loadoutItem: searchLoadoutItem }: ResolvedLoadoutItem
-) {
-  return produce(loadout, (draftLoadout) => {
+): LoadoutUpdateFunction {
+  return produce((draftLoadout) => {
     // Subclasses and some others are always equipped
     if (singularBucketHashes.includes(item.bucket.hash)) {
       return;
@@ -365,12 +376,11 @@ function equipItem(
   });
 }
 
-function applySocketOverrides(
-  loadout: Readonly<Loadout>,
+export function applySocketOverrides(
   { loadoutItem: searchLoadoutItem }: ResolvedLoadoutItem,
   socketOverrides: SocketOverrides
-) {
-  return produce(loadout, (draftLoadout) => {
+): LoadoutUpdateFunction {
+  return produce((draftLoadout) => {
     let loadoutItem = draftLoadout.items.find((li) => li.id === searchLoadoutItem.id);
     // TODO: right now socketOverrides are only really used for subclasses, so we can match by hash
     if (!loadoutItem) {
@@ -399,4 +409,305 @@ function getBucketHashFromItemHash(
 ) {
   const def = defs.InventoryItem.get(itemHash);
   return def && ('bucketTypeHash' in def ? def.bucketTypeHash : def.inventory?.bucketTypeHash);
+}
+
+/**
+ * Remove all Loadout Optimizer parameters from a loadout. This leaves things like mods and fashion in place.
+ */
+export function clearLoadoutParameters(): LoadoutUpdateFunction {
+  return produce((draft) => {
+    if (draft.parameters) {
+      delete draft.parameters.assumeArmorMasterwork;
+      delete draft.parameters.exoticArmorHash;
+      delete draft.parameters.lockArmorEnergyType;
+      delete draft.parameters.query;
+      delete draft.parameters.statConstraints;
+      delete draft.parameters.upgradeSpendTier;
+      delete draft.parameters.autoStatMods;
+    }
+  });
+}
+
+/** Remove the current subclass from the loadout. */
+export function clearSubclass(defs: D2ManifestDefinitions): LoadoutUpdateFunction {
+  return (loadout) => {
+    const isSubclass = (i: LoadoutItem) =>
+      defs.InventoryItem.get(i.hash)?.inventory?.bucketTypeHash === BucketHashes.Subclass;
+
+    return {
+      ...loadout,
+      items: [...loadout.items.filter((i) => !isSubclass(i))],
+    };
+  };
+}
+
+/**
+ * Remove a specific mod by its inventory item hash.
+ */
+export function removeMod(hash: number): LoadoutUpdateFunction {
+  return (loadout) => {
+    const newLoadout = { ...loadout };
+    const newMods = newLoadout.parameters?.mods?.length ? [...newLoadout.parameters.mods] : [];
+    const index = newMods.indexOf(hash);
+    if (index !== -1) {
+      newMods.splice(index, 1);
+      newLoadout.parameters = {
+        ...newLoadout.parameters,
+        mods: newMods,
+      };
+      return newLoadout;
+    }
+    return loadout;
+  };
+}
+
+/** Replace the loadout's subclass with the store's currently equipped subclass */
+export function setLoadoutSubclassFromEquipped(
+  defs: D2ManifestDefinitions,
+  store: DimStore
+): LoadoutUpdateFunction {
+  return (loadout) => {
+    const newSubclass = store.items.find(
+      (item) =>
+        item.equipped && item.bucket.hash === BucketHashes.Subclass && itemCanBeInLoadout(item)
+    );
+
+    if (!newSubclass) {
+      return loadout;
+    }
+
+    const newLoadoutItem: LoadoutItem = {
+      id: newSubclass.id,
+      hash: newSubclass.hash,
+      equip: true,
+      amount: 1,
+      socketOverrides: createSocketOverridesFromEquipped(newSubclass),
+    };
+
+    const isSubclass = (i: LoadoutItem) =>
+      defs.InventoryItem.get(i.hash)?.inventory?.bucketTypeHash === BucketHashes.Subclass;
+
+    const newLoadout = {
+      ...loadout,
+      items: [...loadout.items.filter((i) => !isSubclass(i)), newLoadoutItem],
+    };
+
+    return newLoadout;
+  };
+}
+
+/**
+ * Fill in items from the store's equipped items, keeping any equipped items already in the loadout in place.
+ */
+export function fillLoadoutFromEquipped(
+  defs: D1ManifestDefinitions | D2ManifestDefinitions,
+  store: DimStore,
+  /** Fill in from only this specific category */
+  category?: string
+): LoadoutUpdateFunction {
+  return produce((loadout) => {
+    const equippedItemsByBucket = _.keyBy(
+      loadout.items.filter((li) => li.equip),
+      (li) => getBucketHashFromItemHash(defs, li.hash)
+    );
+
+    const newEquippedItems = store.items.filter(
+      (item) =>
+        item.equipped &&
+        itemCanBeInLoadout(item) &&
+        (category
+          ? category === 'General'
+            ? item.bucket.hash !== BucketHashes.Subclass && item.bucket.sort === category
+            : item.bucket.sort === category
+          : fromEquippedTypes.includes(item.bucket.hash))
+    );
+    const mods: number[] = [];
+    for (const item of newEquippedItems) {
+      if (!(item.bucket.hash in equippedItemsByBucket)) {
+        const loadoutItem: LoadoutItem = {
+          id: item.id,
+          hash: item.hash,
+          equip: true,
+          amount: 1,
+        };
+        if (item.bucket.hash === BucketHashes.Subclass) {
+          loadoutItem.socketOverrides = createSocketOverridesFromEquipped(item);
+        }
+        loadout.items.push(loadoutItem);
+        mods.push(...extractArmorModHashes(item));
+      }
+    }
+    if (mods.length && (loadout.parameters?.mods ?? []).length === 0) {
+      loadout.parameters = {
+        ...loadout.parameters,
+        mods,
+      };
+    }
+    // Save "fashion" mods for equipped items
+    const modsByBucket = {};
+    for (const item of newEquippedItems.filter((i) => i.bucket.inArmor)) {
+      const plugs = item.sockets
+        ? _.compact(
+            getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics).map(
+              (s) => s.plugged?.plugDef.hash
+            )
+          )
+        : [];
+      if (plugs.length) {
+        modsByBucket[item.bucket.hash] = plugs;
+      }
+    }
+    if (!_.isEmpty(modsByBucket)) {
+      loadout.parameters = {
+        ...loadout.parameters,
+        modsByBucket,
+      };
+    }
+  });
+}
+
+/**
+ * Add all the unequipped items on the given character to the loadout.
+ */
+export function fillLoadoutFromUnequipped(
+  defs: D1ManifestDefinitions | D2ManifestDefinitions,
+  store: DimStore,
+  /** Fill in from only this specific category */
+  category?: string
+): LoadoutUpdateFunction {
+  return (loadout) => {
+    const items = getUnequippedItemsForLoadout(store, category);
+    // TODO: batch addItems
+    for (const item of items) {
+      // Add as an unequipped item
+      loadout = addItem(defs, item, false)(loadout);
+    }
+    return loadout;
+  };
+}
+
+export function setName(name: string): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    name,
+  });
+}
+
+export function setNotes(notes: string | undefined): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    notes,
+  });
+}
+
+function setClassType(classType: DestinyClass): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    classType,
+  });
+}
+
+function setClearSpace(clearSpace: boolean): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    clearSpace,
+  });
+}
+
+/**
+ * Replace the mods in this loadout with all the mods currently on this character's equipped armor.
+ */
+export function syncModsFromEquipped(store: DimStore): LoadoutUpdateFunction {
+  return (loadout) => {
+    const mods: number[] = [];
+    const equippedArmor = store.items.filter(
+      (item) => item.equipped && itemCanBeInLoadout(item) && item.bucket.sort === 'Armor'
+    );
+    for (const item of equippedArmor) {
+      mods.push(...extractArmorModHashes(item));
+    }
+
+    return {
+      ...loadout,
+      parameters: {
+        ...loadout.parameters,
+        mods,
+      },
+    };
+  };
+}
+
+export function clearBucketCategory(
+  defs: D1ManifestDefinitions | D2ManifestDefinitions,
+  category: string
+) {
+  return clearBuckets(defs, defs.isDestiny2() ? D2Categories[category] : D1Categories[category]);
+}
+
+/**
+ * Remove all items that are in one or more buckets.
+ */
+export function clearBuckets(
+  defs: D1ManifestDefinitions | D2ManifestDefinitions,
+  bucketHashes: number[]
+): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    items: loadout.items.filter((i) => {
+      const bucketHash = getBucketHashFromItemHash(defs, i.hash);
+
+      return (
+        bucketHash &&
+        // Subclasses are in "general" but shouldn't be cleared when we clear subclass
+        bucketHash !== BucketHashes.Subclass &&
+        bucketHashes.includes(bucketHash)
+      );
+    }),
+  });
+}
+
+export function clearMods(): LoadoutUpdateFunction {
+  return produce((loadout) => {
+    delete loadout.parameters?.mods;
+  });
+}
+
+/* TODO:
+const LoadoutParametersUpdateFunction = ()
+
+function updateLoadoutParameters() {
+
+}
+*/
+
+export function changeClearMods(enabled: boolean): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    parameters: {
+      ...loadout.parameters,
+      clearMods: enabled,
+    },
+  });
+}
+
+export function updateMods(mods: number[]): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    parameters: {
+      ...loadout.parameters,
+      mods,
+    },
+  });
+}
+
+export function updateModsByBucket(
+  modsByBucket: { [bucketHash: number]: number[] } | undefined
+): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    parameters: {
+      ...loadout.parameters,
+      modsByBucket: _.isEmpty(modsByBucket) ? undefined : modsByBucket,
+    },
+  });
 }

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -614,27 +614,28 @@ function setClearSpace(clearSpace: boolean): LoadoutUpdateFunction {
   });
 }
 
+export function setLoadoutParameters(params: Partial<LoadoutParameters>): LoadoutUpdateFunction {
+  return (loadout) => ({
+    ...loadout,
+    parameters: { ...loadout.parameters, ...params },
+  });
+}
+
 /**
  * Replace the mods in this loadout with all the mods currently on this character's equipped armor.
  */
 export function syncModsFromEquipped(store: DimStore): LoadoutUpdateFunction {
-  return (loadout) => {
-    const mods: number[] = [];
-    const equippedArmor = store.items.filter(
-      (item) => item.equipped && itemCanBeInLoadout(item) && item.bucket.sort === 'Armor'
-    );
-    for (const item of equippedArmor) {
-      mods.push(...extractArmorModHashes(item));
-    }
+  const mods: number[] = [];
+  const equippedArmor = store.items.filter(
+    (item) => item.equipped && itemCanBeInLoadout(item) && item.bucket.sort === 'Armor'
+  );
+  for (const item of equippedArmor) {
+    mods.push(...extractArmorModHashes(item));
+  }
 
-    return {
-      ...loadout,
-      parameters: {
-        ...loadout.parameters,
-        mods,
-      },
-    };
-  };
+  return setLoadoutParameters({
+    mods,
+  });
 }
 
 export function clearBucketCategory(
@@ -672,42 +673,22 @@ export function clearMods(): LoadoutUpdateFunction {
   });
 }
 
-/* TODO:
-const LoadoutParametersUpdateFunction = ()
-
-function updateLoadoutParameters() {
-
-}
-*/
-
 export function changeClearMods(enabled: boolean): LoadoutUpdateFunction {
-  return (loadout) => ({
-    ...loadout,
-    parameters: {
-      ...loadout.parameters,
-      clearMods: enabled,
-    },
+  return setLoadoutParameters({
+    clearMods: enabled,
   });
 }
 
 export function updateMods(mods: number[]): LoadoutUpdateFunction {
-  return (loadout) => ({
-    ...loadout,
-    parameters: {
-      ...loadout.parameters,
-      mods,
-    },
+  return setLoadoutParameters({
+    mods,
   });
 }
 
 export function updateModsByBucket(
   modsByBucket: { [bucketHash: number]: number[] } | undefined
 ): LoadoutUpdateFunction {
-  return (loadout) => ({
-    ...loadout,
-    parameters: {
-      ...loadout.parameters,
-      modsByBucket: _.isEmpty(modsByBucket) ? undefined : modsByBucket,
-    },
+  return setLoadoutParameters({
+    modsByBucket: _.isEmpty(modsByBucket) ? undefined : modsByBucket,
   });
 }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -488,3 +488,18 @@ export function getModsFromLoadout(
 
   return mods.sort(sortMods);
 }
+
+/**
+ * filter for items that are in a character's "pockets" but not equipped,
+ * and can be added to a loadout
+ */
+export function getUnequippedItemsForLoadout(dimStore: DimStore, category?: string) {
+  return dimStore.items.filter(
+    (item) =>
+      !item.location.inPostmaster &&
+      item.bucket.hash !== BucketHashes.Subclass &&
+      itemCanBeInLoadout(item) &&
+      (category ? item.bucket.sort === category : fromEquippedTypes.includes(item.bucket.hash)) &&
+      !item.equipped
+  );
+}

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -5,23 +5,13 @@ import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { Action } from 'app/loadout-drawer/loadout-drawer-reducer';
-import { Loadout, LoadoutItem, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
-import {
-  createSocketOverridesFromEquipped,
-  extractArmorModHashes,
-  fromEquippedTypes,
-  getModsFromLoadout,
-} from 'app/loadout-drawer/loadout-utils';
+import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { getModsFromLoadout, getUnequippedItemsForLoadout } from 'app/loadout-drawer/loadout-utils';
 import LoadoutMods from 'app/loadout/loadout-ui/LoadoutMods';
 import { getItemsAndSubclassFromLoadout, loadoutPower } from 'app/loadout/LoadoutView';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { emptyObject } from 'app/utils/empty';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
-import { infoLog } from 'app/utils/log';
-import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
-import produce from 'immer';
 import _ from 'lodash';
 import React, { useCallback, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -68,46 +58,18 @@ export default function LoadoutEdit({
 
   const savedMods = useMemo(() => getModsFromLoadout(defs, loadout), [defs, loadout]);
   const clearUnsetMods = loadout.parameters?.clearMods;
-
   const categories = _.groupBy(items.concat(warnitems), (li) => li.item.bucket.sort);
   const power = loadoutPower(store, categories);
+  const anyClass = loadout.classType === DestinyClass.Unknown;
 
   /** Updates the loadout replacing it's current mods with all the mods in newMods. */
-  const handleUpdateModHashes = (mods: number[]) => stateDispatch({ type: 'updateMods', mods });
   const handleUpdateMods = (newMods: PluggableInventoryItemDefinition[]) =>
-    handleUpdateModHashes(newMods.map((mod) => mod.hash));
-  const handleClearMods = () => handleUpdateMods([]);
-
-  const handleClearCategory = (category: string) => {
-    // TODO: do these all in one action
-    for (const li of items.concat(warnitems)) {
-      if (li.item.bucket.sort === category && li.item.bucket.hash !== BucketHashes.Subclass) {
-        stateDispatch({ type: 'removeItem', resolvedItem: li });
-      }
-    }
-  };
-
-  const onRemoveItem = (resolvedItem: ResolvedLoadoutItem) =>
-    stateDispatch({ type: 'removeItem', resolvedItem });
-
-  const handleClearSubclass = () => subclass && onRemoveItem(subclass);
-
-  const updateLoadout = (loadout: Loadout) => stateDispatch({ type: 'update', loadout });
-
-  const onAddItem = (item: DimItem, equip?: boolean) =>
-    stateDispatch({ type: 'addItem', item, equip });
-
-  const handleSyncModsFromEquipped = () => {
-    const mods: number[] = [];
-    const equippedArmor = store.items.filter(
-      (item) => item.equipped && itemCanBeInLoadout(item) && item.bucket.sort === 'Armor'
-    );
-    for (const item of equippedArmor) {
-      mods.push(...extractArmorModHashes(item));
-    }
-    stateDispatch({ type: 'updateMods', mods });
-  };
-
+    stateDispatch({ type: 'updateMods', mods: newMods.map((mod) => mod.hash) });
+  const handleClearCategory = (category: string) =>
+    stateDispatch({
+      type: 'clearCategory',
+      category,
+    });
   const onModsByBucketUpdated = (
     modsByBucket:
       | {
@@ -115,38 +77,28 @@ export default function LoadoutEdit({
         }
       | undefined
   ) => stateDispatch({ type: 'updateModsByBucket', modsByBucket });
-
   const handleApplySocketOverrides = useCallback(
     (resolvedItem: ResolvedLoadoutItem, socketOverrides: SocketOverrides) => {
       stateDispatch({ type: 'applySocketOverrides', resolvedItem, socketOverrides });
     },
     [stateDispatch]
   );
-
-  const handleToggleEquipped = (resolvedItem: ResolvedLoadoutItem) => {
+  const handleToggleEquipped = (resolvedItem: ResolvedLoadoutItem) =>
     stateDispatch({ type: 'equipItem', resolvedItem });
-  };
-
-  const handleClearUnsetModsChanged = (enabled: boolean) => {
+  const handleClearUnsetModsChanged = (enabled: boolean) =>
     stateDispatch({ type: 'changeClearMods', enabled });
-  };
-
-  const handleClearLoadoutParameters = () => {
-    const newLoadout = produce(loadout, (draft) => {
-      if (draft.parameters) {
-        delete draft.parameters.assumeArmorMasterwork;
-        delete draft.parameters.exoticArmorHash;
-        delete draft.parameters.lockArmorEnergyType;
-        delete draft.parameters.query;
-        delete draft.parameters.statConstraints;
-        delete draft.parameters.upgradeSpendTier;
-        delete draft.parameters.autoStatMods;
-      }
-    });
-    updateLoadout(newLoadout);
-  };
-
-  const anyClass = loadout.classType === DestinyClass.Unknown;
+  const handleClearLoadoutParameters = () => stateDispatch({ type: 'clearLoadoutParameters' });
+  const handleFillSubclassFromEquipped = () =>
+    stateDispatch({ type: 'setLoadoutSubclassFromEquipped', store });
+  const handleFillLoadoutFromEquipped = () =>
+    stateDispatch({ type: 'fillLoadoutFromUnequipped', store });
+  const handleFillCategoryFromEquipped = (category: string) =>
+    stateDispatch({ type: 'fillLoadoutFromEquipped', store, category });
+  const handleClearMods = () => stateDispatch({ type: 'clearMods' });
+  const onRemoveItem = (resolvedItem: ResolvedLoadoutItem) =>
+    stateDispatch({ type: 'removeItem', resolvedItem });
+  const handleClearSubclass = () => stateDispatch({ type: 'clearSubclass' });
+  const handleSyncModsFromEquipped = () => stateDispatch({ type: 'syncModsFromEquipped', store });
 
   // TODO: dedupe styles/code
   return (
@@ -155,9 +107,7 @@ export default function LoadoutEdit({
         <LoadoutEditSection
           title={t('Bucket.Class')}
           onClear={handleClearSubclass}
-          onFillFromEquipped={() =>
-            setLoadoutSubclassFromEquipped(loadout, subclass?.item, store, updateLoadout)
-          }
+          onFillFromEquipped={handleFillSubclassFromEquipped}
         >
           <LoadoutEditBucketDropTarget
             category="Subclass"
@@ -206,19 +156,9 @@ export default function LoadoutEdit({
             key={category}
             title={t(`Bucket.${category}`, { contextList: 'buckets' })}
             onClear={() => handleClearCategory(category)}
-            onFillFromEquipped={() =>
-              fillLoadoutFromEquipped(
-                loadout,
-                items.map((li) => li.item),
-                store,
-                updateLoadout,
-                category
-              )
-            }
+            onFillFromEquipped={() => handleFillCategoryFromEquipped(category)}
             fillFromInventoryCount={getUnequippedItemsForLoadout(store, category).length}
-            onFillFromInventory={() =>
-              fillLoadoutFromUnequipped(loadout, store, onAddItem, category)
-            }
+            onFillFromInventory={handleFillLoadoutFromEquipped}
             onClearLoadoutParameters={
               category === 'Armor' && hasVisibleLoadoutParameters(loadout.parameters)
                 ? handleClearLoadoutParameters
@@ -267,159 +207,5 @@ export default function LoadoutEdit({
         />
       </LoadoutEditSection>
     </div>
-  );
-}
-
-/** Replace the loadout's subclass with the currently equipped subclass */
-function setLoadoutSubclassFromEquipped(
-  loadout: Loadout,
-  existingSubclass: DimItem | undefined,
-  dimStore: DimStore,
-  onUpdateLoadout: (loadout: Loadout) => void
-) {
-  if (!loadout) {
-    return;
-  }
-
-  const newSubclass = dimStore.items.find(
-    (item) =>
-      item.equipped && itemCanBeInLoadout(item) && item.bucket.hash === BucketHashes.Subclass
-  );
-
-  if (!newSubclass) {
-    return;
-  }
-
-  const newLoadoutItem: LoadoutItem = {
-    id: newSubclass.id,
-    hash: newSubclass.hash,
-    equip: true,
-    amount: 1,
-    socketOverrides: createSocketOverridesFromEquipped(newSubclass),
-  };
-
-  const newLoadout = {
-    ...loadout,
-    items: [...loadout.items.filter((i) => existingSubclass?.hash !== i.hash), newLoadoutItem],
-  };
-
-  onUpdateLoadout(newLoadout);
-}
-
-// TODO: push into reducer
-export function fillLoadoutFromEquipped(
-  loadout: Loadout,
-  // TODO: knock this out?
-  items: DimItem[],
-  dimStore: DimStore,
-  onUpdateLoadout: (loadout: Loadout) => void,
-  // This is a bit dangerous as it is only used from the new loadout edit drawer and
-  // has special handling that would break the old loadout drawer
-  category?: string
-) {
-  if (!loadout) {
-    return;
-  }
-
-  const itemsByBucket = _.groupBy(items, (li) => li.bucket.hash);
-
-  const newEquippedItems = dimStore.items.filter(
-    (item) =>
-      item.equipped &&
-      itemCanBeInLoadout(item) &&
-      (category
-        ? category === 'General'
-          ? item.bucket.hash !== BucketHashes.Subclass && item.bucket.sort === category
-          : item.bucket.sort === category
-        : fromEquippedTypes.includes(item.bucket.hash))
-  );
-
-  const hasEquippedInBucket = (bucket: InventoryBucket) =>
-    itemsByBucket[bucket.hash]?.some(
-      (bucketItem) =>
-        loadout.items.find(
-          (loadoutItem) => bucketItem.hash === loadoutItem.hash && bucketItem.id === loadoutItem.id
-        )?.equip
-    );
-
-  const newLoadout = produce(loadout, (draftLoadout) => {
-    const mods: number[] = [];
-    for (const item of newEquippedItems) {
-      if (!hasEquippedInBucket(item.bucket)) {
-        const loadoutItem: LoadoutItem = {
-          id: item.id,
-          hash: item.hash,
-          equip: true,
-          amount: 1,
-        };
-        if (item.bucket.hash === BucketHashes.Subclass) {
-          loadoutItem.socketOverrides = createSocketOverridesFromEquipped(item);
-        }
-        draftLoadout.items.push(loadoutItem);
-        mods.push(...extractArmorModHashes(item));
-      } else {
-        infoLog('loadout', 'Skipping', item, { itemsByBucket, bucketId: item.bucket.hash });
-      }
-    }
-    if (mods.length && (loadout.parameters?.mods ?? []).length === 0) {
-      draftLoadout.parameters = {
-        ...draftLoadout.parameters,
-        mods,
-      };
-    }
-    // Save "fashion" mods for equipped items
-    const modsByBucket = {};
-    for (const item of newEquippedItems.filter((i) => i.bucket.inArmor)) {
-      const plugs = item.sockets
-        ? _.compact(
-            getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics).map(
-              (s) => s.plugged?.plugDef.hash
-            )
-          )
-        : [];
-      if (plugs.length) {
-        modsByBucket[item.bucket.hash] = plugs;
-      }
-    }
-    if (!_.isEmpty(modsByBucket)) {
-      draftLoadout.parameters = {
-        ...draftLoadout.parameters,
-        modsByBucket,
-      };
-    }
-  });
-
-  onUpdateLoadout(newLoadout);
-}
-
-// TODO: push into reducer?
-export async function fillLoadoutFromUnequipped(
-  loadout: Loadout,
-  dimStore: DimStore,
-  add: (item: DimItem, equip?: boolean) => void,
-  category?: string
-) {
-  if (!loadout) {
-    return;
-  }
-
-  const items = getUnequippedItemsForLoadout(dimStore, category);
-  for (const item of items) {
-    add(item, false);
-  }
-}
-
-/**
- * filter for items that are in a character's "pockets" but not equipped,
- * and can be added to a loadout
- */
-function getUnequippedItemsForLoadout(dimStore: DimStore, category?: string) {
-  return dimStore.items.filter(
-    (item) =>
-      !item.location.inPostmaster &&
-      item.bucket.hash !== BucketHashes.Subclass &&
-      itemCanBeInLoadout(item) &&
-      (category ? item.bucket.sort === category : fromEquippedTypes.includes(item.bucket.hash)) &&
-      !item.equipped
   );
 }


### PR DESCRIPTION
This is a refactoring of the LoadoutDrawer to move as much logic as possible into the reducer. Along the way I built out a library of functions that produce updater functions for Loadouts. After this change I actually want to drop the reducer entirely, and start using these mutator functions in other places like Loadout Optimizer.