### PR TITLE
Tweak D1 farming behavior

### DIFF
--- a/src/app/farming/actions.ts
+++ b/src/app/farming/actions.ts
@@ -129,8 +129,11 @@ function farmD1(store: D1Store, cancelToken: CancelToken): ThunkResult {
 function farmItems(store: D1Store, cancelToken: CancelToken): ThunkResult {
   const toMove = store.items.filter(
     (i) =>
+      !i.equipped &&
       !i.notransfer &&
-      (i.isEngram || (i.equipment && i.tier === 'Uncommon') || supplies.includes(i.hash))
+      (i.isEngram ||
+        (i.equipment && i.bucket.hash !== BucketHashes.Emblems && i.tier === 'Uncommon') ||
+        supplies.includes(i.hash))
   );
 
   if (toMove.length === 0) {


### PR DESCRIPTION
It's been a long time since I've thought about D1 farming mode, but these changes seem reasonable:

* Don't move uncommon emblems to the vault. This was originally meant to "move blues to the vault" but it shouldn't apply to emblems.
* Don't move equipped items to the vault. No idea why this wasn't always part of the rule.

Fixes #9877