### PR TITLE
Clean up perks

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -10,6 +10,7 @@ import {
   DestinyEnergyTypeDefinition,
   DestinyInventoryItemDefinition,
   DestinyItemInstanceEnergy,
+  DestinyItemPerkEntryDefinition,
   DestinyItemPlugBase,
   DestinyItemQualityBlockDefinition,
   DestinyItemQuantity,
@@ -117,7 +118,7 @@ export interface DimItem {
   /** Can this be used as infusion fuel? */
   infusionFuel: boolean;
   /** Perks, which are specifically called-out special abilities of items shown in the game's popup UI. */
-  perks: DimPerk[] | null;
+  perks?: DestinyItemPerkEntryDefinition[];
   /** Is this an engram? */
   isEngram: boolean;
   /** The reference hash for lore attached to this item (D2 only). */
@@ -515,11 +516,6 @@ export interface DimSockets {
   allSockets: DimSocket[];
   /** Sockets grouped by category. */
   categories: DimSocketCategory[];
-}
-
-export interface DimPerk extends DestinySandboxPerkDefinition {
-  /** Localized reason for why the perk can't be used. */
-  requirement: string;
 }
 
 export interface DimPursuit {

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -302,9 +302,6 @@ function makeItem(
     primaryStat: null,
     typeName: itemDef.itemTypeName,
     isEngram: (itemDef.itemCategoryHashes || []).includes(34),
-    // "perks" are the two or so talent grid items that are "featured" for an
-    // item in its popup in the game. We don't currently use these.
-    // perks: item.perks,
     equipRequiredLevel: item.equipRequiredLevel,
     maxStackSize: itemDef.maxStackSize > 0 ? itemDef.maxStackSize : 1,
     // 0: titan, 1: hunter, 2: warlock, 3: any
@@ -341,7 +338,6 @@ function makeItem(
     index: '',
     infusable: false,
     infusionFuel: false,
-    perks: null,
     masterworkInfo: null,
     craftedInfo: null,
     deepsightInfo: null,

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -27,6 +27,7 @@ import {
   DictionaryComponentResponse,
   ItemBindStatus,
   ItemLocation,
+  ItemPerkVisibility,
   ItemState,
   SingleComponentResponse,
   TransferStatuses,
@@ -38,7 +39,7 @@ import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
 import { warnMissingDefinition } from '../../manifest/manifest-service-json';
 import { reportException } from '../../utils/exceptions';
 import { InventoryBuckets } from '../inventory-buckets';
-import { DimItem, DimPerk } from '../item-types';
+import { DimItem } from '../item-types';
 import { DimStore } from '../store-types';
 import { getVault } from '../stores-helpers';
 import { buildCraftedInfo } from './crafted';
@@ -544,7 +545,6 @@ export function makeItem(
     infusable: false,
     infusionFuel: false,
     sockets: null,
-    perks: null,
     masterworkInfo: null,
     craftedInfo: null,
     deepsightInfo: null,
@@ -622,18 +622,14 @@ export function makeItem(
     reportException('Objectives', e, { itemHash: item.itemHash });
   }
 
-  // TODO: Are these ever defined??
   if (itemDef.perks?.length) {
-    createdItem.perks = itemDef.perks
-      .map(
-        (p): DimPerk => ({
-          requirement: p.requirementDisplayString,
-          ...defs.SandboxPerk.get(p.perkHash),
-        })
-      )
-      .filter((p) => p.isDisplayable);
-    if (createdItem.perks.length === 0) {
-      createdItem.perks = null;
+    const perks = itemDef.perks.filter(
+      (p) =>
+        p.perkVisibility === ItemPerkVisibility.Visible &&
+        defs.SandboxPerk.get(p.perkHash)?.isDisplayable
+    );
+    if (perks.length) {
+      createdItem.perks = perks;
     }
   }
 

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -29,6 +29,7 @@ import EnergyMeter from './EnergyMeter';
 import { ItemPopupExtraInfo } from './item-popup';
 import ItemDescription from './ItemDescription';
 import ItemExpiration from './ItemExpiration';
+import ItemPerks from './ItemPerks';
 import ItemSockets from './ItemSockets';
 import ItemStats from './ItemStats';
 import ItemTalentGrid from './ItemTalentGrid';
@@ -126,19 +127,7 @@ export default function ItemDetails({
         onApplied={resetSocketOverrides}
       />
 
-      {item.perks && (
-        <div className="item-details item-perks">
-          {item.perks.map((perk) => (
-            <div className="item-perk" key={perk.hash}>
-              {perk.displayProperties.hasIcon && <BungieImage src={perk.displayProperties.icon} />}
-              <div className="item-perk-info">
-                <div className="item-perk-name">{perk.displayProperties.name}</div>
-                <div className="item-perk-description">{perk.displayProperties.description}</div>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      {item.perks && <ItemPerks item={item} />}
 
       {defs && item.objectives && (
         <div className="item-details">

--- a/src/app/item-popup/ItemPerks.tsx
+++ b/src/app/item-popup/ItemPerks.tsx
@@ -1,0 +1,34 @@
+import BungieImage from 'app/dim-ui/BungieImage';
+import { DimItem } from 'app/inventory/item-types';
+import { useD2Definitions } from 'app/manifest/selectors';
+import { DestinyItemPerkEntryDefinition } from 'bungie-api-ts/destiny2';
+
+export default function ItemPerks({ item }: { item: DimItem }) {
+  if (!item.perks) {
+    return null;
+  }
+
+  return (
+    <div className="item-details item-perks">
+      {item.perks.map((perk) => (
+        <ItemPerk key={perk.perkHash} perk={perk} />
+      ))}
+    </div>
+  );
+}
+
+function ItemPerk({ perk }: { perk: DestinyItemPerkEntryDefinition }) {
+  const defs = useD2Definitions()!;
+  const perkDef = defs.SandboxPerk.get(perk.perkHash);
+  const { hasIcon, icon, name, description } = perkDef.displayProperties;
+
+  return (
+    <div className="item-perk">
+      {hasIcon && <BungieImage src={icon} />}
+      <div className="item-perk-info">
+        <div className="item-perk-name">{name}</div>
+        <div className="item-perk-description">{description}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -283,7 +283,6 @@ function makeFakePursuitItem(
     infusable: false,
     infusionFuel: false,
     sockets: null,
-    perks: null,
     masterworkInfo: null,
     craftedInfo: null,
     deepsightInfo: null,

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -127,7 +127,6 @@ const freeformFilters: FilterDefinition[] = [
         // TODO: this definitely does too many array allocations to be performant
         const strings = [
           ...getStringsFromDisplayPropertiesMap(item.talentGrid?.nodes),
-          ...getStringsFromDisplayPropertiesMap(item.perks?.map((p) => p.displayProperties)),
           ...getStringsFromAllSockets(item),
         ];
         return strings.some((s) => startWord.test(plainString(s, language)));
@@ -183,7 +182,6 @@ const freeformFilters: FilterDefinition[] = [
         }
         const perkStrings = [
           ...getStringsFromDisplayPropertiesMap(item.talentGrid?.nodes),
-          ...getStringsFromDisplayPropertiesMap(item.perks?.map((p) => p.displayProperties)),
           ...getStringsFromAllSockets(item),
         ];
         return perkStrings.some((s) => plainString(s, language).includes(filterValue));


### PR DESCRIPTION
Fixes #7983. 

Top level item perks are basically only used to show the effects of certain consumables, and transmat effects. Maybe not worth even keeping around just for that, but these changes reduce the garbage generated during item build and remove the weird thing where all three supers show for Void subclasses. I also removed searching perks from the freeform text search because it almost never matters.