### PR TITLE
Move ingame loadouts above special DIM loadouts

### DIFF
--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -256,6 +256,29 @@ export default function LoadoutPopup({
           </li>
         )}
 
+        {!filteringLoadouts && (
+          <li>
+            <ul
+              className={clsx(styles.inGameLoadouts, {
+                [styles.moreLoadouts]: inGameLoadouts.length > 6,
+              })}
+            >
+              {inGameLoadouts.map((loadout) => (
+                <li key={loadout.id}>
+                  <button
+                    type="button"
+                    className={styles.inGameLoadoutButton}
+                    title={loadout.name}
+                    onClick={() => handleApplyInGameLoadout(loadout)}
+                  >
+                    <InGameLoadoutIconWithIndex loadout={loadout} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </li>
+        )}
+
         {!filteringLoadouts && previousLoadout && (
           <li className={styles.menuItem}>
             <span
@@ -301,29 +324,6 @@ export default function LoadoutPopup({
               </>
             )}
           </>
-        )}
-
-        {!filteringLoadouts && (
-          <li>
-            <ul
-              className={clsx(styles.inGameLoadouts, {
-                [styles.moreLoadouts]: inGameLoadouts.length > 6,
-              })}
-            >
-              {inGameLoadouts.map((loadout) => (
-                <li key={loadout.id}>
-                  <button
-                    type="button"
-                    className={styles.inGameLoadoutButton}
-                    title={loadout.name}
-                    onClick={() => handleApplyInGameLoadout(loadout)}
-                  >
-                    <InGameLoadoutIconWithIndex loadout={loadout} />
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </li>
         )}
 
         {filteredLoadouts.map((loadout) => (


### PR DESCRIPTION
It's been kinda bugging me how the "Max light" loadout is orphaned above ingame loadouts, then the rest of the DIM loadouts are below them. This moves ingame loadouts above all of the special DIM loadouts.

Before:
<img width="302" alt="Screenshot 2023-05-27 at 7 04 39 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/046428c2-1987-4666-bc3e-2e45bffeedb2">
After:
<img width="312" alt="Screenshot 2023-05-27 at 7 04 32 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/7ecb4638-fe55-43b4-b8f4-ef77564754bb">
