### PR TITLE
Add tooltip to archetype socket name

### DIFF
--- a/src/app/item-popup/ArchetypeSocket.tsx
+++ b/src/app/item-popup/ArchetypeSocket.tsx
@@ -1,8 +1,10 @@
+import { PressTip } from 'app/dim-ui/PressTip';
 import { DimItem, DimSocket } from 'app/inventory/item-types';
 import clsx from 'clsx';
 import React from 'react';
 import styles from './ArchetypeSocket.m.scss';
 import { PlugClickHandler } from './ItemSockets';
+import { DimPlugTooltip } from './PlugTooltip';
 import Socket from './Socket';
 
 /**
@@ -33,10 +35,13 @@ export default function ArchetypeSocket({
           onClick={onClick}
         />
       </div>
-      <div className={styles.info}>
+      <PressTip
+        className={styles.info}
+        tooltip={<DimPlugTooltip item={item} plug={archetypeSocket.plugged} />}
+      >
         <div className={styles.name}>{archetypeSocket.plugged.plugDef.displayProperties.name}</div>
         {children}
-      </div>
+      </PressTip>
     </>
   );
 }


### PR DESCRIPTION
This allows hovering the name to see details, not just the icon