### PR TITLE
Deny non-const TS enums

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -152,6 +152,13 @@
         ]
       }
     ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "TSEnumDeclaration:not([const=true])",
+        "message": "Please only use `const enum`s."
+      }
+    ],
     "spaced-comment": [
       "error",
       "always",


### PR DESCRIPTION
We don't use them right now because I removed them in #9377 and I think we generally want to keep it that way.