### PR TITLE
Dial down masterwork overlay opacity

### DIFF
--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -72,11 +72,11 @@ $commonBg: #366f42;
   left: $item-border-width;
 }
 .legendaryMasterwork {
-  @include masterwork(0.15, 0.03, 0.02);
+  @include masterwork(0.15, 0.013, 0.015);
 }
 
 .exoticMasterwork {
-  @include masterwork(0.25, 0.05, 0.03);
+  @include masterwork(0.25, 0.035, 0.01);
 }
 .deepsightBorder {
   border: 2px solid $deepsight-border-color;


### PR DESCRIPTION
Addressing theme feedback that the overlays are too attention grabbing #9634 

Before:
<img width="313" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/6e3b76ea-cd76-4ba4-bfbe-d47c9a710184">

After:
<img width="317" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/b5e59dde-f9b0-4b4e-9c5e-5c3c43edd052">

Knocked back to a level where they no longer visibly stripe over weapon details, but still provide a subtle texture to help differentiate masterworked items. 