### PR TITLE
Revert completed Deepsight weapon objective flag workaround

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -81,7 +81,7 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
           </svg>
         </>
       )}
-      {(item.highlightedObjective || item.deepsightInfo?.complete) && (
+      {item.highlightedObjective && (!item.deepsightInfo || item.deepsightInfo.complete) && (
         <img className={styles.highlightedObjective} src={pursuitComplete} />
       )}
     </>


### PR DESCRIPTION
In retrospect, I didn't fully think through #8334 and I suspect it's going to break next week when the upstream API bug (https://github.com/Bungie-net/api/issues/1650) is fixed. IIRC the highlighted objective flag is set for all Deepsight weapons regardless of whether they are completed and I had previously fixed a bug around this in 29a8f9e98d195d3fad0f873bb26694e6639e9462 for #8043.

I'm unsure when we should merge this. Merging this before Sunday will break beta but ensure both app and beta work correctly when the API bug is fixed on Tuesday. Waiting until after Sunday to merge will reduce the time that beta is broken, but means that this fix won't make it into app on Sunday and app will see a regression on Tuesday (all Deepsight weapons show as completed).

Here's what I expect to happen depending on when this PR is merged:

1. **Merge before Sunday night PST**

|Is representation correct?             |Current behaviour|After this PR is merged|After app release (Sunday)|After API bug is fixed (Tuesday)|
|---------------------------------------|-----------------|-----------------------|--------------------------|--------------------------------|
|**Beta:** Incomplete Deepsight weapons |✔                |✔                      |✔                         |✔                               |
|**Beta:** Complete Deepsight weapons   |✔                |❌                      |❌                         |✔                               |
|**App:** Incomplete Deepsight weapons  |✔                |✔                      |✔                         |✔                               |
|**App:** Complete Deepsight weapons    |❌                |❌                      |❌                         |✔                               |

2. **Merge after Sunday but before weekly reset**

|Is representation correct?             |Current behaviour|After app release (Sunday)|After this PR is merged|After API bug is fixed (Tuesday)|After next app release (next Sunday)|
|---------------------------------------|-----------------|--------------------------|-----------------------|--------------------------------|------------------------------------|
|**Beta:** Incomplete Deepsight weapons |✔                |✔                         |✔                      |✔                               |✔                                   |
|**Beta:** Complete Deepsight weapons   |✔                |✔                         |❌                      |✔                               |✔                                   |
|**App:** Incomplete Deepsight weapons  |✔                |✔                         |✔                      |❌                               |✔                                   |
|**App:** Complete Deepsight weapons    |❌                |✔                         |✔                      |✔                               |✔                                   |

3. **Merge after weekly reset**

|Is representation correct?             |Current behaviour|After app release (Sunday)|After API bug is fixed (Tuesday)|After this PR is merged|After next app release (next Sunday)|
|---------------------------------------|-----------------|--------------------------|--------------------------------|-----------------------|------------------------------------|
|**Beta:** Incomplete Deepsight weapons |✔                |✔                         |❌                               |✔                      |✔                                   |
|**Beta:** Complete Deepsight weapons   |✔                |✔                         |✔                               |✔                      |✔                                   |
|**App:** Incomplete Deepsight weapons  |✔                |✔                         |❌                               |❌                      |✔                                   |
|**App:** Complete Deepsight weapons    |❌                |✔                         |✔                               |✔                      |✔                                   |