### PR TITLE
Keep general items during "Move Other Items Away"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * If you have a title equipped on your character, it will replace your character's race in the character headers.
 * Fixed a crash when trying to assign deprecated Combat Style mods.
+* The "Move other items away" loadout toggle no longer clears ghosts, ships, or sparrows.
 
 ## 7.23.2 <span class="changelog-date">(2022-06-29)</span>
 

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -726,7 +726,15 @@ function clearSpaceAfterLoadout(
 
   for (const [bucketId, loadoutItems] of Object.entries(itemsByType)) {
     // Exclude a handful of buckets from being cleared out
-    if ([BucketHashes.Consumables, BucketHashes.Materials].includes(loadoutItems[0].bucket.hash)) {
+    if (
+      [
+        BucketHashes.Consumables,
+        BucketHashes.Materials,
+        BucketHashes.Ghost,
+        BucketHashes.Ships,
+        BucketHashes.Vehicle,
+      ].includes(loadoutItems[0].bucket.hash)
+    ) {
       continue;
     }
     let numUnequippedLoadoutItems = 0;


### PR DESCRIPTION
When a user applies a loadout with the "Move Other Items Away: toggle applied, it will no longer move Ghosts, Sparrows, or Ships.

Issue: https://github.com/DestinyItemManager/DIM/issues/8498