### PR TITLE
Allow Armory search for extended collectibles (and set DimItem.collectibleHash for those reissues)

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -38,6 +38,7 @@ import extendedBreaker from 'data/d2/extended-breaker.json';
 import extendedFoundry from 'data/d2/extended-foundry.json';
 import extendedICH from 'data/d2/extended-ich.json';
 import { BucketHashes, ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import extraItemCollectibles from 'data/d2/unreferenced-collections-items.json';
 import _ from 'lodash';
 import memoizeOne from 'memoize-one';
 import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
@@ -56,6 +57,10 @@ import { buildObjectives, isTrialsPassage, isWinsObjective } from './objectives'
 import { buildPatternInfo } from './patterns';
 import { buildSockets } from './sockets';
 import { buildStats } from './stats';
+
+const extraItemsToCollectibles = _.mapValues(_.invert(extraItemCollectibles), (val) =>
+  parseInt(val, 10)
+);
 
 const collectiblesByItemHash = memoizeOne(
   (Collectible: ReturnType<D2ManifestDefinitions['Collectible']['getAll']>) =>
@@ -390,7 +395,7 @@ export function makeItem(
     itemDef.iconWatermarkShelved ||
     undefined;
 
-  const collectibleHash = itemDef.collectibleHash;
+  const collectibleHash = itemDef.collectibleHash ?? extraItemsToCollectibles[itemDef.hash];
   // Do we need this now?
   const source = collectibleHash
     ? defs.Collectible.get(collectibleHash, itemDef.hash)?.sourceHash

--- a/src/app/records/PresentationNodeLeaf.tsx
+++ b/src/app/records/PresentationNodeLeaf.tsx
@@ -25,9 +25,9 @@ export default function PresentationNodeLeaf({
         <CollectiblesGrid>
           {node.collectibles.map((collectible) => (
             <Collectible
-              key={collectible.collectibleDef.hash}
+              key={collectible.key}
               collectible={collectible}
-              owned={Boolean(ownedItemHashes?.has(collectible.collectibleDef.itemHash))}
+              owned={Boolean(ownedItemHashes?.has(collectible.item.hash))}
             />
           ))}
         </CollectiblesGrid>

--- a/src/app/records/extra-collectibles.d.ts
+++ b/src/app/records/extra-collectibles.d.ts
@@ -1,0 +1,4 @@
+declare module 'data/d2/unreferenced-collections-items.json' {
+  const x: { readonly [collectibleHash: number]: number };
+  export default x;
+}

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -54,6 +54,7 @@ export interface DimCollectible {
   state: DestinyCollectibleState;
   collectibleDef: DestinyCollectibleDefinition;
   item: DimItem;
+  key: string;
   /**
    * true if this was artificially created by DIM.
    * some items are missing in collectibles, and we can fix that,
@@ -314,6 +315,7 @@ function toCollectibles(
           state,
           collectibleDef,
           item,
+          key: `${collectibleHash}-${itemHash}`,
           fake: fakeItemHash === itemHash,
         };
       });

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -290,7 +290,7 @@ function toCollectibles(
   const { defs, profileResponse } = itemCreationContext;
   return _.compact(
     collectibleChildren.flatMap(({ collectibleHash }) => {
-      const fakeItemHash = (extraItemCollectibles as NodeJS.Dict<number>)[collectibleHash];
+      const fakeItemHash = extraItemCollectibles[collectibleHash];
       const collectibleDef = defs.Collectible.get(collectibleHash);
       if (!collectibleDef) {
         return null;

--- a/src/app/search/armory-search.ts
+++ b/src/app/search/armory-search.ts
@@ -5,6 +5,7 @@ import { chainComparator, compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { getItemYear } from 'app/utils/item-utils';
 import { BucketHashes } from 'data/d2/generated-enums';
+import extraItemCollectibles from 'data/d2/unreferenced-collections-items.json';
 import _ from 'lodash';
 import memoizeOne from 'memoize-one';
 import { ArmorySearchItem, SearchItemType } from './autocomplete';
@@ -25,10 +26,14 @@ export const buildArmoryIndex = memoizeOne((defs: D2ManifestDefinitions, languag
   const results: ArmoryEntry[] = [];
   const invItemTable = defs.InventoryItem.getAll();
   const seasons = Object.values(defs.Season.getAll());
+  const additionalCollectibles = Object.values(extraItemCollectibles);
   for (const h in invItemTable) {
     const i = invItemTable[h];
     if (
-      i.collectibleHash &&
+      // A good heuristic for "is this weapon not totally irrelevant" is the presence of
+      // the exact hash in collections, but some reissues do no reference the latest collections
+      // version. `additionalCollectibles` patches those in.
+      (i.collectibleHash || additionalCollectibles.includes(i.hash)) &&
       i.displayProperties &&
       (i.inventory?.bucketTypeHash === BucketHashes.KineticWeapons ||
         i.inventory?.bucketTypeHash === BucketHashes.EnergyWeapons ||

--- a/src/app/search/armory-search.ts
+++ b/src/app/search/armory-search.ts
@@ -31,8 +31,9 @@ export const buildArmoryIndex = memoizeOne((defs: D2ManifestDefinitions, languag
     const i = invItemTable[h];
     if (
       // A good heuristic for "is this weapon not totally irrelevant" is the presence of
-      // the exact hash in collections, but some reissues do no reference the latest collections
-      // version. `additionalCollectibles` patches those in.
+      // the exact hash in collections, but some reissues do not reference the latest version
+      // in the collections entry (and thus the latest item has ni `collectibleHash`).
+      // Use `additionalCollectibles` to patch those in.
       (i.collectibleHash || additionalCollectibles.includes(i.hash)) &&
       i.displayProperties &&
       (i.inventory?.bucketTypeHash === BucketHashes.KineticWeapons ||


### PR DESCRIPTION
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/041771f5-6282-41df-b636-aa5797ebb673)

Also adds the correct source to the Armory window by falling back to the old collectibleHash in `DimItem`.