### PR TITLE
Fix DIM settings migration

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -21,7 +21,7 @@ import { parseAndValidateQuery } from 'app/search/search-utils';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { errorLog, infoLog, timer } from 'app/utils/log';
-import { count } from 'app/utils/util';
+import { count, uniqBy } from 'app/utils/util';
 import { clearWishLists } from 'app/wishlists/actions';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { deepEqual } from 'fast-equals';
@@ -489,6 +489,14 @@ function migrateSettings(state: DimApiState) {
     // empty out the old-format setting. eventually phase out this old settings key?
     state = changeSetting(state, 'customStats', customStats);
     state = changeSetting(state, 'customTotalStatsByClass', {});
+  }
+
+  // A previous bug ins settings migration could cause duplicate custom stats
+  if (state.settings.customStats.length) {
+    const uniqCustomStats = uniqBy(state.settings.customStats, (stat) => stat.statHash);
+    if (uniqCustomStats.length !== state.settings.customStats.length) {
+      state = changeSetting(state, 'customStats', uniqCustomStats);
+    }
   }
 
   return state;


### PR DESCRIPTION
This fixes settings migration by ensuring `migrateSettings` adds its migrations to the update queue too.

The existing behavior migrates DIM's local settings state, but doesn't flush them back to DIM Sync. This means individual settings are migrated every time DIM fetches the settings from Sync. This is generally not a problem, since migration is pure and the moment the user changes the setting locally, the migrated/changed setting is flushed to Sync.

However, the two custom stat settings are linked; the migration clears out `customTotalStatsByClass` and adds to `customStats`; none of it is flushed to DIM Sync. This works fine until the user interacts with the new `customStats` setting: This flushes the `customStats` back to DIM Sync, so now DIM Sync stores `customTotalStatsByClass` unmodified and also stores the new `customStats`. The next time DIM fetches the Sync profile, it then sees `customTotalStatsByClass` again and performs the migration, adding duplicate entries to `customStats`.

Adding all migrations to the update queue (which is squashed later into an atomic update request) ensures that all DIM migrations are applied to DIM Sync before the user can interact with any setting, which keeps DIM Sync settings and local settings state consistent.