### PR TITLE
Update DIM's loadout mods model to Lightfall

### DIFF
--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -10,14 +10,12 @@ import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { allItemsSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { isValidMasterworkStat } from 'app/inventory/store/masterwork';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import { unlockedByAllModsBeingUnlocked } from 'app/loadout/mod-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import { collectionsVisibleShadersSelector } from 'app/records/selectors';
 import { weaponMasterworkY2SocketTypeHash } from 'app/search/d2-known-values';
 import { createPlugSearchPredicate } from 'app/search/plug-search';
 import { SearchInput } from 'app/search/SearchInput';
-import { artifactModsSelector } from 'app/strip-sockets/strip-sockets';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptySet } from 'app/utils/empty';
 import {
@@ -138,7 +136,6 @@ export default function SocketDetails({
   onPlugSelected?: (value: { item: DimItem; socket: DimSocket; plugHash: number }) => void;
 }) {
   const defs = useD2Definitions()!;
-  const artifactMods = useSelector(artifactModsSelector);
   const plugged = socket.plugged?.plugDef;
   const actuallyPlugged = (socket.actuallyPlugged || socket.plugged)?.plugDef;
   const [selectedPlug, setSelectedPlug] = useState<PluggableInventoryItemDefinition | null>(
@@ -205,8 +202,7 @@ export default function SocketDetails({
   const unlocked = (i: PluggableInventoryItemDefinition) =>
     i.hash === socket.emptyPlugItemHash ||
     unlockedPlugs.has(i.hash) ||
-    otherUnlockedPlugs.has(i.hash) ||
-    unlockedByAllModsBeingUnlocked(i, artifactMods);
+    otherUnlockedPlugs.has(i.hash);
 
   const searchFilter = createPlugSearchPredicate(query, language, defs);
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -15,7 +15,7 @@ import { isPluggableItem } from 'app/inventory/store/sockets';
 import { convertDimLoadoutToApiLoadout } from 'app/loadout-drawer/loadout-type-converters';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { newLoadout, newLoadoutFromEquipped } from 'app/loadout-drawer/loadout-utils';
-import { loadoutsByItemSelector, loadoutsSelector } from 'app/loadout-drawer/selectors';
+import { loadoutsSelector } from 'app/loadout-drawer/selectors';
 import { categorizeArmorMods } from 'app/loadout/mod-assignment-utils';
 import { d2ManifestSelector, useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
@@ -125,7 +125,6 @@ export default memo(function LoadoutBuilder({
   const defs = useD2Definitions()!;
   const allLoadouts = useSelector(loadoutsSelector);
   const allItems = useSelector(allItemsSelector);
-  const loadoutsByItem = useSelector(loadoutsByItemSelector);
   const searchFilter = useSelector(searchFilterSelector);
   const searchQuery = useSelector(querySelector);
   const halfTierMods = useSelector(halfTierModsSelector);
@@ -214,11 +213,7 @@ export default memo(function LoadoutBuilder({
       })),
       statOrder
     );
-    const newSavedLoadoutParams = _.pick(
-      newLoadoutParameters,
-      'assumeArmorMasterwork',
-      'lockArmorEnergyType'
-    );
+    const newSavedLoadoutParams = _.pick(newLoadoutParameters, 'assumeArmorMasterwork');
 
     setSetting('loParameters', newSavedLoadoutParams);
     setSetting('loStatConstraintsByClass', {
@@ -269,14 +264,7 @@ export default memo(function LoadoutBuilder({
   const [armorEnergyRules, filteredItems, filterInfo] = useMemo(() => {
     const armorEnergyRules: ArmorEnergyRules = {
       ...loDefaultArmorEnergyRules,
-      loadouts: {
-        loadoutsByItem,
-        optimizingLoadoutId,
-      },
     };
-    if (loadoutParameters.lockArmorEnergyType !== undefined) {
-      armorEnergyRules.lockArmorEnergyType = loadoutParameters.lockArmorEnergyType;
-    }
     if (loadoutParameters.assumeArmorMasterwork !== undefined) {
       armorEnergyRules.assumeArmorMasterwork = loadoutParameters.assumeArmorMasterwork;
     }
@@ -293,9 +281,6 @@ export default memo(function LoadoutBuilder({
     });
     return [armorEnergyRules, items, filterInfo];
   }, [
-    loadoutsByItem,
-    optimizingLoadoutId,
-    loadoutParameters.lockArmorEnergyType,
     loadoutParameters.assumeArmorMasterwork,
     defs,
     characterItems,
@@ -395,8 +380,6 @@ export default memo(function LoadoutBuilder({
       />
       <EnergyOptions
         assumeArmorMasterwork={loadoutParameters.assumeArmorMasterwork}
-        lockArmorEnergyType={loadoutParameters.lockArmorEnergyType}
-        optimizingLoadoutName={preloadedLoadout?.name}
         lbDispatch={lbDispatch}
       />
       <LockArmorAndPerks

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -36,10 +36,9 @@ const UPPER_STAT_BOUNDS_WARN_RATIO = 0.8;
  */
 const LOWER_STAT_BOUNDS_WARN_RATIO = 0.95;
 /**
- * >98% usually only happens when you select activity mods or restrictive mod settings and tons
- * of combat mods with the same element
+ * Pretty much only from activity mods or too many expensive mods.
  */
-const EARLY_MOD_REJECTION_WARN_RATIO = 0.98;
+const EARLY_MOD_REJECTION_WARN_RATIO = 0.8;
 
 export default function NoBuildsFoundExplainer({
   defs,
@@ -187,11 +186,7 @@ export default function NoBuildsFoundExplainer({
 
   const anyStatMinimums = Object.values(statFilters).some((f) => !f.ignored && f.min > 0);
 
-  const bucketIndependentMods = [
-    ...lockedModMap.generalMods,
-    ...lockedModMap.combatMods,
-    ...lockedModMap.activityMods,
-  ];
+  const bucketIndependentMods = [...lockedModMap.generalMods, ...lockedModMap.activityMods];
 
   const capacityMayCauseProblems =
     armorEnergyRules.assumeArmorMasterwork !== AssumeArmorMasterwork.All &&
@@ -351,14 +346,14 @@ export default function NoBuildsFoundExplainer({
       const suggestions: (ActionableSuggestion | false | undefined)[] = [];
 
       if (isInteresting(modsStats.earlyModsCheck, EARLY_MOD_REJECTION_WARN_RATIO)) {
-        // Early mod rejection is armor elements / mod tags
+        // Early mod rejection is mod tags
         suggestions.push(
-          (lockedModMap.combatMods.length > 0 || lockedModMap.activityMods.length > 0) && {
+          lockedModMap.activityMods.length > 0 && {
             id: 'removeElementOrTagMods',
             contents: (
               <>
                 {t('LoadoutBuilder.NoBuildsFoundExplainer.MaybeRemoveMods')}
-                {modRow([...lockedModMap.combatMods, ...lockedModMap.activityMods])}
+                {modRow([...lockedModMap.activityMods])}
               </>
             ),
           },

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -1,4 +1,4 @@
-import { AssumeArmorMasterwork, LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
+import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import { t } from 'app/i18next-t';
@@ -7,7 +7,6 @@ import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import { ModMap } from 'app/loadout/mod-assignment-utils';
 import { AppIcon, banIcon } from 'app/shell/icons';
 import { uniqBy } from 'app/utils/util';
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { Dispatch } from 'react';
 import ExoticArmorChoice from './filter/ExoticArmorChoice';
@@ -194,14 +193,6 @@ export default function NoBuildsFoundExplainer({
     ...lockedModMap.activityMods,
   ];
 
-  const elementMayCauseProblems =
-    armorEnergyRules.lockArmorEnergyType !== LockArmorEnergyType.None &&
-    (processInfo?.statistics.modsStatistics.earlyModsCheck.timesFailed ||
-      processInfo?.statistics.modsStatistics.finalAssignment.modsAssignmentFailed ||
-      failedModsInBucket) &&
-    lockedModMap.allMods.some(
-      (mod) => mod.plug.energyCost && mod.plug.energyCost.energyType !== DestinyEnergyType.Any
-    );
   const capacityMayCauseProblems =
     armorEnergyRules.assumeArmorMasterwork !== AssumeArmorMasterwork.All &&
     (processInfo?.statistics.modsStatistics.finalAssignment.modsAssignmentFailed ||
@@ -209,10 +200,7 @@ export default function NoBuildsFoundExplainer({
       failedModsInBucket) &&
     (lockedModMap.allMods.length || anyStatMinimums);
 
-  if (
-    (!alwaysInvalidMods || alwaysInvalidMods.length === 0) &&
-    (elementMayCauseProblems || capacityMayCauseProblems)
-  ) {
+  if ((!alwaysInvalidMods || alwaysInvalidMods.length === 0) && capacityMayCauseProblems) {
     // If we might have problems assigning bucket specific mods or mods in the
     // process worker, offer some advice.
     problems.push({
@@ -234,24 +222,6 @@ export default function NoBuildsFoundExplainer({
               }
             >
               {t('LoadoutBuilder.NoBuildsFoundExplainer.AssumeMasterworked')}
-            </button>
-          ),
-        },
-        elementMayCauseProblems && {
-          id: 'allowEnergyChanges',
-          contents: (
-            <button
-              key="allowEnergyChanges"
-              type="button"
-              className="dim-button"
-              onClick={() =>
-                dispatch({
-                  type: 'lockArmorEnergyTypeChanged',
-                  lockArmorEnergyType: LockArmorEnergyType.None,
-                })
-              }
-            >
-              {t('LoadoutBuilder.NoBuildsFoundExplainer.AssumeElementChange')}
             </button>
           ),
         },

--- a/src/app/loadout-builder/filter/EnergyOptions.tsx
+++ b/src/app/loadout-builder/filter/EnergyOptions.tsx
@@ -1,4 +1,4 @@
-import { AssumeArmorMasterwork, LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
+import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import clsx from 'clsx';
@@ -58,68 +58,11 @@ function RadioButton({ label, tooltip, name, selected, onChange }: Option & { na
 
 export default function EnergyOptions({
   assumeArmorMasterwork,
-  lockArmorEnergyType,
-  optimizingLoadoutName,
   lbDispatch,
 }: {
   assumeArmorMasterwork: AssumeArmorMasterwork | undefined;
-  lockArmorEnergyType: LockArmorEnergyType | undefined;
-  optimizingLoadoutName: string | undefined;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
-  const lockEnergyOptions: Option[] = useMemo(
-    () => [
-      {
-        label: t('LoadoutBuilder.None'),
-        tooltip: t('LoadoutBuilder.LockElementOptions.None'),
-        selected: !lockArmorEnergyType || lockArmorEnergyType === LockArmorEnergyType.None,
-        onChange: () => {
-          if (lockArmorEnergyType && lockArmorEnergyType !== LockArmorEnergyType.None) {
-            lbDispatch({
-              type: 'lockArmorEnergyTypeChanged',
-              lockArmorEnergyType: LockArmorEnergyType.None,
-            });
-          }
-        },
-      },
-      {
-        label:
-          optimizingLoadoutName !== undefined
-            ? t('LoadoutBuilder.InOtherLoadouts')
-            : t('LoadoutBuilder.InLoadouts'),
-        tooltip:
-          optimizingLoadoutName !== undefined
-            ? t('LoadoutBuilder.LockElementOptions.InOtherLoadouts', {
-                loadoutName: optimizingLoadoutName,
-              })
-            : t('LoadoutBuilder.LockElementOptions.InLoadouts'),
-        selected: lockArmorEnergyType === LockArmorEnergyType.Masterworked,
-        onChange: () => {
-          if (lockArmorEnergyType !== LockArmorEnergyType.Masterworked) {
-            lbDispatch({
-              type: 'lockArmorEnergyTypeChanged',
-              lockArmorEnergyType: LockArmorEnergyType.Masterworked,
-            });
-          }
-        },
-      },
-      {
-        label: t('LoadoutBuilder.All'),
-        tooltip: t('LoadoutBuilder.LockElementOptions.All'),
-        selected: lockArmorEnergyType === LockArmorEnergyType.All,
-        onChange: () => {
-          if (lockArmorEnergyType !== LockArmorEnergyType.All) {
-            lbDispatch({
-              type: 'lockArmorEnergyTypeChanged',
-              lockArmorEnergyType: LockArmorEnergyType.All,
-            });
-          }
-        },
-      },
-    ],
-    [lbDispatch, lockArmorEnergyType, optimizingLoadoutName]
-  );
-
   const assumeMasterworkOptions: Option[] = useMemo(
     () => [
       {
@@ -167,11 +110,6 @@ export default function EnergyOptions({
 
   return (
     <div className={styles.energyOptions}>
-      <RadioSetting
-        name="lockElement"
-        label={t('LoadoutBuilder.LockElement')}
-        options={lockEnergyOptions}
-      />
       <RadioSetting
         name="assumeMasterwork"
         label={t('LoadoutBuilder.AssumeMasterwork')}

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
@@ -86,6 +86,7 @@
   composes: dim-button from global;
   justify-self: center;
   margin-top: 4px;
+
   @include phone-portrait {
     padding: 8px 20px;
   }
@@ -94,6 +95,7 @@
 .swapButtonContainer {
   display: grid;
   min-height: 24px;
+
   @include phone-portrait {
     min-height: 32px;
   }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -5,7 +5,6 @@ import Sockets from 'app/loadout/loadout-ui/Sockets';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
 import { AppIcon, faRandom, lockIcon } from 'app/shell/icons';
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -31,29 +30,9 @@ function EnergySwap({
   const armorEnergy = defs.EnergyType.get(item.energy!.energyTypeHash);
 
   const modCost = _.sumBy(assignedMods, (mod) => mod.plug.energyCost?.energyCost || 0);
-  const modEnergyHashNotAny = assignedMods?.find(
-    (mod) =>
-      mod.plug.energyCost &&
-      mod.plug.energyCost.energyCost > 0 &&
-      mod.plug.energyCost.energyType !== DestinyEnergyType.Any
-  )?.plug.energyCost?.energyTypeHash;
-  const modEnergy = (modEnergyHashNotAny && defs.EnergyType.get(modEnergyHashNotAny)) || null;
+  const resultingEnergyCapacity = Math.max(armorEnergyCapacity, modCost);
 
-  // The armor energy type and capacity needed for the mods
-  const resultingEnergy = modEnergy ?? armorEnergy;
-  let resultingEnergyCapacity = armorEnergyCapacity;
-
-  // If there is a mod energy type and it's different to the armor energy type
-  // we always use the mod cost as we are swapping energy types on the armor
-  if (modEnergyHashNotAny && modEnergyHashNotAny !== armorEnergy.hash) {
-    resultingEnergyCapacity = modCost;
-  } else {
-    // Otherwise we just take the max of armor capacity and mod cost
-    resultingEnergyCapacity = Math.max(armorEnergyCapacity, modCost);
-  }
-
-  const noEnergyChange =
-    resultingEnergyCapacity === armorEnergyCapacity && resultingEnergy === armorEnergy;
+  const noEnergyChange = resultingEnergyCapacity === armorEnergyCapacity;
 
   return (
     <div className={clsx(styles.energySwapContainer, { [styles.energyHidden]: noEnergyChange })}>
@@ -76,7 +55,7 @@ function EnergySwap({
         >
           {resultingEnergyCapacity}
         </div>
-        <BungieImage className={styles.energyIcon} src={resultingEnergy.displayProperties.icon} />
+        <BungieImage className={styles.energyIcon} src={armorEnergy.displayProperties.icon} />
       </div>
     </div>
   );

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -2,7 +2,6 @@ import {
   AssumeArmorMasterwork,
   defaultLoadoutParameters,
   LoadoutParameters,
-  LockArmorEnergyType,
   StatConstraint,
 } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
@@ -173,6 +172,7 @@ const lbConfigInit = ({
 
   // FIXME: Always require turning on auto mods explicitly for now...
   loadoutParameters = { ...loadoutParameters, autoStatMods: undefined };
+  delete loadoutParameters.lockArmorEnergyType;
 
   return {
     loadoutParameters,
@@ -197,7 +197,6 @@ type LoadoutBuilderConfigAction =
       type: 'assumeArmorMasterworkChanged';
       assumeArmorMasterwork: AssumeArmorMasterwork | undefined;
     }
-  | { type: 'lockArmorEnergyTypeChanged'; lockArmorEnergyType: LockArmorEnergyType | undefined }
   | { type: 'pinItem'; item: DimItem }
   | { type: 'setPinnedItems'; items: DimItem[] }
   | { type: 'unpinItem'; item: DimItem }
@@ -364,13 +363,6 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
         return {
           ...state,
           loadoutParameters: { ...state.loadoutParameters, assumeArmorMasterwork },
-        };
-      }
-      case 'lockArmorEnergyTypeChanged': {
-        const { lockArmorEnergyType } = action;
-        return {
-          ...state,
-          loadoutParameters: { ...state.loadoutParameters, lockArmorEnergyType },
         };
       }
       case 'addGeneralMods': {

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -21,7 +21,6 @@ import {
   pickBackingStore,
 } from 'app/loadout-drawer/loadout-utils';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
-import { isArtificeMod } from 'app/loadout/mod-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
@@ -32,7 +31,7 @@ import {
 } from 'app/utils/socket-utils';
 import { useHistory } from 'app/utils/undo-redo-history';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { BucketHashes } from 'data/d2/generated-enums';
+import { BucketHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { useCallback, useMemo, useReducer } from 'react';
 import { useSelector } from 'react-redux';
@@ -178,7 +177,11 @@ const lbConfigInit = ({
   if (loadoutParameters.mods) {
     loadoutParameters.mods = loadoutParameters.mods.filter((modHash) => {
       const def = defs.InventoryItem.get(modHash);
-      return !def || !isPluggableItem(def) || !isArtificeMod(def);
+      return (
+        !def ||
+        !isPluggableItem(def) ||
+        def.plug.plugCategoryHash !== PlugCategoryHashes.EnhancementsArtifice
+      );
     });
   }
   delete loadoutParameters.lockArmorEnergyType;

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -12,6 +12,7 @@ import {
 import { t } from 'app/i18next-t';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
+import { isPluggableItem } from 'app/inventory/store/sockets';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import {
@@ -20,6 +21,7 @@ import {
   pickBackingStore,
 } from 'app/loadout-drawer/loadout-utils';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
+import { isArtificeMod } from 'app/loadout/mod-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
@@ -172,6 +174,13 @@ const lbConfigInit = ({
 
   // FIXME: Always require turning on auto mods explicitly for now...
   loadoutParameters = { ...loadoutParameters, autoStatMods: undefined };
+  // Also delete artifice mods -- artifice mods are always picked automatically per set.
+  if (loadoutParameters.mods) {
+    loadoutParameters.mods = loadoutParameters.mods.filter((modHash) => {
+      const def = defs.InventoryItem.get(modHash);
+      return !def || !isPluggableItem(def) || !isArtificeMod(def);
+    });
+  }
   delete loadoutParameters.lockArmorEnergyType;
 
   return {

--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.test.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.test.ts
@@ -72,16 +72,16 @@ describe('lo process auto stat mod pick generation', () => {
   ])('for same stats %j generates %i different picks', check);
 
   test.each([
-    [[30, 10, 0, 0, 0, 0], 2],
-    [[10, 20, 0, 0, 0, 0], 3],
-    [[10, 10, 0, 0, 0, 0], 3],
+    [[30, 0, 0, 0, 0, 10], 2],
+    [[10, 0, 0, 0, 0, 20], 3],
+    [[10, 0, 0, 0, 0, 10], 3],
   ])('for stats %j with same mod costs generates minimal equivalent picks %i', check);
 
   test.each([
     // split [none, int, int+rec] (but not rec alone)
     [[0, 0, 10, 0, 10, 0], 3],
-    // split [none, int, res, int+rec, int+res] (but not rec+res)
-    [[0, 10, 10, 0, 10, 0], 5],
+    // split [none, int, str, int+rec, int+str] (but not rec+str)
+    [[0, 10, 0, 0, 10, 10], 5],
     // split [none, rec, mob, mob+mob, rec+mob]
     [[20, 0, 10, 0, 0, 0], 5],
   ])('does not split recovery if intellect can be split for stats %j, generating %i picks', check);
@@ -89,10 +89,10 @@ describe('lo process auto stat mod pick generation', () => {
   test.each([
     [[10, 0, 5, 5, 0, 0], 2],
     [[10, 0, 5, 5, 5, 0], 2],
-    [[10, 10, 5, 5, 0, 0], 2],
-    [[10, 10, 5, 0, 0, 0], 3],
-    [[15, 15, 0, 0, 0, 0], 2],
-    [[10, 15, 0, 0, 0, 0], 3],
+    [[10, 0, 5, 5, 0, 10], 2],
+    [[10, 0, 5, 0, 0, 10], 3],
+    [[15, 0, 0, 0, 0, 15], 2],
+    [[10, 0, 0, 0, 0, 15], 3],
   ])('obeys required minor mods %j to generate %i picks', check);
 });
 

--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.test.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.test.ts
@@ -1,5 +1,4 @@
 import { StatHashes } from 'app/../data/d2/generated-enums';
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import { ArmorStatHashes } from '../types';
 import { createGeneralModsCache, getViableGeneralModPicks, ModsPick } from './auto-stat-mod-utils';
 import { ProcessMod } from './types';
@@ -104,7 +103,6 @@ describe('lo process auto stat mod pick generation with 1 existing mod', () => {
     investmentStats: [],
     plugCategoryHash: -456,
     energy: {
-      type: DestinyEnergyType.Any,
       val: 5,
     },
   };

--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -8,22 +8,22 @@ import { ProcessMod } from './types';
 const largeStatMods: {
   [statHash in ArmorStatHashes]: { hash: number; cost: number; statHash: ArmorStatHashes };
 } = {
-  [StatHashes.Mobility]: { hash: 3961599962, cost: 3, statHash: StatHashes.Mobility },
-  [StatHashes.Resilience]: { hash: 2850583378, cost: 3, statHash: StatHashes.Resilience },
-  [StatHashes.Recovery]: { hash: 2645858828, cost: 4, statHash: StatHashes.Recovery },
-  [StatHashes.Discipline]: { hash: 4048838440, cost: 3, statHash: StatHashes.Discipline },
-  [StatHashes.Intellect]: { hash: 3355995799, cost: 5, statHash: StatHashes.Intellect },
-  [StatHashes.Strength]: { hash: 3253038666, cost: 3, statHash: StatHashes.Strength },
+  [StatHashes.Mobility]: { hash: 4183296050, cost: 3, statHash: StatHashes.Mobility },
+  [StatHashes.Resilience]: { hash: 1180408010, cost: 4, statHash: StatHashes.Resilience },
+  [StatHashes.Recovery]: { hash: 4204488676, cost: 4, statHash: StatHashes.Recovery },
+  [StatHashes.Discipline]: { hash: 1435557120, cost: 3, statHash: StatHashes.Discipline },
+  [StatHashes.Intellect]: { hash: 2724608735, cost: 4, statHash: StatHashes.Intellect },
+  [StatHashes.Strength]: { hash: 4287799666, cost: 3, statHash: StatHashes.Strength },
 };
 
 // Minor stat mods add 5
 const minorStatMods: { [statHash in ArmorStatHashes]: { hash: number; cost: number } } = {
-  [StatHashes.Mobility]: { hash: 204137529, cost: 1 },
-  [StatHashes.Resilience]: { hash: 3682186345, cost: 1 },
-  [StatHashes.Recovery]: { hash: 555005975, cost: 2 },
-  [StatHashes.Discipline]: { hash: 2623485440, cost: 1 },
-  [StatHashes.Intellect]: { hash: 1227870362, cost: 2 },
-  [StatHashes.Strength]: { hash: 3699676109, cost: 1 },
+  [StatHashes.Mobility]: { hash: 1703647492, cost: 1 },
+  [StatHashes.Resilience]: { hash: 2532323436, cost: 2 },
+  [StatHashes.Recovery]: { hash: 1237786518, cost: 2 },
+  [StatHashes.Discipline]: { hash: 4021790309, cost: 1 },
+  [StatHashes.Intellect]: { hash: 350061697, cost: 2 },
+  [StatHashes.Strength]: { hash: 2639422088, cost: 1 },
 };
 
 // If we can split an intellect mod (5 cost into 2, 2 cost), then we don't need to bother with

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -98,16 +98,15 @@ export function process(
 
   const setTracker = new SetTracker(10_000);
 
-  const { activityMods, combatMods, generalMods } = lockedMods;
+  const { activityMods, generalMods } = lockedMods;
 
   const precalculatedInfo = precalculateStructures(
     generalMods,
-    combatMods,
     activityMods,
     autoStatMods,
     statOrder
   );
-  const hasMods = Boolean(combatMods.length || activityMods.length || generalMods.length);
+  const hasMods = Boolean(activityMods.length || generalMods.length);
 
   const setStatistics = {
     skipReasons: {

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -1,4 +1,3 @@
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import { ArmorStats, LockableBucketHash } from '../types';
 
 export interface ProcessItem {
@@ -7,7 +6,6 @@ export interface ProcessItem {
   name: string;
   isExotic: boolean;
   energy?: {
-    type: DestinyEnergyType;
     /** The maximum energy capacity for the item, e.g. if masterworked this will be 10. */
     capacity: number;
     /**
@@ -52,7 +50,6 @@ export interface ProcessMod {
   hash: number;
   plugCategoryHash: number;
   energy?: {
-    type: DestinyEnergyType;
     /** The energy cost of the mod. */
     val: number;
   };

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -60,7 +60,6 @@ export interface ProcessMod {
 
 export interface LockedProcessMods {
   generalMods: ProcessMod[];
-  combatMods: ProcessMod[];
   activityMods: ProcessMod[];
 }
 

--- a/src/app/loadout-builder/process/mappers.test.ts
+++ b/src/app/loadout-builder/process/mappers.test.ts
@@ -1,23 +1,14 @@
-import { AssumeArmorMasterwork, LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
-import { getTestDefinitions, getTestStores } from 'testing/test-utils';
+import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
+import { DimItem } from 'app/inventory/item-types';
+import { getTestStores } from 'testing/test-utils';
 import { loDefaultArmorEnergyRules, MIN_LO_ITEM_ENERGY } from '../types';
 import { mapDimItemToProcessItem } from './mappers';
 
 describe('lo process mappers', () => {
-  let defs: D2ManifestDefinitions;
   let classItem: DimItem;
-  // void class item mod
-  let perpetuationMod: PluggableInventoryItemDefinition;
-  // any class item mod
 
   beforeAll(async () => {
-    const [fetchedDefs, stores] = await Promise.all([getTestDefinitions(), getTestStores()]);
-    defs = fetchedDefs;
-
-    perpetuationMod = defs.InventoryItem.get(4137020505) as PluggableInventoryItemDefinition;
+    const stores = await getTestStores();
 
     for (const store of stores) {
       for (const storeItem of store.items) {
@@ -27,24 +18,6 @@ describe('lo process mappers', () => {
         }
       }
     }
-  });
-
-  test('mapped energy matches slot specific mods', () => {
-    const modifiedItem: DimItem = {
-      ...classItem,
-      energy: { ...classItem.energy!, energyType: DestinyEnergyType.Arc },
-    };
-    const mappedItem = mapDimItemToProcessItem({
-      dimItem: modifiedItem,
-      armorEnergyRules: {
-        ...loDefaultArmorEnergyRules,
-        assumeArmorMasterwork: AssumeArmorMasterwork.All,
-      },
-      modsForSlot: [perpetuationMod],
-    });
-
-    // Use specific energy as we care about that more then the specific mod
-    expect(mappedItem.energy?.type).toBe(DestinyEnergyType.Void);
   });
 
   test('mapped energy capacity is 10 when assumed masterwork is used', () => {
@@ -86,28 +59,5 @@ describe('lo process mappers', () => {
     });
 
     expect(mappedItem.energy?.capacity).toBe(MIN_LO_ITEM_ENERGY);
-  });
-
-  test('mapped energy type is Any when energy is not locked', () => {
-    const mappedItem = mapDimItemToProcessItem({
-      dimItem: classItem,
-      armorEnergyRules: loDefaultArmorEnergyRules,
-      modsForSlot: [],
-    });
-
-    expect(mappedItem.energy?.type).toBe(DestinyEnergyType.Any);
-  });
-
-  test('mapped energy type is the items when energy is locked', () => {
-    const mappedItem = mapDimItemToProcessItem({
-      dimItem: classItem,
-      armorEnergyRules: {
-        ...loDefaultArmorEnergyRules,
-        lockArmorEnergyType: LockArmorEnergyType.All,
-      },
-      modsForSlot: [],
-    });
-
-    expect(mappedItem.energy?.type).toBe(classItem.energy?.energyType);
   });
 });

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -3,7 +3,6 @@ import {
   activityModPlugCategoryHashes,
   knownModPlugCategoryHashes,
 } from 'app/loadout/known-values';
-import { getItemEnergyType } from 'app/loadout/mod-utils';
 import { MAX_ARMOR_ENERGY_CAPACITY, modsWithConditionalStats } from 'app/search/d2-known-values';
 import { DestinyClass, DestinyItemInvestmentStatDefinition } from 'bungie-api-ts/destiny2';
 import { StatHashes } from 'data/d2/generated-enums';
@@ -21,7 +20,6 @@ export function mapArmor2ModToProcessMod(mod: PluggableInventoryItemDefinition):
     hash: mod.hash,
     plugCategoryHash: mod.plug.plugCategoryHash,
     energy: mod.plug.energyCost && {
-      type: mod.plug.energyCost.energyType,
       val: mod.plug.energyCost.energyCost,
     },
     investmentStats: mod.investmentStats,
@@ -138,9 +136,6 @@ export function mapDimItemToProcessItem({
     ? _.sumBy(modsForSlot, (mod) => mod.plug.energyCost?.energyCost || 0)
     : 0;
 
-  // Bucket specific mods have been validated
-  const energyType = getItemEnergyType(dimItem, armorEnergyRules, modsForSlot);
-
   return {
     id,
     hash,
@@ -150,7 +145,6 @@ export function mapDimItemToProcessItem({
     stats: statMap,
     energy: energy
       ? {
-          type: energyType ?? energy.energyType,
           capacity,
           val: modsCost,
         }

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -38,21 +38,10 @@ export function mapArmor2ModToProcessMod(mod: PluggableInventoryItemDefinition):
 export function isModStatActive(
   characterClass: DestinyClass,
   plugHash: number,
-  stat: DestinyItemInvestmentStatDefinition,
-  _lockedMods: PluggableInventoryItemDefinition[]
+  stat: DestinyItemInvestmentStatDefinition
 ): boolean {
   if (!stat.isConditionallyActive) {
     return true;
-  } else if (
-    plugHash === modsWithConditionalStats.powerfulFriends ||
-    plugHash === modsWithConditionalStats.radiantLight
-  ) {
-    // Powerful Friends & Radiant Light
-    // True if another arc charged with light mod is found
-    // Note the this is not entirely correct as another arc mod slotted into the same item would
-    // also trigger it but we don't know that until we try to socket them. Basically it is too hard
-    // to figure that condition out so lets leave it as a known issue for now.
-    return false;
   } else if (
     plugHash === modsWithConditionalStats.chargeHarvester ||
     plugHash === modsWithConditionalStats.echoOfPersistence ||
@@ -90,10 +79,7 @@ export function getTotalModStatChanges(
 
   for (const mod of lockedMods.concat(subclassPlugs)) {
     for (const stat of mod.investmentStats) {
-      if (
-        stat.statTypeHash in totals &&
-        isModStatActive(characterClass, mod.hash, stat, lockedMods)
-      ) {
+      if (stat.statTypeHash in totals && isModStatActive(characterClass, mod.hash, stat)) {
         totals[stat.statTypeHash] += stat.value;
       }
     }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -8,7 +8,6 @@ import { chainComparator, compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { getModTypeTagByPlugCategoryHash } from 'app/utils/item-utils';
 import { infoLog } from 'app/utils/log';
-import { DestinyEnergyType } from 'bungie-api-ts/destiny2';
 import { proxy, releaseProxy, wrap } from 'comlink';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -141,7 +140,6 @@ export function useProcess({
         items,
         statOrder,
         armorEnergyRules,
-        generalMods,
         combatMods,
         activityMods,
         bucketSpecificMods[bucketHash] || []
@@ -273,23 +271,10 @@ function mapItemsToGroups(
   items: readonly DimItem[],
   statOrder: number[],
   armorEnergyRules: ArmorEnergyRules,
-  generalMods: PluggableInventoryItemDefinition[],
   combatMods: PluggableInventoryItemDefinition[],
   activityMods: PluggableInventoryItemDefinition[],
   modsForSlot: PluggableInventoryItemDefinition[]
 ): ItemGroup[] {
-  // Figure out all the energy types that have been requested across all mods.
-  // Purposefully not including bucket-specific mods here, because in either case it doesn't matter:
-  //   1. modsForSlot has no elemental mods. They have no effect on the loop.
-  //   2. modsForSlot has elemental mods. All items will be forced to that element type anyway,
-  //      so elemental affinity doesn't create separate groups.
-  const requiredEnergyTypes = new Set<DestinyEnergyType>();
-  for (const mod of [...combatMods, ...generalMods, ...activityMods]) {
-    if (mod.plug.energyCost && mod.plug.energyCost.energyType !== DestinyEnergyType.Any) {
-      requiredEnergyTypes.add(mod.plug.energyCost.energyType);
-    }
-  }
-
   // Figure out all the interesting mod slots required by mods are.
   // This includes combat mod tags because blue-quality items don't have them
   // and there may be legacy items that can slot CWL/Warmind Cell mods but not
@@ -308,28 +293,9 @@ function mapItemsToGroups(
     processItem: mapDimItemToProcessItem({ dimItem, armorEnergyRules, modsForSlot }),
   }));
 
-  // First, group by exoticness and energy type.
-  const firstPassGroupingFn = ({ hash, isExotic, energy }: ProcessItem) => {
-    // Ensure exotics always form a distinct group
-    let groupId = isExotic ? `${hash}-` : 'legendary-';
-
-    if (requiredEnergyTypes.size) {
-      groupId +=
-        energy &&
-        // We group all items locked to an energy type we don't care about
-        // by using an `X` instead of the numerical energy type -- if we only
-        // want to assign Solar mods, we can put all items locked to Void,
-        // Stasis and Arc into their own group (apart from the Any items and
-        // apart from the items locked to Solar)
-        (energy.type !== DestinyEnergyType.Any
-          ? requiredEnergyTypes.has(energy.type)
-            ? energy.type
-            : 'X'
-          : DestinyEnergyType.Any);
-    }
-
-    return groupId;
-  };
+  // First, group by exoticness to ensure exotics always form a distinct group
+  const firstPassGroupingFn = ({ hash, isExotic }: ProcessItem) =>
+    isExotic ? `${hash}-` : 'legendary-';
 
   // Second pass -- cache the worker-relevant information, except the one we used in the first pass.
   const cache = new Map<

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -116,11 +116,10 @@ export function useProcess({
       currentCleanup: cleanup,
     }));
 
-    const { allMods, bucketSpecificMods, activityMods, combatMods, generalMods } = lockedModMap;
+    const { allMods, bucketSpecificMods, activityMods, generalMods } = lockedModMap;
 
     const lockedProcessMods = {
       generalMods: generalMods.map(mapArmor2ModToProcessMod),
-      combatMods: combatMods.map(mapArmor2ModToProcessMod),
       activityMods: activityMods.map(mapArmor2ModToProcessMod),
     };
 
@@ -140,7 +139,6 @@ export function useProcess({
         items,
         statOrder,
         armorEnergyRules,
-        combatMods,
         activityMods,
         bucketSpecificMods[bucketHash] || []
       );
@@ -271,7 +269,6 @@ function mapItemsToGroups(
   items: readonly DimItem[],
   statOrder: number[],
   armorEnergyRules: ArmorEnergyRules,
-  combatMods: PluggableInventoryItemDefinition[],
   activityMods: PluggableInventoryItemDefinition[],
   modsForSlot: PluggableInventoryItemDefinition[]
 ): ItemGroup[] {
@@ -280,7 +277,7 @@ function mapItemsToGroups(
   // and there may be legacy items that can slot CWL/Warmind Cell mods but not
   // Elemental Well mods?
   const requiredModTags = new Set<string>();
-  for (const mod of [...combatMods, ...activityMods]) {
+  for (const mod of activityMods) {
     const modTag = getModTypeTagByPlugCategoryHash(mod.plug.plugCategoryHash);
     if (modTag) {
       requiredModTags.add(modTag);

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -1,5 +1,4 @@
-import { AssumeArmorMasterwork, LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
-import { LoadoutsByItem } from 'app/loadout-drawer/selectors';
+import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { armorBuckets } from 'app/search/d2-known-values';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import { DimItem } from '../inventory/item-types';
@@ -107,7 +106,6 @@ export const MIN_LO_ITEM_ENERGY = 7;
  * Requires a reasonable and inexpensive amount of upgrade materials.
  */
 export const loDefaultArmorEnergyRules: ArmorEnergyRules = {
-  lockArmorEnergyType: LockArmorEnergyType.None,
   assumeArmorMasterwork: AssumeArmorMasterwork.None,
   minItemEnergy: MIN_LO_ITEM_ENERGY,
 };
@@ -116,7 +114,6 @@ export const loDefaultArmorEnergyRules: ArmorEnergyRules = {
  * make in-game -- none as of now.
  */
 export const inGameArmorEnergyRules: ArmorEnergyRules = {
-  lockArmorEnergyType: LockArmorEnergyType.All,
   assumeArmorMasterwork: AssumeArmorMasterwork.None,
   minItemEnergy: 1,
 };
@@ -126,18 +123,9 @@ export const inGameArmorEnergyRules: ArmorEnergyRules = {
  * to accommodate mods and hit optimal stats.
  */
 export interface ArmorEnergyRules {
-  lockArmorEnergyType: LockArmorEnergyType;
   assumeArmorMasterwork: AssumeArmorMasterwork;
   /**
    * How much energy capacity items have at least.
    */
   minItemEnergy: number;
-  /**
-   * Info about other loadouts. This must be specified if `lockArmorEnergyType`
-   * can be `LockArmorEnergyType.OtherLoadouts`.
-   */
-  loadouts?: {
-    loadoutsByItem: LoadoutsByItem;
-    optimizingLoadoutId: string | undefined;
-  };
 }

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -36,7 +36,6 @@ import {
   fitMostMods,
   pickPlugPositions,
 } from 'app/loadout/mod-assignment-utils';
-import { unlockedByAllModsBeingUnlocked } from 'app/loadout/mod-utils';
 import {
   d2ManifestSelector,
   destiny2CoreSettingsSelector,
@@ -46,7 +45,6 @@ import { showNotification } from 'app/notifications/notifications';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { loadingTracker } from 'app/shell/loading-tracker';
 import { ThunkResult } from 'app/store/types';
-import { artifactModsSelector } from 'app/strip-sockets/strip-sockets';
 import { queueAction } from 'app/utils/action-queue';
 import { CanceledError, CancelToken, withCancel } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
@@ -250,17 +248,11 @@ function doApplyLoadout(
 
       // Filter out mods that no longer exist or that aren't unlocked on this character
       const unlockedPlugSetItems = _.once(() => unlockedPlugSetItemsSelector(getState(), store.id));
-      const artifactMods = artifactModsSelector(getState());
       const checkMod = (h: number) => {
         const mod = defs.InventoryItem.get(h);
         return (
           Boolean(mod) &&
-          (unlockedPlugSetItems().has(h) ||
-            h === DEFAULT_SHADER ||
-            DEFAULT_ORNAMENTS.includes(h) ||
-            ('plug' in mod &&
-              isPluggableItem(mod) &&
-              unlockedByAllModsBeingUnlocked(mod, artifactMods)))
+          (unlockedPlugSetItems().has(h) || h === DEFAULT_SHADER || DEFAULT_ORNAMENTS.includes(h))
         );
       };
 

--- a/src/app/loadout-drawer/loadout-type-converters.ts
+++ b/src/app/loadout-drawer/loadout-type-converters.ts
@@ -86,9 +86,6 @@ function migrateUpgradeSpendTierAndLockItemEnergy(
       return {
         ...migrated,
         assumeArmorMasterwork: AssumeArmorMasterwork.All,
-        lockArmorEnergyType: lockItemEnergyType
-          ? LockArmorEnergyType.All
-          : LockArmorEnergyType.Masterworked,
       };
     case UpgradeSpendTier.AscendantShardsLockEnergyType:
     case UpgradeSpendTier.EnhancementPrisms:
@@ -98,9 +95,6 @@ function migrateUpgradeSpendTierAndLockItemEnergy(
       return {
         ...migrated,
         assumeArmorMasterwork: AssumeArmorMasterwork.None,
-        lockArmorEnergyType: lockItemEnergyType
-          ? LockArmorEnergyType.All
-          : LockArmorEnergyType.None,
       };
   }
 }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -283,7 +283,7 @@ export function getLoadoutStats(
   // Add the mod stats
   for (const mod of mods) {
     for (const stat of mod.investmentStats) {
-      if (stat.statTypeHash in stats && isModStatActive(classType, mod.hash, stat, mods)) {
+      if (stat.statTypeHash in stats && isModStatActive(classType, mod.hash, stat)) {
         stats[stat.statTypeHash].value += stat.value;
       }
     }

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -8,7 +8,6 @@ import {
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import {
-  armor2PlugCategoryHashes,
   armor2PlugCategoryHashesByName,
   MAX_ARMOR_ENERGY_CAPACITY,
 } from 'app/search/d2-known-values';
@@ -93,9 +92,6 @@ function mapStateToProps() {
         return emptyArray();
       }
 
-      // We need the name of the Artifice armor perk to show in one of the headers
-      const artificeString = defs.InventoryItem.get(3727270518)?.displayProperties.name;
-
       // Look at every armor item and see what sockets it has
       for (const item of allItems) {
         if (
@@ -137,8 +133,10 @@ function mapStateToProps() {
             owner ?? currentStore!.id
           );
 
-          const dimPlugs = sockets[0].plugSet!.plugs.filter((p) =>
-            unlockedPlugs.has(p.plugDef.hash)
+          const dimPlugs = sockets[0].plugSet!.plugs.filter(
+            (p) =>
+              unlockedPlugs.has(p.plugDef.hash) &&
+              p.plugDef.hash !== sockets[0].plugSet!.precomputedEmptyPlugItemHash
           );
 
           // Filter down to plugs that match the plugCategoryHashWhitelist
@@ -184,14 +182,6 @@ function mapStateToProps() {
                   plugSetsByHash[plugSetHash].headerSuffix = activityName;
                 }
               }
-            }
-
-            // Artificer armor has a single extra slot that can take slot-specific mods. Give it a special header
-            if (
-              maxSelectable === 1 &&
-              armor2PlugCategoryHashes.includes(plugs[0].plug.plugCategoryHash)
-            ) {
-              plugSetsByHash[plugSetHash].headerSuffix = artificeString;
             }
           } else if (plugs.length && plugSetsByHash[plugSetHash].maxSelectable < sockets.length) {
             plugSetsByHash[plugSetHash].maxSelectable = sockets.length;

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -13,7 +13,6 @@ import {
   MAX_ARMOR_ENERGY_CAPACITY,
 } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
-import { artifactModsSelector } from 'app/strip-sockets/strip-sockets';
 import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { modMetadataByPlugCategoryHash } from 'app/utils/item-utils';
@@ -31,12 +30,7 @@ import {
   knownModPlugCategoryHashes,
   slotSpecificPlugCategoryHashes,
 } from './known-values';
-import {
-  isInsertableArmor2Mod,
-  sortModGroups,
-  sortMods,
-  unlockedByAllModsBeingUnlocked,
-} from './mod-utils';
+import { isInsertableArmor2Mod, sortModGroups, sortMods } from './mod-utils';
 import PlugDrawer from './plug-drawer/PlugDrawer';
 import { PlugSet } from './plug-drawer/types';
 
@@ -79,7 +73,6 @@ function mapStateToProps() {
     profileResponseSelector,
     allItemsSelector,
     d2ManifestSelector,
-    artifactModsSelector,
     (_state: RootState, props: ProvidedProps) => props.classType,
     (_state: RootState, props: ProvidedProps) => props.owner,
     (_state: RootState, props: ProvidedProps) => props.plugCategoryHashWhitelist,
@@ -89,7 +82,6 @@ function mapStateToProps() {
       profileResponse,
       allItems,
       defs,
-      artifactMods,
       classType,
       owner,
       plugCategoryHashWhitelist,
@@ -145,10 +137,8 @@ function mapStateToProps() {
             owner ?? currentStore!.id
           );
 
-          const dimPlugs = sockets[0].plugSet!.plugs.filter(
-            (p) =>
-              unlockedPlugs.has(p.plugDef.hash) ||
-              unlockedByAllModsBeingUnlocked(p.plugDef, artifactMods)
+          const dimPlugs = sockets[0].plugSet!.plugs.filter((p) =>
+            unlockedPlugs.has(p.plugDef.hash)
           );
 
           // Filter down to plugs that match the plugCategoryHashWhitelist

--- a/src/app/loadout/armor-upgrade-utils.ts
+++ b/src/app/loadout/armor-upgrade-utils.ts
@@ -1,4 +1,4 @@
-import { AssumeArmorMasterwork, LockArmorEnergyType } from '@destinyitemmanager/dim-api-types';
+import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { DimItem } from 'app/inventory/item-types';
 import { ArmorEnergyRules } from 'app/loadout-builder/types';
 
@@ -14,25 +14,4 @@ export function calculateAssumedItemEnergy(
       ? 10
       : minItemEnergy;
   return Math.max(itemEnergy, assumedEnergy);
-}
-
-export function isArmorEnergyLocked(
-  item: DimItem,
-  { lockArmorEnergyType, loadouts }: ArmorEnergyRules
-) {
-  switch (lockArmorEnergyType) {
-    default:
-    case LockArmorEnergyType.None: {
-      return false;
-    }
-    case LockArmorEnergyType.Masterworked: {
-      const { loadoutsByItem, optimizingLoadoutId } = loadouts!;
-      return loadoutsByItem[item.id]?.some(
-        (l) => l.loadoutItem.equip && l.loadout.id !== optimizingLoadoutId
-      );
-    }
-    case LockArmorEnergyType.All: {
-      return true;
-    }
-  }
 }

--- a/src/app/loadout/known-values.ts
+++ b/src/app/loadout/known-values.ts
@@ -25,6 +25,5 @@ export const activityModPlugCategoryHashes = [
 export const knownModPlugCategoryHashes = [
   ...armor2PlugCategoryHashes,
   ...activityModPlugCategoryHashes,
-  // FIXME add artifice here
-  99999999,
+  PlugCategoryHashes.EnhancementsArtifice,
 ];

--- a/src/app/loadout/known-values.ts
+++ b/src/app/loadout/known-values.ts
@@ -13,7 +13,10 @@ export const slotSpecificPlugCategoryHashes = [
   armor2PlugCategoryHashesByName.classitem,
 ];
 
-/** The plug category hashes that belong to the 5th mod slot, such as raid and nightmare mods. */
+/**
+ * The plug category hashes that belong to the 5th mod slot, such as raid and nightmare mods.
+ * Note that while artifice mod slots are also the 5th slot, we don't model them as activity mods.
+ */
 export const activityModPlugCategoryHashes = [
   ...raidModPlugCategoryHashes,
   PlugCategoryHashes.EnhancementsSeasonMaverick,
@@ -22,4 +25,6 @@ export const activityModPlugCategoryHashes = [
 export const knownModPlugCategoryHashes = [
   ...armor2PlugCategoryHashes,
   ...activityModPlugCategoryHashes,
+  // FIXME add artifice here
+  99999999,
 ];

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -9,13 +9,12 @@ import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
-import { artifactModsSelector } from 'app/strip-sockets/strip-sockets';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { memo, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import ModAssignmentDrawer from '../mod-assignment-drawer/ModAssignmentDrawer';
-import { createGetModRenderKey, unlockedByAllModsBeingUnlocked } from '../mod-utils';
+import { createGetModRenderKey } from '../mod-utils';
 import ModPicker from '../ModPicker';
 import styles from './LoadoutMods.m.scss';
 import PlugDef from './PlugDef';
@@ -69,7 +68,6 @@ export default memo(function LoadoutMods({
   const unlockedPlugSetItems = useSelector((state: RootState) =>
     unlockedPlugSetItemsSelector(state, storeId)
   );
-  const artifactMods = useSelector(artifactModsSelector);
 
   // Explicitly show only actual saved mods in the mods picker, not auto mods,
   // otherwise we'd duplicate auto mods into loadout parameter mods when coonfirming
@@ -104,7 +102,6 @@ export default memo(function LoadoutMods({
             className={clsx({
               [styles.missingItem]: !(
                 unlockedPlugSetItems.has(mod.hash) ||
-                unlockedByAllModsBeingUnlocked(mod, artifactMods) ||
                 mod.hash === DEFAULT_SHADER ||
                 DEFAULT_ORNAMENTS.includes(mod.hash)
               ),

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -202,9 +202,12 @@ export function fitMostMods({
   // Artifice mods are free and thus can be greedily assigned.
   const artificeItems = items.filter(isArtifice);
   for (const artificeMod of artificeMods) {
-    const targetItem = artificeItems.pop();
-    if (targetItem) {
-      bucketSpecificAssignments[targetItem.id].assigned.push(artificeMod);
+    const targetItemIndex = artificeItems.findIndex((item) =>
+      item.sockets?.allSockets.some((socket) => socket.plugged?.plugDef.hash === artificeMod.hash)
+    );
+    if (targetItemIndex !== -1) {
+      bucketSpecificAssignments[artificeItems[targetItemIndex].id].assigned.push(artificeMod);
+      artificeItems.splice(targetItemIndex, 1);
     } else {
       unassignedMods.push(artificeMod);
     }

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -200,9 +200,13 @@ export function fitMostMods({
   // Artifice mods are free and thus can be greedily assigned.
   const artificeItems = items.filter(isArtifice);
   for (const artificeMod of artificeMods) {
-    const targetItemIndex = artificeItems.findIndex((item) =>
+    let targetItemIndex = artificeItems.findIndex((item) =>
       item.sockets?.allSockets.some((socket) => socket.plugged?.plugDef.hash === artificeMod.hash)
     );
+    if (targetItemIndex === -1) {
+      targetItemIndex = artificeItems.length - 1;
+    }
+
     if (targetItemIndex !== -1) {
       bucketSpecificAssignments[artificeItems[targetItemIndex].id].assigned.push(artificeMod);
       artificeItems.splice(targetItemIndex, 1);

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -114,8 +114,3 @@ export function groupModsByModType(plugs: PluggableInventoryItemDefinition[]) {
   const commonClassItemMod = plugs.find((plugDef) => isClassItemOfTier(plugDef, TierType.Basic));
   return _.groupBy(plugs, getItemTypeOrTierDisplayName(commonClassItemMod?.itemTypeDisplayName));
 }
-
-export function isArtificeMod(plug: PluggableInventoryItemDefinition) {
-  // FIXME(Lightfall)
-  return plug.hash === 11111111;
-}

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -114,3 +114,8 @@ export function groupModsByModType(plugs: PluggableInventoryItemDefinition[]) {
   const commonClassItemMod = plugs.find((plugDef) => isClassItemOfTier(plugDef, TierType.Basic));
   return _.groupBy(plugs, getItemTypeOrTierDisplayName(commonClassItemMod?.itemTypeDisplayName));
 }
+
+export function isArtificeMod(plug: PluggableInventoryItemDefinition) {
+  // FIXME(Lightfall)
+  return plug.hash === 11111111;
+}

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -1,17 +1,11 @@
-import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
-import { ArmorEnergyRules } from 'app/loadout-builder/types';
 import { armor2PlugCategoryHashesByName, armorBuckets } from 'app/search/d2-known-values';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { isArmor2Mod } from 'app/utils/item-utils';
-import {
-  DestinyEnergyType,
-  DestinyInventoryItemDefinition,
-  TierType,
-} from 'bungie-api-ts/destiny2';
+import { DestinyInventoryItemDefinition, TierType } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import { isArmorEnergyLocked } from './armor-upgrade-utils';
 import { knownModPlugCategoryHashes } from './known-values';
 
 export const plugCategoryHashToBucketHash = {
@@ -91,38 +85,6 @@ export function createGetModRenderKey() {
 
     return `${mod.hash}-${counts[mod.hash]++}`;
   };
-}
-
-/**
- * This is used to figure out the energy type of an item used in mod assignments.
- *
- * If the item's energy is locked given the upgrade options, this returns the item's
- * current energy. If not locked, this returns the energy as restricted by the first not-Any
- * mod in `bucketSpecificMods`
- *
- * This does not validate that all the mods match that element.
- *
- * It can return the Any energy type if armour upgrade options allow energy changes
- * and no mods require a specific element.
- */
-export function getItemEnergyType(
-  item: DimItem,
-  armorEnergyRules: ArmorEnergyRules,
-  bucketSpecificMods?: PluggableInventoryItemDefinition[]
-) {
-  if (!item.energy) {
-    return DestinyEnergyType.Any;
-  }
-
-  if (isArmorEnergyLocked(item, armorEnergyRules)) {
-    return item.energy.energyType;
-  } else {
-    const bucketSpecificModType = bucketSpecificMods?.find(
-      (mod) => mod.plug.energyCost && mod.plug.energyCost.energyType !== DestinyEnergyType.Any
-    )?.plug.energyCost?.energyType;
-
-    return bucketSpecificModType ?? DestinyEnergyType.Any;
-  }
 }
 
 function isClassItemOfTier(plugDef: PluggableInventoryItemDefinition, tier: TierType): boolean {

--- a/src/app/loadout/mod-utils.ts
+++ b/src/app/loadout/mod-utils.ts
@@ -114,14 +114,3 @@ export function groupModsByModType(plugs: PluggableInventoryItemDefinition[]) {
   const commonClassItemMod = plugs.find((plugDef) => isClassItemOfTier(plugDef, TierType.Basic));
   return _.groupBy(plugs, getItemTypeOrTierDisplayName(commonClassItemMod?.itemTypeDisplayName));
 }
-
-/**
- * 2023-01-11: All standard Armor Mods (excluding artifact and raid) are unlocked for everyone.
- * The API was not informed, so we must hardcode the rules here.
- */
-export function unlockedByAllModsBeingUnlocked(
-  _plug: PluggableInventoryItemDefinition,
-  _artifactMods: Set<number> | undefined
-) {
-  return false;
-}

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -50,7 +50,7 @@ export default React.forwardRef(function SearchFilter(
         : onProgress
         ? t('Header.FilterHelpProgress')
         : onOptimizer
-        ? t('Header.FilterHelpOptimizer', { example: '-is:exotic, modslot:combatstyle' })
+        ? t('Header.FilterHelpOptimizer', { example: '-is:exotic, modslot:nightmare' })
         : onLoadouts
         ? t('Header.FilterHelpLoadouts')
         : isPhonePortrait

--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -42,6 +42,8 @@ export const modTypeTagByPlugCategoryHash = {
   [PlugCategoryHashes.EnhancementsRaidV520]: 'vaultofglass',
   [PlugCategoryHashes.EnhancementsRaidV600]: 'vowofthedisciple',
   [PlugCategoryHashes.EnhancementsRaidV620]: 'kingsfall',
+  // FIXME(Lightfall)
+  [99999999]: 'artifice',
 };
 
 // FIXME(Lightfall) what about legacy?
@@ -130,6 +132,15 @@ const modSocketMetadata: ModSocketMetadata[] = [
     compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsSeasonMaverick],
     emptyModSocketHashes: [1180997867],
     emptyModSocketHash: 1180997867,
+  },
+  // FIXME(Lightfall)
+  {
+    slotTag: 'artifice',
+    compatibleModTags: ['artifice'],
+    socketTypeHashes: [99999999],
+    compatiblePlugCategoryHashes: [99999999],
+    emptyModSocketHashes: [99999999],
+    emptyModSocketHash: 99999999,
   },
 ];
 

--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -42,8 +42,7 @@ export const modTypeTagByPlugCategoryHash = {
   [PlugCategoryHashes.EnhancementsRaidV520]: 'vaultofglass',
   [PlugCategoryHashes.EnhancementsRaidV600]: 'vowofthedisciple',
   [PlugCategoryHashes.EnhancementsRaidV620]: 'kingsfall',
-  // FIXME(Lightfall)
-  [99999999]: 'artifice',
+  [PlugCategoryHashes.EnhancementsArtifice]: 'artifice',
 };
 
 // FIXME(Lightfall) what about legacy?
@@ -133,14 +132,13 @@ const modSocketMetadata: ModSocketMetadata[] = [
     emptyModSocketHashes: [1180997867],
     emptyModSocketHash: 1180997867,
   },
-  // FIXME(Lightfall)
   {
     slotTag: 'artifice',
     compatibleModTags: ['artifice'],
-    socketTypeHashes: [99999999],
-    compatiblePlugCategoryHashes: [99999999],
-    emptyModSocketHashes: [99999999],
-    emptyModSocketHash: 99999999,
+    socketTypeHashes: [1719555937],
+    compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsArtifice],
+    emptyModSocketHashes: [4173924323],
+    emptyModSocketHash: 4173924323,
   },
 ];
 

--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -21,13 +21,7 @@ export interface ModSocketMetadata {
   modGroupNameOverrideActivityHash?: number;
 }
 
-const legacyCompatibleTags = [
-  'warmindcell',
-  'chargedwithlight',
-  'nightmare',
-  'gardenofsalvation',
-  'lastwish',
-];
+const legacyCompatibleTags = ['nightmare', 'gardenofsalvation', 'lastwish'];
 
 /** The plug categories that will fit in "legacy" sockets */
 export const legacyCompatiblePlugCategoryHashes = [
@@ -48,8 +42,9 @@ export const modTypeTagByPlugCategoryHash = {
   [PlugCategoryHashes.EnhancementsRaidV520]: 'vaultofglass',
   [PlugCategoryHashes.EnhancementsRaidV600]: 'vowofthedisciple',
   [PlugCategoryHashes.EnhancementsRaidV620]: 'kingsfall',
-  [PlugCategoryHashes.EnhancementsSeasonV500]: 'combat',
 };
+
+// FIXME(Lightfall) what about legacy?
 
 const legacySocketTypeHashes = [
   1540673283, // an outlaw-looking one, that's on S11 LW/Reverie,
@@ -127,14 +122,6 @@ const modSocketMetadata: ModSocketMetadata[] = [
     compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsRaidV620],
     emptyModSocketHashes: [1728096240],
     emptyModSocketHash: 1728096240,
-  },
-  {
-    slotTag: 'combatstyle',
-    compatibleModTags: ['chargedwithlight', 'warmindcell', 'combat'],
-    socketTypeHashes: [2955889001],
-    compatiblePlugCategoryHashes: [],
-    emptyModSocketHashes: [2493100093],
-    emptyModSocketHash: 2493100093,
   },
   {
     slotTag: 'nightmare',

--- a/src/app/strip-sockets/StripSockets.tsx
+++ b/src/app/strip-sockets/StripSockets.tsx
@@ -17,13 +17,7 @@ import { useSelector } from 'react-redux';
 import { useSubscription } from 'use-subscription';
 import { DefItemIcon } from '../inventory/ItemIcon';
 import { allItemsSelector } from '../inventory/selectors';
-import {
-  artifactModsSelector,
-  collectSocketsToStrip,
-  doStripSockets,
-  SocketKind,
-  StripAction,
-} from './strip-sockets';
+import { collectSocketsToStrip, doStripSockets, SocketKind, StripAction } from './strip-sockets';
 import { stripSocketsQuery$ } from './strip-sockets-actions';
 import styles from './StripSockets.m.scss';
 
@@ -291,8 +285,6 @@ function StripSocketsChoose({
   const destiny2CoreSettings = useSelector(destiny2CoreSettingsSelector)!;
   const allItems = useSelector(allItemsSelector);
   const filterFactory = useSelector(filterFactorySelector);
-  const artifactMods = useSelector(artifactModsSelector);
-
   const [activeKinds, setActiveKinds] = useState<SocketKind[]>([]);
 
   const socketKinds = useMemo(() => {
@@ -302,8 +294,8 @@ function StripSocketsChoose({
 
     const filterFunc = filterFactory(query);
     const filteredItems = allItems.filter((i) => i.sockets && filterFunc(i));
-    return collectSocketsToStrip(filteredItems, destiny2CoreSettings, defs, artifactMods);
-  }, [allItems, artifactMods, defs, destiny2CoreSettings, filterFactory, query]);
+    return collectSocketsToStrip(filteredItems, destiny2CoreSettings, defs);
+  }, [allItems, defs, destiny2CoreSettings, filterFactory, query]);
 
   useEffect(() => {
     reportSockets(

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -23,11 +23,7 @@ import modSocketMetadata, {
   ModSocketMetadata,
   modTypeTagByPlugCategoryHash,
 } from 'app/search/specialty-modslots';
-import {
-  DestinyClass,
-  DestinyEnergyType,
-  DestinyInventoryItemDefinition,
-} from 'bungie-api-ts/destiny2';
+import { DestinyClass, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import adeptWeaponHashes from 'data/d2/adept-weapon-hashes.json';
 import enhancedIntrinsics from 'data/d2/crafting-enhanced-intrinsics';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
@@ -97,9 +93,7 @@ export const getSpecialtySocketMetadatas = (item?: DimItem): ModSocketMetadata[]
  * this focuses on narrower stuff: raid & nightmare modslots
  */
 export const getInterestingSocketMetadatas = (item?: DimItem): ModSocketMetadata[] | undefined => {
-  const specialtySockets = getSpecialtySocketMetadatas(item)?.filter(
-    (m) => m.slotTag !== 'legacy' && m.slotTag !== 'combatstyle'
-  );
+  const specialtySockets = getSpecialtySocketMetadatas(item)?.filter((m) => m.slotTag !== 'legacy');
   if (specialtySockets?.length) {
     return specialtySockets;
   }
@@ -299,8 +293,7 @@ export function isPlugStatActive(
   item: DimItem,
   plug: DestinyInventoryItemDefinition,
   statHash: number,
-  isConditionallyActive: boolean,
-  modsOnOtherItems?: PluggableInventoryItemDefinition[]
+  isConditionallyActive: boolean
 ): boolean {
   /*
   Some Exotic weapon catalysts can be inserted even though the catalyst objectives are incomplete.
@@ -323,25 +316,6 @@ export function isPlugStatActive(
     return false;
   }
 
-  if (
-    plugHash === modsWithConditionalStats.powerfulFriends ||
-    plugHash === modsWithConditionalStats.radiantLight
-  ) {
-    // Powerful Friends & Radiant Light
-    // True if a second arc mod is socketed or a arc charged with light mod  is found in modsOnOtherItems.
-    return Boolean(
-      item.sockets?.allSockets.some(
-        (s) =>
-          s.plugged?.plugDef.hash !== plugHash &&
-          s.plugged?.plugDef.plug.energyCost?.energyType === DestinyEnergyType.Arc
-      ) ||
-        modsOnOtherItems?.some(
-          (plugDef) =>
-            modTypeTagByPlugCategoryHash[plugDef.plug.plugCategoryHash] === 'chargedwithlight' &&
-            plugDef.plug.energyCost?.energyType === DestinyEnergyType.Arc
-        )
-    );
-  }
   if (
     plugHash === modsWithConditionalStats.chargeHarvester ||
     plugHash === modsWithConditionalStats.echoOfPersistence ||

--- a/src/testing/test-item-utils.ts
+++ b/src/testing/test-item-utils.ts
@@ -2,19 +2,11 @@ import { DimItem } from 'app/inventory/item-types';
 import { BucketHashes } from 'data/d2/generated-enums';
 
 /** any general mod */
-export const recoveryModHash = 2645858828;
-/** any legacy mod, nightmare mod */
-export const nightmareBreakerModHash = 1560574695;
-/** void combat and legacy mod, charged with light first group */
-export const protectiveLightModHash = 3523075120;
-/** any combat mod, elemental well mod */
-export const elementalLightModHash = 2823326549;
-/** solar raid mod, dsc mod */
+export const recoveryModHash = 4204488676;
+/** raid mod, dsc mod */
 export const enhancedOperatorAugmentModHash = 817361141;
-/** void class item mod */
-export const perpetuationModHash = 4137020505;
-/** any class item mod */
-export const distributionModHash = 1513970148;
+/** class item mod */
+export const distributionModHash = 4039026690;
 
 function isArmor2Item(item: DimItem) {
   return item.energy && item.bucket.inArmor && !item.equippingLabel && item.tier === 'Legendary';


### PR DESCRIPTION
Some placeholders left but this removes combat mods, artifact mods, and armor energy type from the loadouts model (i.e. only changes how DIM thinks mods work and how affinity affects them, doesn't remove elemental affinity yet from armor) and adds artifice mods. This is as accurate to the Bungie previews as possible, but there could always be surprises when Lightfall launches.