### PR TITLE
Validate Clarity responses a bit

### DIFF
--- a/src/app/clarity/descriptions/loadDescriptions.ts
+++ b/src/app/clarity/descriptions/loadDescriptions.ts
@@ -2,6 +2,7 @@ import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { errorLog } from 'app/utils/log';
 import { dedupePromise } from 'app/utils/util';
+import _ from 'lodash';
 import * as actions from '../actions';
 import { ClarityDescription, ClarityVersions } from './descriptionInterface';
 
@@ -12,7 +13,13 @@ const urls = {
 
 const fetchClarity = async (type: keyof typeof urls) => {
   const data = await fetch(urls[type]);
+  if (!data.ok) {
+    throw new Error('failed to fetch ' + type);
+  }
   const json = await data.json();
+  if (_.isEmpty(json)) {
+    throw new Error('empty response JSON for ' + type);
+  }
   return json;
 };
 


### PR DESCRIPTION
Not sure if this was the issue in #8820 but it couldn't hurt to validate responses to make sure we don't save a response to IDB when they don't load correctly. cc @Ice-mourne 