### PR TITLE
Remove syntax workarounds for TS/VS Code bugs

### DIFF
--- a/src/app/utils/undo-redo-history.ts
+++ b/src/app/utils/undo-redo-history.ts
@@ -76,13 +76,8 @@ export function useHistory<S>(initialState: S): {
   canUndo: boolean;
   canRedo: boolean;
 } {
-  // Needed for type checking, TS otherwise seems to get lost
-  // in weaker overloads of `useReducer`?
-  // FIXME this should be `useReducer(historyReducer<S>, ...)`
-  // but VS Code throws spurious errors for that construct (see DIM#8819)
-  const reducer: typeof historyReducer<S> = historyReducer;
   const [{ state, undoStack, redoStack }, dispatch] = useReducer(
-    reducer,
+    historyReducer<S>,
     initialState,
     initializer
   );


### PR DESCRIPTION
This was fixed in TS 5.0 (https://github.com/microsoft/TypeScript/pull/52373#issuecomment-1447484101)