### PR TITLE
prevent dim from automatically filling the 50th consumables slot

### DIFF
--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -213,5 +213,5 @@ function moveItemsToVault(
     reservations[store.id][bucket.hash] = 1;
   });
 
-  return clearItemsOffCharacter(store, items, createMoveSession(cancelToken), reservations);
+  return clearItemsOffCharacter(store, items, createMoveSession(cancelToken, items), reservations);
 }

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -126,7 +126,7 @@ export function moveItemTo(
       updateManualMoveTimestamp(item);
 
       const [cancelToken, cancel] = withCancel();
-      const moveSession = createMoveSession(cancelToken);
+      const moveSession = createMoveSession(cancelToken, [item]);
 
       const movePromise = queueAction(() =>
         loadingTracker.addPromise(
@@ -184,7 +184,7 @@ export function consolidate(actionableItem: DimItem, store: DimStore): ThunkResu
           const stores = storesSelector(getState());
           const characters = stores.filter((s) => !s.isVault);
           const vault = getVault(stores)!;
-          const moveSession = createMoveSession(neverCanceled);
+          const moveSession = createMoveSession(neverCanceled, [actionableItem]);
 
           try {
             for (const s of characters) {
@@ -244,7 +244,7 @@ export function distribute(actionableItem: DimItem): ThunkResult {
         (async () => {
           // Sort vault to the end
           const stores = _.sortBy(storesSelector(getState()), (s) => (s.id === 'vault' ? 2 : 1));
-          const moveSession = createMoveSession(neverCanceled);
+          const moveSession = createMoveSession(neverCanceled, [actionableItem]);
 
           let total = 0;
           const amounts = stores.map((store) => {

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -177,8 +177,6 @@ function doApplyLoadout(
     const getLoadoutItem = (loadoutItem: LoadoutItem) =>
       findItemForLoadout(defs, allItemsSelector(getState()), store.id, loadoutItem);
 
-    const moveSession = createMoveSession(cancelToken);
-
     try {
       // Back up the current state as an "undo" loadout
       if (allowUndo && !store.isVault) {
@@ -340,6 +338,10 @@ function doApplyLoadout(
       });
 
       const realItemsToDequip = _.compact(itemsToDequip.map((i) => getLoadoutItem(i)));
+
+      const involvedItems = [..._.compact(itemsToEquip.map(getLoadoutItem)), ...realItemsToDequip];
+      const moveSession = createMoveSession(cancelToken, involvedItems);
+
       // Group dequips per character
       const dequips = _.map(
         _.groupBy(realItemsToDequip, (i) => i.owner),

--- a/src/app/loadout-drawer/postmaster.ts
+++ b/src/app/loadout-drawer/postmaster.ts
@@ -173,7 +173,7 @@ export function pullFromPostmaster(store: DimStore): ThunkResult {
 
     const promise = (async () => {
       let succeeded = 0;
-      const moveSession = createMoveSession(cancelToken);
+      const moveSession = createMoveSession(cancelToken, items);
 
       for (const item of items) {
         let amount = item.amount;
@@ -241,7 +241,7 @@ function moveItemsToVault(
       // reserve space for all move-asides
       [store.id]: _.countBy(items, (i) => i.bucket.hash),
     };
-    const moveSession = createMoveSession(cancelToken);
+    const moveSession = createMoveSession(cancelToken, items);
 
     for (const item of items) {
       const stores = storesSelector(getState());


### PR DESCRIPTION
having consumables completely full has historically been, and currently still is, a very bad idea.
it prevents certain things from dropping in activities, it has broken seasonal quests before, etc.

this prevents DIM from filling the last available consumables slot when performing automatic moves.
the user can still drag an item into the 50th slot, manually. if they really want that. but DIM will never fill it without the user knowing it's happening