### PR TITLE
legendary armor intrinsics: filter & compare

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -179,6 +179,7 @@
     "Adept": "\\(Adept\\)",
     "AmmoType": "Shows items based on their ammo type.",
     "ArmorCategory": "Shows armors based on their category.",
+    "ArmorIntrinsic": "Shows armor which has an intrinsic perk, such as Artifice Armor.",
     "Ascended": "Shows items that have an ascend node which have been ascended.",
     "Unascended": "Shows items that have an ascend node which have not been ascended.",
     "Breaker": "Filter by breaker type or corresponding champion type.",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -179,7 +179,7 @@
     "Adept": "\\(Adept\\)",
     "AmmoType": "Shows items based on their ammo type.",
     "ArmorCategory": "Shows armors based on their category.",
-    "ArmorIntrinsic": "Shows armor which has an intrinsic perk, such as Artifice Armor.",
+    "ArmorIntrinsic": "Shows legendary armor which has an intrinsic perk, such as Artifice Armor.",
     "Ascended": "Shows items that have an ascend node which have been ascended.",
     "Unascended": "Shows items that have an ascend node which have not been ascended.",
     "Breaker": "Filter by breaker type or corresponding champion type.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+* Added `is:armorintrinsic` to find Artifice Armor, armor with seasonal perks, etc.
+* Compare suggestion buttons now offer comparison to similar armor intrinsics.
+
 ## 7.38.0 <span class="changelog-date">(2022-10-09)</span>
 
 ### Beta Only

--- a/src/app/compare/CompareButtons.m.scss
+++ b/src/app/compare/CompareButtons.m.scss
@@ -9,3 +9,7 @@
   height: 1.3em;
   width: 1.3em;
 }
+
+.intrinsicIcon {
+  transform: scale(1.2);
+}

--- a/src/app/compare/CompareButtons.m.scss.d.ts
+++ b/src/app/compare/CompareButtons.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'inlineImageIcon': string;
+  'intrinsicIcon': string;
   'svgIcon': string;
 }
 export const cssExports: CssExports;

--- a/src/app/compare/CompareSuggestions.tsx
+++ b/src/app/compare/CompareSuggestions.tsx
@@ -1,6 +1,6 @@
 import { DimItem } from 'app/inventory/item-types';
 import { filterFactorySelector } from 'app/search/search-filter';
-import React, { memo } from 'react';
+import { memo } from 'react';
 import { useSelector } from 'react-redux';
 import { defaultComparisons, findSimilarArmors, findSimilarWeapons } from './compare-buttons';
 import { compareCategoryItemsSelector } from './selectors';
@@ -31,24 +31,34 @@ export default memo(function CompareSuggestions({
     items: categoryItems.filter(filterFactory(button.query)),
   }));
 
+  let keptPenultimateButton = false;
+
   // Filter out useless buttons
   const filteredCompareButtons = compareButtonsWithItems.filter((compareButton, index) => {
     const nextCompareButton = compareButtonsWithItems[index + 1];
-    // always print the final button
+
+    // always print the final button, unless it matched the penultimate button
     if (!nextCompareButton) {
-      return true;
+      return !keptPenultimateButton;
     }
     // skip empty buttons
     if (!compareButton.items.length) {
       return false;
     }
-    // skip if the next button has [all of, & only] the exact same items in it
+    // if the next button has [all of, & only] the exact same items in it
     if (
-      compareButton.items.length === nextCompareButton.items.length &&
+      compareButton.items.length === nextCompareButton?.items.length &&
       compareButton.items.every((setItem) =>
-        nextCompareButton.items.some((nextSetItem) => nextSetItem === setItem)
+        nextCompareButton?.items.some((nextSetItem) => nextSetItem === setItem)
       )
     ) {
+      // do include this button, if the next button is the "includes sunset items" button.
+      // that's a confusing label to users with no sunset items.
+      if (exampleItem.bucket.inArmor && !nextCompareButton?.query.includes('not:sunset')) {
+        keptPenultimateButton = true;
+        return true;
+      }
+      // otherwise skip it. it's a redundant button.
       return false;
     }
     return true;

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -92,7 +92,7 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
           </PressTip>,
           <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,
         ],
-        query: `not:sunset perk:${exampleItemIntrinsic.name}`,
+        query: `not:sunset perk:${quoteFilterString(exampleItemIntrinsic.name)}`,
       },
 
     // armor 2.0 and needs to match energy capacity element

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -1,12 +1,13 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import ElementIcon from 'app/dim-ui/ElementIcon';
 import { ArmorSlotIcon, WeaponSlotIcon, WeaponTypeIcon } from 'app/dim-ui/ItemCategoryIcon';
