### PR TITLE
Remove support for old-style optimizer parameters share URLs

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -1,4 +1,3 @@
-import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { savedLoStatConstraintsByClassSelector } from 'app/dim-api/selectors';
 import CharacterSelect from 'app/dim-ui/CharacterSelect';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
@@ -56,15 +55,9 @@ const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
  */
 export default memo(function LoadoutBuilder({
   stores,
-  initialClassType,
-  initialLoadoutParameters,
-  notes,
   preloadedLoadout,
 }: {
   stores: DimStore[];
-  initialClassType: DestinyClass | undefined;
-  initialLoadoutParameters: LoadoutParameters | undefined;
-  notes: string | undefined;
   preloadedLoadout: Loadout | undefined;
 }) {
   const defs = useD2Definitions()!;
@@ -110,7 +103,7 @@ export default memo(function LoadoutBuilder({
       canUndo,
     },
     lbDispatch,
-  ] = useLbState(stores, defs, preloadedLoadout, initialClassType, initialLoadoutParameters);
+  ] = useLbState(stores, defs, preloadedLoadout);
   const isPhonePortrait = useIsPhonePortrait();
 
   const lockedExoticHash = loadoutParameters.exoticArmorHash;
@@ -151,11 +144,13 @@ export default memo(function LoadoutBuilder({
 
   // Save a subset of the loadout parameters to settings in order to remember them between sessions
   const setSetting = useSetSetting();
+  const hasPreloadedLoadout = Boolean(preloadedLoadout);
   useEffect(() => {
-    // If the user is playing with an existing loadout (potentially one they received from a loadout share)
-    // or a direct /optimizer link, do not overwrite the global saved loadout parameters.
-    // If they decide to save that loadout, these will still be saved with the loadout.
-    if (initialLoadoutParameters) {
+    // If the user is playing with an existing loadout (potentially one they
+    // received from a loadout share), do not overwrite the global saved loadout
+    // parameters. If they decide to save that loadout, these will still be
+    // saved with the loadout.
+    if (hasPreloadedLoadout) {
       return;
     }
 
@@ -191,8 +186,7 @@ export default memo(function LoadoutBuilder({
     optimizingLoadoutId,
     savedStatConstraintsByClass,
     classType,
-    preloadedLoadout,
-    initialLoadoutParameters,
+    hasPreloadedLoadout,
   ]);
 
   const onCharacterChanged = useCallback(
@@ -429,10 +423,10 @@ export default memo(function LoadoutBuilder({
             <p>{t('LoadoutBuilder.OptimizerExplanationGuide')}</p>
           </div>
         )}
-        {notes && (
+        {preloadedLoadout?.notes && (
           <div className={styles.guide}>
             <p>
-              <b>{t('MovePopup.Notes')}</b> {notes}
+              <b>{t('MovePopup.Notes')}</b> {preloadedLoadout?.notes}
             </p>
           </div>
         )}
@@ -451,7 +445,7 @@ export default memo(function LoadoutBuilder({
             params={params}
             halfTierMods={halfTierMods}
             armorEnergyRules={result.armorEnergyRules}
-            notes={notes}
+            notes={preloadedLoadout?.notes}
           />
         ) : (
           !processing && (
@@ -504,7 +498,7 @@ export default memo(function LoadoutBuilder({
               subclass={subclass}
               classType={classType}
               params={params}
-              notes={notes}
+              notes={preloadedLoadout?.notes}
               lockedMods={modsToAssign}
               onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}
             />

--- a/src/app/loadout-builder/LoadoutBuilderContainer.tsx
+++ b/src/app/loadout-builder/LoadoutBuilderContainer.tsx
@@ -2,7 +2,6 @@ import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { useLoadStores } from 'app/inventory/store/hooks';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
-import { decodeUrlLoadoutParameters } from 'app/loadout/loadout-share/loadout-import';
 import { useD2Definitions } from 'app/manifest/selectors';
 import ErrorPanel from 'app/shell/ErrorPanel';
 import { setSearchQuery } from 'app/shell/actions';
@@ -37,14 +36,7 @@ export default function LoadoutBuilderContainer({ account }: Props) {
   const disabledDueToMaintenance = useSelector(disabledDueToMaintenanceSelector);
   useLoadStores(account);
 
-  const decodedParameters = decodeUrlLoadoutParameters(location.search);
-  const {
-    classType: urlClassType,
-    notes: urlNotes,
-    parameters: urlLoadoutParameters,
-  } = decodedParameters;
-  let query = decodedParameters.query;
-
+  let query: string | undefined;
   const preloadedLoadout = (location.state as { loadout: Loadout } | undefined)?.loadout;
   if (preloadedLoadout?.parameters?.query) {
     query = preloadedLoadout.parameters.query;
@@ -69,14 +61,11 @@ export default function LoadoutBuilderContainer({ account }: Props) {
     );
   }
 
-  // TODO: key off the URL params?
   return (
     <LoadoutBuilder
+      key={preloadedLoadout?.id ?? 'lo'}
       stores={stores}
       preloadedLoadout={preloadedLoadout}
-      initialClassType={urlClassType ?? preloadedLoadout?.classType}
-      initialLoadoutParameters={urlLoadoutParameters || preloadedLoadout?.parameters}
-      notes={urlNotes ?? preloadedLoadout?.notes}
     />
   );
 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -82,25 +82,22 @@ const lbConfigInit = ({
   stores,
   defs,
   preloadedLoadout,
-  initialClassType,
-  initialLoadoutParameters,
   savedLoadoutBuilderParameters,
   savedStatConstraintsPerClass,
 }: {
   stores: DimStore[];
   defs: D2ManifestDefinitions;
   preloadedLoadout: Loadout | undefined;
-  initialClassType: DestinyClass | undefined;
-  initialLoadoutParameters: LoadoutParameters | undefined;
   savedLoadoutBuilderParameters: LoadoutParameters;
   savedStatConstraintsPerClass: { [classType: number]: StatConstraint[] };
 }): LoadoutBuilderConfiguration => {
   const pinnedItems: PinnedItems = {};
 
   // Preloaded loadouts from the "Optimize Armor" button take priority
-  let classType: DestinyClass = initialClassType ?? DestinyClass.Unknown;
+  let classType: DestinyClass = preloadedLoadout?.classType ?? DestinyClass.Unknown;
   // Pick a store that matches the classType
   const storeMatchingClass = pickBackingStore(stores, undefined, classType);
+  let initialLoadoutParameters = preloadedLoadout?.parameters;
 
   // If we requested a specific class type but the user doesn't have it, we
   // need to pick some different store, but ensure that class-specific stuff
@@ -543,9 +540,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
 export function useLbState(
   stores: DimStore[],
   defs: D2ManifestDefinitions,
-  preloadedLoadout: Loadout | undefined,
-  initialClassType: DestinyClass | undefined,
-  initialLoadoutParameters: LoadoutParameters | undefined
+  preloadedLoadout: Loadout | undefined
 ) {
   const savedLoadoutBuilderParameters = useSelector(savedLoadoutParametersSelector);
   const savedStatConstraintsPerClass = useSelector(savedLoStatConstraintsByClassSelector);
@@ -562,8 +557,6 @@ export function useLbState(
       stores,
       defs,
       preloadedLoadout,
-      initialClassType,
-      initialLoadoutParameters,
       savedLoadoutBuilderParameters,
       savedStatConstraintsPerClass,
     })

--- a/src/app/loadout/loadout-share/loadout-import.test.ts
+++ b/src/app/loadout/loadout-share/loadout-import.test.ts
@@ -41,17 +41,4 @@ describe('dim.gg loadout share links parsing', () => {
     }
     expect(decoded.loadout.parameters!.mods!.length).not.toBe(0);
   });
-
-  test.each([
-    [
-      // guardianforge
-      'https://app.destinyitemmanager.com/optimizer?class=0&p=%7B%22mods%22%3A%5B518224751%2C640058316%2C4283235143%2C555005975%2C3394151347%2C3394151347%2C282898303%2C2645858828%2C403494087%2C864745275%2C2216063963%2C2645858828%2C2588939505%2C2216063960%2C2645858828%2C3320641683%2C1708067044%2C2979815167%2C555005975%2C3974455041%2C3974455041%2C1484685887%5D%7D',
-    ],
-  ])('valid deprecated LO link %s', (arg) => {
-    const decoded = decodeShareUrl(arg);
-    if (!decoded || decoded.tag !== 'urlParameters') {
-      throw new Error();
-    }
-    expect(decoded.urlParameters!.parameters!.mods!.length).not.toBe(0);
-  });
 });

--- a/src/app/loadout/loadout-share/loadout-import.ts
+++ b/src/app/loadout/loadout-share/loadout-import.ts
@@ -1,4 +1,4 @@
-import { defaultLoadoutParameters, LoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { getSharedLoadout } from 'app/dim-api/dim-api';
 import { generateMissingLoadoutItemId } from 'app/loadout-drawer/loadout-item-conversion';
 import { convertDimApiLoadoutToLoadout } from 'app/loadout-drawer/loadout-type-converters';
@@ -67,43 +67,8 @@ export function decodeShareUrl(shareUrl: string): DecodedShareLink | undefined {
       if (loadout) {
         return { tag: 'urlLoadout', loadout };
       }
-    } else if (pathname.endsWith('/optimizer')) {
-      const params = decodeUrlLoadoutParameters(search);
-      if (params.classType !== undefined || params.notes || params.parameters || params.query) {
-        return { tag: 'urlParameters', urlParameters: params };
-      }
     }
   } catch {}
-}
-
-/**
- * Decode the deprecated Loadout Optimizer links containing only Loadout Optimizer settings.
- * `search` is the URL query string beginning with ?.
- */
-export function decodeUrlLoadoutParameters(search: string): UrlLoadoutParameters {
-  const searchParams = new URLSearchParams(search);
-  const urlClassTypeString = searchParams.get('class');
-  const urlLoadoutParametersJSON = searchParams.get('p');
-  const notes = searchParams.get('n') ?? undefined;
-
-  const classType = urlClassTypeString ? parseInt(urlClassTypeString) : undefined;
-
-  let query = '';
-  let parameters: LoadoutParameters | undefined;
-  if (urlLoadoutParametersJSON) {
-    parameters = JSON.parse(urlLoadoutParametersJSON);
-    parameters = { ...defaultLoadoutParameters, ...parameters };
-    if (parameters?.query) {
-      query = parameters.query;
-    }
-  }
-
-  return {
-    parameters,
-    classType,
-    notes,
-    query,
-  };
 }
 
 /**


### PR DESCRIPTION
I don't believe these are used anymore, though I could add an analytics event to verify that if you'd like.