### PR TITLE
More presstip pointerevent improvements

### DIFF
--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -232,8 +232,8 @@ export const Tooltip = {
   },
 };
 
-const hoverable = window.matchMedia?.('(hover: hover)').matches;
-const hoverDelay = hoverable ? 100 : 300;
+const hoverTime = 100; // ms that the cursor can be over the target before the presstip shows
+const pressTime = 300; // ms that the element can be pressed before the presstip shows
 
 /**
  * A "press tip" is a tooltip that can be shown by pressing on an element, or via hover.
@@ -259,48 +259,73 @@ export function PressTip(props: Props) {
   const timer = useRef<number>(0);
   const touchStartTime = useRef<number>(0);
   const ref = useRef<HTMLDivElement>(null);
+  const startEvent = useRef<'pointerdown' | 'pointerenter'>();
   const [open, setOpen] = useState<boolean>(false);
 
-  const closeToolTip = useCallback(() => {
+  const closeToolTip = useCallback((e: React.PointerEvent) => {
+    // Ignore events that aren't paired up
+    if (
+      !startEvent.current ||
+      (e.type === 'pointerup' && startEvent.current === 'pointerenter') ||
+      (e.type === 'pointerleave' && startEvent.current === 'pointerdown')
+    ) {
+      return;
+    }
     setOpen(false);
     clearTimeout(timer.current);
-    timer.current = 0;
+    // Don't clear these for 500ms to give the click event time to suppress - pointerup fires before click
+    setTimeout(() => {
+      timer.current = 0;
+      startEvent.current = undefined;
+    }, 500);
   }, []);
 
   const hover = useCallback((e: React.PointerEvent) => {
     e.preventDefault();
+    // If we're already hovering, don't start hovering again
+    if (
+      startEvent.current &&
+      // Safari, at least, fires both pointerenter and pointerdown at the same time. We want the pointerdown event.
+      !(startEvent.current === 'pointerenter' && performance.now() - touchStartTime.current < 10)
+    ) {
+      return;
+    }
     clearTimeout(timer.current);
+    // Save the event type that initiated the hover
+    startEvent.current = e.type as 'pointerenter' | 'pointerdown';
+    // Record the start timestamp of the gesture
+    touchStartTime.current = performance.now();
+    // Hover over should wait for a shorter delay than a press
+    const hoverDelay = e.type === 'pointerenter' ? hoverTime : pressTime;
+    // Start a timer to show the pressTip
     timer.current = window.setTimeout(() => {
       setOpen(true);
     }, hoverDelay);
-    touchStartTime.current = performance.now();
   }, []);
 
   // Stop the hover timer when the component unmounts
   useEffect(() => () => clearTimeout(timer.current), []);
 
-  // Prevent clicks if the tooltip has been pressed long enough to show a tip
-  const absorbClick = useCallback(
-    (e: React.MouseEvent | React.TouchEvent | React.FocusEvent | React.PointerEvent) => {
-      if (performance.now() - touchStartTime.current > hoverDelay) {
-        e.stopPropagation();
-      }
-    },
-    []
-  );
+  // When the tooltip was opened by pressing (pointerdown), prevent the click event when
+  // we end the gesture. If the presstip was opened via hovering we want to allow clicks
+  // through.
+  const absorbClick = useCallback((e: React.MouseEvent) => {
+    if (
+      startEvent.current === 'pointerdown' &&
+      performance.now() - touchStartTime.current > pressTime
+    ) {
+      e.stopPropagation();
+    }
+  }, []);
 
-  const events = hoverable
-    ? {
-        onPointerEnter: hover,
-        onPointerLeave: closeToolTip,
-        onPointerCancel: closeToolTip,
-      }
-    : {
-        onPointerDown: hover,
-        onPointerUp: closeToolTip,
-        onPointerCancel: closeToolTip,
-        onClick: absorbClick,
-      };
+  const events = {
+    onPointerEnter: hover,
+    onPointerDown: hover,
+    onPointerLeave: closeToolTip,
+    onPointerUp: closeToolTip,
+    onPointerCancel: closeToolTip,
+    onClick: absorbClick,
+  };
 
   return <Control open={open} triggerRef={ref} {...events} {...props} />;
 }

--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -264,6 +264,9 @@ export function PressTip(props: Props) {
   const [open, setOpen] = useState<boolean>(false);
 
   const closeToolTip = useCallback((e: React.PointerEvent) => {
+    if (e.type === 'pointerup') {
+      ref.current?.releasePointerCapture(e.pointerId);
+    }
     // Ignore events that aren't paired up
     if (
       !startEvent.current ||
@@ -286,6 +289,10 @@ export function PressTip(props: Props) {
   }, []);
 
   const hover = useCallback((e: React.PointerEvent) => {
+    if (e.type === 'pointerdown') {
+      // Capture pointer so our pointermove absorber works
+      ref.current?.setPointerCapture(e.pointerId);
+    }
     e.preventDefault();
     // If we're already hovering, don't start hovering again
     if (
@@ -295,9 +302,11 @@ export function PressTip(props: Props) {
     ) {
       return;
     }
+
     clearTimeout(timer.current);
     // Save the event type that initiated the hover
     startEvent.current = e.type as 'pointerenter' | 'pointerdown';
+
     // Record the start timestamp of the gesture
     touchStartTime.current = performance.now();
     // Hover over should wait for a shorter delay than a press
@@ -320,10 +329,22 @@ export function PressTip(props: Props) {
     }
   }, []);
 
+  // Prevent dragging from the long press
+  const absorbMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (open) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    },
+    [open]
+  );
+
   const events = {
     onPointerEnter: hover,
     onPointerDown: hover,
     onPointerLeave: closeToolTip,
+    onPointerMove: absorbMove,
     onPointerUp: closeToolTip,
     onPointerCancel: closeToolTip,
     onClick: absorbClick,


### PR DESCRIPTION
OK, I think I got it this time. Now there's no special casing based on the CSS media query for hover - it's all about the actual events that happen, so it should be correct for every type of pointer, whether that's mouse, touch, or pen (with or without a digitizer that can do hover). And it should work for cases where you have multiple pointer types available.