### PR TITLE
Portals for sheets and item popup

### DIFF
--- a/src/app/armory/ArmorySheet.m.scss
+++ b/src/app/armory/ArmorySheet.m.scss
@@ -1,7 +1,6 @@
 .sheet:global(.sheet) {
   max-width: 900px;
   margin: 0 auto;
-  z-index: 14; // higher than item popup
 
   :global(.sheet-close) {
     right: 16px;

--- a/src/app/armory/ItemGrid.tsx
+++ b/src/app/armory/ItemGrid.tsx
@@ -3,7 +3,6 @@
  */
 
 import ItemPopup from 'app/item-popup/ItemPopup';
-import { Portal } from 'app/utils/temp-container';
 import React, { useCallback, useRef, useState } from 'react';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem } from '../inventory/item-types';
@@ -62,15 +61,13 @@ export default function ItemGrid({
         </BasicItemTrigger>
       ))}
       {popup && (
-        <Portal>
-          <ItemPopup
-            onClose={() => setPopup(undefined)}
-            item={popup.item}
-            element={popup.element}
-            zIndex={zIndex + 1}
-            noLink={noLink}
-          />
-        </Portal>
+        <ItemPopup
+          onClose={() => setPopup(undefined)}
+          item={popup.item}
+          element={popup.element}
+          zIndex={zIndex + 1}
+          noLink={noLink}
+        />
       )}
     </div>
   );

--- a/src/app/armory/ItemGrid.tsx
+++ b/src/app/armory/ItemGrid.tsx
@@ -12,34 +12,6 @@ interface PopupState {
   element: HTMLElement;
 }
 
