### PR TITLE
Handle refresh token endpoint errors better

### DIFF
--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -59,12 +59,6 @@ export async function fetchWithBungieOAuth(
 }
 
 async function responseIndicatesBadToken(response: Response) {
-  // https://github.com/Bungie-net/api/issues/1151: D1 endpoints have a bug where they can return 401 if you've logged in via Stadia.
-  // This hack prevents a login loop
-  if (/\/D1\/Platform\/Destiny\/\d+\/Account\/\d+\/$/.test(response.url)) {
-    return false;
-  }
-
   if (response.status === 401) {
     return true;
   }
@@ -134,12 +128,20 @@ async function handleRefreshTokenError(response: Error | Response): Promise<Toke
 
   if (data) {
     if (data.error === 'server_error') {
-      if (data.error_description === 'SystemDisabled') {
-        throw new Error(t('BungieService.Maintenance'));
-      } else if (data.error_description !== 'AuthorizationRecordExpired') {
-        throw new Error(
-          `Unknown error getting response token: ${data.error}, ${data.error_description}`
-        );
+      switch (data.error_description) {
+        case 'SystemDisabled':
+          throw new Error(t('BungieService.Maintenance'));
+        case 'RefreshTokenNotYetValid':
+        case 'AccessTokenHasExpired':
+        case 'AuthorizationCodeInvalid':
+        case 'AuthorizationRecordExpired':
+          throw new FatalTokenError(
+            'Refresh token expired or not valid, platform error ' + data.error_description
+          );
+        default:
+          throw new Error(
+            `Unknown error getting response token: ${data.error}, ${data.error_description}`
+          );
       }
     }
 


### PR DESCRIPTION
I think this should fix the "DIM doesn't work until I log out / log in" issues. We used to catch this by default by looking for status code 400 but I removed that during the big Bungie.net outage. This is a more targeted fix that relies on the weird different response format this API uses for non-success statuses.

I think I understand how this could be triggered if users try to use DIM after not having used it for >90 days. I'm not sure why it seems to have been a problem for people who were actively using DIM...