### PR TITLE
Make collapsed inventory headers more obvious

### DIFF
--- a/src/app/dim-ui/CollapsibleTitle.scss
+++ b/src/app/dim-ui/CollapsibleTitle.scss
@@ -38,7 +38,11 @@
     }
     margin-left: -4px;
     width: 10px;
-    margin-right: 8px;
+    margin-right: 6px;
+    .collapsed & {
+      margin-left: -2px;
+      margin-right: 4px;
+    }
   }
 
   &.disabled-collapsed {

--- a/src/app/inventory-page/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory-page/InventoryCollapsibleTitle.scss
@@ -19,7 +19,7 @@
     }
     &.collapsed {
       color: white;
-      filter: brightness(0.5);
+      font-weight: bold;
       min-height: 32px;
       padding-bottom: 4px;
     }


### PR DESCRIPTION
Another attempt at making inventory headers that are collapsed more visible. They're now brighter and bold.

<img width="319" alt="Screen Shot 2022-05-28 at 11 06 51 AM" src="https://user-images.githubusercontent.com/313208/170837763-b4532512-e9e9-448a-b206-4ffc8f166387.png">
