### PR TITLE
Reenable prettier organize exports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
     {
       "files": "*.html"
     }
-  ]
+  ],
+  "plugins": ["prettier-plugin-organize-imports"]
 }


### PR DESCRIPTION
Turns out prettier v3 needs an explicit plugin declaration.