### PR TITLE
always sort game loadouts by index

### DIFF
--- a/src/app/loadout/loadout-ui/menu-hooks.tsx
+++ b/src/app/loadout/loadout-ui/menu-hooks.tsx
@@ -190,6 +190,6 @@ export function searchAndSortLoadoutsByQuery(
     (l) => (isInGameLoadout(l) ? 0 : 1),
     loadoutSort === LoadoutSort.ByEditTime
       ? (l) => (isInGameLoadout(l) ? l.index : -(l.lastUpdatedAt ?? 0))
-      : (l) => l.name.toLocaleUpperCase()
+      : (l) => (isInGameLoadout(l) ? l.index : l.name.toLocaleUpperCase())
   );
 }


### PR DESCRIPTION
please. they're so arbitrary and the user has so little control over them.
the names are necessarily a compromise with bungie and often not indicative of much if anything.

also they are hugely secondary, you can't even see them ingame without hovering. skillful/proper use of ingame loadouts relies on remembering positioning and icons