### PR TITLE
Include adept variants in is:dupe and remove is:seasonaldupe

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -294,7 +294,6 @@
     "RequiredLevel": "Shows items based on their required level.",
     "SearchPrompt": "Search available filter commands",
     "Season": "Shows items from which season of Destiny 2 they appeared in.",
-    "SeasonalDupe": "Shows duplicate items, not counting reissues from a different season as the same item.",
     "StackLevel": "Shows items based on the quantity of items in its stack.",
     "Stackable": "Shows items that can stack (ammo synths, strange coin, etc)",
     "StackFull": "Show items which are at-capacity for their stack (Enhancement Cores, Strange Coins, Gunsmith Materials etc)",

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -98,7 +98,6 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "rocketlauncher",
   "scoutrifle",
   "seasonalartifacts",
-  "seasonaldupe",
   "shaded",
   "shaped",
   "shapeddupe",

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -25,6 +25,9 @@ export const makeDupeID = (item: DimItem) =>
   }${
     // Some items have the same name across different tiers, e.g. "Traveler's Chosen"
     item.tier
+  }${
+    // The engram that dispenses the Taraxippos scout rifle is also called Taraxippos
+    item.type
   }`;
 
 const sortDupes = (

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -1,7 +1,7 @@
+import { stripAdept } from 'app/compare/compare-buttons';
 import { tl } from 'app/i18next-t';
 import { TagValue } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
-import { getSeason } from 'app/inventory/store/season';
 import { isArtifice } from 'app/item-triage/triage-utils';
 import { StatsSet } from 'app/loadout-builder/process-worker/stats-set';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -16,15 +16,16 @@ const notableTags = ['favorite', 'keep'];
 /** outputs a string combination of the identifying features of an item, or the hash if classified */
 export const makeDupeID = (item: DimItem) =>
   (item.classified && `${item.hash}`) ||
-  `${item.name}${item.classType}${item.tier}${item.itemCategoryHashes.join('.')}`;
-
-// so, duplicate detection has gotten complicated in season 8. same items can have different hashes.
-// we use enough values to ensure this item is intended to be the same, as the index for looking up dupes
-const makeSeasonalDupeID = (item: DimItem) =>
-  (item.classified && `${item.hash}`) ||
-  `${item.name}${item.classType}${item.tier}item.collectibleHash}${item.powerCap}${getSeason(
-    item
-  )}${item.itemCategoryHashes.join('.')}`;
+  `${
+    // Consider adept versions of weapons to be the same as the normal type
+    item.bucket.inWeapons ? stripAdept(item.name) : item.name
+  }${
+    // Some items have the same name across different classes, e.g. "Kairos Function Boots"
+    item.classType
+  }${
+    // Some items have the same name across different tiers, e.g. "Traveler's Chosen"
+    item.tier
+  }`;
 
 const sortDupes = (
   dupes: {
@@ -35,14 +36,14 @@ const sortDupes = (
   // The comparator for sorting dupes - the first item will be the "best" and all others are "dupelower".
   const dupeComparator = reverseComparator(
     chainComparator<DimItem>(
-      // primary stat
-      compareBy((item) => item.power),
-      compareBy((item) => item.masterwork),
-      compareBy((item) => item.locked),
       compareBy((item) => {
         const tag = getTag(item);
         return Boolean(tag && notableTags.includes(tag));
       }),
+      compareBy((item) => item.masterwork),
+      compareBy((item) => item.locked),
+      // primary stat
+      compareBy((item) => item.power),
       compareBy((i) => i.id) // tiebreak by ID
     )
   );
@@ -79,12 +80,6 @@ const computeDupesByIdFn = (allItems: DimItem[], makeDupeIdFn: (item: DimItem) =
  */
 export const computeDupes = (allItems: DimItem[]) => computeDupesByIdFn(allItems, makeDupeID);
 
-/**
- * Find a map of duplicate items using the makeSeasonalDupeID function.
- */
-const computeSeasonalDupes = (allItems: DimItem[]) =>
-  computeDupesByIdFn(allItems, makeSeasonalDupeID);
-
 const dupeFilters: FilterDefinition[] = [
   {
     keywords: 'dupe',
@@ -93,18 +88,6 @@ const dupeFilters: FilterDefinition[] = [
       const duplicates = computeDupes(allItems);
       return (item) => {
         const dupeId = makeDupeID(item);
-        return checkIfIsDupe(duplicates, dupeId, item);
-      };
-    },
-  },
-  {
-    keywords: 'seasonaldupe',
-    description: tl('Filter.SeasonalDupe'),
-    destinyVersion: 2,
-    filter: ({ allItems }) => {
-      const duplicates = computeSeasonalDupes(allItems);
-      return (item) => {
-        const dupeId = makeSeasonalDupeID(item);
         return checkIfIsDupe(duplicates, dupeId, item);
       };
     },

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -292,7 +292,6 @@
     "RetiredPerk": "Shows weapons with perks that no longer obtainable.",
     "SearchPrompt": "Search available filter commands",
     "Season": "Shows items from which season of Destiny 2 they appeared in.",
-    "SeasonalDupe": "Shows duplicate items, not counting reissues from a different season as the same item.",
     "StackFull": "Show items which are at-capacity for their stack (Enhancement Cores, Strange Coins, Gunsmith Materials etc)",
     "StackLevel": "Shows items based on the quantity of items in its stack.",
     "Stackable": "Shows items that can stack (ammo synths, strange coin, etc)",


### PR DESCRIPTION
1. Include the adept variants in `is:dupe` - fixes #9713, assuming that this is what everyone wants. I don't have any adept weapons to try this on.
2. Remove the item category hashes from the dupe string since we now only include comparable items.
3. Document the reason for the elements in the dupe string.
4. Change the priority for "dupelower" (which probably should be removed?) to prioritize tagged items and masterworks over just power, which doesn't really matter anymore.
5. Remove `is:seasonaldupe` because reissues now show up in the same season and I'm not sure anyone could be usefully relying on these

Happy to break these up into separate changes.