### PR TITLE
Use our <Select> for Loadout Compare sheet

### DIFF
--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -186,6 +186,16 @@ export default function CompareDrawer({
 
   const header = <div className={styles.header}>{t('LoadoutBuilder.CompareLoadout')}</div>;
 
+  const loadoutOptions = useMemo(
+    () =>
+      useableLoadouts.map((l) => ({
+        key: l.id,
+        value: l,
+        content: l.name,
+      })),
+    [useableLoadouts]
+  );
+
   // This is likely never to happen but since it is disconnected to the button its here for safety.
   if (!selectedLoadout || !generatedLoadout) {
     return (
@@ -226,11 +236,7 @@ export default function CompareDrawer({
               <Select<Loadout>
                 key="select-loadout"
                 value={selectedLoadout}
-                options={useableLoadouts.map((l) => ({
-                  key: l.id,
-                  value: l,
-                  content: l.name,
-                }))}
+                options={loadoutOptions}
                 onChange={(l) => setSelectedLoadout(l)}
               />,
             ]}

--- a/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareDrawer.tsx
@@ -1,5 +1,6 @@
 import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import Select from 'app/dim-ui/Select';
 import Sheet from 'app/dim-ui/Sheet';
 import { t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
@@ -222,20 +223,16 @@ export default function CompareDrawer({
             store={selectedStore}
             hideOptimizeArmor={true}
             actionButtons={[
-              <select
+              <Select<Loadout>
                 key="select-loadout"
-                value={selectedLoadout.id}
-                onChange={(event) => {
-                  const selected = useableLoadouts.find((l) => l.id === event.target.value);
-                  setSelectedLoadout(selected);
-                }}
-              >
-                {useableLoadouts.map((l) => (
-                  <option key={l.id} value={l.id}>
-                    {l.name}
-                  </option>
-                ))}
-              </select>,
+                value={selectedLoadout}
+                options={useableLoadouts.map((l) => ({
+                  key: l.id,
+                  value: l,
+                  content: l.name,
+                }))}
+                onChange={(l) => setSelectedLoadout(l)}
+              />,
             ]}
           />
         </div>


### PR DESCRIPTION
Firefox doesn't render web fonts in `<option>` https://bugzilla.mozilla.org/show_bug.cgi?id=1536148#c19, and the linked issue says other browsers on macOS also don't.

Before (Firefox):

![grafik](https://user-images.githubusercontent.com/14299449/211262567-06bebc04-d50a-4f89-9e2a-e6d285769d4d.png)

After:

![grafik](https://user-images.githubusercontent.com/14299449/211262642-815a5b68-fdf4-4d0b-a6a0-6e88f071c996.png)
