### PR TITLE
Augment DestinyClass to represent Classified

### DIFF
--- a/src/app/dim-ui/ClassIcon.tsx
+++ b/src/app/dim-ui/ClassIcon.tsx
@@ -9,7 +9,7 @@ const classIcons = {
   [DestinyClass.Titan]: titanIcon,
   [DestinyClass.Warlock]: warlockIcon,
   [DestinyClass.Unknown]: globeIcon,
-  [-1]: globeIcon,
+  [DestinyClass.Classified]: globeIcon,
 } as const;
 
 const classIconsProportional = {
@@ -17,7 +17,7 @@ const classIconsProportional = {
   [DestinyClass.Titan]: dimTitanProportionalIcon,
   [DestinyClass.Warlock]: dimWarlockProportionalIcon,
   [DestinyClass.Unknown]: globeIcon,
-  [-1]: globeIcon,
+  [DestinyClass.Classified]: globeIcon,
 } as const;
 
 /**
@@ -28,7 +28,7 @@ export default function ClassIcon({
   proportional,
   className,
 }: {
-  classType: DestinyClass | -1;
+  classType: DestinyClass;
   proportional?: boolean;
   className?: string;
 }) {

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -96,9 +96,9 @@ export interface DimItem {
   uniqueStack: boolean;
   /**
    * The class this item is restricted to. DestinyClass.Unknown means it can be used by any class.
-   * -1 is for classified armor, which, until proven otherwise, can't be equipped by any class.
+   * DestinyClass.Classified is for classified armor, which, until proven otherwise, can't be equipped by any class.
    * */
-  classType: DestinyClass | -1;
+  classType: DestinyClass;
   /** The localized name of the class this item is restricted to. */
   classTypeNameLocalized: string;
   /** Whether this item can be locked. */

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -20,11 +20,25 @@ import D2Sources from 'data/d2/source-info';
 import _ from 'lodash';
 import Papa from 'papaparse';
 import { setItemNote, setItemTagsBulk } from './actions';
-import { tagConfig, TagValue } from './dim-item-info';
+import { TagValue, tagConfig } from './dim-item-info';
 import { D1GridNode, DimItem, DimSockets } from './item-types';
 import { getNotesSelector, getTagSelector, storesSelector } from './selectors';
-import { getClass } from './store/character-utils';
 import { getEvent, getSeason } from './store/season';
+
+function getClass(type: DestinyClass) {
+  switch (type) {
+    case DestinyClass.Titan:
+      return 'titan';
+    case DestinyClass.Hunter:
+      return 'hunter';
+    case DestinyClass.Warlock:
+      return 'warlock';
+    case DestinyClass.Unknown:
+      return 'unknown';
+    case DestinyClass.Classified:
+      return 'classified';
+  }
+}
 
 // step node names we'll hide, we'll leave "* Chroma" for now though, since we don't otherwise indicate Chroma
 const FILTER_NODE_NAMES = [

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -2,7 +2,6 @@ import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D1CharacterResponse } from 'app/destiny1/d1-manifest-types';
 import { powerLevelByKeyword } from 'app/search/d2-known-values';
 import { warnLog } from 'app/utils/log';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { StatHashes } from 'data/d2/generated-enums';
 import disciplineIcon from 'images/discipline.png';
 import intellectIcon from 'images/intellect.png';
@@ -184,19 +183,6 @@ function getAbilityCooldown(subclass: number, ability: string, tier: number) {
       }
     default:
       return '-:--';
-  }
-}
-
-export function getClass(type: DestinyClass) {
-  switch (type) {
-    case DestinyClass.Titan:
-      return 'titan';
-    case DestinyClass.Hunter:
-      return 'hunter';
-    case DestinyClass.Warlock:
-      return 'warlock';
-    case DestinyClass.Unknown:
-      return 'unknown';
   }
 }
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -4,8 +4,8 @@ import { t } from 'app/i18next-t';
 import { isTrialsPassage, isWinsObjective } from 'app/inventory/store/objectives';
 import {
   D2ItemTiers,
-  d2MissingIcon,
   THE_FORBIDDEN_BUCKET,
+  d2MissingIcon,
   uniqueEquipBuckets,
 } from 'app/search/d2-known-values';
 import { lightStats } from 'app/search/search-filter-values';
