### PR TITLE
Indicate max number of sockets per plug set in plug drawer

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -543,6 +543,8 @@
     "Scaled": "Scaled",
     "SearchAMod": "Search for mod name or description",
     "SearchAnExotic": "Search for exotic name or description",
+    "SelectModsCount": "{{selected}}/{{maxSelectable}}",
+    "SelectModsCountActivityMods": "{{selected}}/{{maxSelectable}} Activity Mods",
     "SelectExotic": "Select exotic",
     "SelectMods": "Select Mods",
     "SelectSubclassOptions": "Customize subclass",

--- a/src/app/loadout/SubclassPlugDrawer.tsx
+++ b/src/app/loadout/SubclassPlugDrawer.tsx
@@ -38,12 +38,12 @@ export default function SubclassPlugDrawer({
 }) {
   const defs = useD2Definitions()!;
 
-  const { plugSets, aspects, fragments, sortPlugGroups } = useMemo(() => {
+  const { plugSets, sortPlugGroups } = useMemo(() => {
     const initiallySelected = objectValues(socketOverrides)
       .map((hash) => defs.InventoryItem.get(hash))
       .filter(isPluggableItem);
 
-    const { plugSets, aspects, fragments } = getPlugsForSubclass(defs, subclass, initiallySelected);
+    const { plugSets } = getPlugsForSubclass(defs, subclass, initiallySelected);
 
     // A flat list of possible subclass plugs we use this to figure out how to sort plugs
     // and the different sections in the plug picker
@@ -55,8 +55,6 @@ export default function SubclassPlugDrawer({
     );
     return {
       plugSets,
-      aspects,
-      fragments,
       sortPlugGroups,
     };
   }, [defs, socketOverrides, subclass]);
@@ -90,36 +88,6 @@ export default function SubclassPlugDrawer({
     [onAccept, subclass.sockets]
   );
 
-  // Determines whether an ability, aspect or fragment is currently selectable
-  // - Any: only a single instace can be selected at a time
-  // - Ability: Only a single ability can be selected at a time.
-  // - Fragments: the energy level of the aspects determines the number that can be selected
-  // - Aspects: A maximum of 2 can be selected.
-  const isPlugSelectable = useCallback(
-    (plug: PluggableInventoryItemDefinition, selected: PluggableInventoryItemDefinition[]) => {
-      if (selected.some((s) => s.hash === plug.hash)) {
-        return false;
-      }
-
-      // Fragments handling
-      const selectedAspects = selected.filter((plugDef) => aspects.has(plugDef));
-      const selectedFragments = selected.filter((plugDef) => fragments.has(plugDef));
-      const allowedFragments = _.sumBy(
-        selectedAspects,
-        (aspect) =>
-          aspect.investmentStats.find(
-            (stat) => stat.statTypeHash === StatHashes.AspectEnergyCapacity
-          )?.value || 0
-      );
-      if (fragments.has(plug)) {
-        return selectedFragments.length < allowedFragments;
-      }
-
-      return true;
-    },
-    [aspects, fragments]
-  );
-
   return (
     <PlugDrawer
       title={t('Loadouts.SubclassOptions', { subclass: subclass.name })}
@@ -129,7 +97,6 @@ export default function SubclassPlugDrawer({
       classType={subclass.classType}
       onAccept={handleAccept}
       onClose={onClose}
-      isPlugSelectable={isPlugSelectable}
       sortPlugGroups={sortPlugGroups}
     />
   );
@@ -152,6 +119,14 @@ function getPlugsForSubclass(
     return { plugSets, aspects, fragments };
   }
 
+  const getFragmentCapacity = (allSelectedPlugs: PluggableInventoryItemDefinition[]) =>
+    _.sumBy(
+      allSelectedPlugs.filter((p) => aspects.has(p)),
+      (aspect) =>
+        aspect.investmentStats.find((stat) => stat.statTypeHash === StatHashes.AspectEnergyCapacity)
+          ?.value || 0
+    );
+
   for (const category of subclass.sockets.categories) {
     const sockets = getSocketsByCategoryHash(subclass.sockets, category.category.hash);
     // Group sockets by their plugSetHash so that we can figure out how many aspect or ability
@@ -169,6 +144,9 @@ function getPlugsForSubclass(
           category.category.hash
         );
 
+        const isAspect = aspectSocketCategoryHashes.includes(category.category.hash);
+        const isFragment = fragmentSocketCategoryHashes.includes(category.category.hash);
+
         const defaultPlugHash = isAbilityLikeSocket
           ? getDefaultAbilityChoiceHash(firstSocket)
           : firstSocket.emptyPlugItemHash;
@@ -178,7 +156,7 @@ function getPlugsForSubclass(
             plugs: [],
             selected: [],
             plugSetHash: firstSocket.plugSet.hash,
-            maxSelectable: socketGroup.length,
+            maxSelectable: isFragment ? getFragmentCapacity : socketGroup.length,
             defaultPlug,
             selectionType: isAbilityLikeSocket ? 'single' : 'multi',
           };
@@ -202,8 +180,6 @@ function getPlugsForSubclass(
           // is why we just take the raw data from the plugSet and there's no kind of unlock check here.
           // See https://github.com/Bungie-net/api/issues/1572
           for (const dimPlug of firstSocket.plugSet.plugs) {
-            const isAspect = aspectSocketCategoryHashes.includes(category.category.hash);
-            const isFragment = fragmentSocketCategoryHashes.includes(category.category.hash);
             const isEmptySocket =
               (isAspect || isFragment) && dimPlug.plugDef.hash === defaultPlugHash;
 
@@ -243,5 +219,5 @@ function getPlugsForSubclass(
     }
   }
 
-  return { plugSets, aspects, fragments };
+  return { plugSets };
 }

--- a/src/app/loadout/plug-drawer/types.ts
+++ b/src/app/loadout/plug-drawer/types.ts
@@ -1,3 +1,4 @@
+import { I18nKey } from 'app/i18next-t';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 
 /**
@@ -14,7 +15,11 @@ export interface PlugSet {
   /** A list of plugs that are currently selected. */
   selected: PluggableInventoryItemDefinition[];
   /** The maximum number of plugs a user can select from this plug set. */
-  maxSelectable: number;
+  maxSelectable: number | ((allSelectedPlugs: PluggableInventoryItemDefinition[]) => number);
+  /** The number of plugs selected from this plug set - used for plug sets that share mod slots, e.g. activity mods. Falls back to `selected.length` */
+  getNumSelected?: (allSelectedPlugs: PluggableInventoryItemDefinition[]) => number;
+  /** Overrides the `selected`/`maxSelectable` localization shown in the plugSet header */
+  overrideSelectedAndMax?: I18nKey;
   /**
    * The select behavior of the plug set.
    * multi: how armour mods are selected in game, you need to manually remove ones that have been added.

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -538,6 +538,8 @@
     "SearchAnExotic": "Search for exotic name or description",
     "SelectExotic": "Select exotic",
     "SelectMods": "Select Mods",
+    "SelectModsCount": "{{selected}}/{{maxSelectable}}",
+    "SelectModsCountActivityMods": "{{selected}}/{{maxSelectable}} Activity Mods",
     "SelectSubclassOptions": "Customize subclass",
     "ShowAllConfigs": "Show all configurations",
     "ShowConfigs": "Show configurations",


### PR DESCRIPTION
This moves some dynamic aspects of subclass plugs / activity mods to functions on the PlugSet so that the PlugDrawer can report numbers/limits, and also moves some more validation logic there.

![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/edc739f5-1d69-4413-ad8e-1ad0d26f4188)
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/56205742-7cc0-4bc5-933a-bcecf1d2ac74)
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/efb715e1-71c5-4895-8956-212b05176b9d)

Fixes #9827.