### PR TITLE
Ensure any-class Loadouts can only use any-class items

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed the "Any Class" Loadout toggle not removing class-specific items.
+
 ## 7.86.0 <span class="changelog-date">(2023-09-17)</span>
 
 * Restored `is:dupelower` to prioritize power when choosing lower dupes.

--- a/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
@@ -21,7 +21,7 @@ import { Loadout, ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useD1Definitions } from 'app/manifest/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useEventBusListener } from 'app/utils/hooks';
-import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isItemLoadoutCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import React, { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import TextareaAutosize from 'react-textarea-autosize';
@@ -189,7 +189,7 @@ function LoadoutDrawerBody({
       filterItems: (item: DimItem) =>
         item.hash === warnItem.hash &&
         itemCanBeInLoadout(item) &&
-        (!loadout || isClassCompatible(item.classType, loadout.classType)),
+        (!loadout || isItemLoadoutCompatible(item.classType, loadout.classType)),
       prompt: t('Loadouts.FindAnother', { name: warnItem.name }),
     });
 

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -15,7 +15,7 @@ import { findSameLoadoutItemIndex, fromEquippedTypes } from 'app/loadout-drawer/
 import { useD1Definitions } from 'app/manifest/selectors';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { AppIcon, addIcon } from 'app/shell/icons';
-import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isItemLoadoutCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { filterMap } from 'app/utils/util';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -148,7 +148,7 @@ async function pickLoadoutItem(
   const item = await showItemPicker({
     filterItems: (item: DimItem) =>
       item.bucket.hash === bucket.hash &&
-      isClassCompatible(item.classType, loadout.classType) &&
+      isItemLoadoutCompatible(item.classType, loadout.classType) &&
       itemCanBeInLoadout(item) &&
       !loadoutHasItem(item),
     prompt: t('Loadouts.ChooseItem', { name: bucket.name }),

--- a/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerDropTarget.tsx
@@ -1,6 +1,6 @@
 import { bucketsSelector, storesSelector } from 'app/inventory/selectors';
 import { emptyArray } from 'app/utils/empty';
-import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isItemLoadoutCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React from 'react';
@@ -46,7 +46,7 @@ export default function LoadoutDrawerDropTarget({
         const result = monitor.getDropResult();
         onDroppedItem(item, result?.equipped);
       },
-      canDrop: (i) => itemCanBeInLoadout(i) && isClassCompatible(i.classType, classType),
+      canDrop: (i) => itemCanBeInLoadout(i) && isItemLoadoutCompatible(i.classType, classType),
       collect: (monitor) => ({ isOver: monitor.isOver() && monitor.canDrop() }),
     }),
     [bucketTypes, onDroppedItem]

--- a/src/app/loadout-drawer/loadout-drawer-reducer.test.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.test.ts
@@ -15,13 +15,14 @@ import {
   fillLoadoutFromUnequipped,
   removeItem,
   removeMod,
+  setClassType,
   setLoadoutParameters,
   setLoadoutSubclassFromEquipped,
   toggleEquipped,
   updateMods,
 } from './loadout-drawer-reducer';
 import { Loadout } from './loadout-types';
-import { newLoadout } from './loadout-utils';
+import { filterLoadoutToAllowedItems, newLoadout } from './loadout-utils';
 
 let defs: D2ManifestDefinitions;
 let store: DimStore;
@@ -203,6 +204,27 @@ describe('addItem', () => {
     expect(invalidItem).toBeDefined();
 
     let loadout = addItem(defs, invalidItem)(emptyLoadout);
+
+    expect(loadout.items).toEqual([]);
+  });
+
+  it('does nothing when adding class-specific item to any-class loadout', () => {
+    const invalidItem = allItems.find((i) => i.classType === DestinyClass.Hunter)!;
+    expect(invalidItem).toBeDefined();
+
+    let loadout = setClassType(DestinyClass.Unknown)(emptyLoadout);
+    loadout = addItem(defs, invalidItem)(loadout);
+
+    expect(loadout.items).toEqual([]);
+  });
+
+  it('removes class-specific items when saving as "any class"', () => {
+    const hunterItem = allItems.find((i) => i.classType === DestinyClass.Hunter)!;
+    expect(hunterItem).toBeDefined();
+
+    let loadout = addItem(defs, hunterItem)(emptyLoadout);
+    loadout = setClassType(DestinyClass.Unknown)(loadout);
+    loadout = filterLoadoutToAllowedItems(defs, loadout);
 
     expect(loadout.items).toEqual([]);
   });

--- a/src/app/loadout-drawer/loadout-drawer-reducer.ts
+++ b/src/app/loadout-drawer/loadout-drawer-reducer.ts
@@ -12,7 +12,7 @@ import { getModExclusionGroup, mapToNonReducedModCostVariant } from 'app/loadout
 import { useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
 import { ItemFilter } from 'app/search/filter-types';
-import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isItemLoadoutCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { errorLog } from 'app/utils/log';
 import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { filterMap } from 'app/utils/util';
@@ -116,7 +116,7 @@ export function addItem(
       return;
     }
 
-    if (!isClassCompatible(item.classType, draftLoadout.classType)) {
+    if (!isItemLoadoutCompatible(item.classType, draftLoadout.classType)) {
       showNotification({
         type: 'warning',
         title: t('Loadouts.ClassTypeMismatch', { className: item.classTypeNameLocalized }),

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -52,7 +52,7 @@ import { LoadoutArtifactUnlocks, LoadoutMods } from 'app/loadout/loadout-ui/Load
 import { useD2Definitions } from 'app/manifest/selectors';
 import { searchFilterSelector } from 'app/search/search-filter';
 import { emptyObject } from 'app/utils/empty';
-import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isItemLoadoutCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -162,7 +162,7 @@ async function pickLoadoutItem(
   const item = await showItemPicker({
     filterItems: (item: DimItem) =>
       item.bucket.hash === bucket.hash &&
-      isClassCompatible(item.classType, loadout.classType) &&
+      isItemLoadoutCompatible(item.classType, loadout.classType) &&
       itemCanBeInLoadout(item) &&
       !loadoutHasItem(item) &&
       (!item.notransfer || item.owner === store.id),
@@ -311,7 +311,7 @@ function LoadoutEditCategorySection({
           ? item.bucket.hash === warnItem.bucket.hash
           : item.hash === warnItem.hash) &&
         itemCanBeInLoadout(item) &&
-        isClassCompatible(item.classType, loadout.classType),
+        isItemLoadoutCompatible(item.classType, loadout.classType),
       prompt: t('Loadouts.FindAnother', {
         name: warnItem.bucket.inArmor ? warnItem.bucket.name : warnItem.name,
       }),

--- a/src/app/loadout/loadout-edit/useEquipDropTargets.tsx
+++ b/src/app/loadout/loadout-edit/useEquipDropTargets.tsx
@@ -1,6 +1,6 @@
 import { DimItem } from 'app/inventory/item-types';
 import { singularBucketHashes } from 'app/loadout-drawer/loadout-utils';
-import { isClassCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
+import { isItemLoadoutCompatible, itemCanBeInLoadout } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { TargetType } from 'dnd-core';
 import { DropTargetHookSpec, useDrop } from 'react-dnd';
@@ -55,7 +55,7 @@ export function useEquipDropTargets(accept: TargetType, classType: DestinyClass)
       drop: () => ({ equipped: type === 'equipped' }),
       canDrop: (i) =>
         itemCanBeInLoadout(i) &&
-        isClassCompatible(i.classType, classType) &&
+        isItemLoadoutCompatible(i.classType, classType) &&
         (type === 'equipped' || !singularBucketHashes.includes(i.bucket.hash)),
       collect: (monitor) => ({
         isOver: monitor.isOver() && monitor.canDrop(),

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -381,3 +381,12 @@ export function isClassCompatible(firstClass: DestinyClass, secondClass: Destiny
     firstClass === secondClass
   );
 }
+
+/**
+ * Can a loadout of classType `loadoutClass` use an item of class `itemClass`?
+ * Global loadouts can only include items equippable by any class, so this is
+ * more restrictive than `isClassCompatible`
+ */
+export function isItemLoadoutCompatible(itemClass: DestinyClass, loadoutClass: DestinyClass) {
+  return itemClass === DestinyClass.Unknown || itemClass === loadoutClass;
+}


### PR DESCRIPTION
Fixes #9907, a likely regression from #9558.