+import { PressTip } from 'app/dim-ui/PressTip';
 import { SpecialtyModSlotIcon } from 'app/dim-ui/SpecialtyModSlotIcon';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { quoteFilterString } from 'app/search/query-parser';
 import { getInterestingSocketMetadatas, getItemDamageShortName } from 'app/utils/item-utils';
-import { getWeaponArchetype } from 'app/utils/socket-utils';
+import { getIntrinsicArmorPerkSocket, getWeaponArchetype } from 'app/utils/socket-utils';
 import rarityIcons from 'data/d2/engram-rarity-icons.json';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -32,6 +33,9 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
     />
   );
   const exampleItemModSlotMetadatas = getInterestingSocketMetadatas(exampleItem);
+  const exampleItemIntrinsic =
+    !exampleItem.isExotic &&
+    getIntrinsicArmorPerkSocket(exampleItem)?.plugged?.plugDef.displayProperties;
 
   let comparisonSets: CompareButton[] = _.compact([
     // same slot on the same class
@@ -76,6 +80,19 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
         query: `not:sunset ${exampleItemModSlotMetadatas
           .map((m) => `modslot:${m.slotTag || 'none'}`)
           .join(' ')}`,
+      },
+
+    // above but also the same special intrinsic, if it has one
+    exampleItem.destinyVersion === 2 &&
+      exampleItem.element &&
+      exampleItemIntrinsic && {
+        buttonLabel: [
+          <PressTip minimal tooltip={exampleItemIntrinsic.name} key="1">
+            <BungieImage key="2" className={styles.intrinsicIcon} src={exampleItemIntrinsic.icon} />
+          </PressTip>,
+          <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,
+        ],
+        query: `not:sunset perk:${exampleItemIntrinsic.name}`,
       },
 
     // armor 2.0 and needs to match energy capacity element

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -5,6 +5,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "arc",
   "armor",
   "armor2.0",
+  "armorintrinsic",
   "armormod",
   "autorifle",
   "blue",

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -6,7 +6,11 @@ import {
   modSlotTags,
   modTypeTags,
 } from 'app/utils/item-utils';
-import { countEnhancedPerks, getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import {
+  countEnhancedPerks,
+  getIntrinsicArmorPerkSocket,
+  getSocketsByCategoryHash,
+} from 'app/utils/socket-utils';
 import { DestinyItemSubType, DestinyRecordState } from 'bungie-api-ts/destiny2';
 import craftingMementos from 'data/d2/crafting-mementos.json';
 import {
@@ -186,14 +190,9 @@ const socketFilters: FilterDefinition[] = [
   },
   {
     keywords: 'armorintrinsic',
-    description: tl('Filter.Mods.Y3'),
+    description: tl('Filter.ArmorIntrinsic'),
     destinyVersion: 2,
-    filter: () => (item: DimItem) =>
-      item.sockets &&
-      !item.isExotic &&
-      getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorPerks_LargePerk).some(
-        (s) => s.plugged?.plugDef.displayProperties.name
-      ),
+    filter: () => (item: DimItem) => Boolean(!item.isExotic && getIntrinsicArmorPerkSocket(item)),
   },
   {
     keywords: 'holdsmod',

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -174,6 +174,7 @@
     "AmmoType": "Shows items based on their ammo type.",
     "Armor": "Shows items that are armor.",
     "ArmorCategory": "Shows armors based on their category.",
+    "ArmorIntrinsic": "Shows armor which has an intrinsic perk, such as Artifice Armor.",
     "Ascended": "Shows items that have an ascend node which have been ascended.",
     "Breaker": "Filter by breaker type or corresponding champion type.",
     "BulkClear": "Removed tag from 1 item.",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -174,7 +174,7 @@
     "AmmoType": "Shows items based on their ammo type.",
     "Armor": "Shows items that are armor.",
     "ArmorCategory": "Shows armors based on their category.",
-    "ArmorIntrinsic": "Shows armor which has an intrinsic perk, such as Artifice Armor.",
+    "ArmorIntrinsic": "Shows legendary armor which has an intrinsic perk, such as Artifice Armor.",
     "Ascended": "Shows items that have an ascend node which have been ascended.",
     "Breaker": "Filter by breaker type or corresponding champion type.",
     "BulkClear": "Removed tag from 1 item.",


### PR DESCRIPTION
filter:
finds artifice etc. accidentally already committed this to master whoops, PR just simplifies it and adds doc/string

compare:
compare button for comparing grasp armor to duality and vice versa. finally.

also:
fixed an annoying confusing label so now if a user has no sunset,
their "all helmets" button shows "helmets" instead of "helmets including sunset helmets"