### PR TITLE
Handle reduced mod costs from artifact, fix some issues with deprecated mods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Fixed deepsight border showing up for weapons whose pattern has already been unlocked.
+* DIM now correctly handles reduced mod costs via artifact unlocks.
 
 ## 7.59.0 <span class="changelog-date">(2023-03-05)</span>
 

--- a/src/app/compare/selectors.ts
+++ b/src/app/compare/selectors.ts
@@ -5,7 +5,7 @@ import { accountRoute } from 'app/routes';
 import { filterFactorySelector } from 'app/search/search-filter';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
-import { currySelector } from 'app/utils/redux-utils';
+import { currySelector } from 'app/utils/selector-utils';
 import { nonCurriedVendorGroupsForCharacterSelector } from 'app/vendors/selectors';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -4,6 +4,7 @@ import { currentProfileSelector, settingSelector, settingsSelector } from 'app/d
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { emptyObject, emptySet } from 'app/utils/empty';
+import { currySelector } from 'app/utils/redux-utils';
 import { DestinyItemPlug } from 'bungie-api-ts/destiny2';
 import { resonantMaterialStringVarHashes } from 'data/d2/crafting-resonant-elements';
 import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
@@ -280,37 +281,39 @@ export const ownedUncollectiblePlugsSelector = createSelector(
 
 /** A set containing all the hashes of unlocked PlugSet items (mods, shaders, ornaments, etc) for the given character. */
 // TODO: reconcile with other owned/unlocked selectors
-export const unlockedPlugSetItemsSelector = createSelector(
-  (_state: RootState, characterId?: string) => characterId,
-  profileResponseSelector,
-  (characterId, profileResponse) => {
-    const unlockedPlugs = new Set<number>();
-    if (profileResponse?.profilePlugSets.data?.plugs) {
-      for (const plugSetHashStr in profileResponse.profilePlugSets.data.plugs) {
-        const plugSetHash = parseInt(plugSetHashStr, 10);
-        const plugs = profileResponse.profilePlugSets.data.plugs[plugSetHash];
-        for (const plugSetItem of plugs) {
-          const useCanInsert = universalOrnamentPlugSetHashes.includes(plugSetHash);
-          if (useCanInsert ? plugSetItem.canInsert : plugSetItem.enabled) {
-            unlockedPlugs.add(plugSetItem.plugItemHash);
+export const unlockedPlugSetItemsSelector = currySelector(
+  createSelector(
+    (_state: RootState, characterId?: string) => characterId,
+    profileResponseSelector,
+    (characterId, profileResponse) => {
+      const unlockedPlugs = new Set<number>();
+      if (profileResponse?.profilePlugSets.data?.plugs) {
+        for (const plugSetHashStr in profileResponse.profilePlugSets.data.plugs) {
+          const plugSetHash = parseInt(plugSetHashStr, 10);
+          const plugs = profileResponse.profilePlugSets.data.plugs[plugSetHash];
+          for (const plugSetItem of plugs) {
+            const useCanInsert = universalOrnamentPlugSetHashes.includes(plugSetHash);
+            if (useCanInsert ? plugSetItem.canInsert : plugSetItem.enabled) {
+              unlockedPlugs.add(plugSetItem.plugItemHash);
+            }
           }
         }
       }
-    }
-    if (characterId && profileResponse?.characterPlugSets.data?.[characterId]?.plugs) {
-      for (const plugSetHashStr in profileResponse.characterPlugSets.data[characterId].plugs) {
-        const plugSetHash = parseInt(plugSetHashStr, 10);
-        const plugs = profileResponse.characterPlugSets.data[characterId].plugs[plugSetHash];
-        for (const plugSetItem of plugs) {
-          const useCanInsert = universalOrnamentPlugSetHashes.includes(plugSetHash);
-          if (useCanInsert ? plugSetItem.canInsert : plugSetItem.enabled) {
-            unlockedPlugs.add(plugSetItem.plugItemHash);
+      if (characterId && profileResponse?.characterPlugSets.data?.[characterId]?.plugs) {
+        for (const plugSetHashStr in profileResponse.characterPlugSets.data[characterId].plugs) {
+          const plugSetHash = parseInt(plugSetHashStr, 10);
+          const plugs = profileResponse.characterPlugSets.data[characterId].plugs[plugSetHash];
+          for (const plugSetItem of plugs) {
+            const useCanInsert = universalOrnamentPlugSetHashes.includes(plugSetHash);
+            if (useCanInsert ? plugSetItem.canInsert : plugSetItem.enabled) {
+              unlockedPlugs.add(plugSetItem.plugItemHash);
+            }
           }
         }
       }
+      return unlockedPlugs;
     }
-    return unlockedPlugs;
-  }
+  )
 );
 
 /** gets all the dynamic strings from a profile response */

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -4,7 +4,7 @@ import { currentProfileSelector, settingSelector, settingsSelector } from 'app/d
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { emptyObject, emptySet } from 'app/utils/empty';
-import { currySelector } from 'app/utils/redux-utils';
+import { currySelector } from 'app/utils/selector-utils';
 import { DestinyItemPlug } from 'bungie-api-ts/destiny2';
 import { resonantMaterialStringVarHashes } from 'data/d2/crafting-resonant-elements';
 import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -20,6 +20,7 @@ import {
   DestinySocketTypeDefinition,
   SocketPlugSources,
 } from 'bungie-api-ts/destiny2';
+import deprecatedMods from 'data/d2/deprecated-mods.json';
 import { emptyPlugHashes } from 'data/d2/empty-plug-hashes';
 import {
   ItemCategoryHashes,
@@ -717,9 +718,13 @@ function buildCachedDimPlugSet(defs: D2ManifestDefinitions, plugSetHash: number)
   const plugs: DimPlug[] = [];
   const defPlugSet = defs.PlugSet.get(plugSetHash);
   for (const plugEntry of defPlugSet.reusablePlugItems) {
-    const plug = buildCachedDefinedPlug(defs, plugEntry.plugItemHash, plugEntry.currentlyCanRoll);
-    if (plug) {
-      plugs.push(plug);
+    // Deprecated mods should not actually be in any PlugSets, but here we are
+    // https://github.com/Bungie-net/api/issues/1801
+    if (!deprecatedMods.includes(plugEntry.plugItemHash)) {
+      const plug = buildCachedDefinedPlug(defs, plugEntry.plugItemHash, plugEntry.currentlyCanRoll);
+      if (plug) {
+        plugs.push(plug);
+      }
     }
   }
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -183,9 +183,7 @@ export default memo(function LoadoutBuilder({
 
   const selectedStore = stores.find((store) => store.id === selectedStoreId)!;
   const classType = selectedStore.classType;
-  const unlockedPlugs = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, selectedStoreId)
-  );
+  const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(selectedStoreId));
 
   const lockedMods = useMemo(
     () =>

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -541,7 +541,7 @@ export default memo(function LoadoutBuilder({
             <ModPicker
               classType={classType}
               owner={selectedStore.id}
-              lockedMods={modsToAssign}
+              lockedMods={resolvedMods}
               plugCategoryHashWhitelist={modPicker.plugCategoryHashWhitelist}
               plugCategoryHashDenyList={autoAssignmentPCHs}
               onAccept={(newLockedMods) =>

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -112,7 +112,7 @@ export default function NoBuildsFoundExplainer({
                   dispatch({
                     type: 'lockedModsChanged',
                     // Drop all invalid mods by setting current mods to only the valid mods
-                    lockedMods: lockedModMap.allMods,
+                    lockedMods: lockedModMap.allMods.map((mod) => mod.hash),
                   })
                 }
               >

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -3,6 +3,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import { t } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { ResolvedLoadoutMod } from 'app/loadout-drawer/loadout-types';
 import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import { ModMap } from 'app/loadout/mod-assignment-utils';
 import { AppIcon, banIcon } from 'app/shell/icons';
@@ -44,6 +45,7 @@ export default function NoBuildsFoundExplainer({
   defs,
   dispatch,
   autoAssignStatMods,
+  resolvedMods,
   lockedModMap,
   alwaysInvalidMods,
   armorEnergyRules,
@@ -56,6 +58,7 @@ export default function NoBuildsFoundExplainer({
   defs: D2ManifestDefinitions;
   dispatch: Dispatch<LoadoutBuilderAction>;
   autoAssignStatMods: boolean;
+  resolvedMods: ResolvedLoadoutMod[];
   lockedModMap: ModMap;
   alwaysInvalidMods: PluggableInventoryItemDefinition[];
   armorEnergyRules: ArmorEnergyRules;
@@ -67,13 +70,23 @@ export default function NoBuildsFoundExplainer({
 }) {
   const problems: ProblemDescription[] = [];
 
+  // Note: This component looks at what happened to mods when they were assigned, and offers ways to
+  // remove them based on that. Unfortunately removal needs ResolvedLoadoutMods, but we don't really want
+  // to make all mod assignment code operate on ResolvedLoadoutMods, so instead we find the original mod
+  // using a search through `resolvedMods`. We should avoid this, so maybe look at using ResolvedLoadoutMod more?
+
   const modRow = (mods: PluggableInventoryItemDefinition[]) => (
     <div key="modsDisplay" className={styles.modRow}>
       {mods.map((mod, index) => (
         <PlugDef
           key={index}
           plug={mod}
-          onClose={() => dispatch({ type: 'removeLockedMod', mod })}
+          onClose={() =>
+            dispatch({
+              type: 'removeLockedMod',
+              mod: resolvedMods.find((resolved) => resolved.resolvedMod === mod)!,
+            })
+          }
         />
       ))}
     </div>
@@ -95,7 +108,13 @@ export default function NoBuildsFoundExplainer({
                 key="removeAllInvalid"
                 type="button"
                 className="dim-button"
-                onClick={() => dispatch({ type: 'removeLockedMods', mods: alwaysInvalidMods })}
+                onClick={() =>
+                  dispatch({
+                    type: 'lockedModsChanged',
+                    // Drop all invalid mods by setting current mods to only the valid mods
+                    lockedMods: lockedModMap.allMods,
+                  })
+                }
               >
                 <AppIcon icon={banIcon} /> {t('LoadoutBuilder.NoBuildsFoundExplainer.RemoveMods')}
               </button>
@@ -329,6 +348,16 @@ export default function NoBuildsFoundExplainer({
                 >
                   {t('LoadoutBuilder.NoBuildsFoundExplainer.AllowAutoStatMods')}
                 </button>
+              ),
+            },
+          autoAssignStatMods &&
+            lockedModMap.generalMods.length > 0 && {
+              id: 'removeGeneralMods',
+              contents: (
+                <>
+                  {t('LoadoutBuilder.NoBuildsFoundExplainer.MaybeRemoveMods')}
+                  {modRow(lockedModMap.generalMods)}
+                </>
               ),
             },
           {

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { hideItemPicker, showItemPicker } from 'app/item-picker/item-picker';
-import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { ResolvedLoadoutItem, ResolvedLoadoutMod } from 'app/loadout-drawer/loadout-types';
 import { isLoadoutBuilderItem, pickSubclass } from 'app/loadout/item-utils';
 import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import { createGetModRenderKey } from 'app/loadout/mod-utils';
@@ -35,7 +35,7 @@ interface Props {
   selectedStore: DimStore;
   pinnedItems: PinnedItems;
   excludedItems: ExcludedItems;
-  lockedMods: PluggableInventoryItemDefinition[];
+  lockedMods: ResolvedLoadoutMod[];
   subclass?: ResolvedLoadoutItem;
   lockedExoticHash?: number;
   searchFilter: ItemFilter;
@@ -103,7 +103,7 @@ export default memo(function LockArmorAndPerks({
     }
   };
 
-  const onModClicked = (mod: PluggableInventoryItemDefinition) =>
+  const onModClicked = (mod: ResolvedLoadoutMod) =>
     lbDispatch({
       type: 'removeLockedMod',
       mod,
@@ -210,7 +210,11 @@ export default memo(function LockArmorAndPerks({
         {Boolean(lockedMods.length) && (
           <div className={styles.itemGrid}>
             {lockedMods.map((mod) => (
-              <PlugDef key={getModRenderKey(mod)} plug={mod} onClose={() => onModClicked(mod)} />
+              <PlugDef
+                key={getModRenderKey(mod.resolvedMod)}
+                plug={mod.resolvedMod}
+                onClose={() => onModClicked(mod)}
+              />
             ))}
           </div>
         )}

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -216,7 +216,7 @@ type LoadoutBuilderConfigAction =
   | { type: 'excludeItem'; item: DimItem }
   | { type: 'unexcludeItem'; item: DimItem }
   | { type: 'autoStatModsChanged'; autoStatMods: boolean }
-  | { type: 'lockedModsChanged'; lockedMods: PluggableInventoryItemDefinition[] }
+  | { type: 'lockedModsChanged'; lockedMods: number[] }
   | { type: 'removeLockedMod'; mod: ResolvedLoadoutMod }
   | { type: 'addGeneralMods'; mods: PluggableInventoryItemDefinition[] }
   | { type: 'updateSubclass'; item: DimItem }
@@ -360,7 +360,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
           ...state,
           loadoutParameters: {
             ...state.loadoutParameters,
-            mods: action.lockedMods.map((m) => m.hash).map(mapToNonReducedModCostVariant),
+            mods: action.lockedMods.map(mapToNonReducedModCostVariant),
           },
         };
       }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -21,7 +21,7 @@ import {
   pickBackingStore,
 } from 'app/loadout-drawer/loadout-utils';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
-import { mapToNonReducedModCostVariant } from 'app/loadout/mod-utils';
+import { mapToNonReducedModCostVariant, mapToOtherModCostVariant } from 'app/loadout/mod-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
@@ -416,7 +416,9 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
       }
       case 'removeLockedMod': {
         const newMods = [...(state.loadoutParameters.mods ?? [])];
-        const indexToRemove = newMods.findIndex((mod) => mod === action.mod.hash);
+        const indexToRemove = newMods.findIndex(
+          (mod) => mod === action.mod.hash || mod === mapToOtherModCostVariant(action.mod.hash)
+        );
         if (indexToRemove >= 0) {
           newMods.splice(indexToRemove, 1);
         }
@@ -431,7 +433,11 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
       }
       case 'removeLockedMods': {
         const newMods = [...(state.loadoutParameters.mods ?? [])].filter(
-          (mod) => !action.mods.some((excludedMod) => excludedMod.hash === mod)
+          (mod) =>
+            !action.mods.some(
+              (excludedMod) =>
+                excludedMod.hash === mod || mod === mapToOtherModCostVariant(excludedMod.hash)
+            )
         );
 
         return {

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -21,6 +21,7 @@ import {
   pickBackingStore,
 } from 'app/loadout-drawer/loadout-utils';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
+import { mapToNonReducedModCostVariant } from 'app/loadout/mod-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
@@ -360,7 +361,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
           ...state,
           loadoutParameters: {
             ...state.loadoutParameters,
-            mods: action.lockedMods.map((m) => m.hash),
+            mods: action.lockedMods.map((m) => m.hash).map(mapToNonReducedModCostVariant),
           },
         };
       }

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -87,7 +87,7 @@ export type ArmorStats = { [statHash in ArmorStatHashes]: number };
  * The reusablePlugSetHash from armour 2.0's general socket.
  * TODO: Find a way to generate this in d2ai.
  */
-export const generalSocketReusablePlugSetHash = 3559124992;
+export const generalSocketReusablePlugSetHash = 731468111;
 
 /**
  * Special value for lockedExoticHash indicating the user would not like any exotics included in their loadouts.

--- a/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
@@ -4,7 +4,7 @@ import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t } from 'app/i18next-t';
 import { AppIcon, deleteIcon, redoIcon, undoIcon } from 'app/shell/icons';
 import { RootState } from 'app/store/types';
-import { currySelector } from 'app/utils/redux-utils';
+import { currySelector } from 'app/utils/selector-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -257,9 +257,10 @@ function doApplyLoadout(
       };
 
       // Don't apply mods when moving to the vault
-      const modsToApply = ((!store.isVault && getModHashesFromLoadout(loadout)) || []).filter(
-        checkMod
-      );
+      const modsToApply = (
+        (!store.isVault && getModHashesFromLoadout(loadout, unlockedPlugSetItems())) ||
+        []
+      ).filter(checkMod);
       // Mods specific to a bucket but not an item - fashion mods (shader/ornament)
       const modsByBucketToApply: {
         [bucketHash: number]: number[];

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -258,7 +258,8 @@ function doApplyLoadout(
 
       // Don't apply mods when moving to the vault
       const modsToApply = (
-        (!store.isVault &&
+        (defs.isDestiny2() &&
+          !store.isVault &&
           getModsFromLoadout(defs, loadout, unlockedPlugSetItems()).map(
             (mod) => mod.resolvedMod.hash
           )) ||

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -247,7 +247,7 @@ function doApplyLoadout(
       });
 
       // Filter out mods that no longer exist or that aren't unlocked on this character
-      const unlockedPlugSetItems = _.once(() => unlockedPlugSetItemsSelector(getState(), store.id));
+      const unlockedPlugSetItems = _.once(() => unlockedPlugSetItemsSelector(store.id)(getState()));
       const checkMod = (h: number) => {
         const mod = defs.InventoryItem.get(h);
         return (

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -79,7 +79,7 @@ import {
   setSocketOverrideResult,
 } from './loadout-apply-state';
 import { Assignment, Loadout, LoadoutItem } from './loadout-types';
-import { backupLoadout, findItemForLoadout, getModHashesFromLoadout } from './loadout-utils';
+import { backupLoadout, findItemForLoadout, getModsFromLoadout } from './loadout-utils';
 
 // TODO: move this whole file to "loadouts" folder
 
@@ -258,9 +258,13 @@ function doApplyLoadout(
 
       // Don't apply mods when moving to the vault
       const modsToApply = (
-        (!store.isVault && getModHashesFromLoadout(loadout, unlockedPlugSetItems())) ||
+        (!store.isVault &&
+          getModsFromLoadout(defs, loadout, unlockedPlugSetItems()).map(
+            (mod) => mod.resolvedMod.hash
+          )) ||
         []
       ).filter(checkMod);
+
       // Mods specific to a bucket but not an item - fashion mods (shader/ornament)
       const modsByBucketToApply: {
         [bucketHash: number]: number[];

--- a/src/app/loadout-drawer/loadout-types.ts
+++ b/src/app/loadout-drawer/loadout-types.ts
@@ -78,6 +78,17 @@ export interface ResolvedLoadoutItem {
   readonly missing?: boolean;
 }
 
+/**
+ * Similarly to loadout items, mods can resolve to something different than what the hash says.
+ * E.g. magic deprecated replacements, or reduced-cost copies.
+ */
+export interface ResolvedLoadoutMod {
+  /** The original hash in the loadout. */
+  readonly originalModHash: number;
+  /** The resolved mod */
+  readonly resolvedMod: PluggableInventoryItemDefinition;
+}
+
 /** represents a single mod, and where to place it (on a non-specific item) */
 export interface Assignment {
   /** what item to plug */

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -648,7 +648,11 @@ export function isMissingItems(
   return false;
 }
 
-/** Returns a flat list of mods hashes in the Loadout, by default including auto stat mods */
+/**
+ * Returns a flat list of mods hashes in the Loadout, by default including auto stat mods.
+ * This INCLUDES both locked and unlocked mods; `unlockedPlugs` is used to identify if the expensive or cheap copy of an
+ * armor mod should be used.
+ */
 export function getModHashesFromLoadout(
   loadout: Loadout,
   unlockedPlugs: Set<number>,
@@ -660,7 +664,11 @@ export function getModHashesFromLoadout(
   ].map((hash) => mapToAvailableModCostVariant(hash, unlockedPlugs));
 }
 
-/** Returns a flat list of mods as PluggableInventoryItemDefinitions in the Loadout, by default including auto stat mods */
+/**
+ * Returns a flat list of mods as PluggableInventoryItemDefinitions in the Loadout, by default including auto stat mods.
+ * This INCLUDES both locked and unlocked mods; `unlockedPlugs` is used to identify if the expensive or cheap copy of an
+ * armor mod should be used.
+ */
 export function getModsFromLoadout(
   defs: D1ManifestDefinitions | D2ManifestDefinitions | undefined,
   loadout: Loadout,

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -15,7 +15,7 @@ import {
 } from 'app/loadout/mod-utils';
 import { manifestSelector } from 'app/manifest/selectors';
 import { D1BucketHashes } from 'app/search/d1-known-values';
-import { armorStats } from 'app/search/d2-known-values';
+import { armorStats, deprecatedPlaceholderArmorModHash } from 'app/search/d2-known-values';
 import { isPlugStatActive, itemCanBeInLoadout } from 'app/utils/item-utils';
 import {
   aspectSocketCategoryHashes,
@@ -683,7 +683,7 @@ export function getModsFromLoadout(
       if (isPluggableItem(item)) {
         mods.push(item);
       } else {
-        const deprecatedPlaceholderMod = defs.InventoryItem.get(3947616002);
+        const deprecatedPlaceholderMod = defs.InventoryItem.get(deprecatedPlaceholderArmorModHash);
         isPluggableItem(deprecatedPlaceholderMod) && mods.push(deprecatedPlaceholderMod);
       }
     }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -654,7 +654,7 @@ export function isMissingItems(
  * armor mod should be used.
  */
 export function getModsFromLoadout(
-  defs: D1ManifestDefinitions | D2ManifestDefinitions | undefined,
+  defs: D2ManifestDefinitions | undefined,
   loadout: Loadout,
   unlockedPlugs: Set<number>,
   includeAutoMods = true
@@ -668,12 +668,12 @@ export function getModsFromLoadout(
 }
 
 export function resolveLoadoutModHashes(
-  defs: D1ManifestDefinitions | D2ManifestDefinitions | undefined,
+  defs: D2ManifestDefinitions | undefined,
   modHashes: number[],
   unlockedPlugs: Set<number>
 ) {
   const mods: ResolvedLoadoutMod[] = [];
-  if (defs?.isDestiny2()) {
+  if (defs) {
     for (const originalModHash of modHashes) {
       const resolvedModHash = mapToAvailableModCostVariant(originalModHash, unlockedPlugs);
       const item = defs.InventoryItem.get(resolvedModHash);

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -8,7 +8,11 @@ import { isPluggableItem } from 'app/inventory/store/sockets';
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { isModStatActive } from 'app/loadout-builder/process/mappers';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
-import { isInsertableArmor2Mod, sortMods } from 'app/loadout/mod-utils';
+import {
+  isInsertableArmor2Mod,
+  mapToAvailableModCostVariant,
+  sortMods,
+} from 'app/loadout/mod-utils';
 import { manifestSelector } from 'app/manifest/selectors';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { armorStats } from 'app/search/d2-known-values';
@@ -645,23 +649,28 @@ export function isMissingItems(
 }
 
 /** Returns a flat list of mods hashes in the Loadout, by default including auto stat mods */
-export function getModHashesFromLoadout(loadout: Loadout, includeAutoMods = true) {
+export function getModHashesFromLoadout(
+  loadout: Loadout,
+  unlockedPlugs: Set<number>,
+  includeAutoMods = true
+) {
   return [
     ...(loadout.parameters?.mods ?? []),
     ...((includeAutoMods && loadout.autoStatMods) || []),
-  ];
+  ].map((hash) => mapToAvailableModCostVariant(hash, unlockedPlugs));
 }
 
 /** Returns a flat list of mods as PluggableInventoryItemDefinitions in the Loadout, by default including auto stat mods */
 export function getModsFromLoadout(
   defs: D1ManifestDefinitions | D2ManifestDefinitions | undefined,
   loadout: Loadout,
+  unlockedPlugs: Set<number>,
   includeAutoMods = true
 ) {
   const mods: PluggableInventoryItemDefinition[] = [];
 
   if (defs?.isDestiny2()) {
-    for (const modHash of getModHashesFromLoadout(loadout, includeAutoMods)) {
+    for (const modHash of getModHashesFromLoadout(loadout, unlockedPlugs, includeAutoMods)) {
       const item = defs.InventoryItem.get(modHash);
       if (isPluggableItem(item)) {
         mods.push(item);

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -3,7 +3,11 @@ import ClassIcon from 'app/dim-ui/ClassIcon';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
+import {
+  allItemsSelector,
+  createItemContextSelector,
+  unlockedPlugSetItemsSelector,
+} from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
@@ -11,6 +15,7 @@ import { Loadout, LoadoutItem, ResolvedLoadoutItem } from 'app/loadout-drawer/lo
 import { getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { RootState } from 'app/store/types';
 import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { count } from 'app/utils/util';
@@ -102,7 +107,14 @@ export default function LoadoutView({
     [itemCreationContext, loadout.items, store, allItems, modsByBucket]
   );
 
-  const allMods = useMemo(() => getModsFromLoadout(defs, loadout), [defs, loadout]);
+  const unlockedPlugs = useSelector((state: RootState) =>
+    unlockedPlugSetItemsSelector(state, store.id)
+  );
+
+  const allMods = useMemo(
+    () => getModsFromLoadout(defs, loadout, unlockedPlugs),
+    [defs, loadout, unlockedPlugs]
+  );
 
   const categories = _.groupBy(items.concat(warnitems), (li) => li.item.bucket.sort);
   const power = loadoutPower(store, categories);

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -3,17 +3,12 @@ import ClassIcon from 'app/dim-ui/ClassIcon';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import {
-  allItemsSelector,
-  createItemContextSelector,
-  unlockedPlugSetItemsSelector,
-} from 'app/inventory/selectors';
+import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
 import { Loadout, LoadoutItem, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
-import { getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
-import { useD2Definitions } from 'app/manifest/selectors';
+import { getLight } from 'app/loadout-drawer/loadout-utils';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
@@ -27,6 +22,7 @@ import LoadoutItemCategorySection from './loadout-ui/LoadoutItemCategorySection'
 import LoadoutMods from './loadout-ui/LoadoutMods';
 import LoadoutSubclassSection from './loadout-ui/LoadoutSubclassSection';
 import styles from './LoadoutView.m.scss';
+import { useLoadoutMods } from './mod-assignment-drawer/selectors';
 
 export function getItemsAndSubclassFromLoadout(
   itemCreationContext: ItemCreationContext,
@@ -81,7 +77,6 @@ export default function LoadoutView({
   hideOptimizeArmor?: boolean;
   hideShowModPlacements?: boolean;
 }) {
-  const defs = useD2Definitions()!;
   const allItems = useSelector(allItemsSelector);
   const itemCreationContext = useSelector(createItemContextSelector);
   const missingSockets =
@@ -106,12 +101,7 @@ export default function LoadoutView({
     [itemCreationContext, loadout.items, store, allItems, modsByBucket]
   );
 
-  const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(store.id));
-
-  const allMods = useMemo(
-    () => getModsFromLoadout(defs, loadout, unlockedPlugs),
-    [defs, loadout, unlockedPlugs]
-  );
+  const [allMods, modDefinitions] = useLoadoutMods(loadout, store.id);
 
   const categories = _.groupBy(items.concat(warnitems), (li) => li.item.bucket.sort);
   const power = loadoutPower(store, categories);
@@ -149,7 +139,7 @@ export default function LoadoutView({
                 subclass={subclass}
                 storeId={store.id}
                 items={categories[category]}
-                allMods={allMods}
+                allMods={modDefinitions}
                 modsByBucket={modsByBucket}
                 loadout={loadout}
                 hideOptimizeArmor={hideOptimizeArmor}

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -15,7 +15,6 @@ import { Loadout, LoadoutItem, ResolvedLoadoutItem } from 'app/loadout-drawer/lo
 import { getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useIsPhonePortrait } from 'app/shell/selectors';
-import { RootState } from 'app/store/types';
 import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { count } from 'app/utils/util';
@@ -107,9 +106,7 @@ export default function LoadoutView({
     [itemCreationContext, loadout.items, store, allItems, modsByBucket]
   );
 
-  const unlockedPlugs = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, store.id)
-  );
+  const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(store.id));
 
   const allMods = useMemo(
     () => getModsFromLoadout(defs, loadout, unlockedPlugs),

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -15,7 +15,6 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { AppIcon, clearIcon, rightArrowIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
-import { RootState } from 'app/store/types';
 import { getSocketsByCategoryHash, plugFitsIntoSocket } from 'app/utils/socket-utils';
 import { Portal } from 'app/utils/temp-container';
 import {
@@ -52,9 +51,7 @@ export default function FashionDrawer({
   onClose: () => void;
 }) {
   const defs = useD2Definitions()!;
-  const unlockedPlugs = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, storeId)
-  );
+  const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(storeId));
   const isPhonePortrait = useIsPhonePortrait();
   const [pickPlug, setPickPlug] = useState<PickPlugState>();
   const allItems = useSelector(allItemsSelector);
@@ -501,9 +498,7 @@ function FashionSocket({
   onPickPlug: (params: PickPlugState) => void;
   onRemovePlug: (bucketHash: number, modHash: number) => void;
 }) {
-  const unlockedPlugSetItems = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, storeId)
-  );
+  const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(storeId));
   const handleOrnamentClick = socket && (() => onPickPlug({ item: exampleItem, socket }));
 
   const unlockedPlugsWithoutTheDefault = Array.from(unlockedPlugSetItems).filter(

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -2,7 +2,7 @@ import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
-import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import {
@@ -107,8 +107,7 @@ export default function LoadoutEdit({
     return (...args: T) => setLoadout(fn(defs, store, ...args));
   }
 
-  const handleUpdateMods = (newMods: PluggableInventoryItemDefinition[]) =>
-    setLoadout(updateMods(newMods.map((mod) => mod.hash)));
+  const handleUpdateMods = (newMods: number[]) => setLoadout(updateMods(newMods));
   const handleRemoveMod = withUpdater(removeMod);
   const handleClearCategory = withDefsUpdater(clearBucketCategory);
   const handleModsByBucketUpdated = withUpdater(updateModsByBucket);

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -3,7 +3,11 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
+import {
+  allItemsSelector,
+  createItemContextSelector,
+  unlockedPlugSetItemsSelector,
+} from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import {
   applySocketOverrides,
@@ -28,6 +32,7 @@ import { getModsFromLoadout, getUnequippedItemsForLoadout } from 'app/loadout-dr
 import LoadoutMods from 'app/loadout/loadout-ui/LoadoutMods';
 import { getItemsAndSubclassFromLoadout, loadoutPower } from 'app/loadout/LoadoutView';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { RootState } from 'app/store/types';
 import { emptyObject } from 'app/utils/empty';
 import { Portal } from 'app/utils/temp-container';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -81,7 +86,14 @@ export default function LoadoutEdit({
     [itemCreationContext, loadout.items, store, allItems, modsByBucket]
   );
 
-  const allMods = useMemo(() => getModsFromLoadout(defs, loadout), [defs, loadout]);
+  const unlockedPlugSetItems = useSelector((state: RootState) =>
+    unlockedPlugSetItemsSelector(state, store.id)
+  );
+
+  const allMods = useMemo(
+    () => getModsFromLoadout(defs, loadout, unlockedPlugSetItems),
+    [defs, loadout, unlockedPlugSetItems]
+  );
   const clearUnsetMods = loadout.parameters?.clearMods;
   const categories = _.groupBy(items.concat(warnitems), (li) => li.item.bucket.sort);
   const power = loadoutPower(store, categories);

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -3,11 +3,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import {
-  allItemsSelector,
-  createItemContextSelector,
-  unlockedPlugSetItemsSelector,
-} from 'app/inventory/selectors';
+import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import {
   applySocketOverrides,
@@ -28,7 +24,7 @@ import {
   updateModsByBucket,
 } from 'app/loadout-drawer/loadout-drawer-reducer';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
-import { getModsFromLoadout, getUnequippedItemsForLoadout } from 'app/loadout-drawer/loadout-utils';
+import { getUnequippedItemsForLoadout } from 'app/loadout-drawer/loadout-utils';
 import LoadoutMods from 'app/loadout/loadout-ui/LoadoutMods';
 import { getItemsAndSubclassFromLoadout, loadoutPower } from 'app/loadout/LoadoutView';
 import { useD2Definitions } from 'app/manifest/selectors';
@@ -39,6 +35,7 @@ import _ from 'lodash';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { hasVisibleLoadoutParameters } from '../loadout-ui/LoadoutParametersDisplay';
+import { useLoadoutMods } from '../mod-assignment-drawer/selectors';
 import SubclassPlugDrawer from '../SubclassPlugDrawer';
 import styles from './LoadoutEdit.m.scss';
 import LoadoutEditBucket, { ArmorExtras } from './LoadoutEditBucket';
@@ -85,12 +82,7 @@ export default function LoadoutEdit({
     [itemCreationContext, loadout.items, store, allItems, modsByBucket]
   );
 
-  const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(store.id));
-
-  const allMods = useMemo(
-    () => getModsFromLoadout(defs, loadout, unlockedPlugSetItems),
-    [defs, loadout, unlockedPlugSetItems]
-  );
+  const [allMods, modDefinitions] = useLoadoutMods(loadout, store.id);
   const clearUnsetMods = loadout.parameters?.clearMods;
   const categories = _.groupBy(items.concat(warnitems), (li) => li.item.bucket.sort);
   const power = loadoutPower(store, categories);
@@ -117,7 +109,7 @@ export default function LoadoutEdit({
 
   const handleUpdateMods = (newMods: PluggableInventoryItemDefinition[]) =>
     setLoadout(updateMods(newMods.map((mod) => mod.hash)));
-  const handleRemoveMod = withDefsUpdater(removeMod);
+  const handleRemoveMod = withUpdater(removeMod);
   const handleClearCategory = withDefsUpdater(clearBucketCategory);
   const handleModsByBucketUpdated = withUpdater(updateModsByBucket);
   const handleApplySocketOverrides = withUpdater(applySocketOverrides);
@@ -215,7 +207,7 @@ export default function LoadoutEdit({
                   storeId={store.id}
                   subclass={subclass}
                   items={categories[category]}
-                  allMods={allMods}
+                  allMods={modDefinitions}
                   onModsByBucketUpdated={handleModsByBucketUpdated}
                 />
               )}

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -32,7 +32,6 @@ import { getModsFromLoadout, getUnequippedItemsForLoadout } from 'app/loadout-dr
 import LoadoutMods from 'app/loadout/loadout-ui/LoadoutMods';
 import { getItemsAndSubclassFromLoadout, loadoutPower } from 'app/loadout/LoadoutView';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { RootState } from 'app/store/types';
 import { emptyObject } from 'app/utils/empty';
 import { Portal } from 'app/utils/temp-container';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -86,9 +85,7 @@ export default function LoadoutEdit({
     [itemCreationContext, loadout.items, store, allItems, modsByBucket]
   );
 
-  const unlockedPlugSetItems = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, store.id)
-  );
+  const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(store.id));
 
   const allMods = useMemo(
     () => getModsFromLoadout(defs, loadout, unlockedPlugSetItems),

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -117,7 +117,7 @@ export default function LoadoutEdit({
 
   const handleUpdateMods = (newMods: PluggableInventoryItemDefinition[]) =>
     setLoadout(updateMods(newMods.map((mod) => mod.hash)));
-  const handleRemoveMod = withUpdater(removeMod);
+  const handleRemoveMod = withDefsUpdater(removeMod);
   const handleClearCategory = withDefsUpdater(clearBucketCategory);
   const handleModsByBucketUpdated = withUpdater(updateModsByBucket);
   const handleApplySocketOverrides = withUpdater(applySocketOverrides);

--- a/src/app/loadout/loadout-ui/FashionMods.tsx
+++ b/src/app/loadout/loadout-ui/FashionMods.tsx
@@ -5,7 +5,6 @@ import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
-import { RootState } from 'app/store/types';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { useSelector } from 'react-redux';
@@ -21,9 +20,7 @@ export function FashionMods({
   storeId?: string;
 }) {
   const defs = useD2Definitions()!;
-  const unlockedPlugSetItems = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, storeId)
-  );
+  const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(storeId));
   const isShader = (m: number) =>
     defs.InventoryItem.get(m)?.plug?.plugCategoryHash === PlugCategoryHashes.Shader;
   const shader = modsForBucket.find(isShader);

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -1,6 +1,5 @@
 import CheckButton from 'app/dim-ui/CheckButton';
 import { t } from 'app/i18next-t';
-import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
 import { Loadout, ResolvedLoadoutMod } from 'app/loadout-drawer/loadout-types';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
@@ -53,7 +52,7 @@ export default memo(function LoadoutMods({
   clearUnsetMods?: boolean;
   missingSockets?: boolean;
   /** If present, show an "Add Mod" button */
-  onUpdateMods?: (newMods: PluggableInventoryItemDefinition[]) => void;
+  onUpdateMods?: (newMods: number[]) => void;
   onRemoveMod?: (mod: ResolvedLoadoutMod) => void;
   onClearUnsetModsChanged?: (checked: boolean) => void;
 }) {
@@ -65,8 +64,8 @@ export default memo(function LoadoutMods({
   const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(storeId));
 
   // Explicitly show only actual saved mods in the mods picker, not auto mods,
-  // otherwise we'd duplicate auto mods into loadout parameter mods when coonfirming
-  const [, mappedMods] = useLoadoutMods(loadout, storeId, false);
+  // otherwise we'd duplicate auto mods into loadout parameter mods when confirming
+  const [resolvedMods] = useLoadoutMods(loadout, storeId, false);
 
   // TODO: filter down by usable mods?
   // TODO: Hide the "Add Mod" button when no more mods can fit
@@ -154,7 +153,7 @@ export default memo(function LoadoutMods({
           <ModPicker
             classType={loadout.classType}
             owner={storeId}
-            lockedMods={mappedMods}
+            lockedMods={resolvedMods}
             onAccept={onUpdateMods}
             onClose={() => setShowModPicker(false)}
           />

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -8,7 +8,6 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
-import { RootState } from 'app/store/types';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { memo, useMemo, useState } from 'react';
@@ -65,9 +64,7 @@ export default memo(function LoadoutMods({
   const [showModAssignmentDrawer, setShowModAssignmentDrawer] = useState(false);
   const [showModPicker, setShowModPicker] = useState(false);
 
-  const unlockedPlugSetItems = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, storeId)
-  );
+  const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(storeId));
 
   // Explicitly show only actual saved mods in the mods picker, not auto mods,
   // otherwise we'd duplicate auto mods into loadout parameter mods when coonfirming

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -71,7 +71,10 @@ export default memo(function LoadoutMods({
 
   // Explicitly show only actual saved mods in the mods picker, not auto mods,
   // otherwise we'd duplicate auto mods into loadout parameter mods when coonfirming
-  const savedMods = useMemo(() => getModsFromLoadout(defs, loadout, false), [defs, loadout]);
+  const savedMods = useMemo(
+    () => getModsFromLoadout(defs, loadout, unlockedPlugSetItems, false),
+    [defs, loadout, unlockedPlugSetItems]
+  );
 
   // TODO: filter down by usable mods?
   // TODO: Hide the "Add Mod" button when no more mods can fit

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -2,17 +2,16 @@ import CheckButton from 'app/dim-ui/CheckButton';
 import { t } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
-import { Loadout } from 'app/loadout-drawer/loadout-types';
-import { getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
-import { useD2Definitions } from 'app/manifest/selectors';
+import { Loadout, ResolvedLoadoutMod } from 'app/loadout-drawer/loadout-types';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
-import { memo, useMemo, useState } from 'react';
+import { memo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import ModAssignmentDrawer from '../mod-assignment-drawer/ModAssignmentDrawer';
+import { useLoadoutMods } from '../mod-assignment-drawer/selectors';
 import { createGetModRenderKey } from '../mod-utils';
 import ModPicker from '../ModPicker';
 import styles from './LoadoutMods.m.scss';
@@ -23,14 +22,14 @@ const LoadoutModMemo = memo(function LoadoutMod({
   className,
   onRemoveMod,
 }: {
-  mod: PluggableInventoryItemDefinition;
+  mod: ResolvedLoadoutMod;
   className: string;
-  onRemoveMod?: (modHash: number) => void;
+  onRemoveMod?: (mod: ResolvedLoadoutMod) => void;
 }) {
   // We need this to be undefined if `onRemoveMod` is not present as the presence of the onClose
   // callback determines whether the close icon is displayed on hover
-  const onClose = onRemoveMod && (() => onRemoveMod(mod.hash));
-  return <PlugDef className={className} plug={mod} onClose={onClose} />;
+  const onClose = onRemoveMod && (() => onRemoveMod(mod));
+  return <PlugDef className={className} plug={mod.resolvedMod} onClose={onClose} />;
 });
 
 /**
@@ -48,17 +47,16 @@ export default memo(function LoadoutMods({
   onClearUnsetModsChanged,
 }: {
   loadout: Loadout;
-  allMods: PluggableInventoryItemDefinition[];
+  allMods: ResolvedLoadoutMod[];
   storeId: string;
   hideShowModPlacements?: boolean;
   clearUnsetMods?: boolean;
   missingSockets?: boolean;
   /** If present, show an "Add Mod" button */
   onUpdateMods?: (newMods: PluggableInventoryItemDefinition[]) => void;
-  onRemoveMod?: (modHash: number) => void;
+  onRemoveMod?: (mod: ResolvedLoadoutMod) => void;
   onClearUnsetModsChanged?: (checked: boolean) => void;
 }) {
-  const defs = useD2Definitions()!;
   const isPhonePortrait = useIsPhonePortrait();
   const getModRenderKey = createGetModRenderKey();
   const [showModAssignmentDrawer, setShowModAssignmentDrawer] = useState(false);
@@ -68,10 +66,7 @@ export default memo(function LoadoutMods({
 
   // Explicitly show only actual saved mods in the mods picker, not auto mods,
   // otherwise we'd duplicate auto mods into loadout parameter mods when coonfirming
-  const savedMods = useMemo(
-    () => getModsFromLoadout(defs, loadout, unlockedPlugSetItems, false),
-    [defs, loadout, unlockedPlugSetItems]
-  );
+  const [, mappedMods] = useLoadoutMods(loadout, storeId, false);
 
   // TODO: filter down by usable mods?
   // TODO: Hide the "Add Mod" button when no more mods can fit
@@ -101,12 +96,12 @@ export default memo(function LoadoutMods({
           <LoadoutModMemo
             className={clsx({
               [styles.missingItem]: !(
-                unlockedPlugSetItems.has(mod.hash) ||
-                mod.hash === DEFAULT_SHADER ||
-                DEFAULT_ORNAMENTS.includes(mod.hash)
+                unlockedPlugSetItems.has(mod.resolvedMod.hash) ||
+                mod.resolvedMod.hash === DEFAULT_SHADER ||
+                DEFAULT_ORNAMENTS.includes(mod.resolvedMod.hash)
               ),
             })}
-            key={getModRenderKey(mod)}
+            key={getModRenderKey(mod.resolvedMod)}
             mod={mod}
             onRemoveMod={onRemoveMod}
           />
@@ -159,7 +154,7 @@ export default memo(function LoadoutMods({
           <ModPicker
             classType={loadout.classType}
             owner={storeId}
-            lockedMods={savedMods}
+            lockedMods={mappedMods}
             onAccept={onUpdateMods}
             onClose={() => setShowModPicker(false)}
           />

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -57,7 +57,7 @@ export default function ModAssignmentDrawer({
 }: {
   loadout: Loadout;
   storeId: string;
-  onUpdateMods?: (newMods: PluggableInventoryItemDefinition[]) => void;
+  onUpdateMods?: (newMods: number[]) => void;
   onClose: () => void;
 }) {
   const [plugCategoryHashWhitelist, setPlugCategoryHashWhitelist] = useState<number[]>();
@@ -66,17 +66,17 @@ export default function ModAssignmentDrawer({
   const { armor, subclass } = useEquippedLoadoutArmorAndSubclass(loadout, storeId);
   const getModRenderKey = createGetModRenderKey();
 
-  const [, resolvedMods] = useLoadoutMods(loadout, storeId);
+  const [resolvedMods, modDefinitions] = useLoadoutMods(loadout, storeId);
 
   const [itemModAssignments, unassignedMods] = useMemo(() => {
     const { itemModAssignments, unassignedMods } = fitMostMods({
       items: armor,
-      plannedMods: resolvedMods,
+      plannedMods: modDefinitions,
       armorEnergyRules: inGameArmorEnergyRules,
     });
 
     return [itemModAssignments, unassignedMods];
-  }, [armor, resolvedMods]);
+  }, [armor, modDefinitions]);
 
   const onSocketClick = useCallback(
     (plugDef: PluggableInventoryItemDefinition, plugCategoryHashWhitelist: number[]) => {

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -4,15 +4,18 @@ import Sheet from 'app/dim-ui/Sheet';
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
 import { inGameArmorEnergyRules } from 'app/loadout-builder/types';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getLoadoutStats, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
+import { RootState } from 'app/store/types';
 import { Portal } from 'app/utils/temp-container';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import PlugDef from '../loadout-ui/PlugDef';
 import Sockets from '../loadout-ui/Sockets';
 import { fitMostMods } from '../mod-assignment-utils';
@@ -63,13 +66,16 @@ export default function ModAssignmentDrawer({
   const [plugCategoryHashWhitelist, setPlugCategoryHashWhitelist] = useState<number[]>();
 
   const defs = useD2Definitions()!;
+  const unlockedPlugs = useSelector((state: RootState) =>
+    unlockedPlugSetItemsSelector(state, storeId)
+  );
   const { armor, subclass } = useEquippedLoadoutArmorAndSubclass(loadout, storeId);
   const getModRenderKey = createGetModRenderKey();
 
   const [itemModAssignments, unassignedMods, mods] = useMemo(() => {
     let mods: PluggableInventoryItemDefinition[] = [];
     if (defs) {
-      mods = getModsFromLoadout(defs, loadout);
+      mods = getModsFromLoadout(defs, loadout, unlockedPlugs);
     }
     const { itemModAssignments, unassignedMods } = fitMostMods({
       items: armor,
@@ -78,7 +84,7 @@ export default function ModAssignmentDrawer({
     });
 
     return [itemModAssignments, unassignedMods, mods];
-  }, [defs, loadout, armor]);
+  }, [defs, armor, loadout, unlockedPlugs]);
 
   const onSocketClick = useCallback(
     (plugDef: PluggableInventoryItemDefinition, plugCategoryHashWhitelist: number[]) => {

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -10,7 +10,6 @@ import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getLoadoutStats, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
-import { RootState } from 'app/store/types';
 import { Portal } from 'app/utils/temp-container';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -66,9 +65,7 @@ export default function ModAssignmentDrawer({
   const [plugCategoryHashWhitelist, setPlugCategoryHashWhitelist] = useState<number[]>();
 
   const defs = useD2Definitions()!;
-  const unlockedPlugs = useSelector((state: RootState) =>
-    unlockedPlugSetItemsSelector(state, storeId)
-  );
+  const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(storeId));
   const { armor, subclass } = useEquippedLoadoutArmorAndSubclass(loadout, storeId);
   const getModRenderKey = createGetModRenderKey();
 

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -3,15 +3,18 @@ import {
   allItemsSelector,
   createItemContextSelector,
   sortedStoresSelector,
+  unlockedPlugSetItemsSelector,
 } from 'app/inventory/selectors';
 import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { LockableBucketHashes } from 'app/loadout-builder/types';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
+import { useDefinitions } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 
 /**
@@ -71,4 +74,21 @@ export function useEquippedLoadoutArmorAndSubclass(
   );
 
   return useSelector(loadoutItemSelector, shallowEqual);
+}
+
+/**
+ * Returns a list of resolved loadout mods for the loadout, for convenience paired
+ * with a (memoized) list of just the defs (for the components that need it).
+ * Loadout mod resolution may choose different versions of mods depending on artifact unlocks
+ * and may replace defs that no longer exist with a placeholder deprecated mod.
+ */
+export function useLoadoutMods(loadout: Loadout, storeId: string, includeAutoMods?: boolean) {
+  const defs = useDefinitions();
+  const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(storeId));
+
+  return useMemo(() => {
+    const allMods = getModsFromLoadout(defs, loadout, unlockedPlugs, includeAutoMods);
+    const modDefinitions = allMods.map((mod) => mod.resolvedMod);
+    return [allMods, modDefinitions] as const;
+  }, [defs, includeAutoMods, loadout, unlockedPlugs]);
 }

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -10,7 +10,7 @@ import { LockableBucketHashes } from 'app/loadout-builder/types';
 import { getItemsFromLoadoutItems } from 'app/loadout-drawer/loadout-item-conversion';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
-import { useDefinitions } from 'app/manifest/selectors';
+import { useD2Definitions } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -83,7 +83,7 @@ export function useEquippedLoadoutArmorAndSubclass(
  * and may replace defs that no longer exist with a placeholder deprecated mod.
  */
 export function useLoadoutMods(loadout: Loadout, storeId: string, includeAutoMods?: boolean) {
-  const defs = useDefinitions();
+  const defs = useD2Definitions();
   const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(storeId));
 
   return useMemo(() => {

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -183,6 +183,9 @@ export const pinnacleSources = [
   73143230, // Pinnacle
 ];
 
+// For loadout mods obliterated from the defs, we instead return this def
+export const deprecatedPlaceholderArmorModHash = 3947616002;
+
 //
 // BUCKETS KNOWN VALUES
 //

--- a/src/app/utils/redux-utils.ts
+++ b/src/app/utils/redux-utils.ts
@@ -25,29 +25,3 @@ export function observeStore<T>(
   handleChange();
   return unsubscribe;
 }
-
-/**
- * Turn a selector output from reselect's createSelector which depends on some input
- * other than state, into a function that produces a selector function based on that
- * input. This makes it nicer to use in useSelector.
- *
- * Example:
- *
- * const upperStoreIdSelector = createSelector(
- *   (state: RootState, storeId: string) => storeId,
- *   (storeId) => storeId.toUpperCase()
- * )
- *
- * // Hard to put into useSelector:
- * const upperStoreId = useSelector((state: RootState) => upperStoreIdSelector(state, storeId))
- *
- * const curriedUpperStoreIdSelector = currySelector(upperStoreIdSelector)
- *
- * // Nice:
- * const upperStoreId = useSelector(curriedUpperStoreIdSelector(storeId))
- */
-export function currySelector<K, R>(
-  selector: (state: RootState, props: K) => R
-): (props: K) => (state: RootState) => R {
-  return (props: K) => (state: RootState) => selector(state, props);
-}

--- a/src/app/utils/selector-utils.ts
+++ b/src/app/utils/selector-utils.ts
@@ -1,0 +1,30 @@
+import { RootState } from 'app/store/types';
+
+// Note: Separate file (even from redux-utils) so that there are no non-type imports,
+// as it's otherwise prone to circular import dependencies that break selectors
+
+/**
+ * Turn a selector output from reselect's createSelector which depends on some input
+ * other than state, into a function that produces a selector function based on that
+ * input. This makes it nicer to use in useSelector.
+ *
+ * Example:
+ *
+ * const upperStoreIdSelector = createSelector(
+ *   (state: RootState, storeId: string) => storeId,
+ *   (storeId) => storeId.toUpperCase()
+ * )
+ *
+ * // Hard to put into useSelector:
+ * const upperStoreId = useSelector((state: RootState) => upperStoreIdSelector(state, storeId))
+ *
+ * const curriedUpperStoreIdSelector = currySelector(upperStoreIdSelector)
+ *
+ * // Nice:
+ * const upperStoreId = useSelector(curriedUpperStoreIdSelector(storeId))
+ */
+export function currySelector<K, R>(
+  selector: (state: RootState, props: K) => R
+): (props: K) => (state: RootState) => R {
+  return (props: K) => (state: RootState) => selector(state, props);
+}

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -7,7 +7,7 @@ import {
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
-import { currySelector } from 'app/utils/redux-utils';
+import { currySelector } from 'app/utils/selector-utils';
 import { createSelector } from 'reselect';
 import { D2VendorGroup, toVendorGroups } from './d2-vendors';
 


### PR DESCRIPTION
Internally prefers to store the normal hashes, but maps to whatever the user has unlocked when presenting or applying the loadout, running LO etc.

Also fixes #9166.