### PR TITLE
Properly forbid bringing up Armory from ItemPopup when noLink is set

### DIFF
--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -5,7 +5,6 @@
   line-height: 17px;
   letter-spacing: -0.02em;
   padding: 10px;
-  cursor: pointer;
 
   background-color: #555;
   color: #eee;
@@ -19,6 +18,7 @@
     a {
       text-decoration: underline;
     }
+    cursor: pointer;
   }
 }
 

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -37,7 +37,7 @@ export default function ItemPopupHeader({
 
   const showElementIcon = Boolean(item.element);
 
-  const linkToArmory = item.destinyVersion === 2;
+  const linkToArmory = !noLink && item.destinyVersion === 2;
 
   return (
     <div
@@ -48,7 +48,7 @@ export default function ItemPopupHeader({
       })}
       onClick={linkToArmory ? () => setShowArmory(true) : undefined}
     >
-      {noLink || item.destinyVersion === 1 ? (
+      {!linkToArmory ? (
         <span className={styles.title}>{item.name}</span>
       ) : (
         <a className={styles.title}>


### PR DESCRIPTION
There wasn't an underline in item popups spawned from the Armory, but the cursor still turned into a pointer and the Armory could still be brought up again.