### PR TITLE
Don't clean item infos when B-net profile may have come from IDB

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -327,7 +327,11 @@ function loadStoresData(
           return;
         }
 
-        dispatch(cleanInfos(stores));
+        // First-time loads can come from IDB, which can be VERY outdated,
+        // so don't remove item tags/notes based on that
+        if (!firstTime) {
+          dispatch(cleanInfos(stores));
+        }
         dispatch(update({ stores, currencies }));
         dispatch(inGameLoadoutLoaded(loadouts));
 


### PR DESCRIPTION
This can cause loss of item tags when using multiple devices and DIM Sync.

Alternatively we could make `loadProfile` return a flag that indicates whether the returned profile is a fresh profile from Bungie.net and only do cleanup for those.