### PR TITLE
Removed WebKit bug 166879 workaround

### DIFF
--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -96,26 +96,29 @@ function loadManifestRemote(version: string, path: string): ThunkResult<object> 
       const manifest = await (response.ok ? response.json() : Promise.reject(response));
 
       // We intentionally don't wait on this promise
-      async () => {
-        try {
-          await set(idbKey, manifest);
-          infoLog('manifest', `Successfully stored manifest file.`);
-          localStorage.setItem(localStorageKey, version);
-        } catch (e) {
-          errorLog('manifest', 'Error saving manifest file', e);
-          showNotification({
-            title: t('Help.NoStorage'),
-            body: t('Help.NoStorageMessage'),
-            type: 'error',
-          });
-        }
-      };
+      saveManifestToIndexedDB(manifest, version);
 
       return manifest;
     } finally {
       dispatch(loadingEnd(t('Manifest.Download')));
     }
   };
+}
+
+// This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
+async function saveManifestToIndexedDB(typedArray: object, version: string) {
+  try {
+    await set(idbKey, typedArray);
+    infoLog('manifest', `Successfully stored manifest file.`);
+    localStorage.setItem(localStorageKey, version);
+  } catch (e) {
+    errorLog('manifest', 'Error saving manifest file', e);
+    showNotification({
+      title: t('Help.NoStorage'),
+      body: t('Help.NoStorageMessage'),
+      type: 'error',
+    });
+  }
 }
 
 function deleteManifestFile() {

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -105,7 +105,6 @@ function loadManifestRemote(version: string, path: string): ThunkResult<object> 
   };
 }
 
-// This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
 async function saveManifestToIndexedDB(typedArray: object, version: string) {
   try {
     await set(idbKey, typedArray);

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -96,29 +96,26 @@ function loadManifestRemote(version: string, path: string): ThunkResult<object> 
       const manifest = await (response.ok ? response.json() : Promise.reject(response));
 
       // We intentionally don't wait on this promise
-      saveManifestToIndexedDB(manifest, version);
+      async () => {
+        try {
+          await set(idbKey, manifest);
+          infoLog('manifest', `Successfully stored manifest file.`);
+          localStorage.setItem(localStorageKey, version);
+        } catch (e) {
+          errorLog('manifest', 'Error saving manifest file', e);
+          showNotification({
+            title: t('Help.NoStorage'),
+            body: t('Help.NoStorageMessage'),
+            type: 'error',
+          });
+        }
+      };
 
       return manifest;
     } finally {
       dispatch(loadingEnd(t('Manifest.Download')));
     }
   };
-}
-
-// This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
-async function saveManifestToIndexedDB(typedArray: object, version: string) {
-  try {
-    await set(idbKey, typedArray);
-    infoLog('manifest', `Successfully stored manifest file.`);
-    localStorage.setItem(localStorageKey, version);
-  } catch (e) {
-    errorLog('manifest', 'Error saving manifest file', e);
-    showNotification({
-      title: t('Help.NoStorage'),
-      body: t('Help.NoStorageMessage'),
-      type: 'error',
-    });
-  }
 }
 
 function deleteManifestFile() {

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -106,7 +106,6 @@ export function getManifest(tableAllowList: string[]): ThunkResult<AllDestinyMan
   return getManifestAction(tableAllowList);
 }
 
