### PR TITLE
Fix search bar color for all sheets

### DIFF
--- a/src/app/_theme.scss
+++ b/src/app/_theme.scss
@@ -87,6 +87,7 @@
 
   // Item sheet (compare, armory)
   --theme-item-sheet-bg: var(--theme-fill-modal);
+  --theme-sheet-search-bg: rgba(255, 255, 255, 0.15);
 
   // Organizer
   --theme-organizer-row-odd-bg: #27263a;

--- a/src/app/search/FilterHelp.m.scss
+++ b/src/app/search/FilterHelp.m.scss
@@ -56,10 +56,6 @@
 
 .search {
   margin: 8px 0 !important;
-
-  :global(.search-filter) {
-    background-color: rgba(255, 255, 255, 0.15);
-  }
 }
 
 .entry {

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  background-color: var(--theme-search-bg);
+  background-color: var(--theme-sheet-search-bg);
   padding-left: 5px;
   padding-right: 5px;
   height: $search-bar-height;


### PR DESCRIPTION
Follows up on #9705 changes

For pretty much all sheets except for the FiltersHelp sheet, the search bar looks like this

![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/7caf5e0f-8707-4164-83c8-8c18721bc9b5)

This applies the fix from #9705 to all search bars, only the header search bar overrides it

![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/392a86d3-0f4b-402f-a7e1-3b6ee33888fe)

Uses a theme variable so that a light theme could also make the search bar darker than the sheet background.