### PR TITLE
Remove old raster backgorund-image / overlay

### DIFF
--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -149,10 +149,6 @@ $rgb-masterworked: dim-hex-to-rgb-values($stat-masterworked);
 }
 .deepsightBorder {
   border: 2px solid $deepsight-border-color;
-
-  &.legendaryMasterwork {
-    background-image: url('../../images/masterwork.png');
-  }
 }
 
 .iconOverlay {


### PR DESCRIPTION
Fix for #9857 

Stripped out an old `background-image` overlay that was still hanging around 