### PR TITLE
fix subclass mod sizes in IGL view

### DIFF
--- a/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
@@ -124,6 +124,8 @@ export function InGameLoadoutDetails({
   );
 }
 
+const majorSubclassPlugSuffixes = ['.trinkets', '.totems', '.fragments', '.aspects', '.supers'];
+
 // Note that the item has already had socket overrides applied by useItemsFromInGameLoadout
 function InGameLoadoutItemDetail({
   resolvedItem: { item, loadoutItem },
@@ -148,13 +150,12 @@ function InGameLoadoutItemDetail({
   const [smallSockets, bigSockets] = _.partition(
     validSockets,
     (s) =>
-      // Shaders and ornaments
+      // Shaders and ornaments should be small
       cosmeticSockets.includes(s) ||
-      // Grenade, jump, etc
+      // subclass mods that aren't super/aspect/fragment should be small (Grenade, jump, etc)
       (s.plugged!.plugDef.itemCategoryHashes?.includes(ItemCategoryHashes.SubclassMods) &&
-        !(
-          s.plugged!.plugDef.plug.plugCategoryIdentifier.endsWith('.fragments') ||
-          s.plugged!.plugDef.plug.plugCategoryIdentifier.endsWith('.aspects')
+        !majorSubclassPlugSuffixes.some((ps) =>
+          s.plugged!.plugDef.plug.plugCategoryIdentifier.endsWith(ps)
         ))
   );
   return (

--- a/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
@@ -12,7 +12,7 @@ import { streamDeckSelectionSelector } from 'app/stream-deck/selectors';
 import { streamDeckSelectLoadout } from 'app/stream-deck/stream-deck';
 import { isKillTrackerSocket } from 'app/utils/item-utils';
 import { getSocketsByCategoryHashes, socketContainsIntrinsicPlug } from 'app/utils/socket-utils';
-import { ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
+import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -124,8 +124,6 @@ export function InGameLoadoutDetails({
   );
 }
 
-const majorSubclassPlugSuffixes = ['.trinkets', '.totems', '.fragments', '.aspects', '.supers'];
-
 // Note that the item has already had socket overrides applied by useItemsFromInGameLoadout
 function InGameLoadoutItemDetail({
   resolvedItem: { item, loadoutItem },
@@ -147,16 +145,19 @@ function InGameLoadoutItemDetail({
     SocketCategoryHashes.ArmorCosmetics,
     SocketCategoryHashes.WeaponCosmetics,
   ]);
+
+  const subclassAbilitySockets = getSocketsByCategoryHashes(item.sockets, [
+    SocketCategoryHashes.Abilities_Abilities,
+    SocketCategoryHashes.Abilities_Abilities_Ikora,
+  ]);
+
   const [smallSockets, bigSockets] = _.partition(
     validSockets,
     (s) =>
       // Shaders and ornaments should be small
       cosmeticSockets.includes(s) ||
       // subclass mods that aren't super/aspect/fragment should be small (Grenade, jump, etc)
-      (s.plugged!.plugDef.itemCategoryHashes?.includes(ItemCategoryHashes.SubclassMods) &&
-        !majorSubclassPlugSuffixes.some((ps) =>
-          s.plugged!.plugDef.plug.plugCategoryIdentifier.endsWith(ps)
-        ))
+      subclassAbilitySockets.includes(s)
   );
   return (
     <React.Fragment key={item.id}>


### PR DESCRIPTION
stasis aspects/fragments had different plug identifiers, this makes them properly the bigger size.
also made the super plug large instead of small, that seems important.

before
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/3d432444-e06d-4966-b758-1630780d30a8)

after
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/f8f2ba1a-a4ab-4f24-b7f3-e87c49185064)
