### PR TITLE
Fix for double descriptions

### DIFF
--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -105,9 +105,13 @@ export default function ItemSocketsGeneral({ item, minimal, onPlugClicked }: Pro
                     <ClarityDescriptions
                       hash={exoticArmorPerkSocket.plugged.plugDef.hash}
                       fallback={
-                        <RichDestinyText
-                          text={exoticArmorPerkSocket.plugged.plugDef.displayProperties.description}
-                        />
+                        !showBungieDescription && (
+                          <RichDestinyText
+                            text={
+                              exoticArmorPerkSocket.plugged.plugDef.displayProperties.description
+                            }
+                          />
+                        )
                       }
                       communityOnly={showCommunityDescriptionOnly}
                     />


### PR DESCRIPTION
Fixed double descriptions then using community and Bungie descriptions
Fallback should not be shown because where is Bungie's description already