### PR TITLE
is:iningameloadout

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -237,6 +237,7 @@
     "HasShader": "Shows items that have a shader applied.",
     "HasOrnament": "Shows items that have an ornament applied.",
     "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
+    "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "Infusable": "Shows items that can be infused.",
     "IsAdept": "Shows weapons compatible with Adept mods.",
     "IsCrafted": "Shows weapons that have been crafted.",

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -56,6 +56,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "infusable",
   "infuse",
   "infusionfodder",
+  "iningameloadout",
   "inleftchar",
   "inloadout",
   "inmiddlechar",

--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -49,6 +49,15 @@ const loadoutFilters: FilterDefinition[] = [
         );
     },
   },
+  {
+    keywords: 'iningameloadout',
+    format: 'simple',
+    description: tl('Filter.InInGameLoadout'),
+    filter:
+      ({ loadoutsByItem }) =>
+      (item) =>
+        Boolean(loadoutsByItem[item.id]?.some((l) => isInGameLoadout(l.loadout))),
+  },
 ];
 
 export default loadoutFilters;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -238,6 +238,7 @@
     "HasOrnament": "Shows items that have an ornament applied.",
     "HasShader": "Shows items that have a shader applied.",
     "HoldsMod": "Shows armor compatible with a specific type of Seasonal Mod.",
+    "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
     "Infusable": "Shows items that can be infused.",
     "InfusionFodder": "Shows items that could be infused into lower-power versions of the same item for only glimmer.",


### PR DESCRIPTION
Fixes #9475 

Open to suggestions on the filter name - is:iningameloadout is max awkward.

I didn't include the ability to search by loadout name since ingame loadout names are not very worthwhile.