### PR TITLE
is:indimloadout

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -242,6 +242,7 @@
     "Harrowed": "\\(Harrowed\\)",
     "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
+    "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "Infusable": "Shows items that can be infused.",
     "IsAdept": "Shows weapons compatible with Adept mods.",
     "IsCrafted": "Shows weapons that have been crafted.",

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -55,6 +55,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "helmet",
   "hunter",
   "incurrentchar",
+  "indimloadout",
   "infusable",
   "infuse",
   "infusionfodder",

--- a/src/app/search/search-filters/loadouts.tsx
+++ b/src/app/search/search-filters/loadouts.tsx
@@ -58,6 +58,15 @@ const loadoutFilters: FilterDefinition[] = [
       (item) =>
         Boolean(loadoutsByItem[item.id]?.some((l) => isInGameLoadout(l.loadout))),
   },
+  {
+    keywords: 'indimloadout',
+    format: 'simple',
+    description: tl('Filter.InDimLoadout'),
+    filter:
+      ({ loadoutsByItem }) =>
+      (item) =>
+        Boolean(loadoutsByItem[item.id]?.some((l) => !isInGameLoadout(l.loadout))),
+  },
 ];
 
 export default loadoutFilters;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -239,6 +239,7 @@
     "HasOrnament": "Shows items that have an ornament applied.",
     "HasShader": "Shows items that have a shader applied.",
     "HoldsMod": "Shows armor compatible with a specific type of Seasonal Mod.",
+    "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
     "Infusable": "Shows items that can be infused.",


### PR DESCRIPTION
Added `is:indimloadout` to mirror `is:iningameloadout`. This allows construction of filters such as `is:iningameloadout -is:indimloadout` that cannot be expressed with the current set of filters since `-is:iningameloadout` and `is:inloadout` include all items not in any load outs.

Not sure if I missed anything here - it seems straight forward, but I'm not particularly familiar with TypeScript.