### PR TITLE
Re-trigger refresh after a completed drag, if dragging interrupted it

### DIFF
--- a/src/app/dim-ui/AutoRefresh.tsx
+++ b/src/app/dim-ui/AutoRefresh.tsx
@@ -59,12 +59,13 @@ function useAutoRefresh() {
       const hasActivePromises = loadingTracker.active();
       const isVisible = !document.hidden;
       const isOnline = navigator.onLine;
+      const currentlyDragging = isDragging$.getCurrentValue();
 
       if (
         !hasActivePromises &&
         isVisible &&
         isOnline &&
-        !isDragging$.getCurrentValue() &&
+        !currentlyDragging &&
         // Don't auto reload on the optimizer page, it makes it recompute all the time
         !onOptimizerPage
       ) {
@@ -74,6 +75,15 @@ function useAutoRefresh() {
         // the loading tracker goes back to inactive.
         const unsubscribe = loadingTracker.active$.subscribe((active) => {
           if (!active) {
+            unsubscribe();
+            // Trigger the event bus which will run the most recent version of this handler
+            triggerTryRefresh();
+          }
+        });
+      } else if (currentlyDragging) {
+        // Same deal as above, but waiting for the drag to end
+        const unsubscribe = isDragging$.subscribe((dragging) => {
+          if (!dragging) {
             unsubscribe();
             // Trigger the event bus which will run the most recent version of this handler
             triggerTryRefresh();


### PR DESCRIPTION
Fixes a little hole in auto refresh - if we canceled refresh because you were dragging, trigger it when the drag is over.