### PR TITLE
Bulk move items in a more consistent order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * When making automatic moves, DIM will always avoid filling in your last open Consumables slot. An item can still be manually moved into your character's pockets as the 50th consumable.
+* When moving multiple items, DIM will transfer them in a more consistent order e.g. Kinetic weapons are moved before Heavy weapons, helmets before chest armor etc.
 
 ## 7.20.1 <span class="changelog-date">(2022-06-06)</span>
 


### PR DESCRIPTION
This PR ensures that when moving multiple items as part of applying a loadout, we transfer items in the same order that the buckets are displayed in DIM (e.g. move Kinetic weapons first, then Energy weapons, then Heavy, Helmets, Gauntlets etc.). This includes fake 'item move' loadouts that are triggered from a search query.

The current behavior is that items get transferred in the order they are present in `Loadout.items`. For real loadouts, this ends up being the order that the user added the item to the loadout i.e. if I add a Heavy weapon to my loadout before a Kinetic weapon, the Heavy weapon will be transferred before the Kinetic weapon. For fake 'item move' loadouts, this seems to be however `DimStore.items` is ordered (anecdotally always seems to be chest armor first, but likely not guaranteed).

The transfer order is also reflected in the loadout apply notification:
![dim-sorted-loadout-apply](https://user-images.githubusercontent.com/17512262/173181079-f99f0365-3ef3-4b4f-81fb-87ecea11a2d9.png)

The 'why?' for this change is _very_ niche. I often bulk transfer a lot of junk items (~70) to my character to delete. I usually don't have enough vault space to move good items away beforehand, so my character typically ends up with a mix of good and junk items after this transfer finishes. I refer to DIM to know which items on my character are junk and can thus be deleted. Transferring ~70 items takes a while (especially if DIM can't efficiently move aside because I'm at 599/600) so I start deleting stuff as soon as all the transfers for one bucket have completed. This change makes this process *slightly* more convenient, since I can go through each bucket in the order they are displayed in DIM.

Besides my very niche use case, I do think it looks neater having items show up in-game in a more logical order. That being said, happy to close this off if we'd rather avoid the extra complexity.