### PR TITLE
Fix item index generation logic

### DIFF
--- a/src/app/inventory/store/item-index.ts
+++ b/src/app/inventory/store/item-index.ts
@@ -9,12 +9,11 @@ export function resetItemIndexGenerator() {
 /** Set an ID for the item that should be unique across all items */
 export function createItemIndex(item: DimItem): string {
   // Try to make a unique, but stable ID. This isn't always possible, such as in the case of consumables.
-  let index = item.id;
   if (item.id === '0') {
-    _idTracker[index] ||= 0;
-    _idTracker[index]++;
-    index = `${index}-t${_idTracker[index]}`;
+    _idTracker[item.hash] ||= 0;
+    _idTracker[item.hash]++;
+    return `${item.hash}-t${_idTracker[item.hash]}`;
   }
 
-  return index;
+  return item.id;
 }


### PR DESCRIPTION
The intention behind the index generator for uninstanced items is that we maintain a separate counter per item hash, so that items can be more easily kept apart - for most consumables where you only have one stack this will result in unique indexes. Somehow it got messed up at some point, this fixes it back to the intended behavior.