### PR TITLE
Reload Clarity descriptions along with store refreshes every hour

### DIFF
--- a/src/app/clarity/descriptions/loadDescriptions.ts
+++ b/src/app/clarity/descriptions/loadDescriptions.ts
@@ -1,5 +1,6 @@
 import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
+import { dedupePromise } from 'app/utils/util';
 import * as actions from '../actions';
 import { ClarityDescription, ClarityVersions } from './descriptionInterface';
 
@@ -14,7 +15,7 @@ const fetchClarity = async (type: keyof typeof urls) => {
   return json;
 };
 
-const loadClarityDescriptions = async () => {
+const loadClarityDescriptions = dedupePromise(async (loadFromIndexedDB) => {
   const savedVersion = Number(localStorage.getItem('clarityDescriptionVersion') ?? '0');
   const liveVersion: ClarityVersions = await fetchClarity('version');
 
@@ -25,17 +26,34 @@ const loadClarityDescriptions = async () => {
     return descriptions;
   }
 
-  const savedDescriptions: ClarityDescription = await get('clarity-descriptions');
-  return savedDescriptions;
-};
+  if (loadFromIndexedDB) {
+    const savedDescriptions: ClarityDescription = await get('clarity-descriptions');
+    return savedDescriptions;
+  }
+
+  return undefined;
+});
+
+/** Reload descriptions at most every 1 hour */
+const descriptionReloadAfter = 60 * 60 * 1000;
+let lastDescriptionUpdate = 0;
 
 /**
  * Load the Clarity database, either remotely or from the local cache.
- * TODO: reload this every so often when stores reload
  */
 export function loadClarity(): ThunkResult {
-  return async (dispatch) => {
-    const descriptions = await loadClarityDescriptions();
-    dispatch(actions.loadDescriptions(descriptions));
+  return async (dispatch, getState) => {
+    const { descriptions } = getState().clarity;
+
+    // Load if it's been long enough, or if there aren't descriptions loaded.
+    // The latter helps if there was an error loading them - it forces the next
+    // refresh to try again.
+    if (!descriptions || Date.now() - lastDescriptionUpdate > descriptionReloadAfter) {
+      const newDescriptions = await loadClarityDescriptions(!descriptions);
+      if (newDescriptions) {
+        dispatch(actions.loadDescriptions(newDescriptions));
+      }
+      lastDescriptionUpdate = Date.now();
+    }
   };
 }

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -50,8 +50,6 @@ import { getCharacterStatsData, makeCharacter, makeVault } from './store/d2-stor
 import { resetItemIndexGenerator } from './store/item-index';
 import { getArtifactBonus } from './stores-helpers';
 
-let isFirstLoad = true;
-
 /**
  * Update the high level character information for all the stores
  * (level, power, stats, etc.). This does not update the
@@ -143,13 +141,8 @@ export function loadStores(): ThunkResult<DimStore[] | undefined> {
       }
     }
 
+    $featureFlags.clarityDescriptions && dispatch(loadClarity()); // no need to await
     const stores = await dispatch(loadStoresData(account));
-
-    if (isFirstLoad) {
-      isFirstLoad = false;
-      $featureFlags.clarityDescriptions && dispatch(loadClarity());
-    }
-
     return stores;
   };
 }


### PR DESCRIPTION
This changes to check for new Clarity descriptions whenever inventory is reloaded, but not more frequently than once per hour. 

Fixes #8469

cc @Ice-mourne 