### PR TITLE
Hot reload translations

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -17,6 +17,7 @@ import marked from 'marked';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import svgToMiniDataURI from 'mini-svg-data-uri';
 import path from 'path';
+import PostCSSAssetsPlugin from 'postcss-assets-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import 'webpack-dev-server';
 import WebpackNotifierPlugin from 'webpack-notifier';
@@ -24,7 +25,6 @@ import { InjectManifest } from 'workbox-webpack-plugin';
 import zlib from 'zlib';
 import csp from './content-security-policy';
 import { makeFeatureFlags } from './feature-flags';
-import PostCSSAssetsPlugin from 'postcss-assets-webpack-plugin';
 const renderer = new marked.Renderer();
 
 import { StatsWriterPlugin } from 'webpack-stats-plugin';
@@ -297,7 +297,7 @@ export default (env: Env) => {
         },
         {
           test: /\.json/,
-          include: /src(\/|\\)locale/,
+          include: /(src(\/|\\)locale)|(i18n\.json)/,
           type: 'asset/resource',
           generator: {
             filename: '[name]-[contenthash:8][ext]',

--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -86,9 +86,6 @@ module.exports = {
       }
     };
 
-    if (isTs) {
-      parser.parseTransFromString(content, { list: ['t', 'tl', 'DimError'] }, dimTransformer);
-    }
     parser.parseFuncFromString(content, { list: ['t', 'tl', 'DimError'] }, dimTransformer);
 
     done();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "i18n": "i18next-scanner",
     "watch": "yarn -s build:dev --watch",
     "start": "run-p watch:i18n devserver",
-    "devserver": "nodemon --watch config/webpack.ts --watch \"src/locale/*.json\" --watch yarn.lock --exec \"webpack serve --config ./config/webpack.ts --env=dev\"",
+    "devserver": "nodemon --watch config/webpack.ts --watch yarn.lock --exec \"webpack serve --config ./config/webpack.ts --env=dev\"",
     "watch:i18n": "nodemon --watch config/i18n.json --exec \"yarn i18n\"",
     "syntax": "find dist -name \"*.js\" | xargs -n 1 node --check",
     "install": "git submodule update --init --recursive",

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -38,7 +38,7 @@ export type DimLanguage = keyof typeof DIM_LANG_INFOS;
 const DIM_LANGS = Object.keys(DIM_LANG_INFOS) as DimLanguage[];
 
 // Hot-reload translations in dev. You'll still need to get things to re-render when
-// translations change (unless we someday switch to react-i1next)
+// translations change (unless we someday switch to react-i18next)
 if (module.hot) {
   module.hot.accept('../../config/i18n.json', () => {
     i18next.reloadResources('en', undefined, () => {


### PR DESCRIPTION
1. No longer restart the webpack server when translations change. Not sure why I had done that - you only ever needed to reload the page.
2. You no longer need to reload the page - translations are hot reloaded by the hot module reloader. You do need to force components to re-render though, since we're not using react-i18next which introduces a Context that updates on translation changes. Doesn't seem worth it.
3. Use the source translations file `i18n.json` in dev mode, so edits are available without having to run `yarn i18n`. It still does run in the background but just so you don't have to remember to do it before committing.