### PR TITLE
Compress even if compressing makes files bigger

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -521,7 +521,7 @@ module.exports = (env) => {
               [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
             },
           },
-          minRatio: 1,
+          minRatio: Infinity,
         })
       );
     }


### PR DESCRIPTION
Fixes #8179. It's a bummer to compress even if files are larger, but because of the way we serve things it's probably better that way.