### PR TITLE
Loadout Subclass Aspects+Fragments improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Applying a Loadout with subclass configuration should now avoid pointless reordering of Aspects and Fragments in their slots.
+
 ## 7.41.0 <span class="changelog-date">(2022-10-30)</span>
 
 * On first visit, DIM will prompt you to select a platform instead of automatically selecting the most recently played one. Also, DIM will no longer fall back to your D1 account when Bungie.net is down.

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -941,17 +941,23 @@ function applySocketOverrides(
                 }
               }
               for (const socket of excessSockets) {
+                // For every socket we didn't find a corresponding requested socketOverride for,
+                // we assign the remaining plugs, resetting all remaining sockets beyond that to empty
                 let override = neededOverrides.pop();
+                let requested = true;
                 if (!override) {
                   override = {
                     hash: socket.emptyPlugItemHash!,
                     loadoutSocketIndex: socket.socketIndex,
                   };
+                  // These emptying actions are not marked as requested because we didn't create
+                  // the corresponding UI element to correctly report progress
+                  requested = false;
                 }
                 const mod = defs.InventoryItem.get(
                   override.hash
                 ) as PluggableInventoryItemDefinition;
-                modsForItem.push({ socketIndex: socket.socketIndex, mod, requested: true });
+                modsForItem.push({ socketIndex: socket.socketIndex, mod, requested });
                 itemSocketToLoadoutOverrideSocket[socket.socketIndex] = override.loadoutSocketIndex;
               }
             }


### PR DESCRIPTION
I am not happy with how complex this is, but it's really mostly due to the fact that subclass options are modeled as `socketOverrides`. Perhaps `socketOverrides` aren't actually the right data representation for these...

Fixes #8749.
Fixes #8718.