### PR TITLE
Hide/indicate unobtainable event seals in records?

### DIFF
--- a/src/app/records/PresentationNode.tsx
+++ b/src/app/records/PresentationNode.tsx
@@ -21,6 +21,7 @@ interface Props {
   isInTriumphs?: boolean;
   overrideName?: string;
   isRootNode?: boolean;
+  isParentLegacy?: boolean;
   onNodePathSelected: (nodePath: number[]) => void;
 }
 
@@ -33,10 +34,12 @@ export default function PresentationNode({
   isInTriumphs,
   isRootNode,
   overrideName,
+  isParentLegacy,
 }: Props) {
   const defs = useD2Definitions()!;
   const completedRecordsHidden = useSelector(settingSelector('completedRecordsHidden'));
   const redactedRecordsRevealed = useSelector(settingSelector('redactedRecordsRevealed'));
+  const unobtainableRecordsHidden = useSelector(settingSelector('unobtainableRecordsHidden'));
   const headerRef = useRef<HTMLDivElement>(null);
   const lastPath = useRef<number[]>();
   const presentationNodeHash = node.nodeDef.hash;
@@ -66,6 +69,10 @@ export default function PresentationNode({
   };
 
   const { visible, acquired, nodeDef } = node;
+  // Hack to indicate children are no longer obtainable
+  const isLegacy =
+    isParentLegacy ||
+    ['Legacy Triumphs', 'Legacy Seals'].includes(node.nodeDef.displayProperties?.name);
   const completed = Boolean(acquired >= visible);
 
   if (!visible) {
@@ -158,6 +165,7 @@ export default function PresentationNode({
             parents={thisAndParents}
             onNodePathSelected={onNodePathSelected}
             isInTriumphs={isInTriumphs}
+            isParentLegacy={isLegacy}
           />
         ))}
       {childrenExpanded && visible > 0 && (
@@ -166,6 +174,8 @@ export default function PresentationNode({
           ownedItemHashes={ownedItemHashes}
           completedRecordsHidden={completedRecordsHidden}
           redactedRecordsRevealed={redactedRecordsRevealed}
+          unobtainableRecordsHidden={unobtainableRecordsHidden}
+          isParentLegacy={isLegacy}
         />
       )}
     </div>

--- a/src/app/records/PresentationNodeLeaf.tsx
+++ b/src/app/records/PresentationNodeLeaf.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Collectible from './Collectible';
 import Craftable from './Craftable';
 import Metrics from './Metrics';
@@ -13,11 +12,15 @@ export default function PresentationNodeLeaf({
   ownedItemHashes,
   completedRecordsHidden,
   redactedRecordsRevealed,
+  unobtainableRecordsHidden,
+  isParentLegacy,
 }: {
   node: DimPresentationNodeLeaf;
   ownedItemHashes?: Set<number>;
   completedRecordsHidden: boolean;
   redactedRecordsRevealed: boolean;
+  unobtainableRecordsHidden: boolean;
+  isParentLegacy?: boolean;
 }) {
   const seenRecords = new Set<number>();
 
@@ -48,6 +51,8 @@ export default function PresentationNodeLeaf({
                 record={record}
                 completedRecordsHidden={completedRecordsHidden}
                 redactedRecordsRevealed={redactedRecordsRevealed}
+                unobtainableRecordsHidden={unobtainableRecordsHidden}
+                isParentLegacy={isParentLegacy}
               />
             );
           })}

--- a/src/app/records/PresentationNodeRoot.tsx
+++ b/src/app/records/PresentationNodeRoot.tsx
@@ -21,6 +21,7 @@ interface Props {
   isTriumphs?: boolean;
   overrideName?: string;
   completedRecordsHidden?: boolean;
+  unobtainableRecordsHidden?: boolean;
 
   /** Whether to show extra plugsets */
   showPlugSets?: boolean;
@@ -42,6 +43,7 @@ export default function PresentationNodeRoot({
   isTriumphs,
   overrideName,
   completedRecordsHidden,
+  unobtainableRecordsHidden,
 }: Props) {
   const itemCreationContext = useSelector(createItemContextSelector);
   const defs = useD2Definitions()!;
@@ -76,6 +78,7 @@ export default function PresentationNodeRoot({
       searchQuery.toLowerCase(),
       searchFilter,
       Boolean(completedRecordsHidden),
+      Boolean(unobtainableRecordsHidden),
       undefined,
       defs
     );

--- a/src/app/records/PresentationNodeSearchResults.tsx
+++ b/src/app/records/PresentationNodeSearchResults.tsx
@@ -1,6 +1,5 @@
 import { settingSelector } from 'app/dim-api/selectors';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { DimPresentationNodeSearchResult } from './presentation-nodes';
 import PresentationNodeLeaf from './PresentationNodeLeaf';
@@ -19,6 +18,7 @@ export default function PresentationNodeSearchResults({
   // TODO: make each node in path linkable
   const completedRecordsHidden = useSelector(settingSelector('completedRecordsHidden'));
   const redactedRecordsRevealed = useSelector(settingSelector('redactedRecordsRevealed'));
+  const unobtainableRecordsHidden = useSelector(settingSelector('unobtainableRecordsHidden'));
 
   return (
     <div>
@@ -49,6 +49,7 @@ export default function PresentationNodeSearchResults({
                     ownedItemHashes={ownedItemHashes}
                     completedRecordsHidden={completedRecordsHidden}
                     redactedRecordsRevealed={redactedRecordsRevealed}
+                    unobtainableRecordsHidden={unobtainableRecordsHidden}
                   />
                 );
               })()}
@@ -57,6 +58,7 @@ export default function PresentationNodeSearchResults({
               ownedItemHashes={ownedItemHashes}
               completedRecordsHidden={completedRecordsHidden}
               redactedRecordsRevealed={redactedRecordsRevealed}
+              unobtainableRecordsHidden={unobtainableRecordsHidden}
             />
           </div>
         </div>

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -32,6 +32,8 @@ interface Props {
   record: DimRecord;
   completedRecordsHidden: boolean;
   redactedRecordsRevealed: boolean;
+  unobtainableRecordsHidden?: boolean;
+  isParentLegacy?: boolean;
   hideRecordIcon?: boolean;
 }
 
@@ -49,6 +51,8 @@ export default function Record({
   record,
   completedRecordsHidden,
   redactedRecordsRevealed,
+  unobtainableRecordsHidden,
+  isParentLegacy,
   hideRecordIcon,
 }: Props) {
   const defs = useD2Definitions()!;
@@ -59,6 +63,7 @@ export default function Record({
 
   const acquired = Boolean(state & DestinyRecordState.RecordRedeemed);
   const unlocked = !acquired && !(state & DestinyRecordState.ObjectiveNotCompleted);
+  const unobtainable = !acquired && isParentLegacy && state && DestinyRecordState.RewardUnavailable;
   const obscured =
     !redactedRecordsRevealed &&
     !unlocked &&
@@ -85,6 +90,9 @@ export default function Record({
     : recordDef.displayProperties.icon;
 
   if (completedRecordsHidden && acquired) {
+    return null;
+  }
+  if (unobtainableRecordsHidden && unobtainable) {
     return null;
   }
 

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -10,7 +10,6 @@ import { searchFilterSelector } from 'app/search/search-filter';
 import { useSetting } from 'app/settings/hooks';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import _ from 'lodash';
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 import { DestinyAccount } from '../accounts/destiny-account';
@@ -47,6 +46,9 @@ export default function Records({ account }: Props) {
   const [completedRecordsHidden, setCompletedRecordsHidden] = useSetting('completedRecordsHidden');
   const [redactedRecordsRevealed, setRedactedRecordsRevealed] =
     useSetting('redactedRecordsRevealed');
+  const [unobtainableRecordsHidden, setUnobtainableRecordsHidden] = useSetting(
+    'unobtainableRecordsHidden'
+  );
 
   const defs = useD2Definitions();
 
@@ -105,6 +107,8 @@ export default function Records({ account }: Props) {
 
   const onToggleCompletedRecordsHidden = (checked: boolean) => setCompletedRecordsHidden(checked);
   const onToggleRedactedRecordsRevealed = (checked: boolean) => setRedactedRecordsRevealed(checked);
+  const onToggleUnobtainableRecordsHidden = (checked: boolean) =>
+    setUnobtainableRecordsHidden(checked);
 
   return (
     <PageWithMenu className="d2-vendors">
@@ -132,6 +136,13 @@ export default function Records({ account }: Props) {
             onChange={onToggleRedactedRecordsRevealed}
           >
             {t('Triumphs.RevealRedacted')}
+          </CheckButton>
+          <CheckButton
+            name="hide-unobtainable"
+            checked={unobtainableRecordsHidden}
+            onChange={onToggleUnobtainableRecordsHidden}
+          >
+            {t('Triumphs.HideUnobtainableTriumphs')}
           </CheckButton>
         </div>
       </PageWithMenu.Menu>

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -164,6 +164,7 @@ export function filterPresentationNodesToSearch(
   searchQuery: string,
   filterItems: ItemFilter,
   completedRecordsHidden: boolean,
+  unobtainableRecordsHidden: boolean,
   path: DimPresentationNode[] = [],
   defs: D2ManifestDefinitions
 ): DimPresentationNodeSearchResult[] {
@@ -181,6 +182,7 @@ export function filterPresentationNodesToSearch(
         searchQuery,
         filterItems,
         completedRecordsHidden,
+        unobtainableRecordsHidden,
         [...path, node],
         defs
       )

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -5,6 +5,9 @@ import { defaultLanguage } from 'app/i18n';
  * We extend the settings interface so we can try out new settings before committing them to dim-api-types
  */
 export interface Settings extends DimApiSettings {
+  /** allows hiding unobtainable triumphs and seals */
+  unobtainableRecordsHidden: boolean;
+
   /** supplements itemSortOrderCustom by allowing each sort to be reversed */
   itemSortReversals: string[];
 
@@ -27,6 +30,7 @@ export interface Settings extends DimApiSettings {
 export const initialSettingsState: Settings = {
   ...defaultSettings,
   language: defaultLanguage(),
+  unobtainableRecordsHidden: false,
   itemSortReversals: [],
   descriptionsToDisplay: 'both',
   compareWeaponMasterwork: false,

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1163,7 +1163,8 @@
   "Triumphs": {
     "GildingTriumph": "Gilding Triumph",
     "HideCompleted": "Hide completed triumphs",
-    "RevealRedacted": "Reveal redacted triumphs"
+    "RevealRedacted": "Reveal redacted triumphs",
+    "HideUnobtainableTriumphs": "Hide unobtainable triumphs"
   },
   "Vendors": {
     "Collections": "Collections",


### PR DESCRIPTION
Addressing #8924 

Still a bit WIP see if it's an ok direction - doing a hack right now to decide if a record is Legacy or not 

Currently mirrors behavior of `Hide completed triumphs` flag

<img width="1387" alt="Screenshot 2023-02-11 at 1 10 33 PM" src="https://user-images.githubusercontent.com/9992882/218281402-07486c4c-a04a-4d02-850a-1862cd999ab3.png">
<img width="1119" alt="Screenshot 2023-02-11 at 1 10 41 PM" src="https://user-images.githubusercontent.com/9992882/218281410-7855f294-72ad-404f-b6da-1fa8be6a861f.png">
