### PR TITLE
Remove pointer events from item children

### DIFF
--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -15,6 +15,10 @@
   width: var(--item-size);
   // searchHidden will adjust opacity/transform, this transitions them
   transition: opacity 0.2s, transform 0.2s;
+
+  > * {
+    pointer-events: none;
+  }
 }
 
 // The wrapper for draggable items. Global because it's referenced by other styles.


### PR DESCRIPTION
Fixes #8100 permanently, I think, and maybe speeds some stuff up by preventing browsers from having to mess with events on all the little bits of an item icon.