### PR TITLE
Don't queue store refresh

### DIFF
--- a/src/app/inventory/store/hooks.ts
+++ b/src/app/inventory/store/hooks.ts
@@ -4,7 +4,6 @@ import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useEventBusListener } from 'app/utils/hooks';
 import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { queueAction } from '../../utils/action-queue';
 import { loadStores as d1LoadStores } from '../d1-stores';
 import { loadStores as d2LoadStores } from '../d2-stores';
 import { storesLoadedSelector } from '../selectors';
@@ -34,13 +33,11 @@ export function useLoadStores(account: DestinyAccount | undefined) {
     refresh$,
     useCallback(() => {
       if (account) {
-        queueAction(() => {
-          if (account?.destinyVersion === 2) {
-            return dispatch(d2LoadStores());
-          } else {
-            return dispatch(d1LoadStores());
-          }
-        });
+        if (account?.destinyVersion === 2) {
+          return dispatch(d2LoadStores());
+        } else {
+          return dispatch(d1LoadStores());
+        }
       }
     }, [account, dispatch])
   );


### PR DESCRIPTION
Fixes #9415 by no longer queueing store refreshes amongst loadout applies and item moves and such. It's maybe an extreme way to solve the problem but it's something I've been thinking about for a while - our move logic should be resilient enough to handle stores updating in the middle of a move.