### PR TITLE
make "classified items" power level warning pickier

### DIFF
--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -4,7 +4,7 @@ import ClassIcon from 'app/dim-ui/ClassIcon';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { startFarming } from 'app/farming/actions';
 import { t } from 'app/i18next-t';
-import { allItemsSelector, bucketsSelector, hasClassifiedSelector } from 'app/inventory/selectors';
+import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import {
   gatherEngramsLoadout,
@@ -70,7 +70,6 @@ export default function LoadoutPopup({
   const query = useSelector(querySelector);
   const searchFilter = useSelector(searchFilterSelector);
   const buckets = useSelector(bucketsSelector)!;
-  const hasClassified = useSelector(hasClassifiedSelector);
   const allItems = useSelector(allItemsSelector);
   const filteredItems = useSelector(filteredItemsSelector);
   const loadoutSort = useSelector(settingSelector('loadoutSort'));
@@ -277,7 +276,7 @@ export default function LoadoutPopup({
               <MaxlightButton
                 allItems={allItems}
                 dimStore={dimStore}
-                hasClassified={hasClassified}
+                hasClassified={Boolean(dimStore.stats.maxGearPower?.statProblems?.hasClassified)}
               />
             </li>
 

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -1,4 +1,5 @@
 import { DestinyEnergyType, TierType } from 'bungie-api-ts/destiny2';
+import { D2CalculatedSeason, D2SeasonInfo } from 'data/d2/d2-season-info';
 import {
   BreakerTypeHashes,
   BucketHashes,
@@ -16,6 +17,14 @@ export const d2MissingIcon = '/img/misc/missing_icon_d2.png';
 //
 // GAME MECHANICS KNOWN VALUES
 //
+
+// shortcuts for power numbers
+export const powerLevelByKeyword = {
+  powerfloor: D2SeasonInfo[D2CalculatedSeason].powerFloor,
+  softcap: D2SeasonInfo[D2CalculatedSeason].softCap,
+  powerfulcap: D2SeasonInfo[D2CalculatedSeason].powerfulCap,
+  pinnaclecap: D2SeasonInfo[D2CalculatedSeason].pinnacleCap,
+};
 
 export const MAX_ARMOR_ENERGY_CAPACITY = 10;
 

--- a/src/app/search/search-filters/range-overload.tsx
+++ b/src/app/search/search-filters/range-overload.tsx
@@ -1,9 +1,13 @@
 import { tl } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { getSeason } from 'app/inventory/store/season';
-import { D2CalculatedSeason, D2SeasonInfo } from 'data/d2/d2-season-info';
+import { D2CalculatedSeason } from 'data/d2/d2-season-info';
 import seasonTags from 'data/d2/season-tags.json';
-import { energyCapacityTypeNames, energyNamesByEnum } from '../d2-known-values';
+import {
+  energyCapacityTypeNames,
+  energyNamesByEnum,
+  powerLevelByKeyword,
+} from '../d2-known-values';
 import { FilterDefinition } from '../filter-types';
 import { allStatNames, statHashByName } from '../search-filter-values';
 
@@ -11,14 +15,6 @@ const seasonTagToNumber = {
   ...seasonTags,
   next: D2CalculatedSeason + 1,
   current: D2CalculatedSeason,
-};
-
-// shortcuts for power numbers
-const powerLevelByKeyword = {
-  powerfloor: D2SeasonInfo[D2CalculatedSeason].powerFloor,
-  softcap: D2SeasonInfo[D2CalculatedSeason].softCap,
-  powerfulcap: D2SeasonInfo[D2CalculatedSeason].powerfulCap,
-  pinnaclecap: D2SeasonInfo[D2CalculatedSeason].pinnacleCap,
 };
 
 // overloadedRangeFilters: stuff that may test a range, but also accepts a word


### PR DESCRIPTION
tired of having 1590 characters and yet getting the asterisk next to power level because of revision zero.
also, we have improved DIM's information/assumptions about classified items, since this warning was implemented.

therefore: this makes more advanced choices about whether to show the warning. also, it consolidates to just the boolean in the store's stats information. no need for a selector using the same conditions.