### PR TITLE
Fix accidentally showing kill tracker socket in perks grid view

### DIFF
--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -3,6 +3,7 @@ import { statsMs } from 'app/inventory/store/stats';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useSetting } from 'app/settings/hooks';
 import { AppIcon, faGrid, faList } from 'app/shell/icons';
+import { isKillTrackerSocket } from 'app/utils/item-utils';
 import { getSocketsByIndexes, getWeaponSockets } from 'app/utils/socket-utils';
 import { LookupTable } from 'app/utils/util-types';
 import clsx from 'clsx';
@@ -121,15 +122,18 @@ export default function ItemSocketsWeapons({
               </button>
             )}
             <div className={clsx('item-sockets', styles.grid)}>
-              {getSocketsByIndexes(item.sockets, perks.socketIndexes).map((socketInfo) => (
-                <Socket
-                  key={socketInfo.socketIndex}
-                  item={item}
-                  socket={socketInfo}
-                  wishlistRoll={wishlistRoll}
-                  onClick={onPlugClicked}
-                />
-              ))}
+              {getSocketsByIndexes(item.sockets, perks.socketIndexes).map(
+                (socketInfo) =>
+                  !isKillTrackerSocket(socketInfo) && (
+                    <Socket
+                      key={socketInfo.socketIndex}
+                      item={item}
+                      socket={socketInfo}
+                      wishlistRoll={wishlistRoll}
+                      onClick={onPlugClicked}
+                    />
+                  )
+              )}
             </div>
           </div>
         ))}


### PR DESCRIPTION
Small regression likely from #9991 - I kept going back and forth between where to do this filtering and ended up not checking the grid view at the end.