### PR TITLE
Enable React Strict Mode

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -24,6 +24,7 @@ import registerServiceWorker from './app/register-service-worker';
 import { safariTouchFix } from './app/safari-touch-fix';
 import { watchLanguageChanges } from './app/settings/observers';
 import { saveWishListToIndexedDB } from './app/wishlists/observers';
+import { StrictMode } from 'react';
 infoLog(
   'app',
   `DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.github.com/DestinyItemManager/DIM/issues`
@@ -81,5 +82,9 @@ const i18nPromise = initi18n();
   // Settings depends on i18n
   watchLanguageChanges();
 
-  root.render(<Root />);
+  root.render(
+    <StrictMode>
+      <Root />
+    </StrictMode>
+  );
 })();


### PR DESCRIPTION
Now that we moved to virtualized lists that don't throw warnings in [Strict Mode](https://react.dev/reference/react/StrictMode), we can do this. I don't remember any bugs in DIM that this would've caught, but the React docs unconditionally recommend enabling this.