### PR TITLE
Remove Deepsight Resonant Element search filters and tooltip

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## Next
 
+* Resonant Element search filters such as `deepsight:ruinous` have been removed as these currencies
+are now deprecated.
+
 ## 7.18.1 <span class="changelog-date">(2022-05-24)</span>
 
 * Added seasonal info for Season of the Haunted and fixed some bugs with new items.
 * Loadouts with a Solar subclass will automatically be upgraded to Solar 3.0.
 * Show Airborne Effectiveness stat on weapons.
-* Resonant Element search filters such as `deepsight:ruinous` have been removed as these currencies
-are now deprecated.
 
 ## 7.18.0 <span class="changelog-date">(2022-05-22)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added seasonal info for Season of the Haunted and fixed some bugs with new items.
 * Loadouts with a Solar subclass will automatically be upgraded to Solar 3.0.
 * Show Airborne Effectiveness stat on weapons.
+* Resonant Element search filters such as `deepsight:ruinous` have been removed as these currencies
+are now deprecated.
 
 ## 7.18.0 <span class="changelog-date">(2022-05-22)</span>
 

--- a/src/app/dim-ui/WeaponDeepsightInfo.m.scss
+++ b/src/app/dim-ui/WeaponDeepsightInfo.m.scss
@@ -6,13 +6,3 @@
 .deepsightObjectiveProgress {
   background: #222;
 }
-
-.element {
-  margin-bottom: 2px;
-
-  img {
-    width: 20px;
-    height: 20px;
-    margin: 0 4px -5px 0;
-  }
-}

