### PR TITLE
Fix fitMostMods not counting the number of mod sockets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* If an armor piece doesn't have enough mod slots to fit the requested mods (e.g. three resist mods but no artifice chest piece), DIM will notice this earlier and show them as unassigned in the Show Mod Placement menu.
+
 ## 7.12.0 <span class="changelog-date">(2022-04-10)</span>
 
 * If a wish list contains only non-enhanced perks, DIM will mark a roll as matching if it has the Enhanced versions of those perks.

--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -1,13 +1,10 @@
 import { AssumeArmorMasterwork, LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { calculateAssumedItemEnergy, isArmorEnergyLocked } from 'app/loadout/armor-upgrade-utils';
+import { assignBucketSpecificMods } from 'app/loadout/mod-assignment-utils';
 import { bucketHashToPlugCategoryHash } from 'app/loadout/mod-utils';
 import { ItemFilter } from 'app/search/filter-types';
-import { compareBy } from 'app/utils/comparators';
-import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
-import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import {
   ExcludedItems,
@@ -60,11 +57,7 @@ export function filterItems({
   const lockedModMap = _.groupBy(lockedMods, (mod) => mod.plug.plugCategoryHash);
 
   for (const bucket of LockableBucketHashes) {
-    const lockedModsForPlugCategoryHash = lockedModMap[bucketHashToPlugCategoryHash[bucket]];
-    const modCost = _.sumBy(
-      lockedModsForPlugCategoryHash,
-      (mod) => mod.plug.energyCost?.energyCost || 0
-    );
+    const lockedModsForPlugCategoryHash = lockedModMap[bucketHashToPlugCategoryHash[bucket]] || [];
 
     if (items[bucket]) {
       // There can only be one pinned item as we hide items from the item picker once
@@ -86,16 +79,20 @@ export function filterItems({
 
       // TODO: Filter out exotics in other buckets that are not the locked exotic?
 
-      // Filter out excluded items and items that can't take the bucket specific locked
-      // mods energy type or cost.
+      // Use only Armor 2.0 items that aren't excluded and can take the bucket specific locked
+      // mods energy type and cost.
       // Filtering the cost is necessary because process only checks mod energy
       // for combinations of bucket independent mods, and we might not pick those.
       const excludedAndModsFilteredItems = firstPassFilteredItems.filter(
         (item) =>
           !excludedItems[bucket]?.some((excluded) => item.id === excluded.id) &&
-          matchedLockedModEnergy(item, lockedModsForPlugCategoryHash, lockArmorEnergyType) &&
-          hasEnoughSocketsForMods(item, lockedModsForPlugCategoryHash) &&
-          modCost <= calculateAssumedItemEnergy(item, assumeArmorMasterwork, MIN_LO_ITEM_ENERGY)
+          assignBucketSpecificMods({
+            assumeArmorMasterwork,
+            lockArmorEnergyType,
+            minItemEnergy: MIN_LO_ITEM_ENERGY,
+            item,
+            modsToAssign: lockedModsForPlugCategoryHash,
+          }).unassigned.length === 0
       );
 
       const searchFilteredItems = excludedAndModsFilteredItems.filter(searchFilter);
@@ -107,71 +104,4 @@ export function filterItems({
   }
 
   return filteredItems;
-}
-
-function matchedLockedModEnergy(
-  item: DimItem,
-  lockedMods: PluggableInventoryItemDefinition[] | undefined,
-  lockArmorEnergyType: LockArmorEnergyType | undefined
-) {
-  if (!lockedMods) {
-    return true;
-  }
-  return lockedMods.every((mod) => doEnergiesMatch(mod, item, lockArmorEnergyType));
-}
-
-/**
- * Checks that:
- *   1. The armour piece is Armour 2.0
- *   2. The mod matches the Armour energy OR the mod has the any Energy type
- */
-function doEnergiesMatch(
-  mod: PluggableInventoryItemDefinition,
-  item: DimItem,
-  lockArmorEnergyType: LockArmorEnergyType | undefined
-) {
-  return (
-    item.energy &&
-    (!mod.plug.energyCost ||
-      mod.plug.energyCost.energyType === DestinyEnergyType.Any ||
-      mod.plug.energyCost.energyType === item.energy.energyType ||
-      !isArmorEnergyLocked(item, lockArmorEnergyType))
-  );
-}
-
-/**
- * This ensures the item has enough sockets for the given mods by checking the plug sets for the items sockets.
- * It does the following
- * 1. Get a list of plugsets from the item sockets and sorts them so the shortest plugsets are used first (needed
- *   for artificer sockets which is a subset of the bucket specific mod sockets)
- * 2. For each locked mod, if it can go into one of the sockets, remove that socket from the list.
- * 3. If we ever can't find a socket, we can't fit them all.
- */
-function hasEnoughSocketsForMods(item: DimItem, lockedMods: PluggableInventoryItemDefinition[]) {
-  if (!lockedMods?.length) {
-    return true;
-  }
-
-  const sockets = getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorMods);
-
-  const socketsOrderedWithArtificeFirst = sockets
-    // If a socket is not plugged (even with an empty socket) we consider it disabled
-    // This needs to be checked as the 30th anniversary armour has the Artifice socket
-    // but the API considers it to be disabled.
-    .filter((socket) => socket.plugSet && socket.plugged)
-    // Artificer sockets only plug a subset of the bucket specific mods so we sort by the size
-    // of the plugItems in the plugset so we use that first if possible.
-    .sort(compareBy((socket) => socket.plugSet?.plugs.length));
-
-  for (const mod of lockedMods) {
-    const socketIndex = socketsOrderedWithArtificeFirst.findIndex((socket) =>
-      socket.plugSet?.plugs.some((plug) => plug.plugDef.hash === mod.hash)
-    );
-    if (socketIndex === -1) {
-      return false;
-    }
-    socketsOrderedWithArtificeFirst.splice(socketIndex, 1);
-  }
-
-  return true;
 }

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -6,6 +6,7 @@ import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import React from 'react';
+import { pickPlugPositions } from '../mod-assignment-utils';
 import Mod from './Mod';
 import styles from './Sockets.m.scss';
 
@@ -43,23 +44,19 @@ function Sockets({ item, lockedMods, size, onSocketClick }: Props) {
   const modsAndWhitelist: { plugDef: PluggableInventoryItemDefinition; whitelist: number[] }[] = [];
   const modsToUse = lockedMods ? [...lockedMods] : [];
 
+  const assignments = pickPlugPositions(defs, item, modsToUse);
+
   for (const socket of item.sockets?.allSockets || []) {
     const socketType = defs.SocketType.get(socket.socketDefinition.socketTypeHash);
-    let toSave: DestinyInventoryItemDefinition | undefined;
-
-    for (let modIndex = 0; modIndex < modsToUse.length; modIndex++) {
-      const mod = modsToUse[modIndex];
-      if (
-        socketType.plugWhitelist.some((plug) => plug.categoryHash === mod.plug.plugCategoryHash)
-      ) {
-        toSave = mod;
-        modsToUse.splice(modIndex, 1);
-        break;
-      }
-    }
+    let toSave: DestinyInventoryItemDefinition | undefined = assignments.find(
+      (a) => a.socketIndex === socket.socketIndex
+    )?.mod;
 
     if (!toSave) {
-      const plugHash = socket.emptyPlugItemHash;
+      const plugHash =
+        socket.emptyPlugItemHash ||
+        (socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics &&
+          socket.plugged.plugDef.hash);
       if (plugHash) {
         toSave = defs.InventoryItem.get(plugHash);
       }


### PR DESCRIPTION
This also unifies the logic between Loadout Optimizer and `fitMostMods` since they pretty much have to do the same thing.

Additionally, this moves `<Sockets>` to use the logic that actual loadout application uses. `pickPlugPositions` has a scary "this will throw if invalid" warning, so this might expose other bugs by crashing.

Given this loadout: 
![grafik](https://user-images.githubusercontent.com/14299449/162760770-d11c5ecf-5f52-4e0b-8f56-43b31d2d65cd.png)

Beta: 
![grafik](https://user-images.githubusercontent.com/14299449/162760863-75ee3c56-ec1c-4948-b288-d05b51a1e9ed.png)

This PR:
![grafik](https://user-images.githubusercontent.com/14299449/162760940-7aaa768a-84fa-4c06-a3e0-a6787a0f88ab.png)

(This also fixes a regression where intrinsic armor perks were missing from LO and mod assignment drawer)

Fixes #8295.