### PR TITLE
Compute collectible state only on vendor items

### DIFF
--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -7,7 +7,6 @@ import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { DimError } from 'app/utils/dim-error';
-import { mergedCollectiblesSelector } from 'app/vendors/selectors';
 import { Destiny2CoreSettings } from 'bungie-api-ts/core';
 import {
   AwaAuthorizationResult,
@@ -242,8 +241,7 @@ function refreshItemAfterAWA(changes: DestinyItemChangeResponse): ThunkResult {
     const defs = d2ManifestSelector(getState())!;
     const buckets = d2BucketsSelector(getState())!;
     const stores = storesSelector(getState());
-    const mergedCollectibles = mergedCollectiblesSelector(getState());
-    const newItem = makeItemSingle(defs, buckets, changes.item, stores, mergedCollectibles);
+    const newItem = makeItemSingle(defs, buckets, changes.item, stores);
 
     dispatch(
       awaItemChanged({

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -118,10 +118,14 @@ export function updateCharacters(): ThunkResult {
   };
 }
 
+export interface MergedCollectibles {
+  [x: number]: DestinyCollectibleComponent;
+}
+
 export function mergeCollectibles(
   profileCollectibles: SingleComponentResponse<DestinyProfileCollectiblesComponent>,
   characterCollectibles: DictionaryComponentResponse<DestinyCollectiblesComponent>
-) {
+): MergedCollectibles {
   const allCollectibles = {
     ...profileCollectibles?.data?.collectibles,
   };
@@ -434,9 +438,7 @@ function processCharacter(
   buckets: InventoryBuckets,
   characterId: string,
   profileInfo: DestinyProfileResponse,
-  mergedCollectibles: {
-    [hash: number]: DestinyCollectibleComponent;
-  },
+  mergedCollectibles: MergedCollectibles,
   lastPlayedDate: Date
 ): DimStore {
   const character = profileInfo.characters.data![characterId];

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -380,18 +380,13 @@ export function buildStores(
 
   const lastPlayedDate = findLastPlayedDate(profileInfo);
 
-  const mergedCollectibles = mergeCollectibles(
-    profileInfo.profileCollectibles,
-    profileInfo.characterCollectibles
-  );
-
   const processSpan = transaction?.startChild({
     op: 'processItems',
   });
-  const vault = processVault(defs, buckets, profileInfo, mergedCollectibles);
+  const vault = processVault(defs, buckets, profileInfo);
 
   const characters = Object.keys(profileInfo.characters.data).map((characterId) =>
-    processCharacter(defs, buckets, characterId, profileInfo, mergedCollectibles, lastPlayedDate)
+    processCharacter(defs, buckets, characterId, profileInfo, lastPlayedDate)
   );
   processSpan?.finish();
 
@@ -439,7 +434,6 @@ function processCharacter(
   buckets: InventoryBuckets,
   characterId: string,
   profileInfo: DestinyProfileResponse,
-  mergedCollectibles: MergedCollectibles,
   lastPlayedDate: Date
 ): DimStore {
   const character = profileInfo.characters.data![characterId];
@@ -472,7 +466,6 @@ function processCharacter(
     store,
     items,
     itemComponents,
-    mergedCollectibles,
     uninstancedItemObjectives,
     profileRecords
   );
@@ -483,8 +476,7 @@ function processCharacter(
 function processVault(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
-  profileInfo: DestinyProfileResponse,
-  mergedCollectibles: MergedCollectibles
+  profileInfo: DestinyProfileResponse
 ): DimStore {
   const profileInventory = profileInfo.profileInventory.data
     ? profileInfo.profileInventory.data.items
@@ -509,7 +501,6 @@ function processVault(
     store,
     items,
     itemComponents,
-    mergedCollectibles,
     undefined,
     profileRecords
   );

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -15,13 +15,8 @@ import { DimError } from 'app/utils/dim-error';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
 import {
   DestinyCharacterProgressionComponent,
-  DestinyCollectibleComponent,
-  DestinyCollectiblesComponent,
   DestinyItemComponent,
-  DestinyProfileCollectiblesComponent,
   DestinyProfileResponse,
-  DictionaryComponentResponse,
-  SingleComponentResponse,
 } from 'bungie-api-ts/destiny2';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import helmetIcon from '../../../destiny-icons/armor_types/helmet.svg';
@@ -114,27 +109,6 @@ export function updateCharacters(): ThunkResult {
     }
 
     dispatch(charactersUpdated(characters));
-  };
-}
-
-export interface MergedCollectibles {
-  profileCollectibles: {
-    [key: number]: DestinyCollectibleComponent;
-  };
-  characterCollectibles: {
-    [key: number]: DestinyCollectibleComponent;
-  }[];
-}
-
-export function mergeCollectibles(
-  profileCollectibles: SingleComponentResponse<DestinyProfileCollectiblesComponent>,
-  characterCollectibles: DictionaryComponentResponse<DestinyCollectiblesComponent>
-): MergedCollectibles {
-  return {
-    profileCollectibles: profileCollectibles?.data?.collectibles ?? {},
-    characterCollectibles: Object.values(characterCollectibles.data ?? {}).map(
-      (c) => c.collectibles ?? {}
-    ),
   };
 }
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -4,7 +4,6 @@ import {
   DestinyAmmunitionType,
   DestinyBreakerTypeDefinition,
   DestinyClass,
-  DestinyCollectibleState,
   DestinyDamageTypeDefinition,
   DestinyDisplayPropertiesDefinition,
   DestinyEnergyTypeDefinition,
@@ -225,8 +224,6 @@ export interface DimItem {
   breakerType: DestinyBreakerTypeDefinition | null;
   /** The foundry this item was made by */
   foundry: string | null;
-  /** The state of this item in the user's D2 Collection */
-  collectibleState?: DestinyCollectibleState;
   /** Extra tooltips to show in the item popup */
   tooltipNotifications?: DestinyItemTooltipNotification[];
   /** Index assigned to item by Bungie */

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -7,14 +7,13 @@ import {
   ItemLocation,
 } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
-import produce, { Draft, original } from 'immer';
+import produce, { Draft } from 'immer';
 import _ from 'lodash';
 import { Reducer } from 'redux';
 import { ActionType, getType } from 'typesafe-actions';
 import { setCurrentAccount } from '../accounts/actions';
 import type { AccountsAction } from '../accounts/reducer';
 import * as actions from './actions';
-import { mergeCollectibles } from './d2-stores';
 import { InventoryBuckets } from './inventory-buckets';
 import { DimItem } from './item-types';
 import { AccountCurrency, DimStore } from './store-types';
@@ -438,12 +437,6 @@ function awaItemChanged(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets
 ) {
-  const { profileResponse } = original(draft)!;
-
-  const mergedCollectibles = profileResponse
-    ? mergeCollectibles(profileResponse.profileCollectibles, profileResponse.characterCollectibles)
-    : {};
-
   // Replace item
   if (!item) {
     warnLog('awaChange', 'No item produced from change');
@@ -534,14 +527,7 @@ function awaItemChanged(
       currency.quantity = Math.min(max, currency.quantity + addedItemComponent.quantity);
     } else if (addedItemComponent.itemInstanceId) {
       const addedOwner = getSource(addedItemComponent);
-      const addedItem = makeItem(
-        defs,
-        buckets,
-        undefined,
-        addedItemComponent,
-        addedOwner,
-        mergedCollectibles
-      );
+      const addedItem = makeItem(defs, buckets, undefined, addedItemComponent, addedOwner);
       if (addedItem) {
         addItem(addedOwner, addedItem);
       }
@@ -553,14 +539,7 @@ function awaItemChanged(
         (i) => i.amount
       );
       let addAmount = addedItemComponent.quantity;
-      const addedItem = makeItem(
-        defs,
-        buckets,
-        undefined,
-        addedItemComponent,
-        target,
-        mergedCollectibles
-      );
+      const addedItem = makeItem(defs, buckets, undefined, addedItemComponent, target);
       if (!addedItem) {
         continue;
       }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -241,7 +241,6 @@ export function makeItemSingle(
  * @param newItems a set of item IDs representing the previous list of new items
  * @param item "raw" item from the Destiny API
  * @param owner the ID of the owning store
- * @param mergedCollectibles collectible information so each DimItem is self-aware of whether it's already owned
  * @param uninstancedItemObjectives the owning character's dictionary of uninstanced objectives
  */
 // TODO: extract individual item components first!

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -424,8 +424,16 @@ export function makeItem(
   // collection stuff: establish a collectedness state, and hashes leading to the collectible and source
   const { collectibleHash } = itemDef;
   let collectibleState: DestinyCollectibleState | undefined;
-  if (collectibleHash) {
-    collectibleState = mergedCollectibles?.[collectibleHash]?.state;
+  if (collectibleHash && mergedCollectibles) {
+    collectibleState = mergedCollectibles?.profileCollectibles[collectibleHash]?.state;
+    if (collectibleState === undefined) {
+      for (const state of mergedCollectibles.characterCollectibles) {
+        collectibleState = state[collectibleHash]?.state;
+        if (collectibleState !== undefined) {
+          break;
+        }
+      }
+    }
   }
   const source = collectibleHash
     ? defs.Collectible.get(collectibleHash, itemDef.hash)?.sourceHash

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -15,7 +15,6 @@ import {
   ComponentPrivacySetting,
   DestinyAmmunitionType,
   DestinyClass,
-  DestinyCollectibleComponent,
   DestinyCollectibleState,
   DestinyInventoryItemDefinition,
   DestinyItemComponent,
@@ -44,6 +43,7 @@ import memoizeOne from 'memoize-one';
 import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
 import { warnMissingDefinition } from '../../manifest/manifest-service-json';
 import { reportException } from '../../utils/exceptions';
+import { MergedCollectibles } from '../d2-stores';
 import { InventoryBuckets } from '../inventory-buckets';
 import { DimItem } from '../item-types';
 import { DimStore } from '../store-types';
@@ -77,9 +77,7 @@ export function processItems(
   owner: DimStore,
   items: DestinyItemComponent[],
   itemComponents: DestinyItemComponentSetOfint64,
-  mergedCollectibles: {
-    [hash: number]: DestinyCollectibleComponent;
-  },
+  mergedCollectibles: MergedCollectibles,
   uninstancedItemObjectives?: {
     [key: number]: DestinyObjectiveProgress[];
   },
@@ -160,9 +158,7 @@ export function makeFakeItem(
   itemHash: number,
   itemInstanceId?: string,
   quantity?: number,
-  mergedCollectibles?: {
-    [hash: number]: DestinyCollectibleComponent;
-  },
+  mergedCollectibles?: MergedCollectibles,
   profileRecords?: DestinyProfileRecordsComponent,
   allowWishList?: boolean
 ): DimItem | null {
@@ -207,9 +203,7 @@ export function makeItemSingle(
   buckets: InventoryBuckets,
   item: DestinyItemResponse,
   stores: DimStore[],
-  mergedCollectibles?: {
-    [hash: number]: DestinyCollectibleComponent;
-  }
+  mergedCollectibles?: MergedCollectibles
 ): DimItem | null {
   if (!item.item.data) {
     return null;
@@ -265,9 +259,7 @@ export function makeItem(
   itemComponents: DestinyItemComponentSetOfint64 | undefined,
   item: DestinyItemComponent,
   owner: DimStore | undefined,
-  mergedCollectibles?: {
-    [hash: number]: DestinyCollectibleComponent;
-  },
+  mergedCollectibles?: MergedCollectibles,
   uninstancedItemObjectives?: {
     [key: number]: DestinyObjectiveProgress[];
   },

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -309,7 +309,6 @@ function toCollectibles(
         collectibleDef.itemHash,
         undefined,
         undefined,
-        undefined,
         profileResponse.profileRecords.data
       );
       if (!item) {

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -18,11 +18,7 @@ import { loadingTracker } from '../shell/loading-tracker';
 import { refresh$ } from '../shell/refresh-events';
 import { loadAllVendors } from './actions';
 import { toVendor } from './d2-vendors';
-import {
-  mergedCollectiblesSelector,
-  ownedVendorItemsSelector,
-  vendorsByCharacterSelector,
-} from './selectors';
+import { ownedVendorItemsSelector, vendorsByCharacterSelector } from './selectors';
 import styles from './SingleVendor.m.scss';
 import { VendorLocation } from './Vendor';
 import VendorItems from './VendorItems';
@@ -39,7 +35,6 @@ export default function SingleVendor({ account }: { account: DestinyAccount }) {
   const profileResponse = useSelector(profileResponseSelector);
   const vendors = useSelector(vendorsByCharacterSelector);
   const defs = useD2Definitions();
-  const mergedCollectibles = useSelector(mergedCollectiblesSelector);
   const dispatch = useThunkDispatch();
 
   // TODO: get for all characters, or let people select a character? This is a hack
@@ -122,8 +117,7 @@ export default function SingleVendor({ account }: { account: DestinyAccount }) {
     account,
     characterId,
     vendorResponse?.itemComponents[vendorHash],
-    vendorResponse?.sales.data?.[vendorHash]?.saleItems,
-    mergedCollectibles
+    vendorResponse?.sales.data?.[vendorHash]?.saleItems
   );
 
   if (!d2Vendor) {

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -43,8 +43,8 @@ export default function VendorItemComponent({
   }
 
   const acquired =
-    item.item.collectibleState !== undefined &&
-    !(item.item.collectibleState & DestinyCollectibleState.NotAcquired);
+    item.collectibleState !== undefined &&
+    !(item.collectibleState & DestinyCollectibleState.NotAcquired);
 
   // Can't buy more copies of emblems or bounties other than repeatables.
   const ownershipRule =

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -188,12 +188,14 @@ export default function VendorItems({
                       )
                     )
                     .map(
-                      (item) =>
-                        item.item && (
+                      (vendorItem) =>
+                        vendorItem.item && (
                           <VendorItemComponent
-                            key={item.key}
-                            item={item}
-                            owned={Boolean(ownedItemHashes?.has(item.item.hash) || item.owned)}
+                            key={vendorItem.key}
+                            item={vendorItem}
+                            owned={Boolean(
+                              ownedItemHashes?.has(vendorItem.item.hash) || vendorItem.owned
+                            )}
                             characterId={characterId}
                           />
                         )

--- a/src/app/vendors/d2-vendors.test.ts
+++ b/src/app/vendors/d2-vendors.test.ts
@@ -1,8 +1,8 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { getBuckets } from 'app/destiny2/d2-buckets';
-import { mergeCollectibles } from 'app/inventory/d2-stores';
 import { getTestDefinitions, getTestProfile, getTestVendors } from 'testing/test-utils';
 import { D2VendorGroup, toVendorGroups } from './d2-vendors';
+import { mergeCollectibles } from './selectors';
 
 async function getTestVendorGroups() {
   const defs = await getTestDefinitions();

--- a/src/app/vendors/d2-vendors.test.ts
+++ b/src/app/vendors/d2-vendors.test.ts
@@ -2,17 +2,12 @@ import { DestinyAccount } from 'app/accounts/destiny-account';
 import { getBuckets } from 'app/destiny2/d2-buckets';
 import { getTestDefinitions, getTestProfile, getTestVendors } from 'testing/test-utils';
 import { D2VendorGroup, toVendorGroups } from './d2-vendors';
-import { mergeCollectibles } from './selectors';
 
 async function getTestVendorGroups() {
   const defs = await getTestDefinitions();
   const profileResponse = getTestProfile();
   const vendorsResponse = getTestVendors();
   const buckets = getBuckets(defs);
-  const mergedCollectibles = mergeCollectibles(
-    profileResponse.profileCollectibles,
-    profileResponse.characterCollectibles
-  );
   const account: DestinyAccount = {
     displayName: '',
     originalPlatformType: 2,
@@ -24,15 +19,7 @@ async function getTestVendorGroups() {
   };
   const characterId = Object.keys(profileResponse.characters.data!)[0];
 
-  return toVendorGroups(
-    vendorsResponse,
-    profileResponse,
-    defs,
-    buckets,
-    account,
-    characterId,
-    mergedCollectibles
-  );
+  return toVendorGroups(vendorsResponse, profileResponse, defs, buckets, account, characterId);
 }
 
 function* allSaleItems(vendorGroups: D2VendorGroup[]) {

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -19,12 +19,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import {
-  MergedCollectibles,
-  VendorItem,
-  vendorItemForDefinitionItem,
-  vendorItemForSaleItem,
-} from './vendor-item';
+import { VendorItem, vendorItemForDefinitionItem, vendorItemForSaleItem } from './vendor-item';
 export interface D2VendorGroup {
   def: DestinyVendorGroupDefinition;
   vendors: D2Vendor[];
@@ -47,8 +42,7 @@ export function toVendorGroups(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
   account: DestinyAccount,
-  characterId: string,
-  mergedCollectibles: MergedCollectibles
+  characterId: string
 ): D2VendorGroup[] {
   if (!vendorsResponse.vendorGroups.data) {
     return [];
@@ -72,8 +66,7 @@ export function toVendorGroups(
                   account,
                   characterId,
                   vendorsResponse.itemComponents[vendorHash],
-                  vendorsResponse.sales.data?.[vendorHash]?.saleItems,
-                  mergedCollectibles
+                  vendorsResponse.sales.data?.[vendorHash]?.saleItems
                 )
               )
               .filter((vendor) => vendor?.items.length)
@@ -102,8 +95,7 @@ export function toVendor(
     | {
         [key: string]: DestinyVendorSaleItemComponent;
       }
-    | undefined,
-  mergedCollectibles: MergedCollectibles
+    | undefined
 ): D2Vendor | undefined {
   const vendorDef = defs.Vendor.get(vendorHash);
 
@@ -119,8 +111,7 @@ export function toVendor(
     profileResponse,
     characterId,
     itemComponents,
-    sales,
-    mergedCollectibles
+    sales
   );
 
   const destinationDef =
@@ -163,8 +154,7 @@ function getVendorItems(
     | {
         [key: string]: DestinyVendorSaleItemComponent;
       }
-    | undefined,
-  mergedCollectibles: MergedCollectibles
+    | undefined
 ): VendorItem[] {
   if (sales) {
     const components = Object.values(sales);
@@ -176,8 +166,7 @@ function getVendorItems(
         profileResponse,
         component,
         characterId,
-        itemComponents,
-        mergedCollectibles
+        itemComponents
       )
     );
   } else if (vendorDef.returnWithVendorRequest) {
@@ -191,7 +180,7 @@ function getVendorItems(
           i.exclusivity === BungieMembershipType.All ||
           i.exclusivity === account.originalPlatformType
       )
-      .map((i) => vendorItemForDefinitionItem(defs, buckets, i, mergedCollectibles, characterId));
+      .map((i) => vendorItemForDefinitionItem(defs, buckets, i, profileResponse, characterId));
   }
 }
 

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -1,6 +1,5 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { MergedCollectibles } from 'app/inventory/d2-stores';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { VENDORS } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
@@ -20,7 +19,12 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import { VendorItem, vendorItemForDefinitionItem, vendorItemForSaleItem } from './vendor-item';
+import {
+  MergedCollectibles,
+  VendorItem,
+  vendorItemForDefinitionItem,
+  vendorItemForSaleItem,
+} from './vendor-item';
 export interface D2VendorGroup {
   def: DestinyVendorGroupDefinition;
   vendors: D2Vendor[];
@@ -44,7 +48,7 @@ export function toVendorGroups(
   buckets: InventoryBuckets,
   account: DestinyAccount,
   characterId: string,
-  mergedCollectibles: MergedCollectibles | undefined
+  mergedCollectibles: MergedCollectibles
 ): D2VendorGroup[] {
   if (!vendorsResponse.vendorGroups.data) {
     return [];
@@ -99,7 +103,7 @@ export function toVendor(
         [key: string]: DestinyVendorSaleItemComponent;
       }
     | undefined,
-  mergedCollectibles: MergedCollectibles | undefined
+  mergedCollectibles: MergedCollectibles
 ): D2Vendor | undefined {
   const vendorDef = defs.Vendor.get(vendorHash);
 
@@ -160,7 +164,7 @@ function getVendorItems(
         [key: string]: DestinyVendorSaleItemComponent;
       }
     | undefined,
-  mergedCollectibles: MergedCollectibles | undefined
+  mergedCollectibles: MergedCollectibles
 ): VendorItem[] {
   if (sales) {
     const components = Object.values(sales);
@@ -187,7 +191,7 @@ function getVendorItems(
           i.exclusivity === BungieMembershipType.All ||
           i.exclusivity === account.originalPlatformType
       )
-      .map((i) => vendorItemForDefinitionItem(defs, buckets, i, mergedCollectibles));
+      .map((i) => vendorItemForDefinitionItem(defs, buckets, i, mergedCollectibles, characterId));
   }
 }
 

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -202,12 +202,12 @@ export function filterVendorGroupsToUnacquired(
         .map((vendor) => ({
           ...vendor,
           items: vendor.items.filter(
-            (item) =>
-              item.item &&
-              (item.item.collectibleState !== undefined
-                ? item.item.collectibleState & DestinyCollectibleState.NotAcquired
-                : item.item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod) &&
-                  !ownedItemHashes.has(item.item.hash))
+            ({ item, collectibleState }) =>
+              item &&
+              (collectibleState !== undefined
+                ? collectibleState & DestinyCollectibleState.NotAcquired
+                : item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod) &&
+                  !ownedItemHashes.has(item.hash))
           ),
         }))
         .filter((v) => v.items.length),
@@ -228,7 +228,7 @@ export function filterVendorGroupsToSearch(
           ...vendor,
           items: vendor.def.displayProperties.name.toLowerCase().includes(searchQuery.toLowerCase())
             ? vendor.items
-            : vendor.items.filter((i) => i.item && filterItems(i.item)),
+            : vendor.items.filter(({ item }) => item && filterItems(item)),
         }))
         .filter((v) => v.items.length),
     }))

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -1,11 +1,11 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { MergedCollectibles } from 'app/inventory/d2-stores';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { VENDORS } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
 import {
   BungieMembershipType,
-  DestinyCollectibleComponent,
   DestinyCollectibleState,
   DestinyDestinationDefinition,
   DestinyInventoryItemDefinition,
@@ -44,11 +44,7 @@ export function toVendorGroups(
   buckets: InventoryBuckets,
   account: DestinyAccount,
   characterId: string,
-  mergedCollectibles:
-    | {
-        [hash: number]: DestinyCollectibleComponent;
-      }
-    | undefined
+  mergedCollectibles: MergedCollectibles | undefined
 ): D2VendorGroup[] {
   if (!vendorsResponse.vendorGroups.data) {
     return [];
@@ -103,11 +99,7 @@ export function toVendor(
         [key: string]: DestinyVendorSaleItemComponent;
       }
     | undefined,
-  mergedCollectibles:
-    | {
-        [hash: number]: DestinyCollectibleComponent;
-      }
-    | undefined
+  mergedCollectibles: MergedCollectibles | undefined
 ): D2Vendor | undefined {
   const vendorDef = defs.Vendor.get(vendorHash);
 
@@ -168,11 +160,7 @@ function getVendorItems(
         [key: string]: DestinyVendorSaleItemComponent;
       }
     | undefined,
-  mergedCollectibles:
-    | {
-        [hash: number]: DestinyCollectibleComponent;
-      }
-    | undefined
+  mergedCollectibles: MergedCollectibles | undefined
 ): VendorItem[] {
   if (sales) {
     const components = Object.values(sales);

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -11,47 +11,10 @@ import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { currySelector } from 'app/utils/redux-utils';
-import {
-  DestinyCollectiblesComponent,
-  DestinyProfileCollectiblesComponent,
-  DictionaryComponentResponse,
-  SingleComponentResponse,
-} from 'bungie-api-ts/destiny2';
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { D2VendorGroup, toVendorGroups } from './d2-vendors';
-import { MergedCollectibles } from './vendor-item';
 
 export const vendorsByCharacterSelector = (state: RootState) => state.vendors.vendorsByCharacter;
-
-const emptyCollectibles: MergedCollectibles = {
-  profileCollectibles: {},
-  characterCollectibles: {},
-};
-
-export function mergeCollectibles(
-  profileCollectibles: SingleComponentResponse<DestinyProfileCollectiblesComponent>,
-  characterCollectibles: DictionaryComponentResponse<DestinyCollectiblesComponent>
-): MergedCollectibles {
-  return {
-    profileCollectibles: profileCollectibles?.data?.collectibles ?? {},
-    characterCollectibles: _.mapValues(
-      characterCollectibles.data ?? {},
-      (c) => c.collectibles ?? {}
-    ),
-  };
-}
-
-export const mergedCollectiblesSelector = createSelector(
-  profileResponseSelector,
-  (profileResponse) =>
-    profileResponse
-      ? mergeCollectibles(
-          profileResponse.profileCollectibles,
-          profileResponse.characterCollectibles
-        )
-      : emptyCollectibles
-);
 
 /**
  * returns a character's vendors and their sale items
@@ -59,22 +22,13 @@ export const mergedCollectiblesSelector = createSelector(
 export const nonCurriedVendorGroupsForCharacterSelector = createSelector(
   d2ManifestSelector,
   vendorsByCharacterSelector,
-  mergedCollectiblesSelector,
   bucketsSelector,
   currentAccountSelector,
   profileResponseSelector,
   // get character ID from props not state
   (state: any, characterId: string | undefined) =>
     characterId || getCurrentStore(sortedStoresSelector(state))?.id,
-  (
-    defs,
-    vendors,
-    mergedCollectibles,
-    buckets,
-    currentAccount,
-    profileResponse,
-    selectedStoreId
-  ) => {
+  (defs, vendors, buckets, currentAccount, profileResponse, selectedStoreId) => {
     const vendorData = selectedStoreId ? vendors[selectedStoreId] : undefined;
     const vendorsResponse = vendorData?.vendorsResponse;
 
@@ -90,8 +44,7 @@ export const nonCurriedVendorGroupsForCharacterSelector = createSelector(
           defs,
           buckets,
           currentAccount,
-          selectedStoreId,
-          mergedCollectibles
+          selectedStoreId
         )
       : emptyArray<D2VendorGroup>();
   }

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -1,5 +1,5 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
-import { mergeCollectibles } from 'app/inventory/d2-stores';
+import { mergeCollectibles, MergedCollectibles } from 'app/inventory/d2-stores';
 import {
   bucketsSelector,
   ownedItemsSelector,
@@ -10,12 +10,17 @@ import {
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
-import { emptyArray, emptyObject } from 'app/utils/empty';
+import { emptyArray } from 'app/utils/empty';
 import { currySelector } from 'app/utils/redux-utils';
 import { createSelector } from 'reselect';
 import { D2VendorGroup, toVendorGroups } from './d2-vendors';
 
 export const vendorsByCharacterSelector = (state: RootState) => state.vendors.vendorsByCharacter;
+
+const emptyCollectibles: MergedCollectibles = {
+  profileCollectibles: {},
+  characterCollectibles: [],
+};
 
 export const mergedCollectiblesSelector = createSelector(
   profileResponseSelector,
@@ -25,7 +30,7 @@ export const mergedCollectiblesSelector = createSelector(
           profileResponse.profileCollectibles,
           profileResponse.characterCollectibles
         )
-      : emptyObject<ReturnType<typeof mergeCollectibles>>()
+      : emptyCollectibles
 );
 
 /**

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -1,5 +1,4 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
-import { mergeCollectibles, MergedCollectibles } from 'app/inventory/d2-stores';
 import {
   bucketsSelector,
   ownedItemsSelector,
@@ -12,15 +11,36 @@ import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { currySelector } from 'app/utils/redux-utils';
+import {
+  DestinyCollectiblesComponent,
+  DestinyProfileCollectiblesComponent,
+  DictionaryComponentResponse,
+  SingleComponentResponse,
+} from 'bungie-api-ts/destiny2';
+import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { D2VendorGroup, toVendorGroups } from './d2-vendors';
+import { MergedCollectibles } from './vendor-item';
 
 export const vendorsByCharacterSelector = (state: RootState) => state.vendors.vendorsByCharacter;
 
 const emptyCollectibles: MergedCollectibles = {
   profileCollectibles: {},
-  characterCollectibles: [],
+  characterCollectibles: {},
 };
+
+export function mergeCollectibles(
+  profileCollectibles: SingleComponentResponse<DestinyProfileCollectiblesComponent>,
+  characterCollectibles: DictionaryComponentResponse<DestinyCollectiblesComponent>
+): MergedCollectibles {
+  return {
+    profileCollectibles: profileCollectibles?.data?.collectibles ?? {},
+    characterCollectibles: _.mapValues(
+      characterCollectibles.data ?? {},
+      (c) => c.collectibles ?? {}
+    ),
+  };
+}
 
 export const mergedCollectiblesSelector = createSelector(
   profileResponseSelector,

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -49,9 +49,10 @@ function getCollectibleState(
   let collectibleState: DestinyCollectibleState | undefined;
   if (collectibleHash) {
     collectibleState =
-      profileResponse?.profileCollectibles?.data?.[collectibleHash]?.state ??
+      profileResponse?.profileCollectibles?.data?.collectibles[collectibleHash]?.state ??
       (characterId
-        ? profileResponse?.characterCollectibles?.data?.[characterId]?.[collectibleHash]?.state
+        ? profileResponse?.characterCollectibles?.data?.[characterId]?.collectibles[collectibleHash]
+            ?.state
         : undefined);
   }
   return collectibleState;

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -1,6 +1,6 @@
+import { MergedCollectibles } from 'app/inventory/d2-stores';
 import { VENDORS } from 'app/search/d2-known-values';
 import {
-  DestinyCollectibleComponent,
   DestinyDisplayPropertiesDefinition,
   DestinyItemComponentSetOfint32,
   DestinyItemQuantity,
@@ -43,11 +43,7 @@ function makeVendorItem(
   vendorItemDef: DestinyVendorItemDefinition | undefined,
   saleItem: DestinyVendorSaleItemComponent | undefined,
   itemComponents: DestinyItemComponentSetOfint32 | undefined,
-  mergedCollectibles:
-    | {
-        [hash: number]: DestinyCollectibleComponent;
-      }
-    | undefined,
+  mergedCollectibles: MergedCollectibles | undefined,
   // the character to whom this item is being offered
   characterId?: string
 ): VendorItem {
@@ -124,11 +120,7 @@ export function vendorItemForSaleItem(
   // all DIM vendor calls are character-specific. any sale item should have an associated character.
   characterId: string,
   itemComponents: DestinyItemComponentSetOfint32 | undefined,
-  mergedCollectibles:
-    | {
-        [hash: number]: DestinyCollectibleComponent;
-      }
-    | undefined
+  mergedCollectibles: MergedCollectibles | undefined
 ): VendorItem {
   const vendorItemDef = vendorDef.itemList[saleItem.vendorItemIndex];
   const failureStrings =
@@ -159,9 +151,7 @@ export function vendorItemForDefinitionItem(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
   vendorItemDef: DestinyVendorItemDefinition,
-  mergedCollectibles?: {
-    [hash: number]: DestinyCollectibleComponent;
-  }
+  mergedCollectibles?: MergedCollectibles
 ): VendorItem {
   return makeVendorItem(
     defs,


### PR DESCRIPTION
I was doing some profiling and realizing we spent a lot of CPU and GC on building up the "merged collectibles" map. I spent some time making it more efficient, then realized it was only needed for vendor items. So I removed it from regular items and moved it to the vendor item interface. Then I realized that we didn't need to look at all characters, just account-wide and the character that's selected on the vendors page. Eventually, I was able to remove the precalculation entirely and just do it directly from the profile response.

This is certainly more efficient now (and cleans up a lot of code), and should theoretically be more accurate though I don't think it actually matters (character-level unlocks appear to mostly be armor).