### PR TITLE
Sync from equipped

### DIFF
--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -437,7 +437,7 @@ export function fillLoadoutFromEquipped(
  * Replace all equipped items from the store's equipped items.
  */
 export function syncLoadoutCategoryFromEquipped(
-  defs: D2ManifestDefinitions,
+  defs: D2ManifestDefinitions | D1ManifestDefinitions,
   store: DimStore,
   category: D2BucketCategory
 ): LoadoutUpdateFunction {
@@ -481,13 +481,12 @@ export function syncLoadoutCategoryFromEquipped(
       };
     }
     // Save "fashion" mods for equipped items
-    const modsByBucket = {};
+    const modsByBucket: { [bucketHash: number]: number[] } = {};
     for (const item of newEquippedItems.filter((i) => i.bucket.inArmor)) {
       const plugs = item.sockets
-        ? _.compact(
-            getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics).map(
-              (s) => s.plugged?.plugDef.hash
-            )
+        ? filterMap(
+            getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.ArmorCosmetics),
+            (s) => s.plugged?.plugDef.hash
           )
         : [];
       if (plugs.length) {

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -444,7 +444,12 @@ export function syncLoadoutCategoryFromEquipped(
   return produce((loadout) => {
     let categoryHashes = D2Categories[category];
     if (category === 'General') {
-      categoryHashes = categoryHashes.filter((h) => h !== BucketHashes.Subclass);
+      categoryHashes = [
+        BucketHashes.Ghost,
+        BucketHashes.Emblems,
+        BucketHashes.Ships,
+        BucketHashes.Vehicle,
+      ];
     }
 
     // Remove equipped items from this bucket

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -339,6 +339,8 @@ function LoadoutEditCategorySection({
       onRandomize={() => handleRandomizeCategory(allItems, category, searchFilter)}
       hasRandomizeQuery={searchFilter !== _.stubTrue}
       onFillFromEquipped={() => handleFillCategoryFromEquipped(artifactUnlocks, category)}
+      fillFromEquippedDisabled={disableFillInForCategory(categories, category)}
+      onSyncFromEquipped={() => handleSyncCategoryFromEquipped(category)}
       fillFromInventoryCount={getUnequippedItemsForLoadout(store, category).length}
       onFillFromInventory={() => handleFillCategoryFromUnequipped(category)}
       onClearLoadoutParameters={

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -1,9 +1,10 @@
 import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
+import { D2Categories } from 'app/destiny2/d2-bucket-categories';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import CheckButton from 'app/dim-ui/CheckButton';
 import { t } from 'app/i18next-t';
-import { InventoryBucket } from 'app/inventory/inventory-buckets';
+import { D2BucketCategory, InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import {
   allItemsSelector,
@@ -34,6 +35,7 @@ import {
   setClearSpace,
   setLoadoutSubclassFromEquipped,
   syncArtifactUnlocksFromEquipped,
+  syncLoadoutCategoryFromEquipped,
   syncModsFromEquipped,
   toggleEquipped,
   updateMods,
@@ -327,6 +329,7 @@ function LoadoutEditCategorySection({
   const handleClearLoadoutParameters = useUpdater(clearLoadoutOptimizerParameters);
   const handleFillCategoryFromUnequipped = useDefsStoreUpdater(fillLoadoutFromUnequipped);
   const handleFillCategoryFromEquipped = useDefsStoreUpdater(fillLoadoutFromEquipped);
+  const handleSyncCategoryFromEquipped = useDefsStoreUpdater(syncLoadoutCategoryFromEquipped);
   const handleRandomizeCategory = useDefsStoreUpdater(randomizeLoadoutItems);
   const onRemoveItem = useDefsUpdater(removeItem);
   const handleSetClear = useUpdater(setClearSpace);
@@ -339,7 +342,7 @@ function LoadoutEditCategorySection({
       onRandomize={() => handleRandomizeCategory(allItems, category, searchFilter)}
       hasRandomizeQuery={searchFilter !== _.stubTrue}
       onFillFromEquipped={() => handleFillCategoryFromEquipped(artifactUnlocks, category)}
-      fillFromEquippedDisabled={disableFillInForCategory(categories, category)}
+      fillFromEquippedDisabled={disableFillInForCategory(items, category)}
       onSyncFromEquipped={() => handleSyncCategoryFromEquipped(category)}
       fillFromInventoryCount={getUnequippedItemsForLoadout(store, category).length}
       onFillFromInventory={() => handleFillCategoryFromUnequipped(category)}
@@ -494,4 +497,19 @@ function LoadoutArtifactUnlocksSection({
       </LoadoutEditSection>
     )
   );
+}
+
+/**
+ * Disable the "Fill in" menu item if it wouldn't do anything.
+ */
+function disableFillInForCategory(items: ResolvedLoadoutItem[], category: D2BucketCategory) {
+  const currentItems = items?.length ?? 0;
+  let maxItems = D2Categories[category].length;
+
+  // Remove the subclass from General
+  if (category === 'General') {
+    maxItems = 4;
+  }
+
+  return currentItems >= maxItems;
 }

--- a/src/app/loadout/loadout-edit/LoadoutEditSection.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSection.tsx
@@ -21,6 +21,7 @@ export default function LoadoutEditSection({
   className,
   onClear,
   onFillFromEquipped,
+  fillFromEquippedDisabled,
   onSyncFromEquipped,
   onRandomize,
   hasRandomizeQuery,
@@ -34,6 +35,7 @@ export default function LoadoutEditSection({
   className?: string;
   onClear: () => void;
   onFillFromEquipped?: () => void;
+  fillFromEquippedDisabled?: boolean;
   onSyncFromEquipped?: () => void;
   onRandomize?: () => void;
   hasRandomizeQuery?: boolean;
@@ -46,6 +48,7 @@ export default function LoadoutEditSection({
       ? {
           key: 'fillFromEquipped',
           onSelected: onFillFromEquipped,
+          disabled: fillFromEquippedDisabled,
           content: (
             <>
               <AppIcon icon={downloadIcon} /> {t('Loadouts.FillFromEquipped')}


### PR DESCRIPTION
Adds "Sync from equipped" to the menus in loadouts, to allow for completely replacing the equipped items in a section with the currently equipped items, rather than just filling them in. Also greyed out "Fill in" when there's nothing to fill in.

<img width="290" alt="Screen Shot 2022-10-15 at 5 53 58 PM" src="https://user-images.githubusercontent.com/313208/196012927-06b65054-995b-49ae-aa2a-90732ed3f95f.png">
