### PR TITLE
Enable the React automatic runtime

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -94,6 +94,8 @@
     "prefer-promise-reject-errors": "error",
     "require-atomic-updates": "off",
     "class-methods-use-this": ["error", { "exceptMethods": ["render"] }],
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off",
     "react/no-unescaped-entities": "off",
     "react/jsx-no-target-blank": "off",
     "react/display-name": "off",

--- a/babel.config.js
+++ b/babel.config.js
@@ -63,7 +63,7 @@ module.exports = function (api) {
   return {
     presets: [
       ['@babel/preset-env', presetEnvOptions],
-      ['@babel/preset-react', { useBuiltIns: true, loose: true, corejs: 3 }],
+      ['@babel/preset-react', { useBuiltIns: true, loose: true, corejs: 3, runtime: 'automatic' }],
     ],
     plugins,
     // https://babeljs.io/docs/en/assumptions


### PR DESCRIPTION
https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

This mostly means we don't need to add `import React from 'react'` just to use JSX.