### PR TITLE
Use Intl.Collator for searching/sorting loadouts

### DIFF
--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -35,7 +35,7 @@ export const DIM_LANG_INFOS = {
 
 export type DimLanguage = keyof typeof DIM_LANG_INFOS;
 
-const DIM_LANGS = Object.keys(DIM_LANG_INFOS) as DimLanguage[];
+export const DIM_LANGS = Object.keys(DIM_LANG_INFOS) as DimLanguage[];
 
 // Hot-reload translations in dev. You'll still need to get things to re-render when
 // translations change (unless we someday switch to react-i18next)

--- a/src/app/loadout-drawer/loadouts-selector.ts
+++ b/src/app/loadout-drawer/loadouts-selector.ts
@@ -1,6 +1,9 @@
 import { currentProfileSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
+import { isClassCompatible } from 'app/utils/item-utils';
+import { currySelector } from 'app/utils/selector-utils';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { createSelector } from 'reselect';
 import { convertDimApiLoadoutToLoadout } from './loadout-type-converters';
 import { Loadout } from './loadout-types';
@@ -14,4 +17,14 @@ export const loadoutsSelector = createSelector(
     loadouts
       ? Object.values(loadouts).map((loadout) => convertDimApiLoadoutToLoadout(loadout))
       : emptyArray<Loadout>()
+);
+
+/** All loadouts for a particular class type */
+export const loadoutsForClassTypeSelector = currySelector(
+  createSelector(
+    loadoutsSelector,
+    (_state: RootState, classType: DestinyClass) => classType,
+    (loadouts, classType) =>
+      loadouts.filter((loadout) => isClassCompatible(classType, loadout.classType))
+  )
 );

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -15,6 +15,7 @@ import { getCurrentStore, getStore } from 'app/inventory/stores-helpers';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { InGameLoadout, Loadout } from 'app/loadout-drawer/loadout-types';
 import { newLoadout, newLoadoutFromEquipped } from 'app/loadout-drawer/loadout-utils';
+import { loadoutsForClassTypeSelector } from 'app/loadout-drawer/loadouts-selector';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useSetting } from 'app/settings/hooks';
 import { AppIcon, addIcon, faCalculator, uploadIcon } from 'app/shell/icons';
@@ -31,11 +32,7 @@ import { InGameLoadoutDetails } from './ingame/InGameLoadoutDetailsSheet';
 import { InGameLoadoutStrip } from './ingame/InGameLoadoutStrip';
 import LoadoutImportSheet from './loadout-share/LoadoutImportSheet';
 import LoadoutShareSheet from './loadout-share/LoadoutShareSheet';
-import {
-  searchAndSortLoadoutsByQuery,
-  useLoadoutFilterPills,
-  useSavedLoadoutsForClassType,
-} from './loadout-ui/menu-hooks';
+import { searchAndSortLoadoutsByQuery, useLoadoutFilterPills } from './loadout-ui/menu-hooks';
 
 const sortOptions = [
   {
@@ -84,7 +81,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
   const language = useSelector(languageSelector);
   const apiPermissionGranted = useSelector(apiPermissionGrantedSelector);
 
-  const savedLoadouts = useSavedLoadoutsForClassType(classType);
+  const savedLoadouts = useSelector(loadoutsForClassTypeSelector(classType));
   const savedLoadoutIds = new Set(savedLoadouts.map((l) => l.id));
 
   const artifactUnlocks = useSelector(artifactUnlocksSelector(selectedStoreId));
@@ -113,8 +110,10 @@ function Loadouts({ account }: { account: DestinyAccount }) {
     }
   );
 
+  const filteringLoadouts = Boolean(query || hasSelectedFilters);
+
   const loadouts = searchAndSortLoadoutsByQuery(filteredLoadouts, query, language, loadoutSort);
-  if (!query && !hasSelectedFilters) {
+  if (!filteringLoadouts) {
     loadouts.unshift(currentLoadout);
   }
 
@@ -187,12 +186,14 @@ function Loadouts({ account }: { account: DestinyAccount }) {
             <AlertIcon /> {t('Storage.DimSyncNotEnabled')}
           </p>
         )}
-        <InGameLoadoutStrip
-          store={selectedStore}
-          onEdit={setEditingInGameLoadout}
-          onShare={setSharedLoadout}
-          onShowDetails={setViewingInGameLoadout}
-        />
+        {!filteringLoadouts && (
+          <InGameLoadoutStrip
+            store={selectedStore}
+            onEdit={setEditingInGameLoadout}
+            onShare={setSharedLoadout}
+            onShowDetails={setViewingInGameLoadout}
+          />
+        )}
         <h2>{t('Loadouts.DimLoadouts')}</h2>
         {filterPills}
         <WindowVirtualList

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -22,6 +22,7 @@ import {
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { InGameLoadout, Loadout } from 'app/loadout-drawer/loadout-types';
 import { isMissingItems, newLoadout } from 'app/loadout-drawer/loadout-utils';
+import { loadoutsForClassTypeSelector } from 'app/loadout-drawer/loadouts-selector';
 import { makeRoomForPostmaster, totalPostmasterItems } from 'app/loadout-drawer/postmaster';
 import { previousLoadoutSelector } from 'app/loadout-drawer/selectors';
 import { manifestSelector, useDefinitions } from 'app/manifest/selectors';
@@ -57,11 +58,7 @@ import { Link } from 'react-router-dom';
 import { InGameLoadoutIconWithIndex } from '../ingame/InGameLoadoutIcon';
 import { applyInGameLoadout } from '../ingame/ingame-loadout-apply';
 import { inGameLoadoutsForCharacterSelector } from '../ingame/selectors';
-import {
-  searchAndSortLoadoutsByQuery,
-  useLoadoutFilterPills,
-  useSavedLoadoutsForClassType,
-} from '../loadout-ui/menu-hooks';
+import { searchAndSortLoadoutsByQuery, useLoadoutFilterPills } from '../loadout-ui/menu-hooks';
 import styles from './LoadoutPopup.m.scss';
 import { RandomLoadoutOptions, useRandomizeLoadout } from './LoadoutPopupRandomize';
 import MaxlightButton from './MaxlightButton';
@@ -89,7 +86,7 @@ export default function LoadoutPopup({
     (state: RootState) => powerLevelSelector(state, dimStore.id)?.problems.hasClassified
   );
 
-  const loadouts = useSavedLoadoutsForClassType(dimStore.classType);
+  const loadouts = useSelector(loadoutsForClassTypeSelector(dimStore.classType));
   const inGameLoadouts = useSelector((state: RootState) =>
     dimStore.isVault
       ? emptyArray<InGameLoadout>()

--- a/src/app/utils/intl.test.ts
+++ b/src/app/utils/intl.test.ts
@@ -1,0 +1,96 @@
+import { DIM_LANGS, DimLanguage } from 'app/i18n';
+import { localizedIncludes, localizedSorter } from './intl';
+
+const sortCases: [language: DimLanguage, input: string[], output: string[]][] = [
+  [
+    'en',
+    [
+      'foo1',
+      'foo10',
+      'foo9',
+      '🥺',
+      '🤯',
+      '\uD83D\uDE00', // 😀
+    ],
+    ['🤯', '🥺', '😀', 'foo1', 'foo9', 'foo10'],
+  ],
+  ['de', ['foo', 'föo', 'ess', 'eß'], ['ess', 'eß', 'foo', 'föo']],
+  ['ko', ['하', '가'], ['가', '하']],
+  ['ja', ['あかさ', '赤け', 'アカコ'], ['アカコ', 'あかさ', '赤け']],
+  [
+    'es',
+    [
+      'ñ',
+      '\u00F1', // ñ
+      '\u006E\u0303', // ñ
+    ],
+    ['ñ', 'ñ', 'ñ'],
+  ],
+  // For the rest, mostly just test that it constructs correctly. We can add special test cases if we find things we want.
+  ['es-mx', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+  ['fr', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+  ['it', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+  ['pl', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+  ['pt-br', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+  ['ru', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+  ['zh-chs', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+  ['zh-cht', ['foo1', 'foo10', 'foo9'], ['foo1', 'foo9', 'foo10']],
+];
+
+it('should include a sorting test case for every supported DIM language', () => {
+  expect(new Set(sortCases.map(([language]) => language))).toStrictEqual(new Set(DIM_LANGS));
+});
+
+// Test that we can construct this for every supported language
+test.each(sortCases)('localizedSorter: %s', (language, input, output) => {
+  expect(
+    // Map them into objects
+    input
+      .map((name) => ({
+        name,
+      }))
+      .sort(
+        localizedSorter(
+          language,
+          // un-map the objects into their sort key
+          (o) => o.name
+        )
+      )
+      // Map back to strings to make the matcher easier
+      .map((o) => o.name)
+  ).toStrictEqual(output);
+});
+
+const includeCases: [language: DimLanguage, input: string, query: string, matches: boolean][] = [
+  ['en', 'bar', 'foobar', true],
+  ['en', '😀', 'Laughing \uD83D\uDE00!!', true],
+  ['en', '\uDE00', 'Laughing \uD83D\uDE00!!', true],
+  // A bit weird - some unicode is composed of multiple other characters. In this case it sorta makes sense...
+  ['en', '👨‍👩‍👧', '👨‍👩‍👧‍👦', true],
+  ['en', 'föo', 'foobar', true],
+  ['en', 'Föo', 'foobar', true],
+  ['de', 'föo', 'foobar', false],
+  ['ko', '가', '하가', true],
+  ['ja', 'かさ', 'あかさ赤け', true],
+  ['es', 'ño', 'niño', true],
+  ['es-mx', 'ño', 'niño', true],
+  // For the rest, mostly just test that it constructs correctly. We can add special test cases if we find things we want.
+  ['fr', 'bar', 'foobar', true],
+  ['it', 'bar', 'foobar', true],
+  ['pl', 'bar', 'foobar', true],
+  ['pt-br', 'bar', 'foobar', true],
+  ['ru', 'bar', 'foobar', true],
+  ['zh-chs', 'bar', 'foobar', true],
+  ['zh-cht', 'bar', 'foobar', true],
+];
+
+it('should include an include test case for every supported DIM language', () => {
+  expect(new Set(includeCases.map(([language]) => language))).toStrictEqual(new Set(DIM_LANGS));
+});
+
+test.each(includeCases)(
+  'localizedIncludes("%s", "%s")("%s") === %s',
+  (language, query, input, matches) => {
+    expect(localizedIncludes(language, query)(input)).toBe(matches);
+  }
+);

--- a/src/app/utils/intl.ts
+++ b/src/app/utils/intl.ts
@@ -1,0 +1,83 @@
+// Helpers for effectively using the browser's Intl.* tools
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
+
+import { DimLanguage } from 'app/i18n';
+import { stubTrue } from 'lodash';
+import memoizeOne from 'memoize-one';
+import { LookupTable } from './util-types';
+
+// Our locale names don't line up with the BCP 47 tags for Chinese
+const localeMap: LookupTable<DimLanguage, string> = {
+  'zh-chs': 'zh-Hans',
+  'zh-cht': 'zh-Hant',
+};
+
+/** Map DIM's locale values to a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646) */
+export function mapLocale(language: DimLanguage): Intl.BCP47LanguageTag {
+  return localeMap[language] ?? language;
+}
+
+const cachedSortCollator = memoizeOne(
+  (language: DimLanguage) =>
+    new Intl.Collator(mapLocale(language), {
+      // Consider "9" to come before "10"
+      numeric: true,
+      usage: 'sort',
+      sensitivity: 'accent',
+    })
+);
+
+const cachedSearchCollator = memoizeOne(
+  (language: DimLanguage) =>
+    new Intl.Collator(mapLocale(language), { usage: 'search', sensitivity: 'base' })
+);
+
+/**
+ * Return a sorting function that can sort arrays of type `T[]` in a locale-aware
+ * way using some projection function on `T`.
+ *
+ * @example
+ * ["foo10", "foo9"].sort(localizedSorter("en")) // ["foo9", "foo10"]
+ */
+export function localizedSorter<T>(language: DimLanguage, iteratee: (input: T) => string) {
+  const sortCollator = cachedSortCollator(language);
+  return (a: T, b: T) => sortCollator.compare(iteratee(a), iteratee(b));
+}
+
+/**
+ * Return a version of `String.prototype.includes` that does locale-aware comparison. The query string is baked in.
+ *
+ * @example
+ * const includes = localizedIncludes('en', 'föo');
+ * ["foobar", "barföo"].every((s) => includes(s)) // true
+ */
+export function localizedIncludes(language: DimLanguage, query: string) {
+  if (query.length === 0) {
+    return stubTrue;
+  }
+  const filterCollator = cachedSearchCollator(language);
+
+  // Normalize the strings so we can compare the same abstract characters regardless of their original representation
+  const normalizedQuery = query.normalize('NFC');
+
+  // Unfortunately Collator does not have a substring search method so we have to walk the string sequentially
+  // See https://github.com/adobe/react-spectrum/blob/7f63e933e61f20891b4cf3f447ab817f918cb263/packages/%40react-aria/i18n/src/useFilter.ts#L58-L76
+  return (string: string) => {
+    if (normalizedQuery.length === 0) {
+      return true;
+    }
+
+    string = string.normalize('NFC');
+
+    let scan = 0;
+    const sliceLen = normalizedQuery.length;
+    for (; scan + sliceLen <= string.length; scan++) {
+      const slice = string.slice(scan, scan + sliceLen);
+      if (filterCollator.compare(normalizedQuery, slice) === 0) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+}


### PR DESCRIPTION
This gets us the behavior of loadouts "properly" ordering names with numbers in them. I also made the search use the collator, but that's less of a win - the object doesn't have a substring "includes" method so you have to roll your own. It's actually pretty fast, but I'm not sure I want to go through and replace all our other text searches with it. Part of that is I don't know how badly our current search is failing folks who use languages that actually have accents.

I also fixed the `loadoutsForClassTypeSelector` that @nev-r pointed out.