### PR TITLE
VendorItem cleanups

### DIFF
--- a/src/app/records/PresentationNodeRoot.tsx
+++ b/src/app/records/PresentationNodeRoot.tsx
@@ -4,7 +4,7 @@ import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { useMemo, useState } from 'react';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import PlugSet from './PlugSet';
-import { itemsForProfilePlugSet } from './plugset-helpers';
+import { unlockedItemsForCharacterOrProfilePlugSet } from './plugset-helpers';
 import { filterPresentationNodesToSearch, toPresentationNodeTree } from './presentation-nodes';
 import PresentationNode from './PresentationNode';
 import PresentationNodeSearchResults from './PresentationNodeSearchResults';
@@ -113,7 +113,11 @@ export default function PresentationNodeRoot({
             <PlugSet
               buckets={buckets}
               plugSetCollection={plugSetCollection}
-              items={itemsForProfilePlugSet(profileResponse, Number(plugSetCollection.hash))}
+              unlockedItems={unlockedItemsForCharacterOrProfilePlugSet(
+                profileResponse,
+                plugSetCollection.hash,
+                ''
+              )}
               path={fullNodePath}
               onNodePathSelected={setNodePath}
             />

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -54,7 +54,7 @@ export default function VendorItemComponent({
 
   const mod = item.item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod);
 
-  const unavailable = !item.canPurchase || !item.canBeSold || (owned && ownershipRule);
+  const unavailable = !item.canBeSold || (owned && ownershipRule);
   return (
     <VendorItemDisplay
       item={item.item}

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -20,7 +20,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import { VendorItem } from './vendor-item';
+import { VendorItem, vendorItemForDefinitionItem, vendorItemForSaleItem } from './vendor-item';
 export interface D2VendorGroup {
   def: DestinyVendorGroupDefinition;
   vendors: D2Vendor[];
@@ -177,7 +177,7 @@ function getVendorItems(
   if (sales) {
     const components = Object.values(sales);
     return components.map((component) =>
-      VendorItem.forVendorSaleItem(
+      vendorItemForSaleItem(
         defs,
         buckets,
         vendorDef,
@@ -199,7 +199,7 @@ function getVendorItems(
           i.exclusivity === BungieMembershipType.All ||
           i.exclusivity === account.originalPlatformType
       )
-      .map((i) => VendorItem.forVendorDefinitionItem(defs, buckets, i, mergedCollectibles));
+      .map((i) => vendorItemForDefinitionItem(defs, buckets, i, mergedCollectibles));
   }
 }
 

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -11,6 +11,7 @@ import {
   DestinyVendorItemState,
   DestinyVendorSaleItemComponent,
 } from 'bungie-api-ts/destiny2';
+import { BucketHashes } from 'data/d2/generated-enums';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { DimItem } from '../inventory/item-types';
@@ -188,7 +189,7 @@ export class VendorItem {
       // if this is sold by a vendor, add vendor information
       if (saleItem && characterId) {
         this.item.vendor = { vendorHash, saleIndex: saleItem.vendorItemIndex, characterId };
-        if (this.item.equipment) {
+        if (this.item.equipment && this.item.bucket.hash !== BucketHashes.Emblems) {
           this.item.comparable = true;
         }
       }

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -57,7 +57,6 @@ export class VendorItem {
       saleItem,
       itemComponents,
       mergedCollectibles,
-      true, // why?
       characterId
     );
   }
@@ -89,7 +88,6 @@ export class VendorItem {
   }
 
   readonly item: DimItem | null;
-  readonly canPurchase: boolean;
   readonly failureStrings: string[];
   readonly key: number;
   readonly displayProperties: DestinyDisplayPropertiesDefinition;
@@ -116,13 +114,11 @@ export class VendorItem {
           [hash: number]: DestinyCollectibleComponent;
         }
       | undefined,
-    canPurchase = true,
     // the character to whom this item is being offered
     characterId?: string
   ) {
     const inventoryItem = defs.InventoryItem.get(itemHash);
 
-    this.canPurchase = canPurchase;
     this.failureStrings = failureStrings;
     this.key = saleItem ? saleItem.vendorItemIndex : inventoryItem.hash;
     this.displayProperties = inventoryItem.displayProperties;

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -4,7 +4,6 @@ import {
   DestinyDisplayPropertiesDefinition,
   DestinyItemComponentSetOfint32,
   DestinyItemQuantity,
-  DestinyItemSocketEntryPlugItemDefinition,
   DestinyProfileResponse,
   DestinyVendorDefinition,
   DestinyVendorItemDefinition,
@@ -18,35 +17,9 @@ import { DimItem } from '../inventory/item-types';
 import { makeFakeItem } from '../inventory/store/d2-item-factory';
 
 /**
- * Not actually always a vendor item.
- * This represents an item inside a vendor or an item contained in a plugset.
+ * This represents an item inside a vendor.
  */
 export class VendorItem {
-  /**
-   * creates a VendorItem that's not actually at a vendor. it's part of a plug set.
-   * this serves something about the collections interface?
-   */
-  static forPlugSetItem(
-    defs: D2ManifestDefinitions,
-    buckets: InventoryBuckets,
-    plugItemDef: DestinyItemSocketEntryPlugItemDefinition,
-    canPurchase = true
-  ): VendorItem {
-    return new VendorItem(
-      defs,
-      buckets,
-      undefined,
-      plugItemDef.plugItemHash,
-      [],
-      0,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      canPurchase
-    );
-  }
-
   /**
    * creates a VendorItem being sold by a vendor in the API vendors response.
    * this can include "instanced" stats plugs etc which describe the specifics

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -19,74 +19,7 @@ import { makeFakeItem } from '../inventory/store/d2-item-factory';
 /**
  * This represents an item inside a vendor.
  */
-export class VendorItem {
-  /**
-   * creates a VendorItem being sold by a vendor in the API vendors response.
-   * this can include "instanced" stats plugs etc which describe the specifics
-   * of that copy they're selling
-   */
-  static forVendorSaleItem(
-    defs: D2ManifestDefinitions,
-    buckets: InventoryBuckets,
-    vendorDef: DestinyVendorDefinition,
-    profileResponse: DestinyProfileResponse | undefined,
-    saleItem: DestinyVendorSaleItemComponent,
-    // all DIM vendor calls are character-specific. any sale item should have an associated character.
-    characterId: string,
-    itemComponents: DestinyItemComponentSetOfint32 | undefined,
-    mergedCollectibles:
-      | {
-          [hash: number]: DestinyCollectibleComponent;
-        }
-      | undefined
-  ): VendorItem {
-    const vendorItemDef = vendorDef.itemList[saleItem.vendorItemIndex];
-    const failureStrings =
-      saleItem && vendorDef
-        ? (saleItem.failureIndexes || []).map((i) => vendorDef.failureStrings[i])
-        : [];
-
-    return new VendorItem(
-      defs,
-      buckets,
-      profileResponse,
-      saleItem.itemHash,
-      failureStrings,
-      vendorDef.hash,
-      vendorItemDef,
-      saleItem,
-      itemComponents,
-      mergedCollectibles,
-      characterId
-    );
-  }
-
-  /**
-   * creates a VendorItem solely according to a vendor's definition.
-   * some vendors are set up so statically, that they have no data in the live Vendors response
-   */
-  static forVendorDefinitionItem(
-    defs: D2ManifestDefinitions,
-    buckets: InventoryBuckets,
-    vendorItemDef: DestinyVendorItemDefinition,
-    mergedCollectibles?: {
-      [hash: number]: DestinyCollectibleComponent;
-    }
-  ): VendorItem {
-    return new VendorItem(
-      defs,
-      buckets,
-      undefined,
-      vendorItemDef.itemHash,
-      [],
-      0,
-      vendorItemDef,
-      undefined,
-      undefined,
-      mergedCollectibles
-    );
-  }
-
+export interface VendorItem {
   readonly item: DimItem | null;
   readonly failureStrings: string[];
   readonly key: number;
@@ -98,80 +31,148 @@ export class VendorItem {
   readonly displayCategoryIndex?: number;
   readonly costs: DestinyItemQuantity[];
   readonly previewVendorHash?: number;
+}
 
-  constructor(
-    defs: D2ManifestDefinitions,
-    buckets: InventoryBuckets,
-    profileResponse: DestinyProfileResponse | undefined,
-    itemHash: number,
-    failureStrings: string[],
-    vendorHash: number,
-    vendorItemDef: DestinyVendorItemDefinition | undefined,
-    saleItem: DestinyVendorSaleItemComponent | undefined,
-    itemComponents: DestinyItemComponentSetOfint32 | undefined,
-    mergedCollectibles:
-      | {
-          [hash: number]: DestinyCollectibleComponent;
-        }
-      | undefined,
-    // the character to whom this item is being offered
-    characterId?: string
-  ) {
-    const inventoryItem = defs.InventoryItem.get(itemHash);
-
-    this.failureStrings = failureStrings;
-    this.key = saleItem ? saleItem.vendorItemIndex : inventoryItem.hash;
-    this.displayProperties = inventoryItem.displayProperties;
-    this.borderless = Boolean(inventoryItem.uiItemDisplayStyle);
-    this.displayTile = inventoryItem.uiItemDisplayStyle === 'ui_display_style_set_container';
-    this.owned = Boolean((saleItem?.augments || 0) & DestinyVendorItemState.Owned);
-    this.canBeSold = !saleItem || saleItem.failureIndexes.length === 0;
-    this.displayCategoryIndex = vendorItemDef ? vendorItemDef.displayCategoryIndex : undefined;
-    this.costs = saleItem?.costs || [];
-    if (inventoryItem.preview?.previewVendorHash) {
-      this.previewVendorHash = inventoryItem.preview.previewVendorHash;
-    }
-
-    this.item = makeFakeItem(
+function makeVendorItem(
+  defs: D2ManifestDefinitions,
+  buckets: InventoryBuckets,
+  profileResponse: DestinyProfileResponse | undefined,
+  itemHash: number,
+  failureStrings: string[],
+  vendorHash: number,
+  vendorItemDef: DestinyVendorItemDefinition | undefined,
+  saleItem: DestinyVendorSaleItemComponent | undefined,
+  itemComponents: DestinyItemComponentSetOfint32 | undefined,
+  mergedCollectibles:
+    | {
+        [hash: number]: DestinyCollectibleComponent;
+      }
+    | undefined,
+  // the character to whom this item is being offered
+  characterId?: string
+): VendorItem {
+  const inventoryItem = defs.InventoryItem.get(itemHash);
+  const key = saleItem ? saleItem.vendorItemIndex : inventoryItem.hash;
+  const vendorItem = {
+    failureStrings,
+    key,
+    displayProperties: inventoryItem.displayProperties,
+    borderless: Boolean(inventoryItem.uiItemDisplayStyle),
+    displayTile: inventoryItem.uiItemDisplayStyle === 'ui_display_style_set_container',
+    owned: Boolean((saleItem?.augments || 0) & DestinyVendorItemState.Owned),
+    canBeSold: !saleItem || saleItem.failureIndexes.length === 0,
+    displayCategoryIndex: vendorItemDef ? vendorItemDef.displayCategoryIndex : undefined,
+    costs: saleItem?.costs || [],
+    previewVendorHash: inventoryItem.preview?.previewVendorHash,
+    item: makeFakeItem(
       defs,
       buckets,
       itemComponents,
       itemHash,
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
-      this.key.toString(),
+      key.toString(),
       vendorItemDef ? vendorItemDef.quantity : 1,
       mergedCollectibles,
       profileResponse?.profileRecords.data,
       // vendor items are wish list enabled!
       true
-    );
+    ),
+  };
 
-    if (this.item) {
-      this.item.hidePercentage = true;
+  if (vendorItem.item) {
+    vendorItem.item.hidePercentage = true;
 
-      // override the DimItem.id for vendor items, so they are each unique enough to identify
-      // (otherwise they'd get their vendor index as an id, which is only unique per-vendor)
-      this.item.id = `${vendorHash}-${this.key}`;
-      this.item.index = this.item.id;
-      this.item.instanced = false;
+    // override the DimItem.id for vendor items, so they are each unique enough to identify
+    // (otherwise they'd get their vendor index as an id, which is only unique per-vendor)
+    vendorItem.item.id = `${vendorHash}-${vendorItem.key}`;
+    vendorItem.item.index = vendorItem.item.id;
+    vendorItem.item.instanced = false;
 
-      // if this is sold by a vendor, add vendor information
-      if (saleItem && characterId) {
-        this.item.vendor = { vendorHash, saleIndex: saleItem.vendorItemIndex, characterId };
-        if (this.item.equipment && this.item.bucket.hash !== BucketHashes.Emblems) {
-          this.item.comparable = true;
-        }
-      }
-    }
-
-    // only apply for 2255782930, master rahool
-    if (vendorHash === VENDORS.RAHOOL && saleItem?.overrideStyleItemHash && this.item) {
-      const itemDef = defs.InventoryItem.get(saleItem.overrideStyleItemHash);
-      if (itemDef) {
-        const display = itemDef.displayProperties;
-        this.item.name = display.name;
-        this.item.icon = display.icon;
+    // if this is sold by a vendor, add vendor information
+    if (saleItem && characterId) {
+      vendorItem.item.vendor = { vendorHash, saleIndex: saleItem.vendorItemIndex, characterId };
+      if (vendorItem.item.equipment && vendorItem.item.bucket.hash !== BucketHashes.Emblems) {
+        vendorItem.item.comparable = true;
       }
     }
   }
+
+  // only apply for 2255782930, master rahool
+  if (vendorHash === VENDORS.RAHOOL && saleItem?.overrideStyleItemHash && vendorItem.item) {
+    const itemDef = defs.InventoryItem.get(saleItem.overrideStyleItemHash);
+    if (itemDef) {
+      const display = itemDef.displayProperties;
+      vendorItem.item.name = display.name;
+      vendorItem.item.icon = display.icon;
+    }
+  }
+
+  return vendorItem;
+}
+
+/**
+ * creates a VendorItem being sold by a vendor in the API vendors response.
+ * this can include "instanced" stats plugs etc which describe the specifics
+ * of that copy they're selling
+ */
+export function vendorItemForSaleItem(
+  defs: D2ManifestDefinitions,
+  buckets: InventoryBuckets,
+  vendorDef: DestinyVendorDefinition,
+  profileResponse: DestinyProfileResponse | undefined,
+  saleItem: DestinyVendorSaleItemComponent,
+  // all DIM vendor calls are character-specific. any sale item should have an associated character.
+  characterId: string,
+  itemComponents: DestinyItemComponentSetOfint32 | undefined,
+  mergedCollectibles:
+    | {
+        [hash: number]: DestinyCollectibleComponent;
+      }
+    | undefined
+): VendorItem {
+  const vendorItemDef = vendorDef.itemList[saleItem.vendorItemIndex];
+  const failureStrings =
+    saleItem && vendorDef
+      ? (saleItem.failureIndexes || []).map((i) => vendorDef.failureStrings[i])
+      : [];
+
+  return makeVendorItem(
+    defs,
+    buckets,
+    profileResponse,
+    saleItem.itemHash,
+    failureStrings,
+    vendorDef.hash,
+    vendorItemDef,
+    saleItem,
+    itemComponents,
+    mergedCollectibles,
+    characterId
+  );
+}
+
+/**
+ * creates a VendorItem solely according to a vendor's definition.
+ * some vendors are set up so statically, that they have no data in the live Vendors response
+ */
+export function vendorItemForDefinitionItem(
+  defs: D2ManifestDefinitions,
+  buckets: InventoryBuckets,
+  vendorItemDef: DestinyVendorItemDefinition,
+  mergedCollectibles?: {
+    [hash: number]: DestinyCollectibleComponent;
+  }
+): VendorItem {
+  return makeVendorItem(
+    defs,
+    buckets,
+    undefined,
+    vendorItemDef.itemHash,
+    [],
+    0,
+    vendorItemDef,
+    undefined,
+    undefined,
+    mergedCollectibles
+  );
 }


### PR DESCRIPTION
Best reviewed commit-by-commit.

It's always bothered me that VendorItem is basically the only remaining `class` in DIM when it doesn't even have instance methods, just a few ways of constructing it. So let's maybe get rid of this class too in favor of factory methods like regular DimItems?