### PR TITLE
Slightly reduce the size of the window where the header links disappear

### DIFF
--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -130,7 +130,7 @@ $header-height: 44px;
   @include phone-portrait {
     display: none;
   }
-  @media (max-width: 1280px) {
+  @media (max-width: 1200px) {
     display: none;
   }
 


### PR DESCRIPTION
Now that "Loadout Optimizer" has been replaced with just "Loadouts" we can relax the breakpoint for hiding the links a bit.

Fixes #8438