### PR TITLE
Search boxes should not render autocomplete results off screen

### DIFF
--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -223,6 +223,7 @@ function SearchBar(
 
   const [liveQueryLive, setLiveQuery] = useState('');
   const [filterHelpOpen, setFilterHelpOpen] = useState(false);
+  const [menuMaxHeight, setMenuMaxHeight] = useState<undefined | number>();
   const inputElement = useRef<HTMLInputElement>(null);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -336,6 +337,17 @@ function SearchBar(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQueryVersion]);
 
+  // Determine a maximum height for the results menu
+  useEffect(() => {
+    if (inputElement.current) {
+      const { y, height } = inputElement.current.getBoundingClientRect();
+      const { height: viewportHeight } = window.visualViewport;
+
+      // constrain to pixels remaining in viewport minus offset minus 10px for padding
+      setMenuMaxHeight(viewportHeight - y - height - 10);
+    }
+  }, [isOpen]);
+
   const deleteSearch = useCallback(
     (e: React.MouseEvent, item: SearchItem) => {
       e.stopPropagation();
@@ -401,7 +413,13 @@ function SearchBar(
 
   const autocompleteMenu = useMemo(
     () => (
-      <ul {...getMenuProps()} className={styles.menu}>
+      <ul
+        {...getMenuProps()}
+        className={styles.menu}
+        style={{
+          maxHeight: menuMaxHeight,
+        }}
+      >
         {isOpen &&
           items.map((item, index) => (
             <li
@@ -431,6 +449,7 @@ function SearchBar(
       isPhonePortrait,
       items,
       tabAutocompleteItem,
+      menuMaxHeight,
     ]
   );
 

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -339,7 +339,7 @@ function SearchBar(
 
   // Determine a maximum height for the results menu
   useEffect(() => {
-    if (inputElement.current) {
+    if (inputElement.current && window.visualViewport) {
       const { y, height } = inputElement.current.getBoundingClientRect();
       const { height: viewportHeight } = window.visualViewport;
 

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -342,9 +342,12 @@ function SearchBar(
     if (inputElement.current && window.visualViewport) {
       const { y, height } = inputElement.current.getBoundingClientRect();
       const { height: viewportHeight } = window.visualViewport;
+      // pixels remaining in viewport minus offset minus 10px for padding
+      const pxAvailable = viewportHeight - y - height - 10;
+      const resultItemHeight = 30;
 
-      // constrain to pixels remaining in viewport minus offset minus 10px for padding
-      setMenuMaxHeight(viewportHeight - y - height - 10);
+      // constrain to size that would allow only whole items to be seen
+      setMenuMaxHeight(Math.floor(pxAvailable / resultItemHeight) * resultItemHeight);
     }
   }, [isOpen]);
 


### PR DESCRIPTION
Closes #5698

When a Downshift combobox renders its results menu / combobox, it should check how much room on the screen exists to render results and not render a greater height than the remaining screen real estate.

This is done through the use of the input element ref, `getBoundingClientRect` and the [Visual Viewport API](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API). This approach works when the window is resized so long as the combobox is closed and re-opened (it does not limit the height responsively as the window is resized). 

### Screenshots

#### Standard suggestions list with no height cap
![75D0E437-0143-4BF0-BA6F-2A1C7FE4E2D6](https://user-images.githubusercontent.com/407639/178055263-65ee6c23-d663-4ad0-ae9c-01f1c6ad2955.png)

#### ItemPickerContainer with taller height than max results
![094B1112-1ED0-4297-B118-582F34FDE6CB](https://user-images.githubusercontent.com/407639/178055411-ee71840b-127f-45f6-9072-534f94550ec0.png)

#### ItemPickerContainer with very short height
![9A37DAD1-C2A4-4D3F-9216-1D05D2B59B6A](https://user-images.githubusercontent.com/407639/178055450-e07d6a61-4d01-4061-9a8f-53e8f6693a8d.png)

#### InfusionFinder also correctly limits combobox height
![D7755FDE-AD9F-4E53-98DC-5110C20768AD](https://user-images.githubusercontent.com/407639/178055680-d48dcc58-fd25-44f9-a091-b53de3539e1c.png)

#### Height-constrained Downshift results menu is still keyboard accessible
![80589704-2631-4855-AC88-0C92436ECB15](https://user-images.githubusercontent.com/407639/178055519-30cfb9df-fb7d-4bf8-8232-c30f7f9eebd3.png)

https://user-images.githubusercontent.com/407639/178055780-dad0b571-eac1-44e7-9908-9e5e572e786f.mov



This is one of my first issues, so I should note that I have not:
* Tested this on older browsers
  * The Visual Viewport API is not supported in IE and Safari < 13. I couldn't find any documented browser support practices, I'm happy to include fallbacks if it's determined that we need them
* Tested this on mobile