### PR TITLE
Bugfix for Records Tab certain exotic weapons missing unless already acquired

### DIFF
--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -271,6 +271,8 @@ function searchRewards(
   );
 }
 
+// START HERE
+
 function toCollectibles(
   itemCreationContext: ItemCreationContext,
   collectibleHashes: DestinyPresentationNodeCollectibleChildEntry[]
@@ -290,6 +292,7 @@ function toCollectibles(
       ) {
         return null;
       }
+      // Below, perhaps try to find/check if collectibleDef.<unlockStatus> is a thing; basically find some wya to check unlock status to determine if it should be added
       const item = makeFakeItem(itemCreationContext, collectibleDef.itemHash);
       if (!item) {
         return null;
@@ -304,6 +307,8 @@ function toCollectibles(
     })
   );
 }
+
+//
 
 function toRecords(
   defs: D2ManifestDefinitions,

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -272,8 +272,6 @@ function searchRewards(
   );
 }
 
-// START HERE
-
 function toCollectibles(
   itemCreationContext: ItemCreationContext,
   collectibleHashes: DestinyPresentationNodeCollectibleChildEntry[]
@@ -308,15 +306,13 @@ function toCollectibles(
       };
     })
   );
-
+  // Filter out duplicates
   return result.filter((item) => {
     const duplicate = encounteredHashes.has(item.collectibleDef.itemHash);
     encounteredHashes.add(item.collectibleDef.itemHash);
     return !duplicate;
   });
 }
-
-//
 
 function toRecords(
   defs: D2ManifestDefinitions,

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -77,7 +77,6 @@ export function toPresentationNodeTree(
     return null;
   }
   if (presentationNodeDef.children.collectibles?.length) {
-    // Add preprocessing to the toCollectibles function to clean it before mounting it
     const collectibles = toCollectibles(
       itemCreationContext,
       presentationNodeDef.children.collectibles
@@ -298,6 +297,7 @@ function toCollectibles(
       if (!item) {
         return null;
       }
+      item.missingSockets = false;
       return {
         state,
         collectibleDef,


### PR DESCRIPTION
This PR attempts to solve #9434. 

Based on the discussion on the thread, it seems like the issue is the DimCollectible array returns duplicate item hashes for some collectibles (Revision Zero, Vexcalibur).

To fix this, I wrote a helper function for the toCollectibles function that cleans the DimCollectible array of duplicate item hashes before returning it. There might be a more elegant solution, but I'm a new contributor and don't know the codebase well enough to find one.

