### PR TITLE
Strip the (Harrowed) suffix for adept KF weapon comparison too, determine suffixes programatically

### DIFF
--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -10,6 +10,7 @@ import { quoteFilterString } from 'app/search/query-parser';
 import { getInterestingSocketMetadatas, getItemDamageShortName } from 'app/utils/item-utils';
 import { warnLog } from 'app/utils/log';
 import { getIntrinsicArmorPerkSocket, getWeaponArchetype } from 'app/utils/socket-utils';
+import { escapeRegExp } from 'app/utils/util';
 import rarityIcons from 'data/d2/engram-rarity-icons.json';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -162,7 +163,7 @@ const exampleAdeptVersions: [baseHash: number, adeptHash: number][] = [
 ];
 
 const collectAdeptSuffixes = memoizeOne((defs: D2ManifestDefinitions) => {
-  const suffixes: string[] = [];
+  const suffixes: RegExp[] = [];
 
   for (const [baseHash, adeptHash] of exampleAdeptVersions) {
     const baseDef = defs.InventoryItem.get(baseHash);
@@ -172,7 +173,7 @@ const collectAdeptSuffixes = memoizeOne((defs: D2ManifestDefinitions) => {
       .trim();
     if (suffix && suffix.length !== adeptDef.displayProperties.name.length) {
       // baseName is a proper substring of adeptName
-      suffixes.push(suffix);
+      suffixes.push(new RegExp(escapeRegExp(suffix), 'gi'));
     } else {
       warnLog('item comparison', 'bad base -> adept mapping', baseHash, adeptHash);
     }

--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -4,7 +4,6 @@ import { showNotification } from 'app/notifications/notifications';
 import { getSelectionTree } from 'app/organizer/ItemTypeSelector';
 import { ActionType, getType, Reducer } from 'typesafe-actions';
 import * as actions from './actions';
-import { stripAdept } from './compare-buttons';
 
 export interface CompareSession {
   /**
@@ -129,9 +128,7 @@ function addCompareItem(state: CompareState, item: DimItem): CompareState {
     // Start a new session
     const itemCategoryHashes = getItemCategoryHashesFromExampleItem(item);
 
-    const itemNameQuery = item.bucket.inWeapons
-      ? `name:"${stripAdept(item.name)}"`
-      : `name:"${item.name}"`;
+    const itemNameQuery = `name:"${item.comparisonName}"`;
 
     const vendorCharacterId = item.vendor?.characterId;
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -229,6 +229,8 @@ export interface DimItem {
   collectibleState?: DestinyCollectibleState;
   /** Extra tooltips to show in the item popup */
   tooltipNotifications?: DestinyItemTooltipNotification[];
+  /** A simplified name of the item for comparison purposes, e.g. without the (Adept)/master raid variant suffix */
+  comparisonName: string;
 }
 
 /**

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -353,6 +353,7 @@ function makeItem(
     energy: null,
     powerCap: null,
     pursuit: null,
+    comparisonName: itemDef.itemName,
   };
 
   // *able

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -1,3 +1,4 @@
+import { stripAdeptSuffix } from 'app/compare/compare-buttons';
 import { D2Categories } from 'app/destiny2/d2-bucket-categories';
 import { t } from 'app/i18next-t';
 import { isTrialsPassage, isWinsObjective } from 'app/inventory/store/objectives';
@@ -569,6 +570,7 @@ export function makeItem(
     masterworkInfo: null,
     infusionQuality: null,
     tooltipNotifications,
+    comparisonName: normalBucket.inWeapons ? stripAdeptSuffix(defs, name) : name,
   };
 
   // *able

--- a/src/app/item-triage/triage-factors.tsx
+++ b/src/app/item-triage/triage-factors.tsx
@@ -1,4 +1,3 @@
-import { stripAdept } from 'app/compare/compare-buttons';
 import BungieImage from 'app/dim-ui/BungieImage';
 import ElementIcon from 'app/dim-ui/ElementIcon';
 import { PressTip } from 'app/dim-ui/PressTip';
@@ -60,7 +59,7 @@ const itemFactors: Record<string, Factor> = {
         <span>{item.name}</span>
       </>
     ),
-    filter: (item) => `name:"${stripAdept(item.name)}"`,
+    filter: (item) => `name:"${item.comparisonName}"`,
   },
   element: {
     id: 'element', //             don't compare exotic weapon elements, that's silly.

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -292,6 +292,7 @@ function makeFakePursuitItem(
     trackable: false,
     energy: null,
     powerCap: null,
+    comparisonName: displayProperties.name,
   };
 }
 

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -4,6 +4,7 @@ import { tl } from 'app/i18next-t';
 import { getNotes } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
 import { isD1Item } from 'app/utils/item-utils';
+import { escapeRegExp } from 'app/utils/util';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import memoizeOne from 'memoize-one';
@@ -12,11 +13,6 @@ import { quoteFilterString } from '../query-parser';
 
 /** global language bool. "latin" character sets are the main driver of string processing changes */
 const isLatinBased = (language: string) => DIM_LANG_INFOS[language].latinBased;
-
-/** escape special characters for a regex */
-function escapeRegExp(s: string) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /** Remove diacritics from latin-based string */
 function latinize(s: string, language: string) {

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -125,3 +125,8 @@ export function uniqBy<T, K>(data: Iterable<T>, iteratee: (input: T) => K): T[] 
   }
   return result;
 }
+
+/** escape special characters for a regex */
+export function escapeRegExp(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -176,7 +176,6 @@
     "Instructions": "Click or drag files"
   },
   "Filter": {
-    "Adept": "\\(Adept\\)",
     "AmmoType": "Shows items based on their ammo type.",
     "Armor": "Shows items that are armor.",
     "ArmorCategory": "Shows armors based on their category.",
@@ -283,7 +282,6 @@
       "Tag": "Shows items that have a specific tag.",
       "Tagged": "Shows items that have any tag."
     },
-    "Timelost": "\\(Timelost\\)",
     "Tracked": "Shows quests/bounties based on their tracked status.",
     "Transferable": "Items that can be moved between characters.",
     "Trashlist": "Shows items that match your wish list's trash list.",


### PR DESCRIPTION
Hardcoding+localizing these suffixes is sort of unsatisfying because it should be possible to programatically determine these from example items, so that's what it'd look like. But it's a pain to get the defs everywhere we need; they're only readily available at item creation time which also doesn't look that great... (ideas welcome)

Alternatively we can just continue to hardcode+localize the Harrowed suffix and whatever suffixes Bungie comes up with in the future.