### PR TITLE
Automatically add enhanced versions of perks to Wishlisted Rolls because we match them too

### DIFF
--- a/src/app/armory/wishlist-collapser.ts
+++ b/src/app/armory/wishlist-collapser.ts
@@ -146,6 +146,29 @@ export function consolidateRollsForOneWeapon(
       }
     }
   }
+
+  // Because a base perk in the wish list matches an enhanced perk on the weapon,
+  // add enhanced perks to the wish list rolls if the weapon can have them and the
+  // roll doesn't specify them
+  for (const roll of Object.values(rollsGroupedByPrimaryPerks)) {
+    for (const perk of roll.commonPrimaryPerks) {
+      const enhancedPerk = perkToEnhanced[perk];
+      if (enhancedPerk && !roll.commonPrimaryPerks.includes(enhancedPerk)) {
+        const socketIndex = socketIndexByPerkHash[perk];
+        if (
+          socketIndex !== undefined &&
+          item.sockets?.allSockets.some(
+            (s) =>
+              s.socketIndex === socketIndex &&
+              s.plugOptions.some((p) => p.plugDef.hash === enhancedPerk)
+          )
+        ) {
+          roll.commonPrimaryPerks.push(enhancedPerk);
+        }
+      }
+    }
+  }
+
   return Object.values(rollsGroupedByPrimaryPerks);
 }
 


### PR DESCRIPTION
Example: Syncopation-53

Before: 
![grafik](https://user-images.githubusercontent.com/14299449/168420703-097e4cfc-bcb8-46ca-af9f-38617988d9a4.png)

After: 
![grafik](https://user-images.githubusercontent.com/14299449/168418724-d2468b9b-fb37-4c50-a320-0a25c1e17492.png)

I know wish lists for crafted weapons are controversial but it does bother me that half of Voltron uses enhanced perks for crafted weapons in addition to the base perks and the other half doesn't. This is also more consistent with the actual matching behavior -- if the item popup gives you thumbs up for a roll, that roll should also appear in the armory somewhere.