### PR TITLE
Indicate fashion sockets that cannot fit ornaments.

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -158,7 +158,7 @@
   },
   "FashionDrawer": {
     "Accept": "Save fashion",
-    "CannotFitOrnament": "This item cannot fit an ornament",
+    "CannotFitOrnament": "This item does not have an ornament socket or you have no ornaments for it.",
     "CannotFitShader": "This item cannot fit a shader",
     "ClearOrnaments": "Clear Ornaments",
     "ClearOrnamentsTitle": "Reset all ornaments to \"no preference\"",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -157,20 +157,22 @@
     "Stop": "Stop"
   },
   "FashionDrawer": {
-    "Title": "Choose shaders and ornaments",
     "Accept": "Save fashion",
-    "Reset": "Clear fashion",
-    "Sync": "Sync",
-    "UseEquipped": "Use equipped fashion",
-    "SyncShaders": "Sync Shaders",
-    "SyncShadersTitle": "Use the same shader on all items",
-    "SyncOrnaments": "Sync Ornaments",
-    "SyncOrnamentsTitle": "Use ornaments from the same set on all items, if they're unlocked",
-    "ClearShaders": "Clear Shaders",
-    "ClearShadersTitle": "Reset all shaders to \"no preference\"",
+    "CannotFitOrnament": "This item cannot fit an ornament",
+    "CannotFitShader": "This item cannot fit a shader",
     "ClearOrnaments": "Clear Ornaments",
     "ClearOrnamentsTitle": "Reset all ornaments to \"no preference\"",
-    "NoPreference": "No preference - this socket won't be changed"
+    "ClearShaders": "Clear Shaders",
+    "ClearShadersTitle": "Reset all shaders to \"no preference\"",
+    "NoPreference": "No preference - this socket won't be changed",
+    "Reset": "Clear fashion",
+    "Sync": "Sync",
+    "SyncOrnaments": "Sync Ornaments",
+    "SyncOrnamentsTitle": "Use ornaments from the same set on all items, if they're unlocked",
+    "SyncShaders": "Sync Shaders",
+    "SyncShadersTitle": "Use the same shader on all items",
+    "Title": "Choose shaders and ornaments",
+    "UseEquipped": "Use equipped fashion"
   },
   "FileUpload": {
     "Instructions": "Click or drag files"

--- a/src/app/loadout/fashion/FashionDrawer.m.scss
+++ b/src/app/loadout/fashion/FashionDrawer.m.scss
@@ -43,3 +43,7 @@
 .missingItem {
   opacity: 0.3;
 }
+
+.noSocket {
+  cursor: not-allowed;
+}

--- a/src/app/loadout/fashion/FashionDrawer.m.scss
+++ b/src/app/loadout/fashion/FashionDrawer.m.scss
@@ -45,5 +45,5 @@
 }
 
 .noSocket {
-  cursor: not-allowed;
+  cursor: default;
 }

--- a/src/app/loadout/fashion/FashionDrawer.m.scss
+++ b/src/app/loadout/fashion/FashionDrawer.m.scss
@@ -44,6 +44,6 @@
   opacity: 0.3;
 }
 
