### PR TITLE
Fix loadout popup positioning

### DIFF
--- a/src/app/character-tile/StoreHeading.tsx
+++ b/src/app/character-tile/StoreHeading.tsx
@@ -1,3 +1,4 @@
+import { usePopper } from 'app/dim-ui/usePopper';
 import { t } from 'app/i18next-t';
 import { isD1Store } from 'app/inventory/stores-helpers';
 import LoadoutPopup from 'app/loadout/loadout-menu/LoadoutPopup';
@@ -78,17 +79,20 @@ export default function StoreHeading({
         extraRef={menuTrigger}
         className={styles.loadoutMenu}
       >
-        <LoadoutPopup
-          dimStore={store}
-          onClick={clickOutsideLoadoutMenu}
-          menuRef={menuRef}
-          positionRef={menuTrigger}
-        />
+        <LoadoutPopup dimStore={store} onClick={clickOutsideLoadoutMenu} />
       </ClickOutside>
     );
 
     loadoutMenu = <Portal>{menuContents}</Portal>;
   }
+
+  usePopper({
+    contents: menuRef,
+    reference: menuTrigger,
+    placement: 'bottom-start',
+    fixed: true,
+    padding: 0,
+  });
 
   // TODO: aria "open"
   return (

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -2,7 +2,6 @@ import { languageSelector, settingSelector } from 'app/dim-api/selectors';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import ClassIcon from 'app/dim-ui/ClassIcon';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
-import { usePopper } from 'app/dim-ui/usePopper';
 import { startFarming } from 'app/farming/actions';
 import { t } from 'app/i18next-t';
 import {
@@ -70,12 +69,8 @@ import MaxlightButton from './MaxlightButton';
 export default function LoadoutPopup({
   dimStore,
   onClick,
-  menuRef,
-  positionRef,
 }: {
   dimStore: DimStore;
-  menuRef: React.RefObject<HTMLElement>;
-  positionRef: React.RefObject<HTMLElement>;
   onClick?: () => void;
 }) {
   // For the most part we don't need to memoize this - this menu is destroyed when closed
@@ -154,14 +149,6 @@ export default function LoadoutPopup({
   const nativeAutoFocus = !isPhonePortrait && !isiOSBrowser();
 
   const filteringLoadouts = loadoutQuery.length > 0 || hasSelectedFilters;
-
-  usePopper({
-    contents: menuRef,
-    reference: positionRef,
-    placement: 'bottom-start',
-    fixed: true,
-    padding: 0,
-  });
 
   return (
     <div className={styles.content} onClick={onClick} role="menu">


### PR DESCRIPTION
Since #9822 the popup is misplaced on beta, but not in dev.

![screenshot](https://cdn.discordapp.com/attachments/493761113171689482/1147924574315479090/image.png)

Fairly sure the way this was set up makes popper position the popup before some ref is set, which React Strict Mode ends up masking because it renders, re-initializes refs, and calls some hook callbacks twice (so much for catching *more* problems at dev time instead of fewer...)

Was there any reason for calling popper down in `LoadoutPopup`?