### PR TITLE
Fix DIM API loading now that we don't default accounts

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -429,6 +429,8 @@ module.exports = (env) => {
         '$featureFlags.loAutoStatMods': JSON.stringify(!env.release),
         // Whether to send cookies to the Bungie.net API
         '$featureFlags.apiCookies': JSON.stringify(false),
+        // If saved DIM API data in IDB is recent enough, don't bother getting it from the server
+        '$featureFlags.skipDimApiFirstLoadIfRecent': JSON.stringify(!env.release),
       }),
 
       new LodashModuleReplacementPlugin({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed an issue where DIM Sync data (loadouts, tags, etc) could not show up until 10 minutes after loading DIM.
+
 ## 7.42.0 <span class="changelog-date">(2022-11-06)</span>
 
 * Applying a Loadout with subclass configuration should now avoid pointless reordering of Aspects and Fragments in their slots.

--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -1,3 +1,4 @@
+import { loadDimApiData } from 'app/dim-api/actions';
 import { deleteDimApiToken } from 'app/dim-api/dim-api-helper';
 import { del, get } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
@@ -85,6 +86,7 @@ export function setActivePlatform(
         localStorage.setItem('dim-last-membership-id', account.membershipId);
         localStorage.setItem('dim-last-destiny-version', account.destinyVersion.toString());
         dispatch(actions.setCurrentAccount(account));
+        dispatch(loadDimApiData());
       }
     }
     return account;

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -1,6 +1,6 @@
 import { DeleteAllResponse } from '@destinyitemmanager/dim-api-types';
 import { needsDeveloper } from 'app/accounts/actions';
-import { compareAccounts } from 'app/accounts/destiny-account';
+import { DestinyAccount } from 'app/accounts/destiny-account';
 import { accountsSelector, currentAccountSelector } from 'app/accounts/selectors';
 import { getActiveToken as getBungieToken } from 'app/bungie-api/authenticated-fetch';
 import { dimErrorToaster } from 'app/bungie-api/error-toaster';
@@ -40,7 +40,7 @@ import {
   setApiPermissionGranted,
 } from './basic-actions';
 import { DimApiState } from './reducer';
-import { apiPermissionGrantedSelector } from './selectors';
+import { apiPermissionGrantedSelector, makeProfileKeyFromAccount } from './selectors';
 
 const installApiPermissionObserver = _.once(() => {
   // Observe API permission and reflect it into local storage
@@ -100,15 +100,6 @@ const installObservers = _.once((dispatch: ThunkDispatch<RootState, undefined, A
     }, 1000)
   );
 
-  // Observe the current account and reload data
-  // Another one that should probably be a thunk action once account transitions are actions
-  observeStore(currentAccountSelector, (oldAccount, newAccount) => {
-    // Force load profile data if the account changed
-    if (oldAccount && newAccount && !compareAccounts(oldAccount, newAccount)) {
-      dispatch(loadDimApiData(true));
-    }
-  });
-
   // Every time data is refreshed, maybe load DIM API data too
   refresh$.subscribe(() => dispatch(loadDimApiData()));
 });
@@ -160,7 +151,7 @@ let waitingForApiPermission = false;
  * for whether the user has opted in to Sync, and if they haven't, we prompt.
  * Usually they already made their choice at login, though.
  */
