### PR TITLE
allow other hostnames in dev

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -82,6 +82,7 @@ module.exports = (env) => {
     devServer: env.dev
       ? {
           host: process.env.DOCKER ? '0.0.0.0' : 'localhost',
+          allowedHosts: 'all',
           server: {
             type: 'https',
             options: {


### PR DESCRIPTION
this allows internal cnames or other hosts file adjustments in dev mode, without dev server rejecting it for (the hostname header) not being named localhost or a self-detected IP address