### PR TITLE
Add log warning when set rendering cannot fit mods

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -22,7 +22,6 @@ import { AppIcon, refreshIcon } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
 import { compareBy } from 'app/utils/comparators';
-import { emptyArray } from 'app/utils/empty';
 import { isArmor2Mod } from 'app/utils/item-utils';
 import { Portal } from 'app/utils/temp-container';
 import { copyString } from 'app/utils/util';
@@ -278,11 +277,11 @@ export default memo(function LoadoutBuilder({
     [loadoutParameters, searchQuery, statFilters, statOrder]
   );
 
-  const sets = result?.sets;
+  const resultSets = result?.sets;
 
   const filteredSets = useMemo(
-    () => sortGeneratedSets(statOrder, enabledStats, sets),
-    [statOrder, enabledStats, sets]
+    () => resultSets && sortGeneratedSets(statOrder, enabledStats, resultSets),
+    [statOrder, enabledStats, resultSets]
   );
 
   const shareBuild = async (notes?: string) => {
@@ -440,11 +439,11 @@ export default memo(function LoadoutBuilder({
             </p>
           </div>
         )}
-        {filteredSets && (
+        {result && filteredSets && (
           <GeneratedSets
             sets={filteredSets}
             subclass={subclass}
-            lockedMods={result?.mods ?? emptyArray()}
+            lockedMods={result.mods}
             pinnedItems={pinnedItems}
             selectedStore={selectedStore}
             lbDispatch={lbDispatch}
@@ -453,7 +452,7 @@ export default memo(function LoadoutBuilder({
             loadouts={loadouts}
             params={params}
             halfTierMods={halfTierMods}
-            armorEnergyRules={armorEnergyRules}
+            armorEnergyRules={result.armorEnergyRules}
             notes={notes}
           />
         )}

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -23,11 +23,8 @@ function getComparatorsForMatchedSetSorting(statOrder: number[], enabledStats: S
 export function sortGeneratedSets(
   statOrder: number[],
   enabledStats: Set<number>,
-  sets?: readonly ArmorSet[]
-): readonly ArmorSet[] | undefined {
-  if (sets === undefined) {
-    return;
-  }
+  sets: readonly ArmorSet[]
+): readonly ArmorSet[] {
   if (sets.length === 0) {
     return emptyArray();
   }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -39,11 +39,14 @@ interface ProcessState {
   result: {
     sets: ArmorSet[];
     /**
-     * The mods used to generate the sets above. The sets are
-     * guaranteed (modulo bugs in worker) to fit these mods, so
-     * set rendering must use this mods list to render sets.
+     * The mods and rules used to generate the sets above. The sets
+     * are guaranteed (modulo bugs in worker) to fit these mods given
+     * these settings, so set rendering must use these to render sets.
+     * Otherwise set rendering may render old sets with new settings/mods,
+     * which will fail in ways indistinguishable from legitimate mismatches.
      */
     mods: PluggableInventoryItemDefinition[];
+    armorEnergyRules: ArmorEnergyRules;
     combos: number;
     processTime: number;
     statRangesFiltered?: StatRanges;
@@ -127,6 +130,7 @@ export function useProcess({
         result: {
           sets: [],
           mods: lockedMods,
+          armorEnergyRules,
           combos: 0,
           processTime: 0,
         },
@@ -206,6 +210,7 @@ export function useProcess({
           result: {
             sets: hydratedSets,
             mods: lockedMods,
+            armorEnergyRules,
             combos,
             processTime: performance.now() - processStart,
             statRangesFiltered,


### PR DESCRIPTION
It always bothered me that we didn't have an easy way to test for consistency between the LO worker and `fitMostMods`, so this adds a log warning if we fail to assign some mods that LO thought were possible to fully assign. This needed a fix very similar to #8616 to not throw random warnings when changing the armor energy settings.

Maybe we'll get some more false positives that need fixing but I do think this additional error checking is nice to have when hacking on LO.