### PR TITLE
Track craftedDate in in-game -> DIM loadout conversion

### DIFF
--- a/src/app/loadout-drawer/loadout-type-converters.ts
+++ b/src/app/loadout-drawer/loadout-type-converters.ts
@@ -24,7 +24,7 @@ import {
   LoadoutItem as DimLoadoutItem,
   InGameLoadout,
 } from './loadout-types';
-import { newLoadout, potentialLoadoutItemsByItemId } from './loadout-utils';
+import { convertToLoadoutItem, newLoadout, potentialLoadoutItemsByItemId } from './loadout-utils';
 
 /**
  * DIM API stores loadouts in a new format, but the app still uses the old format everywhere. These functions convert
@@ -238,11 +238,8 @@ export function convertInGameLoadoutToDimLoadout(
           : undefined;
 
       const loadoutItem: DimLoadoutItem = {
-        id: inGameItem.itemInstanceId,
-        hash: matchingItem.hash,
+        ...convertToLoadoutItem(matchingItem, true),
         socketOverrides,
-        equip: true,
-        amount: 1,
       };
 
       return loadoutItem;


### PR DESCRIPTION
I've been investigating https://old.reddit.com/r/DestinyItemManager/comments/13jmccp/reshaping_weapons_marks_them_as_missing_from/ and couldn't reproduce it at first, but I still looked at the code and found one case where DIM wouldn't track the crafted date.

However, 10 minutes later the other loadout I tested it with was also missing its item, because apparently dim-api just drops the `craftedDate` (DestinyItemManager/dim-api#190), so I'm wondering if this ever worked correctly...