### PR TITLE
Prompt for persistent storage when DIM Sync is disabled and user saves a loadout or tag

### DIFF
--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -6,6 +6,7 @@ import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
 import { get } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
+import { infoLog, warnLog } from 'app/utils/log';
 import {
   DestinyColor,
   DestinyItemChangeResponse,
@@ -201,6 +202,14 @@ function warnNoSync(): ThunkResult {
       !apiPermissionGrantedSelector(getState()) &&
       localStorage.getItem('warned-no-sync') !== 'true'
     ) {
+      if ('storage' in navigator && 'persist' in navigator.storage) {
+        const isPersisted = await navigator.storage.persist();
+        if (isPersisted) {
+          infoLog('storage', 'Persisted storage granted');
+        } else {
+          warnLog('storage', 'Persisted storage not granted');
+        }
+      }
       localStorage.setItem('warned-no-sync', 'true');
       showNotification({
         type: 'warning',

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -15,6 +15,7 @@ import { addIcon, AppIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useEventBusListener } from 'app/utils/hooks';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
+import { infoLog, warnLog } from 'app/utils/log';
 import { useHistory } from 'app/utils/undo-redo-history';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -129,6 +130,21 @@ export default function LoadoutDrawer2({
     }
 
     loadoutToSave = filterLoadoutToAllowedItems(defs, loadoutToSave);
+
+    if (
+      $featureFlags.warnNoSync &&
+      !apiPermissionGranted &&
+      'storage' in navigator &&
+      'persist' in navigator.storage
+    ) {
+      navigator.storage.persist().then((isPersisted) => {
+        if (isPersisted) {
+          infoLog('storage', 'Persisted storage granted');
+        } else {
+          warnLog('storage', 'Persisted storage not granted');
+        }
+      });
+    }
 
     dispatch(updateLoadout(loadoutToSave));
     close();


### PR DESCRIPTION
Persistent storage doesn't matter much if you have DIM Sync enabled, but it really matters if you don't.

Fixes https://github.com/DestinyItemManager/DIM/issues/8598