### PR TITLE
Replace _.forIn with regular for loops

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -121,6 +121,11 @@
         "object": "_",
         "property": "uniqBy",
         "message": "Please use the uniqBy from app/utils/util instead"
+      },
+      {
+        "object": "_",
+        "property": "forIn",
+        "message": "Please use Object.values or Object.entries instead"
       }
     ],
     "no-restricted-imports": [

--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -63,11 +63,11 @@ const sortToVault = {
 };
 
 const bucketHashToSort: { [bucketHash: number]: D1BucketCategory } = {};
-_.forIn(D1Categories, (bucketHashes, category: D1BucketCategory) => {
-  bucketHashes.forEach((bucketHash) => {
-    bucketHashToSort[bucketHash] = category;
-  });
-});
+for (const [category, bucketHashes] of Object.entries(D1Categories)) {
+  for (const bucketHash of bucketHashes) {
+    bucketHashToSort[bucketHash] = category as D1BucketCategory;
+  }
+}
 
 export function getBuckets(defs: D1ManifestDefinitions) {
   const buckets: InventoryBuckets = {
@@ -88,7 +88,7 @@ export function getBuckets(defs: D1ManifestDefinitions) {
       this.byCategory[this.unknown.sort] = [this.unknown];
     },
   };
-  _.forIn(defs.InventoryBucket, (def) => {
+  for (const def of Object.values(defs.InventoryBucket)) {
     if (def.enabled) {
       const type = bucketToType[def.hash];
       const sort = bucketHashToSort[def.hash] ?? vaultTypes[def.hash];
@@ -109,16 +109,16 @@ export function getBuckets(defs: D1ManifestDefinitions) {
       }
       buckets.byHash[bucket.hash] = bucket;
     }
-  });
-  _.forIn(buckets.byHash, (bucket: InventoryBucket) => {
+  }
+  for (const bucket of Object.values(buckets.byHash)) {
     if (bucket.sort && sortToVault[bucket.sort] && sortToVault[bucket.sort] !== bucket.hash) {
       bucket.vaultBucket = buckets.byHash[sortToVault[bucket.sort]];
     }
-  });
-  _.forIn(D1Categories, (bucketHashes, category) => {
+  }
+  for (const [category, bucketHashes] of Object.entries(D1Categories)) {
     buckets.byCategory[category] = _.compact(
       bucketHashes.map((bucketHash) => buckets.byHash[bucketHash])
     );
-  });
+  }
   return buckets;
 }

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -574,7 +574,7 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
 
     if (vendors) {
       // Process vendors here
-      _.forIn(vendors, (vendor) => {
+      for (const vendor of Object.values(vendors)) {
         const vendItems = filterItems(
           vendor.allItems
             .map((i) => i.item)
@@ -601,16 +601,16 @@ class D1LoadoutBuilder extends React.Component<Props, State> {
             );
           }
         });
-      });
+      }
 
       // Remove overlapping perks in allPerks from vendorPerks
