### PR TITLE
Fix lock armor element option

### DIFF
--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -1,9 +1,10 @@
 import { AssumeArmorMasterwork, LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
-import { calculateAssumedItemEnergy, isArmorEnergyLocked } from 'app/loadout/armor-upgrade-utils';
+import { calculateAssumedItemEnergy } from 'app/loadout/armor-upgrade-utils';
 import {
   activityModPlugCategoryHashes,
   knownModPlugCategoryHashes,
 } from 'app/loadout/known-values';
+import { getItemEnergyType } from 'app/loadout/mod-utils';
 import { MAX_ARMOR_ENERGY_CAPACITY, modsWithConditionalStats } from 'app/search/d2-known-values';
 import { chargedWithLightPlugCategoryHashes } from 'app/search/specialty-modslots';
 import {
@@ -114,6 +115,11 @@ export function getTotalModStatChanges(
   return totals;
 }
 
+/**
+ * Turns a real DimItem, armor upgrade rules, and bucket specific mods into the bits of
+ * information relevant for LO. This requires that bucket specific mods have been validated
+ * before.
+ */
 export function mapDimItemToProcessItem({
   dimItem,
   assumeArmorMasterwork,
@@ -145,14 +151,8 @@ export function mapDimItemToProcessItem({
     ? _.sumBy(modsForSlot, (mod) => mod.plug.energyCost?.energyCost || 0)
     : 0;
 
-  // If we have slot specifc mods an energy type has effectively been chosen.
-  let energyType = modsForSlot?.find(
-    (mod) => mod.plug.energyCost?.energyType !== DestinyEnergyType.Any
-  )?.plug.energyCost?.energyType;
-
-  if (!energyType && !isArmorEnergyLocked(dimItem, lockArmorEnergyType)) {
-    energyType = DestinyEnergyType.Any;
-  }
+  // Bucket specific mods have been validated
+  const energyType = getItemEnergyType(dimItem, lockArmorEnergyType, modsForSlot);
 
   return {
     id,

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -91,11 +91,14 @@ export function createGetModRenderKey() {
 /**
  * This is used to figure out the energy type of an item used in mod assignments.
  *
- * It first considers if there are bucket specific mods applied, and returns that
- * energy type if it's not Any. If not then it considers armour upgrade options
- * and returns the appropriate energy type from that.
+ * If the item's energy is locked given the upgrade options, this returns the item's
+ * current energy. If not locked, this returns the energy as restricted by the first not-Any
+ * mod in `bucketSpecificMods`
  *
- * It can return the Any energy type if armour upgrade options allow energy changes.
+ * This does not validate that all the mods match that element.
+ *
+ * It can return the Any energy type if armour upgrade options allow energy changes
+ * and no mods require a specific element.
  */
 export function getItemEnergyType(
   item: DimItem,
@@ -106,18 +109,15 @@ export function getItemEnergyType(
     return DestinyEnergyType.Any;
   }
 
-  const bucketSpecificModType = bucketSpecificMods?.find(
-    (mod) => mod.plug.energyCost && mod.plug.energyCost.energyType !== DestinyEnergyType.Any
-  )?.plug.energyCost?.energyType;
+  if (isArmorEnergyLocked(item, lockArmorEnergyType)) {
+    return item.energy.energyType;
+  } else {
+    const bucketSpecificModType = bucketSpecificMods?.find(
+      (mod) => mod.plug.energyCost && mod.plug.energyCost.energyType !== DestinyEnergyType.Any
+    )?.plug.energyCost?.energyType;
 
-  // if we find bucket specific mods with an energy type we have to use that
-  if (bucketSpecificModType) {
-    return bucketSpecificModType;
+    return bucketSpecificModType ?? DestinyEnergyType.Any;
   }
-
-  return isArmorEnergyLocked(item, lockArmorEnergyType)
-    ? item.energy.energyType
-    : DestinyEnergyType.Any;
 }
 
 /**


### PR DESCRIPTION
This fixes a bug introduced with #8304 and reduces some duplication in `mapDimItemToProcessItem`. The buggy behavior is that DIM uncritically accepts bucket-specific mods of the wrong element and forces the armor to have that element even when it's not allowed to have that element -- both in LO and loadouts.