### PR TITLE
Chill out on updates

### DIFF
--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -128,7 +128,8 @@ function loadGlobalSettings(): ThunkResult {
  * Double the wait time, starting with 30 seconds, until we reach 5 minutes.
  */
 function getBackoffWaitTime(backoff: number) {
-  return Math.min(5 * 60 * 1000, Math.random() * Math.pow(2, backoff) * 15000);
+  // Don't wait less than 10 seconds or more than 10 minutes
+  return Math.max(10_000, Math.min(10 * 60 * 1000, Math.random() * Math.pow(2, backoff) * 15_000));
 }
 
 // Backoff multiplier

--- a/src/app/dim-ui/ActivityTracker.tsx
+++ b/src/app/dim-ui/ActivityTracker.tsx
@@ -177,16 +177,4 @@ function useVisibilityRefresh() {
       document.removeEventListener('visibilitychange', visibilityHandler);
     };
   }, [hasSearchQuery, refreshProfileOnVisible]);
-
-  // Also directly subscribe to dimNeedsUpdate so we'll refresh in the background
-  useEffect(
-    () =>
-      dimNeedsUpdate$.subscribe((needsUpdate) => {
-        if (needsUpdate && !hasSearchQuery && document.hidden) {
-          // Sneaky updates - if DIM is hidden and needs an update, do the update.
-          reloadDIM();
-        }
-      }),
-    [hasSearchQuery]
-  );
 }


### PR DESCRIPTION
The thing where we automatically update when the tab is in the background works too well, and kinda blows up the API server. Let's remove it, and put a floor on how often API can retry.