### PR TITLE
Modify hashtag regex to add support for non-English characters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * The `inloadout` filter now finds hashtags in Loadout notes.
+* Support for non-English hashtags.
 
 ## 7.57.0 <span class="changelog-date">(2023-02-19)</span>
 

--- a/src/app/inventory/note-hashtags.ts
+++ b/src/app/inventory/note-hashtags.ts
@@ -18,5 +18,5 @@ export function collectNotesHashtags(itemInfos: ItemInfos) {
 }
 
 export function getHashtagsFromNote(note?: string | null) {
-  return Array.from(note?.matchAll(/#[\w\uE000-\uF8FF]+/g) ?? [], (m) => m[0]);
+  return Array.from(note?.matchAll(/#[\p{L}\p{N}_\uE000-\uF8FF]+/gu) ?? [], (m) => m[0]);
 }


### PR DESCRIPTION
Currently DIM only supports hashtags in English characters.
As there are many peoples using non-English languages like Korean, Japanese, Chinese, etc..,
It would be nice to have these languages in DIM's hashtags.

this patch simply replaces hashtag regex to include all unicode language letters and numbers(\w -> \p{L}\p{N}_), it will work exactly same as before except it supports other languages.

test cases in other languages:
#item_hashtag_test
#아이템_해시태그_테스트
#アイテム_ハッシュタグ_テスト
#项目标签测试

Current version of DIM (doesn't support unicode hashtags)
![image](https://user-images.githubusercontent.com/1342163/220273482-23599a5c-93d8-4aea-8465-cbaa5f28393b.png)

patched DIM with unicode hashtags support
![image](https://user-images.githubusercontent.com/1342163/220274236-7012c848-7f11-4a30-bf25-12f162987a46.png)

filtering by loadout hashtags (#로드아웃_해시태그_테스트)
![image](https://user-images.githubusercontent.com/1342163/220274629-0c0fd43e-7504-4a6e-a73a-fac2f5be6600.png)
![image](https://user-images.githubusercontent.com/1342163/220278615-e3007441-e1e8-4cd9-8cf3-298b5b439301.png)

