### PR TITLE
Sort triumphs by completion: Sort triumphs stably

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* The "Sort triumphs by completion" toggle on the Records page now maintains the order of triumphs with identical completion progress.
+
 ## 7.84.0 <span class="changelog-date">(2023-09-03)</span>
 
 * The order of vendor items should now much more accurately match the in-game order.

--- a/src/app/records/PresentationNodeLeaf.tsx
+++ b/src/app/records/PresentationNodeLeaf.tsx
@@ -84,7 +84,7 @@ function sortRecords(records: DimRecord[]): DimRecord[] {
       record.recordComponent.state & DestinyRecordState.CanEquipTitle ||
       !record.recordComponent.state
     ) {
-      return -1;
+      return 1;
     }
 
     // check which key is used to track progress
@@ -103,8 +103,8 @@ function sortRecords(records: DimRecord[]): DimRecord[] {
     for (const x of objectives) {
       totalProgress += Math.min(1, x.progress! / x.completionValue);
     }
-    return totalProgress / objectives.length;
-  }).reverse();
+    return -(totalProgress / objectives.length);
+  });
 }
 
 function sortCollectibles(collectibles: DimCollectible[]): DimCollectible[] {
@@ -120,8 +120,8 @@ function sortMetrics(metrics: DimMetric[]): DimMetric[] {
   return sortBy(metrics, (metric) => {
     const objectives = metric.metricComponent.objectiveProgress;
     if (objectives.complete) {
-      return -1;
+      return 1;
     }
-    return objectives.progress! / objectives.completionValue;
-  }).reverse();
+    return -(objectives.progress! / objectives.completionValue);
+  });
 }

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -108,9 +108,6 @@ export default function Records({ account }: Props) {
       })),
   ];
 
-  const onToggleCompletedRecordsHidden = (checked: boolean) => setCompletedRecordsHidden(checked);
-  const onToggleRedactedRecordsRevealed = (checked: boolean) => setRedactedRecordsRevealed(checked);
-  const onToggleSortRecordProgression = (checked: boolean) => setSortRecordProgression(checked);
   return (
     <PageWithMenu className="d2-vendors">
       <PageWithMenu.Menu>
@@ -127,21 +124,21 @@ export default function Records({ account }: Props) {
           <CheckButton
             name="hide-completed"
             checked={completedRecordsHidden}
-            onChange={onToggleCompletedRecordsHidden}
+            onChange={setCompletedRecordsHidden}
           >
             {t('Triumphs.HideCompleted')}
           </CheckButton>
           <CheckButton
             name="reveal-redacted"
             checked={redactedRecordsRevealed}
-            onChange={onToggleRedactedRecordsRevealed}
+            onChange={setRedactedRecordsRevealed}
           >
             {t('Triumphs.RevealRedacted')}
           </CheckButton>
           <CheckButton
             name="sort-progression"
             checked={sortRecordProgression}
-            onChange={onToggleSortRecordProgression}
+            onChange={setSortRecordProgression}
           >
             {t('Triumphs.SortRecords')}
           </CheckButton>


### PR DESCRIPTION
The toggle doesn't use a stable sorting, which ends up reversing the order of completed triumphs and the order of triumphs with 0 progress.

Before:
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/18d4fbd4-e874-4983-9806-d4c5ae74bef6)
After:
![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/6e9ce3f4-6f2a-40bf-b452-964df5d27aa1)
