### PR TITLE
Fix armory link by intercepting url starting with `armory`.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -78,6 +78,7 @@ export default function App() {
               ) : (
                 <>
                   <Route path="search-history" element={<SearchHistory />} />
+                  <Route path="armory/*" element={<DefaultAccount />} />
                   <Route path=":membershipId/:destinyVersion/*" element={<Destiny />} />
                   <Route path="*" element={<DefaultAccount />} />
                 </>


### PR DESCRIPTION
## Overview

Currently links from the armoury to the armoury page are busted as the membership number and destiny version are missing from the url.

This PR fixes that by intercepting the url and using the `DefaultAccount` component to inject the required params.