### PR TITLE
Fix LO item wrapping at higher item-size

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSet.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.m.scss
@@ -32,12 +32,6 @@
   display: flex;
   flex-flow: row wrap;
   padding: 0;
-  max-width: 800px;
-
-  // Prevents odd number of columns messing up the layout
-  @media (max-width: 1079px) {
-    max-width: 500px;
-  }
 
   > * {
     margin-right: 14px;


### PR DESCRIPTION
#7799 

> Item Size above 61 causes LO to add a line of class items instead of extending right when space is available.

Screenshot where Item Size is set to ~90 before fix
![Screen Shot 2023-01-03 at 5 05 54 PM](https://user-images.githubusercontent.com/19579969/210467437-65a7a444-256d-442a-a497-77a5c9c8cbc7.png)

Screenshot after fixing the selector (removing max-width)
![Screen Shot 2023-01-03 at 5 06 20 PM](https://user-images.githubusercontent.com/19579969/210467482-ec8cc473-b85a-4d44-a6e0-61d0b5183123.png)

Removing the max-width property seems to resolve this issue since the sets were bound by the width originally. I have tested these changes comparing my dev to the production website and everything looks fine on my end. Please let me know if there are issues with this small fix.

(Item sizes in the screenshot above are not the default sizes, its set to 90 for demonstration)
