### PR TITLE
Artifact mods style tweaks

### DIFF
--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -74,6 +74,14 @@
 .modsStack {
   display: flex;
   flex-direction: column;
-  row-gap: 20px;
-  flex: 0.5;
+  row-gap: 16px;
+  flex: 1;
+
+  h3 {
+    margin: 0 0 4px 0;
+  }
+}
+
+.artifactMods {
+  --item-size: 40px;
 }

--- a/src/app/loadout/LoadoutView.m.scss.d.ts
+++ b/src/app/loadout/LoadoutView.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'actions': string;
+  'artifactMods': string;
   'classIcon': string;
   'contents': string;
   'loadout': string;

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -156,7 +156,11 @@ export default function LoadoutView({
                   loadout.parameters?.artifactUnlocks?.unlockedItemHashes.length
                 )}
               />
-              <LoadoutArtifactUnlocks loadout={loadout} storeId={store.id} />
+              <LoadoutArtifactUnlocks
+                loadout={loadout}
+                storeId={store.id}
+                className={styles.artifactMods}
+              />
             </div>
           </>
         )}

--- a/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
@@ -8,7 +8,7 @@
 }
 
 .mods {
-  width: 100%;
+  flex: 1;
 }
 
 .buttons {
@@ -16,13 +16,6 @@
   flex-flow: row wrap;
   margin: 10px auto;
   gap: 4px;
-}
-
-.modsStack {
-  display: flex;
-  flex-direction: column;
-  row-gap: 20px;
-  flex: 1;
 }
 
 .section {

--- a/src/app/loadout/loadout-edit/LoadoutEdit.m.scss.d.ts
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.m.scss.d.ts
@@ -4,7 +4,6 @@ interface CssExports {
   'buttons': string;
   'contents': string;
   'mods': string;
-  'modsStack': string;
   'section': string;
 }
 export const cssExports: CssExports;

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -238,38 +238,36 @@ export default function LoadoutEdit({
           </LoadoutEditBucketDropTarget>
         </LoadoutEditSection>
       ))}
-      <div className={clsx(styles.section, styles.modsStack)}>
-        <LoadoutEditSection
-          title={t('Loadouts.Mods')}
-          className={styles.mods}
-          onClear={handleClearMods}
-          onSyncFromEquipped={missingSockets ? undefined : handleSyncModsFromEquipped}
-        >
-          <LoadoutMods
-            loadout={loadout}
-            storeId={store.id}
-            allMods={allMods}
-            onUpdateMods={handleUpdateMods}
-            onRemoveMod={handleRemoveMod}
-            clearUnsetMods={clearUnsetMods}
-            onClearUnsetModsChanged={handleClearUnsetModsChanged}
-          />
-        </LoadoutEditSection>
-        <LoadoutEditSection
-          title={artifactTitle}
-          titleInfo={t('Loadouts.ArtifactUnlocksDesc')}
-          className={styles.mods}
-          onClear={handleClearArtifactUnlocks}
+      <LoadoutEditSection
+        title={t('Loadouts.Mods')}
+        className={clsx(styles.section, styles.mods)}
+        onClear={handleClearMods}
+        onSyncFromEquipped={missingSockets ? undefined : handleSyncModsFromEquipped}
+      >
+        <LoadoutMods
+          loadout={loadout}
+          storeId={store.id}
+          allMods={allMods}
+          onUpdateMods={handleUpdateMods}
+          onRemoveMod={handleRemoveMod}
+          clearUnsetMods={clearUnsetMods}
+          onClearUnsetModsChanged={handleClearUnsetModsChanged}
+        />
+      </LoadoutEditSection>
+      <LoadoutEditSection
+        title={artifactTitle}
+        titleInfo={t('Loadouts.ArtifactUnlocksDesc')}
+        className={styles.section}
+        onClear={handleClearArtifactUnlocks}
+        onSyncFromEquipped={profileResponse ? handleSyncArtifactUnlocksFromEquipped : undefined}
+      >
+        <LoadoutArtifactUnlocks
+          loadout={loadout}
+          storeId={store.id}
+          onRemoveMod={handleRemoveArtifactUnlock}
           onSyncFromEquipped={profileResponse ? handleSyncArtifactUnlocksFromEquipped : undefined}
-        >
-          <LoadoutArtifactUnlocks
-            loadout={loadout}
-            storeId={store.id}
-            onRemoveMod={handleRemoveArtifactUnlock}
-            onSyncFromEquipped={profileResponse ? handleSyncArtifactUnlocksFromEquipped : undefined}
-          />
-        </LoadoutEditSection>
-      </div>
+        />
+      </LoadoutEditSection>
     </div>
   );
 }

