### PR TITLE
Mark curated/collection/`singleInitialItemHash` perks as unavailable

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -850,7 +850,7 @@
     "All": "All",
     "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "CannotCurrentlyRoll": "This perk cannot be rolled on the current version of this item.",
-    "UnreliablePerkOption": "This perk appears only in the collections view, it might not actually roll on this item.",
+    "UnreliablePerkOption": "This perk appears only in the collections view. It might not roll randomly on this item.",
     "Consolidate": "Consolidate",
     "CommunityData": "Community Insight",
     "CraftingPattern": "Crafting Pattern",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -850,6 +850,7 @@
     "All": "All",
     "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
     "CannotCurrentlyRoll": "This perk cannot be rolled on the current version of this item.",
+    "UnreliablePerkOption": "This perk appears only in the collections view, it might not actually roll on this item.",
     "Consolidate": "Consolidate",
     "CommunityData": "Community Insight",
     "CraftingPattern": "Crafting Pattern",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* On the Records and Armory pages, perks only shown on the collections/"curated" roll will now correctly be marked as unavailable on randomly rolled versions.
+
 ## 7.52.0 <span class="changelog-date">(2023-01-15)</span>
 
 * Loadout hashtags are now auto-completed in the Loadout name and notes fields. Type `#` to suggest tags used in other Loadouts.

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -407,6 +407,8 @@ export interface DimPlug {
   } | null;
   /** This plug is one of the random roll options but the current version of this item cannot roll this perk. */
   readonly cannotCurrentlyRoll?: boolean;
+  /** This plug is one of the collections perks and may not 100% roll */
+  readonly unreliablePerkOption?: boolean;
 }
 
 export interface DimPlugSet {

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -292,7 +292,10 @@ function buildDefinedSocket(
   ) {
     const built = buildCachedDefinedPlug(defs, socketDef.singleInitialItemHash);
     if (built) {
-      reusablePlugs.unshift(built);
+      reusablePlugs.push({
+        ...built,
+        unreliablePerkOption: reusablePlugs.length > 0,
+      });
     }
   }
 

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -25,6 +25,7 @@ export default function Plug({
   plugged,
   selected,
   cannotRoll,
+  unreliablePerkOption,
   notSelected,
 }: {
   plug: DimPlug;
@@ -71,6 +72,7 @@ export default function Plug({
           plugged={plugged}
           selected={selected}
           cannotRoll={cannotRoll}
+          unreliablePerkOption={unreliablePerkOption}
           notSelected={notSelected}
         />
       ) : (
@@ -107,6 +109,7 @@ export function PerkCircleWithTooltip({
   plugged,
   selected,
   cannotRoll,
+  unreliablePerkOption,
   notSelected,
 }: {
   item: DimItem;
@@ -120,6 +123,7 @@ export function PerkCircleWithTooltip({
   // This has been selected by the user but isn't the original plugged item
   selected ??= socketInfo.actuallyPlugged && plugged;
   cannotRoll ??= plug.cannotCurrentlyRoll;
+  unreliablePerkOption ??= plug.unreliablePerkOption;
 
   const tooltip = () => (
     <DimPlugTooltip
@@ -141,6 +145,7 @@ export function PerkCircleWithTooltip({
           notSelected={notSelected}
           selected={selected}
           cannotRoll={cannotRoll}
+          unreliablePerkOption={unreliablePerkOption}
         />
       </PressTip>
       {isRecommendedPerk && (
@@ -155,6 +160,7 @@ interface PlugStatuses {
   selected?: boolean;
   cannotRoll?: boolean;
   notSelected?: boolean;
+  unreliablePerkOption?: boolean;
 }
 
 /**
@@ -169,6 +175,7 @@ function PerkCircle({
   selected,
   cannotRoll,
   notSelected,
+  unreliablePerkOption,
 }: {
   plug: DimPlug;
   className?: string;
@@ -178,7 +185,7 @@ function PerkCircle({
     clsx({
       [styles.plugged]: plugged,
       [styles.selected]: selected,
-      [styles.cannotRoll]: cannotRoll,
+      [styles.cannotRoll]: cannotRoll || unreliablePerkOption,
       [styles.notSelected]: notSelected,
     }) || styles.none;
   return (

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -94,6 +94,7 @@ export function DimPlugTooltip({
       plugObjectives={plug.plugObjectives}
       enableFailReasons={plug.enableFailReasons}
       cannotCurrentlyRoll={plug.cannotCurrentlyRoll}
+      unreliablePerkOption={plug.unreliablePerkOption}
       wishListTip={wishListTip}
       hideRequirements={hideRequirements}
       craftingData={craftingData}
@@ -116,6 +117,7 @@ export function PlugTooltip({
   plugObjectives,
   enableFailReasons,
   cannotCurrentlyRoll,
+  unreliablePerkOption,
   wishListTip,
   hideRequirements,
   craftingData,
@@ -125,6 +127,7 @@ export function PlugTooltip({
   plugObjectives?: DestinyObjectiveProgress[];
   enableFailReasons?: string;
   cannotCurrentlyRoll?: boolean;
+  unreliablePerkOption?: boolean;
   wishListTip?: string;
   hideRequirements?: boolean;
   craftingData?: DestinyPlugItemCraftingRequirements;
@@ -278,6 +281,11 @@ export function PlugTooltip({
       {cannotCurrentlyRoll && (
         <Tooltip.Section className={styles.cannotRollSection}>
           <p>{t('MovePopup.CannotCurrentlyRoll')}</p>
+        </Tooltip.Section>
+      )}
+      {unreliablePerkOption && (
+        <Tooltip.Section className={styles.cannotRollSection}>
+          <p>{t('MovePopup.UnreliablePerkOption')}</p>
         </Tooltip.Section>
       )}
       {wishListTip && (

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -808,7 +808,7 @@
       "Untracked": "Untracked"
     },
     "TriageTab": "Triage",
-    "UnreliablePerkOption": "This perk appears only in the collections view, it might not actually roll on this item.",
+    "UnreliablePerkOption": "This perk appears only in the collections view. It might not roll randomly on this item.",
     "Vault": "Vault",
     "WeaponLevel": "Weapon Level {{level}}"
   },

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -808,6 +808,7 @@
       "Untracked": "Untracked"
     },
     "TriageTab": "Triage",
+    "UnreliablePerkOption": "This perk appears only in the collections view, it might not actually roll on this item.",
     "Vault": "Vault",
     "WeaponLevel": "Weapon Level {{level}}"
   },


### PR DESCRIPTION
`singleInitialItemHash` is very unreliable and should not be presented as a regular perk option.

For past curated weapons (fully masterworked drops of otherwise random-perks weapons with special preset perks) this `singleInitialItemHash` did in fact reference the curated perks so there was value in showing them, but curated weapons are a thing of the past now; only Last Wish (and maybe Altars of Sorrow?) still drop them. DIM totally lies about them and marks them as regularly available perks for every single weapon with a weird collections roll.

This puts a disclaimer on perks DIM obtains this way:

![grafik](https://user-images.githubusercontent.com/14299449/212770913-6afd082f-4ed6-48ad-9a72-0f123280c471.png)

We even have a Blinding Nades Wendigo in Voltron and the wish list notes recommend Blinding, which is a bit embarassing but probably happened due to DIM being unreliable here.