### PR TITLE
Account for badge-ness in loadout placeholders

### DIFF
--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -830,7 +830,7 @@ function clearSpaceAfterLoadout(
         // This was one of our loadout items (or it can't be moved)
         numUnequippedLoadoutItems++;
       } else {
-        // Otherwise ee should move it to the vault
+        // Otherwise we should move it to the vault
         itemsToRemove.push(existingItem);
       }
     }

--- a/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.m.scss
@@ -14,7 +14,7 @@
 .buttons {
   display: flex;
   flex-flow: row wrap;
-  margin: 10px auto;
+  margin: 10px auto 0 auto;
   gap: 4px;
 }
 

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.m.scss
@@ -86,7 +86,6 @@
 .buttons {
   display: flex;
   flex-flow: row wrap;
-  margin: 4px 0;
   gap: 4px;
   justify-content: center;
 }

--- a/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss
+++ b/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss
@@ -2,9 +2,13 @@
 
 .empty {
   width: var(--item-size);
-  height: calc(var(--item-size) + #{$badge-height} - #{$item-border-width});
+  height: var(--item-size);
   border: 1px solid #ddd;
   box-sizing: border-box;
+
+  &.hasBadge {
+    height: calc(var(--item-size) + #{$badge-height} - #{$item-border-width});
+  }
 }
 
 .placeholder {

--- a/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss.d.ts
+++ b/src/app/loadout/loadout-ui/BucketPlaceholder.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'clickable': string;
   'empty': string;
+  'hasBadge': string;
   'placeholder': string;
 }
 export const cssExports: CssExports;

--- a/src/app/loadout/loadout-ui/BucketPlaceholder.tsx
+++ b/src/app/loadout/loadout-ui/BucketPlaceholder.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import styles from './BucketPlaceholder.m.scss';
 
+const badgeLessBuckets = [BucketHashes.Ghost, BucketHashes.Emblems, BucketHashes.Ships];
+
 export function BucketPlaceholder({
   bucketHash,
   onClick,
@@ -21,7 +23,10 @@ export function BucketPlaceholder({
 
   return (
     <Component
-      className={clsx(styles.empty, { [styles.clickable]: onClick })}
+      className={clsx(styles.empty, {
+        [styles.clickable]: onClick,
+        [styles.hasBadge]: !badgeLessBuckets.includes(bucketHash),
+      })}
       title={bucket.name}
       onClick={onClick}
       type={onClick ? 'button' : undefined}


### PR DESCRIPTION
Not sure exactly what I was trying to do in this branch but it does re-size loadout placeholders to account for whether they'll have a badge or not:

<img width="181" alt="Screenshot 2023-07-19 at 4 13 22 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/b9df8f5e-c8c8-46f1-8ea7-30979df23a9f">
