### PR TITLE
Move icons into menu for phone search

### DIFF
--- a/src/app/dim-ui/Dropdown.m.scss
+++ b/src/app/dim-ui/Dropdown.m.scss
@@ -22,7 +22,7 @@
   white-space: nowrap;
 
   @include phone-portrait {
-    padding: 10px 16px;
+    padding: 8px 16px;
     font-size: 14px;
   }
 

--- a/src/app/loadout/loadout-edit/LoadoutEditSection.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSection.tsx
@@ -108,7 +108,7 @@ export default function LoadoutEditSection({
             <AppIcon icon={disabledIcon} />
           </button>
         )}
-        <Dropdown kebab options={options} placement="bottom-end" />
+        <Dropdown kebab options={options} />
       </div>
       {children}
     </div>

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -1,7 +1,7 @@
 import { t } from 'app/i18next-t';
 import { toggleSearchResults } from 'app/shell/actions';
 import { AppIcon, faList } from 'app/shell/icons';
-import { querySelector, searchResultsOpenSelector } from 'app/shell/selectors';
+import { querySelector, searchResultsOpenSelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyArray } from 'app/utils/empty';
 import { Portal } from 'app/utils/temp-container';
 import { motion } from 'framer-motion';
@@ -9,8 +9,8 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import styles from './MainSearchBarActions.m.scss';
-import { filteredItemsSelector, queryValidSelector } from './search-filter';
 import SearchResults from './SearchResults';
+import { filteredItemsSelector, queryValidSelector } from './search-filter';
 
 /**
  * The extra buttons that appear in the main search bar when there are matched items.
@@ -21,6 +21,7 @@ export default function MainSearchBarActions() {
   const filteredItems = useSelector(filteredItemsSelector);
   const searchResultsOpen = useSelector(searchResultsOpenSelector);
   const dispatch = useDispatch();
+  const isPhonePortrait = useIsPhonePortrait();
 
   const location = useLocation();
   const onInventory = location.pathname.endsWith('inventory');
@@ -30,7 +31,7 @@ export default function MainSearchBarActions() {
 
   // We don't have access to the selected store so we'd match multiple characters' worth.
   // Just suppress the count for now
-  const showSearchResults = onInventory;
+  const showSearchResults = onInventory && !isPhonePortrait;
   const showSearchCount = Boolean(
     queryValid && searchQuery && !onProgress && !onRecords && !onVendors
   );

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -546,7 +546,7 @@ function SearchBar(
           <AnimatePresence>
             {children}
 
-            {liveQuery.length > 0 && (saveable || saved) && (
+            {liveQuery.length > 0 && (saveable || saved) && !isPhonePortrait && (
               <motion.button
                 layout
                 exit={{ scale: 0 }}


### PR DESCRIPTION
Not sure if this is great, but this is an experiment in removing the favorite and show results icons from the search bar on mobile and moving them into the actions menu. As a result the actions menu needed to get condensed down a little - pretty soon I'll have to make it scrollable.

<img width="440" alt="Screenshot 2023-04-11 at 11 13 34 PM" src="https://user-images.githubusercontent.com/313208/231367168-0b8c6e75-b33e-4b2c-bc2f-ee9a8d19ff17.png">
