### PR TITLE
Format times in clarity stats as mm:ss

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1123,7 +1123,6 @@
     "TierProgress": "T{{tier}} {{statName}} ({{progress}}/60 for T{{nextTier}})\n",
     "TierProgress_Max": "T{{tier}} {{statName}} ({{progress}}/300)\n",
     "Total": "Total",
-    "Second": "s",
     "MetersPerSecond": "m/s",
     "Percentage": "%",
     "HP": "HP",

--- a/src/app/store-stats/ClarityCharacterStat.m.scss
+++ b/src/app/store-stats/ClarityCharacterStat.m.scss
@@ -21,11 +21,6 @@
   th,
   td {
     opacity: 0.5;
-    &:nth-child(2n) {
-      text-align: right;
-      padding-left: 6px;
-      font-variant-numeric: tabular-nums;
-    }
   }
 
   /* stylelint-disable-next-line no-descending-specificity */
@@ -62,4 +57,10 @@
 .override {
   display: block;
   font-size: 11px;
+}
+
+.value {
+  text-align: right;
+  padding-left: 6px;
+  font-variant-numeric: tabular-nums;
 }

--- a/src/app/store-stats/ClarityCharacterStat.m.scss.d.ts
+++ b/src/app/store-stats/ClarityCharacterStat.m.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'currentColumn': string;
   'override': string;
   'unit': string;
