### PR TITLE
One more place that should handle auth errors

### DIFF
--- a/src/app/accounts/platforms.ts
+++ b/src/app/accounts/platforms.ts
@@ -100,6 +100,7 @@ function loadPlatforms(membershipId: string): ThunkResult<readonly DestinyAccoun
       dispatch(actions.accountsLoaded(destinyAccounts));
     } catch (e) {
       if (!accountsSelector(getState()).length) {
+        dispatch(actions.handleAuthErrors(e));
         throw e;
       }
     }


### PR DESCRIPTION
I know I've said it before, but I once again believe I've found the cause of people not being bounced to login. This was one more place where we weren't checking auth errors, and it could happen before we even attempt to load stores if the user didn't have locally stored accounts / default account preference. This should *finally* handle the rest of these.