### PR TITLE
Display Vendor items which have a pattern available

### DIFF
--- a/src/app/inventory/store/deepsight.ts
+++ b/src/app/inventory/store/deepsight.ts
@@ -29,7 +29,7 @@ export function buildDeepsightInfo(item: DimItem): DimDeepsight | undefined {
 }
 
 function getResonanceSocket(item: DimItem): DimSocket | undefined {
-  if (item.bucket.inWeapons && item.sockets) {
+  if (item.sockets && (item.bucket.inWeapons || item.vendor)) {
     return item.sockets.allSockets.find(isDeepsightResonanceSocket);
   }
 }

--- a/src/app/inventory/store/deepsight.ts
+++ b/src/app/inventory/store/deepsight.ts
@@ -1,3 +1,4 @@
+import { THE_FORBIDDEN_BUCKET } from 'app/search/d2-known-values';
 import { socketContainsPlugWithCategory } from 'app/utils/socket-utils';
 import { DestinyObjectiveProgress } from 'bungie-api-ts/destiny2';
 import { resonantElementTagsByObjectiveHash } from 'data/d2/crafting-resonant-elements';
@@ -29,7 +30,7 @@ export function buildDeepsightInfo(item: DimItem): DimDeepsight | undefined {
 }
 
 function getResonanceSocket(item: DimItem): DimSocket | undefined {
-  if (item.sockets && (item.bucket.inWeapons || item.vendor)) {
+  if (item.sockets && (item.bucket.inWeapons || item.bucket.hash === THE_FORBIDDEN_BUCKET)) {
     return item.sockets.allSockets.find(isDeepsightResonanceSocket);
   }
 }


### PR DESCRIPTION
This ended up being a simple fix as the check for deepsight items was skipped because vendor items are not in a weapon bucket.

I think the intention behind this check is essentially "is this a weapon" but I couldn't see a simple alternative to achieve this, so I’ve simply allowed checking vendor items too.

<img width="402" alt="image" src="https://user-images.githubusercontent.com/3736/214032213-b9c0c6b8-87fb-4964-aa67-db427c803e08.png">
