### PR TITLE
fix secondary collapser behavior and document a bit

### DIFF
--- a/src/app/armory/wishlist-collapser.test.ts
+++ b/src/app/armory/wishlist-collapser.test.ts
@@ -8,22 +8,50 @@ describe('perkConsolidator', () => {
           secondaryPerksMap: { 1: 4134353779, 2: 1482024992 },
           secondarySocketIndices: [1, 2],
         },
+
         {
           secondaryPerksMap: { 1: 4134353779, 2: 1467527085 },
           secondarySocketIndices: [1, 2],
         },
+
         {
           secondaryPerksMap: { 1: 106909392, 2: 1332244541 },
           secondarySocketIndices: [1, 2],
         },
+
         {
           secondaryPerksMap: { 1: 106909392, 2: 1467527085 },
           secondarySocketIndices: [1, 2],
         },
       ] as any)
-    ).toEqual([
-      [[4134353779], [1467527085, 1482024992]],
-      [[106909392], [1332244541, 1467527085]],
-    ]);
+    ).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Array [
+            4134353779,
+          ],
+          Array [
+            1482024992,
+          ],
+        ],
+        Array [
+          Array [
+            106909392,
+          ],
+          Array [
+            1332244541,
+          ],
+        ],
+        Array [
+          Array [
+            106909392,
+            4134353779,
+          ],
+          Array [
+            1467527085,
+          ],
+        ],
+      ]
+    `);
   });
 });


### PR DESCRIPTION
sample wishlist with 18 rolls for DMT:
https://gist.githubusercontent.com/nev-r/0bc6011d40ef489dd2a836554d651002/raw/fd649974495a69500e33a0aaf577b3740101e9ce/dmt_vorpal.txt

corrects how secondary perks are collapsed