### PR TITLE
Filter unequipped items to class compatible

### DIFF
--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -852,11 +852,12 @@ function getSubclassFragmentCapacity(subclassItem: DimItem): number {
 export function getUnequippedItemsForLoadout(dimStore: DimStore, category?: string) {
   return dimStore.items.filter(
     (item) =>
+      !item.equipped &&
       !item.location.inPostmaster &&
       !singularBucketHashes.includes(item.bucket.hash) &&
       itemCanBeInLoadout(item) &&
-      (category ? item.bucket.sort === category : fromEquippedTypes.includes(item.bucket.hash)) &&
-      !item.equipped
+      isClassCompatible(item.classType, dimStore.classType) &&
+      (category ? item.bucket.sort === category : fromEquippedTypes.includes(item.bucket.hash))
   );
 }
 


### PR DESCRIPTION
If a character is holding items from another class, "fill in using non-equipped" would pop a bunch of warnings about adding incompatible items. Better to just filter them out.