### PR TITLE
Add Clarity's new description source to content security policy.

### DIFF
--- a/config/content-security-policy.js
+++ b/config/content-security-policy.js
@@ -40,7 +40,7 @@ module.exports = function csp(env) {
       // DIM Sync
       'https://api.destinyitemmanager.com',
       // Clarity
-      'https://ice-mourne.github.io',
+      'https://database-clarity.github.io',
       // Stream Deck Plugin
       'ws://localhost:9119',
     ],

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1250,7 +1250,7 @@
     "About": {
       "APIHistory": "View the history of all actions taken by DIM (and other Destiny apps)",
       "BungieCopyright": "All images and content are property of Bungie.",
-      "CommunityInsight": "Community Perk Insights courtesy of {{clarityLink}} and {{compendiumLink}}. If you notice inaccuracies or have questions, join the {{clarityDiscordLink}}.",
+      "CommunityInsight": "Community Perk Insights courtesy of {{clarityLink}}. If you notice inaccuracies or have questions, join the {{clarityDiscordLink}}.",
       "Discord": "Discord",
       "DiscordHelp": "Ask questions, give feedback, and get support in our Discord channels.",
       "FAQ": "Frequently Asked Questions",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1140,7 +1140,7 @@
     "About": {
       "APIHistory": "View the history of all actions taken by DIM (and other Destiny apps)",
       "BungieCopyright": "All images and content are property of Bungie.",
-      "CommunityInsight": "Community Perk Insights courtesy of {{clarityLink}} and {{compendiumLink}}. If you notice inaccuracies or have questions, join the {{clarityDiscordLink}}.",
+      "CommunityInsight": "Community Perk Insights courtesy of {{clarityLink}}. If you notice inaccuracies or have questions, join the {{clarityDiscordLink}}.",
       "Discord": "Discord",
       "DiscordHelp": "Ask questions, give feedback, and get support in our Discord channels.",
       "FAQ": "Frequently Asked Questions",


### PR DESCRIPTION
Fixes the following CSP error caused by #8641 (the Clarity description source has been updated):

`
Refused to connect to 'https://database-clarity.github.io/Live-Clarity-Database/versions.json' because it violates the document's Content Security Policy.
`