### PR TITLE
Lo class select

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -66,7 +66,7 @@ const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
  */
 export default memo(function LoadoutBuilder({
   preloadedLoadout,
-  initialClassType,
+  storeId,
 }: {
   /**
    * A specific loadout to optimize, chosen from the Loadouts or Loadout Edit
@@ -74,10 +74,9 @@ export default memo(function LoadoutBuilder({
    */
   preloadedLoadout: Loadout | undefined;
   /**
-   * If `preloadedLoadout` is `undefined`, this can be used to preselect a class
-   * type - for example when navigating from the Loadouts page.
+   *A preselected store ID, used when navigating from the Loadouts page.
    */
-  initialClassType: DestinyClass | undefined;
+  storeId: string | undefined;
 }) {
   const isPhonePortrait = useIsPhonePortrait();
   const defs = useD2Definitions()!;
@@ -105,7 +104,7 @@ export default memo(function LoadoutBuilder({
       canUndo,
     },
     lbDispatch,
-  ] = useLbState(stores, defs, preloadedLoadout, initialClassType);
+  ] = useLbState(stores, defs, preloadedLoadout, storeId);
 
   // TODO: if we're editing a loadout, grey out incompatible classes?
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -66,8 +66,18 @@ const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
  */
 export default memo(function LoadoutBuilder({
   preloadedLoadout,
+  initialClassType,
 }: {
+  /**
+   * A specific loadout to optimize, chosen from the Loadouts or Loadout Edit
+   * page.
+   */
   preloadedLoadout: Loadout | undefined;
+  /**
+   * If `preloadedLoadout` is `undefined`, this can be used to preselect a class
+   * type - for example when navigating from the Loadouts page.
+   */
+  initialClassType: DestinyClass | undefined;
 }) {
   const isPhonePortrait = useIsPhonePortrait();
   const defs = useD2Definitions()!;
@@ -95,7 +105,9 @@ export default memo(function LoadoutBuilder({
       canUndo,
     },
     lbDispatch,
-  ] = useLbState(stores, defs, preloadedLoadout);
+  ] = useLbState(stores, defs, preloadedLoadout, initialClassType);
+
+  // TODO: if we're editing a loadout, grey out incompatible classes?
 
   // TODO: bundle these together into an LO context?
   const modHashes = loadoutParameters.mods ?? emptyArray();

--- a/src/app/loadout-builder/LoadoutBuilderContainer.tsx
+++ b/src/app/loadout-builder/LoadoutBuilderContainer.tsx
@@ -42,6 +42,12 @@ export default function LoadoutBuilderContainer({ account }: { account: DestinyA
     query = preloadedLoadout.parameters.query;
   }
 
+  const searchParams = new URLSearchParams(location.search);
+  const urlClassTypeString = searchParams.get('class');
+
+  const classType =
+    !preloadedLoadout && urlClassTypeString ? parseInt(urlClassTypeString) : undefined;
+
   // Apply the preloaded loadout's query to the main search bar
   useEffect(() => {
     if (query) {
@@ -62,5 +68,11 @@ export default function LoadoutBuilderContainer({ account }: { account: DestinyA
     );
   }
 
-  return <LoadoutBuilder key={preloadedLoadout?.id ?? 'lo'} preloadedLoadout={preloadedLoadout} />;
+  return (
+    <LoadoutBuilder
+      key={preloadedLoadout?.id ?? 'lo'}
+      preloadedLoadout={preloadedLoadout}
+      initialClassType={classType}
+    />
+  );
 }

--- a/src/app/loadout-builder/LoadoutBuilderContainer.tsx
+++ b/src/app/loadout-builder/LoadoutBuilderContainer.tsx
@@ -37,16 +37,15 @@ export default function LoadoutBuilderContainer({ account }: { account: DestinyA
   let query: string | undefined;
 
   // Get an entire loadout from state - this is used when optimizing a loadout from within DIM.
-  const preloadedLoadout = (location.state as { loadout: Loadout } | undefined)?.loadout;
+  const locationState = location.state as
+    | { loadout: Loadout | undefined; storeId: string | undefined }
+    | undefined;
+  const preloadedLoadout = locationState?.loadout;
   if (preloadedLoadout?.parameters?.query) {
     query = preloadedLoadout.parameters.query;
   }
 
-  const searchParams = new URLSearchParams(location.search);
-  const urlClassTypeString = searchParams.get('class');
-
-  const classType =
-    !preloadedLoadout && urlClassTypeString ? parseInt(urlClassTypeString) : undefined;
+  const storeId = locationState?.storeId;
 
   // Apply the preloaded loadout's query to the main search bar
   useEffect(() => {
@@ -70,9 +69,9 @@ export default function LoadoutBuilderContainer({ account }: { account: DestinyA
 
   return (
     <LoadoutBuilder
-      key={preloadedLoadout?.id ?? 'lo'}
+      key={preloadedLoadout?.id ?? storeId ?? 'lo'}
       preloadedLoadout={preloadedLoadout}
-      initialClassType={classType}
+      storeId={storeId}
     />
   );
 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -79,11 +79,15 @@ export function warnMissingClass(classType: DestinyClass, defs: D2ManifestDefini
   });
 }
 
+/**
+ * Create the initial state object for the loadout optimizer.
+ */
 const lbConfigInit = ({
   stores,
   allItems,
   defs,
   preloadedLoadout,
+  initialClassType,
   savedLoadoutBuilderParameters,
   savedStatConstraintsPerClass,
 }: {
@@ -91,11 +95,13 @@ const lbConfigInit = ({
   allItems: DimItem[];
   defs: D2ManifestDefinitions;
   preloadedLoadout: Loadout | undefined;
+  initialClassType: DestinyClass | undefined;
   savedLoadoutBuilderParameters: LoadoutParameters;
   savedStatConstraintsPerClass: { [classType: number]: StatConstraint[] };
 }): LoadoutBuilderConfiguration => {
   // Preloaded loadouts from the "Optimize Armor" button take priority
-  const classTypeFromPreloadedLoadout = preloadedLoadout?.classType ?? DestinyClass.Unknown;
+  const classTypeFromPreloadedLoadout =
+    preloadedLoadout?.classType ?? initialClassType ?? DestinyClass.Unknown;
   // Pick a store that matches the classType
   const storeMatchingClass = pickBackingStore(stores, undefined, classTypeFromPreloadedLoadout);
   let initialLoadoutParameters = preloadedLoadout?.parameters;
@@ -544,7 +550,8 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
 export function useLbState(
   stores: DimStore[],
   defs: D2ManifestDefinitions,
-  preloadedLoadout: Loadout | undefined
+  preloadedLoadout: Loadout | undefined,
+  initialClassType: DestinyClass | undefined
 ) {
   const savedLoadoutBuilderParameters = useSelector(savedLoadoutParametersSelector);
   const savedStatConstraintsPerClass = useSelector(savedLoStatConstraintsByClassSelector);
@@ -563,6 +570,7 @@ export function useLbState(
       allItems,
       defs,
       preloadedLoadout,
+      initialClassType,
       savedLoadoutBuilderParameters,
       savedStatConstraintsPerClass,
     })

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -87,23 +87,26 @@ const lbConfigInit = ({
   allItems,
   defs,
   preloadedLoadout,
-  initialClassType,
+  storeId,
   savedLoadoutBuilderParameters,
   savedStatConstraintsPerClass,
 }: {
   stores: DimStore[];
   allItems: DimItem[];
   defs: D2ManifestDefinitions;
+  /**
+   * A loadout that we are starting with, from the Loadouts page or editor.
+   * This can be null to start with a brand new loadout.
+   */
   preloadedLoadout: Loadout | undefined;
-  initialClassType: DestinyClass | undefined;
+  storeId: string | undefined;
   savedLoadoutBuilderParameters: LoadoutParameters;
   savedStatConstraintsPerClass: { [classType: number]: StatConstraint[] };
 }): LoadoutBuilderConfiguration => {
   // Preloaded loadouts from the "Optimize Armor" button take priority
-  const classTypeFromPreloadedLoadout =
-    preloadedLoadout?.classType ?? initialClassType ?? DestinyClass.Unknown;
+  const classTypeFromPreloadedLoadout = preloadedLoadout?.classType ?? DestinyClass.Unknown;
   // Pick a store that matches the classType
-  const storeMatchingClass = pickBackingStore(stores, undefined, classTypeFromPreloadedLoadout);
+  const storeMatchingClass = pickBackingStore(stores, storeId, classTypeFromPreloadedLoadout);
   let initialLoadoutParameters = preloadedLoadout?.parameters;
 
   // If we requested a specific class type but the user doesn't have it, we
@@ -551,7 +554,7 @@ export function useLbState(
   stores: DimStore[],
   defs: D2ManifestDefinitions,
   preloadedLoadout: Loadout | undefined,
-  initialClassType: DestinyClass | undefined
+  storeId: string | undefined
 ) {
   const savedLoadoutBuilderParameters = useSelector(savedLoadoutParametersSelector);
   const savedStatConstraintsPerClass = useSelector(savedLoStatConstraintsByClassSelector);
@@ -570,7 +573,7 @@ export function useLbState(
       allItems,
       defs,
       preloadedLoadout,
-      initialClassType,
+      storeId,
       savedLoadoutBuilderParameters,
       savedStatConstraintsPerClass,
     })

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -161,7 +161,11 @@ function Loadouts({ account }: { account: DestinyAccount }) {
           >
             <AppIcon icon={uploadIcon} /> <span>{t('Loadouts.ImportLoadout')}</span>
           </button>
-          <Link className={styles.menuButton} to={`../optimizer?class=${selectedStore.classType}`}>
+          <Link
+            className={styles.menuButton}
+            to="../optimizer"
+            state={{ storeId: selectedStore.id }}
+          >
             <AppIcon icon={faCalculator} /> {t('LB.LB')}
           </Link>
         </div>

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -138,7 +138,7 @@ export function ArmorExtras({
           storeId={storeId}
           onModsByBucketUpdated={onModsByBucketUpdated}
         />
-        <OptimizerButton loadout={loadout} />
+        <OptimizerButton loadout={loadout} storeId={storeId} />
       </div>
     </>
   );

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -101,7 +101,7 @@ export default function LoadoutItemCategorySection({
             </div>
           )}
           {loadout.parameters && <LoadoutParametersDisplay params={loadout.parameters} />}
-          {!hideOptimizeArmor && <OptimizerButton loadout={loadout} />}
+          {!hideOptimizeArmor && <OptimizerButton loadout={loadout} storeId={storeId} />}
         </>
       )}
     </div>

--- a/src/app/loadout/loadout-ui/OptimizerButton.tsx
+++ b/src/app/loadout/loadout-ui/OptimizerButton.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 /**
  * Link to open a loadout in the Optimizer.
  */
-export function OptimizerButton({ loadout }: { loadout: Loadout }) {
+export function OptimizerButton({ loadout, storeId }: { loadout: Loadout; storeId: string }) {
   // We need to build an absolute path rather than a relative one because the loadout editor is mounted higher than the destiny routes.
   const account = useSelector(currentAccountSelector);
   if (!account) {
@@ -18,7 +18,7 @@ export function OptimizerButton({ loadout }: { loadout: Loadout }) {
     <Link
       className="dim-button"
       to={`/${account.membershipId}/d${account.destinyVersion}/optimizer`}
-      state={{ loadout }}
+      state={{ loadout, storeId }}
     >
       <AppIcon icon={faCalculator} /> {t('Loadouts.OpenInOptimizer')}
     </Link>


### PR DESCRIPTION
In cleaning up support for old LO shares, I accidentally broke the feature where we'd remember which class type was selected when linking from the Loadouts page to LO. This fixes that, then swaps to store ID instead of class type so we can preserve the exact selected store even if you have multiples of the same class.