### PR TITLE
Fix an investmentStat / interpolated stat confusion in SocketDetails

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Echo of Persistence Void Fragment now indicates that it has a stat penalty depending on the Guardian class.
 * We no longer auto-refresh inventory if you "overfill" a bucket, as refreshing too quickly was returning out-of-date info from Bungie.net and making items appear to "revert" to an earlier location. Make sure to refresh manually if DIM is getting out of sync with the game state.
 * Using the Mod Picker to edit loadout mods should now correctly show all picked mods.
+* Selecting a different weapon masterwork tier for previewing should now correctly preview the final value of the changed stat in the masterwork picker.
 
 ## 7.12.0 <span class="changelog-date">(2022-04-10)</span>
 

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -124,17 +124,20 @@ export default function SocketDetailsSelectedPlug({
       if (!itemStat) {
         return null;
       }
+
+      if (!isPlugStatActive(item, plug.hash, stat.statTypeHash, stat.isConditionallyActive)) {
+        return null;
+      }
+
       const statGroupDef = defs.StatGroup.get(
         defs.InventoryItem.get(item.hash).stats!.statGroupHash!
       );
 
       const statDisplay = statGroupDef?.scaledStats.find((s) => s.statHash === stat.statTypeHash);
+      const currentModValue =
+        currentPlug?.plugDef.investmentStats.find((s) => s.statTypeHash === stat.statTypeHash)
+          ?.value || 0;
 
-      const currentModValue = currentPlug?.stats?.[stat.statTypeHash] || 0;
-
-      if (!isPlugStatActive(item, plug.hash, stat.statTypeHash, stat.isConditionallyActive)) {
-        return null;
-      }
       let modValue = stat.value;
       const updatedInvestmentValue = itemStat.investmentValue + modValue - currentModValue;
       let itemStatValue = updatedInvestmentValue;


### PR DESCRIPTION
This was reported on the Discord and is best reproduced with a non-masterworked sword with a moderate weapon tier (say around 4) and previewing the T10 masterwork -- the stat bar next to the "Preview" button shows a different value than what the item actually ends up with. This is because the "now - oldMod + newMod" calculation was meant to operate on investment values, but used the (much lower) interpolated contribution from the old mod instead, overestimating the final value in the SocketDetails sheet.