### PR TITLE
Allow the PageWithMenu sidebar size to be adjusted with a CSS var

### DIFF
--- a/src/app/dim-ui/CharacterSelect.m.scss
+++ b/src/app/dim-ui/CharacterSelect.m.scss
@@ -3,6 +3,7 @@
 .select {
   display: flex;
   justify-content: space-between;
+  max-width: $emblem-width;
 }
 
 .tile {

--- a/src/app/dim-ui/PageWithMenu.m.scss
+++ b/src/app/dim-ui/PageWithMenu.m.scss
@@ -45,6 +45,7 @@
 }
 
 .menu {
+  --page-with-menu-menu-width: 230px;
   font-size: 14px;
   flex-shrink: 0;
   margin-right: 12px;
@@ -52,7 +53,7 @@
   margin-left: -4px; // To undo the padding on the inner div
   position: sticky;
   top: calc(var(--header-height) + 8px);
-  width: 230px + 8px;
+  width: calc(var(--page-with-menu-menu-width) + 8px);
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: none;
@@ -63,14 +64,15 @@
   // while the outer .menu container may change size as the scrollbars appear
   // and disappear.
   > div {
-    width: 230px;
+    width: var(--page-with-menu-menu-width);
     padding: 4px; // To allow for the outline of the character selector to show
   }
 
   // Add in some width when a scrollbar is present!
   // It'd be cooler if https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter existed.
   &.menuScrollbars {
-    width: 230px + 17px + 8px; // Windows scrollbars are 17px, then padding
+    // Windows scrollbars are 17px, then padding p
+    width: calc(var(--page-with-menu-menu-width) + 17px + 8px);
   }
 
   @include phone-portrait {


### PR DESCRIPTION
This will allow us to have differently-sized menus when necessary (e.g. in Loadout Optimizer).