### PR TITLE
Update wording on can't-pull-from-postmaster warning

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -833,7 +833,7 @@
     "AddToLoadoutTitle": "Add this to a loadout",
     "AddNote": "Add notes",
     "All": "All",
-    "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
+    "CantPullFromPostmaster": "You must visit the postmaster in game to retrieve this item.",
     "CannotCurrentlyRoll": "This perk cannot be rolled on the current version of this item.",
     "UnreliablePerkOption": "This perk appears only in the collections view. It might not roll randomly on this item.",
     "Consolidate": "Consolidate",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -829,7 +829,7 @@
     "AddToLoadoutTitle": "Add this to a loadout",
     "All": "All",
     "CannotCurrentlyRoll": "This perk cannot be rolled on the current version of this item.",
-    "CantPullFromPostmaster": "You must go to the tower to retrieve this item.",
+    "CantPullFromPostmaster": "You must visit the postmaster in game to retrieve this item.",
     "CatalystProgress": "Catalyst Progress",
     "CommunityData": "Community Insight",
     "Consolidate": "Consolidate",


### PR DESCRIPTION
Since there are postmasters everywhere now, not just in the tower. 