### PR TITLE
Fix missing border above tooltip sections

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -41,6 +41,16 @@
     "declaration-block-no-duplicate-properties": [
       true,
       { "ignore": ["consecutive-duplicates-with-different-values"] }
+    ],
+    "scss/function-no-unknown": [
+      true,
+      { "ignoreFunctions": "/^dim-([a-z][a-z0-9]*)(-[a-z0-9]+)*$/" }
+    ],
+    "scss/at-function-pattern": [
+      "^dim-([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
+      {
+        "message": "Expected function name to be kebab-case and prefixed with 'dim-'"
+      }
     ]
   }
 }

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 // Variables and mixins that can be used from any SCSS file
 
 // DIM orange and blue, accent colors
@@ -142,4 +144,27 @@ $easeInOutCubic: cubic-bezier(0.645, 0.045, 0.355, 1);
       height: 10px;
     }
   }
+}
+
+/*
+Utility functions to allow for augmenting a hex color value with an alpha component.
+e.g.
+  color: dim-hex-with-alpha(#ff7b00, 0.5);
+produces
+  color: rgba(255, 128, 0, 0.5);
+*/
+
+// Converts a 6-character hex color into a comma-separated list of RGB values, to use within the 'rgba' function.
+@function dim-hex-to-rgb-values($hex) {
+  @return color.red($hex), color.green($hex), color.blue($hex);
+}
+
+// Produces an 'rgba' function usage for the specified comma-separated RGB values and alpha.
+@function dim-rgb-values-to-rgba($values, $alpha: 1) {
+  @return #{'rgba(' + $values + ', ' + $alpha + ')'};
+}
+
+// Augments a hex color with the specified alpha value and returns its 'rgba' representation.
+@function dim-hex-with-alpha($hex, $alpha) {
+  @return dim-rgb-values-to-rgba(dim-hex-to-rgb-values($hex), $alpha);
 }

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -157,6 +157,7 @@ e.g.
 
 produces
 
+  --my-base-color-rgb: 255, 128, 0;
   background-color: rgba(255, 128, 0, 1);
   border-color: rgba(255, 128, 0, 0.75);
 

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -148,10 +148,18 @@ $easeInOutCubic: cubic-bezier(0.645, 0.045, 0.355, 1);
 
 /*
 Utility functions to allow for augmenting a hex color value with an alpha component.
+
 e.g.
-  color: dim-hex-with-alpha(#ff7b00, 0.5);
+
+  --my-base-color-rgb: #{dim-hex-to-rgb-values(#ff7b00)};
+  background-color: dim-rgb-values-to-rgba(var(--my-base-color-rgb));
+  border-color: dim-rgb-values-to-rgba(var(--my-base-color-rgb), $alpha: 0.75);
+
 produces
-  color: rgba(255, 128, 0, 0.5);
+
+  background-color: rgba(255, 128, 0, 1);
+  border-color: rgba(255, 128, 0, 0.75);
+
 */
 
 // Converts a 6-character hex color into a comma-separated list of RGB values, to use within the 'rgba' function.
@@ -162,9 +170,4 @@ produces
 // Produces an 'rgba' function usage for the specified comma-separated RGB values and alpha.
 @function dim-rgb-values-to-rgba($values, $alpha: 1) {
   @return #{'rgba(' + $values + ', ' + $alpha + ')'};
-}
-
-// Augments a hex color with the specified alpha value and returns its 'rgba' representation.
-@function dim-hex-with-alpha($hex, $alpha) {
-  @return dim-rgb-values-to-rgba(dim-hex-to-rgb-values($hex), $alpha);
 }

