### PR TITLE
Fix autocomplete positioning by placing the tempContainer absolutely.

### DIFF
--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -294,11 +294,5 @@ select {
   filter: drop-shadow(0 0 0 #fff);
 }
 
-#temp-container {
-  // Make sure things in the temp container display above others
-  position: relative;
-  z-index: 1000;
-}
-
 /* stylelint-disable-next-line no-invalid-position-at-import-rule */
 @import 'app/dim-ui/dim-button.scss';

--- a/src/app/utils/temp-container.scss
+++ b/src/app/utils/temp-container.scss
@@ -1,0 +1,10 @@
+#temp-container {
+  // Position this at the very top of the screen. Most things won't care
+  // (they're absolutely positioned themselves, but @textcomplete doesn't know
+  // how to position itself within a positioning context that isn't the
+  // document.
+  position: absolute;
+  top: 0;
+  // Make sure things in the temp container display above others
+  z-index: 1000;
+}

--- a/src/app/utils/temp-container.ts
+++ b/src/app/utils/temp-container.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
+import './temp-container.scss';
 
 /**
  * A guaranteed-present element for attaching temporary elements to instead of


### PR DESCRIPTION
Not super proud of this but I think it might be a more robust fix than setting z-index on tempContainer's children. Fixes #9769. The changes in #9770 still need to happen.