### PR TITLE
Minor fixes for Loadout view alignment

### DIFF
--- a/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss
+++ b/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss
@@ -4,6 +4,7 @@
   width: var(--item-size);
   height: calc(var(--item-size) + #{$badge-height} - #{$item-border-width});
   border: 1px solid #ddd;
+  box-sizing: border-box;
 }
 
 .placeholder {

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.m.scss
@@ -45,7 +45,7 @@
   composes: sub-bucket from global;
   width: 100%;
   padding: 0;
-  --item-icon-size: calc(0.5 * var(--item-size) - 2px);
+  --item-icon-size: calc(0.5 * var(--item-size) - 1px);
   > * {
     --item-size: var(--item-icon-size);
   }


### PR DESCRIPTION
Fixes two visual/alignment issues

* `BucketPlaceholder` was a couple pixels taller than `DraggableInventoryItem` (#7941) due to box sizing not taking border into account
* `FashionMods` was several pixels narrower than the `ItemBucket` above it (unticketed AFAIK) again I think due to border calculation

### Before
<img width="987" alt="Screen Shot 2022-07-07 at 9 27 30 PM" src="https://user-images.githubusercontent.com/407639/177903271-974f1da4-c5ef-4e38-93a4-f9a522f12375.png">


### After
<img width="987" alt="Screen Shot 2022-07-07 at 10 12 43 PM" src="https://user-images.githubusercontent.com/407639/177903305-0a69630d-15db-4396-a899-84bc3ee94bfd.png">


Closes https://github.com/DestinyItemManager/DIM/issues/7941 (hope it's okay to take this @bhollis, it was marked assigned to you but also as a good first issue!)
