### PR TITLE
Show count of Postmaster items at all times

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Items in the "Focused Decoding" and "Legacy Gear" screens within the Vendors page will now correctly show collection and inventory checkmarks.
+* Display the current and max Postmaster count at all times
 
 ## 7.61.0 <span class="changelog-date">(2023-03-19)</span>
 

--- a/src/app/inventory-page/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory-page/InventoryCollapsibleTitle.tsx
@@ -2,9 +2,9 @@ import { collapsedSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { DimStore } from 'app/inventory/store-types';
 import {
+  POSTMASTER_SIZE,
   postmasterAlmostFull,
   postmasterSpaceUsed,
-  POSTMASTER_SIZE,
 } from 'app/loadout-drawer/postmaster';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
@@ -93,7 +93,7 @@ export default function InventoryCollapsibleTitle({
                     />{' '}
                     <span>
                       {showPostmasterFull ? text : title}
-                      {checkPostmaster && collapsed && (
+                      {checkPostmaster && (
                         <span className={styles.bucketSize}>
                           ({postMasterSpaceUsed}/{POSTMASTER_SIZE})
                         </span>
@@ -106,7 +106,7 @@ export default function InventoryCollapsibleTitle({
                 ) : (
                   <>
                     {showPostmasterFull && text}
-                    {checkPostmaster && collapsed && (
+                    {checkPostmaster && (
                       <span className={styles.bucketSize}>
                         ({postMasterSpaceUsed}/{POSTMASTER_SIZE})
                       </span>

--- a/src/app/inventory-page/StoreBuckets.tsx
+++ b/src/app/inventory-page/StoreBuckets.tsx
@@ -1,8 +1,12 @@
-import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { PullFromPostmaster } from 'app/inventory/PullFromPostmaster';
+import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimStore } from 'app/inventory/store-types';
 import { findItemsByBucket } from 'app/inventory/stores-helpers';
-import { postmasterAlmostFull } from 'app/loadout-drawer/postmaster';
+import {
+  POSTMASTER_SIZE,
+  postmasterAlmostFull,
+  postmasterSpaceUsed,
+} from 'app/loadout-drawer/postmaster';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import React from 'react';
@@ -33,6 +37,12 @@ export function StoreBuckets({
     !stores.some((s) => findItemsByBucket(s, bucket.hash).length > 0)
   ) {
     return null;
+  }
+
+  const checkPostmaster = bucket.hash === BucketHashes.LostItems;
+  if (!checkPostmaster) {
+    // Only the postmaster needs a header per store, the rest span across all stores
+    stores = [stores[0]];
   }
 
   if (bucket.accountWide) {
@@ -74,11 +84,22 @@ export function StoreBuckets({
     ));
   }
 
+  const postMasterSpaceUsed = postmasterSpaceUsed(stores[0]);
+
   return (
     <div
       className={clsx('store-row', `bucket-${bucket.hash}`, { 'account-wide': bucket.accountWide })}
     >
-      {labels && <div className={clsx(styles.bucketLabel)}>{bucket.name}</div>}
+      {labels && (
+        <div className={clsx(styles.bucketLabel)}>
+          {bucket.name}
+          {checkPostmaster && (
+            <span>
+              ({postMasterSpaceUsed}/{POSTMASTER_SIZE})
+            </span>
+          )}
+        </div>
+      )}
       {content}
     </div>
   );


### PR DESCRIPTION
Implements the suggestion detailed in #9177, now displaying the count of the items in the Postmaster at all times, including on the mobile UI.

![brave_XPsWwTpIxw](https://user-images.githubusercontent.com/13388656/226485132-d61a12f8-19e9-47e9-a22e-c9b230ddea79.png)
![brave_eRYSdRAXV3](https://user-images.githubusercontent.com/13388656/226485138-10f09f9f-3773-4c8a-8da9-1f64610e0246.png)
![brave_qP1BCMwANs](https://user-images.githubusercontent.com/13388656/226485139-75d2e529-202c-4922-a19c-215fa6a6491a.png)
