### PR TITLE
Extract useScrollPaginate hook and apply it to loadouts

### DIFF
--- a/src/app/dim-ui/useScrollPaginate.tsx
+++ b/src/app/dim-ui/useScrollPaginate.tsx
@@ -1,0 +1,36 @@
+import { motion } from 'framer-motion';
+import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * A hook that can detect when the container has been scrolled to the
+ * end of the visible items and will increase the number of items to show.
+ *
+ * It is recommended that your individual items be memoized so they don't
+ * re-render every time you page.
+ *
+ * @example
+ * const [numItemsToShow, _resetPage, marker] = useScrollPaginate(10);
+ * return <div>
+ *   {_.take(allItems, numItemsToShow) => <Item/>}
+ *   {marker}
+ * </div>
+ */
+export default function useScrollPaginate(pageSize: number) {
+  const [numItemsToShow, setItemsToShow] = useState(pageSize);
+
+  const resetPage = useCallback(() => setItemsToShow(pageSize), [pageSize]);
+
+  const handlePaginate = useCallback(
+    () => setItemsToShow((itemsToShow) => itemsToShow + pageSize),
+    [pageSize]
+  );
+
+  const marker = useMemo(
+    () => (
+      <motion.div key="marker" onViewportEnter={handlePaginate} viewport={{ margin: '20px' }} />
+    ),
+    [handlePaginate]
+  );
+
+  return [numItemsToShow, resetPage, marker] as const;
+}

--- a/src/app/item-feed/ItemFeedSidebar.tsx
+++ b/src/app/item-feed/ItemFeedSidebar.tsx
@@ -1,10 +1,10 @@
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
+import { default as useScrollPaginate } from 'app/dim-ui/useScrollPaginate';
 import { t } from 'app/i18next-t';
 import { useSetting } from 'app/settings/hooks';
 import { AppIcon, collapseIcon, faCaretUp } from 'app/shell/icons';
 import clsx from 'clsx';
-import { motion } from 'framer-motion';
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import styles from './ItemFeedSidebar.m.scss';
 
 const ItemFeed = React.lazy(() => import(/* webpackChunkName: "item-feed" */ './ItemFeed'));
