### PR TITLE
Early error reports

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -85,6 +85,7 @@ export default (env: Env) => {
     mode: env.dev ? ('development' as const) : ('production' as const),
 
     entry: {
+      earlyErrorReport: './src/earlyErrorReport.js',
       main: './src/Index.tsx',
       browsercheck: './src/browsercheck.js',
       authReturn: './src/authReturn.ts',
@@ -396,7 +397,8 @@ export default (env: Env) => {
       inject: true,
       filename: 'index.html',
       template: 'src/index.html',
-      chunks: ['main', 'browsercheck'],
+      chunksSortMode: (a, b) => (a === 'earlyErrorReport' ? -1 : b === 'earlyErrorReport' ? 1 : 0),
+      chunks: ['earlyErrorReport', 'main', 'browsercheck'],
       templateParameters: {
         version,
         date: new Date(buildTime).toString(),

--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -163,7 +163,7 @@ export default (env: Env) => {
       runtimeChunk: 'single',
       splitChunks: {
         chunks(chunk) {
-          return chunk.name !== 'browsercheck';
+          return chunk.name !== 'browsercheck' && chunk.name !== 'earlyErrorReport';
         },
         automaticNameDelimiter: '-',
       },
@@ -394,10 +394,9 @@ export default (env: Env) => {
     }),
 
     new HtmlWebpackPlugin({
-      inject: true,
+      inject: false,
       filename: 'index.html',
       template: 'src/index.html',
-      chunksSortMode: (a, b) => (a === 'earlyErrorReport' ? -1 : b === 'earlyErrorReport' ? 1 : 0),
       chunks: ['earlyErrorReport', 'main', 'browsercheck'],
       templateParameters: {
         version,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "cross-env NODE_ENV=test jest --verbose",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint src --ext .js,.ts,.tsx",
-    "lint:prettier": "prettier \"src/**/*.{js,ts,tsx,scss,html}\" --check",
+    "lint:prettier": "prettier \"src/**/*.{js,ts,tsx,scss}\" --check",
     "lint:stylelint": "stylelint \"src/**/*.scss\"",
     "lintcached": "run-p lintcached:*",
     "lintcached:eslint": "yarn lint:eslint --cache --cache-location .eslintcache --cache-strategy content",

--- a/src/earlyErrorReport.js
+++ b/src/earlyErrorReport.js
@@ -1,9 +1,12 @@
-window.onerror = (e) => {
+window.onerror = (message, source, line, col, error) => {
+  const params = { message, source, line, col };
   // eslint-disable-next-line no-console
-  console.log(e);
-  const errorBox = document.querySelector('#errorreport');
+  console.log(params, error);
+  const errorBox = document.querySelector("#errorreport");
   if (errorBox) {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    errorBox.value = e.toString();
+    errorBox.textContent = Object.entries(params)
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      .map(([k, v]) => `${k}:\n${v}`)
+      .join("\n");
   }
 };

--- a/src/earlyErrorReport.js
+++ b/src/earlyErrorReport.js
@@ -1,0 +1,9 @@
+window.onerror = (e) => {
+  // eslint-disable-next-line no-console
+  console.log('startup error', e);
+  const errorBox = document.querySelector('#error-report');
+  if (errorBox) {
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    errorBox.value = e.toString();
+  }
+};

--- a/src/earlyErrorReport.js
+++ b/src/earlyErrorReport.js
@@ -2,11 +2,11 @@ window.onerror = (message, source, line, col, error) => {
   const params = { message, source, line, col };
   // eslint-disable-next-line no-console
   console.log(params, error);
-  const errorBox = document.querySelector("#errorreport");
+  const errorBox = document.querySelector('#errorreport');
   if (errorBox) {
     errorBox.textContent = Object.entries(params)
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      .map(([k, v]) => `${k}:\n${v}`)
-      .join("\n");
+      .map(([k, v]) => `${k}:\n  ${v}`)
+      .join('\n');
   }
 };

--- a/src/earlyErrorReport.js
+++ b/src/earlyErrorReport.js
@@ -1,7 +1,7 @@
 window.onerror = (e) => {
   // eslint-disable-next-line no-console
-  console.log('startup error', e);
-  const errorBox = document.querySelector('#error-report');
+  console.log(e);
+  const errorBox = document.querySelector('#errorreport');
   if (errorBox) {
     // eslint-disable-next-line @typescript-eslint/no-base-to-string
     errorBox.value = e.toString();

--- a/src/index.html
+++ b/src/index.html
@@ -76,6 +76,9 @@
         }
       }
     </style>
+    <%= htmlWebpackPlugin.files.js
+    .sort((a,b)=>a.includes("earlyErrorReport")?-1:b.includes("earlyErrorReport")?1:0)
+    .map((p)=>`<script${p.includes("earlyErrorReport")?"":" defer"} src="${p}"></script>`).join("\n    ") %>
   </head>
   <body>
     <div id="app">

--- a/src/index.html
+++ b/src/index.html
@@ -90,7 +90,7 @@
           >
           to find a solution, and contact us if those steps don't work.
         </p>
-        <textarea id="errorreport"></textarea>
+        <pre id="errorreport"></pre>
       </div>
     </div>
     <div id="temp-container"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -87,6 +87,7 @@
           >
           to find a solution, and contact us if those steps don't work.
         </p>
+        <textarea id="errorreport"></textarea>
       </div>
     </div>
     <div id="temp-container"></div>


### PR DESCRIPTION
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/32979ad2-8f6f-410b-83a4-372f7b6502f9)

early attach a window error handler so the grey "didn't load" screen is a little more useful,
especially in browsers/devices without access to a console log

sentry seems to takes over window.onerror a little later in scripts loadedness

had to disable webpack automatic injection for index.html but duplicated its effect with a simple loop.

**prettier chokes on the EJS in the "javascript" of the index html file, so i had to ignore husky commit hooks. how do we best address this and the presumable below test failures?**