### PR TITLE
Enable useUnknownInCatchVariables

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "@react-hook/resize-observer": "^1.2.0",
     "@sentry/browser": "^7.0.0",
     "@sentry/react": "^7.0.0",
+    "@sentry/tracing": "^7.0.0",
     "@tanstack/react-virtual": "^3.0.0-beta.54",
     "@textcomplete/core": "^0.1.9",
     "@textcomplete/textarea": "^0.1.9",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
     "@react-hook/resize-observer": "^1.2.0",
     "@sentry/browser": "^7.0.0",
     "@sentry/react": "^7.0.0",
-    "@sentry/tracing": "^7.0.0",
     "@tanstack/react-virtual": "^3.0.0-beta.54",
     "@textcomplete/core": "^0.1.9",
     "@textcomplete/textarea": "^0.1.9",

--- a/src/StorageTest.tsx
+++ b/src/StorageTest.tsx
@@ -1,7 +1,6 @@
 import { t } from 'app/i18next-t';
 import ErrorPanel from 'app/shell/ErrorPanel';
-import { deleteDatabase, set } from 'app/storage/idb-keyval';
-import { reportException } from 'app/utils/exceptions';
+import { set } from 'app/storage/idb-keyval';
 import { errorLog } from 'app/utils/log';
 
 export function StorageBroken() {
@@ -32,16 +31,8 @@ export async function storageTest() {
   try {
     await set('idb-test', true);
   } catch (e) {
-    errorLog('storage', 'Failed IndexedDB Test - trying to delete database', e);
-    try {
-      await deleteDatabase();
-      await set('idb-test', true);
-      // Report to sentry, I want to know if this ever works
-      reportException('deleting database fixed IDB', e);
-    } catch (e2) {
-      errorLog('storage', 'Failed IndexedDB Test - deleting database did not help', e);
-      return false;
-    }
+    errorLog('storage', 'Failed IndexedDB Test', e);
+    return false;
   }
 
   return true;

--- a/src/app/accounts/actions.ts
+++ b/src/app/accounts/actions.ts
@@ -17,7 +17,7 @@ export const needsDeveloper = createAction('accounts/DEV_INFO_NEEDED')();
 /**
  * Inspect an error and potentially log out the user or send them to the developer page
  */
-export function handleAuthErrors(e: Error): ThunkResult {
+export function handleAuthErrors(e: unknown): ThunkResult {
   return async (dispatch) => {
     // This means we don't have an API key or the API key is wrong
     if ($DIM_FLAVOR === 'dev' && e instanceof DimError && e.code === 'BungieService.DevVersion') {

--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -3,7 +3,7 @@ import { deleteDimApiToken } from 'app/dim-api/dim-api-helper';
 import { del, get } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { errorLog } from 'app/utils/log';
-import { dedupePromise } from 'app/utils/util';
+import { convertToError, dedupePromise } from 'app/utils/util';
 import { removeToken } from '../bungie-api/oauth-tokens';
 import { loadingTracker } from '../shell/loading-tracker';
 import * as actions from './actions';
@@ -40,7 +40,7 @@ const getPlatformsAction: ThunkResult = dedupePromise(async (dispatch, getState)
     try {
       await realAccountsPromise;
     } catch (e) {
-      dispatch(actions.error(e));
+      dispatch(actions.error(convertToError(e)));
       errorLog('accounts', 'Unable to load accounts from Bungie.net', e);
     }
   }

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -98,15 +98,11 @@ export async function getActiveToken(): Promise<Tokens> {
   try {
     return await getAccessTokenFromRefreshToken(token.refreshToken!);
   } catch (e) {
-    if (e instanceof Error || e instanceof Response) {
-      return await handleRefreshTokenError(e);
-    } else {
-      throw e;
-    }
+    return await handleRefreshTokenError(e);
   }
 }
 
-async function handleRefreshTokenError(response: Error | Response): Promise<Tokens> {
+async function handleRefreshTokenError(response: unknown): Promise<Tokens> {
   if (response instanceof TypeError) {
     warnLog(
       'bungie auth',
@@ -115,7 +111,7 @@ async function handleRefreshTokenError(response: Error | Response): Promise<Toke
     );
     throw response;
   }
-  if (response instanceof Error) {
+  if (!(response instanceof Response)) {
     warnLog(
       'bungie auth',
       'Other error getting auth token from refresh token. Not clearing auth tokens',
@@ -123,7 +119,6 @@ async function handleRefreshTokenError(response: Error | Response): Promise<Toke
     );
     throw response;
   }
-
   let data;
   try {
     data = await response.json();

--- a/src/app/bungie-api/authenticated-fetch.ts
+++ b/src/app/bungie-api/authenticated-fetch.ts
@@ -32,8 +32,7 @@ export async function fetchWithBungieOAuth(
     const token = await getActiveToken();
     request.headers.set('Authorization', `Bearer ${token.accessToken.value}`);
   } catch (e) {
-    // Note: instanceof doesn't work due to a babel bug:
-    if (e.name === 'FatalTokenError') {
+    if (e instanceof FatalTokenError) {
       warnLog('bungie auth', 'Unable to get auth token', e);
     }
     throw e;
@@ -99,7 +98,11 @@ export async function getActiveToken(): Promise<Tokens> {
   try {
     return await getAccessTokenFromRefreshToken(token.refreshToken!);
   } catch (e) {
-    return await handleRefreshTokenError(e);
+    if (e instanceof Error || e instanceof Response) {
+      return await handleRefreshTokenError(e);
+    } else {
+      throw e;
+    }
   }
 }
 

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -2,7 +2,6 @@ import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
 import { DimError } from 'app/utils/dim-error';
 import { errorLog, infoLog } from 'app/utils/log';
-import { convertToError } from 'app/utils/util';
 import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
 import { HttpClient, HttpClientConfig } from 'bungie-api-ts/http';
 import _ from 'lodash';
@@ -209,7 +208,7 @@ function handleErrors(error: unknown) {
 
   // Any other error
   errorLog('bungie api', 'No response data:', error);
-  throw new DimError('BungieService.Difficulties').withError(convertToError(error));
+  throw new DimError('BungieService.Difficulties').withError(error);
 }
 
 // Handle "DestinyUniquenessViolation" (1648)

--- a/src/app/bungie-api/error-toaster.tsx
+++ b/src/app/bungie-api/error-toaster.tsx
@@ -9,13 +9,13 @@ import { AppIcon, twitterIcon } from '../shell/icons';
  *
  * Use this for when you suspect Bungie.net is down.
  */
-export function bungieErrorToaster(e: Error): NotifyInput {
+export function bungieErrorToaster(errorMessage: string | undefined): NotifyInput {
   return {
     type: 'error',
     title: t('BungieService.ErrorTitle'),
     body: (
       <>
-        {e ? e.message : t('BungieService.Difficulties')}{' '}
+        {errorMessage ?? t('BungieService.Difficulties')}{' '}
         <div>
           {t('BungieService.Twitter')}{' '}
           <ExternalLink href={bungieHelpLink}>{bungieTwitterAccount}</ExternalLink>{' '}
@@ -30,14 +30,14 @@ export function bungieErrorToaster(e: Error): NotifyInput {
   };
 }
 
-export function dimErrorToaster(title: string, message: string, e: Error): NotifyInput {
+export function dimErrorToaster(title: string, message: string, errorMessage: string): NotifyInput {
   return {
     type: 'error',
     title,
     body: (
       <>
         <div>{message}</div>
-        <div>{e.message}</div>
+        <div>{errorMessage}</div>
       </>
     ),
     duration: 60_000,

--- a/src/app/bungie-api/http-client.ts
+++ b/src/app/bungie-api/http-client.ts
@@ -1,4 +1,4 @@
-import { delay } from 'app/utils/util';
+import { convertToError, delay } from 'app/utils/util';
 import { PlatformErrorCodes, ServerResponse } from 'bungie-api-ts/destiny2';
 import { HttpClient, HttpClientConfig } from 'bungie-api-ts/http';
 
@@ -172,7 +172,7 @@ export function createHttpClient(fetchFunction: typeof fetch, apiKey: string): H
     try {
       data = await response.json();
     } catch (e) {
-      parseError = e;
+      parseError = convertToError(e);
     }
     // try throwing bungie errors, which have more information, first
     throwBungieError(data, fetchOptions);

--- a/src/app/bungie-api/oauth.ts
+++ b/src/app/bungie-api/oauth.ts
@@ -1,6 +1,7 @@
 import { infoLog } from 'app/utils/log';
 import { dedupePromise } from 'app/utils/util';
 import { oauthClientId, oauthClientSecret } from './bungie-api-utils';
+import { HttpStatusError } from './http-client';
 import { Token, Tokens, setToken } from './oauth-tokens';
 
 // all these api url params don't match our variable naming conventions
@@ -8,52 +9,51 @@ import { Token, Tokens, setToken } from './oauth-tokens';
 const TOKEN_URL = 'https://www.bungie.net/platform/app/oauth/token/';
 
 export const getAccessTokenFromRefreshToken = dedupePromise(
-  (refreshToken: Token): Promise<Tokens> => {
+  async (refreshToken: Token): Promise<Tokens> => {
     const body = new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: refreshToken.value,
       client_id: oauthClientId(),
       client_secret: oauthClientSecret(),
     });
-    // https://github.com/zloirock/core-js/issues/178#issuecomment-192081350
-    // ↑ we return fetch wrapped in an extra Promise.resolve so it has proper followup methods
-    return Promise.resolve(
-      fetch(TOKEN_URL, {
-        method: 'POST',
-        body,
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      })
-        .then((response) => (response.ok ? response.json() : Promise.reject(response)))
-        .then(handleAccessToken)
-        .then((token) => {
-          setToken(token);
-          infoLog('bungie auth', 'Successfully updated auth token from refresh token.');
-          return token;
-        })
-    );
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      body,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+    if (response.ok) {
+      const token = handleAccessToken(await response.json());
+      setToken(token);
+      infoLog('bungie auth', 'Successfully updated auth token from refresh token.');
+      return token;
+    } else {
+      throw response;
+    }
   }
 );
 
-export function getAccessTokenFromCode(code: string): Promise<Tokens> {
+export async function getAccessTokenFromCode(code: string): Promise<Tokens> {
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
     client_id: oauthClientId(),
     client_secret: oauthClientSecret(),
   });
-  return Promise.resolve(
-    fetch(TOKEN_URL, {
-      method: 'POST',
-      body,
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-    })
-      .then((response) => (response.ok ? response.json() : Promise.reject(response)))
-      .then(handleAccessToken)
-  );
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    body,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  });
+
+  if (response.ok) {
+    return handleAccessToken(await response.json());
+  } else {
+    throw new HttpStatusError(response);
+  }
 }
 
 function handleAccessToken(

--- a/src/app/debug/Debug.tsx
+++ b/src/app/debug/Debug.tsx
@@ -21,6 +21,7 @@ import { set } from 'app/storage/idb-keyval';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { DimError } from 'app/utils/dim-error';
 import { usePageTitle } from 'app/utils/hooks';
+import { convertToError } from 'app/utils/util';
 import { wishListsLastFetchedSelector, wishListsSelector } from 'app/wishlists/selectors';
 import { fetchWishList } from 'app/wishlists/wishlist-fetch';
 import { useEffect, useState } from 'react';
@@ -62,7 +63,7 @@ export default function Debug() {
       try {
         await set('idb-test', true);
       } catch (e) {
-        setIdbError(e);
+        setIdbError(convertToError(e));
       }
     })();
   }, []);
@@ -71,7 +72,7 @@ export default function Debug() {
     try {
       localStorage.setItem('test', 'true');
     } catch (e) {
-      setLocalStorageError(e);
+      setLocalStorageError(convertToError(e));
     }
   }, []);
 

--- a/src/app/developer/Developer.tsx
+++ b/src/app/developer/Developer.tsx
@@ -1,4 +1,5 @@
 import { registerApp } from 'app/dim-api/register-app';
+import { errorMessage } from 'app/utils/util';
 import React, { useState } from 'react';
 
 const createAppUrl = 'https://www.bungie.net/en/Application/Create';
@@ -62,7 +63,7 @@ export default function Developer(this: never) {
       setDimApiKey(app.dimApiKey);
     } catch (e) {
       // eslint-disable-next-line no-alert
-      alert(e.message);
+      alert(errorMessage(e));
     }
   };
 

--- a/src/app/dim-api/import.ts
+++ b/src/app/dim-api/import.ts
@@ -10,6 +10,7 @@ import { Settings, initialSettingsState } from 'app/settings/initial-settings';
 import { ThunkResult } from 'app/store/types';
 import { errorLog, infoLog } from 'app/utils/log';
 import { observeStore } from 'app/utils/redux-utils';
+import { errorMessage } from 'app/utils/util';
 import _ from 'lodash';
 import { loadDimApiData } from './actions';
 import { profileLoadedFromIDB } from './basic-actions';
@@ -45,7 +46,7 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
       } catch (e) {
         if (!silent) {
           errorLog('importLegacyData', 'Error importing legacy data into DIM API', e);
-          showImportFailedNotification(e);
+          showImportFailedNotification(errorMessage(e));
         }
         return;
       }
@@ -65,7 +66,7 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
             'Error importing legacy data into DIM - no data found in import file. (no settings upgrade/API upload attempted. DIM Sync is turned off)',
             data
           );
-          showImportFailedNotification(new Error(t('Storage.ImportNotification.NoData')));
+          showImportFailedNotification(t('Storage.ImportNotification.NoData'));
         }
         return;
       }
@@ -176,11 +177,11 @@ function showImportSuccessNotification(
   });
 }
 
-function showImportFailedNotification(e: Error) {
+function showImportFailedNotification(message: string) {
   showNotification({
     type: 'error',
     title: t('Storage.ImportNotification.FailedTitle'),
-    body: t('Storage.ImportNotification.FailedBody', { error: e.message }),
+    body: t('Storage.ImportNotification.FailedBody', { error: message }),
     duration: 15000,
   });
 }

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -299,7 +299,11 @@ async function getAwaToken(
       }
       */
     } catch (e) {
-      throw new DimError('AWA.FailedToken').withError(e);
+      const dimError = new DimError('AWA.FailedToken');
+      if (e instanceof Error) {
+        dimError.withError(e);
+      }
+      throw dimError;
 
       // TODO: handle userSelection, responseReason (TimedOut, Replaced)
     }

--- a/src/app/inventory/advanced-write-actions.ts
+++ b/src/app/inventory/advanced-write-actions.ts
@@ -299,11 +299,7 @@ async function getAwaToken(
       }
       */
     } catch (e) {
-      const dimError = new DimError('AWA.FailedToken');
-      if (e instanceof Error) {
-        dimError.withError(e);
-      }
-      throw dimError;
+      throw new DimError('AWA.FailedToken').withError(e);
 
       // TODO: handle userSelection, responseReason (TimedOut, Replaced)
     }

--- a/src/app/inventory/bulk-actions.tsx
+++ b/src/app/inventory/bulk-actions.tsx
@@ -4,6 +4,7 @@ import NotificationButton from 'app/notifications/NotificationButton';
 import { showNotification } from 'app/notifications/notifications';
 import { AppIcon, undoIcon } from 'app/shell/icons';
 import { ThunkResult } from 'app/store/types';
+import { errorMessage } from 'app/utils/util';
 import _ from 'lodash';
 import { canSyncLockState } from './SyncTagLock';
 import { setItemHashTag, setItemTagsBulk } from './actions';
@@ -128,7 +129,7 @@ export function bulkLockItems(items: DimItem[], locked: boolean): ThunkResult {
       showNotification({
         type: 'error',
         title: locked ? t('Filter.LockAllFailed') : t('Filter.UnlockAllFailed'),
-        body: e.message,
+        body: errorMessage(e),
       });
     }
   };

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -8,6 +8,7 @@ import {
 } from 'app/destiny1/d1-manifest-types';
 import { ThunkResult } from 'app/store/types';
 import { errorLog, infoLog } from 'app/utils/log';
+import { convertToError, errorMessage } from 'app/utils/util';
 import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { getStores } from '../bungie-api/destiny1-api';
@@ -80,9 +81,9 @@ export function loadStores(): ThunkResult<D1Store[] | undefined> {
 
         if (storesSelector(getState()).length > 0) {
           // don't replace their inventory with the error, just notify
-          showNotification(bungieErrorToaster(e));
+          showNotification(bungieErrorToaster(errorMessage(e)));
         } else {
-          dispatch(error(e));
+          dispatch(error(convertToError(e)));
         }
         // It's important that we swallow all errors here - otherwise
         // our observable will fail on the first error. We could work

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -14,6 +14,7 @@ import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { DimError } from 'app/utils/dim-error';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
+import { convertToError, errorMessage } from 'app/utils/util';
 import { DestinyItemComponent, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { getCharacters as d1GetCharacters } from '../bungie-api/destiny1-api';
@@ -226,11 +227,12 @@ function loadProfile(
       dispatch(profileLoaded({ profile: profileResponse, live: true }));
       return profileResponse;
     } catch (e) {
-      dispatch(profileError(e));
+      dispatch(profileError(convertToError(e)));
       if (profileResponse) {
         errorLog(
           'd2-stores',
-          'Error loading profile from Bungie.net, falling back to cached profile'
+          'Error loading profile from Bungie.net, falling back to cached profile',
+          e
         );
         // undefined means skip processing, in case we already have computed stores
         return storesLoadedSelector(getState()) ? undefined : profileResponse;
@@ -339,9 +341,9 @@ function loadStoresData(
 
         if (storesSelector(getState()).length > 0) {
           // don't replace their inventory with the error, just notify
-          showNotification(bungieErrorToaster(e));
+          showNotification(bungieErrorToaster(errorMessage(e)));
         } else {
-          dispatch(error(e));
+          dispatch(error(convertToError(e)));
         }
         return undefined;
       } finally {

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -1,5 +1,4 @@
-import { getCurrentHub } from '@sentry/browser';
-import { Span } from '@sentry/tracing';
+import { Span, getCurrentHub } from '@sentry/browser';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import { isInInGameLoadoutForSelector } from 'app/loadout-drawer/selectors';
@@ -9,7 +8,7 @@ import { CancelToken } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
-import { count } from 'app/utils/util';
+import { count, errorMessage } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -472,7 +471,7 @@ function canEquipExotic(
           t('ItemService.ExoticError', {
             itemname: item.name,
             slot: otherExotic.type,
-            error: e.message,
+            error: errorMessage(e),
           })
         );
       }

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -1,4 +1,5 @@
-import { Span, getCurrentHub } from '@sentry/browser';
+import { getCurrentHub } from '@sentry/browser';
+import { Span } from '@sentry/tracing';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import { isInInGameLoadoutForSelector } from 'app/loadout-drawer/selectors';

--- a/src/app/inventory/move-item.ts
+++ b/src/app/inventory/move-item.ts
@@ -8,6 +8,7 @@ import { CanceledError, neverCanceled, withCancel } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { errorLog, infoLog } from 'app/utils/log';
+import { errorMessage } from 'app/utils/util';
 import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
 import _ from 'lodash';
 import { showNotification } from '../notifications/notifications';
@@ -220,9 +221,9 @@ export function consolidate(actionableItem: DimItem, store: DimStore): ThunkResu
               title: t('ItemMove.Consolidate', data),
               body: message,
             });
-          } catch (a) {
-            showNotification({ type: 'error', title: actionableItem.name, body: a.message });
-            errorLog('move', 'error consolidating', actionableItem, a);
+          } catch (e) {
+            showNotification({ type: 'error', title: actionableItem.name, body: errorMessage(e) });
+            errorLog('move', 'error consolidating', actionableItem, e);
           }
         })()
       )
