### PR TITLE
Mark files as readonly in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,13 @@
     "destiny-icons": true,
     "manifest-cache": true
   },
+  "files.readonlyInclude": {
+    "node_modules/**": true,
+    "src/data/**": true,
+    "destiny-icons/**": true,
+    "src/locale/*": true,
+    "**/*.m.scss.d.ts": true
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },


### PR DESCRIPTION
This will prevent accidental editing of these files.