### PR TITLE
Fix Armory showing wish list thumbs, collections showing unrelated wish list notes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Hid Solstice armor rerolling sockets from Loadout Optimizer too.
+* Fixed Armory perk grid showing arbitrary wish list thumbs, and fixed Collections offering wish list notes for unrelated weapons.
 
 ## 7.27.0 <span class="changelog-date">(2022-07-24)</span>
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -113,6 +113,11 @@ export interface DimItem {
   taggable: boolean;
   /** Can this be compared with other items? */
   comparable: boolean;
+  /**
+   * Can this item receive wish list thumbs up icons?
+   * True for inventory and vendor items, false for really fake items.
+   */
+  wishListEnabled: boolean;
   /** Should we hide the percentage display? */
   hidePercentage: boolean;
   /** Can this be infused? */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -336,6 +336,7 @@ function makeItem(
     hidePercentage: false,
     taggable: false,
     comparable: false,
+    wishListEnabled: false,
     power: item.primaryStat?.value ?? 0,
     index: '',
     infusable: false,

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -160,9 +160,10 @@ export function makeFakeItem(
   quantity = 1,
   mergedCollectibles?: {
     [hash: number]: DestinyCollectibleComponent;
-  }
+  },
+  allowWishList?: boolean
 ): DimItem | null {
-  return makeItem(
+  const item = makeItem(
     defs,
     buckets,
     itemComponents,
@@ -185,6 +186,11 @@ export function makeFakeItem(
     undefined,
     mergedCollectibles
   );
+
+  if (item && !allowWishList) {
+    item.wishListEnabled = false;
+  }
+  return item;
 }
 
 /**
@@ -549,6 +555,7 @@ export function makeItem(
     pursuit: null,
     taggable: false,
     comparable: false,
+    wishListEnabled: false,
     power: 0,
     index: '',
     infusable: false,
@@ -599,6 +606,8 @@ export function makeItem(
     errorLog('d2-stores', `Error building sockets for ${createdItem.name}`, item, itemDef, e);
     reportException('Sockets', e, { itemHash: item.itemHash });
   }
+
+  createdItem.wishListEnabled = Boolean(createdItem.bucket.inWeapons && createdItem.sockets);
 
   // A crafted weapon with an enhanced intrinsic and two enhanced traits is masterworked
   // https://github.com/Bungie-net/api/issues/1662

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -279,6 +279,7 @@ function makeFakePursuitItem(
     pursuit: null,
     taggable: false,
     comparable: false,
+    wishListEnabled: false,
     power: 0,
     index: hash.toString(),
     infusable: false,

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -160,7 +160,9 @@ export class VendorItem {
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
       this.key.toString(),
       vendorItemDef ? vendorItemDef.quantity : 1,
-      mergedCollectibles
+      mergedCollectibles,
+      // vendor items are wish list enabled!
+      true
     );
 
     if (this.item) {

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -35,7 +35,8 @@ export const wishListFunctionSelector = createSelector(
           wishlists &&
           item?.destinyVersion === 2 &&
           item.sockets &&
-          item.bucket.inWeapons
+          item.bucket.inWeapons &&
+          item.id !== '0'
         )
       ) {
         return undefined;

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -29,16 +29,7 @@ export const wishListFunctionSelector = createSelector(
     // Cache of inventory item id to roll. For this to work, make sure vendor/collections rolls have unique ids.
     const cache = new Map<string, InventoryWishListRoll | undefined>();
     return (item: DimItem) => {
-      if (
-        !(
-          $featureFlags.wishLists &&
-          wishlists &&
-          item?.destinyVersion === 2 &&
-          item.sockets &&
-          item.bucket.inWeapons &&
-          item.id !== '0'
-        )
-      ) {
+      if (!($featureFlags.wishLists && wishlists && item.wishListEnabled)) {
         return undefined;
       }
       if (cache.has(item.id)) {


### PR DESCRIPTION
The first weapon you open the armory sheet for from the inventory page ended up setting the wish list cache for id `'0'`, picking the first entry (which should match because the fake item has all perk options). This shows an arbitrary roll with thumbs up in the armory page. Clicking on any item in Records -> Collections would then offer wish list notes from that roll even if it's an entirely different weapon hash because all of them have the id `'0'` too.