### PR TITLE
Fix for Item Feed hiding character collapse button

### DIFF
--- a/src/app/inventory-page/DesktopStores.m.scss
+++ b/src/app/inventory-page/DesktopStores.m.scss
@@ -5,6 +5,7 @@
   grid-template-rows: 46px 1fr;
   padding: 16px 0 6px 0;
   align-items: center;
+  width: 70px;
 }
 
 .singleCharacterButton {


### PR DESCRIPTION
When the screen width is really small collapse button gets hidden behind the item feed button this should prevent that from happening