### PR TITLE
Poll for bungie alerts only when we refresh profile data / every 10 minutes

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -6,7 +6,6 @@ import { saveAccountsToIndexedDB } from 'app/accounts/observers';
 import updateCSSVariables from 'app/css-variables';
 import { loadDimApiData } from 'app/dim-api/actions';
 import { saveItemInfosOnStateChange } from 'app/inventory/observers';
-import { pollForBungieAlerts } from 'app/shell/alerts';
 import store from 'app/store/store';
 import { lazyLoadStreamDeck, startStreamDeckConnection } from 'app/stream-deck/stream-deck';
 import { streamDeckEnabled } from 'app/stream-deck/util/local-storage';
@@ -67,7 +66,6 @@ const i18nPromise = initi18n();
   updateCSSVariables();
 
   store.dispatch(loadDimApiData());
-  store.dispatch(pollForBungieAlerts());
 
   if ($featureFlags.elgatoStreamDeck && streamDeckEnabled()) {
     await lazyLoadStreamDeck();

--- a/src/app/shell/MenuBadge.tsx
+++ b/src/app/shell/MenuBadge.tsx
@@ -1,11 +1,16 @@
 import { dimNeedsUpdate$ } from 'app/register-service-worker';
+import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { useEventBusListener } from 'app/utils/hooks';
 import { GlobalAlertLevelsToToastLevels } from 'app/whats-new/BungieAlerts';
 import { DimVersions } from 'app/whats-new/versions';
 import clsx from 'clsx';
+import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useSubscription } from 'use-subscription';
 import styles from './MenuBadge.m.scss';
+import { pollForBungieAlerts } from './alerts';
 import { AppIcon, updateIcon } from './icons';
+import { refresh$ } from './refresh-events';
 import { bungieAlertsSelector } from './selectors';
 
 /**
@@ -18,6 +23,13 @@ export default function MenuBadge() {
   const showChangelog = useSubscription(DimVersions.showChangelog$);
   const alerts = useSelector(bungieAlertsSelector);
   const dimNeedsUpdate = useSubscription(dimNeedsUpdate$);
+  const dispatch = useThunkDispatch();
+
+  const getAlerts = useCallback(() => dispatch(pollForBungieAlerts()), [dispatch]);
+  useEventBusListener(refresh$, getAlerts);
+  useEffect(() => {
+    getAlerts();
+  }, [getAlerts]);
 
   if (dimNeedsUpdate) {
     return <AppIcon className={styles.upgrade} icon={updateIcon} />;

--- a/src/app/shell/alerts.ts
+++ b/src/app/shell/alerts.ts
@@ -4,16 +4,16 @@ import { errorLog } from 'app/utils/log';
 import { updateBungieAlerts } from './actions';
 
 /**
- * Poll repeatedly for new Bungie alerts
+ * Update Bungie alerts. Throttled to not run more often than once per 10 minutes.
  */
 export function pollForBungieAlerts(): ThunkResult {
-  return async (dispatch) => {
-    setInterval(async () => {
+  return async (dispatch, getState) => {
+    if (Date.now() - getState().shell.bungieAlertsLastUpdated > 10 * 60 * 1000) {
       try {
         dispatch(updateBungieAlerts(await getGlobalAlerts()));
       } catch (e) {
         errorLog('BungieAlerts', 'Unable to get Bungie.net alerts: ', e);
       }
-    }, 10 * 60 * 1000);
+    }
   };
 }

--- a/src/app/shell/alerts.ts
+++ b/src/app/shell/alerts.ts
@@ -3,14 +3,17 @@ import { ThunkResult } from 'app/store/types';
 import { errorLog } from 'app/utils/log';
 import { updateBungieAlerts } from './actions';
 
+let bungieAlertsLastUpdated = 0;
+
 /**
  * Update Bungie alerts. Throttled to not run more often than once per 10 minutes.
  */
 export function pollForBungieAlerts(): ThunkResult {
-  return async (dispatch, getState) => {
-    if (Date.now() - getState().shell.bungieAlertsLastUpdated > 10 * 60 * 1000) {
+  return async (dispatch) => {
+    if (Date.now() - bungieAlertsLastUpdated > 10 * 60 * 1000) {
       try {
         dispatch(updateBungieAlerts(await getGlobalAlerts()));
+        bungieAlertsLastUpdated = Date.now();
       } catch (e) {
         errorLog('BungieAlerts', 'Unable to get Bungie.net alerts: ', e);
       }

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -29,6 +29,7 @@ export interface ShellState {
   readonly routerLocation?: string;
 
   readonly bungieAlerts: GlobalAlert[];
+  readonly bungieAlertsLastUpdated: number;
 }
 
 export type ShellAction = ActionType<typeof actions>;
@@ -41,6 +42,7 @@ const initialState: ShellState = {
   loadingMessages: [],
   routerLocation: '',
   bungieAlerts: [],
+  bungieAlertsLastUpdated: 0,
 };
 
 export const shell: Reducer<ShellState, ShellAction> = (
@@ -110,7 +112,7 @@ export const shell: Reducer<ShellState, ShellAction> = (
     case getType(actions.updateBungieAlerts): {
       return deepEqual(state.bungieAlerts, action.payload)
         ? state
-        : { ...state, bungieAlerts: action.payload };
+        : { ...state, bungieAlerts: action.payload, bungieAlertsLastUpdated: Date.now() };
     }
 
     case getType(actions.setRouterLocation): {

--- a/src/app/shell/reducer.ts
+++ b/src/app/shell/reducer.ts
@@ -29,7 +29,6 @@ export interface ShellState {
   readonly routerLocation?: string;
 
   readonly bungieAlerts: GlobalAlert[];
-  readonly bungieAlertsLastUpdated: number;
 }
 
 export type ShellAction = ActionType<typeof actions>;
@@ -42,7 +41,6 @@ const initialState: ShellState = {
   loadingMessages: [],
   routerLocation: '',
   bungieAlerts: [],
-  bungieAlertsLastUpdated: 0,
 };
 
 export const shell: Reducer<ShellState, ShellAction> = (
@@ -112,7 +110,7 @@ export const shell: Reducer<ShellState, ShellAction> = (
     case getType(actions.updateBungieAlerts): {
       return deepEqual(state.bungieAlerts, action.payload)
         ? state
-        : { ...state, bungieAlerts: action.payload, bungieAlertsLastUpdated: Date.now() };
+        : { ...state, bungieAlerts: action.payload };
     }
 
     case getType(actions.setRouterLocation): {


### PR DESCRIPTION
Right now we poll bungie alerts on an interval, even if the page is in the background. This switches to doing so based on our auto refresh settings.