### PR TITLE
Fashion Loadouts: Fix misidentified ornament socket for Loreley Splendor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed Fashion Loadouts being unable to store an Ornament for the Titan exotic Loreley Splendor Helm.
+
 ## 7.75.0 <span class="changelog-date">(2023-07-02)</span>
 
 * Organizer's "Loadouts" column now sorts items by the number of Loadouts using them.

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -435,6 +435,10 @@ function FashionItem({
     return null;
   }
 
+  // Divide valid sockets (with something plugged) into a shader socket and
+  // an ornament socket -- all items have two cosmetic sockets
+  // (really old Solstice armor has a third one for the glow at the end, and
+  // the exotic Loreley Splendor helm has a dummy socket with nothing plugged)
   const isShaderSocket = (s: DimSocket) =>
     defs.SocketType.get(s.socketDefinition.socketTypeHash)?.plugWhitelist.some(
       (pw) => pw.categoryHash === PlugCategoryHashes.Shader
@@ -442,7 +446,7 @@ function FashionItem({
   const cosmeticSockets = getSocketsByCategoryHash(
     exampleItem.sockets,
     SocketCategoryHashes.ArmorCosmetics
-  );
+  ).filter((s) => s.plugged);
   const shaderSocket = cosmeticSockets.find(isShaderSocket);
   const ornamentSocket = cosmeticSockets.find((s) => !isShaderSocket(s));
 


### PR DESCRIPTION
As reported on the Discord.

data.destinysets query that shows really only Loreley is affected by this:
```js
$InventoryItem.filter((i) => i.collectibleHash && i.itemCategoryHashes?.includes(20)).filter((i) => i.sockets?.socketCategories.find((c) =>c.socketCategoryHash === 1926152773)?.socketIndexes.length > 2).show()
```