### PR TITLE
Fix regression where accepting a loadout from URL params wouldn't clear search params

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -147,9 +147,9 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
         title: t('Loadouts.BadLoadoutShare'),
         body: t('Loadouts.BadLoadoutShareBody', { error: e.message }),
       });
-      // Clear the loadout
-      navigate(pathname, { replace: true });
     }
+    // Clear the loadout
+    navigate(pathname, { replace: true });
   }, [defs, queryString, navigate, pathname, stores]);
 
   // Close the loadout on navigation


### PR DESCRIPTION
I messed this up in #8840. Moving all the code to a separate function removed some nests, and the navigate call ended up in the catch block, meaning loadouts imported by opening DIM with a loadout link would pop up again after saving or closing while DIM refreshed in the background.