### PR TITLE
style: fix organizer header's alignment

### DIFF
--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -75,7 +75,7 @@ $content-cells: 5;
   }
 
   &.stats {
-    text-align: left;
+    text-align: right;
   }
 }
 

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -499,30 +499,33 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
           />
         </div>
       </div>
-      {filteredColumns.map((column: ColumnDefinition) => (
-        <div
-          key={column.id}
-          className={clsx(styles[column.id], styles.header, {
-            [styles.stats]: ['stats', 'baseStats'].includes(column.columnGroup?.id ?? ''),
-          })}
-          role="columnheader"
-          aria-sort="none"
-        >
-          <div onClick={column.noSort ? undefined : toggleColumnSort(column)}>
-            {column.header}
-            {!column.noSort && columnSorts.some((c) => c.columnId === column.id) && (
-              <AppIcon
-                className={styles.sorter}
-                icon={
-                  columnSorts.find((c) => c.columnId === column.id)!.sort === SortDirection.DESC
-                    ? faCaretDown
-                    : faCaretUp
-                }
-              />
-            )}
+      {filteredColumns.map((column: ColumnDefinition) => {
+        const isStatsColumn = ['stats', 'baseStats'].includes(column.columnGroup?.id ?? '');
+        return (
+          <div
+            key={column.id}
+            className={clsx(styles[column.id], styles.header, {
+              [styles.stats]: isStatsColumn,
+            })}
+            role="columnheader"
+            aria-sort="none"
+          >
+            <div onClick={column.noSort ? undefined : toggleColumnSort(column)}>
+              {column.header}
+              {!column.noSort && columnSorts.some((c) => c.columnId === column.id) && (
+                <AppIcon
+                  className={styles.sorter}
+                  icon={
+                    columnSorts.find((c) => c.columnId === column.id)!.sort === SortDirection.DESC
+                      ? faCaretDown
+                      : faCaretUp
+                  }
+                />
+              )}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
       {rows.length === 0 && <div className={styles.noItems}>{t('Organizer.NoItems')}</div>}
       {rows.map((row) => (
         <React.Fragment key={row.item.id}>


### PR DESCRIPTION
Previously [PR](https://github.com/DestinyItemManager/DIM/pull/8136) fixed a stats alignment, but other's column had a wrong alignment. So there's a revert [PR](https://github.com/DestinyItemManager/DIM/pull/9053)
Because it was a `clsx` package's problem that: 
```tsx
// somehow it doesn't work
className={clsx({
  [styles.stats]: ['stats', 'baseStats'].includes(column.columnGroup?.id ?? '')
})}

// work
const isStatsColumn = ['stats', 'baseStats'].includes(column.columnGroup?.id ?? '')

className={clsx({
  [styles.stats]: isStatsColumn
})}
```

It works fine on latest version of `clsx` package. But I worried about side-effects on version upgrade, so I fixed less more risky.