### PR TITLE
Harmonic mods with no description fix

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -322,6 +322,15 @@
     "WishlistUnknown": "Shows items with no roll recommendations in the loaded wish lists.",
     "Year": "Shows items from which year of Destiny they appeared in."
   },
+  "Element": {
+    "Solar": "Solar",
+    "Arc": "Arc",
+    "Void": "Void",
+    "Stasis": "Stasis",
+    "Strand": "Strand",
+    "Harmonic": "Harmonic",
+    "SubclassMatching": "sublass matching elemental"
+  },
   "General": {
     "ClickForDetails": "Click for details",
     "Confirm": "Confirm?",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Next
+* Fixed harmonic mods not having descriptions
 
 * Added Community Insights for the impact of various stat tiers on ability cooldowns, etc. This takes into account your current subclass config and equipped exotic. For loadouts, it uses the subclass config and exotic that are saved in the loadout to display details. This information comes from the Clarity database, and like all Community Insights is sourced from lots of manual investigation.
 * Automatic stat mods in Loadout Optimizer have graduated from Beta! We now remember this setting, and we ignore any manually chosen stat mods when auto stat mods are on. Enabling auto stat mods allows Loadout Optimizer to automatically assign stat mods to potential loadouts in order to hit the stats you've requested, in the priority order that you've chosen.

--- a/src/app/utils/plug-descriptions.ts
+++ b/src/app/utils/plug-descriptions.ts
@@ -11,6 +11,7 @@ import { EXOTIC_CATALYST_TRAIT } from 'app/search/d2-known-values';
 import { DestinyClass, ItemPerkVisibility } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
+import { t } from 'i18next';
 import _ from 'lodash';
 import { useSelector } from 'react-redux';
 import { compareBy } from './comparators';
@@ -227,7 +228,6 @@ function getPerkDescriptions(
     } else {
       addDescriptionAsFunctionality();
     }
-    addTooltipNotifsAsRequirement();
   } else {
     if (plugDescription) {
       addDescriptionAsFunctionality();
@@ -263,9 +263,31 @@ function getPerkDescriptions(
       usedStrings.add(firstPerk.requirementDisplayString);
     }
 
+    // Check if we are dealing with a harmonic mod
+    if (
+      plug.displayProperties.name.includes(t('Element.Harmonic')) &&
+      perkDesc.description?.includes(t('Element.Arc'))
+    ) {
+      perkDesc.description = perkDesc.description.replace(
+        t('Element.Arc').toString(),
+        t('Element.SubclassMatching').toString()
+      );
+    }
+
     if (perkDesc.description || perkDesc.requirement) {
       results.push(perkDesc);
     }
+  }
+
+  /*
+    Some plugs (e.g. armor mods) store their functionality in their perk descriptions and use the description
+    field for auxiliary info like requirements and caveats. For these plugs, we want to prioritize strings in the
+    perks and only fall back to the actual description if we don't have any perks.
+
+    this is here to due some mods stacking and having hidden perks
+  */
+  if (plug.itemCategoryHashes?.includes(ItemCategoryHashes.ArmorMods)) {
+    addTooltipNotifsAsRequirement();
   }
 
   return results;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -129,6 +129,11 @@
     "Cancel": "Cancel",
     "OK": "OK"
   },
+  "Element": {
+    "Arc": "Arc",
+    "Harmonic": "Harmonic",
+    "SubclassMatching": "sublass matching elemental"
+  },
   "EnergyMeter": {
     "Energy": "Energy",
     "Unused": "Unused",


### PR DESCRIPTION
This PR is made to fix the issue where Harmonic mods currently don't have any description

OLD:
![image](https://github.com/DestinyItemManager/DIM/assets/98132549/2647c008-963d-4cb8-bde1-1bfbee1f6936)

NEW:
![image](https://github.com/DestinyItemManager/DIM/assets/98132549/a50f05b9-b9df-468f-8318-e7811e22321a)

This was done using translation via i18n as that is probably the best way to solve this since "Arc" is being replaced with "subclass matching elemental" since its a description in most if not all languages it should correlate correctly.

Also the function that adds perk descriptions was moved to the end since unless we want to do stuff with popping and shifting the results array no point in not just moving it to the end.

resolves #9179 