### PR TITLE
compact some weapon pattern UI in item popup

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -793,6 +793,7 @@
     "CannotCurrentlyRoll": "This perk cannot be rolled on the current version of this item.",
     "Consolidate": "Consolidate",
     "CommunityData": "Community Insight",
+    "CraftingPattern": "Crafting Pattern",
     "Details": "Popup",
     "DistributeEvenly": "Distribute Evenly",
     "Equip": "Equip",

--- a/src/app/dim-ui/WeaponDeepsightInfo.m.scss
+++ b/src/app/dim-ui/WeaponDeepsightInfo.m.scss
@@ -1,8 +1,33 @@
 .deepsightProgress {
-  padding: 4px 10px 4px;
-  background: #333;
+  display: flex;
 
   :global(.objective-progress) {
     background: #222;
   }
+  > :nth-child(n + 2) {
+    margin-left: 4px;
+  }
+}
+
+.deepsightProgressSection {
+  padding: 4px 10px 4px;
+  background: #333;
+  flex-grow: 1;
+}
+
+.patternProgress {
+  display: flex;
+  align-items: center;
+  flex-grow: 0;
+}
+
+.patternIcon {
+  width: 15px;
+  height: 15px;
+  border: 1px solid #999;
+  margin-right: 4px;
+}
+
+.patternOwned {
+  color: #44bd32;
 }

