### PR TITLE
Hashtag pill sorting solution

### DIFF
--- a/src/app/inventory/note-hashtags.ts
+++ b/src/app/inventory/note-hashtags.ts
@@ -18,7 +18,7 @@ export function collectNotesHashtags(itemInfos: ItemInfos) {
   return uniqBy(hashTags, (t) => t.toLowerCase());
 }
 
-const hashtagRegex = /#[^\s]+/gu;
+const hashtagRegex = /#[^\s,]+/gu;
 
 export function getHashtagsFromNote(note?: string | null) {
   return Array.from(note?.matchAll(hashtagRegex) ?? [], (m) => m[0]);
@@ -46,7 +46,7 @@ export function appendedToNote(originalNote: string | undefined, append: string)
     .trim();
 }
 
-const allHashtagsRegex = /^(\s*)((#[^\s]+)\s*)+$/u;
+const allHashtagsRegex = /^(\s*)((#[^\s,]+)\s*)+$/u;
 
 /**
  * Add notes to an existing note. This is hashtag-aware, so it will not remove

--- a/src/app/inventory/note-hashtags.ts
+++ b/src/app/inventory/note-hashtags.ts
@@ -18,7 +18,7 @@ export function collectNotesHashtags(itemInfos: ItemInfos) {
   return uniqBy(hashTags, (t) => t.toLowerCase());
 }
 
-const hashtagRegex = /#[\p{L}\p{N}_\p{Private_Use}\p{Other_Symbol}:-]+/gu;
+const hashtagRegex = /#[^\s]+/gu;
 
 export function getHashtagsFromNote(note?: string | null) {
   return Array.from(note?.matchAll(hashtagRegex) ?? [], (m) => m[0]);
@@ -46,7 +46,7 @@ export function appendedToNote(originalNote: string | undefined, append: string)
     .trim();
 }
 
-const allHashtagsRegex = /^(\s*)((#[\p{L}\p{N}_\p{Private_Use}\p{Other_Symbol}:-]+)\s*)+$/u;
+const allHashtagsRegex = /^(\s*)((#[^\s]+)\s*)+$/u;
 
 /**
  * Add notes to an existing note. This is hashtag-aware, so it will not remove

--- a/src/app/inventory/note-hashtags.ts
+++ b/src/app/inventory/note-hashtags.ts
@@ -18,7 +18,7 @@ export function collectNotesHashtags(itemInfos: ItemInfos) {
   return uniqBy(hashTags, (t) => t.toLowerCase());
 }
 
-const hashtagRegex = /#[^\s,]+/gu;
+const hashtagRegex = /#([^\s,](,(?!\s))?)+/gu;
 
 export function getHashtagsFromNote(note?: string | null) {
   return Array.from(note?.matchAll(hashtagRegex) ?? [], (m) => m[0]);
@@ -46,7 +46,7 @@ export function appendedToNote(originalNote: string | undefined, append: string)
     .trim();
 }
 
-const allHashtagsRegex = /^(\s*)((#[^\s,]+)\s*)+$/u;
+const allHashtagsRegex = /^(\s*)((#([^\s,](,(?!\s))?)+)\s*)+$/u;
 
 /**
  * Add notes to an existing note. This is hashtag-aware, so it will not remove

--- a/src/app/loadout/loadout-ui/menu-hooks.tsx
+++ b/src/app/loadout/loadout-ui/menu-hooks.tsx
@@ -73,7 +73,7 @@ export function useLoadoutFilterPills(
         ...getHashtagsFromNote(loadout.notes),
       ];
       for (const hashtag of hashtags) {
-        (loadoutsByHashtag[hashtag.replace('#', '').replace(/_/g, ' ')] ??= []).push(loadout);
+        (loadoutsByHashtag[hashtag.replace(/_/g, ' ')] ??= []).push(loadout);
       }
     }
     return loadoutsByHashtag;
@@ -83,7 +83,7 @@ export function useLoadoutFilterPills(
     Object.keys(loadoutsByHashtag).map(
       (hashtag): Option => ({
         key: hashtag,
-        content: <ColorDestinySymbols text={hashtag} />,
+        content: <ColorDestinySymbols text={hashtag.replace(/#(\w+\|)?/, '')} />,
       })
     ),
     (o) => o.key

--- a/src/app/loadout/loadout-ui/menu-hooks.tsx
+++ b/src/app/loadout/loadout-ui/menu-hooks.tsx
@@ -73,7 +73,7 @@ export function useLoadoutFilterPills(
         ...getHashtagsFromNote(loadout.notes),
       ];
       for (const hashtag of hashtags) {
-        (loadoutsByHashtag[hashtag.replace(/_/g, ' ')] ??= []).push(loadout);
+        (loadoutsByHashtag[hashtag] ??= []).push(loadout);
       }
     }
     return loadoutsByHashtag;
@@ -83,7 +83,7 @@ export function useLoadoutFilterPills(
     Object.keys(loadoutsByHashtag).map(
       (hashtag): Option => ({
         key: hashtag,
-        content: <ColorDestinySymbols text={hashtag.replace(/#(\w+\|)?/, '')} />,
+        content: <ColorDestinySymbols text={hashtag.replace(/#([^\s]+\|)?/, '').replace(/_/g, ' ')} />,
       })
     ),
     (o) => o.key


### PR DESCRIPTION
This maybe isn't the best solution, but, it is a simple one once I figured out how to get it to work. This change allows users to use a delimiter in the hashtag—my code uses the pipe character `|` but that's open to suggestions—anything before the delimiter becomes hidden on the pill, but, not until after it has been used to sort them.

Additionally, I realized there isn't really a reason to limit what kinds of characters can be included in the hashtag and changed it to allow any non-whitespace characters, so, users could even make ASCII art in pills if they want.