### PR TITLE
Potential fix: item overlay alignment on scaled UIs

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -196,6 +196,24 @@ $search-bar-height: 28px;
       transparent 75%,
       var(--theme-item-polaroid-masterwork-border) 100%
     );
+
+    @media (min-resolution: 1.1dppx) and (max-resolution: 1.1dppx) {
+      height: calc(var(--item-size) - 1.75px);
+      width: calc(var(--item-size) - 1.75px);
+      border-width: 1.1px;
+    }
+
+    @media (min-resolution: 1.25dppx) and (max-resolution: 1.25dppx) {
+      height: calc(var(--item-size) - 1.75px);
+      width: calc(var(--item-size) - 1.75px);
+      border-width: 1.25px;
+    }
+
+    @media (min-resolution: 1.5dppx) and (max-resolution: 1.75dppx) {
+      height: calc(var(--item-size) - 1.25px);
+      width: calc(var(--item-size) - 1.25px);
+      border-width: 1px;
+    }
   }
 }
 

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -70,6 +70,25 @@ $commonBg: #366f42;
   width: calc(var(--item-size) - ($item-border-width * 2));
   top: $item-border-width;
   left: $item-border-width;
+
+  @media (min-resolution: 1.1dppx) and (max-resolution: 1.1dppx) {
+    $item-border-width: 1.1px;
+    height: calc(var(--item-size) - ($item-border-width * 2));
+    width: calc(var(--item-size) - ($item-border-width * 2));
+  }
+
+  @media (min-resolution: 1.25dppx) and (max-resolution: 1.25dppx) {
+    $item-border-width: 1.25px;
+    height: calc(var(--item-size) - ($item-border-width * 2));
+    width: calc(var(--item-size) - ($item-border-width * 2));
+  }
+
+  @media (min-resolution: 1.5dppx) and (max-resolution: 1.75dppx) {
+    height: calc(var(--item-size) - 0.75px);
+    width: calc(var(--item-size) - 0.75px);
+    top: 0.75px;
+    left: 0.75px;
+  }
 }
 .legendaryMasterwork {
   @include masterwork(0.15, 0.03, 0.02);


### PR DESCRIPTION
Potential fix for #9634 

![image](https://github.com/DestinyItemManager/DIM/assets/1396158/f6b9b0a7-0af3-4df4-919f-c0082c4140c4)

This seems to occur:
- On `@1x` displays when using the browser zoom (110%, 125%, 150%, 175%)
    - I can reproduce this on macOS with an external @1x display
    - Cross-browser behaviour is inconsistent — I'm guessing Safari and Chrome handle rounding differently 
- And/Or on high DPI displays when using OS-level display scaling —
    - Assuming this is on Windows only based on @lowPolySkeleton's comment in #9646 
    - Note: I haven't been able to replicate this on macOS display scaling

We could potentially use a set of media queries for affected pixel scales

```
@media (min-resolution: 1.1dppx) and (max-resolution: 1.1dppx){ … } 
@media (min-resolution: 1.25dppx) and (max-resolution: 1.25dppx){ … } 
@media (min-resolution: 1.5dppx) and (max-resolution: 1.5dppx){ … } 
@media (min-resolution: 1.75dppx) and (max-resolution: 1.75dppx){ … } 
```

This is where things start getting hacky, because the tweaked values within the media queries are not as simple as matching the `border-width` variable to the display scale — I'm essentially using magic numbers… and yet it's still not 100% guaranteed to fix the issue depending on the browser (or potentially the OS — as i'm unable to check this on windows) 