### PR TITLE
Make armory more obvious by adding it to action menu

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -31,6 +31,7 @@
     "WeeklyHeroic": "Weekly Heroic Strike"
   },
   "Armory": {
+    "Label": "Item Info",
     "WishlistedRolls": "Wishlisted Roll",
     "WishlistedRolls_plural": "{{count, number}} Wishlisted Rolls",
     "TrashlistedRolls": "Trashlisted Roll",

--- a/src/app/item-actions/ActionButtons.tsx
+++ b/src/app/item-actions/ActionButtons.tsx
@@ -1,3 +1,4 @@
+import ArmorySheet from 'app/armory/ArmorySheet';
 import { addCompareItem } from 'app/compare/actions';
 import { t } from 'app/i18next-t';
 import { showInfuse } from 'app/infuse/infuse';
@@ -11,11 +12,12 @@ import { hideItemPopup } from 'app/item-popup/item-popup';
 import { ItemActionsModel } from 'app/item-popup/item-popup-actions';
 import ItemTagSelector from 'app/item-popup/ItemTagSelector';
 import { addItemToLoadout } from 'app/loadout-drawer/loadout-events';
-import { addIcon, AppIcon, compareIcon } from 'app/shell/icons';
+import { addIcon, AppIcon, compareIcon, faInfo } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
-import React from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import arrowsIn from '../../images/arrows-in.png';
 import arrowsOut from '../../images/arrows-out.png';
@@ -186,6 +188,34 @@ export function LoadoutActionButton({
     <ActionButton onClick={addToLoadout}>
       <AppIcon icon={addIcon} />
       {label && <span className={styles.label}>{t('MovePopup.AddToLoadout')}</span>}
+    </ActionButton>
+  );
+}
+
+export function ArmoryActionButton({
+  item,
+  label,
+  actionModel,
+}: ActionButtonProps & { actionModel: ItemActionsModel }) {
+  const [showArmory, setShowArmory] = useState(false);
+  if (!actionModel.armory) {
+    return null;
+  }
+
+  const show = () => {
+    setShowArmory(true);
+  };
+
+  return (
+    <ActionButton onClick={show}>
+      <AppIcon icon={faInfo} />
+      {label && <span className={styles.label}>{t('Armory.Label')}</span>}
+
+      {showArmory && (
+        <Portal>
+          <ArmorySheet onClose={() => setShowArmory(false)} item={item} />
+        </Portal>
+      )}
     </ActionButton>
   );
 }

--- a/src/app/item-actions/ItemAccessoryButtons.tsx
+++ b/src/app/item-actions/ItemAccessoryButtons.tsx
@@ -1,7 +1,7 @@
 import { DimItem } from 'app/inventory/item-types';
 import { ItemActionsModel } from 'app/item-popup/item-popup-actions';
-import React from 'react';
 import {
+  ArmoryActionButton,
   CompareActionButton,
   ConsolidateActionButton,
   DistributeActionButton,
@@ -43,6 +43,9 @@ export default function ItemAccessoryButtons({
       )}
       {actionsModel.infusable && (
         <InfuseActionButton item={item} label={showLabel} actionModel={actionsModel} />
+      )}
+      {actionsModel.armory && (
+        <ArmoryActionButton item={item} label={showLabel} actionModel={actionsModel} />
       )}
     </>
   );

--- a/src/app/item-popup/item-popup-actions.ts
+++ b/src/app/item-popup/item-popup-actions.ts
@@ -39,6 +39,8 @@ export interface ItemActionsModel {
   maximumMoveAmount: number;
   /** Show an editor for the amount of items to move. */
   showAmounts: boolean;
+  /** Has a meaningful armory view. */
+  armory: boolean;
   /** A list of stores that we could equip to. This includes all valid locations, but some can be disabled. */
   equip: StoreButtonInfo[];
   /** A list of stores that we could move to. This includes all valid locations, but some can be disabled. Vault isn't included. */
@@ -96,6 +98,8 @@ export function buildItemActionsModel(item: DimItem, stores: DimStore[]): ItemAc
   const equip = canEquip.map((s) => ({ store: s, enabled: !disableEquip(s) }));
   const store = canStore.map((s) => ({ store: s, enabled: !disableStore(s) }));
 
+  const armory = item.equipment;
+
   const hasMoveControls = Boolean(
     (inPostmaster && pullFromPostmaster) || equip.length || store.length
   );
@@ -106,7 +110,8 @@ export function buildItemActionsModel(item: DimItem, stores: DimStore[]): ItemAc
       infusable ||
       loadoutable ||
       canConsolidate ||
-      canDistribute
+      canDistribute ||
+      armory
   );
   const hasControls = hasAccessoryControls || hasMoveControls;
 
@@ -128,6 +133,7 @@ export function buildItemActionsModel(item: DimItem, stores: DimStore[]): ItemAc
     hasMoveControls,
     hasAccessoryControls,
     hasControls,
+    armory,
   };
 }
 

--- a/src/app/shell/icons/Library.ts
+++ b/src/app/shell/icons/Library.ts
@@ -80,6 +80,7 @@ const faBookmark = 'far fa-bookmark';
 const faBalanceScaleLeft = 'fas fa-balance-scale-left';
 const faGripVertical = 'fas fa-grip-vertical';
 const faThumbtack = 'fas fa-thumbtack';
+const faInfo = 'fas fa-info-circle';
 
 const faXbox = 'fab fa-xbox';
 const faPlayStation = 'fab fa-playstation';
@@ -178,4 +179,5 @@ export {
   faGrid,
   faAngleLeft,
   faAngleRight,
+  faInfo,
 };

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -27,6 +27,7 @@
     "WeeklyHeroic": "Weekly Heroic Strike"
   },
   "Armory": {
+    "Label": "Item Info",
     "NoNotes": "No Notes",
     "Season": "Season {{season}}, Year {{year}}",
     "TrashlistedRolls": "Trashlisted Roll",


### PR DESCRIPTION
This is an attempt to make the Armory view more discoverable, by adding an entry to the sidecar / icon strip:
<img width="545" alt="Screen Shot 2022-06-09 at 10 42 02 PM" src="https://user-images.githubusercontent.com/313208/172998347-fa31d4bc-cea9-42d1-b3c8-95d822be9d1d.png">
<img width="337" alt="Screen Shot 2022-06-09 at 10 42 09 PM" src="https://user-images.githubusercontent.com/313208/172998353-dc07699b-88b1-4b9c-ac5f-8e0504a8727e.png">

I don't necessarily love it but maybe it'll help?
