### PR TITLE
Fix DIM storing numeric Settings properties as strings

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -176,10 +176,10 @@ export const dimApi = (
         ? {
             ...state,
             profileLoadedFromIndexedDb: true,
-            settings: {
+            settings: fixBadSettingsTypes({
               ...state.settings,
               ...action.payload.settings,
-            },
+            }),
             profiles: {
               ...state.profiles,
               ...action.payload.profiles,
@@ -205,10 +205,10 @@ export const dimApi = (
         profileLoaded: true,
         profileLoadedError: undefined,
         profileLastLoaded: Date.now(),
-        settings: {
+        settings: fixBadSettingsTypes({
           ...state.settings,
           ...profileResponse.settings,
-        },
+        }),
         itemHashTags: profileResponse.itemHashTags
           ? _.keyBy(profileResponse.itemHashTags, (t) => t.hash)
           : state.itemHashTags,
@@ -381,6 +381,26 @@ export const dimApi = (
       return state;
   }
 };
+
+/**
+ * DIM accidentally stored some integer settings as strings,
+ * so fix them up here.
+ */
+function fixBadSettingsTypes(settings: Settings) {
+  if (typeof settings.charCol === 'string') {
+    settings = { ...settings, charCol: parseInt(settings.charCol, 10) };
+  }
+  if (typeof settings.charColMobile === 'string') {
+    settings = { ...settings, charColMobile: parseInt(settings.charColMobile, 10) };
+  }
+  if (typeof settings.inventoryClearSpaces === 'string') {
+    settings = { ...settings, inventoryClearSpaces: parseInt(settings.inventoryClearSpaces, 10) };
+  }
+  if (typeof settings.itemSize === 'string') {
+    settings = { ...settings, itemSize: parseInt(settings.itemSize, 10) };
+  }
+  return settings;
+}
 
 function changeSetting<V extends keyof Settings>(state: DimApiState, prop: V, value: Settings[V]) {
   // Don't worry about changing settings to their current value

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -298,7 +298,7 @@ export default function SettingsPage() {
                     min="48"
                     max="66"
                     name="itemSize"
-                    onChange={onChange}
+                    onChange={onChangeNumeric}
                   />
                   {Math.max(48, settings.itemSize)}px
                   <button type="button" className="dim-button" onClick={resetItemSize}>
@@ -474,7 +474,7 @@ export default function SettingsPage() {
                   name="charColMobile"
                   value={settings.charColMobile}
                   options={charColOptions}
-                  onChange={onChange}
+                  onChange={onChangeNumeric}
                 />
                 <div className="fineprint">{t('Settings.InventoryColumnsMobileLine2')}</div>
               </div>
@@ -484,7 +484,7 @@ export default function SettingsPage() {
                 name="charCol"
                 value={settings.charCol}
                 options={charColOptions}
-                onChange={onChange}
+                onChange={onChangeNumeric}
               />
             )}
             <div className="setting">
@@ -509,7 +509,7 @@ export default function SettingsPage() {
               name="inventoryClearSpaces"
               value={settings.inventoryClearSpaces}
               options={numberOfSpacesOptions}
-              onChange={onChange}
+              onChange={onChangeNumeric}
             />
             <div className="setting">
               <label>{t('Settings.LoadoutSort')}</label>


### PR DESCRIPTION
Supersedes #8609. This wasn't really caught because most of it is just interpolated into CSS strings anyway.