### PR TITLE
Indicate Echo of Persistence's stat penalty

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * If an armor piece doesn't have enough mod slots to fit the requested mods (e.g. three resist mods but no artifice chest piece), DIM will notice this earlier and show them as unassigned in the Show Mod Placement menu.
+* Echo of Persistence Void Fragment now indicates that it has a stat penalty depending on the Guardian class.
 
 ## 7.12.0 <span class="changelog-date">(2022-04-10)</span>
 

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -5,6 +5,7 @@ import {
   DimSocketCategory,
   PluggableInventoryItemDefinition,
 } from 'app/inventory/item-types';
+import { modsWithConditionalStats } from 'app/search/d2-known-values';
 import {
   DestinyInventoryItemDefinition,
   DestinySocketCategoryStyle,
@@ -219,8 +220,17 @@ export function getPerkDescriptions(
   // within this plug, let's not repeat any descriptions or requirement strings
   const uniqueStrings = new Set<string>();
 
+  // Terrible hack here: Echo of Persistence behaves like Charge Harvester, but uses a number of hidden perks
+  // (which we can't associate with stats), But we also can't get the relevant classType in here,
+  // so just copy the "-10 to the stat that governs your class ability recharge rate" perk from Charge Harvester.
+  const perks = [...plug.perks];
+  if (plug.hash === modsWithConditionalStats.echoOfPersistence) {
+    const chargeHarvesterDef = defs.InventoryItem.get(modsWithConditionalStats.chargeHarvester);
+    perks.push(chargeHarvesterDef.perks[1]);
+  }
+
   // filter out things with no displayable text, or that are meant to be hidden
-  for (const perk of plug.perks) {
+  for (const perk of perks) {
     if (perk.perkVisibility === ItemPerkVisibility.Hidden) {
       continue;
     }


### PR DESCRIPTION
Closes #8313, closes #8214. The way [Echo of Persistence](https://data.destinysets.com/i/InventoryItem:2272984671) is set up does not play well with our plug descriptions model. Using actual investment stats is also quite difficult because much of the subclass / mods code operates on definitions, not DimPlugs.