### PR TITLE
More stats optimize

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -442,7 +442,7 @@ function processCharacter(
   const store = makeCharacter(defs, character, lastPlayedDate, profileRecords);
 
   // We work around the weird account-wide buckets by assigning them to the current character
-  const items = characterInventory.concat(characterEquipment.flat());
+  const items = characterInventory.concat(characterEquipment);
 
   if (store.current) {
     for (const i of profileInventory) {

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -292,17 +292,16 @@ function buildDefinedSocket(
       if (plugSetItems.length) {
         // Unique the plugs by hash, but also consider the perk rollable if there's a copy with currentlyCanRoll = true
         // See https://github.com/DestinyItemManager/DIM/issues/7272
-        const plugs: {
-          [plugItemHash: number]: DestinyItemSocketEntryPlugItemRandomizedDefinition;
-        } = {};
+        // We use a Map to preserve insertion order - an object would return its values sorted by hash!
+        const plugs = new Map<number, DestinyItemSocketEntryPlugItemRandomizedDefinition>();
         for (const randomPlug of plugSetItems) {
-          const existing = plugs[randomPlug.plugItemHash];
+          const existing = plugs.get(randomPlug.plugItemHash);
           if (!existing || (!existing.currentlyCanRoll && randomPlug.currentlyCanRoll)) {
-            plugs[randomPlug.plugItemHash] = randomPlug;
+            plugs.set(randomPlug.plugItemHash, randomPlug);
           }
         }
 
-        for (const randomPlug of Object.values(plugs)) {
+        for (const randomPlug of plugs.values()) {
           const built = buildDefinedPlug(
             defs,
             randomPlug.plugItemHash,


### PR DESCRIPTION
Some leftovers from stats optimization. Using a map to dedupe plug set items should guarantee we keep them in the order they started in, though we still resort them later to put retired perks on the bottom.