### PR TITLE
Add an option to disable SnoreToast notifications

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -446,21 +446,25 @@ module.exports = (env) => {
       })
     );
 
-    config.plugins.push(
-      new WebpackNotifierPlugin({
-        title: 'DIM',
-        excludeWarnings: false,
-        alwaysNotify: true,
-        contentImage: path.join(__dirname, '../icons/release/favicon-96x96.png'),
-      })
-    );
-    config.plugins.push(
-      new ForkTsCheckerNotifierWebpackPlugin({
-        title: 'DIM TypeScript',
-        excludeWarnings: false,
-        contentImage: path.join(__dirname, '../icons/release/favicon-96x96.png'),
-      })
-    );
+    if (process.env.SNORETOAST_DISABLE) {
+      console.log("Disabling build notifications as 'SNORETOAST_DISABLE' was defined");
+    } else {
+      config.plugins.push(
+        new WebpackNotifierPlugin({
+          title: 'DIM',
+          excludeWarnings: false,
+          alwaysNotify: true,
+          contentImage: path.join(__dirname, '../icons/release/favicon-96x96.png'),
+        })
+      );
+      config.plugins.push(
+        new ForkTsCheckerNotifierWebpackPlugin({
+          title: 'DIM TypeScript',
+          excludeWarnings: false,
+          contentImage: path.join(__dirname, '../icons/release/favicon-96x96.png'),
+        })
+      );
+    }
 
     config.plugins.push(new ReactRefreshWebpackPlugin({ overlay: false }));
   } else {


### PR DESCRIPTION
This PR disables the SnoreToast notifications (DIM build + DIM TypeScript check) if a `SNORETOAST_DISABLE` environment variable is defined (opt-in). I find these notifications annoying on Windows 10 where they tend to get buffered up and fall behind after a few rebuilds.