### PR TITLE
Fix loadout popups scrolling the window up

### DIFF
--- a/src/app/character-tile/StoreHeading.m.scss
+++ b/src/app/character-tile/StoreHeading.m.scss
@@ -9,7 +9,9 @@
 }
 
 .loadoutMenu {
-  position: absolute;
+  position: fixed;
+  inset: 0 auto auto 0;
+  margin: 0;
   width: 300px;
   box-sizing: border-box;
   max-height: calc(var(--viewport-height) - var(--header-height) - #{62px + 16px});
@@ -17,6 +19,7 @@
   color: rgba(245, 245, 245, 0.6);
   overscroll-behavior: contain;
   background-color: var(--theme-dropdown-menu-bg);
+  will-change: transform;
 
   @include visible-scrollbars;
 


### PR DESCRIPTION
Fixes #9838.

The issue here was that the popup has a field with autofocus, and initially it does not have fixed positioning. So the page scrolls up to show the focused input. Then, in a layout effect, popper applied `position: fixed`, which put it in the right position. By setting `position: fixed` initially, the autofocus no longer has to scroll the page.