### PR TITLE
Make it easier to plumb data into item creation

### DIFF
--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -1,6 +1,5 @@
 import ItemGrid from 'app/armory/ItemGrid';
 import { addCompareItem } from 'app/compare/actions';
-import { settingSelector } from 'app/dim-api/selectors';
 import BungieImage, { bungieNetPath } from 'app/dim-ui/BungieImage';
 import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { DestinyTooltipText } from 'app/dim-ui/DestinyTooltipText';
@@ -55,7 +54,6 @@ export default function Armory({
   const allItems = useSelector(allItemsSelector);
   const isPhonePortrait = useIsPhonePortrait();
   const [socketOverrides, onPlugClicked] = useSocketOverrides();
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
   const createItemContext = useSelector(createItemContextSelector);
 
   const itemDef = defs.InventoryItem.get(itemHash);
@@ -70,13 +68,12 @@ export default function Armory({
     );
   }
 
-  // We apply socket overrides *twice* - once to set the original sockets, then to apply the user's chosen overrides
-  const item = applySocketOverrides(
-    defs,
-    applySocketOverrides(defs, itemWithoutSockets, customTotalStatsByClass, realItemSockets),
-    customTotalStatsByClass,
-    socketOverrides
-  );
+  const item = applySocketOverrides(createItemContext, itemWithoutSockets, {
+    // Start with the item's current sockets
+    ...realItemSockets,
+    // Then apply whatever the user chose in the Armory UI
+    ...socketOverrides,
+  });
 
   const storeItems = allItems.filter((i) => i.hash === itemHash);
 

--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -7,7 +7,7 @@ import { DestinyTooltipText } from 'app/dim-ui/DestinyTooltipText';
 import ElementIcon from 'app/dim-ui/ElementIcon';
 import { t } from 'app/i18next-t';
 import ItemIcon from 'app/inventory/ItemIcon';
-import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
+import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
 import { makeFakeItem } from 'app/inventory/store/d2-item-factory';
 import {
   applySocketOverrides,
@@ -52,21 +52,15 @@ export default function Armory({
 }) {
   const dispatch = useThunkDispatch();
   const defs = useD2Definitions()!;
-  const buckets = useSelector(bucketsSelector)!;
   const allItems = useSelector(allItemsSelector);
   const isPhonePortrait = useIsPhonePortrait();
   const [socketOverrides, onPlugClicked] = useSocketOverrides();
   const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
 
   const itemDef = defs.InventoryItem.get(itemHash);
 
-  const itemWithoutSockets = makeFakeItem(
-    defs,
-    buckets,
-    undefined,
-    itemHash,
-    customTotalStatsByClass
-  );
+  const itemWithoutSockets = makeFakeItem(createItemContext, itemHash);
 
   if (!itemWithoutSockets) {
     return (
@@ -217,13 +211,7 @@ export default function Armory({
           {itemDef.setData?.itemList && (
             <ol>
               {itemDef.setData.itemList.map((h) => {
-                const stepItem = makeFakeItem(
-                  defs,
-                  buckets,
-                  undefined,
-                  h.itemHash,
-                  customTotalStatsByClass
-                );
+                const stepItem = makeFakeItem(createItemContext, h.itemHash);
                 return (
                   stepItem && (
                     <li

--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -1,5 +1,6 @@
 import ItemGrid from 'app/armory/ItemGrid';
 import { addCompareItem } from 'app/compare/actions';
+import { settingSelector } from 'app/dim-api/selectors';
 import BungieImage, { bungieNetPath } from 'app/dim-ui/BungieImage';
 import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { DestinyTooltipText } from 'app/dim-ui/DestinyTooltipText';
@@ -55,10 +56,17 @@ export default function Armory({
   const allItems = useSelector(allItemsSelector);
   const isPhonePortrait = useIsPhonePortrait();
   const [socketOverrides, onPlugClicked] = useSocketOverrides();
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
 
   const itemDef = defs.InventoryItem.get(itemHash);
 
-  const itemWithoutSockets = makeFakeItem(defs, buckets, undefined, itemHash);
+  const itemWithoutSockets = makeFakeItem(
+    defs,
+    buckets,
+    undefined,
+    itemHash,
+    customTotalStatsByClass
+  );
 
   if (!itemWithoutSockets) {
     return (
@@ -71,7 +79,8 @@ export default function Armory({
   // We apply socket overrides *twice* - once to set the original sockets, then to apply the user's chosen overrides
   const item = applySocketOverrides(
     defs,
-    applySocketOverrides(defs, itemWithoutSockets, realItemSockets),
+    applySocketOverrides(defs, itemWithoutSockets, customTotalStatsByClass, realItemSockets),
+    customTotalStatsByClass,
     socketOverrides
   );
 
@@ -208,7 +217,13 @@ export default function Armory({
           {itemDef.setData?.itemList && (
             <ol>
               {itemDef.setData.itemList.map((h) => {
-                const stepItem = makeFakeItem(defs, buckets, undefined, h.itemHash);
+                const stepItem = makeFakeItem(
+                  defs,
+                  buckets,
+                  undefined,
+                  h.itemHash,
+                  customTotalStatsByClass
+                );
                 return (
                   stepItem && (
                     <li

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -1,3 +1,4 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
 import { locateItem } from 'app/inventory/locate-item';
@@ -66,6 +67,7 @@ export default function Compare({ session }: { session: CompareSession }) {
   const defs = useD2Definitions()!;
   const [compareBaseStats, setCompareBaseStats] = useSetting('compareBaseStats');
   const [assumeWeaponMasterwork, setAssumeWeaponMasterwork] = useSetting('compareWeaponMasterwork');
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
   const rawCompareItems = useSelector(compareItemsSelector(session.vendorCharacterId));
   const organizerLink = useSelector(compareOrganizerLinkSelector);
 
@@ -100,7 +102,7 @@ export default function Compare({ session }: { session: CompareSession }) {
               (plugOption) => plugOption.plugDef.investmentStats[0]?.value
             );
             if (fullMasterworkPlug) {
-              return applySocketOverrides(defs, i, {
+              return applySocketOverrides(defs, i, customTotalStatsByClass, {
                 [y2MasterworkSocket.socketIndex]: fullMasterworkPlug.plugDef.hash,
               });
             }
@@ -108,11 +110,13 @@ export default function Compare({ session }: { session: CompareSession }) {
           return i;
         });
       }
-      items = items.map((i) => applySocketOverrides(defs, i, socketOverrides[i.id]));
+      items = items.map((i) =>
+        applySocketOverrides(defs, i, customTotalStatsByClass, socketOverrides[i.id])
+      );
     }
 
     return items;
-  }, [defs, doAssumeWeaponMasterworks, rawCompareItems, socketOverrides]);
+  }, [defs, doAssumeWeaponMasterworks, rawCompareItems, socketOverrides, customTotalStatsByClass]);
 
   const cancel = useCallback(() => {
     dispatch(endCompareSession());

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -1,7 +1,7 @@
-import { settingSelector } from 'app/dim-api/selectors';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
 import { locateItem } from 'app/inventory/locate-item';
+import { createItemContextSelector } from 'app/inventory/selectors';
 import {
   applySocketOverrides,
   useSocketOverridesForItems,
@@ -67,7 +67,7 @@ export default function Compare({ session }: { session: CompareSession }) {
   const defs = useD2Definitions()!;
   const [compareBaseStats, setCompareBaseStats] = useSetting('compareBaseStats');
   const [assumeWeaponMasterwork, setAssumeWeaponMasterwork] = useSetting('compareWeaponMasterwork');
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
   const rawCompareItems = useSelector(compareItemsSelector(session.vendorCharacterId));
   const organizerLink = useSelector(compareOrganizerLinkSelector);
 
@@ -86,37 +86,33 @@ export default function Compare({ session }: { session: CompareSession }) {
   // Produce new items which have had their sockets changed
   const compareItems = useMemo(() => {
     let items = rawCompareItems;
-    if (defs) {
-      if (doAssumeWeaponMasterworks) {
-        items = items.map((i) => {
-          const y2MasterworkSocket = i.sockets?.allSockets.find(
-            (socket) => socket.socketDefinition.socketTypeHash === weaponMasterworkY2SocketTypeHash
+    if (doAssumeWeaponMasterworks) {
+      items = items.map((i) => {
+        const y2MasterworkSocket = i.sockets?.allSockets.find(
+          (socket) => socket.socketDefinition.socketTypeHash === weaponMasterworkY2SocketTypeHash
+        );
+        const plugSet = y2MasterworkSocket?.plugSet;
+        const plugged = y2MasterworkSocket?.plugged;
+        if (plugSet && plugged) {
+          const fullMasterworkPlug = _.maxBy(
+            plugSet.plugs.filter(
+              (p) => p.plugDef.plug.plugCategoryHash === plugged.plugDef.plug.plugCategoryHash
+            ),
+            (plugOption) => plugOption.plugDef.investmentStats[0]?.value
           );
-          const plugSet = y2MasterworkSocket?.plugSet;
-          const plugged = y2MasterworkSocket?.plugged;
-          if (plugSet && plugged) {
-            const fullMasterworkPlug = _.maxBy(
-              plugSet.plugs.filter(
-                (p) => p.plugDef.plug.plugCategoryHash === plugged.plugDef.plug.plugCategoryHash
-              ),
-              (plugOption) => plugOption.plugDef.investmentStats[0]?.value
-            );
-            if (fullMasterworkPlug) {
-              return applySocketOverrides(defs, i, customTotalStatsByClass, {
-                [y2MasterworkSocket.socketIndex]: fullMasterworkPlug.plugDef.hash,
-              });
-            }
+          if (fullMasterworkPlug) {
+            return applySocketOverrides(createItemContext, i, {
+              [y2MasterworkSocket.socketIndex]: fullMasterworkPlug.plugDef.hash,
+            });
           }
-          return i;
-        });
-      }
-      items = items.map((i) =>
-        applySocketOverrides(defs, i, customTotalStatsByClass, socketOverrides[i.id])
-      );
+        }
+        return i;
+      });
     }
+    items = items.map((i) => applySocketOverrides(createItemContext, i, socketOverrides[i.id]));
 
     return items;
-  }, [defs, doAssumeWeaponMasterworks, rawCompareItems, socketOverrides, customTotalStatsByClass]);
+  }, [createItemContext, doAssumeWeaponMasterworks, rawCompareItems, socketOverrides]);
 
   const cancel = useCallback(() => {
     dispatch(endCompareSession());

--- a/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
@@ -1,11 +1,10 @@
-import { settingSelector } from 'app/dim-api/selectors';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import Sheet from 'app/dim-ui/Sheet';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import ItemIcon from 'app/inventory/ItemIcon';
-import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
+import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { deleteLoadout, updateLoadout } from 'app/loadout-drawer/actions';
 import {
@@ -58,25 +57,16 @@ export default function D1LoadoutDrawer({
   const defs = useD1Definitions()!;
 
   const allItems = useSelector(allItemsSelector);
-  const buckets = useSelector(bucketsSelector)!;
   const [showingItemPicker, setShowingItemPicker] = useState(false);
   const [loadout, setLoadout] = useState(initialLoadout);
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
 
   const loadoutItems = loadout?.items;
 
   // Turn loadout items into real DimItems
   const [items, warnitems] = useMemo(
-    () =>
-      getItemsFromLoadoutItems(
-        loadoutItems,
-        defs,
-        storeId,
-        buckets,
-        allItems,
-        customTotalStatsByClass
-      ),
-    [loadoutItems, defs, storeId, buckets, allItems, customTotalStatsByClass]
+    () => getItemsFromLoadoutItems(createItemContext, loadoutItems, storeId, allItems),
+    [createItemContext, loadoutItems, storeId, allItems]
   );
 
   const onAddItem = useCallback(

--- a/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
@@ -1,3 +1,4 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import Sheet from 'app/dim-ui/Sheet';
@@ -60,13 +61,22 @@ export default function D1LoadoutDrawer({
   const buckets = useSelector(bucketsSelector)!;
   const [showingItemPicker, setShowingItemPicker] = useState(false);
   const [loadout, setLoadout] = useState(initialLoadout);
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
 
   const loadoutItems = loadout?.items;
 
   // Turn loadout items into real DimItems
   const [items, warnitems] = useMemo(
-    () => getItemsFromLoadoutItems(loadoutItems, defs, storeId, buckets, allItems),
-    [loadoutItems, defs, storeId, buckets, allItems]
+    () =>
+      getItemsFromLoadoutItems(
+        loadoutItems,
+        defs,
+        storeId,
+        buckets,
+        allItems,
+        customTotalStatsByClass
+      ),
+    [loadoutItems, defs, storeId, buckets, allItems, customTotalStatsByClass]
   );
 
   const onAddItem = useCallback(

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -1,6 +1,5 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { currentAccountSelector } from 'app/accounts/selectors';
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { apiPermissionGrantedSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
@@ -14,9 +13,9 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { createAction } from 'typesafe-actions';
 import { TagCommand, TagValue } from './dim-item-info';
-import { InventoryBuckets } from './inventory-buckets';
 import { DimItem } from './item-types';
 import { AccountCurrency, DimCharacterStat, DimStore } from './store-types';
+import { CreateItemContext } from './store/d2-item-factory';
 
 /**
  * Update the computed/massaged state of inventory, plus account-wide info like currencies.
@@ -73,11 +72,7 @@ export const itemMoved = createAction('inventory/MOVE_ITEM')<{
 export const awaItemChanged = createAction('inventory/AWA_CHANGE')<{
   item: DimItem | null;
   changes: DestinyItemChangeResponse;
-  defs: D2ManifestDefinitions;
-  buckets: InventoryBuckets;
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  };
+  createItemContext: CreateItemContext;
 }>();
 
 /*

--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -75,6 +75,9 @@ export const awaItemChanged = createAction('inventory/AWA_CHANGE')<{
   changes: DestinyItemChangeResponse;
   defs: D2ManifestDefinitions;
   buckets: InventoryBuckets;
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  };
 }>();
 
 /*

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -1,5 +1,6 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { settingSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
@@ -241,7 +242,8 @@ function refreshItemAfterAWA(changes: DestinyItemChangeResponse): ThunkResult {
     const defs = d2ManifestSelector(getState())!;
     const buckets = d2BucketsSelector(getState())!;
     const stores = storesSelector(getState());
-    const newItem = makeItemSingle(defs, buckets, changes.item, stores);
+    const customTotalStatsByClass = settingSelector('customTotalStatsByClass')(getState());
+    const newItem = makeItemSingle(defs, buckets, changes.item, stores, customTotalStatsByClass);
 
     dispatch(
       awaItemChanged({
@@ -249,6 +251,7 @@ function refreshItemAfterAWA(changes: DestinyItemChangeResponse): ThunkResult {
         changes,
         defs: d2ManifestSelector(getState())!,
         buckets: d2BucketsSelector(getState())!,
+        customTotalStatsByClass,
       })
     );
   };

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -1,6 +1,5 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { settingSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
@@ -28,8 +27,8 @@ import { showNotification } from '../notifications/notifications';
 import { awaItemChanged } from './actions';
 import { DimItem, DimSocket } from './item-types';
 import {
+  createItemContextSelector,
   currentStoreSelector,
-  d2BucketsSelector,
   profileResponseSelector,
   storesSelector,
 } from './selectors';
@@ -239,19 +238,15 @@ async function awaInsertSocketPlug(
  */
 function refreshItemAfterAWA(changes: DestinyItemChangeResponse): ThunkResult {
   return async (dispatch, getState) => {
-    const defs = d2ManifestSelector(getState())!;
-    const buckets = d2BucketsSelector(getState())!;
+    const createItemContext = createItemContextSelector(getState());
     const stores = storesSelector(getState());
-    const customTotalStatsByClass = settingSelector('customTotalStatsByClass')(getState());
-    const newItem = makeItemSingle(defs, buckets, changes.item, stores, customTotalStatsByClass);
+    const newItem = makeItemSingle(createItemContext, changes.item, stores);
 
     dispatch(
       awaItemChanged({
         item: newItem,
         changes,
-        defs: d2ManifestSelector(getState())!,
-        buckets: d2BucketsSelector(getState())!,
-        customTotalStatsByClass,
+        createItemContext,
       })
     );
   };

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -42,7 +42,6 @@ import {
 } from './actions';
 import { ArtifactXP } from './ArtifactXP';
 import { cleanInfos } from './dim-item-info';
-import { InventoryBuckets } from './inventory-buckets';
 import { DimItem } from './item-types';
 import { ItemPowerSet } from './ItemPowerSet';
 import { d2BucketsSelector, storesLoadedSelector, storesSelector } from './selectors';
@@ -52,7 +51,7 @@ import {
   getCharacterStatsData as getD1CharacterStatsData,
   hasAffectingClassified,
 } from './store/character-utils';
-import { processItems } from './store/d2-item-factory';
+import { CreateItemContext, processItems } from './store/d2-item-factory';
 import { getCharacterStatsData, makeCharacter, makeVault } from './store/d2-store-factory';
 import { resetItemIndexGenerator } from './store/item-index';
 import { getArtifactBonus } from './stores-helpers';
@@ -259,7 +258,7 @@ function loadStoresData(account: DestinyAccount): ThunkResult<DimStore[] | undef
       try {
         const { readOnly } = getState().inventory;
 
-        const [defs, profileInfo] = await Promise.all([
+        const [defs, profileResponse] = await Promise.all([
           dispatch(getDefinitions())!,
           dispatch(loadProfile(account)),
         ]);
@@ -269,7 +268,7 @@ function loadStoresData(account: DestinyAccount): ThunkResult<DimStore[] | undef
           return;
         }
 
-        if (!defs || !profileInfo) {
+        if (!defs || !profileResponse) {
           return;
         }
 
@@ -278,10 +277,12 @@ function loadStoresData(account: DestinyAccount): ThunkResult<DimStore[] | undef
         const buckets = d2BucketsSelector(getState())!;
         const customTotalStatsByClass = settingSelector('customTotalStatsByClass')(getState());
         const stores = buildStores(
-          defs,
-          buckets,
-          profileInfo,
-          customTotalStatsByClass,
+          {
+            defs,
+            buckets,
+            customTotalStatsByClass,
+            profileResponse,
+          },
           transaction
         );
 
@@ -298,7 +299,7 @@ function loadStoresData(account: DestinyAccount): ThunkResult<DimStore[] | undef
         }
 
         // TODO: we can start moving some of this stuff to selectors? characters too
-        const currencies = processCurrencies(profileInfo, defs);
+        const currencies = processCurrencies(profileResponse, defs);
 
         stopTimer();
 
@@ -347,20 +348,17 @@ function loadStoresData(account: DestinyAccount): ThunkResult<DimStore[] | undef
 }
 
 export function buildStores(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  profileInfo: DestinyProfileResponse,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  },
+  createItemContext: CreateItemContext,
   transaction?: Transaction
 ): DimStore[] {
   // TODO: components may be hidden (privacy)
 
+  const { defs, profileResponse } = createItemContext;
+
   if (
-    !profileInfo.profileInventory.data ||
-    !profileInfo.characterInventories.data ||
-    !profileInfo.characters.data
+    !profileResponse.profileInventory.data ||
+    !profileResponse.characterInventories.data ||
+    !profileResponse.characters.data
   ) {
     errorLog(
       'd2-stores',
@@ -369,22 +367,15 @@ export function buildStores(
     throw new DimError('BungieService.MissingInventory');
   }
 
-  const lastPlayedDate = findLastPlayedDate(profileInfo);
+  const lastPlayedDate = findLastPlayedDate(profileResponse);
 
   const processSpan = transaction?.startChild({
     op: 'processItems',
   });
-  const vault = processVault(defs, buckets, profileInfo, customTotalStatsByClass);
+  const vault = processVault(createItemContext);
 
-  const characters = Object.keys(profileInfo.characters.data).map((characterId) =>
-    processCharacter(
-      defs,
-      buckets,
-      characterId,
-      profileInfo,
-      lastPlayedDate,
-      customTotalStatsByClass
-    )
+  const characters = Object.keys(profileResponse.characters.data).map((characterId) =>
+    processCharacter(createItemContext, characterId, lastPlayedDate)
   );
   processSpan?.finish();
 
@@ -392,7 +383,7 @@ export function buildStores(
 
   const allItems = stores.flatMap((s) => s.items);
   const bucketsWithClassifieds = getBucketsWithClassifiedItems(allItems);
-  const characterProgress = getCharacterProgressions(profileInfo);
+  const characterProgress = getCharacterProgressions(profileResponse);
 
   for (const s of stores) {
     updateBasePower(
@@ -402,7 +393,7 @@ export function buildStores(
       characterProgress,
       // optional chaining here accounts for an edge-case, possible, but type-unadvertised,
       // missing artifact power bonus. please keep this here.
-      profileInfo.profileProgression?.data?.seasonalArtifact?.powerBonusProgression
+      profileResponse.profileProgression?.data?.seasonalArtifact?.powerBonusProgression
         ?.progressionHash,
       bucketsWithClassifieds
     );
@@ -430,25 +421,16 @@ function processCurrencies(profileInfo: DestinyProfileResponse, defs: D2Manifest
  * Process a single character from its raw form to a DIM store, with all the items.
  */
 function processCharacter(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
+  createItemContext: CreateItemContext,
   characterId: string,
-  profileInfo: DestinyProfileResponse,
-  lastPlayedDate: Date,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+  lastPlayedDate: Date
 ): DimStore {
-  const character = profileInfo.characters.data![characterId];
-  const characterInventory = profileInfo.characterInventories.data?.[characterId]?.items || [];
-  const profileInventory = profileInfo.profileInventory.data?.items || [];
-  const characterEquipment = profileInfo.characterEquipment.data?.[characterId]?.items || [];
-  const profileRecords = profileInfo.profileRecords?.data;
-  const itemComponents = profileInfo.itemComponents;
-
-  const characterProgressions = getCharacterProgressions(profileInfo, characterId);
-  const uninstancedItemObjectives = characterProgressions?.uninstancedItemObjectives;
-  const uninstancedItemPerks = characterProgressions?.uninstancedItemPerks;
+  const { defs, buckets, profileResponse } = createItemContext;
+  const character = profileResponse.characters.data![characterId];
+  const characterInventory = profileResponse.characterInventories.data?.[characterId]?.items || [];
+  const profileInventory = profileResponse.profileInventory.data?.items || [];
+  const characterEquipment = profileResponse.characterEquipment.data?.[characterId]?.items || [];
+  const profileRecords = profileResponse.profileRecords?.data;
 
   const store = makeCharacter(defs, character, lastPlayedDate, profileRecords);
 
@@ -465,34 +447,15 @@ function processCharacter(
     }
   }
 
-  const processedItems = processItems(
-    defs,
-    buckets,
-    store,
-    items,
-    itemComponents,
-    customTotalStatsByClass,
-    uninstancedItemObjectives,
-    profileRecords,
-    uninstancedItemPerks
-  );
-  store.items = processedItems;
+  store.items = processItems(createItemContext, store, items);
   return store;
 }
 
-function processVault(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  profileInfo: DestinyProfileResponse,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
-): DimStore {
-  const profileInventory = profileInfo.profileInventory.data
-    ? profileInfo.profileInventory.data.items
+function processVault(createItemContext: CreateItemContext): DimStore {
+  const { buckets, profileResponse } = createItemContext;
+  const profileInventory = profileResponse.profileInventory.data
+    ? profileResponse.profileInventory.data.items
     : [];
-  const profileRecords = profileInfo.profileRecords?.data; // Not present in the initial load
-  const itemComponents = profileInfo.itemComponents;
 
   const store = makeVault();
 
@@ -505,18 +468,7 @@ function processVault(
     }
   }
 
-  const processedItems = processItems(
-    defs,
-    buckets,
-    store,
-    items,
-    itemComponents,
-    customTotalStatsByClass,
-    undefined,
-    profileRecords
-  );
-  store.items = processedItems;
-
+  store.items = processItems(createItemContext, store, items);
   return store;
 }
 

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -101,8 +101,10 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     }
 
     case getType(actions.awaItemChanged): {
-      const { changes, item, defs, buckets } = action.payload;
-      return produce(state, (draft) => awaItemChanged(draft, changes, item, defs, buckets));
+      const { changes, item, defs, buckets, customTotalStatsByClass } = action.payload;
+      return produce(state, (draft) =>
+        awaItemChanged(draft, changes, item, defs, buckets, customTotalStatsByClass)
+      );
     }
 
     case getType(actions.error):
@@ -435,7 +437,10 @@ function awaItemChanged(
   changes: DestinyItemChangeResponse,
   item: DimItem | null,
   defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets
+  buckets: InventoryBuckets,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ) {
   // Replace item
   if (!item) {
@@ -527,7 +532,14 @@ function awaItemChanged(
       currency.quantity = Math.min(max, currency.quantity + addedItemComponent.quantity);
     } else if (addedItemComponent.itemInstanceId) {
       const addedOwner = getSource(addedItemComponent);
-      const addedItem = makeItem(defs, buckets, undefined, addedItemComponent, addedOwner);
+      const addedItem = makeItem(
+        defs,
+        buckets,
+        undefined,
+        addedItemComponent,
+        addedOwner,
+        customTotalStatsByClass
+      );
       if (addedItem) {
         addItem(addedOwner, addedItem);
       }
@@ -539,7 +551,14 @@ function awaItemChanged(
         (i) => i.amount
       );
       let addAmount = addedItemComponent.quantity;
-      const addedItem = makeItem(defs, buckets, undefined, addedItemComponent, target);
+      const addedItem = makeItem(
+        defs,
+        buckets,
+        undefined,
+        addedItemComponent,
+        target,
+        customTotalStatsByClass
+      );
       if (!addedItem) {
         continue;
       }

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -1,6 +1,6 @@
 import { ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { destinyVersionSelector } from 'app/accounts/selectors';
-import { currentProfileSelector, settingsSelector } from 'app/dim-api/selectors';
+import { currentProfileSelector, settingSelector, settingsSelector } from 'app/dim-api/selectors';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { emptyObject, emptySet } from 'app/utils/empty';
@@ -15,6 +15,7 @@ import { characterSortImportanceSelector, characterSortSelector } from '../setti
 import { getTag, ItemInfos } from './dim-item-info';
 import { DimItem } from './item-types';
 import { collectNotesHashtags } from './note-hashtags';
+import { CreateItemContext } from './store/d2-item-factory';
 import { getCurrentStore, getVault } from './stores-helpers';
 
 /** All stores, unsorted. */
@@ -164,6 +165,22 @@ export const craftingMaterialCountsSelector = createSelector(
     }
     return results;
   }
+);
+
+/**
+ * All the dependencies for item creation. Don't use this before profile is loaded...
+ */
+export const createItemContextSelector = createSelector(
+  d2ManifestSelector,
+  profileResponseSelector,
+  bucketsSelector,
+  (state: RootState) => settingSelector('customTotalStatsByClass')(state),
+  (defs, profileResponse, buckets, customTotalStatsByClass): CreateItemContext => ({
+    defs: defs!,
+    buckets: buckets!,
+    profileResponse: profileResponse!,
+    customTotalStatsByClass,
+  })
 );
 
 const STORE_SPECIFIC_OWNERSHIP_BUCKETS = [

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -240,10 +240,6 @@ export function makeItem(
   const profileRecords = profileResponse.profileRecords?.data;
   const characterProgressions =
     owner && !owner?.isVault ? profileResponse.characterProgressions?.data?.[owner.id] : undefined;
-  const uninstancedItemObjectives = characterProgressions?.uninstancedItemObjectives;
-  const uninstancedItemPerks = characterProgressions?.uninstancedItemPerks;
-  const itemUninstancedObjectives = uninstancedItemObjectives?.[item.itemHash];
-  const itemUninstancedPerks = uninstancedItemPerks?.[item.itemHash]?.perks;
 
   const itemInstanceData: Partial<DestinyItemInstanceComponent> = item.itemInstanceId
     ? itemComponents?.instances.data?.[item.itemInstanceId] ?? emptyObject()
@@ -614,6 +610,8 @@ export function makeItem(
     const itemInstancedObjectives = item.itemInstanceId
       ? itemComponents?.objectives?.data?.[item.itemInstanceId]?.objectives
       : undefined;
+    const uninstancedItemObjectives = characterProgressions?.uninstancedItemObjectives;
+    const itemUninstancedObjectives = uninstancedItemObjectives?.[item.itemHash];
 
     createdItem.objectives = buildObjectives(
       itemDef,
@@ -626,6 +624,8 @@ export function makeItem(
   }
 
   if (itemDef.perks?.length) {
+    const uninstancedItemPerks = characterProgressions?.uninstancedItemPerks;
+    const itemUninstancedPerks = uninstancedItemPerks?.[item.itemHash]?.perks;
     const perks = itemDef.perks.filter(
       (p, i) =>
         p.perkVisibility === ItemPerkVisibility.Visible &&

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -78,6 +78,9 @@ export function processItems(
   owner: DimStore,
   items: DestinyItemComponent[],
   itemComponents: DestinyItemComponentSetOfint64,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  },
   uninstancedItemObjectives?: DestinyCharacterProgressionComponent['uninstancedItemObjectives'],
   profileRecords?: DestinyProfileRecordsComponent,
   uninstancedItemPerks?: DestinyCharacterProgressionComponent['uninstancedItemPerks']
@@ -97,6 +100,7 @@ export function processItems(
         itemComponents,
         item,
         owner,
+        customTotalStatsByClass,
         itemUninstancedObjectives,
         itemUninstancedPerks,
         profileRecords
@@ -159,6 +163,9 @@ export function makeFakeItem(
   buckets: InventoryBuckets,
   itemComponents: DestinyItemComponentSetOfint64 | undefined,
   itemHash: number,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  },
   itemInstanceId?: string,
   quantity?: number,
   profileRecords?: DestinyProfileRecordsComponent,
@@ -185,6 +192,7 @@ export function makeFakeItem(
       versionNumber: defs.InventoryItem.get(itemHash)?.quality?.currentVersion,
     },
     undefined,
+    customTotalStatsByClass,
     undefined,
     undefined,
     profileRecords
@@ -204,7 +212,10 @@ export function makeItemSingle(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
   item: DestinyItemResponse,
-  stores: DimStore[]
+  stores: DimStore[],
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ): DimItem | null {
   if (!item.item.data) {
     return null;
@@ -237,7 +248,8 @@ export function makeItemSingle(
       objectives: m(item.objectives),
     },
     item.item.data,
-    owner
+    owner,
+    customTotalStatsByClass
   );
 }
 
@@ -258,6 +270,9 @@ export function makeItem(
   itemComponents: DestinyItemComponentSetOfint64 | undefined,
   item: DestinyItemComponent,
   owner: DimStore | undefined,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  },
   /** this item's uninstanced objectives */
   itemUninstancedObjectives?: DestinyObjectiveProgress[],
   /** this item's uninstanced perks */
@@ -625,7 +640,7 @@ export function makeItem(
   }
 
   try {
-    createdItem.stats = buildStats(defs, createdItem, itemDef);
+    createdItem.stats = buildStats(defs, createdItem, customTotalStatsByClass, itemDef);
   } catch (e) {
     errorLog('d2-stores', `Error building stats for ${createdItem.name}`, item, itemDef, e);
     reportException('Stats', e, { itemHash: item.itemHash });

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -15,7 +15,6 @@ import {
   BucketCategory,
   ComponentPrivacySetting,
   DestinyAmmunitionType,
-  DestinyCharacterProgressionComponent,
   DestinyClass,
   DestinyInventoryItemDefinition,
   DestinyItemComponent,
@@ -25,8 +24,7 @@ import {
   DestinyItemSubType,
   DestinyItemTooltipNotification,
   DestinyObjectiveProgress,
-  DestinyPerkReference,
-  DestinyProfileRecordsComponent,
+  DestinyProfileResponse,
   DictionaryComponentResponse,
   ItemBindStatus,
   ItemLocation,
@@ -66,45 +64,18 @@ const collectiblesByItemHash = memoizeOne(
 
 /**
  * Process an entire list of items into DIM items.
- * @param owner the ID of the owning store.
- * @param items a list of "raw" items from the Destiny API
- * @param previousItems a set of item IDs representing the previous store's items
- * @param newItems a set of item IDs representing the previous list of new items
- * @return a promise for the list of items
  */
 export function processItems(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
+  context: CreateItemContext,
   owner: DimStore,
-  items: DestinyItemComponent[],
-  itemComponents: DestinyItemComponentSetOfint64,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  },
-  uninstancedItemObjectives?: DestinyCharacterProgressionComponent['uninstancedItemObjectives'],
-  profileRecords?: DestinyProfileRecordsComponent,
-  uninstancedItemPerks?: DestinyCharacterProgressionComponent['uninstancedItemPerks']
+  items: DestinyItemComponent[]
 ): DimItem[] {
   const result: DimItem[] = [];
 
   for (const item of items) {
     let createdItem: DimItem | null = null;
-
-    const itemUninstancedObjectives = uninstancedItemObjectives?.[item.itemHash];
-    const itemUninstancedPerks = uninstancedItemPerks?.[item.itemHash]?.perks;
-
     try {
-      createdItem = makeItem(
-        defs,
-        buckets,
-        itemComponents,
-        item,
-        owner,
-        customTotalStatsByClass,
-        itemUninstancedObjectives,
-        itemUninstancedPerks,
-        profileRecords
-      );
+      createdItem = makeItem(context, item, owner);
     } catch (e) {
       errorLog('d2-stores', 'Error processing item', item, e);
       reportException('Processing Dim item', e);
@@ -123,7 +94,7 @@ export function processItems(
       // an exception occurred, or the item lacks a definition
       // not all of these should cause the store to consider itself hadErrors.
       // dummies and invisible items are not a big deal
-
+      const defs = context.defs;
       const bucketDef = defs.InventoryBucket[item.bucketHash];
       // if it's a named, non-invisible bucket, it may be a problem that the item wasn't generated
       if (
@@ -159,25 +130,17 @@ const getClassTypeNameLocalized = _.memoize((type: DestinyClass, defs: D2Manifes
 
 /** Make a "fake" item from other information - used for Collectibles, etc. */
 export function makeFakeItem(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  itemComponents: DestinyItemComponentSetOfint64 | undefined,
+  context: CreateItemContext,
   itemHash: number,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  },
-  itemInstanceId?: string,
-  quantity?: number,
-  profileRecords?: DestinyProfileRecordsComponent,
-  allowWishList?: boolean
+  itemInstanceId = '0',
+  quantity = 1,
+  allowWishList = false
 ): DimItem | null {
   const item = makeItem(
-    defs,
-    buckets,
-    itemComponents,
+    context,
     {
       itemHash,
-      itemInstanceId: itemInstanceId ?? '0',
+      itemInstanceId: itemInstanceId,
       quantity: quantity ?? 1,
       bindStatus: ItemBindStatus.NotBound,
       location: ItemLocation.Vendor,
@@ -189,13 +152,9 @@ export function makeFakeItem(
       isWrapper: false,
       tooltipNotificationIndexes: [],
       metricObjective: {} as DestinyObjectiveProgress,
-      versionNumber: defs.InventoryItem.get(itemHash)?.quality?.currentVersion,
+      versionNumber: context.defs.InventoryItem.get(itemHash)?.quality?.currentVersion,
     },
-    undefined,
-    customTotalStatsByClass,
-    undefined,
-    undefined,
-    profileRecords
+    undefined
   );
 
   if (item && !allowWishList) {
@@ -209,21 +168,19 @@ export function makeFakeItem(
  * We can use this item to refresh a single item in the store from this response.
  */
 export function makeItemSingle(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  item: DestinyItemResponse,
-  stores: DimStore[],
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+  context: CreateItemContext,
+  itemResponse: DestinyItemResponse,
+  stores: DimStore[]
 ): DimItem | null {
-  if (!item.item.data) {
+  if (!itemResponse.item.data) {
     return null;
   }
 
-  const owner = item.characterId ? stores.find((s) => s.id === item.characterId) : getVault(stores);
+  const owner = itemResponse.characterId
+    ? stores.find((s) => s.id === itemResponse.characterId)
+    : getVault(stores);
 
-  const itemId = item.item.data.itemInstanceId;
+  const itemId = itemResponse.item.data.itemInstanceId;
 
   // Convert a single component response into a dictionary component response
   const empty = { privacy: ComponentPrivacySetting.Public, data: {} };
@@ -231,58 +188,65 @@ export function makeItemSingle(
     ? (v) => (v ? { privacy: v.privacy, data: v.data ? { [itemId]: v.data } : {} } : empty)
     : () => empty;
 
+  // We'll override our item components with these ones
+  const itemComponents = {
+    instances: m(itemResponse.instance),
+    perks: m(itemResponse.perks),
+    renderData: m(itemResponse.renderData),
+    stats: m(itemResponse.stats),
+    sockets: m(itemResponse.sockets),
+    reusablePlugs: m(itemResponse.reusablePlugs),
+    plugObjectives: m(itemResponse.plugObjectives),
+    talentGrids: m(itemResponse.talentGrid),
+    plugStates: empty,
+    objectives: m(itemResponse.objectives),
+  };
+
   // Make it look like a full response
-  return makeItem(
-    defs,
-    buckets,
-    {
-      instances: m(item.instance),
-      perks: m(item.perks),
-      renderData: m(item.renderData),
-      stats: m(item.stats),
-      sockets: m(item.sockets),
-      reusablePlugs: m(item.reusablePlugs),
-      plugObjectives: m(item.plugObjectives),
-      talentGrids: m(item.talentGrid),
-      plugStates: empty,
-      objectives: m(item.objectives),
-    },
-    item.item.data,
-    owner,
-    customTotalStatsByClass
-  );
+  return makeItem({ ...context, itemComponents }, itemResponse.item.data, owner);
+}
+
+/**
+ * Stuff that's required to create a DimItem.
+ */
+export interface CreateItemContext {
+  defs: D2ManifestDefinitions;
+  buckets: InventoryBuckets;
+  profileResponse: DestinyProfileResponse;
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  };
+  /**
+   * Sometimes comes from the profile response, but also sometimes from vendors response or mocked out.
+   * If not present, use the one from profileInfo.
+   */
+  itemComponents?: DestinyItemComponentSetOfint64;
 }
 
 /**
  * Process a single raw item into a DIM item.
- * @param defs the manifest definitions
- * @param buckets the bucket definitions
- * @param previousItems a set of item IDs representing the previous store's items
- * @param newItems a set of item IDs representing the previous list of new items
- * @param item "raw" item from the Destiny API
- * @param owner the ID of the owning store
- * @param uninstancedItemObjectives the owning character's dictionary of uninstanced objectives
  */
-// TODO: extract individual item components first!
 export function makeItem(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  itemComponents: DestinyItemComponentSetOfint64 | undefined,
+  { defs, buckets, itemComponents, customTotalStatsByClass, profileResponse }: CreateItemContext,
   item: DestinyItemComponent,
-  owner: DimStore | undefined,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  },
-  /** this item's uninstanced objectives */
-  itemUninstancedObjectives?: DestinyObjectiveProgress[],
-  /** this item's uninstanced perks */
-  itemUninstancedPerks?: DestinyPerkReference[],
-  profileRecords?: DestinyProfileRecordsComponent
+  /** the ID of the owning store - can be undefined for fake collections items */
+  owner: DimStore | undefined
 ): DimItem | null {
+  itemComponents ??= profileResponse.itemComponents;
+
   const itemDef = defs.InventoryItem.get(item.itemHash);
 
+  // Fish relevant data out of the profile.
+  const profileRecords = profileResponse.profileRecords?.data;
+  const characterProgressions =
+    owner && !owner?.isVault ? profileResponse.characterProgressions?.data?.[owner.id] : undefined;
+  const uninstancedItemObjectives = characterProgressions?.uninstancedItemObjectives;
+  const uninstancedItemPerks = characterProgressions?.uninstancedItemPerks;
+  const itemUninstancedObjectives = uninstancedItemObjectives?.[item.itemHash];
+  const itemUninstancedPerks = uninstancedItemPerks?.[item.itemHash]?.perks;
+
   const itemInstanceData: Partial<DestinyItemInstanceComponent> = item.itemInstanceId
-    ? itemComponents?.instances.data?.[item.itemInstanceId ?? ''] ?? emptyObject()
+    ? itemComponents?.instances.data?.[item.itemInstanceId] ?? emptyObject()
     : emptyObject();
 
   // Missing definition?

--- a/src/app/inventory/store/override-sockets.ts
+++ b/src/app/inventory/store/override-sockets.ts
@@ -22,7 +22,10 @@ export interface SocketOverrides {
 export function applySocketOverrides(
   defs: D2ManifestDefinitions,
   item: DimItem,
-  socketOverrides?: SocketOverrides
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  },
+  socketOverrides: SocketOverrides | undefined
 ): DimItem {
   if (!socketOverrides || _.isEmpty(socketOverrides) || !item.sockets) {
     return item;
@@ -103,7 +106,7 @@ export function applySocketOverrides(
   };
 
   // Recalculate the entire item's stats from scratch given the new plugs
-  updatedItem.stats = buildStats(defs, updatedItem);
+  updatedItem.stats = buildStats(defs, updatedItem, customTotalStatsByClass);
 
   return updatedItem;
 }

--- a/src/app/inventory/store/override-sockets.ts
+++ b/src/app/inventory/store/override-sockets.ts
@@ -1,10 +1,10 @@
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { errorLog } from 'app/utils/log';
 import produce from 'immer';
 import _ from 'lodash';
 import { useCallback, useState } from 'react';
 import { DimItem, DimPlug, DimSocket } from '../item-types';
+import { CreateItemContext } from './d2-item-factory';
 import { buildDefinedPlug } from './sockets';
 import { buildStats } from './stats';
 
@@ -20,11 +20,9 @@ export interface SocketOverrides {
  * Transform an item into a new item whose properties (mostly stats) reflect the chosen socket overrides.
  */
 export function applySocketOverrides(
-  defs: D2ManifestDefinitions,
+  // We don't need everything here but I'm assuming over time we'll want to plumb more stuff into stats calculations?
+  { defs, customTotalStatsByClass }: CreateItemContext,
   item: DimItem,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  },
   socketOverrides: SocketOverrides | undefined
 ): DimItem {
   if (!socketOverrides || _.isEmpty(socketOverrides) || !item.sockets) {

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -1,3 +1,4 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import { DestinyTooltipText } from 'app/dim-ui/DestinyTooltipText';
 import { KillTrackerInfo } from 'app/dim-ui/KillTracker';
 import { WeaponCatalystInfo } from 'app/dim-ui/WeaponCatalystInfo';
@@ -44,9 +45,10 @@ export default function ItemDetails({
   extraInfo?: ItemPopupExtraInfo;
 }) {
   const defs = useDefinitions()!;
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
   const [socketOverrides, onPlugClicked, resetSocketOverrides] = useSocketOverrides();
   const item = defs.isDestiny2()
-    ? applySocketOverrides(defs, originalItem, socketOverrides)
+    ? applySocketOverrides(defs, originalItem, customTotalStatsByClass, socketOverrides)
     : originalItem;
   const modTypeIcon = item.itemCategoryHashes.includes(ItemCategoryHashes.ArmorMods)
     ? helmetIcon

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -1,11 +1,10 @@
-import { settingSelector } from 'app/dim-api/selectors';
 import { DestinyTooltipText } from 'app/dim-ui/DestinyTooltipText';
 import { KillTrackerInfo } from 'app/dim-ui/KillTracker';
 import { WeaponCatalystInfo } from 'app/dim-ui/WeaponCatalystInfo';
 import { WeaponCraftedInfo } from 'app/dim-ui/WeaponCraftedInfo';
 import { WeaponDeepsightInfo } from 'app/dim-ui/WeaponDeepsightInfo';
 import { t } from 'app/i18next-t';
-import { storesSelector } from 'app/inventory/selectors';
+import { createItemContextSelector, storesSelector } from 'app/inventory/selectors';
 import { isTrialsPassage } from 'app/inventory/store/objectives';
 import { applySocketOverrides, useSocketOverrides } from 'app/inventory/store/override-sockets';
 import { getStore } from 'app/inventory/stores-helpers';
@@ -45,10 +44,10 @@ export default function ItemDetails({
   extraInfo?: ItemPopupExtraInfo;
 }) {
   const defs = useDefinitions()!;
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
   const [socketOverrides, onPlugClicked, resetSocketOverrides] = useSocketOverrides();
   const item = defs.isDestiny2()
-    ? applySocketOverrides(defs, originalItem, customTotalStatsByClass, socketOverrides)
+    ? applySocketOverrides(createItemContext, originalItem, socketOverrides)
     : originalItem;
   const modTypeIcon = item.itemCategoryHashes.includes(ItemCategoryHashes.ArmorMods)
     ? helmetIcon

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -1,7 +1,6 @@
-import { settingSelector } from 'app/dim-api/selectors';
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
-import { sortedStoresSelector } from 'app/inventory/selectors';
+import { createItemContextSelector, sortedStoresSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { applySocketOverrides } from 'app/inventory/store/override-sockets';
 import { useD2Definitions } from 'app/manifest/selectors';
@@ -24,7 +23,7 @@ interface Props {
 export default function ItemPopupContainer({ boundarySelector }: Props) {
   const stores = useSelector(sortedStoresSelector);
   const defs = useD2Definitions();
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
 
   const currentItem = useSubscription(showItemPopup$);
 
@@ -41,12 +40,7 @@ export default function ItemPopupContainer({ boundarySelector }: Props) {
   let item = currentItem?.item && maybeFindItem(currentItem.item, stores);
   // Apply socket overrides to customize the item (e.g. from a loadout)
   if (item && defs && currentItem?.extraInfo?.socketOverrides) {
-    item = applySocketOverrides(
-      defs,
-      item,
-      customTotalStatsByClass,
-      currentItem.extraInfo.socketOverrides
-    );
+    item = applySocketOverrides(createItemContext, item, currentItem.extraInfo.socketOverrides);
   }
 
   if (!currentItem || !item) {

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -1,3 +1,4 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import { sortedStoresSelector } from 'app/inventory/selectors';
@@ -23,6 +24,7 @@ interface Props {
 export default function ItemPopupContainer({ boundarySelector }: Props) {
   const stores = useSelector(sortedStoresSelector);
   const defs = useD2Definitions();
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
 
   const currentItem = useSubscription(showItemPopup$);
 
@@ -39,7 +41,12 @@ export default function ItemPopupContainer({ boundarySelector }: Props) {
   let item = currentItem?.item && maybeFindItem(currentItem.item, stores);
   // Apply socket overrides to customize the item (e.g. from a loadout)
   if (item && defs && currentItem?.extraInfo?.socketOverrides) {
-    item = applySocketOverrides(defs, item, currentItem.extraInfo.socketOverrides);
+    item = applySocketOverrides(
+      defs,
+      item,
+      customTotalStatsByClass,
+      currentItem.extraInfo.socketOverrides
+    );
   }
 
   if (!currentItem || !item) {

--- a/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
@@ -1,19 +1,16 @@
 import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { settingSelector } from 'app/dim-api/selectors';
 import Select from 'app/dim-ui/Select';
 import Sheet from 'app/dim-ui/Sheet';
 import { t } from 'app/i18next-t';
-import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimItem } from 'app/inventory/item-types';
-import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
+import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
+import { CreateItemContext } from 'app/inventory/store/d2-item-factory';
 import { updateLoadout } from 'app/loadout-drawer/actions';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { convertToLoadoutItem } from 'app/loadout-drawer/loadout-utils';
 import LoadoutView from 'app/loadout/LoadoutView';
-import { useD2Definitions } from 'app/manifest/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -58,29 +55,23 @@ function chooseInitialLoadout(
  * replaced with `subclass`, and the given `params` and `notes`.
  */
 function createLoadoutUsingLOItems(
-  defs: D2ManifestDefinitions,
+  createItemContext: CreateItemContext,
   allItems: DimItem[],
   autoMods: number[],
   storeId: string | undefined,
-  buckets: InventoryBuckets,
   setItems: DimItem[],
   subclass: ResolvedLoadoutItem | undefined,
   loadout: Loadout | undefined,
   params: LoadoutParameters,
-  notes: string | undefined,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+  notes: string | undefined
 ) {
   return produce(loadout, (draftLoadout) => {
     if (draftLoadout) {
       const [resolvedItems, warnItems] = getItemsFromLoadoutItems(
+        createItemContext,
         draftLoadout.items,
-        defs,
         storeId,
-        buckets,
-        allItems,
-        customTotalStatsByClass
+        allItems
       );
       const newItems = setItems.map((item) => convertToLoadoutItem(item, true));
       if (subclass) {
@@ -130,47 +121,41 @@ export default function CompareLoadoutsDrawer({
   onClose,
 }: Props) {
   const dispatch = useThunkDispatch();
-  const defs = useD2Definitions()!;
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
-  const useableLoadouts = loadouts.filter((l) => l.classType === classType);
+  const usableLoadouts = loadouts.filter((l) => l.classType === classType);
 
   const setItems = set.armor.map((items) => items[0]);
 
   const [selectedLoadout, setSelectedLoadout] = useState<Loadout | undefined>(() =>
-    chooseInitialLoadout(setItems, useableLoadouts, initialLoadoutId)
+    chooseInitialLoadout(setItems, usableLoadouts, initialLoadoutId)
   );
 
   const allItems = useSelector(allItemsSelector);
-  const buckets = useSelector(bucketsSelector)!;
+  const createItemContext = useSelector(createItemContextSelector);
 
   // This probably isn't needed but I am being cautious as it iterates over the stores.
   const generatedLoadout = useMemo(
     () =>
       createLoadoutUsingLOItems(
-        defs,
+        createItemContext,
         allItems,
         set.statMods,
         selectedStore.id,
-        buckets,
         setItems,
         subclass,
         selectedLoadout,
         params,
-        notes,
-        customTotalStatsByClass
+        notes
       ),
     [
-      defs,
+      createItemContext,
       allItems,
       set.statMods,
       selectedStore.id,
-      buckets,
       setItems,
       subclass,
       selectedLoadout,
       params,
       notes,
-      customTotalStatsByClass,
     ]
   );
 
@@ -196,12 +181,12 @@ export default function CompareLoadoutsDrawer({
 
   const loadoutOptions = useMemo(
     () =>
-      useableLoadouts.map((l) => ({
+      usableLoadouts.map((l) => ({
         key: l.id,
         value: l,
         content: l.name,
       })),
-    [useableLoadouts]
+    [usableLoadouts]
   );
 
   // This is likely never to happen but since it is disconnected to the button its here for safety.

--- a/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
@@ -1,5 +1,6 @@
 import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { settingSelector } from 'app/dim-api/selectors';
 import Select from 'app/dim-ui/Select';
 import Sheet from 'app/dim-ui/Sheet';
 import { t } from 'app/i18next-t';
@@ -66,7 +67,10 @@ function createLoadoutUsingLOItems(
   subclass: ResolvedLoadoutItem | undefined,
   loadout: Loadout | undefined,
   params: LoadoutParameters,
-  notes: string | undefined
+  notes: string | undefined,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ) {
   return produce(loadout, (draftLoadout) => {
     if (draftLoadout) {
@@ -75,7 +79,8 @@ function createLoadoutUsingLOItems(
         defs,
         storeId,
         buckets,
-        allItems
+        allItems,
+        customTotalStatsByClass
       );
       const newItems = setItems.map((item) => convertToLoadoutItem(item, true));
       if (subclass) {
@@ -126,6 +131,7 @@ export default function CompareLoadoutsDrawer({
 }: Props) {
   const dispatch = useThunkDispatch();
   const defs = useD2Definitions()!;
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
   const useableLoadouts = loadouts.filter((l) => l.classType === classType);
 
   const setItems = set.armor.map((items) => items[0]);
@@ -150,7 +156,8 @@ export default function CompareLoadoutsDrawer({
         subclass,
         selectedLoadout,
         params,
-        notes
+        notes,
+        customTotalStatsByClass
       ),
     [
       defs,
@@ -163,6 +170,7 @@ export default function CompareLoadoutsDrawer({
       selectedLoadout,
       params,
       notes,
+      customTotalStatsByClass,
     ]
   );
 

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -30,7 +30,7 @@ export function getItemsFromLoadoutItems(
     return [emptyArray(), emptyArray()];
   }
 
-  const { defs, buckets, customTotalStatsByClass } = createItemContext;
+  const { defs, buckets } = createItemContext;
 
   const items: ResolvedLoadoutItem[] = [];
   const warnitems: ResolvedLoadoutItem[] = [];
@@ -53,7 +53,7 @@ export function getItemsFromLoadoutItems(
 
       // Apply socket overrides so the item appears as it should be configured in the loadout
       const overriddenItem = defs.isDestiny2()
-        ? applySocketOverrides(defs, item, customTotalStatsByClass, overrides)
+        ? applySocketOverrides(createItemContext, item, overrides)
         : item;
 
       items.push({

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -26,6 +26,9 @@ export function getItemsFromLoadoutItems(
   storeId: string | undefined,
   buckets: InventoryBuckets,
   allItems: DimItem[],
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  },
   modsByBucket?: {
     [bucketHash: number]: number[] | undefined;
   }
@@ -54,7 +57,9 @@ export function getItemsFromLoadoutItems(
       }
 
       // Apply socket overrides so the item appears as it should be configured in the loadout
-      const overriddenItem = defs.isDestiny2() ? applySocketOverrides(defs, item, overrides) : item;
+      const overriddenItem = defs.isDestiny2()
+        ? applySocketOverrides(defs, item, customTotalStatsByClass, overrides)
+        : item;
 
       items.push({
         item: overriddenItem,
@@ -66,7 +71,7 @@ export function getItemsFromLoadoutItems(
       });
     } else {
       const fakeItem: DimItem | null = defs.isDestiny2()
-        ? makeFakeItem(defs, buckets, undefined, loadoutItem.hash)
+        ? makeFakeItem(defs, buckets, undefined, loadoutItem.hash, customTotalStatsByClass)
         : makeFakeD1Item(defs, buckets, loadoutItem.hash);
       if (fakeItem) {
         fakeItem.id = generateMissingLoadoutItemId();

--- a/src/app/loadout-drawer/loadout-item-conversion.ts
+++ b/src/app/loadout-drawer/loadout-item-conversion.ts
@@ -1,8 +1,5 @@
-import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { makeFakeItem as makeFakeD1Item } from 'app/inventory/store/d1-item-factory';
-import { makeFakeItem } from 'app/inventory/store/d2-item-factory';
+import { CreateItemContext, makeFakeItem } from 'app/inventory/store/d2-item-factory';
 import { applySocketOverrides } from 'app/inventory/store/override-sockets';
 import { emptyArray } from 'app/utils/empty';
 import { warnLog } from 'app/utils/log';
@@ -21,14 +18,10 @@ export function generateMissingLoadoutItemId() {
  * are returned as warnitems.
  */
 export function getItemsFromLoadoutItems(
+  createItemContext: CreateItemContext,
   loadoutItems: LoadoutItem[] | undefined,
-  defs: D1ManifestDefinitions | D2ManifestDefinitions,
   storeId: string | undefined,
-  buckets: InventoryBuckets,
   allItems: DimItem[],
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  },
   modsByBucket?: {
     [bucketHash: number]: number[] | undefined;
   }
@@ -36,6 +29,8 @@ export function getItemsFromLoadoutItems(
   if (!loadoutItems) {
     return [emptyArray(), emptyArray()];
   }
+
+  const { defs, buckets, customTotalStatsByClass } = createItemContext;
 
   const items: ResolvedLoadoutItem[] = [];
   const warnitems: ResolvedLoadoutItem[] = [];
@@ -71,7 +66,7 @@ export function getItemsFromLoadoutItems(
       });
     } else {
       const fakeItem: DimItem | null = defs.isDestiny2()
-        ? makeFakeItem(defs, buckets, undefined, loadoutItem.hash, customTotalStatsByClass)
+        ? makeFakeItem(createItemContext, loadoutItem.hash)
         : makeFakeD1Item(defs, buckets, loadoutItem.hash);
       if (fakeItem) {
         fakeItem.id = generateMissingLoadoutItemId();

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -31,6 +31,9 @@ export function getItemsAndSubclassFromLoadout(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
   allItems: DimItem[],
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  },
   modsByBucket?: {
     [bucketHash: number]: number[] | undefined;
   }
@@ -45,6 +48,7 @@ export function getItemsAndSubclassFromLoadout(
     store.id,
     buckets,
     allItems,
+    customTotalStatsByClass,
     modsByBucket
   );
   const subclass = items

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -1,5 +1,6 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { settingSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
@@ -62,6 +63,7 @@ export default function LoadoutEdit({
   const allItems = useSelector(allItemsSelector);
   const missingSockets = allItems.some((i) => i.missingSockets);
   const [plugDrawerOpen, setPlugDrawerOpen] = useState(false);
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
 
   // TODO: filter down by usable mods?
   const modsByBucket: {
@@ -71,8 +73,16 @@ export default function LoadoutEdit({
   // Turn loadout items into real DimItems, filtering out unequippable items
   const [items, subclass, warnitems] = useMemo(
     () =>
-      getItemsAndSubclassFromLoadout(loadout.items, store, defs, buckets, allItems, modsByBucket),
-    [loadout.items, defs, buckets, allItems, store, modsByBucket]
+      getItemsAndSubclassFromLoadout(
+        loadout.items,
+        store,
+        defs,
+        buckets,
+        allItems,
+        customTotalStatsByClass,
+        modsByBucket
+      ),
+    [loadout.items, defs, buckets, allItems, store, customTotalStatsByClass, modsByBucket]
   );
 
   const allMods = useMemo(() => getModsFromLoadout(defs, loadout), [defs, loadout]);

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -1,10 +1,9 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { settingSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
+import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import {
   applySocketOverrides,
@@ -59,11 +58,10 @@ export default function LoadoutEdit({
   onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
 }) {
   const defs = useD2Definitions()!;
-  const buckets = useSelector(bucketsSelector)!;
   const allItems = useSelector(allItemsSelector);
   const missingSockets = allItems.some((i) => i.missingSockets);
   const [plugDrawerOpen, setPlugDrawerOpen] = useState(false);
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
 
   // TODO: filter down by usable mods?
   const modsByBucket: {
@@ -74,15 +72,13 @@ export default function LoadoutEdit({
   const [items, subclass, warnitems] = useMemo(
     () =>
       getItemsAndSubclassFromLoadout(
+        createItemContext,
         loadout.items,
         store,
-        defs,
-        buckets,
         allItems,
-        customTotalStatsByClass,
         modsByBucket
       ),
-    [loadout.items, defs, buckets, allItems, store, customTotalStatsByClass, modsByBucket]
+    [createItemContext, loadout.items, store, allItems, modsByBucket]
   );
 
   const allMods = useMemo(() => getModsFromLoadout(defs, loadout), [defs, loadout]);

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -1,11 +1,13 @@
-import { settingSelector } from 'app/dim-api/selectors';
 import { DimItem } from 'app/inventory/item-types';
-import { allItemsSelector, bucketsSelector, sortedStoresSelector } from 'app/inventory/selectors';
+import {
+  allItemsSelector,
+  createItemContextSelector,
+  sortedStoresSelector,
+} from 'app/inventory/selectors';
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { LockableBucketHashes } from 'app/loadout-builder/types';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
-import { manifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -38,18 +40,14 @@ export function useEquippedLoadoutArmorAndSubclass(
         storeToHydrateFrom?.items.filter((item) => item.equipped && item.bucket.inArmor) ?? [];
       const classType = storeToHydrateFrom?.classType ?? loadout.classType;
       const allItems = allItemsSelector(state);
-      const defs = manifestSelector(state)!;
-      const buckets = bucketsSelector(state)!;
-      const customTotalStatsByClass = settingSelector('customTotalStatsByClass')(state);
+      const createItemContext = createItemContextSelector(state);
       const modsByBucket = loadout.parameters?.modsByBucket;
 
       const [loadoutItems] = getItemsFromLoadoutItems(
+        createItemContext,
         loadout.items.filter((i) => i.equip),
-        defs,
         storeId,
-        buckets,
         allItems,
-        customTotalStatsByClass,
         modsByBucket
       );
 

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -1,3 +1,4 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector, bucketsSelector, sortedStoresSelector } from 'app/inventory/selectors';
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
@@ -39,6 +40,7 @@ export function useEquippedLoadoutArmorAndSubclass(
       const allItems = allItemsSelector(state);
       const defs = manifestSelector(state)!;
       const buckets = bucketsSelector(state)!;
+      const customTotalStatsByClass = settingSelector('customTotalStatsByClass')(state);
       const modsByBucket = loadout.parameters?.modsByBucket;
 
       const [loadoutItems] = getItemsFromLoadoutItems(
@@ -47,6 +49,7 @@ export function useEquippedLoadoutArmorAndSubclass(
         storeId,
         buckets,
         allItems,
+        customTotalStatsByClass,
         modsByBucket
       );
 

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -135,9 +135,11 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
   const items = useMemo(
     () =>
       defs
-        ? originalItems.map((item) => applySocketOverrides(defs, item, socketOverrides[item.id]))
+        ? originalItems.map((item) =>
+            applySocketOverrides(defs, item, customTotalStatsByClass, socketOverrides[item.id])
+          )
         : originalItems,
-    [defs, originalItems, socketOverrides]
+    [defs, originalItems, socketOverrides, customTotalStatsByClass]
   );
 
   // Build a list of all the stats relevant to this set of items

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -8,6 +8,7 @@ import { bulkLockItems, bulkTagItems } from 'app/inventory/bulk-actions';
 import { DimItem } from 'app/inventory/item-types';
 import {
   allItemsSelector,
+  createItemContextSelector,
   itemInfosSelector,
   newItemsSelector,
   storesSelector,
@@ -101,11 +102,13 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
   const wishList = useSelector(wishListFunctionSelector);
   const hasWishList = useSelector(hasWishListSelector);
   const enabledColumns = useSelector(settingSelector(columnSetting(itemType)));
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
   const loadoutsByItem = useSelector(loadoutsByItemSelector);
   const newItems = useSelector(newItemsSelector);
   const destinyVersion = useSelector(destinyVersionSelector);
   const dispatch = useThunkDispatch();
+
+  const { customTotalStatsByClass } = createItemContext;
 
   const classCategoryHash =
     categories.map((n) => n.itemCategoryHash).find((hash) => hash in categoryToClass) ?? 999;
@@ -136,10 +139,10 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
     () =>
       defs
         ? originalItems.map((item) =>
-            applySocketOverrides(defs, item, customTotalStatsByClass, socketOverrides[item.id])
+            applySocketOverrides(createItemContext, item, socketOverrides[item.id])
           )
         : originalItems,
-    [defs, originalItems, socketOverrides, customTotalStatsByClass]
+    [createItemContext, defs, originalItems, socketOverrides]
   );
 
   // Build a list of all the stats relevant to this set of items

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -178,8 +178,6 @@ export default function Progress({ account }: { account: DestinyAccount }) {
                 <SeasonalChallenges
                   seasonalChallengesPresentationNode={seasonalChallengesPresentationNode}
                   store={selectedStore}
-                  buckets={buckets}
-                  profileResponse={profileInfo}
                 />
               </ErrorBoundary>
             )}

--- a/src/app/progress/SeasonalChallenges.tsx
+++ b/src/app/progress/SeasonalChallenges.tsx
@@ -1,18 +1,13 @@
-import { settingSelector, trackedTriumphsSelector } from 'app/dim-api/selectors';
+import { trackedTriumphsSelector } from 'app/dim-api/selectors';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
-import { InventoryBuckets } from 'app/inventory/inventory-buckets';
+import { createItemContextSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
-import { useD2Definitions } from 'app/manifest/selectors';
 import {
   DimPresentationNode,
   DimRecord,
   toPresentationNodeTree,
 } from 'app/records/presentation-nodes';
-import {
-  DestinyPresentationNodeDefinition,
-  DestinyProfileResponse,
-  DestinyRecordState,
-} from 'bungie-api-ts/destiny2';
+import { DestinyPresentationNodeDefinition, DestinyRecordState } from 'bungie-api-ts/destiny2';
 import seasonalChallengesInfo from 'data/d2/seasonal-challenges.json';
 import { useSelector } from 'react-redux';
 import { recordToPursuitItem } from './milestone-items';
@@ -24,22 +19,14 @@ import { PursuitsGroup } from './Pursuits';
 export default function SeasonalChallenges({
   seasonalChallengesPresentationNode,
   store,
-  buckets,
-  profileResponse,
 }: {
   seasonalChallengesPresentationNode: DestinyPresentationNodeDefinition;
   store: DimStore;
-  buckets: InventoryBuckets;
-  profileResponse: DestinyProfileResponse;
 }) {
-  const defs = useD2Definitions()!;
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
   const nodeTree = toPresentationNodeTree(
-    defs,
-    buckets,
-    profileResponse,
-    seasonalChallengesPresentationNode.hash,
-    customTotalStatsByClass
+    createItemContext,
+    seasonalChallengesPresentationNode.hash
   );
 
   const allRecords = nodeTree ? flattenRecords(nodeTree) : [];
@@ -56,7 +43,7 @@ export default function SeasonalChallenges({
     .map((r) =>
       recordToPursuitItem(
         r,
-        buckets,
+        createItemContext.buckets,
         store,
         seasonalChallengesPresentationNode.displayProperties.name,
         trackedRecords.includes(r.recordDef.hash)

--- a/src/app/progress/SeasonalChallenges.tsx
+++ b/src/app/progress/SeasonalChallenges.tsx
@@ -1,4 +1,4 @@
-import { trackedTriumphsSelector } from 'app/dim-api/selectors';
+import { settingSelector, trackedTriumphsSelector } from 'app/dim-api/selectors';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimStore } from 'app/inventory/store-types';
@@ -33,11 +33,13 @@ export default function SeasonalChallenges({
   profileResponse: DestinyProfileResponse;
 }) {
   const defs = useD2Definitions()!;
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
   const nodeTree = toPresentationNodeTree(
     defs,
     buckets,
     profileResponse,
-    seasonalChallengesPresentationNode.hash
+    seasonalChallengesPresentationNode.hash,
+    customTotalStatsByClass
   );
 
   const allRecords = nodeTree ? flattenRecords(nodeTree) : [];

--- a/src/app/progress/selectors.ts
+++ b/src/app/progress/selectors.ts
@@ -9,10 +9,8 @@ export const getCharacterProgressions = (
   characterId?: string
 ) => {
   // try to fill in missing character ID with a valid value
-  characterId =
-    characterId ||
-    (profileResponse?.characterProgressions?.data
-      ? Object.keys(profileResponse.characterProgressions.data)[0]
-      : '');
+  characterId ??= profileResponse?.characterProgressions?.data
+    ? Object.keys(profileResponse.characterProgressions.data)[0]
+    : '';
   return profileResponse?.characterProgressions?.data?.[characterId];
 };

--- a/src/app/records/PlugSet.tsx
+++ b/src/app/records/PlugSet.tsx
@@ -1,5 +1,5 @@
-import { settingSelector } from 'app/dim-api/selectors';
 import { DimItem } from 'app/inventory/item-types';
+import { createItemContextSelector } from 'app/inventory/selectors';
 import { makeFakeItem } from 'app/inventory/store/d2-item-factory';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { percent } from 'app/shell/formatters';
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import _ from 'lodash';
 import { useSelector } from 'react-redux';
 import BungieImage from '../dim-ui/BungieImage';
-import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { AppIcon, collapseIcon, expandIcon } from '../shell/icons';
 import { count } from '../utils/util';
 
@@ -19,7 +18,6 @@ const plugSetOrder = chainComparator<DimItem>(
 );
 
 interface Props {
-  buckets: InventoryBuckets;
   plugSetCollection: {
     hash: number;
     displayItem: number;
@@ -33,7 +31,6 @@ interface Props {
  * A single plug set.
  */
 export default function PlugSet({
-  buckets,
   plugSetCollection,
   unlockedItems,
   path,
@@ -42,12 +39,10 @@ export default function PlugSet({
   const defs = useD2Definitions()!;
   const plugSetHash = plugSetCollection.hash;
   const plugSetDef = defs.PlugSet.get(plugSetHash);
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
 
   const plugSetItems = _.compact(
-    plugSetDef.reusablePlugItems.map((i) =>
-      makeFakeItem(defs, buckets, undefined, i.plugItemHash, customTotalStatsByClass)
-    )
+    plugSetDef.reusablePlugItems.map((i) => makeFakeItem(createItemContext, i.plugItemHash))
   );
 
   plugSetItems.sort(plugSetOrder);

--- a/src/app/records/PlugSet.tsx
+++ b/src/app/records/PlugSet.tsx
@@ -1,3 +1,4 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import { DimItem } from 'app/inventory/item-types';
 import { makeFakeItem } from 'app/inventory/store/d2-item-factory';
 import { useD2Definitions } from 'app/manifest/selectors';
@@ -6,6 +7,7 @@ import { chainComparator, compareBy } from 'app/utils/comparators';
 import { VendorItemDisplay } from 'app/vendors/VendorItemComponent';
 import clsx from 'clsx';
 import _ from 'lodash';
+import { useSelector } from 'react-redux';
 import BungieImage from '../dim-ui/BungieImage';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { AppIcon, collapseIcon, expandIcon } from '../shell/icons';
@@ -40,9 +42,12 @@ export default function PlugSet({
   const defs = useD2Definitions()!;
   const plugSetHash = plugSetCollection.hash;
   const plugSetDef = defs.PlugSet.get(plugSetHash);
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
 
   const plugSetItems = _.compact(
-    plugSetDef.reusablePlugItems.map((i) => makeFakeItem(defs, buckets, undefined, i.plugItemHash))
+    plugSetDef.reusablePlugItems.map((i) =>
+      makeFakeItem(defs, buckets, undefined, i.plugItemHash, customTotalStatsByClass)
+    )
   );
 
   plugSetItems.sort(plugSetOrder);

--- a/src/app/records/PresentationNodeRoot.tsx
+++ b/src/app/records/PresentationNodeRoot.tsx
@@ -1,7 +1,9 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { ItemFilter } from 'app/search/filter-types';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
 import PlugSet from './PlugSet';
 import { unlockedItemsForCharacterOrProfilePlugSet } from './plugset-helpers';
@@ -41,6 +43,7 @@ export default function PresentationNodeRoot({
   overrideName,
   completedRecordsHidden,
 }: Props) {
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
   const defs = useD2Definitions()!;
   const [nodePath, setNodePath] = useState<number[]>([]);
 
@@ -58,8 +61,15 @@ export default function PresentationNodeRoot({
   }
 
   const nodeTree = useMemo(
-    () => toPresentationNodeTree(defs, buckets, profileResponse, presentationNodeHash),
-    [defs, buckets, profileResponse, presentationNodeHash]
+    () =>
+      toPresentationNodeTree(
+        defs,
+        buckets,
+        profileResponse,
+        presentationNodeHash,
+        customTotalStatsByClass
+      ),
+    [defs, buckets, profileResponse, presentationNodeHash, customTotalStatsByClass]
   );
   // console.log(nodeTree);
 

--- a/src/app/records/PresentationNodeRoot.tsx
+++ b/src/app/records/PresentationNodeRoot.tsx
@@ -1,4 +1,4 @@
-import { settingSelector } from 'app/dim-api/selectors';
+import { createItemContextSelector } from 'app/inventory/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { ItemFilter } from 'app/search/filter-types';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
@@ -43,7 +43,7 @@ export default function PresentationNodeRoot({
   overrideName,
   completedRecordsHidden,
 }: Props) {
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
   const defs = useD2Definitions()!;
   const [nodePath, setNodePath] = useState<number[]>([]);
 
@@ -61,15 +61,8 @@ export default function PresentationNodeRoot({
   }
 
   const nodeTree = useMemo(
-    () =>
-      toPresentationNodeTree(
-        defs,
-        buckets,
-        profileResponse,
-        presentationNodeHash,
-        customTotalStatsByClass
-      ),
-    [defs, buckets, profileResponse, presentationNodeHash, customTotalStatsByClass]
+    () => toPresentationNodeTree(createItemContext, presentationNodeHash),
+    [presentationNodeHash, createItemContext]
   );
   // console.log(nodeTree);
 
@@ -121,7 +114,6 @@ export default function PresentationNodeRoot({
         plugSetCollections.map((plugSetCollection) => (
           <div key={plugSetCollection.hash} className="presentation-node">
             <PlugSet
-              buckets={buckets}
               plugSetCollection={plugSetCollection}
               unlockedItems={unlockedItemsForCharacterOrProfilePlugSet(
                 profileResponse,

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -1,4 +1,3 @@
-import { settingSelector } from 'app/dim-api/selectors';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { useLoadStores } from 'app/inventory/store/hooks';
@@ -14,7 +13,12 @@ import { useLocation, useParams } from 'react-router';
 import { DestinyAccount } from '../accounts/destiny-account';
 import Countdown from '../dim-ui/Countdown';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
-import { bucketsSelector, profileResponseSelector, storesSelector } from '../inventory/selectors';
+import {
+  bucketsSelector,
+  createItemContextSelector,
+  profileResponseSelector,
+  storesSelector,
+} from '../inventory/selectors';
 import { loadingTracker } from '../shell/loading-tracker';
 import { refresh$ } from '../shell/refresh-events';
 import { loadAllVendors } from './actions';
@@ -36,7 +40,7 @@ export default function SingleVendor({ account }: { account: DestinyAccount }) {
   const profileResponse = useSelector(profileResponseSelector);
   const vendors = useSelector(vendorsByCharacterSelector);
   const defs = useD2Definitions();
-  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
+  const createItemContext = useSelector(createItemContextSelector);
   const dispatch = useThunkDispatch();
 
   // TODO: get for all characters, or let people select a character? This is a hack
@@ -111,16 +115,11 @@ export default function SingleVendor({ account }: { account: DestinyAccount }) {
   // TODO: there's a cool background image but I'm not sure how to use it
 
   const d2Vendor = toVendor(
+    { ...createItemContext, itemComponents: vendorResponse?.itemComponents[vendorHash] },
     vendorHash,
-    defs,
-    buckets,
-    profileResponse,
     vendor,
-    account,
     characterId,
-    vendorResponse?.itemComponents[vendorHash],
-    vendorResponse?.sales.data?.[vendorHash]?.saleItems,
-    customTotalStatsByClass
+    vendorResponse?.sales.data?.[vendorHash]?.saleItems
   );
 
   if (!d2Vendor) {

--- a/src/app/vendors/SingleVendor.tsx
+++ b/src/app/vendors/SingleVendor.tsx
@@ -1,3 +1,4 @@
+import { settingSelector } from 'app/dim-api/selectors';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { useLoadStores } from 'app/inventory/store/hooks';
@@ -35,6 +36,7 @@ export default function SingleVendor({ account }: { account: DestinyAccount }) {
   const profileResponse = useSelector(profileResponseSelector);
   const vendors = useSelector(vendorsByCharacterSelector);
   const defs = useD2Definitions();
+  const customTotalStatsByClass = useSelector(settingSelector('customTotalStatsByClass'));
   const dispatch = useThunkDispatch();
 
   // TODO: get for all characters, or let people select a character? This is a hack
@@ -117,7 +119,8 @@ export default function SingleVendor({ account }: { account: DestinyAccount }) {
     account,
     characterId,
     vendorResponse?.itemComponents[vendorHash],
-    vendorResponse?.sales.data?.[vendorHash]?.saleItems
+    vendorResponse?.sales.data?.[vendorHash]?.saleItems,
+    customTotalStatsByClass
   );
 
   if (!d2Vendor) {

--- a/src/app/vendors/d2-vendors.test.ts
+++ b/src/app/vendors/d2-vendors.test.ts
@@ -19,7 +19,7 @@ async function getTestVendorGroups() {
   };
   const characterId = Object.keys(profileResponse.characters.data!)[0];
 
-  return toVendorGroups(vendorsResponse, profileResponse, defs, buckets, account, characterId);
+  return toVendorGroups(vendorsResponse, profileResponse, defs, buckets, account, characterId, {});
 }
 
 function* allSaleItems(vendorGroups: D2VendorGroup[]) {

--- a/src/app/vendors/d2-vendors.test.ts
+++ b/src/app/vendors/d2-vendors.test.ts
@@ -1,4 +1,3 @@
-import { DestinyAccount } from 'app/accounts/destiny-account';
 import { getBuckets } from 'app/destiny2/d2-buckets';
 import { getTestDefinitions, getTestProfile, getTestVendors } from 'testing/test-utils';
 import { D2VendorGroup, toVendorGroups } from './d2-vendors';
@@ -8,18 +7,18 @@ async function getTestVendorGroups() {
   const profileResponse = getTestProfile();
   const vendorsResponse = getTestVendors();
   const buckets = getBuckets(defs);
-  const account: DestinyAccount = {
-    displayName: '',
-    originalPlatformType: 2,
-    platformLabel: '',
-    membershipId: '',
-    destinyVersion: 1,
-    platforms: [],
-    lastPlayed: new Date(),
-  };
   const characterId = Object.keys(profileResponse.characters.data!)[0];
 
-  return toVendorGroups(vendorsResponse, profileResponse, defs, buckets, account, characterId, {});
+  return toVendorGroups(
+    {
+      defs,
+      buckets,
+      profileResponse,
+      customTotalStatsByClass: {},
+    },
+    vendorsResponse,
+    characterId
+  );
 }
 
 function* allSaleItems(vendorGroups: D2VendorGroup[]) {

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -42,7 +42,10 @@ export function toVendorGroups(
   defs: D2ManifestDefinitions,
   buckets: InventoryBuckets,
   account: DestinyAccount,
-  characterId: string
+  characterId: string,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ): D2VendorGroup[] {
   if (!vendorsResponse.vendorGroups.data) {
     return [];
@@ -66,7 +69,8 @@ export function toVendorGroups(
                   account,
                   characterId,
                   vendorsResponse.itemComponents[vendorHash],
-                  vendorsResponse.sales.data?.[vendorHash]?.saleItems
+                  vendorsResponse.sales.data?.[vendorHash]?.saleItems,
+                  customTotalStatsByClass
                 )
               )
               .filter((vendor) => vendor?.items.length)
@@ -95,7 +99,10 @@ export function toVendor(
     | {
         [key: string]: DestinyVendorSaleItemComponent;
       }
-    | undefined
+    | undefined,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ): D2Vendor | undefined {
   const vendorDef = defs.Vendor.get(vendorHash);
 
@@ -111,7 +118,8 @@ export function toVendor(
     profileResponse,
     characterId,
     itemComponents,
-    sales
+    sales,
+    customTotalStatsByClass
   );
 
   const destinationDef =
@@ -154,7 +162,10 @@ function getVendorItems(
     | {
         [key: string]: DestinyVendorSaleItemComponent;
       }
-    | undefined
+    | undefined,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ): VendorItem[] {
   if (sales) {
     const components = Object.values(sales);
@@ -166,7 +177,8 @@ function getVendorItems(
         profileResponse,
         component,
         characterId,
-        itemComponents
+        itemComponents,
+        customTotalStatsByClass
       )
     );
   } else if (vendorDef.returnWithVendorRequest) {
@@ -180,7 +192,16 @@ function getVendorItems(
           i.exclusivity === BungieMembershipType.All ||
           i.exclusivity === account.originalPlatformType
       )
-      .map((i) => vendorItemForDefinitionItem(defs, buckets, i, profileResponse, characterId));
+      .map((i) =>
+        vendorItemForDefinitionItem(
+          defs,
+          buckets,
+          i,
+          profileResponse,
+          characterId,
+          customTotalStatsByClass
+        )
+      );
   }
 }
 

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -1,16 +1,11 @@
-import { DestinyAccount } from 'app/accounts/destiny-account';
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { InventoryBuckets } from 'app/inventory/inventory-buckets';
+import { CreateItemContext } from 'app/inventory/store/d2-item-factory';
 import { VENDORS } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
 import {
-  BungieMembershipType,
   DestinyCollectibleState,
   DestinyDestinationDefinition,
   DestinyInventoryItemDefinition,
-  DestinyItemComponentSetOfint32,
   DestinyPlaceDefinition,
-  DestinyProfileResponse,
   DestinyVendorComponent,
   DestinyVendorDefinition,
   DestinyVendorGroupDefinition,
@@ -37,19 +32,15 @@ export interface D2Vendor {
 const vendorOrder = [VENDORS.SPIDER, VENDORS.ADA_TRANSMOG, VENDORS.BANSHEE, VENDORS.EVERVERSE];
 
 export function toVendorGroups(
+  context: CreateItemContext,
   vendorsResponse: DestinyVendorsResponse,
-  profileResponse: DestinyProfileResponse,
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  account: DestinyAccount,
-  characterId: string,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+  characterId: string
 ): D2VendorGroup[] {
   if (!vendorsResponse.vendorGroups.data) {
     return [];
   }
+
+  const { defs } = context;
 
   return _.sortBy(
     Object.values(vendorsResponse.vendorGroups.data.groups).map((group) => {
@@ -61,16 +52,12 @@ export function toVendorGroups(
             group.vendorHashes
               .map((vendorHash) =>
                 toVendor(
+                  // Override the item components from the profile with this vendor's item components
+                  { ...context, itemComponents: vendorsResponse.itemComponents[vendorHash] },
                   vendorHash,
-                  defs,
-                  buckets,
-                  profileResponse,
                   vendorsResponse.vendors.data?.[vendorHash],
-                  account,
                   characterId,
-                  vendorsResponse.itemComponents[vendorHash],
-                  vendorsResponse.sales.data?.[vendorHash]?.saleItems,
-                  customTotalStatsByClass
+                  vendorsResponse.sales.data?.[vendorHash]?.saleItems
                 )
               )
               .filter((vendor) => vendor?.items.length)
@@ -87,40 +74,24 @@ export function toVendorGroups(
 }
 
 export function toVendor(
+  context: CreateItemContext,
   vendorHash: number,
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  profileResponse: DestinyProfileResponse | undefined,
   vendor: DestinyVendorComponent | undefined,
-  account: DestinyAccount,
   characterId: string,
-  itemComponents: DestinyItemComponentSetOfint32 | undefined,
   sales:
     | {
         [key: string]: DestinyVendorSaleItemComponent;
       }
-    | undefined,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+    | undefined
 ): D2Vendor | undefined {
+  const { defs } = context;
   const vendorDef = defs.Vendor.get(vendorHash);
 
   if (!vendorDef) {
     return undefined;
   }
 
-  const vendorItems = getVendorItems(
-    account,
-    defs,
-    buckets,
-    vendorDef,
-    profileResponse,
-    characterId,
-    itemComponents,
-    sales,
-    customTotalStatsByClass
-  );
+  const vendorItems = getVendorItems(context, vendorDef, characterId, sales);
 
   const destinationDef =
     typeof vendor?.vendorLocationIndex === 'number' && vendor.vendorLocationIndex >= 0
@@ -151,57 +122,25 @@ export function toVendor(
 }
 
 function getVendorItems(
-  account: DestinyAccount,
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
+  context: CreateItemContext,
   vendorDef: DestinyVendorDefinition,
-  profileResponse: DestinyProfileResponse | undefined,
   characterId: string,
-  itemComponents: DestinyItemComponentSetOfint32 | undefined,
   sales:
     | {
         [key: string]: DestinyVendorSaleItemComponent;
       }
-    | undefined,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+    | undefined
 ): VendorItem[] {
   if (sales) {
     const components = Object.values(sales);
     return components.map((component) =>
-      vendorItemForSaleItem(
-        defs,
-        buckets,
-        vendorDef,
-        profileResponse,
-        component,
-        characterId,
-        itemComponents,
-        customTotalStatsByClass
-      )
+      vendorItemForSaleItem(context, vendorDef, component, characterId)
     );
   } else if (vendorDef.returnWithVendorRequest) {
     // If the sales should come from the server, don't show anything until we have them
     return [];
   } else {
-    return vendorDef.itemList
-      .filter(
-        (i) =>
-          !i.exclusivity ||
-          i.exclusivity === BungieMembershipType.All ||
-          i.exclusivity === account.originalPlatformType
-      )
-      .map((i) =>
-        vendorItemForDefinitionItem(
-          defs,
-          buckets,
-          i,
-          profileResponse,
-          characterId,
-          customTotalStatsByClass
-        )
-      );
+    return vendorDef.itemList.map((i) => vendorItemForDefinitionItem(context, i, characterId));
   }
 }
 

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -1,13 +1,10 @@
-import { currentAccountSelector } from 'app/accounts/selectors';
 import {
-  bucketsSelector,
+  createItemContextSelector,
   ownedItemsSelector,
   ownedUncollectiblePlugsSelector,
-  profileResponseSelector,
   sortedStoresSelector,
 } from 'app/inventory/selectors';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
-import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { currySelector } from 'app/utils/redux-utils';
@@ -20,42 +17,17 @@ export const vendorsByCharacterSelector = (state: RootState) => state.vendors.ve
  * returns a character's vendors and their sale items
  */
 export const nonCurriedVendorGroupsForCharacterSelector = createSelector(
-  d2ManifestSelector,
+  createItemContextSelector,
   vendorsByCharacterSelector,
-  bucketsSelector,
-  currentAccountSelector,
-  profileResponseSelector,
-  (state: RootState) => state.dimApi.settings.customTotalStatsByClass,
   // get character ID from props not state
-  (state: any, characterId: string | undefined) =>
+  (state: RootState, characterId: string | undefined) =>
     characterId || getCurrentStore(sortedStoresSelector(state))?.id,
-  (
-    defs,
-    vendors,
-    buckets,
-    currentAccount,
-    profileResponse,
-    customTotalStatsByClass,
-    selectedStoreId
-  ) => {
+  (context, vendors, selectedStoreId) => {
     const vendorData = selectedStoreId ? vendors[selectedStoreId] : undefined;
     const vendorsResponse = vendorData?.vendorsResponse;
 
-    return vendorsResponse &&
-      defs &&
-      buckets &&
-      currentAccount &&
-      selectedStoreId &&
-      profileResponse
-      ? toVendorGroups(
-          vendorsResponse,
-          profileResponse,
-          defs,
-          buckets,
-          currentAccount,
-          selectedStoreId,
-          customTotalStatsByClass
-        )
+    return vendorsResponse && vendorData && selectedStoreId
+      ? toVendorGroups(context, vendorsResponse, selectedStoreId)
       : emptyArray<D2VendorGroup>();
   }
 );

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -25,10 +25,19 @@ export const nonCurriedVendorGroupsForCharacterSelector = createSelector(
   bucketsSelector,
   currentAccountSelector,
   profileResponseSelector,
+  (state: RootState) => state.dimApi.settings.customTotalStatsByClass,
   // get character ID from props not state
   (state: any, characterId: string | undefined) =>
     characterId || getCurrentStore(sortedStoresSelector(state))?.id,
-  (defs, vendors, buckets, currentAccount, profileResponse, selectedStoreId) => {
+  (
+    defs,
+    vendors,
+    buckets,
+    currentAccount,
+    profileResponse,
+    customTotalStatsByClass,
+    selectedStoreId
+  ) => {
     const vendorData = selectedStoreId ? vendors[selectedStoreId] : undefined;
     const vendorsResponse = vendorData?.vendorsResponse;
 
@@ -44,7 +53,8 @@ export const nonCurriedVendorGroupsForCharacterSelector = createSelector(
           defs,
           buckets,
           currentAccount,
-          selectedStoreId
+          selectedStoreId,
+          customTotalStatsByClass
         )
       : emptyArray<D2VendorGroup>();
   }

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -1,9 +1,9 @@
 import { VENDORS } from 'app/search/d2-known-values';
+import { emptyArray } from 'app/utils/empty';
 import {
   DestinyCollectibleState,
   DestinyDisplayPropertiesDefinition,
   DestinyInventoryItemDefinition,
-  DestinyItemComponentSetOfint32,
   DestinyItemQuantity,
   DestinyProfileResponse,
   DestinyVendorDefinition,
@@ -12,10 +12,8 @@ import {
   DestinyVendorSaleItemComponent,
 } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
-import { D2ManifestDefinitions } from '../destiny2/d2-definitions';
-import { InventoryBuckets } from '../inventory/inventory-buckets';
 import { DimItem } from '../inventory/item-types';
-import { makeFakeItem } from '../inventory/store/d2-item-factory';
+import { CreateItemContext, makeFakeItem } from '../inventory/store/d2-item-factory';
 
 /**
  * This represents an item inside a vendor.
@@ -59,21 +57,17 @@ function getCollectibleState(
 }
 
 function makeVendorItem(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
-  profileResponse: DestinyProfileResponse | undefined,
+  context: CreateItemContext,
   itemHash: number,
   failureStrings: string[],
   vendorHash: number,
-  vendorItemDef: DestinyVendorItemDefinition | undefined,
+  vendorItemDef: DestinyVendorItemDefinition,
   saleItem: DestinyVendorSaleItemComponent | undefined,
-  itemComponents: DestinyItemComponentSetOfint32 | undefined,
   // the character to whom this item is being offered
-  characterId: string,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+  characterId: string
 ): VendorItem {
+  const { defs, profileResponse } = context;
+
   const inventoryItem = defs.InventoryItem.get(itemHash);
   const key = saleItem ? saleItem.vendorItemIndex : inventoryItem.hash;
   const vendorItem: VendorItem = {
@@ -89,15 +83,11 @@ function makeVendorItem(
     previewVendorHash: inventoryItem.preview?.previewVendorHash,
     collectibleState: getCollectibleState(inventoryItem, profileResponse, characterId),
     item: makeFakeItem(
-      defs,
-      buckets,
-      itemComponents,
+      context,
       itemHash,
-      customTotalStatsByClass,
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
       key.toString(),
       vendorItemDef ? vendorItemDef.quantity : 1,
-      profileResponse?.profileRecords.data,
       // vendor items are wish list enabled!
       true
     ),
@@ -140,36 +130,26 @@ function makeVendorItem(
  * of that copy they're selling
  */
 export function vendorItemForSaleItem(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
+  context: CreateItemContext,
   vendorDef: DestinyVendorDefinition,
-  profileResponse: DestinyProfileResponse | undefined,
   saleItem: DestinyVendorSaleItemComponent,
-  // all DIM vendor calls are character-specific. any sale item should have an associated character.
-  characterId: string,
-  itemComponents: DestinyItemComponentSetOfint32 | undefined,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+  /** all DIM vendor calls are character-specific. any sale item should have an associated character. */
+  characterId: string
 ): VendorItem {
   const vendorItemDef = vendorDef.itemList[saleItem.vendorItemIndex];
   const failureStrings =
-    saleItem && vendorDef
+    saleItem && vendorDef && saleItem.failureIndexes
       ? (saleItem.failureIndexes || []).map((i) => vendorDef.failureStrings[i])
-      : [];
+      : emptyArray<string>();
 
   return makeVendorItem(
-    defs,
-    buckets,
-    profileResponse,
+    context,
     saleItem.itemHash,
     failureStrings,
     vendorDef.hash,
     vendorItemDef,
     saleItem,
-    itemComponents,
-    characterId,
-    customTotalStatsByClass
+    characterId
   );
 }
 
@@ -178,26 +158,17 @@ export function vendorItemForSaleItem(
  * some vendors are set up so statically, that they have no data in the live Vendors response
  */
 export function vendorItemForDefinitionItem(
-  defs: D2ManifestDefinitions,
-  buckets: InventoryBuckets,
+  context: CreateItemContext,
   vendorItemDef: DestinyVendorItemDefinition,
-  profileResponse: DestinyProfileResponse | undefined,
-  characterId: string,
-  customTotalStatsByClass: {
-    [key: number]: number[];
-  }
+  characterId: string
 ): VendorItem {
   return makeVendorItem(
-    defs,
-    buckets,
-    profileResponse,
+    context,
     vendorItemDef.itemHash,
     [],
     0,
     vendorItemDef,
     undefined,
-    undefined,
-    characterId,
-    customTotalStatsByClass
+    characterId
   );
 }

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -69,7 +69,10 @@ function makeVendorItem(
   saleItem: DestinyVendorSaleItemComponent | undefined,
   itemComponents: DestinyItemComponentSetOfint32 | undefined,
   // the character to whom this item is being offered
-  characterId: string
+  characterId: string,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ): VendorItem {
   const inventoryItem = defs.InventoryItem.get(itemHash);
   const key = saleItem ? saleItem.vendorItemIndex : inventoryItem.hash;
@@ -90,6 +93,7 @@ function makeVendorItem(
       buckets,
       itemComponents,
       itemHash,
+      customTotalStatsByClass,
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
       key.toString(),
       vendorItemDef ? vendorItemDef.quantity : 1,
@@ -143,7 +147,10 @@ export function vendorItemForSaleItem(
   saleItem: DestinyVendorSaleItemComponent,
   // all DIM vendor calls are character-specific. any sale item should have an associated character.
   characterId: string,
-  itemComponents: DestinyItemComponentSetOfint32 | undefined
+  itemComponents: DestinyItemComponentSetOfint32 | undefined,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ): VendorItem {
   const vendorItemDef = vendorDef.itemList[saleItem.vendorItemIndex];
   const failureStrings =
@@ -161,7 +168,8 @@ export function vendorItemForSaleItem(
     vendorItemDef,
     saleItem,
     itemComponents,
-    characterId
+    characterId,
+    customTotalStatsByClass
   );
 }
 
@@ -174,7 +182,10 @@ export function vendorItemForDefinitionItem(
   buckets: InventoryBuckets,
   vendorItemDef: DestinyVendorItemDefinition,
   profileResponse: DestinyProfileResponse | undefined,
-  characterId: string
+  characterId: string,
+  customTotalStatsByClass: {
+    [key: number]: number[];
+  }
 ): VendorItem {
   return makeVendorItem(
     defs,
@@ -186,6 +197,7 @@ export function vendorItemForDefinitionItem(
     vendorItemDef,
     undefined,
     undefined,
-    characterId
+    characterId,
+    customTotalStatsByClass
   );
 }

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -87,6 +87,6 @@ export const getTestVendors = () => (vendors as any).Response as DestinyVendorsR
 export const getTestStores = _.once(async () => {
   const manifest = await getTestDefinitions();
 
-  const stores = buildStores(manifest, getBuckets(manifest), getTestProfile());
+  const stores = buildStores(manifest, getBuckets(manifest), getTestProfile(), {});
   return stores;
 });

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -87,6 +87,11 @@ export const getTestVendors = () => (vendors as any).Response as DestinyVendorsR
 export const getTestStores = _.once(async () => {
   const manifest = await getTestDefinitions();
 
-  const stores = buildStores(manifest, getBuckets(manifest), getTestProfile(), {});
+  const stores = buildStores({
+    defs: manifest,
+    buckets: getBuckets(manifest),
+    profileResponse: getTestProfile(),
+    customTotalStatsByClass: {},
+  });
   return stores;
 });


### PR DESCRIPTION
I started off trying to remove the direct access to the Redux store inside `customStat` (for `customTotalStatsByClass`), decided I hated that, and then reworked all the item creation functions to take a "context" object containing their dependencies. This should make it easier to plumb new dependencies down into those functions without cluttering up a bunch of things.