### PR TITLE
Move ingame loadout editor to loadouts level

### DIFF
--- a/src/app/loadout/LoadoutsRow.tsx
+++ b/src/app/loadout/LoadoutsRow.tsx
@@ -9,13 +9,11 @@ import { AppIcon, deleteIcon, faCheckCircle } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { streamDeckSelectionSelector } from 'app/stream-deck/selectors';
 import { streamDeckSelectLoadout } from 'app/stream-deck/stream-deck';
-import { Portal } from 'app/utils/temp-container';
 import _ from 'lodash';
-import { ReactNode, memo, useMemo, useState } from 'react';
+import { ReactNode, memo, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import LoadoutView from './LoadoutView';
 import styles from './LoadoutsRow.m.scss';
-import EditInGameLoadout from './ingame/EditInGameLoadout';
 
 /**
  * A single row in the Loadouts page.
@@ -26,12 +24,14 @@ export default memo(function LoadoutRow({
   saved,
   equippable,
   onShare,
+  onSnapshotInGameLoadout,
 }: {
   loadout: Loadout;
   store: DimStore;
   saved: boolean;
   equippable: boolean;
   onShare: (loadout: Loadout) => void;
+  onSnapshotInGameLoadout: () => void;
 }) {
   const dispatch = useThunkDispatch();
 
@@ -39,8 +39,6 @@ export default memo(function LoadoutRow({
     ? // eslint-disable-next-line
       useSelector(streamDeckSelectionSelector)
     : null;
-
-  const [showSnapshot, setShowSnapshot] = useState(false);
 
   const actionButtons = useMemo(() => {
     const handleDeleteClick = () => dispatch(deleteLoadout(loadout.id));
@@ -50,9 +48,6 @@ export default memo(function LoadoutRow({
 
     const handleEdit = () => editLoadout(loadout, store.id, { isNew: !saved });
     const handleShare = () => onShare(loadout);
-
-    const handleSnapshot = () => setShowSnapshot(true);
-    const handleSnapshotSheetClose = () => setShowSnapshot(false);
 
     const actionButtons: ReactNode[] = [];
 
@@ -102,20 +97,28 @@ export default memo(function LoadoutRow({
       );
     } else {
       actionButtons.push(
-        <button key="snapshot" type="button" className="dim-button" onClick={handleSnapshot}>
+        <button
+          key="snapshot"
+          type="button"
+          className="dim-button"
+          onClick={onSnapshotInGameLoadout}
+        >
           {t('Loadouts.Snapshot')}
         </button>
       );
-      showSnapshot &&
-        actionButtons.push(
-          <Portal key="snapshotsheet">
-            <EditInGameLoadout characterId={store.id} onClose={handleSnapshotSheetClose} />
-          </Portal>
-        );
     }
 
     return actionButtons;
-  }, [dispatch, equippable, loadout, onShare, saved, store, streamDeckSelection, showSnapshot]);
+  }, [
+    dispatch,
+    equippable,
+    loadout,
+    onShare,
+    onSnapshotInGameLoadout,
+    saved,
+    store,
+    streamDeckSelection,
+  ]);
 
   return (
     <LoadoutView

--- a/src/app/loadout/ingame/InGameLoadoutRow.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutRow.tsx
@@ -7,10 +7,8 @@ import { AppIcon, deleteIcon, faCheckCircle } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { streamDeckSelectionSelector } from 'app/stream-deck/selectors';
 import { streamDeckSelectLoadout } from 'app/stream-deck/stream-deck';
-import { Portal } from 'app/utils/temp-container';
-import { ReactNode, memo, useMemo, useState } from 'react';
+import { ReactNode, memo, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import EditInGameLoadout from './EditInGameLoadout';
 import InGameLoadoutView from './InGameLoadoutView';
 import { applyInGameLoadout, deleteInGameLoadout } from './ingame-loadout-apply';
 
@@ -20,12 +18,13 @@ import { applyInGameLoadout, deleteInGameLoadout } from './ingame-loadout-apply'
 export default memo(function InGameLoadoutRow({
   loadout,
   store,
+  onEdit,
 }: {
   loadout: InGameLoadout;
   store: DimStore;
+  onEdit: (loadout: InGameLoadout) => void;
 }) {
   const dispatch = useThunkDispatch();
-  const [editing, setEditing] = useState(false);
 
   const streamDeckSelection = $featureFlags.elgatoStreamDeck
     ? // eslint-disable-next-line
@@ -35,8 +34,6 @@ export default memo(function InGameLoadoutRow({
   const actionButtons = useMemo(() => {
     const handleApply = () => dispatch(applyInGameLoadout(loadout));
     const handleDelete = () => dispatch(deleteInGameLoadout(loadout));
-    const handleEdit = () => setEditing(true);
-    const handleEditSheetClose = () => setEditing(false);
 
     if (streamDeckSelection === 'loadout') {
       const handleSelection = () =>
@@ -68,26 +65,20 @@ export default memo(function InGameLoadoutRow({
         {t('Loadouts.Apply')}
       </button>,
 
-      <button key="edit" type="button" className="dim-button" onClick={handleEdit}>
+      <button key="edit" type="button" className="dim-button" onClick={() => onEdit(loadout)}>
         {t('Loadouts.EditBrief')}
       </button>,
 
       <ConfirmButton key="delete" danger onClick={handleDelete}>
         <AppIcon icon={deleteIcon} title={t('Loadouts.Delete')} />
       </ConfirmButton>,
-
-      editing && (
-        <Portal key="editsheet">
-          <EditInGameLoadout loadout={loadout} onClose={handleEditSheetClose} />
-        </Portal>
-      ),
     ];
 
     // TODO: add snapshotting loadouts - may need a dialog to select the loadout slot
     // TODO: figure out whether this loadout is currently equippable (all items on character or in vault)
 
     return actionButtons;
-  }, [dispatch, loadout, store, streamDeckSelection, editing]);
+  }, [streamDeckSelection, dispatch, loadout, store, onEdit]);
 
   return <InGameLoadoutView loadout={loadout} store={store} actionButtons={actionButtons} />;
 });


### PR DESCRIPTION
This fixes the issue with the sheet disappearing when the currently equipped loadout's ID changes.