### PR TITLE
fix 'out of date' indicator styling

### DIFF
--- a/src/app/shell/RefreshButton.m.scss
+++ b/src/app/shell/RefreshButton.m.scss
@@ -21,16 +21,14 @@
 .outOfDate {
   color: $red;
   background-color: #1b1b2d;
-  height: 14px;
-  width: 14px;
   padding: 2px;
   border-radius: 50%;
   position: absolute;
   bottom: -8px;
   right: -8px;
-
   :global(.app-icon) {
     font-size: 10px;
+    display: block;
   }
 }
 


### PR DESCRIPTION
inlineness and font sizes are hell.
this was offset weird, because despite the only text content being 10 font size, the bg color container was still 13px font size and therefore operating on its vertical spacing despite containing no characters.

![image](https://user-images.githubusercontent.com/68782081/213666825-d0ef006f-e514-4310-86dc-41bb755ad63b.png)
