### PR TITLE
Support comments in searches

### DIFF
--- a/src/app/search/__snapshots__/query-parser.test.ts.snap
+++ b/src/app/search/__snapshots__/query-parser.test.ts.snap
@@ -3180,6 +3180,31 @@ Array [
 ]
 `;
 
+exports[`parse |  /* My cool search */
+ is:armor|: ast 1`] = `
+Object {
+  "args": "armor",
+  "comment": "my cool search",
+  "op": "filter",
+  "type": "is",
+}
+`;
+
+exports[`parse |  /* My cool search */
+ is:armor|: lexer 1`] = `
+Array [
+  Array [
+    "comment",
+    "my cool search",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
+  ],
+]
+`;
+
 exports[`parse |"grenade launcher reserves"|: ast 1`] = `
 Object {
   "args": "grenade launcher reserves",
@@ -3584,6 +3609,127 @@ Array [
   ],
   Array [
     ")",
+  ],
+]
+`;
+
+exports[`parse |/* My cool search */ (/* armor */ is:armor and is:blue) or (/*weapons*/ is:weapon and perkname:"Kill Clip")|: ast 1`] = `
+Object {
+  "comment": "my cool search",
+  "op": "or",
+  "operands": Array [
+    Object {
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "armor",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "blue",
+          "op": "filter",
+          "type": "is",
+        },
+      ],
+    },
+    Object {
+      "comment": "weapons",
+      "op": "and",
+      "operands": Array [
+        Object {
+          "args": "weapon",
+          "op": "filter",
+          "type": "is",
+        },
+        Object {
+          "args": "kill clip",
+          "op": "filter",
+          "type": "perkname",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`parse |/* My cool search */ (/* armor */ is:armor and is:blue) or (/*weapons*/ is:weapon and perkname:"Kill Clip")|: lexer 1`] = `
+Array [
+  Array [
+    "comment",
+    "my cool search",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "comment",
+    "armor",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "filter",
+    "is",
+    "blue",
+  ],
+  Array [
+    ")",
+  ],
+  Array [
+    "or",
+  ],
+  Array [
+    "(",
+  ],
+  Array [
+    "comment",
+    "weapons",
+  ],
+  Array [
+    "filter",
+    "is",
+    "weapon",
+  ],
+  Array [
+    "and",
+  ],
+  Array [
+    "filter",
+    "perkname",
+    "kill clip",
+  ],
+  Array [
+    ")",
+  ],
+]
+`;
+
+exports[`parse |/* My cool search */ is:armor|: ast 1`] = `
+Object {
+  "args": "armor",
+  "comment": "my cool search",
+  "op": "filter",
+  "type": "is",
+}
+`;
+
+exports[`parse |/* My cool search */ is:armor|: lexer 1`] = `
+Array [
+  Array [
+    "comment",
+    "my cool search",
+  ],
+  Array [
+    "filter",
+    "is",
+    "armor",
   ],
 ]
 `;

--- a/src/app/search/query-parser.test.ts
+++ b/src/app/search/query-parser.test.ts
@@ -55,6 +55,12 @@ const cases = [
   ['not (forgotten)'],
   ['not "forgotten"'],
   ['gnawing hunger'],
+  // Comments
+  ['/* My cool search */ is:armor'],
+  ['  /* My cool search */\n is:armor'],
+  [
+    '/* My cool search */ (/* armor */ is:armor and is:blue) or (/*weapons*/ is:weapon and perkname:"Kill Clip")',
+  ],
 ];
 
 // Each of these asserts that the first query is the same as the second query once parsed
@@ -98,6 +104,11 @@ const canonicalize = [
   ],
   ['( power:>1000 and -modslot:arrival ) ', 'power:>1000 -modslot:arrival'],
   ['food fight', 'food and fight'],
+  ['/* My cool search   */\n is:armor', '/* my cool search */ is:armor'],
+  [
+    '/* My cool search */ (/* armor */ is:armor and is:blue) or (/*weapons*/ is:weapon and perkname:"Kill Clip")',
+    '/* my cool search */ (is:armor is:blue) or (is:weapon perkname:"kill clip")',
+  ],
 ];
 
 test.each(cases)('parse |%s|', (query) => {


### PR DESCRIPTION
Fixes #7174 to the extent I want to fix it.

This allows for single-line comments of the form `/* A comment */` in searches. When canonicalizing, all but the top-level comment will be removed, but the top level comment will always be in front. This is mostly an alternative to doing `name:"My cool search" or ...`