### PR TITLE
Switch loadout popup to use popper for positioning

### DIFF
--- a/src/app/character-tile/StoreHeading.m.scss
+++ b/src/app/character-tile/StoreHeading.m.scss
@@ -26,10 +26,8 @@
   }
 
   // The phone layout version
-  :global(.detached) & {
+  @include phone-portrait {
     position: fixed;
-    top: calc(54px + var(--header-height));
-    z-index: 1000;
     width: 100vw;
     padding: 0;
     max-height: calc(

--- a/src/app/character-tile/StoreHeading.m.scss
+++ b/src/app/character-tile/StoreHeading.m.scss
@@ -14,7 +14,6 @@
   box-sizing: border-box;
   max-height: calc(var(--viewport-height) - var(--header-height) - #{62px + 16px});
   overflow: auto;
-  z-index: 2;
   color: rgba(245, 245, 245, 0.6);
   overscroll-behavior: contain;
   background-color: var(--theme-dropdown-menu-bg);

--- a/src/app/character-tile/StoreHeading.tsx
+++ b/src/app/character-tile/StoreHeading.tsx
@@ -1,24 +1,14 @@
 import { t } from 'app/i18next-t';
 import { isD1Store } from 'app/inventory/stores-helpers';
 import LoadoutPopup from 'app/loadout/loadout-menu/LoadoutPopup';
+import { Portal } from 'app/utils/temp-container';
 import React, { forwardRef, useCallback, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import ClickOutside from '../dim-ui/ClickOutside';
 import { DimStore } from '../inventory/store-types';
 import { AppIcon, kebabIcon } from '../shell/icons';
 import CharacterHeaderXPBar from './CharacterHeaderXP';
 import CharacterTileButton from './CharacterTileButton';
 import styles from './StoreHeading.m.scss';
-
-interface Props {
-  store: DimStore;
-  /** If this ref is provided, the loadout menu will be placed inside of it instead of in this tile. */
-  loadoutMenuRef?: React.RefObject<HTMLElement>;
-  /** For mobile, this is whichever store is visible at the time. */
-  selectedStore?: DimStore;
-  /** Fires if a store other than the selected store is tapped. */
-  onTapped?: (storeId: string) => void;
-}
 
 // Wrap the {CharacterTile} with a button for the loadout menu and the D1 XP progress bar
 const CharacterHeader = forwardRef(function CharacterHeader(
@@ -50,7 +40,17 @@ const CharacterHeader = forwardRef(function CharacterHeader(
  * This is the character dropdown used at the top of the inventory page.
  * It will render a {CharacterTile} in addition to a button for the loadout menu
  */
-export default function StoreHeading({ store, selectedStore, loadoutMenuRef, onTapped }: Props) {
+export default function StoreHeading({
+  store,
+  selectedStore,
+  onTapped,
+}: {
+  store: DimStore;
+  /** For mobile, this is whichever store is visible at the time. */
+  selectedStore?: DimStore;
+  /** Fires if a store other than the selected store is tapped. */
+  onTapped?: (storeId: string) => void;
+}) {
   const [loadoutMenuOpen, setLoadoutMenuOpen] = useState(false);
   const menuTrigger = useRef<HTMLDivElement>(null);
 
@@ -68,28 +68,33 @@ export default function StoreHeading({ store, selectedStore, loadoutMenuRef, onT
     }
   }, [loadoutMenuOpen]);
 
+  const menuRef = useRef<HTMLDivElement>(null);
   let loadoutMenu: React.ReactNode | undefined;
   if (loadoutMenuOpen) {
     const menuContents = (
       <ClickOutside
         onClickOutside={clickOutsideLoadoutMenu}
+        ref={menuRef}
         extraRef={menuTrigger}
         className={styles.loadoutMenu}
       >
-        <LoadoutPopup dimStore={store} onClick={clickOutsideLoadoutMenu} />
+        <LoadoutPopup
+          dimStore={store}
+          onClick={clickOutsideLoadoutMenu}
+          menuRef={menuRef}
+          positionRef={menuTrigger}
+        />
       </ClickOutside>
     );
 
-    loadoutMenu = loadoutMenuRef
-      ? createPortal(menuContents, loadoutMenuRef.current!)
-      : menuContents;
+    loadoutMenu = <Portal>{menuContents}</Portal>;
   }
 
   // TODO: aria "open"
   return (
     <>
       <CharacterHeader store={store} ref={menuTrigger} onClick={openLoadoutPopup} />
-      <div>{loadoutMenu}</div>
+      {loadoutMenu}
     </>
   );
 }

--- a/src/app/dim-ui/usePopper.ts
+++ b/src/app/dim-ui/usePopper.ts
@@ -39,14 +39,15 @@ const popperOptions = (
   menuClassName?: string,
   boundarySelector?: string,
   offset = arrowClassName ? popperArrowSize : 0,
-  fixed = false
+  fixed = false,
+  padding?: Padding
 ): Partial<Options> => {
   const headerHeight = parseInt(
     document.querySelector('html')!.style.getPropertyValue('--header-height')!,
     10
   );
   const boundaryElement = boundarySelector && document.querySelector(boundarySelector);
-  const padding: Padding = {
+  padding ??= {
     left: 10,
     top: headerHeight + (boundaryElement ? boundaryElement.clientHeight : 0) + 5,
     right: 10,
@@ -105,6 +106,7 @@ export function usePopper({
   placement,
   offset,
   fixed,
+  padding,
 }: {
   /** A ref to the rendered contents of a popper-positioned item */
   contents: React.RefObject<HTMLElement>;
@@ -122,6 +124,7 @@ export function usePopper({
   offset?: number;
   /** Is this placed on a fixed item? Workaround for https://github.com/popperjs/popper-core/issues/1156. TODO: make a "positioning context" context value for this */
   fixed?: boolean;
+  padding?: Padding;
 }) {
   const popper = useRef<Instance | undefined>();
 
@@ -149,7 +152,8 @@ export function usePopper({
         menuClassName,
         boundarySelector,
         offset,
-        fixed
+        fixed,
+        padding
       );
       popper.current = createPopper(reference.current, contents.current, options);
       popper.current.update();

--- a/src/app/inventory-page/PhoneStores.tsx
+++ b/src/app/inventory-page/PhoneStores.tsx
@@ -6,7 +6,7 @@ import StoreStats from 'app/store-stats/StoreStats';
 import { useEventBusListener } from 'app/utils/hooks';
 import { wrap } from 'app/utils/util';
 import { PanInfo, motion } from 'framer-motion';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { InventoryBucket, InventoryBuckets } from '../inventory/inventory-buckets';
 import { getCurrentStore, getStore, getVault } from '../inventory/stores-helpers';
 import CategoryStrip from './CategoryStrip';
@@ -35,7 +35,6 @@ export default function PhoneStores({ stores, buckets, singleCharacter }: Props)
     direction: 0,
   });
   const [selectedCategoryId, setSelectedCategoryId] = useState<string>('Weapons');
-  const detachedLoadoutMenu = useRef<HTMLDivElement>(null);
 
   // Handle scrolling the right store into view when locating an item
   useEventBusListener(
@@ -117,14 +116,11 @@ export default function PhoneStores({ stores, buckets, singleCharacter }: Props)
           selectedStore={selectedStore}
           direction={direction}
           stores={headerStores}
-          loadoutMenuRef={detachedLoadoutMenu}
           setSelectedStoreId={(selectedStoreId, direction) =>
             setSelectedStoreId({ selectedStoreId, direction })
           }
         />
       </HeaderShadowDiv>
-
-      <div className="detached" ref={detachedLoadoutMenu} />
 
       <motion.div className="horizontal-swipable" onPanEnd={handleSwipe}>
         <StoresInventory

--- a/src/app/inventory-page/PhoneStoresHeader.tsx
+++ b/src/app/inventory-page/PhoneStoresHeader.tsx
@@ -2,7 +2,7 @@ import { DimStore } from 'app/inventory/store-types';
 import { hideItemPopup } from 'app/item-popup/item-popup';
 import { wrap } from 'app/utils/util';
 import { animate, motion, PanInfo, Spring, useMotionValue, useTransform } from 'framer-motion';
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import StoreHeading from '../character-tile/StoreHeading';
 import styles from './PhoneStoresHeader.m.scss';
 
@@ -23,13 +23,11 @@ export default function PhoneStoresHeader({
   stores,
   setSelectedStoreId,
   direction,
-  loadoutMenuRef,
 }: {
   selectedStore: DimStore;
   stores: DimStore[];
   // The direction we changed stores in - positive for an increasing index, negative for decreasing
   direction: number;
-  loadoutMenuRef: React.RefObject<HTMLElement>;
   setSelectedStoreId: (id: string, direction: number) => void;
 }) {
   const onIndexChanged = (index: number, dir: number) => {
@@ -139,7 +137,6 @@ export default function PhoneStoresHeader({
               store={store}
               selectedStore={selectedStore}
               onTapped={(id) => setSelectedStoreId(id, index - 2)}
-              loadoutMenuRef={loadoutMenuRef}
             />
           </div>
         ))}

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -2,6 +2,7 @@ import { languageSelector, settingSelector } from 'app/dim-api/selectors';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import ClassIcon from 'app/dim-ui/ClassIcon';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
+import { usePopper } from 'app/dim-ui/usePopper';
 import { startFarming } from 'app/farming/actions';
 import { t } from 'app/i18next-t';
 import {
@@ -69,9 +70,13 @@ import MaxlightButton from './MaxlightButton';
 export default function LoadoutPopup({
   dimStore,
   onClick,
+  menuRef,
+  positionRef,
 }: {
   dimStore: DimStore;
-  onClick?: (e: React.MouseEvent) => void;
+  menuRef: React.RefObject<HTMLElement>;
+  positionRef: React.RefObject<HTMLElement>;
+  onClick?: () => void;
 }) {
   // For the most part we don't need to memoize this - this menu is destroyed when closed
   const defs = useDefinitions()!;
@@ -149,6 +154,14 @@ export default function LoadoutPopup({
   const nativeAutoFocus = !isPhonePortrait && !isiOSBrowser();
 
   const filteringLoadouts = loadoutQuery.length > 0 || hasSelectedFilters;
+
+  usePopper({
+    contents: menuRef,
+    reference: positionRef,
+    placement: 'bottom-start',
+    fixed: true,
+    padding: 0,
+  });
 
   return (
     <div className={styles.content} onClick={onClick} role="menu">


### PR DESCRIPTION
The visible change here should be that #9818 is fixed - loadout menus stack in the order they're shown.