### PR TITLE
Update DIM wiki links to point to correct pages

### DIFF
--- a/src/app/login/Login.tsx
+++ b/src/app/login/Login.tsx
@@ -9,9 +9,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { oauthClientId } from '../bungie-api/bungie-api-utils';
 import styles from './Login.m.scss';
 
-const dimApiHelpLink = 'https://github.com/DestinyItemManager/DIM/wiki/DIM-Sync';
-const loginHelpLink =
-  'https://github.com/DestinyItemManager/DIM/wiki/Authorizing-Destiny-Item-Manager-with-Bungie.net';
+export const dimApiHelpLink = 'https://github.com/DestinyItemManager/DIM/wiki/DIM-Sync';
+const loginHelpLink = 'https://github.com/DestinyItemManager/DIM/wiki/Accounts-and-Login';
 
 export default function Login() {
   const dispatch = useThunkDispatch();

--- a/src/app/storage/DimApiSettings.tsx
+++ b/src/app/storage/DimApiSettings.tsx
@@ -7,6 +7,7 @@ import { apiPermissionGrantedSelector, dimSyncErrorSelector } from 'app/dim-api/
 import HelpLink from 'app/dim-ui/HelpLink';
 import Switch from 'app/dim-ui/Switch';
 import { t } from 'app/i18next-t';
+import { dimApiHelpLink } from 'app/login/Login';
 import { showNotification } from 'app/notifications/notifications';
 import ErrorPanel from 'app/shell/ErrorPanel';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
@@ -18,9 +19,6 @@ import styles from './DimApiSettings.m.scss';
 import { exportBackupData, exportLocalData } from './export-data';
 import ImportExport from './ImportExport';
 import LocalStorageInfo from './LocalStorageInfo';
-
-const dimApiHelpLink =
-  'https://github.com/DestinyItemManager/DIM/wiki/DIM-Sync-(new-storage-for-tags,-loadouts,-and-settings)';
 
 export default function DimApiSettings() {
   const dispatch = useThunkDispatch();


### PR DESCRIPTION
Fixes #8675. The GitHub wiki pages these links pointed to previously had included only a link to the Fandom wiki, which would in turn link back to a different page of the GitHub wiki -- I've also [changed those](https://github.com/DestinyItemManager/DIM/wiki/_compare/1c67ff45766a8092cdb2a53b280cd0edcc6f9d0e...8b1f140c91722466c7047c085c2fff24373e1185) pages to link to the correct GitHub wiki page directly.