### PR TITLE
Fix background color on loadout menu search

### DIFF
--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -125,7 +125,6 @@
   composes: search-filter from global;
   min-width: unset;
   margin: 8px;
-  background-color: var(--theme-search-bg);
 }
 
 .filterPills {


### PR DESCRIPTION
Not sure how this broke again, but this fixes the color of the search background in the loadout popup:

Before:
<img width="329" alt="Screenshot 2023-10-12 at 12 56 56 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/8e2d6612-7d5c-4fb3-bf04-1a7d5e2206c7">

After:
<img width="349" alt="Screenshot 2023-10-12 at 12 56 48 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/f92e40e7-f4bb-43f4-b22d-1ff46dbec44a">
