### PR TITLE
When creating default socketOverrides for subclass abilities, prefer what's plugged there

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Applying a Loadout with subclass configuration should now avoid pointless reordering of Aspects and Fragments in their slots.
+* When selecting a subclass in Loadout Optimizer, it will now start configured with your currently equipped super and abilities (but not aspects or fragments).
 
 ## 7.41.0 <span class="changelog-date">(2022-10-30)</span>
 

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -128,7 +128,11 @@ export function createSubclassDefaultSocketOverrides(item: DimItem) {
     ]);
 
     for (const socket of abilityAndSuperSockets) {
-      socketOverrides[socket.socketIndex] = getDefaultAbilityChoiceHash(socket);
+      socketOverrides[socket.socketIndex] =
+        socket.plugged &&
+        socket.plugSet?.plugs.some((plug) => plug.plugDef.hash === socket.plugged!.plugDef.hash)
+          ? socket.plugged.plugDef.hash
+          : getDefaultAbilityChoiceHash(socket);
     }
     return socketOverrides;
   }


### PR DESCRIPTION
Three times this season I forgot to switch to High Lift in LO and only realized this upon performing Strafe Lift in loadout locked activities. I feel like this is a reasonable default.