@@ -311,9 +312,9 @@ export function distribute(actionableItem: DimItem): ThunkResult {
               type: 'success',
               title: t('ItemMove.Distributed', { name: actionableItem.name }),
             });
-          } catch (a) {
-            showNotification({ type: 'error', title: actionableItem.name, body: a.message });
-            errorLog('move', 'error distributing', actionableItem, a);
+          } catch (e) {
+            showNotification({ type: 'error', title: actionableItem.name, body: errorMessage(e) });
+            errorLog('move', 'error distributing', actionableItem, e);
           }
         })()
       )

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -732,7 +732,9 @@ export function makeItem(
     buildPursuitInfo(createdItem, item, itemDef);
   } catch (e) {
     errorLog('d2-stores', `Error building Quest info for ${createdItem.name}`, item, itemDef, e);
-    reportException('Quest', e, { itemHash: item.itemHash });
+    if (e instanceof Error) {
+      reportException('Quest', e, { itemHash: item.itemHash });
+    }
   }
 
   if (createdItem.primaryStat && lightStats.includes(createdItem.primaryStat.statHash)) {

--- a/src/app/item-popup/ApplyPerkSelection.tsx
+++ b/src/app/item-popup/ApplyPerkSelection.tsx
@@ -5,6 +5,7 @@ import { destiny2CoreSettingsSelector, useD2Definitions } from 'app/manifest/sel
 import { showNotification } from 'app/notifications/notifications';
 import { AppIcon, faCheckCircle, refreshIcon, thumbsUpIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { errorMessage } from 'app/utils/util';
 import { wishListSelector } from 'app/wishlists/selectors';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -75,7 +76,11 @@ export default function ApplyPerkSelection({
           showNotification({
             type: 'error',
             title: t('AWA.Error'),
-            body: t('AWA.ErrorMessage', { error: e.message, item: item.name, plug: plugName }),
+            body: t('AWA.ErrorMessage', {
+              error: errorMessage(e),
+              item: item.name,
+              plug: plugName,
+            }),
           });
           return; // bail out without calling onApplied
         }

--- a/src/app/item-popup/EnergyMeter.tsx
+++ b/src/app/item-popup/EnergyMeter.tsx
@@ -8,6 +8,7 @@ import { showNotification } from 'app/notifications/notifications';
 import { AppIcon, disabledIcon, enabledIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { getFirstSocketByCategoryHash } from 'app/utils/socket-utils';
+import { errorMessage } from 'app/utils/util';
 import Cost from 'app/vendors/Cost';
 import clsx from 'clsx';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
@@ -64,7 +65,7 @@ export default function EnergyMeter({ item }: { item: DimItem }) {
 
       // TODO: show confirmation, hide preview, update item
     } catch (e) {
-      showNotification({ type: 'error', title: 'Error', body: e.message });
+      showNotification({ type: 'error', title: 'Error', body: errorMessage(e) });
     }
   };
 

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -19,6 +19,7 @@ import AppIcon from 'app/shell/icons/AppIcon';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isPlugStatActive } from 'app/utils/item-utils';
 import { usePlugDescriptions } from 'app/utils/plug-descriptions';
+import { errorMessage } from 'app/utils/util';
 import { LookupTable } from 'app/utils/util-types';
 import { DestinyItemSocketEntryDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -185,7 +186,7 @@ export default function SocketDetailsSelectedPlug({
         showNotification({
           type: 'error',
           title: t('AWA.Error'),
-          body: t('AWA.ErrorMessage', { error: e.message, item: item.name, plug: plugName }),
+          body: t('AWA.ErrorMessage', { error: errorMessage(e), item: item.name, plug: plugName }),
         });
       } finally {
         setInsertInProgress(false);

--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -8,6 +8,7 @@ import { decodeUrlLoadout } from 'app/loadout/loadout-share/loadout-import';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
 import { useEventBusListener } from 'app/utils/hooks';
+import { errorMessage } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -147,7 +148,7 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
       showNotification({
         type: 'error',
         title: t('Loadouts.BadLoadoutShare'),
-        body: t('Loadouts.BadLoadoutShareBody', { error: e.message }),
+        body: t('Loadouts.BadLoadoutShareBody', { error: errorMessage(e) }),
       });
       // ... or if it contained errors
       navigate(pathname, { replace: true });

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -1405,18 +1405,14 @@ function applyMod(
         e
       );
       const plugName = mod.displayProperties.name ?? 'Unknown Plug';
-      const dimError = new DimError(
+      throw new DimError(
         'AWA.ErrorMessage',
         t('AWA.ErrorMessage', {
           error: errorMessage(e),
           item: item.name,
           plug: plugName,
         })
-      );
-      if (e instanceof Error) {
-        dimError.withError(e);
-      }
-      throw dimError;
+      ).withError(e);
     }
   };
 }

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -65,7 +65,7 @@ import {
   plugFitsIntoSocket,
   subclassAbilitySocketCategoryHashes,
 } from 'app/utils/socket-utils';
-import { count } from 'app/utils/util';
+import { convertToError, count, errorMessage } from 'app/utils/util';
 import { HashLookup } from 'app/utils/util-types';
 import { PlatformErrorCodes } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -466,7 +466,8 @@ function doApplyLoadout(
                 }
               })
             );
