### PR TITLE
fix missing level requirements on crafted perks on some guns

### DIFF
--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -326,7 +326,17 @@ function buildDefinedSocket(
       }
     }
   }
-
+  // if there's crafting data, sort plugs by their required level
+  // TO-DO: the order is correct in the original plugset def,
+  // we should address whatever is changing plug order in DIM
+  if (!_.isEmpty(craftingData)) {
+    plugOptions.sort(
+      compareBy((p) =>
+        // shove retired perks to the bottom (our choice) and consider requiredLevel:undefined to be 0 (bungie data works this way)
+        p.cannotCurrentlyRoll ? 999 : craftingData[p.plugDef.hash]?.requiredLevel ?? 0
+      )
+    );
+  }
   // If the socket category is the intrinsic trait, assume that there is only one option and plug it.
   let plugged: DimPlug | null = null;
   if (

--- a/src/app/item-popup/Socket.tsx
+++ b/src/app/item-popup/Socket.tsx
@@ -1,5 +1,4 @@
 import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
-import { compareBy } from 'app/utils/comparators';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import clsx from 'clsx';
 import Plug from './Plug';
@@ -22,19 +21,6 @@ export default function Socket({
   if (!socket.plugOptions.length) {
     return null;
   }
-  let plugOptions = socket.plugOptions;
-
-  // if this is a crafted item's plugset, sort plugs by their required level.
-  // TO-DO: the order is correct in the original plugset def,
-  // we should address whatever is changing plug order in DIM
-  if (socket.craftingData) {
-    plugOptions = [...plugOptions].sort(
-      compareBy((p) =>
-        // shove retired perks to the bottom (our choice) and consider requiredLevel:undefined to be 0 (bungie data works this way)
-        p.cannotCurrentlyRoll ? 999 : socket.craftingData![p.plugDef.hash]?.requiredLevel ?? 0
-      )
-    );
-  }
 
   return (
     <div
@@ -42,7 +28,7 @@ export default function Socket({
         hasMenu,
       })}
     >
-      {plugOptions.map((plug) => (
+      {socket.plugOptions.map((plug) => (
         <Plug
           key={plug.plugDef.hash}
           plug={plug}

--- a/src/app/item-popup/Socket.tsx
+++ b/src/app/item-popup/Socket.tsx
@@ -2,7 +2,6 @@ import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
 import { compareBy } from 'app/utils/comparators';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import clsx from 'clsx';
-import React from 'react';
 import Plug from './Plug';
 
 /**
@@ -30,7 +29,10 @@ export default function Socket({
   // we should address whatever is changing plug order in DIM
   if (socket.craftingData) {
     plugOptions = [...plugOptions].sort(
-      compareBy((p) => socket.craftingData![p.plugDef.hash]?.requiredLevel ?? 0)
+      compareBy((p) =>
+        // shove retired perks to the bottom (our choice) and consider requiredLevel:undefined to be 0 (bungie data works this way)
+        p.cannotCurrentlyRoll ? 999 : socket.craftingData![p.plugDef.hash]?.requiredLevel ?? 0
+      )
     );
   }
 


### PR DESCRIPTION
this fixes
- some guns' armory view missing level requirements in the perk tooltips
- the same guns' perk column being mis-sorted because of no level req info
- magazines and barrels never having been sorted right, and never having level reqs
- doesn't fix the two 0 req things being in the wrong order sometimes because their level reqs match. this would depend on preserving original plugset def order. maybe later.

seems to happen to reissued guns, which in the live version, need to maintain a full randomized plugSet including retired perks, but their crafting recipe needs a reusable plugset with only craftable stuff

the solution was, when creating a randomized plugset for item X, if there's a corresponding crafted X, get its corresponding plugset instead, and include those plugset entries, because they have proper reqs

before:
![image](https://user-images.githubusercontent.com/68782081/213138963-5e2b7eba-02bf-45b7-bd13-fe2a1eb45b03.png)

after:
![image](https://user-images.githubusercontent.com/68782081/213138992-d6f93ec4-6628-4d24-a580-6a0ac8a24306.png)
