### PR TITLE
Revert "Upgrade body-scroll-lock"

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "@textcomplete/core": "^0.1.9",
     "@textcomplete/textarea": "^0.1.9",
     "@use-gesture/react": "^10.2.6",
-    "body-scroll-lock": "^4.0.0-beta.0",
+    "body-scroll-lock": "^3.1.5",
     "bungie-api-ts": "^4.12.0",
     "caniuse-lite": ">=1.0.30000843",
     "clsx": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,10 +2951,10 @@ body-parser@1.20.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-scroll-lock@^4.0.0-beta.0:
-  version "4.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
-  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
+body-scroll-lock@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
+  integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==
 
 bonjour-service@^1.0.11:
   version "1.0.13"


### PR DESCRIPTION
This reverts commit 429b0591c753a7a5e860d6910a6ef399b464afc6.

I think this causes a padding on the bottom of rounded-corner iPhones. Can't wait for iOS 16 where this won't be necessary anymore.