### PR TITLE
Tweak sizing on character tiles to avoid tile scaling

### DIFF
--- a/src/app/character-tile/CharacterTile.m.scss
+++ b/src/app/character-tile/CharacterTile.m.scss
@@ -5,17 +5,25 @@
   display: flex;
   position: relative;
   z-index: 0;
+  height: 48px;
+  max-width: 237px;
 }
 
 .background {
   position: absolute;
   width: 100%;
   height: 100%;
-  background-size: cover;
+  background-size: 237px 48px;
   background-position: left center;
   background-repeat: no-repeat;
   background-color: black;
   z-index: -1;
+  box-sizing: border-box;
+  :global(.vault) & {
+    border: 1px solid rgba(0, 0, 0, 0.3);
+    border-right: none;
+    background-size: cover;
+  }
 }
 
 .top,
@@ -26,6 +34,7 @@
 
 .top {
   font-size: 20px;
+  margin-top: 2px;
 
   @include phone-portrait {
     .maxTotalPower {
@@ -67,6 +76,7 @@
     .top,
     .bottom {
       flex: 1;
+      margin-top: 0;
     }
   }
 

--- a/src/app/character-tile/StoreHeading.scss
+++ b/src/app/character-tile/StoreHeading.scss
@@ -5,15 +5,12 @@
   display: flex;
   flex-direction: row;
   position: relative;
-  height: 100%;
-  height: 46px;
   white-space: nowrap;
   box-sizing: border-box;
+  max-width: 237px + 16px;
 
   &.vault {
     width: calc(6px + var(--character-column-width) - var(--item-margin));
-    border: 1px solid rgba(0, 0, 0, 0.3);
-    border-right: none;
 
     @include phone-portrait {
       width: auto;

--- a/src/app/destiny1/activities/activities.scss
+++ b/src/app/destiny1/activities/activities.scss
@@ -18,7 +18,7 @@
     margin-right: 12px;
 
     .character {
-      height: 46px;
+      height: 48px;
       width: 220px;
     }
 

--- a/src/app/dim-ui/CharacterSelect.m.scss
+++ b/src/app/dim-ui/CharacterSelect.m.scss
@@ -6,7 +6,7 @@
 }
 
 .tile {
-  height: 46px;
+  height: 48px;
 
   @include phone-portrait {
     min-width: 260px;

--- a/src/app/inventory-page/Stores.scss
+++ b/src/app/inventory-page/Stores.scss
@@ -169,7 +169,7 @@
   z-index: 10;
   grid-template-columns:
     repeat(var(--num-characters), calc(6px + var(--character-column-width) + var(--column-padding)))
-    calc(6px + var(--character-column-width) + var(--column-padding)) min-content 1fr !important;
+    min-content min-content 1fr !important;
   background: var(--theme-header-characters-bg);
   background-position: center top;
   background-repeat: no-repeat;


### PR DESCRIPTION
Not sure how I never noticed this, but character tiles were just a *bit* too short which caused some blurry non-integer scaling. This fixes that, and also prevents them from getting super wide when larger inventory column sizes are selected.

Before / After:
<img width="569" alt="Screenshot 2023-08-18 at 4 40 17 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/c381dc83-d451-4728-a63c-fadc0284888d">
<img width="558" alt="Screenshot 2023-08-18 at 4 40 21 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/f5cfdae0-7054-448c-86ae-b07bde82e28d">
