### PR TITLE
Clean up LO Compare Drawer set updating

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Updating/overwriting a Loadout using Loadout Optimizer's "Compare Loadout" button will now correctly remove the placeholders for armor equipped in the Loadout that no longer exists.
+
 ## 7.31.1 <span class="changelog-date">(2022-08-23)</span>
 
 ## 7.31.0 <span class="changelog-date">(2022-08-21)</span>


### PR DESCRIPTION
A long overdue cleanup that hopefully means we don't have to see stuff like this anymore when Loadout Optimizer is involved 
![grafik](https://user-images.githubusercontent.com/14299449/186481105-a3ab6613-3ec9-44bb-acde-e378605a5806.png)
(This could also cause a Loadout to have an Arc 2.0 and an Arc 3.0 subclass at the same time if migration was missing)