### PR TITLE
Use collectible matching for vendor armor collections checkmarks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * "Hide completed triumphs" on the Records page now also hides sections and seals where all triumphs have been completed, not only the triumphs themselves.
+* The Vendors page should now more reliably indicate whether armor sold by Ada-1 is unlocked in collections.
 
 ## 7.88.0 <span class="changelog-date">(2023-10-01)</span>
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -1,6 +1,7 @@
 import { CustomStatDef } from '@destinyitemmanager/dim-api-types';
 import { D2Categories } from 'app/destiny2/d2-bucket-categories';
 import { t } from 'app/i18next-t';
+import { createCollectibleFinder } from 'app/records/collectible-matching';
 import {
   D2ItemTiers,
   THE_FORBIDDEN_BUCKET,
@@ -39,7 +40,6 @@ import extendedBreaker from 'data/d2/extended-breaker.json';
 import extendedFoundry from 'data/d2/extended-foundry.json';
 import extendedICH from 'data/d2/extended-ich.json';
 import { BucketHashes, ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
-import extraItemCollectibles from 'data/d2/unreferenced-collections-items.json';
 import { Draft } from 'immer';
 import _ from 'lodash';
 import memoizeOne from 'memoize-one';
@@ -59,10 +59,6 @@ import { buildObjectives, isTrialsPassage, isWinsObjective } from './objectives'
 import { buildPatternInfo } from './patterns';
 import { buildSockets } from './sockets';
 import { buildStats } from './stats';
-
-const extraItemsToCollectibles = _.mapValues(_.invert(extraItemCollectibles), (val) =>
-  parseInt(val, 10)
-);
 
 const collectiblesByItemHash = memoizeOne(
   (Collectible: ReturnType<D2ManifestDefinitions['Collectible']['getAll']>) =>
@@ -396,7 +392,7 @@ export function makeItem(
     itemDef.iconWatermarkShelved ||
     undefined;
 
-  const collectibleHash = itemDef.collectibleHash ?? extraItemsToCollectibles[itemDef.hash];
+  const collectibleHash = createCollectibleFinder(defs)(itemDef);
   // Do we need this now?
   const source = collectibleHash
     ? defs.Collectible.get(collectibleHash, itemDef.hash)?.sourceHash

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -392,11 +392,9 @@ export function makeItem(
     itemDef.iconWatermarkShelved ||
     undefined;
 
-  const collectibleHash = createCollectibleFinder(defs)(itemDef);
+  const collectible = createCollectibleFinder(defs)(itemDef);
   // Do we need this now?
-  const source = collectibleHash
-    ? defs.Collectible.get(collectibleHash, itemDef.hash)?.sourceHash
-    : undefined;
+  const source = collectible?.sourceHash;
 
   // items' appearance can be overridden at bungie's request
   let overrideStyleItem = item.overrideStyleItemHash
@@ -495,7 +493,7 @@ export function makeItem(
     previewVendor: itemDef.preview?.previewVendorHash,
     ammoType: itemDef.equippingBlock ? itemDef.equippingBlock.ammoType : DestinyAmmunitionType.None,
     source,
-    collectibleHash,
+    collectibleHash: collectible?.hash,
     missingSockets: false,
     displaySource: itemDef.displaySource,
     plug: itemDef.plug && {

--- a/src/app/records/collectible-matching.ts
+++ b/src/app/records/collectible-matching.ts
@@ -1,0 +1,119 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { ARMOR_NODE } from 'app/search/d2-known-values';
+import {
+  DestinyClass,
+  DestinyInventoryItemDefinition,
+  DestinyPresentationNodeDefinition,
+} from 'bungie-api-ts/destiny2';
+import focusingItemOutputs from 'data/d2/focusing-item-outputs.json';
+import extraItemCollectibles from 'data/d2/unreferenced-collections-items.json';
+import _ from 'lodash';
+import memoizeOne from 'memoize-one';
+
+// For some items, the most recent versions don't have a collectible. d2ai gives us the most
+// recent item hash for given collectibles, so the inverted map gives us the collectible
+// for some items.
+const extraItemsToCollectibles = _.mapValues(_.invert(extraItemCollectibles), (val) =>
+  parseInt(val, 10)
+);
+
+function collectPresentationNodes(
+  defs: D2ManifestDefinitions,
+  nodeHash: number,
+  list: DestinyPresentationNodeDefinition[]
+) {
+  const def = defs.PresentationNode.get(nodeHash);
+  if (def && !def.redacted) {
+    if (def.children.collectibles.length) {
+      list.push(def);
+    }
+    for (const childNode of def.children.presentationNodes) {
+      collectPresentationNodes(defs, childNode.presentationNodeHash, list);
+    }
+  }
+  return list;
+}
+
+/**
+ * Finds the most likely collectible for a given item definition. Additionally pass in the classType
+ * to be able to match armor ornaments that don't indicate a classType by themselves.
+ */
+export const createCollectibleFinder = memoizeOne((defs: D2ManifestDefinitions) => {
+  const cache: { [itemHash: number]: number | null } = {};
+  // The Titan/Hunter/Warlock armor presentation nodes, in that order (matches enum order)
+  const classPresentationNodes = defs.PresentationNode.get(ARMOR_NODE).children.presentationNodes;
+
+  const armorCollectiblesByClassType = _.once(() =>
+    Object.fromEntries(
+      [DestinyClass.Titan, DestinyClass.Hunter, DestinyClass.Warlock].map((classType) => {
+        const classNode = classPresentationNodes[classType];
+        const relevantPresentationNodes = collectPresentationNodes(
+          defs,
+          classNode.presentationNodeHash,
+          []
+        );
+        const collectibles = relevantPresentationNodes
+          .flatMap((node) => node.children?.collectibles ?? [])
+          .map((c) => defs.Collectible.get(c.collectibleHash));
+        return [classType, collectibles] as const;
+      })
+    )
+  );
+
+  return (itemDef: DestinyInventoryItemDefinition, knownClassType?: DestinyClass) => {
+    const cacheEntry = cache[itemDef.hash];
+    if (cacheEntry !== undefined) {
+      return cacheEntry ?? undefined;
+    }
+
+    const collectibleHash = (() => {
+      // If this is a fake focusing item, the item we're actually interested in is the output
+      const itemHash = focusingItemOutputs[itemDef.hash] ?? itemDef.hash;
+      const outputItemDef = defs.InventoryItem.get(itemHash);
+      if (!outputItemDef) {
+        return undefined;
+      }
+      // If this has a collectible hash, use that
+      if (outputItemDef.collectibleHash) {
+        return outputItemDef.collectibleHash;
+      }
+
+      // For some items, d2ai knows what the collectible is
+      if (extraItemsToCollectibles[itemHash]) {
+        return extraItemsToCollectibles[itemHash];
+      }
+
+      // Otherwise we try some fuzzy matching with the collectibles.
+      // This currently only handles armor, and needs a classType to
+      // get the correct armor presentation node. This could potentially
+      // be extended to weapons too, but we've not had many problems with weapon
+      // collectibles yet and especially in the case of universal ornaments
+      // the ornaments themselves don't have a good ICH or classType
+      const classType = knownClassType ?? outputItemDef.classType;
+      if (!outputItemDef.redacted && classType !== DestinyClass.Unknown) {
+        // First, find a collectible with the same name
+        const collectibles = armorCollectiblesByClassType()[classType];
+        const sameName = collectibles.find(
+          (c) => c.displayProperties.name === outputItemDef.displayProperties.name
+        );
+        if (sameName) {
+          return sameName.hash;
+        }
+
+        // Sometimes the collectible icon will be different, but reference an item
+        // where the icon matches our icon (e.g. Y1 Trials / Prophecy: Bond Judgment vs. Judgement's Wrap)
+        const reverseCollectibleMatch = collectibles.find((c) => {
+          const reverseItemDef = defs.InventoryItem.get(c.itemHash);
+          return reverseItemDef?.displayProperties.icon === outputItemDef.displayProperties.icon;
+        });
+        if (reverseCollectibleMatch) {
+          return reverseCollectibleMatch.hash;
+        }
+        return undefined;
+      }
+    })();
+
+    cache[itemDef.hash] = collectibleHash ?? null;
+    return collectibleHash;
+  };
+});

--- a/src/app/records/universal-ornaments/UniversalOrnaments.tsx
+++ b/src/app/records/universal-ornaments/UniversalOrnaments.tsx
@@ -59,7 +59,7 @@ export default function UniversalOrnaments({
               {sets.name}
             </>
           }
-          sectionId={`class-${sets.classType}`}
+          sectionId={`ornaments-class-${sets.classType}`}
           defaultCollapsed={true}
         >
           <div className={styles.records}>

--- a/src/app/records/universal-ornaments/universal-ornaments.tsx
+++ b/src/app/records/universal-ornaments/universal-ornaments.tsx
@@ -7,7 +7,7 @@ import { ItemCreationContext, makeFakeItem } from 'app/inventory/store/d2-item-f
 import { ARMOR_NODE, DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
 import { filterMap } from 'app/utils/util';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
+import { DestinyClass, DestinyCollectibleDefinition } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import auxOrnamentSets from 'data/d2/universal-ornament-aux-sets.json';
 import universalOrnamentPlugSetHashes from 'data/d2/universal-ornament-plugset-hashes.json';
@@ -134,12 +134,13 @@ export const buildSets = memoizeOne((defs: D2ManifestDefinitions): OrnamentsData
     [DestinyClass.Warlock]: { classType: DestinyClass.Warlock, sets: {}, name: '', icon: '' },
   };
 
-  const findCollectibleArmorParentNode = (collectibleHash: number | undefined) => {
-    if (collectibleHash) {
-      const collectible = defs.Collectible.get(collectibleHash);
+  const findCollectibleArmorParentNode = (
+    collectible: DestinyCollectibleDefinition | undefined
+  ) => {
+    if (collectible) {
       return collectible.parentNodeHashes
         ?.map((nodeHash) => defs.PresentationNode.get(nodeHash))
-        .find((node) => node.children.collectibles?.length <= 5);
+        .find((node) => node?.children.collectibles?.length <= 5);
     }
   };
 

--- a/src/app/search/armory-search.ts
+++ b/src/app/search/armory-search.ts
@@ -32,8 +32,9 @@ export const buildArmoryIndex = memoizeOne((defs: D2ManifestDefinitions, languag
     if (
       // A good heuristic for "is this weapon not totally irrelevant" is the presence of
       // the exact hash in collections, but some reissues do not reference the latest version
-      // in the collections entry (and thus the latest item has ni `collectibleHash`).
-      // Use `additionalCollectibles` to patch those in.
+      // in the collections entry (and thus the latest item has no `collectibleHash`).
+      // Use `additionalCollectibles` to patch those in. Note that we do not use the
+      // `collectibleFinder` because not matching some old items is the entire point here.
       (i.collectibleHash || additionalCollectibles.includes(i.hash)) &&
       i.displayProperties &&
       (i.inventory?.bucketTypeHash === BucketHashes.KineticWeapons ||

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -52,7 +52,7 @@ function getCollectibleState(
   characterId: string
 ) {
   const collectibleFinder = createCollectibleFinder(defs);
-  const collectibleHash = collectibleFinder(inventoryItem);
+  const collectibleHash = collectibleFinder(inventoryItem)?.hash;
   let collectibleState: DestinyCollectibleState | undefined;
   if (collectibleHash) {
     collectibleState =

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -1,4 +1,5 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { createCollectibleFinder } from 'app/records/collectible-matching';
 import { THE_FORBIDDEN_BUCKET, VENDORS } from 'app/search/d2-known-values';
 import { emptyArray } from 'app/utils/empty';
 import {
@@ -12,7 +13,6 @@ import {
   DestinyVendorItemState,
   DestinyVendorSaleItemComponent,
 } from 'bungie-api-ts/destiny2';
-import focusingItemOutputs from 'data/d2/focusing-item-outputs.json';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { DimItem } from '../inventory/item-types';
 import { ItemCreationContext, makeFakeItem } from '../inventory/store/d2-item-factory';
@@ -51,15 +51,8 @@ function getCollectibleState(
   profileResponse: DestinyProfileResponse | undefined,
   characterId: string
 ) {
-  let collectibleHash = inventoryItem.collectibleHash;
-
-  if (!collectibleHash) {
-    // For fake focusing items, what we really care about is state of what the item produces
-    const focusedItem = focusingItemOutputs[inventoryItem.hash];
-    if (focusedItem) {
-      collectibleHash = defs.InventoryItem.get(focusedItem)?.collectibleHash;
-    }
-  }
+  const collectibleFinder = createCollectibleFinder(defs);
+  const collectibleHash = collectibleFinder(inventoryItem);
   let collectibleState: DestinyCollectibleState | undefined;
   if (collectibleHash) {
     collectibleState =


### PR DESCRIPTION
Fixes #7023.
Fixes #9930.

Generalizes the code from universal ornaments to find a related collectible for armor sold by vendors too. I have all that armor unlocked anyway, so I can't test the "not collected" case but it does mark them as collected for me.