### PR TITLE
Auto hide the artifact unlocks section when we don't know artifact state

### DIFF
--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -648,9 +648,13 @@ export function syncArtifactUnlocksFromEquipped(
 ): LoadoutUpdateFunction {
   const artifactUnlocks = profileResponse && getArtifactUnlocks(profileResponse, store.id);
 
-  return setLoadoutParameters({
-    artifactUnlocks,
-  });
+  if (artifactUnlocks?.unlockedItemHashes.length) {
+    return setLoadoutParameters({
+      artifactUnlocks,
+    });
+  } else {
+    return (loadout) => loadout;
+  }
 }
 
 /**

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -201,7 +201,7 @@ export function newLoadoutFromEquipped(
       mods,
     };
   }
-  if (artifactUnlocks) {
+  if (artifactUnlocks?.unlockedItemHashes.length) {
     loadout.parameters = {
       ...loadout.parameters,
       artifactUnlocks,

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -152,9 +152,6 @@ export default function LoadoutView({
                 storeId={store.id}
                 hideShowModPlacements={hideShowModPlacements}
                 missingSockets={missingSockets}
-                hasArtifactUnlocks={Boolean(
-                  loadout.parameters?.artifactUnlocks?.unlockedItemHashes.length
-                )}
               />
               <LoadoutArtifactUnlocks
                 loadout={loadout}

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -72,6 +72,14 @@ export default function LoadoutEdit({
   const missingSockets = allItems.some((i) => i.missingSockets);
   const [plugDrawerOpen, setPlugDrawerOpen] = useState(false);
   const itemCreationContext = useSelector(createItemContextSelector);
+  const unlockedArtifactMods = useSelector(artifactUnlocksSelector(store.id));
+
+  // Don't show the artifact unlocks section unless there are artifact mods saved in this loadout
+  // or there are unlocked artifact mods we could copy into this loadout.
+  const showArtifactUnlocks = Boolean(
+    unlockedArtifactMods?.unlockedItemHashes.length ||
+      loadout.parameters?.artifactUnlocks?.unlockedItemHashes.length
+  );
 
   // TODO: filter down by usable mods?
   const modsByBucket: {
@@ -247,20 +255,22 @@ export default function LoadoutEdit({
           onClearUnsetModsChanged={handleClearUnsetModsChanged}
         />
       </LoadoutEditSection>
-      <LoadoutEditSection
-        title={artifactTitle}
-        titleInfo={t('Loadouts.ArtifactUnlocksDesc')}
-        className={styles.section}
-        onClear={handleClearArtifactUnlocks}
-        onSyncFromEquipped={profileResponse ? handleSyncArtifactUnlocksFromEquipped : undefined}
-      >
-        <LoadoutArtifactUnlocks
-          loadout={loadout}
-          storeId={store.id}
-          onRemoveMod={handleRemoveArtifactUnlock}
+      {showArtifactUnlocks && (
+        <LoadoutEditSection
+          title={artifactTitle}
+          titleInfo={t('Loadouts.ArtifactUnlocksDesc')}
+          className={styles.section}
+          onClear={handleClearArtifactUnlocks}
           onSyncFromEquipped={profileResponse ? handleSyncArtifactUnlocksFromEquipped : undefined}
-        />
-      </LoadoutEditSection>
+        >
+          <LoadoutArtifactUnlocks
+            loadout={loadout}
+            storeId={store.id}
+            onRemoveMod={handleRemoveArtifactUnlock}
+            onSyncFromEquipped={profileResponse ? handleSyncArtifactUnlocksFromEquipped : undefined}
+          />
+        </LoadoutEditSection>
+      )}
     </div>
   );
 }

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -52,7 +52,6 @@ export const LoadoutMods = memo(function LoadoutMods({
   storeId,
   clearUnsetMods,
   missingSockets,
-  hasArtifactUnlocks,
   hideShowModPlacements,
   onUpdateMods,
   onRemoveMod,
@@ -64,7 +63,6 @@ export const LoadoutMods = memo(function LoadoutMods({
   hideShowModPlacements?: boolean;
   clearUnsetMods?: boolean;
   missingSockets?: boolean;
-  hasArtifactUnlocks?: boolean;
   /** If present, show an "Add Mod" button */
   onUpdateMods?: (newMods: number[]) => void;
   onRemoveMod?: (mod: ResolvedLoadoutMod) => void;
@@ -87,7 +85,7 @@ export const LoadoutMods = memo(function LoadoutMods({
   // TODO: let these be dragged and dropped into the loadout editor
 
   if (allMods.length === 0 && !onUpdateMods) {
-    return !isPhonePortrait && !hasArtifactUnlocks ? (
+    return !isPhonePortrait ? (
       <div className={styles.modsPlaceholder}>
         {missingSockets ? (
           <div className="item-details warning">{t('MovePopup.MissingSockets')}</div>
@@ -216,6 +214,10 @@ export const LoadoutArtifactUnlocks = memo(function LoadoutArtifactUnlocks({
         seasonNumber: loadout.parameters?.artifactUnlocks?.seasonNumber,
       })
     : t('Loadouts.ArtifactUnlocks');
+
+  if (!loadout.parameters?.artifactUnlocks?.unlockedItemHashes.length) {
+    return null;
+  }
 
   return (
     <div className={className}>


### PR DESCRIPTION
This hides the artifact unlocks stuff whenever it won't work (like it currently does due to an API bug). The sections should reappear automatically when and if the API is fixed.