### PR TITLE
Theme prep: Text colour variables

### DIFF
--- a/src/app/_theme.scss
+++ b/src/app/_theme.scss
@@ -8,6 +8,10 @@
   --theme-fill-modal: #000; // Base fill for popups, drawers, dropdowns etc
   --theme-fill-modal-actions: #161616; // Layered/contextual modals (search, item actions)
 
+  // Text
+  --theme-text: #fff;
+  --theme-text-invert: #000;
+
   // Buttons
   --theme-button-bg: rgba(255, 255, 255, 0.2);
 

--- a/src/app/accounts/MenuAccounts.m.scss
+++ b/src/app/accounts/MenuAccounts.m.scss
@@ -1,7 +1,7 @@
 @use '../variables.scss' as *;
 
 .accountSelect {
-  color: white;
+  color: var(--theme-text);
   height: auto;
   flex: 1 0 auto;
   display: flex;
@@ -17,7 +17,7 @@
 
       &:hover,
       &:focus {
-        color: black;
+        color: var(--theme-text-invert);
         background-color: var(--theme-accent-primary);
       }
     }

--- a/src/app/character-tile/CharacterTile.m.scss
+++ b/src/app/character-tile/CharacterTile.m.scss
@@ -38,7 +38,7 @@
 
 .bottom {
   font-size: 12px;
-  color: white;
+  color: var(--theme-text);
   line-height: 10px;
   text-shadow: none;
 

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerOptions.m.scss
@@ -36,7 +36,7 @@
   background: rgb(46, 46, 46);
   border: none;
   border-bottom: 1px solid #555;
-  color: white;
+  color: var(--theme-text);
   width: 100%;
 
   @include phone-portrait {

--- a/src/app/dim-ui/CheckButton.m.scss
+++ b/src/app/dim-ui/CheckButton.m.scss
@@ -25,6 +25,6 @@
   &:hover,
   &:active {
     background-color: rgba(255, 255, 255, 0.2) !important;
-    color: white !important;
+    color: var(--theme-text) !important;
   }
 }

--- a/src/app/dim-ui/CollapsibleTitle.scss
+++ b/src/app/dim-ui/CollapsibleTitle.scss
@@ -3,7 +3,7 @@
 .title {
   padding: 0 16px;
   background-color: rgba(0, 0, 0, 0.2);
-  color: white;
+  color: var(--theme-text);
   min-height: 34px;
   text-transform: uppercase;
   letter-spacing: 2px;
@@ -24,7 +24,7 @@
     &:hover,
     &.collapsed {
       background-color: transparent;
-      color: white;
+      color: var(--theme-text);
     }
   }
 

--- a/src/app/dim-ui/ConfirmButton.m.scss
+++ b/src/app/dim-ui/ConfirmButton.m.scss
@@ -24,7 +24,7 @@
     & > div {
       transition: height 0.1s;
     }
-    color: white !important;
+    color: var(--theme-text) !important;
 
     &:hover {
       background-color: #af7d27 !important;

--- a/src/app/dim-ui/Dropdown.m.scss
+++ b/src/app/dim-ui/Dropdown.m.scss
@@ -8,7 +8,7 @@
 .menu {
   position: absolute;
   background: var(--theme-dropdown-menu-bg);
-  color: white;
+  color: var(--theme-text);
   font-size: 12px;
   z-index: 100;
 }
@@ -27,7 +27,7 @@
   }
 
   :global(.app-icon) {
-    color: white !important;
+    color: var(--theme-text) !important;
     width: 16px;
     text-align: center;
     margin-right: 4px;
@@ -44,9 +44,9 @@
 
 .highlighted {
   background-color: var(--theme-accent-primary);
-  color: black !important;
+  color: var(--theme-text-invert) !important;
   :global(.app-icon) {
-    color: black !important;
+    color: var(--theme-text-invert) !important;
   }
 }
 

--- a/src/app/dim-ui/FilterPills.m.scss
+++ b/src/app/dim-ui/FilterPills.m.scss
@@ -18,7 +18,7 @@
   background: rgba(0, 0, 0, 0.4);
   border-radius: 12px;
   padding: 2px 8px;
-  color: white;
+  color: var(--theme-text);
   border: 1px solid transparent;
   cursor: pointer;
   transition: border-color 150ms;

--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -59,7 +59,7 @@ $horizontal-padding: 11px;
     h2 {
       font-size: 14px;
       margin: 0;
-      color: white;
+      color: var(--theme-text);
 
       @include destiny-header;
     }

--- a/src/app/dim-ui/Select.m.scss
+++ b/src/app/dim-ui/Select.m.scss
@@ -9,7 +9,7 @@
 
 .menu {
   background: var(--theme-dropdown-menu-bg);
-  color: white;
+  color: var(--theme-text);
   font-size: 12px;
   z-index: 100;
   position: absolute;
@@ -31,7 +31,7 @@
   }
 
   :global(.app-icon) {
-    color: white !important;
+    color: var(--theme-text) !important;
     width: 16px;
     text-align: center;
     margin-right: 4px;
@@ -42,9 +42,15 @@
 
 .highlighted {
   background-color: var(--theme-accent-primary);
-  color: #000;
-  :global(.app-icon) {
-    color: black !important;
+  color: var(--theme-text-invert);
+  cursor: pointer;
+  & :global(.app-icon) {
+    color: var(--theme-text-inverted) !important;
+  }
+  // Maintain legibility of keyHelp
+  & span {
+    color: var(--theme-text-invert);
+    border-color: var(--theme-text-invert);
   }
 }
 

--- a/src/app/dim-ui/destiny-symbols/SymbolsPicker.m.scss
+++ b/src/app/dim-ui/destiny-symbols/SymbolsPicker.m.scss
@@ -67,12 +67,12 @@
   font-family: unset;
   text-align: center;
   font-size: 18px;
-  color: white;
+  color: var(--theme-text);
 
   padding: 2px;
 
   &:hover {
-    color: black;
+    color: var(--theme-text-invert);
     background-color: var(--theme-accent-primary);
   }
 }

--- a/src/app/dim-ui/dim-button.scss
+++ b/src/app/dim-ui/dim-button.scss
@@ -7,7 +7,7 @@
   padding: 4px 10px;
   display: inline-block;
   background-color: var(--theme-button-bg);
-  color: white;
+  color: var(--theme-text);
   font-size: 12px;
   line-height: calc(16 / 12);
   font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
@@ -38,7 +38,7 @@
   &:active,
   &.selected {
     background-color: var(--theme-accent-primary) !important;
-    color: black !important;
+    color: var(--theme-text-invert) !important;
     img {
       filter: invert(1) drop-shadow(0 0 1px black);
     }
@@ -54,7 +54,7 @@
     &:active,
     &.selected {
       background-color: var(--theme-button-bg) !important;
-      color: white !important;
+      color: var(--theme-text) !important;
       img {
         filter: drop-shadow(0 0 1px black);
       }

--- a/src/app/dim-ui/useDialog.m.scss
+++ b/src/app/dim-ui/useDialog.m.scss
@@ -3,7 +3,7 @@
 .dialog {
   position: fixed;
   background-color: #08080f;
-  color: white;
+  color: var(--theme-text);
   top: 0;
   top: env(safe-area-inset-top, 0);
   margin-top: 0;

--- a/src/app/farming/farming.scss
+++ b/src/app/farming/farming.scss
@@ -20,7 +20,7 @@
   padding-bottom: Max(0.5rem, env(safe-area-inset-bottom));
 
   button {
-    color: white;
+    color: var(--theme-text);
     background-color: rgba(128, 128, 128, 0.4);
     border: none;
     padding: 0.5rem 1rem;

--- a/src/app/hotkeys/HotkeysCheatSheet.m.scss
+++ b/src/app/hotkeys/HotkeysCheatSheet.m.scss
@@ -11,7 +11,7 @@
   height: 100%;
   top: 0;
   left: 0;
-  color: white;
+  color: var(--theme-text);
   font-size: 1em;
   background-color: rgba(0, 0, 0, 0.9);
   z-index: 2000;
@@ -36,7 +36,7 @@
   grid-template-columns: repeat(auto-fill, 75px minmax(200px, 1fr));
   margin: 0 auto;
   max-width: 800px;
-  color: white;
+  color: var(--theme-text);
 }
 
 .keys {

--- a/src/app/inventory-page/InventoryCollapsibleTitle.scss
+++ b/src/app/inventory-page/InventoryCollapsibleTitle.scss
@@ -15,7 +15,7 @@
       }
     }
     &.collapsed {
-      color: white;
+      color: var(--theme-text);
       font-weight: bold;
       min-height: 32px;
       padding-bottom: 4px;

--- a/src/app/inventory/PullFromPostmaster.m.scss
+++ b/src/app/inventory/PullFromPostmaster.m.scss
@@ -5,7 +5,7 @@
   border-radius: 10px;
   background: var(--theme-accent-primary);
   padding: 0 4px;
-  color: black;
+  color: var(--theme-text-invert);
   font-size: 9px;
   transition: all 150ms ease-out;
 }

--- a/src/app/item-actions/ActionButton.m.scss
+++ b/src/app/item-actions/ActionButton.m.scss
@@ -32,9 +32,9 @@
     &:focus-visible {
       outline: none;
       background: var(--theme-accent-primary);
-      color: black;
+      color: var(--theme-text-invert);
       :global(.app-icon) {
-        color: black;
+        color: var(--theme-text-invert);
       }
     }
   }

--- a/src/app/item-feed/Highlights.m.scss
+++ b/src/app/item-feed/Highlights.m.scss
@@ -30,6 +30,6 @@
   }
   :global(.stat) {
     line-height: 8px;
-    color: white !important;
+    color: var(--theme-text) !important;
   }
 }

--- a/src/app/item-feed/ItemFeedSidebar.m.scss
+++ b/src/app/item-feed/ItemFeedSidebar.m.scss
@@ -36,7 +36,7 @@
   background: black;
   position: absolute;
   right: 100%;
-  color: white;
+  color: var(--theme-text);
   padding: 8px;
   top: -25px;
   transform-origin: bottom right;
@@ -44,7 +44,7 @@
   font-size: 16px;
 
   &:hover {
-    color: black;
+    color: var(--theme-text-invert);
     background-color: var(--theme-accent-primary);
   }
 

--- a/src/app/item-popup/EnergyMeter.m.scss
+++ b/src/app/item-popup/EnergyMeter.m.scss
@@ -24,7 +24,7 @@
 
 .upgradeButton {
   composes: resetButton from '../dim-ui/common.m.scss';
-  color: #fff;
+  color: var(--theme-text);
   font-size: 16px;
 }
 

--- a/src/app/item-popup/ItemObjectives.scss
+++ b/src/app/item-popup/ItemObjectives.scss
@@ -53,7 +53,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  color: white;
+  color: var(--theme-text);
 }
 
 .objective-integer {
@@ -62,7 +62,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  color: white;
+  color: var(--theme-text);
   img {
     width: 16px;
     height: 16px;

--- a/src/app/item-popup/ItemPerksList.m.scss
+++ b/src/app/item-popup/ItemPerksList.m.scss
@@ -64,7 +64,7 @@
     color: #aaa;
   }
   h3 {
-    color: white;
+    color: var(--theme-text);
   }
 }
 

--- a/src/app/item-popup/ItemPopupBody.scss
+++ b/src/app/item-popup/ItemPopupBody.scss
@@ -17,7 +17,7 @@
     border-bottom: 2px solid var(--theme-accent-primary);
   }
   &:hover {
-    color: white;
+    color: var(--theme-text);
     background-color: #3f3f3f;
   }
 }
