### PR TITLE
Separate special from heavy grenade launchers everywhere

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* DIM now considers breech-loaded (special) Grenade Launchers and Heavy Grenade Launchers completely separate item types. This means Special Grenade Launchers now have their own Organizer tab, Triage for Heavy Grenade Launchers will no longer show "similar" Special Grenade Launchers, and Compare will not include them when comparing Heavy Grenade Launchers.
+
 ## 7.76.0 <span class="changelog-date">(2023-07-09)</span>
 
 * Fixed Fashion Loadouts being unable to store an Ornament for the Titan exotic Loreley Splendor Helm.

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -543,12 +543,16 @@ export function makeItem(
   }
 
   if (createdItem.hash in extendedICH) {
-    createdItem.itemCategoryHashes = [
-      ...createdItem.itemCategoryHashes,
-      extendedICH[createdItem.hash]!,
-    ];
+    const additionalICH = extendedICH[createdItem.hash]!;
+    createdItem.itemCategoryHashes = [...createdItem.itemCategoryHashes, additionalICH];
+    // Special grenade launchers are not heavy grenade launchers
+    if (additionalICH === -ItemCategoryHashes.GrenadeLaunchers) {
+      createdItem.itemCategoryHashes = createdItem.itemCategoryHashes.filter(
+        (ich) => ich !== ItemCategoryHashes.GrenadeLaunchers
+      );
+    }
     // Masks are helmets too
-    if (extendedICH[createdItem.hash] === ItemCategoryHashes.Mask) {
+    if (additionalICH === ItemCategoryHashes.Mask) {
       createdItem.itemCategoryHashes = [
         ...createdItem.itemCategoryHashes,
         ItemCategoryHashes.Helmets,

--- a/src/app/organizer/ItemTypeSelector.tsx
+++ b/src/app/organizer/ItemTypeSelector.tsx
@@ -142,9 +142,21 @@ const d2SelectionTree: ItemCategoryTreeNode = {
           terminal: true,
         },
         {
+          id: 'specialgrenadelauncher',
+          itemCategoryHash: -ItemCategoryHashes.GrenadeLaunchers,
+          subCategories: [kinetic, energy],
+          terminal: true,
+        },
+        {
           id: 'tracerifle',
           itemCategoryHash: ItemCategoryHashes.TraceRifles,
           subCategories: [kinetic, energy],
+          terminal: true,
+        },
+        {
+          id: 'glaive',
+          itemCategoryHash: ItemCategoryHashes.Glaives,
+          subCategories: [energy, power],
           terminal: true,
         },
         {
@@ -158,9 +170,9 @@ const d2SelectionTree: ItemCategoryTreeNode = {
           terminal: true,
         },
         {
-          id: 'grenadelauncher',
+          id: 'heavygrenadelauncher',
           itemCategoryHash: ItemCategoryHashes.GrenadeLaunchers,
-          subCategories: [kinetic, energy, power],
+          subCategories: [power],
           terminal: true,
         },
         {
@@ -172,12 +184,6 @@ const d2SelectionTree: ItemCategoryTreeNode = {
           id: 'linearfusionrifle',
           itemCategoryHash: ItemCategoryHashes.LinearFusionRifles,
           subCategories: [kinetic, energy, power],
-          terminal: true,
-        },
-        {
-          id: 'glaive',
-          itemCategoryHash: ItemCategoryHashes.Glaives,
-          subCategories: [energy, power],
           terminal: true,
         },
       ],

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -51,6 +51,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "haspower",
   "hasshader",
   "heavy",
+  "heavygrenadelauncher",
   "helmet",
   "hunter",
   "incurrentchar",

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -151,7 +151,7 @@ export const swordStatsByName = {
 
 /** D2 has these item types but D1 doesn't */
 export const D2ItemCategoryHashesByName = {
-  grenadelauncher: ItemCategoryHashes.GrenadeLaunchers,
+  heavygrenadelauncher: ItemCategoryHashes.GrenadeLaunchers,
   specialgrenadelauncher: -ItemCategoryHashes.GrenadeLaunchers,
   tracerifle: ItemCategoryHashes.TraceRifles,
   linearfusionrifle: ItemCategoryHashes.LinearFusionRifles,

--- a/src/app/search/search-filters/known-values.tsx
+++ b/src/app/search/search-filters/known-values.tsx
@@ -8,7 +8,7 @@ import { StringLookup } from 'app/utils/util-types';
 import { DestinyAmmunitionType, DestinyClass, DestinyRecordState } from 'bungie-api-ts/destiny2';
 import { D2EventEnum, D2EventPredicateLookup } from 'data/d2/d2-event-info';
 import focusingOutputs from 'data/d2/focusing-item-outputs.json';
-import { BreakerTypeHashes } from 'data/d2/generated-enums';
+import { BreakerTypeHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import missingSources from 'data/d2/missing-source-info';
 import D2Sources from 'data/d2/source-info';
 import { D1ItemCategoryHashes } from '../d1-known-values';
@@ -91,12 +91,19 @@ export const itemTypeFilter: FilterDefinition = {
 };
 
 export const itemCategoryFilter: FilterDefinition = {
-  keywords: Object.keys(itemCategoryHashesByName),
+  keywords: [...Object.keys(itemCategoryHashesByName), 'grenadelauncher'],
   description: tl('Filter.WeaponType'),
   filter: ({ filterValue }) => {
     const categoryHash = itemCategoryHashesByName[filterValue.replace(/\s/g, '')];
     if (!categoryHash) {
       throw new Error('Unknown weapon type ' + filterValue);
+    }
+    // Before special GLs and heavy GLs were entirely separated, `is:grenadelauncher` matched both.
+    // This keeps existing searches valid and unchanged in behavior.
+    if (filterValue === 'grenadelauncher') {
+      return (item) =>
+        item.itemCategoryHashes.includes(ItemCategoryHashes.GrenadeLaunchers) ||
+        item.itemCategoryHashes.includes(-ItemCategoryHashes.GrenadeLaunchers);
     }
     return (item) => item.itemCategoryHashes.includes(categoryHash);
   },


### PR DESCRIPTION
It seems d2ai generates the correct hashes for pursuits already https://github.com/DestinyItemManager/d2-additional-info/blob/aecd993d43de97396db84e9835e0c21d36a62b22/data/bounties/bounty-config.ts#L265-L278, so things should Just Work.

Fixes #9472.