### PR TITLE
Replace _.uniq, _.uniqBy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -78,6 +78,16 @@
         "object": "_",
         "property": "filter",
         "message": "Please use the native js filter."
+      },
+      {
+        "object": "_",
+        "property": "uniq",
+        "message": "Please use Array.from(new Set(foo)) or [...new Set(foo)] instead."
+      },
+      {
+        "object": "_",
+        "property": "uniqBy",
+        "message": "Please use the uniqBy from app/utils/util instead"
       }
     ],
     "spaced-comment": [

--- a/src/app/armory/wishlist-collapser.ts
+++ b/src/app/armory/wishlist-collapser.ts
@@ -104,7 +104,7 @@ export function consolidateRollsForOneWeapon(
         const rollsWithSameSecondaryPerks = rollsGroupedBySecondaryStuff[secondaryPerkKey];
 
         const commonPrimaryPerks = _.sortBy(
-          _.uniq(rollsWithSameSecondaryPerks.flatMap((r) => r.primaryPerksList)),
+          [...new Set(rollsWithSameSecondaryPerks.flatMap((r) => r.primaryPerksList))],
           (h) => socketIndexByPerkHash[h]
         );
 
@@ -172,8 +172,8 @@ function isMajorPerk(item?: DestinyInventoryItemDefinition) {
 // ]
 export function consolidateSecondaryPerks(initialRolls: Roll[]) {
   // these are legit socketIndices according the item def. this might be like, [3, 4]
-  const allSecondarySocketIndices = _.uniq(
-    initialRolls.flatMap((r) => r.secondarySocketIndices)
+  const allSecondarySocketIndices = Array.from(
+    new Set(initialRolls.flatMap((r) => r.secondarySocketIndices))
   ).sort((a, b) => a - b);
 
   // newClusteredRolls collapses perks into an array with no blank spaces,
@@ -261,7 +261,7 @@ function combineColumns(
     key: string;
   }[]
 ) {
-  const perks = _.uniq(columns.flatMap((c) => c.perks)).sort();
+  const perks = [...new Set(columns.flatMap((c) => c.perks))].sort();
 
   return {
     perks,

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -9,6 +9,7 @@ import { getColor } from 'app/shell/formatters';
 import { RootState, ThunkDispatchProp } from 'app/store/types';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { errorLog } from 'app/utils/log';
+import { uniqBy } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import { produce } from 'immer';
@@ -138,7 +139,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       );
       if (felwinters.length) {
         this.setState(({ excludeditems }) => ({
-          excludeditems: _.uniqBy([...excludeditems, ...felwinters], (i) => i.id),
+          excludeditems: uniqBy([...excludeditems, ...felwinters], (i) => i.id),
         }));
       }
     }
@@ -152,7 +153,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       );
       if (felwinters.length) {
         this.setState(({ excludeditems }) => ({
-          excludeditems: _.uniqBy([...excludeditems, ...felwinters], (i) => i.id),
+          excludeditems: uniqBy([...excludeditems, ...felwinters], (i) => i.id),
         }));
       }
     }
@@ -175,7 +176,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
       );
       if (felwinters.length) {
         this.setState(({ excludeditems }) => ({
-          excludeditems: _.uniqBy(
+          excludeditems: uniqBy(
             [...excludeditems, ...felwinters.map((si) => si.item)],
             (i) => i.id
           ),
@@ -806,7 +807,7 @@ function filterPerks(perks: D1GridNode[], item: D1Item) {
     return [];
   }
   // ['Infuse', 'Twist Fate', 'Reforge Artifact', 'Reforge Shell', 'Increase Intellect', 'Increase Discipline', 'Increase Strength', 'Deactivate Chroma']
-  return _.uniqBy(perks.concat(item.talentGrid.nodes), (node) => node.hash).filter(
+  return uniqBy(perks.concat(item.talentGrid.nodes), (node) => node.hash).filter(
     (node) => !unwantedPerkHashes.includes(node.hash)
   );
 }

--- a/src/app/destiny1/loadout-builder/utils.ts
+++ b/src/app/destiny1/loadout-builder/utils.ts
@@ -1,5 +1,6 @@
 import { D1BucketHashes, D1_StatHashes } from 'app/search/d1-known-values';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
+import { uniqBy } from 'app/utils/util';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { D1Item } from '../../inventory/item-types';
@@ -200,7 +201,7 @@ export function getBestArmor(
     }
 
     bestCombs = [];
-    _.uniqBy(best, (o) => o.item.index).forEach((obj) => {
+    uniqBy(best, (o) => o.item.index).forEach((obj) => {
       obj.bonusType = getBonusType(obj.item);
       if (obj.bonusType === '') {
         bestCombs.push({ item: obj.item, bonusType: '' });

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.tsx
@@ -8,9 +8,9 @@ import {
   setNotes,
 } from 'app/loadout-drawer/loadout-drawer-reducer';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
+import { uniqBy } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -20,7 +20,7 @@ const classTypeOptionsSelector = createSelector(storesSelector, (stores) => {
   const classTypeValues: {
     label: string;
     value: DestinyClass;
-  }[] = _.uniqBy(
+  }[] = uniqBy(
     stores.filter((s) => !s.isVault),
     (store) => store.classType
   ).map((store) => ({ label: store.className, value: store.classType }));

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -565,7 +565,7 @@ function compactUpdate(
         combinedUpdate = {
           ...existingUpdate,
           // Combine into a unique set
-          payload: Array.from(new Set([...existingUpdate.payload, ...update.payload])),
+          payload: [...new Set([...existingUpdate.payload, ...update.payload])],
         };
       }
       break;

--- a/src/app/inventory/note-hashtags.ts
+++ b/src/app/inventory/note-hashtags.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { uniqBy } from 'app/utils/util';
 import { ItemInfos } from './dim-item-info';
 
 /**
@@ -14,9 +14,9 @@ export function collectNotesHashtags(itemInfos: ItemInfos) {
       }
     }
   }
-  return _.uniqBy([...hashTags], (t) => t.toLowerCase());
+  return uniqBy(hashTags, (t) => t.toLowerCase());
 }
 
 export function getHashtagsFromNote(note?: string | null) {
-  return [...(note?.matchAll(/#\w+/g) ?? [])].map((m) => m[0]);
+  return Array.from(note?.matchAll(/#\w+/g) ?? [], (m) => m[0]);
 }

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -11,6 +11,7 @@ import { D1BucketHashes, D1_StatHashes } from 'app/search/d1-known-values';
 import { lightStats } from 'app/search/search-filter-values';
 import { getItemYear } from 'app/utils/item-utils';
 import { errorLog, warnLog } from 'app/utils/log';
+import { uniqBy } from 'app/utils/util';
 import {
   BucketCategory,
   DamageType,
@@ -634,7 +635,7 @@ function buildTalentGrid(
   }) as D1GridNode[];
 
   // We need to unique-ify because Ornament nodes show up twice!
-  gridNodes = _.uniqBy(_.compact(gridNodes), (n) => n.hash);
+  gridNodes = uniqBy(_.compact(gridNodes), (n) => n.hash);
 
   if (!gridNodes.length) {
     return null;

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -4,6 +4,7 @@ import { ItemFilter } from 'app/search/filter-types';
 import SearchBar from 'app/search/SearchBar';
 import { sortItems } from 'app/shell/item-comparators';
 import { RootState } from 'app/store/types';
+import { uniqBy } from 'app/utils/util';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { useMemo, useState } from 'react';
@@ -83,7 +84,7 @@ function ItemPicker({
       items = _.sortBy(items, sortBy);
     }
     if (uniqueBy) {
-      items = _.uniqBy(items, uniqueBy);
+      items = uniqBy(items, uniqueBy);
     }
     return items;
   }, [allItems, filter, itemSortSettings, sortBy, uniqueBy]);

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -10,6 +10,7 @@ import { startWordRegexp } from 'app/search/search-filters/freeform';
 import { SearchInput } from 'app/search/SearchInput';
 import { compareBy } from 'app/utils/comparators';
 import { socketContainsPlugWithCategory } from 'app/utils/socket-utils';
+import { uniqBy } from 'app/utils/util';
 import { DestinyClass, TierType } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import anyExoticIcon from 'images/anyExotic.svg';
@@ -43,7 +44,7 @@ function findLockableExotics(
   const orderedExotics = _.sortBy(exotics, (item) =>
     LockableBucketHashes.indexOf(item.bucket.hash)
   );
-  const uniqueExotics = _.uniqBy(orderedExotics, (item) => item.hash);
+  const uniqueExotics = uniqBy(orderedExotics, (item) => item.hash);
 
   // Add in armor 1 exotics that don't have an armor 2 version
   const exoticArmorWithoutEnergy = allItems.filter(

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -17,6 +17,7 @@ import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { modMetadataByPlugCategoryHash } from 'app/utils/item-utils';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import { uniqBy } from 'app/utils/util';
 import { DestinyClass, DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -149,7 +150,7 @@ function mapStateToProps() {
           }
 
           // TODO: Why would there be duplicates within a single plugset?
-          const plugs = _.uniqBy(plugsWithDuplicates, (plug) => plug.hash);
+          const plugs = uniqBy(plugsWithDuplicates, (plug) => plug.hash);
 
           // Combat, general and raid mods are restricted across items so we need to manually
           // set the max selectable

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -9,6 +9,7 @@ import { PlugSet } from 'app/loadout/plug-drawer/types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { compareBy } from 'app/utils/comparators';
 import { getDefaultAbilityChoiceHash, getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import { uniqBy } from 'app/utils/util';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -218,7 +219,7 @@ function getPlugsForSubclass(
               }
             }
           }
-          plugSet.plugs = _.uniqBy(plugSet.plugs, (plug) => plug.hash);
+          plugSet.plugs = uniqBy(plugSet.plugs, (plug) => plug.hash);
 
           plugSets.push(plugSet);
         }

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -260,16 +260,18 @@ function ItemTable({
       dispatch(
         setSettingAction(
           columnSetting(itemType),
-          _.uniq(
-            _.compact(
-              columns.map((c) => {
-                const cId = getColumnSelectionId(c);
-                if (cId === id) {
-                  return checked ? cId : undefined;
-                } else {
-                  return enabledColumns.includes(cId) ? cId : undefined;
-                }
-              })
+          Array.from(
+            new Set(
+              _.compact(
+                columns.map((c) => {
+                  const cId = getColumnSelectionId(c);
+                  if (cId === id) {
+                    return checked ? cId : undefined;
+                  } else {
+                    return enabledColumns.includes(cId) ? cId : undefined;
+                  }
+                })
+              )
             )
           )
         )
@@ -429,7 +431,7 @@ function ItemTable({
     }
 
     if (checked) {
-      setSelectedItemIds((selected) => _.uniq([...selected, ...changingIds]));
+      setSelectedItemIds((selected) => [...new Set([...selected, ...changingIds])]);
     } else {
       setSelectedItemIds((selected) => selected.filter((i) => !changingIds.includes(i)));
     }

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -4,6 +4,7 @@ import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimStore } from 'app/inventory/store-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { compareBy } from 'app/utils/comparators';
+import { uniqBy } from 'app/utils/util';
 import { DestinyMilestone, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
@@ -40,7 +41,7 @@ export default function Milestones({
     ? defs.SeasonPass.get(season.seasonPassHash)
     : undefined;
 
-  const milestoneItems = _.uniqBy(
+  const milestoneItems = uniqBy(
     [...milestonesForCharacter(defs, profileInfo, store), ...profileMilestones],
     (m) => m.milestoneHash
   ).flatMap((milestone) => milestoneToItems(milestone, defs, buckets, store));

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -91,7 +91,7 @@ export default function Records({ account }: Props) {
     : [];
 
   // We put the hashes we know about from profile first
-  const nodeHashes = _.uniq([...profileHashes, ...otherHashes]);
+  const nodeHashes = [...new Set([...profileHashes, ...otherHashes])];
 
   const menuItems = [
     { id: 'trackedTriumphs', title: t('Progress.TrackedTriumphs') },

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -1,6 +1,7 @@
 import { Search } from '@destinyitemmanager/dim-api-types';
 import { t } from 'app/i18next-t';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
+import { uniqBy } from 'app/utils/util';
 import _ from 'lodash';
 import memoizeOne from 'memoize-one';
 import { SearchConfig } from './search-config';
@@ -90,10 +91,7 @@ export default function createAutocompleter(searchConfig: SearchConfig) {
     // mix them together
     return [
       ..._.take(
-        _.uniqBy(
-          _.compact([queryItem, ...filterSuggestions, ...recentSearchItems]),
-          (i) => i.query
-        ),
+        uniqBy(_.compact([queryItem, ...filterSuggestions, ...recentSearchItems]), (i) => i.query),
         7
       ),
       helpItem,

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -40,7 +40,7 @@ const getPerkNamesFromManifest = _.once(
         return i.displayProperties.name && pch && interestingPlugTypes.has(pch);
       })
       .map((i) => i.displayProperties.name.toLowerCase());
-    return Array.from(new Set(perkNames));
+    return [...new Set(perkNames)];
   }
 );
 
@@ -67,7 +67,7 @@ const getUniqueItemNamesFromManifest = _.once(
         return !powerCap || !irrelevantPowerCaps.has(powerCap);
       })
       .map((i) => i.displayProperties.name.toLowerCase());
-    return Array.from(new Set(itemNames));
+    return [...new Set(itemNames)];
   }
 );
 

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -16,6 +16,7 @@ import DimApiSettings from 'app/storage/DimApiSettings';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { clearAppBadge } from 'app/utils/app-badge';
 import { errorLog } from 'app/utils/log';
+import { uniqBy } from 'app/utils/util';
 import i18next from 'i18next';
 import exampleWeaponImage from 'images/example-weapon.jpg';
 import _ from 'lodash';
@@ -228,7 +229,7 @@ export default function SettingsPage() {
 
   const uniqChars =
     stores &&
-    _.uniqBy(
+    uniqBy(
       stores.filter((s) => !s.isVault),
       (s) => s.classType
     );

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -1,6 +1,5 @@
 import { GlobalAlert } from 'bungie-api-ts/core';
 import { deepEqual } from 'fast-equals';
-import _ from 'lodash';
 import { Reducer } from 'redux';
 import { ActionType, getType } from 'typesafe-actions';
 import { isPhonePortraitFromMediaQuery } from '../utils/media-queries';
@@ -90,7 +89,7 @@ export const shell: Reducer<ShellState, ShellAction> = (
     case getType(actions.loadingStart): {
       return {
         ...state,
-        loadingMessages: _.uniq([...state.loadingMessages, action.payload]),
+        loadingMessages: [...new Set([...state.loadingMessages, action.payload])],
       };
     }
 

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -117,3 +117,19 @@ export const wrap = (index: number, length: number) => {
   }
   return index;
 };
+
+/**
+ * A faster replacement for _.uniqBy that uses a Set internally
+ */
+export function uniqBy<T, K>(data: Iterable<T>, iteratee: (input: T) => K): T[] {
+  const dedupe = new Set<K>();
+  const result: T[] = [];
+  for (const d of data) {
+    const mapped = iteratee(d);
+    if (!dedupe.has(mapped)) {
+      result.push(d);
+      dedupe.add(mapped);
+    }
+  }
+  return result;
+}

--- a/src/app/vendors/Vendor.tsx
+++ b/src/app/vendors/Vendor.tsx
@@ -2,7 +2,6 @@ import { XurLocation } from '@d2api/d2api-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { VENDORS } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
-import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
@@ -46,9 +45,11 @@ export default function Vendor({
 
   const placeString = xurLocation
     ? extractXurLocationString(defs, xurLocation)
-    : _.uniq(
-        [vendor.destination?.displayProperties.name, vendor.place?.displayProperties.name].filter(
-          (n) => n?.length
+    : Array.from(
+        new Set(
+          [vendor.destination?.displayProperties.name, vendor.place?.displayProperties.name].filter(
+            (n) => n?.length
+          )
         )
       ).join(', ');
 

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -2,6 +2,7 @@ import { t } from 'app/i18next-t';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { VENDORS } from 'app/search/d2-known-values';
 import { chainComparator, compareBy } from 'app/utils/comparators';
+import { uniqBy } from 'app/utils/util';
 import rahoolMats from 'data/d2/spider-mats.json';
 import _ from 'lodash';
 import React from 'react';
@@ -97,7 +98,7 @@ export default function VendorItems({
 
   // add in faction tokens if this vendor has them
   if (!filtering && faction?.tokenValues) {
-    currencies = _.uniqBy(
+    currencies = uniqBy(
       [
         ...Object.keys(faction.tokenValues)
           .map((h) => defs.InventoryItem.get(parseInt(h, 10)))
@@ -110,7 +111,7 @@ export default function VendorItems({
 
   // add all traded planetmats if this vendor is the spider
   if (vendor?.component?.vendorHash === VENDORS.RAHOOL) {
-    currencies = _.uniqBy(
+    currencies = uniqBy(
       [...rahoolMats.map((h) => defs.InventoryItem.get(h)), ...currencies],
       (i) => i.hash
     );


### PR DESCRIPTION
Having found that `Set` is a lot faster than what Lodash does, I've replaced all usages, including building my own little replacement for `uniqBy`. I don't think most of these will get any faster really, but I'd rather have uniformity than only replacing a few.