### PR TITLE
Only show uncollected items: Match shaders without collections entry

### DIFF
--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -229,7 +229,8 @@ export function filterToUnacquired(ownedItemHashes: Set<number>): VendorFilterFu
     !owned &&
     (collectibleState !== undefined
       ? (collectibleState & DestinyCollectibleState.NotAcquired) !== 0
-      : item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod) &&
+      : (item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod) ||
+          item.itemCategoryHashes.includes(ItemCategoryHashes.Shaders)) &&
         !ownedItemHashes.has(item.hash));
 }
 


### PR DESCRIPTION
Ada-1 is selling New Pacific Rush (Worn) this season for the first time. The shader has no collections entry, so the toggle thinks "collected" isn't a concept for it. Use the same workaround as for mods here (note: `Mods_Mod` already includes emotes, transmat effects, subclass plugs, ornaments, and ghost projections, but shaders don't have that ICH).