### PR TITLE
Add a "previous seasons" filter pill for loadouts

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -749,6 +749,7 @@
     "OnWrongCharacterAdvice": "Click here to find this character's highest Power items.",
     "OpenInOptimizer": "Optimize Armor",
     "PickMods": "Add armor mods",
+    "PreviousSeasons": "Previous Seasons",
     "PullFromPostmaster": "Collect Postmaster",
     "PullFromPostmasterNotification": "Pulling 1 Postmaster item to {{store}}.",
     "PullFromPostmasterNotification_female": "Pulling 1 Postmaster item to {{store}}.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* The Loadouts page has an automatic filter pill for loadouts that haven't been updated since the current season started.
+
 ## 7.53.0 <span class="changelog-date">(2023-01-22)</span>
 
 * On the Records and Armory pages, perks only shown on the collections/"curated" roll will now correctly be marked as unavailable on randomly rolled versions.

--- a/src/app/dim-ui/FilterPills.m.scss
+++ b/src/app/dim-ui/FilterPills.m.scss
@@ -42,6 +42,6 @@
 }
 
 .selected {
-  border-color: $orange;
+  border-color: $orange !important;
   background: rgba(0, 0, 0, 0.6);
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -674,6 +674,7 @@
     "OnlyItems": "Only equippable items, materials, and consumables can be added to a loadout.",
     "OpenInOptimizer": "Optimize Armor",
     "PickMods": "Add armor mods",
+    "PreviousSeasons": "Previous Seasons",
     "PullFromPostmaster": "Collect Postmaster",
     "PullFromPostmasterError": "Unable to pull from Postmaster: {{error}}.",
     "PullFromPostmasterGeneralError": "Unable to pull all items from Postmaster.",


### PR DESCRIPTION
As a gentle nudge to clean up old loadouts, this adds a "Previous Seasons" filter pill which shows loadouts that haven't been touched since the current season started.