-          } catch (e) {
+          } catch (err) {
+            const e = convertToError(err);
             if (e instanceof CanceledError) {
               throw e;
             }
@@ -516,7 +517,8 @@ function doApplyLoadout(
               })
             );
           }
-        } catch (e) {
+        } catch (err) {
+          const e = convertToError(err);
           if (e instanceof CanceledError) {
             throw e;
           }
@@ -573,7 +575,8 @@ function doApplyLoadout(
               }
             })
           );
-        } catch (e) {
+        } catch (err) {
+          const e = convertToError(err);
           if (e instanceof CanceledError) {
             throw e;
           }
@@ -928,7 +931,8 @@ export function clearItemsOffCharacter(
             moveSession
           )
         );
-      } catch (e) {
+      } catch (err) {
+        const e = convertToError(err);
         if (e instanceof CanceledError) {
           throw e;
         }
@@ -1357,7 +1361,8 @@ function equipModsToItem(
         try {
           await dispatch(applyMod(item, socket, mod));
           onSuccess(assignment);
-        } catch (e) {
+        } catch (err) {
+          const e = convertToError(err);
           const equipNotPossible =
             e instanceof DimError && checkEquipNotPossible(e.bungieErrorCode());
           onFailure(assignment, e, equipNotPossible);
@@ -1400,14 +1405,18 @@ function applyMod(
         e
       );
       const plugName = mod.displayProperties.name ?? 'Unknown Plug';
-      throw new DimError(
+      const dimError = new DimError(
         'AWA.ErrorMessage',
         t('AWA.ErrorMessage', {
-          error: e.message,
+          error: errorMessage(e),
           item: item.name,
           plug: plugName,
         })
-      ).withError(e);
+      );
+      if (e instanceof Error) {
+        dimError.withError(e);
+      }
+      throw dimError;
     }
   };
 }

