### PR TITLE
Fix missing highlighted objective flag on completed Deepsight weapons

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -81,7 +81,7 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
           </svg>
         </>
       )}
-      {item.highlightedObjective && (!item.deepsightInfo || item.deepsightInfo.complete) && (
+      {(item.highlightedObjective || item.deepsightInfo?.complete) && (
         <img className={styles.highlightedObjective} src={pursuitComplete} />
       )}
     </>


### PR DESCRIPTION
This closes #8331.

![dim-fix-deepsight-complete-flag-missing](https://user-images.githubusercontent.com/17512262/164206202-c39ed28f-6085-4d19-8312-77dd4e4bbead.png)

The root cause is a new API bug (see: https://github.com/Bungie-net/api/issues/1650)