### PR TITLE
style: fixed organizer header's misalignment

### DIFF
--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -75,7 +75,7 @@ $content-cells: 5;
   }
 
   &.stats {
-    text-align: right;
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
Addressing issue #9029 

Simple fix that changes the alignment of the column names in the organizer's header. Brings back the "notes" column name as well!