### PR TITLE
Hide deepsight resonance sockets again for DSC

### DIFF
--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -78,6 +78,7 @@ export default function ItemSocketsWeapons({ item, minimal, grid, onPlugClicked 
 
   const excludedPlugCategoryHashes = [
     PlugCategoryHashes.GenericAllVfx,
+    PlugCategoryHashes.CraftingPlugsWeaponsModsExtractors,
     !item.catalystInfo && PlugCategoryHashes.V400EmptyExoticMasterwork,
   ];
 


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/14299449/208987521-aabb4923-6ac9-497a-91dc-007cb7122015.png)

For some reason my completed-deepsight DSC sniper ended up with the extractor plug (the thing you "plug" into the deepsight socket to extract the materials) now actually plugged in the deepsight socket, so this apparently needs special hiding?