### PR TITLE
Fix modslot:none/modslot:any

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Loadouts created before Lightfall with deprecated stat mods now have their stat mods restored.
 * Mods in the loadout mods picker are now more logically ordered by matching the in-game order.
 * Autocompletion in the search bar now succeeds for terms with umlauts even if you didn't enter any (suggests "jötunn" when typing "jot...").
+* Fixed the `modslot:any`/`modslot:none` filters.
 
 ## 7.62.0 <span class="changelog-date">(2023-03-26)</span>
 

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -80,12 +80,16 @@ const getSpecialtySockets = (item?: DimItem): DimSocket[] | undefined => {
 };
 
 /** returns ModMetadatas if the item has one or more specialty mod slots */
-export const getSpecialtySocketMetadatas = (item?: DimItem): ModSocketMetadata[] | undefined =>
-  _.compact(
+export const getSpecialtySocketMetadatas = (item?: DimItem): ModSocketMetadata[] | undefined => {
+  const metadatas = _.compact(
     getSpecialtySockets(item)?.map(
       (s) => modMetadataBySocketTypeHash[s.socketDefinition.socketTypeHash]
     )
   );
+  if (metadatas?.length) {
+    return metadatas;
+  }
+};
 
 /**
  * combat and legacy slots are boring now. everything has them.


### PR DESCRIPTION
`_.compact(undefined)` returns `[]`, so this function was not adhering to its contract and the filter got confused.