### PR TITLE
Optimize sockets followups

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -475,8 +475,6 @@ export interface DimSocket {
    */
   craftingData?: { [plugHash: number]: DestinyPlugItemCraftingRequirements | undefined };
 
-  /** Plug hashes in this item visible in the collections roll, if this is a perk */
-  curatedRoll: number[] | null;
   /**
    * The plug item hash used to reset this plug to an empty default plug.
    * This is a heuristic improvement over singleInitialItemHash, but it's

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -245,15 +245,14 @@ function buildDefinedSocket(
   // The currently equipped plug, if any
   const reusablePlugs: DimPlug[] = [];
 
-  const craftingData: NonNullable<DimSocket['craftingData']> = {};
-
+  let craftingData: DimSocket['craftingData'];
   function addCraftingReqs(plugEntry: DestinyItemSocketEntryPlugItemRandomizedDefinition) {
     if (
       plugEntry.craftingRequirements &&
       (plugEntry.craftingRequirements.materialRequirementHashes.length ||
         plugEntry.craftingRequirements.unlockRequirements.length)
     ) {
-      craftingData[plugEntry.plugItemHash] = plugEntry.craftingRequirements;
+      (craftingData ??= {})[plugEntry.plugItemHash] = plugEntry.craftingRequirements;
     }
   }
 
@@ -350,11 +349,12 @@ function buildDefinedSocket(
   // if there's crafting data, sort plugs by their required level
   // TO-DO: the order is correct in the original plugset def,
   // we should address whatever is changing plug order in DIM
-  if (!_.isEmpty(craftingData)) {
+  if (craftingData) {
+    const cd = craftingData;
     plugOptions.sort(
-      compareBy((p) =>
+      compareBy((p: DimPlug) =>
         // shove retired perks to the bottom (our choice) and consider requiredLevel:undefined to be 0 (bungie data works this way)
-        p.cannotCurrentlyRoll ? 999 : craftingData[p.plugDef.hash]?.requiredLevel ?? 0
+        p.cannotCurrentlyRoll ? 999 : cd[p.plugDef.hash]?.requiredLevel ?? 0
       )
     );
   }
@@ -389,7 +389,7 @@ function buildDefinedSocket(
     isPerk,
     isReusable,
     socketDefinition: socketDef,
-    craftingData: Object.keys(craftingData).length ? craftingData : undefined,
+    craftingData,
   };
 }
 

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -381,9 +381,8 @@ function buildDefinedSocket(
     plugged,
     plugOptions,
     plugSet,
-    curatedRoll: null,
     emptyPlugItemHash: findEmptyPlug(socketDef, socketTypeDef, plugSet),
-    reusablePlugItems: [],
+    reusablePlugItems: emptyArray(),
     hasRandomizedPlugItems:
       Boolean(socketDef.randomizedPlugSetHash) || socketTypeDef.alwaysRandomizeSockets,
     isPerk,
@@ -616,7 +615,6 @@ function buildSocket(
   // We only build a larger list of plug options if this is a perk socket, since users would
   // only want to see (and search) the plug options for perks. For other socket types (mods, shaders, etc.)
   // we will only populate plugOptions with the currently inserted plug.
-  let curatedRoll: number[] | null = null;
   if (isPerk) {
     if (reusablePlugs) {
       // Get options from live info
@@ -630,7 +628,6 @@ function buildSocket(
           }
         }
       }
-      curatedRoll = socketDef.reusablePlugItems.map((p) => p.plugItemHash);
     } else if (socketDef.reusablePlugSetHash) {
       // Get options from plug set, instead of live info
       const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash, forThisItem);
@@ -649,7 +646,6 @@ function buildSocket(
             }
           }
         }
-        curatedRoll = plugSet.reusablePlugItems.map((p) => p.plugItemHash);
       }
     } else if (socketDef.reusablePlugItems) {
       // Get options from definition itself
@@ -663,7 +659,6 @@ function buildSocket(
           }
         }
       }
-      curatedRoll = socketDef.reusablePlugItems.map((p) => p.plugItemHash);
     }
   } else if (plugged) {
     plugOptions.push(plugged);
@@ -678,7 +673,6 @@ function buildSocket(
     plugged,
     plugOptions,
     plugSet,
-    curatedRoll,
     emptyPlugItemHash: findEmptyPlug(socketDef, socketTypeDef, plugSet, reusablePlugs),
     hasRandomizedPlugItems,
     reusablePlugItems: reusablePlugs,

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -660,7 +660,8 @@ function buildSocket(
         }
       }
     }
-  } else if (plugged) {
+  }
+  if (plugged && !plugOptions.length) {
     plugOptions.push(plugged);
   }
 

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -3,15 +3,14 @@ import { DimItem } from 'app/inventory/item-types';
 import {
   getInterestingSocketMetadatas,
   getSpecialtySocketMetadatas,
-  isKillTrackerSocket,
   modSlotTags,
   modTypeTags,
 } from 'app/utils/item-utils';
 import {
   countEnhancedPerks,
-  getCuratedRollForSocket,
   getIntrinsicArmorPerkSocket,
   getSocketsByCategoryHash,
+  matchesCuratedRoll,
 } from 'app/utils/socket-utils';
 import { DestinyItemSubType, DestinyRecordState } from 'bungie-api-ts/destiny2';
 import craftingMementos from 'data/d2/crafting-mementos.json';
@@ -75,35 +74,8 @@ const socketFilters: FilterDefinition[] = [
     destinyVersion: 2,
     filter:
       ({ d2Definitions }) =>
-      (item: DimItem) => {
-        if (!item) {
-          return false;
-        }
-
-        const legendaryWeapon = item.bucket?.sort === 'Weapons' && item.tier === 'Legendary';
-
-        if (!legendaryWeapon) {
-          return false;
-        }
-
-        const matchesCollectionsRoll = item.sockets?.allSockets
-          // curatedRoll is only set for perk-style sockets
-          .filter(
-            (socket) => socket.isPerk && socket.plugOptions.length && !isKillTrackerSocket(socket)
-          )
-          .map((socket) => ({
-            socket,
-            curatedRoll: getCuratedRollForSocket(d2Definitions!, socket),
-          }))
-          .filter(({ curatedRoll }) => curatedRoll)
-          .every(
-            ({ socket, curatedRoll }) =>
-              curatedRoll!.length === socket.plugOptions.length &&
-              socket.plugOptions.every((option, idx) => option.plugDef.hash === curatedRoll![idx])
-          );
-
-        return matchesCollectionsRoll;
-      },
+      (item: DimItem) =>
+        matchesCuratedRoll(d2Definitions!, item),
   },
   {
     keywords: 'extraperk',

--- a/src/app/search/search-filters/sockets.tsx
+++ b/src/app/search/search-filters/sockets.tsx
@@ -66,7 +66,11 @@ const socketFilters: FilterDefinition[] = [
     description: tl('Filter.RandomRoll'),
     destinyVersion: 2,
     filter: () => (item: DimItem) =>
-      Boolean(item.energy) || item.sockets?.allSockets.some((s) => s.hasRandomizedPlugItems),
+      Boolean(item.bucket.inArmor && item.energy) ||
+      (!item.crafted &&
+        item.sockets?.allSockets.some(
+          (s) => s.isPerk && s.plugOptions.length > 0 && s.hasRandomizedPlugItems
+        )),
   },
   {
     keywords: 'curated',

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -1,3 +1,4 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import {
   DimItem,
   DimSocketCategory,
@@ -250,4 +251,27 @@ export function isModCostVisible(
   }
 
   return true;
+}
+
+/**
+ * Determine the perk selections that correspond to the "curated" roll for this socket.
+ */
+export function getCuratedRollForSocket(defs: D2ManifestDefinitions, socket: DimSocket) {
+  // We only build a larger list of plug options if this is a perk socket, since users would
+  // only want to see (and search) the plug options for perks. For other socket types (mods, shaders, etc.)
+  // we will only populate plugOptions with the currently inserted plug.
+  const socketDef = socket.socketDefinition;
+  let curatedRoll: number[] | null = null;
+  if (socket.isPerk) {
+    if (socketDef.reusablePlugSetHash) {
+      // Get options from plug set, instead of live info
+      const plugSet = defs.PlugSet.get(socketDef.reusablePlugSetHash);
+      if (plugSet) {
+        curatedRoll = plugSet.reusablePlugItems.map((p) => p.plugItemHash);
+      }
+    } else if (socketDef.reusablePlugItems) {
+      curatedRoll = socketDef.reusablePlugItems.map((p) => p.plugItemHash);
+    }
+  }
+  return curatedRoll;
 }


### PR DESCRIPTION
1. Optimize computing crafting data just a bit
2. Stop calculating curated roll at load, move the logic entirely into the search
3. Fix `is:randomroll` to exclude crafted items and things like ghosts and (most) ships.
4. Fix some plugs not showing up.