### PR TITLE
LO: Fix too aggressive set stats clamping

### DIFF
--- a/src/app/loadout-builder/process-utils.test.ts
+++ b/src/app/loadout-builder/process-utils.test.ts
@@ -518,6 +518,8 @@ describe('process-utils optimal mods', () => {
     [[68, 66, 30, 30, 30, 30], [0, 0, 0, 0, 0], 4, [8, 6, 3, 3, 3, 3]],
     // do everything we can to hit min bounds
     [[68, 66, 30, 30, 11, 30], [2, 2, 0, 0, 0], 4, [7, 6, 3, 3, 3, 3]],
+    // ensure that negative stat amounts aren't clamped too early
+    [[30, 61, 30, 30, 30, -14], [5, 5, 5, 5, 5], 5, [5, 6, 3, 3, 3, 3]],
   ];
 
   const pickMods = (setStats: number[], remainingEnergy: number[], numArtifice: number) => {

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -220,13 +220,15 @@ export function pickOptimalStatMods(
   const explorationStats = [0, 0, 0, 0, 0, 0];
 
   for (let statIndex = setStats.length - 1; statIndex >= 0; statIndex--) {
-    const value = Math.min(Math.max(setStats[statIndex], 0), 100);
     const filter = statFiltersInStatOrder[statIndex];
     if (!filter.ignored) {
-      const neededValue = filter.min * 10 - value;
-      if (neededValue > 0) {
-        // As per function preconditions, we know that we can hit these minimum stats
-        explorationStats[statIndex] = neededValue;
+      const value = setStats[statIndex];
+      if (filter.min > 0) {
+        const neededValue = filter.min * 10 - value;
+        if (neededValue > 0) {
+          // As per function preconditions, we know that we can hit these minimum stats
+          explorationStats[statIndex] = neededValue;
+        }
       }
       maxAddedStats[statIndex] = filter.max * 10 - value;
     }

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -269,10 +269,9 @@ export function process(
 
             // Check in which stats we're lacking
             for (let index = 0; index < 6; index++) {
-              const value = Math.min(Math.max(stats[index], 0), 100);
               const filter = statFiltersInStatOrder[index];
-
-              if (!filter.ignored) {
+              if (!filter.ignored && filter.min > 0) {
+                const value = stats[index];
                 const neededValue = filter.min * 10 - value;
                 if (neededValue > 0) {
                   totalNeededStats += neededValue;


### PR DESCRIPTION
Fixes a really small edge case that could occur when:

1. The user has a lower bound set for a stat
2. The selected fragments have a penalty in these stats that exceed...
3. ... the low stat values of a set.

In such cases, LO could end up not honoring the lower bound.