### PR TITLE
CoreJS update

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -53,6 +53,7 @@ jobs:
               - package.json
               - yarn.lock
               - config/webpack.ts
+              - babel.config.js
 
       - name: Send webpack stats to RelativeCI
         if: ${{ steps.filter.outputs.build-pipeline == 'true' }}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const coreJSPackage = require('core-js/package.json');
+
 module.exports = function (api) {
   const isProduction = api.env('production');
   const isTest = api.env('test');
@@ -47,12 +49,14 @@ module.exports = function (api) {
     plugins.push(['@babel/plugin-transform-typescript', { isTSX: true, optimizeConstEnums: true }]);
   }
 
+  const corejs = { version: coreJSPackage.version, proposals: true };
+
   const presetEnvOptions = {
     bugfixes: true,
     modules: false,
     loose: true,
     useBuiltIns: 'usage',
-    corejs: 3,
+    corejs,
     shippedProposals: true,
   };
 
@@ -66,7 +70,13 @@ module.exports = function (api) {
       ['@babel/preset-env', presetEnvOptions],
       [
         '@babel/preset-react',
-        { useBuiltIns: true, loose: true, corejs: 3, runtime: 'automatic', useSpread: true },
+        {
+          useBuiltIns: true,
+          loose: true,
+          corejs,
+          runtime: 'automatic',
+          useSpread: true,
+        },
       ],
     ],
     plugins,

--- a/babel.config.js
+++ b/babel.config.js
@@ -49,7 +49,7 @@ module.exports = function (api) {
     plugins.push(['@babel/plugin-transform-typescript', { isTSX: true, optimizeConstEnums: true }]);
   }
 
-  const corejs = { version: coreJSPackage.version, proposals: true };
+  const corejs = { version: coreJSPackage.version };
 
   const presetEnvOptions = {
     bugfixes: true,
@@ -58,6 +58,28 @@ module.exports = function (api) {
     useBuiltIns: 'usage',
     corejs,
     shippedProposals: true,
+    // Set to true and run `yarn build:beta` to see what plugins and polyfills are being used
+    debug: false,
+    // corejs includes a bunch of polyfills for behavior we don't use or bugs we don't care about
+    exclude: [
+      // Really edge-case bugfix for Array.prototype.push and friends
+      'es.array.push',
+      'es.array.unshift',
+      // Remove this if we start using proposed set methods like .intersection
+      /esnext\.set/,
+      // Not sure what exactly this is, but we have our own error-cause stuff
+      'es.error.cause',
+      // Only used when customizing JSON parsing w/ a "reviver"
+      'esnext.json.parse',
+      // Edge-case bugfixes for URLSearchParams.prototype.has, delete, and size
+      /web\.url-search-params/,
+      // Mis-detected array grouping proposal
+      'esnext.array.group',
+      // Unneeded mis-detected DOMException extension
+      'web.dom-exception.stack',
+      // Not needed in worker context
+      'web.self',
+    ],
   };
 
   if (isTest) {

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,8 @@ module.exports = {
     'Library\\.mjs$': 'identity-obj-proxy',
   },
   setupFiles: ['./src/testing/jest-setup.js'],
-  transformIgnorePatterns: ['node_modules/?!(bungie-api-ts)'],
+  // Babel transform is required to handle some es modules?
+  transformIgnorePatterns: ['node_modules/(?!bungie-api-ts|@popper|@react-hook)'],
   globals: {
     $BROWSERS: [],
     $DIM_FLAVOR: 'test',

--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -10,7 +10,6 @@ import store from 'app/store/store';
 import { lazyLoadStreamDeck, startStreamDeckConnection } from 'app/stream-deck/stream-deck';
 import { streamDeckEnabled } from 'app/stream-deck/util/local-storage';
 import { infoLog } from 'app/utils/log';
-import { scheduleMemoryMeasurement } from 'app/utils/measure-memory';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import idbReady from 'safari-14-idb-fix';
@@ -37,7 +36,6 @@ if ($DIM_FLAVOR !== 'dev') {
 }
 
 setupRateLimiter();
-scheduleMemoryMeasurement();
 
 const i18nPromise = initi18n();
 

--- a/src/app/utils/measure-memory.ts
+++ b/src/app/utils/measure-memory.ts
@@ -3,6 +3,7 @@
 import { humanBytes } from 'app/storage/human-bytes';
 import { infoLog } from './log';
 
+// TODO: Revisit this once we can actually achieve crossOriginIsolated mode: https://web.dev/cross-origin-isolation-guide/
 export function scheduleMemoryMeasurement() {
   // Check measurement API is available.
   if (!window.crossOriginIsolated) {


### PR DESCRIPTION
Turns out by specifying `corejs: 3` we were getting `3.0` which is quite old. Updating to the latest brings in a lot of new polyfills, some of which are fun (`toSpliced` and `toSorted` for example) but also a bunch of weird bugfix polyfills that don't feel necessary (e.g. replacing `JSON.parse` so it supports better error messages?)

I don't think I want to merge this, but I do want to see what it does to the bundle.