### PR TITLE
Display enhanced intrinsic stats in crafted weapons' stat bars similar to masterwork

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Stat bonuses granted to crafted weapons by an enhanced intrinsic are now distinguished in the stat bars similarly to masterwork effects.
+
 ## 7.15.0 <span class="changelog-date">(2022-05-01)</span>
 
 ## 7.14.1 <span class="changelog-date">(2022-04-26)</span>

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -586,6 +586,12 @@ export function makeItem(
     reportException('Sockets', e, { itemHash: item.itemHash });
   }
 
+  // Extract weapon crafting info from the crafted socket but
+  // before building stats because the weapon level affects stats.
+  createdItem.craftedInfo = buildCraftedInfo(createdItem, defs);
+  // Deepsight Resonance
+  createdItem.deepsightInfo = buildDeepsightInfo(createdItem, defs);
+
   try {
     createdItem.stats = buildStats(defs, createdItem, itemDef);
   } catch (e) {
@@ -713,12 +719,6 @@ export function makeItem(
     );
     reportException('MasterworkInfo', e, { itemHash: item.itemHash });
   }
-
-  // Crafted
-  createdItem.craftedInfo = buildCraftedInfo(createdItem, defs);
-
-  // Deepsight Resonance
-  createdItem.deepsightInfo = buildDeepsightInfo(createdItem, defs);
 
   try {
     buildPursuitInfo(createdItem, item, itemDef);


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/14299449/166315401-ca6f8acc-3ff2-4c56-beac-c7991176189e.png)

This makes it possible to actually see the effect of the enhanced intrinsic at a glance (and made it clear the stat code didn't quite catch the weapon level). This diverges from the game, which doesn't show this information at all, but doesn't go as far as to claim that the enhanced intrinsic is actually a masterwork.