### PR TITLE
Use GitHub environments when deploying

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: beta
+      url: https://beta.destinyitemmanager.com
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,9 +55,9 @@ jobs:
         run: yarn build:beta
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
-          WEB_API_KEY: ${{ secrets.WEB_API_KEY }}
-          WEB_OAUTH_CLIENT_ID: ${{ secrets.WEB_OAUTH_CLIENT_ID }}
-          WEB_OAUTH_CLIENT_SECRET: ${{ secrets.WEB_OAUTH_CLIENT_SECRET }}
+          WEB_API_KEY: ${{ secrets.BUNGIE_API_KEY }}
+          WEB_OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          WEB_OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_SECRET }}
           DIM_API_KEY: ${{ secrets.DIM_API_KEY }}
 
       # Send webpack stats and build information to RelativeCI

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://app.destinyitemmanager.com
     steps:
       - uses: actions/checkout@v3
         with:
@@ -73,10 +76,10 @@ jobs:
         run: ./build/deploy-prod.sh
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
-          WEB_API_KEY: ${{ secrets.PROD_API_KEY }}
-          WEB_OAUTH_CLIENT_ID: ${{ secrets.PROD_OAUTH_CLIENT_ID }}
-          WEB_OAUTH_CLIENT_SECRET: ${{ secrets.PROD_OAUTH_CLIENT_SECRET }}
-          DIM_API_KEY: ${{ secrets.PROD_DIM_API_KEY }}
+          WEB_API_KEY: ${{ secrets.BUNGIE_API_KEY }}
+          WEB_OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
+          WEB_OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_SECRET }}
+          DIM_API_KEY: ${{ secrets.DIM_API_KEY }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
           REMOTE_PATH: app.destinyitemmanager.com


### PR DESCRIPTION
This is a pretty minor change to our deploy workflows to leverage [GitHub environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment). The main differences are:

1. Instead of having all our secrets (or environment vars) at the repository level, with different names for beta and prod, we can have secrets defined on each environment, with the same names, and we select which ones to use in the workflow.
2. The secrets won't be made available to workflows that are running on branches other than `master`.
3. GitHub will show a little "Deployments" list on the home page. 