### PR TITLE
Remove inital load of stripped-down components

### DIFF
--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -70,11 +70,9 @@ export async function getLinkedAccounts(
 /**
  * Get the user's stores on this platform. This includes characters, vault, and item information.
  */
-export function getStores(
-  platform: DestinyAccount,
-  components?: DestinyComponentType[]
-): Promise<DestinyProfileResponse> {
-  const defaultComponents = [
+export function getStores(platform: DestinyAccount): Promise<DestinyProfileResponse> {
+  return getProfile(
+    platform,
     DestinyComponentType.Profiles,
     DestinyComponentType.ProfileInventories,
     DestinyComponentType.ProfileCurrencies,
@@ -98,10 +96,8 @@ export function getStores(
     DestinyComponentType.Metrics,
     DestinyComponentType.StringVariables,
     DestinyComponentType.ProfileProgression,
-    DestinyComponentType.Craftables,
-  ];
-
-  return getProfile(platform, ...(components || defaultComponents));
+    DestinyComponentType.Craftables
+  );
 }
 
 /**

--- a/src/app/inventory-page/Inventory.tsx
+++ b/src/app/inventory-page/Inventory.tsx
@@ -7,31 +7,12 @@ import DragPerformanceFix from 'app/inventory/DragPerformanceFix';
 import { storesLoadedSelector } from 'app/inventory/selectors';
 import { useLoadStores } from 'app/inventory/store/hooks';
 import { MaterialCountsSheet } from 'app/material-counts/MaterialCountsWrappers';
-import { DestinyComponentType } from 'bungie-api-ts/destiny2';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import Stores from './Stores';
 
-interface Props {
-  account: DestinyAccount;
-}
-
-const components = [
-  DestinyComponentType.ProfileInventories,
-  DestinyComponentType.ProfileCurrencies,
-  DestinyComponentType.Characters,
-  DestinyComponentType.CharacterInventories,
-  DestinyComponentType.CharacterEquipment,
-  DestinyComponentType.ItemInstances,
-  // Without ItemSockets and ItemReusablePlugs there will be a delay before the thumbs ups.
-  // One solution could be to cache the wishlist info between loads.
-  DestinyComponentType.ItemSockets,
-  DestinyComponentType.ItemReusablePlugs,
-];
-
-export default function Inventory({ account }: Props) {
+export default function Inventory({ account }: { account: DestinyAccount }) {
   const storesLoaded = useSelector(storesLoadedSelector);
-  useLoadStores(account, components);
+  useLoadStores(account);
 
   if (!storesLoaded) {
     return <ShowPageLoading message={t('Loading.Profile')} />;

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -17,7 +17,6 @@ import {
   DestinyCharacterProgressionComponent,
   DestinyCollectibleComponent,
   DestinyCollectiblesComponent,
-  DestinyComponentType,
   DestinyItemComponent,
   DestinyProfileCollectiblesComponent,
   DestinyProfileResponse,
@@ -132,9 +131,7 @@ export function mergeCollectibles(
  * Returns a promise for a fresh view of the stores and their items.
  */
 
-export function loadStores(
-  components?: DestinyComponentType[]
-): ThunkResult<DimStore[] | undefined> {
+export function loadStores(): ThunkResult<DimStore[] | undefined> {
   return async (dispatch, getState) => {
     let account = currentAccountSelector(getState());
     if (!account) {
@@ -146,15 +143,10 @@ export function loadStores(
       }
     }
 
-    const stores = await dispatch(loadStoresData(account, isFirstLoad ? components : undefined));
+    const stores = await dispatch(loadStoresData(account));
 
     if (isFirstLoad) {
       isFirstLoad = false;
-      if (components) {
-        // async load the rest (no await)
-        dispatch(loadStoresData(account));
-      }
-
       $featureFlags.clarityDescriptions && dispatch(loadClarity());
     }
 
@@ -162,10 +154,7 @@ export function loadStores(
   };
 }
 
-function loadStoresData(
-  account: DestinyAccount,
-  components?: DestinyComponentType[]
-): ThunkResult<DimStore[] | undefined> {
+function loadStoresData(account: DestinyAccount): ThunkResult<DimStore[] | undefined> {
   return async (dispatch, getState) => {
     const promise = (async () => {
       // If we switched account since starting this, give up
@@ -189,7 +178,7 @@ function loadStoresData(
           dispatch(loadNewItems(account)),
           mockProfileData
             ? (JSON.parse(mockProfileData) as DestinyProfileResponse)
-            : getStores(account, components),
+            : getStores(account),
         ]);
 
         // If we switched account since starting this, give up

--- a/src/app/inventory/store/hooks.ts
+++ b/src/app/inventory/store/hooks.ts
@@ -2,7 +2,6 @@ import { DestinyAccount } from 'app/accounts/destiny-account';
 import { refresh$ } from 'app/shell/refresh-events';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useEventBusListener } from 'app/utils/hooks';
-import { DestinyComponentType } from 'bungie-api-ts/destiny2';
 import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { queueAction } from '../../utils/action-queue';
@@ -17,22 +16,19 @@ import { storesLoadedSelector } from '../selectors';
  * in the same component. useDispatch() is cheap because it just listens to a
  * context that never changes.
  */
-export function useLoadStores(
-  account: DestinyAccount | undefined,
-  components?: DestinyComponentType[]
-) {
+export function useLoadStores(account: DestinyAccount | undefined) {
   const dispatch = useThunkDispatch();
   const loaded = useSelector(storesLoadedSelector);
 
   useEffect(() => {
     if (account && !loaded) {
       if (account?.destinyVersion === 2) {
-        dispatch(d2LoadStores(components));
+        dispatch(d2LoadStores());
       } else {
         dispatch(d1LoadStores());
       }
     }
-  }, [account, dispatch, components, loaded]);
+  }, [account, dispatch, loaded]);
 
   useEventBusListener(
     refresh$,


### PR DESCRIPTION
A while back we made a change to initially load a smaller set of inventory components in order to display the page faster, then immediately follow up with a load of the rest of the data. This fails sometime (not sure why), leaving people in a weird state. I've done some testing and it seems the initial data load and the second data load take roughly the same time - meaning there's no real savings to doing this. It seems like it's simpler and less error prone to just load the full data every time.