### PR TITLE
Filter out enhanced intrinsics from Organizer perk columns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixed a rare edge case where Loadout Optimizer would miss certain valid elemental mod assignments with locked armor energy types.
 * When moving multiple items, DIM will transfer them in a more consistent order e.g. Kinetic weapons are moved before Heavy weapons, helmets before chest armor etc.
+* Fixed Organizer redundantly showing enhanced weapon intrinsics in multiple columns.
 
 ## 7.21.0 <span class="changelog-date">(2022-06-12)</span>
 

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -59,7 +59,7 @@ import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { D2EventInfo } from 'data/d2/d2-event-info';
-import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import { StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -573,6 +573,10 @@ function PerksCell({
     return null;
   }
 
+  const legendaryWeaponArchetypePlugHash =
+    item.bucket.inWeapons && !item.isExotic
+      ? getWeaponArchetypeSocket(item)?.plugged?.plugDef?.hash
+      : undefined;
   let sockets = item.sockets.categories.flatMap((c) =>
     getSocketsByIndexes(item.sockets!, c.socketIndexes).filter(
       (s) =>
@@ -584,11 +588,8 @@ function PerksCell({
           (s.isPerk &&
             // Filter out the archetype plug for legendary weapons
             // as it's already in the archetype column
-            !(
-              !item.isExotic &&
-              item.bucket.inWeapons &&
-              s.plugged.plugDef.itemCategoryHashes?.includes(ItemCategoryHashes.WeaponModsIntrinsic)
-            )))
+            (!legendaryWeaponArchetypePlugHash ||
+              s.plugged.plugDef.hash !== legendaryWeaponArchetypePlugHash)))
     )
   );
 


### PR DESCRIPTION
We already filter out Legendary weapon archetype perks (e.g. Rapid-Fire Frame) from the **Perks, Mods & Shaders** and **Weapon Traits** columns since they get displayed in the **Archetype** column. Unfortunately, enhanced intrinsics don't have the `WeaponModsIntrinsic` ICH we were using for filtering.

This PR changes the comparison logic to use the `getWeaponArchetypeSocket` utility function, which is consistent with the **Archetype** column.

![dim-organizer-enhanced-intrinsics](https://user-images.githubusercontent.com/17512262/173564311-877d759d-3355-4bcc-8cb7-a2373c375f28.png)
