### PR TITLE
Increase loadout drawer max height.

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawer2.m.scss
+++ b/src/app/loadout-drawer/LoadoutDrawer2.m.scss
@@ -2,7 +2,7 @@
 
 .body {
   padding: 10px;
-  max-height: 35vh;
+  max-height: 50vh;
   @include phone-portrait {
     max-height: unset;
   }


### PR DESCRIPTION
## Overview

A full subclass ensures the loadout drawer contents is scrollable when opening on my 14 inch macbook pro. This increases the max height to what I believe is a reasonable 50vh so that users are less likely to have to scroll the loadout drawer. Personally I wouldn't be against removing the max height altogether but leave would rather defer to the group for a decision on that.

### Before
<img width="1512" alt="Screen Shot 2022-08-13 at 12 08 13 pm" src="https://user-images.githubusercontent.com/7344652/184464673-b597b0ed-c753-4eb9-9ecd-96134ed34ac2.png">

### After
<img width="1512" alt="Screen Shot 2022-08-13 at 12 10 06 pm" src="https://user-images.githubusercontent.com/7344652/184464681-f4e926c0-5d71-4a4e-bd99-bc21ac05863d.png">