--- a/src/app/loadout-drawer/postmaster.ts
+++ b/src/app/loadout-drawer/postmaster.ts
@@ -13,6 +13,7 @@ import { ThunkResult } from 'app/store/types';
 import { CancelToken, CanceledError, withCancel } from 'app/utils/cancel';
 import { DimError } from 'app/utils/dim-error';
 import { errorLog } from 'app/utils/log';
+import { convertToError, errorMessage } from 'app/utils/util';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { InventoryBuckets } from '../inventory/inventory-buckets';
@@ -86,7 +87,7 @@ export function makeRoomForPostmaster(store: DimStore, buckets: InventoryBuckets
         showNotification({
           type: 'error',
           title: t('Loadouts.MakeRoom'),
-          body: t('Loadouts.MakeRoomError', { error: e.message }),
+          body: t('Loadouts.MakeRoomError', { error: errorMessage(e) }),
         });
         throw e;
       }
@@ -188,7 +189,8 @@ export function pullFromPostmaster(store: DimStore): ThunkResult {
         try {
           await dispatch(executeMoveItem(item, store, { equip: false, amount }, moveSession));
           succeeded++;
-        } catch (e) {
+        } catch (err) {
+          const e = convertToError(err);
           if (e instanceof CanceledError) {
             return false;
           }

--- a/src/app/loadout/ingame/ingame-loadout-apply.ts
+++ b/src/app/loadout/ingame/ingame-loadout-apply.ts
@@ -19,6 +19,7 @@ import { InGameLoadout } from 'app/loadout-drawer/loadout-types';
 import { inGameLoadoutItemsFromEquipped } from 'app/loadout-drawer/loadout-utils';
 import { showNotification } from 'app/notifications/notifications';
 import { ThunkResult } from 'app/store/types';
+import { errorMessage } from 'app/utils/util';
 import { inGameLoadoutDeleted, inGameLoadoutUpdated } from './actions';
 import { getItemsFromInGameLoadout } from './ingame-loadout-utils';
 
@@ -89,7 +90,7 @@ export function deleteInGameLoadout(loadout: InGameLoadout): ThunkResult {
       showNotification({
         type: 'error',
         title: t('InGameLoadout.DeleteFailed'),
-        body: e.message,
+        body: errorMessage(e),
       });
     }
   };
@@ -105,7 +106,7 @@ export function editInGameLoadout(loadout: InGameLoadout): ThunkResult {
       showNotification({
         type: 'error',
         title: t('InGameLoadout.EditFailed'),
-        body: e.message,
+        body: errorMessage(e),
       });
     }
   };
