### PR TITLE
Search validate length

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -12,9 +12,8 @@ import {
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { convertDimLoadoutToApiLoadout } from 'app/loadout-drawer/loadout-type-converters';
 import { recentSearchComparator } from 'app/search/autocomplete';
-import { parseQuery } from 'app/search/query-parser';
 import { searchConfigSelector } from 'app/search/search-config';
-import { parseAndValidateQuery, validateQuery } from 'app/search/search-utils';
+import { parseAndValidateQuery } from 'app/search/search-utils';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { errorLog, infoLog, timer } from 'app/utils/log';
@@ -1145,16 +1144,8 @@ function cleanupInvalidSearches(draft: Draft<DimApiState>, account: DestinyAccou
       continue;
     }
 
-    try {
-      const ast = parseQuery(search.query);
-      if (
-        !validateQuery(ast, searchConfigs) ||
-        ast.op === 'noop' ||
-        (ast.op === 'filter' && ast.type === 'keyword')
-      ) {
-        deleteSearch(draft, account.destinyVersion, search.query);
-      }
-    } catch (e) {
+    const { saveInHistory } = parseAndValidateQuery(search.query, searchConfigs);
+    if (!saveInHistory) {
       deleteSearch(draft, account.destinyVersion, search.query);
     }
   }

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -27,7 +27,7 @@ function mapStateToProps(state: RootState): StoreProps {
   const searchQuery = querySelector(state);
   return {
     searchQuery,
-    queryValid: validateQuerySelector(state)(searchQuery),
+    queryValid: validateQuerySelector(state)(searchQuery).valid,
     filteredItems: filteredItemsSelector(state),
     searchResultsOpen: searchResultsOpenSelector(state),
   };

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -77,7 +77,7 @@ interface ProvidedProps {
 
 interface StoreProps {
   recentSearches: Search[];
-  validateQuery: (query: string) => boolean;
+  validateQuery: ReturnType<typeof validateQuerySelector>;
   autocompleter: (query: string, caretIndex: number, recentSearches: Search[]) => SearchItem[];
 }
 
@@ -215,7 +215,7 @@ function SearchBar(
     [onQueryChanged]
   );
 
-  const valid = validateQuery(liveQuery);
+  const { valid, saveable } = validateQuery(liveQuery);
 
   const lastBlurQuery = useRef<string>();
   const onBlur = () => {
@@ -410,7 +410,7 @@ function SearchBar(
         <AnimatePresence>
           {children}
 
-          {liveQuery.length > 0 && valid && (
+          {liveQuery.length > 0 && saveable && (
             <motion.button
               layout
               exit={{ scale: 0 }}

--- a/src/app/search/search-utils.ts
+++ b/src/app/search/search-utils.ts
@@ -27,6 +27,10 @@ export function parseAndValidateQuery(
         // don't save "trivial" single-keyword filters
         saveInHistory = false;
       }
+      // Some sites have people save big lists of item IDs. Even if these aren't too long, don't save them automatically
+      if (ast.op === 'or' && ast.operands.every((op) => op.op === 'filter' && op.type === 'id')) {
+        saveInHistory = false;
+      }
       canonical = canonicalizeQuery(ast);
       saveable = canonical.length <= 2048;
     }

--- a/src/app/search/search-utils.ts
+++ b/src/app/search/search-utils.ts
@@ -1,17 +1,44 @@
-import { parseQuery, QueryAST } from './query-parser';
+import { canonicalizeQuery, parseQuery, QueryAST } from './query-parser';
 import { SearchConfig } from './search-config';
 
-export function parseAndValidateQuery(query: string, searchConfig: SearchConfig) {
+export function parseAndValidateQuery(
+  query: string,
+  searchConfig: SearchConfig
+): {
+  /** Is the query valid at all? */
+  valid: boolean;
+  /** Can the user save this query? */
+  saveable: boolean;
+  /** Should we automatically save this in search history? */
+  saveInHistory: boolean;
+  /** The canonicalized version of the query */
+  canonical: string;
+} {
   let valid = true;
+  let saveable = true;
+  let saveInHistory = true;
+  let canonical = query;
   try {
     const ast = parseQuery(query);
     if (!validateQuery(ast, searchConfig)) {
       valid = false;
+    } else {
+      if (ast.op === 'noop' || (ast.op === 'filter' && ast.type === 'keyword')) {
+        // don't save "trivial" single-keyword filters
+        saveInHistory = false;
+      }
+      canonical = canonicalizeQuery(ast);
+      saveable = canonical.length <= 2048;
     }
   } catch (e) {
     valid = false;
   }
-  return valid;
+  return {
+    valid,
+    saveable: valid && saveable,
+    saveInHistory: valid && saveable && saveInHistory,
+    canonical,
+  };
 }
 
 /**


### PR DESCRIPTION
This has three interesting changes:

1. Consolidate the logic for determining when a search is OK to save (either manually or in history).
2. Don't offer save (or automatically save in history) searches over 2048 characters (they'll be rejected by the server).
3. Don't automatically save searches that are just big lists of IDs generated by tools.