### PR TITLE
Fix a bug where D1 loadout optimizer couldn't handle a page reload

### DIFF
--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -1,10 +1,10 @@
 import { infoLog } from 'app/utils/log';
+import { delay } from 'app/utils/util';
 import disciplineIcon from 'images/discipline.png';
 import intellectIcon from 'images/intellect.png';
 import strengthIcon from 'images/strength.png';
 import _ from 'lodash';
 import { D1Item } from '../../inventory/item-types';
-import { D1Store } from '../../inventory/store-types';
 import {
   ArmorSet,
   ArmorTypes,
@@ -15,8 +15,7 @@ import {
 } from './types';
 import { calcArmorStats, genSetHash, getBestArmor, getBonusConfig } from './utils';
 
-export function getSetBucketsStep(
-  activeGuardian: D1Store,
+export async function getSetBucketsStep(
   activeGuardianBucket: ItemBucket,
   vendorBucket: ItemBucket,
   lockeditems: { [armorType in ArmorTypes]: D1ItemWithNormalStats | null },
@@ -26,11 +25,14 @@ export function getSetBucketsStep(
   includeVendors: boolean,
   fullMode: boolean,
   cancelToken: { cancelled: boolean }
-): Promise<{
-  allSetTiers: string[];
-  activesets: string;
-  highestsets: { [setHash: number]: SetType };
-}> {
+): Promise<
+  | {
+      allSetTiers: string[];
+      activesets: string;
+      highestsets: { [setHash: number]: SetType };
+    }
+  | undefined
+> {
   const bestArmor = getBestArmor(
     activeGuardianBucket,
     vendorBucket,
@@ -87,173 +89,152 @@ export function getSetBucketsStep(
     });
   }
 
-  return new Promise((resolve) => {
-    function step(
-      activeGuardian: D1Store,
-      h: number,
-      g: number,
-      c: number,
-      l: number,
-      ci: number,
-      gh: number,
-      ar: number,
-      processedCount: number
-    ) {
-      for (; h < helms.length; ++h) {
-        for (; g < gauntlets.length; ++g) {
-          for (; c < chests.length; ++c) {
-            for (; l < legs.length; ++l) {
-              for (; ci < classItems.length; ++ci) {
-                for (; gh < ghosts.length; ++gh) {
-                  for (; ar < artifacts.length; ++ar) {
-                    const validSet =
-                      Number(helms[h].item.isExotic) +
-                        Number(gauntlets[g].item.isExotic) +
-                        Number(chests[c].item.isExotic) +
-                        Number(legs[l].item.isExotic) <
-                      2;
+  let processedCount = 0;
 
-                    if (validSet) {
-                      const set: ArmorSet = {
-                        armor: {
-                          Helmet: helms[h],
-                          Gauntlets: gauntlets[g],
-                          Chest: chests[c],
-                          Leg: legs[l],
-                          ClassItem: classItems[ci],
-                          Artifact: artifacts[ar],
-                          Ghost: ghosts[gh],
-                        },
-                        stats: {
-                          144602215: {
-                            hash: 144602215,
-                            value: 0,
-                            name: 'Intellect',
-                            description: '',
-                            icon: intellectIcon,
-                          },
-                          1735777505: {
-                            hash: 1735777505,
-                            value: 0,
-                            name: 'Discipline',
-                            description: '',
-                            icon: disciplineIcon,
-                          },
-                          4244567218: {
-                            hash: 4244567218,
-                            value: 0,
-                            name: 'Strength',
-                            description: '',
-                            icon: strengthIcon,
-                          },
-                        },
-                        setHash: '',
-                        includesVendorItems: false,
+  for (const helm of helms) {
+    for (const gauntlet of gauntlets) {
+      for (const chest of chests) {
+        for (const leg of legs) {
+          for (const classItem of classItems) {
+            for (const ghost of ghosts) {
+              for (const artifact of artifacts) {
+                const validSet =
+                  Number(helm.item.isExotic) +
+                    Number(gauntlet.item.isExotic) +
+                    Number(chest.item.isExotic) +
+                    Number(leg.item.isExotic) <
+                  2;
+
+                if (validSet) {
+                  const set: ArmorSet = {
+                    armor: {
+                      Helmet: helm,
+                      Gauntlets: gauntlet,
+                      Chest: chest,
+                      Leg: leg,
+                      ClassItem: classItem,
+                      Artifact: artifact,
+                      Ghost: ghost,
+                    },
+                    stats: {
+                      144602215: {
+                        hash: 144602215,
+                        value: 0,
+                        name: 'Intellect',
+                        description: '',
+                        icon: intellectIcon,
+                      },
+                      1735777505: {
+                        hash: 1735777505,
+                        value: 0,
+                        name: 'Discipline',
+                        description: '',
+                        icon: disciplineIcon,
+                      },
+                      4244567218: {
+                        hash: 4244567218,
+                        value: 0,
+                        name: 'Strength',
+                        description: '',
+                        icon: strengthIcon,
+                      },
+                    },
+                    setHash: '',
+                    includesVendorItems: false,
+                  };
+
+                  const pieces = Object.values(set.armor);
+                  set.setHash = genSetHash(pieces);
+                  calcArmorStats(pieces, set.stats, scaleType);
+                  const tiersString = `${tierValue(set.stats[144602215].value)}/${tierValue(
+                    set.stats[1735777505].value
+                  )}/${tierValue(set.stats[4244567218].value)}`;
+
+                  tiersSet.add(tiersString);
+
+                  // Build a map of all sets but only keep one copy of armor
+                  // so we reduce memory usage
+                  if (setMap[set.setHash]) {
+                    if (setMap[set.setHash].tiers[tiersString]) {
+                      setMap[set.setHash].tiers[tiersString].configs.push(
+                        getBonusConfig(set.armor)
+                      );
+                    } else {
+                      setMap[set.setHash].tiers[tiersString] = {
+                        stats: set.stats,
+                        configs: [getBonusConfig(set.armor)],
                       };
-
-                      const pieces = Object.values(set.armor);
-                      set.setHash = genSetHash(pieces);
-                      calcArmorStats(pieces, set.stats, scaleType);
-                      const tiersString = `${tierValue(set.stats[144602215].value)}/${tierValue(
-                        set.stats[1735777505].value
-                      )}/${tierValue(set.stats[4244567218].value)}`;
-
-                      tiersSet.add(tiersString);
-
-                      // Build a map of all sets but only keep one copy of armor
-                      // so we reduce memory usage
-                      if (setMap[set.setHash]) {
-                        if (setMap[set.setHash].tiers[tiersString]) {
-                          setMap[set.setHash].tiers[tiersString].configs.push(
-                            getBonusConfig(set.armor)
-                          );
-                        } else {
-                          setMap[set.setHash].tiers[tiersString] = {
-                            stats: set.stats,
-                            configs: [getBonusConfig(set.armor)],
-                          };
-                        }
-                      } else {
-                        setMap[set.setHash] = { set, tiers: {} };
-                        setMap[set.setHash].tiers[tiersString] = {
-                          stats: set.stats,
-                          configs: [getBonusConfig(set.armor)],
-                        };
-                      }
-
-                      // no owner means this is a vendor item
-                      set.includesVendorItems = pieces.some((armor) => !armor.item.owner);
                     }
-
-                    processedCount++;
-                    if (cancelToken.cancelled) {
-                      infoLog('loadout optimizer', 'cancelled processing');
-                      return;
-                    }
-                    if (processedCount % 50000 === 0) {
-                      infoLog(
-                        'loadout optimizer',
-                        processedCount,
-                        'combinations processed, still going...'
-                      );
-                      setTimeout(() =>
-                        step(activeGuardian, h, g, c, l, ci, gh, ar, processedCount)
-                      );
-                      return;
-                    }
+                  } else {
+                    setMap[set.setHash] = { set, tiers: {} };
+                    setMap[set.setHash].tiers[tiersString] = {
+                      stats: set.stats,
+                      configs: [getBonusConfig(set.armor)],
+                    };
                   }
-                  ar = 0;
+
+                  // no owner means this is a vendor item
+                  set.includesVendorItems = pieces.some((armor) => !armor.item.owner);
                 }
-                gh = 0;
+
+                processedCount++;
+                if (cancelToken.cancelled) {
+                  infoLog('loadout optimizer', 'cancelled processing');
+                  return;
+                }
+                if (processedCount % 50000 === 0) {
+                  infoLog(
+                    'loadout optimizer',
+                    processedCount,
+                    'combinations processed, still going...'
+                  );
+                  // Allow the event loop to do other things before we resume
+                  await delay(0);
+                }
               }
-              ci = 0;
             }
-            l = 0;
-          }
-          c = 0;
-        }
-        g = 0;
-      }
-
-      const tiers = _.groupBy(Array.from(tiersSet.keys()), (tierString: string) =>
-        _.sumBy(tierString.split('/'), (num) => parseInt(num, 10))
-      );
-      for (const tier of Object.values(tiers)) {
-        tier.sort().reverse();
-      }
-
-      const allSetTiers: string[] = [];
-      const tierKeys = Object.keys(tiers);
-      for (let t = tierKeys.length; t > tierKeys.length - 3; t--) {
-        if (tierKeys[t]) {
-          allSetTiers.push(`- Tier ${tierKeys[t]} -`);
-          for (const set of tiers[tierKeys[t]]) {
-            allSetTiers.push(set);
           }
         }
       }
-
-      let activesets = '';
-      if (!allSetTiers.includes(activesets)) {
-        activesets = allSetTiers[1];
-      }
-
-      if (cancelToken.cancelled) {
-        infoLog('loadout optimizer', 'cancelled processing');
-        return;
-      }
-
-      // Finish progress
-      infoLog('loadout optimizer', 'processed', combos, 'combinations.');
-
-      resolve({
-        allSetTiers,
-        activesets,
-        highestsets: setMap,
-      });
     }
-    setTimeout(() => step(activeGuardian, 0, 0, 0, 0, 0, 0, 0, 0));
-  });
+  }
+
+  const tiers = _.groupBy(Array.from(tiersSet.keys()), (tierString: string) =>
+    _.sumBy(tierString.split('/'), (num) => parseInt(num, 10))
+  );
+  for (const tier of Object.values(tiers)) {
+    tier.sort().reverse();
+  }
+
+  const allSetTiers: string[] = [];
+  const tierKeys = Object.keys(tiers);
+  for (let t = tierKeys.length; t > tierKeys.length - 3; t--) {
+    if (tierKeys[t]) {
+      allSetTiers.push(`- Tier ${tierKeys[t]} -`);
+      for (const set of tiers[tierKeys[t]]) {
+        allSetTiers.push(set);
+      }
+    }
+  }
+
+  let activesets = '';
+  if (!allSetTiers.includes(activesets)) {
+    activesets = allSetTiers[1];
+  }
+
+  if (cancelToken.cancelled) {
+    infoLog('loadout optimizer', 'cancelled processing');
+    return;
+  }
+
+  // Finish progress
+  infoLog('loadout optimizer', 'processed', combos, 'combinations.');
+
+  return {
+    allSetTiers,
+    activesets,
+    highestsets: setMap,
+  };
 
   // reset: lockedchanged, excludedchanged, perkschanged, hassets
 }


### PR DESCRIPTION
I don't know what compelled me to mess with this, but I found a bad assumption in the D1 loadout builder that causes it to fail unless navigated to from the inventory. 

Also, I made the `setTimeout` yielding thing more async/await-y.