### PR TITLE
Add method-signature-style lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -234,6 +234,7 @@
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/method-signature-style": "error",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/src/app/accounts/MenuAccounts.tsx
+++ b/src/app/accounts/MenuAccounts.tsx
@@ -18,7 +18,7 @@ import { accountsSelector, currentAccountSelector } from './selectors';
 export default function MenuAccounts({
   closeDropdown,
 }: {
-  closeDropdown(e: React.MouseEvent<HTMLElement>): void;
+  closeDropdown: (e: React.MouseEvent<HTMLElement>) => void;
 }) {
   const dispatch = useThunkDispatch();
   const currentAccount = useSelector(currentAccountSelector);

--- a/src/app/armory/ArmorySheet.tsx
+++ b/src/app/armory/ArmorySheet.tsx
@@ -9,7 +9,7 @@ import { useMemo } from 'react';
 import Armory from './Armory';
 import styles from './ArmorySheet.m.scss';
 
-export default function ArmorySheet({ item, onClose }: { item: DimItem; onClose(): void }) {
+export default function ArmorySheet({ item, onClose }: { item: DimItem; onClose: () => void }) {
   const defs = useD2Definitions()!;
   const realItemSockets = useMemo(
     () =>

--- a/src/app/armory/ItemGrid.tsx
+++ b/src/app/armory/ItemGrid.tsx
@@ -82,11 +82,11 @@ function BasicItemTrigger({
   children,
 }: {
   item: DimItem;
-  onShowPopup(state: PopupState): void;
-  children(
+  onShowPopup: (state: PopupState) => void;
+  children: (
     ref: React.Ref<HTMLDivElement>,
     showPopup: (e: React.MouseEvent) => void
-  ): React.ReactNode;
+  ) => React.ReactNode;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 

--- a/src/app/bungie-api/rate-limiter.ts
+++ b/src/app/bungie-api/rate-limiter.ts
@@ -13,8 +13,8 @@ export class RateLimiterQueue {
     fetcher: typeof fetch;
     request: RequestInfo | URL;
     options?: RequestInit;
-    resolver(value?: any): void;
-    rejecter(value?: any): void;
+    resolver: (value?: any) => void;
+    rejecter: (value?: any) => void;
   }[] = [];
   /** number of requests in the current period */
   count = 0;

--- a/src/app/character-tile/CharacterTileButton.tsx
+++ b/src/app/character-tile/CharacterTileButton.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { DimStore } from '../inventory/store-types';
 import CharacterTile from './CharacterTile';
 import './StoreHeading.scss';
@@ -10,7 +9,7 @@ export default function CharacterTileButton({
   onClick,
 }: {
   character: DimStore;
-  onClick?(id: string): void;
+  onClick?: (id: string) => void;
 }) {
   const handleClick = () => onClick?.(character.id);
 

--- a/src/app/character-tile/StoreHeading.tsx
+++ b/src/app/character-tile/StoreHeading.tsx
@@ -18,7 +18,7 @@ interface Props {
   /** For mobile, this is whichever store is visible at the time. */
   selectedStore?: DimStore;
   /** Fires if a store other than the selected store is tapped. */
-  onTapped?(storeId: string): void;
+  onTapped?: (storeId: string) => void;
 }
 
 // Wrap the {CharacterTile} with a button for the loadout menu and the D1 XP progress bar

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -37,10 +37,10 @@ export default memo(function CompareItem({
   item: DimItem;
   stats: StatInfo[];
   compareBaseStats?: boolean;
-  itemClick(item: DimItem): void;
-  remove(item: DimItem): void;
-  setHighlight?(value?: string | number): void;
-  onPlugClicked(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
+  itemClick: (item: DimItem) => void;
+  remove: (item: DimItem) => void;
+  setHighlight?: (value?: string | number) => void;
+  onPlugClicked: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
   isInitialItem: boolean;
 }) {
   const headerRef = useRef<HTMLDivElement>(null);

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -4,7 +4,6 @@ import { t } from 'app/i18next-t';
 import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
 import { getColor, percent } from 'app/shell/formatters';
 import { StatHashes } from 'data/d2/generated-enums';
-import React from 'react';
 import { D1Stat, DimItem } from '../inventory/item-types';
 import { MinimalStat, StatInfo } from './Compare';
 import styles from './CompareStat.m.scss';
@@ -18,7 +17,7 @@ export default function CompareStat({
   stat: StatInfo;
   compareBaseStats?: boolean;
   item: DimItem;
-  setHighlight?(value?: string | number): void;
+  setHighlight?: (value?: string | number) => void;
 }) {
   const itemStat = stat.getStat(item);
 

--- a/src/app/compare/CompareSuggestions.tsx
+++ b/src/app/compare/CompareSuggestions.tsx
@@ -13,7 +13,7 @@ export default memo(function CompareSuggestions({
   onQueryChanged,
 }: {
   exampleItem: DimItem;
-  onQueryChanged(query: string): void;
+  onQueryChanged: (query: string) => void;
 }) {
   const categoryItems = useSelector(compareCategoryItemsSelector);
   const filterFactory = useSelector(filterFactorySelector);

--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -2,7 +2,7 @@ import { settingsSelector } from 'app/dim-api/selectors';
 import { isPhonePortraitSelector } from './shell/selectors';
 import { observeStore } from './utils/redux-utils';
 
-function setCSSVariable(property: string, value: { toString(): string }) {
+function setCSSVariable(property: string, value: { toString: () => string }) {
   if (value) {
     document.querySelector('html')!.style.setProperty(property, value.toString());
   }

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -41,7 +41,7 @@ const lazyTables = [
 const eagerTables = ['InventoryBucket', 'Class', 'Race', 'Faction', 'Vendor'];
 
 export interface DefinitionTable<T> {
-  get: (hash: number) => T;
+  readonly get: (hash: number) => T;
 }
 
 // D1 types don't exist yet

--- a/src/app/destiny1/d1-definitions.ts
+++ b/src/app/destiny1/d1-definitions.ts
@@ -41,7 +41,7 @@ const lazyTables = [
 const eagerTables = ['InventoryBucket', 'Class', 'Race', 'Faction', 'Vendor'];
 
 export interface DefinitionTable<T> {
-  get(hash: number): T;
+  get: (hash: number) => T;
 }
 
 // D1 types don't exist yet

--- a/src/app/destiny1/loadout-builder/ExcludeItemsDropTarget.tsx
+++ b/src/app/destiny1/loadout-builder/ExcludeItemsDropTarget.tsx
@@ -8,7 +8,7 @@ import { DimItem } from '../../inventory/item-types';
 interface Props {
   className?: string;
   children?: React.ReactNode;
-  onExcluded(lockedItem: DimItem): void;
+  onExcluded: (lockedItem: DimItem) => void;
 }
 
 export default function ExcludeItemsDropTarget({ className, children, onExcluded }: Props) {

--- a/src/app/destiny1/loadout-builder/ExcludeItemsDropTarget.tsx
+++ b/src/app/destiny1/loadout-builder/ExcludeItemsDropTarget.tsx
@@ -3,17 +3,17 @@ import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import React from 'react';
 import { useDrop } from 'react-dnd';
-import { DimItem } from '../../inventory/item-types';
+import { D1Item } from '../../inventory/item-types';
 
 interface Props {
   className?: string;
   children?: React.ReactNode;
-  onExcluded: (lockedItem: DimItem) => void;
+  onExcluded: (lockedItem: D1Item) => void;
 }
 
 export default function ExcludeItemsDropTarget({ className, children, onExcluded }: Props) {
   const [{ isOver, canDrop }, dropRef] = useDrop<
-    DimItem,
+    D1Item,
     unknown,
     { isOver: Boolean; canDrop: boolean }
   >(

--- a/src/app/destiny1/loadout-builder/GeneratedSet.tsx
+++ b/src/app/destiny1/loadout-builder/GeneratedSet.tsx
@@ -19,7 +19,7 @@ interface Props {
   store: DimStore;
   setType: SetType;
   activesets: string;
-  excludeItem(item: D1Item): void;
+  excludeItem: (item: D1Item) => void;
 }
 
 export default function GeneratedSet({ setType, store, activesets, excludeItem }: Props) {

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderDropTarget.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderDropTarget.tsx
@@ -6,7 +6,7 @@ import { DimItem } from '../../inventory/item-types';
 interface Props {
   bucketHash: number;
   children?: React.ReactNode;
-  onItemLocked(lockedItem: DimItem): void;
+  onItemLocked: (lockedItem: DimItem) => void;
 }
 
 export default function LoadoutBucketDropTarget({ bucketHash, children, onItemLocked }: Props) {

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
@@ -7,7 +7,7 @@ import ItemPopupTrigger from '../../inventory/ItemPopupTrigger';
 
 interface Props {
   item: D1Item & { vendorIcon?: string };
-  shiftClickCallback?(item: D1Item): void;
+  shiftClickCallback?: (item: D1Item) => void;
 }
 
 export default function LoadoutBuilderItem({ item, shiftClickCallback }: Props) {

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderItem.tsx
@@ -13,7 +13,7 @@ interface Props {
 export default function LoadoutBuilderItem({ item, shiftClickCallback }: Props) {
   const onShiftClick =
     shiftClickCallback &&
-    ((e: React.MouseEvent<HTMLDivElement>) => {
+    ((e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
       shiftClickCallback(item);

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
@@ -17,9 +17,9 @@ interface Props {
   lockedPerks: { [armorType in ArmorTypes]: LockedPerkHash };
   activePerks: PerkCombination;
   i18nItemNames: { [key: string]: string };
-  onRemove({ type }: { type: string }): void;
-  onPerkLocked(perk: D1GridNode, type: ArmorTypes, $event: React.MouseEvent): void;
-  onItemLocked(item: DimItem): void;
+  onRemove: ({ type }: { type: string }) => void;
+  onPerkLocked: (perk: D1GridNode, type: ArmorTypes, $event: React.MouseEvent) => void;
+  onItemLocked: (item: DimItem) => void;
 }
 
 const typeToHash: { [key in ArmorTypes]: BucketHashes | D1BucketHashes } = {

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderLockPerk.tsx
@@ -17,7 +17,7 @@ interface Props {
   lockedPerks: { [armorType in ArmorTypes]: LockedPerkHash };
   activePerks: PerkCombination;
   i18nItemNames: { [key: string]: string };
-  onRemove: ({ type }: { type: string }) => void;
+  onRemove: ({ type }: { type: ArmorTypes }) => void;
   onPerkLocked: (perk: D1GridNode, type: ArmorTypes, $event: React.MouseEvent) => void;
   onItemLocked: (item: DimItem) => void;
 }

--- a/src/app/destiny1/loadout-builder/LoadoutBuilderLocksDialog.tsx
+++ b/src/app/destiny1/loadout-builder/LoadoutBuilderLocksDialog.tsx
@@ -10,8 +10,8 @@ interface Props {
   activePerks: PerkCombination;
   lockedPerks: { [armorType in ArmorTypes]: LockedPerkHash };
   type: ArmorTypes;
-  onPerkLocked(perk: D1GridNode, type: ArmorTypes, $event: React.MouseEvent): void;
-  onClose(): void;
+  onPerkLocked: (perk: D1GridNode, type: ArmorTypes, $event: React.MouseEvent) => void;
+  onClose: () => void;
 }
 
 export default function LoadoutBuilderLocksDialog({

--- a/src/app/destiny1/loadout-drawer/Buttons.tsx
+++ b/src/app/destiny1/loadout-drawer/Buttons.tsx
@@ -1,12 +1,11 @@
 import { addIcon, AppIcon } from 'app/shell/icons';
 import clsx from 'clsx';
-import React from 'react';
 import styles from './Buttons.m.scss';
 
 interface AddButtonProps {
   /** An additional className to be passed to the component. */
   className?: string;
-  onClick(): void;
+  onClick: () => void;
 }
 
 /**

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawer.tsx
@@ -51,7 +51,7 @@ export default function LoadoutDrawer({
   storeId: string;
   isNew: boolean;
   showClass: boolean;
-  onClose(): void;
+  onClose: () => void;
 }) {
   const dispatch = useThunkDispatch();
   const defs = useD1Definitions()!;
@@ -173,7 +173,7 @@ export default function LoadoutDrawer({
     </div>
   );
 
-  const footer = ({ onClose }: { onClose(): void }) => (
+  const footer = ({ onClose }: { onClose: () => void }) => (
     <LoadoutDrawerFooter
       loadout={loadout}
       isNew={isNew}

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerBucket.tsx
@@ -19,9 +19,9 @@ export default function LoadoutDrawerBucket({
 }: {
   bucket: InventoryBucket;
   items: ResolvedLoadoutItem[];
-  pickLoadoutItem(bucket: InventoryBucket): void;
-  equip(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
-  remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
+  pickLoadoutItem: (bucket: InventoryBucket) => void;
+  equip: (resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent) => void;
+  remove: (resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent) => void;
 }) {
   const [equippedItems, unequippedItems] = _.partition(items, (li) => li.loadoutItem.equip);
 

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -61,10 +61,10 @@ export default function LoadoutDrawerContents({
   loadout: Loadout;
   items: ResolvedLoadoutItem[];
   setLoadout: (updater: LoadoutUpdateFunction) => void;
-  equip(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
-  remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
-  add(item: DimItem, equip?: boolean): void;
-  onShowItemPicker(shown: boolean): void;
+  equip: (resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent) => void;
+  remove: (resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent) => void;
+  add: (item: DimItem, equip?: boolean) => void;
+  onShowItemPicker: (shown: boolean) => void;
 }) {
   const defs = useD1Definitions()!;
   const buckets = useSelector(bucketsSelector)!;

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerItem.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerItem.tsx
@@ -11,8 +11,8 @@ export default function LoadoutDrawerItem({
   remove,
 }: {
   resolvedLoadoutItem: ResolvedLoadoutItem;
-  equip(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
-  remove(resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent): void;
+  equip: (resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent) => void;
+  remove: (resolvedItem: ResolvedLoadoutItem, e: React.MouseEvent) => void;
 }) {
   const onClose = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -97,8 +97,8 @@ export interface DefinitionTable<T> {
    * and sentry can gather info about the source of the invalid hash.
    * `requestor` ideally a string/number, or a definition including a "hash" key
    */
-  get: (hash: number, requestor?: { hash: number } | string | number) => T;
-  getAll: () => { [hash: number]: T };
+  readonly get: (hash: number, requestor?: { hash: number } | string | number) => T;
+  readonly getAll: () => { [hash: number]: T };
 }
 
 export interface D2ManifestDefinitions extends ManifestDefinitions {

--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -97,8 +97,8 @@ export interface DefinitionTable<T> {
    * and sentry can gather info about the source of the invalid hash.
    * `requestor` ideally a string/number, or a definition including a "hash" key
    */
-  get(hash: number, requestor?: { hash: number } | string | number): T;
-  getAll(): { [hash: number]: T };
+  get: (hash: number, requestor?: { hash: number } | string | number) => T;
+  getAll: () => { [hash: number]: T };
 }
 
 export interface D2ManifestDefinitions extends ManifestDefinitions {

--- a/src/app/destiny2/definitions.ts
+++ b/src/app/destiny2/definitions.ts
@@ -2,9 +2,9 @@ import { D1ManifestDefinitions } from '../destiny1/d1-definitions';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 export interface ManifestDefinitions {
   /** Check if these defs are from D1. Inside an if statement, these defs will be narrowed to type D1ManifestDefinitions. */
-  isDestiny1(): this is D1ManifestDefinitions;
+  isDestiny1: () => this is D1ManifestDefinitions;
   /** Check if these defs are from D2. Inside an if statement, these defs will be narrowed to type D2ManifestDefinitions. */
-  isDestiny2(): this is D2ManifestDefinitions;
+  isDestiny2: () => this is D2ManifestDefinitions;
 }
 
 export class HashLookupFailure extends Error {

--- a/src/app/destiny2/definitions.ts
+++ b/src/app/destiny2/definitions.ts
@@ -2,9 +2,9 @@ import { D1ManifestDefinitions } from '../destiny1/d1-definitions';
 import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
 export interface ManifestDefinitions {
   /** Check if these defs are from D1. Inside an if statement, these defs will be narrowed to type D1ManifestDefinitions. */
-  isDestiny1: () => this is D1ManifestDefinitions;
+  readonly isDestiny1: () => this is D1ManifestDefinitions;
   /** Check if these defs are from D2. Inside an if statement, these defs will be narrowed to type D2ManifestDefinitions. */
-  isDestiny2: () => this is D2ManifestDefinitions;
+  readonly isDestiny2: () => this is D2ManifestDefinitions;
 }
 
 export class HashLookupFailure extends Error {

--- a/src/app/dim-ui/CharacterSelect.tsx
+++ b/src/app/dim-ui/CharacterSelect.tsx
@@ -4,7 +4,7 @@ import { infoLog } from 'app/utils/log';
 import clsx from 'clsx';
 import { animate, motion, PanInfo, Spring, useMotionValue, useTransform } from 'framer-motion';
 import _ from 'lodash';
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import CharacterTileButton from '../character-tile/CharacterTileButton';
 import { DimStore } from '../inventory/store-types';
 import styles from './CharacterSelect.m.scss';
@@ -30,7 +30,7 @@ export default function CharacterSelect({
 }: {
   stores: DimStore[];
   selectedStore: DimStore;
-  onCharacterChanged(storeId: string): void;
+  onCharacterChanged: (storeId: string) => void;
 }) {
   const isPhonePortrait = useIsPhonePortrait();
   stores = stores.filter((s) => !s.isVault);
@@ -61,7 +61,7 @@ function ListCharacterSelect({
 }: {
   stores: DimStore[];
   selectedStore: DimStore;
-  onCharacterChanged(storeId: string): void;
+  onCharacterChanged: (storeId: string) => void;
 }) {
   return (
     <div className={styles.vertical}>
@@ -86,7 +86,7 @@ function SwipableCharacterSelect({
 }: {
   stores: DimStore[];
   selectedStore: DimStore;
-  onCharacterChanged(storeId: string): void;
+  onCharacterChanged: (storeId: string) => void;
 }) {
   const onIndexChanged = (index: number) => {
     onCharacterChanged(stores[index].id);

--- a/src/app/dim-ui/CheckButton.tsx
+++ b/src/app/dim-ui/CheckButton.tsx
@@ -14,7 +14,7 @@ export default function CheckButton({
   checked: boolean;
   className?: string;
   children: React.ReactNode;
-  onChange(checked: boolean): void;
+  onChange: (checked: boolean) => void;
 }) {
   return (
     <label className={clsx(styles.checkButton, className)}>

--- a/src/app/dim-ui/ClickOutside.tsx
+++ b/src/app/dim-ui/ClickOutside.tsx
@@ -8,7 +8,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode;
   /** An optional second ref that will be excluded from being considered "outside". This is good for preventing the triggering button from double-counting clicks. */
   extraRef?: React.RefObject<HTMLElement>;
-  onClickOutside(event: React.MouseEvent | MouseEvent): void;
+  onClickOutside: (event: React.MouseEvent | MouseEvent) => void;
 };
 
 /**

--- a/src/app/dim-ui/ClosableContainer.tsx
+++ b/src/app/dim-ui/ClosableContainer.tsx
@@ -16,7 +16,7 @@ export default function ClosableContainer({
   children: React.ReactNode;
   className?: string;
   showCloseIconOnHover?: boolean;
-  onClose?(e: React.MouseEvent): void;
+  onClose?: (e: React.MouseEvent) => void;
 }) {
   return (
     <div

--- a/src/app/dim-ui/Dropdown.tsx
+++ b/src/app/dim-ui/Dropdown.tsx
@@ -3,7 +3,7 @@ import { kebabIcon, moveDownIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import clsx from 'clsx';
 import { useSelect } from 'downshift';
-import React, { ReactNode, useRef } from 'react';
+import { ReactNode, useRef } from 'react';
 import styles from './Dropdown.m.scss';
 import { usePopper } from './usePopper';
 
@@ -15,7 +15,7 @@ interface DropdownOption {
   key: string;
   content: ReactNode;
   disabled?: boolean;
-  onSelected(): void;
+  onSelected: () => void;
 }
 
 export type Option = Separator | DropdownOption;

--- a/src/app/dim-ui/FilterPills.tsx
+++ b/src/app/dim-ui/FilterPills.tsx
@@ -21,7 +21,7 @@ export default function FilterPills({
 }: {
   options: readonly Option[];
   selectedOptions: readonly Option[];
-  onOptionsSelected(options: Option[]): void;
+  onOptionsSelected: (options: Option[]) => void;
   className?: string;
   darkBackground?: boolean;
   extra?: React.ReactNode;

--- a/src/app/dim-ui/Select.tsx
+++ b/src/app/dim-ui/Select.tsx
@@ -2,7 +2,7 @@ import { moveDownIcon, moveUpIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import clsx from 'clsx';
 import { useSelect } from 'downshift';
-import React, { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
+import { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
 import styles from './Select.m.scss';
 import { usePopper } from './usePopper';
 
@@ -33,7 +33,7 @@ interface Props<T> {
   options: Option<T>[];
   /** Optional override for the button content */
   children?: ReactNode;
-  onChange(value?: T): void;
+  onChange: (value?: T) => void;
 }
 
 /**

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -33,7 +33,7 @@ const SheetDisabledContext = createContext<(shown: boolean) => void>(() => {
  * takes an "onClose" function that can be used to close the sheet. Using onClose to close
  * the sheet ensures that it will animate away rather than simply disappearing.
  */
-type SheetContent = React.ReactNode | ((args: { onClose(): void }) => React.ReactNode);
+type SheetContent = React.ReactNode | ((args: { onClose: () => void }) => React.ReactNode);
 
 interface Props {
   /** A static, non-scrollable header shown in line with the close button. */
@@ -62,7 +62,7 @@ interface Props {
    * item popup don't close the popup they were spawned from!
    */
   allowClickThrough?: boolean;
-  onClose(): void;
+  onClose: () => void;
 }
 
 const spring: SpringConfig = {

--- a/src/app/hotkeys/hotkeys.ts
+++ b/src/app/hotkeys/hotkeys.ts
@@ -56,7 +56,7 @@ export interface Hotkey {
   description: string;
   action?: 'keypress' | 'keydown' | 'keyup';
   allowIn?: string[];
-  callback(event: KeyboardEvent): void;
+  callback: (event: KeyboardEvent) => void;
 }
 
 class HotkeyRegistry {

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -219,7 +219,7 @@ export default function InfusionFinder() {
     </div>
   );
 
-  const header = ({ onClose }: { onClose(): void }) => (
+  const header = ({ onClose }: { onClose: () => void }) => (
     <div className="infuseHeader">
       <h1>
         {direction === InfuseDirection.INFUSE

--- a/src/app/inventory-page/CategoryStrip.tsx
+++ b/src/app/inventory-page/CategoryStrip.tsx
@@ -13,7 +13,7 @@ export default function CategoryStrip({
 }: {
   buckets: InventoryBuckets;
   category: string;
-  onCategorySelected(category: string): void;
+  onCategorySelected: (category: string) => void;
 }) {
   return (
     <div className={styles.options}>

--- a/src/app/inventory-page/PhoneStoresHeader.tsx
+++ b/src/app/inventory-page/PhoneStoresHeader.tsx
@@ -30,7 +30,7 @@ export default function PhoneStoresHeader({
   // The direction we changed stores in - positive for an increasing index, negative for decreasing
   direction: number;
   loadoutMenuRef: React.RefObject<HTMLElement>;
-  setSelectedStoreId(id: string, direction: number): void;
+  setSelectedStoreId: (id: string, direction: number) => void;
 }) {
   const onIndexChanged = (index: number, dir: number) => {
     const originalIndex = stores.indexOf(selectedStore);

--- a/src/app/inventory/ConnectedInventoryItem.tsx
+++ b/src/app/inventory/ConnectedInventoryItem.tsx
@@ -29,9 +29,9 @@ export default function ConnectedInventoryItem({
   allowFilter?: boolean;
   hideSelectedSuper?: boolean;
   innerRef?: React.Ref<HTMLDivElement>;
-  onClick?(e: React.MouseEvent): void;
-  onShiftClick?(e: React.MouseEvent): void;
-  onDoubleClick?(e: React.MouseEvent): void;
+  onClick?: (e: React.MouseEvent) => void;
+  onShiftClick?: (e: React.MouseEvent) => void;
+  onDoubleClick?: (e: React.MouseEvent) => void;
   dimArchived?: boolean;
 }) {
   // TODO: maybe send these down via Context?

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -33,9 +33,9 @@ interface Props {
   hideSelectedSuper?: boolean;
   innerRef?: React.Ref<HTMLDivElement>;
   /** TODO: item locked needs to be passed in */
-  onClick?(e: React.MouseEvent): void;
-  onShiftClick?(e: React.MouseEvent): void;
-  onDoubleClick?(e: React.MouseEvent): void;
+  onClick?: (e: React.MouseEvent) => void;
+  onShiftClick?: (e: React.MouseEvent) => void;
+  onDoubleClick?: (e: React.MouseEvent) => void;
 }
 
 export default function InventoryItem({

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -55,7 +55,7 @@ export default function InventoryItem({
   let enhancedOnClick = onClick;
 
   if (onShiftClick) {
-    enhancedOnClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    enhancedOnClick = (e: React.MouseEvent) => {
       if (e.shiftKey) {
         onShiftClick(e);
       } else if (onClick) {

--- a/src/app/inventory/ItemPopupTrigger.tsx
+++ b/src/app/inventory/ItemPopupTrigger.tsx
@@ -17,7 +17,10 @@ interface Props {
   extraData?: ItemPopupExtraInfo;
   /** Don't allow adding to compare */
   noCompare?: boolean;
-  children(ref: React.Ref<HTMLDivElement>, onClick: (e: React.MouseEvent) => void): React.ReactNode;
+  children: (
+    ref: React.Ref<HTMLDivElement>,
+    onClick: (e: React.MouseEvent) => void
+  ) => React.ReactNode;
 }
 
 /**

--- a/src/app/inventory/inventory-buckets.ts
+++ b/src/app/inventory/inventory-buckets.ts
@@ -33,5 +33,5 @@ export interface InventoryBuckets {
   byHash: { [hash: number]: InventoryBucket };
   byCategory: { [category: string]: InventoryBucket[] };
   unknown: InventoryBucket; // TODO: get rid of this?
-  setHasUnknown(): void;
+  setHasUnknown: () => void;
 }

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -573,7 +573,7 @@ interface MoveContext {
   /** Bucket hash */
   originalItemType: number;
   excludes: readonly Exclusion[];
-  spaceLeft(s: DimStore, i: DimItem): number;
+  spaceLeft: (s: DimStore, i: DimItem) => number;
 }
 
 /**

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -24,7 +24,7 @@ export default function ItemPicker({
   onCancel,
   onSheetClosed,
 }: ItemPickerState & {
-  onSheetClosed(): void;
+  onSheetClosed: () => void;
 }) {
   const [liveQuery, setQuery] = useState('');
   const query = useDeferredValue(liveQuery);

--- a/src/app/item-picker/item-picker.ts
+++ b/src/app/item-picker/item-picker.ts
@@ -5,10 +5,10 @@ export interface ItemPickerOptions {
   /** Override the default "Choose an Item" prompt. */
   prompt?: string;
   /** Optionally restrict items to a particular subset. */
-  filterItems?(item: DimItem): boolean;
+  filterItems?: (item: DimItem) => boolean;
   /** An extra sort function that items will be sorted by (beyond the default sort chosen by the user)  */
-  sortBy?(item: DimItem): unknown;
-  uniqueBy?(item: DimItem): unknown;
+  sortBy?: (item: DimItem) => unknown;
+  uniqueBy?: (item: DimItem) => unknown;
 }
 
 interface ItemSelectResult {
@@ -16,8 +16,8 @@ interface ItemSelectResult {
 }
 
 export type ItemPickerState = ItemPickerOptions & {
-  onItemSelected(result: ItemSelectResult): void;
-  onCancel(reason?: Error): void;
+  onItemSelected: (result: ItemSelectResult) => void;
+  onCancel: (reason?: Error) => void;
 };
 
 export const showItemPicker$ = new EventBus<ItemPickerState | undefined>();

--- a/src/app/item-popup/ArchetypeSocket.tsx
+++ b/src/app/item-popup/ArchetypeSocket.tsx
@@ -16,7 +16,7 @@ export default function ArchetypeSocket({
   archetypeSocket?: DimSocket;
   item: DimItem;
   children?: React.ReactNode;
-  onClick?(item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean): void;
+  onClick?: (item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean) => void;
 }) {
   if (!archetypeSocket?.plugged) {
     return null;

--- a/src/app/item-popup/EmoteSockets.tsx
+++ b/src/app/item-popup/EmoteSockets.tsx
@@ -2,7 +2,6 @@ import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import React from 'react';
 import styles from './EmoteSockets.m.scss';
 import Socket from './Socket';
 
@@ -20,7 +19,7 @@ export default function EmoteSockets({
   item: DimItem;
   itemDef: DestinyInventoryItemDefinition;
   sockets: DimSocket[];
-  onClick?(item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean): void;
+  onClick?: (item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean) => void;
 }) {
   const selectorIcon = <DefItemIcon itemDef={itemDef} />;
 

--- a/src/app/item-popup/ItemMoveAmount.tsx
+++ b/src/app/item-popup/ItemMoveAmount.tsx
@@ -11,7 +11,7 @@ export default function ItemMoveAmount({
 }: {
   amount: number;
   maximum: number;
-  onAmountChanged(amount: number): void;
+  onAmountChanged: (amount: number) => void;
 }) {
   const constrain = () => {
     const constrained = _.clamp(amount, 1, maximum);

--- a/src/app/item-popup/ItemPerksList.tsx
+++ b/src/app/item-popup/ItemPerksList.tsx
@@ -15,7 +15,7 @@ import { DimPlugTooltip } from './PlugTooltip';
 interface Props {
   item: DimItem;
   perks: DimSocketCategory;
-  onClick?(item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean): void;
+  onClick?: (item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean) => void;
 }
 
 export default function ItemPerksList({ item, perks, onClick }: Props) {
@@ -69,7 +69,7 @@ function PerkSocket({
   socket: DimSocket;
   wishlistRoll?: InventoryWishListRoll;
   selectedPerk?: { socketIndex: number; perkHash: number };
-  onPerkSelected(socketInfo: DimSocket, plug: DimPlug): void;
+  onPerkSelected: (socketInfo: DimSocket, plug: DimPlug) => void;
 }) {
   if (!socket.plugOptions.length) {
     return null;
@@ -110,7 +110,7 @@ function PerkPlug({
   // TODO: maybe use an enum
   selectedSocket: boolean;
   selectedPerk: boolean;
-  onPerkSelected(socketInfo: DimSocket, plug: DimPlug): void;
+  onPerkSelected: (socketInfo: DimSocket, plug: DimPlug) => void;
 }) {
   if (!plug.plugDef.plug) {
     return null;

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -47,7 +47,7 @@ export default function ItemPopup({
   zIndex?: number;
   /** Don't allow opening Armory from the header link */
   noLink?: boolean;
-  onClose(): void;
+  onClose: () => void;
 }) {
   const [tab, setTab] = useState(ItemPopupTab.Overview);
   const stores = useSelector(sortedStoresSelector);

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -23,7 +23,7 @@ export default function ItemPopupBody({
   item: DimItem;
   extraInfo?: ItemPopupExtraInfo;
   tab: ItemPopupTab;
-  onTabChanged(tab: ItemPopupTab): void;
+  onTabChanged: (tab: ItemPopupTab) => void;
 }) {
   const failureStrings = Array.from(extraInfo?.failureStrings || []);
   if (item.owner !== 'unknown' && !item.canPullFromPostmaster && item.location.inPostmaster) {

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -10,7 +10,7 @@ interface ProvidedProps {
   minimal?: boolean;
   /** Force grid style */
   grid?: boolean;
-  onPlugClicked?(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
+  onPlugClicked?: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
 }
 
 type Props = ProvidedProps;

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -27,7 +27,7 @@ interface Props {
   item: DimItem;
   /** minimal style used for loadout generator and compare */
   minimal?: boolean;
-  onPlugClicked?(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
+  onPlugClicked?: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
 }
 
 export default function ItemSocketsGeneral({ item, minimal, onPlugClicked }: Props) {

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -37,7 +37,7 @@ interface Props {
   /** minimal style used for loadout generator and compare */
   minimal?: boolean;
   grid?: boolean;
-  onPlugClicked?(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
+  onPlugClicked?: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
 }
 
 export default function ItemSocketsWeapons({ item, minimal, grid, onPlugClicked }: Props) {

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -32,7 +32,7 @@ export default function Plug({
   socketInfo: DimSocket;
   wishlistRoll?: InventoryWishListRoll;
   hasMenu: boolean;
-  onClick?(plug: DimPlug): void;
+  onClick?: (plug: DimPlug) => void;
 } & PlugStatuses) {
   const defs = useD2Definitions()!;
 

--- a/src/app/item-popup/Socket.tsx
+++ b/src/app/item-popup/Socket.tsx
@@ -2,7 +2,6 @@ import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
 import { compareBy } from 'app/utils/comparators';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import clsx from 'clsx';
-import React from 'react';
 import Plug from './Plug';
 
 /**
@@ -17,7 +16,7 @@ export default function Socket({
   item: DimItem;
   socket: DimSocket;
   wishlistRoll?: InventoryWishListRoll;
-  onClick?(item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean): void;
+  onClick?: (item: DimItem, socket: DimSocket, plug: DimPlug, hasMenu: boolean) => void;
 }) {
   const hasMenu = Boolean(!socket.isPerk && socket.socketDefinition.plugSources);
   if (!socket.plugOptions.length) {

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -105,7 +105,7 @@ export const SocketDetailsMod = memo(
   }: {
     itemDef: PluggableInventoryItemDefinition;
     className?: string;
-    onClick?(mod: PluggableInventoryItemDefinition): void;
+    onClick?: (mod: PluggableInventoryItemDefinition) => void;
   }) => {
     const onClickFn = onClick && (() => onClick(itemDef));
 
@@ -134,8 +134,8 @@ export default function SocketDetails({
   socket: DimSocket;
   /** Set to true if you want to insert the plug when it's selected, rather than returning it. */
   allowInsertPlug: boolean;
-  onClose(): void;
-  onPlugSelected?(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
+  onClose: () => void;
+  onPlugSelected?: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
 }) {
   const defs = useD2Definitions()!;
   const artifactMods = useSelector(artifactModsSelector);
@@ -305,7 +305,7 @@ export default function SocketDetails({
   const footer =
     selectedPlug &&
     isPluggableItem(selectedPlug) &&
-    (({ onClose }: { onClose(): void }) => (
+    (({ onClose }: { onClose: () => void }) => (
       <SocketDetailsSelectedPlug
         plug={selectedPlug}
         item={item}

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -95,9 +95,9 @@ export default function SocketDetailsSelectedPlug({
   currentPlug: DimPlug | null;
   equippable: boolean;
   allowInsertPlug: boolean;
-  closeMenu(): void;
+  closeMenu: () => void;
   /** If this is set, instead of offering to slot the mod, we just notify above */
-  onPlugSelected?(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
+  onPlugSelected?: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
 }) {
   const dispatch = useThunkDispatch();
   const defs = useD2Definitions()!;

--- a/src/app/item-triage/triage-factors.tsx
+++ b/src/app/item-triage/triage-factors.tsx
@@ -35,9 +35,9 @@ import styles from './TriageFactors.m.scss';
 export interface Factor {
   id: string;
   /** bother checking this factor, if the seed item (the one in the item popup) returns truthy */
-  runIf(item: DimItem): unknown;
-  render(item: DimItem): React.ReactElement | null;
-  filter(item: DimItem): string;
+  runIf: (item: DimItem) => unknown;
+  render: (item: DimItem) => React.ReactElement | null;
+  filter: (item: DimItem) => string;
 }
 
 export type FactorComboCategory = keyof typeof factorCombos;

--- a/src/app/loadout-builder/LoadoutBucketDropTarget.tsx
+++ b/src/app/loadout-builder/LoadoutBucketDropTarget.tsx
@@ -9,7 +9,7 @@ import styles from './LoadoutBucketDropTarget.m.scss';
 interface Props {
   className?: string;
   children?: React.ReactNode;
-  onItemLocked(lockedItem: DimItem): void;
+  onItemLocked: (lockedItem: DimItem) => void;
 }
 
 /**

--- a/src/app/loadout-builder/LoadoutBuilderItem.tsx
+++ b/src/app/loadout-builder/LoadoutBuilderItem.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import DraggableInventoryItem from '../inventory/DraggableInventoryItem';
 import { DimItem } from '../inventory/item-types';
@@ -12,7 +11,7 @@ export default function LoadoutBuilderItem({
   onShiftClick,
 }: {
   item: DimItem;
-  onShiftClick(): void;
+  onShiftClick: () => void;
 }) {
   return (
     <DraggableInventoryItem item={item}>

--- a/src/app/loadout-builder/filter/EnergyOptions.tsx
+++ b/src/app/loadout-builder/filter/EnergyOptions.tsx
@@ -10,7 +10,7 @@ interface Option {
   label: string;
   tooltip: string;
   selected: boolean;
-  onChange(): void;
+  onChange: () => void;
 }
 
 const RadioSetting = React.memo(function RadioSetting({

--- a/src/app/loadout-builder/filter/ExoticArmorChoice.tsx
+++ b/src/app/loadout-builder/filter/ExoticArmorChoice.tsx
@@ -4,7 +4,6 @@ import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { useD2Definitions } from 'app/manifest/selectors';
 import anyExoticIcon from 'images/anyExotic.svg';
 import noExoticIcon from 'images/noExotic.svg';
-import React from 'react';
 import { LOCKED_EXOTIC_ANY_EXOTIC, LOCKED_EXOTIC_NO_EXOTIC } from '../types';
 import styles from './ExoticArmorChoice.m.scss';
 
@@ -13,7 +12,7 @@ export default function ExoticArmorChoice({
   onClose,
 }: {
   lockedExoticHash: number;
-  onClose?(): void;
+  onClose?: () => void;
 }) {
   const defs = useD2Definitions()!;
   const exoticArmor =

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -16,7 +16,7 @@ import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import anyExoticIcon from 'images/anyExotic.svg';
 import noExoticIcon from 'images/noExotic.svg';
 import _ from 'lodash';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { LockableBucketHashes, LOCKED_EXOTIC_ANY_EXOTIC, LOCKED_EXOTIC_NO_EXOTIC } from '../types';
 import styles from './ExoticPicker.m.scss';
@@ -25,8 +25,8 @@ import ExoticTile, { FakeExoticTile, LockedExoticWithPlugs } from './ExoticTile'
 interface Props {
   lockedExoticHash?: number;
   classType: DestinyClass;
-  onSelected(lockedExoticHash: number): void;
-  onClose(): void;
+  onSelected: (lockedExoticHash: number) => void;
+  onClose: () => void;
 }
 
 /**

--- a/src/app/loadout-builder/filter/ExoticTile.tsx
+++ b/src/app/loadout-builder/filter/ExoticTile.tsx
@@ -20,7 +20,7 @@ export interface LockedExoticWithPlugs {
 interface Props {
   exotic: LockedExoticWithPlugs;
   selected: boolean;
-  onSelected(): void;
+  onSelected: () => void;
 }
 
 /**

--- a/src/app/loadout-builder/filter/LockedItem.tsx
+++ b/src/app/loadout-builder/filter/LockedItem.tsx
@@ -12,7 +12,7 @@ export default function LockedItem({
   onRemove,
 }: {
   lockedItem: DimItem;
-  onRemove?(item: DimItem): void;
+  onRemove?: (item: DimItem) => void;
 }) {
   return (
     <ClosableContainer

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -30,8 +30,8 @@ export default function TierSelect({
   /** The ranges the stats could have gotten to INCLUDING stat filters and mod compatibility */
   statRangesFiltered?: Readonly<StatRanges>;
   order: number[]; // stat hashes in user order
-  onStatOrderChanged(order: ArmorStatHashes[]): void;
-  onStatFiltersChanged(stats: StatFilters): void;
+  onStatOrderChanged: (order: ArmorStatHashes[]) => void;
+  onStatFiltersChanged: (stats: StatFilters) => void;
 }) {
   const defs = useD2Definitions()!;
   const handleTierChange = (
@@ -168,14 +168,14 @@ function MinMaxSelectInner({
   type: 'Min' | 'Max';
   /** Filter config for a single stat */
   stat: MinMaxIgnored;
-  handleTierChange(
+  handleTierChange: (
     statHash: number,
     changed: {
       min: number;
       max: number;
       ignored: boolean;
     }
-  ): void;
+  ) => void;
 }) {
   const min = 0;
   const max = 10;

--- a/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
@@ -32,7 +32,7 @@ interface Props {
   classType: DestinyClass;
   params: LoadoutParameters;
   notes?: string;
-  onClose(): void;
+  onClose: () => void;
 }
 
 function chooseInitialLoadout(

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -37,7 +37,7 @@ export default function GeneratedSetButtons({
   params: LoadoutParameters;
   canCompareLoadouts: boolean;
   halfTierMods: PluggableInventoryItemDefinition[];
-  onLoadoutSet(loadout: Loadout): void;
+  onLoadoutSet: (loadout: Loadout) => void;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
   const dispatch = useThunkDispatch();

--- a/src/app/loadout-drawer/LoadoutDrawer2.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer2.tsx
@@ -73,7 +73,7 @@ export default function LoadoutDrawer2({
    */
   storeId: string;
   isNew: boolean;
-  onClose(): void;
+  onClose: () => void;
 }) {
   const dispatch = useThunkDispatch();
   const defs = useDefinitions()!;
@@ -248,7 +248,7 @@ export default function LoadoutDrawer2({
     </div>
   );
 
-  const footer = ({ onClose }: { onClose(): void }) => (
+  const footer = ({ onClose }: { onClose: () => void }) => (
     <LoadoutDrawerFooter
       loadout={loadout}
       isNew={isNew}

--- a/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
@@ -35,7 +35,7 @@ export default function LoadoutDrawerDropTarget({
   children?: React.ReactNode;
   className?: string;
   classType: DestinyClass;
-  onDroppedItem(item: DimItem, equip?: boolean): void;
+  onDroppedItem: (item: DimItem, equip?: boolean) => void;
 }) {
   const bucketTypes = useSelector(bucketTypesSelector);
 

--- a/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
@@ -49,8 +49,8 @@ export default function LoadoutDrawerFooter({
   redo?: () => void;
   hasUndo?: boolean;
   hasRedo?: boolean;
-  onSaveLoadout(e: React.FormEvent, saveAsNew: boolean): void;
-  onDeleteLoadout(): void;
+  onSaveLoadout: (e: React.FormEvent, saveAsNew: boolean) => void;
+  onDeleteLoadout: () => void;
 }) {
   const clashingLoadout = useSelector(clashingLoadoutSelector(loadout));
   // There's an existing loadout with the same name & class and it's not the loadout we are currently editing

--- a/src/app/loadout-drawer/LoadoutDrawerHeader.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerHeader.tsx
@@ -13,7 +13,7 @@ export default function LoadoutDrawerHeader({
   onNameChanged,
 }: {
   loadout: Readonly<Loadout>;
-  onNameChanged(name: string): void;
+  onNameChanged: (name: string) => void;
 }) {
   const setName = (e: React.ChangeEvent<HTMLInputElement>) => onNameChanged(e.target.value);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -59,9 +59,9 @@ interface ProvidedProps {
   /** Only show mods that are in these categories. No restriction if this is not provided. */
   plugCategoryHashWhitelist?: number[];
   /** Called with the complete list of lockedMods when the user accepts the new mod selections. */
-  onAccept(newLockedMods: PluggableInventoryItemDefinition[]): void;
+  onAccept: (newLockedMods: PluggableInventoryItemDefinition[]) => void;
   /** Called when the user accepts the new modset of closes the sheet. */
-  onClose(): void;
+  onClose: () => void;
 }
 
 interface StoreProps {

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -31,8 +31,8 @@ export default function SubclassPlugDrawer({
 }: {
   subclass: DimItem;
   socketOverrides: SocketOverrides;
-  onAccept(overrides: SocketOverrides): void;
-  onClose(): void;
+  onAccept: (overrides: SocketOverrides) => void;
+  onClose: () => void;
 }) {
   const defs = useD2Definitions()!;
   const profileResponse = useSelector(profileResponseSelector);

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -48,7 +48,7 @@ export default function FashionDrawer({
   loadout: Loadout;
   storeId?: string;
   items: ResolvedLoadoutItem[];
-  onModsByBucketUpdated(modsByBucket: LoadoutParameters['modsByBucket']): void;
+  onModsByBucketUpdated: (modsByBucket: LoadoutParameters['modsByBucket']) => void;
   onClose: () => void;
 }) {
   const defs = useD2Definitions()!;
@@ -114,7 +114,7 @@ export default function FashionDrawer({
     </>
   );
 
-  const footer = ({ onClose }: { onClose(): void }) => (
+  const footer = ({ onClose }: { onClose: () => void }) => (
     <>
       <button
         type="button"
@@ -421,8 +421,8 @@ function FashionItem({
   bucketHash: number;
   mods?: number[];
   storeId?: string;
-  onPickPlug(params: PickPlugState): void;
-  onRemovePlug(bucketHash: number, modHash: number): void;
+  onPickPlug: (params: PickPlugState) => void;
+  onRemovePlug: (bucketHash: number, modHash: number) => void;
 }) {
   const defs = useD2Definitions()!;
   const isShader = (m: number) =>
@@ -498,8 +498,8 @@ function FashionSocket({
   exampleItem: DimItem;
   storeId?: string;
   defaultPlug: DestinyInventoryItemDefinition;
-  onPickPlug(params: PickPlugState): void;
-  onRemovePlug(bucketHash: number, modHash: number): void;
+  onPickPlug: (params: PickPlugState) => void;
+  onRemovePlug: (bucketHash: number, modHash: number) => void;
 }) {
   const unlockedPlugSetItems = useSelector((state: RootState) =>
     unlockedPlugSetItemsSelector(state, storeId)

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -105,7 +105,7 @@ export function ArmorExtras({
   subclass?: ResolvedLoadoutItem;
   allMods: PluggableInventoryItemDefinition[];
   items?: ResolvedLoadoutItem[];
-  onModsByBucketUpdated(modsByBucket: LoadoutParameters['modsByBucket']): void;
+  onModsByBucketUpdated: (modsByBucket: LoadoutParameters['modsByBucket']) => void;
 }) {
   const defs = useD2Definitions()!;
   const equippedItems =
@@ -241,7 +241,7 @@ function FashionButton({
   loadout: Loadout;
   items: ResolvedLoadoutItem[];
   storeId: string;
-  onModsByBucketUpdated(modsByBucket: LoadoutParameters['modsByBucket']): void;
+  onModsByBucketUpdated: (modsByBucket: LoadoutParameters['modsByBucket']) => void;
 }) {
   const [showFashionDrawer, setShowFashionDrawer] = useState(false);
 

--- a/src/app/loadout/loadout-edit/LoadoutEditSection.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSection.tsx
@@ -20,12 +20,12 @@ export default function LoadoutEditSection({
   title: string;
   children: React.ReactNode;
   className?: string;
-  onClear(): void;
-  onFillFromEquipped?(): void;
-  onSyncFromEquipped?(): void;
+  onClear: () => void;
+  onFillFromEquipped?: () => void;
+  onSyncFromEquipped?: () => void;
   fillFromInventoryCount?: number;
-  onFillFromInventory?(): void;
-  onClearLoadoutParameters?(): void;
+  onFillFromInventory?: () => void;
+  onClearLoadoutParameters?: () => void;
 }) {
   const options: Option[] = _.compact([
     onFillFromEquipped

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -24,8 +24,8 @@ export default function LoadoutEditSubclass({
   defs: D2ManifestDefinitions;
   subclass?: ResolvedLoadoutItem;
   power: number;
-  onRemove(): void;
-  onPick(): void;
+  onRemove: () => void;
+  onPick: () => void;
 }) {
   const getModRenderKey = createGetModRenderKey();
   const plugs = useMemo(() => getSubclassPlugs(defs, subclass), [subclass, defs]);

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -59,7 +59,7 @@ export default function LoadoutPopup({
   onClick,
 }: {
   dimStore: DimStore;
-  onClick?(e: React.MouseEvent): void;
+  onClick?: (e: React.MouseEvent) => void;
 }) {
   // For the most part we don't need to memoize this - this menu is destroyed when closed
   const defs = useDefinitions()!;

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -27,7 +27,7 @@ const LoadoutModMemo = memo(function LoadoutMod({
 }: {
   mod: PluggableInventoryItemDefinition;
   className: string;
-  onRemoveMod?(modHash: number): void;
+  onRemoveMod?: (modHash: number) => void;
 }) {
   // We need this to be undefined if `onRemoveMod` is not present as the presence of the onClose
   // callback determines whether the close icon is displayed on hover
@@ -56,9 +56,9 @@ export default memo(function LoadoutMods({
   clearUnsetMods?: boolean;
   missingSockets?: boolean;
   /** If present, show an "Add Mod" button */
-  onUpdateMods?(newMods: PluggableInventoryItemDefinition[]): void;
-  onRemoveMod?(modHash: number): void;
-  onClearUnsetModsChanged?(checked: boolean): void;
+  onUpdateMods?: (newMods: PluggableInventoryItemDefinition[]) => void;
+  onRemoveMod?: (modHash: number) => void;
+  onClearUnsetModsChanged?: (checked: boolean) => void;
 }) {
   const defs = useD2Definitions()!;
   const isPhonePortrait = useIsPhonePortrait();

--- a/src/app/loadout/loadout-ui/PlugDef.tsx
+++ b/src/app/loadout/loadout-ui/PlugDef.tsx
@@ -8,8 +8,8 @@ import clsx from 'clsx';
 interface Props {
   plug: PluggableInventoryItemDefinition;
   className?: string;
-  onClick?(): void;
-  onClose?(): void;
+  onClick?: () => void;
+  onClose?: () => void;
 }
 
 /**

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -23,12 +23,12 @@ interface Props {
   item: DimItem;
   lockedMods?: PluggableInventoryItemDefinition[];
   size?: 'small';
-  onSocketClick?(
+  onSocketClick?: (
     plugDef: PluggableInventoryItemDefinition,
     /** An allow-list of plug category hashes that can be inserted into this socket */
     // TODO: why not just pass the socketType hash or socket definition?
     plugCategoryHashWhitelist: number[]
-  ): void;
+  ) => void;
 }
 
 /**

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -57,8 +57,8 @@ export default function ModAssignmentDrawer({
 }: {
   loadout: Loadout;
   storeId: string;
-  onUpdateMods?(newMods: PluggableInventoryItemDefinition[]): void;
-  onClose(): void;
+  onUpdateMods?: (newMods: PluggableInventoryItemDefinition[]) => void;
+  onClose: () => void;
 }) {
   const [plugCategoryHashWhitelist, setPlugCategoryHashWhitelist] = useState<number[]>();
 

--- a/src/app/loadout/plug-drawer/Footer.tsx
+++ b/src/app/loadout/plug-drawer/Footer.tsx
@@ -10,8 +10,8 @@ interface Props {
   isPhonePortrait: boolean;
   plugSets: PlugSet[];
   acceptButtonText: string;
-  onSubmit(event: React.FormEvent | KeyboardEvent): void;
-  handlePlugSelected(plug: PluggableInventoryItemDefinition): void;
+  onSubmit: (event: React.FormEvent | KeyboardEvent) => void;
+  handlePlugSelected: (plug: PluggableInventoryItemDefinition) => void;
 }
 
 export default function Footer({

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -33,18 +33,18 @@ interface Props {
   /** The label for the "accept" button in the footer. */
   acceptButtonText: string;
   /** A function to determine if a given plug is currently selectable. */
-  isPlugSelectable(
+  isPlugSelectable: (
     plug: PluggableInventoryItemDefinition,
     selected: PluggableInventoryItemDefinition[]
-  ): boolean;
+  ) => boolean;
   /** How plug groups (e.g. PlugSets) should be sorted in the display. */
   sortPlugGroups?: Comparator<PlugSet>;
   /** How to sort plugs within a group (PlugSet) */
   sortPlugs?: Comparator<PluggableInventoryItemDefinition>;
   /** Called with the full list of selected plugs when the user clicks the accept button. */
-  onAccept(selectedPlugs: PluggableInventoryItemDefinition[]): void;
+  onAccept: (selectedPlugs: PluggableInventoryItemDefinition[]) => void;
   /** Called when the user accepts the new plugset or closes the sheet. */
-  onClose(): void;
+  onClose: () => void;
 }
 
 /**
@@ -171,7 +171,7 @@ export default function PlugDrawer({
     [internalPlugSets, isPlugSelectable]
   );
 
-  const footer = ({ onClose }: { onClose(): void }) => (
+  const footer = ({ onClose }: { onClose: () => void }) => (
     <Footer
       plugSets={internalPlugSets}
       isPhonePortrait={isPhonePortrait}

--- a/src/app/loadout/plug-drawer/PlugSection.tsx
+++ b/src/app/loadout/plug-drawer/PlugSection.tsx
@@ -1,5 +1,5 @@
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { groupModsByModType } from '../mod-utils';
 import styles from './PlugSection.m.scss';
 import SelectablePlug from './SelectablePlug';
@@ -20,13 +20,13 @@ export default function PlugSection({
   /** A restricted list of stat hashes to display for each plug. If not specified, all stats will be shown. */
   displayedStatHashes?: number[];
   /** A function to determine if a given plug is currently selectable. */
-  isPlugSelectable(plug: PluggableInventoryItemDefinition): boolean;
-  onPlugSelected(
+  isPlugSelectable: (plug: PluggableInventoryItemDefinition) => boolean;
+  onPlugSelected: (
     plugSetHash: number,
     mod: PluggableInventoryItemDefinition,
     selectionType: 'multi' | 'single'
-  ): void;
-  onPlugRemoved(plugSetHash: number, mod: PluggableInventoryItemDefinition): void;
+  ) => void;
+  onPlugRemoved: (plugSetHash: number, mod: PluggableInventoryItemDefinition) => void;
 }) {
   const { plugs, maxSelectable, plugSetHash, headerSuffix, selectionType } = plugSet;
 

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -28,8 +28,8 @@ export default function SelectablePlug({
   selectionType: 'multi' | 'single';
   removable: boolean;
   displayedStatHashes?: number[];
-  onPlugSelected(plug: PluggableInventoryItemDefinition): void;
-  onPlugRemoved(plug: PluggableInventoryItemDefinition): void;
+  onPlugSelected: (plug: PluggableInventoryItemDefinition) => void;
+  onPlugRemoved: (plug: PluggableInventoryItemDefinition) => void;
 }) {
   const handleClick = useCallback(() => {
     selectable && onPlugSelected(plug);

--- a/src/app/notifications/Notification.tsx
+++ b/src/app/notifications/Notification.tsx
@@ -19,7 +19,7 @@ const showErrorDuration = 5000;
 
 interface Props extends MotionProps {
   notification: Notify;
-  onClose(notification: Notify): void;
+  onClose: (notification: Notify) => void;
 }
 
 export default function Notification({ notification, onClose, ...animation }: Props) {

--- a/src/app/notifications/NotificationButton.tsx
+++ b/src/app/notifications/NotificationButton.tsx
@@ -11,7 +11,7 @@ export default function NotificationButton({
   onClick,
 }: {
   children: React.ReactChild | React.ReactChild[];
-  onClick(e: React.MouseEvent): void;
+  onClick: (e: React.MouseEvent) => void;
 }) {
   return (
     <span className={styles.button} onClick={onClick}>

--- a/src/app/notifications/notifications.ts
+++ b/src/app/notifications/notifications.ts
@@ -16,8 +16,8 @@ export interface NotifyInput {
   /** The notification will show for the given number of milliseconds. */
   duration?: number;
   /** Return false to not close the notification on click. */
-  onClick?(event: React.MouseEvent): boolean | void;
-  onCancel?(): void;
+  onClick?: (event: React.MouseEvent) => boolean | void;
+  onCancel?: () => void;
 }
 
 export interface Notify {
@@ -30,8 +30,8 @@ export interface Notify {
   promise?: Promise<unknown>;
   /** The notification will show for either the given number of milliseconds, or when the provided promise completes. */
   duration: number;
-  onClick?(event: React.MouseEvent): boolean | void;
-  onCancel?(): void;
+  onClick?: (event: React.MouseEvent) => boolean | void;
+  onCancel?: () => void;
 }
 
 /**

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -597,7 +597,7 @@ function PerksCell({
 }: {
   item: DimItem;
   traitsOnly?: boolean;
-  onPlugClicked?(value: { item: DimItem; socket: DimSocket; plugHash: number }): void;
+  onPlugClicked?: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
 }) {
   if (!item.sockets) {
     return null;

--- a/src/app/organizer/DropDown.tsx
+++ b/src/app/organizer/DropDown.tsx
@@ -12,7 +12,7 @@ export interface DropDownItem {
   content: ReactNode;
   dropdownLabel?: ReactNode;
   checked?: boolean;
-  onItemSelect?(e: React.MouseEvent): void;
+  onItemSelect?: (e: React.MouseEvent) => void;
 }
 
 function MenuItem({ item, forClass }: { item: DropDownItem; forClass?: DestinyClass }) {

--- a/src/app/organizer/EnabledColumnsSelector.tsx
+++ b/src/app/organizer/EnabledColumnsSelector.tsx
@@ -24,7 +24,7 @@ export default React.memo(function EnabledColumnsSelector({
   columns: ColumnDefinition[];
   enabledColumns: string[];
   forClass: DestinyClass;
-  onChangeEnabledColumn(item: { checked: boolean; id: string }): void;
+  onChangeEnabledColumn: (item: { checked: boolean; id: string }) => void;
 }) {
   const items: { [id: string]: DropDownItem } = {};
 

--- a/src/app/organizer/ItemActions.tsx
+++ b/src/app/organizer/ItemActions.tsx
@@ -35,10 +35,10 @@ function ItemActions({
 }: {
   stores: DimStore[];
   itemsAreSelected: boolean;
-  onLock(locked: boolean): void;
-  onNote(note?: string): void;
-  onTagSelectedItems(tagInfo: TagCommandInfo): void;
-  onMoveSelectedItems(store: DimStore): void;
+  onLock: (locked: boolean) => void;
+  onNote: (note?: string) => void;
+  onTagSelectedItems: (tagInfo: TagCommandInfo) => void;
+  onMoveSelectedItems: (store: DimStore) => void;
 }) {
   const tagItems: Option[] = bulkItemTags.map((tagInfo) => ({
     key: tagInfo.label,

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -611,10 +611,10 @@ function TableRow({
 }: {
   row: Row;
   filteredColumns: ColumnDefinition[];
-  onRowClick(
+  onRowClick: (
     row: Row,
     column: ColumnDefinition
-  ): ((event: React.MouseEvent<HTMLTableCellElement>) => void) | undefined;
+  ) => ((event: React.MouseEvent<HTMLTableCellElement>) => void) | undefined;
 }) {
   return (
     <>

--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -4,7 +4,6 @@ import { filteredItemsSelector } from 'app/search/search-filter';
 import clsx from 'clsx';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { itemIncludesCategories } from './filtering-utils';
 import { itemCategoryIcons } from './item-category-icons';
@@ -345,7 +344,7 @@ export default function ItemTypeSelector({
 }: {
   selectionTree: ItemCategoryTreeNode;
   selection: ItemCategoryTreeNode[];
-  onSelection(selection: ItemCategoryTreeNode[]): void;
+  onSelection: (selection: ItemCategoryTreeNode[]) => void;
 }) {
   const defs = useDefinitions()!;
   const filteredItems = useSelector(filteredItemsSelector);

--- a/src/app/organizer/table-types.ts
+++ b/src/app/organizer/table-types.ts
@@ -19,6 +19,8 @@ export interface ColumnGroup {
 
 // TODO: column groupings?
 // TODO: custom configs like the total column?
+// prop methods make this invariant over V, so disable the rule here
+/* eslint-disable @typescript-eslint/method-signature-style */
 export interface ColumnDefinition<V extends Value = Value> {
   /** Unique ID for this column. */
   id: string;

--- a/src/app/progress/BountyGuide.tsx
+++ b/src/app/progress/BountyGuide.tsx
@@ -58,7 +58,7 @@ export default function BountyGuide({
   store: DimStore;
   bounties: DimItem[];
   selectedFilters: BountyFilter[];
-  onSelectedFiltersChanged(filters: BountyFilter[]): void;
+  onSelectedFiltersChanged: (filters: BountyFilter[]) => void;
   pursuitsInfo: { [hash: string]: { [type in DefType]?: number[] } };
 }) {
   const defs = useD2Definitions()!;

--- a/src/app/records/PlugSet.tsx
+++ b/src/app/records/PlugSet.tsx
@@ -24,7 +24,7 @@ interface Props {
   };
   unlockedItems: Set<number>;
   path: number[];
-  onNodePathSelected(nodePath: number[]): void;
+  onNodePathSelected: (nodePath: number[]) => void;
 }
 
 /**

--- a/src/app/records/PresentationNode.tsx
+++ b/src/app/records/PresentationNode.tsx
@@ -5,7 +5,7 @@ import { percent } from 'app/shell/formatters';
 import { DestinyPresentationScreenStyle } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { deepEqual } from 'fast-equals';
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import BungieImage from '../dim-ui/BungieImage';
 import { AppIcon, collapseIcon, expandIcon } from '../shell/icons';
@@ -21,7 +21,7 @@ interface Props {
   isInTriumphs?: boolean;
   overrideName?: string;
   isRootNode?: boolean;
-  onNodePathSelected(nodePath: number[]): void;
+  onNodePathSelected: (nodePath: number[]) => void;
 }
 
 export default function PresentationNode({

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -73,9 +73,9 @@ interface ProvidedProps {
   instant?: boolean;
   className?: string;
   /** Fired whenever the query changes (already debounced) */
-  onQueryChanged(query: string): void;
+  onQueryChanged: (query: string) => void;
   /** Fired whenever the query has been cleared */
-  onClear?(): void;
+  onClear?: () => void;
 }
 
 interface StoreProps {
@@ -133,7 +133,7 @@ const Row = React.memo(
     item: SearchItem;
     isPhonePortrait: boolean;
     isTabAutocompleteItem: boolean;
-    onClick(e: React.MouseEvent, item: SearchItem): void;
+    onClick: (e: React.MouseEvent, item: SearchItem) => void;
   }) => {
     function highlight(text: string, section: string) {
       return item.highlightRange?.section === section ? (
@@ -190,9 +190,9 @@ const Row = React.memo(
 /** An interface for interacting with the search filter through a ref */
 export interface SearchFilterRef {
   /** Switch focus to the filter field */
-  focusFilterInput(): void;
+  focusFilterInput: () => void;
   /** Clear the filter field */
-  clearFilter(): void;
+  clearFilter: () => void;
 }
 
 /**

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -17,7 +17,7 @@ export function SearchFilter(
   {
     onClear,
   }: {
-    onClear?(): void;
+    onClear?: () => void;
   },
   ref: React.Ref<SearchFilterRef>
 ) {

--- a/src/app/search/SearchResults.tsx
+++ b/src/app/search/SearchResults.tsx
@@ -20,7 +20,7 @@ export default memo(function SearchResults({
   onClose,
 }: {
   items: DimItem[];
-  onClose(): void;
+  onClose: () => void;
 }) {
   const sortItems = useSelector(itemSorterSelector);
 

--- a/src/app/settings/CharacterOrderEditor.tsx
+++ b/src/app/settings/CharacterOrderEditor.tsx
@@ -11,7 +11,7 @@ import styles from './CharacterOrderEditor.m.scss';
 export default function CharacterOrderEditor({
   onSortOrderChanged,
 }: {
-  onSortOrderChanged(order: string[]): void;
+  onSortOrderChanged: (order: string[]) => void;
 }) {
   const characters = useSelector(sortedStoresSelector);
 

--- a/src/app/settings/SortOrderEditor.tsx
+++ b/src/app/settings/SortOrderEditor.tsx
@@ -41,7 +41,7 @@ export default function SortOrderEditor({
   onSortOrderChanged,
 }: {
   order: SortProperty[];
-  onSortOrderChanged(order: SortProperty[]): void;
+  onSortOrderChanged: (order: SortProperty[]) => void;
 }) {
   const moveItem = (oldIndex: number, newIndex: number, fromDrag = false) => {
     newIndex = _.clamp(newIndex, 0, order.length);

--- a/src/app/storage/ImportExport.tsx
+++ b/src/app/storage/ImportExport.tsx
@@ -10,8 +10,8 @@ export default function ImportExport({
   onExportData,
   onImportData,
 }: {
-  onExportData(): void;
-  onImportData(data: ExportResponse): Promise<void>;
+  onExportData: () => void;
+  onImportData: (data: ExportResponse) => Promise<void>;
 }) {
   const importData: DropzoneOptions['onDrop'] = (acceptedFiles) => {
     if (acceptedFiles.length < 1) {

--- a/src/app/store/store.ts
+++ b/src/app/store/store.ts
@@ -5,6 +5,7 @@ import { RootState } from './types';
 
 declare global {
   interface Window {
+    // eslint-disable-next-line @typescript-eslint/method-signature-style
     __REDUX_DEVTOOLS_EXTENSION_COMPOSE__(options: any): typeof compose;
   }
 }

--- a/src/app/utils/cancel.ts
+++ b/src/app/utils/cancel.ts
@@ -5,7 +5,7 @@
  */
 export interface CancelToken {
   readonly canceled: boolean;
-  checkCanceled(): void;
+  checkCanceled: () => void;
 }
 
 /**

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
 declare const $DIM_VERSION: string;
 declare const $DIM_FLAVOR: 'release' | 'beta' | 'dev' | 'test';
 declare const $DIM_BUILD_DATE: string;


### PR DESCRIPTION
[`typescript-eslint` recommends](https://typescript-eslint.io/rules/method-signature-style/) enforcing property syntax for methods with this rule in strict / strictFunctionTypes mode since method syntax makes functions (unsoundly) bivariant over argument types even with `strictFunctionTypes` (whose purpose is making property syntax methods contravariant over arguments). So this lint more or less closes a loophole in strict mode.

This does result in a lot of changes and the one time this actually catches anything of significance (Organizer's `ColumnDefinition`) it's easier to just turn off, so if we prefer the slightly more concise method syntax that's fine with me too.

On the other hand we can make some of these `readonly` now, so that's a benefit.