### PR TITLE
Show hidden objective for deepsight items

### DIFF
--- a/src/app/dim-ui/WeaponDeepsightInfo.tsx
+++ b/src/app/dim-ui/WeaponDeepsightInfo.tsx
@@ -28,7 +28,7 @@ export function WeaponDeepsightInfo({ item }: { item: DimItem }) {
         <>
           <PatternUnlockedIndicator record={record} />
           <div className={styles.deepsightProgressSection}>
-            <Objective objective={deepsightInfo.attunementObjective} />
+            <Objective objective={deepsightInfo.attunementObjective} showHidden />
           </div>
         </>
       ) : (
@@ -36,7 +36,7 @@ export function WeaponDeepsightInfo({ item }: { item: DimItem }) {
         relevantObjectives.length > 0 && (
           <div className={styles.deepsightProgressSection}>
             {relevantObjectives.map((objective) => (
-              <Objective key={objective.objectiveHash} objective={objective} />
+              <Objective key={objective.objectiveHash} objective={objective} showHidden />
             ))}
           </div>
         )

--- a/src/app/progress/Objective.tsx
+++ b/src/app/progress/Objective.tsx
@@ -23,10 +23,12 @@ export default function Objective({
   objective,
   suppressObjectiveDescription,
   isTrialsPassage,
+  showHidden,
 }: {
   objective: DestinyObjectiveProgress | D1ObjectiveProgress;
   suppressObjectiveDescription?: boolean;
   isTrialsPassage?: boolean;
+  showHidden?: boolean;
 }) {
   const defs = useDefinitions()!;
   const objectiveDef = defs.Objective.get(objective.objectiveHash);
@@ -60,7 +62,7 @@ export default function Objective({
     (complete ? t('Objectives.Complete') : t('Objectives.Incomplete'));
 
   const valueStyle = getValueStyle(objectiveDef, progress, completionValue);
-  if (valueStyle === DestinyUnlockValueUIStyle.Hidden) {
+  if (!showHidden && valueStyle === DestinyUnlockValueUIStyle.Hidden) {
     return null;
   }
 


### PR DESCRIPTION
I accidentally hid the deepsight objective because its completed value style is hidden. This brings it back somewhat manually. I'm also happy to just omit the deepsight section when it's complete, if folks prefer.

<img width="364" alt="Screen Shot 2022-10-26 at 10 51 02 PM" src="https://user-images.githubusercontent.com/313208/198202450-7d030273-30f9-4084-bc1a-9b3e49e0aa15.png">
