### PR TITLE
Material menu

### DIFF
--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -29,6 +29,10 @@
   box-sizing: border-box;
   user-select: none;
 
+  &.wideTooltip {
+    max-width: 100vw;
+  }
+
   h2,
   h3 {
     background-color: #444;

--- a/src/app/dim-ui/PressTip.m.scss.d.ts
+++ b/src/app/dim-ui/PressTip.m.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'content': string;
   'control': string;
   'tooltip': string;
+  'wideTooltip': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -37,6 +37,8 @@ interface Props {
   /** By default everything gets wrapped in a div, but you can choose a different element type here. */
   elementType?: React.ElementType;
   className?: string;
+  /** Allow the tooltip to be wider than the normal size */
+  wide?: boolean;
   style?: React.CSSProperties;
   placement?: Placement;
 }
@@ -72,6 +74,7 @@ function Control({
   elementType: Component = 'div',
   className,
   placement,
+  wide,
   ...rest
 }: ControlProps) {
   const tooltipContents = useRef<HTMLDivElement>(null);
@@ -100,7 +103,10 @@ function Control({
       {children}
       {open &&
         ReactDOM.createPortal(
-          <div className={styles.tooltip} ref={tooltipContents}>
+          <div
+            className={clsx(styles.tooltip, { [styles.wideTooltip]: wide })}
+            ref={tooltipContents}
+          >
             <div className={styles.content}>{_.isFunction(tooltip) ? tooltip() : tooltip}</div>
             <div className={styles.arrow} />
           </div>,

--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -1,3 +1,4 @@
+import { Placement } from '@popperjs/core';
 import clsx from 'clsx';
 import _ from 'lodash';
 import {
@@ -37,6 +38,7 @@ interface Props {
   elementType?: React.ElementType;
   className?: string;
   style?: React.CSSProperties;
+  placement?: Placement;
 }
 
 type ControlProps = Props &
@@ -69,6 +71,7 @@ function Control({
   children,
   elementType: Component = 'div',
   className,
+  placement,
   ...rest
 }: ControlProps) {
   const tooltipContents = useRef<HTMLDivElement>(null);
@@ -78,7 +81,7 @@ function Control({
     contents: tooltipContents,
     reference: triggerRef,
     arrowClassName: styles.arrow,
-    placement: 'top',
+    placement,
   });
 
   if (!tooltip) {

--- a/src/app/material-counts/MaterialCounts.m.scss
+++ b/src/app/material-counts/MaterialCounts.m.scss
@@ -2,23 +2,30 @@
   display: grid;
   margin: auto;
   width: fit-content;
-  grid-template-columns: max-content max-content max-content;
+  grid-template-columns: repeat(3, max-content);
   gap: 2px 6px;
   align-items: center;
+
+  &.wide {
+    grid-template-columns: repeat(6, max-content);
+  }
 
   img {
     height: 20px;
     width: 20px;
   }
-  .amount {
-    text-align: right;
-    font-weight: bold;
-    font-variant-numeric: tabular-nums;
-  }
-  .spanGrid {
-    grid-column-end: span 3;
-    hr {
-      margin: 3px;
-    }
+}
+
+.amount {
+  text-align: right;
+  font-weight: bold;
+  font-variant-numeric: tabular-nums;
+}
+
+.spanGrid {
+  grid-column: 1/-1;
+
+  hr {
+    margin: 3px;
   }
 }

--- a/src/app/material-counts/MaterialCounts.m.scss.d.ts
+++ b/src/app/material-counts/MaterialCounts.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'amount': string;
   'materialCounts': string;
   'spanGrid': string;
+  'wide': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/material-counts/MaterialCounts.tsx
+++ b/src/app/material-counts/MaterialCounts.tsx
@@ -1,5 +1,6 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import { craftingMaterialCountsSelector, materialsSelector } from 'app/inventory/selectors';
+import clsx from 'clsx';
 import spiderMats from 'data/d2/spider-mats.json';
 import _ from 'lodash';
 import React from 'react';
@@ -12,13 +13,13 @@ const goodMats = [2979281381, 4257549984, 3853748946, 4257549985, 3702027555];
 const seasonal = [747321467, 178490507];
 const crafting = [2497395625, 353704689, 2708128607];
 
-export function MaterialCounts() {
+export function MaterialCounts({ wide }: { wide?: boolean }) {
   const allMats = useSelector(materialsSelector);
   const craftingMaterialCounts = useSelector(craftingMaterialCountsSelector);
   const materials = _.groupBy(allMats, (m) => m.hash);
 
   return (
-    <div className={styles.materialCounts}>
+    <div className={clsx(styles.materialCounts, { [styles.wide]: wide })}>
       {[showMats, seasonal, goodMats, crafting].map((matgroup, i) => (
         <React.Fragment key={matgroup[0]}>
           {i > 0 && (

--- a/src/app/material-counts/MaterialCountsWrappers.tsx
+++ b/src/app/material-counts/MaterialCountsWrappers.tsx
@@ -39,7 +39,7 @@ export function MaterialCountsTooltip() {
     <>
       {t('Header.MaterialCounts')}
       <hr />
-      <MaterialCounts />
+      <MaterialCounts wide />
     </>
   );
 }

--- a/src/app/store-stats/VaultCapacity.tsx
+++ b/src/app/store-stats/VaultCapacity.tsx
@@ -7,6 +7,7 @@ import {
   MaterialCountsTooltip,
   showMaterialCount,
 } from 'app/material-counts/MaterialCountsWrappers';
+import { useIsPhonePortrait } from 'app/shell/selectors';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import vaultIcon from 'destiny-icons/armor_types/helmet.svg';
@@ -90,6 +91,7 @@ const vaultCountsSelector = createSelector(
 export default React.memo(function VaultCapacity() {
   const vaultCounts = useSelector(vaultCountsSelector);
   const mats = <MaterialCountsTooltip />;
+  const isPhonePortrait = useIsPhonePortrait();
 
   return (
     <>
@@ -107,7 +109,11 @@ export default React.memo(function VaultCapacity() {
                   bucket.name.substring(0, 1)
                 )}
               </div>
-              <PressTip tooltip={isConsumables ? mats : undefined} placement="bottom" wide>
+              <PressTip
+                tooltip={isConsumables && !isPhonePortrait ? mats : undefined}
+                placement="bottom"
+                wide
+              >
                 <div
                   title={title}
                   className={clsx({

--- a/src/app/store-stats/VaultCapacity.tsx
+++ b/src/app/store-stats/VaultCapacity.tsx
@@ -107,7 +107,7 @@ export default React.memo(function VaultCapacity() {
                   bucket.name.substring(0, 1)
                 )}
               </div>
-              <PressTip tooltip={isConsumables ? mats : undefined} placement="bottom">
+              <PressTip tooltip={isConsumables ? mats : undefined} placement="bottom" wide>
                 <div
                   title={title}
                   className={clsx({

--- a/src/app/store-stats/VaultCapacity.tsx
+++ b/src/app/store-stats/VaultCapacity.tsx
@@ -107,7 +107,7 @@ export default React.memo(function VaultCapacity() {
                   bucket.name.substring(0, 1)
                 )}
               </div>
-              <PressTip tooltip={isConsumables ? mats : undefined}>
+              <PressTip tooltip={isConsumables ? mats : undefined} placement="bottom">
                 <div
                   title={title}
                   className={clsx({


### PR DESCRIPTION
Some options for fixing #8195.

1. The first commit makes the tooltip not flip to "top" position when there's not enough room. It'll stay on the bottom and get cut off.
2. The second commit makes the tooltip take two columns instead of one big list.
3. The third commit removes the presstip on mobile in favor of the menu item.

<img width="419" alt="image" src="https://user-images.githubusercontent.com/313208/161406319-b44c7787-371b-4f44-a1f9-f4cfc40ad049.png">

We could theoretically swap automatically between wide and not-wide modes based on measuring the screen height but that feels like a lot.