@@ -430,7 +430,7 @@ export function makeItem(
         ? // equipped armor gets marked as that character's class
           owner.classType
         : // unequipped armor gets marked "no class"
-          -1
+          DestinyClass.Classified
       : // other items are marked "any class"
         DestinyClass.Unknown
     : itemDef.classType;

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -72,14 +72,13 @@ const gearSlotOrder: BucketHashes[] = [...D2Categories.Weapons, ...D2Categories.
 /**
  * Creates a new loadout, with all of the items equipped and the items inserted mods saved.
  */
-export function newLoadout(
-  name: string,
-  items: LoadoutItem[],
-  classType?: DestinyClass | -1
-): Loadout {
+export function newLoadout(name: string, items: LoadoutItem[], classType?: DestinyClass): Loadout {
   return {
     id: uuidv4(),
-    classType: classType !== undefined && classType !== -1 ? classType : DestinyClass.Unknown,
+    classType:
+      classType !== undefined && classType !== DestinyClass.Classified
+        ? classType
+        : DestinyClass.Unknown,
     name,
     items,
     clearSpace: false,
@@ -725,9 +724,9 @@ export function getUnequippedItemsForLoadout(dimStore: DimStore, category?: stri
 export function pickBackingStore(
   stores: DimStore[],
   preferredStoreId: string | undefined,
-  classType: DestinyClass | -1
+  classType: DestinyClass
 ) {
-  classType = classType === -1 ? DestinyClass.Unknown : classType;
+  classType = classType === DestinyClass.Classified ? DestinyClass.Unknown : classType;
   const requestedStore =
     !preferredStoreId || preferredStoreId === 'vault'
       ? getCurrentStore(stores)

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -4,10 +4,11 @@ import { DimItem } from 'app/inventory/item-types';
 import { getSeason } from 'app/inventory/store/season';
 import { isArtifice } from 'app/item-triage/triage-utils';
 import { StatsSet } from 'app/loadout-builder/process-worker/stats-set';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { chainComparator, compareBy, reverseComparator } from '../../utils/comparators';
-import { armorStats, DEFAULT_SHADER } from '../d2-known-values';
+import { DEFAULT_SHADER, armorStats } from '../d2-known-values';
 import { FilterDefinition } from '../filter-types';
 
 const notableTags = ['favorite', 'keep'];
@@ -234,7 +235,7 @@ export function checkIfIsDupe(
 
 function computeStatDupeLower(allItems: DimItem[], relevantStatHashes: number[] = armorStats) {
   // disregard no-class armor
-  const armor = allItems.filter((i) => i.bucket.inArmor && i.classType !== -1);
+  const armor = allItems.filter((i) => i.bucket.inArmor && i.classType !== DestinyClass.Classified);
 
   // Group by class and armor type. Also, compare exotics with each other, not the general pool.
   const grouped = Object.values(

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -328,7 +328,7 @@ function calculateMaxPowerPerBucket(allItems: DimItem[]) {
   return _.mapValues(
     _.groupBy(
       // disregard no-class armor
-      allItems.filter((i) => i.classType !== -1),
+      allItems.filter((i) => i.classType !== DestinyClass.Classified),
       (i) => maxPowerKey(i)
     ),
     (items) => _.maxBy(items, (i) => i.power)?.power ?? 0

--- a/src/bungie-api-ts.d.ts
+++ b/src/bungie-api-ts.d.ts
@@ -1,0 +1,13 @@
+import 'bungie-api-ts/destiny2';
+// Extensions/customizations to the generated Bungie.net API types
+
+declare module 'bungie-api-ts/destiny2' {
+  const enum DestinyClass {
+    /*
+     * The class cannot be known because the item is classified.
+     * DestinyClass.Unknown really means "not specific to a class", so we invent this
+     * value to represent classified items.
+     */
+    Classified = -1,
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,20 @@ declare const $DIM_WEB_CLIENT_SECRET: string;
 declare const $DIM_API_KEY: string;
 declare const $BROWSERS: string[];
 
+import 'bungie-api-ts/destiny2';
+
+module 'bungie-api-ts/destiny2' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const enum DestinyClass {
+    /*
+     * The class cannot be known because the item is classified.
+     * DestinyClass.Unknown really means "not specific to a class", so we invent this
+     * value to represent classified items.
+     */
+    Classified = -1,
+  }
+}
+
 declare const $featureFlags: ReturnType<typeof import('../config/feature-flags').makeFeatureFlags>;
 
 declare function ga(...params: string[]): void;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,20 +8,6 @@ declare const $DIM_WEB_CLIENT_SECRET: string;
 declare const $DIM_API_KEY: string;
 declare const $BROWSERS: string[];
 
-import 'bungie-api-ts/destiny2';
-
-module 'bungie-api-ts/destiny2' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const enum DestinyClass {
-    /*
-     * The class cannot be known because the item is classified.
-     * DestinyClass.Unknown really means "not specific to a class", so we invent this
-     * value to represent classified items.
-     */
-    Classified = -1,
-  }
-}
-
 declare const $featureFlags: ReturnType<typeof import('../config/feature-flags').makeFeatureFlags>;
 
 declare function ga(...params: string[]): void;


### PR DESCRIPTION
We had previously defined `DimItem#classType` as a union with -1, but it's a bit cleaner to directly augment the `DestinyClass` enum.