### PR TITLE
Fix Remove other mods resetting in Any class loadouts...

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixed Armory perk grid showing arbitrary wish list thumbs, and fixed Collections offering wish list notes for unrelated weapons.
 * Collections items will now be recognized as craftable. Try the search filter `is:craftable -is:patternunlocked` on the Records page to list craftable weapons you still need to unlock the pattern for, and click the weapons to see your pattern progress.
+* Fixed the "Remove other mods" toggle in Loadouts resetting when saving the Loadout as "Any Class".
 
 ## 7.28.0 <span class="changelog-date">(2022-07-31)</span>
 

--- a/src/app/inventory-page/DesktopStores.tsx
+++ b/src/app/inventory-page/DesktopStores.tsx
@@ -9,7 +9,9 @@ import { useSetSetting } from 'app/settings/hooks';
 import { AppIcon, maximizeIcon, minimizeIcon } from 'app/shell/icons';
 import StoreStats from 'app/store-stats/StoreStats';
 import { useEventBusListener } from 'app/utils/hooks';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
+import { useMemo } from 'react';
 import StoreHeading from '../character-tile/StoreHeading';
 import D1ReputationSection from './D1ReputationSection';
 import styles from './DesktopStores.m.scss';
@@ -33,6 +35,20 @@ export default function DesktopStores({ stores, buckets, singleCharacter }: Prop
   const currentStore = getCurrentStore(stores);
   const setSetting = useSetSetting();
   useEventBusListener(locateItem$, itemPop);
+
+  // Hide the single character toggle for players with only one character
+  // unless they own items that cannot be used by their only character.
+  const singleCharacterHasEffect = useMemo(
+    () =>
+      stores.length > 2 ||
+      (currentStore &&
+        stores.some((s) =>
+          s.items.some(
+            (i) => i.classType !== DestinyClass.Unknown && i.classType !== currentStore.classType
+          )
+        )),
+    [stores, currentStore]
+  );
 
   if (!stores.length || !buckets || !vault || !currentStore) {
     return null;
@@ -62,7 +78,7 @@ export default function DesktopStores({ stores, buckets, singleCharacter }: Prop
             </div>
           ))}
           <div className={styles.buttons}>
-            {stores.length > 2 && (
+            {singleCharacterHasEffect && (
               <button
                 type="button"
                 className={styles.singleCharacterButton}

--- a/src/app/inventory-page/Stores.tsx
+++ b/src/app/inventory-page/Stores.tsx
@@ -1,7 +1,6 @@
 import { settingSelector } from 'app/dim-api/selectors';
 import { bucketsSelector, sortedStoresSelector } from 'app/inventory/selectors';
 import { useIsPhonePortrait } from 'app/shell/selectors';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import PhoneStores from '../inventory-page/PhoneStores';
 import DesktopStores from './DesktopStores';
@@ -12,8 +11,7 @@ import DesktopStores from './DesktopStores';
 export default function Stores() {
   const stores = useSelector(sortedStoresSelector);
   const buckets = useSelector(bucketsSelector);
-  const singleCharacterSetting = useSelector(settingSelector('singleCharacter'));
-  const singleCharacter = stores.length > 2 && singleCharacterSetting;
+  const singleCharacter = useSelector(settingSelector('singleCharacter'));
   const isPhonePortrait = useIsPhonePortrait();
   if (!stores.length || !buckets) {
     return null;

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -285,8 +285,11 @@ function filterLoadoutToAllowedItems(
 
     if (loadout.classType === DestinyClass.Unknown && loadout.parameters) {
       // Remove fashion and non-mod loadout parameters from Any Class loadouts
-      if (loadout.parameters.mods?.length) {
-        loadout.parameters = { mods: loadout.parameters.mods };
+      if (loadout.parameters.mods?.length || loadout.parameters.clearMods) {
+        loadout.parameters = {
+          mods: loadout.parameters.mods,
+          clearMods: loadout.parameters.clearMods,
+        };
       } else {
         delete loadout.parameters;
       }


### PR DESCRIPTION
And fix the single character mode not working as advertised when the user only has one character (description says "Items specific to other classes will be hidden entirely."). On Discord we agreed that the main inventory toggle should still be hidden when the player only has one character, but I thought it'd be cute to show it if the user happens to have e.g. exotics from other classes.

That could still be confusing, but when the user does click it, they'll hopefully see their vault change to exclude some items and hide the class separators, so maybe that's enough?