### PR TITLE
Fix previews for old iOS and force native DnD where available

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed showing the item under your finger while you're dragging it on iOS/iPadOS. As a reminder, on touchscreen devices you need to press the item for a little bit to "pick it up". And as a reminder for everyone, any time you see an item in DIM, pretty much wherever it is, you can drag it around to move the item or add it to a Loadout you're editing. This works from the Inventory, Item Feed, Loadouts screen, etc.
+
 ## 7.71.0 <span class="changelog-date">(2023-06-04)</span>
 
 * Added Community Insights for the impact of various stat tiers on ability cooldowns, etc. This takes into account your current subclass config and equipped exotic. For loadouts, it uses the subclass config and exotic that are saved in the loadout to display details. This information comes from the Clarity database, and like all Community Insights is sourced from lots of manual investigation.

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -3,8 +3,8 @@ import { LocationSwitcher } from 'app/shell/LocationSwitcher';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import {
   DndProvider,
-  MouseTransition,
   MultiBackendOptions,
+  PointerTransition,
   TouchTransition,
 } from 'react-dnd-multi-backend';
 import { TouchBackend } from 'react-dnd-touch-backend';
@@ -16,18 +16,26 @@ import store from './store/store';
 // Wrap App with Sentry profiling
 const WrappedApp = $featureFlags.sentry ? withProfiler(App) : App;
 
+const isNativeDragAndDropSupported = () => 'draggable' in document.createElement('div');
+
 function Root() {
   const options: MultiBackendOptions = {
-    backends: [
-      { id: 'html5', backend: HTML5Backend, transition: MouseTransition },
-      // We can drop this after we only support iOS 15+ and Chrome 108+
-      {
-        id: 'touch',
-        backend: TouchBackend,
-        transition: TouchTransition,
-        options: { delayTouchStart: 150 },
-      },
-    ],
+    backends:
+      // If we have native DnD then use it. iOS 15+ supports both touch and
+      // native dnd, and without this it'd switch to touch.
+      isNativeDragAndDropSupported()
+        ? [{ id: 'html5', backend: HTML5Backend }]
+        : [
+            { id: 'html5', backend: HTML5Backend, transition: PointerTransition },
+            // We can drop this after we only support iOS 15+ and Chrome 108+
+            {
+              id: 'touch',
+              backend: TouchBackend,
+              options: { enableMouseEvents: true, delayTouchStart: 150 },
+              preview: true,
+              transition: TouchTransition,
+            },
+          ],
   };
   return (
     <Router>

--- a/src/app/inventory/ItemDragPreview.tsx
+++ b/src/app/inventory/ItemDragPreview.tsx
@@ -1,0 +1,29 @@
+import { usePreview } from 'react-dnd-multi-backend';
+import ConnectedInventoryItem from './ConnectedInventoryItem';
+import { DimItem } from './item-types';
+
+/**
+ * When we are using the React DnD Touch Backend (iOS < 15 only), this will
+ * render a placeholder so users can see the item they're dragging.
+ *
+ * This can be removed when we drop iOS 14 support and the TouchBackend.
+ */
+export function ItemDragPreview() {
+  const preview = usePreview();
+
+  if (
+    !preview.display ||
+    // Basic check that it's a DimItem
+    !('bucket' in (preview.item as any))
+  ) {
+    return null;
+  }
+
+  const style = preview.style;
+  const item = preview.item as DimItem;
+  return (
+    <div style={style}>
+      <ConnectedInventoryItem item={item} />
+    </div>
+  );
+}

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -13,6 +13,7 @@ import Farming from 'app/farming/Farming';
 import { useHotkey, useHotkeys } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import InfusionFinder from 'app/infuse/InfusionFinder';
+import { ItemDragPreview } from 'app/inventory/ItemDragPreview';
 import SyncTagLock from 'app/inventory/SyncTagLock';
 import { blockingProfileErrorSelector, storesSelector } from 'app/inventory/selectors';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
@@ -249,6 +250,7 @@ export default function Destiny() {
       <ItemPickerContainer />
       <GlobalEffects />
       {autoLockTagged && <SyncTagLock />}
+      <ItemDragPreview />
     </>
   );
 }


### PR DESCRIPTION
For older iOS devices, this fixes #9542 by manually drawing a drag preview. For newer iOS devices, this forces us to use the native drag and drop implementation, which correctly shows a drag preview and has nicer drag implementation.