### PR TITLE
Make webpack.ts typecheck

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -128,7 +128,7 @@ export default (env: Env) => {
           liveReload: false,
           headers: (req) => {
             // This mirrors what's in .htaccess - headers for html paths, COEP for JS.
-            return req.baseUrl.match(/^[^.]+$/)
+            const headers: Record<string, string | string[]> = req.baseUrl.match(/^[^.]+$/)
               ? {
                   'Content-Security-Policy': contentSecurityPolicy,
                   // credentialless is only supported by chrome but require-corp blocks Bungie.net messages
@@ -142,6 +142,8 @@ export default (env: Env) => {
                   //'Cross-Origin-Embedder-Policy': 'require-corp',
                 }
               : {};
+
+            return headers;
           },
         }
       : undefined,


### PR DESCRIPTION
The inferred type of the ternary operator chain is `{ 'Content-Security-Policy': string; } | { 'Content-Security-Policy'?: undefined; }` and TypeScript doesn't want to convert this to a Record<string, string>. Some manual type annotations allow this to typecheck.