### PR TITLE
RFC: Reduce freeform text search to only name and notes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Search filter `deepsight:pattern` finds those items.
   * The search `is:patternunlocked` finds items where the pattern for that item has already been unlocked (whether or not that item is crafted).
   * Don't forget that `is:craftable` highlights any items that can be crafted.
+* "Bare" searches without any keywords now only search name and notes. It used to also search the item type name, and all perks. Use specific `perkname:` searches or item type searches (e.g. `is:handcannon`) instead.
 
 ## 7.18.1 <span class="changelog-date">(2022-05-24)</span>
 

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -168,14 +168,7 @@ const freeformFilters: FilterDefinition[] = [
       const test = (s: string) => plainString(s, language).includes(filterValue);
       return (item) => {
         const notes = getNotes(item, itemInfos, itemHashTags);
-        return (
-          (notes && test(notes)) ||
-          test(item.name) ||
-          test(item.description) ||
-          test(item.typeName) ||
-          testStringsFromDisplayPropertiesMap(test, item.talentGrid?.nodes) ||
-          testStringsFromAllSockets(test, item)
-        );
+        return (notes && test(notes)) || test(item.name);
       };
     },
   },


### PR DESCRIPTION
The default search with no operators (i.e. "freeform search") is meant to be easy to use - just type a bunch of stuff and things might match. However, by default it searches too much, which is both a performance issue and makes it hard to be specific about matching an item.

This proposal is to reduce the freeform search to only search name and notes, and leave searching perks and item type name to specific search keywords. This is harder to use and reduces a bit of the "magic" of DIM search, but now that we autosuggest both perks and item names in the autocompleter, those more specific searches should be more accessible. Thoughts?