--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -15,14 +15,14 @@ $horizontal-padding: 11px;
 .tooltip {
   --tooltip-ribbon-color: #8e8e9e;
   --tooltip-background-color: #151523;
-  --tooltip-border-color: #5d5970;
+  --tooltip-border-color-rgb: #{dim-hex-to-rgb-values(#5d5970)};
 
   position: absolute;
   background-color: var(--tooltip-background-color);
   color: #dadaea;
   width: fit-content;
   max-width: 306px;
-  border: 1px solid var(--tooltip-border-color);
+  border: 1px solid dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
   border-top-width: $ribbon-width;
   border-radius: $ribbon-width;
   box-shadow: 0 0 24px 6px #080811;
@@ -51,7 +51,7 @@ $horizontal-padding: 11px;
   }
 
   hr {
-    border-color: var(--tooltip-border-color);
+    border-color: dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
   }
 
   p {
@@ -87,7 +87,7 @@ $horizontal-padding: 11px;
     border-width: 0;
     border-style: solid;
     position: absolute;
-    border-color: var(--tooltip-border-color);
+    border-color: dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
   }
 
   &[data-popper-placement='top'] .arrow {
@@ -127,8 +127,8 @@ $horizontal-padding: 11px;
 
   &.minimalTooltip {
     border-radius: 3px;
-    --tooltip-ribbon-color: var(--tooltip-border-color);
-    background-color: var(--tooltip-border-color);
+    --tooltip-ribbon-color: #{dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb))};
+    background-color: dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
     border: none;
     box-shadow: 0 0 10px 3px #080811;
 
@@ -152,7 +152,7 @@ $horizontal-padding: 11px;
   .section:not(:empty) {
     margin: 8px #{-$horizontal-padding} -8px #{-$horizontal-padding};
     padding: 5px $horizontal-padding 7px $horizontal-padding;
-    border-top: 1px solid rgba(var(--tooltip-border-color), 0.5);
+    border-top: 1px solid dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb), $alpha: 0.5);
 
     > :first-child {
       margin-top: 0;

--- a/src/app/dim-ui/_tooltip-mixins.scss
+++ b/src/app/dim-ui/_tooltip-mixins.scss
@@ -1,3 +1,4 @@
+@use '../variables' as *;
 @use 'sass:color';
 
 // These mixins are used to customize tooltips hosted within a PressTip (see PressTip.m.scss)
@@ -7,7 +8,7 @@
 }
 
 @mixin tooltip-border-color($color) {
-  --tooltip-border-color: #{$color};
+  --tooltip-border-color-rgb: #{dim-hex-to-rgb-values($color)};
 }
 
 @mixin tooltip-ribbon-color($color) {


### PR DESCRIPTION
This PR fixes a regression introduced by #8904 whereby the separator line between tooltip sections is no longer rendered.

![dim-fix-tooltip-section-border-missing](https://user-images.githubusercontent.com/17512262/211187774-9fb78320-4aae-4168-8cc2-71886be36850.png)

## Root cause

The colour of the section separator line is derived from the tooltip border colour (border colour at 50% opacity). To support further customisation, #8904 changed the tooltip border colour to be set using a CSS custom property instead of a hardcoded value. Unfortunately, we were inadvertently relying on Sass to derive the separator line colour so this broke once the border colour was no longer known at compile time.

Prior to #8904, the code looked like this:
```scss
$border-color: #5d5970;
.section:not(:empty) {
  border-top: 1px solid rgba($border-color, 0.5);
}
```
`rgba($border-color, 0.5)` expands to `rgba(#5d5970, 0.5)`, which is invalid CSS. However, Sass has a [built-in `rgba` function](https://github.com/sass/sass-site/blob/4246de7258a11dfcf5d5423ced99a135c2d88f67/source/documentation/modules.html.md.erb#L272) that fixes this up, resulting in `rgba(93, 89, 112, 0.5)` being emitted, which is valid CSS.

After #8904, the code was changed to look like this:
```scss
.section:not(:empty) {
  // 'var(--tooltip-border-color)' contains a hex value like '#5d5970'
  border-top: 1px solid rgba(var(--tooltip-border-color), 0.5);
}
```
Because the value of `var(--tooltip-border-color)` is only known at runtime, we end up with an evaluated expression that looks like `rgba(#5d5970, 0.5)`, which is invalid. This means that the separator line colour is unset and thus not rendered.

## Solution

To ensure that we produce valid CSS when deriving the separator line colour, we now store the border colour as comma-separated RGB values that can be plugged directly into the `rgba` CSS function e.g.

```scss
.section:not(:empty) {
  // 'var(--tooltip-border-color-rgb)' contains comma-seperated RGB values like '93, 89, 112'
  border-top: 1px solid #{'rgba(' + var(--tooltip-border-color-rgb) + ', 0.5)'};
}
```

This expands to something like `rgba(93, 89, 112, 0.5)` at runtime.

### Stylelint changes

To avoid defining colours using this CSV syntax, I've added some custom Sass functions to make it easier to work with them. This is the first instance of custom Sass functions in the DIM codebase, and I needed to make some Stylelint rule changes to add them.

`scss/function-no-unknown` complains about any Sass functions that it doesn't recognise. This function list is hardcoded, so I've overridden this rule to ignore any functions prefixed with `dim-`. I've also configured the `scss/at-function-pattern` rule to align with this pattern.

FWIW, before going with the `dim-` prefix, I tried using the `--` and `-` prefixes instead. Functions starting with `--` are automatically ignored by `scss/function-no-unknown` so that would remove the need to override that rule. However, it seems like anything prefixed with `-` conflicts with the [Sass mixin configuration functionality](https://sass-lang.com/documentation/at-rules/use#with-mixins), which prevents them from being exported.