### PR TITLE
Don't update DIM in the bg if a sheet is up

### DIFF
--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -116,6 +116,12 @@ function useDisableParent(
 }
 
 /**
+ * The total number of sheets that are open. Used by the sneaky updates code to
+ * determine if the user is in the middle of something.
+ */
+export let sheetsOpen = 0;
+
+/**
  * A Sheet is a UI element that comes up from the bottom of the screen,
  * and can be dragged downward to dismiss
  */
@@ -223,6 +229,14 @@ export default function Sheet({
   useEffect(() => {
     animationControls.start('open');
   }, [animationControls]);
+
+  // Track the total number of sheets that are open (to help prevent reloads while users are doing things)
+  useEffect(() => {
+    sheetsOpen++;
+    return () => {
+      sheetsOpen--;
+    };
+  }, []);
 
   return (
     <SheetDisabledContext.Provider value={setParentDisabled}>


### PR DESCRIPTION
This prevents DIM from auto-updating itself in the background if the user has any sheet up (compare, armory, infuse, loadout, etc) or is on the Loadout Optimizer page.

Fixes #9451.