### PR TITLE
Triage tab fixes for classified items and slug shotguns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 * Enhanced intrinsics on crafted weapons are now treated as a masterwork internally. As a result, you can use e.g. `is:crafted -masterwork:any` to find crafted weapons without an enhanced intrinsic. The golden border additionally requires two enhanced traits, just like in-game.
-* Resonant Element search filters such as `deepsight:ruinous` have been removed as these currenciesare now deprecated.
+* Resonant Element search filters such as `deepsight:ruinous` have been removed as these currencies are now deprecated.
 * Selected Super ability is now displayed on Solar subclass icons.
 * Features around managing crafting patterns:
   * Items that have a pattern to unlock will show the progress to that pattern in the item popup - even on items that do not have deepsight resonance.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Search filter `deepsight:pattern` finds those items.
   * The search `is:patternunlocked` finds items where the pattern for that item has already been unlocked (whether or not that item is crafted).
   * Don't forget that `is:craftable` highlights any items that can be crafted.
+* Fixed Triage tab's similar items search for slug Shotguns.
 
 ## 7.18.1 <span class="changelog-date">(2022-05-24)</span>
 

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -207,25 +207,20 @@ function FactorsTriageSection({ item }: { item: DimItem }) {
 function ArmorStatsTriageSection({ item }: { item: DimItem }) {
   const allItems = useSelector(allItemsSelector);
   const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
-  const notableStats = getNotableStats(item, customTotalStatsByClass, allItems);
 
-  const hasNotable = notableStats.notableStats.length > 0;
+  let extra: JSX.Element | string = '?';
+  let highStats: JSX.Element | null = null;
+  if (!item.classified) {
+    extra = '–';
 
-  let extra: JSX.Element | string = '–';
-  if (hasNotable) {
-    const bestStat = _.maxBy(notableStats.notableStats, (s) => s.percent)!;
-    extra = <span style={{ color: getValueColors(bestStat.quality)[1] }}>{bestStat.percent}%</span>;
-  }
-  return (
-    <CollapsibleTitle
-      title={t('Triage.HighStats')}
-      sectionId="triage-highstat"
-      defaultCollapsed={false}
-      showExtraOnlyWhenCollapsed
-      disabled={!hasNotable}
-      extra={extra}
-    >
-      {hasNotable && (
+    const notableStats = getNotableStats(item, customTotalStatsByClass, allItems);
+    if (notableStats.notableStats.length > 0) {
+      const bestStat = _.maxBy(notableStats.notableStats, (s) => s.percent)!;
+      extra = (
+        <span style={{ color: getValueColors(bestStat.quality)[1] }}>{bestStat.percent}%</span>
+      );
+
+      highStats = (
         <div className={styles.statTable}>
           <div className={styles.header}>
             <div className={styles.statsHeaderLeft}>
@@ -256,7 +251,19 @@ function ArmorStatsTriageSection({ item }: { item: DimItem }) {
             </div>
           ))}
         </div>
-      )}
+      );
+    }
+  }
+  return (
+    <CollapsibleTitle
+      title={t('Triage.HighStats')}
+      sectionId="triage-highstat"
+      defaultCollapsed={false}
+      showExtraOnlyWhenCollapsed
+      disabled={highStats === null}
+      extra={extra}
+    >
+      {highStats}
     </CollapsibleTitle>
   );
 }

--- a/src/app/item-triage/triage-utils.tsx
+++ b/src/app/item-triage/triage-utils.tsx
@@ -120,8 +120,8 @@ export function getNotableStats(
     ) ?? 0;
   const customRatio = customTotal / statMaxes.custom || 0;
   return {
-    notableStats: exampleItem
-      .stats!.filter((stat) => {
+    notableStats: (exampleItem.stats ?? [])
+      .filter((stat) => {
         const statPercent = stat.base / statMaxes[stat.statHash];
         return (
           statPercent >=

--- a/src/app/search/search-filters/known-values.tsx
+++ b/src/app/search/search-filters/known-values.tsx
@@ -96,11 +96,20 @@ export const itemCategoryFilter: FilterDefinition = {
     return (item) => item.itemCategoryHashes.includes(categoryHash);
   },
   fromItem: (item) => {
-    const mostSpecificTypeHash = item.itemCategoryHashes[item.itemCategoryHashes.length - 1];
-    const typeTag = Object.entries(itemCategoryHashesByName).find(
-      ([_tag, ich]) => ich === mostSpecificTypeHash
-    )?.[0];
-    return typeTag ? `is:${typeTag}` : '';
+    /*
+    The last ICH will be the most specific, so start there and try find a corresponding search
+    filter. If we can't find one (e.g. for slug shotguns), try the next most specific ICH and so on.
+    */
+    for (let i = item.itemCategoryHashes.length - 1; i >= 0; i--) {
+      const itemCategoryHash = item.itemCategoryHashes[i];
+      const typeTag = Object.entries(itemCategoryHashesByName).find(
+        ([_tag, ich]) => ich === itemCategoryHash
+      )?.[0];
+      if (typeTag) {
+        return `is:${typeTag}`;
+      }
+    }
+    return '';
   },
 };
 


### PR DESCRIPTION
This PR includes 3 changes for the Triage tab:

1. Fixed a crash when accessing the Triage tab on a classified armor piece

![dim-triage-classified-crash](https://user-images.githubusercontent.com/17512262/170827246-cc8799b1-c9d6-4a53-b5f5-fc4963eecd78.gif)

2. Replace the High Stats summary indicator dash with a question mark for classified items

![dim-triage-high-stat-summary](https://user-images.githubusercontent.com/17512262/170827448-764805ae-16cb-4f8f-9d38-11a99baf49ba.png)

3. Fixed an issue where the Kinetic Shotguns similar item search on slug shotguns would highlight all Kinetic weapons

![dim-triage-similar-slugs](https://user-images.githubusercontent.com/17512262/170827636-db00fab5-d5bc-437d-b61d-44c28162c6fd.png)