@@ -123,7 +124,7 @@ export function snapshotInGameLoadout(loadout: InGameLoadout): ThunkResult {
       showNotification({
         type: 'error',
         title: t('InGameLoadout.SnapshotFailed'),
-        body: e.message,
+        body: errorMessage(e),
       });
     }
   };

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -44,6 +44,7 @@ import { RootState } from 'app/store/types';
 import { queueAction } from 'app/utils/action-queue';
 import { isiOSBrowser } from 'app/utils/browsers';
 import { emptyArray } from 'app/utils/empty';
+import { errorMessage } from 'app/utils/util';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import consumablesIcon from 'destiny-icons/general/consumables.svg';
@@ -149,7 +150,7 @@ export default function LoadoutPopup({
         dispatch(applyLoadout(dimStore, loadout, { allowUndo: true }));
       }
     } catch (e) {
-      showNotification({ type: 'warning', title: t('Loadouts.Random'), body: e.message });
+      showNotification({ type: 'warning', title: t('Loadouts.Random'), body: errorMessage(e) });
     }
     onClick?.(e);
   };

--- a/src/app/loadout/loadout-share/LoadoutImportSheet.tsx
+++ b/src/app/loadout/loadout-share/LoadoutImportSheet.tsx
@@ -5,6 +5,7 @@ import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { AppIcon, refreshIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { isiOSBrowser } from 'app/utils/browsers';
+import { errorMessage } from 'app/utils/util';
 import { useEffect, useState } from 'react';
 import styles from './LoadoutImportSheet.m.scss';
 import { decodeShareUrl, getDecodedLoadout } from './loadout-import';
@@ -46,7 +47,7 @@ export default function LoadoutImportSheet({
         }
       } catch (e) {
         if (!canceled) {
-          setState(`${t('Loadouts.Import.Error')} ${e.message}`);
+          setState(`${t('Loadouts.Import.Error')} ${errorMessage(e)}`);
         }
       }
     })();