-function useZIndex(): [number, React.RefCallback<HTMLDivElement>] {
-  const zIndex = useRef<number>(0);
-  const measureRef = useCallback((el: HTMLDivElement) => {
-    zIndex.current = getZIndex(el);
-  }, []);
-
-  return [zIndex.current, measureRef];
-}
-
-function getZIndex(e: HTMLElement): number {
-  if (!e) {
-    return 0;
-  }
-  let z: string | undefined;
-  try {
-    z = document.defaultView?.getComputedStyle(e).getPropertyValue('z-index');
-  } catch (e) {
-    return 0;
-  }
-  if (!z) {
-    return 0;
-  }
-  if (e.parentNode && (!z || isNaN(parseInt(z, 10)))) {
-    return getZIndex(e.parentNode as HTMLElement);
-  }
-  return parseInt(z, 10);
-}
-
 export default function ItemGrid({
   items,
   noLink,
@@ -48,11 +20,10 @@ export default function ItemGrid({
   /** Don't allow opening Armory from the header link */
   noLink?: boolean;
 }) {
-  const [zIndex, measureRef] = useZIndex();
   const [popup, setPopup] = useState<PopupState | undefined>();
 
   return (
-    <div className="sub-bucket" ref={measureRef}>
+    <div className="sub-bucket">
       {items.map((i) => (
         <BasicItemTrigger item={i} key={i.index} onShowPopup={setPopup}>
           {(ref, showPopup) => (
@@ -65,7 +36,6 @@ export default function ItemGrid({
           onClose={() => setPopup(undefined)}
           item={popup.item}
           element={popup.element}
-          zIndex={zIndex + 1}
           noLink={noLink}
         />
       )}

--- a/src/app/dim-ui/Sheet.scss
+++ b/src/app/dim-ui/Sheet.scss
@@ -8,7 +8,6 @@ $control-color: rgba(255, 255, 255, 0.5);
   right: 0;
   position: fixed;
   backface-visibility: hidden;
-  z-index: 12;
   bottom: 0;
   // Pin the sheet to just over the keyboard
   bottom: var(--viewport-bottom-offset);

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -2,6 +2,7 @@ import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import ItemPickerContainer from 'app/item-picker/ItemPickerContainer';
 import { isAndroid, isiOSBrowser } from 'app/utils/browsers';
+import { Portal } from 'app/utils/temp-container';
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import clsx from 'clsx';
 import {
@@ -300,11 +301,13 @@ export default function Sheet({
   );
 
   return (
-    <SheetDisabledContext.Provider value={setParentDisabled}>
-      <PressTipRoot.Provider value={sheet}>
-        <ItemPickerContainer>{sheetBody}</ItemPickerContainer>
-      </PressTipRoot.Provider>
-    </SheetDisabledContext.Provider>
+    <Portal>
+      <SheetDisabledContext.Provider value={setParentDisabled}>
+        <PressTipRoot.Provider value={sheet}>
+          <ItemPickerContainer>{sheetBody}</ItemPickerContainer>
+        </PressTipRoot.Provider>
+      </SheetDisabledContext.Provider>
+    </Portal>
   );
 }
 

--- a/src/app/item-popup/ItemPopup.m.scss
+++ b/src/app/item-popup/ItemPopup.m.scss
@@ -20,9 +20,6 @@
 }
 
 .movePopupDialog {
-  // Mod drawer has z-index of 14 and needs to sit over this
-  z-index: 13;
-
   --background-color: rgba(0, 0, 0, 1); // Fallback background
 
   &.exotic {

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -1,4 +1,5 @@
 import ClickOutside from 'app/dim-ui/ClickOutside';
+import { PressTipRoot } from 'app/dim-ui/PressTip';
 import Sheet from 'app/dim-ui/Sheet';
 import { usePopper } from 'app/dim-ui/usePopper';
 import { DimItem } from 'app/inventory/item-types';
@@ -122,18 +123,20 @@ export default function ItemPopup({
         aria-modal="false"
       >
         <ClickOutside onClickOutside={onClose}>
-          <ItemTagHotkeys item={item} />
-          <div className={styles.desktopPopup}>
-            <div className={clsx(styles.desktopPopupBody, styles.popupBackground)}>
-              {header}
-              {body}
-            </div>
-            {itemActionsModel.hasControls && (
-              <div className={clsx(styles.desktopActions)}>
-                <DesktopItemActions item={item} actionsModel={itemActionsModel} />
+          <PressTipRoot.Provider value={popupRef}>
+            <ItemTagHotkeys item={item} />
+            <div className={styles.desktopPopup}>
+              <div className={clsx(styles.desktopPopupBody, styles.popupBackground)}>
+                {header}
+                {body}
               </div>
-            )}
-          </div>
+              {itemActionsModel.hasControls && (
+                <div className={clsx(styles.desktopActions)}>
+                  <DesktopItemActions item={item} actionsModel={itemActionsModel} />
+                </div>
+              )}
+            </div>
+          </PressTipRoot.Provider>
         </ClickOutside>
         <div className={clsx('arrow', styles.arrow, tierClasses[item.tier])} />
       </div>

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -7,6 +7,7 @@ import ItemAccessoryButtons from 'app/item-actions/ItemAccessoryButtons';
 import ItemMoveLocations from 'app/item-actions/ItemMoveLocations';
 import type { ItemTierName } from 'app/search/d2-known-values';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -107,33 +108,35 @@ export default function ItemPopup({
       <div className={styles.popupBackground}>{body}</div>
     </Sheet>
   ) : (
-    <div
-      className={clsx(
-        'item-popup',
-        styles.movePopupDialog,
-        tierClasses[item.tier],
-        styles.desktopPopupRoot
-      )}
-      style={{ zIndex }}
-      ref={popupRef}
-      role="dialog"
-      aria-modal="false"
-    >
-      <ClickOutside onClickOutside={onClose}>
-        <ItemTagHotkeys item={item} />
-        <div className={styles.desktopPopup}>
-          <div className={clsx(styles.desktopPopupBody, styles.popupBackground)}>
-            {header}
-            {body}
-          </div>
-          {itemActionsModel.hasControls && (
-            <div className={clsx(styles.desktopActions)}>
-              <DesktopItemActions item={item} actionsModel={itemActionsModel} />
+    <Portal>
+      <div
+        className={clsx(
+          'item-popup',
+          styles.movePopupDialog,
+          tierClasses[item.tier],
+          styles.desktopPopupRoot
+        )}
+        style={{ zIndex }}
+        ref={popupRef}
+        role="dialog"
+        aria-modal="false"
+      >
+        <ClickOutside onClickOutside={onClose}>
+          <ItemTagHotkeys item={item} />
+          <div className={styles.desktopPopup}>
+            <div className={clsx(styles.desktopPopupBody, styles.popupBackground)}>
+              {header}
+              {body}
             </div>
-          )}
-        </div>
-      </ClickOutside>
-      <div className={clsx('arrow', styles.arrow, tierClasses[item.tier])} />
-    </div>
+            {itemActionsModel.hasControls && (
+              <div className={clsx(styles.desktopActions)}>
+                <DesktopItemActions item={item} actionsModel={itemActionsModel} />
+              </div>
+            )}
+          </div>
+        </ClickOutside>
+        <div className={clsx('arrow', styles.arrow, tierClasses[item.tier])} />
+      </div>
+    </Portal>
   );
 }

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -6,7 +6,6 @@ import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import type { ItemTierName } from 'app/search/d2-known-values';
-import { Portal } from 'app/utils/temp-container';
 import { LookupTable } from 'app/utils/util-types';
 import { DestinyAmmunitionType, DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -89,9 +88,7 @@ export default function ItemPopupHeader({
         </div>
       </div>
       {showArmory && linkToArmory && (
-        <Portal>
-          <ArmorySheet onClose={() => setShowArmory(false)} item={item} />
-        </Portal>
+        <ArmorySheet onClose={() => setShowArmory(false)} item={item} />
       )}
     </button>
   );

--- a/src/app/item-popup/ItemSockets.tsx
+++ b/src/app/item-popup/ItemSockets.tsx
@@ -1,4 +1,3 @@
-import { Portal } from 'app/utils/temp-container';
 import { memo, useState } from 'react';
 import { DimItem, DimPlug, DimSocket } from '../inventory/item-types';
 import './ItemSockets.scss';
@@ -55,16 +54,14 @@ export default memo(function ItemSockets({
     <>
       {content}
       {socketInMenu && (
-        <Portal>
-          <SocketDetails
-            key={socketInMenu.socketIndex}
-            item={item}
-            socket={socketInMenu}
-            allowInsertPlug
-            onClose={() => setSocketInMenu(null)}
-            onPlugSelected={onPlugClicked}
-          />
-        </Portal>
+        <SocketDetails
+          key={socketInMenu.socketIndex}
+          item={item}
+          socket={socketInMenu}
+          allowInsertPlug
+          onClose={() => setSocketInMenu(null)}
+          onPlugSelected={onPlugClicked}
+        />
       )}
     </>
   );

--- a/src/app/item-popup/SocketDetails.m.scss
+++ b/src/app/item-popup/SocketDetails.m.scss
@@ -6,7 +6,7 @@
   }
 }
 
-.socketDetailsSheet {
+.socketDetailsSheet:global(.sheet) {
   // This fits 14 plugs + scroll bar
   max-width: 820px;
   margin: 0 auto;

--- a/src/app/item-popup/SocketDetails.m.scss
+++ b/src/app/item-popup/SocketDetails.m.scss
@@ -10,7 +10,6 @@
   // This fits 14 plugs + scroll bar
   max-width: 820px;
   margin: 0 auto;
-  z-index: 14; // higher than item popup
 
   :global(.sheet-header) h1 {
     display: flex;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -25,7 +25,6 @@ import { AppIcon, faExclamationTriangle, redoIcon, refreshIcon, undoIcon } from 
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyObject } from 'app/utils/empty';
 import { isClassCompatible, itemCanBeEquippedBy } from 'app/utils/item-utils';
-import { Portal } from 'app/utils/temp-container';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { deepEqual } from 'fast-equals';
@@ -478,39 +477,35 @@ export default memo(function LoadoutBuilder({
           )
         )}
         {modPicker.open && (
-          <Portal>
-            <ModPicker
-              classType={classType}
-              owner={selectedStore.id}
-              lockedMods={resolvedMods}
-              plugCategoryHashWhitelist={modPicker.plugCategoryHashWhitelist}
-              plugCategoryHashDenyList={
-                autoStatMods
-                  ? // Exclude stat mods from the mod picker when they're auto selected
-                    [...autoAssignmentPCHs, PlugCategoryHashes.EnhancementsV2General]
-                  : autoAssignmentPCHs
-              }
-              onAccept={(newLockedMods) =>
-                lbDispatch({
-                  type: 'lockedModsChanged',
-                  lockedMods: newLockedMods,
-                })
-              }
-              onClose={() => lbDispatch({ type: 'closeModPicker' })}
-            />
-          </Portal>
+          <ModPicker
+            classType={classType}
+            owner={selectedStore.id}
+            lockedMods={resolvedMods}
+            plugCategoryHashWhitelist={modPicker.plugCategoryHashWhitelist}
+            plugCategoryHashDenyList={
+              autoStatMods
+                ? // Exclude stat mods from the mod picker when they're auto selected
+                  [...autoAssignmentPCHs, PlugCategoryHashes.EnhancementsV2General]
+                : autoAssignmentPCHs
+            }
+            onAccept={(newLockedMods) =>
+              lbDispatch({
+                type: 'lockedModsChanged',
+                lockedMods: newLockedMods,
+              })
+            }
+            onClose={() => lbDispatch({ type: 'closeModPicker' })}
+          />
         )}
         {compareSet && (
-          <Portal>
-            <CompareLoadoutsDrawer
-              compareSet={compareSet}
-              selectedStore={selectedStore}
-              loadout={loadout}
-              loadouts={loadouts}
-              lockedMods={modsToAssign}
-              onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}
-            />
-          </Portal>
+          <CompareLoadoutsDrawer
+            compareSet={compareSet}
+            selectedStore={selectedStore}
+            loadout={loadout}
+            loadouts={loadouts}
+            lockedMods={modsToAssign}
+            onClose={() => lbDispatch({ type: 'closeCompareDrawer' })}
+          />
         )}
       </PageWithMenu.Contents>
     </PageWithMenu>

--- a/src/app/loadout-builder/filter/LoadoutOptimizerMenuItems.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerMenuItems.tsx
@@ -13,7 +13,6 @@ import { ItemFilter } from 'app/search/filter-types';
 import { AppIcon, faTimesCircle, pinIcon } from 'app/shell/icons';
 import { emptyObject } from 'app/utils/empty';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
-import { Portal } from 'app/utils/temp-container';
 import { objectValues } from 'app/utils/util-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
@@ -99,16 +98,14 @@ export const LoadoutOptimizerSubclass = memo(function LoadoutOptimizerSubclass({
       </div>
 
       {showSubclassOptionsPicker && subclass && (
-        <Portal>
-          <SubclassPlugDrawer
-            subclass={subclass.item}
-            socketOverrides={subclass.loadoutItem.socketOverrides ?? emptyObject()}
-            onAccept={(socketOverrides) =>
-              lbDispatch({ type: 'updateSubclassSocketOverrides', socketOverrides, subclass })
-            }
-            onClose={() => setShowSubclassOptionsPicker(false)}
-          />
-        </Portal>
+        <SubclassPlugDrawer
+          subclass={subclass.item}
+          socketOverrides={subclass.loadoutItem.socketOverrides ?? emptyObject()}
+          onAccept={(socketOverrides) =>
+            lbDispatch({ type: 'updateSubclassSocketOverrides', socketOverrides, subclass })
+          }
+          onClose={() => setShowSubclassOptionsPicker(false)}
+        />
       )}
     </>
   );
@@ -201,14 +198,12 @@ export const LoadoutOptimizerExotic = memo(function LoadoutOptimizerExotic({
         </div>
       </div>
       {showExoticPicker && (
-        <Portal>
-          <ExoticPicker
-            lockedExoticHash={lockedExoticHash}
-            classType={classType}
-            onSelected={(exotic) => lbDispatch({ type: 'lockExotic', lockedExoticHash: exotic })}
-            onClose={() => setShowExoticPicker(false)}
-          />
-        </Portal>
+        <ExoticPicker
+          lockedExoticHash={lockedExoticHash}
+          classType={classType}
+          onSelected={(exotic) => lbDispatch({ type: 'lockExotic', lockedExoticHash: exotic })}
+          onClose={() => setShowExoticPicker(false)}
+        />
       )}
     </>
   );

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -18,7 +18,6 @@ import { useSetting } from 'app/settings/hooks';
 import { AppIcon, addIcon, faCalculator, uploadIcon } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { usePageTitle } from 'app/utils/hooks';
-import { Portal } from 'app/utils/temp-container';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
@@ -215,42 +214,40 @@ function Loadouts({ account }: { account: DestinyAccount }) {
         {loadouts.length === 0 && <p>{t('Loadouts.NoneMatch', { query })}</p>}
       </PageWithMenu.Contents>
       {sharedLoadout && (
-        <Portal>
-          <LoadoutShareSheet
-            account={account}
-            loadout={sharedLoadout}
-            onClose={() => setSharedLoadout(undefined)}
-          />
-        </Portal>
+        <LoadoutShareSheet
+          account={account}
+          loadout={sharedLoadout}
+          onClose={() => setSharedLoadout(undefined)}
+        />
       )}
       {loadoutImportOpen && (
-        <Portal>
-          <LoadoutImportSheet
-            currentStoreId={selectedStoreId}
-            onClose={() => setLoadoutImportOpen(false)}
-          />
-        </Portal>
+        <LoadoutImportSheet
+          currentStoreId={selectedStoreId}
+          onClose={() => setLoadoutImportOpen(false)}
+        />
       )}
       {viewingInGameLoadout && (
-        <Portal>
-          <InGameLoadoutDetails
-            store={selectedStore}
-            loadout={viewingInGameLoadout}
-            onEdit={setEditingInGameLoadout}
-            onShare={setSharedLoadout}
-            onClose={handleViewingSheetClose}
-          />
-        </Portal>
+        <InGameLoadoutDetails
+          store={selectedStore}
+          loadout={viewingInGameLoadout}
+          onEdit={setEditingInGameLoadout}
+          onShare={setSharedLoadout}
+          onClose={handleViewingSheetClose}
+        />
       )}
       {showSnapshot && (
-        <Portal>
-          <EditInGameLoadout characterId={selectedStoreId} onClose={handleSnapshotSheetClose} />
-        </Portal>
+        <EditInGameLoadout
+          key="snapshot"
+          characterId={selectedStoreId}
+          onClose={handleSnapshotSheetClose}
+        />
       )}
       {editingInGameLoadout && (
-        <Portal key="editsheet">
-          <EditInGameLoadout loadout={editingInGameLoadout} onClose={handleEditSheetClose} />
-        </Portal>
+        <EditInGameLoadout
+          key="editsheet"
+          loadout={editingInGameLoadout}
+          onClose={handleEditSheetClose}
+        />
       )}
     </PageWithMenu>
   );

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -16,7 +16,6 @@ import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { AppIcon, clearIcon, rightArrowIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { getSocketsByCategoryHash, plugFitsIntoSocket } from 'app/utils/socket-utils';
-import { Portal } from 'app/utils/temp-container';
 import { filterMap } from 'app/utils/util';
 import { HashLookup } from 'app/utils/util-types';
 import {
@@ -391,15 +390,13 @@ export default function FashionDrawer({
         </div>
       )}
       {pickPlug && (
-        <Portal>
-          <SocketDetails
-            item={pickPlug.item}
-            allowInsertPlug={false}
-            socket={pickPlug.socket}
-            onClose={() => setPickPlug(undefined)}
-            onPlugSelected={handlePlugSelected}
-          />
-        </Portal>
+        <SocketDetails
+          item={pickPlug.item}
+          allowInsertPlug={false}
+          socket={pickPlug.socket}
+          onClose={() => setPickPlug(undefined)}
+          onPlugSelected={handlePlugSelected}
+        />
       )}
     </Sheet>
   );

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -50,7 +50,6 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { searchFilterSelector } from 'app/search/search-filter';
 import { emptyObject } from 'app/utils/empty';
 import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
-import { Portal } from 'app/utils/temp-container';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -249,14 +248,12 @@ export default function LoadoutEdit({
             </div>
           )}
           {plugDrawerOpen && subclass && (
-            <Portal>
-              <SubclassPlugDrawer
-                subclass={subclass.item}
-                socketOverrides={subclass.loadoutItem.socketOverrides ?? {}}
-                onClose={() => setPlugDrawerOpen(false)}
-                onAccept={(overrides) => handleApplySocketOverrides(subclass, overrides)}
-              />
-            </Portal>
+            <SubclassPlugDrawer
+              subclass={subclass.item}
+              socketOverrides={subclass.loadoutItem.socketOverrides ?? {}}
+              onClose={() => setPlugDrawerOpen(false)}
+              onAccept={(overrides) => handleApplySocketOverrides(subclass, overrides)}
+            />
           )}
         </LoadoutEditSection>
       )}

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -12,7 +12,6 @@ import { singularBucketHashes } from 'app/loadout-drawer/loadout-utils';
 import { AppIcon, addIcon, faTshirt } from 'app/shell/icons';
 import { LoadoutCharacterStats } from 'app/store-stats/CharacterStats';
 import { emptyArray } from 'app/utils/empty';
-import { Portal } from 'app/utils/temp-container';
 import { LookupTable } from 'app/utils/util-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -317,15 +316,13 @@ function FashionButton({
         <AppIcon icon={faTshirt} /> {t('Loadouts.Fashion')}
       </button>
       {showFashionDrawer && (
-        <Portal>
-          <FashionDrawer
-            loadout={loadout}
-            items={items}
-            storeId={storeId}
-            onModsByBucketUpdated={onModsByBucketUpdated}
-            onClose={() => setShowFashionDrawer(false)}
-          />
-        </Portal>
+        <FashionDrawer
+          loadout={loadout}
+          items={items}
+          storeId={storeId}
+          onModsByBucketUpdated={onModsByBucketUpdated}
+          onClose={() => setShowFashionDrawer(false)}
+        />
       )}
     </>
   );

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -7,7 +7,6 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import { AppIcon, addIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
-import { Portal } from 'app/utils/temp-container';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -153,25 +152,21 @@ export const LoadoutMods = memo(function LoadoutMods({
           </div>
         )}
       {showModAssignmentDrawer && (
-        <Portal>
-          <ModAssignmentDrawer
-            loadout={loadout}
-            storeId={storeId}
-            onUpdateMods={onUpdateMods}
-            onClose={() => setShowModAssignmentDrawer(false)}
-          />
-        </Portal>
+        <ModAssignmentDrawer
+          loadout={loadout}
+          storeId={storeId}
+          onUpdateMods={onUpdateMods}
+          onClose={() => setShowModAssignmentDrawer(false)}
+        />
       )}
       {onUpdateMods && showModPicker && (
-        <Portal>
-          <ModPicker
-            classType={loadout.classType}
-            owner={storeId}
-            lockedMods={resolvedMods}
-            onAccept={onUpdateMods}
-            onClose={() => setShowModPicker(false)}
-          />
-        </Portal>
+        <ModPicker
+          classType={loadout.classType}
+          owner={storeId}
+          lockedMods={resolvedMods}
+          onAccept={onUpdateMods}
+          onClose={() => setShowModPicker(false)}
+        />
       )}
     </div>
   );

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -7,7 +7,6 @@ import { permissiveArmorEnergyRules } from 'app/loadout-builder/types';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { LoadoutCharacterStats } from 'app/store-stats/CharacterStats';
-import { Portal } from 'app/utils/temp-container';
 import Cost from 'app/vendors/Cost';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -195,16 +194,14 @@ export default function ModAssignmentDrawer({
         </div>
       </Sheet>
       {onUpdateMods && plugCategoryHashWhitelist && (
-        <Portal>
-          <ModPicker
-            classType={loadout.classType}
-            owner={storeId}
-            lockedMods={resolvedMods}
-            plugCategoryHashWhitelist={plugCategoryHashWhitelist}
-            onAccept={onUpdateMods}
-            onClose={() => setPlugCategoryHashWhitelist(undefined)}
-          />
-        </Portal>
+        <ModPicker
+          classType={loadout.classType}
+          owner={storeId}
+          lockedMods={resolvedMods}
+          plugCategoryHashWhitelist={plugCategoryHashWhitelist}
+          onAccept={onUpdateMods}
+          onClose={() => setPlugCategoryHashWhitelist(undefined)}
+        />
       )}
     </>
   );

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -294,5 +294,11 @@ select {
   filter: drop-shadow(0 0 0 #fff);
 }
 
+#temp-container {
+  // Make sure things in the temp container display above others
+  position: relative;
+  z-index: 1000;
+}
+
 /* stylelint-disable-next-line no-invalid-position-at-import-rule */
 @import 'app/dim-ui/dim-button.scss';

--- a/src/app/search/MainSearchBarActions.tsx
+++ b/src/app/search/MainSearchBarActions.tsx
@@ -3,7 +3,6 @@ import { toggleSearchResults } from 'app/shell/actions';
 import { AppIcon, faList } from 'app/shell/icons';
 import { querySelector, searchResultsOpenSelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { emptyArray } from 'app/utils/empty';
-import { Portal } from 'app/utils/temp-container';
 import { motion } from 'framer-motion';
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -72,12 +71,10 @@ export default function MainSearchBarActions() {
       )}
 
       {searchResultsOpen && (
-        <Portal>
-          <SearchResults
-            items={queryValid ? filteredItems : emptyArray()}
-            onClose={handleCloseSearchResults}
-          />
-        </Portal>
+        <SearchResults
+          items={queryValid ? filteredItems : emptyArray()}
+          onClose={handleCloseSearchResults}
+        />
       )}
     </>
   );

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -12,7 +12,6 @@ import { toggleSearchResults } from 'app/shell/actions';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isiOSBrowser } from 'app/utils/browsers';
-import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { UseComboboxState, UseComboboxStateChangeOptions, useCombobox } from 'downshift';
 import { AnimatePresence, LayoutGroup, Variants, motion } from 'framer-motion';
@@ -170,13 +169,11 @@ export interface SearchFilterRef {
 
 function ArmorySheet({ itemHash, onClose }: { itemHash: number; onClose: () => void }) {
   return (
-    <Portal>
-      <Sheet onClose={onClose} sheetClassName={styles.armorySheet}>
-        <ClickOutsideRoot>
-          <Armory itemHash={itemHash} />
-        </ClickOutsideRoot>
-      </Sheet>
-    </Portal>
+    <Sheet onClose={onClose} sheetClassName={styles.armorySheet}>
+      <ClickOutsideRoot>
+        <Armory itemHash={itemHash} />
+      </ClickOutsideRoot>
+    </Sheet>
   );
 }
 
@@ -540,23 +537,21 @@ function SearchBar(
         </LayoutGroup>
 
         {filterHelpOpen && (
-          <Portal>
-            <Sheet
-              onClose={() => setFilterHelpOpen(false)}
-              header={
-                <>
-                  <h1>{t('Header.Filters')}</h1>
-                  <UserGuideLink topic="Item-Search" />
-                </>
-              }
-              freezeInitialHeight
-              sheetClassName={styles.filterHelp}
-            >
-              <Suspense fallback={<Loading message={t('Loading.FilterHelp')} />}>
-                <LazyFilterHelp />
-              </Suspense>
-            </Sheet>
-          </Portal>
+          <Sheet
+            onClose={() => setFilterHelpOpen(false)}
+            header={
+              <>
+                <h1>{t('Header.Filters')}</h1>
+                <UserGuideLink topic="Item-Search" />
+              </>
+            }
+            freezeInitialHeight
+            sheetClassName={styles.filterHelp}
+          >
+            <Suspense fallback={<Loading message={t('Loading.FilterHelp')} />}>
+              <LazyFilterHelp />
+            </Suspense>
+          </Sheet>
         )}
 
         {autocompleteMenu}

--- a/src/app/shell/Header.tsx
+++ b/src/app/shell/Header.tsx
@@ -12,7 +12,6 @@ import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isiOSBrowser } from 'app/utils/browsers';
 import { useSetCSSVarToHeight } from 'app/utils/hooks';
 import { infoLog } from 'app/utils/log';
-import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { AnimatePresence, Spring, Variants, motion } from 'framer-motion';
 import logo from 'images/logo-type-right-light.svg';
@@ -389,11 +388,9 @@ export default function Header() {
         </HeaderWarningBanner>
       )}
       {promptIosPwa && (
-        <Portal>
-          <Sheet header={<h1>{t('Header.InstallDIM')}</h1>} onClose={() => setPromptIosPwa(false)}>
-            <p className={styles.pwaPrompt}>{t('Header.IosPwaPrompt')}</p>
-          </Sheet>
-        </Portal>
+        <Sheet header={<h1>{t('Header.InstallDIM')}</h1>} onClose={() => setPromptIosPwa(false)}>
+          <p className={styles.pwaPrompt}>{t('Header.IosPwaPrompt')}</p>
+        </Sheet>
       )}
     </header>
   );


### PR DESCRIPTION
1. Always display Sheets in a portal. We did this inconsistently, but it's better to just do it everywhere. This prevents reflows as sheets are added and removed and avoids the insanity of rendering a sheet as a child of some other element.
2. Wrap item popup in a portal too. Same benefit!
3. Remove all the special cased z-index stuff in favor of a single z-index for `tempContainer`. With the Portals added in the previous change, this makes everything stack in source order which happens to be the order they're rendered.