### PR TITLE
Fix color grading for ]99%, 100%[ interval

### DIFF
--- a/src/app/shell/formatters.ts
+++ b/src/app/shell/formatters.ts
@@ -18,7 +18,7 @@ export function getColor(value: number, property = 'background-color') {
     color = 20;
   } else if (value <= 95) {
     color = 60;
-  } else if (value <= 99) {
+  } else if (value < 100) {
     color = 120;
   } else if (value >= 100) {
     color = 190;


### PR DESCRIPTION
Even if all our stats are whole numbers, gear Power Level can have differences greater than 100, so the ratio can be between 99% and 100% and the coloring code broke.

Fixes #8362.