### PR TITLE
Correctly set firstTime

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -125,8 +125,8 @@ export function loadStores(): ThunkResult<DimStore[] | undefined> {
     // The first time we load, allow the data to be loaded from IDB. We then do a second
     // load to make sure that we immediately try to get remote data.
     if (firstTime) {
-      firstTime = false;
       await dispatch(loadStoresData(account, firstTime));
+      firstTime = false;
     }
     const stores = await dispatch(loadStoresData(account, firstTime));
     return stores;


### PR DESCRIPTION
The way I assigned `firstTime` in the stores loading code defeated the purpose of trying to load the stores from IDB before remote.