### PR TITLE
Enable auto stat mods

### DIFF
--- a/config/feature-flags.ts
+++ b/config/feature-flags.ts
@@ -31,7 +31,7 @@ export function makeFeatureFlags(env: { release: boolean; beta: boolean; dev: bo
     // Warn when DIM Sync is off and you save some DIM-specific data
     warnNoSync: true,
     // Expose the "Automatically add stat mods" Loadout Optimizer toggle
-    loAutoStatMods: !env.release,
+    loAutoStatMods: true,
     // Pretend that Bungie.net is down for maintenance
     simulateBungieMaintenance: false,
     // Pretend that Bungie.net is not returning sockets info

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -564,6 +564,7 @@
     "ShareBuildWithNotes": "Share With Notes",
     "AddHalfTierMods": "Add +5 Mods",
     "AutomaticallyPicked": "This mod was added automatically to improve build stats.",
+    "DisabledByAutoStatMods": "Stat mods are being chosen automatically by Loadout Optimizer.",
     "AutoStatMods": "Automatically add stat mods",
     "All": "All",
     "AnyExotic": "Any Exotic",

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -30,19 +30,6 @@ import Objective from '../progress/Objective';
 import './ItemSockets.scss';
 import styles from './PlugTooltip.m.scss';
 
-interface PlugTooltipProps {
-  def: PluggableInventoryItemDefinition;
-  stats?: { statHash: number; value: number }[];
-  plugObjectives?: DestinyObjectiveProgress[];
-  enableFailReasons?: string;
-  cannotCurrentlyRoll?: boolean;
-  unreliablePerkOption?: boolean;
-  wishListTip?: React.ReactNode;
-  automaticallyPicked?: boolean;
-  hideRequirements?: boolean;
-  craftingData?: DestinyPlugItemCraftingRequirements;
-}
-
 export function DimPlugTooltip({
   item,
   plug,
@@ -90,13 +77,22 @@ export function PlugDefTooltip({
   def,
   classType,
   automaticallyPicked,
+  disabledByAutoStatMods,
 }: {
   def: PluggableInventoryItemDefinition;
   classType?: DestinyClass;
   automaticallyPicked?: boolean;
+  disabledByAutoStatMods?: boolean;
 }) {
   const stats = getPlugDefStats(def, classType);
-  return <PlugTooltip def={def} stats={stats} automaticallyPicked={automaticallyPicked} />;
+  return (
+    <PlugTooltip
+      def={def}
+      stats={stats}
+      automaticallyPicked={automaticallyPicked}
+      disabledByAutoStatMods={disabledByAutoStatMods}
+    />
+  );
 }
 
 /**
@@ -114,9 +110,22 @@ function PlugTooltip({
   unreliablePerkOption,
   wishListTip,
   automaticallyPicked,
+  disabledByAutoStatMods,
   hideRequirements,
   craftingData,
-}: PlugTooltipProps) {
+}: {
+  def: PluggableInventoryItemDefinition;
+  stats?: { statHash: number; value: number }[];
+  plugObjectives?: DestinyObjectiveProgress[];
+  enableFailReasons?: string;
+  cannotCurrentlyRoll?: boolean;
+  unreliablePerkOption?: boolean;
+  wishListTip?: React.ReactNode;
+  automaticallyPicked?: boolean;
+  disabledByAutoStatMods?: boolean;
+  hideRequirements?: boolean;
+  craftingData?: DestinyPlugItemCraftingRequirements;
+}) {
   const defs = useD2Definitions();
   const statsArray = stats || [];
   const plugDescriptions = usePlugDescriptions(def, statsArray);
@@ -261,6 +270,11 @@ function PlugTooltip({
       {automaticallyPicked && (
         <Tooltip.Section className={styles.automaticallyPickedSection}>
           <p>{t('LoadoutBuilder.AutomaticallyPicked')}</p>
+        </Tooltip.Section>
+      )}
+      {disabledByAutoStatMods && (
+        <Tooltip.Section className={styles.automaticallyPickedSection}>
+          <p>{t('LoadoutBuilder.DisabledByAutoStatMods')}</p>
         </Tooltip.Section>
       )}
       {Boolean(wishListTip) && (

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -168,7 +168,13 @@ export default memo(function LoadoutBuilder({
       })),
       statOrder
     );
-    const newSavedLoadoutParams = _.pick(newLoadoutParameters, 'assumeArmorMasterwork');
+
+    // Only these properties will be saved between sessions
+    const newSavedLoadoutParams = _.pick(
+      newLoadoutParameters,
+      'assumeArmorMasterwork',
+      'autoStatMods'
+    );
 
     setSetting('loParameters', newSavedLoadoutParams);
     setSetting('loStatConstraintsByClass', {

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -137,7 +137,21 @@ export default memo(function LoadoutBuilder({
     () => resolveLoadoutModHashes(defs, loadoutParameters.mods ?? [], unlockedPlugs),
     [defs, loadoutParameters.mods, unlockedPlugs]
   );
-  const modsToAssign = useMemo(() => resolvedMods.map((mod) => mod.resolvedMod), [resolvedMods]);
+
+  const modsToAssign = useMemo(
+    // If auto stat mods are enabled, ignore any saved stat mods
+    () =>
+      resolvedMods
+        .filter(
+          (mod) =>
+            !(
+              autoStatMods &&
+              mod.resolvedMod.plug.plugCategoryHash === PlugCategoryHashes.EnhancementsV2General
+            )
+        )
+        .map((mod) => mod.resolvedMod),
+    [resolvedMods, autoStatMods]
+  );
 
   const characterItems = items[classType];
 
@@ -523,7 +537,11 @@ export default memo(function LoadoutBuilder({
               owner={selectedStore.id}
               lockedMods={resolvedMods}
               plugCategoryHashWhitelist={modPicker.plugCategoryHashWhitelist}
-              plugCategoryHashDenyList={autoAssignmentPCHs}
+              plugCategoryHashDenyList={
+                autoStatMods
+                  ? [...autoAssignmentPCHs, PlugCategoryHashes.EnhancementsV2General]
+                  : autoAssignmentPCHs
+              }
               onAccept={(newLockedMods) =>
                 lbDispatch({
                   type: 'lockedModsChanged',
@@ -545,6 +563,7 @@ export default memo(function LoadoutBuilder({
               classType={classType}
               params={params}
               notes={notes}
+              lockedMods={modsToAssign}
               onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}
             />
           </Portal>

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -20,6 +20,7 @@ import {
   subclassAbilitySocketCategoryHashes,
 } from 'app/utils/socket-utils';
 import { Portal } from 'app/utils/temp-container';
+import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React, { Dispatch, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import LoadoutBucketDropTarget from '../LoadoutBucketDropTarget';
@@ -210,6 +211,10 @@ export default memo(function LockArmorAndPerks({
                 plug={mod.resolvedMod}
                 onClose={() => onModClicked(mod)}
                 forClassType={selectedStore.classType}
+                disabledByAutoStatMods={
+                  autoStatMods &&
+                  mod.resolvedMod.plug.plugCategoryHash === PlugCategoryHashes.EnhancementsV2General
+                }
               />
             ))}
           </div>

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -279,6 +279,7 @@ function GeneratedSet({
         lbDispatch={lbDispatch}
         notes={notes}
         params={params}
+        lockedMods={lockedMods}
       />
     </div>
   );

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -28,6 +28,7 @@ export default function GeneratedSetButtons({
   halfTierMods,
   onLoadoutSet,
   lbDispatch,
+  lockedMods,
 }: {
   store: DimStore;
   set: ArmorSet;
@@ -39,17 +40,18 @@ export default function GeneratedSetButtons({
   halfTierMods: PluggableInventoryItemDefinition[];
   onLoadoutSet: (loadout: Loadout) => void;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
+  lockedMods: PluggableInventoryItemDefinition[];
 }) {
   const dispatch = useThunkDispatch();
 
   // Opens the loadout menu for the generated set
   const openLoadout = () => {
-    onLoadoutSet(createLoadout(store.classType, set, items, subclass, params, notes));
+    onLoadoutSet(createLoadout(store.classType, set, items, subclass, params, notes, lockedMods));
   };
 
   // Automatically equip items for this generated set to the active store
   const equipItems = () => {
-    const loadout = createLoadout(store.classType, set, items, subclass, params, notes);
+    const loadout = createLoadout(store.classType, set, items, subclass, params, notes, lockedMods);
     return dispatch(applyLoadout(store, loadout, { allowUndo: true }));
   };
 
@@ -105,7 +107,8 @@ function createLoadout(
   items: DimItem[],
   subclass: ResolvedLoadoutItem | undefined,
   params: LoadoutParameters,
-  notes?: string
+  notes: string | undefined,
+  lockedMods: PluggableInventoryItemDefinition[]
 ): Loadout {
   const data = {
     tier: _.sumBy(Object.values(set.stats), statTier),
@@ -118,9 +121,7 @@ function createLoadout(
 
   const loadout = newLoadout(t('Loadouts.Generated', data), loadoutItems, classType);
   loadout.notes = notes;
-  // FIXME(#8733) add auto mods to autoStatMods instead of adding them to regular mods
-  const allMods = [...(params.mods ?? []), ...set.statMods];
+  const allMods = [...lockedMods.map((m) => m.hash), ...set.statMods];
   loadout.parameters = { ...params, mods: allMods.length ? allMods : undefined };
-  // loadout.autoStatMods = set.statMods.length ? set.statMods : undefined;
   return loadout;
 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -172,8 +172,6 @@ const lbConfigInit = ({
   const statOrder = statOrderFromLoadoutParameters(loadoutParameters);
   const statFilters = statFiltersFromLoadoutParamaters(loadoutParameters);
 
-  // FIXME: Always require turning on auto mods explicitly for now...
-  loadoutParameters = { ...loadoutParameters, autoStatMods: undefined };
   // Also delete artifice mods -- artifice mods are always picked automatically per set.
   if (loadoutParameters.mods) {
     loadoutParameters.mods = loadoutParameters.mods.filter((modHash) => {

--- a/src/app/loadout/loadout-ui/PlugDef.tsx
+++ b/src/app/loadout/loadout-ui/PlugDef.tsx
@@ -6,15 +6,6 @@ import { PlugDefTooltip } from 'app/item-popup/PlugTooltip';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 
-interface Props {
-  plug: PluggableInventoryItemDefinition;
-  className?: string;
-  onClick?: () => void;
-  onClose?: () => void;
-  automaticallyPicked?: boolean;
-  forClassType: DestinyClass | undefined;
-}
-
 /**
  * Displays a plug (mod, perk) based on just its definition, with optional close button.
  */
@@ -24,8 +15,17 @@ export default function PlugDef({
   onClick,
   onClose,
   automaticallyPicked,
+  disabledByAutoStatMods,
   forClassType,
-}: Props) {
+}: {
+  plug: PluggableInventoryItemDefinition;
+  className?: string;
+  onClick?: () => void;
+  onClose?: () => void;
+  automaticallyPicked?: boolean;
+  disabledByAutoStatMods?: boolean;
+  forClassType: DestinyClass | undefined;
+}) {
   const contents = (
     <div
       role={onClick ? 'button' : undefined}
@@ -39,11 +39,12 @@ export default function PlugDef({
           <PlugDefTooltip
             def={plug}
             automaticallyPicked={automaticallyPicked}
+            disabledByAutoStatMods={disabledByAutoStatMods}
             classType={forClassType}
           />
         )}
       >
-        <DefItemIcon itemDef={plug} />
+        <DefItemIcon className={disabledByAutoStatMods ? 'disabled' : undefined} itemDef={plug} />
       </PressTip>
     </div>
   );

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -571,6 +571,7 @@
     "ConfirmOverwrite": "Are you sure you want to replace the armor in the loadout \"{{name}}\" with this new set of armor?",
     "CopiedBuild": "Copied build settings URL to clipboard",
     "CreateLoadout": "Save Loadout",
+    "DisabledByAutoStatMods": "Stat mods are being chosen automatically by Loadout Optimizer.",
     "DisabledDueToMaintenance": "The Loadout Optimizer is currently disabled due to Bungie API maintenance.",
     "EquipItems": "Equip",
     "ExcludeItem": "Exclude Item",


### PR DESCRIPTION
Enables auto stat mods on prod, and fixes things so the setting gets remembered between LO sessions. I think this is in a great place right now and should be available to all DIM users.