### PR TITLE
Always pick a backing store of the correct class in Loadout Drawer

### DIFF
--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -45,9 +45,9 @@ export default function LoadoutDrawer({
   /**
    * The store that provides context to how this loadout is being edited from.
    * The store this edit session was launched from. This is to help pick which
-   * mods are enabled, which subclass items to show, etc. Defaults to current store.
+   * mods are enabled, which subclass items to show, etc.
    */
-  storeId?: string;
+  storeId: string;
   isNew: boolean;
   showClass: boolean;
   onClose(): void;

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import type { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
 import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
-import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
+import { getStore } from 'app/inventory/stores-helpers';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import {
   fillLoadoutFromEquipped,
@@ -57,7 +57,7 @@ export default function LoadoutDrawerContents({
   setLoadout,
   onShowItemPicker,
 }: {
-  storeId?: string;
+  storeId: string;
   loadout: Loadout;
   items: ResolvedLoadoutItem[];
   setLoadout: (updater: LoadoutUpdateFunction) => void;
@@ -71,11 +71,7 @@ export default function LoadoutDrawerContents({
   const stores = useSelector(storesSelector);
 
   // The store to use for "fill from equipped/unequipped"
-  const dimStore = storeId
-    ? getStore(stores, storeId)!
-    : (loadout.classType !== DestinyClass.Unknown &&
-        stores.find((s) => s.classType === loadout.classType)) ||
-      getCurrentStore(stores)!;
+  const dimStore = getStore(stores, storeId)!;
 
   const doFillLoadoutFromEquipped = () => setLoadout(fillLoadoutFromEquipped(defs, dimStore));
 

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -133,7 +133,7 @@ function LoadoutsTriageSection({ item }: { item: DimItem }) {
       <ul className={styles.loadoutList}>
         {inLoadouts.map((l) => {
           const edit = () => {
-            editLoadout(l.loadout, 'vault', {
+            editLoadout(l.loadout, item.owner, {
               isNew: false,
             });
             hideItemPopup();

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -4,7 +4,7 @@ import CheckButton from 'app/dim-ui/CheckButton';
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
-import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
+import { getStore } from 'app/inventory/stores-helpers';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { pickSubclass } from 'app/loadout/item-utils';
 import { useDefinitions } from 'app/manifest/selectors';
@@ -61,9 +61,9 @@ export default function LoadoutDrawer2({
   /**
    * The store that provides context to how this loadout is being edited from.
    * The store this edit session was launched from. This is to help pick which
-   * mods are enabled, which subclass items to show, etc. Defaults to current store.
+   * mods are enabled, which subclass items to show, etc.
    */
-  storeId?: string;
+  storeId: string;
   isNew: boolean;
   onClose(): void;
 }) {
@@ -82,10 +82,7 @@ export default function LoadoutDrawer2({
     return (...args: T) => setLoadout(fn(defs, ...args));
   }
 
-  const store = storeId
-    ? getStore(stores, storeId)
-    : stores.find((s) => !s.isVault && s.classType === loadout?.classType) ??
-      getCurrentStore(stores);
+  const store = getStore(stores, storeId)!;
 
   const onAddItem = useCallback(
     (item: DimItem, equip?: boolean, socketOverrides?: SocketOverrides) =>
@@ -331,7 +328,7 @@ async function pickLoadoutItem(
 
 async function pickLoadoutSubclass(
   loadout: Loadout,
-  storeId: string | undefined,
+  storeId: string,
   add: (item: DimItem, equip?: boolean, socketOverrides?: SocketOverrides) => void,
   onShowItemPicker: (shown: boolean) => void
 ) {
@@ -341,7 +338,7 @@ async function pickLoadoutSubclass(
   const subclassItemFilter = (item: DimItem) =>
     item.bucket.hash === BucketHashes.Subclass &&
     item.classType === loadoutClassType &&
-    (!storeId || item.owner === storeId) &&
+    item.owner === storeId &&
     itemCanBeInLoadout(item) &&
     !loadoutHasItem(item);
 

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -4,6 +4,7 @@ import { bungieNetPath } from 'app/dim-ui/BungieImage';
 import { DimCharacterStat, DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { isPluggableItem } from 'app/inventory/store/sockets';
+import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { v3SubclassHashesByV2SubclassHash } from 'app/inventory/subclass';
 import { isModStatActive } from 'app/loadout-builder/process/mappers';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
@@ -545,4 +546,26 @@ export function getUnequippedItemsForLoadout(dimStore: DimStore, category?: stri
       (category ? item.bucket.sort === category : fromEquippedTypes.includes(item.bucket.hash)) &&
       !item.equipped
   );
+}
+
+/**
+ * Pick a (non-vault) store that backs the loadout drawer, using the
+ * preferredStoreId if it matches the classType and using the first
+ * matching store otherwise.
+ */
+export function pickBackingStore(
+  stores: DimStore[],
+  preferredStoreId: string | undefined,
+  classType: DestinyClass
+) {
+  const requestedStore =
+    !preferredStoreId || preferredStoreId === 'vault'
+      ? getCurrentStore(stores)
+      : getStore(stores, preferredStoreId);
+  return requestedStore &&
+    (classType === DestinyClass.Unknown || requestedStore.classType === classType)
+    ? requestedStore
+    : stores.find(
+        (s) => !s.isVault && (s.classType === classType || classType === DestinyClass.Unknown)
+      );
 }

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -40,7 +40,7 @@ export default function LoadoutItemCategorySection({
 }: {
   category: D2BucketCategory;
   subclass?: ResolvedLoadoutItem;
-  storeId?: string;
+  storeId: string;
   items?: ResolvedLoadoutItem[];
   savedMods: PluggableInventoryItemDefinition[];
   modsByBucket: {

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -58,7 +58,7 @@ export default function ModAssignmentDrawer({
   onClose,
 }: {
   loadout: Loadout;
-  storeId: string | undefined;
+  storeId: string;
   onUpdateMods?(newMods: PluggableInventoryItemDefinition[]): void;
   onClose(): void;
 }) {

--- a/src/app/store-stats/CharacterStats.tsx
+++ b/src/app/store-stats/CharacterStats.tsx
@@ -19,7 +19,7 @@ interface CharacterStatProps {
     stat: DimCharacterStat;
     tooltip: React.ReactNode;
   }[];
-  storeId?: string;
+  storeId: string | undefined;
   className?: string;
   showTier?: boolean;
 }
@@ -37,7 +37,7 @@ function CharacterStat({ stats, storeId, className, showTier }: CharacterStatPro
       {stats.map(({ stat, tooltip }) => {
         // if this is the "max gear power" stat
         // add in an onClick and an extra class
-        const isMaxGearPower = stat.hash === fakeCharacterStatHashes.maxGearPower && storeId;
+        const isMaxGearPower = stat.hash === fakeCharacterStatHashes.maxGearPower;
 
         return (
           <PressTip key={stat.hash} tooltip={tooltip}>
@@ -45,7 +45,7 @@ function CharacterStat({ stats, storeId, className, showTier }: CharacterStatPro
               className={clsx('stat', { pointerCursor: isMaxGearPower })}
               aria-label={`${stat.name} ${stat.value}`}
               role={isMaxGearPower ? 'button' : 'group'}
-              onClick={isMaxGearPower ? () => showGearPower(storeId) : undefined}
+              onClick={isMaxGearPower ? () => showGearPower(storeId!) : undefined}
             >
               <img src={stat.icon} alt={stat.name} />
               <div>
@@ -74,7 +74,7 @@ function CharacterStat({ stats, storeId, className, showTier }: CharacterStatPro
   );
 }
 
-export function PowerFormula({ stats, storeId }: { stats: DimStore['stats']; storeId?: string }) {
+export function PowerFormula({ stats, storeId }: { stats: DimStore['stats']; storeId: string }) {
   const powerTooltip = (stat: DimCharacterStat): React.ReactNode => (
     <>
       {stat.name}
@@ -107,13 +107,10 @@ export function PowerFormula({ stats, storeId }: { stats: DimStore['stats']; sto
 
 export function LoadoutStats({
   stats,
-  storeId,
   characterClass,
   showTier,
 }: {
   stats: DimStore['stats'];
-  /** Store is optional because in the loadout drawer we don't have a specific store */
-  storeId?: string;
   characterClass: DestinyClass; // this can be DestinyClass.Unknown
   showTier?: boolean;
 }) {
@@ -124,5 +121,5 @@ export function LoadoutStats({
       tooltip: <StatTooltip stat={stat} characterClass={characterClass} />,
     }));
 
-  return <CharacterStat showTier={showTier} stats={statInfos} storeId={storeId} />;
+  return <CharacterStat showTier={showTier} stats={statInfos} storeId={undefined} />;
 }

--- a/src/app/store-stats/StoreStats.tsx
+++ b/src/app/store-stats/StoreStats.tsx
@@ -29,7 +29,7 @@ export default function StoreStats({
       ) : (
         <div className="stat-bars destiny2">
           <PowerFormula stats={store.stats} storeId={store.id} />
-          <LoadoutStats stats={store.stats} storeId={store.id} characterClass={store.classType} />
+          <LoadoutStats stats={store.stats} characterClass={store.classType} />
         </div>
       )}
     </div>


### PR DESCRIPTION
This is really just meant to unify some existing logic and moves the assumption that we always have at least one store up from lower components to `LoadoutDrawerContainer`. Main motivation is that this makes the "edit loadout" button in Triage more accurate.