### PR TITLE
Show completed pattern unlock bar for uncrafted but unlocked items

### DIFF
--- a/src/app/dim-ui/WeaponDeepsightInfo.tsx
+++ b/src/app/dim-ui/WeaponDeepsightInfo.tsx
@@ -16,7 +16,7 @@ import styles from './WeaponDeepsightInfo.m.scss';
 export function WeaponDeepsightInfo({ item }: { item: DimItem }) {
   const deepsightInfo = item.deepsightInfo;
   const record = item.patternUnlockRecord;
-  const relevantObjectives = record?.objectives.filter((o) => !o.complete);
+  const relevantObjectives = record?.objectives;
 
   if (!deepsightInfo && !relevantObjectives?.length) {
     return null;
@@ -33,7 +33,8 @@ export function WeaponDeepsightInfo({ item }: { item: DimItem }) {
         </>
       ) : (
         relevantObjectives &&
-        relevantObjectives.length > 0 && (
+        relevantObjectives.length > 0 &&
+        !item.crafted && (
           <div className={styles.deepsightProgressSection}>
             {relevantObjectives.map((objective) => (
               <Objective key={objective.objectiveHash} objective={objective} showHidden />


### PR DESCRIPTION
<img width="347" alt="image" src="https://user-images.githubusercontent.com/313208/222028091-5c07a5a6-3f53-4cb2-99a7-ea72085bbda6.png">

This reminds you that the item you're looking at has an unlocked pattern. It won't show up for the crafted version. 