### PR TITLE
Introduce isClassCompatible helper

### DIFF
--- a/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
@@ -21,8 +21,7 @@ import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useD1Definitions } from 'app/manifest/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useEventBusListener } from 'app/utils/hooks';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import TextareaAutosize from 'react-textarea-autosize';
@@ -96,7 +95,6 @@ export default function D1LoadoutDrawer({
 
   /** Prompt the user to select a replacement for a missing item. */
   const fixWarnItem = async (li: ResolvedLoadoutItem) => {
-    const loadoutClassType = loadout?.classType;
     const warnItem = li.item;
 
     setShowingItemPicker(true);
@@ -105,10 +103,7 @@ export default function D1LoadoutDrawer({
         filterItems: (item: DimItem) =>
           item.hash === warnItem.hash &&
           itemCanBeInLoadout(item) &&
-          (!loadout ||
-            loadout.classType === DestinyClass.Unknown ||
-            item.classType === loadoutClassType ||
-            item.classType === DestinyClass.Unknown),
+          (!loadout || isClassCompatible(item.classType, loadout.classType)),
         prompt: t('Loadouts.FindAnother', { name: warnItem.name }),
       });
 

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -15,8 +15,7 @@ import { findSameLoadoutItemIndex, fromEquippedTypes } from 'app/loadout-drawer/
 import { useD1Definitions } from 'app/manifest/selectors';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { AppIcon, addIcon } from 'app/shell/icons';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
@@ -142,7 +141,6 @@ async function pickLoadoutItem(
   add: (item: DimItem) => void,
   onShowItemPicker: (shown: boolean) => void
 ) {
-  const loadoutClassType = loadout?.classType;
   const loadoutHasItem = (item: DimItem) =>
     findSameLoadoutItemIndex(defs, loadout.items, item) !== -1;
 
@@ -151,10 +149,7 @@ async function pickLoadoutItem(
     const { item } = await showItemPicker({
       filterItems: (item: DimItem) =>
         item.bucket.hash === bucket.hash &&
-        (!loadout ||
-          loadout.classType === DestinyClass.Unknown ||
-          item.classType === loadoutClassType ||
-          item.classType === DestinyClass.Unknown) &&
+        isClassCompatible(item.classType, loadout.classType) &&
         itemCanBeInLoadout(item) &&
         !loadoutHasItem(item),
       prompt: t('Loadouts.ChooseItem', { name: bucket.name }),

--- a/src/app/inventory-page/DesktopStores.tsx
+++ b/src/app/inventory-page/DesktopStores.tsx
@@ -9,7 +9,7 @@ import { useSetSetting } from 'app/settings/hooks';
 import { AppIcon, maximizeIcon, minimizeIcon } from 'app/shell/icons';
 import StoreStats from 'app/store-stats/StoreStats';
 import { useEventBusListener } from 'app/utils/hooks';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { isClassCompatible } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { useMemo } from 'react';
 import StoreHeading from '../character-tile/StoreHeading';
@@ -43,9 +43,7 @@ export default function DesktopStores({ stores, buckets, singleCharacter }: Prop
       stores.length > 2 ||
       (currentStore &&
         stores.some((s) =>
-          s.items.some(
-            (i) => i.classType !== DestinyClass.Unknown && i.classType !== currentStore.classType
-          )
+          s.items.some((i) => !isClassCompatible(i.classType, currentStore.classType))
         )),
     [stores, currentStore]
   );

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -4,10 +4,9 @@ import { t } from 'app/i18next-t';
 import { D1ItemCategoryHashes } from 'app/search/d1-known-values';
 import { armorStats, evenStatWeights, TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 import { compareBy } from 'app/utils/comparators';
-import { isPlugStatActive } from 'app/utils/item-utils';
+import { isClassCompatible, isPlugStatActive } from 'app/utils/item-utils';
 import { weakMemoize } from 'app/utils/util';
 import {
-  DestinyClass,
   DestinyInventoryItemDefinition,
   DestinyItemInvestmentStatDefinition,
   DestinyStatAggregationType,
@@ -195,10 +194,7 @@ export function buildStats(
     // synthesize custom stats for meaningfully stat-bearing items
     if (createdItem.type !== 'ClassItem') {
       for (const customStat of customStats) {
-        if (
-          customStat.class === createdItem.classType ||
-          customStat.class === DestinyClass.Unknown
-        ) {
+        if (isClassCompatible(customStat.class, createdItem.classType)) {
           const cStat = makeCustomStat(
             investmentStats,
             customStat.weights,

--- a/src/app/item-triage/triage-utils.tsx
+++ b/src/app/item-triage/triage-utils.tsx
@@ -5,9 +5,8 @@ import { armorStats, CUSTOM_TOTAL_STAT_HASH, TOTAL_STAT_HASH } from 'app/search/
 import { ItemFilter } from 'app/search/filter-types';
 import { quoteFilterString } from 'app/search/query-parser';
 import { classFilter, itemTypeFilter } from 'app/search/search-filters/known-values';
-import { getInterestingSocketMetadatas } from 'app/utils/item-utils';
+import { getInterestingSocketMetadatas, isClassCompatible } from 'app/utils/item-utils';
 import { getIntrinsicArmorPerkSocket } from 'app/utils/socket-utils';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { Factor, factorComboCategories, FactorComboCategory, factorCombos } from './triage-factors';
 
@@ -215,9 +214,7 @@ function collectRelevantStatMaxes(
       // compare only items with the same canonical bucket.
       item.bucket.hash !== exampleItem.bucket.hash ||
       // item needs to be class-comparable
-      (exampleItem.classType !== DestinyClass.Unknown &&
-        item.classType !== DestinyClass.Unknown &&
-        item.classType !== exampleItem.classType) ||
+      !isClassCompatible(exampleItem.classType, item.classType) ||
       // compare exotics' stats only to dupes
       (exampleItem.isExotic && exampleItem.hash !== item.hash)
     ) {

--- a/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
@@ -1,6 +1,6 @@
 import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
 import { emptyArray } from 'app/utils/empty';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React from 'react';
@@ -46,9 +46,7 @@ export default function LoadoutDrawerDropTarget({
         const result = monitor.getDropResult();
         onDroppedItem(item, result?.equipped);
       },
-      canDrop: (i) =>
-        itemCanBeInLoadout(i) &&
-        (i.classType === DestinyClass.Unknown || classType === i.classType),
+      canDrop: (i) => itemCanBeInLoadout(i) && isClassCompatible(i.classType, classType),
       collect: (monitor) => ({ isOver: monitor.isOver() && monitor.canDrop() }),
     }),
     [bucketTypes, onDroppedItem]

--- a/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
@@ -4,8 +4,8 @@ import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t } from 'app/i18next-t';
 import { AppIcon, deleteIcon, redoIcon, undoIcon } from 'app/shell/icons';
 import { RootState } from 'app/store/types';
+import { isClassCompatible } from 'app/utils/item-utils';
 import { currySelector } from 'app/utils/selector-utils';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -24,11 +24,7 @@ const clashingLoadoutSelector = currySelector(
     (_: RootState, loadout: Loadout) => loadout,
     (loadouts, loadout) =>
       loadouts.find(
-        (l) =>
-          loadout.name === l.name &&
-          (loadout.classType === l.classType ||
-            l.classType === DestinyClass.Unknown ||
-            loadout.classType === DestinyClass.Unknown)
+        (l) => loadout.name === l.name && isClassCompatible(l.classType, loadout.classType)
       )
   )
 );

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -53,7 +53,7 @@ import { queueAction } from 'app/utils/action-queue';
 import { CancelToken, CanceledError, withCancel } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
 import { emptyArray } from 'app/utils/empty';
-import { itemCanBeEquippedBy } from 'app/utils/item-utils';
+import { isClassCompatible, itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
 import {
   aspectSocketCategoryHashes,
@@ -67,7 +67,7 @@ import {
 } from 'app/utils/socket-utils';
 import { count } from 'app/utils/util';
 import { HashLookup } from 'app/utils/util-types';
-import { DestinyClass, PlatformErrorCodes } from 'bungie-api-ts/destiny2';
+import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { Draft, produce } from 'immer';
 import _ from 'lodash';
@@ -265,7 +265,7 @@ function doApplyLoadout(
             // Don't apply perks/mods/subclass configs when moving items to the vault
             store.isVault ||
             // Only apply perks/mods/subclass configs if the item is usable by the store we're applying to
-            (item.classType !== DestinyClass.Unknown && item.classType !== store.classType)
+            !isClassCompatible(item.classType, store.classType)
           ) {
             return undefined;
           } else if (item.bucket.hash === BucketHashes.Subclass) {

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -11,7 +11,7 @@ import { DimStore } from 'app/inventory/store-types';
 import { SocketOverrides } from 'app/inventory/store/override-sockets';
 import { mapToNonReducedModCostVariant } from 'app/loadout/mod-utils';
 import { showNotification } from 'app/notifications/notifications';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { errorLog } from 'app/utils/log';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyClass, DestinyProfileResponse, TierType } from 'bungie-api-ts/destiny2';
@@ -76,7 +76,7 @@ export function addItem(
       return;
     }
 
-    if (item.classType !== DestinyClass.Unknown && draftLoadout.classType !== item.classType) {
+    if (!isClassCompatible(item.classType, draftLoadout.classType)) {
       showNotification({
         type: 'warning',
         title: t('Loadouts.ClassTypeMismatch', { className: item.classTypeNameLocalized }),

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -20,7 +20,7 @@ import { getTotalModStatChanges } from 'app/loadout/stats';
 import { manifestSelector } from 'app/manifest/selectors';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { armorStats, deprecatedPlaceholderArmorModHash } from 'app/search/d2-known-values';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import {
   aspectSocketCategoryHashes,
   fragmentSocketCategoryHashes,
@@ -886,10 +886,7 @@ export function pickBackingStore(
     !preferredStoreId || preferredStoreId === 'vault'
       ? getCurrentStore(stores)
       : getStore(stores, preferredStoreId);
-  return requestedStore &&
-    (classType === DestinyClass.Unknown || requestedStore.classType === classType)
+  return requestedStore && isClassCompatible(classType, requestedStore.classType)
     ? requestedStore
-    : stores.find(
-        (s) => !s.isVault && (s.classType === classType || classType === DestinyClass.Unknown)
-      );
+    : stores.find((s) => !s.isVault && isClassCompatible(classType, s.classType));
 }

--- a/src/app/loadout-drawer/selectors.ts
+++ b/src/app/loadout-drawer/selectors.ts
@@ -4,7 +4,7 @@ import { allItemsSelector, storesSelector } from 'app/inventory/selectors';
 import { allInGameLoadoutsSelector } from 'app/loadout/ingame/selectors';
 import { manifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { isClassCompatible } from 'app/utils/item-utils';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { InGameLoadout, Loadout, LoadoutItem, isInGameLoadout } from './loadout-types';
@@ -71,11 +71,7 @@ export const loadoutsByItemSelector = createSelector(
             // applicable stores for the loadout and associate every resolved
             // instance ID with the loadout.
             for (const store of stores) {
-              if (
-                store.classType !== DestinyClass.Unknown &&
-                (loadout.classType === DestinyClass.Unknown ||
-                  loadout.classType === store.classType)
-              ) {
+              if (!store.isVault && isClassCompatible(store.classType, loadout.classType)) {
                 const resolvedItem = getUninstancedLoadoutItem(allItems, info.hash, store.id);
                 if (resolvedItem) {
                   recordLoadout(resolvedItem.id, loadout, loadoutItem);

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -15,7 +15,7 @@ import {
 import { RootState } from 'app/store/types';
 import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
-import { modMetadataByPlugCategoryHash } from 'app/utils/item-utils';
+import { isClassCompatible, modMetadataByPlugCategoryHash } from 'app/utils/item-utils';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { uniqBy } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -111,9 +111,7 @@ function mapStateToProps() {
           // If classType is passed in, only use items from said class,
           // otherwise use items from all characters.
           // Useful if in loadouts and only mods and guns
-          (classType !== DestinyClass.Unknown &&
-            classType !== undefined &&
-            item.classType !== classType)
+          (classType !== undefined && !isClassCompatible(classType, item.classType))
         ) {
           continue;
         }

--- a/src/app/loadout/loadout-edit/useEquipDropTargets.tsx
+++ b/src/app/loadout/loadout-edit/useEquipDropTargets.tsx
@@ -1,6 +1,6 @@
 import { DimItem } from 'app/inventory/item-types';
 import { singularBucketHashes } from 'app/loadout-drawer/loadout-utils';
-import { itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { TargetType } from 'dnd-core';
 import { DropTargetHookSpec, useDrop } from 'react-dnd';
@@ -55,7 +55,7 @@ export function useEquipDropTargets(accept: TargetType, classType: DestinyClass)
       drop: () => ({ equipped: type === 'equipped' }),
       canDrop: (i) =>
         itemCanBeInLoadout(i) &&
-        (i.classType === DestinyClass.Unknown || classType === i.classType) &&
+        isClassCompatible(i.classType, classType) &&
         (type === 'equipped' || !singularBucketHashes.includes(i.bucket.hash)),
       collect: (monitor) => ({
         isOver: monitor.isOver() && monitor.canDrop(),

--- a/src/app/loadout/loadout-ui/menu-hooks.tsx
+++ b/src/app/loadout/loadout-ui/menu-hooks.tsx
@@ -14,6 +14,7 @@ import {
 import { loadoutsSelector } from 'app/loadout-drawer/loadouts-selector';
 import { plainString } from 'app/search/search-filters/freeform';
 import { emptyArray } from 'app/utils/empty';
+import { isClassCompatible } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import deprecatedMods from 'data/d2/deprecated-mods.json';
 import _ from 'lodash';
@@ -32,12 +33,7 @@ export function useSavedLoadoutsForClassType(classType: DestinyClass) {
 }
 
 export function filterLoadoutsToClass(loadouts: Loadout[], classType: DestinyClass) {
-  return loadouts.filter(
-    (loadout) =>
-      classType === DestinyClass.Unknown ||
-      loadout.classType === DestinyClass.Unknown ||
-      loadout.classType === classType
-  );
+  return loadouts.filter((loadout) => isClassCompatible(classType, loadout.classType));
 }
 
 /**

--- a/src/app/progress/SeasonalRank.tsx
+++ b/src/app/progress/SeasonalRank.tsx
@@ -2,6 +2,7 @@ import Countdown from 'app/dim-ui/Countdown';
 import { t } from 'app/i18next-t';
 import { DimStore } from 'app/inventory/store-types';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { isClassCompatible } from 'app/utils/item-utils';
 import {
   DestinyCharacterProgressionComponent,
   DestinyClass,
@@ -95,7 +96,7 @@ export default function SeasonalRank({
         }
       }
 
-      return def.classType === DestinyClass.Unknown || def.classType === store.classType;
+      return isClassCompatible(def.classType, store.classType);
     })
     // Premium reward first to match companion
     .reverse();

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -5,9 +5,9 @@ import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { DimRecord } from 'app/records/presentation-nodes';
 import { d2MissingIcon } from 'app/search/d2-known-values';
+import { isClassCompatible } from 'app/utils/item-utils';
 import {
   DestinyAmmunitionType,
-  DestinyClass,
   DestinyDisplayPropertiesDefinition,
   DestinyMilestone,
   DestinyMilestoneDefinition,
@@ -95,7 +95,7 @@ function availableQuestToItem(
           .filter(
             (i) =>
               i &&
-              (i.classType === store.classType || i.classType === DestinyClass.Unknown) &&
+              isClassCompatible(i.classType, store.classType) &&
               // And quest steps, they're not interesting
               !i.itemCategoryHashes?.includes(ItemCategoryHashes.QuestStep)
           ),

--- a/src/app/search/search-filters/stats.tsx
+++ b/src/app/search/search-filters/stats.tsx
@@ -3,7 +3,7 @@ import { tl } from 'app/i18next-t';
 import { DimItem, DimStat } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { maxLightItemSet, maxStatLoadout } from 'app/loadout-drawer/auto-loadouts';
-import { getStatValuesByHash } from 'app/utils/item-utils';
+import { getStatValuesByHash, isClassCompatible } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { FilterDefinition } from '../filter-types';
@@ -211,8 +211,8 @@ function createStatCombiner(
 
       if (namedCustomStats.length) {
         return (statValuesByHash: NodeJS.Dict<number>, _: any, item: DimItem) => {
-          const thisClassCustomStat = namedCustomStats.find(
-            (c) => c.class === item.classType || c.class === DestinyClass.Unknown
+          const thisClassCustomStat = namedCustomStats.find((c) =>
+            isClassCompatible(c.class, item.classType)
           );
           // if this item's guardian class doesn't have a custom stat named statName
           // return false to not match

--- a/src/app/settings/CustomStatsSettings.tsx
+++ b/src/app/settings/CustomStatsSettings.tsx
@@ -14,6 +14,7 @@ import { CUSTOM_TOTAL_STAT_HASH, armorStats, evenStatWeights } from 'app/search/
 import { allAtomicStats } from 'app/search/search-filter-values';
 import { AppIcon, addIcon, banIcon, deleteIcon, editIcon, saveIcon } from 'app/shell/icons';
 import { chainComparator, compareBy } from 'app/utils/comparators';
+import { isClassCompatible } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
@@ -334,11 +335,7 @@ function useSaveStat() {
       !newStat.shortLabel ||
       // or there's an existing stat with an overlapping label & class
       allOtherStats.some(
-        (s) =>
-          s.shortLabel === newStat.shortLabel &&
-          (s.class === newStat.class ||
-            s.class === DestinyClass.Unknown ||
-            newStat.class === DestinyClass.Unknown)
+        (s) => s.shortLabel === newStat.shortLabel && isClassCompatible(s.class, newStat.class)
       ) ||
       // or this shortLabel conflicts with a real stat.
       // don't name your custom stat discipline!!

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -165,7 +165,7 @@ export function itemCanBeEquippedByStoreId(
           // if it's equipped by this store, it's obviously equippable to this store!
           (item.owner === storeId && item.equipped)
         : // For the right class
-          item.classType === DestinyClass.Unknown || item.classType === storeClassType) &&
+          isClassCompatible(item.classType, storeClassType)) &&
       // can be moved or is already here
       (!item.notransfer || item.owner === storeId) &&
       (allowPostmaster || !item.location.inPostmaster)
@@ -368,4 +368,17 @@ export function getStatValuesByHash(item: DimItem, byWhichValue: 'base' | 'value
     output[stat.statHash] = stat[byWhichValue];
   }
   return output;
+}
+
+/**
+ * Are two Destiny classes compatible? e.g. can an item (firstClass) be equipped
+ * by a character (secondClass)? True if they're the same class or one is the
+ * wildcard class.
+ */
+export function isClassCompatible(firstClass: DestinyClass, secondClass: DestinyClass) {
+  return (
+    firstClass === DestinyClass.Unknown ||
+    secondClass === DestinyClass.Unknown ||
+    firstClass === secondClass
+  );
 }


### PR DESCRIPTION
It's a common operation to see "are these two DestinyClass types compatible", whether it's looking at item equippability or loadout eligibility.

Technically this helper checks more than some of these conditions used to, and could therefore produce a different result, but I don't think in practice it will.