### PR TITLE
Draggable loadout items take 2

### DIFF
--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -84,6 +84,8 @@ export function addItem(
       return;
     }
 
+    const typeInventory = loadoutItemsInBucket(defs, draftLoadout, item.bucket.hash);
+
     const dupeIndex = findSameLoadoutItemIndex(defs, draftLoadout.items, loadoutItem);
     if (dupeIndex !== -1) {
       const dupe = draftLoadout.items[dupeIndex];
@@ -92,11 +94,19 @@ export function addItem(
         const increment = Math.min(dupe.amount + item.amount, item.maxStackSize) - dupe.amount;
         dupe.amount += increment;
       }
-      // Otherwise just bail and don't modify the loadout
+      // Handles dnd of items already in the loadout, e.g. this allows us to drag an unequipped item
+      // into equipped.
+      if (equip !== undefined && dupe.equip !== equip) {
+        if (equip) {
+          for (const item of typeInventory) {
+            item.equip = false;
+          }
+        }
+        dupe.equip = equip;
+      }
+      // No need for further modifications so we bail out
       return;
     }
-
-    const typeInventory = loadoutItemsInBucket(defs, draftLoadout, item.bucket.hash);
 
     if (typeInventory.length >= maxSlots) {
       // We're already full

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -195,7 +195,10 @@ export default function LoadoutEdit({
           </LoadoutEditBucketDropTarget>
         </LoadoutEditSection>
       )}
-      {(anyClass ? (['Weapons'] as const) : (['Weapons', 'Armor'] as const)).map((category) => (
+      {(anyClass
+        ? (['Weapons', 'General'] as const)
+        : (['Weapons', 'Armor', 'General'] as const)
+      ).map((category) => (
         <LoadoutEditSection
           key={category}
           className={styles.section}
@@ -215,7 +218,6 @@ export default function LoadoutEdit({
             storeId={store.id}
             classType={loadout.classType}
             items={categories[category]}
-            itemBehavior="draggable"
             modsByBucket={modsByBucket}
             onClickPlaceholder={onClickPlaceholder}
             onClickWarnItem={onClickWarnItem}
@@ -235,29 +237,6 @@ export default function LoadoutEdit({
           </LoadoutEditBucket>
         </LoadoutEditSection>
       ))}
-      <LoadoutEditSection
-        className={styles.section}
-        title={t(`Bucket.General`, { metadata: { keys: 'buckets' } })}
-        onClear={() => handleClearCategory('General')}
-        onFillFromEquipped={() => handleFillCategoryFromEquipped(artifactUnlocks, 'General')}
-        fillFromInventoryCount={getUnequippedItemsForLoadout(store, 'General').length}
-        onFillFromInventory={() => handleFillCategoryFromUnequipped('General')}
-      >
-        <LoadoutEditBucketDropTarget category="General" classType={loadout.classType}>
-          <LoadoutEditBucket
-            category="General"
-            storeId={store.id}
-            classType={loadout.classType}
-            items={categories['General']}
-            itemBehavior="static"
-            modsByBucket={modsByBucket}
-            onClickPlaceholder={onClickPlaceholder}
-            onClickWarnItem={onClickWarnItem}
-            onRemoveItem={onRemoveItem}
-            onToggleEquipped={handleToggleEquipped}
-          />
-        </LoadoutEditBucketDropTarget>
-      </LoadoutEditSection>
       <LoadoutEditSection
         title={t('Loadouts.Mods')}
         className={clsx(styles.section, styles.mods)}

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -213,29 +213,29 @@ export default function LoadoutEdit({
               : undefined
           }
         >
-          <LoadoutEditBucketDropTarget category={category} classType={loadout.classType}>
-            <LoadoutEditBucket
-              category={category}
-              storeId={store.id}
-              items={categories[category]}
-              modsByBucket={modsByBucket}
-              onClickPlaceholder={onClickPlaceholder}
-              onClickWarnItem={onClickWarnItem}
-              onRemoveItem={onRemoveItem}
-              onToggleEquipped={handleToggleEquipped}
-            >
-              {category === 'Armor' && (
-                <ArmorExtras
-                  loadout={loadout}
-                  storeId={store.id}
-                  subclass={subclass}
-                  items={categories[category]}
-                  allMods={modDefinitions}
-                  onModsByBucketUpdated={handleModsByBucketUpdated}
-                />
-              )}
-            </LoadoutEditBucket>
-          </LoadoutEditBucketDropTarget>
+          <LoadoutEditBucket
+            category={category}
+            storeId={store.id}
+            classType={loadout.classType}
+            items={categories[category]}
+            itemBehavior={category === 'General' ? 'static' : 'draggable'}
+            modsByBucket={modsByBucket}
+            onClickPlaceholder={onClickPlaceholder}
+            onClickWarnItem={onClickWarnItem}
+            onRemoveItem={onRemoveItem}
+            onToggleEquipped={handleToggleEquipped}
+          >
+            {category === 'Armor' && (
+              <ArmorExtras
+                loadout={loadout}
+                storeId={store.id}
+                subclass={subclass}
+                items={categories[category]}
+                allMods={modDefinitions}
+                onModsByBucketUpdated={handleModsByBucketUpdated}
+              />
+            )}
+          </LoadoutEditBucket>
         </LoadoutEditSection>
       ))}
       <LoadoutEditSection

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -195,10 +195,7 @@ export default function LoadoutEdit({
           </LoadoutEditBucketDropTarget>
         </LoadoutEditSection>
       )}
-      {(anyClass
-        ? (['Weapons', 'General'] as const)
-        : (['Weapons', 'Armor', 'General'] as const)
-      ).map((category) => (
+      {(anyClass ? (['Weapons'] as const) : (['Weapons', 'Armor'] as const)).map((category) => (
         <LoadoutEditSection
           key={category}
           className={styles.section}
@@ -218,7 +215,7 @@ export default function LoadoutEdit({
             storeId={store.id}
             classType={loadout.classType}
             items={categories[category]}
-            itemBehavior={category === 'General' ? 'static' : 'draggable'}
+            itemBehavior="draggable"
             modsByBucket={modsByBucket}
             onClickPlaceholder={onClickPlaceholder}
             onClickWarnItem={onClickWarnItem}
@@ -238,6 +235,29 @@ export default function LoadoutEdit({
           </LoadoutEditBucket>
         </LoadoutEditSection>
       ))}
+      <LoadoutEditSection
+        className={styles.section}
+        title={t(`Bucket.General`, { metadata: { keys: 'buckets' } })}
+        onClear={() => handleClearCategory('General')}
+        onFillFromEquipped={() => handleFillCategoryFromEquipped(artifactUnlocks, 'General')}
+        fillFromInventoryCount={getUnequippedItemsForLoadout(store, 'General').length}
+        onFillFromInventory={() => handleFillCategoryFromUnequipped('General')}
+      >
+        <LoadoutEditBucketDropTarget category="General" classType={loadout.classType}>
+          <LoadoutEditBucket
+            category="General"
+            storeId={store.id}
+            classType={loadout.classType}
+            items={categories['General']}
+            itemBehavior="static"
+            modsByBucket={modsByBucket}
+            onClickPlaceholder={onClickPlaceholder}
+            onClickWarnItem={onClickWarnItem}
+            onRemoveItem={onRemoveItem}
+            onToggleEquipped={handleToggleEquipped}
+          />
+        </LoadoutEditBucketDropTarget>
+      </LoadoutEditSection>
       <LoadoutEditSection
         title={t('Loadouts.Mods')}
         className={clsx(styles.section, styles.mods)}

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
@@ -98,10 +98,6 @@
   padding: 0 0 4px 0;
 }
 
-.dropTarget {
-  position: relative;
-}
-
 .canDrop {
   filter: invert(20%);
   background-color: rgba(255, 255, 255, 0.2);

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
@@ -70,6 +70,7 @@
 .categoryGeneral {
   // 2x2 grid
   @include items-width(2);
+
   @include phone-portrait {
     // 4 in a line
     @include items-width(4);
@@ -95,4 +96,18 @@
   color: currentColor;
   width: 100%;
   padding: 0 0 4px 0;
+}
+
+.dropTarget {
+  position: relative;
+}
+
+.canDrop {
+  filter: invert(20%);
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.isOver {
+  filter: invert(40%);
+  background-color: rgba(255, 255, 255, 0.4);
 }

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss.d.ts
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'categoryArmor': string;
   'categoryGeneral': string;
   'categoryWeapons': string;
-  'dropTarget': string;
   'equipped': string;
   'isOver': string;
   'itemBucket': string;

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss.d.ts
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss.d.ts
@@ -3,10 +3,13 @@
 interface CssExports {
   'addButton': string;
   'buttons': string;
+  'canDrop': string;
   'categoryArmor': string;
   'categoryGeneral': string;
   'categoryWeapons': string;
+  'dropTarget': string;
   'equipped': string;
+  'isOver': string;
   'itemBucket': string;
   'itemCategory': string;
   'items': string;

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -237,7 +237,7 @@ function ItemBucket({
     <div className={clsx(styles.itemBucket)}>
       <div
         ref={equippedRef}
-        className={clsx(styles.dropTarget, {
+        className={clsx({
           [styles.canDrop]: canDropEquipped,
           [styles.isOver]: isOverEquipped,
         })}
@@ -259,7 +259,7 @@ function ItemBucket({
       </div>
       <div
         ref={unequippedRef}
-        className={clsx(styles.dropTarget, {
+        className={clsx({
           [styles.canDrop]: canDropUnequipped,
           [styles.isOver]: isOverUnequipped,
         })}

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -2,22 +2,26 @@ import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
+import DraggableInventoryItem from 'app/inventory/DraggableInventoryItem';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
-import { D2BucketCategory, InventoryBucket } from 'app/inventory/inventory-buckets';
-import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { bucketsSelector } from 'app/inventory/selectors';
+import { InventoryBucket } from 'app/inventory/inventory-buckets';
+import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { getLoadoutStats, singularBucketHashes } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, addIcon, faTshirt } from 'app/shell/icons';
 import { LoadoutStats } from 'app/store-stats/CharacterStats';
 import { emptyArray } from 'app/utils/empty';
+import { itemCanBeInLoadout } from 'app/utils/item-utils';
 import { Portal } from 'app/utils/temp-container';
 import { LookupTable } from 'app/utils/util-types';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { useState } from 'react';
+import { DropTargetHookSpec, useDrop } from 'react-dnd';
 import { useSelector } from 'react-redux';
 import FashionDrawer from '../fashion/FashionDrawer';
 import { BucketPlaceholder } from '../loadout-ui/BucketPlaceholder';
@@ -26,7 +30,9 @@ import LoadoutParametersDisplay from '../loadout-ui/LoadoutParametersDisplay';
 import { OptimizerButton } from '../loadout-ui/OptimizerButton';
 import styles from './LoadoutEditBucket.m.scss';
 
-const categoryStyles: LookupTable<D2BucketCategory, string> = {
+export type EditableCategories = 'Weapons' | 'Armor' | 'General';
+
+const categoryStyles: LookupTable<EditableCategories, string> = {
   Weapons: styles.categoryWeapons,
   Armor: styles.categoryArmor,
   General: styles.categoryGeneral,
@@ -34,8 +40,10 @@ const categoryStyles: LookupTable<D2BucketCategory, string> = {
 
 export default function LoadoutEditBucket({
   category,
+  classType,
   storeId,
   items,
+  itemBehavior,
   modsByBucket,
   onClickPlaceholder,
   onClickWarnItem,
@@ -43,9 +51,11 @@ export default function LoadoutEditBucket({
   onToggleEquipped,
   children,
 }: {
-  category: D2BucketCategory;
+  category: EditableCategories;
+  classType: DestinyClass;
   storeId: string;
   items?: ResolvedLoadoutItem[];
+  itemBehavior: 'static' | 'draggable';
   modsByBucket: {
     [bucketHash: number]: number[] | undefined;
   };
@@ -72,7 +82,10 @@ export default function LoadoutEditBucket({
           <ItemBucket
             key={bucket.hash}
             bucket={bucket}
+            category={category}
+            classType={classType}
             items={itemsByBucket[bucket.hash]}
+            itemBehavior={itemBehavior}
             onClickPlaceholder={onClickPlaceholder}
             onClickWarnItem={onClickWarnItem}
             onRemoveItem={onRemoveItem}
@@ -138,7 +151,10 @@ export function ArmorExtras({
 
 function ItemBucket({
   bucket,
+  classType,
+  category,
   items,
+  itemBehavior,
   equippedContent,
   onClickPlaceholder,
   onClickWarnItem,
@@ -146,7 +162,10 @@ function ItemBucket({
   onToggleEquipped,
 }: {
   bucket: InventoryBucket;
+  classType: DestinyClass;
+  category: EditableCategories;
   items: ResolvedLoadoutItem[];
+  itemBehavior: 'static' | 'draggable';
   equippedContent?: React.ReactNode;
   onClickPlaceholder: (params: { bucket: InventoryBucket; equip: boolean }) => void;
   onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
@@ -155,6 +174,38 @@ function ItemBucket({
 }) {
   const bucketHash = bucket.hash;
   const [equipped, unequipped] = _.partition(items, (li) => li.loadoutItem.equip);
+
+  const stores = useSelector(storesSelector);
+  const buckets = useSelector(bucketsSelector)!;
+
+  const dropSpec =
+    (type: 'equipped' | 'unequipped') =>
+    (): DropTargetHookSpec<
+      DimItem,
+      { equipped: boolean },
+      { isOver: boolean; canDrop: boolean }
+    > => ({
+      accept: [bucket.hash.toString(), ...stores.flatMap((store) => `${store.id}-${bucket.hash}`)],
+      drop: () => ({ equipped: type === 'equipped' }),
+      canDrop: (i) =>
+        itemCanBeInLoadout(i) &&
+        (i.classType === DestinyClass.Unknown || classType === i.classType) &&
+        (type === 'equipped' || !singularBucketHashes.includes(i.bucket.hash)),
+      collect: (monitor) => ({
+        isOver: monitor.isOver() && monitor.canDrop(),
+        canDrop: monitor.canDrop(),
+      }),
+    });
+
+  const [{ isOver: isOverEquipped, canDrop: canDropEquipped }, equippedRef] = useDrop(
+    dropSpec('equipped'),
+    [category, stores, buckets]
+  );
+
+  const [{ isOver: isOverUnequipped, canDrop: canDropUnequipped }, unequippedRef] = useDrop(
+    dropSpec('unequipped'),
+    [category, stores, buckets]
+  );
 
   const handlePlaceholderClick = (equip: boolean) => onClickPlaceholder({ bucket, equip });
 
@@ -177,59 +228,148 @@ function ItemBucket({
     </button>
   );
 
+  const renderItem = (li: ResolvedLoadoutItem) =>
+    itemBehavior === 'draggable' ? (
+      <DraggableItem
+        key={li.item.id}
+        resolvedLoadoutItem={li}
+        onClickWarnItem={() => onClickWarnItem(li)}
+        onRemoveItem={() => onRemoveItem(li)}
+        onToggleEquipped={() => onToggleEquipped(li)}
+      />
+    ) : (
+      <StaticItem
+        key={li.item.id}
+        resolvedLoadoutItem={li}
+        onClickWarnItem={() => onClickWarnItem(li)}
+        onRemoveItem={() => onRemoveItem(li)}
+        onToggleEquipped={() => onToggleEquipped(li)}
+      />
+    );
+
   return (
     <div className={clsx(styles.itemBucket)}>
-      {[equipped, unequipped].map((items, index) =>
-        items.length > 0 ? (
-          <div
-            className={clsx(styles.items, index === 0 ? styles.equipped : styles.unequipped)}
-            key={index}
-          >
-            {items.map((li) => (
-              <ClosableContainer
-                key={li.item.id}
-                onClose={() => onRemoveItem(li)}
-                showCloseIconOnHover
-              >
-                <ItemPopupTrigger
-                  item={li.item}
-                  extraData={{ socketOverrides: li.loadoutItem.socketOverrides }}
-                >
-                  {(ref, onClick) => (
-                    <div
-                      className={clsx({
-                        [styles.missingItem]: li.missing,
-                      })}
-                    >
-                      <ConnectedInventoryItem
-                        item={li.item}
-                        innerRef={ref}
-                        onClick={li.missing ? () => onClickWarnItem(li) : onClick}
-                        onDoubleClick={() => onToggleEquipped(li)}
-                      />
-                    </div>
-                  )}
-                </ItemPopupTrigger>
-              </ClosableContainer>
-            ))}
-            {index === 0 ? equippedContent : addUnequipped}
+      <div
+        ref={equippedRef}
+        className={clsx(styles.dropTarget, {
+          [styles.canDrop]: canDropEquipped,
+          [styles.isOver]: isOverEquipped,
+        })}
+      >
+        {equipped.length > 0 ? (
+          <div className={clsx(styles.items, styles.equipped)}>
+            {equipped.map(renderItem)}
+            {equippedContent}
           </div>
-        ) : index === 0 ? (
-          <div
-            className={clsx(styles.items, index === 0 ? styles.equipped : styles.unequipped)}
-            key={index}
-          >
+        ) : (
+          <div className={clsx(styles.items, styles.equipped)}>
             <BucketPlaceholder
               bucketHash={bucketHash}
               onClick={() => handlePlaceholderClick(true)}
             />
             {equippedContent}
           </div>
+        )}
+      </div>
+      <div
+        ref={unequippedRef}
+        className={clsx(styles.dropTarget, {
+          [styles.canDrop]: canDropUnequipped,
+          [styles.isOver]: isOverUnequipped,
+        })}
+      >
+        {unequipped.length > 0 ? (
+          <div ref={unequippedRef} className={clsx(styles.items, styles.unequipped)}>
+            {unequipped.map(renderItem)}
+            {addUnequipped}
+          </div>
         ) : (
           addUnequipped
-        )
-      )}
+        )}
+      </div>
     </div>
+  );
+}
+
+function StaticItem({
+  resolvedLoadoutItem,
+  onClickWarnItem,
+  onRemoveItem,
+  onToggleEquipped,
+}: {
+  resolvedLoadoutItem: ResolvedLoadoutItem;
+  onClickWarnItem: () => void;
+  onRemoveItem: () => void;
+  onToggleEquipped: () => void;
+}) {
+  return (
+    <ClosableContainer
+      key={resolvedLoadoutItem.item.id}
+      onClose={onRemoveItem}
+      showCloseIconOnHover
+    >
+      <ItemPopupTrigger
+        item={resolvedLoadoutItem.item}
+        extraData={{ socketOverrides: resolvedLoadoutItem.loadoutItem.socketOverrides }}
+      >
+        {(ref, onClick) => (
+          <div
+            className={clsx({
+              [styles.missingItem]: resolvedLoadoutItem.missing,
+            })}
+          >
+            <ConnectedInventoryItem
+              item={resolvedLoadoutItem.item}
+              innerRef={ref}
+              onClick={resolvedLoadoutItem.missing ? onClickWarnItem : onClick}
+              onDoubleClick={onToggleEquipped}
+            />
+          </div>
+        )}
+      </ItemPopupTrigger>
+    </ClosableContainer>
+  );
+}
+
+function DraggableItem({
+  resolvedLoadoutItem,
+  onClickWarnItem,
+  onRemoveItem,
+  onToggleEquipped,
+}: {
+  resolvedLoadoutItem: ResolvedLoadoutItem;
+  onClickWarnItem: () => void;
+  onRemoveItem: () => void;
+  onToggleEquipped: () => void;
+}) {
+  return (
+    <ClosableContainer
+      key={resolvedLoadoutItem.item.id}
+      onClose={onRemoveItem}
+      showCloseIconOnHover
+    >
+      <DraggableInventoryItem item={resolvedLoadoutItem.item}>
+        <ItemPopupTrigger
+          item={resolvedLoadoutItem.item}
+          extraData={{ socketOverrides: resolvedLoadoutItem.loadoutItem.socketOverrides }}
+        >
+          {(ref, onClick) => (
+            <div
+              className={clsx({
+                [styles.missingItem]: resolvedLoadoutItem.missing,
+              })}
+            >
+              <ConnectedInventoryItem
+                item={resolvedLoadoutItem.item}
+                innerRef={ref}
+                onClick={resolvedLoadoutItem.missing ? onClickWarnItem : onClick}
+                onDoubleClick={onToggleEquipped}
+              />
+            </div>
+          )}
+        </ItemPopupTrigger>
+      </DraggableInventoryItem>
+    </ClosableContainer>
   );
 }
 

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -43,7 +43,6 @@ export default function LoadoutEditBucket({
   classType,
   storeId,
   items,
-  itemBehavior,
   modsByBucket,
   onClickPlaceholder,
   onClickWarnItem,
@@ -55,7 +54,6 @@ export default function LoadoutEditBucket({
   classType: DestinyClass;
   storeId: string;
   items?: ResolvedLoadoutItem[];
-  itemBehavior: 'static' | 'draggable';
   modsByBucket: {
     [bucketHash: number]: number[] | undefined;
   };
@@ -85,7 +83,6 @@ export default function LoadoutEditBucket({
             category={category}
             classType={classType}
             items={itemsByBucket[bucket.hash]}
-            itemBehavior={itemBehavior}
             onClickPlaceholder={onClickPlaceholder}
             onClickWarnItem={onClickWarnItem}
             onRemoveItem={onRemoveItem}
@@ -154,7 +151,6 @@ function ItemBucket({
   classType,
   category,
   items,
-  itemBehavior,
   equippedContent,
   onClickPlaceholder,
   onClickWarnItem,
@@ -165,7 +161,6 @@ function ItemBucket({
   classType: DestinyClass;
   category: EditableCategories;
   items: ResolvedLoadoutItem[];
-  itemBehavior: 'static' | 'draggable';
   equippedContent?: React.ReactNode;
   onClickPlaceholder: (params: { bucket: InventoryBucket; equip: boolean }) => void;
   onClickWarnItem: (resolvedItem: ResolvedLoadoutItem) => void;
@@ -228,24 +223,15 @@ function ItemBucket({
     </button>
   );
 
-  const renderItem = (li: ResolvedLoadoutItem) =>
-    itemBehavior === 'draggable' ? (
-      <DraggableItem
-        key={li.item.id}
-        resolvedLoadoutItem={li}
-        onClickWarnItem={() => onClickWarnItem(li)}
-        onRemoveItem={() => onRemoveItem(li)}
-        onToggleEquipped={() => onToggleEquipped(li)}
-      />
-    ) : (
-      <StaticItem
-        key={li.item.id}
-        resolvedLoadoutItem={li}
-        onClickWarnItem={() => onClickWarnItem(li)}
-        onRemoveItem={() => onRemoveItem(li)}
-        onToggleEquipped={() => onToggleEquipped(li)}
-      />
-    );
+  const renderItem = (li: ResolvedLoadoutItem) => (
+    <DraggableItem
+      key={li.item.id}
+      resolvedLoadoutItem={li}
+      onClickWarnItem={() => onClickWarnItem(li)}
+      onRemoveItem={() => onRemoveItem(li)}
+      onToggleEquipped={() => onToggleEquipped(li)}
+    />
+  );
 
   return (
     <div className={clsx(styles.itemBucket)}>
@@ -288,46 +274,6 @@ function ItemBucket({
         )}
       </div>
     </div>
-  );
-}
-
-function StaticItem({
-  resolvedLoadoutItem,
-  onClickWarnItem,
-  onRemoveItem,
-  onToggleEquipped,
-}: {
-  resolvedLoadoutItem: ResolvedLoadoutItem;
-  onClickWarnItem: () => void;
-  onRemoveItem: () => void;
-  onToggleEquipped: () => void;
-}) {
-  return (
-    <ClosableContainer
-      key={resolvedLoadoutItem.item.id}
-      onClose={onRemoveItem}
-      showCloseIconOnHover
-    >
-      <ItemPopupTrigger
-        item={resolvedLoadoutItem.item}
-        extraData={{ socketOverrides: resolvedLoadoutItem.loadoutItem.socketOverrides }}
-      >
-        {(ref, onClick) => (
-          <div
-            className={clsx({
-              [styles.missingItem]: resolvedLoadoutItem.missing,
-            })}
-          >
-            <ConnectedInventoryItem
-              item={resolvedLoadoutItem.item}
-              innerRef={ref}
-              onClick={resolvedLoadoutItem.missing ? onClickWarnItem : onClick}
-              onDoubleClick={onToggleEquipped}
-            />
-          </div>
-        )}
-      </ItemPopupTrigger>
-    </ClosableContainer>
   );
 }
 


### PR DESCRIPTION
## Overview

This PR enables dnd of items within the loadout edit drawer.

Decided to start again as my old branch was so old, also I would like to have another pass over this as cleanup but decided to leave it as functional as possible while changing behaviour. For example, the old drop target is now only used for subclasses. I will probably extract some functionality out for the dnd stuff and push the drop target but down into subclass itself.

## Example

https://user-images.githubusercontent.com/7344652/230762317-47f7f54b-3f25-418d-b13e-49e38a9c9b2f.mov
