### PR TITLE
[Issue #8807] Gilding Triumph Indicators

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1208,7 +1208,8 @@
   },
   "Triumphs": {
     "HideCompleted": "Hide completed triumphs",
-    "RevealRedacted": "Reveal redacted triumphs"
+    "RevealRedacted": "Reveal redacted triumphs",
+    "GildingTriumph": "Gilding Triumph"
   },
   "VendorEngramsXyz": {
     "DroppingHigh": "VendorEngrams.xyz reports that this vendor is dropping high-level items.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Gilding Triumphs for Seals are now denoted with a background, darker colors, and label text.
 
 ## 7.42.0 <span class="changelog-date">(2022-11-06)</span>
 
@@ -6,7 +7,6 @@
 * When selecting a subclass in Loadout Optimizer, it will now start configured with your currently equipped super and abilities (but not aspects or fragments).
 * Fixed Compare drawer closing when clicking the button to compare all of a certain weapon type.
 * The Materials menu now includes Transmog currencies (Synthweave Bolts/Straps/Plates).
-* Gilding Triumphs for Seals are now denoted with a background, darker colors, and label text.
 
 ## 7.41.0 <span class="changelog-date">(2022-10-30)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * When selecting a subclass in Loadout Optimizer, it will now start configured with your currently equipped super and abilities (but not aspects or fragments).
 * Fixed Compare drawer closing when clicking the button to compare all of a certain weapon type.
 * The Materials menu now includes Transmog currencies (Synthweave Bolts/Straps/Plates).
+* Gilding Triumphs for Seals are now denoted with a background, darker colors, and label text.
 
 ## 7.41.0 <span class="changelog-date">(2022-10-30)</span>
 

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -39,6 +39,7 @@ $power: $gold;
 // Color of the item border for masterworks
 $masterwork-border-color: #eade8b;
 $deepsight-border-color: #d25336;
+$gilded-triumph-border-color: #a78355;
 
 // Yellow used for enhanced weapon perks
 $enhancedYellow: #f3cf55;

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -25,6 +25,14 @@
     color: #a1a2a2;
     white-space: pre-wrap;
   }
+
+  p.gildingText {
+    margin: 8px 0 0 0;
+  }
+
+  p + p.gildingText {
+    margin: 0;
+  }
 }
 
 .obscured h3 {
@@ -81,7 +89,7 @@
       scale-color(#a1a2a2, $alpha: -80%) 1px,
       transparent calc(25% + 1px)
     );
-  background-size: 70px 100%;
+  background-size: 60px 100%;
   // The following offset and repeat settings
   // prevent the two gradients making up the chevron pattern
   // (which both use reduced opacity colors) from overlapping
@@ -111,6 +119,10 @@
       scale-color($gilded-triumph-border-color, $alpha: -80%) 1px,
       transparent calc(25% + 1px)
     );
+}
+
+.gildingText {
+  font-style: italic;
 }
 
 .dimTrackedIcon {

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -117,23 +117,6 @@
     );
 }
 
-.gildingGlow {
-  display: none;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  background: linear-gradient(
-    scale-color($gilded-triumph-border-color, $alpha: -100%) 80%,
-    scale-color($gilded-triumph-border-color, $alpha: -90%) 100%
-  );
-}
-
-.gildingTriumph.redeemed .gildingGlow {
-  display: block;
-}
-
 .redeemed .gildingText {
   opacity: 0.5;
 }
@@ -165,6 +148,9 @@
     display: block;
     opacity: 1;
     top: -10px;
+  }
+  .gildingTriumph & {
+    top: -22px;
   }
   .triumphRecord:hover & {
     display: block;

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -68,6 +68,51 @@
   );
 }
 
