### PR TITLE
Lie about missing mods

### DIFF
--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -627,9 +627,11 @@ export function getModsFromLoadout(
   if (defs?.isDestiny2()) {
     for (const modHash of getModHashesFromLoadout(loadout, includeAutoMods)) {
       const item = defs.InventoryItem.get(modHash);
-
       if (isPluggableItem(item)) {
         mods.push(item);
+      } else {
+        const deprecatedPlaceholderMod = defs.InventoryItem.get(3947616002);
+        isPluggableItem(deprecatedPlaceholderMod) && mods.push(deprecatedPlaceholderMod);
       }
     }
   }


### PR DESCRIPTION
This shows a random deprecated mod in place of mods that have been unceremoniously deleted from the manifest.