### PR TITLE
Remove finisher favoriting functionality, since game removed it

### DIFF
--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import React, { useMemo } from 'react';
 import BungieImage from '../dim-ui/BungieImage';
-import { AppIcon, lockIcon, starIcon, stickyNoteIcon } from '../shell/icons';
+import { AppIcon, lockIcon, stickyNoteIcon } from '../shell/icons';
 import { InventoryWishListRoll } from '../wishlists/wishlists';
 import BadgeInfo, { shouldShowBadge } from './BadgeInfo';
 import styles from './InventoryItem.m.scss';
@@ -106,10 +106,7 @@ export default function InventoryItem({
         {(tag || item.locked || hasNotes) && (
           <div className={styles.icons}>
             {item.locked && (!autoLockTagged || !tag || !canSyncLockState(item)) && (
-              <AppIcon
-                className={styles.icon}
-                icon={item.bucket.hash !== BucketHashes.Finishers ? lockIcon : starIcon}
-              />
+              <AppIcon className={styles.icon} icon={lockIcon} />
             )}
             {tag && <TagIcon className={styles.icon} tag={tag} />}
             {hasNotes && <AppIcon className={styles.icon} icon={stickyNoteIcon} />}

--- a/src/app/inventory/SyncTagLock.tsx
+++ b/src/app/inventory/SyncTagLock.tsx
@@ -1,7 +1,6 @@
 import { TagValue } from '@destinyitemmanager/dim-api-types';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { errorLog, infoLog } from 'app/utils/log';
-import { BucketHashes } from 'data/d2/generated-enums';
 import { memo, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -15,9 +14,7 @@ export function canSyncLockState(item: DimItem) {
     item.lockable &&
     item.taggable &&
     // don't auto-lock crafted items because they must be unlocked to reshape and DIM shouldn't re-lock an item while the user is choosing new perks
-    !item.crafted &&
-    // locking means something very different for finishers
-    item.bucket.hash !== BucketHashes.Finishers
+    !item.crafted
   );
 }
 

--- a/src/app/item-actions/ActionButtons.tsx
+++ b/src/app/item-actions/ActionButtons.tsx
@@ -16,7 +16,6 @@ import { addItemToLoadout } from 'app/loadout-drawer/loadout-events';
 import { AppIcon, addIcon, compareIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
-import { BucketHashes } from 'data/d2/generated-enums';
 import { useDispatch, useSelector } from 'react-redux';
 import arrowsIn from '../../images/arrows-in.png';
 import arrowsOut from '../../images/arrows-out.png';
@@ -63,14 +62,13 @@ export function LockActionButton({
   const disabled = autoLockTagged && tag !== undefined && canSyncLockState(item);
 
   const type = item.lockable ? 'lock' : 'track';
+  // Let's keep these translations around?
+  // t('MovePopup.FavoriteUnFavorite.Favorited')
+  // t('MovePopup.FavoriteUnFavorite.Unfavorited')
   const title =
     type === 'lock'
       ? item.locked
-        ? item.bucket.hash === BucketHashes.Finishers
-          ? t('MovePopup.FavoriteUnFavorite.Favorited')
-          : t('MovePopup.LockUnlock.Locked')
-        : item.bucket.hash === BucketHashes.Finishers
-        ? t('MovePopup.FavoriteUnFavorite.Unfavorited')
+        ? t('MovePopup.LockUnlock.Locked')
         : t('MovePopup.LockUnlock.Unlocked')
       : item.tracked
       ? t('MovePopup.TrackUntrack.Tracked')

--- a/src/app/item-actions/LockButton.tsx
+++ b/src/app/item-actions/LockButton.tsx
@@ -5,18 +5,9 @@ import { setItemLockState } from 'app/inventory/item-move-service';
 import { hideItemPopup } from 'app/item-popup/item-popup';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import clsx from 'clsx';
-import { BucketHashes } from 'data/d2/generated-enums';
 import React, { useState } from 'react';
 import { DimItem } from '../inventory/item-types';
-import {
-  AppIcon,
-  lockIcon,
-  starIcon,
-  starOutlineIcon,
-  trackedIcon,
-  unlockedIcon,
-  unTrackedIcon,
-} from '../shell/icons';
+import { AppIcon, lockIcon, trackedIcon, unlockedIcon, unTrackedIcon } from '../shell/icons';
 import ActionButton from './ActionButton';
 import styles from './LockButton.m.scss';
 
@@ -69,11 +60,7 @@ export default function LockButton({
   const icon =
     type === 'lock'
       ? item.locked
-        ? item.bucket.hash === BucketHashes.Finishers
-          ? starIcon
-          : lockIcon
-        : item.bucket.hash === BucketHashes.Finishers
-        ? starOutlineIcon
+        ? lockIcon
         : unlockedIcon
       : item.tracked
       ? trackedIcon
@@ -102,13 +89,12 @@ export default function LockButton({
 
 function lockButtonTitle(item: DimItem, type: 'lock' | 'track') {
   const data = { itemType: item.typeName };
+  // Let's keep these translations around?
+  // t('MovePopup.FavoriteUnFavorite.Favorite', data)
+  // t('MovePopup.FavoriteUnFavorite.Unfavorite', data)
   return type === 'lock'
     ? !item.locked
-      ? item.bucket.hash === BucketHashes.Finishers
-        ? t('MovePopup.FavoriteUnFavorite.Favorite', data)
-        : t('MovePopup.LockUnlock.Lock', data)
-      : item.bucket.hash === BucketHashes.Finishers
-      ? t('MovePopup.FavoriteUnFavorite.Unfavorite', data)
+      ? t('MovePopup.LockUnlock.Lock', data)
       : t('MovePopup.LockUnlock.Unlock', data)
     : !item.tracked
     ? t('MovePopup.TrackUntrack.Track', data)


### PR DESCRIPTION
This functionality is obsolete now. As per the [TWID 2023-08-24](https://www.bungie.net/7/en/News/Article/this-week-in-destiny-8-24-23):

> FINISHER CHANGES
>
> With the launch of 7.2.0, the option to favorite cosmetics was added to the game. As a result of this implementation, the option to favorite Finishers in player inventories was deprecated. Players who would like to only use specific Finishers in gameplay can Store their Finishers in their Flair Collections. To obtain them again or to obtain other Finishers, players can reacquire them in their Collections under Flair > Finishers.