### PR TITLE
Add transmog currencies to material dropdown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Applying a Loadout with subclass configuration should now avoid pointless reordering of Aspects and Fragments in their slots.
 * When selecting a subclass in Loadout Optimizer, it will now start configured with your currently equipped super and abilities (but not aspects or fragments).
 * Fixed Compare drawer closing when clicking the button to compare all of a certain weapon type.
+* The Materials menu now includes Transmog currencies (Synthweave Bolts/Straps/Plates).
 
 ## 7.41.0 <span class="changelog-date">(2022-10-30)</span>
 

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -96,6 +96,19 @@ export const currenciesSelector = createSelector(
   (currencies) => currencies.filter((c) => visibleCurrencies.includes(c.itemHash))
 );
 
+const transmogCurrencies = [
+  1583786617, // InventoryItem "Synthweave Template"
+  4238733045, // InventoryItem "Synthweave Plate"
+  1498161294, // InventoryItem "Synthweave Bolt"
+  4019412287, // InventoryItem "Synthweave Strap"
+];
+
+/** Synthweave {Template, Bolt, Plate, Strap} currencies */
+export const transmogCurrenciesSelector = createSelector(
+  (state: RootState) => state.inventory.currencies,
+  (currencies) => currencies.filter((c) => transmogCurrencies.includes(c.itemHash))
+);
+
 /** materials/currencies that aren't top level stuff */
 export const materialsSelector = (state: RootState) =>
   allItemsSelector(state).filter(

--- a/src/app/material-counts/MaterialCounts.tsx
+++ b/src/app/material-counts/MaterialCounts.tsx
@@ -3,6 +3,7 @@ import {
   craftingMaterialCountsSelector,
   currenciesSelector,
   materialsSelector,
+  transmogCurrenciesSelector,
 } from 'app/inventory/selectors';
 import clsx from 'clsx';
 import spiderMats from 'data/d2/spider-mats.json';
@@ -29,6 +30,7 @@ export function MaterialCounts({
   const materials = _.groupBy(allMats, (m) => m.hash);
 
   const currencies = useSelector(currenciesSelector);
+  const transmogCurrencies = useSelector(transmogCurrenciesSelector);
 
   return (
     <div className={clsx(styles.materialCounts, { [styles.wide]: wide })}>
@@ -83,6 +85,20 @@ export function MaterialCounts({
           })}
         </React.Fragment>
       ))}
+      {transmogCurrencies.length > 0 && (
+        <>
+          <span className={styles.spanGrid}>
+            <hr />
+          </span>
+          {transmogCurrencies.map((currency) => (
+            <div className={styles.material} key={currency.itemHash}>
+              <span className={styles.amount}>{currency.quantity.toLocaleString()}</span>
+              <BungieImage src={currency.displayProperties.icon} />
+              <span>{currency.displayProperties.name}</span>
+            </div>
+          ))}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
I was briefly trying to allow all currencies and then saw the two indistinguishable event tickets from Solstice and FotL there and realized it would probably be not a great idea.