### PR TITLE
Explicitly model "instanced" on items

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -351,8 +351,8 @@ export function setTrackedState(
   item: DimItem,
   trackedState: boolean
 ): Promise<ServerResponse<number>> {
-  if (item.id === '0') {
-    throw new Error("Can't track non-instanced items");
+  if (!item.trackable) {
+    throw new Error("Can't track non-trackable items");
   }
 
   return setQuestTrackedState(authenticatedHttpClient, {

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -137,6 +137,50 @@ export const setItemHashNote = createAction('tag_notes/SET_HASH_NOTE')<{
   note?: string;
 }>();
 
+/**
+ * Set the tag for an item regardless of whether it's instanced or not. Prefer this to setItemTag / setItemHashTag.
+ */
+export function setTag(item: DimItem, tag: TagValue | undefined): ThunkResult {
+  return async (dispatch) => {
+    if (!item.taggable) {
+      return;
+    }
+    dispatch(
+      item.instanced
+        ? setItemTag({
+            itemId: item.id,
+            tag: tag === 'clear' ? undefined : tag,
+          })
+        : setItemHashTag({
+            itemHash: item.hash,
+            tag: tag === 'clear' ? undefined : tag,
+          })
+    );
+  };
+}
+
+/**
+ * Set the note for an item regardless of whether it's instanced or not. Prefer this to setItemNote / setItemHashNote.
+ */
+export function setNote(item: DimItem, note: string | undefined): ThunkResult {
+  return async (dispatch) => {
+    if (!item.taggable) {
+      return;
+    }
+    dispatch(
+      item.instanced
+        ? setItemNote({
+            itemId: item.id,
+            note,
+          })
+        : setItemHashNote({
+            itemHash: item.hash,
+            note,
+          })
+    );
+  };
+}
+
 /** Clear out tags and notes for items that no longer exist. Argument is the list of inventory item IDs to remove. */
 export const tagCleanup = createAction('tag_notes/CLEANUP')<string[]>();
 

--- a/src/app/inventory/bulk-actions.tsx
+++ b/src/app/inventory/bulk-actions.tsx
@@ -4,7 +4,6 @@ import { showNotification } from 'app/notifications/notifications';
 import { AppIcon, undoIcon } from 'app/shell/icons';
 import { ThunkResult } from 'app/store/types';
 import _ from 'lodash';
-import React from 'react';
 import { setItemHashTag, setItemTagsBulk } from './actions';
 import { getTag, tagConfig, TagValue } from './dim-item-info';
 import { setItemLockState } from './item-move-service';
@@ -30,7 +29,7 @@ export function bulkTagItems(
       previousState.set(item, getTag(item, itemInfos, itemHashTags));
     }
 
-    const [instanced, nonInstanced] = _.partition(itemsToBeTagged, (i) => i.id && i.id !== '0');
+    const [instanced, nonInstanced] = _.partition(itemsToBeTagged, (i) => i.instanced);
 
     if (instanced.length) {
       dispatch(
@@ -42,17 +41,14 @@ export function bulkTagItems(
         )
       );
     }
-    if (nonInstanced.length) {
-      for (const item of nonInstanced) {
-        dispatch(
-          setItemHashTag({
-            itemHash: item.hash,
-            tag: selectedTag === 'clear' ? undefined : selectedTag,
-          })
-        );
-      }
+    for (const item of nonInstanced) {
+      dispatch(
+        setItemHashTag({
+          itemHash: item.hash,
+          tag: selectedTag === 'clear' ? undefined : selectedTag,
+        })
+      );
     }
-
     if (notification) {
       showNotification({
         type: 'success',

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -2,7 +2,6 @@ import { ItemAnnotation, ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { tl } from 'app/i18next-t';
 import { RootState, ThunkResult } from 'app/store/types';
-import { itemIsInstanced } from 'app/utils/item-utils';
 import _ from 'lodash';
 import { archiveIcon, banIcon, boltIcon, heartIcon, tagIcon } from '../shell/icons';
 import { tagCleanup } from './actions';
@@ -157,8 +156,7 @@ export function getTag(
   }
 ): TagValue | undefined {
   return item.taggable
-    ? (itemIsInstanced(item) ? itemInfos[item.id]?.tag : itemHashTags?.[item.hash]?.tag) ||
-        undefined
+    ? (item.instanced ? itemInfos[item.id]?.tag : itemHashTags?.[item.hash]?.tag) || undefined
     : undefined;
 }
 
@@ -170,8 +168,7 @@ export function getNotes(
   }
 ): string | undefined {
   return item.taggable
-    ? (itemIsInstanced(item) ? itemInfos[item.id]?.notes : itemHashTags?.[item.hash]?.notes) ||
-        undefined
+    ? (item.instanced ? itemInfos[item.id]?.notes : itemHashTags?.[item.hash]?.notes) || undefined
     : undefined;
 }
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -44,6 +44,8 @@ export interface DimItem {
   id: string;
   /** The inventoryItemHash, see DestinyInventoryItemDefinition. */
   hash: number;
+  /** Is the item an instance of an item, in the user's inventory? Uninstanced items include stacked consumables, some bounties/quests, and fake items created for vendors, progress, etc. */
+  instanced: boolean;
   /** Is this classified? Some items are classified in the manifest. */
   classified: boolean;
   /** The version of Destiny this comes from. */

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -197,7 +197,7 @@ function updateCharacters(state: InventoryState, characters: actions.CharacterIn
 
 /** Can an item be marked as new? */
 const canBeNew = (item: DimItem) =>
-  item.equipment && item.id !== '0' && item.bucket.hash !== BucketHashes.Subclass;
+  item.equipment && item.instanced && item.bucket.hash !== BucketHashes.Subclass;
 
 /**
  * Given an old inventory, a new inventory, and all the items that were previously marked as new,

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -9,7 +9,7 @@ import {
 import { t } from 'app/i18next-t';
 import { D1BucketHashes, D1_StatHashes } from 'app/search/d1-known-values';
 import { lightStats } from 'app/search/search-filter-values';
-import { getItemYear } from 'app/utils/item-utils';
+import { getItemYear, itemIdIsInstanced } from 'app/utils/item-utils';
 import { errorLog, warnLog } from 'app/utils/log';
 import { uniqBy } from 'app/utils/util';
 import {
@@ -294,6 +294,7 @@ function makeItem(
         itemDef.redacted
     ),
     id: item.itemInstanceId,
+    instanced: itemIdIsInstanced(item.itemInstanceId || '0'),
     equipped: item.isEquipped,
     equipment: item.isEquipment,
     equippingLabel:

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -9,7 +9,7 @@ import {
 import { t } from 'app/i18next-t';
 import { D1BucketHashes, D1_StatHashes } from 'app/search/d1-known-values';
 import { lightStats } from 'app/search/search-filter-values';
-import { getItemYear, itemIdIsInstanced } from 'app/utils/item-utils';
+import { getItemYear } from 'app/utils/item-utils';
 import { errorLog, warnLog } from 'app/utils/log';
 import { uniqBy } from 'app/utils/util';
 import {
@@ -294,7 +294,7 @@ function makeItem(
         itemDef.redacted
     ),
     id: item.itemInstanceId,
-    instanced: itemIdIsInstanced(item.itemInstanceId || '0'),
+    instanced: item.itemInstanceId !== '0',
     equipped: item.isEquipped,
     equipment: item.isEquipment,
     equippingLabel:

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -8,7 +8,6 @@ import {
   uniqueEquipBuckets,
 } from 'app/search/d2-known-values';
 import { lightStats } from 'app/search/search-filter-values';
-import { itemIdIsInstanced } from 'app/utils/item-utils';
 import { errorLog, warnLog } from 'app/utils/log';
 import { isEnhancedPerk } from 'app/utils/socket-utils';
 import {
@@ -496,7 +495,7 @@ export function makeItem(
     ),
     canPullFromPostmaster: !itemDef.doesPostmasterPullHaveSideEffects,
     id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
-    instanced: itemIdIsInstanced(item.itemInstanceId || '0'),
+    instanced: item.itemInstanceId !== '0',
     equipped: Boolean(itemInstanceData.isEquipped),
     // TODO: equippingBlock has a ton of good info for the item move logic
     equipment:

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -8,6 +8,7 @@ import {
   uniqueEquipBuckets,
 } from 'app/search/d2-known-values';
 import { lightStats } from 'app/search/search-filter-values';
+import { itemIdIsInstanced } from 'app/utils/item-utils';
 import { errorLog, warnLog } from 'app/utils/log';
 import { isEnhancedPerk } from 'app/utils/socket-utils';
 import {
@@ -495,6 +496,7 @@ export function makeItem(
     ),
     canPullFromPostmaster: !itemDef.doesPostmasterPullHaveSideEffects,
     id: item.itemInstanceId || '0', // zero for non-instanced is legacy hack
+    instanced: itemIdIsInstanced(item.itemInstanceId || '0'),
     equipped: Boolean(itemInstanceData.isEquipped),
     // TODO: equippingBlock has a ton of good info for the item move logic
     equipment:

--- a/src/app/item-actions/ItemActionsDropdown.tsx
+++ b/src/app/item-actions/ItemActionsDropdown.tsx
@@ -1,7 +1,7 @@
 import { compareFilteredItems } from 'app/compare/actions';
 import Dropdown, { Option } from 'app/dim-ui/Dropdown';
 import { t } from 'app/i18next-t';
-import { setItemNote } from 'app/inventory/actions';
+import { setNote } from 'app/inventory/actions';
 import { bulkLockItems, bulkTagItems } from 'app/inventory/bulk-actions';
 import { storesSortedByImportanceSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
@@ -70,7 +70,7 @@ export default React.memo(function ItemActionsDropdown({
     const note = prompt(t('Organizer.NotePrompt'));
     if (note !== null && filteredItems.length) {
       for (const item of filteredItems) {
-        dispatch(setItemNote({ itemId: item.id, note: note || undefined }));
+        dispatch(setNote(item, note));
       }
     }
   };

--- a/src/app/item-feed/TagButtons.tsx
+++ b/src/app/item-feed/TagButtons.tsx
@@ -1,10 +1,9 @@
-import { clearNewItem, setItemTag } from 'app/inventory/actions';
+import { clearNewItem, setTag } from 'app/inventory/actions';
 import { tagConfig, TagValue } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
 import { AppIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import _ from 'lodash';
-import React from 'react';
 import styles from './TagButtons.m.scss';
 
 /**
@@ -17,13 +16,8 @@ export default function TagButtons({ item, tag }: { item: DimItem; tag: TagValue
     (t) => t.sortOrder
   );
 
-  const setTag = (tag: TagValue) => {
-    dispatch(
-      setItemTag({
-        itemId: item.id,
-        tag,
-      })
-    );
+  const handleSetTag = (tag: TagValue) => {
+    dispatch(setTag(item, tag));
     dispatch(clearNewItem(item.id));
   };
 
@@ -35,7 +29,7 @@ export default function TagButtons({ item, tag }: { item: DimItem; tag: TagValue
           className={styles.tagButton}
           type="button"
           disabled={tagOption.type === tag}
-          onClick={() => setTag(tagOption.type)}
+          onClick={() => handleSetTag(tagOption.type)}
         >
           <AppIcon icon={tagOption.icon} />
         </button>

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -4,7 +4,7 @@ import { sortedStoresSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { applySocketOverrides } from 'app/inventory/store/override-sockets';
 import { useD2Definitions } from 'app/manifest/selectors';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { useSubscription } from 'use-subscription';
@@ -65,7 +65,7 @@ export default function ItemPopupContainer({ boundarySelector }: Props) {
  */
 function maybeFindItem(item: DimItem, stores: DimStore[]) {
   // Don't worry about non-instanced items
-  if (item.id === '0') {
+  if (!item.instanced) {
     return item;
   }
 

--- a/src/app/item-popup/ItemTagHotkeys.tsx
+++ b/src/app/item-popup/ItemTagHotkeys.tsx
@@ -3,10 +3,9 @@ import { t } from 'app/i18next-t';
 import { tagSelector } from 'app/inventory/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { emptyArray } from 'app/utils/empty';
-import { itemIsInstanced } from 'app/utils/item-utils';
 import { useSelector } from 'react-redux';
 import { Hotkey } from '../hotkeys/hotkeys';
-import { setItemHashTag, setItemTag } from '../inventory/actions';
+import { setTag } from '../inventory/actions';
 import { itemTagList } from '../inventory/dim-item-info';
 import { DimItem } from '../inventory/item-types';
 
@@ -23,15 +22,7 @@ export default function ItemTagHotkeys({ item }: Props) {
       {
         combo: 'shift+0',
         description: t('Tags.ClearTag'),
-        callback: () =>
-          dispatch(
-            itemIsInstanced(item)
-              ? setItemTag({ itemId: item.id, tag: undefined })
-              : setItemHashTag({
-                  itemHash: item.hash,
-                  tag: undefined,
-                })
-          ),
+        callback: () => dispatch(setTag(item, 'clear')),
       },
     ];
 
@@ -40,15 +31,7 @@ export default function ItemTagHotkeys({ item }: Props) {
         hotkeys.push({
           combo: tag.hotkey,
           description: t('Hotkey.MarkItemAs', { tag: tag.type }),
-          callback: () =>
-            dispatch(
-              itemIsInstanced(item)
-                ? setItemTag({ itemId: item.id, tag: itemTag === tag.type ? undefined : tag.type })
-                : setItemHashTag({
-                    itemHash: item.hash,
-                    tag: itemTag === tag.type ? undefined : tag.type,
-                  })
-            ),
+          callback: () => dispatch(setTag(item, itemTag === tag.type ? 'clear' : tag.type)),
         });
       }
     });

--- a/src/app/item-popup/ItemTagSelector.tsx
+++ b/src/app/item-popup/ItemTagSelector.tsx
@@ -1,14 +1,12 @@
 import KeyHelp from 'app/dim-ui/KeyHelp';
 import Select, { Option } from 'app/dim-ui/Select';
 import { t, tl } from 'app/i18next-t';
-import { setItemHashTag, setItemTag } from 'app/inventory/actions';
+import { setTag } from 'app/inventory/actions';
 import { tagSelector } from 'app/inventory/selectors';
 import { AppIcon, clearIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import { itemIsInstanced } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import _ from 'lodash';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { itemTagSelectorList, TagInfo, TagValue } from '../inventory/dim-item-info';
 import { DimItem } from '../inventory/item-types';
@@ -25,19 +23,7 @@ export default function ItemTagSelector({ item, className, hideKeys, hideButtonL
   const dispatch = useThunkDispatch();
   const tag = useSelector(tagSelector(item));
 
-  const onChange = (tag?: TagValue) => {
-    dispatch(
-      itemIsInstanced(item)
-        ? setItemTag({
-            itemId: item.id,
-            tag: tag === 'clear' ? undefined : tag,
-          })
-        : setItemHashTag({
-            itemHash: item.hash,
-            tag: tag === 'clear' ? undefined : tag,
-          })
-    );
-  };
+  const onChange = (tag?: TagValue) => dispatch(setTag(item, tag));
 
   const dropdownOptions: Option<TagValue>[] = _.sortBy(
     itemTagSelectorList.map((t) =>

--- a/src/app/item-popup/NotesArea.tsx
+++ b/src/app/item-popup/NotesArea.tsx
@@ -1,18 +1,18 @@
 import { Textcomplete } from '@textcomplete/core';
 import { TextareaEditor } from '@textcomplete/textarea';
 import { t } from 'app/i18next-t';
-import { setItemHashNote, setItemNote } from 'app/inventory/actions';
+import { setNote } from 'app/inventory/actions';
 import { itemNoteSelector } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
 import { getHashtagsFromNote } from 'app/inventory/note-hashtags';
 import { allNotesHashtagsSelector } from 'app/inventory/selectors';
 import { AppIcon, editIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isiOSBrowser } from 'app/utils/browsers';
-import { itemIsInstanced } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import styles from './NotesArea.m.scss';
 
 const maxLength = 120;
@@ -85,14 +85,10 @@ function NotesEditor({
   // without relying on the constantly refreshing liveNotes value
   const textArea = useRef<HTMLTextAreaElement>(null);
   // dispatch notes updates
-  const dispatch = useDispatch();
+  const dispatch = useThunkDispatch();
   const saveNotes = useCallback(() => {
     const newNotes = textArea.current?.value.trim();
-    dispatch(
-      itemIsInstanced(item)
-        ? setItemNote({ itemId: item.id, note: newNotes })
-        : setItemHashNote({ itemHash: item.hash, note: newNotes })
-    );
+    dispatch(setNote(item, newNotes));
   }, [dispatch, item]);
 
   const stopEvents = (e: React.SyntheticEvent) => e.stopPropagation();

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -16,18 +16,14 @@ import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { refreshIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import {
-  emptySpecialtySocketHashes,
-  isPlugStatActive,
-  itemIsInstanced,
-} from 'app/utils/item-utils';
+import { emptySpecialtySocketHashes, isPlugStatActive } from 'app/utils/item-utils';
 import { getPerkDescriptions } from 'app/utils/socket-utils';
 import { DestinyItemSocketEntryDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes, SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import { motion } from 'framer-motion';
 import _ from 'lodash';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import ItemStats from './ItemStats';
 import { StatValue } from './PlugTooltip';
@@ -161,7 +157,7 @@ export default function SocketDetailsSelectedPlug({
   // Can we actually insert this mod instead of just previewing it?
   const canDoAWA =
     allowInsertPlug &&
-    itemIsInstanced(item) &&
+    item.instanced &&
     canInsertPlug(socket, plug.hash, destiny2CoreSettings, defs);
 
   const kind = uiCategorizeSocket(defs, socket.socketDefinition);

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -5,7 +5,7 @@ import { settingsSelector } from 'app/dim-api/selectors';
 import { StatHashListsKeyedByDestinyClass } from 'app/dim-ui/CustomStatTotal';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t, tl } from 'app/i18next-t';
-import { setItemNote } from 'app/inventory/actions';
+import { setNote } from 'app/inventory/actions';
 import { bulkLockItems, bulkTagItems } from 'app/inventory/bulk-actions';
 import { ItemInfos, TagInfo } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
@@ -292,7 +292,7 @@ function ItemTable({
     }
     if (selectedItems.length) {
       for (const item of selectedItems) {
-        dispatch(setItemNote({ itemId: item.id, note }));
+        dispatch(setNote(item, note));
       }
     }
   };

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -247,6 +247,7 @@ function makeFakePursuitItem(
     notransfer: true,
     canPullFromPostmaster: false,
     id: '0', // zero for non-instanced is legacy hack
+    instanced: false,
     equipped: false,
     equipment: false, // TODO: this has a ton of good info for the item move logic
     complete: false,

--- a/src/app/shell/item-comparators.ts
+++ b/src/app/shell/item-comparators.ts
@@ -12,7 +12,7 @@ import store from '../store/store';
 import { chainComparator, Comparator, compareBy, reverseComparator } from '../utils/comparators';
 
 export const acquisitionRecencyComparator = reverseComparator(
-  compareBy((item: DimItem) => item.id.padStart(20, '0'))
+  compareBy((item: DimItem) => (item.instanced ? item.id.padStart(20, '0') : 0))
 );
 
 const D1_CONSUMABLE_SORT_ORDER = [

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -124,19 +124,6 @@ export function getMasterworkStatNames(mw: DimMasterwork | null) {
   );
 }
 
-// some DimItem.id are non-0 but represent vendor "instances" of an item
-// a real (owned) instanceId is a long int but in DIM it's a string
-// this checks DimItem.id for something that looks like an owned item
-const instancedId = /^\d+$/;
-
-/**
- * "Instanced" items are uniquely identifiable by an id, while "uninstanced" items don't have any such
- * identifier even though there may be multiple of them in a given location.
- */
-export function itemIdIsInstanced(id: string): boolean {
-  return id !== '0' && instancedId.test(id);
-}
-
 /**
  * Items that are sunset are always sunset.
  */

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -133,8 +133,8 @@ const instancedId = /^\d+$/;
  * "Instanced" items are uniquely identifiable by an id, while "uninstanced" items don't have any such
  * identifier even though there may be multiple of them in a given location.
  */
-export function itemIsInstanced(item: DimItem): boolean {
-  return item.id !== '0' && instancedId.test(item.id);
+export function itemIdIsInstanced(id: string): boolean {
+  return id !== '0' && instancedId.test(id);
 }
 
 /**

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -128,7 +128,6 @@ export class VendorItem {
     vendorHash: number,
     vendorItemDef?: DestinyVendorItemDefinition,
     saleItem?: DestinyVendorSaleItemComponent,
-    // TODO: this will be useful for showing the move-popup details
     itemComponents?: DestinyItemComponentSetOfint32,
     mergedCollectibles?: {
       [hash: number]: DestinyCollectibleComponent;
@@ -170,6 +169,8 @@ export class VendorItem {
       // override the DimItem.id for vendor items, so they are each unique enough to identify
       // (otherwise they'd get their vendor index as an id, which is only unique per-vendor)
       this.item.id = `${vendorHash}-${this.key}`;
+      this.item.index = this.item.id;
+      this.item.instanced = false;
 
       // if this is sold by a vendor, add vendor information
       if (saleItem && characterId) {

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -29,7 +29,7 @@ export const wishListFunctionSelector = createSelector(
     // Cache of inventory item id to roll. For this to work, make sure vendor/collections rolls have unique ids.
     const cache = new Map<string, InventoryWishListRoll | undefined>();
     return (item: DimItem) => {
-      if (item.id === '0') {
+      if (!item.instanced) {
         return undefined;
       }
       if (cache.has(item.id)) {

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -155,12 +155,13 @@ export function getInventoryWishListRoll(
   wishListRolls: { [itemHash: number]: WishListRoll[] }
 ): InventoryWishListRoll | undefined {
   if (
-    !$featureFlags.wishLists ||
-    !wishListRolls ||
-    !item ||
-    item.destinyVersion === 1 ||
-    !item.sockets ||
-    item.id === '0'
+    !(
+      $featureFlags.wishLists &&
+      wishListRolls &&
+      item?.destinyVersion === 2 &&
+      item.sockets &&
+      item.instanced
+    )
   ) {
     return;
   }


### PR DESCRIPTION
This is a cleanup I've wanted to do for a while, but recently I noticed that `itemIsInstanced` was being called a lot, and causing a small performance impact, so I wanted to do away with it. This models whether an item is instanced directly on the item, rather than intuiting it from the instance id.