### PR TITLE
Rate limit

### DIFF
--- a/src/app/bungie-api/rate-limit-config.ts
+++ b/src/app/bungie-api/rate-limit-config.ts
@@ -1,47 +1,35 @@
 import { addLimiter, RateLimiterQueue } from './rate-limiter';
 
 export default function setupRateLimiter() {
-  // Bungie's API will start throttling an API if it's called more than once per second. It does this
-  // by making responses take 2s to return, not by sending an error code or throttling response. Choosing
-  // our throttling limit to be 1 request every 1100ms lets us achieve best throughput while accounting for
-  // what I assume is clock skew between Bungie's hosts when they calculate a global rate limit.
-  addLimiter(
-    new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1, 1100)
-  );
-  addLimiter(new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1, 1100));
+  addLimiter(new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/TransferItem/, 1000));
+  addLimiter(new RateLimiterQueue(/www\.bungie\.net\/D1\/Platform\/Destiny\/EquipItem/, 1000));
 
   // Destiny 2 has a faster rate limit!
   addLimiter(
-    new RateLimiterQueue(
-      /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/,
-      1,
-      100
-    )
+    new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/TransferItem/, 100)
   );
   addLimiter(
     new RateLimiterQueue(
       /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/PullFromPostmaster/,
-      1,
+
       100
     )
   );
   addLimiter(
-    new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100)
+    new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 100)
   );
   addLimiter(
-    new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItems/, 1, 100)
+    new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItems/, 100)
   );
   addLimiter(
     new RateLimiterQueue(
       /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/InsertSocketPlugFree/,
-      2,
       500
     )
   );
   addLimiter(
     new RateLimiterQueue(
       /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/InsertSocketPlug/,
-      2,
       500
     )
   );

--- a/src/app/bungie-api/rate-limit-config.ts
+++ b/src/app/bungie-api/rate-limit-config.ts
@@ -29,10 +29,20 @@ export default function setupRateLimiter() {
     new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItem/, 1, 100)
   );
   addLimiter(
+    new RateLimiterQueue(/www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/EquipItems/, 1, 100)
+  );
+  addLimiter(
     new RateLimiterQueue(
       /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/InsertSocketPlugFree/,
       2,
-      1100
+      500
+    )
+  );
+  addLimiter(
+    new RateLimiterQueue(
+      /www\.bungie\.net\/Platform\/Destiny2\/Actions\/Items\/InsertSocketPlug/,
+      2,
+      500
     )
   );
 }


### PR DESCRIPTION
I can't really test this until the API is back to full speed, but this is based on my interpretation of the API docs property `ThrottleSecondsBetweenActionPerUser`. Using that, we can both set better limits, and change the behavior of rate limiting to delay between the end of one action and the start of the next, instead of just ensuring no more than 1 request per period. This should avoid some of the cases where we get ahead of Bungie's rate limiter and get slowed down.