### PR TITLE
Some more Artifact mod fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added text labels to "icon-only" columns (lock icon, power icon, etc.) in dropdowns on the Organizer page. Only show label in dropdowns, columns show icon only.
 * Echo of Persistence Void Fragment now indicates that it has a stat penalty depending on the Guardian class.
 * We no longer auto-refresh inventory if you "overfill" a bucket, as refreshing too quickly was returning out-of-date info from Bungie.net and making items appear to "revert" to an earlier location. Make sure to refresh manually if DIM is getting out of sync with the game state.
+* Using the Mod Picker to edit loadout mods should now correctly show all picked mods.
 
 ## 7.12.0 <span class="changelog-date">(2022-04-10)</span>
 

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -54,9 +54,10 @@ function Sockets({ item, lockedMods, size, onSocketClick }: Props) {
 
     if (!toSave) {
       const plugHash =
-        socket.emptyPlugItemHash ||
-        (socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics &&
-          socket.plugged.plugDef.hash);
+        socket.plugged &&
+        (socket.emptyPlugItemHash ||
+          (socket.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics &&
+            socket.plugged.plugDef.hash));
       if (plugHash) {
         toSave = defs.InventoryItem.get(plugHash);
       }


### PR DESCRIPTION
These are buggy on app and beta and slipped through the cracks in earlier PRs.

Mod Assignment Drawer showing artifice sockets on non-artifice armor is harmless but wrong and a straightforward fix.

Mod Picker fails in this scenario (no tampered loadout link necessary this time): 
![grafik](https://user-images.githubusercontent.com/14299449/163187195-2550dcf8-866d-48b9-b455-a256539e7798.png)  
Clicking the (+) button shows this:  
![grafik](https://user-images.githubusercontent.com/14299449/163187703-74d23119-d783-49e6-b858-80815ba5f330.png)  
(failure to distribute the mods among the plugSets, hitting "Save" removes the normal mod from the loadout).

`plugSets.sort((a, b) => b.plugs.length - a.plugs.length);` sorts them by descending length, so this doesn't actually prefer artifice sockets, contrary to what the comment says. I changed it to the loadout mods behavior of assigning more picky mods first and decided to NOT use artifice sockets unless necessary, which is essentially the existing behavior.