### PR TITLE
Remove deprecated mods for seasonal artifact

### DIFF
--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -242,6 +242,12 @@ export const VENDORS = {
   VAULT: 1037843411,
   XUR: 2190858386,
   WAR_TABLE_UPGRADES_RISEN: 3950870173,
+  /**
+   * this has always been named "The Gate Lord's Eye" from season 8,
+   * but every season this vendor is updated with the new contents
+   * of that season's artifact
+   */
+  ARTIFACT: 2894222926,
 };
 
 /** used to snag the icon for display */

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -3,6 +3,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { VENDORS } from 'app/search/d2-known-values';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { uniqBy } from 'app/utils/util';
+import deprecatedMods from 'data/d2/deprecated-mods.json';
 import rahoolMats from 'data/d2/spider-mats.json';
 import _ from 'lodash';
 import { Link } from 'react-router-dom';
@@ -86,7 +87,22 @@ export default function VendorItems({
     return <div className={styles.vendorContents}>{t('Vendors.NoItems')}</div>;
   }
 
-  const itemsByCategory = _.groupBy(vendor.items, (item: VendorItem) => item.displayCategoryIndex);
+  // remove deprecated mods from seasonal artifact
+  if (vendor.def.hash === 2894222926) {
+    const first = vendor.items.findIndex((firstDepMod) =>
+      deprecatedMods.includes(firstDepMod?.item?.hash ?? 0)
+    );
+    const reverseList = [...vendor.items].reverse();
+    const last =
+      vendor.items.length -
+      2 -
+      reverseList.findIndex((lastDepMod) => deprecatedMods.includes(lastDepMod?.item?.hash ?? 0));
+    if (first > -1 && last > -1) {
+      vendor.items.splice(first, last);
+    }
+  }
+
+  const itemsByCategory = _.groupBy(vendor.items, (item: VendorItem) => item?.displayCategoryIndex);
 
   const faction = vendor.def.factionHash ? defs.Faction[vendor.def.factionHash] : undefined;
   const rewardVendorHash = faction?.rewardVendorHash || undefined;

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -88,7 +88,7 @@ export default function VendorItems({
   }
 
   // remove deprecated mods from seasonal artifact
-  if (vendor.def.hash === 2894222926) {
+  if (vendor.def.hash === VENDORS.ARTIFACT) {
     const first = vendor.items.findIndex((firstDepMod) =>
       deprecatedMods.includes(firstDepMod?.item?.hash ?? 0)
     );

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -89,20 +89,12 @@ export default function VendorItems({
 
   // remove deprecated mods from seasonal artifact
   if (vendor.def.hash === VENDORS.ARTIFACT) {
-    const first = vendor.items.findIndex((firstDepMod) =>
-      deprecatedMods.includes(firstDepMod?.item?.hash ?? 0)
+    vendor.items = vendor.items.filter(
+      (i) => i.item?.hash && !deprecatedMods.includes(i.item.hash)
     );
-    const reverseList = [...vendor.items].reverse();
-    const last =
-      vendor.items.length -
-      2 -
-      reverseList.findIndex((lastDepMod) => deprecatedMods.includes(lastDepMod?.item?.hash ?? 0));
-    if (first > -1 && last > -1) {
-      vendor.items.splice(first, last);
-    }
   }
 
-  const itemsByCategory = _.groupBy(vendor.items, (item: VendorItem) => item?.displayCategoryIndex);
+  const itemsByCategory = _.groupBy(vendor.items, (item) => item?.displayCategoryIndex);
 
   const faction = vendor.def.factionHash ? defs.Faction[vendor.def.factionHash] : undefined;
   const rewardVendorHash = faction?.rewardVendorHash || undefined;


### PR DESCRIPTION
Remove deprecated mods from seasonal artifact...

There is probably an ~easier~ more efficient way...

![image](https://user-images.githubusercontent.com/4798491/188258560-32025ef1-c471-4b95-b2b1-d089555d863b.png)
