### PR TITLE
Don't try to move to vault if dragging a "vault" item in single character mode

### DIFF
--- a/src/app/item-picker/ItemPickerContainer.tsx
+++ b/src/app/item-picker/ItemPickerContainer.tsx
@@ -11,7 +11,7 @@ import ItemPicker from './ItemPicker';
  * single element to help prevent multiple pickers from showing
  * at once and to make the API easier.
  */
-function ItemPickerContainer() {
+export default function ItemPickerContainer() {
   const [generation, setGeneration] = useState(0);
   const [options, setOptions] = useState<ItemPickerState>();
 
@@ -45,5 +45,3 @@ function ItemPickerContainer() {
 
   return <ItemPicker key={generation} {...options} onSheetClosed={onClose} />;
 }
-
-export default ItemPickerContainer;


### PR DESCRIPTION
I noticed in single character mode, if I dragged an item and dropped it back where it started, it would sometimes try to move it. This is because we display some items as if they're in the vault even when they're not. This change makes dragging from "apparent vault" to "apparent vault" a no-op.