### PR TITLE
More LO optimizations

### DIFF
--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -66,7 +66,7 @@ export function chooseAutoMods(
     numArtificeMods,
     remainingEnergyCapacities,
     remainingTotalEnergy,
-    []
+    undefined
   );
 }
 
@@ -74,11 +74,12 @@ function doGeneralModsFit(
   info: LoSessionInfo,
   /** variants of remaining energy capacities given our activity mod assignment, each sorted descending */
   remainingEnergyCapacities: number[][],
-  pickedMods: ModsPick[]
+  pickedMods: ModsPick[] | undefined
 ) {
   // These are already sorted
   let generalModCosts = info.generalModCosts;
-  if (pickedMods.length) {
+  // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+  if (pickedMods !== undefined && pickedMods.length) {
     generalModCosts = generalModCosts.slice();
     // Intentionally open-coded for performance
     // eslint-disable-next-line @typescript-eslint/prefer-for-of
@@ -108,7 +109,7 @@ function recursivelyChooseMods(
   /** variants of remaining energy capacities given our activity mod assignment, each sorted descending */
   remainingEnergyCapacities: number[][],
   remainingTotalEnergy: number,
-  pickedMods: ModsPick[]
+  pickedMods: ModsPick[] | undefined
 ): ModsPick[] | undefined {
   while (statIndex < neededStats.length && neededStats[statIndex] === 0) {
     statIndex++;
@@ -117,7 +118,7 @@ function recursivelyChooseMods(
   if (statIndex === neededStats.length) {
     // We've hit the end of our needed stats, check if this is possible
     if (doGeneralModsFit(info, remainingEnergyCapacities, pickedMods)) {
-      return pickedMods;
+      return pickedMods ?? [];
     } else {
       return undefined;
     }
@@ -130,7 +131,7 @@ function recursivelyChooseMods(
   }
 
   // Create a new array we append the pick for this stat to.
-  const subArray = pickedMods.slice();
+  const subArray = pickedMods !== undefined ? pickedMods.slice() : [];
   // Dummy value just so we don't repeatedly push and pop.
   subArray.push(subArray[0]);
 

--- a/src/app/loadout-builder/process-worker/set-tracker.ts
+++ b/src/app/loadout-builder/process-worker/set-tracker.ts
@@ -40,9 +40,9 @@ export class SetTracker {
   /**
    * Insert this set into the tracker. If the tracker is at capacity this set or another one may be dropped.
    */
-  insert(tier: number, statMix: string, armor: ProcessItem[], stats: number[], statMods: number[]) {
+  insert(tier: number, statMix: string, armor: ProcessItem[], stats: number[]) {
     if (this.tiers.length === 0) {
-      this.tiers.push({ tier, statMixes: [{ statMix, armorSets: [{ armor, stats, statMods }] }] });
+      this.tiers.push({ tier, statMixes: [{ statMix, armorSets: [{ armor, stats }] }] });
     } else {
       // We have very few tiers at one time, so insertion sort is fine
       outer: for (let tierIndex = 0; tierIndex < this.tiers.length; tierIndex++) {
@@ -52,7 +52,7 @@ export class SetTracker {
         if (tier > currentTier.tier) {
           this.tiers.splice(tierIndex, 0, {
             tier,
-            statMixes: [{ statMix, armorSets: [{ armor, stats, statMods }] }],
+            statMixes: [{ statMix, armorSets: [{ armor, stats }] }],
           });
           break outer;
         }
@@ -61,7 +61,7 @@ export class SetTracker {
         if (tier === currentTier.tier) {
           const currentStatMixes = currentTier.statMixes;
 
-          if (insertStatMix(currentStatMixes, statMix, armor, stats, statMods)) {
+          if (insertStatMix(currentStatMixes, statMix, armor, stats)) {
             break outer;
           } else {
             return false;
@@ -73,7 +73,7 @@ export class SetTracker {
           if (this.totalSets < this.capacity) {
             this.tiers.push({
               tier,
-              statMixes: [{ statMix, armorSets: [{ armor, stats, statMods }] }],
+              statMixes: [{ statMix, armorSets: [{ armor, stats }] }],
             });
             break outer;
           } else {
@@ -140,8 +140,7 @@ function insertStatMix(
   }[],
   statMix: string,
   armor: ProcessItem[],
-  stats: number[],
-  statMods: number[]
+  stats: number[]
 ): boolean {
   // This is a binary search insertion strategy, since these lists may grow large
   let start = 0;
@@ -153,9 +152,9 @@ function insertStatMix(
     const comparison =
       statMix > currentStatMix.statMix ? 1 : statMix < currentStatMix.statMix ? -1 : 0;
 
-    // Same mix, pick the one that uses fewest stat mods
+    // Same mix
     if (comparison === 0) {
-      return insertArmorSet(armor, stats, statMods, currentStatMix.armorSets);
+      return insertArmorSet(armor, stats, currentStatMix.armorSets);
     }
     if (comparison > 0) {
       end = statMixIndex - 1;
@@ -170,7 +169,7 @@ function insertStatMix(
 
   currentStatMixes.splice(comparison > 0 ? start : start + 1, 0, {
     statMix,
-    armorSets: [{ armor, stats, statMods }],
+    armorSets: [{ armor, stats }],
   });
   return true;
 }
@@ -178,18 +177,17 @@ function insertStatMix(
 function insertArmorSet(
   armor: ProcessItem[],
   stats: number[],
-  statMods: number[],
   armorSets: IntermediateProcessArmorSet[]
 ) {
   // These lists don't tend to grow large, so it's back to insertion sort
   const armorSetPower = getPower(armor);
   for (let armorSetIndex = 0; armorSetIndex < armorSets.length; armorSetIndex++) {
     if (armorSetPower > getPower(armorSets[armorSetIndex].armor)) {
-      armorSets.splice(armorSetIndex, 0, { armor, stats, statMods });
+      armorSets.splice(armorSetIndex, 0, { armor, stats });
       return true;
     }
     if (armorSetIndex === armorSets.length - 1) {
-      armorSets.push({ armor, stats, statMods });
+      armorSets.push({ armor, stats });
       return true;
     }
   }

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -33,8 +33,6 @@ export interface IntermediateProcessArmorSet {
   stats: number[];
   /** The first (highest-power) valid set from this stat mix. */
   armor: ProcessItem[];
-  /** Which stat mods were added? */
-  statMods: number[];
 }
 
 export interface ProcessMod {

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -160,6 +160,17 @@ export function useProcess({
       }
     }
 
+    // NB this looks like a no-op but what's sorted here aren't the array entries but the object keys.
+    // Ensuring all array members have properties in the same order helps the JIT keep the code monomorphic...
+    const sortedResolvedStatConstraints: ResolvedStatConstraint[] = resolvedStatConstraints.map(
+      (c) => ({
+        minTier: c.minTier,
+        maxTier: c.maxTier,
+        statHash: c.statHash,
+        ignored: c.ignored,
+      })
+    );
+
     // TODO: could potentially partition the problem (split the largest item category maybe) to spread across more cores
     const workerStart = performance.now();
     worker
@@ -167,7 +178,7 @@ export function useProcess({
         processItems,
         _.mapValues(modStatChanges, (stat) => stat.value),
         lockedProcessMods,
-        resolvedStatConstraints,
+        sortedResolvedStatConstraints,
         anyExotic,
         autoModsData,
         autoStatMods


### PR DESCRIPTION
Turns out V8 optimistically assumes empty arrays are packed small integer arrays until we push a heap object onto it, at which point they become simple packed arrays (and all code that uses them becomes polymorphic).

The performance improvement from these is probably on the order of a few tens of milliseconds at best and there are almost certainly larger wins elsewhere but might as well fix the things V8 points out.

Also we haven't actually used the modHashes from our first feasibility check anywhere, so we don't actually need to do any flatMapping, which optimizes remarkably poorly.