### PR TITLE
LO: Fix small behavioral change for subclasses without socketOverrides

### DIFF
--- a/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
+++ b/src/app/loadout-builder/filter/LockArmorAndPerks.tsx
@@ -1,24 +1,19 @@
 import CheckButton from 'app/dim-ui/CheckButton';
 import { t } from 'app/i18next-t';
-import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { hideItemPicker, showItemPicker } from 'app/item-picker/item-picker';
 import { ResolvedLoadoutItem, ResolvedLoadoutMod } from 'app/loadout-drawer/loadout-types';
 import SubclassPlugDrawer from 'app/loadout/SubclassPlugDrawer';
-import { isLoadoutBuilderItem, pickSubclass } from 'app/loadout/item-utils';
+import { getSubclassPlugs, isLoadoutBuilderItem, pickSubclass } from 'app/loadout/item-utils';
 import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import { createGetModRenderKey } from 'app/loadout/mod-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { ItemFilter } from 'app/search/filter-types';
 import { AppIcon, faTimesCircle, pinIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
-import { emptyArray, emptyObject } from 'app/utils/empty';
+import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy, itemCanBeInLoadout } from 'app/utils/item-utils';
-import {
-  getSocketByIndex,
-  getSocketsByCategoryHashes,
-  subclassAbilitySocketCategoryHashes,
-} from 'app/utils/socket-utils';
 import { Portal } from 'app/utils/temp-container';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -134,37 +129,7 @@ export default memo(function LockArmorAndPerks({
     LockableBucketHashes.indexOf(i.bucket.hash)
   );
 
-  // This creates a list of socket override plugs for the subclass.
-  // We need to track whether it is a default ability as those cannot be deleted.
-  const socketOverridePlugs: {
-    plug: PluggableInventoryItemDefinition;
-    isAbility: boolean;
-  }[] = useMemo(() => {
-    if (!subclass?.loadoutItem.socketOverrides || !subclass.item.sockets) {
-      return emptyArray();
-    }
-
-    const rtn: { plug: PluggableInventoryItemDefinition; isAbility: boolean }[] = [];
-
-    for (const socketIndexString of Object.keys(subclass?.loadoutItem.socketOverrides)) {
-      const socketIndex = parseInt(socketIndexString, 10);
-      const socket = getSocketByIndex(subclass.item.sockets, socketIndex);
-      const abilityAndSuperSockets = getSocketsByCategoryHashes(
-        subclass.item.sockets,
-        subclassAbilitySocketCategoryHashes
-      );
-
-      const overridePlug = defs.InventoryItem.get(
-        subclass.loadoutItem.socketOverrides[socketIndex]
-      ) as PluggableInventoryItemDefinition;
-
-      const isAbility = Boolean(socket && abilityAndSuperSockets.includes(socket));
-
-      rtn.push({ plug: overridePlug, isAbility });
-    }
-
-    return rtn;
-  }, [defs, subclass?.loadoutItem.socketOverrides, subclass?.item.sockets]);
+  const socketOverridePlugs = useMemo(() => getSubclassPlugs(defs, subclass), [defs, subclass]);
 
   const onMaxStatModsChanged = (autoStatMods: boolean) =>
     lbDispatch({ type: 'autoStatModsChanged', autoStatMods });
@@ -237,15 +202,15 @@ export default memo(function LockArmorAndPerks({
               lockedItem={subclass.item}
               onRemove={() => lbDispatch({ type: 'removeSubclass' })}
             />
-            {socketOverridePlugs.map(({ plug, isAbility }) => (
+            {socketOverridePlugs.map(({ plug, canBeRemoved }) => (
               <PlugDef
                 key={getModRenderKey(plug)}
                 plug={plug}
                 onClose={
-                  isAbility
-                    ? undefined
-                    : () =>
+                  canBeRemoved
+                    ? () =>
                         lbDispatch({ type: 'removeSingleSubclassSocketOverride', plug, subclass })
+                    : undefined
                 }
                 forClassType={selectedStore.classType}
               />

--- a/src/app/loadout/ingame/ingame-loadout-utils.ts
+++ b/src/app/loadout/ingame/ingame-loadout-utils.ts
@@ -131,7 +131,7 @@ export function implementsDimLoadout(
     for (const plug of dimSubclassPlugs) {
       // We only check one direction as DIM subclasses can be partially complete by
       // design.
-      if (!inGameSubclass.plugItemHashes.includes(plug.hash)) {
+      if (!inGameSubclass.plugItemHashes.includes(plug.plug.hash)) {
         return false;
       }
     }

--- a/src/app/loadout/item-utils.ts
+++ b/src/app/loadout/item-utils.ts
@@ -47,22 +47,22 @@ export function getSubclassPlugs(
   defs: D2ManifestDefinitions,
   subclass: ResolvedLoadoutItem | undefined
 ) {
-  const plugs: PluggableInventoryItemDefinition[] = [];
+  const plugs: { plug: PluggableInventoryItemDefinition; canBeRemoved: boolean }[] = [];
 
   if (subclass?.item.sockets?.categories) {
     for (const category of subclass.item.sockets.categories) {
-      const showInitial =
-        !aspectSocketCategoryHashes.includes(category.category.hash) &&
-        !fragmentSocketCategoryHashes.includes(category.category.hash);
+      const canBeRemoved =
+        aspectSocketCategoryHashes.includes(category.category.hash) ||
+        fragmentSocketCategoryHashes.includes(category.category.hash);
       const sockets = getSocketsByIndexes(subclass.item.sockets, category.socketIndexes);
 
       for (const socket of sockets) {
         const override = subclass.loadoutItem.socketOverrides?.[socket.socketIndex];
         const initial = getDefaultAbilityChoiceHash(socket);
-        const hash = override || (showInitial && initial);
+        const hash = override || (!canBeRemoved && initial);
         const plug = hash && defs.InventoryItem.get(hash);
         if (plug && isPluggableItem(plug)) {
-          plugs.push(plug);
+          plugs.push({ plug, canBeRemoved });
         }
       }
     }

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -99,8 +99,8 @@ export default function LoadoutEditSubclass({
         <div className={styles.subclassMods}>
           {plugs?.map((plug) => (
             <PlugDef
-              key={getModRenderKey(plug)}
-              plug={plug}
+              key={getModRenderKey(plug.plug)}
+              plug={plug.plug}
               forClassType={subclass?.item.classType}
             />
           ))}

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -63,8 +63,8 @@ export default function LoadoutSubclassSection({
         <div className={styles.subclassMods}>
           {plugs?.map((plug) => (
             <PlugDef
-              key={getModRenderKey(plug)}
-              plug={plug}
+              key={getModRenderKey(plug.plug)}
+              plug={plug.plug}
               forClassType={subclass?.item.classType}
             />
           ))}


### PR DESCRIPTION
A weird behavior of DIM Loadouts is that subclasses without socketOverrides have their in-game default abilities applied instead. The recent change removed the code that explicitly sets socketOverrides for LO's managed subclass, so this moves LO's code to do the same thing the loadouts page+drawer and loadout application do. Otherwise optimizing a Loadout where a subclass doesn't have socketOverrides would show no abilities in LO's sidebar.