### PR TITLE
only update relative-ci on PRs that change the build pipeline

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,7 +43,17 @@ jobs:
         env:
           PR_BUILD: true
 
+      - name: Check for updates to build pipeline
+        shell: pwsh
+        id: build_pipeline
+        run: |
+          $diff = git diff --name-only HEAD^ HEAD
+          $SourceDiff = $diff | Where-Object { $_ -match 'package.json' -or $_ -match 'yarn.lock' -or $_ -match 'webpack.js' }
+          $HasDiff = $SourceDiff.Length -gt 0
+          Write-Host "::set-output name=changed::$HasDiff"
+
       - name: Send webpack stats to RelativeCI
+        if: steps.build_pipeline.outputs.changed == 'True'
         uses: relative-ci/agent-action@v2
         with:
           webpackStatsFile: ./webpack-stats.json

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,16 +44,16 @@ jobs:
           PR_BUILD: true
 
       - name: Check for updates to build pipeline
-        shell: pwsh
         id: build_pipeline
-        run: |
-          $diff = git diff --name-only HEAD^ HEAD
-          $SourceDiff = $diff | Where-Object { $_ -match 'package.json' -or $_ -match 'yarn.lock' -or $_ -match 'webpack.js' }
-          $HasDiff = $SourceDiff.Length -gt 0
-          Write-Host "::set-output name=changed::$HasDiff"
+        uses: technote-space/get-diff-action@v4
+        with:
+          FILES: |
+            package.json
+            yarn.lock
+            webpack.js
 
       - name: Send webpack stats to RelativeCI
-        if: steps.build_pipeline.outputs.changed == 'True'
+        if: (steps.build_pipeline.outputs.insertions >= 1)
         uses: relative-ci/agent-action@v2
         with:
           webpackStatsFile: ./webpack-stats.json

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -47,13 +47,13 @@ jobs:
         id: build_pipeline
         uses: technote-space/get-diff-action@v4
         with:
-          FILES: |
+          PATTERNS: |
             package.json
             yarn.lock
-            webpack.js
+            config/webpack.js
 
       - name: Send webpack stats to RelativeCI
-        if: (steps.build_pipeline.outputs.insertions >= 1)
+        if: (steps.build_pipeline.outputs.insertions > 0)
         uses: relative-ci/agent-action@v2
         with:
           webpackStatsFile: ./webpack-stats.json


### PR DESCRIPTION
This **_should_** bring the number of RelativeCI jobs down by only submitting webpack-stats to RelativeCI if one of the following files has been updated:
 - package.json
 - yarn.lock
 - webpack.js