### PR TITLE
fix custom stat visibility toggles failing to persist

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -57,7 +57,6 @@ import {
   isUsedArmorModSocket,
 } from 'app/utils/socket-utils';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { D2EventInfo } from 'data/d2/d2-event-info';
 import { StatHashes } from 'data/d2/generated-enums';
@@ -98,7 +97,6 @@ export function getColumns(
   statHashes: {
     [statHash: number]: StatInfo;
   },
-  classType: DestinyClass,
   itemInfos: ItemInfos,
   wishList: (item: DimItem) => InventoryWishListRoll | undefined,
   hasWishList: boolean,
@@ -242,7 +240,7 @@ export function getColumns(
     return columnDef;
   }
 
-  const customStats = createCustomStatColumns(customStatDefs, classType);
+  const customStats = createCustomStatColumns(customStatDefs);
 
   const columns: ColumnDefinition[] = _.compact([
     c({

--- a/src/app/organizer/CustomStatColumns.tsx
+++ b/src/app/organizer/CustomStatColumns.tsx
@@ -5,27 +5,23 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { ColumnDefinition, SortDirection } from './table-types';
 
 export function createCustomStatColumns(
-  customStatDefs: CustomStatDef[],
-  classType: DestinyClass
+  customStatDefs: CustomStatDef[]
 ): (ColumnDefinition | undefined)[] {
-  return customStatDefs.map((c) => {
-    if (c.class === classType || c.class === DestinyClass.Unknown) {
-      return {
-        id: 'customstat_' + c.shortLabel + c.statHash,
-        header: (
-          <>
-            {c.label}
-            <CustomStatWeightsDisplay customStat={c} />
-          </>
-        ),
-        value: (item: DimItem) => item.stats?.find((s) => s.statHash === c.statHash)?.value,
-        defaultSort: SortDirection.DESC,
-        filter: (value) => `stat:${c.label}:>=${value}`,
-        columnGroup: {
-          id: c.shortLabel + c.statHash,
-          header: c.label,
-        },
-      };
-    }
-  });
+  return customStatDefs.map((c) => ({
+    id: 'customstat_' + c.shortLabel + c.statHash,
+    header: (
+      <>
+        {c.label}
+        <CustomStatWeightsDisplay customStat={c} />
+      </>
+    ),
+    value: (item: DimItem) => item.stats?.find((s) => s.statHash === c.statHash)?.value,
+    defaultSort: SortDirection.DESC,
+    filter: (value) => `stat:${c.label}:>=${value}`,
+    columnGroup: {
+      id: c.shortLabel + c.statHash,
+      header: c.label,
+    },
+    limitToClass: c.class === DestinyClass.Unknown ? undefined : c.class,
+  }));
 }

--- a/src/app/organizer/EnabledColumnsSelector.tsx
+++ b/src/app/organizer/EnabledColumnsSelector.tsx
@@ -34,7 +34,11 @@ export default React.memo(function EnabledColumnsSelector({
     const dropdownLabel = column.columnGroup
       ? column.columnGroup.dropdownLabel
       : column.dropdownLabel;
-    if (id === 'selection' || column.noHide) {
+    if (
+      id === 'selection' ||
+      column.noHide ||
+      (column.limitToClass !== undefined && column.limitToClass !== forClass)
+    ) {
       continue;
     }
 

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -167,7 +167,6 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
       getColumns(
         itemType,
         statHashes,
-        classIfAny,
         itemInfos,
         wishList,
         hasWishList,
@@ -184,7 +183,6 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
       itemType,
       itemInfos,
       customStats,
-      classIfAny,
       loadoutsByItem,
       newItems,
       destinyVersion,
@@ -197,10 +195,14 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
     () =>
       _.compact(
         enabledColumns.flatMap((id) =>
-          columns.filter((column) => id === getColumnSelectionId(column))
+          columns.filter(
+            (column) =>
+              id === getColumnSelectionId(column) &&
+              (column.limitToClass === undefined || column.limitToClass === classIfAny)
+          )
         )
       ),
-    [columns, enabledColumns]
+    [columns, enabledColumns, classIfAny]
   );
 
   // process items into Rows

--- a/src/app/organizer/table-types.ts
+++ b/src/app/organizer/table-types.ts
@@ -1,4 +1,5 @@
 import { DimItem } from 'app/inventory/item-types';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import React from 'react';
 
 export const enum SortDirection {
@@ -48,6 +49,11 @@ export interface ColumnDefinition<V extends Value = Value> {
   filter?(value: V, item: DimItem): string | undefined;
   /** A custom sort function. Default: Something reasonable. */
   sort?(firstValue: V, secondValue: V): 0 | 1 | -1;
+  /**
+   * a column def needs to exist all the time, so enabledness setting is aware of it,
+   * but sometimes a custom stat should be limited to only displaying for a certain class
+   */
+  limitToClass?: DestinyClass;
 }
 
 export interface Row {


### PR DESCRIPTION
turns out a column def needs to exist all the time because toggling rebuilds the whole thing from the base list.
fixes toggling any of a char's columns, causing custom stat to become untoggled on another.