### PR TITLE
Temporarily enable the PresentationNodes profile component for Solstice

### DIFF
--- a/config/feature-flags.ts
+++ b/config/feature-flags.ts
@@ -40,7 +40,7 @@ export function makeFeatureFlags(env: { release: boolean; beta: boolean; dev: bo
     loadoutFilterPills: true,
     // Request the PresentationNodes component only needed during
     // Solstice to associate each character with a set of triumphs.
-    solsticePresentationNodes: false,
+    solsticePresentationNodes: true,
     // not ready to turn these on but the code is there
     customStatWeights: false,
   };


### PR DESCRIPTION
As per the [TWID](https://www.bungie.net/7/en/News/Article/7_13_23_twid), Solstice is returning next week. Last year this was needed to associate the correct presentation node for event challenges with the selected character and with this, app might just work without adjustments.