### PR TITLE
Hide Black Armory Radiance socket

### DIFF
--- a/src/app/inventory/store/deepsight.ts
+++ b/src/app/inventory/store/deepsight.ts
@@ -1,4 +1,5 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { socketContainsPlugWithCategory } from 'app/utils/socket-utils';
 import { resonantElementTagsByObjectiveHash } from 'data/d2/crafting-resonant-elements';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { DimDeepsight, DimItem, DimResonantElement, DimSocket } from '../item-types';
@@ -39,8 +40,8 @@ function getResonanceSocket(item: DimItem): DimSocket | undefined {
 
 export function isDeepsightResonanceSocket(socket: DimSocket): boolean {
   return Boolean(
-    socket.plugged?.plugDef.plug.plugCategoryHash ===
-      PlugCategoryHashes.CraftingPlugsWeaponsModsMemories && socket.plugged?.plugDef.objectives
+    socketContainsPlugWithCategory(socket, PlugCategoryHashes.CraftingPlugsWeaponsModsMemories) &&
+      socket.plugged.plugDef.objectives
   );
 }
 

--- a/src/app/item-feed/Highlights.tsx
+++ b/src/app/item-feed/Highlights.tsx
@@ -4,7 +4,7 @@ import { DimItem, DimStat } from 'app/inventory/item-types';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { ItemTypeName } from 'app/item-popup/ItemPopupHeader';
 import { DimPlugTooltip } from 'app/item-popup/PlugTooltip';
-import { getWeaponArchetype } from 'app/utils/socket-utils';
+import { getWeaponArchetype, socketContainsPlugWithCategory } from 'app/utils/socket-utils';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
@@ -17,7 +17,7 @@ export default function Highlights({ item }: { item: DimItem }) {
   if (item.bucket.sort === 'Weapons' && item.sockets) {
     // Don't ask me why Traits are called "Frames" but it does work.
     const perkSockets = item.sockets.allSockets.filter(
-      (s) => s.isPerk && s.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Frames
+      (s) => s.isPerk && socketContainsPlugWithCategory(s, PlugCategoryHashes.Frames)
     );
     const archetype = !item.isExotic && getWeaponArchetype(item)?.displayProperties.name;
 

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -10,10 +10,16 @@ import {
   getSocketByIndex,
   getSocketsByIndexes,
   getWeaponArchetypeSocket,
+  socketContainsPlugWithCategory,
 } from 'app/utils/socket-utils';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { ItemCategoryHashes, SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import {
+  ItemCategoryHashes,
+  PlugCategoryHashes,
+  SocketCategoryHashes,
+  StatHashes,
+} from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -82,7 +88,9 @@ export default function ItemSocketsWeapons({ item, minimal, grid, onPlugClicked 
     )
     .filter(
       (socket) =>
-        socket.plugged?.plugDef.displayProperties.name && !isDeepsightResonanceSocket(socket)
+        socket.plugged?.plugDef.displayProperties.name &&
+        !isDeepsightResonanceSocket(socket) &&
+        !socketContainsPlugWithCategory(socket, PlugCategoryHashes.GenericAllVfx)
     );
 
   const keyStats =

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -9,6 +9,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { startWordRegexp } from 'app/search/search-filters/freeform';
 import { SearchInput } from 'app/search/SearchInput';
 import { compareBy } from 'app/utils/comparators';
+import { socketContainsPlugWithCategory } from 'app/utils/socket-utils';
 import { DestinyClass, TierType } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import anyExoticIcon from 'images/anyExotic.svg';
@@ -63,17 +64,14 @@ function findLockableExotics(
     if (def?.displayProperties.hasIcon) {
       const exoticPerk = item.sockets?.allSockets.find(
         (socket) =>
-          socket.plugged &&
-          socket.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics &&
+          socketContainsPlugWithCategory(socket, PlugCategoryHashes.Intrinsics) &&
           socket.plugged.plugDef.inventory?.tierType === TierType.Exotic
       )?.plugged?.plugDef;
 
       const exoticMods =
         item.sockets?.allSockets
-          .find(
-            (socket) =>
-              socket.plugged?.plugDef.plug.plugCategoryHash ===
-              PlugCategoryHashes.EnhancementsExoticAeonCult
+          .find((socket) =>
+            socketContainsPlugWithCategory(socket, PlugCategoryHashes.EnhancementsExoticAeonCult)
           )
           ?.plugSet?.plugs.map((dimPlug) => dimPlug.plugDef) || [];
 

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -142,6 +142,14 @@ export function getArmorExoticPerkSocket(item: DimItem): DimSocket | undefined {
   }
 }
 
+export function socketContainsPlugWithCategory(
+  socket: DimSocket,
+  category: PlugCategoryHashes
+): socket is Omit<DimSocket, 'plugged'> & { plugged: DimPlug } {
+  // the above type predicate removes the need to null-check `plugged` after this call
+  return socket.plugged?.plugDef.plug.plugCategoryHash === category;
+}
+
 /**
  * the "intrinsic" plug type is:
  * - weapon frames
@@ -149,8 +157,11 @@ export function getArmorExoticPerkSocket(item: DimItem): DimSocket | undefined {
  * - exotic armor special effect plugs
  * - the special invisible plugs that contribute to armor 2.0 stat rolls
  */
-export function socketContainsIntrinsicPlug(socket: DimSocket) {
-  return socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics;
+export function socketContainsIntrinsicPlug(
+  socket: DimSocket
+): socket is Omit<DimSocket, 'plugged'> & { plugged: DimPlug } {
+  // the above type predicate removes the need to null-check `plugged` after this call
+  return socketContainsPlugWithCategory(socket, PlugCategoryHashes.Intrinsics);
 }
 
 /**


### PR DESCRIPTION
The Radiance socket on Black Armory weapons has been useless since Beyond Light. The consumable mods that were inserted into this socket were deprecated and any existing weapons that had Radiance applied had it removed.

This PR hides that socket to clear up room on the archetype bar:
![dim-hide-radiance-socket](https://user-images.githubusercontent.com/17512262/161408159-a046757d-8dc3-4996-8ab7-d3c78fc57a2b.png)
