### PR TITLE
Fix missing localization in bounty guide, const remaining TS enums

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -462,6 +462,14 @@
     "StackFull": "You already have a full stack of {{name}}",
     "StoreName": "{{genderRace}} {{className}}"
   },
+  "KillType": {
+    "Melee": "Melee",
+    "Super": "Super",
+    "Grenade": "Grenade",
+    "Finisher": "Finisher",
+    "Precision": "Precision",
+    "ClassAbilities": "Class Ability"
+  },
   "PostmasterWarningBanner": {
     "PostmasterAlmostFull": "The postmaster is almost full! ({{number}}/{{postmasterSize}})",
     "PostmasterFull": "The postmaster is full! ({{number}}/{{postmasterSize}})"

--- a/src/app/loadout-builder/process-worker/stats-set.ts
+++ b/src/app/loadout-builder/process-worker/stats-set.ts
@@ -14,7 +14,7 @@ interface StatNode<T> {
 /**
  * Result helper for distinguishing between different cases in the better stats helper
  */
-enum BetterStatsResult {
+const enum BetterStatsResult {
   // There exists a known set of stats with at least one higher stat than the input, and NO lower stats
   BETTER_STATS_EXIST = -1,
   // There exists a known set of stats with exactly the same stats as the input, but nothing better

--- a/src/app/loadout-drawer/loadout-apply-state.ts
+++ b/src/app/loadout-drawer/loadout-apply-state.ts
@@ -7,7 +7,7 @@ import produce from 'immer';
 /**
  * What part of the loadout application process are we currently in?
  */
-export enum LoadoutApplyPhase {
+export const enum LoadoutApplyPhase {
   NotStarted,
   /** De-equip loadout items from other characters so they can be moved */
   Deequip,
@@ -27,7 +27,7 @@ export enum LoadoutApplyPhase {
   Failed,
 }
 
-export enum LoadoutItemState {
+export const enum LoadoutItemState {
   Pending,
   /** A successful state (maybe we don't need to distinguish this) for items that didn't need to be moved. */
   AlreadyThere,
@@ -47,7 +47,7 @@ export interface LoadoutItemResult {
   readonly error?: Error;
 }
 
-export enum LoadoutModState {
+export const enum LoadoutModState {
   Pending,
   Unassigned,
   Applied,
@@ -60,7 +60,7 @@ export interface LoadoutModResult {
   readonly error?: Error;
 }
 
-export enum LoadoutSocketOverrideState {
+export const enum LoadoutSocketOverrideState {
   Pending,
   Applied,
   Failed,

--- a/src/app/progress/BountyGuide.tsx
+++ b/src/app/progress/BountyGuide.tsx
@@ -1,17 +1,17 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage from 'app/dim-ui/BungieImage';
 import BucketIcon from 'app/dim-ui/svgs/BucketIcon';
-import { t } from 'app/i18next-t';
+import { t, tl } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { moveItemTo } from 'app/inventory/move-item';
 import { DimStore } from 'app/inventory/store-types';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { addIcon, AppIcon } from 'app/shell/icons';
+import { AppIcon, addIcon } from 'app/shell/icons';
 import { ThunkDispatchProp } from 'app/store/types';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
-import { isIn, LookupTable } from 'app/utils/util-types';
+import { LookupTable, isIn } from 'app/utils/util-types';
 import clsx from 'clsx';
 import grenade from 'destiny-icons/weapons/grenade.svg';
 import headshot from 'destiny-icons/weapons/headshot.svg';
@@ -21,7 +21,7 @@ import { useDispatch } from 'react-redux';
 import styles from './BountyGuide.m.scss';
 import { xpItems } from './xp';
 
-enum KillType {
+const enum KillType {
   Melee,
   Super,
   Grenade,
@@ -33,6 +33,15 @@ const killTypeIcons: LookupTable<KillType, string> = {
   [KillType.Melee]: melee,
   [KillType.Grenade]: grenade,
   [KillType.Precision]: headshot,
+};
+
+const killTypeDescriptions: Record<KillType, string> = {
+  [KillType.Melee]: tl('KillType.Melee'),
+  [KillType.Super]: tl('KillType.Super'),
+  [KillType.Grenade]: tl('KillType.Grenade'),
+  [KillType.Finisher]: tl('KillType.Finisher'),
+  [KillType.Precision]: tl('KillType.Precision'),
+  [KillType.ClassAbilities]: tl('KillType.ClassAbilities'),
 };
 
 export type DefType =
@@ -239,7 +248,7 @@ function PillContent({
           {isIn(value, killTypeIcons) && (
             <img className={styles.invert} height="16" src={killTypeIcons[value]} />
           )}
-          {KillType[value]}
+          {t(killTypeDescriptions[value as KillType])}
         </>
       );
     case 'Reward':

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -463,6 +463,14 @@
     "StackFull": "You already have a full stack of {{name}}",
     "StoreName": "{{genderRace}} {{className}}"
   },
+  "KillType": {
+    "ClassAbilities": "Class Ability",
+    "Finisher": "Finisher",
+    "Grenade": "Grenade",
+    "Melee": "Melee",
+    "Precision": "Precision",
+    "Super": "Super"
+  },
   "LB": {
     "AdvancedOptions": "Advanced Options",
     "ChooseAMod": "Choose your mods",


### PR DESCRIPTION
DIM doesn't really need the features from non-const TS enums, and in the process of converting them the BountyGuide didn't compile anymore, so this adds the missing localization.