### PR TITLE
Adding maxHeight / overflow-y scroll to Loadouts Select Dropdown

### DIFF
--- a/src/app/dim-ui/Select.tsx
+++ b/src/app/dim-ui/Select.tsx
@@ -2,6 +2,8 @@ import { moveDownIcon, moveUpIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import clsx from 'clsx';
 import { useSelect } from 'downshift';
+
+import { useHeightFromViewportBottom } from 'app/utils/hooks';
 import { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
 import styles from './Select.m.scss';
 import { usePopper } from './usePopper';
@@ -74,6 +76,7 @@ export default function Select<T>({
   const [dropdownWidth, setDropdownWidth] = useState<number | undefined>(() =>
     typeof maxDropdownWidth === 'number' ? maxDropdownWidth : undefined
   );
+  const [dropdownHeight, setDropdownHeight] = useState<number | undefined>();
 
   usePopper({
     contents: menuRef,
@@ -97,18 +100,24 @@ export default function Select<T>({
     }
   }, [dropdownWidth, maxButtonWidth, maxDropdownWidth]);
 
+  useHeightFromViewportBottom(
+    buttonRef.current ? buttonRef : undefined,
+    setDropdownHeight,
+    28,
+    true
+  );
+
   let buttonStyle: CSSProperties | undefined;
-  let dropdownStyle: CSSProperties | undefined;
+
+  const dropdownStyle: CSSProperties = {
+    overflowY: 'scroll',
+    overscrollBehaviorY: 'contain',
+    maxHeight: dropdownHeight,
+  };
 
   if (maxButtonWidth !== undefined) {
     buttonStyle = {
       maxWidth: maxButtonWidth,
-    };
-  }
-
-  if (dropdownWidth !== undefined) {
-    dropdownStyle = {
-      maxWidth: dropdownWidth,
     };
   }
 

--- a/src/app/dim-ui/Select.tsx
+++ b/src/app/dim-ui/Select.tsx
@@ -101,7 +101,7 @@ export default function Select<T>({
   }, [dropdownWidth, maxButtonWidth, maxDropdownWidth]);
 
   useHeightFromViewportBottom(
-    buttonRef.current ? buttonRef : undefined,
+    buttonRef?.current
     setDropdownHeight,
     28,
     true

--- a/src/app/dim-ui/Select.tsx
+++ b/src/app/dim-ui/Select.tsx
@@ -100,12 +100,7 @@ export default function Select<T>({
     }
   }, [dropdownWidth, maxButtonWidth, maxDropdownWidth]);
 
-  useHeightFromViewportBottom(
-    buttonRef?.current
-    setDropdownHeight,
-    28,
-    true
-  );
+  useHeightFromViewportBottom(buttonRef, setDropdownHeight, 28, true);
 
   let buttonStyle: CSSProperties | undefined;
 

--- a/src/app/utils/hooks.ts
+++ b/src/app/utils/hooks.ts
@@ -100,7 +100,7 @@ export function useThrottledSubscription<T>(observable: Observable<T>, delay: nu
 }
 
 /**
- * Determine a height for a given element based on its position and height
+ * Determine a height for a given element based on its height and position
  * relative to the bottom of the viewport.
  */
 export function useHeightFromViewportBottom(

--- a/src/app/utils/hooks.ts
+++ b/src/app/utils/hooks.ts
@@ -116,9 +116,9 @@ export function useHeightFromViewportBottom(
       return;
     }
     const updateHeight = () => {
-      const rect = elementRef.current.getBoundingClientRect();
+      const rect = elementRef.current!.getBoundingClientRect();
       const { y, height } = rect;
-      const { height: viewportHeight } = window.visualViewport;
+      const { height: viewportHeight } = window.visualViewport!;
       // pixels remaining in viewport minus offset minus padding
       const pxAvailable = viewportHeight - y - height - padding;
       const heightFromBottom =
@@ -131,6 +131,6 @@ export function useHeightFromViewportBottom(
 
     updateHeight();
     window.visualViewport.addEventListener('resize', updateHeight);
-    return () => window.visualViewport.removeEventListener('resize', updateHeight);
+    return () => window.visualViewport!.removeEventListener('resize', updateHeight);
   }, [setHeightFromViewportBottom, elementRef, itemHeight, padding]);
 }


### PR DESCRIPTION
#9334: Adding maxHeight / overflow-y scroll to Loadouts Select Dropdown

**Problem**
Compare loadouts selection menu can grow too long if a User has many loadouts - this makes it impossible to selct those that have rendered off-screen. 

**Solution**
Limit the `maxDropdownHeight` by adding a new prop on the common `Select.tsx` component. 
When `maxDropdownHeight` is defined also set the `overflow-y: scroll` to enable scrolling in the dropdown. 

**Possible issues**
1. Body scrolling still possible on Safari so once the user scrolls to the bottom of the dropdown and tries to scroll the background content will scroll. 
2. If the mouse focus is even slightly off the dropdown when scrolling the background will scroll 
3. Untested on mobile (my Charles Proxy / Map Remote wasn't working for some reason)

There's a scrollbar here, trust. 
<img width="1790" alt="Screenshot 2023-05-08 at 12 48 19" src="https://user-images.githubusercontent.com/10519003/236821731-cf2646a4-d57b-4d01-b089-c0e01a153739.png">

