### PR TITLE
Add workaround for missing fourth column class item artifact mods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * DIM can now automatically sync an item's log state to its tag - favorite, keep, and archive tags auto lock the item, and junk or infuse tags unlock the item. This option needs to be enabled in settings, and when it's on the item tile will no longer show the lock icon for tagged items.
 * Loadouts can be filtered with buttons that appear on the list of loadouts. These buttons are populated by any hashtags you use in the loadout name or notes.
 * Crafted items will no longer lose their tags/notes or be missing from loadouts after being reshaped. This only affects items that are newly tagged or added to loadouts - crafted weapons that were already tagged or in loadouts will not be preserved when reshaping them.
+* Worked around an issue where class item mods from the fourth artifact column would be missing for some players.
 
 ## 7.49.0 <span class="changelog-date">(2022-12-25)</span>
 

--- a/src/app/records/plugset-helpers.ts
+++ b/src/app/records/plugset-helpers.ts
@@ -16,6 +16,12 @@ export function itemsForCharacterOrProfilePlugSet(
   );
 }
 
+// https://github.com/Bungie-net/api/issues/1757
+// These should really be removed sooner rather than later
+const additionalPlugSetsToCheck = {
+  963686427: 4120188593,
+};
+
 /**
  * The set of plug item hashes that are unlocked in the given plugset by the given character.
  */
@@ -25,7 +31,14 @@ export function unlockedItemsForCharacterOrProfilePlugSet(
   characterId: string
 ): Set<number> {
   const unlockedPlugs = new Set<number>();
-  const plugSetItems = itemsForCharacterOrProfilePlugSet(profileResponse, plugSetHash, characterId);
+
+  let plugSetItems = itemsForCharacterOrProfilePlugSet(profileResponse, plugSetHash, characterId);
+  const checkSubset = additionalPlugSetsToCheck[plugSetHash];
+  if (checkSubset) {
+    plugSetItems = plugSetItems.concat(
+      itemsForCharacterOrProfilePlugSet(profileResponse, checkSubset, characterId)
+    );
+  }
   const useCanInsert = universalOrnamentPlugSetHashes.includes(plugSetHash);
   // TODO: would be great to precalculate/memoize this by character ID and profileResponse
   for (const plugSetItem of plugSetItems) {


### PR DESCRIPTION
This has been reported on Discord and the subreddit, and also affects me, so this is what I've been using locally to make LO with class item mods usable for me.

Could merge this right away or give Bungie some time to respond in the linked issue.