### PR TITLE
use gap on ranks progress boxes

### DIFF
--- a/src/app/progress/ReputationRank.m.scss
+++ b/src/app/progress/ReputationRank.m.scss
@@ -58,9 +58,11 @@
 
 .winStreak {
   margin-top: 5px;
+  gap: 4px;
   & > :global(.objective-checkbox) {
     height: 14px;
     width: 14px;
+    margin: 0;
     &:global(.objective-complete) {
       opacity: 1;
       /* yellow for crucibles, green override for gambit */

--- a/src/app/progress/ReputationRank.tsx
+++ b/src/app/progress/ReputationRank.tsx
@@ -92,7 +92,7 @@ function ReputationRankIcon({ progress }: { progress: DestinyProgression }) {
         <circle r="21" cx="27" cy="27" fill="#222" />
         {progress.progressToNextLevel > 0 && (
           <circle
-            r="22"
+            r="22.5"
             cx="-27"
             cy="27"
             transform="rotate(-90)"
@@ -106,7 +106,7 @@ function ReputationRankIcon({ progress }: { progress: DestinyProgression }) {
         )}
         {progress.currentProgress > 0 && (
           <circle
-            r="25"
+            r="25.5"
             cx="-27"
             cy="27"
             transform="rotate(-90)"


### PR DESCRIPTION
from discord, this should align those boxes a bit better and also use more gap where applicable. 
![image](https://user-images.githubusercontent.com/29002828/224727483-edd105ba-ee11-4ef4-b8e3-7f453ba1ac99.png)

before: 
![image](https://user-images.githubusercontent.com/29002828/224728714-8c277378-d9ea-4929-936f-fcd339981ddb.png)



after: 
![image](https://user-images.githubusercontent.com/29002828/224728653-cded5b7f-73ec-463f-85e6-db3dde5443bb.png)

