### PR TITLE
Fixed weapons missing from source:ritual-weapon

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Next
-* Added several weapons missing weapons to source:ritual-weapon search filter
+* Added several missing weapons to source:ritual-weapon search filter.
 
 ## 7.67.0 <span class="changelog-date">(2023-05-07)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Added several weapons missing weapons to source:ritual-weapon search filter
 
 ## 7.67.0 <span class="changelog-date">(2023-05-07)</span>
 

--- a/src/data/d2/source-info.ts
+++ b/src/data/d2/source-info.ts
@@ -1150,21 +1150,8 @@ const D2Sources: {
       4227181568, // Exit Strategy
       3001205424, // Ecliptic Distaff
       2060863616, // Salvagers Salvo
-      616582330, // Cry Mutiny
-      3105930175, // Chain of Command
-      153979396, // Luna's Howl
-      153979399, // Not Forgotten
-      1161276682, // Redrix's Broadsword
-      3993415705, // The mountaintop
-      3354242550, // The Recluse
-      654608616, // Revoker
-      324382200, // Breakneck
-      1600633250, // 21% Delirium
-      1584643826, // Hush
-      580961571, // Loaded Question
-      792755504, // Nightshade
-      3907337522, // Oxygen SR3
-      578459533, // Wendigo GL3
+      616582329, // Cry Mutiny
+      3105930174, // Chain of Command
     ],
     sourceHashes: [
       3299964501, // Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.

--- a/src/data/d2/source-info.ts
+++ b/src/data/d2/source-info.ts
@@ -1152,6 +1152,7 @@ const D2Sources: {
       2060863616, // Salvagers Salvo
       616582329, // Cry Mutiny
       3105930174, // Chain of Command
+      3216652511, // Reckless Endangerment
     ],
     sourceHashes: [
       3299964501, // Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.

--- a/src/data/d2/source-info.ts
+++ b/src/data/d2/source-info.ts
@@ -1148,6 +1148,19 @@ const D2Sources: {
       3535742959, // Randy's Throwing Knife
       4184808992, // Adored
       4227181568, // Exit Strategy
+      3001205424, // Ecliptic Distaff
+      2060863616, // Salvagers Salvo
+      616582330, // Cry Mutiny
+      3105930175, // Chain of Command
+      153979396, // Luna's Howl
+      153979399, // Not Forgotten
+      1161276682, // Redrix's Broadsword
+      3993415705, // The mountaintop
+      3354242550, // The Recluse
+      654608616, // Revoker
+      324382200, // Breakneck
+      1600633250, // 21% Delirium
+      1584643826, // Hush
     ],
     sourceHashes: [
       3299964501, // Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.

--- a/src/data/d2/source-info.ts
+++ b/src/data/d2/source-info.ts
@@ -1161,6 +1161,10 @@ const D2Sources: {
       324382200, // Breakneck
       1600633250, // 21% Delirium
       1584643826, // Hush
+      580961571, // Loaded Question
+      792755504, // Nightshade
+      3907337522, // Oxygen SR3
+      578459533, // Wendigo GL3
     ],
     sourceHashes: [
       3299964501, // Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.


### PR DESCRIPTION
Added weapons to src/data/source-info.ts with several items that were missing from the source:ritual-weapon search.

![image](https://user-images.githubusercontent.com/98132549/236984552-b2376e4e-4ee7-46ca-aa9a-b3e380b1e22e.png)

other weapons were added as well but these are the weapons mentioned in #9446 

Solves issue #9446 