### PR TITLE
Variable-ise styles + visual tweaks in prep for theming 

### DIFF
--- a/src/app/App.m.scss
+++ b/src/app/App.m.scss
@@ -3,7 +3,7 @@
 .app {
   &::before {
     @include below-header;
-    background: $gradient;
+    background: var(--theme-background-app-body);
     background-position: center top;
     background-repeat: no-repeat;
     content: '';

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -142,21 +142,36 @@ produces
 
 // Theme variables
 :root {
+  // Font
   --theme-font-primary: 'Open Sans';
 
   // Base colours
   --theme-accent-primary: #e8a534;
   --theme-accent-secondary: #68a0b7;
 
+  --theme-fill-primary: red; // Base popups, drawers, dropdowns
+  --theme-fill-secondary: #161616; // Certain layered dropdowns e.g. so far only search
+
+  // Panels and sub-frames e.g. masterwork/catalyst progress
+  --theme-fill-lighten: rgba(255, 255, 255, 0.15);
+  --theme-fill-darken: rgba(0, 0, 0, 0.35);
+
+  --theme-button: rgba(255, 255, 255, 0.2);
+
+  --theme-corner-radius-search: 6px;
+  --theme-corner-radius-tooltip: 6px;
+
+  // App background gradient
   --theme-background-app-gradient-start: hsl(240, 20%, 28%);
   --theme-background-app-gradient-end: hsl(240, 27%, 12%);
+
   --theme-background-app-gradient: radial-gradient(
     circle at 50% 70px,
     var(--theme-background-app-gradient-start) 0%,
     var(--theme-background-app-gradient-end) 100%
   );
 
-  // Discreet segments of header and app body
+  // Discreet sections of header and app body
   --theme-background-app-header-primary: var(--theme-background-app-gradient);
   --theme-background-app-header-secondary: var(--theme-background-app-gradient);
   --theme-background-app-body: var(--theme-background-app-gradient);

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -86,7 +86,21 @@ $easeInOutCubic: cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
 @mixin draggable-hover-border {
-  outline: 1px solid #ddd;
+  &:hover {
+    outline: 1px solid #fff;
+    transform: scale(1.3);
+    transition: all 0.2s ease-out;
+    box-shadow: var(--theme-drop-shadow-only);
+    z-index: 1;
+  }
+
+  // Shrink item on click so an 'enlarged' tile isn't clipped whilst dragging
+  &:active {
+    transition: 0s;
+    transform: scale(1);
+    outline: 2px solid white;
+    box-shadow: 0 3px 12px 0 rgba(0, 0, 0, 1);
+  }
 
   @include phone-portrait {
     outline: none;
@@ -162,7 +176,7 @@ produces
   --theme-corner-radius-tooltip: 6px;
 
   // Shadows and layering styles
-  --theme-drop-shadow-only: 0 0 10px 0 #000;
+  --theme-drop-shadow-only: 0 0 18px 0 #000;
   --theme-inset-outline: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
   --theme-drop-shadow-framed: var(--theme-inset-outline), var(--theme-drop-shadow-only);
 

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -164,21 +164,27 @@ produces
   --theme-accent-secondary: #68a0b7;
 
   --theme-fill-primary: #000; // Base popups, drawers, dropdowns
-  --theme-fill-secondary: #161616; // Certain layered dropdowns e.g. so far only search
+  --theme-fill-secondary: #161616; // Layered dropdowns inc search, item actions
 
-  // Panels and sub-frames e.g. masterwork/catalyst progress
+  // Fills to tint panels and sub-frames e.g. masterwork/catalyst progress
   --theme-fill-lighten: rgba(255, 255, 255, 0.15);
   --theme-fill-darken: rgba(0, 0, 0, 0.35);
 
   --theme-button: rgba(255, 255, 255, 0.2);
-
   --theme-corner-radius-search: 6px;
-  --theme-corner-radius-tooltip: 6px;
 
-  // Shadows and layering styles
+  // Outlines + shadows for layering
   --theme-drop-shadow-only: 0 0 18px 0 #000;
-  --theme-inset-outline: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
-  --theme-drop-shadow-framed: var(--theme-inset-outline), var(--theme-drop-shadow-only);
+  --theme-outline-inset: inset 0 0 0 1px rgba(255, 255, 255, 0.2); // Outline on most popups/panels
+  --theme-outline-inset-strong: inset 0 0 0 1px rgba(255, 255, 255, 0.4); // Search box hover
+  --theme-drop-shadow-framed: var(--theme-outline-inset), var(--theme-drop-shadow-only);
+
+  // Tooltips and arrows
+  --theme-tooltip-arrow-size: 8px; // Ensure this stays in sync with 'popperArrowSize' in 'usePopper.ts'
+  --theme-tooltip-background-color: #151523;
+  --theme-tooltip-border-color: #8e8e9e;
+  --theme-tooltip-minimal-color: #5d5970;
+  --theme-tooltip-corner-radius: 6px;
 
   // App background gradient
   --theme-background-app-gradient-start: hsl(240, 20%, 28%);
@@ -190,12 +196,8 @@ produces
     var(--theme-background-app-gradient-end) 100%
   );
 
-  // Discreet sections of header and app body
+  // Discreet segments of header and app body
   --theme-background-app-header-primary: var(--theme-background-app-gradient);
   --theme-background-app-header-secondary: var(--theme-background-app-gradient);
   --theme-background-app-body: var(--theme-background-app-gradient);
 }
-
-// TODO: fix sass functions that need colors
-$orange: #e8a534;
-$blue: #68a0b7;

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -149,7 +149,7 @@ produces
   --theme-accent-primary: #e8a534;
   --theme-accent-secondary: #68a0b7;
 
-  --theme-fill-primary: red; // Base popups, drawers, dropdowns
+  --theme-fill-primary: #000; // Base popups, drawers, dropdowns
   --theme-fill-secondary: #161616; // Certain layered dropdowns e.g. so far only search
 
   // Panels and sub-frames e.g. masterwork/catalyst progress
@@ -160,6 +160,11 @@ produces
 
   --theme-corner-radius-search: 6px;
   --theme-corner-radius-tooltip: 6px;
+
+  // Shadows and layering styles
+  --theme-drop-shadow-only: 0 0 10px 0 #000;
+  --theme-inset-outline: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+  --theme-drop-shadow-framed: var(--theme-inset-outline), var(--theme-drop-shadow-only);
 
   // App background gradient
   --theme-background-app-gradient-start: hsl(240, 20%, 28%);

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -2,16 +2,8 @@
 
 // Variables and mixins that can be used from any SCSS file
 
-// DIM orange and blue, accent colors
-$orange: #e8a534;
-$blue: #68a0b7;
 $red: #ff3232; // For warnings/errors
 $green: #51a351; // For success statuses or positive deltas
-$gradient: radial-gradient(
-  circle at 50% 70px,
-  hsl(240, 20%, 28%) 0%,
-  hsl(240, 27%, 12%) 100%
-); // new background gradient
 
 // Blue used to denote community-provided data
 $communityBlue: #0d7fad;
@@ -147,3 +139,29 @@ produces
 @function dim-rgb-values-to-rgba($values, $alpha: 1) {
   @return #{'rgba(' + $values + ', ' + $alpha + ')'};
 }
+
+// Theme variables
+:root {
+  --theme-font-primary: 'Open Sans';
+
+  // Base colours
+  --theme-accent-primary: #e8a534;
+  --theme-accent-secondary: #68a0b7;
+
+  --theme-background-app-gradient-start: hsl(240, 20%, 28%);
+  --theme-background-app-gradient-end: hsl(240, 27%, 12%);
+  --theme-background-app-gradient: radial-gradient(
+    circle at 50% 70px,
+    var(--theme-background-app-gradient-start) 0%,
+    var(--theme-background-app-gradient-end) 100%
+  );
+
+  // Discreet segments of header and app body
+  --theme-background-app-header-primary: var(--theme-background-app-gradient);
+  --theme-background-app-header-secondary: var(--theme-background-app-gradient);
+  --theme-background-app-body: var(--theme-background-app-gradient);
+}
+
+// TODO: fix sass functions that need colors
+$orange: #e8a534;
+$blue: #68a0b7;

--- a/src/app/accounts/Account.m.scss
+++ b/src/app/accounts/Account.m.scss
@@ -27,7 +27,7 @@
 }
 
 .selectedAccount {
-  border-left: 4px solid $orange;
+  border-left: 4px solid var(--theme-accent-primary);
   padding-left: calc(1rem - 4px) !important;
   padding-right: 24px;
   height: 100%;

--- a/src/app/accounts/MenuAccounts.m.scss
+++ b/src/app/accounts/MenuAccounts.m.scss
@@ -18,7 +18,7 @@
       &:hover,
       &:focus {
         color: black;
-        background-color: $orange;
+        background-color: var(--theme-accent-primary);
       }
     }
   }

--- a/src/app/accounts/SelectAccount.m.scss
+++ b/src/app/accounts/SelectAccount.m.scss
@@ -26,8 +26,8 @@
   }
   &:hover,
   &:focus {
-    border-color: $orange;
-    color: $orange;
+    border-color: var(--theme-accent-primary);
+    color: var(--theme-accent-primary);
     background-color: rgba(255, 255, 255, 0.1);
   }
 }

--- a/src/app/character-tile/StoreHeading.scss
+++ b/src/app/character-tile/StoreHeading.scss
@@ -11,6 +11,7 @@
 
   &.vault {
     width: calc(6px + var(--character-column-width) - var(--item-margin));
+
     @include phone-portrait {
       width: auto;
     }
@@ -22,7 +23,7 @@
     top: 0;
     left: 0;
     z-index: 1;
-    border-top: 13px solid $orange;
+    border-top: 13px solid var(--theme-accent-primary);
     border-right: 13px solid transparent;
   }
 
@@ -40,10 +41,7 @@
         content: '';
         display: block;
         position: absolute;
-        top: -4px;
-        left: -4px;
-        right: -4px;
-        bottom: -4px;
+        inset: -4px -4px -4px -4px;
         border: 1px solid white;
         pointer-events: none;
       }

--- a/src/app/compare/Compare.m.scss
+++ b/src/app/compare/Compare.m.scss
@@ -15,7 +15,7 @@
 }
 
 .sorted {
-  color: $orange;
+  color: var(--theme-accent-primary);
 }
 
 .spacer {

--- a/src/app/compare/CompareItem.m.scss
+++ b/src/app/compare/CompareItem.m.scss
@@ -18,7 +18,7 @@
 }
 
 .initialItem {
-  color: $orange;
+  color: var(--theme-accent-primary);
   font-weight: bold;
 }
 