@@ -47,7 +47,7 @@
     white-space: normal;
     max-width: fit-content;
     a {
-      color: white;
+      color: var(--theme-text);
       font-size: 12px;
     }
   }
@@ -126,7 +126,7 @@
   margin-bottom: 2px;
 }
 .failure-reason {
-  color: white;
+  color: var(--theme-text);
   background-color: #923c3c;
   margin: 0;
   padding: 2px 8px;
@@ -158,7 +158,7 @@
   &.is-Rare,
   &.is-Legendary {
     .sheet-close {
-      color: white;
+      color: var(--theme-text);
     }
     .sheet-handle div {
       background-color: white;

--- a/src/app/item-popup/ItemSocketsGeneral.m.scss
+++ b/src/app/item-popup/ItemSocketsGeneral.m.scss
@@ -4,7 +4,7 @@
   color: #aaa;
   white-space: pre-line;
   h3 {
-    color: white;
+    color: var(--theme-text);
   }
 }
 .clarityDescription {

--- a/src/app/item-popup/ItemSocketsWeapons.m.scss
+++ b/src/app/item-popup/ItemSocketsWeapons.m.scss
@@ -44,12 +44,12 @@
   height: 24px;
   z-index: 1;
   background-color: rgba(255, 255, 255, 0.2);
-  color: white;
+  color: var(--theme-text);
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   &:hover,
   &:active {
     background-color: var(--theme-accent-primary) !important;
-    color: black !important;
+    color: var(--theme-text-invert) !important;
   }
 }
 

--- a/src/app/loadout-drawer/LoadoutDrawerHeader.m.scss
+++ b/src/app/loadout-drawer/LoadoutDrawerHeader.m.scss
@@ -19,7 +19,7 @@
   background: var(--theme-input-bg);
   border: none;
   border-bottom: 1px solid #555;
-  color: white;
+  color: var(--theme-text);
   width: 100%;
   font-size: 18px;
 

--- a/src/app/loadout/ingame/EditInGameLoadout.m.scss
+++ b/src/app/loadout/ingame/EditInGameLoadout.m.scss
@@ -34,7 +34,7 @@
   &:active,
   &.checked {
     background-color: var(--theme-accent-primary);
-    color: black;
+    color: var(--theme-text-invert);
     > img {
       filter: none !important;
     }
@@ -46,7 +46,7 @@
     &:hover,
     &:active,
     &.checked {
-      color: white !important;
+      color: var(--theme-text) !important;
     }
   }
 }

--- a/src/app/loadout/loadout-edit/LoadoutEditSection.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditSection.m.scss
@@ -29,6 +29,6 @@
   &:active,
   &:hover,
   &:focus-visible {
-    color: white;
+    color: var(--theme-text);
   }
 }

