### PR TITLE
Include DIM environment/release in Sentry CSP reports

### DIFF
--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -7,7 +7,11 @@ const SELF = "'self'";
 /**
  * Generate a Content Security Policy directive for a particular DIM environment (beta, release)
  */
-export default function csp(env: 'release' | 'beta' | 'dev' | 'pr', featureFlags: FeatureFlags) {
+export default function csp(
+  env: 'release' | 'beta' | 'dev' | 'pr',
+  featureFlags: FeatureFlags,
+  version: string | undefined
+) {
   const baseCSP: Record<string, string[] | string | boolean> = {
     defaultSrc: ["'none'"],
     scriptSrc: [
@@ -79,9 +83,11 @@ export default function csp(env: 'release' | 'beta' | 'dev' | 'pr', featureFlags
   };
 
   // Turn on CSP reporting to sentry.io on beta only
-  if (env === 'beta') {
-    baseCSP.reportUri =
-      'https://sentry.io/api/279673/csp-report/?sentry_key=1367619d45da481b8148dd345c1a1330';
+  if (featureFlags.sentry && env === 'beta') {
+    baseCSP.reportUri = `https://sentry.io/api/279673/csp-report/?sentry_key=1367619d45da481b8148dd345c1a1330&sentry_environment=${env}`;
+    if (version) {
+      baseCSP.reportUri += `&sentry_release=${version}`;
+    }
   }
 
   return builder({

--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -80,7 +80,7 @@ export default (env: Env) => {
   const publicPath = process.env.PUBLIC_PATH ?? '/';
 
   const featureFlags = makeFeatureFlags(env);
-  const contentSecurityPolicy = csp(env.name, featureFlags);
+  const contentSecurityPolicy = csp(env.name, featureFlags, version);
 
   const analyticsProperty = env.release ? 'G-1PW23SGMHN' : 'G-MYWW38Z3LR';
   const jsFilenamePattern = env.dev ? '[name]-[fullhash].js' : '[name]-[contenthash:8].js';


### PR DESCRIPTION
Turns out Sentry allows us to tag CSP reports with the environment and version, should help sort them out (or ignore them!)