### PR TITLE
Fix loadout application with holes in subclass socketOverrides not showing ability plugs in progress notification

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixed Adept Draw Time marking the draw time stat as negatively affected (red) instead of positively affected (blue).
 * Loadout Optimizer and Loadouts now consistently allow you to choose not yet unlocked Fragments and Aspects. Previously this was only working for some characters.
+* Fixed an issue where the DIM Loadout apply notification was sometimes not showing that it performed changes to subclass abilities.
 
 ## 7.64.1 <span class="changelog-date">(2023-04-16)</span>
 

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -15,7 +15,6 @@ import { useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyArray, emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
 import {
-  getDefaultAbilityChoiceHash,
   getSocketByIndex,
   getSocketsByCategoryHashes,
   subclassAbilitySocketCategoryHashes,
@@ -138,13 +137,13 @@ export default memo(function LockArmorAndPerks({
   // We need to track whether it is a default ability as those cannot be deleted.
   const socketOverridePlugs: {
     plug: PluggableInventoryItemDefinition;
-    isDefaultAbility: boolean;
+    isAbility: boolean;
   }[] = useMemo(() => {
     if (!subclass?.loadoutItem.socketOverrides || !subclass.item.sockets) {
       return emptyArray();
     }
 
-    const rtn: { plug: PluggableInventoryItemDefinition; isDefaultAbility: boolean }[] = [];
+    const rtn: { plug: PluggableInventoryItemDefinition; isAbility: boolean }[] = [];
 
     for (const socketIndexString of Object.keys(subclass?.loadoutItem.socketOverrides)) {
       const socketIndex = parseInt(socketIndexString, 10);
@@ -158,13 +157,9 @@ export default memo(function LockArmorAndPerks({
         subclass.loadoutItem.socketOverrides[socketIndex]
       ) as PluggableInventoryItemDefinition;
 
-      const isDefaultAbility = Boolean(
-        socket &&
-          getDefaultAbilityChoiceHash(socket) === overridePlug.hash &&
-          abilityAndSuperSockets.includes(socket)
-      );
+      const isAbility = Boolean(socket && abilityAndSuperSockets.includes(socket));
 
-      rtn.push({ plug: overridePlug, isDefaultAbility });
+      rtn.push({ plug: overridePlug, isAbility });
     }
 
     return rtn;
@@ -237,12 +232,12 @@ export default memo(function LockArmorAndPerks({
               lockedItem={subclass.item}
               onRemove={() => lbDispatch({ type: 'removeSubclass' })}
             />
-            {socketOverridePlugs.map(({ plug, isDefaultAbility }) => (
+            {socketOverridePlugs.map(({ plug, isAbility }) => (
               <PlugDef
                 key={getModRenderKey(plug)}
                 plug={plug}
                 onClose={
-                  isDefaultAbility
+                  isAbility
                     ? undefined
                     : () => lbDispatch({ type: 'removeSingleSubclassSocketOverride', plug })
                 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -25,8 +25,8 @@ import { mapToNonReducedModCostVariant } from 'app/loadout/mod-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName } from 'app/search/d2-known-values';
 import { emptyObject } from 'app/utils/empty';
+import { errorLog } from 'app/utils/log';
 import {
-  getDefaultAbilityChoiceHash,
   getSocketsByCategoryHashes,
   subclassAbilitySocketCategoryHashes,
 } from 'app/utils/socket-utils';
@@ -485,17 +485,16 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
           }
         }
 
-        // If we are removing from an ability/super socket, find the socket so we can
-        // show the default plug instead
-        const abilitySocketRemovingFrom = abilityAndSuperSockets.find(
+        const isAbilitySocket = abilityAndSuperSockets.find(
           (socket) => socket.socketIndex === socketIndexToRemove
         );
 
-        if (socketIndexToRemove !== undefined && abilitySocketRemovingFrom) {
-          // If this is an ability socket, replace with the default plug hash
-          newSocketOverrides[socketIndexToRemove] =
-            getDefaultAbilityChoiceHash(abilitySocketRemovingFrom);
-        } else if (socketIndexToRemove) {
+        if (isAbilitySocket) {
+          errorLog('loadout builder', 'cannot remove ability');
+          return state;
+        }
+
+        if (socketIndexToRemove !== undefined) {
           // If its not an ability we just remove it from the overrides
           delete newSocketOverrides[socketIndexToRemove];
         }

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -588,7 +588,6 @@ function doApplyLoadout(
       if (itemsWithOverrides.length) {
         setLoadoutState(setLoadoutApplyPhase(LoadoutApplyPhase.SocketOverrides));
 
-        // TODO (ryan) the items with overrides here don't have the default plugs included in them
         infoLog('loadout socket overrides', 'Socket overrides to apply', itemsWithOverrides);
         await dispatch(
           applySocketOverrides(itemsWithOverrides, setLoadoutState, getLoadoutItem, cancelToken)


### PR DESCRIPTION
Fixes the issue we discussed. Also changes LO to not offer a "drop" button for ability sockets, since it doesn't make sense to privilege one of the plug options and we should just all treat them equally.