-export function loadDimApiData(forceLoad = false): ThunkResult {
+export function loadDimApiData(): ThunkResult {
   return async (dispatch, getState) => {
     installApiPermissionObserver();
 
@@ -218,20 +209,22 @@ export function loadDimApiData(forceLoad = false): ThunkResult {
       } catch (e) {}
     }
 
+    // get current account
+    await getPlatformsPromise;
+    if (!accountsSelector(getState()).length) {
+      // User isn't logged in or has no accounts, nothing to load!
+      return;
+    }
+    const currentAccount = currentAccountSelector(getState());
+
     // How long before the API data is considered stale is controlled from the server
-    const profileOutOfDate =
-      Date.now() - getState().dimApi.profileLastLoaded >
+    const profileOutOfDateOrMissing =
+      profileLastLoaded(getState().dimApi, currentAccount) >
       getState().dimApi.globalSettings.dimProfileMinimumRefreshInterval * 1000;
 
-    if (forceLoad || !getState().dimApi.profileLoaded || profileOutOfDate) {
-      // get current account
-      await getPlatformsPromise;
-      if (!accountsSelector(getState()).length) {
-        // User isn't logged in or has no accounts, nothing to load!
-        return;
-      }
-      const currentAccount = currentAccountSelector(getState());
+    const needsFirstLoad = !getState().dimApi.profileLoaded;
 
+    if (needsFirstLoad || profileOutOfDateOrMissing) {
       try {
         const profileResponse = await getDimApiProfile(currentAccount);
         dispatch(profileLoaded({ profileResponse, account: currentAccount }));
@@ -254,7 +247,7 @@ export function loadDimApiData(forceLoad = false): ThunkResult {
           infoLog('loadDimApiData', 'Waiting', waitTime, 'ms before re-attempting profile fetch');
 
           // Wait, then retry. We don't await this here so we don't stop the finally block from running
-          delay(waitTime).then(() => dispatch(loadDimApiData(forceLoad)));
+          delay(waitTime).then(() => dispatch(loadDimApiData()));
         } else if ($DIM_FLAVOR === 'dev') {
           dispatch(needsDeveloper());
         }
@@ -265,11 +258,26 @@ export function loadDimApiData(forceLoad = false): ThunkResult {
         // reload) than to block the app working if the DIM API is down.
         readyResolve();
       }
+    } else {
+      readyResolve();
     }
 
     // Make sure any queued updates get sent to the server
     await dispatch(flushUpdates());
   };
+}
+
+/**
+ * Get either the profile-specific last loaded time, or the global one if we don't have
+ * an account selected.
+ */
+function profileLastLoaded(dimApi: DimApiState, account: DestinyAccount | undefined) {
+  return (
+    Date.now() -
+    (account
+      ? dimApi.profiles[makeProfileKeyFromAccount(account)]?.profileLastLoaded ?? 0
+      : dimApi.profileLastLoaded)
+  );
 }
 
 // Backoff multiplier

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -151,7 +151,7 @@ let waitingForApiPermission = false;
  * for whether the user has opted in to Sync, and if they haven't, we prompt.
  * Usually they already made their choice at login, though.
  */
-export function loadDimApiData(): ThunkResult {
+export function loadDimApiData(forceLoad = false): ThunkResult {
   return async (dispatch, getState) => {
     installApiPermissionObserver();
 
@@ -225,7 +225,7 @@ export function loadDimApiData(): ThunkResult {
     const needsFirstLoad =
       !getState().dimApi.profileLoaded && !$featureFlags.skipDimApiFirstLoadIfRecent;
 
-    if (needsFirstLoad || profileOutOfDateOrMissing) {
+    if (forceLoad || needsFirstLoad || profileOutOfDateOrMissing) {
       try {
         const profileResponse = await getDimApiProfile(currentAccount);
         dispatch(profileLoaded({ profileResponse, account: currentAccount }));
@@ -248,7 +248,7 @@ export function loadDimApiData(): ThunkResult {
           infoLog('loadDimApiData', 'Waiting', waitTime, 'ms before re-attempting profile fetch');
 
           // Wait, then retry. We don't await this here so we don't stop the finally block from running
-          delay(waitTime).then(() => dispatch(loadDimApiData()));
+          delay(waitTime).then(() => dispatch(loadDimApiData(forceLoad)));
         } else if ($DIM_FLAVOR === 'dev') {
           dispatch(needsDeveloper());
         }

--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -222,7 +222,8 @@ export function loadDimApiData(): ThunkResult {
       profileLastLoaded(getState().dimApi, currentAccount) >
       getState().dimApi.globalSettings.dimProfileMinimumRefreshInterval * 1000;
 
-    const needsFirstLoad = !getState().dimApi.profileLoaded;
+    const needsFirstLoad =
+      !getState().dimApi.profileLoaded && !$featureFlags.skipDimApiFirstLoadIfRecent;
 
     if (needsFirstLoad || profileOutOfDateOrMissing) {
       try {

--- a/src/app/dim-api/import.ts
+++ b/src/app/dim-api/import.ts
@@ -78,6 +78,7 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
           const key = makeProfileKey(platformMembershipId, destinyVersion);
           if (!profiles[key]) {
             profiles[key] = {
+              profileLastLoaded: 0,
               loadouts: {},
               tags: {},
               triumphs: [],
@@ -92,6 +93,7 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
           const key = makeProfileKey(platformMembershipId, destinyVersion);
           if (!profiles[key]) {
             profiles[key] = {
+              profileLastLoaded: 0,
               loadouts: {},
               tags: {},
               triumphs: [],
@@ -107,6 +109,7 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
           const key = makeProfileKey(platformMembershipId, 2);
           if (!profiles[key]) {
             profiles[key] = {
+              profileLastLoaded: 0,
               loadouts: {},
               tags: {},
               triumphs: [],

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -28,12 +28,14 @@ declare const $featureFlags: {
   clarityDescriptions: boolean;
   /** Elgato Stream Deck integration */
   elgatoStreamDeck: boolean;
-  /* Warn when DIM Sync is off and you save some DIM-specific data */
+  /** Warn when DIM Sync is off and you save some DIM-specific data */
   warnNoSync: boolean;
-  /* Expose the "Add required stat mods" Loadout Optimizer toggle */
+  /** Expose the "Add required stat mods" Loadout Optimizer toggle */
   loAutoStatMods: boolean;
-  /* Whether to send cookies to the Bungie.net API */
+  /** Whether to send cookies to the Bungie.net API */
   apiCookies: boolean;
+  /** If saved DIM API data in IDB is recent enough, don't bother getting it from the server */
+  skipDimApiFirstLoadIfRecent: boolean;
 };
 
 declare function ga(...params: string[]): void;


### PR DESCRIPTION
This fixes the logic to be correct in the presence of multiple accounts in general, by tracking "last loaded time" per-profile instead of globally. The problem before was that we would load profile for account `undefined` (just settings, mostly for language setting) and then when we went to load the real account we'd skip because the profile had already been loaded too recently. After this change, we'd recognize that the profile that's being requested hasn't been loaded and load it anyway.

This allowed me to add a bit of an experiment that I've been wanting to do for a while, which is to avoid reloading data from the API if the locally cached data is already fresh enough. This should help with folks reloading the page manually instead of using R.