### PR TITLE
Keep community perk text in line with the rest of the tooltip

### DIFF
--- a/src/app/item-popup/PlugTooltip.m.scss
+++ b/src/app/item-popup/PlugTooltip.m.scss
@@ -16,4 +16,5 @@
   margin-top: 2px;
   border-left: 2px solid $communityBlue;
   padding-left: 6px;
+  margin-left: -8px;
 }


### PR DESCRIPTION
I've been a bit annoyed by the community perk descriptions being indented in the tooltops. Not saying this is the best fix, but:

Before:
<img width="327" alt="Screen Shot 2022-07-02 at 3 19 27 PM" src="https://user-images.githubusercontent.com/313208/177017675-f11574d0-6e27-437f-b710-9deb26d57fc1.png">

After:
<img width="338" alt="Screen Shot 2022-07-02 at 3 19 03 PM" src="https://user-images.githubusercontent.com/313208/177017674-7af7fd4b-59bc-445f-a6f5-c3d066ed4f72.png">
