### PR TITLE
Masterwork revised designs

### DIFF
--- a/src/app/_theme-dimdark.scss
+++ b/src/app/_theme-dimdark.scss
@@ -64,7 +64,6 @@
   --theme-item-polaroid-hover-border: #ddd;
   --theme-item-polaroid-masterwork: #745700;
   --theme-item-polaroid-masterwork-txt: var(--theme-text);
-  --theme-item-polaroid-masterwork-border: #745700;
   --theme-item-polaroid-capped: #745700;
   --theme-item-polaroid-capped-txt: var(--theme-text);
   --theme-item-polaroid-godroll: var(--theme-text);

--- a/src/app/_theme-europa.scss
+++ b/src/app/_theme-europa.scss
@@ -69,7 +69,6 @@
   --theme-item-polaroid-txt: black;
   --theme-item-polaroid-masterwork: #88cbed;
   --theme-item-polaroid-masterwork-txt: #000;
-  --theme-item-polaroid-masterwork-border: #3fefff;
   --theme-item-polaroid-capped: #f2a5ce;
   --theme-item-polaroid-capped-txt: #be0a99;
   --theme-item-polaroid-godroll: white;

--- a/src/app/_theme-neomuna.scss
+++ b/src/app/_theme-neomuna.scss
@@ -71,7 +71,6 @@
   --theme-item-polaroid-txt: black;
   --theme-item-polaroid-masterwork: #c9009e;
   --theme-item-polaroid-masterwork-txt: #dec1d8;
-  --theme-item-polaroid-masterwork-border: #40abb5;
   --theme-item-polaroid-capped: #ebb920;
   --theme-item-polaroid-capped-txt: #000;
   --theme-item-polaroid-godroll: white;

--- a/src/app/_theme-pyramid.scss
+++ b/src/app/_theme-pyramid.scss
@@ -68,7 +68,6 @@
   --theme-item-polaroid-txt: white;
   --theme-item-polaroid-masterwork: #d19b00;
   --theme-item-polaroid-masterwork-txt: #000;
-  --theme-item-polaroid-masterwork-border: #e2761d;
   --theme-item-polaroid-capped: #f55656;
   --theme-item-polaroid-capped-txt: #fff;
   --theme-item-polaroid-godroll: #fff;

--- a/src/app/_theme-throneworld.scss
+++ b/src/app/_theme-throneworld.scss
@@ -65,7 +65,6 @@
   --theme-item-polaroid-hover-border: #ddd;
   --theme-item-polaroid-masterwork: #9aad11;
   --theme-item-polaroid-masterwork-txt: black;
-  --theme-item-polaroid-masterwork-border: #d1e15d;
   --theme-item-polaroid-capped: #eab53c;
   --theme-item-polaroid-capped-txt: #b44e09;
   --theme-item-polaroid-godroll: #0b486b;

--- a/src/app/_theme-vexnet.scss
+++ b/src/app/_theme-vexnet.scss
@@ -69,7 +69,6 @@
   --theme-item-polaroid-txt: black;
   --theme-item-polaroid-masterwork: #5ed12c;
   --theme-item-polaroid-masterwork-txt: #000;
-  --theme-item-polaroid-masterwork-border: #d3c2ce;
   --theme-item-polaroid-capped: #ffc4c4;
   --theme-item-polaroid-capped-txt: #e54127;
   --theme-item-polaroid-godroll: white;

--- a/src/app/_theme.scss
+++ b/src/app/_theme.scss
@@ -65,7 +65,6 @@
   --theme-item-polaroid-hover-border: #ddd;
   --theme-item-polaroid-masterwork: #eade8b;
   --theme-item-polaroid-masterwork-txt: var(--theme-text-invert);
-  --theme-item-polaroid-masterwork-border: #ae791e;
   --theme-item-polaroid-capped: #f5dc56;
   --theme-item-polaroid-capped-txt: #f2721b;
   --theme-item-polaroid-godroll: #0b486b;

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -172,32 +172,6 @@ $search-bar-height: 28px;
     50% 50%,
     50% 50%,
     50% 50%;
