### PR TITLE
Implement schema versioned Clarity stats

### DIFF
--- a/src/app/clarity/descriptions/character-stats.ts
+++ b/src/app/clarity/descriptions/character-stats.ts
@@ -13,7 +13,7 @@ export interface ClarityStatsVersion {
 }
 
 export interface Ability {
-  /** D2 Manifest inventoryItem hash */
+  /** D2 Manifest inventoryItem hash. This is the hash of the subclass ability plug. */
   Hash: number;
   /** Array index represents the Character Stat tier. Cooldowns are in seconds. Rounded to 2 decimal points. Note: Rounding to 2 decimal places is solely for improving math precision when combined with Override objects. When displaying these cooldown times, it is STRONGLY recommended to round them to an integer. */
   Cooldowns: number[];
@@ -25,7 +25,7 @@ export interface Ability {
 type Description = string;
 
 export interface SuperAbility {
-  /** D2 Manifest inventoryItem hash */
+  /** D2 Manifest inventoryItem hash. This is the hash of the super ability subclass plug. */
   Hash: number;
   /** Array index represents the Character Stat tier. Cooldowns are in seconds. Rounded to 2 decimal points. Note: Rounding to 2 decimal places is solely for improving math precision when combined with Override objects. When displaying these cooldown times, it is STRONGLY recommended to round them to an integer. */
   Cooldowns: number[];
@@ -38,20 +38,21 @@ export interface SuperAbility {
 }
 
 export interface Override {
+  /** D2 Manifest inventoryItem hash. This is the "reason for the override" hash, such as an equipped exotic or aspect. */
   Hash: number;
-  /** The inventoryItem hash of each ability that is required to trigger the effects of this Scalar. Any one of these will trigger its effect as only one is required to do so. (These are usually also the same ability but for the different subclasses, hence you should NOT be able to have more than one equipped at once) */
+  /** The inventoryItem hash of each ability that is required to trigger the effects of this 'Override'. Only overrides 'Abilities' under the same Character Stat as the 'Override'. Any one of these will trigger its effect defined in the other 'Override' properties. Wildcards: if the requirements array only contains 1 item and it's a 0, any ability tied to this Character Stat will have its cooldown overwritten. Negative numbers in the array indicate filters, these will be the inventoryItem hashes of subclasses multiplied by -1. Any abilities tied to the given subclass will have their cooldowns overwritten. */
   Requirements: number[];
 
   // One of CooldownOverride, Scalar, or FlatIncrease will be set.
 
-  /** Array index represents the Character Stat tier. Cooldowns are in seconds. Rounded to 2 decimal points. Overrides the cooldowns of the items listed in the 'Requirements' array before the scalar is applied. Identical to the 'Cooldowns' array of the 'Ability' object. Contains 11 0s if not in use. */
+  /** Array index represents the Character Stat tier. Cooldowns are in seconds. Rounded to 2 decimal points. Overrides the cooldowns of the items listed in the 'Requirements' array before the scalar is applied. Identical to the 'Cooldowns' array of the 'Ability' object. */
   CooldownOverride?: number[];
   /**
-   * Length of the array is equal to the length of the 'Requirements' array. Each item represents a multiplier to the cooldown time of the abilities listed in the 'Requirements' array at the same array index. Multiple scalars can stack with each other if their requirements are met (eg. Bastion Aspect and Citan's Ramparts Exotic Gauntlets). If 'CooldownOverride' property is specified: 'Scalar's are factored in after 'CooldownOverride's
+   * Length of the array is equal to the length of the 'Requirements' array. Each item represents a multiplier to the cooldown time of the abilities (of a subclass) listed in the 'Requirements' array at the same array index. Multiple scalars can stack with each other if their requirements are met (eg. Bastion Aspect and Citan's Ramparts Exotic Gauntlets). If 'CooldownOverride' property is specified: 'Scalar's are factored in after 'CooldownOverride's.
    */
   Scalar?: number[];
   /**
-   * Length of the array is equal to the length of the 'Requirements' array. Each item represents a flat increase to the cooldown time of the abilities listed in the 'Requirements' array at the same array index. If 'CooldownOverride' or 'Scalar' property is specified: Time is added to the cooldown times at every tier after 'CooldownOverride's and 'Scalar's have been applied.
+   * Length of the array is equal to the length of the 'Requirements' array. Each item represents a flat increase to the cooldown time of the abilities (of a subclass) listed in the 'Requirements' array at the same array index. If 'CooldownOverride' or 'Scalar' property is specified: Time is added to the cooldown times at every tier after 'CooldownOverride's and 'Scalar's have been applied.
    */
   FlatIncrease?: number[];
 }

--- a/src/app/clarity/descriptions/character-stats.ts
+++ b/src/app/clarity/descriptions/character-stats.ts
@@ -1,15 +1,15 @@
 export interface ClarityCharacterStats {
   Mobility: Mobility;
   Resilience: Resilience;
-  Recovery: Recovery | DeprecatedRecovery;
+  Recovery: Recovery;
   Discipline: StatAbilities;
-  Intellect: Intellect | StatAbilities;
+  Intellect: Intellect;
   Strength: StatAbilities;
 }
 
 export interface ClarityStatsVersion {
   lastUpdate: number;
-  lastBreakingChange: number;
+  schemaVersion: string;
 }
 
 export interface Ability {
@@ -17,15 +17,24 @@ export interface Ability {
   Hash: number;
   /** Array index represents the Character Stat tier. Cooldowns are in seconds. Rounded to 2 decimal points. Note: Rounding to 2 decimal places is solely for improving math precision when combined with Override objects. When displaying these cooldown times, it is STRONGLY recommended to round them to an integer. */
   Cooldowns: number[];
+  /** Represents the behavior of certain abilities possessing additional scaling on their cooldown depending on the number of stored ability charges. The array's length represents the number of charges an ability has intrinsically. Numbers at every array index represent the Charge Rate scalar for the ability with [index] number of stored ability charges. As this is a Charge Rate scalar, cooldown times can be calculated by dividing the times in the Cooldowns member of abilities by the scalars in this array. Do note that this is not a required member of Ability objects and will only be present if an ability has multiple charges. (Therefore, if this property is absent, it is to be assumed that the ability only has a single charge by default) */
+  ChargeBasedScaling?: number[];
 }
 
-export interface SuperAbility extends Ability {
+/** Contains a locale ID that you can use to grab the description for the item in your selected language. The ID is provided in a [key].[value] format where there can be an arbitrary number of keys (though it'll be 2-3 at most). Then you can use these keys and values to query the './locale/[language code].json' files for the desired description. */
+type Description = string;
+
+export interface SuperAbility {
+  /** D2 Manifest inventoryItem hash */
+  Hash: number;
+  /** Array index represents the Character Stat tier. Cooldowns are in seconds. Rounded to 2 decimal points. Note: Rounding to 2 decimal places is solely for improving math precision when combined with Override objects. When displaying these cooldown times, it is STRONGLY recommended to round them to an integer. */
+  Cooldowns: number[];
   /** Numbers are provided in Damage Resist percentages and represent the Damage Resistance the super provied inside PvP. If the array is empty, the DR value is still unknown. If the array only contains one value, it represents the passive DR of the super. If the value is -9999, the value is still unknown (workaround that allows only inputting one of the PvE or PvP values. If other values are present, check the condition array for the conditions of each of them. */
   PvPDamageResistance: number[];
   /** Same length as the PvPDamageResistance array and works the exact same way except it stores the DR values for PvE. */
   PvEDamageResistance: number[];
   /** Array length matches the length of the DamageResistance arrays. This property can be ignored when the length of the arrays is 1 as that represents the passive DR of the Super that doesn't have a condition. The array contains the condition for each Damage Resist value at the same index in the DamageResistance arrays. Unfortunately, there is no way to realistically account for all the different conditions without using simple text for it so these will be succinct descriptions instead of item hashes or the like. */
-  DRCondition: string[];
+  DRCondition: Description[];
 }
 
 export interface Override {
@@ -50,48 +59,47 @@ export interface Override {
 export interface StatAbilities {
   Abilities: Ability[];
   Overrides: Override[];
+  Description: Description;
+}
+
+export interface DescriptionArray {
+  Description: Description;
+  Array: number[];
 }
 
 export interface Mobility extends StatAbilities {
   /** Represents how fast you can walk (not sprint) forward in meters per second. Array index represents the Mobility tier. Rounding beyond 2 decimal places is not recommended. */
-  WalkingSpeed: number[];
+  WalkSpeed: DescriptionArray;
   /** Represents how fast you can walk side-to-side and backwards in meters per second (85% of Walking Speed). Array index represents the Mobility tier. Rounding beyond 2 decimal places is not recommended. */
-  StrafeSpeed: number[];
+  StrafeSpeed: DescriptionArray;
   /** Represents how fast you can move while crouching in meters per second (55% of Walking Speed). Array index represents the Mobility tier. The speeds are represented in meters per second. Rounding beyond 2 decimal places is not recommended. */
-  CrouchSpeed: number[];
+  CrouchSpeed: DescriptionArray;
 }
 
 export interface Recovery extends StatAbilities {
   /** Array index represents the Recovery tier. The numbers represent how many seconds it takes to heal from 0 to full HP. Rounding is not recommended. */
-  TotalRegenTime: number[];
+  TotalRegenTime: DescriptionArray;
   /** Array index represents the Recovery tier. The numbers representhow many seconds after taking damage Health Regeneration starts. Rounding is not recommended. Good to know: Health is a fixed 70 HP portion of your total health alongside 'Shields' which a 115-130 HP portion of total health determined by Resilience. */
-  HealthRegenDelay: number[];
+  HealthRegenDelay: DescriptionArray;
   /** Array index represents the Recovery tier. The numbers represent how fast your health regens after the delay. The numbers are provided in % of total health per second (total health is a fixed 70HP). Rounding beyond 1-2 decimal places is not recommended. For all intents and purposes, you can divide the numbers by 100, multiply by 70, and display it as HP/second. */
-  HealthRegenSpeed: number[];
+  HealthRegenSpeed: DescriptionArray;
   /** Array index represents the Recovery tier. The numbers represent how many seconds after taking damage Shield Regeneration starts. Rounding is not recommended. Good to know: Shield health is a 115-130 HP portion of total health determined by Resilience. */
-  ShieldRegenDelay: number[];
+  ShieldRegenDelay: DescriptionArray;
   /** Array index represents the Recovery tier. The numbers represent how fast your shields regen after the delay. The numbers are provided in % of total shield health per second (shield health is a 115-130 HP portion of total health determined by Resilience). Rounding beyond 1-2 decimal places is not recommended. For all intents and purposes, you can take the TotalHP value at a specified Resilience tier and subtract 70 to get the shield health. After that, you can divide the ShieldRegenSpeed numbers by 100, multiply it by the selected shield health, and display it as HP/second. (Though it's probably better to leave it in % to avoid potentially causing confusion for users) */
-  ShieldRegenSpeed: number[];
-}
-
-export interface DeprecatedRecovery extends StatAbilities {
-  /**
-   * Array index represents the Recovery tier. The numbers represent how many seconds it takes to heal to full HP.
-   * @deprecated this was renamed to TotalRegenTime
-   */
-  TimeToFullHP: number[] | undefined;
+  ShieldRegenSpeed: DescriptionArray;
 }
 
 export interface Resilience extends StatAbilities {
   /** Array index represents the Resilience tier. The numbers represent your total HP at each tier. 'Health' is a static 70 HP, the rest are what Bungie calls 'Shields' in-game. If you wish to display them separately, just subtract 70 from the numbers to get your shield HP. */
-  TotalHP: number[];
-  /** Array index represents the Resilience tier. The numbers represent the percentage damage resistance granted *IN PVE* at each tier. */
-  DamageResistance: number[];
+  TotalHP: DescriptionArray;
+  /** Array index represents the Resilience tier. The numbers represent the percentage damage resistance granted IN PVE at each tier. */
+  PvEDamageResistance: DescriptionArray;
   /** Array index represents the Resilience tier. The numbers represent the percentage flinch resistance granted at each tier. */
-  FlinchResistance: number[];
+  FlinchResistance: DescriptionArray;
 }
 
 export interface Intellect {
   SuperAbilities: SuperAbility[];
   Overrides: Override[];
+  Description: Description;
 }

--- a/src/app/clarity/descriptions/loadDescriptions.ts
+++ b/src/app/clarity/descriptions/loadDescriptions.ts
@@ -16,7 +16,7 @@ const urls = {
   statsVersion: `${CLARITY_BASE}Character-Stats/update.json`,
 } as const;
 
-const CLARITY_STATS_SUPPORTED_SCHEMA = '1.7';
+const CLARITY_STATS_SUPPORTED_SCHEMA = '1.8';
 
 const fetchClarity = async <T>(type: keyof typeof urls, version?: string) => {
   const url = urls[type];

--- a/src/app/clarity/descriptions/loadDescriptions.ts
+++ b/src/app/clarity/descriptions/loadDescriptions.ts
@@ -10,13 +10,17 @@ import { ClarityDescription, ClarityVersions } from './descriptionInterface';
 const CLARITY_BASE = 'https://database-clarity.github.io/';
 const urls = {
   descriptions: `${CLARITY_BASE}Live-Clarity-Database/descriptions/dim.json`,
-  characterStats: `${CLARITY_BASE}Character-Stats/CharacterStatInfo-NI.json`,
+  characterStats: (version: string) =>
+    `${CLARITY_BASE}Character-Stats/versions/${version}/CharacterStatInfo-NI.json`,
   version: `${CLARITY_BASE}Live-Clarity-Database/versions.json`,
   statsVersion: `${CLARITY_BASE}Character-Stats/update.json`,
 } as const;
 
-const fetchClarity = async <T>(type: keyof typeof urls) => {
-  const data = await fetch(urls[type]);
+const CLARITY_STATS_SUPPORTED_SCHEMA = '1.7';
+
+const fetchClarity = async <T>(type: keyof typeof urls, version?: string) => {
+  const url = urls[type];
+  const data = await fetch(typeof url === 'function' ? url(version!) : url);
   if (!data.ok) {
     throw new Error(`failed to fetch ${type}`);
   }
@@ -58,32 +62,53 @@ const loadClarityDescriptions = dedupePromise(async (loadFromIndexedDB: boolean)
   return undefined;
 });
 
-const fetchRemoteStats = async (version: number) => {
-  const descriptions = await fetchClarity<ClarityCharacterStats>('characterStats');
+const fetchRemoteStats = async (version: ClarityStatsVersion) => {
+  const descriptions = await fetchClarity<ClarityCharacterStats>(
+    'characterStats',
+    version.schemaVersion
+  );
   set('clarity-characterStats', descriptions);
-  localStorage.setItem('clarityStatsVersion', version.toString());
+  localStorage.setItem('clarityStatsVersion2', JSON.stringify(version));
   return descriptions;
 };
 
 const loadClarityStats = dedupePromise(async (loadFromIndexedDB: boolean) => {
-  const savedStatsVersion = Number(localStorage.getItem('clarityStatsVersion') ?? '0');
+  const savedStatsValue = localStorage.getItem('clarityStatsVersion2');
+  const savedStats =
+    savedStatsValue !== null ? (JSON.parse(savedStatsValue) as ClarityStatsVersion) : undefined;
   let liveStatsVersion: ClarityStatsVersion | undefined;
   try {
     liveStatsVersion = await fetchClarity<ClarityStatsVersion>('statsVersion');
-    if (savedStatsVersion !== liveStatsVersion.lastUpdate) {
-      return await fetchRemoteStats(liveStatsVersion.lastUpdate);
+    if (
+      liveStatsVersion.schemaVersion === CLARITY_STATS_SUPPORTED_SCHEMA &&
+      (!savedStats || savedStats.lastUpdate !== liveStatsVersion.lastUpdate)
+    ) {
+      // There's been a live update and we support the update's schema -- fetch it
+      return await fetchRemoteStats(liveStatsVersion);
     }
   } catch (e) {
     errorLog('clarity', 'failed to load remote character stats', e);
   }
 
   if (loadFromIndexedDB) {
-    const savedCharacterStats = await get<ClarityCharacterStats>('clarity-characterStats');
-    return (
-      savedCharacterStats ??
-      // If IDB doesn't have the data (e.g. after deleting IDB but not localStorage), fetch it
-      (liveStatsVersion && (await fetchRemoteStats(liveStatsVersion.lastUpdate)))
-    );
+    if (savedStats?.schemaVersion === CLARITY_STATS_SUPPORTED_SCHEMA) {
+      const savedCharacterStats = await get<ClarityCharacterStats>('clarity-characterStats');
+      if (savedCharacterStats) {
+        return savedCharacterStats;
+      }
+    }
+
+    // If IDB doesn't have the data (e.g. after deleting IDB but not localStorage),
+    // or our IDB data has an unsupported schema version, fetch whatever we need
+    const remoteToFetch =
+      liveStatsVersion?.schemaVersion === CLARITY_STATS_SUPPORTED_SCHEMA
+        ? liveStatsVersion
+        : // NB if we're an old app release and don't support the most recent schema,
+          // we don't get a useful `lastUpdate` value anyway, and we'll never
+          // use this `lastUpdate` to decide when to re-fetch -- outdated apps
+          // use whatever they have in IDB, only fetching if there's nothing useful in IDB
+          { schemaVersion: CLARITY_STATS_SUPPORTED_SCHEMA, lastUpdate: 0 };
+    return fetchRemoteStats(remoteToFetch);
   }
 
   return undefined;

--- a/src/app/store-stats/ClarityCharacterStat.tsx
+++ b/src/app/store-stats/ClarityCharacterStat.tsx
@@ -90,42 +90,36 @@ export default function ClarityCharacterStat({
 
   // Cooldowns that are not about some specific ability
   const intrinsicCooldowns: JSX.Element[] = [];
-  const regenArray =
-    'TimeToFullHP' in clarityStatData
-      ? clarityStatData.TimeToFullHP
-      : 'TotalRegenTime' in clarityStatData
-      ? clarityStatData.TotalRegenTime
-      : undefined;
-  if (regenArray !== undefined) {
+  if ('TotalRegenTime' in clarityStatData) {
     intrinsicCooldowns.push(
       <StatTableRow
         key="TimeToFullHP"
         name={t('Stats.TimeToFullHP')}
-        cooldowns={regenArray}
+        cooldowns={clarityStatData.TotalRegenTime.Array}
         tier={tier}
         unit="s"
       />
     );
-  } else if ('WalkingSpeed' in clarityStatData) {
+  } else if ('WalkSpeed' in clarityStatData) {
     intrinsicCooldowns.push(
       <StatTableRow
         key="WalkingSpeed"
         name={t('Stats.WalkingSpeed')}
-        cooldowns={clarityStatData.WalkingSpeed}
+        cooldowns={clarityStatData.WalkSpeed.Array}
         tier={tier}
         unit={t('Stats.MetersPerSecond')}
       />,
       <StatTableRow
         key="StrafingSpeed"
         name={t('Stats.StrafingSpeed')}
-        cooldowns={clarityStatData.StrafeSpeed}
+        cooldowns={clarityStatData.StrafeSpeed.Array}
         tier={tier}
         unit={t('Stats.MetersPerSecond')}
       />,
       <StatTableRow
         key="CrouchingSpeed"
         name={t('Stats.CrouchingSpeed')}
-        cooldowns={clarityStatData.CrouchSpeed}
+        cooldowns={clarityStatData.CrouchSpeed.Array}
         tier={tier}
         unit={t('Stats.MetersPerSecond')}
       />
@@ -135,21 +129,21 @@ export default function ClarityCharacterStat({
       <StatTableRow
         key="TotalHP"
         name={t('Stats.TotalHP')}
-        cooldowns={clarityStatData.TotalHP}
+        cooldowns={clarityStatData.TotalHP.Array}
         tier={tier}
         unit={t('Stats.HP')}
       />,
       <StatTableRow
         key="DamageResistance"
         name={t('Stats.DamageResistance')}
-        cooldowns={clarityStatData.DamageResistance}
+        cooldowns={clarityStatData.PvEDamageResistance.Array}
         tier={tier}
         unit={t('Stats.Percentage')}
       />,
       <StatTableRow
         key="FlinchResistance"
         name={t('Stats.FlinchResistance')}
-        cooldowns={clarityStatData.FlinchResistance}
+        cooldowns={clarityStatData.FlinchResistance.Array}
         tier={tier}
         unit={t('Stats.Percentage')}
       />

--- a/src/app/store-stats/ClarityCharacterStat.tsx
+++ b/src/app/store-stats/ClarityCharacterStat.tsx
@@ -67,7 +67,20 @@ export default function ClarityCharacterStat({
 
     // Apply cooldown overrides based on equipped items.
     for (const o of applicableOverrides) {
-      const abilityIndex = o.Requirements.indexOf(a.Hash);
+      const abilityIndex = (() => {
+        const abilityIndex = o.Requirements.indexOf(a.Hash);
+        if (abilityIndex !== -1) {
+          return abilityIndex;
+        }
+        const subclassIdx = o.Requirements.findIndex((r) => r < 0 && equippedHashes.has(-r));
+        if (subclassIdx !== -1) {
+          return subclassIdx;
+        }
+        if (o.Requirements.length === 1 && o.Requirements[0] === 0) {
+          return 0;
+        }
+        return -1;
+      })();
       if (abilityIndex !== -1) {
         if (o.CooldownOverride?.some((v) => v > 0)) {
           cooldowns = o.CooldownOverride;


### PR DESCRIPTION
Clarity wants to make more breaking changes to their stats database and I've suggested that they properly version their schema so that DIM can update independently after a breaking change happens and no synchronization between Clarity and DIM is needed.

With this PR a given DIM release only supports a given schema version. If this schema is the latest one, we'll get updates from Clarity, if Clarity stats made a breaking change, that DIM release will just stay on the old version/data until DIM updates. This ensures DIM won't ever see Clarity stats data with an unsupported schema, which hopefully means fewer crashes for users on inexplicably old DIM versions and a smoother upgrade path when breaking changes happen.