### PR TITLE
macOS Sonoma/Safari 17 PWA title bars respect theme 

### DIFF
--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -176,7 +176,7 @@ body {
 
 body {
   margin: 0 auto;
-  background-color: #313233;
+  background-color: var(--theme-pwa-background);
   color: var(--theme-text);
   font-family: 'Open Sans', sans-serif, 'Destiny Symbols';
   font-size: 12px;


### PR DESCRIPTION
Before (same grey on all themes):
<img width="276" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/cd8d2603-f9de-43d7-a906-1572434150bb">


After (title bar matches theme): 
<img width="296" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/b2429b05-e422-4eac-9507-1aa4f3387622"> <img width="276" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/1396158/b4da316c-360d-47fb-8a15-97073395244d">

