### PR TITLE
Sort undefined properties last in organizer, make loadouts sortable

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -314,7 +314,7 @@ export function getColumns(
     c({
       id: 'tag',
       header: t('Organizer.Columns.Tag'),
-      value: (item) => getTag(item, itemInfos),
+      value: (item) => getTag(item, itemInfos) ?? '',
       cell: (value) => value && <TagIcon tag={value} />,
       sort: compareBy((tag) => (tag && tagConfig[tag] ? tagConfig[tag].sortOrder : 1000)),
       filter: (value) => `tag:${value || 'none'}`,
@@ -574,17 +574,26 @@ export function getColumns(
     c({
       id: 'loadouts',
       header: t('Organizer.Columns.Loadouts'),
-      value: () => 0,
+      value: (item) =>
+        loadoutsByItem[item.id]
+          ?.map((l) => l.loadout.name)
+          .sort()
+          .join(','),
       cell: (_val, item) => {
         const inloadouts = loadoutsByItem[item.id];
         return (
           inloadouts &&
           inloadouts.length > 0 && (
-            <LoadoutsCell loadouts={inloadouts.map((l) => l.loadout)} owner={item.owner} />
+            <LoadoutsCell
+              loadouts={_.sortBy(
+                inloadouts.map((l) => l.loadout),
+                (l) => l.name
+              )}
+              owner={item.owner}
+            />
           )
         );
       },
-      noSort: true,
       filter: (value, item) => {
         if (typeof value === 'string') {
           const inloadouts = loadoutsByItem[item.id];

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -562,7 +562,11 @@ function sortRows(
         const compare = column.sort
           ? (row1: Row, row2: Row) => column.sort!(row1.values[column.id], row2.values[column.id])
           : compareBy((row: Row) => row.values[column.id] ?? 0);
-        return sorter.sort === SortDirection.ASC ? compare : reverseComparator(compare);
+        // Always sort undefined values to the end
+        return chainComparator(
+          compareBy((row: Row) => row.values[column.id] === undefined),
+          sorter.sort === SortDirection.ASC ? compare : reverseComparator(compare)
+        );
       }
       return compareBy(() => 0);
     })


### PR DESCRIPTION
This changes organizer sorting a bit, to always sorts undefined values to the end - this is most notable when sorting armor by modslot, where it was kinda random before.