### PR TITLE
Themes polaroid colour tweaks

### DIFF
--- a/src/app/_theme-dimdark.scss
+++ b/src/app/_theme-dimdark.scss
@@ -67,6 +67,7 @@
   --theme-item-polaroid-masterwork-border: #745700;
   --theme-item-polaroid-godroll: #efefef;
   --theme-item-polaroid-trashroll: #efefef;
+  --theme-item-polaroid-element-adjust-brightness: 100%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #222;

--- a/src/app/_theme-europa.scss
+++ b/src/app/_theme-europa.scss
@@ -69,6 +69,8 @@
   --theme-item-polaroid-masterwork: #88cbed;
   --theme-item-polaroid-masterwork-txt: #000;
   --theme-item-polaroid-masterwork-border: #3fefff;
+  --theme-item-polaroid-capped: #f2a5ce;
+  --theme-item-polaroid-capped-txt: #be0a99;
   --theme-item-polaroid-godroll: white;
   --theme-item-polaroid-trashroll: #d14334;
 

--- a/src/app/_theme-neomuna.scss
+++ b/src/app/_theme-neomuna.scss
@@ -75,6 +75,7 @@
   --theme-item-polaroid-capped-txt: #000;
   --theme-item-polaroid-godroll: white;
   --theme-item-polaroid-trashroll: #d14334;
+  --theme-item-polaroid-element-adjust-brightness: 125%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #333;

--- a/src/app/_theme-neomuna.scss
+++ b/src/app/_theme-neomuna.scss
@@ -7,8 +7,8 @@
   // More vibrant P3 colourspace tints for displays that support them
   @supports (color: color(display-p3 1 1 1)) {
     --theme-accent-primary: oklch(0.61 0.29 336.78);
-    --theme-item-polaroid: oklch(0.77 0.16 213.81);
-    --theme-item-polaroid-masterwork: oklch(0.59 0.27 341.42);
+    --theme-item-polaroid: oklch(0.74 0.15 213.27);
+    --theme-item-polaroid-masterwork: oklch(0.55 0.26 340.71);
   }
 
   // Generic fills for modal backgrounds (see below)
@@ -66,9 +66,9 @@
   --theme-search-dropdown-border: rgba(255, 255, 255, 0.2);
 
   // Items 'polaroid' framed icons
-  --theme-item-polaroid: #1ad2f3;
+  --theme-item-polaroid: #00c2e3;
   --theme-item-polaroid-txt: black;
-  --theme-item-polaroid-masterwork: #db00aa;
+  --theme-item-polaroid-masterwork: #c9009e;
   --theme-item-polaroid-masterwork-txt: #dec1d8;
   --theme-item-polaroid-masterwork-border: #40abb5;
   --theme-item-polaroid-capped: #ebb920;

--- a/src/app/_theme-neomuna.scss
+++ b/src/app/_theme-neomuna.scss
@@ -75,7 +75,7 @@
   --theme-item-polaroid-capped-txt: #000;
   --theme-item-polaroid-godroll: white;
   --theme-item-polaroid-trashroll: #d14334;
-  --theme-item-polaroid-element-adjust-brightness: 125%; // Adjust brightness level of Arc, Strand, Void icons
+  --theme-item-polaroid-element-adjust-brightness: 110%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #333;

--- a/src/app/_theme-neomuna.scss
+++ b/src/app/_theme-neomuna.scss
@@ -75,7 +75,7 @@
   --theme-item-polaroid-capped-txt: #000;
   --theme-item-polaroid-godroll: white;
   --theme-item-polaroid-trashroll: #d14334;
-  --theme-item-polaroid-element-adjust-brightness: 110%; // Adjust brightness level of Arc, Strand, Void icons
+  --theme-item-polaroid-element-adjust-brightness: 120%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #333;

--- a/src/app/_theme-neomuna.scss
+++ b/src/app/_theme-neomuna.scss
@@ -71,6 +71,8 @@
   --theme-item-polaroid-masterwork: #db00aa;
   --theme-item-polaroid-masterwork-txt: #dec1d8;
   --theme-item-polaroid-masterwork-border: #40abb5;
+  --theme-item-polaroid-capped: #ebb920;
+  --theme-item-polaroid-capped-txt: #000;
   --theme-item-polaroid-godroll: white;
   --theme-item-polaroid-trashroll: #d14334;
 

--- a/src/app/_theme-pyramid.scss
+++ b/src/app/_theme-pyramid.scss
@@ -73,6 +73,7 @@
   --theme-item-polaroid-capped-txt: #fff;
   --theme-item-polaroid-godroll: #fff;
   --theme-item-polaroid-trashroll: #d14334;
+  --theme-item-polaroid-element-adjust-brightness: 85%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #333;

--- a/src/app/_theme-pyramid.scss
+++ b/src/app/_theme-pyramid.scss
@@ -69,7 +69,9 @@
   --theme-item-polaroid-masterwork: #d19b00;
   --theme-item-polaroid-masterwork-txt: #000;
   --theme-item-polaroid-masterwork-border: #e2761d;
-  --theme-item-polaroid-godroll: white;
+  --theme-item-polaroid-capped: #f55656;
+  --theme-item-polaroid-capped-txt: #fff;
+  --theme-item-polaroid-godroll: #fff;
   --theme-item-polaroid-trashroll: #d14334;
 
   // Item popup

