### PR TITLE
clearer equippedness markings

### DIFF
--- a/src/app/loadout/ingame/InGameLoadoutStrip.m.scss
+++ b/src/app/loadout/ingame/InGameLoadoutStrip.m.scss
@@ -28,7 +28,7 @@
   display: flex;
 }
 .isEquipped {
-  outline: #ccc solid 2px;
+  outline: $green solid 2px;
 }
 .kebab {
   background-color: black;
@@ -36,6 +36,9 @@
     height: 100%;
     cursor: pointer;
   }
+}
+.equipAlready {
+  color: $green;
 }
 .equipOk {
   color: #fffa;

--- a/src/app/loadout/ingame/InGameLoadoutStrip.m.scss.d.ts
+++ b/src/app/loadout/ingame/InGameLoadoutStrip.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'deleteDanger': string;
+  'equipAlready': string;
   'equipNok': string;
   'equipOk': string;
   'igtIcon': string;

--- a/src/app/loadout/ingame/InGameLoadoutStrip.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutStrip.tsx
@@ -146,24 +146,25 @@ function InGameLoadoutTile({
     tooltipContent.push(
       <React.Fragment key="isequipped">
         {tooltipContent.length > 1 && <hr />}
+        <AppIcon icon={faCheckCircle} className={clsx(styles.statusAppIcon, styles.equipAlready)} />
         <span> {t('InGameLoadout.CurrentlyEquipped')}</span>
       </React.Fragment>
     );
+  } else {
+    tooltipContent.push(
+      <React.Fragment key="equippable">
+        {tooltipContent.length > 1 && <hr />}
+        <AppIcon
+          icon={isEquippable ? faCheckCircle : faExclamationCircle}
+          className={clsx(styles.statusAppIcon, isEquippable ? styles.equipOk : styles.equipNok)}
+        />
+        <span>
+          {' '}
+          {isEquippable ? t('InGameLoadout.EquipReady') : t('InGameLoadout.EquipNotReady')}
+        </span>
+      </React.Fragment>
+    );
   }
-
-  tooltipContent.push(
-    <React.Fragment key="equippable">
-      {tooltipContent.length > 1 && <hr />}
-      <AppIcon
-        icon={isEquippable ? faCheckCircle : faExclamationCircle}
-        className={clsx(styles.statusAppIcon, isEquippable ? styles.equipOk : styles.equipNok)}
-      />
-      <span>
-        {' '}
-        {isEquippable ? t('InGameLoadout.EquipReady') : t('InGameLoadout.EquipNotReady')}
-      </span>
-    </React.Fragment>
-  );
 
   return (
     <div
@@ -176,8 +177,11 @@ function InGameLoadoutTile({
             <InGameLoadoutIconWithIndex loadout={gameLoadout} className={styles.igtIcon} />
           </div>
           <AppIcon
-            icon={isEquippable ? faCheckCircle : faExclamationCircle}
-            className={clsx(styles.statusAppIcon, isEquippable ? styles.equipOk : styles.equipNok)}
+            icon={isEquipped || isEquippable ? faCheckCircle : faExclamationCircle}
+            className={clsx(
+              styles.statusAppIcon,
+              isEquipped ? styles.equipAlready : isEquippable ? styles.equipOk : styles.equipNok
+            )}
           />
           {matchingLoadouts.length > 0 && (
             <AppIcon icon={saveIcon} className={styles.statusAppIcon} />


### PR DESCRIPTION
remove a redundant signifier of both equippable & equipped.
provide a clearer color hint about what the outline means.

before
![image](https://user-images.githubusercontent.com/68782081/231673154-1f6d0e35-4072-4141-95ca-7c491684c089.png)

after
![image](https://user-images.githubusercontent.com/68782081/231673186-c60c89e4-82f6-416b-9a33-93e1b5ef9d70.png)
