### PR TITLE
Update color-scheme to state dark only

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest-webapp-6-2018.json" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444" />
     <meta name="theme-color" content="black" />
-    <meta name="color-scheme" content="only light" />
+    <meta name="color-scheme" content="dark" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
I think the spec for `color-scheme` has changed, and `only light` no longer prevents Android's aggressive auto-dark mode. This should help and as a bonus automatically colors UI elements like checkboxes and stuff.