### PR TITLE
D2 core settings may not be loaded if the API is down

### DIFF
--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -41,7 +41,7 @@ let awaCache: {
 export function canInsertPlug(
   socket: DimSocket,
   plugItemHash: number,
-  destiny2CoreSettings: Destiny2CoreSettings,
+  destiny2CoreSettings: Destiny2CoreSettings | undefined,
   defs: D2ManifestDefinitions
 ) {
   return $featureFlags.awa || canInsertForFree(socket, plugItemHash, destiny2CoreSettings, defs);
@@ -61,15 +61,18 @@ function hasInsertionCost(defs: D2ManifestDefinitions, plug: DestinyInventoryIte
 function canInsertForFree(
   socket: DimSocket,
   plugItemHash: number,
-  destiny2CoreSettings: Destiny2CoreSettings,
+  destiny2CoreSettings: Destiny2CoreSettings | undefined,
   defs: D2ManifestDefinitions
 ) {
-  const { insertPlugFreeProtectedPlugItemHashes, insertPlugFreeBlockedSocketTypeHashes } =
-    destiny2CoreSettings;
   const pluggedDef = (socket.actuallyPlugged || socket.plugged)?.plugDef;
   if (
-    (pluggedDef && (insertPlugFreeProtectedPlugItemHashes || []).includes(pluggedDef.hash)) ||
-    (insertPlugFreeBlockedSocketTypeHashes || []).includes(socket.socketDefinition.socketTypeHash)
+    (pluggedDef &&
+      (destiny2CoreSettings?.insertPlugFreeProtectedPlugItemHashes || []).includes(
+        pluggedDef.hash
+      )) ||
+    (destiny2CoreSettings?.insertPlugFreeBlockedSocketTypeHashes || []).includes(
+      socket.socketDefinition.socketTypeHash
+    )
   ) {
     return false;
   }
@@ -136,7 +139,7 @@ export function insertPlug(item: DimItem, socket: DimSocket, plugItemHash: numbe
   return async (dispatch, getState) => {
     const account = currentAccountSelector(getState())!;
     const defs = d2ManifestSelector(getState())!;
-    const coreSettings = getState().manifest.destiny2CoreSettings!;
+    const coreSettings = getState().manifest.destiny2CoreSettings;
 
     // This is a special case for transmog ornaments - you can't apply a
     // transmog ornament to the same item it was created with. So instead we

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -8,6 +8,7 @@ import { loadClarity } from 'app/clarity/descriptions/loadDescriptions';
 import { settingSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { maxLightItemSet } from 'app/loadout-drawer/auto-loadouts';
+import { loadCoreSettings } from 'app/manifest/actions';
 import { d2ManifestSelector, manifestSelector } from 'app/manifest/selectors';
 import { getCharacterProgressions } from 'app/progress/selectors';
 import { get, set } from 'app/storage/idb-keyval';
@@ -132,6 +133,7 @@ export function loadStores(): ThunkResult<DimStore[] | undefined> {
       }
     }
 
+    dispatch(loadCoreSettings()); // no need to wait
     $featureFlags.clarityDescriptions && dispatch(loadClarity()); // no need to await
     await dispatch(loadNewItems(account));
     const stores = await dispatch(loadStoresData(account));

--- a/src/app/strip-sockets/strip-sockets.ts
+++ b/src/app/strip-sockets/strip-sockets.ts
@@ -67,7 +67,7 @@ export const artifactModsSelector = createSelector(
 
 export function collectSocketsToStrip(
   filteredItems: DimItem[],
-  destiny2CoreSettings: Destiny2CoreSettings,
+  destiny2CoreSettings: Destiny2CoreSettings | undefined,
   defs: D2ManifestDefinitions,
   artifactMods: Set<number> | undefined
 ) {


### PR DESCRIPTION
Saw this in Sentry - the fix is to handle when core settings are missing, and to reload them every stores load if they're still missing. Future work would be to stash the results in IDB.