### PR TITLE
Prevent mod picker tiles from overflowing from long text

### DIFF
--- a/src/app/dim-ui/TileGrid.m.scss
+++ b/src/app/dim-ui/TileGrid.m.scss
@@ -37,6 +37,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  width: 0;
 }
 
 .selected {


### PR DESCRIPTION
I don't have Strand on my warlock so someone else will need to test that this improves the display of Weavewalk.