### PR TITLE
restore "Send to Stream Deck" button in the new in-game loadout sheet

### DIFF
--- a/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
@@ -8,6 +8,8 @@ import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { convertInGameLoadoutToDimLoadout } from 'app/loadout-drawer/loadout-type-converters';
 import { InGameLoadout, Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { streamDeckSelectionSelector } from 'app/stream-deck/selectors';
+import { streamDeckSelectLoadout } from 'app/stream-deck/stream-deck';
 import { isKillTrackerSocket } from 'app/utils/item-utils';
 import { getSocketsByCategoryHashes, socketContainsIntrinsicPlug } from 'app/utils/socket-utils';
 import { ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
@@ -43,6 +45,7 @@ export function InGameLoadoutDetails({
     const dimLoadout = convertInGameLoadoutToDimLoadout(loadout, store.classType, allItems);
     editLoadout(dimLoadout, store.id, { isNew: true });
   };
+
   const handleShare = () => {
     const dimLoadout = convertInGameLoadoutToDimLoadout(loadout, store.classType, allItems);
     onShare(dimLoadout);
@@ -53,6 +56,11 @@ export function InGameLoadoutDetails({
       <h1>{loadout.name}</h1>
     </div>
   );
+
+  const streamDeckSelection = $featureFlags.elgatoStreamDeck
+    ? // eslint-disable-next-line
+      useSelector(streamDeckSelectionSelector)
+    : null;
 
   return (
     <Sheet onClose={onClose} header={header} sheetClassName={styles.sheet} allowClickThrough>
@@ -83,6 +91,15 @@ export function InGameLoadoutDetails({
         <ConfirmButton danger onClick={() => dispatch(deleteInGameLoadout(loadout))}>
           {t('InGameLoadout.ClearSlot', { index: loadout.index + 1 })}
         </ConfirmButton>
+        {streamDeckSelection === 'loadout' && (
+          <button
+            type="button"
+            className="dim-button"
+            onClick={() => dispatch(streamDeckSelectLoadout({ type: 'game', loadout }, store))}
+          >
+            {t('StreamDeck.SelectLoadout')}
+          </button>
+        )}
       </div>
       <div className={styles.itemGroups}>
         {_.partition(gameLoadoutCompatibleBuckets, (h) => buckets.byHash[h].sort !== 'Armor').map(


### PR DESCRIPTION
Fix for #9395 
![image](https://user-images.githubusercontent.com/6225939/231885255-b04fc4da-b337-4600-97cc-dea8403d86c1.png)
