### PR TITLE
When requested, hide nodes where all triumphs have been completed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* "Hide completed triumphs" on the Records page now also hides sections and seals where all triumphs have been completed, not only the triumphs themselves.
+
 ## 7.88.0 <span class="changelog-date">(2023-10-01)</span>
 
 * Added a Universal Ornaments section to the Records page showing which legendary armor pieces you have unlocked as Transmog ornaments and which ones you could turn into ornaments.

--- a/src/app/progress/TrackedTriumphs.tsx
+++ b/src/app/progress/TrackedTriumphs.tsx
@@ -54,7 +54,5 @@ export function TrackedTriumphs({ searchQuery }: { searchQuery?: string }) {
     );
   }
 
-  return (
-    <RecordGrid records={records} completedRecordsHidden={false} redactedRecordsRevealed={true} />
-  );
+  return <RecordGrid records={records} redactedRecordsRevealed={true} />;
 }

--- a/src/app/records/PresentationNode.tsx
+++ b/src/app/records/PresentationNode.tsx
@@ -128,7 +128,6 @@ export default function PresentationNode({
         <PresentationNodeLeaf
           node={node}
           ownedItemHashes={ownedItemHashes}
-          completedRecordsHidden={completedRecordsHidden}
           redactedRecordsRevealed={redactedRecordsRevealed}
           sortRecordProgression={sortRecordProgression}
         />

--- a/src/app/records/PresentationNodeLeaf.tsx
+++ b/src/app/records/PresentationNodeLeaf.tsx
@@ -19,13 +19,11 @@ import {
 export default function PresentationNodeLeaf({
   node,
   ownedItemHashes,
-  completedRecordsHidden,
   redactedRecordsRevealed,
   sortRecordProgression,
 }: {
   node: DimPresentationNodeLeaf;
   ownedItemHashes?: Set<number>;
-  completedRecordsHidden: boolean;
   redactedRecordsRevealed: boolean;
   sortRecordProgression: boolean;
 }) {
@@ -48,7 +46,6 @@ export default function PresentationNodeLeaf({
       {node.records && node.records.length > 0 && (
         <RecordGrid
           records={sortRecordProgression ? sortRecords(node.records) : node.records}
-          completedRecordsHidden={completedRecordsHidden}
           redactedRecordsRevealed={redactedRecordsRevealed}
         />
       )}

--- a/src/app/records/PresentationNodeRoot.tsx
+++ b/src/app/records/PresentationNodeRoot.tsx
@@ -7,7 +7,11 @@ import { useSelector } from 'react-redux';
 import PresentationNode from './PresentationNode';
 import styles from './PresentationNodeRoot.m.scss';
 import PresentationNodeSearchResults from './PresentationNodeSearchResults';
-import { filterPresentationNodesToSearch, toPresentationNodeTree } from './presentation-nodes';
+import {
+  filterPresentationNodesToSearch,
+  hideCompletedRecords,
+  toPresentationNodeTree,
+} from './presentation-nodes';
 
 interface Props {
   presentationNodeHash: number;
@@ -65,7 +69,7 @@ export default function PresentationNodeRoot({
 
   const currentStore = useSelector(currentStoreSelector);
 
-  const nodeTree = useMemo(
+  const unfilteredNodeTree = useMemo(
     () =>
       toPresentationNodeTree(
         itemCreationContext,
@@ -74,6 +78,14 @@ export default function PresentationNodeRoot({
         currentStore?.genderHash
       ),
     [itemCreationContext, presentationNodeHash, showPlugSets, currentStore?.genderHash]
+  );
+
+  const nodeTree = useMemo(
+    () =>
+      unfilteredNodeTree && completedRecordsHidden
+        ? hideCompletedRecords(unfilteredNodeTree)
+        : unfilteredNodeTree,
+    [completedRecordsHidden, unfilteredNodeTree]
   );
 
   if (!nodeTree) {
@@ -85,7 +97,6 @@ export default function PresentationNodeRoot({
       nodeTree,
       searchQuery.toLowerCase(),
       searchFilter,
-      Boolean(completedRecordsHidden),
       undefined,
       defs
     );

--- a/src/app/records/PresentationNodeSearchResults.tsx
+++ b/src/app/records/PresentationNodeSearchResults.tsx
@@ -16,7 +16,6 @@ export default function PresentationNodeSearchResults({
   profileResponse: DestinyProfileResponse;
 }) {
   // TODO: make each node in path linkable
-  const completedRecordsHidden = useSelector(settingSelector('completedRecordsHidden'));
   const redactedRecordsRevealed = useSelector(settingSelector('redactedRecordsRevealed'));
   const sortRecordProgression = useSelector(settingSelector('sortRecordProgression'));
   return (
@@ -44,7 +43,6 @@ export default function PresentationNodeSearchResults({
                   <PresentationNodeLeaf
                     node={node}
                     ownedItemHashes={ownedItemHashes}
-                    completedRecordsHidden={completedRecordsHidden}
                     redactedRecordsRevealed={redactedRecordsRevealed}
                     sortRecordProgression={sortRecordProgression}
                   />
@@ -53,7 +51,6 @@ export default function PresentationNodeSearchResults({
             <PresentationNodeLeaf
               node={sr}
               ownedItemHashes={ownedItemHashes}
-              completedRecordsHidden={completedRecordsHidden}
               redactedRecordsRevealed={redactedRecordsRevealed}
               sortRecordProgression={sortRecordProgression}
             />

--- a/src/app/records/Record.tsx
+++ b/src/app/records/Record.tsx
@@ -41,11 +41,9 @@ const catalystIconsTable = catalystIcons as HashLookup<string>;
 
 export default function Record({
   record,
-  completedRecordsHidden,
   redactedRecordsRevealed,
 }: {
   record: DimRecord;
-  completedRecordsHidden: boolean;
   redactedRecordsRevealed: boolean;
 }) {
   const defs = useD2Definitions()!;
@@ -81,10 +79,6 @@ export default function Record({
     recordHash in catalystIconsTable
       ? catalystIconsTable[recordHash]
       : recordDef.displayProperties.icon;
-
-  if (completedRecordsHidden && acquired) {
-    return null;
-  }
 
   const intervals = getIntervals(recordDef, recordComponent);
   const intervalBarStyle = {
@@ -266,11 +260,9 @@ function getIntervals(
 /** A grid of records as seen in triumph presentation nodes or Tracked Triumphs. */
 export function RecordGrid({
   records,
-  completedRecordsHidden,
   redactedRecordsRevealed,
 }: {
   records: DimRecord[];
-  completedRecordsHidden: boolean;
   redactedRecordsRevealed: boolean;
 }) {
   // TODO: was there really a problem with duplicate records?
@@ -287,7 +279,6 @@ export function RecordGrid({
           <Record
             key={record.recordDef.hash}
             record={record}
-            completedRecordsHidden={completedRecordsHidden}
             redactedRecordsRevealed={redactedRecordsRevealed}
           />
         );

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -179,6 +179,7 @@ export default function Records({ account }: Props) {
                     overrideName={overrideTitles[nodeDef.hash]}
                     isTriumphs={nodeDef.hash === recordsRootHash}
                     showPlugSets={nodeDef.hash === collectionsRootHash}
+                    completedRecordsHidden={completedRecordsHidden}
                   />
                 </ErrorBoundary>
               </CollapsibleTitle>

--- a/src/app/records/presentation-nodes.ts
+++ b/src/app/records/presentation-nodes.ts
@@ -255,6 +255,46 @@ function buildPlugSetPresentationNode(
   return subnode;
 }
 
+function dropEmptyNodes(node: DimPresentationNode | undefined): DimPresentationNode | undefined {
+  if (!node) {
+    return undefined;
+  }
+  const children =
+    node.collectibles ??
+    node.craftables ??
+    node.records ??
+    node.metrics ??
+    node.plugs ??
+    node.childPresentationNodes;
+  if (children?.length) {
+    return node;
+  } else {
+    return undefined;
+  }
+}
+
+export function hideCompletedRecords(node: DimPresentationNode): DimPresentationNode {
+  if (node.childPresentationNodes) {
+    return {
+      ...node,
+      childPresentationNodes: filterMap(node.childPresentationNodes, (node) =>
+        dropEmptyNodes(hideCompletedRecords(node))
+      ),
+    };
+  }
+
+  if (node.records) {
+    return {
+      ...node,
+      records: node.records.filter(
+        (r) => !(r.recordComponent.state & DestinyRecordState.RecordRedeemed)
+      ),
+    };
+  }
+
+  return node;
+}
+
 // TODO: how to flatten this down to individual category trees
 // TODO: how to handle simple searches plus bigger queries
 // TODO: this uses the entire search field as one big string search. no "and". no fun.
@@ -262,7 +302,6 @@ export function filterPresentationNodesToSearch(
   node: DimPresentationNode,
   searchQuery: string,
   filterItems: ItemFilter,
-  completedRecordsHidden: boolean,
   path: DimPresentationNode[] = [],
   defs: D2ManifestDefinitions
 ): DimPresentationNodeSearchResult[] {
@@ -275,14 +314,7 @@ export function filterPresentationNodesToSearch(
   if (node.childPresentationNodes) {
     // TODO: build up the tree?
     return node.childPresentationNodes.flatMap((c) =>
-      filterPresentationNodesToSearch(
-        c,
-        searchQuery,
-        filterItems,
-        completedRecordsHidden,
-        [...path, node],
-        defs
-      )
+      filterPresentationNodesToSearch(c, searchQuery, filterItems, [...path, node], defs)
     );
   }
 
@@ -302,12 +334,8 @@ export function filterPresentationNodesToSearch(
   if (node.records) {
     const records = node.records.filter(
       (r) =>
-        !(
-          completedRecordsHidden &&
-          Boolean(r.recordComponent.state & DestinyRecordState.RecordRedeemed)
-        ) &&
-        (searchDisplayProperties(r.recordDef.displayProperties, searchQuery) ||
-          searchRewards(r.recordDef, searchQuery, defs))
+        searchDisplayProperties(r.recordDef.displayProperties, searchQuery) ||
+        searchRewards(r.recordDef, searchQuery, defs)
     );
 
     return records.length


### PR DESCRIPTION
Fixes #7341.

Component-level filtering is incompatible with trying to hide parent nodes too, so we need to preprocess the node tree itself (this also gets rid of some props drilling).
But we didn't pass `completedRecordsHidden` to `PresentationNodeRoot`, so we always relied on the Record-component-level filtering, and `filterPresentationNodesToSearch` does not interact well with hiding completed records because it short circuits when a node name itself matches, so this uses a two-stage approach.