### PR TITLE
Turn off React Strict Mode

### DIFF
--- a/src/Index.tsx
+++ b/src/Index.tsx
@@ -23,7 +23,6 @@ import registerServiceWorker from './app/register-service-worker';
 import { safariTouchFix } from './app/safari-touch-fix';
 import { watchLanguageChanges } from './app/settings/observers';
 import { saveWishListToIndexedDB } from './app/wishlists/observers';
-import { StrictMode } from 'react';
 infoLog(
   'app',
   `DIM v${$DIM_VERSION} (${$DIM_FLAVOR}) - Please report any errors to https://www.github.com/DestinyItemManager/DIM/issues`
@@ -80,9 +79,5 @@ const i18nPromise = initi18n();
   // Settings depends on i18n
   watchLanguageChanges();
 
-  root.render(
-    <StrictMode>
-      <Root />
-    </StrictMode>
-  );
+  root.render(<Root />);
 })();


### PR DESCRIPTION
* Enabled in #9587
* Caught a technical violation of function purity (fixed in #9603) that probably wasn't relevant in practice
* Ended up masking a bug with how we call popper (fixed in #9837) that ended up breaking beta but worked fine in dev.
* "Also really confuses me when I see double renders" - Ben

It's a nice idea but in practice it didn't help with catching any issues and instead introduces weird behavior when interfacing with Refs and/or the DOM, where it more or less ends up introducing a different render/effect schedule in dev that we develop for, but doesn't actually reflect what's going on in beta/app. I suspect Strict Mode is more geared towards rooting out the real egregious bugs like failure to clean up resources in `useEffect` or relying on side effects from reducers or state update functions, bugs that stem from greater misunderstandings about React.

There is of course a chance that our `usePopper` hook is also buggy under React's guarantees, but even then Strict Mode masking that bug is pretty bad.
