### PR TITLE
Avoid repeated translation of custom/total stat name

### DIFF
--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -72,13 +72,14 @@ export function makeCharacter(
 }
 
 export function makeVault(): DimStore {
+  const vaultName = t('Bucket.Vault');
   return {
     destinyVersion: 2,
     id: 'vault',
-    name: t('Bucket.Vault'),
+    name: vaultName,
     classType: DestinyClass.Unknown,
     current: false,
-    className: t('Bucket.Vault'),
+    className: vaultName,
     genderName: '',
     lastPlayed: new Date(-1),
     icon: vaultIcon,
@@ -112,7 +113,7 @@ export function getCharacterStatsData(
   // TODO: Fill in effect and countdown for D2 stats
 
   // Fill in missing stats
-  statAllowList.forEach((statHash) => {
+  for (const statHash of statAllowList) {
     const def = defs.Stat.get(statHash);
     const value = stats[statHash] || 0;
     const stat: DimCharacterStat = {
@@ -123,7 +124,7 @@ export function getCharacterStatsData(
       icon: bungieNetPath(def.displayProperties.icon),
     };
     ret[statHash] = stat;
-  });
+  }
 
   return ret;
 }

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -475,9 +475,21 @@ function attachPlugStats(
   socket.plugOptions = plugOptionsWithStats;
 }
 
+// Only compute this once, to avoid repeated translation lookups
+const totalStatTemplate = _.once(() => ({
+  statHash: TOTAL_STAT_HASH,
+  displayProperties: {
+    name: t('Stats.Total'),
+  } as DestinyDisplayPropertiesDefinition,
+  sort: statAllowList.indexOf(TOTAL_STAT_HASH),
+  maximumValue: 1000,
+  bar: false,
+  smallerIsBetter: false,
+  additive: false,
+  isConditionallyActive: false,
+}));
+
 function totalStat(stats: DimStat[]): DimStat {
-  // TODO: base only
-  // TODO: search terms?
   let total = 0;
   let baseTotal = 0;
 
@@ -487,21 +499,26 @@ function totalStat(stats: DimStat[]): DimStat {
   }
 
   return {
+    ...totalStatTemplate(),
     investmentValue: total,
-    statHash: TOTAL_STAT_HASH,
-    displayProperties: {
-      name: t('Stats.Total'),
-    } as DestinyDisplayPropertiesDefinition,
-    sort: statAllowList.indexOf(TOTAL_STAT_HASH),
     value: total,
     base: baseTotal,
-    maximumValue: 1000,
-    bar: false,
-    smallerIsBetter: false,
-    additive: false,
-    isConditionallyActive: false,
   };
 }
+
+const customStatTemplate = _.once(() => ({
+  statHash: CUSTOM_TOTAL_STAT_HASH,
+  displayProperties: {
+    name: t('Stats.Custom'),
+    description: t('Stats.CustomDesc'),
+  } as DestinyDisplayPropertiesDefinition,
+  sort: statAllowList.indexOf(CUSTOM_TOTAL_STAT_HASH),
+  maximumValue: 100,
+  bar: false,
+  smallerIsBetter: false,
+  additive: false,
+  isConditionallyActive: false,
+}));
 
 function customStat(stats: DimStat[], destinyClass: DestinyClass): DimStat | undefined {
   const customStatDef = settingsSelector(reduxStore.getState()).customTotalStatsByClass[
@@ -522,20 +539,10 @@ function customStat(stats: DimStat[], destinyClass: DestinyClass): DimStat | und
   }
 
   return {
+    ...customStatTemplate(),
     investmentValue: total,
-    statHash: CUSTOM_TOTAL_STAT_HASH,
-    displayProperties: {
-      name: t('Stats.Custom'),
-      description: t('Stats.CustomDesc'),
-    } as DestinyDisplayPropertiesDefinition,
-    sort: statAllowList.indexOf(CUSTOM_TOTAL_STAT_HASH),
     value: total,
     base: total,
-    maximumValue: 100,
-    bar: false,
-    smallerIsBetter: false,
-    additive: false,
-    isConditionallyActive: false,
   };
 }
 


### PR DESCRIPTION
This shows up in profiles - apparently repeatedly getting the same translation still allocates a lot and can trigger GC. Not sure why it isn't cached...