### PR TITLE
Fix bad defs lookup in Bounty Guide

### DIFF
--- a/src/app/progress/BountyGuide.tsx
+++ b/src/app/progress/BountyGuide.tsx
@@ -148,11 +148,14 @@ export default function BountyGuide({
           }
         }
       }
-      const traitHashes = defs.InventoryItem.get(i.hash)?.traitHashes;
-      if (traitHashes) {
-        for (const traitHash of traitHashes) {
-          if (pursuitCategoryTraitHashes.includes(traitHash)) {
-            (mapped.QuestTrait[traitHash] ??= []).push(i);
+      // Don't look up InventoryItem for "items" that were created from Records.
+      if (!i.pursuit?.recordHash) {
+        const traitHashes = defs.InventoryItem.get(i.hash)?.traitHashes;
+        if (traitHashes) {
+          for (const traitHash of traitHashes) {
+            if (pursuitCategoryTraitHashes.includes(traitHash)) {
+              (mapped.QuestTrait[traitHash] ??= []).push(i);
+            }
           }
         }
       }


### PR DESCRIPTION
This fixes the hash lookup warnings on the Progress page - we were looking up definitions for fake items.