### PR TITLE
Improve sub-vendor focusing items

### DIFF
--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -140,7 +140,9 @@ function getVendorItems(
     // If the sales should come from the server, don't show anything until we have them
     return [];
   } else {
-    return vendorDef.itemList.map((i) => vendorItemForDefinitionItem(context, i, characterId));
+    return vendorDef.itemList.map((i, index) =>
+      vendorItemForDefinitionItem(context, i, characterId, index)
+    );
   }
 }
 


### PR DESCRIPTION
When going to Vendors -> e.g. Zavala -> Focused Decoding, clicking any item shows a scary error message about missing sockets. Clicking the item name for the armory view shows the armory with the dummy item.

This removes the error message and enables Armory to find the correct replacement item.