### PR TITLE
Don't misidentify deprecated combat style mods as being a valid plug option

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed a crash when trying to assign deprecated Combat Style mods.
+
 ## 7.23.1 <span class="changelog-date">(2022-06-27)</span>
 
 * Fix missing icons in the subclass and mod menus.


### PR DESCRIPTION
This certainly is a way to fix #8524. There might be a better option, but this approach at least works for both LO and set mod assignment.