### PR TITLE
Remove vendor reward engrams

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1279,7 +1279,7 @@
   },
   "Vendors": {
     "Collections": "Collections",
-    "Engram": "Reward Engram",
+    "Engram": "Rank",
     "FilterToUnacquired": "Only show uncollected items",
     "NoItems": "This Vendor is currently not offering any items.",
     "Vendors": "Vendors",

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -8,7 +8,6 @@ import deprecatedMods from 'data/d2/deprecated-mods.json';
 import focusingItemOutputs from 'data/d2/focusing-item-outputs.json';
 import rahoolMats from 'data/d2/spider-mats.json';
 import _ from 'lodash';
-import { Link } from 'react-router-dom';
 import BungieImage from '../dim-ui/BungieImage';
 import { PressTip } from '../dim-ui/PressTip';
 import FactionIcon from '../progress/FactionIcon';
@@ -153,16 +152,6 @@ export default function VendorItems({
                     />
                   </div>
                 </PressTip>
-              )}
-              {Boolean(rewardVendorHash) && rewardItem && (
-                <Link to={`../vendors/${rewardVendorHash}?characterId=${characterId}`}>
-                  <div className="item" title={rewardItem.displayProperties.name}>
-                    <BungieImage
-                      className="item-img transparent"
-                      src={rewardItem.displayProperties.icon}
-                    />
-                  </div>
-                </Link>
               )}
             </div>
           </div>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1268,7 +1268,7 @@
   },
   "Vendors": {
     "Collections": "Collections",
-    "Engram": "Reward Engram",
+    "Engram": "Rank",
     "FilterToUnacquired": "Only show uncollected items",
     "NoItems": "This Vendor is currently not offering any items.",
     "RefreshTime": "Inventory refreshes in:",


### PR DESCRIPTION
I don't think vendor reward engrams are a thing (that's exposed in the API) anymore. This renames the section to "Rank" and removes the code for showing reward engrams.