### PR TITLE
Add Crota's End activity mods to Loadouts/LO/filters

### DIFF
--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -41,6 +41,7 @@ export const modTypeTagByPlugCategoryHash: LookupTable<PlugCategoryHashes, strin
   [PlugCategoryHashes.EnhancementsRaidV620]: 'kingsfall',
   [PlugCategoryHashes.EnhancementsArtifice]: 'artifice',
   [PlugCategoryHashes.EnhancementsRaidV700]: 'rootofnightmares',
+  [PlugCategoryHashes.EnhancementsRaidV720]: 'crotasend',
 };
 
 // FIXME(Lightfall) what about legacy?
@@ -112,6 +113,13 @@ const modSocketMetadata: ModSocketMetadata[] = [
     socketTypeHashes: [1956816524],
     compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsRaidV700],
     emptyModSocketHash: 4144354978,
+  },
+  {
+    slotTag: 'crotasend',
+    compatibleModTags: ['crotasend'],
+    socketTypeHashes: [2804745000],
+    compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsRaidV720],
+    emptyModSocketHash: 717667840,
   },
   {
     slotTag: 'nightmare',


### PR DESCRIPTION
This should:

* Highlight Crota armor with `modslot:crotasend`
* Add the Crota's End mods to the Loadout/LO mods picker should the character have Crota's End armor available and mods collected
* Make LO/Mod Assignment Drawer assign them correctly and Loadout application plug them successfully.

I insta-dismantled all of my Crota armor before I realized I need a piece to actually test this.