### PR TITLE
Fix armory crash

### DIFF
--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -131,13 +131,13 @@ function WishlistRolls({
                 // }
                 const primariesGroupedByColumn = Object.groupBy(
                   cr.commonPrimaryPerks,
-                  (h) => socketByPerkHash[h]?.socketIndex ?? 0
+                  (h) => socketByPerkHash[h]?.socketIndex ?? -1
                 );
 
                 // turns the above into
                 // [[outlaw, enhanced outlaw], [rampage]]
                 const primaryBundles = cr.rolls[0].primarySocketIndices.map((socketIndex) =>
-                  primariesGroupedByColumn[socketIndex].sort(
+                  primariesGroupedByColumn[socketIndex ?? -1].sort(
                     // establish a consistent base -> enhanced perk order
                     compareBy((h) => (h in enhancedToPerk ? 1 : 0))
                   )


### PR DESCRIPTION
Not like I understand this code or why it was creating objects keyed by `undefined` but this restores the pre-#9963 behavior, I think.