### PR TITLE
Stop sending cookies with API requests

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -427,6 +427,8 @@ module.exports = (env) => {
         '$featureFlags.warnNoSync': JSON.stringify(!env.release),
         // Expose the "Add required stat mods" Loadout Optimizer toggle
         '$featureFlags.loAutoStatMods': JSON.stringify(!env.release),
+        // Whether to send cookies to the Bungie.net API
+        '$featureFlags.apiCookies': JSON.stringify(env.release),
       }),
 
       new LodashModuleReplacementPlugin({

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -60,7 +60,7 @@ export const authenticatedHttpClient = dimErrorHandledHttpClient(
           notifyTimeout
         ),
         API_KEY,
-        true
+        $featureFlags.apiCookies
       )
     ),
     logThrottle

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -32,6 +32,8 @@ declare const $featureFlags: {
   warnNoSync: boolean;
   /* Expose the "Add required stat mods" Loadout Optimizer toggle */
   loAutoStatMods: boolean;
+  /* Whether to send cookies to the Bungie.net API */
+  apiCookies: boolean;
 };
 
 declare function ga(...params: string[]): void;


### PR DESCRIPTION
Based on @afpac's info in https://github.com/DestinyItemManager/DIM/issues/8742, this changes to suppress sending cookies for all browsers, given that Chrome is already blocking them. Out of caution this is feature flagged so we still send cookies in the release version, so we can test it out. The expected outcome is that we see less "stale data" on Firefox and Safari browsers.