### PR TITLE
Wrap potentially-long actions in a screen wake lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "@testing-library/react": "^14.0.0",
     "@types/body-scroll-lock": "^3.1.0",
     "@types/dialog-polyfill": "^0.5.2",
+    "@types/dom-chromium-installation-events": "^101.0.0",
+    "@types/dom-screen-wake-lock": "^1.0.1",
     "@types/generate-json-webpack-plugin": "^0.3.4",
     "@types/jest": "^29.0.0",
     "@types/lodash": "^4.14.0",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -22,10 +22,6 @@ interface Window {
   skipWaiting(): void;
 }
 
-interface WindowEventMap {
-  beforeinstallprompt: BeforeInstallPromptEvent;
-}
-
 interface Navigator {
   /** iOS-only: True if the app is running in installed mode */
   standalone?: boolean;
@@ -50,36 +46,6 @@ interface MeasureMemoryResult {
     ];
     types: string[];
   }[];
-}
-
-/**
- * The BeforeInstallPromptEvent is fired at the Window.onbeforeinstallprompt handler
- * before a user is prompted to "install" a web site to a home screen on mobile.
- *
- * Only supported on Chrome and Android Webview.
- */
-interface BeforeInstallPromptEvent extends Event {
-  /**
-   * Returns an array of DOMString items containing the platforms on which the event was dispatched.
-   * This is provided for user agents that want to present a choice of versions to the user such as,
-   * for example, "web" or "play" which would allow the user to chose between a web version or
-   * an Android version.
-   */
-  readonly platforms: string[];
-
-  /**
-   * Returns a Promise that resolves to a DOMString containing either "accepted" or "dismissed".
-   */
-  readonly userChoice: Promise<{
-    outcome: 'accepted' | 'dismissed';
-    platform: string;
-  }>;
-
-  /**
-   * Allows a developer to show the install prompt at a time of their own choosing.
-   * This method returns a Promise.
-   */
-  prompt(): Promise<void>;
 }
 
 declare module '*/CHANGELOG.md' {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,6 +1862,16 @@
   dependencies:
     dialog-polyfill "*"
 
+"@types/dom-chromium-installation-events@^101.0.0":
+  version "101.0.0"
+  resolved "https://registry.yarnpkg.com/@types/dom-chromium-installation-events/-/dom-chromium-installation-events-101.0.0.tgz#3dc20e4a1b4f15f4f5d32881677ce24f1ea7d6eb"
+  integrity sha512-tHDvmXhv/UDE2r/LherlBe/sQ+cV53yG3vd5bY/7t3IsZYzP5Gy6SRFUoFgilR6/SvlFYa+WMJ07F8tettji6Q==
+
+"@types/dom-screen-wake-lock@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dom-screen-wake-lock/-/dom-screen-wake-lock-1.0.1.tgz#8f125f91821d49f51feee95e6db128eb6974aea9"
+  integrity sha512-WJQas3OFGcC8AeMzaa7FwzzbNNfanuV2R12kQYNp4BkUMghsRz5JxJ5RgVhJifhw7t0s6LvRSWZArmKbMDZ+5g==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"


### PR DESCRIPTION
Fixes #9199. This is probably overkill for individual moves but it also applies to pull from postmaster, loadouts, etc.

I think we probably shouldn't acquire a wake lock for farming mode, but I could be convinced.