### PR TITLE
tidy suggestion generators, fix max filters

### DIFF
--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -35,7 +35,7 @@ export interface FilterContext {
     [itemHash: string]: ItemHashTag;
   };
   language: string;
-  customStats: Settings['customStats'];
+  customStats: Settings['customStats'] | undefined;
   d2Definitions: D2ManifestDefinitions | undefined;
 }
 
@@ -140,8 +140,20 @@ export interface FilterDefinition<I extends DimItem = DimItem> {
 
   /**
    * A list of suggested keywords, for `query` and `stat` formats.
+   * note these are KEYWORDS not full valid filters.
+   * i.e. for a `tag` filter, this would be
+   * `[junk, keep, etc]` not `[tag:junk, tag:keep, etc]`
+   *
+   * based on the filter format being `query`,
+   * buildSearchConfig will automatically create the latter
    */
-  suggestions?: string[];
+  suggestionKeywords?: string[];
+
+  /**
+   * for `query` and `stat` formats, this provides a way
+   * to dynamically create keywords. see suggestionKeywords docs.
+   */
+  suggestionKeywordGenerator?: (args: SuggestionsContext) => string[] | undefined;
 
   /**
    * For range-like filters, a mapping of strings to numbers (like season names or power cap aliases)

--- a/src/app/search/search-config.ts
+++ b/src/app/search/search-config.ts
@@ -67,6 +67,16 @@ export function buildSearchConfig(
   const allApplicableFilters: FilterDefinition[] = [];
   for (const filter of allFilters) {
     if (!filter.destinyVersion || filter.destinyVersion === destinyVersion) {
+      // augment filter's suggestionKeywords with dynamic additions
+      if (filter.suggestionKeywordGenerator) {
+        const suggestionKeywords = new Set(filter.suggestionKeywords ?? []);
+        for (const keyword of filter.suggestionKeywordGenerator(suggestionsContext) ?? []) {
+          suggestionKeywords.add(keyword);
+        }
+        if (suggestionKeywords.size) {
+          filter.suggestionKeywords = Array.from(suggestionKeywords);
+        }
+      }
       for (const suggestion of generateSuggestionsForFilter(filter)) {
         suggestions.add(suggestion);
       }

--- a/src/app/search/search-filter.ts
+++ b/src/app/search/search-filter.ts
@@ -248,7 +248,7 @@ export function matchFilter(
         break;
       }
       case 'query': {
-        if (filterDef.suggestions!.includes(filterValue)) {
+        if (filterDef.suggestionKeywords!.includes(filterValue)) {
           return (filterContext) =>
             filterDef.filter({
               lhs,

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -180,7 +180,7 @@ const dupeFilters: FilterDefinition[] = [
     filter: ({ allItems, customStats }) => {
       const duplicateSetsByClass: Partial<Record<DimItem['classType'], Set<string>[]>> = {};
 
-      for (const customStat of customStats) {
+      for (const customStat of customStats ?? []) {
         const relevantStatHashes: number[] = [];
         const statWeights = customStat.weights;
         for (const statHash in statWeights) {

--- a/src/app/search/search-filters/item-infos.tsx
+++ b/src/app/search/search-filters/item-infos.tsx
@@ -16,7 +16,7 @@ const itemInfosFilters: FilterDefinition[] = [
     keywords: 'tag',
     description: tl('Filter.Tags.Tag'),
     format: 'query',
-    suggestions: itemTagSelectorList.map((tag) => tag.type ?? 'none'),
+    suggestionKeywords: itemTagSelectorList.map((tag) => tag.type ?? 'none'),
     filter:
       ({ filterValue, itemInfos, itemHashTags }) =>
       (item) =>

--- a/src/app/search/search-filters/known-values.tsx
+++ b/src/app/search/search-filters/known-values.tsx
@@ -163,7 +163,7 @@ const knownValuesFilters: FilterDefinition[] = [
     keywords: 'breaker',
     description: tl('Filter.Breaker'),
     format: 'query',
-    suggestions: Object.keys(breakerTypes),
+    suggestionKeywords: Object.keys(breakerTypes),
     destinyVersion: 2,
     filter: ({ filterValue }) => {
       const breakerType = breakerTypes[filterValue];
@@ -177,7 +177,7 @@ const knownValuesFilters: FilterDefinition[] = [
     keywords: 'foundry',
     description: tl('Filter.Foundry'),
     format: 'query',
-    suggestions: ['daito', 'hakke', 'omolon', 'suros', 'tex-mechanica', 'veist', 'any'],
+    suggestionKeywords: ['daito', 'hakke', 'omolon', 'suros', 'tex-mechanica', 'veist', 'any'],
     destinyVersion: 2,
     filter: ({ filterValue }) => {
       switch (filterValue) {
@@ -218,7 +218,7 @@ const knownValuesFilters: FilterDefinition[] = [
     keywords: 'source',
     description: tl('Filter.Event'), // or 'Filter.Source'
     format: 'query',
-    suggestions: [...Object.keys(D2Sources), ...Object.keys(D2EventPredicateLookup)],
+    suggestionKeywords: [...Object.keys(D2Sources), ...Object.keys(D2EventPredicateLookup)],
     destinyVersion: 2,
     filter: ({ filterValue }) => {
       if (D2Sources[filterValue]) {

--- a/src/app/search/search-filters/range-numeric.tsx
+++ b/src/app/search/search-filters/range-numeric.tsx
@@ -36,7 +36,7 @@ const simpleRangeFilters: FilterDefinition[] = [
     description: tl('Filter.MasterworkKills'),
     format: ['range', 'stat'],
     destinyVersion: 2,
-    suggestions: ['pve', 'pvp', 'gambit'],
+    suggestionKeywords: ['pve', 'pvp', 'gambit'],
     validateStat: () => (stat) => ['pve', 'pvp', 'gambit'].includes(stat),
     filter:
       ({ filterValue, compare }) =>

--- a/src/app/search/search-filters/range-overload.tsx
+++ b/src/app/search/search-filters/range-overload.tsx
@@ -23,7 +23,7 @@ const overloadedRangeFilters: FilterDefinition[] = [
     description: tl('Filter.Masterwork'),
     format: ['simple', 'query', 'range'],
     destinyVersion: 2,
-    suggestions: allStatNames,
+    suggestionKeywords: allStatNames,
     filter: ({ lhs, filterValue, compare }) => {
       // the "is:masterwork" case
       if (lhs === 'is') {

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -31,7 +31,7 @@ export const modslotFilter: FilterDefinition = {
   keywords: 'modslot',
   description: tl('Filter.ModSlot'),
   format: 'query',
-  suggestions: modSlotTags.concat(['any', 'none', 'activity']),
+  suggestionKeywords: modSlotTags.concat(['any', 'none', 'activity']),
   destinyVersion: 2,
   filter:
     ({ filterValue }) =>
@@ -190,7 +190,7 @@ const socketFilters: FilterDefinition[] = [
   {
     keywords: 'armorintrinsic',
     format: ['simple', 'query'],
-    suggestions: ['none'],
+    suggestionKeywords: ['none'],
     description: tl('Filter.ArmorIntrinsic'),
     destinyVersion: 2,
     filter: ({ filterValue, language }) => {
@@ -212,7 +212,7 @@ const socketFilters: FilterDefinition[] = [
     keywords: 'holdsmod',
     description: tl('Filter.HoldsMod'),
     format: 'query',
-    suggestions: modTypeTags.concat(['any', 'none']),
+    suggestionKeywords: modTypeTags.concat(['any', 'none']),
     destinyVersion: 2,
     filter:
       ({ filterValue }) =>
@@ -246,7 +246,7 @@ const socketFilters: FilterDefinition[] = [
     description: tl('Filter.HasMemento'),
     format: 'query',
     destinyVersion: 2,
-    suggestions: ['any', ...Object.keys(craftingMementos)],
+    suggestionKeywords: ['any', ...Object.keys(craftingMementos)],
     filter: ({ filterValue }) => {
       const list: number[] | undefined = craftingMementos[filterValue];
       return (item: DimItem) =>
@@ -262,7 +262,7 @@ const socketFilters: FilterDefinition[] = [
     description: tl('Filter.Catalyst'),
     format: 'query',
     destinyVersion: 2,
-    suggestions: ['complete', 'incomplete', 'missing'],
+    suggestionKeywords: ['complete', 'incomplete', 'missing'],
     filter:
       ({ filterValue }) =>
       (item: DimItem) => {

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -34,6 +34,7 @@ const statFilters: FilterDefinition[] = [
     // t('Filter.StatsExtras')
     description: tl('Filter.Stats'),
     format: 'stat',
+    suggestionKeywords: allAtomicStats,
     suggestionKeywordGenerator: ({ customStats }) => customStats?.map((c) => c.shortLabel),
     validateStat,
     filter: ({ filterValue, compare, customStats }) =>

--- a/src/app/search/search-utils.test.ts
+++ b/src/app/search/search-utils.test.ts
@@ -6,7 +6,7 @@ describe('generateSuggestionsForFilter', () => {
   const cases: [
     format: FilterDefinition['format'],
     keywords: FilterDefinition['keywords'],
-    suggestions: FilterDefinition['suggestions'],
+    suggestions: FilterDefinition['suggestionKeywords'],
     overload: { [key: string]: number } | undefined
   ][] = [
     [undefined, ['a', 'b', 'c'], undefined, undefined],
@@ -33,7 +33,7 @@ describe('generateSuggestionsForFilter', () => {
       const candidates = generateSuggestionsForFilter({
         format,
         keywords,
-        suggestions,
+        suggestionKeywords: suggestions,
         overload,
       });
       expect(candidates).toMatchSnapshot();

--- a/src/app/search/suggestions-generation.ts
+++ b/src/app/search/suggestions-generation.ts
@@ -62,7 +62,7 @@ const operators = ['<', '>', '<=', '>=']; // TODO: add "none"? remove >=, <=?
 export function generateSuggestionsForFilter(
   filterDefinition: Pick<
     FilterDefinition,
-    'keywords' | 'suggestions' | 'format' | 'overload' | 'deprecated'
+    'keywords' | 'suggestionKeywords' | 'format' | 'overload' | 'deprecated'
   >
 ) {
   return generateGroupedSuggestionsForFilter(filterDefinition, false).flatMap(
@@ -79,18 +79,17 @@ export function generateSuggestionsForFilter(
 export function generateGroupedSuggestionsForFilter(
   filterDefinition: Pick<
     FilterDefinition,
-    'keywords' | 'suggestions' | 'format' | 'overload' | 'deprecated'
+    'keywords' | 'suggestionKeywords' | 'format' | 'overload' | 'deprecated'
   >,
   forHelp?: boolean
 ): { keyword: string; ops?: string[] }[] {
   if (filterDefinition.deprecated) {
     return [];
   }
-
-  const { suggestions, keywords } = filterDefinition;
+  const { suggestionKeywords, keywords } = filterDefinition;
   const thisFilterKeywords = Array.isArray(keywords) ? keywords : [keywords];
 
-  const filterSuggestions = suggestions === undefined ? [] : suggestions;
+  const filterSuggestions = suggestionKeywords === undefined ? [] : suggestionKeywords;
 
   const allSuggestions = [];
 


### PR DESCRIPTION
fixes `maxstatvalue` and `maxbasestatvalue` for custom stats.
`maxstatloadout` was never supported.

it was weird to manually run generateSuggestionsForFilter just to do dynamic suggestions, so now there's a dynamic keyword generator.
it adds `mystatname` into `[discipline, mobility, etc]`
instead of only adding `stat:mystatname` into `[stat:discipline, stat:mobility, etc]`

so that normal suggestion generation can run on dynamic values