### PR TITLE
Don't extend archetype socket presstip beyond icon

### DIFF
--- a/src/app/item-popup/ArchetypeSocket.tsx
+++ b/src/app/item-popup/ArchetypeSocket.tsx
@@ -1,10 +1,8 @@
-import { PressTip } from 'app/dim-ui/PressTip';
 import { DimItem, DimSocket } from 'app/inventory/item-types';
 import clsx from 'clsx';
 import React from 'react';
 import styles from './ArchetypeSocket.m.scss';
 import { PlugClickHandler } from './ItemSockets';
-import { DimPlugTooltip } from './PlugTooltip';
 import Socket from './Socket';
 
 /**
@@ -35,13 +33,10 @@ export default function ArchetypeSocket({
           onClick={onClick}
         />
       </div>
-      <PressTip
-        className={styles.info}
-        tooltip={<DimPlugTooltip item={item} plug={archetypeSocket.plugged} />}
-      >
+      <div className={styles.info}>
         <div className={styles.name}>{archetypeSocket.plugged.plugDef.displayProperties.name}</div>
         {children}
-      </PressTip>
+      </div>
     </>
   );
 }

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -79,10 +79,12 @@ export default function Plug({
           unreliablePerkOption={unreliablePerkOption}
           notSelected={notSelected}
         />
-      ) : (
+      ) : !(item.isExotic && item.bucket.inArmor) ? (
         <PressTip tooltip={<DimPlugTooltip item={item} plug={plug} wishlistRoll={wishlistRoll} />}>
           <DefItemIcon itemDef={plug.plugDef} />
         </PressTip>
+      ) : (
+        <DefItemIcon itemDef={plug.plugDef} />
       )}
     </div>
   );


### PR DESCRIPTION
This makes the archetype plug match other plugs - the icon shows a presstip, but the name does not. I also removed the tooltip entirely from exotic armor perks, since their details are already shown. This fixes #9832