### PR TITLE
Move user guide links back to GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      Thank you for taking the time to fill out a bug report! To save both you and us time, please make sure to check the [FAQ](https://destinyitemmanager.fandom.com/wiki/Category:FAQ) and [search issues](https://github.com/DestinyItemManager/DIM/issues?q=is%3Aissue) to see if this has already been reported.
+      Thank you for taking the time to fill out a bug report! To save both you and us time, please make sure to check the [FAQ](https://github.com/DestinyItemManager/DIM/wiki/FAQ) and [search issues](https://github.com/DestinyItemManager/DIM/issues?q=is%3Aissue) to see if this has already been reported.
 - type: input
   id: DIMversion
   attributes:

--- a/docs/OLD_CHANGELOG/OLD_CHANGELOG_6.X.X.md
+++ b/docs/OLD_CHANGELOG/OLD_CHANGELOG_6.X.X.md
@@ -143,7 +143,7 @@
 ## 6.94.0 <span class="changelog-date">(2021-12-05)</span>
 
 * You can change perks and slot zero-cost mods from the item Popup.
-* Loadouts can now apply mods. See [Mods in Loadouts](https://destinyitemmanager.fandom.com/wiki/Mods_in_Loadouts) for details. Some things to keep in mind:
+* Loadouts can now apply mods. See [Mods in Loadouts](https://github.com/DestinyItemManager/DIM/wiki/Mods-in-Loadouts) for details. Some things to keep in mind:
   * This will not work until the 30th Anniversary patch.
   * Applying mods will also strip off any mods that aren't in your loadout from your equipped armor.
   * Mods will be placed on your equipped armor whether that armor came from your loadout or not.
@@ -1029,7 +1029,7 @@
 ## 6.26.0 <span class="changelog-date">(2020-08-23)</span>
 
 * Better touchscreen support for drag and drop.
-* Wishlists now support Github gists (raw text URLs), so there's no need to set up an entire repository to host them. If you are making wishlists, you can try out changes easier than ever. If you're not making wishlists, hopefully you're using them. If you don't know what wishlists are, [here you go](https://destinyitemmanager.fandom.com/wiki/Wish_Lists)
+* Wishlists now support Github gists (raw text URLs), so there's no need to set up an entire repository to host them. If you are making wishlists, you can try out changes easier than ever. If you're not making wishlists, hopefully you're using them. If you don't know what wishlists are, [here you go](https://github.com/DestinyItemManager/DIM/wiki/Wish-Lists)
 * Engrams get a more form-fitting outline on mouse hover.
 * If you have a search query active, DIM will not automatically reload to update itself.
 * The `is:curated` search has been overhauled to better find curated rolls.

--- a/src/app/dim-ui/UserGuideLink.tsx
+++ b/src/app/dim-ui/UserGuideLink.tsx
@@ -1,6 +1,5 @@
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
-import React from 'react';
 import { AppIcon, helpIcon } from '../shell/icons';
 import ExternalLink from './ExternalLink';
 
@@ -20,7 +19,7 @@ export default function UserGuideLink({
     return null;
   }
 
-  const link = `https://destinyitemmanager.fandom.com/wiki/${topic}`;
+  const link = `https://github.com/DestinyItemManager/DIM/wiki/${topic}`;
 
   return (
     <ExternalLink href={link} className={clsx('dim-button', className)}>

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -35,7 +35,7 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { AnimatePresence, motion } from 'framer-motion';
 import _ from 'lodash';
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { allItemsSelector } from '../inventory/selectors';
@@ -433,7 +433,7 @@ function LoadoutBuilder({
           )}
         </AnimatePresence>
         <div className={styles.toolbar}>
-          <UserGuideLink topic="Loadout_Optimizer" />
+          <UserGuideLink topic="Loadout-Optimizer" />
           <button
             type="button"
             className="dim-button"

--- a/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
+++ b/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
@@ -91,7 +91,7 @@ export default function LoadoutShareSheet({
       header={
         <>
           <h1>{t('Loadouts.Share.Title', { name: loadout.name })}</h1>
-          <UserGuideLink topic="Share_Loadouts" />
+          <UserGuideLink topic="Share-Loadouts" />
         </>
       }
       sheetClassName={styles.sheet}

--- a/src/app/login/Login.tsx
+++ b/src/app/login/Login.tsx
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { oauthClientId } from '../bungie-api/bungie-api-utils';
 import styles from './Login.m.scss';
 
-const dimApiHelpLink = 'https://destinyitemmanager.fandom.com/wiki/DIM_Sync';
+const dimApiHelpLink = 'https://github.com/DestinyItemManager/DIM/wiki/DIM-Sync';
 const loginHelpLink =
   'https://github.com/DestinyItemManager/DIM/wiki/Authorizing-Destiny-Item-Manager-with-Bungie.net';
 

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -517,7 +517,7 @@ function SearchBar(
             header={
               <>
                 <h1>{t('Header.Filters')}</h1>
-                <UserGuideLink topic="Item_Search" />
+                <UserGuideLink topic="Item-Search" />
               </>
             }
             sheetClassName="filterHelp"

--- a/src/app/shell/About.tsx
+++ b/src/app/shell/About.tsx
@@ -1,7 +1,7 @@
 import { getToken } from 'app/bungie-api/oauth-tokens';
 import StaticPage from 'app/dim-ui/StaticPage';
 import { t } from 'app/i18next-t';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import logo from '../../images/logo-light.svg';
 import ExternalLink from '../dim-ui/ExternalLink';
@@ -34,7 +34,7 @@ const youTubeLink = 'https://www.youtube.com/channel/UCsNRmUfaeIi5Tk7U0mlZ6UQ';
 const twitterLink = 'https://twitter.com/ThisIsDIM';
 const redditLink = 'https://destinyitemmanager.reddit.com';
 const discordLink = 'https://discord.gg/UK2GWC7';
-const wikiLink = 'https://destinyitemmanager.fandom.com/wiki/Destiny_Item_Manager_Wiki';
+const wikiLink = 'https://github.com/DestinyItemManager/DIM/wiki';
 
 export default function About() {
   const iOSApp = document.cookie.includes('app-platform=iOS App Store;');

--- a/src/app/shell/ErrorPanel.tsx
+++ b/src/app/shell/ErrorPanel.tsx
@@ -8,7 +8,7 @@ import styles from './ErrorPanel.m.scss';
 
 const bungieHelpLink = 'http://twitter.com/BungieHelp';
 const dimHelpLink = 'http://twitter.com/ThisIsDIM';
-const troubleshootingLink = 'https://destinyitemmanager.fandom.com/wiki/Troubleshooting';
+const troubleshootingLink = 'https://github.com/DestinyItemManager/DIM/wiki/Troubleshooting';
 const Timeline = React.lazy(async () => {
   const m = await import(/* webpackChunkName: "twitter" */ 'react-twitter-widgets');
   return { default: m.Timeline };

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -315,7 +315,7 @@ export default function Header() {
                 )}
                 <ExternalLink
                   className={styles.menuItem}
-                  href="https://destinyitemmanager.fandom.com/wiki/Category:User_Guide"
+                  href="https://github.com/DestinyItemManager/DIM/wiki"
                 >
                   {t('General.UserGuideLink')}
                 </ExternalLink>

--- a/src/index.html
+++ b/src/index.html
@@ -80,7 +80,7 @@
         </p>
         <ul>
           <li>
-            <a href="https://destinyitemmanager.fandom.com/wiki/Troubleshooting"
+            <a href="https://github.com/DestinyItemManager/DIM/wiki/Troubleshooting"
               >Troubleshooting Guide</a
             >
           </li>


### PR DESCRIPTION
I've moved all the user guide into the GitHub wiki.