### PR TITLE
Show tooltips for why save/saveAsNew is disabled for Loadouts

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -629,8 +629,6 @@
     "AddEquippedItems": "Add Equipped",
     "AddNotes": "Add Notes",
     "AddUnequippedItems": "Add Unequipped",
-    "AlreadyExists": "A loadout with this name already exists for your {{className}}.",
-    "AlreadyExistsGlobal": "A global loadout with this name already exists.",
     "Any": "Any class",
     "AppliedAuto": "Automatic Loadout Builder",
     "Apply": "Apply",
@@ -723,6 +721,12 @@
     "SaveLoadout": "Save Loadout",
     "SaveAsNew": "Save as New",
     "SaveAsNewTooltip": "Keep the original loadout and save this as a new loadout",
+    "SaveDisabled": {
+      "Header": "This loadout cannot be saved",
+      "AlreadyExists": "Choose a new name for the loadout.",
+      "Empty": "The loadout is empty.",
+      "NoName": "The loadout needs a name."
+    },
     "SortByName": "Sort by name",
     "SortByEditTime": "Sort by last edited",
     "Share": {

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -722,7 +722,6 @@
     "SaveAsNew": "Save as New",
     "SaveAsNewTooltip": "Keep the original loadout and save this as a new loadout",
     "SaveDisabled": {
-      "Header": "This loadout cannot be saved",
       "AlreadyExists": "Choose a new name for the loadout.",
       "Empty": "The loadout is empty.",
       "NoName": "The loadout needs a name."

--- a/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
@@ -1,7 +1,7 @@
 import { ConfirmButton } from 'app/dim-ui/ConfirmButton';
+import { PressTip } from 'app/dim-ui/PressTip';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t } from 'app/i18next-t';
-import { getClass } from 'app/inventory/store/character-utils';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
 import { RootState } from 'app/store/types';
 import { currySelector } from 'app/utils/redux-utils';
@@ -48,26 +48,30 @@ export default function LoadoutDrawerFooter({
   // There's an existing loadout with the same name & class and it's not the loadout we are currently editing
   const clashesWithAnotherLoadout = clashingLoadout && clashingLoadout.id !== loadout.id;
 
-  const clashingLoadoutWarning = clashesWithAnotherLoadout
-    ? clashingLoadout.classType !== DestinyClass.Unknown
-      ? t('Loadouts.AlreadyExistsClass', {
-          className: getClass(clashingLoadout.classType),
-        })
-      : t('Loadouts.AlreadyExistsGlobal')
-    : undefined;
+  const saveDisabledReasons: string[] = [];
 
-  const saveDisabled =
-    !loadout.name.length ||
-    clashesWithAnotherLoadout ||
-    (!loadout.items.length &&
-      // Allow mod only loadouts
-      !loadout.parameters?.mods?.length &&
-      !loadout.parameters?.clearMods &&
-      // Allow fashion only loadouts
-      _.isEmpty(loadout.parameters?.modsByBucket));
+  if (!loadout.name.length) {
+    saveDisabledReasons.push(t('Loadouts.SaveDisabled.NoName'));
+  }
+  if (clashesWithAnotherLoadout) {
+    saveDisabledReasons.push(t('Loadouts.SaveDisabled.AlreadyExists'));
+  }
+
+  const loadoutEmpty =
+    !loadout.items.length &&
+    // Allow mod only loadouts
+    !loadout.parameters?.mods?.length &&
+    !loadout.parameters?.clearMods &&
+    // Allow fashion only loadouts
+    _.isEmpty(loadout.parameters?.modsByBucket);
+  if (loadoutEmpty) {
+    saveDisabledReasons.push(t('Loadouts.SaveDisabled.Empty'));
+  }
+
+  const saveDisabled = saveDisabledReasons.length > 0;
 
   // Don't show "Save as New" if this is a new loadout or we haven't changed the name
-  const showSaveAsNew = !isNew && (!clashingLoadout || clashingLoadout.id !== loadout.id);
+  const showSaveAsNew = !isNew;
 
   const saveAsNewDisabled =
     saveDisabled ||
@@ -76,34 +80,35 @@ export default function LoadoutDrawerFooter({
 
   return (
     <div className={styles.loadoutOptions}>
-      {clashingLoadoutWarning && <div>{clashingLoadoutWarning}</div>}
       <form onSubmit={(e) => onSaveLoadout(e, isNew)}>
-        <button
-          className="dim-button"
-          type="submit"
-          disabled={saveDisabled}
-          title={clashingLoadoutWarning}
+        <PressTip
+          tooltip={saveDisabledReasons.map((reason) => (
+            <div key={reason}>{reason}</div>
+          ))}
         >
-          {isNew ? t('Loadouts.Save') : t('Loadouts.Update')}
-        </button>
+          <button className="dim-button" type="submit" disabled={saveDisabled}>
+            {isNew ? t('Loadouts.Save') : t('Loadouts.Update')}
+          </button>
+        </PressTip>
         {showSaveAsNew && (
-          <button
-            className="dim-button"
-            onClick={(e) => onSaveLoadout(e, true)}
-            type="button"
-            title={
+          <PressTip
+            tooltip={
               clashingLoadout
-                ? clashingLoadout.classType !== DestinyClass.Unknown
-                  ? t('Loadouts.AlreadyExistsClass', {
-                      className: getClass(clashingLoadout.classType),
-                    })
-                  : t('Loadouts.AlreadyExistsGlobal')
+                ? t('Loadouts.SaveDisabled.AlreadyExists')
+                : saveDisabled
+                ? saveDisabledReasons.join('\n')
                 : t('Loadouts.SaveAsNewTooltip')
             }
-            disabled={saveAsNewDisabled}
           >
-            {t('Loadouts.SaveAsNew')}
-          </button>
+            <button
+              className="dim-button"
+              onClick={(e) => onSaveLoadout(e, true)}
+              type="button"
+              disabled={saveAsNewDisabled}
+            >
+              {t('Loadouts.SaveAsNew')}
+            </button>
+          </PressTip>
         )}
         {!isNew && (
           <ConfirmButton key="delete" danger onClick={onDeleteLoadout}>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -550,8 +550,6 @@
     "AddEquippedItems": "Add Equipped",
     "AddNotes": "Add Notes",
     "AddUnequippedItems": "Add Unequipped",
-    "AlreadyExistsClass": "",
-    "AlreadyExistsGlobal": "A global loadout with this name already exists.",
     "Any": "Any class",
     "Apply": "Apply",
     "ApplyMods": "Applying mods",
@@ -645,6 +643,11 @@
     "Save": "Save",
     "SaveAsNew": "Save as New",
     "SaveAsNewTooltip": "Keep the original loadout and save this as a new loadout",
+    "SaveDisabled": {
+      "AlreadyExists": "Choose a new name for the loadout.",
+      "Empty": "The loadout is empty.",
+      "NoName": "The loadout needs a name."
+    },
     "SaveLoadout": "Save Loadout",
     "Share": {
       "Copied": "Copied loadout link to clipboard",


### PR DESCRIPTION
Fixes https://github.com/DestinyItemManager/DIM/issues/8726 by adding presstips that explain why the Save button is disabled. I also switched to always showing Save as New for existing loadouts, but having a tooltip that explains you need to choose a new name.

<img width="289" alt="Screen Shot 2022-10-15 at 4 58 28 PM" src="https://user-images.githubusercontent.com/313208/196011809-88dee237-b9ba-40bd-a7f7-c3c51243a384.png">
<img width="289" alt="Screen Shot 2022-10-15 at 4 59 08 PM" src="https://user-images.githubusercontent.com/313208/196011811-3ff556e2-5de0-4a27-a4e9-182063e36af7.png">
