### PR TITLE
Don't show "enable DIM sync" notification before login

### DIFF
--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -3,6 +3,7 @@ import { needsDeveloper } from 'app/accounts/actions';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { accountsSelector, currentAccountSelector } from 'app/accounts/selectors';
 import { dimErrorToaster } from 'app/bungie-api/error-toaster';
+import { getToken } from 'app/bungie-api/oauth-tokens';
 import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
 import { Settings, initialSettingsState } from 'app/settings/initial-settings';
@@ -168,7 +169,8 @@ export function loadDimApiData(forceLoad = false): ThunkResult {
     }
 
     // Show a prompt if the user has not said one way or another whether they want to use the API
-    if (getState().dimApi.apiPermissionGranted === null) {
+    const hasBungieToken = Boolean(getToken());
+    if (getState().dimApi.apiPermissionGranted === null && hasBungieToken) {
       waitingForApiPermission = true;
       try {
         const useApi = await promptForApiPermission();


### PR DESCRIPTION
This got broken when I rearranged the order of loading DIM Sync / Bungie.net profile to handle offline mode. With this change we shouldn't show the DIM Sync popup while prompting people to log in.