### PR TITLE
Update CI actions to fix deprecated ::set-output usage

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.1.0
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
 
       - name: set beta
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.1.0
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
 
       - name: set feature
         if: ${{ !github.event.inputs.patch }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Bump release version
         id: bump_version
-        uses: christian-draeger/increment-semantic-version@1.0.2
+        uses: christian-draeger/increment-semantic-version@1.0.3
         with:
           current-version: ${{ steps.package-version.outputs.current-version }}
           version-fragment: ${{ env.build_level }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: get-npm-version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.1.0
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
 
       - name: set beta
         run: |


### PR DESCRIPTION
GitHub is having a bit of a [surprised Pikachu face moment](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) where [workflows are throwing deprecation warnings](https://github.com/DestinyItemManager/DIM/actions/runs/6068180190) but the GitHub UI gives you no indication that your workflows are doing this unless you manually check a bunch of historical workflow runs, so of course users didn't even know they were relying on deprecated APIs and GitHub couldn't remove the deprecated functionality at the planned date.

Still, this should fix the deprecation warnings.