### PR TITLE
Mobile theme tweaks

### DIFF
--- a/src/app/_theme-europa.scss
+++ b/src/app/_theme-europa.scss
@@ -48,6 +48,7 @@
   --theme-app-bg: var(--theme-app-bg-gradient);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #1d2b5e;
+  --theme-mobile-background: #1d2b5e;
 
   // Header
   --theme-header-nav-bg: #1d2b5e;

--- a/src/app/_theme-neomuna.scss
+++ b/src/app/_theme-neomuna.scss
@@ -50,6 +50,7 @@
   --theme-app-bg: var(--theme-app-bg-gradient);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #0b2432;
+  --theme-mobile-background: #0b2432;
 
   // Header
   --theme-header-nav-bg: #0b2432;

--- a/src/app/_theme-throneworld.scss
+++ b/src/app/_theme-throneworld.scss
@@ -43,6 +43,7 @@
   --theme-app-bg: var(--theme-app-bg-gradient);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #1b422c;
+  --theme-mobile-background: #1b422c;
 
   // Header
   --theme-header-nav-bg: #1b422c;

--- a/src/app/_theme-vexnet.scss
+++ b/src/app/_theme-vexnet.scss
@@ -48,6 +48,7 @@
   --theme-app-bg: var(--theme-app-bg-gradient);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #0d2f63;
+  --theme-mobile-background: #0d2f63;
 
   // Header
   --theme-header-nav-bg: #0d2f63;

--- a/src/app/_theme.scss
+++ b/src/app/_theme.scss
@@ -43,6 +43,7 @@
   --theme-app-bg: var(--theme-app-bg-gradient);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #202034;
+  --theme-mobile-background: #000;
 
   // Header
   --theme-header-nav-bg: var(--theme-app-bg-gradient);

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -7,6 +7,7 @@ $green: #51a351; // For success statuses or positive deltas
 $stat-modded: #68a0b7; // For highlighting the difference in modded item stats
 $stat-masterworked: #e8a534;
 $new-notification-dot: #cf0707;
+$upgrade-notification-dot: #e8a534;
 
 // Blue used to denote community-provided data
 $communityBlue: #0d7fad;

--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -36,7 +36,7 @@ export default function updateCSSVariables() {
     if ($featureFlags.themePicker && currentState.theme !== nextState.theme) {
       const themeClass = 'theme-' + nextState.theme;
       document.body.className = themeClass;
-      syncThemeColor();
+      syncThemeColor(isPhonePortraitSelector(state));
     }
   });
 
@@ -48,6 +48,7 @@ export default function updateCSSVariables() {
       '--tiles-per-char-column',
       isPhonePortrait ? settings.charColMobile : settings.charCol
     );
+    syncThemeColor(isPhonePortrait);
   });
 
   // Set a CSS var for the true viewport height. This changes when the keyboard appears/disappears.
@@ -79,11 +80,11 @@ export default function updateCSSVariables() {
 /**
  * Read the --theme-pwa-background CSS variable and use it to set the meta theme-color element.
  */
-export function syncThemeColor() {
+export function syncThemeColor(isPhonePortrait: boolean) {
   let background = getComputedStyle(document.body).getPropertyValue('--theme-pwa-background');
 
   // Extract tint from mobile header on mobile devices to match notch/dynamic island fill
-  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+  if (isPhonePortrait) {
     background = getComputedStyle(document.body).getPropertyValue('--theme-mobile-background');
   }
 

--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -80,7 +80,13 @@ export default function updateCSSVariables() {
  * Read the --theme-pwa-background CSS variable and use it to set the meta theme-color element.
  */
 export function syncThemeColor() {
-  const background = getComputedStyle(document.body).getPropertyValue('--theme-pwa-background');
+  let background = getComputedStyle(document.body).getPropertyValue('--theme-pwa-background');
+
+  // Extract tint from mobile header on mobile devices to match notch/dynamic island fill
+  if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+    background = getComputedStyle(document.body).getPropertyValue('--theme-mobile-background');
+  }
+
   if (background) {
     const metaElem = document.querySelector("meta[name='theme-color']");
     if (metaElem) {

--- a/src/app/inventory-page/CategoryStrip.m.scss
+++ b/src/app/inventory-page/CategoryStrip.m.scss
@@ -2,7 +2,7 @@
 
 .options {
   display: flex;
-  background-color: black;
+  background-color: var(--theme-mobile-background);
   position: fixed;
   align-items: center;
   bottom: 0;

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -42,6 +42,8 @@
     overflow-y: auto;
     overscroll-behavior: none;
     max-height: calc(var(--viewport-height) - var(--header-height)) !important;
+    box-shadow: none;
+    border-radius: 0;
   }
 }
 

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -41,7 +41,7 @@ $header-height: 44px;
   container-type: inline-size;
 
   @include phone-portrait {
-    background: #000;
+    background: var(--theme-mobile-background);
   }
 
   button,

--- a/src/app/shell/MenuBadge.m.scss
+++ b/src/app/shell/MenuBadge.m.scss
@@ -11,6 +11,10 @@
   height: 8px;
   width: 8px;
   box-shadow: 0 0 0 2px var(--theme-pwa-background); // Use PWA fill var as it'll always be solid (not a gradient)
+
+  @include phone-portrait {
+    box-shadow: 0 0 0 2px var(--theme-mobile-background);
+  }
 }
 .upgrade {
   margin: 0 !important;

--- a/src/app/shell/MenuBadge.m.scss
+++ b/src/app/shell/MenuBadge.m.scss
@@ -1,26 +1,30 @@
 @use '../variables.scss' as *;
 
-.badgeNew {
+.dot {
   margin: 0 !important;
   position: absolute;
-  bottom: 0;
-  right: -5px;
-  display: block;
-  background-color: $new-notification-dot;
   border-radius: 50%;
-  height: 8px;
-  width: 8px;
   box-shadow: 0 0 0 2px var(--theme-pwa-background); // Use PWA fill var as it'll always be solid (not a gradient)
 
   @include phone-portrait {
     box-shadow: 0 0 0 2px var(--theme-mobile-background);
   }
 }
+
+.badgeNew {
+  composes: dot;
+  bottom: 0;
+  right: -5px;
+  display: block;
+  background-color: $new-notification-dot;
+  height: 8px;
+  width: 8px;
+}
+
 .upgrade {
-  margin: 0 !important;
-  position: absolute;
+  composes: dot;
   bottom: -8px;
   right: -12px;
-  color: $new-notification-dot !important;
+  color: $upgrade-notification-dot !important;
   font-size: 18px !important;
 }

--- a/src/app/shell/MenuBadge.m.scss.d.ts
+++ b/src/app/shell/MenuBadge.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'badgeNew': string;
+  'dot': string;
   'upgrade': string;
 }
 export const cssExports: CssExports;

--- a/src/app/whats-new/WhatsNewLink.m.scss
+++ b/src/app/whats-new/WhatsNewLink.m.scss
@@ -1,7 +1,7 @@
 @use '../variables.scss' as *;
 
 .upgrade {
-  color: $new-notification-dot !important;
+  color: $upgrade-notification-dot !important;
   font-size: 18px !important;
   margin-right: 4px;
 }


### PR DESCRIPTION
Mobile theme fixes for #9634 

Added a variable to control the mobile header colour. 
Inherit the PWA tint from the mobile header on mobile devices to fill in the block around notches/dynamic islands on iPhones (checked in iOS simulator) 

<img width="554" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/1132f147-6e57-49da-931d-86442b9857f1">

Removed the corner rounding/outline in the search dropdown 

