### PR TITLE
Displayable perk determination fixes

### DIFF
--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -7,12 +7,12 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { thumbsUpIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { isPlugStatActive } from 'app/utils/item-utils';
+import { getPerkDescriptions } from 'app/utils/socket-utils';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import {
   DestinyInventoryItemDefinition,
   DestinyObjectiveProgress,
   DestinyPlugItemCraftingRequirements,
-  DestinySandboxPerkDefinition,
 } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
@@ -68,7 +68,6 @@ export function DimPlugTooltip({
   return (
     <PlugTooltip
       def={plug.plugDef}
-      perks={plug.perks}
       stats={stats}
       plugObjectives={plug.plugObjectives}
       enableFailReasons={plug.enableFailReasons}
@@ -91,7 +90,6 @@ export function DimPlugTooltip({
  */
 export function PlugTooltip({
   def,
-  perks,
   stats,
   plugObjectives,
   enableFailReasons,
@@ -101,7 +99,6 @@ export function PlugTooltip({
   craftingData,
 }: {
   def: DestinyInventoryItemDefinition;
-  perks?: DestinySandboxPerkDefinition[];
   stats?: { [statHash: string]: number };
   plugObjectives?: DestinyObjectiveProgress[];
   enableFailReasons?: string;
@@ -113,18 +110,7 @@ export function PlugTooltip({
   const defs = useD2Definitions();
   const sourceString =
     defs && def.collectibleHash && defs.Collectible.get(def.collectibleHash).sourceString;
-
-  let displayedPerks = perks;
-
-  // If perks aren't available from a prop, see if we can get them.
-  if (!displayedPerks) {
-    displayedPerks = _.compact(
-      _.uniqBy(
-        def.perks,
-        (p) => defs?.SandboxPerk.get(p.perkHash).displayProperties.description
-      ).map((perk) => defs?.SandboxPerk.get(perk.perkHash))
-    );
-  }
+  const perkDescriptions = (defs && getPerkDescriptions(def, defs)) || [];
 
   // filter out plug objectives related to Resonant Elements
   const filteredPlugObjectives = plugObjectives?.filter(
@@ -136,22 +122,14 @@ export function PlugTooltip({
       <h2>{def.displayProperties.name}</h2>
       {!hidePlugSubtype && def.itemTypeDisplayName && <h3>{def.itemTypeDisplayName}</h3>}
 
-      {def.displayProperties.description ? (
-        <div>
-          <RichDestinyText text={def.displayProperties.description} />
-        </div>
-      ) : (
-        displayedPerks.map((perk) => (
-          <div key={perk.hash}>
-            {def.displayProperties.name !== perk.displayProperties.name && (
-              <div>{perk.displayProperties.name}</div>
-            )}
-            <div>
-              <RichDestinyText text={perk.displayProperties.description} />
-            </div>
+      {perkDescriptions.map((perkDesc) => (
+        <div key={perkDesc.perkHash}>
+          {perkDesc.name && <div>{perkDesc.name}</div>}
+          <div>
+            <RichDestinyText text={perkDesc.description || perkDesc.requirement} />
           </div>
-        ))
-      )}
+        </div>
+      ))}
       {sourceString && <div className="plug-source">{sourceString}</div>}
       {stats && Object.entries(stats).length > 0 && (
         <div className="plug-stats">

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -21,6 +21,7 @@ import {
   isPlugStatActive,
   itemIsInstanced,
 } from 'app/utils/item-utils';
+import { getPerkDescriptions } from 'app/utils/socket-utils';
 import { DestinyItemSocketEntryDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes, SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
@@ -104,9 +105,7 @@ export default function SocketDetailsSelectedPlug({
   const dispatch = useThunkDispatch();
   const defs = useD2Definitions()!;
   const destiny2CoreSettings = useSelector(destiny2CoreSettingsSelector)!;
-  const plugPerkDescriptions = _.compact(
-    plug.perks?.map((p) => defs.SandboxPerk.get(p.perkHash)?.displayProperties.description)
-  );
+  const perkDescriptions = getPerkDescriptions(plug, defs);
 
   const materialRequirementSet =
     (plug.plug.insertionMaterialRequirementHash &&
@@ -222,9 +221,9 @@ export default function SocketDetailsSelectedPlug({
             <> &mdash; {plug.itemTypeDisplayName}</>
           )}
         </h3>
-        {plugPerkDescriptions.length
-          ? plugPerkDescriptions.map((desc, idx) => <div key={idx}>{desc}</div>)
-          : plug.displayProperties.description && <div>{plug.displayProperties.description}</div>}
+        {perkDescriptions.map((perkDesc) => (
+          <div key={perkDesc.perkHash}>{perkDesc.description || perkDesc.requirement}</div>
+        ))}
         {sourceString && <div>{sourceString}</div>}
       </div>
       {stats.length > 0 && (

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -1,3 +1,4 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import {
   DimItem,
   DimPlug,
@@ -7,6 +8,7 @@ import {
 import {
   DestinyInventoryItemDefinition,
   DestinySocketCategoryStyle,
+  ItemPerkVisibility,
   TierType,
 } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
@@ -196,4 +198,93 @@ export function getDefaultAbilityChoiceHash(socket: DimSocket) {
 export function isEnhancedPerk(perk: DimPlug | DestinyInventoryItemDefinition) {
   const plugDef = 'plugDef' in perk ? perk.plugDef : perk;
   return plugDef.inventory!.tierType === TierType.Common;
+}
+
+export function getPerkDescriptions(
+  plug: DestinyInventoryItemDefinition,
+  defs: D2ManifestDefinitions
+): {
+  perkHash: number;
+  name?: string;
+  description?: string;
+  requirement?: string;
+}[] {
+  const results: {
+    perkHash: number;
+    name?: string;
+    description?: string;
+    requirement?: string;
+  }[] = [];
+
+  // within this plug, let's not repeat any descriptions or requirement strings
+  const uniqueStrings = new Set<string>();
+
+  // filter out things with no displayable text, or that are meant to be hidden
+  for (const perk of plug.perks) {
+    if (perk.perkVisibility === ItemPerkVisibility.Hidden) {
+      continue;
+    }
+
+    const sandboxPerk = defs.SandboxPerk.get(perk.perkHash);
+    const perkName = sandboxPerk.displayProperties.name;
+    let perkDescription = sandboxPerk.displayProperties.description || undefined;
+    let perkRequirement = perk.requirementDisplayString || undefined;
+
+    if (perkDescription) {
+      if (uniqueStrings.has(perkDescription)) {
+        perkDescription = undefined;
+      } else {
+        uniqueStrings.add(perkDescription);
+      }
+    }
+    if (perkRequirement) {
+      if (uniqueStrings.has(perkRequirement)) {
+        perkRequirement = undefined;
+      } else {
+        uniqueStrings.add(perkRequirement);
+      }
+    }
+
+    if (perkDescription || perkRequirement) {
+      results.push({
+        perkHash: perk.perkHash,
+        name: perkName && perkName !== plug.displayProperties.name ? perkName : undefined,
+        description: perkDescription,
+        requirement: perkRequirement,
+      });
+    }
+  }
+
+  const plugDescription = plug.displayProperties.description || undefined;
+  if (plugDescription && !uniqueStrings.has(plugDescription)) {
+    // if we already have some displayable perks, this means the description is basically
+    // a "requirements" string like "This mod's perks are only active" etc etc etc
+    results.push(
+      results.length > 0
+        ? {
+            perkHash: 0,
+            requirement: plugDescription,
+          }
+        : {
+            perkHash: 0,
+            description: plugDescription,
+          }
+    );
+  }
+
+  // a fallback: if we still don't have any perk descriptions, at least keep the first perk for display.
+  // there are mods like this: no desc, and annoyingly all perks are set to ItemPerkVisibility.Hidden
+  if (!results.length && plug.perks.length) {
+    const firstPerk = plug.perks[0];
+    const sandboxPerk = defs.SandboxPerk.get(firstPerk.perkHash);
+    const perkName = sandboxPerk.displayProperties.name;
+    results.push({
+      perkHash: firstPerk.perkHash,
+      name: perkName && perkName !== plug.displayProperties.name ? perkName : undefined,
+      description: sandboxPerk.displayProperties.description,
+      requirement: firstPerk.requirementDisplayString,
+    });
+  }
+
+  return results;
 }


### PR DESCRIPTION
This PR takes the logic we use to determine which perks to display in in the loadout plug drawer details and applies it to the plug picker and plug tooltips. This fixes two issues:
1. Hidden 'perks' (such as the ones that relate to Stasis ability unlocks) are now correctly hidden
2. Duplicate perk strings are filtered out (e.g. Font of Might's four identical perks)

![dim-displayable-perk-fixes](https://user-images.githubusercontent.com/17512262/161545822-d3d0679d-2d47-444e-b59e-773498ae1335.png)

I've tried to do my due diligence while testing this but it probably needs more eyes on it to catch the outliers.