### PR TITLE
Remove unused components from GetProfile

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -437,6 +437,9 @@ module.exports = (env) => {
         '$featureFlags.simulateMissingSockets': JSON.stringify(false),
         // Show a "pills" UI for filtering loadouts
         '$featureFlags.loadoutFilterPills': JSON.stringify(true),
+        // Request the PresentationNodes component only needed during
+        // Solstice to associate each character with a set of triumphs.
+        '$featureFlags.solsticePresentationNodes': JSON.stringify(false),
       }),
 
       new LodashModuleReplacementPlugin({

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -95,10 +95,12 @@ export function getStores(platform: DestinyAccount): Promise<DestinyProfileRespo
     DestinyComponentType.Metrics,
     DestinyComponentType.StringVariables,
     DestinyComponentType.ProfileProgression,
-    DestinyComponentType.Craftables,
-    DestinyComponentType.Transitory,
-    // TODO: This is only needed for event progress
-    DestinyComponentType.PresentationNodes
+    // This is a lot of data and currently not used.
+    // DestinyComponentType.Craftables,
+    DestinyComponentType.Transitory
+    // TODO: This is only needed for Solstice with its weird one node per character
+    // Re-enable this before Solstice
+    // DestinyComponentType.PresentationNodes
   );
 }
 

--- a/src/app/bungie-api/destiny2-api.ts
+++ b/src/app/bungie-api/destiny2-api.ts
@@ -71,8 +71,7 @@ export async function getLinkedAccounts(
  * Get the user's stores on this platform. This includes characters, vault, and item information.
  */
 export function getStores(platform: DestinyAccount): Promise<DestinyProfileResponse> {
-  return getProfile(
-    platform,
+  const components = [
     DestinyComponentType.Profiles,
     DestinyComponentType.ProfileInventories,
     DestinyComponentType.ProfileCurrencies,
@@ -95,13 +94,16 @@ export function getStores(platform: DestinyAccount): Promise<DestinyProfileRespo
     DestinyComponentType.Metrics,
     DestinyComponentType.StringVariables,
     DestinyComponentType.ProfileProgression,
+    DestinyComponentType.Transitory,
+
     // This is a lot of data and currently not used.
     // DestinyComponentType.Craftables,
-    DestinyComponentType.Transitory
-    // TODO: This is only needed for Solstice with its weird one node per character
-    // Re-enable this before Solstice
-    // DestinyComponentType.PresentationNodes
-  );
+  ];
+
+  if ($featureFlags.solsticePresentationNodes) {
+    components.push(DestinyComponentType.PresentationNodes);
+  }
+  return getProfile(platform, ...components);
 }
 
 /**

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -42,6 +42,11 @@ declare const $featureFlags: {
   simulateMissingSockets: boolean;
   /** Show a "pills" UI for filtering loadouts */
   loadoutFilterPills: boolean;
+  /**
+   * Request the PresentationNodes component only needed during
+   * Solstice to associate each character with a set of triumphs.
+   */
+  solsticePresentationNodes: boolean;
 };
 
 declare function ga(...params: string[]): void;


### PR DESCRIPTION
These components both are unused. In my measurements, 2/3rds of the savings come from craftables, 1/3rd from presentation nodes. This saves about 17% in compressed size and 20.5% in plain JSON, so it should reduce GetProfile traffic a bit and also make decoding the JSON faster.

|    | compressed | plain |
|---|-----------|--|
| beta | 473.04 kB | 4.99 MB  |
| this | 392.53 kB  | 3.97 MB |