### PR TITLE
Fix not logging out on expired token

### DIFF
--- a/src/app/accounts/actions.ts
+++ b/src/app/accounts/actions.ts
@@ -1,3 +1,4 @@
+import { FatalTokenError } from 'app/bungie-api/authenticated-fetch';
 import { ThunkResult } from 'app/store/types';
 import { DimError } from 'app/utils/dim-error';
 import { createAction } from 'typesafe-actions';
@@ -24,8 +25,9 @@ export function handleAuthErrors(e: unknown): ThunkResult {
       dispatch(needsDeveloper());
     } else if (
       e instanceof Error &&
-      (e.name === 'FatalTokenError' ||
-        (e instanceof DimError && e.code === 'BungieService.NotLoggedIn'))
+      (e instanceof FatalTokenError ||
+        (e instanceof DimError &&
+          (e.code === 'BungieService.NotLoggedIn' || e.cause instanceof FatalTokenError)))
     ) {
       dispatch(loggedOut());
     }

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpClientConfig } from 'bungie-api-ts/http';
 import _ from 'lodash';
 import { DimItem } from '../inventory/item-types';
 import { DimStore } from '../inventory/store-types';
-import { fetchWithBungieOAuth } from './authenticated-fetch';
+import { FatalTokenError, fetchWithBungieOAuth } from './authenticated-fetch';
 import { API_KEY } from './bungie-api-utils';
 import {
   BungieError,
@@ -107,6 +107,10 @@ function handleErrors(error: unknown) {
         ? new DimError('BungieService.NotConnectedOrBlocked')
         : new DimError('BungieService.NotConnected')
     ).withError(error);
+  }
+
+  if (error instanceof FatalTokenError) {
+    throw new DimError('BungieService.NotLoggedIn').withError(error);
   }
 
   if (error instanceof HttpStatusError) {

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -227,6 +227,7 @@ function loadProfile(
       dispatch(profileLoaded({ profile: profileResponse, live: true }));
       return profileResponse;
     } catch (e) {
+      dispatch(handleAuthErrors(e));
       dispatch(profileError(convertToError(e)));
       if (profileResponse) {
         errorLog(

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -1,5 +1,6 @@
 import { getCurrentHub } from '@sentry/browser';
 import { Span } from '@sentry/tracing';
+import { handleAuthErrors } from 'app/accounts/actions';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { t } from 'app/i18next-t';
 import { isInInGameLoadoutForSelector } from 'app/loadout-drawer/selectors';
@@ -307,33 +308,44 @@ export function equipItems(
     }
 
     session.cancelToken.checkCanceled();
-    const results = await equipItemsApi(items[0])(
-      currentAccountSelector(getState())!,
-      store,
-      items
-    );
-    // Update our view of each successful item
-    for (const [itemInstanceId, resultCode] of Object.entries(results)) {
-      if (resultCode === PlatformErrorCodes.Success) {
-        const item = items.find((i) => i.id === itemInstanceId);
-        if (item) {
-          dispatch(updateItemModel(item, store, store, true));
+
+    try {
+      const results = await equipItemsApi(items[0])(
+        currentAccountSelector(getState())!,
+        store,
+        items
+      );
+      // Update our view of each successful item
+      for (const [itemInstanceId, resultCode] of Object.entries(results)) {
+        if (resultCode === PlatformErrorCodes.Success) {
+          const item = items.find((i) => i.id === itemInstanceId);
+          if (item) {
+            dispatch(updateItemModel(item, store, store, true));
+          }
         }
       }
+      return results;
+    } catch (e) {
+      dispatch(handleAuthErrors(e));
+      throw e;
     }
-    return results;
   };
 }
 
 function equipItem(item: DimItem, cancelToken: CancelToken): ThunkResult<DimItem> {
   return async (dispatch, getState) => {
-    const store = getStore(storesSelector(getState()), item.owner)!;
-    if ($featureFlags.debugMoves) {
-      infoLog('equip', 'Equip', item.name, item.type, 'to', store.name);
+    try {
+      const store = getStore(storesSelector(getState()), item.owner)!;
+      if ($featureFlags.debugMoves) {
+        infoLog('equip', 'Equip', item.name, item.type, 'to', store.name);
+      }
+      cancelToken.checkCanceled();
+      await equipApi(item)(currentAccountSelector(getState())!, item);
+      return dispatch(updateItemModel(item, store, store, true));
+    } catch (e) {
+      dispatch(handleAuthErrors(e));
+      throw e;
     }
-    cancelToken.checkCanceled();
-    await equipApi(item)(currentAccountSelector(getState())!, item);
-    return dispatch(updateItemModel(item, store, store, true));
   };
 }
 
@@ -407,6 +419,7 @@ function moveToStore(
     try {
       await transferApi(item)(currentAccountSelector(getState())!, item, store, amount);
     } catch (e) {
+      dispatch(handleAuthErrors(e));
       // Not sure why this happens - maybe out of sync game state?
       if (
         e instanceof DimError &&


### PR DESCRIPTION
I still don't have any clue why people's refresh token stops working, but this should at least log them out when the refresh token can't get a new access token. It also does a better job of plumbing down the "you're not logged in" message, and can trigger on item moves instead of just profile loads.

The root regression was that when I added the offline mode, we were no longer checking the error to see if it was time to log out, since we could still show the offline inventory. This change shouldn't break offline mode, since we only log out on positively identifying a response from the server that indicates a bad token.