### PR TITLE
Move tags down 1px

### DIFF
--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -101,7 +101,7 @@
 .icons {
   position: absolute;
   left: $item-border-width + 2px;
-  top: calc(var(--item-size) - #{$badge-height} - #{$item-border-width});
+  top: calc(var(--item-size) - #{$badge-height});
   display: flex;
   flex-direction: row;
 }


### PR DESCRIPTION
This had just started bugging me, the icons felt a touch too high.

Before:
<img width="572" alt="Screen Shot 2022-06-28 at 10 26 23 PM" src="https://user-images.githubusercontent.com/313208/176358356-a8946221-1c2a-4d83-84e7-180c8bc5f81d.png">

After:
<img width="581" alt="Screen Shot 2022-06-28 at 10 26 16 PM" src="https://user-images.githubusercontent.com/313208/176358349-2fe3084b-a891-4fbb-8d86-f97469a81e53.png">
