### PR TITLE
Fix twitter panels on error screens

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -125,7 +125,7 @@
     "Title": "Something went wrong"
   },
   "ErrorPanel": {
-    "Description": "This is likely an issue that affects all third-party apps. Check to see if Bungie.net loads, or the Destiny 2 Companion App works.",
+    "Description": "Try loading your inventory in the Destiny 2 Companion App to see if Bungie.net is down.",
     "Troubleshooting": "Troubleshooting Guide"
   },
   "FarmingMode": {

--- a/src/app/shell/ErrorPanel.m.scss
+++ b/src/app/shell/ErrorPanel.m.scss
@@ -40,13 +40,25 @@
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
+  @include flex-gap(16px);
 
   @include phone-portrait {
     flex-direction: column;
   }
+}
 
-  > div > div {
+.timeline {
+  box-sizing: border-box;
+  flex: 1;
+  position: relative;
+  border: 4px solid rgba(255, 255, 255, 0.3);
+
+  [twdiv='yes'] {
+    overflow: auto;
     height: 400px;
-    outline: 4px solid rgba(255, 255, 255, 0.3);
+    background-color: black;
+    @include phone-portrait {
+      height: 300px;
+    }
   }
 }

--- a/src/app/shell/ErrorPanel.m.scss.d.ts
+++ b/src/app/shell/ErrorPanel.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'errorCode': string;
   'errorPanel': string;
+  'timeline': string;
   'twitterLinks': string;
   'twitters': string;
 }

--- a/src/app/shell/ErrorPanel.tsx
+++ b/src/app/shell/ErrorPanel.tsx
@@ -2,7 +2,7 @@ import { BungieError, HttpStatusError } from 'app/bungie-api/http-client';
 import ExternalLink from 'app/dim-ui/ExternalLink';
 import { t } from 'app/i18next-t';
 import { DimError } from 'app/utils/dim-error';
-import React from 'react';
+import React, { useState } from 'react';
 import { AppIcon, helpIcon, refreshIcon, twitterIcon } from '../shell/icons';
 import styles from './ErrorPanel.m.scss';
 
@@ -14,38 +14,38 @@ const Timeline = React.lazy(async () => {
   return { default: m.Timeline };
 });
 
-const twitters = (
-  <div className={styles.twitters}>
-    <React.Suspense fallback={null}>
-      <Timeline
-        dataSource={{
-          sourceType: 'profile',
-          screenName: 'BungieHelp',
-        }}
-        options={{
-          dnt: true,
-          via: 'BungieHelp',
-          username: 'BungieHelp',
-          height: '100%',
-          theme: 'dark',
-        }}
-      />
-      <Timeline
-        dataSource={{
-          sourceType: 'profile',
-          screenName: 'ThisIsDIM',
-        }}
-        options={{
-          dnt: true,
-          via: 'ThisIsDIM',
-          username: 'ThisIsDIM',
-          height: '100%',
-          theme: 'dark',
-        }}
-      />
-    </React.Suspense>
-  </div>
-);
+function Twitters() {
+  const [error, setError] = useState(false);
+  // If the user has blocked twitter just don't show them
+  if (error) {
+    return null;
+  }
+  return (
+    <div className={styles.twitters}>
+      <React.Suspense fallback={null}>
+        {['BungieHelp', 'ThisIsDIM'].map((account) => (
+          <div key={account} className={styles.timeline}>
+            <Timeline
+              dataSource={{
+                sourceType: 'profile',
+                screenName: account,
+              }}
+              options={{
+                dnt: true,
+                theme: 'dark',
+                chrome: 'noheader nofooter noborders',
+              }}
+              renderError={() => {
+                setError(true);
+                return null;
+              }}
+            />
+          </div>
+        ))}
+      </React.Suspense>
+    </div>
+  );
+}
 
 export default function ErrorPanel({
   title,
@@ -117,7 +117,7 @@ export default function ErrorPanel({
           )}
         </div>
       </div>
-      {showTwitters && twitters}
+      {showTwitters && <Twitters />}
     </div>
   );
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -120,7 +120,7 @@
     "Title": "Something went wrong"
   },
   "ErrorPanel": {
-    "Description": "This is likely an issue that affects all third-party apps. Check to see if Bungie.net loads, or the Destiny 2 Companion App works.",
+    "Description": "Try loading your inventory in the Destiny 2 Companion App to see if Bungie.net is down.",
     "Troubleshooting": "Troubleshooting Guide"
   },
   "FarmingMode": {


### PR DESCRIPTION
Twitter changed something that had caused the inline timeline widgets to collapse.

Before:
<img width="1002" alt="Screen Shot 2022-10-22 at 6 38 31 PM" src="https://user-images.githubusercontent.com/313208/197369034-6c4b7b48-ca04-4099-8ad4-54899a93b72a.png">

Now, when they load:
<img width="1028" alt="Screen Shot 2022-10-22 at 5 44 21 PM" src="https://user-images.githubusercontent.com/313208/197369001-3f083504-c313-4d4e-8d4f-7f8015bb0e26.png">

When they don't:
<img width="991" alt="Screen Shot 2022-10-22 at 5 44 26 PM" src="https://user-images.githubusercontent.com/313208/197369005-3b0c7212-307a-4be2-bd2f-e74f7c73aa8b.png">
