### PR TITLE
D1 types

### DIFF
--- a/src/app/accounts/destiny-account.ts
+++ b/src/app/accounts/destiny-account.ts
@@ -1,5 +1,6 @@
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { D1MungedCharacter } from 'app/destiny1/d1-manifest-types';
 import { t } from 'app/i18next-t';
 import {
   battleNetIcon,
@@ -231,13 +232,13 @@ async function findD1Characters(account: DestinyAccount): Promise<DestinyAccount
 /**
  * Find the date of the most recently played character.
  */
-function getLastPlayedD1Character(response: { id: string; dateLastPlayed: string }[]): Date {
+function getLastPlayedD1Character(response: D1MungedCharacter[]): Date {
   return response.reduce((memo, rawStore) => {
     if (rawStore.id === 'vault') {
       return memo;
     }
 
-    const d1 = new Date(rawStore.dateLastPlayed);
+    const d1 = new Date(rawStore.dateLastPlayed ?? 0);
 
     return memo ? (d1 >= memo ? d1 : memo) : d1;
   }, new Date(0));

--- a/src/app/accounts/destiny-account.ts
+++ b/src/app/accounts/destiny-account.ts
@@ -1,6 +1,6 @@
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
-import { D1MungedCharacter } from 'app/destiny1/d1-manifest-types';
+import { D1Character } from 'app/destiny1/d1-manifest-types';
 import { t } from 'app/i18next-t';
 import {
   battleNetIcon,
@@ -196,14 +196,14 @@ export async function generatePlatforms(
 
 async function findD1Characters(account: DestinyAccount): Promise<DestinyAccount | null> {
   try {
-    const response = await getCharacters(account);
-    if (response?.length) {
+    const { characters } = await getCharacters(account);
+    if (characters?.length) {
       return {
         ...account,
         destinyVersion: 1,
         // D1 didn't support cross-save!
         platforms: [account.originalPlatformType],
-        lastPlayed: getLastPlayedD1Character(response),
+        lastPlayed: getLastPlayedD1Character(characters),
       };
     }
     return null;
@@ -232,13 +232,9 @@ async function findD1Characters(account: DestinyAccount): Promise<DestinyAccount
 /**
  * Find the date of the most recently played character.
  */
-function getLastPlayedD1Character(response: D1MungedCharacter[]): Date {
-  return response.reduce((memo, rawStore) => {
-    if (rawStore.id === 'vault') {
-      return memo;
-    }
-
-    const d1 = new Date(rawStore.dateLastPlayed ?? 0);
+function getLastPlayedD1Character(characters: D1Character[]): Date {
+  return characters.reduce((memo, character) => {
+    const d1 = new Date(character.characterBase.dateLastPlayed ?? 0);
 
     return memo ? (d1 >= memo ? d1 : memo) : d1;
   }, new Date(0));

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -173,9 +173,9 @@ export default function Activities({ account }: Props) {
     ];
 
     const rawActivities = Object.values(stores[0].advisors.activities).filter(
-      (a: any) => a.activityTiers && allowList.includes(a.identifier)
+      (a) => a.activityTiers && allowList.includes(a.identifier)
     );
-    const activities = _.sortBy(rawActivities, (a: any) => {
+    const activities = _.sortBy(rawActivities, (a) => {
       const ix = allowList.indexOf(a.identifier);
       return ix === -1 ? 999 : ix;
     }).map((a) => processActivities(defs, stores, a));

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -88,7 +88,7 @@ export default function Activities({ account }: Props) {
       activityId === 'heroicstrike'
         ? []
         : stores.map((store) => {
-            const activity = store.advisors.activities![activityId];
+            const activity = store.advisors.activities[activityId];
             let steps = activity.activityTiers[index].steps;
 
             if (!steps) {
@@ -172,7 +172,7 @@ export default function Activities({ account }: Props) {
       'elderchallenge',
     ];
 
-    const rawActivities = Object.values(stores[0].advisors.activities!).filter(
+    const rawActivities = Object.values(stores[0].advisors.activities).filter(
       (a: any) => a.activityTiers && allowList.includes(a.identifier)
     );
     const activities = _.sortBy(rawActivities, (a: any) => {
@@ -182,7 +182,7 @@ export default function Activities({ account }: Props) {
 
     for (const a of activities) {
       for (const t of a.tiers) {
-        if (t.hash === stores[0].advisors.activities!.weeklyfeaturedraid.display.activityHash) {
+        if (t.hash === stores[0].advisors.activities.weeklyfeaturedraid.display.activityHash) {
           a.featured = true;
           t.name = t.hash === 1387993552 ? '390' : t.name;
         }

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -154,7 +154,7 @@ export interface D1DamageTypeDefinition {
   redacted: boolean;
 }
 
-interface D1TalentGridNodeStepDefinition {
+export interface D1TalentGridNodeStepDefinition {
   stepIndex: number;
   nodeStepHash: number;
   nodeStepName?: string;
@@ -181,7 +181,7 @@ interface D1TalentGridNodeStepDefinition {
   affectsLevel: boolean;
 }
 
-interface D1TalentGridNodeDefinition {
+export interface D1TalentGridNodeDefinition {
   nodeIndex: number;
   nodeHash: number;
   row: number;
@@ -665,7 +665,7 @@ export interface D1VendorDefinition {
 }
 
 export interface D1CharacterWithInventory {
-  character: D1MungedCharacter | D1Vault;
+  character: D1Vault | D1MungedCharacter;
   data: D1Inventory;
 }
 
@@ -680,6 +680,10 @@ export interface D1MungedCharacter {
 export interface D1Vault {
   id: 'vault';
   base: null;
+}
+
+export function isD1Vault(character: D1Vault | D1MungedCharacter): character is D1Vault {
+  return character.id === 'vault';
 }
 
 export interface D1GetAccountResponse {
@@ -743,7 +747,7 @@ export interface D1LevelProgression {
 
 export interface D1Inventory {
   buckets: D1Buckets;
-  currencies: DestinyItemQuantity[];
+  currencies: { itemHash: number; value: number }[];
 }
 
 export interface D1Buckets {

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -653,27 +653,12 @@ export interface D1StoresData {
   vaultInventory: D1VaultInventory;
 }
 
-export type D1CharacterWithInventory =
-  | {
-      type: 'character';
-      character: D1CharacterData;
-    }
-  | {
-      type: 'vault';
-      character: D1Vault;
-      data: D1VaultInventory;
-    };
-
 export interface D1CharacterData {
   id: string;
   character: D1Character;
   inventory: D1Inventory;
   progression?: D1GetProgressionResponse['data'];
   advisors?: D1GetAdvisorsResponse['data'];
-}
-
-export interface D1Vault {
-  id: 'vault';
 }
 
 export interface D1GetAccountResponse {

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -647,11 +647,16 @@ export interface D1VendorDefinition {
   redacted: boolean;
 }
 
+export interface D1StoresData {
+  characters: D1CharacterData[];
+  profileInventory: D1Inventory;
+  vaultInventory: D1VaultInventory;
+}
+
 export type D1CharacterWithInventory =
   | {
       type: 'character';
-      character: D1MungedCharacter;
-      data: D1Inventory;
+      character: D1CharacterData;
     }
   | {
       type: 'vault';
@@ -659,10 +664,10 @@ export type D1CharacterWithInventory =
       data: D1VaultInventory;
     };
 
-export interface D1MungedCharacter {
+export interface D1CharacterData {
   id: string;
-  base: D1Character & { inventory: D1Inventory };
-  dateLastPlayed?: string;
+  character: D1Character;
+  inventory: D1Inventory;
   progression?: D1GetProgressionResponse['data'];
   advisors?: D1GetAdvisorsResponse['data'];
 }

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -1,3 +1,4 @@
+import { D1Progression } from 'app/inventory/store-types';
 import {
   BungieMembershipType,
   DamageType,
@@ -312,24 +313,6 @@ export interface D1RecordDefinition {
   index: number;
   contentIdentifier: string;
   redacted: boolean;
-}
-
-export interface D1Progression extends D1LevelProgression {
-  name: string;
-  scope: number;
-  repeatLastStep: boolean;
-  steps: D1ProgressionStep[];
-  visible: boolean;
-  hash: number;
-  index: number;
-  redacted: boolean;
-  identifier?: string;
-  icon?: string;
-  label?: string;
-  order?: number;
-  faction?: D1FactionDefinition;
-  description?: string;
-  source?: string;
 }
 
 export interface D1ProgressionStep {
@@ -664,10 +647,17 @@ export interface D1VendorDefinition {
   redacted: boolean;
 }
 
-export interface D1CharacterWithInventory {
-  character: D1Vault | D1MungedCharacter;
-  data: D1Inventory;
-}
+export type D1CharacterWithInventory =
+  | {
+      type: 'character';
+      character: D1MungedCharacter;
+      data: D1Inventory;
+    }
+  | {
+      type: 'vault';
+      character: D1Vault;
+      data: D1VaultInventory;
+    };
 
 export interface D1MungedCharacter {
   id: string;
@@ -679,11 +669,6 @@ export interface D1MungedCharacter {
 
 export interface D1Vault {
   id: 'vault';
-  base: null;
-}
-
-export function isD1Vault(character: D1Vault | D1MungedCharacter): character is D1Vault {
-  return character.id === 'vault';
 }
 
 export interface D1GetAccountResponse {
@@ -700,6 +685,10 @@ export interface D1GetAccountResponse {
 
 export interface D1GetInventoryResponse {
   data: D1Inventory;
+}
+
+export interface D1GetVaultInventoryResponse {
+  data: D1VaultInventory;
 }
 
 export interface D1Character {
@@ -732,6 +721,7 @@ export interface D1CharacterBase {
   genderType: DestinyGender;
   classType: DestinyClass;
   buildStatGroupHash: number;
+  peerView?: { equipment: { itemHash: number }[] };
 }
 
 export interface D1LevelProgression {
@@ -746,15 +736,15 @@ export interface D1LevelProgression {
 }
 
 export interface D1Inventory {
-  buckets: D1Buckets;
+  buckets: { [bucketLabel in D1BucketLabel]: D1Bucket[] };
   currencies: { itemHash: number; value: number }[];
 }
 
-export interface D1Buckets {
-  Invisible: D1Bucket[];
-  Item: D1Bucket[];
-  Currency: D1Bucket[];
+export interface D1VaultInventory {
+  buckets: { [bucketLabel in D1BucketLabel]: D1Bucket };
 }
+
+export type D1BucketLabel = 'Invisible' | 'Item' | 'Currency';
 
 export interface D1Bucket {
   items: D1ItemComponent[];
@@ -774,7 +764,7 @@ export interface D1GetProgressionResponse {
 
 export interface D1GetAdvisorsResponse {
   data: {
-    activities: { [activityHash: number]: D1ActivityComponent };
+    activities: { [activityLabel: string]: D1ActivityComponent };
     activityCategories: { [activityHash: number]: { categoryHash: number } };
     bounties: { [pursuitHash: number]: D1Pursuit };
     quests: { [pursuitHash: number]: D1Pursuit };
@@ -803,5 +793,7 @@ export type D1StatLabel =
   | 'STAT_ARMOR'
   | 'STAT_AGILITY'
   | 'STAT_RECOVERY'
-  | 'STAT_OPTICS';
-export type D1Stats = { [stat in D1StatLabel]: D1Stat };
+  | 'STAT_OPTICS'
+  | 'STAT_MAGAZINE_SIZE'
+  | 'STAT_ATTACK_ENERGY';
+export type D1Stats = { [stat in D1StatLabel]: D1Stat | undefined };

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -40,7 +40,7 @@ export function getSetBucketsStep(
   activeHighestSets: { [setHash: number]: SetType };
   collapsedConfigs: boolean[];
 }> {
-  const bestArmor: any = getBestArmor(
+  const bestArmor = getBestArmor(
     activeGuardianBucket,
     vendorBucket,
     lockeditems,

--- a/src/app/destiny1/record-books/RecordBooks.tsx
+++ b/src/app/destiny1/record-books/RecordBooks.tsx
@@ -4,7 +4,6 @@ import { useLoadStores } from 'app/inventory/store/hooks';
 import { useD1Definitions } from 'app/manifest/selectors';
 import { useSetting } from 'app/settings/hooks';
 import { usePageTitle } from 'app/utils/hooks';
-import { DestinyObjectiveProgress } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import _ from 'lodash';
 import React from 'react';
@@ -17,7 +16,7 @@ import { D1Store } from '../../inventory/store-types';
 import Objective from '../../progress/Objective';
 import { count } from '../../utils/util';
 import { D1ManifestDefinitions } from '../d1-definitions';
-import { D1RecordBook, D1RecordComponent } from '../d1-manifest-types';
+import { D1ObjectiveProgress, D1RecordBook, D1RecordComponent } from '../d1-manifest-types';
 import './record-books.scss';
 
 interface Props {
@@ -49,7 +48,7 @@ interface RecordBookPage {
     icon: string;
     name: string;
     description: string;
-    objectives: DestinyObjectiveProgress[];
+    objectives: D1ObjectiveProgress[];
   }[];
   complete: boolean;
   completedCount: number;
@@ -104,7 +103,7 @@ export default function RecordBooks({ account }: Props) {
         description: recordDef.description,
         name: recordDef.displayName,
         objectives: record.objectives,
-        complete: record.objectives.every((o: any) => o.isComplete),
+        complete: record.objectives.every((o) => o.isComplete),
       };
     };
 
@@ -112,13 +111,13 @@ export default function RecordBooks({ account }: Props) {
     const recordByHash = _.keyBy(records, (r) => r.hash);
 
     let i = 0;
-    recordBook.pages = recordBookDef.pages.map((page: any) => {
+    recordBook.pages = recordBookDef.pages.map((page) => {
       const createdPage: RecordBookPage = {
         id: `${recordBook.hash}-${i++}`,
         name: page.displayName,
         description: page.displayDescription,
         rewardsPage: page.displayStyle === 1,
-        records: page.records.map((r: any) => recordByHash[r.recordHash]),
+        records: page.records.map((r) => recordByHash[r.recordHash]),
         // rewards - map to items!
         // ItemFactory.processItems({ id: null }
         // may have to extract store service bits...
@@ -140,7 +139,7 @@ export default function RecordBooks({ account }: Props) {
       rawRecordBook.progress = rawRecordBook.progression;
       rawRecordBook.percentComplete =
         rawRecordBook.progress.currentProgress /
-        _.sumBy(rawRecordBook.progress.steps, (s: any) => s.progressTotal);
+        _.sumBy(rawRecordBook.progress.steps, (s) => s.progressTotal);
     } else {
       recordBook.percentComplete = count(records, (r) => r.complete) / records.length;
     }

--- a/src/app/destiny1/vendors/vendor.service.ts
+++ b/src/app/destiny1/vendors/vendor.service.ts
@@ -15,6 +15,7 @@ import { processItems } from '../../inventory/store/d1-item-factory';
 import { loadingTracker } from '../../shell/loading-tracker';
 import { D1ManifestDefinitions } from '../d1-definitions';
 import { factionAligned } from '../d1-factions';
+import { D1ItemComponent, D1VendorDefinition } from '../d1-manifest-types';
 
 /*
 const allVendors = [
@@ -106,7 +107,7 @@ export interface Vendor {
     title: string;
     saleItems: VendorSaleItem[];
   }[];
-  def: VendorDefinition;
+  def: D1VendorDefinition;
 
   cacheKeys: {
     [storeId: string]: {
@@ -118,7 +119,7 @@ export interface Vendor {
 
   saleItemCategories: {
     saleItems: {
-      item: { itemInstanceId: string };
+      item: D1ItemComponent;
       vendorItemIndex: number;
       costs: { value: number; itemHash: number }[];
       failureIndexes: number[];
@@ -126,21 +127,6 @@ export interface Vendor {
     }[];
     categoryIndex: number;
   }[];
-}
-
-interface VendorDefinition {
-  hash: number;
-  summary: {
-    vendorName: string;
-    factionHash: number;
-    factionIcon?: string;
-    vendorIcon: string;
-    vendorOrder: number;
-    vendorSubcategoryHash: number;
-    vendorCategoryHash: number;
-  };
-  categories: { [x: string]: any };
-  failureStrings: { [x: string]: any };
 }
 
 /**
@@ -173,7 +159,7 @@ export function loadVendors(): ThunkResult<{ [vendorHash: number]: Vendor }> {
 }
 
 async function fetchVendor(
-  vendorDef: VendorDefinition,
+  vendorDef: D1VendorDefinition,
   characters: D1Store[],
   account: DestinyAccount,
   defs: D1ManifestDefinitions,
@@ -243,7 +229,7 @@ function mergeCategory(
 async function loadVendorForCharacter(
   account: DestinyAccount,
   store: D1Store,
-  vendorDef: VendorDefinition,
+  vendorDef: D1VendorDefinition,
   defs: D1ManifestDefinitions,
   buckets: InventoryBuckets
 ) {
@@ -275,7 +261,7 @@ function factionLevel(store: D1Store, factionHash: number) {
  * changed level for the faction associated with this vendor (or changed whether
  * they're aligned with that faction).
  */
-function cachedVendorUpToDate(vendor: Vendor, store: D1Store, vendorDef: VendorDefinition) {
+function cachedVendorUpToDate(vendor: Vendor, store: D1Store, vendorDef: D1VendorDefinition) {
   return (
     vendor &&
     vendor.expires > Date.now() &&
@@ -287,7 +273,7 @@ function cachedVendorUpToDate(vendor: Vendor, store: D1Store, vendorDef: VendorD
 function loadVendor(
   account: DestinyAccount,
   store: D1Store,
-  vendorDef: VendorDefinition,
+  vendorDef: D1VendorDefinition,
   defs: D1ManifestDefinitions,
   buckets: InventoryBuckets
 ) {
@@ -364,7 +350,7 @@ function calculateExpiration(nextRefreshDate: string, vendorHash: number): numbe
 
 async function processVendor(
   vendor: Vendor,
-  vendorDef: VendorDefinition,
+  vendorDef: D1VendorDefinition,
   defs: D1ManifestDefinitions,
   store: D1Store,
   buckets: InventoryBuckets
@@ -403,8 +389,8 @@ async function processVendor(
   }
 
   const items: (D1Item & { vendorIcon?: string })[] = processItems(
-    { id: null } as any,
-    saleItems.map((i) => i.item) as any[],
+    undefined,
+    saleItems.map((i) => i.item),
     defs,
     buckets
   );

--- a/src/app/inventory/d1-stores.ts
+++ b/src/app/inventory/d1-stores.ts
@@ -3,6 +3,7 @@ import { getPlatforms } from 'app/accounts/platforms';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import {
   D1CharacterResponse,
+  D1CharacterWithInventory,
   D1ItemComponent,
   D1VaultResponse,
 } from 'app/destiny1/d1-manifest-types';
@@ -151,13 +152,14 @@ function processStore(
 /**
  * Find the date of the most recently played character.
  */
-function findLastPlayedDate(rawStores: any[]): Date {
+function findLastPlayedDate(rawStores: D1CharacterWithInventory[]): Date {
   return Object.values(rawStores).reduce((memo, rawStore) => {
-    if (rawStore.id === 'vault') {
+    const character = rawStore.character;
+    if (character.id === 'vault') {
       return memo;
     }
 
-    const d1 = new Date(rawStore.character.base.characterBase.dateLastPlayed);
+    const d1 = new Date(character.base.characterBase.dateLastPlayed);
 
     return memo ? (d1 >= memo ? d1 : memo) : d1;
   }, new Date(0));

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -78,18 +78,18 @@ export function updateCharacters(): ThunkResult {
         : [];
     } else {
       const profileInfo = await d1GetCharacters(account);
-      characters = profileInfo.map((character) => ({
-        characterId: character.id,
-        level: character.base.characterLevel,
-        powerLevel: character.base.characterBase.powerLevel,
-        percentToNextLevel: character.base.percentToNextLevel / 100,
-        background: bungieNetPath(character.base.backgroundPath),
-        icon: bungieNetPath(character.base.emblemPath),
-        stats: getD1CharacterStatsData(
-          getState().manifest.d1Manifest!,
-          character.base.characterBase
-        ),
-      }));
+      characters = profileInfo.characters.map((character) => {
+        const characterBase = character.characterBase;
+        return {
+          characterId: characterBase.characterId,
+          level: character.characterLevel,
+          powerLevel: characterBase.powerLevel,
+          percentToNextLevel: character.percentToNextLevel / 100,
+          background: bungieNetPath(character.backgroundPath),
+          icon: bungieNetPath(character.emblemPath),
+          stats: getD1CharacterStatsData(getState().manifest.d1Manifest!, characterBase),
+        };
+      });
     }
 
     // If we switched account since starting this, give up

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -1,8 +1,8 @@
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import {
-  D1ActivityComponent,
   D1FactionDefinition,
-  D1RecordBook,
+  D1GetAdvisorsResponse,
+  D1ProgressionStep,
 } from 'app/destiny1/d1-manifest-types';
 import {
   DestinyClass,
@@ -135,8 +135,21 @@ export interface DimCharacterStat {
 
 export interface D1Progression extends DestinyProgression {
   /** The faction definition associated with this progress. */
-  faction: D1FactionDefinition;
+  name: string;
+  scope: number;
+  repeatLastStep: boolean;
+  steps: D1ProgressionStep[];
+  visible: boolean;
+  hash: number;
+  index: number;
+  redacted: boolean;
+  identifier?: string;
+  icon?: string;
+  label?: string;
   order: number;
+  faction: D1FactionDefinition;
+  description?: string;
+  source?: string;
 }
 
 /**
@@ -144,10 +157,5 @@ export interface D1Progression extends DestinyProgression {
  */
 export interface D1Store extends DimStore<D1Item> {
   progressions: D1Progression[];
-
-  // TODO: shape?
-  advisors: {
-    recordBooks?: D1RecordBook[];
-    activities?: { [activityId: string]: D1ActivityComponent };
-  };
+  advisors: D1GetAdvisorsResponse['data'];
 }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -134,7 +134,6 @@ export interface DimCharacterStat {
 }
 
 export interface D1Progression extends DestinyProgression {
-  /** The faction definition associated with this progress. */
   name: string;
   scope: number;
   repeatLastStep: boolean;

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -1,5 +1,5 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
-import { D1CharacterResponse } from 'app/destiny1/d1-manifest-types';
+import { D1MungedCharacter, D1StatLabel } from 'app/destiny1/d1-manifest-types';
 import { warnLog } from 'app/utils/log';
 import { StatHashes } from 'data/d2/generated-enums';
 import disciplineIcon from 'images/discipline.png';
@@ -93,7 +93,7 @@ export function getD1CharacterStatTiers(stat: DimCharacterStat) {
   return tiers;
 }
 
-const stats = [
+const stats: D1StatLabel[] = [
   'STAT_INTELLECT',
   'STAT_DISCIPLINE',
   'STAT_STRENGTH',
@@ -107,7 +107,7 @@ const stats = [
  */
 export function getCharacterStatsData(
   defs: D1ManifestDefinitions,
-  data: D1CharacterResponse['character']['base']['characterBase']
+  data: D1MungedCharacter['base']['characterBase']
 ) {
   const ret: { [statHash: string]: DimCharacterStat } = {};
   for (const statId of stats) {
@@ -135,6 +135,8 @@ export function getCharacterStatsData(
       case 'STAT_STRENGTH':
         stat.effect = 'Melee';
         stat.icon = strengthIcon;
+        break;
+      default:
         break;
     }
 

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -1,5 +1,5 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
-import { D1MungedCharacter, D1StatLabel } from 'app/destiny1/d1-manifest-types';
+import { D1Character, D1StatLabel } from 'app/destiny1/d1-manifest-types';
 import { warnLog } from 'app/utils/log';
 import { StatHashes } from 'data/d2/generated-enums';
 import disciplineIcon from 'images/discipline.png';
@@ -107,7 +107,7 @@ const stats: D1StatLabel[] = [
  */
 export function getCharacterStatsData(
   defs: D1ManifestDefinitions,
-  data: D1MungedCharacter['base']['characterBase']
+  data: D1Character['characterBase']
 ) {
   const ret: { [statHash: string]: DimCharacterStat } = {};
   for (const statId of stats) {

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -1,8 +1,4 @@
-import {
-  D1CharacterResponse,
-  D1ItemComponent,
-  D1VaultResponse,
-} from 'app/destiny1/d1-manifest-types';
+import { D1CharacterWithInventory, D1ItemComponent } from 'app/destiny1/d1-manifest-types';
 import { t } from 'app/i18next-t';
 import { HashLookup } from 'app/utils/util-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -30,7 +26,7 @@ const progressionMeta: HashLookup<{ label: string; order: number }> = {
 };
 
 export function makeCharacter(
-  raw: D1CharacterResponse,
+  raw: D1CharacterWithInventory,
   defs: D1ManifestDefinitions,
   mostRecentLastPlayed: Date
 ): {
@@ -128,7 +124,7 @@ export function makeCharacter(
   };
 }
 
-export function makeVault(raw: D1VaultResponse): {
+export function makeVault(raw: D1CharacterWithInventory): {
   store: D1Store;
   items: D1ItemComponent[];
 } {

--- a/src/app/inventory/store/d1-store-factory.ts
+++ b/src/app/inventory/store/d1-store-factory.ts
@@ -1,9 +1,4 @@
-import {
-  D1Inventory,
-  D1ItemComponent,
-  D1MungedCharacter,
-  D1VaultInventory,
-} from 'app/destiny1/d1-manifest-types';
+import { D1CharacterData } from 'app/destiny1/d1-manifest-types';
 import { t } from 'app/i18next-t';
 import { HashLookup } from 'app/utils/util-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -31,15 +26,11 @@ const progressionMeta: HashLookup<{ label: string; order: number }> = {
 };
 
 export function makeCharacter(
-  characterComponent: D1MungedCharacter,
-  inventory: D1Inventory,
+  characterComponent: D1CharacterData,
   defs: D1ManifestDefinitions,
   mostRecentLastPlayed: Date
-): {
-  store: D1Store;
-  items: D1ItemComponent[];
-} {
-  const character = characterComponent.base;
+) {
+  const character = characterComponent.character;
   const race = defs.Race[character.characterBase.raceHash];
   const klass = defs.Class[character.characterBase.classHash];
   let genderRace = '';
@@ -104,36 +95,10 @@ export function makeCharacter(
     hadErrors: false,
   };
 
-  let items: D1ItemComponent[] = [];
-  for (const buckets of Object.values(inventory.buckets)) {
-    for (const bucket of buckets) {
-      for (const item of bucket.items) {
-        item.bucket = bucket.bucketHash;
-      }
-      items = items.concat(bucket.items);
-    }
-  }
-
-  if (_.has(character.inventory.buckets, 'Invisible')) {
-    const buckets = character.inventory.buckets.Invisible;
-    for (const bucket of buckets) {
-      for (const item of bucket.items) {
-        item.bucket = bucket.bucketHash;
-      }
-      items = items.concat(bucket.items);
-    }
-  }
-
-  return {
-    store,
-    items,
-  };
+  return store;
 }
 
-export function makeVault(inventory: D1VaultInventory): {
-  store: D1Store;
-  items: D1ItemComponent[];
-} {
+export function makeVault() {
   const store: D1Store = {
     destinyVersion: 1,
     id: 'vault',
@@ -165,18 +130,5 @@ export function makeVault(inventory: D1VaultInventory): {
     stats: [],
     hadErrors: false,
   };
-
-  let items: D1ItemComponent[] = [];
-
-  for (const bucket of Object.values(inventory.buckets)) {
-    for (const item of bucket.items) {
-      item.bucket = bucket.bucketHash;
-    }
-    items = items.concat(bucket.items);
-  }
-
-  return {
-    store,
-    items,
-  };
+  return store;
 }

--- a/src/app/manifest/d1-manifest-service.ts
+++ b/src/app/manifest/d1-manifest-service.ts
@@ -106,7 +106,7 @@ function loadManifestRemote(version: string, path: string): ThunkResult<object> 
   };
 }
 
-async function saveManifestToIndexedDB(typedArray: object, version: string) {
+async function saveManifestToIndexedDB(typedArray: unknown, version: string) {
   try {
     await set(idbKey, typedArray);
     infoLog('manifest', `Successfully stored manifest file.`);


### PR DESCRIPTION
This gets types in place for all the old D1 APIs, and then simplifies/clarifies some of the API helpers and store builder stuff. TBH I never understood this stuff - `base` and `raw` and objects having other data merged into them. I think this is a bit easier to follow. This is a prerequisite for enabling some of the stricter lints around always having types.