### PR TITLE
identifier editing - default to selected slot identifiers

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -406,7 +406,7 @@
     "DeletedBody": "Cleared the in-game loadout at slot {{index}}",
     "DeleteFailed": "Failed to delete loadout",
     "Save": "Update Loadout",
-    "Replace": "Replace Loadout",
+    "Replace": "Replace Loadout  {{index}}",
     "SnapshotFailed": "Failed to snapshot equipped loadout"
   },
   "Inventory": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -396,7 +396,7 @@
     "EditFailed": "Failed to update loadout",
     "EditTitle": "Edit Loadout Name and Icon",
     "LoadoutSlotNum": "Slot {{index}}",
-    "Replace": "Replace Loadout",
+    "Replace": "Replace Loadout  {{index}}",
     "Save": "Update Loadout",
     "SnapshotFailed": "Failed to snapshot equipped loadout"
   },


### PR DESCRIPTION
clicking a slot defaults to overwriting with that slot's same identifiers
(unless you have been already clicking around in the identifiers section)

also the Replace button explicitly states what slot it will be overwriting.

this seems to work exactly as intended but if it needs a useCallback, would love to have a chat later, about what and why