### PR TITLE
fix vertical alignment (confirm-button), spacing (dim-button)

### DIFF
--- a/src/app/dim-ui/ConfirmButton.m.scss
+++ b/src/app/dim-ui/ConfirmButton.m.scss
@@ -16,8 +16,8 @@
     overflow: hidden;
   }
 
-  // applies to just the "confirm" message container
-  & > div:nth-child(2) {
+  // applies to both icon and "confirm" message container
+  & > div {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -342,6 +342,10 @@ select {
   &:focus:not(:focus-visible) {
     border-color: transparent;
   }
+
+  & .app-icon {
+    margin-right: 4px;
+  }
 }
 
 a.dim-button {


### PR DESCRIPTION
Not so evident, anyways the confirm icon was just a bit uncentered, I also added a small margin on the right of the app-icon

![image](https://user-images.githubusercontent.com/6225939/175807398-bbe4a55e-2ca0-44ff-b3d6-f536b15ba3d1.png)
