### PR TITLE
Set a minimum height for vendor titles

### DIFF
--- a/src/app/vendors/single-vendor/SingleVendor.m.scss
+++ b/src/app/vendors/single-vendor/SingleVendor.m.scss
@@ -3,6 +3,7 @@
 
   h1 {
     margin: 0;
+    min-height: 1lh;
   }
 
   img,


### PR DESCRIPTION
Fixes Hawthorne's last wish subvendor which has no title. `lh` units are a recent invention but it's no big loss for users of older browsers.