### PR TITLE
Upgrade terser

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6917,7 +6917,7 @@ packages:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.21.0
+      terser: 5.22.0
     dev: true
 
   /html-minifier-terser@7.2.0:
@@ -6931,7 +6931,7 @@ packages:
       entities: 4.5.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.21.0
+      terser: 5.22.0
     dev: true
 
   /html-tags@3.3.1:
@@ -10642,7 +10642,7 @@ packages:
       jest-worker: 26.6.2
       rollup: 2.79.1
       serialize-javascript: 4.0.0
-      terser: 5.21.0
+      terser: 5.22.0
     dev: true
 
   /rollup@2.79.1:
@@ -11613,12 +11613,12 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      terser: 5.21.0
+      terser: 5.22.0
       webpack: 5.88.2(webpack-cli@5.1.4)
     dev: true
 
-  /terser@5.21.0:
-    resolution: {integrity: sha512-WtnFKrxu9kaoXuiZFSGrcAvvBqAdmKx0SFNmVNYdJamMu9yyN3I/QF0FbH4QcqJQ+y1CJnzxGIKH0cSj+FGYRw==}
+  /terser@5.22.0:
+    resolution: {integrity: sha512-hHZVLgRA2z4NWcN6aS5rQDc+7Dcy58HOf2zbYwmFcQ+ua3h6eEFf5lIDKTzbWwlazPyOZsFQO8V80/IjVNExEw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
This fixes a bug in minification where `item.primaryStat?.value.toString()` was turned into `"" + item.primaryStat?.value`, changing an `undefined` expression to `"undefined"` but only in beta/app, not dev.

![grafik](https://github.com/DestinyItemManager/DIM/assets/14299449/fa1d7162-da95-4634-a651-8417eb49ec3e)

We'll probably want to do a hotfix for this but that can wait until tomorrow so that we can pick up the new d2ai info from Festival of the Lost 2023.