### PR TITLE
Centralize mod categorization for mod assignment and LO

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -16,6 +16,7 @@ import { convertDimLoadoutToApiLoadout } from 'app/loadout-drawer/loadout-type-c
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { newLoadout, newLoadoutFromEquipped } from 'app/loadout-drawer/loadout-utils';
 import { loadoutsByItemSelector, loadoutsSelector } from 'app/loadout-drawer/selectors';
+import { categorizeArmorMods } from 'app/loadout/mod-assignment-utils';
 import { d2ManifestSelector, useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
 import { armorStats } from 'app/search/d2-known-values';
@@ -178,6 +179,11 @@ export default memo(function LoadoutBuilder({
     [defs, loadoutParameters.mods]
   );
 
+  const { modMap: lockedModMap, unassignedMods } = useMemo(
+    () => categorizeArmorMods(lockedMods, allItems),
+    [allItems, lockedMods]
+  );
+
   const selectedStore = stores.find((store) => store.id === selectedStoreId)!;
   const classType = selectedStore.classType;
 
@@ -270,27 +276,30 @@ export default memo(function LoadoutBuilder({
     if (loadoutParameters.assumeArmorMasterwork !== undefined) {
       armorEnergyRules.assumeArmorMasterwork = loadoutParameters.assumeArmorMasterwork;
     }
+
     const items = filterItems({
       defs,
       items: characterItems,
       pinnedItems,
       excludedItems,
-      lockedMods,
+      lockedModMap,
+      unassignedMods,
       lockedExoticHash,
       armorEnergyRules,
       searchFilter,
     });
     return [armorEnergyRules, items];
   }, [
-    loadoutParameters.lockArmorEnergyType,
-    loadoutParameters.assumeArmorMasterwork,
     loadoutsByItem,
     optimizingLoadoutId,
+    loadoutParameters.lockArmorEnergyType,
+    loadoutParameters.assumeArmorMasterwork,
     defs,
     characterItems,
     pinnedItems,
     excludedItems,
-    lockedMods,
+    lockedModMap,
+    unassignedMods,
     lockedExoticHash,
     searchFilter,
   ]);
@@ -299,7 +308,7 @@ export default memo(function LoadoutBuilder({
     defs,
     selectedStore,
     filteredItems,
-    lockedMods,
+    lockedModMap,
     subclass,
     armorEnergyRules,
     statOrder,

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -1,9 +1,4 @@
 import _ from 'lodash';
-import {
-  activityModPlugCategoryHashes,
-  knownModPlugCategoryHashes,
-} from '../../loadout/known-values';
-import { armor2PlugCategoryHashesByName } from '../../search/d2-known-values';
 import { infoLog } from '../../utils/log';
 import {
   ArmorStatHashes,
@@ -15,13 +10,7 @@ import {
 } from '../types';
 import { pickAndAssignSlotIndependentMods, precalculateStructures } from './process-utils';
 import { SetTracker } from './set-tracker';
-import {
-  LockedProcessMods,
-  ProcessArmorSet,
-  ProcessItem,
-  ProcessItemsByBucket,
-  ProcessMod,
-} from './types';
+import { LockedProcessMods, ProcessArmorSet, ProcessItem, ProcessItemsByBucket } from './types';
 
 /** Caps the maximum number of total armor sets that'll be returned */
 const RETURNED_ARMOR_SETS = 200;
@@ -36,7 +25,7 @@ export function process(
   /** Selected mods' total contribution to each stat */
   modStatTotals: ArmorStats,
   /** Mods to add onto the sets */
-  lockedModMap: LockedProcessMods,
+  lockedMods: LockedProcessMods,
   /** The user's chosen stat order, including disabled stats */
   statOrder: ArmorStatHashes[],
   statFilters: StatFilters,
@@ -102,20 +91,7 @@ export function process(
 
   const setTracker = new SetTracker(10_000);
 
-  let generalMods: ProcessMod[] = [];
-  let combatMods: ProcessMod[] = [];
-  let activityMods: ProcessMod[] = [];
-
-  for (const [plugCategoryHash, mods] of Object.entries(lockedModMap)) {
-    const pch = Number(plugCategoryHash);
-    if (pch === armor2PlugCategoryHashesByName.general) {
-      generalMods = generalMods.concat(mods);
-    } else if (activityModPlugCategoryHashes.includes(pch)) {
-      activityMods = activityMods.concat(mods);
-    } else if (!knownModPlugCategoryHashes.includes(pch)) {
-      combatMods = combatMods.concat(mods);
-    }
-  }
+  const { activityMods, combatMods, generalMods } = lockedMods;
 
   const precalculatedInfo = precalculateStructures(
     generalMods,

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -62,5 +62,7 @@ export interface ProcessMod {
 }
 
 export interface LockedProcessMods {
-  [plugCategoryHash: number]: ProcessMod[];
+  generalMods: ProcessMod[];
+  combatMods: ProcessMod[];
+  activityMods: ProcessMod[];
 }

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -9,12 +9,12 @@ import _ from 'lodash';
 import { isArmorEnergyLocked } from './armor-upgrade-utils';
 import { knownModPlugCategoryHashes } from './known-values';
 
-export const bucketHashToPlugCategoryHash = {
-  [armorBuckets.helmet]: armor2PlugCategoryHashesByName.helmet,
-  [armorBuckets.gauntlets]: armor2PlugCategoryHashesByName.gauntlets,
-  [armorBuckets.chest]: armor2PlugCategoryHashesByName.chest,
-  [armorBuckets.leg]: armor2PlugCategoryHashesByName.leg,
-  [armorBuckets.classitem]: armor2PlugCategoryHashesByName.classitem,
+export const plugCategoryHashToBucketHash = {
+  [armor2PlugCategoryHashesByName.helmet]: armorBuckets.helmet,
+  [armor2PlugCategoryHashesByName.gauntlets]: armorBuckets.gauntlets,
+  [armor2PlugCategoryHashesByName.chest]: armorBuckets.chest,
+  [armor2PlugCategoryHashesByName.leg]: armorBuckets.leg,
+  [armor2PlugCategoryHashesByName.classitem]: armorBuckets.classitem,
 };
 
 /**


### PR DESCRIPTION
Refactoring without intended behavioral changes -- while working on #8798 I noticed this sort of mod categorization by bucket hash and mod "column" was going on in many different places and would have to be duplicated again for LO error reporting, so I figured this should happen in a central place.