### PR TITLE
Solar 3.0: Display selected Super icon and hide fragment costs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added seasonal info for Season of the Haunted and fixed some bugs with new items.
 * Loadouts with a Solar subclass will automatically be upgraded to Solar 3.0.
 * Show Airborne Effectiveness stat on weapons.
+* Selected Super ability is now displayed on Solar subclass icons.
 
 ## 7.18.0 <span class="changelog-date">(2022-05-22)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## Next
 
+* Selected Super ability is now displayed on Solar subclass icons.
+
 ## 7.18.1 <span class="changelog-date">(2022-05-24)</span>
 
 * Added seasonal info for Season of the Haunted and fixed some bugs with new items.
 * Loadouts with a Solar subclass will automatically be upgraded to Solar 3.0.
 * Show Airborne Effectiveness stat on weapons.
-* Selected Super ability is now displayed on Solar subclass icons.
 
 ## 7.18.0 <span class="changelog-date">(2022-05-22)</span>
 

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -1,6 +1,6 @@
 import { percent } from 'app/shell/formatters';
 import clsx from 'clsx';
-import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes } from 'data/d2/generated-enums';
 import React, { useMemo } from 'react';
 import BungieImage from '../dim-ui/BungieImage';
 import { AppIcon, lockIcon, starIcon, stickyNoteIcon } from '../shell/icons';
@@ -61,8 +61,7 @@ export default function InventoryItem({
     };
   }
 
-  const isSubclass =
-    item?.destinyVersion === 2 && item.itemCategoryHashes.includes(ItemCategoryHashes.Subclasses);
+  const isSubclass = item?.destinyVersion === 2 && item.bucket.hash === BucketHashes.Subclass;
   const subclassIconInfo =
     isSubclass && selectedSuperDisplay !== 'disabled'
       ? getSubclassIconInfo(item, selectedSuperDisplay === 'v3SubclassesOnly')

--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -166,7 +166,8 @@ function getModCostInfo(mod: DestinyInventoryItemDefinition | number, defs: D2Ma
   if (
     mod?.plug &&
     mod.plug.plugCategoryHash !== PlugCategoryHashes.SharedStasisTrinkets &&
-    mod.plug.plugCategoryHash !== PlugCategoryHashes.SharedVoidFragments
+    mod.plug.plugCategoryHash !== PlugCategoryHashes.SharedVoidFragments &&
+    mod.plug.plugCategoryHash !== PlugCategoryHashes.SharedSolarFragments
   ) {
     modCostInfo.energyCost = mod.plug.energyCost?.energyCost;
 


### PR DESCRIPTION
This PR brings how DIM displays the Solar 3.0 subclasses closer in line with Void and Stasis.
1. Work around the Solar subclasses missing the Subclasses ItemCategoryHash (see https://github.com/Bungie-net/api/issues/1661) by testing for the Subclass bucket hash instead
2. Hide the Fragment energy cost for Solar V3 subclasses, just like we do for Void and Stasis

![dim-solar-v3-icons](https://user-images.githubusercontent.com/17512262/170256235-998957a3-5b26-41fa-9dd6-15c75cfd918c.png)
