### PR TITLE
Fix border colors on sockets with new variable

### DIFF
--- a/src/app/_theme.scss
+++ b/src/app/_theme.scss
@@ -69,7 +69,8 @@
   --theme-item-polaroid-capped-txt: #f2721b;
   --theme-item-polaroid-godroll: #0b486b;
   --theme-item-polaroid-trashroll: #d14334;
-  --theme-item-polaroid-element-adjust-brightness: 70%; // Adjust brightness level of Arc, Strand, Void icons
+  --theme-item-polaroid-element-adjust-brightness: 70%; // Adjust for legibility of Arc, Strand, Void icons
+  --theme-item-socket-border: #888; // Socketable slots (mods, fashion, sub-class/abilities)
 
   // Item popup
   --theme-item-popup-border: #222;

--- a/src/app/item-popup/Plug.m.scss
+++ b/src/app/item-popup/Plug.m.scss
@@ -34,14 +34,14 @@
 // In game, mods have a border around them that isn't part of the icon
 .mod {
   :global(.item-img) {
-    border-color: #888;
+    border-color: var(--theme-item-socket-border);
   }
 }
 
 // In game, mods have a border around them that isn't part of the icon
 .masterwork {
   :global(.item-img) {
-    border-color: var(--theme-item-polaroid-masterwork);
+    border-color: var(--theme-item-polaroid-masterwork) !important;
   }
 }
 
@@ -87,5 +87,9 @@
   &:hover,
   &:focus-visible {
     outline: 1px solid var(--theme-accent-primary);
+  }
+
+  :global(.item-img) {
+    border-color: var(--theme-item-socket-border);
   }
 }

--- a/src/app/item-popup/SocketDetails.m.scss
+++ b/src/app/item-popup/SocketDetails.m.scss
@@ -28,7 +28,7 @@
   cursor: pointer;
 
   :global(.item-img) {
-    border-color: #888;
+    border-color: var(--theme-item-socket-border);
   }
 }
 

--- a/src/app/item-popup/SocketDetailsSelectedPlug.m.scss
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.m.scss
@@ -47,7 +47,7 @@
   grid-area: mod;
 
   :global(.item-img) {
-    border-color: #888;
+    border-color: var(--theme-item-socket-border);
   }
 }
 

--- a/src/app/loadout/loadout-ui/FashionMods.m.scss
+++ b/src/app/loadout/loadout-ui/FashionMods.m.scss
@@ -7,6 +7,9 @@
   :global(.item) {
     height: var(--item-icon-size) !important;
   }
+  :global(.item-img) {
+    border-color: var(--theme-item-socket-border);
+  }
 }
 
 .unequipped {

--- a/src/app/loadout/loadout-ui/LoadoutMods.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutMods.m.scss
@@ -11,6 +11,9 @@
   :global(.item) {
     --item-size: var(--item-icon-size);
   }
+  :global(.item-img) {
+    border-color: var(--theme-item-socket-border);
+  }
 }
 
 .modsPlaceholder {

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.m.scss
@@ -39,6 +39,9 @@
   :global(.item) {
     --item-size: var(--item-icon-size);
   }
+  :global(.item-img) {
+    border-color: var(--theme-item-socket-border);
+  }
 }
 
 .modsPlaceholder {

--- a/src/app/loadout/loadout-ui/Sockets.m.scss
+++ b/src/app/loadout/loadout-ui/Sockets.m.scss
@@ -11,6 +11,9 @@
   :global(.item) {
     --item-size: var(--item-icon-size);
   }
+  :global(.item-img) {
+    border-color: var(--theme-item-socket-border);
+  }
 }
 
 .automaticallyPicked {


### PR DESCRIPTION
Fix for #9634 

Added a variable for the socketable slot border color 

- Applies to weapon/armour mods, fashion, subclass/abilities
- Kept it neutral grey — this has made the loadouts page a lot cleaner 
- Have (currently) only defined this in the main theme so it gets inherited across all themes as the default
- Masterworked weapon stat has been kept as the primary accent color in weapon popups 

Before/After for Neomuna theme which this was most aggressively presenting on: 
<img width="1428" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/804c1a90-a6b3-4743-84b6-23979ea0103d">
<img width="1431" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/7c808d05-d631-499b-b252-f803f29f5c7c">

