### PR TITLE
Flex gap

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "last 2 Firefox versions",
     "Firefox ESR",
     "last 2 Safari versions",
-    "iOS >= 14",
+    "iOS >= 14.5",
     "last 2 Edge versions",
     "last 2 Opera versions"
   ],

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -98,32 +98,6 @@ $easeInOutCubic: cubic-bezier(0.645, 0.045, 0.355, 1);
   }
 }
 
-// Apply spacing between children
-@mixin vertical-space-children($space) {
-  > *:nth-last-child(n + 2) {
-    margin-bottom: $space;
-  }
-}
-
-// Apply spacing between children
-@mixin horizontal-space-children($space) {
-  > *:nth-last-child(n + 2) {
-    margin-right: $space;
-  }
-}
-
-// Emulate the gap property for flexbox. Not all browsers support it (notably
-// iOS Safari < 14.5 and Chrome < 84). Use this instead of
-// horizontal/vertical-space-children only if you'll have wrapping content.
-@mixin flex-gap($gapRow, $gapColumn: $gapRow, $marginBottom: 0, $marginRight: 0) {
-  margin-bottom: -1 * $gapRow + $marginBottom;
-  margin-right: -1 * $gapColumn + $marginRight;
-  > * {
-    margin-bottom: $gapRow;
-    margin-right: $gapColumn;
-  }
-}
-
 // Show visible scrollbars when scrollable, even if the OS (e.g. macOS) prefers hidden scrollbars.
 @mixin visible-scrollbars {
   &::-webkit-scrollbar-track {

--- a/src/app/armory/AllWishlistRolls.m.scss
+++ b/src/app/armory/AllWishlistRolls.m.scss
@@ -7,8 +7,5 @@
   border: 1px solid #333;
   border-radius: calc((16 / 50 * var(--item-size)) + 2px);
   padding: 2px;
-
-  &:nth-child(n + 1) {
-    margin-left: 2px;
-  }
+  gap: 2px;
 }

--- a/src/app/armory/AllWishlistRolls.m.scss
+++ b/src/app/armory/AllWishlistRolls.m.scss
@@ -1,11 +1,11 @@
 .roll {
   display: flex;
   flex-direction: row;
+  gap: 2px;
 }
 
 .orGroup {
   border: 1px solid #333;
   border-radius: calc((16 / 50 * var(--item-size)) + 2px);
   padding: 2px;
-  gap: 2px;
 }

--- a/src/app/armory/Armory.m.scss
+++ b/src/app/armory/Armory.m.scss
@@ -94,7 +94,7 @@
   > * {
     margin: 0;
   }
-  @include horizontal-space-children(4px);
+  gap: 4px;
 }
 
 .element {

--- a/src/app/armory/Links.m.scss
+++ b/src/app/armory/Links.m.scss
@@ -5,7 +5,7 @@
   margin: 0 0 0 32px;
   padding: 0;
   list-style: none;
-  @include vertical-space-children(4px);
+  gap: 4px;
 
   li {
     white-space: nowrap;

--- a/src/app/armory/Links.m.scss
+++ b/src/app/armory/Links.m.scss
@@ -1,6 +1,8 @@
 @import '../variables';
 
 .links {
+  display: flex;
+  flex-direction: column;
   float: right;
   margin: 0 0 0 32px;
   padding: 0;
@@ -18,7 +20,6 @@
   @media (max-width: 675px) {
     margin: 0 0 8px 0;
     float: none;
-    display: flex;
     flex-flow: row wrap;
     justify-content: space-between;
     > li {

--- a/src/app/compare/Compare.m.scss
+++ b/src/app/compare/Compare.m.scss
@@ -63,21 +63,19 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  min-height: 32px;
+  gap: 4px;
+
   :global(.setting) {
     margin-right: 4px;
   }
   :global(.dim-button) {
     display: flex;
     align-items: center;
-    margin-bottom: 2px;
-    margin-top: 2px;
+    min-height: 26px;
     // Undo the general mobile "big-buttons"
     padding: 4px 10px;
     font-size: 12px;
-    // button outer spacing margin
-    &:nth-last-child(n + 2) {
-      margin-right: 3px;
-    }
     // button's children's spacing margin
     :nth-child(n + 2) {
       margin-left: 4px;

--- a/src/app/compare/Compare.m.scss
+++ b/src/app/compare/Compare.m.scss
@@ -63,7 +63,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  min-height: 32px;
+  min-height: 30px;
   gap: 4px;
 
   :global(.setting) {

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
@@ -23,7 +23,7 @@
     margin-bottom: 0;
   }
 
-  @include horizontal-space-children(4px);
+  gap: 4px;
 }
 
 .loadoutName {

--- a/src/app/destiny1/loadout-drawer/loadout-drawer.scss
+++ b/src/app/destiny1/loadout-drawer/loadout-drawer.scss
@@ -74,7 +74,7 @@
 .loadout-warn-items {
   display: flex;
   flex-direction: row;
-  @include horizontal-space-children(4px);
+  gap: 4px;
 }
 
 .loadout-contents {

--- a/src/app/inventory/MoveNotifications.m.scss
+++ b/src/app/inventory/MoveNotifications.m.scss
@@ -60,7 +60,7 @@
 }
 
 .errorList {
-  @include vertical-space-children(4px);
+  gap: 4px;
 }
 
 .warning {

--- a/src/app/inventory/MoveNotifications.m.scss
+++ b/src/app/inventory/MoveNotifications.m.scss
@@ -60,6 +60,8 @@
 }
 
 .errorList {
+  display: flex;
+  flex-direction: column;
   gap: 4px;
 }
 

--- a/src/app/inventory/PullFromPostmaster.m.scss
+++ b/src/app/inventory/PullFromPostmaster.m.scss
@@ -15,7 +15,7 @@
   align-self: center;
   display: inline-flex;
   align-items: center;
-  @include horizontal-space-children(4px);
+  gap: 4px;
 
   &:hover .badge {
     background-color: black;

--- a/src/app/item-popup/ApplyPerkSelection.m.scss
+++ b/src/app/item-popup/ApplyPerkSelection.m.scss
@@ -3,7 +3,7 @@
 .buttons {
   composes: item-details from global;
   composes: flexRow from '../dim-ui/common.m.scss';
-  @include horizontal-space-children(8px);
+  gap: 8px;
 }
 
 .insertButton {
@@ -13,5 +13,5 @@
   align-items: center;
   transition: none;
 
-  @include horizontal-space-children(8px);
+  gap: 8px;
 }

--- a/src/app/item-popup/EnergyMeter.m.scss
+++ b/src/app/item-popup/EnergyMeter.m.scss
@@ -22,7 +22,7 @@
   overflow: hidden;
   box-sizing: border-box;
 
-  @include horizontal-space-children(8px);
+  gap: 8px;
 
   > :first-child {
     flex: 1;

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -8,7 +8,7 @@ import ItemMoveLocations from 'app/item-actions/ItemMoveLocations';
 import type { ItemTierName } from 'app/search/d2-known-values';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import clsx from 'clsx';
-import React, { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DesktopItemActions, { menuClassName } from './DesktopItemActions';
 import { ItemPopupExtraInfo } from './item-popup';
@@ -78,7 +78,7 @@ export default function ItemPopup({
     />
   );
 
-  const header = <ItemPopupHeader item={item} key={`header${item.index}`} noLink={noLink} />;
+  const header = <ItemPopupHeader item={item} key={`header${item.hash}`} noLink={noLink} />;
 
   return isPhonePortrait ? (
     <Sheet

--- a/src/app/item-popup/SocketDetailsSelectedPlug.m.scss
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.m.scss
@@ -104,7 +104,7 @@
   align-self: center;
   transition: none;
 
-  @include horizontal-space-children(8px);
+  gap: 8px;
 
   > span {
     display: flex;

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss
@@ -14,7 +14,7 @@
     padding: 0 10px;
   }
 
-  @include vertical-space-children(8px);
+  gap: 8px;
 }
 
 .processing {
@@ -50,7 +50,7 @@
   @include phone-portrait {
     padding: 0 10px;
   }
-  @include horizontal-space-children(4px);
+  gap: 4px;
   margin-top: 12px;
 }
 
@@ -77,7 +77,7 @@
   > * {
     flex: 1;
   }
-  @include horizontal-space-children(4px);
+  gap: 4px;
 }
 
 .speedReport {

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss
@@ -13,8 +13,6 @@
   @include phone-portrait {
     padding: 0 10px;
   }
-
-  gap: 8px;
 }
 
 .processing {
@@ -46,6 +44,9 @@
 }
 
 .toolbar {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
   box-sizing: border-box;
   @include phone-portrait {
     padding: 0 10px;

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.m.scss
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.m.scss
@@ -28,7 +28,7 @@
     flex: 1;
   }
 
-  @include horizontal-space-children(4px);
+  gap: 4px;
 }
 
 // TODO: dedupe this

--- a/src/app/loadout-drawer/LoadoutDrawer2.m.scss
+++ b/src/app/loadout-drawer/LoadoutDrawer2.m.scss
@@ -26,5 +26,5 @@
   display: flex;
   flex-flow: row wrap;
   align-items: center;
-  @include flex-gap(4px);
+  gap: 4px;
 }

--- a/src/app/loadout-drawer/LoadoutDrawerFooter.m.scss
+++ b/src/app/loadout-drawer/LoadoutDrawerFooter.m.scss
@@ -17,7 +17,7 @@
     &:last-child {
       margin-bottom: 0;
     }
-    @include flex-gap(4px);
+    gap: 4px;
 
     > a {
       margin-left: auto;

--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -27,7 +27,7 @@
 .actions {
   composes: flexRow from '../dim-ui/common.m.scss';
   flex-flow: row wrap;
-  @include flex-gap(4px);
+  gap: 4px;
   @include phone-portrait {
     margin-top: 16px;
     margin-bottom: 16px;
@@ -51,9 +51,9 @@
   flex-flow: row wrap;
   margin-top: 10px;
   min-height: 16px;
-  @include flex-gap(24px);
+  gap: 24px;
   @include phone-portrait {
-    @include flex-gap(12px);
+    gap: 12px;
   }
 }
 

--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -13,7 +13,7 @@
 
 .menuButtons {
   margin: 8px 0;
-  @include vertical-space-children(8px);
+  gap: 8px;
   @include phone-portrait {
     padding-left: 10px;
     padding-right: 10px;

--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -12,6 +12,8 @@
 }
 
 .menuButtons {
+  display: flex;
+  flex-direction: column;
   margin: 8px 0;
   gap: 8px;
   @include phone-portrait {

--- a/src/app/loadout/fashion/FashionDrawer.m.scss
+++ b/src/app/loadout/fashion/FashionDrawer.m.scss
@@ -5,13 +5,13 @@
   flex-flow: row wrap;
   margin: 10px;
   justify-content: center;
-  @include horizontal-space-children(10px);
+  gap: 10px;
 }
 
 .item {
   display: flex;
   flex-direction: column;
-  @include vertical-space-children(4px);
+  gap: 4px;
 }
 
 .buttons {

--- a/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-flow: row wrap;
   gap: 12px;
+  margin-bottom: 10px;
 }
 
 .mods {

--- a/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
@@ -3,10 +3,7 @@
 .contents {
   display: flex;
   flex-flow: row wrap;
-  @include flex-gap(12px, $marginBottom: 10px);
-  @include phone-portrait {
-    @include flex-gap(12px, $marginBottom: 10px);
-  }
+  gap: 12px;
 }
 
 .mods {
@@ -17,5 +14,5 @@
   display: flex;
   flex-flow: row wrap;
   margin: 10px auto;
-  @include flex-gap(4px);
+  gap: 4px;
 }

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
@@ -25,6 +25,8 @@
 }
 
 .itemBucket {
+  display: flex;
+  flex-direction: column;
   width: var(--item-size);
   gap: var(--item-margin);
 }
@@ -58,7 +60,7 @@
 .showFashion {
   .equipped {
     :global(.item) {
-      height: calc(var(--item-size) + #{$badge-height} - #{$item-border-width});
+      height: calc(var(--item-size));
     }
   }
 }

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  @include vertical-space-children(var(--item-margin));
+  gap: var(--item-margin);
 
   :global(.stat-row) {
     justify-content: space-between;
@@ -26,7 +26,7 @@
 
 .itemBucket {
   width: var(--item-size);
-  @include vertical-space-children(var(--item-margin));
+  gap: var(--item-margin);
 }
 
 .items {
@@ -90,7 +90,7 @@
   display: flex;
   flex-flow: row wrap;
   margin: 4px 0;
-  @include flex-gap(4px);
+  gap: 4px;
   justify-content: center;
 }
 

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.m.scss
@@ -12,7 +12,7 @@
   flex-direction: column;
   align-items: center;
   margin-right: var(--item-margin);
-  @include vertical-space-children(var(--item-margin));
+  gap: var(--item-margin);
 }
 
 .power {

--- a/src/app/loadout/loadout-ui/FashionMods.m.scss
+++ b/src/app/loadout/loadout-ui/FashionMods.m.scss
@@ -4,6 +4,9 @@
 
 .items {
   composes: items from './LoadoutItemCategorySection.m.scss';
+  :global(.item) {
+    height: var(--item-icon-size) !important;
+  }
 }
 
 .unequipped {

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.m.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  @include vertical-space-children(var(--item-margin));
+  gap: var(--item-margin);
 
   :global(.stat-row) {
     justify-content: space-between;
@@ -24,7 +24,7 @@
 
 .itemBucket {
   width: var(--item-size);
-  @include vertical-space-children(var(--item-margin));
+  gap: var(--item-margin);
 }
 
 .items {

--- a/src/app/loadout/loadout-ui/LoadoutMods.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutMods.m.scss
@@ -46,5 +46,5 @@
   display: flex;
   flex-flow: row wrap;
   margin-top: 8px;
-  @include flex-gap(4px);
+  gap: 4px;
 }

--- a/src/app/loadout/loadout-ui/LoadoutParametersDisplay.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutParametersDisplay.m.scss
@@ -2,14 +2,14 @@
 
 .loParams {
   max-width: 100%;
-  @include vertical-space-children(4px);
+  gap: 4px;
 }
 
 .loStats {
   composes: flexRow from '../../dim-ui/common.m.scss';
   align-items: center;
   width: 100%;
-  @include horizontal-space-children(8px);
+  gap: 8px;
 }
 
 .loStat {

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.m.scss
@@ -12,7 +12,7 @@
   flex-direction: column;
   align-items: center;
   margin-right: var(--item-margin);
-  @include vertical-space-children(var(--item-margin));
+  gap: var(--item-margin);
 }
 
 .power {

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -41,7 +41,7 @@ $content-cells: 5;
     position: sticky;
     left: calc(4px + env(safe-area-inset-left));
     width: calc(98vw - env(safe-area-inset-left) - env(safe-area-inset-right));
-    @include horizontal-space-children(4px);
+    gap: 4px;
   }
 }
 
@@ -185,7 +185,7 @@ $content-cells: 5;
   columns: 2;
   height: 100%;
   box-sizing: border-box;
-  @include vertical-space-children(4px);
+  gap: 4px;
   column-gap: 8px;
   &.header {
     display: flex;

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -185,8 +185,10 @@ $content-cells: 5;
   columns: 2;
   height: 100%;
   box-sizing: border-box;
-  gap: 4px;
   column-gap: 8px;
+  > *:nth-last-child(n + 2) {
+    margin-bottom: 4px;
+  }
   &.header {
     display: flex;
     flex-direction: column;

--- a/src/app/organizer/ItemTypeSelector.m.scss
+++ b/src/app/organizer/ItemTypeSelector.m.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  @include vertical-space-children(8px);
+  gap: 8px;
 }
 
 .level {

--- a/src/app/progress/SeasonalRank.m.scss
+++ b/src/app/progress/SeasonalRank.m.scss
@@ -41,7 +41,7 @@
 .seasonalRewards {
   display: flex;
   flex-direction: row;
-  @include horizontal-space-children(2px);
+  gap: 2px;
 }
 
 .progressBar {

--- a/src/app/progress/milestone.scss
+++ b/src/app/progress/milestone.scss
@@ -92,7 +92,7 @@
     margin-top: 4px;
     display: flex;
     flex-flow: row wrap;
-    @include horizontal-space-children(8px);
+    gap: 8px;
   }
 }
 

--- a/src/app/records/Metric.m.scss
+++ b/src/app/records/Metric.m.scss
@@ -5,8 +5,6 @@
   margin: 8px 0 16px 0;
   position: relative;
 
-  gap: 8px;
-
   p {
     margin: 8px 0 8px 36px;
     color: #a1a2a2;

--- a/src/app/records/Metric.m.scss
+++ b/src/app/records/Metric.m.scss
@@ -5,7 +5,7 @@
   margin: 8px 0 16px 0;
   position: relative;
 
-  @include horizontal-space-children(8px);
+  gap: 8px;
 
   p {
     margin: 8px 0 8px 36px;

--- a/src/app/records/Metrics.m.scss
+++ b/src/app/records/Metrics.m.scss
@@ -2,7 +2,7 @@
 
 .metrics {
   margin: 6px 10px 8px;
-  @include vertical-space-children(24px);
+  gap: 24px;
 }
 
 .title {

--- a/src/app/records/Metrics.m.scss
+++ b/src/app/records/Metrics.m.scss
@@ -1,8 +1,10 @@
 @use '../variables.scss' as *;
 
 .metrics {
+  display: flex;
+  flex-direction: column;
   margin: 6px 10px 8px;
-  gap: 24px;
+  gap: 8px;
 }
 
 .title {

--- a/src/app/records/Records.m.scss
+++ b/src/app/records/Records.m.scss
@@ -6,6 +6,8 @@
 }
 
 .presentationNodeOptions {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
   @include phone-portrait {
     padding: 8px var(--inventory-column-padding) 0 var(--inventory-column-padding);

--- a/src/app/records/Records.m.scss
+++ b/src/app/records/Records.m.scss
@@ -6,7 +6,7 @@
 }
 
 .presentationNodeOptions {
-  @include vertical-space-children(8px);
+  gap: 8px;
   @include phone-portrait {
     padding: 8px var(--inventory-column-padding) 0 var(--inventory-column-padding);
   }

--- a/src/app/settings/settings.scss
+++ b/src/app/settings/settings.scss
@@ -78,7 +78,7 @@
     margin: 0 0 4px 0;
     display: flex;
     flex-direction: row;
-    @include horizontal-space-children(4px);
+    gap: 4px;
   }
 
   .radioOptions {

--- a/src/app/shell/ErrorPanel.m.scss
+++ b/src/app/shell/ErrorPanel.m.scss
@@ -23,7 +23,7 @@
 .twitterLinks {
   composes: flexRow from '../dim-ui/common.m.scss';
   flex-wrap: wrap;
-  @include horizontal-space-children(8px);
+  gap: 8px;
   gap: 8px 0;
 
   :global(.fa-twitter) {
@@ -43,7 +43,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
-  @include flex-gap(16px);
+  gap: 16px;
 
   @include phone-portrait {
     flex-direction: column;

--- a/src/app/strip-sockets/StripSockets.m.scss
+++ b/src/app/strip-sockets/StripSockets.m.scss
@@ -7,7 +7,7 @@
   align-items: center;
   transition: none;
 
-  @include horizontal-space-children(8px);
+  gap: 8px;
 }
 
 .stripSheet {

--- a/src/app/vendors/Vendors.m.scss
+++ b/src/app/vendors/Vendors.m.scss
@@ -1,6 +1,8 @@
 @import '../variables';
 
 .buttons {
+  display: flex;
+  flex-direction: column;
   margin: 8px 0;
   gap: 8px;
 }

--- a/src/app/vendors/Vendors.m.scss
+++ b/src/app/vendors/Vendors.m.scss
@@ -2,5 +2,5 @@
 
 .buttons {
   margin: 8px 0;
-  @include vertical-space-children(8px);
+  gap: 8px;
 }


### PR DESCRIPTION
By increasing our minimum iOS version to 14.5, we can get rid of all our special spacing helpers in favor of `gap` for flex layout.