### PR TITLE
Show number of fragment slots in loadout plug tooltips

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * You can now click a Loadout name in Organizer's Loadouts column to quickly bring up this loadout for editing.
+* When hovering over subclass Aspects in Loadouts and Loadout Optimizer, the tooltip will now show the number of Fragment slots granted.
 
 ## 7.56.0 <span class="changelog-date">(2023-02-12)</span>
 

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -26,6 +26,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import enhancedIntrinsics from 'data/d2/crafting-enhanced-intrinsics';
+import { StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { useCallback } from 'react';
 import { DimItem, DimPlug } from '../inventory/item-types';
@@ -140,6 +141,19 @@ export function PlugTooltip({
         statHash: parseInt(statHash, 10),
       }))) ||
     [];
+
+  // HACK Loadout plugs operate on defs very often and they show their stats via perks,
+  // which are handled below. But the number of fragment slots is just a direct stat.
+  const aspectCapacityStat = def.investmentStats?.find(
+    (stat) => stat.statTypeHash === StatHashes.AspectEnergyCapacity
+  );
+  if (aspectCapacityStat) {
+    statsArray.push({
+      statHash: aspectCapacityStat.statTypeHash,
+      value: aspectCapacityStat.value,
+    });
+  }
+
   const plugDescriptions = usePlugDescriptions(def, statsArray);
   const sourceString =
     defs && def.collectibleHash && defs.Collectible.get(def.collectibleHash).sourceString;


### PR DESCRIPTION
This was missing before
![grafik](https://user-images.githubusercontent.com/14299449/218261978-4107fc41-241f-49e8-8b68-940e76565593.png)

At some point the whole defs vs DimPlug duality needs to be cleaned up because we keep adding hacks specifically for subclass plugs where all we have is defs, but /shrug