### PR TITLE
Use CSS to handle scrolling to anchors

### DIFF
--- a/src/app/dim-ui/PageWithMenu.tsx
+++ b/src/app/dim-ui/PageWithMenu.tsx
@@ -2,7 +2,6 @@ import useResizeObserver from '@react-hook/resize-observer';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
 import styles from './PageWithMenu.m.scss';
-import { scrollToHref } from './scroll';
 
 function PageWithMenu({ children, className }: { children: React.ReactNode; className?: string }) {
   return <div className={clsx(className, styles.page)}>{children}</div>;
@@ -82,7 +81,7 @@ PageWithMenu.MenuButton = function MenuButton({
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   const classes = clsx(className, styles.menuButton);
   return anchor ? (
-    <a className={classes} href={`#${anchor}`} onClick={scrollToHref} {...otherProps}>
+    <a className={classes} href={`#${anchor}`} {...otherProps}>
       {children}
     </a>
   ) : (

--- a/src/app/dim-ui/scroll.ts
+++ b/src/app/dim-ui/scroll.ts
@@ -14,34 +14,6 @@ export function scrollToPosition(options: ScrollToOptions) {
 }
 
 /**
- * Scroll a particular element to the top of the view.
- */
-export function scrollToElement(elem: Element | null) {
-  if (elem) {
-    const headerHeight = parseInt(
-      document.querySelector('html')!.style.getPropertyValue('--header-height'),
-      10
-    );
-    const rect = elem.getBoundingClientRect();
-    scrollToPosition({
-      top: window.scrollY + rect.top - (headerHeight + 6),
-      left: 0,
-      behavior: 'smooth',
-    });
-  }
-}
-
-/**
- * An event handler for link (a) elements which scrolls the window until the element whose ID matches
- * the hash of the link is in view.
- */
-export function scrollToHref(e: React.MouseEvent) {
-  e.preventDefault();
-  const elem = document.getElementById((e.currentTarget as HTMLAnchorElement).hash.slice(1));
-  scrollToElement(elem);
-}
-
-/**
  * Scroll to an item tile and make it briefly zoom/wobble for attention
  */
 export const itemPop = (item: DimItem) => {
@@ -55,7 +27,7 @@ export const itemPop = (item: DimItem) => {
   const headerHeight = parseInt(html.style.getPropertyValue('--header-height'), 10);
   const storeHeaderHeight = parseInt(html.style.getPropertyValue('--store-header-height'), 10);
   const absoluteElementTop = elementRect.top + window.pageYOffset;
-  scrollToPosition({ left: 0, top: absoluteElementTop - (headerHeight + storeHeaderHeight + 24) });
+  scrollToPosition({ left: 0, top: absoluteElementTop - (headerHeight + storeHeaderHeight + 12) });
   element.classList.add(styles.itemPop);
 
   const removePop = () => {

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -166,6 +166,8 @@ html,
 body {
   // Disable pull to refresh in Android
   overscroll-behavior: none;
+  // Adjust so the anchor we scroll to doesn't end up behind the anchor
+  scroll-padding-top: var(--header-height);
 
   @include phone-portrait {
     user-select: none;

--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -166,7 +166,7 @@ html,
 body {
   // Disable pull to refresh in Android
   overscroll-behavior: none;
-  // Adjust so the anchor we scroll to doesn't end up behind the anchor
+  // Adjust so the anchor we scroll to doesn't end up behind the header
   scroll-padding-top: var(--header-height);
 
   @include phone-portrait {

--- a/src/app/shell/Destiny.m.scss
+++ b/src/app/shell/Destiny.m.scss
@@ -2,5 +2,4 @@
   user-select: none;
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
-  scroll-margin-top: var(--header-height);
 }


### PR DESCRIPTION
This uses normal anchor scrolling instead of our own function, but prevents headers from tucking under the header by using a CSS property. I'd clearly attempted to use this before but it wasn't quite right. A nice side effect is that navigating via anchors now updates history, so you can bounce back and forth between vendors.