### PR TITLE
Fix LO grouping locked items into Any group

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed a rare edge case where Loadout Optimizer would miss certain valid elemental mod assignments with locked armor energy types.
+
 ## 7.21.0 <span class="changelog-date">(2022-06-12)</span>
 
 * The [DIM User Guide](https://github.com/DestinyItemManager/DIM/wiki) has moved back to GitHub from Fandom, so you can read about DIM without intrusive ads.
@@ -12,7 +14,6 @@
 ### Beta Only
 
 * Weapon perks now include community-sourced weapon and armor perk descriptions courtesy of [Clarity](https://d2clarity.page.link/websiteDIM) and [Pip1n's Destiny Data Compendium](https://docs.google.com/spreadsheets/d/1WaxvbLx7UoSZaBqdFr1u32F2uWVLo-CJunJB4nlGUE4/htmlview?pru=AAABe9E7ngw*TxEsfbPsk5ukmr0FbZfK8w#). These can be disabled in settings.
-
 
 ## 7.20.1 <span class="changelog-date">(2022-06-06)</span>
 

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -306,13 +306,17 @@ function groupItems(
 
     if (requiredEnergyTypes.size) {
       groupId +=
-        // Only add the grouping key if the socket matches what we need, otherwise it doesn't matter
         item.energy &&
-        requiredEnergyTypes.has(item.energy.energyType) &&
-        // If we can swap to another energy type, there's no need to group by current energy type
-        isArmorEnergyLocked(item, armorEnergyRules)
-          ? item.energy.energyType
-          : DestinyEnergyType.Any;
+        // We group all items locked to an energy type we don't care about
+        // by using an `X` instead of the numerical energy type -- if we only
+        // want to assign Solar mods, we can put all items locked to Void,
+        // Stasis and Arc into their own group (apart from the Any items and
+        // apart from the items locked to Solar)
+        (isArmorEnergyLocked(item, armorEnergyRules)
+          ? requiredEnergyTypes.has(item.energy.energyType)
+            ? item.energy.energyType
+            : 'X'
+          : DestinyEnergyType.Any);
     }
 
     return groupId;


### PR DESCRIPTION
Fixes #8466.

These grouping bugs (see #8290 for another) are really unfortunate and I'm thinking it could make sense to unify mapping and grouping -- eagerly map items to `ProcessItems` and then group by the relevant bits to make it easier to see that grouping and mapping are agreeing with each other. But for now this is an easy fix.