### PR TITLE
Slight redesign of accounts menu

### DIFF
--- a/src/app/accounts/Account.m.scss
+++ b/src/app/accounts/Account.m.scss
@@ -5,8 +5,7 @@
   line-height: 15px;
   text-align: left;
   position: relative;
-  font-weight: bold;
-  font-size: 14px;
+  font-size: 16px;
   margin: 1px 0 0 0;
   white-space: nowrap;
   display: flex;
@@ -16,7 +15,6 @@
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
   :global(.app-icon) {
-    font-size: 115% !important;
     margin: 0 0 0 4px;
     &.first {
       border-left: 1px solid #666;

--- a/src/app/accounts/MenuAccounts.m.scss
+++ b/src/app/accounts/MenuAccounts.m.scss
@@ -13,7 +13,6 @@
     text-decoration: none;
     > div {
       padding: 10px 2rem 10px 1rem;
-      color: var(--theme-text-secondary);
 
       &:hover,
       &:focus {
@@ -36,5 +35,8 @@
 }
 
 .accountName {
-  padding: 2px 2rem 4px 1rem;
+  all: initial;
+  font: inherit;
+  font-size: 12px;
+  color: var(--theme-text-secondary);
 }

--- a/src/app/accounts/MenuAccounts.tsx
+++ b/src/app/accounts/MenuAccounts.tsx
@@ -35,8 +35,9 @@ export default function MenuAccounts({
 
   return (
     <div className={styles.accountSelect}>
-      <h3>{t('Accounts.Title')}</h3>
-      <div className={styles.accountName}>{bungieName}</div>
+      <h3>
+        {t('Accounts.Title')} <span className={styles.accountName}>{bungieName}</span>
+      </h3>
       {sortedAccounts.map((account) => (
         <Link
           key={`${account.membershipId}-${account.destinyVersion}`}


### PR DESCRIPTION
I realized that the accounts being "dimmed" made them look disabled. I figured while I was in there I could make them the same size as the other menu items, and collapse the account info into the same line as the accounts header.

Before:
<img width="229" alt="Screenshot 2023-09-24 at 2 24 15 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/6b3bbc9d-67d0-45c2-8d26-135f5a8b8c66">

After:
<img width="226" alt="Screenshot 2023-09-24 at 2 24 20 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/204f3635-93ec-4024-b3b1-70c14d6cd7a9">
