### PR TITLE
Ignore enhanced/adept weapons' minor masterwork stat boosts for filtering, organizer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Autocompletion in the search bar now succeeds for terms with umlauts even if you didn't enter any (suggests "jötunn" when typing "jot...").
 * Fixed the `modslot:any`/`modslot:none` filters.
 * Fixed an issue where some subclass fragments and armor mods would be missing descriptions in Loadout Optimizer and the Loadout editor.
+* The minor boosts to all stats that enhanced crafted and masterworked adept weapons have are now ignored in Organizer's "Masterwork Stat" column and by the `masterwork:statname` filter. Only the primary +10 boost is considered.
 
 ## 7.62.0 <span class="changelog-date">(2023-03-26)</span>
 

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -251,11 +251,13 @@ export interface DimMasterwork {
   tier?: number;
   /** The stats that are enhanced by this masterwork. */
   stats?: {
-    hash?: number;
+    hash: number;
     /** The name of the stat enhanced by this masterwork. */
-    name?: string;
+    name: string;
     /** How much the stat is enhanced by this masterwork. */
-    value?: number;
+    value: number;
+    /** Is this a primary stat effect or secondary? Adept/crafted weapons can get a small +X to all stats; these are secondary */
+    isPrimary: boolean;
   }[];
 }
 

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -2,7 +2,10 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { isPlugStatActive } from 'app/utils/item-utils';
 import { getFirstSocketByCategoryHash, isWeaponMasterworkSocket } from 'app/utils/socket-utils';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import enhancedIntrinsics from 'data/d2/crafting-enhanced-intrinsics';
 import { ItemCategoryHashes, SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import masterworksWithCondStats from 'data/d2/masterworks-with-cond-stats.json';
+import _ from 'lodash';
 import { DimItem, DimMasterwork, DimSockets } from '../item-types';
 
 /**
@@ -61,6 +64,12 @@ function buildMasterworkInfo(
 
   const stats: DimMasterwork['stats'] = [];
 
+  const primaryMWStatHash =
+    enhancedIntrinsics.has(masterworkPlug.plugDef.hash) ||
+    masterworksWithCondStats.includes(masterworkPlug.plugDef.hash)
+      ? _.maxBy(investmentStats, (stat) => stat.value)?.statTypeHash
+      : undefined;
+
   for (const stat of investmentStats) {
     if (
       !isPlugStatActive(
@@ -76,6 +85,7 @@ function buildMasterworkInfo(
       hash: stat.statTypeHash,
       name: defs.Stat.get(stat.statTypeHash).displayProperties.name,
       value: masterworkPlug.stats?.[stat.statTypeHash] || 0,
+      isPrimary: primaryMWStatHash === undefined || primaryMWStatHash === stat.statTypeHash,
     });
   }
 

--- a/src/app/search/search-filters/range-overload.tsx
+++ b/src/app/search/search-filters/range-overload.tsx
@@ -38,7 +38,7 @@ const overloadedRangeFilters: FilterDefinition[] = [
       return (item) =>
         Boolean(
           item.masterworkInfo?.stats?.some(
-            (s) => filterValue === 'any' || s.hash === searchedMasterworkStatHash
+            (s) => filterValue === 'any' || (s.isPrimary && s.hash === searchedMasterworkStatHash)
           )
         );
     },

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -118,7 +118,8 @@ export const isArmor2Mod = (item: DestinyInventoryItemDefinition): boolean =>
 export function getMasterworkStatNames(mw: DimMasterwork | null) {
   return (
     mw?.stats
-      ?.map((stat) => stat.name)
+      ?.filter((stat) => stat.isPrimary)
+      .map((stat) => stat.name)
       .filter(Boolean)
       .join(', ') ?? ''
   );


### PR DESCRIPTION
Fixes #9263.

Justification: These features are for identifying differences between weapons. Different copies of the same gun have the same minor stat boost behavior, so that part is not really interesting.

We can't just remove them from DimMasterwork because we still want to show their effects with a yellow highlight in the item popup.