-
-  // Border
-  &::before {
-    content: '';
-    position: absolute;
-    box-sizing: border-box;
-    height: calc(var(--item-size) - #{2 * $item-border-width});
-    width: calc(var(--item-size) - #{2 * $item-border-width});
-    left: 0;
-    top: 0;
-
-    border-width: 1px;
-    border-style: solid;
-    border-image-slice: 1;
-    border-image-source: conic-gradient(
-      from 45deg at 50% 50%,
-      var(--theme-item-polaroid-masterwork-border) 0%,
-      transparent 24%,
-      transparent 25%,
-      var(--theme-item-polaroid-masterwork-border) 50%,
-      var(--theme-item-polaroid-masterwork-border) 50%,
-      transparent 74%,
-      transparent 75%,
-      var(--theme-item-polaroid-masterwork-border) 100%
-    );
-  }
 }
 
 /*

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -122,58 +122,6 @@ $search-bar-height: 28px;
   }
 }
 
-// Masterwork pattern a la .src/images/exotic-masterwork.png
-// Border with gradient running into top-right / bottom-left corners
-// Dark gradient from top, masterwork border gradient from bottom, striped diamond overlay for texture
-@mixin masterwork($top-gradient: 0.05, $light-stripe: 0.05, $dark-stripe: 0.02) {
-  // Overlay
-  $light-stripe: rgba(255, 255, 255, $light-stripe);
-  $dark-stripe: rgba(0, 0, 0, $dark-stripe);
-  background:
-    linear-gradient(rgba(0, 0, 0, $top-gradient) 0%, transparent 33%),
-    linear-gradient(transparent 50%, var(--theme-item-polaroid-masterwork-border) 200%),
-    repeating-linear-gradient(
-        to bottom right,
-        #{$light-stripe} 0%,
-        #{$light-stripe} 5%,
-        #{$dark-stripe} 5%,
-        #{$dark-stripe} 10%
-      )
-      bottom right,
-    repeating-linear-gradient(
-        to bottom left,
-        #{$light-stripe} 0%,
-        #{$light-stripe} 5%,
-        #{$dark-stripe} 5%,
-        #{$dark-stripe} 10%
-      )
-      bottom left,
-    repeating-linear-gradient(
-        to top left,
-        #{$light-stripe} 0%,
-        #{$light-stripe} 5%,
-        #{$dark-stripe} 5%,
-        #{$dark-stripe} 10%
-      )
-      top left,
-    repeating-linear-gradient(
-        to top right,
-        #{$light-stripe} 0%,
-        #{$light-stripe} 5%,
-        #{$dark-stripe} 5%,
-        #{$dark-stripe} 10%
-      )
-      top right;
-  background-repeat: no-repeat;
-  background-size:
-    100%,
-    100%,
-    50% 50%,
-    50% 50%,
-    50% 50%,
-    50% 50%;
-}
-
 /*
 Utility functions to allow for augmenting a hex color value with an alpha component.
 

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -62,7 +62,7 @@ $commonBg: #366f42;
   border-color: transparent;
 }
 
-// The overlay image for masterworks and Deepsight weapons
+// Masterwork pattern emulating .src/images/masterwork.png
 .backgroundOverlay {
   position: absolute;
   box-sizing: border-box;
@@ -72,11 +72,70 @@ $commonBg: #366f42;
   left: $item-border-width;
 }
 .legendaryMasterwork {
-  @include masterwork(0.15, 0.013, 0.015);
+  box-shadow: inset 0 0 2px 1px rgba(0, 0, 0, 0.25);
+  background:
+    radial-gradient(ellipse at center bottom, rgba(255, 255, 255, 0.2), transparent 75%) center
+      bottom,
+    radial-gradient(ellipse at center bottom, rgba(255, 255, 255, 0.1), transparent 75%) center
+      bottom;
+  background-size:
+    125% 30%,
+    50% 50%;
+  background-repeat: no-repeat, no-repeat;
 }
 
+// Exotic Masterwork pattern emulating .src/images/exotic-masterwork.png
 .exoticMasterwork {
-  @include masterwork(0.25, 0.035, 0.01);
+  $light-stripe: rgba(255, 255, 255, 0.003);
+  $dark-stripe: rgba(0, 0, 0, 0.025);
+  box-shadow: inset 0 0 2px 1px rgba(0, 0, 0, 0.25);
+  background:
+    linear-gradient(rgba(0, 0, 0, 0.3) 0%, transparent 20%),
+    linear-gradient(
+      transparent 50%,
+      rgba(255, 255, 255, 0.225) 65%,
+      rgba(255, 255, 255, 0.225) 100%
+    ),
+    repeating-linear-gradient(
+        to bottom right,
+        #{$light-stripe} 0%,
+        #{$light-stripe} 5%,
+        #{$dark-stripe} 5%,
+        #{$dark-stripe} 12.5%
+      )
+      bottom right,
+    repeating-linear-gradient(
+        to bottom left,
+        #{$light-stripe} 0%,
+        #{$light-stripe} 5%,
+        #{$dark-stripe} 5%,
+        #{$dark-stripe} 12.5%
+      )
+      bottom left,
+    repeating-linear-gradient(
+        to top left,
+        #{$light-stripe} 0%,
+        #{$light-stripe} 5%,
+        #{$dark-stripe} 5%,
+        #{$dark-stripe} 12.5%
+      )
+      top left,
+    repeating-linear-gradient(
+        to top right,
+        #{$light-stripe} 0%,
+        #{$light-stripe} 5%,
+        #{$dark-stripe} 5%,
+        #{$dark-stripe} 12.5%
+      )
+      top right;
+  background-repeat: no-repeat;
+  background-size:
+    100%,
+    100%,
+    50% 50%,
+    50% 50%,
+    50% 50%,
+    50% 50%;
 }
 .deepsightBorder {
   border: 2px solid $deepsight-border-color;

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -72,7 +72,7 @@ $commonBg: #366f42;
   left: $item-border-width;
 }
 .legendaryMasterwork {
-  box-shadow: inset 0 0 2px 1px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 1px 0 rgba(0, 0, 0, 0.25);
   background:
     radial-gradient(ellipse at center bottom, rgba(255, 255, 255, 0.2), transparent 75%) center
       bottom,
@@ -88,7 +88,7 @@ $commonBg: #366f42;
 .exoticMasterwork {
   $light-stripe: rgba(255, 255, 255, 0.003);
   $dark-stripe: rgba(0, 0, 0, 0.025);
-  box-shadow: inset 0 0 2px 1px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 1px 1px rgba(0, 0, 0, 0.15);
   background:
     linear-gradient(rgba(0, 0, 0, 0.3) 0%, transparent 20%),
     linear-gradient(

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -62,7 +62,6 @@ $commonBg: #366f42;
   border-color: transparent;
 }
 
-// Masterwork pattern emulating .src/images/masterwork.png
 .backgroundOverlay {
   position: absolute;
   box-sizing: border-box;
@@ -71,12 +70,15 @@ $commonBg: #366f42;
   top: $item-border-width;
   left: $item-border-width;
 }
+
+// Masterwork pattern emulating .src/images/masterwork.png
+// Tint hue is based an RGB of $stat-masterworked
 .legendaryMasterwork {
   box-shadow: inset 0 0 1px 0 rgba(0, 0, 0, 0.25);
   background:
-    radial-gradient(ellipse at center bottom, rgba(255, 255, 255, 0.2), transparent 75%) center
+    radial-gradient(ellipse at center bottom, rgba(232, 165, 52, 0.2), transparent 75%) center
       bottom,
-    radial-gradient(ellipse at center bottom, rgba(255, 255, 255, 0.1), transparent 75%) center
+    radial-gradient(ellipse at center bottom, rgba(232, 165, 52, 0.1), transparent 75%) center
       bottom;
   background-size:
     125% 30%,

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -72,14 +72,22 @@ $commonBg: #366f42;
 }
 
 // Masterwork pattern emulating .src/images/masterwork.png
-// Tint hue is based an RGB of $stat-masterworked
+$rgb-masterworked: dim-hex-to-rgb-values($stat-masterworked);
 .legendaryMasterwork {
   box-shadow: inset 0 0 1px 0 rgba(0, 0, 0, 0.25);
   background:
-    radial-gradient(ellipse at center bottom, rgba(232, 165, 52, 0.2), transparent 75%) center
-      bottom,
-    radial-gradient(ellipse at center bottom, rgba(232, 165, 52, 0.1), transparent 75%) center
-      bottom;
+    radial-gradient(
+        ellipse at center bottom,
+        dim-rgb-values-to-rgba($rgb-masterworked, $alpha: 0.2),
+        transparent 75%
+      )
+      center bottom,
+    radial-gradient(
+        ellipse at center bottom,
+        dim-rgb-values-to-rgba($rgb-masterworked, $alpha: 0.1),
+        transparent 75%
+      )
+      center bottom;
   background-size:
     125% 30%,
     50% 50%;

--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -101,11 +101,10 @@ $rgb-masterworked: dim-hex-to-rgb-values($stat-masterworked);
   box-shadow: inset 0 0 1px 1px rgba(0, 0, 0, 0.15);
   background:
     linear-gradient(rgba(0, 0, 0, 0.3) 0%, transparent 20%),
-    linear-gradient(
-      transparent 50%,
-      rgba(255, 255, 255, 0.225) 65%,
-      rgba(255, 255, 255, 0.225) 100%
-    ),
+    radial-gradient(ellipse at center bottom, rgba(255, 255, 255, 0.225), transparent 75%) center
+      bottom,
+    radial-gradient(ellipse at center bottom, rgba(255, 255, 255, 0.15), transparent 75%) center
+      bottom,
     repeating-linear-gradient(
         to bottom right,
         #{$light-stripe} 0%,
@@ -141,7 +140,8 @@ $rgb-masterworked: dim-hex-to-rgb-values($stat-masterworked);
   background-repeat: no-repeat;
   background-size:
     100%,
-    100%,
+    125% 30%,
+    50% 50%,
     50% 50%,
     50% 50%,
     50% 50%,


### PR DESCRIPTION
Bringing the masterwork styles more inline with the original PNGs following feedback in #9634 and #9679 

- Both overlays: 
    - Removed border with gradient 
    - Added subtle inset shadow on both overlays
    - Removed `@include` since overlays no longer need to be re-usable
- Exotic masterwork:
   - Made bottom gradient always white (instead of inheriting the often muddy masterwork yellow)
    - Increased spacing between lines in the overlay pattern to reduce tripyness 
    - Adjusted gradient curves and opacity 
    - Note: Bottom white overlay has been reduced a little as this was previously making thumbnails appear overly faded 
- Legendary masterwork:
    - Removed pattern overlay
    - Added white bottom radial gradients emulating the previous PNG

![image](https://github.com/DestinyItemManager/DIM/assets/1396158/d989eb8a-ce48-4be4-850e-2ec8444038c3)
