### PR TITLE
Further utilize the Loadout at the heart of LO state

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -586,7 +586,6 @@
     "Filter": "Filters",
     "IncludeVendorItems": "Include Vendor items",
     "Legendary": "Legendary",
-    "LoadoutName": "Optimized Loadout",
     "LockEquipped": "Pin equipped",
     "LockItem": "Pin item",
     "MissingClass": "Build is for: {{className}}",

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -451,7 +451,7 @@ export default memo(function LoadoutBuilder({
         {compareSet && (
           <Portal>
             <CompareLoadoutsDrawer
-              set={compareSet}
+              compareSet={compareSet}
               selectedStore={selectedStore}
               loadout={loadout}
               loadouts={loadouts}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -82,8 +82,6 @@ export default memo(function LoadoutBuilder({
   const savedStatConstraintsByClass = useSelector(savedLoStatConstraintsByClassSelector);
   const [includeVendorItems, setIncludeVendorItems] = useSetting('loIncludeVendorItems');
 
-  const optimizingLoadoutId = preloadedLoadout?.id;
-
   // All Loadout Optimizer state is managed via this hook/reducer
   const [
     {
@@ -458,11 +456,8 @@ export default memo(function LoadoutBuilder({
             <CompareLoadoutsDrawer
               set={compareSet}
               selectedStore={selectedStore}
+              loadout={loadout}
               loadouts={loadouts}
-              initialLoadoutId={optimizingLoadoutId}
-              subclass={subclass}
-              params={loadoutParameters}
-              notes={preloadedLoadout?.notes}
               lockedMods={modsToAssign}
               onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}
             />

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -398,6 +398,7 @@ export default memo(function LoadoutBuilder({
         )}
         {result && sortedSets?.length ? (
           <GeneratedSets
+            loadout={loadout}
             sets={sortedSets}
             subclass={subclass}
             lockedMods={result.mods}
@@ -407,9 +408,7 @@ export default memo(function LoadoutBuilder({
             resolvedStatConstraints={resolvedStatConstraints}
             modStatChanges={result.modStatChanges}
             loadouts={loadouts}
-            params={loadoutParameters}
             armorEnergyRules={result.armorEnergyRules}
-            notes={preloadedLoadout?.notes}
           />
         ) : (
           !processing && (

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -88,6 +88,7 @@ export default memo(function LoadoutBuilder({
     {
       loadout,
       resolvedStatConstraints,
+      existingLoadout,
       pinnedItems,
       excludedItems,
       selectedStoreId,
@@ -409,6 +410,7 @@ export default memo(function LoadoutBuilder({
             modStatChanges={result.modStatChanges}
             loadouts={loadouts}
             armorEnergyRules={result.armorEnergyRules}
+            existingLoadout={existingLoadout}
           />
         ) : (
           !processing && (

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -101,11 +101,11 @@ export default memo(function LoadoutBuilder({
 
   // TODO: if we're editing a loadout, grey out incompatible classes?
 
-  // TODO: bundle these together into an LO context?
   const loadoutParameters = loadout.parameters!;
   const lockedExoticHash = loadoutParameters.exoticArmorHash;
   const statConstraints = loadoutParameters.statConstraints!;
   const autoStatMods = Boolean(loadoutParameters.autoStatMods);
+  const assumeArmorMasterwork = loadoutParameters.assumeArmorMasterwork;
 
   const selectedStore = stores.find((store) => store.id === selectedStoreId)!;
   const classType = selectedStore.classType;
@@ -193,8 +193,8 @@ export default memo(function LoadoutBuilder({
     const armorEnergyRules: ArmorEnergyRules = {
       ...loDefaultArmorEnergyRules,
     };
-    if (loadoutParameters.assumeArmorMasterwork !== undefined) {
-      armorEnergyRules.assumeArmorMasterwork = loadoutParameters.assumeArmorMasterwork;
+    if (assumeArmorMasterwork !== undefined) {
+      armorEnergyRules.assumeArmorMasterwork = assumeArmorMasterwork;
     }
     const [items, filterInfo] = filterItems({
       defs,
@@ -209,7 +209,7 @@ export default memo(function LoadoutBuilder({
     });
     return [armorEnergyRules, items, filterInfo];
   }, [
-    loadoutParameters.assumeArmorMasterwork,
+    assumeArmorMasterwork,
     defs,
     armorItems,
     pinnedItems,
@@ -283,10 +283,7 @@ export default memo(function LoadoutBuilder({
         statRangesFiltered={result?.statRangesFiltered}
         lbDispatch={lbDispatch}
       />
-      <EnergyOptions
-        assumeArmorMasterwork={loadoutParameters.assumeArmorMasterwork}
-        lbDispatch={lbDispatch}
-      />
+      <EnergyOptions assumeArmorMasterwork={assumeArmorMasterwork} lbDispatch={lbDispatch} />
       <div className={styles.area}>
         <CheckButton
           onChange={setIncludeVendorItems}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -87,7 +87,7 @@ export default memo(function LoadoutBuilder({
     {
       loadout,
       resolvedStatConstraints,
-      existingLoadout,
+      isEditingExistingLoadout,
       pinnedItems,
       excludedItems,
       selectedStoreId,
@@ -406,7 +406,7 @@ export default memo(function LoadoutBuilder({
             modStatChanges={result.modStatChanges}
             loadouts={loadouts}
             armorEnergyRules={result.armorEnergyRules}
-            existingLoadout={existingLoadout}
+            isEditingExistingLoadout={isEditingExistingLoadout}
           />
         ) : (
           !processing && (

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -106,9 +106,9 @@ export default memo(function LoadoutBuilder({
   const statConstraints = loadoutParameters.statConstraints!;
   const autoStatMods = Boolean(loadoutParameters.autoStatMods);
   const assumeArmorMasterwork = loadoutParameters.assumeArmorMasterwork;
+  const classType = loadout.classType;
 
   const selectedStore = stores.find((store) => store.id === selectedStoreId)!;
-  const classType = selectedStore.classType;
   const loadouts = useRelevantLoadouts(selectedStore);
 
   const resolvedMods = useResolvedMods(defs, loadoutParameters.mods, selectedStoreId);

--- a/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
@@ -43,11 +43,14 @@ export default function CompareLoadoutsDrawer({
   loadouts,
   loadout,
   selectedStore,
-  set,
+  compareSet,
   lockedMods,
   onClose,
 }: {
-  set: ArmorSet;
+  compareSet: {
+    set: ArmorSet;
+    items: DimItem[];
+  };
   selectedStore: DimStore;
   loadouts: Loadout[];
   loadout: Loadout;
@@ -56,26 +59,16 @@ export default function CompareLoadoutsDrawer({
 }) {
   const defs = useD2Definitions()!;
   const dispatch = useThunkDispatch();
-
-  const setItems = set.armor.map((items) => items[0]);
+  const { set, items } = compareSet;
 
   const [selectedLoadout, setSelectedLoadout] = useState(() =>
-    chooseInitialLoadout(setItems, loadouts, loadout.id)
+    chooseInitialLoadout(items, loadouts, loadout.id)
   );
 
   // This probably isn't needed but I am being cautious as it iterates over the stores.
   const generatedLoadout = useMemo(
-    () =>
-      mergeLoadout(
-        defs,
-        selectedLoadout,
-        loadout,
-        set,
-        // TODO: pass along the displayItems
-        set.armor.map((a) => a[0]),
-        lockedMods
-      ),
-    [defs, selectedLoadout, loadout, set, lockedMods]
+    () => mergeLoadout(defs, selectedLoadout, loadout, set, items, lockedMods),
+    [defs, selectedLoadout, loadout, set, items, lockedMods]
   );
 
   const [confirmDialog, confirm] = useConfirm();

--- a/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
+++ b/src/app/loadout-builder/generated-sets/CompareLoadoutsDrawer.tsx
@@ -103,7 +103,6 @@ export default function CompareLoadoutsDrawer({
   initialLoadoutId,
   set,
   subclass,
-  classType,
   params,
   notes,
   lockedMods,
@@ -114,19 +113,17 @@ export default function CompareLoadoutsDrawer({
   loadouts: Loadout[];
   initialLoadoutId?: string;
   subclass: ResolvedLoadoutItem | undefined;
-  classType: DestinyClass;
   params: LoadoutParameters;
   notes?: string;
   lockedMods: PluggableInventoryItemDefinition[];
   onClose: () => void;
 }) {
   const dispatch = useThunkDispatch();
-  const usableLoadouts = loadouts.filter((l) => l.classType === classType);
 
   const setItems = set.armor.map((items) => items[0]);
 
   const [selectedLoadout, setSelectedLoadout] = useState<Loadout | undefined>(() =>
-    chooseInitialLoadout(setItems, usableLoadouts, initialLoadoutId)
+    chooseInitialLoadout(setItems, loadouts, initialLoadoutId)
   );
 
   const allItems = useSelector(allItemsSelector);
@@ -184,12 +181,12 @@ export default function CompareLoadoutsDrawer({
 
   const loadoutOptions = useMemo(
     () =>
-      usableLoadouts.map((l) => ({
+      loadouts.map((l) => ({
         key: l.id,
         value: l,
         content: l.name,
       })),
-    [usableLoadouts]
+    [loadouts]
   );
 
   // This is likely never to happen but since it is disconnected to the button its here for safety.

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -1,8 +1,7 @@
-import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore, statSourceOrder } from 'app/inventory/store-types';
-import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
+import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { fitMostMods } from 'app/loadout/mod-assignment-utils';
 import { getTotalModStatChanges } from 'app/loadout/stats';
 import { useD2Definitions } from 'app/manifest/selectors';
@@ -34,9 +33,8 @@ import SetStats from './SetStats';
  * but only the highest light set is displayed.
  */
 export default memo(function GeneratedSet({
+  originalLoadout,
   set,
-  subclass,
-  notes,
   selectedStore,
   lockedMods,
   pinnedItems,
@@ -44,13 +42,12 @@ export default memo(function GeneratedSet({
   modStatChanges,
   loadouts,
   lbDispatch,
-  params,
   halfTierMods,
   armorEnergyRules,
+  equippedHashes,
 }: {
+  originalLoadout: Loadout;
   set: ArmorSet;
-  subclass: ResolvedLoadoutItem | undefined;
-  notes?: string;
   selectedStore: DimStore;
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
@@ -58,9 +55,9 @@ export default memo(function GeneratedSet({
   modStatChanges: ModStatChanges;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
-  params: LoadoutParameters;
   halfTierMods: PluggableInventoryItemDefinition[];
   armorEnergyRules: ArmorEnergyRules;
+  equippedHashes: Set<number>;
 }) {
   const defs = useD2Definitions()!;
 
@@ -159,8 +156,7 @@ export default memo(function GeneratedSet({
         resolvedStatConstraints={resolvedStatConstraints}
         boostedStats={boostedStats}
         existingLoadoutName={existingLoadout?.name}
-        subclass={subclass}
-        exoticArmorHash={params.exoticArmorHash}
+        equippedHashes={equippedHashes}
       />
       <div className={styles.build}>
         <div className={styles.items}>
@@ -178,16 +174,13 @@ export default memo(function GeneratedSet({
           ))}
         </div>
         <GeneratedSetButtons
+          originalLoadout={originalLoadout}
           set={set}
           items={displayedItems}
-          subclass={subclass}
           store={selectedStore}
           canCompareLoadouts={canCompareLoadouts}
           halfTierMods={halfTierMods}
           lbDispatch={lbDispatch}
-          notes={notes}
-          params={params}
-          lockedMods={lockedMods}
         />
       </div>
     </>

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -145,9 +145,7 @@ export default memo(function GeneratedSet({
     return autoModHashes;
   });
 
-  const canCompareLoadouts =
-    set.armor.every((items) => items[0].classType === selectedStore.classType) &&
-    loadouts.some((l) => l.classType === selectedStore.classType);
+  const canCompareLoadouts = loadouts.length > 0;
 
   return (
     <>

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -45,6 +45,7 @@ export default memo(function GeneratedSet({
   halfTierMods,
   armorEnergyRules,
   equippedHashes,
+  existingLoadout,
 }: {
   originalLoadout: Loadout;
   set: ArmorSet;
@@ -58,10 +59,11 @@ export default memo(function GeneratedSet({
   halfTierMods: PluggableInventoryItemDefinition[];
   armorEnergyRules: ArmorEnergyRules;
   equippedHashes: Set<number>;
+  existingLoadout: boolean;
 }) {
   const defs = useD2Definitions()!;
 
-  let existingLoadout: Loadout | undefined;
+  let overlappingLoadout: Loadout | undefined;
   // Items are sorted by their energy capacity when grouping
   let displayedItems: DimItem[] = set.armor.map((items) => items[0]);
   const allSetItems = set.armor.flat();
@@ -72,7 +74,7 @@ export default memo(function GeneratedSet({
     const equippedLoadoutItems = loadout.items.filter((item) => item.equip);
     const intersection = _.intersectionBy(allSetItems, equippedLoadoutItems, (item) => item.id);
     if (intersection.length === set.armor.length) {
-      existingLoadout = loadout;
+      overlappingLoadout = loadout;
       // Replace the list of items to show with the ones that were from the matching loadout
       displayedItems = intersection;
       break;
@@ -155,7 +157,7 @@ export default memo(function GeneratedSet({
         maxPower={getPower(displayedItems)}
         resolvedStatConstraints={resolvedStatConstraints}
         boostedStats={boostedStats}
-        existingLoadoutName={existingLoadout?.name}
+        existingLoadoutName={overlappingLoadout?.name}
         equippedHashes={equippedHashes}
       />
       <div className={styles.build}>
@@ -177,7 +179,9 @@ export default memo(function GeneratedSet({
           originalLoadout={originalLoadout}
           set={set}
           items={displayedItems}
+          lockedMods={lockedMods}
           store={selectedStore}
+          existingLoadout={existingLoadout}
           canCompareLoadouts={canCompareLoadouts}
           halfTierMods={halfTierMods}
           lbDispatch={lbDispatch}

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -45,7 +45,7 @@ export default memo(function GeneratedSet({
   halfTierMods,
   armorEnergyRules,
   equippedHashes,
-  existingLoadout,
+  isEditingExistingLoadout,
 }: {
   originalLoadout: Loadout;
   set: ArmorSet;
@@ -59,7 +59,7 @@ export default memo(function GeneratedSet({
   halfTierMods: PluggableInventoryItemDefinition[];
   armorEnergyRules: ArmorEnergyRules;
   equippedHashes: Set<number>;
-  existingLoadout: boolean;
+  isEditingExistingLoadout: boolean;
 }) {
   const defs = useD2Definitions()!;
 
@@ -179,7 +179,7 @@ export default memo(function GeneratedSet({
           items={displayedItems}
           lockedMods={lockedMods}
           store={selectedStore}
-          existingLoadout={existingLoadout}
+          isEditingExistingLoadout={isEditingExistingLoadout}
           canCompareLoadouts={canCompareLoadouts}
           halfTierMods={halfTierMods}
           lbDispatch={lbDispatch}

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -77,7 +77,7 @@ export default function GeneratedSetButtons({
         <button
           type="button"
           className="dim-button"
-          onClick={() => lbDispatch({ type: 'openCompareDrawer', set })}
+          onClick={() => lbDispatch({ type: 'openCompareDrawer', set, items })}
         >
           {t('LoadoutBuilder.CompareLoadout')}
         </button>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -20,7 +20,7 @@ export default function GeneratedSetButtons({
   store,
   set,
   items,
-  existingLoadout,
+  isEditingExistingLoadout,
   lockedMods,
   canCompareLoadouts,
   halfTierMods,
@@ -32,7 +32,7 @@ export default function GeneratedSetButtons({
   /** The list of items to use - these are chosen from the set's options and match what's displayed. */
   items: DimItem[];
   lockedMods: PluggableInventoryItemDefinition[];
-  existingLoadout: boolean;
+  isEditingExistingLoadout: boolean;
   canCompareLoadouts: boolean;
   halfTierMods: PluggableInventoryItemDefinition[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -45,7 +45,7 @@ export default function GeneratedSetButtons({
   const openLoadout = () =>
     editLoadout(loadout(), store.id, {
       showClass: false,
-      isNew: !existingLoadout,
+      isNew: !isEditingExistingLoadout,
     });
 
   // Automatically equip items for this generated set to the active store

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -1,18 +1,15 @@
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { applyLoadout } from 'app/loadout-drawer/loadout-apply';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
-import { convertToLoadoutItem } from 'app/loadout-drawer/loadout-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import _ from 'lodash';
 import { Dispatch } from 'react';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
-import { ArmorSet, LockableBucketHashes } from '../types';
-import { statTier } from '../utils';
+import { ArmorSet } from '../types';
+import { updateLoadoutWithArmorSet } from '../updated-loadout';
 import styles from './GeneratedSetButtons.m.scss';
 
 /**
@@ -42,7 +39,7 @@ export default function GeneratedSetButtons({
 }) {
   const defs = useD2Definitions()!;
   const dispatch = useThunkDispatch();
-  const loadout = () => createLoadout(defs, originalLoadout, set, items, lockedMods);
+  const loadout = () => updateLoadoutWithArmorSet(defs, originalLoadout, set, items, lockedMods);
 
   // Opens the loadout menu for the generated set
   const openLoadout = () =>
@@ -95,41 +92,4 @@ export default function GeneratedSetButtons({
       )}
     </div>
   );
-}
-
-/**
- * Create a new loadout from the original prototype loadout, but with the armor items replaced with this loadout's armor.
- * Used for equipping or creating a new saved loadout.
- */
-function createLoadout(
-  defs: D2ManifestDefinitions,
-  originalLoadout: Loadout,
-  set: ArmorSet,
-  items: DimItem[],
-  lockedMods: PluggableInventoryItemDefinition[]
-): Loadout {
-  const data = {
-    tier: _.sumBy(Object.values(set.stats), statTier),
-  };
-  const existingItemsWithoutArmor = originalLoadout.items.filter(
-    (li) =>
-      !LockableBucketHashes.includes(
-        defs.InventoryItem.get(li.hash)?.inventory?.bucketTypeHash ?? 0
-      )
-  );
-  const loadoutItems = items.map((item) => convertToLoadoutItem(item, true));
-
-  // We need to add in this set's specific stat mods (artifice, general) to the list of user-chosen mods
-  // We can't start with the list of mods in the existing loadout parameters because lockedMods has filtered out
-  // invalid mods, mods that don't fit, and general mods if we're auto-assigning general mods.
-  const allMods = [...lockedMods.map((m) => m.hash), ...set.statMods];
-  return {
-    ...originalLoadout,
-    parameters: {
-      ...originalLoadout.parameters,
-      mods: allMods.length ? allMods : undefined,
-    },
-    items: [...existingItemsWithoutArmor, ...loadoutItems],
-    name: originalLoadout.name ?? t('Loadouts.Generated', data),
-  };
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -37,7 +37,7 @@ export default function GeneratedSets({
   lbDispatch,
   armorEnergyRules,
   loadout,
-  existingLoadout,
+  isEditingExistingLoadout,
 }: {
   selectedStore: DimStore;
   sets: readonly ArmorSet[];
@@ -50,7 +50,7 @@ export default function GeneratedSets({
   lbDispatch: Dispatch<LoadoutBuilderAction>;
   armorEnergyRules: ArmorEnergyRules;
   loadout: Loadout;
-  existingLoadout: boolean;
+  isEditingExistingLoadout: boolean;
 }) {
   const params = loadout.parameters!;
   const halfTierMods = useHalfTierMods(
@@ -95,7 +95,7 @@ export default function GeneratedSets({
           armorEnergyRules={armorEnergyRules}
           originalLoadout={loadout}
           equippedHashes={equippedHashes}
-          existingLoadout={existingLoadout}
+          isEditingExistingLoadout={isEditingExistingLoadout}
         />
       )}
     </WindowVirtualList>

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -37,6 +37,7 @@ export default function GeneratedSets({
   lbDispatch,
   armorEnergyRules,
   loadout,
+  existingLoadout,
 }: {
   selectedStore: DimStore;
   sets: readonly ArmorSet[];
@@ -49,6 +50,7 @@ export default function GeneratedSets({
   lbDispatch: Dispatch<LoadoutBuilderAction>;
   armorEnergyRules: ArmorEnergyRules;
   loadout: Loadout;
+  existingLoadout: boolean;
 }) {
   const params = loadout.parameters!;
   const halfTierMods = useHalfTierMods(
@@ -93,6 +95,7 @@ export default function GeneratedSets({
           armorEnergyRules={armorEnergyRules}
           originalLoadout={loadout}
           equippedHashes={equippedHashes}
+          existingLoadout={existingLoadout}
         />
       )}
     </WindowVirtualList>

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -18,10 +18,6 @@ import {
 } from '../types';
 import GeneratedSet, { containerClass } from './GeneratedSet';
 
-function getItemKey(index: number) {
-  return index;
-}
-
 /**
  * Renders the entire list of generated stat mixes, one per mix.
  */
@@ -79,7 +75,7 @@ export default function GeneratedSets({
       numElements={sets.length}
       estimatedSize={160}
       itemContainerClassName={containerClass}
-      getItemKey={getItemKey}
+      getItemKey={_.identity}
     >
       {(index) => (
         <GeneratedSet

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -1,7 +1,6 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
-import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, powerIndicatorIcon } from 'app/shell/icons';
 import StatTooltip from 'app/store-stats/StatTooltip';
@@ -16,7 +15,7 @@ import { calculateTotalTier, sumEnabledStats } from './utils';
  * Displays the overall tier and per-stat tier of a generated loadout set.
  */
 // TODO: would be a lot easier if this was just passed a Loadout or FullyResolvedLoadout...
-function SetStats({
+export default function SetStats({
   stats,
   getStatsBreakdown,
   maxPower,
@@ -24,8 +23,7 @@ function SetStats({
   boostedStats,
   className,
   existingLoadoutName,
-  subclass,
-  exoticArmorHash,
+  equippedHashes,
 }: {
   stats: ArmorStats;
   getStatsBreakdown: () => ModStatChanges;
@@ -34,8 +32,7 @@ function SetStats({
   boostedStats: Set<ArmorStatHashes>;
   className?: string;
   existingLoadoutName?: string;
-  subclass?: ResolvedLoadoutItem;
-  exoticArmorHash?: number;
+  equippedHashes: Set<number>;
 }) {
   const defs = useD2Definitions()!;
   const totalTier = calculateTotalTier(stats);
@@ -43,17 +40,6 @@ function SetStats({
     stats,
     resolvedStatConstraints.filter((c) => !c.ignored)
   );
-
-  // Fill in info about selected items / subclass options for Clarity character stats
-  const equippedHashes = new Set<number>();
-  if (exoticArmorHash) {
-    equippedHashes.add(exoticArmorHash);
-  }
-  if (subclass?.loadoutItem.socketOverrides) {
-    for (const hash of Object.values(subclass.loadoutItem.socketOverrides)) {
-      equippedHashes.add(hash);
-    }
-  }
 
   return (
     <div className={clsx(styles.container, className)}>
@@ -146,5 +132,3 @@ function Stat({
     </span>
   );
 }
-
-export default SetStats;

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -159,7 +159,7 @@ const lbConfigInit = ({
   const selectedStore = storeMatchingClass ?? getCurrentStore(stores)!;
   const selectedStoreId = selectedStore.id;
   const classType = selectedStore.classType;
-  let loadout = preloadedLoadout ?? newLoadout(t('LoadoutBuilder.LoadoutName'), [], classType);
+  let loadout = preloadedLoadout ?? newLoadout('', [], classType);
 
   // In order of increasing priority:
   // default parameters, global saved parameters, stat order for this class,

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -56,7 +56,14 @@ interface LoadoutBuilderUI {
     open: boolean;
     plugCategoryHashWhitelist?: number[];
   };
-  compareSet?: ArmorSet;
+  compareSet?: {
+    set: ArmorSet;
+    /**
+     * The items selected from the armor set's options to use. This isn't
+     * always just the first option for each bucket.
+     */
+    items: DimItem[];
+  };
 }
 
 interface LoadoutBuilderConfiguration {
@@ -271,7 +278,7 @@ type LoadoutBuilderConfigAction =
 type LoadoutBuilderUIAction =
   | { type: 'openModPicker'; plugCategoryHashWhitelist?: number[] }
   | { type: 'closeModPicker' }
-  | { type: 'openCompareDrawer'; set: ArmorSet }
+  | { type: 'openCompareDrawer'; set: ArmorSet; items: DimItem[] }
   | { type: 'closeCompareDrawer' };
 
 export type LoadoutBuilderAction =
@@ -283,7 +290,7 @@ export type LoadoutBuilderAction =
 function lbUIReducer(state: LoadoutBuilderUI, action: LoadoutBuilderUIAction) {
   switch (action.type) {
     case 'openCompareDrawer':
-      return { ...state, compareSet: action.set };
+      return { ...state, compareSet: { set: action.set, items: action.items } };
     case 'openModPicker':
       return {
         ...state,

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -77,7 +77,7 @@ interface LoadoutBuilderConfiguration {
    * have been saved (e.g. coming from a loadout share) but this still
    * distinguishes between "clean slate" and when we started with a loadout.
    */
-  existingLoadout: boolean;
+  isEditingExistingLoadout: boolean;
 
   /**
    * A copy of `loadout.parameters.statConstraints`, but with ignored stats
@@ -143,7 +143,7 @@ const lbConfigInit = ({
   const storeMatchingClass = pickBackingStore(stores, storeId, classTypeFromPreloadedLoadout);
   const initialLoadoutParameters = preloadedLoadout?.parameters;
 
-  const existingLoadout = Boolean(preloadedLoadout);
+  const isEditingExistingLoadout = Boolean(preloadedLoadout);
 
   // If we requested a specific class type but the user doesn't have it, we
   // need to pick some different store, but ensure that class-specific stuff
@@ -222,7 +222,7 @@ const lbConfigInit = ({
 
   return {
     loadout,
-    existingLoadout,
+    isEditingExistingLoadout,
     resolvedStatConstraints: resolveStatConstraints(loadoutParameters.statConstraints!),
     pinnedItems,
     excludedItems: emptyObject(),

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -306,7 +306,6 @@ function lbUIReducer(state: LoadoutBuilderUI, action: LoadoutBuilderUIAction) {
   }
 }
 
-// TODO: Move more logic inside the reducer
 function lbConfigReducer(defs: D2ManifestDefinitions) {
   return (
     state: LoadoutBuilderConfiguration,
@@ -314,17 +313,21 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
   ): LoadoutBuilderConfiguration => {
     switch (action.type) {
       case 'changeCharacter': {
+        const { store } = action;
+        const originalLoadout = state.loadout;
+        let loadout: Loadout = { ...originalLoadout, classType: store.classType };
+
         // Always remove the subclass
-        let loadout = clearSubclass(defs)(state.loadout);
+        loadout = clearSubclass(defs)(loadout);
 
         // And the exotic
         let loadoutParameters = {
-          ...state.loadout.parameters,
+          ...loadout.parameters,
           exoticArmorHash: undefined,
         };
 
         // Apply stat constraint preferences
-        const constraints = action.savedStatConstraintsByClass[action.store.classType];
+        const constraints = action.savedStatConstraintsByClass[store.classType];
         if (constraints) {
           loadoutParameters = { ...loadoutParameters, statConstraints: constraints };
         }
@@ -335,7 +338,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
           ...state,
           loadout,
           resolvedStatConstraints: resolveStatConstraints(loadoutParameters.statConstraints!),
-          selectedStoreId: action.store.id,
+          selectedStoreId: store.id,
           // Also clear out pinned/excluded items
           pinnedItems: {},
           excludedItems: {},

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -184,6 +184,7 @@ const lbConfigInit = ({
           pinnedItems[item.bucket.hash] = item;
         }
       }
+      // TODO: maybe swap in the updated item ID for items here, to make future manipulation easier
     }
 
     // If we load a loadout with an exotic, pre-fill the exotic armor selection

--- a/src/app/loadout-builder/updated-loadout.ts
+++ b/src/app/loadout-builder/updated-loadout.ts
@@ -9,8 +9,9 @@ import { ArmorSet, LockableBucketHashes } from './types';
 import { statTier } from './utils';
 
 /**
- * Create a new loadout from the original prototype loadout, but with the armor items replaced with this loadout's armor.
- * Used for equipping or creating a new saved loadout.
+ * Create a new loadout from the original prototype loadout, but with the armor
+ * items replaced with this loadout's armor. Used for equipping or creating a
+ * new saved loadout.
  */
 export function updateLoadoutWithArmorSet(
   defs: D2ManifestDefinitions,
@@ -37,9 +38,11 @@ export function updateLoadoutWithArmorSet(
   );
   const loadoutItems = items.map((item) => convertToLoadoutItem(item, true));
 
-  // We need to add in this set's specific stat mods (artifice, general) to the list of user-chosen mods
-  // We can't start with the list of mods in the existing loadout parameters because lockedMods has filtered out
-  // invalid mods, mods that don't fit, and general mods if we're auto-assigning general mods.
+  // We need to add in this set's specific stat mods (artifice, general) to the
+  // list of user-chosen mods We can't start with the list of mods in the
+  // existing loadout parameters because lockedMods has filtered out invalid
+  // mods, mods that don't fit, and general mods if we're auto-assigning general
+  // mods.
   const allMods = [...lockedMods.map((m) => m.hash), ...set.statMods];
   return {
     ...loadout,
@@ -53,8 +56,9 @@ export function updateLoadoutWithArmorSet(
 }
 
 /**
- * Create a new loadout from the original prototype loadout, but with the armor items replaced with this loadout's armor.
- * Used for equipping or creating a new saved loadout.
+ * Create a new loadout from an original prototype loadout, using mods and
+ * subclass from another loadout, and the items from an armor set. Used for the
+ * "compare loadout" drawer.
  */
 export function mergeLoadout(
   defs: D2ManifestDefinitions,

--- a/src/app/loadout-builder/updated-loadout.ts
+++ b/src/app/loadout-builder/updated-loadout.ts
@@ -1,0 +1,45 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { Loadout } from 'app/loadout-drawer/loadout-types';
+import { convertToLoadoutItem } from 'app/loadout-drawer/loadout-utils';
+import { t } from 'i18next';
+import _ from 'lodash';
+import { ArmorSet, LockableBucketHashes } from './types';
+import { statTier } from './utils';
+
+/**
+ * Create a new loadout from the original prototype loadout, but with the armor items replaced with this loadout's armor.
+ * Used for equipping or creating a new saved loadout.
+ */
+export function updateLoadoutWithArmorSet(
+  defs: D2ManifestDefinitions,
+  originalLoadout: Loadout,
+  set: ArmorSet,
+  items: DimItem[],
+  lockedMods: PluggableInventoryItemDefinition[]
+): Loadout {
+  const data = {
+    tier: _.sumBy(Object.values(set.stats), statTier),
+  };
+  const existingItemsWithoutArmor = originalLoadout.items.filter(
+    (li) =>
+      !LockableBucketHashes.includes(
+        defs.InventoryItem.get(li.hash)?.inventory?.bucketTypeHash ?? 0
+      )
+  );
+  const loadoutItems = items.map((item) => convertToLoadoutItem(item, true));
+
+  // We need to add in this set's specific stat mods (artifice, general) to the list of user-chosen mods
+  // We can't start with the list of mods in the existing loadout parameters because lockedMods has filtered out
+  // invalid mods, mods that don't fit, and general mods if we're auto-assigning general mods.
+  const allMods = [...lockedMods.map((m) => m.hash), ...set.statMods];
+  return {
+    ...originalLoadout,
+    parameters: {
+      ...originalLoadout.parameters,
+      mods: allMods.length ? allMods : undefined,
+    },
+    items: [...existingItemsWithoutArmor, ...loadoutItems],
+    name: originalLoadout.name ?? t('Loadouts.Generated', data),
+  };
+}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -579,7 +579,6 @@
     "Filter": "Filters",
     "IncludeVendorItems": "Include Vendor items",
     "Legendary": "Legendary",
-    "LoadoutName": "Optimized Loadout",
     "LockEquipped": "Pin equipped",
     "LockItem": "Pin item",
     "MaxTier": "Max {{tier}}",


### PR DESCRIPTION
This builds on my previous PR to make more use of the loadout at the center of LO state. This simplifies things by no longer having us re-assemble a loadout out of parts when saving.

There is an intentional behavior change - "Save loadout" now saves a modified version of the original loadout with the new armor items subbed in. I think this is much more intuitive than the existing behavior, though I haven't yet taken the step of displaying the context of the loadout being edited, so it's possible the user could forget what they're working on.