+.gildingTriumph {
+  background-image: linear-gradient(
+      to left bottom,
+      transparent 25%,
+      scale-color(#a1a2a2, $alpha: -80%) 1px,
+      transparent calc(25% + 1px)
+    ),
+    linear-gradient(
+      to left top,
+      transparent 25%,
+      scale-color(#a1a2a2, $alpha: -80%) 1px,
+      transparent calc(25% + 1px)
+    );
+  background-size: 70px 100%;
+  // The following offset and repeat settings
+  // prevent the two gradients making up the chevron pattern
+  // (which both use reduced opacity colors) from overlapping
+  // at the 0 point, which prevents that one point from being
+  // more saturated than the rest of the lines.
+  // There is no visible gap.
+  background-position: 0 0, 0 2px;
+  background-repeat: repeat-x;
+}
+
+.redeemed.gildingTriumph {
+  border-color: $gilded-triumph-border-color;
+  // background: linear-gradient(
+  //   scale-color($gilded-triumph-border-color, $alpha: -100%) 80%,
+  //   scale-color($gilded-triumph-border-color, $alpha: -82%) 100%
+  // );
+  // background-size: 100px 100px;
+  background-image: linear-gradient(
+      to left bottom,
+      transparent 25%,
+      scale-color($gilded-triumph-border-color, $alpha: -80%) 1px,
+      transparent calc(25% + 1px)
+    ),
+    linear-gradient(
+      to left top,
+      transparent 25%,
+      scale-color($gilded-triumph-border-color, $alpha: -80%) 1px,
+      transparent calc(25% + 1px)
+    );
+}
+
 .dimTrackedIcon {
   position: absolute;
   display: none;

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -102,11 +102,6 @@
 
 .redeemed.gildingTriumph {
   border-color: $gilded-triumph-border-color;
-  // background: linear-gradient(
-  //   scale-color($gilded-triumph-border-color, $alpha: -100%) 80%,
-  //   scale-color($gilded-triumph-border-color, $alpha: -82%) 100%
-  // );
-  // background-size: 100px 100px;
   background-image: linear-gradient(
       to left bottom,
       transparent 25%,
@@ -119,6 +114,23 @@
       scale-color($gilded-triumph-border-color, $alpha: -80%) 1px,
       transparent calc(25% + 1px)
     );
+}
+
+.gildingGlow {
+  display: none;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: linear-gradient(
+    scale-color($gilded-triumph-border-color, $alpha: -100%) 80%,
+    scale-color($gilded-triumph-border-color, $alpha: -90%) 100%
+  );
+}
+
+.gildingTriumph.redeemed .gildingGlow {
+  display: block;
 }
 
 .gildingText {
@@ -168,6 +180,7 @@
 
 .info {
   flex: 1;
+  position: relative;
 }
 
 .recordLore {

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -36,31 +36,6 @@
   }
 }
 
-.glow {
-  display: none;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
-.trackedInDim .glow {
-  display: block;
-  background: linear-gradient(
-    scale-color($orange, $alpha: -100%) 0%,
-    scale-color($orange, $alpha: -80%) 100%
-  );
-}
-
-.redeemed.gildingTriumph .glow {
-  display: block;
-  background: linear-gradient(
-    scale-color($gilded-triumph-border-color, $alpha: -100%) 80%,
-    scale-color($gilded-triumph-border-color, $alpha: -90%) 100%
-  );
-}
-
 .obscured h3 {
   color: #a1a2a2;
 }
@@ -96,6 +71,7 @@
   position: relative;
   border-color: #f37423;
   outline: 1px solid #f37423;
+  background: transparent;
 }
 
 .gildingTriumph {
@@ -138,6 +114,31 @@
     );
 }
 
+.glow {
+  display: none;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.trackedInDim .glow {
+  display: block;
+  background: linear-gradient(
+    scale-color($orange, $alpha: -100%) 0%,
+    scale-color($orange, $alpha: -80%) 100%
+  );
+}
+
+.redeemed.gildingTriumph .glow {
+  display: block;
+  background: linear-gradient(
+    scale-color($gilded-triumph-border-color, $alpha: -100%) 80%,
+    scale-color($gilded-triumph-border-color, $alpha: -90%) 100%
+  );
+}
+
 .redeemed .gildingText {
   opacity: 0.5;
 }
@@ -169,9 +170,6 @@
     display: block;
     opacity: 1;
     top: -10px;
-  }
-  .gildingTriumph & {
-    top: -22px;
   }
   .triumphRecord:hover & {
     display: block;

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -87,6 +87,9 @@
       scale-color(#a1a2a2, $alpha: -80%) 1px,
       transparent calc(25% + 1px)
     );
+  // To increase the number of chevrons in the background
+  // decrease the first number of `background-size`, and vice versa for
+  // decreasing.
   background-size: 60px 100%;
   // The following offset and repeat settings
   // prevent the two gradients making up the chevron pattern

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -28,6 +28,7 @@
 
   p.gildingText {
     margin: 8px 0 0 0;
+    color: white;
   }
 
   p + p.gildingText {
@@ -133,8 +134,8 @@
   display: block;
 }
 
-.gildingText {
-  font-style: italic;
+.redeemed .gildingText {
+  opacity: 0.5;
 }
 
 .dimTrackedIcon {

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -36,6 +36,31 @@
   }
 }
 
+.glow {
+  display: none;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.trackedInDim .glow {
+  display: block;
+  background: linear-gradient(
+    scale-color($orange, $alpha: -100%) 0%,
+    scale-color($orange, $alpha: -80%) 100%
+  );
+}
+
+.redeemed.gildingTriumph .glow {
+  display: block;
+  background: linear-gradient(
+    scale-color($gilded-triumph-border-color, $alpha: -100%) 80%,
+    scale-color($gilded-triumph-border-color, $alpha: -90%) 100%
+  );
+}
+
 .obscured h3 {
   color: #a1a2a2;
 }
@@ -71,10 +96,6 @@
   position: relative;
   border-color: #f37423;
   outline: 1px solid #f37423;
-  background: linear-gradient(
-    scale-color($orange, $alpha: -100%) 0%,
-    scale-color($orange, $alpha: -80%) 100%
-  );
 }
 
 .gildingTriumph {

--- a/src/app/records/Record.m.scss.d.ts
+++ b/src/app/records/Record.m.scss.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'dimTrackedIcon': string;
   'gildingText': string;
   'gildingTriumph': string;
+  'glow': string;
   'icon': string;
   'info': string;
   'interval': string;

--- a/src/app/records/Record.m.scss.d.ts
+++ b/src/app/records/Record.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'complete': string;
   'currentScore': string;
   'dimTrackedIcon': string;
+  'gildingTriumph': string;
   'icon': string;
   'info': string;
   'interval': string;

--- a/src/app/records/Record.m.scss.d.ts
+++ b/src/app/records/Record.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'complete': string;
   'currentScore': string;
   'dimTrackedIcon': string;
+  'gildingText': string;
   'gildingTriumph': string;
   'icon': string;
   'info': string;

--- a/src/app/records/Record.m.scss.d.ts
+++ b/src/app/records/Record.m.scss.d.ts
@@ -4,7 +4,6 @@ interface CssExports {
   'complete': string;
   'currentScore': string;
   'dimTrackedIcon': string;
-  'gildingGlow': string;
   'gildingText': string;
   'gildingTriumph': string;
   'icon': string;

--- a/src/app/records/Record.m.scss.d.ts
+++ b/src/app/records/Record.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'complete': string;
   'currentScore': string;
   'dimTrackedIcon': string;
+  'gildingGlow': string;
   'gildingText': string;
   'gildingTriumph': string;
   'icon': string;

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -171,18 +171,17 @@ export default function Record({
       className={clsx(styles.triumphRecord, {
         [styles.redeemed]: acquired,
         [styles.unlocked]: unlocked,
+        [styles.gildingTriumph]: recordDef.forTitleGilding,
         [styles.obscured]: obscured,
         [styles.tracked]: trackedInGame,
         [styles.trackedInDim]: trackedInDim,
         [styles.multistep]: intervals.length > 0,
-        [styles.gildingTriumph]: record.recordDef.forTitleGilding,
       })}
     >
       {!hideRecordIcon && recordIcon && <BungieImage className={styles.icon} src={recordIcon} />}
       <div className={styles.info}>
         {!obscured && recordDef.completionInfo && <div className={styles.score}>{scoreValue}</div>}
         <h3>{name}</h3>
-        {record.recordDef.forTitleGilding && <p>{t('Triumphs.GildingTriumph')}</p>}
         {description && (
           <p>
             <RichDestinyText text={description} />
@@ -207,6 +206,9 @@ export default function Record({
           !acquired &&
           !obscured &&
           rewards.map((reward) => <Reward key={reward.itemHash} reward={reward} />)}
+        {recordDef.forTitleGilding && !obscured && (
+          <p className={styles.gildingText}>{t('Triumphs.GildingTriumph')}</p>
+        )}
         {trackedInGame && <img className={styles.trackedIcon} src={trackedIcon} />}
         {(!acquired || trackedInDim) && (
           <div role="button" onClick={toggleTracked} className={styles.dimTrackedIcon}>

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -178,7 +178,6 @@ export default function Record({
         [styles.multistep]: intervals.length > 0,
       })}
     >
-      <div className={styles.gildingGlow} />
       {!hideRecordIcon && recordIcon && <BungieImage className={styles.icon} src={recordIcon} />}
       <div className={styles.info}>
         {!obscured && recordDef.completionInfo && <div className={styles.score}>{scoreValue}</div>}

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -211,12 +211,12 @@ export default function Record({
           <p className={styles.gildingText}>{t('Triumphs.GildingTriumph')}</p>
         )}
         {trackedInGame && <img className={styles.trackedIcon} src={trackedIcon} />}
-        {(!acquired || trackedInDim) && (
-          <div role="button" onClick={toggleTracked} className={styles.dimTrackedIcon}>
-            <img src={dimTrackedIcon} />
-          </div>
-        )}
       </div>
+      {(!acquired || trackedInDim) && (
+        <div role="button" onClick={toggleTracked} className={styles.dimTrackedIcon}>
+          <img src={dimTrackedIcon} />
+        </div>
+      )}
       {intervalProgressBar}
     </div>
   );

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -178,6 +178,7 @@ export default function Record({
         [styles.multistep]: intervals.length > 0,
       })}
     >
+      <div className={styles.glow} />
       {!hideRecordIcon && recordIcon && <BungieImage className={styles.icon} src={recordIcon} />}
       <div className={styles.info}>
         {!obscured && recordDef.completionInfo && <div className={styles.score}>{scoreValue}</div>}

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -178,6 +178,7 @@ export default function Record({
         [styles.multistep]: intervals.length > 0,
       })}
     >
+      <div className={styles.gildingGlow} />
       {!hideRecordIcon && recordIcon && <BungieImage className={styles.icon} src={recordIcon} />}
       <div className={styles.info}>
         {!obscured && recordDef.completionInfo && <div className={styles.score}>{scoreValue}</div>}

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -72,6 +72,8 @@ export default function Record({
     recordDef.loreHash &&
     `http://www.ishtar-collective.net/entries/${recordDef.loreHash}`;
 
+  const recordShouldGlow = (recordDef.forTitleGilding && acquired) || trackedInDim;
+
   const name = obscured ? t('Progress.SecretTriumph') : recordDef.displayProperties.name;
 
   const description = obscured
@@ -178,7 +180,7 @@ export default function Record({
         [styles.multistep]: intervals.length > 0,
       })}
     >
-      <div className={styles.glow} />
+      {recordShouldGlow && <div className={styles.glow} />}
       {!hideRecordIcon && recordIcon && <BungieImage className={styles.icon} src={recordIcon} />}
       <div className={styles.info}>
         {!obscured && recordDef.completionInfo && <div className={styles.score}>{scoreValue}</div>}

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -175,12 +175,14 @@ export default function Record({
         [styles.tracked]: trackedInGame,
         [styles.trackedInDim]: trackedInDim,
         [styles.multistep]: intervals.length > 0,
+        [styles.gildingTriumph]: record.recordDef.forTitleGilding,
       })}
     >
       {!hideRecordIcon && recordIcon && <BungieImage className={styles.icon} src={recordIcon} />}
       <div className={styles.info}>
         {!obscured && recordDef.completionInfo && <div className={styles.score}>{scoreValue}</div>}
         <h3>{name}</h3>
+        {record.recordDef.forTitleGilding && <p>{t('Triumphs.GildingTriumph')}</p>}
         {description && (
           <p>
             <RichDestinyText text={description} />

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1105,6 +1105,7 @@
     "YourBestItem": "Your best item"
   },
   "Triumphs": {
+    "GildingTriumph": "Gilding Triumph",
     "HideCompleted": "Hide completed triumphs",
     "RevealRedacted": "Reveal redacted triumphs"
   },


### PR DESCRIPTION
closes https://github.com/DestinyItemManager/DIM/issues/8807

This PR adds a background styled after the geometric chevron background found in the Destiny UI to Gilding Triumphs. It also adds a new `gilded-triumph-border-color` to `_variables.scss` that matches the Destiny UI's slightly darker / orangier color for gilding triumphs, as well as a subtle glow on completed Gilding Triumphs like the one found in the triumph screen. 

Additionally, "Gilding Triumph" text has been added to appropriate triumphs  below the "rewards" section. The user who posted this issue suggested that a background might be sufficient, but I think for accessibility / clarity, having actual text is ideal.

SCREENSHOTS:

Gilding and non-gilding triumphs in complete and incomplete states:
<img width="990" alt="Gilding and Non-gilding triumphs in complete and incomplete states" src="https://user-images.githubusercontent.com/19507611/200174552-dcbea040-323e-4074-a75a-0f2475273fbd.png">

Tracked gilding triumph:
<img width="506" alt="Tracked Gilding Triumph" src="https://user-images.githubusercontent.com/19507611/200174563-549ef045-1f34-4973-a670-2477daffc924.png">

Destiny UI:
![triumphs](https://user-images.githubusercontent.com/19507611/200175118-b18204ee-1f6c-41b7-b094-db8579f2ae83.png)

