### PR TITLE
Use execCommand to autocomplete without messing up undo

### DIFF
--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -24,7 +24,6 @@ import React, {
   useDeferredValue,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -435,15 +434,6 @@ function SearchBar(
     [clearFilter]
   );
 
-  // Setting this ref's value allows us to set the cursor position to a specific index on the next render
-  const selectionRef = useRef<number>();
-  useLayoutEffect(() => {
-    if (selectionRef.current !== undefined && inputElement.current) {
-      inputElement.current.setSelectionRange(selectionRef.current, selectionRef.current);
-      selectionRef.current = undefined;
-    }
-  });
-
   // Implement tab completion on the tab key. If the highlighted item is an autocomplete suggestion,
   // accept it. Otherwise, we scan from the beginning to find the first autocomplete suggestion and
   // accept that. If there's nothing to accept, the tab key does its normal thing, which is to switch
@@ -455,9 +445,14 @@ function SearchBar(
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Tab' && !e.altKey && !e.ctrlKey && tabAutocompleteItem && isOpen) {
       e.preventDefault();
-      setInputValue(tabAutocompleteItem.query.fullText);
-      if (tabAutocompleteItem.highlightRange) {
-        selectionRef.current = tabAutocompleteItem.highlightRange.range[1];
+      if (inputElement.current) {
+        // Use execCommand to make the insertion as if the user typed it, so it can be undone with Ctrl-Z
+        inputElement.current.setSelectionRange(0, inputElement.current.value.length);
+        document.execCommand('insertText', false, tabAutocompleteItem.query.fullText);
+        if (tabAutocompleteItem.highlightRange) {
+          const cursorPos = tabAutocompleteItem.highlightRange.range[1];
+          inputElement.current.setSelectionRange(cursorPos, cursorPos);
+        }
       }
     } else if (e.key === 'Home' || e.key === 'End') {
       // Disable the use of Home/End to select items in the menu


### PR DESCRIPTION
This switches how we set the text on tab-autocomplete such that you can undo the autocomplete with Ctrl-Z. For some reason undoing the change also selects all the text - I'm not sure how to fix that part.

This doesn't solve #8833... probably that'd require changes to Downshift itself.