--- a/src/app/_theme-throneworld.scss
+++ b/src/app/_theme-throneworld.scss
@@ -69,6 +69,7 @@
   --theme-item-polaroid-capped-txt: #b44e09;
   --theme-item-polaroid-godroll: #0b486b;
   --theme-item-polaroid-trashroll: #d14334;
+  --theme-item-polaroid-element-adjust-brightness: 90%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #222;

--- a/src/app/_theme-throneworld.scss
+++ b/src/app/_theme-throneworld.scss
@@ -65,6 +65,8 @@
   --theme-item-polaroid-masterwork: #9aad11;
   --theme-item-polaroid-masterwork-txt: black;
   --theme-item-polaroid-masterwork-border: #d1e15d;
+  --theme-item-polaroid-capped: #eab53c;
+  --theme-item-polaroid-capped-txt: #b44e09;
   --theme-item-polaroid-godroll: #0b486b;
   --theme-item-polaroid-trashroll: #d14334;
 

--- a/src/app/_theme-vexnet.scss
+++ b/src/app/_theme-vexnet.scss
@@ -73,6 +73,7 @@
   --theme-item-polaroid-capped-txt: #e54127;
   --theme-item-polaroid-godroll: white;
   --theme-item-polaroid-trashroll: #d14334;
+  --theme-item-polaroid-element-adjust-brightness: 120%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #333;

--- a/src/app/_theme-vexnet.scss
+++ b/src/app/_theme-vexnet.scss
@@ -69,6 +69,8 @@
   --theme-item-polaroid-masterwork: #5ed12c;
   --theme-item-polaroid-masterwork-txt: #000;
   --theme-item-polaroid-masterwork-border: #d3c2ce;
+  --theme-item-polaroid-capped: #ffc4c4;
+  --theme-item-polaroid-capped-txt: #e54127;
   --theme-item-polaroid-godroll: white;
   --theme-item-polaroid-trashroll: #d14334;
 

--- a/src/app/_theme.scss
+++ b/src/app/_theme.scss
@@ -65,6 +65,8 @@
   --theme-item-polaroid-masterwork: #eade8b;
   --theme-item-polaroid-masterwork-txt: var(--theme-text-invert);
   --theme-item-polaroid-masterwork-border: #ae791e;
+  --theme-item-polaroid-capped: #f5dc56;
+  --theme-item-polaroid-capped-txt: #f2721b;
   --theme-item-polaroid-godroll: #0b486b;
   --theme-item-polaroid-trashroll: #d14334;
 

--- a/src/app/_theme.scss
+++ b/src/app/_theme.scss
@@ -69,6 +69,7 @@
   --theme-item-polaroid-capped-txt: #f2721b;
   --theme-item-polaroid-godroll: #0b486b;
   --theme-item-polaroid-trashroll: #d14334;
+  --theme-item-polaroid-element-adjust-brightness: 70%; // Adjust brightness level of Arc, Strand, Void icons
 
   // Item popup
   --theme-item-popup-border: #222;

--- a/src/app/dim-ui/ElementIcon.m.scss
+++ b/src/app/dim-ui/ElementIcon.m.scss
@@ -5,6 +5,7 @@
   background-size: 100%;
   background-repeat: no-repeat;
   display: inline-block;
+  filter: saturate(2.5);
 
   :global(.destiny1) & {
     width: calc((10 / 50) * var(--item-size));

--- a/src/app/inventory/BadgeInfo.m.scss
+++ b/src/app/inventory/BadgeInfo.m.scss
@@ -81,8 +81,8 @@
   margin-right: auto;
 }
 
-/* some element icons don't show up well on polaroid white. we darken these. */
+/* some elements icons (arc / void / strand) don't show up well on polaroid white. we darken these. */
 .fixContrast {
-  filter: brightness(75%) saturate(200%);
+  filter: brightness(var(--theme-item-polaroid-element-adjust-brightness)) saturate(2.5);
   background-color: transparent !important;
 }

--- a/src/app/inventory/BadgeInfo.m.scss
+++ b/src/app/inventory/BadgeInfo.m.scss
@@ -56,11 +56,11 @@
 
 .fullstack {
   font-weight: bold;
-  color: #f2721b;
+  color: var(--theme-item-polaroid-capped-txt);
 }
 
 .capped {
-  background-color: $gold;
+  background-color: var(--theme-item-polaroid-capped);
 }
 
 .masterwork {

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -54,7 +54,7 @@ $commonBg: #366f42;
 
 // Completed items or capped stackables image
 .complete {
-  border-color: $gold;
+  border-color: var(--theme-item-polaroid-capped);
 }
 
 // Engrams and packages


### PR DESCRIPTION
Polaroid colour adjustments for #9634 

- New theme variable for polaroid/text for capped items 
    - @lowPolySkeleton I left these unspecified in the DIM Dark theme so you can plug in any tints you were considering  
- New theme variable for polaroid element icon brightness
    - Increased the base saturation of element icons so they stand out more strongly across themes 
    - Since this icons are PNGs, modifying the fill colours with variables isn't currently easily possible 
- Reduced vibrancy of neomuna polaroids 