### PR TITLE
Use a stable temporary ID for equipped loadout

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -863,6 +863,9 @@ function deleteLoadout(state: DimApiState, loadoutId: string) {
 }
 
 function updateLoadout(state: DimApiState, loadout: DimLoadout, account: DestinyAccount) {
+  if (loadout.id === 'equipped') {
+    throw new Error('You have to change the ID before saving the equipped loadout');
+  }
   return produce(state, (draft) => {
     const profileKey = makeProfileKey(account.membershipId, account.destinyVersion);
     const profile = ensureProfile(draft, profileKey);

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -192,6 +192,8 @@ export function newLoadoutFromEquipped(
     return item;
   });
   const loadout = newLoadout(name, loadoutItems, dimStore.classType);
+  // Choose a stable ID
+  loadout.id = 'equipped';
   const mods = items.flatMap((i) => extractArmorModHashes(i));
   if (mods.length) {
     loadout.parameters = {


### PR DESCRIPTION
This prevents the equipped loadout from being considered "new" every time it updates. This is another way of fixing sheets that disappear every time inventory refreshes.