### PR TITLE
Remove LO progress popup and replace with inline text

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -619,7 +619,7 @@
     "OptimizerExplanationSearch": "Use the search bar to narrow down which armor to consider. If no armor matches the search in a slot, all armor in that slot will be considered.",
     "OptimizerExplanationGuide": "Read the User Guide for more info and a video tutorial.",
     "OptimizerSet": "Optimizer Set",
-    "ProcessingSets": "Processing sets for\n{{character}} ({{remainingTime}}s)",
+    "ProcessingSets": "Finding highest tier sets...",
     "SaveAs": "Save as",
     "SelectMax": "- Max -",
     "SelectMin": "- Min -",

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss
@@ -22,35 +22,6 @@
   }
 }
 
-.processing {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: black;
-  font-size: 1.2em;
-  padding: 10px 10px;
-  position: fixed;
-  left: 50%;
-
-  @include below-header;
-
-  white-space: nowrap;
-  z-index: 10;
-
-  > div {
-    margin-right: 8px;
-  }
-
-  > span {
-    font-size: 1.4em;
-  }
-
-  @include phone-portrait {
-    left: 0;
-    width: 100%;
-  }
-}
-
 .toolbar {
   display: flex;
   flex-flow: row wrap;
@@ -91,10 +62,11 @@
 }
 
 .speedReport {
-  font-size: 11px;
   user-select: text;
-  display: inline;
   margin-left: 1em;
+  > :global(.app-icon) {
+    margin-right: 0.5em;
+  }
 }
 
 // Style for sections borrowed from LoadoutEdit

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
@@ -5,7 +5,6 @@ interface CssExports {
   'loadoutEditSection': string;
   'menuContent': string;
   'page': string;
-  'processing': string;
   'speedReport': string;
   'toolbar': string;
   'undoRedo': string;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -34,7 +34,6 @@ import { isClassCompatible, itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { deepEqual } from 'fast-equals';
-import { AnimatePresence, Tween, Variants, motion } from 'framer-motion';
 import { Dispatch, memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -69,12 +68,6 @@ import {
   LockableBucketHashes,
   loDefaultArmorEnergyRules,
 } from './types';
-
-const processingAnimateVariants: Variants = {
-  hidden: { opacity: 0, y: -50 },
-  shown: { opacity: 1, y: 0 },
-};
-const processingAnimateTransition: Tween = { ease: 'easeInOut', duration: 0.5 };
 
 /**
  * The Loadout Optimizer screen
@@ -250,7 +243,7 @@ export default memo(function LoadoutBuilder({
   );
 
   // Run the actual loadout generation process in a web worker
-  const { result, processing, remainingTime } = useProcess({
+  const { result, processing } = useProcess({
     defs,
     selectedStore,
     filteredItems,
@@ -408,35 +401,26 @@ export default memo(function LoadoutBuilder({
       </PageWithMenu.Menu>
 
       <PageWithMenu.Contents>
-        <AnimatePresence>
-          {processing && (
-            <motion.div
-              className={styles.processing}
-              initial="hidden"
-              animate="shown"
-              exit="hidden"
-              variants={processingAnimateVariants}
-              transition={processingAnimateTransition}
-            >
-              <div>
-                {t('LoadoutBuilder.ProcessingSets', {
-                  character: selectedStore.name,
-                  remainingTime: remainingTime || '??',
-                })}
-              </div>
-              <AppIcon icon={refreshIcon} spinning={true} />
-            </motion.div>
-          )}
-        </AnimatePresence>
         <div className={styles.toolbar}>
           <UserGuideLink topic="Loadout-Optimizer" />
-          {result && (
-            <div className={styles.speedReport}>
-              {t('LoadoutBuilder.SpeedReport', {
-                combos: result.combos,
-                time: (result.processTime / 1000).toFixed(2),
-              })}
-            </div>
+          {processing ? (
+            <span className={styles.speedReport} role="status">
+              <AppIcon icon={refreshIcon} spinning={true} />
+              <span>
+                {t('LoadoutBuilder.ProcessingSets', {
+                  character: selectedStore.name,
+                })}
+              </span>
+            </span>
+          ) : (
+            result && (
+              <span className={styles.speedReport} role="status">
+                {t('LoadoutBuilder.SpeedReport', {
+                  combos: result.combos,
+                  time: (result.processTime / 1000).toFixed(2),
+                })}
+              </span>
+            )
           )}
         </div>
         {!isPhonePortrait && (

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -45,8 +45,7 @@ export function process(
   /** Which artifice mods, large, and small stat mods are available */
   autoModOptions: AutoModData,
   /** Use stat mods to hit stat minimums */
-  autoStatMods: boolean,
-  onProgress: (remainingTime: number) => void
+  autoStatMods: boolean
 ): {
   sets: ProcessArmorSet[];
   combos: number;
@@ -144,8 +143,6 @@ export function process(
     numValidSets: 0,
     statistics: setStatistics,
   };
-
-  let elapsedSeconds = 0;
 
   for (const helm of helms) {
     for (const gaunt of gauntlets) {
@@ -372,17 +369,6 @@ export function process(
             setTracker.insert(totalTier + predictedExtraTiers, tiersString, armor, stats, statMods);
           }
         }
-      }
-
-      // Report speed every so often
-      const totalTime = performance.now() - pstart;
-      const newElapsedSeconds = Math.floor(totalTime / 500);
-
-      if (newElapsedSeconds > elapsedSeconds) {
-        elapsedSeconds = newElapsedSeconds;
-        const speed = (processStatistics.numProcessed * 1000) / totalTime;
-        const remaining = Math.round((combos - processStatistics.numProcessed) / speed);
-        onProgress(remaining);
       }
     }
   }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -9,7 +9,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { getModTypeTagByPlugCategoryHash } from 'app/utils/item-utils';
 import { infoLog } from 'app/utils/log';
-import { proxy, releaseProxy, wrap } from 'comlink';
+import { releaseProxy, wrap } from 'comlink';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -83,7 +83,6 @@ export function useProcess({
   anyExotic: boolean;
   autoStatMods: boolean;
 }) {
-  const [remainingTime, setRemainingTime] = useState(0);
   const [{ result, processing }, setState] = useState<ProcessState>({
     processing: false,
     resultStoreId: selectedStore.id,
@@ -117,7 +116,6 @@ export function useProcess({
     const { worker, cleanup } = createWorker();
     cleanupRef.current = cleanup;
 
-    setRemainingTime(0);
     setState((state) => ({
       processing: true,
       resultStoreId: selectedStore.id,
@@ -172,8 +170,7 @@ export function useProcess({
         resolvedStatConstraints,
         anyExotic,
         autoModsData,
-        autoStatMods,
-        proxy(setRemainingTime)
+        autoStatMods
       )
       .then(({ sets, combos, statRangesFiltered, processInfo }) => {
         infoLog(
@@ -220,7 +217,7 @@ export function useProcess({
     modStatChanges,
   ]);
 
-  return { result, processing, remainingTime };
+  return { result, processing };
 }
 
 function createWorker() {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -613,7 +613,7 @@
     "OptimizerExplanationSearch": "Use the search bar to narrow down which armor to consider. If no armor matches the search in a slot, all armor in that slot will be considered.",
     "OptimizerExplanationStats": "Drag the most important stats to the top, and set stats you don't care about to Ignore.",
     "OptimizerSet": "Optimizer Set",
-    "ProcessingSets": "Processing sets for\n{{character}} ({{remainingTime}}s)",
+    "ProcessingSets": "Finding highest tier sets...",
     "SaveAs": "Save as",
     "SelectMax": "- Max -",
     "SelectMin": "- Min -",


### PR DESCRIPTION
This removes the little slide-down progress toast on the Loadout Optimizer, and its time estimate. On my, admittedly very fast, computer it never even gets to the point of estimating time as it never takes more than about 200ms to compute sets. I've replaced this with some progress text where the "Generated X combinations" text goes. I think it's less distracting this way.