### PR TITLE
add shortcuts for overview/triage tabs issue #9058

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Fixed "Fill in using equipped" in a Loadout's subclass section failing to copy Aspects and Fragments.
+* You can now use left and right keys to switch between Overview and Triage tabs.
 
 ## 7.79.0 <span class="changelog-date">(2023-07-30)</span>
 

--- a/src/app/item-popup/ItemPopupBody.tsx
+++ b/src/app/item-popup/ItemPopupBody.tsx
@@ -1,8 +1,10 @@
 import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
+import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import { doShowTriage, ItemTriage, TriageTabToggle } from 'app/item-triage/ItemTriage';
 import { percent } from 'app/shell/formatters';
 import clsx from 'clsx';
+import { useCallback } from 'react';
 import { DimItem } from '../inventory/item-types';
 import { ItemPopupExtraInfo } from './item-popup';
 import ItemDetails from './ItemDetails';
@@ -49,6 +51,27 @@ export default function ItemPopupBody({
       component: <ItemTriage item={item} />,
     });
   }
+
+  const changeToTriageTab = useCallback((event: KeyboardEvent) => {
+    if (tabs.length < 2) {
+      return;
+    }
+    event.preventDefault();
+    onTabChanged(tabs[1].tab);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const changeToOverviewTab = useCallback((event: KeyboardEvent) => {
+    if (tabs.length < 2) {
+      return;
+    }
+    event.preventDefault();
+    onTabChanged(tabs[0].tab);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useHotkey('right', 'Switch to Triage tab', changeToTriageTab);
+  useHotkey('left', 'Switch to Overview tab', changeToOverviewTab);
 
   return (
     <div>


### PR DESCRIPTION
Hi! This is my firs contribution to your project.
Now it is possible to switch overview/triage tabs using left and right keys. It was made using useHotkey hook, hope this was the right decision. 