### PR TITLE
Group loadouts by season when sorting by edit time

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -761,6 +761,7 @@
       "Empty": "The loadout is empty.",
       "NoName": "The loadout needs a name."
     },
+    "Season": "Season {{season}}",
     "Snapshot": "Save As In-Game Loadout",
     "SortByName": "Sort by name",
     "SortByEditTime": "Sort by last edited",

--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -32,3 +32,12 @@
 .loadoutRow {
   padding-bottom: 10px;
 }
+
+.seasonHeader {
+  composes: flexRow from '../dim-ui/common.m.scss';
+  align-items: center;
+  gap: 0.25em;
+  margin: 16px 0 0 0;
+  border-bottom: 1px solid var(--theme-text);
+  font-size: 16px;
+}

--- a/src/app/loadout/Loadouts.m.scss.d.ts
+++ b/src/app/loadout/Loadouts.m.scss.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'menu': string;
   'menuButton': string;
   'menuButtons': string;
+  'seasonHeader': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -762,6 +762,7 @@
       "NoName": "The loadout needs a name."
     },
     "SaveLoadout": "Save Loadout",
+    "Season": "Season {{season}}",
     "Share": {
       "Copied": "Copied loadout link to clipboard",
       "CopyButton": "Copy Link",


### PR DESCRIPTION
This groups loadouts under headers labeled with the season they were last edited, only when the sort order is "by last edited". It was a bit tricky because we still need to emit a flat list of elements for the virtual scroller.

<img width="550" alt="Screenshot 2023-09-01 at 6 15 01 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/36ba615f-1bc6-4fc4-a2a8-c3fd14396b2e">
