### PR TITLE
Don't consider font mods active in background optimization

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -226,7 +226,7 @@ function getStatsBreakdown(
     autoMods,
     /* subclass */ undefined,
     classType,
-    /* includeRuntimeStatBenefits */ true
+    /* includeRuntimeStatBenefits */ true // auto mods have no dynamic behavior so that doesn't matter
   );
 
   // We have a bit of a problem where armor mods can come from both

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -429,8 +429,8 @@ export function process(
       const value = stats[i] + bonusStats[i];
       fullStats[statHash] = value;
 
-      if (strictUpgrades && !hasStrictUpgrade) {
-        const statFilter = resolvedStatConstraints[i];
+      const statFilter = resolvedStatConstraints[i];
+      if (!statFilter.ignored && strictUpgrades && !hasStrictUpgrade) {
         const tier = Math.min(Math.max(Math.floor(value / 10), 0), 10);
         hasStrictUpgrade ||= tier > statFilter.minTier;
       }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -285,7 +285,13 @@ export function getLoadoutStats(
   armor: DimItem[],
   mods: PluggableInventoryItemDefinition[],
   /** Assume armor is masterworked according to these rules when calculating stats */
-  armorEnergyRules?: ArmorEnergyRules
+  armorEnergyRules?: ArmorEnergyRules,
+  /**
+   * If set, this simulates the dynamically granted stat effects of certain mods
+   * that are active under specific conditions so that they don't have investmentStats,
+   * but are active often enough to be important for loadout building.
+   */
+  includeRuntimeStatBenefits = true
 ) {
   const statDefs = armorStats.map((hash) => defs.Stat.get(hash));
 
@@ -331,7 +337,7 @@ export function getLoadoutStats(
     mods,
     subclass,
     classType,
-    /* includeRuntimeStatBenefits */ true
+    includeRuntimeStatBenefits
   );
 
   for (const [statHash, value] of Object.entries(modStats)) {


### PR DESCRIPTION
Context https://discord.com/channels/316217202766512130/892215498018807808/1169204759991959582

Disabling Font mods when we try to figure out whether a strict upgrade exists results in more accurate analysis, as users who intentionally exceed T10 with Font mods won't have those excess stats reassigned elsewhere and get "better stats available" advice they don't want to follow, and in general loadouts with Font mods can be improved by increasing their always-active stats if they're below T10.

The core unsolved problem here is transferring this configuration to Loadout Optimizer. Loadout Optimizer would need that same toggle to ignore Font mods, but even if we automatically enabled it, the result might be unexpected:

* The displayed stats would suddenly be different from the stats the user normally sees in the Loadout.
* LO might suggest improvements to stats that are already effectively at T10 or higher when bumps to other stats below T10 are possible