### PR TITLE
Don't open empty mods picker when clicking general auto-mod

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -453,6 +453,7 @@ export default memo(function LoadoutBuilder({
             modStatChanges={result.modStatChanges}
             loadouts={loadouts}
             armorEnergyRules={result.armorEnergyRules}
+            autoStatMods={autoStatMods}
             isEditingExistingLoadout={isEditingExistingLoadout}
           />
         ) : (

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -45,6 +45,7 @@ export default memo(function GeneratedSet({
   halfTierMods,
   armorEnergyRules,
   equippedHashes,
+  autoStatMods,
   isEditingExistingLoadout,
 }: {
   originalLoadout: Loadout;
@@ -59,6 +60,7 @@ export default memo(function GeneratedSet({
   halfTierMods: PluggableInventoryItemDefinition[];
   armorEnergyRules: ArmorEnergyRules;
   equippedHashes: Set<number>;
+  autoStatMods: boolean;
   isEditingExistingLoadout: boolean;
 }) {
   const defs = useD2Definitions()!;
@@ -169,6 +171,7 @@ export default memo(function GeneratedSet({
               pinned={pinnedItems[item.bucket.hash] === item}
               lbDispatch={lbDispatch}
               assignedMods={itemModAssignments[item.id]}
+              autoStatMods={autoStatMods}
               automaticallyPickedMods={autoModsPerItem[item.id]}
               energy={resultingItemEnergies[item.id]}
             />

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -55,6 +55,7 @@ export default function GeneratedSetItem({
   pinned,
   itemOptions,
   assignedMods,
+  autoStatMods,
   automaticallyPickedMods,
   energy,
   lbDispatch,
@@ -63,6 +64,7 @@ export default function GeneratedSetItem({
   pinned: boolean;
   itemOptions: DimItem[];
   assignedMods?: PluggableInventoryItemDefinition[];
+  autoStatMods: boolean;
   automaticallyPickedMods?: number[];
   energy: { energyCapacity: number; energyUsed: number };
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -97,7 +99,10 @@ export default function GeneratedSetItem({
       if (item.isExotic) {
         lbDispatch({ type: 'lockExotic', lockedExoticHash: item.hash });
       }
-    } else if (plugCategoryHash !== PlugCategoryHashes.EnhancementsArtifice) {
+    } else if (
+      plugCategoryHash !== PlugCategoryHashes.EnhancementsArtifice &&
+      (!autoStatMods || plugCategoryHash !== PlugCategoryHashes.EnhancementsV2General)
+    ) {
       lbDispatch({
         type: 'openModPicker',
         plugCategoryHashWhitelist,

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -34,6 +34,7 @@ export default function GeneratedSets({
   lbDispatch,
   armorEnergyRules,
   loadout,
+  autoStatMods,
   isEditingExistingLoadout,
 }: {
   selectedStore: DimStore;
@@ -47,6 +48,7 @@ export default function GeneratedSets({
   lbDispatch: Dispatch<LoadoutBuilderAction>;
   armorEnergyRules: ArmorEnergyRules;
   loadout: Loadout;
+  autoStatMods: boolean;
   isEditingExistingLoadout: boolean;
 }) {
   const params = loadout.parameters!;
@@ -92,6 +94,7 @@ export default function GeneratedSets({
           armorEnergyRules={armorEnergyRules}
           originalLoadout={loadout}
           equippedHashes={equippedHashes}
+          autoStatMods={autoStatMods}
           isEditingExistingLoadout={isEditingExistingLoadout}
         />
       )}


### PR DESCRIPTION
We don't allow the mods picker to show mods that LO is picking automatically, so clicking a general mod with auto mods enabled will cause an empty mods picker to appear. Prevent this from happening by drilling more props