### PR TITLE
Fix socket details headers using :where

### DIFF
--- a/src/app/dim-ui/Sheet.m.scss
+++ b/src/app/dim-ui/Sheet.m.scss
@@ -39,7 +39,7 @@ $control-color: rgba(255, 255, 255, 0.5);
     flex: 1;
   }
 
-  h1 {
+  :where(h1) {
     @include destiny-header;
     font-size: 16px;
     margin: 0 0 8px 0;


### PR DESCRIPTION
This uses the `:where` pseudo-class, which has been supported for quite a long time, but not quite as far back as Chrome 85. Steam users can just deal with an ugly header. `:where` reduces the specificity of the selector it wraps to 0, so it can be overridden more easily. Again, `@layer` would help here too...

Fixes #9935