### PR TITLE
Hotkeys/accessibility/setting for item popup tab

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -392,6 +392,7 @@
     "ClearDialog": "Dismiss dialog",
     "ClearNewItems": "Clear new items",
     "Enter": "ENTER",
+    "ItemPopupTab": "Switch item details tab",
     "LockUnlock": "Lock or unlock an item",
     "MarkItemAs": "Mark item as '{{tag}}'",
     "Menu": "Toggle menu",
@@ -888,6 +889,7 @@
       "Type": "{{classType}} {{typeName}}",
       "QuestProgress": "Step {{questStepNum}} of {{questStepsTotal}}"
     },
+    "TabList": "Item detail tabs",
     "ToggleSidecar": "Expand or collapse item actions",
     "TrackUntrack": {
       "Track": "Track {{itemType}}",

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -42,9 +42,11 @@ import { ItemPopupExtraInfo } from './item-popup';
 // TODO: probably need to load manifest. We can take a lot of properties off the item if we just load the definition here.
 export default function ItemDetails({
   item: originalItem,
+  id,
   extraInfo = {},
 }: {
   item: DimItem;
+  id: string;
   extraInfo?: ItemPopupExtraInfo;
 }) {
   const defs = useDefinitions()!;
@@ -64,7 +66,7 @@ export default function ItemDetails({
   const showVendor = useContext(SingleVendorSheetContext);
 
   return (
-    <div className={styles.itemDetailsBody}>
+    <div id={id} role="tabpanel" aria-labelledby={`${id}-tab`} className={styles.itemDetailsBody}>
       {item.itemCategoryHashes.includes(ItemCategoryHashes.Shaders) && (
         <BungieImage className={styles.itemShader} src={item.icon} width="96" height="96" />
       )}

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -12,7 +12,7 @@ import type { ItemTierName } from 'app/search/d2-known-values';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
-import { useId, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import DesktopItemActions, { menuClassName } from './DesktopItemActions';
 import styles from './ItemPopup.m.scss';
@@ -53,7 +53,6 @@ export default function ItemPopup({
   noLink?: boolean;
   onClose: () => void;
 }) {
-  const id = useId();
   const { content, tabButtons } = useItemPopupTabs(item, extraInfo);
   const stores = useSelector(sortedStoresSelector);
   const isPhonePortrait = useIsPhonePortrait();

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -54,7 +54,7 @@ export default function ItemPopup({
   onClose: () => void;
 }) {
   const id = useId();
-  const { content, tabButtons } = useItemPopupTabs(item, extraInfo, id);
+  const { content, tabButtons } = useItemPopupTabs(item, extraInfo);
   const stores = useSelector(sortedStoresSelector);
   const isPhonePortrait = useIsPhonePortrait();
 

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -12,7 +12,7 @@ import type { ItemTierName } from 'app/search/d2-known-values';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
-import { useMemo, useRef } from 'react';
+import { useId, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import DesktopItemActions, { menuClassName } from './DesktopItemActions';
 import styles from './ItemPopup.m.scss';
@@ -53,7 +53,8 @@ export default function ItemPopup({
   noLink?: boolean;
   onClose: () => void;
 }) {
-  const { content, tabButtons } = useItemPopupTabs(item, extraInfo);
+  const id = useId();
+  const { content, tabButtons } = useItemPopupTabs(item, extraInfo, id);
   const stores = useSelector(sortedStoresSelector);
   const isPhonePortrait = useIsPhonePortrait();
 

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -10,6 +10,7 @@ import ItemAccessoryButtons from 'app/item-actions/ItemAccessoryButtons';
 import ItemMoveLocations from 'app/item-actions/ItemMoveLocations';
 import type { ItemTierName } from 'app/search/d2-known-values';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { useFocusFirstFocusableElement } from 'app/utils/hooks';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { useMemo, useRef } from 'react';
@@ -66,6 +67,8 @@ export default function ItemPopup({
     arrowClassName: styles.arrow,
     menuClassName: menuClassName,
   });
+
+  useFocusFirstFocusableElement(popupRef);
 
   const itemActionsModel = useMemo(
     () => item && buildItemActionsModel(item, stores),

--- a/src/app/item-popup/ItemPopupTabs.m.scss
+++ b/src/app/item-popup/ItemPopupTabs.m.scss
@@ -5,6 +5,7 @@
   justify-content: space-around;
 }
 .movePopupTab {
+  composes: resetButton from '../dim-ui/common.m.scss';
   color: hsl(0, 0%, 80%);
   padding: 5px 0 3px;
   cursor: pointer;

--- a/src/app/item-popup/ItemPopupTabs.tsx
+++ b/src/app/item-popup/ItemPopupTabs.tsx
@@ -1,53 +1,91 @@
+import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { ItemTriage, TriageTabToggle, doShowTriage } from 'app/item-triage/ItemTriage';
+import { useSetting } from 'app/settings/hooks';
+import { ItemPopupTab } from 'app/settings/initial-settings';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useCallback, useId } from 'react';
 import ItemDetails from './ItemDetails';
 import styles from './ItemPopupTabs.m.scss';
 import { ItemPopupExtraInfo } from './item-popup';
 
-const enum ItemPopupTab {
-  Overview,
-  Triage,
-}
-
 export function useItemPopupTabs(item: DimItem, extraInfo: ItemPopupExtraInfo | undefined) {
-  const [tab, setTab] = useState(ItemPopupTab.Overview);
+  const [tab, setTab] = useSetting('itemPopupTab');
+  const id = useId();
+  const detailsId = `${id}-details`;
+  const triageId = `${id}-triage`;
+
   const tabs: {
     tab: ItemPopupTab;
+    id: string;
     title: JSX.Element | string;
     component: JSX.Element;
   }[] = [
     {
       tab: ItemPopupTab.Overview,
       title: t('MovePopup.OverviewTab'),
-      component: <ItemDetails item={item} extraInfo={extraInfo} />,
+      id: detailsId,
+      component: <ItemDetails item={item} extraInfo={extraInfo} id={detailsId} />,
     },
   ];
   if ($featureFlags.triage && doShowTriage(item)) {
     tabs.push({
       tab: ItemPopupTab.Triage,
       title: <TriageTabToggle item={item} tabActive={tab === ItemPopupTab.Triage} />,
-      component: <ItemTriage item={item} />,
+      id: triageId,
+      component: <ItemTriage item={item} id={triageId} />,
     });
   }
+
+  // https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+  // The keyboard handling code would need to be modified if we ever have more than two tabs
+
+  const toggleTab = useCallback(
+    () => setTab(tab === ItemPopupTab.Overview ? ItemPopupTab.Triage : ItemPopupTab.Overview),
+    [setTab, tab]
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowRight':
+      case 'Home':
+      case 'End':
+        toggleTab();
+        event.stopPropagation();
+        event.preventDefault();
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  useHotkey('t', t('Hotkey.ItemPopupTab'), toggleTab);
 
   const content = (tabs.length > 1 ? tabs.find((t) => t.tab === tab)! : tabs[0]).component;
 
   const tabButtons =
     tabs.length > 1 ? (
-      <div className={styles.movePopupTabs}>
+      <div className={styles.movePopupTabs} role="tablist" aria-label={t('MovePopup.TabList')}>
         {tabs.map((ta) => (
-          <span
+          <button
+            type="button"
+            role="tab"
+            id={`${id}-tab`}
+            aria-keyshortcuts="t"
             key={ta.tab}
             className={clsx(styles.movePopupTab, {
               [styles.selected]: tab === ta.tab,
             })}
+            aria-selected={tab === ta.tab}
+            aria-controls={ta.id}
             onClick={() => setTab(ta.tab)}
+            onKeyDown={handleKeyDown}
           >
             {ta.title}
-          </span>
+          </button>
         ))}
       </div>
     ) : undefined;

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -79,9 +79,9 @@ export function TriageTabToggle({ tabActive, item }: { tabActive: boolean; item:
   );
 }
 
-export function ItemTriage({ item }: { item: DimItem }) {
+export function ItemTriage({ item, id }: { item: DimItem; id: string }) {
   return (
-    <div className={styles.itemTriagePane}>
+    <div id={id} role="tabpanel" aria-labelledby={`${id}-tab`} className={styles.itemTriagePane}>
       {item.bucket.inWeapons && <WishlistTriageSection item={item} />}
       <LoadoutsTriageSection item={item} />
       <SimilarItemsTriageSection item={item} />

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -1,6 +1,11 @@
 import { defaultSettings, Settings as DimApiSettings } from '@destinyitemmanager/dim-api-types';
 import { defaultLanguage, DimLanguage } from 'app/i18n';
 
+export const enum ItemPopupTab {
+  Overview,
+  Triage,
+}
+
 /**
  * We extend the settings interface so we can try out new settings before committing them to dim-api-types
  */
@@ -10,6 +15,7 @@ export interface Settings extends DimApiSettings {
   theme: string;
   sortRecordProgression: boolean;
   vendorsHideSilverItems: boolean;
+  itemPopupTab: ItemPopupTab;
 }
 
 export const initialSettingsState: Settings = {
@@ -19,4 +25,5 @@ export const initialSettingsState: Settings = {
   theme: 'default',
   sortRecordProgression: false,
   vendorsHideSilverItems: false,
+  itemPopupTab: ItemPopupTab.Overview,
 };

--- a/src/app/utils/hooks.ts
+++ b/src/app/utils/hooks.ts
@@ -146,3 +146,15 @@ export function usePageTitle(title: string, active?: boolean) {
     }
   }, [active, title]);
 }
+
+// On first render, focus the first focusable element.
+export function useFocusFirstFocusableElement(ref: React.RefObject<HTMLElement>) {
+  useEffect(() => {
+    if (ref.current) {
+      const firstFocusable = ref.current.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      (firstFocusable as HTMLElement)?.focus();
+    }
+  }, [ref]);
+}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -391,6 +391,7 @@
     "ClearDialog": "Dismiss dialog",
     "ClearNewItems": "Clear new items",
     "Enter": "ENTER",
+    "ItemPopupTab": "Switch item details tab",
     "LockUnlock": "Lock or unlock an item",
     "MarkItemAs": "Mark item as '{{tag}}'",
     "Menu": "Toggle menu",
@@ -875,6 +876,7 @@
       "QuestProgress": "Step {{questStepNum}} of {{questStepsTotal}}",
       "Type": "{{classType}} {{typeName}}"
     },
+    "TabList": "Item detail tabs",
     "ToggleSidecar": "Expand or collapse item actions",
     "TrackUntrack": {
       "Track": "Track {{itemType}}",


### PR DESCRIPTION
1. Add a hotkey to toggle the tab in the item popup ("t" for "tab" 🤷‍♂️ ). Supercedes #9698, fixes #9058
2. Save the selected tab in settings, so it stays where you put it. Fixes #9803
2. Implement the ARIA tabs pattern for fun (it's not 100% because I don't change focus with the arrow keys but I feel like I was already going overboard by supporting arrow keys at all)