### PR TITLE
Typed i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "fast-copy": "^3.0.0",
     "fast-equals": "^5.0.0",
     "framer-motion": "^10.0.0",
-    "i18next": "^22.0.4",
+    "i18next": "^23.2.6",
     "i18next-http-backend": "^2.0.0",
     "immer": "^10.0.1",
     "lodash": "^4.17.8",

--- a/src/@types/i18next.d.ts
+++ b/src/@types/i18next.d.ts
@@ -1,0 +1,10 @@
+// import the original type declarations
+import en from 'config/i18n.json' assert { type: 'json' };
+import 'i18next';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'translation';
+    resources: { translation: typeof en };
+  }
+}

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -1,5 +1,5 @@
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { useLoadStores } from 'app/inventory/store/hooks';
 import { useD1Definitions } from 'app/manifest/selectors';
 import Objective from 'app/progress/Objective';
@@ -79,7 +79,7 @@ export default function Activities({ account }: Props) {
       tier.activityData.recommendedLight === 390
         ? '390'
         : tier.tierDisplayName
-        ? t(`Activities.${tier.tierDisplayName}`, {
+        ? t(`Activities.${tier.tierDisplayName}` as I18nKey, {
             metadata: { keys: 'difficulty' },
           })
         : tierDef.activityName;

--- a/src/app/dim-ui/destiny-symbols/destiny-symbols.tsx
+++ b/src/app/dim-ui/destiny-symbols/destiny-symbols.tsx
@@ -1,5 +1,5 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { t, tl } from 'app/i18next-t';
+import { I18nKey, t, tl } from 'app/i18next-t';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { StringLookup } from 'app/utils/util-types';
 import { FontGlyphs } from 'data/d2/d2-font-glyphs';
@@ -7,7 +7,7 @@ import { TranslateManually, symbolData } from 'data/d2/symbol-name-sources';
 import { createSelector } from 'reselect';
 import { conversionTableSelector } from './rich-destiny-text';
 
-const manualTranslations: { [key in TranslateManually]: string } = {
+const manualTranslations: { [key in TranslateManually]: I18nKey } = {
   [FontGlyphs.gilded_title]: tl('Glyphs.Gilded'),
   [FontGlyphs.hunter_smoke]: tl('Glyphs.Smoke'),
   [FontGlyphs.environment_hazard]: tl('Glyphs.Misadventure'),
@@ -46,7 +46,7 @@ export const symbolsSelector = createSelector(
     }
 
     for (const { codepoint, glyph, source } of symbolData) {
-      const manualTranslation = (manualTranslations as StringLookup<string>)[codepoint];
+      const manualTranslation = (manualTranslations as StringLookup<I18nKey>)[codepoint];
       if (manualTranslation) {
         const hardCodedName = t(manualTranslation);
         list.push({

--- a/src/app/hotkeys/hotkeys.ts
+++ b/src/app/hotkeys/hotkeys.ts
@@ -1,4 +1,4 @@
-import { t, tl } from 'app/i18next-t';
+import { I18nKey, t, tl } from 'app/i18next-t';
 import { isMac } from 'app/utils/browsers';
 import { compareBy } from 'app/utils/comparators';
 import { StringLookup } from 'app/utils/util-types';
@@ -17,7 +17,7 @@ const map: StringLookup<string> = {
 };
 
 /** We translate the keys that don't have fun symbols. */
-const keyi18n: StringLookup<string> = {
+const keyi18n: StringLookup<I18nKey> = {
   tab: tl('Hotkey.Tab'),
   enter: tl('Hotkey.Enter'),
 };

--- a/src/app/i18next-t.ts
+++ b/src/app/i18next-t.ts
@@ -1,4 +1,7 @@
 export { t } from 'i18next';
+import type { ParseKeys } from 'i18next';
+
+export type I18nKey = ParseKeys;
 
 /**
  * This is a "marker function" that tells our i18next-scanner that you will translate this string later (tl = translate later).
@@ -6,6 +9,6 @@ export { t } from 'i18next';
  * has no runtime presence.
  */
 /*@__INLINE__*/
-export function tl<T extends string>(key: T): T {
+export function tl<T extends I18nKey>(key: T): T {
   return key;
 }

--- a/src/app/i18next-t.ts
+++ b/src/app/i18next-t.ts
@@ -1,10 +1,4 @@
-import i18next, { TOptions } from 'i18next';
-
-/**
- * Wrap the t function so we can import a properly typed version. The default library won't let you.
- */
-export const t = (key: string | string[], options?: TOptions): string =>
-  i18next.t(key, options as any) as unknown as string;
+export { t } from 'i18next';
 
 /**
  * This is a "marker function" that tells our i18next-scanner that you will translate this string later (tl = translate later).

--- a/src/app/inventory-page/CategoryStrip.tsx
+++ b/src/app/inventory-page/CategoryStrip.tsx
@@ -1,4 +1,4 @@
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import clsx from 'clsx';
 import styles from './CategoryStrip.m.scss';
@@ -25,7 +25,7 @@ export default function CategoryStrip({
             onClick={() => onCategorySelected(category)}
             className={clsx({ [styles.selected]: category === selectedCategoryId })}
           >
-            {t(`Bucket.${category}`, { metadata: { keys: 'buckets' } })}
+            {t(`Bucket.${category}` as I18nKey, { metadata: { keys: 'buckets' } })}
           </div>
         ))}
     </div>

--- a/src/app/inventory-page/DesktopStores.tsx
+++ b/src/app/inventory-page/DesktopStores.tsx
@@ -1,5 +1,5 @@
 import { itemPop } from 'app/dim-ui/scroll';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { InventoryBucket, InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { locateItem$ } from 'app/inventory/locate-item';
 import { DimStore } from 'app/inventory/store-types';
@@ -149,7 +149,7 @@ function CollapsibleContainer({
 
   return (
     <InventoryCollapsibleTitle
-      title={t(`Bucket.${category}`, { metadata: { keys: 'buckets' } })}
+      title={t(`Bucket.${category}` as I18nKey, { metadata: { keys: 'buckets' } })}
       sectionId={category}
       stores={stores}
     >

--- a/src/app/inventory/MoveNotifications.tsx
+++ b/src/app/inventory/MoveNotifications.tsx
@@ -1,5 +1,5 @@
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
-import { t, tl } from 'app/i18next-t';
+import { I18nKey, t, tl } from 'app/i18next-t';
 import {
   LoadoutApplyPhase,
   LoadoutApplyState,
@@ -76,7 +76,7 @@ export function loadoutNotification(
   };
 }
 
-const messageByPhase: { [phase in LoadoutApplyPhase]: string } = {
+const messageByPhase: { [phase in LoadoutApplyPhase]: I18nKey } = {
   [LoadoutApplyPhase.NotStarted]: tl('Loadouts.NotStarted'),
   [LoadoutApplyPhase.Deequip]: tl('Loadouts.Deequip'),
   [LoadoutApplyPhase.MoveItems]: tl('Loadouts.MoveItems'),

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -1,6 +1,6 @@
 import { ItemAnnotation, ItemHashTag } from '@destinyitemmanager/dim-api-types';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { tl } from 'app/i18next-t';
+import { I18nKey, tl } from 'app/i18next-t';
 import { ThunkResult } from 'app/store/types';
 import _ from 'lodash';
 import { archiveIcon, banIcon, boltIcon, heartIcon, tagIcon } from '../shell/icons';
@@ -105,7 +105,7 @@ export interface ItemInfos {
 
 export interface TagInfo {
   type?: TagValue;
-  label: string;
+  label: I18nKey;
   sortOrder?: number;
   displacePriority?: number;
   hotkey?: string;

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -4,7 +4,7 @@ import BungieImage from 'app/dim-ui/BungieImage';
 import { CustomStatWeightsFromHash } from 'app/dim-ui/CustomStatWeights';
 import ExternalLink from 'app/dim-ui/ExternalLink';
 import { PressTip } from 'app/dim-ui/PressTip';
-import { t, tl } from 'app/i18next-t';
+import { I18nKey, t, tl } from 'app/i18next-t';
 import { D1Item, D1Stat, DimItem, DimSocket, DimStat } from 'app/inventory/item-types';
 import { statsMs } from 'app/inventory/store/stats';
 import { TOTAL_STAT_HASH, armorStats } from 'app/search/d2-known-values';
@@ -30,7 +30,7 @@ const modItemCategoryHashes = [
 ];
 
 // Some stat labels are long. This lets us replace them with i18n
-const statLabels: LookupTable<StatHashes, string> = {
+const statLabels: LookupTable<StatHashes, I18nKey> = {
   [StatHashes.RoundsPerMinute]: tl('Organizer.Stats.RPM'),
   [StatHashes.AirborneEffectiveness]: tl('Organizer.Stats.Airborne'),
 };

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -1,7 +1,7 @@
 import ClarityDescriptions from 'app/clarity/descriptions/ClarityDescriptions';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage from 'app/dim-ui/BungieImage';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { canInsertPlug, insertPlug } from 'app/inventory/advanced-write-actions';
 import {
   DimItem,
@@ -168,8 +168,8 @@ export default function SocketDetailsSelectedPlug({
 
   const kind = uiCategorizeSocket(defs, socket.socketDefinition);
   const insertName = canDoAWA
-    ? t(`Sockets.Insert.${kind}`, { metadata: { keys: 'sockets' } })
-    : t(`Sockets.Select.${kind}`, { metadata: { keys: 'sockets' } });
+    ? t(`Sockets.Insert.${kind}` as I18nKey, { metadata: { keys: 'sockets' } })
+    : t(`Sockets.Select.${kind}` as I18nKey, { metadata: { keys: 'sockets' } });
 
   const [insertInProgress, setInsertInProgress] = useState(false);
 

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -9,7 +9,7 @@ import { SetFilterButton } from 'app/dim-ui/SetFilterButton';
 import filterButtonStyles from 'app/dim-ui/SetFilterButton.m.scss';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import BucketIcon from 'app/dim-ui/svgs/BucketIcon';
-import { t, tl } from 'app/i18next-t';
+import { I18nKey, t, tl } from 'app/i18next-t';
 import { allItemsSelector } from 'app/inventory/selectors';
 import { ItemPopupTab } from 'app/item-popup/ItemPopupBody';
 import { hideItemPopup } from 'app/item-popup/item-popup';
@@ -263,7 +263,7 @@ function BetterItemsTriageSection({ item }: { item: DimItem }) {
     artificeWorseStatItems,
   } = betterWorseResults;
 
-  const rows: [string, readonly [string, string], DimItem[], boolean][] = [
+  const rows: [I18nKey, readonly [I18nKey, I18nKey], DimItem[], boolean][] = [
     [t('Triage.BetterArmor'), descriptionBulletPoints.better, betterItems, false],
     [t('Triage.WorseStatArmor'), descriptionBulletPoints.betterStats, betterStatItems, false],
     [t('Triage.BetterArtificeArmor'), descriptionBulletPoints.better, artificeBetterItems, true],

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -6,7 +6,7 @@ import ElementIcon from 'app/dim-ui/ElementIcon';
 import { KillTrackerInfo } from 'app/dim-ui/KillTracker';
 import { PressTip, Tooltip } from 'app/dim-ui/PressTip';
 import { SpecialtyModSlotIcon } from 'app/dim-ui/SpecialtyModSlotIcon';
-import { t, tl } from 'app/i18next-t';
+import { I18nKey, t, tl } from 'app/i18next-t';
 import ItemIcon, { DefItemIcon } from 'app/inventory/ItemIcon';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import NewItemIndicator from 'app/inventory/NewItemIndicator';
@@ -79,7 +79,7 @@ export function getColumnSelectionId(column: ColumnDefinition) {
 }
 
 // Some stat labels are long. This lets us replace them with i18n
-export const statLabels: LookupTable<StatHashes, string> = {
+export const statLabels: LookupTable<StatHashes, I18nKey> = {
   [StatHashes.RoundsPerMinute]: tl('Organizer.Stats.RPM'),
   [StatHashes.ReloadSpeed]: tl('Organizer.Stats.Reload'),
   [StatHashes.AimAssistance]: tl('Organizer.Stats.Aim'),

--- a/src/app/organizer/ItemActions.tsx
+++ b/src/app/organizer/ItemActions.tsx
@@ -2,7 +2,7 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import Dropdown, { Option } from 'app/dim-ui/Dropdown';
 import KeyHelp from 'app/dim-ui/KeyHelp';
 import { useHotkey, useHotkeys } from 'app/hotkeys/useHotkey';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { TagCommand, itemTagList } from 'app/inventory/dim-item-info';
 import { DimStore } from 'app/inventory/store-types';
 import { getCurrentStore, getVault } from 'app/inventory/stores-helpers';
@@ -21,7 +21,7 @@ import styles from './ItemActions.m.scss';
 
 export interface TagCommandInfo {
   type?: TagCommand;
-  label: string;
+  label: I18nKey;
   sortOrder?: number;
   displacePriority?: number;
   hotkey?: string;

--- a/src/app/progress/BountyGuide.tsx
+++ b/src/app/progress/BountyGuide.tsx
@@ -1,7 +1,7 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import BungieImage from 'app/dim-ui/BungieImage';
 import BucketIcon from 'app/dim-ui/svgs/BucketIcon';
-import { t, tl } from 'app/i18next-t';
+import { I18nKey, t, tl } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { moveItemTo } from 'app/inventory/move-item';
 import { DimStore } from 'app/inventory/store-types';
@@ -35,7 +35,7 @@ const killTypeIcons: LookupTable<KillType, string> = {
   [KillType.Precision]: headshot,
 };
 
-const killTypeDescriptions: Record<KillType, string> = {
+const killTypeDescriptions: Record<KillType, I18nKey> = {
   [KillType.Melee]: tl('KillType.Melee'),
   [KillType.Super]: tl('KillType.Super'),
   [KillType.Grenade]: tl('KillType.Grenade'),

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -1,5 +1,5 @@
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { findItemsByBucket } from 'app/inventory/stores-helpers';
@@ -59,7 +59,7 @@ export default function Pursuits({ store }: { store: DimStore }) {
           pursuits[group] && (
             <section id={group} key={group}>
               <CollapsibleTitle
-                title={t(`Progress.${group}`, { metadata: { keys: 'progress' } })}
+                title={t(`Progress.${group}` as I18nKey, { metadata: { keys: 'progress' } })}
                 sectionId={'pursuits-' + group}
               >
                 <PursuitsGroup pursuits={pursuits[group]} store={store} />

--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -1,7 +1,7 @@
 import { CustomStatDef } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimLanguage } from 'app/i18n';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { TagValue } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
@@ -112,7 +112,7 @@ export interface FilterDefinition<
    * A t()-compatible arg tuple or i18n key pointing to a full description of
    * the filter, to show in filter help
    */
-  description: string | I18nInput;
+  description: I18nKey | I18nInput;
 
   /**
    * What kind of query this is, used to help generate suggestions.

--- a/src/app/store-stats/D1CharacterStats.tsx
+++ b/src/app/store-stats/D1CharacterStats.tsx
@@ -1,5 +1,5 @@
 import { PressTip } from 'app/dim-ui/PressTip';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import type { DimStore } from 'app/inventory/store-types';
 import { getD1CharacterStatTiers, statsWithTiers } from 'app/inventory/store/character-utils';
 import { percent } from 'app/shell/formatters';
@@ -26,7 +26,7 @@ export default function D1CharacterStats({ stats }: Props) {
 
       let cooldown = stat.cooldown || '';
       if (cooldown) {
-        cooldown = t(`Cooldown.${stat.effect}`, {
+        cooldown = t(`Cooldown.${stat.effect}` as I18nKey, {
           cooldown,
           metadata: { keys: 'cooldowns' },
         });

--- a/src/app/strip-sockets/strip-sockets.ts
+++ b/src/app/strip-sockets/strip-sockets.ts
@@ -1,5 +1,5 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { tl } from 'app/i18next-t';
+import { I18nKey, tl } from 'app/i18next-t';
 import { canInsertPlug, insertPlug } from 'app/inventory/advanced-write-actions';
 import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
@@ -50,7 +50,7 @@ export function collectSocketsToStrip(
 ) {
   const socketsByKind: {
     [kind in SocketKind]: {
-      name: string;
+      name: I18nKey;
       items?: StripAction[];
     };
   } = {

--- a/src/app/utils/dim-error.ts
+++ b/src/app/utils/dim-error.ts
@@ -1,5 +1,5 @@
 import { BungieError } from 'app/bungie-api/http-client';
-import { t } from 'app/i18next-t';
+import { I18nKey, t } from 'app/i18next-t';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 
 /**
@@ -14,7 +14,7 @@ export class DimError extends Error {
   cause?: Error;
 
   /** Pass in just a message key to set the message to the localized version of that key, or override with the second parameter. */
-  constructor(messageKey: string, message?: string) {
+  constructor(messageKey: I18nKey, message?: string) {
     super(message || t(messageKey));
     this.code = messageKey;
     this.name = 'DimError';

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -21,9 +21,7 @@
   },
   "Activities": {
     "Activities": "Activities",
-    "Hard": "Hard",
     "Nightfall": "Nightfall Strike",
-    "Normal": "Normal",
     "WeeklyHeroic": "Weekly Heroic Strike"
   },
   "Armory": {
@@ -105,11 +103,6 @@
     "InitialItem": "This is the item the Compare tool was launched from",
     "IsVendorItem": "This item is not owned. This is in a vendor's inventory and may be for sale.",
     "SoldBy": "Sold by: {{vendorName}}"
-  },
-  "Cooldown": {
-    "Grenade": "Grenade cooldown: {{cooldown}}",
-    "Melee": "Melee cooldown: {{cooldown}}",
-    "Super": "Super cooldown: {{cooldown}}"
   },
   "Countdown": {
     "Days": "1 Day",
@@ -1073,30 +1066,8 @@
   "Sockets": {
     "ApplyPerks": "Apply Perks",
     "GridStyle": "Display perks as a grid",
-    "Insert": {
-      "Ability": "Equip Ability",
-      "Aspect": "Insert Aspect",
-      "Fragment": "Insert Fragment",
-      "Mod": "Insert Mod",
-      "Ornament": "Apply Ornament",
-      "Projection": "Apply Ghost Projection",
-      "Shader": "Apply Shader",
-      "Super": "Equip Super",
-      "Transmat": "Apply Transmat Effect"
-    },
     "ListStyle": "Display perks as a list",
     "Search": "Search names or descriptions",
-    "Select": {
-      "Ability": "Preview Ability",
-      "Aspect": "Preview Aspect",
-      "Fragment": "Preview Fragment",
-      "Mod": "Preview Mod",
-      "Ornament": "Preview Ornament",
-      "Projection": "Preview Ghost Projection",
-      "Shader": "Preview Shader",
-      "Super": "Preview Super",
-      "Transmat": "Preview Transmat Effect"
-    },
     "SelectWishlistPerks": "Preview Wishlist Perks"
   },
   "Stats": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,7 +1058,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.6", "@babel/runtime@^7.20.7", "@babel/runtime@^7.22.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7", "@babel/runtime@^7.22.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
   integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
@@ -5858,19 +5858,12 @@ i18next-scanner@^4.0.0:
     vinyl "^2.2.0"
     vinyl-fs "^3.0.1"
 
-i18next@*:
+i18next@*, i18next@^23.2.6:
   version "23.2.6"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.2.6.tgz#70c09517c301f206615acd6fc35b4a2570629300"
   integrity sha512-i0P2XBisewaICJ7UQtwymeJj6cXUigM+s8XNIXmWk4oJ8iTok2taCbOTX0ps+u9DFcQ6FWH6xLIU0dLEnMaNbA==
   dependencies:
     "@babel/runtime" "^7.22.5"
-
-i18next@^22.0.4:
-  version "22.5.1"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-22.5.1.tgz#99df0b318741a506000c243429a7352e5f44d424"
-  integrity sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==
-  dependencies:
-    "@babel/runtime" "^7.20.6"
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
This utilizes the new types available in i18next to find mistakes in our usage of translation keys. I'm not actually sure the extra typechecking time is worth it, but I did find some mistakes. We could probably also just scan `en.json` for empty keys, though somehow that didn't cover all of them.