### PR TITLE
Stats optimize

### DIFF
--- a/src/app/inventory/d2-stores.test.ts
+++ b/src/app/inventory/d2-stores.test.ts
@@ -78,4 +78,21 @@ describe('process stores', () => {
       }
     }
   });
+
+  // This relies on the sample profile having at least one item that has a plug
+  // that can no longer roll. I keep a Commemoration around for that.
+  it('item perks can be marked as cannotCurrentlyRoll', async () => {
+    for (const store of stores) {
+      for (const item of store.items) {
+        if (item.sockets) {
+          if (
+            item.sockets.allSockets.some((s) => s.plugOptions.some((p) => p.cannotCurrentlyRoll))
+          ) {
+            return; // All good, we found one!
+          }
+        }
+      }
+    }
+    throw new Error('Expected at least one item with a perk that cannot roll');
+  });
 });

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -467,7 +467,7 @@ export function buildDefinedPlug(
     enableFailReasons: '',
     plugObjectives: emptyArray(),
     stats: null,
-    cannotCurrentlyRoll: currentlyCanRoll !== undefined && !currentlyCanRoll,
+    cannotCurrentlyRoll: currentlyCanRoll === false,
   };
 }
 

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -291,6 +291,8 @@ function buildStat(
   statDef: DestinyStatDefinition,
   statDisplaysByStatHash: StatDisplayLookup
 ): DimStat {
+  value = value || 0;
+  const investmentValue = value;
   let maximumValue = statGroup.maximumValue;
   let bar = !statsNoBar.includes(statHash);
   let smallerIsBetter = false;
@@ -306,7 +308,7 @@ function buildStat(
   }
 
   return {
-    investmentValue: value || 0,
+    investmentValue,
     statHash,
     displayProperties: statDef.displayProperties,
     sort: getStatSortOrder(statHash),
@@ -420,7 +422,9 @@ function applyPlugsToStats(
   // We sort the sockets by length so that we count contributions from plugs with fewer options first.
   // This is because multiple plugs can contribute to the same stat, so we want to sink the non-changeable
   // stats in first.
-  const sortedSockets = createdItem.sockets.allSockets.sort(compareBy((s) => s.plugOptions.length));
+  const sortedSockets = [...createdItem.sockets.allSockets].sort(
+    compareBy((s) => s.plugOptions.length)
+  );
   for (const socket of sortedSockets) {
     attachPlugStats(socket, existingStatsByHash, statDisplaysByStatHash);
   }


### PR DESCRIPTION
This is the other half of the inventory build optimization task. It improves the process of computing stats by 2-4x on my machine, bringing the overall inventory build under 30ms. Memory allocation is also greatly reduced which reduces GC time. This should all hopefully help with reducing the CPU and memory impact of DIM updating.

A few major changes:
* We no longer cache defined sockets - it was not saving memory since we had to modify them for `cannotCurrentlyRoll` and it forced several spread copies that are no longer needed.
* Replacing `_.keyBy` with a more manual construction was a noticeable savings, worth keeping in mind. More significant was memoizing the repeated calculation of `statDisplaysByStatHash`.
* Reduced a few more allocations by changing the arguments of `buildStat`.
* Removed a redundant check of whether a stat should be shown.