@@ -14,17 +14,14 @@ const ItemFeed = React.lazy(() => import(/* webpackChunkName: "item-feed" */ './
  */
 export default function ItemFeedSidebar() {
   const [expanded, setExpanded] = useSetting('itemFeedExpanded');
-  const [itemsToShow, setItemsToShow] = useState(10);
+
+  const [numItemsToShow, resetPage, marker] = useScrollPaginate(10);
 
   const handleToggle = () => {
     setExpanded(!expanded);
     if (!expanded) {
-      setItemsToShow(10);
+      resetPage();
     }
-  };
-
-  const handlePaginate = () => {
-    setItemsToShow((itemsToShow) => itemsToShow + 10);
   };
 
   useEffect(() => {
@@ -39,9 +36,9 @@ export default function ItemFeedSidebar() {
       {expanded && (
         <div className={styles.sideTray}>
           <Suspense fallback={<ShowPageLoading message={t('Loading.Code')} />}>
-            <ItemFeed itemsToShow={itemsToShow} resetItemCount={() => setItemsToShow(10)} />
+            <ItemFeed itemsToShow={numItemsToShow} resetItemCount={resetPage} />
           </Suspense>
-          <motion.div onViewportEnter={handlePaginate} />
+          {marker}
         </div>
       )}
     </div>

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -120,7 +120,8 @@ function Loadouts({ account }: { account: DestinyAccount }) {
     editLoadout(loadout, selectedStore.id, { isNew: true });
   };
 
-  const [numItemsToShow, _resetPage, marker] = useScrollPaginate(isPhonePortrait ? 2 : 10);
+  const [numItemsToShow, _resetPage, marker] = useScrollPaginate(2);
+  const paginatedLoadouts = isPhonePortrait ? _.take(loadouts, numItemsToShow) : loadouts;
 
   return (
     <PageWithMenu>
@@ -177,7 +178,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
         />
         <h2>{t('Loadouts.DimLoadouts')}</h2>
         {filterPills}
-        {_.take(loadouts, numItemsToShow).map((loadout) => (
+        {paginatedLoadouts.map((loadout) => (
           <LoadoutRow
             key={loadout.id}
             loadout={loadout}
@@ -189,7 +190,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
           />
         ))}
         {loadouts.length === 0 && <p>{t('Loadouts.NoneMatch', { query })}</p>}
-        {marker}
+        {isPhonePortrait && marker}
       </PageWithMenu.Contents>
       {sharedLoadout && (
         <Portal>

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -6,6 +6,7 @@ import CharacterSelect from 'app/dim-ui/CharacterSelect';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
+import useScrollPaginate from 'app/dim-ui/useScrollPaginate';
 import { t, tl } from 'app/i18next-t';
 import { artifactUnlocksSelector, sortedStoresSelector } from 'app/inventory/selectors';
 import { useLoadStores } from 'app/inventory/store/hooks';
@@ -17,6 +18,7 @@ import { useSetting } from 'app/settings/hooks';
 import { AppIcon, addIcon, faCalculator, uploadIcon } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { Portal } from 'app/utils/temp-container';
+import _ from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
@@ -118,6 +120,8 @@ function Loadouts({ account }: { account: DestinyAccount }) {
     editLoadout(loadout, selectedStore.id, { isNew: true });
   };
 
+  const [numItemsToShow, _resetPage, marker] = useScrollPaginate(isPhonePortrait ? 2 : 10);
+
   return (
     <PageWithMenu>
       <PageWithMenu.Menu className={styles.menu}>
@@ -173,7 +177,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
         />
         <h2>{t('Loadouts.DimLoadouts')}</h2>
         {filterPills}
-        {loadouts.map((loadout) => (
+        {_.take(loadouts, numItemsToShow).map((loadout) => (
           <LoadoutRow
             key={loadout.id}
             loadout={loadout}
@@ -185,6 +189,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
           />
         ))}
         {loadouts.length === 0 && <p>{t('Loadouts.NoneMatch', { query })}</p>}
+        {marker}
       </PageWithMenu.Contents>
       {sharedLoadout && (
         <Portal>

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -19,7 +19,7 @@ import { AppIcon, addIcon, faCalculator, uploadIcon } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { Portal } from 'app/utils/temp-container';
 import _ from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
 import styles from './Loadouts.m.scss';
@@ -120,8 +120,22 @@ function Loadouts({ account }: { account: DestinyAccount }) {
     editLoadout(loadout, selectedStore.id, { isNew: true });
   };
 
-  const [numItemsToShow, _resetPage, marker] = useScrollPaginate(2);
+  const [numItemsToShow, resetPage, marker] = useScrollPaginate(2);
   const paginatedLoadouts = isPhonePortrait ? _.take(loadouts, numItemsToShow) : loadouts;
+
+  const handleCharacterChanged = (selectedStoreId: string) => {
+    setSelectedStoreId(selectedStoreId);
+    if (selectedStoreId !== selectedStore.id) {
+      resetPage();
+    }
+  };
+
+  // Reset the paginator whenever we filter the loadouts list
+  useEffect(() => {
+    if (loadouts.length < numItemsToShow) {
+      resetPage();
+    }
+  }, [loadouts.length, numItemsToShow, resetPage]);
 
   return (
     <PageWithMenu>
@@ -129,7 +143,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
         <CharacterSelect
           stores={stores}
           selectedStore={selectedStore}
-          onCharacterChanged={setSelectedStoreId}
+          onCharacterChanged={handleCharacterChanged}
         />
         <div className={styles.menuButtons}>
           <select


### PR DESCRIPTION
iOS is really struggling to load the Loadouts page, even with a small number of loadouts. Before I go down the route I had to for making the inventory page work (https://github.com/DestinyItemManager/DIM/pull/8509), I figured I'd just lazy-paginate in loadouts as you scroll.

This could fix #9460 and #9232 and help in general with people who have too damn many loadouts: #9231

One thing I haven't figured out is how to make the sidebar shortcuts work - if the item isn't loaded yet, our approach of scrolling to an ID won't work. For now, I'm limiting this to phone mode.