-.noSocket {
+.noOrnament {
   cursor: default;
 }

--- a/src/app/loadout/fashion/FashionDrawer.m.scss.d.ts
+++ b/src/app/loadout/fashion/FashionDrawer.m.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'item': string;
   'items': string;
   'missingItem': string;
+  'noSocket': string;
   'right': string;
   'sheet': string;
   'verticalButtons': string;

--- a/src/app/loadout/fashion/FashionDrawer.m.scss.d.ts
+++ b/src/app/loadout/fashion/FashionDrawer.m.scss.d.ts
@@ -5,7 +5,7 @@ interface CssExports {
   'item': string;
   'items': string;
   'missingItem': string;
-  'noSocket': string;
+  'noOrnament': string;
   'right': string;
   'sheet': string;
   'verticalButtons': string;

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -494,9 +494,9 @@ function FashSocketTooltip({
   let text = t('FashionDrawer.NoPreference');
 
   if (!socket && bucketHash === BucketHashes.Shaders) {
-    text = 'This item cannot fit a shader';
+    text = t('FashionDrawer.CannotFitShader');
   } else if (!socket) {
-    text = 'This item cannot fit an ornament';
+    text = t('FashionDrawer.CannotFitOrnament');
   }
   return <div>{text}</div>;
 }

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -562,7 +562,7 @@ function FashionSocket({
   return (
     <ClosableContainer
       onClose={plugHash ? () => onRemovePlug(bucketHash, plugHash) : undefined}
-      showCloseIconOnHover={true}
+      showCloseIconOnHover
     >
       {content}
     </ClosableContainer>

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -547,6 +547,7 @@ function FashionSocket({
     content = (
       <PressTip tooltip={<FashSocketTooltip bucketHash={bucketHash} socket={socket} />}>
         <div
+          role={socket && 'button'}
           className={clsx('item', {
             [styles.missingItem]: !canSlotOrnament,
             [styles.noSocket]: !socket,

--- a/src/app/loadout/loadout-ui/FashionMods.tsx
+++ b/src/app/loadout/loadout-ui/FashionMods.tsx
@@ -1,4 +1,7 @@
+import { PressTip } from 'app/dim-ui/PressTip';
+import { t } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
@@ -44,10 +47,18 @@ export function FashionMods({
         className={clsx({ [styles.missingItem]: !canSlotShader })}
         plug={(shaderItem ?? defaultShader) as PluggableInventoryItemDefinition}
       />
-      <PlugDef
-        className={clsx({ [styles.missingItem]: !canSlotOrnament })}
-        plug={(ornamentItem ?? defaultOrnament) as PluggableInventoryItemDefinition}
-      />
+      {ornamentItem ? (
+        <PlugDef
+          className={clsx({ [styles.missingItem]: !canSlotOrnament })}
+          plug={ornamentItem as PluggableInventoryItemDefinition}
+        />
+      ) : (
+        <PressTip tooltip={<div>{t('FashionDrawer.NoPreference')}</div>}>
+          <div className={clsx('item', styles.missingItem)}>
+            <DefItemIcon itemDef={defaultOrnament} />
+          </div>
+        </PressTip>
+      )}
     </div>
   );
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -152,7 +152,7 @@
   },
   "FashionDrawer": {
     "Accept": "Save fashion",
-    "CannotFitOrnament": "This item cannot fit an ornament",
+    "CannotFitOrnament": "This item does not have an ornament socket or you have no ornaments for it.",
     "CannotFitShader": "This item cannot fit a shader",
     "ClearOrnaments": "Clear Ornaments",
     "ClearOrnamentsTitle": "Reset all ornaments to \"no preference\"",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -152,6 +152,8 @@
   },
   "FashionDrawer": {
     "Accept": "Save fashion",
+    "CannotFitOrnament": "This item cannot fit an ornament",
+    "CannotFitShader": "This item cannot fit a shader",
     "ClearOrnaments": "Clear Ornaments",
     "ClearOrnamentsTitle": "Reset all ornaments to \"no preference\"",
     "ClearShaders": "Clear Shaders",


### PR DESCRIPTION
I noticed today while making some arc loadouts in anticipation for next season that items without ornaments sockets aren't indicated in the fashion drawer. Normally this is fine as it is usually exotics and players just realise but I was trying to make a build with some illicit invader armour and that also doesn't have a socket. Took me a bit to figure out that a legendary item could possibly be missing an ornament socket.

This PR adds tool tips when the socket is missing and changes the cursor to indicate that it is not clickable.

<img width="1512" alt="Screen Shot 2022-08-12 at 8 55 10 pm" src="https://user-images.githubusercontent.com/7344652/184340580-e4a737b8-6695-4317-a1d7-bf5dfd189e97.png">
<img width="1512" alt="Screen Shot 2022-08-12 at 8 55 07 pm" src="https://user-images.githubusercontent.com/7344652/184340615-af2cb5db-7bb9-4226-a395-09d2407e354b.png">
