### PR TITLE
Fix query autocomplete with muti-word item and perk names (no more duplicated words)

### DIFF
--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -191,8 +191,8 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |r
       "section": "body",
     },
     "query": {
-      "body": "rare curio or name:"arctic haze"",
-      "fullText": "rare curio or name:"arctic haze"",
+      "body": "rare curio or arctic name:"arctic haze"",
+      "fullText": "rare curio or arctic name:"arctic haze"",
       "helpText": undefined,
     },
     "type": 3,
@@ -245,14 +245,14 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |t
   {
     "highlightRange": {
       "range": [
-        0,
-        23,
+        9,
+        32,
       ],
       "section": "body",
     },
     "query": {
-      "body": "name:"toil and trouble"",
-      "fullText": "name:"toil and trouble"",
+      "body": "toil and name:"toil and trouble"",
+      "fullText": "toil and name:"toil and trouble"",
       "helpText": undefined,
     },
     "type": 3,

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |(is:a or is:b) and (is:c or multi w)| with caret at position 35 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        28,
+        45,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "(is:a or is:b) and (is:c or name:\\"multi word\\")",
+      "fullText": "(is:a or is:b) and (is:c or name:\\"multi word\\")",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |acd/0 fee| with caret at position 9 with exact match 1`] = `
 Array [
   Object {

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |(is:a or is:b) and (is:c or multi w)| with caret at position 35 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         28,
         45,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "(is:a or is:b) and (is:c or name:\\"multi word\\")",
-      "fullText": "(is:a or is:b) and (is:c or name:\\"multi word\\")",
+    "query": {
+      "body": "(is:a or is:b) and (is:c or name:"multi word")",
+      "fullText": "(is:a or is:b) and (is:c or name:"multi word")",
       "helpText": undefined,
     },
     "type": 3,
@@ -21,18 +21,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |acd/0 fee| with caret at position 9 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         0,
         27,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"acd/0 feedback fence\\"",
-      "fullText": "name:\\"acd/0 feedback fence\\"",
+    "query": {
+      "body": "name:"acd/0 feedback fence"",
+      "fullText": "name:"acd/0 feedback fence"",
       "helpText": undefined,
     },
     "type": 3,
@@ -41,18 +41,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |ager's sce| with caret at position 10 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         0,
         21,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"ager's scepter\\"",
-      "fullText": "name:\\"ager's scepter\\"",
+    "query": {
+      "body": "name:"ager's scepter"",
+      "fullText": "name:"ager's scepter"",
       "helpText": undefined,
     },
     "type": 3,
@@ -61,18 +61,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |arctic  haz| with caret at position 11 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         0,
         18,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"arctic haze\\"",
-      "fullText": "name:\\"arctic haze\\"",
+    "query": {
+      "body": "name:"arctic haze"",
+      "fullText": "name:"arctic haze"",
       "helpText": undefined,
     },
     "type": 3,
@@ -81,18 +81,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |arctic haz| with caret at position 10 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         0,
         18,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"arctic haze\\"",
-      "fullText": "name:\\"arctic haze\\"",
+    "query": {
+      "body": "name:"arctic haze"",
+      "fullText": "name:"arctic haze"",
       "helpText": undefined,
     },
     "type": 3,
@@ -101,18 +101,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |is:weapon arctic haz -is:exotic| with caret at position 20 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         10,
         28,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "is:weapon name:\\"arctic haze\\" -is:exotic",
-      "fullText": "is:weapon name:\\"arctic haze\\" -is:exotic",
+    "query": {
+      "body": "is:weapon name:"arctic haze" -is:exotic",
+      "fullText": "is:weapon name:"arctic haze" -is:exotic",
       "helpText": undefined,
     },
     "type": 3,
@@ -121,18 +121,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |name:"foo" arctic haz| with caret at position 21 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         11,
         29,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"foo\\" name:\\"arctic haze\\"",
-      "fullText": "name:\\"foo\\" name:\\"arctic haze\\"",
+    "query": {
+      "body": "name:"foo" name:"arctic haze"",
+      "fullText": "name:"foo" name:"arctic haze"",
       "helpText": undefined,
     },
     "type": 3,
@@ -141,18 +141,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |rare curio or arctic haz| with caret at position 24 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         14,
         32,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "rare curio or name:\\"arctic haze\\"",
-      "fullText": "rare curio or name:\\"arctic haze\\"",
+    "query": {
+      "body": "rare curio or name:"arctic haze"",
+      "fullText": "rare curio or name:"arctic haze"",
       "helpText": undefined,
     },
     "type": 3,
@@ -161,18 +161,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |stat:rpm:200 first in, last| with caret at position 27 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         13,
         38,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "stat:rpm:200 name:\\"first in, last out\\"",
-      "fullText": "stat:rpm:200 name:\\"first in, last out\\"",
+    "query": {
+      "body": "stat:rpm:200 name:"first in, last out"",
+      "fullText": "stat:rpm:200 name:"first in, last out"",
       "helpText": undefined,
     },
     "type": 3,
@@ -181,18 +181,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |the last word| with caret at position 13 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         0,
         20,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"the last word\\"",
-      "fullText": "name:\\"the last word\\"",
+    "query": {
+      "body": "name:"the last word"",
+      "fullText": "name:"the last word"",
       "helpText": undefined,
     },
     "type": 3,
@@ -201,18 +201,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |toil and trou| with caret at position 13 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         0,
         23,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"toil and trouble\\"",
-      "fullText": "name:\\"toil and trouble\\"",
+    "query": {
+      "body": "name:"toil and trouble"",
+      "fullText": "name:"toil and trouble"",
       "helpText": undefined,
     },
     "type": 3,
@@ -221,18 +221,18 @@ Array [
 `;
 
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |two-tail| with caret at position 8 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
+[
+  {
+    "highlightRange": {
+      "range": [
         0,
         21,
       ],
       "section": "body",
     },
-    "query": Object {
-      "body": "name:\\"two-tailed fox\\"",
-      "fullText": "name:\\"two-tailed fox\\"",
+    "query": {
+      "body": "name:"two-tailed fox"",
+      "fullText": "name:"two-tailed fox"",
       "helpText": undefined,
     },
     "type": 3,
@@ -315,9 +315,9 @@ exports[`autocompleteTermSuggestions autocomplete within query for |is:haspower 
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |not(| with caret at position 4 1`] = `Array []`;
+exports[`autocompleteTermSuggestions autocomplete within query for |not(| with caret at position 4 1`] = `[]`;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `Array []`;
+exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `[]`;
 
 exports[`filterComplete autocomplete terms for |is:b| 1`] = `
 [

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |"rare curio" arctic haz| with caret at position 23 with exact match 1`] = `
+[
+  {
+    "highlightRange": {
+      "range": [
+        13,
+        31,
+      ],
+      "section": "body",
+    },
+    "query": {
+      "body": ""rare curio" name:"arctic haze"",
+      "fullText": ""rare curio" name:"arctic haze"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |(is:a or is:b) and (is:c or multi w)| with caret at position 35 with exact match 1`] = `
 [
   {
@@ -133,26 +153,6 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |n
     "query": {
       "body": "name:"foo" name:"arctic haze"",
       "fullText": "name:"foo" name:"arctic haze"",
-      "helpText": undefined,
-    },
-    "type": 3,
-  },
-]
-`;
-
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |rare curio or arctic haz| with caret at position 24 with exact match 1`] = `
-[
-  {
-    "highlightRange": {
-      "range": [
-        14,
-        32,
-      ],
-      "section": "body",
-    },
-    "query": {
-      "body": "rare curio or name:"arctic haze"",
-      "fullText": "rare curio or name:"arctic haze"",
       "helpText": undefined,
     },
     "type": 3,

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -1,5 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |acd/0 fee| with caret at position 9 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        6,
+        33,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "acd/0 name:\\"acd/0 feedback fence\\"",
+      "fullText": "acd/0 name:\\"acd/0 feedback fence\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |ager's sce| with caret at position 10 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        7,
+        28,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "ager's name:\\"ager's scepter\\"",
+      "fullText": "ager's name:\\"ager's scepter\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |arctic haz| with caret at position 10 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        7,
+        25,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "arctic name:\\"arctic haze\\"",
+      "fullText": "arctic name:\\"arctic haze\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |first in, last| with caret at position 14 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        10,
+        35,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "first in, name:\\"first in, last out\\"",
+      "fullText": "first in, name:\\"first in, last out\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |the last word| with caret at position 13 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        9,
+        29,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "the last name:\\"the last word\\"",
+      "fullText": "the last name:\\"the last word\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |two-tail| with caret at position 8 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        4,
+        25,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "two-name:\\"two-tailed fox\\"",
+      "fullText": "two-name:\\"two-tailed fox\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
 exports[`autocompleteTermSuggestions autocomplete within query for |(is:blue jun)| with caret at position 11 1`] = `
 [
   {

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -20,6 +20,26 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |"
 ]
 `;
 
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |"rare curio" or arctic haz| with caret at position 26 with exact match 1`] = `
+[
+  {
+    "highlightRange": {
+      "range": [
+        16,
+        34,
+      ],
+      "section": "body",
+    },
+    "query": {
+      "body": ""rare curio" or name:"arctic haze"",
+      "fullText": ""rare curio" or name:"arctic haze"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |(is:a or is:b) and (is:c or multi w)| with caret at position 35 with exact match 1`] = `
 [
   {
@@ -153,6 +173,26 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |n
     "query": {
       "body": "name:"foo" name:"arctic haze"",
       "fullText": "name:"foo" name:"arctic haze"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |rare curio or arctic haz| with caret at position 24 with exact match 1`] = `
+[
+  {
+    "highlightRange": {
+      "range": [
+        21,
+        39,
+      ],
+      "section": "body",
+    },
+    "query": {
+      "body": "rare curio or name:"arctic haze"",
+      "fullText": "rare curio or name:"arctic haze"",
       "helpText": undefined,
     },
     "type": 3,

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -65,14 +65,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        8,
-        26,
+        0,
+        18,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "arctic  name:\\"arctic haze\\"",
-      "fullText": "arctic  name:\\"arctic haze\\"",
+      "body": "name:\\"arctic haze\\"",
+      "fullText": "name:\\"arctic haze\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -140,6 +140,26 @@ Array [
 ]
 `;
 
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |rare curio or arctic haz| with caret at position 24 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        14,
+        32,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "rare curio or name:\\"arctic haze\\"",
+      "fullText": "rare curio or name:\\"arctic haze\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |stat:rpm:200 first in, last| with caret at position 27 with exact match 1`] = `
 Array [
   Object {
@@ -173,6 +193,26 @@ Array [
     "query": Object {
       "body": "name:\\"the last word\\"",
       "fullText": "name:\\"the last word\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |toil and trou| with caret at position 13 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        0,
+        23,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "name:\\"toil and trouble\\"",
+      "fullText": "name:\\"toil and trouble\\"",
       "helpText": undefined,
     },
     "type": 3,

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -40,6 +40,26 @@ Array [
 ]
 `;
 
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |arctic  haz| with caret at position 11 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        8,
+        26,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "arctic  name:\\"arctic haze\\"",
+      "fullText": "arctic  name:\\"arctic haze\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |arctic haz| with caret at position 10 with exact match 1`] = `
 Array [
   Object {
@@ -53,26 +73,6 @@ Array [
     "query": Object {
       "body": "name:\\"arctic haze\\"",
       "fullText": "name:\\"arctic haze\\"",
-      "helpText": undefined,
-    },
-    "type": 3,
-  },
-]
-`;
-
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |first in, last| with caret at position 14 with exact match 1`] = `
-Array [
-  Object {
-    "highlightRange": Object {
-      "range": Array [
-        0,
-        25,
-      ],
-      "section": "body",
-    },
-    "query": Object {
-      "body": "name:\\"first in, last out\\"",
-      "fullText": "name:\\"first in, last out\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -113,6 +113,26 @@ Array [
     "query": Object {
       "body": "name:\\"foo\\" name:\\"arctic haze\\"",
       "fullText": "name:\\"foo\\" name:\\"arctic haze\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |stat:rpm:200 first in, last| with caret at position 27 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        13,
+        38,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "stat:rpm:200 name:\\"first in, last out\\"",
+      "fullText": "stat:rpm:200 name:\\"first in, last out\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -235,7 +255,9 @@ exports[`autocompleteTermSuggestions autocomplete within query for |is:haspower 
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `[]`;
+exports[`autocompleteTermSuggestions autocomplete within query for |not(| with caret at position 4 1`] = `Array []`;
+
+exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `Array []`;
 
 exports[`filterComplete autocomplete terms for |is:b| 1`] = `
 [

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -5,14 +5,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        6,
-        33,
+        0,
+        27,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "acd/0 name:\\"acd/0 feedback fence\\"",
-      "fullText": "acd/0 name:\\"acd/0 feedback fence\\"",
+      "body": "name:\\"acd/0 feedback fence\\"",
+      "fullText": "name:\\"acd/0 feedback fence\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -25,14 +25,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        7,
-        28,
+        0,
+        21,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "ager's name:\\"ager's scepter\\"",
-      "fullText": "ager's name:\\"ager's scepter\\"",
+      "body": "name:\\"ager's scepter\\"",
+      "fullText": "name:\\"ager's scepter\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -45,14 +45,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        7,
-        25,
+        0,
+        18,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "arctic name:\\"arctic haze\\"",
-      "fullText": "arctic name:\\"arctic haze\\"",
+      "body": "name:\\"arctic haze\\"",
+      "fullText": "name:\\"arctic haze\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -65,14 +65,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        10,
-        35,
+        0,
+        25,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "first in, name:\\"first in, last out\\"",
-      "fullText": "first in, name:\\"first in, last out\\"",
+      "body": "name:\\"first in, last out\\"",
+      "fullText": "name:\\"first in, last out\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -85,14 +85,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        17,
-        35,
+        10,
+        28,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "is:weapon arctic name:\\"arctic haze\\" -is:exotic",
-      "fullText": "is:weapon arctic name:\\"arctic haze\\" -is:exotic",
+      "body": "is:weapon name:\\"arctic haze\\" -is:exotic",
+      "fullText": "is:weapon name:\\"arctic haze\\" -is:exotic",
       "helpText": undefined,
     },
     "type": 3,
@@ -105,14 +105,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        18,
-        36,
+        11,
+        29,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "name:\\"foo\\" arctic name:\\"arctic haze\\"",
-      "fullText": "name:\\"foo\\" arctic name:\\"arctic haze\\"",
+      "body": "name:\\"foo\\" name:\\"arctic haze\\"",
+      "fullText": "name:\\"foo\\" name:\\"arctic haze\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -125,14 +125,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        9,
-        29,
+        0,
+        20,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "the last name:\\"the last word\\"",
-      "fullText": "the last name:\\"the last word\\"",
+      "body": "name:\\"the last word\\"",
+      "fullText": "name:\\"the last word\\"",
       "helpText": undefined,
     },
     "type": 3,
@@ -145,14 +145,14 @@ Array [
   Object {
     "highlightRange": Object {
       "range": Array [
-        4,
-        25,
+        0,
+        21,
       ],
       "section": "body",
     },
     "query": Object {
-      "body": "two-name:\\"two-tailed fox\\"",
-      "fullText": "two-name:\\"two-tailed fox\\"",
+      "body": "name:\\"two-tailed fox\\"",
+      "fullText": "name:\\"two-tailed fox\\"",
       "helpText": undefined,
     },
     "type": 3,

--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -80,6 +80,46 @@ Array [
 ]
 `;
 
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |is:weapon arctic haz -is:exotic| with caret at position 20 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        17,
+        35,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "is:weapon arctic name:\\"arctic haze\\" -is:exotic",
+      "fullText": "is:weapon arctic name:\\"arctic haze\\" -is:exotic",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for |name:"foo" arctic haz| with caret at position 21 with exact match 1`] = `
+Array [
+  Object {
+    "highlightRange": Object {
+      "range": Array [
+        18,
+        36,
+      ],
+      "section": "body",
+    },
+    "query": Object {
+      "body": "name:\\"foo\\" arctic name:\\"arctic haze\\"",
+      "fullText": "name:\\"foo\\" arctic name:\\"arctic haze\\"",
+      "helpText": undefined,
+    },
+    "type": 3,
+  },
+]
+`;
+
 exports[`autocompleteTermSuggestions autocomplete within multi-word query for |the last word| with caret at position 13 with exact match 1`] = `
 Array [
   Object {

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -15,6 +15,7 @@ describe('autocompleteTermSuggestions', () => {
     ['(is:blue jun)', 11],
     ['is:bow is:void', 11],
     ['season:>outl', 12],
+    ['not(', 4],
   ];
 
   test.each(cases)(
@@ -37,8 +38,9 @@ describe('autocompleteTermSuggestions', () => {
     ["ager's sce", 10, "ager's scepter"],
     ['the last word', 13, 'the last word'],
     ['acd/0 fee', 9, 'acd/0 feedback fence'],
-    ['first in, last', 14, 'first in, last out'],
+    ['stat:rpm:200 first in, last', 27, 'first in, last out'],
     ['two-tail', 8, 'two-tailed fox'],
+    ['arctic  haz', 11, 'arctic haze'], // this currently isn't handled due to the double space
   ];
 
   test.each(multiWordCases)(

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -41,7 +41,9 @@ describe('autocompleteTermSuggestions', () => {
     ['stat:rpm:200 first in, last', 27, 'first in, last out'],
     ['two-tail', 8, 'two-tailed fox'],
     ['(is:a or is:b) and (is:c or multi w)', 35, 'multi word'],
-    ['arctic  haz', 11, 'arctic haze'], // this currently isn't handled due to the double space
+    ['arctic  haz', 11, 'arctic haze'], // todo: not handled due to the double space
+    ['toil and trou', 13, 'toil and trouble'], // todo: handled due to the `and`
+    ['rare curio or arctic haz', 24, 'arctic haze'], // todo: not handled, eats all five words
   ];
 
   test.each(multiWordCases)(

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -42,10 +42,10 @@ describe('autocompleteTermSuggestions', () => {
     ['two-tail', 8, 'two-tailed fox'],
     ['(is:a or is:b) and (is:c or multi w)', 35, 'multi word'],
     ['arctic  haz', 11, 'arctic haze'],
-    ['toil and trou', 13, 'toil and trouble'], // todo: not handled due to the `and`
     ['"rare curio" arctic haz', 23, 'arctic haze'],
     ['"rare curio" or arctic haz', 26, 'arctic haze'],
-    ['rare curio or arctic haz', 24, 'arctic haze'], // todo: not handled due to the `or`
+    ['toil and trou', 13, 'toil and trouble'], // todo: not handled due to the `and`
+    ['rare curio or arctic haz', 24, 'arctic haze'], // todo: parser result is unexpected here
   ];
 
   test.each(multiWordCases)(

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -29,6 +29,29 @@ describe('autocompleteTermSuggestions', () => {
       expect(candidates).toMatchSnapshot();
     }
   );
+
+  const multiWordCases: [query: string, caretIndex: number, mockCandidate: string][] = [
+    ['arctic haz', 10, 'arctic haze'],
+    ["ager's sce", 10, "ager's scepter"],
+    ['the last word', 13, 'the last word'],
+    ['acd/0 fee', 9, 'acd/0 feedback fence'],
+    ['first in, last', 14, 'first in, last out'],
+    ['two-tail', 8, 'two-tailed fox'],
+  ];
+
+  test.each(multiWordCases)(
+    'autocomplete within multi-word query for |%s| with caret at position %d with exact match',
+    (query: string, caretIndex: number, mockCandidate: string) => {
+      const candidates = autocompleteTermSuggestions(
+        query,
+        caretIndex,
+        // use mock candidates to simulate exact name-matches for multiword items
+        () => [`name:"${mockCandidate}"`],
+        searchConfig
+      );
+      expect(candidates).toMatchSnapshot();
+    }
+  );
 });
 
 describe('filterSortRecentSearches', () => {

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -43,7 +43,7 @@ describe('autocompleteTermSuggestions', () => {
     ['(is:a or is:b) and (is:c or multi w)', 35, 'multi word'],
     ['arctic  haz', 11, 'arctic haze'],
     ['toil and trou', 13, 'toil and trouble'], // todo: handled due to the `and`
-    ['rare curio or arctic haz', 24, 'arctic haze'], // todo: not handled, eats all five words
+    ['"rare curio" arctic haz', 23, 'arctic haze'],
   ];
 
   test.each(multiWordCases)(

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -42,8 +42,10 @@ describe('autocompleteTermSuggestions', () => {
     ['two-tail', 8, 'two-tailed fox'],
     ['(is:a or is:b) and (is:c or multi w)', 35, 'multi word'],
     ['arctic  haz', 11, 'arctic haze'],
-    ['toil and trou', 13, 'toil and trouble'], // todo: handled due to the `and`
+    ['toil and trou', 13, 'toil and trouble'], // todo: not handled due to the `and`
     ['"rare curio" arctic haz', 23, 'arctic haze'],
+    ['"rare curio" or arctic haz', 26, 'arctic haze'],
+    ['rare curio or arctic haz', 24, 'arctic haze'], // todo: not handled due to the `or`
   ];
 
   test.each(multiWordCases)(

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -32,6 +32,8 @@ describe('autocompleteTermSuggestions', () => {
 
   const multiWordCases: [query: string, caretIndex: number, mockCandidate: string][] = [
     ['arctic haz', 10, 'arctic haze'],
+    ['is:weapon arctic haz -is:exotic', 20, 'arctic haze'],
+    ['name:"foo" arctic haz', 21, 'arctic haze'],
     ["ager's sce", 10, "ager's scepter"],
     ['the last word', 13, 'the last word'],
     ['acd/0 fee', 9, 'acd/0 feedback fence'],

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -40,6 +40,7 @@ describe('autocompleteTermSuggestions', () => {
     ['acd/0 fee', 9, 'acd/0 feedback fence'],
     ['stat:rpm:200 first in, last', 27, 'first in, last out'],
     ['two-tail', 8, 'two-tailed fox'],
+    ['(is:a or is:b) and (is:c or multi w)', 35, 'multi word'],
     ['arctic  haz', 11, 'arctic haze'], // this currently isn't handled due to the double space
   ];
 

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -41,7 +41,7 @@ describe('autocompleteTermSuggestions', () => {
     ['stat:rpm:200 first in, last', 27, 'first in, last out'],
     ['two-tail', 8, 'two-tailed fox'],
     ['(is:a or is:b) and (is:c or multi w)', 35, 'multi word'],
-    ['arctic  haz', 11, 'arctic haze'], // todo: not handled due to the double space
+    ['arctic  haz', 11, 'arctic haze'],
     ['toil and trou', 13, 'toil and trouble'], // todo: handled due to the `and`
     ['rare curio or arctic haz', 24, 'arctic haze'], // todo: not handled, eats all five words
   ];

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -222,12 +222,13 @@ const caretEndRegex = /([\s)]|$)/;
 
 // most times, insist on at least 3 typed characters, but for #, start suggesting immediately
 const lastWordRegex = /(\b[\w:"'<=>]{3,}|#\w*)$/;
-// match all completed filters
-const completeFiltersRegex = new RegExp(
-  `^(-?(?:${filterNames.join('|')}):(?:\\S+|"(?:.*?)")\\s+)*(.+)$`
-);
 // matches a string that seems to end with a closing, not opening, quote
 const closingQuoteRegex = /\w["']$/;
+
+// match all completed filters
+// const completeFiltersRegex = new RegExp(
+//   `^(-?(?:${filterNames.join('|')}):(?:\\S+|"(?:.*?)")\\s+)*(.+)$`
+// );
 
 /**
  * Find the position of the last "complete" filter segment of the query before the caretIndex

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -253,6 +253,7 @@ export function findLastFilter(
     true // traverse in reverse
   );
 
+  // @TODO: This could be cleaner if the AST parser returned column locations; we wouldn't have to guess at indexes by doing space normalization
   const trailingKeywordStrings = trailingKeywordArgs.reverse().join(' ');
   const spaceNormalizedQuery = queryUpToCaret.trim().replace(/\s+/, ' ');
   const execResult = lastWordRegex.exec(queryUpToCaret);

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -244,7 +244,7 @@ export function findLastFilter(
   traverseAST(
     ast,
     (filter: FilterOp) => {
-      if (keepTraversing && filter.type === 'keyword') {
+      if (keepTraversing && filter.type === 'keyword' && !/\s+/.test(filter.args)) {
         trailingKeywordArgs.push(filter.args);
       } else {
         keepTraversing = false;

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -226,6 +226,26 @@ const lastWordRegex = /(\b[\w:"'<=>]{3,}|#\w*)$/;
 const closingQuoteRegex = /\w["']$/;
 
 /**
+ * Find the position of the last "complete" filter segment of the query before the caretIndex
+ * @returns the start index and term of the last complete filter
+ */
+export function findLastFilter(
+  query: string,
+  caretIndex: number
+): {
+  term: string;
+  index: number;
+} | null {
+  const execResult = lastWordRegex.exec(query.slice(0, caretIndex));
+  if (execResult) {
+    const [__, term] = execResult;
+    const { index } = execResult;
+    return { term, index };
+  }
+  return null;
+}
+
+/**
  * Given a query and a cursor position, isolate the term that's being typed and offer reformulated queries
  * that replace that term with one from our filterComplete function.
  */
@@ -242,17 +262,14 @@ export function autocompleteTermSuggestions(
   // Seek to the end of the current part
   caretIndex = (caretEndRegex.exec(query.slice(caretIndex))?.index || 0) + caretIndex;
 
-  // Find the last word that looks like a search
-  const match = lastWordRegex.exec(query.slice(0, caretIndex));
-  if (!match) {
+  const lastFilter = findLastFilter(query, caretIndex);
+
+  if (!lastFilter || closingQuoteRegex.test(lastFilter.term)) {
     return [];
   }
-  const term = match[1];
-  if (closingQuoteRegex.test(term)) {
-    return [];
-  }
-  const candidates = filterComplete(term);
-  const base = query.slice(0, match.index);
+
+  const base = query.slice(0, lastFilter.index);
+  const candidates = filterComplete(lastFilter.term);
 
   // new query is existing query minus match plus suggestion
   return candidates.map((word) => {
@@ -272,7 +289,7 @@ export function autocompleteTermSuggestions(
       type: SearchItemType.Autocomplete,
       highlightRange: {
         section: 'body',
-        range: [match.index, match.index + word.length],
+        range: [lastFilter.index, lastFilter.index + word.length],
       },
     };
   });

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -253,14 +253,13 @@ export function findLastFilter(
     true // traverse in reverse
   );
 
-  // @TODO: Assumes these "keywords" are separated by just one space and no trailing spaces.
-  // To fix, turn this into a regex. But first it would need to be escaped - it can have parens, etc
   const trailingKeywordStrings = trailingKeywordArgs.reverse().join(' ');
+  const spaceNormalizedQuery = queryUpToCaret.trim().replace(/\s+/, ' ');
   const execResult = lastWordRegex.exec(queryUpToCaret);
 
-  if (trailingKeywordStrings && queryUpToCaret.endsWith(trailingKeywordStrings)) {
-    const index = queryUpToCaret.length - trailingKeywordStrings.length;
-    const term = queryUpToCaret.substring(index);
+  if (trailingKeywordStrings && spaceNormalizedQuery.endsWith(trailingKeywordStrings)) {
+    const index = spaceNormalizedQuery.length - trailingKeywordStrings.length;
+    const term = spaceNormalizedQuery.substring(index);
     return { term, index };
   } else if (execResult) {
     const [__, term] = execResult;

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -476,3 +476,24 @@ export function canonicalizeQuery(query: QueryAST, depth = 0): string {
 
   return result;
 }
+
+/**
+ * Invoke `callback` on each FilterOp of the `ast` in depth-first order (ie, left-to-right)
+ * If optional `reverse` argument is true, traversal goes the other way
+ */
+export const traverseAST = (
+  ast: QueryAST,
+  callback: (ast: FilterOp) => void,
+  reverse = false
+): void => {
+  if ('operand' in ast) {
+    traverseAST(ast.operand, callback, reverse);
+  } else if ('operands' in ast) {
+    const operands = reverse ? [...ast.operands].reverse() : ast.operands;
+    for (const operand of operands) {
+      traverseAST(operand, callback, reverse);
+    }
+  } else if ('type' in ast) {
+    callback(ast);
+  }
+};


### PR DESCRIPTION
Refs https://github.com/DestinyItemManager/DIM/issues/8435

Aims to fix the issue where you type the name of an item that has several words (eg: `arctic haz`) and hit `TAB` and your query is updated to `arctic name:"arctic haze"`. 

This is done by parsing the query up to the cursor location to AST, then traversing the AST from the end backwards to find elements (`keywords`) in the AST that are not part of any filter. Working back from the cursor, these trailing keywords are eliminated from the query if the query contains them in order as bare strings separated by spaces. If the query does not have any unbound keywords or it does not end in a string that matches a joined representation of those keywords, we just fall back on the old behavior of looking for a space with a regex and deleting back to that.

I added a bunch of test cases and also manually tested quite a bit. The only rough edge I've found is that this still falls back to the old behavior if the filter term you're trying to get autocompleted has irregular (duplicate) spaces. I added some notes about how this could be improved. It does work with complex nested queries, negations, the doubled-up `stat:rpm:###` filters, special characters, and all the other edge cases I've thought of. But this'll definitely be something I'd like to get more eyes on to test as I am sure there are kinds of filters I don't even know exist.
