### PR TITLE
Restore dupelower

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -302,7 +302,7 @@
     "CustomStatLower": "Shows armor whose stats are strictly lower than another of the same type of armor, only taking into account stats in that class' custom stat total list.",
     "Stats": "Shows items based on a specific stat value. $t(Filter.StatsExtras)",
     "StatsBase": "Filters armor based on its base stat value, not including attached mods or masterworking. $t(Filter.StatsExtras)",
-    "StatsExtras": "Supports stat addition by connecting multiple stat names with the + or & symbol.  There are also special keywords highest, secondhighest, thirdhighest, etc. which match stats based on their rank within an item's stats.",
+    "StatsExtras": "Supports stat addition by connecting multiple stat names with the + or & symbol.  There are also special keywords highest, secondhighest, thirdhighest, etc. which match stats based on their rank within an item's stats. Each custom stats also has its own search term, shown in the Custom Stats settings.",
     "StatsLoadout": "Finds a set of items to equip for the maximum total value of a specific stat.",
     "StatsMax": "Finds armor with the highest number for a specific stat. Includes all items with the highest stat.",
     "Tags": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Restored `is:dupelower` to prioritize power when choosing lower dupes.
+
 ## 7.85.0 <span class="changelog-date">(2023-09-10)</span>
 
 * Adding a subclass to a Loadout or selecting a subclass in Loadout Optimizer will now copy all currently equipped Aspects and Fragments too.

--- a/src/app/search/search-filters/dupes.tsx
+++ b/src/app/search/search-filters/dupes.tsx
@@ -39,14 +39,14 @@ const sortDupes = (
   // The comparator for sorting dupes - the first item will be the "best" and all others are "dupelower".
   const dupeComparator = reverseComparator(
     chainComparator<DimItem>(
+      // primary stat
+      compareBy((item) => item.power),
       compareBy((item) => {
         const tag = getTag(item);
         return Boolean(tag && notableTags.includes(tag));
       }),
       compareBy((item) => item.masterwork),
       compareBy((item) => item.locked),
-      // primary stat
-      compareBy((item) => item.power),
       compareBy((i) => i.id) // tiebreak by ID
     )
   );

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -299,7 +299,7 @@
     "StatLower": "Shows armor whose stats are strictly lower than another of the same type of armor.",
     "Stats": "Shows items based on a specific stat value. $t(Filter.StatsExtras)",
     "StatsBase": "Filters armor based on its base stat value, not including attached mods or masterworking. $t(Filter.StatsExtras)",
-    "StatsExtras": "Supports stat addition by connecting multiple stat names with the + or & symbol.  There are also special keywords highest, secondhighest, thirdhighest, etc. which match stats based on their rank within an item's stats.",
+    "StatsExtras": "Supports stat addition by connecting multiple stat names with the + or & symbol.  There are also special keywords highest, secondhighest, thirdhighest, etc. which match stats based on their rank within an item's stats. Each custom stats also has its own search term, shown in the Custom Stats settings.",
     "StatsLoadout": "Finds a set of items to equip for the maximum total value of a specific stat.",
     "StatsMax": "Finds armor with the highest number for a specific stat. Includes all items with the highest stat.",
     "Tags": {


### PR DESCRIPTION
I didn't realize that armor still has the "same item only costs glimmer" infusion rule, which makes dupe by item hash still somewhat useful for armor. Given that I don't really have another strong use for `is:dupelower` it seems reasonable to restore it to sorting based on power. I still left it breaking ties with tag before masterwork.

Fixes #9850 