### PR TITLE
Fix aggressive LO filtering bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * You can choose between a number of different themes for DIM's interface in settings.
 * The Vendors page now has a toggle to hide all items sold for Silver.
+* Fixed a bug where Loadout Optimizer would sometimes interpret a search query too literally and require that all items match it, even if a slot doesn't have any items that match the query.
 
 ## 7.82.1 <span class="changelog-date">(2023-08-22)</span>
 

--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -88,16 +88,16 @@ export function filterItems({
     return [filteredItems, filterInfo];
   }
 
-  // Usability hack: If the user requests exotics but none of the exotics match the search filter, ignore the search filter for exotics.
+  // Usability hack: If the user requests any exotic but none of the exotics match the search filter, ignore the search filter for exotics.
   // This allows things like `modslot:xyz` to apply to legendary armor without removing all exotics.
-  const excludeExoticsFromFilter = !Object.values(items)
-    .flat()
-    .some(
-      (item) =>
-        item.isExotic &&
-        (lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC || item.hash === lockedExoticHash) &&
-        searchFilter(item)
-    );
+  const excludeExoticsFromFilter =
+    lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC &&
+    !Object.values(items)
+      .flat()
+      .some(
+        (item) =>
+          item.isExotic && lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC && searchFilter(item)
+      );
 
   // Group by bucket (the types for _.groupBy don't work out...)
   const itemsByBucket: Draft<ItemsByBucket> = {


### PR DESCRIPTION
We should add tests for the item-filter at some point, but the test case from the Discord was as follows:

* Inventory has a single "iron lord's pride" helmet
* LO configuration doesn't have anything specified for the exotic
* search for "iron lord's pride"

Then we would figure out that there's not a single exotic that matches the query, so it would ignore the search query for exotics. That however meant that the code responsible for ignoring the query for a bucket now thinks that the filter is totally okay and applies to the slot, so we end up with only exotics in gauntlets, chest piece, legs.

The case where `lockedExoticHash` specifies a real exotic should not make a difference with this change because in that case the slot containing the exotic will be reduced to just those exotics, so there's no value in ignoring the filter for exotics in that case -- if none of them match, the old query ignoring code kicks in -- and the other slots will be reduced to legendaries anyway.