### PR TITLE
Use cut-down version of Fontawesome fonts

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -158,6 +158,7 @@ module.exports = (env) => {
         {
           // Optimize SVGs - mostly for destiny-icons.
           test: /\.svg$/,
+          exclude: /data\/webfonts\//,
           type: 'asset',
           generator: {
             dataUrl: (content) => svgToMiniDataURI(content.toString()),
@@ -210,7 +211,7 @@ module.exports = (env) => {
               },
             },
             'postcss-loader',
-            'sass-loader',
+            { loader: 'sass-loader', options: { sassOptions: { quietDeps: true } } },
           ],
         },
         // Regular *.scss are global
@@ -226,7 +227,7 @@ module.exports = (env) => {
               },
             },
             'postcss-loader',
-            'sass-loader',
+            { loader: 'sass-loader', options: { sassOptions: { quietDeps: true } } },
           ],
         },
         {
@@ -264,6 +265,11 @@ module.exports = (env) => {
           generator: {
             filename: '[name]-[contenthash:8][ext]',
           },
+        },
+        {
+          // Force webfonts to be separate files instead of having small ones inlined into CSS
+          test: /data\/webfonts\//,
+          type: 'asset/resource',
         },
         {
           type: 'javascript/auto',
@@ -380,7 +386,6 @@ module.exports = (env) => {
           { from: `./icons/${env.name}/` },
           { from: `./icons/splash`, to: 'splash/' },
           { from: './src/safari-pinned-tab.svg' },
-          { from: './src/data/webfonts', to: 'static' },
         ],
       }),
 
@@ -499,7 +504,7 @@ module.exports = (env) => {
 
       // Generate a service worker
       new InjectManifest({
-        include: [/\.(html|js|css|woff2|json|wasm)$/, /static\/.*\.(png|gif|jpg|svg)$/],
+        include: [/\.(html|js|css|woff2|json|wasm)$/, /static\/(?!fa-).*\.(png|gif|jpg|svg)$/],
         exclude: [
           /version\.json/,
           /extension-dist/,
@@ -523,6 +528,7 @@ module.exports = (env) => {
           filename: '[path][base].br',
           algorithm: 'brotliCompress',
           exclude: /data\/d1\/manifests/,
+          // Skip .woff and .woff2, they're already well compressed
           test: /\.js$|\.css$|\.html$|\.json$|\.map$|\.ttf$|\.eot$|\.svg$|\.wasm$/,
           compressionOptions: {
             params: {

--- a/src/app/shell/icons/AppIcon.scss
+++ b/src/app/shell/icons/AppIcon.scss
@@ -1,0 +1,22 @@
+$fa-font-path: 'data/webfonts';
+
+/* Importing FontAwesome SCSS from node modules */
+
+// We import specific files from the main "fontawesome" module to slim things down
+@import '@fortawesome/fontawesome-free/scss/variables';
+@import '@fortawesome/fontawesome-free/scss/mixins';
+@import '@fortawesome/fontawesome-free/scss/core';
+//@import '@fortawesome/fontawesome-free/scss/larger';
+//@import '@fortawesome/fontawesome-free/scss/fixed-width';
+//@import '@fortawesome/fontawesome-free/scss/list';
+//@import '@fortawesome/fontawesome-free/scss/bordered-pulled';
+@import '@fortawesome/fontawesome-free/scss/animated';
+//@import '@fortawesome/fontawesome-free/scss/rotated-flipped';
+//@import '@fortawesome/fontawesome-free/scss/stacked';
+@import '@fortawesome/fontawesome-free/scss/icons';
+//@import '@fortawesome/fontawesome-free/scss/screen-reader';
+
+// And this imports the actual fonts
+@import '@fortawesome/fontawesome-free/scss/solid';
+@import '@fortawesome/fontawesome-free/scss/regular';
+@import '@fortawesome/fontawesome-free/scss/brands';

--- a/src/app/shell/icons/AppIcon.tsx
+++ b/src/app/shell/icons/AppIcon.tsx
@@ -1,8 +1,8 @@
-import '@fortawesome/fontawesome-free/css/all.css';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
 import React from 'react';
+import './AppIcon.scss';
 
 function AppIcon({
   icon,


### PR DESCRIPTION
Some while back we set up a tool to subset the Fontawesome fonts to only include the symbols we use. However, we never switched to actually using those fonts. This finishes that up by switching to the Sass version of Fontawesome, cutting things down to just what we use, and forcing fonts to not be inlined into our CSS.