### PR TITLE
Hover colour + cursor for search bar controls

### DIFF
--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -57,6 +57,10 @@
   padding: 6px 9px 6px 9px;
   gap: 6px;
 
+  &:hover {
+    cursor: pointer;
+  }
+
   @include phone-portrait {
     padding: 10px 10px 10px 9px;
   }
@@ -187,7 +191,7 @@
   > :global(.app-icon),
   > button > :global(.app-icon) {
     font-size: 14px !important;
-    color: #999 !important;
+    color: #999;
     // Increase touch target size
     padding: 4px;
     margin: -4px;
@@ -195,12 +199,15 @@
     &:first-child {
       margin-left: -4px;
     }
-    &:hover {
-      color: #e8a534 !important;
-    }
     :global(.mobile-search-link) & {
       font-size: 18px !important;
     }
+  }
+
+  &:hover > span,
+  &:hover > :global(.app-icon),
+  &:hover button > :global(.app-icon) {
+    color: var(--theme-accent-primary);
   }
 
   > span,


### PR DESCRIPTION
Style tweak ahead of theming #9010 

Use primary accent for hover interactions on search bar controls + pointer cursor when hovering autocomplete items. 

Note: we were previously forcing icons to always be grey, which was overriding the defined hover style. 

The 'Star' saved filter icon always appears orange — this wasn't explicitly changed, it's another existing style that was forcibly being overridden. 

Before:
![search-current](https://github.com/DestinyItemManager/DIM/assets/1396158/032c82ca-e1e2-4327-9c7e-9ee0d376569b)

After:
![search-new](https://github.com/DestinyItemManager/DIM/assets/1396158/7faf458e-be6c-428b-9582-e11be53e3b40)
