### PR TITLE
Indicate which postmaster items can't be pulled

### DIFF
--- a/src/app/inventory/DraggableInventoryItem.m.scss
+++ b/src/app/inventory/DraggableInventoryItem.m.scss
@@ -19,3 +19,7 @@
 .cantDrag {
   cursor: pointer;
 }
+
+.inPostmasterCantTransfer {
+  opacity: 50%;
+}

--- a/src/app/inventory/DraggableInventoryItem.m.scss.d.ts
+++ b/src/app/inventory/DraggableInventoryItem.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'cantDrag': string;
   'engram': string;
+  'inPostmasterCantTransfer': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -19,6 +19,9 @@ export default function DraggableInventoryItem({ children, item }: Props) {
       ? item.equipment
       : item.equipment || item.bucket.hasTransferDestination;
 
+  const inPostmasterCantTransfer =
+    item.location.inPostmaster && (item.canPullFromPostmaster || item.notransfer);
+
   const [_collect, dragRef] = useDrag<DimItem>(
     () => ({
       type: item.location.inPostmaster
@@ -54,6 +57,7 @@ export default function DraggableInventoryItem({ children, item }: Props) {
       className={clsx('item-drag-container', {
         [styles.engram]: item.isEngram,
         [styles.cantDrag]: !canDrag,
+        [styles.inPostmasterCantTransfer]: inPostmasterCantTransfer,
       })}
     >
       {children}

--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -20,7 +20,7 @@ export default function DraggableInventoryItem({ children, item }: Props) {
       : item.equipment || item.bucket.hasTransferDestination;
 
   const inPostmasterCantTransfer =
-    item.location.inPostmaster && (item.canPullFromPostmaster || item.notransfer);
+    item.location.inPostmaster && (!item.canPullFromPostmaster || item.notransfer);
 
   const [_collect, dragRef] = useDrag<DimItem>(
     () => ({


### PR DESCRIPTION
Closes #4715

# Evidence
## New dimmed icons changes with items that can't be pulled
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/54964587/210303694-f791afff-718e-4b75-9b49-e52e54398b14.png">

## With some blues that CAN be pulled
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/54964587/210418989-f1b876af-2a41-47f2-826d-b47546492158.png">


Note: First time trying to contribute to DIM so let me know how I'm doing!