### PR TITLE
Loadout tweaks

### DIFF
--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -18,6 +18,7 @@ import { addItem$ } from 'app/loadout-drawer/loadout-events';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import LoadoutDrawerDropTarget from 'app/loadout-drawer/LoadoutDrawerDropTarget';
+import LoadoutDrawerFooter from 'app/loadout-drawer/LoadoutDrawerFooter';
 import { useD1Definitions } from 'app/manifest/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useEventBusListener } from 'app/utils/hooks';
@@ -149,26 +150,18 @@ export default function LoadoutDrawer({
     return null;
   }
 
-  const onDeleteLoadout = () => {
+  const onDeleteLoadout = (onClose: () => void) => {
     dispatch(deleteLoadout(loadout.id));
-    close();
+    onClose();
   };
 
   const handleNotesChanged: React.ChangeEventHandler<HTMLTextAreaElement> = (e) =>
     setLoadout(setNotes(e.target.value));
 
-  const header = ({ onClose }: { onClose(): void }) => (
+  const header = (
     <div className="loadout-drawer-header">
       <h1>{isNew ? t('Loadouts.Create') : t('Loadouts.Edit')}</h1>
-      <LoadoutDrawerOptions
-        loadout={loadout}
-        showClass={showClass}
-        isNew={isNew}
-        setLoadout={setLoadout}
-        saveLoadout={(e) => (isNew ? saveAsNew(e, onClose) : onSaveLoadout(e, loadout, onClose))}
-        saveAsNew={(e) => saveAsNew(e, onClose)}
-        deleteLoadout={onDeleteLoadout}
-      />
+      <LoadoutDrawerOptions loadout={loadout} showClass={showClass} setLoadout={setLoadout} />
       {loadout.notes !== undefined && (
         <textarea
           onChange={handleNotesChanged}
@@ -180,8 +173,19 @@ export default function LoadoutDrawer({
     </div>
   );
 
+  const footer = ({ onClose }: { onClose(): void }) => (
+    <LoadoutDrawerFooter
+      loadout={loadout}
+      isNew={isNew}
+      onSaveLoadout={(e, isNew) =>
+        isNew ? saveAsNew(e, onClose) : onSaveLoadout(e, loadout, onClose)
+      }
+      onDeleteLoadout={() => onDeleteLoadout(onClose)}
+    />
+  );
+
   return (
-    <Sheet onClose={onClose} header={header} disabled={showingItemPicker}>
+    <Sheet onClose={onClose} header={header} footer={footer} disabled={showingItemPicker}>
       <div className="loadout-drawer loadout-create">
         <div className="loadout-content">
           <LoadoutDrawerDropTarget onDroppedItem={onAddItem} classType={loadout.classType}>

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
@@ -5,10 +5,8 @@
     font-size: 14px;
   }
 
-  form {
-    display: flex;
-    flex-flow: row wrap;
-  }
+  display: flex;
+  flex-flow: row wrap;
 
   input {
     vertical-align: middle;

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.tsx
@@ -1,7 +1,5 @@
-import { ConfirmButton } from 'app/dim-ui/ConfirmButton';
 import { t } from 'app/i18next-t';
 import { storesSelector } from 'app/inventory/selectors';
-import { getClass } from 'app/inventory/store/character-utils';
 import {
   LoadoutUpdateFunction,
   setClassType,
@@ -10,8 +8,6 @@ import {
   setNotes,
 } from 'app/loadout-drawer/loadout-drawer-reducer';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
-import { loadoutsSelector } from 'app/loadout-drawer/selectors';
-import { AppIcon, deleteIcon } from 'app/shell/icons';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import _ from 'lodash';
@@ -34,37 +30,13 @@ const classTypeOptionsSelector = createSelector(storesSelector, (stores) => {
 export default function LoadoutDrawerOptions({
   loadout,
   showClass,
-  isNew,
   setLoadout,
-  saveLoadout,
-  saveAsNew,
-  deleteLoadout,
 }: {
-  loadout: Readonly<Loadout> | undefined;
+  loadout: Readonly<Loadout>;
   showClass: boolean;
-  isNew: boolean;
   setLoadout: (updater: LoadoutUpdateFunction) => void;
-  saveLoadout(e: React.FormEvent): void;
-  saveAsNew(e: React.MouseEvent): void;
-  deleteLoadout(): void;
 }) {
   const classTypeOptions = useSelector(classTypeOptionsSelector);
-
-  const loadouts = useSelector(loadoutsSelector);
-
-  if (!loadout) {
-    return null;
-  }
-
-  // Find a loadout with the same name that could overlap with this one
-  // Note that this might be the saved version of this very same loadout!
-  const clashingLoadout = loadouts.find(
-    (l) =>
-      loadout.name === l.name &&
-      (loadout.classType === l.classType ||
-        l.classType === DestinyClass.Unknown ||
-        loadout.classType === DestinyClass.Unknown)
-  );
 
   const handleSetName = (e: React.ChangeEvent<HTMLInputElement>) =>
     setLoadout(setName(e.target.value));
@@ -77,109 +49,52 @@ export default function LoadoutDrawerOptions({
 
   const addNotes = () => setLoadout(setNotes(''));
 
-  // TODO: make the link to loadout optimizer bring the currently equipped items along in route state
-
-  const saveDisabled =
-    !loadout.name.length ||
-    (!loadout.items.length &&
-      !loadout.parameters?.mods?.length &&
-      _.isEmpty(loadout.parameters?.modsByBucket)) ||
-    // There's an existing loadout with the same name & class and it's not the loadout we are currently editing
-    Boolean(clashingLoadout && clashingLoadout.id !== loadout.id);
-
-  const saveAsNewDisabled =
-    saveDisabled ||
-    // There's an existing loadout with the same name & class
-    Boolean(clashingLoadout);
-
   return (
     <div className={styles.loadoutOptions}>
-      <form onSubmit={saveLoadout}>
-        <div className={clsx(styles.inputGroup, styles.loadoutName)}>
-          <input
-            className={styles.dimInput}
-            name="name"
-            onChange={handleSetName}
-            minLength={1}
-            maxLength={50}
-            required={true}
-            type="text"
-            value={loadout.name}
-            placeholder={t('Loadouts.LoadoutName')}
-          />
-          {showClass && (
-            <select name="classType" onChange={handleSetClassType} value={loadout.classType}>
-              {classTypeOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          )}
-        </div>
+      <div className={clsx(styles.inputGroup, styles.loadoutName)}>
+        <input
+          className={styles.dimInput}
+          name="name"
+          onChange={handleSetName}
+          minLength={1}
+          maxLength={50}
+          required={true}
+          type="text"
+          value={loadout.name}
+          placeholder={t('Loadouts.LoadoutName')}
+        />
+        {showClass && (
+          <select name="classType" onChange={handleSetClassType} value={loadout.classType}>
+            {classTypeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+      {loadout.notes === undefined && (
         <div className={styles.inputGroup}>
-          <button className="dim-button" type="submit" disabled={saveDisabled}>
-            {t('Loadouts.Save')}
+          <button
+            className="dim-button"
+            onClick={addNotes}
+            type="button"
+            title={t('Loadouts.AddNotes')}
+          >
+            {t('Loadouts.AddNotes')}
           </button>
-          {!isNew && (
-            <button
-              className="dim-button"
-              onClick={saveAsNew}
-              type="button"
-              title={
-                clashingLoadout
-                  ? clashingLoadout.classType !== DestinyClass.Unknown
-                    ? t('Loadouts.AlreadyExistsClass', {
-                        className: getClass(clashingLoadout.classType),
-                      })
-                    : t('Loadouts.AlreadyExistsGlobal')
-                  : t('Loadouts.SaveAsNew')
-              }
-              disabled={saveAsNewDisabled}
-            >
-              {t('Loadouts.SaveAsNew')}
-            </button>
-          )}
-        </div>
-        {!isNew && (
-          <div className={styles.inputGroup}>
-            <ConfirmButton key="delete" danger onClick={deleteLoadout}>
-              <AppIcon icon={deleteIcon} title={t('Loadouts.Delete')} />
-            </ConfirmButton>
-          </div>
-        )}
-        {loadout.notes === undefined && (
-          <div className={styles.inputGroup}>
-            <button
-              className="dim-button"
-              onClick={addNotes}
-              type="button"
-              title={t('Loadouts.AddNotes')}
-            >
-              {t('Loadouts.AddNotes')}
-            </button>
-          </div>
-        )}
-        <div className={styles.inputGroup}>
-          <label>
-            <input
-              type="checkbox"
-              checked={Boolean(loadout.clearSpace)}
-              onChange={handleSetClearSpace}
-            />{' '}
-            {t('Loadouts.ClearSpace')}
-          </label>
-        </div>
-      </form>
-      {clashingLoadout && clashingLoadout.id !== loadout.id && (
-        <div>
-          {clashingLoadout.classType !== DestinyClass.Unknown
-            ? t('Loadouts.AlreadyExistsClass', {
-                className: getClass(clashingLoadout.classType),
-              })
-            : t('Loadouts.AlreadyExistsGlobal')}
         </div>
       )}
+      <div className={styles.inputGroup}>
+        <label>
+          <input
+            type="checkbox"
+            checked={Boolean(loadout.clearSpace)}
+            onChange={handleSetClearSpace}
+          />{' '}
+          {t('Loadouts.ClearSpace')}
+        </label>
+      </div>
     </div>
   );
 }

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -206,7 +206,6 @@ export default function LoadoutDrawer2({
     </div>
   );
 
-  // TODO: use this on the old loadout editor?
   const footer = ({ onClose }: { onClose(): void }) => (
     <LoadoutDrawerFooter
       loadout={loadout}


### PR DESCRIPTION
1. Convert the old D1 loadout editor to use the same footer as the new loadout editor
2. lazy load editor code when the sheet shows, which further reduces the initial code bundle