### PR TITLE
Only highlight meaningfully comparable items with `is:dupe`

### DIFF
--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -61,6 +61,9 @@ const computeDupesByIdFn = (allItems: DimItem[], makeDupeIdFn: (item: DimItem) =
   const duplicates: { [dupeID: string]: DimItem[] } = {};
 
   for (const i of allItems) {
+    if (!i.comparable) {
+      continue;
+    }
     const dupeID = makeDupeIdFn(i);
     if (!duplicates[dupeID]) {
       duplicates[dupeID] = [];


### PR DESCRIPTION
Fixes #9471 -- this also gets rid of `dupe` highlighting engrams or material stacks.