### PR TITLE
Switch to lodash-es for some small size savings

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -351,6 +351,7 @@ export default (env: Env) => {
         docs: path.resolve('./docs/'),
         'destiny-icons': path.resolve('./destiny-icons/'),
         'textarea-caret': path.resolve('./src/app/utils/textarea-caret'),
+        lodash: 'lodash-es',
       },
 
       fallback: {

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "i18next": "^23.2.11",
     "i18next-http-backend": "^2.0.0",
     "immer": "^10.0.1",
-    "lodash": "^4.17.8",
+    "lodash-es": "^4.17.21",
     "memoize-one": "^6.0.0",
     "papaparse": "^5.0.0",
     "react": "^18.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7317,6 +7317,11 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash-webpack-plugin@^0.11.5:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.6.tgz#8204c6b78beb62ce5211217dfe783c21557ecd33"
@@ -7364,7 +7369,7 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@>=4.17.21, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.8:
+lodash@>=4.17.21, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Using the es modules version of lodash shaves off some bytes. I tested and babel-plugin-lodash still helps shave even more on top of this.