### PR TITLE
Show deepsight harmonizable note in item popup

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -386,8 +386,6 @@ export function makeItem(
         // why the optional chain? well, somehow, an item can return tooltipNotificationIndexes,
         // but have no tooltipNotifications in its def
         .map((i) => itemDef.tooltipNotifications?.[i])
-        // a temporary filter because as of witch queen, all tooltips are set to "on"
-        .filter((t) => t && t.displayStyle !== 'ui_display_style_info')
     : emptyArray<DestinyItemTooltipNotification>();
 
   // null out falsy values like a blank string for a url


### PR DESCRIPTION
As suggested by @robojumper for #9810 

Removes the filter that was suppressing the hint text from appearing at bottom of the item popup indicating whether an item is `deepsight:harmonizable`

![image](https://github.com/DestinyItemManager/DIM/assets/1396158/984a8a99-91e9-498a-aab0-a8493e3f9a32)

Note: this also shows the popup text for enhanceable adept raid weapons 

![image](https://github.com/DestinyItemManager/DIM/assets/1396158/17dbb2f3-4aa9-4116-a697-fdc5dd5bf5d3)
