### PR TITLE
Consistently select ability but not aspect/fragment configuration when adding subclass to loadout

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -8,7 +8,6 @@ import { useAutocomplete } from 'app/dim-ui/text-complete/text-complete';
 import { t } from 'app/i18next-t';
 import { InventoryBucket } from 'app/inventory/inventory-buckets';
 import { DimStore } from 'app/inventory/store-types';
-import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { getStore } from 'app/inventory/stores-helpers';
 import { showItemPicker } from 'app/item-picker/item-picker';
 import { pickSubclass } from 'app/loadout/item-utils';
@@ -45,7 +44,7 @@ import {
 } from './loadout-drawer-reducer';
 import { addItem$ } from './loadout-events';
 import { Loadout, ResolvedLoadoutItem } from './loadout-types';
-import { createSubclassDefaultSocketOverrides, findSameLoadoutItemIndex } from './loadout-utils';
+import { findSameLoadoutItemIndex } from './loadout-utils';
 import styles from './LoadoutDrawer.m.scss';
 import LoadoutDrawerDropTarget from './LoadoutDrawerDropTarget';
 import LoadoutDrawerFooter from './LoadoutDrawerFooter';
@@ -100,14 +99,12 @@ export default function LoadoutDrawer({
   const store = getStore(stores, storeId)!;
 
   const onAddItem = useCallback(
-    (item: DimItem, equip?: boolean, socketOverrides?: SocketOverrides) =>
-      setLoadout(addItem(defs, item, equip, socketOverrides)),
+    (item: DimItem, equip?: boolean) => setLoadout(addItem(defs, item, equip)),
     [defs, setLoadout]
   );
 
   const onDropItem = useCallback(
-    (item: DimItem, equip?: boolean, socketOverrides?: SocketOverrides) =>
-      setLoadout(dropItem(defs, item, equip, socketOverrides)),
+    (item: DimItem, equip?: boolean) => setLoadout(dropItem(defs, item, equip)),
     [defs, setLoadout]
   );
 
@@ -400,7 +397,7 @@ async function pickLoadoutItem(
 async function pickLoadoutSubclass(
   loadout: Loadout,
   storeId: string,
-  add: (item: DimItem, equip?: boolean, socketOverrides?: SocketOverrides) => void,
+  add: (item: DimItem, equip?: boolean) => void,
   onShowItemPicker: (shown: boolean) => void
 ) {
   const loadoutClassType = loadout.classType;
@@ -416,7 +413,7 @@ async function pickLoadoutSubclass(
   onShowItemPicker(true);
   const item = await pickSubclass(subclassItemFilter);
   if (item) {
-    add(item, undefined, createSubclassDefaultSocketOverrides(item));
+    add(item, undefined);
   }
   onShowItemPicker(false);
 }

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -22,6 +22,7 @@ import { Loadout, LoadoutItem, ResolvedLoadoutItem, ResolvedLoadoutMod } from '.
 import {
   convertToLoadoutItem,
   createSocketOverridesFromEquipped,
+  createSubclassDefaultSocketOverrides,
   extractArmorModHashes,
   findSameLoadoutItemIndex,
   fromEquippedTypes,
@@ -58,12 +59,11 @@ export type LoadoutUpdateFunction = (loadout: Loadout) => Loadout;
 export function addItem(
   defs: D2ManifestDefinitions | D1ManifestDefinitions,
   item: DimItem,
-  equip?: boolean,
-  socketOverrides?: SocketOverrides
+  equip?: boolean
 ): LoadoutUpdateFunction {
   const loadoutItem = convertToLoadoutItem(item, false, 1);
-  if (socketOverrides) {
-    loadoutItem.socketOverrides = socketOverrides;
+  if (item.sockets && item.bucket.hash === BucketHashes.Subclass) {
+    loadoutItem.socketOverrides = createSubclassDefaultSocketOverrides(item);
   }
 
   // We only allow one subclass, and it must be equipped. Same with a couple other things.
@@ -153,8 +153,7 @@ export function addItem(
 export function dropItem(
   defs: D2ManifestDefinitions | D1ManifestDefinitions,
   item: DimItem,
-  equip?: boolean,
-  socketOverrides?: SocketOverrides
+  equip?: boolean
 ): LoadoutUpdateFunction {
   return produce((draftLoadout) => {
     if (item.bucket.hash === BucketHashes.Subclass) {
@@ -170,7 +169,7 @@ export function dropItem(
     if (loadoutItemIndex !== -1) {
       setEquipForItemInLoadout(defs, item, draftLoadout, Boolean(equip));
     } else {
-      draftLoadout = addItem(defs, item, equip, socketOverrides)(draftLoadout);
+      draftLoadout = addItem(defs, item, equip)(draftLoadout);
     }
     return draftLoadout;
   });


### PR DESCRIPTION
Maybe doesn't entirely address #9519 but makes behavior more consistent.