### PR TITLE
Debug page: report type of recommendedPerks, not wishlistRoll

### DIFF
--- a/src/app/debug/Debug.tsx
+++ b/src/app/debug/Debug.tsx
@@ -251,7 +251,7 @@ export default function Debug() {
           </p>
           <p>
             <b>Weird recommendedPerks?:</b>{' '}
-            {weirdWishlistRoll ? typeof weirdWishlistRoll : 'All good'}
+            {weirdWishlistRoll ? typeof weirdWishlistRoll.recommendedPerks : 'All good'}
           </p>
         </section>
 


### PR DESCRIPTION
I think this is what we're interested in. Could also try `JSON.stringify`-ing it...