### PR TITLE
Revert shaped weapon icon move

### DIFF
--- a/src/app/inventory/BadgeInfo.m.scss
+++ b/src/app/inventory/BadgeInfo.m.scss
@@ -33,6 +33,12 @@
   padding: 0 4px;
 }
 
+.shapedIcon {
+  width: calc((8 / 50) * var(--item-size));
+  height: calc((8 / 50) * var(--item-size));
+  margin-right: auto;
+}
+
 .quality {
   display: none;
   margin-right: auto;

--- a/src/app/inventory/BadgeInfo.m.scss.d.ts
+++ b/src/app/inventory/BadgeInfo.m.scss.d.ts
@@ -11,6 +11,7 @@ interface CssExports {
   'fullstack': string;
   'masterwork': string;
   'quality': string;
+  'shapedIcon': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -5,6 +5,7 @@ import { InventoryWishListRoll, toUiWishListRoll } from 'app/wishlists/wishlists
 import { DamageType } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
+import shapedIcon from 'images/shaped.png';
 import { useSelector } from 'react-redux';
 import ElementIcon from '../dim-ui/ElementIcon';
 import styles from './BadgeInfo.m.scss';
@@ -71,7 +72,11 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
       item.element.enumValue === DamageType.Strand);
 
   const wishlistRollIcon = toUiWishListRoll(wishlistRoll);
-  const summaryIcon = wishlistRollIcon && <RatingIcon uiWishListRoll={wishlistRollIcon} />;
+  const summaryIcon = item.crafted ? (
+    <img className={styles.shapedIcon} src={shapedIcon} />
+  ) : (
+    wishlistRollIcon && <RatingIcon uiWishListRoll={wishlistRollIcon} />
+  );
 
   return (
     <div

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -76,17 +76,11 @@
 
 // The container for the tag/notes/wishlist icons
 .icons {
-  width: var(--item-size);
-  height: var(--item-size);
-  max-width: 66%;
   position: absolute;
-  right: ($item-border-width * 3);
-  bottom: calc(#{$badge-height} + (#{$item-border-width} * 3));
-  padding-bottom: $item-border-width;
+  left: $item-border-width + 2px;
+  top: calc(var(--item-size) - #{$badge-height});
   display: flex;
-  flex-flow: row-reverse wrap-reverse;
-  align-content: flex-start;
-  align-items: baseline;
+  flex-direction: row;
 }
 
 // Individual icons in the icon tray
@@ -96,8 +90,7 @@
   width: calc(var(--item-size) / 5);
   height: calc(var(--item-size) / 5);
   font-size: calc(var(--item-size) / 5);
-  margin-left: 3px;
-  margin-top: 3px;
+  margin-right: 1px;
   color: #29f36a; // #5eff92;
   filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));
 }

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -105,13 +105,13 @@ export default function InventoryItem({
         <BadgeInfo item={item} isCapped={isCapped} wishlistRoll={wishlistRoll} />
         {(tag || item.locked || hasNotes) && (
           <div className={styles.icons}>
-            {tag && <TagIcon className={styles.icon} tag={tag} />}
             {item.locked && (!autoLockTagged || !tag || !canSyncLockState(item)) && (
               <AppIcon
                 className={styles.icon}
                 icon={item.bucket.hash !== BucketHashes.Finishers ? lockIcon : starIcon}
               />
             )}
+            {tag && <TagIcon className={styles.icon} tag={tag} />}
             {hasNotes && <AppIcon className={styles.icon} icon={stickyNoteIcon} />}
           </div>
         )}

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -94,7 +94,6 @@ $commonBg: #366f42;
   background-size: contain;
   position: absolute;
   pointer-events: none;
-  z-index: 2;
 }
 
 .energyCostOverlay {
@@ -104,25 +103,6 @@ $commonBg: #366f42;
   background-position: center;
   background-size: cover;
   pointer-events: none;
-}
-
-.shapedOverlay {
-  position: absolute;
-  width: calc(var(--item-size) - (2 * $item-border-width));
-  height: calc(var(--item-size) - (2 * $item-border-width));
-  top: $item-border-width;
-  left: $item-border-width;
-  background-image: linear-gradient(to top right, #d25336, transparent 45%);
-}
-
-.shapedIcon {
-  position: absolute;
-  bottom: 3px;
-  left: 3px;
-  width: calc(var(--item-size) / 5); // Match dimensions of tag icons
-  height: calc(var(--item-size) / 5);
-  filter: brightness(200%);
-  z-index: 1;
 }
 
 .energyCost {

--- a/src/app/inventory/ItemIcon.m.scss.d.ts
+++ b/src/app/inventory/ItemIcon.m.scss.d.ts
@@ -19,8 +19,6 @@ interface CssExports {
   'legendaryMasterwork': string;
   'masterwork': string;
   'rare': string;
-  'shapedIcon': string;
-  'shapedOverlay': string;
   'strandColorFix': string;
 }
 export const cssExports: CssExports;

--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -8,7 +8,6 @@ import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes, ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import pursuitComplete from 'images/highlightedObjective.svg';
-import shapedIcon from 'images/shaped.png';
 import { DimItem } from './item-types';
 import styles from './ItemIcon.m.scss';
 import { isPluggableItem } from './store/sockets';
@@ -74,11 +73,6 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
       )}
       {item.iconOverlay && (
         <div className={styles.iconOverlay} style={bungieBackgroundStyle(item.iconOverlay)} />
-      )}
-      {item.crafted && (
-        <div className={styles.shapedOverlay}>
-          <img className={styles.shapedIcon} src={shapedIcon} />
-        </div>
       )}
       {(item.masterwork || item.deepsightInfo) && (
         <div

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -62,6 +62,7 @@ import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import clsx from 'clsx';
 import { D2EventInfo } from 'data/d2/d2-event-info';
 import { StatHashes } from 'data/d2/generated-enums';
+import shapedOverlay from 'images/shapedOverlay.png';
 import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -254,6 +255,7 @@ export function getColumns(
           {(ref, onClick) => (
             <div ref={ref} onClick={onClick} className="item">
               <ItemIcon item={item} />
+              {item.crafted && <img src={shapedOverlay} className={styles.shapedIconOverlay} />}
             </div>
           )}
         </ItemPopupTrigger>

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -325,6 +325,11 @@ $modslotSize: 30px;
   }
 }
 
+.shapedIcon {
+  width: calc((16 / 50) * var(--item-size));
+  height: calc((16 / 50) * var(--item-size));
+}
+
 .shapedIconOverlay {
   position: absolute;
   bottom: 1px;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -35,6 +35,7 @@ interface CssExports {
   'rating': string;
   'season': string;
   'selection': string;
+  'shapedIcon': string;
   'shapedIconOverlay': string;
   'shiftHeld': string;
   'sorter': string;


### PR DESCRIPTION
Got some comments from the Discord that this isn't a big improvement. A couple notes from myself:

1. It's harder to distinguish shaped weapons this way than with the icon in the polaroid. I thought it'd be otherwise but it blends in.
2. It does obscure the weapon icon - we should be doing what we can to clearly show the icon.
3. While some folks will definitely appreciate having the thumbs-up visible, I agree with our original argument that wishlists are irrelevant for shaped weapons.

The reorganization of the green DIM icons should probably be a separate PR.