-      _.forIn(vendorPerks, (perksWithType, classType) => {
-        _.forIn(perksWithType, (perkArr, type) => {
+      for (const [classType, perksWithType] of Object.entries(vendorPerks)) {
+        for (const [type, perkArr] of Object.entries(perksWithType)) {
           vendorPerks[classType][type] = _.reject(perkArr, (perk) =>
             perks[classType][type].map((i: D1GridNode) => i.hash).includes(perk.hash)
           );
-        });
-      });
+        }
+      }
     }
 
     return getActiveBuckets<D1GridNode[]>(

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -226,9 +226,9 @@ export function getSetBucketsStep(
       const tiers = _.groupBy(Array.from(tiersSet.keys()), (tierString: string) =>
         _.sumBy(tierString.split('/'), (num) => parseInt(num, 10))
       );
-      _.forIn(tiers, (tier) => {
+      for (const tier of Object.values(tiers)) {
         tier.sort().reverse();
-      });
+      }
 
       const allSetTiers: string[] = [];
       const tierKeys = Object.keys(tiers);

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -1,5 +1,5 @@
 import { VENDORS } from 'app/search/d2-known-values';
-import { BucketCategory, DestinyInventoryBucketDefinition } from 'bungie-api-ts/destiny2';
+import { BucketCategory } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import type {
@@ -59,11 +59,11 @@ export const bucketToType: {
 } = bucketToTypeRaw;
 
 const bucketHashToSort: { [bucketHash: number]: D2BucketCategory } = {};
-_.forIn(D2Categories, (bucketHashes, category: D2BucketCategory) => {
-  bucketHashes.forEach((bucketHash) => {
-    bucketHashToSort[bucketHash] = category;
-  });
-});
+for (const [category, bucketHashes] of Object.entries(D2Categories)) {
+  for (const bucketHash of bucketHashes) {
+    bucketHashToSort[bucketHash] = category as D2BucketCategory;
+  }
+}
 
 export function getBuckets(defs: D2ManifestDefinitions) {
   const buckets: InventoryBuckets = {
@@ -84,7 +84,7 @@ export function getBuckets(defs: D2ManifestDefinitions) {
       this.byCategory[this.unknown.sort] = [this.unknown];
     },
   };
-  _.forIn(defs.InventoryBucket, (def: DestinyInventoryBucketDefinition) => {
+  for (const def of Object.values(defs.InventoryBucket)) {
     const type = bucketToType[def.hash];
     const sort = bucketHashToSort[def.hash];
     const bucket: InventoryBucket = {
@@ -103,20 +103,20 @@ export function getBuckets(defs: D2ManifestDefinitions) {
       bucket[`in${bucket.sort}`] = true;
     }
     buckets.byHash[bucket.hash] = bucket;
-  });
-  const vaultMappings = {};
+  }
+  const vaultMappings: { [bucketHash: number]: number } = {};
   defs.Vendor.get(VENDORS.VAULT).acceptedItems.forEach((items) => {
     vaultMappings[items.acceptedInventoryBucketHash] = items.destinationInventoryBucketHash;
   });
-  _.forIn(buckets.byHash, (bucket: InventoryBucket) => {
+  for (const bucket of Object.values(buckets.byHash)) {
     if (vaultMappings[bucket.hash]) {
       bucket.vaultBucket = buckets.byHash[vaultMappings[bucket.hash]];
     }
-  });
-  _.forIn(D2Categories, (bucketHashes, category) => {
+  }
+  for (const [category, bucketHashes] of Object.entries(D2Categories)) {
     buckets.byCategory[category] = _.compact(
       bucketHashes.map((bucketHash) => buckets.byHash[bucketHash])
     );
-  });
+  }
   return buckets;
 }

--- a/src/app/hotkeys/hotkeys.ts
+++ b/src/app/hotkeys/hotkeys.ts
@@ -1,5 +1,4 @@
 import { t, tl } from 'app/i18next-t';
-import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 
 // A unique ID generator
@@ -81,12 +80,12 @@ class HotkeyRegistry {
 
   getAllHotkeys() {
     const combos: { [combo: string]: string } = {};
-    _.forIn(this.hotkeys, (hotkeys) => {
+    for (const hotkeys of Object.values(this.hotkeys)) {
       for (const hotkey of hotkeys) {
         const combo = format(hotkey);
         combos[combo] = hotkey.description;
       }
-    });
+    }
     return combos;
   }
 }

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -8,7 +8,6 @@ import { DestinyItemPlug } from 'bungie-api-ts/destiny2';
 import { resonantMaterialStringVarHashes } from 'data/d2/crafting-resonant-elements';
 import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import universalOrnamentPlugSetHashes from 'data/d2/universal-ornament-plugset-hashes.json';
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { getBuckets as getBucketsD1 } from '../destiny1/d1-buckets';
 import { getBuckets as getBucketsD2 } from '../destiny2/d2-buckets';
@@ -231,13 +230,13 @@ export const ownedUncollectiblePlugsSelector = createSelector(
         plugs: { [key: number]: DestinyItemPlug[] },
         insertInto: Set<number>
       ) => {
-        _.forIn(plugs, (plugSet) => {
+        for (const plugSet of Object.values(plugs)) {
           for (const plug of plugSet) {
             if (plug.enabled && !defs.InventoryItem.get(plug.plugItemHash)?.collectibleHash) {
               insertInto.add(plug.plugItemHash);
             }
           }
-        });
+        }
       };
 
       if (profileResponse.profilePlugSets?.data) {

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -301,10 +301,15 @@ export function optimalItemSet(
   // Solve for the case where our optimizer decided to equip two exotics
   const getLabel = (i: DimItem) => i.equippingLabel;
   // All items that share an equipping label, grouped by label
-  const overlaps = _.groupBy(unrestricted.filter(getLabel), getLabel);
-  _.forIn(overlaps, (overlappingItems) => {
+
+  const overlaps: { [label: string]: DimItem[] } = _.groupBy(
+    unrestricted.filter(getLabel),
+    getLabel
+  );
+
+  for (const overlappingItems of Object.values(overlaps)) {
     if (overlappingItems.length <= 1) {
-      return;
+      continue;
     }
 
     const options: { [x: string]: DimItem }[] = [];
@@ -336,7 +341,7 @@ export function optimalItemSet(
       const bestOption = _.maxBy(options, (opt) => _.sumBy(Object.values(opt), bestItemFn))!;
       items = bestOption;
     }
-  });
+  }
 
   const equippable = _.sortBy(Object.values(items), (i) => gearSlotOrder.indexOf(i.bucket.hash));
 

--- a/src/app/loadout-drawer/postmaster.ts
+++ b/src/app/loadout-drawer/postmaster.ts
@@ -48,7 +48,7 @@ export function makeRoomForPostmaster(store: DimStore, buckets: InventoryBuckets
 
     // If any category is full, we'll move enough aside
     const itemsToMove: DimItem[] = [];
-    _.forIn(postmasterItemCountsByType, (count, bucket) => {
+    for (const [bucket, count] of Object.entries(postmasterItemCountsByType)) {
       const bucketHash = parseInt(bucket, 10);
       if (count > 0 && findItemsByBucket(store, bucketHash).length > 0) {
         const items: DimItem[] = findItemsByBucket(store, bucketHash);
@@ -68,7 +68,7 @@ export function makeRoomForPostmaster(store: DimStore, buckets: InventoryBuckets
           itemsToMove.push(..._.take(candidates, numNeededToMove));
         }
       }
-    });
+    }
     try {
       await dispatch(moveItemsToVault(store, itemsToMove, cancelToken));
       showNotification({

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -50,11 +50,11 @@ const sortDupes = (
     )
   );
 
-  _.forIn(dupes, (dupes) => {
-    if (dupes.length > 1) {
-      dupes.sort(dupeComparator);
+  for (const dupeList of Object.values(dupes)) {
+    if (dupeList.length > 1) {
+      dupeList.sort(dupeComparator);
     }
-  });
+  }
 
   return dupes;
 };

--- a/src/app/shell/item-comparators.ts
+++ b/src/app/shell/item-comparators.ts
@@ -132,12 +132,7 @@ const ITEM_COMPARATORS: {
   basePower: reverseComparator(compareBy((item) => item.power)),
   // This only sorts by D1 item quality
   rating: reverseComparator(
-    compareBy((item: DimItem & { quality: { min: number } }) => {
-      if (item.quality?.min) {
-        return item.quality.min;
-      }
-      return undefined;
-    })
+    compareBy((item: DimItem & { quality: { min: number } }) => item.quality?.min)
   ),
   // Titan -> Hunter -> Warlock -> Unknown
   classType: compareBy((item) => item.classType),


### PR DESCRIPTION
Seeing _.forIn taking a fair bit of memory in profiles. Not sure switching to `Object.value` / `Object.entries` is necessarily more efficient, but one less library dependency doesn't hurt.