### PR TITLE
Add code snippet for importing CSS module file

### DIFF
--- a/.vscode/dim.code-snippets
+++ b/.vscode/dim.code-snippets
@@ -27,18 +27,28 @@
       "}",
       ""
     ],
-    "description": "TypeScript Stateless Functional Component"
+    "description": "TypeScript Stateless Functional Component",
+    "scope": "javascriptreact,typescriptreact"
   },
 
   "import i18next": {
     "prefix": "imt",
     "body": ["import { t } from 'app/i18next-t';"],
-    "description": "Import t helper from i18next"
+    "description": "Import t helper from i18next",
+    "scope": "javascriptreact,typescriptreact"
   },
 
   "import clsx": {
     "prefix": "imc",
     "body": ["import clsx from 'clsx';"],
-    "description": "Import clsx"
+    "description": "Import clsx",
+    "scope": "javascriptreact,typescriptreact"
+  },
+
+  "import styles": {
+    "prefix": "ims",
+    "body": ["import styles from './$TM_FILENAME_BASE.m.scss';"],
+    "description": "Import CSS module",
+    "scope": "javascriptreact,typescriptreact"
   },
 }


### PR DESCRIPTION
Typing "ims" will import the corresponding CSS modules file for the current file.