### PR TITLE
CSP, COOP, COEP

### DIFF
--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -63,6 +63,7 @@ export default function csp(env: 'release' | 'beta' | 'dev') {
     ],
     fontSrc: [
       SELF,
+      'data:',
       // Google Fonts
       'https://fonts.gstatic.com',
     ],

--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -73,6 +73,8 @@ export default (env: Env) => {
 
   const buildTime = Date.now();
 
+  const contentSecurityPolicy = csp(env.name);
+
   const config: webpack.Configuration = {
     mode: env.dev ? ('development' as const) : ('production' as const),
 
@@ -115,6 +117,11 @@ export default (env: Env) => {
           historyApiFallback: true,
           hot: 'only',
           liveReload: false,
+          headers: {
+            'Content-Security-Policy': contentSecurityPolicy,
+            'Cross-Origin-Embedder-Policy': 'credentialless',
+            'Cross-Origin-Opener-Policy': 'same-origin',
+          },
         }
       : undefined,
 
@@ -394,7 +401,7 @@ export default (env: Env) => {
       inject: false,
       minify: false,
       templateParameters: {
-        csp: csp(env.name),
+        csp: contentSecurityPolicy,
       },
     }),
 

--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -119,6 +119,7 @@ export default (env: Env) => {
           liveReload: false,
           headers: {
             'Content-Security-Policy': contentSecurityPolicy,
+            // credentialless is only supported by chrome but require-corp blocks Bungie.net messages
             'Cross-Origin-Embedder-Policy': 'credentialless',
             'Cross-Origin-Opener-Policy': 'same-origin',
           },

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -7,19 +7,20 @@ import store from 'app/store/store';
 import { lazyLoadStreamDeck, startStreamDeckConnection } from 'app/stream-deck/stream-deck';
 import { streamDeckEnabled } from 'app/stream-deck/util/local-storage';
 import { infoLog } from 'app/utils/log';
+import { scheduleMemoryMeasurement } from 'app/utils/measure-memory';
 import ReactDOM from 'react-dom/client';
 import idbReady from 'safari-14-idb-fix';
+import { StorageBroken, storageTest } from './StorageTest';
+import Root from './app/Root';
 import setupRateLimiter from './app/bungie-api/rate-limit-config';
 import './app/google';
 import { initi18n } from './app/i18n';
 import './app/main.scss';
 import registerServiceWorker from './app/register-service-worker';
-import Root from './app/Root';
 import { safariTouchFix } from './app/safari-touch-fix';
 import { watchLanguageChanges } from './app/settings/observers';
 import './app/utils/exceptions';
 import { saveWishListToIndexedDB } from './app/wishlists/observers';
-import { StorageBroken, storageTest } from './StorageTest';
 
 infoLog(
   'app',
@@ -33,6 +34,7 @@ if ($DIM_FLAVOR !== 'dev') {
 }
 
 setupRateLimiter();
+scheduleMemoryMeasurement();
 
 const i18nPromise = initi18n();
 

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -99,7 +99,6 @@ $header-height: 44px;
 .menu {
   composes: resetButton from '../dim-ui/common.m.scss';
   position: relative;
-  margin-right: none !important;
   margin-left: 16px !important;
 }
 

--- a/src/app/utils/measure-memory.ts
+++ b/src/app/utils/measure-memory.ts
@@ -1,0 +1,46 @@
+// https://web.dev/monitor-total-page-memory-usage/
+
+import { humanBytes } from 'app/storage/human-bytes';
+import { infoLog } from './log';
+
+export function scheduleMemoryMeasurement() {
+  // Check measurement API is available.
+  if (!window.crossOriginIsolated) {
+    return;
+  }
+  if (!performance.measureUserAgentSpecificMemory) {
+    return;
+  }
+  const interval = measurementInterval();
+  setTimeout(performMeasurement, interval);
+}
+
+const MEAN_INTERVAL_IN_MS = 5 * 60 * 1000;
+function measurementInterval() {
+  return -Math.log(Math.random()) * MEAN_INTERVAL_IN_MS;
+}
+
+async function performMeasurement() {
+  // 1. Invoke performance.measureUserAgentSpecificMemory().
+  let result: MeasureMemoryResult;
+  try {
+    result = await performance.measureUserAgentSpecificMemory();
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'SecurityError') {
+      return;
+    }
+    // Rethrow other errors.
+    throw error;
+  }
+  // 2. Record the result.
+  infoLog(
+    'memory',
+    `DIM is using ${humanBytes(result.bytes)} of memory.`,
+    result.breakdown
+      .filter((b) => b.bytes)
+      .map((b) => `${b.types.join('/')}: ${humanBytes(b.bytes)}`)
+      .join(', ')
+  );
+  // 3. Schedule the next measurement.
+  scheduleMemoryMeasurement();
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -34,6 +34,24 @@ interface Navigator {
   clearAppBadge();
 }
 
+interface Performance {
+  measureUserAgentSpecificMemory(): Promise<MeasureMemoryResult>;
+}
+
+interface MeasureMemoryResult {
+  bytes: number;
+  breakdown: {
+    bytes: number;
+    attribution: [
+      {
+        url: string;
+        scope: string;
+      }
+    ];
+    types: string[];
+  }[];
+}
+
 /**
  * The BeforeInstallPromptEvent is fired at the Window.onbeforeinstallprompt handler
  * before a user is prompted to "install" a web site to a home screen on mobile.

--- a/src/htaccess
+++ b/src/htaccess
@@ -477,6 +477,9 @@ AddDefaultCharset utf-8
 <IfModule mod_headers.c>
 
     Header set Content-Security-Policy "<%= csp %>"
+    # credentialless is only supported by chrome but require-corp blocks Bungie.net messages
+    Header set Cross-Origin-Embedder-Policy "credentialless"
+    Header set Cross-Origin-Opener-Policy "same-origin"
 
     # `mod_headers` cannot match based on the content-type, however,
     # the `Content-Security-Policy` response header should be send
@@ -484,6 +487,8 @@ AddDefaultCharset utf-8
 
     <FilesMatch "\.(appcache|atom|bbaw|bmp|crx|css|cur|eot|f4[abpv]|flv|geojson|gif|htc|ico|jpe?g|js|json(ld)?|m4[av]|manifest|map|mp4|oex|og[agv]|opus|otf|pdf|png|rdf|rss|safariextz|svgz?|swf|topojson|tt[cf]|txt|vcard|vcf|vtt|webapp|web[mp]|webmanifest|woff2?|xloc|xml|xpi)(\.(gz|br))?$">
         Header unset Content-Security-Policy
+        Header unset Cross-Origin-Embedder-Policy
+        Header unset Cross-Origin-Opener-Policy
     </FilesMatch>
 
 </IfModule>


### PR DESCRIPTION
This change:

1. Adds our Content-Security-Policy header to the devserver so we should see violations while developing, rather than only when deployed.
2. Adds Cross-Origin-Embedder-Policy and Cross-Origin-Opener-Policy headers, which protect against some classes of security issue, but more importantly opt us un to the [`crossOriginIsolated`](https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated) state that allows things like `SharedArrayBuffer`, `measureUserAgentSpecificMemory`, and high precision timers, in case we wanted those sometime.