### PR TITLE
Plug drawer / socket details: Keep armor mods and subclass plugs in PlugSet order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 * The "Show Mod Placement" sheet will now show the required armor energy capacity upgrades to make all mods fit (and the total upgrade costs).
 * Loadout Optimizer sets will now show energy capacity bars below armor pieces, similar to the "Show Mod Placement" sheet.
 * Loadouts created before Lightfall with deprecated stat mods now have their stat mods restored.
+* Mods in the loadout mods picker are now more logically ordered by matching the in-game order.
 
 ## 7.62.0 <span class="changelog-date">(2023-03-26)</span>
 

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -5,8 +5,8 @@ import { EnergyCostIcon } from 'app/dim-ui/ElementIcon';
 import Sheet from 'app/dim-ui/Sheet';
 import { t } from 'app/i18next-t';
 import 'app/inventory-page/StoreBucket.scss';
-import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
+import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { allItemsSelector, profileResponseSelector } from 'app/inventory/selectors';
 import { isValidMasterworkStat } from 'app/inventory/store/masterwork';
 import { isPluggableItem } from 'app/inventory/store/sockets';
@@ -14,9 +14,9 @@ import { mapToOtherModCostVariant } from 'app/loadout/mod-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import { collectionsVisibleShadersSelector } from 'app/records/selectors';
+import { SearchInput } from 'app/search/SearchInput';
 import { weaponMasterworkY2SocketTypeHash } from 'app/search/d2-known-values';
 import { createPlugSearchPredicate } from 'app/search/plug-search';
-import { SearchInput } from 'app/search/SearchInput';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { emptySet } from 'app/utils/empty';
 import { DestinyProfileResponse, PlugUiStyles, SocketPlugSources } from 'bungie-api-ts/destiny2';
@@ -239,9 +239,16 @@ export default function SocketDetails({
       chainComparator(
         compareBy((i) => i.hash !== socket.emptyPlugItemHash),
         reverseComparator(compareBy((i) => unlocked(i.hash))),
-        compareBy((i) => i.plug?.energyCost?.energyCost),
         compareBy((i) => -i.inventory!.tierType),
-        compareBy((i) => i.displayProperties.name)
+        compareBy(
+          (i) =>
+            // subclass plugs in PlugSet order
+            item.bucket.hash === BucketHashes.Subclass ||
+            // mods that cost something in PlugSet order
+            (i.plug?.energyCost?.energyCost ?? 0) > 0 ||
+            // everything else by name
+            i.displayProperties.name
+        )
       )
     );
 

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -9,8 +9,8 @@ import { ResolvedLoadoutMod } from 'app/loadout-drawer/loadout-types';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
 import {
-  armor2PlugCategoryHashesByName,
   MAX_ARMOR_ENERGY_CAPACITY,
+  armor2PlugCategoryHashesByName,
 } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
 import { compareBy } from 'app/utils/comparators';
@@ -30,7 +30,7 @@ import {
   knownModPlugCategoryHashes,
   slotSpecificPlugCategoryHashes,
 } from './known-values';
-import { isInsertableArmor2Mod, sortModGroups, sortMods } from './mod-utils';
+import { isInsertableArmor2Mod, sortModGroups } from './mod-utils';
 import PlugDrawer from './plug-drawer/PlugDrawer';
 import { PlugSet } from './plug-drawer/types';
 
@@ -294,7 +294,6 @@ function ModPicker({ plugSets, classType, lockedMods, initialQuery, onAccept, on
       classType={classType}
       isPlugSelectable={isModSelectable}
       sortPlugGroups={sortModPickerPlugGroups}
-      sortPlugs={sortMods}
       onAccept={onAcceptWithHiddenSelectedMods}
       onClose={onClose}
     />

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -41,7 +41,7 @@ export default function SubclassPlugDrawer({
   const defs = useD2Definitions()!;
   const profileResponse = useSelector(profileResponseSelector);
 
-  const { plugSets, aspects, fragments, sortPlugs, sortPlugGroups } = useMemo(() => {
+  const { plugSets, aspects, fragments, sortPlugGroups } = useMemo(() => {
     const initiallySelected = Object.values(socketOverrides)
       .map((hash) => defs.InventoryItem.get(hash))
       .filter(isPluggableItem);
@@ -56,9 +56,6 @@ export default function SubclassPlugDrawer({
     // A flat list of possible subclass plugs we use this to figure out how to sort plugs
     // and the different sections in the plug picker
     const flatPlugs = plugSets.flatMap((set) => set.plugs);
-    const sortPlugs = compareBy((plug: PluggableInventoryItemDefinition) =>
-      flatPlugs.indexOf(plug)
-    );
     // This ensures the plug groups are ordered by the socket order in the item def.
     // The order in the item def matches the order displayed in the game.
     const sortPlugGroups = compareBy(
@@ -68,7 +65,6 @@ export default function SubclassPlugDrawer({
       plugSets,
       aspects,
       fragments,
-      sortPlugs,
       sortPlugGroups,
     };
   }, [defs, profileResponse, socketOverrides, subclass]);
@@ -146,7 +142,6 @@ export default function SubclassPlugDrawer({
       onAccept={handleAccept}
       onClose={onClose}
       isPlugSelectable={isPlugSelectable}
-      sortPlugs={sortPlugs}
       sortPlugGroups={sortPlugGroups}
     />
   );


### PR DESCRIPTION
This is admittedly subjective but I think Bungie's PlugSet order makes a bit more sense this time around and it's very confusing to have the mods shifted around in DIM as you keep unlocking artifact mods that change specific armor mods' costs. It was more useful in the past when we still had mod/armor elemental affinity but I think there's value in matching the in-game order.