### PR TITLE
include item uninstanced perks visibility information

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -422,8 +422,10 @@ function processCharacter(
   const characterEquipment = profileInfo.characterEquipment.data?.[characterId]?.items || [];
   const profileRecords = profileInfo.profileRecords?.data;
   const itemComponents = profileInfo.itemComponents;
-  const uninstancedItemObjectives =
-    getCharacterProgressions(profileInfo, characterId)?.uninstancedItemObjectives || [];
+
+  const characterProgressions = getCharacterProgressions(profileInfo, characterId);
+  const uninstancedItemObjectives = characterProgressions?.uninstancedItemObjectives;
+  const uninstancedItemPerks = characterProgressions?.uninstancedItemPerks;
 
   const store = makeCharacter(defs, character, lastPlayedDate, profileRecords);
 
@@ -447,7 +449,8 @@ function processCharacter(
     items,
     itemComponents,
     uninstancedItemObjectives,
-    profileRecords
+    profileRecords,
+    uninstancedItemPerks
   );
   store.items = processedItems;
   return store;

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -197,7 +197,7 @@ export interface DimItem {
   /** Detailed stats for the item. */
   stats: DimStat[] | null;
   /** Any objectives associated with the item. */
-  objectives: DestinyObjectiveProgress[] | null;
+  objectives?: DestinyObjectiveProgress[];
   /** Stat Tracker */
   metricHash?: number;
   /** Stat Tracker Progress */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -328,7 +328,7 @@ function makeItem(
     percentComplete: 0,
     talentGrid: null,
     stats: null,
-    objectives: null,
+    objectives: undefined,
     quality: null,
     sockets: null,
     breakerType: null,
@@ -413,7 +413,7 @@ function makeItem(
           completionValue: defs.Objective.get(o.objectiveHash).completionValue,
           visible: true,
         }))
-      : null;
+      : undefined;
 
   if (createdItem.talentGrid && createdItem.infusable && item.primaryStat) {
     try {

--- a/src/app/inventory/store/objectives.ts
+++ b/src/app/inventory/store/objectives.ts
@@ -2,8 +2,6 @@ import { D1ObjectiveDefinition } from 'app/destiny1/d1-manifest-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import {
   DestinyInventoryItemDefinition,
-  DestinyItemComponent,
-  DestinyItemObjectivesComponent,
   DestinyObjectiveDefinition,
   DestinyObjectiveProgress,
   DestinyUnlockValueUIStyle,
@@ -20,23 +18,15 @@ import trialsHashes from 'data/d2/d2-trials-objectives.json';
  * Build regular item-level objectives.
  */
 export function buildObjectives(
-  item: DestinyItemComponent,
   itemDef: DestinyInventoryItemDefinition,
-  objectivesMap: { [key: string]: DestinyItemObjectivesComponent } | undefined,
   defs: D2ManifestDefinitions,
-  uninstancedItemObjectives?: {
-    [key: number]: DestinyObjectiveProgress[];
-  }
-): DestinyObjectiveProgress[] | null {
-  const objectives =
-    item.itemInstanceId && objectivesMap?.[item.itemInstanceId]
-      ? objectivesMap[item.itemInstanceId].objectives
-      : uninstancedItemObjectives
-      ? uninstancedItemObjectives[item.itemHash]
-      : [];
+  itemInstancedObjectives: DestinyObjectiveProgress[] | undefined,
+  itemUninstancedObjectives: DestinyObjectiveProgress[] | undefined
+): DestinyObjectiveProgress[] | undefined {
+  const objectives = itemInstancedObjectives ?? itemUninstancedObjectives ?? [];
 
   if (!objectives?.length) {
-    // Hmm, it should have objectives
+    // fill in objectives from its definition. not sure why if there's no available progression data? what case does this catch?
     if (itemDef.objectives) {
       return itemDef.objectives.objectiveHashes.map((o) => ({
         objectiveHash: o,
@@ -46,7 +36,7 @@ export function buildObjectives(
       }));
     }
 
-    return null;
+    return;
   }
 
   // TODO: we could make a tooltip with the location + activities for each objective (and maybe offer a ghost?)
@@ -88,7 +78,7 @@ export function isTrialsPassage(itemHash: number) {
 /**
  * Checks if the trials passage is flawless
  */
-export function isFlawlessPassage(objectives: DestinyObjectiveProgress[] | null) {
+export function isFlawlessPassage(objectives: DestinyObjectiveProgress[] | undefined) {
   return objectives?.some((obj) => isFlawlessObjective(obj.objectiveHash) && obj.complete);
 }
 

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -271,7 +271,7 @@ function makeFakePursuitItem(
     percentComplete: 0, // filled in later
     hidePercentage: false,
     stats: null, // filled in later
-    objectives: null, // filled in later
+    objectives: undefined, // filled in later
     ammoType: DestinyAmmunitionType.None,
     missingSockets: false,
     breakerType: null,


### PR DESCRIPTION
this causes trials mercy card to correctly show its mercy status, instead of both possible mercy statuses