### PR TITLE
Improve IDB testing / mitigation

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -44,7 +44,7 @@ const i18nPromise = initi18n();
 (async () => {
   const root = createRoot(document.getElementById('app')!);
 
-  // idbReady works around a bug in Safari 14 where IndexedDB doesn't initialize sometimes
+  // idbReady works around a bug in Safari 14 where IndexedDB doesn't initialize sometimes. Fixed in Safari 14.7
   await idbReady();
   // Block on testing that we can use LocalStorage and IDB, before everything starts trying to use it
   const storageWorks = await storageTest();

--- a/src/StorageTest.tsx
+++ b/src/StorageTest.tsx
@@ -1,6 +1,6 @@
 import { t } from 'app/i18next-t';
 import ErrorPanel from 'app/shell/ErrorPanel';
-import { set } from 'app/storage/idb-keyval';
+import { get, set } from 'app/storage/idb-keyval';
 import { errorLog } from 'app/utils/log';
 
 export function StorageBroken() {
@@ -35,5 +35,11 @@ export async function storageTest() {
     return false;
   }
 
-  return true;
+  try {
+    const idbValue = await get<boolean>('idb-test');
+    return idbValue;
+  } catch (e) {
+    errorLog('storage', 'Failed IndexedDB Test', e);
+    return false;
+  }
 }

--- a/src/StorageTest.tsx
+++ b/src/StorageTest.tsx
@@ -39,7 +39,7 @@ export async function storageTest() {
       // Report to sentry, I want to know if this ever works
       reportException('deleting database fixed IDB set', e);
     } catch (e2) {
-      errorLog('storage', 'Failed IndexedDB Set Test - deleting database did not help', e);
+      errorLog('storage', 'Failed IndexedDB Set Test - deleting database did not help', e2);
     }
     reportException('Failed IndexedDB Set Test', e);
     return false;
@@ -59,7 +59,7 @@ export async function storageTest() {
       }
       return idbValue;
     } catch (e2) {
-      errorLog('storage', 'Failed IndexedDB Get Test - deleting database did not help', e);
+      errorLog('storage', 'Failed IndexedDB Get Test - deleting database did not help', e2);
     }
     reportException('Failed IndexedDB Get Test', e);
     return false;

--- a/src/StorageTest.tsx
+++ b/src/StorageTest.tsx
@@ -1,6 +1,7 @@
 import { t } from 'app/i18next-t';
 import ErrorPanel from 'app/shell/ErrorPanel';
-import { get, set } from 'app/storage/idb-keyval';
+import { deleteDatabase, get, set } from 'app/storage/idb-keyval';
+import { reportException } from 'app/utils/exceptions';
 import { errorLog } from 'app/utils/log';
 
 export function StorageBroken() {
@@ -31,7 +32,16 @@ export async function storageTest() {
   try {
     await set('idb-test', true);
   } catch (e) {
-    errorLog('storage', 'Failed IndexedDB Test', e);
+    errorLog('storage', 'Failed IndexedDB Set Test - trying to delete database', e);
+    try {
+      await deleteDatabase();
+      await set('idb-test', true);
+      // Report to sentry, I want to know if this ever works
+      reportException('deleting database fixed IDB set', e);
+    } catch (e2) {
+      errorLog('storage', 'Failed IndexedDB Set Test - deleting database did not help', e);
+    }
+    reportException('Failed IndexedDB Set Test', e);
     return false;
   }
 
@@ -39,7 +49,19 @@ export async function storageTest() {
     const idbValue = await get<boolean>('idb-test');
     return idbValue;
   } catch (e) {
-    errorLog('storage', 'Failed IndexedDB Test', e);
+    errorLog('storage', 'Failed IndexedDB Get Test - trying to delete database', e);
+    try {
+      await deleteDatabase();
+      const idbValue = await get<boolean>('idb-test');
+      if (idbValue) {
+        // Report to sentry, I want to know if this ever works
+        reportException('deleting database fixed IDB get', e);
+      }
+      return idbValue;
+    } catch (e2) {
+      errorLog('storage', 'Failed IndexedDB Get Test - deleting database did not help', e);
+    }
+    reportException('Failed IndexedDB Get Test', e);
     return false;
   }
 }

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -152,17 +152,21 @@ function loadProfile(
     // First try loading from IndexedDB
     let profileResponse = getState().inventory.profileResponse;
     if (!profileResponse) {
-      profileResponse = await get<DestinyProfileResponse>(`profile-${account.membershipId}`);
-      // Check to make sure the profile hadn't been loaded in the meantime
-      if (getState().inventory.profileResponse) {
-        profileResponse = getState().inventory.profileResponse;
-      } else {
-        infoLog('d2-stores', 'Loaded cached profile from IndexedDB');
-        dispatch(profileLoaded({ profile: profileResponse, live: false }));
-        // The first time we load, just use the IDB version if we can, to speed up loading
-        if (firstTime) {
-          return profileResponse;
+      try {
+        profileResponse = await get<DestinyProfileResponse>(`profile-${account.membershipId}`);
+        // Check to make sure the profile hadn't been loaded in the meantime
+        if (getState().inventory.profileResponse) {
+          profileResponse = getState().inventory.profileResponse;
+        } else {
+          infoLog('d2-stores', 'Loaded cached profile from IndexedDB');
+          dispatch(profileLoaded({ profile: profileResponse, live: false }));
+          // The first time we load, just use the IDB version if we can, to speed up loading
+          if (firstTime) {
+            return profileResponse;
+          }
         }
+      } catch (e) {
+        errorLog('d2-stores', 'Failed to load profile response from IDB', e);
       }
     }
 

--- a/src/app/storage/idb-keyval.ts
+++ b/src/app/storage/idb-keyval.ts
@@ -45,7 +45,8 @@ export class Store {
         new Promise<void>((resolve, reject) => {
           const transaction = db.transaction(this.storeName, type);
           transaction.oncomplete = () => resolve();
-          transaction.onabort = transaction.onerror = () => reject(transaction.error);
+          transaction.onerror = (e) => reject((e.target as IDBTransaction).error);
+          transaction.onabort = () => reject(transaction.error);
           callback(transaction.objectStore(this.storeName));
         })
     );

--- a/src/app/utils/exceptions.ts
+++ b/src/app/utils/exceptions.ts
@@ -47,15 +47,7 @@ if ($featureFlags.sentry) {
     dsn: 'https://1367619d45da481b8148dd345c1a1330@sentry.io/279673',
     release: $DIM_VERSION,
     environment: $DIM_FLAVOR,
-    ignoreErrors: [
-      /QuotaExceededError/,
-      'HTTP 503 returned',
-      'Waiting due to HTTP 503',
-      /FatalTokenError/,
-      /Failed to fetch/,
-      /AbortError/,
-      /Non-Error promise rejection/,
-    ],
+    ignoreErrors: [],
     sampleRate: $DIM_VERSION === 'beta' ? 0.5 : 0.01, // Sample Beta at 50%, Prod at 1%
     attachStacktrace: true,
     integrations: [

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -144,14 +144,18 @@ function loadWishListAndInfoFromIndexedDB(): ThunkResult {
       return;
     }
 
-    const wishListState = await get<WishListsState>('wishlist');
+    try {
+      const wishListState = await get<WishListsState>('wishlist');
 
-    if (getState().wishLists.loaded) {
-      return;
-    }
+      if (getState().wishLists.loaded) {
+        return;
+      }
 
-    if (wishListState?.wishListAndInfo?.wishListRolls?.length) {
-      dispatch(loadWishLists(wishListState));
+      if (wishListState?.wishListAndInfo?.wishListRolls?.length) {
+        dispatch(loadWishLists(wishListState));
+      }
+    } catch (e) {
+      errorLog('wishlist', 'unable to load wishlists from IDB', e);
     }
   };
 }


### PR DESCRIPTION
May fix #9716.

This: 
* Backports the fix from https://github.com/jakearchibald/idb-keyval/pull/164 so we hopefully get a better error than `null`.
* Adds a `get` test to the `StorageTest`.
* Adds a second layer of "don't crash" to the places where we rely on IDB get.
* Restores the delete-database hack to `StorageTest`. My new hypothesis is that that was working, but we were filtering out the exception reporting to Sentry. I've removed our ignored errors list to make sure they get through (though I'll probably have to add some back in, I don't know what they were all for).