### PR TITLE
bulk note autocomplete: fix dropdown missing on first render

### DIFF
--- a/src/app/dim-ui/text-complete/text-complete.ts
+++ b/src/app/dim-ui/text-complete/text-complete.ts
@@ -76,7 +76,7 @@ function createSymbolsAutocompleter(symbols: SymbolsMap): StrategyProps {
 export function useAutocomplete(
   textArea: React.RefObject<HTMLTextAreaElement | HTMLInputElement>,
   tags: string[],
-  parent?: HTMLElement
+  parent?: React.RefObject<HTMLElement>
 ) {
   const symbols = useSelector(symbolsSelector);
   useEffect(() => {
@@ -91,7 +91,7 @@ export function useAutocomplete(
         {
           dropdown: {
             className: clsx(styles.dropdownMenu, 'textcomplete-dropdown'),
-            parent: parent ?? tempContainer,
+            parent: parent?.current ?? tempContainer,
           },
         }
       );

--- a/src/app/dim-ui/useBulkNote.tsx
+++ b/src/app/dim-ui/useBulkNote.tsx
@@ -173,7 +173,7 @@ function NotesEditor({
   const isPhonePortrait = useIsPhonePortrait();
 
   const tags = useSelector(allNotesHashtagsSelector);
-  useAutocomplete(textArea, tags, form.current ?? undefined);
+  useAutocomplete(textArea, tags, form);
 
   // On iOS at least, focusing the keyboard pushes the content off the screen
   const nativeAutoFocus = !isPhonePortrait && !isiOSBrowser();


### PR DESCRIPTION
Steps to repro on app/beta: Search for something, bulk note, focus textarea, press `#`. Autocomplete dropdown fails to appear. Backspace, `#`, now it appears.

Ref object changes don't trigger a re-render, so on the first render, `useAutocomplete` is called with an `undefined` parent, since the hook is called before we even return anything to render. When we hit a key, we re-render (since it's a controlled component), which destroys and re-creates the autocompleter because `parent.current` changes, which eats the key press and prevents the autocomplete dropdown from appearing the first time.