### PR TITLE
Fix too-small archetype icon

### DIFF
--- a/src/app/compare/CompareItem.m.scss
+++ b/src/app/compare/CompareItem.m.scss
@@ -16,6 +16,10 @@
   // TODO push these into sockets component?
   :global(.plug) {
     --item-size-mod: calc(26 / 50 * var(--item-size));
+
+    @include phone-portrait {
+      --item-size-mod: 26px;
+    }
     // This relies on the fact that only mods are img - perks are svg
     img {
       --item-size: var(--item-size-mod) !important;

--- a/src/app/item-popup/ArchetypeSocket.m.scss
+++ b/src/app/item-popup/ArchetypeSocket.m.scss
@@ -11,9 +11,10 @@
   :global(.plug) {
     padding: 4px;
 
+    --item-size-mod: calc(24 / 50 * var(--item-size));
+
     img {
-      width: calc(24 / 50 * var(--item-size));
-      height: calc(24 / 50 * var(--item-size));
+      --item-size: var(--item-size-mod);
       transform: scale(1.4);
 
       .minimal & {


### PR DESCRIPTION
I think I'm going to take another pass at these, using more explicit CSS vars (e.g. "perk-size" and "mod-size") but for now I think this fixes #9493 