--- a/src/app/loadout/loadout-ui/LoadoutMods.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutMods.m.scss
@@ -1,9 +1,5 @@
 @use '../../variables.scss' as *;
 
-.mods {
-  flex: 1;
-}
-
 .modsGrid {
   --item-icon-size: calc(0.8 * var(--item-size));
   min-width: calc(5 * var(--item-icon-size) + 4 * var(--item-margin));

--- a/src/app/loadout/loadout-ui/LoadoutMods.m.scss.d.ts
+++ b/src/app/loadout/loadout-ui/LoadoutMods.m.scss.d.ts
@@ -4,7 +4,6 @@ interface CssExports {
   'artifactUnlock': string;
   'buttons': string;
   'missingItem': string;
-  'mods': string;
   'modsGrid': string;
   'modsPlaceholder': string;
   'pickModButton': string;

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -103,7 +103,7 @@ export const LoadoutMods = memo(function LoadoutMods({
   }
 
   return (
-    <div className={styles.mods}>
+    <div>
       <div className={styles.modsGrid}>
         {allMods.map((mod) => (
           <LoadoutModMemo
@@ -185,11 +185,13 @@ export const LoadoutMods = memo(function LoadoutMods({
 export const LoadoutArtifactUnlocks = memo(function LoadoutArtifactUnlocks({
   loadout,
   storeId,
+  className,
   onRemoveMod,
   onSyncFromEquipped,
 }: {
   loadout: Loadout;
   storeId: string;
+  className?: string;
   onRemoveMod?: (mod: number) => void;
   onSyncFromEquipped?: () => void;
 }) {
@@ -209,29 +211,37 @@ export const LoadoutArtifactUnlocks = memo(function LoadoutArtifactUnlocks({
     (mod: ResolvedLoadoutMod) => onRemoveMod!(mod.originalModHash),
     [onRemoveMod]
   );
+  const artifactTitle = loadout.parameters?.artifactUnlocks
+    ? t('Loadouts.ArtifactUnlocksWithSeason', {
+        seasonNumber: loadout.parameters?.artifactUnlocks?.seasonNumber,
+      })
+    : t('Loadouts.ArtifactUnlocks');
 
   return (
-    <div className={styles.mods}>
+    <div className={className}>
       {loadoutArtifactMods.length > 0 ? (
-        <div className={styles.modsGrid}>
-          {loadoutArtifactMods.map((mod) => {
-            const unlocked = unlockedArtifactMods?.unlockedItemHashes.includes(
-              mod.resolvedMod.hash
-            );
-            return (
-              <LoadoutModMemo
-                key={mod.resolvedMod.hash}
-                mod={mod}
-                className={clsx({
-                  [styles.artifactUnlock]: unlocked,
-                  [styles.missingItem]: !unlocked,
-                })}
-                classType={loadout.classType}
-                onRemoveMod={onRemoveMod ? handleRemoveMod : undefined}
-              />
-            );
-          })}
-        </div>
+        <>
+          {!onRemoveMod && <h3>{artifactTitle}</h3>}
+          <div className={styles.modsGrid}>
+            {loadoutArtifactMods.map((mod) => {
+              const unlocked = unlockedArtifactMods?.unlockedItemHashes.includes(
+                mod.resolvedMod.hash
+              );
+              return (
+                <LoadoutModMemo
+                  key={mod.resolvedMod.hash}
+                  mod={mod}
+                  className={clsx({
+                    [styles.artifactUnlock]: unlocked,
+                    [styles.missingItem]: !unlocked,
+                  })}
+                  classType={loadout.classType}
+                  onRemoveMod={onRemoveMod ? handleRemoveMod : undefined}
+                />
+              );
+            })}
+          </div>
+        </>
       ) : (
         onSyncFromEquipped && (
           <div className={styles.buttons}>


### PR DESCRIPTION
* Restore mod lists to full width in loadout view
* Slightly smaller artifact mods in loadout view, plus the seasonal header.
* In the edit sheet, break the mods into distinct sections so it's clearer they can be edited via the dots menu.

<img width="1154" alt="Screenshot 2023-04-01 at 4 02 48 PM" src="https://user-images.githubusercontent.com/313208/229319928-e01d2e31-5b5c-4eba-9ca7-3d7ec08842eb.png">
<img width="975" alt="Screenshot 2023-04-01 at 4 02 53 PM" src="https://user-images.githubusercontent.com/313208/229319931-2ed2ec2a-e3e0-40f2-bd94-89c1b4c0db42.png">
