### PR TITLE
Update loadout sort to be based on uppercase

### DIFF
--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -81,7 +81,9 @@ function Loadouts({ account }: { account: DestinyAccount }) {
             loadout.classType === DestinyClass.Unknown ||
             loadout.classType === classType
         ),
-        loadoutSort === LoadoutSort.ByEditTime ? (l) => -(l.lastUpdatedAt ?? 0) : (l) => l.name
+        loadoutSort === LoadoutSort.ByEditTime
+          ? (l) => -(l.lastUpdatedAt ?? 0)
+          : (l) => l.name.toUpperCase()
       ),
     [allLoadouts, classType, loadoutSort]
   );

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -82,7 +82,9 @@ export default function LoadoutPopup({
             loadout.classType === DestinyClass.Unknown ||
             loadout.classType === dimStore.classType
         ),
-        loadoutSort === LoadoutSort.ByEditTime ? (l) => -(l.lastUpdatedAt ?? 0) : (l) => l.name
+        loadoutSort === LoadoutSort.ByEditTime
+          ? (l) => -(l.lastUpdatedAt ?? 0)
+          : (l) => l.name.toLocaleUpperCase()
       ),
     [allLoadouts, dimStore.classType, loadoutSort]
   );


### PR DESCRIPTION
Since the sort was based on the name and the display was forced upper case, the sort appeared inconsistent. This updates it so that the sort is no longer case sensitive. Screenshots below of my loadouts in beta vs local. 

| **Current** | **Updated** |
|---|---|
|<img width="249" alt="Screenshot 2022-12-18 at 8 10 43 AM" src="https://user-images.githubusercontent.com/1295580/208303043-1dda007f-8921-4f0f-9bc0-d927da4dc978.png">|<img width="245" alt="Screenshot 2022-12-18 at 8 09 12 AM" src="https://user-images.githubusercontent.com/1295580/208302963-20b504de-4e00-4c88-b361-57c662dddd4c.png">|

Note: the PVE is broken up by PVP because the lower options were typed out as PvE. 
