### PR TITLE
Classic theme: Match PWA tint to nav header

### DIFF
--- a/src/app/_theme-classic.scss
+++ b/src/app/_theme-classic.scss
@@ -7,7 +7,7 @@
   --theme-app-bg-gradient: var(--theme-app-bg);
 
   // The color of PWA elements like the title bar. This cannot be a gradient.
-  --theme-pwa-background: #1d2b5e;
+  --theme-pwa-background: #000;
 
   // Header
   --theme-header-nav-bg: #000;


### PR DESCRIPTION
Small fix for classic theme #9634 

PWA tint made black to match the nav header. 

This appears to have been (mistakenly?) using the same blue from the Europa theme which doesn't match the other colours in the classic theme. 