### PR TITLE
In-game loadouts: Save as DIM, Share

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -717,6 +717,7 @@
     "RestoreAllItems": "All Items",
     "Save": "Save",
     "SaveLoadout": "Save Loadout",
+    "SaveAsDIM": "Save as DIM Loadout",
     "SaveAsNew": "Save as New",
     "SaveAsNewTooltip": "Keep the original loadout and save this as a new loadout",
     "SaveDisabled": {

--- a/src/app/loadout-drawer/loadout-type-converters.ts
+++ b/src/app/loadout-drawer/loadout-type-converters.ts
@@ -2,20 +2,29 @@ import {
   AssumeArmorMasterwork,
   Loadout,
   LoadoutItem,
+  LoadoutParameters,
   UpgradeSpendTier,
 } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { DimItem } from 'app/inventory/item-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { UNSET_PLUG_HASH } from 'app/loadout/known-values';
 import { emptyObject } from 'app/utils/empty';
-import { DestinyLoadoutComponent, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
+import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import {
+  DestinyClass,
+  DestinyLoadoutComponent,
+  DestinyProfileResponse,
+} from 'bungie-api-ts/destiny2';
 import { emptyPlugHashes } from 'data/d2/empty-plug-hashes';
+import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import {
   Loadout as DimLoadout,
   LoadoutItem as DimLoadoutItem,
   InGameLoadout,
 } from './loadout-types';
+import { newLoadout, potentialLoadoutItemsByItemId } from './loadout-utils';
 
 /**
  * DIM API stores loadouts in a new format, but the app still uses the old format everywhere. These functions convert
@@ -178,6 +187,74 @@ function convertDestinyLoadoutComponentToInGameLoadout(
     icon,
     id: `ingame-${characterId}-${index}`,
   };
+}
+
+export function convertInGameLoadoutToDimLoadout(
+  inGameLoadout: InGameLoadout,
+  classType: DestinyClass,
+  allItems: DimItem[]
+) {
+  const armorMods: number[] = [];
+  const modsByBucket: LoadoutParameters['modsByBucket'] = {};
+
+  const loadoutItems = _.compact(
+    inGameLoadout.items.map((inGameItem) => {
+      if (inGameItem.itemInstanceId === '0') {
+        return;
+      }
+
+      const matchingItem = potentialLoadoutItemsByItemId(allItems)[inGameItem.itemInstanceId];
+      if (!matchingItem) {
+        return;
+      }
+
+      if (matchingItem.bucket.inArmor) {
+        const armorModSockets = getSocketsByCategoryHash(
+          matchingItem.sockets,
+          SocketCategoryHashes.ArmorMods
+        );
+        const fashionModSockets = getSocketsByCategoryHash(
+          matchingItem.sockets,
+          SocketCategoryHashes.ArmorCosmetics
+        );
+        for (let i = 0; i < inGameItem.plugItemHashes.length; i++) {
+          const plugHash = inGameItem.plugItemHashes[i];
+          if (plugHash === UNSET_PLUG_HASH) {
+            continue;
+          }
+          if (!emptyPlugHashes.has(plugHash) && armorModSockets.some((s) => s.socketIndex === i)) {
+            armorMods.push(plugHash);
+          } else if (fashionModSockets.some((s) => s.socketIndex === i)) {
+            // For fashion, we do record the emply plug hashes
+            (modsByBucket[matchingItem.bucket.hash] ||= []).push(plugHash);
+          }
+        }
+      }
+
+      const socketOverrides =
+        // TODO: Pretty soon we can capture all the socket overrides, but for now only copy over subclass config.
+        matchingItem.bucket.hash === BucketHashes.Subclass
+          ? convertInGameLoadoutPlugItemHashesToSocketOverrides(inGameItem.plugItemHashes)
+          : undefined;
+
+      const loadoutItem: DimLoadoutItem = {
+        id: inGameItem.itemInstanceId,
+        hash: matchingItem.hash,
+        socketOverrides,
+        equip: true,
+        amount: 1,
+      };
+
+      return loadoutItem;
+    })
+  );
+
+  const loadout = newLoadout(inGameLoadout.name, loadoutItems, classType);
+  loadout.parameters = {
+    mods: armorMods,
+    modsByBucket,
+  };
+  return loadout;
 }
 
 /**

--- a/src/app/loadout-drawer/loadout-type-converters.ts
+++ b/src/app/loadout-drawer/loadout-type-converters.ts
@@ -5,8 +5,11 @@ import {
   UpgradeSpendTier,
 } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { SocketOverrides } from 'app/inventory/store/override-sockets';
+import { UNSET_PLUG_HASH } from 'app/loadout/known-values';
 import { emptyObject } from 'app/utils/empty';
 import { DestinyLoadoutComponent, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
+import { emptyPlugHashes } from 'data/d2/empty-plug-hashes';
 import _ from 'lodash';
 import {
   Loadout as DimLoadout,
@@ -175,4 +178,21 @@ function convertDestinyLoadoutComponentToInGameLoadout(
     icon,
     id: `ingame-${characterId}-${index}`,
   };
+}
+
+/**
+ * In game loadouts' plug item hashes are a list of plug items, one per socket index. We strip
+ * out unset or empty plugs when converting to DIM's SocketOverrides, which are only set for sockets
+ * that should be modified.
+ */
+export function convertInGameLoadoutPlugItemHashesToSocketOverrides(
+  plugItemHashes: number[]
+): SocketOverrides {
+  return Object.fromEntries(
+    _.compact(
+      plugItemHashes.map((plugHash, i) =>
+        plugHash !== UNSET_PLUG_HASH && !emptyPlugHashes.has(plugHash) ? [i, plugHash] : undefined
+      )
+    )
+  );
 }

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -177,6 +177,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
               loadout={loadout}
               store={selectedStore}
               onEdit={setEditingInGameLoadout}
+              onShare={setSharedLoadout}
             />
           ) : (
             <LoadoutRow

--- a/src/app/loadout/ingame/InGameLoadoutView.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutView.tsx
@@ -1,8 +1,9 @@
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import DraggableInventoryItem from 'app/inventory/DraggableInventoryItem';
-import { DimItem } from 'app/inventory/item-types';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
+import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
+import { convertInGameLoadoutPlugItemHashesToSocketOverrides } from 'app/loadout-drawer/loadout-type-converters';
 import { InGameLoadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getLight } from 'app/loadout-drawer/loadout-utils';
 import clsx from 'clsx';
@@ -10,9 +11,9 @@ import { t } from 'i18next';
 import _ from 'lodash';
 import { ReactNode } from 'react';
 import LoadoutSubclassSection from '../loadout-ui/LoadoutSubclassSection';
-import { useItemsFromInGameLoadout } from './ingame-loadout-utils';
 import InGameLoadoutIcon from './InGameLoadoutIcon';
 import styles from './InGameLoadoutView.m.scss';
+import { useItemsFromInGameLoadout } from './ingame-loadout-utils';
 
 const categoryStyles = {
   Weapons: styles.categoryWeapons,
@@ -38,6 +39,7 @@ export default function InGameLoadoutView({
   const power = loadoutPower(store, categories);
 
   const subclassItem = categories['General']?.[0];
+  const subclassInGameLoadoutItem = loadout.items.find((i) => i.itemInstanceId === subclassItem.id);
   const subclass: ResolvedLoadoutItem | undefined = subclassItem && {
     item: subclassItem,
     loadoutItem: {
@@ -45,8 +47,11 @@ export default function InGameLoadoutView({
       id: subclassItem.id,
       amount: 1,
       equip: true,
-      socketOverrides: loadout.items.find((i) => i.itemInstanceId === subclassItem.id)
-        ?.plugItemHashes,
+      socketOverrides:
+        subclassInGameLoadoutItem &&
+        convertInGameLoadoutPlugItemHashesToSocketOverrides(
+          subclassInGameLoadoutItem.plugItemHashes
+        ),
     },
   };
 

--- a/src/app/loadout/ingame/ingame-loadout-apply.ts
+++ b/src/app/loadout/ingame/ingame-loadout-apply.ts
@@ -9,7 +9,11 @@ import { t } from 'app/i18next-t';
 import { inGameLoadoutNotification } from 'app/inventory/MoveNotifications';
 import { itemMoved } from 'app/inventory/actions';
 import { updateCharacters } from 'app/inventory/d2-stores';
-import { allItemsSelector, storesSelector } from 'app/inventory/selectors';
+import {
+  allItemsSelector,
+  createItemContextSelector,
+  storesSelector,
+} from 'app/inventory/selectors';
 import { getStore } from 'app/inventory/stores-helpers';
 import { InGameLoadout } from 'app/loadout-drawer/loadout-types';
 import { inGameLoadoutItemsFromEquipped } from 'app/loadout-drawer/loadout-utils';
@@ -21,6 +25,7 @@ import { DimError } from 'app/utils/dim-error';
 import { reportException } from 'app/utils/exceptions';
 import { errorLog } from 'app/utils/log';
 import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
+import { useSelector } from 'react-redux';
 import { inGameLoadoutDeleted, inGameLoadoutUpdated } from './actions';
 import { getItemsFromInGameLoadout } from './ingame-loadout-utils';
 
@@ -29,6 +34,7 @@ import { getItemsFromInGameLoadout } from './ingame-loadout-utils';
  */
 export function applyInGameLoadout(loadout: InGameLoadout): ThunkResult {
   return async (dispatch, getState) => {
+    const itemCreationContext = useSelector(createItemContextSelector);
     const account = currentAccountSelector(getState())!;
     const stores = storesSelector(getState());
     const target = getStore(stores, loadout.characterId)!;
@@ -41,7 +47,11 @@ export function applyInGameLoadout(loadout: InGameLoadout): ThunkResult {
       await applyPromise;
 
       // Find each item, and update it to be equipped!
-      const items = getItemsFromInGameLoadout(loadout.items, allItemsSelector(getState()));
+      const items = getItemsFromInGameLoadout(
+        itemCreationContext,
+        loadout.items,
+        allItemsSelector(getState())
+      );
 
       for (const item of items) {
         // Update items to be equipped

--- a/src/app/loadout/ingame/ingame-loadout-utils.ts
+++ b/src/app/loadout/ingame/ingame-loadout-utils.ts
@@ -1,5 +1,8 @@
 import { DimItem } from 'app/inventory/item-types';
-import { allItemsSelector } from 'app/inventory/selectors';
+import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
+import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
+import { applySocketOverrides } from 'app/inventory/store/override-sockets';
+import { convertInGameLoadoutPlugItemHashesToSocketOverrides } from 'app/loadout-drawer/loadout-type-converters';
 import { InGameLoadout } from 'app/loadout-drawer/loadout-types';
 import { potentialLoadoutItemsByItemId } from 'app/loadout-drawer/loadout-utils';
 import { DestinyLoadoutItemComponent } from 'bungie-api-ts/destiny2';
@@ -13,16 +16,26 @@ import { useSelector } from 'react-redux';
  * TODO: These aren't ResolvedLoadoutItems because we don't know how D2 will handle missing items yet.
  */
 export function getItemsFromInGameLoadout(
+  itemCreationContext: ItemCreationContext,
   loadoutItems: DestinyLoadoutItemComponent[],
   allItems: DimItem[]
 ): DimItem[] {
   // TODO: apply socket overrides once we know what those are?
   return _.compact(
-    loadoutItems.map((li) =>
-      li.itemInstanceId !== '0'
-        ? potentialLoadoutItemsByItemId(allItems)[li.itemInstanceId]
-        : undefined
-    )
+    loadoutItems.map((li) => {
+      const realItem =
+        li.itemInstanceId !== '0'
+          ? potentialLoadoutItemsByItemId(allItems)[li.itemInstanceId]
+          : undefined;
+      if (realItem) {
+        return applySocketOverrides(
+          itemCreationContext,
+          realItem,
+          convertInGameLoadoutPlugItemHashesToSocketOverrides(li.plugItemHashes)
+        );
+      }
+      return realItem;
+    })
   );
 }
 
@@ -31,8 +44,9 @@ export function getItemsFromInGameLoadout(
  */
 export function useItemsFromInGameLoadout(loadout: InGameLoadout) {
   const allItems = useSelector(allItemsSelector);
+  const itemCreationContext = useSelector(createItemContextSelector);
   return useMemo(
-    () => getItemsFromInGameLoadout(loadout.items, allItems),
-    [loadout.items, allItems]
+    () => getItemsFromInGameLoadout(itemCreationContext, loadout.items, allItems),
+    [itemCreationContext, loadout.items, allItems]
   );
 }

--- a/src/app/stream-deck/async-module.ts
+++ b/src/app/stream-deck/async-module.ts
@@ -3,7 +3,11 @@
 // serialize the data and send it if connected
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import { allItemsSelector, currentStoreSelector } from 'app/inventory/selectors';
+import {
+  allItemsSelector,
+  createItemContextSelector,
+  currentStoreSelector,
+} from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { hideItemPopup } from 'app/item-popup/item-popup';
 import { LoadoutItem } from 'app/loadout-drawer/loadout-types';
@@ -110,7 +114,8 @@ function findSubClass(items: LoadoutItem[], state: RootState) {
 
 function findSubClassInGame(items: DestinyLoadoutItemComponent[], state: RootState) {
   const allItems = allItemsSelector(state);
-  const mappedItems = getItemsFromInGameLoadout(items, allItems);
+  const itemCreationContext = createItemContextSelector(state);
+  const mappedItems = getItemsFromInGameLoadout(itemCreationContext, items, allItems);
   const categories = _.groupBy(mappedItems, (item) => item.bucket.sort);
   const subclassItem = categories['General']?.[0];
   return subclassItem?.icon;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -723,6 +723,7 @@
     "Redo": "Redo",
     "RestoreAllItems": "All Items",
     "Save": "Save",
+    "SaveAsDIM": "Save as DIM Loadout",
     "SaveAsNew": "Save as New",
     "SaveAsNewTooltip": "Keep the original loadout and save this as a new loadout",
     "SaveDisabled": {


### PR DESCRIPTION
This implements a conversion from ingame loadout to DIM loadout, allowing you to both save it and share it. 

* I'm not copying socket overrides for weapons even though DIM loadouts could handle it, as I don't really have display/editing for that yet. Soon.
* I included a direct share for convenience, but I could be convinced you have to save as DIM first, then share, so you get a chance to give it a decent name and description. That said, we allow direct shares of the Equipped loadout too, and people do that all the time (23% of all shared loadouts are named "Equipped").
* I also applied socket overrides to the resolved inventory item in In Game Loadouts, which makes their ornament and selected perks show up correctly.