### PR TITLE
move from wss to ws (stream deck local)

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -42,7 +42,7 @@ module.exports = function csp(env) {
       // Clarity
       'https://ice-mourne.github.io',
       // Stream Deck Plugin
-      'wss://localhost:9119',
+      'ws://localhost:9119',
     ],
     imgSrc: [
       SELF,

--- a/src/app/stream-deck/async-module.ts
+++ b/src/app/stream-deck/async-module.ts
@@ -205,7 +205,7 @@ function startStreamDeckConnection(): ThunkResult {
       }
 
       // try to connect to the stream deck local instance
-      streamDeckWebSocket = new WebSocket('wss://localhost:9119', clientIdentifier());
+      streamDeckWebSocket = new WebSocket('ws://localhost:9119', clientIdentifier());
 
       streamDeckWebSocket.onopen = function () {
         dispatch(streamDeckConnected());


### PR DESCRIPTION
Testing the Stream Deck feature on https://beta.destinyitemmanager.com/ made me discover that it's impossible to connect using a `wss`  from a site (that is not `https://localhost` after accepting the self signed policy) to a WebSocket server that uses self signed certificates.

So now we've 2 possible solutions:
- remove the self signed certs from the plugin server and use only a `ws` server since we are running on localhost (**this pr**) 
- use a valid domain (like streamdeck.destinyitemmanager.com) that points to `127.0.0.1` and its generated SSL certificates

LMKWYT