### PR TITLE
More tweaks to compare / mods styles

### DIFF
--- a/src/app/compare/CompareItem.m.scss
+++ b/src/app/compare/CompareItem.m.scss
@@ -8,9 +8,11 @@
   // Make sure even if there are no stats that there's enough room to not clip
   // the icon (e.g. for ghosts)
   min-height: calc(var(--item-size) + 60px);
+  padding-bottom: 8px;
 
   > * {
     padding-left: 4px;
+    padding-right: 4px;
   }
 
   // TODO push these into sockets component?

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -82,7 +82,7 @@ export default memo(function CompareItem({
         <ItemPopupTrigger item={item} noCompare={true}>
           {(ref, onClick) => (
             <div className={styles.itemAside} ref={ref} onClick={onClick}>
-              <PressTip minimal className={styles.itemAside} tooltip={itemNotes}>
+              <PressTip minimal tooltip={itemNotes}>
                 <ConnectedInventoryItem item={item} />
               </PressTip>
             </div>

--- a/src/app/item-popup/ArchetypeSocket.m.scss
+++ b/src/app/item-popup/ArchetypeSocket.m.scss
@@ -39,7 +39,8 @@
   &.minimal {
     background-color: transparent;
     align-items: center;
-    padding: 0;
+    padding: 0 4px;
+    margin: 0;
   }
 
   :global(.armory) & {
@@ -49,6 +50,10 @@
 
   &.isWeapons {
     align-items: center;
+
+    &.minimal {
+      padding-left: 0;
+    }
   }
 }
 

--- a/src/app/item-popup/ItemSocketsGeneral.m.scss
+++ b/src/app/item-popup/ItemSocketsGeneral.m.scss
@@ -14,9 +14,6 @@
 }
 .minimalSockets {
   flex-flow: column nowrap;
-  > * {
-    margin-bottom: 8px !important;
-  }
 }
 .generalSockets {
   margin: 10px;
@@ -25,6 +22,6 @@
   gap: 4px 16px;
 
   &.minimalSockets {
-    margin: 0;
+    margin: 4px 0;
   }
 }

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -86,16 +86,18 @@ export default function ItemSocketsGeneral({
   // Remove categories where all the sockets were filtered out.
   categories = categories.filter((c) => socketsByCategory.get(c)?.length);
 
+  const intrinsicRow = intrinsicArmorPerkSocket && (
+    <IntrinsicArmorPerk
+      item={item}
+      socket={intrinsicArmorPerkSocket}
+      minimal={minimal}
+      onPlugClicked={onPlugClicked}
+    />
+  );
+
   return (
     <>
-      {intrinsicArmorPerkSocket && (
-        <IntrinsicArmorPerk
-          item={item}
-          socket={intrinsicArmorPerkSocket}
-          minimal={minimal}
-          onPlugClicked={onPlugClicked}
-        />
-      )}
+      {!minimal && intrinsicRow}
       <div className={clsx(styles.generalSockets, { [styles.minimalSockets]: minimal })}>
         {emoteWheelCategory && (
           <EmoteSockets
@@ -126,6 +128,7 @@ export default function ItemSocketsGeneral({
           </div>
         ))}
       </div>
+      {minimal && intrinsicRow}
     </>
   );
 }

--- a/src/app/item-popup/ItemSocketsWeapons.m.scss
+++ b/src/app/item-popup/ItemSocketsWeapons.m.scss
@@ -55,12 +55,7 @@
 
 .minimal {
   > * {
-    margin-bottom: 8px !important;
-  }
-
-  // Tighten up spacing between sockets
-  :global(.item-sockets) {
-    gap: 2px;
+    margin-bottom: 4px !important;
   }
 }
 
@@ -69,7 +64,7 @@
 
   .minimal & {
     margin: 0;
-    gap: 2px;
+    gap: 0;
 
     // Remove line between sockets in minimal mode
     :global(.item-socket) {
@@ -79,7 +74,7 @@
   }
 
   :global(.item-socket) {
-    gap: 1px;
+    gap: 0;
   }
 
   :global(.plug) {


### PR DESCRIPTION
Some more gentle tweaks to the compare item styles to establish padding where necessary, tighten up the grid a bit, and to prevent armor intrinsic perks from disrupting the alignment of mods.

Before:
<img width="949" alt="Screenshot 2023-05-31 at 11 30 23 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/52afa427-6bcd-4390-9524-2c1648ea27a0">
After:
<img width="986" alt="Screenshot 2023-05-31 at 11 30 01 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/cf8eb25b-7b88-4a25-b325-120f612e0627">

Before:
<img width="1061" alt="Screenshot 2023-05-31 at 11 30 47 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/d54a7b20-a90a-4daa-8b48-cb7c8309d5b2">
After:
<img width="1098" alt="Screenshot 2023-05-31 at 11 30 41 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/1047f7aa-8a7c-4339-916e-63684e0cb5fb">
