### PR TITLE
update IGL equippability measurement

### DIFF
--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -181,7 +181,6 @@ function Loadouts({ account }: { account: DestinyAccount }) {
             <AlertIcon /> {t('Storage.DimSyncNotEnabled')}
           </p>
         )}
-        <h2>{t('Loadouts.InGameLoadouts')}</h2>
         <InGameLoadoutStrip
           store={selectedStore}
           onEdit={setEditingInGameLoadout}

--- a/src/app/loadout/ingame/ingame-loadout-utils.ts
+++ b/src/app/loadout/ingame/ingame-loadout-utils.ts
@@ -5,7 +5,6 @@ import { allItemsSelector, createItemContextSelector } from 'app/inventory/selec
 import { DimStore } from 'app/inventory/store-types';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { applySocketOverrides } from 'app/inventory/store/override-sockets';
-import { spaceLeftForItem } from 'app/inventory/stores-helpers';
 import { convertInGameLoadoutPlugItemHashesToSocketOverrides } from 'app/loadout-drawer/loadout-type-converters';
 import {
   InGameLoadout,
@@ -138,11 +137,16 @@ export function implementsDimLoadout(
 
 /**
  * to be equipped via in-game loadouts, an item must be on the char already,
- * or in the vault, but with room in the character's pockets for a transfer
+ * or in the vault, but with room in the character's pockets for a transfer.
+ *
+ * AUG 29 2023:
+ * Bungie has reenabled in-game loadouts, but they cannot pull from the vault.
+ * we temporarily only consider an item IGL-equippable if it's on the char in question.
  */
-export function itemCouldBeEquipped(store: DimStore, item: DimItem, stores: DimStore[]) {
+export function itemCouldBeEquipped(store: DimStore, item: DimItem, _stores: DimStore[]) {
   return (
-    item.owner === store.id || (item.owner === 'vault' && spaceLeftForItem(store, item, stores) > 0)
+    item.owner === store.id
+    // || (item.owner === 'vault' && spaceLeftForItem(store, item, stores) > 0)
   );
 }
 

--- a/src/app/loadout/ingame/selectors.ts
+++ b/src/app/loadout/ingame/selectors.ts
@@ -138,8 +138,9 @@ export const inGameLoadoutsWithMetadataSelector = createSelector(
 
     return (
       inGameLoadouts
-        // seems unlikely the game would return valid, itemful loadouts for slot you havne't earned, but we respect this setting.
-        // inGameLoadoutsForCharacterSelector filters out empty loadouts, so we have to go by their self-stated index, not array length
+        // seems unlikely the game would return valid, itemful loadouts for slots you haven't earned,
+        // but we respect this setting by filtering out any loadout whose index defies how many you have supposedly unlocked.
+        // inGameLoadoutsForCharacterSelector filters out empty loadouts, so we have to go by their self-stated index, not by array length
         .filter((gameLoadout) => gameLoadout.index < availableLoadoutSlots)
         .map((gameLoadout) => {
           const isEquippable = gameLoadout.items.every((li) => {


### PR DESCRIPTION
fixes #9801 

bungie loadouts can't currently pull from vault
also delete a stray extra IGL header