### PR TITLE
Sort items perf

### DIFF
--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -1,7 +1,6 @@
 import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { customStatsSelector, languageSelector } from 'app/dim-api/selectors';
 import { Settings } from 'app/settings/initial-settings';
-import { RootState } from 'app/store/types';
 import { errorLog } from 'app/utils/log';
 import { WishListRoll } from 'app/wishlists/types';
 import _ from 'lodash';
@@ -14,6 +13,7 @@ import {
   displayableBucketHashesSelector,
   itemHashTagsSelector,
   itemInfosSelector,
+  newItemsSelector,
   sortedStoresSelector,
 } from '../inventory/selectors';
 import { DimStore } from '../inventory/store-types';
@@ -43,7 +43,7 @@ export const filterFactorySelector = createSelector(
   loadoutsByItemSelector,
   wishListFunctionSelector,
   wishListsByHashSelector,
-  (state: RootState) => state.inventory.newItems,
+  newItemsSelector,
   itemInfosSelector,
   itemHashTagsSelector,
   languageSelector,

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -31,7 +31,7 @@ import CharacterOrderEditor from './CharacterOrderEditor';
 import Checkbox from './Checkbox';
 import { useSetSetting } from './hooks';
 import { Settings } from './initial-settings';
-import { itemSortSettings } from './item-sort';
+import { itemSortSettingsSelector } from './item-sort';
 import Select, { mapToOptions } from './Select';
 import './settings.scss';
 import SortOrderEditor, { SortProperty } from './SortOrderEditor';
@@ -200,7 +200,7 @@ export default function SettingsPage() {
   }));
   vaultColOptions.unshift({ value: 999, name: t('Settings.ColumnSizeAuto') });
 
-  const sortSettings = itemSortSettings(settings);
+  const sortSettings = useSelector(itemSortSettingsSelector);
 
   const itemSortCustom = _.sortBy(
     _.map(

--- a/src/app/settings/item-sort.ts
+++ b/src/app/settings/item-sort.ts
@@ -1,5 +1,6 @@
 import { settingsSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
+import { createSelector } from 'reselect';
 import { Settings } from './initial-settings';
 
 export type ItemSortSettings = {
@@ -7,10 +8,15 @@ export type ItemSortSettings = {
   sortReversals: Settings['itemSortReversals'];
 };
 
-export const itemSortSettings: (settings: Settings) => ItemSortSettings = (settings: Settings) => ({
-  sortOrder: settings.itemSortOrderCustom || ['primStat', 'name'],
-  sortReversals: settings.itemSortReversals || [],
-});
+const itemSortOrderCustomSelector = (state: RootState) =>
+  settingsSelector(state).itemSortOrderCustom;
+const itemSortReversalsSelector = (state: RootState) => settingsSelector(state).itemSortReversals;
 
-export const itemSortSettingsSelector = (state: RootState) =>
-  itemSortSettings(settingsSelector(state));
+export const itemSortSettingsSelector = createSelector(
+  itemSortOrderCustomSelector,
+  itemSortReversalsSelector,
+  (itemSortOrderCustom, itemSortReversals) => ({
+    sortOrder: itemSortOrderCustom || ['primStat', 'name'],
+    sortReversals: itemSortReversals || [],
+  })
+);

--- a/src/app/shell/item-comparators.ts
+++ b/src/app/shell/item-comparators.ts
@@ -156,8 +156,13 @@ const ITEM_COMPARATORS: { [key: string]: Comparator<DimItem> } = {
 
 /**
  * Sort items according to the user's preferences (via the sort parameter).
+ * Returned array is readonly since it could either be a new array or the
+ * original.
  */
-export function sortItems(items: DimItem[], itemSortSettings: ItemSortSettings) {
+export function sortItems(
+  items: readonly DimItem[],
+  itemSortSettings: ItemSortSettings
+): readonly DimItem[] {
   if (!items.length) {
     return items;
   }
@@ -192,12 +197,12 @@ export function sortItems(items: DimItem[], itemSortSettings: ItemSortSettings) 
     if (itemSortSettings.sortOrder.includes('rarity')) {
       comparators.unshift(ITEM_COMPARATORS.rarity);
     }
-    return items.sort(chainComparator(...comparators));
+    return [...items].sort(chainComparator(...comparators));
   }
 
   // Re-sort consumables
   if (itemLocationId === BucketHashes.Consumables) {
-    return items.sort(
+    return [...items].sort(
       chainComparator(
         ITEM_COMPARATORS.typeName,
         ITEM_COMPARATORS.rarity,
@@ -209,7 +214,7 @@ export function sortItems(items: DimItem[], itemSortSettings: ItemSortSettings) 
 
   // Engrams and Postmaster always sort by recency, oldest to newest, like in game
   if (itemLocationId === BucketHashes.Engrams || itemLocationId === BucketHashes.LostItems) {
-    return items.sort(reverseComparator(acquisitionRecencyComparator));
+    return [...items].sort(reverseComparator(acquisitionRecencyComparator));
   }
 
   // always sort by archive first
@@ -225,5 +230,5 @@ export function sortItems(items: DimItem[], itemSortSettings: ItemSortSettings) 
         : comparator;
     })
   );
-  return items.sort(comparator);
+  return [...items].sort(comparator);
 }


### PR DESCRIPTION
This fixes a couple of performance issues, one of which was introduced when we added reversible sorts:

1. Memoize the itemSortSettingsSelector so it doesn't produce a new value on every invocation. This was causing StoreBucket to re-render basically all the time.
2. Don't overwrite the input in sortItems. This is an old bug but it causes the vault buckets to re-render when new items are clicked, because changing new-item causes... something to recalculate, and then the interned array which had been sorted during render doesn't match the new one (different order) and bam you have a re-render.