### PR TITLE
Allow DIM title bar to overlay app title bar

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -69,6 +69,7 @@ $theme-tooltip-corner-radius: 6px;
 
 // Search
 $theme-corner-radius-search: 4px;
+$search-bar-height: 28px;
 
 // A mixin that allows targeting styles only when in phone-portrait display mode
 @mixin phone-portrait {

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -27,7 +27,7 @@
   padding: 0;
   left: 0;
   right: 0;
-  top: 32px;
+  top: $search-bar-height;
   border-bottom-left-radius: $theme-corner-radius-search;
   border-bottom-right-radius: $theme-corner-radius-search;
 

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -13,7 +13,7 @@
   background: #313233;
   padding-left: 5px;
   padding-right: 5px;
-  height: 32px;
+  height: $search-bar-height;
   border-radius: $theme-corner-radius-search;
   min-width: 350px;
   box-sizing: border-box;

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -21,11 +21,12 @@ $header-height: 44px;
 .header {
   width: 100%;
   box-sizing: border-box;
-  padding-left: env(safe-area-inset-left, 2px);
-  padding-right: env(safe-area-inset-right);
-  padding-top: env(safe-area-inset-top);
-  height: $header-height;
-  height: calc(#{$header-height} + env(safe-area-inset-top));
+  padding-left: env(titlebar-area-x, env(safe-area-inset-left, 2px));
+  padding-right: calc(
+    100% - env(titlebar-area-width, 100%) - env(titlebar-area-x, 0) + env(safe-area-inset-right)
+  );
+  padding-top: env(titlebar-area-y, env(safe-area-inset-top));
+  height: calc(env(titlebar-area-height, #{$header-height}) + env(safe-area-inset-top));
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -33,6 +34,7 @@ $header-height: 44px;
   background-position: center top;
   background-repeat: no-repeat;
   background-size: 100vw 100vh;
+  -webkit-app-region: drag;
 
   @include phone-portrait {
     background: #000;
@@ -40,6 +42,7 @@ $header-height: 44px;
 
   button,
   a {
+    -webkit-app-region: no-drag;
     > :global(.app-icon) {
       font-size: 1.33em;
 
@@ -89,6 +92,7 @@ $header-height: 44px;
 }
 
 .headerRight {
+  -webkit-app-region: no-drag;
   cursor: default;
   display: flex;
   flex: 1;

--- a/src/manifest-webapp.json
+++ b/src/manifest-webapp.json
@@ -35,9 +35,10 @@
       "url": "/settings"
     }
   ],
-  "theme_color": "#000000",
-  "background_color": "#000000",
+  "theme_color": "#202034",
+  "background_color": "#202034",
   "display": "standalone",
+  "display_override": ["window-controls-overlay"],
   "categories": ["games", "entertainment", "productivity", "utilities"],
   "start_url": "/index.html?utm_source=homescreen",
   "launch_handler": {


### PR DESCRIPTION
When installed as a PWA, this allows DIM's header to occupy the header of the installed app, instead of leaving a black bar. The user can choose either mode via a Chrome/Edge button.

Before:
<img width="1517" alt="Screenshot 2023-05-31 at 12 03 41 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/213f428d-63da-4604-8460-f5d24dfaa90f">

After:
<img width="1513" alt="Screenshot 2023-05-31 at 12 03 34 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/b3f57c59-9709-43ec-9cb3-b1421320eeb7">

I chose to slim down the search field a bit since it looked odd when included in the header. We could make that dynamic, dependent on whether the title bar is collapsed, but for now I chose to change it everywhere - the extra 4px doesn't make a big difference.

Also, I changed the theme colors in the manifest to better match the background, which should cause the system chrome to "merge" better, but I couldn't get the color to change when testing locally. This will be an issue when we allow themes...