### PR TITLE
handle wishlists with perk recommendations and no stat parts

### DIFF
--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -150,6 +150,12 @@ function WishlistRolls({
                 //   [[tac mag], [rifled barrel, extended barrel]]
                 // ]
                 const consolidatedSecondaries = consolidateSecondaryPerks(cr.rolls);
+                // if there were no secondary perks in any of the rolls,
+                // consolidateSecondaryPerks will *correctly* return an array with no permutations.
+                // if so, we'll add a blank dummy one so there's something to iterate below.
+                if (!consolidatedSecondaries.length) {
+                  consolidatedSecondaries.push([]);
+                }
 
                 return consolidatedSecondaries.map((secondaryBundle) => {
                   const bundles = [...primaryBundles, ...secondaryBundle];

--- a/src/app/armory/wishlist-collapser.ts
+++ b/src/app/armory/wishlist-collapser.ts
@@ -174,15 +174,17 @@ export function consolidateSecondaryPerks(initialRolls: Roll[]) {
   const allSecondaryIndices = _.uniq(initialRolls.flatMap((r) => r.secondarySocketIndices)).sort(
     (a, b) => a - b
   );
+  let newClusteredRolls = initialRolls
+    // ignore rolls with no secondary perks in them
+    .filter((r) => r.secondarySocketIndices.length)
+    .map((r) =>
+      allSecondaryIndices.map((i) => {
+        const perkHash = r.secondaryPerksMap[i];
+        return perkHash ? { perks: [perkHash], key: `${perkHash}` } : { perks: [], key: `` };
+      })
+    );
 
-  let newClusteredRolls = initialRolls.map((r) =>
-    allSecondaryIndices.map((i) => {
-      const perkHash = r.secondaryPerksMap[i];
-      return perkHash ? { perks: [perkHash], key: `${perkHash}` } : { perks: [], key: `` };
-    })
-  );
-  // yes, this is an `in`
-  for (const socketIndex in allSecondaryIndices) {
+  for (let socketIndex = 0; socketIndex < allSecondaryIndices.length; socketIndex++) {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const perkBundleToConsolidate = newClusteredRolls.find((r1) =>
@@ -199,7 +201,7 @@ export function consolidateSecondaryPerks(initialRolls: Roll[]) {
 
       newClusteredRolls = bundlesToLeaveAlone;
       const newPerkBundle = Array.from(perkBundleToConsolidate);
-      for (const i in newPerkBundle) {
+      for (let i = 0; i < newPerkBundle.length; i++) {
         if (i === socketIndex) {
           continue;
         }


### PR DESCRIPTION
secondary perk (mags/barrels/etc) consolidator returned too many blank rows when rolls lacked any recommendations for them. this addresses it and prevents dupe permutations from showing up