### PR TITLE
StoreBucket no connect

### DIFF
--- a/src/app/inventory-page/StoreInventoryItem.tsx
+++ b/src/app/inventory-page/StoreInventoryItem.tsx
@@ -1,7 +1,7 @@
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { streamDeckSelectionSelector } from 'app/stream-deck/selectors';
 import { streamDeckSelectItem } from 'app/stream-deck/stream-deck';
-import React, { useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import DraggableInventoryItem from '../inventory/DraggableInventoryItem';
@@ -16,7 +16,7 @@ interface Props {
 /**
  * The "full" inventory item, which can be dragged around and which pops up a move popup when clicked.
  */
-export default function StoreInventoryItem({ item }: Props) {
+export default memo(function StoreInventoryItem({ item }: Props) {
   const dispatch = useThunkDispatch();
   const doubleClicked = useCallback(
     (e: React.MouseEvent) => dispatch(moveItemToCurrentStore(item, e)),
@@ -26,7 +26,7 @@ export default function StoreInventoryItem({ item }: Props) {
   const selection = $featureFlags.elgatoStreamDeck
     ? // eslint-disable-next-line
       useSelector(streamDeckSelectionSelector)
-    : null;
+    : undefined;
 
   return (
     <DraggableInventoryItem item={item}>
@@ -47,4 +47,4 @@ export default function StoreInventoryItem({ item }: Props) {
       </ItemPopupTrigger>
     </DraggableInventoryItem>
   );
-}
+});

--- a/src/app/inventory/ItemPopupTrigger.tsx
+++ b/src/app/inventory/ItemPopupTrigger.tsx
@@ -46,13 +46,11 @@ export default function ItemPopupTrigger({
   // Close the popup if this component is unmounted
   useEffect(
     () => () => {
-      if (showItemPopup$.getCurrentValue()?.item === item) {
+      if (showItemPopup$.getCurrentValue()?.item?.index === item.index) {
         hideItemPopup();
       }
     },
-    // We really only want to do this on unmount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [item.index]
   );
 
   return children(ref, clicked) as JSX.Element;


### PR DESCRIPTION
StoreBucket was using some weird tricks with `connect` and `mapStateToProps` to skip rendering in most cases. This was hard to understand, and was one of the few remaining uses of `connect`. This PR changes it to use some more standard techniques that fit better with the rest of the codebase.

I also fixed an issue with RefreshButton where it would no-op render every second, and memoized StoreInventoryItem to shave off a little bit of render time when we *do* re-render items.