### PR TITLE
Add Solar v3 subclass info for Loadouts migration

### DIFF
--- a/src/app/inventory/subclass.ts
+++ b/src/app/inventory/subclass.ts
@@ -138,6 +138,9 @@ const subclassInfoByHash: Record<number, SubclassInfo> = {
   2453351420: v3Subclass(DamageType.Void, DestinyClass.Hunter), // Nightstalker (v3)
   2842471112: v3Subclass(DamageType.Void, DestinyClass.Titan), // Sentinel (v3)
   2849050827: v3Subclass(DamageType.Void, DestinyClass.Warlock), // Voidwalker (v3)
+  2240888816: v3Subclass(DamageType.Thermal, DestinyClass.Hunter), // Gunslinger (v3)
+  3941205951: v3Subclass(DamageType.Thermal, DestinyClass.Warlock), // Dawnblade (v3)
+  2550323932: v3Subclass(DamageType.Thermal, DestinyClass.Titan), // Sunbreaker (v3)
 };
 
 // build up a map of V2 -> V3 subclass hashes


### PR DESCRIPTION
This is required for loadouts with a Solar v2 subclass to show a v3 subclass now instead.