### PR TITLE
Add sizes to currency icons

### DIFF
--- a/src/app/vendors/Cost.tsx
+++ b/src/app/vendors/Cost.tsx
@@ -25,7 +25,7 @@ export default function Cost({
       title={`${cost.quantity.toLocaleString()} ${currencyItem.displayProperties.name}`}
     >
       {cost.quantity.toLocaleString()}
-      <BungieImage src={currencyItem.displayProperties.icon} />
+      <BungieImage height={12} width={12} src={currencyItem.displayProperties.icon} />
     </div>
   );
 }

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -126,6 +126,8 @@ export default function VendorItems({
             <div className={styles.currency} key={currency.hash}>
               {(currencyLookups?.[currency.hash] || 0).toLocaleString()}{' '}
               <BungieImage
+                height={16}
+                width={16}
                 src={currency.displayProperties.icon}
                 title={currency.displayProperties.name}
               />


### PR DESCRIPTION
I've been noticing iOS having trouble loading the Vendors screen - likely the same offscreen-image bug that forced us into having to make everything into background images. Before I go that far, I wanted to see if adding height/width helped any.