### PR TITLE
Move specificity around to ensure margin on filter pills in lodout popup

### DIFF
--- a/src/app/dim-ui/FilterPills.m.scss
+++ b/src/app/dim-ui/FilterPills.m.scss
@@ -3,7 +3,8 @@
 .guide {
   composes: flexRow from '../dim-ui/common.m.scss';
   flex-wrap: wrap;
-  margin: 8px 0;
+  margin-top: 8px;
+  margin-bottom: 8px;
   gap: 4px;
 
   @include phone-portrait {

--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -119,15 +119,17 @@
 
 .content {
   color: var(--theme-text);
+
+  // This is nested so its specificity is high enough to override the defaults
+  .filterPills {
+    margin-left: 8px;
+    margin-right: 8px;
+  }
 }
 
 .filterInput {
   composes: search-filter from global;
   min-width: unset;
-  margin: 8px;
-}
-
-.filterPills {
   margin: 8px;
 }
 


### PR DESCRIPTION
Depending on the order CSS files were loaded, this margin could get overridden apparently.