### PR TITLE
Re-add the D2Gunsmith link to the weapons armory page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `is:extraperk` filter finds weapons with additional toggleable perks, from pinnacle activities and Umbral Focusing.
 * Fixed perk grouping for some perk-only wish lists.
 * Armory wish list view now shows perks, magazines, barrels, etc. in a similar order to the in-game view.
+* Re-added the D2Gunsmith link to the weapons armory page.
 
 ## 7.11.0 <span class="changelog-date">(2022-04-03)</span>
 

--- a/src/app/armory/Links.tsx
+++ b/src/app/armory/Links.tsx
@@ -5,6 +5,7 @@ import { LoreLink } from 'app/item-popup/ItemDescription';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { getSocketsWithStyle, isWeaponMasterworkSocket } from 'app/utils/socket-utils';
 import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import destinysets from 'images/destinysets.svg';
 import destinytracker from 'images/destinytracker.png';
 import logo from 'images/dimlogo.svg';
@@ -115,17 +116,18 @@ function buildGunsmithSockets(item: DimItem) {
     const perks = getSocketsWithStyle(item.sockets, DestinySocketCategoryStyle.Reusable);
     perks.unshift(); // remove the archetype perk
     let i = 0;
+    // Only pick 4 perks and purposefully ignore the origin perk
+    // on some guns as the link format doesn't support them.
     for (const perk of _.take(perks, 4)) {
       perkValues[i] = perk.plugged?.plugDef.hash ?? 0;
       i++;
     }
     const masterwork = item.sockets.allSockets.find(isWeaponMasterworkSocket);
     perkValues[4] = masterwork?.plugged?.plugDef.hash ?? 0;
-    // I dunno how to find weapon mod, it's usually the last non-masterwork non-plug socket
-    const weaponMod = Array.from(item.sockets.allSockets)
-      .reverse()
-      .find((s) => s !== masterwork && !s.isPerk);
-    perkValues[5] = weaponMod?.plugged?.plugDef.hash ?? 0;
+    const weaponMod = item.sockets.allSockets.find((s) =>
+      s.plugged?.plugDef.itemCategoryHashes?.includes(ItemCategoryHashes.WeaponModsDamage)
+    );
+    perkValues[5] = weaponMod?.plugged!.plugDef.hash ?? 0;
 
     return perkValues.join(',');
   }

--- a/src/app/armory/Links.tsx
+++ b/src/app/armory/Links.tsx
@@ -3,10 +3,14 @@ import ExternalLink from 'app/dim-ui/ExternalLink';
 import { DimItem } from 'app/inventory/item-types';
 import { LoreLink } from 'app/item-popup/ItemDescription';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { getSocketsWithStyle, isWeaponMasterworkSocket } from 'app/utils/socket-utils';
+import { DestinySocketCategoryStyle } from 'bungie-api-ts/destiny2';
 import destinysets from 'images/destinysets.svg';
 import destinytracker from 'images/destinytracker.png';
 import logo from 'images/dimlogo.svg';
+import gunsmith from 'images/gunsmith.png';
 import lightgg from 'images/lightgg.png';
+import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import styles from './Links.m.scss';
@@ -26,6 +30,12 @@ const links = [
   },
   { name: 'DestinyTracker', icon: destinytracker, link: destinyDBLink },
   {
+    name: 'Gunsmith',
+    icon: gunsmith,
+    link: (item: DimItem) =>
+      `https://d2gunsmith.com/w/${item.hash}?s=${buildGunsmithSockets(item)}`,
+  },
+  {
     name: 'data.destinysets.com',
     icon: destinysets,
     link: (item: DimItem, language: string) =>
@@ -39,17 +49,19 @@ export default function Links({ item }: { item: DimItem }) {
   const isPhonePortrait = useIsPhonePortrait();
   return (
     <ul className={styles.links}>
-      {links.map(
-        ({ link, name, icon, hideOnPhone }) =>
-          !(isPhonePortrait && hideOnPhone) && (
-            <li key={name}>
-              <ExternalLink href={link(item, language)}>
-                <img src={icon} height={16} width={16} />
-                {name}
-              </ExternalLink>
-            </li>
-          )
-      )}
+      {links
+        .filter((l) => l.name !== 'Gunsmith' || item.bucket.inWeapons)
+        .map(
+          ({ link, name, icon, hideOnPhone }) =>
+            !(isPhonePortrait && hideOnPhone) && (
+              <li key={name}>
+                <ExternalLink href={link(item, language)}>
+                  <img src={icon} height={16} width={16} />
+                  {name}
+                </ExternalLink>
+              </li>
+            )
+        )}
       {item.loreHash && (
         <li>
           <LoreLink loreHash={item.loreHash} />
@@ -92,4 +104,31 @@ function buildSocketParam(item: DimItem): string {
   }
 
   return perkValues.join(',');
+}
+
+/**
+ * D2Gunsmith's socket format is: [...<first four perks, padded out if necessary, masterwork, weapon mod].join(',')
+ */
+function buildGunsmithSockets(item: DimItem) {
+  if (item.sockets) {
+    const perkValues: number[] = [0, 0, 0, 0];
+    const perks = getSocketsWithStyle(item.sockets, DestinySocketCategoryStyle.Reusable);
+    perks.unshift(); // remove the archetype perk
+    let i = 0;
+    for (const perk of _.take(perks, 4)) {
+      perkValues[i] = perk.plugged?.plugDef.hash ?? 0;
+      i++;
+    }
+    const masterwork = item.sockets.allSockets.find(isWeaponMasterworkSocket);
+    perkValues[4] = masterwork?.plugged?.plugDef.hash ?? 0;
+    // I dunno how to find weapon mod, it's usually the last non-masterwork non-plug socket
+    const weaponMod = Array.from(item.sockets.allSockets)
+      .reverse()
+      .find((s) => s !== masterwork && !s.isPerk);
+    perkValues[5] = weaponMod?.plugged?.plugDef.hash ?? 0;
+
+    return perkValues.join(',');
+  }
+
+  return '';
 }


### PR DESCRIPTION
First commit reverts 4b5b75f338dc9919584d30f894f2ddf8d3d677d4, second commit makes the weapon mod finder more robust as the old code picks up dummy deepsight plugs.