### PR TITLE
Autocomplete test cleanup

### DIFF
--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |"rare curio" arctic haz| with caret at position 23 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {"rare curio" arctic haz} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -20,7 +20,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |"
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |"rare curio" or arctic haz| with caret at position 26 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {"rare curio" or arctic haz} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -40,7 +40,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |"
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |(is:a or is:b) and (is:c or multi w)| with caret at position 35 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {(is:a or is:b) and (is:c or multi w|)} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -60,7 +60,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |(
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |acd/0 fee| with caret at position 9 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {acd/0 fee} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -80,7 +80,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |a
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |ager's sce| with caret at position 10 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {ager's sce} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -100,7 +100,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |a
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |arctic  haz| with caret at position 11 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {arctic  haz} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -120,7 +120,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |a
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |arctic haz| with caret at position 10 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {arctic haz} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -140,7 +140,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |a
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |is:weapon arctic haz -is:exotic| with caret at position 20 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {is:weapon arctic haz| -is:exotic} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -160,7 +160,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |i
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |name:"foo" arctic haz| with caret at position 21 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {name:"foo" arctic haz} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -180,7 +180,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |n
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |rare curio or arctic haz| with caret at position 24 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {rare curio or arctic haz} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -200,7 +200,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |r
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |stat:rpm:200 first in, last| with caret at position 27 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {stat:rpm:200 first in, last} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -220,7 +220,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |s
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |the last word| with caret at position 13 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {the last word} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -240,7 +240,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |t
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |toil and trou| with caret at position 13 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {toil and trou} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -260,7 +260,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |t
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within multi-word query for |two-tail| with caret at position 8 with exact match 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within multi-word query for {two-tail} with exact match 1`] = `
 [
   {
     "highlightRange": {
@@ -280,7 +280,7 @@ exports[`autocompleteTermSuggestions autocomplete within multi-word query for |t
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |(is:blue jun)| with caret at position 11 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within query for {(is:blue ju|n)} 1`] = `
 [
   {
     "highlightRange": {
@@ -300,7 +300,7 @@ exports[`autocompleteTermSuggestions autocomplete within query for |(is:blue jun
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |is:bow is:void| with caret at position 11 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within query for {is:bow is:v|oid} 1`] = `
 [
   {
     "highlightRange": {
@@ -320,7 +320,7 @@ exports[`autocompleteTermSuggestions autocomplete within query for |is:bow is:vo
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |is:haspower is:b| with caret at position 16 1`] = `
+exports[`autocompleteTermSuggestions autocomplete within query for {is:haspower is:b} 1`] = `
 [
   {
     "highlightRange": {
@@ -355,9 +355,9 @@ exports[`autocompleteTermSuggestions autocomplete within query for |is:haspower 
 ]
 `;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |not(| with caret at position 4 1`] = `[]`;
+exports[`autocompleteTermSuggestions autocomplete within query for {not(} 1`] = `[]`;
 
-exports[`autocompleteTermSuggestions autocomplete within query for |season:>outl| with caret at position 12 1`] = `[]`;
+exports[`autocompleteTermSuggestions autocomplete within query for {season:>outl} 1`] = `[]`;
 
 exports[`filterComplete autocomplete terms for |is:b| 1`] = `
 [

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -6,51 +6,59 @@ import {
 } from './autocomplete';
 import { buildSearchConfig } from './search-config';
 
+/**
+ * Given a string like "foo ba|r", find where the "|" is and remove it,
+ * returning its index. This allows for readable test cases that depend on
+ * cursor position. If the cursor should be at the end of the string, it can be
+ * omitted entirely.
+ */
+function extractCaret(stringWithCaretPlaceholder: string): [caretIndex: number, query: string] {
+  const caretIndex = stringWithCaretPlaceholder.indexOf('|');
+  if (caretIndex == -1) {
+    return [stringWithCaretPlaceholder.length - 1, stringWithCaretPlaceholder];
+  }
+  return [caretIndex, stringWithCaretPlaceholder.replace('|', '')];
+}
+
 describe('autocompleteTermSuggestions', () => {
   const searchConfig = buildSearchConfig(2);
   const filterComplete = makeFilterComplete(searchConfig);
 
-  const cases: [query: string, caretIndex: number][] = [
-    ['is:haspower is:b', 16],
-    ['(is:blue jun)', 11],
-    ['is:bow is:void', 11],
-    ['season:>outl', 12],
-    ['not(', 4],
+  const cases: string[] = [
+    'is:haspower is:b',
+    '(is:blue ju|n)',
+    'is:bow is:v|oid',
+    'season:>outl',
+    'not(',
   ];
 
-  test.each(cases)(
-    'autocomplete within query for |%s| with caret at position %d',
-    (query: string, caretIndex: number) => {
-      const candidates = autocompleteTermSuggestions(
-        query,
-        caretIndex,
-        filterComplete,
-        searchConfig
-      );
-      expect(candidates).toMatchSnapshot();
-    }
-  );
+  test.each(cases)('autocomplete within query for {%s}', (queryWithCaret) => {
+    const [caretIndex, query] = extractCaret(queryWithCaret);
+    const candidates = autocompleteTermSuggestions(query, caretIndex, filterComplete, searchConfig);
+    expect(candidates).toMatchSnapshot();
+  });
 
-  const multiWordCases: [query: string, caretIndex: number, mockCandidate: string][] = [
-    ['arctic haz', 10, 'arctic haze'],
-    ['is:weapon arctic haz -is:exotic', 20, 'arctic haze'],
-    ['name:"foo" arctic haz', 21, 'arctic haze'],
-    ["ager's sce", 10, "ager's scepter"],
-    ['the last word', 13, 'the last word'],
-    ['acd/0 fee', 9, 'acd/0 feedback fence'],
-    ['stat:rpm:200 first in, last', 27, 'first in, last out'],
-    ['two-tail', 8, 'two-tailed fox'],
-    ['(is:a or is:b) and (is:c or multi w)', 35, 'multi word'],
-    ['arctic  haz', 11, 'arctic haze'],
-    ['"rare curio" arctic haz', 23, 'arctic haze'],
-    ['"rare curio" or arctic haz', 26, 'arctic haze'],
-    ['toil and trou', 13, 'toil and trouble'], // todo: not handled due to the `and`
-    ['rare curio or arctic haz', 24, 'arctic haze'], // todo: parser result is unexpected here
+  const multiWordCases: [query: string, mockCandidate: string][] = [
+    ['arctic haz', 'arctic haze'],
+    ['is:weapon arctic haz| -is:exotic', 'arctic haze'],
+    ['name:"foo" arctic haz', 'arctic haze'],
+    ["ager's sce", "ager's scepter"],
+    ['the last word', 'the last word'],
+    ['acd/0 fee', 'acd/0 feedback fence'],
+    ['stat:rpm:200 first in, last', 'first in, last out'],
+    ['two-tail', 'two-tailed fox'],
+    ['(is:a or is:b) and (is:c or multi w|)', 'multi word'],
+    ['arctic  haz', 'arctic haze'], // two spaces inbetween words
+    ['"rare curio" arctic haz', 'arctic haze'],
+    ['"rare curio" or arctic haz', 'arctic haze'],
+    ['toil and trou', 'toil and trouble'], // todo: not handled due to the `and`
+    ['rare curio or arctic haz', 'arctic haze'], // todo: parser result is unexpected here
   ];
 
   test.each(multiWordCases)(
-    'autocomplete within multi-word query for |%s| with caret at position %d with exact match',
-    (query: string, caretIndex: number, mockCandidate: string) => {
+    'autocomplete within multi-word query for {%s} with exact match',
+    (queryWithCaret: string, mockCandidate: string) => {
+      const [caretIndex, query] = extractCaret(queryWithCaret);
       const candidates = autocompleteTermSuggestions(
         query,
         caretIndex,

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -15,7 +15,7 @@ import { buildSearchConfig } from './search-config';
 function extractCaret(stringWithCaretPlaceholder: string): [caretIndex: number, query: string] {
   const caretIndex = stringWithCaretPlaceholder.indexOf('|');
   if (caretIndex == -1) {
-    return [stringWithCaretPlaceholder.length - 1, stringWithCaretPlaceholder];
+    return [stringWithCaretPlaceholder.length, stringWithCaretPlaceholder];
   }
   return [caretIndex, stringWithCaretPlaceholder.replace('|', '')];
 }


### PR DESCRIPTION
This makes the tests for autocomplete a bit easier to read by embedding the cursor position in the string. I also cleaned up the `traverseAST` function so that it can early-exit.