### PR TITLE
Ensure we grab the correct artifact when collecting artifact mods

### DIFF
--- a/src/app/strip-sockets/strip-sockets.ts
+++ b/src/app/strip-sockets/strip-sockets.ts
@@ -53,8 +53,9 @@ function identifySocket(
 export const artifactModsSelector = createSelector(
   manifestSelector,
   (state: RootState) =>
-    allItemsSelector(state).find((i) => i.bucket.hash === BucketHashes.SeasonalArtifact)
-      ?.previewVendor,
+    allItemsSelector(state).find(
+      (i) => i.bucket.hash === BucketHashes.SeasonalArtifact && i.previewVendor
+    )?.previewVendor,
   (defs, vendorHash) => {
     if (!defs?.isDestiny2()) {
       return undefined;


### PR DESCRIPTION
This season there's an issue where you can pull and equip the previous season's artifact from collections, which breaks our approach of collecting artifact mods because it doesn't have an artifact mods vendor. And you also can't discard it, so users don't have a workaround.