### PR TITLE
Theme fix: LO remove border color override 

### DIFF
--- a/src/app/loadout/loadout-ui/Sockets.m.scss
+++ b/src/app/loadout/loadout-ui/Sockets.m.scss
@@ -11,9 +11,6 @@
   :global(.item) {
     --item-size: var(--item-icon-size);
   }
-  :global(.item-img) {
-    border-color: var(--theme-item-socket-border);
-  }
 }
 
 .automaticallyPicked {


### PR DESCRIPTION
Fix for issue #9706 (part of theming #9634)

Removed the border colour override on mod sockets in the Loadout Optimzer 

- Intrinsic perks no longer have a border 
- Armour mod socket borders reverted to the default item/polaroid border colour

<img width="644" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/3dcb11c6-842c-42e7-af8d-bc2c15c2f99a">
