### PR TITLE
Fix Elemental Well mod grouping in the ModPicker

### DIFF
--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -120,20 +120,18 @@ export function getItemEnergyType(
   }
 }
 
+function getItemTypeOrTierDisplayName(plugDef: PluggableInventoryItemDefinition): string {
+  // XXX: Class Item Artifact Mods are labeled "Class Item Mod" instead of "Class Item Armor Mod"
+  if (plugDef.itemTypeDisplayName === 'Class Item Mod') {
+    return 'Class Item Armor Mod';
+  } else {
+    return plugDef.itemTypeDisplayName || plugDef.itemTypeAndTierDisplayName;
+  }
+}
+
 /**
  * group a whole variety of mod definitions into related mod-type groups
  */
 export function groupModsByModType(plugs: PluggableInventoryItemDefinition[]) {
-  // allow a plug category hash to be "locked" to
-  // the first itemTypeDisplayName that shows up using it.
-  // this prevents "Class Item Mod" and "Class Item Armor Mod"
-  // from forming two different categories
-  const nameByPCH: NodeJS.Dict<string> = {};
-
-  return _.groupBy(
-    plugs,
-    (plugDef) =>
-      (nameByPCH[plugDef.plug.plugCategoryHash] ??=
-        plugDef.itemTypeDisplayName || plugDef.itemTypeAndTierDisplayName)
-  );
+  return _.groupBy(plugs, getItemTypeOrTierDisplayName);
 }

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -9,6 +9,7 @@ import {
   DestinyInventoryItemDefinition,
   TierType,
 } from 'bungie-api-ts/destiny2';
+import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { isArmorEnergyLocked } from './armor-upgrade-utils';
 import { knownModPlugCategoryHashes } from './known-values';
@@ -124,15 +125,17 @@ export function getItemEnergyType(
   }
 }
 
-const classItemHash = 912441879;
 function isClassItemOfTier(plugDef: PluggableInventoryItemDefinition, tier: TierType): boolean {
-  return plugDef.plug.plugCategoryHash === classItemHash && plugDef.inventory?.tierType === tier;
+  return (
+    plugDef.plug.plugCategoryHash === PlugCategoryHashes.EnhancementsV2ClassItem &&
+    plugDef.inventory?.tierType === tier
+  );
 }
 
 // XXX: Class Item Artifact Mods are labeled "Class Item Mod" instead of "Class Item Armor Mod"
 function getItemTypeOrTierDisplayName(newDisplayName?: string) {
-  return function (plugDef: PluggableInventoryItemDefinition): string {
-    if (newDisplayName && isClassItemOfTier(plugDef, 5)) {
+  return (plugDef: PluggableInventoryItemDefinition): string => {
+    if (newDisplayName && isClassItemOfTier(plugDef, TierType.Superior)) {
       return newDisplayName;
     } else {
       return plugDef.itemTypeDisplayName;
@@ -146,6 +149,6 @@ function getItemTypeOrTierDisplayName(newDisplayName?: string) {
  * e.g. "General Armor Mod", "Helmet Armor Mod", "Nightmare Mod"
  */
 export function groupModsByModType(plugs: PluggableInventoryItemDefinition[]) {
-  const commonClassItemMod = plugs.find((plugDef) => isClassItemOfTier(plugDef, 2));
+  const commonClassItemMod = plugs.find((plugDef) => isClassItemOfTier(plugDef, TierType.Basic));
   return _.groupBy(plugs, getItemTypeOrTierDisplayName(commonClassItemMod?.itemTypeDisplayName));
 }


### PR DESCRIPTION
I had a fun trip through the DIM codebase/Bungie API today and discovered the hashing function for grouping mod types was failing due to the fact Counter Charge sharing the same `plugCategoryHash` as Elemental Well mods.

The original change for using the hashing seems to focus around fixing the fact that some of Season 19's `Class Item Armor Mods` are categorized as `Class Item Mod`.

I understand it might be a little hard-coded to solve this issue, but, I hope you'd agree it's more readable than an assignment in a lambda 😊. And it actually works:

Live DIM site:
![image](https://user-images.githubusercontent.com/66404855/211946293-b95e5161-3930-48e3-a126-6edfe16facd0.png)

With my change:
![image](https://user-images.githubusercontent.com/66404855/211946551-0cba9147-921b-4e97-b9ba-055d522d6443.png)