### PR TITLE
Collapse stat: filters' operators in filter help like the others

### DIFF
--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -77,12 +77,8 @@ export default function FilterHelp() {
 
 function FilterExplanation({ filter }: { filter: FilterDefinition }) {
   const dispatch = useDispatch();
-  const additionalSuggestions = filter.suggestionsGenerator?.({}) ?? [];
   const suggestions = Array.from(
-    new Set([
-      ...generateGroupedSuggestionsForFilter(filter, true),
-      ...additionalSuggestions.map((keyword) => ({ keyword, ops: undefined })),
-    ])
+    new Set([...generateGroupedSuggestionsForFilter(filter, true, {})])
   );
   const localDesc = Array.isArray(filter.description)
     ? t(...filter.description)

--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -157,7 +157,9 @@ export interface FilterDefinition<I extends DimItem = DimItem> {
    * A custom function used to generate (additional) suggestions.
    * This should only be necessary for freeform or custom formats.
    */
-  suggestionsGenerator?: (args: SuggestionsContext) => string[] | undefined;
+  suggestionsGenerator?: (
+    args: SuggestionsContext
+  ) => string[] | { keyword: string; ops?: string[] }[] | undefined;
 
   /**
    * given an item, this generates a filter that should match that item

--- a/src/app/search/search-config.ts
+++ b/src/app/search/search-config.ts
@@ -121,10 +121,7 @@ export function buildSearchConfig(
   const suggestions = new Set<string>();
   const filtersMap = buildFiltersMap(destinyVersion);
   for (const filter of filtersMap.allFilters) {
-    for (const suggestion of generateSuggestionsForFilter(filter)) {
-      suggestions.add(suggestion);
-    }
-    for (const suggestion of filter.suggestionsGenerator?.(suggestionsContext) ?? []) {
+    for (const suggestion of generateSuggestionsForFilter(filter, suggestionsContext)) {
       suggestions.add(suggestion);
     }
   }

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -18,7 +18,7 @@ import {
   statHashByName,
   weaponStatNames,
 } from '../search-filter-values';
-import { generateSuggestionsForFilter } from '../suggestions-generation';
+import { generateGroupedSuggestionsForFilter } from '../suggestions-generation';
 
 const validateStat: FilterDefinition['validateStat'] = (filterContext) => {
   const customStatLabels = filterContext?.customStats?.map((c) => c.shortLabel) ?? [];
@@ -36,7 +36,7 @@ const statFilters: FilterDefinition[] = [
     description: tl('Filter.Stats'),
     format: 'stat',
     suggestionsGenerator: ({ customStats }) =>
-      generateSuggestionsForFilter({
+      generateGroupedSuggestionsForFilter({
         keywords: 'stat',
         format: 'stat',
         suggestions: [...allAtomicStats, ...(customStats?.map((c) => c.shortLabel) ?? [])],

--- a/src/app/search/suggestions-generation.ts
+++ b/src/app/search/suggestions-generation.ts
@@ -66,10 +66,11 @@ const operators = ['<', '>', '<=', '>=']; // TODO: add "none"? remove >=, <=?
 export function generateSuggestionsForFilter(
   filterDefinition: Pick<
     FilterDefinition,
-    'keywords' | 'suggestions' | 'format' | 'overload' | 'deprecated'
-  >
+    'keywords' | 'suggestions' | 'format' | 'overload' | 'deprecated' | 'suggestionsGenerator'
+  >,
+  suggestionsContext: SuggestionsContext = {}
 ) {
-  return generateGroupedSuggestionsForFilter(filterDefinition, false).flatMap(
+  return generateGroupedSuggestionsForFilter(filterDefinition, false, suggestionsContext).flatMap(
     ({ keyword, ops }) => {
       if (ops) {
         return [keyword].concat(ops.map((op) => `${keyword}${op}`));
@@ -83,9 +84,10 @@ export function generateSuggestionsForFilter(
 export function generateGroupedSuggestionsForFilter(
   filterDefinition: Pick<
     FilterDefinition,
-    'keywords' | 'suggestions' | 'format' | 'overload' | 'deprecated'
+    'keywords' | 'suggestions' | 'format' | 'overload' | 'deprecated' | 'suggestionsGenerator'
   >,
-  forHelp?: boolean
+  forHelp?: boolean,
+  suggestionsContext: SuggestionsContext = {}
 ): { keyword: string; ops?: string[] }[] {
   if (filterDefinition.deprecated) {
     return [];
@@ -162,6 +164,14 @@ export function generateGroupedSuggestionsForFilter(
         break;
       case 'custom':
         break;
+    }
+  }
+
+  for (const suggestion of filterDefinition.suggestionsGenerator?.(suggestionsContext) ?? []) {
+    if (typeof suggestion === 'string') {
+      allSuggestions.push({ keyword: suggestion });
+    } else {
+      allSuggestions.push(suggestion);
     }
   }
 


### PR DESCRIPTION
This probably broke with custom stats; the Filters Help page collapses suggestions where only the operator differs into a single line, but the stat filter suggestions are now constructed differently. Reduces the sheet height by about a fifth.