### PR TITLE
fix equip item action (stream deck)

### DIFF
--- a/src/app/stream-deck/msg-handlers.ts
+++ b/src/app/stream-deck/msg-handlers.ts
@@ -216,13 +216,10 @@ function pullItemHandler({ msg, state, store }: HandlerArgs<PullItemAction>): Th
       // no matching item found
       return;
     }
-    if (moveToVaultItem) {
-      if (!msg.equip) {
-        // move to vault only if the action is not a long press
-        // because on stream deck it is only an EQUIP action
-        // not a toggle one
-        await dispatch(moveItemTo(moveToVaultItem, vaultStore!, false, moveToVaultItem.amount));
-      }
+    // move to vault only if the action is not a long press (EQUIP action)
+    // this will equip item even if it is already in the character inventory
+    if (!msg.equip && moveToVaultItem) {
+      await dispatch(moveItemTo(moveToVaultItem, vaultStore!, false, moveToVaultItem.amount));
     } else {
       const item = selected[0];
       await dispatch(moveItemTo(item, store, msg.equip, item.amount));


### PR DESCRIPTION
small bugfix, an user make me notice that the `equip` action was working only for vault items