### PR TITLE
Show bounty guide XP/dust pills for pursuits with no extended info too

### DIFF
--- a/src/app/progress/BountyGuide.tsx
+++ b/src/app/progress/BountyGuide.tsx
@@ -138,11 +138,11 @@ export default function BountyGuide({
             }
           }
         }
-        if (i.pursuit) {
-          for (const reward of i.pursuit.rewards) {
-            if (rewardAllowList.includes(reward.itemHash)) {
-              (mapped.Reward[reward.itemHash] ??= []).push(i);
-            }
+      }
+      if (i.pursuit) {
+        for (const reward of i.pursuit.rewards) {
+          if (rewardAllowList.includes(reward.itemHash)) {
+            (mapped.Reward[reward.itemHash] ??= []).push(i);
           }
         }
       }


### PR DESCRIPTION
I was so close to catching this pre-existing bug in #9654 especially since I temporarily made *the exact same mistake*, but I somehow didn't put two and two together until I today realized the XP reward counts were off.