### PR TITLE
Unlock all standard Armor Mods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Loadout hashtags are now auto-completed in the Loadout name and notes fields. Type `#` to suggest tags used in other Loadouts.
 * Destiny symbols are now available in Loadout names and notes, and item notes. Type `:` for symbol suggestions or use the symbols picker in the text fields.
+* In accordance with all standard armor mods being unlocked in-game, DIM now also considers these mods unlocked.
 
 ## 7.51.0 <span class="changelog-date">(2023-01-08)</span>
 

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -119,7 +119,8 @@ export const materialsSelector = (state: RootState) =>
   );
 
 /** The actual raw profile response from the Bungie.net profile API */
-export const profileResponseSelector = (state: RootState) => state.inventory.profileResponse;
+export const profileResponseSelector = (state: RootState) =>
+  state.inventory.mockProfileData ?? state.inventory.profileResponse;
 
 /** Whether or not the user is currently playing Destiny 2 */
 export const userIsPlayingSelector = (state: RootState) =>

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -10,12 +10,14 @@ import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { allItemsSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { isValidMasterworkStat } from 'app/inventory/store/masterwork';
 import { isPluggableItem } from 'app/inventory/store/sockets';
+import { unlockedByAllModsBeingUnlocked } from 'app/loadout/mod-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import { collectionsVisibleShadersSelector } from 'app/records/selectors';
 import { weaponMasterworkY2SocketTypeHash } from 'app/search/d2-known-values';
 import { createPlugSearchPredicate } from 'app/search/plug-search';
 import { SearchInput } from 'app/search/SearchInput';
+import { artifactModsSelector } from 'app/strip-sockets/strip-sockets';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptySet } from 'app/utils/empty';
 import {
@@ -136,6 +138,7 @@ export default function SocketDetails({
   onPlugSelected?(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
 }) {
   const defs = useD2Definitions()!;
+  const artifactMods = useSelector(artifactModsSelector);
   const plugged = socket.plugged?.plugDef;
   const actuallyPlugged = (socket.actuallyPlugged || socket.plugged)?.plugDef;
   const [selectedPlug, setSelectedPlug] = useState<PluggableInventoryItemDefinition | null>(
@@ -202,7 +205,8 @@ export default function SocketDetails({
   const unlocked = (i: PluggableInventoryItemDefinition) =>
     i.hash === socket.emptyPlugItemHash ||
     unlockedPlugs.has(i.hash) ||
-    otherUnlockedPlugs.has(i.hash);
+    otherUnlockedPlugs.has(i.hash) ||
+    unlockedByAllModsBeingUnlocked(i, artifactMods);
 
   const searchFilter = createPlugSearchPredicate(query, language, defs);
 

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -6,13 +6,14 @@ import {
   profileResponseSelector,
 } from 'app/inventory/selectors';
 import { d2ManifestSelector } from 'app/manifest/selectors';
-import { filterDimPlugsUnlockedOnCharacterOrProfile } from 'app/records/plugset-helpers';
+import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import {
   armor2PlugCategoryHashes,
   armor2PlugCategoryHashesByName,
   MAX_ARMOR_ENERGY_CAPACITY,
 } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
+import { artifactModsSelector } from 'app/strip-sockets/strip-sockets';
 import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { modMetadataByPlugCategoryHash } from 'app/utils/item-utils';
@@ -21,7 +22,7 @@ import { uniqBy } from 'app/utils/util';
 import { DestinyClass, DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import { isLoadoutBuilderItem } from './item-utils';
@@ -30,7 +31,12 @@ import {
   knownModPlugCategoryHashes,
   slotSpecificPlugCategoryHashes,
 } from './known-values';
-import { isInsertableArmor2Mod, sortModGroups, sortMods } from './mod-utils';
+import {
+  isInsertableArmor2Mod,
+  sortModGroups,
+  sortMods,
+  unlockedByAllModsBeingUnlocked,
+} from './mod-utils';
 import PlugDrawer from './plug-drawer/PlugDrawer';
 import { PlugSet } from './plug-drawer/types';
 
@@ -73,6 +79,7 @@ function mapStateToProps() {
     profileResponseSelector,
     allItemsSelector,
     d2ManifestSelector,
+    artifactModsSelector,
     (_state: RootState, props: ProvidedProps) => props.classType,
     (_state: RootState, props: ProvidedProps) => props.owner,
     (_state: RootState, props: ProvidedProps) => props.plugCategoryHashWhitelist,
@@ -82,6 +89,7 @@ function mapStateToProps() {
       profileResponse,
       allItems,
       defs,
+      artifactMods,
       classType,
       owner,
       plugCategoryHashWhitelist,
@@ -130,11 +138,17 @@ function mapStateToProps() {
         // and the maximum number of those sockets that can appear on a single item.
         for (const [hashAsString, sockets] of Object.entries(socketsGroupedByPlugSetHash)) {
           const plugSetHash = parseInt(hashAsString, 10);
-          const dimPlugs = filterDimPlugsUnlockedOnCharacterOrProfile(
+          const unlockedPlugs = unlockedItemsForCharacterOrProfilePlugSet(
             profileResponse,
-            sockets[0].plugSet!,
+            sockets[0].plugSet!.hash,
             // TODO: For vaulted items, union all the unlocks and then be smart about picking the right store
             owner ?? currentStore!.id
+          );
+
+          const dimPlugs = sockets[0].plugSet!.plugs.filter(
+            (p) =>
+              unlockedPlugs.has(p.plugDef.hash) ||
+              unlockedByAllModsBeingUnlocked(p.plugDef, artifactMods)
           );
 
           // Filter down to plugs that match the plugCategoryHashWhitelist

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -9,12 +9,13 @@ import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
+import { artifactModsSelector } from 'app/strip-sockets/strip-sockets';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { memo, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import ModAssignmentDrawer from '../mod-assignment-drawer/ModAssignmentDrawer';
-import { createGetModRenderKey } from '../mod-utils';
+import { createGetModRenderKey, unlockedByAllModsBeingUnlocked } from '../mod-utils';
 import ModPicker from '../ModPicker';
 import styles from './LoadoutMods.m.scss';
 import PlugDef from './PlugDef';
@@ -68,6 +69,7 @@ export default memo(function LoadoutMods({
   const unlockedPlugSetItems = useSelector((state: RootState) =>
     unlockedPlugSetItemsSelector(state, storeId)
   );
+  const artifactMods = useSelector(artifactModsSelector);
 
   // Explicitly show only actual saved mods in the mods picker, not auto mods,
   // otherwise we'd duplicate auto mods into loadout parameter mods when coonfirming
@@ -102,6 +104,7 @@ export default memo(function LoadoutMods({
             className={clsx({
               [styles.missingItem]: !(
                 unlockedPlugSetItems.has(mod.hash) ||
+                unlockedByAllModsBeingUnlocked(mod, artifactMods) ||
                 mod.hash === DEFAULT_SHADER ||
                 DEFAULT_ORNAMENTS.includes(mod.hash)
               ),

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -1,7 +1,12 @@
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { ArmorEnergyRules } from 'app/loadout-builder/types';
-import { armor2PlugCategoryHashesByName, armorBuckets } from 'app/search/d2-known-values';
+import {
+  armor2PlugCategoryHashes,
+  armor2PlugCategoryHashesByName,
+  armorBuckets,
+} from 'app/search/d2-known-values';
+import { combatCompatiblePlugCategoryHashes } from 'app/search/specialty-modslots';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { isArmor2Mod } from 'app/utils/item-utils';
 import {
@@ -9,6 +14,7 @@ import {
   DestinyInventoryItemDefinition,
   TierType,
 } from 'bungie-api-ts/destiny2';
+import deprecatedMods from 'data/d2/deprecated-mods.json';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { isArmorEnergyLocked } from './armor-upgrade-utils';
@@ -151,4 +157,20 @@ function getItemTypeOrTierDisplayName(newDisplayName?: string) {
 export function groupModsByModType(plugs: PluggableInventoryItemDefinition[]) {
   const commonClassItemMod = plugs.find((plugDef) => isClassItemOfTier(plugDef, TierType.Basic));
   return _.groupBy(plugs, getItemTypeOrTierDisplayName(commonClassItemMod?.itemTypeDisplayName));
+}
+
+/**
+ * 2023-01-11: All standard Armor Mods (excluding artifact and raid) are unlocked for everyone.
+ * The API was not informed, so we must hardcode the rules here.
+ */
+export function unlockedByAllModsBeingUnlocked(
+  plug: PluggableInventoryItemDefinition,
+  artifactMods: Set<number> | undefined
+) {
+  return (
+    !deprecatedMods.includes(plug.hash) &&
+    !artifactMods?.has(plug.hash) &&
+    (armor2PlugCategoryHashes.includes(plug.plug.plugCategoryHash) ||
+      combatCompatiblePlugCategoryHashes.includes(plug.plug.plugCategoryHash))
+  );
 }

--- a/src/app/records/plugset-helpers.ts
+++ b/src/app/records/plugset-helpers.ts
@@ -1,4 +1,3 @@
-import { DimPlugSet } from 'app/inventory/item-types';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import universalOrnamentPlugSetHashes from 'data/d2/universal-ornament-plugset-hashes.json';
 
@@ -48,22 +47,6 @@ export function unlockedItemsForCharacterOrProfilePlugSet(
     }
   }
   return unlockedPlugs;
-}
-
-/**
- * Narrow down the passed in plugSet's plugs to only those that are unlocked by the given character.
- */
-export function filterDimPlugsUnlockedOnCharacterOrProfile(
-  profileResponse: DestinyProfileResponse,
-  dimPlugSet: DimPlugSet,
-  characterId: string
-) {
-  const unlockedPlugs = unlockedItemsForCharacterOrProfilePlugSet(
-    profileResponse,
-    dimPlugSet.hash,
-    characterId
-  );
-  return dimPlugSet.plugs.filter((plug) => unlockedPlugs.has(plug.plugDef.hash));
 }
 
 /**


### PR DESCRIPTION
Mods the API considers as locked/"should not be shown" are entirely missing from the profile response, so we can't just ignore the `enabled`/`canInsert` flags for some plugSets. Instead this just looks at mods' `plugCategoryHash`es based on a list of PCHs that Bungie unlocked, excluding deprecated and artifact mods. Yes this code is ugly, but we can hopefully get rid of it in six weeks anyway.

Someone who doesn't have every single mod unlocked already please test this.