### PR TITLE
Add Launch Handler config for DIM webapp

### DIFF
--- a/build/purge-cloudflare.sh
+++ b/build/purge-cloudflare.sh
@@ -9,4 +9,4 @@ curl -X POST "https://api.cloudflare.com/client/v4/zones/2c34c69276ed0f6eb2b9e15
     -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
     -H "X-Auth-Key: $CLOUDFLARE_KEY" \
     -H "Content-Type: application/json" \
-    --data '{"files":["https://'"$APP_DOMAIN"'", "https://'"$APP_DOMAIN"'/index.html", "https://'"$APP_DOMAIN"'/version.json", "https://'"$APP_DOMAIN"'/service-worker.js", "https://'"$APP_DOMAIN"'/return.html", "https://'"$APP_DOMAIN"'/.well-known/assetlinks.json", "https://'"$APP_DOMAIN"'/.well-known/apple-app-site-association", "https://'"$APP_DOMAIN"'/manifest-webapp-6-2018.json", "https://'"$APP_DOMAIN"'/manifest-webapp-6-2018-ios.json"]}'
+    --data '{"files":["https://'"$APP_DOMAIN"'", "https://'"$APP_DOMAIN"'/index.html", "https://'"$APP_DOMAIN"'/version.json", "https://'"$APP_DOMAIN"'/service-worker.js", "https://'"$APP_DOMAIN"'/return.html", "https://'"$APP_DOMAIN"'/.well-known/assetlinks.json", "https://'"$APP_DOMAIN"'/.well-known/apple-app-site-association", "https://'"$APP_DOMAIN"'/manifest-webapp.json"]}'

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -380,7 +380,7 @@ module.exports = (env) => {
 
       new CopyWebpackPlugin({
         patterns: [
-          { from: './src/manifest-webapp-6-2018.json' },
+          { from: './src/manifest-webapp.json' },
           // Only copy the manifests out of the data folder. Everything else we import directly into the bundle.
           { from: './src/data/d1/manifests', to: 'data/d1/manifests' },
           { from: `./icons/${env.name}/` },

--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-6-2018.png" />
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
-    <link rel="manifest" href="/manifest-webapp-6-2018.json" />
+    <link rel="manifest" href="/manifest-webapp.json" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#434444" />
     <meta name="theme-color" content="black" />
     <meta name="color-scheme" content="dark" />

--- a/src/manifest-webapp.json
+++ b/src/manifest-webapp.json
@@ -39,5 +39,8 @@
   "background_color": "black",
   "display": "standalone",
   "categories": ["games", "entertainment", "productivity", "utilities"],
-  "start_url": "/index.html?utm_source=homescreen"
+  "start_url": "/index.html?utm_source=homescreen",
+  "launch_handler": {
+    "client_mode": ["navigate-existing"]
+  }
 }


### PR DESCRIPTION
https://developer.chrome.com/docs/web-platform/launch-handler/

This should, in Chrome 110, change the behavior of clicking on a DIM link from opening a new window to navigating the existing app window.

This does *not* allow us to directly open dim.gg links - that requires the [scope_extensions](https://chromestatus.com/feature/5746537956114432) property which is still only in discussion. So with this, you'll still open the dim.gg share page, then click either "Open in DIM" or "Open in DIM Beta", but it will open in your existing tab/window instead of in a new tab.