### PR TITLE
Fix master: Use item id when resolving loadout subclass.

### DIFF
--- a/src/app/loadout/ingame/ingame-loadout-utils.ts
+++ b/src/app/loadout/ingame/ingame-loadout-utils.ts
@@ -124,7 +124,7 @@ export function implementsDimLoadout(
   if (dimSubclass?.loadoutItem?.socketOverrides) {
     // This was checked as part of item matching.
     const inGameSubclass = inGameLoadout.items.find(
-      (item) => item.itemInstanceId === dimSubclass.loadoutItem.id
+      (item) => item.itemInstanceId === dimSubclass.item.id
     )!;
 
     const dimSubclassPlugs = getSubclassPlugs(defs, dimSubclass);


### PR DESCRIPTION
## Overview

Apparently you cannot use the loadout item id to resolve the subclass.