-// This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
 function doGetManifest(tableAllowList: string[]): ThunkResult<AllDestinyManifestComponents> {
   return async (dispatch) => {
     dispatch(loadingStart(t('Manifest.Load')));
@@ -258,7 +257,6 @@ export async function downloadManifestComponents(
   return manifest as AllDestinyManifestComponents;
 }
 
-// This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
 async function saveManifestToIndexedDB(
   typedArray: object,
   version: string,

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -99,54 +99,51 @@ export const warnMissingDefinition = _.debounce(
 
 const getManifestAction = _.once(
   (tableAllowList: string[]): ThunkResult<AllDestinyManifestComponents> =>
-    dedupePromise((dispatch) => dispatch(doGetManifest(tableAllowList)))
+    dedupePromise((dispatch) =>
+      dispatch(async () => {
+        dispatch(loadingStart(t('Manifest.Load')));
+        const stopTimer = timer('Load manifest');
+        try {
+          const manifest = await dispatch(loadManifest(tableAllowList));
+          if (!manifest.DestinyVendorDefinition) {
+            throw new Error('Manifest corrupted, please reload');
+          }
+          return manifest;
+        } catch (e) {
+          let message = e.message || e;
+
+          if (e instanceof TypeError || e.status === -1) {
+            message = navigator.onLine
+              ? t('BungieService.NotConnectedOrBlocked')
+              : t('BungieService.NotConnected');
+          } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
+            message = t('BungieService.Difficulties');
+          } else if (e.status < 200 || e.status >= 400) {
+            message = t('BungieService.NetworkError', {
+              status: e.status,
+              statusText: e.statusText,
+            });
+          } else {
+            // Something may be wrong with the manifest
+            await deleteManifestFile();
+          }
+
+          const statusText = t('Manifest.Error', { error: message });
+          errorLog('manifest', 'Manifest loading error', { error: e }, e);
+          reportException('manifest load', e);
+          const error = new Error(statusText);
+          error.name = 'ManifestError';
+          throw error;
+        } finally {
+          dispatch(loadingEnd(t('Manifest.Load')));
+          stopTimer();
+        }
+      })
+    )
 );
 
 export function getManifest(tableAllowList: string[]): ThunkResult<AllDestinyManifestComponents> {
   return getManifestAction(tableAllowList);
-}
-
-// This is not an anonymous arrow function inside getManifest because of https://bugs.webkit.org/show_bug.cgi?id=166879
-function doGetManifest(tableAllowList: string[]): ThunkResult<AllDestinyManifestComponents> {
-  return async (dispatch) => {
-    dispatch(loadingStart(t('Manifest.Load')));
-    const stopTimer = timer('Load manifest');
-    try {
-      const manifest = await dispatch(loadManifest(tableAllowList));
-      if (!manifest.DestinyVendorDefinition) {
-        throw new Error('Manifest corrupted, please reload');
-      }
-      return manifest;
-    } catch (e) {
-      let message = e.message || e;
-
-      if (e instanceof TypeError || e.status === -1) {
-        message = navigator.onLine
-          ? t('BungieService.NotConnectedOrBlocked')
-          : t('BungieService.NotConnected');
-      } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
-        message = t('BungieService.Difficulties');
-      } else if (e.status < 200 || e.status >= 400) {
-        message = t('BungieService.NetworkError', {
-          status: e.status,
-          statusText: e.statusText,
-        });
-      } else {
-        // Something may be wrong with the manifest
-        await deleteManifestFile();
-      }
-
-      const statusText = t('Manifest.Error', { error: message });
-      errorLog('manifest', 'Manifest loading error', { error: e }, e);
-      reportException('manifest load', e);
-      const error = new Error(statusText);
-      error.name = 'ManifestError';
-      throw error;
-    } finally {
-      dispatch(loadingEnd(t('Manifest.Load')));
-      stopTimer();
-    }
-  };
 }
 
 function loadManifest(tableAllowList: string[]): ThunkResult<AllDestinyManifestComponents> {
@@ -199,7 +196,21 @@ function loadManifestRemote(
       const manifest = await downloadManifestComponents(components, tableAllowList);
 
       // We intentionally don't wait on this promise
-      saveManifestToIndexedDB(manifest, version, tableAllowList);
+      async () => {
+        try {
+          await set(idbKey, manifest);
+          infoLog('manifest', `Successfully stored manifest file.`);
+          localStorage.setItem(localStorageKey, version);
+          localStorage.setItem(localStorageKey + '-whitelist', JSON.stringify(tableAllowList));
+        } catch (e) {
+          errorLog('manifest', 'Error saving manifest file', e);
+          showNotification({
+            title: t('Help.NoStorage'),
+            body: t('Help.NoStorageMessage'),
+            type: 'error',
+          });
+        }
+      };
       return manifest;
     } finally {
       dispatch(loadingEnd(t('Manifest.Download')));
@@ -256,27 +267,6 @@ export async function downloadManifestComponents(
   await Promise.all(futures);
 
   return manifest as AllDestinyManifestComponents;
-}
-
-// This is not an anonymous arrow function inside loadManifestRemote because of https://bugs.webkit.org/show_bug.cgi?id=166879
-async function saveManifestToIndexedDB(
-  typedArray: object,
-  version: string,
-  tableAllowList: string[]
-) {
-  try {
-    await set(idbKey, typedArray);
-    infoLog('manifest', `Successfully stored manifest file.`);
-    localStorage.setItem(localStorageKey, version);
-    localStorage.setItem(localStorageKey + '-whitelist', JSON.stringify(tableAllowList));
-  } catch (e) {
-    errorLog('manifest', 'Error saving manifest file', e);
-    showNotification({
-      title: t('Help.NoStorage'),
-      body: t('Help.NoStorageMessage'),
-      type: 'error',
-    });
-  }
 }
 
 function deleteManifestFile() {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=166879
As the issue states, this bug was fixed back in 2017 and safari v10, which is no longer supported by DIM. This re-adds the anonymous arrow functions instead of unneeded function declarations.
Fixes #7316