### PR TITLE
Theme fix: translucent rows in filter help dialog

### DIFF
--- a/src/app/search/FilterHelp.m.scss
+++ b/src/app/search/FilterHelp.m.scss
@@ -8,15 +8,18 @@
     padding: 0;
     border-collapse: collapse;
     border-spacing: 0;
-    background-color: #222;
+    background-color: rgba(255, 255, 255, 0.1);
     width: 100%;
 
     @include phone-portrait {
       table-layout: fixed;
     }
 
+    tr:nth-child(2n) {
+      background-color: rgba(0, 0, 0, 0.1);
+    }
     tr:nth-child(2n + 1) {
-      background-color: #1b1b1b;
+      background-color: rgba(0, 0, 0, 0.3);
     }
   }
   th {

--- a/src/app/search/FilterHelp.m.scss
+++ b/src/app/search/FilterHelp.m.scss
@@ -8,7 +8,7 @@
     padding: 0;
     border-collapse: collapse;
     border-spacing: 0;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(255, 255, 255, 0.15);
     width: 100%;
 
     @include phone-portrait {
@@ -56,6 +56,10 @@
 
 .search {
   margin: 8px 0 !important;
+
+  :global(.search-filter) {
+    background-color: rgba(255, 255, 255, 0.15);
+  }
 }
 
 .entry {

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  background: var(--theme-search-bg);
+  background-color: var(--theme-search-bg);
   padding-left: 5px;
   padding-right: 5px;
   height: $search-bar-height;

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  background: #313233;
+  background: var(--theme-search-bg);
   padding-left: 5px;
   padding-right: 5px;
   height: $search-bar-height;


### PR DESCRIPTION
Small fix for #9634

The table rows in the Filter Help dialog were hard-coded 'blacks'. 

- Made filter help dialog rows translucent to fit in better with all themes  
- Use a translucent tint for the filter box background colour 

Note: I tried re-using the organizer row tint variables (`--theme-organizer-row-odd-bg` + `--theme-organizer-row-even-bg`), but these looked too harsh since the modal background is generally a lot darker than the page background in most themes 

***

Before (Throne World theme):
<img width="822" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/389824c7-c82b-4b7e-96ab-d6aeea58ae22">

After:
<img width="840" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/0efd54e4-6a52-4ffd-8b78-1da6003f7a8b">

***

Before (default theme):
<img width="829" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/b4fbfc3a-375d-4f41-80b3-5ca13e6646d0">

After: 
<img width="819" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/45674ae0-98d6-46b7-8a58-b9a5b3635b7f">