### PR TITLE
Move def-based plug stats from perks to investment stats

### DIFF
--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -42,7 +42,7 @@ import { makeCustomStat } from './stats-custom';
 /**
  * Which stats to display, and in which order.
  */
-const statAllowList = [
+const itemStatAllowList = [
   StatHashes.RoundsPerMinute,
   StatHashes.ChargeTime,
   StatHashes.DrawTime,
@@ -70,12 +70,21 @@ const statAllowList = [
   TOTAL_STAT_HASH,
 ];
 export function getStatSortOrder(statHash: number) {
-  const order = statAllowList.indexOf(statHash);
+  const order = itemStatAllowList.indexOf(statHash);
   return order === -1 ? 999999 + Math.abs(statHash) : order;
 }
 
-export function isAllowedStat(statHash: number) {
-  return statAllowList.includes(statHash) || statHash < 0;
+export function isAllowedItemStat(statHash: number) {
+  return itemStatAllowList.includes(statHash) || statHash < 0;
+}
+
+/**
+ * Stats that are allowed for plugs, in addition to stats their items own.
+ */
+const plugStatAllowList = [StatHashes.AspectEnergyCapacity];
+
+export function isAllowedPlugStat(statHash: number) {
+  return plugStatAllowList.includes(statHash);
 }
 
 /** Stats that are measured in milliseconds. */
@@ -216,7 +225,7 @@ function shouldShowStat(
 
   return Boolean(
     // Must be a stat we want to display
-    isAllowedStat(statHash) &&
+    isAllowedItemStat(statHash) &&
       // Must be on the list of interpolated stats, or included in the hardcoded hidden stats list
       (statDisplaysByStatHash[statHash] ||
         (includeHiddenStats && hiddenStatsAllowList.includes(statHash)))

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -15,7 +15,7 @@ import {
   DestinyStatDisplayDefinition,
   DestinyStatGroupDefinition,
 } from 'bungie-api-ts/destiny2';
-import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { socketContainsIntrinsicPlug } from '../../utils/socket-utils';
 import { DimItem, DimPlug, DimSocket, DimStat } from '../item-types';
@@ -146,8 +146,8 @@ export function buildStats(
   // Include the contributions from perks and mods
   applyPlugsToStats(itemDef, investmentStats, createdItem, defs, statGroup, statDisplaysByStatHash);
 
-  if (createdItem.bucket.inArmor) {
-    // one last check for missing stats on armor
+  if (createdItem.bucket.hash === BucketHashes.Subclass || createdItem.bucket.inArmor) {
+    // one last check for missing stats on armor or subclasses
     const existingStatHashes = investmentStats.map((s) => s.statHash);
     for (const armorStat of armorStats) {
       if (!existingStatHashes.includes(armorStat)) {
@@ -165,7 +165,9 @@ export function buildStats(
         );
       }
     }
+  }
 
+  if (createdItem.bucket.inArmor) {
     // synthesize the "Total" stat for armor
     // it's effectively just a custom total with 6 stats evenly weighted
     const tStat = makeCustomStat(

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -482,6 +482,7 @@ export default memo(function LoadoutBuilder({
         ) : (
           <NoBuildsFoundExplainer
             defs={defs}
+            classType={classType}
             dispatch={lbDispatch}
             resolvedMods={resolvedMods}
             lockedModMap={lockedModMap}

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -8,6 +8,7 @@ import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import { ModMap } from 'app/loadout/mod-assignment-utils';
 import { AppIcon, banIcon } from 'app/shell/icons';
 import { uniqBy } from 'app/utils/util';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { Dispatch } from 'react';
 import ExoticArmorChoice from './filter/ExoticArmorChoice';
@@ -44,6 +45,7 @@ const EARLY_MOD_REJECTION_WARN_RATIO = 0.8;
 export default function NoBuildsFoundExplainer({
   defs,
   dispatch,
+  classType,
   autoAssignStatMods,
   resolvedMods,
   lockedModMap,
@@ -57,6 +59,7 @@ export default function NoBuildsFoundExplainer({
 }: {
   defs: D2ManifestDefinitions;
   dispatch: Dispatch<LoadoutBuilderAction>;
+  classType: DestinyClass;
   autoAssignStatMods: boolean;
   resolvedMods: ResolvedLoadoutMod[];
   lockedModMap: ModMap;
@@ -87,6 +90,7 @@ export default function NoBuildsFoundExplainer({
               mod: resolvedMods.find((resolved) => resolved.resolvedMod === mod)!,
             })
           }
+          forClassType={classType}
         />
       ))}
     </div>

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -214,6 +214,7 @@ export default memo(function LockArmorAndPerks({
                 key={getModRenderKey(mod.resolvedMod)}
                 plug={mod.resolvedMod}
                 onClose={() => onModClicked(mod)}
+                forClassType={selectedStore.classType}
               />
             ))}
           </div>
@@ -245,6 +246,7 @@ export default memo(function LockArmorAndPerks({
                     ? undefined
                     : () => lbDispatch({ type: 'removeSingleSubclassSocketOverride', plug })
                 }
+                forClassType={selectedStore.classType}
               />
             ))}
           </div>

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -60,7 +60,6 @@ export function isModStatActive(
   if (!stat.isConditionallyActive) {
     return true;
   } else if (
-    plugHash === modsWithConditionalStats.chargeHarvester ||
     plugHash === modsWithConditionalStats.echoOfPersistence ||
     plugHash === modsWithConditionalStats.sparkOfFocus
   ) {

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -43,11 +43,11 @@ interface ProvidedProps {
   /** An array of mods that are already selected by the user. */
   lockedMods: ResolvedLoadoutMod[];
   /** The character class we'll show unlocked mods for. */
-  classType?: DestinyClass;
+  classType: DestinyClass;
   /**
    * The store ID that we're picking mods for. Used to restrict mods to those unlocked by that store.
    */
-  owner?: string;
+  owner: string;
   /** A query string that is passed to the filtering logic to prefilter the available mods. */
   initialQuery?: string;
   /** Only show mods that are in these categories. No restriction if this is not provided. */
@@ -251,7 +251,7 @@ function mapStateToProps() {
  * chosen too many mods. It also can be filtered down to a specific set of mods
  * using plugCategoryHashWhitelist.
  */
-function ModPicker({ plugSets, lockedMods, initialQuery, onAccept, onClose }: Props) {
+function ModPicker({ plugSets, classType, lockedMods, initialQuery, onAccept, onClose }: Props) {
   // Partition the locked (selected) mods into ones that will be shown in this
   // picker (based on plugCategoryHashWhitelist) and ones that will not. The
   // ones that won't (hidden mods) are still part of the locked mods set and
@@ -291,6 +291,7 @@ function ModPicker({ plugSets, lockedMods, initialQuery, onAccept, onClose }: Pr
       acceptButtonText={t('LB.SelectMods')}
       initialQuery={initialQuery}
       plugSets={plugSets}
+      classType={classType}
       isPlugSelectable={isModSelectable}
       sortPlugGroups={sortModPickerPlugGroups}
       sortPlugs={sortMods}

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -22,8 +22,6 @@ import _ from 'lodash';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-const DISPLAYED_PLUG_STATS = [StatHashes.AspectEnergyCapacity];
-
 type PlugSetWithDefaultPlug = PlugSet & { defaultPlug: PluggableInventoryItemDefinition };
 
 /**
@@ -144,7 +142,7 @@ export default function SubclassPlugDrawer({
       searchPlaceholder={t('Loadouts.SubclassOptionsSearch', { subclass: subclass.name })}
       acceptButtonText={t('Loadouts.Apply')}
       plugSets={plugSets}
-      displayedStatHashes={DISPLAYED_PLUG_STATS}
+      classType={subclass.classType}
       onAccept={handleAccept}
       onClose={onClose}
       isPlugSelectable={isPlugSelectable}

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -523,7 +523,11 @@ function FashionSocket({
       showCloseIconOnHover
     >
       {plug && canSlotOrnament ? (
-        <PlugDef onClick={handleOrnamentClick} plug={plug as PluggableInventoryItemDefinition} />
+        <PlugDef
+          onClick={handleOrnamentClick}
+          plug={plug as PluggableInventoryItemDefinition}
+          forClassType={undefined}
+        />
       ) : (
         <PressTip
           tooltip={

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -71,7 +71,11 @@ export default function LoadoutEditSubclass({
       {plugs.length ? (
         <div className={styles.subclassMods}>
           {plugs?.map((plug) => (
-            <PlugDef key={getModRenderKey(plug)} plug={plug} />
+            <PlugDef
+              key={getModRenderKey(plug)}
+              plug={plug}
+              forClassType={subclass?.item.classType}
+            />
           ))}
         </div>
       ) : (

--- a/src/app/loadout/loadout-ui/FashionMods.tsx
+++ b/src/app/loadout/loadout-ui/FashionMods.tsx
@@ -43,11 +43,13 @@ export function FashionMods({
       <PlugDef
         className={clsx({ [styles.missingItem]: !canSlotShader })}
         plug={(shaderItem ?? defaultShader) as PluggableInventoryItemDefinition}
+        forClassType={undefined}
       />
       {ornamentItem ? (
         <PlugDef
           className={clsx({ [styles.missingItem]: !canSlotOrnament })}
           plug={ornamentItem as PluggableInventoryItemDefinition}
+          forClassType={undefined}
         />
       ) : (
         <PressTip tooltip={<div>{t('FashionDrawer.NoPreference')}</div>}>

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { addIcon, AppIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { Portal } from 'app/utils/temp-container';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { memo, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -19,16 +20,25 @@ import PlugDef from './PlugDef';
 const LoadoutModMemo = memo(function LoadoutMod({
   mod,
   className,
+  classType,
   onRemoveMod,
 }: {
   mod: ResolvedLoadoutMod;
   className: string;
+  classType: DestinyClass;
   onRemoveMod?: (mod: ResolvedLoadoutMod) => void;
 }) {
   // We need this to be undefined if `onRemoveMod` is not present as the presence of the onClose
   // callback determines whether the close icon is displayed on hover
   const onClose = onRemoveMod && (() => onRemoveMod(mod));
-  return <PlugDef className={className} plug={mod.resolvedMod} onClose={onClose} />;
+  return (
+    <PlugDef
+      className={className}
+      plug={mod.resolvedMod}
+      forClassType={classType}
+      onClose={onClose}
+    />
+  );
 });
 
 /**
@@ -102,6 +112,7 @@ export default memo(function LoadoutMods({
             })}
             key={getModRenderKey(mod.resolvedMod)}
             mod={mod}
+            classType={loadout.classType}
             onRemoveMod={onRemoveMod}
           />
         ))}

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -95,7 +95,11 @@ export default function LoadoutSubclassSection({
       {plugs.length ? (
         <div className={styles.subclassMods}>
           {plugs?.map((plug) => (
-            <PlugDef key={getModRenderKey(plug)} plug={plug} />
+            <PlugDef
+              key={getModRenderKey(plug)}
+              plug={plug}
+              forClassType={subclass?.item.classType}
+            />
           ))}
         </div>
       ) : (

--- a/src/app/loadout/loadout-ui/PlugDef.tsx
+++ b/src/app/loadout/loadout-ui/PlugDef.tsx
@@ -2,7 +2,8 @@ import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
-import { ExtraPlugTooltipInfo, PlugTooltip } from 'app/item-popup/PlugTooltip';
+import { PlugDefTooltip } from 'app/item-popup/PlugTooltip';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import styles from './PlugDef.m.scss';
@@ -12,7 +13,8 @@ interface Props {
   className?: string;
   onClick?: () => void;
   onClose?: () => void;
-  extraProps?: ExtraPlugTooltipInfo;
+  automaticallyPicked?: boolean;
+  forClassType: DestinyClass | undefined;
 }
 
 const strandWrongColorPlugCategoryHashes = [
@@ -27,7 +29,14 @@ const strandWrongColorPlugCategoryHashes = [
 /**
  * Displays a plug (mod, perk) based on just its definition, with optional close button.
  */
-export default function PlugDef({ plug, className, onClick, onClose, extraProps }: Props) {
+export default function PlugDef({
+  plug,
+  className,
+  onClick,
+  onClose,
+  automaticallyPicked,
+  forClassType,
+}: Props) {
   const needsStrandColorFix = strandWrongColorPlugCategoryHashes.includes(
     plug.plug.plugCategoryHash
   );
@@ -39,7 +48,15 @@ export default function PlugDef({ plug, className, onClick, onClose, extraProps 
       // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={onClick ? 0 : undefined}
     >
-      <PressTip tooltip={() => <PlugTooltip def={plug} {...extraProps} />}>
+      <PressTip
+        tooltip={() => (
+          <PlugDefTooltip
+            def={plug}
+            automaticallyPicked={automaticallyPicked}
+            classType={forClassType}
+          />
+        )}
+      >
         <DefItemIcon itemDef={plug} />
       </PressTip>
     </div>

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -101,7 +101,8 @@ function Sockets({ item, lockedMods, size, onSocketClick, automaticallyPickedMod
           key={index}
           plug={plugDef}
           onClick={onSocketClick ? () => onSocketClick(plugDef, whitelist) : undefined}
-          extraProps={{ automaticallyPicked }}
+          automaticallyPicked={automaticallyPicked}
+          forClassType={item.classType}
         />
       ))}
     </div>

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -151,7 +151,7 @@ export default function ModAssignmentDrawer({
               <h3>{t('Loadouts.UnassignedMods')}</h3>
               <div className={styles.unassigned}>
                 {unassignedMods.map((mod) => (
-                  <PlugDef key={getModRenderKey(mod)} plug={mod} />
+                  <PlugDef key={getModRenderKey(mod)} plug={mod} forClassType={loadout.classType} />
                 ))}
               </div>
             </>

--- a/src/app/loadout/plug-drawer/Footer.tsx
+++ b/src/app/loadout/plug-drawer/Footer.tsx
@@ -1,5 +1,6 @@
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import React from 'react';
 import PlugDef from '../loadout-ui/PlugDef';
 import { createGetModRenderKey } from '../mod-utils';
@@ -9,6 +10,7 @@ import { PlugSet } from './types';
 interface Props {
   isPhonePortrait: boolean;
   plugSets: PlugSet[];
+  classType: DestinyClass;
   acceptButtonText: string;
   onSubmit: (event: React.FormEvent | KeyboardEvent) => void;
   handlePlugSelected: (plug: PluggableInventoryItemDefinition) => void;
@@ -17,6 +19,7 @@ interface Props {
 export default function Footer({
   isPhonePortrait,
   plugSets,
+  classType,
   acceptButtonText,
   onSubmit,
   handlePlugSelected,
@@ -41,6 +44,7 @@ export default function Footer({
               onClose={
                 plugSet.selectionType === 'multi' ? () => handlePlugSelected(plug) : undefined
               }
+              forClassType={classType}
             />
           ))
         )}

--- a/src/app/loadout/plug-drawer/PlugDrawer.tsx
+++ b/src/app/loadout/plug-drawer/PlugDrawer.tsx
@@ -6,6 +6,7 @@ import { SearchInput } from 'app/search/SearchInput';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { isiOSBrowser } from 'app/utils/browsers';
 import { Comparator } from 'app/utils/comparators';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { produce } from 'immer';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -22,8 +23,8 @@ interface Props {
    * drawer are the union of plugs from these plug sets.
    */
   plugSets: PlugSet[];
-  /** A restricted list of stat hashes to display for each plug. If not specified, no stats will be shown. */
-  displayedStatHashes?: number[];
+  /** The class type we're choosing mods for */
+  classType: DestinyClass;
   /** Title of the sheet, displayed in the header. */
   title: string;
   /** The placeholder text for the search bar. */
@@ -55,7 +56,7 @@ interface Props {
  */
 export default function PlugDrawer({
   plugSets,
-  displayedStatHashes,
+  classType,
   title,
   searchPlaceholder,
   initialQuery,
@@ -174,6 +175,7 @@ export default function PlugDrawer({
   const footer = ({ onClose }: { onClose: () => void }) => (
     <Footer
       plugSets={internalPlugSets}
+      classType={classType}
       isPhonePortrait={isPhonePortrait}
       acceptButtonText={acceptButtonText}
       onSubmit={(e) => onSubmit(e, onClose)}
@@ -210,7 +212,7 @@ export default function PlugDrawer({
         <PlugSection
           key={plugSet.plugSetHash}
           plugSet={plugSet}
-          displayedStatHashes={displayedStatHashes}
+          classType={classType}
           isPlugSelectable={handleIsPlugSelectable}
           onPlugSelected={handlePlugSelected}
           onPlugRemoved={handlePlugRemoved}

--- a/src/app/loadout/plug-drawer/PlugSection.tsx
+++ b/src/app/loadout/plug-drawer/PlugSection.tsx
@@ -1,4 +1,5 @@
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { useCallback } from 'react';
 import { groupModsByModType } from '../mod-utils';
 import styles from './PlugSection.m.scss';
@@ -11,14 +12,13 @@ import { PlugSet } from './types';
  */
 export default function PlugSection({
   plugSet,
-  displayedStatHashes,
+  classType,
   isPlugSelectable,
   onPlugSelected,
   onPlugRemoved,
 }: {
   plugSet: PlugSet;
-  /** A restricted list of stat hashes to display for each plug. If not specified, all stats will be shown. */
-  displayedStatHashes?: number[];
+  classType: DestinyClass;
   /** A function to determine if a given plug is currently selectable. */
   isPlugSelectable: (plug: PluggableInventoryItemDefinition) => boolean;
   onPlugSelected: (
@@ -73,7 +73,7 @@ export default function PlugSection({
                     key={plug.hash}
                     selected={isSelected}
                     plug={plug}
-                    displayedStatHashes={displayedStatHashes}
+                    classType={classType}
                     selectable={selectable}
                     selectionType={selectionType}
                     removable={multiSelect}

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -3,7 +3,8 @@ import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { StatValue } from 'app/item-popup/PlugTooltip';
-import { usePlugDescriptions } from 'app/utils/plug-descriptions';
+import { getPlugDefStats, usePlugDescriptions } from 'app/utils/plug-descriptions';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { useCallback, useMemo } from 'react';
 import styles from './SelectablePlug.m.scss';
@@ -14,20 +15,20 @@ import styles from './SelectablePlug.m.scss';
  */
 export default function SelectablePlug({
   plug,
+  classType,
   selected,
   selectable,
   selectionType,
   removable,
-  displayedStatHashes,
   onPlugSelected,
   onPlugRemoved,
 }: {
   plug: PluggableInventoryItemDefinition;
+  classType: DestinyClass;
   selected: boolean;
   selectable: boolean;
   selectionType: 'multi' | 'single';
   removable: boolean;
-  displayedStatHashes?: number[];
   onPlugSelected: (plug: PluggableInventoryItemDefinition) => void;
   onPlugRemoved: (plug: PluggableInventoryItemDefinition) => void;
 }) {
@@ -39,8 +40,8 @@ export default function SelectablePlug({
 
   // Memoize the meat of the component as it doesn't need to re-render every time
   const plugDetails = useMemo(
-    () => <SelectablePlugDetails plug={plug} displayedStatHashes={displayedStatHashes} />,
-    [plug, displayedStatHashes]
+    () => <SelectablePlugDetails plug={plug} classType={classType} />,
+    [plug, classType]
   );
 
   return (
@@ -62,18 +63,13 @@ export default function SelectablePlug({
 
 function SelectablePlugDetails({
   plug,
-  displayedStatHashes,
+  classType,
 }: {
   plug: PluggableInventoryItemDefinition;
-  displayedStatHashes?: number[];
+  classType: DestinyClass;
 }) {
-  const displayedStats = plug.investmentStats.filter((stat) =>
-    displayedStatHashes?.includes(stat.statTypeHash)
-  );
-  const plugDescriptions = usePlugDescriptions(
-    plug,
-    displayedStats.map((stat) => ({ statHash: stat.statTypeHash, value: stat.value }))
-  );
+  const stats = getPlugDefStats(plug, classType);
+  const plugDescriptions = usePlugDescriptions(plug, stats);
   return (
     <>
       <div className="item" title={plug.displayProperties.name}>
@@ -89,10 +85,10 @@ function SelectablePlugDetails({
             )}
           </div>
         ))}
-        {displayedStats.length > 0 && (
+        {stats.length > 0 && (
           <div className="plug-stats">
-            {displayedStats.map((stat) => (
-              <StatValue key={stat.statTypeHash} statHash={stat.statTypeHash} value={stat.value} />
+            {stats.map((stat) => (
+              <StatValue key={stat.statHash} statHash={stat.statHash} value={stat.value} />
             ))}
           </div>
         )}

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -321,11 +321,8 @@ export const breakerTypes = {
 };
 
 export const modsWithConditionalStats = {
-  powerfulFriends: 1484685887,
-  radiantLight: 2979815167,
-  chargeHarvester: 2263321587,
-  elementalCapacitor: 3511092054,
-  echoOfPersistence: 2272984671,
-  enhancedElementalCapacitor: 711234314,
-  sparkOfFocus: 1727069360,
+  elementalCapacitor: 3511092054, // InventoryItem "Elemental Capacitor"
+  echoOfPersistence: 2272984671, // InventoryItem "Echo of Persistence"
+  enhancedElementalCapacitor: 711234314, // InventoryItem "Elemental Capacitor"
+  sparkOfFocus: 1727069360, // InventoryItem "Spark of Focus"
 } as const;

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -281,10 +281,8 @@ export function getItemYear(
 /**
  * This function indicates whether a mod's stat effect is active on the item.
  *
- * For example, powerful friends only gives its stat effect if another arc mod is
- * slotted or some other item has a charged with light arc mod slotted.
- * This will return true if another arc mod is slotted or if we can pass in the
- * other slotted mods via modsOnOtherItems, an arc charged with light mod is found.
+ * For example, some subclass plugs reduce a different stat per character class,
+ * which we identify using the passed subclass item.
  *
  * If the plugHash isn't recognized then the default is to return true.
  */
@@ -316,7 +314,6 @@ export function isPlugStatActive(
   }
 
   if (
-    plugHash === modsWithConditionalStats.chargeHarvester ||
     plugHash === modsWithConditionalStats.echoOfPersistence ||
     plugHash === modsWithConditionalStats.sparkOfFocus
   ) {


### PR DESCRIPTION
Previously, `DimPlug`-based components would use their computed stats, while `PluggableInventoryItemDefinition`-based ("def-based") components would use perks that only show their stat effects via text descriptions. This moves def-based plugs to show their stats based on `investmentStats`, which is necessary to correctly show the stat effects when they differ between subclasses.

Before:
![grafik](https://user-images.githubusercontent.com/14299449/225922965-c2daa491-4473-40b6-9682-c0e1fbccf76f.png)
After:
![grafik](https://user-images.githubusercontent.com/14299449/225923123-c3832c31-aada-4c31-a308-92cd9b47abd5.png)
(Same thing in loadout plug tooltips)

The code is not necessarily better but it's hard to find a good plug/stats model that works in all cases, so let's at least get the conditional stats showing again.

Fixes #9153.