### PR TITLE
For vendor armor offers, show stat total instead of power level

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Item tiles for armor on the Vendors page will now show their stat total instead of power level.
+
 ## 7.67.0 <span class="changelog-date">(2023-05-07)</span>
 
 ## 7.66.0 <span class="changelog-date">(2023-04-30)</span>

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -1,3 +1,4 @@
+import { TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 import { getColor } from 'app/shell/formatters';
 import { isD1Item } from 'app/utils/item-utils';
 import { InventoryWishListRoll, toUiWishListRoll } from 'app/wishlists/wishlists';
@@ -38,6 +39,12 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   const isBounty = Boolean(!item.primaryStat && item.objectives);
   const isStackable = Boolean(item.maxStackSize > 1);
   const isGeneric = !isBounty && !isStackable;
+  // For vendor armor that reports stats (thus often randomized),
+  // show the total points as a means to indicate whether it's worth picking up
+  const totalArmorStat =
+    item.bucket?.inArmor &&
+    item.vendor &&
+    item.stats?.find((stat) => stat.statHash === TOTAL_STAT_HASH);
 
   const hideBadge = Boolean(
     item.location.hash === BucketHashes.Subclass ||
@@ -54,6 +61,9 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   const badgeContent =
     (isBounty && `${Math.floor(100 * item.percentComplete)}%`) ||
     (isStackable && item.amount.toString()) ||
+    // totalArmorStat can be false, so optional chain is wrong here
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+    (totalArmorStat && totalArmorStat.value.toString()) ||
     (isGeneric && item.primaryStat?.value.toString()) ||
     (item.classified && <ClassifiedNotes item={item} />);
 


### PR DESCRIPTION
Fixes #8836.

Most vendor armor is at the power floor (currently 1600) anyway and people will look at this armor because of stats, not power level, so this could be more useful. Pairs well with the `is:armor` filter on the Vendors page.

![grafik](https://user-images.githubusercontent.com/14299449/236527418-34fd77e3-f0ca-43c9-8e53-0752902f14cd.png)

Drawbacks: Could be controversial or confusing, or people may start asking for this on the main inventory screen.
