### PR TITLE
Always allow configuring locked subclass plugs instead of only sometimes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Fixed Adept Draw Time marking the draw time stat as negatively affected (red) instead of positively affected (blue).
+* Loadout Optimizer and Loadouts now consistently allow you to choose not yet unlocked Fragments and Aspects. Previously this was only working for some characters.
 
 ## 7.64.1 <span class="changelog-date">(2023-04-16)</span>
 


### PR DESCRIPTION
I don't believe there was a situation where unlocked plugs were erroneously hidden, but it's confusing when we mostly ignore unlock status and then honor it for Stasis. Fixes #9399.