--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -91,7 +91,7 @@
 
   input[type='text'] {
     border: none;
-    color: white;
+    color: var(--theme-text);
     outline: none;
     flex: 1;
     width: 0;
@@ -106,12 +106,16 @@
   &:hover,
   a:hover {
     background-color: var(--theme-accent-primary);
-    color: black !important;
+    color: var(--theme-text-invert) !important;
     > span:first-child > :global(.app-icon) {
-      color: black !important;
+      color: var(--theme-text-invert) !important;
     }
     > span:first-child > img:first-child {
       filter: none;
+    }
+
+    .note {
+      color: var(--theme-text-invert);
     }
   }
 
@@ -167,7 +171,7 @@
   &:hover,
   a:hover {
     background-color: black;
-    color: white !important;
+    color: var(--theme-text) !important;
     cursor: default;
   }
 }

--- a/src/app/login/Login.m.scss
+++ b/src/app/login/Login.m.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   align-items: stretch;
   background-color: rgba(0, 0, 0, 0.6);
-  color: white;
+  color: var(--theme-text);
   max-width: 800px;
   border-top: 5px solid #888;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
@@ -68,7 +68,7 @@
     text-transform: none !important;
   }
   a {
-    color: white;
+    color: var(--theme-text);
     font-size: 12px;
   }
   button {
@@ -84,7 +84,7 @@
   text-align: center;
   padding: 1em 3em;
   background-color: var(--theme-accent-primary);
-  color: black;
+  color: var(--theme-text-invert);
   text-shadow: none;
   &:hover {
     transform: scale(1.05);

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -171,7 +171,7 @@ body {
 body {
   margin: 0 auto;
   background-color: #313233;
-  color: white;
+  color: var(--theme-text);
   font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
   font-size: 12px;
   line-height: calc(16 / 12);
@@ -216,7 +216,7 @@ textarea {
   padding: 4px 8px;
   border: none;
   outline: none;
-  color: white;
+  color: var(--theme-text);
   box-sizing: border-box;
   font-family: monospace, 'Destiny Symbols';
   font-size: inherit;
@@ -237,7 +237,7 @@ select {
   height: 27px;
   font-size: 12px;
   line-height: calc(16 / 12);
-  color: white;
+  color: var(--theme-text);
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
   border: 1px solid transparent;
 
@@ -251,7 +251,7 @@ select {
   &:hover,
   &:active {
     background-color: var(--theme-accent-primary);
-    color: black;
+    color: var(--theme-text-invert);
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="black" d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"></path></svg>');
   }
   // Set focus styles
@@ -266,7 +266,7 @@ select {
 
   option {
     background: black;
-    color: white;
+    color: var(--theme-text);
   }
 }
 

--- a/src/app/notifications/Notification.m.scss
+++ b/src/app/notifications/Notification.m.scss
@@ -11,7 +11,7 @@
 }
 
 .inner {
-  color: white;
+  color: var(--theme-text);
   box-sizing: border-box;
   border-top: 4px solid black;
   pointer-events: all;

--- a/src/app/notifications/NotificationButton.m.scss
+++ b/src/app/notifications/NotificationButton.m.scss
@@ -5,7 +5,7 @@
   padding: 6px;
   border-radius: 4px;
   text-align: center;
-  color: white;
+  color: var(--theme-text);
   background-color: #222;
   display: block;
   width: 30%;

--- a/src/app/organizer/DropDown.m.scss
+++ b/src/app/organizer/DropDown.m.scss
@@ -39,7 +39,7 @@ $dropdown-menu: 10;
   border-radius: 0;
   border: none;
   box-sizing: border-box;
-  color: white;
+  color: var(--theme-text);
   cursor: pointer;
   display: flex;
   flex-direction: row;
@@ -52,7 +52,7 @@ $dropdown-menu: 10;
 
   &:hover,
   &:active {
-    color: #000;
+    color: var(--theme-text-invert);
     box-shadow: none;
     background-color: var(--theme-accent-primary);
   }

--- a/src/app/organizer/ItemTypeSelector.m.scss
+++ b/src/app/organizer/ItemTypeSelector.m.scss
@@ -27,7 +27,7 @@
   &:active,
   &.checked {
     background-color: var(--theme-accent-primary);
-    color: black;
+    color: var(--theme-text-invert);
     > img {
       filter: none !important;
     }

--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -41,7 +41,7 @@
 
   p.gildingText {
     margin: 8px 0 0 0;
-    color: white;
+    color: var(--theme-text);
   }
 
   p + p.gildingText {
@@ -223,7 +223,7 @@
   }
 
   .currentScore {
-    color: white;
+    color: var(--theme-text);
     font-weight: bold;
   }
 

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -16,7 +16,7 @@
 }
 
 .menu {
-  color: white;
+  color: var(--theme-text);
   overflow: hidden;
   margin: 0;
   border-top: 0;
@@ -114,9 +114,9 @@
 
 .highlightedItem {
   background-color: var(--theme-accent-primary);
-  color: black !important;
+  color: var(--theme-text-invert) !important;
   .menuItemIcon {
-    color: black;
+    color: var(--theme-text-invert);
   }
   .deleteIcon {
     color: #333;
@@ -153,8 +153,8 @@
 .keyHelp {
   margin-top: 2px;
   .highlightedItem & {
-    color: #222;
-    border-color: #222;
+    color: var(--theme-text-invert);
+    border-color: var(--theme-text-invert);
   }
 }
 

--- a/src/app/search/SearchHistory.m.scss
+++ b/src/app/search/SearchHistory.m.scss
@@ -27,7 +27,7 @@
 .iconButton {
   composes: resetButton from '../dim-ui/common.m.scss';
   margin-left: 6px;
-  color: white;
+  color: red;
   padding: 0 2px;
 }
 

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -34,7 +34,7 @@
 
   > input[type='text'] {
     border: none;
-    color: white;
+    color: var(--theme-text);
     background: transparent;
     outline: none;
     flex: 1;

--- a/src/app/settings/CustomStatsSettings.m.scss
+++ b/src/app/settings/CustomStatsSettings.m.scss
@@ -12,7 +12,7 @@
 
 // a style for inputs or input wrappers
 .inputlike {
-  color: white;
+  color: var(--theme-text);
   align-items: center;
   background: #4443;
   border-radius: 4px;

--- a/src/app/shell/AppInstallBanner.m.scss
+++ b/src/app/shell/AppInstallBanner.m.scss
@@ -16,5 +16,5 @@
 .hideButton {
   composes: resetButton from '../dim-ui/common.m.scss';
   margin-left: 16px;
-  color: white;
+  color: var(--theme-text);
 }

--- a/src/app/shell/ErrorPanel.m.scss
+++ b/src/app/shell/ErrorPanel.m.scss
@@ -12,7 +12,7 @@
     text-transform: none !important;
   }
   :global(.dim-button) {
-    color: white;
+    color: var(--theme-text);
     font-size: 12px;
   }
   p {

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -78,7 +78,7 @@ $header-height: 44px;
     margin: 0 12px;
   }
 
-  color: white;
+  color: var(--theme-text);
   cursor: pointer;
 
   &:hover,
@@ -191,7 +191,7 @@ $header-height: 44px;
     transition: none;
 
     &.active {
-      color: white;
+      color: var(--theme-text);
       border-left: 4px solid var(--theme-accent-primary);
       padding-left: calc(1rem - 4px);
     }
@@ -205,7 +205,7 @@ $header-height: 44px;
     &:hover,
     &:focus {
       background-color: var(--theme-accent-primary);
-      color: black;
+      color: var(--theme-text-invert);
     }
 
     .launchSeparateIcon {

--- a/src/app/storage/LocalStorageInfo.m.scss
+++ b/src/app/storage/LocalStorageInfo.m.scss
@@ -1,7 +1,7 @@
 @use '../variables.scss' as *;
 
 .warningBlock {
-  color: white;
+  color: var(--theme-text);
   background: $red;
   padding: 0.5em 1em;
   display: inline-block;
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  color: white;
+  color: var(--theme-text);
   div {
     background-color: $green;
     position: absolute;

--- a/src/app/store-stats/VaultCapacity.m.scss
+++ b/src/app/store-stats/VaultCapacity.m.scss
@@ -15,6 +15,6 @@
 }
 
 .full {
-  color: white;
+  color: var(--theme-text);
   font-weight: bold;
 }

--- a/src/app/whats-new/BungieAlerts.m.scss
+++ b/src/app/whats-new/BungieAlerts.m.scss
@@ -4,7 +4,7 @@
   margin: 1em 0;
   padding: 1em;
   a {
-    color: white;
+    color: var(--theme-text);
   }
   h2 {
     margin: 0 0 8px 0 !important;


### PR DESCRIPTION
Theme prep for #9010 

Added global text colour variables for standard + inverted text. 

Improved legibility of keyboard shortcuts + loadout farming mode helper text in hover states by using the inverted text style. 

Not tackled by this PR: 
- Component specific text colours — this feels better handled if/when components need to override the global text colour 
- Some icon colours/hover states have been left with hard-coded black/white colours as these appear to be bespoke instances of icons that have explicitly defined base/hover colours — recommend changing these as/when needed 