### PR TITLE
Remove missing name workaround for 'The Flow, the Metal' emblem in French manifest

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -274,11 +274,7 @@ export function makeItem(
   }
 
   if (!(itemDef.displayProperties.name || itemDef.setData?.questLineName)) {
-    // https://github.com/Bungie-net/api/issues/1626
-    if (item.itemHash === 3752071771) {
-      // This happens only in the French manifest, for this one item. Just overwrite the definition.
-      (itemDef.displayProperties as any).name = 'Le Flow, le Métal';
-    } else if (item.itemHash === 3377778206) {
+    if (item.itemHash === 3377778206) {
       // https://d2.destinygamewiki.com/wiki/Gift_of_the_Lighthouse
       (itemDef.displayProperties as any).name = 'Gift of the Lighthouse';
     } else {


### PR DESCRIPTION
The game-side bug was fixed today in [update 4.0.1](https://www.bungie.net/en/Explore/Detail/News/51249) so this workaround is no longer necessary:

> French: Fixed an issue where The Flow, The Metal emblems did not have text strings.

https://data.destinysets.com/i/InventoryItem:3752071771
![image](https://user-images.githubusercontent.com/17512262/164215393-7885bd0f-0f4e-4e65-90e5-ae367230ea78.png)

DIM:
![image](https://user-images.githubusercontent.com/17512262/164215528-41c561d1-d4e7-48be-a0b4-9dbb40e583d5.png)
