### PR TITLE
Slightly redesign radio buttons

### DIFF
--- a/src/app/dim-ui/RadioButtons.m.scss
+++ b/src/app/dim-ui/RadioButtons.m.scss
@@ -1,6 +1,7 @@
 @use '../variables' as *;
 .buttons {
   composes: flexRow from '../dim-ui/common.m.scss';
+  gap: 4px;
 }
 
 .button {
@@ -9,16 +10,6 @@
 }
 
 .selected {
+  composes: selected from global;
   cursor: default;
-  position: relative;
-  &::after {
-    content: '';
-    display: block;
-    position: absolute;
-    background-color: var(--theme-accent-primary);
-    height: 2px;
-    bottom: -1px;
-    left: -1px;
-    right: -1px;
-  }
 }


### PR DESCRIPTION
Pretty simple - these are only really used for this one control in LO and they are weird compared to our other radio buttons such as in organizer.

Before:
<img width="247" alt="Screenshot 2023-10-20 at 11 14 46 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/3c9d54f5-8d3b-4c89-9f8a-3a2a3fd4576d">

After:
<img width="245" alt="Screenshot 2023-10-20 at 11 12 16 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/fd6a4d8d-8f21-4f46-bd07-95c626f6917c">
