### PR TITLE
Remove auto refresh for overfilled buckets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * If an armor piece doesn't have enough mod slots to fit the requested mods (e.g. three resist mods but no artifice chest piece), DIM will notice this earlier and show them as unassigned in the Show Mod Placement menu.
 * Added text labels to "icon-only" columns (lock icon, power icon, etc.) in dropdowns on the Organizer page. Only show label in dropdowns, columns show icon only.
 * Echo of Persistence Void Fragment now indicates that it has a stat penalty depending on the Guardian class.
+* We no longer auto-refresh inventory if you "overfill" a bucket, as refreshing too quickly was returning out-of-date info from Bungie.net and making items appear to "revert" to an earlier location. Make sure to refresh manually if DIM is getting out of sync with the game state.
 
 ## 7.12.0 <span class="changelog-date">(2022-04-10)</span>
 

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -2,7 +2,6 @@ import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import type { ItemTierName } from 'app/search/d2-known-values';
-import { refresh } from 'app/shell/refresh-events';
 import { RootState, ThunkResult } from 'app/store/types';
 import { CancelToken } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
@@ -1173,9 +1172,11 @@ export function checkForOverFill(): ThunkResult {
 
     const countByBucket = _.countBy(store.items, (i) => i.bucket.hash);
     for (const [bucketHashStr, amount] of Object.entries(countByBucket)) {
-      if (amount > buckets.byHash[parseInt(bucketHashStr, 10)].capacity) {
+      const bucket = buckets.byHash[parseInt(bucketHashStr, 10)];
+      if (amount > bucket.capacity) {
         // Request a refresh of the store, this bucket is overfilled
-        refresh();
+        // refresh();
+        infoLog('move', 'Bucket', bucket.name, 'overfilled');
         return;
       }
     }


### PR DESCRIPTION
Rather than try to pick a smart delay for auto refresh, remove it altogether. I'm just not sure how to do it in a way that'll minimize issues.

Fixes #8306