### PR TITLE
correctly sort collapsed wishlist columns

### DIFF
--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -2,13 +2,19 @@ import { t } from 'app/i18next-t';
 import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
 import Plug from 'app/item-popup/Plug';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { compareBy } from 'app/utils/comparators';
 import { wishListRollsForItemHashSelector } from 'app/wishlists/selectors';
 import { WishListRoll } from 'app/wishlists/types';
 import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import styles from './AllWishlistRolls.m.scss';
-import { consolidateRollsForOneWeapon, consolidateSecondaryPerks } from './wishlistCollapser';
+import { getCraftingTemplate } from './crafting-utils';
+import {
+  consolidateRollsForOneWeapon,
+  consolidateSecondaryPerks,
+  enhancedToPerk,
+} from './wishlist-collapser';
 
 /**
  * List out all the known wishlist rolls for a given item.
@@ -71,17 +77,36 @@ function WishlistRolls({
    */
   realAvailablePlugHashes?: number[];
 }) {
-  const defs = useD2Definitions();
+  const defs = useD2Definitions()!;
   const groupedWishlistRolls = _.groupBy(wishlistRolls, (r) => r.notes || t('Armory.NoNotes'));
+
+  const templateSockets = getCraftingTemplate(defs, item.hash)?.sockets?.socketEntries;
 
   const socketByPerkHash: Record<number, DimSocket> = {};
   const plugByPerkHash: Record<number, DimPlug> = {};
+  // the order, within their column, that perks appear. for sorting barrels mags etc.
+  const columnOrderByPlugHash: Record<number, number> = {};
+
   if (item.sockets) {
     for (const s of item.sockets.allSockets) {
       if (s.isReusable) {
         for (const p of s.plugOptions) {
           socketByPerkHash[p.plugDef.hash] = s;
           plugByPerkHash[p.plugDef.hash] = p;
+        }
+
+        const plugSetHash =
+          templateSockets?.[s.socketIndex].reusablePlugSetHash ??
+          (s.socketDefinition.randomizedPlugSetHash || s.socketDefinition.reusablePlugSetHash);
+
+        if (plugSetHash) {
+          const plugItems = defs.PlugSet.get(plugSetHash).reusablePlugItems;
+          for (let i = 0; i < plugItems.length; i++) {
+            const plugItem = plugItems[i];
+            if (plugItem.currentlyCanRoll) {
+              columnOrderByPlugHash[plugItem.plugItemHash] = i;
+            }
+          }
         }
       }
     }
@@ -92,22 +117,30 @@ function WishlistRolls({
   return (
     <>
       {_.map(groupedWishlistRolls, (rolls, notes) => {
-        const consolidatedRolls = consolidateRollsForOneWeapon(defs!, item, rolls);
+        const consolidatedRolls = consolidateRollsForOneWeapon(defs, item, rolls);
 
         return (
           <div key={notes}>
             <div>{notes}</div>
             <ul>
               {consolidatedRolls.map((cr) => {
-                // this is 1 set of primary perks. just
+                // groups [outlaw, enhanced outlaw, rampage]
+                // into {
+                //   "3": [outlaw, enhanced outlaw]
+                //   "4": [rampage]
+                // }
                 const primariesGroupedByColumn = _.groupBy(
                   cr.commonPrimaryPerks,
                   (h) => socketByPerkHash[h]?.socketIndex
                 );
 
-                // i.e. [[outlaw, enhanced outlaw], [rampage]]
-                const primaryBundles = cr.rolls[0].primarySocketIndices.map(
-                  (socketIndex) => primariesGroupedByColumn[socketIndex]
+                // turns the above into
+                // [[outlaw, enhanced outlaw], [rampage]]
+                const primaryBundles = cr.rolls[0].primarySocketIndices.map((socketIndex) =>
+                  primariesGroupedByColumn[socketIndex].sort(
+                    // establish a consistent base -> enhanced perk order
+                    compareBy((h) => (h in enhancedToPerk ? 1 : 0))
+                  )
                 );
 
                 // i.e.
@@ -123,23 +156,32 @@ function WishlistRolls({
                     <li key={bundles.map((b) => b.join()).join()} className={styles.roll}>
                       {bundles.map((hashes) => (
                         <div key={hashes.join()} className={styles.orGroup}>
-                          {hashes.map((h) => {
-                            const socket = socketByPerkHash[h];
-                            const plug = plugByPerkHash[h];
-                            return (
-                              plug &&
-                              socket && (
-                                <Plug
-                                  key={plug.plugDef.hash}
-                                  plug={plug}
-                                  item={item}
-                                  socketInfo={socket}
-                                  hasMenu={false}
-                                  notSelected={realAvailablePlugHashes?.includes(plug.plugDef.hash)}
-                                />
+                          {hashes
+                            .sort(
+                              compareBy(
+                                // unrecognized/unrollable perks last
+                                (h) => columnOrderByPlugHash[h] ?? 9999
                               )
-                            );
-                          })}
+                            )
+                            .map((h) => {
+                              const socket = socketByPerkHash[h];
+                              const plug = plugByPerkHash[h];
+                              return (
+                                plug &&
+                                socket && (
+                                  <Plug
+                                    key={plug.plugDef.hash}
+                                    plug={plug}
+                                    item={item}
+                                    socketInfo={socket}
+                                    hasMenu={false}
+                                    notSelected={realAvailablePlugHashes?.includes(
+                                      plug.plugDef.hash
+                                    )}
+                                  />
+                                )
+                              );
+                            })}
                         </div>
                       ))}
                     </li>

--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -95,6 +95,7 @@ function WishlistRolls({
           plugByPerkHash[p.plugDef.hash] = p;
         }
 
+        // if this is a crafted item, use its template's plug order. otherwise fall back to its reusable or randomized plugsets
         const plugSetHash =
           templateSockets?.[s.socketIndex].reusablePlugSetHash ??
           (s.socketDefinition.randomizedPlugSetHash || s.socketDefinition.reusablePlugSetHash);
@@ -159,7 +160,7 @@ function WishlistRolls({
                           {hashes
                             .sort(
                               compareBy(
-                                // unrecognized/unrollable perks last
+                                // unrecognized/unrollable perks sort to last
                                 (h) => columnOrderByPlugHash[h] ?? 9999
                               )
                             )

--- a/src/app/armory/crafting-utils.ts
+++ b/src/app/armory/crafting-utils.ts
@@ -1,0 +1,28 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import _ from 'lodash';
+
+const buildTemplateLookup = _.once((defs: D2ManifestDefinitions) => {
+  const results: NodeJS.Dict<DestinyInventoryItemDefinition> = {};
+  const invItemTable = defs.InventoryItem.getAll();
+  for (const h in invItemTable) {
+    const i = invItemTable[h];
+    if (i.crafting) {
+      results[i.crafting.outputItemHash] = i;
+    }
+  }
+  return results;
+});
+
+/**
+ * input a weapon's hash. if it's a craftable weapon, this returns the crafting template item.
+ * the template contains its possible perks/plugs/etc in proper order.
+ *
+ * for instance, template 2335939410 outputs weapon 2856514843.
+ * only 2335939410 has the barrels & magazines in the right order, and with level requirements attached.
+ *
+ * KEEP IN MIND: this will be the wrong item hash for, say, wishlists. wishlists are pointed at the *output* item hash.
+ */
+export function getCraftingTemplate(defs: D2ManifestDefinitions, itemHash: number) {
+  return buildTemplateLookup(defs)[itemHash];
+}

--- a/src/app/armory/wishlist-collapser.test.ts
+++ b/src/app/armory/wishlist-collapser.test.ts
@@ -1,4 +1,4 @@
-import { consolidateSecondaryPerks } from './wishlistCollapser';
+import { consolidateSecondaryPerks } from './wishlist-collapser';
 
 describe('perkConsolidator', () => {
   it('does its thing', () => {

--- a/src/app/armory/wishlist-collapser.ts
+++ b/src/app/armory/wishlist-collapser.ts
@@ -6,7 +6,7 @@ import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import _ from 'lodash';
 
-const enhancedToPerk = _.mapValues(_.invert(perkToEnhanced), Number);
+export const enhancedToPerk = _.mapValues(_.invert(perkToEnhanced), Number);
 
 type Roll = {
   /** rampage, outlaw, etc. */

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -546,11 +546,18 @@ function findOtherCopies(
   item: DestinyInventoryItemDefinition | DimItem | number
 ) {
   const itemDef = defs.InventoryItem.get(typeof item === 'number' ? item : item.hash);
-  return Object.values(defs.InventoryItem.getAll()).filter(
-    (i) =>
+  const results: DestinyInventoryItemDefinition[] = [];
+  const invItemTable = defs.InventoryItem.getAll();
+  for (const h in invItemTable) {
+    const i = invItemTable[h];
+    if (
       i.displayProperties.name === itemDef.displayProperties.name &&
       i.displayProperties.icon === itemDef.displayProperties.icon
-  );
+    ) {
+      results.push(i);
+    }
+  }
+  return results;
 }
 
 function manuallyFindItemForCollectible(
@@ -558,7 +565,11 @@ function manuallyFindItemForCollectible(
   collectible: DestinyCollectibleDefinition | number
 ) {
   const collectibleHash = typeof collectible === 'number' ? collectible : collectible.hash;
-  return Object.values(defs.InventoryItem.getAll()).find(
-    (i) => i.collectibleHash === collectibleHash
-  );
+  const invItemTable = defs.InventoryItem.getAll();
+  for (const h in invItemTable) {
+    const i = invItemTable[h];
+    if (i.collectibleHash === collectibleHash) {
+      return i;
+    }
+  }
 }


### PR DESCRIPTION
- sorts wishlist perks in the armory view according to their order in the craftable version of the item
- sorts base/enhanced perks in the same column consistently
- corrects a filename casing issue
- replaces a few `Object.values(invItemComponent)` with `for..in`, because why allocate a large array of all items