### PR TITLE
Fix some bucketIcons getting inverted outside of dim-buttons

### DIFF
--- a/src/app/dim-ui/svgs/BucketIcon.m.scss
+++ b/src/app/dim-ui/svgs/BucketIcon.m.scss
@@ -1,3 +1,6 @@
 .icon {
   filter: invert(1) !important;
+  &:global(.dontInvert) {
+    filter: none !important;
+  }
 }


### PR DESCRIPTION
One way to fix #9794 inventing new damage types in the Loadout Drawer/View.

Before
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/00e96577-0ec3-4c46-83f7-df1f04005ec9)

After
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/573bad1a-1175-4cb5-bf44-22c5291baf61)

