### PR TITLE
Don't extend archetype socket presstip beyond icon (take 2)

### DIFF
--- a/src/app/item-popup/ArchetypeSocket.tsx
+++ b/src/app/item-popup/ArchetypeSocket.tsx
@@ -1,10 +1,8 @@
-import { PressTip } from 'app/dim-ui/PressTip';
 import { DimItem, DimSocket } from 'app/inventory/item-types';
 import clsx from 'clsx';
 import React from 'react';
 import styles from './ArchetypeSocket.m.scss';
 import { PlugClickHandler } from './ItemSockets';
-import { DimPlugTooltip } from './PlugTooltip';
 import Socket from './Socket';
 
 /**
@@ -13,11 +11,13 @@ import Socket from './Socket';
 export default function ArchetypeSocket({
   archetypeSocket,
   item,
+  noTooltip,
   children,
   onClick,
 }: {
   archetypeSocket?: DimSocket;
   item: DimItem;
+  noTooltip?: boolean;
   children?: React.ReactNode;
   onClick?: PlugClickHandler;
 }) {
@@ -31,17 +31,15 @@ export default function ArchetypeSocket({
         <Socket
           key={archetypeSocket.socketIndex}
           item={item}
+          noTooltip={noTooltip}
           socket={archetypeSocket}
           onClick={onClick}
         />
       </div>
-      <PressTip
-        className={styles.info}
-        tooltip={<DimPlugTooltip item={item} plug={archetypeSocket.plugged} />}
-      >
+      <div className={styles.info}>
         <div className={styles.name}>{archetypeSocket.plugged.plugDef.displayProperties.name}</div>
         {children}
-      </PressTip>
+      </div>
     </>
   );
 }

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -158,7 +158,7 @@ function IntrinsicArmorPerk({
   const plugDescriptions = usePlugDescriptions(socket.plugged?.plugDef);
   return (
     <ArchetypeRow minimal={minimal}>
-      <ArchetypeSocket archetypeSocket={socket} item={item} onClick={onPlugClicked}>
+      <ArchetypeSocket archetypeSocket={socket} noTooltip item={item} onClick={onPlugClicked}>
         {!minimal && (
           <div className={styles.armorIntrinsicDescription}>
             {plugDescriptions.perks.map(

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -158,7 +158,13 @@ function IntrinsicArmorPerk({
   const plugDescriptions = usePlugDescriptions(socket.plugged?.plugDef);
   return (
     <ArchetypeRow minimal={minimal}>
-      <ArchetypeSocket archetypeSocket={socket} noTooltip item={item} onClick={onPlugClicked}>
+      <ArchetypeSocket
+        archetypeSocket={socket}
+        /* entire description is shown when not minimal, so no tooltip needed then */
+        noTooltip={!minimal}
+        item={item}
+        onClick={onPlugClicked}
+      >
         {!minimal && (
           <div className={styles.armorIntrinsicDescription}>
             {plugDescriptions.perks.map(

--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -27,6 +27,7 @@ export default function Plug({
   socketInfo,
   wishlistRoll,
   hasMenu,
+  noTooltip,
   isMod,
   onClick,
   plugged,
@@ -40,6 +41,7 @@ export default function Plug({
   socketInfo: DimSocket;
   wishlistRoll?: InventoryWishListRoll;
   hasMenu: boolean;
+  noTooltip?: boolean;
   isMod?: boolean;
   onClick?: (plug: DimPlug) => void;
 } & PlugStatuses) {
@@ -79,6 +81,8 @@ export default function Plug({
           unreliablePerkOption={unreliablePerkOption}
           notSelected={notSelected}
         />
+      ) : noTooltip ? (
+        <DefItemIcon itemDef={plug.plugDef} />
       ) : (
         <PressTip tooltip={<DimPlugTooltip item={item} plug={plug} wishlistRoll={wishlistRoll} />}>
           <DefItemIcon itemDef={plug.plugDef} />

--- a/src/app/item-popup/Socket.tsx
+++ b/src/app/item-popup/Socket.tsx
@@ -10,12 +10,14 @@ import './Socket.scss';
 export default function Socket({
   item,
   socket,
+  noTooltip,
   wishlistRoll,
   onClick,
   pluggedOnly = false,
 }: {
   item: DimItem;
   socket: DimSocket;
+  noTooltip?: boolean;
   wishlistRoll?: InventoryWishListRoll;
   onClick?: PlugClickHandler;
   pluggedOnly?: boolean;
@@ -35,6 +37,7 @@ export default function Socket({
               plug={plug}
               item={item}
               socketInfo={socket}
+              noTooltip={noTooltip}
               wishlistRoll={wishlistRoll}
               hasMenu={hasMenu}
               isMod={socket.isMod}


### PR DESCRIPTION
#9927 but with a better working approach. Fixes #9832.