### PR TITLE
Season of the Witch currencies update

### DIFF
--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -133,14 +133,20 @@ export const vendorCurrencyEngramsSelector = createSelector(
   }
 );
 
+const materialsWithMissingICH = [
+  3702027555, // InventoryItem "Spoils of Conquest"
+  2329379380, // InventoryItem "Salvage Key"
+  2329379381, // InventoryItem "Deep Dive Key",
+  1289622079, // InventoryItem "Strand Meditations"
+];
+
 /** materials/currencies that aren't top level stuff */
 export const materialsSelector = createSelector(allItemsSelector, (allItems) =>
   allItems.filter(
     (i) =>
       i.itemCategoryHashes.includes(ItemCategoryHashes.Materials) ||
       i.itemCategoryHashes.includes(ItemCategoryHashes.ReputationTokens) ||
-      i.hash === 3702027555 || // Spoils of Conquest do not have item category hashes
-      i.hash === 1289622079 // neither do Strand Meditations
+      materialsWithMissingICH.includes(i.hash)
   )
 );
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -295,7 +295,7 @@ export function makeItem(
   const needsShaderFix =
     itemDef.inventory!.bucketTypeHash === THE_FORBIDDEN_BUCKET &&
     itemDef.itemCategoryHashes?.includes(ItemCategoryHashes.Shaders);
-  // The same thing can happen with mods!
+  // The same thing can happen with mods and transmat effects (included in Mods)!
   const needsModsFix =
     itemDef.inventory!.bucketTypeHash === THE_FORBIDDEN_BUCKET &&
     itemDef.itemCategoryHashes?.includes(ItemCategoryHashes.Mods_Mod);

--- a/src/app/material-counts/MaterialCounts.tsx
+++ b/src/app/material-counts/MaterialCounts.tsx
@@ -15,9 +15,8 @@ import { useSelector } from 'react-redux';
 import styles from './MaterialCounts.m.scss';
 
 const showMats = spiderMats;
-const goodMats = [2979281381, 4257549984, 3853748946, 4257549985, 3702027555];
-const seasonal = [1224079819, 1289622079, 1471199156];
-const crafting = [2497395625, 353704689, 2708128607];
+const goodMats = [2979281381, 4257549984, 3853748946, 4257549985, 3702027555, 353704689];
+const seasonal = [1224079819, 2329379380, 2329379381, 2392300858, 1289622079, 1471199156];
 
 export function MaterialCounts({
   wide,
@@ -35,7 +34,7 @@ export function MaterialCounts({
 
   const content = [
     includeCurrencies && <CurrencyGroup key="currencies" currencies={currencies} />,
-    ...[seasonal, goodMats, crafting, showMats].map((matgroup) => (
+    ...[seasonal, goodMats, showMats].map((matgroup) => (
       <React.Fragment key={matgroup[0]}>
         {matgroup.map((h) => {
           const items = materials[h];

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -105,7 +105,9 @@ export function toVendor(
   gatherVendorCurrencies(defs, vendorDef, vendorsResponse, sales, vendorCurrencyHashes);
   const currencies = _.compact(
     Array.from(vendorCurrencyHashes, (h) => defs.InventoryItem.get(h)).filter(
-      (i) => !i?.itemCategoryHashes?.includes(ItemCategoryHashes.Shaders)
+      (i) =>
+        !i?.itemCategoryHashes?.includes(ItemCategoryHashes.Shaders) &&
+        !i?.itemCategoryHashes?.includes(ItemCategoryHashes.ShipModsTransmatEffects)
     )
   );
   currencies.sort(compareBy((i) => i.inventory?.tierType));


### PR DESCRIPTION
* Transmat effects are now plugs, and Rahool wants all of them. That's not important though.
* Crafting materials except for Ascendant Shards are gone, and any user who still has them can turn them in for a grand total of 70k glimmer. This does not justify a place in the materials tooltip; Ascendant Shards are moved to the rest of the upgrade materials.
* The three tiers of seasonal offerings could be interesting but I wasn't sure about them. Let's at least make the seasonal keys complete though.