### PR TITLE
Right-align vendor costs

### DIFF
--- a/src/app/vendors/Cost.m.scss
+++ b/src/app/vendors/Cost.m.scss
@@ -1,8 +1,8 @@
 .cost {
   composes: flexRow from '../dim-ui/common.m.scss';
   align-items: center;
+  justify-content: flex-end;
   font-size: 10px;
-  text-align: center;
   img {
     height: 12px;
     width: 12px;


### PR DESCRIPTION
Super minor but multiple-cost items read better this way:

Before:
<img width="64" alt="Screenshot 2023-08-29 at 10 57 01 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/e7620de8-e5c6-4042-8567-a8ad33ee5d92">

After:
<img width="65" alt="Screenshot 2023-08-29 at 10 56 41 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/8d365653-91b9-4429-a910-3a4d1e4b860b">

