### PR TITLE
Holistically sort vendor items according to in-game order, add locked vendor item augment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* The order of vendor items should now much more accurately match the in-game order.
 * Filters and toggles on the Vendors page now consider focusing/decoding subvendors. E.g. the "Only show uncollected items" toggle will now show focusing subvendors if they allow focusing items you don't have collected.
 
 ## 7.83.1 <span class="changelog-date">(2023-08-29)</span>

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -227,8 +227,6 @@ export interface DimItem {
   foundry?: string;
   /** Extra tooltips to show in the item popup */
   tooltipNotifications?: DestinyItemTooltipNotification[];
-  /** Index assigned to item by Bungie */
-  bungieIndex: number;
 }
 
 /**

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -59,7 +59,7 @@ export interface DimItem {
   /** Is this an Exotic item? */
   isExotic: boolean;
   /** If this came from a vendor (instead of character inventory), this houses enough information to re-identify the item. */
-  vendor?: { vendorHash: number; saleIndex: number; characterId: string };
+  vendor?: { vendorHash: number; vendorItemIndex: number; characterId: string };
   /** Localized name of the item. */
   name: string;
   /** Localized description of the item. */

--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -362,7 +362,6 @@ function makeItem(
     energy: null,
     powerCap: null,
     pursuit: null,
-    bungieIndex: 0,
   };
 
   // *able

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -528,7 +528,6 @@ export function makeItem(
     masterworkInfo: null,
     infusionQuality: null,
     tooltipNotifications,
-    bungieIndex: itemDef.index,
   };
 
   // *able

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -291,7 +291,6 @@ function makeFakePursuitItem(
     trackable: false,
     energy: null,
     powerCap: null,
-    bungieIndex: 0,
   };
 }
 

--- a/src/app/vendors/VendorItem.m.scss
+++ b/src/app/vendors/VendorItem.m.scss
@@ -32,6 +32,11 @@
   background: $acquiredGreen;
 }
 
