### PR TITLE
Fix sheet style precedence issues

### DIFF
--- a/src/app/item-popup/ItemPopup.m.scss
+++ b/src/app/item-popup/ItemPopup.m.scss
@@ -142,13 +142,13 @@
   flex-wrap: wrap;
 }
 
-.itemPopup {
-  &:global(.sheet) :global(.sheet-header) {
+.itemPopup:global(.sheet) {
+  :global(.sheet-header) {
     padding: 0;
     border: none;
   }
   :global(.sheet-close) {
-    padding: 12px 10px;
+    padding: 10px;
     color: black;
     opacity: 0.7;
   }

--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -87,7 +87,7 @@
   height: 24px;
 }
 
-.armorySheet {
+.armorySheet:global(.sheet) {
   max-width: 900px;
   margin: 0 auto;
   z-index: 14; // higher than item popup

--- a/src/app/vendors/single-vendor/SingleVendorSheet.m.scss
+++ b/src/app/vendors/single-vendor/SingleVendorSheet.m.scss
@@ -1,10 +1,5 @@
 .vendorSheet {
-  max-width: 900px;
-  margin: 0 auto;
-
-  :global(.sheet-close) {
-    right: 16px;
-  }
+  composes: sheet from 'app/armory/ArmorySheet.m.scss';
 }
 
 .sheetContents {


### PR DESCRIPTION
A few more where the sheet base styles were getting precedence because they shuffled later in the stylesheet order.

Long-term, the right solution is:

1. Find some other ways to customize sheet styles.
2. [`@layer`](https://caniuse.com/css-cascade-layers) once we bump the browser minimum to last year's versions.