### PR TITLE
Updated and improved flow of contributing.md doc

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Here are some tips to make sure your Pull Request (PR) can be merged smoothly:
 
 ### Clone the repo
 
-If you only want to **run a copy** of DIM locally and are not interested in contributing changes to the project, you can directly clone the original repository to your local machine using
+To locally **run a copy** of DIM, you can simply clone the code repository:
 ```sh
 git clone https://github.com/DestinyItemManager/DIM.git
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Here are some tips to make sure your Pull Request (PR) can be merged smoothly:
 
 1. [Install Pre-requisites](#pre-requisites)
 1. [Clone](#clone-the-repo)
-1. [Get your own API key](#get-your-own-api-key)
 1. [Start Dev Server](#start-dev-server)
+1. [Get your own API key](#get-your-own-api-key)
 1. [Enter API credentials](#enter-api-credentials)
 
 ### Pre-requisites
@@ -22,17 +22,17 @@ Here are some tips to make sure your Pull Request (PR) can be merged smoothly:
 * Install [Git](https://git-scm.com/downloads)
 * Install [NodeJS](https://nodejs.org/).
 * Install [Yarn](https://yarnpkg.com/en/docs/install). If you're used to NPM, see "[Migrating from NPM](https://yarnpkg.com/lang/en/docs/migrating-from-npm/)".
-* Windows-based developers will need to install `windows-build-tools` (`yarn global add windows-build-tools`) globally prior to running `yarn install`. Refer to issue #1439 for [details](https://github.com/DestinyItemManager/DIM/issues/1439).
-* It is highly recommended to use [VSCode](https://code.visualstudio.com/) to work on DIM. When you open DIM in VSCode, accept the recommended plugins it suggests.
+* Windows-based developers will need to install `windows-build-tools` (run `yarn global add windows-build-tools` in your terminal) globally prior to running `yarn install`. Refer to issue #1439 for [details](https://github.com/DestinyItemManager/DIM/issues/1439).
+* It is highly recommended to use [VSCode](https://code.visualstudio.com/) to work on DIM. When you open DIM in VSCode, accept the recommended plugins it suggests (find them manually by searching "@recommended" in the Extensions window).
 * Linux-based developers will need to install `build-essential` (`sudo apt-get install -y build-essential`) prior to running `yarn install`.
 
 **Docker Development**
 * As an alternative to installing the above, you can try a docker-based development environment, but be aware that none of the core developers use it so it may be broken. See: [Docker Development Guide](Docker.md)
 
-
 ### Clone the repo
 
 To locally **run a copy** of DIM, you can simply clone the code repository:
+If you only want to **run a copy** of DIM locally and are not interested in contributing changes to the project, you can directly clone the original repository to your local machine using
 ```sh
 git clone https://github.com/DestinyItemManager/DIM.git
 ```
@@ -40,15 +40,25 @@ git clone https://github.com/DestinyItemManager/DIM.git
 To **contribute changes to the project**, you'll want to:
 
 1. Fork DIM to make your own copy of the repository
+1. Clone the forked repository to your local machine
 1. Edit the local files
 1. Commit and push your code changes to your fork
-1. Create a Pull Request, allowing DIM maintainers to accept and merge your changes
+1. Create a Pull Request from your forked repository to the original upstream repository, allowing DIM maintainers to accept and merge your changes
 
 More detailed information on these steps is [here](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).
 
+### Start Dev Server
+
+Once you have cloned the repository or a fork of the repository to your local machine, in the root directory:
+
+* Run `yarn install`
+* Run `yarn start`
+
+On Windows machines this will also install SnoreToast to provide notifications for parts of the development process, like when a build completes.
+
 ### Get your own API key:
 
-1. Go to [Bungie](https://www.bungie.net/en/Application)
+1. Go to [Bungie's Developer Portal](https://www.bungie.net/en/Application) (you will have to be signed in)
 1. Click `Create New App`
 1. Enter any application name
 1. Enter `https://github.com/YourGithubUsername/DIM` under website
@@ -56,19 +66,16 @@ More detailed information on these steps is [here](https://docs.github.com/en/ge
 1. Set your redirect url to `https://localhost:8080/return.html` (or whatever the IP or hostname is of your dev server)
 1. Select all scopes _except_ the Administrate Groups/Clans
 1. Enter `https://localhost:8080` as the `Origin Header`
-
-### Start Dev Server
-
-* Run `yarn install`
-* Run `yarn start`
+1. Check the box to agree to the Terms of Use and click Create New App
 
 ### Enter API Credentials
 
 This step will need to be done each time you clear your browser cache. You will be automatically redirected to a screen to enter these credentials
 if the app can't load them from local storage when it starts.
 
-1. Open your browser and navigate to https://localhost:8080
-1. Copy your API-key, Oauth Client_id, and OAuth client_secret from bungie.net into DIM developer settings panel when it is loaded.
+1. Open your browser and navigate to https://localhost:8080 (your browser will likely give a security warning, it is safe to continue anyways, see Overview below for details)
+1. Copy your API-key, Oauth Client_id, and OAuth client_secret from bungie.net into DIM developer settings panel when it is loaded
+1. Below the section for Bungie API credentials, follow the instructions to generate a DIM API key
 
 ### Development
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Here are some tips to make sure your Pull Request (PR) can be merged smoothly:
 
 * Install [Git](https://git-scm.com/downloads)
 * Install [NodeJS](https://nodejs.org/).
-* Install [Yarn](https://yarnpkg.com/en/docs/install). If you're used to NPM, see "[Migrating from NPM](https://yarnpkg.com/lang/en/docs/migrating-from-npm/)".
+* Install [Yarn](https://yarnpkg.com/en/docs/install). Use Yarn 1.x as DIM is not guaranteed to be compatible with later versions of Yarn. If you're used to NPM, see "[Migrating from NPM](https://yarnpkg.com/lang/en/docs/migrating-from-npm/)".
 * Windows-based developers will need to install `windows-build-tools` (run `yarn global add windows-build-tools` in your terminal) globally prior to running `yarn install`. Refer to issue #1439 for [details](https://github.com/DestinyItemManager/DIM/issues/1439).
 * It is highly recommended to use [VSCode](https://code.visualstudio.com/) to work on DIM. When you open DIM in VSCode, accept the recommended plugins it suggests (find them manually by searching "@recommended" in the Extensions window).
 * Linux-based developers will need to install `build-essential` (`sudo apt-get install -y build-essential`) prior to running `yarn install`.
@@ -31,7 +31,6 @@ Here are some tips to make sure your Pull Request (PR) can be merged smoothly:
 
 ### Clone the repo
 
-To locally **run a copy** of DIM, you can simply clone the code repository:
 If you only want to **run a copy** of DIM locally and are not interested in contributing changes to the project, you can directly clone the original repository to your local machine using
 ```sh
 git clone https://github.com/DestinyItemManager/DIM.git


### PR DESCRIPTION
Added notes or improved wording for
- yarn version
- installing windows build tools
- finding recommended extensions in VSCode
- only running a local copy versus contributing
- installation of Snore Toast for windows machines
- generating Bungie API credentials
- accessing the locally hosted dev server

And changed the order of the "Get your own API key" and "Start Dev Server" steps