### PR TITLE
Get rid of some hashLookupFailure spam on the Loadouts page

### DIFF
--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -107,6 +107,8 @@ export interface DefinitionTable<T> {
    * `requestor` ideally a string/number, or a definition including a "hash" key
    */
   readonly get: (hash: number, requestor?: { hash: number } | string | number) => T;
+  /** for lookups that frequently may reasonably fail due to def data removal */
+  readonly getOptional: (hash: number) => T | undefined;
   readonly getAll: () => { [hash: number]: T };
 }
 
@@ -196,7 +198,7 @@ export function buildDefinitionsFromManifest(db: AllDestinyManifestComponents) {
     defs[tableShort] = {
       get(id: number, requestor?: { hash: number } | string | number) {
         const dbEntry = dbTable[id];
-        if (!dbEntry && tableShort !== 'Record') {
+        if (!dbEntry) {
           // there are valid negative hashes that we have added ourselves via enhanceDBWithFakeEntries,
           // but other than that they should be whole & reasonable sized numbers
           if (id < 1 || !Number.isSafeInteger(id)) {
@@ -212,6 +214,9 @@ export function buildDefinitionsFromManifest(db: AllDestinyManifestComponents) {
           }
         }
         return dbEntry;
+      },
+      getOptional(id: number) {
+        return dbTable[id];
       },
       getAll() {
         return dbTable;

--- a/src/app/progress/TrackedTriumphs.tsx
+++ b/src/app/progress/TrackedTriumphs.tsx
@@ -19,7 +19,9 @@ export function TrackedTriumphs({ searchQuery }: { searchQuery?: string }) {
   const recordHashes = trackedRecordHash
     ? [...new Set([trackedRecordHash, ...trackedTriumphs])]
     : trackedTriumphs;
-  let records = filterMap(recordHashes, (h) => toRecord(defs, profileResponse, h));
+  let records = filterMap(recordHashes, (h) =>
+    toRecord(defs, profileResponse, h, /* mayBeMissing */ true)
+  );
 
   if (searchQuery) {
     records = records.filter((r) =>

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -445,9 +445,12 @@ function toRecords(
 export function toRecord(
   defs: D2ManifestDefinitions,
   profileResponse: DestinyProfileResponse,
-  recordHash: number
+  recordHash: number,
+  mayBeMissing?: boolean
 ): DimRecord | undefined {
-  const recordDef = defs.Record.get(recordHash);
+  const recordDef = mayBeMissing
+    ? defs.Record.getOptional(recordHash)
+    : defs.Record.get(recordHash);
   if (!recordDef) {
     return undefined;
   }


### PR DESCRIPTION
One possible way to hande this. The change in toRecord is maybe a bit too weird and I'd be okay dropping that change