### PR TITLE
Introduce a move session concept, support blind moves in way more cases

### DIFF
--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -21,7 +21,11 @@ import { BucketCategory } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { InventoryBucket } from '../inventory/inventory-buckets';
-import { MoveReservations, sortMoveAsideCandidatesForStore } from '../inventory/item-move-service';
+import {
+  createMoveSession,
+  MoveReservations,
+  sortMoveAsideCandidatesForStore,
+} from '../inventory/item-move-service';
 import { DimItem } from '../inventory/item-types';
 import { D1Store, DimStore } from '../inventory/store-types';
 import { clearItemsOffCharacter } from '../loadout-drawer/loadout-apply';
@@ -209,5 +213,5 @@ function moveItemsToVault(
     reservations[store.id][bucket.hash] = 1;
   });
 
-  return clearItemsOffCharacter(store, items, cancelToken, reservations);
+  return clearItemsOffCharacter(store, items, createMoveSession(cancelToken), reservations);
 }

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -978,7 +978,15 @@ export function executeMoveItem(
     // catch any errors. If we find out that the store is full through this
     // probe, don't try again for a while.
     const timeSinceCurrentStoreWasReallyFull = Date.now() - lastTimeCurrentStoreWasReallyFull;
-    if (source.isVault && target.current && timeSinceCurrentStoreWasReallyFull > 5000) {
+    if (
+      // Either pulling from the vault,
+      (source.isVault ||
+        // or pulling from the postmaster
+        (item.location.inPostmaster && (source.id === target.id || item.bucket.accountWide))) &&
+      // To the current character
+      target.current &&
+      timeSinceCurrentStoreWasReallyFull > 5000
+    ) {
       try {
         infoLog('move', 'Try blind move of', item.name, 'to', target.name);
         return await dispatch(moveToStore(item, target, cancelToken, equip, amount));

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { hideItemPopup } from 'app/item-popup/item-popup';
 import { ThunkResult } from 'app/store/types';
-import { CanceledError, withCancel } from 'app/utils/cancel';
+import { CanceledError, neverCanceled, withCancel } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog } from 'app/utils/log';
@@ -15,7 +15,7 @@ import { queueAction } from '../utils/action-queue';
 import { reportException } from '../utils/exceptions';
 import { updateCharacters } from './d2-stores';
 import { InventoryBucket } from './inventory-buckets';
-import { executeMoveItem } from './item-move-service';
+import { executeMoveItem, MoveSession } from './item-move-service';
 import { DimItem } from './item-types';
 import { updateManualMoveTimestamp } from './manual-moves';
 import { moveItemNotification } from './MoveNotifications';
@@ -173,6 +173,7 @@ export function consolidate(actionableItem: DimItem, store: DimStore): ThunkResu
           const stores = storesSelector(getState());
           const characters = stores.filter((s) => !s.isVault);
           const vault = getVault(stores)!;
+          const moveSession: MoveSession = { currentStoreWasFull: false };
 
           try {
             for (const s of characters) {
@@ -183,7 +184,14 @@ export function consolidate(actionableItem: DimItem, store: DimStore): ThunkResu
               );
               if (item) {
                 const amount = amountOfItem(s, actionableItem);
-                await dispatch(executeMoveItem(item, vault, { equip: false, amount }));
+                await dispatch(
+                  executeMoveItem(
+                    item,
+                    vault,
+                    { equip: false, amount, cancelToken: neverCanceled },
+                    moveSession
+                  )
+                );
               }
             }
 
@@ -195,7 +203,14 @@ export function consolidate(actionableItem: DimItem, store: DimStore): ThunkResu
               );
               if (item) {
                 const amount = amountOfItem(vault, actionableItem);
-                await dispatch(executeMoveItem(item, store, { equip: false, amount }));
+                await dispatch(
+                  executeMoveItem(
+                    item,
+                    store,
+                    { equip: false, amount, cancelToken: neverCanceled },
+                    moveSession
+                  )
+                );
               }
             }
             const data = { name: actionableItem.name, store: store.name };
@@ -232,6 +247,7 @@ export function distribute(actionableItem: DimItem): ThunkResult {
         (async () => {
           // Sort vault to the end
           const stores = _.sortBy(storesSelector(getState()), (s) => (s.id === 'vault' ? 2 : 1));
+          const moveSession: MoveSession = { currentStoreWasFull: false };
 
           let total = 0;
           const amounts = stores.map((store) => {
@@ -279,7 +295,12 @@ export function distribute(actionableItem: DimItem): ThunkResult {
             for (const move of moves) {
               const item = move.source.items.find((i) => i.hash === actionableItem.hash)!;
               await dispatch(
-                executeMoveItem(item, move.target, { equip: false, amount: move.amount })
+                executeMoveItem(
+                  item,
+                  move.target,
+                  { equip: false, amount: move.amount, cancelToken: neverCanceled },
+                  moveSession
+                )
               );
             }
           }

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -4,6 +4,7 @@ import { t } from 'app/i18next-t';
 import { canInsertPlug, insertPlug } from 'app/inventory/advanced-write-actions';
 import { updateCharacters } from 'app/inventory/d2-stores';
 import {
+  checkForOverFill,
   createMoveSession,
   equipItems,
   Exclusion,
@@ -574,6 +575,7 @@ function doApplyLoadout(
       // Update the characters to get the latest stats
       dispatch(updateCharacters());
       dispatch(resumeFarming());
+      dispatch(checkForOverFill());
     }
   };
 }

--- a/src/app/loadout-drawer/postmaster.ts
+++ b/src/app/loadout-drawer/postmaster.ts
@@ -17,6 +17,7 @@ import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import {
+  checkForOverFill,
   createMoveSession,
   executeMoveItem,
   MoveReservations,
@@ -91,6 +92,8 @@ export function makeRoomForPostmaster(store: DimStore, buckets: InventoryBuckets
         throw e;
       }
     }
+
+    dispatch(checkForOverFill());
   };
 }
 
@@ -217,6 +220,8 @@ export function pullFromPostmaster(store: DimStore): ThunkResult {
       if (!succeeded) {
         throw new Error(t('Loadouts.PullFromPostmasterGeneralError'));
       }
+
+      dispatch(checkForOverFill());
     })();
 
     showNotification(postmasterNotification(items.length, store, promise, cancel));


### PR DESCRIPTION
This is a pretty big change to how we handle moves, but hopefully should reduce frustration for folks who are moving while deleting things in game. Today we have some basic support for the scenario where you delete items in game, but DIM doesn't know about that yet, and you can still move into that bucket (potentially "overfilling" it from DIM's perspective). But this breaks down if we find out the bucket really is full, which can lead to DIM moving a lot of items away to try and make space.

1. Expand the support for "blind moves" (where we just start by asking the API to move, and only do our fancy logic if it fails) to cover pulling an item from postmaster.
3. Introduce "move session" which can track things across a single move (and any dependent moves it makes) or a multi-move sequence like loadout apply or pull from postmaster. Move cancel token into this session object.
2. Replace the 5 second cooldown on blind move failures with *per bucket* lockouts that are tracked on a "move session" basis.
3. Track blind move failures per bucket instead of per store, allowing us to continue "overfilling" a different bucket even if another failed.
4. After completion of a move session, dispatch a task that will find any buckets that are obviously overfilled (over their capacity) and request a reload of data automatically if so. The reload follows our standard rules for how often you can refresh profile.