### PR TITLE
Use responseMintedTimestamp for time travel detection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * The filter help menu item is now keyboard accessible.
 * Fixed a bug where opening a loadout link could result in the loadout reopening later.
+* DIM should be better at ignoring when Bungie.net sends back outdated inventory data.
 
 ## 7.48.0 <span class="changelog-date">(2022-12-18)</span>
 


### PR DESCRIPTION
This will be superseded by #8881 but makes a nice isolated change that should help prevent data going backwards.