--- a/src/app/dim-ui/WeaponDeepsightInfo.m.scss.d.ts
+++ b/src/app/dim-ui/WeaponDeepsightInfo.m.scss.d.ts
@@ -3,7 +3,6 @@
 interface CssExports {
   'deepsightObjectiveProgress': string;
   'deepsightProgress': string;
-  'element': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/dim-ui/WeaponDeepsightInfo.tsx
+++ b/src/app/dim-ui/WeaponDeepsightInfo.tsx
@@ -6,8 +6,7 @@ import React from 'react';
 import styles from './WeaponDeepsightInfo.m.scss';
 
 /**
- * A progress bar that shows a weapon's Deepsight Resonance attunement progress and lists the extractable
- * Resonant Elements.
+ * A progress bar that shows a weapon's Deepsight Resonance attunement progress.
  */
 export function WeaponDeepsightInfo({ deepsightInfo }: { deepsightInfo: DimDeepsight }) {
   const pct = percent(deepsightInfo.progress || 0);

--- a/src/app/dim-ui/WeaponDeepsightInfo.tsx
+++ b/src/app/dim-ui/WeaponDeepsightInfo.tsx
@@ -3,8 +3,6 @@ import { DimDeepsight } from 'app/inventory/item-types';
 import { percent } from 'app/shell/formatters';
 import clsx from 'clsx';
 import React from 'react';
-import BungieImage from './BungieImage';
-import PressTip from './PressTip';
 import styles from './WeaponDeepsightInfo.m.scss';
 
 /**
@@ -14,29 +12,20 @@ import styles from './WeaponDeepsightInfo.m.scss';
 export function WeaponDeepsightInfo({ deepsightInfo }: { deepsightInfo: DimDeepsight }) {
   const pct = percent(deepsightInfo.progress || 0);
 
-  const resonantElements = deepsightInfo.resonantElements.map((e) => (
-    <div key={e.tag} className={styles.element}>
-      <BungieImage src={e.icon} />
-      <span>{e.name}</span>
-    </div>
-  ));
-
   return (
     <div className={styles.deepsightProgress}>
-      <PressTip tooltip={resonantElements?.length > 0 ? resonantElements : undefined}>
-        <div
-          className={clsx('objective-row', {
-            ['objective-complete']: deepsightInfo.complete,
-          })}
-        >
-          <div className="objective-checkbox" />
-          <div className={clsx('objective-progress', styles.deepsightObjectiveProgress)}>
-            <div className="objective-progress-bar" style={{ width: pct }} />
-            <div className="objective-description">{t('MovePopup.AttunementProgress')}</div>
-            <div className="objective-text">{pct}</div>
-          </div>
+      <div
+        className={clsx('objective-row', {
+          ['objective-complete']: deepsightInfo.complete,
+        })}
+      >
+        <div className="objective-checkbox" />
+        <div className={clsx('objective-progress', styles.deepsightObjectiveProgress)}>
+          <div className="objective-progress-bar" style={{ width: pct }} />
+          <div className="objective-description">{t('MovePopup.AttunementProgress')}</div>
+          <div className="objective-text">{pct}</div>
         </div>
-      </PressTip>
+      </div>
     </div>
   );
 }

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -24,7 +24,6 @@ import {
   DestinyStatDefinition,
 } from 'bungie-api-ts/destiny2';
 import { InventoryBucket } from './inventory-buckets';
-import { DimResonantElementTag } from './store/deepsight';
 
 /**
  * A generic DIM item, representing almost anything. This completely represents any D2 item, and most D1 items,
@@ -257,18 +256,11 @@ export interface DimCrafted {
   dateCrafted?: number;
 }
 
-export interface DimResonantElement {
-  tag: DimResonantElementTag;
-  icon: string;
-  name: string;
-}
 export interface DimDeepsight {
   /** Whether the weapon is ready for resonant material extraction */
   complete: boolean;
   /** 0-1 progress until the weapon is attuned */
   progress: number;
-  /** A collection of Resonant Elements that can be extracted from this weapon once attuned */
-  resonantElements: DimResonantElement[];
 }
 
 export interface DimStat {

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -590,7 +590,7 @@ export function makeItem(
   // before building stats because the weapon level affects stats.
   createdItem.craftedInfo = buildCraftedInfo(createdItem, defs);
   // Deepsight Resonance
-  createdItem.deepsightInfo = buildDeepsightInfo(createdItem, defs);
+  createdItem.deepsightInfo = buildDeepsightInfo(createdItem);
 
   try {
     createdItem.stats = buildStats(defs, createdItem, itemDef);

--- a/src/app/inventory/store/deepsight.ts
+++ b/src/app/inventory/store/deepsight.ts
@@ -1,22 +1,13 @@
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { socketContainsPlugWithCategory } from 'app/utils/socket-utils';
 import { resonantElementTagsByObjectiveHash } from 'data/d2/crafting-resonant-elements';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
-import { DimDeepsight, DimItem, DimResonantElement, DimSocket } from '../item-types';
+import { DimDeepsight, DimItem, DimSocket } from '../item-types';
 
-export type DimResonantElementTag =
-  typeof resonantElementTagsByObjectiveHash[keyof typeof resonantElementTagsByObjectiveHash];
-export const resonantElementTags: DimResonantElementTag[] = Object.values(
-  resonantElementTagsByObjectiveHash
-);
 export const resonantElementObjectiveHashes = Object.keys(resonantElementTagsByObjectiveHash).map(
   (objectiveHashStr) => parseInt(objectiveHashStr, 10)
 );
 
-export function buildDeepsightInfo(
-  item: DimItem,
-  defs: D2ManifestDefinitions
-): DimDeepsight | null {
+export function buildDeepsightInfo(item: DimItem): DimDeepsight | null {
   const resonanceSocket = getResonanceSocket(item);
   if (!resonanceSocket || !resonanceSocket.plugged?.plugObjectives) {
     return null;
@@ -28,7 +19,6 @@ export function buildDeepsightInfo(
     progress: attunementObjective?.progress
       ? attunementObjective.progress / attunementObjective.completionValue
       : 0,
-    resonantElements: getResonantElements(item, defs),
   };
 }
 
@@ -43,34 +33,4 @@ export function isDeepsightResonanceSocket(socket: DimSocket): boolean {
     socketContainsPlugWithCategory(socket, PlugCategoryHashes.CraftingPlugsWeaponsModsMemories) &&
       socket.plugged.plugDef.objectives
   );
-}
-
-function getResonantElements(item: DimItem, defs: D2ManifestDefinitions): DimResonantElement[] {
-  const results: DimResonantElement[] = [];
-
-  const existingElementTags: string[] = [];
-
-  const sockets = item.sockets?.allSockets;
-  if (sockets) {
-    for (const socket of sockets) {
-      for (const plug of socket.plugOptions) {
-        for (const objective of plug.plugObjectives) {
-          const elementTag = resonantElementTagsByObjectiveHash[objective.objectiveHash];
-          if (elementTag && !existingElementTags.includes(elementTag)) {
-            const def = defs.Objective.get(objective.objectiveHash);
-            if (def) {
-              existingElementTags.push(elementTag);
-              results.push({
-                tag: elementTag,
-                icon: def.displayProperties?.iconSequences[0]?.frames[1],
-                name: def.progressDescription,
-              });
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return results;
 }

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -1,6 +1,5 @@
 import { tl } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import { resonantElementTags } from 'app/inventory/store/deepsight';
 import {
   getInterestingSocketMetadatas,
   getSpecialtySocketMetadatas,
@@ -207,16 +206,12 @@ const socketFilters: FilterDefinition[] = [
     description: tl('Filter.Deepsight'),
     format: ['simple', 'query'],
     destinyVersion: 2,
-    suggestions: resonantElementTags.concat(['complete', 'incomplete']),
+    suggestions: ['complete', 'incomplete'],
     filter:
       ({ filterValue }) =>
       (item: DimItem) => {
         if (!item.deepsightInfo) {
           return false;
-        }
-
-        if (resonantElementTags.includes(filterValue)) {
-          return item.deepsightInfo.resonantElements.some((e) => e.tag === filterValue);
         }
 
         switch (filterValue) {


### PR DESCRIPTION
With the release of Season of the Haunted, the majority of Resonant Element currencies (e.g. Ruinous Element, Adroit Element etc.) were removed. This means that the Resonant Element search filters (added in #8026) and extractable Resonant Element tooltip (added in #8171) are no longer necessary. This PR removes them.