@@ -54,6 +54,6 @@
   background-position: center;
   background-repeat: no-repeat;
   &:hover {
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
   }
 }

--- a/src/app/destiny1/loadout-builder/loadout-builder.scss
+++ b/src/app/destiny1/loadout-builder/loadout-builder.scss
@@ -1,6 +1,6 @@
 @import '../../variables';
 
-$or-color: $orange;
+$or-color: var(--theme-accent-primary);
 $and-color: #814bcf;
 
 .loadout-builder {
@@ -8,6 +8,7 @@ $and-color: #814bcf;
 
   .section {
     margin-bottom: 16px;
+
     @include phone-portrait {
       margin-left: 16px;
       margin-right: 16px;
@@ -97,7 +98,7 @@ $and-color: #814bcf;
   }
 
   .expand-configs:hover {
-    color: $orange;
+    color: var(--theme-accent-primary);
     cursor: pointer;
   }
 
@@ -297,6 +298,7 @@ $and-color: #814bcf;
   .dim-stats {
     display: inline-block;
     margin-left: 22px;
+
     @media (max-width: 680px) {
       margin-left: 4px;
     }
@@ -304,6 +306,7 @@ $and-color: #814bcf;
     .stat-bars {
       width: 375px;
       margin-top: 0;
+
       @media (max-width: 680px) {
         width: 150px;
         display: inline-block;

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
@@ -48,6 +48,6 @@
   &:focus {
     background: black;
     outline: none;
-    border-bottom: 1px solid $orange;
+    border-bottom: 1px solid var(--theme-accent-primary);
   }
 }

--- a/src/app/dim-ui/CheckButton.m.scss
+++ b/src/app/dim-ui/CheckButton.m.scss
@@ -21,10 +21,9 @@
     flex-shrink: 0;
   }
 
-  // Don't do hover
   &:hover,
   &:active {
-    background-color: rgba(255, 255, 255, 0.2) !important;
+    background-color: rgba(255, 255, 255, 0.3) !important;
     color: white !important;
   }
 }

--- a/src/app/dim-ui/ClosableContainer.m.scss
+++ b/src/app/dim-ui/ClosableContainer.m.scss
@@ -16,10 +16,10 @@
   background-image: url('images/close.png');
   background-color: rgba(100, 100, 100, 0.8);
   &:hover {
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
   }
   &:focus {
-    outline: 1px solid $blue;
+    outline: 1px solid var(--theme-accent-secondary);
   }
 }
 

--- a/src/app/dim-ui/CollapsibleTitle.scss
+++ b/src/app/dim-ui/CollapsibleTitle.scss
@@ -42,7 +42,7 @@
   .collapse-icon {
     font-size: 16px;
     &:hover {
-      color: $orange;
+      color: var(--theme-accent-primary);
     }
     margin-left: -4px;
     width: 10px;

--- a/src/app/dim-ui/Dropdown.m.scss
+++ b/src/app/dim-ui/Dropdown.m.scss
@@ -7,7 +7,7 @@
 
 .menu {
   position: absolute;
-  background: black;
+  background: var(--theme-fill-primary);
   color: white;
   font-size: 12px;
   z-index: 100;

--- a/src/app/dim-ui/Dropdown.m.scss
+++ b/src/app/dim-ui/Dropdown.m.scss
@@ -43,7 +43,7 @@
 }
 
 .highlighted {
-  background-color: $orange;
+  background-color: var(--theme-accent-primary);
   color: black !important;
   :global(.app-icon) {
     color: black !important;

--- a/src/app/dim-ui/Dropdown.m.scss
+++ b/src/app/dim-ui/Dropdown.m.scss
@@ -8,6 +8,7 @@
 .menu {
   position: absolute;
   background: var(--theme-fill-primary);
+  box-shadow: var(--theme-drop-shadow-framed);
   color: white;
   font-size: 12px;
   z-index: 100;
@@ -51,7 +52,9 @@
 }
 
 .disabled {
-  color: #999 !important;
+  color: #666 !important;
+  cursor: not-allowed;
+
   :global(.app-icon) {
     color: #999 !important;
   }
@@ -63,7 +66,6 @@
 .kebabButton {
   composes: resetButton from './common.m.scss';
   padding: 4px 8px;
-  color: #999;
   transition: all 150ms ease-out;
   &:active,
   &:hover,

--- a/src/app/dim-ui/FilterPills.m.scss
+++ b/src/app/dim-ui/FilterPills.m.scss
@@ -42,6 +42,6 @@
 }
 
 .selected {
-  border-color: $orange !important;
+  border-color: var(--theme-accent-primary) !important;
   background: rgba(0, 0, 0, 0.6);
 }

--- a/src/app/dim-ui/KeyHelp.m.scss
+++ b/src/app/dim-ui/KeyHelp.m.scss
@@ -17,9 +17,4 @@
     display: none;
     margin: 0;
   }
-
-  :global(.highlighted) & {
-    color: #222;
-    border-color: #222;
-  }
 }

--- a/src/app/dim-ui/PageWithMenu.m.scss
+++ b/src/app/dim-ui/PageWithMenu.m.scss
@@ -34,6 +34,7 @@
   }
   :global(.issue-banner-shown) & {
     padding-bottom: $issue-banner-height;
+
     @include phone-portrait {
       padding-bottom: 0;
     }
@@ -99,6 +100,12 @@
   align-items: center;
   margin-bottom: 4px;
   min-height: 24px;
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 4px;
+  }
 
   img {
     height: 24px;

--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -1,7 +1,6 @@
 @use '../variables.scss' as *;
 @use 'sass:color';
 
-$ribbon-width: 6px;
 $arrow-size: 15px; // ensure this stays in sync with 'popperArrowSize' in 'usePopper.ts'
 $minimal-arrow-size: 10px;
 $horizontal-padding: 11px;
@@ -23,8 +22,8 @@ $horizontal-padding: 11px;
   width: fit-content;
   max-width: 306px;
   border: 1px solid dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
-  border-top-width: $ribbon-width;
-  border-radius: $ribbon-width;
+  border-top-width: var(--theme-corner-radius);
+  border-radius: var(--theme-corner-radius);
   box-shadow: 0 0 24px 6px #080811;
   text-align: left;
   z-index: 99999;
@@ -39,11 +38,11 @@ $horizontal-padding: 11px;
     display: block;
     position: absolute;
     background-color: var(--tooltip-ribbon-color);
-    height: $ribbon-width;
-    top: -$ribbon-width;
+    height: var(--theme-corner-radius);
+    top: calc(-1 * var(--theme-corner-radius));
     left: -1px;
     right: -1px;
-    border-radius: $ribbon-width $ribbon-width 0 0;
+    border-radius: var(--theme-corner-radius) var(--theme-corner-radius) 0 0;
   }
 
   &.wideTooltip {
@@ -66,6 +65,7 @@ $horizontal-padding: 11px;
       font-size: 14px;
       margin: 0;
       color: white;
+
       @include destiny-header;
     }
 
@@ -104,7 +104,7 @@ $horizontal-padding: 11px;
     height: 0;
     border-width: 0 var(--length) var(--length) var(--length);
     border-color: transparent transparent var(--tooltip-ribbon-color) transparent;
-    top: calc(#{-$ribbon-width} - var(--length));
+    top: calc(calc(-1 * var(--theme-corner-radius)) - var(--length));
   }
   &[data-popper-placement='right'] .arrow {
     width: 0;

--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -1,8 +1,7 @@
 @use '../variables.scss' as *;
 @use 'sass:color';
 
-$arrow-size: 16px; // ensure this stays in sync with 'popperArrowSize' in 'usePopper.ts'
-$minimal-arrow-size: 10px;
+$minimal-arrow-size: 8px;
 $horizontal-padding: 11px;
 
 .control {
@@ -16,18 +15,18 @@ $horizontal-padding: 11px;
 }
 
 .tooltip {
-  --tooltip-ribbon-color: #8e8e9e;
-  --tooltip-background-color: #151523;
-  --tooltip-border-color-rgb: #{dim-hex-to-rgb-values(#5d5970)};
+  // --tooltip-ribbon-color: #8e8e9e;
+  // --theme-tooltip-background-color: #151523;
+  // --theme-tooltip-border-color-rgb: #{dim-hex-to-rgb-values(#5d5970)};
 
   position: absolute;
-  background-color: var(--tooltip-background-color);
+  background-color: var(--theme-tooltip-background-color);
   color: #dadaea;
   width: fit-content;
   max-width: 306px;
-  border: 1px solid dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
-  border-top-width: var(--theme-corner-radius-tooltip);
-  border-radius: var(--theme-corner-radius-tooltip);
+  border: 1px solid var(--theme-tooltip-border-color);
+  border-top-width: var(--theme-tooltip-corner-radius);
+  border-radius: var(--theme-tooltip-corner-radius);
   box-shadow: 0 0 24px 6px #080811;
   text-align: left;
   z-index: 99999;
@@ -41,12 +40,12 @@ $horizontal-padding: 11px;
     content: '';
     display: block;
     position: absolute;
-    background-color: var(--tooltip-ribbon-color);
-    height: var(--theme-corner-radius-tooltip);
-    top: calc(-1 * var(--theme-corner-radius-tooltip));
+    background-color: var(--theme-tooltip-border-color);
+    height: var(--theme-tooltip-corner-radius);
+    top: calc(-1 * var(--theme-tooltip-corner-radius));
     left: -1px;
     right: -1px;
-    border-radius: var(--theme-corner-radius-tooltip) var(--theme-corner-radius-tooltip) 0 0;
+    border-radius: var(--theme-tooltip-corner-radius) var(--theme-tooltip-corner-radius) 0 0;
   }
 
   &.wideTooltip {
@@ -54,7 +53,7 @@ $horizontal-padding: 11px;
   }
 
   hr {
-    border-color: dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
+    border-color: var(--theme-tooltip-border-color);
   }
 
   p {
@@ -62,7 +61,7 @@ $horizontal-padding: 11px;
   }
 
   .header {
-    background-color: #0a0a0f;
+    background-color: var(--theme-fill-secondary);
     padding: 6px $horizontal-padding;
 
     h2 {
@@ -85,56 +84,48 @@ $horizontal-padding: 11px;
   }
 
   .arrow {
-    --length: #{$arrow-size * 0.5};
-    width: calc(var(--length) * 2);
-    height: calc(var(--length) * 2);
-    border-width: 0;
+    width: var(--theme-tooltip-arrow-size);
+    height: var(--theme-tooltip-arrow-size);
     border-style: solid;
     position: absolute;
-    border-color: var(--tooltip-ribbon-color);
+    border-color: transparent;
+    border-width: var(--theme-tooltip-arrow-size);
   }
 
   &[data-popper-placement='top'] .arrow {
     width: 0;
     height: 0;
-    border-width: var(--length) var(--length) 0 var(--length);
-    border-left-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    bottom: calc(var(--length) * -1);
+    border-bottom-width: 0;
+    border-top-color: var(--theme-tooltip-border-color);
+    bottom: calc(var(--theme-tooltip-arrow-size) * -1);
   }
   &[data-popper-placement='bottom'] .arrow {
     width: 0;
     height: 0;
-    border-width: 0 var(--length) var(--length) var(--length);
-    border-color: transparent transparent var(--tooltip-ribbon-color) transparent;
-    top: calc(calc(-1 * var(--theme-corner-radius-tooltip)) - var(--length));
+    border-top-width: 0;
+    border-bottom-color: var(--theme-tooltip-border-color);
+    top: calc(calc(-1 * var(--theme-tooltip-corner-radius)) - var(--theme-tooltip-arrow-size));
   }
   &[data-popper-placement='right'] .arrow {
     width: 0;
     height: 0;
-    border-width: var(--length) var(--length) var(--length) 0;
-    border-left-color: transparent;
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    left: calc(var(--length) * -1);
+    border-left-width: 0;
+    border-right-color: var(--theme-tooltip-border-color);
+    left: calc(var(--theme-tooltip-arrow-size) * -1);
   }
   &[data-popper-placement='left'] .arrow {
     width: 0;
     height: 0;
-    border-width: var(--length) 0 var(--length) var(--length);
-    border-top-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    right: calc(var(--length) * -1);
+    border-right-width: 0;
+    border-left-color: var(--theme-tooltip-border-color);
+    right: calc(var(--theme-tooltip-arrow-size) * -1);
   }
 
   &.minimalTooltip {
     border-radius: 3px;
-    --tooltip-ribbon-color: #{dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb))};
-    background-color: dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
     border: none;
-    box-shadow: 0 0 10px 3px #080811;
+    box-shadow: var(--theme-drop-shadow-only);
+    background-color: var(--theme-tooltip-minimal-color);
 
     // hide ribbon
     &::after {
@@ -146,17 +137,31 @@ $horizontal-padding: 11px;
     }
 
     .arrow {
-      --length: #{$minimal-arrow-size * 0.5};
+      --theme-tooltip-arrow-size: 6px;
+    }
+
+    &[data-popper-placement='left'] .arrow {
+      border-left-color: var(--theme-tooltip-minimal-color);
+      top: calc(var(--theme-tooltip-arrow-size) / 2) !important;
+    }
+    &[data-popper-placement='right'] .arrow {
+      border-right-color: var(--theme-tooltip-minimal-color);
+      top: calc(var(--theme-tooltip-arrow-size) / 2) !important;
+    }
+    &[data-popper-placement='top'] .arrow {
+      border-top-color: var(--theme-tooltip-minimal-color);
+      bottom: calc(100% - 2px) !important;
     }
     &[data-popper-placement='bottom'] .arrow {
-      top: calc(var(--length) * -1);
+      border-bottom-color: var(--theme-tooltip-minimal-color);
+      top: calc(var(--theme-tooltip-arrow-size) * -1) !important;
     }
   }
 
   .section:not(:empty) {
     margin: 8px #{-$horizontal-padding} -8px #{-$horizontal-padding};
     padding: 5px $horizontal-padding 7px $horizontal-padding;
-    border-top: 1px solid dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb), $alpha: 0.5);
+    border-top: 1px solid var(--theme-tooltip-border-color);
 
     > :first-child {
       margin-top: 0;

--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -15,10 +15,6 @@ $horizontal-padding: 11px;
 }
 
 .tooltip {
-  // --tooltip-ribbon-color: #8e8e9e;
-  // --theme-tooltip-background-color: #151523;
-  // --theme-tooltip-border-color-rgb: #{dim-hex-to-rgb-values(#5d5970)};
-
   position: absolute;
   background-color: var(--theme-tooltip-background-color);
   color: #dadaea;

--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -1,7 +1,7 @@
 @use '../variables.scss' as *;
 @use 'sass:color';
 
-$arrow-size: 15px; // ensure this stays in sync with 'popperArrowSize' in 'usePopper.ts'
+$arrow-size: 16px; // ensure this stays in sync with 'popperArrowSize' in 'usePopper.ts'
 $minimal-arrow-size: 10px;
 $horizontal-padding: 11px;
 
@@ -9,6 +9,10 @@ $horizontal-padding: 11px;
   user-select: none;
   touch-action: none;
   -webkit-touch-callout: none;
+
+  &:hover {
+    fill: rgba(255, 255, 255, 0.4);
+  }
 }
 
 .tooltip {
@@ -22,8 +26,8 @@ $horizontal-padding: 11px;
   width: fit-content;
   max-width: 306px;
   border: 1px solid dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
-  border-top-width: var(--theme-corner-radius);
-  border-radius: var(--theme-corner-radius);
+  border-top-width: var(--theme-corner-radius-tooltip);
+  border-radius: var(--theme-corner-radius-tooltip);
   box-shadow: 0 0 24px 6px #080811;
   text-align: left;
   z-index: 99999;
@@ -38,11 +42,11 @@ $horizontal-padding: 11px;
     display: block;
     position: absolute;
     background-color: var(--tooltip-ribbon-color);
-    height: var(--theme-corner-radius);
-    top: calc(-1 * var(--theme-corner-radius));
+    height: var(--theme-corner-radius-tooltip);
+    top: calc(-1 * var(--theme-corner-radius-tooltip));
     left: -1px;
     right: -1px;
-    border-radius: var(--theme-corner-radius) var(--theme-corner-radius) 0 0;
+    border-radius: var(--theme-corner-radius-tooltip) var(--theme-corner-radius-tooltip) 0 0;
   }
 
   &.wideTooltip {
@@ -87,7 +91,7 @@ $horizontal-padding: 11px;
     border-width: 0;
     border-style: solid;
     position: absolute;
-    border-color: dim-rgb-values-to-rgba(var(--tooltip-border-color-rgb));
+    border-color: var(--tooltip-ribbon-color);
   }
 
   &[data-popper-placement='top'] .arrow {
@@ -104,7 +108,7 @@ $horizontal-padding: 11px;
     height: 0;
     border-width: 0 var(--length) var(--length) var(--length);
     border-color: transparent transparent var(--tooltip-ribbon-color) transparent;
-    top: calc(calc(-1 * var(--theme-corner-radius)) - var(--length));
+    top: calc(calc(-1 * var(--theme-corner-radius-tooltip)) - var(--length));
   }
   &[data-popper-placement='right'] .arrow {
     width: 0;

--- a/src/app/dim-ui/RadioButtons.m.scss
+++ b/src/app/dim-ui/RadioButtons.m.scss
@@ -15,7 +15,7 @@
     content: '';
     display: block;
     position: absolute;
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
     height: 2px;
     bottom: -1px;
     left: -1px;

--- a/src/app/dim-ui/Select.m.scss
+++ b/src/app/dim-ui/Select.m.scss
@@ -15,6 +15,7 @@
   position: absolute;
   &.open {
     outline: 2px solid change-color($orange, $alpha: 0.4) !important;
+    box-shadow: var(--theme-drop-shadow-only);
   }
 }
 

--- a/src/app/dim-ui/Select.m.scss
+++ b/src/app/dim-ui/Select.m.scss
@@ -14,8 +14,7 @@
   z-index: 100;
   position: absolute;
   &.open {
-    outline: 2px solid change-color($orange, $alpha: 0.4) !important;
-    box-shadow: var(--theme-drop-shadow-only);
+    box-shadow: var(--theme-outline-inset-strong), var(--theme-drop-shadow-only);
   }
 }
 
@@ -43,7 +42,14 @@
 
 .highlighted {
   background-color: var(--theme-accent-primary);
-  color: black !important;
+  color: #000;
+
+  // Maintain legibility of keyhelp
+  & span {
+    color: #000;
+    border-color: #000;
+  }
+
   :global(.app-icon) {
     color: black !important;
   }

--- a/src/app/dim-ui/Select.m.scss
+++ b/src/app/dim-ui/Select.m.scss
@@ -24,6 +24,7 @@
   align-items: center;
   min-width: 10em;
   padding: 6px 9px;
+
   @include phone-portrait {
     padding: 10px 16px;
     font-size: 14px;
@@ -40,7 +41,7 @@
 }
 
 .highlighted {
-  background-color: $orange;
+  background-color: var(--theme-accent-primary);
   color: black !important;
   :global(.app-icon) {
     color: black !important;

--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -12,7 +12,7 @@ $control-color: rgba(255, 255, 255, 0.5);
   bottom: 0;
   // Pin the sheet to just over the keyboard
   bottom: var(--viewport-bottom-offset);
-  background-color: black;
+  background-color: var(--theme-fill-primary);
   color: #e0e0e0;
   box-shadow: 0 -1px 24px 0 #222;
   user-select: none;

--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -14,7 +14,7 @@ $control-color: rgba(255, 255, 255, 0.5);
   bottom: var(--viewport-bottom-offset);
   background-color: var(--theme-fill-primary);
   color: #e0e0e0;
-  box-shadow: 0 -1px 24px 0 #222;
+  box-shadow: var(--theme-drop-shadow-framed);
   user-select: none;
 
   .sheet-header {

--- a/src/app/dim-ui/StaticPage.m.scss
+++ b/src/app/dim-ui/StaticPage.m.scss
@@ -29,8 +29,11 @@
   h2 {
     a {
       color: var(--theme-accent-primary);
-      text-decoration: none;
-      border-bottom: 1px solid scale-color($orange, $alpha: -50%);
+      text-decoration: underline;
+      text-underline-offset: 6px;
+      :global(.app-icon) {
+        margin-right: 6px;
+      }
     }
   }
   > p {

--- a/src/app/dim-ui/StaticPage.m.scss
+++ b/src/app/dim-ui/StaticPage.m.scss
@@ -28,7 +28,7 @@
   }
   h2 {
     a {
-      color: $orange;
+      color: var(--theme-accent-primary);
       text-decoration: none;
       border-bottom: 1px solid scale-color($orange, $alpha: -50%);
     }

--- a/src/app/dim-ui/Switch.m.scss
+++ b/src/app/dim-ui/Switch.m.scss
@@ -64,7 +64,7 @@ $touchPadding: 2px; // A bit of extra hit area
         // The dot
         &::after {
           left: $touchPadding + $barWidth - $barHeight;
-          background-color: $orange;
+          background-color: var(--theme-accent-primary);
         }
       }
     }

--- a/src/app/dim-ui/Switch.m.scss
+++ b/src/app/dim-ui/Switch.m.scss
@@ -59,7 +59,8 @@ $touchPadding: 2px; // A bit of extra hit area
     &:checked {
       & + label {
         &::before {
-          background-color: change-color($orange, $alpha: 0.5);
+          background-color: var(--theme-accent-primary);
+          opacity: 0.5;
         }
         // The dot
         &::after {

--- a/src/app/dim-ui/WeaponCatalystInfo.m.scss
+++ b/src/app/dim-ui/WeaponCatalystInfo.m.scss
@@ -12,16 +12,15 @@
 .catalystProgress {
   display: flex;
   flex-direction: column;
-  background: #222;
+  background: var(--theme-fill-lighten);
   gap: 4px;
 
   :global(.objective-progress) {
-    background: #222;
+    background: var(--theme-fill-darken);
   }
 }
 
 .catalystProgressSection {
   padding: 4px 10px 4px;
-  background: #333;
   flex-grow: 1;
 }

--- a/src/app/dim-ui/WeaponCatalystInfo.m.scss
+++ b/src/app/dim-ui/WeaponCatalystInfo.m.scss
@@ -5,7 +5,7 @@
   padding-top: 2px;
   padding-bottom: 2px;
 
-  color: $orange;
+  color: var(--theme-accent-primary);
   font-weight: bold;
 }
 

--- a/src/app/dim-ui/WeaponDeepsightInfo.m.scss
+++ b/src/app/dim-ui/WeaponDeepsightInfo.m.scss
@@ -5,12 +5,12 @@
   gap: 4px;
 
   :global(.objective-progress) {
-    background: #222;
+    background: var(--theme-fill-darken);
   }
 }
 
 .deepsightProgressSection {
   padding: 4px 10px 4px;
-  background: #333;
+  background: var(--theme-fill-lighten);
   flex-grow: 1;
 }

--- a/src/app/dim-ui/_tooltip-mixins.scss
+++ b/src/app/dim-ui/_tooltip-mixins.scss
@@ -4,11 +4,11 @@
 // These mixins are used to customize tooltips hosted within a PressTip (see PressTip.m.scss)
 
 @mixin tooltip-background-color($color) {
-  --tooltip-background-color: #{$color};
+  --theme-tooltip-background-color: #{$color};
 }
 
 @mixin tooltip-border-color($color) {
-  --tooltip-border-color-rgb: #{dim-hex-to-rgb-values($color)};
+  --theme-tooltip-border-color-rgb: #{dim-hex-to-rgb-values($color)};
 }
 
 @mixin tooltip-ribbon-color($color) {
@@ -19,6 +19,6 @@
   &:not(:empty) {
     color: color.mix(white, $color, 80%);
     background-color: rgba($color, 0.175);
-    border-top-color: var(--tooltip-background-color);
+    border-top-color: var(--theme-tooltip-background-color);
   }
 }

--- a/src/app/dim-ui/destiny-symbols/SymbolsPicker.m.scss
+++ b/src/app/dim-ui/destiny-symbols/SymbolsPicker.m.scss
@@ -4,11 +4,10 @@
 .symbolsWindow {
   width: 300px;
   height: 350px;
-  background-color: black;
+  background-color: var(--theme-fill-primary);
   display: flex;
   flex-flow: column;
-
-  box-shadow: 0 0 24px 6px #080811;
+  box-shadow: var(--theme-drop-shadow-framed);
 }
 
 .symbolsButton {

--- a/src/app/dim-ui/destiny-symbols/SymbolsPicker.m.scss
+++ b/src/app/dim-ui/destiny-symbols/SymbolsPicker.m.scss
@@ -20,7 +20,7 @@
   }
   &:hover {
     color: black;
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
   }
 }
 
@@ -74,7 +74,7 @@
 
   &:hover {
     color: black;
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
   }
 }
 

--- a/src/app/dim-ui/dim-button.scss
+++ b/src/app/dim-ui/dim-button.scss
@@ -37,7 +37,7 @@
   &:hover,
   &:active,
   &.selected {
-    background-color: $orange !important;
+    background-color: var(--theme-accent-primary) !important;
     color: black !important;
     img {
       filter: invert(1) drop-shadow(0 0 1px black);
@@ -67,7 +67,7 @@
   }
   // Set focus styles
   &:focus {
-    border-color: $orange;
+    border-color: var(--theme-accent-primary);
     outline: none;
   }
   // For browsers that support :focus-visible, remove focus styles when focus-visible would be unset

--- a/src/app/dim-ui/dim-button.scss
+++ b/src/app/dim-ui/dim-button.scss
@@ -6,11 +6,11 @@
   cursor: pointer;
   padding: 4px 10px;
   display: inline-block;
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: var(--theme-button);
   color: white;
   font-size: 12px;
   line-height: calc(16 / 12);
-  font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
+  font-family: var(--theme-font-primary), sans-serif, 'Destiny Symbols';
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   border: 1px solid transparent;
   transition: all 150ms ease-out;
@@ -53,7 +53,7 @@
     &:hover,
     &:active,
     &.selected {
-      background-color: rgba(255, 255, 255, 0.2) !important;
+      background-color: var(--theme-button) !important;
       color: white !important;
       img {
         filter: drop-shadow(0 0 1px black);

--- a/src/app/dim-ui/usePopper.ts
+++ b/src/app/dim-ui/usePopper.ts
@@ -17,7 +17,7 @@ import _ from 'lodash';
 import React, { useLayoutEffect, useRef } from 'react';
 
 // ensure this stays in sync with 'arrow-size' in 'PressTip.m.scss'
-const popperArrowSize = 16;
+const popperArrowSize = 8;
 
 /** Makes a custom popper that doesn't have the event listeners modifier */
 const createPopper = popperGenerator({

--- a/src/app/dim-ui/usePopper.ts
+++ b/src/app/dim-ui/usePopper.ts
@@ -17,7 +17,7 @@ import _ from 'lodash';
 import React, { useLayoutEffect, useRef } from 'react';
 
 // ensure this stays in sync with 'arrow-size' in 'PressTip.m.scss'
-const popperArrowSize = 15;
+const popperArrowSize = 16;
 
 /** Makes a custom popper that doesn't have the event listeners modifier */
 const createPopper = popperGenerator({

--- a/src/app/infuse/InfusionFinder.scss
+++ b/src/app/infuse/InfusionFinder.scss
@@ -57,7 +57,7 @@
   }
 
   .infuse-selected .item {
-    outline: 2px solid $orange !important;
+    outline: 2px solid var(--theme-accent-primary) !important;
   }
 
   .infuseControls {

--- a/src/app/inventory-page/CategoryStrip.m.scss
+++ b/src/app/inventory-page/CategoryStrip.m.scss
@@ -28,6 +28,6 @@
 }
 
 .selected {
-  color: $orange;
-  border-bottom: 2px solid $orange;
+  color: var(--theme-accent-primary);
+  border-bottom: 2px solid var(--theme-accent-primary);
 }

--- a/src/app/inventory-page/HeaderShadowDiv.m.scss
+++ b/src/app/inventory-page/HeaderShadowDiv.m.scss
@@ -17,7 +17,7 @@
   position: absolute;
   left: 0;
   z-index: 9;
-  background: $gradient;
+  background: var(--theme-background-app-header-secondary);
   background-position: center top;
   background-repeat: no-repeat;
   background-size: 100% 100vh;

--- a/src/app/inventory-page/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory-page/InventoryCollapsibleTitle.scss
@@ -27,7 +27,7 @@
     height: 100%;
     padding-right: 8px;
     &:hover .collapse {
-      color: $orange;
+      color: var(--theme-accent-primary);
     }
   }
 }

--- a/src/app/inventory-page/StoreBucketDropTarget.m.scss
+++ b/src/app/inventory-page/StoreBucketDropTarget.m.scss
@@ -1,6 +1,6 @@
 .canDrop {
-  background-color: rgba(200, 200, 200, 0.2);
+  background-color: var(--theme-fill-lighten);
 }
 .over {
-  box-shadow: inset 0 0 6px 0 rgba(200, 200, 200, 0.7);
+  box-shadow: inset 0 0 0 1px #fff;
 }

--- a/src/app/inventory-page/Stores.scss
+++ b/src/app/inventory-page/Stores.scss
@@ -12,6 +12,7 @@
     (var(--num-characters) + 1) *
       (var(--inventory-column-padding) * 2 + var(--character-column-width))
   );
+
   @include phone-portrait {
     min-width: auto;
     // Give room for the category selector strip (height 53px)
@@ -31,7 +32,7 @@
       var(--num-characters),
       calc(#{$equipped-item-total-outset} + var(--character-column-width) + var(--column-padding))
     )
-    // Vault takes the rest
+    /* Vault takes the rest*/
     1fr;
   box-sizing: border-box;
   padding-right: calc(var(--sidebar-size) * var(--expanded-sidebars));
@@ -65,6 +66,7 @@
 
   &.vault {
     min-width: calc(var(--character-column-width) + var(--inventory-column-padding));
+
     @include phone-portrait {
       min-width: auto;
     }
@@ -111,6 +113,7 @@
       grid-template-columns: repeat(10, 1fr);
       gap: 0;
       padding: 4px 0 0 0;
+
       @include phone-portrait {
         padding: 4px 0;
       }
@@ -119,6 +122,7 @@
     .item-drag-container,
     .empty-engram {
       --item-size: var(--engram-size);
+
       @include phone-portrait {
         --item-size: calc((100vw - (2 * var(--inventory-column-padding))) / 10);
       }
@@ -158,6 +162,7 @@
 .store-header {
   position: fixed;
   backface-visibility: hidden;
+
   @include below-header;
   left: 0;
   width: 100%;
@@ -165,7 +170,7 @@
   grid-template-columns:
     repeat(var(--num-characters), calc(6px + var(--character-column-width) + var(--column-padding)))
     calc(6px + var(--character-column-width) + var(--column-padding)) 1fr !important;
-  background: $gradient;
+  background: var(--theme-background-app-header-secondary);
   background-position: center top;
   background-repeat: no-repeat;
   background-size: 100% 100vh;
@@ -173,6 +178,7 @@
   &:focus {
     outline: none;
   }
+
   @supports (position: sticky) {
     position: sticky;
   }

--- a/src/app/inventory-page/Stores.scss
+++ b/src/app/inventory-page/Stores.scss
@@ -45,6 +45,11 @@
     }
   }
 
+  // Add margin in first row to prevent clipping enlarged items on hover
+  &:first-child:not(.store-header) {
+    margin-top: 15px;
+  }
+
   @include phone-portrait {
     // Full-width, single column
     display: block;

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -29,9 +29,12 @@
   width: var(--item-size);
   cursor: grab;
 
-  &:hover {
-    @include draggable-hover-border;
-  }
+  @include draggable-hover-border;
+}
+
+// Remove shadow on diamond subclass items on hover
+:global(.sub-bucket[aria-label='Subclass'] .item-drag-container) {
+  box-shadow: none;
 }
 
 // Subclass items

--- a/src/app/inventory/PullFromPostmaster.m.scss
+++ b/src/app/inventory/PullFromPostmaster.m.scss
@@ -3,7 +3,7 @@
 .badge {
   border-radius: 50%;
   border-radius: 10px;
-  background: $orange;
+  background: var(--theme-accent-primary);
   padding: 0 4px;
   color: black;
   font-size: 9px;
@@ -19,6 +19,6 @@
 
   &:hover .badge {
     background-color: black;
-    color: $orange;
+    color: var(--theme-accent-primary);
   }
 }

--- a/src/app/item-actions/ActionButton.m.scss
+++ b/src/app/item-actions/ActionButton.m.scss
@@ -31,7 +31,7 @@
     &:hover,
     &:focus-visible {
       outline: none;
-      background: $orange;
+      background: var(--theme-accent-primary);
       color: black;
       :global(.app-icon) {
         color: black;

--- a/src/app/item-feed/ItemFeedSidebar.m.scss
+++ b/src/app/item-feed/ItemFeedSidebar.m.scss
@@ -2,6 +2,7 @@
 
 .trayContainer {
   position: fixed;
+
   @include below-header;
   right: 0;
   height: calc(var(--viewport-height) - var(--header-height));
@@ -48,7 +49,7 @@
 
   &:hover {
     color: black;
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
   }
 
   :global(.app-icon) {

--- a/src/app/item-feed/ItemFeedSidebar.m.scss
+++ b/src/app/item-feed/ItemFeedSidebar.m.scss
@@ -17,6 +17,7 @@
 
 .sideTray {
   background-color: var(--theme-fill-primary);
+  box-shadow: var(--theme-drop-shadow-framed);
   padding: 10px;
   overflow-y: auto;
   overflow-x: hidden;
@@ -28,11 +29,6 @@
   &::-webkit-scrollbar {
     display: none;
   }
-
-  // THEME TBD
-  // > div {
-  //   background-color: black;
-  // }
 }
 
 .trayButton {

--- a/src/app/item-feed/ItemFeedSidebar.m.scss
+++ b/src/app/item-feed/ItemFeedSidebar.m.scss
@@ -16,7 +16,7 @@
 }
 
 .sideTray {
-  background-color: black;
+  background-color: var(--theme-fill-primary);
   padding: 10px;
   overflow-y: auto;
   overflow-x: hidden;
@@ -29,9 +29,10 @@
     display: none;
   }
 
-  > div {
-    background-color: black;
-  }
+  // THEME TBD
+  // > div {
+  //   background-color: black;
+  // }
 }
 
 .trayButton {

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background-color: black;
+  background-color: var(--theme-fill-primary);
   user-select: none;
 }
 

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background-color: var(--theme-fill-primary);
+  background-color: var(--theme-fill-secondary);
   box-shadow: var(--theme-drop-shadow-framed);
   user-select: none;
 }

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -22,7 +22,7 @@
   }
 
   &:hover :global(.app-icon) {
-    color: $orange;
+    color: var(--theme-accent-primary);
   }
 
   .collapsed & {

--- a/src/app/item-popup/DesktopItemActions.m.scss
+++ b/src/app/item-popup/DesktopItemActions.m.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   justify-content: space-between;
   background-color: var(--theme-fill-primary);
+  box-shadow: var(--theme-drop-shadow-framed);
   user-select: none;
 }
 

--- a/src/app/item-popup/ItemPerksList.m.scss
+++ b/src/app/item-popup/ItemPerksList.m.scss
@@ -19,6 +19,10 @@
   &:last-child {
     border-bottom: none;
   }
+
+  &:hover {
+    background-color: var(--theme-fill-lighten);
+  }
 }
 
 .plug {

--- a/src/app/item-popup/ItemPopup.m.scss
+++ b/src/app/item-popup/ItemPopup.m.scss
@@ -7,19 +7,17 @@
 @use '../variables.scss' as *;
 
 .arrow {
-  width: 10px;
-  height: 10px;
+  width: var(--theme-tooltip-arrow-size);
+  height: var(--theme-tooltip-arrow-size);
   border-style: solid;
   position: absolute;
-  border-color: white;
   z-index: -1;
+  border-width: var(--theme-tooltip-arrow-size);
+  border-color: transparent;
 }
 
 .desktopPopupRoot {
   pointer-events: none;
-  .arrow {
-    border-color: white;
-  }
 }
 
 .movePopupDialog {
@@ -47,19 +45,17 @@
   &[data-popper-placement^='top'] .arrow {
     width: 0;
     height: 0;
-    border-width: 5px 5px 0 5px;
-    border-left-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    bottom: -5px;
+    border-bottom-width: 0;
+    border-top-color: var(--theme-tooltip-border-color);
+    bottom: calc(-1 * var(--theme-tooltip-arrow-size));
   }
 
   &[data-popper-placement^='bottom'] .arrow {
     width: 0;
     height: 0;
-    border-width: 0 5px 5px 5px;
-    top: -5px;
-    border-color: transparent transparent white transparent;
+    border-top-width: 0;
+    border-bottom-color: var(--theme-tooltip-border-color);
+    top: calc(-1 * var(--theme-tooltip-arrow-size));
 
     &.exotic {
       border-bottom-color: $exotic;
@@ -80,20 +76,16 @@
   &[data-popper-placement^='right'] .arrow {
     width: 0;
     height: 0;
-    border-width: 8px 8px 8px 0;
-    border-left-color: transparent;
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    left: -8px;
+    border-left-width: 0;
+    border-right-color: var(--theme-tooltip-border-color);
+    left: calc(-1 * var(--theme-tooltip-arrow-size));
   }
   &[data-popper-placement^='left'] .arrow {
     width: 0;
     height: 0;
-    border-width: 8px 0 8px 8px;
-    border-top-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    right: -8px;
+    border-right-width: 0;
+    border-left-color: var(--theme-tooltip-border-color);
+    right: calc(-1 * var(--theme-tooltip-arrow-size));
   }
   textarea {
     resize: vertical;

--- a/src/app/item-popup/ItemPopup.m.scss
+++ b/src/app/item-popup/ItemPopup.m.scss
@@ -103,7 +103,7 @@
 .popupBackground {
   background-color: var(--background-color);
   contain: content;
-  box-shadow: 0 -1px 24px 4px #161626;
+  box-shadow: var(--theme-drop-shadow-framed);
 
   @include phone-portrait {
     box-shadow: none;

--- a/src/app/item-popup/ItemPopup.m.scss
+++ b/src/app/item-popup/ItemPopup.m.scss
@@ -26,22 +26,22 @@
   // Mod drawer has z-index of 14 and needs to sit over this
   z-index: 13;
 
-  --background-color: 0, 0%, 0%;
+  --background-color: rgba(0, 0, 0, 1);
 
   &.exotic {
-    --background-color: 48, 71%, 5%;
+    --background-color: rgba(22, 18, 4, 1);
   }
   &.legendary {
-    --background-color: 279, 36%, 5%;
+    --background-color: rgba(14, 8, 17, 1);
   }
   &.rare {
-    --background-color: 213, 34%, 6%;
+    --background-color: rgba(10, 15, 21, 1);
   }
   &.uncommon {
-    --background-color: 126, 35%, 5%;
+    --background-color: rgba(8, 17, 9, 1);
   }
   &.common {
-    --background-color: 0, 0%, 7%;
+    --background-color: rgba(18, 18, 18, 1);
   }
 
   &[data-popper-placement^='top'] .arrow {
@@ -101,9 +101,10 @@
 }
 
 .popupBackground {
-  background-color: #{'hsl(var(--background-color))'};
+  background-color: var(--background-color);
   contain: content;
   box-shadow: 0 -1px 24px 4px #161626;
+
   @include phone-portrait {
     box-shadow: none;
   }

--- a/src/app/item-popup/ItemPopup.m.scss
+++ b/src/app/item-popup/ItemPopup.m.scss
@@ -11,9 +11,9 @@
   height: var(--theme-tooltip-arrow-size);
   border-style: solid;
   position: absolute;
-  z-index: -1;
   border-width: var(--theme-tooltip-arrow-size);
   border-color: transparent;
+  filter: drop-shadow(0 0 3px #000);
 }
 
 .desktopPopupRoot {

--- a/src/app/item-popup/ItemPopup.m.scss
+++ b/src/app/item-popup/ItemPopup.m.scss
@@ -11,14 +11,14 @@
   height: 10px;
   border-style: solid;
   position: absolute;
-  border-color: black;
+  border-color: white;
   z-index: -1;
 }
 
 .desktopPopupRoot {
   pointer-events: none;
   .arrow {
-    border-color: #161626;
+    border-color: white;
   }
 }
 
@@ -80,20 +80,20 @@
   &[data-popper-placement^='right'] .arrow {
     width: 0;
     height: 0;
-    border-width: 5px 5px 5px 0;
+    border-width: 8px 8px 8px 0;
     border-left-color: transparent;
     border-top-color: transparent;
     border-bottom-color: transparent;
-    left: -5px;
+    left: -8px;
   }
   &[data-popper-placement^='left'] .arrow {
     width: 0;
     height: 0;
-    border-width: 5px 0 5px 5px;
+    border-width: 8px 0 8px 8px;
     border-top-color: transparent;
     border-right-color: transparent;
     border-bottom-color: transparent;
-    right: -5px;
+    right: -8px;
   }
   textarea {
     resize: vertical;

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -14,7 +14,7 @@
   background-color: black;
   &.selected {
     opacity: 1;
-    border-bottom: 2px solid $orange;
+    border-bottom: 2px solid var(--theme-accent-primary);
   }
   &:hover {
     color: white;
@@ -75,7 +75,7 @@
   background: #333;
 
   span {
-    color: $orange;
+    color: var(--theme-accent-primary);
     font-weight: bold;
   }
 

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -72,7 +72,7 @@
 .masterwork-progress {
   margin: 4px 0;
   padding: 4px 10px 4px;
-  background: #333;
+  background: var(--theme-fill-lighten);
 
   span {
     color: var(--theme-accent-primary);
@@ -88,14 +88,14 @@
 
 .crafted-progress {
   padding: 4px 10px 4px;
-  background: #333;
+  background: var(--theme-fill-lighten);
   gap: 4px;
 
   display: flex;
   align-items: center;
 
   .objective-progress {
-    background: #222;
+    background: var(--theme-fill-darken);
   }
 
   .objective-progress-bar {

--- a/src/app/item-popup/ItemSockets.scss
+++ b/src/app/item-popup/ItemSockets.scss
@@ -53,7 +53,7 @@
   &.hasMenu {
     cursor: pointer;
     &:hover {
-      outline: 1px solid $orange;
+      outline: 1px solid var(--theme-accent-primary);
     }
   }
 }

--- a/src/app/item-popup/ItemSocketsWeapons.m.scss
+++ b/src/app/item-popup/ItemSocketsWeapons.m.scss
@@ -34,7 +34,7 @@
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   &:hover,
   &:active {
-    background-color: $orange !important;
+    background-color: var(--theme-accent-primary) !important;
     color: black !important;
   }
 }

--- a/src/app/item-popup/ItemStat.m.scss
+++ b/src/app/item-popup/ItemStat.m.scss
@@ -6,6 +6,7 @@
   text-align: right;
   margin-right: 8px;
   max-width: 130px;
+
   @include phone-portrait {
     max-width: 40vw;
   }
@@ -79,10 +80,10 @@
 
 // Colors for the stat bars
 .masterworkStatBar {
-  background-color: $orange;
+  background-color: var(--theme-accent-primary);
 }
 .moddedStatBar {
-  background-color: $blue;
+  background-color: var(--theme-accent-secondary);
   & + .moddedStatBar {
     background-color: color.adjust($blue, $lightness: -10%);
     & + .moddedStatBar {
@@ -92,14 +93,14 @@
 }
 
 .masterworked {
-  color: $orange;
+  color: var(--theme-accent-primary);
   .statName {
     font-weight: bold;
   }
 }
 
 .modded {
-  color: $blue;
+  color: var(--theme-accent-secondary);
   .statName {
     font-weight: bold;
   }
@@ -126,7 +127,7 @@
 }
 
 .totalStatModded {
-  color: $blue;
+  color: var(--theme-accent-secondary);
 }
 
 .totalStatNegativeModded {
@@ -134,7 +135,7 @@
 }
 
 .totalStatMasterwork {
-  color: $orange;
+  color: var(--theme-accent-primary);
 }
 
 .customTotal {

--- a/src/app/item-popup/ItemStat.m.scss
+++ b/src/app/item-popup/ItemStat.m.scss
@@ -85,9 +85,11 @@
 .moddedStatBar {
   background-color: var(--theme-accent-secondary);
   & + .moddedStatBar {
-    background-color: color.adjust($blue, $lightness: -10%);
+    background-color: var(--theme-accent-secondary);
+    opacity: 0.8;
     & + .moddedStatBar {
-      background-color: color.adjust($blue, $lightness: -20%);
+      background-color: var(--theme-accent-secondary);
+      opacity: 0.6;
     }
   }
 }

--- a/src/app/item-popup/NotesArea.m.scss
+++ b/src/app/item-popup/NotesArea.m.scss
@@ -6,7 +6,7 @@
   margin-top: 0 !important;
   margin-bottom: 0 !important;
   &:hover {
-    color: $orange;
+    color: var(--theme-accent-primary);
   }
   &.noNotesYet {
     // if there's no existing notes, don't span the entire

--- a/src/app/item-popup/Plug.m.scss
+++ b/src/app/item-popup/Plug.m.scss
@@ -14,7 +14,7 @@
 }
 // This has been selected by the user but isn't the original plugged item
 .selected {
-  fill: $orange;
+  fill: var(--theme-accent-primary);
 }
 
 .cannotRoll {

--- a/src/app/item-popup/Plug.m.scss
+++ b/src/app/item-popup/Plug.m.scss
@@ -1,12 +1,10 @@
 @use '../variables.scss' as *;
 
 .none {
-  fill: transparent;
 }
 
 // Another plug was selected by the user
 .notSelected {
-  fill: #4887ba80;
 }
 
 .plugged {

--- a/src/app/item-popup/Plug.m.scss
+++ b/src/app/item-popup/Plug.m.scss
@@ -1,10 +1,12 @@
 @use '../variables.scss' as *;
 
 .none {
+  fill: auto;
 }
 
 // Another plug was selected by the user
 .notSelected {
+  fill: auto;
 }
 
 .plugged {

--- a/src/app/item-popup/Plug.m.scss.d.ts
+++ b/src/app/item-popup/Plug.m.scss.d.ts
@@ -2,6 +2,8 @@
 // Please do not change this file!
 interface CssExports {
   'cannotRoll': string;
+  'none': string;
+  'notSelected': string;
   'plugged': string;
   'selected': string;
 }

--- a/src/app/item-popup/Plug.m.scss.d.ts
+++ b/src/app/item-popup/Plug.m.scss.d.ts
@@ -2,8 +2,6 @@
 // Please do not change this file!
 interface CssExports {
   'cannotRoll': string;
-  'none': string;
-  'notSelected': string;
   'plugged': string;
   'selected': string;
 }

--- a/src/app/item-popup/PlugTooltip.m.scss
+++ b/src/app/item-popup/PlugTooltip.m.scss
@@ -59,7 +59,7 @@
     @include tooltip-section-color($red);
   }
   .automaticallyPickedSection {
-    @include tooltip-section-color($orange);
+    @include tooltip-section-color(#e8a534);
   }
 }
 .tooltipExotic {

--- a/src/app/item-popup/SocketDetails.m.scss
+++ b/src/app/item-popup/SocketDetails.m.scss
@@ -39,7 +39,7 @@
 
 .selected,
 .clickableMod:focus {
-  outline: 2px solid $orange !important;
+  outline: 2px solid var(--theme-accent-primary) !important;
 }
 
 .energyElement {

--- a/src/app/item-triage/ItemTriage.m.scss
+++ b/src/app/item-triage/ItemTriage.m.scss
@@ -205,5 +205,5 @@
 }
 
 .artificeExplanation {
-  color: $orange;
+  color: var(--theme-accent-primary);
 }

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss
@@ -3,13 +3,14 @@
 .page {
   :global .perk-image {
     &.locked-perk {
-      border-color: $orange;
+      border-color: var(--theme-accent-primary);
     }
   }
 }
 
 .menuContent {
   box-sizing: border-box;
+
   @include phone-portrait {
     padding: 0 10px;
   }
@@ -24,6 +25,7 @@
   padding: 10px 10px;
   position: fixed;
   left: 50%;
+
   @include below-header;
 
   white-space: nowrap;
@@ -48,6 +50,7 @@
   flex-flow: row wrap;
   align-items: center;
   box-sizing: border-box;
+
   @include phone-portrait {
     padding: 0 10px;
   }
@@ -57,6 +60,7 @@
 
 .guide {
   box-sizing: border-box;
+
   @include phone-portrait {
     padding: 0 10px;
   }

--- a/src/app/loadout-builder/filter/ExoticTile.m.scss
+++ b/src/app/loadout-builder/filter/ExoticTile.m.scss
@@ -18,7 +18,7 @@
 }
 
 .selected {
-  border-color: $orange;
+  border-color: var(--theme-accent-primary);
 }
 
 .disabled {

--- a/src/app/loadout-builder/generated-sets/SetStats.m.scss
+++ b/src/app/loadout-builder/generated-sets/SetStats.m.scss
@@ -87,5 +87,5 @@
 }
 
 .boostedValue {
-  color: $blue;
+  color: var(--theme-accent-secondary);
 }

--- a/src/app/loadout-drawer/LoadoutDrawerHeader.m.scss
+++ b/src/app/loadout-drawer/LoadoutDrawerHeader.m.scss
@@ -16,7 +16,7 @@
 .dimInput {
   padding-left: 5px;
   height: 23px;
-  background: rgb(46, 46, 46);
+  background: var(--theme-fill-darken);
   border: none;
   border-bottom: 1px solid #555;
   color: white;

--- a/src/app/loadout-drawer/LoadoutDrawerHeader.m.scss
+++ b/src/app/loadout-drawer/LoadoutDrawerHeader.m.scss
@@ -34,7 +34,7 @@
   &:focus {
     background: black;
     outline: none;
-    border-bottom: 1px solid $orange;
+    border-bottom: 1px solid var(--theme-accent-primary);
   }
 
   > input {

--- a/src/app/loadout/ingame/EditInGameLoadout.m.scss
+++ b/src/app/loadout/ingame/EditInGameLoadout.m.scss
@@ -33,7 +33,7 @@
   &:hover,
   &:active,
   &.checked {
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
     color: black;
     > img {
       filter: none !important;

--- a/src/app/loadout/loadout-edit/LoadoutEditBucketDropTarget.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucketDropTarget.m.scss
@@ -1,8 +1,8 @@
 @use '../../variables.scss' as *;
 
 .over {
-  border-color: $orange !important;
-  color: $orange;
+  border-color: var(--theme-accent-primary) !important;
+  color: var(--theme-accent-primary);
 }
 
 .options {

--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -10,7 +10,7 @@
   z-index: 2;
   color: rgba(245, 245, 245, 0.6);
   overscroll-behavior: contain;
-  background-color: black;
+  background-color: var(--theme-fill-primary);
 
   @include visible-scrollbars;
 
@@ -155,7 +155,6 @@
 }
 
 .content {
-  background-color: black;
   color: #e4e4e4;
 }
 

--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -105,7 +105,7 @@
 
   &:hover,
   a:hover {
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
     color: black !important;
     > span:first-child > :global(.app-icon) {
       color: black !important;
@@ -141,7 +141,7 @@
     }
   }
   &:hover {
-    background-color: $blue;
+    background-color: var(--theme-accent-secondary);
     color: #222;
   }
 }
@@ -200,7 +200,7 @@
   composes: resetButton from '../../dim-ui/common.m.scss';
   &:hover,
   &:focus-visible {
-    outline: 2px solid $orange;
+    outline: 2px solid var(--theme-accent-primary);
   }
   display: block;
 }

--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -11,6 +11,7 @@
   color: rgba(245, 245, 245, 0.6);
   overscroll-behavior: contain;
   background-color: var(--theme-fill-primary);
+  box-shadow: var(--theme-drop-shadow-framed);
 
   @include visible-scrollbars;
 

--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -127,6 +127,13 @@
       margin: 4px 4px 4px 2px;
     }
   }
+
+  .note {
+    color: #888;
+  }
+  &:hover .note {
+    color: #333;
+  }
 }
 
 .altButton {
@@ -157,10 +164,6 @@
 
 .content {
   color: #e4e4e4;
-}
-
-.note {
-  color: #888;
 }
 
 .filterInput {

--- a/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss
+++ b/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss
@@ -19,7 +19,7 @@
 .clickable {
   composes: resetButton from '../../dim-ui/common.m.scss';
   &:focus {
-    border-color: $orange;
+    border-color: var(--theme-accent-primary);
   }
   .placeholder {
     &:hover {

--- a/src/app/loadout/loadout-ui/LoadoutMods.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutMods.m.scss
@@ -34,7 +34,7 @@
   width: var(--item-icon-size);
 
   &:focus {
-    border-color: $orange;
+    border-color: var(--theme-accent-primary);
   }
 
   &:hover {

--- a/src/app/loadout/loadout-ui/Sockets.m.scss
+++ b/src/app/loadout/loadout-ui/Sockets.m.scss
@@ -15,6 +15,6 @@
 
 .automaticallyPicked {
   :global(.item-img) {
-    border: 1px solid $orange;
+    border: 1px solid var(--theme-accent-primary);
   }
 }

--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss
@@ -16,7 +16,7 @@
     background-color: rgba(255, 255, 255, 0.1);
   }
   &:focus {
-    outline: 1px solid $blue;
+    outline: 1px solid var(--theme-accent-secondary);
   }
 }
 
@@ -38,7 +38,7 @@
 }
 
 .lockedPerk {
-  border-color: $orange;
+  border-color: var(--theme-accent-primary);
   &:focus {
     outline: none;
   }

--- a/src/app/login/Login.m.scss
+++ b/src/app/login/Login.m.scss
@@ -83,7 +83,7 @@
   font-weight: bold;
   text-align: center;
   padding: 1em 3em;
-  background-color: $orange;
+  background-color: var(--theme-accent-primary);
   color: black;
   text-shadow: none;
   &:hover {

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -208,7 +208,7 @@ input[type='search'] {
 textarea {
   width: 100%;
   height: 30px;
-  background-color: #333;
+  background-color: var(--theme-fill-darken);
   padding: 4px 8px;
   border: none;
   outline: none;
@@ -228,7 +228,7 @@ select {
   background-position: calc(100% - 10px) center;
   background-repeat: no-repeat;
   border-radius: 0;
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: var(--theme-button);
   padding: 2px 28px 2px 10px;
   height: 27px;
   font-size: 12px;

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -168,10 +168,10 @@ body {
   margin: 0 auto;
   background-color: #313233;
   color: white;
-  font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
+  font-family: var(--theme-font-primary), sans-serif, 'Destiny Symbols';
   font-size: 12px;
   line-height: calc(16 / 12);
-  accent-color: $orange;
+  accent-color: var(--theme-accent-primary);
   // Disable drag and drop so we can use our polyfill
   -webkit-user-drag: none;
   // Don't let iOS Safari mess with font sizes
@@ -198,7 +198,7 @@ h4 {
 input,
 select,
 option {
-  font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
+  font-family: var(--theme-font-primary), sans-serif, 'Destiny Symbols';
 }
 
 input[type='search'] {
@@ -246,13 +246,13 @@ select {
 
   &:hover,
   &:active {
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
     color: black;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="black" d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"></path></svg>');
   }
   // Set focus styles
   &:focus {
-    border-color: $orange;
+    border-color: var(--theme-accent-primary);
     outline: none;
   }
   // For browsers that support :focus-visible, remove focus styles when focus-visible would be unset

--- a/src/app/notifications/NotificationButton.m.scss
+++ b/src/app/notifications/NotificationButton.m.scss
@@ -11,7 +11,7 @@
   width: 30%;
   cursor: pointer;
   &:hover {
-    background-color: $blue;
+    background-color: var(--theme-accent-secondary);
     color: #222;
   }
   & > svg {

--- a/src/app/organizer/DropDown.m.scss
+++ b/src/app/organizer/DropDown.m.scss
@@ -31,6 +31,7 @@ $dropdown-menu: 10;
   }
 
   background: black;
+
   @include visible-scrollbars;
 }
 
@@ -56,7 +57,7 @@ $dropdown-menu: 10;
 
   &:active {
     box-shadow: none;
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
   }
 
   :global(.app-icon) {

--- a/src/app/organizer/DropDown.m.scss
+++ b/src/app/organizer/DropDown.m.scss
@@ -30,13 +30,12 @@ $dropdown-menu: 10;
     right: 0;
   }
 
-  background: black;
+  background: var(--theme-fill-primary);
 
   @include visible-scrollbars;
 }
 
 .checkButton {
-  background-color: black;
   border-radius: 0;
   border: none;
   box-sizing: border-box;

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -160,6 +160,11 @@ $content-cells: 5;
   > :global(.item) {
     --item-size: var(--icon-item-size) !important;
     height: var(--item-size);
+
+    &:hover {
+      cursor: pointer;
+      outline: 1px solid #fff;
+    }
   }
 }
 

--- a/src/app/organizer/ItemTypeSelector.m.scss
+++ b/src/app/organizer/ItemTypeSelector.m.scss
@@ -26,7 +26,7 @@
   &:hover,
   &:active,
   &.checked {
-    background-color: $orange;
+    background-color: var(--theme-accent-primary);
     color: black;
     > img {
       filter: none !important;

--- a/src/app/progress/BountyGuide.m.scss
+++ b/src/app/progress/BountyGuide.m.scss
@@ -28,7 +28,7 @@
 }
 
 .selected {
-  border-color: $orange;
+  border-color: var(--theme-accent-primary);
   background: rgba(0, 0, 0, 0.6);
 }
 

--- a/src/app/progress/ReputationRank.m.scss
+++ b/src/app/progress/ReputationRank.m.scss
@@ -43,7 +43,7 @@
 }
 
 .crucibleRankTotalProgress {
-  stroke: $blue;
+  stroke: var(--theme-accent-secondary);
   fill: none;
 }
 

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -165,6 +165,7 @@
     width: calc(var(--item-size) / 3.1) !important;
     height: auto !important;
   }
+
   @media (hover: none) {
     display: block;
     opacity: 0.7;

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -128,10 +128,7 @@
 
 .trackedInDim .glow {
   display: block;
-  background: linear-gradient(
-    scale-color($orange, $alpha: -100%) 0%,
-    scale-color($orange, $alpha: -80%) 100%
-  );
+  background: linear-gradient(transparent 0%, var(--theme-accent-primary) 500%);
 }
 
 .redeemed.gildingTriumph .glow {

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -11,8 +11,14 @@
 }
 
 .open {
+  box-shadow: var(--theme-drop-shadow-framed);
   border-bottom-left-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
+
+  // Maintain dropshadow when hovering in and out of the open dropdown
+  &:hover {
+    box-shadow: var(--theme-drop-shadow-framed);
+  }
 }
 
 .menu {
@@ -21,6 +27,7 @@
   margin: 0;
   border-top: 0;
   background: var(--theme-fill-secondary);
+  box-shadow: var(--theme-drop-shadow-framed);
   position: absolute;
   z-index: 50;
   list-style: none;
@@ -175,6 +182,12 @@
   background: transparent;
   border: 0;
   cursor: pointer;
+  color: #999;
+
+  &:hover,
+  &:hover > span {
+    color: white;
+  }
 
   &:focus-visible {
     outline: 1px solid var(--theme-accent-primary);
@@ -187,7 +200,6 @@
   > :global(.app-icon),
   > button > :global(.app-icon) {
     font-size: 14px !important;
-    color: #999 !important;
     // Increase touch target size
     padding: 4px;
     margin: -4px;

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -20,7 +20,7 @@
   overflow: hidden;
   margin: 0;
   border-top: 0;
-  background: #161616;
+  background: var(--theme-fill-secondary);
   position: absolute;
   z-index: 50;
   list-style: none;
@@ -28,8 +28,8 @@
   left: 0;
   right: 0;
   top: 32px;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: var(--theme-corner-radius-search);
+  border-bottom-right-radius: var(--theme-corner-radius-search);
 
   @include phone-portrait {
     top: calc(100% + 1px);

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -113,7 +113,7 @@
 }
 
 .highlightedItem {
-  background-color: $orange;
+  background-color: var(--theme-accent-primary);
   color: black !important;
   .menuItemIcon {
     color: black;
@@ -159,7 +159,7 @@
 }
 
 .saveSearchButton > :global(.app-icon) {
-  color: $orange !important;
+  color: var(--theme-accent-primary) !important;
 }
 
 .filterHelp {
@@ -177,7 +177,7 @@
   cursor: pointer;
 
   &:focus-visible {
-    outline: 1px solid $orange;
+    outline: 1px solid var(--theme-accent-primary);
   }
 
   @include phone-portrait {

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -11,13 +11,16 @@
 }
 
 .open {
-  box-shadow: var(--theme-drop-shadow-framed);
   border-bottom-left-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
+  background: var(--theme-fill-darken);
+  transition: all 0.2s linear;
+  box-shadow: var(--theme-outline-inset-strong), var(--theme-drop-shadow-only);
 
   // Maintain dropshadow when hovering in and out of the open dropdown
   &:hover {
-    box-shadow: var(--theme-drop-shadow-framed);
+    box-shadow: var(--theme-outline-inset-strong), var(--theme-drop-shadow-only);
+    transition: all 0.2s linear;
   }
 }
 

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -10,7 +10,6 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  background: #313233;
   padding-left: 5px;
   padding-right: 5px;
   height: 32px;
@@ -27,7 +26,11 @@
     height: 34px;
   }
 
-  &:hover,
+  &:hover {
+    outline: none;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+  }
+
   &:focus {
     outline: none;
   }

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -16,6 +16,13 @@
   border-radius: var(--theme-corner-radius-search);
   min-width: 350px;
   box-sizing: border-box;
+  box-shadow: var(--theme-outline-inset), inset 0 0 8px 0 #000;
+  background: var(--theme-fill-darken);
+
+  &:hover {
+    outline: none;
+    box-shadow: var(--theme-outline-inset-strong);
+  }
 
   ::placeholder {
     color: #999;
@@ -24,11 +31,6 @@
   @include phone-portrait {
     width: auto;
     height: 34px;
-  }
-
-  &:hover {
-    outline: none;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
   }
 
   &:focus {

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -14,7 +14,7 @@
   padding-left: 5px;
   padding-right: 5px;
   height: 32px;
-  border-radius: 4px;
+  border-radius: var(--theme-corner-radius-search);
   min-width: 350px;
   box-sizing: border-box;
 

--- a/src/app/settings/SortOrderEditor.scss
+++ b/src/app/settings/SortOrderEditor.scss
@@ -13,6 +13,10 @@
   align-items: center;
   transition: opacity 0.2s;
 
+  &:hover {
+    background-color: var(--theme-fill-lighten);
+  }
+
   .fa,
   .app-icon {
     padding: 4px;

--- a/src/app/settings/SortOrderEditor.scss
+++ b/src/app/settings/SortOrderEditor.scss
@@ -40,9 +40,9 @@
   }
 
   .sort-forward {
-    color: $orange;
+    color: var(--theme-accent-primary);
   }
   .sort-reverse {
-    color: $blue;
+    color: var(--theme-accent-secondary);
   }
 }

--- a/src/app/settings/settings.scss
+++ b/src/app/settings/settings.scss
@@ -34,6 +34,11 @@
       padding: 0;
       margin: 0;
       background-color: transparent;
+
+      & > label:hover {
+        text-decoration: underline;
+        cursor: pointer;
+      }
     }
   }
 
@@ -92,6 +97,11 @@
       flex-direction: row;
       align-items: center;
       gap: 0.25em;
+
+      &:hover {
+        text-decoration: underline;
+        cursor: pointer;
+      }
     }
     input {
       margin: 0 4px 0 0;

--- a/src/app/shell/About.m.scss
+++ b/src/app/shell/About.m.scss
@@ -6,7 +6,7 @@
     font-weight: 400;
     font-size: 1.1em;
     margin-top: 10px;
-    color: $orange;
+    color: var(--theme-accent-primary);
   }
   dd {
     margin: 4px 0 8px 0;

--- a/src/app/shell/About.tsx
+++ b/src/app/shell/About.tsx
@@ -126,7 +126,8 @@ export default function About() {
           <div>
             <h2>
               <ExternalLink href={openCollectiveLinkDirect}>
-                <AppIcon icon={heartIcon} /> {t('Views.Support.Support')}
+                <AppIcon icon={heartIcon} />
+                {t('Views.Support.Support')}
               </ExternalLink>
             </h2>
             <div
@@ -139,7 +140,8 @@ export default function About() {
         <div>
           <h2>
             <ExternalLink href={wikiLink}>
-              <AppIcon icon={helpIcon} /> {t('Views.About.Wiki')}
+              <AppIcon icon={helpIcon} />
+              {t('Views.About.Wiki')}
             </ExternalLink>
           </h2>
           {t('Views.About.WikiHelp')} <br />
@@ -148,7 +150,8 @@ export default function About() {
           <div>
             <h2>
               <ExternalLink href={storeLinkDirect}>
-                <AppIcon icon={faTshirt} /> {t('Header.Shop')}
+                <AppIcon icon={faTshirt} />
+                {t('Header.Shop')}
               </ExternalLink>
             </h2>
             <div
@@ -161,7 +164,8 @@ export default function About() {
         <div>
           <h2>
             <ExternalLink href={discordLink}>
-              <AppIcon icon={faDiscord} /> {t('Views.About.Discord')}
+              <AppIcon icon={faDiscord} />
+              {t('Views.About.Discord')}
             </ExternalLink>
           </h2>
           {t('Views.About.DiscordHelp')}
@@ -169,7 +173,8 @@ export default function About() {
         <div>
           <h2>
             <ExternalLink href={redditLink}>
-              <AppIcon icon={faReddit} /> {t('Views.About.Reddit')}
+              <AppIcon icon={faReddit} />
+              {t('Views.About.Reddit')}
             </ExternalLink>
           </h2>
           {t('Views.About.RedditHelp')} <br />
@@ -178,7 +183,8 @@ export default function About() {
         <div>
           <h2>
             <ExternalLink href={mastodonLink}>
-              <AppIcon icon={mastodonIcon} /> Mastodon
+              <AppIcon icon={mastodonIcon} />
+              Mastodon
             </ExternalLink>
           </h2>
           {t('Views.About.TwitterHelp')} <br />
@@ -187,7 +193,8 @@ export default function About() {
         <div>
           <h2>
             <ExternalLink href={githubLinkDirect}>
-              <AppIcon icon={faGithub} /> {t('Views.About.GitHub')}
+              <AppIcon icon={faGithub} />
+              {t('Views.About.GitHub')}
             </ExternalLink>
           </h2>
           <div

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -166,6 +166,7 @@ $header-height: 44px;
   padding: 0;
   min-width: 150px;
   background-color: var(--theme-fill-primary);
+  box-shadow: var(--theme-drop-shadow-framed);
   padding-left: env(safe-area-inset-left);
   padding-bottom: Max(4px, env(safe-area-inset-bottom));
   flex-direction: column;

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -165,7 +165,7 @@ $header-height: 44px;
   margin: 0;
   padding: 0;
   min-width: 150px;
-  background-color: black;
+  background-color: var(--theme-fill-primary);
   padding-left: env(safe-area-inset-left);
   padding-bottom: Max(4px, env(safe-area-inset-bottom));
   flex-direction: column;

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -29,7 +29,7 @@ $header-height: 44px;
   display: flex;
   flex-direction: row;
   align-items: center;
-  background: $gradient;
+  background: var(--theme-background-app-header-primary);
   background-position: center top;
   background-repeat: no-repeat;
   background-size: 100vw 100vh;
@@ -47,7 +47,7 @@ $header-height: 44px;
         font-size: 24px;
       }
       &:hover {
-        color: $orange;
+        color: var(--theme-accent-primary);
         cursor: pointer;
         transition: color 0.2s linear;
       }
@@ -83,7 +83,7 @@ $header-height: 44px;
 
   &:hover,
   &.active {
-    color: $orange;
+    color: var(--theme-accent-primary);
     transition: color 0.2s linear;
   }
 }
@@ -113,7 +113,7 @@ $header-height: 44px;
     height: 24px * 1.2;
     width: 68px * 1.2;
   }
-  color: $orange !important;
+  color: var(--theme-accent-primary) !important;
   font-size: 16px !important;
   font-weight: bold;
   font-weight: 400;
@@ -149,7 +149,7 @@ $header-height: 44px;
     box-sizing: border-box;
 
     &.active {
-      border-bottom: 2px solid $orange;
+      border-bottom: 2px solid var(--theme-accent-primary);
     }
   }
 }
@@ -192,7 +192,7 @@ $header-height: 44px;
 
     &.active {
       color: white;
-      border-left: 4px solid $orange;
+      border-left: 4px solid var(--theme-accent-primary);
       padding-left: calc(1rem - 4px);
     }
 
@@ -204,7 +204,7 @@ $header-height: 44px;
 
     &:hover,
     &:focus {
-      background-color: $orange;
+      background-color: var(--theme-accent-primary);
       color: black;
     }
 

--- a/src/app/shell/MenuBadge.m.scss
+++ b/src/app/shell/MenuBadge.m.scss
@@ -6,7 +6,7 @@
   bottom: 0;
   right: -5px;
   display: block;
-  background-color: $orange;
+  background-color: var(--theme-accent-primary);
   border-radius: 50%;
   height: 8px;
   width: 8px;
@@ -16,6 +16,6 @@
   position: absolute;
   bottom: -8px;
   right: -12px;
-  color: $orange !important;
+  color: var(--theme-accent-primary) !important;
   font-size: 18px !important;
 }

--- a/src/app/store-stats/CharacterStats.scss
+++ b/src/app/store-stats/CharacterStats.scss
@@ -106,8 +106,11 @@
       flex: 0;
       font-size: 11px;
       color: #ccc;
-      &.pointerCursor {
-        cursor: pointer;
+      &:hover {
+        color: #fff;
+        cursor: help;
+      }
+      &:hover.pointerCursor {
       }
       .phone-portrait & {
         font-size: 12px;

--- a/src/app/store-stats/StatTooltip.m.scss
+++ b/src/app/store-stats/StatTooltip.m.scss
@@ -14,7 +14,7 @@
 .row {
   display: contents;
   &.boostedValue {
-    color: $blue;
+    color: var(--theme-accent-secondary);
   }
 }
 

--- a/src/app/strip-sockets/StripSockets.m.scss
+++ b/src/app/strip-sockets/StripSockets.m.scss
@@ -37,7 +37,7 @@
     background-color: rgba(255, 255, 255, 0.1);
   }
   &:focus {
-    outline: 1px solid $blue;
+    outline: 1px solid var(--theme-accent-secondary);
   }
 }
 
@@ -49,7 +49,7 @@
 
 .buttonTitle {
   &.selectedTitle {
-    color: $orange;
+    color: var(--theme-accent-primary);
   }
   font-weight: bold;
   font-size: 13px;
@@ -57,7 +57,7 @@
 }
 
 .selectedButton {
-  border-color: $orange;
+  border-color: var(--theme-accent-primary);
   &:focus {
     outline: none;
   }

--- a/src/app/whats-new/WhatsNewLink.m.scss
+++ b/src/app/whats-new/WhatsNewLink.m.scss
@@ -1,14 +1,14 @@
 @use '../variables.scss' as *;
 
 .upgrade {
-  color: $orange !important;
+  color: var(--theme-accent-primary) !important;
   font-size: 18px !important;
   margin-right: 4px;
 }
 
 .badgeNew {
   display: inline-block;
-  background-color: $orange;
+  background-color: var(--theme-accent-primary);
   border-radius: 50%;
   height: 8px;
   width: 8px;


### PR DESCRIPTION
#9010 

Refactored sass variables → css variables in `_variables.scss`. 
Future aim: these would be customisable on a per-theme basis. 

Base styles/branding kept largely as-is.

Numerous visual tweaks to improve the visual hierarchy of components:

- Modal views (item popup, compare tray, armory sheet, item feed etc):
    - Inset borders so edges are visible when views are layered 
    - Drop shadows reinforce layer hierarchy 
- Item tiles: clearer visual + interaction styles (size, shadows, borders)
- Item popup: interaction styles on perks + mods
- Search box: clearer visual + interaction styles in search box, dropdown and actions (shadows, borders)
- Tooltips: standardised and clarified arrows, colours
- Settings + Navigation: Added hover interaction styles to improve accessibility 