--- a/src/app/dim-ui/WeaponDeepsightInfo.m.scss.d.ts
+++ b/src/app/dim-ui/WeaponDeepsightInfo.m.scss.d.ts
@@ -2,6 +2,10 @@
 // Please do not change this file!
 interface CssExports {
   'deepsightProgress': string;
+  'deepsightProgressSection': string;
+  'patternIcon': string;
+  'patternOwned': string;
+  'patternProgress': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/dim-ui/WeaponDeepsightInfo.tsx
+++ b/src/app/dim-ui/WeaponDeepsightInfo.tsx
@@ -1,6 +1,12 @@
+import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import Objective from 'app/progress/Objective';
-import React from 'react';
+import { useD2Definitions } from 'app/manifest/selectors';
+import Objective, { ObjectiveValue } from 'app/progress/Objective';
+import { faCheck } from 'app/shell/icons';
+import AppIcon from 'app/shell/icons/AppIcon';
+import { DestinyRecordComponent } from 'bungie-api-ts/destiny2';
+import clsx from 'clsx';
+import PressTip from './PressTip';
 import styles from './WeaponDeepsightInfo.m.scss';
 
 /**
@@ -9,17 +15,70 @@ import styles from './WeaponDeepsightInfo.m.scss';
 export function WeaponDeepsightInfo({ item }: { item: DimItem }) {
   const deepsightInfo = item.deepsightInfo;
   const record = item.patternUnlockRecord;
+  const relevantObjectives = record?.objectives.filter((o) => !o.complete);
 
-  if (!deepsightInfo && !record?.objectives[0]) {
+  if (!deepsightInfo && !relevantObjectives?.length) {
     return null;
   }
 
   return (
     <div className={styles.deepsightProgress}>
-      {deepsightInfo && <Objective objective={deepsightInfo.attunementObjective} />}
-      {record?.objectives.map((objective) => (
-        <Objective key={objective.objectiveHash} objective={objective} />
-      ))}
+      {deepsightInfo ? (
+        <>
+          <PatternUnlockedIndicator record={record} />
+          <div className={styles.deepsightProgressSection}>
+            <Objective objective={deepsightInfo.attunementObjective} />
+          </div>
+        </>
+      ) : (
+        Boolean(relevantObjectives?.length) && (
+          <div className={styles.deepsightProgressSection}>
+            {relevantObjectives!.map((objective) => (
+              <Objective key={objective.objectiveHash} objective={objective} />
+            ))}
+          </div>
+        )
+      )}
     </div>
+  );
+}
+
+function PatternUnlockedIndicator({ record }: { record: DestinyRecordComponent | undefined }) {
+  const defs = useD2Definitions()!;
+  const weaponPatternIcon = defs.InventoryItem.get(3131030715)?.displayProperties.icon;
+
+  if (!record) {
+    return null;
+  }
+  return (
+    <PressTip
+      className={clsx(styles.patternProgress, styles.deepsightProgressSection)}
+      tooltip={
+        <>
+          <h2>{t('MovePopup.CraftingPattern')}</h2>
+          {record?.objectives.map((objective) => (
+            <Objective key={objective.objectiveHash} objective={objective} />
+          ))}
+        </>
+      }
+    >
+      <img className={styles.patternIcon} src={weaponPatternIcon} />
+      <span>
+        {record.objectives.every((o) => o.complete) ? (
+          <AppIcon className={styles.patternOwned} icon={faCheck} />
+        ) : (
+          <>
+            {record.objectives.map((o) => (
+              <ObjectiveValue
+                key={o.objectiveHash}
+                objectiveDef={defs.Objective.get(o.objectiveHash)}
+                progress={o.progress!}
+                completionValue={o.completionValue}
+              />
+            ))}
+          </>
+        )}
+      </span>
+    </PressTip>
   );
 }

--- a/src/app/dim-ui/WeaponDeepsightInfo.tsx
+++ b/src/app/dim-ui/WeaponDeepsightInfo.tsx
@@ -6,6 +6,7 @@ import { faCheck } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { DestinyRecordComponent } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
+import BungieImage from './BungieImage';
 import PressTip from './PressTip';
 import styles from './WeaponDeepsightInfo.m.scss';
 
@@ -62,7 +63,7 @@ function PatternUnlockedIndicator({ record }: { record: DestinyRecordComponent |
         </>
       }
     >
-      <img className={styles.patternIcon} src={weaponPatternIcon} />
+      <BungieImage className={styles.patternIcon} src={weaponPatternIcon} />
       <span>
         {record.objectives.every((o) => o.complete) ? (
           <AppIcon className={styles.patternOwned} icon={faCheck} />

--- a/src/app/dim-ui/WeaponDeepsightInfo.tsx
+++ b/src/app/dim-ui/WeaponDeepsightInfo.tsx
@@ -32,9 +32,10 @@ export function WeaponDeepsightInfo({ item }: { item: DimItem }) {
           </div>
         </>
       ) : (
-        Boolean(relevantObjectives?.length) && (
+        relevantObjectives &&
+        relevantObjectives.length > 0 && (
           <div className={styles.deepsightProgressSection}>
-            {relevantObjectives!.map((objective) => (
+            {relevantObjectives.map((objective) => (
               <Objective key={objective.objectiveHash} objective={objective} />
             ))}
           </div>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -8,22 +8,18 @@
     "IrreversiblePlugging": "You don't own {{plug}}, so we won't overwrite it."
   },
   "Accounts": {
+    "": "",
     "ErrorLoadInventory": "Unable to load your Destiny {{version}} characters and inventory",
     "ErrorLoadManifest": "Unable to load Destiny info database from Bungie",
     "ErrorLoading": "Unable to load Destiny accounts from Bungie.net",
     "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile.",
     "MissingTitle": "Account Not Found",
-    "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account.",
-    "PlayStation": "PlayStation",
-    "Stadia": "Stadia",
-    "Steam": "Steam",
-    "Xbox": "Xbox"
+    "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account."
   },
   "Activities": {
+    "": "",
     "Activities": "Activities",
-    "Hard": "Hard",
     "Nightfall": "Nightfall Strike",
-    "Normal": "Normal",
     "WeeklyHeroic": "Weekly Heroic Strike"
   },
   "Armory": {
@@ -37,19 +33,14 @@
     "YourItems": "Your Items"
   },
   "Browsercheck": {
-    "Steam": "It looks like this page is loaded in Steam's browser. Due to its limited features and resources, it may unexpectedly or intermittently fail to run DIM. We cannot provide support for it.",
-    "Unsupported": "The DIM team does not support using this browser. Some or all DIM features may not work."
+    "": ""
   },
   "Bucket": {
+    "": "",
     "Armor": "Armor",
     "Class": "Subclass",
-    "General": "General",
     "Ghost": "Ghost",
-    "Inventory": "Inventory",
-    "Postmaster": "Postmaster",
-    "Progress": "Progress",
     "Reputation": "Reputation",
-    "Unknown": "Unknown",
     "Vault": "Vault",
     "Weapons": "Weapons"
   },
@@ -96,14 +87,14 @@
     "SoldBy": "Sold by: {{vendorName}}"
   },
   "Cooldown": {
-    "Grenade": "Grenade cooldown: {{cooldown}}",
-    "Melee": "Melee cooldown: {{cooldown}}",
-    "Super": "Super cooldown: {{cooldown}}"
+    "": ""
   },
   "Countdown": {
     "Days": "1 Day",
-    "Days_compact": "{{count}}d",
-    "Days_compact_plural": "{{count}}d",
+    "Days_female": "",
+    "Days_female_plural": "",
+    "Days_male": "",
+    "Days_male_plural": "",
     "Days_plural": "{{count}} Days"
   },
   "Csv": {
@@ -528,8 +519,7 @@
     "OptimizerSet": "Optimizer Set",
     "ProcessingSets": "Processing sets for\n{{character}} ({{remainingTime}}s)",
     "SaveAs": "Save as",
-    "SelectMax": "- Max -",
-    "SelectMin": "- Min -",
+    "Select": "",
     "ShareBuild": "Share Build Settings",
     "ShareBuildTitle": "Loadout Optimizer Settings",
     "ShareBuildWithNotes": "Share With Notes",
@@ -706,6 +696,7 @@
     "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "CommunityData": "Community Insight",
     "Consolidate": "Consolidate",
+    "CraftingPattern": "Crafting Pattern",
     "DistributeEvenly": "Distribute Evenly",
     "Equip": "Equip",
     "FavoriteUnFavorite": {
@@ -829,6 +820,7 @@
     "PostmasterFull": "The postmaster is full! ({{number}}/{{postmasterSize}})"
   },
   "Progress": {
+    "": "",
     "Bounties": "Bounties",
     "CrucibleRank": "Ranks",
     "Items": "Quest Items",
@@ -935,28 +927,12 @@
     "ApplyPerks": "Apply Perks",
     "GridStyle": "Display perks as a grid",
     "Insert": {
-      "Ability": "Equip Ability",
-      "Aspect": "Insert Aspect",
-      "Fragment": "Insert Fragment",
-      "Mod": "Insert Mod",
-      "Ornament": "Apply Ornament",
-      "Projection": "Apply Ghost Projection",
-      "Shader": "Apply Shader",
-      "Super": "Equip Super",
-      "Transmat": "Apply Transmat Effect"
+      "": ""
     },
     "ListStyle": "Display perks as a list",
     "Search": "Search names or descriptions",
     "Select": {
-      "Ability": "Preview Ability",
-      "Aspect": "Preview Aspect",
-      "Fragment": "Preview Fragment",
-      "Mod": "Preview Mod",
-      "Ornament": "Preview Ornament",
-      "Projection": "Preview Ghost Projection",
-      "Shader": "Preview Shader",
-      "Super": "Preview Super",
-      "Transmat": "Preview Transmat Effect"
+      "": ""
     },
     "SelectWishlistPerks": "Preview Wishlist Perks"
   },
@@ -980,7 +956,8 @@
     "Sunset": "Sunset",
     "Tier": "Tier {{tier}}",
     "TierProgress": "T{{tier}} {{statName}} ({{progress}}/60 for T{{nextTier}})\n",
-    "TierProgress_Max": "T{{tier}} {{statName}} ({{progress}}/300)\n",
+    "TierProgress_female": "",
+    "TierProgress_male": "",
     "Total": "Total"
   },
   "Storage": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -8,18 +8,22 @@
     "IrreversiblePlugging": "You don't own {{plug}}, so we won't overwrite it."
   },
   "Accounts": {
-    "": "",
     "ErrorLoadInventory": "Unable to load your Destiny {{version}} characters and inventory",
     "ErrorLoadManifest": "Unable to load Destiny info database from Bungie",
     "ErrorLoading": "Unable to load Destiny accounts from Bungie.net",
     "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile.",
     "MissingTitle": "Account Not Found",
-    "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account."
+    "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account.",
+    "PlayStation": "PlayStation",
+    "Stadia": "Stadia",
+    "Steam": "Steam",
+    "Xbox": "Xbox"
   },
   "Activities": {
-    "": "",
     "Activities": "Activities",
+    "Hard": "Hard",
     "Nightfall": "Nightfall Strike",
+    "Normal": "Normal",
     "WeeklyHeroic": "Weekly Heroic Strike"
   },
   "Armory": {
@@ -33,14 +37,19 @@
     "YourItems": "Your Items"
   },
   "Browsercheck": {
-    "": ""
+    "Steam": "It looks like this page is loaded in Steam's browser. Due to its limited features and resources, it may unexpectedly or intermittently fail to run DIM. We cannot provide support for it.",
+    "Unsupported": "The DIM team does not support using this browser. Some or all DIM features may not work."
   },
   "Bucket": {
-    "": "",
     "Armor": "Armor",
     "Class": "Subclass",
+    "General": "General",
     "Ghost": "Ghost",
+    "Inventory": "Inventory",
+    "Postmaster": "Postmaster",
+    "Progress": "Progress",
     "Reputation": "Reputation",
+    "Unknown": "Unknown",
     "Vault": "Vault",
     "Weapons": "Weapons"
   },
@@ -87,14 +96,14 @@
     "SoldBy": "Sold by: {{vendorName}}"
   },
   "Cooldown": {
-    "": ""
+    "Grenade": "Grenade cooldown: {{cooldown}}",
+    "Melee": "Melee cooldown: {{cooldown}}",
+    "Super": "Super cooldown: {{cooldown}}"
   },
   "Countdown": {
     "Days": "1 Day",
-    "Days_female": "",
-    "Days_female_plural": "",
-    "Days_male": "",
-    "Days_male_plural": "",
+    "Days_compact": "{{count}}d",
+    "Days_compact_plural": "{{count}}d",
     "Days_plural": "{{count}} Days"
   },
   "Csv": {
@@ -519,7 +528,8 @@
     "OptimizerSet": "Optimizer Set",
     "ProcessingSets": "Processing sets for\n{{character}} ({{remainingTime}}s)",
     "SaveAs": "Save as",
-    "Select": "",
+    "SelectMax": "- Max -",
+    "SelectMin": "- Min -",
     "ShareBuild": "Share Build Settings",
     "ShareBuildTitle": "Loadout Optimizer Settings",
     "ShareBuildWithNotes": "Share With Notes",
@@ -820,7 +830,6 @@
     "PostmasterFull": "The postmaster is full! ({{number}}/{{postmasterSize}})"
   },
   "Progress": {
-    "": "",
     "Bounties": "Bounties",
     "CrucibleRank": "Ranks",
     "Items": "Quest Items",
@@ -927,12 +936,28 @@
     "ApplyPerks": "Apply Perks",
     "GridStyle": "Display perks as a grid",
     "Insert": {
-      "": ""
+      "Ability": "Equip Ability",
+      "Aspect": "Insert Aspect",
+      "Fragment": "Insert Fragment",
+      "Mod": "Insert Mod",
+      "Ornament": "Apply Ornament",
+      "Projection": "Apply Ghost Projection",
+      "Shader": "Apply Shader",
+      "Super": "Equip Super",
+      "Transmat": "Apply Transmat Effect"
     },
     "ListStyle": "Display perks as a list",
     "Search": "Search names or descriptions",
     "Select": {
-      "": ""
+      "Ability": "Preview Ability",
+      "Aspect": "Preview Aspect",
+      "Fragment": "Preview Fragment",
+      "Mod": "Preview Mod",
+      "Ornament": "Preview Ornament",
+      "Projection": "Preview Ghost Projection",
+      "Shader": "Preview Shader",
+      "Super": "Preview Super",
+      "Transmat": "Preview Transmat Effect"
     },
     "SelectWishlistPerks": "Preview Wishlist Perks"
   },
@@ -956,8 +981,7 @@
     "Sunset": "Sunset",
     "Tier": "Tier {{tier}}",
     "TierProgress": "T{{tier}} {{statName}} ({{progress}}/60 for T{{nextTier}})\n",
-    "TierProgress_female": "",
-    "TierProgress_male": "",
+    "TierProgress_Max": "T{{tier}} {{statName}} ({{progress}}/300)\n",
     "Total": "Total"
   },
   "Storage": {


### PR DESCRIPTION
the number of bars at the top of the item popup is a little overboard.
this is too much and too busy, to consistently stick into items where it's not relevant.
![image](https://user-images.githubusercontent.com/68782081/174415483-61ccdeed-a29c-4eca-82ce-7e7b91299586.png)

the availability of the pattern info is appreciated/good but it's not a great ratio of space used to information communicated, and often the crafting info slowly becomes irrelevant as people have earned stuff.

this hides the pattern progress if the pattern is already earned and the item isn't attuneable, and compacts the multiple crafting-related progress bars.

attuneable but not a craftable type of item:
![image](https://user-images.githubusercontent.com/68782081/174415735-ead47a61-a9da-4356-a734-9a71e8a34ae7.png)

crafted item:
![image](https://user-images.githubusercontent.com/68782081/174415627-8c934ace-9ae6-42f1-b6f7-b62b6bbe9480.png)
(obviously, the pattern has been earned!)

attuneable but pattern already earned:
![image](https://user-images.githubusercontent.com/68782081/174415634-0103a1cc-4533-423e-ab26-eb493dbd046f.png)
(reminds user that the attunement isn't that important bc pattern is already earned)

attuned and already earned:
![image](https://user-images.githubusercontent.com/68782081/174415659-58d710e4-b0e1-43e5-af14-6d2bdbdaaf45.png)

not attuneable, but pattern not earned yet:
![image](https://user-images.githubusercontent.com/68782081/174415683-29bdadc9-b9f9-4fc6-8694-e82fe0ea1419.png)
(reminds user how many more attunements are needed)

attuneable and pattern not yet earned:
![image](https://user-images.githubusercontent.com/68782081/174415705-6ff94835-af03-425b-9185-c47a54ed767a.png)
![image](https://user-images.githubusercontent.com/68782081/174415720-b4617cf4-98da-45af-a9e1-8e0b57d9093e.png)
