### PR TITLE
Overcomplicated search for loadouts by items in them (on the Loadouts page only)

### DIFF
--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -17,6 +17,7 @@ import { InGameLoadout, Loadout } from 'app/loadout-drawer/loadout-types';
 import { newLoadout, newLoadoutFromEquipped } from 'app/loadout-drawer/loadout-utils';
 import { loadoutsForClassTypeSelector } from 'app/loadout-drawer/loadouts-selector';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { thingFilterSelector } from 'app/search/search-filter';
 import { useSetting } from 'app/settings/hooks';
 import { AppIcon, addIcon, faCalculator, uploadIcon } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
@@ -30,6 +31,7 @@ import LoadoutRow from './LoadoutsRow';
 import EditInGameLoadout from './ingame/EditInGameLoadout';
 import { InGameLoadoutDetails } from './ingame/InGameLoadoutDetailsSheet';
 import { InGameLoadoutStrip } from './ingame/InGameLoadoutStrip';
+import { fullyResolvedLoadoutsSelector } from './ingame/selectors';
 import LoadoutImportSheet from './loadout-share/LoadoutImportSheet';
 import LoadoutShareSheet from './loadout-share/LoadoutShareSheet';
 import { searchAndSortLoadoutsByQuery, useLoadoutFilterPills } from './loadout-ui/menu-hooks';
@@ -111,8 +113,16 @@ function Loadouts({ account }: { account: DestinyAccount }) {
   );
 
   const filteringLoadouts = Boolean(query || hasSelectedFilters);
+  const thingFilterFactory = useSelector(thingFilterSelector);
+  const fullyResolvedLoadouts = useSelector(fullyResolvedLoadoutsSelector(selectedStoreId));
 
-  const loadouts = searchAndSortLoadoutsByQuery(filteredLoadouts, query, language, loadoutSort);
+  const loadouts = searchAndSortLoadoutsByQuery(
+    filteredLoadouts,
+    fullyResolvedLoadouts.loadouts,
+    thingFilterFactory,
+    language,
+    loadoutSort
+  );
   if (!filteringLoadouts) {
     loadouts.unshift(currentLoadout);
   }

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -28,7 +28,11 @@ import { previousLoadoutSelector } from 'app/loadout-drawer/selectors';
 import { manifestSelector, useDefinitions } from 'app/manifest/selectors';
 import { showMaterialCount } from 'app/material-counts/MaterialCountsWrappers';
 import { showNotification } from 'app/notifications/notifications';
-import { filteredItemsSelector, searchFilterSelector } from 'app/search/search-filter';
+import {
+  filteredItemsSelector,
+  onlyMatchKeywords,
+  searchFilterSelector,
+} from 'app/search/search-filter';
 import {
   AppIcon,
   addIcon,
@@ -57,7 +61,10 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { InGameLoadoutIconWithIndex } from '../ingame/InGameLoadoutIcon';
 import { applyInGameLoadout } from '../ingame/ingame-loadout-apply';
-import { inGameLoadoutsForCharacterSelector } from '../ingame/selectors';
+import {
+  fullyResolvedLoadoutsSelector,
+  inGameLoadoutsForCharacterSelector,
+} from '../ingame/selectors';
 import { searchAndSortLoadoutsByQuery, useLoadoutFilterPills } from '../loadout-ui/menu-hooks';
 import styles from './LoadoutPopup.m.scss';
 import { RandomLoadoutOptions, useRandomizeLoadout } from './LoadoutPopupRandomize';
@@ -133,9 +140,12 @@ export default function LoadoutPopup({
     dimStore.id,
     { className: styles.filterPills, darkBackground: true }
   );
+  const fullyResolvedLoadouts = useSelector(fullyResolvedLoadoutsSelector(dimStore.id));
+
   const filteredLoadouts = searchAndSortLoadoutsByQuery(
     pillFilteredLoadouts,
-    loadoutQuery,
+    fullyResolvedLoadouts.loadouts,
+    onlyMatchKeywords(loadoutQuery),
     language,
     loadoutSort
   );

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -34,13 +34,14 @@ export default function LoadoutSubclassSection({
       >
         {subclass ? (
           <DraggableInventoryItem item={subclass.item}>
-            <ItemPopupTrigger item={subclass.item}>
+            <ItemPopupTrigger
+              item={subclass.item}
+              extraData={{ socketOverrides: subclass.loadoutItem.socketOverrides }}
+            >
               {(ref, onClick) => (
                 <ConnectedInventoryItem
                   innerRef={ref}
-                  // Disable the popup when plugs are available as we are showing
-                  // plugs in the loadout and they may be different to the popup
-                  onClick={plugs.length ? undefined : onClick}
+                  onClick={onClick}
                   item={subclass.item}
                   // don't show the selected Super ability because we are displaying the Super ability plug next
                   // to the subclass icon

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -8,7 +8,6 @@ import { setSearchQuery } from '../shell/actions';
 import MainSearchBarActions from './MainSearchBarActions';
 import MainSearchBarMenu from './MainSearchBarMenu';
 import SearchBar, { SearchFilterRef } from './SearchBar';
-import { SearchInput } from './SearchInput';
 
 /**
  * The main search filter that's in the header.
@@ -62,9 +61,7 @@ export default forwardRef(function SearchFilter(
   const extras = useMemo(() => <MainSearchBarActions key="actions" />, []);
   const menu = useMemo(() => <MainSearchBarMenu key="actions-menu" />, []);
 
-  const itemSearch = !onLoadouts;
-
-  return itemSearch ? (
+  return (
     <SearchBar
       ref={ref}
       onQueryChanged={onQueryChanged}
@@ -77,7 +74,5 @@ export default forwardRef(function SearchFilter(
     >
       {extras}
     </SearchBar>
-  ) : (
-    <SearchInput onQueryChanged={onQueryChanged} placeholder={placeholder} query={searchQuery} />
   );
 });

--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -13,9 +13,14 @@ import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 type I18nInput = Parameters<typeof t>;
 
 // a filter can return various bool-ish values
-type ValidFilterOutput = boolean | null | undefined;
+export type ValidFilterOutput = boolean | null | undefined;
 
 export type ItemFilter<I = DimItem> = (item: I) => ValidFilterOutput;
+
+export type ThingFilterFactory<I> = <T>(
+  itemExtractor: (i: T) => I[],
+  thingMatcher: (thing: T, keyword: string) => ValidFilterOutput
+) => ItemFilter<T>;
 
 /**
  * A slice of data that could be used by filter functions to


### PR DESCRIPTION
Fixes #8571.

Picked up a somewhat older branch I had. The types started getting worse by the minute but I did want to see how this would play out (I'd be totally fine if we conclude "this is way too complicated, we should do something simpler").

This essentially allows searching for loadouts by name/description and by their items using a single search query. E.g.:

* `perkname:rangefinder or #pvp` matches loadouts where any contained item has Rangefinder OR any contained item matches `#pvp` OR or the loadout name/description matches `#pvp`.
* `perkname:rangefinder #pvp` matches loadouts where any contained item has Rangefinder AND (any contained item matches `#pvp` OR or the loadout name/description matches `#pvp`)

The comments on `makeSearchFilterFactory` illustrate this behavior, but essentially instead of mapping the AST to a predicate tree for `DimItems`, the predicates work for arbitrary Things, given a function to turn those Things into DimItems and a function to match text on those Things.

