### PR TITLE
Improved recoil stat display

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Stat bonuses granted to crafted weapons by an enhanced intrinsic are now distinguished in the stat bars similarly to masterwork effects.
 * Make sure DIM displays the scoring thresholds on the Shoot To Score quest.
+* The recoil direction stat has been tweaked to show a much wider spread as the recoil stat value decreases.
 
 ## 7.15.0 <span class="changelog-date">(2022-05-01)</span>
 

--- a/src/app/item-popup/RecoilStat.tsx
+++ b/src/app/item-popup/RecoilStat.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 /**
- * A value from 100 to -100 where positive is right and negative is left
+ * A value from 100 to -100 where positive is right and negative is left and zero is straight up
  * See https://imgur.com/LKwWUNV
  */
 function recoilDirection(value: number) {
-  return Math.sin((value + 5) * ((2 * Math.PI) / 20)) * (100 - value) * (Math.PI / 180);
+  return Math.sin((value + 5) * (Math.PI / 10)) * (100 - value);
 }
 
 /**
@@ -16,29 +16,42 @@ export function recoilValue(value: number) {
   return 100 - deviation + value / 100000;
 }
 
+// How much to bias the direction towards the center - at 1.0 this would mean recoil would swing ±90°
+const verticalScale = 0.8;
+// The maximum angle of the pie, where zero recoil is the widest and 100 recoil is the narrowest
+const maxSpread = 180; // degrees
+
 export default function RecoilStat({ value }: { value: number }) {
-  const direction = recoilDirection(value);
+  const direction = recoilDirection(value) * verticalScale * (Math.PI / 180); // Convert to radians
   const x = Math.sin(direction);
   const y = Math.cos(direction);
 
-  const spread = 0.75;
-  const xSpreadMore = Math.sin(direction + direction * spread);
-  const ySpreadMore = Math.cos(direction + direction * spread);
-  const xSpreadLess = Math.sin(direction - direction * spread);
-  const ySpreadLess = Math.cos(direction - direction * spread);
+  const spread =
+    // Higher value means less spread
+    ((100 - value) / 100) *
+    // scaled by the spread factor (halved since we expand to either side)
+    (maxSpread / 2) *
+    // in radians
+    (Math.PI / 180) *
+    // flipped for negative
+    Math.sign(direction);
+  const xSpreadMore = Math.sin(direction + spread);
+  const ySpreadMore = Math.cos(direction + spread);
+  const xSpreadLess = Math.sin(direction - spread);
+  const ySpreadLess = Math.cos(direction - spread);
 
   return (
     <svg height="12" viewBox="0 0 2 1">
       <circle r={1} cx={1} cy={1} fill="#333" />
-      {Math.abs(direction) > 0.1 ? (
+      {value >= 95 ? (
+        <line x1={1 - x} y1={1 + y} x2={1 + x} y2={1 - y} stroke="white" strokeWidth="0.1" />
+      ) : (
         <path
           d={`M1,1 L${1 + xSpreadMore},${1 - ySpreadMore} A1,1 0 0,${direction < 0 ? '1' : '0'} ${
             1 + xSpreadLess
           },${1 - ySpreadLess} Z`}
           fill="#FFF"
         />
-      ) : (
-        <line x1={1 - x} y1={1 + y} x2={1 + x} y2={1 - y} stroke="white" strokeWidth="0.1" />
       )}
     </svg>
   );


### PR DESCRIPTION
A while ago some folks in the Discord were claiming DIM's recoil display wasn't representative of the real effects on spread for lower recoil stat values. I took another pass at it, cleaning up the math and making things a bit more parameterized so we can tweak how far things spread as the stat varies. I also reduced the number of cases where we'll draw a simple line instead of a wedge. Open to tweaks to both the math and the parameters to match the current wisdom about the game behavior.

Before:
<img width="1667" alt="Screen Shot 2022-05-05 at 11 54 57 PM" src="https://user-images.githubusercontent.com/313208/167082364-20148d32-2de7-4ef7-8de8-8ee6c15311be.png">

After:
<img width="1632" alt="Screen Shot 2022-05-05 at 11 54 40 PM" src="https://user-images.githubusercontent.com/313208/167082390-a8453ac9-201f-4548-ae0b-811528524525.png">
