### PR TITLE
fix: shift-clicking rpm shows === rpm weapons

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -160,10 +160,10 @@ export function getColumns(
             return <ItemStatValue stat={stat} item={item} />;
           },
           defaultSort: statInfo.lowerBetter ? SortDirection.ASC : SortDirection.DESC,
-          filter: (value) =>
-            `stat:${_.invert(statHashByName)[statHash]}:${
-              _.invert(statHashByName)[statHash] === `rof` ? `` : `>`
-            }=${value}`,
+          filter: (value) => {
+            const statName = _.invert(statHashByName)[statHash];
+            return `stat:${statName}:${statName === 'rof' ? '=' : '>='}${value}`;
+          },
         };
       })
     ),

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -160,7 +160,10 @@ export function getColumns(
             return <ItemStatValue stat={stat} item={item} />;
           },
           defaultSort: statInfo.lowerBetter ? SortDirection.ASC : SortDirection.DESC,
-          filter: (value) => `stat:${_.invert(statHashByName)[statHash]}:>=${value}`,
+          filter: (value) =>
+            `stat:${_.invert(statHashByName)[statHash]}:${
+              _.invert(statHashByName)[statHash] === `rof` ? `` : `>`
+            }=${value}`,
         };
       })
     ),


### PR DESCRIPTION
Addressing issue #9067. After a wild goose chase of variable and type definition tracking, I've found the culprit and have added a working fix that checks if the selected search filter term matches "rof", then removes the > symbol from the search, which will now show all weapons of that matching rpm / rof and no others.

Hope this helps, and if there's any problems with the PR or implementation of the fix please let me know. 