### PR TITLE
add is:extraperk filter

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -210,6 +210,7 @@
     "Equipment": "Items that can be equipped.",
     "Equipped": "Items that are currently equipped on a character.",
     "Event": "Shows items from which event in Destiny 2 they appeared in.",
+    "ExtraPerk": "Shows random-rolled Legendary weapons with an additional selectable perk.",
     "Filter": "Filter",
     "Glimmer": "Shows items that are consumables that are related to gaining glimmer.",
     "InfusionFodder": "Shows items that could be infused into lower-power versions of the same item for only glimmer.",

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -31,6 +31,7 @@ Array [
   "equippable",
   "equipped",
   "exotic",
+  "extraperk",
   "finishers",
   "fusionrifle",
   "gauntlets",

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -7,8 +7,9 @@ import {
   modSlotTags,
   modTypeTags,
 } from 'app/utils/item-utils';
+import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyItemSubType } from 'bungie-api-ts/destiny2';
-import { ItemCategoryHashes } from 'data/d2/generated-enums';
+import { ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import {
   DEFAULT_GLOW,
   DEFAULT_ORNAMENTS,
@@ -85,6 +86,24 @@ const socketFilters: FilterDefinition[] = [
         );
 
       return matchesCollectionsRoll;
+    },
+  },
+  {
+    keywords: 'extraperk',
+    description: tl('Filter.ExtraPerk'),
+    destinyVersion: 2,
+    filter: () => (item: DimItem) => {
+      if (!(item.bucket?.sort === 'Weapons' && item.tier.toLowerCase() === 'legendary')) {
+        return false;
+      }
+
+      return getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.WeaponPerks_Reusable)
+        .filter(
+          (socket) =>
+            socket.plugged?.plugDef.plug.plugCategoryIdentifier === 'frames' &&
+            socket.hasRandomizedPlugItems
+        )
+        .some((socket) => socket.plugOptions.length > 1);
     },
   },
   {

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -9,7 +9,11 @@ import {
 } from 'app/utils/item-utils';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyItemSubType } from 'bungie-api-ts/destiny2';
-import { ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
+import {
+  ItemCategoryHashes,
+  PlugCategoryHashes,
+  SocketCategoryHashes,
+} from 'data/d2/generated-enums';
 import {
   DEFAULT_GLOW,
   DEFAULT_ORNAMENTS,
@@ -100,7 +104,7 @@ const socketFilters: FilterDefinition[] = [
       return getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.WeaponPerks_Reusable)
         .filter(
           (socket) =>
-            socket.plugged?.plugDef.plug.plugCategoryIdentifier === 'frames' &&
+            socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Frames &&
             socket.hasRandomizedPlugItems
         )
         .some((socket) => socket.plugOptions.length > 1);

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -205,6 +205,7 @@
     "Equipment": "Items that can be equipped.",
     "Equipped": "Items that are currently equipped on a character.",
     "Event": "Shows items from which event in Destiny 2 they appeared in.",
+    "ExtraPerk": "Shows random-rolled Legendary weapons with an additional selectable perk.",
     "Filter": "Filter",
     "Glimmer": "Shows items that are consumables that are related to gaining glimmer.",
     "HasNotes": "Show items that have notes applied.",


### PR DESCRIPTION
highlights randomized weapons with extra perks

the main focus here is their rarity/prestige, and the limited time you're able to acquire them.
limiting to legendaries w/ randomized sockets causes the filter to exclude
- pinnacle/pursuit weapons, which always come with fixed selectable perks
- exotics like suros (are there other exotics like suros?)
- y1 ikelos weapons

and include:
- adept/timelost weapons, whose column(s) have a random perk, plus one that's always the same
- "additional perk" umbral focusings, from arrivals and later

the wording for this feature in-game seems to usually be "additional perk" but frankly that's a long word i don't like it