### PR TITLE
Some stat building cleanups

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -308,10 +308,6 @@ export interface DimStat {
    * This is true of armor stats.
    */
   additive: boolean;
-  /**
-   * Whether the stat is always active or certain conditions need to be met before it is.
-   */
-  isConditionallyActive: boolean;
 }
 
 export interface D1Stat extends DimStat {

--- a/src/app/inventory/store/stats-custom.ts
+++ b/src/app/inventory/store/stats-custom.ts
@@ -70,6 +70,5 @@ export function makeCustomStat(
     bar: false,
     smallerIsBetter: false,
     additive: false,
-    isConditionallyActive: false,
   };
 }

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -1,7 +1,6 @@
 import { CustomStatDef } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
-import { D1ItemCategoryHashes } from 'app/search/d1-known-values';
 import { armorStats, evenStatWeights, TOTAL_STAT_HASH } from 'app/search/d2-known-values';
 import { compareBy } from 'app/utils/comparators';
 import { isClassCompatible, isPlugStatActive } from 'app/utils/item-utils';
@@ -107,14 +106,6 @@ const statsNoBar = [
   ...statsMs,
 ];
 
-/** Show these stats in addition to any "natural" stats */
-const hiddenStatsAllowList = [
-  StatHashes.AimAssistance,
-  StatHashes.Zoom,
-  StatHashes.RecoilDirection,
-  StatHashes.AirborneEffectiveness,
-];
-
 /** a dictionary to look up StatDisplay info by statHash */
 interface StatDisplayLookup {
   [statHash: number]: DestinyStatDisplayDefinition | undefined;
@@ -211,13 +202,9 @@ function shouldShowStat(
     return false;
   }
 
-  // Swords shouldn't show any hidden stats
-  const includeHiddenStats = !itemDef.itemCategoryHashes?.includes(D1ItemCategoryHashes.sword);
-
   return Boolean(
-    // Must be on the list of interpolated stats, or included in the hardcoded hidden stats list
-    (statDisplaysByStatHash[statHash] ||
-      (includeHiddenStats && hiddenStatsAllowList.includes(statHash))) &&
+    // Must be on the list of interpolated stats
+    statDisplaysByStatHash[statHash] &&
       // Must be a stat we want to display
       isAllowedItemStat(statHash)
   );

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -165,14 +165,7 @@ export function buildStats(
     for (const armorStat of armorStats) {
       if (!existingStatHashes.includes(armorStat)) {
         investmentStats.push(
-          buildStat(
-            armorStat,
-            0,
-            false,
-            statGroup,
-            defs.Stat.get(armorStat),
-            statDisplaysByStatHash
-          )
+          buildStat(armorStat, 0, statGroup, defs.Stat.get(armorStat), statDisplaysByStatHash)
         );
       }
     }
@@ -269,14 +262,7 @@ function buildInvestmentStats(
     }
 
     ret.push(
-      buildStat(
-        itemStat.statTypeHash,
-        itemStat.value,
-        itemStat.isConditionallyActive,
-        statGroup,
-        def,
-        statDisplaysByStatHash
-      )
+      buildStat(itemStat.statTypeHash, itemStat.value, statGroup, def, statDisplaysByStatHash)
     );
   }
 
@@ -291,7 +277,6 @@ function buildInvestmentStats(
 function buildStat(
   statHash: number,
   value: number,
-  isConditionallyActive: boolean,
   statGroup: DestinyStatGroupDefinition,
   statDef: DestinyStatDefinition,
   statDisplaysByStatHash: StatDisplayLookup
@@ -326,7 +311,6 @@ function buildStat(
     additive:
       statDef.statCategory === DestinyStatCategory.Defense &&
       statDef.aggregationType === DestinyStatAggregationType.Character,
-    isConditionallyActive: isConditionallyActive,
   };
 }
 
@@ -384,7 +368,6 @@ function applyPlugsToStats(
           const newStat = buildStat(
             affectedStatHash,
             0,
-            pluggedInvestmentStat.isConditionallyActive,
             statGroup,
             statDef,
             statDisplaysByStatHash


### PR DESCRIPTION
Right now we happen to "lazily" build some stats when we observe plugs adding them and even do some last-minute fixups to add any missing stats based on some hardcoded criteria. But we only add plug stats to the item when they pass the `shouldShowStat` check, which checks for whether the stat is in the statGroup's `scaledStats` or is contained in our hardcoded `hiddenStatsAllowList` for some weapon stats.

But all weapons have the appropriate hidden stats already in their investmentStats and their statGroup, so the missing stats from the statGroup can be added by simply adding any `scaledStats` beforehand (I guess this happened when Bungie promoted these to proper stats that should always show in the item popup etc.)

This doesn't seem to change anything about the inventory item stats, and actually improves some very slight edge cases like Goldtusk on the Records page - beta shows three stats until you click "swordmaster's guard" in the item popup (which itself doesn't show these stats) where two additional stats appear from nothing, this PR shows two additional stats at 0 and clicking "swordmaster's guard" properly adds to those stats.