### PR TITLE
Organizer: item icon fixes (overlay / hovers)

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -172,6 +172,8 @@ $search-bar-height: 28px;
     box-sizing: border-box;
     height: calc(var(--item-size) - #{2 * $item-border-width});
     width: calc(var(--item-size) - #{2 * $item-border-width});
+    left: 0;
+    top: 0;
 
     border-width: 1px;
     border-style: solid;

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -254,7 +254,7 @@ export function getColumns(
         <ItemPopupTrigger item={item}>
           {(ref, onClick) => (
             <div ref={ref} onClick={onClick} className="item">
-              <ItemIcon item={item} className={styles.itemIcon} />
+              <ItemIcon item={item} />
               {item.crafted && <img src={shapedOverlay} className={styles.shapedIconOverlay} />}
             </div>
           )}

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -160,6 +160,10 @@ $content-cells: 5;
   > :global(.item) {
     --item-size: var(--icon-item-size) !important;
     height: var(--item-size);
+    &:hover {
+      outline: 1px solid var(--theme-item-polaroid-hover-border);
+      cursor: pointer;
+    }
   }
 }
 
@@ -308,10 +312,6 @@ $modslotSize: 30px;
   text-align: center;
   grid-column: 1 / -1;
   padding: 2em !important;
-}
-
-.itemIcon {
-  cursor: pointer;
 }
 
 // The numeric value of the stat

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -13,7 +13,6 @@ interface CssExports {
   'importButton': string;
   'inlineIcon': string;
   'isPerk': string;
-  'itemIcon': string;
   'killTrackerDisplay': string;
   'loadout': string;
   'loadouts': string;


### PR DESCRIPTION
- Fixed mis-aligned masterwork overlays
- Added missing item hover styles
- Removed redundant class that was attempting (unsuccessfully) to apply partial hover styles

Fix part of #9634 

Before: 
<img width="257" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/d46d4256-eff8-4f1b-a544-a22a920aa749">

After: 
<img width="324" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/b985c463-d6aa-481d-9066-f9f188c5f56e">