+  'value': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/store-stats/ClarityCharacterStat.tsx
+++ b/src/app/store-stats/ClarityCharacterStat.tsx
@@ -3,7 +3,7 @@ import { clarityCharacterStatsSelector } from 'app/clarity/selectors';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { Tooltip } from 'app/dim-ui/PressTip';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { timerDurationFromMs } from 'app/utils/time';
+import { timerDurationFromMsWithDecimal } from 'app/utils/time';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { StatHashes } from 'data/d2/generated-enums';
@@ -93,8 +93,7 @@ export default function ClarityCharacterStat({
         name={t('Stats.TimeToFullHP')}
         cooldowns={clarityStatData.TimeToFullHP}
         tier={tier}
-        unit={t('Stats.Second')}
-        seconds
+        unit="s"
       />
     );
   } else if ('WalkingSpeed' in clarityStatData) {
@@ -160,16 +159,19 @@ export default function ClarityCharacterStat({
             <th />
             {tier - 1 >= 0 && (
               <>
-                <th>{t('LoadoutBuilder.TierNumber', { tier: tier - 1 })}</th>
-                <th />
+                <th colSpan={2} className={styles.value}>
+                  {t('LoadoutBuilder.TierNumber', { tier: tier - 1 })}
+                </th>
               </>
             )}
-            <th className={styles.currentColumn}>{t('LoadoutBuilder.TierNumber', { tier })}</th>
-            <th />
+            <th colSpan={2} className={clsx(styles.value, styles.currentColumn)}>
+              {t('LoadoutBuilder.TierNumber', { tier })}
+            </th>
             {tier + 1 <= 10 && (
               <>
-                <th>{t('LoadoutBuilder.TierNumber', { tier: tier + 1 })}</th>
-                <th />
+                <th colSpan={2} className={styles.value}>
+                  {t('LoadoutBuilder.TierNumber', { tier: tier + 1 })}
+                </th>
               </>
             )}
           </tr>
@@ -185,8 +187,7 @@ export default function ClarityCharacterStat({
                 cooldowns={cooldowns}
                 tier={tier}
                 overrides={overrides}
-                unit={t('Stats.Second')}
-                seconds
+                unit="s"
               />
             ))}
           {intrinsicCooldowns}
@@ -202,25 +203,26 @@ function StatTableRow({
   cooldowns,
   tier,
   unit,
-  seconds,
   overrides = [],
 }: {
   name: string;
   icon?: string;
   unit: string;
-  seconds?: boolean;
   tier: number;
   cooldowns: number[];
   overrides?: DestinyInventoryItemDefinition[];
 }) {
   const unitEl = <td className={styles.unit}>{unit}</td>;
+  const seconds = unit === 's';
 
   const formatValue = (val: number) => {
     if (seconds) {
-      return timerDurationFromMs(val * 1000, 0);
+      return timerDurationFromMsWithDecimal(val * 1000);
     }
     return val.toLocaleString();
   };
+
+  const colspan = seconds ? 2 : 1;
 
   return (
     <tr>
@@ -241,16 +243,22 @@ function StatTableRow({
       </th>
       {tier - 1 >= 0 && (
         <>
-          <td>{formatValue(cooldowns[tier - 1])}</td>
-          {unitEl}
+          <td className={styles.value} colSpan={colspan}>
+            {formatValue(cooldowns[tier - 1])}
+          </td>
+          {!seconds && unitEl}
         </>
       )}
-      <td className={styles.currentColumn}>{formatValue(cooldowns[tier])}</td>
-      <td className={clsx(styles.unit, styles.currentColumn)}>{unit}</td>
+      <td className={clsx(styles.value, styles.currentColumn)} colSpan={colspan}>
+        {formatValue(cooldowns[tier])}
+      </td>
+      {!seconds && <td className={clsx(styles.unit, styles.currentColumn)}>{unit}</td>}
       {tier + 1 <= 10 && (
         <>
-          <td>{formatValue(cooldowns[tier + 1])}</td>
-          {unitEl}
+          <td className={styles.value} colSpan={colspan}>
+            {formatValue(cooldowns[tier + 1])}
+          </td>
+          {!seconds && unitEl}
         </>
       )}
     </tr>

--- a/src/app/store-stats/ClarityCharacterStat.tsx
+++ b/src/app/store-stats/ClarityCharacterStat.tsx
@@ -3,6 +3,7 @@ import { clarityCharacterStatsSelector } from 'app/clarity/selectors';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { Tooltip } from 'app/dim-ui/PressTip';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { timerDurationFromMs } from 'app/utils/time';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { StatHashes } from 'data/d2/generated-enums';
@@ -93,6 +94,7 @@ export default function ClarityCharacterStat({
         cooldowns={clarityStatData.TimeToFullHP}
         tier={tier}
         unit={t('Stats.Second')}
+        seconds
       />
     );
   } else if ('WalkingSpeed' in clarityStatData) {
@@ -184,6 +186,7 @@ export default function ClarityCharacterStat({
                 tier={tier}
                 overrides={overrides}
                 unit={t('Stats.Second')}
+                seconds
               />
             ))}
           {intrinsicCooldowns}
@@ -199,16 +202,25 @@ function StatTableRow({
   cooldowns,
   tier,
   unit,
+  seconds,
   overrides = [],
 }: {
   name: string;
   icon?: string;
   unit: string;
+  seconds?: boolean;
   tier: number;
   cooldowns: number[];
   overrides?: DestinyInventoryItemDefinition[];
 }) {
   const unitEl = <td className={styles.unit}>{unit}</td>;
+
+  const formatValue = (val: number) => {
+    if (seconds) {
+      return timerDurationFromMs(val * 1000, 0);
+    }
+    return val.toLocaleString();
+  };
 
   return (
     <tr>
@@ -229,15 +241,15 @@ function StatTableRow({
       </th>
       {tier - 1 >= 0 && (
         <>
-          <td>{cooldowns[tier - 1].toLocaleString()}</td>
+          <td>{formatValue(cooldowns[tier - 1])}</td>
           {unitEl}
         </>
       )}
-      <td className={styles.currentColumn}>{cooldowns[tier].toLocaleString()}</td>
+      <td className={styles.currentColumn}>{formatValue(cooldowns[tier])}</td>
       <td className={clsx(styles.unit, styles.currentColumn)}>{unit}</td>
       {tier + 1 <= 10 && (
         <>
-          <td>{cooldowns[tier + 1].toLocaleString()}</td>
+          <td>{formatValue(cooldowns[tier + 1])}</td>
           {unitEl}
         </>
       )}

--- a/src/app/utils/time.test.ts
+++ b/src/app/utils/time.test.ts
@@ -1,6 +1,11 @@
 import i18next from 'i18next';
 import { setupi18n } from 'testing/test-utils';
-import { i15dDurationFromMs, i15dDurationFromMsWithSeconds, timerDurationFromMs } from './time';
+import {
+  i15dDurationFromMs,
+  i15dDurationFromMsWithSeconds,
+  timerDurationFromMs,
+  timerDurationFromMsWithDecimal,
+} from './time';
 
 beforeAll(() => {
   setupi18n();
@@ -13,6 +18,15 @@ test.each([
   [20041234, '5:34:01'],
 ])('timerDurationFromMs(%s) === "%s"', (timestamp, expected) => {
   expect(timerDurationFromMs(timestamp)).toBe(expected);
+});
+
+test.each([
+  [1000, '0:01'],
+  [0, '0:00'],
+  [279241234, '3:05:34:01.234'],
+  [20041234, '5:34:01.234'],
+])('timerDurationFromMs(%s) === "%s"', (timestamp, expected) => {
+  expect(timerDurationFromMsWithDecimal(timestamp)).toBe(expected);
 });
 
 describe('english localization', () => {

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -32,6 +32,23 @@ export function timerDurationFromMs(milliseconds: number, minSegments = 3) {
 }
 
 /**
+ * print a number of milliseconds as m:s.ms
+ *
+ * negative durations are treated as 0
+ */
+export function timerDurationFromMsWithDecimal(milliseconds: number) {
+  const duration = durationFromMs(milliseconds);
+  while (duration[0] === 0 && duration.length > 3) {
+    duration.shift();
+  }
+
+  const ms = duration.pop()!;
+  duration[duration.length - 1] = (duration[duration.length - 1] * 1000 + ms) / 1000;
+
+  return duration.map((u, i) => (i !== 0 && u < 10 ? `0${u}` : u)).join(':');
+}
+
+/**
  * print a number of milliseconds as something like "4d 0:51",
  * containing days, minutes, and hours.
  * uses i18n to choose an appropriate substitute for that "d"

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -23,9 +23,9 @@ function durationFromMs(ms: number) {
  *
  * negative durations are treated as 0
  */
-export function timerDurationFromMs(milliseconds: number) {
+export function timerDurationFromMs(milliseconds: number, minSegments = 3) {
   const duration = durationFromMs(milliseconds).slice(0, -1);
-  while (duration[0] === 0 && duration.length > 3) {
+  while (duration[0] === 0 && duration.length > minSegments) {
     duration.shift();
   }
   return duration.map((u, i) => `${u}`.padStart(i === 0 ? 0 : 2, '0')).join(':');

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1118,7 +1118,6 @@
     "PowerModifier": "Power granted by seasonal experience progression",
     "Prestige": "Prestige Level: {{level}}\n{{exp}}xp until 5 motes of light.",
     "Quality": "Stats quality",
-    "Second": "s",
     "StrafingSpeed": "Strafing",
     "Strength": "Strength",
     "Sunset": "Sunset",


### PR DESCRIPTION
Fixes #9533. I struggled with what to show in the units column and decided that still showing "s" was appropriate.