### PR TITLE
Bump browser compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
   },
   "homepage": "https://destinyitemmanager.com",
   "browserslist": [
-    "Chrome >= 79",
+    "Chrome >= 85",
     "last 2 ChromeAndroid versions",
     "last 2 FirefoxAndroid versions",
     "last 2 Firefox versions",
     "Firefox ESR",
     "last 2 Safari versions",
-    "iOS >= 12",
+    "iOS >= 14",
     "last 2 Edge versions",
     "last 2 Opera versions"
   ],


### PR DESCRIPTION
This updates the Chrome version to the current Steam Overlay version (Chrome 85, sigh) and updates iOS Safari to version 14 (which is >2yrs old now).