### PR TITLE
Don't set power initially for D1 items

### DIFF
--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -347,7 +347,7 @@ function makeItem(
     taggable: false,
     comparable: false,
     wishListEnabled: false,
-    power: item.primaryStat?.value ?? 0,
+    power: 0,
     index: '',
     infusable: false,
     infusionFuel: false,


### PR DESCRIPTION
Fixes #9742

Before:
<img width="345" alt="Screenshot 2023-08-21 at 11 01 09 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/cd8d3fc9-8cbb-44da-99b7-9cec74f37488">

After:
<img width="335" alt="Screenshot 2023-08-21 at 11 01 14 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/8dc49c2e-d2ce-4eef-af01-967393dd579b">
