### PR TITLE
Use a loadout for LO state

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -586,6 +586,7 @@
     "Filter": "Filters",
     "IncludeVendorItems": "Include Vendor items",
     "Legendary": "Legendary",
+    "LoadoutName": "Optimized Loadout",
     "LockEquipped": "Pin equipped",
     "LockItem": "Pin item",
     "MissingClass": "Build is for: {{className}}",

--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -41,7 +41,6 @@ module.exports = {
       buckets: { list: ['General', 'Inventory', 'Postmaster', 'Progress', 'Unknown'] },
       cooldowns: { list: ['Grenade', 'Melee', 'Super'] },
       difficulty: { list: ['Normal', 'Hard'] },
-      minMax: { list: ['Min', 'Max'] },
       progress: { list: ['Bounties', 'Items', 'Quests'] },
       sockets: { list: ['Mod', 'Ability', 'Shader', 'Ornament', 'Fragment', 'Aspect', 'Projection', 'Transmat', 'Super'] },
       unsupported: { list: ['Unsupported', 'Steam'] },

--- a/src/app/item-triage/triage-utils.test.ts
+++ b/src/app/item-triage/triage-utils.test.ts
@@ -1,5 +1,5 @@
 import { DimStat } from 'app/inventory/item-types';
-import { armorStatHashes } from 'app/search/search-filter-values';
+import { armorStats } from 'app/search/d2-known-values';
 import { compareBetterStats } from './triage-utils';
 
 describe('triage armor comparison works', () => {
@@ -11,11 +11,11 @@ describe('triage armor comparison works', () => {
   ): 'left' | 'right' | undefined => {
     const statsToDict = (stats: Stats) =>
       Object.fromEntries(
-        armorStatHashes.map((hash, index) => [hash, { base: stats[index] } as DimStat])
+        armorStats.map((hash, index) => [hash, { base: stats[index] } as DimStat])
       );
     const leftStats = statsToDict(left);
     const rightStats = statsToDict(right);
-    const result = compareBetterStats(leftStats, rightStats, leftArtifice, armorStatHashes);
+    const result = compareBetterStats(leftStats, rightStats, leftArtifice, armorStats);
     return result === leftStats ? 'left' : result === rightStats ? 'right' : undefined;
   };
 

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -51,11 +51,7 @@ import { sortGeneratedSets } from './generated-sets/utils';
 import { filterItems } from './item-filter';
 import { useLbState } from './loadout-builder-reducer';
 import { useLoVendorItems } from './loadout-builder-vendors';
-import {
-  buildLoadoutParams,
-  statFiltersFromLoadoutParameters,
-  statOrderFromLoadoutParameters,
-} from './loadout-params';
+import { statFiltersFromLoadoutParameters, statOrderFromLoadoutParameters } from './loadout-params';
 import { useProcess } from './process/useProcess';
 import { ArmorEnergyRules, LOCKED_EXOTIC_ANY_EXOTIC, loDefaultArmorEnergyRules } from './types';
 
@@ -200,6 +196,13 @@ export default memo(function LoadoutBuilder({
     [lbDispatch, savedStatConstraintsByClass, stores]
   );
 
+  // Write the search query into the loadout
+  useEffect(() => {
+    if ((searchQuery || undefined) !== loadoutParameters.query) {
+      lbDispatch({ type: 'setSearchQuery', query: searchQuery });
+    }
+  }, [lbDispatch, loadoutParameters.query, searchQuery]);
+
   // TODO: build a bundled up context object to pass to GeneratedSets?
 
   const [armorEnergyRules, filteredItems, filterInfo] = useMemo(() => {
@@ -252,14 +255,6 @@ export default memo(function LoadoutBuilder({
     anyExotic: lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC,
     autoStatMods,
   });
-
-  // A representation of the current loadout optimizer parameters that can be saved with generated loadouts
-  // TODO: replace some of these individual params with this object << what
-  // TODO: build a skeleton loadout here?
-  const params = useMemo(
-    () => buildLoadoutParams(loadoutParameters, searchQuery, statFilters, statOrder),
-    [loadoutParameters, searchQuery, statFilters, statOrder]
-  );
 
   const resultSets = result?.sets;
 
@@ -432,7 +427,7 @@ export default memo(function LoadoutBuilder({
             enabledStats={enabledStats}
             modStatChanges={result.modStatChanges}
             loadouts={loadouts}
-            params={params}
+            params={loadoutParameters}
             armorEnergyRules={result.armorEnergyRules}
             notes={preloadedLoadout?.notes}
           />
@@ -487,7 +482,7 @@ export default memo(function LoadoutBuilder({
               initialLoadoutId={optimizingLoadoutId}
               subclass={subclass}
               classType={classType}
-              params={params}
+              params={loadoutParameters}
               notes={preloadedLoadout?.notes}
               lockedMods={modsToAssign}
               onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -111,7 +111,7 @@ export default memo(function LoadoutBuilder({
   const lockedExoticHash = loadoutParameters.exoticArmorHash;
   const statConstraints =
     loadoutParameters.statConstraints ?? defaultLoadoutParameters.statConstraints!;
-  const autoStatMods = loadoutParameters.autoStatMods ?? false;
+  const autoStatMods = Boolean(loadoutParameters.autoStatMods);
   const statOrder = useMemo(() => statOrderFromStatConstraints(statConstraints), [statConstraints]);
 
   const selectedStore = stores.find((store) => store.id === selectedStoreId)!;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -417,13 +417,11 @@ export default memo(function LoadoutBuilder({
               defs={defs}
               classType={classType}
               dispatch={lbDispatch}
+              params={loadoutParameters}
               resolvedMods={resolvedMods}
               lockedModMap={lockedModMap}
               alwaysInvalidMods={unassignedMods}
-              autoAssignStatMods={autoStatMods}
               armorEnergyRules={armorEnergyRules}
-              lockedExoticHash={lockedExoticHash}
-              statConstraints={statConstraints}
               pinnedItems={pinnedItems}
               filterInfo={filterInfo}
               processInfo={result?.processInfo}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -1,4 +1,8 @@
-import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
+import {
+  LoadoutParameters,
+  StatConstraint,
+  defaultLoadoutParameters,
+} from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { savedLoStatConstraintsByClassSelector } from 'app/dim-api/selectors';
 import CharacterSelect from 'app/dim-ui/CharacterSelect';
@@ -50,7 +54,7 @@ import { sortGeneratedSets } from './generated-sets/utils';
 import { filterItems } from './item-filter';
 import { useLbState } from './loadout-builder-reducer';
 import { useLoVendorItems } from './loadout-builder-vendors';
-import { statOrderFromLoadoutParameters } from './loadout-params';
+import { statOrderFromStatConstraints } from './loadout-params';
 import { useProcess } from './process/useProcess';
 import { ArmorEnergyRules, LOCKED_EXOTIC_ANY_EXOTIC, loDefaultArmorEnergyRules } from './types';
 
@@ -105,12 +109,10 @@ export default memo(function LoadoutBuilder({
   const loadoutParameters = loadout.parameters!;
   const modHashes = loadoutParameters.mods ?? emptyArray();
   const lockedExoticHash = loadoutParameters.exoticArmorHash;
-  const statConstraints = loadoutParameters.statConstraints ?? emptyArray();
+  const statConstraints =
+    loadoutParameters.statConstraints ?? defaultLoadoutParameters.statConstraints!;
   const autoStatMods = loadoutParameters.autoStatMods ?? false;
-  const statOrder = useMemo(
-    () => statOrderFromLoadoutParameters(loadoutParameters),
-    [loadoutParameters]
-  );
+  const statOrder = useMemo(() => statOrderFromStatConstraints(statConstraints), [statConstraints]);
 
   const selectedStore = stores.find((store) => store.id === selectedStoreId)!;
   const classType = selectedStore.classType;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -289,9 +289,7 @@ export default memo(function LoadoutBuilder({
       <TierSelect
         statConstraints={statConstraints}
         statRangesFiltered={result?.statRangesFiltered}
-        onStatConstraintsChanged={(statConstraints) =>
-          lbDispatch({ type: 'statConstraintsChanged', statConstraints })
-        }
+        lbDispatch={lbDispatch}
       />
       <EnergyOptions
         assumeArmorMasterwork={loadoutParameters.assumeArmorMasterwork}

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -1,4 +1,4 @@
-import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
+import { AssumeArmorMasterwork, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import { t } from 'app/i18next-t';
@@ -17,7 +17,7 @@ import LockedItem from './filter/LockedItem';
 import { FilterInfo } from './item-filter';
 import { LoadoutBuilderAction } from './loadout-builder-reducer';
 import { ProcessStatistics, RejectionRate } from './process-worker/types';
-import { ArmorEnergyRules, LockableBucketHashes, PinnedItems, StatFilters } from './types';
+import { ArmorEnergyRules, LockableBucketHashes, PinnedItems } from './types';
 
 interface ActionableSuggestion {
   id: string;
@@ -51,7 +51,7 @@ export default function NoBuildsFoundExplainer({
   lockedModMap,
   alwaysInvalidMods,
   armorEnergyRules,
-  statFilters,
+  statConstraints,
   pinnedItems,
   lockedExoticHash,
   filterInfo,
@@ -65,7 +65,7 @@ export default function NoBuildsFoundExplainer({
   lockedModMap: ModMap;
   alwaysInvalidMods: PluggableInventoryItemDefinition[];
   armorEnergyRules: ArmorEnergyRules;
-  statFilters: StatFilters;
+  statConstraints: StatConstraint[];
   pinnedItems: PinnedItems;
   lockedExoticHash: number | undefined;
   filterInfo?: FilterInfo;
@@ -207,7 +207,7 @@ export default function NoBuildsFoundExplainer({
   // two non-solar combat mods, mod assignment is trivially infeasible and we
   // can point that out directly?
 
-  const anyStatMinimums = Object.values(statFilters).some((f) => !f.ignored && f.min > 0);
+  const anyStatMinimums = statConstraints.some((f) => Boolean(f.minTier));
 
   const bucketIndependentMods = [...lockedModMap.generalMods, ...lockedModMap.activityMods];
 

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -1,4 +1,4 @@
-import { AssumeArmorMasterwork, StatConstraint } from '@destinyitemmanager/dim-api-types';
+import { AssumeArmorMasterwork, LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import { t } from 'app/i18next-t';
@@ -46,28 +46,24 @@ export default function NoBuildsFoundExplainer({
   defs,
   dispatch,
   classType,
-  autoAssignStatMods,
+  params,
   resolvedMods,
   lockedModMap,
   alwaysInvalidMods,
   armorEnergyRules,
-  statConstraints,
   pinnedItems,
-  lockedExoticHash,
   filterInfo,
   processInfo,
 }: {
   defs: D2ManifestDefinitions;
   dispatch: Dispatch<LoadoutBuilderAction>;
   classType: DestinyClass;
-  autoAssignStatMods: boolean;
+  params: LoadoutParameters;
   resolvedMods: ResolvedLoadoutMod[];
   lockedModMap: ModMap;
   alwaysInvalidMods: PluggableInventoryItemDefinition[];
   armorEnergyRules: ArmorEnergyRules;
-  statConstraints: StatConstraint[];
   pinnedItems: PinnedItems;
-  lockedExoticHash: number | undefined;
   filterInfo?: FilterInfo;
   processInfo?: ProcessStatistics;
 }) {
@@ -136,6 +132,7 @@ export default function NoBuildsFoundExplainer({
   // then we should consider removing some item restrictions (such as unpinning/unrestricting items)
   // or removing mods.
   if (filterInfo) {
+    const lockedExoticHash = params.exoticArmorHash;
     const lockedExoticBucketHash =
       lockedExoticHash !== undefined &&
       lockedExoticHash > 0 &&
@@ -207,7 +204,7 @@ export default function NoBuildsFoundExplainer({
   // two non-solar combat mods, mod assignment is trivially infeasible and we
   // can point that out directly?
 
-  const anyStatMinimums = statConstraints.some((f) => Boolean(f.minTier));
+  const anyStatMinimums = params.statConstraints!.some((f) => Boolean(f.minTier));
 
   const bucketIndependentMods = [...lockedModMap.generalMods, ...lockedModMap.activityMods];
 
@@ -335,7 +332,7 @@ export default function NoBuildsFoundExplainer({
         id: 'lowerBoundsExceeded',
         description: t('LoadoutBuilder.NoBuildsFoundExplainer.LowerBoundsFailed'),
         suggestions: _.compact([
-          !autoAssignStatMods &&
+          !params.autoStatMods &&
             $featureFlags.loAutoStatMods && {
               id: 'hint1',
               contents: (
@@ -354,7 +351,7 @@ export default function NoBuildsFoundExplainer({
                 </button>
               ),
             },
-          autoAssignStatMods &&
+          params.autoStatMods &&
             lockedModMap.generalMods.length > 0 && {
               id: 'removeGeneralMods',
               contents: (

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -314,7 +314,7 @@ export default memo(function LockArmorAndPerks({
             subclass={subclass.item}
             socketOverrides={subclass.loadoutItem.socketOverrides ?? emptyObject()}
             onAccept={(socketOverrides) =>
-              lbDispatch({ type: 'updateSubclassSocketOverrides', socketOverrides })
+              lbDispatch({ type: 'updateSubclassSocketOverrides', socketOverrides, subclass })
             }
             onClose={() => setShowSubclassOptionsPicker(false)}
           />

--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -244,7 +244,8 @@ export default memo(function LockArmorAndPerks({
                 onClose={
                   isAbility
                     ? undefined
-                    : () => lbDispatch({ type: 'removeSingleSubclassSocketOverride', plug })
+                    : () =>
+                        lbDispatch({ type: 'removeSingleSubclassSocketOverride', plug, subclass })
                 }
                 forClassType={selectedStore.classType}
               />

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -1,16 +1,13 @@
-import { StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { t } from 'app/i18next-t';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, dragHandleIcon } from 'app/shell/icons';
-import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React, { Dispatch, memo } from 'react';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
-import { statFiltersFromStatConstraints, statOrderFromStatConstraints } from '../loadout-params';
-import { ArmorStatHashes, MinMaxIgnored, StatRanges } from '../types';
+import { ArmorStatHashes, ResolvedStatConstraint, StatRanges } from '../types';
 import { statTierWithHalf } from '../utils';
 import styles from './TierSelect.m.scss';
 
@@ -23,28 +20,19 @@ const MinMaxSelect = memo(MinMaxSelectInner);
  * A selector that allows for choosing minimum and maximum stat ranges, plus reordering the stat priority.
  */
 export default function TierSelect({
-  statConstraints,
+  resolvedStatConstraints,
   statRangesFiltered,
   lbDispatch,
 }: {
-  statConstraints: StatConstraint[];
+  resolvedStatConstraints: ResolvedStatConstraint[];
   /** The ranges the stats could have gotten to INCLUDING stat filters and mod compatibility */
   statRangesFiltered?: Readonly<StatRanges>;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
   const defs = useD2Definitions()!;
-  const order = statOrderFromStatConstraints(statConstraints);
-  const stats = statFiltersFromStatConstraints(statConstraints);
 
-  const statDefs: { [statHash: number]: DestinyStatDefinition } = {};
-  for (const statHash of order) {
-    statDefs[statHash] = defs.Stat.get(statHash);
-  }
-
-  const handleTierChange = (
-    statHash: ArmorStatHashes,
-    changed: { min: number; max: number; ignored: boolean }
-  ) => lbDispatch({ type: 'statConstraintChanged', statHash: statHash, constraint: changed });
+  const handleTierChange = (constraint: ResolvedStatConstraint) =>
+    lbDispatch({ type: 'statConstraintChanged', constraint });
 
   const onDragEnd = (result: DropResult) => {
     // dropped outside the list
@@ -54,7 +42,7 @@ export default function TierSelect({
     const sourceIndex = result.source.index;
     lbDispatch({
       type: 'statOrderChanged',
-      statHash: order[sourceIndex],
+      statHash: resolvedStatConstraints[sourceIndex].statHash,
       sourceIndex,
       destinationIndex: result.destination.index,
     });
@@ -65,55 +53,51 @@ export default function TierSelect({
       <Droppable droppableId="droppable">
         {(provided) => (
           <div ref={provided.innerRef}>
-            {order.map((statHash, index) => (
-              <DraggableItem
-                key={statHash}
-                id={statHash.toString()}
-                index={index}
-                className={styles.row}
-                name={
-                  <span
-                    className={clsx(
-                      { [styles.ignored]: stats[statHash].ignored },
-                      styles.statDisplayInfo
-                    )}
-                  >
-                    <BungieImage
-                      className={styles.iconStat}
-                      src={statDefs[statHash].displayProperties.icon}
-                    />
-                    <span
-                      className={styles.statName}
-                      title={statDefs[statHash].displayProperties.name}
-                    >
-                      {statDefs[statHash].displayProperties.name}
+            {resolvedStatConstraints.map((c, index) => {
+              const statHash = c.statHash as ArmorStatHashes;
+              const statDef = defs.Stat.get(statHash);
+              return (
+                <DraggableItem
+                  key={statHash}
+                  id={statHash.toString()}
+                  index={index}
+                  className={styles.row}
+                  name={
+                    <span className={clsx({ [styles.ignored]: c.ignored }, styles.statDisplayInfo)}>
+                      <BungieImage
+                        className={styles.iconStat}
+                        src={statDef.displayProperties.icon}
+                      />
+                      <span className={styles.statName} title={statDef.displayProperties.name}>
+                        {statDef.displayProperties.name}
+                      </span>
                     </span>
+                  }
+                >
+                  <span className={styles.range}>
+                    {statRangesFiltered
+                      ? t('LoadoutBuilder.MaxTier', {
+                          tier: t('LoadoutBuilder.TierNumber', {
+                            tier: statTierWithHalf(statRangesFiltered[statHash].max),
+                          }),
+                        })
+                      : '-'}
                   </span>
-                }
-              >
-                <span className={styles.range}>
-                  {statRangesFiltered
-                    ? t('LoadoutBuilder.MaxTier', {
-                        tier: t('LoadoutBuilder.TierNumber', {
-                          tier: statTierWithHalf(statRangesFiltered[statHash].max),
-                        }),
-                      })
-                    : '-'}
-                </span>
-                <MinMaxSelect
-                  statHash={statHash}
-                  stat={stats[statHash]}
-                  type="Min"
-                  handleTierChange={handleTierChange}
-                />
-                <MinMaxSelect
-                  statHash={statHash}
-                  stat={stats[statHash]}
-                  type="Max"
-                  handleTierChange={handleTierChange}
-                />
-              </DraggableItem>
-            ))}
+                  <MinMaxSelect
+                    statHash={statHash}
+                    stat={c}
+                    type="min"
+                    handleTierChange={handleTierChange}
+                  />
+                  <MinMaxSelect
+                    statHash={statHash}
+                    stat={c}
+                    type="max"
+                    handleTierChange={handleTierChange}
+                  />
+                </DraggableItem>
+              );
+            })}
 
             {provided.placeholder}
           </div>
@@ -165,52 +149,44 @@ function MinMaxSelectInner({
   handleTierChange,
 }: {
   statHash: number;
-  type: 'Min' | 'Max';
+  type: 'min' | 'max';
   /** Filter config for a single stat */
-  stat: MinMaxIgnored;
-  handleTierChange: (
-    statHash: number,
-    changed: {
-      min: number;
-      max: number;
-      ignored: boolean;
-    }
-  ) => void;
+  stat: ResolvedStatConstraint;
+  handleTierChange: (changed: ResolvedStatConstraint) => void;
 }) {
   const min = 0;
   const max = 10;
   const ignored = stat.ignored;
 
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    let update: {
-      min: number;
-      max: number;
-      ignored: boolean;
-    };
+    let update: ResolvedStatConstraint;
     if (e.target.value === IGNORE || e.target.value === INCLUDE) {
       update = {
-        min: stat.min,
-        max: stat.max,
+        statHash,
+        minTier: stat.minTier,
+        maxTier: stat.maxTier,
         ignored: e.target.value === IGNORE,
       };
     } else {
       const value = parseInt(e.target.value, 10);
-      const lower = type.toLowerCase();
-      const opposite = lower === 'min' ? 'max' : 'min';
+      const lower = `${type}Tier` as const;
+      const opposite = lower === 'minTier' ? 'maxTier' : 'minTier';
       update = {
+        statHash,
         [lower]: value,
-        [opposite]: opposite === 'min' ? Math.min(stat.min, value) : Math.max(stat.max, value),
+        [opposite]:
+          opposite === 'minTier' ? Math.min(stat.minTier, value) : Math.max(stat.maxTier, value),
         ignored: false,
-      } as typeof update;
+      } as unknown as ResolvedStatConstraint;
     }
 
-    handleTierChange(statHash, update);
+    handleTierChange(update);
   }
 
-  const value = type === 'Min' ? Math.max(min, stat.min) : Math.min(max, stat.max);
+  const value = type === 'min' ? Math.max(min, stat.minTier) : Math.min(max, stat.maxTier);
   return (
     <select
-      className={type === 'Min' ? styles.minimum : styles.maximum}
+      className={type === 'min' ? styles.minimum : styles.maximum}
       value={ignored ? '-' : value}
       onChange={handleChange}
     >

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -166,15 +166,23 @@ function MinMaxSelectInner({
       };
     } else {
       const value = parseInt(e.target.value, 10);
-      const lower = `${type}Tier` as const;
-      const opposite = lower === 'minTier' ? 'maxTier' : 'minTier';
+      // Bump the opposite tier to match this value if necessary, to avoid them
+      // becoming inverted
+      const minMax =
+        type === 'min'
+          ? {
+              minTier: value,
+              maxTier: Math.max(stat.maxTier, value),
+            }
+          : {
+              minTier: Math.min(stat.minTier, value),
+              maxTier: value,
+            };
       update = {
+        ...minMax,
         statHash,
-        [lower]: value,
-        [opposite]:
-          opposite === 'minTier' ? Math.min(stat.minTier, value) : Math.max(stat.maxTier, value),
         ignored: false,
-      } as unknown as ResolvedStatConstraint;
+      };
     }
 
     handleTierChange(update);
@@ -188,7 +196,7 @@ function MinMaxSelectInner({
       onChange={handleChange}
     >
       <option disabled>
-        {t(`LoadoutBuilder.Select${type}`, { metadata: { keys: 'minMax' } })}
+        {type === 'min' ? t('LoadoutBuilder.SelectMin') : t('LoadoutBuilder.SelectMax')}
       </option>
       {!ignored &&
         _.range(min, max + 1).map((tier) => (

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -42,7 +42,6 @@ export default function TierSelect({
     const sourceIndex = result.source.index;
     lbDispatch({
       type: 'statOrderChanged',
-      statHash: resolvedStatConstraints[sourceIndex].statHash,
       sourceIndex,
       destinationIndex: result.destination.index,
     });

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -8,10 +8,7 @@ import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React, { memo } from 'react';
-import {
-  statFiltersFromLoadoutParameters,
-  statOrderFromLoadoutParameters,
-} from '../loadout-params';
+import { statFiltersFromStatConstraints, statOrderFromStatConstraints } from '../loadout-params';
 import { ArmorStatHashes, MinMaxIgnored, StatRanges } from '../types';
 import { statTierWithHalf } from '../utils';
 import styles from './TierSelect.m.scss';
@@ -35,8 +32,8 @@ export default function TierSelect({
   onStatConstraintsChanged: (constraints: StatConstraint[]) => void;
 }) {
   const defs = useD2Definitions()!;
-  const order = statOrderFromLoadoutParameters({ statConstraints });
-  const stats = statFiltersFromLoadoutParameters({ statConstraints });
+  const order = statOrderFromStatConstraints(statConstraints);
+  const stats = statFiltersFromStatConstraints(statConstraints);
   const handleTierChange = (
     statHash: ArmorStatHashes,
     changed: { min: number; max: number; ignored: boolean }

--- a/src/app/loadout-builder/filter/TierSelect.tsx
+++ b/src/app/loadout-builder/filter/TierSelect.tsx
@@ -162,9 +162,7 @@ function MinMaxSelectInner({
     let update: ResolvedStatConstraint;
     if (e.target.value === IGNORE || e.target.value === INCLUDE) {
       update = {
-        statHash,
-        minTier: stat.minTier,
-        maxTier: stat.maxTier,
+        ...stat,
         ignored: e.target.value === IGNORE,
       };
     } else {

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -1,4 +1,4 @@
-import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore, statSourceOrder } from 'app/inventory/store-types';
@@ -34,7 +34,7 @@ export default memo(function GeneratedSet({
   lockedMods,
   pinnedItems,
   statOrder,
-  enabledStats,
+  statConstraints,
   modStatChanges,
   loadouts,
   lbDispatch,
@@ -49,7 +49,7 @@ export default memo(function GeneratedSet({
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
   statOrder: ArmorStatHashes[];
-  enabledStats: Set<number>;
+  statConstraints: StatConstraint[];
   modStatChanges: ModStatChanges;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -152,7 +152,7 @@ export default memo(function GeneratedSet({
         getStatsBreakdown={getStatsBreakdownOnce}
         maxPower={getPower(displayedItems)}
         statOrder={statOrder}
-        enabledStats={enabledStats}
+        statConstraints={statConstraints}
         boostedStats={boostedStats}
         existingLoadoutName={existingLoadout?.name}
         subclass={subclass}

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -1,4 +1,4 @@
-import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore, statSourceOrder } from 'app/inventory/store-types';
@@ -15,7 +15,14 @@ import { t } from 'i18next';
 import _ from 'lodash';
 import { Dispatch, memo, useMemo } from 'react';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
-import { ArmorEnergyRules, ArmorSet, ArmorStatHashes, ModStatChanges, PinnedItems } from '../types';
+import {
+  ArmorEnergyRules,
+  ArmorSet,
+  ArmorStatHashes,
+  ModStatChanges,
+  PinnedItems,
+  ResolvedStatConstraint,
+} from '../types';
 import { getPower } from '../utils';
 import styles from './GeneratedSet.m.scss';
 import GeneratedSetButtons from './GeneratedSetButtons';
@@ -33,8 +40,7 @@ export default memo(function GeneratedSet({
   selectedStore,
   lockedMods,
   pinnedItems,
-  statOrder,
-  statConstraints,
+  resolvedStatConstraints,
   modStatChanges,
   loadouts,
   lbDispatch,
@@ -48,8 +54,7 @@ export default memo(function GeneratedSet({
   selectedStore: DimStore;
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
-  statOrder: ArmorStatHashes[];
-  statConstraints: StatConstraint[];
+  resolvedStatConstraints: ResolvedStatConstraint[];
   modStatChanges: ModStatChanges;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -151,8 +156,7 @@ export default memo(function GeneratedSet({
         stats={set.stats}
         getStatsBreakdown={getStatsBreakdownOnce}
         maxPower={getPower(displayedItems)}
-        statOrder={statOrder}
-        statConstraints={statConstraints}
+        resolvedStatConstraints={resolvedStatConstraints}
         boostedStats={boostedStats}
         existingLoadoutName={existingLoadout?.name}
         subclass={subclass}

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -119,11 +119,11 @@ export default memo(function GeneratedSet({
   const boostedStats = useMemo(
     () =>
       new Set(
-        statOrder.filter((hash) =>
+        armorStats.filter((hash) =>
           modStatChanges[hash].breakdown?.some((change) => change.source === 'runtimeEffect')
         )
       ),
-    [modStatChanges, statOrder]
+    [modStatChanges]
   );
 
   // Distribute our automatically picked mods across the items so that item components

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,4 +1,4 @@
-import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { WindowVirtualList } from 'app/dim-ui/VirtualList';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
@@ -21,7 +21,7 @@ export default function GeneratedSets({
   sets,
   subclass,
   statOrder,
-  enabledStats,
+  statConstraints,
   modStatChanges,
   loadouts,
   lbDispatch,
@@ -35,7 +35,7 @@ export default function GeneratedSets({
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
   statOrder: number[];
-  enabledStats: Set<number>;
+  statConstraints: StatConstraint[];
   modStatChanges: ModStatChanges;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -46,8 +46,7 @@ export default function GeneratedSets({
   const halfTierMods = useHalfTierMods(
     selectedStore.id,
     Boolean(params.autoStatMods),
-    statOrder,
-    enabledStats
+    statConstraints
   );
 
   return (
@@ -66,7 +65,7 @@ export default function GeneratedSets({
           pinnedItems={pinnedItems}
           lbDispatch={lbDispatch}
           statOrder={statOrder}
-          enabledStats={enabledStats}
+          statConstraints={statConstraints}
           modStatChanges={modStatChanges}
           loadouts={loadouts}
           params={params}
@@ -87,8 +86,7 @@ export default function GeneratedSets({
 function useHalfTierMods(
   selectedStoreId: string,
   autoStatMods: boolean,
-  statOrder: ArmorStatHashes[],
-  enabledStats: Set<ArmorStatHashes>
+  statConstraints: StatConstraint[]
 ): PluggableInventoryItemDefinition[] {
   // Info about stat mods
   const autoMods = useAutoMods(selectedStoreId);
@@ -98,10 +96,10 @@ function useHalfTierMods(
       autoStatMods
         ? emptyArray()
         : _.compact(
-            statOrder.map(
-              (statHash) => enabledStats.has(statHash) && autoMods.generalMods[statHash]?.minorMod
+            statConstraints.map(
+              (s) => autoMods.generalMods[s.statHash as ArmorStatHashes]?.minorMod
             )
           ),
-    [autoMods.generalMods, enabledStats, autoStatMods, statOrder]
+    [autoMods.generalMods, statConstraints, autoStatMods]
   );
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,8 +1,4 @@
-import {
-  LoadoutParameters,
-  StatConstraint,
-  defaultLoadoutParameters,
-} from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { WindowVirtualList } from 'app/dim-ui/VirtualList';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
@@ -55,7 +51,7 @@ export default function GeneratedSets({
   const halfTierMods = useHalfTierMods(
     selectedStore.id,
     Boolean(params.autoStatMods),
-    params.statConstraints ?? defaultLoadoutParameters.statConstraints!
+    params.statConstraints!
   );
 
   return (

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,4 +1,8 @@
-import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
+import {
+  LoadoutParameters,
+  StatConstraint,
+  defaultLoadoutParameters,
+} from '@destinyitemmanager/dim-api-types';
 import { WindowVirtualList } from 'app/dim-ui/VirtualList';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
@@ -8,7 +12,14 @@ import _ from 'lodash';
 import { Dispatch, useMemo } from 'react';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { useAutoMods } from '../process/useProcess';
-import { ArmorEnergyRules, ArmorSet, ArmorStatHashes, ModStatChanges, PinnedItems } from '../types';
+import {
+  ArmorEnergyRules,
+  ArmorSet,
+  ArmorStatHashes,
+  ModStatChanges,
+  PinnedItems,
+  ResolvedStatConstraint,
+} from '../types';
 import GeneratedSet, { containerClass } from './GeneratedSet';
 
 /**
@@ -20,8 +31,7 @@ export default function GeneratedSets({
   selectedStore,
   sets,
   subclass,
-  statOrder,
-  statConstraints,
+  resolvedStatConstraints,
   modStatChanges,
   loadouts,
   lbDispatch,
@@ -34,8 +44,7 @@ export default function GeneratedSets({
   subclass: ResolvedLoadoutItem | undefined;
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
-  statOrder: number[];
-  statConstraints: StatConstraint[];
+  resolvedStatConstraints: ResolvedStatConstraint[];
   modStatChanges: ModStatChanges;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -46,7 +55,7 @@ export default function GeneratedSets({
   const halfTierMods = useHalfTierMods(
     selectedStore.id,
     Boolean(params.autoStatMods),
-    statConstraints
+    params.statConstraints ?? defaultLoadoutParameters.statConstraints!
   );
 
   return (
@@ -64,8 +73,7 @@ export default function GeneratedSets({
           lockedMods={lockedMods}
           pinnedItems={pinnedItems}
           lbDispatch={lbDispatch}
-          statOrder={statOrder}
-          statConstraints={statConstraints}
+          resolvedStatConstraints={resolvedStatConstraints}
           modStatChanges={modStatChanges}
           loadouts={loadouts}
           params={params}

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -4,6 +4,7 @@ import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { armorStats } from 'app/search/d2-known-values';
 import { AppIcon, powerIndicatorIcon } from 'app/shell/icons';
 import StatTooltip from 'app/store-stats/StatTooltip';
 import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
@@ -42,7 +43,7 @@ function SetStats({
 }) {
   const defs = useD2Definitions()!;
   const statDefs: { [statHash: number]: DestinyStatDefinition } = {};
-  for (const statHash of statOrder) {
+  for (const statHash of armorStats) {
     statDefs[statHash] = defs.Stat.get(statHash);
   }
   const totalTier = calculateTotalTier(stats);

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -1,3 +1,4 @@
+import { StatConstraint } from '@destinyitemmanager/dim-api-types';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
@@ -20,8 +21,8 @@ function SetStats({
   stats,
   getStatsBreakdown,
   maxPower,
+  statConstraints,
   statOrder,
-  enabledStats,
   boostedStats,
   className,
   existingLoadoutName,
@@ -32,7 +33,7 @@ function SetStats({
   getStatsBreakdown: () => ModStatChanges;
   maxPower: number;
   statOrder: ArmorStatHashes[];
-  enabledStats: Set<ArmorStatHashes>;
+  statConstraints: StatConstraint[];
   boostedStats: Set<ArmorStatHashes>;
   className?: string;
   existingLoadoutName?: string;
@@ -45,7 +46,7 @@ function SetStats({
     statDefs[statHash] = defs.Stat.get(statHash);
   }
   const totalTier = calculateTotalTier(stats);
-  const enabledTier = sumEnabledStats(stats, enabledStats);
+  const enabledTier = sumEnabledStats(stats, statConstraints);
 
   // Fill in info about selected items / subclass options for Clarity character stats
   const equippedHashes = new Set<number>();
@@ -91,7 +92,7 @@ function SetStats({
           )}
         >
           <Stat
-            isActive={enabledStats.has(statHash)}
+            isActive={statConstraints.some((s) => s.statHash === statHash)}
             isBoosted={boostedStats.has(statHash)}
             stat={statDefs[statHash]}
             value={stats[statHash]}

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -7,13 +7,11 @@ import { statTier } from '../utils';
 
 function getComparatorsForMatchedSetSorting(statConstraints: StatConstraint[]) {
   const comparators: Comparator<ArmorSet>[] = [
-    compareBy((s: ArmorSet) => -sumEnabledStats(s.stats, statConstraints)),
+    compareBy((s) => -sumEnabledStats(s.stats, statConstraints)),
   ];
 
   for (const constraint of statConstraints) {
-    comparators.push(
-      compareBy((s: ArmorSet) => -statTier(s.stats[constraint.statHash as ArmorStatHashes]))
-    );
+    comparators.push(compareBy((s) => -statTier(s.stats[constraint.statHash as ArmorStatHashes])));
   }
   return comparators;
 }

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -1,21 +1,19 @@
+import { StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { armorStats } from 'app/search/d2-known-values';
 import { chainComparator, Comparator, compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
 import { ArmorSet, ArmorStatHashes, ArmorStats } from '../types';
 import { statTier } from '../utils';
 
-function getComparatorsForMatchedSetSorting(
-  statOrder: ArmorStatHashes[],
-  enabledStats: Set<number>
-) {
+function getComparatorsForMatchedSetSorting(statConstraints: StatConstraint[]) {
   const comparators: Comparator<ArmorSet>[] = [
-    compareBy((s: ArmorSet) => -sumEnabledStats(s.stats, enabledStats)),
+    compareBy((s: ArmorSet) => -sumEnabledStats(s.stats, statConstraints)),
   ];
 
-  for (const statHash of statOrder) {
-    if (enabledStats.has(statHash)) {
-      comparators.push(compareBy((s: ArmorSet) => -statTier(s.stats[statHash])));
-    }
+  for (const constraint of statConstraints) {
+    comparators.push(
+      compareBy((s: ArmorSet) => -statTier(s.stats[constraint.statHash as ArmorStatHashes]))
+    );
   }
   return comparators;
 }
@@ -25,12 +23,8 @@ function getComparatorsForMatchedSetSorting(
  * but it may do a final pass over the returned sets to add more stat mods and that requires us
  * to sort again. So just do that here.
  */
-export function sortGeneratedSets(
-  sets: ArmorSet[],
-  statOrder: ArmorStatHashes[],
-  enabledStats: Set<number>
-): ArmorSet[] {
-  return sets.sort(chainComparator(...getComparatorsForMatchedSetSorting(statOrder, enabledStats)));
+export function sortGeneratedSets(sets: ArmorSet[], statConstraints: StatConstraint[]): ArmorSet[] {
+  return sets.sort(chainComparator(...getComparatorsForMatchedSetSorting(statConstraints)));
 }
 
 /**
@@ -41,8 +35,8 @@ export function calculateTotalTier(stats: ArmorStats) {
   return _.sum(Object.values(stats).map(statTier));
 }
 
-export function sumEnabledStats(stats: ArmorStats, enabledStats: Set<number>) {
+export function sumEnabledStats(stats: ArmorStats, statConstraints: StatConstraint[]) {
   return _.sumBy(armorStats, (statHash) =>
-    enabledStats.has(statHash) ? statTier(stats[statHash]) : 0
+    statConstraints.some((s) => s.statHash === statHash) ? statTier(stats[statHash]) : 0
   );
 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -302,7 +302,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
           loadoutParameters = { ...loadoutParameters, statConstraints: constraints };
         }
 
-        loadout = setLoadoutParameters(loadoutParameters)(state.loadout);
+        loadout = setLoadoutParameters(loadoutParameters)(loadout);
 
         return {
           ...state,

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -245,7 +245,8 @@ type LoadoutBuilderConfigAction =
       subclass: ResolvedLoadoutItem;
     }
   | { type: 'lockExotic'; lockedExoticHash: number }
-  | { type: 'removeLockedExotic' };
+  | { type: 'removeLockedExotic' }
+  | { type: 'setSearchQuery'; query: string };
 
 type LoadoutBuilderUIAction =
   | { type: 'openModPicker'; plugCategoryHashWhitelist?: number[] }
@@ -513,6 +514,11 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
         return {
           ...state,
           loadout: setLoadoutParameters({ autoStatMods: action.autoStatMods })(state.loadout),
+        };
+      case 'setSearchQuery':
+        return {
+          ...state,
+          loadout: setLoadoutParameters({ query: action.query || undefined })(state.loadout),
         };
     }
   };

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -333,46 +333,15 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
       }
       case 'statConstraintChanged': {
         const { constraint } = action;
-        const newStatConstraints = state.resolvedStatConstraints.map((s) => {
-          if (s.statHash !== constraint.statHash) {
-            return s;
-          }
-
-          if (constraint.ignored) {
-            return undefined;
-          }
-
-          const newStat = { ...s };
-          if (constraint.min > 0) {
-            newStat.minTier = constraint.min;
-          } else {
-            delete newStat.minTier;
-          }
-          if (constraint.max < 10) {
-            newStat.maxTier = constraint.max;
-          } else {
-            delete newStat.maxTier;
-          }
-          return newStat;
-        });
+        const newStatConstraints = state.resolvedStatConstraints.map((c) =>
+          c.statHash === constraint.statHash ? constraint : c
+        );
         return updateStatConstraints(state, newStatConstraints);
       }
       case 'statOrderChanged': {
-        const { destinationIndex, statHash } = action;
-        let { sourceIndex } = action;
-
-        const originalConstraints = state.loadout.parameters?.statConstraints ?? [];
-        let newStatConstraints = originalConstraints;
-        if (sourceIndex >= originalConstraints.length) {
-          newStatConstraints = [...originalConstraints, { statHash }];
-          sourceIndex = newStatConstraints.length - 1;
-        }
-        const newOrder = reorder(newStatConstraints, sourceIndex, destinationIndex);
-
-        return {
-          ...state,
-          loadout: setLoadoutParameters({ statConstraints: newOrder })(state.loadout),
-        };
+        const { sourceIndex, destinationIndex } = action;
+        const newOrder = reorder(state.resolvedStatConstraints, sourceIndex, destinationIndex);
+        return updateStatConstraints(state, newOrder);
       }
       case 'pinItem': {
         const { item } = action;

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -326,6 +326,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
         return {
           ...state,
           loadout,
+          resolvedStatConstraints: resolveStatConstraints(loadoutParameters.statConstraints!),
           selectedStoreId: action.store.id,
           // Also clear out pinned/excluded items
           pinnedItems: {},

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -236,7 +236,7 @@ type LoadoutBuilderConfigAction =
       savedStatConstraintsByClass: { [classType: number]: StatConstraint[] };
     }
   | { type: 'statConstraintChanged'; constraint: ResolvedStatConstraint }
-  | { type: 'statOrderChanged'; sourceIndex: number; destinationIndex: number; statHash: number }
+  | { type: 'statOrderChanged'; sourceIndex: number; destinationIndex: number }
   | {
       type: 'assumeArmorMasterworkChanged';
       assumeArmorMasterwork: AssumeArmorMasterwork | undefined;

--- a/src/app/loadout-builder/loadout-params.ts
+++ b/src/app/loadout-builder/loadout-params.ts
@@ -1,40 +1,16 @@
 /* Functions for dealing with the LoadoutParameters structure we save with loadouts and use to save and share LO settings. */
 
-import {
-  defaultLoadoutParameters,
-  LoadoutParameters,
-  StatConstraint,
-} from '@destinyitemmanager/dim-api-types';
+import { defaultLoadoutParameters, LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { armorStats } from 'app/search/d2-known-values';
 import _ from 'lodash';
-import { ArmorStatHashes, MinMaxIgnored, StatFilters } from './types';
+import { ArmorStatHashes, StatFilters } from './types';
 
 export function buildLoadoutParams(
   loadoutParameters: LoadoutParameters,
-  searchQuery: string,
-  statFilters: Readonly<{ [statType in ArmorStatHashes]: MinMaxIgnored }>,
-  statOrder: ArmorStatHashes[]
+  searchQuery: string
 ): LoadoutParameters {
   const params: LoadoutParameters = {
     ...loadoutParameters,
-    statConstraints: _.compact(
-      statOrder.map((statHash) => {
-        const minMax = statFilters[statHash];
-        if (minMax.ignored) {
-          return undefined;
-        }
-        const stat: StatConstraint = {
-          statHash,
-        };
-        if (minMax.min > 0) {
-          stat.minTier = minMax.min;
-        }
-        if (minMax.max < 10) {
-          stat.maxTier = minMax.max;
-        }
-        return stat;
-      })
-    ),
   };
 
   if (searchQuery) {

--- a/src/app/loadout-builder/loadout-params.ts
+++ b/src/app/loadout-builder/loadout-params.ts
@@ -1,6 +1,6 @@
 /* Functions for dealing with the LoadoutParameters structure we save with loadouts and use to save and share LO settings. */
 
-import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
+import { StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { armorStats } from 'app/search/d2-known-values';
 import _ from 'lodash';
 import { ArmorStatHashes, StatFilters } from './types';
@@ -17,8 +17,8 @@ export function statOrderFromStatConstraints(statConstraints: StatConstraint[]):
   });
 }
 
-export function statFiltersFromLoadoutParameters(params: LoadoutParameters): StatFilters {
-  const statConstraintsByStatHash = _.keyBy(params.statConstraints, (c) => c.statHash);
+export function statFiltersFromStatConstraints(statConstraints: StatConstraint[]): StatFilters {
+  const statConstraintsByStatHash = _.keyBy(statConstraints, (c) => c.statHash);
   return armorStats.reduce((memo, statHash) => {
     const c = statConstraintsByStatHash[statHash];
     memo[statHash] = c

--- a/src/app/loadout-builder/loadout-params.ts
+++ b/src/app/loadout-builder/loadout-params.ts
@@ -3,19 +3,7 @@
 import { StatConstraint, defaultLoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { armorStats } from 'app/search/d2-known-values';
 import _ from 'lodash';
-import { ArmorStatHashes, ResolvedStatConstraint } from './types';
-
-/**
- * Stat constraints are already in priority order, but they do not include
- * ignored stats. This fills in the ignored stats as well and returns a list of
- * armor stat hashes.
- */
-export function statOrderFromStatConstraints(statConstraints: StatConstraint[]): ArmorStatHashes[] {
-  return _.sortBy(armorStats, (h) => {
-    const index = statConstraints.findIndex((c) => c.statHash === h);
-    return index >= 0 ? index : 100;
-  });
-}
+import { ResolvedStatConstraint } from './types';
 
 /**
  * Stat constraints are already in priority order, but they do not include
@@ -27,7 +15,7 @@ export function resolveStatConstraints(
   const statConstraintsByStatHash = _.keyBy(statConstraints, (c) => c.statHash);
   const resolvedStatConstraints: ResolvedStatConstraint[] = armorStats.map((statHash) => {
     const c = statConstraintsByStatHash[statHash];
-    return { statHash, minTier: c?.minTier ?? 0, maxTier: c?.maxTier ?? 0, ignored: Boolean(c) };
+    return { statHash, minTier: c?.minTier ?? 0, maxTier: c?.maxTier ?? 10, ignored: !c };
   });
 
   return _.sortBy(resolvedStatConstraints, (h) => {

--- a/src/app/loadout-builder/loadout-params.ts
+++ b/src/app/loadout-builder/loadout-params.ts
@@ -1,34 +1,20 @@
 /* Functions for dealing with the LoadoutParameters structure we save with loadouts and use to save and share LO settings. */
 
-import { defaultLoadoutParameters, LoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { armorStats } from 'app/search/d2-known-values';
 import _ from 'lodash';
 import { ArmorStatHashes, StatFilters } from './types';
 
-export function buildLoadoutParams(
-  loadoutParameters: LoadoutParameters,
-  searchQuery: string
-): LoadoutParameters {
-  const params: LoadoutParameters = {
-    ...loadoutParameters,
-  };
-
-  if (searchQuery) {
-    params.query = searchQuery;
-  } else {
-    delete params.query;
-  }
-
-  return params;
-}
-
-export function statOrderFromLoadoutParameters(params: LoadoutParameters): ArmorStatHashes[] {
+/**
+ * Stat constraints are already in priority order, but they do not include
+ * ignored stats. This fills in the ignored stats as well and returns a list of
+ * armor stat hashes.
+ */
+export function statOrderFromStatConstraints(statConstraints: StatConstraint[]): ArmorStatHashes[] {
   return _.sortBy(armorStats, (h) => {
-    const index = (params.statConstraints ?? defaultLoadoutParameters.statConstraints!).findIndex(
-      (c) => c.statHash === h
-    );
+    const index = statConstraints.findIndex((c) => c.statHash === h);
     return index >= 0 ? index : 100;
-  }) as ArmorStatHashes[];
+  });
 }
 
 export function statFiltersFromLoadoutParameters(params: LoadoutParameters): StatFilters {

--- a/src/app/loadout-builder/process-utils.test.ts
+++ b/src/app/loadout-builder/process-utils.test.ts
@@ -27,7 +27,7 @@ import {
   mapAutoMods,
   mapDimItemToProcessItem,
 } from './process/mappers';
-import { MIN_LO_ITEM_ENERGY, MinMaxIgnored } from './types';
+import { MIN_LO_ITEM_ENERGY, ResolvedStatConstraint } from './types';
 import { statTier } from './utils';
 
 // We don't really pay attention to this in the tests but the parameter is needed
@@ -467,7 +467,7 @@ describe('process-utils optimal mods', () => {
 
   // use these for testing as they are reset after each test
   let items: ProcessItem[];
-  let statFilters: MinMaxIgnored[];
+  let resolvedStatConstraints: ResolvedStatConstraint[];
   let loSessionInfo: LoSessionInfo;
 
   beforeAll(async () => {
@@ -494,10 +494,11 @@ describe('process-utils optimal mods', () => {
     const autoModData = mapAutoMods(getAutoMods(defs, emptySet()));
     loSessionInfo = precalculateStructures(autoModData, [], [], true, armorStats);
 
-    statFilters = armorStats.map(() => ({
+    resolvedStatConstraints = armorStats.map((statHash) => ({
+      statHash,
       ignored: false,
-      max: 8,
-      min: 3,
+      maxTier: 8,
+      minTier: 3,
     }));
   });
 
@@ -531,7 +532,12 @@ describe('process-utils optimal mods', () => {
         isArtifice: i < numArtifice,
       });
     }
-    const statMods = pickOptimalStatMods(loSessionInfo, ourItems, setStats, statFilters)!;
+    const statMods = pickOptimalStatMods(
+      loSessionInfo,
+      ourItems,
+      setStats,
+      resolvedStatConstraints
+    )!;
     const finalStats = [...setStats];
     for (let i = 0; i < armorStats.length; i++) {
       finalStats[i] += statMods.bonusStats[i];

--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -298,7 +298,7 @@ function buildLessCostlyRelations(
 export function buildAutoModsMap(
   autoModOptions: AutoModData,
   availableGeneralStatMods: number,
-  statOrder: number[]
+  statOrder: ArmorStatHashes[]
 ): AutoModsMap {
   return {
     statCaches: Object.fromEntries(

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -1,6 +1,6 @@
 import { generatePermutationsOfFive } from 'app/loadout/mod-permutations';
 import _ from 'lodash';
-import { ArmorStatHashes, MinMaxIgnored } from '../types';
+import { ArmorStatHashes, ResolvedStatConstraint } from '../types';
 import { AutoModsMap, ModsPick, buildAutoModsMap, chooseAutoMods } from './auto-stat-mod-utils';
 import { AutoModData, ModAssignmentStatistics, ProcessItem, ProcessMod } from './types';
 
@@ -173,7 +173,7 @@ export function pickOptimalStatMods(
   info: LoSessionInfo,
   items: ProcessItem[],
   setStats: number[],
-  statFiltersInStatOrder: MinMaxIgnored[]
+  resolvedStatConstraints: ResolvedStatConstraint[]
 ): { mods: number[]; numBonusTiers: number; bonusStats: number[] } | undefined {
   const remainingEnergiesPerAssignment: number[][] = [];
 
@@ -220,17 +220,17 @@ export function pickOptimalStatMods(
   const explorationStats = [0, 0, 0, 0, 0, 0];
 
   for (let statIndex = setStats.length - 1; statIndex >= 0; statIndex--) {
-    const filter = statFiltersInStatOrder[statIndex];
+    const filter = resolvedStatConstraints[statIndex];
     if (!filter.ignored) {
       const value = setStats[statIndex];
-      if (filter.min > 0) {
-        const neededValue = filter.min * 10 - value;
+      if (filter.minTier > 0) {
+        const neededValue = filter.minTier * 10 - value;
         if (neededValue > 0) {
           // As per function preconditions, we know that we can hit these minimum stats
           explorationStats[statIndex] = neededValue;
         }
       }
-      maxAddedStats[statIndex] = filter.max * 10 - value;
+      maxAddedStats[statIndex] = filter.maxTier * 10 - value;
     }
   }
 

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -59,11 +59,14 @@ export function process(
   const pstart = performance.now();
 
   const modStatsInStatOrder = statOrder.map((h) => modStatTotals[h]);
-  const statFiltersInStatOrder: MinMaxIgnored[] = statOrder.map((h) => ({
-    min: statConstraints[h]?.minTier ?? 0,
-    max: statConstraints[h]?.maxTier ?? 10,
-    ignored: !statConstraints[h],
-  }));
+  const statFiltersInStatOrder: MinMaxIgnored[] = statOrder.map((h) => {
+    const statConstraint = statConstraints.find((s) => s.statHash === h);
+    return {
+      min: statConstraint?.minTier ?? 0,
+      max: statConstraint?.maxTier ?? 10,
+      ignored: !statConstraint,
+    };
+  });
 
   // This stores the computed min and max value for each stat as we process all sets, so we
   // can display it on the stat filter dropdowns

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -1,5 +1,6 @@
 import { infoLog } from '../../utils/log';
 import {
+  ArmorStatHashes,
   ArmorStats,
   artificeStatBoost,
   LockableBucketHashes,
@@ -55,7 +56,7 @@ export function process(
 } {
   const pstart = performance.now();
 
-  const statOrder = resolvedStatConstraints.map(({ statHash }) => statHash);
+  const statOrder = resolvedStatConstraints.map(({ statHash }) => statHash as ArmorStatHashes);
   const modStatsInStatOrder = statOrder.map((h) => modStatTotals[h]);
 
   // This stores the computed min and max value for each stat as we process all sets, so we

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -1,13 +1,11 @@
-import { StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { infoLog } from '../../utils/log';
 import {
-  ArmorStatHashes,
   ArmorStats,
   artificeStatBoost,
   LockableBucketHashes,
   LockableBuckets,
   majorStatBoost,
-  MinMaxIgnored,
+  ResolvedStatConstraint,
   StatRanges,
 } from '../types';
 import {
@@ -39,9 +37,8 @@ export function process(
   modStatTotals: ArmorStats,
   /** Mods to add onto the sets */
   lockedMods: LockedProcessMods,
-  /** The user's chosen stat order, including disabled stats */
-  statOrder: ArmorStatHashes[],
-  statConstraints: StatConstraint[],
+  /** The user's chosen stat constraints, including disabled stats */
+  resolvedStatConstraints: ResolvedStatConstraint[],
   /** Ensure every set includes one exotic */
   anyExotic: boolean,
   /** Which artifice mods, large, and small stat mods are available */
@@ -58,15 +55,8 @@ export function process(
 } {
   const pstart = performance.now();
 
+  const statOrder = resolvedStatConstraints.map(({ statHash }) => statHash);
   const modStatsInStatOrder = statOrder.map((h) => modStatTotals[h]);
-  const statFiltersInStatOrder: MinMaxIgnored[] = statOrder.map((h) => {
-    const statConstraint = statConstraints.find((s) => s.statHash === h);
-    return {
-      min: statConstraint?.minTier ?? 0,
-      max: statConstraint?.maxTier ?? 10,
-      ignored: !statConstraint,
-    };
-  });
 
   // This stores the computed min and max value for each stat as we process all sets, so we
   // can display it on the stat filter dropdowns
@@ -243,9 +233,9 @@ export function process(
             let statRangeExceeded = false;
             for (let index = 0; index < 6; index++) {
               const tier = tiers[index];
-              const filter = statFiltersInStatOrder[index];
+              const filter = resolvedStatConstraints[index];
               if (!filter.ignored) {
-                if (tier > filter.max) {
+                if (tier > filter.maxTier) {
                   statRangeExceeded = true;
                 }
                 totalTier += tier;
@@ -281,10 +271,10 @@ export function process(
 
             // Check in which stats we're lacking
             for (let index = 0; index < 6; index++) {
-              const filter = statFiltersInStatOrder[index];
-              if (!filter.ignored && filter.min > 0) {
+              const filter = resolvedStatConstraints[index];
+              if (!filter.ignored && filter.minTier > 0) {
                 const value = stats[index];
-                const neededValue = filter.min * 10 - value;
+                const neededValue = filter.minTier * 10 - value;
                 if (neededValue > 0) {
                   totalNeededStats += neededValue;
                   neededStats[index] = neededValue;
@@ -332,12 +322,12 @@ export function process(
             for (let index = 0; index < 6; index++) {
               const tier = tiers[index];
               // Make each stat exactly one code unit so the string compares correctly
-              const filter = statFiltersInStatOrder[index];
+              const filter = resolvedStatConstraints[index];
               if (!filter.ignored) {
                 // using a power of 2 (16) instead of 11 is faster
                 tiersString += tier.toString(16);
 
-                if (stats[index] < filter.max * 10) {
+                if (stats[index] < filter.maxTier * 10) {
                   pointsNeededForTiers.push(
                     Math.ceil((10 - (stats[index] % 10)) / artificeStatBoost)
                   );
@@ -405,7 +395,7 @@ export function process(
       precalculatedInfo,
       armor,
       stats,
-      statFiltersInStatOrder
+      resolvedStatConstraints
     )!;
 
     const armorOnlyStats: Partial<ArmorStats> = {};

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -1,4 +1,4 @@
-import { TagValue } from '@destinyitemmanager/dim-api-types';
+import { StatConstraint, TagValue } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { getTagSelector, unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
@@ -18,11 +18,11 @@ import { ProcessItem, ProcessItemsByBucket, ProcessStatistics } from '../process
 import {
   ArmorEnergyRules,
   ArmorSet,
+  ArmorStatHashes,
   ItemGroup,
   ItemsByBucket,
   LockableBucketHash,
   ModStatChanges,
-  StatFilters,
   StatRanges,
 } from '../types';
 import {
@@ -69,7 +69,7 @@ export function useProcess({
   modStatChanges,
   armorEnergyRules,
   statOrder,
-  statFilters,
+  statConstraints,
   anyExotic,
   autoStatMods,
 }: {
@@ -80,8 +80,8 @@ export function useProcess({
   subclass: ResolvedLoadoutItem | undefined;
   modStatChanges: ModStatChanges;
   armorEnergyRules: ArmorEnergyRules;
-  statOrder: number[];
-  statFilters: StatFilters;
+  statOrder: ArmorStatHashes[];
+  statConstraints: StatConstraint[];
   anyExotic: boolean;
   autoStatMods: boolean;
 }) {
@@ -172,7 +172,7 @@ export function useProcess({
         _.mapValues(modStatChanges, (stat) => stat.value),
         lockedProcessMods,
         statOrder,
-        statFilters,
+        statConstraints,
         anyExotic,
         autoModsData,
         autoStatMods,
@@ -212,7 +212,7 @@ export function useProcess({
     filteredItems,
     selectedStore.classType,
     selectedStore.id,
-    statFilters,
+    statConstraints,
     statOrder,
     anyExotic,
     subclass,

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -1,4 +1,4 @@
-import { StatConstraint, TagValue } from '@destinyitemmanager/dim-api-types';
+import { TagValue } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { getTagSelector, unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
@@ -18,11 +18,11 @@ import { ProcessItem, ProcessItemsByBucket, ProcessStatistics } from '../process
 import {
   ArmorEnergyRules,
   ArmorSet,
-  ArmorStatHashes,
   ItemGroup,
   ItemsByBucket,
   LockableBucketHash,
   ModStatChanges,
+  ResolvedStatConstraint,
   StatRanges,
 } from '../types';
 import {
@@ -68,8 +68,7 @@ export function useProcess({
   subclass,
   modStatChanges,
   armorEnergyRules,
-  statOrder,
-  statConstraints,
+  resolvedStatConstraints,
   anyExotic,
   autoStatMods,
 }: {
@@ -80,8 +79,7 @@ export function useProcess({
   subclass: ResolvedLoadoutItem | undefined;
   modStatChanges: ModStatChanges;
   armorEnergyRules: ArmorEnergyRules;
-  statOrder: ArmorStatHashes[];
-  statConstraints: StatConstraint[];
+  resolvedStatConstraints: ResolvedStatConstraint[];
   anyExotic: boolean;
   autoStatMods: boolean;
 }) {
@@ -151,7 +149,7 @@ export function useProcess({
 
       const groupedItems = mapItemsToGroups(
         items,
-        statOrder,
+        resolvedStatConstraints,
         armorEnergyRules,
         activityMods,
         bucketSpecificMods[bucketHash] || [],
@@ -171,8 +169,7 @@ export function useProcess({
         processItems,
         _.mapValues(modStatChanges, (stat) => stat.value),
         lockedProcessMods,
-        statOrder,
-        statConstraints,
+        resolvedStatConstraints,
         anyExotic,
         autoModsData,
         autoStatMods,
@@ -212,8 +209,7 @@ export function useProcess({
     filteredItems,
     selectedStore.classType,
     selectedStore.id,
-    statConstraints,
-    statOrder,
+    resolvedStatConstraints,
     anyExotic,
     subclass,
     armorEnergyRules,
@@ -289,7 +285,7 @@ const groupComparator = (getTag: (item: DimItem) => TagValue | undefined) =>
  */
 function mapItemsToGroups(
   items: readonly DimItem[],
-  statOrder: number[],
+  resolvedStatConstraints: ResolvedStatConstraint[],
   armorEnergyRules: ArmorEnergyRules,
   activityMods: PluggableInventoryItemDefinition[],
   modsForSlot: PluggableInventoryItemDefinition[],
@@ -332,7 +328,9 @@ function mapItemsToGroups(
     // Energy value is the same for all items.
 
     // Item stats are important for the stat results of a full set
-    const statValues: number[] = statOrder.map((s) => item.processItem.stats[s]);
+    const statValues: number[] = resolvedStatConstraints.map(
+      (c) => item.processItem.stats[c.statHash]
+    );
     // Energy capacity affects mod assignment
     const energyCapacity = item.processItem.energy?.capacity || 0;
     // Supported mod tags affect mod assignment

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -10,12 +10,6 @@ export interface MinMax {
   max: number;
 }
 
-export interface MinMaxIgnored {
-  min: number;
-  max: number;
-  ignored: boolean;
-}
-
 /**
  * Normally stat constraints are simply missing if ignored - the resolved
  * version still exists but has an ignored flag. Also, values cannot be undefined.

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -1,4 +1,4 @@
-import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
+import { AssumeArmorMasterwork, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { DimCharacterStat } from 'app/inventory/store-types';
 import { armorBuckets } from 'app/search/d2-known-values';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
@@ -13,6 +13,14 @@ export interface MinMax {
 export interface MinMaxIgnored {
   min: number;
   max: number;
+  ignored: boolean;
+}
+
+/**
+ * Normally stat constraints are simply missing if ignored - the resolved
+ * version still exists but has an ignored flag. Also, values cannot be undefined.
+ */
+export interface ResolvedStatConstraint extends Required<StatConstraint> {
   ignored: boolean;
 }
 
@@ -100,7 +108,6 @@ export type ArmorStatHashes =
   | StatHashes.Strength;
 
 export type StatRanges = { [statHash in ArmorStatHashes]: MinMax };
-export type StatFilters = { [statHash in ArmorStatHashes]: MinMaxIgnored };
 export type ArmorStats = { [statHash in ArmorStatHashes]: number };
 
 /**

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -89,15 +89,14 @@ export function addItem(
       const dupe = draftLoadout.items[dupeIndex];
       if (item.maxStackSize > 1) {
         // The item is already here but we'd like to add more of it (only D1 loadouts hold stackables)
-        const increment = Math.min(dupe.amount + item.amount, item.maxStackSize) - dupe.amount;
-        dupe.amount += increment;
+        loadoutItem.amount += Math.min(dupe.amount + item.amount, item.maxStackSize);
       }
-      // No need for further modifications so we bail out
-      return;
+      // Remove the dupe, we'll replace it with the new item
+      draftLoadout.items.splice(dupeIndex, 1);
     }
 
     const typeInventory = loadoutItemsInBucket(defs, draftLoadout, item.bucket.hash);
-    if (typeInventory.length >= maxSlots) {
+    if (dupeIndex === -1 && typeInventory.length >= maxSlots && !singular) {
       // We're already full
       errorLog('loadouts', "Can't add", item);
       showNotification({

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -304,7 +304,7 @@ export function equipItem(
 
 export function applySocketOverrides(
   { loadoutItem: searchLoadoutItem }: ResolvedLoadoutItem,
-  socketOverrides: SocketOverrides
+  socketOverrides: SocketOverrides | undefined
 ): LoadoutUpdateFunction {
   return produce((draftLoadout) => {
     // TODO: it might be nice if we just assigned a unique ID to every loadout item just for in-memory ops like deleting

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -832,11 +832,11 @@ const oldToNewMod: HashLookup<number> = {
  */
 export function resolveLoadoutModHashes(
   defs: D2ManifestDefinitions | undefined,
-  modHashes: number[],
+  modHashes: number[] | undefined,
   unlockedPlugs: Set<number>
 ) {
   const mods: ResolvedLoadoutMod[] = [];
-  if (defs) {
+  if (defs && modHashes) {
     for (const originalModHash of modHashes) {
       const migratedModHash = oldToNewMod[originalModHash] ?? originalModHash;
       const resolvedModHash = mapToAvailableModCostVariant(migratedModHash, unlockedPlugs);

--- a/src/app/settings/CharacterOrderEditor.tsx
+++ b/src/app/settings/CharacterOrderEditor.tsx
@@ -1,4 +1,5 @@
 import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
+import { reorder } from 'app/utils/util';
 import _ from 'lodash';
 import { useSelector } from 'react-redux';
 import { sortedStoresSelector } from '../inventory/selectors';
@@ -75,13 +76,4 @@ export default function CharacterOrderEditor({
       </Droppable>
     </DragDropContext>
   );
-}
-
-// a little function to help us with reordering the result
-function reorder<T>(list: T[], startIndex: number, endIndex: number): T[] {
-  const result = Array.from(list);
-  const [removed] = result.splice(startIndex, 1);
-  result.splice(endIndex, 0, removed);
-
-  return result;
 }

--- a/src/app/settings/SortOrderEditor.tsx
+++ b/src/app/settings/SortOrderEditor.tsx
@@ -1,5 +1,6 @@
 import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
 import { t } from 'app/i18next-t';
+import { reorder } from 'app/utils/util';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React, { memo } from 'react';
@@ -110,15 +111,6 @@ export default function SortOrderEditor({
       </Droppable>
     </DragDropContext>
   );
-}
-
-// a little function to help us with reordering the result
-function reorder<T>(list: T[], startIndex: number, endIndex: number): T[] {
-  const result = Array.from(list);
-  const [removed] = result.splice(startIndex, 1);
-  result.splice(endIndex, 0, removed);
-
-  return result;
 }
 
 function SortEditorItem(props: { index: number; item: SortProperty }) {

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -124,3 +124,15 @@ export function uniqBy<T, K>(data: Iterable<T>, iteratee: (input: T) => K): T[] 
   }
   return result;
 }
+
+/**
+ * Immutably reorder a list by moving an element at index `startIndex` to
+ * `endIndex`. Helpful for drag and drop. Returns a copy of the initial list.
+ */
+export function reorder<T>(list: T[], startIndex: number, endIndex: number): T[] {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+
+  return result;
+}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -579,6 +579,7 @@
     "Filter": "Filters",
     "IncludeVendorItems": "Include Vendor items",
     "Legendary": "Legendary",
+    "LoadoutName": "Optimized Loadout",
     "LockEquipped": "Pin equipped",
     "LockItem": "Pin item",
     "MaxTier": "Max {{tier}}",


### PR DESCRIPTION
This switches from using *pieces* of a loadout to using an entire full loadout for the LO's state. Along the way I was able to reuse some of the loadout drawer reducer functions, and clean out some uses of derivations of `statConstraints`. This is one more step in making the loadout optimizer always work on optimizing a real loadout, whether that's a brand new loadout or one that already exists.

One bit that frustrated me is that my decision to represent ignored stats by omitting them from `statConstraints` really wasn't great, as we lose information about things like the order of ignored stats. This shows up as a slight functionality regression. I was thinking that we might adopt the data model from #8841 and instead represent them with `priority: StatPriority.Ignored`. Until we do that, I might end up needing to maintain a separate copy of `statConstraints` in the LO state to make tracking the full stat preferences work better.