### PR TITLE
More consistently use the correct valueStyle, and show a single decimal place where appropriate

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * When moving multiple items, DIM will transfer them in a more consistent order e.g. Kinetic weapons are moved before Heavy weapons, helmets before chest armor etc.
 * Fixed Organizer redundantly showing enhanced weapon intrinsics in multiple columns.
 * Vendor items once again show wish list thumbsup icons.
+* Weapon attunement and leveling progress now shows a single digit of additional precision.
 
 ## 7.21.0 <span class="changelog-date">(2022-06-12)</span>
 

--- a/src/app/dim-ui/WeaponCraftedInfo.tsx
+++ b/src/app/dim-ui/WeaponCraftedInfo.tsx
@@ -1,7 +1,6 @@
 import { t } from 'app/i18next-t';
 import { DimCrafted } from 'app/inventory/item-types';
-import { percent } from 'app/shell/formatters';
-import React from 'react';
+import { percentWithSingleDecimal } from 'app/shell/formatters';
 
 /**
  * A progress bar that shows weapon crafting info like the game does.
@@ -13,7 +12,7 @@ export function WeaponCraftedInfo({
   craftInfo: DimCrafted;
   className: string;
 }) {
-  const pct = percent(craftInfo.progress || 0);
+  const pct = percentWithSingleDecimal(craftInfo.progress || 0);
   const progressBarStyle = {
     width: pct,
   };

--- a/src/app/inventory/store/objectives.ts
+++ b/src/app/inventory/store/objectives.ts
@@ -53,12 +53,27 @@ export function buildObjectives(
   return objectives.filter((o) => o.visible && defs.Objective.get(o.objectiveHash));
 }
 
+export function getValueStyle(
+  objectiveDef: DestinyObjectiveDefinition | D1ObjectiveDefinition | undefined,
+  progress: number,
+  completionValue = 0
+) {
+  return objectiveDef
+    ? (progress < completionValue
+        ? 'inProgressValueStyle' in objectiveDef && objectiveDef.inProgressValueStyle
+        : 'completedValueStyle' in objectiveDef && objectiveDef.completedValueStyle) ??
+        objectiveDef.valueStyle
+    : DestinyUnlockValueUIStyle.Automatic;
+}
+
 export function isBooleanObjective(
   objectiveDef: DestinyObjectiveDefinition | D1ObjectiveDefinition,
+  progress: number | undefined,
   completionValue: number
 ) {
   return (
-    objectiveDef.valueStyle === DestinyUnlockValueUIStyle.Checkbox ||
+    getValueStyle(objectiveDef, progress ?? 0, completionValue) ===
+      DestinyUnlockValueUIStyle.Checkbox ||
     (completionValue === 1 &&
       (!('allowOvercompletion' in objectiveDef) ||
         !objectiveDef.allowOvercompletion ||

--- a/src/app/progress/Pursuit.tsx
+++ b/src/app/progress/Pursuit.tsx
@@ -9,7 +9,6 @@ import { searchFilterSelector } from 'app/search/search-filter';
 import { percent } from 'app/shell/formatters';
 import { RootState } from 'app/store/types';
 import clsx from 'clsx';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { ObjectiveValue } from './Objective';
 import PursuitItem from './PursuitItem';
@@ -44,7 +43,7 @@ export default function Pursuit({
   const isBoolean =
     firstObjective &&
     firstObjectiveDef &&
-    isBooleanObjective(firstObjectiveDef, firstObjective.completionValue);
+    isBooleanObjective(firstObjectiveDef, firstObjective.progress, firstObjective.completionValue);
   const showObjectiveDetail = objectives.length === 1 && !isBoolean;
 
   const showObjectiveProgress = objectives.length > 1 || (objectives.length === 1 && !isBoolean);

--- a/src/app/progress/PursuitItem.tsx
+++ b/src/app/progress/PursuitItem.tsx
@@ -29,7 +29,7 @@ function PursuitItem(
   // Either there's a counter progress bar, or multiple checkboxes
   const showProgressBoolean = (objectives: DestinyObjectiveProgress[]) => {
     const numBooleans = count(objectives, (o) =>
-      isBooleanObjective(defs.Objective.get(o.objectiveHash), o.completionValue)
+      isBooleanObjective(defs.Objective.get(o.objectiveHash), o.progress, o.completionValue)
     );
     return numBooleans > 1 || objectives.length !== numBooleans;
   };

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -2,6 +2,7 @@ import { trackTriumph } from 'app/dim-api/basic-actions';
 import { trackedTriumphsSelector } from 'app/dim-api/selectors';
 import RichDestinyText from 'app/dim-ui/RichDestinyText';
 import { t } from 'app/i18next-t';
+import { isBooleanObjective } from 'app/inventory/store/objectives';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { Reward } from 'app/progress/Reward';
 import { percent } from 'app/shell/formatters';
@@ -12,7 +13,6 @@ import {
   DestinyRecordComponent,
   DestinyRecordDefinition,
   DestinyRecordState,
-  DestinyUnlockValueUIStyle,
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import catalystIcons from 'data/d2/catalyst-triumph-icons.json';
@@ -153,11 +153,10 @@ export default function Record({
     objectives &&
     ((!obscured && objectives.length > 1) ||
       (objectives.length === 1 &&
-        !(
-          defs.Objective.get(objectives[0].objectiveHash).valueStyle ===
-            DestinyUnlockValueUIStyle.Checkbox ||
-          (objectives[0].completionValue === 1 &&
-            !defs.Objective.get(objectives[0].objectiveHash).allowOvercompletion)
+        !isBooleanObjective(
+          defs.Objective.get(objectives[0].objectiveHash),
+          objectives[0].progress ?? 0,
+          objectives[0].completionValue
         )));
 
   // TODO: show track badge greyed out / on hover

--- a/src/app/shell/formatters.ts
+++ b/src/app/shell/formatters.ts
@@ -6,6 +6,13 @@ export function percent(val: number): string {
 }
 
 /**
+ * Given a value 0-1, returns a string describing it as a percentage from 0-100
+ */
+export function percentWithSingleDecimal(val: number): string {
+  return `${Math.min(100, Math.floor(1000 * val) / 10).toLocaleString()}%`;
+}
+
+/**
  * Given a value on (or outside) a 0-100 scale, returns a css color key and value for a react `style` attribute
  */
 export function getColor(value: number, property = 'background-color') {


### PR DESCRIPTION
DIM has always shown a little extra info besides what's shown in game. Since the attunement/leveling objectives are out of 1000, not 100, we can show an extra decimal place:

<img width="344" alt="Screen Shot 2022-06-17 at 11 18 37 PM" src="https://user-images.githubusercontent.com/313208/174425645-047a3446-6500-448c-9477-f9af25e0e61d.png">
<img width="342" alt="Screen Shot 2022-06-17 at 11 18 58 PM" src="https://user-images.githubusercontent.com/313208/174425646-fd1f39df-283b-443b-8204-6309b95d48bd.png">

I also cleaned up our use of `valueStyle` since the old one is deprecated.