### PR TITLE
Remove autoStatMods list

### DIFF
--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -414,14 +414,6 @@ export function clearSubclass(
  */
 export function removeMod(mod: ResolvedLoadoutMod): LoadoutUpdateFunction {
   return produce((loadout) => {
-    if (loadout.autoStatMods) {
-      const index = loadout.autoStatMods.indexOf(mod.originalModHash);
-      if (index !== -1) {
-        loadout.autoStatMods.splice(index, 1);
-        return;
-      }
-    }
-
     if (loadout.parameters?.mods) {
       const index = loadout.parameters?.mods.indexOf(mod.originalModHash);
       if (index !== -1) {
@@ -636,7 +628,6 @@ function clearBuckets(
 export function clearMods(): LoadoutUpdateFunction {
   return produce((loadout) => {
     delete loadout.parameters?.mods;
-    delete loadout.autoStatMods;
   });
 }
 

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -629,8 +629,6 @@ export const potentialLoadoutItemsByCraftedDate = weakMemoize((allItems: DimItem
 );
 
 export function getInstancedLoadoutItem(allItems: DimItem[], loadoutItem: LoadoutItem) {
-  // TODO: so inefficient to look through all items over and over again - need an index by ID and hash
-  // yup
   const result = potentialLoadoutItemsByItemId(allItems)[loadoutItem.id];
   if (result) {
     return result;
@@ -790,13 +788,9 @@ export function isMissingItems(
 export function getModsFromLoadout(
   defs: D2ManifestDefinitions | undefined,
   loadout: Loadout,
-  unlockedPlugs: Set<number>,
-  includeAutoMods = true
+  unlockedPlugs: Set<number>
 ) {
-  const internalModHashes = [
-    ...(loadout.parameters?.mods ?? []),
-    ...((includeAutoMods && loadout.autoStatMods) || []),
-  ];
+  const internalModHashes = loadout.parameters?.mods ?? [];
 
   return resolveLoadoutModHashes(defs, internalModHashes, unlockedPlugs);
 }

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -77,7 +77,7 @@ export const LoadoutMods = memo(function LoadoutMods({
 
   // Explicitly show only actual saved mods in the mods picker, not auto mods,
   // otherwise we'd duplicate auto mods into loadout parameter mods when confirming
-  const [resolvedMods] = useLoadoutMods(loadout, storeId, false);
+  const [resolvedMods] = useLoadoutMods(loadout, storeId);
 
   // TODO: filter down by usable mods?
   // TODO: Hide the "Add Mod" button when no more mods can fit

--- a/src/app/loadout/mod-assignment-drawer/selectors.ts
+++ b/src/app/loadout/mod-assignment-drawer/selectors.ts
@@ -91,13 +91,13 @@ export function useEquippedLoadoutArmorAndSubclass(
  * Loadout mod resolution may choose different versions of mods depending on artifact unlocks
  * and may replace defs that no longer exist with a placeholder deprecated mod.
  */
-export function useLoadoutMods(loadout: Loadout, storeId: string, includeAutoMods?: boolean) {
+export function useLoadoutMods(loadout: Loadout, storeId: string) {
   const defs = useD2Definitions();
   const unlockedPlugs = useSelector(unlockedPlugSetItemsSelector(storeId));
 
   return useMemo(() => {
-    const allMods = getModsFromLoadout(defs, loadout, unlockedPlugs, includeAutoMods);
+    const allMods = getModsFromLoadout(defs, loadout, unlockedPlugs);
     const modDefinitions = allMods.map((mod) => mod.resolvedMod);
     return [allMods, modDefinitions] as const;
-  }, [defs, includeAutoMods, loadout, unlockedPlugs]);
+  }, [defs, loadout, unlockedPlugs]);
 }


### PR DESCRIPTION
This is the deprecated list of mods at the top level of loadouts - afaik we never populated them, so it's safe to not read them.