### PR TITLE
Remove perks from sockets

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -19,7 +19,6 @@ import {
   DestinyObjectiveProgress,
   DestinyPlugItemCraftingRequirements,
   DestinyRecordComponent,
-  DestinySandboxPerkDefinition,
   DestinySocketCategoryDefinition,
   DestinyStat,
   DestinyStatDefinition,
@@ -141,6 +140,7 @@ export interface DimItem {
   /** Localized string for where this item comes from... or other stuff like it not being recoverable from collections */
   displaySource?: string;
   collectibleHash?: number;
+  // TODO: pull search-only fields out
   /** The DestinyCollectibleDefinition sourceHash for a specific item (D2). Derived entirely from collectibleHash */
   source?: number;
   /** Information about this item as a plug. Mostly useful for mod collectibles. */
@@ -399,8 +399,6 @@ export interface PluggableInventoryItemDefinition extends DestinyInventoryItemDe
 export interface DimPlug {
   /** The InventoryItem definition associated with this plug. */
   readonly plugDef: PluggableInventoryItemDefinition;
-  /** Perks associated with the use of this plug. TODO: load on demand? */
-  readonly perks: DestinySandboxPerkDefinition[];
   /** Objectives associated with this plug, usually used to unlock it. */
   readonly plugObjectives: DestinyObjectiveProgress[];
   /** Is the plug enabled? For example, some perks only activate on certain planets. */

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -390,7 +390,6 @@ function buildPlug(
     enabled: enabled && (!isDestinyItemPlug(plug) || plug.canInsert),
     enableFailReasons: failReasons,
     plugObjectives: plugObjectivesData?.[plugHash] || [],
-    perks: plugDef.perks ? plugDef.perks.map((perk) => defs.SandboxPerk.get(perk.perkHash)) : [],
     stats: null,
   };
 }
@@ -406,7 +405,6 @@ export function buildDefinedPlug(defs: D2ManifestDefinitions, plugHash: number):
     enabled: true,
     enableFailReasons: '',
     plugObjectives: [],
-    perks: (plugDef.perks || []).map((perk) => defs.SandboxPerk.get(perk.perkHash)),
     stats: null,
   };
 }

--- a/src/app/search/search-filters/freeform.tsx
+++ b/src/app/search/search-filters/freeform.tsx
@@ -268,10 +268,7 @@ function testStringsFromAllSockets(
           plug.plugDef.displayProperties,
           includeDescription
         ) ||
-        test(plug.plugDef.itemTypeDisplayName) ||
-        plug.perks.some((perk) =>
-          testStringsFromDisplayPropertiesMap(test, perk.displayProperties, includeDescription)
-        )
+        test(plug.plugDef.itemTypeDisplayName)
       ) {
         return true;
       }


### PR DESCRIPTION
Taking a look at some profiles, we spend a lot of time generating these perks lists. The actual data isn't used anywhere except in searching, and I don't think it's a great idea to have searches match on something we never display. So, I've removed them.