### PR TITLE
Re-Enable the Sync from Equipped button for artifact unlocks

### DIFF
--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -215,7 +215,7 @@ export const LoadoutArtifactUnlocks = memo(function LoadoutArtifactUnlocks({
       })
     : t('Loadouts.ArtifactUnlocks');
 
-  if (!loadout.parameters?.artifactUnlocks?.unlockedItemHashes.length) {
+  if (!unlockedArtifactMods?.unlockedItemHashes.length) {
     return null;
   }
 


### PR DESCRIPTION
Also closes #9517 -- apparently this started working again on Bungie.net's side very recently, but the change to hide the section when the loadout has no artifact unlocks also caused the "Sync from Equipped" button to stop working. The correct thing to check is the Bungie.net response.