### PR TITLE
Organizer tweaks

### DIFF
--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -511,8 +511,8 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
                 className={styles.sorter}
                 icon={
                   columnSorts.find((c) => c.columnId === column.id)!.sort === SortDirection.DESC
-                    ? faCaretUp
-                    : faCaretDown
+                    ? faCaretDown
+                    : faCaretUp
                 }
               />
             )}

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -47,7 +47,7 @@ import { itemIncludesCategories } from './filtering-utils';
 import ItemActions, { TagCommandInfo } from './ItemActions';
 // eslint-disable-next-line css-modules/no-unused-class
 import styles from './ItemTable.m.scss';
-import { ItemCategoryTreeNode } from './ItemTypeSelector';
+import { armorTopLevelCatHashes, ItemCategoryTreeNode } from './ItemTypeSelector';
 import { ColumnDefinition, ColumnSort, Row, SortDirection } from './table-types';
 
 const categoryToClass = {
@@ -84,7 +84,11 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
     if (!terminal) {
       return emptyArray<DimItem>();
     }
-    const categoryHashes = categories.map((s) => s.itemCategoryHash).filter((h) => h !== 0);
+    const categoryHashes = categories.map((s) => s.itemCategoryHash).filter(Boolean);
+    // a top level class-specific category implies armor
+    if (armorTopLevelCatHashes.some((h) => categoryHashes.includes(h))) {
+      categoryHashes.push(ItemCategoryHashes.Armor);
+    }
     const items = allItems.filter(
       (i) => i.comparable && itemIncludesCategories(i, categoryHashes) && searchFilter(i)
     );

--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -16,7 +16,7 @@ import styles from './ItemTypeSelector.m.scss';
  */
 export interface ItemCategoryTreeNode {
   id: string;
-  itemCategoryHash: number;
+  itemCategoryHash: ItemCategoryHashes;
   subCategories?: ItemCategoryTreeNode[];
   /** A terminal node can have items displayed for it. It may still have other drilldowns available. */
   terminal?: boolean;
@@ -164,12 +164,6 @@ const d2SelectionTree: ItemCategoryTreeNode = {
           terminal: true,
         },
         {
-          id: 'grenadelauncherFF',
-          itemCategoryHash: -ItemCategoryHashes.GrenadeLaunchers,
-          subCategories: [kinetic, energy],
-          terminal: true,
-        },
-        {
           id: 'rocketlauncher',
           itemCategoryHash: ItemCategoryHashes.RocketLauncher,
           terminal: true,
@@ -192,21 +186,23 @@ const d2SelectionTree: ItemCategoryTreeNode = {
       id: 'hunter',
       itemCategoryHash: ItemCategoryHashes.Hunter,
       subCategories: armorCategories,
+      terminal: true,
     },
     {
       id: 'titan',
       itemCategoryHash: ItemCategoryHashes.Titan,
       subCategories: armorCategories,
+      terminal: true,
     },
     {
       id: 'warlock',
       itemCategoryHash: ItemCategoryHashes.Warlock,
       subCategories: armorCategories,
+      terminal: true,
     },
     {
       id: 'ghosts',
       itemCategoryHash: ItemCategoryHashes.Ghost,
-
       terminal: true,
     },
   ],
@@ -327,7 +323,7 @@ export function getSelectionTree(destinyVersion: DestinyVersion) {
   return destinyVersion === 2 ? d2SelectionTree : d1SelectionTree;
 }
 
-const armorTopLevelCatHashes = [
+export const armorTopLevelCatHashes: ItemCategoryHashes[] = [
   ItemCategoryHashes.Hunter,
   ItemCategoryHashes.Titan,
   ItemCategoryHashes.Warlock,


### PR DESCRIPTION
1. Reverse the direction of the arrows for sorting.
2. Remove special grenade launchers as a category - you can click grenade launchers and filter to special.
3. Allow viewing all armor for a certain class at once, because people really seem to want to compare across slots.