### PR TITLE
Fix the is:curated filter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed the color of Strand movement and class abilities on Loadouts screen.
 * Fixed an issue where DIM Sync data might not be available when Bungie.net is down.
 * Added `source:rootofnightmares`/`source:ron` and `modslot:rootofnightmares` searches.
+* Fixed the `is:curated` filter never matching weapons without an equipped kill tracker.
 
 ## 7.60.1 <span class="changelog-date">(2023-03-14)</span>
 

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -3,6 +3,7 @@ import { DimItem } from 'app/inventory/item-types';
 import {
   getInterestingSocketMetadatas,
   getSpecialtySocketMetadatas,
+  isKillTrackerSocket,
   modSlotTags,
   modTypeTags,
 } from 'app/utils/item-utils';
@@ -84,13 +85,16 @@ const socketFilters: FilterDefinition[] = [
 
       const matchesCollectionsRoll = item.sockets?.allSockets
         // curatedRoll is only set for perk-style sockets
-        .filter((socket) => socket.plugOptions.length && socket.curatedRoll)
+        .filter(
+          (socket) =>
+            socket.plugOptions.length && socket.curatedRoll && !isKillTrackerSocket(socket)
+        )
         .every(
           (socket) =>
             socket.curatedRoll!.length === socket.plugOptions.length &&
-            socket.plugOptions.every(function (e, i) {
-              return e.plugDef.hash === socket.curatedRoll![i];
-            })
+            socket.plugOptions.every(
+              (option, idx) => option.plugDef.hash === socket.curatedRoll![idx]
+            )
         );
 
       return matchesCollectionsRoll;


### PR DESCRIPTION
Turns out it was considering kill trackers and a bunch of weapons just have the "no tracker plug" inserted even though it's not a valid option, and that breaks this filter for them. I'm not too attached to this filter but might as well make it work correctly before discussing removing it because it doesn't match anything.