### PR TITLE
Transition group

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@types/react-dnd-multi-backend": "^6.0.0",
     "@types/react-dom": "^18.0.3",
     "@types/react-test-renderer": "^18.0.0",
-    "@types/react-transition-group": "^4.2.0",
     "@types/ua-parser-js": "^0.7.36",
     "@types/use-subscription": "^1.0.0",
     "@types/uuid": "^9.0.0",

--- a/src/app/dim-ui/CollapsibleTitle.tsx
+++ b/src/app/dim-ui/CollapsibleTitle.tsx
@@ -1,7 +1,7 @@
 import { collapsedSelector } from 'app/dim-api/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
-import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
+import { AnimatePresence, Spring, Variants, motion } from 'framer-motion';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { toggleCollapsedSection } from '../settings/actions';
@@ -68,7 +68,7 @@ const collapsibleTitleAnimateVariants: Variants = {
   open: { height: 'auto' },
   collapsed: { height: 0 },
 };
-const collapsibleTitleAnimateTransition: Tween = { duration: 0.3 };
+const collapsibleTitleAnimateTransition: Spring = { type: 'spring', duration: 0.5, bounce: 0 };
 
 export function CollapsedSection({
   collapsed,

--- a/src/app/dim-ui/CollapsibleTitle.tsx
+++ b/src/app/dim-ui/CollapsibleTitle.tsx
@@ -1,14 +1,24 @@
 import { collapsedSelector } from 'app/dim-api/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { toggleCollapsedSection } from '../settings/actions';
 import { AppIcon, collapseIcon, expandIcon } from '../shell/icons';
 import './CollapsibleTitle.scss';
 
-interface Props {
+export default function CollapsibleTitle({
+  title,
+  defaultCollapsed,
+  children,
+  extra,
+  showExtraOnlyWhenCollapsed,
+  className,
+  disabled,
+  sectionId,
+  style,
+}: {
   sectionId: string;
   defaultCollapsed?: boolean;
   title: React.ReactNode;
@@ -21,27 +31,10 @@ interface Props {
   children?: React.ReactNode;
   style?: React.CSSProperties;
   className?: string;
-}
-
-export default function CollapsibleTitle({
-  title,
-  defaultCollapsed,
-  children,
-  extra,
-  showExtraOnlyWhenCollapsed,
-  className,
-  disabled,
-  sectionId,
-  style,
-}: Props) {
+}) {
   const dispatch = useThunkDispatch();
   const collapsedSetting = useSelector(collapsedSelector(sectionId));
   const collapsed = Boolean(disabled) || (collapsedSetting ?? Boolean(defaultCollapsed));
-  const initialMount = useRef(true);
-
-  useEffect(() => {
-    initialMount.current = false;
-  }, [initialMount]);
 
   const toggle = useCallback(
     () => disabled || dispatch(toggleCollapsedSection(sectionId)),
@@ -66,24 +59,45 @@ export default function CollapsibleTitle({
         </span>
         {showExtraOnlyWhenCollapsed ? collapsed && extra : extra}
       </div>
-      <AnimatePresence>
-        {!collapsed && (
-          <motion.div
-            key="content"
-            initial={initialMount.current ? false : 'collapsed'}
-            animate="open"
-            exit="collapsed"
-            variants={{
-              open: { height: 'auto' },
-              collapsed: { height: 0 },
-            }}
-            transition={{ duration: 0.3 }}
-            className="collapse-content"
-          >
-            {children}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <CollapsedSection collapsed={collapsed}>{children}</CollapsedSection>
     </>
+  );
+}
+
+const collapsibleTitleAnimateVariants: Variants = {
+  open: { height: 'auto' },
+  collapsed: { height: 0 },
+};
+const collapsibleTitleAnimateTransition: Tween = { duration: 0.3 };
+
+export function CollapsedSection({
+  collapsed,
+  children,
+}: {
+  collapsed: boolean;
+  children: React.ReactNode;
+}) {
+  const initialMount = useRef(true);
+
+  useEffect(() => {
+    initialMount.current = false;
+  }, [initialMount]);
+
+  return (
+    <AnimatePresence>
+      {!collapsed && (
+        <motion.div
+          key="content"
+          initial={initialMount.current ? false : 'collapsed'}
+          animate="open"
+          exit="collapsed"
+          variants={collapsibleTitleAnimateVariants}
+          transition={collapsibleTitleAnimateTransition}
+          className="collapse-content"
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/src/app/dim-ui/Loading.m.scss
+++ b/src/app/dim-ui/Loading.m.scss
@@ -97,8 +97,6 @@ $image: (
   }
 }
 
-$loadingTextDuration: 200ms;
-$loadingTextDistance: 16px;
 .textContainer {
   width: 300px;
   height: 3em;
@@ -107,29 +105,9 @@ $loadingTextDistance: 16px;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  opacity: 0;
-  animation: 500ms linear $initialDelay forwards fade-in;
 }
 .text {
-  position: absolute;
   font-size: 16px;
   text-align: center;
-}
-.textEnter {
-  transform: translateY(-$loadingTextDistance);
-  opacity: 0;
-}
-.textEnter.textEnterActive {
-  transform: translateY(0);
-  opacity: 1;
-  transition: all $loadingTextDuration ease-out;
-}
-.textExit {
-  transform: translateY(0);
-  opacity: 1;
-}
-.textExit.textExitActive {
-  transform: translateY($loadingTextDistance);
-  opacity: 0;
-  transition: all $loadingTextDuration ease-out;
+  position: absolute;
 }

--- a/src/app/dim-ui/Loading.m.scss.d.ts
+++ b/src/app/dim-ui/Loading.m.scss.d.ts
@@ -8,10 +8,6 @@ interface CssExports {
   'square': string;
   'text': string;
   'textContainer': string;
-  'textEnter': string;
-  'textEnterActive': string;
-  'textExit': string;
-  'textExitActive': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/dim-ui/Loading.tsx
+++ b/src/app/dim-ui/Loading.tsx
@@ -1,17 +1,24 @@
+import { AnimatePresence, Orchestration, Tween, Variants, motion } from 'framer-motion';
 import _ from 'lodash';
-import { useRef } from 'react';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import styles from './Loading.m.scss';
 
-const transitionClasses = {
-  enter: styles.textEnter,
-  enterActive: styles.textEnterActive,
-  exit: styles.textExit,
-  exitActive: styles.textExitActive,
+const containerAnimateVariants: Variants = {
+  initial: { opacity: 0 },
+  open: { opacity: 1 },
+};
+const containerAnimateTransition: Tween & Orchestration = {
+  duration: 0.5,
+  delay: 1,
 };
 
+const messageAnimateVariants: Variants = {
+  initial: { y: -16, opacity: 0 },
+  open: { y: 0, opacity: 1 },
+  leave: { y: 16, opacity: 0 },
+};
+const messageAnimateTransition: Tween = { duration: 0.2, ease: 'easeOut' };
+
 export function Loading({ message }: { message?: string }) {
-  const nodeRef = useRef<HTMLDivElement>(null);
   return (
     <section className={styles.loading}>
       <div className={styles.container}>
@@ -20,20 +27,29 @@ export function Loading({ message }: { message?: string }) {
         ))}
       </div>
 
-      {message && (
-        <TransitionGroup className={styles.textContainer}>
-          <CSSTransition
-            key={message}
-            nodeRef={nodeRef}
-            classNames={transitionClasses}
-            timeout={{ enter: 200, exit: 200 }}
-          >
-            <div ref={nodeRef} className={styles.text}>
+      <motion.div
+        className={styles.textContainer}
+        initial="initial"
+        animate="open"
+        variants={containerAnimateVariants}
+        transition={containerAnimateTransition}
+      >
+        <AnimatePresence>
+          {message && (
+            <motion.div
+              key={message}
+              className={styles.text}
+              initial="initial"
+              animate="open"
+              exit="leave"
+              variants={messageAnimateVariants}
+              transition={messageAnimateTransition}
+            >
               {message}
-            </div>
-          </CSSTransition>
-        </TransitionGroup>
-      )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.div>
     </section>
   );
 }

--- a/src/app/dim-ui/PageLoading.m.scss
+++ b/src/app/dim-ui/PageLoading.m.scss
@@ -2,17 +2,3 @@
   position: relative;
   pointer-events: none;
 }
-
-.pageLoadingEnter {
-  opacity: 0;
-}
-.pageLoadingEnter.pageLoadingEnterActive {
-  opacity: 1;
-  transition: opacity 100ms ease-in 500ms;
-}
-
-.pageLoadingExit.pageLoadingExitActive {
-  > section {
-    opacity: 0;
-  }
-}

--- a/src/app/dim-ui/PageLoading.m.scss.d.ts
+++ b/src/app/dim-ui/PageLoading.m.scss.d.ts
@@ -2,10 +2,6 @@
 // Please do not change this file!
 interface CssExports {
   'pageLoading': string;
-  'pageLoadingEnter': string;
-  'pageLoadingEnterActive': string;
-  'pageLoadingExit': string;
-  'pageLoadingExitActive': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/dim-ui/PageLoading.tsx
+++ b/src/app/dim-ui/PageLoading.tsx
@@ -26,7 +26,7 @@ export default function PageLoading() {
   const message = useSelector(messageSelector);
   const nodeRef = useRef<HTMLDivElement>(null);
   return (
-    message !== undefined && (
+    Boolean(message) && (
       <motion.div
         ref={nodeRef}
         className={clsx('dim-page', styles.pageLoading)}

--- a/src/app/dim-ui/PageLoading.tsx
+++ b/src/app/dim-ui/PageLoading.tsx
@@ -1,40 +1,42 @@
 import { RootState } from 'app/store/types';
 import clsx from 'clsx';
+import { Orchestration, Tween, Variants, motion } from 'framer-motion';
 import _ from 'lodash';
 import { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { Loading } from './Loading';
 import styles from './PageLoading.m.scss';
 
 const messageSelector = (state: RootState) => _.last(state.shell.loadingMessages);
 
-const transitionClasses = {
-  enter: styles.pageLoadingEnter,
-  enterActive: styles.pageLoadingEnterActive,
-  exit: styles.pageLoadingExit,
-  exitActive: styles.pageLoadingExitActive,
+const animateVariants: Variants = {
+  initial: { opacity: 0 },
+  open: { opacity: 1 },
+};
+const animateTransition: Tween & Orchestration = {
+  duration: 0.1,
+  delay: 0.5,
+  ease: 'easeIn',
 };
 
 /**
- * This displays the page-level loading screen. React Suspense can make this obsolete once it's available.
+ * This displays the page-level loading screen.
  */
 export default function PageLoading() {
   const message = useSelector(messageSelector);
   const nodeRef = useRef<HTMLDivElement>(null);
   return (
-    <TransitionGroup component={null}>
-      {message !== undefined && (
-        <CSSTransition
-          nodeRef={nodeRef}
-          classNames={transitionClasses}
-          timeout={{ enter: 600, exit: 300 }}
-        >
-          <div ref={nodeRef} className={clsx('dim-page', styles.pageLoading)}>
-            <Loading message={message} />
-          </div>
-        </CSSTransition>
-      )}
-    </TransitionGroup>
+    message !== undefined && (
+      <motion.div
+        ref={nodeRef}
+        className={clsx('dim-page', styles.pageLoading)}
+        initial="initial"
+        animate="open"
+        variants={animateVariants}
+        transition={animateTransition}
+      >
+        <Loading message={message} />
+      </motion.div>
+    )
   );
 }

--- a/src/app/farming/Farming.tsx
+++ b/src/app/farming/Farming.tsx
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import { useSetting } from 'app/settings/hooks';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
-import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
+import { AnimatePresence, Spring, Variants, motion } from 'framer-motion';
 import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { stopFarming } from './actions';
@@ -14,7 +14,7 @@ const animateVariants: Variants = {
   shown: { y: 0, x: '-50%' },
   hidden: { y: 60, x: '-50%' },
 };
-const animateTransition: Tween = { duration: 0.2 };
+const animateTransition: Spring = { type: 'spring', duration: 0.3, bounce: 0 };
 
 export default function Farming() {
   const dispatch = useThunkDispatch();

--- a/src/app/farming/Farming.tsx
+++ b/src/app/farming/Farming.tsx
@@ -3,12 +3,18 @@ import { t } from 'app/i18next-t';
 import { useSetting } from 'app/settings/hooks';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
+import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
 import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { stopFarming } from './actions';
 import './farming.scss';
 import { farmingStoreSelector } from './selectors';
+
+const animateVariants: Variants = {
+  shown: { y: 0, x: '-50%' },
+  hidden: { y: 60, x: '-50%' },
+};
+const animateTransition: Tween = { duration: 0.2 };
 
 export default function Farming() {
   const dispatch = useThunkDispatch();
@@ -24,61 +30,64 @@ export default function Farming() {
   const onStopClicked = () => dispatch(stopFarming());
 
   return (
-    <TransitionGroup component={null}>
+    <AnimatePresence>
       {store && (
-        <CSSTransition nodeRef={nodeRef} classNames="farming" timeout={{ enter: 500, exit: 500 }}>
-          <div
-            ref={nodeRef}
-            id="item-farming"
-            className={clsx({ 'd2-farming': store.destinyVersion === 2 })}
-          >
-            {store.destinyVersion === 2 ? (
-              <div>
-                <p>
-                  {t('FarmingMode.D2Desc', {
-                    store: store.name,
-                    context: store.genderName,
-                    count: inventoryClearSpaces,
-                  })}{' '}
-                  {t('FarmingMode.Vault')}
-                </p>
-              </div>
-            ) : (
-              <div>
-                <p>
-                  {makeRoomForItems
-                    ? t('FarmingMode.Desc', {
-                        store: store.name,
-                        context: store.genderName,
-                        count: inventoryClearSpaces,
-                      })
-                    : t('FarmingMode.MakeRoom.Desc', {
-                        store: store.name,
-                        context: store.genderName,
-                      })}
-                </p>
-                <p>
-                  <input
-                    name="make-room-for-items"
-                    type="checkbox"
-                    checked={makeRoomForItems}
-                    onChange={makeRoomForItemsChanged}
-                  />
-                  <label htmlFor="make-room-for-items" title={t('FarmingMode.MakeRoom.Tooltip')}>
-                    {t('FarmingMode.MakeRoom.MakeRoom')}
-                  </label>
-                </p>
-              </div>
-            )}
-
+        <motion.div
+          ref={nodeRef}
+          id="item-farming"
+          className={clsx({ 'd2-farming': store.destinyVersion === 2 })}
+          initial="hidden"
+          animate="shown"
+          exit="hidden"
+          variants={animateVariants}
+          transition={animateTransition}
+        >
+          {store.destinyVersion === 2 ? (
             <div>
-              <button type="button" onClick={onStopClicked}>
-                {t('FarmingMode.Stop')}
-              </button>
+              <p>
+                {t('FarmingMode.D2Desc', {
+                  store: store.name,
+                  context: store.genderName,
+                  count: inventoryClearSpaces,
+                })}{' '}
+                {t('FarmingMode.Vault')}
+              </p>
             </div>
+          ) : (
+            <div>
+              <p>
+                {makeRoomForItems
+                  ? t('FarmingMode.Desc', {
+                      store: store.name,
+                      context: store.genderName,
+                      count: inventoryClearSpaces,
+                    })
+                  : t('FarmingMode.MakeRoom.Desc', {
+                      store: store.name,
+                      context: store.genderName,
+                    })}
+              </p>
+              <p>
+                <input
+                  name="make-room-for-items"
+                  type="checkbox"
+                  checked={makeRoomForItems}
+                  onChange={makeRoomForItemsChanged}
+                />
+                <label htmlFor="make-room-for-items" title={t('FarmingMode.MakeRoom.Tooltip')}>
+                  {t('FarmingMode.MakeRoom.MakeRoom')}
+                </label>
+              </p>
+            </div>
+          )}
+
+          <div>
+            <button type="button" onClick={onStopClicked}>
+              {t('FarmingMode.Stop')}
+            </button>
           </div>
-        </CSSTransition>
+        </motion.div>
       )}
-    </TransitionGroup>
+    </AnimatePresence>
   );
 }

--- a/src/app/inventory-page/InventoryCollapsibleTitle.tsx
+++ b/src/app/inventory-page/InventoryCollapsibleTitle.tsx
@@ -1,4 +1,5 @@
 import { collapsedSelector } from 'app/dim-api/selectors';
+import { CollapsedSection } from 'app/dim-ui/CollapsibleTitle';
 import { t } from 'app/i18next-t';
 import { DimStore } from 'app/inventory/store-types';
 import {
@@ -8,7 +9,6 @@ import {
 } from 'app/loadout-drawer/postmaster';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
-import { AnimatePresence, motion } from 'framer-motion';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import '../dim-ui/CollapsibleTitle.scss';
@@ -113,24 +113,7 @@ export default function InventoryCollapsibleTitle({
           })}
       </div>
 
-      <AnimatePresence>
-        {!collapsed && (
-          <motion.div
-            key="content"
-            initial={initialMount.current ? false : 'collapsed'}
-            animate="open"
-            exit="collapsed"
-            variants={{
-              open: { height: 'auto' },
-              collapsed: { height: 0 },
-            }}
-            transition={{ duration: 0.3 }}
-            className="collapse-content"
-          >
-            {children}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <CollapsedSection collapsed={collapsed}>{children}</CollapsedSection>
     </>
   );
 }

--- a/src/app/item-popup/EnergyMeter.tsx
+++ b/src/app/item-popup/EnergyMeter.tsx
@@ -12,10 +12,16 @@ import { errorMessage } from 'app/utils/util';
 import Cost from 'app/vendors/Cost';
 import clsx from 'clsx';
 import { SocketCategoryHashes } from 'data/d2/generated-enums';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
 import _ from 'lodash';
 import { useState } from 'react';
 import styles from './EnergyMeter.m.scss';
+
+const upgradeAnimateVariants: Variants = {
+  shown: { height: 'auto', opacity: 1 },
+  hidden: { height: 0, opacity: 0 },
+};
+const upgradeAnimateTransition: Tween = { duration: 0.3 };
 
 export default function EnergyMeter({ item }: { item: DimItem }) {
   const defs = useD2Definitions()!;
@@ -92,14 +98,11 @@ export default function EnergyMeter({ item }: { item: DimItem }) {
           {previewCapacity > minCapacity && (
             <motion.div
               className={styles.upgradePreview}
-              initial="collapsed"
-              animate="open"
-              exit="collapsed"
-              variants={{
-                open: { height: 'auto', opacity: 1 },
-                collapsed: { height: 0, opacity: 0 },
-              }}
-              transition={{ duration: 0.3 }}
+              initial="hidden"
+              animate="shown"
+              exit="hidden"
+              variants={upgradeAnimateVariants}
+              transition={upgradeAnimateTransition}
             >
               <EnergyUpgradePreview
                 item={item}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -28,7 +28,7 @@ import { Portal } from 'app/utils/temp-container';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { deepEqual } from 'fast-equals';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -56,6 +56,12 @@ import { ArmorEnergyRules, LOCKED_EXOTIC_ANY_EXOTIC, loDefaultArmorEnergyRules }
 
 /** Do not allow the user to choose artifice mods manually in Loadout Optimizer since we're supposed to be doing that */
 const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
+
+const processingAnimateVariants: Variants = {
+  hidden: { opacity: 0, y: -50 },
+  shown: { opacity: 1, y: 0 },
+};
+const processingAnimateTransition: Tween = { ease: 'easeInOut', duration: 0.5 };
 
 /**
  * The Loadout Optimizer screen
@@ -350,10 +356,11 @@ export default memo(function LoadoutBuilder({
           {processing && (
             <motion.div
               className={styles.processing}
-              initial={{ opacity: 0, y: -50 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -50 }}
-              transition={{ ease: 'easeInOut', duration: 0.5 }}
+              initial="hidden"
+              animate="shown"
+              exit="hidden"
+              variants={processingAnimateVariants}
+              transition={processingAnimateTransition}
             >
               <div>
                 {t('LoadoutBuilder.ProcessingSets', {

--- a/src/app/notifications/NotificationsContainer.tsx
+++ b/src/app/notifications/NotificationsContainer.tsx
@@ -1,11 +1,16 @@
 import { useEventBusListener } from 'app/utils/hooks';
-import { AnimatePresence, Spring } from 'framer-motion';
+import { AnimatePresence, Spring, Variants } from 'framer-motion';
 import { useCallback, useState } from 'react';
 import Notification from './Notification';
 import styles from './NotificationsContainer.m.scss';
 import { Notify, notifications$ } from './notifications';
 
 const spring: Spring = { type: 'spring', bounce: 0, duration: 0.3 };
+
+const animateVariants: Variants = {
+  hidden: { opacity: 0, height: 0 },
+  shown: { height: 'auto', opacity: 1 },
+};
 
 /** This is the root element that displays popup notifications. */
 export default function NotificationsContainer() {
@@ -28,9 +33,10 @@ export default function NotificationsContainer() {
           <Notification
             key={item.id}
             transition={spring}
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ opacity: 0, height: 0 }}
+            initial="hidden"
+            animate="shown"
+            exit="hidden"
+            variants={animateVariants}
             notification={item}
             onClose={onNotificationClosed}
           />

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -9,6 +9,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import styles from './MainSearchBarActions.m.scss';
+import { searchButtonAnimateVariants } from './SearchBar';
 import SearchResults from './SearchResults';
 import { filteredItemsSelector, queryValidSelector } from './search-filter';
 
@@ -46,9 +47,10 @@ export default function MainSearchBarActions() {
         <motion.div
           key="count"
           layout
-          exit={{ scale: 0 }}
-          initial={{ scale: 0 }}
-          animate={{ scale: 1 }}
+          variants={searchButtonAnimateVariants}
+          exit="hidden"
+          initial="hidden"
+          animate="shown"
         >
           {showSearchResults ? (
             <button

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -46,7 +46,6 @@ export default function MainSearchBarActions() {
       {showSearchCount && (
         <motion.div
           key="count"
-          layout
           variants={searchButtonAnimateVariants}
           exit="hidden"
           initial="hidden"

--- a/src/app/search/MainSearchBarMenu.tsx
+++ b/src/app/search/MainSearchBarMenu.tsx
@@ -4,6 +4,7 @@ import { querySelector } from 'app/shell/selectors';
 import { motion } from 'framer-motion';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
+import { searchButtonAnimateVariants } from './SearchBar';
 import { filteredItemsSelector, queryValidSelector } from './search-filter';
 
 /**
@@ -28,9 +29,10 @@ export default function MainSearchBarMenu() {
     <motion.div
       layout
       key="action"
-      exit={{ scale: 0 }}
-      initial={{ scale: 0 }}
-      animate={{ scale: 1 }}
+      variants={searchButtonAnimateVariants}
+      exit="hidden"
+      initial="hidden"
+      animate="shown"
     >
       {promptDialog}
       <ItemActionsDropdown

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -56,7 +56,7 @@ import './search-filter.scss';
 
 export const searchButtonAnimateVariants: Variants = {
   hidden: { scale: 0 },
-  shown: { scale: 0 },
+  shown: { scale: 1 },
 };
 
 const searchItemIcons: { [key in SearchItemType]: string } = {
@@ -539,7 +539,6 @@ function SearchBar(
 
             {liveQuery.length > 0 && (saveable || saved) && !isPhonePortrait && (
               <motion.button
-                layout
                 variants={searchButtonAnimateVariants}
                 exit="hidden"
                 initial="hidden"
@@ -556,7 +555,6 @@ function SearchBar(
 
             {(liveQuery.length > 0 || (isPhonePortrait && mainSearchBar)) && (
               <motion.button
-                layout
                 variants={searchButtonAnimateVariants}
                 exit="hidden"
                 initial="hidden"

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -16,7 +16,7 @@ import { isiOSBrowser } from 'app/utils/browsers';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { UseComboboxState, UseComboboxStateChangeOptions, useCombobox } from 'downshift';
-import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
+import { AnimatePresence, LayoutGroup, Variants, motion } from 'framer-motion';
 import _ from 'lodash';
 import React, {
   Suspense,
@@ -53,6 +53,11 @@ import { canonicalizeQuery, parseQuery } from './query-parser';
 import { searchConfigSelector } from './search-config';
 import { validateQuerySelector } from './search-filter';
 import './search-filter.scss';
+
+export const searchButtonAnimateVariants: Variants = {
+  hidden: { scale: 0 },
+  shown: { scale: 0 },
+};
 
 const searchItemIcons: { [key in SearchItemType]: string } = {
   [SearchItemType.Recent]: faClock,
@@ -535,9 +540,10 @@ function SearchBar(
             {liveQuery.length > 0 && (saveable || saved) && !isPhonePortrait && (
               <motion.button
                 layout
-                exit={{ scale: 0 }}
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
+                variants={searchButtonAnimateVariants}
+                exit="hidden"
+                initial="hidden"
+                animate="shown"
                 key="save"
                 type="button"
                 className={clsx(styles.filterBarButton, styles.saveSearchButton)}
@@ -551,9 +557,10 @@ function SearchBar(
             {(liveQuery.length > 0 || (isPhonePortrait && mainSearchBar)) && (
               <motion.button
                 layout
-                exit={{ scale: 0 }}
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
+                variants={searchButtonAnimateVariants}
+                exit="hidden"
+                initial="hidden"
+                animate="shown"
                 key="clear"
                 type="button"
                 className={styles.filterBarButton}

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -228,23 +228,6 @@ $header-height: 44px;
     }
   }
 }
-.dropdownEnter {
-  transform: translateX(-250px);
-}
-
-.dropdownEnter.dropdownEnterActive {
-  transform: translateX(0);
-  transition: transform 200ms $easeOutCubic;
-}
-
-.dropdownExit {
-  transform: translateX(0);
-}
-
-.dropdownExit.dropdownExitActive {
-  transform: translateX(-250px);
-  transition: transform 200ms $easeInCubic;
-}
 
 .pwaPrompt {
   margin: 1em 10px;

--- a/src/app/shell/Header.m.scss.d.ts
+++ b/src/app/shell/Header.m.scss.d.ts
@@ -6,10 +6,6 @@ interface CssExports {
   'container': string;
   'dev': string;
   'dropdown': string;
-  'dropdownEnter': string;
-  'dropdownEnterActive': string;
-  'dropdownExit': string;
-  'dropdownExitActive': string;
   'header': string;
   'headerLinks': string;
   'headerRight': string;

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -14,13 +14,13 @@ import { useSetCSSVarToHeight } from 'app/utils/hooks';
 import { infoLog } from 'app/utils/log';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
+import { AnimatePresence, motion } from 'framer-motion';
 import logo from 'images/logo-type-right-light.svg';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { Link, NavLink } from 'react-router-dom';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { useSubscription } from 'use-subscription';
 import ClickOutside from '../dim-ui/ClickOutside';
 import ExternalLink from '../dim-ui/ExternalLink';
@@ -44,13 +44,6 @@ const logoStyles = {
   dev: styles.dev,
   release: undefined,
   test: undefined,
-} as const;
-
-const transitionClasses = {
-  enter: styles.dropdownEnter,
-  enterActive: styles.dropdownEnterActive,
-  exit: styles.dropdownExit,
-  exitActive: styles.dropdownExitActive,
 } as const;
 
 // TODO: finally time to hack apart the header styles!
@@ -293,20 +286,25 @@ export default function Header() {
           <AppIcon icon={menuIcon} />
           <MenuBadge />
         </button>
-        <TransitionGroup component={null}>
+        <AnimatePresence>
           {dropdownOpen && (
-            <CSSTransition
-              nodeRef={dropdownRef}
-              classNames={transitionClasses}
-              timeout={{ enter: 500, exit: 500 }}
+            <motion.div
+              key="dropdown"
+              className={styles.dropdown}
+              role="menu"
+              initial="collapsed"
+              animate="open"
+              exit="collapsed"
+              variants={{
+                open: { x: 0 },
+                collapsed: { x: -250 },
+              }}
+              transition={{ duration: 0.2 }}
             >
               <ClickOutside
                 ref={dropdownRef}
                 extraRef={dropdownToggler}
-                key="dropdown"
-                className={styles.dropdown}
                 onClickOutside={hideDropdown}
-                role="menu"
               >
                 {destinyLinks}
                 <hr />
@@ -334,9 +332,9 @@ export default function Header() {
                 {dimLinks}
                 <MenuAccounts closeDropdown={hideDropdown} />
               </ClickOutside>
-            </CSSTransition>
+            </motion.div>
           )}
-        </TransitionGroup>
+        </AnimatePresence>
         <Link to="/" className={clsx(styles.menuItem, styles.logoLink)}>
           <img
             className={clsx(styles.logo, logoStyles[$DIM_FLAVOR])}

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -14,7 +14,7 @@ import { useSetCSSVarToHeight } from 'app/utils/hooks';
 import { infoLog } from 'app/utils/log';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
-import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
+import { AnimatePresence, Spring, Variants, motion } from 'framer-motion';
 import logo from 'images/logo-type-right-light.svg';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -50,7 +50,7 @@ const menuAnimateVariants: Variants = {
   open: { x: 0 },
   collapsed: { x: -250 },
 };
-const menuAnimateTransition: Tween = { duration: 0.3, ease: 'easeOut' };
+const menuAnimateTransition: Spring = { type: 'spring', duration: 0.3, bounce: 0 };
 
 // TODO: finally time to hack apart the header styles!
 

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -14,7 +14,7 @@ import { useSetCSSVarToHeight } from 'app/utils/hooks';
 import { infoLog } from 'app/utils/log';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
 import logo from 'images/logo-type-right-light.svg';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -45,6 +45,12 @@ const logoStyles = {
   release: undefined,
   test: undefined,
 } as const;
+
+const menuAnimateVariants: Variants = {
+  open: { x: 0 },
+  collapsed: { x: -250 },
+};
+const menuAnimateTransition: Tween = { duration: 0.3, ease: 'easeOut' };
 
 // TODO: finally time to hack apart the header styles!
 
@@ -295,11 +301,8 @@ export default function Header() {
               initial="collapsed"
               animate="open"
               exit="collapsed"
-              variants={{
-                open: { x: 0 },
-                collapsed: { x: -250 },
-              }}
-              transition={{ duration: 0.2 }}
+              variants={menuAnimateVariants}
+              transition={menuAnimateTransition}
             >
               <ClickOutside
                 ref={dropdownRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,13 +2195,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^4.2.0":
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.6.tgz#18187bcda5281f8e10dfc48f0943e2fdf4f75e2e"
-  integrity sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*", "@types/react@18.2.16", "@types/react@^18.0.12":
   version "18.2.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.16.tgz#403dda0e933caccac9efde569923239ac426786c"


### PR DESCRIPTION
While I like the idea of using pure CSS transitions for enter/exit animations, `react-transition-group` is both hard to use and a [weirdly large dependency](https://bundlephobia.com/package/react-transition-group@4.4.5). Since we're already using Framer Motion I figured we should just swap to that and drop the dependency. I also cleaned up our other Framer animations to use constant variants lists.

That said, as flexible and easy as Framer Motion is, I've found it to have lots of quirks as well, and we don't use much of its very large feature set. I sometimes wonder if we could replace our usages with some relatively small Web Animation API hooks and a spring function.