+.lockedIcon {
+  composes: ownershipIcon;
+  background: grey;
+}
+
 .vendorItem {
   display: flex;
   flex-direction: column;

--- a/src/app/vendors/VendorItem.m.scss
+++ b/src/app/vendors/VendorItem.m.scss
@@ -20,6 +20,8 @@
   top: calc(#{$item-border-width} - 4px - var(--item-size) / 4 + var(--item-size));
   right: $item-border-width + 2px;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
 }
 
 .acquiredIcon {
@@ -35,6 +37,7 @@
 .lockedIcon {
   composes: ownershipIcon;
   background: grey;
+  align-items: center;
 }
 
 .vendorItem {

--- a/src/app/vendors/VendorItem.m.scss.d.ts
+++ b/src/app/vendors/VendorItem.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'acquiredIcon': string;
   'cost': string;
+  'lockedIcon': string;
   'ownedIcon': string;
   'ownershipIcon': string;
   'tile': string;

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -8,7 +8,7 @@ import BungieImage from '../dim-ui/BungieImage';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import ItemPopupTrigger from '../inventory/ItemPopupTrigger';
 import '../progress/milestone.scss';
-import { AppIcon, faCheck } from '../shell/icons';
+import { AppIcon, faCheck, lockIcon } from '../shell/icons';
 import Cost from './Cost';
 import styles from './VendorItem.m.scss';
 import { SingleVendorSheetContext } from './single-vendor/SingleVendorSheetContainer';
@@ -63,6 +63,7 @@ export default function VendorItemComponent({
       allowFilter={false}
       unavailable={unavailable}
       owned={owned}
+      locked={item.locked}
       acquired={acquired}
       extraData={{ failureStrings: item.failureStrings, characterId, owned, acquired, mod }}
     >
@@ -81,6 +82,7 @@ export function VendorItemDisplay({
   allowFilter,
   unavailable,
   owned,
+  locked,
   acquired,
   item,
   extraData,
@@ -90,6 +92,7 @@ export function VendorItemDisplay({
   /** i.e. greyed out */
   unavailable?: boolean;
   owned?: boolean;
+  locked?: boolean;
   acquired?: boolean;
   item: DimItem;
   extraData?: ItemPopupExtraInfo;
@@ -103,8 +106,10 @@ export function VendorItemDisplay({
     >
       {owned ? (
         <AppIcon className={styles.ownedIcon} icon={faCheck} />
+      ) : acquired ? (
+        <AppIcon className={styles.acquiredIcon} icon={faCheck} />
       ) : (
-        acquired && <AppIcon className={styles.acquiredIcon} icon={faCheck} />
+        locked && <AppIcon className={styles.lockedIcon} icon={lockIcon} />
       )}
       <ItemPopupTrigger item={item} extraData={extraData}>
         {(ref, onClick) => (

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -126,7 +126,7 @@ export default function VendorItems({
                     (vendorItem) =>
                       vendorItem.item && (
                         <VendorItemComponent
-                          key={vendorItem.key}
+                          key={vendorItem.vendorItemIndex}
                           item={vendorItem}
                           owned={Boolean(
                             ownedItemHashes?.has(vendorItem.item.hash) ||

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -2,7 +2,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { VENDORS, silverItemHash } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
-import { compareBy } from 'app/utils/comparators';
+import { chainComparator, compareBy } from 'app/utils/comparators';
 import { filterMap } from 'app/utils/util';
 import {
   DestinyCollectibleState,
@@ -95,10 +95,13 @@ export function toVendor(
 
   const vendorItems = getVendorItems(context, vendorDef, characterId, sales);
   vendorItems.sort(
-    compareBy(
-      (item) =>
-        item.originalCategoryIndex !== undefined &&
-        vendorDef.originalCategories[item.originalCategoryIndex]?.sortValue
+    chainComparator(
+      compareBy(
+        (item) =>
+          item.originalCategoryIndex !== undefined &&
+          vendorDef.originalCategories[item.originalCategoryIndex]?.sortValue
+      ),
+      compareBy((item) => item.vendorItemIndex)
     )
   );
 

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -94,6 +94,13 @@ export function toVendor(
   }
 
   const vendorItems = getVendorItems(context, vendorDef, characterId, sales);
+  vendorItems.sort(
+    compareBy(
+      (item) =>
+        item.originalCategoryIndex !== undefined &&
+        vendorDef.originalCategories[item.originalCategoryIndex]?.sortValue
+    )
+  );
 
   const destinationDef =
     typeof vendor?.vendorLocationIndex === 'number' && vendor.vendorLocationIndex >= 0

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -1,5 +1,5 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
-import { VENDORS } from 'app/search/d2-known-values';
+import { THE_FORBIDDEN_BUCKET, VENDORS } from 'app/search/d2-known-values';
 import { emptyArray } from 'app/utils/empty';
 import {
   DestinyCollectibleState,
@@ -13,7 +13,7 @@ import {
   DestinyVendorSaleItemComponent,
 } from 'bungie-api-ts/destiny2';
 import focusingItemOutputs from 'data/d2/focusing-item-outputs.json';
-import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes } from 'data/d2/generated-enums';
 import { DimItem } from '../inventory/item-types';
 import { ItemCreationContext, makeFakeItem } from '../inventory/store/d2-item-factory';
 
@@ -94,7 +94,8 @@ function makeVendorItem(
     borderless: Boolean(inventoryItem.uiItemDisplayStyle),
     displayTile: inventoryItem.uiItemDisplayStyle === 'ui_display_style_set_container',
     owned: Boolean(
-      inventoryItem.itemCategoryHashes?.includes(ItemCategoryHashes.Dummies) &&
+      (!inventoryItem.inventory ||
+        inventoryItem.inventory.bucketTypeHash === THE_FORBIDDEN_BUCKET) &&
         (saleItem?.augments || 0) & DestinyVendorItemState.Owned
     ),
     locked: Boolean((saleItem?.augments || 0) & DestinyVendorItemState.Locked),

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -13,7 +13,7 @@ import {
   DestinyVendorSaleItemComponent,
 } from 'bungie-api-ts/destiny2';
 import focusingItemOutputs from 'data/d2/focusing-item-outputs.json';
-import { BucketHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import { DimItem } from '../inventory/item-types';
 import { ItemCreationContext, makeFakeItem } from '../inventory/store/d2-item-factory';
 
@@ -28,6 +28,7 @@ export interface VendorItem {
   readonly borderless: boolean;
   readonly displayTile: boolean;
   readonly owned: boolean;
+  readonly locked: boolean;
   readonly canBeSold: boolean;
   readonly displayCategoryIndex?: number;
   readonly originalCategoryIndex?: number;
@@ -90,7 +91,11 @@ function makeVendorItem(
     displayProperties: inventoryItem.displayProperties,
     borderless: Boolean(inventoryItem.uiItemDisplayStyle),
     displayTile: inventoryItem.uiItemDisplayStyle === 'ui_display_style_set_container',
-    owned: Boolean((saleItem?.augments || 0) & DestinyVendorItemState.Owned),
+    owned: Boolean(
+      inventoryItem.itemCategoryHashes?.includes(ItemCategoryHashes.Dummies) &&
+        (saleItem?.augments || 0) & DestinyVendorItemState.Owned
+    ),
+    locked: Boolean((saleItem?.augments || 0) & DestinyVendorItemState.Locked),
     canBeSold: !saleItem || saleItem.failureIndexes.length === 0,
     displayCategoryIndex: vendorItemDef?.displayCategoryIndex,
     originalCategoryIndex: vendorItemDef?.originalCategoryIndex,

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -30,6 +30,7 @@ export interface VendorItem {
   readonly owned: boolean;
   readonly canBeSold: boolean;
   readonly displayCategoryIndex?: number;
+  readonly originalCategoryIndex?: number;
   readonly costs: DestinyItemQuantity[];
   readonly previewVendorHash?: number;
   /** The state of this item in the user's D2 Collection */
@@ -91,7 +92,8 @@ function makeVendorItem(
     displayTile: inventoryItem.uiItemDisplayStyle === 'ui_display_style_set_container',
     owned: Boolean((saleItem?.augments || 0) & DestinyVendorItemState.Owned),
     canBeSold: !saleItem || saleItem.failureIndexes.length === 0,
-    displayCategoryIndex: vendorItemDef ? vendorItemDef.displayCategoryIndex : undefined,
+    displayCategoryIndex: vendorItemDef?.displayCategoryIndex,
+    originalCategoryIndex: vendorItemDef?.originalCategoryIndex,
     costs: saleItem?.costs || [],
     previewVendorHash: inventoryItem.preview?.previewVendorHash,
     collectibleState: getCollectibleState(


### PR DESCRIPTION
I think I cracked how the in-game vendors sort their items and verified this with all current vendors, where it matches the in-game order. This should once and for all obviate the need to manually work around weird orders.

Also implements the Locked augment for vendor items 'cause it seems to be needed now.

Beta:
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/d4b005cd-88f6-490d-969c-a94aa62ddfbf)

PR (NB I went to double check and picked up the engram, hence the missing checkmark on three engrams):
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/3b735646-809f-4ebc-8f99-dda09edc97d0)

(and many improvements to other vendors, bounties, ...
