### PR TITLE
Ensure subclass stats are correct after overriding sockets.

### DIFF
--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -11,7 +11,7 @@ import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
 import { isInsertableArmor2Mod, sortMods } from 'app/loadout/mod-utils';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { armorStats } from 'app/search/d2-known-values';
-import { isPlugStatActive, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import {
   getDefaultAbilityChoiceHash,
   getFirstSocketByCategoryHash,
@@ -237,20 +237,9 @@ export function getLoadoutStats(
     });
   });
 
-  // Add stats that come from the subclass fragments
-  // TODO: Now that we apply socket overrides when we resolve items, do we need to do this calculation?
-  if (subclass?.loadoutItem.socketOverrides) {
-    for (const plugHash of Object.values(subclass.loadoutItem.socketOverrides)) {
-      const plug = defs.InventoryItem.get(plugHash);
-      for (const stat of plug.investmentStats) {
-        if (
-          stat.statTypeHash in stats &&
-          isPlugStatActive(subclass.item, plugHash, stat.statTypeHash, stat.isConditionallyActive)
-        ) {
-          stats[stat.statTypeHash].value += stat.value;
-        }
-      }
-    }
+  // Add stats that come from the subclass
+  for (const stat of subclass?.item.stats || []) {
+    stats[stat.statHash].value += stat.value;
   }
 
   // Add the mod stats

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -13,7 +13,7 @@ import { uniqBy } from 'app/utils/util';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 const DISPLAYED_PLUG_STATS = [StatHashes.AspectEnergyCapacity];


### PR DESCRIPTION
This fixes an issue where we were properly emptying sockets or considering inactive fragments when dealing with subclass overrides.

I have a slight concern with this that this is loadouts specific behaviour and if we have a use case where a user can change a single fragment in the UI, this is empty all the other fragments. I can't see that behaviour atm as I only believe the subclass fragments are available through the item popup. If I am not wrong, I will put a warning comment on the socket override function.

Fixes #8139 