### PR TITLE
Fix compare regression from search query validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Applying a Loadout with subclass configuration should now avoid pointless reordering of Aspects and Fragments in their slots.
 * When selecting a subclass in Loadout Optimizer, it will now start configured with your currently equipped super and abilities (but not aspects or fragments).
+* Fixed Compare drawer closing when clicking the button to compare all of a certain weapon type.
 
 ## 7.41.0 <span class="changelog-date">(2022-10-30)</span>
 

--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -70,7 +70,7 @@ export const compare: Reducer<CompareState, CompareAction> = (
         ...state,
         session: {
           ...state.session,
-          query: `(${action.payload})`,
+          query: action.payload ? `(${action.payload})` : '',
         },
       };
     }


### PR DESCRIPTION
There's probably a cleaner fix involving not abusing the `id` filters to include/exclude items from compare internally so that we don't have to parenthesize queries in the first place, but this just fixes the regression. 