### PR TITLE
Fix icon watermark scaling at reduced item sizes

### DIFF
--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -92,6 +92,12 @@ $commonBg: #366f42;
   height: calc(var(--item-size) - #{2 * $item-border-width});
   width: calc(var(--item-size) - #{2 * $item-border-width});
   position: absolute;
+
+  // Ensure that the contained image is correctly scaled down in cases where --item-size is reduced
+  // e.g. Loadout Optimizer Exotic armor picker, Loadout Fashion Mods, Loadout Organizer perk columns
+  & > img {
+    width: 100%;
+  }
 }
 
 .energyCostOverlay {

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -92,12 +92,6 @@ $commonBg: #366f42;
   height: calc(var(--item-size) - #{2 * $item-border-width});
   width: calc(var(--item-size) - #{2 * $item-border-width});
   position: absolute;
-
-  // Ensure that the contained image is correctly scaled down in cases where --item-size is reduced
-  // e.g. Loadout Optimizer Exotic armor picker, Loadout Fashion Mods, Loadout Organizer perk columns
-  & > img {
-    width: 100%;
-  }
 }
 
 .energyCostOverlay {

--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -131,11 +131,7 @@ export function DefItemIcon({
   return (
     <>
       <BungieImage src={itemDef.displayProperties.icon} className={itemImageStyles} alt="" />
-      {iconOverlay && (
-        <div className={styles.iconOverlay}>
-          <BungieImage src={iconOverlay} />
-        </div>
-      )}
+      {iconOverlay && <BungieImage src={iconOverlay} className={styles.iconOverlay} alt="" />}
       {modInfo?.energyCostElementOverlay && (
         <>
           <div


### PR DESCRIPTION
This PR fixes a regression introduced by 122165d for #8478 and will close #8491.

![dim-fix-icon-overlay-scaling](https://user-images.githubusercontent.com/17512262/173823316-84b49b0c-05f1-4d07-88ed-1188ecc23472.png)
