### PR TITLE
Make power level and store problems reactive

### DIFF
--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -1,10 +1,13 @@
 import type { DimStore, DimTitle } from 'app/inventory/store-types';
+import { powerLevelSelector } from 'app/inventory/store/selectors';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import VaultCapacity from 'app/store-stats/VaultCapacity';
+import { RootState } from 'app/store/types';
 import clsx from 'clsx';
 import { FontGlyphs } from 'data/d2/d2-font-glyphs';
 import { memo } from 'react';
+import { useSelector } from 'react-redux';
 import styles from './CharacterTile.m.scss';
 
 function CharacterEmblem({ store }: { store: DimStore }) {
@@ -18,7 +21,10 @@ const gildedIcon = String.fromCodePoint(FontGlyphs.gilded_title);
  * This is currently being shared between StoreHeading and CharacterTileButton
  */
 export default memo(function CharacterTile({ store }: { store: DimStore }) {
-  const maxTotalPower = Math.floor(store.stats?.maxTotalPower?.value || store.powerLevel);
+  const maxTotalPower = useSelector(
+    (state: RootState) => powerLevelSelector(state, store.id)?.maxTotalPower
+  );
+  const floorTotalPower = Math.floor(maxTotalPower || store.powerLevel);
   const isPhonePortrait = useIsPhonePortrait();
 
   return (
@@ -44,7 +50,7 @@ export default memo(function CharacterTile({ store }: { store: DimStore }) {
                 <AppIcon icon={powerActionIcon} />
                 {store.powerLevel}
               </div>
-              {isPhonePortrait && <div className={styles.maxTotalPower}>/ {maxTotalPower}</div>}
+              {isPhonePortrait && <div className={styles.maxTotalPower}>/ {floorTotalPower}</div>}
             </>
           )}
         </div>

--- a/src/app/gear-power/GearPower.tsx
+++ b/src/app/gear-power/GearPower.tsx
@@ -5,17 +5,17 @@ import { SetFilterButton } from 'app/dim-ui/SetFilterButton';
 import BucketIcon from 'app/dim-ui/svgs/BucketIcon';
 import { t } from 'app/i18next-t';
 import { locateItem } from 'app/inventory/locate-item';
-import { maxLightItemSet } from 'app/loadout-drawer/auto-loadouts';
-import { getLight } from 'app/loadout-drawer/loadout-utils';
+import { powerLevelSelector } from 'app/inventory/store/selectors';
 import { classFilter } from 'app/search/search-filters/known-values';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
+import { RootState } from 'app/store/types';
 import { LookupTable } from 'app/utils/util-types';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { useSelector } from 'react-redux';
 import { useSubscription } from 'use-subscription';
 import Sheet from '../dim-ui/Sheet';
-import { allItemsSelector, storesSelector } from '../inventory/selectors';
+import { storesSelector } from '../inventory/selectors';
 import styles from './GearPower.m.scss';
 import { showGearPower$ } from './gear-power';
 
@@ -32,7 +32,6 @@ const bucketClassNames: LookupTable<BucketHashes, string> = {
 
 export default function GearPower() {
   const stores = useSelector(storesSelector);
-  const allItems = useSelector(allItemsSelector);
   const reset = () => {
     showGearPower$.next(undefined);
   };
@@ -40,14 +39,12 @@ export default function GearPower() {
   const selectedStoreId = useSubscription(showGearPower$);
   const selectedStore = stores.find((s) => s.id === selectedStoreId);
 
-  if (!selectedStore) {
+  const powerLevel = useSelector((state: RootState) => powerLevelSelector(state, selectedStoreId));
+
+  if (!selectedStore || !powerLevel) {
     return null;
   }
 
-  const { unrestricted, equippable } = maxLightItemSet(allItems, selectedStore);
-  const maxBasePower = getLight(selectedStore, unrestricted);
-  const equippableMaxBasePower = getLight(selectedStore, equippable);
-  const powerFloor = Math.floor(maxBasePower);
   const header = (
     <div className={styles.gearPowerHeader}>
       <img src={selectedStore.icon} />
@@ -55,13 +52,16 @@ export default function GearPower() {
         <h1>{selectedStore.name}</h1>
         <h1 className={styles.powerLevel}>
           <AppIcon icon={powerActionIcon} />
-          <FractionalPowerLevel power={maxBasePower} />
+          <FractionalPowerLevel power={powerLevel.maxGearPower} />
         </h1>
       </div>
     </div>
   );
 
-  const exampleItem = equippable.find((i) => i.classType === selectedStore.classType);
+  const exampleItem = powerLevel.highestPowerItems.find(
+    (i) => i.classType === selectedStore.classType
+  );
+  const powerFloor = Math.floor(powerLevel.maxGearPower);
   const classFilterString = exampleItem && classFilter.fromItem!(exampleItem);
   const maxItemsSearchString = classFilterString && `${classFilterString} is:maxpower`;
 
@@ -69,7 +69,7 @@ export default function GearPower() {
     <Sheet onClose={reset} header={header} sheetClassName={styles.gearPowerSheet}>
       <div className={styles.gearPowerSheetContent}>
         <div className={styles.gearGrid}>
-          {unrestricted.map((i) => {
+          {powerLevel.highestPowerItems.map((i) => {
             const powerDiff = (powerFloor - i.power) * -1;
             const diffSymbol = powerDiff >= 0 ? '+' : '';
             const diffClass =
@@ -96,7 +96,7 @@ export default function GearPower() {
             );
           })}
         </div>
-        {selectedStore.stats.maxGearPower?.statProblems?.notOnStore && (
+        {powerLevel.problems.notOnStore && (
           <div className={styles.notes}>
             <AlertIcon /> {t('Loadouts.OnWrongCharacterWarning')}
             {maxItemsSearchString && (
@@ -107,7 +107,7 @@ export default function GearPower() {
             )}
           </div>
         )}
-        {maxBasePower !== equippableMaxBasePower && (
+        {powerLevel.problems.notEquippable && (
           <>
             <div className={styles.footNote}>* {t('Loadouts.EquippableDifferent1')}</div>
             <div className={styles.footNote}>{t('Loadouts.EquippableDifferent2')}</div>

--- a/src/app/inventory/ArtifactXP.tsx
+++ b/src/app/inventory/ArtifactXP.tsx
@@ -5,12 +5,15 @@ import xpIcon from '../../images/xpIcon.svg';
 import styles from './ArtifactXP.m.scss';
 const formatter = new Intl.NumberFormat();
 
-export function ArtifactXP(
-  characterProgress: DestinyCharacterProgressionComponent | undefined,
-  bonusPowerProgressionHash: number | undefined
-) {
+export function ArtifactXP({
+  characterProgress,
+  bonusPowerProgressionHash,
+}: {
+  characterProgress: DestinyCharacterProgressionComponent | undefined;
+  bonusPowerProgressionHash: number | undefined;
+}) {
   if (!bonusPowerProgressionHash) {
-    return;
+    return null;
   }
   const artifactProgress =
     characterProgress?.progressions[bonusPowerProgressionHash] ??
@@ -18,7 +21,7 @@ export function ArtifactXP(
   const { progressToNextLevel, nextLevelAt, level } = artifactProgress;
 
   if (!progressToNextLevel || !nextLevelAt || level === undefined) {
-    return;
+    return null;
   }
   const progressBarStyle = {
     width: percent(progressToNextLevel / nextLevelAt),

--- a/src/app/inventory/ItemPowerSet.tsx
+++ b/src/app/inventory/ItemPowerSet.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import styles from './ItemPowerSet.m.scss';
 import { DimItem } from './item-types';
 
-export function ItemPowerSet(items: DimItem[], powerFloor: number) {
+export function ItemPowerSet({ items, powerFloor }: { items: DimItem[]; powerFloor: number }) {
   let lastSort: string | undefined;
   return (
     <div className={styles.itemPowerSet}>

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -6,36 +6,24 @@ import { getPlatforms } from 'app/accounts/platforms';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { loadClarity } from 'app/clarity/descriptions/loadDescriptions';
 import { customStatsSelector } from 'app/dim-api/selectors';
-import { t } from 'app/i18next-t';
-import { maxLightItemSet } from 'app/loadout-drawer/auto-loadouts';
 import { processInGameLoadouts } from 'app/loadout-drawer/loadout-type-converters';
 import { inGameLoadoutLoaded } from 'app/loadout/ingame/actions';
 import { loadCoreSettings } from 'app/manifest/actions';
 import { d2ManifestSelector, manifestSelector } from 'app/manifest/selectors';
-import { getCharacterProgressions } from 'app/progress/selectors';
 import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { DimError } from 'app/utils/dim-error';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
-import {
-  DestinyCharacterProgressionComponent,
-  DestinyItemComponent,
-  DestinyProfileResponse,
-} from 'bungie-api-ts/destiny2';
-import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
-import helmetIcon from '../../../destiny-icons/armor_types/helmet.svg';
-import xpIcon from '../../images/xpIcon.svg';
+import { DestinyItemComponent, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
+import { BucketHashes } from 'data/d2/generated-enums';
 import { getCharacters as d1GetCharacters } from '../bungie-api/destiny1-api';
 import { getCharacters, getStores } from '../bungie-api/destiny2-api';
 import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions';
 import { bungieNetPath } from '../dim-ui/BungieImage';
-import { getLight } from '../loadout-drawer/loadout-utils';
 import { showNotification } from '../notifications/notifications';
 import { loadingTracker } from '../shell/loading-tracker';
 import { reportException } from '../utils/exceptions';
-import { ArtifactXP } from './ArtifactXP';
-import { ItemPowerSet } from './ItemPowerSet';
 import {
   CharacterInfo,
   charactersUpdated,
@@ -46,18 +34,12 @@ import {
   update,
 } from './actions';
 import { cleanInfos } from './dim-item-info';
-import { DimItem } from './item-types';
 import { d2BucketsSelector, storesLoadedSelector, storesSelector } from './selectors';
-import { DimCharacterStat, DimStore } from './store-types';
-import {
-  getBucketsWithClassifiedItems,
-  getCharacterStatsData as getD1CharacterStatsData,
-  hasAffectingClassified,
-} from './store/character-utils';
+import { DimStore } from './store-types';
+import { getCharacterStatsData as getD1CharacterStatsData } from './store/character-utils';
 import { ItemCreationContext, processItems } from './store/d2-item-factory';
 import { getCharacterStatsData, makeCharacter, makeVault } from './store/d2-store-factory';
 import { resetItemIndexGenerator } from './store/item-index';
-import { getArtifactBonus } from './stores-helpers';
 
 /**
  * Update the high level character information for all the stores
@@ -360,7 +342,7 @@ export function buildStores(
 ): DimStore[] {
   // TODO: components may be hidden (privacy)
 
-  const { defs, profileResponse } = itemCreationContext;
+  const { profileResponse } = itemCreationContext;
 
   if (
     !profileResponse.profileInventory.data ||
@@ -387,24 +369,6 @@ export function buildStores(
   processSpan?.finish();
 
   const stores = [...characters, vault];
-
-  const allItems = stores.flatMap((s) => s.items);
-  const bucketsWithClassifieds = getBucketsWithClassifiedItems(allItems);
-  const characterProgress = getCharacterProgressions(profileResponse);
-
-  for (const s of stores) {
-    updateBasePower(
-      allItems,
-      s,
-      defs,
-      characterProgress,
-      // optional chaining here accounts for an edge-case, possible, but type-unadvertised,
-      // missing artifact power bonus. please keep this here.
-      profileResponse.profileProgression?.data?.seasonalArtifact?.powerBonusProgression
-        ?.progressionHash,
-      bucketsWithClassifieds
-    );
-  }
 
   return stores;
 }
@@ -488,74 +452,4 @@ function findLastPlayedDate(profileInfo: DestinyProfileResponse) {
     return new Date(dateLastPlayed);
   }
   return new Date(0);
-}
-
-export const fakeCharacterStatHashes = {
-  maxGearPower: -3,
-  powerBonus: -2,
-  maxTotalPower: -1,
-};
-
-// Add a fake stat for "max base power"
-function updateBasePower(
-  allItems: DimItem[],
-  store: DimStore,
-  defs: D2ManifestDefinitions,
-  characterProgress: DestinyCharacterProgressionComponent | undefined,
-  bonusPowerProgressionHash: number | undefined,
-  // calculate this once in the parent function then use it for each store this function assesses
-  bucketsWithClassifieds: Set<number>
-) {
-  if (!store.isVault) {
-    const def = defs.Stat.get(StatHashes.Power);
-    const { equippable, unrestricted } = maxLightItemSet(allItems, store);
-
-    // ALL WEAPONS count toward your drops. armor on another character doesn't count.
-    // (maybe just because it's on a different class? who knows. can't test.)
-    const dropPowerItemSet = maxLightItemSet(
-      allItems.filter((i) => i.bucket.inWeapons || i.owner === 'vault' || i.owner === store.id),
-      store
-    ).unrestricted;
-    const dropPowerLevel = getLight(store, dropPowerItemSet);
-
-    const unrestrictedMaxGearPower = getLight(store, unrestricted);
-    const unrestrictedPowerFloor = Math.floor(unrestrictedMaxGearPower);
-    const equippableMaxGearPower = getLight(store, equippable);
-
-    const statProblems: DimCharacterStat['statProblems'] = {};
-
-    statProblems.notEquippable = unrestrictedMaxGearPower !== equippableMaxGearPower;
-    statProblems.notOnStore = dropPowerLevel !== unrestrictedMaxGearPower;
-
-    statProblems.hasClassified = hasAffectingClassified(unrestricted, bucketsWithClassifieds);
-    store.stats.maxGearPower = {
-      hash: fakeCharacterStatHashes.maxGearPower,
-      name: t('Stats.MaxGearPowerAll'),
-      // used to be t('Stats.MaxGearPower'), a translation i don't want to lose yet
-      statProblems,
-      description: '',
-      richTooltip: ItemPowerSet(unrestricted, unrestrictedPowerFloor),
-      value: unrestrictedMaxGearPower,
-      icon: helmetIcon,
-    };
-
-    const artifactPower = getArtifactBonus(store);
-    store.stats.powerModifier = {
-      hash: fakeCharacterStatHashes.powerBonus,
-      name: t('Stats.PowerModifier'),
-      description: '',
-      richTooltip: ArtifactXP(characterProgress, bonusPowerProgressionHash),
-      value: artifactPower,
-      icon: xpIcon,
-    };
-
-    store.stats.maxTotalPower = {
-      hash: fakeCharacterStatHashes.maxTotalPower,
-      name: t('Stats.MaxTotalPower'),
-      statProblems,
-      description: '',
-      value: unrestrictedMaxGearPower + artifactPower,
-      icon: bungieNetPath(def.displayProperties.icon),
-    };
-  }
 }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -10,7 +10,6 @@ import {
   DestinyDisplayPropertiesDefinition,
   DestinyProgression,
 } from 'bungie-api-ts/destiny2';
-import React from 'react';
 import { D1Item, DimItem } from './item-types';
 
 /**
@@ -64,18 +63,12 @@ export interface DimStore<Item = DimItem> {
   level: number;
   /** Progress towards the next level (or "prestige level") */
   percentToNextLevel: number;
-  /** Power/light level. */
+  /** The Bungie.net-reported power level */
   powerLevel: number;
   /** The record corresponding to the currently equipped Title. */
   titleInfo?: DimTitle;
   /** Character stats. */
   stats: {
-    /** average of your highest simultaneously equippable gear with bonus fields for rich tooltip content and equippability warnings */
-    maxGearPower?: DimCharacterStat;
-    /** currently represents the power level bonus provided by the Seasonal Artifact */
-    powerModifier?: DimCharacterStat;
-    /** maxGearPower + powerModifier. the highest PL you can get your inventory screen to show */
-    maxTotalPower?: DimCharacterStat;
     [hash: number]: DimCharacterStat;
   };
   /** Did any of the items in the last inventory build fail? */
@@ -108,19 +101,6 @@ export interface DimCharacterStat {
 
   /** The localized description of the stat. */
   description: string;
-
-  /** maxGearPower and maxTotalPower can come with various caveats */
-  statProblems?: {
-    /** this stat may be inaccurate because it relies on classified items */
-    hasClassified?: boolean;
-    /** mutually excluded exotics are included in the max possible power */
-    notEquippable?: boolean;
-    /** this character is in danger of dropping at a worse Power Level! another character is holding their best item(s) */
-    notOnStore?: boolean;
-  };
-
-  /** additional rich content available to display in a stat's tooltip */
-  richTooltip?: React.ReactChild;
 
   /** A localized description of this stat's effect. */
   effect?: string;

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -1,12 +1,10 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
 import { D1CharacterResponse } from 'app/destiny1/d1-manifest-types';
-import { powerLevelByKeyword } from 'app/search/d2-known-values';
 import { warnLog } from 'app/utils/log';
 import { StatHashes } from 'data/d2/generated-enums';
 import disciplineIcon from 'images/discipline.png';
 import intellectIcon from 'images/intellect.png';
 import strengthIcon from 'images/strength.png';
-import { DimItem } from '../item-types';
 import { DimCharacterStat } from '../store-types';
 
 // Cooldowns
@@ -184,39 +182,4 @@ function getAbilityCooldown(subclass: number, ability: string, tier: number) {
     default:
       return '-:--';
   }
-}
-
-const pinnacleCap = powerLevelByKeyword.pinnaclecap;
-
-/**
- * Does this store (character) have any classified items that might affect their power level?
- * Things to consider:
- * - Classified items don't always lack a power level.
- * - If a char has an equippable item at pinnacle cap in a particular slot,
- *   who cares if there's a classified item in that slot? Not like it's higher.
- *
- * This relies on a precalculated set generated from allItems, using getBucketsWithClassifiedItems.
- */
-export function hasAffectingClassified(
-  unrestrictedMaxLightGear: DimItem[],
-  bucketsWithClassifieds: Set<number>
-) {
-  return unrestrictedMaxLightGear.some(
-    (i) =>
-      // isn't pinnacle cap
-      i.power !== pinnacleCap &&
-      // and shares a bucket with a classified item (which might be higher power)
-      bucketsWithClassifieds.has(i.bucket.hash)
-  );
-}
-
-/** figures out which buckets contain classified items */
-export function getBucketsWithClassifiedItems(allItems: DimItem[]) {
-  const bucketsWithClassifieds = new Set<number>();
-  for (const i of allItems) {
-    if (i.classified && !i.power && (i.location.inWeapons || i.location.inArmor)) {
-      bucketsWithClassifieds.add(i.bucket.hash);
-    }
-  }
-  return bucketsWithClassifieds;
 }

--- a/src/app/inventory/store/selectors.ts
+++ b/src/app/inventory/store/selectors.ts
@@ -114,8 +114,5 @@ const allPowerLevelsSelector = createSelector(
   }
 );
 
-export const powerLevelSelector = createSelector(
-  allPowerLevelsSelector,
-  (_state: RootState, storeId?: string) => storeId,
-  (allPowerLevels, storeId) => (storeId !== undefined ? allPowerLevels?.[storeId] : undefined)
-);
+export const powerLevelSelector = (state: RootState, storeId: string | undefined) =>
+  storeId !== undefined ? allPowerLevelsSelector(state)[storeId] : undefined;

--- a/src/app/inventory/store/selectors.ts
+++ b/src/app/inventory/store/selectors.ts
@@ -1,0 +1,121 @@
+import { maxLightItemSet } from 'app/loadout-drawer/auto-loadouts';
+import { getLight } from 'app/loadout-drawer/loadout-utils';
+import { powerLevelByKeyword } from 'app/search/d2-known-values';
+import { RootState } from 'app/store/types';
+import { createSelector } from 'reselect';
+import { DimItem } from '../item-types';
+import { allItemsSelector, storesSelector } from '../selectors';
+import { getArtifactBonus } from '../stores-helpers';
+
+const pinnacleCap = powerLevelByKeyword.pinnaclecap;
+
+/**
+ * Does this store (character) have any classified items that might affect their power level?
+ * Things to consider:
+ * - Classified items don't always lack a power level.
+ * - If a char has an equippable item at pinnacle cap in a particular slot,
+ *   who cares if there's a classified item in that slot? Not like it's higher.
+ *
+ * This relies on a precalculated set generated from allItems, using getBucketsWithClassifiedItems.
+ */
+export function hasAffectingClassified(
+  unrestrictedMaxLightGear: DimItem[],
+  bucketsWithClassifieds: Set<number>
+) {
+  return unrestrictedMaxLightGear.some(
+    (i) =>
+      // isn't pinnacle cap
+      i.power !== pinnacleCap &&
+      // and shares a bucket with a classified item (which might be higher power)
+      bucketsWithClassifieds.has(i.bucket.hash)
+  );
+}
+
+/** figures out which buckets contain classified items */
+export function getBucketsWithClassifiedItems(allItems: DimItem[]) {
+  const bucketsWithClassifieds = new Set<number>();
+  for (const i of allItems) {
+    if (i.classified && !i.power && (i.location.inWeapons || i.location.inArmor)) {
+      bucketsWithClassifieds.add(i.bucket.hash);
+    }
+  }
+  return bucketsWithClassifieds;
+}
+
+export interface StorePowerLevel {
+  /** average of your highest gear, even if not equippable at the same time */
+  maxGearPower: number;
+  /** currently represents the power level bonus provided by the Seasonal Artifact */
+  powerModifier: number;
+  /** maxGearPower + powerModifier. the highest PL you can get your inventory screen to show */
+  maxTotalPower: number;
+
+  /** the highest-power items per bucket, even if not equippable at the same time */
+  highestPowerItems: DimItem[];
+
+  /** maxGearPower and maxTotalPower can come with various caveats */
+  problems: {
+    /** this stat may be inaccurate because it relies on classified items */
+    hasClassified: boolean;
+    /** mutually excluded exotics are included in the max possible power */
+    notEquippable: boolean;
+    /** this character is in danger of dropping at a worse Power Level! another character is holding their best item(s) */
+    notOnStore: boolean;
+  };
+}
+
+const allPowerLevelsSelector = createSelector(
+  storesSelector,
+  allItemsSelector,
+  (stores, allItems) => {
+    const bucketsWithClassifieds = getBucketsWithClassifiedItems(allItems);
+
+    const levels: {
+      [storeId: string]: StorePowerLevel;
+    } = {};
+
+    for (const store of stores) {
+      if (store.isVault) {
+        continue;
+      }
+
+      const { equippable, unrestricted } = maxLightItemSet(allItems, store);
+
+      // ALL WEAPONS count toward your drops. armor on another character doesn't count.
+      // (maybe just because it's on a different class? who knows. can't test.)
+      const dropPowerItemSet = maxLightItemSet(
+        allItems.filter((i) => i.bucket.inWeapons || i.owner === 'vault' || i.owner === store.id),
+        store
+      ).unrestricted;
+      const dropPowerLevel = getLight(store, dropPowerItemSet);
+
+      const unrestrictedMaxGearPower = getLight(store, unrestricted);
+      const equippableMaxGearPower = getLight(store, equippable);
+
+      const notEquippable = unrestrictedMaxGearPower !== equippableMaxGearPower;
+      const notOnStore = dropPowerLevel !== unrestrictedMaxGearPower;
+      const hasClassified = hasAffectingClassified(unrestricted, bucketsWithClassifieds);
+      const artifactPower = getArtifactBonus(store);
+
+      levels[store.id] = {
+        maxGearPower: unrestrictedMaxGearPower,
+        powerModifier: artifactPower,
+        maxTotalPower: unrestrictedMaxGearPower + artifactPower,
+        highestPowerItems: unrestricted,
+        problems: {
+          hasClassified,
+          notEquippable,
+          notOnStore,
+        },
+      };
+    }
+
+    return levels;
+  }
+);
+
+export const powerLevelSelector = createSelector(
+  allPowerLevelsSelector,
+  (_state: RootState, storeId?: string) => storeId,
+  (allPowerLevels, storeId) => (storeId !== undefined ? allPowerLevels?.[storeId] : undefined)
+);

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -7,6 +7,7 @@ import { startFarming } from 'app/farming/actions';
 import { t } from 'app/i18next-t';
 import { allItemsSelector, bucketsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
+import { powerLevelSelector } from 'app/inventory/store/selectors';
 import {
   gatherEngramsLoadout,
   itemLevelingLoadout,
@@ -80,6 +81,9 @@ export default function LoadoutPopup({
   const filteredItems = useSelector(filteredItemsSelector);
   const loadoutSort = useSelector(settingSelector('loadoutSort'));
   const dispatch = useThunkDispatch();
+  const hasClassifiedAffectingMaxPower = useSelector(
+    (state: RootState) => powerLevelSelector(state, dimStore.id)?.problems.hasClassified
+  );
 
   const loadouts = useSavedLoadoutsForClassType(dimStore.classType);
   const inGameLoadouts = useSelector((state: RootState) =>
@@ -295,7 +299,7 @@ export default function LoadoutPopup({
               <MaxlightButton
                 allItems={allItems}
                 dimStore={dimStore}
-                hasClassified={Boolean(dimStore.stats.maxGearPower?.statProblems?.hasClassified)}
+                hasClassified={Boolean(hasClassifiedAffectingMaxPower)}
               />
             </li>
 

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -2,11 +2,14 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimStore } from 'app/inventory/store-types';
+import { powerLevelSelector } from 'app/inventory/store/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { RootState } from 'app/store/types';
 import { compareBy } from 'app/utils/comparators';
 import { uniqBy } from 'app/utils/util';
 import { DestinyMilestone, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
+import { useSelector } from 'react-redux';
 import styles from './Milestones.m.scss';
 import { PowerCaps } from './PowerCaps';
 import Pursuit from './Pursuit';
@@ -34,6 +37,9 @@ export default function Milestones({
   const defs = useD2Definitions()!;
   const profileMilestones = milestonesForProfile(defs, profileInfo, store.id);
   const characterProgressions = getCharacterProgressions(profileInfo, store.id);
+  const maxGearPower = useSelector(
+    (state: RootState) => powerLevelSelector(state, store.id)?.maxGearPower
+  );
   const season = profileInfo.profile?.data?.currentSeasonHash
     ? defs.Season.get(profileInfo.profile.data.currentSeasonHash)
     : undefined;
@@ -48,11 +54,7 @@ export default function Milestones({
 
   const milestonesByPower = _.groupBy(milestoneItems, (m) => {
     for (const reward of m.pursuit?.rewards ?? []) {
-      const powerBonus = getEngramPowerBonus(
-        reward.itemHash,
-        store?.stats.maxGearPower?.value,
-        m.hash
-      );
+      const powerBonus = getEngramPowerBonus(reward.itemHash, maxGearPower, m.hash);
       return powerBonus;
     }
   });

--- a/src/app/progress/Reward.tsx
+++ b/src/app/progress/Reward.tsx
@@ -1,10 +1,13 @@
 import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { DimStore } from 'app/inventory/store-types';
+import { powerLevelSelector } from 'app/inventory/store/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { RootState } from 'app/store/types';
 import { DestinyItemQuantity } from 'bungie-api-ts/destiny2';
+import { useSelector } from 'react-redux';
 import BungieImage from '../dim-ui/BungieImage';
-import { getEngramPowerBonus } from './engrams';
 import styles from './Reward.m.scss';
+import { getEngramPowerBonus } from './engrams';
 import { getXPValue } from './xp';
 
 export function Reward({
@@ -19,14 +22,13 @@ export function Reward({
   itemHash?: number;
 }) {
   const defs = useD2Definitions()!;
+  const maxGearPower = useSelector(
+    (state: RootState) => powerLevelSelector(state, store?.id)?.maxGearPower
+  );
   const rewardItem = defs.InventoryItem.get(reward.itemHash);
   const rewardDisplay = rewardItem.displayProperties;
 
-  const powerBonus = getEngramPowerBonus(
-    rewardItem.hash,
-    store?.stats.maxGearPower?.value,
-    itemHash
-  );
+  const powerBonus = getEngramPowerBonus(rewardItem.hash, maxGearPower, itemHash);
 
   const xpValue = getXPValue(reward.itemHash);
 

--- a/src/app/store-stats/CharacterStats.tsx
+++ b/src/app/store-stats/CharacterStats.tsx
@@ -43,7 +43,7 @@ function CharacterStats({ stats, showTier }: CharacterStatProps) {
       )}
       {stats.map(({ stat }) => (
         <PressTip key={stat.hash} tooltip={() => <StatTooltip stat={stat} />}>
-          <div className={clsx('stat')} aria-label={`${stat.name} ${stat.value}`} role="group">
+          <div className="stat" aria-label={`${stat.name} ${stat.value}`} role="group">
             <img src={stat.icon} alt={stat.name} />
             <div>{stat.value}</div>
           </div>

--- a/src/app/store-stats/CharacterStats.tsx
+++ b/src/app/store-stats/CharacterStats.tsx
@@ -1,31 +1,39 @@
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
+import { bungieNetPath } from 'app/dim-ui/BungieImage';
 import FractionalPowerLevel from 'app/dim-ui/FractionalPowerLevel';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { showGearPower } from 'app/gear-power/gear-power';
 import { t } from 'app/i18next-t';
-import { fakeCharacterStatHashes } from 'app/inventory/d2-stores';
+import { ArtifactXP } from 'app/inventory/ArtifactXP';
+import { ItemPowerSet } from 'app/inventory/ItemPowerSet';
+import { profileResponseSelector } from 'app/inventory/selectors';
 import type { DimCharacterStat, DimStore } from 'app/inventory/store-types';
+import { StorePowerLevel, powerLevelSelector } from 'app/inventory/store/selectors';
 import { statTier } from 'app/loadout-builder/utils';
+import { useD2Definitions } from 'app/manifest/selectors';
+import { getCharacterProgressions } from 'app/progress/selectors';
 import { armorStats } from 'app/search/d2-known-values';
+import { RootState } from 'app/store/types';
 import clsx from 'clsx';
+import { StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
+import { useSelector } from 'react-redux';
+import helmetIcon from '../../../destiny-icons/armor_types/helmet.svg';
+import xpIcon from '../../images/xpIcon.svg';
 import './CharacterStats.scss';
 import StatTooltip from './StatTooltip';
 
 interface CharacterStatProps {
   stats: {
     stat: DimCharacterStat;
-    tooltip: React.ReactNode;
   }[];
-  storeId: string | undefined;
-  className?: string;
   showTier?: boolean;
 }
 
-function CharacterStat({ stats, storeId, className, showTier }: CharacterStatProps) {
+function CharacterStats({ stats, showTier }: CharacterStatProps) {
   return (
-    <div className={clsx('stat-row', className)}>
+    <div className="stat-row">
       {showTier && (
         <div className="stat tier">
           {t('LoadoutBuilder.TierNumber', {
@@ -33,75 +41,132 @@ function CharacterStat({ stats, storeId, className, showTier }: CharacterStatPro
           })}
         </div>
       )}
-      {stats.map(({ stat, tooltip }) => {
-        // if this is the "max gear power" stat
-        // add in an onClick and an extra class
-        const isMaxGearPower = stat.hash === fakeCharacterStatHashes.maxGearPower;
-
-        return (
-          <PressTip key={stat.hash} tooltip={tooltip}>
-            <div
-              className={clsx('stat', { pointerCursor: isMaxGearPower })}
-              aria-label={`${stat.name} ${stat.value}`}
-              role={isMaxGearPower ? 'button' : 'group'}
-              onClick={isMaxGearPower ? () => showGearPower(storeId!) : undefined}
-            >
-              <img src={stat.icon} alt={stat.name} />
-              <div>
-                {/* if stat.hash is negative, this is one of our custom stats */}
-                {stat.hash < 0 ? (
-                  <span className="powerStat">
-                    <FractionalPowerLevel power={stat.value} />
-                  </span>
-                ) : (
-                  stat.value
-                )}
-                {stat.statProblems?.notOnStore &&
-                stat.hash === fakeCharacterStatHashes.maxGearPower ? (
-                  <AlertIcon className="warningIcon" />
-                ) : (
-                  (stat.statProblems?.hasClassified || stat.statProblems?.notEquippable) && (
-                    <sup className="asterisk">*</sup>
-                  )
-                )}
-              </div>
-            </div>
-          </PressTip>
-        );
-      })}
+      {stats.map(({ stat }) => (
+        <PressTip key={stat.hash} tooltip={() => <StatTooltip stat={stat} />}>
+          <div className={clsx('stat')} aria-label={`${stat.name} ${stat.value}`} role="group">
+            <img src={stat.icon} alt={stat.name} />
+            <div>{stat.value}</div>
+          </div>
+        </PressTip>
+      ))}
     </div>
   );
 }
 
-export function PowerFormula({ stats, storeId }: { stats: DimStore['stats']; storeId: string }) {
-  const powerTooltip = (stat: DimCharacterStat): React.ReactNode => (
-    <>
-      {stat.name}
-      {stat.statProblems?.hasClassified && `\n\n${t('Loadouts.Classified')}`}
-      {Boolean(stat.richTooltip) && (
-        <>
-          <hr />
-          <div className="richTooltipWrapper">
-            {stat.richTooltip}
-            {(stat.statProblems?.notEquippable || stat.statProblems?.notOnStore) && (
-              <div className="tooltipFootnote">
-                {stat.statProblems?.notOnStore ? <AlertIcon /> : '*'} {t('General.ClickForDetails')}
-              </div>
-            )}
+function CharacterPower({ stats }: { stats: PowerStat[] }) {
+  return (
+    <div className={clsx('stat-row', 'powerFormula')}>
+      {stats.map((stat) => (
+        <PressTip
+          key={stat.name}
+          tooltip={() => (
+            <>
+              {stat.name}
+              {stat.problems?.hasClassified && `\n\n${t('Loadouts.Classified')}`}
+              {stat.richTooltipContent && (
+                <>
+                  <hr />
+                  <div className="richTooltipWrapper">
+                    {stat.richTooltipContent()}
+                    {(stat.problems?.notEquippable || stat.problems?.notOnStore) && (
+                      <div className="tooltipFootnote">
+                        {stat.problems.notOnStore ? <AlertIcon /> : '*'}{' '}
+                        {t('General.ClickForDetails')}
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        >
+          <div
+            className={clsx('stat', { pointerCursor: stat.onClick })}
+            aria-label={`${stat.name} ${stat.value}`}
+            role={stat.onClick ? 'button' : 'group'}
+            onClick={stat.onClick}
+          >
+            <img src={stat.icon} alt={stat.name} />
+            <div>
+              <span className="powerStat">
+                <FractionalPowerLevel power={stat.value} />
+              </span>
+              {stat.problems?.notOnStore ? (
+                <AlertIcon className="warningIcon" />
+              ) : (
+                (stat.problems?.hasClassified || stat.problems?.notEquippable) && (
+                  <sup className="asterisk">*</sup>
+                )
+              )}
+            </div>
           </div>
-        </>
-      )}
-    </>
+        </PressTip>
+      ))}
+    </div>
   );
+}
 
-  const statInfos = _.compact([stats.maxTotalPower, stats.maxGearPower, stats.powerModifier]).map(
-    (stat) => ({
-      stat,
-      tooltip: powerTooltip(stat),
-    })
-  );
+interface PowerStat {
+  value: number;
+  icon: string;
+  name: string;
+  richTooltipContent?: () => React.ReactNode;
+  onClick?: () => void;
+  problems?: StorePowerLevel['problems'];
+}
 
-  return <CharacterStat stats={statInfos} storeId={storeId} className="powerFormula" />;
+export function PowerFormula({ storeId }: { storeId: string }) {
+  const defs = useD2Definitions();
+  const powerLevel = useSelector((state: RootState) => powerLevelSelector(state, storeId));
+
+  const profileResponse = useSelector(profileResponseSelector);
+  const characterProgress = getCharacterProgressions(profileResponse);
+
+  if (!defs || !profileResponse || !powerLevel) {
+    return null;
+  }
+
+  const maxTotalPower: PowerStat = {
+    value: powerLevel.maxTotalPower,
+    icon: bungieNetPath(defs.Stat.get(StatHashes.Power).displayProperties.icon),
+    name: t('Stats.MaxTotalPower'),
+    problems: { ...powerLevel.problems, notOnStore: false },
+  };
+
+  const maxGearPower: PowerStat = {
+    value: powerLevel.maxGearPower,
+    icon: helmetIcon,
+    name: t('Stats.MaxGearPowerAll'),
+    // used to be t('Stats.MaxGearPower'), a translation i don't want to lose yet
+    problems: powerLevel.problems,
+    onClick: () => showGearPower(storeId),
+    richTooltipContent: () => (
+      <ItemPowerSet
+        items={powerLevel.highestPowerItems}
+        powerFloor={Math.floor(powerLevel.maxGearPower)}
+      />
+    ),
+  };
+
+  // optional chaining here accounts for an edge-case, possible, but type-unadvertised,
+  // missing artifact power bonus. please keep this here.
+  const bonusPowerProgressionHash =
+    profileResponse.profileProgression?.data?.seasonalArtifact?.powerBonusProgression
+      ?.progressionHash;
+
+  const artifactPower: PowerStat = {
+    value: powerLevel.powerModifier,
+    name: t('Stats.PowerModifier'),
+    richTooltipContent: () => (
+      <ArtifactXP
+        characterProgress={characterProgress}
+        bonusPowerProgressionHash={bonusPowerProgressionHash}
+      />
+    ),
+    icon: xpIcon,
+  };
+
+  return <CharacterPower stats={[maxTotalPower, maxGearPower, artifactPower]} />;
 }
 
 export function LoadoutStats({
@@ -118,5 +183,5 @@ export function LoadoutStats({
       tooltip: <StatTooltip stat={stat} />,
     }));
 
-  return <CharacterStat showTier={showTier} stats={statInfos} storeId={undefined} />;
+  return <CharacterStats showTier={showTier} stats={statInfos} />;
 }

--- a/src/app/store-stats/StoreStats.tsx
+++ b/src/app/store-stats/StoreStats.tsx
@@ -28,7 +28,7 @@ export default function StoreStats({
         <D1CharacterStats stats={store.stats} />
       ) : (
         <div className="stat-bars destiny2">
-          <PowerFormula stats={store.stats} storeId={store.id} />
+          <PowerFormula storeId={store.id} />
           <LoadoutStats stats={store.stats} />
         </div>
       )}


### PR DESCRIPTION
Fixes #9168. I also had a half completed branch because `statProblems` and `richTooltip` in `DimCharacterStat` started to get a bit annoying and they were only used for things that are... not really character stats.

This needs to be tested for D1.