### PR TITLE
more displayed loadout warnings

### DIFF
--- a/src/app/loadout-drawer/auto-loadouts.ts
+++ b/src/app/loadout-drawer/auto-loadouts.ts
@@ -328,10 +328,11 @@ export function randomSubclassConfiguration(
   randomizeSocketSeries(aspectSockets, aspectSockets.length);
 
   // Pick as many fragments as allowed
-  const fragmentCount = getLoadoutSubclassFragmentCapacity(defs, {
-    item: item,
+  const resolved = {
+    item,
     loadoutItem: { ...convertToLoadoutItem(item, false), socketOverrides },
-  });
+  };
+  const fragmentCount = getLoadoutSubclassFragmentCapacity(defs, resolved, true);
 
   const fragmentSockets = getSocketsByCategoryHashes(item.sockets, fragmentSocketCategoryHashes);
   randomizeSocketSeries(fragmentSockets, fragmentCount);

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -1033,10 +1033,8 @@ function applySocketOverrides(
           if (aspectSocketCategoryHashes.includes(category.category.hash)) {
             handleShuffledSockets(category.socketIndexes);
           } else if (fragmentSocketCategoryHashes.includes(category.category.hash)) {
-            const fragmentCapacity = getLoadoutSubclassFragmentCapacity(defs, {
-              item: dimItem,
-              loadoutItem,
-            });
+            const resolved = { item: dimItem, loadoutItem };
+            const fragmentCapacity = getLoadoutSubclassFragmentCapacity(defs, resolved, true);
             handleShuffledSockets(category.socketIndexes.slice(0, fragmentCapacity));
           } else {
             const sockets = getSocketsByIndexes(dimItem.sockets!, category.socketIndexes);

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -37,12 +37,13 @@ import {
   DestinyInventoryItemDefinition,
   DestinyLoadoutItemComponent,
 } from 'bungie-api-ts/destiny2';
+import deprecatedMods from 'data/d2/deprecated-mods.json';
 import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
 import { v4 as uuidv4 } from 'uuid';
 import { D2Categories } from '../destiny2/d2-bucket-categories';
-import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
+import { DimItem, DimSocket, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import { Loadout, LoadoutItem, ResolvedLoadoutItem, ResolvedLoadoutMod } from './loadout-types';
 
 // We don't want to prepopulate the loadout with D1 cosmetics
@@ -627,19 +628,32 @@ export const potentialUninstancedLoadoutItemsByHash = weakMemoize((allItems: Dim
 export function getUninstancedLoadoutItem(
   allItems: DimItem[],
   hash: number,
-  storeId: string | undefined
+  storeId: string | undefined,
+  /** try to find a copy of this item, even if its location isn't ideal */
+  anyOk?: boolean
 ) {
   // This is mostly for subclasses - it finds all matching items by hash and then picks the one that's on the desired character
   const candidates = potentialUninstancedLoadoutItemsByHash(allItems)[hash] ?? [];
-  const onCurrent =
+  // the copy of this item being held by the specified store
+  const heldItem =
     storeId !== undefined ? candidates.find((item) => item.owner === storeId) : undefined;
-  return onCurrent ?? (candidates[0]?.notransfer ? undefined : candidates[0]);
+  return (
+    // preferably one on the right character
+    heldItem ??
+    // use any copy if asked
+    (anyOk
+      ? candidates[0]
+      : // finally, return a misplaced candidate IF it can be transferred
+      candidates[0]?.notransfer
+      ? undefined
+      : candidates[0])
+  );
 }
 
 export const isMissingItemsSelector = createSelector(
   manifestSelector,
   allItemsSelector,
-  (defs, allItems) => (storeId: string, loadout: Loadout) =>
+  (defs, allItems) => (storeId: string | undefined, loadout: Loadout) =>
     isMissingItems(defs!, allItems, storeId, loadout)
 );
 
@@ -651,19 +665,25 @@ export const enum FragmentProblem {
 export const getFragmentProblemsSelector = createSelector(
   manifestSelector,
   allItemsSelector,
-  (defs, allItems) => (storeId: string, loadout: Loadout) =>
+  (defs, allItems) => (storeId: string | undefined, loadout: Loadout) =>
     defs?.isDestiny2() ? getFragmentProblems(defs, allItems, storeId, loadout.items) : undefined
 );
 
 function getFragmentProblems(
   defs: D2ManifestDefinitions,
   allItems: DimItem[],
-  storeId: string,
+  // this store-specific functionality is vestigial right now,
+  // storeId will always be undefined where this is used.
+  // this function is CURRENTLY only used to evaluate Loadouts
+  // at rest, not check for problems while applying.
+  // the plug assignment algorithm would deal with problems applying.
+  storeId: string | undefined,
   loadoutItems: LoadoutItem[]
 ) {
   const subclass = getSubclass(defs, allItems, storeId, loadoutItems);
   if (subclass) {
-    const fragmentCapacity = getLoadoutSubclassFragmentCapacity(defs, subclass);
+    // this will be 0 if no aspects were provided in the loadout subclass config
+    const fragmentCapacity = getLoadoutSubclassFragmentCapacity(defs, subclass, false);
     const fragmentSockets = getSocketsByCategoryHashes(
       subclass.item.sockets,
       fragmentSocketCategoryHashes
@@ -673,7 +693,7 @@ function getFragmentProblems(
     ).length;
     return fragmentCapacity > loadoutFragments
       ? FragmentProblem.EmptyFragmentSlots
-      : fragmentCapacity < loadoutFragments
+      : fragmentCapacity && fragmentCapacity < loadoutFragments
       ? FragmentProblem.TooManyFragments
       : undefined;
   }
@@ -681,16 +701,17 @@ function getFragmentProblems(
   return undefined;
 }
 
+/** find the subclass inside a Loadout, and retrieve the real DimItem it should refer to */
 function getSubclass(
   defs: D2ManifestDefinitions,
   allItems: DimItem[],
-  storeId: string,
+  storeId: string | undefined,
   loadoutItems: LoadoutItem[]
 ): ResolvedLoadoutItem | undefined {
   for (const loadoutItem of loadoutItems) {
     const info = getResolutionInfo(defs, loadoutItem.hash);
     if (info?.bucketHash === BucketHashes.Subclass) {
-      const item = getUninstancedLoadoutItem(allItems, info.hash, storeId);
+      const item = getUninstancedLoadoutItem(allItems, info.hash, storeId, !storeId); // with no store provided, loosely search for any copy
       if (item) {
         return { item, loadoutItem };
       }
@@ -699,14 +720,19 @@ function getSubclass(
   return undefined;
 }
 
+/**
+ * Given a loadout, see how many Fragments can be plugged
+ *
+ * If the loadout supplies Aspects, we use them to calculate Fragment capacity.
+ *
+ * When *applying* a Loadout subclass configuration with no Aspects, we make no Aspect changes.
+ * Thus, `fallbackToCurrent` controls whether to use the subclass's current Aspect config.
+ */
 export function getLoadoutSubclassFragmentCapacity(
   defs: D2ManifestDefinitions,
-  item: ResolvedLoadoutItem
+  item: ResolvedLoadoutItem,
+  fallbackToCurrent: boolean
 ): number {
-  // For fragments, we first need to figure out how many sockets we have available.
-  // If the loadout specifies overrides for aspects, we use all override aspects to calculate
-  // fragment capacity, otherwise we look at the item itself because we don't unplug any aspects
-  // if the overrides don't list any.
   if (item.item.sockets) {
     const aspectSocketIndices = item.item.sockets.categories.find((c) =>
       aspectSocketCategoryHashes.includes(c.category.hash)
@@ -718,9 +744,13 @@ export function getLoadoutSubclassFragmentCapacity(
         return aspectHash ? defs.InventoryItem.get(aspectHash) : undefined;
       });
     if (aspectDefs?.length) {
-      return _.sumBy(aspectDefs, (aspectDef) => aspectDef.plug?.energyCapacity?.capacityValue || 0);
-    } else {
+      // the loadout provided some aspects. use those.
+      return sumAspectCapacity(aspectDefs);
+    } else if (fallbackToCurrent) {
+      // the loadout provided no aspects. assume the currently applied aspects.
       return getSubclassFragmentCapacity(item.item);
+    } else {
+      return 0;
     }
   }
   return 0;
@@ -729,7 +759,7 @@ export function getLoadoutSubclassFragmentCapacity(
 export function isMissingItems(
   defs: D1ManifestDefinitions | D2ManifestDefinitions,
   allItems: DimItem[],
-  storeId: string,
+  storeId: string | undefined,
   loadout: Loadout
 ): boolean {
   for (const loadoutItem of loadout.items) {
@@ -751,6 +781,14 @@ export function isMissingItems(
     }
   }
   return false;
+}
+
+export function hasDeprecatedMods(loadout: Loadout, defs: D2ManifestDefinitions): boolean {
+  return Boolean(
+    loadout.parameters?.mods?.some(
+      (modHash) => deprecatedMods.includes(modHash) || !defs.InventoryItem.get(modHash)
+    )
+  );
 }
 
 /**
@@ -813,12 +851,23 @@ export function resolveLoadoutModHashes(
   return mods.sort((a, b) => sortMods(a.resolvedMod, b.resolvedMod));
 }
 
+/**
+ * given a real (or overridden) subclass item,
+ * determine how many Fragment slots are provided by its current Aspects
+ */
 function getSubclassFragmentCapacity(subclassItem: DimItem): number {
   const aspects = getSocketsByCategoryHashes(subclassItem.sockets, aspectSocketCategoryHashes);
-  return _.sumBy(
-    aspects,
-    (aspect) => aspect.plugged?.plugDef.plug.energyCapacity?.capacityValue || 0
-  );
+  return sumAspectCapacity(aspects.map((a) => a.plugged?.plugDef));
+}
+
+/** given some Aspects or Aspect sockets, see how many Fragment slots they'll provide */
+function sumAspectCapacity(
+  aspects: (DestinyInventoryItemDefinition | DimSocket | undefined)[] | undefined
+) {
+  return _.sumBy(aspects, (aspect) => {
+    const aspectDef = aspect && 'plugged' in aspect ? aspect.plugged?.plugDef : aspect;
+    return aspectDef?.plug?.energyCapacity?.capacityValue || 0;
+  });
 }
 
 /**

--- a/src/app/loadout-drawer/loadouts-selector.ts
+++ b/src/app/loadout-drawer/loadouts-selector.ts
@@ -1,4 +1,5 @@
 import { currentProfileSelector } from 'app/dim-api/selectors';
+import { d2ManifestSelector } from 'app/manifest/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { isClassCompatible } from 'app/utils/item-utils';
@@ -7,6 +8,12 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { createSelector } from 'reselect';
 import { convertDimApiLoadoutToLoadout } from './loadout-type-converters';
 import { Loadout } from './loadout-types';
+import {
+  FragmentProblem,
+  getFragmentProblemsSelector,
+  hasDeprecatedMods,
+  isMissingItemsSelector,
+} from './loadout-utils';
 
 // had to pull this out to another file because things got weird :(
 
@@ -17,6 +24,39 @@ export const loadoutsSelector = createSelector(
     loadouts
       ? Object.values(loadouts).map((loadout) => convertDimApiLoadoutToLoadout(loadout))
       : emptyArray<Loadout>()
+);
+
+interface LoadoutIssues {
+  hasMissingItems: boolean;
+  hasDeprecatedMods: boolean;
+  emptyFragmentSlots: boolean;
+  tooManyFragments: boolean;
+}
+
+/**
+ * notable loadout issues, keyed by loadout ID.
+ *
+ * this is for flagging loadouts,
+ * so it only checks fragment issues according to the Aspects specified by the loadout
+ */
+export const loadoutIssuesSelector = createSelector(
+  loadoutsSelector,
+  getFragmentProblemsSelector,
+  isMissingItemsSelector,
+  d2ManifestSelector,
+  (loadouts, fragmentProblemChecker, missingItemChecker, d2defs) => {
+    const issues: NodeJS.Dict<LoadoutIssues> = {};
+    for (const loadout of loadouts) {
+      const fragmentProblem = fragmentProblemChecker(undefined, loadout);
+      issues[loadout.id] = {
+        hasMissingItems: missingItemChecker(undefined, loadout),
+        hasDeprecatedMods: Boolean(d2defs && hasDeprecatedMods(loadout, d2defs)),
+        emptyFragmentSlots: fragmentProblem === FragmentProblem.EmptyFragmentSlots,
+        tooManyFragments: fragmentProblem === FragmentProblem.TooManyFragments,
+      };
+    }
+    return issues;
+  }
 );
 
 /** All loadouts for a particular class type */


### PR DESCRIPTION
a second stab at #9817. 21 more stabs and we have reenacted the death of caesar.
this makes loadout problems into a selector, so they're calculated once, and then used in both filter pills, and the loadout displays themselves. a lot cleaner!

what does this enable/result in?:
- currently only missing items trigger a ⚠️ on a loadouts page loadout. the rest must be identified via pill filters.
this PR puts ⚠️ and an explanation, on LoadoutView, if it has any of the identifiable issues.
a little more incentive than just the pill, to fix your existing loadouts.
- this fixes "deprecated mods" pill to correctly detect the missing-def mod hashes (we fake those into looking like deprecated mods)
- i felt strange about the _live state_ of your subclass, potentially suddenly ⚠️ing a bunch of your loadouts on the loadouts page
this could be removed from PR, but i prefer "too many fragments for current subclass state" to be an _apply-time only_ problem/warning.
i would prefer fragment flagging on loadout page, to be based only on the loadout's selected Aspects. thoughts?

a more sensitive ⚠️ _could_ be done to the emblem loadout dropdown as well, rn it only shows for missing items.
maybe we could visually flag ladouts in the side column list of the loadouts page.
design decisions for another day, but easily executed with the issues selector now available.