### PR TITLE
Stop embedding stat definition into primaryStat

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -427,7 +427,7 @@ function getAllStats(comparisonItems: DimItem[], compareBaseStats: boolean): Sta
     stats.push(
       makeFakeStat(
         firstComparison.primaryStat.statHash,
-        firstComparison.primaryStat.stat.displayProperties,
+        firstComparison.primaryStatDisplayProperties!,
         (item: DimItem) => item.primaryStat || undefined
       )
     );

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -20,7 +20,6 @@ import {
   DestinyRecordComponent,
   DestinySocketCategoryDefinition,
   DestinyStat,
-  DestinyStatDefinition,
 } from 'bungie-api-ts/destiny2';
 import { InventoryBucket } from './inventory-buckets';
 
@@ -176,12 +175,11 @@ export interface DimItem {
   /**
    * The primary stat (Attack, Defense, Speed) of the item. Useful for display and for some weirder stat types. Prefer using "power" if what you want is power.
    */
-  primaryStat:
-    | (DestinyStat & {
-        // TODO: get rid of this
-        stat: DestinyStatDefinition;
-      })
-    | null;
+  primaryStat: DestinyStat | null;
+  /**
+   * Display info for the primary stat (Attack, Defense, Speed, etc).
+   */
+  primaryStatDisplayProperties?: DestinyDisplayPropertiesDefinition;
   /** The power level of the item. This is a synonym for (primaryStat?.value ?? 0) for items with power, and 0 otherwise. */
   power: number;
   /** Is this a masterwork? (D2 only) */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -19,7 +19,6 @@ import {
   DestinyClass,
   DestinyDamageTypeDefinition,
   DestinyDisplayPropertiesDefinition,
-  DestinyStatCategory,
   ItemBindStatus,
   ItemLocation,
   ItemState,
@@ -370,20 +369,13 @@ function makeItem(
 
   if (item.primaryStat) {
     const statDef = defs.Stat.get(item.primaryStat.statHash);
-    createdItem.primaryStat = {
-      ...item.primaryStat,
-      stat: {
-        ...statDef,
-        statCategory: DestinyStatCategory.Primary,
-        // D2 is much better about display info
-        displayProperties: {
-          name: statDef.statName,
-          description: statDef.statDescription,
-          icon: statDef.icon,
-          hasIcon: Boolean(statDef.icon),
-        } as DestinyDisplayPropertiesDefinition,
-      },
-    };
+    createdItem.primaryStat = item.primaryStat;
+    createdItem.primaryStatDisplayProperties = {
+      name: statDef.statName,
+      description: statDef.statDescription,
+      icon: statDef.icon,
+      hasIcon: Boolean(statDef.icon),
+    } as DestinyDisplayPropertiesDefinition;
 
     if (lightStats.includes(createdItem.primaryStat.statHash)) {
       createdItem.power = createdItem.primaryStat.value;

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -346,11 +346,7 @@ export function makeItem(
     itemType !== 'Class' &&
     !itemDef.stats?.disablePrimaryStatDisplay
   ) {
-    primaryStat = {
-      ...itemInstanceData.primaryStat,
-      stat: defs.Stat.get(itemInstanceData.primaryStat.statHash),
-      value: itemInstanceData.primaryStat.value,
-    };
+    primaryStat = itemInstanceData.primaryStat;
   }
 
   if (
@@ -365,7 +361,6 @@ export function makeItem(
         D2Categories.Armor.includes(item.bucketHash)))
   ) {
     primaryStat = {
-      stat: defs.Stat.get(StatHashes.Power),
       statHash: StatHashes.Power,
       value: (itemInstanceData.itemLevel ?? 0) * 10 + (itemInstanceData.quality ?? 0),
     };
@@ -563,8 +558,9 @@ export function makeItem(
   );
 
   if (createdItem.primaryStat) {
-    const statDef = defs.Stat.get(createdItem.primaryStat.statHash);
-    createdItem.primaryStat.stat = statDef;
+    createdItem.primaryStatDisplayProperties = defs.Stat.get(
+      createdItem.primaryStat.statHash
+    ).displayProperties;
   }
 
   if (extendedICH[createdItem.hash]) {


### PR DESCRIPTION
This was always clunky, and moving these to a separate property avoids an extra allocation.