### PR TITLE
Introduce DimSocket.emptyPlugItemHash

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+* Fixed loadouts with Void 3.0 subclasses accidentally including empty fragment or aspect sockets.
+* Fixed loadouts failing to remove mods from some armor or inadvertantly changing the Aeon sect mod.
+
 ## 7.10.0 <span class="changelog-date">(2022-03-27)</span>
 
 * Dragging horizontally on items in Compare will scroll the list - even on iOS.

--- a/src/app/dim-ui/SpecialtyModSlotIcon.tsx
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.tsx
@@ -29,6 +29,7 @@ export function SpecialtyModSlotIcon({
   return (
     <>
       {modMetadatas.map((m) => {
+        // TODO: Why not look this up through emptyPlugItemHash?
         const emptySlotItem = defs.InventoryItem.get(m.emptyModSocketHash);
         return (
           <PressTip tooltip={emptySlotItem.itemTypeDisplayName} key={emptySlotItem.hash}>
@@ -66,7 +67,7 @@ export function ArmorSlotSpecificModSocketIcon({ item, className, lowRes }: ModS
   const defs = useD2Definitions()!;
   const foundSocket = getArmorSlotSpecificModSocket(item);
   // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-  const emptySocketHash = foundSocket && foundSocket.socketDefinition.singleInitialItemHash;
+  const emptySocketHash = foundSocket && foundSocket.emptyPlugItemHash;
   const emptySocketIcon = emptySocketHash && defs.InventoryItem.get(emptySocketHash);
   return emptySocketIcon ? (
     <PressTip elementType="span" tooltip={emptySocketIcon.itemTypeDisplayName}>

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -1,7 +1,6 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
-import { getDefaultPlugHash } from 'app/loadout/mod-utils';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
@@ -145,7 +144,7 @@ export function insertPlug(item: DimItem, socket: DimSocket, plugItemHash: numbe
     // swap at the last minute to applying the default ornament which should
     // match the appearance that the user wanted.
     if (plugItemHash === item.hash) {
-      const defaultPlugHash = getDefaultPlugHash(socket, defs);
+      const defaultPlugHash = socket.emptyPlugItemHash;
       plugItemHash = defaultPlugHash ?? plugItemHash;
     }
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -433,7 +433,8 @@ export interface DimSocket {
    * The displayable/searchable list of potential plug choices for this socket.
    * For perks, this is all the potential perks in the perk column.
    * Otherwise, it'll just be the inserted plug for mods, shaders, etc.
-   * Look at TODO to figure out the full list of possible plugs for this socket.
+   * Look at the plugSet and the socketDefinition's reusablePlugItems for
+   * items that could fit into this socket.
    */
   plugOptions: DimPlug[];
   /**
@@ -468,6 +469,17 @@ export interface DimSocket {
 
   /** Plug hashes in this item visible in the collections roll, if this is a perk */
   curatedRoll: number[] | null;
+  /**
+   * The plug item hash used to reset this plug to an empty default plug.
+   * This is a heuristic improvement over singleInitialItemHash, but it's
+   * entirely possible that this contains a value even when there isn't really
+   * an empty plug. We do our best to leave this unset for sockets without
+   * a meaningful empty plug (abilities, perks, intrinsics, ...), but this should
+   * only be relied upon when you have a good reason to assume it exists.
+   * If you rely on this, you can cheat and assume that this is always available --
+   * for blues, runtime info seems to be missing the empty shader entirely.
+   */
+  emptyPlugItemHash?: number;
   /** Reusable plug items from runtime info, for the plug viewer. */
   reusablePlugItems?: DestinyItemPlugBase[];
   /** Does the socket contain randomized plug items? */

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -414,6 +414,11 @@ export interface DimPlugSet {
    * available to the profile/character.
    */
   readonly plugs: DimPlug[];
+  /**
+   * The cached empty plug item hash from this plugSet. You really
+   * want to access DimSocket.emptyPlugItemHash instead!
+   */
+  readonly precomputedEmptyPlugItemHash?: number;
 }
 
 export interface DimSocket {

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -217,6 +217,7 @@ export default function SocketDetailsSelectedPlug({
       <div className={styles.modDescription}>
         <h3>
           {plug.displayProperties.name}
+          {/* TODO: Use emptyPlugItemHash here? */}
           {emptySpecialtySocketHashes.includes(plug.hash) && (
             <> &mdash; {plug.itemTypeDisplayName}</>
           )}

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -14,7 +14,7 @@ import { useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyArray, emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
 import {
-  getDefaultPlugChoiceHash,
+  getDefaultAbilityChoiceHash,
   getSocketByIndex,
   getSocketsByCategoryHashes,
 } from 'app/utils/socket-utils';
@@ -158,7 +158,7 @@ export default memo(function LockArmorAndPerks({
 
       const isDefaultAbility = Boolean(
         socket &&
-          getDefaultPlugChoiceHash(socket) === overridePlug.hash &&
+          getDefaultAbilityChoiceHash(socket) === overridePlug.hash &&
           abilityAndSuperSockets.includes(socket)
       );
 

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -5,7 +5,7 @@ import { hideItemPicker, showItemPicker } from 'app/item-picker/item-picker';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { isLoadoutBuilderItem, pickSubclass } from 'app/loadout/item-utils';
 import PlugDef from 'app/loadout/loadout-ui/PlugDef';
-import { createGetModRenderKey, getDefaultPlugHash } from 'app/loadout/mod-utils';
+import { createGetModRenderKey } from 'app/loadout/mod-utils';
 import SubclassPlugDrawer from 'app/loadout/SubclassPlugDrawer';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { ItemFilter } from 'app/search/filter-types';
@@ -13,7 +13,11 @@ import { AppIcon, faTimesCircle, pinIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyArray, emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
-import { getSocketByIndex, getSocketsByCategoryHashes } from 'app/utils/socket-utils';
+import {
+  getDefaultPlugChoiceHash,
+  getSocketByIndex,
+  getSocketsByCategoryHashes,
+} from 'app/utils/socket-utils';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { Dispatch, memo, useCallback, useEffect, useMemo, useState } from 'react';
@@ -154,7 +158,7 @@ export default memo(function LockArmorAndPerks({
 
       const isDefaultAbility = Boolean(
         socket &&
-          getDefaultPlugHash(socket, defs) === overridePlug.hash &&
+          getDefaultPlugChoiceHash(socket) === overridePlug.hash &&
           abilityAndSuperSockets.includes(socket)
       );
 

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -18,7 +18,7 @@ import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
-import { getSocketsByCategoryHashes } from 'app/utils/socket-utils';
+import { getDefaultPlugChoiceHash, getSocketsByCategoryHashes } from 'app/utils/socket-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -432,7 +432,7 @@ function lbStateReducer(defs: D2ManifestDefinitions) {
         if (socketIndexToRemove !== undefined && abilitySocketRemovingFrom) {
           // If this is an ability socket, replace with the default plug hash
           newSocketOverrides[socketIndexToRemove] =
-            abilitySocketRemovingFrom.socketDefinition.singleInitialItemHash;
+            getDefaultPlugChoiceHash(abilitySocketRemovingFrom)!;
         } else if (socketIndexToRemove) {
           // If its not an ability we just remove it from the overrides
           delete newSocketOverrides[socketIndexToRemove];

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -18,7 +18,7 @@ import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
-import { getDefaultPlugChoiceHash, getSocketsByCategoryHashes } from 'app/utils/socket-utils';
+import { getDefaultAbilityChoiceHash, getSocketsByCategoryHashes } from 'app/utils/socket-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -432,7 +432,7 @@ function lbStateReducer(defs: D2ManifestDefinitions) {
         if (socketIndexToRemove !== undefined && abilitySocketRemovingFrom) {
           // If this is an ability socket, replace with the default plug hash
           newSocketOverrides[socketIndexToRemove] =
-            getDefaultPlugChoiceHash(abilitySocketRemovingFrom)!;
+            getDefaultAbilityChoiceHash(abilitySocketRemovingFrom);
         } else if (socketIndexToRemove) {
           // If its not an ability we just remove it from the overrides
           delete newSocketOverrides[socketIndexToRemove];

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -33,7 +33,6 @@ import {
   fitMostMods,
   pickPlugPositions,
 } from 'app/loadout/mod-assignment-utils';
-import { getDefaultPlugHash } from 'app/loadout/mod-utils';
 import {
   d2ManifestSelector,
   destiny2CoreSettingsSelector,
@@ -843,7 +842,7 @@ function applySocketOverrides(
                 category.category.hash === SocketCategoryHashes.Abilities_Abilities_LightSubclass ||
                 category.category.hash === SocketCategoryHashes.Super)
             ) {
-              modHash = getDefaultPlugHash(socket, defs);
+              modHash = socket.socketDefinition.singleInitialItemHash;
             }
             if (modHash) {
               const mod = defs.InventoryItem.get(modHash) as PluggableInventoryItemDefinition;
@@ -1022,7 +1021,7 @@ function applyLoadoutMods(
         }
       }
 
-      const pluggingSteps = createPluggingStrategy(item, assignments, defs);
+      const pluggingSteps = createPluggingStrategy(item, assignments);
       const assignmentSequence = pluggingSteps.filter((assignment) => assignment.required);
       infoLog('loadout mods', 'Applying', assignmentSequence, 'to', item.name);
       if (assignmentSequence) {
@@ -1126,7 +1125,7 @@ function equipModsToItem(
       // match the appearance that the user wanted. We'll still report as if we
       // applied the ornament.
       if (mod.hash === item.hash) {
-        const defaultPlugHash = getDefaultPlugHash(socket, defs);
+        const defaultPlugHash = socket.emptyPlugItemHash;
         if (defaultPlugHash) {
           mod = (defs.InventoryItem.get(defaultPlugHash) ??
             mod) as PluggableInventoryItemDefinition;

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -48,7 +48,12 @@ import { DimError } from 'app/utils/dim-error';
 import { emptyArray } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
-import { getSocketByIndex, getSocketsByIndexes, plugFitsIntoSocket } from 'app/utils/socket-utils';
+import {
+  getDefaultPlugChoiceHash,
+  getSocketByIndex,
+  getSocketsByIndexes,
+  plugFitsIntoSocket,
+} from 'app/utils/socket-utils';
 import { count } from 'app/utils/util';
 import { DestinyClass, PlatformErrorCodes } from 'bungie-api-ts/destiny2';
 import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
@@ -842,7 +847,7 @@ function applySocketOverrides(
                 category.category.hash === SocketCategoryHashes.Abilities_Abilities_LightSubclass ||
                 category.category.hash === SocketCategoryHashes.Super)
             ) {
-              modHash = socket.socketDefinition.singleInitialItemHash;
+              modHash = getDefaultPlugChoiceHash(socket)!;
             }
             if (modHash) {
               const mod = defs.InventoryItem.get(modHash) as PluggableInventoryItemDefinition;

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -49,7 +49,7 @@ import { emptyArray } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
 import {
-  getDefaultPlugChoiceHash,
+  getDefaultAbilityChoiceHash,
   getSocketByIndex,
   getSocketsByIndexes,
   plugFitsIntoSocket,
@@ -847,7 +847,7 @@ function applySocketOverrides(
                 category.category.hash === SocketCategoryHashes.Abilities_Abilities_LightSubclass ||
                 category.category.hash === SocketCategoryHashes.Super)
             ) {
-              modHash = getDefaultPlugChoiceHash(socket)!;
+              modHash = getDefaultAbilityChoiceHash(socket);
             }
             if (modHash) {
               const mod = defs.InventoryItem.get(modHash) as PluggableInventoryItemDefinition;

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -11,6 +11,7 @@ import { D1BucketHashes } from 'app/search/d1-known-values';
 import { armorStats } from 'app/search/d2-known-values';
 import { isPlugStatActive, itemCanBeInLoadout } from 'app/utils/item-utils';
 import {
+  getDefaultPlugChoiceHash,
   getFirstSocketByCategoryHash,
   getSocketsByCategoryHash,
   getSocketsByCategoryHashes,
@@ -110,9 +111,7 @@ export function createSubclassDefaultSocketOverrides(item: DimItem) {
     ]);
 
     for (const socket of abilityAndSuperSockets) {
-      // HACK: Void grenades do not have a singleInitialItemHash
-      socketOverrides[socket.socketIndex] =
-        socket.socketDefinition.singleInitialItemHash || socket.plugSet!.plugs[0].plugDef.hash;
+      socketOverrides[socket.socketIndex] = getDefaultPlugChoiceHash(socket)!;
     }
     return socketOverrides;
   }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -11,7 +11,7 @@ import { D1BucketHashes } from 'app/search/d1-known-values';
 import { armorStats } from 'app/search/d2-known-values';
 import { isPlugStatActive, itemCanBeInLoadout } from 'app/utils/item-utils';
 import {
-  getDefaultPlugChoiceHash,
+  getDefaultAbilityChoiceHash,
   getFirstSocketByCategoryHash,
   getSocketsByCategoryHash,
   getSocketsByCategoryHashes,
@@ -111,7 +111,7 @@ export function createSubclassDefaultSocketOverrides(item: DimItem) {
     ]);
 
     for (const socket of abilityAndSuperSockets) {
-      socketOverrides[socket.socketIndex] = getDefaultPlugChoiceHash(socket)!;
+      socketOverrides[socket.socketIndex] = getDefaultAbilityChoiceHash(socket);
     }
     return socketOverrides;
   }

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -8,7 +8,7 @@ import PlugDrawer from 'app/loadout/plug-drawer/PlugDrawer';
 import { PlugSet } from 'app/loadout/plug-drawer/types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { compareBy } from 'app/utils/comparators';
-import { getDefaultPlugChoiceHash, getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import { getDefaultAbilityChoiceHash, getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -184,7 +184,7 @@ function getPlugsForSubclass(
           category.category.hash === SocketCategoryHashes.Super;
 
         const defaultPlugHash = isAbilityLikeSocket
-          ? getDefaultPlugChoiceHash(firstSocket)
+          ? getDefaultAbilityChoiceHash(firstSocket)
           : firstSocket.emptyPlugItemHash;
         const defaultPlug = defaultPlugHash ? defs.InventoryItem.get(defaultPlugHash) : undefined;
         if (firstSocket.plugSet && profileResponse && isPluggableItem(defaultPlug)) {

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -8,7 +8,7 @@ import PlugDrawer from 'app/loadout/plug-drawer/PlugDrawer';
 import { PlugSet } from 'app/loadout/plug-drawer/types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { compareBy } from 'app/utils/comparators';
-import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import { getDefaultPlugChoiceHash, getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -183,10 +183,8 @@ function getPlugsForSubclass(
           category.category.hash === SocketCategoryHashes.Abilities_Abilities_LightSubclass ||
           category.category.hash === SocketCategoryHashes.Super;
 
-        // Void grenades do not have a singleInitialItemHash
         const defaultPlugHash = isAbilityLikeSocket
-          ? firstSocket.socketDefinition.singleInitialItemHash ||
-            firstSocket.plugSet!.plugs[0].plugDef.hash
+          ? getDefaultPlugChoiceHash(firstSocket)
           : firstSocket.emptyPlugItemHash;
         const defaultPlug = defaultPlugHash ? defs.InventoryItem.get(defaultPlugHash) : undefined;
         if (firstSocket.plugSet && profileResponse && isPluggableItem(defaultPlug)) {

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -510,7 +510,7 @@ function FashionSocket({
   const handleOrnamentClick = socket && (() => onPickPlug({ item: exampleItem, socket }));
   const canSlotOrnament =
     plugHash !== undefined &&
-    (plugHash === socket?.socketDefinition.singleInitialItemHash ||
+    (plugHash === socket?.emptyPlugItemHash ||
       (unlockedPlugSetItems.has(plugHash) &&
         socket?.plugSet?.plugs.some((p) => p.plugDef.hash === plugHash)) ||
       socket?.reusablePlugItems?.some((p) => p.plugItemHash === plugHash && p.enabled));

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -6,7 +6,7 @@ import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
-import { getDefaultPlugChoiceHash, getSocketsByIndexes } from 'app/utils/socket-utils';
+import { getDefaultAbilityChoiceHash, getSocketsByIndexes } from 'app/utils/socket-utils';
 import clsx from 'clsx';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import React, { useMemo } from 'react';
@@ -30,7 +30,7 @@ export function getSubclassPlugs(
 
       for (const socket of sockets) {
         const override = subclass.loadoutItem.socketOverrides?.[socket.socketIndex];
-        const initial = getDefaultPlugChoiceHash(socket);
+        const initial = getDefaultAbilityChoiceHash(socket);
         const hash = override || (showInitial && initial);
         const plug = hash && defs.InventoryItem.get(hash);
         if (plug && isPluggableItem(plug)) {

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -6,7 +6,7 @@ import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
-import { getSocketsByIndexes } from 'app/utils/socket-utils';
+import { getDefaultPlugChoiceHash, getSocketsByIndexes } from 'app/utils/socket-utils';
 import clsx from 'clsx';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import React, { useMemo } from 'react';
@@ -30,9 +30,7 @@ export function getSubclassPlugs(
 
       for (const socket of sockets) {
         const override = subclass.loadoutItem.socketOverrides?.[socket.socketIndex];
-        // Void grenades do not have a singleInitialItemHash
-        const initial =
-          socket.socketDefinition.singleInitialItemHash || socket.plugSet!.plugs[0].plugDef.hash;
+        const initial = getDefaultPlugChoiceHash(socket);
         const hash = override || (showInitial && initial);
         const plug = hash && defs.InventoryItem.get(hash);
         if (plug && isPluggableItem(plug)) {

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -6,7 +6,6 @@ import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
-import { getDefaultPlugHash } from '../mod-utils';
 import Mod from './Mod';
 import styles from './Sockets.m.scss';
 
@@ -60,7 +59,7 @@ function Sockets({ item, lockedMods, size, onSocketClick }: Props) {
     }
 
     if (!toSave) {
-      const plugHash = getDefaultPlugHash(socket, defs);
+      const plugHash = socket.emptyPlugItemHash;
       if (plugHash) {
         toSave = defs.InventoryItem.get(plugHash);
       }

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -28,7 +28,6 @@ import { generateModPermutations } from './mod-permutations';
 import {
   activityModPlugCategoryHashes,
   bucketHashToPlugCategoryHash,
-  getDefaultPlugHash,
   getItemEnergyType,
 } from './mod-utils';
 
@@ -387,7 +386,7 @@ export function pickPlugPositions(
   // For each remaining armor mod socket that won't have mods assigned,
   // allow it to be returned to its default (usually "Empty Mod Socket").
   for (const socket of existingModSockets) {
-    const defaultModHash = getDefaultPlugHash(socket, defs);
+    const defaultModHash = socket.emptyPlugItemHash;
     const mod =
       defaultModHash &&
       (defs.InventoryItem.get(defaultModHash) as PluggableInventoryItemDefinition);
@@ -418,11 +417,7 @@ export function pickPlugPositions(
  * on this item, with its specific mod slots, and will throw if they are not.
  * This consumes the output of `pickPlugPositions` and just orders & adds metadata
  */
-export function createPluggingStrategy(
-  item: DimItem,
-  assignments: Assignment[],
-  defs: D2ManifestDefinitions
-): PluggingAction[] {
+export function createPluggingStrategy(item: DimItem, assignments: Assignment[]): PluggingAction[] {
   // stuff we need to apply, that frees up energy. we'll apply these first
   const requiredRegains: PluggingAction[] = [];
   // stuff we need to apply, but it will cost us...
@@ -448,7 +443,7 @@ export function createPluggingStrategy(
 
     if (pluggingAction.energySpend > 0) {
       requiredSpends.push(pluggingAction);
-    } else if (!pluggingAction.required && isAssigningToDefault(item, assignment, defs)) {
+    } else if (!pluggingAction.required && isAssigningToDefault(item, assignment)) {
       optionalRegains.push(pluggingAction);
     } else {
       requiredRegains.push(pluggingAction);
@@ -725,8 +720,7 @@ function energyTypesAreCompatible(first: DestinyEnergyType, second: DestinyEnerg
   return first === second || first === DestinyEnergyType.Any || second === DestinyEnergyType.Any;
 }
 
-/** Artifice Armor won't be properly detected unless defs are passed in */
-function isAssigningToDefault(item: DimItem, assignment: Assignment, defs: D2ManifestDefinitions) {
+function isAssigningToDefault(item: DimItem, assignment: Assignment) {
   const socket = item.sockets && getSocketByIndex(item.sockets, assignment.socketIndex);
   if (!socket) {
     warnLog(
@@ -738,7 +732,7 @@ function isAssigningToDefault(item: DimItem, assignment: Assignment, defs: D2Man
       item.hash
     );
   }
-  return socket && assignment.mod.hash === getDefaultPlugHash(socket, defs);
+  return socket && assignment.mod.hash === socket.emptyPlugItemHash;
 }
 
 /**

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -1,6 +1,5 @@
 import { LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { armor2PlugCategoryHashesByName, armorBuckets } from 'app/search/d2-known-values';
 import { chainComparator, compareBy } from 'app/utils/comparators';
@@ -127,25 +126,6 @@ export function getItemEnergyType(
   return isArmorEnergyLocked(item, lockArmorEnergyType)
     ? item.energy.energyType
     : DestinyEnergyType.Any;
-}
-
-// this exists because singleInitialItemHash may be absent,
-// for example on Artifice Armor. in that case, the default
-// plug can be found in the socket's reusable PlugSet.
-
-/**
- * gets the InventoryItem hash corresponding to a socket's default contents
- * (what should be plugged in order to "revert/clear" it)
- */
-export function getDefaultPlugHash(socket: DimSocket, defs: D2ManifestDefinitions) {
-  if (socket.plugged) {
-    const { singleInitialItemHash, reusablePlugSetHash } = socket.socketDefinition;
-    return singleInitialItemHash
-      ? singleInitialItemHash
-      : reusablePlugSetHash
-      ? defs?.PlugSet.get(reusablePlugSetHash).reusablePlugItems[0].plugItemHash
-      : undefined;
-  }
 }
 
 /**

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -170,18 +170,16 @@ export function plugFitsIntoSocket(socket: DimSocket, plugHash: number) {
 }
 
 /**
- * For a "choice socket" (a socket where all options are equivalent and
- * there's no empty option), like Subclass supers or abilities, or the
- * Aeon cult plugs, find whatever should be equipped as a default.
+ * Abilities and supers are "choice sockets", there might be a default
+ * but it's not really a meaningful empty or reset option.
+ * Still, this can be a useful to initialize user selections.
  */
-export function getDefaultPlugChoiceHash(socket: DimSocket) {
-  if (socket.plugged && !socket.emptyPlugItemHash) {
-    const { singleInitialItemHash } = socket.socketDefinition;
-    return singleInitialItemHash
-      ? singleInitialItemHash
-      : // Some sockets like Void 3.0 grenades don't have a singleInitialItemHash
-        socket.plugSet?.plugs[0]?.plugDef.hash;
-  }
+export function getDefaultAbilityChoiceHash(socket: DimSocket) {
+  const { singleInitialItemHash } = socket.socketDefinition;
+  return singleInitialItemHash
+    ? singleInitialItemHash
+    : // Some sockets like Void 3.0 grenades don't have a singleInitialItemHash
+      socket.plugSet!.plugs[0]!.plugDef.hash;
 }
 
 export function isEnhancedPerk(perk: DimPlug | DestinyInventoryItemDefinition) {

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -169,6 +169,21 @@ export function plugFitsIntoSocket(socket: DimSocket, plugHash: number) {
   );
 }
 
+/**
+ * For a "choice socket" (a socket where all options are equivalent and
+ * there's no empty option), like Subclass supers or abilities, or the
+ * Aeon cult plugs, find whatever should be equipped as a default.
+ */
+export function getDefaultPlugChoiceHash(socket: DimSocket) {
+  if (socket.plugged && !socket.emptyPlugItemHash) {
+    const { singleInitialItemHash } = socket.socketDefinition;
+    return singleInitialItemHash
+      ? singleInitialItemHash
+      : // Some sockets like Void 3.0 grenades don't have a singleInitialItemHash
+        socket.plugSet?.plugs[0]?.plugDef.hash;
+  }
+}
+
 export function isEnhancedPerk(perk: DimPlug | DestinyInventoryItemDefinition) {
   const plugDef = 'plugDef' in perk ? perk.plugDef : perk;
   return plugDef.inventory!.tierType === TierType.Common;

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -58,18 +58,12 @@ function isArmorModSocket(socket: DimSocket) {
 
 /** isModSocket and contains its default plug */
 export function isEmptyArmorModSocket(socket: DimSocket) {
-  return (
-    isArmorModSocket(socket) &&
-    socket.socketDefinition.singleInitialItemHash === socket.plugged?.plugDef.hash
-  );
+  return isArmorModSocket(socket) && socket.emptyPlugItemHash === socket.plugged?.plugDef.hash;
 }
 
 /** isModSocket and contains something other than its default plug */
 export function isUsedArmorModSocket(socket: DimSocket) {
-  return (
-    isArmorModSocket(socket) &&
-    socket.socketDefinition.singleInitialItemHash !== socket.plugged?.plugDef.hash
-  );
+  return isArmorModSocket(socket) && socket.emptyPlugItemHash !== socket.plugged?.plugDef.hash;
 }
 
 /** Given an item and a list of socketIndexes, find all the sockets that match those indices, in the order the indexes were provided */
@@ -166,7 +160,7 @@ export function socketContainsIntrinsicPlug(socket: DimSocket) {
  */
 export function plugFitsIntoSocket(socket: DimSocket, plugHash: number) {
   return (
-    socket.socketDefinition.singleInitialItemHash === plugHash ||
+    socket.emptyPlugItemHash === plugHash ||
     socket.plugSet?.plugs.some((dimPlug) => dimPlug.plugDef.hash === plugHash) ||
     // TODO(#7793): This should use reusablePlugItems on the socket def
     // because the check should operate on static definitions. This is still


### PR DESCRIPTION
Getting this ready for the next beta cycle.

Fixes #7442.
Fixes #7896.
Fixes #8019.

Helps with #7817. This will still show some empty sockets, but these aren't actually empty and are more like deprecated mods.
We may want to use `plugFitsIntoSocket` more.