### PR TITLE
Fix Loadout Optimizer rendering old sets with new mods

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -444,7 +444,7 @@ export default memo(function LoadoutBuilder({
           <GeneratedSets
             sets={filteredSets}
             subclass={subclass}
-            lockedMods={processing ? emptyArray() : lockedMods}
+            lockedMods={result?.mods ?? emptyArray()}
             pinnedItems={pinnedItems}
             selectedStore={selectedStore}
             lbDispatch={lbDispatch}

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -38,6 +38,12 @@ interface ProcessState {
   resultStoreId: string;
   result: {
     sets: ArmorSet[];
+    /**
+     * The mods used to generate the sets above. The sets are
+     * guaranteed (modulo bugs in worker) to fit these mods, so
+     * set rendering must use this mods list to render sets.
+     */
+    mods: PluggableInventoryItemDefinition[];
     combos: number;
     processTime: number;
     statRangesFiltered?: StatRanges;
@@ -120,6 +126,7 @@ export function useProcess({
         processing: false,
         result: {
           sets: [],
+          mods: lockedMods,
           combos: 0,
           processTime: 0,
         },
@@ -198,6 +205,7 @@ export function useProcess({
           processing: false,
           result: {
             sets: hydratedSets,
+            mods: lockedMods,
             combos,
             processTime: performance.now() - processStart,
             statRangesFiltered,


### PR DESCRIPTION
So we fixed the algorithmic issue behind the LO mod assignment crashes in #8476, and now #8615 was still reporting a crash caused by trying to render a combat style mod in a blue class item. Turns out that `useProcess` uses `useEffect` internally, which isn't quite synchronous -- it's possible for `LoadoutBuilder` to call `useProcess` with new mods, without getting the update from `useProcess` that LO is now calculating stuff again (`processing` flag) and we shouldn't try to render any mods in the sets.

This approach remembers the mods that the list of sets was generated with so that we never try to render something LO didn't verify was possible. I genuinely like the new behavior a lot better -- previously, changing mods would invisibly render those new mods on the old sets for one frame only to empty them out immediately for the duration of the process, and then render the new mods on the new sets. Now we just show the old sets and mods until we're done calculating, which means a lot less flashing on the screen and a lot less sets changing heights.

Fixes #8615.