### PR TITLE
Fix loadouts considering last season's artifact mods as unlocked

### DIFF
--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -363,7 +363,7 @@ function getArtifactUnlocks(
   const unlockedItemHashes =
     artifactData.tiers
       ?.flatMap((tier) => tier.items)
-      .filter((item) => item.isActive)
+      .filter((item) => item.isVisible && item.isActive)
       .map((item) => item.itemHash) || [];
   return {
     unlockedItemHashes,


### PR DESCRIPTION
DIM says these are currently equipped, which is clearly wrong 
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/f2838572-a1f5-4590-ae9a-da1e4978f1ec)