--- a/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
+++ b/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
@@ -9,7 +9,7 @@ import { showNotification } from 'app/notifications/notifications';
 import ErrorPanel from 'app/shell/ErrorPanel';
 import { copyIcon, shareIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
-import { copyString, count } from 'app/utils/util';
+import { convertToError, copyString, count } from 'app/utils/util';
 import React, { useEffect, useState } from 'react';
 import styles from './LoadoutShareSheet.m.scss';
 
@@ -41,7 +41,7 @@ export default function LoadoutShareSheet({
         }
       } catch (e) {
         if (!canceled) {
-          setShareError(e);
+          setShareError(convertToError(e));
         }
       }
     })();

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -1,10 +1,11 @@
+import { HttpStatusError } from 'app/bungie-api/http-client';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { loadingEnd, loadingStart } from 'app/shell/actions';
 import { del, get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { errorLog, infoLog } from 'app/utils/log';
-import { dedupePromise } from 'app/utils/util';
+import { convertToError, dedupePromise } from 'app/utils/util';
 import { AllDestinyManifestComponents } from 'bungie-api-ts/destiny2';
 import { showNotification } from '../notifications/notifications';
 import { settingsReady } from '../settings/settings';
@@ -38,20 +39,23 @@ function doGetManifest(): ThunkResult<AllDestinyManifestComponents> {
         throw new Error('Manifest corrupted, please reload');
       }
       return manifest;
-    } catch (e) {
-      let message = e.message || e;
+    } catch (err) {
+      const e = convertToError(err);
+      let message = e.message;
 
-      if (e instanceof TypeError || e.status === -1) {
+      if (e instanceof TypeError || (e instanceof HttpStatusError && e.status === -1)) {
         message = navigator.onLine
           ? t('BungieService.NotConnectedOrBlocked')
           : t('BungieService.NotConnected');
-      } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
-        message = t('BungieService.Difficulties');
-      } else if (e.status < 200 || e.status >= 400) {
-        message = t('BungieService.NetworkError', {
-          status: e.status,
-          statusText: e.statusText,
-        });
+      } else if (e instanceof HttpStatusError) {
+        if (e.status === 503 || e.status === 522 /* cloudflare */) {
+          message = t('BungieService.Difficulties');
+        } else if (e.status < 200 || e.status >= 400) {
+          message = t('BungieService.NetworkError', {
+            status: e.status,
+            statusText: e.message,
+          });
+        }
       } else {
         // Something may be wrong with the manifest
         deleteManifestFile();
@@ -94,7 +98,9 @@ function loadManifestRemote(version: string, path: string): ThunkResult<object> 
 
     try {
       const response = await fetch(path);
-      const manifest = await (response.ok ? response.json() : Promise.reject(response));
+      const manifest = await (response.ok
+        ? response.json()
+        : Promise.reject(new HttpStatusError(response)));
 
       // We intentionally don't wait on this promise
       saveManifestToIndexedDB(manifest, version);

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -1,3 +1,4 @@
+import { HttpStatusError } from 'app/bungie-api/http-client';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { loadingEnd, loadingStart } from 'app/shell/actions';
@@ -5,7 +6,7 @@ import { del, get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { emptyArray, emptyObject } from 'app/utils/empty';
 import { errorLog, infoLog, timer } from 'app/utils/log';
-import { dedupePromise } from 'app/utils/util';
+import { convertToError, dedupePromise } from 'app/utils/util';
 import { LookupTable } from 'app/utils/util-types';
 import {
   AllDestinyManifestComponents,
@@ -116,26 +117,28 @@ function doGetManifest(tableAllowList: string[]): ThunkResult<AllDestinyManifest
       }
       return manifest;
     } catch (e) {
-      let message = e.message || e;
+      let message = e instanceof Error ? e.message : e;
 
-      if (e instanceof TypeError || e.status === -1) {
+      if (e instanceof TypeError || (e instanceof HttpStatusError && e.status === -1)) {
         message = navigator.onLine
           ? t('BungieService.NotConnectedOrBlocked')
           : t('BungieService.NotConnected');
-      } else if (e.status === 503 || e.status === 522 /* cloudflare */) {
-        message = t('BungieService.Difficulties');
-      } else if (e.status < 200 || e.status >= 400) {
-        message = t('BungieService.NetworkError', {
-          status: e.status,
-          statusText: e.statusText,
-        });
+      } else if (e instanceof HttpStatusError) {
+        if (e.status === 503 || e.status === 522 /* cloudflare */) {
+          message = t('BungieService.Difficulties');
+        } else if (e.status < 200 || e.status >= 400) {
+          message = t('BungieService.NetworkError', {
+            status: e.status,
+            statusText: e.message,
+          });
+        }
       } else {
         // Something may be wrong with the manifest
         await deleteManifestFile();
       }
 
       const statusText = t('Manifest.Error', { error: message });
-      errorLog('manifest', 'Manifest loading error', { error: e }, e);
+      errorLog('manifest', 'Manifest loading error', e);
       reportException('manifest load', e);
       const error = new Error(statusText);
       error.name = 'ManifestError';
@@ -228,8 +231,8 @@ export async function downloadManifestComponents(
   const futures = tableAllowList
     .map((t) => `Destiny${t}Definition` as DestinyManifestComponentName)
     .map(async (table) => {
-      let response: Response | null = null;
-      let error = null;
+      let response: Response;
+      let error: Error | undefined;
       let body = null;
 
       for (const query of cacheBusterStrings) {
@@ -240,9 +243,9 @@ export async function downloadManifestComponents(
             body = await response.json();
             break;
           }
-          error ??= response;
+          error ??= new HttpStatusError(response);
         } catch (e) {
-          error ??= e;
+          error ??= convertToError(e);
         }
       }
       if (!body && error) {

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -51,6 +51,7 @@ import { itemIncludesCategories } from './filtering-utils';
 
 import { compareSelectedItems } from 'app/compare/actions';
 
+import { errorMessage } from 'app/utils/util';
 import { createPortal } from 'react-dom';
 // eslint-disable-next-line css-modules/no-unused-class
 import styles from './ItemTable.m.scss';
@@ -456,7 +457,7 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
       const result = await dispatch(importTagsNotesFromCsv(acceptedFiles));
       showNotification({ type: 'success', title: t('Csv.ImportSuccess', { count: result }) });
     } catch (e) {
-      showNotification({ type: 'error', title: t('Csv.ImportFailed', { error: e.message }) });
+      showNotification({ type: 'error', title: t('Csv.ImportFailed', { error: errorMessage(e) }) });
     }
   };
 

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -18,6 +18,8 @@
 <string> ::= WORD | "\"" WORD {" " WORD} "\"" | "'" WORD {" " WORD} "'\"'"
 */
 
+import { convertToError } from 'app/utils/util';
+
 /* **** Parser **** */
 
 interface QueryASTCommon {
@@ -263,7 +265,7 @@ export function parseQuery(query: string): QueryAST {
         }
       }
     } catch (e) {
-      ast.error = e;
+      ast.error = convertToError(e);
     }
 
     return ast;
@@ -275,7 +277,7 @@ export function parseQuery(query: string): QueryAST {
       return { op: 'noop', startIndex: 0, length: 0 };
     }
   } catch (e) {
-    return { op: 'noop', error: e, startIndex: 0, length: 0 };
+    return { op: 'noop', error: convertToError(e), startIndex: 0, length: 0 };
   }
   const ast = parse(tokens);
   return ast;

--- a/src/app/settings/Spreadsheets.tsx
+++ b/src/app/settings/Spreadsheets.tsx
@@ -5,6 +5,7 @@ import { storesLoadedSelector } from 'app/inventory/selectors';
 import { downloadCsvFiles, importTagsNotesFromCsv } from 'app/inventory/spreadsheets';
 import { showNotification } from 'app/notifications/notifications';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { errorMessage } from 'app/utils/util';
 import { DropzoneOptions } from 'react-dropzone';
 import { useSelector } from 'react-redux';
 import { AppIcon, spreadsheetIcon } from '../shell/icons';
@@ -27,7 +28,7 @@ export default function Spreadsheets() {
       const result = await dispatch(importTagsNotesFromCsv(acceptedFiles));
       showNotification({ type: 'success', title: t('Csv.ImportSuccess', { count: result }) });
     } catch (e) {
-      showNotification({ type: 'error', title: t('Csv.ImportFailed', { error: e.message }) });
+      showNotification({ type: 'error', title: t('Csv.ImportFailed', { error: errorMessage(e) }) });
     }
   };
 

--- a/src/app/settings/Troubleshooting.tsx
+++ b/src/app/settings/Troubleshooting.tsx
@@ -6,7 +6,7 @@ import { setMockProfileResponse } from 'app/inventory/actions';
 import { loadStores } from 'app/inventory/d2-stores';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { ThunkResult } from 'app/store/types';
-import { download } from 'app/utils/util';
+import { download, errorMessage } from 'app/utils/util';
 import { DropzoneOptions } from 'react-dropzone';
 import { useSelector } from 'react-redux';
 import './settings.scss';
@@ -37,7 +37,7 @@ export function TroubleshootingSettings() {
       alert('succeeded');
     } catch (e) {
       // eslint-disable-next-line no-alert
-      alert(e.message);
+      alert(errorMessage(e));
     }
   };
 

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -3,6 +3,7 @@ import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
 import { wishListGuideLink } from 'app/shell/links';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { errorMessage } from 'app/utils/util';
 import { fetchWishList, transformAndStoreWishList } from 'app/wishlists/wishlist-fetch';
 import { toWishList } from 'app/wishlists/wishlist-file';
 import React, { useEffect, useState } from 'react';
@@ -56,7 +57,7 @@ export default function WishListSettings() {
       showNotification({
         type: 'error',
         title: t('WishListRoll.Header'),
-        body: t('WishListRoll.ImportError', { error: e.message }),
+        body: t('WishListRoll.ImportError', { error: errorMessage(e) }),
       });
     }
   };

--- a/src/app/storage/DimApiSettings.tsx
+++ b/src/app/storage/DimApiSettings.tsx
@@ -13,6 +13,7 @@ import { showNotification } from 'app/notifications/notifications';
 import ErrorPanel from 'app/shell/ErrorPanel';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { errorMessage } from 'app/utils/util';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -53,7 +54,7 @@ export default function DimApiSettings() {
         showNotification({
           type: 'error',
           title: t('Storage.ExportError'),
-          body: t('Storage.ExportErrorBody', { error: e.message }),
+          body: t('Storage.ExportErrorBody', { error: errorMessage(e) }),
           duration: 15000,
         });
         data = await dispatch(exportLocalData());

--- a/src/app/storage/ImportExport.tsx
+++ b/src/app/storage/ImportExport.tsx
@@ -3,6 +3,7 @@ import FileUpload from 'app/dim-ui/FileUpload';
 import { t } from 'app/i18next-t';
 import { showNotification } from 'app/notifications/notifications';
 import { AppIcon, downloadIcon } from 'app/shell/icons';
+import { errorMessage } from 'app/utils/util';
 import React from 'react';
 import { DropzoneOptions } from 'react-dropzone';
 import './storage.scss';
@@ -34,7 +35,7 @@ export default function ImportExport({
         } catch (e) {
           showNotification({
             type: 'error',
-            title: t('Storage.ImportFailed', { error: e.message }),
+            title: t('Storage.ImportFailed', { error: errorMessage(e) }),
           });
         }
       }

--- a/src/app/strip-sockets/strip-sockets.ts
+++ b/src/app/strip-sockets/strip-sockets.ts
@@ -5,7 +5,7 @@ import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/invent
 import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { ThunkResult } from 'app/store/types';
 import { CancelToken } from 'app/utils/cancel';
-import { uniqBy } from 'app/utils/util';
+import { errorMessage, uniqBy } from 'app/utils/util';
 import { Destiny2CoreSettings } from 'bungie-api-ts/core';
 import { ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 
@@ -148,7 +148,7 @@ export function doStripSockets(
         await dispatch(insertPlug(entry.item, socket, socket.emptyPlugItemHash!));
         progressCallback(i, undefined);
       } catch (e) {
-        progressCallback(i, e.message ?? '???');
+        progressCallback(i, errorMessage(e));
       }
     }
   };

--- a/src/app/utils/dim-error.ts
+++ b/src/app/utils/dim-error.ts
@@ -1,6 +1,7 @@
 import { BungieError } from 'app/bungie-api/http-client';
 import { t } from 'app/i18next-t';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
+import { convertToError } from './util';
 
 /**
  * An internal error that captures more error info for reporting.
@@ -20,8 +21,8 @@ export class DimError extends Error {
     this.name = 'DimError';
   }
 
-  public withError(error: Error): DimError {
-    this.cause = error;
+  public withError(error: unknown): DimError {
+    this.cause = convertToError(error);
     return this;
   }
 

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -1,5 +1,5 @@
-import { BrowserTracing } from '@sentry/browser';
 import { BrowserOptions, captureException, init, setTag, setUser, withScope } from '@sentry/react';
+import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import { BungieError } from 'app/bungie-api/http-client';
 import { getToken } from 'app/bungie-api/oauth-tokens';
 import { HashLookupFailure } from 'app/destiny2/definitions';
@@ -51,7 +51,7 @@ if ($featureFlags.sentry) {
     sampleRate: $DIM_VERSION === 'beta' ? 0.5 : 0.01, // Sample Beta at 50%, Prod at 1%
     attachStacktrace: true,
     integrations: [
-      new BrowserTracing({
+      new TracingIntegrations.BrowserTracing({
         // Only send trace headers to our own server
         tracePropagationTargets: ['api.destinyitemmanager.com'],
         beforeNavigate: (context) => ({

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -1,5 +1,5 @@
+import { BrowserTracing } from '@sentry/browser';
 import { BrowserOptions, captureException, init, setTag, setUser, withScope } from '@sentry/react';
-import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import { BungieError } from 'app/bungie-api/http-client';
 import { getToken } from 'app/bungie-api/oauth-tokens';
 import { HashLookupFailure } from 'app/destiny2/definitions';
@@ -11,7 +11,7 @@ import { errorLog } from './log';
 // TODO: rename this file "sentry"
 
 /** Sentry.io exception reporting */
-export let reportException = (name: string, e: Error, errorInfo?: Record<string, unknown>) => {
+export let reportException = (name: string, e: any, errorInfo?: Record<string, unknown>) => {
   errorLog(
     'exception',
     name,
@@ -51,7 +51,7 @@ if ($featureFlags.sentry) {
     sampleRate: $DIM_VERSION === 'beta' ? 0.5 : 0.01, // Sample Beta at 50%, Prod at 1%
     attachStacktrace: true,
     integrations: [
-      new TracingIntegrations.BrowserTracing({
+      new BrowserTracing({
         // Only send trace headers to our own server
         tracePropagationTargets: ['api.destinyitemmanager.com'],
         beforeNavigate: (context) => ({
@@ -133,7 +133,7 @@ if ($featureFlags.sentry) {
   // Capture locale
   setTag('lang', defaultLanguage());
 
-  reportException = (name: string, e: Error, errorInfo?: Record<string, unknown>) => {
+  reportException = (name: string, e: any, errorInfo?: Record<string, unknown>) => {
     // TODO: we can also do this in some situations to gather more feedback from users
     // Sentry.showReportDialog();
     withScope((scope) => {

--- a/src/app/utils/util.ts
+++ b/src/app/utils/util.ts
@@ -136,3 +136,23 @@ export function reorder<T>(list: T[], startIndex: number, endIndex: number): T[]
 
   return result;
 }
+
+/**
+ * Produce an error message either from an Error object, or a stringy
+ * representation of a non-Error object. Meant to be used when displaying or
+ * logging errors from catch blocks.
+ */
+export function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : JSON.stringify(e);
+}
+
+/**
+ * If the parameter is not an Error, wrap a stringified version of it in an
+ * Error. Meant to be used from catch blocks where the thrown type is not known.
+ */
+export function convertToError(e: unknown): Error {
+  if (e instanceof Error) {
+    return e;
+  }
+  return new Error(JSON.stringify(e));
+}

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -1,5 +1,6 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { ThunkResult } from 'app/store/types';
+import { convertToError } from 'app/utils/util';
 import { DestinyVendorsResponse } from 'bungie-api-ts/destiny2';
 import { createAction } from 'typesafe-actions';
 import { getVendors as getVendorsApi } from '../bungie-api/destiny2-api';
@@ -33,7 +34,8 @@ export function loadAllVendors(
     try {
       const vendorsResponse = await getVendorsApi(account, characterId);
       dispatch(loadedAll({ vendorsResponse, characterId }));
-    } catch (error) {
+    } catch (e) {
+      const error = convertToError(e);
       dispatch(loadedError({ characterId, error }));
     }
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "strict": true,
-    "useUnknownInCatchVariables": false,
     "esModuleInterop": true,
     "outDir": "./dist/",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,13 +1716,6 @@
     "@sentry/types" "7.60.0"
     "@sentry/utils" "7.60.0"
 
-"@sentry/tracing@^7.0.0":
-  version "7.60.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.60.0.tgz#c1e8fe67a1d65f4ce324a08c0cde1ad9b0c04d21"
-  integrity sha512-J8RV5NL4GS8Sc7h7qKDiGYX9kLigKZQVNXHKDQVGnXLJyFCCdNTTVI9NG5r2fCMGE8mgpUVInppxRLCHLJa+8g==
-  dependencies:
-    "@sentry-internal/tracing" "7.60.0"
-
 "@sentry/types@7.60.0":
   version "7.60.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.60.0.tgz#e3e5f16436feff802b1b126a16dba537000cef55"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,6 +1716,13 @@
     "@sentry/types" "7.60.0"
     "@sentry/utils" "7.60.0"
 
+"@sentry/tracing@^7.0.0":
+  version "7.60.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.60.0.tgz#c1e8fe67a1d65f4ce324a08c0cde1ad9b0c04d21"
+  integrity sha512-J8RV5NL4GS8Sc7h7qKDiGYX9kLigKZQVNXHKDQVGnXLJyFCCdNTTVI9NG5r2fCMGE8mgpUVInppxRLCHLJa+8g==
+  dependencies:
+    "@sentry-internal/tracing" "7.60.0"
+
 "@sentry/types@7.60.0":
   version "7.60.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.60.0.tgz#e3e5f16436feff802b1b126a16dba537000cef55"


### PR DESCRIPTION
This enables (or rather, removes the suppression of) the `useUnknownInCatchVariables` TS option, and then fixes the errors that come from it. This helps our `catch` blocks no longer be `any` typed.